### PR TITLE
Add top toolbar and adopt Material Symbols icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "gui-chat-protocol": "0.3.3",
     "js-yaml": "^4.1.0",
     "marked": "^18.0.5",
+    "material-symbols": "^0.45.1",
     "node-pty": "^1.1.0",
     "puppeteer": "^24.8.1",
     "socket.io": "^4.8.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -134,62 +134,94 @@ function onSession(id: string) {
 </script>
 
 <template>
-  <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
-    <Sidebar
-      v-if="layout === 'vertical'"
-      v-model:filter="filter"
-      :sessions="sessions"
-      :loading="loading"
-      :error="error"
-      :active-id="activeId"
-      @select="selectSession"
-      @new="newSession"
-      @toggle-layout="toggleLayout"
-      @refresh="refresh"
-    />
-    <SessionTabBar
-      v-else
-      v-model:filter="filter"
-      :sessions="sessions"
-      :active-id="activeId"
-      @select="selectSession"
-      @new="newSession"
-      @toggle-layout="toggleLayout"
-      @refresh="refresh"
-    />
-    <div class="main">
-      <TerminalView
-        ref="terminalRef"
-        class="terminal-pane"
-        :style="{ flex: `0 0 ${terminalWidth}px` }"
-        :session-id="activeId"
-        :connect-key="connectKey"
-        @session="onSession"
+  <div class="shell">
+    <header class="toolbar">
+      <span class="toolbar-title">MulmoTerminal</span>
+    </header>
+    <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
+      <Sidebar
+        v-if="layout === 'vertical'"
+        v-model:filter="filter"
+        :sessions="sessions"
+        :loading="loading"
+        :error="error"
+        :active-id="activeId"
+        @select="selectSession"
+        @new="newSession"
+        @toggle-layout="toggleLayout"
+        @refresh="refresh"
       />
-      <div
-        class="splitter"
-        role="separator"
-        tabindex="0"
-        aria-orientation="vertical"
-        aria-label="Resize terminal"
-        :aria-valuenow="terminalWidth"
-        :aria-valuemin="MIN_TERMINAL"
-        :aria-valuemax="maxTerminal"
-        title="Drag (or use arrow keys) to resize the terminal"
-        @mousedown="startDrag"
-        @keydown="onSplitterKey"
+      <SessionTabBar
+        v-else
+        v-model:filter="filter"
+        :sessions="sessions"
+        :active-id="activeId"
+        @select="selectSession"
+        @new="newSession"
+        @toggle-layout="toggleLayout"
+        @refresh="refresh"
       />
-      <GuiPanel :session-id="activeId" :send-text-message="sendTextMessage" :tools-open="showTools" @toggle-tools="toggleTools" />
-      <ToolsPane v-if="showTools" :session-id="activeId" />
+      <div class="main">
+        <TerminalView
+          ref="terminalRef"
+          class="terminal-pane"
+          :style="{ flex: `0 0 ${terminalWidth}px` }"
+          :session-id="activeId"
+          :connect-key="connectKey"
+          @session="onSession"
+        />
+        <div
+          class="splitter"
+          role="separator"
+          tabindex="0"
+          aria-orientation="vertical"
+          aria-label="Resize terminal"
+          :aria-valuenow="terminalWidth"
+          :aria-valuemin="MIN_TERMINAL"
+          :aria-valuemax="maxTerminal"
+          title="Drag (or use arrow keys) to resize the terminal"
+          @mousedown="startDrag"
+          @keydown="onSplitterKey"
+        />
+        <GuiPanel :session-id="activeId" :send-text-message="sendTextMessage" :tools-open="showTools" @toggle-tools="toggleTools" />
+        <ToolsPane v-if="showTools" :session-id="activeId" @close="toggleTools" />
+      </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.app {
+.shell {
   display: flex;
+  flex-direction: column;
   height: 100vh;
   width: 100vw;
+  overflow: hidden;
+}
+
+/* Top toolbar with the app title. */
+.toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 16px;
+  background: #16213e;
+  border-bottom: 1px solid #2a2a4e;
+}
+.toolbar-title {
+  font-family: system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  color: #e6e6f0;
+  letter-spacing: 0.02em;
+}
+
+.app {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
   overflow: hidden;
 }
 

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -110,17 +110,9 @@ const hasContent = computed(() => results.value.length > 0);
 <template>
   <section class="gui-panel">
     <div class="header">
