### PR TITLE
feat: グリッドレイアウトを実行中数から自動化（手動ピッカー廃止＋ツールバー＋）

### DIFF
--- a/plans/feat-grid-auto-layout.md
+++ b/plans/feat-grid-auto-layout.md
@@ -1,0 +1,34 @@
+# Plan: グリッドレイアウトの自動化（実行中数ベース）＋ツールバー追加
+
+Issue: #81
+作成日: 2026-06-21
+
+## ゴール
+固定レイアウトの手動選択をやめ、**実行中ターミナル数からレイアウトを自動導出**。追加は**ツールバーの「＋」で1つずつ**。
+
+## レイアウト導出
+`gridLayout.ts`:
+- `LAYOUTS = ["1","2","2x2","3x2","4x2","3x3"]`（`1`=1×1, `2`=1×2 横並びを追加）。
+- `layoutForCount(n)` = n（1..9 にクランプ）が収まる最小レイアウト: 1→`1`, 2→`2`, ≤4→`2x2`, ≤6→`3x2`, ≤8→`4x2`, else→`3x3`。
+
+## TerminalGrid.vue
+- `layout` prop を削除。
+- `runningCount` = session 付き slot 数。
+- `adding` ref。`cellCount = min(9, runningCount + ((adding || runningCount===0) ? 1 : 0))`。
+- `layout = layoutForCount(cellCount)` → `gridStyle = trackStyle(layout, null)`。
+- `addCell()`（expose）: `adding` をトグル（true は running<9 のときのみ）。
+- `setSession`: 非 null id で `adding=false`（起動セルが実行中に昇格）。
+- `add-state` emit `{ canAdd: running<9, adding }`（ツールバー側のボタン状態）。
+- 据え置き: compaction / zoom(teleport) / persistence / UUID 検証。
+
+## GridView.vue
+- 手動レイアウトピッカー・`LAYOUTS`・`grid_layout` localStorage を削除。
+- ツールバーに「＋」ボタン: `gridRef.addCell()`。`adding` 中はアクティブ表示、`!canAdd && !adding` で disabled。
+- `<TerminalGrid ref=... @add-state=...>`（`layout` prop は渡さない）。
+
+## テスト
+- `gridLayout.spec.ts`: LAYOUTS 更新、`1`/`2` の dims、`layoutForCount` の境界（1,2,3,4,5,6,7,8,9,0,超過）。
+- `TerminalGrid.spec.ts`: 旧 layout-prop 前提を、実行中数からの自動導出に書き換え（0→1セル/復元で実行中のみ表示/`addCell` で+1/launch で adding 解除/close で縮小/compaction 据え置き）。
+
+## 据え置き・スコープ外
+- 複数タブ（面）や 9 超のセッションは対象外（従来どおり 1 グリッド・最大 9）。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,17 +1,16 @@
 <script setup lang="ts">
