### PR TITLE
fix: land collection action routes on main (#54 went to the wrong base)

### DIFF
--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -23,6 +23,8 @@ const SCHEMA = {
     name: { type: "string", label: "Name" },
   },
   views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+  actions: [{ id: "enrich", label: "Enrich", kind: "chat", role: "general", template: "templates/enrich.md" }],
+  collectionActions: [{ id: "audit", label: "Audit", kind: "chat", role: "general", template: "templates/audit.md" }],
 };
 
 let server: Server;
@@ -32,6 +34,10 @@ beforeAll(async () => {
   const ws = mkdtempSync(path.join(tmpdir(), "mt-col-"));
   mkdirSync(path.join(ws, ".claude", "skills", "testcol"), { recursive: true });
   writeFileSync(path.join(ws, ".claude", "skills", "testcol", "schema.json"), JSON.stringify(SCHEMA));
+  // Action templates live under the skill dir's templates/ (readSkillTemplate).
+  mkdirSync(path.join(ws, ".claude", "skills", "testcol", "templates"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "templates", "enrich.md"), "ENRICH_TEMPLATE: complete this record.");
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "templates", "audit.md"), "AUDIT_TEMPLATE: review all records.");
   mkdirSync(path.join(ws, "data", "testcol", "items"), { recursive: true });
   writeFileSync(path.join(ws, "data", "testcol", "items", "item1.json"), JSON.stringify({ id: "item1", name: "Foo" }));
   mkdirSync(path.join(ws, "data", "skills", "testcol", "views"), { recursive: true });
@@ -182,5 +188,34 @@ describe("record CRUD", () => {
     });
     expect(put.status).toBe(404);
     expect((await fetch(`${base}/api/collections/nope/items/x`, { method: "DELETE" })).status).toBe(404);
+  });
+});
+
+describe("action routes (seed prompts)", () => {
+  const post = (url: string) => fetch(`${base}${url}`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+
+  it("returns a per-record action's seed prompt + role", async () => {
+    const res = await post("/api/collections/testcol/items/item1/actions/enrich");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prompt: string; role: string };
+    expect(body.role).toBe("general");
+    expect(body.prompt).toContain("ENRICH_TEMPLATE");
+  });
+
+  it("returns a collection-level action's seed prompt + role", async () => {
+    const res = await post("/api/collections/testcol/actions/audit");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prompt: string; role: string };
+    expect(body.role).toBe("general");
+    expect(body.prompt).toContain("AUDIT_TEMPLATE");
+  });
+
+  it("404s an unknown action id", async () => {
+    expect((await post("/api/collections/testcol/items/item1/actions/nope")).status).toBe(404);
+    expect((await post("/api/collections/testcol/actions/nope")).status).toBe(404);
+  });
+
+  it("404s a per-record action on a missing item", async () => {
+    expect((await post("/api/collections/testcol/items/ghost/actions/enrich")).status).toBe(404);
   });
 });

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -24,15 +24,19 @@ import {
   readCustomViewHtml,
   writeItem,
   deleteItem,
+  readItem,
   generateItemId,
   resolveCreateItemId,
+  readSkillTemplate,
+  buildActionSeedPrompt,
+  buildCollectionActionSeedPrompt,
   toSummary,
   toDetail,
   validateCollectionRecords,
   type RecordIssue,
 } from "@mulmoclaude/collection-plugin/server";
-// CollectionItem lives in the isomorphic core entry (not re-exported from /server).
-import type { CollectionItem } from "@mulmoclaude/collection-plugin";
+// CollectionItem + actionVisible live in the isomorphic core entry.
+import { actionVisible, type CollectionItem } from "@mulmoclaude/collection-plugin";
 import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
