### PR TITLE
refactor: rename presentMarkdown GUI tool to presentDocument

### DIFF
--- a/docs/gui-protocol-spike.md
+++ b/docs/gui-protocol-spike.md
@@ -1,12 +1,12 @@
 # GUI Chat Protocol Spike (mulmoterminal)
 
 A throwaway spike inside **mulmoterminal** to learn what it takes to support
-MulmoClaude's **GUI chat protocol** (`presentMarkdown`, `presentForm`, …) on top
+MulmoClaude's **GUI chat protocol** (`presentDocument`, `presentForm`, …) on top
 of the **interactive PTY** architecture. The lessons feed the larger MulmoClaude
 migration — see [Background](#background).
 
 > Status: Phase I + II **validated against a real interactive `claude`**
-> (`presentMarkdown` one-way and `presentForm` round-trip both work). Permissions
+> (`presentDocument` one-way and `presentForm` round-trip both work). Permissions
 > are **decided, not probed** — terminal-native (see
 > [Decision](#decision-permissions-are-terminal-native)).
 
@@ -31,7 +31,7 @@ MulmoClaude.
 
 ```
  interactive claude (PTY)
-        │  calls MCP tool  presentMarkdown({ markdown })
+        │  calls MCP tool  presentDocument({ markdown })
         ▼
  stdio MCP server  ──HTTP POST /api/gui {sessionId,type,data}──►  mulmoterminal server
         ▲                                                              │ publish on "gui"
@@ -47,17 +47,17 @@ MulmoClaude.
 
 ---
 
-## Phase I — `presentMarkdown` (one-way)
+## Phase I — `presentDocument` (one-way)
 
 **Goal:** prove the full **MCP tool → `data` → GUI panel** pipe with the
-simplest possible plugin. `presentMarkdown` is one-directional (LLM emits
+simplest possible plugin. `presentDocument` is one-directional (LLM emits
 markdown, panel renders it), so it isolates the data pipe with no round-trip.
 
 ### Steps
 
 1. **MCP server** — a small stdio server (`server/mcp/present-markdown.js`)
-   exposing one tool `presentMarkdown({ markdown })`. On call, it `POST`s
-   `{ sessionId, type: "presentMarkdown", data: { markdown } }` to
+   exposing one tool `presentDocument({ markdown })`. On call, it `POST`s
+   `{ sessionId, type: "presentDocument", data: { markdown } }` to
    `http://localhost:<PORT>/api/gui`, then returns a short ack string to claude.
    - `sessionId` + `PORT` reach the MCP process via **env** (set when we build
      its mcp-config), mirroring MulmoClaude's `MULMOCLAUDE_CHAT_SESSION_ID`.
@@ -78,7 +78,7 @@ markdown, panel renders it), so it isolates the data pipe with no round-trip.
 
 ### Acceptance
 
-- Tell claude "use presentMarkdown to show me a table of …"; the **terminal**
+- Tell claude "use presentDocument to show me a table of …"; the **terminal**
   shows the tool call and the **right panel** renders the markdown.
 - Switching sessions in the sidebar replays the correct session's GUI.
 
@@ -92,7 +92,7 @@ interactive `claude` is the remaining manual check.
   `claude` accepts `--mcp-config <configs...>` as **JSON strings** (not only file
   paths), so `server/index.js` builds the config inline per session
   (`mcpConfigJson(sessionId)`) and appends `--mcp-config <json>
-  --strict-mcp-config --allowedTools mcp__mulmoterminal-gui__presentMarkdown` to
+  --strict-mcp-config --allowedTools mcp__mulmoterminal-gui__presentDocument` to
   the existing `--settings`/`--session-id`/`--resume` args. No temp file to
   manage. `--strict-mcp-config` keeps the user's own MCP servers out of the
   spike; `--allowedTools` auto-runs the tool (no permission prompt — permissions
@@ -107,7 +107,7 @@ interactive `claude` is the remaining manual check.
   keyed by `sessionId` and `pubsub.publish("gui", { sessionId, type, data })`.
   The panel filters the `gui` channel by the foreground `sessionId` and replays
   history from `GET /api/gui/:sessionId`. `type` is the discriminator
-  (`presentMarkdown` now; `presentForm` next) and `data` is the opaque
+  (`presentDocument` now; `presentForm` next) and `data` is the opaque
   tool-specific payload — exactly MulmoClaude's "MCP server posts a toolResult
   to an internal route" pattern, transport-agnostic over the PTY.
 - **Surprises / blockers:** none blocking. Notes: used the official

--- a/server/index.js
+++ b/server/index.js
@@ -37,20 +37,20 @@ function isAllowedOrigin(origin) {
 // Pub/sub channel the sidebar subscribes to for live session-activity changes.
 const SESSIONS_CHANNEL = "sessions";
 
-// Pub/sub channel the GUI panel subscribes to. The presentMarkdown MCP tool
+// Pub/sub channel the GUI panel subscribes to. The presentDocument MCP tool
 // POSTs to /api/gui, which stores the payload and publishes it here keyed by
 // session id (see docs/gui-protocol-spike.md).
 const GUI_CHANNEL = "gui";
 
 // Stdio MCP server wired into each spawned claude (--mcp-config). It exposes the
-// GUI-protocol tools (presentMarkdown, presentForm) that drive the GUI panel.
+// GUI-protocol tools (presentDocument, presentForm) that drive the GUI panel.
 const MCP_SERVER_PATH = path.join(__dirname, "mcp", "present-markdown.js");
 
 // MCP tool names claude uses, in the mcp__<server>__<tool> form. Auto-allowed via
 // --allowedTools so the spike doesn't trip the permission prompt (a deferred
 // probe — see the doc). Comma-joined into a single --allowedTools value.
 const GUI_MCP_TOOLS = [
-  "mcp__mulmoterminal-gui__presentMarkdown",
+  "mcp__mulmoterminal-gui__presentDocument",
   "mcp__mulmoterminal-gui__presentForm",
 ].join(",");
 
@@ -177,7 +177,7 @@ function hookSettingsJson() {
 }
 
 // MCP config injected via `claude --mcp-config <json>`. Registers the stdio
-// presentMarkdown server and passes this session's id + the server port to it
+// presentDocument server and passes this session's id + the server port to it
 // via env (the MCP process can't otherwise know which session it belongs to).
 function mcpConfigJson(sessionId) {
   return JSON.stringify({
@@ -293,7 +293,7 @@ app.post("/api/gui", (req, res) => {
   }
 
   let frame;
-  if (type === "presentMarkdown") {
+  if (type === "presentDocument") {
     if (typeof data.markdown !== "string") {
       return res.status(400).json({ error: "invalid markdown" });
     }
@@ -522,7 +522,7 @@ wss.on("connection", (ws, req) => {
     }
   } else {
     const settings = hookSettingsJson();
-    // Register the GUI MCP server and auto-allow its tool so presentMarkdown
+    // Register the GUI MCP server and auto-allow its tool so presentDocument
     // runs without a permission prompt (--strict-mcp-config keeps the user's
     // other MCP servers out of the spike).
     const mcp = mcpConfigJson(sessionId);

--- a/server/mcp/present-markdown.js
+++ b/server/mcp/present-markdown.js
@@ -1,7 +1,7 @@
 // Stdio MCP server for the GUI chat protocol spike.
 //
 // Exposes the GUI-protocol tools:
-//   presentMarkdown({ markdown })  - Phase I, one-way: render markdown.
+//   presentDocument({ markdown })  - Phase I, one-way: render markdown.
 //   presentForm({ title, fields }) - Phase II, round-trip: render a form and
 //                                    block until the user submits, returning
 //                                    the answer to claude so the turn continues.
@@ -33,9 +33,9 @@ const FORM_TIMEOUT_MS = 10 * 60 * 1000;
 const server = new McpServer({ name: "mulmoterminal-gui", version: "0.0.0" });
 
 server.registerTool(
-  "presentMarkdown",
+  "presentDocument",
   {
-    title: "Present Markdown",
+    title: "Present Document",
     description:
       "Render markdown in the user's GUI panel (right side), beside the terminal. " +
       "Use this to show formatted content — tables, lists, headings, code — that is " +
@@ -48,7 +48,7 @@ server.registerTool(
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         sessionId: SESSION_ID,
-        type: "presentMarkdown",
+        type: "presentDocument",
         data: { markdown },
       }),
     });

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -6,7 +6,7 @@ import { usePubSub } from "../composables/usePubSub";
 import GuiForm from "./GuiForm.vue";
 
 // The GUI panel renders the structured `data` pushed by GUI-protocol MCP tools
-// (presentMarkdown, presentForm). It mirrors the terminal's active session: live
+// (presentDocument, presentForm). It mirrors the terminal's active session: live
 // frames arrive on the "gui" pub/sub channel, and history is replayed from
 // /api/gui/:sessionId when a session is (re)selected. See the spike doc.
 const props = defineProps<{ sessionId: string | null }>();
@@ -94,7 +94,7 @@ const hasContent = computed(() => frames.value.length > 0);
     </div>
     <div class="content">
       <div v-if="!hasContent" class="empty">
-        Ask Claude to use <code>presentMarkdown</code> or <code>presentForm</code>
+        Ask Claude to use <code>presentDocument</code> or <code>presentForm</code>
         to render content here.
       </div>
       <template v-for="(f, i) in frames" :key="i">


### PR DESCRIPTION
## Summary
Renames the Phase I GUI-protocol tool from `presentMarkdown` to `presentDocument` throughout the spike.

Changes:
- `server/mcp/present-markdown.js` — tool registration name, title ("Present Document"), and pub/sub message `type`.
- `server/index.js` — `--allowedTools` entry (`mcp__mulmoterminal-gui__presentDocument`), the `/api/gui` frame-type check, and comments.
- `src/components/GuiPanel.vue` — placeholder hint text.
- `docs/gui-protocol-spike.md` — all prose references.

Left unchanged intentionally:
- The `markdown` payload field — content is still markdown; only the tool name changed.
- The `present-markdown.js` filename and its `MCP_SERVER_PATH` — keeps the spawn path stable.

The Vue panel renders any non-`presentForm` frame as markdown, so no rendering logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)