### PR TITLE
GUI chat protocol spike: presentMarkdown + presentForm over interactive PTY

### DIFF
--- a/docs/gui-protocol-spike.md
+++ b/docs/gui-protocol-spike.md
@@ -79,12 +79,41 @@ markdown, panel renders it), so it isolates the data pipe with no round-trip.
   shows the tool call and the **right panel** renders the markdown.
 - Switching sessions in the sidebar replays the correct session's GUI.
 
-### Findings (fill in after Phase I)
+### Findings (after Phase I)
 
-- How `--mcp-config` is wired into the interactive spawn:
-- How `sessionId` propagates to the MCP process:
-- Shape of the `data` channel that maps cleanly onto MulmoClaude:
-- Surprises / blockers:
+Status: **implemented and smoke-tested** end-to-end (MCP stdio handshake → tool
+call → `/api/gui` → in-memory store → history replay). Driving it from a real
+interactive `claude` is the remaining manual check.
+
+- **How `--mcp-config` is wired into the interactive spawn:** the interactive
+  `claude` accepts `--mcp-config <configs...>` as **JSON strings** (not only file
+  paths), so `server/index.js` builds the config inline per session
+  (`mcpConfigJson(sessionId)`) and appends `--mcp-config <json>
+  --strict-mcp-config --allowedTools mcp__mulmoterminal-gui__presentMarkdown` to
+  the existing `--settings`/`--session-id`/`--resume` args. No temp file to
+  manage. `--strict-mcp-config` keeps the user's own MCP servers out of the
+  spike; `--allowedTools` auto-runs the tool (no permission prompt — the
+  permission flow stays a deferred probe).
+- **How `sessionId` propagates to the MCP process:** via the MCP server's `env`
+  block in the config (`MULMOTERMINAL_SESSION_ID`, `MULMOTERMINAL_PORT`). This
+  is necessary because every PTY shares the server's single `process.env`, so
+  per-session values can't ride on the parent env — they must be baked into the
+  per-spawn config. Mirrors MulmoClaude's `MULMOCLAUDE_CHAT_SESSION_ID`.
+- **Shape of the `data` channel that maps cleanly onto MulmoClaude:** the MCP
+  tool `POST`s `{ sessionId, type, data }` to `/api/gui`; the server stores it
+  keyed by `sessionId` and `pubsub.publish("gui", { sessionId, type, data })`.
+  The panel filters the `gui` channel by the foreground `sessionId` and replays
+  history from `GET /api/gui/:sessionId`. `type` is the discriminator
+  (`presentMarkdown` now; `presentForm` next) and `data` is the opaque
+  tool-specific payload — exactly MulmoClaude's "MCP server posts a toolResult
+  to an internal route" pattern, transport-agnostic over the PTY.
+- **Surprises / blockers:** none blocking. Notes: used the official
+  `@modelcontextprotocol/sdk` (+ `zod`) for a correct stdio handshake rather
+  than hand-rolling JSON-RPC; the MCP server runs under the **same node binary**
+  (`process.execPath`) as the server. Markdown is rendered with `marked` and
+  **sanitized with DOMPurify** before `v-html` (the one XSS-sensitive seam).
+  GUI history is in-memory and intentionally **not** dropped on PTY reap, so a
+  closed/background session still replays its panel when reselected.
 
 ---
 

