### PR TITLE
ci: run CI + Codex review on dev_tool PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev_tool]
   pull_request:
-    branches: [main]
+    branches: [main, dev_tool]
 
 jobs:
   lint-and-build:

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -43,7 +43,7 @@ on:
   # take is wanted on draft promotion, use `workflow_dispatch` instead.
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
+    branches: [main, dev_tool]
   # Manual escalation: run on demand against any PR (re-review,
   # one-off check on a closed PR, etc.).
   workflow_dispatch:


### PR DESCRIPTION
## Summary

PRs targeting **`dev_tool`** (the multi-terminal integration branch) currently get no checks — both workflows only trigger on `main`. Add `dev_tool` to the `pull_request` branch filters so dev_tool PRs get the same gates and review:

- **`ci.yml`** — `pull_request` (and `push`) branches: `[main, dev_tool]` → lint / typecheck / typecheck:server / build / test + the package-smoke (incl. `/ws` PTY) job.
- **`codex_review.yaml`** — `pull_request` branches: `[main, dev_tool]` → Codex auto-review.

## Note

This is a chicken-and-egg PR: it itself targets `dev_tool`, so the new triggers apply to *subsequent* dev_tool PRs (and to this one once merged). Existing open dev_tool PRs (e.g. #48) will pick up the checks on their next push after this merges.

## User Prompt

- dev_tool 向けの PR も review の CI を走らせる。

base: `dev_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)