### PR TITLE
feat: spawnBackgroundChat MCP tool that spawns a new terminal session

### DIFF
--- a/server/host-tools.ts
+++ b/server/host-tools.ts
@@ -1,0 +1,45 @@
+// Host tools: built-in GUI-protocol tools whose execute lives in the main server
+// (server/index.ts) rather than in a plugin module, because they need server
+// internals the plugin sandbox doesn't expose — e.g. the live PTY table. The
+// registry owns only their DEFINITIONS, so the MCP broker lists them and they're
+// auto-allowed (allowedToolNames); index.ts mounts their dispatch route itself,
+// before plugins-registry's catch-all /api/plugin/:toolName.
+import type { ToolDefinition } from "gui-chat-protocol";
+
+// Mirrors MulmoClaude's spawnBackgroundChat signature (message/role/hidden) so the
+// tool is a drop-in from the model's point of view — but the implementation is
+// completely different: instead of starting an SDK chat, it spawns a brand-new
+// interactive Claude terminal session on the server, seeded with `message`, that
+// the user can open from the sidebar. `role` and `hidden` are accepted for
+// signature parity but ignored: the spawned session is always a visible terminal.
+export const SPAWN_BACKGROUND_CHAT: ToolDefinition = {
+  type: "function",
+  name: "spawnBackgroundChat",
+  description:
+    "Launch a separate, parallel chat session that runs its own agent turn concurrently with this conversation, then returns immediately (fire-and-forget). Use it to do work off the critical path — e.g. pre-generate an artifact the user will need soon — without blocking the current turn. Returns the new session's chatId.",
+  prompt:
+    "Use `spawnBackgroundChat` to run work in parallel with the current conversation instead of making the user wait for it inline. " +
+    "The `message` must be fully self-contained — the spawned session shares NONE of this chat's context — and should state exactly what to produce and where to write it. " +
+    "It returns right away with a `chatId`; it does NOT wait for the spawned session to finish. The new session appears in the sidebar and the user can open it at any time.",
+  parameters: {
+    type: "object",
+    properties: {
+      message: {
+        type: "string",
+        description:
+          "The first user turn for the spawned session — a complete, self-contained instruction, since the worker shares none of this conversation's context.",
+      },
+      role: {
+        type: "string",
+        description: "Role id the spawned session runs in. (Accepted for compatibility; currently ignored.)",
+      },
+      hidden: {
+        type: "boolean",
+        description: "Accepted for compatibility; currently ignored — the spawned session is always visible to the user.",
+      },
+    },
+    required: ["message", "role", "hidden"],
+  },
+};
+
+export const HOST_TOOL_DEFINITIONS: ToolDefinition[] = [SPAWN_BACKGROUND_CHAT];

--- a/server/index.ts
+++ b/server/index.ts
@@ -491,6 +491,29 @@ const app = express();
 // the hook and leave its tool-call entry stuck on "running").
 app.use(express.json({ limit: "25mb" }));
 
+// Host tool: spawnBackgroundChat. Unlike a plugin (handled by mountAllRoutes'
+// catch-all), it needs server internals — it spawns a brand-new interactive Claude
+// terminal session, seeded with `message`, that the user can open from the sidebar.
+// `role`/`hidden` are accepted for signature parity with MulmoClaude but ignored:
+// the session is always visible. Registered BEFORE mountAllRoutes so this specific
+// route wins over /api/plugin/:toolName.
+app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
+  const body = isRecord(req.body) ? req.body : {};
+  const message = typeof body.message === "string" ? body.message.trim() : "";
+  if (!message) {
+    return res.json({ message: "spawnBackgroundChat: `message` is required (non-empty string)." });
+  }
+  const sessionId = randomUUID();
+  // ws is null: the session runs headless until the user opens it (reattach
+  // replays the buffered output). The "created" pubsub event in spawnClaudePty
+  // surfaces it in the sidebar right away.
+  spawnClaudePty(sessionId, null, null, message);
+  return res.json({
+    message: `Spawned a new terminal session (chatId ${sessionId}). It runs in parallel; the user can open it from the sidebar.`,
+    jsonData: { chatId: sessionId },
+  });
+});
+
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
 // POST /api/form). The MCP broker dispatches tool calls to these.
 mountAllRoutes(app);
@@ -738,8 +761,16 @@ function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntr
 }
 
 // Spawn a fresh claude PTY for this session, register it, and wire its output /
-// exit back to the browser socket.
-function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket): PtyEntry {
+// exit back to the browser socket. `ws` may be null for a session spawned without
+// a viewer yet (e.g. spawnBackgroundChat) — output just buffers until a client
+// reattaches. `initialPrompt`, when given, is passed to claude as the first turn
+// so the session starts working immediately, before anyone opens it.
+function spawnClaudePty(
+  sessionId: string,
+  resume: string | null,
+  ws: WebSocket | null,
+  initialPrompt?: string,
+): PtyEntry {
   const settings = hookSettingsJson();
   // Register the GUI MCP broker and auto-allow its tools so the plugin tools run
   // without a permission prompt (--strict-mcp-config keeps the user's other MCP
@@ -754,9 +785,13 @@ function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket)
     "--allowedTools",
     GUI_MCP_TOOLS,
   ];
