### PR TITLE
feat: route file-change live-refresh through @mulmoclaude/file-change-publisher

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/chart-plugin": "^0.1.1",
     "@mulmoclaude/collection-plugin": "^0.5.1",
+    "@mulmoclaude/file-change-publisher": "^0.1.1",
     "@mulmoclaude/form-plugin": "^0.1.1",
     "@mulmoclaude/html-plugin": "^0.2.2",
     "@mulmoclaude/markdown-plugin": "^0.1.4",

--- a/server/backends/fileChange.spec.ts
+++ b/server/backends/fileChange.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { initFileChangePublisher, publishFileChange } from "./fileChange.js";
+
+let ws: string;
+const captured: { channel: string; payload: unknown }[] = [];
+
+beforeAll(() => {
+  ws = mkdtempSync(path.join(tmpdir(), "mt-fc-"));
+  for (const rel of ["artifacts/documents/2026/06/doc.md", "artifacts/html/2026/06/page.html", "artifacts/other/note.txt"]) {
+    const abs = path.join(ws, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, "x");
+  }
+  // Minimal pubsub stub that records what gets published.
+  const pubsub = { publish: (channel: string, payload: unknown) => captured.push({ channel, payload }) } as never;
+  initFileChangePublisher({ workspace: ws, pubsub });
+});
+
+afterAll(() => rmSync(ws, { recursive: true, force: true }));
+
+describe("file-change publisher wiring", () => {
+  it("forwards a markdown doc to plugin:markdown:file:<path> with a real mtime", async () => {
+    captured.length = 0;
+    const rel = "artifacts/documents/2026/06/doc.md";
+    await publishFileChange(rel);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].channel).toBe(`plugin:markdown:file:${rel}`);
+    const payload = captured[0].payload as { path: string; mtimeMs: number };
+    expect(payload.path).toBe(rel);
+    expect(payload.mtimeMs).toBeGreaterThan(0);
+  });
+
+  it("forwards an html page to plugin:html:file:<path>", async () => {
+    captured.length = 0;
+    const rel = "artifacts/html/2026/06/page.html";
+    await publishFileChange(rel);
+    expect(captured.map((c) => c.channel)).toEqual([`plugin:html:file:${rel}`]);
+  });
+
+  it("does not publish for a path matching no plugin scope", async () => {
+    captured.length = 0;
+    await publishFileChange("artifacts/other/note.txt");
+    expect(captured).toHaveLength(0);
+  });
+
+  it("drops a path that escapes the workspace (no publish)", async () => {
+    captured.length = 0;
+    await publishFileChange("../escape.md");
+    await publishFileChange("../../etc/passwd");
+    expect(captured).toHaveLength(0);
+  });
+});

--- a/server/backends/fileChange.ts
+++ b/server/backends/fileChange.ts
@@ -1,0 +1,38 @@
+// Workspace file-change publisher — thin host binding over
+// @mulmoclaude/file-change-publisher (shared with MulmoClaude). A write route
+// calls `publishFileChange(rel)` after a successful write; the package stats the
+// post-write mtime, contains the path to the workspace, and forwards to the
+// plugin-scoped channels the open Views subscribe to (markdown / html).
+//
+// MulmoTerminal has no general "files explorer" subscriber, so there's no
+// primaryChannel — only the plugin scopes. The frontend plugin runtime
+// subscribes via runtime.pubsub("file:<path>") → "plugin:<scope>:file:<path>"
+// (src/composables/pluginRuntime.ts: pluginChannelName), which is exactly the
+// channel the package's pluginFileChannel produces.
+
+import path from "node:path";
+import { configureFileChangePublisher, publishFileChange } from "@mulmoclaude/file-change-publisher";
+import type { createPubSub } from "../pubsub.js";
+
+type PubSub = ReturnType<typeof createPubSub>;
+
+const DOCS_DIR = "artifacts/documents";
+
+export function initFileChangePublisher(deps: { workspace: string; pubsub: PubSub | null }): void {
+  configureFileChangePublisher({
+    publish: (channel, payload) => deps.pubsub?.publish(channel, payload),
+    workspaceRoot: deps.workspace,
+    // MT workspace-relative paths are already POSIX (forward-slash); split on the
+    // platform separator defensively so the channel suffix can't drift on Windows.
+    toPosix: (rel) => rel.split(path.sep).join("/"),
+    pluginScopes: [
+      // Matches the markdown backend's isDocPath gate (artifacts/documents/**.md).
+      { scope: "markdown", matches: (rel) => rel.startsWith(`${DOCS_DIR}/`) && rel.endsWith(".md") },
+      // presentHtml pages live under artifacts/html/**.html.
+      { scope: "html", matches: (rel) => rel.endsWith(".html") },
+    ],
+    warn: (message, data) => console.warn(`[file-change] ${message}`, data ?? ""),
+  });
+}
+
+export { publishFileChange };

