### PR TITLE
feat: add a tools pane (available tools + full tool-call history)

### DIFF
--- a/docs/gui-protocol-spike.md
+++ b/docs/gui-protocol-spike.md
@@ -285,6 +285,30 @@ interactive `claude`** is the remaining manual check (the unit under it —
   the spike now exercises the *actual* GUI→LLM mechanism the migration depends on,
   and removes ~70 lines of parked-response/timeout bookkeeping.
 
+### Tools pane (gear toggle)
+
+Mirrors MulmoClaude's right sidebar (`RightSidebar.vue`): a gear button in the GUI
+panel header toggles a third column (`src/components/ToolsPane.vue`, visibility
+persisted in `localStorage`) with two sections:
+
+- **Available Tools** — the enabled GUI plugin tools (name + collapsible
+  description) from `GET /api/tools` (registry `toolSummaries`). The full set claude
+  can call (built-ins, other MCP) isn't enumerable server-side, so it isn't listed
+  here — but it *does* appear in the history below.
+- **Tool Call History** — **every** tool call for the session (Bash, Read, other
+  MCP, and the GUI plugin tools), each row showing name, status/duration, time, and
+  collapsible arguments + result.
+
+**Key point — the history is hook-driven, not broker-driven.** The MCP broker only
+sees GUI-protocol tool calls, so it can't be the history source. Instead the spawn's
+`--settings` registers **`PreToolUse` + `PostToolUse` hooks (matcher `""` = all
+tools)** that `curl` each event to `/api/hook`; the server keys a per-session history
+by **`tool_use_id`** (PreToolUse → "running", PostToolUse → completes it with
+`tool_output` + `duration_ms`) and publishes on `toolcalls:<id>`, replayed from
+`GET /api/tool-calls/:id`. This is the same shape as MulmoClaude's
+`toolCallHistory` (toolCall event → toolCallResult event), and confirms hooks are a
+viable, complete tool-call feed under the interactive PTY — useful beyond this pane.
+
 ---
 
 ## Decision: permissions are terminal-native

--- a/docs/gui-protocol-spike.md
+++ b/docs/gui-protocol-spike.md
@@ -231,12 +231,15 @@ real protocol**, so M3 is a near-copy port rather than a translation. Three shif
 
 **Persistence (what we store, and why so little).** Chat + message history already
 live in the terminal and Claude's `.jsonl` (resume), so the only GUI-side store is
-the **list of toolResults per session id** (`toolResultsBySession`, in-memory for
-the spike), replayed from `GET /api/agent/toolResults/:id` on (re)select. A view's
-state change (e.g. a submitted form's `viewState`) is persisted by re-`POST`ing the
-same `uuid` to `/api/agent/toolResult`, which upserts in place (dedupe by `uuid`,
-mirroring `applyToolResultToSession`) — so a revisited session shows the form as
-already submitted.
+the **list of toolResults per session id**, replayed from
+`GET /api/agent/toolResults/:id` on (re)select. A view's state change (e.g. a
+submitted form's `viewState`) is persisted by re-`POST`ing the same `uuid` to
+`/api/agent/toolResult`, which upserts in place (dedupe by `uuid`, mirroring
+`applyToolResultToSession`) — so a revisited session shows the form as already
+submitted. The store is **mirrored to disk** (one JSON file per session under
+`<workspace>/.toolresults/`, via a small `createSessionStore(dirName)` helper: an
+in-memory Map as the working copy, rewritten on each change and lazy-loaded on
+first access) so the rendered views also survive a **server reboot**.
 
 ### Updated seam
 

--- a/docs/gui-protocol-spike.md
+++ b/docs/gui-protocol-spike.md
@@ -309,6 +309,12 @@ by **`tool_use_id`** (PreToolUse → "running", PostToolUse → completes it wit
 `toolCallHistory` (toolCall event → toolCallResult event), and confirms hooks are a
 viable, complete tool-call feed under the interactive PTY — useful beyond this pane.
 
+**Persistence (survives reboot).** The tool-call history is mirrored to disk via the
+same `createSessionStore(dirName)` helper the GUI toolResults use — one JSON file per
+session under `<workspace>/.toolcalls/<sessionId>.json` (`<workspace>` = `CLAUDE_CWD`).
+The in-memory Map is the working copy; the file is rewritten on each change and
+lazy-loaded on first access, so the history is still there after a server restart.
+
 ---
 
 ## Decision: permissions are terminal-native

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,7 @@ export default [
         WebSocket: "readonly",
         ResizeObserver: "readonly",
         location: "readonly",
+        localStorage: "readonly",
         setTimeout: "readonly",
         fetch: "readonly",
       },

--- a/server/index.js
+++ b/server/index.js
@@ -53,18 +53,66 @@ const MCP_SERVER_PATH = path.join(__dirname, "mcp", "broker.js");
 // prompt (permissions stay terminal-native). Comma-joined into one --allowedTools.
 const GUI_MCP_TOOLS = allowedToolNames().join(",");
 
-// GUI toolResults per session, kept in memory for the spike so the panel can
-// replay them when a session is (re)selected. (Chat + message history already
-// live in the terminal and Claude's .jsonl; this is the only GUI-side store.)
+// A per-session list store mirrored to disk so it survives a server reboot — one
+// JSON file per session under <workspace>/<dirName>/<sessionId>.json
+// (<workspace> = CLAUDE_CWD). The in-memory Map is the working copy; the file is
+// rewritten on each change and lazy-loaded on first access. Session ids are
+// validated UUIDs (SESSION_ID_RE), so they're safe to use as filenames.
+function createSessionStore(dirName) {
+  const dir = path.join(CLAUDE_CWD, dirName);
+  const fileFor = (id) => path.join(dir, `${id}.json`);
+  const map = new Map(); // id -> list (the working copy; mutate in place)
+  const loading = new Map(); // id -> Promise<list>, dedupes concurrent loads
+
+  // Lazily load a session's list from disk, then keep using the in-memory copy.
+  function get(sessionId) {
+    const cached = map.get(sessionId);
+    if (cached) return Promise.resolve(cached);
+    if (loading.has(sessionId)) return loading.get(sessionId);
+    const p = (async () => {
+      let list = [];
+      if (SESSION_ID_RE.test(sessionId)) {
+        try {
+          const parsed = JSON.parse(await fs.readFile(fileFor(sessionId), "utf8"));
+          if (Array.isArray(parsed)) list = parsed;
+        } catch {
+          // No file yet (or unreadable) => start empty.
+        }
+      }
+      map.set(sessionId, list);
+      loading.delete(sessionId);
+      return list;
+    })();
+    loading.set(sessionId, p);
+    return p;
+  }
+
+  // Persist a session's list (best-effort, fire-and-forget).
+  async function save(sessionId) {
+    if (!SESSION_ID_RE.test(sessionId)) return;
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(fileFor(sessionId), JSON.stringify(map.get(sessionId) || []));
+    } catch (e) {
+      console.error(`[${dirName}] failed to persist ${sessionId}: ${e.message}`);
+    }
+  }
+
+  return { get, save };
+}
+
+// GUI toolResults per session, persisted under <workspace>/.toolresults so the
+// panel replays the rendered views even after a server reboot. (Chat + message
+// history live in the terminal and Claude's .jsonl; this is the GUI-side store.)
 // Each entry is an array of toolResults, capped to the most recent N.
-const toolResultsBySession = new Map(); // id -> [toolResult]
+const toolResultsStore = createSessionStore(".toolresults");
 const GUI_HISTORY_LIMIT = 50;
 
 // Upsert a toolResult into a session's list, deduped by uuid — a re-emitted result
 // (e.g. a form whose viewState changed after the user submitted) updates in place.
 // Mirrors MulmoClaude's applyToolResultToSession.
-function storeToolResult(sessionId, result) {
-  const list = toolResultsBySession.get(sessionId) || [];
+async function storeToolResult(sessionId, result) {
+  const list = await toolResultsStore.get(sessionId);
   const idx = list.findIndex((r) => r.uuid === result.uuid);
   if (idx >= 0) {
     list[idx] = result;
@@ -72,7 +120,7 @@ function storeToolResult(sessionId, result) {
     list.push(result);
     if (list.length > GUI_HISTORY_LIMIT) list.splice(0, list.length - GUI_HISTORY_LIMIT);
   }
-  toolResultsBySession.set(sessionId, list);
+  toolResultsStore.save(sessionId);
 }
 
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
@@ -290,7 +338,7 @@ app.post("/api/hook", (req, res) => {
 // We store the result keyed by session id and publish it on that session's channel
 // so the active panel renders/updates it live. Mirrors MulmoClaude's internal
 // toolResult route + applyToolResultToSession.
-app.post("/api/agent/toolResult", (req, res) => {
+app.post("/api/agent/toolResult", async (req, res) => {
   const { sessionId, toolName, uuid } = req.body || {};
   // The session id flows from env (broker) / the client and ends up in a pub/sub
   // channel name — keep it to the known UUID shape.
@@ -308,7 +356,7 @@ app.post("/api/agent/toolResult", (req, res) => {
   // the panel renders.
   const result = { ...req.body };
   delete result.sessionId;
-  storeToolResult(sessionId, result);
+  await storeToolResult(sessionId, result);
 
   pubsub?.publish(sessionChannel(sessionId), result);
   console.log(`[gui] toolResult ${toolName} for ${sessionId}`);
@@ -316,13 +364,14 @@ app.post("/api/agent/toolResult", (req, res) => {
 });
 
 // Replay a session's stored toolResults so the panel can render them when the
-// user (re)selects that session.
-app.get("/api/agent/toolResults/:sessionId", (req, res) => {
+// user (re)selects that session. Loads from disk (<workspace>/.toolresults) on
+// first access so the views survive a reboot.
+app.get("/api/agent/toolResults/:sessionId", async (req, res) => {
   const { sessionId } = req.params;
   if (!SESSION_ID_RE.test(sessionId)) {
     return res.status(400).json({ error: "invalid sessionId" });
   }
-  res.json({ sessionId, toolResults: toolResultsBySession.get(sessionId) || [] });
+  res.json({ sessionId, toolResults: await toolResultsStore.get(sessionId) });
 });
 
 // List the chat sessions for the current project (CLAUDE_CWD), including

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ import fs from "fs/promises";
 import { randomUUID } from "crypto";
 import { fileURLToPath } from "url";
 import { createPubSub } from "./pubsub.js";
-import { mountAllRoutes, allowedToolNames } from "./plugins-registry.js";
+import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-registry.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -123,6 +123,44 @@ async function storeToolResult(sessionId, result) {
   toolResultsStore.save(sessionId);
 }
 
+// Per-session tool-call history, fed by Claude's PreToolUse/PostToolUse hooks so
+// it captures EVERY tool call — built-ins (Bash, Read, …), the user's MCP tools,
+// AND our GUI plugin tools — not just the GUI ones the broker sees. Published on a
+// per-session channel the tools pane subscribes to. (The broker's toolResults
+// store above is separate; it only drives rendering of GUI views.)
+const toolCallsBySession = new Map(); // id -> [{ toolUseId, toolName, toolInput, toolOutput?, status, at, durationMs? }]
+const TOOLCALLS_LIMIT = 200;
+const toolCallsChannel = (id) => `toolcalls:${id}`;
+
+// PreToolUse: a tool started. Append a "running" entry (deduped by tool_use_id).
+function recordToolCallStart(sessionId, { toolUseId, toolName, toolInput }) {
+  const list = toolCallsBySession.get(sessionId) || [];
+  if (toolUseId && list.some((c) => c.toolUseId === toolUseId)) return;
+  const call = { toolUseId, toolName, toolInput, status: "running", at: Date.now() };
+  list.push(call);
+  if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
+  toolCallsBySession.set(sessionId, list);
+  pubsub?.publish(toolCallsChannel(sessionId), call);
+}
+
+// PostToolUse: a tool finished. Complete the matching entry by tool_use_id (or add
+// one if we somehow never saw the start).
+function recordToolCallEnd(sessionId, { toolUseId, toolName, toolInput, toolOutput, durationMs }) {
+  const list = toolCallsBySession.get(sessionId) || [];
+  let call = toolUseId ? list.find((c) => c.toolUseId === toolUseId) : undefined;
+  if (call) {
+    call.status = "completed";
+    call.toolOutput = toolOutput;
+    call.durationMs = durationMs;
+  } else {
+    call = { toolUseId, toolName, toolInput, toolOutput, status: "completed", at: Date.now(), durationMs };
+    list.push(call);
+    if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
+    toolCallsBySession.set(sessionId, list);
+  }
+  pubsub?.publish(toolCallsChannel(sessionId), call);
+}
+
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
 const SESSION_LIST_LIMIT = 50;
@@ -212,17 +250,26 @@ function setWaiting(id, waiting, event) {
   publishActivity(id);
 }
 
-// Hook config injected via `claude --settings <json>`. Each event POSTs the
-// hook payload (session_id + hook_event_name) to /api/hook:
-//   UserPromptSubmit => working, Stop => idle,
-//   Notification     => waiting for input (permission / question / idle).
+// Hook config injected via `claude --settings <json>`. Each event POSTs the full
+// hook payload to /api/hook. UserPromptSubmit => working, Stop => idle,
+// Notification => waiting for input. PreToolUse/PostToolUse (matcher "" => every
+// tool, including built-ins and MCP tools) feed the per-session tool-call history
+// that the GUI's tools pane shows.
 function hookSettingsJson() {
   const cmd =
     `curl -s -X POST http://localhost:${PORT}/api/hook ` +
     `-H 'content-type: application/json' -d @- >/dev/null 2>&1`;
   const entry = [{ hooks: [{ type: "command", command: cmd }] }];
+  // Tool hooks take a matcher; "" matches all tools.
+  const toolEntry = [{ matcher: "", hooks: [{ type: "command", command: cmd }] }];
   return JSON.stringify({
-    hooks: { UserPromptSubmit: entry, Stop: entry, Notification: entry },
+    hooks: {
+      UserPromptSubmit: entry,
+      Stop: entry,
+      Notification: entry,
+      PreToolUse: toolEntry,
+      PostToolUse: toolEntry,
+    },
   });
 }
 
@@ -311,7 +358,16 @@ app.use(express.static(path.join(__dirname, "../dist")));
 // Claude hooks (Stop / Notification) POST their payload here so we can flag
 // which background sessions have new activity.
 app.post("/api/hook", (req, res) => {
-  const { session_id, hook_event_name } = req.body || {};
+  const {
+    session_id,
+    hook_event_name,
+    tool_name,
+    tool_input,
+    tool_use_id,
+    tool_output,
+    tool_response,
+    duration_ms,
+  } = req.body || {};
   if (session_id) {
     const entry = ptys.get(session_id);
     const foreground = entry && entry.ws; // a ws is attached => being viewed
@@ -325,6 +381,20 @@ app.post("/api/hook", (req, res) => {
     } else if (hook_event_name === "Notification") {
       // Background session waiting for input (permission / question / idle).
       if (!foreground) setWaiting(session_id, true, hook_event_name);
+    } else if (hook_event_name === "PreToolUse") {
+      recordToolCallStart(session_id, {
+        toolUseId: tool_use_id,
+        toolName: tool_name,
+        toolInput: tool_input,
+      });
+    } else if (hook_event_name === "PostToolUse") {
+      recordToolCallEnd(session_id, {
+        toolUseId: tool_use_id,
+        toolName: tool_name,
+        toolInput: tool_input,
+        toolOutput: tool_output ?? tool_response,
+        durationMs: duration_ms,
+      });
     }
     console.log(`[hook] ${hook_event_name} for ${session_id}`);
   }
@@ -372,6 +442,23 @@ app.get("/api/agent/toolResults/:sessionId", async (req, res) => {
     return res.status(400).json({ error: "invalid sessionId" });
   }
   res.json({ sessionId, toolResults: await toolResultsStore.get(sessionId) });
+});
+
+// The GUI plugin tools available this session (for the tools pane's "Available
+// Tools" list). The full set claude can call — built-ins, other MCP — is not
+// enumerable server-side; those still show up in the tool-call history below.
+app.get("/api/tools", (_req, res) => {
+  res.json({ tools: toolSummaries });
+});
+
+// Replay a session's tool-call history (every tool, via the Pre/PostToolUse hooks)
+// so the tools pane can render it when the user (re)selects that session.
+app.get("/api/tool-calls/:sessionId", (req, res) => {
+  const { sessionId } = req.params;
+  if (!SESSION_ID_RE.test(sessionId)) {
+    return res.status(400).json({ error: "invalid sessionId" });
+  }
+  res.json({ sessionId, toolCalls: toolCallsBySession.get(sessionId) || [] });
 });
 
 // List the chat sessions for the current project (CLAUDE_CWD), including

--- a/server/index.js
+++ b/server/index.js
@@ -134,6 +134,17 @@ async function storeToolResult(sessionId, result) {
 const toolCallsStore = createSessionStore(".toolcalls");
 const TOOLCALLS_LIMIT = 200;
 const toolCallsChannel = (id) => `toolcalls:${id}`;
+// Stored tool outputs are capped so one verbose tool can't bloat the on-disk
+// history (and the pane). The raw output still reaches the LLM via the terminal;
+// this is only the history copy.
+const TOOL_OUTPUT_CAP = 20_000;
+
+function capToolOutput(output) {
+  if (typeof output === "string" && output.length > TOOL_OUTPUT_CAP) {
+    return output.slice(0, TOOL_OUTPUT_CAP) + `\n… (truncated ${output.length - TOOL_OUTPUT_CAP} chars)`;
+  }
+  return output;
+}
 
 // PreToolUse: a tool started. Append a "running" entry (deduped by tool_use_id).
 async function recordToolCallStart(sessionId, { toolUseId, toolName, toolInput }) {
@@ -146,17 +157,20 @@ async function recordToolCallStart(sessionId, { toolUseId, toolName, toolInput }
   toolCallsStore.save(sessionId);
 }
 
-// PostToolUse: a tool finished. Complete the matching entry by tool_use_id (or add
-// one if we somehow never saw the start).
-async function recordToolCallEnd(sessionId, { toolUseId, toolName, toolInput, toolOutput, durationMs }) {
+// PostToolUse (status "completed") or PostToolUseFailure (status "failed"):
+// complete the matching entry by tool_use_id (or add one if we never saw the
+// start). A failed tool fires PostToolUseFailure, NOT PostToolUse, so both route
+// here — otherwise the entry would be stuck on "running".
+async function recordToolCallEnd(sessionId, { toolUseId, toolName, toolInput, toolOutput, durationMs, status }) {
   const list = await toolCallsStore.get(sessionId);
+  const output = capToolOutput(toolOutput);
   let call = toolUseId ? list.find((c) => c.toolUseId === toolUseId) : undefined;
   if (call) {
-    call.status = "completed";
-    call.toolOutput = toolOutput;
+    call.status = status;
+    call.toolOutput = output;
     call.durationMs = durationMs;
   } else {
-    call = { toolUseId, toolName, toolInput, toolOutput, status: "completed", at: Date.now(), durationMs };
+    call = { toolUseId, toolName, toolInput, toolOutput: output, status, at: Date.now(), durationMs };
     list.push(call);
     if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
   }
@@ -255,9 +269,11 @@ function setWaiting(id, waiting, event) {
 
 // Hook config injected via `claude --settings <json>`. Each event POSTs the full
 // hook payload to /api/hook. UserPromptSubmit => working, Stop => idle,
-// Notification => waiting for input. PreToolUse/PostToolUse (matcher "" => every
-// tool, including built-ins and MCP tools) feed the per-session tool-call history
-// that the GUI's tools pane shows.
+// Notification => waiting for input. PreToolUse/PostToolUse/PostToolUseFailure
+// (matcher "" => every tool, including built-ins and MCP tools) feed the
+// per-session tool-call history that the GUI's tools pane shows. A failed tool
+// fires PostToolUseFailure (NOT PostToolUse), so we register both to complete the
+// entry either way — otherwise a failed call would stay stuck on "running".
 function hookSettingsJson() {
   const cmd =
     `curl -s -X POST http://localhost:${PORT}/api/hook ` +
@@ -272,6 +288,7 @@ function hookSettingsJson() {
       Notification: entry,
       PreToolUse: toolEntry,
       PostToolUse: toolEntry,
+      PostToolUseFailure: toolEntry,
     },
   });
 }
@@ -349,7 +366,10 @@ async function readSessionMeta(dir, file) {
 }
 
 const app = express();
-app.use(express.json());
+// Generous body limit: PostToolUse hook payloads carry the tool's full output
+// (a big Read/Bash result can blow past Express's 100kb default, which would 413
+// the hook and leave its tool-call entry stuck on "running").
+app.use(express.json({ limit: "25mb" }));
 
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
 // POST /api/form). The MCP broker dispatches tool calls to these.
@@ -390,13 +410,14 @@ app.post("/api/hook", async (req, res) => {
         toolName: tool_name,
         toolInput: tool_input,
       });
-    } else if (hook_event_name === "PostToolUse") {
+    } else if (hook_event_name === "PostToolUse" || hook_event_name === "PostToolUseFailure") {
       await recordToolCallEnd(session_id, {
         toolUseId: tool_use_id,
         toolName: tool_name,
         toolInput: tool_input,
         toolOutput: tool_output ?? tool_response,
         durationMs: duration_ms,
+        status: hook_event_name === "PostToolUseFailure" ? "failed" : "completed",
       });
     }
     console.log(`[hook] ${hook_event_name} for ${session_id}`);

--- a/server/index.js
+++ b/server/index.js
@@ -128,25 +128,28 @@ async function storeToolResult(sessionId, result) {
 // AND our GUI plugin tools — not just the GUI ones the broker sees. Published on a
 // per-session channel the tools pane subscribes to. (The broker's toolResults
 // store above is separate; it only drives rendering of GUI views.)
-const toolCallsBySession = new Map(); // id -> [{ toolUseId, toolName, toolInput, toolOutput?, status, at, durationMs? }]
+//
+// Persisted under <workspace>/.toolcalls via the same disk-backed store as the
+// toolResults, so the history survives a server reboot.
+const toolCallsStore = createSessionStore(".toolcalls");
 const TOOLCALLS_LIMIT = 200;
 const toolCallsChannel = (id) => `toolcalls:${id}`;
 
 // PreToolUse: a tool started. Append a "running" entry (deduped by tool_use_id).
-function recordToolCallStart(sessionId, { toolUseId, toolName, toolInput }) {
-  const list = toolCallsBySession.get(sessionId) || [];
+async function recordToolCallStart(sessionId, { toolUseId, toolName, toolInput }) {
+  const list = await toolCallsStore.get(sessionId);
   if (toolUseId && list.some((c) => c.toolUseId === toolUseId)) return;
   const call = { toolUseId, toolName, toolInput, status: "running", at: Date.now() };
   list.push(call);
   if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
-  toolCallsBySession.set(sessionId, list);
   pubsub?.publish(toolCallsChannel(sessionId), call);
+  toolCallsStore.save(sessionId);
 }
 
 // PostToolUse: a tool finished. Complete the matching entry by tool_use_id (or add
 // one if we somehow never saw the start).
-function recordToolCallEnd(sessionId, { toolUseId, toolName, toolInput, toolOutput, durationMs }) {
-  const list = toolCallsBySession.get(sessionId) || [];
+async function recordToolCallEnd(sessionId, { toolUseId, toolName, toolInput, toolOutput, durationMs }) {
+  const list = await toolCallsStore.get(sessionId);
   let call = toolUseId ? list.find((c) => c.toolUseId === toolUseId) : undefined;
   if (call) {
     call.status = "completed";
@@ -156,9 +159,9 @@ function recordToolCallEnd(sessionId, { toolUseId, toolName, toolInput, toolOutp
     call = { toolUseId, toolName, toolInput, toolOutput, status: "completed", at: Date.now(), durationMs };
     list.push(call);
     if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
-    toolCallsBySession.set(sessionId, list);
   }
   pubsub?.publish(toolCallsChannel(sessionId), call);
+  toolCallsStore.save(sessionId);
 }
 
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
@@ -357,7 +360,7 @@ app.use(express.static(path.join(__dirname, "../dist")));
 
 // Claude hooks (Stop / Notification) POST their payload here so we can flag
 // which background sessions have new activity.
-app.post("/api/hook", (req, res) => {
+app.post("/api/hook", async (req, res) => {
   const {
     session_id,
     hook_event_name,
@@ -382,13 +385,13 @@ app.post("/api/hook", (req, res) => {
       // Background session waiting for input (permission / question / idle).
       if (!foreground) setWaiting(session_id, true, hook_event_name);
     } else if (hook_event_name === "PreToolUse") {
-      recordToolCallStart(session_id, {
+      await recordToolCallStart(session_id, {
         toolUseId: tool_use_id,
         toolName: tool_name,
         toolInput: tool_input,
       });
     } else if (hook_event_name === "PostToolUse") {
-      recordToolCallEnd(session_id, {
+      await recordToolCallEnd(session_id, {
         toolUseId: tool_use_id,
         toolName: tool_name,
         toolInput: tool_input,
@@ -452,13 +455,14 @@ app.get("/api/tools", (_req, res) => {
 });
 
 // Replay a session's tool-call history (every tool, via the Pre/PostToolUse hooks)
-// so the tools pane can render it when the user (re)selects that session.
-app.get("/api/tool-calls/:sessionId", (req, res) => {
+// so the tools pane can render it when the user (re)selects that session. Loads
+// from disk (<workspace>/.toolcalls) on first access so it survives a reboot.
+app.get("/api/tool-calls/:sessionId", async (req, res) => {
   const { sessionId } = req.params;
   if (!SESSION_ID_RE.test(sessionId)) {
     return res.status(400).json({ error: "invalid sessionId" });
   }
-  res.json({ sessionId, toolCalls: toolCallsBySession.get(sessionId) || [] });
+  res.json({ sessionId, toolCalls: await toolCallsStore.get(sessionId) });
 });
 
 // List the chat sessions for the current project (CLAUDE_CWD), including

--- a/server/plugins-registry.js
+++ b/server/plugins-registry.js
@@ -46,6 +46,13 @@ export const toolDefinitions = plugins.map((p) => ({
 // toolName -> meta, so the broker can resolve a call to its REST dispatch route.
 export const metas = Object.fromEntries(plugins.map((p) => [p.meta.toolName, p.meta]));
 
+// JSON-serializable summaries (no zod inputSchema) for the GUI's tools pane.
+export const toolSummaries = plugins.map((p) => ({
+  toolName: p.meta.toolName,
+  title: p.definition.title,
+  description: p.definition.description,
+}));
+
 // Mount each enabled plugin's REST routes under /api/<apiNamespace>. The MCP
 // broker POSTs tool args here and gets back the result envelope.
 export function mountAllRoutes(app) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,21 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import Sidebar from "./components/Sidebar.vue";
 import TerminalView from "./components/Terminal.vue";
 import GuiPanel from "./components/GuiPanel.vue";
+import ToolsPane from "./components/ToolsPane.vue";
 
 const activeId = ref<string | null>(null);
 const connectKey = ref(0);
 const terminalRef = ref<InstanceType<typeof TerminalView> | null>(null);
+
+// Tools pane visibility, persisted across reloads (mirrors MulmoClaude's
+// right-sidebar toggle).
+const showTools = ref(localStorage.getItem("tools_pane_visible") === "true");
+watch(showTools, (v) => localStorage.setItem("tools_pane_visible", String(v)));
+function toggleTools() {
+  showTools.value = !showTools.value;
+}
 
 // GUI -> LLM: a plugin view (e.g. a submitted form) calls this with the user's
 // response. Terminal.submitText types it into the PTY and submits it (text + a
@@ -49,7 +58,13 @@ function onSession(id: string) {
         :connect-key="connectKey"
         @session="onSession"
       />
-      <GuiPanel :session-id="activeId" :send-text-message="sendTextMessage" />
+      <GuiPanel
+        :session-id="activeId"
+        :send-text-message="sendTextMessage"
+        :tools-open="showTools"
+        @toggle-tools="toggleTools"
+      />
+      <ToolsPane v-if="showTools" :session-id="activeId" />
     </div>
   </div>
 </template>

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -21,7 +21,9 @@ interface ToolResult {
 const props = defineProps<{
   sessionId: string | null;
   sendTextMessage: (text: string) => boolean;
+  toolsOpen?: boolean;
 }>();
+const emit = defineEmits<{ toggleTools: [] }>();
 
 const results = ref<ToolResult[]>([]);
 
@@ -93,6 +95,15 @@ const hasContent = computed(() => results.value.length > 0);
   <section class="gui-panel">
     <div class="header">
       <span class="title">GUI</span>
+      <button
+        type="button"
+        class="gear"
+        :class="{ active: toolsOpen }"
+        title="Tools & tool-call history"
+        @click="emit('toggleTools')"
+      >
+        ⚙
+      </button>
     </div>
     <div class="content">
       <div v-if="!hasContent" class="empty">
@@ -130,9 +141,28 @@ const hasContent = computed(() => results.value.length > 0);
   color: #e0e0e0;
   font-family: system-ui, sans-serif;
   font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 .title {
   font-weight: 600;
+}
+.gear {
+  background: none;
+  border: none;
+  color: #7c87a8;
+  font-size: 15px;
+  line-height: 1;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.gear:hover {
+  color: #e0e0e0;
+}
+.gear.active {
+  color: #4a8cff;
 }
 
 .content {

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -40,11 +40,15 @@ function upsert(result: ToolResult) {
 async function loadHistory(id: string) {
   try {
     const res = await fetch(`/api/agent/toolResults/${encodeURIComponent(id)}`);
+    // Guard against a session-switch race: a slow response for an old session must
+    // not clobber the pane after the user has switched to a newer one.
+    if (id !== props.sessionId) return;
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
+    if (id !== props.sessionId) return;
     results.value = data.toolResults ?? [];
   } catch {
-    results.value = [];
+    if (id === props.sessionId) results.value = [];
   }
 }
 
@@ -100,6 +104,8 @@ const hasContent = computed(() => results.value.length > 0);
         class="gear"
         :class="{ active: toolsOpen }"
         title="Tools & tool-call history"
+        aria-label="Toggle tools pane"
+        :aria-pressed="toolsOpen ? 'true' : 'false'"
         @click="emit('toggleTools')"
       >
         ⚙

--- a/src/components/ToolsPane.spec.ts
+++ b/src/components/ToolsPane.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import ToolsPane from "./ToolsPane.vue";
+
+// Capture the pub/sub callback so tests can simulate a server push without a
+// real socket (mirrors Sidebar.spec.ts).
+let captured: ((data: unknown) => void) | null = null;
+vi.mock("../composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (_channel: string, cb: (data: unknown) => void) => {
+      captured = cb;
+      return () => {};
+    },
+  }),
+}));
+
+function jsonRes(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+// A promise whose resolution we control from the test.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+// Route fetch by URL so /api/tools and /api/tool-calls/:id can return distinct
+// (and individually controllable) responses.
+function mockFetch(handler: (url: string) => Promise<unknown>) {
+  globalThis.fetch = vi.fn((url: string) => handler(String(url))) as unknown as typeof fetch;
+}
+
+describe("ToolsPane", () => {
+  beforeEach(() => {
+    captured = null;
+  });
+
+  it("lists available tools and renders history rows with running/completed/failed badges", async () => {
+    mockFetch((url) => {
+      if (url.startsWith("/api/tools")) {
+        return Promise.resolve(jsonRes({ tools: [{ toolName: "presentDocument", description: "Render markdown" }] }));
+      }
+      return Promise.resolve(
+        jsonRes({
+          toolCalls: [
+            { toolUseId: "t1", toolName: "Bash", status: "completed", at: 1, durationMs: 5, toolOutput: "ok" },
+            { toolUseId: "t2", toolName: "Read", status: "running", at: 2 },
+            { toolUseId: "t3", toolName: "Edit", status: "failed", at: 3, toolOutput: "boom" },
+          ],
+        })
+      );
+    });
+
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+
+    expect(wrapper.find(".tool-name").text()).toBe("presentDocument");
+    expect(wrapper.findAll(".call")).toHaveLength(3);
+    expect(wrapper.find(".badge.done").exists()).toBe(true);
+    expect(wrapper.find(".badge.running").exists()).toBe(true);
+    expect(wrapper.find(".badge.failed").exists()).toBe(true);
+  });
+
+  it("completes a running call in place when a pub/sub push arrives (deduped by tool_use_id)", async () => {
+    mockFetch((url) => {
+      if (url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ tools: [] }));
+      return Promise.resolve(jsonRes({ toolCalls: [{ toolUseId: "t1", toolName: "Bash", status: "running", at: 1 }] }));
+    });
+
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find(".badge.running").exists()).toBe(true);
+
+    // Server pushes the completion for the same tool_use_id.
+    captured?.({ toolUseId: "t1", toolName: "Bash", status: "completed", at: 1, durationMs: 9, toolOutput: "ok" });
+    await flushPromises();
+
+    expect(wrapper.findAll(".call")).toHaveLength(1); // updated in place, not appended
+    expect(wrapper.find(".badge.running").exists()).toBe(false);
+    expect(wrapper.find(".badge.done").exists()).toBe(true);
+  });
+
+  it("drops a stale history response when the session changes mid-flight", async () => {
+    const aGate = deferred<void>();
+    mockFetch((url) => {
+      if (url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ tools: [] }));
+      if (url.includes("/api/tool-calls/a")) {
+        // Session A's history stays pending until we release the gate.
+        return aGate.promise.then(() =>
+          jsonRes({ toolCalls: [{ toolUseId: "old", toolName: "OldTool", status: "completed", at: 1 }] })
+        );
+      }
+      return Promise.resolve(jsonRes({ toolCalls: [{ toolUseId: "new", toolName: "NewTool", status: "completed", at: 2 }] }));
+    });
+
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    // Switch to B before A resolves; B resolves immediately.
+    await wrapper.setProps({ sessionId: "b" });
+    await flushPromises();
+    expect(wrapper.text()).toContain("NewTool");
+
+    // A's response arrives late — it must NOT overwrite B's pane.
+    aGate.resolve();
+    await flushPromises();
+    expect(wrapper.text()).toContain("NewTool");
+    expect(wrapper.text()).not.toContain("OldTool");
+  });
+});

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -1,0 +1,331 @@
+<script setup lang="ts">
+import { ref, watch, onUnmounted } from "vue";
+import { usePubSub } from "../composables/usePubSub";
+
+// The tools pane mirrors MulmoClaude's right sidebar: an "Available Tools" list
+// (the GUI plugin tools, with collapsible descriptions) and a "Tool Call History"
+// for the active session. The history is fed by Claude's PreToolUse/PostToolUse
+// hooks, so it shows EVERY tool call — built-ins (Bash, Read, …), other MCP tools,
+// and our GUI plugin tools — not just the GUI ones. Live updates arrive on the
+// toolcalls:<id> channel; history replays from /api/tool-calls/:id on (re)select.
+interface AvailableTool {
+  toolName: string;
+  title?: string;
+  description?: string;
+}
+interface ToolCall {
+  toolUseId?: string;
+  toolName: string;
+  toolInput?: unknown;
+  toolOutput?: unknown;
+  status: "running" | "completed";
+  at: number;
+  durationMs?: number;
+}
+
+const props = defineProps<{ sessionId: string | null }>();
+
+const availableTools = ref<AvailableTool[]>([]);
+const toolCalls = ref<ToolCall[]>([]);
+const expandedTools = ref<Set<string>>(new Set());
+const expandedCalls = ref<Set<string>>(new Set());
+
+// Available tools are the same for every session; load once.
+async function loadAvailableTools() {
+  try {
+    const res = await fetch("/api/tools");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    availableTools.value = (await res.json()).tools ?? [];
+  } catch {
+    availableTools.value = [];
+  }
+}
+loadAvailableTools();
+
+function callKey(c: ToolCall, i: number): string {
+  return c.toolUseId ?? `${c.toolName}-${i}`;
+}
+
+// Insert or update a call, keyed by tool_use_id (a PostToolUse completes the
+// "running" entry its PreToolUse created).
+function upsert(call: ToolCall) {
+  const list = toolCalls.value;
+  const idx = call.toolUseId ? list.findIndex((c) => c.toolUseId === call.toolUseId) : -1;
+  if (idx >= 0) list[idx] = call;
+  else toolCalls.value = [...list, call];
+}
+
+async function loadHistory(id: string) {
+  try {
+    const res = await fetch(`/api/tool-calls/${encodeURIComponent(id)}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    toolCalls.value = (await res.json()).toolCalls ?? [];
+  } catch {
+    toolCalls.value = [];
+  }
+}
+
+const { subscribe } = usePubSub();
+let unsubscribe: (() => void) | undefined;
+
+function subscribeTo(id: string | null) {
+  unsubscribe?.();
+  unsubscribe = undefined;
+  if (!id) return;
+  unsubscribe = subscribe(`toolcalls:${id}`, (data) => upsert(data as ToolCall));
+}
+
+watch(
+  () => props.sessionId,
+  (id) => {
+    expandedCalls.value = new Set();
+    if (id) loadHistory(id);
+    else toolCalls.value = [];
+    subscribeTo(id);
+  },
+  { immediate: true }
+);
+
+onUnmounted(() => unsubscribe?.());
+
+function toggleTool(name: string) {
+  const next = new Set(expandedTools.value);
+  if (next.has(name)) next.delete(name);
+  else next.add(name);
+  expandedTools.value = next;
+}
+function toggleCall(key: string) {
+  const next = new Set(expandedCalls.value);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  expandedCalls.value = next;
+}
+
+function formatTime(at: number): string {
+  const d = new Date(at);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+function formatValue(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+</script>
+
+<template>
+  <section class="tools-pane">
+    <div class="header">
+      <span class="title">Tools</span>
+    </div>
+    <div class="content">
+      <!-- Available tools -->
+      <div class="section">
+        <div class="section-title">
+          Available Tools
+        </div>
+        <div v-if="availableTools.length === 0" class="muted">
+          No GUI plugin tools enabled.
+        </div>
+        <div v-for="tool in availableTools" :key="tool.toolName" class="tool">
+          <button class="tool-head" type="button" @click="toggleTool(tool.toolName)">
+            <code class="tool-name">{{ tool.toolName }}</code>
+            <span v-if="tool.description" class="caret">{{ expandedTools.has(tool.toolName) ? "▲" : "▼" }}</span>
+          </button>
+          <div v-if="expandedTools.has(tool.toolName)" class="tool-desc">
+            {{ tool.description }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Tool call history -->
+      <div class="section">
+        <div class="section-title">
+          Tool Call History
+        </div>
+        <div v-if="toolCalls.length === 0" class="muted">
+          No tool calls yet.
+        </div>
+        <div v-for="(call, i) in toolCalls" :key="callKey(call, i)" class="call">
+          <button class="call-head" type="button" @click="toggleCall(callKey(call, i))">
+            <code class="call-name">{{ call.toolName }}</code>
+            <span class="call-meta">
+              <span v-if="call.status === 'running'" class="badge running">running…</span>
+              <span v-else class="badge done">{{ call.durationMs != null ? `${call.durationMs} ms` : "done" }}</span>
+              <span class="time">{{ formatTime(call.at) }}</span>
+            </span>
+          </button>
+          <div v-if="expandedCalls.has(callKey(call, i))" class="call-body">
+            <div class="label">
+              arguments
+            </div>
+            <pre class="block">{{ formatValue(call.toolInput) }}</pre>
+            <template v-if="call.status === 'completed'">
+              <div class="label">
+                result
+              </div>
+              <pre class="block result">{{ formatValue(call.toolOutput) || "(no output)" }}</pre>
+            </template>
+            <div v-else class="muted italic">
+              Waiting for result…
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.tools-pane {
+  display: flex;
+  flex-direction: column;
+  width: 340px;
+  flex-shrink: 0;
+  height: 100vh;
+  background: #0d1124;
+  border-left: 1px solid #2a2a4e;
+}
+
+.header {
+  padding: 8px 16px;
+  background: #16213e;
+  color: #e0e0e0;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+}
+.title {
+  font-weight: 600;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  color: #e0e0e0;
+  font-family: system-ui, sans-serif;
+  font-size: 13px;
+}
+
+.section {
+  border-bottom: 1px solid #2a2a4e;
+  padding: 10px 12px;
+}
+.section-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #7c87a8;
+  margin-bottom: 8px;
+}
+
+.muted {
+  color: #7c87a8;
+  font-size: 12px;
+}
+.italic {
+  font-style: italic;
+}
+
+/* Available tools */
+.tool + .tool {
+  margin-top: 4px;
+}
+.tool-head,
+.call-head {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: none;
+  border: none;
+  padding: 4px 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+}
+.tool-name,
+.call-name {
+  background: #1d2b4e;
+  color: #cfe0ff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  word-break: break-all;
+}
+.caret {
+  color: #7c87a8;
+  font-size: 10px;
+}
+.tool-desc {
+  color: #9aa5c4;
+  font-size: 12px;
+  margin: 2px 0 6px;
+  white-space: pre-wrap;
+}
+
+/* Tool call history */
+.call {
+  border: 1px solid #2a2a4e;
+  border-radius: 6px;
+  padding: 6px 8px;
+  margin-top: 6px;
+  background: #11162a;
+}
+.call-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+.badge.running {
+  background: #4a3a10;
+  color: #ffcc80;
+}
+.badge.done {
+  background: #14361c;
+  color: #a5d6a7;
+}
+.time {
+  color: #6b769a;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.call-body {
+  margin-top: 6px;
+}
+.label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #7c87a8;
+  margin: 6px 0 2px;
+}
+.block {
+  background: #0a0e1f;
+  border: 1px solid #20284a;
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.block.result {
+  border-color: #1c3a24;
+}
+</style>

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -18,7 +18,7 @@ interface ToolCall {
   toolName: string;
   toolInput?: unknown;
   toolOutput?: unknown;
-  status: "running" | "completed";
+  status: "running" | "completed" | "failed";
   at: number;
   durationMs?: number;
 }
@@ -58,10 +58,15 @@ function upsert(call: ToolCall) {
 async function loadHistory(id: string) {
   try {
     const res = await fetch(`/api/tool-calls/${encodeURIComponent(id)}`);
+    // Guard against a session-switch race: if the user moved on while this was in
+    // flight, drop the stale response instead of clobbering the new session's pane.
+    if (id !== props.sessionId) return;
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    toolCalls.value = (await res.json()).toolCalls ?? [];
+    const data = await res.json();
+    if (id !== props.sessionId) return;
+    toolCalls.value = data.toolCalls ?? [];
   } catch {
-    toolCalls.value = [];
+    if (id === props.sessionId) toolCalls.value = [];
   }
 }
 
@@ -155,6 +160,7 @@ function formatValue(v: unknown): string {
             <code class="call-name">{{ call.toolName }}</code>
             <span class="call-meta">
               <span v-if="call.status === 'running'" class="badge running">running…</span>
+              <span v-else-if="call.status === 'failed'" class="badge failed">failed</span>
               <span v-else class="badge done">{{ call.durationMs != null ? `${call.durationMs} ms` : "done" }}</span>
               <span class="time">{{ formatTime(call.at) }}</span>
             </span>
@@ -164,11 +170,11 @@ function formatValue(v: unknown): string {
               arguments
             </div>
             <pre class="block">{{ formatValue(call.toolInput) }}</pre>
-            <template v-if="call.status === 'completed'">
+            <template v-if="call.status === 'completed' || call.status === 'failed'">
               <div class="label">
-                result
+                {{ call.status === 'failed' ? 'error' : 'result' }}
               </div>
-              <pre class="block result">{{ formatValue(call.toolOutput) || "(no output)" }}</pre>
+              <pre class="block" :class="call.status === 'failed' ? 'error' : 'result'">{{ formatValue(call.toolOutput) || "(no output)" }}</pre>
             </template>
             <div v-else class="muted italic">
               Waiting for result…
@@ -297,6 +303,10 @@ function formatValue(v: unknown): string {
   background: #14361c;
   color: #a5d6a7;
 }
+.badge.failed {
+  background: #4a1414;
+  color: #ef9a9a;
+}
 .time {
   color: #6b769a;
   font-size: 11px;
@@ -327,5 +337,9 @@ function formatValue(v: unknown): string {
 }
 .block.result {
   border-color: #1c3a24;
+}
+.block.error {
+  border-color: #4a1414;
+  color: #ef9a9a;
 }
 </style>


### PR DESCRIPTION
Now targets `main` (PR #8 is merged). Three commits:

### 1. `feat: persist GUI toolResults across server reboot`
> ⚠️ This was originally pushed to PR #8, but **PR #8 was merged one commit earlier** (at the form-lock fix), so this change did **not** land in main. It rides along here instead.

Mirrors the GUI toolResults to disk so rendered views survive a reboot — one JSON file per session under `<workspace>/.toolresults/<sessionId>.json`, via a reusable `createSessionStore(dirName)` helper (in-memory Map working copy; file rewritten on each change; lazy-loaded on first access with an in-flight load promise to dedupe concurrent loads). `storeToolResult` + the toolResult routes are now async.

### 2. `feat: add a tools pane (available tools + full tool-call history)`
A gear button in the GUI panel header toggles a third column (`ToolsPane.vue`, visibility persisted in `localStorage`):
- **Available Tools** — enabled GUI plugin tools + collapsible descriptions (`GET /api/tools`).
- **Tool Call History** — **every** tool call for the session (Bash, Read, other MCP, and GUI tools), with name, status/duration, time, collapsible args + result.

The history is **hook-driven, not broker-driven**: the spawn's `--settings` registers `PreToolUse`/`PostToolUse` hooks (matcher `""` = all tools) → `/api/hook` → per-session history keyed by `tool_use_id` → published on `toolcalls:<id>`, replayed from `GET /api/tool-calls/:id`. Same shape as MulmoClaude's `toolCallHistory`.

### 3. `feat: persist tool-call history to <workspace>/.toolcalls`
Persists the tool-call history to disk too, reusing the same `createSessionStore` helper, so it survives a reboot.

## Verification
- ✅ `npm run build`, `npm run lint`, `npm run typecheck` clean.
- ✅ Both stores verified to **persist across an actual process restart** (toolResults: count + a submitted form's `viewState`; tool-call history: completed Bash entry with output + duration), loading from disk on first access.
- ✅ Hook-driven history captures non-GUI calls (Bash) and GUI calls alike; config-gating still drops disabled plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)