-  const args = resume
+  const baseArgs = resume
     ? ["--resume", resume, "--settings", settings, ...guiArgs]
     : ["--session-id", sessionId, "--settings", settings, ...guiArgs];
+  // The initial prompt goes last as a positional arg (claude's initial-prompt
+  // form). "--" ends option parsing so a prompt that happens to start with "-"
+  // can't be reinterpreted as a flag.
+  const args = initialPrompt ? [...baseArgs, "--", initialPrompt] : baseArgs;
 
   console.log(`[ws] client connected (${resume ? "resume" : "new"} ${sessionId})`);
 
@@ -773,8 +808,11 @@ function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket)
   ptys.set(sessionId, entry);
 
   if (!resume) {
-    // Brand-new session: surface it in the sidebar before it's persisted.
-    knownSessions.set(sessionId, { createdAt: Date.now(), title: "New session" });
+    // Brand-new session: surface it in the sidebar before it's persisted. A
+    // spawned session (initialPrompt) gets a title from its first message so it's
+    // recognizable in the sidebar before anyone opens it.
+    const title = initialPrompt ? initialPrompt.replace(/\s+/g, " ").trim().slice(0, 60) || "New session" : "New session";
+    knownSessions.set(sessionId, { createdAt: Date.now(), title });
     pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" });
   }
 

--- a/server/plugins-registry.ts
+++ b/server/plugins-registry.ts
@@ -18,6 +18,7 @@ import { fileURLToPath, pathToFileURL } from "url";
 import type { Express } from "express";
 import { generateImage } from "./backends/image-gen.js";
 import { markdownHostApp } from "./backends/markdown.js";
+import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLUGINS_DIR = path.join(__dirname, "..", "plugins");
@@ -82,14 +83,15 @@ export const plugins = [
 const byName = Object.fromEntries(plugins.map((p) => [p.toolName, p]));
 
 // MCP tool definitions the broker registers — gui-chat-protocol ToolDefinitions
-// ({ name, description, prompt?, parameters }), one per enabled plugin.
-export const toolDefinitions = plugins.map((p) => p.definition);
+// ({ name, description, prompt?, parameters }), one per enabled plugin plus the
+// built-in host tools (which the server dispatches itself; see host-tools.ts).
+export const toolDefinitions = [...plugins.map((p) => p.definition), ...HOST_TOOL_DEFINITIONS];
 
 // JSON-serializable summaries (no schema) for the GUI's tools pane.
-export const toolSummaries = plugins.map((p) => ({
-  toolName: p.toolName,
-  title: p.toolName,
-  description: p.definition.description,
+export const toolSummaries = toolDefinitions.map((d) => ({
+  toolName: d.name,
+  title: d.name,
+  description: d.description,
 }));
 
 // Mount the uniform dispatch route. The MCP broker POSTs a tool's args to
@@ -108,6 +110,7 @@ export function mountAllRoutes(app: Express) {
 }
 
 // Fully-qualified MCP tool names for claude's --allowedTools (auto-run, no prompt).
+// Includes host tools so they run without a permission prompt too.
 export function allowedToolNames() {
-  return plugins.map((p) => `mcp__${MCP_SERVER_NAME}__${p.toolName}`);
+  return toolDefinitions.map((d) => `mcp__${MCP_SERVER_NAME}__${d.name}`);
 }


### PR DESCRIPTION
## What

Adds a `spawnBackgroundChat` MCP tool that mirrors MulmoClaude's signature (`message` / `role` / `hidden`, all required) so it's a **drop-in from the model's point of view** — but the implementation is completely different.

Instead of starting an SDK chat, it **spawns a brand-new interactive Claude terminal session on the server**, seeded with `message`, that the user can open from the sidebar. It's fire-and-forget: returns immediately with a `chatId`.

`role` and `hidden` are accepted for signature parity but **ignored** — the spawned session is always visible to the user.

## How

- **`server/host-tools.ts`** (new) — introduces the "host tool" concept: built-in GUI tools whose execute needs server internals (the live PTY table) the plugin sandbox can't reach. The registry owns only their *definitions*; the server mounts the dispatch route itself.
- **`server/plugins-registry.ts`** — merges `HOST_TOOL_DEFINITIONS` into `toolDefinitions`, `toolSummaries`, and `allowedToolNames()`, so the MCP broker lists the tool and it auto-runs without a permission prompt.
- **`server/index.ts`**:
  - `spawnClaudePty` now takes a nullable `ws` (headless until the user opens it; `reattachPty` replays the buffer) and an optional `initialPrompt` (passed as claude's positional prompt after `--`, so a `-`-leading message can't be reparsed as a flag). Sidebar title is derived from the message.
  - `POST /api/plugin/spawnBackgroundChat`, registered **before** `mountAllRoutes` so it wins over the `/api/plugin/:toolName` catch-all and can use server internals. The existing `"created"` pubsub event surfaces the session in the sidebar instantly.

## Testing

- `tsc -p tsconfig.server.json` and `eslint` pass.
- Registry wiring verified at runtime — tool appears in `toolDefinitions`, `allowedToolNames`, and `toolSummaries`.
- Verified live end-to-end: the model discovered the tool via `ToolSearch`, called it with `message: "こんにちは"`, and got back a `chatId` for a freshly spawned, visible session (31ms, confirming fire-and-forget). The `--` seeding handled the non-ASCII prompt correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)