### PR TITLE
fix: node-pty spawn-helper perms on hoisted installs (posix_spawnp crash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,19 +50,22 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      # The launcher's pre-flight requires `claude --version` to succeed. The
-      # smoke test only needs the server to boot and serve "/", so a tiny stub
-      # on PATH passes the check without the real CLI + auth.
+      # The launcher's pre-flight requires `claude --version` to succeed, and the
+      # PTY check spawns `claude` — so the stub answers --version AND, for any
+      # other invocation, prints a line and exits cleanly (a real PTY lifecycle)
+      # without needing the real CLI + auth.
       - name: Stub Claude Code CLI
         run: |
           mkdir -p "$HOME/.local/bin"
-          printf '#!/usr/bin/env bash\n[ "$1" = "--version" ] && { echo "claude 0.0.0 (smoke-stub)"; exit 0; }\nexit 1\n' > "$HOME/.local/bin/claude"
+          printf '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo "claude 0.0.0 (smoke-stub)"; exit 0; fi\necho "smoke-stub claude started"\nexit 0\n' > "$HOME/.local/bin/claude"
           chmod +x "$HOME/.local/bin/claude"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       # `npm pack` runs prepack (yarn build) to produce dist/, then we install
-      # the exact tarball into a clean dir and boot the launcher.
-      - name: Pack, install, and boot the tarball
+      # the exact tarball into a clean (hoisted) dir, boot the launcher, and
+      # exercise the /ws PTY path — the failure mode (#33) where node-pty's
+      # spawn-helper shipped non-executable on hoisted installs.
+      - name: Pack, install, boot, and exercise the /ws PTY path
         run: |
           set -euo pipefail
           TGZ="$(npm pack | tail -1)"
@@ -70,13 +73,28 @@ jobs:
           mkdir -p /tmp/mt-smoke && cd /tmp/mt-smoke
           npm init -y >/dev/null
           npm install "$GITHUB_WORKSPACE/$TGZ"
+
+          # Regression guard for #33: the node-pty spawn-helper must be executable
+          # after the postinstall, even though node-pty is hoisted here.
+          HELPER="node_modules/node-pty/prebuilds/linux-x64/spawn-helper"
+          if [ -f "$HELPER" ] && [ ! -x "$HELPER" ]; then
+            echo "regression: $HELPER is not executable (644) after install"; exit 1
+          fi
+
           node_modules/.bin/mulmoterminal --no-open --port 3457 &
           LAUNCHER_PID=$!
+          trap 'kill "$LAUNCHER_PID" 2>/dev/null || true' EXIT
           ok=
           for _ in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:3457/ >/dev/null 2>&1; then ok=1; break; fi
             sleep 1
           done
-          kill "$LAUNCHER_PID" 2>/dev/null || true
           [ -n "$ok" ] || { echo "launcher did not serve / within 30s"; exit 1; }
           echo "✓ tarball booted and served /"
+
+          # A /ws connection must spawn a PTY (session + output/exit), not an
+          # error frame — and the server must survive it. ws resolves from the
+          # repo's own node_modules (installed by the job's `yarn install`).
+          MT_PORT=3457 node "$GITHUB_WORKSPACE/scripts/ci-ws-smoke.mjs"
+          curl -fsS -o /dev/null http://127.0.0.1:3457/ || { echo "server died after the PTY session"; exit 1; }
+          echo "✓ /ws spawned a PTY and the server is still serving"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,7 @@ export default [
     },
   },
   {
-    files: ["server/**/*.js", "bin/**/*.js"],
+    files: ["server/**/*.js", "bin/**/*.js", "scripts/**/*.{js,mjs}"],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",

--- a/plans/fix-pty-helper-perms.md
+++ b/plans/fix-pty-helper-perms.md
@@ -1,0 +1,42 @@
+# fix: posix_spawnp failed — node-pty spawn-helper perms on hoisted installs
+
+## 症状
+
+公開版 (`npx mulmoterminal` 0.1.1) で、ターミナル接続時（WebSocket 接続 → `claude`
+を PTY 起動）に `Error: posix_spawnp failed.` でサーバーがクラッシュする。
+
+## 原因
+
+`server/fix-pty-perms.js`（postinstall で node-pty の `spawn-helper` を 755 に直す）が
+`path.resolve(__dirname, "../node_modules/node-pty/prebuilds")` という**固定相対パス**で
+node-pty を探していた。
+
+- リポジトリ（dev）では node-pty が `repo/node_modules/node-pty` にネストするので当たる。
+- 一方、利用者の install（`npx` / `npm i`）では node-pty が**トップレベルに hoist** され
+  (`<root>/node_modules/node-pty`)、`<pkg>/node_modules/node-pty` には無い → postinstall が
+  helper を見つけられず、`spawn-helper` が **644（実行不可）** のまま → `posix_spawnp` 失敗。
+
+ローカルで tgz を hoist レイアウトに install して再現確認済み（helper が 644、spawn 失敗）。
+
+## 修正
+
+- **server/fix-pty-perms.js**: `createRequire(import.meta.url).resolve("node-pty/package.json")`
+  で node-pty の実体を解決し（nested/hoist どちらでも）、`prebuilds/*/spawn-helper` を全アーキ
+  分 755 に。node-pty 未解決時は no-op で終了。
+- **server/index.ts（堅牢化）**: WebSocket 接続時の `spawnClaudePty` を try/catch で囲み、
+  spawn 失敗時は**その接続だけ**を閉じてクライアントにエラーフレームを返す（サーバー全体は
+  落とさない）。`spawnBackgroundChat` の spawn も同様にガード。
+
+## 検証（ローカル・hoist レイアウトで実機）
+
+- 修正後 tgz を install → `spawn-helper` が **755**、node-pty は `lib/index.js` 解決。
+- 単体 `pty.spawn('claude','--version')` → exit 0（バージョン出力）。
+- **実 WebSocket を /ws に接続 → `[pty] spawned claude (pid=...)` ＋ 出力ストリーム受信（PTY-OK）**、
+  `posix_spawnp` なし。
+- `CLAUDE_BIN=/nonexistent` で spawn 失敗 → 接続だけ閉じ、サーバーは生存（`GET / → 200`）。
+- `lint` / `typecheck` / `typecheck:server` / `test`(16) / `build` / `format:check` 緑。
+
+## 備考
+
+これは publish 済み 0.1.1 を壊していた回帰。マージ後 0.1.2 として publish 予定。
+HTTP `/` だけ見ていた CI の package-smoke では検出できなかったため、WS+PTY も確認すべき。

--- a/scripts/ci-ws-smoke.mjs
+++ b/scripts/ci-ws-smoke.mjs
@@ -1,0 +1,34 @@
+// CI regression check for the terminal (PTY) path: connect to the running
+// launcher's /ws and assert it actually spawns a PTY — a `session` frame
+// followed by `output`/`exit` — rather than an `error` frame (which is what a
+// failed spawn, e.g. a non-executable node-pty spawn-helper, produces). Exits
+// non-zero on failure so CI fails if the PTY path regresses. Port via MT_PORT.
+import WebSocket from "ws";
+
+const port = process.env.MT_PORT ?? "3457";
+const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, { headers: { origin: "http://localhost" } });
+let sawSession = false;
+
+const done = (ok, msg) => {
+  console.log(`${ok ? "✓" : "✗"} PTY: ${msg}`);
+  try {
+    ws.close();
+  } catch {
+    // ignore close errors during teardown
+  }
+  process.exit(ok ? 0 : 1);
+};
+
+ws.on("message", (data) => {
+  let frame;
+  try {
+    frame = JSON.parse(data.toString());
+  } catch {
+    return;
+  }
+  if (frame.type === "session") sawSession = true;
+  else if (frame.type === "output" || frame.type === "exit") done(sawSession, `spawned (${frame.type})`);
+  else if (frame.type === "error") done(false, `spawn failed: ${frame.message}`);
+});
+ws.on("error", (e) => done(false, `ws error: ${e.message}`));
+setTimeout(() => done(false, `timeout (session=${sawSession})`), 15000);

