### PR TITLE
chore: stricter lint — typescript-eslint strict + eslint-plugin-sonarjs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,14 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
+import sonarjs from "eslint-plugin-sonarjs";
 
 export default [
   { ignores: ["dist/", "node_modules/"] },
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.strict,
   ...pluginVue.configs["flat/recommended"],
+  sonarjs.configs.recommended,
   {
     files: ["**/*.vue"],
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@vue/tsconfig": "^0.9.1",
     "concurrently": "^10.0.3",
     "eslint": "^10.5.0",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "eslint-plugin-vue": "^10.9.2",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.1",

--- a/plans/chore-stricter-lint.md
+++ b/plans/chore-stricter-lint.md
@@ -1,0 +1,27 @@
+# chore: stricter lint (typescript-eslint strict + eslint-plugin-sonarjs)
+
+## ゴール
+
+lint ルールを厳し目にする。`eslint-plugin-sonarjs` を導入し、`typescript-eslint`
+を `recommended` → `strict` に引き上げ、出た違反を実コード修正で解消する。
+
+## 変更
+
+- `eslint-plugin-sonarjs`（v4）を devDependency に追加。
+- `eslint.config.js`: `tseslint.configs.recommended` → `strict`、`sonarjs.configs.recommended` を追加。
+- 違反修正（全13件、`any`/`as` 不使用）:
+  - **no-non-null-assertion**（PluginFrame.vue / Terminal.vue）: `ref.value!` を
+    `const x = ref.value; if (!x) return;` のガードに置換。
+  - **unified-signatures**（Sidebar.vue / SessionTabBar.vue）: ペイロードなしの
+    emit 3つを `(e: "new" | "toggle-layout" | "refresh"): void` に統合。
+  - **no-invalid-void-type**（ToolsPane.spec.ts）: `deferred<void>()` →
+    `deferred<undefined>()`（`resolve(undefined)`）。
+  - **cognitive-complexity**（server/index.ts、3関数）: `readSessionMeta`、
+    `/api/hook` ハンドラ、WebSocket 接続ハンドラを小さな名前付き関数に分割
+    （`userPromptText` / `parseJsonl` / `handleActivityHook` / `handleToolHook` /
+    `reattachPty` / `spawnClaudePty` / `handleClientFrame` / `handleClientClose`）。挙動は不変。
+
+## 確認
+
+- `yarn lint` ✅ / `yarn typecheck` ✅ / `yarn typecheck:server` ✅ /
+  `yarn test` ✅（16件）/ `yarn build` ✅ / tsx 起動 ✅。

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import http from "http";
-import { WebSocketServer, WebSocket } from "ws";
+import { WebSocketServer, WebSocket, type RawData } from "ws";
 import pty from "node-pty";
 import type { IPty } from "node-pty";
 import path from "path";
@@ -75,6 +75,8 @@ const hasErrnoCode = (e: unknown): e is { code?: string } => typeof e === "objec
 
 // Error message extracted defensively from an unknown thrown value.
 const messageOf = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -410,6 +412,34 @@ function projectSessionsDir(cwd: string) {
   return path.join(os.homedir(), ".claude", "projects", encoded);
 }
 
+// A real user prompt from a JSONL "user" line's content, or null if it's a
+// slash-/local-command wrapper rather than a typed prompt. Content may be a
+// plain string or an array of blocks (guard against null elements).
+function userPromptText(content: unknown): string | null {
+  const text = Array.isArray(content)
+    ? content.map((x) => (isRecord(x) ? String(x.text ?? "") : String(x))).join(" ")
+    : content;
+  if (typeof text === "string" && text.trim() && !/^\s*<(local-command|command-|bash-)/.test(text)) {
+    return text.trim();
+  }
+  return null;
+}
+
+// Parse a JSONL file into the objects on each non-blank, valid line.
+function parseJsonl(raw: string): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const o: unknown = JSON.parse(line);
+      if (isRecord(o)) out.push(o);
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+  return out;
+}
+
 // Scan a session JSONL for a human-friendly title and last activity.
 async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> {
   const full = path.join(dir, file);
@@ -418,30 +448,15 @@ async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> 
     fs.stat(full),
   ]);
 
-  let aiTitle = null;
-  let lastPrompt = null;
-  let firstUserMsg = null;
+  let aiTitle: string | null = null;
+  let lastPrompt: string | null = null;
+  let firstUserMsg: string | null = null;
 
