### PR TITLE
fix: sanitize session ids so an invalid persisted id can't infinite-loop (#46)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -990,12 +990,14 @@ wss.on("connection", (ws, req) => {
   // ?session=<id> resumes an existing conversation; absent => fresh session. For
   // new sessions we generate the id ourselves (--session-id) so the server always
   // knows the current session's id, even before any file exists.
-  const requested = new URL(req.url ?? "/", "http://localhost").searchParams.get("session");
-  if (requested && !SESSION_ID_RE.test(requested)) {
-    console.warn(`[ws] rejecting non-UUID session id: ${JSON.stringify(requested)}`);
-    ws.close();
-    return;
-  }
+  const raw = new URL(req.url ?? "/", "http://localhost").searchParams.get("session");
+  // A non-UUID id is never used (it could smuggle path/flag fragments into
+  // sessionExistsOnDisk / --resume). Treat it as "no session requested" rather
+  // than closing the socket — closing without a replacement id makes the client
+  // auto-reconnect with the same bad id forever. Falling through mints a fresh
+  // session and tells the browser the new id, so the cell self-recovers.
+  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
+  if (raw && !requested) console.warn(`[ws] ignoring non-UUID session id: ${JSON.stringify(raw)} — starting fresh`);
 
   // Decide the effective session id BEFORE telling the browser. A requested id
   // is honored only if it can actually be served: a live pty (reattach) or an

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -34,13 +34,15 @@ describe("TerminalGrid", () => {
   });
 
   it("restores each cell's session id and the zoom from localStorage", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ["id-a", null, "id-c", null], expanded: 2 }));
+    const idA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const idC = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [idA, null, idC, null], expanded: 2 }));
     const w = mount(TerminalGrid);
     await flushPromises();
     const cells = cellsOf(w);
-    expect(cells[0].props("initialSessionId")).toBe("id-a");
+    expect(cells[0].props("initialSessionId")).toBe(idA);
     expect(cells[1].props("initialSessionId")).toBe(null);
-    expect(cells[2].props("initialSessionId")).toBe("id-c");
+    expect(cells[2].props("initialSessionId")).toBe(idC);
     expect(cells[2].props("expanded")).toBe(true);
     expect(cells[0].props("expanded")).toBe(false);
   });
@@ -81,6 +83,24 @@ describe("TerminalGrid", () => {
     await nextTick();
     expect(cellsOf(w)[3].props("expanded")).toBe(false);
     expect(saved().expanded).toBe(null);
+  });
+
+  it("drops non-UUID persisted session ids (no invalid id reaches a cell)", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ["not-a-uuid", "../etc/passwd", "id-a", null], expanded: null }));
+    const w = mount(TerminalGrid);
+    await flushPromises();
+    const cells = cellsOf(w);
+    expect(cells[0].props("initialSessionId")).toBe(null);
+    expect(cells[1].props("initialSessionId")).toBe(null);
+    expect(cells[2].props("initialSessionId")).toBe(null); // "id-a" isn't a valid UUID either
+  });
+
+  it("keeps a valid UUID persisted id", async () => {
+    const uuid = "abcdef01-2345-6789-abcd-ef0123456789";
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [uuid, null, null, null], expanded: null }));
+    const w = mount(TerminalGrid);
+    await flushPromises();
+    expect(cellsOf(w)[0].props("initialSessionId")).toBe(uuid);
   });
 
   it("ignores a corrupt localStorage payload", async () => {

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -25,6 +25,10 @@ onMounted(async () => {
 // Persisted so a page reload restores the open terminals (each cell resumes its
 // session) and the zoom state.
 const STORE_KEY = "grid_state_v1";
+// Session ids are UUIDs. Drop anything else from a stale/tampered localStorage so
+// a cell never mounts with an invalid id (which the server rejects, leaving the
+// terminal reconnecting forever).
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function loadState(): { sessions: (string | null)[]; expanded: number | null } {
   const fallback = { sessions: Array<string | null>(CELL_COUNT).fill(null), expanded: null };
@@ -34,7 +38,7 @@ function loadState(): { sessions: (string | null)[]; expanded: number | null } {
     const parsed = JSON.parse(raw);
     const sessions = Array.from({ length: CELL_COUNT }, (_, i) => {
       const v = parsed?.sessions?.[i];
-      return typeof v === "string" ? v : null;
+      return typeof v === "string" && UUID_RE.test(v) ? v : null;
     });
     const e = parsed?.expanded;
     const expanded = typeof e === "number" && e >= 0 && e < CELL_COUNT ? e : null;


### PR DESCRIPTION
## Summary

Follow-up to #48 — the last open Codex point. A non-UUID session id persisted in
`localStorage` made a grid cell connect `?session=<invalid>`; the server rejected it
by **closing the socket without a replacement id**, so the client's auto-reconnect
retried the same bad id **forever** and the cell never recovered.

Two layers:
- **`TerminalGrid`**: validate persisted ids against the UUID shape on load and drop
  invalid ones (the cell starts empty), so a bad id never reaches the server.
- **`server`**: a non-UUID `?session=` is now treated as "no session requested" — mint
  a fresh id and send it back — instead of close-without-recovery, so the cell self-heals
  even if a bad id slips through. The id is still never used in path / `--resume` positions,
  so the original security guard is intact.
- **tests**: invalid/non-UUID persisted ids are dropped; a valid UUID is kept (43 tests).

## Verification

`lint` / `typecheck` / `typecheck:server` / `test` (43) / `build` ✅.

base: `dev_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)