### PR TITLE
feat(grid): cell header shows more of the dir (~-anchored, front-truncated)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -743,7 +743,7 @@ app.get("/api/tool-calls/:sessionId", async (req, res) => {
 // Server-wide config the UI shows: the default workspace dir + the user's saved
 // directory presets (offered in the cell launch form).
 app.get("/api/config", (_req, res) => {
-  res.json({ cwd: CLAUDE_CWD, cwdPresets });
+  res.json({ cwd: CLAUDE_CWD, cwdPresets, home: os.homedir() });
 });
 
 // Update the directory presets (from the settings screen) and persist them.

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ watch(layout, (v) => localStorage.setItem("grid_layout", v));
 
 // Server config: the default workspace dir + the user's directory presets.
 const defaultCwd = ref<string | null>(null);
+const home = ref<string | null>(null);
 const presets = ref<CwdPreset[]>([]);
 const showSettings = ref(false);
 const savingSettings = ref(false);
@@ -23,6 +24,7 @@ async function loadConfig() {
     if (!res.ok) return;
     const c = await res.json();
     defaultCwd.value = c.cwd ?? null;
+    home.value = c.home ?? null;
     presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
   } catch {
     // grid still works; presets just unavailable
@@ -66,7 +68,7 @@ function closeSettings() {
       </span>
       <button class="settings-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>
-    <TerminalGrid class="main" :layout="layout" :default-cwd="defaultCwd" :presets="presets" />
+    <TerminalGrid class="main" :layout="layout" :default-cwd="defaultCwd" :presets="presets" :home="home" />
     <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
   </div>
 </template>

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 
 function mountCell(
   initialSessionId: string | null,
-  opts: { initialCwd?: string | null; defaultCwd?: string | null; presets?: { label: string; path: string }[] } = {},
+  opts: { initialCwd?: string | null; defaultCwd?: string | null; presets?: { label: string; path: string }[]; home?: string | null } = {},
 ) {
   return mount(TerminalCell, {
     props: {
@@ -45,21 +45,22 @@ function mountCell(
       initialCwd: opts.initialCwd ?? null,
       defaultCwd: opts.defaultCwd ?? "/home/me/my-project",
       presets: opts.presets ?? [],
+      home: opts.home ?? "/home/me",
     },
   });
 }
 
 describe("TerminalCell", () => {
-  it("shows the workspace dir basename in the header", async () => {
-    const w = mountCell("11111111-1111-1111-1111-111111111111");
+  it("shows the ~-anchored workspace path in the header", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/ss/my-project" });
     await flushPromises();
-    expect(w.find(".cell-dir").text()).toBe("my-project");
+    expect(w.find(".cell-dir").text()).toBe("~/ss/my-project");
   });
 
-  it("derives the basename from a Windows-style path too", async () => {
-    const w = mountCell("55555555-5555-5555-5555-555555555555", { initialCwd: "C:\\work\\proj" });
+  it("shows a non-home path in full", async () => {
+    const w = mountCell("55555555-5555-5555-5555-555555555555", { initialCwd: "/var/data/proj" });
     await flushPromises();
-    expect(w.find(".cell-dir").text()).toBe("proj");
+    expect(w.find(".cell-dir").text()).toBe("/var/data/proj");
   });
 
   it("launches in the dir typed in the form and sends it to the terminal", async () => {
@@ -105,7 +106,7 @@ describe("TerminalCell", () => {
     await nextTick();
     // The cell persists + displays the effective cwd, not the typed one.
     expect(w.emitted("cwd")?.at(-1)).toEqual(["/home/me/default"]);
-    expect(w.find(".cell-dir").text()).toBe("default");
+    expect(w.find(".cell-dir").text()).toBe("~/default");
   });
 
   it("reflects working/waiting/lastPrompt pushed for its own session", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vue";
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
+import { formatCwd } from "./cwdDisplay";
 import type { CwdPreset } from "./presets";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
@@ -9,8 +10,16 @@ const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 // `expanded` reflects whether this cell is zoomed to fill the grid (parent owns
 // the state). `initialSessionId` resumes a session on mount (reload restore).
 // `initialCwd` is this cell's persisted working dir; `defaultCwd` is the server
-// default used to prefill the launch form; `presets` are quick-pick dirs.
-const props = defineProps<{ expanded: boolean; initialSessionId: string | null; initialCwd: string | null; defaultCwd: string | null; presets: CwdPreset[] }>();
+// default used to prefill the launch form; `presets` are quick-pick dirs; `home`
+// is the server home dir (to anchor the header path on ~).
+const props = defineProps<{
+  expanded: boolean;
+  initialSessionId: string | null;
+  initialCwd: string | null;
+  defaultCwd: string | null;
+  presets: CwdPreset[];
+  home: string | null;
+}>();
 const emit = defineEmits<{ (e: "toggle-expand" | "close"): void; (e: "session" | "cwd", value: string): void }>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
@@ -123,13 +132,8 @@ function onSession(id: string) {
   loadInitial(id);
 }
 
-const dirBase = computed(() => {
-  const c = cwd.value;
-  if (!c) return "";
-  // Split on both separators so a Windows path (C:\work\proj) yields the basename.
-  const parts = c.split(/[/\\]/).filter(Boolean);
-  return parts[parts.length - 1] || c;
-});
+// ~-anchored, front-truncated path for the header (keeps the tail).
+const dirDisplay = computed(() => formatCwd(cwd.value, props.home));
 
 // Attention (waiting) wins over working wins over idle.
 const status = computed<"waiting" | "working" | "idle">(() => {
@@ -150,7 +154,7 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
     <template v-if="launched">
       <div class="cell-header">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
-        <span v-if="dirBase" class="cell-dir" :title="cwd ?? ''">{{ dirBase }}</span>
+        <span v-if="dirDisplay" class="cell-dir" :title="cwd ?? ''">{{ dirDisplay }}</span>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <span class="cell-actions">
           <button
@@ -228,8 +232,8 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 }
 
 .cell-dir {
-  flex: 0 0 auto;
-  max-width: 40%;
+  flex: 0 1 auto;
+  max-width: 60%;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 11px;
   color: #7f88ad;

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -9,14 +9,14 @@ import type { Layout } from "./gridLayout";
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
-    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets"],
+    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home"],
     emits: ["toggle-expand", "session", "cwd", "close"],
     template: '<div class="stub-cell" />',
   },
 }));
 
 const STORE_KEY = "grid_state_v1";
-const mountGrid = (layout: Layout = "2x2") => mount(TerminalGrid, { props: { layout, defaultCwd: "/work/proj", presets: [] } });
+const mountGrid = (layout: Layout = "2x2") => mount(TerminalGrid, { props: { layout, defaultCwd: "/work/proj", presets: [], home: "/work" } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const saved = () => JSON.parse(localStorage.getItem(STORE_KEY) || "{}");
 

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -8,8 +8,9 @@ import type { CwdPreset } from "./presets";
 // the area and shrinks the others to zero — animated by transitioning the grid
 // track sizes (Mac-like zoom). All cells stay MOUNTED while zoomed, so their
 // terminals keep running. The layout (cell arrangement) is chosen in the toolbar.
-// `defaultCwd` prefills the launch form; `presets` are the quick-pick dirs.
-const props = defineProps<{ layout: Layout; defaultCwd: string | null; presets: CwdPreset[] }>();
+// `defaultCwd` prefills the launch form; `presets` are the quick-pick dirs;
+// `home` anchors the cell header path on ~.
+const props = defineProps<{ layout: Layout; defaultCwd: string | null; presets: CwdPreset[]; home: string | null }>();
 
 const cellCount = computed(() => dims(props.layout).cellCount);
 // Render only the visible cells; the persisted arrays are kept at MAX_CELLS so a
@@ -87,6 +88,7 @@ const gridStyle = computed(() => trackStyle(props.layout, expanded.value));
       :initial-cwd="cellCwds[i]"
       :default-cwd="defaultCwd"
       :presets="presets"
+      :home="home"
       @toggle-expand="toggleExpand(i)"
       @session="(id) => setSession(i, id)"
       @cwd="(c) => (cellCwds[i] = c)"

--- a/src/components/cwdDisplay.spec.ts
+++ b/src/components/cwdDisplay.spec.ts
@@ -11,6 +11,13 @@ describe("homeRelative", () => {
     expect(homeRelative("/Users/mehmet/x", "/Users/me")).toBe("/Users/mehmet/x"); // not a real segment boundary
     expect(homeRelative("/var/data", null)).toBe("/var/data");
   });
+
+  it("anchors Windows paths (backslashes, case-insensitive drive/segments)", () => {
+    expect(homeRelative("C:\\Users\\me\\proj", "C:\\Users\\me")).toBe("~\\proj");
+    expect(homeRelative("c:\\users\\ME\\proj", "C:\\Users\\me")).toBe("~\\proj"); // case-insensitive
+    expect(homeRelative("C:\\Users\\me", "C:\\Users\\me")).toBe("~");
+    expect(homeRelative("D:\\other\\x", "C:\\Users\\me")).toBe("D:\\other\\x");
+  });
 });
 
 describe("truncateFront", () => {

--- a/src/components/cwdDisplay.spec.ts
+++ b/src/components/cwdDisplay.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { homeRelative, truncateFront, formatCwd } from "./cwdDisplay";
+
+describe("homeRelative", () => {
+  it("anchors a path under home on ~", () => {
+    expect(homeRelative("/Users/me/ss/proj", "/Users/me")).toBe("~/ss/proj");
+    expect(homeRelative("/Users/me", "/Users/me")).toBe("~");
+  });
+  it("leaves non-home and home-prefix-lookalike paths untouched", () => {
+    expect(homeRelative("/var/data", "/Users/me")).toBe("/var/data");
+    expect(homeRelative("/Users/mehmet/x", "/Users/me")).toBe("/Users/mehmet/x"); // not a real segment boundary
+    expect(homeRelative("/var/data", null)).toBe("/var/data");
+  });
+});
+
+describe("truncateFront", () => {
+  it("returns the string unchanged when it fits", () => {
+    expect(truncateFront("~/ss/proj", 30)).toBe("~/ss/proj");
+  });
+  it("keeps the tail and prefixes an ellipsis when too long", () => {
+    const out = truncateFront("~/a/b/c/d/e/f/g/h/i/j/k", 10);
+    expect(out.startsWith("…")).toBe(true);
+    expect(out).toHaveLength(10);
+    expect("~/a/b/c/d/e/f/g/h/i/j/k".endsWith(out.slice(1))).toBe(true); // it's a suffix
+  });
+});
+
+describe("formatCwd", () => {
+  it("combines home-anchoring and front truncation", () => {
+    expect(formatCwd("/Users/me/ss/proj", "/Users/me")).toBe("~/ss/proj");
+    const long = "/Users/me/work/clients/acme/backend/services/auth/handlers";
+    const out = formatCwd(long, "/Users/me", 20);
+    expect(out.startsWith("…")).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(20);
+    expect(long.endsWith(out.slice(1))).toBe(true);
+  });
+  it("returns empty for a null cwd", () => {
+    expect(formatCwd(null, "/Users/me")).toBe("");
+  });
+});

--- a/src/components/cwdDisplay.ts
+++ b/src/components/cwdDisplay.ts
@@ -3,7 +3,17 @@
 // and drop the front behind an ellipsis — e.g. "…hoge/foo/bar".
 
 export function homeRelative(cwd: string, home: string | null): string {
-  if (home && (cwd === home || cwd.startsWith(`${home}/`))) return `~${cwd.slice(home.length)}`;
+  if (!home) return cwd;
+  // Windows paths use "\" and are case-insensitive (incl. the drive letter).
+  const windows = home.includes("\\") || /^[a-zA-Z]:/.test(home);
+  const matches = (a: string, b: string) => (windows ? a.toLowerCase() === b.toLowerCase() : a === b);
+  if (matches(cwd, home)) return "~";
+  // cwd must continue with a separator right after the home prefix (so /Users/me
+  // doesn't match /Users/mehmet).
+  const next = cwd.charAt(home.length);
+  if ((next === "/" || next === "\\") && matches(cwd.slice(0, home.length), home)) {
+    return `~${cwd.slice(home.length)}`;
+  }
   return cwd;
 }
 

--- a/src/components/cwdDisplay.ts
+++ b/src/components/cwdDisplay.ts
@@ -1,0 +1,18 @@
+// Format an absolute working directory for the compact cell header: anchor on the
+// home dir (~), and if it's still too long keep the TAIL (the most specific part)
+// and drop the front behind an ellipsis — e.g. "…hoge/foo/bar".
+
+export function homeRelative(cwd: string, home: string | null): string {
+  if (home && (cwd === home || cwd.startsWith(`${home}/`))) return `~${cwd.slice(home.length)}`;
+  return cwd;
+}
+
+// Keep the last `max` chars (the tail), prefixed with "…" when truncated.
+export function truncateFront(s: string, max: number): string {
+  return s.length <= max ? s : `…${s.slice(s.length - (max - 1))}`;
+}
+
+export function formatCwd(cwd: string | null, home: string | null, max = 30): string {
+  if (!cwd) return "";
+  return truncateFront(homeRelative(cwd, home), max);
+}


### PR DESCRIPTION
## Summary

The cell header showed only the directory **basename**. Now it shows as much of the path as fits:

- **Anchored on home** → `~/ss/llm/mulmoterminal` (and `~` for home itself).
- **Non-home paths in full** → `/var/log/system`.
- **Too long → drop the front, keep the tail** behind an ellipsis → `…services/auth/handlers/v2`.

Full absolute path remains on hover (`title`).

## Changes

- **server**: `GET /api/config` now includes `home` (`os.homedir()`).
- **App → TerminalGrid → TerminalCell**: thread `home` through.
- **`cwdDisplay.ts`** (new): `homeRelative` + `truncateFront` + `formatCwd`, unit-tested.
- Cell header uses `formatCwd(cwd, home)`; the dir column widened (40% → 60%).

## Verification

- `lint` / `typecheck` / `typecheck:server` / `test` (77) / `build` ✅.
- `/api/config` returns `home`; samples: `~/ss/llm/mulmoterminal`, `~`, `/var/log/system`, and a long path → `…end/services/auth/handlers/v2`.

base: `dev_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)