@@ -221,6 +225,80 @@ export function mountCollectionRoutes(app: Express): void {
       res.json({ deleted: true, itemId: result.itemId });
     } catch (err) {
       log.warn("collections", "item delete failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Actions (kind: "chat") — return a seed prompt + role; the frontend feeds it
+  //    to startChat, which spawns a visible chat. The records are edited by that
+  //    agent session directly (the intended model). ──
+
+  // Per-record action (e.g. Repair / enrich this record).
+  app.post(
+    "/api/collections/:slug/items/:itemId/actions/:actionId",
+    async (req: Request<{ slug: string; itemId: string; actionId: string }>, res: Response) => {
+      const collection = await loadCollection(req.params.slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+        return;
+      }
+      const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
+      if (!action) {
+        res.status(404).json({ error: `action '${req.params.actionId}' not found on collection '${collection.slug}'` });
+        return;
+      }
+      try {
+        const record = await readItem(collection.dataDir, req.params.itemId);
+        if (!record) {
+          res.status(404).json({ error: `item '${req.params.itemId}' not found` });
+          return;
+        }
+        // The action's `when` predicate is the authorization rule: the client hides
+        // out-of-state buttons, but a stale/crafted request could still target one.
+        if (!actionVisible(action, record)) {
+          res.status(409).json({ error: `action '${action.id}' is not available for item '${req.params.itemId}' in its current state` });
+          return;
+        }
+        const template = await readSkillTemplate(collection.skillDir, action.template);
+        if (template === null) {
+          res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
+          return;
+        }
+        res.json({ prompt: buildActionSeedPrompt(record, template), role: action.role });
+      } catch (err) {
+        log.warn("collections", "item action seed failed", {
+          slug: collection.slug,
+          itemId: req.params.itemId,
+          actionId: req.params.actionId,
+          error: errorMessage(err),
+        });
+        res.status(500).json({ error: errorMessage(err) });
+      }
+    },
+  );
+
+  // Collection-level action (operates over all records).
+  app.post("/api/collections/:slug/actions/:actionId", async (req: Request<{ slug: string; actionId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const action = collection.schema.collectionActions?.find((entry) => entry.id === req.params.actionId);
+    if (!action) {
+      res.status(404).json({ error: `collection action '${req.params.actionId}' not found on collection '${collection.slug}'` });
+      return;
+    }
+    try {
+      const template = await readSkillTemplate(collection.skillDir, action.template);
+      if (template === null) {
+        res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
+        return;
+      }
+      const allItems = await listItems(collection.dataDir);
+      res.json({ prompt: buildCollectionActionSeedPrompt(allItems, collection.schema, template), role: action.role });
+    } catch (err) {
+      log.warn("collections", "collection action seed failed", { slug: collection.slug, actionId: req.params.actionId, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   });

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -1,16 +1,15 @@
 // Wire @mulmoclaude/collection-plugin/vue to MulmoTerminal. Imported for its side
 // effect from main.ts so the package's View layer can resolve data before any
 // presentCollection card mounts. MulmoTerminal's counterpart to MulmoClaude's
-// src/composables/collections/uiHost.ts — but a much leaner host (no router, no
-// vue-i18n host instance, no confirm/shortcut/notifier stores), so most write/chat/
-// favorite capabilities are stubs for this read-side increment.
+// src/composables/collections/uiHost.ts — a leaner host (no router, no vue-i18n host
+// instance, no confirm/notifier stores).
 //
-// What's REAL here: fetchCollectionDetail + listCollections, the read-only custom
-// view surface (mintViewToken / fetchViewHtml / buildViewSrcdoc), localeTag, confirm.
-// Write / feeds / favorites / chat are typed failures / no-ops until the interactive
-// (Tier 1) and toolbar (Tier 2) work lands.
+// Wired: data fetch (detail/list), record CRUD, read-only custom views, actions
+// (seed prompt → startChat → a visible chat), favorites (useShortcuts), and
+// state-based navigation (useCollectionBrowse — the toolbar + browse overlay).
+// Still stubbed: feeds, collection/view deletion, feed refresh, and the notifier.
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
-import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionApiResult, CollectionViewToken, CollectionActionResult } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity, ItemMutationResponse } from "@mulmoclaude/collection-plugin";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
 import { useShortcuts } from "./useShortcuts";
@@ -141,8 +140,15 @@ configureCollectionUi({
   // ── collection/feed delete, actions, feeds, view-delete: deferred. ──
   deleteCollection: () => Promise.resolve(mutationFail),
   deleteFeed: () => Promise.resolve(mutationFail),
-  runItemAction: () => Promise.resolve(apiFail),
-  runCollectionAction: () => Promise.resolve(apiFail),
+  // ── actions (kind: "chat"): fetch the seed prompt + role; CollectionView feeds it
+  //    to startChat (→ a visible chat). ──
+  runItemAction: (slug, itemId, actionId) =>
+    apiPost<CollectionActionResult>(
+      `/api/collections/${encodeURIComponent(slug)}/items/${encodeURIComponent(itemId)}/actions/${encodeURIComponent(actionId)}`,
+      {},
+    ),
+  runCollectionAction: (slug, actionId) =>
+    apiPost<CollectionActionResult>(`/api/collections/${encodeURIComponent(slug)}/actions/${encodeURIComponent(actionId)}`, {}),
   refreshCollection: () => Promise.resolve(apiFail),
   deleteView: () => Promise.resolve(mutationFail),
   listFeeds: () => Promise.resolve(apiFail),


### PR DESCRIPTION
## Why

PR #54 was created with base `feat/collection-startchat` (a stacked PR) and **GitHub did not retarget it to `main`** after #53 merged. So merging #54 landed its changes on the already-merged `feat/collection-startchat` branch (`b9de3b1`), and **`main` never received them**. Result: on `main`, `runItemAction`/`runCollectionAction` are still the Tier-0 stubs, so the Biology **Learn** action button errors with *"変更を保存できませんでした: not supported in MulmoTerminal yet"* — a regression vs the stacked branch where it worked.

## What

Cherry-picks #54's squash (`b9de3b1`) onto a branch based on `main`. The diff is exactly the action-routes work:
- `server/backends/collections.ts` — `POST …/items/:itemId/actions/:actionId` + `POST …/actions/:actionId` (seed prompt + role).
- `src/composables/collectionUi.ts` — `runItemAction`/`runCollectionAction` now POST those routes.
- `server/backends/collections.spec.ts` — 4 action-route tests.

No new work — it's the reviewed #54 content, just targeted at `main` this time.

## Verification

client + server typecheck, `yarn build`, `yarn lint`, **84 tests** — all pass.

(Follow-up housekeeping: the orphaned `feat/collection-startchat` branch with #54 piled on it can be deleted after this merges.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)