### PR TITLE
feat: startChat — collection actions spawn a visible chat

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue"
 import { useSessions, type Filter } from "./composables/useSessions";
 import { useShortcuts } from "./composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
+import { registerChatOpener } from "./composables/useChatLauncher";
 import type { Shortcut } from "./types/shortcuts";
 
 // Shared launcher favorites (pinned collections / feeds), backing the toolbar.
@@ -131,6 +132,13 @@ function selectSession(id: string) {
   activeId.value = id;
   connectKey.value++;
 }
+
+// A collection action (startChat) spawned a new chat and wants it shown: close the
+// browse overlay (if open) and select the session so the terminal displays it.
+registerChatOpener((id: string) => {
+  browseClose();
+  selectSession(id);
+});
 
 function newSession() {
   activeId.value = null;

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -24,6 +24,7 @@ import {
   browseSetSelectedId,
 } from "./useCollectionBrowse";
 import PinToggle from "../components/PinToggle.vue";
+import { startCollectionChat } from "./useChatLauncher";
 
 // ── Modal teleport target (Shadow DOM) ──
 // PluginFrame mounts each card inside a per-instance shadow root, but
@@ -149,8 +150,12 @@ configureCollectionUi({
   // ── favorites: the shared useShortcuts store over /api/shortcuts. ──
   reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
   unpin: (kind, slug) => useShortcuts().unpin(kind, slug),
-  // ── chat / notifications: no chat-seed hook or notifier in MulmoTerminal. ──
-  startChat: () => {},
+  // ── chat: spawn a new terminal session seeded with the prompt and surface it
+  //    (hidden=false → make it visible). Backs the index "create" button + the
+  //    collection/record action buttons (Repair, etc.). MulmoTerminal has no roles,
+  //    so `role` is ignored. ──
+  startChat: (prompt) => void startCollectionChat(prompt, { hidden: false }),
+  // No notifier in MulmoTerminal.
   notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
 
   // ── Shadow-DOM modal target ── ShadowRoot is a valid Teleport target at runtime

--- a/src/composables/useChatLauncher.spec.ts
+++ b/src/composables/useChatLauncher.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerChatOpener, startCollectionChat } from "./useChatLauncher";
+
+function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; json: () => unknown }) {
+  const fn = vi.fn((url: string, init?: RequestInit) => {
+    const r = impl(url, init);
+    return Promise.resolve({ ok: r.ok, status: r.ok ? 200 : 500, json: () => Promise.resolve(r.json()) } as Response);
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("startCollectionChat", () => {
+  beforeEach(() => registerChatOpener(vi.fn()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("spawns a chat seeded with the prompt and selects it (hidden=false)", async () => {
+    const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-1" } }) }));
+    const opener = vi.fn();
+    registerChatOpener(opener);
+
+    await startCollectionChat("fix my records", { hidden: false });
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("/api/plugin/spawnBackgroundChat");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ message: "fix my records" });
+    expect(opener).toHaveBeenCalledWith("sess-1");
+  });
+
+  it("does NOT select when hidden=true (stays in the sidebar)", async () => {
+    mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-2" } }) }));
+    const opener = vi.fn();
+    registerChatOpener(opener);
+
+    await startCollectionChat("background work", { hidden: true });
+
+    expect(opener).not.toHaveBeenCalled();
+  });
+
+  it("ignores an empty prompt (no spawn)", async () => {
+    const fetchFn = mockFetch(() => ({ ok: true, json: () => ({}) }));
+    await startCollectionChat("   ");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("does not select when the spawn fails", async () => {
+    mockFetch(() => ({ ok: false, json: () => ({}) }));
+    const opener = vi.fn();
+    registerChatOpener(opener);
+
+    await startCollectionChat("oops");
+
+    expect(opener).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -1,0 +1,41 @@
+// Bridges the collection plugin's `startChat` capability to MulmoTerminal's terminal.
+// The plugin calls startChat(prompt, role) from contexts with no active chat (the
+// collections index "create" button, a collection/record action like Repair). We
+// spawn a fresh terminal session seeded with the prompt (the server's
+// spawnBackgroundChat), and — unless `hidden` — select it so the user SEES it in the
+// terminal (App.vue registers the opener, which also closes the browse overlay).
+//
+// `hidden` defaults to false: a collection action's chat is something the user should
+// watch, so we surface it. A future hidden=true caller would leave it in the sidebar.
+
+let openSessionFn: ((sessionId: string) => void) | null = null;
+
+/** App.vue registers how to make a session visible (close the overlay + select it). */
+export function registerChatOpener(fn: (sessionId: string) => void): void {
+  openSessionFn = fn;
+}
+
+/** Spawn a new chat seeded with `prompt`; when not hidden, make it visible. */
+export async function startCollectionChat(prompt: string, opts: { hidden?: boolean } = {}): Promise<void> {
+  const message = prompt.trim();
+  if (!message) return;
+  let chatId: string | undefined;
+  try {
+    const res = await fetch("/api/plugin/spawnBackgroundChat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message }),
+    });
+    if (!res.ok) {
+      console.error(`[startChat] spawn failed: HTTP ${res.status}`);
+      return;
+    }
+    const data = (await res.json()) as { jsonData?: { chatId?: unknown } };
+    chatId = typeof data?.jsonData?.chatId === "string" ? data.jsonData.chatId : undefined;
+  } catch (err) {
+    console.error("[startChat] spawn failed", err);
+    return;
+  }
+  // hidden=false → bring the new terminal session into view for the user.
+  if (chatId && !opts.hidden) openSessionFn?.(chatId);
+}


### PR DESCRIPTION
## What

The collection plugin's `startChat` capability was a no-op. This wires it to MulmoTerminal's terminal: spawn a new session seeded with the prompt and surface it.

Per the ask: **a non-hidden (`hidden=false`) chat is made visible to the user** — we select the new session so it shows in the terminal.

## How

- `src/composables/useChatLauncher.ts` — `startCollectionChat(prompt, { hidden })` POSTs the existing `spawnBackgroundChat` route (seeds a fresh Claude session, returns `chatId`); when `hidden` is false it asks the app to show the session.
- `App.vue` registers the opener: it **closes the browse overlay** (if open) and **selects the session** so the terminal displays it.
- `collectionUi` binding: `startChat(prompt)` → `startCollectionChat(prompt, { hidden: false })`. `role` is ignored (MulmoTerminal has no roles).

The chat-card path is unchanged — a `presentCollection` card still uses the `sendTextMessage` prop to talk to its active session; `startChat` only fires from the no-active-chat contexts (index / overlay).

## What this unlocks (and what it doesn't)

`startChat` powers the **direct** seed-prompt callers — the index **"create collection"** button and the **malformed-record Repair** prompt: clicking them now spawns a visible chat seeded with the prompt.

It does **not** by itself make the schema-defined **action buttons** (per-record / collection custom actions) work: those call `cui.runItemAction` / `runCollectionAction` *first* to fetch their seed prompt, and those routes are still stubbed. Wiring the two action routes (`POST …/items/:id/actions/:actionId` and `…/actions/:actionId`, via the package's `buildActionSeedPrompt` / `buildCollectionActionSeedPrompt`) is the natural next step — they'd then feed straight into this `startChat`.

## Verification

- 4 unit tests for the bridge: spawns with the prompt + selects when visible; no-select when `hidden: true`; ignores an empty prompt; no-select on spawn failure. **80 tests** total.
- client + server typecheck, `yarn build`, `yarn lint` pass.
- The `{ jsonData: { chatId } }` contract is the same shape `spawnBackgroundChat` already returns for the agent tool.

## Still stubbed (follow-ups)

Action routes (above), custom-view writes (`PUT /view-data`), feed refresh, collection/view deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)