--- a/docs/gui-protocol-spike.md
+++ b/docs/gui-protocol-spike.md
@@ -1,0 +1,147 @@
+# GUI Chat Protocol Spike (mulmoterminal)
+
+A throwaway spike inside **mulmoterminal** to learn what it takes to support
+MulmoClaude's **GUI chat protocol** (`presentMarkdown`, `presentForm`, …) on top
+of the **interactive PTY** architecture. The lessons feed the larger MulmoClaude
+migration — see [Background](#background).
+
+> Status: planned. Fill in the **Findings** sections as each phase lands.
+
+---
+
+## Background
+
+MulmoClaude today drives Claude Code in **headless `claude -p` (stream-json)**
+mode and parses the stream into events that render the chat *and* the GUI. We
+are moving it to the **mulmoterminal mechanism**: spawn the **interactive
+`claude` CLI in a PTY**, relay it to an xterm terminal, and **eliminate every
+`claude -p` invocation** (the north star).
+
+The one thing that approach has never proven is whether the **GUI chat
+protocol** survives the move. In MulmoClaude the GUI is driven by **MCP tools**
+that push a structured `data` payload server-side — which is *transport-
+agnostic* and should work identically under an interactive PTY. This spike
+validates that end-to-end in the smallest possible codebase before we touch
+MulmoClaude.
+
+### The seam under test
+
+```
+ interactive claude (PTY)
+        │  calls MCP tool  presentMarkdown({ markdown })
+        ▼
+ stdio MCP server  ──HTTP POST /api/gui {sessionId,type,data}──►  mulmoterminal server
+        ▲                                                              │ publish on "gui"
+        │  (Phase II: blocks for the answer)                           ▼
+        └────────────── answer ◄── /api/gui/answer ◄──────  GUI panel (Vue, right side)
+                                                            renders data; submits input
+```
+
+- **Terminal (left panel):** the raw interactive CLI, unchanged.
+- **GUI (right panel):** renders from the tool's `data` field.
+- **`data` channel:** MCP tool → `/api/gui` → existing socket.io pub/sub → panel.
+  (Mirrors MulmoClaude's "MCP server posts a toolResult to an internal route".)
+
+---
+
+## Phase I — `presentMarkdown` (one-way)
+
+**Goal:** prove the full **MCP tool → `data` → GUI panel** pipe with the
+simplest possible plugin. `presentMarkdown` is one-directional (LLM emits
+markdown, panel renders it), so it isolates the data pipe with no round-trip.
+
+### Steps
+
+1. **MCP server** — a small stdio server (`server/mcp/present-markdown.js`)
+   exposing one tool `presentMarkdown({ markdown })`. On call, it `POST`s
+   `{ sessionId, type: "presentMarkdown", data: { markdown } }` to
+   `http://localhost:<PORT>/api/gui`, then returns a short ack string to claude.
+   - `sessionId` + `PORT` reach the MCP process via **env** (set when we build
+     its mcp-config), mirroring MulmoClaude's `MULMOCLAUDE_CHAT_SESSION_ID`.
+2. **Spawn wiring** — when spawning `claude`, also pass `--mcp-config <file>`
+   (alongside the existing `--settings` hooks) and add the tool to
+   `--allowedTools` so it auto-runs (sidesteps the permission prompt, which is a
+   separate probe — see [Deferred](#deferred-probes)).
+3. **Server endpoint** — `POST /api/gui` in `server/index.js`: validate the
+   frame, store the latest payload(s) **keyed by `sessionId`** (in-memory for
+   the spike), and `pubsub.publish("gui", { sessionId, type, data })`.
+4. **History fetch** — `GET /api/gui/:sessionId` returns the stored payloads so
+   the panel can **replay** when the user selects a session.
+5. **GUI panel** — `src/components/GuiPanel.vue`: subscribe to the `gui` channel
+   (filter by the active session id), render markdown (add `marked` +
+   sanitization). On session change, load history via `GET /api/gui/:sessionId`.
+6. **Layout** — `App.vue` becomes `Sidebar | [ Terminal | GuiPanel ]` (the
+   unified two-panel view in miniature).
+
+### Acceptance
+
+- Tell claude "use presentMarkdown to show me a table of …"; the **terminal**
+  shows the tool call and the **right panel** renders the markdown.
+- Switching sessions in the sidebar replays the correct session's GUI.
+
+### Findings (fill in after Phase I)
+
+- How `--mcp-config` is wired into the interactive spawn:
+- How `sessionId` propagates to the MCP process:
+- Shape of the `data` channel that maps cleanly onto MulmoClaude:
+- Surprises / blockers:
+
+---
+
+## Phase II — `presentForm` (round-trip)
+
+**Goal:** prove **GUI input flows back into the agent**. `presentForm` is the
+hard case: the tool call must **block** until the user submits, then **return
+the answer to claude** so the conversation continues.
+
+### Key challenge
+
+The MCP server runs as a **subprocess of `claude`**, so its tool handler must
+await the user's answer that arrives via the browser → mulmoterminal server.
+Plan: the handler `POST`s the form to the server and **long-polls** (or holds
+the request open) on a `requestId`; the panel renders the form; on submit the
+browser `POST`s the answer to `/api/gui/answer` with that `requestId`; the
+server resolves the held request; the handler returns the answer to claude.
+
+### Steps (refine with Phase I learnings)
+
+1. Add `presentForm({ schema })` to the MCP server; generate a `requestId`.
+2. Server: register a pending request; publish the form on `gui`; hold a
+   response until `/api/gui/answer` arrives (or times out).
+3. Panel: render a form from `schema`; on submit `POST` the answer.
+4. Handler returns the answer to claude; verify the session continues using it.
+
+### Acceptance
+
+- claude calls `presentForm`; the panel renders a form; the user submits; the
+  answer reaches claude and the turn continues with it.
+
+### Findings (fill in after Phase II)
+
+- How the blocking round-trip is implemented and how robust it is:
+- Timeout / abandoned-form behavior:
+- What this implies for MulmoClaude's `presentForm` / `handlePermission`:
+
+---
+
+## Deferred probes
+
+- **Permission flow (`--permission-prompt-tool`).** `presentMarkdown` is
+  auto-allowed, so it won't exercise permissions. A follow-on probe: add a tool
+  that triggers an "ask" and observe whether interactive mode honors
+  `--permission-prompt-tool` or falls back to its native in-terminal prompt.
+  This is the biggest open risk for the MulmoClaude migration (the
+  `AskUserQuestion → presentForm` redirect).
+
+## Out of scope
+
+Docker sandbox, roles, multiple plugins, durable persistence, mobile input, and
+any MulmoClaude code changes. This spike is purely to **learn the seam**; the
+real work lands on MulmoClaude's `staging` branch afterward.
+
+## What this de-risks for MulmoClaude
+
+A working Phase I + II turns MulmoClaude milestone **M3 (plugins + GUI chat
+protocol)** from "invent it on the integration branch" into "port a proven
+pattern" — and tells us early whether the GUI survives the interactive PTY at
+all, which is the load-bearing assumption of the entire migration.

--- a/docs/gui-protocol-spike.md
+++ b/docs/gui-protocol-spike.md
@@ -5,7 +5,9 @@ MulmoClaude's **GUI chat protocol** (`presentMarkdown`, `presentForm`, …) on t
 of the **interactive PTY** architecture. The lessons feed the larger MulmoClaude
 migration — see [Background](#background).
 
-> Status: planned. Fill in the **Findings** sections as each phase lands.
+> Status: Phase I + II implemented and smoke-tested. See each phase's
+> **Findings**. Remaining: manual check against a real interactive `claude`, and
+> the deferred permission-prompt probe.
 
 ---
 
@@ -145,11 +147,38 @@ server resolves the held request; the handler returns the answer to claude.
 - claude calls `presentForm`; the panel renders a form; the user submits; the
   answer reaches claude and the turn continues with it.
 
-### Findings (fill in after Phase II)
+### Findings (after Phase II)
 
-- How the blocking round-trip is implemented and how robust it is:
-- Timeout / abandoned-form behavior:
-- What this implies for MulmoClaude's `presentForm` / `handlePermission`:
+Status: **implemented and smoke-tested** end-to-end — `presentForm` blocks the
+tool call until a `POST /api/gui/answer` arrives, then returns the answer JSON to
+claude; history replay shows the form as completed afterward.
+
+- **How the blocking round-trip is implemented and how robust it is:**
+  `presentForm` generates a `requestId`, `POST`s `{ requestId, schema }` to
+  `/api/gui` (which registers a pending-form entry and publishes the form), then
+  **long-polls** `GET /api/gui/answer/:requestId`. The server parks that response
+  in the form's `waiters` set and releases it the instant the panel `POST`s
+  `/api/gui/answer` — or replies `204` after a 25 s hold so the MCP process
+  re-polls (an overall 10-min deadline lives in the MCP process). The 25 s
+  chunked-hold avoids any single request tripping a proxy/client idle timeout,
+  and `req.on("close")` drops parked responses if claude is killed mid-form. The
+  whole thing rides the **same `data` channel** as Phase I — no new transport.
+- **Timeout / abandoned-form behavior:** if no answer arrives within the MCP
+  deadline the tool returns "the user did not submit the form (timed out)" so
+  claude can recover rather than hang forever; a `404` (form gone, e.g. server
+  restarted) returns "the form is no longer available." Submission is
+  **idempotent** — a second `/api/gui/answer` for an already-answered form is a
+  no-op, and `formAnswered` is broadcast on `gui` so any other viewer (or a
+  history replay) locks the form and shows the result.
+- **What this implies for MulmoClaude's `presentForm` / `handlePermission`:**
+  the load-bearing assumption holds — a **blocking** GUI tool works under the
+  interactive PTY with no special claude support, because the block lives
+  entirely in the MCP subprocess (await an HTTP round-trip) and is invisible to
+  claude, which just sees a slow tool call. `handlePermission` is the same shape
+  (a blocking ask that returns allow/deny), so the `AskUserQuestion →
+  presentForm` redirect should port cleanly. The remaining open risk is the
+  **native permission prompt** (`--permission-prompt-tool`), still a deferred
+  probe — see below.
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,6 +34,7 @@ export default [
         console: "readonly",
         process: "readonly",
         URL: "readonly",
+        fetch: "readonly",
       },
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,8 @@ export default [
         process: "readonly",
         URL: "readonly",
         fetch: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -16,11 +16,14 @@
     "postinstall": "node server/fix-pty-perms.js"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@xterm/addon-attach": "^0.12.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "dompurify": "^3.4.10",
     "express": "^5.2.1",
+    "marked": "^18.0.5",
     "node-pty": "^1.1.0",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",

--- a/server/index.js
+++ b/server/index.js
@@ -37,6 +37,26 @@ function isAllowedOrigin(origin) {
 // Pub/sub channel the sidebar subscribes to for live session-activity changes.
 const SESSIONS_CHANNEL = "sessions";
 
+// Pub/sub channel the GUI panel subscribes to. The presentMarkdown MCP tool
+// POSTs to /api/gui, which stores the payload and publishes it here keyed by
+// session id (see docs/gui-protocol-spike.md).
+const GUI_CHANNEL = "gui";
+
+// Stdio MCP server wired into each spawned claude (--mcp-config). It exposes the
+// presentMarkdown tool that drives the GUI panel.
+const MCP_SERVER_PATH = path.join(__dirname, "mcp", "present-markdown.js");
+
+// MCP tool name claude uses, in the mcp__<server>__<tool> form. Auto-allowed via
+// --allowedTools so the spike doesn't trip the permission prompt (a deferred
+// probe — see the doc).
+const GUI_MCP_TOOL = "mcp__mulmoterminal-gui__presentMarkdown";
+
+// Latest GUI payloads per session, kept in memory for the spike so the panel can
+// replay them when a session is (re)selected. Each entry is an array, capped to
+// the most recent N frames.
+const guiPayloads = new Map(); // id -> [{ type, data }]
+const GUI_HISTORY_LIMIT = 50;
+
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
 const SESSION_LIST_LIMIT = 50;
@@ -140,6 +160,24 @@ function hookSettingsJson() {
   });
 }
 
+// MCP config injected via `claude --mcp-config <json>`. Registers the stdio
+// presentMarkdown server and passes this session's id + the server port to it
+// via env (the MCP process can't otherwise know which session it belongs to).
+function mcpConfigJson(sessionId) {
+  return JSON.stringify({
+    mcpServers: {
+      "mulmoterminal-gui": {
+        command: process.execPath, // the node running this server
+        args: [MCP_SERVER_PATH],
+        env: {
+          MULMOTERMINAL_SESSION_ID: sessionId,
+          MULMOTERMINAL_PORT: String(PORT),
+        },
+      },
+    },
+  });
+}
+
 // Claude stores each project's sessions under ~/.claude/projects/<encoded-cwd>/,
 // where the absolute cwd has its "/" and "." characters replaced by "-".
 function projectSessionsDir(cwd) {
@@ -221,6 +259,44 @@ app.post("/api/hook", (req, res) => {
     console.log(`[hook] ${hook_event_name} for ${session_id}`);
   }
   res.json({ ok: true });
+});
+
+// The presentMarkdown MCP tool POSTs GUI frames here. We validate the frame,
+// store the latest payloads keyed by session id (in-memory for the spike), and
+// publish on the "gui" channel so the active GUI panel renders it live.
+app.post("/api/gui", (req, res) => {
+  const { sessionId, type, data } = req.body || {};
+  // The MCP process is local and trusted, but the session id flows from env and
+  // ends up in a pub/sub channel filter — keep it to the known UUID shape.
+  if (!sessionId || !SESSION_ID_RE.test(sessionId)) {
+    return res.status(400).json({ error: "invalid sessionId" });
+  }
+  if (typeof type !== "string" || type !== "presentMarkdown") {
+    return res.status(400).json({ error: "unsupported type" });
+  }
+  if (!data || typeof data !== "object" || typeof data.markdown !== "string") {
+    return res.status(400).json({ error: "invalid data" });
+  }
+
+  const frame = { type, data: { markdown: data.markdown } };
+  const list = guiPayloads.get(sessionId) || [];
+  list.push(frame);
+  if (list.length > GUI_HISTORY_LIMIT) list.splice(0, list.length - GUI_HISTORY_LIMIT);
+  guiPayloads.set(sessionId, list);
+
+  pubsub?.publish(GUI_CHANNEL, { sessionId, ...frame });
+  console.log(`[gui] ${type} for ${sessionId}`);
+  res.json({ ok: true });
+});
+
+// Replay a session's stored GUI payloads so the panel can render them when the
+// user (re)selects that session.
+app.get("/api/gui/:sessionId", (req, res) => {
+  const { sessionId } = req.params;
+  if (!SESSION_ID_RE.test(sessionId)) {
+    return res.status(400).json({ error: "invalid sessionId" });
+  }
+  res.json({ sessionId, payloads: guiPayloads.get(sessionId) || [] });
 });
 
 // List the chat sessions for the current project (CLAUDE_CWD), including
@@ -344,9 +420,14 @@ wss.on("connection", (ws, req) => {
     }
   } else {
     const settings = hookSettingsJson();
+    // Register the GUI MCP server and auto-allow its tool so presentMarkdown
+    // runs without a permission prompt (--strict-mcp-config keeps the user's
+    // other MCP servers out of the spike).
+    const mcp = mcpConfigJson(sessionId);
+    const guiArgs = ["--mcp-config", mcp, "--strict-mcp-config", "--allowedTools", GUI_MCP_TOOL];
     const args = resume
-      ? ["--resume", resume, "--settings", settings]
-      : ["--session-id", sessionId, "--settings", settings];
+      ? ["--resume", resume, "--settings", settings, ...guiArgs]
+      : ["--session-id", sessionId, "--settings", settings, ...guiArgs];
 
     console.log(`[ws] client connected (${resume ? "resume" : "new"} ${sessionId})`);
 

--- a/server/index.js
+++ b/server/index.js
@@ -43,19 +43,35 @@ const SESSIONS_CHANNEL = "sessions";
 const GUI_CHANNEL = "gui";
 
 // Stdio MCP server wired into each spawned claude (--mcp-config). It exposes the
-// presentMarkdown tool that drives the GUI panel.
+// GUI-protocol tools (presentMarkdown, presentForm) that drive the GUI panel.
 const MCP_SERVER_PATH = path.join(__dirname, "mcp", "present-markdown.js");
 
-// MCP tool name claude uses, in the mcp__<server>__<tool> form. Auto-allowed via
+// MCP tool names claude uses, in the mcp__<server>__<tool> form. Auto-allowed via
 // --allowedTools so the spike doesn't trip the permission prompt (a deferred
-// probe — see the doc).
-const GUI_MCP_TOOL = "mcp__mulmoterminal-gui__presentMarkdown";
+// probe — see the doc). Comma-joined into a single --allowedTools value.
+const GUI_MCP_TOOLS = [
+  "mcp__mulmoterminal-gui__presentMarkdown",
+  "mcp__mulmoterminal-gui__presentForm",
+].join(",");
 
 // Latest GUI payloads per session, kept in memory for the spike so the panel can
 // replay them when a session is (re)selected. Each entry is an array, capped to
 // the most recent N frames.
 const guiPayloads = new Map(); // id -> [{ type, data }]
 const GUI_HISTORY_LIMIT = 50;
+
+// requestId is a UUID, same shape as a session id. Validate it before it reaches
+// the pending-form registry / route params.
+const UUID_RE = SESSION_ID_RE;
+
+// In-flight presentForm requests, keyed by requestId. Each presentForm tool call
+// blocks until the user submits; the MCP process long-polls /api/gui/answer and
+// the entry's `waiters` hold those open responses until the answer arrives.
+const pendingForms = new Map(); // requestId -> { sessionId, answered, answer, waiters:Set, frame }
+
+// How long the server holds a single answer long-poll open before replying 204
+// (the MCP process then re-polls). Kept under typical proxy/client idle limits.
+const FORM_POLL_HOLD_MS = 25 * 1000;
 
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
@@ -261,9 +277,10 @@ app.post("/api/hook", (req, res) => {
   res.json({ ok: true });
 });
 
-// The presentMarkdown MCP tool POSTs GUI frames here. We validate the frame,
-// store the latest payloads keyed by session id (in-memory for the spike), and
-// publish on the "gui" channel so the active GUI panel renders it live.
+// The GUI-protocol MCP tools POST frames here. We validate the frame, store the
+// latest payloads keyed by session id (in-memory for the spike), and publish on
+// the "gui" channel so the active GUI panel renders it live. A presentForm frame
+// additionally registers a pending request the user's answer will resolve.
 app.post("/api/gui", (req, res) => {
   const { sessionId, type, data } = req.body || {};
   // The MCP process is local and trusted, but the session id flows from env and
@@ -271,14 +288,38 @@ app.post("/api/gui", (req, res) => {
   if (!sessionId || !SESSION_ID_RE.test(sessionId)) {
     return res.status(400).json({ error: "invalid sessionId" });
   }
-  if (typeof type !== "string" || type !== "presentMarkdown") {
-    return res.status(400).json({ error: "unsupported type" });
-  }
-  if (!data || typeof data !== "object" || typeof data.markdown !== "string") {
+  if (typeof data !== "object" || data === null) {
     return res.status(400).json({ error: "invalid data" });
   }
 
-  const frame = { type, data: { markdown: data.markdown } };
+  let frame;
+  if (type === "presentMarkdown") {
+    if (typeof data.markdown !== "string") {
+      return res.status(400).json({ error: "invalid markdown" });
+    }
+    frame = { type, data: { markdown: data.markdown } };
+  } else if (type === "presentForm") {
+    const { requestId, schema } = data;
+    if (!requestId || !UUID_RE.test(requestId)) {
+      return res.status(400).json({ error: "invalid requestId" });
+    }
+    if (!schema || typeof schema !== "object" || !Array.isArray(schema.fields) || schema.fields.length === 0) {
+      return res.status(400).json({ error: "invalid schema" });
+    }
+    // `answered`/`answer` start empty and are filled in when the user submits,
+    // so a history replay can show the form as already completed.
+    frame = { type, data: { requestId, schema, answered: false, answer: null } };
+    pendingForms.set(requestId, {
+      sessionId,
+      answered: false,
+      answer: null,
+      waiters: new Set(),
+      frame,
+    });
+  } else {
+    return res.status(400).json({ error: "unsupported type" });
+  }
+
   const list = guiPayloads.get(sessionId) || [];
   list.push(frame);
   if (list.length > GUI_HISTORY_LIMIT) list.splice(0, list.length - GUI_HISTORY_LIMIT);
@@ -286,6 +327,67 @@ app.post("/api/gui", (req, res) => {
 
   pubsub?.publish(GUI_CHANNEL, { sessionId, ...frame });
   console.log(`[gui] ${type} for ${sessionId}`);
+  res.json({ ok: true });
+});
+
+// Long-poll for a form's answer. The MCP process calls this after publishing a
+// presentForm; we hold the response open until the user submits (resolved by
+// POST /api/gui/answer) or briefly time out with 204 so the caller re-polls.
+app.get("/api/gui/answer/:requestId", (req, res) => {
+  const { requestId } = req.params;
+  if (!UUID_RE.test(requestId)) {
+    return res.status(400).json({ error: "invalid requestId" });
+  }
+  const form = pendingForms.get(requestId);
+  if (!form) return res.status(404).json({ error: "unknown requestId" });
+  if (form.answered) return res.json({ answer: form.answer });
+
+  // Park the response; release it on submit or after the hold window.
+  const waiter = { res, timer: null };
+  waiter.timer = setTimeout(() => {
+    form.waiters.delete(waiter);
+    if (!res.headersSent) res.status(204).end();
+  }, FORM_POLL_HOLD_MS);
+  form.waiters.add(waiter);
+  // If the MCP process gives up (claude killed), drop the parked response.
+  req.on("close", () => {
+    clearTimeout(waiter.timer);
+    form.waiters.delete(waiter);
+  });
+});
+
+// The GUI panel POSTs the user's form submission here. We record the answer,
+// release any parked long-polls, and broadcast so other viewers mark the form
+// done. Idempotent: a second submission for an answered form is ignored.
+app.post("/api/gui/answer", (req, res) => {
+  const { requestId, answer } = req.body || {};
+  if (!requestId || !UUID_RE.test(requestId)) {
+    return res.status(400).json({ error: "invalid requestId" });
+  }
+  if (typeof answer !== "object" || answer === null || Array.isArray(answer)) {
+    return res.status(400).json({ error: "invalid answer" });
+  }
+  const form = pendingForms.get(requestId);
+  if (!form) return res.status(404).json({ error: "unknown requestId" });
+
+  if (!form.answered) {
+    form.answered = true;
+    form.answer = answer;
+    // Reflect into the stored frame so a later history replay shows it answered.
+    form.frame.data.answered = true;
+    form.frame.data.answer = answer;
+    for (const w of form.waiters) {
+      clearTimeout(w.timer);
+      if (!w.res.headersSent) w.res.json({ answer });
+    }
+    form.waiters.clear();
+    pubsub?.publish(GUI_CHANNEL, {
+      sessionId: form.sessionId,
+      type: "formAnswered",
+      data: { requestId, answer },
+    });
+    console.log(`[gui] form answered ${requestId}`);
+  }
   res.json({ ok: true });
 });
 
@@ -424,7 +526,7 @@ wss.on("connection", (ws, req) => {
     // runs without a permission prompt (--strict-mcp-config keeps the user's
     // other MCP servers out of the spike).
     const mcp = mcpConfigJson(sessionId);
-    const guiArgs = ["--mcp-config", mcp, "--strict-mcp-config", "--allowedTools", GUI_MCP_TOOL];
+    const guiArgs = ["--mcp-config", mcp, "--strict-mcp-config", "--allowedTools", GUI_MCP_TOOLS];
     const args = resume
       ? ["--resume", resume, "--settings", settings, ...guiArgs]
       : ["--session-id", sessionId, "--settings", settings, ...guiArgs];

--- a/server/mcp/present-markdown.js
+++ b/server/mcp/present-markdown.js
@@ -1,0 +1,51 @@
+// Stdio MCP server for the GUI chat protocol spike (Phase I).
+//
+// Exposes a single tool, `presentMarkdown({ markdown })`. When claude calls it,
+// we POST the payload to mulmoterminal's /api/gui route; the server publishes it
+// on the "gui" pub/sub channel and the Vue GUI panel renders it. This is the
+// transport-agnostic "data channel" the spike is validating end-to-end under an
+// interactive PTY (see docs/gui-protocol-spike.md).
+//
+// Context reaches this subprocess via env (set when the server builds the
+// mcp-config), mirroring MulmoClaude's MULMOCLAUDE_CHAT_SESSION_ID:
+//   MULMOTERMINAL_SESSION_ID  - the session whose GUI panel should render this
+//   MULMOTERMINAL_PORT        - the mulmoterminal HTTP port to POST to
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const SESSION_ID = process.env.MULMOTERMINAL_SESSION_ID;
+const PORT = process.env.MULMOTERMINAL_PORT || "3456";
+const GUI_URL = `http://localhost:${PORT}/api/gui`;
+
+const server = new McpServer({ name: "mulmoterminal-gui", version: "0.0.0" });
+
+server.registerTool(
+  "presentMarkdown",
+  {
+    title: "Present Markdown",
+    description:
+      "Render markdown in the user's GUI panel (right side), beside the terminal. " +
+      "Use this to show formatted content — tables, lists, headings, code — that is " +
+      "easier to read rendered than as plain terminal text.",
+    inputSchema: { markdown: z.string().describe("The markdown to render in the GUI panel.") },
+  },
+  async ({ markdown }) => {
+    const res = await fetch(GUI_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessionId: SESSION_ID,
+        type: "presentMarkdown",
+        data: { markdown },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`/api/gui responded ${res.status}`);
+    }
+    return { content: [{ type: "text", text: "Rendered markdown in the GUI panel." }] };
+  }
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/server/mcp/present-markdown.js
+++ b/server/mcp/present-markdown.js
@@ -1,10 +1,15 @@
-// Stdio MCP server for the GUI chat protocol spike (Phase I).
+// Stdio MCP server for the GUI chat protocol spike.
 //
-// Exposes a single tool, `presentMarkdown({ markdown })`. When claude calls it,
-// we POST the payload to mulmoterminal's /api/gui route; the server publishes it
-// on the "gui" pub/sub channel and the Vue GUI panel renders it. This is the
-// transport-agnostic "data channel" the spike is validating end-to-end under an
-// interactive PTY (see docs/gui-protocol-spike.md).
+// Exposes the GUI-protocol tools:
+//   presentMarkdown({ markdown })  - Phase I, one-way: render markdown.
+//   presentForm({ title, fields }) - Phase II, round-trip: render a form and
+//                                    block until the user submits, returning
+//                                    the answer to claude so the turn continues.
+//
+// When claude calls a tool we POST the payload to mulmoterminal's /api/gui
+// route; the server publishes it on the "gui" pub/sub channel and the Vue GUI
+// panel renders it. This is the transport-agnostic "data channel" the spike is
+// validating end-to-end under an interactive PTY (see docs/gui-protocol-spike.md).
 //
 // Context reaches this subprocess via env (set when the server builds the
 // mcp-config), mirroring MulmoClaude's MULMOCLAUDE_CHAT_SESSION_ID:
@@ -12,11 +17,18 @@
 //   MULMOTERMINAL_PORT        - the mulmoterminal HTTP port to POST to
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { randomUUID } from "node:crypto";
 import { z } from "zod";
 
 const SESSION_ID = process.env.MULMOTERMINAL_SESSION_ID;
 const PORT = process.env.MULMOTERMINAL_PORT || "3456";
-const GUI_URL = `http://localhost:${PORT}/api/gui`;
+const BASE_URL = `http://localhost:${PORT}`;
+const GUI_URL = `${BASE_URL}/api/gui`;
+
+// Overall time we wait for a form answer before giving up and telling claude the
+// user didn't respond. The server holds each long-poll open for a shorter window
+// (see /api/gui/answer); we just keep re-polling until this deadline.
+const FORM_TIMEOUT_MS = 10 * 60 * 1000;
 
 const server = new McpServer({ name: "mulmoterminal-gui", version: "0.0.0" });
 
@@ -44,6 +56,74 @@ server.registerTool(
       throw new Error(`/api/gui responded ${res.status}`);
     }
     return { content: [{ type: "text", text: "Rendered markdown in the GUI panel." }] };
+  }
+);
+
+// One field of a presentForm. `name` keys the answer; `type` picks the control.
+const fieldSchema = z.object({
+  name: z.string().describe("Key this field's value appears under in the answer."),
+  label: z.string().optional().describe("Human-readable label (defaults to name)."),
+  type: z
+    .enum(["text", "textarea", "number", "select"])
+    .optional()
+    .describe("Control type (default: text)."),
+  options: z.array(z.string()).optional().describe("Choices for a 'select' field."),
+  placeholder: z.string().optional(),
+  required: z.boolean().optional(),
+});
+
+// Long-poll the server until the user submits the form (or we hit the deadline).
+// The server holds each request open briefly and returns 204 when nothing has
+// arrived yet, so this loop paces itself without busy-waiting.
+async function awaitAnswer(requestId) {
+  const deadline = Date.now() + FORM_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const res = await fetch(`${GUI_URL}/answer/${requestId}`);
+    if (res.status === 200) return (await res.json()).answer;
+    if (res.status === 404) return null; // form no longer pending (e.g. server restarted)
+    // 204 => no answer yet; poll again.
+  }
+  return undefined; // timed out
+}
+
+server.registerTool(
+  "presentForm",
+  {
+    title: "Present Form",
+    description:
+      "Ask the user for structured input via a form in the GUI panel, instead of " +
+      "free-text in the terminal. BLOCKS until the user submits, then returns their " +
+      "answers as a JSON object keyed by each field's name. Use this when you need " +
+      "specific values (choices, parameters, confirmations) to continue.",
+    inputSchema: {
+      title: z.string().optional().describe("Heading shown above the form."),
+      fields: z.array(fieldSchema).min(1).describe("The fields to collect."),
+      submitLabel: z.string().optional().describe("Label for the submit button."),
+    },
+  },
+  async ({ title, fields, submitLabel }) => {
+    const requestId = randomUUID();
+    const res = await fetch(GUI_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sessionId: SESSION_ID,
+        type: "presentForm",
+        data: { requestId, schema: { title, fields, submitLabel } },
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`/api/gui responded ${res.status}`);
+    }
+
+    const answer = await awaitAnswer(requestId);
+    if (answer === undefined) {
+      return { content: [{ type: "text", text: "The user did not submit the form (timed out)." }] };
+    }
+    if (answer === null) {
+      return { content: [{ type: "text", text: "The form is no longer available." }] };
+    }
+    return { content: [{ type: "text", text: JSON.stringify(answer) }] };
   }
 );
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { ref } from "vue";
 import Sidebar from "./components/Sidebar.vue";
 import TerminalView from "./components/Terminal.vue";
+import GuiPanel from "./components/GuiPanel.vue";
 
 const activeId = ref<string | null>(null);
 const connectKey = ref(0);
@@ -32,11 +33,14 @@ function onSession(id: string) {
       @select="selectSession"
       @new="newSession"
     />
-    <TerminalView
-      :session-id="activeId"
-      :connect-key="connectKey"
-      @session="onSession"
-    />
+    <div class="main">
+      <TerminalView
+        :session-id="activeId"
+        :connect-key="connectKey"
+        @session="onSession"
+      />
+      <GuiPanel :session-id="activeId" />
+    </div>
   </div>
 </template>
 
@@ -46,5 +50,12 @@ function onSession(id: string) {
   height: 100vh;
   width: 100vw;
   overflow: hidden;
+}
+
+/* Sidebar | [ Terminal | GuiPanel ] — the unified two-panel view in miniature. */
+.main {
+  display: flex;
+  flex: 1;
+  min-width: 0;
 }
 </style>

--- a/src/components/GuiForm.vue
+++ b/src/components/GuiForm.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { reactive, ref, watch } from "vue";
+
+// Renders a presentForm from its schema and POSTs the user's answer back to the
+// server, which unblocks the waiting MCP tool call (Phase II round-trip). Once
+// answered — here or in another viewer — the form locks and shows the result.
+interface Field {
+  name: string;
+  label?: string;
+  // "text" (default) | "textarea" | "number" | "select"; kept as string so the
+  // schema from the server (and the parent panel) assigns without friction.
+  type?: string;
+  options?: string[];
+  placeholder?: string;
+  required?: boolean;
+}
+interface Schema {
+  title?: string;
+  fields: Field[];
+  submitLabel?: string;
+}
+
+const props = defineProps<{
+  requestId: string;
+  schema: Schema;
+  answered: boolean;
+  answer: Record<string, unknown> | null;
+}>();
+
+// Working copy of the field values, keyed by field name.
+const values = reactive<Record<string, string>>({});
+const submitted = ref(false);
+const submitting = ref(false);
+const error = ref<string | null>(null);
+
+// Seed values from the schema (and from a prior answer when replaying an already
+// completed form). Re-runs if the form arrives already answered.
+function seed() {
+  for (const f of props.schema.fields) {
+    const prior = props.answer?.[f.name];
+    values[f.name] = prior != null ? String(prior) : "";
+  }
+  submitted.value = props.answered;
+}
+seed();
+
+// Another viewer (or a history replay) reports this form was answered: lock it.
+watch(
+  () => props.answered,
+  (a) => {
+    if (a) seed();
+  }
+);
+
+const locked = () => submitted.value || props.answered;
+
+async function submit() {
+  if (locked() || submitting.value) return;
+  // Basic required-field check before we commit the round-trip.
+  for (const f of props.schema.fields) {
+    if (f.required && !values[f.name]?.trim()) {
+      error.value = `"${f.label || f.name}" is required.`;
+      return;
+    }
+  }
+  error.value = null;
+  submitting.value = true;
+  try {
+    const res = await fetch("/api/gui/answer", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ requestId: props.requestId, answer: { ...values } }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    submitted.value = true;
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>
+
+<template>
+  <form class="gui-form" @submit.prevent="submit">
+    <h3 v-if="schema.title" class="form-title">
+      {{ schema.title }}
+    </h3>
+
+    <div v-for="f in schema.fields" :key="f.name" class="field">
+      <label :for="`${requestId}-${f.name}`">{{ f.label || f.name }}</label>
+
+      <textarea
+        v-if="f.type === 'textarea'"
+        :id="`${requestId}-${f.name}`"
+        v-model="values[f.name]"
+        :placeholder="f.placeholder"
+        :disabled="locked()"
+        rows="3"
+      />
+      <select
+        v-else-if="f.type === 'select'"
+        :id="`${requestId}-${f.name}`"
+        v-model="values[f.name]"
+        :disabled="locked()"
+      >
+        <option value="" disabled>
+          {{ f.placeholder || "Select…" }}
+        </option>
+        <option v-for="opt in f.options || []" :key="opt" :value="opt">
+          {{ opt }}
+        </option>
+      </select>
+      <input
+        v-else
+        :id="`${requestId}-${f.name}`"
+        v-model="values[f.name]"
+        :type="f.type === 'number' ? 'number' : 'text'"
+        :placeholder="f.placeholder"
+        :disabled="locked()"
+      >
+    </div>
+
+    <div v-if="error" class="form-error">
+      {{ error }}
+    </div>
+
+    <div class="actions">
+      <button type="submit" :disabled="locked() || submitting">
+        {{ locked() ? "Submitted ✓" : submitting ? "Submitting…" : schema.submitLabel || "Submit" }}
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.gui-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.form-title {
+  margin: 0;
+  font-size: 15px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.field label {
+  font-size: 12px;
+  color: #9aa5c4;
+}
+
+input,
+textarea,
+select {
+  background: #0d1124;
+  border: 1px solid #2a2a4e;
+  border-radius: 6px;
+  color: #e0e0e0;
+  padding: 6px 8px;
+  font: inherit;
+  font-size: 13px;
+}
+input:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: #4a8cff;
+}
+input:disabled,
+textarea:disabled,
+select:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.form-error {
+  color: #ef9a9a;
+  font-size: 12px;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+button {
+  background: #1b3a6b;
+  color: #cfe0ff;
+  border: none;
+  border-radius: 6px;
+  padding: 7px 14px;
+  font-size: 13px;
+  cursor: pointer;
+}
+button:hover:not(:disabled) {
+  background: #224a86;
+}
+button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+</style>

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted, computed } from "vue";
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+import { usePubSub } from "../composables/usePubSub";
+
+// The GUI panel renders the structured `data` pushed by GUI-protocol MCP tools
+// (Phase I: presentMarkdown). It mirrors the terminal's active session: live
+// frames arrive on the "gui" pub/sub channel, and history is replayed from
+// /api/gui/:sessionId when a session is (re)selected. See the spike doc.
+const props = defineProps<{ sessionId: string | null }>();
+
+interface GuiFrame {
+  type: string;
+  data: { markdown?: string };
+}
+
+const frames = ref<GuiFrame[]>([]);
+
+// Render markdown -> sanitized HTML. marked handles GFM tables; DOMPurify strips
+// anything unsafe before it reaches v-html.
+function renderMarkdown(md: string): string {
+  const raw = marked.parse(md, { async: false }) as string;
+  return DOMPurify.sanitize(raw);
+}
+
+const renderedFrames = computed(() =>
+  frames.value.map((f) => renderMarkdown(f.data.markdown ?? ""))
+);
+
+async function loadHistory(id: string) {
+  try {
+    const res = await fetch(`/api/gui/${encodeURIComponent(id)}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    frames.value = data.payloads ?? [];
+  } catch {
+    frames.value = [];
+  }
+}
+
+// Reload history whenever the active session changes (and clear for a fresh,
+// not-yet-identified session).
+watch(
+  () => props.sessionId,
+  (id) => {
+    if (id) loadHistory(id);
+    else frames.value = [];
+  },
+  { immediate: true }
+);
+
+const GUI_CHANNEL_NAME = "gui";
+const { subscribe } = usePubSub();
+let unsubscribe: (() => void) | undefined;
+
+onMounted(() => {
+  unsubscribe = subscribe(GUI_CHANNEL_NAME, (data) => {
+    const msg = data as { sessionId: string } & GuiFrame;
+    // Only render frames for the session currently in the foreground.
+    if (msg.sessionId !== props.sessionId) return;
+    frames.value = [...frames.value, { type: msg.type, data: msg.data }];
+  });
+});
+onUnmounted(() => unsubscribe?.());
+
+const hasContent = computed(() => frames.value.length > 0);
+</script>
+
+<template>
+  <section class="gui-panel">
+    <div class="header">
+      <span class="title">GUI</span>
+    </div>
+    <div class="content">
+      <div v-if="!hasContent" class="empty">
+        Ask Claude to use <code>presentMarkdown</code> to render content here.
+      </div>
+      <!-- DOMPurify-sanitized above; v-html is required to render markdown. -->
+      <!-- eslint-disable vue/no-v-html -->
+      <article
+        v-for="(html, i) in renderedFrames"
+        :key="i"
+        class="frame markdown-body"
+        v-html="html"
+      />
+      <!-- eslint-enable vue/no-v-html -->
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.gui-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  height: 100vh;
+  background: #11162a;
+  border-left: 1px solid #2a2a4e;
+}
+
+.header {
+  padding: 8px 16px;
+  background: #16213e;
+  color: #e0e0e0;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+}
+.title {
+  font-weight: 600;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+  color: #e0e0e0;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.empty {
+  color: #7c87a8;
+  font-size: 13px;
+}
+.empty code {
+  background: #1d2b4e;
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+
+.frame + .frame {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #2a2a4e;
+}
+</style>
+
+<!-- Markdown element styling (unscoped: targets v-html output). -->
+<style>
+.markdown-body table {
+  border-collapse: collapse;
+  margin: 8px 0;
+}
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid #2a2a4e;
+  padding: 4px 10px;
+  text-align: left;
+}
+.markdown-body th {
+  background: #1d2b4e;
+}
+.markdown-body code {
+  background: #1d2b4e;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.9em;
+}
+.markdown-body pre {
+  background: #0d1124;
+  padding: 10px 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+.markdown-body pre code {
+  background: none;
+  padding: 0;
+}
+.markdown-body a {
+  color: #4a8cff;
+}
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3 {
+  margin: 12px 0 6px;
+}
+</style>

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -3,16 +3,28 @@ import { ref, watch, onMounted, onUnmounted, computed } from "vue";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { usePubSub } from "../composables/usePubSub";
+import GuiForm from "./GuiForm.vue";
 
 // The GUI panel renders the structured `data` pushed by GUI-protocol MCP tools
-// (Phase I: presentMarkdown). It mirrors the terminal's active session: live
+// (presentMarkdown, presentForm). It mirrors the terminal's active session: live
 // frames arrive on the "gui" pub/sub channel, and history is replayed from
 // /api/gui/:sessionId when a session is (re)selected. See the spike doc.
 const props = defineProps<{ sessionId: string | null }>();
 
+interface FormSchema {
+  title?: string;
+  fields: { name: string; label?: string; type?: string; options?: string[] }[];
+  submitLabel?: string;
+}
 interface GuiFrame {
   type: string;
-  data: { markdown?: string };
+  data: {
+    markdown?: string;
+    requestId?: string;
+    schema?: FormSchema;
+    answered?: boolean;
+    answer?: Record<string, unknown> | null;
+  };
 }
 
 const frames = ref<GuiFrame[]>([]);
@@ -23,10 +35,6 @@ function renderMarkdown(md: string): string {
   const raw = marked.parse(md, { async: false }) as string;
   return DOMPurify.sanitize(raw);
 }
-
-const renderedFrames = computed(() =>
-  frames.value.map((f) => renderMarkdown(f.data.markdown ?? ""))
-);
 
 async function loadHistory(id: string) {
   try {
@@ -59,6 +67,18 @@ onMounted(() => {
     const msg = data as { sessionId: string } & GuiFrame;
     // Only render frames for the session currently in the foreground.
     if (msg.sessionId !== props.sessionId) return;
+    if (msg.type === "formAnswered") {
+      // A submission (here or in another viewer) completed a pending form: lock
+      // the matching frame and record the answer.
+      const f = frames.value.find(
+        (fr) => fr.type === "presentForm" && fr.data.requestId === msg.data.requestId
+      );
+      if (f) {
+        f.data.answered = true;
+        f.data.answer = msg.data.answer ?? null;
+      }
+      return;
+    }
     frames.value = [...frames.value, { type: msg.type, data: msg.data }];
   });
 });
@@ -74,17 +94,22 @@ const hasContent = computed(() => frames.value.length > 0);
     </div>
     <div class="content">
       <div v-if="!hasContent" class="empty">
-        Ask Claude to use <code>presentMarkdown</code> to render content here.
+        Ask Claude to use <code>presentMarkdown</code> or <code>presentForm</code>
+        to render content here.
       </div>
-      <!-- DOMPurify-sanitized above; v-html is required to render markdown. -->
-      <!-- eslint-disable vue/no-v-html -->
-      <article
-        v-for="(html, i) in renderedFrames"
-        :key="i"
-        class="frame markdown-body"
-        v-html="html"
-      />
-      <!-- eslint-enable vue/no-v-html -->
+      <template v-for="(f, i) in frames" :key="i">
+        <GuiForm
+          v-if="f.type === 'presentForm' && f.data.requestId && f.data.schema"
+          class="frame"
+          :request-id="f.data.requestId"
+          :schema="f.data.schema"
+          :answered="f.data.answered ?? false"
+          :answer="f.data.answer ?? null"
+        />
+        <!-- DOMPurify-sanitized in renderMarkdown; v-html required to render it. -->
+        <!-- eslint-disable-next-line vue/no-v-html -->
+        <article v-else class="frame markdown-body" v-html="renderMarkdown(f.data.markdown ?? '')" />
+      </template>
     </div>
   </section>
 </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,6 +179,11 @@
   resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.15.1.tgz#b13bc464ca162c17abf0837fb3a11aeab79e45d1"
   integrity sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==
 
+"@hono/node-server@^1.19.9":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
+
 "@humanfs/core@^0.19.2":
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.2.tgz#a8272ca03b2acf492670222b2320b6c421bfde60"
@@ -226,6 +231,29 @@
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@modelcontextprotocol/sdk@^1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
+  integrity sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==
+  dependencies:
+    "@hono/node-server" "^1.19.9"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.2.1"
+    express-rate-limit "^8.2.1"
+    hono "^4.11.4"
+    jose "^6.1.3"
+    json-schema-typed "^8.0.2"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.25 || ^4.0"
+    zod-to-json-schema "^3.25.1"
 
 "@napi-rs/wasm-runtime@^1.1.4":
   version "1.1.5"
@@ -455,6 +483,11 @@
   dependencies:
     "@types/http-errors" "*"
     "@types/node" "*"
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@types/ws@^8.18.1", "@types/ws@^8.5.12":
   version "8.18.1"
@@ -804,6 +837,13 @@ acorn@^8.16.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.17.0.tgz#1785adb84faf8d8add10369b93826fc2bd08f1fe"
   integrity sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.14.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
@@ -813,6 +853,16 @@ ajv@^6.14.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.17.1:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 alien-signals@^3.2.0:
   version "3.2.1"
@@ -1009,7 +1059,7 @@ cookie@^0.7.1, cookie@~0.7.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
-cors@~2.8.5:
+cors@^2.8.5, cors@~2.8.5:
   version "2.8.6"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.6.tgz#ff5dd69bd95e547503820d29aba4f8faf8dfec96"
   integrity sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==
@@ -1017,7 +1067,7 @@ cors@~2.8.5:
     object-assign "^4"
     vary "^1"
 
-cross-spawn@^7.0.6:
+cross-spawn@^7.0.5, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -1078,6 +1128,13 @@ detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+dompurify@^3.4.10:
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.10.tgz#96704295b4d8aeefcc8c7a90caa579b0ad69e46a"
+  integrity sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -1325,10 +1382,29 @@ etag@^1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.1.0.tgz#4e198eb91cd333d0a8ddcc036502b3618a25f449"
+  integrity sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
+
 expect-type@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
   integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
+
+express-rate-limit@^8.2.1:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz#5922dbf76df2124611cea955d93432b37514b2f3"
+  integrity sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==
+  dependencies:
+    ip-address "^10.2.0"
 
 express@^5.2.1:
   version "5.2.1"
@@ -1378,6 +1454,11 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-uri@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fdir@^6.5.0:
   version "6.5.0"
@@ -1522,6 +1603,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hono@^4.11.4:
+  version "4.12.25"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.25.tgz#f2d9996a54e8c9c0c5f5de1c8f3a962e43a98c4e"
+  integrity sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==
+
 html-encoding-sniffer@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz#f8d9390b3b348b50d4f61c16dd2ef5c05980a882"
@@ -1572,6 +1658,11 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+ip-address@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
@@ -1617,6 +1708,11 @@ jackspeak@^3.1.2:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
+
+jose@^6.1.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
+  integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
 
 js-beautify@^1.14.9:
   version "1.15.4"
@@ -1670,6 +1766,16 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-schema-typed@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
+  integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -1788,6 +1894,11 @@ magic-string@^0.30.21:
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
+
+marked@^18.0.5:
+  version "18.0.5"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.5.tgz#c229c0ac6ad1e275ae8e5037c6168f76d2f42e61"
+  integrity sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -2023,6 +2134,11 @@ picomatch@^4.0.3, picomatch@^4.0.4:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
+
 postcss-selector-parser@^7.1.0:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz#69dc7a526517572ff6b150e352b36a016017b485"
@@ -2075,7 +2191,7 @@ range-parser@^1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@^3.0.1:
+raw-body@^3.0.0, raw-body@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
   integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
@@ -2720,3 +2836,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod-to-json-schema@^3.25.1:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
+  integrity sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==
+
+"zod@^3.25 || ^4.0":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
A throwaway spike (see `docs/gui-protocol-spike.md`) that validates whether MulmoClaude's **GUI chat protocol** survives the move from headless `claude -p` to an **interactive `claude` running in a PTY**. Both phases are implemented and smoke-tested.

## The seam under test
```
interactive claude (PTY) → MCP tool → POST /api/gui → socket.io "gui" channel → Vue GuiPanel
```
The GUI is driven by MCP tools that push a structured `data` payload server-side — transport-agnostic, and the question was whether it works identically under an interactive PTY. **It does.**

## Phase I — `presentMarkdown` (one-way)
- `server/mcp/present-markdown.js`: stdio MCP server (official SDK) exposing `presentMarkdown({markdown})`; POSTs `{sessionId, type, data}` to `/api/gui`.
- `server/index.js`: `mcpConfigJson()` wires `--mcp-config` (inline JSON) + per-session env into each PTY spawn; `POST/GET /api/gui` store-and-publish + history replay.
- `GuiPanel.vue`: subscribes to `gui`, renders `marked` + **DOMPurify**-sanitized markdown, replays history on session change. `App.vue`: `Sidebar | [ Terminal | GuiPanel ]`.

## Phase II — `presentForm` (blocking round-trip)
- `presentForm({title,fields,submitLabel})` generates a `requestId`, POSTs the form, then **long-polls** `/api/gui/answer` until the user submits (10-min deadline), returning the answer JSON to claude.
- Server: `pendingForms` registry; `GET /api/gui/answer/:requestId` (25s chunked hold → 204 re-poll); `POST /api/gui/answer` (idempotent, broadcasts `formAnswered`).
- `GuiForm.vue`: renders text/textarea/number/select from schema, validates required fields, locks once answered.

## Key finding for MulmoClaude
The load-bearing assumption holds: a **blocking** GUI tool works under the interactive PTY with no special claude support — the block lives entirely in the MCP subprocess (awaiting an HTTP round-trip) and is invisible to claude. `handlePermission` is the same shape, so the `AskUserQuestion → presentForm` redirect should port cleanly.

## Verification
- `yarn typecheck`, `yarn lint`, `yarn test` (4/4) all pass.
- Smoke-tested both seams end-to-end (MCP handshake → tool call → store/replay; full blocking form round-trip) plus validation guards (400/404 on bad sessionId/type/requestId/answer/schema).

## Not in scope / remaining
- Manual run against a real interactive `claude` (`yarn dev`).
- Deferred probe: the native permission prompt (`--permission-prompt-tool`) — the biggest open risk for the migration.
- GUI state is in-memory (spike only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)