-import { ref, watch, onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
-import { LAYOUTS, isLayout, type Layout } from "./gridLayout";
 import type { CwdPreset } from "./presets";
 
 // The multi-terminal grid view. Toggled with the classic single view from App.vue.
 const emit = defineEmits<{ (e: "exit"): void }>();
 
-// Grid layout (cell arrangement), chosen in the toolbar and persisted.
-const stored = localStorage.getItem("grid_layout");
-const layout = ref<Layout>(isLayout(stored) ? stored : "2x2");
-watch(layout, (v) => localStorage.setItem("grid_layout", v));
+// The grid arranges itself by the running-terminal count; the toolbar "+" (wired to
+// TerminalGrid via this ref) adds one launch cell, and add-state drives its button.
+const gridRef = ref<InstanceType<typeof TerminalGrid> | null>(null);
+const addState = ref<{ canAdd: boolean; adding: boolean }>({ canAdd: true, adding: false });
 
 // Server config: the default workspace dir + the user's directory presets.
 const defaultCwd = ref<string | null>(null);
@@ -64,15 +63,19 @@ function closeSettings() {
   <div class="shell">
     <header class="toolbar">
       <span class="toolbar-title">MulmoTerminal</span>
-      <span class="layout-picker" role="group" aria-label="Grid layout">
-        <button v-for="l in LAYOUTS" :key="l" :class="['layout-btn', { active: layout === l }]" :aria-pressed="layout === l" @click="layout = l">
-          {{ l }}
-        </button>
-      </span>
+      <button
+        class="tb-btn tb-add"
+        :class="{ active: addState.adding }"
+        :disabled="!addState.canAdd && !addState.adding"
+        :title="addState.adding ? 'Cancel adding a terminal' : 'New terminal'"
+        @click="gridRef?.addCell()"
+      >
+        ＋ Terminal
+      </button>
       <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
       <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>
-    <TerminalGrid class="main" :layout="layout" :default-cwd="defaultCwd" :presets="presets" :home="home" />
+    <TerminalGrid ref="gridRef" class="main" :default-cwd="defaultCwd" :presets="presets" :home="home" @add-state="addState = $event" />
     <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
   </div>
 </template>
@@ -104,26 +107,14 @@ function closeSettings() {
   letter-spacing: 0.02em;
 }
 
-.layout-picker {
+.tb-add {
   margin-left: auto;
-  display: flex;
-  gap: 4px;
 }
-.layout-btn {
-  border: 1px solid #2a2a4e;
-  background: #1a1a2e;
-  color: #9aa3c0;
-  font-family: ui-monospace, monospace;
-  font-size: 12px;
-  padding: 3px 8px;
-  border-radius: 6px;
-  cursor: pointer;
+.tb-add:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
-.layout-btn:hover {
-  background: #2a3b66;
-  color: #e6e6f0;
-}
-.layout-btn.active {
+.tb-add.active {
   background: #2a3b66;
   color: #fff;
   border-color: #4a8cff;

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -2,10 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
-import type { Layout } from "./gridLayout";
 
-// Stub the cell so the grid's own state (localStorage persist/restore + zoom +
-// layout) can be tested without pulling in Terminal/xterm/pub-sub.
+// Stub the cell so the grid's own state (persist/restore + zoom + auto-layout) can
+// be tested without pulling in Terminal/xterm/pub-sub.
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
@@ -16,50 +15,79 @@ vi.mock("./TerminalCell.vue", () => ({
 }));
 
 const STORE_KEY = "grid_state_v1";
-const mountGrid = (layout: Layout = "2x2") => mount(TerminalGrid, { props: { layout, defaultCwd: "/work/proj", presets: [], home: "/work" } });
+const mountGrid = () => mount(TerminalGrid, { props: { defaultCwd: "/work/proj", presets: [], home: "/work" } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const saved = () => JSON.parse(localStorage.getItem(STORE_KEY) || "{}");
+const lastAddState = (w: ReturnType<typeof mount>) => w.emitted("add-state")?.at(-1)?.[0];
+
+const A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const D = "dddddddd-dddd-dddd-dddd-dddddddddddd";
 
 beforeEach(() => {
   localStorage.clear();
   globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ cwd: "/work/proj" }) })) as unknown as typeof fetch;
 });
 
-describe("TerminalGrid", () => {
-  it("renders cellCount cells per layout", () => {
-    expect(cellsOf(mountGrid("2x2"))).toHaveLength(4);
-    expect(cellsOf(mountGrid("3x2"))).toHaveLength(6);
-    expect(cellsOf(mountGrid("4x2"))).toHaveLength(8);
-    expect(cellsOf(mountGrid("3x3"))).toHaveLength(9);
-  });
-
-  it("re-renders the cell count when the layout prop changes", async () => {
-    const w = mountGrid("2x2");
-    expect(cellsOf(w)).toHaveLength(4);
-    await w.setProps({ layout: "3x3" });
-    expect(cellsOf(w)).toHaveLength(9);
-  });
-
-  it("un-zooms when the layout shrinks below the expanded cell", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [], expanded: 8 }));
-    const w = mountGrid("3x3");
+describe("TerminalGrid auto-layout", () => {
+  it("shows a single launch cell on an empty grid", async () => {
+    const w = mountGrid();
     await flushPromises();
-    expect(cellsOf(w)[8].props("expanded")).toBe(true);
-    await w.setProps({ layout: "2x2" });
-    expect(cellsOf(w).every((c) => c.props("expanded") === false)).toBe(true);
-    expect(saved().expanded).toBe(null);
+    expect(cellsOf(w)).toHaveLength(1);
   });
 
-  it("restores each cell's session id and the zoom from localStorage", async () => {
-    const idA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-    const idC = "cccccccc-cccc-cccc-cccc-cccccccccccc";
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [idA, null, idC, null], expanded: 2 }));
-    const w = mountGrid("2x2");
+  it("shows exactly the running terminals, packed (interleaved state is compacted on load)", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, C, null], cwds: ["/a", null, "/c", null], expanded: null }));
+    const w = mountGrid();
     await flushPromises();
     const cells = cellsOf(w);
-    expect(cells[0].props("initialSessionId")).toBe(idA);
-    expect(cells[2].props("initialSessionId")).toBe(idC);
-    expect(cells[2].props("expanded")).toBe(true);
+    expect(cells).toHaveLength(2); // 2 running, no empty filler, no add cell
+    expect(cells[0].props("initialSessionId")).toBe(A);
+    expect(cells[1].props("initialSessionId")).toBe(C);
+    expect(cells[1].props("initialCwd")).toBe("/c");
+  });
+
+  it("addCell toggles one trailing launch cell and reports add-state", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: [], expanded: null }));
+    const w = mountGrid();
+    await flushPromises();
+    expect(cellsOf(w)).toHaveLength(1);
+
+    w.vm.addCell();
+    await nextTick();
+    expect(cellsOf(w)).toHaveLength(2);
+    expect(cellsOf(w)[1].props("initialSessionId")).toBe(null);
+    expect(lastAddState(w)).toEqual({ canAdd: true, adding: true });
+
+    w.vm.addCell(); // toggle off (cancel)
+    await nextTick();
+    expect(cellsOf(w)).toHaveLength(1);
+    expect(lastAddState(w)).toEqual({ canAdd: true, adding: false });
+  });
+
+  it("launching the add cell promotes it to a running terminal and stops adding", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: [], expanded: null }));
+    const w = mountGrid();
+    await flushPromises();
+    w.vm.addCell();
+    await nextTick();
+    cellsOf(w)[1].vm.$emit("session", B);
+    await nextTick();
+    expect(cellsOf(w)).toHaveLength(2); // both running now, add cell consumed
+    expect(saved().sessions.slice(0, 2)).toEqual([A, B]);
+    expect(lastAddState(w)).toEqual({ canAdd: true, adding: false });
+  });
+
+  it("caps the grid at 9 running (no 10th cell)", async () => {
+    const ids = Array.from({ length: 9 }, (_, i) => `${String(i).repeat(8)}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`);
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ids, cwds: [], expanded: null }));
+    const w = mountGrid();
+    await flushPromises();
+    expect(cellsOf(w)).toHaveLength(9);
+    w.vm.addCell();
+    await nextTick();
+    expect(cellsOf(w)).toHaveLength(9);
   });
 
   it("forwards defaultCwd to cells", async () => {
@@ -68,104 +96,82 @@ describe("TerminalGrid", () => {
     expect(cellsOf(w)[0].props("defaultCwd")).toBe("/work/proj");
   });
 
-  it("persists a cell's chosen cwd and restores it as initialCwd", async () => {
+  it("persists a cell's chosen cwd", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: ["/a", null, null, null], expanded: null }));
     const w = mountGrid();
     await flushPromises();
-    cellsOf(w)[2].vm.$emit("cwd", "/work/proj/sub");
+    cellsOf(w)[0].vm.$emit("cwd", "/work/proj/sub");
     await nextTick();
-    expect(saved().cwds[2]).toBe("/work/proj/sub");
-
-    const w2 = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w2)[2].props("initialCwd")).toBe("/work/proj/sub");
+    expect(saved().cwds[0]).toBe("/work/proj/sub");
   });
 
