### PR TITLE
feat: Tier 2 collections toolbar (favorites + full-screen browse)

### DIFF
--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -215,15 +215,27 @@ MulmoTerminal equivalent needs three pieces, adapted to a no-router, state-drive
 
 ---
 
-## Open questions for the maintainers
+## Resolved decisions
 
-- **Shortcuts sharing**: shared package (recommended; the only optional MulmoClaude change) vs
-  reimplement-verbatim + format test?
-- **Browse panel placement**: replace the GuiPanel content, a new tab/pane, or overlay?
-- **CSS isolation**: keep the shadow frame (and the teleport-target wrapper) or treat the collection
-  plugin as first-party in light DOM?
-- **Raw-file route**: add one so `image`/`file` fields render, or accept the v1 gap?
-- **`/feeds`**: wanted, or collections-only?
+- **Shortcuts sharing** → **reimplement verbatim + fixture test** (`server/backends/shortcuts.ts` +
+  `src/types/shortcuts.ts`, `shortcuts.spec.ts` pins the `{ shortcuts: [...] }` wrapper). Keeps
+  MulmoTerminal MulmoClaude-change-free; the shared file is the contract.
+- **Browse panel placement** → **full-screen overlay** (`CollectionsBrowseOverlay.vue`), driven by
+  `useCollectionBrowse` view-state; the binding's nav fns map onto it.
+- **CSS isolation** → keep the shadow frame (the overlay reuses `PluginFrame` + `collectionShadowCss`,
+  and registers its shadow root as the modal teleport target like the card).
+- **Raw-file route** → added (`/api/files/raw`), so `image`/`file` fields render.
+- **`/feeds`** → the launcher/overlay support `kind: "feed"` shortcuts, but the collections index
+  filters feeds out; a dedicated feeds index/`FeedsView` is deferred.
+
+## Tier 2 status (implemented)
+
+Shipped: shared favorites (`GET/PUT /api/shortcuts` over `config/shortcuts.json`), `useShortcuts` store
++ `PinToggle`, the toolbar launcher (`<header class="toolbar">`: a "Collections" button + one per
+favorite), and the full-screen browse overlay (`CollectionsIndexView` / standalone `CollectionView`
+via `useCollectionBrowse`). Verified: MulmoClaude's pinned collections appear in MulmoTerminal's
+toolbar from the shared file; the overlay opens and the index renders. Still open: `startChat` is a
+no-op (collection "create"/action buttons that seed a chat are inert), and Tier 1 write routes.
 
 Bottom line: **the package is drop-in-ready and needs zero MulmoClaude changes.** The work is entirely
 in MulmoTerminal: server read engine + routes, the frontend ToolPlugin + binding + teleport wrapper,

--- a/server/backends/shortcuts.spec.ts
+++ b/server/backends/shortcuts.spec.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { normalizeShortcuts, mountShortcutsRoutes } from "./shortcuts.js";
+
+describe("normalizeShortcuts", () => {
+  it("drops malformed entries and dedupes on (kind, slug)", () => {
+    const out = normalizeShortcuts([
+      { kind: "collection", slug: "a", title: "A", icon: "star" },
+      { kind: "bogus", slug: "x", title: "X", icon: "y" }, // bad kind → dropped
+      { kind: "feed", slug: "" }, // empty slug → dropped
+      { kind: "collection", slug: "a", title: "dupe" }, // dupe (kind,slug) → dropped
+      { kind: "feed", slug: "b" }, // defaults title→slug, icon→bookmark
+      "not an object",
+    ]);
+    expect(out).toEqual([
+      { kind: "collection", slug: "a", title: "A", icon: "star" },
+      { kind: "feed", slug: "b", title: "b", icon: "bookmark" },
+    ]);
+  });
+
+  it("returns [] for non-array input", () => {
+    expect(normalizeShortcuts(undefined)).toEqual([]);
+    expect(normalizeShortcuts({ shortcuts: [] })).toEqual([]);
+  });
+});
+
+describe("/api/shortcuts routes", () => {
+  let ws: string;
+  let server: Server;
+  let base: string;
+
+  beforeEach(async () => {
+    ws = mkdtempSync(path.join(tmpdir(), "mt-sc-"));
+    const app = express();
+    app.use(express.json());
+    mountShortcutsRoutes(app, { workspace: ws });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const addr = server.address();
+    base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+  });
+
+  afterEach(() => {
+    server?.close();
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  it("GET returns [] when the file is absent", async () => {
+    const res = await fetch(`${base}/api/shortcuts`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ shortcuts: [] });
+  });
+
+  it("PUT persists the OBJECT-WRAPPER format and GET round-trips it", async () => {
+    const shortcuts = [{ kind: "collection", slug: "watchlist", title: "映画", icon: "movie" }];
+    const put = await fetch(`${base}/api/shortcuts`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ shortcuts }),
+    });
+    expect(put.status).toBe(200);
+    expect(await put.json()).toEqual({ shortcuts });
+
+    // On-disk: object wrapper { shortcuts: [...] }, NOT a bare array — the contract
+    // MulmoClaude shares.
+    const onDisk = JSON.parse(readFileSync(path.join(ws, "config", "shortcuts.json"), "utf8"));
+    expect(Array.isArray(onDisk)).toBe(false);
+    expect(onDisk).toEqual({ shortcuts });
+
+    expect(await (await fetch(`${base}/api/shortcuts`)).json()).toEqual({ shortcuts });
+  });
+
+  it("PUT normalises (drops junk, dedupes) before persisting", async () => {
+    const res = await fetch(`${base}/api/shortcuts`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        shortcuts: [
+          { kind: "collection", slug: "a" },
+          { kind: "nope", slug: "b" },
+          { kind: "collection", slug: "a" },
+        ],
+      }),
+    });
+    expect(await res.json()).toEqual({ shortcuts: [{ kind: "collection", slug: "a", title: "a", icon: "bookmark" }] });
+  });
+
+  it("PUT 400s when the body is not { shortcuts: [...] }", async () => {
+    const res = await fetch(`${base}/api/shortcuts`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ nope: true }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("reads an existing MulmoClaude-written file (wrapper format)", async () => {
+    mkdirSync(path.join(ws, "config"), { recursive: true });
+    writeFileSync(path.join(ws, "config", "shortcuts.json"), JSON.stringify({ shortcuts: [{ kind: "feed", slug: "news", title: "News", icon: "rss_feed" }] }));
+    const res = await fetch(`${base}/api/shortcuts`);
+    expect(await res.json()).toEqual({ shortcuts: [{ kind: "feed", slug: "news", title: "News", icon: "rss_feed" }] });
+  });
+});

