### PR TITLE
fix(terminal): stop reconnecting on a server-declared startup error

### DIFF
--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -104,6 +104,14 @@ function connect() {
       sawExit = true;
       term.write("\r\n\x1b[33m[detached — this session is open in another window]\x1b[0m\r\n");
       status.value = "disconnected";
+    } else if (msg.type === "error") {
+      // Server-declared terminal failure (e.g. the `claude` CLI isn't installed).
+      // Not transient — reconnecting would just re-trigger the failed spawn, so
+      // stop and surface a stable error instead of looping.
+      sawExit = true;
+      const detail = typeof msg.message === "string" ? msg.message : "failed to start";
+      term.write(`\r\n\x1b[31m[${detail}]\x1b[0m\r\n`);
+      status.value = "disconnected";
     }
   };
 


### PR DESCRIPTION
## Summary
PR #66 の Codex 指摘（CHANGES REQUESTED）への対応。`Terminal.vue` の auto-reconnect が**全ての socket close を transient 扱い**していたため、サーバが claude を spawn できず `{type:"error"}` を送って close した場合、クライアントがその frame を処理せず `onclose` が再接続を無限にスケジュール → 失敗 spawn を延々と繰り返す問題。

`{type:"error"}` を `exit`/`superseded` と同様に扱い、`sawExit` を立てて再接続を止め、メッセージを表示する（5行）。

## Items to Confirm / Review
- [ ] `{type:"error"}` 受信時に再接続が止まること（`sawExit=true` で `scheduleReconnect` が早期 return）。
- [ ] 既存の transient 切断（サーバ再起動・瞬断）では従来どおり再接続すること。

## 検証
- 停止メカニズム（`sawExit`）は exit 経路で puppeteer 実測済み（frame 受信後に再接続が止まる）。error frame は同一機構を使用。
- node-pty はこの macOS では bad bin/cwd でも同期 throw せず exit 経路を通る（error frame は他プラットフォーム/pty ヘルパ不可時に発生）。サーバ側に当該経路が存在する以上クライアントは処理すべき、という指摘どおりの修正。
- `format`/`lint`/`typecheck`/`test`(173)/`build` 全 green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)