### PR TITLE
ci: run server typecheck + tests, bump actions to v6 (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,8 @@ jobs:
       - name: Typecheck
         run: yarn typecheck
 
+      - name: Typecheck (server)
+        run: yarn typecheck:server
+
       - name: Build
         run: yarn build


### PR DESCRIPTION
## Summary

Harden CI for the now-TypeScript server:

- Add a **"Typecheck (server)"** step (`yarn typecheck:server`, strict `tsconfig.server.json`).
- Add a **"Test"** step (`yarn test`, 16 vitest cases) — CI previously ran no tests.
- Bump **`actions/checkout` and `actions/setup-node` `v4` → `v6`** so the actions run on
  Node 24 (v4 used the deprecated Node 20 runtime).

CI now runs: Lint → Typecheck (vue-tsc) → Typecheck (server) → Build → Test.

## Items to Confirm / Review

- CI Node stays `22` (resolves to latest 22.x ≥ our `engines` `>=22.9`); only the
  action runtimes move to Node 24 via v6.
- `typecheck:server` is pure `tsc` (no `tsx` needed).

## User Prompt

- （#17 を）取り込んだ。つづけて CI に組み込んで。
- 1（テスト）を追加。2（Node20 非推奨）は v6 で 24 に。

## Verification

- `yarn typecheck:server` ✅ · `yarn test` ✅ (16/16) locally.
- Earlier CI run on this branch passed the new server-typecheck step; re-running with
  the Test step + v6 actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)