### PR TITLE
merge: bring main into dev_tool (single ⇄ grid switch, split files)

### DIFF
--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -1,0 +1,242 @@
+# Integrating `@mulmoclaude/collection-plugin` into MulmoTerminal
+
+Status: **the cross-repo blocker is gone.** The package shipped `0.5.0`/`0.5.1` with exactly the
+host-contract changes this doc originally said were still needed (ToolPlugin entry, router-optional
+nav, configurable teleport target, server engine). What remains is **MulmoTerminal-side wiring only** —
+**no MulmoClaude changes are required.**
+
+This doc was originally written against `0.4.1` and assumed a future `0.5.0` was on the critical path.
+It has been updated against the **published `@mulmoclaude/collection-plugin@0.5.1`** and the current
+MulmoTerminal tree.
+
+---
+
+## TL;DR verdict
+
+**Can this be done without any changes to MulmoClaude? Yes.** Everything MulmoTerminal needs is already
+published in `@mulmoclaude/collection-plugin@0.5.1`:
+
+- `./vue` exports a `plugin: ToolPlugin` (chat-result `View` + `Preview`) — the runtime registration
+  shape MulmoTerminal uses, just like chart/form/markdown.
+- Navigation is **router-optional**: `CollectionEmbedView` no longer renders a bare `<router-link>`;
+  refs/embeds go through `collectionUi().navigateToRecord(slug, recordId?)` (`src/vue/refLink.ts`), and
+  `recordHref`/`navigate` are optional so a router-less host returns `undefined`.
+- The record modal teleports to a host-supplied target: `modalTeleportTarget?: () => string | HTMLElement`
+  (defaults to `"body"`), so a Shadow-DOM host points it at an in-shadow node.
+- `./server` exports the full read-side engine: `configureCollectionHost({ workspaceRoot, log, paths,
+  isPresetSlug })` plus `discoverCollections` / `loadCollection` / `toSummary` / `toDetail` /
+  `listItems` / `validateCollectionRecords`.
+
+The **only** MulmoClaude artifact that is NOT packaged is the favorites/shortcuts format
+(`Shortcut` type + `shortcuts-io`), which still lives in MulmoClaude's app tree. MulmoTerminal must
+**reimplement that format verbatim** for the Tier 2 toolbar (see the drift warning). That is a
+MulmoTerminal-side change — it requires no MulmoClaude edit. Extracting a shared shortcuts package
+later (to eliminate drift risk) is optional and deferrable.
+
+---
+
+## Correction to the original plan: even the read-only card needs the server
+
+The original doc claimed a "Tier 0 — read-only chat card, no server." **That is wrong for the 0.5.x
+design.** `executePresentCollection` only echoes the addressing `{ collectionSlug, itemId? }` — it does
+**not** embed records. The chat `View` passes just the `slug` to `CollectionView`, which then calls
+`collectionUi().fetchCollectionDetail(slug)` to load the live schema + records (see
+`CollectionView.vue` and `useCollectionRendering.ts`). So the smallest increment that actually renders
+data is **frontend wiring + the server read route** — not a snapshot-only card.
+
+This is consistent with the foundational model below: MulmoTerminal is a *second live view over the
+shared workspace*, never a renderer of a passed-in snapshot.
+
+---
+
+## What's published and ready (`0.5.1`)
+
+| Entry | Contents | MulmoTerminal needs it? |
+|---|---|---|
+| `.` | isomorphic core (schema, derive/formula, `TOOL_DEFINITION`/`executePresentCollection`, list/detail response types) | yes (tool def + types) |
+| `./server` | node-only engine behind `configureCollectionHost(...)` + `discoverCollections`/`loadCollection`/`toSummary`/`toDetail`/`listItems`/`validateCollectionRecords` (read side) and CRUD/delete/views (write side) | yes (read side now; write later) |
+| `./vue` | `plugin: ToolPlugin`, `configureCollectionUi()`/`collectionUi()`, `CollectionView`, `CollectionsIndexView`, all sub-views | yes |
+| `./style.css` | compiled Tailwind | yes (inject into the shadow root) |
+
+Peer deps: `gui-chat-protocol@^0.4.0` (MulmoTerminal already has it), `vue@^3.5`, `vue-i18n@^11.4.4`
+(MulmoTerminal must add). The plugin owns its **own vue-i18n instance** (all 8 locales) — it needs no
+host translation keys, only a `localeTag()`.
+
+---
+
+## MulmoTerminal architecture (the relevant facts)
+
+- **Already consumes `@mulmoclaude/{chart,form,markdown,x}-plugin`** — imports `{ plugin } from "@X/vue"`
+  in `src/plugins-registry.ts` and renders `getPlugin(toolName).viewComponent` in `GuiPanel.vue`. CSS is
+  imported `?inline` and injected into a per-view **Shadow DOM** (`PluginFrame.vue` → `attachShadow` +
+  `Teleport` into the shadow mount).
+- **No vue-router** (so "navigate" = switch a panel's state).
+- **No vue-i18n** yet (must add `vue-i18n@^11`).
+- **Shared workspace**: `CLAUDE_CWD` (defaults to `~/mulmoclaude`) is the PTY cwd and the root for
+  persisted state; `<workspace>/artifacts` is the user-browsable output area. Server backends are
+  initialised at boot (`initMarkdownBackend`, `initArtifactsBackend`) — the same hook point where
+  `configureCollectionHost` goes.
+
+---
+
+## Foundational model: two views over one workspace
+
+MulmoClaude and MulmoTerminal **share a workspace**, and everything that matters is workspace state:
+
+- **Collection definitions are skills** (`<workspace>/.claude/skills/<slug>/` + sibling `schema.json`,
+  plus `~/.claude/skills` user scope) — shared.
+- **Records** — shared, under the schema's data dir.
+- **Favorites** = pinned launcher shortcuts at `<workspace>/config/shortcuts.json` — shared.
+
+So MulmoTerminal is a second live view, not a snapshot renderer. To *show* collections its server must
+wire the engine against the shared `workspaceRoot` using the **same path layout** MulmoClaude uses
+(below), so discovery sees the same files.
+
+### Shared path layout (must match MulmoClaude exactly)
+
+| Host path | Value |
+|---|---|
+| `userSkillsDir` | `~/.claude/skills` |
+| `projectSkillsDir(root)` | `<root>/.claude/skills` |
+| `feedsRoot(root)` | `<root>/feeds` |
+| `skillsStagingDir(root)` | `<root>/data/skills` |
+| `archiveDir` | `archive` |
+| `isPresetSlug(slug)` | `slug.startsWith("mc-") && slug.length > 3` |
+
+---
+
+## Gap analysis (updated for `0.5.1`)
+
+| # | Original gap | Status |
+|---|---|---|
+| 1 | No `plugin: ToolPlugin` export | ✅ shipped — `export const plugin` in `./vue` |
+| 2 | `<router-link>` / vue-router assumed | ✅ shipped — router-optional via `refLink.ts` + `navigateToRecord`/optional `recordHref`/`navigate` |
+| 3 | `Teleport to="body"` escapes Shadow DOM | ✅ shipped — `modalTeleportTarget?: () => string \| HTMLElement` |
+| 4 | vue-i18n peer | **[term]** add `vue-i18n@^11` |
+| 5 | ~30 host-capability stubs | **[term]** most can stub; `fetchCollectionDetail`/`listCollections`/`localeTag`/`confirm` must be real |
+| 6 | Server engine over shared workspace | **[term]** `configureCollectionHost` + read routes (now required for the card too, see correction above) |
+
+### The binding (`CollectionUi`) — what's real vs stub for the read-side increment
+
+Base the MulmoTerminal binding on MulmoClaude's `src/composables/collections/uiHost.ts`. For a
+read-only card over the shared workspace:
+
+- **Real:** `fetchCollectionDetail` (→ `GET /api/collections/:slug/detail`), `listCollections`
+  (→ `GET /api/collections/list`), `localeTag` (host i18n), `confirm` (`window.confirm`-backed),
+  `generalRoleId`/`personalRoleId` (constants), `pinToggle` (stub component rendering nothing for now).
+- **Required-but-no-op for an embedded card:** routing fns `routeSlug`/`routeSelectedId`/`isFeedRoute`/
+  `setSelectedId`/`gotoIndex`/`gotoDetail`/`navigateToRecord` (wired to view-state in Tier 2; safe
+  no-ops until then).
+- **Stub (write/feeds/views):** `createItem`/`updateItem`/`deleteItem`/`deleteCollection`/`deleteFeed`/
+  `runItemAction`/`runCollectionAction`/`refreshCollection`/`deleteView`/`mintViewToken`/`fetchViewHtml`/
+  `buildViewSrcdoc`/`listFeeds` → typed failure; `reconcileShortcuts`/`unpin` → no-op;
+  `notifiedSeverities` → empty map; `startChat` → no-op (the card uses the `sendTextMessage` prop, not
+  this binding hook).
+- **Asset URLs:** `imageSrc`/`fileAssetUrl` resolve to `GET /api/files/raw?path=<workspace-relative>`
+  (server/backends/files.ts), mirroring MulmoClaude's `resolveImageSrc`, so `image`/`file` fields and
+  custom-view `<img>` thumbnails render. `fileRoutePath` stays null (no in-app File Explorer).
+
+### Teleport + Shadow DOM
+
+`PluginFrame` Teleports each card into a **per-instance** shadow `mount`, but `configureCollectionUi`
+sets a **single global** binding — so `modalTeleportTarget` can't statically know which card's shadow
+root to use. Approach: `PluginFrame` `provide()`s its shadow mount; a thin MulmoTerminal wrapper around
+the collection `View` injects it and registers it as the "active" teleport target while mounted; the
+binding's `modalTeleportTarget` returns that module-level active mount. Correct for the common
+single-card case; multi-card simultaneously-open modals are an accepted v1 limitation (documented).
+
+---
+
+## Required feature: a collections toolbar (tabs) — the actual ask
+
+MulmoClaude's top chrome (`PluginLauncher.vue` + `useShortcuts` + `PinToggle.vue`) has a **Collections**
+button → the `/collections` index, plus one button **per favorite** → that collection's
+`CollectionView`. Favoriting toggles the star.
+
+MulmoTerminal equivalent needs three pieces, adapted to a no-router, state-driven host:
+
+1. **A favorites store — SHARED via the workspace** `[term]`. Favorites are NOT app-local. MulmoClaude
+   persists them server-side at **`<workspace>/config/shortcuts.json`** via `GET`/`PUT /api/shortcuts`.
+   The on-disk shape is an **object wrapper** (NOT a bare array):
+
+   ```jsonc
+   { "shortcuts": [ { "kind": "collection" | "feed", "slug": "...", "title": "...", "icon": "..." } ] }
+   ```
+
+   (`mulmoclaude/src/types/shortcuts.ts` — wrapper "so the schema can grow without a migration".)
+   MulmoTerminal must read/write **the same file in the same wrapper format**, plus a frontend
+   `useShortcuts`-equivalent backing `pinToggle`/`unpin`/`reconcileShortcuts`.
+
+   **Drift risk:** two independent writers of one on-disk format diverge over time (note `PUT` rewrites
+   the whole object). **Recommended:** extract `shortcuts-io` + the `Shortcut` type into a shared
+   package (the move that already worked for the collection engine). Pragmatic fallback: reimplement
+   verbatim + a shared schema/fixture test. **Either way the format is the contract** — and a shared
+   package would be the one optional MulmoClaude-side change in this whole effort.
+
+2. **A launcher in `<header class="toolbar">`** `[term]` — a "Collections" button + a button per
+   favorite, each switching the panel to a collection view.
+
+3. **A state-based "collection browse" panel** `[term]` — since there's no router, a panel mode that can
+   show `CollectionsIndexView` or a standalone `CollectionView(slug)`. The binding's nav fns map to this
+   view state (the router-optional change makes this clean).
+
+---
+
+## Scope tiers
+
+1. **Read-side foundation (this PR's increment).** Wire the server engine + read routes and the
+   frontend ToolPlugin + binding, so a `presentCollection` chat card renders **real data from the shared
+   workspace**. (Supersedes the old "Tier 0 — no server", which couldn't render anything.)
+2. **Tier 1 — interactive card.** Inline edit + add/delete + actions. Adds the **write** routes
+   (`items`/`item`/actions/refresh/views) + a real `startChat`.
+3. **Tier 2 — browsable + toolbar (THE ASK).** Toolbar "Collections" button + per-favorite buttons →
+   `CollectionsIndexView` / standalone `CollectionView(slug)`. Adds state-based nav, the
+   shared-favorites store (`/api/shortcuts` over `config/shortcuts.json`) + launcher + browse panel.
+   The `/feeds` half is optional — include only if feeds matter in a terminal UI. Tier 2 does **not**
+   require Tier 1's write routes (browse is read-only until editing is added).
+
+---
+
+## Implementation sequence
+
+1. ~~Package `0.5.0`~~ **DONE** — published as `0.5.1` (ToolPlugin + router-optional nav + teleport
+   target + server engine). No further MulmoClaude work required for Tiers 0–2.
+2. **MulmoTerminal — deps**: add `vue-i18n@^11` + `@mulmoclaude/collection-plugin@^0.5.1`.
+3. **MulmoTerminal — server (read side)**: `configureCollectionHost({ workspaceRoot: CLAUDE_CWD, … })`
+   at boot (using the shared path layout above); add `GET /api/collections/list` +
+   `GET /api/collections/:slug/detail` backed by the package's read helpers.
+4. **MulmoTerminal — frontend wiring**: register the `plugin` ToolPlugin in `plugins-registry.ts` +
+   inject `style.css?inline`; implement the `collectionUi` binding (read real, write/chat/shortcuts
+   stubbed per §gap 5); resolve the teleport target via the shadow-mount wrapper.
+5. **MulmoTerminal — toolbar + favorites (Tier 2, the ask)**: decide shortcuts sharing (shared package
+   vs verbatim+test); `GET`/`PUT /api/shortcuts` over `config/shortcuts.json`; a `useShortcuts`
+   equivalent; the launcher in the toolbar; the browse panel mode.
+6. **Tier 1 later**: write routes + `manageCollection` MCP tool + real `startChat`.
+
+---
+
+## Resolved decisions
+
+- **Shortcuts sharing** → **reimplement verbatim + fixture test** (`server/backends/shortcuts.ts` +
+  `src/types/shortcuts.ts`, `shortcuts.spec.ts` pins the `{ shortcuts: [...] }` wrapper). Keeps
+  MulmoTerminal MulmoClaude-change-free; the shared file is the contract.
+- **Browse panel placement** → **full-screen overlay** (`CollectionsBrowseOverlay.vue`), driven by
+  `useCollectionBrowse` view-state; the binding's nav fns map onto it.
+- **CSS isolation** → keep the shadow frame (the overlay reuses `PluginFrame` + `collectionShadowCss`,
+  and registers its shadow root as the modal teleport target like the card).
+- **Raw-file route** → added (`/api/files/raw`), so `image`/`file` fields render.
+- **`/feeds`** → the launcher/overlay support `kind: "feed"` shortcuts, but the collections index
+  filters feeds out; a dedicated feeds index/`FeedsView` is deferred.
+
+## Tier 2 status (implemented)
+
+Shipped: shared favorites (`GET/PUT /api/shortcuts` over `config/shortcuts.json`), `useShortcuts` store
++ `PinToggle`, the toolbar launcher (`<header class="toolbar">`: a "Collections" button + one per
+favorite), and the full-screen browse overlay (`CollectionsIndexView` / standalone `CollectionView`
+via `useCollectionBrowse`). Verified: MulmoClaude's pinned collections appear in MulmoTerminal's
+toolbar from the shared file; the overlay opens and the index renders. Still open: `startChat` is a
+no-op (collection "create"/action buttons that seed a chat are inert), and Tier 1 write routes.
+
+Bottom line: **the package is drop-in-ready and needs zero MulmoClaude changes.** The work is entirely
+in MulmoTerminal: server read engine + routes, the frontend ToolPlugin + binding + teleport wrapper,
+then the toolbar/favorites/browse panel for the actual ask.

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -215,15 +215,27 @@ MulmoTerminal equivalent needs three pieces, adapted to a no-router, state-drive
 
 ---
 
-## Open questions for the maintainers
+## Resolved decisions
 
-- **Shortcuts sharing**: shared package (recommended; the only optional MulmoClaude change) vs
-  reimplement-verbatim + format test?
-- **Browse panel placement**: replace the GuiPanel content, a new tab/pane, or overlay?
-- **CSS isolation**: keep the shadow frame (and the teleport-target wrapper) or treat the collection
-  plugin as first-party in light DOM?
-- **Raw-file route**: add one so `image`/`file` fields render, or accept the v1 gap?
-- **`/feeds`**: wanted, or collections-only?
+- **Shortcuts sharing** → **reimplement verbatim + fixture test** (`server/backends/shortcuts.ts` +
+  `src/types/shortcuts.ts`, `shortcuts.spec.ts` pins the `{ shortcuts: [...] }` wrapper). Keeps
+  MulmoTerminal MulmoClaude-change-free; the shared file is the contract.
+- **Browse panel placement** → **full-screen overlay** (`CollectionsBrowseOverlay.vue`), driven by
+  `useCollectionBrowse` view-state; the binding's nav fns map onto it.
+- **CSS isolation** → keep the shadow frame (the overlay reuses `PluginFrame` + `collectionShadowCss`,
+  and registers its shadow root as the modal teleport target like the card).
+- **Raw-file route** → added (`/api/files/raw`), so `image`/`file` fields render.
+- **`/feeds`** → the launcher/overlay support `kind: "feed"` shortcuts, but the collections index
+  filters feeds out; a dedicated feeds index/`FeedsView` is deferred.
+
+## Tier 2 status (implemented)
+
+Shipped: shared favorites (`GET/PUT /api/shortcuts` over `config/shortcuts.json`), `useShortcuts` store
++ `PinToggle`, the toolbar launcher (`<header class="toolbar">`: a "Collections" button + one per
+favorite), and the full-screen browse overlay (`CollectionsIndexView` / standalone `CollectionView`
+via `useCollectionBrowse`). Verified: MulmoClaude's pinned collections appear in MulmoTerminal's
+toolbar from the shared file; the overlay opens and the index renders. Still open: `startChat` is a
+no-op (collection "create"/action buttons that seed a chat are inert), and Tier 1 write routes.
 
 Bottom line: **the package is drop-in-ready and needs zero MulmoClaude changes.** The work is entirely
 in MulmoTerminal: server read engine + routes, the frontend ToolPlugin + binding + teleport wrapper,

--- a/docs/collection-plugin-integration.md
+++ b/docs/collection-plugin-integration.md
@@ -1,0 +1,230 @@
+# Integrating `@mulmoclaude/collection-plugin` into MulmoTerminal
+
+Status: **the cross-repo blocker is gone.** The package shipped `0.5.0`/`0.5.1` with exactly the
+host-contract changes this doc originally said were still needed (ToolPlugin entry, router-optional
+nav, configurable teleport target, server engine). What remains is **MulmoTerminal-side wiring only** —
+**no MulmoClaude changes are required.**
+
+This doc was originally written against `0.4.1` and assumed a future `0.5.0` was on the critical path.
+It has been updated against the **published `@mulmoclaude/collection-plugin@0.5.1`** and the current
+MulmoTerminal tree.
+
+---
+
+## TL;DR verdict
+
+**Can this be done without any changes to MulmoClaude? Yes.** Everything MulmoTerminal needs is already
+published in `@mulmoclaude/collection-plugin@0.5.1`:
+
+- `./vue` exports a `plugin: ToolPlugin` (chat-result `View` + `Preview`) — the runtime registration
+  shape MulmoTerminal uses, just like chart/form/markdown.
+- Navigation is **router-optional**: `CollectionEmbedView` no longer renders a bare `<router-link>`;
+  refs/embeds go through `collectionUi().navigateToRecord(slug, recordId?)` (`src/vue/refLink.ts`), and
+  `recordHref`/`navigate` are optional so a router-less host returns `undefined`.
+- The record modal teleports to a host-supplied target: `modalTeleportTarget?: () => string | HTMLElement`
+  (defaults to `"body"`), so a Shadow-DOM host points it at an in-shadow node.
+- `./server` exports the full read-side engine: `configureCollectionHost({ workspaceRoot, log, paths,
+  isPresetSlug })` plus `discoverCollections` / `loadCollection` / `toSummary` / `toDetail` /
+  `listItems` / `validateCollectionRecords`.
+
+The **only** MulmoClaude artifact that is NOT packaged is the favorites/shortcuts format
+(`Shortcut` type + `shortcuts-io`), which still lives in MulmoClaude's app tree. MulmoTerminal must
+**reimplement that format verbatim** for the Tier 2 toolbar (see the drift warning). That is a
+MulmoTerminal-side change — it requires no MulmoClaude edit. Extracting a shared shortcuts package
+later (to eliminate drift risk) is optional and deferrable.
+
+---
+
+## Correction to the original plan: even the read-only card needs the server
+
+The original doc claimed a "Tier 0 — read-only chat card, no server." **That is wrong for the 0.5.x
+design.** `executePresentCollection` only echoes the addressing `{ collectionSlug, itemId? }` — it does
+**not** embed records. The chat `View` passes just the `slug` to `CollectionView`, which then calls
+`collectionUi().fetchCollectionDetail(slug)` to load the live schema + records (see
+`CollectionView.vue` and `useCollectionRendering.ts`). So the smallest increment that actually renders
+data is **frontend wiring + the server read route** — not a snapshot-only card.
+
+This is consistent with the foundational model below: MulmoTerminal is a *second live view over the
+shared workspace*, never a renderer of a passed-in snapshot.
+
+---
+
+## What's published and ready (`0.5.1`)
+
+| Entry | Contents | MulmoTerminal needs it? |
+|---|---|---|
+| `.` | isomorphic core (schema, derive/formula, `TOOL_DEFINITION`/`executePresentCollection`, list/detail response types) | yes (tool def + types) |
+| `./server` | node-only engine behind `configureCollectionHost(...)` + `discoverCollections`/`loadCollection`/`toSummary`/`toDetail`/`listItems`/`validateCollectionRecords` (read side) and CRUD/delete/views (write side) | yes (read side now; write later) |
+| `./vue` | `plugin: ToolPlugin`, `configureCollectionUi()`/`collectionUi()`, `CollectionView`, `CollectionsIndexView`, all sub-views | yes |
+| `./style.css` | compiled Tailwind | yes (inject into the shadow root) |
+
+Peer deps: `gui-chat-protocol@^0.4.0` (MulmoTerminal already has it), `vue@^3.5`, `vue-i18n@^11.4.4`
+(MulmoTerminal must add). The plugin owns its **own vue-i18n instance** (all 8 locales) — it needs no
+host translation keys, only a `localeTag()`.
+
+---
+
+## MulmoTerminal architecture (the relevant facts)
+
+- **Already consumes `@mulmoclaude/{chart,form,markdown,x}-plugin`** — imports `{ plugin } from "@X/vue"`
+  in `src/plugins-registry.ts` and renders `getPlugin(toolName).viewComponent` in `GuiPanel.vue`. CSS is
+  imported `?inline` and injected into a per-view **Shadow DOM** (`PluginFrame.vue` → `attachShadow` +
+  `Teleport` into the shadow mount).
+- **No vue-router** (so "navigate" = switch a panel's state).
+- **No vue-i18n** yet (must add `vue-i18n@^11`).
+- **Shared workspace**: `CLAUDE_CWD` (defaults to `~/mulmoclaude`) is the PTY cwd and the root for
+  persisted state; `<workspace>/artifacts` is the user-browsable output area. Server backends are
+  initialised at boot (`initMarkdownBackend`, `initArtifactsBackend`) — the same hook point where
+  `configureCollectionHost` goes.
+
+---
+
+## Foundational model: two views over one workspace
+
+MulmoClaude and MulmoTerminal **share a workspace**, and everything that matters is workspace state:
+
+- **Collection definitions are skills** (`<workspace>/.claude/skills/<slug>/` + sibling `schema.json`,
+  plus `~/.claude/skills` user scope) — shared.
+- **Records** — shared, under the schema's data dir.
+- **Favorites** = pinned launcher shortcuts at `<workspace>/config/shortcuts.json` — shared.
+
+So MulmoTerminal is a second live view, not a snapshot renderer. To *show* collections its server must
+wire the engine against the shared `workspaceRoot` using the **same path layout** MulmoClaude uses
+(below), so discovery sees the same files.
+
+### Shared path layout (must match MulmoClaude exactly)
+
+| Host path | Value |
+|---|---|
+| `userSkillsDir` | `~/.claude/skills` |
+| `projectSkillsDir(root)` | `<root>/.claude/skills` |
+| `feedsRoot(root)` | `<root>/feeds` |
+| `skillsStagingDir(root)` | `<root>/data/skills` |
+| `archiveDir` | `archive` |
+| `isPresetSlug(slug)` | `slug.startsWith("mc-") && slug.length > 3` |
+
+---
+
+## Gap analysis (updated for `0.5.1`)
+
+| # | Original gap | Status |
+|---|---|---|
+| 1 | No `plugin: ToolPlugin` export | ✅ shipped — `export const plugin` in `./vue` |
+| 2 | `<router-link>` / vue-router assumed | ✅ shipped — router-optional via `refLink.ts` + `navigateToRecord`/optional `recordHref`/`navigate` |
+| 3 | `Teleport to="body"` escapes Shadow DOM | ✅ shipped — `modalTeleportTarget?: () => string \| HTMLElement` |
+| 4 | vue-i18n peer | **[term]** add `vue-i18n@^11` |
+| 5 | ~30 host-capability stubs | **[term]** most can stub; `fetchCollectionDetail`/`listCollections`/`localeTag`/`confirm` must be real |
+| 6 | Server engine over shared workspace | **[term]** `configureCollectionHost` + read routes (now required for the card too, see correction above) |
+
+### The binding (`CollectionUi`) — what's real vs stub for the read-side increment
+
+Base the MulmoTerminal binding on MulmoClaude's `src/composables/collections/uiHost.ts`. For a
+read-only card over the shared workspace:
+
+- **Real:** `fetchCollectionDetail` (→ `GET /api/collections/:slug/detail`), `listCollections`
+  (→ `GET /api/collections/list`), `localeTag` (host i18n), `confirm` (`window.confirm`-backed),
+  `generalRoleId`/`personalRoleId` (constants), `pinToggle` (stub component rendering nothing for now).
+- **Required-but-no-op for an embedded card:** routing fns `routeSlug`/`routeSelectedId`/`isFeedRoute`/
+  `setSelectedId`/`gotoIndex`/`gotoDetail`/`navigateToRecord` (wired to view-state in Tier 2; safe
+  no-ops until then).
+- **Stub (write/feeds/views):** `createItem`/`updateItem`/`deleteItem`/`deleteCollection`/`deleteFeed`/
+  `runItemAction`/`runCollectionAction`/`refreshCollection`/`deleteView`/`mintViewToken`/`fetchViewHtml`/
+  `buildViewSrcdoc`/`listFeeds` → typed failure; `reconcileShortcuts`/`unpin` → no-op;
+  `notifiedSeverities` → empty map; `startChat` → no-op (the card uses the `sendTextMessage` prop, not
+  this binding hook).
+- **Asset URLs:** `imageSrc`/`fileAssetUrl` resolve to `GET /api/files/raw?path=<workspace-relative>`
+  (server/backends/files.ts), mirroring MulmoClaude's `resolveImageSrc`, so `image`/`file` fields and
+  custom-view `<img>` thumbnails render. `fileRoutePath` stays null (no in-app File Explorer).
+
+### Teleport + Shadow DOM
+
+`PluginFrame` Teleports each card into a **per-instance** shadow `mount`, but `configureCollectionUi`
+sets a **single global** binding — so `modalTeleportTarget` can't statically know which card's shadow
+root to use. Approach: `PluginFrame` `provide()`s its shadow mount; a thin MulmoTerminal wrapper around
+the collection `View` injects it and registers it as the "active" teleport target while mounted; the
+binding's `modalTeleportTarget` returns that module-level active mount. Correct for the common
+single-card case; multi-card simultaneously-open modals are an accepted v1 limitation (documented).
+
+---
+
+## Required feature: a collections toolbar (tabs) — the actual ask
+
+MulmoClaude's top chrome (`PluginLauncher.vue` + `useShortcuts` + `PinToggle.vue`) has a **Collections**
+button → the `/collections` index, plus one button **per favorite** → that collection's
+`CollectionView`. Favoriting toggles the star.
+
+MulmoTerminal equivalent needs three pieces, adapted to a no-router, state-driven host:
+
+1. **A favorites store — SHARED via the workspace** `[term]`. Favorites are NOT app-local. MulmoClaude
+   persists them server-side at **`<workspace>/config/shortcuts.json`** via `GET`/`PUT /api/shortcuts`.
+   The on-disk shape is an **object wrapper** (NOT a bare array):
+
+   ```jsonc
+   { "shortcuts": [ { "kind": "collection" | "feed", "slug": "...", "title": "...", "icon": "..." } ] }
+   ```
+
+   (`mulmoclaude/src/types/shortcuts.ts` — wrapper "so the schema can grow without a migration".)
+   MulmoTerminal must read/write **the same file in the same wrapper format**, plus a frontend
+   `useShortcuts`-equivalent backing `pinToggle`/`unpin`/`reconcileShortcuts`.
+
+   **Drift risk:** two independent writers of one on-disk format diverge over time (note `PUT` rewrites
+   the whole object). **Recommended:** extract `shortcuts-io` + the `Shortcut` type into a shared
+   package (the move that already worked for the collection engine). Pragmatic fallback: reimplement
+   verbatim + a shared schema/fixture test. **Either way the format is the contract** — and a shared
+   package would be the one optional MulmoClaude-side change in this whole effort.
+
+2. **A launcher in `<header class="toolbar">`** `[term]` — a "Collections" button + a button per
+   favorite, each switching the panel to a collection view.
+
+3. **A state-based "collection browse" panel** `[term]` — since there's no router, a panel mode that can
+   show `CollectionsIndexView` or a standalone `CollectionView(slug)`. The binding's nav fns map to this
+   view state (the router-optional change makes this clean).
+
+---
+
+## Scope tiers
+
+1. **Read-side foundation (this PR's increment).** Wire the server engine + read routes and the
+   frontend ToolPlugin + binding, so a `presentCollection` chat card renders **real data from the shared
+   workspace**. (Supersedes the old "Tier 0 — no server", which couldn't render anything.)
+2. **Tier 1 — interactive card.** Inline edit + add/delete + actions. Adds the **write** routes
+   (`items`/`item`/actions/refresh/views) + a real `startChat`.
+3. **Tier 2 — browsable + toolbar (THE ASK).** Toolbar "Collections" button + per-favorite buttons →
+   `CollectionsIndexView` / standalone `CollectionView(slug)`. Adds state-based nav, the
+   shared-favorites store (`/api/shortcuts` over `config/shortcuts.json`) + launcher + browse panel.
+   The `/feeds` half is optional — include only if feeds matter in a terminal UI. Tier 2 does **not**
+   require Tier 1's write routes (browse is read-only until editing is added).
+
+---
+
+## Implementation sequence
+
+1. ~~Package `0.5.0`~~ **DONE** — published as `0.5.1` (ToolPlugin + router-optional nav + teleport
+   target + server engine). No further MulmoClaude work required for Tiers 0–2.
+2. **MulmoTerminal — deps**: add `vue-i18n@^11` + `@mulmoclaude/collection-plugin@^0.5.1`.
+3. **MulmoTerminal — server (read side)**: `configureCollectionHost({ workspaceRoot: CLAUDE_CWD, … })`
+   at boot (using the shared path layout above); add `GET /api/collections/list` +
+   `GET /api/collections/:slug/detail` backed by the package's read helpers.
+4. **MulmoTerminal — frontend wiring**: register the `plugin` ToolPlugin in `plugins-registry.ts` +
+   inject `style.css?inline`; implement the `collectionUi` binding (read real, write/chat/shortcuts
+   stubbed per §gap 5); resolve the teleport target via the shadow-mount wrapper.
+5. **MulmoTerminal — toolbar + favorites (Tier 2, the ask)**: decide shortcuts sharing (shared package
+   vs verbatim+test); `GET`/`PUT /api/shortcuts` over `config/shortcuts.json`; a `useShortcuts`
+   equivalent; the launcher in the toolbar; the browse panel mode.
+6. **Tier 1 later**: write routes + `manageCollection` MCP tool + real `startChat`.
+
+---
+
+## Open questions for the maintainers
+
+- **Shortcuts sharing**: shared package (recommended; the only optional MulmoClaude change) vs
+  reimplement-verbatim + format test?
+- **Browse panel placement**: replace the GuiPanel content, a new tab/pane, or overlay?
+- **CSS isolation**: keep the shadow frame (and the teleport-target wrapper) or treat the collection
+  plugin as first-party in light DOM?
+- **Raw-file route**: add one so `image`/`file` fields render, or accept the v1 gap?
+- **`/feeds`**: wanted, or collections-only?
+
+Bottom line: **the package is drop-in-ready and needs zero MulmoClaude changes.** The work is entirely
+in MulmoTerminal: server read engine + routes, the frontend ToolPlugin + binding + teleport wrapper,
+then the toolbar/favorites/browse panel for the actual ask.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "@mulmochat-plugin/generate-image": "^0.4.1",
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/chart-plugin": "^0.1.1",
+    "@mulmoclaude/collection-plugin": "^0.5.1",
     "@mulmoclaude/form-plugin": "^0.1.1",
+    "@mulmoclaude/html-plugin": "^0.2.2",
     "@mulmoclaude/markdown-plugin": "^0.1.4",
     "@mulmoclaude/x-plugin": "^0.1.1",
     "@xterm/addon-attach": "^0.12.0",
@@ -72,6 +74,7 @@
     "socket.io-client": "^4.8.3",
     "tsx": "^4.22.4",
     "vue": "^3.5.34",
+    "vue-i18n": "^11.4.4",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@mulmoclaude/chart-plugin": "^0.1.1",
     "@mulmoclaude/collection-plugin": "^0.5.1",
     "@mulmoclaude/form-plugin": "^0.1.1",
+    "@mulmoclaude/html-plugin": "^0.2.2",
     "@mulmoclaude/markdown-plugin": "^0.1.4",
     "@mulmoclaude/x-plugin": "^0.1.1",
     "@xterm/addon-attach": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@mulmochat-plugin/generate-image": "^0.4.1",
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/chart-plugin": "^0.1.1",
+    "@mulmoclaude/collection-plugin": "^0.5.1",
     "@mulmoclaude/form-plugin": "^0.1.1",
     "@mulmoclaude/markdown-plugin": "^0.1.4",
     "@mulmoclaude/x-plugin": "^0.1.1",
@@ -72,6 +73,7 @@
     "socket.io-client": "^4.8.3",
     "tsx": "^4.22.4",
     "vue": "^3.5.34",
+    "vue-i18n": "^11.4.4",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,5 +1,5 @@
 {
-  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin", "@mulmoclaude/collection-plugin"],
+  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin", "@mulmoclaude/collection-plugin", "@mulmoclaude/html-plugin"],
   "servers": ["@mulmoclaude/x-plugin"],
   "local": []
 }

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,5 +1,5 @@
 {
-  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin"],
+  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin", "@mulmoclaude/collection-plugin", "@mulmoclaude/html-plugin"],
   "servers": ["@mulmoclaude/x-plugin"],
   "local": []
 }

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -1,5 +1,5 @@
 {
-  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin"],
+  "packages": ["@mulmoclaude/markdown-plugin", "@mulmoclaude/form-plugin", "@mulmochat-plugin/generate-image", "@mulmoclaude/chart-plugin", "@mulmoclaude/collection-plugin"],
   "servers": ["@mulmoclaude/x-plugin"],
   "local": []
 }

--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -1,0 +1,221 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { initCollectionsBackend, mountCollectionRoutes } from "./collections.js";
+
+// A minimal project-scope collection skill + one record + one read-only custom
+// view, laid out exactly where the engine's discovery looks (matching the shared
+// path layout initCollectionsBackend configures):
+//   <ws>/.claude/skills/testcol/schema.json   — the collection schema
+//   <ws>/data/testcol/items/item1.json        — one record (dataPath)
+//   <ws>/data/skills/testcol/views/v1.html    — the custom view (project staging)
+const SCHEMA = {
+  title: "Test Collection",
+  icon: "star",
+  dataPath: "data/testcol/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    name: { type: "string", label: "Name" },
+  },
+  views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+  actions: [{ id: "enrich", label: "Enrich", kind: "chat", role: "general", template: "templates/enrich.md" }],
+  collectionActions: [{ id: "audit", label: "Audit", kind: "chat", role: "general", template: "templates/audit.md" }],
+};
+
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  const ws = mkdtempSync(path.join(tmpdir(), "mt-col-"));
+  mkdirSync(path.join(ws, ".claude", "skills", "testcol"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "schema.json"), JSON.stringify(SCHEMA));
+  // Action templates live under the skill dir's templates/ (readSkillTemplate).
+  mkdirSync(path.join(ws, ".claude", "skills", "testcol", "templates"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "templates", "enrich.md"), "ENRICH_TEMPLATE: complete this record.");
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "templates", "audit.md"), "AUDIT_TEMPLATE: review all records.");
+  mkdirSync(path.join(ws, "data", "testcol", "items"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "testcol", "items", "item1.json"), JSON.stringify({ id: "item1", name: "Foo" }));
+  mkdirSync(path.join(ws, "data", "skills", "testcol", "views"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v1.html"), "<head></head><body>view</body>");
+
+  // Point the (singleton) collection host at the fixture. vitest isolates modules
+  // per test file, so this configure is fresh for this worker.
+  initCollectionsBackend({ workspace: ws });
+
+  const app = express();
+  app.use(express.json());
+  mountCollectionRoutes(app);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /api/collections/list", () => {
+  it("lists the fixture collection", async () => {
+    const res = await fetch(`${base}/api/collections/list`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collections: Array<{ slug: string; title: string; source: string }> };
+    const testcol = body.collections.find((c) => c.slug === "testcol");
+    expect(testcol).toMatchObject({ slug: "testcol", title: "Test Collection", source: "project" });
+  });
+});
+
+describe("GET /api/collections/:slug/detail", () => {
+  it("returns the schema + records", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/detail`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collection: { slug: string }; items: Array<{ id: string; name: string }> };
+    expect(body.collection.slug).toBe("testcol");
+    expect(body.items).toEqual([{ id: "item1", name: "Foo" }]);
+  });
+
+  it("404s for a missing slug", async () => {
+    expect((await fetch(`${base}/api/collections/nope/detail`)).status).toBe(404);
+  });
+});
+
+describe("custom view routes", () => {
+  it("mints a read-only token (write clamped off)", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "v1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string; dataUrl: string; capabilities: string[] };
+    expect(body.capabilities).toEqual(["read"]);
+    expect(body.dataUrl).toBe("/api/collections/testcol/view-data");
+    expect(typeof body.token).toBe("string");
+  });
+
+  it("400s when viewId is missing", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s view-file for an unknown view id", async () => {
+    expect((await fetch(`${base}/api/collections/testcol/view-file?id=nope`)).status).toBe(404);
+  });
+
+  it("serves view-file HTML with sandbox + nosniff hardening", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-file?id=v1`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-security-policy")).toBe("sandbox");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(await res.text()).toContain("view");
+  });
+
+  it("401s view-data without a token", async () => {
+    expect((await fetch(`${base}/api/collections/testcol/view-data`)).status).toBe(401);
+  });
+
+  it("serves view-data records with a valid token", async () => {
+    const mint = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "v1" }),
+    });
+    const { token } = (await mint.json()) as { token: string };
+    const res = await fetch(`${base}/api/collections/testcol/view-data`, { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(["item1"]);
+  });
+});
+
+describe("record CRUD", () => {
+  // Functions, not constants: `base` is only assigned in beforeAll (after the
+  // describe body runs), so the URLs must be built at call time.
+  const items = () => `${base}/api/collections/testcol/items`;
+  const itemUrl = (id: string) => `${base}/api/collections/testcol/items/${id}`;
+  const detailItems = async () =>
+    ((await (await fetch(`${base}/api/collections/testcol/detail`)).json()) as { items: Array<{ id: string; name?: string }> }).items;
+
+  it("creates, updates, then deletes a record", async () => {
+    const create = await fetch(items(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "crud1", name: "New" }),
+    });
+    expect(create.status).toBe(200);
+    expect((await create.json()) as { itemId: string }).toMatchObject({ itemId: "crud1" });
+    expect((await detailItems()).find((i) => i.id === "crud1")).toMatchObject({ name: "New" });
+
+    const upd = await fetch(itemUrl("crud1"), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "crud1", name: "Updated" }),
+    });
+    expect(upd.status).toBe(200);
+    expect(((await upd.json()) as { item: { name: string } }).item).toMatchObject({ name: "Updated" });
+
+    const del = await fetch(itemUrl("crud1"), { method: "DELETE" });
+    expect(del.status).toBe(200);
+    expect(await del.json()).toEqual({ deleted: true, itemId: "crud1" });
+    expect((await detailItems()).find((i) => i.id === "crud1")).toBeUndefined();
+  });
+
+  it("409s creating a record whose id already exists", async () => {
+    const dupe = await fetch(items(), { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: "item1", name: "dupe" }) });
+    expect(dupe.status).toBe(409);
+  });
+
+  it("400s on a non-object create body", async () => {
+    const res = await fetch(items(), { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify([1, 2, 3]) });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s update/delete on a missing collection", async () => {
+    const put = await fetch(`${base}/api/collections/nope/items/x`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "x" }),
+    });
+    expect(put.status).toBe(404);
+    expect((await fetch(`${base}/api/collections/nope/items/x`, { method: "DELETE" })).status).toBe(404);
+  });
+});
+
+describe("action routes (seed prompts)", () => {
+  const post = (url: string) => fetch(`${base}${url}`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+
+  it("returns a per-record action's seed prompt + role", async () => {
+    const res = await post("/api/collections/testcol/items/item1/actions/enrich");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prompt: string; role: string };
+    expect(body.role).toBe("general");
+    expect(body.prompt).toContain("ENRICH_TEMPLATE");
+  });
+
+  it("returns a collection-level action's seed prompt + role", async () => {
+    const res = await post("/api/collections/testcol/actions/audit");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prompt: string; role: string };
+    expect(body.role).toBe("general");
+    expect(body.prompt).toContain("AUDIT_TEMPLATE");
+  });
+
+  it("404s an unknown action id", async () => {
+    expect((await post("/api/collections/testcol/items/item1/actions/nope")).status).toBe(404);
+    expect((await post("/api/collections/testcol/actions/nope")).status).toBe(404);
+  });
+
+  it("404s a per-record action on a missing item", async () => {
+    expect((await post("/api/collections/testcol/items/ghost/actions/enrich")).status).toBe(404);
+  });
+});

