### PR TITLE
feat: startup update notice + unit-tested version check (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ npm install -g mulmoterminal
 mulmoterminal
 ```
 
+A global install isn't auto-updated, so on startup MulmoTerminal checks npm and
+prints a one-line notice when a newer version is available (`npm i -g mulmoterminal`
+to update). Disable with `MULMOTERMINAL_NO_UPDATE_CHECK=1` (or `NO_UPDATE_NOTIFIER=1`).
+
 Options: `--cwd <dir>` (working directory — relative paths allowed; defaults to the
 directory you run the command from), `--port <n>` (default 3456), `--no-open`,
 `--version`, `--help`.

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -12,6 +12,7 @@ import { createRequire } from "node:module";
 import { createServer } from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { fetchLatestVersion, isNewerVersion } from "./update-check.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = join(__dirname, "..");
@@ -29,6 +30,21 @@ const { version: VERSION } = createRequire(import.meta.url)("../package.json");
 
 const log = (msg) => console.log(`\x1b[36m[mulmoterminal]\x1b[0m ${msg}`);
 const error = (msg) => console.error(`\x1b[31m[mulmoterminal]\x1b[0m ${msg}`);
+
+// Non-blocking notice when a newer version is published — `npm i -g` never
+// auto-updates. Opt out via MULMOTERMINAL_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
+function checkForUpdate() {
+  if (process.env.MULMOTERMINAL_NO_UPDATE_CHECK || process.env.NO_UPDATE_NOTIFIER) return;
+  fetchLatestVersion()
+    .then((latest) => {
+      if (latest && isNewerVersion(latest, VERSION)) {
+        log(`\x1b[33mUpdate available: ${VERSION} → ${latest}  ·  run: npm i -g mulmoterminal\x1b[0m`);
+      }
+    })
+    .catch(() => {
+      // best-effort; never disrupt startup
+    });
+}
 
 function claudeInstalled() {
   try {
@@ -229,6 +245,8 @@ Options:
     console.log(`mulmoterminal ${VERSION}`);
     return;
   }
+
+  checkForUpdate();
 
   if (!claudeInstalled()) {
     error("Claude Code CLI not found.");

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -1,0 +1,37 @@
+// Update-check helpers for the launcher, split out so the version comparison is
+// unit-testable. Network calls are best-effort and never throw.
+
+const REGISTRY = (process.env.npm_config_registry || "https://registry.npmjs.org").replace(/\/$/, "");
+
+// Best-effort latest-version lookup. Resolves null on any failure (offline,
+// timeout, non-OK, bad payload) so callers never block or break startup.
+export async function fetchLatestVersion(pkg = "mulmoterminal") {
+  try {
+    const res = await fetch(`${REGISTRY}/${pkg}/latest`, {
+      signal: AbortSignal.timeout(1500),
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const body = await res.json();
+    return typeof body.version === "string" ? body.version : null;
+  } catch {
+    return null;
+  }
+}
+
+// True if `latest` is a strictly newer major.minor.patch than `current`.
+// Pre-release suffixes are ignored and parts are compared numerically (so
+// 0.1.10 > 0.1.9, which a lexical compare would get wrong).
+export function isNewerVersion(latest, current) {
+  const parts = (v) =>
+    String(v)
+      .split("-")[0]
+      .split(".")
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const a = parts(latest);
+  const b = parts(current);
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] ?? 0) !== (b[i] ?? 0)) return (a[i] ?? 0) > (b[i] ?? 0);
+  }
+  return false;
+}

--- a/bin/update-check.spec.ts
+++ b/bin/update-check.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isNewerVersion, fetchLatestVersion } from "./update-check.js";
+
+describe("isNewerVersion", () => {
+  const cases: [string, string, boolean][] = [
+    ["0.1.3", "0.1.0", true],
+    ["0.2.0", "0.1.9", true],
+    ["1.0.0", "0.9.9", true],
+    ["0.1.10", "0.1.9", true], // numeric, not lexical (the bug a string compare hits)
+    ["0.1.3", "0.1.3", false],
+    ["0.1.0", "0.1.3", false],
+    ["0.9.9", "1.0.0", false],
+    ["0.1.4-beta.1", "0.1.3", true], // pre-release suffix ignored on the core
+    ["0.1.3", "0.1.3-beta.1", false], // equal core → not newer
+  ];
+  it.each(cases)("isNewerVersion(%s, %s) === %s", (latest, current, expected) => {
+    expect(isNewerVersion(latest, current)).toBe(expected);
+  });
+});
+
+describe("fetchLatestVersion", () => {
+  const stubFetch = (impl: () => Promise<unknown>) => vi.stubGlobal("fetch", vi.fn(impl));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns the version from a 200 response", async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ version: "1.2.3" }) }));
+    expect(await fetchLatestVersion()).toBe("1.2.3");
+  });
+
+  it("returns null on a non-OK response", async () => {
+    stubFetch(async () => ({ ok: false, json: async () => ({}) }));
+    expect(await fetchLatestVersion()).toBeNull();
+  });
+
+  it("returns null when fetch rejects (offline / timeout)", async () => {
+    stubFetch(async () => {
+      throw new Error("offline");
+    });
+    expect(await fetchLatestVersion()).toBeNull();
+  });
+
+  it("returns null when the payload has no version string", async () => {
+    stubFetch(async () => ({ ok: true, json: async () => ({ name: "mulmoterminal" }) }));
+    expect(await fetchLatestVersion()).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",

--- a/plans/feat-update-notice.md
+++ b/plans/feat-update-notice.md
@@ -1,0 +1,35 @@
+# feat: startup update notice + unit test (#38)
+
+## ゴール
+
+`npm i -g mulmoterminal` は自動更新されないので、起動時に npm 最新版と比較して
+更新案内を出す。ロジックは unit test して CI で回す。
+
+## 変更
+
+- **`bin/update-check.js`**（新規・テスト可能に分離）:
+  - `fetchLatestVersion(pkg?)` — `${registry}/<pkg>/latest` を取得。1.5s タイムアウト、
+    失敗（オフライン/非OK/パース不可）は `null`。`npm_config_registry` を尊重。
+  - `isNewerVersion(latest, current)` — major.minor.patch を**数値比較**（pre-release は無視）。
+    0.1.10 > 0.1.9 を正しく判定（文字列比較のバグを回避）。
+- **`bin/mulmoterminal.js`**: 上記を import。`checkForUpdate()` を起動時（`--version`/`--help`
+  以外）に**非ブロッキング**で呼び、新しければ黄色で1行案内。
+  `MULMOTERMINAL_NO_UPDATE_CHECK` / `NO_UPDATE_NOTIFIER` でオプトアウト。
+- **`bin/update-check.spec.ts`**（新規 unit test, vitest）:
+  - `isNewerVersion` 9ケース（新しい/同じ/古い/数値比較/pre-release）。
+  - `fetchLatestVersion` 4ケース（200→version / 非OK→null / reject→null / version無→null、`fetch` を vi.stubGlobal）。
+- README に更新チェックの記載＋オプトアウト。
+
+## CI
+
+`lint-and-build` の既存 `yarn test`（vitest）が `bin/**.spec.ts` を自動で拾う（vitest デフォルト include）。
+専用ステップ追加は不要。
+
+## 検証
+
+- `yarn test` 16 → **29 件**（新規13）緑 / `lint` / `format:check` / `build` 緑。
+- 実機: 古い version を擬似 → `Update available: 0.0.1 → 0.1.3 …` 表示。最新時は無音。起動はブロックしない。
+
+## 備考
+
+マージ後 0.1.4 として publish 予定。


### PR DESCRIPTION
## Summary

`npm i -g mulmoterminal` never auto-updates, so the launcher now checks npm on startup and prints a one-line notice when a newer version is published:

```
[mulmoterminal] Update available: 0.1.3 → 0.1.4  ·  run: npm i -g mulmoterminal
```

- **`bin/update-check.js`** (split out to be unit-testable):
  - `fetchLatestVersion()` — GETs `<registry>/mulmoterminal/latest`, 1.5s timeout, returns `null` on any failure (offline / non-OK / bad payload). Respects `npm_config_registry`.
  - `isNewerVersion(latest, current)` — numeric `major.minor.patch` compare (so `0.1.10 > 0.1.9`, which a string compare gets wrong); pre-release suffixes ignored.
- **`bin/mulmoterminal.js`** — non-blocking `checkForUpdate()` at startup (not on `--version`/`--help`). Opt out via `MULMOTERMINAL_NO_UPDATE_CHECK` / `NO_UPDATE_NOTIFIER`.
- **`bin/update-check.spec.ts`** — unit tests: 9 `isNewerVersion` cases (newer/equal/older, numeric-vs-lexical, pre-release) + 4 `fetchLatestVersion` cases (200→version, non-OK→null, reject→null, no-version→null) with a stubbed `fetch`.

## CI

The existing `Test` step (`yarn test`, vitest) auto-discovers `bin/**/*.spec.ts` — no workflow change needed. **16 → 29 tests.**

## Verification

- `yarn test` 29/29 · `yarn lint` · `yarn format:check` · `yarn build` ✅.
- Manual: a faked-old version prints `Update available: 0.0.1 → 0.1.3`; up-to-date is silent; startup is never blocked (1.5s timeout, errors swallowed).

## User Prompt

- `npm i -g` だとバージョンアップされないので、起動時に自身と npm のバージョンを比較して update 案内を出したい。
- unit test を追加して CI で回したい。

Bumps to 0.1.4. See `plans/feat-update-notice.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)