### PR TITLE
feat: default workspace to ~/mulmoclaude

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.PORT || 3456;
 const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude";
-const CLAUDE_CWD = process.env.CLAUDE_CWD || process.env.HOME;
+const CLAUDE_CWD =
+  process.env.CLAUDE_CWD || path.join(os.homedir(), "mulmoclaude");
+
+// CLAUDE_CWD is the workspace used as the PTY cwd and as the root for persisted
+// session state, so it must exist before we spawn anything into it.
+await fs.mkdir(CLAUDE_CWD, { recursive: true });
 
 // A session id is always a UUID (server-generated, or a .jsonl basename). Reject
 // anything else so a client can't smuggle CLI flags (e.g. "--resume" followed by


### PR DESCRIPTION
## Summary
- Change the default workspace (`CLAUDE_CWD`) from `$HOME` to `~/mulmoclaude`.
- Create the directory at startup, since `CLAUDE_CWD` is used as the PTY cwd and as the root for persisted session state (`.toolresults`, `.toolcalls`, per-session JSON).
- An explicit `CLAUDE_CWD` env var still overrides the default.

## Why
The home directory is a poor default workspace — terminal/Claude sessions and persisted state should live in a dedicated folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)