### PR TITLE
fix: spawn the GUI MCP broker via tsx (broker.ts, not broker.js)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -120,6 +120,11 @@ const sessionChannel = (id: string) => `session:${id}`;
 // GUI-protocol tool per enabled plugin (driven by plugins/plugins.json) and drives
 // the GUI panel via the toolResult route.
 const MCP_SERVER_PATH = path.join(__dirname, "mcp", "broker.ts");
+// Absolute URL of the tsx ESM loader, so the broker can execute its `.ts` entry
+// regardless of the cwd claude spawns it in. claude runs in the WORKSPACE
+// (CLAUDE_CWD), where tsx isn't installed — a bare `--import tsx` would resolve
+// against that cwd and fail with ERR_MODULE_NOT_FOUND.
+const TSX_LOADER = import.meta.resolve("tsx");
 
 // MCP tool names claude uses, in the mcp__<server>__<tool> form, one per enabled
 // plugin. Auto-allowed via --allowedTools so the spike doesn't trip the permission
@@ -396,9 +401,9 @@ function mcpConfigJson(sessionId: string) {
       "mulmoterminal-gui": {
         command: process.execPath, // the node running this server
         // Run the stdio broker through tsx (same as the main server) — it's a
-        // .ts file, so plain `node broker.ts` can't execute it. Before the
-        // server TS migration this was a .js file run without a loader.
-        args: ["--import", "tsx", MCP_SERVER_PATH],
+        // .ts file, so plain `node broker.ts` can't execute it. Use the resolved
+        // absolute loader URL (see TSX_LOADER) so it works from the workspace cwd.
+        args: ["--import", TSX_LOADER, MCP_SERVER_PATH],
         env: {
           MULMOTERMINAL_SESSION_ID: sessionId,
           MULMOTERMINAL_PORT: String(PORT),

--- a/server/index.ts
+++ b/server/index.ts
@@ -119,7 +119,7 @@ const sessionChannel = (id: string) => `session:${id}`;
 // Stdio MCP broker wired into each spawned claude (--mcp-config). It exposes one
 // GUI-protocol tool per enabled plugin (driven by plugins/plugins.json) and drives
 // the GUI panel via the toolResult route.
-const MCP_SERVER_PATH = path.join(__dirname, "mcp", "broker.js");
+const MCP_SERVER_PATH = path.join(__dirname, "mcp", "broker.ts");
 
 // MCP tool names claude uses, in the mcp__<server>__<tool> form, one per enabled
 // plugin. Auto-allowed via --allowedTools so the spike doesn't trip the permission
@@ -395,7 +395,10 @@ function mcpConfigJson(sessionId: string) {
     mcpServers: {
       "mulmoterminal-gui": {
         command: process.execPath, // the node running this server
-        args: [MCP_SERVER_PATH],
+        // Run the stdio broker through tsx (same as the main server) — it's a
+        // .ts file, so plain `node broker.ts` can't execute it. Before the
+        // server TS migration this was a .js file run without a loader.
+        args: ["--import", "tsx", MCP_SERVER_PATH],
         env: {
           MULMOTERMINAL_SESSION_ID: sessionId,
           MULMOTERMINAL_PORT: String(PORT),

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -120,6 +120,26 @@ function formatValue(v: unknown): string {
     return String(v);
   }
 }
+
+// Copy the WHOLE tool-call history (arguments + results) as pretty JSON — handy
+// to paste into a bug report / share when a run goes sideways. Mirrors
+// MulmoClaude's RightSidebar copy-history button.
+const historyCopied = ref(false);
+let historyCopyTimer: ReturnType<typeof window.setTimeout> | undefined;
+async function copyHistory(): Promise<void> {
+  if (toolCalls.value.length === 0) return;
+  try {
+    await window.navigator.clipboard.writeText(JSON.stringify(toolCalls.value, null, 2));
+    historyCopied.value = true;
+    window.clearTimeout(historyCopyTimer);
+    historyCopyTimer = window.setTimeout(() => {
+      historyCopied.value = false;
+    }, 2000);
+  } catch {
+    // Clipboard blocked (insecure context / permissions) — leave the hint off.
+  }
+}
+onUnmounted(() => window.clearTimeout(historyCopyTimer));
 </script>
 
 <template>
@@ -149,8 +169,18 @@ function formatValue(v: unknown): string {
 
       <!-- Tool call history -->
       <div class="section">
-        <div class="section-title">
-          Tool Call History
+        <div class="section-title section-title--with-action">
+          <span>Tool Call History</span>
+          <button
+            class="copy-history"
+            type="button"
+            :disabled="toolCalls.length === 0"
+            :title="historyCopied ? 'Copied!' : 'Copy all call history'"
+            :aria-label="historyCopied ? 'Copied!' : 'Copy all call history'"
+            @click="copyHistory"
+          >
+            {{ historyCopied ? "✓ Copied" : "Copy all" }}
+          </button>
         </div>
         <div v-if="toolCalls.length === 0" class="muted">
           No tool calls yet.
@@ -227,6 +257,35 @@ function formatValue(v: unknown): string {
   letter-spacing: 0.04em;
   color: #7c87a8;
   margin-bottom: 8px;
+}
+.section-title--with-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.copy-history {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  color: #9aa5c4;
+  background: #1d2b4e;
+  border: 1px solid #2a2a4e;
+  border-radius: 4px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+.copy-history:hover:not(:disabled) {
+  color: #cfe0ff;
+  background: #243763;
+}
+.copy-history:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .muted {


### PR DESCRIPTION
## Problem (regression from the server TS migration #17/#18)
The migration renamed `server/mcp/broker.js` → `broker.ts`, but `server/index.ts` still launched the stdio MCP broker as:
```ts
const MCP_SERVER_PATH = path.join(__dirname, "mcp", "broker.js"); // ← no such file
…
args: [MCP_SERVER_PATH], // ← bare node, no tsx loader
```
So every spawned `claude` session got a broker that **failed to start** (`broker.js` doesn't exist; and even the real `broker.ts` can't run under plain `node`). The result: the `mulmoterminal-gui` MCP tools — **presentDocument / presentForm / generateImage** — silently vanish from the tool set, so the model can't render documents/forms/images and ends up fruitlessly `ToolSearch`-ing for `presentDocument`.

Observable in a session's tool-call history: `total_deferred_tools` drops by 3, and `select:mcp__mulmoterminal-gui__presentDocument` returns `[]` (vs a healthy session where it matches and the tool is callable).

## Fix
- `MCP_SERVER_PATH` → `broker.ts`.
- Launch with `--import tsx` (mirrors the main server `node --import tsx server/index.ts`) so node can execute the `.ts` entry.

## Verification
`typecheck:server`; spawning the broker exactly as the MCP config does now starts a **healthy stdio server** (stays alive with stdin open) instead of exiting with a module-not-found error.

> ⚠️ This breaks **all** GUI plugin tools on `main`, so it's worth merging ahead of the markdown / copy-history work.