### PR TITLE
feat: insert file paths into the terminal (drag-drop + file-picker button)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ WebSocket. A sidebar lists every Claude session for the project and reflects, in
 real time, which sessions are **working** (Claude is thinking) and which **need
 attention** (waiting for input, or finished with output you haven't seen).
 
+**Inserting a file path** — like a native terminal, you can put a file's absolute
+path into the prompt: **drag a file** onto the terminal (works where the browser
+exposes the path via `file://` — Firefox/Safari), or click the **📎 file button**
+in the terminal header, which asks the local server to open the OS file dialog and
+inserts the chosen path (works in every browser, including Chrome). The path is
+inserted at the cursor — it is not submitted, so you can review it first.
+
 ---
 
 ## Install & run

--- a/plans/feat-browser-file-drop.md
+++ b/plans/feat-browser-file-drop.md
@@ -1,0 +1,78 @@
+# Plan: ブラウザ端末へのファイルD&Dで絶対パス挿入
+
+Issue: #75
+作成日: 2026-06-21
+
+ネイティブ端末（Terminal.app / iTerm）でファイルをD&Dすると絶対パスが挿入されるのと
+同じことを、ブラウザの xterm.js 端末でも実現する。
+
+---
+
+## 背景・調査
+
+- 入力経路は `Terminal.vue` の `term.onData → ws.send({type:"input", data}) → pty.write`。
+  パス文字列を input として送れば挿入できる。
+- ブラウザはセキュリティ上、ドロップ `File` の絶対パスを渡さない（`File.name` のみ。
+  `File.path` は Electron 専用）。
+- 絶対パスは `dataTransfer.getData("text/uri-list")`（無ければ `text/plain`）の
+  `file://` URI から取得できる**場合がある**。Firefox / Safari は公開、Chrome は
+  公開しないことが多い（= ブラウザ依存）。
+
+## 方針（確定）
+
+1. **file:// のみ**: `file://` URI を解析して絶対パスを取り出して挿入。ファイル内容の
+   アップロードや一時コピーはしない。
+2. **挿入のみ・Enter なし**: パスをそのまま input として送る。送信はユーザーに委ねる。
+3. **複数ファイル**: スペース区切り。スペース等を含むパスはシェルクォート（単一引用符）。
+4. `file://` が取れないブラウザでは何も挿入しない（誤った文字列を入れない）。
+5. 単一表示・グリッド両方の `Terminal.vue` で有効。
+
+## 実装
+
+### 純粋関数（テスト可能） — `src/components/dropPaths.ts`
+- `parseFileUris(uriList: string): string[]`
+  - 改行区切り、`#` コメント行と空行を無視、各行を `file://` URI として絶対パスへ。
+  - `new URL()` で解析、`decodeURIComponent(pathname)`、Windows `/C:/...` は先頭スラッシュ除去。
+  - `file://` 以外・解析不能はスキップ。
+- `toShellArg(path: string): string`
+  - 安全な文字のみならそのまま、それ以外は単一引用符で囲み `'` をエスケープ。
+- `dropTextFromUriList(uriList: string): string`
+  - 上記2つを合成してスペース区切りの挿入文字列を返す（空なら空文字）。
+
+### Terminal.vue
+- `.terminal-container` に `@dragover.prevent` と `@drop` を付与。
+- `onDrop`: `dataTransfer.files.length === 0` なら無視（ファイル以外のドラッグを誤挿入しない）。
+  `text/uri-list`（無ければ `text/plain`）から `dropTextFromUriList` で文字列化し、空でなければ
+  既存の input チャンネルで送信。`term.focus()`。
+- ドラッグ中の軽いハイライト（`dragOver` ref）。
+
+### テスト — `src/components/dropPaths.spec.ts`（vitest）
+- 単一/複数 file:// URI、`%20`（スペース）デコード、`#` コメント・空行無視、
+  非 file:// 行スキップ、Windows ドライブパス、単一引用符エスケープ、空入力。
+
+## 追加: file アイコン（全ブラウザ向け・サーバ側ネイティブダイアログ）
+
+D&D の `file://` は Firefox/Safari でしか取れない。Chrome を含む全ブラウザで実パスを
+得るため、**ローカルサーバが OS のファイル選択ダイアログを開いて絶対パスを返す**経路を
+追加する（`<input type=file>`/`webkitdirectory` はブラウザが絶対パスを伏せるため不可）。
+
+### サーバ — `server/pick-file.ts`（`open-dir.ts` を踏襲）
+- `pickFileCommand(platform)`: macOS `osascript`（`choose file ... multiple`）/
+  Windows `powershell`（OpenFileDialog）/ その他 `zenity`。固定コマンド＋固定 argv
+  （プロンプトは定数）でシェル無し・入力補間なし。
+- `parsePickerOutput(stdout)`: 改行分割・trim・絶対パスのみ。キャンセルは空 → `[]`。
+- `mountPickFileRoute`: `POST /api/pick-file` → ダイアログを開き `{ paths: string[] }`。
+  同一オリジンガードは他のローカル操作ルートと同じ。
+- テスト `server/pick-file.spec.ts`（vitest, node 環境で実行）。
+
+### Terminal.vue
+- ヘッダに file アイコン（Material Symbols `attach_file`）。クリックで `/api/pick-file`
+  を叩き、返った絶対パスを `toInsertText`（D&D と共通）で挿入。
+- 挿入ロジックは `insertText()` に集約し D&D と共有。
+
+## スコープ外
+- ファイル内容のアップロード／サーバ一時保存方式（コピーのパスになるため）。
+
+## 確認事項（手動）
+- OSネイティブのドラッグは Playwright で再現困難。対象ブラウザ（Chrome/Safari/Firefox）で
+  実際にドロップして挙動を確認する。

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,6 +19,7 @@ import { mountConfigRoutes } from "./config-routes.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { isRecord, parseJsonl, userPromptText, latestUserPromptFromJsonl } from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
+import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
@@ -775,6 +776,11 @@ mountConfigRoutes(app, CLAUDE_CWD);
 // GRID-ONLY (dev_tool): POST /api/open-dir reveals a cell's working directory in the
 // OS file manager (a browser tab can't, but this local server can).
 mountOpenDirRoute(app, { isAllowedOrigin });
+
+// POST /api/pick-file opens the OS file dialog and returns the chosen absolute
+// path(s) — how a browser tab inserts a real filesystem path into the terminal
+// (the browser hides paths from drag/drop and <input type=file>).
+mountPickFileRoute(app, { isAllowedOrigin });
 
 // GRID-ONLY (dev_tool): initial per-session status + last prompt, so a grid cell
 // can render its header immediately (live updates then arrive via the "sessions"

--- a/server/pick-file.spec.ts
+++ b/server/pick-file.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { pickFileCommand, parsePickerOutput } from "./pick-file.js";
+
+describe("pickFileCommand", () => {
+  it("uses osascript on macOS", () => {
+    expect(pickFileCommand("darwin").cmd).toBe("osascript");
+  });
+  it("uses powershell on Windows", () => {
+    expect(pickFileCommand("win32").cmd).toBe("powershell");
+  });
+  it("falls back to zenity elsewhere (Linux)", () => {
+    expect(pickFileCommand("linux").cmd).toBe("zenity");
+  });
+});
+
+describe("parsePickerOutput", () => {
+  it("splits newline-separated absolute paths", () => {
+    expect(parsePickerOutput("/a/b.txt\n/c/d.txt")).toEqual(["/a/b.txt", "/c/d.txt"]);
+  });
+  it("trims and drops blank lines", () => {
+    expect(parsePickerOutput("  /a.txt  \n\n")).toEqual(["/a.txt"]);
+  });
+  it("handles CRLF output", () => {
+    expect(parsePickerOutput("/a.txt\r\n/b.txt\r\n")).toEqual(["/a.txt", "/b.txt"]);
+  });
+  it("rejects relative or junk lines (e.g. a cancel message)", () => {
+    expect(parsePickerOutput("not a path\nrelative/p.txt")).toEqual([]);
+  });
+  it("returns empty for empty output (user canceled)", () => {
+    expect(parsePickerOutput("")).toEqual([]);
+  });
+});

--- a/server/pick-file.ts
+++ b/server/pick-file.ts
@@ -1,0 +1,73 @@
+import type { Express, Request } from "express";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+// A native "open file" dialog per platform whose stdout is the selection's
+// absolute path(s), newline-separated. Browsers can't hand the terminal a real
+// filesystem path, but the local server can ask the OS. Fixed command + literal
+// argv (the prompt is a constant) — no shell, no input interpolation.
+const PICK_PROMPT = "Select file(s)";
+
+export function pickFileCommand(platform: NodeJS.Platform): { cmd: string; args: string[] } {
+  if (platform === "darwin")
+    return {
+      cmd: "osascript",
+      args: [
+        "-e",
+        `set chosen to choose file with prompt "${PICK_PROMPT}" with multiple selections allowed`,
+        "-e",
+        "set text item delimiters to linefeed",
+        "-e",
+        "set out to {}",
+        "-e",
+        "repeat with f in chosen",
+        "-e",
+        "set end of out to POSIX path of f",
+        "-e",
+        "end repeat",
+        "-e",
+        "return out as text",
+      ],
+    };
+  if (platform === "win32")
+    return {
+      cmd: "powershell",
+      args: [
+        "-NoProfile",
+        "-STA",
+        "-Command",
+        "Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join \"`n\" }",
+      ],
+    };
+  return { cmd: "zenity", args: ["--file-selection", "--multiple", "--separator=\n", `--title=${PICK_PROMPT}`] };
+}
+
+export function parsePickerOutput(stdout: string): string[] {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && path.isAbsolute(line));
+}
+
+interface PickFileOptions {
+  isAllowedOrigin: (origin?: string) => boolean;
+}
+
+// POST /api/pick-file — open the OS file dialog and return the chosen absolute
+// path(s). A user cancel yields empty stdout, so the response is { paths: [] }.
+// Same-origin guarded like the other local-action routes.
+export function mountPickFileRoute(app: Express, { isAllowedOrigin }: PickFileOptions) {
+  app.post("/api/pick-file", (req: Request, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).json({ error: "forbidden origin" });
+    const { cmd, args } = pickFileCommand(process.platform);
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const out: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => out.push(chunk));
+    child.on("error", (e) => {
+      if (!res.headersSent) res.status(500).json({ error: `file dialog unavailable: ${e.message}` });
+    });
+    child.on("close", () => {
+      if (!res.headersSent) res.json({ paths: parsePickerOutput(Buffer.concat(out).toString()) });
+    });
+  });
+}

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -5,6 +5,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl } from "./wsUrl";
+import { dropTextFromUriList, toInsertText } from "./dropPaths";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
@@ -18,6 +19,7 @@ const emit = defineEmits<{ (e: "session" | "cwd", value: string): void }>();
 
 const terminalRef = ref<HTMLDivElement>();
 const status = ref<"connecting" | "connected" | "disconnected">("connecting");
