### PR TITLE
feat: --cwd flag (relative paths; default current dir) (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ npm install -g mulmoterminal
 mulmoterminal
 ```
 
-Options: `--port <n>` (default 3456), `--no-open`, `--version`, `--help`.
+Options: `--cwd <dir>` (working directory — relative paths allowed; defaults to the
+directory you run the command from), `--port <n>` (default 3456), `--no-open`,
+`--version`, `--help`.
+
+```bash
+npx mulmoterminal --cwd ./my-project   # work in a specific directory
+```
 
 The published package ships the server (run via `tsx`) plus the pre-built web UI;
 `npx mulmoterminal` checks for the `claude` CLI, picks a free port, starts the
@@ -118,7 +124,7 @@ the server runs without one.
 | ------------ | -------------- | ----------- |
 | `PORT`       | `3456`         | HTTP/WebSocket port. |
 | `CLAUDE_BIN` | `claude`       | The Claude Code binary to spawn. |
-| `CLAUDE_CWD` | `$HOME`        | Working directory each `claude` PTY runs in. Determines which project's sessions the sidebar lists. **Must be an absolute path** — `~` is not expanded for values read from `.env`. |
+| `CLAUDE_CWD` | current dir    | Working directory each `claude` PTY runs in; determines which project's sessions the sidebar lists. Via `npx mulmoterminal` it defaults to the directory you ran the command from (override with `--cwd <dir>`, relative allowed); when the server is run directly it falls back to `~/mulmoclaude`. A value read from `.env` must be an absolute path (`~` is not expanded). |
 
 Example `.env` (gitignored):
 

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -6,11 +6,11 @@
 // runs the server via tsx. Mirrors the mulmoclaude launcher.
 
 import { execSync, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { get as httpGet } from "node:http";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -129,6 +129,29 @@ function parsePortArg(args) {
   return { requestedPort: parsed, portExplicit: true };
 }
 
+// Resolve the workspace directory claude runs in (and whose sessions the sidebar
+// lists). Precedence: --cwd (relative paths allowed) > CLAUDE_CWD env > the
+// directory npx was run from. Always returned absolute. An explicit --cwd that
+// isn't an existing directory is a hard error (catches typos before launch).
+function resolveCwd(args) {
+  const idx = args.indexOf("--cwd");
+  let flagValue;
+  if (idx !== -1) {
+    flagValue = args[idx + 1];
+    if (flagValue === undefined || flagValue.startsWith("-")) {
+      error("--cwd requires a directory path");
+      process.exit(1);
+    }
+  }
+  const chosen = flagValue ?? process.env.CLAUDE_CWD ?? ".";
+  const abs = resolve(process.cwd(), chosen);
+  if (idx !== -1 && (!existsSync(abs) || !statSync(abs).isDirectory())) {
+    error(`--cwd is not a directory: ${abs}`);
+    process.exit(1);
+  }
+  return abs;
+}
+
 async function choosePort(requested, explicit) {
   if (await isPortFree(requested)) return requested;
   if (explicit) {
@@ -149,12 +172,12 @@ async function choosePort(requested, explicit) {
 // the port was taken at bind time before it became ready — the caller then
 // retries on a fresh port. In every other case (clean shutdown, fatal error,
 // or the server simply running) the process exits with the server's code.
-function runServer(port, noOpen, onChild) {
-  return new Promise((resolve) => {
+function runServer(port, noOpen, cwd, onChild) {
+  return new Promise((resolveExit) => {
     log(`Starting MulmoTerminal on port ${port}...`);
     const server = spawn(process.execPath, ["--import", "tsx", SERVER_ENTRY], {
       cwd: PKG_DIR,
-      env: { ...process.env, NODE_ENV: "production", PORT: String(port) },
+      env: { ...process.env, NODE_ENV: "production", PORT: String(port), CLAUDE_CWD: cwd },
       stdio: "inherit",
     });
     onChild(server);
@@ -178,7 +201,7 @@ function runServer(port, noOpen, onChild) {
       // served — always retriable, regardless of what a probe to the port saw
       // (another process could have answered it). Other exits are terminal.
       if (code === PORT_IN_USE_EXIT_CODE) {
-        resolve();
+        resolveExit();
         return;
       }
       process.exit(code ?? 1);
@@ -194,6 +217,7 @@ async function main() {
 Usage: npx mulmoterminal [options]
 
 Options:
+  --cwd <dir>       Working directory claude runs in (default: current directory; relative paths allowed)
   --port <number>   Server port (default: ${DEFAULT_PORT}; a free port is chosen if it's busy)
   --no-open         Don't open the browser automatically
   --version         Show version
@@ -220,6 +244,8 @@ Options:
 
   const { requestedPort, portExplicit } = parsePortArg(args);
   const noOpen = args.includes("--no-open");
+  const cwd = resolveCwd(args);
+  log(`Workspace: ${cwd}`);
 
   // Registered once; always targets the live child across bind-retries.
   let child = null;
@@ -235,7 +261,7 @@ Options:
   // second-guessed. `runServer` only returns when the port was raced.
   let port = await choosePort(requestedPort, portExplicit);
   for (let attempt = 0; attempt <= MAX_BIND_RETRIES; attempt++) {
-    await runServer(port, noOpen, (c) => {
+    await runServer(port, noOpen, cwd, (c) => {
       child = c;
     });
     if (portExplicit) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",

--- a/plans/feat-cwd-flag.md
+++ b/plans/feat-cwd-flag.md
@@ -1,0 +1,32 @@
+# feat: --cwd flag (relative paths, default = current directory) (#36)
+
+## ゴール
+
+`npx mulmoterminal` で作業ディレクトリを指定できるようにする。
+
+## 変更（bin/mulmoterminal.js のみ）
+
+- `--cwd <dir>` フラグを追加。`resolveCwd(args)` が作業ディレクトリを解決:
+  - 優先順位: **`--cwd`（相対パス可）> `CLAUDE_CWD` env > 実行時の現在ディレクトリ**。
+  - すべて `path.resolve(process.cwd(), …)` で絶対パス化（相対 `--cwd ./x` 対応）。
+  - 明示 `--cwd` が存在しないディレクトリならエラー終了（タイポ検出）。
+- 解決した値を `CLAUDE_CWD` 環境変数として server spawn に渡す（server 側は変更なし。
+  直接起動時のフォールバックは従来どおり `~/mulmoclaude`）。
+- 起動時に `Workspace: <abs>` を表示。`--help` に `--cwd` を追記。
+
+## 挙動変更
+
+`npx mulmoterminal` のデフォルト cwd が `~/mulmoclaude` → **実行したディレクトリ**になる
+（`CLAUDE_CWD` env を設定していればそれを優先）。
+
+## 検証（ローカル実機・/api/sessions の cwd で確認）
+
+- `--cwd /abs` → `/abs`。
+- `--cwd` なしで dir X から実行 → `X`（process.cwd()）。
+- 相対 `--cwd proj`（/tmp/foo から）→ `/tmp/foo/proj`。
+- `--cwd /nonexistent` → `--cwd is not a directory` でエラー終了。
+- `--help` に `--cwd` 表示、`lint`/`format:check`/`typecheck`/`test`/`build` 緑。
+
+## 備考
+
+マージ後 0.1.3 として publish 予定。


### PR DESCRIPTION
## Summary

Lets you pick the working directory for `npx mulmoterminal`:

```bash
npx mulmoterminal --cwd ./my-project   # relative ok
npx mulmoterminal                      # uses the directory you ran it from
```

`--cwd` sets the directory claude runs in (and whose sessions the sidebar lists).

## Behavior

- Precedence: **`--cwd` (relative paths resolved against the invocation dir) > `CLAUDE_CWD` env > the current directory** — all resolved to absolute.
- An explicit `--cwd` that isn't an existing directory is a hard error (catches typos).
- The launcher passes the resolved path as `CLAUDE_CWD` to the server; the server's
  direct-run fallback is unchanged (`~/mulmoclaude`). Logs `Workspace: <abs>` on start.

**Behavior change:** the default workspace via `npx` is now the directory you run it
from (previously `~/mulmoclaude`). Setting `CLAUDE_CWD` still takes precedence over the
default.

## Verification (local, via `/api/sessions` `cwd`)

- `--cwd /abs` → `/abs`.
- no `--cwd`, run from `X` → `X` (current dir).
- relative `--cwd proj` from `/tmp/foo` → `/tmp/foo/proj`.
- `--cwd /nonexistent` → `--cwd is not a directory` + exit 1.
- `--help` lists `--cwd`; `lint` / `format:check` / `typecheck:server` / `test` (16/16) / `build` ✅.

## User Prompt

- `npx mulmoterminal` で cwd を指定したい（特定の dir で作業したい）。
- `--cwd` フラグで、相対パス対応、パスなければ現在の dir を cwd に。

Bumps to 0.1.3. See `plans/feat-cwd-flag.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)