-      <span class="title">GUI</span>
-      <button
-        type="button"
-        class="gear"
-        :class="{ active: toolsOpen }"
-        title="Tools & tool-call history"
-        aria-label="Toggle tools pane"
-        :aria-pressed="toolsOpen ? 'true' : 'false'"
-        @click="emit('toggleTools')"
-      >
-        ⚙
+      <span class="title">Canvas</span>
+      <button v-if="!toolsOpen" type="button" class="gear" title="Tools & tool-call history" aria-label="Open tools pane" @click="emit('toggleTools')">
+        <span class="material-symbols-outlined">build</span>
       </button>
     </div>
     <div class="content">
@@ -178,9 +170,6 @@ const hasContent = computed(() => results.value.length > 0);
 }
 .gear:hover {
   color: #e0e0e0;
-}
-.gear.active {
-  color: #4a8cff;
 }
 
 .content {

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -33,12 +33,16 @@ const visibleSessions = computed(() => {
 
 <template>
   <div class="tabbar">
-    <button class="new-btn" title="New session" aria-label="New session" @click="emit('new')">+</button>
+    <button class="new-btn" title="New session" aria-label="New session" @click="emit('new')">
+      <span class="material-symbols-outlined">add</span>
+    </button>
 
     <div class="filters">
       <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
       <FilterChip label="Unread" :count="unreadCount" :active="filter === 'unread'" @click="emit('update:filter', 'unread')" />
-      <button class="icon-btn sort-btn" title="Sort by most recent" aria-label="Sort by most recent" @click="emit('refresh')">⟳</button>
+      <button class="icon-btn sort-btn" title="Sort by most recent" aria-label="Sort by most recent" @click="emit('refresh')">
+        <span class="material-symbols-outlined">refresh</span>
+      </button>
     </div>
 
     <div class="tabs">
@@ -57,7 +61,9 @@ const visibleSessions = computed(() => {
     </div>
 
     <div class="actions">
-      <button class="icon-btn" title="Switch to vertical sidebar" aria-label="Switch to vertical sidebar" @click="emit('toggle-layout')">⇤</button>
+      <button class="icon-btn" title="Switch to vertical sidebar" aria-label="Switch to vertical sidebar" @click="emit('toggle-layout')">
+        <span class="material-symbols-outlined">dock_to_right</span>
+      </button>
     </div>
   </div>
 </template>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -40,15 +40,19 @@ function relativeTime(ms: number): string {
   <aside class="sidebar">
     <div class="sidebar-header">
       <span class="heading">Sessions</span>
-      <button class="icon-btn" title="Switch to horizontal tabs" aria-label="Switch to horizontal tabs" @click="emit('toggle-layout')">⇥</button>
+      <button class="icon-btn" title="Switch to horizontal tabs" aria-label="Switch to horizontal tabs" @click="emit('toggle-layout')">
+        <span class="material-symbols-outlined">toolbar</span>
+      </button>
     </div>
 
-    <button class="new-btn" @click="emit('new')">+ New session</button>
+    <button class="new-btn" @click="emit('new')"><span class="material-symbols-outlined">add</span> New session</button>
 
     <div class="filters">
       <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
       <FilterChip label="Unread" :count="unreadCount" :active="filter === 'unread'" @click="emit('update:filter', 'unread')" />
-      <button class="icon-btn sort-btn" title="Sort by most recent" aria-label="Sort by most recent" @click="emit('refresh')">⟳</button>
+      <button class="icon-btn sort-btn" title="Sort by most recent" aria-label="Sort by most recent" @click="emit('refresh')">
+        <span class="material-symbols-outlined">refresh</span>
+      </button>
     </div>
 
     <div v-if="loading" class="state">Loading…</div>
@@ -99,7 +103,6 @@ function relativeTime(ms: number): string {
 .heading {
   font-size: 13px;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
   color: #9aa5c4;
 }
@@ -117,6 +120,10 @@ function relativeTime(ms: number): string {
 }
 
 .new-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   margin: 0 12px 8px;
   padding: 8px;
   background: #1b3a6b;
@@ -125,6 +132,9 @@ function relativeTime(ms: number): string {
   border-radius: 6px;
   font-size: 13px;
   cursor: pointer;
+}
+.new-btn .material-symbols-outlined {
+  font-size: 18px;
 }
 .new-btn:hover {
   background: #224a86;

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -142,7 +142,7 @@ onUnmounted(() => {
 <template>
   <div class="terminal-wrapper">
     <div class="header">
-      <span class="title">mulmoterminal</span>
+      <span class="title">Terminal</span>
       <span :class="['status', status]">{{ status }}</span>
     </div>
     <div ref="terminalRef" class="terminal-container" />

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -24,6 +24,7 @@ interface ToolCall {
 }
 
 const props = defineProps<{ sessionId: string | null }>();
+const emit = defineEmits<{ close: [] }>();
 
 const availableTools = ref<AvailableTool[]>([]);
 const toolCalls = ref<ToolCall[]>([]);
@@ -146,6 +147,9 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   <section class="tools-pane">
     <div class="header">
       <span class="title">Tools</span>
+      <button type="button" class="close-btn" title="Close tools pane" aria-label="Close tools pane" @click="emit('close')">
+        <span class="material-symbols-outlined">close</span>
+      </button>
     </div>
     <div class="content">
       <!-- Available tools -->
@@ -155,7 +159,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
         <div v-for="tool in availableTools" :key="tool.toolName" class="tool">
           <button class="tool-head" type="button" @click="toggleTool(tool.toolName)">
             <code class="tool-name">{{ tool.toolName }}</code>
-            <span v-if="tool.description" class="caret">{{ expandedTools.has(tool.toolName) ? "▲" : "▼" }}</span>
+            <span v-if="tool.description" class="caret material-symbols-outlined">{{ expandedTools.has(tool.toolName) ? "expand_less" : "expand_more" }}</span>
           </button>
           <div v-if="expandedTools.has(tool.toolName)" class="tool-desc">
             {{ tool.description }}
@@ -175,7 +179,8 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
             :aria-label="historyCopied ? 'Copied!' : 'Copy all call history'"
             @click="copyHistory"
           >
-            {{ historyCopied ? "✓ Copied" : "Copy all" }}
+            <span class="material-symbols-outlined">{{ historyCopied ? "check" : "content_copy" }}</span>
+            {{ historyCopied ? "Copied" : "Copy all" }}
           </button>
         </div>
         <div v-if="toolCalls.length === 0" class="muted">No tool calls yet.</div>
@@ -223,9 +228,25 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   color: #e0e0e0;
   font-family: system-ui, sans-serif;
   font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 .title {
   font-weight: 600;
+}
+.close-btn {
+  background: none;
+  border: none;
+  color: #7c87a8;
+  font-size: 15px;
+  line-height: 1;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.close-btn:hover {
+  color: #e0e0e0;
 }
 
 .content {
@@ -255,6 +276,9 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   gap: 8px;
 }
 .copy-history {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 10px;
   font-weight: 600;
   text-transform: none;
@@ -265,6 +289,9 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   border-radius: 4px;
   padding: 2px 8px;
   cursor: pointer;
+}
+.copy-history .material-symbols-outlined {
+  font-size: 14px;
   transition:
     color 0.15s,
     background 0.15s;
@@ -316,7 +343,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
 }
 .caret {
   color: #7c87a8;
-  font-size: 10px;
+  font-size: 18px;
 }
 .tool-desc {
   color: #9aa5c4;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from "vue";
+import "material-symbols/outlined.css";
 import "./style.css";
 import App from "./App.vue";
 

--- a/src/style.css
+++ b/src/style.css
@@ -8,3 +8,18 @@ body {
   background: #1a1a2e;
   overflow: hidden;
 }
+
+/* Project-wide icon convention: Material Symbols (outlined). Icons inherit the
+   surrounding text size by default; set font-size on the element to scale, and
+   the optical-size axis (opsz) follows so weight stays balanced. */
+.material-symbols-outlined {
+  font-size: inherit;
+  line-height: 1;
+  vertical-align: middle;
+  user-select: none;
+  font-variation-settings:
+    "FILL" 0,
+    "wght" 400,
+    "GRAD" 0,
+    "opsz" 20;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2452,14 +2452,9 @@ glob@^10.4.2:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
-globals@^17.4.0:
+globals@^17.4.0, globals@^17.6.0:
   version "17.6.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-17.6.0.tgz#0f0be018d5cca8690e6375ead1f65c4bb96191fc"
-  integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
-
-globals@^17.6.0:
-  version "17.6.0"
-  resolved "https://npm.flatt.tech/globals/-/globals-17.6.0.tgz#0f0be018d5cca8690e6375ead1f65c4bb96191fc"
   integrity sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==
 
 google-auth-library@^10.3.0:
@@ -2948,6 +2943,11 @@ marked@^18.0.5:
   version "18.0.5"
   resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.5.tgz#c229c0ac6ad1e275ae8e5037c6168f76d2f42e61"
   integrity sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==
+
+material-symbols@^0.45.1:
+  version "0.45.1"
+  resolved "https://registry.yarnpkg.com/material-symbols/-/material-symbols-0.45.1.tgz#1d763e8d47cbc126435a52017d6a7a8a763fd1bd"
+  integrity sha512-iQibeoKymxHthNqTjYg/jCN2pRySFQ+DAD0sYK9FS7rUpf38i1qR3N4I1jfi/bLS5qdEKvkkJAvf2mE89amSZw==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary
- Adds a top toolbar with the **MulmoTerminal** title spanning above both the vertical (Sidebar) and horizontal (SessionTabBar) layouts.
- Establishes **Material Symbols (outlined)** as the project-wide icon convention, self-hosted via the `material-symbols` npm package (no Google CDN, so it works offline). Imported once in `src/main.ts`; a global base rule in `src/style.css` makes icons inherit text size and align to the baseline.
- Replaces the ad-hoc unicode glyphs (`⟳ ⇤ ⇥ + ⚙ ▲▼ ✓`) with named icons across `Sidebar`, `SessionTabBar`, `GuiPanel`, and `ToolsPane`.

## Label / naming tweaks
- Terminal pane header: `mulmoterminal` → **Terminal**
- GUI panel header: `GUI` → **Canvas**
- Sidebar heading no longer force-uppercased → **Sessions**

## Tools pane toggle
- The toggle now uses the `build` icon.
- While the tools pane is **open**, the toggle is hidden and a **close (✕)** button on the ToolsPane's own header collapses it (`@close` → `toggleTools`).

## Icon mapping
| Action | Icon |
|---|---|
| Refresh / sort | `refresh` |
| New session | `add` |
| Switch to tabs | `toolbar` |
| Switch to sidebar | `dock_to_right` |
| Toggle tools pane | `build` |
| Close tools pane | `close` |
| Expand/collapse | `expand_less` / `expand_more` |
| Copy history | `content_copy` / `check` |

## Notes
- The `material-symbols` package ships the full variable font (~3.9MB woff2, bundled into `dist`). Acceptable for a localhost tool (cached after first load); can be subset later if bundle size matters.
- `yarn.lock` also dedups a stray duplicate `globals` entry (re-resolved during install).

## Test plan
- `yarn typecheck` ✅
- `yarn lint` ✅
- `yarn build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)