-  it("persists a cell's session id when it emits 'session'", async () => {
+  it("persists a session id when a cell emits 'session'", async () => {
     const w = mountGrid();
     await flushPromises();
-    cellsOf(w)[1].vm.$emit("session", "new-id");
+    cellsOf(w)[0].vm.$emit("session", A);
     await nextTick();
-    expect(saved().sessions[1]).toBe("new-id");
+    expect(saved().sessions[0]).toBe(A);
   });
 
-  it("clears the slot (and un-zooms) when a cell emits 'close'", async () => {
-    const idA = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [idA, null, null, null], expanded: 0 }));
-    const w = mountGrid("2x2");
+  it("clears the slot, un-zooms, and shrinks on close", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, C, D], cwds: ["/a", "/b", "/c", "/d"], expanded: 1 }));
+    const w = mountGrid();
     await flushPromises();
-    cellsOf(w)[0].vm.$emit("close");
+    expect(cellsOf(w)).toHaveLength(4);
+    cellsOf(w)[1].vm.$emit("close"); // close B (zoomed)
     await nextTick();
-    expect(saved().sessions[0]).toBe(null);
+    expect(saved().sessions.slice(0, 4)).toEqual([A, C, D, null]); // gap filled
+    expect(saved().cwds.slice(0, 4)).toEqual(["/a", "/c", "/d", null]);
+    expect(saved().expanded).toBe(null);
+    expect(cellsOf(w)).toHaveLength(3); // 3 running now
+    expect(cellsOf(w)[1].props("initialSessionId")).toBe(C);
+  });
+
+  it("toggles zoom on 'toggle-expand' and back off again", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, null, null], cwds: [], expanded: null }));
+    const w = mountGrid();
+    await flushPromises();
+    cellsOf(w)[1].vm.$emit("toggle-expand");
+    await nextTick();
+    expect(cellsOf(w)[1].props("expanded")).toBe(true);
+    expect(saved().expanded).toBe(1);
+    cellsOf(w)[1].vm.$emit("toggle-expand");
+    await nextTick();
     expect(saved().expanded).toBe(null);
   });
 
