### PR TITLE
feat: seed helps + preset skills at boot (@mulmoclaude/workspace-setup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@mulmoclaude/form-plugin": "^0.1.1",
     "@mulmoclaude/html-plugin": "^0.2.2",
     "@mulmoclaude/markdown-plugin": "^0.1.4",
+    "@mulmoclaude/workspace-setup": "^0.1.1",
     "@mulmoclaude/x-plugin": "^0.1.1",
     "@xterm/addon-attach": "^0.12.0",
     "@xterm/addon-fit": "^0.11.0",

--- a/server/backends/workspaceSetup.spec.ts
+++ b/server/backends/workspaceSetup.spec.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import path from "node:path";
+import { initWorkspaceSetup, isManagedWorkspace } from "./workspaceSetup.js";
+
+const ORIG = process.env.MULMOCLAUDE_WORKSPACE_PATH;
+afterEach(() => {
+  if (ORIG === undefined) delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+  else process.env.MULMOCLAUDE_WORKSPACE_PATH = ORIG;
+});
+
+describe("workspace setup gating + seeding", () => {
+  it("treats ~/mulmoclaude + MULMOCLAUDE_WORKSPACE_PATH as managed, arbitrary dirs not", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-managed-"));
+    try {
+      delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+      expect(isManagedWorkspace(dir)).toBe(false);
+      expect(isManagedWorkspace(path.join(homedir(), "mulmoclaude"))).toBe(true);
+      process.env.MULMOCLAUDE_WORKSPACE_PATH = dir;
+      expect(isManagedWorkspace(dir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("seeds helps + presets into a managed workspace", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-seed-"));
+    process.env.MULMOCLAUDE_WORKSPACE_PATH = dir;
+    try {
+      initWorkspaceSetup({ workspace: dir });
+      expect(existsSync(path.join(dir, "config", "helps", "index.md"))).toBe(true);
+      expect(readdirSync(path.join(dir, "data", "skills", "catalog", "preset")).some((slug) => slug.startsWith("mc-"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT write into a non-managed workspace (e.g. an arbitrary launcher cwd)", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-skip-"));
+    try {
+      delete process.env.MULMOCLAUDE_WORKSPACE_PATH;
+      initWorkspaceSetup({ workspace: dir });
+      expect(existsSync(path.join(dir, "config"))).toBe(false);
+      expect(existsSync(path.join(dir, "data"))).toBe(false);
+      expect(existsSync(path.join(dir, ".claude"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -12,35 +12,73 @@
 // skillsCatalogPreset,claudeSkills}.)
 
 import path from "node:path";
+import { homedir } from "node:os";
 import { seedHelps, syncPresetSkills, syncActivePresetSkills, presetSkillsAssetDir } from "@mulmoclaude/workspace-setup";
+
+/** True only for the MANAGED mulmoclaude workspace — the server default
+ *  (~/mulmoclaude) or an explicit MULMOCLAUDE_WORKSPACE_PATH. We seed only there.
+ *
+ *  The launcher resolves CLAUDE_CWD to the directory `npx mulmoterminal` was run
+ *  from when no --cwd is given (bin/mulmoterminal.js resolveCwd), so seeding
+ *  unconditionally would write mulmoclaude presets/helps — and refresh entries
+ *  under `.claude/skills`, which many dev repos already have — into whatever
+ *  project the user happened to launch from. Gating to the managed workspace
+ *  keeps the terminal usable in any dir without polluting it. */
+export function isManagedWorkspace(workspace: string): boolean {
+  const resolved = path.resolve(workspace);
+  const candidates = [path.join(homedir(), "mulmoclaude")];
+  if (process.env.MULMOCLAUDE_WORKSPACE_PATH) candidates.push(process.env.MULMOCLAUDE_WORKSPACE_PATH);
+  return candidates.some((candidate) => path.resolve(candidate) === resolved);
+}
+
+// Each seeding step is fault-isolated: a filesystem edge case (EACCES, ENOSPC, a
+// path collision) in one step must neither abort server boot nor block the other
+// steps. The package's sync paths are already best-effort internally; this guards
+// the rest (seedHelps) and the call site so the whole thing can never throw.
+function safeStep(label: string, run: () => void): void {
+  try {
+    run();
+  } catch (err) {
+    console.warn(`[workspace-setup] ${label} failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
 
 export function initWorkspaceSetup(deps: { workspace: string }): void {
   const { workspace } = deps;
+  // Never seed an arbitrary launcher cwd — only the managed mulmoclaude workspace.
+  if (!isManagedWorkspace(workspace)) {
+    console.log(`[workspace-setup] skipping seed for non-managed workspace: ${workspace}`);
+    return;
+  }
   const onInfo = (message: string, data?: Record<string, unknown>) => console.log(`[workspace-setup] ${message}`, data ?? "");
   const onWarn = (message: string, data?: Record<string, unknown>) => console.warn(`[workspace-setup] ${message}`, data ?? "");
 
   // Always refresh the bundled help docs (idempotent).
-  seedHelps({ destDir: path.join(workspace, "config", "helps") });
+  safeStep("seed helps", () => seedHelps({ destDir: path.join(workspace, "config", "helps") }));
 
   // Seed/refresh preset skills into the catalog. Catalog entries are visible to
   // UI / tooling but NOT discovered by Claude Code's slash-command resolver, so
   // they don't enter the system prompt unless explicitly starred into the
   // active layer.
-  syncPresetSkills({
-    sourceDir: presetSkillsAssetDir(),
-    destDir: path.join(workspace, "data", "skills", "catalog", "preset"),
-    onInfo,
-    onWarn,
-  });
+  safeStep("sync preset catalog", () =>
+    syncPresetSkills({
+      sourceDir: presetSkillsAssetDir(),
+      destDir: path.join(workspace, "data", "skills", "catalog", "preset"),
+      onInfo,
+      onWarn,
+    }),
+  );
 
   // Refresh the ACTIVE copy of any already-starred mc-* preset so a user who
   // starred one earlier doesn't stay pinned to a stale (buggy) version. Only
   // mc-* slugs are touched; user-authored skills are never modified, and slugs
   // that aren't starred yet are left alone (never auto-starred).
-  syncActivePresetSkills({
-    sourceDir: presetSkillsAssetDir(),
-    activeDir: path.join(workspace, ".claude", "skills"),
-    onInfo,
-    onWarn,
-  });
+  safeStep("refresh active presets", () =>
+    syncActivePresetSkills({
+      sourceDir: presetSkillsAssetDir(),
+      activeDir: path.join(workspace, ".claude", "skills"),
+      onInfo,
+      onWarn,
+    }),
+  );
 }

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -1,0 +1,46 @@
+// Workspace bootstrap — thin host binding over @mulmoclaude/workspace-setup
+// (shared with MulmoClaude). Seeds the bundled help docs and preset skills
+// into the shared workspace so a MulmoTerminal-alone run (without MulmoClaude
+// ever booting) still gets a populated workspace.
+//
+// Destinations MUST match MulmoClaude's layout exactly (both apps share
+// CLAUDE_CWD, default ~/mulmoclaude) so the two never diverge on disk:
+//   helps          → <workspace>/config/helps
+//   preset catalog → <workspace>/data/skills/catalog/preset
+//   active presets → <workspace>/.claude/skills   (already-starred mc-* only)
+// (See mulmoclaude/server/workspace/paths.ts: WORKSPACE_DIRS.{helps,
+// skillsCatalogPreset,claudeSkills}.)
+
+import path from "node:path";
+import { seedHelps, syncPresetSkills, syncActivePresetSkills, presetSkillsAssetDir } from "@mulmoclaude/workspace-setup";
+
+export function initWorkspaceSetup(deps: { workspace: string }): void {
+  const { workspace } = deps;
+  const onInfo = (message: string, data?: Record<string, unknown>) => console.log(`[workspace-setup] ${message}`, data ?? "");
+  const onWarn = (message: string, data?: Record<string, unknown>) => console.warn(`[workspace-setup] ${message}`, data ?? "");
+
+  // Always refresh the bundled help docs (idempotent).
+  seedHelps({ destDir: path.join(workspace, "config", "helps") });
+
+  // Seed/refresh preset skills into the catalog. Catalog entries are visible to
+  // UI / tooling but NOT discovered by Claude Code's slash-command resolver, so
+  // they don't enter the system prompt unless explicitly starred into the
+  // active layer.
+  syncPresetSkills({
+    sourceDir: presetSkillsAssetDir(),
+    destDir: path.join(workspace, "data", "skills", "catalog", "preset"),
+    onInfo,
+    onWarn,
+  });
+
+  // Refresh the ACTIVE copy of any already-starred mc-* preset so a user who
+  // starred one earlier doesn't stay pinned to a stale (buggy) version. Only
+  // mc-* slugs are touched; user-authored skills are never modified, and slugs
+  // that aren't starred yet are left alone (never auto-starred).
+  syncActivePresetSkills({
+    sourceDir: presetSkillsAssetDir(),
+    activeDir: path.join(workspace, ".claude", "skills"),
+    onInfo,
+    onWarn,
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createPubSub } from "./pubsub.js";
 import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-registry.js";
 import { buildGuiMcpServer } from "./mcp/broker.js";
+import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
@@ -103,6 +104,12 @@ const CLAUDE_CWD = process.env.CLAUDE_CWD || path.join(os.homedir(), "mulmoclaud
 // CLAUDE_CWD is the workspace used as the PTY cwd and as the root for persisted
 // session state, so it must exist before we spawn anything into it.
 await fs.mkdir(CLAUDE_CWD, { recursive: true });
+
+// Seed the bundled help docs + preset skills into the shared workspace so a
+// MulmoTerminal-alone run still gets a populated workspace (shared with
+// MulmoClaude via @mulmoclaude/workspace-setup). Idempotent — safe to run on
+// every boot. Done right after the workspace dir is guaranteed to exist.
+initWorkspaceSetup({ workspace: CLAUDE_CWD });
 
 // MulmoTerminal's own per-session GUI state (tool-result render data + tool-call
 // history) lives here, keyed by sessionId (a global UUID) — NOT under the

--- a/yarn.lock
+++ b/yarn.lock
@@ -579,6 +579,11 @@
     js-yaml "^4.2.0"
     marked "^18.0.5"
 
+"@mulmoclaude/workspace-setup@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/workspace-setup/-/workspace-setup-0.1.1.tgz#49db392b08b7c3bd7db668fcc387508685cef3c9"
+  integrity sha512-FgMDrMM6cUhezRxCJ+CMfe/McRZMySHueXFxYXanUGcdHKPez0qp6EYVsZiUQ/+rjVHGaJ6kvOhw1feEmKDevw==
+
 "@mulmoclaude/x-plugin@^0.1.1":
   version "0.1.1"
   resolved "https://registry.npmjs.org/@mulmoclaude/x-plugin/-/x-plugin-0.1.1.tgz#9923ac1b981b88af5be297f2fd4372f127ca2781"


### PR DESCRIPTION
## What

First of the **shared backend-service wirings** — MulmoClaude PR #1733 extracted its headless backend behavior into reusable `packages/services/*` packages; this PR consumes the first one in MulmoTerminal.

MulmoTerminal now seeds the bundled **help docs** and **preset skills** into the shared workspace at startup, so a MulmoTerminal-alone run (without MulmoClaude ever booting) gets a populated workspace instead of an empty one.

## Changes

- **`server/backends/workspaceSetup.ts`** — thin host binding over `@mulmoclaude/workspace-setup`:
  - `seedHelps` → `<workspace>/config/helps`
  - `syncPresetSkills` → `<workspace>/data/skills/catalog/preset` (catalog; not in Claude's prompt)
  - `syncActivePresetSkills` → `<workspace>/.claude/skills` (refresh already-starred `mc-*` only)
  - Destinations match MulmoClaude's layout exactly (both apps share `CLAUDE_CWD`), so the two never diverge on disk.
- **`server/index.ts`** — `initWorkspaceSetup({ workspace: CLAUDE_CWD })` right after the workspace dir is created. Idempotent; safe on every boot.
- **`package.json`** — `@mulmoclaude/workspace-setup@^0.1.1`.

## Verification

- Smoke-tested against a temp workspace: **22 help docs** (incl. `index.md`) + **8 `mc-*` presets** seeded.
- `yarn typecheck` + `yarn lint` clean; **94 tests pass**.

## Next in this series

`file-change-publisher` (close the collection/html live-refresh gap), then `notifier` + `collection-watchers` (with a bell + dropdown panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)