--- a/server/backends/html.spec.ts
+++ b/server/backends/html.spec.ts
@@ -21,7 +21,9 @@ beforeAll(async () => {
 
   const app = express();
   app.use(express.json());
-  mountHtmlDispatchRoute(app, { getPubsub: () => null });
+  // File-change live-refresh now flows through the shared publisher (a no-op
+  // until configured), so the dispatch route no longer takes a pubsub thunk.
+  mountHtmlDispatchRoute(app);
   mountHtmlPreviewRoute(app, { workspace: ws });
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => resolve());

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -19,9 +19,7 @@ import { createReadStream } from "node:fs";
 import type { Express, Request, Response, NextFunction } from "express";
 import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
 import { artifactsFileOps } from "./artifacts.js";
-import type { createPubSub } from "../pubsub.js";
-
-type PubSub = ReturnType<typeof createPubSub>;
+import { publishFileChange } from "./fileChange.js";
 
 // Curated CDN allowlist (matches the collection custom-view policy) for an
 // LLM-authored page that may pull a charting/util lib or font from a CDN.
@@ -55,9 +53,8 @@ const HTML_PREVIEW_CSP = [
 
 /** Intercept the View's dispatch (loadHtml/saveHtml) on /api/plugin/presentHtml,
  *  before the generic plugin catch-all (which handles the tool-call). MUST be
- *  registered BEFORE mountAllRoutes. `getPubsub` is a thunk because pubsub is
- *  created after routes are mounted; the handler reads it live at request time. */
-export function mountHtmlDispatchRoute(app: Express, deps: { getPubsub: () => PubSub | null }): void {
+ *  registered BEFORE mountAllRoutes. */
+export function mountHtmlDispatchRoute(app: Express): void {
   app.post("/api/plugin/presentHtml", async (req: Request, res: Response, next: NextFunction) => {
     const args = (req.body ?? {}) as { kind?: unknown; path?: unknown };
     // A tool-call (no `kind`) is left to the package execute via the catch-all.
@@ -65,24 +62,16 @@ export function mountHtmlDispatchRoute(app: Express, deps: { getPubsub: () => Pu
     try {
       const result = await executeHtmlDispatch({ files: { artifacts: artifactsFileOps } }, args as never);
       if (args.kind === "saveHtml" && typeof args.path === "string") {
-        // Live-refresh: bump any open View watching this file (channel matches the
-        // frontend runtime scope "html" → plugin:html:file:<path>).
-        try {
-          const stat = await artifactsFileOps.stat(toArtifactsRel(args.path));
-          deps.getPubsub()?.publish(`plugin:html:file:${args.path}`, { mtimeMs: stat.mtimeMs });
-        } catch {
-          // Best-effort; the saver already updated its local state.
-        }
+        // Live-refresh via the shared publisher: it stats the post-write mtime,
+        // contains the path to the workspace, and forwards to the "html" plugin
+        // scope (plugin:html:file:<path>) the open View subscribes to.
+        void publishFileChange(args.path);
       }
       res.json(result);
     } catch (err) {
       res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });
-}
-
-function toArtifactsRel(workspaceRel: string): string {
-  return workspaceRel.startsWith("artifacts/") ? workspaceRel.slice("artifacts/".length) : workspaceRel;
 }
 
 /** Serve `GET /artifacts/html/<rest>` — the iframe preview source — from the

--- a/server/backends/markdown.ts
+++ b/server/backends/markdown.ts
@@ -18,21 +18,17 @@ import { randomUUID } from "node:crypto";
 import { marked } from "marked";
 import { renderMarpDeck, fillImagePlaceholders } from "@mulmoclaude/markdown-plugin";
 import type { MarkdownHostApp, ExportPdfOptions } from "@mulmoclaude/markdown-plugin";
-import type { createPubSub } from "../pubsub.js";
+import { publishFileChange } from "./fileChange.js";
 import { generateImage } from "./image-gen.js";
-
-type PubSub = ReturnType<typeof createPubSub>;
 
 const DOCS_DIR = "artifacts/documents";
 
-// Set once at boot (server/index.ts) — workspace = CLAUDE_CWD, pubsub for
-// live-refresh forwarding to the plugin-scoped channel.
+// Set once at boot (server/index.ts) — workspace = CLAUDE_CWD. File-change
+// live-refresh is forwarded via the shared publisher (./fileChange.js).
 let workspace: string | null = null;
-let pubsub: PubSub | null = null;
 
-export function initMarkdownBackend(deps: { workspace: string; pubsub: PubSub | null }): void {
+export function initMarkdownBackend(deps: { workspace: string }): void {
   workspace = deps.workspace;
-  pubsub = deps.pubsub ?? null;
 }
 
 // Strict gate (matches the package's isFilePath + MulmoClaude's isMarkdownPath):
@@ -67,12 +63,6 @@ function buildNewDocPath(prefix: string): string {
   return `${DOCS_DIR}/${yyyy}/${mm}/${sanitizePrefix(prefix)}-${rand}.md`;
 }
 
-function publishFileChange(rel: string): void {
-  // The package View subscribes via runtime.pubsub "file:<path>" →
-  // "plugin:markdown:file:<path>". Forward self-saves so other tabs refresh.
-  pubsub?.publish(`plugin:markdown:file:${rel}`, { path: rel, mtimeMs: Date.now() });
-}
-
 const MARKDOWN_PDF_CSS = `
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 13px; line-height: 1.6; color: #1f2937; max-width: 800px; margin: 0 auto; padding: 32px 48px; }
   h1 { font-size: 1.75rem; } h2 { font-size: 1.25rem; border-bottom: 1px solid #e5e7eb; padding-bottom: .25rem; } h3 { font-size: 1rem; }
@@ -90,7 +80,7 @@ export const markdownHostApp: MarkdownHostApp = {
   async saveDoc(rel, markdown) {
     if (!isDocPath(rel)) throw new Error(`invalid document path: ${rel}`);
     await fs.promises.writeFile(absFor(rel), markdown);
-    publishFileChange(rel);
+    void publishFileChange(rel);
     return { path: rel };
   },
 
@@ -99,6 +89,9 @@ export const markdownHostApp: MarkdownHostApp = {
     const abs = absFor(rel);
     await fs.promises.mkdir(path.dirname(abs), { recursive: true });
     await fs.promises.writeFile(abs, markdown);
+    // Forward the create too — a previous gap (only saveDoc published), so a
+    // freshly-created doc now live-refreshes any View that opens it.
+    void publishFileChange(rel);
     return { path: rel };
   },
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createPubSub } from "./pubsub.js";
 import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-registry.js";
 import { buildGuiMcpServer } from "./mcp/broker.js";
+import { initFileChangePublisher } from "./backends/fileChange.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
@@ -532,7 +533,7 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
 // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
 // /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
 // catch-all (which handles the tool-call); a request without `kind` falls through.
-mountHtmlDispatchRoute(app, { getPubsub: () => pubsub });
+mountHtmlDispatchRoute(app);
 
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
 // POST /api/form). The GUI MCP server dispatches tool calls to these.
@@ -788,10 +789,14 @@ app.get("/api/sessions", async (_req, res) => {
 const server = http.createServer(app);
 pubsub = createPubSub(server, isAllowedOrigin);
 
-// Give the markdown host app its workspace (for artifacts/documents storage) +
-// pubsub (to forward file-change events to the plugin-scoped channel so the
-// presentDocument view live-refreshes). Done after pubsub exists (task #6).
-initMarkdownBackend({ workspace: CLAUDE_CWD, pubsub });
+// Configure the shared workspace file-change publisher (forwards post-write
+// events to the plugin-scoped channels open Views subscribe to). Done right
+// after pubsub exists, before the write backends below route through it.
+initFileChangePublisher({ workspace: CLAUDE_CWD, pubsub });
+
+// Give the markdown host app its workspace (for artifacts/documents storage).
+// File-change live-refresh now flows through the shared publisher above.
+initMarkdownBackend({ workspace: CLAUDE_CWD });
 
 // Give the artifacts FileOps backend its workspace root (<workspace>/artifacts) so
 // @mulmoclaude/chart-plugin's executeChart can persist chart documents there.

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,6 +560,11 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
+"@mulmoclaude/file-change-publisher@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/file-change-publisher/-/file-change-publisher-0.1.1.tgz#9dfa0359c9ba74016f7512e614bef751660fb0e7"
+  integrity sha512-tuiG1XcDh9u3DnJUvluqHkARVKvgZ/JSvcdlCE1e5XG6niEZUy42ON9kdFxBgrYI6xchtST6MP+RFJSq52rd1g==
+
 "@mulmoclaude/form-plugin@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@mulmoclaude/form-plugin/-/form-plugin-0.1.1.tgz#54825cc7ecb3eded0d9d6d7bc0c04214bf7c78da"


### PR DESCRIPTION
## What

Second of the shared backend-service wirings. Unifies MulmoTerminal's ad-hoc file-change publishing through `@mulmoclaude/file-change-publisher`, which:
- stats the **post-write mtime** (was `Date.now()` in markdown),
- **contains the path** to the workspace (drops out-of-workspace `../…` paths before publish/stat),
- forwards to the plugin-scoped channels open Views subscribe to: `plugin:<scope>:file:<path>` (matches `src/composables/pluginRuntime.ts`'s `pluginChannelName`).

## Changes

- **`server/backends/fileChange.ts`** — thin binding: `configureFileChangePublisher` with MT's pubsub, workspace, `toPosix`, and plugin scopes `[markdown (artifacts/documents/**.md), html (**.html)]`. No `primaryChannel` (MT has no general files-explorer subscriber).
- **`markdown.ts`** — drop the local pubsub plumbing + hand-rolled `publishFileChange`; route `saveDoc` through the shared publisher **and fix a gap**: `saveNewDoc` never published, so a freshly-created doc didn't live-refresh — it does now.
- **`html.ts`** — drop the `getPubsub` thunk + manual stat+publish; route `saveHtml` through the shared publisher. `mountHtmlDispatchRoute` no longer takes a pubsub arg.
- **`index.ts`** — `initFileChangePublisher({ workspace, pubsub })` right after pubsub is created, before the write backends.

## Not in scope

Collection live-refresh — `@mulmoclaude/collection-plugin`'s View has **no file-change subscriber**, so that's a separate collection-plugin concern, not a publish-only fix. Flagged for a later pass.

## Verification

- New `fileChange.spec.ts` (4): correct scope/channel for md + html, no publish for an unmatched path, out-of-workspace paths dropped.
- `yarn typecheck` + `yarn lint` clean; **98 tests pass**.

Follows #63 (workspace-setup). Next: `notifier` + `collection-watchers` with a bell + dropdown panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)