### PR TITLE
feat: honor user/project Claude Code config — drop --strict-mcp-config (#44)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",

--- a/plans/feat-honor-claude-config.md
+++ b/plans/feat-honor-claude-config.md
@@ -1,0 +1,33 @@
+# feat: honor user/project Claude Code config (drop --strict-mcp-config) (#44)
+
+## Direction
+
+"mulmo GUI layer (presentDocument/presentForm/generateImage/…) + a real Claude
+Code dev terminal." Reflect the user's `~/.claude/` config and the launched dir's
+`<dir>/.claude` / `<dir>/.mcp.json`.
+
+## Change
+
+- Remove `--strict-mcp-config` from the spawn args. `--mcp-config` is additive, so:
+  - the **GUI MCP (`mulmoterminal-gui`) stays**, AND
+  - claude also loads the user MCP (`~/.claude.json`) + project MCP (`<cwd>/.mcp.json`).
+- `--permission-mode auto` kept (per decision); `CLAUDE_PERMISSION_MODE` still overrides.
+- Skills already honored (`~/.claude/skills` + `<cwd>/.claude/skills`, cwd-scoped) — no change.
+
+## Verify in a real environment
+
+- `--settings` (our hooks) merges with `~/.claude/settings.json` / `<dir>/.claude/settings.json`
+  (the user's hooks/permissions/env also apply).
+- project `.mcp.json` trust-prompt works in the interactive terminal; GUI + user/project MCP coexist.
+
+## Note
+
+- MCP servers in `~/mulmoclaude/config/mcp.json` are NOT picked up (that's a MulmoClaude
+  path). Move them to `~/.claude.json` (user) or `<dir>/.mcp.json` (project).
+
+## Verified (automated)
+
+- spawn no longer passes `--strict-mcp-config`; a session still spawns + streams (WS smoke).
+- `lint` / `typecheck:server` / `test` (29) / `build` green. GUI tools still registered (`/api/tools`).
+
+Bumps to 0.1.5 (also ships #42's GUI-store relocation, previously unpublished).

--- a/server/index.ts
+++ b/server/index.ts
@@ -791,11 +791,14 @@ function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntr
 // so the session starts working immediately, before anyone opens it.
 function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, initialPrompt?: string): PtyEntry {
   const settings = hookSettingsJson();
-  // Register the GUI MCP broker and auto-allow its tools so the plugin tools run
-  // without a permission prompt (--strict-mcp-config keeps the user's other MCP
-  // servers out of the spike).
+  // Register the GUI MCP server and auto-allow its tools so the plugin tools run
+  // without a permission prompt. We deliberately do NOT pass --strict-mcp-config:
+  // --mcp-config is additive, so the user's (~/.claude.json) and the project's
+  // (<cwd>/.mcp.json) MCP servers load alongside the GUI MCP — MulmoTerminal is a
+  // real Claude Code dev terminal, not just the GUI layer. (skills are already
+  // honored: claude reads ~/.claude/skills + <cwd>/.claude/skills by cwd.)
   const mcp = mcpConfigJson(sessionId);
-  const guiArgs = ["--permission-mode", CLAUDE_PERMISSION_MODE, "--mcp-config", mcp, "--strict-mcp-config", "--allowedTools", GUI_MCP_TOOLS];
+  const guiArgs = ["--permission-mode", CLAUDE_PERMISSION_MODE, "--mcp-config", mcp, "--allowedTools", GUI_MCP_TOOLS];
   const baseArgs = resume ? ["--resume", resume, "--settings", settings, ...guiArgs] : ["--session-id", sessionId, "--settings", settings, ...guiArgs];
   // The initial prompt goes last as a positional arg (claude's initial-prompt
   // form). "--" ends option parsing so a prompt that happens to start with "-"


### PR DESCRIPTION
## Summary

Make MulmoTerminal a **real Claude Code dev terminal**, not just the GUI layer.
Removing `--strict-mcp-config` from the spawn lets claude load the user's
(`~/.claude.json`) and the project's (`<cwd>/.mcp.json`) MCP servers **alongside**
the GUI MCP — `--mcp-config` is additive, so `presentDocument` / `presentForm` /
`generateImage` / `presentChart` keep working.

- Skills were **already** honored (`~/.claude/skills` + `<cwd>/.claude/skills`,
  resolved by claude relative to `cwd`) — no change there.
- `--permission-mode auto` is kept (per decision); `CLAUDE_PERMISSION_MODE` still overrides.

## Items to Confirm / Review

- **`--settings` merge** — we inject hooks via `--settings`. Please confirm in a real
  setup that this **merges** with `~/.claude/settings.json` / `<dir>/.claude/settings.json`
  (so the user's own hooks/permissions/env also apply) rather than replacing them.
- **Project `.mcp.json` trust prompt** + **GUI MCP coexistence** — a project MCP triggers
  claude's "trust this server?" prompt, handled in the interactive terminal; verify the GUI
  MCP and user/project MCP coexist on your CLI version.
- **Heads-up:** MCP servers currently in `~/mulmoclaude/config/mcp.json` are **not** picked
  up — that's a MulmoClaude-only path. Move them to `~/.claude.json` (user) or
  `<dir>/.mcp.json` (project) for Claude Code to load them. (See `docs/spawn-architecture.md`.)

## Verification (automated)

- The spawn no longer passes `--strict-mcp-config`; a session still spawns and streams
  (WS PTY smoke). GUI tools still registered (`/api/tools`).
- `yarn lint` / `typecheck:server` / `test` (29/29) / `build` ✅.

## User Prompt

- 方向性: presentDocument/presentForm/generateImage の仕組みは使いたい／`~/.claude/` の設定も読みたい／起動した dir ごとに `.claude` があれば反映したい。= 「mulmo 的なもの＋開発環境としてのターミナル設定」。permission は auto 維持。

Bumps to **0.1.5** (also ships #42's GUI-store relocation to `~/.mulmoterminal/`, not yet published). See `plans/feat-honor-claude-config.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)