### PR TITLE
feat(grid): タブ＝1つの端末配列のページ化（9で溢れ／閉じると跨ぎで前詰め）

### DIFF
--- a/plans/feat-grid-tabs.md
+++ b/plans/feat-grid-tabs.md
@@ -1,0 +1,39 @@
+# Plan: グリッドをタブ（ページ）で複数面化 — 1配列モデル
+
+Issue: #83（#46 の req7）
+作成日: 2026-06-21
+
+## モデル（確定）
+**ターミナルは1つのフラットな配列 `cells`。タブはメタデータ（ページ）** — 9個ごとのページ＝タブ。
+- 端末は配列の末尾に追加。**満杯で「＋Terminal」を押すと新ページ（タブ）に溢れる**。
+- **端末を閉じると配列全体が前詰めされ、後続ページの端末が前のページへ流れ込む**（タブ跨ぎの繰り上げ）。
+- 末尾の空き起動セルは1つだけ。空グリッドは入口の起動セル1つ。
+- タブバーはページが2つ以上のときだけ表示。完全自動（手動の＋タブ/✕無し）。
+- アクティブページのみマウント。他ページの端末はサーバ側 PTY で生存→再表示で再接続/resume。
+
+## 永続化
+- 単一キー `grid_v2` = `{ cells:[{uid,session,cwd}], expanded:uid|null, page, nextUid }`。
+- 旧 `grid_state_v1`（単一グリッド）を初回に1配列へ移行（移行後に旧キー削除）。
+
+## 実装
+### `gridTabs.ts`（純関数・テスト可能 — 状態の単一ソース）
+- 型 `Cell` / `GridState`、定数 `PAGE_SIZE=9` / `MAX_TERMINALS=81` / `STATE_KEY` / `LEGACY_KEY`。
+- 導出: `pageCount` / `pageSlice` / `runningCount`。
+- ミューテーション（GridState→GridState）: `addCell`（追加/溢れ/キャンセル）・`setSession`・`setCwd`・`closeCell`（削除＋前詰め＋entry保持＋page clamp）・`toggleExpand`・`switchPage`（末尾空きセル除去＋zoomクリア）。
+- 復元/移行: `parseGridState` / `migrateLegacy` / `initialState`。
+
+### `TerminalGrid.vue`（制御コンポーネント＝1ページを描くだけ）
+- props `cells`（ページのスライス）/ `expanded-uid` / dir系。emits `session/cwd/close/toggle-expand`（uid付き）。
+- `layoutForCount(cells.length)` で自動レイアウト＋ teleport zoom。状態・localStorage は持たない。
+
+### `GridView.vue`（1つの `GridState` ref を所有）
+- 純関数でミューテート、`pageCount`/`pageSlice` で導出、deep watch で永続化、初回移行。
+- タブバー（>1）: 番号ページ、クリックで `switchPage`。「＋Terminal」= `addCell`。
+
+## テスト
+- `gridTabs.spec.ts`: ページング＋全ミューテーション＋前詰め（page2→page1）＋復元/移行。
+- `TerminalGrid.spec.ts`: ページ描画・props透過・uid付き emit・zoom クラス。
+- 計 209 tests / lint・typecheck・build 緑。
+
+## スコープ外（別issue）
+- req8: 裏タブの入力待ち/終了バッジ。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -27,9 +27,15 @@ const emit = defineEmits<{ (e: "exit"): void }>();
 // page is mounted — other pages' terminals live on as background PTYs and
 // reconnect when their page is shown again.
 const init = initialState(localStorage.getItem(STATE_KEY), localStorage.getItem(LEGACY_KEY));
-if (init.migrated) localStorage.removeItem(LEGACY_KEY);
 const state = ref<GridState>(init.state);
-watch(state, () => localStorage.setItem(STATE_KEY, JSON.stringify(state.value)), { deep: true });
+const persist = () => localStorage.setItem(STATE_KEY, JSON.stringify(state.value));
+// Write the migrated state before dropping the legacy key, so a reload between
+// migration and the first change can't lose the sessions.
+if (init.migrated) {
+  persist();
+  localStorage.removeItem(LEGACY_KEY);
+}
+watch(state, persist, { deep: true });
 
 const pages = computed(() => pageCount(state.value.cells.length));
 const pageCells = computed(() => pageSlice(state.value.cells, state.value.page));

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,16 +1,56 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, computed, watch, onMounted } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
+import {
+  initialState,
+  addCell,
+  setSession,
+  setCwd,
+  closeCell,
+  toggleExpand,
+  switchPage,
+  pageCount,
+  pageSlice,
+  runningCount,
+  STATE_KEY,
+  LEGACY_KEY,
+  type GridState,
+} from "./gridTabs";
 import type { CwdPreset } from "./presets";
 
 // The multi-terminal grid view. Toggled with the classic single view from App.vue.
 const emit = defineEmits<{ (e: "exit"): void }>();
 
-// The grid arranges itself by the running-terminal count; the toolbar "+" (wired to
-// TerminalGrid via this ref) adds one launch cell, and add-state drives its button.
-const gridRef = ref<InstanceType<typeof TerminalGrid> | null>(null);
-const addState = ref<{ canAdd: boolean; adding: boolean }>({ canAdd: true, adding: false });
+// One flat list of terminal cells; tabs are just pages (9 each) over it. Closing a
+// cell reflows the list so terminals flow across page boundaries. Only the active
+// page is mounted — other pages' terminals live on as background PTYs and
+// reconnect when their page is shown again.
+const init = initialState(localStorage.getItem(STATE_KEY), localStorage.getItem(LEGACY_KEY));
+if (init.migrated) localStorage.removeItem(LEGACY_KEY);
+const state = ref<GridState>(init.state);
+watch(state, () => localStorage.setItem(STATE_KEY, JSON.stringify(state.value)), { deep: true });
+
+const pages = computed(() => pageCount(state.value.cells.length));
+const pageCells = computed(() => pageSlice(state.value.cells, state.value.page));
+const pageExpanded = computed(() =>
+  state.value.expanded !== null && pageCells.value.some((c) => c.uid === state.value.expanded) ? state.value.expanded : null,
+);
+// A launch cell is open beyond the sole entry cell (so "+ Terminal" cancels it).
+const launchOpen = computed(() => {
+  const last = state.value.cells[state.value.cells.length - 1];
+  return !!last && last.session === null && state.value.cells.length > 1;
+});
+
+function onAddTerminal() {
+  if (runningCount(state.value.cells) >= 81 && !launchOpen.value) return; // surfaced by the disabled button
+  state.value = addCell(state.value);
+}
+const onSession = (uid: number, id: string) => (state.value = setSession(state.value, uid, id));
+const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, uid, cwd));
+const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
+const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
+const switchTo = (page: number) => (state.value = switchPage(state.value, page));
 
 // Server config: the default workspace dir + the user's directory presets.
 const defaultCwd = ref<string | null>(null);
