### PR TITLE
feat: integrate @mulmoclaude/html-plugin (presentHtml)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@mulmoclaude/chart-plugin": "^0.1.1",
     "@mulmoclaude/collection-plugin": "^0.5.1",
     "@mulmoclaude/form-plugin": "^0.1.1",
+    "@mulmoclaude/html-plugin": "^0.2.2",
     "@mulmoclaude/markdown-plugin": "^0.1.4",
     "@mulmoclaude/x-plugin": "^0.1.1",
     "@xterm/addon-attach": "^0.12.0",

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,5 +1,5 @@
 {
-  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin", "@mulmoclaude/collection-plugin"],
+  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin", "@mulmoclaude/collection-plugin", "@mulmoclaude/html-plugin"],
   "servers": ["@mulmoclaude/x-plugin"],
   "local": []
 }

--- a/server/backends/html.spec.ts
+++ b/server/backends/html.spec.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { initArtifactsBackend } from "./artifacts.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./html.js";
+
+let server: Server;
+let base: string;
+let ws: string;
+const REL = "artifacts/html/2026/06/page.html";
+
+beforeAll(async () => {
+  ws = mkdtempSync(path.join(tmpdir(), "mt-html-"));
+  mkdirSync(path.join(ws, "artifacts", "html", "2026", "06"), { recursive: true });
+  writeFileSync(path.join(ws, REL), "<!doctype html><html><body>ORIGINAL</body></html>");
+  initArtifactsBackend({ workspace: ws });
+
+  const app = express();
+  app.use(express.json());
+  mountHtmlDispatchRoute(app, { getPubsub: () => null });
+  mountHtmlPreviewRoute(app, { workspace: ws });
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => server?.close());
+
+const dispatch = (body: unknown) =>
+  fetch(`${base}/api/plugin/presentHtml`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+describe("html dispatch route", () => {
+  it("loadHtml returns the page bytes", async () => {
+    const res = await dispatch({ kind: "loadHtml", path: REL });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { html: string }).html).toContain("ORIGINAL");
+  });
+
+  it("saveHtml overwrites the file in place", async () => {
+    const res = await dispatch({ kind: "saveHtml", path: REL, html: "<html><body>EDITED</body></html>" });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { path: string }).path).toBe(REL);
+    expect(readFileSync(path.join(ws, REL), "utf8")).toContain("EDITED");
+  });
+
+  it("rejects a path outside artifacts/html", async () => {
+    expect((await dispatch({ kind: "loadHtml", path: "artifacts/secrets.html" })).status).toBe(400);
+  });
+
+  it("falls through (no handler → 404) for a tool-call with no kind", async () => {
+    // The real server has the generic catch-all after this route; here there's none,
+    // so next() lands on Express's 404 — proving the tool-call path isn't intercepted.
+    expect((await dispatch({ html: "<p>x</p>", title: "t" })).status).toBe(404);
+  });
+});
+
+describe("html preview route", () => {
+  it("serves the page with the preview CSP + nosniff", async () => {
+    const res = await fetch(`${base}/${REL}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toMatch(/script-src 'unsafe-inline'/);
+  });
+
+  it("403s a path that escapes artifacts/html", async () => {
+    const res = await fetch(`${base}/artifacts/html/${encodeURIComponent("../../etc/passwd")}`);
+    expect([403, 404]).toContain(res.status); // blocked either by containment or non-.html
+  });
+
+  it("404s a missing file", async () => {
+    expect((await fetch(`${base}/artifacts/html/nope.html`)).status).toBe(404);
+  });
+});

--- a/server/backends/html.spec.ts
+++ b/server/backends/html.spec.ts
@@ -67,6 +67,9 @@ describe("html preview route", () => {
     expect(res.headers.get("content-type")).toContain("text/html");
     expect(res.headers.get("x-content-type-options")).toBe("nosniff");
     const csp = res.headers.get("content-security-policy") ?? "";
+    // Response-level sandbox so direct navigation can't run the LLM HTML with the
+    // app origin's privileges (not just relying on the embedding iframe).
+    expect(csp).toContain("sandbox allow-scripts");
     expect(csp).toContain("connect-src 'none'");
     expect(csp).toMatch(/script-src 'unsafe-inline'/);
   });

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -1,0 +1,114 @@
+// Host wiring for @mulmoclaude/html-plugin (presentHtml). The tool-call path
+// (executeHtml: save new HTML / present an existing path) is handled by the generic
+// package loader (plugins.json `packages` → /api/plugin/presentHtml via the FileOps
+// context). This module adds the two host-specific pieces:
+//
+//   1. The View's source-editor DISPATCH — `useRuntime().dispatch({kind})` POSTs to
+//      the same /api/plugin/presentHtml route, but with `kind: "loadHtml"|"saveHtml"`,
+//      which executeHtml doesn't handle. We intercept those before the generic
+//      catch-all and route them to executeHtmlDispatch (read/write via the artifacts
+//      FileOps); a tool-call (no `kind`) falls through to the package execute. After a
+//      save we publish a file-change so any open View live-refreshes.
+//   2. Serving the page for the iframe — the View renders `<iframe src=
+//      "/artifacts/html/…">` (htmlArtifactPreviewUrl). We serve that path from the
+//      workspace with an HTML preview CSP (sandboxed-ish: inline scripts + a curated
+//      CDN allowlist, but connect-src 'none' so a page can't phone home).
+import path from "node:path";
+import fs from "node:fs";
+import { createReadStream } from "node:fs";
+import type { Express, Request, Response, NextFunction } from "express";
+import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
+import { artifactsFileOps } from "./artifacts.js";
+import type { createPubSub } from "../pubsub.js";
+
+type PubSub = ReturnType<typeof createPubSub>;
+
+// Curated CDN allowlist (matches the collection custom-view policy) for an
+// LLM-authored page that may pull a charting/util lib or font from a CDN.
+const ALLOWED_CDNS = [
+  "https://cdn.jsdelivr.net",
+  "https://unpkg.com",
+  "https://cdnjs.cloudflare.com",
+  "https://fonts.googleapis.com",
+  "https://fonts.gstatic.com",
+  "https://cdn.plot.ly",
+].join(" ");
+
+// Preview CSP for a presentHtml page. The iframe is sandbox="allow-scripts"
+// (opaque origin), so its scripts can't reach the app origin's cookies/API anyway;
+// this additionally blocks outbound fetch/XHR (connect-src 'none' — no phone-home)
+// while allowing inline scripts + the CDN allowlist + images/media.
+const HTML_PREVIEW_CSP = [
+  "default-src 'none'",
+  `script-src 'unsafe-inline' ${ALLOWED_CDNS}`,
+  `style-src 'unsafe-inline' ${ALLOWED_CDNS}`,
+  `font-src ${ALLOWED_CDNS}`,
+  `img-src 'self' ${ALLOWED_CDNS} data: blob: https:`,
+  `media-src 'self' https: data: blob:`,
+  "connect-src 'none'",
+].join("; ");
+
+/** Intercept the View's dispatch (loadHtml/saveHtml) on /api/plugin/presentHtml,
+ *  before the generic plugin catch-all (which handles the tool-call). MUST be
+ *  registered BEFORE mountAllRoutes. `getPubsub` is a thunk because pubsub is
+ *  created after routes are mounted; the handler reads it live at request time. */
+export function mountHtmlDispatchRoute(app: Express, deps: { getPubsub: () => PubSub | null }): void {
+  app.post("/api/plugin/presentHtml", async (req: Request, res: Response, next: NextFunction) => {
+    const args = (req.body ?? {}) as { kind?: unknown; path?: unknown };
+    // A tool-call (no `kind`) is left to the package execute via the catch-all.
+    if (args.kind !== "loadHtml" && args.kind !== "saveHtml") return next();
+    try {
+      const result = await executeHtmlDispatch({ files: { artifacts: artifactsFileOps } }, args as never);
+      if (args.kind === "saveHtml" && typeof args.path === "string") {
+        // Live-refresh: bump any open View watching this file (channel matches the
+        // frontend runtime scope "html" → plugin:html:file:<path>).
+        try {
+          const stat = await artifactsFileOps.stat(toArtifactsRel(args.path));
+          deps.getPubsub()?.publish(`plugin:html:file:${args.path}`, { mtimeMs: stat.mtimeMs });
+        } catch {
+          // Best-effort; the saver already updated its local state.
+        }
+      }
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+}
+
+function toArtifactsRel(workspaceRel: string): string {
+  return workspaceRel.startsWith("artifacts/") ? workspaceRel.slice("artifacts/".length) : workspaceRel;
+}
+
+/** Serve `GET /artifacts/html/<rest>` — the iframe preview source — from the
+ *  workspace, with the HTML preview CSP. Path-contained to artifacts/html. */
+export function mountHtmlPreviewRoute(app: Express, deps: { workspace: string }): void {
+  const root = path.resolve(deps.workspace, "artifacts", "html");
+  app.get(/^\/artifacts\/html\/(.+)/, (req: Request, res: Response) => {
+    const rel = req.params[0] ?? "";
+    const abs = path.resolve(root, rel);
+    if (abs !== root && !abs.startsWith(root + path.sep)) {
+      res.status(403).json({ error: "path escapes artifacts/html" });
+      return;
+    }
+    if (!abs.toLowerCase().endsWith(".html")) {
+      res.status(400).json({ error: "not an .html file" });
+      return;
+    }
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(abs);
+    } catch {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    if (!stat.isFile()) {
+      res.status(404).json({ error: "not a file" });
+      return;
+    }
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Content-Security-Policy", HTML_PREVIEW_CSP);
+    createReadStream(abs).pipe(res);
+  });
+}

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -34,11 +34,16 @@ const ALLOWED_CDNS = [
   "https://cdn.plot.ly",
 ].join(" ");
 
-// Preview CSP for a presentHtml page. The iframe is sandbox="allow-scripts"
-// (opaque origin), so its scripts can't reach the app origin's cookies/API anyway;
-// this additionally blocks outbound fetch/XHR (connect-src 'none' — no phone-home)
-// while allowing inline scripts + the CDN allowlist + images/media.
+// Preview CSP for a presentHtml page. This HTML is LLM-authored, so the RESPONSE
+// itself must sandbox it — not just the embedding iframe. `sandbox allow-scripts`
+// (no allow-same-origin) gives the document an opaque origin even on DIRECT
+// navigation to /artifacts/html/…, so its inline scripts can't reach the app
+// origin's cookies / /api/* (matches the collection view-file hardening). The
+// iframe (also sandbox="allow-scripts") renders identically — it was already
+// opaque-origin. `connect-src 'none'` additionally blocks fetch/XHR (no phone-home);
+// inline scripts + the CDN allowlist + images/media are allowed.
 const HTML_PREVIEW_CSP = [
+  "sandbox allow-scripts",
   "default-src 'none'",
   `script-src 'unsafe-inline' ${ALLOWED_CDNS}`,
   `style-src 'unsafe-inline' ${ALLOWED_CDNS}`,

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -528,6 +529,11 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   });
 });
 
+// presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
+// /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
+// catch-all (which handles the tool-call); a request without `kind` falls through.
+mountHtmlDispatchRoute(app, { getPubsub: () => pubsub });
+
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
 // POST /api/form). The GUI MCP server dispatches tool calls to these.
 mountAllRoutes(app);
@@ -541,6 +547,10 @@ mountCollectionRoutes(app);
 // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
 // fields and custom-view <img> URLs. Rooted at the shared workspace.
 mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
+// Serve presentHtml pages for the View's iframe (GET /artifacts/html/<rest>) with an
+// HTML preview CSP. The View navigates the iframe to this URL (htmlArtifactPreviewUrl).
+mountHtmlPreviewRoute(app, { workspace: CLAUDE_CWD });
 
 // Shared launcher favorites (GET/PUT /api/shortcuts) over the same
 // <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -10,6 +10,7 @@ import { plugin as markdownPlugin } from "@mulmoclaude/markdown-plugin/vue";
 import { plugin as formPlugin } from "@mulmoclaude/form-plugin/vue";
 import { plugin as chartPlugin } from "@mulmoclaude/chart-plugin/vue";
 import { plugin as collectionPlugin } from "@mulmoclaude/collection-plugin/vue";
+import { plugin as htmlPlugin } from "@mulmoclaude/html-plugin/vue";
 import GenerateImagePlugin from "@mulmochat-plugin/generate-image/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import CollectionCardView from "./components/CollectionCardView.vue";
@@ -20,6 +21,7 @@ import CollectionCardView from "./components/CollectionCardView.vue";
 import markdownCss from "@mulmoclaude/markdown-plugin/style.css?inline";
 import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
+import htmlCss from "@mulmoclaude/html-plugin/style.css?inline";
 import { collectionShadowCss } from "./collectionShadowCss";
 // The @mulmochat-plugin family (generate-image + its peer ui-image) ships incomplete
 // CSS — it assumes a Tailwind host. This is MulmoTerminal's Tailwind layer compiled
@@ -52,6 +54,18 @@ const PACKAGES: Record<string, Registration> = {
     toolName: formPlugin.toolDefinition.name,
     viewComponent: formPlugin.viewComponent as Component,
     css: formCss,
+  },
+  "@mulmoclaude/html-plugin": {
+    toolName: htmlPlugin.toolDefinition.name,
+    // The presentHtml View uses useRuntime() (dispatch for loadHtml/saveHtml, pubsub
+    // for live-refresh). scope "html" matches the server's file-change channel
+    // (plugin:html:file:<path>); dispatch targets /api/plugin/presentHtml, where the
+    // server intercepts loadHtml/saveHtml (see server/backends/html.ts).
+    viewComponent: wrapWithPluginRuntime("html", htmlPlugin.toolDefinition.name, htmlPlugin.viewComponent as unknown as Component),
+    css: htmlCss,
+    // The View renders an h-full iframe; give it a definite frame height (like the
+    // collection card) so the page renders, with internal scroll.
+    height: "80vh",
   },
   "@mulmochat-plugin/generate-image": {
     toolName: GenerateImagePlugin.plugin.toolDefinition.name,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig({
         target: "http://localhost:3456",
         changeOrigin: true,
       },
+      // presentHtml page serving (the View's iframe src). Without this, the dev
+      // Vite catch-all returns index.html instead of the HTML artifact.
+      "/artifacts": {
+        target: "http://localhost:3456",
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,6 +565,11 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/form-plugin/-/form-plugin-0.1.1.tgz#54825cc7ecb3eded0d9d6d7bc0c04214bf7c78da"
   integrity sha512-gTXROs5Qs98GVPb5f8MM6EtlDXHFcLeeNMfiUnG/A05rMQobmiTw9QoEGVROIJlFBbFsD7s6DAsrBBx1KDvFBA==
 
+"@mulmoclaude/html-plugin@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/html-plugin/-/html-plugin-0.2.2.tgz#5cf97960ab31d4a0f9551a1e8d3bb7d3633cc599"
+  integrity sha512-Tp3451o/3uQQxoFcYRQLOfom4sG+AC4XERVyV/CdNJFYj1tgagSkhwVqKdQJnc/Xt1oirrAV5E6qyE4CgTOwlA==
+
 "@mulmoclaude/markdown-plugin@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-0.1.4.tgz#767684c558686248691148837e0a6107e8d580e6"


### PR DESCRIPTION
## What

Adds **`presentHtml`** to MulmoTerminal by consuming the just-published **`@mulmoclaude/html-plugin@0.2.2`** (Option B from `mulmoclaude/plans/feat-presenthtml-mulmoterminal.md`). This closes the gap where HTML-page skills (e.g. `lessons-biology`'s `learn.md`) made the agent hunt for a non-existent `presentHtml` and fall back to `presentDocument` (markdown), losing the styled page.

## How

**Server** (`server/backends/html.ts`)
- `mountHtmlDispatchRoute` — intercepts the View's source-editor dispatch (`loadHtml`/`saveHtml`) on `/api/plugin/presentHtml` **before** the generic plugin catch-all, routing to the package's `executeHtmlDispatch` over the artifacts `FileOps`. A tool-call (no `kind`) falls through to the package's `executeHtml`. Publishes `plugin:html:file:<path>` after a save for live-refresh.
- `mountHtmlPreviewRoute` — serves `GET /artifacts/html/<rest>` (the View's iframe `src`, `htmlArtifactPreviewUrl`) from the workspace with an **HTML preview CSP** (inline scripts + curated CDN allowlist, `connect-src 'none'`), `nosniff`, and path containment.
- The `presentHtml` tool-call itself is handled by the generic package loader (`plugins.json` `packages` → artifacts `FileOps` context) — no bespoke server execute.

**Frontend**
- Register the html `ToolPlugin` in `plugins-registry.ts`, wrapped with `wrapWithPluginRuntime("html", …)` (so the View's `dispatch`/`pubsub` work) + `style.css?inline` + a fixed `80vh` frame (the View's iframe is `h-full`).
- `plugins.json` `packages` += `@mulmoclaude/html-plugin` (drives both server load + frontend).
- `vite.config.ts` — proxy `/artifacts` to the backend in dev (the iframe src).

## Verification

- 7 new route tests (loadHtml / saveHtml / containment / tool-call fall-through; preview serving CSP / 403 / 404). **94 tests** total.
- client + server typecheck, `yarn build`, `yarn lint` pass.
- Live smoke: tool-call save → `artifacts/html/…html`; the page serves at `/artifacts/html/…` with the preview CSP + content; `loadHtml`/`saveHtml` dispatch round-trips; `../../etc/passwd` blocked.

## Notes

- Live-refresh fires on the View's own `saveHtml`. A background agent editing the file *directly* (Write tool) won't publish the change (same broad live-refresh gap as collections) — a follow-up could forward workspace file-change events onto `plugin:html:file:<path>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)