-  it("toggles zoom on 'toggle-expand' and back off when emitted again", async () => {
+  it("restores running sessions and the zoom from localStorage", async () => {
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, C, null, null], expanded: 1 }));
     const w = mountGrid();
     await flushPromises();
-    cellsOf(w)[3].vm.$emit("toggle-expand");
-    await nextTick();
-    expect(cellsOf(w)[3].props("expanded")).toBe(true);
-    expect(saved().expanded).toBe(3);
-    cellsOf(w)[3].vm.$emit("toggle-expand");
-    await nextTick();
-    expect(saved().expanded).toBe(null);
+    const cells = cellsOf(w);
+    expect(cells).toHaveLength(2);
+    expect(cells[0].props("initialSessionId")).toBe(A);
+    expect(cells[1].props("initialSessionId")).toBe(C);
+    expect(cells[1].props("expanded")).toBe(true);
+  });
+
+  it("drops a restored zoom that no longer lands on a running cell", async () => {
+    // Only A is valid; the stored expanded position points past the running cell.
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], expanded: 2 }));
+    const w = mountGrid();
+    await flushPromises();
+    expect(cellsOf(w).every((c) => c.props("expanded") === false)).toBe(true);
   });
 
   it("drops non-UUID persisted session ids", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ["not-a-uuid", "../etc/passwd", "id-a", null], expanded: null }));
