### PR TITLE
feat(grid): directory presets — settings screen + one-click launch (#46)

### DIFF
--- a/server/cwd-presets.spec.ts
+++ b/server/cwd-presets.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { sanitizePresets, loadPresets, savePresets } from "./cwd-presets";
+
+const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-presets-"));
+
+describe("sanitizePresets", () => {
+  it("keeps valid {label,path}, trims, and drops incomplete/junk rows", () => {
+    expect(sanitizePresets([{ label: " a ", path: " /a " }, { label: "", path: "/b" }, { label: "c", path: "" }, { nope: 1 }, "x"])).toEqual([
+      { label: "a", path: "/a" },
+    ]);
+  });
+
+  it("returns [] for non-array input", () => {
+    expect(sanitizePresets(null)).toEqual([]);
+    expect(sanitizePresets({ cwdPresets: [] })).toEqual([]);
+  });
+
+  it("caps the count", () => {
+    const many = Array.from({ length: 60 }, (_, i) => ({ label: `l${i}`, path: `/p${i}` }));
+    expect(sanitizePresets(many, 50)).toHaveLength(50);
+  });
+});
+
+describe("savePresets / loadPresets", () => {
+  it("round-trips through a file", () => {
+    const dir = tmp();
+    const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
+    expect(savePresets(file, [{ label: "x", path: "/x" }])).toBe(true);
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ cwdPresets: [{ label: "x", path: "/x" }] });
+    expect(loadPresets(file)).toEqual([{ label: "x", path: "/x" }]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("loadPresets returns [] for a missing or invalid file", () => {
+    const dir = tmp();
+    expect(loadPresets(path.join(dir, "none.json"))).toEqual([]);
+    const bad = path.join(dir, "bad.json");
+    writeFileSync(bad, "not json{");
+    expect(loadPresets(bad)).toEqual([]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("savePresets returns false when the path can't be written (regression for the 500 path)", () => {
+    const dir = tmp();
+    const asFile = path.join(dir, "afile");
+    writeFileSync(asFile, "x"); // a file where a directory is needed
+    // mkdir(`<file>/sub`) fails because the parent is a file → save reports false.
+    expect(savePresets(path.join(asFile, "sub", "config.json"), [{ label: "x", path: "/x" }])).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/server/cwd-presets.ts
+++ b/server/cwd-presets.ts
@@ -1,0 +1,44 @@
+// Directory presets the launch form offers, persisted at config.json. Extracted
+// from index.ts so the sanitize/load/save logic is unit-testable.
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+
+export interface CwdPreset {
+  label: string;
+  path: string;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const isPreset = (v: unknown): v is CwdPreset => isRecord(v) && typeof v.label === "string" && typeof v.path === "string";
+
+// Normalize arbitrary input into clean presets: keep only {label,path} objects,
+// trim, drop entries missing either field, and cap the count.
+export function sanitizePresets(input: unknown, max = 50): CwdPreset[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .filter(isPreset)
+    .map((p) => ({ label: p.label.trim(), path: p.path.trim() }))
+    .filter((p) => p.label && p.path)
+    .slice(0, max);
+}
+
+export function loadPresets(file: string): CwdPreset[] {
+  try {
+    if (!existsSync(file)) return [];
+    return sanitizePresets(JSON.parse(readFileSync(file, "utf8"))?.cwdPresets);
+  } catch {
+    return [];
+  }
+}
+
+// Persist; returns false on any write failure so the caller can surface it
+// instead of reporting a false success.
+export function savePresets(file: string, presets: CwdPreset[]): boolean {
+  try {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ cwdPresets: presets }, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import path from "path";
 import os from "os";
 import fs from "fs/promises";
 import { randomUUID } from "crypto";
-import { existsSync, statSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { fileURLToPath } from "url";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createPubSub } from "./pubsub.js";
@@ -15,6 +15,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
+import { loadPresets, savePresets, sanitizePresets, type CwdPreset } from "./cwd-presets.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -104,38 +105,9 @@ await fs.mkdir(CLAUDE_CWD, { recursive: true });
 const MULMOTERMINAL_HOME = path.join(os.homedir(), ".mulmoterminal");
 
 // User config (currently just directory presets the launch form offers),
-// persisted at ~/.mulmoterminal/config.json.
-interface CwdPreset {
-  label: string;
-  path: string;
-}
+// persisted at ~/.mulmoterminal/config.json. Logic lives in ./cwd-presets.
 const CONFIG_FILE = path.join(MULMOTERMINAL_HOME, "config.json");
-const MAX_PRESETS = 50;
-
-const isPreset = (v: unknown): v is CwdPreset => isRecord(v) && typeof v.label === "string" && typeof v.path === "string";
-
-function loadCwdPresets(): CwdPreset[] {
-  try {
-    const parsed = JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
-    if (Array.isArray(parsed?.cwdPresets)) return parsed.cwdPresets.filter(isPreset);
-  } catch {
-    // no/invalid config — none
-  }
-  return [];
-}
-
-let cwdPresets: CwdPreset[] = loadCwdPresets();
-
-function saveCwdPresets(): boolean {
-  try {
-    mkdirSync(MULMOTERMINAL_HOME, { recursive: true });
-    writeFileSync(CONFIG_FILE, JSON.stringify({ cwdPresets }, null, 2));
-    return true;
-  } catch (e) {
-    console.error(`[config] failed to save: ${messageOf(e)}`);
-    return false;
-  }
-}
+let cwdPresets: CwdPreset[] = loadPresets(CONFIG_FILE);
 
 // A session id is always a UUID (server-generated, or a .jsonl basename). Reject
 // anything else so a client can't smuggle CLI flags (e.g. "--resume" followed by
@@ -778,14 +750,11 @@ app.get("/api/config", (_req, res) => {
 app.post("/api/config", (req, res) => {
   const body = req.body || {};
   if (!Array.isArray(body.cwdPresets)) return res.status(400).json({ error: "cwdPresets must be an array" });
-  cwdPresets = body.cwdPresets
-    .filter(isPreset)
-    .map((p: CwdPreset) => ({ label: p.label.trim(), path: p.path.trim() }))
-    .filter((p: CwdPreset) => p.label && p.path)
-    .slice(0, MAX_PRESETS);
-  // Surface a persistence failure so the client doesn't report false success
-  // (the presets would otherwise be lost on restart).
-  if (!saveCwdPresets()) return res.status(500).json({ error: "failed to persist presets" });
+  // Stage, persist, then commit in-memory only on success — a failed write must
+  // not leave GET exposing presets that won't survive a restart.
+  const next = sanitizePresets(body.cwdPresets);
+  if (!savePresets(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist presets" });
+  cwdPresets = next;
   res.json({ cwd: CLAUDE_CWD, cwdPresets });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -126,12 +126,14 @@ function loadCwdPresets(): CwdPreset[] {
 
 let cwdPresets: CwdPreset[] = loadCwdPresets();
 
-function saveCwdPresets() {
+function saveCwdPresets(): boolean {
   try {
     mkdirSync(MULMOTERMINAL_HOME, { recursive: true });
     writeFileSync(CONFIG_FILE, JSON.stringify({ cwdPresets }, null, 2));
+    return true;
   } catch (e) {
     console.error(`[config] failed to save: ${messageOf(e)}`);
+    return false;
   }
 }
 
@@ -781,7 +783,9 @@ app.post("/api/config", (req, res) => {
     .map((p: CwdPreset) => ({ label: p.label.trim(), path: p.path.trim() }))
     .filter((p: CwdPreset) => p.label && p.path)
     .slice(0, MAX_PRESETS);
-  saveCwdPresets();
+  // Surface a persistence failure so the client doesn't report false success
+  // (the presets would otherwise be lost on restart).
+  if (!saveCwdPresets()) return res.status(500).json({ error: "failed to persist presets" });
   res.json({ cwd: CLAUDE_CWD, cwdPresets });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import path from "path";
 import os from "os";
 import fs from "fs/promises";
 import { randomUUID } from "crypto";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, statSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "url";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createPubSub } from "./pubsub.js";
@@ -102,6 +102,38 @@ await fs.mkdir(CLAUDE_CWD, { recursive: true });
 // history) lives here, keyed by sessionId (a global UUID) — NOT under the
 // workspace dir, so it stays valid regardless of which directory is active.
 const MULMOTERMINAL_HOME = path.join(os.homedir(), ".mulmoterminal");
+
+// User config (currently just directory presets the launch form offers),
+// persisted at ~/.mulmoterminal/config.json.
+interface CwdPreset {
+  label: string;
+  path: string;
+}
+const CONFIG_FILE = path.join(MULMOTERMINAL_HOME, "config.json");
+const MAX_PRESETS = 50;
+
+const isPreset = (v: unknown): v is CwdPreset => isRecord(v) && typeof v.label === "string" && typeof v.path === "string";
+
+function loadCwdPresets(): CwdPreset[] {
+  try {
+    const parsed = JSON.parse(readFileSync(CONFIG_FILE, "utf8"));
+    if (Array.isArray(parsed?.cwdPresets)) return parsed.cwdPresets.filter(isPreset);
+  } catch {
+    // no/invalid config — none
+  }
+  return [];
+}
+
+let cwdPresets: CwdPreset[] = loadCwdPresets();
+
+function saveCwdPresets() {
+  try {
+    mkdirSync(MULMOTERMINAL_HOME, { recursive: true });
+    writeFileSync(CONFIG_FILE, JSON.stringify({ cwdPresets }, null, 2));
+  } catch (e) {
+    console.error(`[config] failed to save: ${messageOf(e)}`);
+  }
+}
 
 // A session id is always a UUID (server-generated, or a .jsonl basename). Reject
 // anything else so a client can't smuggle CLI flags (e.g. "--resume" followed by
@@ -734,9 +766,23 @@ app.get("/api/tool-calls/:sessionId", async (req, res) => {
   res.json({ sessionId, toolCalls: await toolCallsStore.get(sessionId) });
 });
 
-// Server-wide config the UI shows (currently just the active workspace dir).
+// Server-wide config the UI shows: the default workspace dir + the user's saved
+// directory presets (offered in the cell launch form).
 app.get("/api/config", (_req, res) => {
-  res.json({ cwd: CLAUDE_CWD });
+  res.json({ cwd: CLAUDE_CWD, cwdPresets });
+});
+
+// Update the directory presets (from the settings screen) and persist them.
+app.post("/api/config", (req, res) => {
+  const body = req.body || {};
+  if (!Array.isArray(body.cwdPresets)) return res.status(400).json({ error: "cwdPresets must be an array" });
+  cwdPresets = body.cwdPresets
+    .filter(isPreset)
+    .map((p: CwdPreset) => ({ label: p.label.trim(), path: p.path.trim() }))
+    .filter((p: CwdPreset) => p.label && p.path)
+    .slice(0, MAX_PRESETS);
+  saveCwdPresets();
+  res.json({ cwd: CLAUDE_CWD, cwdPresets });
 });
 
 // Initial per-session status + last prompt, so a cell can render its header

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,8 @@ watch(layout, (v) => localStorage.setItem("grid_layout", v));
 const defaultCwd = ref<string | null>(null);
 const presets = ref<CwdPreset[]>([]);
 const showSettings = ref(false);
+const savingSettings = ref(false);
+const settingsError = ref<string | null>(null);
 
 async function loadConfig() {
   try {
@@ -29,17 +31,27 @@ async function loadConfig() {
 onMounted(loadConfig);
 
 async function savePresets(next: CwdPreset[]) {
+  savingSettings.value = true;
+  settingsError.value = null;
   try {
     const res = await fetch("/api/config", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ cwdPresets: next }),
     });
-    if (res.ok) presets.value = (await res.json()).cwdPresets ?? [];
+    if (!res.ok) throw new Error(`save failed (${res.status})`);
+    presets.value = (await res.json()).cwdPresets ?? [];
+    showSettings.value = false; // close only on success — keep edits otherwise
   } catch {
-    // keep the modal's intent; leave existing presets on failure
+    settingsError.value = "Couldn't save presets. Check the server and try again.";
+  } finally {
+    savingSettings.value = false;
   }
+}
+
+function closeSettings() {
   showSettings.value = false;
+  settingsError.value = null;
 }
 </script>
 
@@ -55,7 +67,7 @@ async function savePresets(next: CwdPreset[]) {
       <button class="settings-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>
     <TerminalGrid class="main" :layout="layout" :default-cwd="defaultCwd" :presets="presets" />
-    <SettingsModal v-if="showSettings" :presets="presets" @save="savePresets" @close="showSettings = false" />
+    <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
   </div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,46 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, onMounted } from "vue";
 import TerminalGrid from "./components/TerminalGrid.vue";
+import SettingsModal from "./components/SettingsModal.vue";
 import { LAYOUTS, isLayout, type Layout } from "./components/gridLayout";
+import type { CwdPreset } from "./components/presets";
 
 // Grid layout (cell arrangement), chosen in the toolbar and persisted.
 const stored = localStorage.getItem("grid_layout");
 const layout = ref<Layout>(isLayout(stored) ? stored : "2x2");
 watch(layout, (v) => localStorage.setItem("grid_layout", v));
+
+// Server config: the default workspace dir + the user's directory presets.
+const defaultCwd = ref<string | null>(null);
+const presets = ref<CwdPreset[]>([]);
+const showSettings = ref(false);
+
+async function loadConfig() {
+  try {
+    const res = await fetch("/api/config");
+    if (!res.ok) return;
+    const c = await res.json();
+    defaultCwd.value = c.cwd ?? null;
+    presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
+  } catch {
+    // grid still works; presets just unavailable
+  }
+}
+onMounted(loadConfig);
+
+async function savePresets(next: CwdPreset[]) {
+  try {
+    const res = await fetch("/api/config", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cwdPresets: next }),
+    });
+    if (res.ok) presets.value = (await res.json()).cwdPresets ?? [];
+  } catch {
+    // keep the modal's intent; leave existing presets on failure
+  }
+  showSettings.value = false;
+}
 </script>
 
 <template>
@@ -18,8 +52,10 @@ watch(layout, (v) => localStorage.setItem("grid_layout", v));
           {{ l }}
         </button>
       </span>
+      <button class="settings-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>
-    <TerminalGrid class="main" :layout="layout" />
+    <TerminalGrid class="main" :layout="layout" :default-cwd="defaultCwd" :presets="presets" />
+    <SettingsModal v-if="showSettings" :presets="presets" @save="savePresets" @close="showSettings = false" />
   </div>
 </template>
 
@@ -32,7 +68,7 @@ watch(layout, (v) => localStorage.setItem("grid_layout", v));
   overflow: hidden;
 }
 
-/* Top toolbar with the app title + layout picker. */
+/* Top toolbar with the app title + layout picker + settings. */
 .toolbar {
   flex: 0 0 auto;
   display: flex;
@@ -74,6 +110,21 @@ watch(layout, (v) => localStorage.setItem("grid_layout", v));
   background: #2a3b66;
   color: #fff;
   border-color: #4a8cff;
+}
+
+.settings-btn {
+  border: 1px solid #2a2a4e;
+  background: #1a1a2e;
+  color: #c7cdf0;
+  font-size: 15px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.settings-btn:hover {
+  background: #2a3b66;
+  color: #fff;
 }
 
 /* The grid fills everything under the toolbar. */

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -43,6 +43,20 @@ describe("SettingsModal", () => {
     expect(w.emitted("close")).toBeTruthy();
   });
 
+  it("emits close on Escape", async () => {
+    const w = mountModal();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(w.emitted("close")).toBeTruthy();
+    w.unmount();
+  });
+
+  it("shows an error and disables Save while saving", () => {
+    const w = mount(SettingsModal, { props: { presets: [], saving: true, error: "boom" } });
+    expect(w.find(".error").text()).toBe("boom");
+    const save = w.findAll(".btn").find((b) => b.text().includes("Saving"));
+    expect(save?.attributes("disabled")).toBeDefined();
+  });
+
   it("does not mutate the prop array until save", async () => {
     const presets = [{ label: "a", path: "/a" }];
     const w = mountModal(presets);

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -63,13 +63,24 @@ describe("SettingsModal", () => {
     expect(save?.attributes("disabled")).toBeDefined();
   });
 
-  it("resyncs rows when presets arrive after mount (early-open race)", async () => {
+  it("resyncs rows when presets arrive after mount while pristine (early-open race)", async () => {
     const w = mountModal([]); // opened before config loaded
     expect(w.findAll(".row")).toHaveLength(0);
     await w.setProps({ presets: [{ label: "a", path: "/a" }] }); // config resolves
     expect(w.findAll(".row")).toHaveLength(1);
     await clickBtn(w, (t) => t === "Save");
     expect(w.emitted("save")?.at(-1)?.[0]).toEqual([{ label: "a", path: "/a" }]);
+  });
+
+  it("does NOT clobber in-progress edits when presets arrive late", async () => {
+    const w = mountModal([]); // opened before config loaded
+    await clickBtn(w, (t) => t.includes("Add"));
+    await w.find(".label-field").setValue("mine");
+    await w.find(".path-field").setValue("/mine");
+    // config resolves with server presets — must not overwrite the user's edits
+    await w.setProps({ presets: [{ label: "server", path: "/server" }] });
+    await clickBtn(w, (t) => t === "Save");
+    expect(w.emitted("save")?.at(-1)?.[0]).toEqual([{ label: "mine", path: "/mine" }]);
   });
 
   it("does not mutate the prop array until save", async () => {

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -11,6 +11,12 @@ function clickBtn(w: ReturnType<typeof mount>, match: (text: string) => boolean)
 }
 
 describe("SettingsModal", () => {
+  it("gives each preset input an accessible name", () => {
+    const w = mountModal([{ label: "a", path: "/a" }]);
+    expect(w.find(".label-field").attributes("aria-label")).toBe("Preset label");
+    expect(w.find(".path-field").attributes("aria-label")).toBe("Preset directory path");
+  });
+
   it("shows a row per preset", () => {
     const w = mountModal([
       { label: "a", path: "/a" },

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SettingsModal from "./SettingsModal.vue";
+
+const mountModal = (presets = [{ label: "proj", path: "/work/proj" }]) => mount(SettingsModal, { props: { presets } });
+
+function clickBtn(w: ReturnType<typeof mount>, match: (text: string) => boolean) {
+  const btn = w.findAll(".btn").find((b) => match(b.text()));
+  if (!btn) throw new Error("button not found");
+  return btn.trigger("click");
+}
+
+describe("SettingsModal", () => {
+  it("shows a row per preset", () => {
+    const w = mountModal([
+      { label: "a", path: "/a" },
+      { label: "b", path: "/b" },
+    ]);
+    expect(w.findAll(".row")).toHaveLength(2);
+  });
+
+  it("adds and removes rows", async () => {
+    const w = mountModal([{ label: "a", path: "/a" }]);
+    await clickBtn(w, (t) => t.includes("Add"));
+    expect(w.findAll(".row")).toHaveLength(2);
+    await w.findAll(".row")[0].find(".icon-btn").trigger("click");
+    expect(w.findAll(".row")).toHaveLength(1);
+  });
+
+  it("save emits trimmed presets, dropping rows missing a label or path", async () => {
+    const w = mountModal([
+      { label: " keep ", path: " /keep " },
+      { label: "", path: "/nolabel" },
+      { label: "nopath", path: "" },
+    ]);
+    await clickBtn(w, (t) => t === "Save");
+    expect(w.emitted("save")?.[0]?.[0]).toEqual([{ label: "keep", path: "/keep" }]);
+  });
+
+  it("emits close on Cancel", async () => {
+    const w = mountModal();
+    await clickBtn(w, (t) => t === "Cancel");
+    expect(w.emitted("close")).toBeTruthy();
+  });
+
+  it("does not mutate the prop array until save", async () => {
+    const presets = [{ label: "a", path: "/a" }];
+    const w = mountModal(presets);
+    await clickBtn(w, (t) => t.includes("Add"));
+    expect(presets).toHaveLength(1); // edits are on a local copy
+  });
+});

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -57,6 +57,15 @@ describe("SettingsModal", () => {
     expect(save?.attributes("disabled")).toBeDefined();
   });
 
+  it("resyncs rows when presets arrive after mount (early-open race)", async () => {
+    const w = mountModal([]); // opened before config loaded
+    expect(w.findAll(".row")).toHaveLength(0);
+    await w.setProps({ presets: [{ label: "a", path: "/a" }] }); // config resolves
+    expect(w.findAll(".row")).toHaveLength(1);
+    await clickBtn(w, (t) => t === "Save");
+    expect(w.emitted("save")?.at(-1)?.[0]).toEqual([{ label: "a", path: "/a" }]);
+  });
+
   it("does not mutate the prop array until save", async () => {
     const presets = [{ label: "a", path: "/a" }];
     const w = mountModal(presets);

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -7,21 +7,25 @@ const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "close")
 
 // Edit a local copy; commit on Save.
 const rows = ref<CwdPreset[]>(props.presets.map((p) => ({ ...p })));
+// Becomes true once the user edits, so a late prop sync can't clobber their work.
+const dirty = ref(false);
 // Resync if the presets arrive/change after mount — e.g. the modal opened before
 // /api/config resolved (would otherwise edit empty data and Save could wipe the
-// real presets).
+// real presets). Only while the form is pristine, to preserve in-progress edits.
 watch(
   () => props.presets,
   (next) => {
-    rows.value = next.map((p) => ({ ...p }));
+    if (!dirty.value) rows.value = next.map((p) => ({ ...p }));
   },
 );
 const modalEl = ref<HTMLElement>();
 
 function addRow() {
+  dirty.value = true;
   rows.value.push({ label: "", path: "" });
 }
 function removeRow(i: number) {
+  dirty.value = true;
   rows.value.splice(i, 1);
 }
 function save() {
@@ -69,8 +73,24 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 
       <div class="rows">
         <div v-for="(row, i) in rows" :key="i" class="row">
-          <input v-model="row.label" class="field label-field" type="text" placeholder="Label" aria-label="Preset label" spellcheck="false" />
-          <input v-model="row.path" class="field path-field" type="text" placeholder="/absolute/path" aria-label="Preset directory path" spellcheck="false" />
+          <input
+            v-model="row.label"
+            class="field label-field"
+            type="text"
+            placeholder="Label"
+            aria-label="Preset label"
+            spellcheck="false"
+            @input="dirty = true"
+          />
+          <input
+            v-model="row.path"
+            class="field path-field"
+            type="text"
+            placeholder="/absolute/path"
+            aria-label="Preset directory path"
+            spellcheck="false"
+            @input="dirty = true"
+          />
           <button class="icon-btn" title="Remove" aria-label="Remove preset" @click="removeRow(i)">✕</button>
         </div>
         <p v-if="rows.length === 0" class="empty">No presets yet.</p>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, onMounted, onUnmounted, nextTick } from "vue";
 import type { CwdPreset } from "./presets";
 
-const props = defineProps<{ presets: CwdPreset[] }>();
+const props = defineProps<{ presets: CwdPreset[]; saving?: boolean; error?: string | null }>();
 const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "close"): void }>();
 
 // Edit a local copy; commit on Save.
 const rows = ref<CwdPreset[]>(props.presets.map((p) => ({ ...p })));
+const modalEl = ref<HTMLElement>();
 
 function addRow() {
   rows.value.push({ label: "", path: "" });
@@ -18,11 +19,39 @@ function save() {
   const cleaned = rows.value.map((r) => ({ label: r.label.trim(), path: r.path.trim() })).filter((r) => r.label && r.path);
   emit("save", cleaned);
 }
+
+// Modal keyboard behavior: Escape closes; Tab is trapped within the dialog.
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    emit("close");
+    return;
+  }
+  if (e.key !== "Tab" || !modalEl.value) return;
+  const focusable = [...modalEl.value.querySelectorAll<HTMLElement>('button, input, [tabindex]:not([tabindex="-1"])')].filter(
+    (el) => !el.hasAttribute("disabled"),
+  );
+  if (focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", onKeydown);
+  nextTick(() => modalEl.value?.querySelector<HTMLElement>("input, button")?.focus());
+});
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 </script>
 
 <template>
   <div class="overlay" @click.self="emit('close')">
-    <div class="modal" role="dialog" aria-modal="true" aria-label="Settings">
+    <div ref="modalEl" class="modal" role="dialog" aria-modal="true" aria-label="Settings">
       <div class="modal-head">
         <h2 class="modal-title">Directory presets</h2>
         <button class="icon-btn" title="Close" aria-label="Close settings" @click="emit('close')">✕</button>
@@ -38,11 +67,13 @@ function save() {
         <p v-if="rows.length === 0" class="empty">No presets yet.</p>
       </div>
 
+      <p v-if="error" class="error" role="alert">{{ error }}</p>
+
       <div class="modal-foot">
         <button class="btn" @click="addRow">＋ Add preset</button>
         <span class="spacer" />
         <button class="btn" @click="emit('close')">Cancel</button>
-        <button class="btn btn-primary" @click="save">Save</button>
+        <button class="btn btn-primary" :disabled="saving" @click="save">{{ saving ? "Saving…" : "Save" }}</button>
       </div>
     </div>
   </div>
@@ -120,11 +151,20 @@ function save() {
   font-size: 12px;
   color: #6b7394;
 }
+.error {
+  margin: 12px 0 0;
+  font-size: 12px;
+  color: #ff8080;
+}
 .modal-foot {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-top: 16px;
+}
+.btn:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 .spacer {
   flex: 1;

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -69,8 +69,8 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 
       <div class="rows">
         <div v-for="(row, i) in rows" :key="i" class="row">
-          <input v-model="row.label" class="field label-field" type="text" placeholder="Label" spellcheck="false" />
-          <input v-model="row.path" class="field path-field" type="text" placeholder="/absolute/path" spellcheck="false" />
+          <input v-model="row.label" class="field label-field" type="text" placeholder="Label" aria-label="Preset label" spellcheck="false" />
+          <input v-model="row.path" class="field path-field" type="text" placeholder="/absolute/path" aria-label="Preset directory path" spellcheck="false" />
           <button class="icon-btn" title="Remove" aria-label="Remove preset" @click="removeRow(i)">✕</button>
         </div>
         <p v-if="rows.length === 0" class="empty">No presets yet.</p>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, nextTick } from "vue";
+import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
 import type { CwdPreset } from "./presets";
 
 const props = defineProps<{ presets: CwdPreset[]; saving?: boolean; error?: string | null }>();
@@ -7,6 +7,15 @@ const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "close")
 
 // Edit a local copy; commit on Save.
 const rows = ref<CwdPreset[]>(props.presets.map((p) => ({ ...p })));
+// Resync if the presets arrive/change after mount — e.g. the modal opened before
+// /api/config resolved (would otherwise edit empty data and Save could wipe the
+// real presets).
+watch(
+  () => props.presets,
+  (next) => {
+    rows.value = next.map((p) => ({ ...p }));
+  },
+);
 const modalEl = ref<HTMLElement>();
 
 function addRow() {

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import type { CwdPreset } from "./presets";
+
+const props = defineProps<{ presets: CwdPreset[] }>();
+const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "close"): void }>();
+
+// Edit a local copy; commit on Save.
+const rows = ref<CwdPreset[]>(props.presets.map((p) => ({ ...p })));
+
+function addRow() {
+  rows.value.push({ label: "", path: "" });
+}
+function removeRow(i: number) {
+  rows.value.splice(i, 1);
+}
+function save() {
+  const cleaned = rows.value.map((r) => ({ label: r.label.trim(), path: r.path.trim() })).filter((r) => r.label && r.path);
+  emit("save", cleaned);
+}
+</script>
+
+<template>
+  <div class="overlay" @click.self="emit('close')">
+    <div class="modal" role="dialog" aria-modal="true" aria-label="Settings">
+      <div class="modal-head">
+        <h2 class="modal-title">Directory presets</h2>
+        <button class="icon-btn" title="Close" aria-label="Close settings" @click="emit('close')">✕</button>
+      </div>
+      <p class="hint">Quick-pick directories offered when launching a terminal.</p>
+
+      <div class="rows">
+        <div v-for="(row, i) in rows" :key="i" class="row">
+          <input v-model="row.label" class="field label-field" type="text" placeholder="Label" spellcheck="false" />
+          <input v-model="row.path" class="field path-field" type="text" placeholder="/absolute/path" spellcheck="false" />
+          <button class="icon-btn" title="Remove" aria-label="Remove preset" @click="removeRow(i)">✕</button>
+        </div>
+        <p v-if="rows.length === 0" class="empty">No presets yet.</p>
+      </div>
+
+      <div class="modal-foot">
+        <button class="btn" @click="addRow">＋ Add preset</button>
+        <span class="spacer" />
+        <button class="btn" @click="emit('close')">Cancel</button>
+        <button class="btn btn-primary" @click="save">Save</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.modal {
+  width: min(560px, 92vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background: #1a1a2e;
+  border: 1px solid #2a2a4e;
+  border-radius: 10px;
+  padding: 16px;
+  color: #e6e6f0;
+  font-family: system-ui, sans-serif;
+}
+.modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.modal-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+.hint {
+  margin: 6px 0 12px;
+  font-size: 12px;
+  color: #8b93b8;
+}
+.rows {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.field {
+  box-sizing: border-box;
+  padding: 7px 10px;
+  background: #11111f;
+  border: 1px solid #2a2a4e;
+  border-radius: 6px;
+  color: #e6e6f0;
+  font-size: 12px;
+}
+.field:focus {
+  outline: none;
+  border-color: #4a8cff;
+}
+.label-field {
+  flex: 0 0 30%;
+}
+.path-field {
+  flex: 1 1 auto;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+}
+.empty {
+  font-size: 12px;
+  color: #6b7394;
+}
+.modal-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 16px;
+}
+.spacer {
+  flex: 1;
+}
+.icon-btn {
+  border: none;
+  background: transparent;
+  color: #9aa3c0;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px 6px;
+  border-radius: 6px;
+}
+.icon-btn:hover {
+  background: #3a2030;
+  color: #ff6b6b;
+}
+.btn {
+  border: 1px solid #2a2a4e;
+  background: #20203a;
+  color: #c7cdf0;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 6px 14px;
+  border-radius: 6px;
+}
+.btn:hover {
+  background: #2a3b66;
+  color: #fff;
+}
+.btn-primary {
+  background: #2f5bd0;
+  border-color: #4a8cff;
+  color: #fff;
+}
+.btn-primary:hover {
+  background: #3a6be0;
+}
+</style>

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -34,9 +34,18 @@ beforeEach(() => {
   globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) })) as unknown as typeof fetch;
 });
 
-function mountCell(initialSessionId: string | null, opts: { initialCwd?: string | null; defaultCwd?: string | null } = {}) {
+function mountCell(
+  initialSessionId: string | null,
+  opts: { initialCwd?: string | null; defaultCwd?: string | null; presets?: { label: string; path: string }[] } = {},
+) {
   return mount(TerminalCell, {
-    props: { expanded: false, initialSessionId, initialCwd: opts.initialCwd ?? null, defaultCwd: opts.defaultCwd ?? "/home/me/my-project" },
+    props: {
+      expanded: false,
+      initialSessionId,
+      initialCwd: opts.initialCwd ?? null,
+      defaultCwd: opts.defaultCwd ?? "/home/me/my-project",
+      presets: opts.presets ?? [],
+    },
   });
 }
 
@@ -62,6 +71,17 @@ describe("TerminalCell", () => {
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/home/me/picked");
+  });
+
+  it("launches in a preset dir on one click", async () => {
+    const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
+    await flushPromises();
+    const btn = w.findAll(".cell-preset").find((b) => b.text() === "proj");
+    if (!btn) throw new Error("preset button not found");
+    await btn.trigger("click");
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.exists()).toBe(true);
+    expect(term.props("cwd")).toBe("/work/proj");
   });
 
   it("resets the launch form to the default dir after close", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -2,14 +2,15 @@
 import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vue";
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
+import type { CwdPreset } from "./presets";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 
 // `expanded` reflects whether this cell is zoomed to fill the grid (parent owns
 // the state). `initialSessionId` resumes a session on mount (reload restore).
 // `initialCwd` is this cell's persisted working dir; `defaultCwd` is the server
-// default used to prefill the launch form for a fresh cell.
-const props = defineProps<{ expanded: boolean; initialSessionId: string | null; initialCwd: string | null; defaultCwd: string | null }>();
+// default used to prefill the launch form; `presets` are quick-pick dirs.
+const props = defineProps<{ expanded: boolean; initialSessionId: string | null; initialCwd: string | null; defaultCwd: string | null; presets: CwdPreset[] }>();
 const emit = defineEmits<{ (e: "toggle-expand" | "close"): void; (e: "session" | "cwd", value: string): void }>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
@@ -83,6 +84,12 @@ function launch() {
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
+}
+
+// Quick-pick a preset directory: fill the field and launch in one click.
+function launchPreset(p: CwdPreset) {
+  dirInput.value = p.path;
+  launch();
 }
 
 // The server reports where the PTY actually runs (it may have rejected the
@@ -160,6 +167,9 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
       <TerminalView ref="termRef" class="cell-term" :session-id="sessionId" :connect-key="connectKey" :cwd="cwd" @session="onSession" @cwd="onServerCwd" />
     </template>
     <div v-else class="cell-launch">
+      <div v-if="presets.length" class="cell-presets">
+        <button v-for="p in presets" :key="p.label + p.path" class="cell-preset" :title="p.path" @click="launchPreset(p)">{{ p.label }}</button>
+      </div>
       <label class="cell-launch-label">
         <span class="cell-launch-caption">Working directory</span>
         <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
@@ -280,6 +290,27 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   justify-content: center;
   gap: 8px;
   padding: 16px;
+}
+.cell-presets {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  max-width: 360px;
+}
+.cell-preset {
+  border: 1px solid #2a2a4e;
+  background: #20203a;
+  color: #c7cdf0;
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 14px;
+}
+.cell-preset:hover {
+  background: #2a3b66;
+  color: #fff;
 }
 .cell-launch-label {
   display: flex;

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -9,14 +9,14 @@ import type { Layout } from "./gridLayout";
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
-    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd"],
+    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets"],
     emits: ["toggle-expand", "session", "cwd", "close"],
     template: '<div class="stub-cell" />',
   },
 }));
 
 const STORE_KEY = "grid_state_v1";
-const mountGrid = (layout: Layout = "2x2") => mount(TerminalGrid, { props: { layout } });
+const mountGrid = (layout: Layout = "2x2") => mount(TerminalGrid, { props: { layout, defaultCwd: "/work/proj", presets: [] } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const saved = () => JSON.parse(localStorage.getItem(STORE_KEY) || "{}");
 
@@ -62,7 +62,7 @@ describe("TerminalGrid", () => {
     expect(cells[2].props("expanded")).toBe(true);
   });
 
-  it("passes the fetched cwd to cells as defaultCwd", async () => {
+  it("forwards defaultCwd to cells", async () => {
     const w = mountGrid();
     await flushPromises();
     expect(cellsOf(w)[0].props("defaultCwd")).toBe("/work/proj");

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1,30 +1,20 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from "vue";
+import { ref, computed, watch } from "vue";
 import TerminalCell from "./TerminalCell.vue";
 import { MAX_CELLS, dims, trackStyle, type Layout } from "./gridLayout";
+import type { CwdPreset } from "./presets";
 
 // Zooming interface: the grid is the base view; expanding a cell grows it to fill
 // the area and shrinks the others to zero — animated by transitioning the grid
 // track sizes (Mac-like zoom). All cells stay MOUNTED while zoomed, so their
 // terminals keep running. The layout (cell arrangement) is chosen in the toolbar.
-const props = defineProps<{ layout: Layout }>();
+// `defaultCwd` prefills the launch form; `presets` are the quick-pick dirs.
+const props = defineProps<{ layout: Layout; defaultCwd: string | null; presets: CwdPreset[] }>();
 
 const cellCount = computed(() => dims(props.layout).cellCount);
 // Render only the visible cells; the persisted arrays are kept at MAX_CELLS so a
 // session/cwd survives switching to a smaller layout and back.
 const cells = computed(() => Array.from({ length: cellCount.value }, (_, i) => i));
-
-// The active workspace dir, shown in each cell header (server global for now;
-// per-cell dirs are a follow-up).
-const cwd = ref<string | null>(null);
-onMounted(async () => {
-  try {
-    const res = await fetch("/api/config");
-    if (res.ok) cwd.value = (await res.json()).cwd ?? null;
-  } catch {
-    // header just omits the dir if config can't be fetched
-  }
-});
 
 // Persisted so a page reload restores the open terminals and the zoom state.
 const STORE_KEY = "grid_state_v1";
@@ -95,7 +85,8 @@ const gridStyle = computed(() => trackStyle(props.layout, expanded.value));
       :expanded="expanded === i"
       :initial-session-id="cellSessions[i]"
       :initial-cwd="cellCwds[i]"
-      :default-cwd="cwd"
+      :default-cwd="defaultCwd"
+      :presets="presets"
       @toggle-expand="toggleExpand(i)"
       @session="(id) => setSession(i, id)"
       @cwd="(c) => (cellCwds[i] = c)"

--- a/src/components/presets.ts
+++ b/src/components/presets.ts
@@ -1,0 +1,5 @@
+// A directory preset offered in the cell launch form, editable in settings.
+export interface CwdPreset {
+  label: string;
+  path: string;
+}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -19,5 +19,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["server/**/*.ts"]
+  "include": ["server/**/*.ts"],
+  "exclude": ["server/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

Saved working-directory **presets**, so launching a terminal in a known project is one click.

- **⚙ Settings** in the toolbar opens a modal to add / edit / remove presets (`{label, path}`).
- The cell launch form shows **preset chips**; clicking one launches a terminal in that dir immediately. Manual entry still works.
- Persisted server-side at `~/.mulmoterminal/config.json` (survives restart).

## Changes

- **server**: `GET /api/config` → `{ cwd, cwdPresets }`; `POST /api/config` validates (trims, drops rows missing label/path, caps at 50) and persists.
- **App.vue**: owns config (default cwd + presets), the ⚙ button, and `SettingsModal`; passes them to the grid.
- **TerminalGrid**: forwards `defaultCwd` + `presets` to cells (config fetch moved up to App).
- **TerminalCell**: preset chips in the launch form (`launchPreset`).
- **SettingsModal.vue** (new) + `presets.ts` (shared type).

## Verification

- `lint` / `typecheck` / `typecheck:server` / `test` (60) / `build` ✅.
- End-to-end: POST trims/filters junk rows, persists to `config.json`, and reloads after a server restart.
- Tests: SettingsModal (add/remove/save-trims/cancel/no-prop-mutation), grid forwards presets, cell one-click preset launch.

## Note

Current dir + latest user prompt are already shown in each cell header (from #59). This PR adds the presets + settings screen.

base: `dev_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)