### PR TITLE
feat: package for npm distribution (npx mulmoterminal) (#21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: yarn
 
       - run: yarn install --frozen-lockfile
 
@@ -29,3 +30,53 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      - name: Test
+        run: yarn test
+
+  # Verifies the published package actually works: pack the exact tarball
+  # (prepack builds dist/), install it into a clean dir, and boot the launcher
+  # until it serves "/". Mirrors mulmoclaude's publish smoke.
+  package-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      # The launcher's pre-flight requires `claude --version` to succeed. The
+      # smoke test only needs the server to boot and serve "/", so a tiny stub
+      # on PATH passes the check without the real CLI + auth.
+      - name: Stub Claude Code CLI
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          printf '#!/usr/bin/env bash\n[ "$1" = "--version" ] && { echo "claude 0.0.0 (smoke-stub)"; exit 0; }\nexit 1\n' > "$HOME/.local/bin/claude"
+          chmod +x "$HOME/.local/bin/claude"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # `npm pack` runs prepack (yarn build) to produce dist/, then we install
+      # the exact tarball into a clean dir and boot the launcher.
+      - name: Pack, install, and boot the tarball
+        run: |
+          set -euo pipefail
+          TGZ="$(npm pack | tail -1)"
+          echo "packed: $TGZ"
+          mkdir -p /tmp/mt-smoke && cd /tmp/mt-smoke
+          npm init -y >/dev/null
+          npm install "$GITHUB_WORKSPACE/$TGZ"
+          node_modules/.bin/mulmoterminal --no-open --port 3457 &
+          LAUNCHER_PID=$!
+          ok=
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:3457/ >/dev/null 2>&1; then ok=1; break; fi
+            sleep 1
+          done
+          kill "$LAUNCHER_PID" 2>/dev/null || true
+          [ -n "$ok" ] || { echo "launcher did not serve / within 30s"; exit 1; }
+          echo "✓ tarball booted and served /"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Receptron
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ attention** (waiting for input, or finished with output you haven't seen).
 
 ---
 
+## Install & run
+
+Requires the [`claude`](https://claude.com/claude-code) CLI on your `PATH` and
+**Node ≥ 22.9**.
+
+```bash
+npx mulmoterminal           # start on http://localhost:3456 and open the browser
+# or install globally:
+npm install -g mulmoterminal
+mulmoterminal
+```
+
+Options: `--port <n>` (default 3456), `--no-open`, `--version`, `--help`.
+
+The published package ships the server (run via `tsx`) plus the pre-built web UI;
+`npx mulmoterminal` checks for the `claude` CLI, picks a free port, starts the
+server, and opens the browser. For local development from a clone, see
+[Running](#running).
+
+---
+
 ## Contents
 
 - [Architecture](#architecture)

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+// MulmoTerminal launcher — `npx mulmoterminal` entry point.
+//
+// Ships the server source (TypeScript) + a pre-built client (Vite dist/), and
+// runs the server via tsx. Mirrors the mulmoclaude launcher.
+
+import { execSync, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { get as httpGet } from "node:http";
+import { createServer } from "node:net";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = join(__dirname, "..");
+const SERVER_ENTRY = join(PKG_DIR, "server", "index.ts");
+const DEFAULT_PORT = 3456;
+const READY_TIMEOUT_MS = 15_000;
+const MAX_PORT_PROBES = 20;
+
+const VERSION = "0.1.0";
+
+const log = (msg) => console.log(`\x1b[36m[mulmoterminal]\x1b[0m ${msg}`);
+const error = (msg) => console.error(`\x1b[31m[mulmoterminal]\x1b[0m ${msg}`);
+
+function claudeInstalled() {
+  try {
+    // Intentionally resolves `claude` from the user's PATH — detecting their
+    // Claude Code CLI install is the whole point of this pre-flight check.
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
+    execSync("claude --version", { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pickOpenCommand() {
+  if (process.platform === "darwin") return "open";
+  if (process.platform === "win32") return "start";
+  return "xdg-open";
+}
+
+// Resolve with true if nothing is listening on `port`, false otherwise.
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once("error", () => resolve(false));
+    probe.once("listening", () => probe.close(() => resolve(true)));
+    probe.listen(port, "127.0.0.1");
+  });
+}
+
+async function findAvailablePort(start) {
+  for (let port = start; port < start + MAX_PORT_PROBES; port++) {
+    if (await isPortFree(port)) return port;
+  }
+  return null;
+}
+
+// Poll the server until it answers, then call onReady; give up after the timeout
+// so the launcher never hangs on a crash loop.
+function waitUntilReady(port, onReady) {
+  const startedAt = Date.now();
+  const attempt = () => {
+    const req = httpGet({ host: "127.0.0.1", port, path: "/", timeout: 1000 }, (res) => {
+      res.resume();
+      onReady();
+    });
+    req.on("error", retry);
+    req.on("timeout", () => {
+      req.destroy();
+      retry();
+    });
+  };
+  const retry = () => {
+    if (Date.now() - startedAt > READY_TIMEOUT_MS) return;
+    setTimeout(attempt, 300);
+  };
+  attempt();
+}
+
+function printReadyBanner(url) {
+  const bar = "\x1b[32m" + "─".repeat(48) + "\x1b[0m";
+  console.log(`\n${bar}`);
+  console.log(`\x1b[32m  ✓ MulmoTerminal is ready\x1b[0m`);
+  console.log(`\x1b[32m  → ${url}\x1b[0m`);
+  console.log(`\x1b[32m  Press Ctrl+C to stop.\x1b[0m`);
+  console.log(`${bar}\n`);
+}
+
+function parsePortArg(args) {
+  const idx = args.indexOf("--port");
+  if (idx === -1) return { requestedPort: DEFAULT_PORT, portExplicit: false };
+  const raw = args[idx + 1];
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isInteger(parsed) || String(parsed) !== raw || parsed < 1 || parsed > 65535) {
+    error(`Invalid --port value: "${raw ?? ""}" (expected integer 1..65535)`);
+    process.exit(1);
+  }
+  return { requestedPort: parsed, portExplicit: true };
+}
+
+async function choosePort(requested, explicit) {
+  if (await isPortFree(requested)) return requested;
+  if (explicit) {
+    error(`Port ${requested} is already in use. Stop the other process or pick a different --port.`);
+    process.exit(1);
+  }
+  const fallback = await findAvailablePort(requested + 1);
+  if (fallback === null) {
+    error(`Port ${requested} is in use and no free port found nearby.`);
+    process.exit(1);
+  }
+  log(`Port ${requested} busy → using ${fallback} instead. (Pass --port <N> to pin.)`);
+  return fallback;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Usage: npx mulmoterminal [options]
+
+Options:
+  --port <number>   Server port (default: ${DEFAULT_PORT})
+  --no-open         Don't open the browser automatically
+  --version         Show version
+  --help            Show this help
+`);
+    return;
+  }
+  if (args.includes("--version")) {
+    console.log(`mulmoterminal ${VERSION}`);
+    return;
+  }
+
+  if (!claudeInstalled()) {
+    error("Claude Code CLI not found.");
+    error("Install it first:  npm install -g @anthropic-ai/claude-code  &&  claude auth login");
+    process.exit(1);
+  }
+  log("Claude Code CLI ✓");
+
+  if (!existsSync(SERVER_ENTRY)) {
+    error(`Server entry not found at ${SERVER_ENTRY}`);
+    process.exit(1);
+  }
+
+  const { requestedPort, portExplicit } = parsePortArg(args);
+  const port = await choosePort(requestedPort, portExplicit);
+
+  log(`Starting MulmoTerminal on port ${port}...`);
+  const server = spawn(process.execPath, ["--import", "tsx", SERVER_ENTRY], {
+    cwd: PKG_DIR,
+    env: { ...process.env, NODE_ENV: "production", PORT: String(port) },
+    stdio: "inherit",
+  });
+
+  const url = `http://localhost:${port}`;
+  const noOpen = args.includes("--no-open");
+  waitUntilReady(port, () => {
+    printReadyBanner(url);
+    if (noOpen) return;
+    try {
+      // The command is a hardcoded literal; url is http://localhost:<numeric port>.
+      // eslint-disable-next-line sonarjs/os-command
+      execSync(`${pickOpenCommand()} ${url}`, { stdio: "pipe" });
+    } catch {
+      log(`Open your browser: ${url}`);
+    }
+  });
+
+  const shutdown = () => {
+    server.kill("SIGTERM");
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+  server.on("exit", (code) => process.exit(code ?? 1));
+}
+
+main();

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -8,6 +8,7 @@
 import { execSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { get as httpGet } from "node:http";
+import { createRequire } from "node:module";
 import { createServer } from "node:net";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,7 +20,9 @@ const DEFAULT_PORT = 3456;
 const READY_TIMEOUT_MS = 15_000;
 const MAX_PORT_PROBES = 20;
 
-const VERSION = "0.1.0";
+// Single source of truth: read the version from the shipped package.json so
+// `--version` never drifts from the published version.
+const { version: VERSION } = createRequire(import.meta.url)("../package.json");
 
 const log = (msg) => console.log(`\x1b[36m[mulmoterminal]\x1b[0m ${msg}`);
 const error = (msg) => console.error(`\x1b[31m[mulmoterminal]\x1b[0m ${msg}`);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,7 @@ export default [
     },
   },
   {
-    files: ["server/**/*.js"],
+    files: ["server/**/*.js", "bin/**/*.js"],
     languageOptions: {
       globals: {
         console: "readonly",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,31 @@
 {
   "name": "mulmoterminal",
-  "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/receptron/mulmoterminal.git"
+  },
+  "keywords": [
+    "claude",
+    "claude-code",
+    "terminal",
+    "gui",
+    "ai",
+    "agent",
+    "mulmoterminal"
+  ],
+  "bin": {
+    "mulmoterminal": "bin/mulmoterminal.js"
+  },
+  "files": [
+    "bin/",
+    "dist/",
+    "server/",
+    "plugins/"
+  ],
   "engines": {
     "node": ">=22.9"
   },
@@ -17,6 +40,7 @@
     "preview": "vite preview",
     "server": "node --import tsx --env-file-if-exists=.env server/index.ts",
     "test": "vitest run",
+    "prepack": "yarn build",
     "postinstall": "node server/fix-pty-perms.js"
   },
   "dependencies": {
@@ -37,6 +61,7 @@
     "node-pty": "^1.1.0",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
+    "tsx": "^4.22.4",
     "vue": "^3.5.34",
     "ws": "^8.21.0"
   },
@@ -55,7 +80,6 @@
     "eslint-plugin-vue": "^10.9.2",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.1",
-    "tsx": "^4.22.4",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.12",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "preview": "vite preview",
     "server": "node --import tsx --env-file-if-exists=.env server/index.ts",
     "test": "vitest run",
-    "prepack": "yarn build",
+    "prepack": "vue-tsc -b && vite build",
     "postinstall": "node server/fix-pty-perms.js"
   },
   "dependencies": {

--- a/plans/feat-npm-package.md
+++ b/plans/feat-npm-package.md
@@ -1,0 +1,46 @@
+# feat: npm パッケージ化（`npx mulmoterminal`）(#21)
+
+## ゴール
+
+`npx mulmoterminal` / `npm i -g mulmoterminal` で起動できる npm パッケージにする。
+`receptron/mulmoclaude`（`packages/mulmoclaude`）の構成を参考にする。
+
+## 方針
+
+mulmoclaude と同じく **サーバーは TypeScript のまま同梱して `tsx` で実行**、
+クライアントはビルド済み（`dist/`）を同梱、`bin/` に plain-JS ランチャを置く。
+MulmoTerminal は単一パッケージなので、リポジトリルートから直接 publish 可能
+（mulmoclaude のような monorepo→subpackage コピーは不要）。
+
+## 変更
+
+- `bin/mulmoterminal.js`（plain JS, shebang）: `claude` 存在チェック → 空きポート
+  探索（`net` で自前 probe）→ `node --import tsx server/index.ts` を spawn → 起動
+  完了をポーリングしてブラウザを開く。`--port` / `--no-open` / `--version` / `--help`。
+- `package.json`:
+  - `private` 削除、`version` 0.1.0。
+  - `description` / `license: MIT` / `repository` / `keywords` / `bin` / `files` 追加。
+  - `files`: `bin/` `dist/` `server/` `plugins/`。
+  - `tsx` を devDependencies → dependencies へ移動（実行時に必要）。
+  - `prepack: yarn build`（pack/publish 前に `dist/` を生成）。
+  - `postinstall`（fix-pty-perms.js）は維持、`node-pty` は dependencies のまま。
+- `LICENSE`（MIT）追加。
+- README に「Install & run」節を追加。
+
+## 同梱物の根拠
+
+- サーバーは `../src` を import しない＝Vue ソースは同梱不要。
+- `plugins/plugins.json` は npm パッケージのみ参照（local プラグインなし）＝
+  `plugins/` を同梱すれば足りる（参照パッケージは dependencies）。
+- サーバーは `path.join(__dirname, "../dist")` を静的配信＝`dist/` を同梱。
+
+## 検証
+
+- `npm pack --dry-run` で同梱物に bin/dist/server/plugins/LICENSE/README が含まれることを確認。
+- tgz を一時ディレクトリに install → `mulmoterminal --no-open --port <n>` で
+  `MulmoTerminal is ready` とサーバー起動を確認。
+
+## 備考
+
+- 実際の `npm publish` は別ステップ（認証・最終バージョン確定）。本 PR はパッケージ化まで。
+- `license`（MIT）・`version`（0.1.0）・copyright holder（Receptron）は要確認の前提。


### PR DESCRIPTION
## Summary

Make MulmoTerminal a publishable npm package so `npx mulmoterminal` /
`npm i -g mulmoterminal` just works. Follows `receptron/mulmoclaude`'s approach:
**ship the server as TypeScript run via `tsx` + a pre-built client (`dist/`)**, with a
plain-JS launcher. MulmoTerminal is a single package, so it publishes straight from the
repo root (no monorepo→subpackage copy step).

## What's included

- **`bin/mulmoterminal.js`** — `npx mulmoterminal` entry: checks the `claude` CLI is on
  PATH, finds a free port, spawns `node --import tsx server/index.ts`, polls until ready,
  then opens the browser. Flags: `--port` / `--no-open` / `--version` / `--help`.
- **`package.json`** — drop `private`, `version` 0.1.0, add `bin` / `files` /
  `description` / `license` / `repository` / `keywords`; move `tsx` devDeps → deps
  (runtime); `prepack: yarn build` produces `dist/` at pack time. `files` ships
  `bin/` `dist/` `server/` `plugins/`.
- **`LICENSE`** (MIT), README **"Install & run"** section, eslint node globals for `bin/`.

## Items to Confirm / Review

- **Assumptions (please confirm):** `license: MIT` + `LICENSE` copyright "Receptron"
  (matching mulmoclaude), `version: 0.1.0`, package name `mulmoterminal`.
- **Not published here.** This sets up packaging only; actual `npm publish` is a separate
  authenticated step (run when you're ready, or via the `/publish` skill).
- **Ships server as `.ts` + `tsx`** (not compiled), same as mulmoclaude. `node-pty` stays a
  regular dependency (it's the core terminal); `postinstall` (`fix-pty-perms.js`) ships in
  `server/`.
- Server reads `CLAUDE_CWD` (default `~/mulmoclaude`) — unchanged in this PR; tell me if the
  published default should be `~/mulmoterminal`.

## User Prompt

- npm で配布できるようにしたい。build とかパッケージ化。`../mulmoclaude` を参考に。

## Verification

- `npm pack --dry-run` ships: `bin/mulmoterminal.js`, `dist/` (index.html + assets),
  `server/*.ts` (+ `fix-pty-perms.js`), `plugins/plugins.json`, `LICENSE`, `README.md`,
  `package.json`.
- Packed the tgz, `npm install`ed it into a clean temp project, ran
  `mulmoterminal --no-open --port 39901` → `✓ MulmoTerminal is ready` (server booted).
- `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn test` (16/16) /
  `yarn build` all green.

See `plans/feat-npm-package.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)