-    const w = mountGrid("2x2");
+    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ["not-a-uuid", "../etc/passwd", A, null], expanded: null }));
+    const w = mountGrid();
     await flushPromises();
-    expect(cellsOf(w).every((c) => c.props("initialSessionId") === null)).toBe(true);
-  });
-
-  it("keeps a valid UUID persisted id", async () => {
-    const uuid = "abcdef01-2345-6789-abcd-ef0123456789";
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [uuid, null, null, null], expanded: null }));
-    const w = mountGrid("2x2");
-    await flushPromises();
-    expect(cellsOf(w)[0].props("initialSessionId")).toBe(uuid);
+    const cells = cellsOf(w);
+    expect(cells).toHaveLength(1); // only A survives
+    expect(cells[0].props("initialSessionId")).toBe(A);
   });
 
   it("ignores a corrupt localStorage payload", async () => {
     localStorage.setItem(STORE_KEY, "not json{");
-    const w = mountGrid("2x2");
+    const w = mountGrid();
     await flushPromises();
-    expect(cellsOf(w)).toHaveLength(4);
-    expect(cellsOf(w).every((c) => c.props("initialSessionId") === null)).toBe(true);
-  });
-
-  const A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-  const B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
-  const C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
-  const D = "dddddddd-dddd-dddd-dddd-dddddddddddd";
-  const E = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
-
-  it("close fills the gap and keeps each session paired with its cwd (compaction)", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, C, D], cwds: ["/a", "/b", "/c", "/d"], expanded: null }));
-    const w = mountGrid("2x2");
-    await flushPromises();
-    cellsOf(w)[1].vm.$emit("close"); // close B (position 1)
-    await nextTick();
-
-    // B's slot is emptied and the rest pack forward, cwds following their session.
-    expect(saved().sessions.slice(0, 4)).toEqual([A, C, D, null]);
-    expect(saved().cwds.slice(0, 4)).toEqual(["/a", "/c", "/d", null]);
-    const cells = cellsOf(w);
-    expect(cells[1].props("initialSessionId")).toBe(C);
-    expect(cells[1].props("initialCwd")).toBe("/c");
-  });
-
-  it("packs running terminals to the top-left on layout shrink, preserving session/cwd pairing", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, C, null, E], cwds: ["/a", null, "/c", null, "/e"], expanded: null }));
-    const w = mountGrid("3x3");
-    await flushPromises();
-    await w.setProps({ layout: "2x2" });
-    await nextTick();
-
-    expect(saved().sessions.slice(0, 3)).toEqual([A, C, E]);
-    expect(saved().cwds.slice(0, 3)).toEqual(["/a", "/c", "/e"]);
-    const cells = cellsOf(w); // 2x2 → 4 visible
-    expect(cells.map((c) => c.props("initialSessionId")).slice(0, 3)).toEqual([A, C, E]);
-    expect(cells[1].props("initialCwd")).toBe("/c");
+    expect(cellsOf(w)).toHaveLength(1);
   });
 });

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from "vue";
 import TerminalCell from "./TerminalCell.vue";
-import { MAX_CELLS, dims, trackStyle, type Layout } from "./gridLayout";
+import { MAX_CELLS, trackStyle, layoutForCount } from "./gridLayout";
 import type { CwdPreset } from "./presets";
 
 // Zooming interface: the grid is the base view; expanding a cell switches to a
@@ -10,11 +10,11 @@ import type { CwdPreset } from "./presets";
 // Only the ZOOMED cell is moved (with <Teleport>) up to the overlay; every other
 // cell stays put in the grid, which is just restyled into the strip. Nothing else
 // is relocated or re-created, so terminals keep running and headers never flicker.
