### PR TITLE
fix: hidden background chats never render bold/unread

### DIFF
--- a/server/host-tools.ts
+++ b/server/host-tools.ts
@@ -10,8 +10,10 @@ import type { ToolDefinition } from "gui-chat-protocol";
 // tool is a drop-in from the model's point of view — but the implementation is
 // completely different: instead of starting an SDK chat, it spawns a brand-new
 // interactive Claude terminal session on the server, seeded with `message`, that
-// the user can open from the sidebar. `role` and `hidden` are accepted for
-// signature parity but ignored: the spawned session is always a visible terminal.
+// the user can open from the sidebar. `role` is accepted for signature parity but
+// ignored (MulmoTerminal has no roles). `hidden:true` marks the session a background
+// worker: it still lists in the sidebar but never renders bold/unread when it
+// finishes (so a background helper doesn't pull the user's attention).
 export const SPAWN_BACKGROUND_CHAT: ToolDefinition = {
   type: "function",
   name: "spawnBackgroundChat",

--- a/server/index.ts
+++ b/server/index.ts
@@ -62,6 +62,10 @@ interface SessionMeta {
   mtime: number;
   working: boolean;
   waiting: boolean;
+  /** Spawned as a hidden background worker (spawnBackgroundChat hidden:true). The
+   *  tab still lists, but it never renders bold/unread — a background helper
+   *  finishing shouldn't pull the user's attention. */
+  hidden: boolean;
 }
 
 // Recency rank for an on-disk .jsonl, before its contents are read.
@@ -304,6 +308,12 @@ const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
 // once the file exists (the on-disk record takes over) or the pty is reaped.
 const knownSessions = new Map<string, KnownSession>(); // id -> { createdAt, title }
 
+// Sessions spawned as hidden background workers (spawnBackgroundChat hidden:true).
+// They list normally but never render bold/unread. Process-lifetime only (not
+// persisted) — and tied to `activity`'s lifecycle in reap() so a finished hidden
+// worker that stays `waiting` doesn't lose its hidden flag and re-bold.
+const hiddenSessions = new Set<string>(); // id
+
 // Bytes of recent output kept per pty and replayed when a client reattaches to
 // a background session, so the user sees context instead of a blank screen.
 const OUTPUT_BUFFER_LIMIT = 64 * 1024;
@@ -324,7 +334,12 @@ function reap(id: string) {
   // visible via its on-disk record.
   knownSessions.delete(id);
   const a = activity.get(id);
-  if (!a || (!a.working && !a.waiting)) activity.delete(id);
+  if (!a || (!a.working && !a.waiting)) {
+    activity.delete(id);
+    // Drop the hidden flag only when activity is dropped too — while `waiting`
+    // persists (the bold-until-viewed window), keep it so the row stays un-bold.
+    hiddenSessions.delete(id);
+  }
   try {
     entry.term.kill();
   } catch {
@@ -473,6 +488,7 @@ async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> 
     mtime: stat.mtimeMs,
     working: a?.working ?? false,
     waiting: a?.waiting ?? false,
+    hidden: hiddenSessions.has(id),
   };
 }
 
@@ -485,9 +501,10 @@ app.use(express.json({ limit: "25mb" }));
 // Host tool: spawnBackgroundChat. Unlike a plugin (handled by mountAllRoutes'
 // catch-all), it needs server internals — it spawns a brand-new interactive Claude
 // terminal session, seeded with `message`, that the user can open from the sidebar.
-// `role`/`hidden` are accepted for signature parity with MulmoClaude but ignored:
-// the session is always visible. Registered BEFORE mountAllRoutes so this specific
-// route wins over /api/plugin/:toolName.
+// `role` is ignored (MulmoTerminal has no roles). `hidden:true` marks it a background
+// worker: it still lists in the sidebar but never renders bold/unread when it
+// finishes. Registered BEFORE mountAllRoutes so this specific route wins over
+// /api/plugin/:toolName.
 app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   const body = isRecord(req.body) ? req.body : {};
   const message = typeof body.message === "string" ? body.message.trim() : "";
@@ -495,6 +512,7 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
     return res.json({ message: "spawnBackgroundChat: `message` is required (non-empty string)." });
   }
   const sessionId = randomUUID();