@@ -65,17 +105,32 @@ function closeSettings() {
       <span class="toolbar-title">MulmoTerminal</span>
       <button
         class="tb-btn tb-add"
-        :class="{ active: addState.adding }"
-        :disabled="!addState.canAdd && !addState.adding"
-        :title="addState.adding ? 'Cancel adding a terminal' : 'New terminal'"
-        @click="gridRef?.addCell()"
+        :class="{ active: launchOpen }"
+        :title="launchOpen ? 'Cancel adding a terminal' : 'New terminal (overflows to a new tab when full)'"
+        @click="onAddTerminal"
       >
         ＋ Terminal
       </button>
       <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
       <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>
-    <TerminalGrid ref="gridRef" class="main" :default-cwd="defaultCwd" :presets="presets" :home="home" @add-state="addState = $event" />
+    <nav v-if="pages > 1" class="tabbar" aria-label="Grid tabs">
+      <button v-for="p in pages" :key="p" :class="['tab', { active: p - 1 === state.page }]" :aria-pressed="p - 1 === state.page" @click="switchTo(p - 1)">
+        {{ p }}
+      </button>
+    </nav>
+    <TerminalGrid
+      class="main"
+      :cells="pageCells"
+      :expanded-uid="pageExpanded"
+      :default-cwd="defaultCwd"
+      :presets="presets"
+      :home="home"
+      @session="onSession"
+      @cwd="onCwd"
+      @close="onClose"
+      @toggle-expand="onToggleExpand"
+    />
     <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
   </div>
 </template>
@@ -110,10 +165,6 @@ function closeSettings() {
 .tb-add {
   margin-left: auto;
 }
-.tb-add:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
 .tb-add.active {
   background: #2a3b66;
   color: #fff;
@@ -134,6 +185,37 @@ function closeSettings() {
 .tb-btn:hover {
   background: #2a3b66;
   color: #fff;
+}
+
+.tabbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 30px;
+  padding: 0 16px;
+  background: #14203a;
+  border-bottom: 1px solid #2a2a4e;
+}
+.tab {
+  border: 1px solid #2a2a4e;
+  background: #1a1a2e;
+  color: #9aa3c0;
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  min-width: 28px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.tab:hover {
+  background: #2a3b66;
+  color: #e6e6f0;
+}
+.tab.active {
+  background: #2a3b66;
+  color: #fff;
+  border-color: #4a8cff;
 }
 
 .main {

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount, flushPromises } from "@vue/test-utils";
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
+import type { Cell } from "./gridTabs";
 
-// Stub the cell so the grid's own state (persist/restore + zoom + auto-layout) can
-// be tested without pulling in Terminal/xterm/pub-sub.
+// Stub the cell so the page renderer can be tested without Terminal/xterm/pub-sub.
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
@@ -14,164 +14,43 @@ vi.mock("./TerminalCell.vue", () => ({
   },
 }));
 
-const STORE_KEY = "grid_state_v1";
-const mountGrid = () => mount(TerminalGrid, { props: { defaultCwd: "/work/proj", presets: [], home: "/work" } });
+const cell = (uid: number, session: string | null = null, cwd: string | null = null): Cell => ({ uid, session, cwd });
+const mountGrid = (cells: Cell[], expandedUid: number | null = null) =>
+  mount(TerminalGrid, { props: { cells, expandedUid, defaultCwd: "/work", presets: [], home: "/work" } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
-const saved = () => JSON.parse(localStorage.getItem(STORE_KEY) || "{}");
-const lastAddState = (w: ReturnType<typeof mount>) => w.emitted("add-state")?.at(-1)?.[0];
 
-const A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
-const B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
-const C = "cccccccc-cccc-cccc-cccc-cccccccccccc";
-const D = "dddddddd-dddd-dddd-dddd-dddddddddddd";
-
-beforeEach(() => {
-  localStorage.clear();
-  globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ cwd: "/work/proj" }) })) as unknown as typeof fetch;
-});
-
-describe("TerminalGrid auto-layout", () => {
-  it("shows a single launch cell on an empty grid", async () => {
-    const w = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w)).toHaveLength(1);
+describe("TerminalGrid (page renderer)", () => {
+  it("renders one TerminalCell per cell", () => {
+    expect(cellsOf(mountGrid([cell(0), cell(1), cell(2)]))).toHaveLength(3);
   });
 
-  it("shows exactly the running terminals, packed (interleaved state is compacted on load)", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, C, null], cwds: ["/a", null, "/c", null], expanded: null }));
-    const w = mountGrid();
-    await flushPromises();
-    const cells = cellsOf(w);
-    expect(cells).toHaveLength(2); // 2 running, no empty filler, no add cell
-    expect(cells[0].props("initialSessionId")).toBe(A);
-    expect(cells[1].props("initialSessionId")).toBe(C);
-    expect(cells[1].props("initialCwd")).toBe("/c");
+  it("passes session / cwd / expanded through to the cells", () => {
+    const cs = cellsOf(mountGrid([cell(0, "s0", "/a"), cell(1, "s1", "/b")], 1));
+    expect(cs[0].props("initialSessionId")).toBe("s0");
+    expect(cs[0].props("expanded")).toBe(false);
+    expect(cs[1].props("expanded")).toBe(true);
   });
 
-  it("addCell toggles one trailing launch cell and reports add-state", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: [], expanded: null }));
-    const w = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w)).toHaveLength(1);
+  it("re-emits each cell event tagged with the cell uid", () => {
+    const w = mountGrid([cell(7, "s")]);
+    cellsOf(w)[0].vm.$emit("session", "new");
+    cellsOf(w)[0].vm.$emit("cwd", "/x");
+    cellsOf(w)[0].vm.$emit("close");
+    cellsOf(w)[0].vm.$emit("toggle-expand");
+    expect(w.emitted("session")?.[0]).toEqual([7, "new"]);
+    expect(w.emitted("cwd")?.[0]).toEqual([7, "/x"]);
+    expect(w.emitted("close")?.[0]).toEqual([7]);
+    expect(w.emitted("toggle-expand")?.[0]).toEqual([7]);
+  });
 
