### PR TITLE
feat: integrate @mulmoclaude/collection-plugin (read-side foundation)

### DIFF
--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -1,0 +1,230 @@
+# Integrating `@mulmoclaude/collection-plugin` into MulmoTerminal
+
+Status: **the cross-repo blocker is gone.** The package shipped `0.5.0`/`0.5.1` with exactly the
+host-contract changes this doc originally said were still needed (ToolPlugin entry, router-optional
+nav, configurable teleport target, server engine). What remains is **MulmoTerminal-side wiring only** —
+**no MulmoClaude changes are required.**
+
+This doc was originally written against `0.4.1` and assumed a future `0.5.0` was on the critical path.
+It has been updated against the **published `@mulmoclaude/collection-plugin@0.5.1`** and the current
+MulmoTerminal tree.
+
+---
+
+## TL;DR verdict
+
+**Can this be done without any changes to MulmoClaude? Yes.** Everything MulmoTerminal needs is already
+published in `@mulmoclaude/collection-plugin@0.5.1`:
+
+- `./vue` exports a `plugin: ToolPlugin` (chat-result `View` + `Preview`) — the runtime registration
+  shape MulmoTerminal uses, just like chart/form/markdown.
+- Navigation is **router-optional**: `CollectionEmbedView` no longer renders a bare `<router-link>`;
+  refs/embeds go through `collectionUi().navigateToRecord(slug, recordId?)` (`src/vue/refLink.ts`), and
+  `recordHref`/`navigate` are optional so a router-less host returns `undefined`.
+- The record modal teleports to a host-supplied target: `modalTeleportTarget?: () => string | HTMLElement`
+  (defaults to `"body"`), so a Shadow-DOM host points it at an in-shadow node.
+- `./server` exports the full read-side engine: `configureCollectionHost({ workspaceRoot, log, paths,
+  isPresetSlug })` plus `discoverCollections` / `loadCollection` / `toSummary` / `toDetail` /
+  `listItems` / `validateCollectionRecords`.
+
+The **only** MulmoClaude artifact that is NOT packaged is the favorites/shortcuts format
+(`Shortcut` type + `shortcuts-io`), which still lives in MulmoClaude's app tree. MulmoTerminal must
+**reimplement that format verbatim** for the Tier 2 toolbar (see the drift warning). That is a
+MulmoTerminal-side change — it requires no MulmoClaude edit. Extracting a shared shortcuts package
+later (to eliminate drift risk) is optional and deferrable.
+
+---
+
+## Correction to the original plan: even the read-only card needs the server
+
+The original doc claimed a "Tier 0 — read-only chat card, no server." **That is wrong for the 0.5.x
+design.** `executePresentCollection` only echoes the addressing `{ collectionSlug, itemId? }` — it does
+**not** embed records. The chat `View` passes just the `slug` to `CollectionView`, which then calls
+`collectionUi().fetchCollectionDetail(slug)` to load the live schema + records (see
+`CollectionView.vue` and `useCollectionRendering.ts`). So the smallest increment that actually renders
+data is **frontend wiring + the server read route** — not a snapshot-only card.
+
+This is consistent with the foundational model below: MulmoTerminal is a *second live view over the
+shared workspace*, never a renderer of a passed-in snapshot.
+
+---
+
+## What's published and ready (`0.5.1`)
+
+| Entry | Contents | MulmoTerminal needs it? |
+|---|---|---|
+| `.` | isomorphic core (schema, derive/formula, `TOOL_DEFINITION`/`executePresentCollection`, list/detail response types) | yes (tool def + types) |
+| `./server` | node-only engine behind `configureCollectionHost(...)` + `discoverCollections`/`loadCollection`/`toSummary`/`toDetail`/`listItems`/`validateCollectionRecords` (read side) and CRUD/delete/views (write side) | yes (read side now; write later) |
+| `./vue` | `plugin: ToolPlugin`, `configureCollectionUi()`/`collectionUi()`, `CollectionView`, `CollectionsIndexView`, all sub-views | yes |
+| `./style.css` | compiled Tailwind | yes (inject into the shadow root) |
+
+Peer deps: `gui-chat-protocol@^0.4.0` (MulmoTerminal already has it), `vue@^3.5`, `vue-i18n@^11.4.4`
+(MulmoTerminal must add). The plugin owns its **own vue-i18n instance** (all 8 locales) — it needs no
+host translation keys, only a `localeTag()`.
+
+---
+
+## MulmoTerminal architecture (the relevant facts)
+
+- **Already consumes `@mulmoclaude/{chart,form,markdown,x}-plugin`** — imports `{ plugin } from "@X/vue"`
+  in `src/plugins-registry.ts` and renders `getPlugin(toolName).viewComponent` in `GuiPanel.vue`. CSS is
+  imported `?inline` and injected into a per-view **Shadow DOM** (`PluginFrame.vue` → `attachShadow` +
+  `Teleport` into the shadow mount).
+- **No vue-router** (so "navigate" = switch a panel's state).
+- **No vue-i18n** yet (must add `vue-i18n@^11`).
+- **Shared workspace**: `CLAUDE_CWD` (defaults to `~/mulmoclaude`) is the PTY cwd and the root for
+  persisted state; `<workspace>/artifacts` is the user-browsable output area. Server backends are
+  initialised at boot (`initMarkdownBackend`, `initArtifactsBackend`) — the same hook point where
+  `configureCollectionHost` goes.
+
+---
+
+## Foundational model: two views over one workspace
+
+MulmoClaude and MulmoTerminal **share a workspace**, and everything that matters is workspace state:
+
+- **Collection definitions are skills** (`<workspace>/.claude/skills/<slug>/` + sibling `schema.json`,
+  plus `~/.claude/skills` user scope) — shared.
+- **Records** — shared, under the schema's data dir.
+- **Favorites** = pinned launcher shortcuts at `<workspace>/config/shortcuts.json` — shared.
+
+So MulmoTerminal is a second live view, not a snapshot renderer. To *show* collections its server must
+wire the engine against the shared `workspaceRoot` using the **same path layout** MulmoClaude uses
+(below), so discovery sees the same files.
+
+### Shared path layout (must match MulmoClaude exactly)
+
+| Host path | Value |
+|---|---|
+| `userSkillsDir` | `~/.claude/skills` |
+| `projectSkillsDir(root)` | `<root>/.claude/skills` |
+| `feedsRoot(root)` | `<root>/feeds` |
+| `skillsStagingDir(root)` | `<root>/data/skills` |
+| `archiveDir` | `archive` |
+| `isPresetSlug(slug)` | `slug.startsWith("mc-") && slug.length > 3` |
+
+---
+
+## Gap analysis (updated for `0.5.1`)
+
+| # | Original gap | Status |
+|---|---|---|
+| 1 | No `plugin: ToolPlugin` export | ✅ shipped — `export const plugin` in `./vue` |
+| 2 | `<router-link>` / vue-router assumed | ✅ shipped — router-optional via `refLink.ts` + `navigateToRecord`/optional `recordHref`/`navigate` |
+| 3 | `Teleport to="body"` escapes Shadow DOM | ✅ shipped — `modalTeleportTarget?: () => string \| HTMLElement` |
+| 4 | vue-i18n peer | **[term]** add `vue-i18n@^11` |
+| 5 | ~30 host-capability stubs | **[term]** most can stub; `fetchCollectionDetail`/`listCollections`/`localeTag`/`confirm` must be real |
+| 6 | Server engine over shared workspace | **[term]** `configureCollectionHost` + read routes (now required for the card too, see correction above) |
+
+### The binding (`CollectionUi`) — what's real vs stub for the read-side increment
+
+Base the MulmoTerminal binding on MulmoClaude's `src/composables/collections/uiHost.ts`. For a
+read-only card over the shared workspace:
+
+- **Real:** `fetchCollectionDetail` (→ `GET /api/collections/:slug/detail`), `listCollections`
+  (→ `GET /api/collections/list`), `localeTag` (host i18n), `confirm` (`window.confirm`-backed),
+  `generalRoleId`/`personalRoleId` (constants), `pinToggle` (stub component rendering nothing for now).
+- **Required-but-no-op for an embedded card:** routing fns `routeSlug`/`routeSelectedId`/`isFeedRoute`/
+  `setSelectedId`/`gotoIndex`/`gotoDetail`/`navigateToRecord` (wired to view-state in Tier 2; safe
+  no-ops until then).
+- **Stub (write/feeds/views):** `createItem`/`updateItem`/`deleteItem`/`deleteCollection`/`deleteFeed`/
+  `runItemAction`/`runCollectionAction`/`refreshCollection`/`deleteView`/`mintViewToken`/`fetchViewHtml`/
+  `buildViewSrcdoc`/`listFeeds` → typed failure; `reconcileShortcuts`/`unpin` → no-op;
+  `notifiedSeverities` → empty map; `startChat` → no-op (the card uses the `sendTextMessage` prop, not
+  this binding hook).
+- **Known v1 gap:** `fileAssetUrl`/`fileRoutePath`/`imageSrc` — MulmoTerminal has no general raw-file
+  serving route yet, so these return `null`/`""`. Collections with `image`/`file` fields won't render
+  those assets until a raw-file route is added. Collections without them render fully.
+
+### Teleport + Shadow DOM
+
+`PluginFrame` Teleports each card into a **per-instance** shadow `mount`, but `configureCollectionUi`
+sets a **single global** binding — so `modalTeleportTarget` can't statically know which card's shadow
+root to use. Approach: `PluginFrame` `provide()`s its shadow mount; a thin MulmoTerminal wrapper around
+the collection `View` injects it and registers it as the "active" teleport target while mounted; the
+binding's `modalTeleportTarget` returns that module-level active mount. Correct for the common
+single-card case; multi-card simultaneously-open modals are an accepted v1 limitation (documented).
+
+---
+
+## Required feature: a collections toolbar (tabs) — the actual ask
+
+MulmoClaude's top chrome (`PluginLauncher.vue` + `useShortcuts` + `PinToggle.vue`) has a **Collections**
+button → the `/collections` index, plus one button **per favorite** → that collection's
+`CollectionView`. Favoriting toggles the star.
+
+MulmoTerminal equivalent needs three pieces, adapted to a no-router, state-driven host:
+
+1. **A favorites store — SHARED via the workspace** `[term]`. Favorites are NOT app-local. MulmoClaude
+   persists them server-side at **`<workspace>/config/shortcuts.json`** via `GET`/`PUT /api/shortcuts`.
+   The on-disk shape is an **object wrapper** (NOT a bare array):
+
+   ```jsonc
+   { "shortcuts": [ { "kind": "collection" | "feed", "slug": "...", "title": "...", "icon": "..." } ] }
+   ```
+
+   (`mulmoclaude/src/types/shortcuts.ts` — wrapper "so the schema can grow without a migration".)
+   MulmoTerminal must read/write **the same file in the same wrapper format**, plus a frontend
+   `useShortcuts`-equivalent backing `pinToggle`/`unpin`/`reconcileShortcuts`.
+
+   **Drift risk:** two independent writers of one on-disk format diverge over time (note `PUT` rewrites
+   the whole object). **Recommended:** extract `shortcuts-io` + the `Shortcut` type into a shared
+   package (the move that already worked for the collection engine). Pragmatic fallback: reimplement
+   verbatim + a shared schema/fixture test. **Either way the format is the contract** — and a shared
+   package would be the one optional MulmoClaude-side change in this whole effort.
+
+2. **A launcher in `<header class="toolbar">`** `[term]` — a "Collections" button + a button per
+   favorite, each switching the panel to a collection view.
+
+3. **A state-based "collection browse" panel** `[term]` — since there's no router, a panel mode that can
+   show `CollectionsIndexView` or a standalone `CollectionView(slug)`. The binding's nav fns map to this
+   view state (the router-optional change makes this clean).
+
+---
+
+## Scope tiers
+
+1. **Read-side foundation (this PR's increment).** Wire the server engine + read routes and the
+   frontend ToolPlugin + binding, so a `presentCollection` chat card renders **real data from the shared
+   workspace**. (Supersedes the old "Tier 0 — no server", which couldn't render anything.)
+2. **Tier 1 — interactive card.** Inline edit + add/delete + actions. Adds the **write** routes
+   (`items`/`item`/actions/refresh/views) + a real `startChat`.
+3. **Tier 2 — browsable + toolbar (THE ASK).** Toolbar "Collections" button + per-favorite buttons →
+   `CollectionsIndexView` / standalone `CollectionView(slug)`. Adds state-based nav, the
+   shared-favorites store (`/api/shortcuts` over `config/shortcuts.json`) + launcher + browse panel.
+   The `/feeds` half is optional — include only if feeds matter in a terminal UI. Tier 2 does **not**
+   require Tier 1's write routes (browse is read-only until editing is added).
+
+---
+
+## Implementation sequence
+
+1. ~~Package `0.5.0`~~ **DONE** — published as `0.5.1` (ToolPlugin + router-optional nav + teleport
+   target + server engine). No further MulmoClaude work required for Tiers 0–2.
+2. **MulmoTerminal — deps**: add `vue-i18n@^11` + `@mulmoclaude/collection-plugin@^0.5.1`.
+3. **MulmoTerminal — server (read side)**: `configureCollectionHost({ workspaceRoot: CLAUDE_CWD, … })`
+   at boot (using the shared path layout above); add `GET /api/collections/list` +
+   `GET /api/collections/:slug/detail` backed by the package's read helpers.
+4. **MulmoTerminal — frontend wiring**: register the `plugin` ToolPlugin in `plugins-registry.ts` +
+   inject `style.css?inline`; implement the `collectionUi` binding (read real, write/chat/shortcuts
+   stubbed per §gap 5); resolve the teleport target via the shadow-mount wrapper.
+5. **MulmoTerminal — toolbar + favorites (Tier 2, the ask)**: decide shortcuts sharing (shared package
+   vs verbatim+test); `GET`/`PUT /api/shortcuts` over `config/shortcuts.json`; a `useShortcuts`
+   equivalent; the launcher in the toolbar; the browse panel mode.
+6. **Tier 1 later**: write routes + `manageCollection` MCP tool + real `startChat`.
+
+---
+
+## Open questions for the maintainers
+
+- **Shortcuts sharing**: shared package (recommended; the only optional MulmoClaude change) vs
+  reimplement-verbatim + format test?
+- **Browse panel placement**: replace the GuiPanel content, a new tab/pane, or overlay?
+- **CSS isolation**: keep the shadow frame (and the teleport-target wrapper) or treat the collection
+  plugin as first-party in light DOM?
+- **Raw-file route**: add one so `image`/`file` fields render, or accept the v1 gap?
+- **`/feeds`**: wanted, or collections-only?
+
+Bottom line: **the package is drop-in-ready and needs zero MulmoClaude changes.** The work is entirely
+in MulmoTerminal: server read engine + routes, the frontend ToolPlugin + binding + teleport wrapper,
+then the toolbar/favorites/browse panel for the actual ask.

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -132,9 +132,9 @@ read-only card over the shared workspace:
   `buildViewSrcdoc`/`listFeeds` → typed failure; `reconcileShortcuts`/`unpin` → no-op;
   `notifiedSeverities` → empty map; `startChat` → no-op (the card uses the `sendTextMessage` prop, not
   this binding hook).
-- **Known v1 gap:** `fileAssetUrl`/`fileRoutePath`/`imageSrc` — MulmoTerminal has no general raw-file
-  serving route yet, so these return `null`/`""`. Collections with `image`/`file` fields won't render
-  those assets until a raw-file route is added. Collections without them render fully.
+- **Asset URLs:** `imageSrc`/`fileAssetUrl` resolve to `GET /api/files/raw?path=<workspace-relative>`
+  (server/backends/files.ts), mirroring MulmoClaude's `resolveImageSrc`, so `image`/`file` fields and
+  custom-view `<img>` thumbnails render. `fileRoutePath` stays null (no in-app File Explorer).
 
 ### Teleport + Shadow DOM
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@mulmochat-plugin/generate-image": "^0.4.1",
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/chart-plugin": "^0.1.1",
+    "@mulmoclaude/collection-plugin": "^0.5.1",
     "@mulmoclaude/form-plugin": "^0.1.1",
     "@mulmoclaude/markdown-plugin": "^0.1.4",
     "@mulmoclaude/x-plugin": "^0.1.1",
@@ -72,6 +73,7 @@
     "socket.io-client": "^4.8.3",
     "tsx": "^4.22.4",
     "vue": "^3.5.34",
+    "vue-i18n": "^11.4.4",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,5 +1,5 @@
 {
-  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin"],
+  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin", "@mulmoclaude/collection-plugin"],
   "servers": ["@mulmoclaude/x-plugin"],
   "local": []
 }

--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { initCollectionsBackend, mountCollectionRoutes } from "./collections.js";
+
+// A minimal project-scope collection skill + one record + one read-only custom
+// view, laid out exactly where the engine's discovery looks (matching the shared
+// path layout initCollectionsBackend configures):
+//   <ws>/.claude/skills/testcol/schema.json   — the collection schema
+//   <ws>/data/testcol/items/item1.json        — one record (dataPath)
+//   <ws>/data/skills/testcol/views/v1.html    — the custom view (project staging)
+const SCHEMA = {
+  title: "Test Collection",
+  icon: "star",
+  dataPath: "data/testcol/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    name: { type: "string", label: "Name" },
+  },
+  views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+};
+
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  const ws = mkdtempSync(path.join(tmpdir(), "mt-col-"));
+  mkdirSync(path.join(ws, ".claude", "skills", "testcol"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "schema.json"), JSON.stringify(SCHEMA));
+  mkdirSync(path.join(ws, "data", "testcol", "items"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "testcol", "items", "item1.json"), JSON.stringify({ id: "item1", name: "Foo" }));
+  mkdirSync(path.join(ws, "data", "skills", "testcol", "views"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v1.html"), "<head></head><body>view</body>");
+
+  // Point the (singleton) collection host at the fixture. vitest isolates modules
+  // per test file, so this configure is fresh for this worker.
+  initCollectionsBackend({ workspace: ws });
+
+  const app = express();
+  app.use(express.json());
+  mountCollectionRoutes(app);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /api/collections/list", () => {
+  it("lists the fixture collection", async () => {
+    const res = await fetch(`${base}/api/collections/list`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collections: Array<{ slug: string; title: string; source: string }> };
+    const testcol = body.collections.find((c) => c.slug === "testcol");
+    expect(testcol).toMatchObject({ slug: "testcol", title: "Test Collection", source: "project" });
+  });
+});
+
+describe("GET /api/collections/:slug/detail", () => {
+  it("returns the schema + records", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/detail`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collection: { slug: string }; items: Array<{ id: string; name: string }> };
+    expect(body.collection.slug).toBe("testcol");
+    expect(body.items).toEqual([{ id: "item1", name: "Foo" }]);
+  });
+
+  it("404s for a missing slug", async () => {
+    expect((await fetch(`${base}/api/collections/nope/detail`)).status).toBe(404);
+  });
+});
+
+describe("custom view routes", () => {
+  it("mints a read-only token (write clamped off)", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "v1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string; dataUrl: string; capabilities: string[] };
+    expect(body.capabilities).toEqual(["read"]);
+    expect(body.dataUrl).toBe("/api/collections/testcol/view-data");
+    expect(typeof body.token).toBe("string");
+  });
+
+  it("400s when viewId is missing", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s view-file for an unknown view id", async () => {
+    expect((await fetch(`${base}/api/collections/testcol/view-file?id=nope`)).status).toBe(404);
+  });
+
+  it("serves view-file HTML with sandbox + nosniff hardening", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-file?id=v1`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-security-policy")).toBe("sandbox");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(await res.text()).toContain("view");
+  });
+
+  it("401s view-data without a token", async () => {
+    expect((await fetch(`${base}/api/collections/testcol/view-data`)).status).toBe(401);
+  });
+
+  it("serves view-data records with a valid token", async () => {
+    const mint = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "v1" }),
+    });
+    const { token } = (await mint.json()) as { token: string };
+    const res = await fetch(`${base}/api/collections/testcol/view-data`, { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(["item1"]);
+  });
+});

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -1,0 +1,107 @@
+// Read-side backend for @mulmoclaude/collection-plugin. MulmoTerminal is a second
+// live view over the SHARED workspace (CLAUDE_CWD, default ~/mulmoclaude) — it does
+// not render a passed-in snapshot. The presentCollection chat card passes only a
+// slug to CollectionView, which then calls the UI binding's fetchCollectionDetail()
+// → GET /api/collections/:slug/detail here to load the live schema + records. So
+// this engine wiring is required even for a read-only card.
+//
+// The path layout below MUST match MulmoClaude's exactly (see
+// mulmoclaude/server/workspace/{skills,feeds}/paths.ts + skills-preset.ts) so
+// discovery finds the same collection skills both apps share on disk.
+//
+// Only the read side is wired here (list + detail). Write routes (CRUD / actions /
+// custom views) and the manageCollection MCP tool are deferred to the interactive
+// tier.
+import path from "node:path";
+import os from "node:os";
+import type { Express, Request, Response } from "express";
+import {
+  configureCollectionHost,
+  discoverCollections,
+  loadCollection,
+  listItems,
+  toSummary,
+  toDetail,
+  validateCollectionRecords,
+  type RecordIssue,
+} from "@mulmoclaude/collection-plugin/server";
+
+// Console-backed logger matching the engine's CollectionLogger shape
+// (prefix, message, optional structured data).
+const log = {
+  error: (prefix: string, message: string, data?: Record<string, unknown>) => console.error(`[${prefix}] ${message}`, data ?? ""),
+  warn: (prefix: string, message: string, data?: Record<string, unknown>) => console.warn(`[${prefix}] ${message}`, data ?? ""),
+  info: (prefix: string, message: string, data?: Record<string, unknown>) => console.log(`[${prefix}] ${message}`, data ?? ""),
+  debug: (prefix: string, message: string, data?: Record<string, unknown>) => console.debug(`[${prefix}] ${message}`, data ?? ""),
+};
+
+/** Wire the collection engine to the shared workspace. Call once at boot, before
+ *  any collection route is hit. The path layout mirrors MulmoClaude verbatim. */
+export function initCollectionsBackend(deps: { workspace: string }): void {
+  configureCollectionHost({
+    workspaceRoot: deps.workspace,
+    log,
+    paths: {
+      // ~/.claude/skills — user scope (read-only).
+      userSkillsDir: path.join(os.homedir(), ".claude", "skills"),
+      // <root>/.claude/skills — project scope.
+      projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+      // <root>/feeds — feed registry root.
+      feedsRoot: (root) => path.join(root, "feeds"),
+      // <root>/data/skills — project-skills staging.
+      skillsStagingDir: (root) => path.join(root, "data", "skills"),
+      // Workspace-relative archive dir (removed collections move here).
+      archiveDir: "archive",
+    },
+    // MulmoClaude's launcher preset namespace.
+    isPresetSlug: (slug) => slug.startsWith("mc-") && slug.length > "mc-".length,
+  });
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Mount the read-side REST surface. Mirrors MulmoClaude's
+ *  GET /api/collections + GET /api/collections/:slug response shapes, which is what
+ *  the package's UI binding (fetchCollectionDetail / listCollections) expects. */
+export function mountCollectionRoutes(app: Express): void {
+  // List skill-backed collections for the index + toolbar.
+  app.get("/api/collections/list", async (_req: Request, res: Response) => {
+    try {
+      const collections = await discoverCollections();
+      res.json({ collections: collections.map(toSummary) });
+    } catch (err) {
+      log.warn("collections", "list failed", { error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // A collection's live schema + records by slug. Backs both the card's own load
+  // (CollectionView reads `status` for 404 → not-found) and ref/embed resolution.
+  app.get("/api/collections/:slug/detail", async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    try {
+      const items = await listItems(collection.dataDir);
+      // Best-effort validation: a malformed record is silently skipped at read
+      // time, so surface the problems here too and let the view offer a Repair
+      // button. Never let validation failure turn a successful detail into a 500.
+      let issues: RecordIssue[] = [];
+      try {
+        issues = await validateCollectionRecords(collection);
+      } catch (err) {
+        log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
+      }
+      // Omit `issues` entirely when everything is fine (the "absent when clean"
+      // contract the view relies on).
+      res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
+    } catch (err) {
+      log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -134,6 +134,14 @@ export function mountCollectionRoutes(app: Express): void {
         res.status(404).json({ error: `view file '${view.file}' not found` });
         return;
       }
+      // This is LLM-authored HTML. The frontend renders it sandboxed via a
+      // fetch()→srcdoc iframe (not by navigating here), so harden the raw response
+      // against DIRECT navigation: `sandbox` gives it an opaque origin (its scripts
+      // can't reach the app origin's /api/*), and `nosniff` stops re-interpretation.
+      // The iframe path is unaffected — a fetch() reads the body regardless of this
+      // response-level CSP.
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("Content-Security-Policy", "sandbox");
       res.type("text/html").send(html);
     } catch (err) {
       log.warn("collections", "view-file read failed", { slug: req.params.slug, error: errorMessage(err) });

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -14,17 +14,20 @@
 // tier.
 import path from "node:path";
 import os from "node:os";
-import type { Express, Request, Response } from "express";
+import type { Express, Request, Response, NextFunction } from "express";
 import {
   configureCollectionHost,
   discoverCollections,
   loadCollection,
   listItems,
+  enrichItems,
+  readCustomViewHtml,
   toSummary,
   toDetail,
   validateCollectionRecords,
   type RecordIssue,
 } from "@mulmoclaude/collection-plugin/server";
+import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
 // (prefix, message, optional structured data).
@@ -101,6 +104,103 @@ export function mountCollectionRoutes(app: Express): void {
       res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
     } catch (err) {
       log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Custom views (sandboxed-iframe HTML views, e.g. a poster gallery) ──
+  // A custom view is LLM-authored HTML rendered in a sandboxed iframe that fetches
+  // its records from view-data with a scoped token. Read-only here: the GET data
+  // route is wired; write (PUT) is deferred to the interactive tier.
+
+  // The custom view's raw HTML, read from the staging path via the package's
+  // path-safe reader. The frontend renders it sandboxed (token injected).
+  app.get("/api/collections/:slug/view-file", async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const { slug } = req.params;
+      const viewId = typeof req.query.id === "string" ? req.query.id : "";
+      const collection = await loadCollection(slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${slug}' not found` });
+        return;
+      }
+      const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+      if (!view) {
+        res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
+        return;
+      }
+      const html = await readCustomViewHtml(collection, view.file);
+      if (html === null) {
+        res.status(404).json({ error: `view file '${view.file}' not found` });
+        return;
+      }
+      res.type("text/html").send(html);
+    } catch (err) {
+      log.warn("collections", "view-file read failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Mint a scoped token for a custom view, clamped to what the view declared so a
+  // read-only view can never obtain a write token.
+  app.post("/api/collections/:slug/view-token", async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const { slug } = req.params;
+      const body = (req.body ?? {}) as { viewId?: unknown; capabilities?: unknown };
+      const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
+      if (!viewId) {
+        res.status(400).json({ error: "`viewId` is required" });
+        return;
+      }
+      const collection = await loadCollection(slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${slug}' not found` });
+        return;
+      }
+      const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+      if (!view) {
+        res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
+        return;
+      }
+      // Read-only for now: MulmoTerminal has no view-data write route yet, so never
+      // grant `write` even if the view declares it (clamp the request to ["read"]).
+      // Drop the `write` clamp here once the interactive tier wires PUT /view-data.
+      const granted = clampCapabilities(view.capabilities as ViewCapability[] | undefined, ["read"]);
+      const minted = mintViewToken(slug, granted);
+      res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
+    } catch (err) {
+      log.warn("collections", "view-token mint failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // CORS for the view-data endpoint: the sandboxed iframe has an opaque origin, so
+  // its fetch is cross-origin and preflighted. `*` is safe — auth is the unguessable
+  // scoped token in the Authorization header (not a cookie), so no ambient-credential
+  // leak; an origin without the token just gets a 401.
+  const viewDataCors = (_req: Request, res: Response, next: NextFunction): void => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+    next();
+  };
+  app.options("/api/collections/:slug/view-data", viewDataCors, (_req: Request, res: Response) => {
+    res.status(204).end();
+  });
+
+  // Scoped read: the view's enriched records as `{ items }` — the shape custom views
+  // fetch from `window.__MC_VIEW.dataUrl`. Guarded by the view token only.
+  app.get("/api/collections/:slug/view-data", viewDataCors, requireViewToken("read"), async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const collection = await loadCollection(req.params.slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+        return;
+      }
+      const items = await enrichItems(collection, await listItems(collection.dataDir));
+      res.json({ items });
+    } catch (err) {
+      log.warn("collections", "view-data read failed", { slug: req.params.slug, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   });

--- a/server/backends/files.spec.ts
+++ b/server/backends/files.spec.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { mountFilesRoutes } from "./files.js";
+
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  const ws = mkdtempSync(path.join(tmpdir(), "mt-files-"));
+  mkdirSync(path.join(ws, "downloads", "images"), { recursive: true });
+  // 4-byte PNG signature — enough to assert byte length + Range.
+  writeFileSync(path.join(ws, "downloads", "images", "a.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  writeFileSync(path.join(ws, "secret.txt"), "top secret");
+
+  const app = express();
+  mountFilesRoutes(app, { workspace: ws });
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /api/files/raw", () => {
+  it("serves a file with the hardening headers", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=downloads/images/a.png`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("content-security-policy")).toBe("sandbox");
+    expect((await res.arrayBuffer()).byteLength).toBe(4);
+  });
+
+  it("400s when path is missing", async () => {
+    expect((await fetch(`${base}/api/files/raw`)).status).toBe(400);
+  });
+
+  it("403s on path traversal", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=${encodeURIComponent("../../etc/passwd")}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("403s on an absolute path escaping the root", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=${encodeURIComponent("/etc/passwd")}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("404s on a missing file", async () => {
+    expect((await fetch(`${base}/api/files/raw?path=downloads/images/nope.png`)).status).toBe(404);
+  });
+
+  it("honours a Range request (206 partial)", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=downloads/images/a.png`, { headers: { Range: "bytes=0-1" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 0-1/4");
+    expect((await res.arrayBuffer()).byteLength).toBe(2);
+  });
+});

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -1,0 +1,126 @@
+// Raw workspace-file serving — GET /api/files/raw?path=<workspace-relative>.
+//
+// Consumers: the collection plugin's image/file fields (the binding's imageSrc maps
+// here) and its custom views, whose LLM-authored HTML builds
+// `<img src="<origin>/api/files/raw?path=...">` for poster/thumbnail fields. Mirrors
+// MulmoClaude's server/api/routes/files.ts GET /files/raw (the path the gallery view
+// hardcodes), trimmed to what MulmoTerminal needs.
+//
+// Security (this serves arbitrary workspace files):
+//   - Path containment: the resolved absolute path must stay within the workspace
+//     root — reject traversal / absolute escapes (the only real attack surface on a
+//     loopback server).
+//   - `Content-Security-Policy: sandbox` + `X-Content-Type-Options: nosniff` so an
+//     `.svg`/`.html` with embedded JS can't run in the app origin via direct
+//     navigation or <iframe>; PDFs skip the sandbox CSP (WebKit refuses to render
+//     sandbox-opaque PDFs) but keep nosniff. Matches MulmoClaude's RAW_SECURITY_HEADERS.
+import path from "node:path";
+import fs from "node:fs";
+import { createReadStream } from "node:fs";
+import type { Express, Request, Response } from "express";
+
+const MAX_RAW_BYTES = 25 * 1024 * 1024; // images / text / generic
+const MAX_MEDIA_BYTES = 500 * 1024 * 1024; // audio / video (streamed via Range)
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".ico": "image/x-icon",
+  ".pdf": "application/pdf",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".txt": "text/plain; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".csv": "text/csv; charset=utf-8",
+};
+
+function isMedia(mime: string): boolean {
+  return mime.startsWith("audio/") || mime.startsWith("video/");
+}
+
+function parseRange(header: string, size: number): { start: number; end: number } | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!match) return null;
+  const [, startStr, endStr] = match;
+  if (startStr === "" && endStr === "") return null;
+  const start = startStr === "" ? size - Number(endStr) : Number(startStr);
+  const end = endStr === "" ? size - 1 : Number(endStr);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  if (start < 0 || end < start || end >= size) return null;
+  return { start, end };
+}
+
+export function mountFilesRoutes(app: Express, deps: { workspace: string }): void {
+  const root = path.resolve(deps.workspace);
+
+  app.get("/api/files/raw", (req: Request, res: Response) => {
+    const rel = typeof req.query.path === "string" ? req.query.path : "";
+    if (!rel) {
+      res.status(400).json({ error: "`path` query is required" });
+      return;
+    }
+    // Containment: resolve against the workspace root and reject anything that
+    // escapes it (absolute input, `..`, symlink-free check on the resolved string).
+    const abs = path.resolve(root, rel);
+    if (abs !== root && !abs.startsWith(root + path.sep)) {
+      res.status(403).json({ error: "path escapes the workspace root" });
+      return;
+    }
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(abs);
+    } catch {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    if (!stat.isFile()) {
+      res.status(404).json({ error: "not a file" });
+      return;
+    }
+
+    const ext = path.extname(abs).toLowerCase();
+    const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
+    const cap = isMedia(mime) ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
+    if (stat.size > cap) {
+      res.status(413).json({ error: `file too large (${stat.size} bytes, limit ${cap})` });
+      return;
+    }
+
+    res.setHeader("Content-Type", mime);
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    // Sandbox the response so an SVG/HTML with embedded JS can't escape into the app
+    // origin. PDFs skip it (WebKit won't render sandbox-opaque PDFs).
+    if (mime !== "application/pdf") res.setHeader("Content-Security-Policy", "sandbox");
+    res.setHeader("Accept-Ranges", "bytes");
+
+    // Range support (required for <video>/<audio> seeking in Safari).
+    const rangeHeader = req.headers.range;
+    if (rangeHeader) {
+      const range = parseRange(rangeHeader, stat.size);
+      if (!range) {
+        res.status(416).setHeader("Content-Range", `bytes */${stat.size}`);
+        res.json({ error: "invalid range" });
+        return;
+      }
+      res.status(206);
+      res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
+      res.setHeader("Content-Length", String(range.end - range.start + 1));
+      createReadStream(abs, { start: range.start, end: range.end }).pipe(res);
+      return;
+    }
+
+    res.setHeader("Content-Length", String(stat.size));
+    createReadStream(abs).pipe(res);
+  });
+}

--- a/server/backends/viewToken.spec.ts
+++ b/server/backends/viewToken.spec.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import { mintViewToken, verifyViewToken, clampCapabilities, requireViewToken, VIEW_TOKEN_TTL_MS, type ViewCapability } from "./viewToken.js";
+import type { Request, Response, NextFunction } from "express";
+
+describe("viewToken mint/verify", () => {
+  it("round-trips a minted token", () => {
+    const { token, exp } = mintViewToken("watchlist", ["read"], 1000);
+    expect(exp).toBe(1000 + VIEW_TOKEN_TTL_MS);
+    const payload = verifyViewToken(token, 2000);
+    expect(payload).toEqual({ slug: "watchlist", caps: ["read"], exp: 1000 + VIEW_TOKEN_TTL_MS });
+  });
+
+  it("rejects a tampered payload", () => {
+    const { token } = mintViewToken("watchlist", ["read"], 1000);
+    const [payloadB64, sig] = token.split(".");
+    // Re-encode a payload claiming a different slug, keep the original signature.
+    const forged = Buffer.from(JSON.stringify({ slug: "secrets", caps: ["read", "write"], exp: 1000 + VIEW_TOKEN_TTL_MS }), "utf8").toString("base64url");
+    expect(verifyViewToken(`${forged}.${sig}`, 2000)).toBeNull();
+    // Sanity: the untouched token still verifies.
+    expect(verifyViewToken(`${payloadB64}.${sig}`, 2000)).not.toBeNull();
+  });
+
+  it("rejects a bad signature", () => {
+    const { token } = mintViewToken("watchlist", ["read"], 1000);
+    const [payloadB64] = token.split(".");
+    expect(verifyViewToken(`${payloadB64}.deadbeef`, 2000)).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    const { token, exp } = mintViewToken("watchlist", ["read"], 1000);
+    expect(verifyViewToken(token, exp)).toBeNull(); // exactly at exp → expired
+    expect(verifyViewToken(token, exp + 1)).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    expect(verifyViewToken("")).toBeNull();
+    expect(verifyViewToken("nodot")).toBeNull();
+    expect(verifyViewToken(".onlysig")).toBeNull();
+  });
+});
+
+describe("clampCapabilities", () => {
+  const cases: Array<[ViewCapability[] | undefined, ViewCapability[] | undefined, ViewCapability[]]> = [
+    [["read", "write"], ["read"], ["read"]], // requested narrows the declared set
+    [["read"], ["read", "write"], ["read"]], // declared caps the grant (no write escalation)
+    [undefined, undefined, ["read"]], // least-privilege default
+    [["read", "write"], undefined, ["read", "write"]], // undefined requested ⇒ full declared set
+    [[], ["read"], ["read"]], // empty declared ⇒ default ["read"]
+  ];
+  it.each(cases)("clamp(%j, %j) → %j", (declared, requested, expected) => {
+    expect(clampCapabilities(declared, requested)).toEqual(expected);
+  });
+});
+
+interface MockRes {
+  statusCode: number;
+  body: unknown;
+  status(code: number): MockRes;
+  json(b: unknown): MockRes;
+}
+function mockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(b) {
+      this.body = b;
+      return this;
+    },
+  };
+}
+
+function runGuard(action: ViewCapability, headers: Record<string, string>, slug: string) {
+  const res = mockRes();
+  const next = vi.fn();
+  requireViewToken(action)({ headers, params: { slug } } as unknown as Request, res as unknown as Response, next as NextFunction);
+  return { res, next };
+}
+
+describe("requireViewToken middleware", () => {
+  it("401s with no Authorization header", () => {
+    const { res, next } = runGuard("read", {}, "watchlist");
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next() for a valid token with the right slug + capability", () => {
+    const { token } = mintViewToken("watchlist", ["read"]);
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("401s when the token's slug differs from the route", () => {
+    const { token } = mintViewToken("watchlist", ["read"]);
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "other");
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401s when the required capability is missing", () => {
+    const { token } = mintViewToken("watchlist", ["read"]);
+    const { res, next } = runGuard("write", { authorization: `Bearer ${token}` }, "watchlist");
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/backends/viewToken.ts
+++ b/server/backends/viewToken.ts
@@ -1,0 +1,101 @@
+// Scoped capability tokens for custom collection views — MulmoTerminal's port of
+// MulmoClaude's server/api/auth/viewToken.ts.
+//
+// A custom view is LLM-authored HTML rendered in a sandboxed (allow-scripts,
+// opaque-origin) iframe. It must reach ONLY its collection's view-data endpoint,
+// for one slug, with an explicit capability set (read/write). The authenticated
+// parent mints a short-lived signed token (`base64url(payload).HMAC`); the iframe
+// sends it as `Authorization: Bearer <token>`; `requireViewToken` verifies it.
+//
+// MulmoTerminal has no global bearer auth (loopback tool), so — unlike MulmoClaude,
+// which keys the HMAC by its per-startup bearer token — we generate a per-PROCESS
+// random signing key here. A restart invalidates outstanding view tokens (the key
+// changes), the same lifecycle MulmoClaude gets for free.
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { Request, Response, NextFunction } from "express";
+
+export type ViewCapability = "read" | "write";
+
+function isCapability(value: unknown): value is ViewCapability {
+  return value === "read" || value === "write";
+}
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+/** How long a minted view token stays valid. The parent re-mints on each render. */
+export const VIEW_TOKEN_TTL_MS = ONE_HOUR_MS;
+
+const BEARER_PREFIX = "Bearer ";
+
+// Per-process signing key — generated once, lost on restart (intentional).
+const SIGNING_KEY = randomBytes(32).toString("hex");
+
+interface ViewTokenPayload {
+  slug: string;
+  caps: ViewCapability[];
+  exp: number;
+}
+
+function signPayload(payloadB64: string): string {
+  return createHmac("sha256", SIGNING_KEY).update(payloadB64).digest("base64url");
+}
+
+/** Clamp a view's requested capabilities to what it declared in its schema — a
+ *  `["read"]` view can never get a `write` token. The result is declared ∩
+ *  requested; undefined declared ⇒ least-privilege `["read"]`. */
+export function clampCapabilities(declared: ViewCapability[] | undefined, requested: ViewCapability[] | undefined): ViewCapability[] {
+  const declaredCaps = declared && declared.length > 0 ? declared : (["read"] as ViewCapability[]);
+  const requestedCaps = requested && requested.length > 0 ? requested : declaredCaps;
+  return declaredCaps.filter((cap) => requestedCaps.includes(cap));
+}
+
+/** Mint a signed token for `slug` granting `caps`, valid for {@link VIEW_TOKEN_TTL_MS}. */
+export function mintViewToken(slug: string, caps: ViewCapability[], nowMs: number = Date.now()): { token: string; exp: number } {
+  const exp = nowMs + VIEW_TOKEN_TTL_MS;
+  const payload: ViewTokenPayload = { slug, caps, exp };
+  const payloadB64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return { token: `${payloadB64}.${signPayload(payloadB64)}`, exp };
+}
+
+/** Verify a token's signature + expiry; return its payload or null on any failure. */
+export function verifyViewToken(token: string, nowMs: number = Date.now()): ViewTokenPayload | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot >= token.length - 1) return null;
+  const payloadB64 = token.slice(0, dot);
+  const providedSig = token.slice(dot + 1);
+  const expectedSig = signPayload(payloadB64);
+  // Compare byte lengths before timingSafeEqual — it throws on a length mismatch.
+  const providedBuf = Buffer.from(providedSig);
+  const expectedBuf = Buffer.from(expectedSig);
+  if (providedBuf.length !== expectedBuf.length) return null;
+  if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const candidate = parsed as Record<string, unknown>;
+  if (typeof candidate.slug !== "string" || typeof candidate.exp !== "number") return null;
+  if (!Array.isArray(candidate.caps) || !candidate.caps.every(isCapability)) return null;
+  if (nowMs >= candidate.exp) return null;
+  return { slug: candidate.slug, caps: candidate.caps as ViewCapability[], exp: candidate.exp };
+}
+
+/** Express middleware: require a valid scoped token whose slug matches the route
+ *  param and whose caps include `action`. 401 on any failure. */
+export function requireViewToken(action: ViewCapability) {
+  return function requireViewTokenMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const header = req.headers.authorization;
+    if (typeof header !== "string" || !header.startsWith(BEARER_PREFIX)) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    const payload = verifyViewToken(header.slice(BEARER_PREFIX.length));
+    if (!payload || payload.slug !== req.params.slug || !payload.caps.includes(action)) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    next();
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,6 +15,7 @@ import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
+import { mountFilesRoutes } from "./backends/files.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -517,6 +518,10 @@ mountAllRoutes(app);
 // card and (later) the collections toolbar. The engine itself is configured below
 // once CLAUDE_CWD is the confirmed workspace.
 mountCollectionRoutes(app);
+
+// Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
+// fields and custom-view <img> URLs. Rooted at the shared workspace.
+mountFilesRoutes(app, { workspace: CLAUDE_CWD });
 
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
+import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -511,6 +512,12 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
 // POST /api/form). The GUI MCP server dispatches tool calls to these.
 mountAllRoutes(app);
 
+// Read-side collection routes (GET /api/collections/list + /:slug/detail) over the
+// shared workspace, backing the @mulmoclaude/collection-plugin presentCollection
+// card and (later) the collections toolbar. The engine itself is configured below
+// once CLAUDE_CWD is the confirmed workspace.
+mountCollectionRoutes(app);
+
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in
 // STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
@@ -750,6 +757,10 @@ initMarkdownBackend({ workspace: CLAUDE_CWD, pubsub });
 // Give the artifacts FileOps backend its workspace root (<workspace>/artifacts) so
 // @mulmoclaude/chart-plugin's executeChart can persist chart documents there.
 initArtifactsBackend({ workspace: CLAUDE_CWD });
+
+// Configure the collection engine against the shared workspace (CLAUDE_CWD). The
+// path layout matches MulmoClaude's so discovery sees the same collection skills.
+initCollectionsBackend({ workspace: CLAUDE_CWD });
 
 // Terminal WebSocket. Uses noServer + manual upgrade routing so it shares the
 // HTTP server with socket.io (the pub/sub at /ws/pubsub) without the two

--- a/server/plugins-registry.ts
+++ b/server/plugins-registry.ts
@@ -65,7 +65,16 @@ function loadConfig() {
 async function loadPackage(name: string) {
   const mod = await import(name);
   const definition = mod.TOOL_DEFINITION ?? mod.pluginCore?.toolDefinition;
-  const execute = mod.pluginCore?.execute ?? mod.execute;
+  // Some packages (e.g. @mulmoclaude/collection-plugin) export their executor under
+  // a descriptive name like `executePresentCollection` rather than a bare `execute`,
+  // and ship no `pluginCore` on the core entry (their origin host registers the tool
+  // as a built-in). Fall back to a sole `execute*` function export so such packages
+  // still load without hardcoding their name.
+  const soleExecuteStar = (() => {
+    const fns = Object.entries(mod).filter(([key, val]) => key.startsWith("execute") && typeof val === "function");
+    return fns.length === 1 ? (fns[0][1] as (...args: unknown[]) => unknown) : undefined;
+  })();
+  const execute = mod.pluginCore?.execute ?? mod.execute ?? soleExecuteStar;
   if (!definition || typeof execute !== "function") {
     throw new Error(`Package "${name}" is not a gui-chat-protocol plugin (missing TOOL_DEFINITION/execute).`);
   }

--- a/src/components/CollectionCardView.vue
+++ b/src/components/CollectionCardView.vue
@@ -39,7 +39,12 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div ref="rootEl">
+  <!-- Fill the fixed-height frame (PluginFrame `height` → shadow mount 100%) so the
+       package View's internal h-full layout — table/kanban scroll, custom-view
+       iframe — resolves against a definite height. Inline style, not scoped CSS:
+       this element lives inside the plugin's shadow root, which document-head
+       <style> (where Vue puts scoped CSS) can't reach. -->
+  <div ref="rootEl" :style="{ height: '100%' }">
     <component
       :is="ChatView"
       :selected-result="selectedResult"

--- a/src/components/CollectionCardView.vue
+++ b/src/components/CollectionCardView.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+// MulmoTerminal wrapper around the collection plugin's chat View. It forwards the
+// GUI-panel props to the package View unchanged, and — because the package's record
+// modal teleports to the host-supplied `modalTeleportTarget` — registers THIS card's
+// shadow root (resolved via getRootNode(), since PluginFrame mounts us inside one)
+// as the active teleport target while mounted. Without this, the modal would
+// teleport to <body>, escape the shadow root, and lose the injected plugin styles.
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import type { ToolResult } from "gui-chat-protocol";
+import { plugin } from "@mulmoclaude/collection-plugin/vue";
+import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
+
+defineProps<{
+  selectedResult: ToolResult | null;
+  sendTextMessage?: (text?: string) => void;
+}>();
+const emit = defineEmits<{ updateResult: [result: ToolResult] }>();
+
+const ChatView = plugin.viewComponent;
+
+const rootEl = ref<HTMLElement>();
+let registered: HTMLElement | ShadowRoot | null = null;
+
+onMounted(() => {
+  // Inside PluginFrame's shadow root, getRootNode() returns that ShadowRoot.
+  const root = rootEl.value?.getRootNode();
+  if (root instanceof ShadowRoot) {
+    registered = root;
+    pushCollectionTeleportTarget(root);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (registered) {
+    popCollectionTeleportTarget(registered);
+    registered = null;
+  }
+});
+</script>
+
+<template>
+  <div ref="rootEl">
+    <component
+      :is="ChatView"
+      :selected-result="selectedResult"
+      :send-text-message="sendTextMessage"
+      @update-result="(result: ToolResult) => emit('updateResult', result)"
+    />
+  </div>
+</template>

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -121,7 +121,7 @@ const hasContent = computed(() => results.value.length > 0);
         to render content here.
       </div>
       <template v-for="r in results" :key="r.uuid">
-        <PluginFrame v-if="getPlugin(r.toolName)" class="frame" :css="getPlugin(r.toolName)!.css">
+        <PluginFrame v-if="getPlugin(r.toolName)" class="frame" :css="getPlugin(r.toolName)!.css" :height="getPlugin(r.toolName)!.height">
           <component
             :is="getPlugin(r.toolName)!.viewComponent"
             :selected-result="r"

--- a/src/components/PluginFrame.vue
+++ b/src/components/PluginFrame.vue
@@ -44,7 +44,7 @@ import { ref, onMounted } from "vue";
 // `height` (optional): a fixed frame height for plugin views that rely on an
 // internal `h-full` (100%) layout rather than flowing at natural content height —
 // e.g. the collection card's table/kanban/custom-view iframe. Mirrors MulmoClaude's
-// StackView, which wraps such tools in a `min(100vh, 560px)` box. When set, the host
+// StackView, which wraps such tools in a fixed-height box. When set, the host
 // + shadow mount become that height so the plugin's `h-full` chain resolves; when
 // omitted, the frame flows naturally (chart/form/markdown).
 const props = defineProps<{ css?: string; height?: string }>();

--- a/src/components/PluginFrame.vue
+++ b/src/components/PluginFrame.vue
@@ -41,7 +41,13 @@ import { ref, onMounted } from "vue";
 // We Teleport the slotted view into the shadow root rather than mounting a separate
 // Vue app, so the plugin component stays in the parent app's context (props,
 // emits, provide/inject, reactivity all work normally).
-const props = defineProps<{ css?: string }>();
+// `height` (optional): a fixed frame height for plugin views that rely on an
+// internal `h-full` (100%) layout rather than flowing at natural content height —
+// e.g. the collection card's table/kanban/custom-view iframe. Mirrors MulmoClaude's
+// StackView, which wraps such tools in a `min(60vh, 560px)` box. When set, the host
+// + shadow mount become that height so the plugin's `h-full` chain resolves; when
+// omitted, the frame flows naturally (chart/form/markdown).
+const props = defineProps<{ css?: string; height?: string }>();
 
 const hostEl = ref<HTMLDivElement>();
 const target = ref<HTMLDivElement | null>(null);
@@ -65,13 +71,16 @@ onMounted(() => {
   mount.style.color = "#111827";
   mount.style.borderRadius = "8px";
   mount.style.overflow = "hidden";
+  // Carry the fixed height into the shadow so the plugin's internal h-full resolves
+  // (the host below is sized to props.height too).
+  if (props.height) mount.style.height = "100%";
   shadow.appendChild(mount);
   target.value = mount;
 });
 </script>
 
 <template>
-  <div ref="hostEl" class="plugin-frame-host">
+  <div ref="hostEl" class="plugin-frame-host" :style="height ? { height } : undefined">
     <Teleport v-if="target" :to="target">
       <slot />
     </Teleport>

--- a/src/components/PluginFrame.vue
+++ b/src/components/PluginFrame.vue
@@ -44,7 +44,7 @@ import { ref, onMounted } from "vue";
 // `height` (optional): a fixed frame height for plugin views that rely on an
 // internal `h-full` (100%) layout rather than flowing at natural content height —
 // e.g. the collection card's table/kanban/custom-view iframe. Mirrors MulmoClaude's
-// StackView, which wraps such tools in a `min(60vh, 560px)` box. When set, the host
+// StackView, which wraps such tools in a `min(100vh, 560px)` box. When set, the host
 // + shadow mount become that height so the plugin's `h-full` chain resolves; when
 // omitted, the frame flows naturally (chart/form/markdown).
 const props = defineProps<{ css?: string; height?: string }>();

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -54,6 +54,11 @@ async function apiPost<T>(url: string, body: unknown): Promise<CollectionApiResu
   }
 }
 
+/** Browser URL for a workspace-relative file path, via the raw-file route. */
+function rawFileUrl(value: unknown): string {
+  return `/api/files/raw?path=${encodeURIComponent(String(value))}`;
+}
+
 // Shared "not supported yet" results for the write/feeds/view capabilities.
 const UNSUPPORTED = "not supported in MulmoTerminal yet";
 const apiFail = { ok: false as const, error: UNSUPPORTED, status: 501 };
@@ -74,11 +79,13 @@ configureCollectionUi({
   personalRoleId: "personal",
   pinToggle: PinTogglePlaceholder,
 
-  // ── asset URLs: MulmoTerminal has no general raw-file serving route yet, so
-  //    image/file fields don't resolve (collections without them render fully). ──
-  fileAssetUrl: () => null,
+  // ── asset URLs → the raw workspace-file route (server/backends/files.ts).
+  //    Mirrors MulmoClaude's resolveImageSrc: data: URIs pass through, everything
+  //    else resolves to /api/files/raw?path=<workspace-relative>. fileRoutePath
+  //    (in-app File Explorer nav) stays null — MulmoTerminal has no file explorer. ──
+  imageSrc: (imageData) => (typeof imageData === "string" && imageData.startsWith("data:") ? imageData : rawFileUrl(imageData)),
+  fileAssetUrl: (value) => (typeof value === "string" && value.length > 0 ? rawFileUrl(value) : null),
   fileRoutePath: () => null,
-  imageSrc: () => "",
 
   // ── routing: no router; these are safe no-ops for an embedded card (wired to
   //    view-state in the Tier 2 toolbar). ──

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -1,0 +1,105 @@
+// Wire @mulmoclaude/collection-plugin/vue to MulmoTerminal. Imported for its side
+// effect from main.ts so the package's View layer can resolve data before any
+// presentCollection card mounts. MulmoTerminal's counterpart to MulmoClaude's
+// src/composables/collections/uiHost.ts — but a much leaner host (no router, no
+// vue-i18n host instance, no confirm/shortcut/notifier stores), so most write/chat/
+// favorite capabilities are stubs for this read-side increment.
+//
+// What's REAL here: fetchCollectionDetail + listCollections (→ the server read
+// routes over the shared workspace), localeTag, confirm. Everything else is a typed
+// failure / no-op until the interactive (Tier 1) and toolbar (Tier 2) work lands.
+import { defineComponent } from "vue";
+import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionApiResult } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity } from "@mulmoclaude/collection-plugin";
+
+// ── Modal teleport target (Shadow DOM) ──
+// PluginFrame mounts each card inside a per-instance shadow root, but
+// configureCollectionUi sets ONE global binding — so it can't statically know which
+// card's shadow root to teleport the record modal into. The card wrapper
+// (CollectionCardView) registers its own shadow root here on mount via
+// element.getRootNode(); the binding returns the top of the stack. Correct for the
+// common single-open-card case; simultaneous modals across multiple cards fall back
+// to the last-mounted card (accepted v1 limitation).
+const teleportStack: Array<HTMLElement | ShadowRoot> = [];
+export function pushCollectionTeleportTarget(target: HTMLElement | ShadowRoot): void {
+  teleportStack.push(target);
+}
+export function popCollectionTeleportTarget(target: HTMLElement | ShadowRoot): void {
+  const i = teleportStack.lastIndexOf(target);
+  if (i >= 0) teleportStack.splice(i, 1);
+}
+
+// Read helper: normalise fetch into the package's CollectionApiResult (the view
+// treats `ok:false` with `status` 404 as not-found, any other failure as a skip).
+async function apiGet<T>(url: string): Promise<CollectionApiResult<T>> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
+  }
+}
+
+// Shared "not supported yet" results for the write/feeds/view capabilities.
+const UNSUPPORTED = "not supported in MulmoTerminal yet";
+const apiFail = { ok: false as const, error: UNSUPPORTED, status: 501 };
+const mutationFail = { ok: false as const, error: UNSUPPORTED };
+
+// Renders nothing — MulmoTerminal has no favorites store yet (Tier 2).
+const PinTogglePlaceholder = defineComponent({ name: "CollectionPinTogglePlaceholder", render: () => null });
+
+configureCollectionUi({
+  // ── real (read side) ──
+  fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
+  listCollections: () => apiGet<CollectionsListResponse>("/api/collections/list"),
+  confirm: (options) => Promise.resolve(window.confirm(options.message)),
+  // MulmoTerminal has no host i18n; the plugin runs its own. Pick the browser's
+  // base language, defaulting to English.
+  localeTag: () => (navigator.language || "en").split("-")[0],
+  generalRoleId: "general",
+  personalRoleId: "personal",
+  pinToggle: PinTogglePlaceholder,
+
+  // ── asset URLs: MulmoTerminal has no general raw-file serving route yet, so
+  //    image/file fields don't resolve (collections without them render fully). ──
+  fileAssetUrl: () => null,
+  fileRoutePath: () => null,
+  imageSrc: () => "",
+
+  // ── routing: no router; these are safe no-ops for an embedded card (wired to
+  //    view-state in the Tier 2 toolbar). ──
+  routeSlug: () => undefined,
+  routeSelectedId: () => undefined,
+  isFeedRoute: () => false,
+  setSelectedId: () => {},
+  gotoIndex: () => {},
+  gotoDetail: () => {},
+  navigateToRecord: () => {},
+
+  // ── write / feeds / custom views: deferred to Tier 1. ──
+  createItem: () => Promise.resolve(apiFail),
+  updateItem: () => Promise.resolve(apiFail),
+  deleteItem: () => Promise.resolve(mutationFail),
+  deleteCollection: () => Promise.resolve(mutationFail),
+  deleteFeed: () => Promise.resolve(mutationFail),
+  runItemAction: () => Promise.resolve(apiFail),
+  runCollectionAction: () => Promise.resolve(apiFail),
+  refreshCollection: () => Promise.resolve(apiFail),
+  deleteView: () => Promise.resolve(mutationFail),
+  mintViewToken: () => Promise.resolve(apiFail),
+  fetchViewHtml: () => Promise.resolve({ ok: false as const, status: 501 }),
+  buildViewSrcdoc: () => "",
+  listFeeds: () => Promise.resolve(apiFail),
+
+  // ── favorites / chat / notifications: no stores yet (Tier 2). ──
+  reconcileShortcuts: () => Promise.resolve(),
+  unpin: () => Promise.resolve(false),
+  startChat: () => {},
+  notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
+
+  // ── Shadow-DOM modal target ── ShadowRoot is a valid Teleport target at runtime
+  //    though the declared type is string | HTMLElement.
+  modalTeleportTarget: () => (teleportStack[teleportStack.length - 1] ?? "body") as unknown as string | HTMLElement,
+});

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -5,13 +5,15 @@
 // vue-i18n host instance, no confirm/shortcut/notifier stores), so most write/chat/
 // favorite capabilities are stubs for this read-side increment.
 //
-// What's REAL here: fetchCollectionDetail + listCollections (→ the server read
-// routes over the shared workspace), localeTag, confirm. Everything else is a typed
-// failure / no-op until the interactive (Tier 1) and toolbar (Tier 2) work lands.
+// What's REAL here: fetchCollectionDetail + listCollections, the read-only custom
+// view surface (mintViewToken / fetchViewHtml / buildViewSrcdoc), localeTag, confirm.
+// Write / feeds / favorites / chat are typed failures / no-ops until the interactive
+// (Tier 1) and toolbar (Tier 2) work lands.
 import { defineComponent } from "vue";
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
-import type { CollectionApiResult } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity } from "@mulmoclaude/collection-plugin";
+import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
 
 // ── Modal teleport target (Shadow DOM) ──
 // PluginFrame mounts each card inside a per-instance shadow root, but
@@ -35,6 +37,16 @@ export function popCollectionTeleportTarget(target: HTMLElement | ShadowRoot): v
 async function apiGet<T>(url: string): Promise<CollectionApiResult<T>> {
   try {
     const res = await fetch(url);
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
+  }
+}
+
+async function apiPost<T>(url: string, body: unknown): Promise<CollectionApiResult<T>> {
+  try {
+    const res = await fetch(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
     if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
     return { ok: true, data: (await res.json()) as T };
   } catch (err) {
@@ -78,7 +90,21 @@ configureCollectionUi({
   gotoDetail: () => {},
   navigateToRecord: () => {},
 
-  // ── write / feeds / custom views: deferred to Tier 1. ──
+  // ── custom views (read-only): sandboxed-iframe HTML views over the shared
+  //    workspace. Mint a scoped token, fetch the view HTML, and wrap it in a
+  //    CSP-locked srcdoc with the token injected. ──
+  mintViewToken: (slug, viewId) => apiPost<CollectionViewToken>(`/api/collections/${encodeURIComponent(slug)}/view-token`, { viewId }),
+  fetchViewHtml: async (slug, viewId) => {
+    try {
+      const res = await fetch(`/api/collections/${encodeURIComponent(slug)}/view-file?id=${encodeURIComponent(viewId)}`);
+      return res.ok ? { ok: true as const, html: await res.text() } : { ok: false as const, status: res.status };
+    } catch {
+      return { ok: false as const, status: 0 };
+    }
+  },
+  buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
+
+  // ── write / feeds / view-delete: deferred to Tier 1. ──
   createItem: () => Promise.resolve(apiFail),
   updateItem: () => Promise.resolve(apiFail),
   deleteItem: () => Promise.resolve(mutationFail),
@@ -88,9 +114,6 @@ configureCollectionUi({
   runCollectionAction: () => Promise.resolve(apiFail),
   refreshCollection: () => Promise.resolve(apiFail),
   deleteView: () => Promise.resolve(mutationFail),
-  mintViewToken: () => Promise.resolve(apiFail),
-  fetchViewHtml: () => Promise.resolve({ ok: false as const, status: 501 }),
-  buildViewSrcdoc: () => "",
   listFeeds: () => Promise.resolve(apiFail),
 
   // ── favorites / chat / notifications: no stores yet (Tier 2). ──

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { createApp } from "vue";
 import "material-symbols/outlined.css";
 import "./style.css";
+// Configure the @mulmoclaude/collection-plugin UI binding (data fetch, asset URLs,
+// nav, confirm, modal teleport) once, before any presentCollection card mounts.
+import "./composables/collectionUi";
 import App from "./App.vue";
 
 createApp(App).mount("#app");

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -108,7 +108,7 @@ const PACKAGES: Record<string, Registration> = {
     // areas, and the custom-view iframe has no intrinsic content height). Give it a
     // fixed frame so that chain resolves — matches MulmoClaude's StackView
     // DEFAULT_PLUGIN_HEIGHT.
-    height: "min(100vh, 560px)",
+    height: "100vh",
   },
 };
 

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -108,7 +108,7 @@ const PACKAGES: Record<string, Registration> = {
     // areas, and the custom-view iframe has no intrinsic content height). Give it a
     // fixed frame so that chain resolves — matches MulmoClaude's StackView
     // DEFAULT_PLUGIN_HEIGHT.
-    height: "min(60vh, 560px)",
+    height: "min(100vh, 560px)",
   },
 };
 

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -9,8 +9,10 @@ import config from "../plugins/plugins.json";
 import { plugin as markdownPlugin } from "@mulmoclaude/markdown-plugin/vue";
 import { plugin as formPlugin } from "@mulmoclaude/form-plugin/vue";
 import { plugin as chartPlugin } from "@mulmoclaude/chart-plugin/vue";
+import { plugin as collectionPlugin } from "@mulmoclaude/collection-plugin/vue";
 import GenerateImagePlugin from "@mulmochat-plugin/generate-image/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
+import CollectionCardView from "./components/CollectionCardView.vue";
 // Import each package's compiled stylesheet as a STRING (?inline), not as a global
 // side-effect. GuiPanel injects it into a per-view Shadow DOM (see PluginFrame),
 // which encapsulates the plugin's Tailwind preflight so it can't clobber
@@ -18,11 +20,42 @@ import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import markdownCss from "@mulmoclaude/markdown-plugin/style.css?inline";
 import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
+import collectionCss from "@mulmoclaude/collection-plugin/style.css?inline";
 // The @mulmochat-plugin family (generate-image + its peer ui-image) ships incomplete
 // CSS — it assumes a Tailwind host. This is MulmoTerminal's Tailwind layer compiled
 // against those packages' dists (see src/plugin-tailwind.css), supplying the
 // utilities their components use.
 import mulmochatPluginCss from "./plugin-tailwind.css?inline";
+
+// The collection plugin renders ~56 icons via the classic `.material-icons` class
+// (plus a few `.material-symbols-outlined`). MulmoTerminal only loads the Material
+// Symbols font (main.ts), and in any case the global icon class rule can't pierce
+// the plugin's Shadow DOM — so the ligature names ("movie", "search", "arrow_upward")
+// render as plain TEXT. The font's `@font-face` IS global (document-level font-faces
+// apply inside shadow roots), so we just need the class rule inside the shadow:
+// map both icon classes to the loaded "Material Symbols Outlined" font (a superset
+// that supports the same ligature names). Prepended BEFORE the plugin's Tailwind so
+// the components' `text-sm`/`text-lg` size overrides still win (equal specificity →
+// later rule wins); unsized icons fall back to the 24px default here.
+const COLLECTION_ICON_CSS = `
+.material-icons, .material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga";
+}
+`;
 
 interface Registration {
   toolName: string;
@@ -59,6 +92,15 @@ const PACKAGES: Record<string, Registration> = {
     // ?? "en"), so it renders standalone. Its style.css is self-contained Tailwind.
     viewComponent: chartPlugin.viewComponent as Component,
     css: chartCss,
+  },
+  "@mulmoclaude/collection-plugin": {
+    toolName: collectionPlugin.toolDefinition.name,
+    // CollectionCardView wraps the package's chat View so it can register its shadow
+    // root as the record modal's teleport target (see the component + collectionUi).
+    // The binding (data fetch, asset URLs, nav, confirm) is configured once at
+    // startup by importing ./composables/collectionUi in main.ts.
+    viewComponent: CollectionCardView as Component,
+    css: COLLECTION_ICON_CSS + collectionCss,
   },
 };
 

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -61,6 +61,9 @@ interface Registration {
   toolName: string;
   viewComponent: Component;
   css?: string;
+  // Optional fixed frame height for views that rely on an internal h-full layout
+  // (vs flowing at natural content height). See PluginFrame's `height` prop.
+  height?: string;
 }
 
 // Statically-known packages, keyed by package name; the config gates which load.
@@ -101,6 +104,11 @@ const PACKAGES: Record<string, Registration> = {
     // startup by importing ./composables/collectionUi in main.ts.
     viewComponent: CollectionCardView as Component,
     css: COLLECTION_ICON_CSS + collectionCss,
+    // The collection View uses an internal h-full layout (table/kanban scroll
+    // areas, and the custom-view iframe has no intrinsic content height). Give it a
+    // fixed frame so that chain resolves — matches MulmoClaude's StackView
+    // DEFAULT_PLUGIN_HEIGHT.
+    height: "min(60vh, 560px)",
   },
 };
 

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -108,7 +108,7 @@ const PACKAGES: Record<string, Registration> = {
     // areas, and the custom-view iframe has no intrinsic content height). Give it a
     // fixed frame so that chain resolves — matches MulmoClaude's StackView
     // DEFAULT_PLUGIN_HEIGHT.
-    height: "100vh",
+    height: "80vh",
   },
 };
 

--- a/src/utils/customViewSrcdoc.spec.ts
+++ b/src/utils/customViewSrcdoc.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { buildCustomViewSrcdoc } from "./customViewSrcdoc";
+
+const boot = { slug: "watchlist", token: "tok", dataUrl: "/api/collections/watchlist/view-data", origin: "http://localhost:5173" };
+
+describe("buildCustomViewSrcdoc", () => {
+  it("injects __MC_VIEW with an absolutised dataUrl", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    expect(out).toContain("window.__MC_VIEW=");
+    expect(out).toContain('"dataUrl":"http://localhost:5173/api/collections/watchlist/view-data"');
+    expect(out).toContain('"token":"tok"');
+    expect(out).toContain('"slug":"watchlist"');
+  });
+
+  it("locks connect-src to the server origin only", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    const csp = /content="([^"]*)"/.exec(out)?.[1] ?? "";
+    expect(csp).toContain("connect-src http://localhost:5173");
+    expect(csp).toContain("default-src 'none'");
+    // connect-src must not be widened to https: (that's the exfil channel that matters).
+    expect(csp).not.toMatch(/connect-src[^;]*https:/);
+  });
+
+  it("allows https: images/media (matches MulmoClaude's documented tradeoff)", () => {
+    const csp = /content="([^"]*)"/.exec(buildCustomViewSrcdoc("<head></head>", boot))?.[1] ?? "";
+    expect(csp).toMatch(/img-src[^;]*https:/);
+    expect(csp).toMatch(/media-src[^;]*https:/);
+  });
+
+  it("injects into an existing <head>", () => {
+    const out = buildCustomViewSrcdoc('<head data-x="1"><title>t</title></head>', boot);
+    expect(out).toMatch(/<head data-x="1"><meta http-equiv="Content-Security-Policy"/);
+  });
+
+  it("wraps a fragment with no <head>", () => {
+    const out = buildCustomViewSrcdoc("<div>hi</div>", boot);
+    expect(out.startsWith("<!DOCTYPE html><html><head>")).toBe(true);
+    expect(out).toContain("<body><div>hi</div></body>");
+  });
+
+  it("escapes < in the injected JSON so a hostile value can't break out of <script>", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", { ...boot, token: "</script><script>alert(1)" });
+    expect(out).not.toContain("</script><script>alert(1)");
+    expect(out).toContain("\\u003c/script>\\u003cscript>alert(1)");
+  });
+});

--- a/src/utils/customViewSrcdoc.ts
+++ b/src/utils/customViewSrcdoc.ts
@@ -1,0 +1,67 @@
+// Build the sandboxed-iframe `srcdoc` for a custom collection view — MulmoTerminal's
+// port of MulmoClaude's customViewSrcdoc.ts + the buildCustomViewCsp policy.
+//
+// Injected at the START of <head> so the bootstrap runs before the view's own
+// scripts: (1) a CSP <meta> locking connect-src to the server origin (the view may
+// fetch its data endpoint but no third party), and (2)
+// `window.__MC_VIEW = { slug, token, dataUrl }` — the scoped token + absolute data
+// URL the view reads.
+
+// Curated CDN allowlist the LLM commonly pulls charting/util libs + fonts from.
+const ALLOWED_CDNS: readonly string[] = [
+  "https://cdn.jsdelivr.net",
+  "https://unpkg.com",
+  "https://cdnjs.cloudflare.com",
+  "https://fonts.googleapis.com",
+  "https://fonts.gstatic.com",
+  "https://cdn.plot.ly",
+];
+
+// CSP for a custom view. connect-src = the server origin ONLY (the exfiltration
+// channel that matters — fetch/XHR/WebSocket can reach only the view's own data
+// endpoint). script/style/font reuse the curated CDN allowlist; img/media also allow
+// any https: so feed records' external thumbnails / audio render (a one-way,
+// GET-only, response-unreadable channel — accepted, same as MulmoClaude). `origin`
+// MUST be explicit: the sandboxed iframe's origin is opaque, so `'self'` never matches.
+function buildCustomViewCsp(origin: string): string {
+  const cdns = ALLOWED_CDNS.join(" ");
+  return [
+    "default-src 'none'",
+    `script-src 'unsafe-inline' ${cdns}`,
+    `style-src 'unsafe-inline' ${cdns}`,
+    `font-src ${cdns}`,
+    `img-src ${origin} ${cdns} data: blob: https:`,
+    `media-src ${origin} https: data: blob:`,
+    `connect-src ${origin}`,
+  ].join("; ");
+}
+
+export interface CustomViewBootstrap {
+  slug: string;
+  /** Scoped capability token (Authorization: Bearer <token>). */
+  token: string;
+  /** Data endpoint URL; absolutised against `origin` when root-relative (the iframe
+   *  is `about:srcdoc`, so a relative `/api/...` would not resolve). */
+  dataUrl: string;
+  /** Explicit server origin — for the CSP and the absolute dataUrl. */
+  origin: string;
+}
+
+function absoluteDataUrl(dataUrl: string, origin: string): string {
+  return dataUrl.startsWith("/") ? `${origin}${dataUrl}` : dataUrl;
+}
+
+export function buildCustomViewSrcdoc(html: string, boot: CustomViewBootstrap): string {
+  const cspMeta = `<meta http-equiv="Content-Security-Policy" content="${buildCustomViewCsp(boot.origin)}">`;
+  // `<`-escape the JSON so a hostile token/slug value can't break out of <script>.
+  const json = JSON.stringify({
+    slug: boot.slug,
+    token: boot.token,
+    dataUrl: absoluteDataUrl(boot.dataUrl, boot.origin),
+  }).replace(/</g, "\\u003c");
+  const injection = `${cspMeta}<script>window.__MC_VIEW=${json};</script>`;
+  if (/<head\b[^>]*>/i.test(html)) {
+    return html.replace(/(<head\b[^>]*>)/i, `$1${injection}`);
+  }
+  return `<!DOCTYPE html><html><head>${injection}</head><body>${html}</body></html>`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,18 @@ export default defineConfig({
   // a global side-effect, so the app's styles are untouched.
   plugins: [vue(), tailwindcss()],
   server: {
+    // Disable Vite's dev CORS middleware. The app is same-origin in dev (the page
+    // and the proxied `/api` both live on :5173), so it needs no CORS headers from
+    // Vite. The one cross-origin consumer is a custom collection view: it renders in
+    // a sandboxed (opaque-origin) iframe whose fetch to
+    // `/api/collections/:slug/view-data` is cross-origin and preflighted. With Vite's
+    // CORS enabled, Vite answers that OPTIONS itself WITHOUT an
+    // `Access-Control-Allow-Origin` (it rejects the "null" origin) and the preflight
+    // fails before reaching the backend. Disabling it lets the preflight (and the
+    // request) flow through the proxy to Express, which sets the correct CORS headers
+    // (viewDataCors in server/backends/collections.ts). Production has no Vite proxy
+    // — the iframe hits Express directly — so this is dev-only. Matches MulmoClaude.
+    cors: false,
     proxy: {
       // socket.io pub/sub (sidebar activity). Must precede the "/ws" rule.
       "/ws/pubsub": {
@@ -21,6 +33,7 @@ export default defineConfig({
       },
       "/api": {
         target: "http://localhost:3456",
+        changeOrigin: true,
       },
     },
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,36 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@intlify/core-base@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.4.6.tgz#7402cd6f7e1c813e7a8370afa3654d2d9034783a"
+  integrity sha512-EOeHO95XESK9IFHgHeZXunsM/WBAoCA0DlaWODvx14vKmetAuS97t+l6Xe9hTUqntPpF93vtVSjjUDafw3wXMw==
+  dependencies:
+    "@intlify/devtools-types" "11.4.6"
+    "@intlify/message-compiler" "11.4.6"
+    "@intlify/shared" "11.4.6"
+
+"@intlify/devtools-types@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-types/-/devtools-types-11.4.6.tgz#2280698191c7a238f7ce9fe69cafba6280277b40"
+  integrity sha512-wowQPpNem56b2d43IJmqbrzG2FeBKe5f/kUGlpNuBmXs6OSqncF8m1+1lxHuW8ISZJF0ma2RkW3iLkw0g0G4VA==
+  dependencies:
+    "@intlify/core-base" "11.4.6"
+    "@intlify/shared" "11.4.6"
+
+"@intlify/message-compiler@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.4.6.tgz#4afde994de403f2e2d9569cd52eae7707f5d3008"
+  integrity sha512-5nj3jULqeTAC1WovwMs1LQWgatTa2pM/rXN9T3XW8rdOtXW9ZF6/GLSNFTKDQmPLwclhPdgUWLJ/4w3fMeeC/Q==
+  dependencies:
+    "@intlify/shared" "11.4.6"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.4.6.tgz#06431217c1ea12f91b303f026f485eb0a4cebe6a"
+  integrity sha512-m1p1HHAMLhqSpTRH7VnXdrN0CQ4y+9vunFkpLkbD8soIuBsnQdawZXqMCgvwI2UVF9Ww7sVaw7g9tV2VO7shoA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -521,6 +551,14 @@
   version "0.1.1"
   resolved "https://registry.npmjs.org/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.1.tgz#bef604d53e82a1d406a65ddde3e6c3cdff9cc6e3"
   integrity sha512-Hv+FyTSiPWsF+eaxmBQ0Le8tu4FLnFMvmMQ+c6/MmM1gvHe49SrHvBcEYvSQb9bkNghJRsgSV0tADVjPFPwZMA==
+
+"@mulmoclaude/collection-plugin@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.5.1.tgz#848fa5639dcba569e8570833dee85484106e3cb0"
+  integrity sha512-krK2hHe1GLaVPoKr6MzyZNRGeWVuLT8DrJklGdNpiLzhk8UfwTgS/OE8kd938B1g5yqqANNpkF2G2vaoZ//Lwg==
+  dependencies:
+    vuedraggable "^4.1.0"
+    zod "^4.4.3"
 
 "@mulmoclaude/form-plugin@^0.1.1":
   version "0.1.1"
@@ -1196,6 +1234,11 @@
   dependencies:
     "@vue/compiler-dom" "3.5.38"
     "@vue/shared" "3.5.38"
+
+"@vue/devtools-api@^6.5.0":
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
 
 "@vue/language-core@3.3.5":
   version "3.3.5"
@@ -3754,7 +3797,12 @@ socks@^2.8.3:
     ip-address "^10.1.1"
     smart-buffer "^4.2.0"
 
-source-map-js@^1.2.1:
+sortablejs@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
+  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
+
+source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -4133,6 +4181,16 @@ vue-eslint-parser@^10.4.1:
     esquery "^1.6.0"
     semver "^7.6.3"
 
+vue-i18n@^11.4.4:
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-11.4.6.tgz#6ce49dc15b128b5de6e3813cf06f7de5410d9ae3"
+  integrity sha512-l0gE7Rfy0phCa5ChKYkOq543Wgd39BCK6hkktfr1Ed4D99oRkgPK9ffShASZdeC8OJxGfdWmpYoAaAH6iLEuIg==
+  dependencies:
+    "@intlify/core-base" "11.4.6"
+    "@intlify/devtools-types" "11.4.6"
+    "@intlify/shared" "11.4.6"
+    "@vue/devtools-api" "^6.5.0"
+
 vue-tsc@^3.2.8:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-3.3.5.tgz#080783e24add23cf860647e905a7f0506c70c21e"
@@ -4151,6 +4209,13 @@ vue@^3.5.34:
     "@vue/runtime-dom" "3.5.38"
     "@vue/server-renderer" "3.5.38"
     "@vue/shared" "3.5.38"
+
+vuedraggable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-4.1.0.tgz#edece68adb8a4d9e06accff9dfc9040e66852270"
+  integrity sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==
+  dependencies:
+    sortablejs "1.14.0"
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"
@@ -4355,7 +4420,7 @@ zod@^3.24.1:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-"zod@^3.25 || ^4.0":
+"zod@^3.25 || ^4.0", zod@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## What

First increment of the collection-plugin integration: **`presentCollection` chat cards render real collections from the shared workspace** — table/kanban/custom (sandboxed-iframe) views, with images. Read-side foundation toward the collections toolbar (Tier 2).

**Needs zero MulmoClaude changes** — everything required ships in `@mulmoclaude/collection-plugin@0.5.1`.

## Changes

**Server**
- `server/backends/collections.ts` — `configureCollectionHost` over the shared workspace (`CLAUDE_CWD`) with MulmoClaude's exact path layout; read routes `GET /api/collections/list` and `/:slug/detail`; and the read-only custom-view surface: `view-file` (HTML), `view-token` (scoped token), `view-data` (enriched `{ items }`, token-guarded + CORS for the opaque-origin iframe).
- `server/backends/viewToken.ts` — HMAC scoped-token mint/verify/require/clamp (port of MulmoClaude's), keyed by a per-process secret.
- `server/backends/files.ts` — `GET /api/files/raw?path=` (workspace-file serving for image/file fields + custom-view `<img>` URLs): path containment, MIME, size caps, Range, and MulmoClaude's `sandbox`+`nosniff` security headers.
- `server/plugins-registry.ts` — `loadPackage` resolves a sole `execute*` export so the collection core loads like the others.

**Frontend**
- `src/composables/collectionUi.ts` — the `CollectionUi` binding: real `fetchCollectionDetail`/`listCollections`/`confirm`/`localeTag`, read-only custom views (`mintViewToken`/`fetchViewHtml`/`buildViewSrcdoc`), and `imageSrc`/`fileAssetUrl` → the raw-file route; write/feeds/favorites/chat stubbed; teleport-target stack for the Shadow-DOM modal.
- `src/utils/customViewSrcdoc.ts` — sandboxed `srcdoc` builder + CSP policy.
- `src/components/CollectionCardView.vue` — wraps the package View, registers its shadow root as the modal teleport target, and fills the fixed-height frame.
- `PluginFrame`/`GuiPanel`/registry — a fixed frame `height` (`100vh` for the collection card) threaded through the Shadow DOM so the View's `h-full` layout resolves (matches MulmoClaude's StackView).
- Registered the ToolPlugin in `plugins-registry.ts` + `plugins.json`; binding configured in `main.ts`.
- **Icons** — shadow-scoped rule mapping `.material-icons`/`.material-symbols-outlined` to the loaded "Material Symbols Outlined" font (the plugin's glyphs rendered as text otherwise).

**Dev** — `vite.config.ts`: `server.cors: false` + `changeOrigin` so the sandboxed iframe's `view-data` preflight reaches Express (matches MulmoClaude).

**Deps** — `@mulmoclaude/collection-plugin@^0.5.1`, `vue-i18n@^11`.

## Verification

- client + server typecheck, `yarn build`, `yarn lint`, 29 tests — all pass
- live: collections list/detail, custom-view round-trip (`view-token`→`view-file`→`view-data`), and `/api/files/raw` (200 + full bytes, traversal → 403, missing → 404); preflight through the Vite proxy → 204 with ACAO; icon + height fixes verified via Puppeteer

## Not in this PR (next)

Tier 1 (write routes / interactive editing) and **Tier 2 — the collections toolbar**: shared favorites (`/api/shortcuts` over `config/shortcuts.json`), a toolbar launcher, and a state-based browse panel. See `docs/collection-plugin-integration.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)