--- a/server/backends/shortcuts.spec.ts
+++ b/server/backends/shortcuts.spec.ts
@@ -100,6 +100,21 @@ describe("/api/shortcuts routes", () => {
     expect(res.status).toBe(400);
   });
 
+  it("handles concurrent PUTs without ENOENT/500 (unique temp files)", async () => {
+    const put = (slug: string) =>
+      fetch(`${base}/api/shortcuts`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ shortcuts: [{ kind: "collection", slug }] }),
+      });
+    const results = await Promise.all(Array.from({ length: 8 }, (_, i) => put(`c${i}`)));
+    expect(results.every((r) => r.status === 200)).toBe(true);
+    // The file is intact (valid wrapper) — one of the writers won, none half-written.
+    const onDisk = JSON.parse(readFileSync(path.join(ws, "config", "shortcuts.json"), "utf8"));
+    expect(Array.isArray(onDisk.shortcuts)).toBe(true);
+    expect(onDisk.shortcuts).toHaveLength(1);
+  });
+
   it("reads an existing MulmoClaude-written file (wrapper format)", async () => {
     mkdirSync(path.join(ws, "config"), { recursive: true });
     writeFileSync(path.join(ws, "config", "shortcuts.json"), JSON.stringify({ shortcuts: [{ kind: "feed", slug: "news", title: "News", icon: "rss_feed" }] }));

--- a/server/backends/shortcuts.ts
+++ b/server/backends/shortcuts.ts
@@ -11,6 +11,7 @@
 //   PUT /api/shortcuts  → replace the whole array → { shortcuts }
 import path from "node:path";
 import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
 import type { Express, Request, Response } from "express";
 
 /** Which route family a shortcut points at. */
@@ -92,9 +93,18 @@ async function writeShortcuts(workspace: string, input: unknown): Promise<Shortc
   const payload: ShortcutsFile = { shortcuts: clean };
   const file = shortcutsFilePath(workspace);
   await fs.mkdir(path.dirname(file), { recursive: true });
-  const tmp = `${file}.${process.pid}.tmp`;
-  await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-  await fs.rename(tmp, file);
+  // Unique temp name per write so concurrent PUTs (two tabs / clients) can't clobber
+  // each other's temp file and ENOENT on rename. Each writes its own temp then
+  // atomically renames onto `file` — last writer wins, which is fine for a
+  // replace-all endpoint (the client also serializes its own PUTs).
+  const tmp = `${file}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    await fs.rename(tmp, file);
+  } catch (err) {
+    await fs.rm(tmp, { force: true }); // don't leave a stray temp on failure
+    throw err;
+  }
   return clean;
 }
 

--- a/server/backends/shortcuts.ts
+++ b/server/backends/shortcuts.ts
@@ -1,0 +1,129 @@
+// Shared launcher shortcuts (pinned collections / feeds) over
+// `<workspace>/config/shortcuts.json`. MulmoClaude and MulmoTerminal SHARE this
+// file — favoriting a collection in one app must show up in the other — so the
+// on-disk format is the contract: an OBJECT WRAPPER `{ shortcuts: Shortcut[] }`
+// (not a bare array), matching mulmoclaude/src/types/shortcuts.ts +
+// server/utils/files/shortcuts-io.ts. Reimplemented verbatim here (the format is
+// tiny and stable; shortcuts.spec.ts pins it) rather than sharing a package, so
+// MulmoTerminal stays MulmoClaude-change-free.
+//
+//   GET /api/shortcuts  → { shortcuts }
+//   PUT /api/shortcuts  → replace the whole array → { shortcuts }
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import type { Express, Request, Response } from "express";
+
+/** Which route family a shortcut points at. */
+export const SHORTCUT_KINDS = ["collection", "feed"] as const;
+export type ShortcutKind = (typeof SHORTCUT_KINDS)[number];
+
+export interface Shortcut {
+  kind: ShortcutKind;
+  /** Target collection / feed slug. */
+  slug: string;
+  /** Cached display label (refreshed on reconcile). */
+  title: string;
+  /** Cached material-symbols glyph (refreshed on reconcile). */
+  icon: string;
+}
+
+/** On-disk shape — object wrapper (not a bare array) so the schema can grow
+ *  without a migration. THIS is the cross-app contract. */
+interface ShortcutsFile {
+  shortcuts: Shortcut[];
+}
+
+const KINDS = new Set<string>(SHORTCUT_KINDS);
+
+/** True when two shortcuts target the same thing (the dedupe key). */
+function sameShortcut(left: Pick<Shortcut, "kind" | "slug">, right: Pick<Shortcut, "kind" | "slug">): boolean {
+  return left.kind === right.kind && left.slug === right.slug;
+}
+
+/** Coerce arbitrary JSON into a clean `Shortcut[]`: drop malformed entries (bad
+ *  kind / empty slug / non-string fields), default title→slug and icon→"bookmark",
+ *  and dedupe on (kind, slug) keeping the first. Pure — exported for tests. */
+export function normalizeShortcuts(input: unknown): Shortcut[] {
+  if (!Array.isArray(input)) return [];
+  const out: Shortcut[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const candidate = raw as Record<string, unknown>;
+    const { kind, slug, title, icon } = candidate;
+    if (typeof kind !== "string" || !KINDS.has(kind)) continue;
+    if (typeof slug !== "string" || slug.length === 0) continue;
+    const entry: Shortcut = {
+      kind: kind as ShortcutKind,
+      slug,
+      title: typeof title === "string" ? title : slug,
+      icon: typeof icon === "string" && icon.length > 0 ? icon : "bookmark",
+    };
+    if (out.some((existing) => sameShortcut(existing, entry))) continue;
+    out.push(entry);
+  }
+  return out;
+}
+
+function shortcutsFilePath(workspace: string): string {
+  return path.join(workspace, "config", "shortcuts.json");
+}
+
+/** Read the pinned shortcuts. Missing / unreadable / malformed → `[]`. */
+async function readShortcuts(workspace: string): Promise<Shortcut[]> {
+  let text: string;
+  try {
+    text = await fs.readFile(shortcutsFilePath(workspace), "utf8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(text) as Partial<ShortcutsFile>;
+    return normalizeShortcuts(parsed?.shortcuts);
+  } catch {
+    return [];
+  }
+}
+
+/** Replace the full list. Normalises (validate + dedupe) before an atomic write
+ *  (temp file + rename) so the on-disk file is always clean and never half-written.
+ *  Returns the canonical list. */
+async function writeShortcuts(workspace: string, input: unknown): Promise<Shortcut[]> {
+  const clean = normalizeShortcuts(input);
+  const payload: ShortcutsFile = { shortcuts: clean };
+  const file = shortcutsFilePath(workspace);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  await fs.rename(tmp, file);
+  return clean;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function mountShortcutsRoutes(app: Express, deps: { workspace: string }): void {
+  app.get("/api/shortcuts", async (_req: Request, res: Response) => {
+    try {
+      res.json({ shortcuts: await readShortcuts(deps.workspace) });
+    } catch (err) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // The client owns ordering / add / remove and sends the whole array; the server
+  // normalises (validate kind, non-empty slug, dedupe) before persisting. A single
+  // replace endpoint avoids add/remove route sprawl.
+  app.put("/api/shortcuts", async (req: Request, res: Response) => {
+    const incoming = (req.body ?? {}) as { shortcuts?: unknown };
+    if (!Array.isArray(incoming.shortcuts)) {
+      res.status(400).json({ error: "Request body must be { shortcuts: Shortcut[] }" });
+      return;
+    }
+    try {
+      res.json({ shortcuts: await writeShortcuts(deps.workspace, incoming.shortcuts) });
+    } catch (err) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
+import { mountShortcutsRoutes } from "./backends/shortcuts.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -522,6 +523,10 @@ mountCollectionRoutes(app);
 // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
 // fields and custom-view <img> URLs. Rooted at the shared workspace.
 mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
+// Shared launcher favorites (GET/PUT /api/shortcuts) over the same
+// <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.
+mountShortcutsRoutes(app, { workspace: CLAUDE_CWD });
 
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,13 @@ import SessionTabBar from "./components/SessionTabBar.vue";
 import TerminalView from "./components/Terminal.vue";
 import GuiPanel from "./components/GuiPanel.vue";
 import ToolsPane from "./components/ToolsPane.vue";
+import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
+import { useShortcuts } from "./composables/useShortcuts";
+import { browseGotoIndex, browseGotoDetail } from "./composables/useCollectionBrowse";
+
+// Shared launcher favorites (pinned collections / feeds), backing the toolbar.
+const { shortcuts } = useShortcuts();
 
 const activeId = ref<string | null>(null);
 const connectKey = ref(0);
@@ -137,6 +143,23 @@ function onSession(id: string) {
   <div class="shell">
     <header class="toolbar">
       <span class="toolbar-title">MulmoTerminal</span>
+      <nav class="launcher" aria-label="Collections">
+        <button type="button" class="launcher-btn" title="Browse collections" @click="browseGotoIndex('collection')">
+          <span class="material-symbols-outlined">apps</span>
+          <span class="launcher-label">Collections</span>
+        </button>
+        <button
+          v-for="s in shortcuts"
+          :key="`${s.kind}:${s.slug}`"
+          type="button"
+          class="launcher-btn"
+          :title="s.title"
+          @click="browseGotoDetail(s.kind, s.slug)"
+        >
+          <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
+          <span class="launcher-label">{{ s.title }}</span>
+        </button>
+      </nav>
     </header>
     <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
       <Sidebar
@@ -187,6 +210,9 @@ function onSession(id: string) {
         <ToolsPane v-if="showTools" :session-id="activeId" @close="toggleTools" />
       </div>
     </div>
+    <!-- Full-screen collection browser; shown when the launcher / an index card / a
+         ref hop opens it (driven by useCollectionBrowse). -->
+    <CollectionsBrowseOverlay />
   </div>
 </template>
 
@@ -215,6 +241,44 @@ function onSession(id: string) {
   font-size: 14px;
   color: #e6e6f0;
   letter-spacing: 0.02em;
+}
+
+/* Collections launcher: a "Collections" button + one per pinned favorite. */
+.launcher {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 16px;
+  min-width: 0;
+  overflow-x: auto;
+}
+.launcher-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid #2a3a66;
+  background: #1d2b4e;
+  color: #c8d2f0;
+  border-radius: 14px;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.launcher-btn:hover {
+  background: #26375f;
+  color: #fff;
+}
+.launcher-btn .material-symbols-outlined {
+  font-size: 17px;
+  line-height: 1;
+}
+.launcher-label {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .app {

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,10 +8,17 @@ import ToolsPane from "./components/ToolsPane.vue";
 import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
 import { useShortcuts } from "./composables/useShortcuts";
-import { browseGotoIndex, browseGotoDetail } from "./composables/useCollectionBrowse";
+import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
+import type { Shortcut } from "./types/shortcuts";
 
 // Shared launcher favorites (pinned collections / feeds), backing the toolbar.
 const { shortcuts } = useShortcuts();
+// Toolbar tabs reflect the browse view-state: Chat (overlay closed) | Collections
+// (index open) | a favorite (its detail open).
+const { view: browseView, isOpen: browseOpen } = useCollectionBrowse();
+function favActive(s: Shortcut): boolean {
+  return browseView.value.mode === "detail" && browseView.value.kind === s.kind && browseView.value.slug === s.slug;
+}
 
 const activeId = ref<string | null>(null);
 const connectKey = ref(0);
@@ -143,21 +150,31 @@ function onSession(id: string) {
   <div class="shell">
     <header class="toolbar">
       <span class="toolbar-title">MulmoTerminal</span>
-      <nav class="launcher" aria-label="Collections">
-        <button type="button" class="launcher-btn" title="Browse collections" @click="browseGotoIndex('collection')">
+      <nav class="launcher" aria-label="Views">
+        <button type="button" class="launcher-btn" :class="{ active: !browseOpen }" title="Chat" aria-label="Chat" @click="browseClose">
+          <span class="material-symbols-outlined">chat</span>
+        </button>
+        <button
+          type="button"
+          class="launcher-btn"
+          :class="{ active: browseView.mode === 'index' }"
+          title="Collections"
+          aria-label="Collections"
+          @click="browseGotoIndex('collection')"
+        >
           <span class="material-symbols-outlined">apps</span>
-          <span class="launcher-label">Collections</span>
         </button>
         <button
           v-for="s in shortcuts"
           :key="`${s.kind}:${s.slug}`"
           type="button"
           class="launcher-btn"
+          :class="{ active: favActive(s) }"
           :title="s.title"
+          :aria-label="s.title"
           @click="browseGotoDetail(s.kind, s.slug)"
         >
           <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
-          <span class="launcher-label">{{ s.title }}</span>
         </button>
       </nav>
     </header>
@@ -243,11 +260,11 @@ function onSession(id: string) {
   letter-spacing: 0.02em;
 }
 
-/* Collections launcher: a "Collections" button + one per pinned favorite. */
+/* Toolbar tabs: Chat + Collections + one per pinned favorite. Icon-only. */
 .launcher {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   margin-left: 16px;
   min-width: 0;
   overflow-x: auto;
@@ -255,30 +272,28 @@ function onSession(id: string) {
 .launcher-btn {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  height: 28px;
-  padding: 0 10px;
-  border: 1px solid #2a3a66;
-  background: #1d2b4e;
-  color: #c8d2f0;
-  border-radius: 14px;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  white-space: nowrap;
+  justify-content: center;
+  flex: 0 0 auto;
+  height: 30px;
+  width: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #9aa6cc;
+  border-radius: 6px;
   cursor: pointer;
 }
 .launcher-btn:hover {
   background: #26375f;
   color: #fff;
 }
-.launcher-btn .material-symbols-outlined {
-  font-size: 17px;
-  line-height: 1;
+.launcher-btn.active {
+  background: #2f59c0;
+  color: #fff;
 }
-.launcher-label {
-  max-width: 140px;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.launcher-btn .material-symbols-outlined {
+  font-size: 19px;
+  line-height: 1;
 }
 
 .app {

--- a/src/collectionShadowCss.ts
+++ b/src/collectionShadowCss.ts
@@ -1,0 +1,32 @@
+// The compiled CSS injected into the collection plugin's Shadow DOM — used by both
+// the chat card (plugins-registry) and the full-screen browse overlay. Combines the
+// package's Tailwind sheet with an icon rule, since:
+//   - the package's `style.css` carries its components' Tailwind classes, but
+//   - the plugin renders ~56 `.material-icons` glyphs whose class rule can't pierce
+//     the shadow root (and `material-icons` isn't loaded), so map both icon classes
+//     to the globally-loaded "Material Symbols Outlined" font (same ligature names).
+// Prepended BEFORE the Tailwind sheet so the components' `text-sm`/`text-lg` size
+// overrides still win; unsized icons fall back to the 24px default here.
+import collectionCss from "@mulmoclaude/collection-plugin/style.css?inline";
+
+const ICON_CSS = `
+.material-icons, .material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga";
+}
+`;
+
+export const collectionShadowCss = ICON_CSS + collectionCss;

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -5,13 +5,16 @@
 // inside a PluginFrame shadow root with the collection styles, exactly like the chat
 // card. Opened by the toolbar launcher / index cards / ref hops via the binding's nav
 // capabilities (collectionUi.ts).
-import { onBeforeUnmount, ref, watch } from "vue";
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { CollectionsIndexView, CollectionView } from "@mulmoclaude/collection-plugin/vue";
 import PluginFrame from "./PluginFrame.vue";
 import { collectionShadowCss } from "../collectionShadowCss";
-import { useCollectionBrowse, browseGotoIndex } from "../composables/useCollectionBrowse";
+import { useCollectionBrowse } from "../composables/useCollectionBrowse";
 import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
 
+// Navigation is the toolbar's job (the Chat tab closes this; Collections / favorite
+// tabs switch what it shows), so the overlay itself carries no chrome — it just fills
+// the page below the toolbar.
 const { view, isOpen, close } = useCollectionBrowse();
 
 // Register this overlay's shadow root as the record-modal teleport target while a
@@ -34,86 +37,38 @@ watch(probe, (el) => {
     pushCollectionTeleportTarget(root);
   }
 });
-onBeforeUnmount(unregister);
+onBeforeUnmount(() => {
+  unregister();
+  window.removeEventListener("keydown", onKeydown);
+});
 
-function backToIndex(): void {
-  if (view.value.mode === "detail") browseGotoIndex(view.value.kind);
-}
-
-// Close on Escape for keyboard users.
+// Close on Escape (window-level so it fires without focusing the overlay).
 function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape") close();
+  if (e.key === "Escape" && isOpen.value) close();
 }
+onMounted(() => window.addEventListener("keydown", onKeydown));
 </script>
 
 <template>
-  <div v-if="isOpen" class="browse-overlay" role="dialog" aria-modal="true" aria-label="Collections" tabindex="-1" @keydown="onKeydown">
-    <header class="browse-chrome">
-      <button v-if="view.mode === 'detail'" type="button" class="chrome-btn" title="Back to index" aria-label="Back to index" @click="backToIndex">
-        <span class="material-symbols-outlined">arrow_back</span>
-      </button>
-      <span class="chrome-title">{{ view.mode === "detail" && view.kind === "feed" ? "Feeds" : "Collections" }}</span>
-      <button type="button" class="chrome-btn close" title="Close" aria-label="Close" @click="close">
-        <span class="material-symbols-outlined">close</span>
-      </button>
-    </header>
-    <div class="browse-body">
-      <PluginFrame :css="collectionShadowCss" height="100%">
-        <div ref="probe" style="height: 100%">
-          <CollectionsIndexView v-if="view.mode === 'index'" />
-          <CollectionView v-else-if="view.mode === 'detail'" />
-        </div>
-      </PluginFrame>
-    </div>
+  <div v-if="isOpen" class="browse-overlay" role="region" aria-label="Collections">
+    <PluginFrame :css="collectionShadowCss" height="100%">
+      <div ref="probe" style="height: 100%">
+        <CollectionsIndexView v-if="view.mode === 'index'" />
+        <CollectionView v-else-if="view.mode === 'detail'" />
+      </div>
+    </PluginFrame>
   </div>
 </template>
 
 <style scoped>
+/* Fills the page BELOW the toolbar (40px) — the toolbar stays visible + clickable. */
 .browse-overlay {
   position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  flex-direction: column;
+  top: 40px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
   background: #0b1020;
-}
-.browse-chrome {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: #16213e;
-  color: #e0e0e0;
-  border-bottom: 1px solid #2a2a4e;
-  font-family: system-ui, sans-serif;
-}
-.chrome-title {
-  font-weight: 600;
-  font-size: 14px;
-}
-.chrome-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 32px;
-  width: 32px;
-  border: none;
-  background: transparent;
-  color: #b9c2e0;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.chrome-btn:hover {
-  color: #fff;
-  background: #243056;
-}
-.chrome-btn.close {
-  margin-left: auto;
-}
-.browse-body {
-  flex: 1 1 auto;
-  min-height: 0;
-  padding: 12px;
 }
 </style>

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+// Full-screen collection browser — the no-router replacement for MulmoClaude's
+// /collections + /collections/:slug pages. Driven by useCollectionBrowse: shows the
+// CollectionsIndexView (index) or a standalone CollectionView (detail), rendered
+// inside a PluginFrame shadow root with the collection styles, exactly like the chat
+// card. Opened by the toolbar launcher / index cards / ref hops via the binding's nav
+// capabilities (collectionUi.ts).
+import { onBeforeUnmount, ref, watch } from "vue";
+import { CollectionsIndexView, CollectionView } from "@mulmoclaude/collection-plugin/vue";
+import PluginFrame from "./PluginFrame.vue";
+import { collectionShadowCss } from "../collectionShadowCss";
+import { useCollectionBrowse, browseGotoIndex } from "../composables/useCollectionBrowse";
+import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
+
+const { view, isOpen, close } = useCollectionBrowse();
+
+// Register this overlay's shadow root as the record-modal teleport target while a
+// detail page is open (the package's CollectionRecordModal teleports there; the
+// global binding can't otherwise know which shadow root to use). Same getRootNode()
+// trick as CollectionCardView — the probe sits inside the PluginFrame shadow.
+const probe = ref<HTMLElement>();
+let registered: HTMLElement | ShadowRoot | null = null;
+function unregister(): void {
+  if (registered) {
+    popCollectionTeleportTarget(registered);
+    registered = null;
+  }
+}
+watch(probe, (el) => {
+  unregister();
+  const root = el?.getRootNode();
+  if (root instanceof ShadowRoot) {
+    registered = root;
+    pushCollectionTeleportTarget(root);
+  }
+});
+onBeforeUnmount(unregister);
+
+function backToIndex(): void {
+  if (view.value.mode === "detail") browseGotoIndex(view.value.kind);
+}
+
+// Close on Escape for keyboard users.
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === "Escape") close();
+}
+</script>
+
+<template>
+  <div v-if="isOpen" class="browse-overlay" role="dialog" aria-modal="true" aria-label="Collections" tabindex="-1" @keydown="onKeydown">
+    <header class="browse-chrome">
+      <button v-if="view.mode === 'detail'" type="button" class="chrome-btn" title="Back to index" aria-label="Back to index" @click="backToIndex">
+        <span class="material-symbols-outlined">arrow_back</span>
+      </button>
+      <span class="chrome-title">{{ view.mode === "detail" && view.kind === "feed" ? "Feeds" : "Collections" }}</span>
+      <button type="button" class="chrome-btn close" title="Close" aria-label="Close" @click="close">
+        <span class="material-symbols-outlined">close</span>
+      </button>
+    </header>
+    <div class="browse-body">
+      <PluginFrame :css="collectionShadowCss" height="100%">
+        <div ref="probe" style="height: 100%">
+          <CollectionsIndexView v-if="view.mode === 'index'" />
+          <CollectionView v-else-if="view.mode === 'detail'" />
+        </div>
+      </PluginFrame>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.browse-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  background: #0b1020;
+}
+.browse-chrome {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #16213e;
+  color: #e0e0e0;
+  border-bottom: 1px solid #2a2a4e;
+  font-family: system-ui, sans-serif;
+}
+.chrome-title {
+  font-weight: 600;
+  font-size: 14px;
+}
+.chrome-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  width: 32px;
+  border: none;
+  background: transparent;
+  color: #b9c2e0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.chrome-btn:hover {
+  color: #fff;
+  background: #243056;
+}
+.chrome-btn.close {
+  margin-left: auto;
+}
+.browse-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 12px;
+}
+</style>

--- a/src/components/PinToggle.vue
+++ b/src/components/PinToggle.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+// The ★ favorite toggle the collection plugin renders (via the binding's
+// `pinToggle`) on index cards + the view header. Talks to the useShortcuts
+// singleton directly — a parent only supplies the target's identity + cached
+// label/icon. Click/keyboard activation are stopped so toggling never also opens
+// the underlying card.
+//
+// Rendered INSIDE the plugin's shadow root, where scoped CSS (document-head) and the
+// host's Tailwind don't reach — so styling is inline. The star glyph uses the
+// `material-icons` class, which the shadow-injected icon CSS maps to Material Symbols.
+import { computed } from "vue";
+import { useShortcuts } from "../composables/useShortcuts";
+import type { ShortcutKind } from "../types/shortcuts";
+
+const props = defineProps<{
+  kind: ShortcutKind;
+  slug: string;
+  /** Cached at pin time so the launcher renders without re-fetching. */
+  title: string;
+  icon: string;
+}>();
+
+const { isPinned, pin, unpin } = useShortcuts();
+const pinned = computed(() => isPinned(props.kind, props.slug));
+
+function toggle(): void {
+  if (pinned.value) void unpin(props.kind, props.slug);
+  else void pin({ kind: props.kind, slug: props.slug, title: props.title, icon: props.icon });
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    :title="pinned ? 'Unpin from toolbar' : 'Pin to toolbar'"
+    :aria-label="pinned ? 'Unpin from toolbar' : 'Pin to toolbar'"
+    :aria-pressed="pinned"
+    :data-testid="`pin-toggle-${kind}-${slug}`"
+    :style="{
+      height: '32px',
+      width: '32px',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: '6px',
+      border: 'none',
+      background: 'transparent',
+      cursor: 'pointer',
+      color: pinned ? '#f59e0b' : '#94a3b8',
+    }"
+    @click.stop="toggle"
+    @keydown.enter.stop
+    @keydown.space.stop
+  >
+    <span class="material-icons" style="font-size: 20px">{{ pinned ? "star" : "star_border" }}</span>
+  </button>
+</template>

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -9,11 +9,21 @@
 // view surface (mintViewToken / fetchViewHtml / buildViewSrcdoc), localeTag, confirm.
 // Write / feeds / favorites / chat are typed failures / no-ops until the interactive
 // (Tier 1) and toolbar (Tier 2) work lands.
-import { defineComponent } from "vue";
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity } from "@mulmoclaude/collection-plugin";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
+import { useShortcuts } from "./useShortcuts";
+import {
+  browseGotoIndex,
+  browseGotoDetail,
+  browseNavigateToRecord,
+  browseRouteSlug,
+  browseRouteSelectedId,
+  browseIsFeedRoute,
+  browseSetSelectedId,
+} from "./useCollectionBrowse";
+import PinToggle from "../components/PinToggle.vue";
 
 // ── Modal teleport target (Shadow DOM) ──
 // PluginFrame mounts each card inside a per-instance shadow root, but
@@ -64,9 +74,6 @@ const UNSUPPORTED = "not supported in MulmoTerminal yet";
 const apiFail = { ok: false as const, error: UNSUPPORTED, status: 501 };
 const mutationFail = { ok: false as const, error: UNSUPPORTED };
 
-// Renders nothing — MulmoTerminal has no favorites store yet (Tier 2).
-const PinTogglePlaceholder = defineComponent({ name: "CollectionPinTogglePlaceholder", render: () => null });
-
 configureCollectionUi({
   // ── real (read side) ──
   fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
@@ -77,7 +84,7 @@ configureCollectionUi({
   localeTag: () => (navigator.language || "en").split("-")[0],
   generalRoleId: "general",
   personalRoleId: "personal",
-  pinToggle: PinTogglePlaceholder,
+  pinToggle: PinToggle,
 
   // ── asset URLs → the raw workspace-file route (server/backends/files.ts).
   //    Mirrors MulmoClaude's resolveImageSrc: data: URIs pass through, everything
@@ -87,15 +94,15 @@ configureCollectionUi({
   fileAssetUrl: (value) => (typeof value === "string" && value.length > 0 ? rawFileUrl(value) : null),
   fileRoutePath: () => null,
 
-  // ── routing: no router; these are safe no-ops for an embedded card (wired to
-  //    view-state in the Tier 2 toolbar). ──
-  routeSlug: () => undefined,
-  routeSelectedId: () => undefined,
-  isFeedRoute: () => false,
-  setSelectedId: () => {},
-  gotoIndex: () => {},
-  gotoDetail: () => {},
-  navigateToRecord: () => {},
+  // ── navigation: no router — map onto useCollectionBrowse's view-state, which
+  //    drives the full-screen browse overlay + the toolbar launcher. ──
+  routeSlug: () => browseRouteSlug(),
+  routeSelectedId: () => browseRouteSelectedId(),
+  isFeedRoute: () => browseIsFeedRoute(),
+  setSelectedId: (itemId) => browseSetSelectedId(itemId),
+  gotoIndex: (kind) => browseGotoIndex(kind),
+  gotoDetail: (kind, slug) => browseGotoDetail(kind, slug),
+  navigateToRecord: (targetSlug, recordId) => browseNavigateToRecord(targetSlug, recordId),
 
   // ── custom views (read-only): sandboxed-iframe HTML views over the shared
   //    workspace. Mint a scoped token, fetch the view HTML, and wrap it in a
@@ -123,9 +130,10 @@ configureCollectionUi({
   deleteView: () => Promise.resolve(mutationFail),
   listFeeds: () => Promise.resolve(apiFail),
 
-  // ── favorites / chat / notifications: no stores yet (Tier 2). ──
-  reconcileShortcuts: () => Promise.resolve(),
-  unpin: () => Promise.resolve(false),
+  // ── favorites: the shared useShortcuts store over /api/shortcuts. ──
+  reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
+  unpin: (kind, slug) => useShortcuts().unpin(kind, slug),
+  // ── chat / notifications: no chat-seed hook or notifier in MulmoTerminal. ──
   startChat: () => {},
   notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
 

--- a/src/composables/useCollectionBrowse.ts
+++ b/src/composables/useCollectionBrowse.ts
@@ -1,0 +1,66 @@
+// View-state for the full-screen collection browser (the no-router replacement for
+// MulmoClaude's /collections + /collections/:slug routes). The collection plugin's
+// nav capabilities map onto this single reactive store (see collectionUi.ts), and
+// CollectionsBrowseOverlay renders from it: the index, or a standalone CollectionView
+// reading `routeSlug`/`routeSelectedId` back off the same store.
+import { computed, reactive, type ComputedRef } from "vue";
+import type { ShortcutKind } from "../types/shortcuts";
+
+type BrowseView = { mode: "closed" } | { mode: "index"; kind: ShortcutKind } | { mode: "detail"; kind: ShortcutKind; slug: string; selectedId: string | null };
+
+const state = reactive<{ view: BrowseView }>({ view: { mode: "closed" } });
+
+// ── Mutators the binding's nav capabilities call (module-level so the global
+//    binding can reach them without component context) ──
+
+/** Open the index for a kind (collections / feeds). */
+export function browseGotoIndex(kind: ShortcutKind): void {
+  state.view = { mode: "index", kind };
+}
+
+/** Open one collection / feed's detail page. */
+export function browseGotoDetail(kind: ShortcutKind, slug: string): void {
+  state.view = { mode: "detail", kind, slug, selectedId: null };
+}
+
+/** A ref/embed hop into another collection, optionally deep-linking a record. */
+export function browseNavigateToRecord(targetSlug: string, recordId?: string): void {
+  state.view = { mode: "detail", kind: "collection", slug: targetSlug, selectedId: recordId ?? null };
+}
+
+/** Current detail slug (CollectionView reads this in standalone mode), or undefined. */
+export function browseRouteSlug(): string | undefined {
+  return state.view.mode === "detail" ? state.view.slug : undefined;
+}
+
+/** Current deep-linked record id, or undefined. */
+export function browseRouteSelectedId(): string | undefined {
+  return state.view.mode === "detail" ? (state.view.selectedId ?? undefined) : undefined;
+}
+
+/** True when the open page is the feeds (vs collections) family. */
+export function browseIsFeedRoute(): boolean {
+  return state.view.mode !== "closed" && state.view.kind === "feed";
+}
+
+/** Set/clear the open record (the modal deep-link), no history. */
+export function browseSetSelectedId(itemId: string | null): void {
+  if (state.view.mode === "detail") state.view.selectedId = itemId;
+}
+
+/** Close the browser overlay. */
+export function browseClose(): void {
+  state.view = { mode: "closed" };
+}
+
+export function useCollectionBrowse(): {
+  view: ComputedRef<BrowseView>;
+  isOpen: ComputedRef<boolean>;
+  close: () => void;
+} {
+  return {
+    view: computed(() => state.view),
+    isOpen: computed(() => state.view.mode !== "closed"),
+    close: browseClose,
+  };
+}

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -1,0 +1,165 @@
+// Client store for shared launcher favorites (pinned collections / feeds).
+// Singleton module state shared across every consumer — the toolbar launcher
+// renders them, the index/view PinToggle toggles them, the indexes reconcile stale
+// labels — so they all see one list. Ported from MulmoClaude's useShortcuts, using
+// fetch (MulmoTerminal has no api helper) over GET/PUT /api/shortcuts.
+//
+// Persistence is server-side (`config/shortcuts.json`, shared with MulmoClaude); the
+// client owns the full array and replaces it wholesale. Mutations are optimistic
+// with rollback, and serialized so overlapping replace-all PUTs can't reorder.
+import { computed, ref, type ComputedRef } from "vue";
+import { sameShortcut, type Shortcut, type ShortcutKind } from "../types/shortcuts";
+
+const shortcuts = ref<Shortcut[]>([]);
+const loadError = ref<string | null>(null);
+/** True only after a GET has authoritatively populated `shortcuts`. Until then,
+ *  mutations refuse to persist — a replace-all PUT built on the empty default would
+ *  clobber an existing shortcuts.json. */
+const loaded = ref(false);
+let loadPromise: Promise<void> | null = null;
+
+interface ShortcutsResponse {
+  shortcuts: Shortcut[];
+}
+
+type ApiResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+async function apiGet<T>(url: string): Promise<ApiResult<T>> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function apiPut<T>(url: string, body: unknown): Promise<ApiResult<T>> {
+  try {
+    const res = await fetch(url, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Load once per session (deduped). A FAILED load is not cached so the next call
+ *  retries. */
+async function load(force = false): Promise<void> {
+  if (loadPromise && !force) return loadPromise;
+  loadPromise = (async () => {
+    const result = await apiGet<ShortcutsResponse>("/api/shortcuts");
+    if (!result.ok) {
+      loadError.value = result.error;
+      loadPromise = null; // allow retry
+      return;
+    }
+    loadError.value = null;
+    shortcuts.value = result.data.shortcuts;
+    loaded.value = true;
+  })();
+  return loadPromise;
+}
+
+// Serialize mutations so the replace-all PUTs never overlap (two in-flight saves
+// could land out of order and resurrect a removed pin). Each task awaits load()
+// first so the server list is in the ref before reading `previous`.
+let mutationChain: Promise<unknown> = Promise.resolve();
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const run = mutationChain.then(task, task);
+  mutationChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/** Persist `next`, rolling back to `previous` on failure. Call only inside enqueue. */
+async function persist(next: Shortcut[], previous: Shortcut[]): Promise<boolean> {
+  shortcuts.value = next;
+  const result = await apiPut<ShortcutsResponse>("/api/shortcuts", { shortcuts: next });
+  if (!result.ok) {
+    shortcuts.value = previous;
+    loadError.value = result.error;
+    console.error("[useShortcuts] persist failed", result.error);
+    return false;
+  }
+  shortcuts.value = result.data.shortcuts; // adopt the server's canonical list
+  loadError.value = null;
+  return true;
+}
+
+function isPinned(kind: ShortcutKind, slug: string): boolean {
+  return shortcuts.value.some((entry) => sameShortcut(entry, { kind, slug }));
+}
+
+function pin(shortcut: Shortcut): Promise<boolean> {
+  return enqueue(async () => {
+    await load();
+    if (!loaded.value) return false;
+    if (isPinned(shortcut.kind, shortcut.slug)) return true;
+    const previous = shortcuts.value;
+    return persist([...previous, shortcut], previous);
+  });
+}
+
+function unpin(kind: ShortcutKind, slug: string): Promise<boolean> {
+  return enqueue(async () => {
+    await load();
+    if (!loaded.value) return false;
+    if (!isPinned(kind, slug)) return true;
+    const previous = shortcuts.value;
+    return persist(
+      previous.filter((entry) => !sameShortcut(entry, { kind, slug })),
+      previous,
+    );
+  });
+}
+
+/** Bulk reconcile one kind against the authoritative {slug,title,icon} list an
+ *  index just fetched: prune dead slugs, refresh stale title/icon, self-heal the
+ *  file. Other kinds untouched. */
+function reconcile(kind: ShortcutKind, live: { slug: string; title: string; icon: string }[]): Promise<void> {
+  return enqueue(async () => {
+    await load();
+    if (!loaded.value) return;
+    const liveBySlug = new Map(live.map((entry) => [entry.slug, entry]));
+    let drifted = false;
+    const next = shortcuts.value.flatMap((entry) => {
+      if (entry.kind !== kind) return [entry];
+      const fresh = liveBySlug.get(entry.slug);
+      if (!fresh) {
+        drifted = true;
+        return [];
+      }
+      if (fresh.title !== entry.title || fresh.icon !== entry.icon) {
+        drifted = true;
+        return [{ ...entry, title: fresh.title, icon: fresh.icon }];
+      }
+      return [entry];
+    });
+    if (drifted) await persist(next, shortcuts.value);
+  });
+}
+
+export function useShortcuts(): {
+  shortcuts: ComputedRef<Shortcut[]>;
+  loadError: ComputedRef<string | null>;
+  load: (force?: boolean) => Promise<void>;
+  isPinned: (kind: ShortcutKind, slug: string) => boolean;
+  pin: (shortcut: Shortcut) => Promise<boolean>;
+  unpin: (kind: ShortcutKind, slug: string) => Promise<boolean>;
+  reconcile: (kind: ShortcutKind, live: { slug: string; title: string; icon: string }[]) => Promise<void>;
+} {
+  void load();
+  return {
+    shortcuts: computed(() => shortcuts.value),
+    loadError: computed(() => loadError.value),
+    load,
+    isPinned,
+    pin,
+    unpin,
+    reconcile,
+  };
+}

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -20,42 +20,12 @@ import CollectionCardView from "./components/CollectionCardView.vue";
 import markdownCss from "@mulmoclaude/markdown-plugin/style.css?inline";
 import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
-import collectionCss from "@mulmoclaude/collection-plugin/style.css?inline";
+import { collectionShadowCss } from "./collectionShadowCss";
 // The @mulmochat-plugin family (generate-image + its peer ui-image) ships incomplete
 // CSS — it assumes a Tailwind host. This is MulmoTerminal's Tailwind layer compiled
 // against those packages' dists (see src/plugin-tailwind.css), supplying the
 // utilities their components use.
 import mulmochatPluginCss from "./plugin-tailwind.css?inline";
-
-// The collection plugin renders ~56 icons via the classic `.material-icons` class
-// (plus a few `.material-symbols-outlined`). MulmoTerminal only loads the Material
-// Symbols font (main.ts), and in any case the global icon class rule can't pierce
-// the plugin's Shadow DOM — so the ligature names ("movie", "search", "arrow_upward")
-// render as plain TEXT. The font's `@font-face` IS global (document-level font-faces
-// apply inside shadow roots), so we just need the class rule inside the shadow:
-// map both icon classes to the loaded "Material Symbols Outlined" font (a superset
-// that supports the same ligature names). Prepended BEFORE the plugin's Tailwind so
-// the components' `text-sm`/`text-lg` size overrides still win (equal specificity →
-// later rule wins); unsized icons fall back to the 24px default here.
-const COLLECTION_ICON_CSS = `
-.material-icons, .material-symbols-outlined {
-  font-family: "Material Symbols Outlined";
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-  font-feature-settings: "liga";
-}
-`;
 
 interface Registration {
   toolName: string;
@@ -103,7 +73,7 @@ const PACKAGES: Record<string, Registration> = {
     // The binding (data fetch, asset URLs, nav, confirm) is configured once at
     // startup by importing ./composables/collectionUi in main.ts.
     viewComponent: CollectionCardView as Component,
-    css: COLLECTION_ICON_CSS + collectionCss,
+    css: collectionShadowCss,
     // The collection View uses an internal h-full layout (table/kanban scroll
     // areas, and the custom-view iframe has no intrinsic content height). Give it a
     // fixed frame so that chain resolves — matches MulmoClaude's StackView

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -1,0 +1,24 @@
+// Launcher shortcut (pinned collection / feed) — browser-safe shape shared by the
+// shortcuts store, PinToggle, and the toolbar launcher. The on-disk format
+// (`{ shortcuts: Shortcut[] }`) is written/read by the server (server/backends/
+// shortcuts.ts) and is the SAME file + format MulmoClaude uses — keep this type in
+// sync with mulmoclaude/src/types/shortcuts.ts.
+
+export const SHORTCUT_KINDS = ["collection", "feed"] as const;
+export type ShortcutKind = (typeof SHORTCUT_KINDS)[number];
+
+export interface Shortcut {
+  /** Which route family — drives the launcher's navigation target. */
+  kind: ShortcutKind;
+  /** The target collection / feed slug. */
+  slug: string;
+  /** Cached display label (user-named) — refreshed on reconcile. */
+  title: string;
+  /** Cached material-symbols glyph — refreshed on reconcile. */
+  icon: string;
+}
+
+/** True when two shortcuts target the same thing (the dedupe key). */
+export function sameShortcut(left: Pick<Shortcut, "kind" | "slug">, right: Pick<Shortcut, "kind" | "slug">): boolean {
+  return left.kind === right.kind && left.slug === right.slug;
+}


### PR DESCRIPTION
## What

The actual goal of the collection-plugin work: a **collections toolbar** like MulmoClaude's, adapted to MulmoTerminal's no-router, state-driven host. Builds on the merged read-side foundation (#50).

Two design decisions (per maintainer): **favorites = reimplement verbatim + fixture test**; **browse panel = full-screen overlay**.

**Favorites are SHARED with MulmoClaude via the workspace** — a collection pinned in either app shows up in the other (same `<workspace>/config/shortcuts.json`, same format). Still zero MulmoClaude changes.

## Changes

**Server**
- `server/backends/shortcuts.ts` — `GET`/`PUT /api/shortcuts` over the shared `config/shortcuts.json`, in MulmoClaude's exact **object-wrapper** format `{ shortcuts: Shortcut[] }`, normalized + atomically written. `shortcuts.spec.ts` pins the on-disk contract.

**Frontend**
- `src/types/shortcuts.ts` — the `Shortcut` type (verbatim from MulmoClaude).
- `src/composables/useShortcuts.ts` — singleton favorites store over `/api/shortcuts`: optimistic mutation + rollback, serialized replace-all PUTs (ported).
- `src/components/PinToggle.vue` — the ★ toggle (inline-styled, since it renders inside the plugin shadow root); wired into the binding's `pinToggle`.
- `src/composables/useCollectionBrowse.ts` — reactive view-state (`closed | index | detail`). The binding's nav fns (`gotoIndex`/`gotoDetail`/`navigateToRecord`/`routeSlug`/`routeSelectedId`/`isFeedRoute`/`setSelectedId`) map onto it; `unpin`/`reconcileShortcuts` onto `useShortcuts`.
- `src/components/CollectionsBrowseOverlay.vue` — full-screen overlay rendering `CollectionsIndexView` (index) or standalone `CollectionView` (detail) in a `PluginFrame` shadow root; registers its shadow root as the record-modal teleport target.
- `App.vue` — the toolbar launcher (a "Collections" button + one per favorite) + the overlay mount.
- `src/collectionShadowCss.ts` — shared shadow CSS (icon rule + `style.css`), now used by both the chat card and the overlay.

## Verification

- client + server typecheck, `yarn build`, `yarn lint`, **71 tests** (7 new shortcuts tests)
- Puppeteer smoke: MulmoClaude's pinned collections appear in MulmoTerminal's toolbar from the shared file; the "Collections" button opens the overlay; the index renders (27 cards).

## Known limits / next

- `startChat` is still a no-op — collection "create"/action buttons that seed a chat are inert (needs a hook into the terminal session).
- A dedicated `/feeds` index (`FeedsView`) is deferred; the launcher/overlay handle `kind: "feed"` shortcuts but the collections index filters feeds out.
- Tier 1 (write routes / interactive editing) still pending.

See `docs/collection-plugin-integration.md` (resolved decisions + Tier 2 status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)