### PR TITLE
refactor: centralize GUI stores under ~/.mulmoterminal (#41)

### DIFF
--- a/plans/refactor-global-gui-stores.md
+++ b/plans/refactor-global-gui-stores.md
@@ -1,0 +1,30 @@
+# refactor: centralize GUI stores under ~/.mulmoterminal (#41)
+
+Prerequisite for the "open any directory" feature.
+
+## Change
+
+- `createSessionStore` now roots at `~/.mulmoterminal/<name>` (new `MULMOTERMINAL_HOME`)
+  instead of `<CLAUDE_CWD>/<name>`.
+- `.toolresults`/`.toolcalls` → `~/.mulmoterminal/toolresults` / `~/.mulmoterminal/toolcalls`
+  (sessionId-keyed; sessionIds are global UUIDs, so no per-dir namespacing is needed).
+- `artifacts/` (markdown/charts generated content) intentionally stays under the
+  workspace dir — claude references it relative to its cwd; it follows the active
+  directory and is handled in the dir-switch step.
+- claude's own session transcripts (`~/.claude/projects/...`) are unchanged.
+
+## Why
+
+The stores were pinned to the startup `CLAUDE_CWD`, blocking runtime directory
+switching. Keyed by sessionId, they don't need to be per-dir.
+
+## Notes
+
+- No migration of existing `<CLAUDE_CWD>/.toolresults|.toolcalls` (old sessions lose
+  GUI-replay / tool-pane history; terminal + claude .jsonl unaffected). 0.1.x.
+- Behavior otherwise unchanged. No version bump — bundled with the dir-switch feature.
+
+## Verified
+
+- `lint` / `typecheck:server` / `test` (29) / `build` green.
+- Posting a PreToolUse hook + a toolResult writes to `~/.mulmoterminal/{toolcalls,toolresults}/<id>.json`, not under `CLAUDE_CWD`.

--- a/server/index.ts
+++ b/server/index.ts
@@ -96,6 +96,11 @@ const CLAUDE_CWD = process.env.CLAUDE_CWD || path.join(os.homedir(), "mulmoclaud
 // session state, so it must exist before we spawn anything into it.
 await fs.mkdir(CLAUDE_CWD, { recursive: true });
 
+// MulmoTerminal's own per-session GUI state (tool-result render data + tool-call
+// history) lives here, keyed by sessionId (a global UUID) — NOT under the
+// workspace dir, so it stays valid regardless of which directory is active.
+const MULMOTERMINAL_HOME = path.join(os.homedir(), ".mulmoterminal");
+
 // A session id is always a UUID (server-generated, or a .jsonl basename). Reject
 // anything else so a client can't smuggle CLI flags (e.g. "--resume" followed by
 // a value that claude re-parses as a flag) into the spawned process.
@@ -139,7 +144,7 @@ const GUI_MCP_TOOLS = allowedToolNames().join(",");
 // rewritten on each change and lazy-loaded on first access. Session ids are
 // validated UUIDs (SESSION_ID_RE), so they're safe to use as filenames.
 function createSessionStore<T>(dirName: string) {
-  const dir = path.join(CLAUDE_CWD, dirName);
+  const dir = path.join(MULMOTERMINAL_HOME, dirName);
   const fileFor = (id: string) => path.join(dir, `${id}.json`);
   const map = new Map<string, T[]>(); // id -> list (the working copy; mutate in place)
   const loading = new Map<string, Promise<T[]>>(); // id -> Promise<list>, dedupes concurrent loads
@@ -182,11 +187,11 @@ function createSessionStore<T>(dirName: string) {
   return { get, save };
 }
 
-// GUI toolResults per session, persisted under <workspace>/.toolresults so the
-// panel replays the rendered views even after a server reboot. (Chat + message
-// history live in the terminal and Claude's .jsonl; this is the GUI-side store.)
-// Each entry is an array of toolResults, capped to the most recent N.
-const toolResultsStore = createSessionStore<ToolResult>(".toolresults");
+// GUI toolResults per session, persisted under ~/.mulmoterminal/toolresults so
+// the panel replays the rendered views even after a server reboot. (Chat +
+// message history live in the terminal and Claude's .jsonl; this is the GUI-side
+// store.) Each entry is an array of toolResults, capped to the most recent N.
+const toolResultsStore = createSessionStore<ToolResult>("toolresults");
 const GUI_HISTORY_LIMIT = 50;
 
 // Upsert a toolResult into a session's list, deduped by uuid — a re-emitted result
@@ -210,9 +215,9 @@ async function storeToolResult(sessionId: string, result: ToolResult) {
 // per-session channel the tools pane subscribes to. (The broker's toolResults
 // store above is separate; it only drives rendering of GUI views.)
 //
-// Persisted under <workspace>/.toolcalls via the same disk-backed store as the
-// toolResults, so the history survives a server reboot.
-const toolCallsStore = createSessionStore<ToolCall>(".toolcalls");
+// Persisted under ~/.mulmoterminal/toolcalls via the same disk-backed store as
+// the toolResults, so the history survives a server reboot.
+const toolCallsStore = createSessionStore<ToolCall>("toolcalls");
 const TOOLCALLS_LIMIT = 200;
 const toolCallsChannel = (id: string) => `toolcalls:${id}`;
 // Stored tool outputs are capped so one verbose tool can't bloat the on-disk
@@ -638,7 +643,7 @@ app.post("/api/agent/toolResult", async (req, res) => {
 });
 
 // Replay a session's stored toolResults so the panel can render them when the
-// user (re)selects that session. Loads from disk (<workspace>/.toolresults) on
+// user (re)selects that session. Loads from disk (~/.mulmoterminal/toolresults) on
 // first access so the views survive a reboot.
 app.get("/api/agent/toolResults/:sessionId", async (req, res) => {
   const { sessionId } = req.params;
@@ -657,7 +662,7 @@ app.get("/api/tools", (_req, res) => {
 
 // Replay a session's tool-call history (every tool, via the Pre/PostToolUse hooks)
 // so the tools pane can render it when the user (re)selects that session. Loads
-// from disk (<workspace>/.toolcalls) on first access so it survives a reboot.
+// from disk (~/.mulmoterminal/toolcalls) on first access so it survives a reboot.
 app.get("/api/tool-calls/:sessionId", async (req, res) => {
   const { sessionId } = req.params;
   if (!SESSION_ID_RE.test(sessionId)) {


### PR DESCRIPTION
## Summary

Prerequisite for the upcoming "open any directory" feature. MulmoTerminal's
per-session GUI stores were created at startup **under `CLAUDE_CWD`**, pinning them
to one directory. They're keyed by **sessionId (a global UUID)**, so they don't need
per-directory namespacing — move them to a single global location.

- `.toolresults` / `.toolcalls` → **`~/.mulmoterminal/toolresults` / `~/.mulmoterminal/toolcalls`** (via a new `MULMOTERMINAL_HOME`).
- `artifacts/` (markdown/chart generated content) **stays under the workspace dir** on purpose — claude references it relative to its cwd, so it should follow the active directory (handled in the dir-switch step).
- claude's own session transcripts (`~/.claude/projects/...`) are unchanged.

## Items to Confirm / Review

- **No migration** of existing `<CLAUDE_CWD>/.toolresults|.toolcalls` — pre-existing sessions lose their GUI-panel replay data + Tools-pane history (the terminal + claude `.jsonl` transcript are unaffected). Acceptable at 0.1.x; flag if you want a one-time migration.
- **No version bump** — this is an internal relocation with no user-facing change on its own; I'll bump + publish together with the directory-switch feature.

## Verification

- `yarn lint` / `typecheck:server` / `test` (29/29) / `build` ✅.
- Posting a `PreToolUse` hook + a `toolResult` writes to `~/.mulmoterminal/{toolcalls,toolresults}/<id>.json` and **not** under `CLAUDE_CWD`.

## User Prompt

- 任意 dir を開いてセッションを見たい（設定画面で dir 指定／一覧は従来UI／現在 dir 表示）。その前提として GUI ストアを `~/.mulmoterminal/` に中央集約。

See `plans/refactor-global-gui-stores.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)