### PR TITLE
feat: serve GUI MCP in-process over Streamable HTTP (drop stdio broker)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,8 +8,10 @@ import os from "os";
 import fs from "fs/promises";
 import { randomUUID } from "crypto";
 import { fileURLToPath } from "url";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createPubSub } from "./pubsub.js";
 import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-registry.js";
+import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
@@ -121,15 +123,10 @@ const SESSIONS_CHANNEL = "sessions";
 // publishes it here (mirrors MulmoClaude's sessionChannel; see the spike doc).
 const sessionChannel = (id: string) => `session:${id}`;
 
-// Stdio MCP broker wired into each spawned claude (--mcp-config). It exposes one
-// GUI-protocol tool per enabled plugin (driven by plugins/plugins.json) and drives
-// the GUI panel via the toolResult route.
-const MCP_SERVER_PATH = path.join(__dirname, "mcp", "broker.ts");
-// Absolute URL of the tsx ESM loader, so the broker can execute its `.ts` entry
-// regardless of the cwd claude spawns it in. claude runs in the WORKSPACE
-// (CLAUDE_CWD), where tsx isn't installed — a bare `--import tsx` would resolve
-// against that cwd and fail with ERR_MODULE_NOT_FOUND.
-const TSX_LOADER = import.meta.resolve("tsx");
+// The GUI MCP server is served in-process over Streamable HTTP at /mcp/:sessionId
+// (see the route below) and wired into each spawned claude via --mcp-config. It
+// exposes one GUI-protocol tool per enabled plugin (driven by plugins/plugins.json)
+// and drives the GUI panel via the toolResult route.
 
 // MCP tool names claude uses, in the mcp__<server>__<tool> form, one per enabled
 // plugin. Auto-allowed via --allowedTools so the spike doesn't trip the permission
@@ -397,22 +394,18 @@ function hookSettingsJson() {
   });
 }
 
-// MCP config injected via `claude --mcp-config <json>`. Registers the stdio GUI
-// broker and passes this session's id + the server port to it via env (the MCP
-// process can't otherwise know which session it belongs to).
+// MCP config injected via `claude --mcp-config <json>`. Points claude at the
+// in-process GUI MCP server served over Streamable HTTP. The session id rides in
+// the URL path (the MCP server is otherwise stateless), so no env or subprocess is
+// needed — the agent just makes an HTTP call back to this server. Using
+// 127.0.0.1 (not localhost) avoids an IPv6/IPv4 resolution mismatch against the
+// server's listen address.
 function mcpConfigJson(sessionId: string) {
   return JSON.stringify({
     mcpServers: {
       "mulmoterminal-gui": {
-        command: process.execPath, // the node running this server
-        // Run the stdio broker through tsx (same as the main server) — it's a
-        // .ts file, so plain `node broker.ts` can't execute it. Use the resolved
-        // absolute loader URL (see TSX_LOADER) so it works from the workspace cwd.
-        args: ["--import", TSX_LOADER, MCP_SERVER_PATH],
-        env: {
-          MULMOTERMINAL_SESSION_ID: sessionId,
-          MULMOTERMINAL_PORT: String(PORT),
-        },
+        type: "http",
+        url: `http://127.0.0.1:${PORT}/mcp/${sessionId}`,
       },
     },
   });
@@ -515,8 +508,37 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
 });
 
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
-// POST /api/form). The MCP broker dispatches tool calls to these.
+// POST /api/form). The GUI MCP server dispatches tool calls to these.
 mountAllRoutes(app);