-  for (const line of raw.split("\n")) {
-    if (!line.trim()) continue;
-    let o;
-    try {
-      o = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (o.type === "ai-title" && o.aiTitle) aiTitle = o.aiTitle;
-    else if (o.type === "last-prompt" && o.lastPrompt) lastPrompt = o.lastPrompt;
+  for (const o of parseJsonl(raw)) {
+    if (o.type === "ai-title" && o.aiTitle) aiTitle = String(o.aiTitle);
+    else if (o.type === "last-prompt" && o.lastPrompt) lastPrompt = String(o.lastPrompt);
     else if (o.type === "user" && firstUserMsg === null) {
-      let c = o.message?.content;
-      if (Array.isArray(c)) {
-        // Guard against null elements (`typeof null === "object"`).
-        c = c.map((x) => (x && typeof x === "object" ? x.text || "" : x)).join(" ");
-      }
-      // Skip slash-command / local-command wrappers that aren't real prompts.
-      if (typeof c === "string" && c.trim() && !/^\s*<(local-command|command-|bash-)/.test(c)) {
-        firstUserMsg = c.trim();
-      }
+      firstUserMsg = userPromptText(isRecord(o.message) ? o.message.content : undefined);
     }
   }
 
@@ -470,49 +485,60 @@ mountAllRoutes(app);
 // Serve Vite build output
 app.use(express.static(path.join(__dirname, "../dist")));
 
-// Claude hooks (Stop / Notification) POST their payload here so we can flag
-// which background sessions have new activity.
+// Activity hooks update a session's working / needs-attention flags.
+// `foreground` (a ws is attached => being viewed) suppresses the attention flag.
+function handleActivityHook(sessionId: string, event: string, foreground: boolean) {
+  if (event === "UserPromptSubmit") {
+    setWorking(sessionId, true, event);
+  } else if (event === "Stop") {
+    // A background session that finished a turn has output the user hasn't seen
+    // yet (and is ready for another message) — flag it for attention.
+    if (!foreground) setWaiting(sessionId, true, event);
+    setWorking(sessionId, false, event);
+  } else if (event === "Notification") {
+    // Background session waiting for input (permission / question / idle).
+    if (!foreground) setWaiting(sessionId, true, event);
+  }
+}
+
+interface HookToolPayload {
+  tool_use_id?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  tool_output?: unknown;
+  tool_response?: unknown;
+  duration_ms?: number;
+}
+
+// Pre/PostToolUse hooks feed the per-session tool-call history. A failed tool
+// fires PostToolUseFailure (NOT PostToolUse), so both complete the entry.
+async function handleToolHook(sessionId: string, event: string, p: HookToolPayload) {
+  if (event === "PreToolUse") {
+    await recordToolCallStart(sessionId, { toolUseId: p.tool_use_id, toolName: p.tool_name, toolInput: p.tool_input });
+  } else if (event === "PostToolUse" || event === "PostToolUseFailure") {
+    await recordToolCallEnd(sessionId, {
+      toolUseId: p.tool_use_id,
+      toolName: p.tool_name,
+      toolInput: p.tool_input,
+      toolOutput: p.tool_output ?? p.tool_response,
+      durationMs: p.duration_ms,
+      status: event === "PostToolUseFailure" ? "failed" : "completed",
+    });
+  }
+}
+
+// Claude hooks (Stop / Notification / Pre|PostToolUse) POST their payload here so
+// we can flag which background sessions have new activity / build tool history.
 app.post("/api/hook", async (req, res) => {
-  const {
-    session_id,
-    hook_event_name,
-    tool_name,
-    tool_input,
-    tool_use_id,
-    tool_output,
-    tool_response,
-    duration_ms,
-  } = req.body || {};
-  if (session_id) {
-    const entry = ptys.get(session_id);
-    const foreground = entry && entry.ws; // a ws is attached => being viewed
-    if (hook_event_name === "UserPromptSubmit") {
-      setWorking(session_id, true, hook_event_name);
-    } else if (hook_event_name === "Stop") {
-      // A background session that finished a turn has output the user hasn't
-      // seen yet (and is ready for another message) — flag it for attention.
-      if (!foreground) setWaiting(session_id, true, hook_event_name);
-      setWorking(session_id, false, hook_event_name);
-    } else if (hook_event_name === "Notification") {
-      // Background session waiting for input (permission / question / idle).
-      if (!foreground) setWaiting(session_id, true, hook_event_name);
-    } else if (hook_event_name === "PreToolUse") {
-      await recordToolCallStart(session_id, {
-        toolUseId: tool_use_id,
-        toolName: tool_name,
-        toolInput: tool_input,
-      });
-    } else if (hook_event_name === "PostToolUse" || hook_event_name === "PostToolUseFailure") {
-      await recordToolCallEnd(session_id, {
-        toolUseId: tool_use_id,
-        toolName: tool_name,
-        toolInput: tool_input,
-        toolOutput: tool_output ?? tool_response,
-        durationMs: duration_ms,
-        status: hook_event_name === "PostToolUseFailure" ? "failed" : "completed",
-      });
-    }
-    console.log(`[hook] ${hook_event_name} for ${session_id}`);
+  const body = req.body || {};
+  const sessionId = body.session_id;
+  const event = body.hook_event_name;
+  if (sessionId) {
+    const entry = ptys.get(sessionId);
+    const foreground = !!(entry && entry.ws);
+    handleActivityHook(sessionId, event, foreground);
+    await handleToolHook(sessionId, event, body);
+    console.log(`[hook] ${event} for ${sessionId}`);
   }
   res.json({ ok: true });
 });
@@ -677,10 +703,129 @@ server.on("upgrade", (req, socket, head) => {
   // Other paths (e.g. /ws/pubsub) are left to socket.io's own upgrade handler.
 });
 
+// Reattach a live background PTY to a new socket: drop any stale socket, swap in
+// the new one, and replay the buffered tail for context.
+function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntry {
+  console.log(`[ws] reattach ${sessionId} (pid=${entry.term.pid})`);
+  // Drop any socket still attached (e.g. the same session open in another tab)
+  // so it can't keep writing to this PTY.
+  if (entry.ws && entry.ws !== ws && entry.ws.readyState === entry.ws.OPEN) {
+    entry.ws.close();
+  }
+  entry.ws = ws;
+  if (entry.buffer && ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify({ type: "output", data: entry.buffer }));
+  }
+  return entry;
+}
+
+// Spawn a fresh claude PTY for this session, register it, and wire its output /
+// exit back to the browser socket.
+function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket): PtyEntry {
+  const settings = hookSettingsJson();
+  // Register the GUI MCP broker and auto-allow its tools so the plugin tools run
+  // without a permission prompt (--strict-mcp-config keeps the user's other MCP
+  // servers out of the spike).
+  const mcp = mcpConfigJson(sessionId);
+  const guiArgs = ["--mcp-config", mcp, "--strict-mcp-config", "--allowedTools", GUI_MCP_TOOLS];
+  const args = resume
+    ? ["--resume", resume, "--settings", settings, ...guiArgs]
+    : ["--session-id", sessionId, "--settings", settings, ...guiArgs];
+
+  console.log(`[ws] client connected (${resume ? "resume" : "new"} ${sessionId})`);
+
+  const term = pty.spawn(CLAUDE_BIN, args, {
+    name: "xterm-256color",
+    cols: 120,
+    rows: 30,
+    cwd: CLAUDE_CWD,
+    env: process.env,
+  });
+  console.log(`[pty] spawned claude (pid=${term.pid})`);
+
+  const entry: PtyEntry = { term, ws, buffer: "" };
+  ptys.set(sessionId, entry);
+
+  if (!resume) {
+    // Brand-new session: surface it in the sidebar before it's persisted.
+    knownSessions.set(sessionId, { createdAt: Date.now(), title: "New session" });
+    pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" });
+  }
+
+  // PTY -> browser (buffering a bounded tail for reattach).
+  term.onData((data) => {
+    entry.buffer = (entry.buffer + data).slice(-OUTPUT_BUFFER_LIMIT);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.send(JSON.stringify({ type: "output", data }));
+    }
+  });
+
+  term.onExit(({ exitCode, signal }) => {
+    console.log(`[pty] exited code=${exitCode} signal=${signal}`);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.send(JSON.stringify({ type: "exit", exitCode, signal }));
+      entry.ws.close();
+    }
+    // Clear the dot if it died mid-turn, then tear down everything (deletes
+    // ptys/knownSessions/activity and publishes "closed") so a process that
+    // exits on its own — e.g. a brand-new session that never persisted —
+    // doesn't linger in the sidebar.
+    setWorking(sessionId, false);
+    reap(sessionId);
+  });
+
+  return entry;
+}
+
+// browser -> PTY. The protocol is client-controlled, so validate every frame
+// before touching node-pty (bad cols/rows or non-string input can throw).
+function handleClientFrame(entry: PtyEntry, ws: WebSocket, raw: RawData, sessionId: string) {
+  // Ignore frames from a socket that a newer client has already superseded.
+  if (entry.ws !== ws) return;
+  let msg;
+  try {
+    msg = JSON.parse(raw.toString());
+  } catch {
+    return; // not JSON — never write arbitrary payloads to the PTY
+  }
+  try {
+    if (msg.type === "input" && typeof msg.data === "string") {
+      entry.term.write(msg.data);
+    } else if (
+      msg.type === "resize" &&
+      Number.isInteger(msg.cols) &&
+      Number.isInteger(msg.rows) &&
+      msg.cols >= 2 &&
+      msg.cols <= 500 &&
+      msg.rows >= 1 &&
+      msg.rows <= 200
+    ) {
+      entry.term.resize(msg.cols, msg.rows);
+    }
+  } catch (err) {
+    // e.g. a write/resize that races the PTY exiting — drop it, never crash.
+    console.warn(`[ws] dropped message for ${sessionId}: ${messageOf(err)}`);
+  }
+}
+
+// Socket closed: detach it; keep the PTY alive if Claude is mid-turn (reaped on
+// the Stop hook), otherwise reap now.
+function handleClientClose(entry: PtyEntry, ws: WebSocket, sessionId: string) {
+  // Ignore if a newer client already reattached to this session.
+  if (entry.ws !== ws) return;
+  entry.ws = null;
+  if (activity.get(sessionId)?.working) {
+    console.log(`[ws] disconnected; keeping working session ${sessionId} alive`);
+  } else {
+    console.log(`[ws] disconnected; killing idle session ${sessionId}`);
+    reap(sessionId);
+  }
+}
+
 wss.on("connection", (ws, req) => {
-  // ?session=<id> resumes an existing conversation; absent => fresh session.
-  // For new sessions we generate the id ourselves (--session-id) so the server
-  // always knows the current session's id, even before any file exists.
+  // ?session=<id> resumes an existing conversation; absent => fresh session. For
+  // new sessions we generate the id ourselves (--session-id) so the server always
+  // knows the current session's id, even before any file exists.
   const resume = new URL(req.url ?? "/", "http://localhost").searchParams.get("session");
   if (resume && !SESSION_ID_RE.test(resume)) {
     console.warn(`[ws] rejecting non-UUID session id: ${JSON.stringify(resume)}`);
@@ -693,124 +838,14 @@ wss.on("connection", (ws, req) => {
   ws.send(JSON.stringify({ type: "session", id: sessionId }));
 
   const existing = ptys.get(sessionId);
-  let entry: PtyEntry;
-  if (existing) {
-    entry = existing;
-    // A background pty for this session is still alive — reattach instead of
-    // spawning a duplicate claude. Replay recent output for context.
-    console.log(`[ws] reattach ${sessionId} (pid=${entry.term.pid})`);
-    // Drop any socket still attached (e.g. the same session open in another
-    // tab) so it can't keep writing to this PTY.
-    if (entry.ws && entry.ws !== ws && entry.ws.readyState === entry.ws.OPEN) {
-      entry.ws.close();
-    }
-    entry.ws = ws;
-    if (entry.buffer && ws.readyState === ws.OPEN) {
-      ws.send(JSON.stringify({ type: "output", data: entry.buffer }));
-    }
-  } else {
-    const settings = hookSettingsJson();
-    // Register the GUI MCP broker and auto-allow its tools so the plugin tools
-    // run without a permission prompt (--strict-mcp-config keeps the user's
-    // other MCP servers out of the spike).
-    const mcp = mcpConfigJson(sessionId);
-    const guiArgs = ["--mcp-config", mcp, "--strict-mcp-config", "--allowedTools", GUI_MCP_TOOLS];
-    const args = resume
-      ? ["--resume", resume, "--settings", settings, ...guiArgs]
-      : ["--session-id", sessionId, "--settings", settings, ...guiArgs];
-
-    console.log(`[ws] client connected (${resume ? "resume" : "new"} ${sessionId})`);
-
-    const term = pty.spawn(CLAUDE_BIN, args, {
-      name: "xterm-256color",
-      cols: 120,
-      rows: 30,
-      cwd: CLAUDE_CWD,
-      env: process.env,
-    });
-    console.log(`[pty] spawned claude (pid=${term.pid})`);
-
-    entry = { term, ws, buffer: "" };
-    ptys.set(sessionId, entry);
-
-    if (!resume) {
-      // Brand-new session: surface it in the sidebar before it's persisted.
-      knownSessions.set(sessionId, { createdAt: Date.now(), title: "New session" });
-      pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" });
-    }
-
-    // PTY -> browser (buffering a bounded tail for reattach).
-    term.onData((data) => {
-      entry.buffer = (entry.buffer + data).slice(-OUTPUT_BUFFER_LIMIT);
-      if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
-        entry.ws.send(JSON.stringify({ type: "output", data }));
-      }
-    });
-
-    term.onExit(({ exitCode, signal }) => {
-      console.log(`[pty] exited code=${exitCode} signal=${signal}`);
-      if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
-        entry.ws.send(JSON.stringify({ type: "exit", exitCode, signal }));
-        entry.ws.close();
-      }
-      // Clear the dot if it died mid-turn, then tear down everything (deletes
-      // ptys/knownSessions/activity and publishes "closed") so a process that
-      // exits on its own — e.g. a brand-new session that never persisted —
-      // doesn't linger in the sidebar.
-      setWorking(sessionId, false);
-      reap(sessionId);
-    });
-  }
+  const entry = existing ? reattachPty(existing, ws, sessionId) : spawnClaudePty(sessionId, resume, ws);
 
   // The session is now in the foreground (being viewed): clear any
   // "waiting for input" flag so it stops showing as bold.
   setWaiting(sessionId, false);
 
-  // browser -> PTY. The protocol is client-controlled, so validate every frame
-  // before touching node-pty (bad cols/rows or non-string input can throw).
-  ws.on("message", (raw) => {
-    // Ignore frames from a socket that a newer client has already superseded.
-    if (entry.ws !== ws) return;
-    let msg;
-    try {
-      msg = JSON.parse(raw.toString());
-    } catch {
-      return; // not JSON — never write arbitrary payloads to the PTY
-    }
-    try {
-      if (msg.type === "input" && typeof msg.data === "string") {
-        entry.term.write(msg.data);
-      } else if (
-        msg.type === "resize" &&
-        Number.isInteger(msg.cols) &&
-        Number.isInteger(msg.rows) &&
-        msg.cols >= 2 &&
-        msg.cols <= 500 &&
-        msg.rows >= 1 &&
-        msg.rows <= 200
-      ) {
-        entry.term.resize(msg.cols, msg.rows);
-      }
-    } catch (err) {
-      // e.g. a write/resize that races the PTY exiting — drop it, never crash.
-      console.warn(`[ws] dropped message for ${sessionId}: ${messageOf(err)}`);
-    }
-  });
-
-  ws.on("close", () => {
-    // Ignore if a newer client already reattached to this session.
-    if (entry.ws !== ws) return;
-    entry.ws = null;
-
-    // Keep the pty running if Claude is still working — it will be reaped when
-    // the Stop hook fires (see setWorking). Otherwise kill it now.
-    if (activity.get(sessionId)?.working) {
-      console.log(`[ws] disconnected; keeping working session ${sessionId} alive`);
-    } else {
-      console.log(`[ws] disconnected; killing idle session ${sessionId}`);
-      reap(sessionId);
-    }
-  });
+  ws.on("message", (raw) => handleClientFrame(entry, ws, raw, sessionId));
+  ws.on("close", () => handleClientClose(entry, ws, sessionId));
 });
 
 server.listen(PORT, () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -417,7 +417,7 @@ function projectSessionsDir(cwd: string) {
 // plain string or an array of blocks (guard against null elements).
 function userPromptText(content: unknown): string | null {
   const text = Array.isArray(content)
-    ? content.map((x) => (isRecord(x) ? String(x.text ?? "") : String(x))).join(" ")
+    ? content.map((x) => (isRecord(x) ? String(x.text ?? "") : String(x ?? ""))).join(" ")
     : content;
   if (typeof text === "string" && text.trim() && !/^\s*<(local-command|command-|bash-)/.test(text)) {
     return text.trim();

--- a/src/components/PluginFrame.vue
+++ b/src/components/PluginFrame.vue
@@ -48,7 +48,9 @@ const target = ref<HTMLDivElement | null>(null);
 
 onMounted(() => {
   hoistAtPropertyRules(props.css);
-  const shadow = hostEl.value!.attachShadow({ mode: "open" });
+  const host = hostEl.value;
+  if (!host) return;
+  const shadow = host.attachShadow({ mode: "open" });
   if (props.css) {
     const style = document.createElement("style");
     style.textContent = props.css;

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -12,9 +12,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   (e: "select", id: string): void;
-  (e: "new"): void;
-  (e: "toggle-layout"): void;
-  (e: "refresh"): void;
+  (e: "new" | "toggle-layout" | "refresh"): void;
   (e: "update:filter", f: Filter): void;
 }>();
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -15,9 +15,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   (e: "select", id: string): void;
-  (e: "new"): void;
-  (e: "toggle-layout"): void;
-  (e: "refresh"): void;
+  (e: "new" | "toggle-layout" | "refresh"): void;
   (e: "update:filter", f: Filter): void;
 }>();
 

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -76,7 +76,9 @@ onMounted(() => {
   term.loadAddon(fitAddon);
   term.loadAddon(new WebLinksAddon());
 
-  term.open(terminalRef.value!);
+  const container = terminalRef.value;
+  if (!container) return;
+  term.open(container);
   fitAddon.fit();
 
   // Terminal input -> server
@@ -93,7 +95,7 @@ onMounted(() => {
       ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
     }
   });
-  resizeObserver.observe(terminalRef.value!);
+  resizeObserver.observe(container);
 
   connect();
   term.focus();

--- a/src/components/ToolsPane.spec.ts
+++ b/src/components/ToolsPane.spec.ts
@@ -84,7 +84,7 @@ describe("ToolsPane", () => {
   });
 
   it("drops a stale history response when the session changes mid-flight", async () => {
-    const aGate = deferred<void>();
+    const aGate = deferred<undefined>();
     mockFetch((url) => {
       if (url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ tools: [] }));
       if (url.includes("/api/tool-calls/a")) {
@@ -103,7 +103,7 @@ describe("ToolsPane", () => {
     expect(wrapper.text()).toContain("NewTool");
 
     // A's response arrives late — it must NOT overwrite B's pane.
-    aGate.resolve();
+    aGate.resolve(undefined);
     await flushPromises();
     expect(wrapper.text()).toContain("NewTool");
     expect(wrapper.text()).not.toContain("OldTool");

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,7 +280,7 @@
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
-"@eslint-community/regexpp@^4.12.2":
+"@eslint-community/regexpp@^4.12.2", "@eslint-community/regexpp@^4.8.0":
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
   integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
@@ -1347,6 +1347,11 @@ buffer-equal-constant-time@^1.0.1:
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
+builtin-modules@^3.3.0:
+  version "3.3.0"
+  resolved "https://npm.flatt.tech/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
+  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
+
 bytes@^3.1.2, bytes@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -1711,6 +1716,24 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-plugin-sonarjs@^4.0.3:
+  version "4.0.3"
+  resolved "https://npm.flatt.tech/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz#78bda46bd2f91d0f7445f974fd417dce088b2efa"
+  integrity sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==
+  dependencies:
+    "@eslint-community/regexpp" "^4.12.2"
+    builtin-modules "^3.3.0"
+    bytes "^3.1.2"
+    functional-red-black-tree "^1.0.1"
+    globals "^17.4.0"
+    jsx-ast-utils-x "^0.1.0"
+    lodash.merge "^4.6.2"
+    minimatch "^10.2.5"
+    scslre "^0.3.0"
+    semver "^7.7.4"
+    ts-api-utils "^2.5.0"
+    typescript ">=5"
+
 eslint-plugin-vue@^10.9.2:
   version "10.9.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-10.9.2.tgz#571a3e1d826628f078094a748c9d4df49ad18668"
@@ -2000,6 +2023,11 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://npm.flatt.tech/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
 gaxios@^7.0.0, gaxios@^7.1.4:
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-7.1.5.tgz#fd9c21e896f27794d0483e0f129a238145d7fdf2"
@@ -2070,6 +2098,11 @@ glob@^10.4.2:
     minipass "^7.1.2"
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
+
+globals@^17.4.0:
+  version "17.6.0"
+  resolved "https://npm.flatt.tech/globals/-/globals-17.6.0.tgz#0f0be018d5cca8690e6375ead1f65c4bb96191fc"
+  integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
 
 google-auth-library@^10.3.0:
   version "10.7.0"
@@ -2319,6 +2352,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+jsx-ast-utils-x@^0.1.0:
+  version "0.1.0"
+  resolved "https://npm.flatt.tech/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz#b0933d66a69e0aa1ae23f74fb87b079ec298652f"
+  integrity sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==
+
 jwa@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.1.tgz#bf8176d1ad0cd72e0f3f58338595a13e110bc804"
@@ -2432,6 +2470,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://npm.flatt.tech/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 long@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
@@ -2508,7 +2551,7 @@ mime-types@~2.1.34:
   dependencies:
     mime-db "1.52.0"
 
-minimatch@^10.2.2, minimatch@^10.2.4:
+minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
   integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
@@ -2804,6 +2847,21 @@ raw-body@^3.0.0, raw-body@^3.0.1:
     iconv-lite "~0.7.0"
     unpipe "~1.0.0"
 
+refa@^0.12.0, refa@^0.12.1:
+  version "0.12.1"
+  resolved "https://npm.flatt.tech/refa/-/refa-0.12.1.tgz#dac13c4782dc22b6bae6cce81a2b863888ea39c6"
+  integrity sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==
+  dependencies:
+    "@eslint-community/regexpp" "^4.8.0"
+
+regexp-ast-analysis@^0.7.0:
+  version "0.7.1"
+  resolved "https://npm.flatt.tech/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz#c0e24cb2a90f6eadd4cbaaba129317e29d29c482"
+  integrity sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==
+  dependencies:
+    "@eslint-community/regexpp" "^4.8.0"
+    refa "^0.12.1"
+
 require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
@@ -2873,7 +2931,16 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-semver@^7.5.3, semver@^7.6.3, semver@^7.7.3:
+scslre@^0.3.0:
+  version "0.3.0"
+  resolved "https://npm.flatt.tech/scslre/-/scslre-0.3.0.tgz#c3211e9bfc5547fc86b1eabaa34ed1a657060155"
+  integrity sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==
+  dependencies:
+    "@eslint-community/regexpp" "^4.8.0"
+    refa "^0.12.0"
+    regexp-ast-analysis "^0.7.0"
+
+semver@^7.5.3, semver@^7.6.3, semver@^7.7.3, semver@^7.7.4:
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
   integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
@@ -3217,7 +3284,7 @@ typescript-eslint@^8.61.0:
     "@typescript-eslint/typescript-estree" "8.61.0"
     "@typescript-eslint/utils" "8.61.0"
 
-typescript@~6.0.2:
+typescript@>=5, typescript@~6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==


### PR DESCRIPTION
## Summary

Make lint stricter: add **`eslint-plugin-sonarjs`** (recommended, ~269 rules) and bump
**`typescript-eslint` `recommended` → `strict`**, then fix all **13** resulting
violations with real code changes (no `any`, no `as`).

The codebase was already clean — only 13 problems surfaced.

## Items to Confirm / Review

- **`no-non-null-assertion`** (PluginFrame.vue, Terminal.vue): `ref.value!` replaced
  with a `const x = ref.value; if (!x) return;` guard inside `onMounted`.
- **`@typescript-eslint/unified-signatures`** (Sidebar.vue, SessionTabBar.vue): the three
  payload-less emits merged into `(e: "new" | "toggle-layout" | "refresh"): void`.
- **`no-invalid-void-type`** (ToolsPane.spec.ts): `deferred<void>()` → `deferred<undefined>()`
  (`resolve(undefined)`).
- **`sonarjs/cognitive-complexity`** (server/index.ts, 3 functions): `readSessionMeta`, the
  `/api/hook` handler, and the WebSocket connection handler were split into small named
  helpers (`userPromptText`, `parseJsonl`, `handleActivityHook`, `handleToolHook`,
  `reattachPty`, `spawnClaudePty`, `handleClientFrame`, `handleClientClose`).
  **Behaviour is unchanged** — please sanity-check the connection-handler split (the
  spawn/reattach/message/close logic), since it's the core PTY path and has no unit tests.

## User Prompt

- そして lint rule も厳し目に。
- eslint-plugin-sonarjs（を使って）。

## Implementation

See `plans/chore-stricter-lint.md`.

## Verification

- `yarn lint` ✅ · `yarn typecheck` ✅ · `yarn typecheck:server` ✅ · `yarn test` ✅ (16/16)
  · `yarn build` ✅ · booted via `node --import tsx … server/index.ts` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)