### PR TITLE
fix: make .env optional (--env-file-if-exists) and require Node ≥ 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,16 @@ SDK; we drive the real interactive CLI and relay its TTY over the WebSocket.
 | Backend  | Node (ESM), Express 5, `ws` (terminal WebSocket), `node-pty`, socket.io |
 | Tests    | Vitest + @vue/test-utils + jsdom |
 
-Requires **Node ≥ 20.6** (uses `node --env-file`) and the `claude` CLI on `PATH`.
+Requires **Node ≥ 22** (uses `node --env-file-if-exists`) and the `claude` CLI on `PATH`.
 
 ---
 
 ## Configuration
 
-The server is configured entirely through environment variables, loaded from a
-`.env` file via `node --env-file=.env` (wired into the npm scripts).
+The server is configured entirely through environment variables, optionally
+loaded from a `.env` file via `node --env-file-if-exists=.env` (wired into the
+npm scripts). The `.env` is optional — every variable below has a default, so
+the server runs without one.
 
 | Variable     | Default        | Description |
 | ------------ | -------------- | ----------- |
@@ -112,7 +114,7 @@ yarn install            # postinstall fixes node-pty prebuilt binary perms
 
 yarn dev                # server (:3456) + Vite dev server, concurrently
 # or individually:
-yarn dev:server         # backend only  (node --env-file=.env server/index.js)
+yarn dev:server         # backend only  (node --env-file-if-exists=.env server/index.js)
 yarn dev:client         # Vite dev server only
 
 yarn build              # type-check (vue-tsc) + vite build -> dist/

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ SDK; we drive the real interactive CLI and relay its TTY over the WebSocket.
 | Backend  | Node (ESM), Express 5, `ws` (terminal WebSocket), `node-pty`, socket.io |
 | Tests    | Vitest + @vue/test-utils + jsdom |
 
-Requires **Node ≥ 22** (uses `node --env-file-if-exists`) and the `claude` CLI on `PATH`.
+Requires **Node ≥ 22.9** (uses `node --env-file-if-exists`) and the `claude` CLI on `PATH`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,15 +3,18 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
-    "dev": "concurrently -n server,vite -c blue,green \"node --env-file=.env server/index.js\" \"vite\"",
-    "dev:server": "node --env-file=.env server/index.js",
+    "dev": "concurrently -n server,vite -c blue,green \"node --env-file-if-exists=.env server/index.js\" \"vite\"",
+    "dev:server": "node --env-file-if-exists=.env server/index.js",
     "dev:client": "vite",
     "build": "vue-tsc -b && vite build",
     "typecheck": "vue-tsc -b",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "node --env-file=.env server/index.js",
+    "server": "node --env-file-if-exists=.env server/index.js",
     "test": "vitest run",
     "postinstall": "node server/fix-pty-perms.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.9"
   },
   "scripts": {
     "dev": "concurrently -n server,vite -c blue,green \"node --env-file-if-exists=.env server/index.js\" \"vite\"",


### PR DESCRIPTION
## Summary

`yarn dev` launched Vite but the Express server was dead. Root cause: the npm scripts used `node --env-file=.env`, and Node **aborts on startup when `.env` is missing**. `concurrently` keeps the other process alive, so only Vite survived. Since every config var already has a code default (`PORT`, `CLAUDE_BIN`, `CLAUDE_CWD`), `.env` was never actually required — only the flag made it mandatory.

This switches `dev` / `dev:server` / `server` to `--env-file-if-exists=.env` (load if present, skip if absent), pins `engines.node` to `>=22`, and updates the README.

## Items to Confirm / Review

- **Node ≥ 22.9 bump**: `--env-file-if-exists` needs Node ≥ 22.9 (or ≥ 20.18). We set `engines.node` to `>=22.9` per request. Confirm no contributor/CI runs an older Node. CI workflow Node version was **not** touched in this PR — check if it needs aligning.
- **`engines` is advisory**: `yarn`/`npm` warn but don't hard-fail on engine mismatch unless `engine-strict` is enabled. Fine as documentation; flag if you want enforcement.
- No `.env.example` was added (the `.env` is gitignored and now fully optional). Say if you'd like one.

## User Prompt

Consolidated from the conversation:
- `yarn dev` starts but the Express server doesn't seem to be running — why?
- Can we make it skip when `.env` is absent? Is `.env` even required?
- Let's require Node 22+.
- Create a PR.

## Changes

- `package.json`: `--env-file=.env` → `--env-file-if-exists=.env` in `dev`, `dev:server`, `server`; add `"engines": { "node": ">=22" }`.
- `README.md`: bump requirement to Node ≥ 22, note `.env` is optional, update the `dev:server` command reference.

## Verification

- `node --env-file-if-exists=.env server/index.js` with no `.env` → `".env not found. Continuing without it."` then `mulmoterminal running at http://localhost:...` (no crash).
- `yarn lint` ✅ · `yarn build` ✅ (pre-existing chunk-size warning unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