+
+// In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
+// mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in
+// STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
+// request, no session header / no initialize handshake required across requests.
+// The SDK forbids reusing a stateless transport, so we never cache it.
+const mcpReject = (_req: express.Request, res: express.Response) => res.status(405).set("Allow", "POST").json({ error: "method not allowed" });
+app.post("/mcp/:sessionId", async (req, res) => {
+  const { sessionId } = req.params;
+  if (!SESSION_ID_RE.test(sessionId)) {
+    return res.status(400).json({ error: "invalid sessionId" });
+  }
+  const server = buildGuiMcpServer(sessionId, `http://127.0.0.1:${PORT}`);
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  res.on("close", () => {
+    transport.close();
+    server.close();
+  });
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (err) {
+    console.error(`[mcp] request failed for ${sessionId}:`, err);
+    if (!res.headersSent) res.status(500).json({ error: "mcp error" });
+  }
+});
+// No SSE stream / session teardown in stateless mode — reject the rest.
+app.get("/mcp/:sessionId", mcpReject);
+app.delete("/mcp/:sessionId", mcpReject);
 
 // Serve Vite build output
 app.use(express.static(path.join(__dirname, "../dist")));

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -1,6 +1,7 @@
-// Stdio MCP broker for the GUI chat protocol. Registers one MCP tool per enabled
-// plugin (from server/plugins-registry.js, driven by plugins/plugins.json) and acts
-// as a thin HTTP bridge to the main server:
+// GUI chat-protocol MCP server, built per session and served over HTTP from the
+// main mulmoterminal process (see the `/mcp/:sessionId` route in server/index.ts).
+// Registers one MCP tool per enabled plugin (from server/plugins-registry.js,
+// driven by plugins/plugins.json) and acts as a thin bridge to the host routes:
 //
 //   tool call  ->  POST /api/plugin/<toolName>         (the dispatch route)
 //              ->  envelope { data, message, instructions, title? }
@@ -17,18 +18,15 @@
 // The form round-trip is NOT a blocking call: the user's answer comes back by being
 // typed into the PTY (see the GUI panel / form view), so every tool returns at once.
 //
-// Context reaches this subprocess via env (set when the server builds the mcp-config):
-//   MULMOTERMINAL_SESSION_ID  - the session whose GUI panel should render this
-//   MULMOTERMINAL_PORT        - the mulmoterminal HTTP port to POST to
+// Previously this ran as a per-session stdio subprocess that claude spawned via
+// --mcp-config. It now lives in-process and is exposed over Streamable HTTP so the
+// agent can reach it from anywhere (host or, later, a Docker sandbox) without us
+// shipping the server code + tsx into the agent's environment. The session id and
+// the host base URL are passed in by the caller instead of via env.
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "node:crypto";
 import { toolDefinitions } from "../plugins-registry.js";
-
-const SESSION_ID = process.env.MULMOTERMINAL_SESSION_ID;
-const PORT = process.env.MULMOTERMINAL_PORT || "3456";
-const BASE_URL = `http://localhost:${PORT}`;
 
 // Shape of the dispatch route's response (POST /api/plugin/<tool>). `data` gates
 // whether a toolResult is published to the GUI; the rest is narration/metadata.
@@ -41,11 +39,6 @@ interface ToolEnvelope {
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
-
-const server = new Server(
-  { name: "mulmoterminal-gui", version: "0.0.0" },
-  { capabilities: { tools: {} } }
-);
 
 async function postJson(url: string, body: unknown) {
   const res = await fetch(url, {
@@ -64,38 +57,49 @@ function describe(def: { description?: string; prompt?: string }) {
   return [def.description, def.prompt].filter(Boolean).join("\n\n");
 }
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: toolDefinitions.map((def) => ({
-    name: def.name,
-    description: describe(def),
-    inputSchema: def.parameters ?? { type: "object", properties: {} },
-  })),
-}));
+/**
+ * Build a fresh GUI MCP server bound to one chat session. Stateless: create one
+ * per request (Streamable HTTP in stateless mode forbids reusing a transport, and
+ * the server has no per-connection state beyond the captured `sessionId`).
+ *
+ * @param sessionId  the chat session whose GUI panel should render tool results
+ * @param baseUrl    the mulmoterminal host origin to POST plugin dispatch + results to
+ */
+export function buildGuiMcpServer(sessionId: string, baseUrl: string): Server {
+  const server = new Server({ name: "mulmoterminal-gui", version: "0.0.0" }, { capabilities: { tools: {} } });
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: toolDefinitions.map((def) => ({
+      name: def.name,
+      description: describe(def),
+      inputSchema: def.parameters ?? { type: "object", properties: {} },
+    })),
+  }));
 
-  // 1. Dispatch to the plugin's server-side handler.
-  const parsed = await (await postJson(`${BASE_URL}/api/plugin/${name}`, args ?? {})).json();
-  const envelope: ToolEnvelope = isRecord(parsed) ? parsed : {};
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
 
