### PR TITLE
feat: spawn backend Claude sessions in auto permission mode

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -83,6 +83,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.PORT || 3456;
 const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude";
+// Permission mode for backend-spawned Claude sessions. Defaults to "auto" so
+// the backend runs hands-off; override with CLAUDE_PERMISSION_MODE (e.g.
+// "default" / "acceptEdits" / "bypassPermissions" / "plan") when needed.
+const CLAUDE_PERMISSION_MODE = process.env.CLAUDE_PERMISSION_MODE || "auto";
 const CLAUDE_CWD =
   process.env.CLAUDE_CWD || path.join(os.homedir(), "mulmoclaude");
 
@@ -741,7 +745,15 @@ function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket)
   // without a permission prompt (--strict-mcp-config keeps the user's other MCP
   // servers out of the spike).
   const mcp = mcpConfigJson(sessionId);
-  const guiArgs = ["--mcp-config", mcp, "--strict-mcp-config", "--allowedTools", GUI_MCP_TOOLS];
+  const guiArgs = [
+    "--permission-mode",
+    CLAUDE_PERMISSION_MODE,
+    "--mcp-config",
+    mcp,
+    "--strict-mcp-config",
+    "--allowedTools",
+    GUI_MCP_TOOLS,
+  ];
   const args = resume
     ? ["--resume", resume, "--settings", settings, ...guiArgs]
     : ["--session-id", sessionId, "--settings", settings, ...guiArgs];


### PR DESCRIPTION
## What

Backend-spawned Claude PTYs (`spawnClaudePty` in `server/index.ts`) ran in the **default** permission mode, so every `Write` / `Edit` / `Bash` halted on a permission prompt. That's unworkable for the hands-off backend, where no human is at the terminal to approve each action.

This passes `--permission-mode auto` on every spawned session by default, overridable via a new `CLAUDE_PERMISSION_MODE` env var (e.g. `default` / `acceptEdits` / `bypassPermissions` / `plan`).

## Why auto (not bypass)

`auto` is classifier-gated rather than a blanket bypass: read-only actions and working-directory edits run without prompting, while escalating/destructive actions (prod deploys, force push, mass deletion, `curl | bash`, etc.) are still reviewed. That fits an unattended backend without giving up the safety net.

## Notes

- Requires Claude Code ≥ 2.1.83 and a supported model (Opus 4.6+/Sonnet 4.6); otherwise auto silently falls back to default.
- Separately, a user-level `permissions.disableAutoMode: "disable"` in `~/.claude/settings.json` locks auto off — not part of this repo, but worth knowing if prompts persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)