-    w.vm.addCell();
+  it("adds the zoomed class only when a cell is expanded", async () => {
+    expect(
+      mountGrid([cell(0, "s")], null)
+        .find(".stage")
+        .classes(),
+    ).not.toContain("zoomed");
+    const w = mountGrid([cell(0, "s")], 0);
     await nextTick();
-    expect(cellsOf(w)).toHaveLength(2);
-    expect(cellsOf(w)[1].props("initialSessionId")).toBe(null);
-    expect(lastAddState(w)).toEqual({ canAdd: true, adding: true });
-
-    w.vm.addCell(); // toggle off (cancel)
-    await nextTick();
-    expect(cellsOf(w)).toHaveLength(1);
-    expect(lastAddState(w)).toEqual({ canAdd: true, adding: false });
-  });
-
-  it("launching the add cell promotes it to a running terminal and stops adding", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: [], expanded: null }));
-    const w = mountGrid();
-    await flushPromises();
-    w.vm.addCell();
-    await nextTick();
-    cellsOf(w)[1].vm.$emit("session", B);
-    await nextTick();
-    expect(cellsOf(w)).toHaveLength(2); // both running now, add cell consumed
-    expect(saved().sessions.slice(0, 2)).toEqual([A, B]);
-    expect(lastAddState(w)).toEqual({ canAdd: true, adding: false });
-  });
-
-  it("caps the grid at 9 running (no 10th cell)", async () => {
-    const ids = Array.from({ length: 9 }, (_, i) => `${String(i).repeat(8)}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`);
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ids, cwds: [], expanded: null }));
-    const w = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w)).toHaveLength(9);
-    w.vm.addCell();
-    await nextTick();
-    expect(cellsOf(w)).toHaveLength(9);
-  });
-
-  it("forwards defaultCwd to cells", async () => {
-    const w = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w)[0].props("defaultCwd")).toBe("/work/proj");
-  });
-
-  it("persists a cell's chosen cwd", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], cwds: ["/a", null, null, null], expanded: null }));
-    const w = mountGrid();
-    await flushPromises();
-    cellsOf(w)[0].vm.$emit("cwd", "/work/proj/sub");
-    await nextTick();
-    expect(saved().cwds[0]).toBe("/work/proj/sub");
-  });
-
-  it("persists a session id when a cell emits 'session'", async () => {
-    const w = mountGrid();
-    await flushPromises();
-    cellsOf(w)[0].vm.$emit("session", A);
-    await nextTick();
-    expect(saved().sessions[0]).toBe(A);
-  });
-
-  it("clears the slot, un-zooms, and shrinks on close", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, C, D], cwds: ["/a", "/b", "/c", "/d"], expanded: 1 }));
-    const w = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w)).toHaveLength(4);
-    cellsOf(w)[1].vm.$emit("close"); // close B (zoomed)
-    await nextTick();
-    expect(saved().sessions.slice(0, 4)).toEqual([A, C, D, null]); // gap filled
-    expect(saved().cwds.slice(0, 4)).toEqual(["/a", "/c", "/d", null]);
-    expect(saved().expanded).toBe(null);
-    expect(cellsOf(w)).toHaveLength(3); // 3 running now
-    expect(cellsOf(w)[1].props("initialSessionId")).toBe(C);
-  });
-
-  it("toggles zoom on 'toggle-expand' and back off again", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, B, null, null], cwds: [], expanded: null }));
-    const w = mountGrid();
-    await flushPromises();
-    cellsOf(w)[1].vm.$emit("toggle-expand");
-    await nextTick();
-    expect(cellsOf(w)[1].props("expanded")).toBe(true);
-    expect(saved().expanded).toBe(1);
-    cellsOf(w)[1].vm.$emit("toggle-expand");
-    await nextTick();
-    expect(saved().expanded).toBe(null);
-  });
-
-  it("restores running sessions and the zoom from localStorage", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, C, null, null], expanded: 1 }));
-    const w = mountGrid();
-    await flushPromises();
-    const cells = cellsOf(w);
-    expect(cells).toHaveLength(2);
-    expect(cells[0].props("initialSessionId")).toBe(A);
-    expect(cells[1].props("initialSessionId")).toBe(C);
-    expect(cells[1].props("expanded")).toBe(true);
-  });
-
-  it("drops a restored zoom that no longer lands on a running cell", async () => {
-    // Only A is valid; the stored expanded position points past the running cell.
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: [A, null, null, null], expanded: 2 }));
-    const w = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w).every((c) => c.props("expanded") === false)).toBe(true);
-  });
-
-  it("drops non-UUID persisted session ids", async () => {
-    localStorage.setItem(STORE_KEY, JSON.stringify({ sessions: ["not-a-uuid", "../etc/passwd", A, null], expanded: null }));
-    const w = mountGrid();
-    await flushPromises();
-    const cells = cellsOf(w);
-    expect(cells).toHaveLength(1); // only A survives
-    expect(cells[0].props("initialSessionId")).toBe(A);
-  });
-
-  it("ignores a corrupt localStorage payload", async () => {
-    localStorage.setItem(STORE_KEY, "not json{");
-    const w = mountGrid();
-    await flushPromises();
-    expect(cellsOf(w)).toHaveLength(1);
+    expect(w.find(".stage").classes()).toContain("zoomed");
   });
 });

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1,190 +1,47 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import TerminalCell from "./TerminalCell.vue";
-import { MAX_CELLS, trackStyle, layoutForCount } from "./gridLayout";
+import { trackStyle, layoutForCount } from "./gridLayout";
+import type { Cell } from "./gridTabs";
 import type { CwdPreset } from "./presets";
 
-// Zooming interface: the grid is the base view; expanding a cell switches to a
-// filmstrip — the zoomed cell fills the top, the others line up in a
-// horizontally-scrolling strip below (click any cell's ⤢ to swap which is zoomed).
-// Only the ZOOMED cell is moved (with <Teleport>) up to the overlay; every other
-// cell stays put in the grid, which is just restyled into the strip. Nothing else
-// is relocated or re-created, so terminals keep running and headers never flicker.
-// The layout is derived from the running-terminal count (no manual picker); a "+"
-// in the toolbar adds one launch cell at a time. `defaultCwd` prefills the launch
-// form; `presets` are the quick-pick dirs; `home` anchors the cell header path on ~.
-defineProps<{ defaultCwd: string | null; presets: CwdPreset[]; home: string | null }>();
-const emit = defineEmits<{ (e: "add-state", v: { canAdd: boolean; adding: boolean }): void }>();
+// Renders ONE page of the grid (≤9 cells), auto-sized to the cell count. The page
+// is fully controlled by GridView: `cells` is the page's slice and `expandedUid`
+// the zoomed cell (if it is on this page); every change is emitted up by uid.
+// Expanding a cell switches to a filmstrip — the zoomed cell (teleported to the
+// overlay) fills the top, the rest line up in a scrollable strip below.
+const props = defineProps<{ cells: Cell[]; expandedUid: number | null; defaultCwd: string | null; presets: CwdPreset[]; home: string | null }>();
+const emit = defineEmits<{
+  (e: "session" | "cwd", uid: number, value: string): void;
+  (e: "close" | "toggle-expand", uid: number): void;
+}>();
 
