### PR TITLE
fix: グリッド拡大viewの回帰を修正（744a777のsolo zoomをrevert）

### DIFF
--- a/plans/fix-grid-solo-zoom-regression.md
+++ b/plans/fix-grid-solo-zoom-regression.md
@@ -1,0 +1,26 @@
+# Plan: グリッド拡大view 回帰の修正（solo full-height zoom を revert）
+
+Issue: #77
+作成日: 2026-06-21
+
+## 症状
+グリッドの拡大view（filmstrip zoom, PR #71）が不調。特に**端末1つだけ拡大すると header が消える/拡大が出ない**。
+
+## 原因（git 二分法）
+`0830d3b`（PR#71ブランチ=good）↔ `main`（bad）の差分で**グリッドを触るのは `744a777` のみ**:
+> fix(grid): full-height zoom when solo + compaction regression tests (PR #71 review)
+
+追加された solo 対応（`soloZoom` computed / `.stage` の `solo` クラス / `.stage.zoomed.solo .grid { display: none; }`）が原因。`.grid` は `<Teleport>` のソースコンテナ（拡大セルのみ `zoom-main` へ teleport、残りは `.grid` に留まる）。そこを `display:none` で隠す処理が単一端末・拡大ケースの表示を壊す。ユーザが両ブランチを実機確認し good/bad を確定。
+
+## 対応（低リスク revert）
+- `TerminalGrid.vue` の solo 変更を除去 → `0830d3b` と完全一致（既知good）。
+- `TerminalGrid.spec.ts` の solo テスト2件を削除、**compaction 回帰テストは残置**。
+- 「solo時フルheight zoom」機能は一旦失う。再実装は `display:none` を使わず strip を `flex:0/height:0/overflow:hidden` で潰す等で別途。
+
+## 検証
+- `TerminalGrid.vue` が `feat/grid-filmstrip-zoom` と diff 空。
+- lint 0 errors / typecheck / build / grid 単体テスト 14 pass。
+- 実機（localhost:5173）で単一/複数端末の拡大・解除・header を確認。
+
+## 別件（このPR対象外）
+- **スクロール最下部が表示されない問題**は本 revert では直らず、独立の既存バグとして別途調査。

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -168,18 +168,4 @@ describe("TerminalGrid", () => {
     expect(cells.map((c) => c.props("initialSessionId")).slice(0, 3)).toEqual([A, C, E]);
     expect(cells[1].props("initialCwd")).toBe("/c");
   });
-
-  it("collapses the filmstrip strip (full-height zoom) when the zoomed cell is the only running terminal", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: [], expanded: 0 }));
-    const w = mountGrid("2x2");
-    await flushPromises();
-    expect(w.find(".stage").classes()).toContain("solo");
-  });
-
-  it("keeps the strip when another terminal is running while zoomed", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, null, null], cwds: [], expanded: 0 }));
-    const w = mountGrid("2x2");
-    await flushPromises();
-    expect(w.find(".stage").classes()).not.toContain("solo");
-  });
 });

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -137,18 +137,13 @@ onMounted(() => (mounted.value = true));
 
 const zoomed = computed(() => expandedUid.value !== null && mounted.value);
 
-// When the zoomed cell is the only RUNNING terminal, there's nothing useful to put
-// in the strip (just empty launch forms), so collapse it and let the zoom fill the
-// full height — matching the pre-filmstrip full-height zoom.
-const soloZoom = computed(() => zoomed.value && !visibleSlots.value.some((s) => s.uid !== expandedUid.value && s.session !== null));
-
 // While zoomed, push empty cells to the end of the strip so the open terminals line
 // up on the left. Pure CSS order — never reorders the DOM.
 const stripOrder = (slot: Slot) => (zoomed.value && slot.uid !== expandedUid.value && slot.session === null ? { order: 1 } : undefined);
 </script>
 
 <template>
-  <div class="stage" :class="{ zoomed, solo: soloZoom }">
+  <div class="stage" :class="{ zoomed }">
     <div ref="zoomMain" class="zoom-main" />
     <div class="grid" :style="gridStyle">
       <Teleport v-for="slot in visibleSlots" :key="slot.uid" :to="zoomMain" :disabled="!(zoomed && slot.uid === expandedUid)">
@@ -221,10 +216,5 @@ const stripOrder = (slot: Slot) => (zoomed.value && slot.uid !== expandedUid.val
   flex: 0 0 260px;
   height: 100%;
   min-width: 0;
-}
-
-/* No other running terminal — hide the strip so the zoom uses the full height. */
-.stage.zoomed.solo .grid {
-  display: none;
 }
 </style>


### PR DESCRIPTION
## Summary

グリッドの拡大view（filmstrip zoom, PR #71）が不調になる回帰を修正します。原因は PR#71 レビュー対応 `744a777` の「solo時フルheight zoom」で、filmstrip strip（`.grid`）を `display:none` で隠す処理。`.grid` は `<Teleport>` のソースコンテナのため、**端末1つだけ拡大したとき（最も普通のケース）に拡大セル/header が壊れて**いました。

`744a777` の `TerminalGrid.vue` 変更を revert し、既知good（`0830d3b`＝PR#71ブランチ）と同一の挙動に戻します。

Closes #77

## Items to Confirm / Review

- **二分法で原因を特定**: `0830d3b`(good) ↔ `main`(bad) の差分でグリッドを触るのは `744a777` のみ。ユーザが両ブランチを実機確認し good/bad を確定済み。
- **`TerminalGrid.vue` は known-good と完全一致**（`git diff feat/grid-filmstrip-zoom` が空）。
- **テスト**: solo テスト2件を削除、compaction 回帰テストは残置。grid 単体テスト 14 pass。
- **失う機能**: 「solo時フルheight zoom」は一旦なくなる（単一端末拡大時、下に空 strip が残る）。`display:none` を使わない安全な再実装（strip を flex:0/height:0 で潰す等）は別途可能。要否を判断ください。
- **別件**: 「スクロール最下部が表示されない」問題は本 revert では直らず、独立の既存バグとして別途調査します（このPR対象外）。

## User Prompt

> あれ。PR71での拡大viewがうまく動いてない？あと、この画面のスクロールがおかしくて最下部が表示されないことがある。
> あれ、headerも消えた。前のバグの修正が全部入ってない？なんかおかしい？
> （#71ブランチに切り替えて）このブランチなら期待した動作になるね。
> （mainでの修正方針として）solo変更を revert（推奨・低リスク）。まずlocalで試す。
> おおよそ直っている。ただ、スクロール問題はなおってないかも。

## 実装

`744a777` が追加した以下を `TerminalGrid.vue` から除去（＝`0830d3b` と同一に）:
- `soloZoom` computed
- `.stage` の `solo` クラス（`:class="{ zoomed }"` に戻す）
- `.stage.zoomed.solo .grid { display: none; }`

`TerminalGrid.spec.ts` は solo 関連2テスト（`solo` クラスの有無を assert）を削除。compaction 回帰テストは残置。

詳細・二分法の記録は `plans/fix-grid-solo-zoom-regression.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