+  if (body.hidden === true) hiddenSessions.add(sessionId);
   // ws is null: the session runs headless until the user opens it (reattach
   // replays the buffered output). The "created" pubsub event in spawnClaudePty
   // surfaces it in the sidebar right away.
@@ -731,6 +749,7 @@ app.get("/api/sessions", async (_req, res) => {
         mtime: meta.createdAt,
         working: activity.get(id)?.working ?? false,
         waiting: activity.get(id)?.waiting ?? false,
+        hidden: hiddenSessions.has(id),
       });
     }
 
@@ -741,7 +760,7 @@ app.get("/api/sessions", async (_req, res) => {
       await Promise.all(
         top.map((s) =>
           s.kind === "pending"
-            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting }
+            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, hidden: s.hidden }
             : readSessionMeta(dir, s.file).catch(() => null),
         ),
       )

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { Session, Filter } from "../composables/useSessions";
+import { isUnread, type Session, type Filter } from "../composables/useSessions";
 import FilterChip from "./FilterChip.vue";
 
 // Presentational: list + filter are owned by App.vue and shared with the
@@ -16,9 +16,9 @@ const emit = defineEmits<{
   (e: "update:filter", f: Filter): void;
 }>();
 
-// Same "unread" = `waiting` mapping as the vertical sidebar; the filter applies
-// to the horizontal tabs too.
-const unreadCount = computed(() => props.sessions.filter((s) => s.waiting).length);
+// Same "unread" mapping as the vertical sidebar (waiting, excluding hidden
+// background workers); the filter applies to the horizontal tabs too.
+const unreadCount = computed(() => props.sessions.filter(isUnread).length);
 
 // The horizontal bar never scrolls — tabs flex to share the available width.
 // Cap to the most-recent N (sessions are already sorted by recency) so they
