### PR TITLE
feat: 入力待ち/ターン終了を音で通知＋ヘッダ色で状態表示（#46 req6）

### DIFF
--- a/plans/feat-attention-sound.md
+++ b/plans/feat-attention-sound.md
@@ -1,0 +1,32 @@
+# Plan: 入力待ちの音通知＋ヘッダ色での状態表示
+
+Issue: #85（#46 の req6）
+作成日: 2026-06-21
+
+## ゴール
+- 端末が **`waiting`（入力待ち）** になったら**音**で通知（全セッション対象・裏ページ含む）。
+- グリッドセルの**ヘッダ色**でも状態（waiting/working/idle）が分かる。
+
+## 音
+- セルと同じ「sessions」pub/sub の push を**直接購読**（`useSessions` の再取得リストではなく、色と同一ソース）。
+- **鳴動条件 = そのセッションが「あなたの番」になった瞬間**: `working` が **true→false**（claude がターン終了＝Stop。全セッションで publish）または `waiting` が false→true（許可/質問。背景セッションのみ立つ）。
+  - 当初「waiting のみ」だったが、サーバ実装上 `waiting` は **foreground セッションには立たない**（Stop で working=false になるだけ）ため、foreground でも鳴らすには `working` の立ち下がりを見る必要があった。
+- 初回 push はベースライン（鳴らさない）。push は delta（変化時のみ）でスナップショット replay 無し。
+- **🔔トグル**: `useSoundEnabled`（localStorage `sound_enabled`、デフォルト ON）。App.vue と GridView 両方。
+- **🔊テストボタン**: チャイムを即再生（兼オーディオ解錠）。AudioContext は初回ユーザー操作で解錠。
+
+### 実装
+- `src/composables/useSoundEnabled.ts`: localStorage 同期の singleton ref ＋ toggle。
+- `src/composables/useAttentionSound.ts`: `useAttentionSound(enabled)` が「sessions」を購読してビープ。純関数 `needsAttention(prev, msg)` を分離（テスト可能）。`playAttentionSound()` を export（テストボタン用）。
+- `App.vue`: `useAttentionSound(soundEnabled)` ＋🔔/🔊ボタン。
+- `GridView.vue`: 🔔/🔊ボタン。
+
+## ヘッダ色
+- `TerminalCell` の `.cell-header` に `statusClass`（既存）を付与。
+- CSS: `.cell-header.is-waiting`（琥珀の枠／薄い背景）/ `.is-working`（青みがかり）/ `.is-idle`（無色）。ドットは据え置き。
+
+## テスト
+- `useAttentionSound.spec.ts`: `needsAttention` の遷移検出（ターン終了 working true→false で発火・waiting false→true で発火・初回ベースライン無音・作業継続/開始で無音・セッション独立）。
+
+## スコープ外（別issue）
+- req8: 裏タブ（ページ）の集約バッジ。

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,8 @@ import { useSessions, type Filter } from "./composables/useSessions";
 import { useShortcuts } from "./composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
 import { registerChatOpener } from "./composables/useChatLauncher";
+import { useSoundEnabled } from "./composables/useSoundEnabled";
+import { useAttentionSound, playAttentionSound } from "./composables/useAttentionSound";
 import type { Shortcut } from "./types/shortcuts";
 
 // View mode: the classic single-terminal view (default) or the multi-terminal
@@ -38,6 +40,13 @@ const terminalRef = ref<InstanceType<typeof TerminalView> | null>(null);
 // the filter. Both layouts render this same shared state.
 const { sessions, loading, error, refresh } = useSessions();
 const filter = ref<Filter>("all");
+
+// Beep when any session needs attention (waiting) — across the single and grid
+// views, including terminals on background grid pages. Listens to the "sessions"
+// activity stream directly (same source as the cell status), independent of the
+// fetched list above.
+const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
+useAttentionSound(soundEnabled);
 
 // Terminal column width (px), set by dragging the splitter between the terminal
 // and the GUI panel; the GUI panel absorbs whatever is left. Persisted across
