### PR TITLE
Harden terminal WebSocket message handling

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -333,6 +333,11 @@ wss.on("connection", (ws, req) => {
     // A background pty for this session is still alive — reattach instead of
     // spawning a duplicate claude. Replay recent output for context.
     console.log(`[ws] reattach ${sessionId} (pid=${entry.term.pid})`);
+    // Drop any socket still attached (e.g. the same session open in another
+    // tab) so it can't keep writing to this PTY.
+    if (entry.ws && entry.ws !== ws && entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.close();
+    }
     entry.ws = ws;
     if (entry.buffer && ws.readyState === ws.OPEN) {
       ws.send(JSON.stringify({ type: "output", data: entry.buffer }));
@@ -390,17 +395,34 @@ wss.on("connection", (ws, req) => {
   // "waiting for input" flag so it stops showing as bold.
   setWaiting(sessionId, false);
 
-  // browser -> PTY
+  // browser -> PTY. The protocol is client-controlled, so validate every frame
+  // before touching node-pty (bad cols/rows or non-string input can throw).
   ws.on("message", (raw) => {
+    // Ignore frames from a socket that a newer client has already superseded.
+    if (entry.ws !== ws) return;
+    let msg;
     try {
-      const msg = JSON.parse(raw.toString());
-      if (msg.type === "input") {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return; // not JSON — never write arbitrary payloads to the PTY
+    }
+    try {
+      if (msg.type === "input" && typeof msg.data === "string") {
         entry.term.write(msg.data);
-      } else if (msg.type === "resize") {
+      } else if (
+        msg.type === "resize" &&
+        Number.isInteger(msg.cols) &&
+        Number.isInteger(msg.rows) &&
+        msg.cols >= 2 &&
+        msg.cols <= 500 &&
+        msg.rows >= 1 &&
+        msg.rows <= 200
+      ) {
         entry.term.resize(msg.cols, msg.rows);
       }
-    } catch {
-      entry.term.write(raw.toString());
+    } catch (err) {
+      // e.g. a write/resize that races the PTY exiting — drop it, never crash.
+      console.warn(`[ws] dropped message for ${sessionId}: ${err.message}`);
     }
   });
 


### PR DESCRIPTION
Addresses two Codex review findings on the client-controlled `/ws` terminal protocol.

## 1 (High) — Malformed messages could crash the server
The handler passed unvalidated fields straight into node-pty (`term.resize(msg.cols, msg.rows)`, `term.write(msg.data)`), and the parse-failure `catch` wrote the raw payload back to the PTY.

Fix:
- Only accept `input` when `typeof msg.data === "string"`.
- Only accept `resize` when `cols`/`rows` are integers in range (`cols 2..500`, `rows 1..200`).
- Drop non-JSON frames instead of writing them to the PTY.
- Wrap the pty write/resize in try/catch so a frame racing the PTY exit can't crash the process.

## 2 (Medium) — Stale sockets could write to the active PTY after reattach
The `message` handler lacked the `entry.ws !== ws` guard the close handler already had, so an old tab/socket could still inject keystrokes/resizes.

Fix:
- Guard the message handler with `if (entry.ws !== ws) return;`.
- Close the previously-attached socket when a new client reattaches.

## Verified
- Barrage of malformed frames (`cols:"x"`, `cols:999999999`, `data:{}`, non-JSON, …) → server stays alive, frames dropped, no crash.
- Reattach closes the old socket.
- typecheck, lint, and unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)