+const dragOver = ref(false);
 
 let term: Terminal;
 let fitAddon: FitAddon;
@@ -215,6 +217,52 @@ function terminate() {
 }
 defineExpose({ submitText, terminate });
 
+// Insert text (a path, or space-joined paths) at the terminal cursor via the
+// normal input channel — no trailing CR, so the user reviews and submits.
+function insertText(text: string) {
+  if (!text) return;
+  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: "input", data: text }));
+  term.focus();
+}
+
+// Drop a file onto the terminal to insert its absolute path, like a native
+// terminal. Browsers expose the real path only via the drag's file:// URIs
+// (text/uri-list); the File object hides it. Browsers that withhold the path
+// (e.g. Chrome) yield no URIs, so we insert nothing rather than a wrong string —
+// the file-picker button is the path-in-Chrome route.
+function onDrop(e: DragEvent) {
+  dragOver.value = false;
+  const dt = e.dataTransfer;
+  if (!dt || dt.files.length === 0) return; // not a file drop — leave text drags alone
+  e.preventDefault();
+  insertText(dropTextFromUriList(dt.getData("text/uri-list") || dt.getData("text/plain")));
+}
+
+function onDragOver(e: DragEvent) {
+  if (!e.dataTransfer?.types.includes("Files")) return;
+  e.preventDefault(); // required for the drop event to fire
+  dragOver.value = true;
+}
+
+// The file-icon button: the browser can't reveal a real path, so the local
+// server opens the OS file dialog and returns the chosen absolute path(s). Works
+// in every browser (the cross-browser path route, unlike file:// drag/drop).
+async function pickFile() {
+  try {
+    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" } });
+    if (!res.ok) return;
+    const data: unknown = await res.json();
+    const paths = isRecord(data) && Array.isArray(data.paths) ? data.paths.filter((p): p is string => typeof p === "string") : [];
+    insertText(toInsertText(paths));
+  } catch {
+    // best-effort — the native dialog is unavailable or the user canceled
+  }
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
 onUnmounted(() => {
   disposed = true;
   if (reconnectTimer) clearTimeout(reconnectTimer);
@@ -229,8 +277,11 @@ onUnmounted(() => {
     <div class="header">
       <span class="title">Terminal</span>
       <span :class="['status', status]">{{ status }}</span>
+      <button type="button" class="pick-file" title="Insert a file path" aria-label="Insert a file path" @click="pickFile">
+        <span class="material-symbols-outlined">attach_file</span>
+      </button>
     </div>
-    <div ref="terminalRef" class="terminal-container" />
+    <div ref="terminalRef" :class="['terminal-container', { 'drag-over': dragOver }]" @dragover="onDragOver" @dragleave="dragOver = false" @drop="onDrop" />
   </div>
 </template>
 
@@ -259,6 +310,27 @@ onUnmounted(() => {
   font-weight: 600;
 }
 
+.pick-file {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: #9aa7d0;
+  cursor: pointer;
+}
+
+.pick-file:hover {
+  background: #25325a;
+  color: #e0e0e0;
+}
+
+.pick-file .material-symbols-outlined {
+  font-size: 18px;
+}
+
 .status {
   font-size: 12px;
   padding: 2px 8px;
@@ -283,5 +355,10 @@ onUnmounted(() => {
 .terminal-container {
   flex: 1;
   padding: 4px;
+}
+
+.terminal-container.drag-over {
+  outline: 2px dashed #7e8ce0;
+  outline-offset: -2px;
 }
 </style>

--- a/src/components/dropPaths.spec.ts
+++ b/src/components/dropPaths.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { parseFileUris, toShellArg, toInsertText, dropTextFromUriList } from "./dropPaths";
+
+describe("parseFileUris", () => {
+  it("parses a single file:// URI into an absolute path", () => {
+    expect(parseFileUris("file:///Users/me/a.txt")).toEqual(["/Users/me/a.txt"]);
+  });
+
+  it("parses multiple newline-separated URIs", () => {
+    expect(parseFileUris("file:///a/b.txt\nfile:///c/d.txt")).toEqual(["/a/b.txt", "/c/d.txt"]);
+  });
+
+  it("decodes percent-encoded characters (spaces, unicode)", () => {
+    expect(parseFileUris("file:///Users/me/My%20File.txt")).toEqual(["/Users/me/My File.txt"]);
+    expect(parseFileUris("file:///Users/me/%E6%97%A5%E6%9C%AC.md")).toEqual(["/Users/me/日本.md"]);
+  });
+
+  it("ignores comment lines and blanks (uri-list format)", () => {
+    expect(parseFileUris("# comment\n\nfile:///a.txt\n")).toEqual(["/a.txt"]);
+  });
+
+  it("skips non-file:// lines (http, bare text)", () => {
+    expect(parseFileUris("https://example.com\njust text\nfile:///a.txt")).toEqual(["/a.txt"]);
+  });
+
+  it("strips the leading slash from a Windows drive path", () => {
+    expect(parseFileUris("file:///C:/Users/me/a.txt")).toEqual(["C:/Users/me/a.txt"]);
+  });
+
+  it("returns empty for empty or path-less input", () => {
+    expect(parseFileUris("")).toEqual([]);
+    expect(parseFileUris("# only a comment")).toEqual([]);
+  });
+});
+
+describe("toShellArg", () => {
+  it("leaves a bare safe path unquoted", () => {
+    expect(toShellArg("/Users/me/a.txt")).toBe("/Users/me/a.txt");
+  });
+
+  it("single-quotes paths with spaces or shell-special chars", () => {
+    expect(toShellArg("/Users/me/My File.txt")).toBe("'/Users/me/My File.txt'");
+    expect(toShellArg("/Users/me/a;rm -rf b")).toBe("'/Users/me/a;rm -rf b'");
+  });
+
+  it("escapes embedded single quotes", () => {
+    expect(toShellArg("/Users/me/it's.txt")).toBe("'/Users/me/it'\\''s.txt'");
+  });
+});
+
+describe("toInsertText", () => {
+  it("joins quoted paths with spaces", () => {
+    expect(toInsertText(["/a.txt", "/My Dir/b.txt"])).toBe("/a.txt '/My Dir/b.txt'");
+  });
+  it("returns empty string for no paths", () => {
+    expect(toInsertText([])).toBe("");
+  });
+});
+
+describe("dropTextFromUriList", () => {
+  it("joins quoted paths with spaces", () => {
+    expect(dropTextFromUriList("file:///a.txt\nfile:///My%20Dir/b.txt")).toBe("/a.txt '/My Dir/b.txt'");
+  });
+
+  it("returns empty string when no file path is present", () => {
+    expect(dropTextFromUriList("")).toBe("");
+    expect(dropTextFromUriList("https://example.com")).toBe("");
+  });
+});

--- a/src/components/dropPaths.spec.ts
+++ b/src/components/dropPaths.spec.ts
@@ -27,6 +27,14 @@ describe("parseFileUris", () => {
     expect(parseFileUris("file:///C:/Users/me/a.txt")).toEqual(["C:/Users/me/a.txt"]);
   });
 
+  it("preserves the host for a UNC share (does not drop the authority)", () => {
+    expect(parseFileUris("file://server/share/a.txt")).toEqual(["\\\\server\\share\\a.txt"]);
+  });
+
+  it("treats a localhost authority as a local path", () => {
+    expect(parseFileUris("file://localhost/Users/me/a.txt")).toEqual(["/Users/me/a.txt"]);
+  });
+
   it("returns empty for empty or path-less input", () => {
     expect(parseFileUris("")).toEqual([]);
     expect(parseFileUris("# only a comment")).toEqual([]);

--- a/src/components/dropPaths.ts
+++ b/src/components/dropPaths.ts
@@ -1,0 +1,42 @@
+// Browsers hide a dropped file's real path on the File object (security); the
+// absolute path is only reachable through the file:// URIs some browsers put in
+// the drag's text/uri-list. These helpers turn that list into the text we inject
+// into the terminal — pure so they can be unit-tested without a DataTransfer.
+
+const SHELL_SAFE = /^[A-Za-z0-9_./:@%+,=-]+$/;
+
+function fileUriToPath(uri: string): string | null {
+  try {
+    const url = new URL(uri);
+    if (url.protocol !== "file:") return null;
+    const decoded = decodeURIComponent(url.pathname);
+    // A Windows drive path arrives as "/C:/dir"; drop the leading slash.
+    return /^\/[A-Za-z]:/.test(decoded) ? decoded.slice(1) : decoded;
+  } catch {
+    return null;
+  }
+}
+
+export function parseFileUris(uriList: string): string[] {
+  return uriList
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .map(fileUriToPath)
+    .filter((path): path is string => path !== null);
+}
+
+// Single-quote anything that isn't a bare safe path so spaces and shell-special
+// characters survive both a shell prompt and Claude's TUI.
+export function toShellArg(path: string): string {
+  if (SHELL_SAFE.test(path)) return path;
+  return `'${path.replace(/'/g, "'\\''")}'`;
+}
+
+export function toInsertText(paths: string[]): string {
+  return paths.map(toShellArg).join(" ");
+}
+
+export function dropTextFromUriList(uriList: string): string {
+  return toInsertText(parseFileUris(uriList));
+}

--- a/src/components/dropPaths.ts
+++ b/src/components/dropPaths.ts
@@ -9,9 +9,12 @@ function fileUriToPath(uri: string): string | null {
   try {
     const url = new URL(uri);
     if (url.protocol !== "file:") return null;
-    const decoded = decodeURIComponent(url.pathname);
+    const pathname = decodeURIComponent(url.pathname);
+    // A UNC share (Windows) arrives as file://server/share/x — preserve the host,
+    // or the inserted path silently loses it. → \\server\share\x
+    if (url.hostname && url.hostname !== "localhost") return `\\\\${url.hostname}${pathname}`.replace(/\//g, "\\");
     // A Windows drive path arrives as "/C:/dir"; drop the leading slash.
-    return /^\/[A-Za-z]:/.test(decoded) ? decoded.slice(1) : decoded;
+    return /^\/[A-Za-z]:/.test(pathname) ? pathname.slice(1) : pathname;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

ネイティブ端末のように、ファイルの**絶対パスをターミナルに挿入**できるようにします（挿入のみ・Enterは押さない）。経路は2つ:

- **ドラッグ&ドロップ** — ドラッグの `file://` URI を解析して絶対パスを挿入。ブラウザがパスを公開する **Firefox/Safari** で動作。公開しないブラウザ（Chrome）では誤った文字列を入れず**何もしない**。
- **📎 file ボタン** — ローカルサーバが OS ネイティブのファイルダイアログ（macOS `osascript` / Windows PowerShell / Linux `zenity`）を開き、選んだ**絶対パスを返して挿入**。**全ブラウザ（Chrome含む）で動作・コピーを作らない**。

複数ファイルはスペース区切り＋シェルクォート。`<input type=file webkitdirectory>` はブラウザが絶対パスを伏せるため不採用（ネイティブダイアログを採用）。

Closes #75

## Items to Confirm / Review

- **ネイティブダイアログは手動確認が必要**: GUI操作が要るため自動テスト不可。実機で 📎 → ダイアログ → パス挿入を確認してください（macOS の `osascript choose file` で検証想定。Windows/Linux はベストエフォート・未実機検証）。
- **D&D は実機ブラウザ確認が必要**: OSネイティブのドラッグは Playwright で再現困難。Firefox/Safari でドロップ→パス挿入を確認してください。Chrome は仕様上 `file://` を出さないため D&D では何も挿入しない想定（= 📎 ボタンを使う）。
- **クォート方針**: 安全な文字のみのパスは素のまま、それ以外は単一引用符で囲み `'` をエスケープ（`toShellArg`）。claude TUI / シェル双方で破綻しない狙い。妥当か確認ください。
- **セキュリティ**: `/api/pick-file` は他のローカル操作ルートと同じ same-origin ガード。ダイアログのコマンドは固定・argv は定数（プロンプト文字列も定数）でシェル無し・入力補間なし。

## User Prompt

> ターミナルならファイルをD&Dでわたせるけど、ブラウザもできるようにしたい。あれってファイルパスわたしているのかな？仕組み調べてできれば対応をしてほしい。まずはissue化や調査かな。
>
> （調査の結果を踏まえ）ブラウザが絶対パスを隠す場合のフォールバックは **file:// のみ（コピーなし）**、ドロップ時は **挿入のみ（Enterなし）** を選択。
>
> chromeで、`<input type="file" webkitdirectory>` を使う方法ってある？ file アイコンつけて。chrome以外がD&Dで。
>
> （調査の結果、file input/webkitdirectory も絶対パスを取れないと判明 → Chrome含む全ブラウザ向けに）**サーバ側ネイティブダイアログ**を採用。

## 実装

### 調査の結論
ブラウザはドロップ/選択ファイルの絶対パスを伏せる（`File.name` のみ、`File.path` は Electron 専用、`webkitdirectory` は選んだフォルダ起点の相対パスのみ）。絶対パスが取れるのは ① ドラッグの `text/uri-list` の `file://`（Firefox/Safari）、② ローカルサーバ経由の OS ダイアログ、の2つ。本PRは両方を実装。

### クライアント
- `src/components/dropPaths.ts`（純関数, テスト容易）: `parseFileUris` / `toShellArg`（単一引用符クォート）/ `toInsertText` / `dropTextFromUriList`。
- `Terminal.vue`: `.terminal-container` の `@dragover`/`@drop`（ドラッグ中ハイライト）、ヘッダに `attach_file` ボタン（`pickFile()` → `/api/pick-file`）。挿入は `insertText()` に集約しD&Dと共有（既存の `{type:"input"}` チャンネル、CRなし）。
- グリッドの各セル（TerminalCell 内の Terminal）でも有効。

### サーバ
- `server/pick-file.ts`（`open-dir.ts` を踏襲）: `pickFileCommand(platform)` / `parsePickerOutput(stdout)` / `mountPickFileRoute` → `POST /api/pick-file` が `{ paths: string[] }` を返す（キャンセルは `[]`）。
- `server/index.ts`: ルート登録。

### テスト
- `src/components/dropPaths.spec.ts`（vitest, 14 cases）, `server/pick-file.spec.ts`（純関数）。
- ローカルは **node 24**（CIは node 22）由来で無関係な既存 spec が落ちるため、picker 純関数は `tsx` でも検証（8項目 PASS）。lint 0 errors / client+server typecheck / build 緑。

### ドキュメント
- `README.md`（使い方を追記）, `plans/feat-browser-file-drop.md`（設計・確認事項）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
