### PR TITLE
fix: グリッドの狭いセルで端末の最下部入力を表示（min-height:0 + scrollToBottom）

### DIFF
--- a/plans/fix-grid-terminal-scroll.md
+++ b/plans/fix-grid-terminal-scroll.md
@@ -1,0 +1,23 @@
+# Plan: グリッド端末の最下部スクロール/fit 修正
+
+Issue: #79
+作成日: 2026-06-21
+
+## 症状
+1. グリッドviewで狭いレイアウト（3x3 等）にすると、端末の**最下部の入力行が見えず、スクロールもできない**。改行すると xterm がスクロールして時々見える。
+2. **拡大（フルスクリーン）→ grid に戻したとき**、スクロール位置が入力部分になっていない。
+
+## 根本原因
+1. `Terminal.vue` の `.terminal-container`（xterm ホスト, `flex:1`）に **`min-height:0` が無い**。flexbox の自動最小サイズで flex アイテムの `min-height` 既定 `auto`＝コンテンツ（xterm 全行）の min-content 高さが下限になり、低いセルで縮めず親 `.cell{overflow:hidden}` にクリップされる。`FitAddon.fit()` も縮まない `clientHeight` を読み行数を減らさず膠着。
+2. `fit()` のリフロー後、ビューポートが最下部に残らないことがある（拡大⇄復帰で顕著）。
+
+## 修正（CSS + 最小JS）
+- `.terminal-container`（および `.terminal-wrapper`）に `min-height: 0` を追加。容器が縮めるようになり、`fit()` がセル高さに合わせて行数を再計算。
+- ResizeObserver の `fit()` 後に `term.scrollToBottom()` を呼び、リサイズ/拡大復帰後も入力行を表示（引き継ぎ不可なら最下部、というユーザ方針）。
+
+## 検証
+- lint 0 errors / typecheck / build。
+- 実機（localhost:5173）: 3x3 で入力行が見える / 拡大→復帰で最下部表示 / レイアウト切替で追従。
+
+## 備考
+- 回帰修正 #78（`TerminalGrid.vue` の solo zoom revert）とはファイルが別の独立変更。

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -166,6 +166,9 @@ onMounted(() => {
     if (ws && ws.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
     }
+    // Reflow after a resize (e.g. restoring a cell from zoom) can leave the
+    // viewport scrolled up; stick to the bottom so the prompt stays in view.
+    term.scrollToBottom();
   });
   resizeObserver.observe(container);
 
@@ -240,6 +243,7 @@ onUnmounted(() => {
   flex-direction: column;
   flex: 1;
   min-width: 0;
+  min-height: 0;
   height: 100%;
   background: #1a1a2e;
 }
@@ -280,8 +284,15 @@ onUnmounted(() => {
   color: #ef9a9a;
 }
 
+/* min-height:0 is load-bearing: a flex item's default min-height is `auto`
+   (its content's min size), which pins this xterm host to the terminal's full
+   rendered height. In a short grid cell that overflows and is clipped — the
+   bottom input row can't be seen or scrolled to — and FitAddon then reads the
+   un-shrunk height and never reduces the rows. min-height:0 lets it shrink so
+   fit() can size the terminal to the cell. */
 .terminal-container {
   flex: 1;
+  min-height: 0;
   padding: 4px;
 }
 </style>


### PR DESCRIPTION
## Summary

グリッドviewの端末で、**狭いセル（3x3 等）で最下部の入力行が見えず・スクロールできない**問題と、**拡大→grid 復帰後にスクロール位置が入力部分にならない**問題を修正します。`Terminal.vue` のみの変更。

Closes #79

## Items to Confirm / Review

- **根本原因（CSS）**: `.terminal-container`（xterm ホスト, `flex:1`）に `min-height: 0` が無く、flexbox の自動最小サイズが xterm のコンテンツ高さに張り付いて低いセルで縮まず、親 `.cell{overflow:hidden}` でクリップ。`FitAddon.fit()` も縮まない高さを読み行数を減らせず膠着。→ `min-height:0` で解消。
- **スクロール位置（JS）**: ResizeObserver の `fit()` 後に `term.scrollToBottom()` を追加。拡大⇄復帰やリサイズ後に入力行を表示（「引き継げないなら最下部」というユーザ方針）。**履歴を読むため上スクロールしている最中にリサイズが入ると bottom に飛ぶ**点は許容としています（要否レビュー）。
- ブラウザ自動操作が使えず**実機検証はユーザが localhost:5173 で実施**（3x3 で入力可視・拡大復帰で最下部・レイアウト切替で追従を確認済み）。
- **#78（grid 拡大view 回帰の revert）とは独立**（ファイルが別: 本PRは `Terminal.vue`、#78 は `TerminalGrid.vue`）。どちらも main に独立適用可。

## User Prompt

> （グリッド端末について）3x3 とかにして狭くすると最下部の入力部分が見えない。スクロールできない。改行して入力すると移動して見えることがある。
> フルスクリーンから grid にもどしたときにスクロール位置が入力部分になっていない。引き継げないなら最下部がよいね。

## 実装

`src/components/Terminal.vue`:
- `.terminal-container` と `.terminal-wrapper` に `min-height: 0` を追加。
- ResizeObserver の `fit()` 後に `term.scrollToBottom()`。

詳細・根本原因は `plans/fix-grid-terminal-scroll.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
