### PR TITLE
feat(mcp): grid dev terminals run plain claude (no GUI MCP); single view unchanged

### DIFF
--- a/server/claude-args.spec.ts
+++ b/server/claude-args.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildClaudeArgs, type ClaudeArgsInput } from "./claude-args.js";
+
+const base: ClaudeArgsInput = {
+  sessionId: "11111111-1111-1111-1111-111111111111",
+  resume: null,
+  canResume: false,
+  settings: "{hooks}",
+  permissionMode: "auto",
+  attachGuiMcp: true,
+  mcpConfig: "{gui-mcp}",
+  guiMcpTools: "mcp__gui__a,mcp__gui__b",
+};
+
+describe("buildClaudeArgs", () => {
+  it("single view (attachGuiMcp): attaches GUI MCP + --strict-mcp-config + --allowedTools", () => {
+    const args = buildClaudeArgs(base);
+    expect(args).toEqual([
+      "--session-id",
+      base.sessionId,
+      "--settings",
+      "{hooks}",
+      "--permission-mode",
+      "auto",
+      "--mcp-config",
+      "{gui-mcp}",
+      "--strict-mcp-config",
+      "--allowedTools",
+      "mcp__gui__a,mcp__gui__b",
+    ]);
+  });
+
+  it("grid dev terminal (attachGuiMcp=false): no GUI MCP, no --strict-mcp-config, no --allowedTools", () => {
+    const args = buildClaudeArgs({ ...base, attachGuiMcp: false });
+    expect(args).toEqual(["--session-id", base.sessionId, "--settings", "{hooks}", "--permission-mode", "auto"]);
+    expect(args).not.toContain("--mcp-config");
+    expect(args).not.toContain("--strict-mcp-config");
+    expect(args).not.toContain("--allowedTools");
+  });
+
+  it("resumes with --resume when canResume, keeping the chosen MCP mode", () => {
+    const resume = "22222222-2222-2222-2222-222222222222";
+    const args = buildClaudeArgs({ ...base, attachGuiMcp: false, resume, canResume: true });
+    expect(args.slice(0, 4)).toEqual(["--resume", resume, "--settings", "{hooks}"]);
+    expect(args).not.toContain("--session-id");
+    expect(args).not.toContain("--strict-mcp-config");
+  });
+
+  it("falls back to --session-id when canResume is false even if a resume id is present", () => {
+    const args = buildClaudeArgs({ ...base, resume: "33333333-3333-3333-3333-333333333333", canResume: false });
+    expect(args).toContain("--session-id");
+    expect(args).not.toContain("--resume");
+  });
+
+  it("appends the initial prompt as a positional after -- (option terminator)", () => {
+    const args = buildClaudeArgs({ ...base, initialPrompt: "-rf danger" });
+    expect(args.slice(-2)).toEqual(["--", "-rf danger"]);
+  });
+});

--- a/server/claude-args.ts
+++ b/server/claude-args.ts
@@ -1,0 +1,37 @@
+// Pure builder for the `claude` CLI argv. Kept separate so the exact flag set —
+// especially the GUI-MCP / --strict-mcp-config switch — is unit-testable without
+// spawning a PTY.
+
+export interface ClaudeArgsInput {
+  sessionId: string;
+  resume: string | null;
+  // Whether the requested session has an on-disk transcript to --resume. When
+  // false we start fresh, reusing the id via --session-id.
+  canResume: boolean;
+  settings: string; // hook settings JSON (--settings)
+  permissionMode: string; // --permission-mode
+  // true  (single view): attach the in-process GUI MCP, auto-allow its tools, and
+  //        isolate to it with --strict-mcp-config (main's classic behavior).
+  // false (grid dev terminal): no GUI MCP and no --strict-mcp-config, so the user's
+  //        + project's MCP servers load normally.
+  attachGuiMcp: boolean;
+  mcpConfig: string; // GUI MCP config JSON (--mcp-config), used only when attachGuiMcp
+  guiMcpTools: string; // comma-joined GUI tool names (--allowedTools), used only when attachGuiMcp
+  initialPrompt?: string;
+}
+
+export function buildClaudeArgs(input: ClaudeArgsInput): string[] {
+  const guiArgs = ["--permission-mode", input.permissionMode];
+  if (input.attachGuiMcp) {
+    guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config", "--allowedTools", input.guiMcpTools);
+  }
+
+  const baseArgs =
+    input.canResume && input.resume !== null
+      ? ["--resume", input.resume, "--settings", input.settings, ...guiArgs]
+      : ["--session-id", input.sessionId, "--settings", input.settings, ...guiArgs];
+
+  // The initial prompt goes last as a positional arg; "--" ends option parsing so a
+  // prompt starting with "-" can't be reinterpreted as a flag.
+  return input.initialPrompt ? [...baseArgs, "--", input.initialPrompt] : baseArgs;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes } from "./config-routes.js";
+import { buildClaudeArgs } from "./claude-args.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
@@ -781,10 +782,13 @@ app.get("/api/tool-calls/:sessionId", async (req, res) => {
 });
 
 // GET/POST /api/config (workspace dir + directory presets) — in its own module.
+// GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
+// modal's directory presets. The single view never calls it.
 mountConfigRoutes(app, CLAUDE_CWD);
 
-// Initial per-session status + last prompt, so a cell can render its header
-// immediately (the live updates then arrive via the "sessions" pub/sub channel).
+// GRID-ONLY (dev_tool): initial per-session status + last prompt, so a grid cell
+// can render its header immediately (live updates then arrive via the "sessions"
+// pub/sub channel). The single view reads activity straight from that channel.
 app.get("/api/session/:id", (req, res) => {
   const { id } = req.params;
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
@@ -936,27 +940,32 @@ function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntr
 // a viewer yet (e.g. spawnBackgroundChat) — output just buffers until a client
 // reattaches. `initialPrompt`, when given, is passed to claude as the first turn
 // so the session starts working immediately, before anyone opens it.
-function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, initialPrompt?: string, cwd: string = CLAUDE_CWD): PtyEntry {
-  const settings = hookSettingsJson();
-  // Register the GUI MCP server and auto-allow its tools so the plugin tools run
-  // without a permission prompt. We deliberately do NOT pass --strict-mcp-config:
-  // --mcp-config is additive, so the user's (~/.claude.json) and the project's
-  // (<cwd>/.mcp.json) MCP servers load alongside the GUI MCP — MulmoTerminal is a
-  // real Claude Code dev terminal, not just the GUI layer. (skills are already
-  // honored: claude reads ~/.claude/skills + <cwd>/.claude/skills by cwd.)
-  const mcp = mcpConfigJson(sessionId);
-  const guiArgs = ["--permission-mode", CLAUDE_PERMISSION_MODE, "--mcp-config", mcp, "--allowedTools", GUI_MCP_TOOLS];
-  // Only `--resume` when the session actually exists on disk. claude doesn't write
-  // a session's .jsonl until its first prompt, so a started-but-unused session has
-  // no record — resuming it would fail ("[session ended]"). In that case (no live
-  // pty either, since reattach already happened upstream) restart fresh, reusing
-  // the same id via --session-id, so a reload of an idle cell just reopens it.
+function spawnClaudePty(
+  sessionId: string,
+  resume: string | null,
+  ws: WebSocket | null,
+  initialPrompt?: string,
+  cwd: string = CLAUDE_CWD,
+  attachGuiMcp: boolean = true,
+): PtyEntry {
+  // attachGuiMcp picks the MCP mode (see buildClaudeArgs): the single view (default)
+  // attaches the GUI MCP + --strict-mcp-config (main's classic behavior); the grid's
+  // dev terminals attach neither, so the user's + project's MCP servers load normally.
+  // Only --resume when the session has an on-disk transcript — claude doesn't write
+  // a session's .jsonl until its first prompt, so a started-but-unused session can't
+  // be resumed; we restart fresh (reusing the id via --session-id) instead.
   const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
-  const baseArgs = canResume ? ["--resume", resume, "--settings", settings, ...guiArgs] : ["--session-id", sessionId, "--settings", settings, ...guiArgs];
-  // The initial prompt goes last as a positional arg (claude's initial-prompt
-  // form). "--" ends option parsing so a prompt that happens to start with "-"
-  // can't be reinterpreted as a flag.
-  const args = initialPrompt ? [...baseArgs, "--", initialPrompt] : baseArgs;
+  const args = buildClaudeArgs({
+    sessionId,
+    resume,
+    canResume,
+    settings: hookSettingsJson(),
+    permissionMode: CLAUDE_PERMISSION_MODE,
+    attachGuiMcp,
+    mcpConfig: mcpConfigJson(sessionId),
+    guiMcpTools: GUI_MCP_TOOLS,
+    initialPrompt,
+  });
 
   console.log(`[ws] client connected (${canResume ? "resume" : "new"} ${sessionId})`);
 
@@ -1076,6 +1085,11 @@ wss.on("connection", (ws, req) => {
   // falls back to CLAUDE_CWD.
   const cwd = resolveWorkspace(url.searchParams.get("cwd"));
 
+  // ?gui=0 (the grid's dev terminals) spawns claude WITHOUT the GUI plugin MCP /
+  // --strict-mcp-config, so the user's + project's MCP servers load normally. Absent
+  // (the single view) keeps main's behavior: GUI MCP attached + strict.
+  const attachGuiMcp = url.searchParams.get("gui") !== "0";
+
   // Decide the effective session id BEFORE telling the browser. A requested id
   // is honored only if it can actually be served: a live pty (reattach) or an
   // on-disk transcript (`--resume`). A requested id that's neither — e.g. a cell
@@ -1097,7 +1111,7 @@ wss.on("connection", (ws, req) => {
 
   let entry: PtyEntry;
   try {
-    entry = live ? reattachPty(live, ws, sessionId) : spawnClaudePty(sessionId, resume, ws, undefined, cwd);
+    entry = live ? reattachPty(live, ws, sessionId) : spawnClaudePty(sessionId, resume, ws, undefined, cwd, attachGuiMcp);
   } catch (err) {
     // A failed spawn (claude missing, or node-pty's spawn-helper not executable)
     // must close just this connection — never crash the whole server.

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -4,11 +4,16 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
+import { buildTerminalWsUrl } from "./wsUrl";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
 // session (or starting another fresh one) still forces a reconnect.
-const props = defineProps<{ sessionId: string | null; connectKey: number; cwd?: string | null }>();
+// `devTerminal` runs claude as a plain dev terminal (the grid): NO GUI plugin MCP
+// and NO --strict-mcp-config, so the user's (~/.claude.json) + project's (.mcp.json)
+// MCP servers load normally. Default (false, the single view) keeps main's behavior:
+// the in-process GUI MCP attached and isolated with --strict-mcp-config.
+const props = defineProps<{ sessionId: string | null; connectKey: number; cwd?: string | null; devTerminal?: boolean }>();
 const emit = defineEmits<{ (e: "session" | "cwd", value: string): void }>();
 
 const terminalRef = ref<HTMLDivElement>();
@@ -54,16 +59,18 @@ function connect() {
   sawExit = false;
   status.value = "connecting";
 
-  const proto = location.protocol === "https:" ? "wss:" : "ws:";
   // Resume the known id (learned from the server, or the prop) so a reconnect
   // re-attaches the same session instead of spawning a fresh one each retry.
   const resumeId = knownSessionId ?? props.sessionId;
-  const params = new URLSearchParams();
-  if (resumeId) params.set("session", resumeId);
-  if (props.cwd) params.set("cwd", props.cwd); // launch this terminal in the chosen dir
-  const qs = params.toString();
-  const suffix = qs ? `?${qs}` : "";
-  const sock = new WebSocket(`${proto}//${location.host}/ws${suffix}`);
+  const sock = new WebSocket(
+    buildTerminalWsUrl({
+      host: location.host,
+      secure: location.protocol === "https:",
+      sessionId: resumeId,
+      cwd: props.cwd,
+      devTerminal: props.devTerminal,
+    }),
+  );
   ws = sock;
 
   sock.onopen = () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -235,7 +235,16 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
           <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
         </span>
       </div>
-      <TerminalView ref="termRef" class="cell-term" :session-id="sessionId" :connect-key="connectKey" :cwd="cwd" @session="onSession" @cwd="onServerCwd" />
+      <TerminalView
+        ref="termRef"
+        class="cell-term"
+        :session-id="sessionId"
+        :connect-key="connectKey"
+        :cwd="cwd"
+        dev-terminal
+        @session="onSession"
+        @cwd="onServerCwd"
+      />
     </template>
     <div v-else class="cell-launch">
       <div v-if="presets.length" class="cell-presets">

--- a/src/components/wsUrl.spec.ts
+++ b/src/components/wsUrl.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { buildTerminalWsUrl } from "./wsUrl";
+
+describe("buildTerminalWsUrl", () => {
+  it("single view: session only, no gui=0", () => {
+    const url = buildTerminalWsUrl({ host: "localhost:3456", secure: false, sessionId: "abc" });
+    expect(url).toBe("ws://localhost:3456/ws?session=abc");
+    expect(url).not.toContain("gui=0");
+  });
+
+  it("grid dev terminal: adds gui=0 so the server skips the GUI MCP", () => {
+    const url = buildTerminalWsUrl({ host: "h", secure: false, sessionId: "abc", devTerminal: true });
+    expect(new URL(url).searchParams.get("gui")).toBe("0");
+  });
+
+  it("includes the chosen cwd", () => {
+    const url = buildTerminalWsUrl({ host: "h", secure: false, sessionId: "abc", cwd: "/work/proj", devTerminal: true });
+    const q = new URL(url).searchParams;
+    expect(q.get("cwd")).toBe("/work/proj");
+    expect(q.get("gui")).toBe("0");
+  });
+
+  it("fresh session (null id): no session param", () => {
+    const url = buildTerminalWsUrl({ host: "h", secure: false, sessionId: null });
+    expect(url).toBe("ws://h/ws");
+  });
+
+  it("uses wss when secure", () => {
+    const url = buildTerminalWsUrl({ host: "h", secure: true, sessionId: "abc" });
+    expect(url.startsWith("wss://")).toBe(true);
+  });
+});

--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -1,0 +1,22 @@
+// Pure builder for the terminal WebSocket URL. Kept separate from Terminal.vue so
+// the query it sends — including ?gui=0, which tells the server to run a plain dev
+// terminal (no GUI MCP) — is unit-testable without xterm/WebSocket.
+
+export interface TerminalWsUrlInput {
+  host: string; // location.host
+  secure: boolean; // location.protocol === "https:"
+  sessionId: string | null; // resume this session; null => fresh session
+  cwd?: string | null; // launch in this directory
+  devTerminal?: boolean; // grid dev terminal: no GUI MCP (?gui=0)
+}
+
+export function buildTerminalWsUrl({ host, secure, sessionId, cwd, devTerminal }: TerminalWsUrlInput): string {
+  const params = new URLSearchParams();
+  if (sessionId) params.set("session", sessionId);
+  if (cwd) params.set("cwd", cwd);
+  if (devTerminal) params.set("gui", "0");
+  const qs = params.toString();
+  const suffix = qs ? `?${qs}` : "";
+  const proto = secure ? "wss:" : "ws:";
+  return `${proto}//${host}/ws${suffix}`;
+}


### PR DESCRIPTION
## Summary
dev_tool → main の取り込みに向け、**MCP の扱いを起動時の呼び出しで切替**えます。フィードバック「dev_tool（grid）側では GUI の MCP を使わない方が良い」への対応です。

- **single view（main の view）**: 従来どおり GUI MCP を attach + 自動許可し `--strict-mcp-config` で隔離。**main と完全同一**（spawn 引数がバイト単位で一致）。
- **grid（dev_tool の dev ターミナル）**: GUI プラグイン MCP を付けず、`--strict-mcp-config` も外す → user `~/.claude.json` + project `<cwd>/.mcp.json` の MCP が普通に読まれる素の Claude Code dev ターミナル。

モードは接続してくる view が起動時に選択: grid セルは terminal WebSocket に `?gui=0` を付与、single view は何も付けない。これにより **dev_tool→main マージは single view の MCP 挙動にとって no-op** になります。

## Items to Confirm / Review
- [ ] single view の spawn 引数が main と同一であること（`server/claude-args.spec.ts` の「single view」ケースで固定）。
- [ ] grid の dev ターミナルで GUI MCP が消え、user/project MCP が読まれること（`?gui=0` → `attachGuiMcp=false`）。
- [ ] hooks（activity ドット・lastPrompt・tool-call 履歴）は両モードとも維持（`--settings` は不変）。grid のステータスドットは hooks 由来なので影響なし。
- [ ] `spawnBackgroundChat`（GUI ホストツール）は既定 `attachGuiMcp=true` のまま GUI MCP を保持（意図通りか）。

## User Prompt
> このコメントの本質は GUI の mcp を dev_tool では使わないほうが良いのでは？ということだと思う。確かに理にかなっている。なので、呼び出しによって切り替える。main で使っている view からは main のそのままの mcp を、dev_tool のは、gui のプラグインをよみこまない ＆ `--strict-mcp-config` を削除 で動かすのが整理されているよね？
> そして mcp の変更を PR でつくろう。
> （事前に）dev_tool だけで使っている server api はコメントなどで区別できると良いし、共通部分のものはとくに副作用をみてね。

## 実装
- `server/claude-args.ts`（新規）: 純粋関数 `buildClaudeArgs()` に argv 生成を分離。`attachGuiMcp` で GUI-MCP / `--strict-mcp-config` を切替。`server/claude-args.spec.ts` で single/grid/resume/initial-prompt を固定。
- `server/index.ts`: `spawnClaudePty(..., attachGuiMcp=true)`。ws ハンドラで `?gui=0` を読み `attachGuiMcp` を決定。`/api/config`・`/api/session/:id` に **GRID-ONLY (dev_tool)** マーカーを追記。
- `src/components/wsUrl.ts`（新規）: 純粋関数 `buildTerminalWsUrl()`（`?gui=0`/`cwd`/`session`）。`wsUrl.spec.ts` で固定。`Terminal.vue` に `devTerminal` prop を追加し、grid セル（`TerminalCell.vue`）が付与。

## バックエンド差分の影響調査
dev_tool→main の共有/専用 API と副作用の表は #66 にコメント済み。結論: **main 利用者の挙動が実際に変わるのは MCP の strict 削除だけ**で、本PRでそれを single view では発生させない形に整理。

## テスト
`yarn format` / `lint` / `typecheck` / `typecheck:server` / `test`(157) / `build` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)