### PR TITLE
feat: テーマカラー切替（4配色プリセット）

### DIFF
--- a/plans/feat-theme-color.md
+++ b/plans/feat-theme-color.md
@@ -1,0 +1,82 @@
+# feat: テーマカラー（4プリセット配色）
+
+作成日: 2026-06-21
+
+## User Prompt
+
+- 色を変えられるようにしたい。テーマカラー的な。
+- 4パターンくらいの配色が欲しい。それができるか調査を。
+- 配色の方向性: 全く異なる4世界観 / 切替UI: 設定モーダルに追加
+
+## ゴール
+
+アプリ全体の配色を、見た目の世界観ごとに切り替えられる **4テーマ** を用意する。
+選択は localStorage に永続化し、設定モーダルから切り替える。
+
+## 現状調査
+
+- 配色は **63種類の hex 値が15ファイルの `<style scoped>` に直書き**（Tailwind は導入済みだが配色はほぼ手書きCSS）。
+- 意味ごとにきれいにクラスタリングでき、**約18個のセマンティックトークン（CSS変数）** に集約可能。
+- 非CSSの色指定は **xterm（`Terminal.vue` の JS テーマオブジェクト）のみ**。プラグイン iframe（白背景）は意図的にアプリ chrome と分離、Shadow DOM / srcdoc にハードコード色なし。
+- `SettingsModal` は現状 `GridView`（グリッド表示）の⚙からしか開けない。単一表示にも⚙を追加する必要がある。
+
+## トークン設計（セマンティック）
+
+テーマで変わるトークン:
+
+| トークン | 用途 |
+| --- | --- |
+| `--bg-base` | 最下層背景（body / ターミナル / モーダル） |
+| `--bg-panel` | パネル / ツールバー / ヘッダ / サイドバー |
+| `--bg-elevated` | ボタン / 二次サーフェス / タブ |
+| `--bg-input` | 入力フィールド |
+| `--bg-hover` | インタラクティブ要素の hover 背景 |
+| `--border` | 標準ボーダー / 区切り線 |
+| `--accent` | テーマカラー核（focus / active / リンク） |
+| `--accent-bg` | アクセント塗り（primary ボタン / active タブ） |
+| `--accent-bg-hover` | アクセント塗りの hover |
+| `--on-accent` | アクセント面上のテキスト |
+| `--text` | 一次テキスト |
+| `--text-muted` | 二次テキスト |
+| `--text-dim` | 三次 / ヒント |
+| `--term-fg` | xterm 前景 |
+| `--term-selection` | xterm 選択範囲 |
+
+ステータス系（**全テーマ共通で固定** = 意味が色に紐づくため）:
+
+`--success` / `--success-bg` / `--warn` / `--warn-bg` / `--error` / `--error-strong` / `--error-bg`
+
+## 4テーマ
+
+暗→明・寒色→暖色で明確に差をつける（ユーザー要望: 明るい背景の配色が欲しい / 変化が小さい）。
+
+1. **Midnight**（デフォルト・現状維持）— 紺/藍のダーク。accent 青。
+2. **Nord** — クールなスレート（中間の暗さ）+ フロストシアン。
+3. **Daylight** — 明るい寒色。白パネル + 淡グレー背景 + 鮮やかな青。
+4. **Solarized Light** — 明るい暖色。クリーム背景 + Solarized ブルー。
+
+### 明テーマ対応（落とし穴と対策）
+
+- **ステータス色をテーマ連動化**: 暗テーマは「暗背景ピル + 明テキスト」、明テーマは「淡色ピル + 濃テキスト」。`:root` に暗版を定義し、`[data-theme="daylight"], [data-theme="solarized"]` で淡色版を上書き。
+- **hover/選択時テキスト**: 一括置換で `#fff`→`--on-accent` にした箇所のうち、背景が `--accent-bg` でない（hover/選択/waiting）9箇所を `--text` に修正（明背景で白文字が消えるため）。`--on-accent` は `--accent-bg` 上の3箇所のみ。
+- **xterm の ANSI 16色**: 明テーマは light 端末向けパレットを指定（bright-white を濃色にマップ）し、色付きTUI出力が明背景で潰れないようにする。
+
+## 実装ステップ
+
+1. `src/composables/useTheme.ts` を新規作成
+   - 4テーマ定義（id, label, スウォッチ色, xterm テーマ）
+   - module-level の reactive `themeId`、localStorage 永続化、`document.documentElement` への `data-theme` 適用
+   - `themes` / `themeId` / `setTheme` / `xtermTheme()` を公開
+2. `src/style.css` に `:root` のセマンティック変数（Midnight）+ `:root[data-theme="..."]` 上書き + 固定ステータストークンを定義
+3. 15ファイルの直書き hex を `var(--token)` に置換（Midnight が現状と視覚的に一致するようマッピング）
+4. `Terminal.vue` を xterm テーマと連動（`themeId` を watch して `term.options.theme` をライブ更新）
+5. `SettingsModal.vue` に「Theme」セクション（4スウォッチ選択）を追加。`useTheme` で自己完結（新規 props 無し）。`presets` を任意化。
+6. 到達性: `App.vue` 単一表示ツールバーに⚙を追加。config ロード/保存を `useAppConfig` composable に切り出し、`App.vue` と `GridView.vue` で共有（DRY）。
+7. `main.ts` で `useTheme` を早期初期化（マウント前に `data-theme` 適用しフラッシュ回避）。
+
+## 確認ポイント（レビュー観点）
+
+- Midnight テーマが既存の見た目と差異ないか。
+- xterm のテーマ切替がライブで反映されるか（開いている端末も即時）。
+- 単一表示 / グリッド表示の両方からテーマ変更できるか。
+- ステータス色（接続状態・エラー）が全テーマで判読できるか。

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,11 +7,14 @@ import GuiPanel from "./components/GuiPanel.vue";
 import ToolsPane from "./components/ToolsPane.vue";
 import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
 import GridView from "./components/GridView.vue";
+import SettingsModal from "./components/SettingsModal.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
 import { useShortcuts } from "./composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
 import { registerChatOpener } from "./composables/useChatLauncher";
+import { useAppConfig } from "./composables/useAppConfig";
 import type { Shortcut } from "./types/shortcuts";
+import type { CwdPreset } from "./components/presets";
 
 // View mode: the classic single-terminal view (default) or the multi-terminal
 // grid. Persisted so a reload keeps the chosen view.
@@ -104,6 +107,19 @@ function onViewportResize() {
   terminalWidth.value = clampWidth(terminalWidth.value);
 }
 onMounted(() => window.addEventListener("resize", onViewportResize));