-// Each cell is a persistent SLOT with a stable `uid`. The slots array's ORDER is
-// the display order; the visible cells are the first `cellCount`. v-for keys by
-// uid, so reordering the array (compaction) MOVES the cell instances — the running
-// terminals follow their slot instead of reconnecting.
-interface Slot {
-  uid: number;
-  session: string | null;
-  cwd: string | null;
-}
-
-// Persisted so a page reload restores the open terminals and the zoom state.
-const STORE_KEY = "grid_state_v1";
-// Session ids are UUIDs. Drop anything else from a stale/tampered localStorage so
-// a cell never mounts with an invalid id (which the server rejects, leaving the
-// terminal reconnecting forever).
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function loadState(): { slots: Slot[]; expandedUid: number | null } {
-  const sessions = Array<string | null>(MAX_CELLS).fill(null);
-  const cwds = Array<string | null>(MAX_CELLS).fill(null);
-  let expandedIndex: number | null = null;
-  try {
-    const parsed = JSON.parse(localStorage.getItem(STORE_KEY) || "");
-    for (let i = 0; i < MAX_CELLS; i++) {
-      const v = parsed?.sessions?.[i];
-      if (typeof v === "string" && UUID_RE.test(v)) sessions[i] = v;
-      const c = parsed?.cwds?.[i];
-      if (typeof c === "string") cwds[i] = c;
-    }
-    const e = parsed?.expanded;
-    if (typeof e === "number" && e >= 0 && e < MAX_CELLS) expandedIndex = e;
-  } catch {
-    // no/invalid state — defaults
-  }
-  // uid === initial index; the order changes via compaction, the uid never does.
-  const built = Array.from({ length: MAX_CELLS }, (_, i) => ({ uid: i, session: sessions[i], cwd: cwds[i] }));
-  // Pack running terminals to the front: the auto-sized grid shows exactly
-  // `running` cells, so an older/interleaved saved state must not leave gaps.
-  const slots = [...built.filter((s) => s.session !== null), ...built.filter((s) => s.session === null)];
-  return { slots, expandedUid: expandedIndex };
-}
-
-const initial = loadState();
-const slots = ref<Slot[]>(initial.slots);
-const expandedUid = ref<number | null>(initial.expandedUid);
-
-const runningCount = computed(() => slots.value.filter((s) => s.session !== null).length);
-// One launch cell is shown to start the first terminal (empty grid) or when the
-// user clicks "+"; otherwise the grid holds exactly the running terminals.
-const adding = ref(false);
-const cellCount = computed(() => Math.min(MAX_CELLS, runningCount.value + (adding.value || runningCount.value === 0 ? 1 : 0)));
-const layout = computed(() => layoutForCount(cellCount.value));
-
-const visibleSlots = computed(() => slots.value.slice(0, cellCount.value));
-const slotByUid = (uid: number) => slots.value.find((s) => s.uid === uid);
-const slotPos = (uid: number) => slots.value.findIndex((s) => s.uid === uid);
-
-// Persist as position-indexed arrays (+ the expanded cell's position) so the
-// on-disk shape is unchanged across this refactor.
-watch(
-  [slots, expandedUid],
-  () =>
-    localStorage.setItem(
-      STORE_KEY,
-      JSON.stringify({
-        sessions: slots.value.map((s) => s.session),
-        cwds: slots.value.map((s) => s.cwd),
-        expanded: expandedUid.value === null ? null : slotPos(expandedUid.value),
-      }),
-    ),
-  { deep: true },
-);
-
-// Pack the running terminals to the front (top-left), empties to the back, keeping
-// relative order. Stable uids mean the live cells move without remounting.
-function compact() {
-  const occupied = slots.value.filter((s) => s.session !== null);
-  const empty = slots.value.filter((s) => s.session === null);
-  slots.value = [...occupied, ...empty];
-}
-
-// On a layout change, re-pack so the running terminals stay visible (top-left), and
-// drop the zoom if the expanded cell fell outside the new, smaller layout.
-watch(cellCount, () => {
-  compact();
-  if (expandedUid.value !== null) {
-    const pos = slotPos(expandedUid.value);
-    if (pos < 0 || pos >= cellCount.value) expandedUid.value = null;
-  }
-});
-
-function toggleExpand(uid: number) {
-  expandedUid.value = expandedUid.value === uid ? null : uid;
-}
-
-function setSession(uid: number, id: string | null) {
-  const s = slotByUid(uid);
-  if (!s) return;
-  s.session = id;
-  if (id !== null) adding.value = false; // the launch cell became a running terminal
-  if (id === null && expandedUid.value === uid) expandedUid.value = null; // a closed cell can't stay zoomed
-}
-
-function setCwd(uid: number, cwd: string) {
-  const s = slotByUid(uid);
-  if (s) s.cwd = cwd;
-}
-
-// Closing a cell empties its slot and packs the gap right away, so the remaining
-// terminals shift up to fill it.
-function onClose(uid: number) {
-  const s = slotByUid(uid);
-  if (s) {
-    s.session = null;
-    s.cwd = null;
-  }
-  if (expandedUid.value === uid) expandedUid.value = null;
-  compact();
-}
-
-// Toolbar "+" toggles a single trailing launch cell. Capped at MAX_CELLS running.
-function addCell() {
-  if (adding.value) adding.value = false;
-  else if (runningCount.value < MAX_CELLS) adding.value = true;
-}
-defineExpose({ addCell });
-
-// Tell the toolbar whether "+" can add and whether a launch cell is already open.
-watch([runningCount, adding], () => emit("add-state", { canAdd: runningCount.value < MAX_CELLS, adding: adding.value }), { immediate: true });
-
-// The grid (non-zoomed) always uses full equal tracks; zoom restyles the grid into
-// the bottom strip via CSS, so no track collapsing is needed.
-const gridStyle = computed(() => trackStyle(layout.value, null));
+const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length), null));
 
 // The zoomed cell is teleported up here; the target must exist before it moves, so
-// hold off until mounted (covers a page reload that restores a zoom).
+// hold off until mounted (covers a reload that restores a zoom).
 const zoomMain = ref<HTMLElement | null>(null);
 const mounted = ref(false);
-onMounted(() => {
-  mounted.value = true;
-  // Drop a restored zoom that no longer lands on a running cell (stale state).
-  const s = expandedUid.value === null ? undefined : slotByUid(expandedUid.value);
-  if (expandedUid.value !== null && (!s || s.session === null)) expandedUid.value = null;
-});
-
-const zoomed = computed(() => expandedUid.value !== null && mounted.value);
-
-// While zoomed, push empty cells to the end of the strip so the open terminals line
-// up on the left. Pure CSS order — never reorders the DOM.
-const stripOrder = (slot: Slot) => (zoomed.value && slot.uid !== expandedUid.value && slot.session === null ? { order: 1 } : undefined);
+onMounted(() => (mounted.value = true));
+const zoomed = computed(() => props.expandedUid !== null && mounted.value);
 </script>
 
 <template>
   <div class="stage" :class="{ zoomed }">
     <div ref="zoomMain" class="zoom-main" />
     <div class="grid" :style="gridStyle">
-      <Teleport v-for="slot in visibleSlots" :key="slot.uid" :to="zoomMain" :disabled="!(zoomed && slot.uid === expandedUid)">
+      <Teleport v-for="cell in cells" :key="cell.uid" :to="zoomMain" :disabled="!(zoomed && cell.uid === expandedUid)">
         <TerminalCell
-          :style="stripOrder(slot)"
-          :expanded="slot.uid === expandedUid"
-          :initial-session-id="slot.session"
-          :initial-cwd="slot.cwd"
+          :expanded="cell.uid === expandedUid"
+          :initial-session-id="cell.session"
+          :initial-cwd="cell.cwd"
           :default-cwd="defaultCwd"
           :presets="presets"
           :home="home"
-          @toggle-expand="toggleExpand(slot.uid)"
-          @session="(id) => setSession(slot.uid, id)"
-          @cwd="(c) => setCwd(slot.uid, c)"
-          @close="() => onClose(slot.uid)"
+          @toggle-expand="emit('toggle-expand', cell.uid)"
+          @session="(id) => emit('session', cell.uid, id)"
+          @cwd="(c) => emit('cwd', cell.uid, c)"
+          @close="() => emit('close', cell.uid)"
         />
       </Teleport>
     </div>

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -120,6 +120,25 @@ describe("parseGridState / migrateLegacy / initialState", () => {
     expect(parseGridState(null)).toBeNull();
     expect(parseGridState("not json{")).toBeNull();
   });