-// `defaultCwd` prefills the launch form; `presets` are the quick-pick dirs; `home`
-// anchors the cell header path on ~.
-const props = defineProps<{ layout: Layout; defaultCwd: string | null; presets: CwdPreset[]; home: string | null }>();
-
-const cellCount = computed(() => dims(props.layout).cellCount);
+// The layout is derived from the running-terminal count (no manual picker); a "+"
+// in the toolbar adds one launch cell at a time. `defaultCwd` prefills the launch
+// form; `presets` are the quick-pick dirs; `home` anchors the cell header path on ~.
+defineProps<{ defaultCwd: string | null; presets: CwdPreset[]; home: string | null }>();
+const emit = defineEmits<{ (e: "add-state", v: { canAdd: boolean; adding: boolean }): void }>();
 
 // Each cell is a persistent SLOT with a stable `uid`. The slots array's ORDER is
 // the display order; the visible cells are the first `cellCount`. v-for keys by
@@ -51,13 +51,23 @@ function loadState(): { slots: Slot[]; expandedUid: number | null } {
     // no/invalid state — defaults
   }
   // uid === initial index; the order changes via compaction, the uid never does.
-  const slots = Array.from({ length: MAX_CELLS }, (_, i) => ({ uid: i, session: sessions[i], cwd: cwds[i] }));
+  const built = Array.from({ length: MAX_CELLS }, (_, i) => ({ uid: i, session: sessions[i], cwd: cwds[i] }));
+  // Pack running terminals to the front: the auto-sized grid shows exactly
+  // `running` cells, so an older/interleaved saved state must not leave gaps.
+  const slots = [...built.filter((s) => s.session !== null), ...built.filter((s) => s.session === null)];
   return { slots, expandedUid: expandedIndex };
 }
 
 const initial = loadState();
 const slots = ref<Slot[]>(initial.slots);
 const expandedUid = ref<number | null>(initial.expandedUid);
+
+const runningCount = computed(() => slots.value.filter((s) => s.session !== null).length);
+// One launch cell is shown to start the first terminal (empty grid) or when the
+// user clicks "+"; otherwise the grid holds exactly the running terminals.
+const adding = ref(false);
+const cellCount = computed(() => Math.min(MAX_CELLS, runningCount.value + (adding.value || runningCount.value === 0 ? 1 : 0)));
+const layout = computed(() => layoutForCount(cellCount.value));
 
 const visibleSlots = computed(() => slots.value.slice(0, cellCount.value));
 const slotByUid = (uid: number) => slots.value.find((s) => s.uid === uid);
@@ -105,6 +115,7 @@ function setSession(uid: number, id: string | null) {
   const s = slotByUid(uid);
   if (!s) return;
   s.session = id;
+  if (id !== null) adding.value = false; // the launch cell became a running terminal
   if (id === null && expandedUid.value === uid) expandedUid.value = null; // a closed cell can't stay zoomed
 }
 
@@ -125,15 +136,30 @@ function onClose(uid: number) {
   compact();
 }
 
+// Toolbar "+" toggles a single trailing launch cell. Capped at MAX_CELLS running.
+function addCell() {
+  if (adding.value) adding.value = false;
+  else if (runningCount.value < MAX_CELLS) adding.value = true;
+}
+defineExpose({ addCell });
+
+// Tell the toolbar whether "+" can add and whether a launch cell is already open.
+watch([runningCount, adding], () => emit("add-state", { canAdd: runningCount.value < MAX_CELLS, adding: adding.value }), { immediate: true });
+
 // The grid (non-zoomed) always uses full equal tracks; zoom restyles the grid into
 // the bottom strip via CSS, so no track collapsing is needed.
-const gridStyle = computed(() => trackStyle(props.layout, null));
+const gridStyle = computed(() => trackStyle(layout.value, null));
 
 // The zoomed cell is teleported up here; the target must exist before it moves, so
 // hold off until mounted (covers a page reload that restores a zoom).
 const zoomMain = ref<HTMLElement | null>(null);
 const mounted = ref(false);