+
+// Settings (directory presets + theme), shared with the grid view via useAppConfig
+// and opened from the toolbar's gear button.
+const { presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets } = useAppConfig();
+const showSettings = ref(false);
+onMounted(loadConfig);
+async function savePresets(next: CwdPreset[]) {
+  if (await persistPresets(next)) showSettings.value = false;
+}
+function closeSettings() {
+  showSettings.value = false;
+  settingsError.value = null;
+}
 onUnmounted(() => {
   stopDrag?.();
   window.removeEventListener("resize", onViewportResize);
@@ -196,6 +212,9 @@ function onSession(id: string) {
           <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
         </button>
       </nav>
+      <button type="button" class="launcher-btn settings-btn" title="Settings" aria-label="Settings" @click="showSettings = true">
+        <span class="material-symbols-outlined">settings</span>
+      </button>
     </header>
     <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
       <Sidebar
@@ -249,6 +268,7 @@ function onSession(id: string) {
     <!-- Full-screen collection browser; shown when the launcher / an index card / a
          ref hop opens it (driven by useCollectionBrowse). -->
     <CollectionsBrowseOverlay />
+    <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
   </div>
 </template>
 
@@ -268,14 +288,14 @@ function onSession(id: string) {
   align-items: center;
   height: 40px;
   padding: 0 16px;
-  background: #16213e;
-  border-bottom: 1px solid #2a2a4e;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
 }
 .toolbar-title {
   font-family: system-ui, sans-serif;
   font-weight: 600;
   font-size: 14px;
-  color: #e6e6f0;
+  color: var(--text);
   letter-spacing: 0.02em;
 }
 
@@ -298,21 +318,25 @@ function onSession(id: string) {
   padding: 0;
   border: none;
   background: transparent;
-  color: #9aa6cc;
+  color: var(--text-muted);
   border-radius: 6px;
   cursor: pointer;
 }
 .launcher-btn:hover {
-  background: #26375f;
-  color: #fff;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 .launcher-btn.active {
-  background: #2f59c0;
-  color: #fff;
+  background: var(--accent-bg);
+  color: var(--on-accent);
 }
 .launcher-btn .material-symbols-outlined {
   font-size: 19px;
   line-height: 1;
+}
+/* Pin the gear to the far right of the toolbar. */
+.settings-btn {
+  margin-left: auto;
 }
 
 .app {
@@ -354,15 +378,15 @@ function onSession(id: string) {
 .splitter {
   flex: 0 0 5px;
   cursor: col-resize;
-  background: #16213e;
-  border-left: 1px solid #2a2a4e;
-  border-right: 1px solid #2a2a4e;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
 }
 .splitter:hover {
-  background: #2a3b66;
+  background: var(--bg-hover);
 }
 .splitter:focus-visible {
   outline: none;
-  background: #4a8cff;
+  background: var(--accent);
 }
 </style>

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -69,6 +69,6 @@ onMounted(() => window.addEventListener("keydown", onKeydown));
   right: 0;
   bottom: 0;
   z-index: 50;
-  background: #0b1020;
+  background: var(--bg-deep);
 }
 </style>

--- a/src/components/FilterChip.vue
+++ b/src/components/FilterChip.vue
@@ -23,9 +23,9 @@ defineEmits<{ (e: "click"): void }>();
   font-size: 11px;
   line-height: 16px;
   border-radius: 9999px;
-  border: 1px solid #2a2a4e;
-  background: #1b2647;
-  color: #9aa5c4;
+  border: 1px solid var(--border);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
   cursor: pointer;
   transition:
     background 0.12s,
@@ -33,12 +33,12 @@ defineEmits<{ (e: "click"): void }>();
     border-color 0.12s;
 }
 .chip:hover {
-  background: #224a86;
-  color: #cfe0ff;
+  background: var(--bg-selected-hover);
+  color: var(--text-secondary);
 }
 .chip.active {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #ffffff;
+  background: var(--accent-bg);
+  border-color: var(--accent-bg);
+  color: var(--on-accent);
 }
 </style>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -4,6 +4,7 @@ import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
 import { LAYOUTS, isLayout, type Layout } from "./gridLayout";
 import type { CwdPreset } from "./presets";
+import { useAppConfig } from "../composables/useAppConfig";
 
 // The multi-terminal grid view. Toggled with the classic single view from App.vue.
 const emit = defineEmits<{ (e: "exit"): void }>();
@@ -14,44 +15,12 @@ const layout = ref<Layout>(isLayout(stored) ? stored : "2x2");
 watch(layout, (v) => localStorage.setItem("grid_layout", v));
 
 // Server config: the default workspace dir + the user's directory presets.
-const defaultCwd = ref<string | null>(null);
-const home = ref<string | null>(null);
-const presets = ref<CwdPreset[]>([]);
+const { defaultCwd, home, presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets } = useAppConfig();
 const showSettings = ref(false);
-const savingSettings = ref(false);
-const settingsError = ref<string | null>(null);
-
-async function loadConfig() {
-  try {
-    const res = await fetch("/api/config");
-    if (!res.ok) return;
-    const c = await res.json();
-    defaultCwd.value = c.cwd ?? null;
-    home.value = c.home ?? null;
-    presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
-  } catch {
-    // grid still works; presets just unavailable
-  }
-}
 onMounted(loadConfig);
 
 async function savePresets(next: CwdPreset[]) {
-  savingSettings.value = true;
-  settingsError.value = null;
-  try {
-    const res = await fetch("/api/config", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwdPresets: next }),
-    });
-    if (!res.ok) throw new Error(`save failed (${res.status})`);
-    presets.value = (await res.json()).cwdPresets ?? [];
-    showSettings.value = false; // close only on success — keep edits otherwise
-  } catch {
-    settingsError.value = "Couldn't save presets. Check the server and try again.";
-  } finally {
-    savingSettings.value = false;
-  }
+  if (await persistPresets(next)) showSettings.value = false; // close only on success — keep edits otherwise
 }
 
 function closeSettings() {
@@ -93,14 +62,14 @@ function closeSettings() {
   gap: 16px;
   height: 40px;
   padding: 0 16px;
-  background: #16213e;
-  border-bottom: 1px solid #2a2a4e;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
 }
 .toolbar-title {
   font-family: system-ui, sans-serif;
   font-weight: 600;
   font-size: 14px;
-  color: #e6e6f0;
+  color: var(--text);
   letter-spacing: 0.02em;
 }
 
@@ -110,9 +79,9 @@ function closeSettings() {
   gap: 4px;
 }
 .layout-btn {
-  border: 1px solid #2a2a4e;
-  background: #1a1a2e;
-  color: #9aa3c0;
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-muted);
   font-family: ui-monospace, monospace;
   font-size: 12px;
   padding: 3px 8px;
@@ -120,19 +89,19 @@ function closeSettings() {
   cursor: pointer;
 }
 .layout-btn:hover {
-  background: #2a3b66;
-  color: #e6e6f0;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 .layout-btn.active {
-  background: #2a3b66;
-  color: #fff;
-  border-color: #4a8cff;
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--accent);
 }
 
 .tb-btn {
-  border: 1px solid #2a2a4e;
-  background: #1a1a2e;
-  color: #c7cdf0;
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-secondary);
   font-family: system-ui, sans-serif;
   font-size: 12px;
   line-height: 1;
@@ -141,8 +110,8 @@ function closeSettings() {
   cursor: pointer;
 }
 .tb-btn:hover {
-  background: #2a3b66;
-  color: #fff;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 
 .main {

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -141,14 +141,14 @@ const hasContent = computed(() => results.value.length > 0);
   flex: 1;
   min-width: 0;
   height: 100%;
-  background: #11162a;
-  border-left: 1px solid #2a2a4e;
+  background: var(--bg-deep);
+  border-left: 1px solid var(--border);
 }
 
 .header {
   padding: 8px 16px;
-  background: #16213e;
-  color: #e0e0e0;
+  background: var(--bg-panel);
+  color: var(--text);
   font-family: system-ui, sans-serif;
   font-size: 14px;
   display: flex;
@@ -161,7 +161,7 @@ const hasContent = computed(() => results.value.length > 0);
 .gear {
   background: none;
   border: none;
-  color: #7c87a8;
+  color: var(--text-dim);
   font-size: 15px;
   line-height: 1;
   padding: 2px 4px;
@@ -169,25 +169,25 @@ const hasContent = computed(() => results.value.length > 0);
   border-radius: 4px;
 }
 .gear:hover {
-  color: #e0e0e0;
+  color: var(--text);
 }
 
 .content {
   flex: 1;
   overflow-y: auto;
   padding: 12px 16px;
-  color: #e0e0e0;
+  color: var(--text);
   font-family: system-ui, sans-serif;
   font-size: 14px;
   line-height: 1.5;
 }
 
 .empty {
-  color: #7c87a8;
+  color: var(--text-dim);
   font-size: 13px;
 }
 .empty code {
-  background: #1d2b4e;
+  background: var(--bg-subtle);
   padding: 1px 5px;
   border-radius: 4px;
 }
@@ -195,6 +195,6 @@ const hasContent = computed(() => results.value.length > 0);
 .frame + .frame {
   margin-top: 16px;
   padding-top: 16px;
-  border-top: 1px solid #2a2a4e;
+  border-top: 1px solid var(--border);
 }
 </style>

--- a/src/components/PinToggle.vue
+++ b/src/components/PinToggle.vue
@@ -46,7 +46,7 @@ function toggle(): void {
       border: 'none',
       background: 'transparent',
       cursor: 'pointer',
-      color: pinned ? '#f59e0b' : '#94a3b8',
+      color: pinned ? 'var(--amber, #f59e0b)' : 'var(--text-dim, #94a3b8)',
     }"
     @click.stop="toggle"
     @keydown.enter.stop

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -76,10 +76,10 @@ const visibleSessions = computed(() => {
   height: 40px;
   flex-shrink: 0;
   padding: 0 10px;
-  background: #16213e;
-  color: #e0e0e0;
+  background: var(--bg-panel);
+  color: var(--text);
   font-family: system-ui, sans-serif;
-  border-bottom: 1px solid #2a2a4e;
+  border-bottom: 1px solid var(--border);
   overflow: hidden;
 }
 
@@ -87,8 +87,8 @@ const visibleSessions = computed(() => {
   flex-shrink: 0;
   width: 26px;
   height: 26px;
-  background: #1b3a6b;
-  color: #cfe0ff;
+  background: var(--bg-selected);
+  color: var(--text-secondary);
   border: none;
   border-radius: 6px;
   font-size: 16px;
@@ -96,7 +96,7 @@ const visibleSessions = computed(() => {
   cursor: pointer;
 }
 .new-btn:hover {
-  background: #224a86;
+  background: var(--bg-selected-hover);
 }
 
 .filters {
@@ -131,17 +131,17 @@ const visibleSessions = computed(() => {
   background: transparent;
   border: 1px solid transparent;
   border-radius: 6px;
-  color: #cdd5ee;
+  color: var(--text-secondary);
   font-size: 12px;
   cursor: pointer;
   transition: background 0.12s;
 }
 .tab:hover {
-  background: #1d2b4e;
+  background: var(--bg-subtle);
 }
 .tab.active {
-  background: #1d2b4e;
-  border-color: #4a8cff;
+  background: var(--bg-subtle);
+  border-color: var(--accent);
 }
 
 .tab-title {
@@ -153,7 +153,7 @@ const visibleSessions = computed(() => {
 /* Background session waiting for input (unread): bold, like the sidebar. */
 .tab.waiting .tab-title {
   font-weight: 700;
-  color: #ffffff;
+  color: var(--text);
 }
 
 .unread-dot {
@@ -161,8 +161,8 @@ const visibleSessions = computed(() => {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #ef4444;
-  box-shadow: 0 0 0 2px #16213e;
+  background: var(--err-strong);
+  box-shadow: 0 0 0 2px var(--bg-panel);
 }
 
 /* Spinning "thinking" ring — mirrors the vertical sidebar's spinner. */
@@ -170,8 +170,8 @@ const visibleSessions = computed(() => {
   flex-shrink: 0;
   width: 10px;
   height: 10px;
-  border: 2px solid rgba(74, 140, 255, 0.3);
-  border-top-color: #4a8cff;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
   border-radius: 50%;
   animation: tabbar-spin 0.9s linear infinite;
 }
@@ -192,12 +192,12 @@ const visibleSessions = computed(() => {
 .icon-btn {
   background: none;
   border: none;
-  color: #9aa5c4;
+  color: var(--text-muted);
   font-size: 16px;
   cursor: pointer;
   line-height: 1;
 }
 .icon-btn:hover {
-  color: #e0e0e0;
+  color: var(--text);
 }
 </style>

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -89,4 +89,23 @@ describe("SettingsModal", () => {
     await clickBtn(w, (t) => t.includes("Add"));
     expect(presets).toHaveLength(1); // edits are on a local copy
   });
+
+  it("theme picker honors the radiogroup keyboard contract (arrows + roving tabindex)", async () => {
+    const w = mountModal();
+    const cards = () => w.findAll(".theme-card");
+    const n = cards().length;
+    expect(n).toBeGreaterThanOrEqual(2);
+    const checked = () => cards().findIndex((c) => c.attributes("aria-checked") === "true");
+
+    const start = checked();
+    // roving tabindex: only the checked radio is tabbable
+    expect(cards()[start].attributes("tabindex")).toBe("0");
+    expect(cards()[(start + 1) % n].attributes("tabindex")).toBe("-1");
+
+    await cards()[start].trigger("keydown", { key: "ArrowRight" });
+    expect(checked()).toBe((start + 1) % n); // advances, wrapping at the end
+
+    await cards()[checked()].trigger("keydown", { key: "ArrowLeft" });
+    expect(checked()).toBe(start); // back to where we started
+  });
 });

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
 import type { CwdPreset } from "./presets";
+import { useTheme } from "../composables/useTheme";
 
 const props = defineProps<{ presets: CwdPreset[]; saving?: boolean; error?: string | null }>();
 const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "close"): void }>();
+
+// Theme is applied immediately on click (independent of the Save button, which
+// only commits the directory presets).
+const { themeId, themes, setTheme } = useTheme();
 
 // Edit a local copy; commit on Save.
 const rows = ref<CwdPreset[]>(props.presets.map((p) => ({ ...p })));
@@ -66,9 +71,32 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
   <div class="overlay" @click.self="emit('close')">
     <div ref="modalEl" class="modal" role="dialog" aria-modal="true" aria-label="Settings">
       <div class="modal-head">
-        <h2 class="modal-title">Directory presets</h2>
+        <h2 class="modal-title">Settings</h2>
         <button class="icon-btn" title="Close" aria-label="Close settings" @click="emit('close')">✕</button>
       </div>
+
+      <h3 class="section-title">Theme</h3>
+      <div class="themes" role="radiogroup" aria-label="Theme">
+        <button
+          v-for="t in themes"
+          :key="t.id"
+          type="button"
+          class="theme-card"
+          :class="{ active: themeId === t.id }"
+          role="radio"
+          :aria-checked="themeId === t.id"
+          :title="t.label"
+          @click="setTheme(t.id)"
+        >
+          <span class="swatch" :style="{ background: t.swatch.base }">
+            <span class="swatch-dot" :style="{ background: t.swatch.panel }" />
+            <span class="swatch-dot" :style="{ background: t.swatch.accent }" />
+          </span>
+          <span class="theme-label">{{ t.label }}</span>
+        </button>
+      </div>
+
+      <h3 class="section-title">Directory presets</h3>
       <p class="hint">Quick-pick directories offered when launching a terminal.</p>
 
       <div class="rows">
@@ -123,11 +151,11 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  background: #1a1a2e;
-  border: 1px solid #2a2a4e;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
   border-radius: 10px;
   padding: 16px;
-  color: #e6e6f0;
+  color: var(--text);
   font-family: system-ui, sans-serif;
 }
 .modal-head {
@@ -140,10 +168,68 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
   font-size: 15px;
   font-weight: 600;
 }
+.section-title {
+  margin: 14px 0 8px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.themes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.theme-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 84px;
+  padding: 8px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.theme-card:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.theme-card.active {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.swatch {
+  position: relative;
+  width: 100%;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.swatch-dot {
+  position: absolute;
+  bottom: 6px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+.swatch-dot:nth-child(1) {
+  left: 8px;
+}
+.swatch-dot:nth-child(2) {
+  left: 24px;
+}
+.theme-label {
+  font-size: 12px;
+}
 .hint {
   margin: 6px 0 12px;
   font-size: 12px;
-  color: #8b93b8;
+  color: var(--text-dim);
 }
 .rows {
   overflow-y: auto;
@@ -159,15 +245,15 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 .field {
   box-sizing: border-box;
   padding: 7px 10px;
-  background: #11111f;
-  border: 1px solid #2a2a4e;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: #e6e6f0;
+  color: var(--text);
   font-size: 12px;
 }
 .field:focus {
   outline: none;
-  border-color: #4a8cff;
+  border-color: var(--accent);
 }
 .label-field {
   flex: 0 0 30%;
@@ -178,12 +264,12 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 }
 .empty {
   font-size: 12px;
-  color: #6b7394;
+  color: var(--text-dim);
 }
 .error {
   margin: 12px 0 0;
   font-size: 12px;
-  color: #ff8080;
+  color: var(--err-text);
 }
 .modal-foot {
   display: flex;
@@ -201,35 +287,35 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 .icon-btn {
   border: none;
   background: transparent;
-  color: #9aa3c0;
+  color: var(--text-muted);
   cursor: pointer;
   font-size: 14px;
   padding: 4px 6px;
   border-radius: 6px;
 }
 .icon-btn:hover {
-  background: #3a2030;
-  color: #ff6b6b;
+  background: var(--err-hover-bg);
+  color: var(--err-text);
 }
 .btn {
-  border: 1px solid #2a2a4e;
-  background: #20203a;
-  color: #c7cdf0;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 13px;
   padding: 6px 14px;
   border-radius: 6px;
 }
 .btn:hover {
-  background: #2a3b66;
-  color: #fff;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 .btn-primary {
-  background: #2f5bd0;
-  border-color: #4a8cff;
-  color: #fff;
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--on-accent);
 }
 .btn-primary:hover {
-  background: #3a6be0;
+  background: var(--accent-bg-hover);
 }
 </style>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -9,6 +9,20 @@ const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "close")
 // Theme is applied immediately on click (independent of the Save button, which
 // only commits the directory presets).
 const { themeId, themes, setTheme } = useTheme();
+const themesEl = ref<HTMLElement>();
+
+// ARIA radiogroup keyboard contract: arrows move selection (and focus) within
+// the group, wrapping at the ends; only the checked radio is tabbable (roving
+// tabindex), so Tab enters/leaves the group as one stop.
+function onThemeKey(e: KeyboardEvent, index: number) {
+  const forward = e.key === "ArrowRight" || e.key === "ArrowDown";
+  const backward = e.key === "ArrowLeft" || e.key === "ArrowUp";
+  if (!forward && !backward) return;
+  e.preventDefault();
+  const next = (index + (forward ? 1 : themes.length - 1)) % themes.length;
+  setTheme(themes[next].id);
+  themesEl.value?.querySelectorAll<HTMLElement>(".theme-card")[next]?.focus();
+}
 
 // Edit a local copy; commit on Save.
 const rows = ref<CwdPreset[]>(props.presets.map((p) => ({ ...p })));
@@ -76,17 +90,19 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
       </div>
 
       <h3 class="section-title">Theme</h3>
-      <div class="themes" role="radiogroup" aria-label="Theme">
+      <div ref="themesEl" class="themes" role="radiogroup" aria-label="Theme">
         <button
-          v-for="t in themes"
+          v-for="(t, i) in themes"
           :key="t.id"
           type="button"
           class="theme-card"
           :class="{ active: themeId === t.id }"
           role="radio"
           :aria-checked="themeId === t.id"
+          :tabindex="themeId === t.id ? 0 : -1"
           :title="t.label"
           @click="setTheme(t.id)"
+          @keydown="onThemeKey($event, i)"
         >
           <span class="swatch" :style="{ background: t.swatch.base }">
             <span class="swatch-dot" :style="{ background: t.swatch.panel }" />

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -86,10 +86,10 @@ function relativeTime(ms: number): string {
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  background: #16213e;
-  color: #e0e0e0;
+  background: var(--bg-panel);
+  color: var(--text);
   font-family: system-ui, sans-serif;
-  border-right: 1px solid #2a2a4e;
+  border-right: 1px solid var(--border);
   overflow: hidden;
 }
 
@@ -104,19 +104,19 @@ function relativeTime(ms: number): string {
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.05em;
-  color: #9aa5c4;
+  color: var(--text-muted);
 }
 
 .icon-btn {
   background: none;
   border: none;
-  color: #9aa5c4;
+  color: var(--text-muted);
   font-size: 16px;
   cursor: pointer;
   line-height: 1;
 }
 .icon-btn:hover {
-  color: #e0e0e0;
+  color: var(--text);
 }
 
 .new-btn {
@@ -126,8 +126,8 @@ function relativeTime(ms: number): string {
   gap: 6px;
   margin: 0 12px 8px;
   padding: 8px;
-  background: #1b3a6b;
-  color: #cfe0ff;
+  background: var(--bg-selected);
+  color: var(--text-secondary);
   border: none;
   border-radius: 6px;
   font-size: 13px;
@@ -137,7 +137,7 @@ function relativeTime(ms: number): string {
   font-size: 18px;
 }
 .new-btn:hover {
-  background: #224a86;
+  background: var(--bg-selected-hover);
 }
 
 .filters {
@@ -156,10 +156,10 @@ function relativeTime(ms: number): string {
 .state {
   padding: 12px 14px;
   font-size: 13px;
-  color: #9aa5c4;
+  color: var(--text-muted);
 }
 .state.error {
-  color: #ef9a9a;
+  color: var(--err);
 }
 
 .list {
@@ -179,11 +179,11 @@ function relativeTime(ms: number): string {
   gap: 2px;
 }
 .item:hover {
-  background: #1d2b4e;
+  background: var(--bg-subtle);
 }
 .item.active {
-  background: #1d2b4e;
-  border-left-color: #4a8cff;
+  background: var(--bg-subtle);
+  border-left-color: var(--accent);
 }
 
 .item-title {
@@ -196,7 +196,7 @@ function relativeTime(ms: number): string {
 /* Background session waiting for input (Notification); cleared on foreground. */
 .item.waiting .item-title {
   font-weight: 700;
-  color: #ffffff;
+  color: var(--text);
 }
 
 /* Shown while Claude is working/"thinking" in a session (UserPromptSubmit →
@@ -206,8 +206,8 @@ function relativeTime(ms: number): string {
   width: 10px;
   height: 10px;
   margin-right: 5px;
-  border: 2px solid rgba(74, 140, 255, 0.3);
-  border-top-color: #4a8cff;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
   border-radius: 50%;
   vertical-align: middle;
   animation: sidebar-spin 0.9s linear infinite;
@@ -221,6 +221,6 @@ function relativeTime(ms: number): string {
 
 .item-time {
   font-size: 11px;
-  color: #7c87a8;
+  color: var(--text-dim);
 }
 </style>

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -6,6 +6,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl } from "./wsUrl";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
+import { useTheme, currentTermTheme } from "../composables/useTheme";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
@@ -20,6 +21,7 @@ const emit = defineEmits<{ (e: "session" | "cwd", value: string): void }>();
 const terminalRef = ref<HTMLDivElement>();
 const status = ref<"connecting" | "connected" | "disconnected">("connecting");
 const dragOver = ref(false);
+const { themeId } = useTheme();
 
 let term: Terminal;
 let fitAddon: FitAddon;
@@ -138,12 +140,7 @@ onMounted(() => {
     cursorBlink: true,
     fontSize: 14,
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
-    theme: {
-      background: "#1a1a2e",
-      foreground: "#e0e0e0",
-      cursor: "#e0e0e0",
-      selectionBackground: "#3a3a5e",
-    },
+    theme: currentTermTheme(),
   });
 
   fitAddon = new FitAddon();
@@ -190,6 +187,12 @@ watch(
     term.focus();
   },
 );
+
+// xterm can't read CSS variables, so repaint its canvas palette when the theme
+// changes (keeps an already-open terminal in sync with the rest of the app).
+watch(themeId, () => {
+  if (term) term.options.theme = currentTermTheme();
+});
 
 // Submit a GUI-originated message into the PTY (same channel as keyboard input).
 // This is the GUI->LLM feedback path. We type the text, then send a SEPARATE
@@ -296,13 +299,13 @@ onUnmounted(() => {
   min-width: 0;
   min-height: 0;
   height: 100%;
-  background: #1a1a2e;
+  background: var(--bg-base);
 }
 
 .header {
   padding: 8px 16px;
-  background: #16213e;
-  color: #e0e0e0;
+  background: var(--bg-panel);
+  color: var(--text);
   font-family: system-ui, sans-serif;
   font-size: 14px;
   display: flex;
@@ -322,13 +325,13 @@ onUnmounted(() => {
   background: transparent;
   border: none;
   border-radius: 4px;
-  color: #9aa7d0;
+  color: var(--text-muted);
   cursor: pointer;
 }
 
 .pick-file:hover {
-  background: #25325a;
-  color: #e0e0e0;
+  background: var(--bg-selected);
+  color: var(--text);
 }
 
 .pick-file .material-symbols-outlined {
@@ -342,18 +345,18 @@ onUnmounted(() => {
 }
 
 .status.connected {
-  background: #1b5e20;
-  color: #a5d6a7;
+  background: var(--ok-bg);
+  color: var(--ok);
 }
 
 .status.connecting {
-  background: #e65100;
-  color: #ffcc80;
+  background: var(--warn-bg);
+  color: var(--warn);
 }
 
 .status.disconnected {
-  background: #b71c1c;
-  color: #ef9a9a;
+  background: var(--err-deep);
+  color: var(--err);
 }
 
 /* min-height:0 is load-bearing: a flex item's default min-height is `auto`
@@ -369,7 +372,7 @@ onUnmounted(() => {
 }
 
 .terminal-container.drag-over {
-  outline: 2px dashed #7e8ce0;
+  outline: 2px dashed var(--accent);
   outline-offset: -2px;
 }
 </style>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -294,8 +294,8 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  background: #1a1a2e;
-  border: 1px solid #2a2a4e;
+  background: var(--bg-base);
+  border: 1px solid var(--border);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -307,8 +307,8 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   gap: 8px;
   height: 34px;
   padding: 0 8px;
-  background: #16213e;
-  border-bottom: 1px solid #2a2a4e;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
 }
 
 /* Status dot: idle / working (pulsing) / waiting (attention). */
@@ -317,14 +317,14 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  background: #4a5070;
+  background: var(--text-dim);
 }
 .cell-dot.is-working {
-  background: #4a8cff;
+  background: var(--accent);
   animation: pulse 1.2s ease-in-out infinite;
 }
 .cell-dot.is-waiting {
-  background: #ffb454;
+  background: var(--amber);
 }
 @keyframes pulse {
   0%,
@@ -346,13 +346,13 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   cursor: pointer;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 11px;
-  color: #7f88ad;
+  color: var(--text-dim);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .cell-dir:hover {
-  color: #aeb6dd;
+  color: var(--text-muted);
   text-decoration: underline;
 }
 .cell-prompt {
@@ -360,7 +360,7 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   min-width: 0;
   font-family: system-ui, sans-serif;
   font-size: 12px;
-  color: #c7cdf0;
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -379,19 +379,19 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   height: 26px;
   border: none;
   background: transparent;
-  color: #c7cdf0;
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 16px;
   line-height: 1;
   border-radius: 6px;
 }
 .cell-btn:hover {
-  background: #2a3b66;
-  color: #e6e6f0;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 .cell-close:hover {
-  background: #3a2030;
-  color: #ff6b6b;
+  background: var(--err-hover-bg);
+  color: var(--err-text);
 }
 
 .cell-term {
@@ -422,9 +422,9 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   max-width: 360px;
 }
 .cell-preset {
-  border: 1px solid #2a2a4e;
-  background: #20203a;
-  color: #c7cdf0;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
   cursor: pointer;
   font-family: system-ui, sans-serif;
   font-size: 12px;
@@ -432,13 +432,13 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   border-radius: 14px;
 }
 .cell-preset:hover {
-  background: #2a3b66;
-  color: #fff;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 .cell-preset.active {
-  background: #2a3b66;
-  color: #fff;
-  border-color: #4a8cff;
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--accent);
 }
 .cell-launch-label {
   display: flex;
@@ -451,7 +451,7 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 .cell-launch-caption {
   font-family: system-ui, sans-serif;
   font-size: 11px;
-  color: #6b7394;
+  color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -459,21 +459,21 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   width: 100%;
   box-sizing: border-box;
   padding: 7px 10px;
-  background: #11111f;
-  border: 1px solid #2a2a4e;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: #e6e6f0;
+  color: var(--text);
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 12px;
 }
 .cell-dir-input:focus {
   outline: none;
-  border-color: #4a8cff;
+  border-color: var(--accent);
 }
 .cell-start {
-  border: 1px solid #2a2a4e;
-  background: #20203a;
-  color: #c7cdf0;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
   cursor: pointer;
   font-family: system-ui, sans-serif;
   font-size: 14px;
@@ -482,8 +482,8 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   border-radius: 6px;
 }
 .cell-start:hover {
-  background: #2a3b66;
-  color: #fff;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 
 .cell-resume {
@@ -506,9 +506,9 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   align-items: baseline;
   justify-content: space-between;
   gap: 8px;
-  border: 1px solid #2a2a4e;
-  background: #14142a;
-  color: #c7cdf0;
+  border: 1px solid var(--border);
+  background: var(--bg-deep);
+  color: var(--text-secondary);
   cursor: pointer;
   font-family: system-ui, sans-serif;
   font-size: 12px;
@@ -517,8 +517,8 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   border-radius: 6px;
 }
 .cell-resume-item:hover {
-  background: #20203a;
-  border-color: #4a8cff;
+  background: var(--bg-elevated);
+  border-color: var(--accent);
 }
 .ri-title {
   overflow: hidden;
@@ -527,7 +527,7 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 }
 .ri-time {
   flex: 0 0 auto;
-  color: #6b7394;
+  color: var(--text-dim);
   font-size: 11px;
 }
 </style>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -173,7 +173,7 @@ const stripOrder = (slot: Slot) => (zoomed.value && slot.uid !== expandedUid.val
   flex-direction: column;
   min-height: 0;
   min-width: 0;
-  background: #0f0f1e;
+  background: var(--bg-deep);
 }
 
 .grid {

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -218,14 +218,14 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   width: 340px;
   flex-shrink: 0;
   height: 100%;
-  background: #0d1124;
-  border-left: 1px solid #2a2a4e;
+  background: var(--bg-deep);
+  border-left: 1px solid var(--border);
 }
 
 .header {
   padding: 8px 16px;
-  background: #16213e;
-  color: #e0e0e0;
+  background: var(--bg-panel);
+  color: var(--text);
   font-family: system-ui, sans-serif;
   font-size: 14px;
   display: flex;
@@ -238,7 +238,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
 .close-btn {
   background: none;
   border: none;
-  color: #7c87a8;
+  color: var(--text-dim);
   font-size: 15px;
   line-height: 1;
   padding: 2px 4px;
@@ -246,19 +246,19 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   border-radius: 4px;
 }
 .close-btn:hover {
-  color: #e0e0e0;
+  color: var(--text);
 }
 
 .content {
   flex: 1;
   overflow-y: auto;
-  color: #e0e0e0;
+  color: var(--text);
   font-family: system-ui, sans-serif;
   font-size: 13px;
 }
 
 .section {
-  border-bottom: 1px solid #2a2a4e;
+  border-bottom: 1px solid var(--border);
   padding: 10px 12px;
 }
 .section-title {
@@ -266,7 +266,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #7c87a8;
+  color: var(--text-dim);
   margin-bottom: 8px;
 }
 .section-title--with-action {
@@ -283,9 +283,9 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   font-weight: 600;
   text-transform: none;
   letter-spacing: 0.02em;
-  color: #9aa5c4;
-  background: #1d2b4e;
-  border: 1px solid #2a2a4e;
+  color: var(--text-muted);
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 2px 8px;
   cursor: pointer;
@@ -297,8 +297,8 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
     background 0.15s;
 }
 .copy-history:hover:not(:disabled) {
-  color: #cfe0ff;
-  background: #243763;
+  color: var(--text-secondary);
+  background: var(--bg-selected-hover);
 }
 .copy-history:disabled {
   opacity: 0.4;
@@ -306,7 +306,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
 }
 
 .muted {
-  color: #7c87a8;
+  color: var(--text-dim);
   font-size: 12px;
 }
 .italic {
@@ -333,8 +333,8 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
 }
 .tool-name,
 .call-name {
-  background: #1d2b4e;
-  color: #cfe0ff;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
   padding: 2px 6px;
   border-radius: 4px;
   font-family: "JetBrains Mono", monospace;
@@ -342,11 +342,11 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   word-break: break-all;
 }
 .caret {
-  color: #7c87a8;
+  color: var(--text-dim);
   font-size: 18px;
 }
 .tool-desc {
-  color: #9aa5c4;
+  color: var(--text-muted);
   font-size: 12px;
   margin: 2px 0 6px;
   white-space: pre-wrap;
@@ -354,11 +354,11 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
 
 /* Tool call history */
 .call {
-  border: 1px solid #2a2a4e;
+  border: 1px solid var(--border);
   border-radius: 6px;
   padding: 6px 8px;
   margin-top: 6px;
-  background: #11162a;
+  background: var(--bg-deep);
 }
 .call-meta {
   display: flex;
@@ -372,19 +372,19 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   border-radius: 999px;
 }
 .badge.running {
-  background: #4a3a10;
-  color: #ffcc80;
+  background: var(--warn-bg-subtle);
+  color: var(--warn);
 }
 .badge.done {
-  background: #14361c;
-  color: #a5d6a7;
+  background: var(--ok-bg-subtle);
+  color: var(--ok);
 }
 .badge.failed {
-  background: #4a1414;
-  color: #ef9a9a;
+  background: var(--err-bg);
+  color: var(--err);
 }
 .time {
-  color: #6b769a;
+  color: var(--text-dim);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
 }
@@ -395,12 +395,12 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #7c87a8;
+  color: var(--text-dim);
   margin: 6px 0 2px;
 }
 .block {
-  background: #0a0e1f;
-  border: 1px solid #20284a;
+  background: var(--bg-deep);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 6px 8px;
   margin: 0;
@@ -412,10 +412,10 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   word-break: break-word;
 }
 .block.result {
-  border-color: #1c3a24;
+  border-color: var(--ok-border);
 }
 .block.error {
-  border-color: #4a1414;
-  color: #ef9a9a;
+  border-color: var(--err-bg);
+  color: var(--err);
 }
 </style>

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -1,0 +1,50 @@
+import { ref } from "vue";
+import type { CwdPreset } from "../components/presets";
+
+// Server config (default workspace dir, home, directory presets) shared by both
+// the single view and the grid view so each can open the settings modal without
+// duplicating the fetch/save logic.
+export function useAppConfig() {
+  const defaultCwd = ref<string | null>(null);
+  const home = ref<string | null>(null);
+  const presets = ref<CwdPreset[]>([]);
+  const saving = ref(false);
+  const error = ref<string | null>(null);
+
+  async function loadConfig() {
+    try {
+      const res = await fetch("/api/config");
+      if (!res.ok) return;
+      const c = await res.json();
+      defaultCwd.value = c.cwd ?? null;
+      home.value = c.home ?? null;
+      presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
+    } catch {
+      // the app still works; presets are just unavailable
+    }
+  }
+
+  // Returns whether the save succeeded so the caller can close the modal only on
+  // success (and keep the user's edits otherwise).
+  async function savePresets(next: CwdPreset[]): Promise<boolean> {
+    saving.value = true;
+    error.value = null;
+    try {
+      const res = await fetch("/api/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cwdPresets: next }),
+      });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      presets.value = (await res.json()).cwdPresets ?? [];
+      return true;
+    } catch {
+      error.value = "Couldn't save presets. Check the server and try again.";
+      return false;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  return { defaultCwd, home, presets, saving, error, loadConfig, savePresets };
+}

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -1,0 +1,123 @@
+import { ref } from "vue";
+import type { ITheme } from "@xterm/xterm";
+
+export type ThemeId = "midnight" | "nord" | "daylight" | "solarized";
+
+export interface Theme {
+  id: ThemeId;
+  label: string;
+  // Three representative colors shown as the picker swatch.
+  swatch: { base: string; panel: string; accent: string };
+  // xterm renders on a canvas and can't read CSS variables, so each theme carries
+  // an explicit terminal palette mirroring its CSS tokens. Light themes also set
+  // the 16 ANSI colors (mapping bright-white to a dark tone) so colored TUI output
+  // stays legible on a light background — xterm's defaults assume a dark canvas.
+  term: ITheme;
+}
+
+export const THEMES: Theme[] = [
+  {
+    id: "midnight",
+    label: "Midnight",
+    swatch: { base: "#1a1a2e", panel: "#16213e", accent: "#4a8cff" },
+    term: { background: "#1a1a2e", foreground: "#e0e0e0", cursor: "#e0e0e0", selectionBackground: "#3a3a5e" },
+  },
+  {
+    id: "nord",
+    label: "Nord",
+    swatch: { base: "#2e3440", panel: "#3b4252", accent: "#88c0d0" },
+    term: { background: "#2e3440", foreground: "#d8dee9", cursor: "#d8dee9", selectionBackground: "#434c5e" },
+  },
+  {
+    id: "daylight",
+    label: "Daylight",
+    swatch: { base: "#f4f6fb", panel: "#ffffff", accent: "#2563eb" },
+    term: {
+      background: "#f4f6fb",
+      foreground: "#1b2430",
+      cursor: "#1b2430",
+      selectionBackground: "#cfe0ff",
+      black: "#1b2430",
+      red: "#cf222e",
+      green: "#1a7f37",
+      yellow: "#9a6700",
+      blue: "#2563eb",
+      magenta: "#8250df",
+      cyan: "#1b7c83",
+      white: "#57606a",
+      brightBlack: "#57606a",
+      brightRed: "#a40e26",
+      brightGreen: "#116329",
+      brightYellow: "#7d4e00",
+      brightBlue: "#1d4ed8",
+      brightMagenta: "#6639ba",
+      brightCyan: "#3192aa",
+      brightWhite: "#1b2430",
+    },
+  },
+  {
+    id: "solarized",
+    label: "Solarized Light",
+    swatch: { base: "#fdf6e3", panel: "#eee8d5", accent: "#268bd2" },
+    term: {
+      background: "#fdf6e3",
+      foreground: "#586e75",
+      cursor: "#586e75",
+      selectionBackground: "#eee8d5",
+      black: "#073642",
+      red: "#dc322f",
+      green: "#859900",
+      yellow: "#b58900",
+      blue: "#268bd2",
+      magenta: "#d33682",
+      cyan: "#2aa198",
+      white: "#657b83",
+      brightBlack: "#073642",
+      brightRed: "#cb4b16",
+      brightGreen: "#586e75",
+      brightYellow: "#657b83",
+      brightBlue: "#268bd2",
+      brightMagenta: "#6c71c4",
+      brightCyan: "#2aa198",
+      brightWhite: "#586e75",
+    },
+  },
+];
+
+const STORAGE_KEY = "theme";
+const DEFAULT_THEME: ThemeId = "midnight";
+
+function isThemeId(value: string | null): value is ThemeId {
+  return value !== null && THEMES.some((t) => t.id === value);
+}
+
+function loadThemeId(): ThemeId {
+  return isThemeId(localStorage.getItem(STORAGE_KEY)) ? (localStorage.getItem(STORAGE_KEY) as ThemeId) : DEFAULT_THEME;
+}
+
+const themeId = ref<ThemeId>(loadThemeId());
+
+function applyTheme(id: ThemeId) {
+  document.documentElement.setAttribute("data-theme", id);
+}
+
+// The xterm palette for the active theme; Terminal.vue feeds this into the
+// terminal's `theme` option and refreshes it whenever the theme changes.
+export function currentTermTheme(): Theme["term"] {
+  return (THEMES.find((t) => t.id === themeId.value) ?? THEMES[0]).term;
+}
+
+// Called from main.ts before mount so the persisted theme is on <html> before
+// the first paint (no flash of the default palette).
+export function initTheme() {
+  applyTheme(themeId.value);
+}
+
+export function useTheme() {
+  function setTheme(id: ThemeId) {
+    themeId.value = id;
+    localStorage.setItem(STORAGE_KEY, id);
+    applyTheme(id);
+  }
+  return { themeId, themes: THEMES, setTheme };
+}

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -91,8 +91,16 @@ function isThemeId(value: string | null): value is ThemeId {
   return value !== null && THEMES.some((t) => t.id === value);
 }
 
+// Storage access can throw (private mode / sandboxed contexts with storage
+// blocked), so persistence is best-effort: a failure falls back to the default
+// rather than crashing app startup.
 function loadThemeId(): ThemeId {
-  return isThemeId(localStorage.getItem(STORAGE_KEY)) ? (localStorage.getItem(STORAGE_KEY) as ThemeId) : DEFAULT_THEME;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return isThemeId(stored) ? stored : DEFAULT_THEME;
+  } catch {
+    return DEFAULT_THEME;
+  }
 }
 
 const themeId = ref<ThemeId>(loadThemeId());
@@ -116,7 +124,11 @@ export function initTheme() {
 export function useTheme() {
   function setTheme(id: ThemeId) {
     themeId.value = id;
-    localStorage.setItem(STORAGE_KEY, id);
+    try {
+      localStorage.setItem(STORAGE_KEY, id);
+    } catch {
+      // storage blocked: the theme still applies for this session, just isn't persisted
+    }
     applyTheme(id);
   }
   return { themeId, themes: THEMES, setTheme };

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,11 @@ import "./style.css";
 // Configure the @mulmoclaude/collection-plugin UI binding (data fetch, asset URLs,
 // nav, confirm, modal teleport) once, before any presentCollection card mounts.
 import "./composables/collectionUi";
+import { initTheme } from "./composables/useTheme";
 import App from "./App.vue";
+
+// Apply the persisted theme to <html> before mount so there's no flash of the
+// default palette.
+initTheme();
 
 createApp(App).mount("#app");

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,144 @@
+/* Theme tokens. The default (:root) palette is "Midnight"; [data-theme] blocks
+   below override it. Components reference these via var(--token), so switching
+   the data-theme attribute on <html> recolors the whole app. The four themes
+   span dark→light and cool→warm so they read as clearly different. */
+:root,
+:root[data-theme="midnight"] {
+  --bg-base: #1a1a2e;
+  --bg-deep: #11162a;
+  --bg-panel: #16213e;
+  --bg-subtle: #1d2b4e;
+  --bg-elevated: #20203a;
+  --bg-input: #11111f;
+  --bg-hover: #2a3b66;
+  --bg-selected: #1b3a6b;
+  --bg-selected-hover: #224a86;
+  --border: #2a2a4e;
+  --accent: #4a8cff;
+  --accent-bg: #2f5bd0;
+  --accent-bg-hover: #3a6be0;
+  --on-accent: #ffffff;
+  --text: #e6e6f0;
+  --text-secondary: #c7cdf0;
+  --text-muted: #9aa5c4;
+  --text-dim: #7c87a8;
+  --term-fg: #e0e0e0;
+  --term-selection: #3a3a5e;
+}
+
+/* Nord — cool slate, frost-cyan accent (medium-dark). */
+:root[data-theme="nord"] {
+  --bg-base: #2e3440;
+  --bg-deep: #272b35;
+  --bg-panel: #3b4252;
+  --bg-subtle: #353c4a;
+  --bg-elevated: #434c5e;
+  --bg-input: #21252e;
+  --bg-hover: #4c566a;
+  --bg-selected: #3b4a63;
+  --bg-selected-hover: #4c5d7d;
+  --border: #434c5e;
+  --accent: #88c0d0;
+  --accent-bg: #5e81ac;
+  --accent-bg-hover: #6b8fbb;
+  --on-accent: #eceff4;
+  --text: #eceff4;
+  --text-secondary: #d8dee9;
+  --text-muted: #abb4c4;
+  --text-dim: #7e879b;
+  --term-fg: #d8dee9;
+  --term-selection: #434c5e;
+}
+
+/* Daylight — bright, cool. White panels on a soft gray base, vivid blue accent. */
+:root[data-theme="daylight"] {
+  --bg-base: #f4f6fb;
+  --bg-deep: #e8edf6;
+  --bg-panel: #ffffff;
+  --bg-subtle: #eef2fa;
+  --bg-elevated: #eef2fb;
+  --bg-input: #ffffff;
+  --bg-hover: #e2e9f6;
+  --bg-selected: #d6e4fb;
+  --bg-selected-hover: #c3d6f7;
+  --border: #d4dbe8;
+  --accent: #2563eb;
+  --accent-bg: #2563eb;
+  --accent-bg-hover: #1d4ed8;
+  --on-accent: #ffffff;
+  --text: #1b2430;
+  --text-secondary: #38445a;
+  --text-muted: #5d6b82;
+  --text-dim: #8492a8;
+  --term-fg: #1b2430;
+  --term-selection: #cfe0ff;
+}
+
+/* Solarized Light — bright, warm. Cream base, classic Solarized blue accent. */
+:root[data-theme="solarized"] {
+  --bg-base: #fdf6e3;
+  --bg-deep: #ece5cf;
+  --bg-panel: #eee8d5;
+  --bg-subtle: #f4eed9;
+  --bg-elevated: #f4eed9;
+  --bg-input: #fffbf0;
+  --bg-hover: #e3dcc4;
+  --bg-selected: #d6e4ec;
+  --bg-selected-hover: #c4d8e4;
+  --border: #ded7c0;
+  --accent: #268bd2;
+  --accent-bg: #268bd2;
+  --accent-bg-hover: #1f78ba;
+  --on-accent: #ffffff;
+  --text: #34474d;
+  --text-secondary: #49595d;
+  --text-muted: #657b83;
+  --text-dim: #93a1a1;
+  --term-fg: #586e75;
+  --term-selection: #eee8d5;
+}
+
+/* Status colors carry meaning (success / warning / error). They don't follow the
+   palette hue, but they DO flip with background lightness: dark themes get
+   dark-filled pills with light text (below); light themes get light-tinted pills
+   with dark text (further down). */
+:root {
+  --ok: #a5d6a7;
+  --ok-bg: #1b5e20;
+  --ok-bg-subtle: #14361c;
+  --ok-border: #1c3a24;
+  --warn: #ffcc80;
+  --warn-bg: #e65100;
+  --warn-bg-subtle: #4a3a10;
+  --amber: #f5a623;
+  --err: #ef9a9a;
+  --err-text: #ff7b7b;
+  --err-strong: #ef4444;
+  --err-deep: #b71c1c;
+  --err-bg: #4a1414;
+  --err-hover-bg: #3a2030;
+}
+
+/* Light themes: status pills become light-tinted with dark, saturated text so
+   they stay legible on a bright background. */
+:root[data-theme="daylight"],
+:root[data-theme="solarized"] {
+  --ok: #1b7a2e;
+  --ok-bg: #d7f0db;
+  --ok-bg-subtle: #e6f4ea;
+  --ok-border: #b7e0bf;
+  --warn: #8a4b00;
+  --warn-bg: #ffe0b2;
+  --warn-bg-subtle: #fff0db;
+  --amber: #b8860b;
+  --err: #c0392b;
+  --err-text: #c0392b;
+  --err-strong: #d32f2f;
+  --err-deep: #fadbd8;
+  --err-bg: #fadbd8;
+  --err-hover-bg: #f6d4d7;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -5,7 +146,7 @@
 }
 
 body {
-  background: #1a1a2e;
+  background: var(--bg-base);
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

アプリ全体の配色を切り替えられる **テーマカラー** 機能。4テーマ（**Midnight / Nord / Daylight / Solarized Light**）を用意し、暗→明・寒色→暖色で明確に差別化。設定モーダルから選択でき、選択は `localStorage` に永続化される。

- 直書き hex（約63色／15ファイル）を **約20個のセマンティック CSS 変数**に集約し、`:root[data-theme="…"]` で切替
- **ステータス色は明るさで反転**：暗テーマ=暗ピル+明文字／明テーマ=淡ピル+濃文字（接続状態・エラー表示が両方で判読可能）
- **xterm はテーマ切替でライブ再描画**。明テーマには light 向け ANSI 16色を指定し、Claude のカラー出力が明背景で潰れないようにした
- 切替UIは設定モーダルに「Theme」セクションを追加。**単一表示にも設定（⚙）ボタンを新設**し、単一/グリッドの両方から変更可能
- config（presets）取得・保存を `useAppConfig` に切り出して両画面で共有（DRY）

| テーマ | 明るさ | 背景 |
|---|---|---|
| Midnight（デフォルト・現状維持） | 暗（紺） | `#1a1a2e` |
| Nord | 中間（スレート） | `#2e3440` |
| Daylight | 明（白・寒色） | `#f4f6fb` |
| Solarized Light | 明（クリーム・暖色） | `#fdf6e3` |

## Items to Confirm / Review

- **色味の好み**：4テーマの具体色は調整容易。特に Nord（半ダーク）や明テーマのアクセント色など、好みに合わせて変更可能。
- **Midnight の同一性**：デフォルトの Midnight が既存の見た目と差異ないか（現状維持を意図）。
- **明テーマのターミナル**：Daylight / Solarized Light で xterm の ANSI 出力が明背景で十分なコントラストか（welcome 画面では確認済み。実運用の各種カラー出力での見え方）。
- **ステータス色の固定方針**：success/warn/error は palette の色相に従わず明るさのみ反転させている設計でよいか。
- **設定モーダルの責務拡大**：従来「Directory presets」専用だったモーダルにテーマ選択を追加し、タイトルを "Settings" に変更。単一表示に⚙を追加（presets 取得を `useAppConfig` で共有）。

## User Prompt

- 色を変えられるようにしたい。テーマカラー的な。
- 4パターンくらいの配色が欲しい。それができるか調査してほしい。
- 配色は「全く異なる4世界観」、切替UIは「設定モーダルに追加」。
- （初回実装後）色の変化が小さく、ダークモードのような暗い色ばかり。**明るい背景の配色が欲しい** → 暗→明・寒色→暖色で差をつけ、明るいテーマを含める。

## 実装の要点

### トークン設計
- テーマで変わる約20トークン：`--bg-base/-deep/-panel/-subtle/-elevated/-input/-hover/-selected/-selected-hover`, `--border`, `--accent/-bg/-bg-hover`, `--on-accent`, `--text/-secondary/-muted/-dim`, `--term-fg/-selection`
- ステータス（テーマ連動）：`--ok* / --warn* / --err* / --amber`（`:root` に暗版、`[data-theme="daylight"], [data-theme="solarized"]` で淡色版を上書き）

### 主要な判断
- xterm はキャンバス描画で CSS 変数を読めないため、`useTheme.ts` に各テーマの端末パレットを保持し、`themeId` を watch して `term.options.theme` をライブ更新。
- 一括置換で hover/選択時の白文字を `--on-accent` 化していた箇所のうち、背景が `--accent-bg` でない9箇所を `--text` に修正（明背景で文字が消えるため）。`--on-accent` は accent 塗りの3箇所のみ。
- プラグイン iframe（白背景）は意図的にアプリ chrome と分離しているためテーマ対象外。

### 検証
- `yarn format / lint / typecheck / build / test(199 passed)` 全グリーン
- Puppeteer 実機確認：4テーマ全てでアプリ全体＋xterm が正しく再配色、ステータスピルの判読性も確認

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)