@@ -196,6 +205,19 @@ function onSession(id: string) {
           <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
         </button>
       </nav>
+      <button
+        type="button"
+        class="launcher-btn sound-toggle"
+        :class="{ active: soundEnabled }"
+        :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
+        :aria-label="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
+        @click="toggleSound"
+      >
+        <span class="material-symbols-outlined">{{ soundEnabled ? "notifications_active" : "notifications_off" }}</span>
+      </button>
+      <button type="button" class="launcher-btn" title="Test sound" aria-label="Test sound" @click="playAttentionSound">
+        <span class="material-symbols-outlined">volume_up</span>
+      </button>
     </header>
     <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
       <Sidebar
@@ -309,6 +331,9 @@ function onSession(id: string) {
 .launcher-btn.active {
   background: #2f59c0;
   color: #fff;
+}
+.sound-toggle {
+  margin-left: auto;
 }
 .launcher-btn .material-symbols-outlined {
   font-size: 19px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -211,6 +211,7 @@ function onSession(id: string) {
         :class="{ active: soundEnabled }"
         :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
         :aria-label="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
+        :aria-pressed="soundEnabled"
         @click="toggleSound"
       >
         <span class="material-symbols-outlined">{{ soundEnabled ? "notifications_active" : "notifications_off" }}</span>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -17,10 +17,15 @@ import {
   LEGACY_KEY,
   type GridState,
 } from "./gridTabs";
+import { useSoundEnabled } from "../composables/useSoundEnabled";
+import { playAttentionSound } from "../composables/useAttentionSound";
 import type { CwdPreset } from "./presets";
 
 // The multi-terminal grid view. Toggled with the classic single view from App.vue.
 const emit = defineEmits<{ (e: "exit"): void }>();
+
+// Attention-sound toggle (shared singleton with the single view's toolbar).
+const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
 
 // One flat list of terminal cells; tabs are just pages (9 each) over it. Closing a
 // cell reflows the list so terminals flow across page boundaries. Only the active
@@ -117,6 +122,8 @@ function closeSettings() {
       >
         ＋ Terminal
       </button>
+      <button class="tb-btn" :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'" @click="toggleSound">{{ soundEnabled ? "🔔" : "🔕" }}</button>
+      <button class="tb-btn" title="Test sound" aria-label="Test sound" @click="playAttentionSound">🔊</button>
       <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
       <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -122,7 +122,15 @@ function closeSettings() {
       >
         ＋ Terminal
       </button>
-      <button class="tb-btn" :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'" @click="toggleSound">{{ soundEnabled ? "🔔" : "🔕" }}</button>
+      <button
+        class="tb-btn"
+        :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
+        :aria-label="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
+        :aria-pressed="soundEnabled"
+        @click="toggleSound"
+      >
+        {{ soundEnabled ? "🔔" : "🔕" }}
+      </button>
       <button class="tb-btn" title="Test sound" aria-label="Test sound" @click="playAttentionSound">🔊</button>
       <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
       <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -235,9 +235,9 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 </script>
 
 <template>
-  <div class="cell">
+  <div class="cell" :class="statusClass">
     <template v-if="launched">
-      <div class="cell-header">
+      <div class="cell-header" :class="statusClass">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
         <button v-if="dirDisplay" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">{{ dirDisplay }}</button>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
@@ -299,6 +299,15 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   border-radius: 6px;
   overflow: hidden;
 }
+/* Frame the whole cell by status so it's obvious at a glance which terminal is
+   busy (blue) or needs you (amber glow). */
+.cell.is-working {
+  border-color: #4a8cff;
+}
+.cell.is-waiting {
+  border-color: #ffb454;
+  box-shadow: 0 0 0 2px rgba(255, 180, 84, 0.55);
+}
 
 .cell-header {
   flex: 0 0 auto;
@@ -309,6 +318,16 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   padding: 0 8px;
   background: #16213e;
   border-bottom: 1px solid #2a2a4e;
+}
+/* The header also tints by status (working = blue, waiting = amber). */
+.cell-header.is-working {
+  background: #1e3a6b;
+  border-bottom-color: #4a8cff;
+}
+.cell-header.is-waiting {
+  background: #6b4a16;
+  color: #ffe2b0;
+  border-bottom-color: #ffb454;
 }
 
 /* Status dot: idle / working (pulsing) / waiting (attention). */

--- a/src/composables/useAttentionSound.spec.ts
+++ b/src/composables/useAttentionSound.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { needsAttention } from "./useAttentionSound";
+
+const msg = (id: string, working?: boolean, waiting?: boolean) => ({ id, working, waiting });
+
+describe("needsAttention", () => {
+  it("fires when a turn finishes (working true→false)", () => {
+    const prev = new Map();
+    needsAttention(prev, msg("a", true, false)); // working baseline
+    expect(needsAttention(prev, msg("a", false, false))).toBe(true);
+  });
+
+  it("fires when waiting goes false→true", () => {
+    const prev = new Map();
+    needsAttention(prev, msg("a", false, false));
+    expect(needsAttention(prev, msg("a", false, true))).toBe(true);
+  });
+
+  it("is baseline-only on first sight (no beep)", () => {
+    expect(needsAttention(new Map(), msg("a", false, true))).toBe(false);
+    expect(needsAttention(new Map(), msg("a", true, false))).toBe(false);
+  });
+
+  it("does not fire while still working", () => {
+    const prev = new Map();
+    needsAttention(prev, msg("a", true, false));
+    expect(needsAttention(prev, msg("a", true, false))).toBe(false);
+  });
+
+  it("does not fire when work starts (working false→true)", () => {
+    const prev = new Map();
+    needsAttention(prev, msg("a", false, false));
+    expect(needsAttention(prev, msg("a", true, false))).toBe(false);
+  });
+
+  it("treats missing fields as not-working / not-waiting", () => {
+    const prev = new Map();
+    needsAttention(prev, msg("a", true)); // working, no waiting field
+    expect(needsAttention(prev, { id: "a" })).toBe(true); // working dropped to false = finished
+  });
+
+  it("tracks sessions independently", () => {
+    const prev = new Map();
+    needsAttention(prev, msg("a", true, false));
+    needsAttention(prev, msg("b", true, false));
+    expect(needsAttention(prev, msg("b", false, false))).toBe(true);
+    expect(needsAttention(prev, msg("a", true, false))).toBe(false);
+  });
+});

--- a/src/composables/useAttentionSound.ts
+++ b/src/composables/useAttentionSound.ts
@@ -1,0 +1,95 @@
+import { onUnmounted, type Ref } from "vue";
+import { usePubSub } from "./usePubSub";
+
+interface ActivityMsg {
+  id: string;
+  working?: boolean;
+  waiting?: boolean;
+}
+interface ActivityState {
+  working: boolean;
+  waiting: boolean;
+}
+const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" && d !== null && "id" in d;
+
+// True when this activity push means the session now needs you: it just finished a
+// turn (working true→false — Claude's Stop, published for every session) or it set
+// `waiting` (a prompt/permission, published for background sessions). First sight is
+// baseline only (no beep). Mutates `prev` to the latest state.
+export function needsAttention(prev: Map<string, ActivityState>, msg: ActivityMsg): boolean {
+  const now: ActivityState = { working: msg.working ?? false, waiting: msg.waiting ?? false };
+  const was = prev.get(msg.id);
+  prev.set(msg.id, now);
+  if (!was) return false;
+  const finishedTurn = was.working && !now.working;
+  const becameWaiting = !was.waiting && now.waiting;
+  return finishedTurn || becameWaiting;
+}
+
+let audioCtx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  try {
+    audioCtx = audioCtx ?? new AudioContext();
+    return audioCtx;
+  } catch {
+    return null;
+  }
+}
+
+// Autoplay policy: an AudioContext starts suspended until a user gesture, so a beep
+// fired from an event (not a gesture) would be silent. Arm a one-shot listener that
+// resumes the context on the first click/keypress anywhere; after that, beeps play.
+let unlockArmed = false;
+function armUnlock() {
+  if (unlockArmed) return;
+  unlockArmed = true;
+  const unlock = () => {
+    const ctx = getCtx();
+    if (ctx && ctx.state === "suspended") ctx.resume().catch(() => {});
+    window.removeEventListener("pointerdown", unlock);
+    window.removeEventListener("keydown", unlock);
+  };
+  window.addEventListener("pointerdown", unlock);
+  window.addEventListener("keydown", unlock);
+}
+
+// A short two-note attention chime via Web Audio (no asset). Exported so a toolbar
+// "test" button can preview it (and, being a user gesture, unlock the context).
+export function playAttentionSound() {
+  const ctx = getCtx();
+  if (!ctx) return;
+  if (ctx.state === "suspended") ctx.resume().catch(() => {});
+  const tone = (freq: number, start: number, dur: number) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = "sine";
+    osc.frequency.value = freq;
+    const t = ctx.currentTime + start;
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.exponentialRampToValueAtTime(0.25, t + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+    osc.connect(gain).connect(ctx.destination);
+    osc.start(t);
+    osc.stop(t + dur + 0.02);
+  };
+  try {
+    tone(784, 0, 0.16); // G5
+    tone(1047, 0.14, 0.22); // C6
+  } catch {
+    // no Web Audio — stay silent
+  }
+}
+
+// Beep when any session transitions into `waiting` (needs attention), across every
+// page/view, by listening to the same "sessions" activity stream the cells use — so
+// the beep tracks the amber header exactly. `enabled` gates it (the 🔔 toggle).
+export function useAttentionSound(enabled: Ref<boolean>) {
+  armUnlock();
+  const prev = new Map<string, ActivityState>();
+  const { subscribe } = usePubSub();
+  const unsubscribe = subscribe("sessions", (d) => {
+    if (isActivityMsg(d) && needsAttention(prev, d) && enabled.value) playAttentionSound();
+  });
+  onUnmounted(unsubscribe);
+}

--- a/src/composables/useSoundEnabled.ts
+++ b/src/composables/useSoundEnabled.ts
@@ -1,0 +1,12 @@
+import { ref, watch } from "vue";
+
+// Whether the attention beep is on. A singleton ref shared across both toolbars,
+// synced to localStorage so the choice survives reloads. Default on (anything but
+// the explicit "0").
+const STORAGE_KEY = "sound_enabled";
+const enabled = ref(localStorage.getItem(STORAGE_KEY) !== "0");
+watch(enabled, (v) => localStorage.setItem(STORAGE_KEY, v ? "1" : "0"));
+
+export function useSoundEnabled() {
+  return { enabled, toggle: () => (enabled.value = !enabled.value) };
+}


### PR DESCRIPTION
## Summary

ターミナルが**あなたの番になった瞬間に音で通知**し、**セルのヘッダ/枠の色**でも状態が分かるようにします（#46 req6）。

- **音**: セルと同じ「sessions」activity の push を直接購読し、**ターン終了（`working` true→false ＝ Claude の Stop。全セッションで publish）** または **waiting（背景での許可/質問）** の瞬間にチャイム。単一/グリッド両 view・**裏ページの端末でも鳴る**。
- **🔔トグル**（localStorage、デフォルト ON）＋**🔊テストボタン**（即再生＝オーディオ解錠も兼ねる）。
- **色**: セルのヘッダ＋枠を状態で着色 — **working=青／waiting=琥珀（グロー）／idle=無色**。

Closes #85

## Items to Confirm / Review

- **実機確認済み**（localhost:5173, ユーザ確認 — ターン終了で鳴ることを確認）。
- **鳴動条件の変更理由**: 当初「waiting のみ」だったが、サーバ実装上 `waiting` は **foreground（見ている）セッションには立たない**（`Stop` は `working=false` にするだけ／`Notification` も `!foreground` のみ）。foreground でも鳴らすため **`working` の立ち下がり（ターン終了）** を主トリガーにした。`waiting`（背景の許可/質問）も併せて発火。
- **オーディオ解錠**: AudioContext は自動再生ポリシーで suspended。最初の click/keydown で resume するワンショットリスナーを張る（🔊ボタンでも解錠）。
- **音のソース**: `useSessions` の再取得リストではなく pub/sub push を直接購読（色と同一ソース＝色が変われば必ず鳴る）。スナップショット replay 無し・delta のみ。
- 純関数 `needsAttention` を分離してテスト（7 cases）。CLAUDE.md準拠（emit/型ガード、非null/void 不使用）。

## User Prompt

> 音を！あと、header の色などでも状態がわかると良いねぇ
>
> （実機反復: 「色は変わるが分かりづらい」→枠＋グローで強調 / 「ボタンでは鳴るがイベントでは鳴らない」→ pub/sub 直接購読＋ターン終了検出に修正 / 「音のテストボタンを！」→🔊追加 / 「なった！」）

## 実装
- `src/composables/useSoundEnabled.ts`(新): 🔔状態の localStorage 同期 singleton。
- `src/composables/useAttentionSound.ts`(新)+spec: 「sessions」購読、`needsAttention()` 検出、Web Audio チャイム、解錠、`playAttentionSound()` export。
- `App.vue` / `GridView.vue`: 🔔トグル＋🔊テストボタン、`useAttentionSound(soundEnabled)` 配線。
- `TerminalCell.vue`: ヘッダ＋セル枠を status で着色。

詳細は `plans/feat-attention-sound.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