--- a/server/fix-pty-perms.js
+++ b/server/fix-pty-perms.js
@@ -1,15 +1,29 @@
-// Fix node-pty spawn-helper permissions (macOS npm tarball ships 644)
-import { chmodSync, existsSync } from "fs";
+// Fix node-pty spawn-helper permissions (the npm tarball ships it 644, but
+// posix_spawnp needs it executable). node-pty may be hoisted to a top-level
+// node_modules (consumer / npx install) or nested (this repo), so resolve its
+// real location via Node's module resolution instead of a fixed relative path —
+// the hardcoded "../node_modules/node-pty" only worked in the nested case and
+// left the helper non-executable on installs where node-pty was hoisted.
+import { chmodSync, existsSync, readdirSync } from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
+import { createRequire } from "module";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const base = path.resolve(__dirname, "../node_modules/node-pty/prebuilds");
+const require = createRequire(import.meta.url);
 
-for (const arch of ["darwin-arm64", "darwin-x64"]) {
-  const helper = path.join(base, arch, "spawn-helper");
-  if (existsSync(helper)) {
-    chmodSync(helper, 0o755);
-    console.log(`Fixed permissions: ${helper}`);
+let prebuilds;
+try {
+  prebuilds = path.join(path.dirname(require.resolve("node-pty/package.json")), "prebuilds");
+} catch {
+  // node-pty isn't installed/resolvable yet — nothing to fix.
+  process.exit(0);
+}
+
+if (existsSync(prebuilds)) {
+  for (const arch of readdirSync(prebuilds)) {
+    const helper = path.join(prebuilds, arch, "spawn-helper");
+    if (existsSync(helper)) {
+      chmodSync(helper, 0o755);
+      console.log(`Fixed permissions: ${helper}`);
+    }
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -489,7 +489,12 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   // ws is null: the session runs headless until the user opens it (reattach
   // replays the buffered output). The "created" pubsub event in spawnClaudePty
   // surfaces it in the sidebar right away.
-  spawnClaudePty(sessionId, null, null, message);
+  try {
+    spawnClaudePty(sessionId, null, null, message);
+  } catch (err) {
+    console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);
+    return res.json({ message: `Failed to spawn a new session: ${messageOf(err)}` });
+  }
   return res.json({
     message: `Spawned a new terminal session (chatId ${sessionId}). It runs in parallel; the user can open it from the sidebar.`,
     jsonData: { chatId: sessionId },
@@ -896,7 +901,19 @@ wss.on("connection", (ws, req) => {
   ws.send(JSON.stringify({ type: "session", id: sessionId }));
 
   const existing = ptys.get(sessionId);
-  const entry = existing ? reattachPty(existing, ws, sessionId) : spawnClaudePty(sessionId, resume, ws);
+  let entry: PtyEntry;
+  try {
+    entry = existing ? reattachPty(existing, ws, sessionId) : spawnClaudePty(sessionId, resume, ws);
+  } catch (err) {
+    // A failed spawn (claude missing, or node-pty's spawn-helper not executable)
+    // must close just this connection — never crash the whole server.
+    console.error(`[ws] failed to start session ${sessionId}: ${messageOf(err)}`);
+    if (ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify({ type: "error", message: "Failed to start Claude. Is the `claude` CLI installed and on your PATH?" }));
+      ws.close();
+    }
+    return;
+  }
 
   // The session is now in the foreground (being viewed): clear any
   // "waiting for input" flag so it stops showing as bold.


### PR DESCRIPTION
## Summary

Published `npx mulmoterminal` (0.1.1) crashed with `Error: posix_spawnp failed.` on the
first terminal connection (WebSocket → `pty.spawn(claude)`). Root cause + fix:

- `server/fix-pty-perms.js` (postinstall, makes node-pty's `spawn-helper` executable)
  looked for node-pty at `<pkg>/node_modules/node-pty` — only true in this repo. Consumer
  installs (`npx`/`npm i`) **hoist node-pty to the top-level `node_modules`**, so the
  postinstall missed it and the helper stayed `644` → `posix_spawnp failed`. Reproduced
  locally by installing the tarball into a hoisted layout.
- Now resolves node-pty via `createRequire().resolve("node-pty/package.json")` (works
  nested or hoisted) and chmods every `prebuilds/*/spawn-helper` to `755`.
- Hardening: the WebSocket spawn and `spawnBackgroundChat` spawn are wrapped so a failed
  spawn closes just that connection (error frame) instead of crashing the whole server.

## Why CI didn't catch it

`package-smoke` only checks `GET /` (HTTP 200) — it never opens a WebSocket, so the PTY
path was untested. (Follow-up idea: add a WS+PTY check to the smoke job.)

## Verification (local, hoisted install — as requested)

- After fix: `spawn-helper` is `755`; node-pty resolves to `lib/index.js` under tsx.
- Isolated `pty.spawn('claude','--version')` → exit 0.
- **Real WebSocket to `/ws` → `[pty] spawned claude (pid=…)` + output streams (PTY-OK)**, no `posix_spawnp`.
- Forced spawn failure (`CLAUDE_BIN=/nonexistent`) → connection closed, **server still serves `GET / → 200`**.
- `yarn lint` / `typecheck` / `typecheck:server` / `test` (16/16) / `build` / `format:check` ✅.

## User Prompt

- `npx mulmoterminal` 起動後、ターミナル接続で `posix_spawnp failed` クラッシュ。直して。
- ちゃんと local でテストして。

Bumps version to 0.1.2. See `plans/fix-pty-helper-perms.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)