-  // 2. Publish a toolResult to the GUI — only when there is data to render.
-  if (envelope.data !== undefined) {
-    await postJson(`${BASE_URL}/api/agent/toolResult`, {
-      sessionId: SESSION_ID,
-      toolName: name,
-      uuid: randomUUID(),
-      title: envelope.title,
-      data: envelope.data,
-      jsonData: envelope.jsonData ?? envelope.data,
-      message: envelope.message,
-    });
-  }
+    // 1. Dispatch to the plugin's server-side handler.
+    const parsed = await (await postJson(`${baseUrl}/api/plugin/${name}`, args ?? {})).json();
+    const envelope: ToolEnvelope = isRecord(parsed) ? parsed : {};
 
-  // 3. Return the narration to claude.
-  const parts = [envelope.message, envelope.instructions].filter(Boolean);
-  return { content: [{ type: "text", text: parts.length ? parts.join("\n") : "Done" }] };
-});
+    // 2. Publish a toolResult to the GUI — only when there is data to render.
+    if (envelope.data !== undefined) {
+      await postJson(`${baseUrl}/api/agent/toolResult`, {
+        sessionId,
+        toolName: name,
+        uuid: randomUUID(),
+        title: envelope.title,
+        data: envelope.data,
+        jsonData: envelope.jsonData ?? envelope.data,
+        message: envelope.message,
+      });
+    }
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+    // 3. Return the narration to claude.
+    const parts = [envelope.message, envelope.instructions].filter(Boolean);
+    return { content: [{ type: "text", text: parts.length ? parts.join("\n") : "Done" }] };
+  });
+
+  return server;
+}


### PR DESCRIPTION
## What

The GUI chat-protocol MCP server no longer runs as a per-session **stdio subprocess** that `claude` spawns via `--mcp-config`. It now lives **in-process** in the main server and is exposed over **Streamable HTTP** at `POST /mcp/:sessionId`.

## Why

Two wins:

1. **Simplifies the current path** — removes a per-session subprocess spawn and the `tsx`-loader dance (`claude` runs in the workspace cwd, where `tsx` isn't installed, which is why the old config had to resolve an absolute loader URL).
2. **Enables Docker-sandboxing the agent** — with MCP on the host, a sandboxed `claude` reaches the GUI tools via an **outbound HTTP call**, so we don't have to ship `server/` + `node_modules` + `tsx` into the container (the messy part of mulmoclaude's in-container broker).

## How

- `server/mcp/broker.ts`: exports `buildGuiMcpServer(sessionId, baseUrl)` instead of reading the session id/port from env and connecting a `StdioServerTransport`. Same `tools/list` / `tools/call` handlers.
- `server/index.ts`:
  - Mounts `POST /mcp/:sessionId` in **stateless** mode (`sessionIdGenerator: undefined`): a fresh `Server`+transport per request (the SDK forbids reusing a stateless transport), session id carried in the URL path, no `initialize` handshake required across requests. `GET`/`DELETE` → 405; invalid session id → 400.
  - `mcpConfigJson` now emits `{ type: "http", url: "http://127.0.0.1:${PORT}/mcp/${sessionId}" }` (127.0.0.1 to avoid an IPv6/IPv4 mismatch). Drops `MCP_SERVER_PATH` / `TSX_LOADER`.

## Verification

- ✅ End-to-end with a real `claude` session — `generateImage` GUI tool resolved and ran through the new HTTP path (~12s).
- ✅ `tools/list` works statelessly (no prior `initialize`); `tools/call presentDocument` → dispatch → narration to claude → `toolResult` stored + published under the session id from the URL path.
- ✅ Invalid session id → 400; `GET`/`DELETE` → 405.
- ✅ `typecheck:server` and `lint` clean.

## Follow-up (not in this PR)

Docker sandbox: swap `pty.spawn("claude", …)` → `pty.spawn("docker", ["run","-it",…])`, change `127.0.0.1` → `host.docker.internal` (+ `--add-host` on Linux), add a per-session bearer token to the `/mcp` URL since it becomes container-reachable, and replace `env: process.env` with credential mounts + an env allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)