### PR TITLE
mulmoterminal@0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Release bump 0.1.5 → 0.2.0 (minor) for the npm publish.

Includes (since 0.1.4): multi-terminal grid view + filmstrip zoom, per-terminal working dir + directory presets, resumed-session prompt display, open-dir in the OS file manager, MCP mode split (grid runs plain dev terminals; single view unchanged), and reload resilience (grace-reap / reattach / auto-reconnect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)