--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { initCollectionsBackend, mountCollectionRoutes } from "./collections.js";
+
+// A minimal project-scope collection skill + one record + one read-only custom
+// view, laid out exactly where the engine's discovery looks (matching the shared
+// path layout initCollectionsBackend configures):
+//   <ws>/.claude/skills/testcol/schema.json   — the collection schema
+//   <ws>/data/testcol/items/item1.json        — one record (dataPath)
+//   <ws>/data/skills/testcol/views/v1.html    — the custom view (project staging)
+const SCHEMA = {
+  title: "Test Collection",
+  icon: "star",
+  dataPath: "data/testcol/items",
+  primaryKey: "id",
+  fields: {
+    id: { type: "string", label: "ID", primary: true, required: true },
+    name: { type: "string", label: "Name" },
+  },
+  views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+};
+
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  const ws = mkdtempSync(path.join(tmpdir(), "mt-col-"));
+  mkdirSync(path.join(ws, ".claude", "skills", "testcol"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "schema.json"), JSON.stringify(SCHEMA));
+  mkdirSync(path.join(ws, "data", "testcol", "items"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "testcol", "items", "item1.json"), JSON.stringify({ id: "item1", name: "Foo" }));
+  mkdirSync(path.join(ws, "data", "skills", "testcol", "views"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v1.html"), "<head></head><body>view</body>");
+
+  // Point the (singleton) collection host at the fixture. vitest isolates modules
+  // per test file, so this configure is fresh for this worker.
+  initCollectionsBackend({ workspace: ws });
+
+  const app = express();
+  app.use(express.json());
+  mountCollectionRoutes(app);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /api/collections/list", () => {
+  it("lists the fixture collection", async () => {
+    const res = await fetch(`${base}/api/collections/list`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collections: Array<{ slug: string; title: string; source: string }> };
+    const testcol = body.collections.find((c) => c.slug === "testcol");
+    expect(testcol).toMatchObject({ slug: "testcol", title: "Test Collection", source: "project" });
+  });
+});
+
+describe("GET /api/collections/:slug/detail", () => {
+  it("returns the schema + records", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/detail`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { collection: { slug: string }; items: Array<{ id: string; name: string }> };
+    expect(body.collection.slug).toBe("testcol");
+    expect(body.items).toEqual([{ id: "item1", name: "Foo" }]);
+  });
+
+  it("404s for a missing slug", async () => {
+    expect((await fetch(`${base}/api/collections/nope/detail`)).status).toBe(404);
+  });
+});
+
+describe("custom view routes", () => {
+  it("mints a read-only token (write clamped off)", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "v1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string; dataUrl: string; capabilities: string[] };
+    expect(body.capabilities).toEqual(["read"]);
+    expect(body.dataUrl).toBe("/api/collections/testcol/view-data");
+    expect(typeof body.token).toBe("string");
+  });
+
+  it("400s when viewId is missing", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s view-file for an unknown view id", async () => {
+    expect((await fetch(`${base}/api/collections/testcol/view-file?id=nope`)).status).toBe(404);
+  });
+
+  it("serves view-file HTML with sandbox + nosniff hardening", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/view-file?id=v1`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-security-policy")).toBe("sandbox");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(await res.text()).toContain("view");
+  });
+
+  it("401s view-data without a token", async () => {
+    expect((await fetch(`${base}/api/collections/testcol/view-data`)).status).toBe(401);
+  });
+
+  it("serves view-data records with a valid token", async () => {
+    const mint = await fetch(`${base}/api/collections/testcol/view-token`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ viewId: "v1" }),
+    });
+    const { token } = (await mint.json()) as { token: string };
+    const res = await fetch(`${base}/api/collections/testcol/view-data`, { headers: { Authorization: `Bearer ${token}` } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: Array<{ id: string }> };
+    expect(body.items.map((i) => i.id)).toEqual(["item1"]);
+  });
+});

--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -23,6 +23,8 @@ const SCHEMA = {
     name: { type: "string", label: "Name" },
   },
   views: [{ id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] }],
+  actions: [{ id: "enrich", label: "Enrich", kind: "chat", role: "general", template: "templates/enrich.md" }],
+  collectionActions: [{ id: "audit", label: "Audit", kind: "chat", role: "general", template: "templates/audit.md" }],
 };
 
 let server: Server;
@@ -32,6 +34,10 @@ beforeAll(async () => {
   const ws = mkdtempSync(path.join(tmpdir(), "mt-col-"));
   mkdirSync(path.join(ws, ".claude", "skills", "testcol"), { recursive: true });
   writeFileSync(path.join(ws, ".claude", "skills", "testcol", "schema.json"), JSON.stringify(SCHEMA));
+  // Action templates live under the skill dir's templates/ (readSkillTemplate).
+  mkdirSync(path.join(ws, ".claude", "skills", "testcol", "templates"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "templates", "enrich.md"), "ENRICH_TEMPLATE: complete this record.");
+  writeFileSync(path.join(ws, ".claude", "skills", "testcol", "templates", "audit.md"), "AUDIT_TEMPLATE: review all records.");
   mkdirSync(path.join(ws, "data", "testcol", "items"), { recursive: true });
   writeFileSync(path.join(ws, "data", "testcol", "items", "item1.json"), JSON.stringify({ id: "item1", name: "Foo" }));
   mkdirSync(path.join(ws, "data", "skills", "testcol", "views"), { recursive: true });
@@ -182,5 +188,34 @@ describe("record CRUD", () => {
     });
     expect(put.status).toBe(404);
     expect((await fetch(`${base}/api/collections/nope/items/x`, { method: "DELETE" })).status).toBe(404);
+  });
+});
+
+describe("action routes (seed prompts)", () => {
+  const post = (url: string) => fetch(`${base}${url}`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+
+  it("returns a per-record action's seed prompt + role", async () => {
+    const res = await post("/api/collections/testcol/items/item1/actions/enrich");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prompt: string; role: string };
+    expect(body.role).toBe("general");
+    expect(body.prompt).toContain("ENRICH_TEMPLATE");
+  });
+
+  it("returns a collection-level action's seed prompt + role", async () => {
+    const res = await post("/api/collections/testcol/actions/audit");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { prompt: string; role: string };
+    expect(body.role).toBe("general");
+    expect(body.prompt).toContain("AUDIT_TEMPLATE");
+  });
+
+  it("404s an unknown action id", async () => {
+    expect((await post("/api/collections/testcol/items/item1/actions/nope")).status).toBe(404);
+    expect((await post("/api/collections/testcol/actions/nope")).status).toBe(404);
+  });
+
+  it("404s a per-record action on a missing item", async () => {
+    expect((await post("/api/collections/testcol/items/ghost/actions/enrich")).status).toBe(404);
   });
 });

--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -131,3 +131,56 @@ describe("custom view routes", () => {
     expect(body.items.map((i) => i.id)).toEqual(["item1"]);
   });
 });
+
+describe("record CRUD", () => {
+  // Functions, not constants: `base` is only assigned in beforeAll (after the
+  // describe body runs), so the URLs must be built at call time.
+  const items = () => `${base}/api/collections/testcol/items`;
+  const itemUrl = (id: string) => `${base}/api/collections/testcol/items/${id}`;
+  const detailItems = async () =>
+    ((await (await fetch(`${base}/api/collections/testcol/detail`)).json()) as { items: Array<{ id: string; name?: string }> }).items;
+
+  it("creates, updates, then deletes a record", async () => {
+    const create = await fetch(items(), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "crud1", name: "New" }),
+    });
+    expect(create.status).toBe(200);
+    expect((await create.json()) as { itemId: string }).toMatchObject({ itemId: "crud1" });
+    expect((await detailItems()).find((i) => i.id === "crud1")).toMatchObject({ name: "New" });
+
+    const upd = await fetch(itemUrl("crud1"), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "crud1", name: "Updated" }),
+    });
+    expect(upd.status).toBe(200);
+    expect(((await upd.json()) as { item: { name: string } }).item).toMatchObject({ name: "Updated" });
+
+    const del = await fetch(itemUrl("crud1"), { method: "DELETE" });
+    expect(del.status).toBe(200);
+    expect(await del.json()).toEqual({ deleted: true, itemId: "crud1" });
+    expect((await detailItems()).find((i) => i.id === "crud1")).toBeUndefined();
+  });
+
+  it("409s creating a record whose id already exists", async () => {
+    const dupe = await fetch(items(), { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: "item1", name: "dupe" }) });
+    expect(dupe.status).toBe(409);
+  });
+
+  it("400s on a non-object create body", async () => {
+    const res = await fetch(items(), { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify([1, 2, 3]) });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s update/delete on a missing collection", async () => {
+    const put = await fetch(`${base}/api/collections/nope/items/x`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "x" }),
+    });
+    expect(put.status).toBe(404);
+    expect((await fetch(`${base}/api/collections/nope/items/x`, { method: "DELETE" })).status).toBe(404);
+  });
+});

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -22,11 +22,17 @@ import {
   listItems,
   enrichItems,
   readCustomViewHtml,
+  writeItem,
+  deleteItem,
+  generateItemId,
+  resolveCreateItemId,
   toSummary,
   toDetail,
   validateCollectionRecords,
   type RecordIssue,
 } from "@mulmoclaude/collection-plugin/server";
+// CollectionItem lives in the isomorphic core entry (not re-exported from /server).
+import type { CollectionItem } from "@mulmoclaude/collection-plugin";
 import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
