### PR TITLE
feat: record write routes — editing from a collection view (Tier 1)

### DIFF
--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -131,3 +131,56 @@ describe("custom view routes", () => {
     expect(body.items.map((i) => i.id)).toEqual(["item1"]);
   });
 });
+
+describe("record CRUD", () => {
+  // Functions, not constants: `base` is only assigned in beforeAll (after the
+  // describe body runs), so the URLs must be built at call time.
+  const items = () => `${base}/api/collections/testcol/items`;
+  const itemUrl = (id: string) => `${base}/api/collections/testcol/items/${id}`;
+  const detailItems = async () =>
+    ((await (await fetch(`${base}/api/collections/testcol/detail`)).json()) as { items: Array<{ id: string; name?: string }> }).items;
+
+  it("creates, updates, then deletes a record", async () => {
+    const create = await fetch(items(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "crud1", name: "New" }),
+    });
+    expect(create.status).toBe(200);
+    expect((await create.json()) as { itemId: string }).toMatchObject({ itemId: "crud1" });
+    expect((await detailItems()).find((i) => i.id === "crud1")).toMatchObject({ name: "New" });
+
+    const upd = await fetch(itemUrl("crud1"), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "crud1", name: "Updated" }),
+    });
+    expect(upd.status).toBe(200);
+    expect(((await upd.json()) as { item: { name: string } }).item).toMatchObject({ name: "Updated" });
+
+    const del = await fetch(itemUrl("crud1"), { method: "DELETE" });
+    expect(del.status).toBe(200);
+    expect(await del.json()).toEqual({ deleted: true, itemId: "crud1" });
+    expect((await detailItems()).find((i) => i.id === "crud1")).toBeUndefined();
+  });
+
+  it("409s creating a record whose id already exists", async () => {
+    const dupe = await fetch(items(), { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: "item1", name: "dupe" }) });
+    expect(dupe.status).toBe(409);
+  });
+
+  it("400s on a non-object create body", async () => {
+    const res = await fetch(items(), { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify([1, 2, 3]) });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s update/delete on a missing collection", async () => {
+    const put = await fetch(`${base}/api/collections/nope/items/x`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "x" }),
+    });
+    expect(put.status).toBe(404);
+    expect((await fetch(`${base}/api/collections/nope/items/x`, { method: "DELETE" })).status).toBe(404);
+  });
+});

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -22,11 +22,17 @@ import {
   listItems,
   enrichItems,
   readCustomViewHtml,
+  writeItem,
+  deleteItem,
+  generateItemId,
+  resolveCreateItemId,
   toSummary,
   toDetail,
   validateCollectionRecords,
   type RecordIssue,
 } from "@mulmoclaude/collection-plugin/server";
+// CollectionItem lives in the isomorphic core entry (not re-exported from /server).
+import type { CollectionItem } from "@mulmoclaude/collection-plugin";
 import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