-onMounted(() => (mounted.value = true));
+onMounted(() => {
+  mounted.value = true;
+  // Drop a restored zoom that no longer lands on a running cell (stale state).
+  const s = expandedUid.value === null ? undefined : slotByUid(expandedUid.value);
+  if (expandedUid.value !== null && (!s || s.session === null)) expandedUid.value = null;
+});
 
 const zoomed = computed(() => expandedUid.value !== null && mounted.value);
 

--- a/src/components/gridLayout.spec.ts
+++ b/src/components/gridLayout.spec.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { LAYOUTS, isLayout, dims, trackStyle } from "./gridLayout";
+import { LAYOUTS, isLayout, dims, trackStyle, layoutForCount } from "./gridLayout";
 
 describe("gridLayout", () => {
-  it("exposes the four layouts", () => {
-    expect(LAYOUTS).toEqual(["2x2", "3x2", "4x2", "3x3"]);
+  it("exposes the layouts smallest→largest", () => {
+    expect(LAYOUTS).toEqual(["1", "2", "2x2", "3x2", "4x2", "3x3"]);
   });
 
   it("isLayout accepts known layouts and rejects everything else", () => {
-    expect(isLayout("2x2")).toBe(true);
+    expect(isLayout("1")).toBe(true);
+    expect(isLayout("2")).toBe(true);
     expect(isLayout("3x3")).toBe(true);
     expect(isLayout("5x5")).toBe(false);
     expect(isLayout(null)).toBe(false);
@@ -15,10 +16,30 @@ describe("gridLayout", () => {
   });
 
   it("dims returns cols/rows/cellCount", () => {
+    expect(dims("1")).toEqual({ cols: 1, rows: 1, cellCount: 1 });
+    expect(dims("2")).toEqual({ cols: 2, rows: 1, cellCount: 2 });
     expect(dims("2x2")).toEqual({ cols: 2, rows: 2, cellCount: 4 });
     expect(dims("3x2")).toEqual({ cols: 3, rows: 2, cellCount: 6 });
     expect(dims("4x2")).toEqual({ cols: 4, rows: 2, cellCount: 8 });
     expect(dims("3x3")).toEqual({ cols: 3, rows: 3, cellCount: 9 });
+  });
+
+  it("layoutForCount picks the smallest layout that fits", () => {
+    expect(layoutForCount(1)).toBe("1");
+    expect(layoutForCount(2)).toBe("2");
+    expect(layoutForCount(3)).toBe("2x2");
+    expect(layoutForCount(4)).toBe("2x2");
+    expect(layoutForCount(5)).toBe("3x2");
+    expect(layoutForCount(6)).toBe("3x2");
+    expect(layoutForCount(7)).toBe("4x2");
+    expect(layoutForCount(8)).toBe("4x2");
+    expect(layoutForCount(9)).toBe("3x3");
+  });
+
+  it("layoutForCount clamps out-of-range counts to 1..9", () => {
+    expect(layoutForCount(0)).toBe("1");
+    expect(layoutForCount(-3)).toBe("1");
+    expect(layoutForCount(12)).toBe("3x3");
   });
 
   it("trackStyle: full even tracks when nothing is zoomed", () => {

--- a/src/components/gridLayout.ts
+++ b/src/components/gridLayout.ts
@@ -1,10 +1,13 @@
 // Grid layout definitions shared by App (the picker) and TerminalGrid.
 
-export const LAYOUTS = ["2x2", "3x2", "4x2", "3x3"] as const;
+// Ordered smallest→largest: the grid grows through these as terminals are added.
+export const LAYOUTS = ["1", "2", "2x2", "3x2", "4x2", "3x3"] as const;
 export type Layout = (typeof LAYOUTS)[number];
 
 // cols × rows per layout. Max cells is 9 (3x3), which bounds the persisted arrays.
 const DIMS: Record<Layout, { cols: number; rows: number }> = {
+  "1": { cols: 1, rows: 1 },
+  "2": { cols: 2, rows: 1 },
   "2x2": { cols: 2, rows: 2 },
   "3x2": { cols: 3, rows: 2 },
   "4x2": { cols: 4, rows: 2 },
@@ -20,6 +23,13 @@ export function isLayout(v: unknown): v is Layout {
 export function dims(layout: Layout) {
   const { cols, rows } = DIMS[layout];
   return { cols, rows, cellCount: cols * rows };
+}
+
+// The smallest layout whose cells fit `count` terminals (clamped to 1..MAX_CELLS).
+// Drives the auto-growing grid: 1→"1", 2→"2", 3-4→"2x2", 5-6→"3x2", 7-8→"4x2", 9→"3x3".
+export function layoutForCount(count: number): Layout {
+  const n = Math.max(1, Math.min(MAX_CELLS, Math.floor(count)));
+  return LAYOUTS.find((l) => dims(l).cellCount >= n) ?? "3x3";
 }
 
 // CSS grid track template for the layout, or — when a cell is zoomed — collapse


### PR DESCRIPTION
## Summary

グリッドのレイアウトを**実行中ターミナル数から自動導出**するようにし、固定レイアウトの手動選択を廃止します。追加は**ツールバーの「＋」で1つずつ**。

| 実行中 | レイアウト |
|---|---|
| 1 | `1`（全画面） |
| 2 | `2`（横2分割） |
| 3–4 | `2x2` |
| 5–6 | `3x2` |
| 7–8 | `4x2` |
| 9 | `3x3`（上限・「＋」無効） |

Closes #81

## Items to Confirm / Review

- **実機確認済み**（localhost:5173, ユーザ確認）。ブラウザ自動操作は使えないため、UIの最終確認は実機で実施。
- **手動レイアウトピッカーと `grid_layout` localStorage を削除**（後方互換: 残骸キーは無視されるだけ）。
- **ロード時に実行中を前詰め**: 旧モデルは空セルを並べたので interleaved な `grid_state_v1` があり得る。新モデルは `cellCount = 実行中数` なので、ギャップがあると端末が隠れる → ロード時 compaction で対処（テスト有り）。
- **0個のとき「＋」**: 入口セルが既にあるため `adding` をトグルしても見た目は変わらない（無害）。仕様として許容。レビュー観点として共有。
- **親子連携**: `addCell()` は `defineExpose`、状態は `add-state` emit。CLAUDE.md「関数を prop で渡さない」に準拠（ref 経由のメソッド呼び出し＋イベント emit）。

## User Prompt

> grid って 3x3 にしてもそれを全部起動するのってなかなかないよね。新しく起動するのは1つだけ追加できるようにして 1, 2, 2x2, 3x2, 4x2, 3x3 と起動が増えるたびに grid を変更していくほうが自然かなぁ。
>
> （方針確認の結果）完全自動（手動ピッカー廃止）＋ツールバーの「＋」ボタン。

## 実装

- `gridLayout.ts`: `1`(1×1)・`2`(1×2横並び) を追加、`layoutForCount(n)` = n（1..9 にクランプ）が収まる最小レイアウト。
- `TerminalGrid.vue`: `layout` prop 廃止。`runningCount` / `adding` から `cellCount`・`layout` を導出。`addCell()`（トグル, 9 で打ち止め）を expose、`add-state {canAdd, adding}` を emit、起動で `adding` 解除、`loadState` で前詰め、mount で stale zoom を破棄。
- `GridView.vue`: ピッカー削除、ツールバー「＋ Terminal」を `gridRef.addCell()` に接続（`adding` 中アクティブ／`!canAdd && !adding` で disabled）。
- テスト: `gridLayout.spec.ts`（layoutForCount 境界）、`TerminalGrid.spec.ts`（自動導出・追加/起動/上限・前詰め・zoom・復元）。計 201 tests pass。

詳細は `plans/feat-grid-auto-layout.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
