### PR TITLE
fix(grid): full-height solo zoom + compaction regression tests (PR #71 review)

### DIFF
--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -133,4 +133,53 @@ describe("TerminalGrid", () => {
     expect(cellsOf(w)).toHaveLength(4);
     expect(cellsOf(w).every((c) => c.props("initialSessionId") === null)).toBe(true);
   });
+
+  const A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  const B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  const C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+  const D = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+  const E = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+
+  it("close fills the gap and keeps each session paired with its cwd (compaction)", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, C, D], cwds: ["/a", "/b", "/c", "/d"], expanded: null }));
+    const w = mountGrid("2x2");
+    await flushPromises();
+    cellsOf(w)[1].vm.$emit("close"); // close B (position 1)
+    await nextTick();
+
+    // B's slot is emptied and the rest pack forward, cwds following their session.
+    expect(saved().sessions.slice(0, 4)).toEqual([A, C, D, null]);
+    expect(saved().cwds.slice(0, 4)).toEqual(["/a", "/c", "/d", null]);
+    const cells = cellsOf(w);
+    expect(cells[1].props("initialSessionId")).toBe(C);
+    expect(cells[1].props("initialCwd")).toBe("/c");
+  });
+
+  it("packs running terminals to the top-left on layout shrink, preserving session/cwd pairing", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, C, null, E], cwds: ["/a", null, "/c", null, "/e"], expanded: null }));
+    const w = mountGrid("3x3");
+    await flushPromises();
+    await w.setProps({ layout: "2x2" });
+    await nextTick();
+
+    expect(saved().sessions.slice(0, 3)).toEqual([A, C, E]);
+    expect(saved().cwds.slice(0, 3)).toEqual(["/a", "/c", "/e"]);
+    const cells = cellsOf(w); // 2x2 → 4 visible
+    expect(cells.map((c) => c.props("initialSessionId")).slice(0, 3)).toEqual([A, C, E]);
+    expect(cells[1].props("initialCwd")).toBe("/c");
+  });
+
+  it("collapses the filmstrip strip (full-height zoom) when the zoomed cell is the only running terminal", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: [], expanded: 0 }));
+    const w = mountGrid("2x2");
+    await flushPromises();
+    expect(w.find(".stage").classes()).toContain("solo");
+  });
+
+  it("keeps the strip when another terminal is running while zoomed", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, null, null], cwds: [], expanded: 0 }));
+    const w = mountGrid("2x2");
+    await flushPromises();
+    expect(w.find(".stage").classes()).not.toContain("solo");
+  });
 });

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -137,13 +137,18 @@ onMounted(() => (mounted.value = true));
 
 const zoomed = computed(() => expandedUid.value !== null && mounted.value);
 
+// When the zoomed cell is the only RUNNING terminal, there's nothing useful to put
+// in the strip (just empty launch forms), so collapse it and let the zoom fill the
+// full height — matching the pre-filmstrip full-height zoom.
+const soloZoom = computed(() => zoomed.value && !visibleSlots.value.some((s) => s.uid !== expandedUid.value && s.session !== null));
+
 // While zoomed, push empty cells to the end of the strip so the open terminals line
 // up on the left. Pure CSS order — never reorders the DOM.
 const stripOrder = (slot: Slot) => (zoomed.value && slot.uid !== expandedUid.value && slot.session === null ? { order: 1 } : undefined);
 </script>
 
 <template>
-  <div class="stage" :class="{ zoomed }">
+  <div class="stage" :class="{ zoomed, solo: soloZoom }">
     <div ref="zoomMain" class="zoom-main" />
     <div class="grid" :style="gridStyle">
       <Teleport v-for="slot in visibleSlots" :key="slot.uid" :to="zoomMain" :disabled="!(zoomed && slot.uid === expandedUid)">
@@ -216,5 +221,10 @@ const stripOrder = (slot: Slot) => (zoomed.value && slot.uid !== expandedUid.val
   flex: 0 0 260px;
   height: 100%;
   min-width: 0;
+}
+
+/* No other running terminal — hide the strip so the zoom uses the full height. */
+.stage.zoomed.solo .grid {
+  display: none;
 }
 </style>


### PR DESCRIPTION
## Summary
PR #71（マージ済み）の Codex レビュー指摘への後追い対応。

| 指摘 | 対応 |
|---|---|
| `POST /api/_debug`（無認証の書き込みエンドポイント） | ✅ 既に #71 マージ前に revert 済み（main に無し）。確認のみ |
| `1x1` ズームで 150px ストリップが残り本体が縮む | ✅ `1x1` レイアウトは存在しないが、本質（**他に起動中端末が無いのにストリップ分の高さを取る**）に対応。zoom 中に起動中が拡大セルだけなら `solo` 判定でストリップを畳み、**フルハイトズーム**に |
| `compact()` の回帰テストが無い | ✅ close のギャップ詰め／レイアウト縮小のパックで、**session↔cwd のペア維持**と**永続化された詰め順**を検証するテストを追加 |

## Items to Confirm / Review
- [ ] solo zoom: 起動中が1つだけのとき zoom でストリップが消えてフルハイトになる（`.stage.zoomed.solo .grid { display:none }`）。
- [ ] compaction: close と layout 縮小で session/cwd の対応と詰め順が保たれる（テストで固定）。

## テスト
`TerminalGrid.spec.ts` に4件追加（close ギャップ詰め＋ペア維持 / layout 縮小パック＋ペア維持 / solo クラス / 非 solo）。`lint`/`typecheck`/`test`(177)/`build` 全 green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)