@@ -63,6 +69,12 @@ export function initCollectionsBackend(deps: { workspace: string }): void {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** A request body usable as a record: a non-null, non-array object. */
+function extractRecord(body: unknown): CollectionItem | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  return body as CollectionItem;
 }
 
 /** Mount the read-side REST surface. Mirrors MulmoClaude's
@@ -104,6 +116,111 @@ export function mountCollectionRoutes(app: Express): void {
       res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
     } catch (err) {
       log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Record CRUD (Tier 1: interactive editing — e.g. checking a to-do item) ──
+  // Create a record. The id is the schema's primaryKey value from the body, or a
+  // generated one; a singleton collection pins every create to its fixed id.
+  app.post("/api/collections/:slug/items", async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const record = extractRecord(req.body);
+    if (!record) {
+      res.status(400).json({ error: "request body must be a JSON object" });
+      return;
+    }
+    const itemId = resolveCreateItemId(collection.schema, record) ?? generateItemId();
+    const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
+    try {
+      const result = await writeItem(collection.dataDir, itemId, recordWithId, { refuseOverwrite: true });
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "conflict") {
+        res.status(409).json({ error: `item '${result.itemId}' already exists` });
+        return;
+      }
+      res.json({ itemId: result.itemId, item: result.item });
+    } catch (err) {
+      log.warn("collections", "item create failed", { slug: collection.slug, itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Update a record. The primaryKey is pinned to the URL itemId (the body can't
+  // smuggle a different id). Singletons only accept their one fixed id.
+  app.put("/api/collections/:slug/items/:itemId", async (req: Request<{ slug: string; itemId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const record = extractRecord(req.body);
+    if (!record) {
+      res.status(400).json({ error: "request body must be a JSON object" });
+      return;
+    }
+    const { singleton, primaryKey } = collection.schema;
+    if (singleton && req.params.itemId !== singleton) {
+      res.status(400).json({ error: `collection '${collection.slug}' is a singleton; the only valid item id is '${singleton}'` });
+      return;
+    }
+    const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
+    try {
+      const result = await writeItem(collection.dataDir, req.params.itemId, recordWithId);
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "conflict") {
+        res.status(500).json({ error: "unexpected conflict on update" });
+        return;
+      }
+      res.json({ itemId: result.itemId, item: result.item });
+    } catch (err) {
+      log.warn("collections", "item update failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Delete a record.
+  app.delete("/api/collections/:slug/items/:itemId", async (req: Request<{ slug: string; itemId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    try {
+      const result = await deleteItem(collection.dataDir, req.params.itemId);
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "not-found") {
+        res.status(404).json({ error: `item '${result.itemId}' not found` });
+        return;
+      }
+      res.json({ deleted: true, itemId: result.itemId });
+    } catch (err) {
+      log.warn("collections", "item delete failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   });

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -11,7 +11,7 @@
 // (Tier 1) and toolbar (Tier 2) work lands.
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
-import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity } from "@mulmoclaude/collection-plugin";
+import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity, ItemMutationResponse } from "@mulmoclaude/collection-plugin";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
 import { useShortcuts } from "./useShortcuts";
 import {
@@ -54,15 +54,29 @@ async function apiGet<T>(url: string): Promise<CollectionApiResult<T>> {
   }
 }
 
-async function apiPost<T>(url: string, body: unknown): Promise<CollectionApiResult<T>> {
+async function apiSend<T>(method: "POST" | "PUT", url: string, body: unknown): Promise<CollectionApiResult<T>> {
   try {
-    const res = await fetch(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const res = await fetch(url, { method, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
     if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
     return { ok: true, data: (await res.json()) as T };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
   }
 }
+const apiPost = <T>(url: string, body: unknown) => apiSend<T>("POST", url, body);
+const apiPut = <T>(url: string, body: unknown) => apiSend<T>("PUT", url, body);
+
+// Delete → the view layer's CollectionMutationResult ({ ok } | { ok:false, error }).
+async function apiDelete(url: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(url, { method: "DELETE" });
+    return res.ok ? { ok: true } : { ok: false, error: `HTTP ${res.status}` };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+const itemUrl = (slug: string, itemId: string) => `/api/collections/${encodeURIComponent(slug)}/items/${encodeURIComponent(itemId)}`;
 
 /** Browser URL for a workspace-relative file path, via the raw-file route. */
 function rawFileUrl(value: unknown): string {
@@ -118,10 +132,12 @@ configureCollectionUi({
   },
   buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
 
-  // ── write / feeds / view-delete: deferred to Tier 1. ──
-  createItem: () => Promise.resolve(apiFail),
-  updateItem: () => Promise.resolve(apiFail),
-  deleteItem: () => Promise.resolve(mutationFail),
+  // ── record CRUD: create / update (e.g. checking a to-do item) / delete. ──
+  createItem: (slug, record) => apiPost<ItemMutationResponse>(`/api/collections/${encodeURIComponent(slug)}/items`, record),
+  updateItem: (slug, itemId, record) => apiPut<ItemMutationResponse>(itemUrl(slug, itemId), record),
+  deleteItem: (slug, itemId) => apiDelete(itemUrl(slug, itemId)),
+
+  // ── collection/feed delete, actions, feeds, view-delete: deferred. ──
   deleteCollection: () => Promise.resolve(mutationFail),
   deleteFeed: () => Promise.resolve(mutationFail),
   runItemAction: () => Promise.resolve(apiFail),


### PR DESCRIPTION
## What

Editing a record from a collection view (e.g. **checking a to-do item**) failed with `変更を保存できませんでした: not supported in MulmoTerminal yet` — `createItem`/`updateItem`/`deleteItem` were Tier-0 stubs in the binding. This wires up the record write routes over the shared workspace, matching MulmoClaude's handlers. Still zero MulmoClaude changes.

## Changes

**Server** (`server/backends/collections.ts`)
- `POST /api/collections/:slug/items` — create. Id = the schema primaryKey value in the body, or generated; a singleton collection pins every create to its fixed id; `409` on an existing id.
- `PUT /api/collections/:slug/items/:itemId` — update. primaryKey is pinned to the URL id (the body can't smuggle a different id); singleton guard.
- `DELETE /api/collections/:slug/items/:itemId` — delete; `404` when absent.

Uses the package's `writeItem`/`deleteItem`/`generateItemId`/`resolveCreateItemId`, mapping the result kinds (`invalid-id`→400, `path-escape`→403, `conflict`→409, `not-found`→404).

**Frontend** (`collectionUi` binding) — `createItem`/`updateItem`/`deleteItem` now POST/PUT/DELETE those routes (new `apiPut`/`apiDelete` helpers).

## Verification

- 4 new route tests (create→update→delete round-trip, 409 duplicate, 400 non-object body, 404 missing collection) against the fixture workspace + real engine — **76 tests** total.
- client + server typecheck, `yarn build`, `yarn lint` all pass.

## Not in this PR

Still stubbed: per-record / collection **actions** (`runItemAction`/`runCollectionAction` — they seed a chat, which needs the `startChat` terminal hook), feed refresh, collection/view deletion. Those are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)