@@ -26,7 +26,7 @@ const unreadCount = computed(() => props.sessions.filter((s) => s.waiting).lengt
 // applies before the cap.
 const MAX_TABS = 8;
 const visibleSessions = computed(() => {
-  const list = props.filter === "unread" ? props.sessions.filter((s) => s.waiting) : props.sessions;
+  const list = props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions;
   return list.slice(0, MAX_TABS);
 });
 </script>
@@ -49,14 +49,14 @@ const visibleSessions = computed(() => {
       <button
         v-for="s in visibleSessions"
         :key="s.id"
-        :class="['tab', { active: s.id === props.activeId, waiting: s.waiting }]"
+        :class="['tab', { active: s.id === props.activeId, waiting: isUnread(s) }]"
         :title="s.title"
         :aria-current="s.id === props.activeId ? 'page' : undefined"
         @click="emit('select', s.id)"
       >
         <span v-if="s.working && !s.waiting && s.id !== props.activeId" class="spinner" title="Claude is working" aria-label="Claude is working" />
         <span class="tab-title">{{ s.title }}</span>
-        <span v-if="s.waiting && s.id !== props.activeId" class="unread-dot" aria-label="Unread" />
+        <span v-if="isUnread(s) && s.id !== props.activeId" class="unread-dot" aria-label="Unread" />
       </button>
     </div>
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { Session, Filter } from "../composables/useSessions";
+import { isUnread, type Session, type Filter } from "../composables/useSessions";
 import FilterChip from "./FilterChip.vue";
 
 // Presentational: the session list + filter are owned by App.vue (a single
@@ -19,11 +19,11 @@ const emit = defineEmits<{
   (e: "update:filter", f: Filter): void;
 }>();
 
-// A background session that is `waiting` for the user's attention is what
-// mulmoclaude calls "unread" — render it bold and let the user filter to just
-// those rows.
-const unreadCount = computed(() => props.sessions.filter((s) => s.waiting).length);
-const visibleSessions = computed(() => (props.filter === "unread" ? props.sessions.filter((s) => s.waiting) : props.sessions));
+// A session that is `waiting` for the user's attention is what mulmoclaude calls
+// "unread" — render it bold and let the user filter to just those rows. Hidden
+// background workers are excluded (see isUnread).
+const unreadCount = computed(() => props.sessions.filter(isUnread).length);
+const visibleSessions = computed(() => (props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions));
 
 function relativeTime(ms: number): string {
   const diff = Date.now() - ms;
@@ -66,7 +66,7 @@ function relativeTime(ms: number): string {
       <li
         v-for="s in visibleSessions"
         :key="s.id"
-        :class="['item', { active: s.id === props.activeId, waiting: s.waiting }]"
+        :class="['item', { active: s.id === props.activeId, waiting: isUnread(s) }]"
         :title="s.title"
         @click="emit('select', s.id)"
       >

--- a/src/composables/useSessions.spec.ts
+++ b/src/composables/useSessions.spec.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { mergeStable, type Session } from "./useSessions";
+import { mergeStable, isUnread, type Session } from "./useSessions";
 
 function row(id: string): Session {
   return { id, title: id, mtime: 1, working: false, waiting: false };
 }
+
+describe("isUnread", () => {
+  it("is true for a waiting, non-hidden session", () => {
+    expect(isUnread({ ...row("a"), waiting: true })).toBe(true);
+  });
+
+  it("is false when not waiting", () => {
+    expect(isUnread(row("a"))).toBe(false);
+  });
+
+  it("is false for a hidden background worker even when waiting (the bug fix)", () => {
+    expect(isUnread({ ...row("a"), waiting: true, hidden: true })).toBe(false);
+  });
+});
 
 describe("mergeStable", () => {
   it("takes the server order on the first load (empty prev)", () => {

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -7,10 +7,20 @@ export interface Session {
   mtime: number;
   working: boolean;
   waiting: boolean;
+  /** A hidden background worker (spawnBackgroundChat hidden:true) — listed, but
+   *  never treated as unread/bold. */
+  hidden?: boolean;
 }
 
-// "unread" = a session whose `waiting` flag is set (mulmoclaude's unread).
+// "unread" = a session whose `waiting` flag is set, EXCEPT hidden background
+// workers (mulmoclaude's unread, minus the background noise).
 export type Filter = "all" | "unread";
+
+/** A session that should draw the user's attention (bold + Unread filter): waiting
+ *  for input, and not a hidden background worker. */
+export function isUnread(s: Session): boolean {
+  return !!s.waiting && !s.hidden;
+}
 
 // Merge a freshly-fetched list into the displayed one while keeping the order
 // stable. The server sorts by recency (mtime), so a background update — e.g.


### PR DESCRIPTION
## Problem

A chat spawned with `spawnBackgroundChat` **`hidden:true`** (e.g. the `lessons-biology` lesson-pre-generation worker) **bolded its sidebar/tab title when it finished**. The title goes bold because the session sets `waiting` (the "unread / needs attention" signal). A hidden background worker shouldn't pull the user's attention — it's fine for the tab to list, but it shouldn't be bold.

`spawnBackgroundChat` was ignoring the `hidden` flag entirely.

## Fix

**Server**
- Track hidden session ids in a process-lifetime `Set`; `spawnBackgroundChat` records `body.hidden === true`.
- `/api/sessions` now includes `hidden` on every session (both the pending and on-disk build paths), and `SessionMeta` carries it.
- `reap()` drops the hidden flag **only when `activity` is also dropped** — so a finished-but-still-`waiting` worker keeps its hidden flag and doesn't re-bold during the bold-until-viewed window.

**Frontend**
- `Session` gains `hidden`; a shared `isUnread(s) = waiting && !hidden` now drives the bold class, the unread dot, the Unread count, and the Unread filter in **both** the `Sidebar` and `SessionTabBar`.

## Verification

- `isUnread` unit tests: waiting + non-hidden → unread; not waiting → not; **waiting + hidden → not** (the bug). **83 tests** total.
- client + server typecheck, `yarn build`, `yarn lint` pass.

Independent of the collection PRs (#54) — touches the session/sidebar plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)