### PR TITLE
feat(grid): layout selection (2x2/3x2/4x2/3x3) + per-terminal working dir (#46)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1031,8 +1031,10 @@ wss.on("connection", (ws, req) => {
   const sessionId = reattachId ?? resume ?? randomUUID();
   const live = reattachId ? ptys.get(reattachId) : undefined;
 
-  // Tell the browser which session this is (it learns the id of new sessions).
-  ws.send(JSON.stringify({ type: "session", id: sessionId }));
+  // Tell the browser which session this is (it learns the id of new sessions) and
+  // the EFFECTIVE cwd — which may differ from what was requested (resolveWorkspace
+  // falls back to CLAUDE_CWD), so the cell shows/persists where claude really runs.
+  ws.send(JSON.stringify({ type: "session", id: sessionId, cwd }));
 
   let entry: PtyEntry;
   try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import path from "path";
 import os from "os";
 import fs from "fs/promises";
 import { randomUUID } from "crypto";
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { fileURLToPath } from "url";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createPubSub } from "./pubsub.js";
@@ -456,9 +456,23 @@ function projectSessionsDir(cwd: string) {
 }
 
 // Whether a session has an on-disk transcript (claude only writes it after the
-// first prompt). Determines whether `--resume <id>` will succeed.
-function sessionExistsOnDisk(id: string): boolean {
-  return existsSync(path.join(projectSessionsDir(CLAUDE_CWD), `${id}.jsonl`));
+// first prompt) in the given workspace. Determines whether `--resume` will work.
+function sessionExistsOnDisk(id: string, cwd: string): boolean {
+  return existsSync(path.join(projectSessionsDir(cwd), `${id}.jsonl`));
+}
+
+// Validate a client-supplied workspace dir: must be an absolute, existing
+// directory. Anything else (relative, missing, a file) falls back to CLAUDE_CWD,
+// so a cell can launch a terminal in a chosen dir without trusting raw input.
+function resolveWorkspace(cwd: string | null): string {
+  if (cwd && path.isAbsolute(cwd)) {
+    try {
+      if (statSync(cwd).isDirectory()) return cwd;
+    } catch {
+      // not a dir / doesn't exist — fall through
+    }
+  }
+  return CLAUDE_CWD;
 }
 
 // A real user prompt from a JSONL "user" line's content, or null if it's a
@@ -865,7 +879,7 @@ function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntr
 // a viewer yet (e.g. spawnBackgroundChat) — output just buffers until a client
 // reattaches. `initialPrompt`, when given, is passed to claude as the first turn
 // so the session starts working immediately, before anyone opens it.
-function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, initialPrompt?: string): PtyEntry {
+function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, initialPrompt?: string, cwd: string = CLAUDE_CWD): PtyEntry {
   const settings = hookSettingsJson();
   // Register the GUI MCP server and auto-allow its tools so the plugin tools run
   // without a permission prompt. We deliberately do NOT pass --strict-mcp-config:
@@ -880,7 +894,7 @@ function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket 
   // no record — resuming it would fail ("[session ended]"). In that case (no live
   // pty either, since reattach already happened upstream) restart fresh, reusing
   // the same id via --session-id, so a reload of an idle cell just reopens it.
-  const canResume = resume !== null && sessionExistsOnDisk(resume);
+  const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
   const baseArgs = canResume ? ["--resume", resume, "--settings", settings, ...guiArgs] : ["--session-id", sessionId, "--settings", settings, ...guiArgs];
   // The initial prompt goes last as a positional arg (claude's initial-prompt
   // form). "--" ends option parsing so a prompt that happens to start with "-"
@@ -893,10 +907,10 @@ function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket 
     name: "xterm-256color",
     cols: 120,
     rows: 30,
-    cwd: CLAUDE_CWD,
+    cwd,
     env: process.env,
   });
-  console.log(`[pty] spawned claude (pid=${term.pid})`);
+  console.log(`[pty] spawned claude (pid=${term.pid}) in ${cwd}`);
 
   const entry: PtyEntry = { term, ws, buffer: "" };
   ptys.set(sessionId, entry);