@@ -63,6 +69,12 @@ export function initCollectionsBackend(deps: { workspace: string }): void {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** A request body usable as a record: a non-null, non-array object. */
+function extractRecord(body: unknown): CollectionItem | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  return body as CollectionItem;
 }
 
 /** Mount the read-side REST surface. Mirrors MulmoClaude's
@@ -104,6 +116,111 @@ export function mountCollectionRoutes(app: Express): void {
       res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
     } catch (err) {
       log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Record CRUD (Tier 1: interactive editing — e.g. checking a to-do item) ──
+  // Create a record. The id is the schema's primaryKey value from the body, or a
+  // generated one; a singleton collection pins every create to its fixed id.
+  app.post("/api/collections/:slug/items", async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const record = extractRecord(req.body);
+    if (!record) {
+      res.status(400).json({ error: "request body must be a JSON object" });
+      return;
+    }
+    const itemId = resolveCreateItemId(collection.schema, record) ?? generateItemId();
+    const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
+    try {
+      const result = await writeItem(collection.dataDir, itemId, recordWithId, { refuseOverwrite: true });
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "conflict") {
+        res.status(409).json({ error: `item '${result.itemId}' already exists` });
+        return;
+      }
+      res.json({ itemId: result.itemId, item: result.item });
+    } catch (err) {
+      log.warn("collections", "item create failed", { slug: collection.slug, itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Update a record. The primaryKey is pinned to the URL itemId (the body can't
+  // smuggle a different id). Singletons only accept their one fixed id.
+  app.put("/api/collections/:slug/items/:itemId", async (req: Request<{ slug: string; itemId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const record = extractRecord(req.body);
+    if (!record) {
+      res.status(400).json({ error: "request body must be a JSON object" });
+      return;
+    }
+    const { singleton, primaryKey } = collection.schema;
+    if (singleton && req.params.itemId !== singleton) {
+      res.status(400).json({ error: `collection '${collection.slug}' is a singleton; the only valid item id is '${singleton}'` });
+      return;
+    }
+    const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
+    try {
+      const result = await writeItem(collection.dataDir, req.params.itemId, recordWithId);
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "conflict") {
+        res.status(500).json({ error: "unexpected conflict on update" });
+        return;
+      }
+      res.json({ itemId: result.itemId, item: result.item });
+    } catch (err) {
+      log.warn("collections", "item update failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Delete a record.
+  app.delete("/api/collections/:slug/items/:itemId", async (req: Request<{ slug: string; itemId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    try {
+      const result = await deleteItem(collection.dataDir, req.params.itemId);
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "not-found") {
+        res.status(404).json({ error: `item '${result.itemId}' not found` });
+        return;
+      }
+      res.json({ deleted: true, itemId: result.itemId });
+    } catch (err) {
+      log.warn("collections", "item delete failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   });

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -1,0 +1,410 @@
+// Read-side backend for @mulmoclaude/collection-plugin. MulmoTerminal is a second
+// live view over the SHARED workspace (CLAUDE_CWD, default ~/mulmoclaude) — it does
+// not render a passed-in snapshot. The presentCollection chat card passes only a
+// slug to CollectionView, which then calls the UI binding's fetchCollectionDetail()
+// → GET /api/collections/:slug/detail here to load the live schema + records. So
+// this engine wiring is required even for a read-only card.
+//
+// The path layout below MUST match MulmoClaude's exactly (see
+// mulmoclaude/server/workspace/{skills,feeds}/paths.ts + skills-preset.ts) so
+// discovery finds the same collection skills both apps share on disk.
+//
+// Only the read side is wired here (list + detail). Write routes (CRUD / actions /
+// custom views) and the manageCollection MCP tool are deferred to the interactive
+// tier.
+import path from "node:path";
+import os from "node:os";
+import type { Express, Request, Response, NextFunction } from "express";
+import {
+  configureCollectionHost,
+  discoverCollections,
+  loadCollection,
+  listItems,
+  enrichItems,
+  readCustomViewHtml,
+  writeItem,
+  deleteItem,
+  readItem,
+  generateItemId,
+  resolveCreateItemId,
+  readSkillTemplate,
+  buildActionSeedPrompt,
+  buildCollectionActionSeedPrompt,
+  toSummary,
+  toDetail,
+  validateCollectionRecords,
+  type RecordIssue,
+} from "@mulmoclaude/collection-plugin/server";
+// CollectionItem + actionVisible live in the isomorphic core entry.
+import { actionVisible, type CollectionItem } from "@mulmoclaude/collection-plugin";
+import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
+
+// Console-backed logger matching the engine's CollectionLogger shape
+// (prefix, message, optional structured data).
+const log = {
+  error: (prefix: string, message: string, data?: Record<string, unknown>) => console.error(`[${prefix}] ${message}`, data ?? ""),
+  warn: (prefix: string, message: string, data?: Record<string, unknown>) => console.warn(`[${prefix}] ${message}`, data ?? ""),
+  info: (prefix: string, message: string, data?: Record<string, unknown>) => console.log(`[${prefix}] ${message}`, data ?? ""),
+  debug: (prefix: string, message: string, data?: Record<string, unknown>) => console.debug(`[${prefix}] ${message}`, data ?? ""),
+};
+
+/** Wire the collection engine to the shared workspace. Call once at boot, before
+ *  any collection route is hit. The path layout mirrors MulmoClaude verbatim. */
+export function initCollectionsBackend(deps: { workspace: string }): void {
+  configureCollectionHost({
+    workspaceRoot: deps.workspace,
+    log,
+    paths: {
+      // ~/.claude/skills — user scope (read-only).
+      userSkillsDir: path.join(os.homedir(), ".claude", "skills"),
+      // <root>/.claude/skills — project scope.
+      projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+      // <root>/feeds — feed registry root.
+      feedsRoot: (root) => path.join(root, "feeds"),
+      // <root>/data/skills — project-skills staging.
+      skillsStagingDir: (root) => path.join(root, "data", "skills"),
+      // Workspace-relative archive dir (removed collections move here).
+      archiveDir: "archive",
+    },
+    // MulmoClaude's launcher preset namespace.
+    isPresetSlug: (slug) => slug.startsWith("mc-") && slug.length > "mc-".length,
+  });
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** A request body usable as a record: a non-null, non-array object. */
+function extractRecord(body: unknown): CollectionItem | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  return body as CollectionItem;
+}
+
+/** Mount the read-side REST surface. Mirrors MulmoClaude's
+ *  GET /api/collections + GET /api/collections/:slug response shapes, which is what
+ *  the package's UI binding (fetchCollectionDetail / listCollections) expects. */
+export function mountCollectionRoutes(app: Express): void {
+  // List skill-backed collections for the index + toolbar.
+  app.get("/api/collections/list", async (_req: Request, res: Response) => {
+    try {
+      const collections = await discoverCollections();
+      res.json({ collections: collections.map(toSummary) });
+    } catch (err) {
+      log.warn("collections", "list failed", { error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // A collection's live schema + records by slug. Backs both the card's own load
+  // (CollectionView reads `status` for 404 → not-found) and ref/embed resolution.
+  app.get("/api/collections/:slug/detail", async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    try {
+      const items = await listItems(collection.dataDir);
+      // Best-effort validation: a malformed record is silently skipped at read
+      // time, so surface the problems here too and let the view offer a Repair
+      // button. Never let validation failure turn a successful detail into a 500.
+      let issues: RecordIssue[] = [];
+      try {
+        issues = await validateCollectionRecords(collection);
+      } catch (err) {
+        log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
+      }
+      // Omit `issues` entirely when everything is fine (the "absent when clean"
+      // contract the view relies on).
+      res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
+    } catch (err) {
+      log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Record CRUD (Tier 1: interactive editing — e.g. checking a to-do item) ──
+  // Create a record. The id is the schema's primaryKey value from the body, or a
+  // generated one; a singleton collection pins every create to its fixed id.
+  app.post("/api/collections/:slug/items", async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const record = extractRecord(req.body);
+    if (!record) {
+      res.status(400).json({ error: "request body must be a JSON object" });
+      return;
+    }
+    const itemId = resolveCreateItemId(collection.schema, record) ?? generateItemId();
+    const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
+    try {
+      const result = await writeItem(collection.dataDir, itemId, recordWithId, { refuseOverwrite: true });
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "conflict") {
+        res.status(409).json({ error: `item '${result.itemId}' already exists` });
+        return;
+      }
+      res.json({ itemId: result.itemId, item: result.item });
+    } catch (err) {
+      log.warn("collections", "item create failed", { slug: collection.slug, itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Update a record. The primaryKey is pinned to the URL itemId (the body can't
+  // smuggle a different id). Singletons only accept their one fixed id.
+  app.put("/api/collections/:slug/items/:itemId", async (req: Request<{ slug: string; itemId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const record = extractRecord(req.body);
+    if (!record) {
+      res.status(400).json({ error: "request body must be a JSON object" });
+      return;
+    }
+    const { singleton, primaryKey } = collection.schema;
+    if (singleton && req.params.itemId !== singleton) {
+      res.status(400).json({ error: `collection '${collection.slug}' is a singleton; the only valid item id is '${singleton}'` });
+      return;
+    }
+    const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
+    try {
+      const result = await writeItem(collection.dataDir, req.params.itemId, recordWithId);
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "conflict") {
+        res.status(500).json({ error: "unexpected conflict on update" });
+        return;
+      }
+      res.json({ itemId: result.itemId, item: result.item });
+    } catch (err) {
+      log.warn("collections", "item update failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Delete a record.
+  app.delete("/api/collections/:slug/items/:itemId", async (req: Request<{ slug: string; itemId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    try {
+      const result = await deleteItem(collection.dataDir, req.params.itemId);
+      if (result.kind === "invalid-id") {
+        res.status(400).json({ error: `invalid item id: ${result.itemId}` });
+        return;
+      }
+      if (result.kind === "path-escape") {
+        res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
+        return;
+      }
+      if (result.kind === "not-found") {
+        res.status(404).json({ error: `item '${result.itemId}' not found` });
+        return;
+      }
+      res.json({ deleted: true, itemId: result.itemId });
+    } catch (err) {
+      log.warn("collections", "item delete failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Actions (kind: "chat") — return a seed prompt + role; the frontend feeds it
+  //    to startChat, which spawns a visible chat. The records are edited by that
+  //    agent session directly (the intended model). ──
+
+  // Per-record action (e.g. Repair / enrich this record).
+  app.post(
+    "/api/collections/:slug/items/:itemId/actions/:actionId",
+    async (req: Request<{ slug: string; itemId: string; actionId: string }>, res: Response) => {
+      const collection = await loadCollection(req.params.slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+        return;
+      }
+      const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
+      if (!action) {
+        res.status(404).json({ error: `action '${req.params.actionId}' not found on collection '${collection.slug}'` });
+        return;
+      }
+      try {
+        const record = await readItem(collection.dataDir, req.params.itemId);
+        if (!record) {
+          res.status(404).json({ error: `item '${req.params.itemId}' not found` });
+          return;
+        }
+        // The action's `when` predicate is the authorization rule: the client hides
+        // out-of-state buttons, but a stale/crafted request could still target one.
+        if (!actionVisible(action, record)) {
+          res.status(409).json({ error: `action '${action.id}' is not available for item '${req.params.itemId}' in its current state` });
+          return;
+        }
+        const template = await readSkillTemplate(collection.skillDir, action.template);
+        if (template === null) {
+          res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
+          return;
+        }
+        res.json({ prompt: buildActionSeedPrompt(record, template), role: action.role });
+      } catch (err) {
+        log.warn("collections", "item action seed failed", {
+          slug: collection.slug,
+          itemId: req.params.itemId,
+          actionId: req.params.actionId,
+          error: errorMessage(err),
+        });
+        res.status(500).json({ error: errorMessage(err) });
+      }
+    },
+  );
+
+  // Collection-level action (operates over all records).
+  app.post("/api/collections/:slug/actions/:actionId", async (req: Request<{ slug: string; actionId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const action = collection.schema.collectionActions?.find((entry) => entry.id === req.params.actionId);
+    if (!action) {
+      res.status(404).json({ error: `collection action '${req.params.actionId}' not found on collection '${collection.slug}'` });
+      return;
+    }
+    try {
+      const template = await readSkillTemplate(collection.skillDir, action.template);
+      if (template === null) {
+        res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
+        return;
+      }
+      const allItems = await listItems(collection.dataDir);
+      res.json({ prompt: buildCollectionActionSeedPrompt(allItems, collection.schema, template), role: action.role });
+    } catch (err) {
+      log.warn("collections", "collection action seed failed", { slug: collection.slug, actionId: req.params.actionId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Custom views (sandboxed-iframe HTML views, e.g. a poster gallery) ──
+  // A custom view is LLM-authored HTML rendered in a sandboxed iframe that fetches
+  // its records from view-data with a scoped token. Read-only here: the GET data
+  // route is wired; write (PUT) is deferred to the interactive tier.
+
+  // The custom view's raw HTML, read from the staging path via the package's
+  // path-safe reader. The frontend renders it sandboxed (token injected).
+  app.get("/api/collections/:slug/view-file", async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const { slug } = req.params;
+      const viewId = typeof req.query.id === "string" ? req.query.id : "";
+      const collection = await loadCollection(slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${slug}' not found` });
+        return;
+      }
+      const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+      if (!view) {
+        res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
+        return;
+      }
+      const html = await readCustomViewHtml(collection, view.file);
+      if (html === null) {
+        res.status(404).json({ error: `view file '${view.file}' not found` });
+        return;
+      }
+      // This is LLM-authored HTML. The frontend renders it sandboxed via a
+      // fetch()→srcdoc iframe (not by navigating here), so harden the raw response
+      // against DIRECT navigation: `sandbox` gives it an opaque origin (its scripts
+      // can't reach the app origin's /api/*), and `nosniff` stops re-interpretation.
+      // The iframe path is unaffected — a fetch() reads the body regardless of this
+      // response-level CSP.
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("Content-Security-Policy", "sandbox");
+      res.type("text/html").send(html);
+    } catch (err) {
+      log.warn("collections", "view-file read failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Mint a scoped token for a custom view, clamped to what the view declared so a
+  // read-only view can never obtain a write token.
+  app.post("/api/collections/:slug/view-token", async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const { slug } = req.params;
+      const body = (req.body ?? {}) as { viewId?: unknown; capabilities?: unknown };
+      const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
+      if (!viewId) {
+        res.status(400).json({ error: "`viewId` is required" });
+        return;
+      }
+      const collection = await loadCollection(slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${slug}' not found` });
+        return;
+      }
+      const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+      if (!view) {
+        res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
+        return;
+      }
+      // Read-only for now: MulmoTerminal has no view-data write route yet, so never
+      // grant `write` even if the view declares it (clamp the request to ["read"]).
+      // Drop the `write` clamp here once the interactive tier wires PUT /view-data.
+      const granted = clampCapabilities(view.capabilities as ViewCapability[] | undefined, ["read"]);
+      const minted = mintViewToken(slug, granted);
+      res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
+    } catch (err) {
+      log.warn("collections", "view-token mint failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // CORS for the view-data endpoint: the sandboxed iframe has an opaque origin, so
+  // its fetch is cross-origin and preflighted. `*` is safe — auth is the unguessable
+  // scoped token in the Authorization header (not a cookie), so no ambient-credential
+  // leak; an origin without the token just gets a 401.
+  const viewDataCors = (_req: Request, res: Response, next: NextFunction): void => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+    next();
+  };
+  app.options("/api/collections/:slug/view-data", viewDataCors, (_req: Request, res: Response) => {
+    res.status(204).end();
+  });
+
+  // Scoped read: the view's enriched records as `{ items }` — the shape custom views
+  // fetch from `window.__MC_VIEW.dataUrl`. Guarded by the view token only.
+  app.get("/api/collections/:slug/view-data", viewDataCors, requireViewToken("read"), async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const collection = await loadCollection(req.params.slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+        return;
+      }
+      const items = await enrichItems(collection, await listItems(collection.dataDir));
+      res.json({ items });
+    } catch (err) {
+      log.warn("collections", "view-data read failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -24,15 +24,19 @@ import {
   readCustomViewHtml,
   writeItem,
   deleteItem,
+  readItem,
   generateItemId,
   resolveCreateItemId,
+  readSkillTemplate,
+  buildActionSeedPrompt,
+  buildCollectionActionSeedPrompt,
   toSummary,
   toDetail,
   validateCollectionRecords,
   type RecordIssue,
 } from "@mulmoclaude/collection-plugin/server";
-// CollectionItem lives in the isomorphic core entry (not re-exported from /server).
-import type { CollectionItem } from "@mulmoclaude/collection-plugin";
+// CollectionItem + actionVisible live in the isomorphic core entry.
+import { actionVisible, type CollectionItem } from "@mulmoclaude/collection-plugin";
 import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
@@ -221,6 +225,80 @@ export function mountCollectionRoutes(app: Express): void {
       res.json({ deleted: true, itemId: result.itemId });
     } catch (err) {
       log.warn("collections", "item delete failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Actions (kind: "chat") — return a seed prompt + role; the frontend feeds it
+  //    to startChat, which spawns a visible chat. The records are edited by that
+  //    agent session directly (the intended model). ──
+
+  // Per-record action (e.g. Repair / enrich this record).
+  app.post(
+    "/api/collections/:slug/items/:itemId/actions/:actionId",
+    async (req: Request<{ slug: string; itemId: string; actionId: string }>, res: Response) => {
+      const collection = await loadCollection(req.params.slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+        return;
+      }
+      const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
+      if (!action) {
+        res.status(404).json({ error: `action '${req.params.actionId}' not found on collection '${collection.slug}'` });
+        return;
+      }
+      try {
+        const record = await readItem(collection.dataDir, req.params.itemId);
+        if (!record) {
+          res.status(404).json({ error: `item '${req.params.itemId}' not found` });
+          return;
+        }
+        // The action's `when` predicate is the authorization rule: the client hides
+        // out-of-state buttons, but a stale/crafted request could still target one.
+        if (!actionVisible(action, record)) {
+          res.status(409).json({ error: `action '${action.id}' is not available for item '${req.params.itemId}' in its current state` });
+          return;
+        }
+        const template = await readSkillTemplate(collection.skillDir, action.template);
+        if (template === null) {
+          res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
+          return;
+        }
+        res.json({ prompt: buildActionSeedPrompt(record, template), role: action.role });
+      } catch (err) {
+        log.warn("collections", "item action seed failed", {
+          slug: collection.slug,
+          itemId: req.params.itemId,
+          actionId: req.params.actionId,
+          error: errorMessage(err),
+        });
+        res.status(500).json({ error: errorMessage(err) });
+      }
+    },
+  );
+
+  // Collection-level action (operates over all records).
+  app.post("/api/collections/:slug/actions/:actionId", async (req: Request<{ slug: string; actionId: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    const action = collection.schema.collectionActions?.find((entry) => entry.id === req.params.actionId);
+    if (!action) {
+      res.status(404).json({ error: `collection action '${req.params.actionId}' not found on collection '${collection.slug}'` });
+      return;
+    }
+    try {
+      const template = await readSkillTemplate(collection.skillDir, action.template);
+      if (template === null) {
+        res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
+        return;
+      }
+      const allItems = await listItems(collection.dataDir);
+      res.json({ prompt: buildCollectionActionSeedPrompt(allItems, collection.schema, template), role: action.role });
+    } catch (err) {
+      log.warn("collections", "collection action seed failed", { slug: collection.slug, actionId: req.params.actionId, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   });

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -1,0 +1,215 @@
+// Read-side backend for @mulmoclaude/collection-plugin. MulmoTerminal is a second
+// live view over the SHARED workspace (CLAUDE_CWD, default ~/mulmoclaude) — it does
+// not render a passed-in snapshot. The presentCollection chat card passes only a
+// slug to CollectionView, which then calls the UI binding's fetchCollectionDetail()
+// → GET /api/collections/:slug/detail here to load the live schema + records. So
+// this engine wiring is required even for a read-only card.
+//
+// The path layout below MUST match MulmoClaude's exactly (see
+// mulmoclaude/server/workspace/{skills,feeds}/paths.ts + skills-preset.ts) so
+// discovery finds the same collection skills both apps share on disk.
+//
+// Only the read side is wired here (list + detail). Write routes (CRUD / actions /
+// custom views) and the manageCollection MCP tool are deferred to the interactive
+// tier.
+import path from "node:path";
+import os from "node:os";
+import type { Express, Request, Response, NextFunction } from "express";
+import {
+  configureCollectionHost,
+  discoverCollections,
+  loadCollection,
+  listItems,
+  enrichItems,
+  readCustomViewHtml,
+  toSummary,
+  toDetail,
+  validateCollectionRecords,
+  type RecordIssue,
+} from "@mulmoclaude/collection-plugin/server";
+import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
+
+// Console-backed logger matching the engine's CollectionLogger shape
+// (prefix, message, optional structured data).
+const log = {
+  error: (prefix: string, message: string, data?: Record<string, unknown>) => console.error(`[${prefix}] ${message}`, data ?? ""),
+  warn: (prefix: string, message: string, data?: Record<string, unknown>) => console.warn(`[${prefix}] ${message}`, data ?? ""),
+  info: (prefix: string, message: string, data?: Record<string, unknown>) => console.log(`[${prefix}] ${message}`, data ?? ""),
+  debug: (prefix: string, message: string, data?: Record<string, unknown>) => console.debug(`[${prefix}] ${message}`, data ?? ""),
+};
+
+/** Wire the collection engine to the shared workspace. Call once at boot, before
+ *  any collection route is hit. The path layout mirrors MulmoClaude verbatim. */
+export function initCollectionsBackend(deps: { workspace: string }): void {
+  configureCollectionHost({
+    workspaceRoot: deps.workspace,
+    log,
+    paths: {
+      // ~/.claude/skills — user scope (read-only).
+      userSkillsDir: path.join(os.homedir(), ".claude", "skills"),
+      // <root>/.claude/skills — project scope.
+      projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+      // <root>/feeds — feed registry root.
+      feedsRoot: (root) => path.join(root, "feeds"),
+      // <root>/data/skills — project-skills staging.
+      skillsStagingDir: (root) => path.join(root, "data", "skills"),
+      // Workspace-relative archive dir (removed collections move here).
+      archiveDir: "archive",
+    },
+    // MulmoClaude's launcher preset namespace.
+    isPresetSlug: (slug) => slug.startsWith("mc-") && slug.length > "mc-".length,
+  });
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Mount the read-side REST surface. Mirrors MulmoClaude's
+ *  GET /api/collections + GET /api/collections/:slug response shapes, which is what
+ *  the package's UI binding (fetchCollectionDetail / listCollections) expects. */
+export function mountCollectionRoutes(app: Express): void {
+  // List skill-backed collections for the index + toolbar.
+  app.get("/api/collections/list", async (_req: Request, res: Response) => {
+    try {
+      const collections = await discoverCollections();
+      res.json({ collections: collections.map(toSummary) });
+    } catch (err) {
+      log.warn("collections", "list failed", { error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // A collection's live schema + records by slug. Backs both the card's own load
+  // (CollectionView reads `status` for 404 → not-found) and ref/embed resolution.
+  app.get("/api/collections/:slug/detail", async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    try {
+      const items = await listItems(collection.dataDir);
+      // Best-effort validation: a malformed record is silently skipped at read
+      // time, so surface the problems here too and let the view offer a Repair
+      // button. Never let validation failure turn a successful detail into a 500.
+      let issues: RecordIssue[] = [];
+      try {
+        issues = await validateCollectionRecords(collection);
+      } catch (err) {
+        log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
+      }
+      // Omit `issues` entirely when everything is fine (the "absent when clean"
+      // contract the view relies on).
+      res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
+    } catch (err) {
+      log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // ── Custom views (sandboxed-iframe HTML views, e.g. a poster gallery) ──
+  // A custom view is LLM-authored HTML rendered in a sandboxed iframe that fetches
+  // its records from view-data with a scoped token. Read-only here: the GET data
+  // route is wired; write (PUT) is deferred to the interactive tier.
+
+  // The custom view's raw HTML, read from the staging path via the package's
+  // path-safe reader. The frontend renders it sandboxed (token injected).
+  app.get("/api/collections/:slug/view-file", async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const { slug } = req.params;
+      const viewId = typeof req.query.id === "string" ? req.query.id : "";
+      const collection = await loadCollection(slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${slug}' not found` });
+        return;
+      }
+      const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+      if (!view) {
+        res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
+        return;
+      }
+      const html = await readCustomViewHtml(collection, view.file);
+      if (html === null) {
+        res.status(404).json({ error: `view file '${view.file}' not found` });
+        return;
+      }
+      // This is LLM-authored HTML. The frontend renders it sandboxed via a
+      // fetch()→srcdoc iframe (not by navigating here), so harden the raw response
+      // against DIRECT navigation: `sandbox` gives it an opaque origin (its scripts
+      // can't reach the app origin's /api/*), and `nosniff` stops re-interpretation.
+      // The iframe path is unaffected — a fetch() reads the body regardless of this
+      // response-level CSP.
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      res.setHeader("Content-Security-Policy", "sandbox");
+      res.type("text/html").send(html);
+    } catch (err) {
+      log.warn("collections", "view-file read failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Mint a scoped token for a custom view, clamped to what the view declared so a
+  // read-only view can never obtain a write token.
+  app.post("/api/collections/:slug/view-token", async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const { slug } = req.params;
+      const body = (req.body ?? {}) as { viewId?: unknown; capabilities?: unknown };
+      const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
+      if (!viewId) {
+        res.status(400).json({ error: "`viewId` is required" });
+        return;
+      }
+      const collection = await loadCollection(slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${slug}' not found` });
+        return;
+      }
+      const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+      if (!view) {
+        res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
+        return;
+      }
+      // Read-only for now: MulmoTerminal has no view-data write route yet, so never
+      // grant `write` even if the view declares it (clamp the request to ["read"]).
+      // Drop the `write` clamp here once the interactive tier wires PUT /view-data.
+      const granted = clampCapabilities(view.capabilities as ViewCapability[] | undefined, ["read"]);
+      const minted = mintViewToken(slug, granted);
+      res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
+    } catch (err) {
+      log.warn("collections", "view-token mint failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // CORS for the view-data endpoint: the sandboxed iframe has an opaque origin, so
+  // its fetch is cross-origin and preflighted. `*` is safe — auth is the unguessable
+  // scoped token in the Authorization header (not a cookie), so no ambient-credential
+  // leak; an origin without the token just gets a 401.
+  const viewDataCors = (_req: Request, res: Response, next: NextFunction): void => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+    next();
+  };
+  app.options("/api/collections/:slug/view-data", viewDataCors, (_req: Request, res: Response) => {
+    res.status(204).end();
+  });
+
+  // Scoped read: the view's enriched records as `{ items }` — the shape custom views
+  // fetch from `window.__MC_VIEW.dataUrl`. Guarded by the view token only.
+  app.get("/api/collections/:slug/view-data", viewDataCors, requireViewToken("read"), async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const collection = await loadCollection(req.params.slug);
+      if (!collection) {
+        res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+        return;
+      }
+      const items = await enrichItems(collection, await listItems(collection.dataDir));
+      res.json({ items });
+    } catch (err) {
+      log.warn("collections", "view-data read failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/backends/files.spec.ts
+++ b/server/backends/files.spec.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { mountFilesRoutes } from "./files.js";
+
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  const ws = mkdtempSync(path.join(tmpdir(), "mt-files-"));
+  mkdirSync(path.join(ws, "downloads", "images"), { recursive: true });
+  // 4-byte PNG signature — enough to assert byte length + Range.
+  writeFileSync(path.join(ws, "downloads", "images", "a.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  writeFileSync(path.join(ws, "secret.txt"), "top secret");
+
+  const app = express();
+  mountFilesRoutes(app, { workspace: ws });
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /api/files/raw", () => {
+  it("serves a file with the hardening headers", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=downloads/images/a.png`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("content-security-policy")).toBe("sandbox");
+    expect((await res.arrayBuffer()).byteLength).toBe(4);
+  });
+
+  it("400s when path is missing", async () => {
+    expect((await fetch(`${base}/api/files/raw`)).status).toBe(400);
+  });
+
+  it("403s on path traversal", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=${encodeURIComponent("../../etc/passwd")}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("403s on an absolute path escaping the root", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=${encodeURIComponent("/etc/passwd")}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("404s on a missing file", async () => {
+    expect((await fetch(`${base}/api/files/raw?path=downloads/images/nope.png`)).status).toBe(404);
+  });
+
+  it("honours a Range request (206 partial)", async () => {
+    const res = await fetch(`${base}/api/files/raw?path=downloads/images/a.png`, { headers: { Range: "bytes=0-1" } });
+    expect(res.status).toBe(206);
+    expect(res.headers.get("content-range")).toBe("bytes 0-1/4");
+    expect((await res.arrayBuffer()).byteLength).toBe(2);
+  });
+});

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -1,0 +1,126 @@
+// Raw workspace-file serving — GET /api/files/raw?path=<workspace-relative>.
+//
+// Consumers: the collection plugin's image/file fields (the binding's imageSrc maps
+// here) and its custom views, whose LLM-authored HTML builds
+// `<img src="<origin>/api/files/raw?path=...">` for poster/thumbnail fields. Mirrors
+// MulmoClaude's server/api/routes/files.ts GET /files/raw (the path the gallery view
+// hardcodes), trimmed to what MulmoTerminal needs.
+//
+// Security (this serves arbitrary workspace files):
+//   - Path containment: the resolved absolute path must stay within the workspace
+//     root — reject traversal / absolute escapes (the only real attack surface on a
+//     loopback server).
+//   - `Content-Security-Policy: sandbox` + `X-Content-Type-Options: nosniff` so an
+//     `.svg`/`.html` with embedded JS can't run in the app origin via direct
+//     navigation or <iframe>; PDFs skip the sandbox CSP (WebKit refuses to render
+//     sandbox-opaque PDFs) but keep nosniff. Matches MulmoClaude's RAW_SECURITY_HEADERS.
+import path from "node:path";
+import fs from "node:fs";
+import { createReadStream } from "node:fs";
+import type { Express, Request, Response } from "express";
+
+const MAX_RAW_BYTES = 25 * 1024 * 1024; // images / text / generic
+const MAX_MEDIA_BYTES = 500 * 1024 * 1024; // audio / video (streamed via Range)
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".ico": "image/x-icon",
+  ".pdf": "application/pdf",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".txt": "text/plain; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".csv": "text/csv; charset=utf-8",
+};
+
+function isMedia(mime: string): boolean {
+  return mime.startsWith("audio/") || mime.startsWith("video/");
+}
+
+function parseRange(header: string, size: number): { start: number; end: number } | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!match) return null;
+  const [, startStr, endStr] = match;
+  if (startStr === "" && endStr === "") return null;
+  const start = startStr === "" ? size - Number(endStr) : Number(startStr);
+  const end = endStr === "" ? size - 1 : Number(endStr);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  if (start < 0 || end < start || end >= size) return null;
+  return { start, end };
+}
+
+export function mountFilesRoutes(app: Express, deps: { workspace: string }): void {
+  const root = path.resolve(deps.workspace);
+
+  app.get("/api/files/raw", (req: Request, res: Response) => {
+    const rel = typeof req.query.path === "string" ? req.query.path : "";
+    if (!rel) {
+      res.status(400).json({ error: "`path` query is required" });
+      return;
+    }
+    // Containment: resolve against the workspace root and reject anything that
+    // escapes it (absolute input, `..`, symlink-free check on the resolved string).
+    const abs = path.resolve(root, rel);
+    if (abs !== root && !abs.startsWith(root + path.sep)) {
+      res.status(403).json({ error: "path escapes the workspace root" });
+      return;
+    }
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(abs);
+    } catch {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    if (!stat.isFile()) {
+      res.status(404).json({ error: "not a file" });
+      return;
+    }
+
+    const ext = path.extname(abs).toLowerCase();
+    const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
+    const cap = isMedia(mime) ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
+    if (stat.size > cap) {
+      res.status(413).json({ error: `file too large (${stat.size} bytes, limit ${cap})` });
+      return;
+    }
+
+    res.setHeader("Content-Type", mime);
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    // Sandbox the response so an SVG/HTML with embedded JS can't escape into the app
+    // origin. PDFs skip it (WebKit won't render sandbox-opaque PDFs).
+    if (mime !== "application/pdf") res.setHeader("Content-Security-Policy", "sandbox");
+    res.setHeader("Accept-Ranges", "bytes");
+
+    // Range support (required for <video>/<audio> seeking in Safari).
+    const rangeHeader = req.headers.range;
+    if (rangeHeader) {
+      const range = parseRange(rangeHeader, stat.size);
+      if (!range) {
+        res.status(416).setHeader("Content-Range", `bytes */${stat.size}`);
+        res.json({ error: "invalid range" });
+        return;
+      }
+      res.status(206);
+      res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
+      res.setHeader("Content-Length", String(range.end - range.start + 1));
+      createReadStream(abs, { start: range.start, end: range.end }).pipe(res);
+      return;
+    }
+
+    res.setHeader("Content-Length", String(stat.size));
+    createReadStream(abs).pipe(res);
+  });
+}

--- a/server/backends/html.spec.ts
+++ b/server/backends/html.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { initArtifactsBackend } from "./artifacts.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./html.js";
+
+let server: Server;
+let base: string;
+let ws: string;
+const REL = "artifacts/html/2026/06/page.html";
+
+beforeAll(async () => {
+  ws = mkdtempSync(path.join(tmpdir(), "mt-html-"));
+  mkdirSync(path.join(ws, "artifacts", "html", "2026", "06"), { recursive: true });
+  writeFileSync(path.join(ws, REL), "<!doctype html><html><body>ORIGINAL</body></html>");
+  initArtifactsBackend({ workspace: ws });
+
+  const app = express();
+  app.use(express.json());
+  mountHtmlDispatchRoute(app, { getPubsub: () => null });
+  mountHtmlPreviewRoute(app, { workspace: ws });
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => server?.close());
+
+const dispatch = (body: unknown) =>
+  fetch(`${base}/api/plugin/presentHtml`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+describe("html dispatch route", () => {
+  it("loadHtml returns the page bytes", async () => {
+    const res = await dispatch({ kind: "loadHtml", path: REL });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { html: string }).html).toContain("ORIGINAL");
+  });
+
+  it("saveHtml overwrites the file in place", async () => {
+    const res = await dispatch({ kind: "saveHtml", path: REL, html: "<html><body>EDITED</body></html>" });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { path: string }).path).toBe(REL);
+    expect(readFileSync(path.join(ws, REL), "utf8")).toContain("EDITED");
+  });
+
+  it("rejects a path outside artifacts/html", async () => {
+    expect((await dispatch({ kind: "loadHtml", path: "artifacts/secrets.html" })).status).toBe(400);
+  });
+
+  it("falls through (no handler → 404) for a tool-call with no kind", async () => {
+    // The real server has the generic catch-all after this route; here there's none,
+    // so next() lands on Express's 404 — proving the tool-call path isn't intercepted.
+    expect((await dispatch({ html: "<p>x</p>", title: "t" })).status).toBe(404);
+  });
+});
+
+describe("html preview route", () => {
+  it("serves the page with the preview CSP + nosniff", async () => {
+    const res = await fetch(`${base}/${REL}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    const csp = res.headers.get("content-security-policy") ?? "";
+    // Response-level sandbox so direct navigation can't run the LLM HTML with the
+    // app origin's privileges (not just relying on the embedding iframe).
+    expect(csp).toContain("sandbox allow-scripts");
+    expect(csp).toContain("connect-src 'none'");
+    expect(csp).toMatch(/script-src 'unsafe-inline'/);
+  });
+
+  it("403s a path that escapes artifacts/html", async () => {
+    const res = await fetch(`${base}/artifacts/html/${encodeURIComponent("../../etc/passwd")}`);
+    expect([403, 404]).toContain(res.status); // blocked either by containment or non-.html
+  });
+
+  it("404s a missing file", async () => {
+    expect((await fetch(`${base}/artifacts/html/nope.html`)).status).toBe(404);
+  });
+});

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -1,0 +1,119 @@
+// Host wiring for @mulmoclaude/html-plugin (presentHtml). The tool-call path
+// (executeHtml: save new HTML / present an existing path) is handled by the generic
+// package loader (plugins.json `packages` → /api/plugin/presentHtml via the FileOps
+// context). This module adds the two host-specific pieces:
+//
+//   1. The View's source-editor DISPATCH — `useRuntime().dispatch({kind})` POSTs to
+//      the same /api/plugin/presentHtml route, but with `kind: "loadHtml"|"saveHtml"`,
+//      which executeHtml doesn't handle. We intercept those before the generic
+//      catch-all and route them to executeHtmlDispatch (read/write via the artifacts
+//      FileOps); a tool-call (no `kind`) falls through to the package execute. After a
+//      save we publish a file-change so any open View live-refreshes.
+//   2. Serving the page for the iframe — the View renders `<iframe src=
+//      "/artifacts/html/…">` (htmlArtifactPreviewUrl). We serve that path from the
+//      workspace with an HTML preview CSP (sandboxed-ish: inline scripts + a curated
+//      CDN allowlist, but connect-src 'none' so a page can't phone home).
+import path from "node:path";
+import fs from "node:fs";
+import { createReadStream } from "node:fs";
+import type { Express, Request, Response, NextFunction } from "express";
+import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
+import { artifactsFileOps } from "./artifacts.js";
+import type { createPubSub } from "../pubsub.js";
+
+type PubSub = ReturnType<typeof createPubSub>;
+
+// Curated CDN allowlist (matches the collection custom-view policy) for an
+// LLM-authored page that may pull a charting/util lib or font from a CDN.
+const ALLOWED_CDNS = [
+  "https://cdn.jsdelivr.net",
+  "https://unpkg.com",
+  "https://cdnjs.cloudflare.com",
+  "https://fonts.googleapis.com",
+  "https://fonts.gstatic.com",
+  "https://cdn.plot.ly",
+].join(" ");
+
+// Preview CSP for a presentHtml page. This HTML is LLM-authored, so the RESPONSE
+// itself must sandbox it — not just the embedding iframe. `sandbox allow-scripts`
+// (no allow-same-origin) gives the document an opaque origin even on DIRECT
+// navigation to /artifacts/html/…, so its inline scripts can't reach the app
+// origin's cookies / /api/* (matches the collection view-file hardening). The
+// iframe (also sandbox="allow-scripts") renders identically — it was already
+// opaque-origin. `connect-src 'none'` additionally blocks fetch/XHR (no phone-home);
+// inline scripts + the CDN allowlist + images/media are allowed.
+const HTML_PREVIEW_CSP = [
+  "sandbox allow-scripts",
+  "default-src 'none'",
+  `script-src 'unsafe-inline' ${ALLOWED_CDNS}`,
+  `style-src 'unsafe-inline' ${ALLOWED_CDNS}`,
+  `font-src ${ALLOWED_CDNS}`,
+  `img-src 'self' ${ALLOWED_CDNS} data: blob: https:`,
+  `media-src 'self' https: data: blob:`,
+  "connect-src 'none'",
+].join("; ");
+
+/** Intercept the View's dispatch (loadHtml/saveHtml) on /api/plugin/presentHtml,
+ *  before the generic plugin catch-all (which handles the tool-call). MUST be
+ *  registered BEFORE mountAllRoutes. `getPubsub` is a thunk because pubsub is
+ *  created after routes are mounted; the handler reads it live at request time. */
+export function mountHtmlDispatchRoute(app: Express, deps: { getPubsub: () => PubSub | null }): void {
+  app.post("/api/plugin/presentHtml", async (req: Request, res: Response, next: NextFunction) => {
+    const args = (req.body ?? {}) as { kind?: unknown; path?: unknown };
+    // A tool-call (no `kind`) is left to the package execute via the catch-all.
+    if (args.kind !== "loadHtml" && args.kind !== "saveHtml") return next();
+    try {
+      const result = await executeHtmlDispatch({ files: { artifacts: artifactsFileOps } }, args as never);
+      if (args.kind === "saveHtml" && typeof args.path === "string") {
+        // Live-refresh: bump any open View watching this file (channel matches the
+        // frontend runtime scope "html" → plugin:html:file:<path>).
+        try {
+          const stat = await artifactsFileOps.stat(toArtifactsRel(args.path));
+          deps.getPubsub()?.publish(`plugin:html:file:${args.path}`, { mtimeMs: stat.mtimeMs });
+        } catch {
+          // Best-effort; the saver already updated its local state.
+        }
+      }
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+}
+
+function toArtifactsRel(workspaceRel: string): string {
+  return workspaceRel.startsWith("artifacts/") ? workspaceRel.slice("artifacts/".length) : workspaceRel;
+}
+
+/** Serve `GET /artifacts/html/<rest>` — the iframe preview source — from the
+ *  workspace, with the HTML preview CSP. Path-contained to artifacts/html. */
+export function mountHtmlPreviewRoute(app: Express, deps: { workspace: string }): void {
+  const root = path.resolve(deps.workspace, "artifacts", "html");
+  app.get(/^\/artifacts\/html\/(.+)/, (req: Request, res: Response) => {
+    const rel = req.params[0] ?? "";
+    const abs = path.resolve(root, rel);
+    if (abs !== root && !abs.startsWith(root + path.sep)) {
+      res.status(403).json({ error: "path escapes artifacts/html" });
+      return;
+    }
+    if (!abs.toLowerCase().endsWith(".html")) {
+      res.status(400).json({ error: "not an .html file" });
+      return;
+    }
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(abs);
+    } catch {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    if (!stat.isFile()) {
+      res.status(404).json({ error: "not a file" });
+      return;
+    }
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Content-Security-Policy", HTML_PREVIEW_CSP);
+    createReadStream(abs).pipe(res);
+  });
+}

--- a/server/backends/shortcuts.spec.ts
+++ b/server/backends/shortcuts.spec.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { normalizeShortcuts, mountShortcutsRoutes } from "./shortcuts.js";
+
+describe("normalizeShortcuts", () => {
+  it("drops malformed entries and dedupes on (kind, slug)", () => {
+    const out = normalizeShortcuts([
+      { kind: "collection", slug: "a", title: "A", icon: "star" },
+      { kind: "bogus", slug: "x", title: "X", icon: "y" }, // bad kind → dropped
+      { kind: "feed", slug: "" }, // empty slug → dropped
+      { kind: "collection", slug: "a", title: "dupe" }, // dupe (kind,slug) → dropped
+      { kind: "feed", slug: "b" }, // defaults title→slug, icon→bookmark
+      "not an object",
+    ]);
+    expect(out).toEqual([
+      { kind: "collection", slug: "a", title: "A", icon: "star" },
+      { kind: "feed", slug: "b", title: "b", icon: "bookmark" },
+    ]);
+  });
+
+  it("returns [] for non-array input", () => {
+    expect(normalizeShortcuts(undefined)).toEqual([]);
+    expect(normalizeShortcuts({ shortcuts: [] })).toEqual([]);
+  });
+});
+
+describe("/api/shortcuts routes", () => {
+  let ws: string;
+  let server: Server;
+  let base: string;
+
+  beforeEach(async () => {
+    ws = mkdtempSync(path.join(tmpdir(), "mt-sc-"));
+    const app = express();
+    app.use(express.json());
+    mountShortcutsRoutes(app, { workspace: ws });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const addr = server.address();
+    base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+  });
+
+  afterEach(() => {
+    server?.close();
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  it("GET returns [] when the file is absent", async () => {
+    const res = await fetch(`${base}/api/shortcuts`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ shortcuts: [] });
+  });
+
+  it("PUT persists the OBJECT-WRAPPER format and GET round-trips it", async () => {
+    const shortcuts = [{ kind: "collection", slug: "watchlist", title: "映画", icon: "movie" }];
+    const put = await fetch(`${base}/api/shortcuts`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ shortcuts }),
+    });
+    expect(put.status).toBe(200);
+    expect(await put.json()).toEqual({ shortcuts });
+
+    // On-disk: object wrapper { shortcuts: [...] }, NOT a bare array — the contract
+    // MulmoClaude shares.
+    const onDisk = JSON.parse(readFileSync(path.join(ws, "config", "shortcuts.json"), "utf8"));
+    expect(Array.isArray(onDisk)).toBe(false);
+    expect(onDisk).toEqual({ shortcuts });
+
+    expect(await (await fetch(`${base}/api/shortcuts`)).json()).toEqual({ shortcuts });
+  });
+
+  it("PUT normalises (drops junk, dedupes) before persisting", async () => {
+    const res = await fetch(`${base}/api/shortcuts`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        shortcuts: [
+          { kind: "collection", slug: "a" },
+          { kind: "nope", slug: "b" },
+          { kind: "collection", slug: "a" },
+        ],
+      }),
+    });
+    expect(await res.json()).toEqual({ shortcuts: [{ kind: "collection", slug: "a", title: "a", icon: "bookmark" }] });
+  });
+
+  it("PUT 400s when the body is not { shortcuts: [...] }", async () => {
+    const res = await fetch(`${base}/api/shortcuts`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ nope: true }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("handles concurrent PUTs without ENOENT/500 (unique temp files)", async () => {
+    const put = (slug: string) =>
+      fetch(`${base}/api/shortcuts`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ shortcuts: [{ kind: "collection", slug }] }),
+      });
+    const results = await Promise.all(Array.from({ length: 8 }, (_, i) => put(`c${i}`)));
+    expect(results.every((r) => r.status === 200)).toBe(true);
+    // The file is intact (valid wrapper) — one of the writers won, none half-written.
+    const onDisk = JSON.parse(readFileSync(path.join(ws, "config", "shortcuts.json"), "utf8"));
+    expect(Array.isArray(onDisk.shortcuts)).toBe(true);
+    expect(onDisk.shortcuts).toHaveLength(1);
+  });
+
+  it("reads an existing MulmoClaude-written file (wrapper format)", async () => {
+    mkdirSync(path.join(ws, "config"), { recursive: true });
+    writeFileSync(path.join(ws, "config", "shortcuts.json"), JSON.stringify({ shortcuts: [{ kind: "feed", slug: "news", title: "News", icon: "rss_feed" }] }));
+    const res = await fetch(`${base}/api/shortcuts`);
+    expect(await res.json()).toEqual({ shortcuts: [{ kind: "feed", slug: "news", title: "News", icon: "rss_feed" }] });
+  });
+});

--- a/server/backends/shortcuts.ts
+++ b/server/backends/shortcuts.ts
@@ -1,0 +1,139 @@
+// Shared launcher shortcuts (pinned collections / feeds) over
+// `<workspace>/config/shortcuts.json`. MulmoClaude and MulmoTerminal SHARE this
+// file — favoriting a collection in one app must show up in the other — so the
+// on-disk format is the contract: an OBJECT WRAPPER `{ shortcuts: Shortcut[] }`
+// (not a bare array), matching mulmoclaude/src/types/shortcuts.ts +
+// server/utils/files/shortcuts-io.ts. Reimplemented verbatim here (the format is
+// tiny and stable; shortcuts.spec.ts pins it) rather than sharing a package, so
+// MulmoTerminal stays MulmoClaude-change-free.
+//
+//   GET /api/shortcuts  → { shortcuts }
+//   PUT /api/shortcuts  → replace the whole array → { shortcuts }
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
+import type { Express, Request, Response } from "express";
+
+/** Which route family a shortcut points at. */
+export const SHORTCUT_KINDS = ["collection", "feed"] as const;
+export type ShortcutKind = (typeof SHORTCUT_KINDS)[number];
+
+export interface Shortcut {
+  kind: ShortcutKind;
+  /** Target collection / feed slug. */
+  slug: string;
+  /** Cached display label (refreshed on reconcile). */
+  title: string;
+  /** Cached material-symbols glyph (refreshed on reconcile). */
+  icon: string;
+}
+
+/** On-disk shape — object wrapper (not a bare array) so the schema can grow
+ *  without a migration. THIS is the cross-app contract. */
+interface ShortcutsFile {
+  shortcuts: Shortcut[];
+}
+
+const KINDS = new Set<string>(SHORTCUT_KINDS);
+
+/** True when two shortcuts target the same thing (the dedupe key). */
+function sameShortcut(left: Pick<Shortcut, "kind" | "slug">, right: Pick<Shortcut, "kind" | "slug">): boolean {
+  return left.kind === right.kind && left.slug === right.slug;
+}
+
+/** Coerce arbitrary JSON into a clean `Shortcut[]`: drop malformed entries (bad
+ *  kind / empty slug / non-string fields), default title→slug and icon→"bookmark",
+ *  and dedupe on (kind, slug) keeping the first. Pure — exported for tests. */
+export function normalizeShortcuts(input: unknown): Shortcut[] {
+  if (!Array.isArray(input)) return [];
+  const out: Shortcut[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "object" || raw === null) continue;
+    const candidate = raw as Record<string, unknown>;
+    const { kind, slug, title, icon } = candidate;
+    if (typeof kind !== "string" || !KINDS.has(kind)) continue;
+    if (typeof slug !== "string" || slug.length === 0) continue;
+    const entry: Shortcut = {
+      kind: kind as ShortcutKind,
+      slug,
+      title: typeof title === "string" ? title : slug,
+      icon: typeof icon === "string" && icon.length > 0 ? icon : "bookmark",
+    };
+    if (out.some((existing) => sameShortcut(existing, entry))) continue;
+    out.push(entry);
+  }
+  return out;
+}
+
+function shortcutsFilePath(workspace: string): string {
+  return path.join(workspace, "config", "shortcuts.json");
+}
+
+/** Read the pinned shortcuts. Missing / unreadable / malformed → `[]`. */
+async function readShortcuts(workspace: string): Promise<Shortcut[]> {
+  let text: string;
+  try {
+    text = await fs.readFile(shortcutsFilePath(workspace), "utf8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(text) as Partial<ShortcutsFile>;
+    return normalizeShortcuts(parsed?.shortcuts);
+  } catch {
+    return [];
+  }
+}
+
+/** Replace the full list. Normalises (validate + dedupe) before an atomic write
+ *  (temp file + rename) so the on-disk file is always clean and never half-written.
+ *  Returns the canonical list. */
+async function writeShortcuts(workspace: string, input: unknown): Promise<Shortcut[]> {
+  const clean = normalizeShortcuts(input);
+  const payload: ShortcutsFile = { shortcuts: clean };
+  const file = shortcutsFilePath(workspace);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  // Unique temp name per write so concurrent PUTs (two tabs / clients) can't clobber
+  // each other's temp file and ENOENT on rename. Each writes its own temp then
+  // atomically renames onto `file` — last writer wins, which is fine for a
+  // replace-all endpoint (the client also serializes its own PUTs).
+  const tmp = `${file}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    await fs.rename(tmp, file);
+  } catch (err) {
+    await fs.rm(tmp, { force: true }); // don't leave a stray temp on failure
+    throw err;
+  }
+  return clean;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function mountShortcutsRoutes(app: Express, deps: { workspace: string }): void {
+  app.get("/api/shortcuts", async (_req: Request, res: Response) => {
+    try {
+      res.json({ shortcuts: await readShortcuts(deps.workspace) });
+    } catch (err) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // The client owns ordering / add / remove and sends the whole array; the server
+  // normalises (validate kind, non-empty slug, dedupe) before persisting. A single
+  // replace endpoint avoids add/remove route sprawl.
+  app.put("/api/shortcuts", async (req: Request, res: Response) => {
+    const incoming = (req.body ?? {}) as { shortcuts?: unknown };
+    if (!Array.isArray(incoming.shortcuts)) {
+      res.status(400).json({ error: "Request body must be { shortcuts: Shortcut[] }" });
+      return;
+    }
+    try {
+      res.json({ shortcuts: await writeShortcuts(deps.workspace, incoming.shortcuts) });
+    } catch (err) {
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/backends/viewToken.spec.ts
+++ b/server/backends/viewToken.spec.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import { mintViewToken, verifyViewToken, clampCapabilities, requireViewToken, VIEW_TOKEN_TTL_MS, type ViewCapability } from "./viewToken.js";
+import type { Request, Response, NextFunction } from "express";
+
+describe("viewToken mint/verify", () => {
+  it("round-trips a minted token", () => {
+    const { token, exp } = mintViewToken("watchlist", ["read"], 1000);
+    expect(exp).toBe(1000 + VIEW_TOKEN_TTL_MS);
+    const payload = verifyViewToken(token, 2000);
+    expect(payload).toEqual({ slug: "watchlist", caps: ["read"], exp: 1000 + VIEW_TOKEN_TTL_MS });
+  });
+
+  it("rejects a tampered payload", () => {
+    const { token } = mintViewToken("watchlist", ["read"], 1000);
+    const [payloadB64, sig] = token.split(".");
+    // Re-encode a payload claiming a different slug, keep the original signature.
+    const forged = Buffer.from(JSON.stringify({ slug: "secrets", caps: ["read", "write"], exp: 1000 + VIEW_TOKEN_TTL_MS }), "utf8").toString("base64url");
+    expect(verifyViewToken(`${forged}.${sig}`, 2000)).toBeNull();
+    // Sanity: the untouched token still verifies.
+    expect(verifyViewToken(`${payloadB64}.${sig}`, 2000)).not.toBeNull();
+  });
+
+  it("rejects a bad signature", () => {
+    const { token } = mintViewToken("watchlist", ["read"], 1000);
+    const [payloadB64] = token.split(".");
+    expect(verifyViewToken(`${payloadB64}.deadbeef`, 2000)).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    const { token, exp } = mintViewToken("watchlist", ["read"], 1000);
+    expect(verifyViewToken(token, exp)).toBeNull(); // exactly at exp → expired
+    expect(verifyViewToken(token, exp + 1)).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    expect(verifyViewToken("")).toBeNull();
+    expect(verifyViewToken("nodot")).toBeNull();
+    expect(verifyViewToken(".onlysig")).toBeNull();
+  });
+});
+
+describe("clampCapabilities", () => {
+  const cases: Array<[ViewCapability[] | undefined, ViewCapability[] | undefined, ViewCapability[]]> = [
+    [["read", "write"], ["read"], ["read"]], // requested narrows the declared set
+    [["read"], ["read", "write"], ["read"]], // declared caps the grant (no write escalation)
+    [undefined, undefined, ["read"]], // least-privilege default
+    [["read", "write"], undefined, ["read", "write"]], // undefined requested ⇒ full declared set
+    [[], ["read"], ["read"]], // empty declared ⇒ default ["read"]
+  ];
+  it.each(cases)("clamp(%j, %j) → %j", (declared, requested, expected) => {
+    expect(clampCapabilities(declared, requested)).toEqual(expected);
+  });
+});
+
+interface MockRes {
+  statusCode: number;
+  body: unknown;
+  status(code: number): MockRes;
+  json(b: unknown): MockRes;
+}
+function mockRes(): MockRes {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(b) {
+      this.body = b;
+      return this;
+    },
+  };
+}
+
+function runGuard(action: ViewCapability, headers: Record<string, string>, slug: string) {
+  const res = mockRes();
+  const next = vi.fn();
+  requireViewToken(action)({ headers, params: { slug } } as unknown as Request, res as unknown as Response, next as NextFunction);
+  return { res, next };
+}
+
+describe("requireViewToken middleware", () => {
+  it("401s with no Authorization header", () => {
+    const { res, next } = runGuard("read", {}, "watchlist");
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next() for a valid token with the right slug + capability", () => {
+    const { token } = mintViewToken("watchlist", ["read"]);
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "watchlist");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("401s when the token's slug differs from the route", () => {
+    const { token } = mintViewToken("watchlist", ["read"]);
+    const { res, next } = runGuard("read", { authorization: `Bearer ${token}` }, "other");
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401s when the required capability is missing", () => {
+    const { token } = mintViewToken("watchlist", ["read"]);
+    const { res, next } = runGuard("write", { authorization: `Bearer ${token}` }, "watchlist");
+    expect(res.statusCode).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/backends/viewToken.ts
+++ b/server/backends/viewToken.ts
@@ -1,0 +1,101 @@
+// Scoped capability tokens for custom collection views — MulmoTerminal's port of
+// MulmoClaude's server/api/auth/viewToken.ts.
+//
+// A custom view is LLM-authored HTML rendered in a sandboxed (allow-scripts,
+// opaque-origin) iframe. It must reach ONLY its collection's view-data endpoint,
+// for one slug, with an explicit capability set (read/write). The authenticated
+// parent mints a short-lived signed token (`base64url(payload).HMAC`); the iframe
+// sends it as `Authorization: Bearer <token>`; `requireViewToken` verifies it.
+//
+// MulmoTerminal has no global bearer auth (loopback tool), so — unlike MulmoClaude,
+// which keys the HMAC by its per-startup bearer token — we generate a per-PROCESS
+// random signing key here. A restart invalidates outstanding view tokens (the key
+// changes), the same lifecycle MulmoClaude gets for free.
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import type { Request, Response, NextFunction } from "express";
+
+export type ViewCapability = "read" | "write";
+
+function isCapability(value: unknown): value is ViewCapability {
+  return value === "read" || value === "write";
+}
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+/** How long a minted view token stays valid. The parent re-mints on each render. */
+export const VIEW_TOKEN_TTL_MS = ONE_HOUR_MS;
+
+const BEARER_PREFIX = "Bearer ";
+
+// Per-process signing key — generated once, lost on restart (intentional).
+const SIGNING_KEY = randomBytes(32).toString("hex");
+
+interface ViewTokenPayload {
+  slug: string;
+  caps: ViewCapability[];
+  exp: number;
+}
+
+function signPayload(payloadB64: string): string {
+  return createHmac("sha256", SIGNING_KEY).update(payloadB64).digest("base64url");
+}
+
+/** Clamp a view's requested capabilities to what it declared in its schema — a
+ *  `["read"]` view can never get a `write` token. The result is declared ∩
+ *  requested; undefined declared ⇒ least-privilege `["read"]`. */
+export function clampCapabilities(declared: ViewCapability[] | undefined, requested: ViewCapability[] | undefined): ViewCapability[] {
+  const declaredCaps = declared && declared.length > 0 ? declared : (["read"] as ViewCapability[]);
+  const requestedCaps = requested && requested.length > 0 ? requested : declaredCaps;
+  return declaredCaps.filter((cap) => requestedCaps.includes(cap));
+}
+
+/** Mint a signed token for `slug` granting `caps`, valid for {@link VIEW_TOKEN_TTL_MS}. */
+export function mintViewToken(slug: string, caps: ViewCapability[], nowMs: number = Date.now()): { token: string; exp: number } {
+  const exp = nowMs + VIEW_TOKEN_TTL_MS;
+  const payload: ViewTokenPayload = { slug, caps, exp };
+  const payloadB64 = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return { token: `${payloadB64}.${signPayload(payloadB64)}`, exp };
+}
+
+/** Verify a token's signature + expiry; return its payload or null on any failure. */
+export function verifyViewToken(token: string, nowMs: number = Date.now()): ViewTokenPayload | null {
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot >= token.length - 1) return null;
+  const payloadB64 = token.slice(0, dot);
+  const providedSig = token.slice(dot + 1);
+  const expectedSig = signPayload(payloadB64);
+  // Compare byte lengths before timingSafeEqual — it throws on a length mismatch.
+  const providedBuf = Buffer.from(providedSig);
+  const expectedBuf = Buffer.from(expectedSig);
+  if (providedBuf.length !== expectedBuf.length) return null;
+  if (!timingSafeEqual(providedBuf, expectedBuf)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const candidate = parsed as Record<string, unknown>;
+  if (typeof candidate.slug !== "string" || typeof candidate.exp !== "number") return null;
+  if (!Array.isArray(candidate.caps) || !candidate.caps.every(isCapability)) return null;
+  if (nowMs >= candidate.exp) return null;
+  return { slug: candidate.slug, caps: candidate.caps as ViewCapability[], exp: candidate.exp };
+}
+
+/** Express middleware: require a valid scoped token whose slug matches the route
+ *  param and whose caps include `action`. 401 on any failure. */
+export function requireViewToken(action: ViewCapability) {
+  return function requireViewTokenMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const header = req.headers.authorization;
+    if (typeof header !== "string" || !header.startsWith(BEARER_PREFIX)) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    const payload = verifyViewToken(header.slice(BEARER_PREFIX.length));
+    if (!payload || payload.slug !== req.params.slug || !payload.caps.includes(action)) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+    next();
+  };
+}

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -1,0 +1,28 @@
+// GET/POST /api/config — the default workspace dir + the user's directory presets
+// (persisted at ~/.mulmoterminal/config.json), shown/edited in the UI. Kept in its
+// own module (mounted from index.ts) so grid/preset work doesn't churn index.ts
+// and collide with unrelated server changes.
+import os from "node:os";
+import path from "node:path";
+import type { Express } from "express";
+import { loadPresets, savePresets, sanitizePresets, type CwdPreset } from "./cwd-presets.js";
+
+const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
+let cwdPresets: CwdPreset[] = loadPresets(CONFIG_FILE);
+
+export function mountConfigRoutes(app: Express, claudeCwd: string): void {
+  app.get("/api/config", (_req, res) => {
+    res.json({ cwd: claudeCwd, cwdPresets, home: os.homedir() });
+  });
+
+  app.post("/api/config", (req, res) => {
+    const body = req.body ?? {};
+    if (!Array.isArray(body.cwdPresets)) return res.status(400).json({ error: "cwdPresets must be an array" });
+    // Stage, persist, commit in-memory only on success — a failed write must not
+    // leave GET exposing presets that won't survive a restart.
+    const next = sanitizePresets(body.cwdPresets);
+    if (!savePresets(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist presets" });
+    cwdPresets = next;
+    res.json({ cwd: claudeCwd, cwdPresets });
+  });
+}

--- a/server/host-tools.ts
+++ b/server/host-tools.ts
@@ -10,8 +10,10 @@ import type { ToolDefinition } from "gui-chat-protocol";
 // tool is a drop-in from the model's point of view — but the implementation is
 // completely different: instead of starting an SDK chat, it spawns a brand-new
 // interactive Claude terminal session on the server, seeded with `message`, that
-// the user can open from the sidebar. `role` and `hidden` are accepted for
-// signature parity but ignored: the spawned session is always a visible terminal.
+// the user can open from the sidebar. `role` is accepted for signature parity but
+// ignored (MulmoTerminal has no roles). `hidden:true` marks the session a background
+// worker: it still lists in the sidebar but never renders bold/unread when it
+// finishes (so a background helper doesn't pull the user's attention).
 export const SPAWN_BACKGROUND_CHAT: ToolDefinition = {
   type: "function",
   name: "spawnBackgroundChat",

--- a/server/index.ts
+++ b/server/index.ts
@@ -62,6 +62,10 @@ interface SessionMeta {
   mtime: number;
   working: boolean;
   waiting: boolean;
+  /** Spawned as a hidden background worker (spawnBackgroundChat hidden:true). The
+   *  tab still lists, but it never renders bold/unread — a background helper
+   *  finishing shouldn't pull the user's attention. */
+  hidden: boolean;
 }
 
 // Recency rank for an on-disk .jsonl, before its contents are read.
@@ -304,6 +308,12 @@ const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
 // once the file exists (the on-disk record takes over) or the pty is reaped.
 const knownSessions = new Map<string, KnownSession>(); // id -> { createdAt, title }
 
+// Sessions spawned as hidden background workers (spawnBackgroundChat hidden:true).
+// They list normally but never render bold/unread. Process-lifetime only (not
+// persisted) — and tied to `activity`'s lifecycle in reap() so a finished hidden
+// worker that stays `waiting` doesn't lose its hidden flag and re-bold.
+const hiddenSessions = new Set<string>(); // id
+
 // Bytes of recent output kept per pty and replayed when a client reattaches to
 // a background session, so the user sees context instead of a blank screen.
 const OUTPUT_BUFFER_LIMIT = 64 * 1024;
@@ -324,7 +334,12 @@ function reap(id: string) {
   // visible via its on-disk record.
   knownSessions.delete(id);
   const a = activity.get(id);
-  if (!a || (!a.working && !a.waiting)) activity.delete(id);
+  if (!a || (!a.working && !a.waiting)) {
+    activity.delete(id);
+    // Drop the hidden flag only when activity is dropped too — while `waiting`
+    // persists (the bold-until-viewed window), keep it so the row stays un-bold.
+    hiddenSessions.delete(id);
+  }
   try {
     entry.term.kill();
   } catch {
@@ -473,6 +488,7 @@ async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> 
     mtime: stat.mtimeMs,
     working: a?.working ?? false,
     waiting: a?.waiting ?? false,
+    hidden: hiddenSessions.has(id),
   };
 }
 
@@ -485,9 +501,10 @@ app.use(express.json({ limit: "25mb" }));
 // Host tool: spawnBackgroundChat. Unlike a plugin (handled by mountAllRoutes'
 // catch-all), it needs server internals — it spawns a brand-new interactive Claude
 // terminal session, seeded with `message`, that the user can open from the sidebar.
-// `role`/`hidden` are accepted for signature parity with MulmoClaude but ignored:
-// the session is always visible. Registered BEFORE mountAllRoutes so this specific
-// route wins over /api/plugin/:toolName.
+// `role` is ignored (MulmoTerminal has no roles). `hidden:true` marks it a background
+// worker: it still lists in the sidebar but never renders bold/unread when it
+// finishes. Registered BEFORE mountAllRoutes so this specific route wins over
+// /api/plugin/:toolName.
 app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   const body = isRecord(req.body) ? req.body : {};
   const message = typeof body.message === "string" ? body.message.trim() : "";
@@ -495,6 +512,7 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
     return res.json({ message: "spawnBackgroundChat: `message` is required (non-empty string)." });
   }
   const sessionId = randomUUID();
+  if (body.hidden === true) hiddenSessions.add(sessionId);
   // ws is null: the session runs headless until the user opens it (reattach
   // replays the buffered output). The "created" pubsub event in spawnClaudePty
   // surfaces it in the sidebar right away.
@@ -731,6 +749,7 @@ app.get("/api/sessions", async (_req, res) => {
         mtime: meta.createdAt,
         working: activity.get(id)?.working ?? false,
         waiting: activity.get(id)?.waiting ?? false,
+        hidden: hiddenSessions.has(id),
       });
     }
 
@@ -741,7 +760,7 @@ app.get("/api/sessions", async (_req, res) => {
       await Promise.all(
         top.map((s) =>
           s.kind === "pending"
-            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting }
+            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, hidden: s.hidden }
             : readSessionMeta(dir, s.file).catch(() => null),
         ),
       )

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
+import { mountShortcutsRoutes } from "./backends/shortcuts.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -522,6 +523,10 @@ mountCollectionRoutes(app);
 // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
 // fields and custom-view <img> URLs. Rooted at the shared workspace.
 mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
+// Shared launcher favorites (GET/PUT /api/shortcuts) over the same
+// <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.
+mountShortcutsRoutes(app, { workspace: CLAUDE_CWD });
 
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -528,6 +529,11 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   });
 });
 
+// presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
+// /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
+// catch-all (which handles the tool-call); a request without `kind` falls through.
+mountHtmlDispatchRoute(app, { getPubsub: () => pubsub });
+
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
 // POST /api/form). The GUI MCP server dispatches tool calls to these.
 mountAllRoutes(app);
@@ -541,6 +547,10 @@ mountCollectionRoutes(app);
 // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
 // fields and custom-view <img> URLs. Rooted at the shared workspace.
 mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
+// Serve presentHtml pages for the View's iframe (GET /artifacts/html/<rest>) with an
+// HTML preview CSP. The View navigates the iframe to this URL (htmlArtifactPreviewUrl).
+mountHtmlPreviewRoute(app, { workspace: CLAUDE_CWD });
 
 // Shared launcher favorites (GET/PUT /api/shortcuts) over the same
 // <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,10 @@ import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { loadPresets, savePresets, sanitizePresets, type CwdPreset } from "./cwd-presets.js";
+import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
+import { mountFilesRoutes } from "./backends/files.js";
+import { mountShortcutsRoutes } from "./backends/shortcuts.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -62,6 +66,10 @@ interface SessionMeta {
   mtime: number;
   working: boolean;
   waiting: boolean;
+  /** Spawned as a hidden background worker (spawnBackgroundChat hidden:true). The
+   *  tab still lists, but it never renders bold/unread — a background helper
+   *  finishing shouldn't pull the user's attention. */
+  hidden: boolean;
 }
 
 // Recency rank for an on-disk .jsonl, before its contents are read.
@@ -314,6 +322,12 @@ const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
 // once the file exists (the on-disk record takes over) or the pty is reaped.
 const knownSessions = new Map<string, KnownSession>(); // id -> { createdAt, title }
 
+// Sessions spawned as hidden background workers (spawnBackgroundChat hidden:true).
+// They list normally but never render bold/unread. Process-lifetime only (not
+// persisted) — and tied to `activity`'s lifecycle in reap() so a finished hidden
+// worker that stays `waiting` doesn't lose its hidden flag and re-bold.
+const hiddenSessions = new Set<string>(); // id
+
 // Bytes of recent output kept per pty and replayed when a client reattaches to
 // a background session, so the user sees context instead of a blank screen.
 const OUTPUT_BUFFER_LIMIT = 64 * 1024;
@@ -364,7 +378,12 @@ function reap(id: string) {
   knownSessions.delete(id);
   lastPrompts.delete(id); // don't leak prompt text for torn-down sessions
   const a = activity.get(id);
-  if (!a || (!a.working && !a.waiting)) activity.delete(id);
+  if (!a || (!a.working && !a.waiting)) {
+    activity.delete(id);
+    // Drop the hidden flag only when activity is dropped too — while `waiting`
+    // persists (the bold-until-viewed window), keep it so the row stays un-bold.
+    hiddenSessions.delete(id);
+  }
   try {
     entry.term.kill();
   } catch {
@@ -534,6 +553,7 @@ async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> 
     mtime: stat.mtimeMs,
     working: a?.working ?? false,
     waiting: a?.waiting ?? false,
+    hidden: hiddenSessions.has(id),
   };
 }
 
@@ -546,9 +566,10 @@ app.use(express.json({ limit: "25mb" }));
 // Host tool: spawnBackgroundChat. Unlike a plugin (handled by mountAllRoutes'
 // catch-all), it needs server internals — it spawns a brand-new interactive Claude
 // terminal session, seeded with `message`, that the user can open from the sidebar.
-// `role`/`hidden` are accepted for signature parity with MulmoClaude but ignored:
-// the session is always visible. Registered BEFORE mountAllRoutes so this specific
-// route wins over /api/plugin/:toolName.
+// `role` is ignored (MulmoTerminal has no roles). `hidden:true` marks it a background
+// worker: it still lists in the sidebar but never renders bold/unread when it
+// finishes. Registered BEFORE mountAllRoutes so this specific route wins over
+// /api/plugin/:toolName.
 app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   const body = isRecord(req.body) ? req.body : {};
   const message = typeof body.message === "string" ? body.message.trim() : "";
@@ -556,6 +577,7 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
     return res.json({ message: "spawnBackgroundChat: `message` is required (non-empty string)." });
   }
   const sessionId = randomUUID();
+  if (body.hidden === true) hiddenSessions.add(sessionId);
   // ws is null: the session runs headless until the user opens it (reattach
   // replays the buffered output). The "created" pubsub event in spawnClaudePty
   // surfaces it in the sidebar right away.
@@ -571,9 +593,32 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   });
 });
 
+// presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
+// /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
+// catch-all (which handles the tool-call); a request without `kind` falls through.
+mountHtmlDispatchRoute(app, { getPubsub: () => pubsub });
+
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
 // POST /api/form). The GUI MCP server dispatches tool calls to these.
 mountAllRoutes(app);
+
+// Read-side collection routes (GET /api/collections/list + /:slug/detail) over the
+// shared workspace, backing the @mulmoclaude/collection-plugin presentCollection
+// card and (later) the collections toolbar. The engine itself is configured below
+// once CLAUDE_CWD is the confirmed workspace.
+mountCollectionRoutes(app);
+
+// Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
+// fields and custom-view <img> URLs. Rooted at the shared workspace.
+mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
+// Serve presentHtml pages for the View's iframe (GET /artifacts/html/<rest>) with an
+// HTML preview CSP. The View navigates the iframe to this URL (htmlArtifactPreviewUrl).
+mountHtmlPreviewRoute(app, { workspace: CLAUDE_CWD });
+
+// Shared launcher favorites (GET/PUT /api/shortcuts) over the same
+// <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.
+mountShortcutsRoutes(app, { workspace: CLAUDE_CWD });
 
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in
@@ -816,6 +861,7 @@ app.get("/api/sessions", async (_req, res) => {
         mtime: meta.createdAt,
         working: activity.get(id)?.working ?? false,
         waiting: activity.get(id)?.waiting ?? false,
+        hidden: hiddenSessions.has(id),
       });
     }
 
@@ -826,7 +872,7 @@ app.get("/api/sessions", async (_req, res) => {
       await Promise.all(
         top.map((s) =>
           s.kind === "pending"
-            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting }
+            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, hidden: s.hidden }
             : readSessionMeta(dir, s.file).catch(() => null),
         ),
       )
@@ -852,6 +898,10 @@ initMarkdownBackend({ workspace: CLAUDE_CWD, pubsub });
 // Give the artifacts FileOps backend its workspace root (<workspace>/artifacts) so
 // @mulmoclaude/chart-plugin's executeChart can persist chart documents there.
 initArtifactsBackend({ workspace: CLAUDE_CWD });
+
+// Configure the collection engine against the shared workspace (CLAUDE_CWD). The
+// path layout matches MulmoClaude's so discovery sees the same collection skills.
+initCollectionsBackend({ workspace: CLAUDE_CWD });
 
 // Terminal WebSocket. Uses noServer + manual upgrade routing so it shares the
 // HTTP server with socket.io (the pub/sub at /ws/pubsub) without the two

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { loadPresets, savePresets, sanitizePresets, type CwdPreset } from "./cwd-presets.js";
+import { mountConfigRoutes } from "./config-routes.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
@@ -111,11 +111,6 @@ await fs.mkdir(CLAUDE_CWD, { recursive: true });
 // history) lives here, keyed by sessionId (a global UUID) — NOT under the
 // workspace dir, so it stays valid regardless of which directory is active.
 const MULMOTERMINAL_HOME = path.join(os.homedir(), ".mulmoterminal");
-
-// User config (currently just directory presets the launch form offers),
-// persisted at ~/.mulmoterminal/config.json. Logic lives in ./cwd-presets.
-const CONFIG_FILE = path.join(MULMOTERMINAL_HOME, "config.json");
-let cwdPresets: CwdPreset[] = loadPresets(CONFIG_FILE);
 
 // A session id is always a UUID (server-generated, or a .jsonl basename). Reject
 // anything else so a client can't smuggle CLI flags (e.g. "--resume" followed by
@@ -785,23 +780,8 @@ app.get("/api/tool-calls/:sessionId", async (req, res) => {
   res.json({ sessionId, toolCalls: await toolCallsStore.get(sessionId) });
 });
 
-// Server-wide config the UI shows: the default workspace dir + the user's saved
-// directory presets (offered in the cell launch form).
-app.get("/api/config", (_req, res) => {
-  res.json({ cwd: CLAUDE_CWD, cwdPresets, home: os.homedir() });
-});
-
-// Update the directory presets (from the settings screen) and persist them.
-app.post("/api/config", (req, res) => {
-  const body = req.body || {};
-  if (!Array.isArray(body.cwdPresets)) return res.status(400).json({ error: "cwdPresets must be an array" });
-  // Stage, persist, then commit in-memory only on success — a failed write must
-  // not leave GET exposing presets that won't survive a restart.
-  const next = sanitizePresets(body.cwdPresets);
-  if (!savePresets(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist presets" });
-  cwdPresets = next;
-  res.json({ cwd: CLAUDE_CWD, cwdPresets });
-});
+// GET/POST /api/config (workspace dir + directory presets) — in its own module.
+mountConfigRoutes(app, CLAUDE_CWD);
 
 // Initial per-session status + last prompt, so a cell can render its header
 // immediately (the live updates then arrive via the "sessions" pub/sub channel).

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,8 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
+import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
+import { mountFilesRoutes } from "./backends/files.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 interface Activity {
@@ -511,6 +513,16 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
 // POST /api/form). The GUI MCP server dispatches tool calls to these.
 mountAllRoutes(app);
 
+// Read-side collection routes (GET /api/collections/list + /:slug/detail) over the
+// shared workspace, backing the @mulmoclaude/collection-plugin presentCollection
+// card and (later) the collections toolbar. The engine itself is configured below
+// once CLAUDE_CWD is the confirmed workspace.
+mountCollectionRoutes(app);
+
+// Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
+// fields and custom-view <img> URLs. Rooted at the shared workspace.
+mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in
 // STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
@@ -750,6 +762,10 @@ initMarkdownBackend({ workspace: CLAUDE_CWD, pubsub });
 // Give the artifacts FileOps backend its workspace root (<workspace>/artifacts) so
 // @mulmoclaude/chart-plugin's executeChart can persist chart documents there.
 initArtifactsBackend({ workspace: CLAUDE_CWD });
+
+// Configure the collection engine against the shared workspace (CLAUDE_CWD). The
+// path layout matches MulmoClaude's so discovery sees the same collection skills.
+initCollectionsBackend({ workspace: CLAUDE_CWD });
 
 // Terminal WebSocket. Uses noServer + manual upgrade routing so it shares the
 // HTTP server with socket.io (the pub/sub at /ws/pubsub) without the two

--- a/server/plugins-registry.ts
+++ b/server/plugins-registry.ts
@@ -65,7 +65,16 @@ function loadConfig() {
 async function loadPackage(name: string) {
   const mod = await import(name);
   const definition = mod.TOOL_DEFINITION ?? mod.pluginCore?.toolDefinition;
-  const execute = mod.pluginCore?.execute ?? mod.execute;
+  // Some packages (e.g. @mulmoclaude/collection-plugin) export their executor under
+  // a descriptive name like `executePresentCollection` rather than a bare `execute`,
+  // and ship no `pluginCore` on the core entry (their origin host registers the tool
+  // as a built-in). Fall back to a sole `execute*` function export so such packages
+  // still load without hardcoding their name.
+  const soleExecuteStar = (() => {
+    const fns = Object.entries(mod).filter(([key, val]) => key.startsWith("execute") && typeof val === "function");
+    return fns.length === 1 ? (fns[0][1] as (...args: unknown[]) => unknown) : undefined;
+  })();
+  const execute = mod.pluginCore?.execute ?? mod.execute ?? soleExecuteStar;
   if (!definition || typeof execute !== "function") {
     throw new Error(`Package "${name}" is not a gui-chat-protocol plugin (missing TOOL_DEFINITION/execute).`);
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,75 +1,254 @@
 <script setup lang="ts">
-import { ref, watch, onMounted } from "vue";
-import TerminalGrid from "./components/TerminalGrid.vue";
-import SettingsModal from "./components/SettingsModal.vue";
-import { LAYOUTS, isLayout, type Layout } from "./components/gridLayout";
-import type { CwdPreset } from "./components/presets";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
+import Sidebar from "./components/Sidebar.vue";
+import SessionTabBar from "./components/SessionTabBar.vue";
+import TerminalView from "./components/Terminal.vue";
+import GuiPanel from "./components/GuiPanel.vue";
+import ToolsPane from "./components/ToolsPane.vue";
+import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
+import GridView from "./components/GridView.vue";
+import { useSessions, type Filter } from "./composables/useSessions";
+import { useShortcuts } from "./composables/useShortcuts";
+import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
+import { registerChatOpener } from "./composables/useChatLauncher";
+import type { Shortcut } from "./types/shortcuts";
 
-// Grid layout (cell arrangement), chosen in the toolbar and persisted.
-const stored = localStorage.getItem("grid_layout");
-const layout = ref<Layout>(isLayout(stored) ? stored : "2x2");
-watch(layout, (v) => localStorage.setItem("grid_layout", v));
+// View mode: the classic single-terminal view (default) or the multi-terminal
+// grid. Persisted so a reload keeps the chosen view.
+type ViewMode = "single" | "grid";
+const viewMode = ref<ViewMode>(localStorage.getItem("view_mode") === "grid" ? "grid" : "single");
+watch(viewMode, (v) => localStorage.setItem("view_mode", v));
 
-// Server config: the default workspace dir + the user's directory presets.
-const defaultCwd = ref<string | null>(null);
-const home = ref<string | null>(null);
-const presets = ref<CwdPreset[]>([]);
-const showSettings = ref(false);
-const savingSettings = ref(false);
-const settingsError = ref<string | null>(null);
-
-async function loadConfig() {
-  try {
-    const res = await fetch("/api/config");
-    if (!res.ok) return;
-    const c = await res.json();
-    defaultCwd.value = c.cwd ?? null;
-    home.value = c.home ?? null;
-    presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
-  } catch {
-    // grid still works; presets just unavailable
-  }
-}
-onMounted(loadConfig);
-
-async function savePresets(next: CwdPreset[]) {
-  savingSettings.value = true;
-  settingsError.value = null;
-  try {
-    const res = await fetch("/api/config", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwdPresets: next }),
-    });
-    if (!res.ok) throw new Error(`save failed (${res.status})`);
-    presets.value = (await res.json()).cwdPresets ?? [];
-    showSettings.value = false; // close only on success — keep edits otherwise
-  } catch {
-    settingsError.value = "Couldn't save presets. Check the server and try again.";
-  } finally {
-    savingSettings.value = false;
-  }
+// Shared launcher favorites (pinned collections / feeds), backing the toolbar.
+const { shortcuts } = useShortcuts();
+// Toolbar tabs reflect the browse view-state: Chat (overlay closed) | Collections
+// (index open) | a favorite (its detail open).
+const { view: browseView, isOpen: browseOpen } = useCollectionBrowse();
+function favActive(s: Shortcut): boolean {
+  return browseView.value.mode === "detail" && browseView.value.kind === s.kind && browseView.value.slug === s.slug;
 }
 
-function closeSettings() {
-  showSettings.value = false;
-  settingsError.value = null;
+const activeId = ref<string | null>(null);
+const connectKey = ref(0);
+const terminalRef = ref<InstanceType<typeof TerminalView> | null>(null);
+
+// Single source of truth for the session list, owned here (not inside the
+// layout components) so toggling vertical/horizontal — which swaps Sidebar and
+// SessionTabBar via v-if/v-else — never unmounts the store, refetches, or resets
+// the filter. Both layouts render this same shared state.
+const { sessions, loading, error, refresh } = useSessions();
+const filter = ref<Filter>("all");
+
+// Terminal column width (px), set by dragging the splitter between the terminal
+// and the GUI panel; the GUI panel absorbs whatever is left. Persisted across
+// reloads. The terminal's own ResizeObserver refits xterm's cols/rows as this
+// changes, so a drag live-resizes the PTY.
+const MIN_TERMINAL = 320;
+const MIN_GUI = 360;
+const terminalWidth = ref<number>(Number(localStorage.getItem("terminal_width")) || 560);
+
+// Track the viewport so the splitter's max (and aria-valuemax) stays correct and
+// the saved width re-clamps when the window shrinks.
+const viewportWidth = ref(window.innerWidth);
+const maxTerminal = computed(() => Math.max(MIN_TERMINAL, viewportWidth.value - MIN_GUI));
+
+function clampWidth(w: number): number {
+  return Math.max(MIN_TERMINAL, Math.min(w, maxTerminal.value));
+}
+
+function persistWidth() {
+  localStorage.setItem("terminal_width", String(terminalWidth.value));
+}
+
+let stopDrag: (() => void) | null = null;
+function startDrag(e: MouseEvent) {
+  e.preventDefault();
+  const startX = e.clientX;
+  const startW = terminalWidth.value;
+  const onMove = (ev: MouseEvent) => {
+    terminalWidth.value = clampWidth(startW + (ev.clientX - startX));
+  };
+  const onUp = () => {
+    persistWidth();
+    stopDrag?.();
+  };
+  stopDrag = () => {
+    window.removeEventListener("mousemove", onMove);
+    window.removeEventListener("mouseup", onUp);
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+    stopDrag = null;
+  };
+  // Suppress text selection / keep the resize cursor for the whole drag.
+  document.body.style.cursor = "col-resize";
+  document.body.style.userSelect = "none";
+  window.addEventListener("mousemove", onMove);
+  window.addEventListener("mouseup", onUp);
+}
+
+// Keyboard resize for the separator (arrows nudge, Home/End jump to the limits)
+// so the splitter is operable without a mouse.
+function onSplitterKey(e: KeyboardEvent) {
+  const STEP = 16;
+  if (e.key === "ArrowLeft") terminalWidth.value = clampWidth(terminalWidth.value - STEP);
+  else if (e.key === "ArrowRight") terminalWidth.value = clampWidth(terminalWidth.value + STEP);
+  else if (e.key === "Home") terminalWidth.value = MIN_TERMINAL;
+  else if (e.key === "End") terminalWidth.value = maxTerminal.value;
+  else return;
+  e.preventDefault();
+  persistWidth();
+}
+
+function onViewportResize() {
+  viewportWidth.value = window.innerWidth;
+  terminalWidth.value = clampWidth(terminalWidth.value);
+}
+onMounted(() => window.addEventListener("resize", onViewportResize));
+onUnmounted(() => {
+  stopDrag?.();
+  window.removeEventListener("resize", onViewportResize);
+});
+
+// Session-history layout: "vertical" (left Sidebar) or "horizontal" (top
+// SessionTabBar), mirroring mulmoclaude's two history layouts. Persisted across
+// reloads like the tools pane.
+type Layout = "vertical" | "horizontal";
+const layout = ref<Layout>(localStorage.getItem("session_layout") === "horizontal" ? "horizontal" : "vertical");
+watch(layout, (v) => localStorage.setItem("session_layout", v));
+function toggleLayout() {
+  layout.value = layout.value === "vertical" ? "horizontal" : "vertical";
+}
+
+// Tools pane visibility, persisted across reloads (mirrors MulmoClaude's
+// right-sidebar toggle).
+const showTools = ref(localStorage.getItem("tools_pane_visible") === "true");
+watch(showTools, (v) => localStorage.setItem("tools_pane_visible", String(v)));
+function toggleTools() {
+  showTools.value = !showTools.value;
+}
+
+// GUI -> LLM: a plugin view (e.g. a submitted form) calls this with the user's
+// response. Terminal.submitText types it into the PTY and submits it (text + a
+// delayed CR, both pinned to the same socket). Returns whether it was delivered
+// so the caller only locks/persists on success.
+function sendTextMessage(text: string): boolean {
+  return terminalRef.value?.submitText(text) ?? false;
+}
+
+function selectSession(id: string) {
+  activeId.value = id;
+  connectKey.value++;
+}
+
+// A collection action (startChat) spawned a new chat and wants it shown: close the
+// browse overlay (if open) and select the session so the terminal displays it.
+registerChatOpener((id: string) => {
+  browseClose();
+  selectSession(id);
+});
+
+function newSession() {
+  activeId.value = null;
+  connectKey.value++;
+}
+
+// The server reports the live session id (a generated id for new sessions).
+// Adopt it as the active id so it highlights. The sidebar list itself is
+// driven server-side: the server publishes the new session on the "sessions"
+// channel, so no client-side reload is needed here.
+function onSession(id: string) {
+  activeId.value = id;
 }
 </script>
 
 <template>
-  <div class="shell">
+  <GridView v-if="viewMode === 'grid'" @exit="viewMode = 'single'" />
+  <div v-else class="shell">
     <header class="toolbar">
       <span class="toolbar-title">MulmoTerminal</span>
-      <span class="layout-picker" role="group" aria-label="Grid layout">
-        <button v-for="l in LAYOUTS" :key="l" :class="['layout-btn', { active: layout === l }]" :aria-pressed="layout === l" @click="layout = l">
-          {{ l }}
+      <nav class="launcher" aria-label="Views">
+        <button type="button" class="launcher-btn" :class="{ active: !browseOpen }" title="Chat" aria-label="Chat" @click="browseClose">
+          <span class="material-symbols-outlined">chat</span>
         </button>
-      </span>
-      <button class="settings-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
+        <button type="button" class="launcher-btn" title="Grid (multiple terminals)" aria-label="Grid view" @click="viewMode = 'grid'">
+          <span class="material-symbols-outlined">grid_view</span>
+        </button>
+        <button
+          type="button"
+          class="launcher-btn"
+          :class="{ active: browseView.mode === 'index' }"
+          title="Collections"
+          aria-label="Collections"
+          @click="browseGotoIndex('collection')"
+        >
+          <span class="material-symbols-outlined">apps</span>
+        </button>
+        <button
+          v-for="s in shortcuts"
+          :key="`${s.kind}:${s.slug}`"
+          type="button"
+          class="launcher-btn"
+          :class="{ active: favActive(s) }"
+          :title="s.title"
+          :aria-label="s.title"
+          @click="browseGotoDetail(s.kind, s.slug)"
+        >
+          <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
+        </button>
+      </nav>
     </header>
-    <TerminalGrid class="main" :layout="layout" :default-cwd="defaultCwd" :presets="presets" :home="home" />
-    <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
+    <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
+      <Sidebar
+        v-if="layout === 'vertical'"
+        v-model:filter="filter"
+        :sessions="sessions"
+        :loading="loading"
+        :error="error"
+        :active-id="activeId"
+        @select="selectSession"
+        @new="newSession"
+        @toggle-layout="toggleLayout"
+        @refresh="refresh"
+      />
+      <SessionTabBar
+        v-else
+        v-model:filter="filter"
+        :sessions="sessions"
+        :active-id="activeId"
+        @select="selectSession"
+        @new="newSession"
+        @toggle-layout="toggleLayout"
+        @refresh="refresh"
+      />
+      <div class="main">
+        <TerminalView
+          ref="terminalRef"
+          class="terminal-pane"
+          :style="{ flex: `0 0 ${terminalWidth}px` }"
+          :session-id="activeId"
+          :connect-key="connectKey"
+          @session="onSession"
+        />
+        <div
+          class="splitter"
+          role="separator"
+          tabindex="0"
+          aria-orientation="vertical"
+          aria-label="Resize terminal"
+          :aria-valuenow="terminalWidth"
+          :aria-valuemin="MIN_TERMINAL"
+          :aria-valuemax="maxTerminal"
+          title="Drag (or use arrow keys) to resize the terminal"
+          @mousedown="startDrag"
+          @keydown="onSplitterKey"
+        />
+        <GuiPanel :session-id="activeId" :send-text-message="sendTextMessage" :tools-open="showTools" @toggle-tools="toggleTools" />
+        <ToolsPane v-if="showTools" :session-id="activeId" @close="toggleTools" />
+      </div>
+    </div>
+    <!-- Full-screen collection browser; shown when the launcher / an index card / a
+         ref hop opens it (driven by useCollectionBrowse). -->
+    <CollectionsBrowseOverlay />
   </div>
 </template>
 
@@ -82,12 +261,11 @@ function closeSettings() {
   overflow: hidden;
 }
 
-/* Top toolbar with the app title + layout picker + settings. */
+/* Top toolbar with the app title. */
 .toolbar {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 16px;
   height: 40px;
   padding: 0 16px;
   background: #16213e;
@@ -101,50 +279,90 @@ function closeSettings() {
   letter-spacing: 0.02em;
 }
 
-.layout-picker {
-  margin-left: auto;
+/* Toolbar tabs: Chat + Collections + one per pinned favorite. Icon-only. */
+.launcher {
   display: flex;
-  gap: 4px;
+  align-items: center;
+  gap: 3px;
+  margin-left: 16px;
+  min-width: 0;
+  overflow-x: auto;
 }
-.layout-btn {
-  border: 1px solid #2a2a4e;
-  background: #1a1a2e;
-  color: #9aa3c0;
-  font-family: ui-monospace, monospace;
-  font-size: 12px;
-  padding: 3px 8px;
+.launcher-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  height: 30px;
+  width: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #9aa6cc;
   border-radius: 6px;
   cursor: pointer;
 }
-.layout-btn:hover {
-  background: #2a3b66;
-  color: #e6e6f0;
-}
-.layout-btn.active {
-  background: #2a3b66;
+.launcher-btn:hover {
+  background: #26375f;
   color: #fff;
-  border-color: #4a8cff;
 }
-
-.settings-btn {
-  border: 1px solid #2a2a4e;
-  background: #1a1a2e;
-  color: #c7cdf0;
-  font-size: 15px;
+.launcher-btn.active {
+  background: #2f59c0;
+  color: #fff;
+}
+.launcher-btn .material-symbols-outlined {
+  font-size: 19px;
   line-height: 1;
-  padding: 4px 8px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.settings-btn:hover {
-  background: #2a3b66;
-  color: #fff;
 }
 
-/* The grid fills everything under the toolbar. */
-.main {
+.app {
+  display: flex;
   flex: 1;
   min-height: 0;
+  width: 100%;
+  overflow: hidden;
+}
+
+/* Vertical: Sidebar | [ Terminal | GuiPanel ]. */
+.app-vertical {
+  flex-direction: row;
+}
+
+/* Horizontal: SessionTabBar stacked above [ Terminal | GuiPanel ]. */
+.app-horizontal {
+  flex-direction: column;
+}
+
+/* [ Terminal | GuiPanel ] — the unified two-panel view in miniature. Bounded to
+   the leftover height (full viewport in vertical mode, viewport minus the tab
+   bar in horizontal mode) so the panes fill it exactly instead of overflowing
+   under `.app { overflow: hidden }`. Panes size to height:100% of this. */
+.main {
+  display: flex;
+  flex: 1;
   min-width: 0;
+  min-height: 0;
+}
+
+/* Terminal pane: fixed flex-basis (set inline from terminalWidth); the GUI
+   panel beside it absorbs the remaining width. */
+.terminal-pane {
+  min-width: 0;
+}
+
+/* Draggable divider between the terminal and the GUI panel. */
+.splitter {
+  flex: 0 0 5px;
+  cursor: col-resize;
+  background: #16213e;
+  border-left: 1px solid #2a2a4e;
+  border-right: 1px solid #2a2a4e;
+}
+.splitter:hover {
+  background: #2a3b66;
+}
+.splitter:focus-visible {
+  outline: none;
+  background: #4a8cff;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue"
 import { useSessions, type Filter } from "./composables/useSessions";
 import { useShortcuts } from "./composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
+import { registerChatOpener } from "./composables/useChatLauncher";
 import type { Shortcut } from "./types/shortcuts";
 
 // Shared launcher favorites (pinned collections / feeds), backing the toolbar.
@@ -131,6 +132,13 @@ function selectSession(id: string) {
   activeId.value = id;
   connectKey.value++;
 }
+
+// A collection action (startChat) spawned a new chat and wants it shown: close the
+// browse overlay (if open) and select the session so the terminal displays it.
+registerChatOpener((id: string) => {
+  browseClose();
+  selectSession(id);
+});
 
 function newSession() {
   activeId.value = null;

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,20 @@ import SessionTabBar from "./components/SessionTabBar.vue";
 import TerminalView from "./components/Terminal.vue";
 import GuiPanel from "./components/GuiPanel.vue";
 import ToolsPane from "./components/ToolsPane.vue";
+import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
+import { useShortcuts } from "./composables/useShortcuts";
+import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
+import type { Shortcut } from "./types/shortcuts";
+
+// Shared launcher favorites (pinned collections / feeds), backing the toolbar.
+const { shortcuts } = useShortcuts();
+// Toolbar tabs reflect the browse view-state: Chat (overlay closed) | Collections
+// (index open) | a favorite (its detail open).
+const { view: browseView, isOpen: browseOpen } = useCollectionBrowse();
+function favActive(s: Shortcut): boolean {
+  return browseView.value.mode === "detail" && browseView.value.kind === s.kind && browseView.value.slug === s.slug;
+}
 
 const activeId = ref<string | null>(null);
 const connectKey = ref(0);
@@ -137,6 +150,33 @@ function onSession(id: string) {
   <div class="shell">
     <header class="toolbar">
       <span class="toolbar-title">MulmoTerminal</span>
+      <nav class="launcher" aria-label="Views">
+        <button type="button" class="launcher-btn" :class="{ active: !browseOpen }" title="Chat" aria-label="Chat" @click="browseClose">
+          <span class="material-symbols-outlined">chat</span>
+        </button>
+        <button
+          type="button"
+          class="launcher-btn"
+          :class="{ active: browseView.mode === 'index' }"
+          title="Collections"
+          aria-label="Collections"
+          @click="browseGotoIndex('collection')"
+        >
+          <span class="material-symbols-outlined">apps</span>
+        </button>
+        <button
+          v-for="s in shortcuts"
+          :key="`${s.kind}:${s.slug}`"
+          type="button"
+          class="launcher-btn"
+          :class="{ active: favActive(s) }"
+          :title="s.title"
+          :aria-label="s.title"
+          @click="browseGotoDetail(s.kind, s.slug)"
+        >
+          <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
+        </button>
+      </nav>
     </header>
     <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
       <Sidebar
@@ -187,6 +227,9 @@ function onSession(id: string) {
         <ToolsPane v-if="showTools" :session-id="activeId" @close="toggleTools" />
       </div>
     </div>
+    <!-- Full-screen collection browser; shown when the launcher / an index card / a
+         ref hop opens it (driven by useCollectionBrowse). -->
+    <CollectionsBrowseOverlay />
   </div>
 </template>
 
@@ -215,6 +258,42 @@ function onSession(id: string) {
   font-size: 14px;
   color: #e6e6f0;
   letter-spacing: 0.02em;
+}
+
+/* Toolbar tabs: Chat + Collections + one per pinned favorite. Icon-only. */
+.launcher {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 16px;
+  min-width: 0;
+  overflow-x: auto;
+}
+.launcher-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  height: 30px;
+  width: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #9aa6cc;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.launcher-btn:hover {
+  background: #26375f;
+  color: #fff;
+}
+.launcher-btn.active {
+  background: #2f59c0;
+  color: #fff;
+}
+.launcher-btn .material-symbols-outlined {
+  font-size: 19px;
+  line-height: 1;
 }
 
 .app {

--- a/src/collectionShadowCss.ts
+++ b/src/collectionShadowCss.ts
@@ -1,0 +1,32 @@
+// The compiled CSS injected into the collection plugin's Shadow DOM — used by both
+// the chat card (plugins-registry) and the full-screen browse overlay. Combines the
+// package's Tailwind sheet with an icon rule, since:
+//   - the package's `style.css` carries its components' Tailwind classes, but
+//   - the plugin renders ~56 `.material-icons` glyphs whose class rule can't pierce
+//     the shadow root (and `material-icons` isn't loaded), so map both icon classes
+//     to the globally-loaded "Material Symbols Outlined" font (same ligature names).
+// Prepended BEFORE the Tailwind sheet so the components' `text-sm`/`text-lg` size
+// overrides still win; unsized icons fall back to the 24px default here.
+import collectionCss from "@mulmoclaude/collection-plugin/style.css?inline";
+
+const ICON_CSS = `
+.material-icons, .material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga";
+}
+`;
+
+export const collectionShadowCss = ICON_CSS + collectionCss;

--- a/src/components/CollectionCardView.vue
+++ b/src/components/CollectionCardView.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+// MulmoTerminal wrapper around the collection plugin's chat View. It forwards the
+// GUI-panel props to the package View unchanged, and — because the package's record
+// modal teleports to the host-supplied `modalTeleportTarget` — registers THIS card's
+// shadow root (resolved via getRootNode(), since PluginFrame mounts us inside one)
+// as the active teleport target while mounted. Without this, the modal would
+// teleport to <body>, escape the shadow root, and lose the injected plugin styles.
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import type { ToolResult } from "gui-chat-protocol";
+import { plugin } from "@mulmoclaude/collection-plugin/vue";
+import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
+
+defineProps<{
+  selectedResult: ToolResult | null;
+  sendTextMessage?: (text?: string) => void;
+}>();
+const emit = defineEmits<{ updateResult: [result: ToolResult] }>();
+
+const ChatView = plugin.viewComponent;
+
+const rootEl = ref<HTMLElement>();
+let registered: HTMLElement | ShadowRoot | null = null;
+
+onMounted(() => {
+  // Inside PluginFrame's shadow root, getRootNode() returns that ShadowRoot.
+  const root = rootEl.value?.getRootNode();
+  if (root instanceof ShadowRoot) {
+    registered = root;
+    pushCollectionTeleportTarget(root);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (registered) {
+    popCollectionTeleportTarget(registered);
+    registered = null;
+  }
+});
+</script>
+
+<template>
+  <!-- Fill the fixed-height frame (PluginFrame `height` → shadow mount 100%) so the
+       package View's internal h-full layout — table/kanban scroll, custom-view
+       iframe — resolves against a definite height. Inline style, not scoped CSS:
+       this element lives inside the plugin's shadow root, which document-head
+       <style> (where Vue puts scoped CSS) can't reach. -->
+  <div ref="rootEl" :style="{ height: '100%' }">
+    <component
+      :is="ChatView"
+      :selected-result="selectedResult"
+      :send-text-message="sendTextMessage"
+      @update-result="(result: ToolResult) => emit('updateResult', result)"
+    />
+  </div>
+</template>

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+// Full-screen collection browser — the no-router replacement for MulmoClaude's
+// /collections + /collections/:slug pages. Driven by useCollectionBrowse: shows the
+// CollectionsIndexView (index) or a standalone CollectionView (detail), rendered
+// inside a PluginFrame shadow root with the collection styles, exactly like the chat
+// card. Opened by the toolbar launcher / index cards / ref hops via the binding's nav
+// capabilities (collectionUi.ts).
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { CollectionsIndexView, CollectionView } from "@mulmoclaude/collection-plugin/vue";
+import PluginFrame from "./PluginFrame.vue";
+import { collectionShadowCss } from "../collectionShadowCss";
+import { useCollectionBrowse } from "../composables/useCollectionBrowse";
+import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
+
+// Navigation is the toolbar's job (the Chat tab closes this; Collections / favorite
+// tabs switch what it shows), so the overlay itself carries no chrome — it just fills
+// the page below the toolbar.
+const { view, isOpen, close } = useCollectionBrowse();
+
+// Register this overlay's shadow root as the record-modal teleport target while a
+// detail page is open (the package's CollectionRecordModal teleports there; the
+// global binding can't otherwise know which shadow root to use). Same getRootNode()
+// trick as CollectionCardView — the probe sits inside the PluginFrame shadow.
+const probe = ref<HTMLElement>();
+let registered: HTMLElement | ShadowRoot | null = null;
+function unregister(): void {
+  if (registered) {
+    popCollectionTeleportTarget(registered);
+    registered = null;
+  }
+}
+watch(probe, (el) => {
+  unregister();
+  const root = el?.getRootNode();
+  if (root instanceof ShadowRoot) {
+    registered = root;
+    pushCollectionTeleportTarget(root);
+  }
+});
+onBeforeUnmount(() => {
+  unregister();
+  window.removeEventListener("keydown", onKeydown);
+});
+
+// Close on Escape (window-level so it fires without focusing the overlay).
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === "Escape" && isOpen.value) close();
+}
+onMounted(() => window.addEventListener("keydown", onKeydown));
+</script>
+
+<template>
+  <div v-if="isOpen" class="browse-overlay" role="region" aria-label="Collections">
+    <PluginFrame :css="collectionShadowCss" height="100%">
+      <div ref="probe" style="height: 100%">
+        <CollectionsIndexView v-if="view.mode === 'index'" />
+        <CollectionView v-else-if="view.mode === 'detail'" />
+      </div>
+    </PluginFrame>
+  </div>
+</template>
+
+<style scoped>
+/* Fills the page BELOW the toolbar (40px) — the toolbar stays visible + clickable. */
+.browse-overlay {
+  position: fixed;
+  top: 40px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: #0b1020;
+}
+</style>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref, watch, onMounted } from "vue";
+import TerminalGrid from "./TerminalGrid.vue";
+import SettingsModal from "./SettingsModal.vue";
+import { LAYOUTS, isLayout, type Layout } from "./gridLayout";
+import type { CwdPreset } from "./presets";
+
+// The multi-terminal grid view. Toggled with the classic single view from App.vue.
+const emit = defineEmits<{ (e: "exit"): void }>();
+
+// Grid layout (cell arrangement), chosen in the toolbar and persisted.
+const stored = localStorage.getItem("grid_layout");
+const layout = ref<Layout>(isLayout(stored) ? stored : "2x2");
+watch(layout, (v) => localStorage.setItem("grid_layout", v));
+
+// Server config: the default workspace dir + the user's directory presets.
+const defaultCwd = ref<string | null>(null);
+const home = ref<string | null>(null);
+const presets = ref<CwdPreset[]>([]);
+const showSettings = ref(false);
+const savingSettings = ref(false);
+const settingsError = ref<string | null>(null);
+
+async function loadConfig() {
+  try {
+    const res = await fetch("/api/config");
+    if (!res.ok) return;
+    const c = await res.json();
+    defaultCwd.value = c.cwd ?? null;
+    home.value = c.home ?? null;
+    presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
+  } catch {
+    // grid still works; presets just unavailable
+  }
+}
+onMounted(loadConfig);
+
+async function savePresets(next: CwdPreset[]) {
+  savingSettings.value = true;
+  settingsError.value = null;
+  try {
+    const res = await fetch("/api/config", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cwdPresets: next }),
+    });
+    if (!res.ok) throw new Error(`save failed (${res.status})`);
+    presets.value = (await res.json()).cwdPresets ?? [];
+    showSettings.value = false; // close only on success — keep edits otherwise
+  } catch {
+    settingsError.value = "Couldn't save presets. Check the server and try again.";
+  } finally {
+    savingSettings.value = false;
+  }
+}
+
+function closeSettings() {
+  showSettings.value = false;
+  settingsError.value = null;
+}
+</script>
+
+<template>
+  <div class="shell">
+    <header class="toolbar">
+      <span class="toolbar-title">MulmoTerminal</span>
+      <span class="layout-picker" role="group" aria-label="Grid layout">
+        <button v-for="l in LAYOUTS" :key="l" :class="['layout-btn', { active: layout === l }]" :aria-pressed="layout === l" @click="layout = l">
+          {{ l }}
+        </button>
+      </span>
+      <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
+      <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
+    </header>
+    <TerminalGrid class="main" :layout="layout" :default-cwd="defaultCwd" :presets="presets" :home="home" />
+    <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
+  </div>
+</template>
+
+<style scoped>
+.shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+.toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 40px;
+  padding: 0 16px;
+  background: #16213e;
+  border-bottom: 1px solid #2a2a4e;
+}
+.toolbar-title {
+  font-family: system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  color: #e6e6f0;
+  letter-spacing: 0.02em;
+}
+
+.layout-picker {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+.layout-btn {
+  border: 1px solid #2a2a4e;
+  background: #1a1a2e;
+  color: #9aa3c0;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.layout-btn:hover {
+  background: #2a3b66;
+  color: #e6e6f0;
+}
+.layout-btn.active {
+  background: #2a3b66;
+  color: #fff;
+  border-color: #4a8cff;
+}
+
+.tb-btn {
+  border: 1px solid #2a2a4e;
+  background: #1a1a2e;
+  color: #c7cdf0;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.tb-btn:hover {
+  background: #2a3b66;
+  color: #fff;
+}
+
+.main {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+}
+</style>

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -121,7 +121,7 @@ const hasContent = computed(() => results.value.length > 0);
         to render content here.
       </div>
       <template v-for="r in results" :key="r.uuid">
-        <PluginFrame v-if="getPlugin(r.toolName)" class="frame" :css="getPlugin(r.toolName)!.css">
+        <PluginFrame v-if="getPlugin(r.toolName)" class="frame" :css="getPlugin(r.toolName)!.css" :height="getPlugin(r.toolName)!.height">
           <component
             :is="getPlugin(r.toolName)!.viewComponent"
             :selected-result="r"

--- a/src/components/PinToggle.vue
+++ b/src/components/PinToggle.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+// The ★ favorite toggle the collection plugin renders (via the binding's
+// `pinToggle`) on index cards + the view header. Talks to the useShortcuts
+// singleton directly — a parent only supplies the target's identity + cached
+// label/icon. Click/keyboard activation are stopped so toggling never also opens
+// the underlying card.
+//
+// Rendered INSIDE the plugin's shadow root, where scoped CSS (document-head) and the
+// host's Tailwind don't reach — so styling is inline. The star glyph uses the
+// `material-icons` class, which the shadow-injected icon CSS maps to Material Symbols.
+import { computed } from "vue";
+import { useShortcuts } from "../composables/useShortcuts";
+import type { ShortcutKind } from "../types/shortcuts";
+
+const props = defineProps<{
+  kind: ShortcutKind;
+  slug: string;
+  /** Cached at pin time so the launcher renders without re-fetching. */
+  title: string;
+  icon: string;
+}>();
+
+const { isPinned, pin, unpin } = useShortcuts();
+const pinned = computed(() => isPinned(props.kind, props.slug));
+
+function toggle(): void {
+  if (pinned.value) void unpin(props.kind, props.slug);
+  else void pin({ kind: props.kind, slug: props.slug, title: props.title, icon: props.icon });
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    :title="pinned ? 'Unpin from toolbar' : 'Pin to toolbar'"
+    :aria-label="pinned ? 'Unpin from toolbar' : 'Pin to toolbar'"
+    :aria-pressed="pinned"
+    :data-testid="`pin-toggle-${kind}-${slug}`"
+    :style="{
+      height: '32px',
+      width: '32px',
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: '6px',
+      border: 'none',
+      background: 'transparent',
+      cursor: 'pointer',
+      color: pinned ? '#f59e0b' : '#94a3b8',
+    }"
+    @click.stop="toggle"
+    @keydown.enter.stop
+    @keydown.space.stop
+  >
+    <span class="material-icons" style="font-size: 20px">{{ pinned ? "star" : "star_border" }}</span>
+  </button>
+</template>

--- a/src/components/PluginFrame.vue
+++ b/src/components/PluginFrame.vue
@@ -41,7 +41,13 @@ import { ref, onMounted } from "vue";
 // We Teleport the slotted view into the shadow root rather than mounting a separate
 // Vue app, so the plugin component stays in the parent app's context (props,
 // emits, provide/inject, reactivity all work normally).
-const props = defineProps<{ css?: string }>();
+// `height` (optional): a fixed frame height for plugin views that rely on an
+// internal `h-full` (100%) layout rather than flowing at natural content height —
+// e.g. the collection card's table/kanban/custom-view iframe. Mirrors MulmoClaude's
+// StackView, which wraps such tools in a fixed-height box. When set, the host
+// + shadow mount become that height so the plugin's `h-full` chain resolves; when
+// omitted, the frame flows naturally (chart/form/markdown).
+const props = defineProps<{ css?: string; height?: string }>();
 
 const hostEl = ref<HTMLDivElement>();
 const target = ref<HTMLDivElement | null>(null);
@@ -65,13 +71,16 @@ onMounted(() => {
   mount.style.color = "#111827";
   mount.style.borderRadius = "8px";
   mount.style.overflow = "hidden";
+  // Carry the fixed height into the shadow so the plugin's internal h-full resolves
+  // (the host below is sized to props.height too).
+  if (props.height) mount.style.height = "100%";
   shadow.appendChild(mount);
   target.value = mount;
 });
 </script>
 
 <template>
-  <div ref="hostEl" class="plugin-frame-host">
+  <div ref="hostEl" class="plugin-frame-host" :style="height ? { height } : undefined">
     <Teleport v-if="target" :to="target">
       <slot />
     </Teleport>

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { Session, Filter } from "../composables/useSessions";
+import { isUnread, type Session, type Filter } from "../composables/useSessions";
 import FilterChip from "./FilterChip.vue";
 
 // Presentational: list + filter are owned by App.vue and shared with the
@@ -16,9 +16,9 @@ const emit = defineEmits<{
   (e: "update:filter", f: Filter): void;
 }>();
 
-// Same "unread" = `waiting` mapping as the vertical sidebar; the filter applies
-// to the horizontal tabs too.
-const unreadCount = computed(() => props.sessions.filter((s) => s.waiting).length);
+// Same "unread" mapping as the vertical sidebar (waiting, excluding hidden
+// background workers); the filter applies to the horizontal tabs too.
+const unreadCount = computed(() => props.sessions.filter(isUnread).length);
 
 // The horizontal bar never scrolls — tabs flex to share the available width.
 // Cap to the most-recent N (sessions are already sorted by recency) so they
@@ -26,7 +26,7 @@ const unreadCount = computed(() => props.sessions.filter((s) => s.waiting).lengt
 // applies before the cap.
 const MAX_TABS = 8;
 const visibleSessions = computed(() => {
-  const list = props.filter === "unread" ? props.sessions.filter((s) => s.waiting) : props.sessions;
+  const list = props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions;
   return list.slice(0, MAX_TABS);
 });
 </script>
@@ -49,14 +49,14 @@ const visibleSessions = computed(() => {
       <button
         v-for="s in visibleSessions"
         :key="s.id"
-        :class="['tab', { active: s.id === props.activeId, waiting: s.waiting }]"
+        :class="['tab', { active: s.id === props.activeId, waiting: isUnread(s) }]"
         :title="s.title"
         :aria-current="s.id === props.activeId ? 'page' : undefined"
         @click="emit('select', s.id)"
       >
         <span v-if="s.working && !s.waiting && s.id !== props.activeId" class="spinner" title="Claude is working" aria-label="Claude is working" />
         <span class="tab-title">{{ s.title }}</span>
-        <span v-if="s.waiting && s.id !== props.activeId" class="unread-dot" aria-label="Unread" />
+        <span v-if="isUnread(s) && s.id !== props.activeId" class="unread-dot" aria-label="Unread" />
       </button>
     </div>
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { Session, Filter } from "../composables/useSessions";
+import { isUnread, type Session, type Filter } from "../composables/useSessions";
 import FilterChip from "./FilterChip.vue";
 
 // Presentational: the session list + filter are owned by App.vue (a single
@@ -19,11 +19,11 @@ const emit = defineEmits<{
   (e: "update:filter", f: Filter): void;
 }>();
 
-// A background session that is `waiting` for the user's attention is what
-// mulmoclaude calls "unread" — render it bold and let the user filter to just
-// those rows.
-const unreadCount = computed(() => props.sessions.filter((s) => s.waiting).length);
-const visibleSessions = computed(() => (props.filter === "unread" ? props.sessions.filter((s) => s.waiting) : props.sessions));
+// A session that is `waiting` for the user's attention is what mulmoclaude calls
+// "unread" — render it bold and let the user filter to just those rows. Hidden
+// background workers are excluded (see isUnread).
+const unreadCount = computed(() => props.sessions.filter(isUnread).length);
+const visibleSessions = computed(() => (props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions));
 
 function relativeTime(ms: number): string {
   const diff = Date.now() - ms;
@@ -66,7 +66,7 @@ function relativeTime(ms: number): string {
       <li
         v-for="s in visibleSessions"
         :key="s.id"
-        :class="['item', { active: s.id === props.activeId, waiting: s.waiting }]"
+        :class="['item', { active: s.id === props.activeId, waiting: isUnread(s) }]"
         :title="s.title"
         @click="emit('select', s.id)"
       >

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -1,16 +1,15 @@
 // Wire @mulmoclaude/collection-plugin/vue to MulmoTerminal. Imported for its side
 // effect from main.ts so the package's View layer can resolve data before any
 // presentCollection card mounts. MulmoTerminal's counterpart to MulmoClaude's
-// src/composables/collections/uiHost.ts — but a much leaner host (no router, no
-// vue-i18n host instance, no confirm/shortcut/notifier stores), so most write/chat/
-// favorite capabilities are stubs for this read-side increment.
+// src/composables/collections/uiHost.ts — a leaner host (no router, no vue-i18n host
+// instance, no confirm/notifier stores).
 //
-// What's REAL here: fetchCollectionDetail + listCollections, the read-only custom
-// view surface (mintViewToken / fetchViewHtml / buildViewSrcdoc), localeTag, confirm.
-// Write / feeds / favorites / chat are typed failures / no-ops until the interactive
-// (Tier 1) and toolbar (Tier 2) work lands.
+// Wired: data fetch (detail/list), record CRUD, read-only custom views, actions
+// (seed prompt → startChat → a visible chat), favorites (useShortcuts), and
+// state-based navigation (useCollectionBrowse — the toolbar + browse overlay).
+// Still stubbed: feeds, collection/view deletion, feed refresh, and the notifier.
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
-import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionApiResult, CollectionViewToken, CollectionActionResult } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity, ItemMutationResponse } from "@mulmoclaude/collection-plugin";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
 import { useShortcuts } from "./useShortcuts";
@@ -141,8 +140,15 @@ configureCollectionUi({
   // ── collection/feed delete, actions, feeds, view-delete: deferred. ──
   deleteCollection: () => Promise.resolve(mutationFail),
   deleteFeed: () => Promise.resolve(mutationFail),
-  runItemAction: () => Promise.resolve(apiFail),
-  runCollectionAction: () => Promise.resolve(apiFail),
+  // ── actions (kind: "chat"): fetch the seed prompt + role; CollectionView feeds it
+  //    to startChat (→ a visible chat). ──
+  runItemAction: (slug, itemId, actionId) =>
+    apiPost<CollectionActionResult>(
+      `/api/collections/${encodeURIComponent(slug)}/items/${encodeURIComponent(itemId)}/actions/${encodeURIComponent(actionId)}`,
+      {},
+    ),
+  runCollectionAction: (slug, actionId) =>
+    apiPost<CollectionActionResult>(`/api/collections/${encodeURIComponent(slug)}/actions/${encodeURIComponent(actionId)}`, {}),
   refreshCollection: () => Promise.resolve(apiFail),
   deleteView: () => Promise.resolve(mutationFail),
   listFeeds: () => Promise.resolve(apiFail),

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -24,6 +24,7 @@ import {
   browseSetSelectedId,
 } from "./useCollectionBrowse";
 import PinToggle from "../components/PinToggle.vue";
+import { startCollectionChat } from "./useChatLauncher";
 
 // ── Modal teleport target (Shadow DOM) ──
 // PluginFrame mounts each card inside a per-instance shadow root, but
@@ -149,8 +150,12 @@ configureCollectionUi({
   // ── favorites: the shared useShortcuts store over /api/shortcuts. ──
   reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
   unpin: (kind, slug) => useShortcuts().unpin(kind, slug),
-  // ── chat / notifications: no chat-seed hook or notifier in MulmoTerminal. ──
-  startChat: () => {},
+  // ── chat: spawn a new terminal session seeded with the prompt and surface it
+  //    (hidden=false → make it visible). Backs the index "create" button + the
+  //    collection/record action buttons (Repair, etc.). MulmoTerminal has no roles,
+  //    so `role` is ignored. ──
+  startChat: (prompt) => void startCollectionChat(prompt, { hidden: false }),
+  // No notifier in MulmoTerminal.
   notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
 
   // ── Shadow-DOM modal target ── ShadowRoot is a valid Teleport target at runtime

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -1,0 +1,170 @@
+// Wire @mulmoclaude/collection-plugin/vue to MulmoTerminal. Imported for its side
+// effect from main.ts so the package's View layer can resolve data before any
+// presentCollection card mounts. MulmoTerminal's counterpart to MulmoClaude's
+// src/composables/collections/uiHost.ts — a leaner host (no router, no vue-i18n host
+// instance, no confirm/notifier stores).
+//
+// Wired: data fetch (detail/list), record CRUD, read-only custom views, actions
+// (seed prompt → startChat → a visible chat), favorites (useShortcuts), and
+// state-based navigation (useCollectionBrowse — the toolbar + browse overlay).
+// Still stubbed: feeds, collection/view deletion, feed refresh, and the notifier.
+import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionApiResult, CollectionViewToken, CollectionActionResult } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity, ItemMutationResponse } from "@mulmoclaude/collection-plugin";
+import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
+import { useShortcuts } from "./useShortcuts";
+import {
+  browseGotoIndex,
+  browseGotoDetail,
+  browseNavigateToRecord,
+  browseRouteSlug,
+  browseRouteSelectedId,
+  browseIsFeedRoute,
+  browseSetSelectedId,
+} from "./useCollectionBrowse";
+import PinToggle from "../components/PinToggle.vue";
+import { startCollectionChat } from "./useChatLauncher";
+
+// ── Modal teleport target (Shadow DOM) ──
+// PluginFrame mounts each card inside a per-instance shadow root, but
+// configureCollectionUi sets ONE global binding — so it can't statically know which
+// card's shadow root to teleport the record modal into. The card wrapper
+// (CollectionCardView) registers its own shadow root here on mount via
+// element.getRootNode(); the binding returns the top of the stack. Correct for the
+// common single-open-card case; simultaneous modals across multiple cards fall back
+// to the last-mounted card (accepted v1 limitation).
+const teleportStack: Array<HTMLElement | ShadowRoot> = [];
+export function pushCollectionTeleportTarget(target: HTMLElement | ShadowRoot): void {
+  teleportStack.push(target);
+}
+export function popCollectionTeleportTarget(target: HTMLElement | ShadowRoot): void {
+  const i = teleportStack.lastIndexOf(target);
+  if (i >= 0) teleportStack.splice(i, 1);
+}
+
+// Read helper: normalise fetch into the package's CollectionApiResult (the view
+// treats `ok:false` with `status` 404 as not-found, any other failure as a skip).
+async function apiGet<T>(url: string): Promise<CollectionApiResult<T>> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
+  }
+}
+
+async function apiSend<T>(method: "POST" | "PUT", url: string, body: unknown): Promise<CollectionApiResult<T>> {
+  try {
+    const res = await fetch(url, { method, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
+  }
+}
+const apiPost = <T>(url: string, body: unknown) => apiSend<T>("POST", url, body);
+const apiPut = <T>(url: string, body: unknown) => apiSend<T>("PUT", url, body);
+
+// Delete → the view layer's CollectionMutationResult ({ ok } | { ok:false, error }).
+async function apiDelete(url: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(url, { method: "DELETE" });
+    return res.ok ? { ok: true } : { ok: false, error: `HTTP ${res.status}` };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+const itemUrl = (slug: string, itemId: string) => `/api/collections/${encodeURIComponent(slug)}/items/${encodeURIComponent(itemId)}`;
+
+/** Browser URL for a workspace-relative file path, via the raw-file route. */
+function rawFileUrl(value: unknown): string {
+  return `/api/files/raw?path=${encodeURIComponent(String(value))}`;
+}
+
+// Shared "not supported yet" results for the write/feeds/view capabilities.
+const UNSUPPORTED = "not supported in MulmoTerminal yet";
+const apiFail = { ok: false as const, error: UNSUPPORTED, status: 501 };
+const mutationFail = { ok: false as const, error: UNSUPPORTED };
+
+configureCollectionUi({
+  // ── real (read side) ──
+  fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
+  listCollections: () => apiGet<CollectionsListResponse>("/api/collections/list"),
+  confirm: (options) => Promise.resolve(window.confirm(options.message)),
+  // MulmoTerminal has no host i18n; the plugin runs its own. Pick the browser's
+  // base language, defaulting to English.
+  localeTag: () => (navigator.language || "en").split("-")[0],
+  generalRoleId: "general",
+  personalRoleId: "personal",
+  pinToggle: PinToggle,
+
+  // ── asset URLs → the raw workspace-file route (server/backends/files.ts).
+  //    Mirrors MulmoClaude's resolveImageSrc: data: URIs pass through, everything
+  //    else resolves to /api/files/raw?path=<workspace-relative>. fileRoutePath
+  //    (in-app File Explorer nav) stays null — MulmoTerminal has no file explorer. ──
+  imageSrc: (imageData) => (typeof imageData === "string" && imageData.startsWith("data:") ? imageData : rawFileUrl(imageData)),
+  fileAssetUrl: (value) => (typeof value === "string" && value.length > 0 ? rawFileUrl(value) : null),
+  fileRoutePath: () => null,
+
+  // ── navigation: no router — map onto useCollectionBrowse's view-state, which
+  //    drives the full-screen browse overlay + the toolbar launcher. ──
+  routeSlug: () => browseRouteSlug(),
+  routeSelectedId: () => browseRouteSelectedId(),
+  isFeedRoute: () => browseIsFeedRoute(),
+  setSelectedId: (itemId) => browseSetSelectedId(itemId),
+  gotoIndex: (kind) => browseGotoIndex(kind),
+  gotoDetail: (kind, slug) => browseGotoDetail(kind, slug),
+  navigateToRecord: (targetSlug, recordId) => browseNavigateToRecord(targetSlug, recordId),
+
+  // ── custom views (read-only): sandboxed-iframe HTML views over the shared
+  //    workspace. Mint a scoped token, fetch the view HTML, and wrap it in a
+  //    CSP-locked srcdoc with the token injected. ──
+  mintViewToken: (slug, viewId) => apiPost<CollectionViewToken>(`/api/collections/${encodeURIComponent(slug)}/view-token`, { viewId }),
+  fetchViewHtml: async (slug, viewId) => {
+    try {
+      const res = await fetch(`/api/collections/${encodeURIComponent(slug)}/view-file?id=${encodeURIComponent(viewId)}`);
+      return res.ok ? { ok: true as const, html: await res.text() } : { ok: false as const, status: res.status };
+    } catch {
+      return { ok: false as const, status: 0 };
+    }
+  },
+  buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
+
+  // ── record CRUD: create / update (e.g. checking a to-do item) / delete. ──
+  createItem: (slug, record) => apiPost<ItemMutationResponse>(`/api/collections/${encodeURIComponent(slug)}/items`, record),
+  updateItem: (slug, itemId, record) => apiPut<ItemMutationResponse>(itemUrl(slug, itemId), record),
+  deleteItem: (slug, itemId) => apiDelete(itemUrl(slug, itemId)),
+
+  // ── collection/feed delete, actions, feeds, view-delete: deferred. ──
+  deleteCollection: () => Promise.resolve(mutationFail),
+  deleteFeed: () => Promise.resolve(mutationFail),
+  // ── actions (kind: "chat"): fetch the seed prompt + role; CollectionView feeds it
+  //    to startChat (→ a visible chat). ──
+  runItemAction: (slug, itemId, actionId) =>
+    apiPost<CollectionActionResult>(
+      `/api/collections/${encodeURIComponent(slug)}/items/${encodeURIComponent(itemId)}/actions/${encodeURIComponent(actionId)}`,
+      {},
+    ),
+  runCollectionAction: (slug, actionId) =>
+    apiPost<CollectionActionResult>(`/api/collections/${encodeURIComponent(slug)}/actions/${encodeURIComponent(actionId)}`, {}),
+  refreshCollection: () => Promise.resolve(apiFail),
+  deleteView: () => Promise.resolve(mutationFail),
+  listFeeds: () => Promise.resolve(apiFail),
+
+  // ── favorites: the shared useShortcuts store over /api/shortcuts. ──
+  reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
+  unpin: (kind, slug) => useShortcuts().unpin(kind, slug),
+  // ── chat: spawn a new terminal session seeded with the prompt and surface it
+  //    (hidden=false → make it visible). Backs the index "create" button + the
+  //    collection/record action buttons (Repair, etc.). MulmoTerminal has no roles,
+  //    so `role` is ignored. ──
+  startChat: (prompt) => void startCollectionChat(prompt, { hidden: false }),
+  // No notifier in MulmoTerminal.
+  notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
+
+  // ── Shadow-DOM modal target ── ShadowRoot is a valid Teleport target at runtime
+  //    though the declared type is string | HTMLElement.
+  modalTeleportTarget: () => (teleportStack[teleportStack.length - 1] ?? "body") as unknown as string | HTMLElement,
+});

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -9,11 +9,21 @@
 // view surface (mintViewToken / fetchViewHtml / buildViewSrcdoc), localeTag, confirm.
 // Write / feeds / favorites / chat are typed failures / no-ops until the interactive
 // (Tier 1) and toolbar (Tier 2) work lands.
-import { defineComponent } from "vue";
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity } from "@mulmoclaude/collection-plugin";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
+import { useShortcuts } from "./useShortcuts";
+import {
+  browseGotoIndex,
+  browseGotoDetail,
+  browseNavigateToRecord,
+  browseRouteSlug,
+  browseRouteSelectedId,
+  browseIsFeedRoute,
+  browseSetSelectedId,
+} from "./useCollectionBrowse";
+import PinToggle from "../components/PinToggle.vue";
 
 // ── Modal teleport target (Shadow DOM) ──
 // PluginFrame mounts each card inside a per-instance shadow root, but
@@ -64,9 +74,6 @@ const UNSUPPORTED = "not supported in MulmoTerminal yet";
 const apiFail = { ok: false as const, error: UNSUPPORTED, status: 501 };
 const mutationFail = { ok: false as const, error: UNSUPPORTED };
 
-// Renders nothing — MulmoTerminal has no favorites store yet (Tier 2).
-const PinTogglePlaceholder = defineComponent({ name: "CollectionPinTogglePlaceholder", render: () => null });
-
 configureCollectionUi({
   // ── real (read side) ──
   fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
@@ -77,7 +84,7 @@ configureCollectionUi({
   localeTag: () => (navigator.language || "en").split("-")[0],
   generalRoleId: "general",
   personalRoleId: "personal",
-  pinToggle: PinTogglePlaceholder,
+  pinToggle: PinToggle,
 
   // ── asset URLs → the raw workspace-file route (server/backends/files.ts).
   //    Mirrors MulmoClaude's resolveImageSrc: data: URIs pass through, everything
@@ -87,15 +94,15 @@ configureCollectionUi({
   fileAssetUrl: (value) => (typeof value === "string" && value.length > 0 ? rawFileUrl(value) : null),
   fileRoutePath: () => null,
 
-  // ── routing: no router; these are safe no-ops for an embedded card (wired to
-  //    view-state in the Tier 2 toolbar). ──
-  routeSlug: () => undefined,
-  routeSelectedId: () => undefined,
-  isFeedRoute: () => false,
-  setSelectedId: () => {},
-  gotoIndex: () => {},
-  gotoDetail: () => {},
-  navigateToRecord: () => {},
+  // ── navigation: no router — map onto useCollectionBrowse's view-state, which
+  //    drives the full-screen browse overlay + the toolbar launcher. ──
+  routeSlug: () => browseRouteSlug(),
+  routeSelectedId: () => browseRouteSelectedId(),
+  isFeedRoute: () => browseIsFeedRoute(),
+  setSelectedId: (itemId) => browseSetSelectedId(itemId),
+  gotoIndex: (kind) => browseGotoIndex(kind),
+  gotoDetail: (kind, slug) => browseGotoDetail(kind, slug),
+  navigateToRecord: (targetSlug, recordId) => browseNavigateToRecord(targetSlug, recordId),
 
   // ── custom views (read-only): sandboxed-iframe HTML views over the shared
   //    workspace. Mint a scoped token, fetch the view HTML, and wrap it in a
@@ -123,9 +130,10 @@ configureCollectionUi({
   deleteView: () => Promise.resolve(mutationFail),
   listFeeds: () => Promise.resolve(apiFail),
 
-  // ── favorites / chat / notifications: no stores yet (Tier 2). ──
-  reconcileShortcuts: () => Promise.resolve(),
-  unpin: () => Promise.resolve(false),
+  // ── favorites: the shared useShortcuts store over /api/shortcuts. ──
+  reconcileShortcuts: (kind, live) => useShortcuts().reconcile(kind, live),
+  unpin: (kind, slug) => useShortcuts().unpin(kind, slug),
+  // ── chat / notifications: no chat-seed hook or notifier in MulmoTerminal. ──
   startChat: () => {},
   notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
 

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -11,7 +11,7 @@
 // (Tier 1) and toolbar (Tier 2) work lands.
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
-import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity } from "@mulmoclaude/collection-plugin";
+import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity, ItemMutationResponse } from "@mulmoclaude/collection-plugin";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
 import { useShortcuts } from "./useShortcuts";
 import {
@@ -54,15 +54,29 @@ async function apiGet<T>(url: string): Promise<CollectionApiResult<T>> {
   }
 }
 
-async function apiPost<T>(url: string, body: unknown): Promise<CollectionApiResult<T>> {
+async function apiSend<T>(method: "POST" | "PUT", url: string, body: unknown): Promise<CollectionApiResult<T>> {
   try {
-    const res = await fetch(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    const res = await fetch(url, { method, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
     if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
     return { ok: true, data: (await res.json()) as T };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
   }
 }
+const apiPost = <T>(url: string, body: unknown) => apiSend<T>("POST", url, body);
+const apiPut = <T>(url: string, body: unknown) => apiSend<T>("PUT", url, body);
+
+// Delete → the view layer's CollectionMutationResult ({ ok } | { ok:false, error }).
+async function apiDelete(url: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    const res = await fetch(url, { method: "DELETE" });
+    return res.ok ? { ok: true } : { ok: false, error: `HTTP ${res.status}` };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+const itemUrl = (slug: string, itemId: string) => `/api/collections/${encodeURIComponent(slug)}/items/${encodeURIComponent(itemId)}`;
 
 /** Browser URL for a workspace-relative file path, via the raw-file route. */
 function rawFileUrl(value: unknown): string {
@@ -118,10 +132,12 @@ configureCollectionUi({
   },
   buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
 
-  // ── write / feeds / view-delete: deferred to Tier 1. ──
-  createItem: () => Promise.resolve(apiFail),
-  updateItem: () => Promise.resolve(apiFail),
-  deleteItem: () => Promise.resolve(mutationFail),
+  // ── record CRUD: create / update (e.g. checking a to-do item) / delete. ──
+  createItem: (slug, record) => apiPost<ItemMutationResponse>(`/api/collections/${encodeURIComponent(slug)}/items`, record),
+  updateItem: (slug, itemId, record) => apiPut<ItemMutationResponse>(itemUrl(slug, itemId), record),
+  deleteItem: (slug, itemId) => apiDelete(itemUrl(slug, itemId)),
+
+  // ── collection/feed delete, actions, feeds, view-delete: deferred. ──
   deleteCollection: () => Promise.resolve(mutationFail),
   deleteFeed: () => Promise.resolve(mutationFail),
   runItemAction: () => Promise.resolve(apiFail),

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -1,0 +1,135 @@
+// Wire @mulmoclaude/collection-plugin/vue to MulmoTerminal. Imported for its side
+// effect from main.ts so the package's View layer can resolve data before any
+// presentCollection card mounts. MulmoTerminal's counterpart to MulmoClaude's
+// src/composables/collections/uiHost.ts — but a much leaner host (no router, no
+// vue-i18n host instance, no confirm/shortcut/notifier stores), so most write/chat/
+// favorite capabilities are stubs for this read-side increment.
+//
+// What's REAL here: fetchCollectionDetail + listCollections, the read-only custom
+// view surface (mintViewToken / fetchViewHtml / buildViewSrcdoc), localeTag, confirm.
+// Write / feeds / favorites / chat are typed failures / no-ops until the interactive
+// (Tier 1) and toolbar (Tier 2) work lands.
+import { defineComponent } from "vue";
+import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionApiResult, CollectionViewToken } from "@mulmoclaude/collection-plugin/vue";
+import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity } from "@mulmoclaude/collection-plugin";
+import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
+
+// ── Modal teleport target (Shadow DOM) ──
+// PluginFrame mounts each card inside a per-instance shadow root, but
+// configureCollectionUi sets ONE global binding — so it can't statically know which
+// card's shadow root to teleport the record modal into. The card wrapper
+// (CollectionCardView) registers its own shadow root here on mount via
+// element.getRootNode(); the binding returns the top of the stack. Correct for the
+// common single-open-card case; simultaneous modals across multiple cards fall back
+// to the last-mounted card (accepted v1 limitation).
+const teleportStack: Array<HTMLElement | ShadowRoot> = [];
+export function pushCollectionTeleportTarget(target: HTMLElement | ShadowRoot): void {
+  teleportStack.push(target);
+}
+export function popCollectionTeleportTarget(target: HTMLElement | ShadowRoot): void {
+  const i = teleportStack.lastIndexOf(target);
+  if (i >= 0) teleportStack.splice(i, 1);
+}
+
+// Read helper: normalise fetch into the package's CollectionApiResult (the view
+// treats `ok:false` with `status` 404 as not-found, any other failure as a skip).
+async function apiGet<T>(url: string): Promise<CollectionApiResult<T>> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
+  }
+}
+
+async function apiPost<T>(url: string, body: unknown): Promise<CollectionApiResult<T>> {
+  try {
+    const res = await fetch(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
+  }
+}
+
+/** Browser URL for a workspace-relative file path, via the raw-file route. */
+function rawFileUrl(value: unknown): string {
+  return `/api/files/raw?path=${encodeURIComponent(String(value))}`;
+}
+
+// Shared "not supported yet" results for the write/feeds/view capabilities.
+const UNSUPPORTED = "not supported in MulmoTerminal yet";
+const apiFail = { ok: false as const, error: UNSUPPORTED, status: 501 };
+const mutationFail = { ok: false as const, error: UNSUPPORTED };
+
+// Renders nothing — MulmoTerminal has no favorites store yet (Tier 2).
+const PinTogglePlaceholder = defineComponent({ name: "CollectionPinTogglePlaceholder", render: () => null });
+
+configureCollectionUi({
+  // ── real (read side) ──
+  fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
+  listCollections: () => apiGet<CollectionsListResponse>("/api/collections/list"),
+  confirm: (options) => Promise.resolve(window.confirm(options.message)),
+  // MulmoTerminal has no host i18n; the plugin runs its own. Pick the browser's
+  // base language, defaulting to English.
+  localeTag: () => (navigator.language || "en").split("-")[0],
+  generalRoleId: "general",
+  personalRoleId: "personal",
+  pinToggle: PinTogglePlaceholder,
+
+  // ── asset URLs → the raw workspace-file route (server/backends/files.ts).
+  //    Mirrors MulmoClaude's resolveImageSrc: data: URIs pass through, everything
+  //    else resolves to /api/files/raw?path=<workspace-relative>. fileRoutePath
+  //    (in-app File Explorer nav) stays null — MulmoTerminal has no file explorer. ──
+  imageSrc: (imageData) => (typeof imageData === "string" && imageData.startsWith("data:") ? imageData : rawFileUrl(imageData)),
+  fileAssetUrl: (value) => (typeof value === "string" && value.length > 0 ? rawFileUrl(value) : null),
+  fileRoutePath: () => null,
+
+  // ── routing: no router; these are safe no-ops for an embedded card (wired to
+  //    view-state in the Tier 2 toolbar). ──
+  routeSlug: () => undefined,
+  routeSelectedId: () => undefined,
+  isFeedRoute: () => false,
+  setSelectedId: () => {},
+  gotoIndex: () => {},
+  gotoDetail: () => {},
+  navigateToRecord: () => {},
+
+  // ── custom views (read-only): sandboxed-iframe HTML views over the shared
+  //    workspace. Mint a scoped token, fetch the view HTML, and wrap it in a
+  //    CSP-locked srcdoc with the token injected. ──
+  mintViewToken: (slug, viewId) => apiPost<CollectionViewToken>(`/api/collections/${encodeURIComponent(slug)}/view-token`, { viewId }),
+  fetchViewHtml: async (slug, viewId) => {
+    try {
+      const res = await fetch(`/api/collections/${encodeURIComponent(slug)}/view-file?id=${encodeURIComponent(viewId)}`);
+      return res.ok ? { ok: true as const, html: await res.text() } : { ok: false as const, status: res.status };
+    } catch {
+      return { ok: false as const, status: 0 };
+    }
+  },
+  buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
+
+  // ── write / feeds / view-delete: deferred to Tier 1. ──
+  createItem: () => Promise.resolve(apiFail),
+  updateItem: () => Promise.resolve(apiFail),
+  deleteItem: () => Promise.resolve(mutationFail),
+  deleteCollection: () => Promise.resolve(mutationFail),
+  deleteFeed: () => Promise.resolve(mutationFail),
+  runItemAction: () => Promise.resolve(apiFail),
+  runCollectionAction: () => Promise.resolve(apiFail),
+  refreshCollection: () => Promise.resolve(apiFail),
+  deleteView: () => Promise.resolve(mutationFail),
+  listFeeds: () => Promise.resolve(apiFail),
+
+  // ── favorites / chat / notifications: no stores yet (Tier 2). ──
+  reconcileShortcuts: () => Promise.resolve(),
+  unpin: () => Promise.resolve(false),
+  startChat: () => {},
+  notifiedSeverities: () => new Map<string, CollectionNotifySeverity>(),
+
+  // ── Shadow-DOM modal target ── ShadowRoot is a valid Teleport target at runtime
+  //    though the declared type is string | HTMLElement.
+  modalTeleportTarget: () => (teleportStack[teleportStack.length - 1] ?? "body") as unknown as string | HTMLElement,
+});

--- a/src/composables/useChatLauncher.spec.ts
+++ b/src/composables/useChatLauncher.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerChatOpener, startCollectionChat } from "./useChatLauncher";
+
+function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; json: () => unknown }) {
+  const fn = vi.fn((url: string, init?: RequestInit) => {
+    const r = impl(url, init);
+    return Promise.resolve({ ok: r.ok, status: r.ok ? 200 : 500, json: () => Promise.resolve(r.json()) } as Response);
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("startCollectionChat", () => {
+  beforeEach(() => registerChatOpener(vi.fn()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("spawns a chat seeded with the prompt and selects it (hidden=false)", async () => {
+    const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-1" } }) }));
+    const opener = vi.fn();
+    registerChatOpener(opener);
+
+    await startCollectionChat("fix my records", { hidden: false });
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(url).toBe("/api/plugin/spawnBackgroundChat");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(String(init?.body))).toEqual({ message: "fix my records" });
+    expect(opener).toHaveBeenCalledWith("sess-1");
+  });
+
+  it("does NOT select when hidden=true (stays in the sidebar)", async () => {
+    mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-2" } }) }));
+    const opener = vi.fn();
+    registerChatOpener(opener);
+
+    await startCollectionChat("background work", { hidden: true });
+
+    expect(opener).not.toHaveBeenCalled();
+  });
+
+  it("ignores an empty prompt (no spawn)", async () => {
+    const fetchFn = mockFetch(() => ({ ok: true, json: () => ({}) }));
+    await startCollectionChat("   ");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("does not select when the spawn fails", async () => {
+    mockFetch(() => ({ ok: false, json: () => ({}) }));
+    const opener = vi.fn();
+    registerChatOpener(opener);
+
+    await startCollectionChat("oops");
+
+    expect(opener).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -1,0 +1,41 @@
+// Bridges the collection plugin's `startChat` capability to MulmoTerminal's terminal.
+// The plugin calls startChat(prompt, role) from contexts with no active chat (the
+// collections index "create" button, a collection/record action like Repair). We
+// spawn a fresh terminal session seeded with the prompt (the server's
+// spawnBackgroundChat), and — unless `hidden` — select it so the user SEES it in the
+// terminal (App.vue registers the opener, which also closes the browse overlay).
+//
+// `hidden` defaults to false: a collection action's chat is something the user should
+// watch, so we surface it. A future hidden=true caller would leave it in the sidebar.
+
+let openSessionFn: ((sessionId: string) => void) | null = null;
+
+/** App.vue registers how to make a session visible (close the overlay + select it). */
+export function registerChatOpener(fn: (sessionId: string) => void): void {
+  openSessionFn = fn;
+}
+
+/** Spawn a new chat seeded with `prompt`; when not hidden, make it visible. */
+export async function startCollectionChat(prompt: string, opts: { hidden?: boolean } = {}): Promise<void> {
+  const message = prompt.trim();
+  if (!message) return;
+  let chatId: string | undefined;
+  try {
+    const res = await fetch("/api/plugin/spawnBackgroundChat", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ message }),
+    });
+    if (!res.ok) {
+      console.error(`[startChat] spawn failed: HTTP ${res.status}`);
+      return;
+    }
+    const data = (await res.json()) as { jsonData?: { chatId?: unknown } };
+    chatId = typeof data?.jsonData?.chatId === "string" ? data.jsonData.chatId : undefined;
+  } catch (err) {
+    console.error("[startChat] spawn failed", err);
+    return;
+  }
+  // hidden=false → bring the new terminal session into view for the user.
+  if (chatId && !opts.hidden) openSessionFn?.(chatId);
+}

--- a/src/composables/useCollectionBrowse.ts
+++ b/src/composables/useCollectionBrowse.ts
@@ -1,0 +1,66 @@
+// View-state for the full-screen collection browser (the no-router replacement for
+// MulmoClaude's /collections + /collections/:slug routes). The collection plugin's
+// nav capabilities map onto this single reactive store (see collectionUi.ts), and
+// CollectionsBrowseOverlay renders from it: the index, or a standalone CollectionView
+// reading `routeSlug`/`routeSelectedId` back off the same store.
+import { computed, reactive, type ComputedRef } from "vue";
+import type { ShortcutKind } from "../types/shortcuts";
+
+type BrowseView = { mode: "closed" } | { mode: "index"; kind: ShortcutKind } | { mode: "detail"; kind: ShortcutKind; slug: string; selectedId: string | null };
+
+const state = reactive<{ view: BrowseView }>({ view: { mode: "closed" } });
+
+// ── Mutators the binding's nav capabilities call (module-level so the global
+//    binding can reach them without component context) ──
+
+/** Open the index for a kind (collections / feeds). */
+export function browseGotoIndex(kind: ShortcutKind): void {
+  state.view = { mode: "index", kind };
+}
+
+/** Open one collection / feed's detail page. */
+export function browseGotoDetail(kind: ShortcutKind, slug: string): void {
+  state.view = { mode: "detail", kind, slug, selectedId: null };
+}
+
+/** A ref/embed hop into another collection, optionally deep-linking a record. */
+export function browseNavigateToRecord(targetSlug: string, recordId?: string): void {
+  state.view = { mode: "detail", kind: "collection", slug: targetSlug, selectedId: recordId ?? null };
+}
+
+/** Current detail slug (CollectionView reads this in standalone mode), or undefined. */
+export function browseRouteSlug(): string | undefined {
+  return state.view.mode === "detail" ? state.view.slug : undefined;
+}
+
+/** Current deep-linked record id, or undefined. */
+export function browseRouteSelectedId(): string | undefined {
+  return state.view.mode === "detail" ? (state.view.selectedId ?? undefined) : undefined;
+}
+
+/** True when the open page is the feeds (vs collections) family. */
+export function browseIsFeedRoute(): boolean {
+  return state.view.mode !== "closed" && state.view.kind === "feed";
+}
+
+/** Set/clear the open record (the modal deep-link), no history. */
+export function browseSetSelectedId(itemId: string | null): void {
+  if (state.view.mode === "detail") state.view.selectedId = itemId;
+}
+
+/** Close the browser overlay. */
+export function browseClose(): void {
+  state.view = { mode: "closed" };
+}
+
+export function useCollectionBrowse(): {
+  view: ComputedRef<BrowseView>;
+  isOpen: ComputedRef<boolean>;
+  close: () => void;
+} {
+  return {
+    view: computed(() => state.view),
+    isOpen: computed(() => state.view.mode !== "closed"),
+    close: browseClose,
+  };
+}

--- a/src/composables/useSessions.spec.ts
+++ b/src/composables/useSessions.spec.ts
@@ -1,9 +1,23 @@
 import { describe, it, expect } from "vitest";
-import { mergeStable, type Session } from "./useSessions";
+import { mergeStable, isUnread, type Session } from "./useSessions";
 
 function row(id: string): Session {
   return { id, title: id, mtime: 1, working: false, waiting: false };
 }
+
+describe("isUnread", () => {
+  it("is true for a waiting, non-hidden session", () => {
+    expect(isUnread({ ...row("a"), waiting: true })).toBe(true);
+  });
+
+  it("is false when not waiting", () => {
+    expect(isUnread(row("a"))).toBe(false);
+  });
+
+  it("is false for a hidden background worker even when waiting (the bug fix)", () => {
+    expect(isUnread({ ...row("a"), waiting: true, hidden: true })).toBe(false);
+  });
+});
 
 describe("mergeStable", () => {
   it("takes the server order on the first load (empty prev)", () => {

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -7,10 +7,20 @@ export interface Session {
   mtime: number;
   working: boolean;
   waiting: boolean;
+  /** A hidden background worker (spawnBackgroundChat hidden:true) — listed, but
+   *  never treated as unread/bold. */
+  hidden?: boolean;
 }
 
-// "unread" = a session whose `waiting` flag is set (mulmoclaude's unread).
+// "unread" = a session whose `waiting` flag is set, EXCEPT hidden background
+// workers (mulmoclaude's unread, minus the background noise).
 export type Filter = "all" | "unread";
+
+/** A session that should draw the user's attention (bold + Unread filter): waiting
+ *  for input, and not a hidden background worker. */
+export function isUnread(s: Session): boolean {
+  return !!s.waiting && !s.hidden;
+}
 
 // Merge a freshly-fetched list into the displayed one while keeping the order
 // stable. The server sorts by recency (mtime), so a background update — e.g.

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -1,0 +1,165 @@
+// Client store for shared launcher favorites (pinned collections / feeds).
+// Singleton module state shared across every consumer — the toolbar launcher
+// renders them, the index/view PinToggle toggles them, the indexes reconcile stale
+// labels — so they all see one list. Ported from MulmoClaude's useShortcuts, using
+// fetch (MulmoTerminal has no api helper) over GET/PUT /api/shortcuts.
+//
+// Persistence is server-side (`config/shortcuts.json`, shared with MulmoClaude); the
+// client owns the full array and replaces it wholesale. Mutations are optimistic
+// with rollback, and serialized so overlapping replace-all PUTs can't reorder.
+import { computed, ref, type ComputedRef } from "vue";
+import { sameShortcut, type Shortcut, type ShortcutKind } from "../types/shortcuts";
+
+const shortcuts = ref<Shortcut[]>([]);
+const loadError = ref<string | null>(null);
+/** True only after a GET has authoritatively populated `shortcuts`. Until then,
+ *  mutations refuse to persist — a replace-all PUT built on the empty default would
+ *  clobber an existing shortcuts.json. */
+const loaded = ref(false);
+let loadPromise: Promise<void> | null = null;
+
+interface ShortcutsResponse {
+  shortcuts: Shortcut[];
+}
+
+type ApiResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+async function apiGet<T>(url: string): Promise<ApiResult<T>> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function apiPut<T>(url: string, body: unknown): Promise<ApiResult<T>> {
+  try {
+    const res = await fetch(url, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Load once per session (deduped). A FAILED load is not cached so the next call
+ *  retries. */
+async function load(force = false): Promise<void> {
+  if (loadPromise && !force) return loadPromise;
+  loadPromise = (async () => {
+    const result = await apiGet<ShortcutsResponse>("/api/shortcuts");
+    if (!result.ok) {
+      loadError.value = result.error;
+      loadPromise = null; // allow retry
+      return;
+    }
+    loadError.value = null;
+    shortcuts.value = result.data.shortcuts;
+    loaded.value = true;
+  })();
+  return loadPromise;
+}
+
+// Serialize mutations so the replace-all PUTs never overlap (two in-flight saves
+// could land out of order and resurrect a removed pin). Each task awaits load()
+// first so the server list is in the ref before reading `previous`.
+let mutationChain: Promise<unknown> = Promise.resolve();
+function enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const run = mutationChain.then(task, task);
+  mutationChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+/** Persist `next`, rolling back to `previous` on failure. Call only inside enqueue. */
+async function persist(next: Shortcut[], previous: Shortcut[]): Promise<boolean> {
+  shortcuts.value = next;
+  const result = await apiPut<ShortcutsResponse>("/api/shortcuts", { shortcuts: next });
+  if (!result.ok) {
+    shortcuts.value = previous;
+    loadError.value = result.error;
+    console.error("[useShortcuts] persist failed", result.error);
+    return false;
+  }
+  shortcuts.value = result.data.shortcuts; // adopt the server's canonical list
+  loadError.value = null;
+  return true;
+}
+
+function isPinned(kind: ShortcutKind, slug: string): boolean {
+  return shortcuts.value.some((entry) => sameShortcut(entry, { kind, slug }));
+}
+
+function pin(shortcut: Shortcut): Promise<boolean> {
+  return enqueue(async () => {
+    await load();
+    if (!loaded.value) return false;
+    if (isPinned(shortcut.kind, shortcut.slug)) return true;
+    const previous = shortcuts.value;
+    return persist([...previous, shortcut], previous);
+  });
+}
+
+function unpin(kind: ShortcutKind, slug: string): Promise<boolean> {
+  return enqueue(async () => {
+    await load();
+    if (!loaded.value) return false;
+    if (!isPinned(kind, slug)) return true;
+    const previous = shortcuts.value;
+    return persist(
+      previous.filter((entry) => !sameShortcut(entry, { kind, slug })),
+      previous,
+    );
+  });
+}
+
+/** Bulk reconcile one kind against the authoritative {slug,title,icon} list an
+ *  index just fetched: prune dead slugs, refresh stale title/icon, self-heal the
+ *  file. Other kinds untouched. */
+function reconcile(kind: ShortcutKind, live: { slug: string; title: string; icon: string }[]): Promise<void> {
+  return enqueue(async () => {
+    await load();
+    if (!loaded.value) return;
+    const liveBySlug = new Map(live.map((entry) => [entry.slug, entry]));
+    let drifted = false;
+    const next = shortcuts.value.flatMap((entry) => {
+      if (entry.kind !== kind) return [entry];
+      const fresh = liveBySlug.get(entry.slug);
+      if (!fresh) {
+        drifted = true;
+        return [];
+      }
+      if (fresh.title !== entry.title || fresh.icon !== entry.icon) {
+        drifted = true;
+        return [{ ...entry, title: fresh.title, icon: fresh.icon }];
+      }
+      return [entry];
+    });
+    if (drifted) await persist(next, shortcuts.value);
+  });
+}
+
+export function useShortcuts(): {
+  shortcuts: ComputedRef<Shortcut[]>;
+  loadError: ComputedRef<string | null>;
+  load: (force?: boolean) => Promise<void>;
+  isPinned: (kind: ShortcutKind, slug: string) => boolean;
+  pin: (shortcut: Shortcut) => Promise<boolean>;
+  unpin: (kind: ShortcutKind, slug: string) => Promise<boolean>;
+  reconcile: (kind: ShortcutKind, live: { slug: string; title: string; icon: string }[]) => Promise<void>;
+} {
+  void load();
+  return {
+    shortcuts: computed(() => shortcuts.value),
+    loadError: computed(() => loadError.value),
+    load,
+    isPinned,
+    pin,
+    unpin,
+    reconcile,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,9 @@
 import { createApp } from "vue";
 import "material-symbols/outlined.css";
 import "./style.css";
+// Configure the @mulmoclaude/collection-plugin UI binding (data fetch, asset URLs,
+// nav, confirm, modal teleport) once, before any presentCollection card mounts.
+import "./composables/collectionUi";
 import App from "./App.vue";
 
 createApp(App).mount("#app");

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -20,42 +20,12 @@ import CollectionCardView from "./components/CollectionCardView.vue";
 import markdownCss from "@mulmoclaude/markdown-plugin/style.css?inline";
 import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
-import collectionCss from "@mulmoclaude/collection-plugin/style.css?inline";
+import { collectionShadowCss } from "./collectionShadowCss";
 // The @mulmochat-plugin family (generate-image + its peer ui-image) ships incomplete
 // CSS — it assumes a Tailwind host. This is MulmoTerminal's Tailwind layer compiled
 // against those packages' dists (see src/plugin-tailwind.css), supplying the
 // utilities their components use.
 import mulmochatPluginCss from "./plugin-tailwind.css?inline";
-
-// The collection plugin renders ~56 icons via the classic `.material-icons` class
-// (plus a few `.material-symbols-outlined`). MulmoTerminal only loads the Material
-// Symbols font (main.ts), and in any case the global icon class rule can't pierce
-// the plugin's Shadow DOM — so the ligature names ("movie", "search", "arrow_upward")
-// render as plain TEXT. The font's `@font-face` IS global (document-level font-faces
-// apply inside shadow roots), so we just need the class rule inside the shadow:
-// map both icon classes to the loaded "Material Symbols Outlined" font (a superset
-// that supports the same ligature names). Prepended BEFORE the plugin's Tailwind so
-// the components' `text-sm`/`text-lg` size overrides still win (equal specificity →
-// later rule wins); unsized icons fall back to the 24px default here.
-const COLLECTION_ICON_CSS = `
-.material-icons, .material-symbols-outlined {
-  font-family: "Material Symbols Outlined";
-  font-weight: normal;
-  font-style: normal;
-  font-size: 24px;
-  line-height: 1;
-  letter-spacing: normal;
-  text-transform: none;
-  display: inline-block;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-  font-feature-settings: "liga";
-}
-`;
 
 interface Registration {
   toolName: string;
@@ -103,7 +73,7 @@ const PACKAGES: Record<string, Registration> = {
     // The binding (data fetch, asset URLs, nav, confirm) is configured once at
     // startup by importing ./composables/collectionUi in main.ts.
     viewComponent: CollectionCardView as Component,
-    css: COLLECTION_ICON_CSS + collectionCss,
+    css: collectionShadowCss,
     // The collection View uses an internal h-full layout (table/kanban scroll
     // areas, and the custom-view iframe has no intrinsic content height). Give it a
     // fixed frame so that chain resolves — matches MulmoClaude's StackView

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -9,8 +9,11 @@ import config from "../plugins/plugins.json";
 import { plugin as markdownPlugin } from "@mulmoclaude/markdown-plugin/vue";
 import { plugin as formPlugin } from "@mulmoclaude/form-plugin/vue";
 import { plugin as chartPlugin } from "@mulmoclaude/chart-plugin/vue";
+import { plugin as collectionPlugin } from "@mulmoclaude/collection-plugin/vue";
+import { plugin as htmlPlugin } from "@mulmoclaude/html-plugin/vue";
 import GenerateImagePlugin from "@mulmochat-plugin/generate-image/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
+import CollectionCardView from "./components/CollectionCardView.vue";
 // Import each package's compiled stylesheet as a STRING (?inline), not as a global
 // side-effect. GuiPanel injects it into a per-view Shadow DOM (see PluginFrame),
 // which encapsulates the plugin's Tailwind preflight so it can't clobber
@@ -18,6 +21,8 @@ import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import markdownCss from "@mulmoclaude/markdown-plugin/style.css?inline";
 import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
+import htmlCss from "@mulmoclaude/html-plugin/style.css?inline";
+import { collectionShadowCss } from "./collectionShadowCss";
 // The @mulmochat-plugin family (generate-image + its peer ui-image) ships incomplete
 // CSS — it assumes a Tailwind host. This is MulmoTerminal's Tailwind layer compiled
 // against those packages' dists (see src/plugin-tailwind.css), supplying the
@@ -28,6 +33,9 @@ interface Registration {
   toolName: string;
   viewComponent: Component;
   css?: string;
+  // Optional fixed frame height for views that rely on an internal h-full layout
+  // (vs flowing at natural content height). See PluginFrame's `height` prop.
+  height?: string;
 }
 
 // Statically-known packages, keyed by package name; the config gates which load.
@@ -47,6 +55,18 @@ const PACKAGES: Record<string, Registration> = {
     viewComponent: formPlugin.viewComponent as Component,
     css: formCss,
   },
+  "@mulmoclaude/html-plugin": {
+    toolName: htmlPlugin.toolDefinition.name,
+    // The presentHtml View uses useRuntime() (dispatch for loadHtml/saveHtml, pubsub
+    // for live-refresh). scope "html" matches the server's file-change channel
+    // (plugin:html:file:<path>); dispatch targets /api/plugin/presentHtml, where the
+    // server intercepts loadHtml/saveHtml (see server/backends/html.ts).
+    viewComponent: wrapWithPluginRuntime("html", htmlPlugin.toolDefinition.name, htmlPlugin.viewComponent as unknown as Component),
+    css: htmlCss,
+    // The View renders an h-full iframe; give it a definite frame height (like the
+    // collection card) so the page renders, with internal scroll.
+    height: "80vh",
+  },
   "@mulmochat-plugin/generate-image": {
     toolName: GenerateImagePlugin.plugin.toolDefinition.name,
     viewComponent: GenerateImagePlugin.plugin.viewComponent as Component,
@@ -59,6 +79,20 @@ const PACKAGES: Record<string, Registration> = {
     // ?? "en"), so it renders standalone. Its style.css is self-contained Tailwind.
     viewComponent: chartPlugin.viewComponent as Component,
     css: chartCss,
+  },
+  "@mulmoclaude/collection-plugin": {
+    toolName: collectionPlugin.toolDefinition.name,
+    // CollectionCardView wraps the package's chat View so it can register its shadow
+    // root as the record modal's teleport target (see the component + collectionUi).
+    // The binding (data fetch, asset URLs, nav, confirm) is configured once at
+    // startup by importing ./composables/collectionUi in main.ts.
+    viewComponent: CollectionCardView as Component,
+    css: collectionShadowCss,
+    // The collection View uses an internal h-full layout (table/kanban scroll
+    // areas, and the custom-view iframe has no intrinsic content height). Give it a
+    // fixed frame so that chain resolves — matches MulmoClaude's StackView
+    // DEFAULT_PLUGIN_HEIGHT.
+    height: "80vh",
   },
 };
 

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -10,6 +10,7 @@ import { plugin as markdownPlugin } from "@mulmoclaude/markdown-plugin/vue";
 import { plugin as formPlugin } from "@mulmoclaude/form-plugin/vue";
 import { plugin as chartPlugin } from "@mulmoclaude/chart-plugin/vue";
 import { plugin as collectionPlugin } from "@mulmoclaude/collection-plugin/vue";
+import { plugin as htmlPlugin } from "@mulmoclaude/html-plugin/vue";
 import GenerateImagePlugin from "@mulmochat-plugin/generate-image/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import CollectionCardView from "./components/CollectionCardView.vue";
@@ -20,6 +21,7 @@ import CollectionCardView from "./components/CollectionCardView.vue";
 import markdownCss from "@mulmoclaude/markdown-plugin/style.css?inline";
 import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
+import htmlCss from "@mulmoclaude/html-plugin/style.css?inline";
 import { collectionShadowCss } from "./collectionShadowCss";
 // The @mulmochat-plugin family (generate-image + its peer ui-image) ships incomplete
 // CSS — it assumes a Tailwind host. This is MulmoTerminal's Tailwind layer compiled
@@ -52,6 +54,18 @@ const PACKAGES: Record<string, Registration> = {
     toolName: formPlugin.toolDefinition.name,
     viewComponent: formPlugin.viewComponent as Component,
     css: formCss,
+  },
+  "@mulmoclaude/html-plugin": {
+    toolName: htmlPlugin.toolDefinition.name,
+    // The presentHtml View uses useRuntime() (dispatch for loadHtml/saveHtml, pubsub
+    // for live-refresh). scope "html" matches the server's file-change channel
+    // (plugin:html:file:<path>); dispatch targets /api/plugin/presentHtml, where the
+    // server intercepts loadHtml/saveHtml (see server/backends/html.ts).
+    viewComponent: wrapWithPluginRuntime("html", htmlPlugin.toolDefinition.name, htmlPlugin.viewComponent as unknown as Component),
+    css: htmlCss,
+    // The View renders an h-full iframe; give it a definite frame height (like the
+    // collection card) so the page renders, with internal scroll.
+    height: "80vh",
   },
   "@mulmochat-plugin/generate-image": {
     toolName: GenerateImagePlugin.plugin.toolDefinition.name,

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -9,8 +9,10 @@ import config from "../plugins/plugins.json";
 import { plugin as markdownPlugin } from "@mulmoclaude/markdown-plugin/vue";
 import { plugin as formPlugin } from "@mulmoclaude/form-plugin/vue";
 import { plugin as chartPlugin } from "@mulmoclaude/chart-plugin/vue";
+import { plugin as collectionPlugin } from "@mulmoclaude/collection-plugin/vue";
 import GenerateImagePlugin from "@mulmochat-plugin/generate-image/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
+import CollectionCardView from "./components/CollectionCardView.vue";
 // Import each package's compiled stylesheet as a STRING (?inline), not as a global
 // side-effect. GuiPanel injects it into a per-view Shadow DOM (see PluginFrame),
 // which encapsulates the plugin's Tailwind preflight so it can't clobber
@@ -18,16 +20,50 @@ import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import markdownCss from "@mulmoclaude/markdown-plugin/style.css?inline";
 import formCss from "@mulmoclaude/form-plugin/style.css?inline";
 import chartCss from "@mulmoclaude/chart-plugin/style.css?inline";
+import collectionCss from "@mulmoclaude/collection-plugin/style.css?inline";
 // The @mulmochat-plugin family (generate-image + its peer ui-image) ships incomplete
 // CSS — it assumes a Tailwind host. This is MulmoTerminal's Tailwind layer compiled
 // against those packages' dists (see src/plugin-tailwind.css), supplying the
 // utilities their components use.
 import mulmochatPluginCss from "./plugin-tailwind.css?inline";
 
+// The collection plugin renders ~56 icons via the classic `.material-icons` class
+// (plus a few `.material-symbols-outlined`). MulmoTerminal only loads the Material
+// Symbols font (main.ts), and in any case the global icon class rule can't pierce
+// the plugin's Shadow DOM — so the ligature names ("movie", "search", "arrow_upward")
+// render as plain TEXT. The font's `@font-face` IS global (document-level font-faces
+// apply inside shadow roots), so we just need the class rule inside the shadow:
+// map both icon classes to the loaded "Material Symbols Outlined" font (a superset
+// that supports the same ligature names). Prepended BEFORE the plugin's Tailwind so
+// the components' `text-sm`/`text-lg` size overrides still win (equal specificity →
+// later rule wins); unsized icons fall back to the 24px default here.
+const COLLECTION_ICON_CSS = `
+.material-icons, .material-symbols-outlined {
+  font-family: "Material Symbols Outlined";
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "liga";
+}
+`;
+
 interface Registration {
   toolName: string;
   viewComponent: Component;
   css?: string;
+  // Optional fixed frame height for views that rely on an internal h-full layout
+  // (vs flowing at natural content height). See PluginFrame's `height` prop.
+  height?: string;
 }
 
 // Statically-known packages, keyed by package name; the config gates which load.
@@ -59,6 +95,20 @@ const PACKAGES: Record<string, Registration> = {
     // ?? "en"), so it renders standalone. Its style.css is self-contained Tailwind.
     viewComponent: chartPlugin.viewComponent as Component,
     css: chartCss,
+  },
+  "@mulmoclaude/collection-plugin": {
+    toolName: collectionPlugin.toolDefinition.name,
+    // CollectionCardView wraps the package's chat View so it can register its shadow
+    // root as the record modal's teleport target (see the component + collectionUi).
+    // The binding (data fetch, asset URLs, nav, confirm) is configured once at
+    // startup by importing ./composables/collectionUi in main.ts.
+    viewComponent: CollectionCardView as Component,
+    css: COLLECTION_ICON_CSS + collectionCss,
+    // The collection View uses an internal h-full layout (table/kanban scroll
+    // areas, and the custom-view iframe has no intrinsic content height). Give it a
+    // fixed frame so that chain resolves — matches MulmoClaude's StackView
+    // DEFAULT_PLUGIN_HEIGHT.
+    height: "80vh",
   },
 };
 

--- a/src/types/shortcuts.ts
+++ b/src/types/shortcuts.ts
@@ -1,0 +1,24 @@
+// Launcher shortcut (pinned collection / feed) — browser-safe shape shared by the
+// shortcuts store, PinToggle, and the toolbar launcher. The on-disk format
+// (`{ shortcuts: Shortcut[] }`) is written/read by the server (server/backends/
+// shortcuts.ts) and is the SAME file + format MulmoClaude uses — keep this type in
+// sync with mulmoclaude/src/types/shortcuts.ts.
+
+export const SHORTCUT_KINDS = ["collection", "feed"] as const;
+export type ShortcutKind = (typeof SHORTCUT_KINDS)[number];
+
+export interface Shortcut {
+  /** Which route family — drives the launcher's navigation target. */
+  kind: ShortcutKind;
+  /** The target collection / feed slug. */
+  slug: string;
+  /** Cached display label (user-named) — refreshed on reconcile. */
+  title: string;
+  /** Cached material-symbols glyph — refreshed on reconcile. */
+  icon: string;
+}
+
+/** True when two shortcuts target the same thing (the dedupe key). */
+export function sameShortcut(left: Pick<Shortcut, "kind" | "slug">, right: Pick<Shortcut, "kind" | "slug">): boolean {
+  return left.kind === right.kind && left.slug === right.slug;
+}

--- a/src/utils/customViewSrcdoc.spec.ts
+++ b/src/utils/customViewSrcdoc.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { buildCustomViewSrcdoc } from "./customViewSrcdoc";
+
+const boot = { slug: "watchlist", token: "tok", dataUrl: "/api/collections/watchlist/view-data", origin: "http://localhost:5173" };
+
+describe("buildCustomViewSrcdoc", () => {
+  it("injects __MC_VIEW with an absolutised dataUrl", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    expect(out).toContain("window.__MC_VIEW=");
+    expect(out).toContain('"dataUrl":"http://localhost:5173/api/collections/watchlist/view-data"');
+    expect(out).toContain('"token":"tok"');
+    expect(out).toContain('"slug":"watchlist"');
+  });
+
+  it("locks connect-src to the server origin only", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    const csp = /content="([^"]*)"/.exec(out)?.[1] ?? "";
+    expect(csp).toContain("connect-src http://localhost:5173");
+    expect(csp).toContain("default-src 'none'");
+    // connect-src must not be widened to https: (that's the exfil channel that matters).
+    expect(csp).not.toMatch(/connect-src[^;]*https:/);
+  });
+
+  it("allows https: images/media (matches MulmoClaude's documented tradeoff)", () => {
+    const csp = /content="([^"]*)"/.exec(buildCustomViewSrcdoc("<head></head>", boot))?.[1] ?? "";
+    expect(csp).toMatch(/img-src[^;]*https:/);
+    expect(csp).toMatch(/media-src[^;]*https:/);
+  });
+
+  it("injects into an existing <head>", () => {
+    const out = buildCustomViewSrcdoc('<head data-x="1"><title>t</title></head>', boot);
+    expect(out).toMatch(/<head data-x="1"><meta http-equiv="Content-Security-Policy"/);
+  });
+
+  it("wraps a fragment with no <head>", () => {
+    const out = buildCustomViewSrcdoc("<div>hi</div>", boot);
+    expect(out.startsWith("<!DOCTYPE html><html><head>")).toBe(true);
+    expect(out).toContain("<body><div>hi</div></body>");
+  });
+
+  it("escapes < in the injected JSON so a hostile value can't break out of <script>", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", { ...boot, token: "</script><script>alert(1)" });
+    expect(out).not.toContain("</script><script>alert(1)");
+    expect(out).toContain("\\u003c/script>\\u003cscript>alert(1)");
+  });
+});

--- a/src/utils/customViewSrcdoc.ts
+++ b/src/utils/customViewSrcdoc.ts
@@ -1,0 +1,67 @@
+// Build the sandboxed-iframe `srcdoc` for a custom collection view — MulmoTerminal's
+// port of MulmoClaude's customViewSrcdoc.ts + the buildCustomViewCsp policy.
+//
+// Injected at the START of <head> so the bootstrap runs before the view's own
+// scripts: (1) a CSP <meta> locking connect-src to the server origin (the view may
+// fetch its data endpoint but no third party), and (2)
+// `window.__MC_VIEW = { slug, token, dataUrl }` — the scoped token + absolute data
+// URL the view reads.
+
+// Curated CDN allowlist the LLM commonly pulls charting/util libs + fonts from.
+const ALLOWED_CDNS: readonly string[] = [
+  "https://cdn.jsdelivr.net",
+  "https://unpkg.com",
+  "https://cdnjs.cloudflare.com",
+  "https://fonts.googleapis.com",
+  "https://fonts.gstatic.com",
+  "https://cdn.plot.ly",
+];
+
+// CSP for a custom view. connect-src = the server origin ONLY (the exfiltration
+// channel that matters — fetch/XHR/WebSocket can reach only the view's own data
+// endpoint). script/style/font reuse the curated CDN allowlist; img/media also allow
+// any https: so feed records' external thumbnails / audio render (a one-way,
+// GET-only, response-unreadable channel — accepted, same as MulmoClaude). `origin`
+// MUST be explicit: the sandboxed iframe's origin is opaque, so `'self'` never matches.
+function buildCustomViewCsp(origin: string): string {
+  const cdns = ALLOWED_CDNS.join(" ");
+  return [
+    "default-src 'none'",
+    `script-src 'unsafe-inline' ${cdns}`,
+    `style-src 'unsafe-inline' ${cdns}`,
+    `font-src ${cdns}`,
+    `img-src ${origin} ${cdns} data: blob: https:`,
+    `media-src ${origin} https: data: blob:`,
+    `connect-src ${origin}`,
+  ].join("; ");
+}
+
+export interface CustomViewBootstrap {
+  slug: string;
+  /** Scoped capability token (Authorization: Bearer <token>). */
+  token: string;
+  /** Data endpoint URL; absolutised against `origin` when root-relative (the iframe
+   *  is `about:srcdoc`, so a relative `/api/...` would not resolve). */
+  dataUrl: string;
+  /** Explicit server origin — for the CSP and the absolute dataUrl. */
+  origin: string;
+}
+
+function absoluteDataUrl(dataUrl: string, origin: string): string {
+  return dataUrl.startsWith("/") ? `${origin}${dataUrl}` : dataUrl;
+}
+
+export function buildCustomViewSrcdoc(html: string, boot: CustomViewBootstrap): string {
+  const cspMeta = `<meta http-equiv="Content-Security-Policy" content="${buildCustomViewCsp(boot.origin)}">`;
+  // `<`-escape the JSON so a hostile token/slug value can't break out of <script>.
+  const json = JSON.stringify({
+    slug: boot.slug,
+    token: boot.token,
+    dataUrl: absoluteDataUrl(boot.dataUrl, boot.origin),
+  }).replace(/</g, "\\u003c");
+  const injection = `${cspMeta}<script>window.__MC_VIEW=${json};</script>`;
+  if (/<head\b[^>]*>/i.test(html)) {
+    return html.replace(/(<head\b[^>]*>)/i, `$1${injection}`);
+  }
+  return `<!DOCTYPE html><html><head>${injection}</head><body>${html}</body></html>`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,18 @@ export default defineConfig({
   // a global side-effect, so the app's styles are untouched.
   plugins: [vue(), tailwindcss()],
   server: {
+    // Disable Vite's dev CORS middleware. The app is same-origin in dev (the page
+    // and the proxied `/api` both live on :5173), so it needs no CORS headers from
+    // Vite. The one cross-origin consumer is a custom collection view: it renders in
+    // a sandboxed (opaque-origin) iframe whose fetch to
+    // `/api/collections/:slug/view-data` is cross-origin and preflighted. With Vite's
+    // CORS enabled, Vite answers that OPTIONS itself WITHOUT an
+    // `Access-Control-Allow-Origin` (it rejects the "null" origin) and the preflight
+    // fails before reaching the backend. Disabling it lets the preflight (and the
+    // request) flow through the proxy to Express, which sets the correct CORS headers
+    // (viewDataCors in server/backends/collections.ts). Production has no Vite proxy
+    // — the iframe hits Express directly — so this is dev-only. Matches MulmoClaude.
+    cors: false,
     proxy: {
       // socket.io pub/sub (sidebar activity). Must precede the "/ws" rule.
       "/ws/pubsub": {
@@ -21,6 +33,13 @@ export default defineConfig({
       },
       "/api": {
         target: "http://localhost:3456",
+        changeOrigin: true,
+      },
+      // presentHtml page serving (the View's iframe src). Without this, the dev
+      // Vite catch-all returns index.html instead of the HTML artifact.
+      "/artifacts": {
+        target: "http://localhost:3456",
+        changeOrigin: true,
       },
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,18 @@ export default defineConfig({
   // a global side-effect, so the app's styles are untouched.
   plugins: [vue(), tailwindcss()],
   server: {
+    // Disable Vite's dev CORS middleware. The app is same-origin in dev (the page
+    // and the proxied `/api` both live on :5173), so it needs no CORS headers from
+    // Vite. The one cross-origin consumer is a custom collection view: it renders in
+    // a sandboxed (opaque-origin) iframe whose fetch to
+    // `/api/collections/:slug/view-data` is cross-origin and preflighted. With Vite's
+    // CORS enabled, Vite answers that OPTIONS itself WITHOUT an
+    // `Access-Control-Allow-Origin` (it rejects the "null" origin) and the preflight
+    // fails before reaching the backend. Disabling it lets the preflight (and the
+    // request) flow through the proxy to Express, which sets the correct CORS headers
+    // (viewDataCors in server/backends/collections.ts). Production has no Vite proxy
+    // — the iframe hits Express directly — so this is dev-only. Matches MulmoClaude.
+    cors: false,
     proxy: {
       // socket.io pub/sub (sidebar activity). Must precede the "/ws" rule.
       "/ws/pubsub": {
@@ -21,6 +33,7 @@ export default defineConfig({
       },
       "/api": {
         target: "http://localhost:3456",
+        changeOrigin: true,
       },
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig({
         target: "http://localhost:3456",
         changeOrigin: true,
       },
+      // presentHtml page serving (the View's iframe src). Without this, the dev
+      // Vite catch-all returns index.html instead of the HTML artifact.
+      "/artifacts": {
+        target: "http://localhost:3456",
+        changeOrigin: true,
+      },
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,6 +565,11 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/form-plugin/-/form-plugin-0.1.1.tgz#54825cc7ecb3eded0d9d6d7bc0c04214bf7c78da"
   integrity sha512-gTXROs5Qs98GVPb5f8MM6EtlDXHFcLeeNMfiUnG/A05rMQobmiTw9QoEGVROIJlFBbFsD7s6DAsrBBx1KDvFBA==
 
+"@mulmoclaude/html-plugin@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/html-plugin/-/html-plugin-0.2.2.tgz#5cf97960ab31d4a0f9551a1e8d3bb7d3633cc599"
+  integrity sha512-Tp3451o/3uQQxoFcYRQLOfom4sG+AC4XERVyV/CdNJFYj1tgagSkhwVqKdQJnc/Xt1oirrAV5E6qyE4CgTOwlA==
+
 "@mulmoclaude/markdown-plugin@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@mulmoclaude/markdown-plugin/-/markdown-plugin-0.1.4.tgz#767684c558686248691148837e0a6107e8d580e6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,36 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@intlify/core-base@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.4.6.tgz#7402cd6f7e1c813e7a8370afa3654d2d9034783a"
+  integrity sha512-EOeHO95XESK9IFHgHeZXunsM/WBAoCA0DlaWODvx14vKmetAuS97t+l6Xe9hTUqntPpF93vtVSjjUDafw3wXMw==
+  dependencies:
+    "@intlify/devtools-types" "11.4.6"
+    "@intlify/message-compiler" "11.4.6"
+    "@intlify/shared" "11.4.6"
+
+"@intlify/devtools-types@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-types/-/devtools-types-11.4.6.tgz#2280698191c7a238f7ce9fe69cafba6280277b40"
+  integrity sha512-wowQPpNem56b2d43IJmqbrzG2FeBKe5f/kUGlpNuBmXs6OSqncF8m1+1lxHuW8ISZJF0ma2RkW3iLkw0g0G4VA==
+  dependencies:
+    "@intlify/core-base" "11.4.6"
+    "@intlify/shared" "11.4.6"
+
+"@intlify/message-compiler@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.4.6.tgz#4afde994de403f2e2d9569cd52eae7707f5d3008"
+  integrity sha512-5nj3jULqeTAC1WovwMs1LQWgatTa2pM/rXN9T3XW8rdOtXW9ZF6/GLSNFTKDQmPLwclhPdgUWLJ/4w3fMeeC/Q==
+  dependencies:
+    "@intlify/shared" "11.4.6"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.4.6.tgz#06431217c1ea12f91b303f026f485eb0a4cebe6a"
+  integrity sha512-m1p1HHAMLhqSpTRH7VnXdrN0CQ4y+9vunFkpLkbD8soIuBsnQdawZXqMCgvwI2UVF9Ww7sVaw7g9tV2VO7shoA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -521,6 +551,14 @@
   version "0.1.1"
   resolved "https://registry.npmjs.org/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.1.tgz#bef604d53e82a1d406a65ddde3e6c3cdff9cc6e3"
   integrity sha512-Hv+FyTSiPWsF+eaxmBQ0Le8tu4FLnFMvmMQ+c6/MmM1gvHe49SrHvBcEYvSQb9bkNghJRsgSV0tADVjPFPwZMA==
+
+"@mulmoclaude/collection-plugin@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.5.1.tgz#848fa5639dcba569e8570833dee85484106e3cb0"
+  integrity sha512-krK2hHe1GLaVPoKr6MzyZNRGeWVuLT8DrJklGdNpiLzhk8UfwTgS/OE8kd938B1g5yqqANNpkF2G2vaoZ//Lwg==
+  dependencies:
+    vuedraggable "^4.1.0"
+    zod "^4.4.3"
 
 "@mulmoclaude/form-plugin@^0.1.1":
   version "0.1.1"
@@ -1196,6 +1234,11 @@
   dependencies:
     "@vue/compiler-dom" "3.5.38"
     "@vue/shared" "3.5.38"
+
+"@vue/devtools-api@^6.5.0":
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
 
 "@vue/language-core@3.3.5":
   version "3.3.5"
@@ -3754,7 +3797,12 @@ socks@^2.8.3:
     ip-address "^10.1.1"
     smart-buffer "^4.2.0"
 
-source-map-js@^1.2.1:
+sortablejs@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
+  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
+
+source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -4133,6 +4181,16 @@ vue-eslint-parser@^10.4.1:
     esquery "^1.6.0"
     semver "^7.6.3"
 
+vue-i18n@^11.4.4:
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-11.4.6.tgz#6ce49dc15b128b5de6e3813cf06f7de5410d9ae3"
+  integrity sha512-l0gE7Rfy0phCa5ChKYkOq543Wgd39BCK6hkktfr1Ed4D99oRkgPK9ffShASZdeC8OJxGfdWmpYoAaAH6iLEuIg==
+  dependencies:
+    "@intlify/core-base" "11.4.6"
+    "@intlify/devtools-types" "11.4.6"
+    "@intlify/shared" "11.4.6"
+    "@vue/devtools-api" "^6.5.0"
+
 vue-tsc@^3.2.8:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-3.3.5.tgz#080783e24add23cf860647e905a7f0506c70c21e"
@@ -4151,6 +4209,13 @@ vue@^3.5.34:
     "@vue/runtime-dom" "3.5.38"
     "@vue/server-renderer" "3.5.38"
     "@vue/shared" "3.5.38"
+
+vuedraggable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-4.1.0.tgz#edece68adb8a4d9e06accff9dfc9040e66852270"
+  integrity sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==
+  dependencies:
+    sortablejs "1.14.0"
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"
@@ -4355,7 +4420,7 @@ zod@^3.24.1:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-"zod@^3.25 || ^4.0":
+"zod@^3.25 || ^4.0", zod@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,36 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@intlify/core-base@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.4.6.tgz#7402cd6f7e1c813e7a8370afa3654d2d9034783a"
+  integrity sha512-EOeHO95XESK9IFHgHeZXunsM/WBAoCA0DlaWODvx14vKmetAuS97t+l6Xe9hTUqntPpF93vtVSjjUDafw3wXMw==
+  dependencies:
+    "@intlify/devtools-types" "11.4.6"
+    "@intlify/message-compiler" "11.4.6"
+    "@intlify/shared" "11.4.6"
+
+"@intlify/devtools-types@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-types/-/devtools-types-11.4.6.tgz#2280698191c7a238f7ce9fe69cafba6280277b40"
+  integrity sha512-wowQPpNem56b2d43IJmqbrzG2FeBKe5f/kUGlpNuBmXs6OSqncF8m1+1lxHuW8ISZJF0ma2RkW3iLkw0g0G4VA==
+  dependencies:
+    "@intlify/core-base" "11.4.6"
+    "@intlify/shared" "11.4.6"
+
+"@intlify/message-compiler@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.4.6.tgz#4afde994de403f2e2d9569cd52eae7707f5d3008"
+  integrity sha512-5nj3jULqeTAC1WovwMs1LQWgatTa2pM/rXN9T3XW8rdOtXW9ZF6/GLSNFTKDQmPLwclhPdgUWLJ/4w3fMeeC/Q==
+  dependencies:
+    "@intlify/shared" "11.4.6"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@11.4.6":
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.4.6.tgz#06431217c1ea12f91b303f026f485eb0a4cebe6a"
+  integrity sha512-m1p1HHAMLhqSpTRH7VnXdrN0CQ4y+9vunFkpLkbD8soIuBsnQdawZXqMCgvwI2UVF9Ww7sVaw7g9tV2VO7shoA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -522,10 +552,23 @@
   resolved "https://registry.npmjs.org/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.1.tgz#bef604d53e82a1d406a65ddde3e6c3cdff9cc6e3"
   integrity sha512-Hv+FyTSiPWsF+eaxmBQ0Le8tu4FLnFMvmMQ+c6/MmM1gvHe49SrHvBcEYvSQb9bkNghJRsgSV0tADVjPFPwZMA==
 
+"@mulmoclaude/collection-plugin@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.5.1.tgz#848fa5639dcba569e8570833dee85484106e3cb0"
+  integrity sha512-krK2hHe1GLaVPoKr6MzyZNRGeWVuLT8DrJklGdNpiLzhk8UfwTgS/OE8kd938B1g5yqqANNpkF2G2vaoZ//Lwg==
+  dependencies:
+    vuedraggable "^4.1.0"
+    zod "^4.4.3"
+
 "@mulmoclaude/form-plugin@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@mulmoclaude/form-plugin/-/form-plugin-0.1.1.tgz#54825cc7ecb3eded0d9d6d7bc0c04214bf7c78da"
   integrity sha512-gTXROs5Qs98GVPb5f8MM6EtlDXHFcLeeNMfiUnG/A05rMQobmiTw9QoEGVROIJlFBbFsD7s6DAsrBBx1KDvFBA==
+
+"@mulmoclaude/html-plugin@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/html-plugin/-/html-plugin-0.2.2.tgz#5cf97960ab31d4a0f9551a1e8d3bb7d3633cc599"
+  integrity sha512-Tp3451o/3uQQxoFcYRQLOfom4sG+AC4XERVyV/CdNJFYj1tgagSkhwVqKdQJnc/Xt1oirrAV5E6qyE4CgTOwlA==
 
 "@mulmoclaude/markdown-plugin@^0.1.4":
   version "0.1.4"
@@ -1196,6 +1239,11 @@
   dependencies:
     "@vue/compiler-dom" "3.5.38"
     "@vue/shared" "3.5.38"
+
+"@vue/devtools-api@^6.5.0":
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
 
 "@vue/language-core@3.3.5":
   version "3.3.5"
@@ -3754,7 +3802,12 @@ socks@^2.8.3:
     ip-address "^10.1.1"
     smart-buffer "^4.2.0"
 
-source-map-js@^1.2.1:
+sortablejs@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.14.0.tgz#6d2e17ccbdb25f464734df621d4f35d4ab35b3d8"
+  integrity sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==
+
+source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -4133,6 +4186,16 @@ vue-eslint-parser@^10.4.1:
     esquery "^1.6.0"
     semver "^7.6.3"
 
+vue-i18n@^11.4.4:
+  version "11.4.6"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-11.4.6.tgz#6ce49dc15b128b5de6e3813cf06f7de5410d9ae3"
+  integrity sha512-l0gE7Rfy0phCa5ChKYkOq543Wgd39BCK6hkktfr1Ed4D99oRkgPK9ffShASZdeC8OJxGfdWmpYoAaAH6iLEuIg==
+  dependencies:
+    "@intlify/core-base" "11.4.6"
+    "@intlify/devtools-types" "11.4.6"
+    "@intlify/shared" "11.4.6"
+    "@vue/devtools-api" "^6.5.0"
+
 vue-tsc@^3.2.8:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-3.3.5.tgz#080783e24add23cf860647e905a7f0506c70c21e"
@@ -4151,6 +4214,13 @@ vue@^3.5.34:
     "@vue/runtime-dom" "3.5.38"
     "@vue/server-renderer" "3.5.38"
     "@vue/shared" "3.5.38"
+
+vuedraggable@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-4.1.0.tgz#edece68adb8a4d9e06accff9dfc9040e66852270"
+  integrity sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==
+  dependencies:
+    sortablejs "1.14.0"
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"
@@ -4355,7 +4425,7 @@ zod@^3.24.1:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-"zod@^3.25 || ^4.0":
+"zod@^3.25 || ^4.0", zod@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary

Merges **`main`** into `dev_tool` so the grid line picks up main's recent work
(collections plugin, files/html/shortcuts/viewToken backends, launcher, etc.)
**without losing the grid**.

Only 3 files conflicted — `package.json` (auto-merged), `server/index.ts` (just
imports), and `src/App.vue`.

### Single ⇄ Grid as separate files
- `src/App.vue` = **main's single view, kept intact**, with a small switch: a
  `grid_view` launcher button enters grid mode; `viewMode` is persisted.
- The grid app moved to **`src/components/GridView.vue`** (its own file), with a
  "▢ Single" button to switch back. Default view is **single**.

### Reduce future conflicts (per request: split files)
- Frontend grid code is already isolated (`GridView`, `TerminalGrid`,
  `TerminalCell`, `gridLayout`, `cwdDisplay`, `presets`, `SettingsModal`); App.vue
  only carries the minimal switch.
- Extracted the `/api/config` (workspace + presets) routes into
  **`server/config-routes.ts`** (`mountConfigRoutes(app, CLAUDE_CWD)`), matching
  main's `mount*Routes` pattern, so index.ts stays lean.

## Verification

- `lint` / `typecheck` / `typecheck:server` / `test` (**143**, 17 files) / `build` ✅.
- Puppeteer: default = single (chat/collections launcher); clicking Grid → 2x2 grid
  (4 cells, `view_mode=grid` persisted); clicking Single → back. `/api/config`
  GET/POST work after the extraction.

base: `dev_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)