### PR TITLE
fix: remove debug test-sound buttons from toolbars

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,7 +14,7 @@ import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } f
 import { registerChatOpener } from "./composables/useChatLauncher";
 import { useAppConfig } from "./composables/useAppConfig";
 import { useSoundEnabled } from "./composables/useSoundEnabled";
-import { useAttentionSound, playAttentionSound } from "./composables/useAttentionSound";
+import { useAttentionSound } from "./composables/useAttentionSound";
 import type { Shortcut } from "./types/shortcuts";
 import type { CwdPreset } from "./components/presets";
 
@@ -232,9 +232,6 @@ function onSession(id: string) {
       >
         <span class="material-symbols-outlined">{{ soundEnabled ? "notifications_active" : "notifications_off" }}</span>
       </button>
-      <button type="button" class="launcher-btn" title="Test sound" aria-label="Test sound" @click="playAttentionSound">
-        <span class="material-symbols-outlined">volume_up</span>
-      </button>
       <button type="button" class="launcher-btn settings-btn" title="Settings" aria-label="Settings" @click="showSettings = true">
         <span class="material-symbols-outlined">settings</span>
       </button>
@@ -353,7 +350,7 @@ function onSession(id: string) {
   background: var(--accent-bg);
   color: var(--on-accent);
 }
-/* Push the action buttons (sound, test, settings) to the far right as a group. */
+/* Push the action buttons (sound, settings) to the far right as a group. */
 .sound-toggle {
   margin-left: auto;
 }

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -19,7 +19,6 @@ import {
   type GridState,
 } from "./gridTabs";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
-import { playAttentionSound } from "../composables/useAttentionSound";
 import type { CwdPreset } from "./presets";
 import { useAppConfig } from "../composables/useAppConfig";
 
@@ -103,7 +102,6 @@ function closeSettings() {
       >
         {{ soundEnabled ? "🔔" : "🔕" }}
       </button>
-      <button class="tb-btn" title="Test sound" aria-label="Test sound" @click="playAttentionSound">🔊</button>
       <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
       <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>

--- a/src/composables/useAttentionSound.ts
+++ b/src/composables/useAttentionSound.ts
@@ -54,9 +54,8 @@ function armUnlock() {
   window.addEventListener("keydown", unlock);
 }
 
-// A short two-note attention chime via Web Audio (no asset). Exported so a toolbar
-// "test" button can preview it (and, being a user gesture, unlock the context).
-export function playAttentionSound() {
+// A short two-note attention chime via Web Audio (no asset).
+function playAttentionSound() {
   const ctx = getCtx();
   if (!ctx) return;
   if (ctx.state === "suspended") ctx.resume().catch(() => {});


### PR DESCRIPTION
## Summary
デバッグ用に残っていた 🔊「Test sound」ボタンを、シングルビュー（`App.vue`）とグリッドビュー（`GridView.vue`）のツールバーから削除します。注意チャイムの動作確認用に追加したものが消し忘れられていました。

## Items to Confirm / Review
- `playAttentionSound()` 関数**自体は削除していません**。`useAttentionSound.ts` 内部で、セッションが注意を要する状態になった時に鳴る本来の通知チャイムとして使われているためです（テストボタン経由の外部参照がなくなったので `export` のみ除去）。
- 🔔/🔕 の「Attention sound on/off」トグルは本来の機能なので残しています。
- 音声コンテキストの unlock は、`armUnlock()` が最初のクリック/キー入力で行うため、テストボタン削除による影響はありません。

## User Prompt
> デバック用のサウンドボタン、消し忘れた → PR

## Changes
| File | Change |
|---|---|
| `src/App.vue` | 「Test sound」ボタン（volume_up）と import の `playAttentionSound`、CSSコメントの "test" 言及を削除 |
| `src/components/GridView.vue` | 「Test sound」ボタン（🔊）と専用 import 行を削除 |
| `src/composables/useAttentionSound.ts` | `playAttentionSound` の `export` を除去（コメント修正） |

## Verification
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`: pass（lint の警告は `server/open-dir.ts` の既存・無関係なもの）
- `yarn test`: 247 passed (27 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)