@@ -990,7 +1004,8 @@ wss.on("connection", (ws, req) => {
   // ?session=<id> resumes an existing conversation; absent => fresh session. For
   // new sessions we generate the id ourselves (--session-id) so the server always
   // knows the current session's id, even before any file exists.
-  const raw = new URL(req.url ?? "/", "http://localhost").searchParams.get("session");
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const raw = url.searchParams.get("session");
   // A non-UUID id is never used (it could smuggle path/flag fragments into
   // sessionExistsOnDisk / --resume). Treat it as "no session requested" rather
   // than closing the socket — closing without a replacement id makes the client
@@ -998,6 +1013,11 @@ wss.on("connection", (ws, req) => {
   // session and tells the browser the new id, so the cell self-recovers.
   const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
   if (raw && !requested) console.warn(`[ws] ignoring non-UUID session id: ${JSON.stringify(raw)} — starting fresh`);
+
+  // The cell may launch a terminal in a chosen directory (?cwd=<abs>). Validated
+  // (absolute, existing dir) and used as the PTY cwd + the project to resume from;
+  // falls back to CLAUDE_CWD.
+  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
 
   // Decide the effective session id BEFORE telling the browser. A requested id
   // is honored only if it can actually be served: a live pty (reattach) or an
@@ -1007,7 +1027,7 @@ wss.on("connection", (ws, req) => {
   // So mint a fresh id; the browser adopts it from this `session` message and
   // re-persists, so the reload just reopens a working terminal seamlessly.
   const reattachId = requested && ptys.has(requested) ? requested : null;
-  const resume = !reattachId && requested && sessionExistsOnDisk(requested) ? requested : null;
+  const resume = !reattachId && requested && sessionExistsOnDisk(requested, cwd) ? requested : null;
   const sessionId = reattachId ?? resume ?? randomUUID();
   const live = reattachId ? ptys.get(reattachId) : undefined;
 
@@ -1016,7 +1036,7 @@ wss.on("connection", (ws, req) => {
 
   let entry: PtyEntry;
   try {
-    entry = live ? reattachPty(live, ws, sessionId) : spawnClaudePty(sessionId, resume, ws);
+    entry = live ? reattachPty(live, ws, sessionId) : spawnClaudePty(sessionId, resume, ws, undefined, cwd);
   } catch (err) {
     // A failed spawn (claude missing, or node-pty's spawn-helper not executable)
     // must close just this connection — never crash the whole server.

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ interface PtyEntry {
   term: IPty;
   ws: WebSocket | null;
   buffer: string;
+  cwd: string; // the dir the PTY actually runs in (reported on reattach)
 }
 
 interface KnownSession {
@@ -912,7 +913,7 @@ function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket 
   });
   console.log(`[pty] spawned claude (pid=${term.pid}) in ${cwd}`);
 
-  const entry: PtyEntry = { term, ws, buffer: "" };
+  const entry: PtyEntry = { term, ws, buffer: "", cwd };
   ptys.set(sessionId, entry);
 
   if (!canResume) {
@@ -1032,9 +1033,11 @@ wss.on("connection", (ws, req) => {
   const live = reattachId ? ptys.get(reattachId) : undefined;
 
   // Tell the browser which session this is (it learns the id of new sessions) and
-  // the EFFECTIVE cwd — which may differ from what was requested (resolveWorkspace
-  // falls back to CLAUDE_CWD), so the cell shows/persists where claude really runs.
-  ws.send(JSON.stringify({ type: "session", id: sessionId, cwd }));
+  // the EFFECTIVE cwd — where claude really runs. On reattach that's the live
+  // PTY's own cwd (NOT this request's ?cwd=, which it ignores); otherwise it's the
+  // resolved cwd the new PTY will spawn in.
+  const reportedCwd = live?.cwd ?? cwd;
+  ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: reportedCwd }));
 
   let entry: PtyEntry;
   try {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,25 @@
 <script setup lang="ts">
+import { ref, watch } from "vue";
 import TerminalGrid from "./components/TerminalGrid.vue";
+import { LAYOUTS, isLayout, type Layout } from "./components/gridLayout";
+
+// Grid layout (cell arrangement), chosen in the toolbar and persisted.
+const stored = localStorage.getItem("grid_layout");
+const layout = ref<Layout>(isLayout(stored) ? stored : "2x2");
+watch(layout, (v) => localStorage.setItem("grid_layout", v));
 </script>
 
 <template>
   <div class="shell">
     <header class="toolbar">
       <span class="toolbar-title">MulmoTerminal</span>
+      <span class="layout-picker" role="group" aria-label="Grid layout">
+        <button v-for="l in LAYOUTS" :key="l" :class="['layout-btn', { active: layout === l }]" :aria-pressed="layout === l" @click="layout = l">
+          {{ l }}
+        </button>
+      </span>
     </header>
-    <TerminalGrid class="main" />
+    <TerminalGrid class="main" :layout="layout" />
   </div>
 </template>
 
@@ -20,11 +32,12 @@ import TerminalGrid from "./components/TerminalGrid.vue";
   overflow: hidden;
 }
 
-/* Top toolbar with the app title. */
+/* Top toolbar with the app title + layout picker. */
 .toolbar {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  gap: 16px;
   height: 40px;
   padding: 0 16px;
   background: #16213e;
@@ -36,6 +49,31 @@ import TerminalGrid from "./components/TerminalGrid.vue";
   font-size: 14px;
   color: #e6e6f0;
   letter-spacing: 0.02em;
+}
+
+.layout-picker {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+.layout-btn {
+  border: 1px solid #2a2a4e;
+  background: #1a1a2e;
+  color: #9aa3c0;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.layout-btn:hover {
+  background: #2a3b66;
+  color: #e6e6f0;
+}
+.layout-btn.active {
+  background: #2a3b66;
+  color: #fff;
+  border-color: #4a8cff;
 }
 
 /* The grid fills everything under the toolbar. */

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -8,7 +8,7 @@ import "@xterm/xterm/css/xterm.css";
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
 // session (or starting another fresh one) still forces a reconnect.
-const props = defineProps<{ sessionId: string | null; connectKey: number }>();
+const props = defineProps<{ sessionId: string | null; connectKey: number; cwd?: string | null }>();
 const emit = defineEmits<{ (e: "session", id: string): void }>();
 
 const terminalRef = ref<HTMLDivElement>();
@@ -58,8 +58,12 @@ function connect() {
   // Resume the known id (learned from the server, or the prop) so a reconnect
   // re-attaches the same session instead of spawning a fresh one each retry.
   const resumeId = knownSessionId ?? props.sessionId;
-  const query = resumeId ? `?session=${encodeURIComponent(resumeId)}` : "";
-  const sock = new WebSocket(`${proto}//${location.host}/ws${query}`);
+  const params = new URLSearchParams();
+  if (resumeId) params.set("session", resumeId);
+  if (props.cwd) params.set("cwd", props.cwd); // launch this terminal in the chosen dir
+  const qs = params.toString();
+  const suffix = qs ? `?${qs}` : "";
+  const sock = new WebSocket(`${proto}//${location.host}/ws${suffix}`);
   ws = sock;
 
   sock.onopen = () => {

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -9,7 +9,7 @@ import "@xterm/xterm/css/xterm.css";
 // `connectKey` increments on every user action so re-selecting the same
 // session (or starting another fresh one) still forces a reconnect.
 const props = defineProps<{ sessionId: string | null; connectKey: number; cwd?: string | null }>();
-const emit = defineEmits<{ (e: "session", id: string): void }>();
+const emit = defineEmits<{ (e: "session" | "cwd", value: string): void }>();
 
 const terminalRef = ref<HTMLDivElement>();
 const status = ref<"connecting" | "connected" | "disconnected">("connecting");
@@ -80,9 +80,12 @@ function connect() {
       term.write(msg.data);
     } else if (msg.type === "session") {
       // Server reports the live session id — remember it so a later reconnect
-      // resumes THIS session (esp. for brand-new sessions that had no id yet).
+      // resumes THIS session (esp. for brand-new sessions that had no id yet) —
+      // and the EFFECTIVE cwd, which the cell adopts (the server may have fallen
+      // back from the requested dir).
       knownSessionId = msg.id;
       emit("session", msg.id);
+      if (typeof msg.cwd === "string") emit("cwd", msg.cwd);
     } else if (msg.type === "exit") {
       // claude itself exited — an intentional end; don't auto-reconnect.
       sawExit = true;

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -19,7 +19,7 @@ vi.mock("../composables/usePubSub", () => ({
 vi.mock("./Terminal.vue", () => ({
   default: {
     name: "TerminalView",
-    props: ["sessionId", "connectKey"],
+    props: ["sessionId", "connectKey", "cwd"],
     emits: ["session"],
     template: '<div class="stub-term" />',
     methods: { terminate() {} },
@@ -34,8 +34,10 @@ beforeEach(() => {
   globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) })) as unknown as typeof fetch;
 });
 
-function mountCell(initialSessionId: string | null) {
-  return mount(TerminalCell, { props: { expanded: false, initialSessionId, cwd: "/home/me/my-project" } });
+function mountCell(initialSessionId: string | null, opts: { initialCwd?: string | null; defaultCwd?: string | null } = {}) {
+  return mount(TerminalCell, {
+    props: { expanded: false, initialSessionId, initialCwd: opts.initialCwd ?? null, defaultCwd: opts.defaultCwd ?? "/home/me/my-project" },
+  });
 }
 
 describe("TerminalCell", () => {
@@ -46,9 +48,20 @@ describe("TerminalCell", () => {
   });
 
   it("derives the basename from a Windows-style path too", async () => {
-    const w = mount(TerminalCell, { props: { expanded: false, initialSessionId: "55555555-5555-5555-5555-555555555555", cwd: "C:\\work\\proj" } });
+    const w = mountCell("55555555-5555-5555-5555-555555555555", { initialCwd: "C:\\work\\proj" });
     await flushPromises();
     expect(w.find(".cell-dir").text()).toBe("proj");
+  });
+
+  it("launches in the dir typed in the form (emits cwd, mounts the terminal)", async () => {
+    const w = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    expect(w.find(".cell-launch").exists()).toBe(true);
+    await w.find(".cell-dir-input").setValue("/home/me/picked");
+    await w.find(".cell-start").trigger("click");
+    expect(w.emitted("cwd")?.[0]).toEqual(["/home/me/picked"]);
+    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true);
+    expect(w.findComponent({ name: "TerminalView" }).props("cwd")).toBe("/home/me/picked");
   });
 
   it("reflects working/waiting/lastPrompt pushed for its own session", async () => {

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -64,6 +64,17 @@ describe("TerminalCell", () => {
     expect(term.props("cwd")).toBe("/home/me/picked");
   });
 
+  it("resets the launch form to the default dir after close", async () => {
+    const w = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    await w.find(".cell-dir-input").setValue("/home/me/picked");
+    await w.find(".cell-start").trigger("click");
+    await w.find(".cell-close").trigger("click");
+    await nextTick();
+    expect(w.find(".cell-launch").exists()).toBe(true);
+    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/default");
+  });
+
   it("adopts the EFFECTIVE cwd the server reports (persists/shows that, not the typed one)", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -53,15 +53,28 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-dir").text()).toBe("proj");
   });
 
-  it("launches in the dir typed in the form (emits cwd, mounts the terminal)", async () => {
+  it("launches in the dir typed in the form and sends it to the terminal", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
     expect(w.find(".cell-launch").exists()).toBe(true);
     await w.find(".cell-dir-input").setValue("/home/me/picked");
     await w.find(".cell-start").trigger("click");
-    expect(w.emitted("cwd")?.[0]).toEqual(["/home/me/picked"]);
-    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true);
-    expect(w.findComponent({ name: "TerminalView" }).props("cwd")).toBe("/home/me/picked");
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.exists()).toBe(true);
+    expect(term.props("cwd")).toBe("/home/me/picked");
+  });
+
+  it("adopts the EFFECTIVE cwd the server reports (persists/shows that, not the typed one)", async () => {
+    const w = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    await w.find(".cell-dir-input").setValue("relative/bad/path");
+    await w.find(".cell-start").trigger("click");
+    // Server rejected the bad path and fell back; it reports the real cwd.
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/default");
+    await nextTick();
+    // The cell persists + displays the effective cwd, not the typed one.
+    expect(w.emitted("cwd")?.at(-1)).toEqual(["/home/me/default"]);
+    expect(w.find(".cell-dir").text()).toBe("default");
   });
 
   it("reflects working/waiting/lastPrompt pushed for its own session", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -101,6 +101,10 @@ function close() {
   working.value = false;
   waiting.value = false;
   lastPrompt.value = null;
+  // The cell isn't remounted (stable key), so reset the dir state too — otherwise
+  // the empty launch form would still show the closed session's directory.
+  cwd.value = props.defaultCwd;
+  dirInput.value = props.defaultCwd ?? "";
   emit("close");
 }
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1,22 +1,35 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, useTemplateRef } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vue";
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 
 // `expanded` reflects whether this cell is zoomed to fill the grid (parent owns
-// the state). `initialSessionId` is a persisted session to resume on mount, so a
-// page reload restores the terminals that were open (empty if null). `cwd` is the
-// workspace directory shown in the header.
-const props = defineProps<{ expanded: boolean; initialSessionId: string | null; cwd: string | null }>();
-const emit = defineEmits<{ (e: "toggle-expand" | "close"): void; (e: "session", id: string): void }>();
+// the state). `initialSessionId` resumes a session on mount (reload restore).
+// `initialCwd` is this cell's persisted working dir; `defaultCwd` is the server
+// default used to prefill the launch form for a fresh cell.
+const props = defineProps<{ expanded: boolean; initialSessionId: string | null; initialCwd: string | null; defaultCwd: string | null }>();
+const emit = defineEmits<{ (e: "toggle-expand" | "close"): void; (e: "session" | "cwd", value: string): void }>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
-// starts empty and lazy-launches when the user clicks "New terminal".
+// starts empty and lazy-launches when the user picks a dir and clicks Start.
 const launched = ref(props.initialSessionId !== null);
 const sessionId = ref<string | null>(props.initialSessionId);
 const connectKey = ref(0);
+
+// The directory this terminal runs in (shown in the header, sent to the server).
+const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
+// The launch form's editable dir; prefilled with the default once it's fetched.
+const dirInput = ref(props.initialCwd ?? props.defaultCwd ?? "");
+watch(
+  () => props.defaultCwd,
+  (d) => {
+    if (!d) return;
+    if (!dirInput.value) dirInput.value = d;
+    if (cwd.value === null) cwd.value = d;
+  },
+);
 
 // Live activity for this session, from the "sessions" pub/sub channel.
 const working = ref(false);
@@ -42,8 +55,6 @@ function applyActivity(d: ActivityMsg) {
   if (d.lastPrompt !== undefined) lastPrompt.value = d.lastPrompt;
 }
 
-// Pull the initial status + last prompt so the header is populated immediately;
-// live changes then arrive via pub/sub.
 async function loadInitial(id: string) {
   try {
     const res = await fetch(`/api/session/${id}`);
@@ -66,6 +77,8 @@ onMounted(() => {
 onUnmounted(() => unsubscribe?.());
 
 function launch() {
+  cwd.value = dirInput.value.trim() || props.defaultCwd;
+  if (cwd.value) emit("cwd", cwd.value);
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
@@ -92,11 +105,11 @@ function onSession(id: string) {
 }
 
 const dirBase = computed(() => {
-  if (!props.cwd) return "";
-  // Split on both separators so a Windows path (C:\work\proj) yields the basename
-  // too, not the whole path.
-  const parts = props.cwd.split(/[/\\]/).filter(Boolean);
-  return parts[parts.length - 1] || props.cwd;
+  const c = cwd.value;
+  if (!c) return "";
+  // Split on both separators so a Windows path (C:\work\proj) yields the basename.
+  const parts = c.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] || c;
 });
 
 // Attention (waiting) wins over working wins over idle.
@@ -132,9 +145,13 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
           <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
         </span>
       </div>
-      <TerminalView ref="termRef" class="cell-term" :session-id="sessionId" :connect-key="connectKey" @session="onSession" />
+      <TerminalView ref="termRef" class="cell-term" :session-id="sessionId" :connect-key="connectKey" :cwd="cwd" @session="onSession" />
     </template>
-    <button v-else class="cell-empty" @click="launch">＋ New terminal</button>
+    <div v-else class="cell-launch">
+      <label class="cell-launch-label">Working directory</label>
+      <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
+      <button class="cell-start" @click="launch">＋ New terminal</button>
+    </div>
   </div>
 </template>
 
@@ -240,18 +257,52 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   min-height: 0;
 }
 
-.cell-empty {
+/* Empty cell: pick a directory, then launch. */
+.cell-launch {
   flex: 1;
-  border: none;
-  background: transparent;
-  color: #8b93b8;
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 16px;
-  font-weight: 500;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 16px;
 }
-.cell-empty:hover {
+.cell-launch-label {
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  color: #6b7394;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.cell-dir-input {
+  width: 100%;
+  max-width: 360px;
+  box-sizing: border-box;
+  padding: 7px 10px;
+  background: #11111f;
+  border: 1px solid #2a2a4e;
+  border-radius: 6px;
+  color: #e6e6f0;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+}
+.cell-dir-input:focus {
+  outline: none;
+  border-color: #4a8cff;
+}
+.cell-start {
+  border: 1px solid #2a2a4e;
   background: #20203a;
   color: #c7cdf0;
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 7px 16px;
+  border-radius: 6px;
+}
+.cell-start:hover {
+  background: #2a3b66;
+  color: #fff;
 }
 </style>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -77,11 +77,19 @@ onMounted(() => {
 onUnmounted(() => unsubscribe?.());
 
 function launch() {
+  // Optimistic display only; the persisted/displayed truth is the EFFECTIVE cwd
+  // the server confirms (onServerCwd), since it may fall back from a bad path.
   cwd.value = dirInput.value.trim() || props.defaultCwd;
-  if (cwd.value) emit("cwd", cwd.value);
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
+}
+
+// The server reports where the PTY actually runs (it may have rejected the
+// requested dir). Adopt it as the truth — display and persist the effective cwd.
+function onServerCwd(c: string) {
+  cwd.value = c;
+  emit("cwd", c);
 }
 
 function close() {
@@ -145,7 +153,7 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
           <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
         </span>
       </div>
-      <TerminalView ref="termRef" class="cell-term" :session-id="sessionId" :connect-key="connectKey" :cwd="cwd" @session="onSession" />
+      <TerminalView ref="termRef" class="cell-term" :session-id="sessionId" :connect-key="connectKey" :cwd="cwd" @session="onSession" @cwd="onServerCwd" />
     </template>
     <div v-else class="cell-launch">
       <label class="cell-launch-label">Working directory</label>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -160,8 +160,10 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
       <TerminalView ref="termRef" class="cell-term" :session-id="sessionId" :connect-key="connectKey" :cwd="cwd" @session="onSession" @cwd="onServerCwd" />
     </template>
     <div v-else class="cell-launch">
-      <label class="cell-launch-label">Working directory</label>
-      <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
+      <label class="cell-launch-label">
+        <span class="cell-launch-caption">Working directory</span>
+        <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
+      </label>
       <button class="cell-start" @click="launch">＋ New terminal</button>
     </div>
   </div>
@@ -280,6 +282,14 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   padding: 16px;
 }
 .cell-launch-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  max-width: 360px;
+}
+.cell-launch-caption {
   font-family: system-ui, sans-serif;
   font-size: 11px;
   color: #6b7394;
@@ -288,7 +298,6 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 }
 .cell-dir-input {
   width: 100%;
-  max-width: 360px;
   box-sizing: border-box;
   padding: 7px 10px;
   background: #11111f;

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
+import type { Layout } from "./gridLayout";
 
-// Stub the cell so the grid's own state (localStorage persist/restore + zoom)
-// can be tested without pulling in Terminal/xterm/pub-sub.
+// Stub the cell so the grid's own state (localStorage persist/restore + zoom +
+// layout) can be tested without pulling in Terminal/xterm/pub-sub.
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
@@ -15,6 +16,7 @@ vi.mock("./TerminalCell.vue", () => ({
 }));
 
 const STORE_KEY = "grid_state_v1";
+const mountGrid = (layout: Layout = "2x2") => mount(TerminalGrid, { props: { layout } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const saved = () => JSON.parse(localStorage.getItem(STORE_KEY) || "{}");
 
@@ -24,37 +26,50 @@ beforeEach(() => {
 });
 
 describe("TerminalGrid", () => {
-  it("renders a fixed 2x2 of empty cells by default", async () => {
-    const w = mount(TerminalGrid);
+  it("renders cellCount cells per layout", () => {
+    expect(cellsOf(mountGrid("2x2"))).toHaveLength(4);
+    expect(cellsOf(mountGrid("3x2"))).toHaveLength(6);
+    expect(cellsOf(mountGrid("4x2"))).toHaveLength(8);
+    expect(cellsOf(mountGrid("3x3"))).toHaveLength(9);
+  });
+
+  it("re-renders the cell count when the layout prop changes", async () => {
+    const w = mountGrid("2x2");
+    expect(cellsOf(w)).toHaveLength(4);
+    await w.setProps({ layout: "3x3" });
+    expect(cellsOf(w)).toHaveLength(9);
+  });
+
+  it("un-zooms when the layout shrinks below the expanded cell", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [], expanded: 8 }));
+    const w = mountGrid("3x3");
     await flushPromises();
-    const cells = cellsOf(w);
-    expect(cells).toHaveLength(4);
-    expect(cells.every((c) => c.props("initialSessionId") === null)).toBe(true);
-    expect(cells.every((c) => c.props("expanded") === false)).toBe(true);
+    expect(cellsOf(w)[8].props("expanded")).toBe(true);
+    await w.setProps({ layout: "2x2" });
+    expect(cellsOf(w).every((c) => c.props("expanded") === false)).toBe(true);
+    expect(saved().expanded).toBe(null);
   });
 
   it("restores each cell's session id and the zoom from localStorage", async () => {
     const idA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
     const idC = "cccccccc-cccc-cccc-cccc-cccccccccccc";
     localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [idA, null, idC, null], expanded: 2 }));
-    const w = mount(TerminalGrid);
+    const w = mountGrid("2x2");
     await flushPromises();
     const cells = cellsOf(w);
     expect(cells[0].props("initialSessionId")).toBe(idA);
-    expect(cells[1].props("initialSessionId")).toBe(null);
     expect(cells[2].props("initialSessionId")).toBe(idC);
     expect(cells[2].props("expanded")).toBe(true);
-    expect(cells[0].props("expanded")).toBe(false);
   });
 
   it("passes the fetched cwd to cells", async () => {
-    const w = mount(TerminalGrid);
+    const w = mountGrid();
     await flushPromises();
     expect(cellsOf(w)[0].props("cwd")).toBe("/work/proj");
   });
 
   it("persists a cell's session id when it emits 'session'", async () => {
-    const w = mount(TerminalGrid);
+    const w = mountGrid();
     await flushPromises();
     cellsOf(w)[1].vm.$emit("session", "new-id");
     await nextTick();
@@ -62,18 +77,18 @@ describe("TerminalGrid", () => {
   });
 
   it("clears the slot (and un-zooms) when a cell emits 'close'", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ["id-a", null, null, null], expanded: 0 }));
-    const w = mount(TerminalGrid);
+    const idA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [idA, null, null, null], expanded: 0 }));
+    const w = mountGrid("2x2");
     await flushPromises();
     cellsOf(w)[0].vm.$emit("close");
     await nextTick();
     expect(saved().sessions[0]).toBe(null);
     expect(saved().expanded).toBe(null);
-    expect(cellsOf(w)[0].props("expanded")).toBe(false);
   });
 
   it("toggles zoom on 'toggle-expand' and back off when emitted again", async () => {
-    const w = mount(TerminalGrid);
+    const w = mountGrid();
     await flushPromises();
     cellsOf(w)[3].vm.$emit("toggle-expand");
     await nextTick();
@@ -81,34 +96,29 @@ describe("TerminalGrid", () => {
     expect(saved().expanded).toBe(3);
     cellsOf(w)[3].vm.$emit("toggle-expand");
     await nextTick();
-    expect(cellsOf(w)[3].props("expanded")).toBe(false);
     expect(saved().expanded).toBe(null);
   });
 
-  it("drops non-UUID persisted session ids (no invalid id reaches a cell)", async () => {
+  it("drops non-UUID persisted session ids", async () => {
     localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ["not-a-uuid", "../etc/passwd", "id-a", null], expanded: null }));
-    const w = mount(TerminalGrid);
+    const w = mountGrid("2x2");
     await flushPromises();
-    const cells = cellsOf(w);
-    expect(cells[0].props("initialSessionId")).toBe(null);
-    expect(cells[1].props("initialSessionId")).toBe(null);
-    expect(cells[2].props("initialSessionId")).toBe(null); // "id-a" isn't a valid UUID either
+    expect(cellsOf(w).every((c) => c.props("initialSessionId") === null)).toBe(true);
   });
 
   it("keeps a valid UUID persisted id", async () => {
     const uuid = "abcdef01-2345-6789-abcd-ef0123456789";
     localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [uuid, null, null, null], expanded: null }));
-    const w = mount(TerminalGrid);
+    const w = mountGrid("2x2");
     await flushPromises();
     expect(cellsOf(w)[0].props("initialSessionId")).toBe(uuid);
   });
 
   it("ignores a corrupt localStorage payload", async () => {
     localStorage.setItem(STORE_KEY, "not json{");
-    const w = mount(TerminalGrid);
+    const w = mountGrid("2x2");
     await flushPromises();
-    const cells = cellsOf(w);
-    expect(cells).toHaveLength(4);
-    expect(cells.every((c) => c.props("initialSessionId") === null)).toBe(true);
+    expect(cellsOf(w)).toHaveLength(4);
+    expect(cellsOf(w).every((c) => c.props("initialSessionId") === null)).toBe(true);
   });
 });

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -9,8 +9,8 @@ import type { Layout } from "./gridLayout";
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
-    props: ["expanded", "initialSessionId", "cwd"],
-    emits: ["toggle-expand", "session", "close"],
+    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd"],
+    emits: ["toggle-expand", "session", "cwd", "close"],
     template: '<div class="stub-cell" />',
   },
 }));
@@ -62,10 +62,22 @@ describe("TerminalGrid", () => {
     expect(cells[2].props("expanded")).toBe(true);
   });
 
-  it("passes the fetched cwd to cells", async () => {
+  it("passes the fetched cwd to cells as defaultCwd", async () => {
     const w = mountGrid();
     await flushPromises();
-    expect(cellsOf(w)[0].props("cwd")).toBe("/work/proj");
+    expect(cellsOf(w)[0].props("defaultCwd")).toBe("/work/proj");
+  });
+
+  it("persists a cell's chosen cwd and restores it as initialCwd", async () => {
+    const w = mountGrid();
+    await flushPromises();
+    cellsOf(w)[2].vm.$emit("cwd", "/work/proj/sub");
+    await nextTick();
+    expect(saved().cwds[2]).toBe("/work/proj/sub");
+
+    const w2 = mountGrid();
+    await flushPromises();
+    expect(cellsOf(w2)[2].props("initialCwd")).toBe("/work/proj/sub");
   });
 
   it("persists a cell's session id when it emits 'session'", async () => {

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1,17 +1,21 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from "vue";
 import TerminalCell from "./TerminalCell.vue";
+import { MAX_CELLS, dims, trackStyle, type Layout } from "./gridLayout";
 
-// Fixed 2x2 grid. Zooming interface: the grid is the base view; expanding a cell
-// grows it to fill the area and shrinks the others to zero — animated by
-// transitioning the grid track sizes (Mac-like zoom). All cells stay MOUNTED the
-// whole time, so their terminals keep running while another is zoomed.
-const COLS = 2;
-const CELL_COUNT = 4;
-const cells = Array.from({ length: CELL_COUNT }, (_, i) => i);
+// Zooming interface: the grid is the base view; expanding a cell grows it to fill
+// the area and shrinks the others to zero — animated by transitioning the grid
+// track sizes (Mac-like zoom). All cells stay MOUNTED while zoomed, so their
+// terminals keep running. The layout (cell arrangement) is chosen in the toolbar.
+const props = defineProps<{ layout: Layout }>();
 
-// The active workspace dir, shown in each cell header. One value for now (server
-// global); becomes per-cell once per-terminal dirs land (plan P5).
+const cellCount = computed(() => dims(props.layout).cellCount);
+// Render only the visible cells; the persisted arrays are kept at MAX_CELLS so a
+// session/cwd survives switching to a smaller layout and back.
+const cells = computed(() => Array.from({ length: cellCount.value }, (_, i) => i));
+
+// The active workspace dir, shown in each cell header (server global for now;
+// per-cell dirs are a follow-up).
 const cwd = ref<string | null>(null);
 onMounted(async () => {
   try {
@@ -22,8 +26,7 @@ onMounted(async () => {
   }
 });
 
-// Persisted so a page reload restores the open terminals (each cell resumes its
-// session) and the zoom state.
+// Persisted so a page reload restores the open terminals and the zoom state.
 const STORE_KEY = "grid_state_v1";
 // Session ids are UUIDs. Drop anything else from a stale/tampered localStorage so
 // a cell never mounts with an invalid id (which the server rejects, leaving the
@@ -31,21 +34,20 @@ const STORE_KEY = "grid_state_v1";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 function loadState(): { sessions: (string | null)[]; expanded: number | null } {
-  const fallback = { sessions: Array<string | null>(CELL_COUNT).fill(null), expanded: null };
+  const sessions = Array<string | null>(MAX_CELLS).fill(null);
+  let expanded: number | null = null;
   try {
-    const raw = localStorage.getItem(STORE_KEY);
-    if (!raw) return fallback;
-    const parsed = JSON.parse(raw);
-    const sessions = Array.from({ length: CELL_COUNT }, (_, i) => {
+    const parsed = JSON.parse(localStorage.getItem(STORE_KEY) || "");
+    for (let i = 0; i < MAX_CELLS; i++) {
       const v = parsed?.sessions?.[i];
-      return typeof v === "string" && UUID_RE.test(v) ? v : null;
-    });
+      if (typeof v === "string" && UUID_RE.test(v)) sessions[i] = v;
+    }
     const e = parsed?.expanded;
-    const expanded = typeof e === "number" && e >= 0 && e < CELL_COUNT ? e : null;
-    return { sessions, expanded };
+    if (typeof e === "number" && e >= 0 && e < MAX_CELLS) expanded = e;
   } catch {
-    return fallback;
+    // no/invalid state — defaults
   }
+  return { sessions, expanded };
 }
 
 const initial = loadState();
@@ -56,31 +58,25 @@ watch([cellSessions, expanded], () => localStorage.setItem(STORE_KEY, JSON.strin
   deep: true,
 });
 
+// A zoomed cell that's no longer visible (layout shrank) can't stay zoomed.
+watch(cellCount, (n) => {
+  if (expanded.value !== null && expanded.value >= n) expanded.value = null;
+});
+
 function toggleExpand(i: number) {
   expanded.value = expanded.value === i ? null : i;
 }
 
 function setSession(i: number, id: string | null) {
   cellSessions.value[i] = id;
-  // A closed cell can't stay zoomed.
-  if (id === null && expanded.value === i) expanded.value = null;
+  if (id === null && expanded.value === i) expanded.value = null; // a closed cell can't stay zoomed
 }
 
-// Drive the zoom purely through the grid track template: the expanded cell's
-// row/column become 1fr and the others collapse to 0fr. Transitioning these
-// (plus the gap) gives the grow/shrink animation.
-const trackStyle = computed(() => {
-  const e = expanded.value;
-  if (e === null) {
-    return { gridTemplateColumns: "1fr 1fr", gridTemplateRows: "1fr 1fr", gap: "6px" };
-  }
-  const axis = (active: number) => [0, 1].map((n) => (n === active ? "1fr" : "0fr")).join(" ");
-  return { gridTemplateColumns: axis(e % COLS), gridTemplateRows: axis(Math.floor(e / COLS)), gap: "0px" };
-});
+const gridStyle = computed(() => trackStyle(props.layout, expanded.value));
 </script>
 
 <template>
-  <div class="grid" :style="trackStyle">
+  <div class="grid" :style="gridStyle">
     <TerminalCell
       v-for="i in cells"
       :key="i"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -33,30 +33,36 @@ const STORE_KEY = "grid_state_v1";
 // terminal reconnecting forever).
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-function loadState(): { sessions: (string | null)[]; expanded: number | null } {
+function loadState(): { sessions: (string | null)[]; cwds: (string | null)[]; expanded: number | null } {
   const sessions = Array<string | null>(MAX_CELLS).fill(null);
+  const cwds = Array<string | null>(MAX_CELLS).fill(null);
   let expanded: number | null = null;
   try {
     const parsed = JSON.parse(localStorage.getItem(STORE_KEY) || "");
     for (let i = 0; i < MAX_CELLS; i++) {
       const v = parsed?.sessions?.[i];
       if (typeof v === "string" && UUID_RE.test(v)) sessions[i] = v;
+      const c = parsed?.cwds?.[i];
+      if (typeof c === "string") cwds[i] = c;
     }
     const e = parsed?.expanded;
     if (typeof e === "number" && e >= 0 && e < MAX_CELLS) expanded = e;
   } catch {
     // no/invalid state — defaults
   }
-  return { sessions, expanded };
+  return { sessions, cwds, expanded };
 }
 
 const initial = loadState();
 const cellSessions = ref<(string | null)[]>(initial.sessions);
+const cellCwds = ref<(string | null)[]>(initial.cwds);
 const expanded = ref<number | null>(initial.expanded);
 
-watch([cellSessions, expanded], () => localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: cellSessions.value, expanded: expanded.value })), {
-  deep: true,
-});
+watch(
+  [cellSessions, cellCwds, expanded],
+  () => localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: cellSessions.value, cwds: cellCwds.value, expanded: expanded.value })),
+  { deep: true },
+);
 
 // A zoomed cell that's no longer visible (layout shrank) can't stay zoomed.
 watch(cellCount, (n) => {
@@ -72,6 +78,12 @@ function setSession(i: number, id: string | null) {
   if (id === null && expanded.value === i) expanded.value = null; // a closed cell can't stay zoomed
 }
 
+function onClose(i: number) {
+  cellSessions.value[i] = null;
+  cellCwds.value[i] = null;
+  if (expanded.value === i) expanded.value = null;
+}
+
 const gridStyle = computed(() => trackStyle(props.layout, expanded.value));
 </script>
 
@@ -82,10 +94,12 @@ const gridStyle = computed(() => trackStyle(props.layout, expanded.value));
       :key="i"
       :expanded="expanded === i"
       :initial-session-id="cellSessions[i]"
-      :cwd="cwd"
+      :initial-cwd="cellCwds[i]"
+      :default-cwd="cwd"
       @toggle-expand="toggleExpand(i)"
       @session="(id) => setSession(i, id)"
-      @close="() => setSession(i, null)"
+      @cwd="(c) => (cellCwds[i] = c)"
+      @close="() => onClose(i)"
     />
   </div>
 </template>

--- a/src/components/gridLayout.spec.ts
+++ b/src/components/gridLayout.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { LAYOUTS, isLayout, dims, trackStyle } from "./gridLayout";
+
+describe("gridLayout", () => {
+  it("exposes the four layouts", () => {
+    expect(LAYOUTS).toEqual(["2x2", "3x2", "4x2", "3x3"]);
+  });
+
+  it("isLayout accepts known layouts and rejects everything else", () => {
+    expect(isLayout("2x2")).toBe(true);
+    expect(isLayout("3x3")).toBe(true);
+    expect(isLayout("5x5")).toBe(false);
+    expect(isLayout(null)).toBe(false);
+    expect(isLayout(42)).toBe(false);
+  });
+
+  it("dims returns cols/rows/cellCount", () => {
+    expect(dims("2x2")).toEqual({ cols: 2, rows: 2, cellCount: 4 });
+    expect(dims("3x2")).toEqual({ cols: 3, rows: 2, cellCount: 6 });
+    expect(dims("4x2")).toEqual({ cols: 4, rows: 2, cellCount: 8 });
+    expect(dims("3x3")).toEqual({ cols: 3, rows: 3, cellCount: 9 });
+  });
+
+  it("trackStyle: full even tracks when nothing is zoomed", () => {
+    expect(trackStyle("3x2", null)).toEqual({
+      gridTemplateColumns: "1fr 1fr 1fr",
+      gridTemplateRows: "1fr 1fr",
+      gap: "6px",
+    });
+  });
+
+  it("trackStyle: collapses other tracks around the zoomed cell", () => {
+    // 3x3, expand index 4 (center): col 1, row 1.
+    expect(trackStyle("3x3", 4)).toEqual({
+      gridTemplateColumns: "0fr 1fr 0fr",
+      gridTemplateRows: "0fr 1fr 0fr",
+      gap: "0px",
+    });
+    // index 0 (top-left): col 0, row 0.
+    expect(trackStyle("3x3", 0)).toEqual({
+      gridTemplateColumns: "1fr 0fr 0fr",
+      gridTemplateRows: "1fr 0fr 0fr",
+      gap: "0px",
+    });
+  });
+});

--- a/src/components/gridLayout.ts
+++ b/src/components/gridLayout.ts
@@ -1,0 +1,38 @@
+// Grid layout definitions shared by App (the picker) and TerminalGrid.
+
+export const LAYOUTS = ["2x2", "3x2", "4x2", "3x3"] as const;
+export type Layout = (typeof LAYOUTS)[number];
+
+// cols × rows per layout. Max cells is 9 (3x3), which bounds the persisted arrays.
+const DIMS: Record<Layout, { cols: number; rows: number }> = {
+  "2x2": { cols: 2, rows: 2 },
+  "3x2": { cols: 3, rows: 2 },
+  "4x2": { cols: 4, rows: 2 },
+  "3x3": { cols: 3, rows: 3 },
+};
+
+export const MAX_CELLS = 9;
+
+export function isLayout(v: unknown): v is Layout {
+  return typeof v === "string" && (LAYOUTS as readonly string[]).includes(v);
+}
+
+export function dims(layout: Layout) {
+  const { cols, rows } = DIMS[layout];
+  return { cols, rows, cellCount: cols * rows };
+}
+
+// CSS grid track template for the layout, or — when a cell is zoomed — collapse
+// every other track to 0fr so that cell fills the area (animated by the caller).
+export function trackStyle(layout: Layout, expanded: number | null) {
+  const { cols, rows } = dims(layout);
+  const tracks = (count: number, active: number) => Array.from({ length: count }, (_, n) => (active < 0 || n === active ? "1fr" : "0fr")).join(" ");
+  if (expanded === null) {
+    return { gridTemplateColumns: tracks(cols, -1), gridTemplateRows: tracks(rows, -1), gap: "6px" };
+  }
+  return {
+    gridTemplateColumns: tracks(cols, expanded % cols),
+    gridTemplateRows: tracks(rows, Math.floor(expanded / cols)),
+    gap: "0px",
+  };
+}


### PR DESCRIPTION
## Summary

Two grid features requested after #48:

### 1. Layout selection
- Toolbar picker for **2x2 / 3x2 / 4x2 / 3x3** (persisted).
- The grid generalizes cols/rows/cellCount from the layout; the Mac-like zoom
  (track-collapse) works for any layout. Persisted cell arrays are kept at
  `MAX_CELLS` (9) so a session/cwd survives switching to a smaller layout and back;
  a zoomed cell that the new layout hides un-zooms.
- Layout math is in `gridLayout.ts` (unit-tested).

### 2. Per-terminal working directory
- An empty cell shows a **dir field (prefilled with the server default) + Start**.
  The chosen dir is sent as `?cwd=<abs>` and used as the PTY cwd (and the project
  to `--resume` from). Each cell can run in a **different directory**, shown in its
  header; the dir is **persisted per cell** so a reload restores it.
- Server `resolveWorkspace()` validates the dir (absolute, existing directory) and
  **falls back to `CLAUDE_CWD`** for anything else — raw client input is never used
  in a path/flag position unchecked.

## Verification

- `lint` / `typecheck` / `typecheck:server` / `test` (52) / `build` ✅.
- End-to-end: two cells launch claude in `/tmp/celldir-a` and `/tmp/celldir-b`;
  an invalid `?cwd=` falls back to `CLAUDE_CWD` (server log confirms).
- Tests: `gridLayout` (dims/trackStyle/isLayout), grid per-layout cell counts +
  layout-change un-zoom + per-cell cwd persist/restore, cell launch form emits cwd
  and passes it to the terminal.

## Out of scope (later)

dir **presets** in a settings screen (this PR is manual entry, prefilled with the
default); sound/notifications; tabs + 20-session cap; GUI/Tools inside the
expanded cell.

base: `dev_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)