+  it("drops cells with invalid uids and dedupes duplicate uids (keeping the first)", () => {
+    const raw = JSON.stringify({
+      cells: [
+        cell(0, U(0)),
+        { uid: -1, session: null, cwd: null }, // negative
+        { uid: 1.5, session: null, cwd: null }, // fractional
+        cell(0, U(1)), // duplicate uid 0
+        cell(2, U(2)),
+      ],
+      expanded: null,
+      page: 0,
+      nextUid: 1,
+    });
+    const s = parseGridState(raw);
+    if (!s) throw new Error("expected parsed state");
+    expect(s.cells.map((c) => c.uid)).toEqual([0, 2]);
+    expect(s.cells[0].session).toBe(U(0)); // first uid 0 kept
+    expect(s.nextUid).toBe(3); // > max uid even though stored nextUid was 1
+  });
   it("migrates the legacy single-grid shape into the flat list", () => {
     const legacy = JSON.stringify({ sessions: [U(0), null, U(2), null], cwds: ["/a", null, "/c", null], expanded: 1 });
     const s = migrateLegacy(legacy);

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -113,12 +113,13 @@ describe("switchPage", () => {
 });
 
 describe("parseGridState / migrateLegacy / initialState", () => {
-  it("round-trips a valid state and drops bad cells", () => {
-    const raw = JSON.stringify({ cells: [cell(0, U(0)), { uid: 1, session: "bad", cwd: null }, cell(2)], expanded: 0, page: 0, nextUid: 3 });
+  it("keeps running cells, renumbers uids, and drops malformed entries", () => {
+    const raw = JSON.stringify({ cells: [cell(0, U(0)), { uid: 1, session: "bad", cwd: null }, cell(2, U(2))], expanded: 2, page: 0, nextUid: 3 });
     const s = parseGridState(raw);
     if (!s) throw new Error("expected parsed state");
-    expect(s.cells.map((c) => c.uid)).toEqual([0, 2]); // "bad" session dropped
-    expect(s.expanded).toBe(0);
+    expect(s.cells.map((c) => c.session)).toEqual([U(0), U(2)]); // "bad" session dropped
+    expect(s.cells.map((c) => c.uid)).toEqual([0, 1]); // renumbered from position
+    expect(s.expanded).toBe(1); // old uid 2 -> new index 1
   });
   it("returns null for missing/corrupt input", () => {
     expect(parseGridState(null)).toBeNull();
@@ -131,14 +132,13 @@ describe("parseGridState / migrateLegacy / initialState", () => {
     expect(Number.isInteger(s.page)).toBe(true);
     expect(s.page).toBe(0);
   });
-  it("drops cells with invalid uids and dedupes duplicate uids (keeping the first)", () => {
+  it("renumbers duplicate/oversized persisted uids and keeps nextUid safe", () => {
     const raw = JSON.stringify({
       cells: [
         cell(0, U(0)),
-        { uid: -1, session: null, cwd: null }, // negative
-        { uid: 1.5, session: null, cwd: null }, // fractional
         cell(0, U(1)), // duplicate uid 0
-        cell(2, U(2)),
+        { uid: 5, session: null, cwd: null }, // empty launch cell — dropped
+        { uid: Number.MAX_SAFE_INTEGER, session: U(2), cwd: null }, // oversized uid
       ],
       expanded: null,
       page: 0,
@@ -146,9 +146,10 @@ describe("parseGridState / migrateLegacy / initialState", () => {
     });
     const s = parseGridState(raw);
     if (!s) throw new Error("expected parsed state");
-    expect(s.cells.map((c) => c.uid)).toEqual([0, 2]);
-    expect(s.cells[0].session).toBe(U(0)); // first uid 0 kept
-    expect(s.nextUid).toBe(3); // > max uid even though stored nextUid was 1
+    expect(s.cells.map((c) => c.session)).toEqual([U(0), U(1), U(2)]); // empty dropped, all running kept
+    expect(s.cells.map((c) => c.uid)).toEqual([0, 1, 2]); // renumbered — no collision
+    expect(s.nextUid).toBe(3);
+    expect(Number.isSafeInteger(s.nextUid)).toBe(true);
   });
   it("migrates the legacy single-grid shape into the flat list", () => {
     const legacy = JSON.stringify({ sessions: [U(0), null, U(2), null], cwds: ["/a", null, "/c", null], expanded: 1 });

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -99,6 +99,10 @@ describe("setSession / setCwd / toggleExpand", () => {
 });
 
 describe("switchPage", () => {
+  it("is a no-op when selecting the already-active page (keeps zoom + launch cell)", () => {
+    const s = make([...running(9), cell(9)], { page: 1, expanded: 3 });
+    expect(switchPage(s, 1)).toBe(s);
+  });
   it("drops an abandoned trailing launch cell and clears zoom", () => {
     const s = make([...running(9), cell(9)], { page: 1, expanded: 0 });
     const after = switchPage(s, 0);

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -120,6 +120,13 @@ describe("parseGridState / migrateLegacy / initialState", () => {
     expect(parseGridState(null)).toBeNull();
     expect(parseGridState("not json{")).toBeNull();
   });
+  it("constrains a malformed persisted page to a valid integer", () => {
+    const cells = Array.from({ length: 18 }, (_, i) => cell(i, U(i))); // 2 pages
+    const s = parseGridState(JSON.stringify({ cells, expanded: null, page: 1.5, nextUid: 18 }));
+    if (!s) throw new Error("expected parsed state");
+    expect(Number.isInteger(s.page)).toBe(true);
+    expect(s.page).toBe(0);
+  });
   it("drops cells with invalid uids and dedupes duplicate uids (keeping the first)", () => {
     const raw = JSON.stringify({
       cells: [

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  pageCount,
+  pageSlice,
+  runningCount,
+  addCell,
+  setSession,
+  setCwd,
+  closeCell,
+  toggleExpand,
+  switchPage,
+  parseGridState,
+  migrateLegacy,
+  initialState,
+  type GridState,
+  type Cell,
+} from "./gridTabs";
+
+const U = (n: number) => `${String(n % 10).repeat(8)}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`;
+const cell = (uid: number, session: string | null = null, cwd: string | null = null): Cell => ({ uid, session, cwd });
+const running = (count: number): Cell[] => Array.from({ length: count }, (_, i) => cell(i, U(i)));
+const make = (cells: Cell[], extra: Partial<GridState> = {}): GridState => ({ cells, expanded: null, page: 0, nextUid: cells.length, ...extra });
+
+describe("pagination helpers", () => {
+  it("pageCount is 1..n in chunks of 9", () => {
+    expect(pageCount(0)).toBe(1);
+    expect(pageCount(9)).toBe(1);
+    expect(pageCount(10)).toBe(2);
+    expect(pageCount(18)).toBe(2);
+    expect(pageCount(19)).toBe(3);
+  });
+  it("pageSlice returns the page's window", () => {
+    const xs = Array.from({ length: 11 }, (_, i) => i);
+    expect(pageSlice(xs, 0)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(pageSlice(xs, 1)).toEqual([9, 10]);
+  });
+  it("runningCount counts non-null sessions", () => {
+    expect(runningCount([cell(0, U(0)), cell(1), cell(2, U(2))])).toBe(2);
+  });
+});
+
+describe("addCell", () => {
+  it("appends a launch cell and jumps to its (last) page", () => {
+    const s = addCell(make(running(9)));
+    expect(s.cells).toHaveLength(10);
+    expect(s.cells[9].session).toBeNull();
+    expect(s.page).toBe(1); // overflowed to page 2
+  });
+  it("cancels an open launch cell (but never the sole entry cell)", () => {
+    const open = make([...running(2), cell(2)]);
+    expect(addCell(open).cells).toHaveLength(2);
+    const entryOnly = make([cell(0)]);
+    expect(addCell(entryOnly).cells).toHaveLength(1);
+  });
+  it("does not exceed MAX_TERMINALS", () => {
+    const s = addCell(make(running(81)));
+    expect(runningCount(s.cells)).toBe(81);
+    expect(s.cells).toHaveLength(81);
+  });
+});
+
+describe("closeCell reflows across pages", () => {
+  it("removes a cell and packs later cells forward (page 2 -> page 1)", () => {
+    const s = make(running(10), { page: 0 }); // 10 terminals -> 2 pages
+    expect(pageCount(s.cells.length)).toBe(2);
+    const after = closeCell(s, 0); // close the first terminal
+    expect(after.cells).toHaveLength(9); // the 10th flowed back onto page 1
+    expect(pageCount(after.cells.length)).toBe(1);
+    expect(after.cells.map((c) => c.uid)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+  it("clamps the active page when a page disappears", () => {
+    const s = make(running(10), { page: 1 });
+    const after = closeCell(s, 0);
+    expect(after.page).toBe(0);
+  });
+  it("keeps an entry cell after the last terminal closes", () => {
+    const after = closeCell(make([cell(0, U(0))]), 0);
+    expect(after.cells).toHaveLength(1);
+    expect(after.cells[0].session).toBeNull();
+  });
+  it("un-zooms when the zoomed cell is closed", () => {
+    const after = closeCell(make(running(2), { expanded: 0 }), 0);
+    expect(after.expanded).toBeNull();
+  });
+});
+
+describe("setSession / setCwd / toggleExpand", () => {
+  it("promotes a launch cell to running", () => {
+    const s = setSession(make([cell(0)]), 0, U(5));
+    expect(s.cells[0].session).toBe(U(5));
+  });
+  it("setCwd updates the matching cell", () => {
+    expect(setCwd(make([cell(0)]), 0, "/x").cells[0].cwd).toBe("/x");
+  });
+  it("toggleExpand flips the zoom uid", () => {
+    expect(toggleExpand(make(running(2)), 1).expanded).toBe(1);
+    expect(toggleExpand(make(running(2), { expanded: 1 }), 1).expanded).toBeNull();
+  });
+});
+
+describe("switchPage", () => {
+  it("drops an abandoned trailing launch cell and clears zoom", () => {
+    const s = make([...running(9), cell(9)], { page: 1, expanded: 0 });
+    const after = switchPage(s, 0);
+    expect(after.cells).toHaveLength(9); // launch cell trimmed
+    expect(after.expanded).toBeNull();
+    expect(after.page).toBe(0);
+  });
+});
+
+describe("parseGridState / migrateLegacy / initialState", () => {
+  it("round-trips a valid state and drops bad cells", () => {
+    const raw = JSON.stringify({ cells: [cell(0, U(0)), { uid: 1, session: "bad", cwd: null }, cell(2)], expanded: 0, page: 0, nextUid: 3 });
+    const s = parseGridState(raw);
+    if (!s) throw new Error("expected parsed state");
+    expect(s.cells.map((c) => c.uid)).toEqual([0, 2]); // "bad" session dropped
+    expect(s.expanded).toBe(0);
+  });
+  it("returns null for missing/corrupt input", () => {
+    expect(parseGridState(null)).toBeNull();
+    expect(parseGridState("not json{")).toBeNull();
+  });
+  it("migrates the legacy single-grid shape into the flat list", () => {
+    const legacy = JSON.stringify({ sessions: [U(0), null, U(2), null], cwds: ["/a", null, "/c", null], expanded: 1 });
+    const s = migrateLegacy(legacy);
+    if (!s) throw new Error("expected migration");
+    expect(s.cells.map((c) => c.session)).toEqual([U(0), U(2)]);
+    expect(s.cells[1].cwd).toBe("/c");
+    expect(s.expanded).toBe(s.cells[1].uid); // old position 1 -> the 2nd running cell
+  });
+  it("initialState prefers current, then legacy, then a fresh entry", () => {
+    expect(initialState(JSON.stringify({ cells: [cell(0, U(0))] }), null).migrated).toBe(false);
+    const fromLegacy = initialState(null, JSON.stringify({ sessions: [U(0)] }));
+    expect(fromLegacy.migrated).toBe(true);
+    const fresh = initialState(null, null);
+    expect(fresh.state.cells).toHaveLength(1);
+    expect(fresh.state.cells[0].session).toBeNull();
+  });
+});

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -69,8 +69,10 @@ export function toggleExpand(state: GridState, uid: number): GridState {
 }
 
 // Switch page: drop an abandoned trailing launch cell first and clear the zoom
-// (zoom is scoped to a page).
+// (zoom is scoped to a page). Selecting the already-active page is a no-op so it
+// doesn't discard the open launch cell or zoom.
 export function switchPage(state: GridState, page: number): GridState {
+  if (page === state.page) return state;
   const last = state.cells[state.cells.length - 1];
   const cells = last && last.session === null && state.cells.length > 1 ? state.cells.slice(0, -1) : state.cells;
   return clampPage({ ...state, cells, expanded: null, page });

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -79,33 +79,31 @@ export function switchPage(state: GridState, page: number): GridState {
 }
 
 const isUuid = (s: unknown): s is string => typeof s === "string" && UUID_RE.test(s);
-// uid must be a non-negative safe integer: localStorage is untrusted, and a bad or
-// duplicate uid would collide v-for keys and make uid-targeted mutators hit more
-// than one cell.
+// A cell entry is kept if its session/cwd are well-formed; uid is validated only to
+// match the persisted `expanded` (it is renumbered below regardless).
 const isCell = (c: unknown): c is Cell => {
   const o = c as Cell | null;
-  return !!o && Number.isSafeInteger(o.uid) && o.uid >= 0 && (o.session === null || isUuid(o.session)) && (o.cwd === null || typeof o.cwd === "string");
-};
-
-const dedupeByUid = (cells: Cell[]): Cell[] => {
-  const seen = new Set<number>();
-  return cells.filter((c) => {
-    if (seen.has(c.uid)) return false;
-    seen.add(c.uid);
-    return true;
-  });
+  return !!o && (o.session === null || isUuid(o.session)) && (o.cwd === null || typeof o.cwd === "string");
 };
 
 export function parseGridState(raw: string | null): GridState | null {
   try {
     const parsed = JSON.parse(raw ?? "");
     if (!Array.isArray(parsed?.cells)) return null;
-    const cells: Cell[] = dedupeByUid(parsed.cells.filter(isCell)).slice(0, MAX_TERMINALS);
-    const maxUid = cells.reduce((m: number, c: Cell) => Math.max(m, c.uid), -1);
-    const nextUid = Number.isSafeInteger(parsed.nextUid) && parsed.nextUid > maxUid ? parsed.nextUid : maxUid + 1;
-    const expanded = typeof parsed.expanded === "number" && cells.some((c) => c.uid === parsed.expanded && c.session !== null) ? parsed.expanded : null;
+    // Keep only running cells (the trailing launch cell is ephemeral) and renumber
+    // uids from position. Persisted uids are untrusted: duplicates would collide
+    // v-for keys, and a near-MAX_SAFE_INTEGER value would overflow the nextUid
+    // counter. uid is internal identity only, so a clean 0..n-1 space (nextUid =
+    // count) is always safe and in range.
+    const running = parsed.cells
+      .filter(isCell)
+      .filter((c: Cell) => c.session !== null)
+      .slice(0, MAX_TERMINALS);
+    const cells: Cell[] = running.map((c: Cell, i: number) => ({ uid: i, session: c.session, cwd: c.cwd }));
+    const expandedIdx = running.findIndex((c: Cell) => c.uid === parsed.expanded);
+    const expanded = typeof parsed.expanded === "number" && expandedIdx >= 0 ? expandedIdx : null;
     const page = Number.isSafeInteger(parsed.page) && parsed.page >= 0 ? parsed.page : 0;
-    return clampPage(ensureEntry({ cells, expanded, page, nextUid }));
+    return clampPage(ensureEntry({ cells, expanded, page, nextUid: cells.length }));
   } catch {
     return null;
   }

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -77,18 +77,30 @@ export function switchPage(state: GridState, page: number): GridState {
 }
 
 const isUuid = (s: unknown): s is string => typeof s === "string" && UUID_RE.test(s);
+// uid must be a non-negative safe integer: localStorage is untrusted, and a bad or
+// duplicate uid would collide v-for keys and make uid-targeted mutators hit more
+// than one cell.
 const isCell = (c: unknown): c is Cell => {
   const o = c as Cell | null;
-  return !!o && typeof o.uid === "number" && (o.session === null || isUuid(o.session)) && (o.cwd === null || typeof o.cwd === "string");
+  return !!o && Number.isSafeInteger(o.uid) && o.uid >= 0 && (o.session === null || isUuid(o.session)) && (o.cwd === null || typeof o.cwd === "string");
+};
+
+const dedupeByUid = (cells: Cell[]): Cell[] => {
+  const seen = new Set<number>();
+  return cells.filter((c) => {
+    if (seen.has(c.uid)) return false;
+    seen.add(c.uid);
+    return true;
+  });
 };
 
 export function parseGridState(raw: string | null): GridState | null {
   try {
     const parsed = JSON.parse(raw ?? "");
     if (!Array.isArray(parsed?.cells)) return null;
-    const cells: Cell[] = parsed.cells.filter(isCell).slice(0, MAX_TERMINALS);
+    const cells: Cell[] = dedupeByUid(parsed.cells.filter(isCell)).slice(0, MAX_TERMINALS);
     const maxUid = cells.reduce((m: number, c: Cell) => Math.max(m, c.uid), -1);
-    const nextUid = typeof parsed.nextUid === "number" && parsed.nextUid > maxUid ? parsed.nextUid : maxUid + 1;
+    const nextUid = Number.isSafeInteger(parsed.nextUid) && parsed.nextUid > maxUid ? parsed.nextUid : maxUid + 1;
     const expanded = typeof parsed.expanded === "number" && cells.some((c) => c.uid === parsed.expanded && c.session !== null) ? parsed.expanded : null;
     return clampPage(ensureEntry({ cells, expanded, page: typeof parsed.page === "number" ? parsed.page : 0, nextUid }));
   } catch {

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -27,7 +27,7 @@ export const pageCount = (cellCount: number) => Math.max(1, Math.ceil(cellCount 
 export const pageSlice = <T>(cells: T[], page: number) => cells.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
 export const runningCount = (cells: Cell[]) => cells.filter((c) => c.session !== null).length;
 
-const clampPage = (s: GridState): GridState => ({ ...s, page: Math.min(Math.max(0, s.page), pageCount(s.cells.length) - 1) });
+const clampPage = (s: GridState): GridState => ({ ...s, page: Math.min(Math.max(0, Math.floor(s.page)), pageCount(s.cells.length) - 1) });
 
 // Always keep at least one cell — the entry launch cell on an otherwise empty grid.
 const ensureEntry = (s: GridState): GridState =>
@@ -102,7 +102,8 @@ export function parseGridState(raw: string | null): GridState | null {
     const maxUid = cells.reduce((m: number, c: Cell) => Math.max(m, c.uid), -1);
     const nextUid = Number.isSafeInteger(parsed.nextUid) && parsed.nextUid > maxUid ? parsed.nextUid : maxUid + 1;
     const expanded = typeof parsed.expanded === "number" && cells.some((c) => c.uid === parsed.expanded && c.session !== null) ? parsed.expanded : null;
-    return clampPage(ensureEntry({ cells, expanded, page: typeof parsed.page === "number" ? parsed.page : 0, nextUid }));
+    const page = Number.isSafeInteger(parsed.page) && parsed.page >= 0 ? parsed.page : 0;
+    return clampPage(ensureEntry({ cells, expanded, page, nextUid }));
   } catch {
     return null;
   }

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -1,0 +1,121 @@
+// The grid is ONE flat, ordered list of terminal cells, split into pages of 9
+// (the tabs). Closing a cell reflows the whole list so later pages pack forward
+// into the gap (terminals flow across page boundaries); "+ Terminal" appends a
+// launch cell, overflowing into a new page when the last one is full. GridView
+// owns a single GridState ref and drives it through these pure transforms;
+// TerminalGrid just renders the active page's slice.
+
+export interface Cell {
+  uid: number;
+  session: string | null;
+  cwd: string | null;
+}
+export interface GridState {
+  cells: Cell[];
+  expanded: number | null; // uid of the zoomed cell, or null
+  page: number;
+  nextUid: number;
+}
+
+export const PAGE_SIZE = 9;
+export const MAX_TERMINALS = 81; // 9 pages
+export const STATE_KEY = "grid_v2";
+export const LEGACY_KEY = "grid_state_v1";
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const pageCount = (cellCount: number) => Math.max(1, Math.ceil(cellCount / PAGE_SIZE));
+export const pageSlice = <T>(cells: T[], page: number) => cells.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
+export const runningCount = (cells: Cell[]) => cells.filter((c) => c.session !== null).length;
+
+const clampPage = (s: GridState): GridState => ({ ...s, page: Math.min(Math.max(0, s.page), pageCount(s.cells.length) - 1) });
+
+// Always keep at least one cell — the entry launch cell on an otherwise empty grid.
+const ensureEntry = (s: GridState): GridState =>
+  s.cells.length > 0 ? s : { ...s, cells: [{ uid: s.nextUid, session: null, cwd: null }], nextUid: s.nextUid + 1 };
+
+// "+ Terminal": append a launch cell (overflowing into a new page when full), or
+// cancel an already-open launch cell. The sole entry cell is never removed.
+export function addCell(state: GridState): GridState {
+  const last = state.cells[state.cells.length - 1];
+  if (last && last.session === null) {
+    if (state.cells.length <= 1) return state; // the entry cell — nothing to add or cancel
+    return clampPage({ ...state, cells: state.cells.slice(0, -1) }); // cancel the open launch cell
+  }
+  if (runningCount(state.cells) >= MAX_TERMINALS) return state;
+  const cells = [...state.cells, { uid: state.nextUid, session: null, cwd: null }];
+  return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1 };
+}
+
+export function setSession(state: GridState, uid: number, id: string | null): GridState {
+  const cells = state.cells.map((c) => (c.uid === uid ? { ...c, session: id } : c));
+  const expanded = id === null && state.expanded === uid ? null : state.expanded;
+  return { ...state, cells, expanded };
+}
+
+export function setCwd(state: GridState, uid: number, cwd: string): GridState {
+  return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, cwd } : c)) };
+}
+
+// Close a cell: drop it and reflow the list (later cells pack forward across
+// pages), un-zoom if it was zoomed, keep an entry cell, and clamp the page.
+export function closeCell(state: GridState, uid: number): GridState {
+  const cells = state.cells.filter((c) => c.uid !== uid);
+  const expanded = state.expanded === uid ? null : state.expanded;
+  return ensureEntry(clampPage({ ...state, cells, expanded }));
+}
+
+export function toggleExpand(state: GridState, uid: number): GridState {
+  return { ...state, expanded: state.expanded === uid ? null : uid };
+}
+
+// Switch page: drop an abandoned trailing launch cell first and clear the zoom
+// (zoom is scoped to a page).
+export function switchPage(state: GridState, page: number): GridState {
+  const last = state.cells[state.cells.length - 1];
+  const cells = last && last.session === null && state.cells.length > 1 ? state.cells.slice(0, -1) : state.cells;
+  return clampPage({ ...state, cells, expanded: null, page });
+}
+
+const isUuid = (s: unknown): s is string => typeof s === "string" && UUID_RE.test(s);
+const isCell = (c: unknown): c is Cell => {
+  const o = c as Cell | null;
+  return !!o && typeof o.uid === "number" && (o.session === null || isUuid(o.session)) && (o.cwd === null || typeof o.cwd === "string");
+};
+
+export function parseGridState(raw: string | null): GridState | null {
+  try {
+    const parsed = JSON.parse(raw ?? "");
+    if (!Array.isArray(parsed?.cells)) return null;
+    const cells: Cell[] = parsed.cells.filter(isCell).slice(0, MAX_TERMINALS);
+    const maxUid = cells.reduce((m: number, c: Cell) => Math.max(m, c.uid), -1);
+    const nextUid = typeof parsed.nextUid === "number" && parsed.nextUid > maxUid ? parsed.nextUid : maxUid + 1;
+    const expanded = typeof parsed.expanded === "number" && cells.some((c) => c.uid === parsed.expanded && c.session !== null) ? parsed.expanded : null;
+    return clampPage(ensureEntry({ cells, expanded, page: typeof parsed.page === "number" ? parsed.page : 0, nextUid }));
+  } catch {
+    return null;
+  }
+}
+
+// Migrate the legacy single-grid shape ({ sessions, cwds, expanded:position }).
+export function migrateLegacy(raw: string | null): GridState | null {
+  try {
+    const parsed = JSON.parse(raw ?? "");
+    if (!Array.isArray(parsed?.sessions)) return null;
+    const cells: Cell[] = [];
+    parsed.sessions.forEach((s: unknown, i: number) => {
+      if (isUuid(s)) cells.push({ uid: cells.length, session: s, cwd: typeof parsed.cwds?.[i] === "string" ? parsed.cwds[i] : null });
+    });
+    const expanded = typeof parsed.expanded === "number" && parsed.expanded >= 0 && parsed.expanded < cells.length ? cells[parsed.expanded].uid : null;
+    return clampPage(ensureEntry({ cells, expanded, page: 0, nextUid: cells.length }));
+  } catch {
+    return null;
+  }
+}
+
+export function initialState(curRaw: string | null, legacyRaw: string | null): { state: GridState; migrated: boolean } {
+  const cur = parseGridState(curRaw);
+  if (cur) return { state: cur, migrated: false };
+  const migrated = migrateLegacy(legacyRaw);
+  if (migrated) return { state: migrated, migrated: true };
+  return { state: ensureEntry({ cells: [], expanded: null, page: 0, nextUid: 0 }), migrated: false };
+}


### PR DESCRIPTION
## Summary

グリッドを**1つのフラットな端末配列**にし、**タブはその配列のページ（9個ごと）= メタデータ**として扱います（#46 の req7）。

- **「＋Terminal」** が満杯(9)で**新タブに溢れる**（増）。
- **端末を閉じると配列全体が前詰めされ、後続ページの端末が前ページへ流れ込む**（タブ跨ぎの繰り上げ）。空になった末尾ページ＝タブは自動で消える（減）。
- タブバーはページが2つ以上のときだけ表示。完全自動（手動の＋タブ/✕は無し）。
- アクティブページのみマウント。他ページの端末はサーバ側 PTY で生存→再表示で resume。

Closes #83

## Items to Confirm / Review

- **実機確認済み**（localhost:5173, ユーザ確認）。特に「タブ1の端末を閉じる→タブ2の端末がタブ1へ流れ込む」を確認。
- **アーキ**: 状態の単一ソースは `gridTabs.ts` の純関数群（`GridState`＝`cells` 配列＋`page`）。`TerminalGrid.vue` は **state を持たない制御コンポーネント**（1ページ描画＋uid付き emit）に変更。`GridView.vue` が `GridState` を1つ所有。
- **永続化/移行**: 単一キー `grid_v2`。旧 `grid_state_v1`（単一グリッド）を初回に1配列へ移行（移行後に旧キー削除）。
- **上限**: `MAX_TERMINALS=81`（9ページ）。zoom はページ内スコープ（ページ切替でクリア）。
- **CLAUDE.md準拠**: 関数を prop で渡さず emit。非null assertion 不使用。

## User Prompt

> 46進めよう。3x3で数オーバーしたらタブで増やせるようにしよう。
>
> 当然、ターミナルの数減ったらタブも自然に減らしてね。前に詰める感じで。
>
> ２つタブがあるときに1つめのタブのターミナルを閉じると２つ目のタブのターミナルが移動してほしい。
>
> タブ自体はメタデータで、ターミナルは１つの配列で管理すればよさそうだけど。

（確認の結果、跨ぎ挙動は「1つの列のページ（跨ぎで常に詰める）」を採用。）

## 実装
- `gridTabs.ts`(新): `Cell`/`GridState`、`PAGE_SIZE=9`/`MAX_TERMINALS=81`、`pageCount`/`pageSlice`/`runningCount`、純ミューテーション `addCell`/`setSession`/`setCwd`/`closeCell`/`toggleExpand`/`switchPage`、`parseGridState`/`migrateLegacy`/`initialState`。
- `TerminalGrid.vue`: 制御コンポーネント化（`cells`/`expanded-uid` props、`session/cwd/close/toggle-expand` emit）。`layoutForCount` 自動レイアウト＋ teleport zoom。
- `GridView.vue`: `GridState` ref を所有、ページ導出、deep watch 永続化、初回移行、タブバー。
- テスト: `gridTabs.spec.ts`（前詰め page2→page1 等）/ `TerminalGrid.spec.ts`（制御）。計 209 tests。

詳細は `plans/feat-grid-tabs.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
