### PR TITLE
feat(grid): resumed-cell prompt + 3x3 fit + open dir in OS

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes } from "./config-routes.js";
 import { buildClaudeArgs } from "./claude-args.js";
+import { isRecord, parseJsonl, userPromptText, latestUserPromptFromJsonl } from "./transcript.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
@@ -91,8 +92,6 @@ const hasErrnoCode = (e: unknown): e is { code?: string } => typeof e === "objec
 
 // Error message extracted defensively from an unknown thrown value.
 const messageOf = (e: unknown): string => (e instanceof Error ? e.message : String(e));
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -497,30 +496,16 @@ function resolveWorkspace(cwd: string | null): string {
   return CLAUDE_CWD;
 }
 
-// A real user prompt from a JSONL "user" line's content, or null if it's a
-// slash-/local-command wrapper rather than a typed prompt. Content may be a
-// plain string or an array of blocks (guard against null elements).
-function userPromptText(content: unknown): string | null {
-  const text = Array.isArray(content) ? content.map((x) => (isRecord(x) ? String(x.text ?? "") : String(x ?? ""))).join(" ") : content;
-  if (typeof text === "string" && text.trim() && !/^\s*<(local-command|command-|bash-)/.test(text)) {
-    return text.trim();
+// The most recent user prompt from a resumed session's on-disk transcript, so a
+// freshly-resumed cell can show its last prompt instead of just the id. null if
+// there's no transcript yet (a never-prompted session) or it can't be read.
+async function latestUserPrompt(cwd: string, id: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
+    return latestUserPromptFromJsonl(raw);
+  } catch {
+    return null;
   }
-  return null;
-}
-
-// Parse a JSONL file into the objects on each non-blank, valid line.
-function parseJsonl(raw: string): Record<string, unknown>[] {
-  const out: Record<string, unknown>[] = [];
-  for (const line of raw.split("\n")) {
-    if (!line.trim()) continue;
-    try {
-      const o: unknown = JSON.parse(line);
-      if (isRecord(o)) out.push(o);
-    } catch {
-      // Skip malformed lines.
-    }
-  }
-  return out;
 }
 
 // Scan a session JSONL for a human-friendly title and last activity.
@@ -789,16 +774,20 @@ mountConfigRoutes(app, CLAUDE_CWD);
 // GRID-ONLY (dev_tool): initial per-session status + last prompt, so a grid cell
 // can render its header immediately (live updates then arrive via the "sessions"
 // pub/sub channel). The single view reads activity straight from that channel.
-app.get("/api/session/:id", (req, res) => {
+// ?cwd= locates the transcript so a freshly-resumed session shows its most recent
+// prompt; the live in-memory prompt (this process run) takes precedence.
+app.get("/api/session/:id", async (req, res) => {
   const { id } = req.params;
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   const a = activity.get(id) || {};
+  const lastPrompt = lastPrompts.get(id) ?? (await latestUserPrompt(cwd, id));
   res.json({
     id,
-    cwd: CLAUDE_CWD,
+    cwd,
     working: a.working ?? false,
     waiting: a.waiting ?? false,
-    lastPrompt: lastPrompts.get(id) ?? null,
+    lastPrompt,
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes } from "./config-routes.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { isRecord, parseJsonl, userPromptText, latestUserPromptFromJsonl } from "./transcript.js";
+import { mountOpenDirRoute } from "./open-dir.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
@@ -770,6 +771,10 @@ app.get("/api/tool-calls/:sessionId", async (req, res) => {
 // GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
 // modal's directory presets. The single view never calls it.
 mountConfigRoutes(app, CLAUDE_CWD);
+
+// GRID-ONLY (dev_tool): POST /api/open-dir reveals a cell's working directory in the
+// OS file manager (a browser tab can't, but this local server can).
+mountOpenDirRoute(app, { isAllowedOrigin });
 
 // GRID-ONLY (dev_tool): initial per-session status + last prompt, so a grid cell
 // can render its header immediately (live updates then arrive via the "sessions"

--- a/server/open-dir.spec.ts
+++ b/server/open-dir.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { openCommand } from "./open-dir.js";
+
+describe("openCommand", () => {
+  it("uses `open` on macOS", () => {
+    expect(openCommand("darwin")).toBe("open");
+  });
+  it("uses `explorer` on Windows", () => {
+    expect(openCommand("win32")).toBe("explorer");
+  });
+  it("falls back to `xdg-open` elsewhere (Linux)", () => {
+    expect(openCommand("linux")).toBe("xdg-open");
+  });
+});

--- a/server/open-dir.ts
+++ b/server/open-dir.ts
@@ -1,0 +1,46 @@
+import type { Express, Request } from "express";
+import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
+import path from "node:path";
+import { isRecord } from "./transcript.js";
+
+// The native file-manager opener for a platform. The command is a fixed
+// allowlist (never built from input); the directory is passed as a separate argv
+// entry, so there's no shell and no injection surface.
+export function openCommand(platform: NodeJS.Platform): string {
+  if (platform === "win32") return "explorer";
+  if (platform === "darwin") return "open";
+  return "xdg-open";
+}
+
+interface OpenDirOptions {
+  isAllowedOrigin: (origin?: string) => boolean;
+}
+
+// POST /api/open-dir { path } — reveal an absolute, existing directory in the OS
+// file manager. The server runs locally, so this is how a browser tab (which can't
+// touch the filesystem) opens a folder. Guarded by the same-origin check used for
+// the sockets so a random website can't drive it.
+export function mountOpenDirRoute(app: Express, { isAllowedOrigin }: OpenDirOptions) {
+  app.post("/api/open-dir", (req: Request, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).json({ error: "forbidden origin" });
+
+    const dir = isRecord(req.body) && typeof req.body.path === "string" ? req.body.path : "";
+    if (!dir || !path.isAbsolute(dir)) return res.status(400).json({ error: "absolute path required" });
+    try {
+      if (!statSync(dir).isDirectory()) return res.status(400).json({ error: "not a directory" });
+    } catch {
+      return res.status(404).json({ error: "directory not found" });
+    }
+
+    try {
+      // eslint-disable-next-line security/detect-child-process -- fixed command allowlist (open/explorer/xdg-open); dir is a validated existing directory passed as argv, no shell
+      const child = spawn(openCommand(process.platform), [dir], { detached: true, stdio: "ignore" });
+      child.on("error", (e) => console.error(`[open-dir] failed to open ${dir}: ${e.message}`));
+      child.unref();
+      res.json({ ok: true });
+    } catch (e) {
+      res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+    }
+  });
+}

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { latestUserPromptFromJsonl, userPromptText, parseJsonl } from "./transcript.js";
+
+const line = (o: unknown) => JSON.stringify(o);
+
+describe("latestUserPromptFromJsonl", () => {
+  it("returns the last user-typed prompt (string content)", () => {
+    const raw = [
+      line({ type: "user", message: { content: "first prompt" } }),
+      line({ type: "assistant", message: { content: "ok" } }),
+      line({ type: "user", message: { content: "second prompt" } }),
+    ].join("\n");
+    expect(latestUserPromptFromJsonl(raw)).toBe("second prompt");
+  });
+
+  it("handles array block content", () => {
+    const raw = line({
+      type: "user",
+      message: {
+        content: [
+          { type: "text", text: "hello" },
+          { type: "text", text: "world" },
+        ],
+      },
+    });
+    expect(latestUserPromptFromJsonl(raw)).toBe("hello world");
+  });
+
+  it("skips slash/local-command wrappers (not real typed prompts)", () => {
+    const raw = [
+      line({ type: "user", message: { content: "real prompt" } }),
+      line({ type: "user", message: { content: "<local-command>/clear</local-command>" } }),
+    ].join("\n");
+    expect(latestUserPromptFromJsonl(raw)).toBe("real prompt");
+  });
+
+  it("falls back to a last-prompt record when there are no user lines", () => {
+    const raw = [line({ type: "assistant", message: { content: "hi" } }), line({ type: "last-prompt", lastPrompt: "from record" })].join("\n");
+    expect(latestUserPromptFromJsonl(raw)).toBe("from record");
+  });
+
+  it("prefers a user line over a last-prompt record", () => {
+    const raw = [line({ type: "last-prompt", lastPrompt: "record" }), line({ type: "user", message: { content: "typed" } })].join("\n");
+    expect(latestUserPromptFromJsonl(raw)).toBe("typed");
+  });
+
+  it("returns null for an empty transcript", () => {
+    expect(latestUserPromptFromJsonl("")).toBeNull();
+  });
+
+  it("tolerates blank and malformed lines", () => {
+    const raw = ["", "not json", line({ type: "user", message: { content: "ok" } }), "{bad"].join("\n");
+    expect(latestUserPromptFromJsonl(raw)).toBe("ok");
+  });
+});
+
+describe("userPromptText", () => {
+  it("trims and returns plain text", () => {
+    expect(userPromptText("  hi  ")).toBe("hi");
+  });
+  it("rejects empty / whitespace", () => {
+    expect(userPromptText("   ")).toBeNull();
+  });
+  it("rejects command wrappers", () => {
+    expect(userPromptText("<bash-input>ls</bash-input>")).toBeNull();
+  });
+});
+
+describe("parseJsonl", () => {
+  it("keeps valid object lines and skips blank / malformed ones", () => {
+    expect(parseJsonl(['{"a":1}', "", "oops", '{"b":2}'].join("\n"))).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+});

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -1,0 +1,48 @@
+// Pure helpers for reading Claude session transcripts (the per-project .jsonl
+// files). Kept separate from index.ts so they're unit-testable without the server's
+// startup side effects.
+
+export const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+// A real user prompt from a JSONL "user" line's content, or null if it's a
+// slash-/local-command wrapper rather than a typed prompt. Content may be a plain
+// string or an array of blocks (guard against null elements).
+export function userPromptText(content: unknown): string | null {
+  const text = Array.isArray(content) ? content.map((x) => (isRecord(x) ? String(x.text ?? "") : String(x ?? ""))).join(" ") : content;
+  if (typeof text === "string" && text.trim() && !/^\s*<(local-command|command-|bash-)/.test(text)) {
+    return text.trim();
+  }
+  return null;
+}
+
+// Parse a JSONL file into the objects on each non-blank, valid line.
+export function parseJsonl(raw: string): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const o: unknown = JSON.parse(line);
+      if (isRecord(o)) out.push(o);
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+  return out;
+}
+
+// The most recent user-typed prompt in a transcript: the last "user" line with real
+// text, falling back to a "last-prompt" record if there are no user lines. Used to
+// show a freshly-resumed session's latest prompt when no live in-memory prompt exists.
+export function latestUserPromptFromJsonl(raw: string): string | null {
+  let lastUser: string | null = null;
+  let lastPromptRecord: string | null = null;
+  for (const o of parseJsonl(raw)) {
+    if (o.type === "user") {
+      const prompt = userPromptText(isRecord(o.message) ? o.message.content : undefined);
+      if (prompt) lastUser = prompt;
+    } else if (o.type === "last-prompt" && o.lastPrompt) {
+      lastPromptRecord = String(o.lastPrompt);
+    }
+  }
+  return lastUser ?? lastPromptRecord;
+}

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -102,6 +102,22 @@ describe("TerminalCell", () => {
     expect(term.props("cwd")).toBe("/home/me/proj");
   });
 
+  it("shows the resumed session's latest prompt from /api/session (with cwd), not the bare id", async () => {
+    const urls: string[] = [];
+    globalThis.fetch = vi.fn((url: string) => {
+      urls.push(String(url));
+      if (String(url).includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: "refactor the parser" }) });
+    }) as unknown as typeof fetch;
+
+    const id = "11111111-1111-1111-1111-111111111111";
+    const w = mountCell(id, { initialCwd: "/home/me/proj" });
+    await flushPromises();
+
+    expect(w.find(".cell-prompt").text()).toBe("refactor the parser");
+    expect(urls.some((u) => u.includes(`/api/session/${id}`) && u.includes("cwd=%2Fhome%2Fme%2Fproj"))).toBe(true);
+  });
+
   it("shows no resume list when the dir has no sessions", async () => {
     const w = mountCell(null);
     await flushPromises();

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -71,6 +71,24 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-dir").text()).toBe("~/ss/my-project");
   });
 
+  it("clicking the header dir asks the server to open that folder", async () => {
+    const urls: string[] = [];
+    const bodies: string[] = [];
+    globalThis.fetch = vi.fn((url: string, init?: { body?: string }) => {
+      urls.push(String(url));
+      if (init?.body) bodies.push(init.body);
+      if (String(url).includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/ss/proj" });
+    await flushPromises();
+    await w.find(".cell-dir").trigger("click");
+
+    expect(urls).toContain("/api/open-dir");
+    expect(bodies.some((b) => b.includes("/home/me/ss/proj"))).toBe(true);
+  });
+
   it("shows a non-home path in full", async () => {
     const w = mountCell("55555555-5555-5555-5555-555555555555", { initialCwd: "/var/data/proj" });
     await flushPromises();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -67,7 +67,10 @@ function applyActivity(d: ActivityMsg) {
 
 async function loadInitial(id: string) {
   try {
-    const res = await fetch(`/api/session/${id}`);
+    // Pass the cell's dir so the server can read the transcript and report the
+    // session's most recent prompt (not just the bare id) after a resume.
+    const q = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
+    const res = await fetch(`/api/session/${id}${q}`);
     if (!res.ok) return;
     const data = await res.json();
     // Guard against a stale response: the cell may have closed / switched session

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -170,6 +170,21 @@ function relativeTime(ms: number): string {
   return `${Math.floor(hr / 24)}d ago`;
 }
 
+// Reveal this cell's working directory in the OS file manager. The browser can't
+// open a folder, but the local server can (POST /api/open-dir).
+async function openDir() {
+  if (!cwd.value) return;
+  try {
+    await fetch("/api/open-dir", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: cwd.value }),
+    });
+  } catch {
+    // best-effort — opening a folder is non-critical
+  }
+}
+
 // The server reports where the PTY actually runs (it may have rejected the
 // requested dir). Adopt it as the truth — display and persist the effective cwd.
 function onServerCwd(c: string) {
@@ -224,7 +239,7 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
     <template v-if="launched">
       <div class="cell-header">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
-        <span v-if="dirDisplay" class="cell-dir" :title="cwd ?? ''">{{ dirDisplay }}</span>
+        <button v-if="dirDisplay" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">{{ dirDisplay }}</button>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <span class="cell-actions">
           <button
@@ -324,12 +339,21 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 .cell-dir {
   flex: 0 1 auto;
   max-width: 60%;
+  border: none;
+  background: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 11px;
   color: #7f88ad;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.cell-dir:hover {
+  color: #aeb6dd;
+  text-decoration: underline;
 }
 .cell-prompt {
   flex: 1 1 auto;
@@ -378,12 +402,17 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 /* Empty cell: pick a directory, then launch. */
 .cell-launch {
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  /* `safe` centers when it fits but falls back to top-aligned (so nothing is
+     clipped past the scroll origin) when the form is taller than a short cell —
+     e.g. a 3x3 cell with a long resume list. overflow-y makes it reachable. */
+  justify-content: safe center;
   gap: 8px;
   padding: 16px;
+  overflow-y: auto;
 }
 .cell-presets {
   display: flex;
@@ -471,8 +500,6 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   flex-direction: column;
   gap: 4px;
   width: 100%;
-  max-height: 160px;
-  overflow-y: auto;
 }
 .cell-resume-item {
   display: flex;


### PR DESCRIPTION
## Summary
grid セルの UX を3点修正。**#68 (MCP) に stack** しています（base = `feat/mcp-gate-and-audit`、diff を grid-UX だけに保つため）。#68 が dev_tool にマージされたら base を dev_tool に付け替えます。

1. **resume したセルの直近プロンプト表示** — resume 直後にヘッダがセッションID 8桁になっていた。`/api/session/:id` が in-memory の `lastPrompts`（プロセス起動中のみ）しか見ていなかったため。`?cwd=` を受けて transcript(.jsonl) から最新の user prompt を読むフォールバックを追加（ライブの prompt が優先）。
2. **3x3 でセル下部が見切れる** — グリッド自体は収まっている（3×245px、ビューポート内）。短いセルで launch フォーム（長い resume リスト付き）が 245px を超えて `overflow:hidden` でクリップされ、下のセッションに到達できなかった。フォームを `overflow-y:auto` + `justify-content: safe center` に（収まる時は中央、溢れる時は上揃え＋スクロール）。**puppeteer で 3x3 の最下要素まで到達可能なことを確認**。
3. **ヘッダの dir クリックで OS のファイルマネージャを開く** — ブラウザ単体ではフォルダを開けないが、ローカルの Express なら可能。`POST /api/open-dir` が検証済みの絶対・実在ディレクトリに対し OS opener（`open`/`explorer`/`xdg-open`）を実行。ソケットと同じ same-origin チェックでガード。

## Items to Confirm / Review
- [ ] resume 時、`/api/session/:id?cwd=` の transcript フォールバックが意図どおり（ライブ prompt 優先）。
- [ ] `/api/open-dir` のセキュリティ: same-origin ガード + 絶対パス + 実在ディレクトリ検証。`open <dir>` は `.app`(ディレクトリ)を渡すと起動し得るが、cross-origin は 403 で弾く想定。
- [ ] 3x3 以外（2x2 等）の launch フォームが従来どおり中央寄せで崩れないこと。

## User Prompt
> - ちょっきん（直近）のユーザプロンプトを表示させるのってできる？ → resume をなおしてほしい。
> - 3x3 の表示だと、行の下の方が表示されないっぽい。windows サイズ変えても全部見えるようにしてほしい。
> - header の dir をクリックすると OS 側でそのフォルダを開いてほしい。（electron じゃないから無理か… express から開けるか？ → はい）

## 実装
- `server/transcript.ts`（新規・別コミット）: `parseJsonl`/`userPromptText`/`latestUserPromptFromJsonl`（index.ts から抽出・`readSessionMeta` も再利用）。`/api/session/:id` を async + `?cwd=` + transcript フォールバックに。
- `src/components/TerminalCell.vue`: `.cell-launch` をスクロール可能に（`safe center`）/ resume リストの内側 max-height を撤去し単一スクロール。ヘッダ dir を button 化 → `openDir()`。
- `server/open-dir.ts`（新規）: `openCommand(platform)` + `mountOpenDirRoute`（origin/絶対/実在ディレクトリ検証 → `spawn` no-shell）。

## テスト
- `server/transcript.spec.ts` / `server/open-dir.spec.ts` / `TerminalCell.spec.ts`（resume プロンプト・open-dir クリック）追加。
- `/api/open-dir` の 400/400/404/403 を curl で確認。3x3 到達性は puppeteer で確認。
- `format`/`lint`/`typecheck`/`typecheck:server`/`test`(173)/`build` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)