### PR TITLE
feat: セルheaderに「意味のある」直近プロンプトを出す（ok/マージ等で埋もれない）

### DIFF
--- a/plans/feat-cell-header-meaningful-prompt.md
+++ b/plans/feat-cell-header-meaningful-prompt.md
@@ -1,0 +1,42 @@
+# feat: グリッドセルの header に「意味のある」プロンプトを出す
+
+## 背景 / User Prompt
+
+> 今、直近の user prompt を header に出しているけど、なにをやっているか要約をだすことはできないよね？
+>
+> （課題の整理）`ok` や `マージ` みたいな簡素な指示が最後だと、そのセッションが結局何の作業か分からなくなる。文字数で filter して、短い場合はもっと古いのを参照すれば良い？
+
+→ おすすめ（**文字数フォールバック＋ack denylist 併用**）で実装。
+
+## 設計
+
+セル header は今 `lastPrompt`（＝最後の UserPromptSubmit プロンプト）を出している。`ok`/`はい`/`マージ`
+のような **trivial なつなぎ指示**が最後だと本題が埋もれる。そこで **「最後の *意味のある* プロンプト」**
+を出すようにする。表示側（`TerminalCell.vue`）は変更不要 — サーバが渡す `lastPrompt` を「意味のあるもの」に
+するだけ。
+
+### trivial 判定（純粋関数, テスト対象）
+`server/transcript.ts` に `isTrivialPrompt(text)`:
+- 前後の空白・句読点を除去し小文字化
+- 空 → trivial
+- ack denylist（`ok`/`yes`/`merge`/`はい`/`マージ`/`続けて`/`お願いします` 等）に一致 → trivial
+- コードポイント長 < 4 → trivial（`ok`/`はい`/`マージ`/`yes` を拾う。`バグ直して`(5) 等は残す）
+
+### 適用箇所（サーバ）
+1. **ライブ**（UserPromptSubmit フック, `index.ts`）: `lastPrompts.set` を **trivial なら上書きしない**
+   （ただし未設定時は最初のプロンプトを入れる）。＝ 直近の意味あるプロンプトを保持。
+2. **resume/初期**（トランスクリプト, `index.ts:latestUserPrompt`）: `latestMeaningfulUserPromptFromJsonl`
+   を使い、新しい順に走査して最初の非 trivial を返す（全部 trivial なら最新へフォールバック）。
+
+`transcript.ts` は `collectPrompts` に切り出し、`latestUserPromptFromJsonl`（従来挙動）と
+`latestMeaningfulUserPromptFromJsonl`（新）の両方を提供。
+
+## 変更
+- `server/transcript.ts`: `isTrivialPrompt` / `latestMeaningfulUserPromptFromJsonl` / `collectPrompts`
+- `server/index.ts`: import 差し替え、`latestUserPrompt` を meaningful 版に、ライブフックで trivial 上書き抑止
+- `server/transcript.spec.ts`: `isTrivialPrompt` / `latestMeaningfulUserPromptFromJsonl` のテスト
+
+## 確認ポイント
+- 閾値（長さ < 4）と denylist は控えめ。意味ある短い日本語（`バグ直して`）は残す方針
+- 全プロンプトが trivial なセッションは最新（trivial）を出す（空表示にはしない）
+- 別 PR（#87 とは独立、main ベース）

--- a/server/index.ts
+++ b/server/index.ts
@@ -680,6 +680,21 @@ async function handleToolHook(sessionId: string, event: string, p: HookToolPaylo
   }
 }
 
+// Track the prompt the cell header shows for a session, from a UserPromptSubmit
+// hook. On the FIRST live prompt after a (re)start/resume the in-memory baseline is
+// empty, so seed it from the transcript's meaningful prompt — otherwise a trivial
+// ack ("ok") would overwrite the restored task. (Brand-new sessions have no
+// transcript yet => null => the new prompt becomes the first shown.) Then keep the
+// last MEANINGFUL prompt (preferredHeaderPrompt) while still tracking the latest for
+// an all-trivial session.
+async function trackPromptForHeader(sessionId: string, prompt: string, cwd: string | undefined) {
+  if (!lastPrompts.has(sessionId)) {
+    const seeded = cwd ? await latestUserPrompt(cwd, sessionId) : null;
+    if (seeded) lastPrompts.set(sessionId, seeded);
+  }
+  lastPrompts.set(sessionId, preferredHeaderPrompt(lastPrompts.get(sessionId) ?? null, prompt));
+}
+
 // Claude hooks (Stop / Notification / Pre|PostToolUse) POST their payload here so
 // we can flag which background sessions have new activity / build tool history.
 app.post("/api/hook", async (req, res) => {
@@ -689,13 +704,11 @@ app.post("/api/hook", async (req, res) => {
   if (sessionId) {
     const entry = ptys.get(sessionId);
     const foreground = !!(entry && entry.ws);
-    // Capture the prompt BEFORE handleActivityHook so the activity publish it
-    // triggers already carries the new lastPrompt. preferredHeaderPrompt keeps the
-    // last MEANINGFUL prompt (a trivial ack like "ok"/"merge" doesn't hide the task)
-    // while still tracking the latest for an all-trivial session.
+    // Update the displayed prompt BEFORE handleActivityHook so the activity publish
+    // it triggers already carries the new lastPrompt.
     if (event === "UserPromptSubmit" && typeof body.prompt === "string" && body.prompt.trim()) {
-      const prompt = body.prompt.trim().slice(0, LAST_PROMPT_CAP);
-      lastPrompts.set(sessionId, preferredHeaderPrompt(lastPrompts.get(sessionId) ?? null, prompt));
+      const cwd = typeof body.cwd === "string" ? body.cwd : entry?.cwd;
+      await trackPromptForHeader(sessionId, body.prompt.trim().slice(0, LAST_PROMPT_CAP), cwd);
     }
     handleActivityHook(sessionId, event, foreground);
     await handleToolHook(sessionId, event, body);

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,7 +18,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes } from "./config-routes.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
-import { isRecord, parseJsonl, userPromptText, latestUserPromptFromJsonl } from "./transcript.js";
+import { isRecord, parseJsonl, userPromptText, latestMeaningfulUserPromptFromJsonl, isTrivialPrompt } from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
@@ -303,8 +303,10 @@ const SESSION_LIST_LIMIT = 50;
 // UserPromptSubmit => Claude started thinking; Stop => it finished.
 const activity = new Map<string, Activity>(); // id -> { working, event, at }
 
-// Latest user prompt per session (from the UserPromptSubmit hook), shown on the
-// grid cell header so you can tell at a glance what each terminal is doing.
+// Latest MEANINGFUL user prompt per session (from the UserPromptSubmit hook), shown
+// on the grid cell header so you can tell at a glance what each terminal is about. A
+// trivial ack ("ok", "merge") doesn't replace it (see the hook handler), so a short
+// follow-up can't hide the task.
 const lastPrompts = new Map<string, string>(); // id -> prompt text
 const LAST_PROMPT_CAP = 200;
 
@@ -505,7 +507,7 @@ function resolveWorkspace(cwd: string | null): string {
 async function latestUserPrompt(cwd: string, id: string): Promise<string | null> {
   try {
     const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
-    return latestUserPromptFromJsonl(raw);
+    return latestMeaningfulUserPromptFromJsonl(raw);
   } catch {
     return null;
   }
@@ -688,9 +690,13 @@ app.post("/api/hook", async (req, res) => {
     const entry = ptys.get(sessionId);
     const foreground = !!(entry && entry.ws);
     // Capture the prompt BEFORE handleActivityHook so the activity publish it
-    // triggers already carries the new lastPrompt.
+    // triggers already carries the new lastPrompt. Keep the last MEANINGFUL prompt:
+    // a trivial ack ("ok", "merge", "はい") shouldn't replace the task already shown,
+    // so it doesn't obscure what the session is about — but always set if we have
+    // nothing yet (the first prompt, even if short, beats a bare session id).
     if (event === "UserPromptSubmit" && typeof body.prompt === "string" && body.prompt.trim()) {
-      lastPrompts.set(sessionId, body.prompt.trim().slice(0, LAST_PROMPT_CAP));
+      const prompt = body.prompt.trim().slice(0, LAST_PROMPT_CAP);
+      if (!isTrivialPrompt(prompt) || !lastPrompts.has(sessionId)) lastPrompts.set(sessionId, prompt);
     }
     handleActivityHook(sessionId, event, foreground);
     await handleToolHook(sessionId, event, body);

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,7 +18,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes } from "./config-routes.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
-import { isRecord, parseJsonl, userPromptText, latestMeaningfulUserPromptFromJsonl, isTrivialPrompt } from "./transcript.js";
+import { isRecord, parseJsonl, userPromptText, latestMeaningfulUserPromptFromJsonl, preferredHeaderPrompt } from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
@@ -690,13 +690,12 @@ app.post("/api/hook", async (req, res) => {
     const entry = ptys.get(sessionId);
     const foreground = !!(entry && entry.ws);
     // Capture the prompt BEFORE handleActivityHook so the activity publish it
-    // triggers already carries the new lastPrompt. Keep the last MEANINGFUL prompt:
-    // a trivial ack ("ok", "merge", "はい") shouldn't replace the task already shown,
-    // so it doesn't obscure what the session is about — but always set if we have
-    // nothing yet (the first prompt, even if short, beats a bare session id).
+    // triggers already carries the new lastPrompt. preferredHeaderPrompt keeps the
+    // last MEANINGFUL prompt (a trivial ack like "ok"/"merge" doesn't hide the task)
+    // while still tracking the latest for an all-trivial session.
     if (event === "UserPromptSubmit" && typeof body.prompt === "string" && body.prompt.trim()) {
       const prompt = body.prompt.trim().slice(0, LAST_PROMPT_CAP);
-      if (!isTrivialPrompt(prompt) || !lastPrompts.has(sessionId)) lastPrompts.set(sessionId, prompt);
+      lastPrompts.set(sessionId, preferredHeaderPrompt(lastPrompts.get(sessionId) ?? null, prompt));
     }
     handleActivityHook(sessionId, event, foreground);
     await handleToolHook(sessionId, event, body);

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -62,13 +62,15 @@ describe("latestUserPromptFromJsonl", () => {
 });
 
 describe("isTrivialPrompt", () => {
-  it("treats empty / one-word acks / bare commands as trivial", () => {
-    for (const t of ["", "  ", "ok", "OK", " ok. ", "yes", "はい", "マージ", "merge", "okay", "sure", "続けて", "お願いします", "fix"]) {
+  it("treats empty / ack words / bare commands / a lone char as trivial", () => {
+    for (const t of ["", "  ", "ok", "OK", " ok. ", "yes", "はい", "うん", "マージ", "merge", "okay", "sure", "続けて", "お願いします", "y", "k", "👍"]) {
       expect(isTrivialPrompt(t)).toBe(true);
     }
   });
-  it("treats a substantial prompt as meaningful (incl. short Japanese)", () => {
-    for (const t of ["Fix the parser bug", "deploy to prod", "バグ直して", "テスト追加", "リファクタして"]) {
+  it("treats a substantial prompt as meaningful — including short, non-ack terms", () => {
+    // Regression for the i18n / terse-prompt false-positive: length alone must not
+    // mark short-but-meaningful prompts trivial.
+    for (const t of ["Fix the parser bug", "deploy to prod", "バグ直して", "UI", "DB", "修正", "対応", "fix", "api"]) {
       expect(isTrivialPrompt(t)).toBe(false);
     }
   });

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { latestUserPromptFromJsonl, userPromptText, parseJsonl } from "./transcript.js";
+import { latestUserPromptFromJsonl, latestMeaningfulUserPromptFromJsonl, isTrivialPrompt, userPromptText, parseJsonl } from "./transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 
@@ -51,6 +51,45 @@ describe("latestUserPromptFromJsonl", () => {
   it("tolerates blank and malformed lines", () => {
     const raw = ["", "not json", line({ type: "user", message: { content: "ok" } }), "{bad"].join("\n");
     expect(latestUserPromptFromJsonl(raw)).toBe("ok");
+  });
+});
+
+describe("isTrivialPrompt", () => {
+  it("treats empty / one-word acks / bare commands as trivial", () => {
+    for (const t of ["", "  ", "ok", "OK", " ok. ", "yes", "はい", "マージ", "merge", "okay", "sure", "続けて", "お願いします", "fix"]) {
+      expect(isTrivialPrompt(t)).toBe(true);
+    }
+  });
+  it("treats a substantial prompt as meaningful (incl. short Japanese)", () => {
+    for (const t of ["Fix the parser bug", "deploy to prod", "バグ直して", "テスト追加", "リファクタして"]) {
+      expect(isTrivialPrompt(t)).toBe(false);
+    }
+  });
+});
+
+describe("latestMeaningfulUserPromptFromJsonl", () => {
+  const user = (content: string) => line({ type: "user", message: { content } });
+
+  it("skips trailing trivial acks and returns the last substantial prompt", () => {
+    const raw = [user("Fix the parser bug"), user("ok"), user("merge")].join("\n");
+    expect(latestMeaningfulUserPromptFromJsonl(raw)).toBe("Fix the parser bug");
+  });
+
+  it("returns the most recent substantial prompt when interleaved with acks", () => {
+    const raw = [user("task A"), user("ok"), user("now add the tests"), user("はい")].join("\n");
+    expect(latestMeaningfulUserPromptFromJsonl(raw)).toBe("now add the tests");
+  });
+
+  it("falls back to the latest prompt when every prompt is trivial", () => {
+    expect(latestMeaningfulUserPromptFromJsonl([user("ok"), user("はい")].join("\n"))).toBe("はい");
+  });
+
+  it("falls back to a last-prompt record when there are no user lines", () => {
+    expect(latestMeaningfulUserPromptFromJsonl(line({ type: "last-prompt", lastPrompt: "from record" }))).toBe("from record");
+  });
+
+  it("returns null for an empty transcript", () => {
+    expect(latestMeaningfulUserPromptFromJsonl("")).toBeNull();
   });
 });
 

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { latestUserPromptFromJsonl, latestMeaningfulUserPromptFromJsonl, isTrivialPrompt, userPromptText, parseJsonl } from "./transcript.js";
+import {
+  latestUserPromptFromJsonl,
+  latestMeaningfulUserPromptFromJsonl,
+  isTrivialPrompt,
+  preferredHeaderPrompt,
+  userPromptText,
+  parseJsonl,
+} from "./transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 
@@ -64,6 +71,22 @@ describe("isTrivialPrompt", () => {
     for (const t of ["Fix the parser bug", "deploy to prod", "バグ直して", "テスト追加", "リファクタして"]) {
       expect(isTrivialPrompt(t)).toBe(false);
     }
+  });
+});
+
+describe("preferredHeaderPrompt", () => {
+  it("uses a meaningful incoming prompt (over null or anything)", () => {
+    expect(preferredHeaderPrompt(null, "Fix the bug")).toBe("Fix the bug");
+    expect(preferredHeaderPrompt("old task", "new task here")).toBe("new task here");
+    expect(preferredHeaderPrompt("ok", "Fix the bug")).toBe("Fix the bug");
+  });
+  it("keeps a meaningful current prompt when the incoming is trivial", () => {
+    expect(preferredHeaderPrompt("Fix the parser bug", "ok")).toBe("Fix the parser bug");
+    expect(preferredHeaderPrompt("Fix the parser bug", "マージ")).toBe("Fix the parser bug");
+  });
+  it("tracks the latest trivial prompt when there's nothing meaningful yet", () => {
+    expect(preferredHeaderPrompt(null, "ok")).toBe("ok"); // first prompt, even if trivial
+    expect(preferredHeaderPrompt("ok", "merge")).toBe("merge"); // trivial replaces trivial
   });
 });
 

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -52,25 +52,38 @@ export function latestUserPromptFromJsonl(raw: string): string | null {
   return prompts[prompts.length - 1] ?? lastPromptRecord;
 }
 
-// A trivial prompt is an empty/one-word ack or a bare command ("ok", "merge", "はい")
-// that doesn't describe what a session is about. The cell header skips these so a
-// short follow-up doesn't hide the task. Matched case-insensitively after trimming
-// surrounding punctuation/whitespace.
-const TRIVIAL_PROMPT_MIN_LEN = 4; // < this many code points => trivial (catches ok / はい / マージ / yes)
+// A trivial prompt is an empty ack or a bare command ("ok", "merge", "はい") that
+// doesn't describe what a session is about. The cell header skips these so a short
+// follow-up doesn't hide the task. The explicit ack list is the primary signal —
+// NOT prompt length, since terse but meaningful prompts exist ("UI", "DB", "修正",
+// "対応"). Only a stray single character is treated as noise by length. Matched
+// case-insensitively after trimming surrounding punctuation/whitespace.
+const TRIVIAL_PROMPT_MIN_LEN = 2; // < 2 code points => a lone char, treated as noise
 const TRIVIAL_PROMPT_WORDS = new Set([
-  // English acks / one-word commands (length >= MIN_LEN, so listed explicitly)
+  // English acks / one-word commands
+  "ok",
   "okay",
+  "k",
+  "kk",
+  "yes",
   "yep",
   "yeah",
-  "sure",
+  "ya",
+  "no",
   "nope",
+  "nah",
+  "sure",
+  "go",
+  "run",
   "next",
   "done",
   "stop",
   "wait",
+  "skip",
   "merge",
   "commit",
   "push",
+  "pr",
   "continue",
   "proceed",
   "retry",
@@ -78,8 +91,19 @@ const TRIVIAL_PROMPT_WORDS = new Set([
   "good",
   "nice",
   "thanks",
+  "thx",
+  "lgtm",
   // Japanese acks / one-word commands
+  "はい",
+  "うん",
+  "ええ",
   "いいえ",
+  "よし",
+  "了解",
+  "りょ",
+  "りょうかい",
+  "おk",
+  "おけ",
   "マージ",
   "コミット",
   "プッシュ",
@@ -93,6 +117,7 @@ const TRIVIAL_PROMPT_WORDS = new Set([
   "お願いします",
   "それで",
   "よろしく",
+  "どうぞ",
 ]);
 
 // Punctuation stripped from a prompt's edges before ack matching, so "ok." / "はい、"

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -117,6 +117,15 @@ export function isTrivialPrompt(text: string): boolean {
   return [...norm].length < TRIVIAL_PROMPT_MIN_LEN;
 }
 
+// The prompt the live cell header should show after a new one is submitted. Prefer
+// the latest MEANINGFUL prompt: a trivial ack replaces nothing or another trivial
+// prompt (so an all-trivial session still tracks the latest), but never overwrites a
+// meaningful one. Mirrors latestMeaningfulUserPromptFromJsonl's fallback.
+export function preferredHeaderPrompt(current: string | null, incoming: string): string {
+  if (!isTrivialPrompt(incoming) || current === null || isTrivialPrompt(current)) return incoming;
+  return current;
+}
+
 // Like latestUserPromptFromJsonl, but skips trivial acks and returns the most recent
 // SUBSTANTIAL prompt, so a resumed session's header shows the task instead of a
 // one-word follow-up. Falls back to the latest prompt (then the record) if every

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -30,19 +30,101 @@ export function parseJsonl(raw: string): Record<string, unknown>[] {
   return out;
 }
 
-// The most recent user-typed prompt in a transcript: the last "user" line with real
-// text, falling back to a "last-prompt" record if there are no user lines. Used to
-// show a freshly-resumed session's latest prompt when no live in-memory prompt exists.
-export function latestUserPromptFromJsonl(raw: string): string | null {
-  let lastUser: string | null = null;
+// Ordered user-typed prompts in a transcript + the "last-prompt" fallback record.
+function collectPrompts(raw: string): { prompts: string[]; lastPromptRecord: string | null } {
+  const prompts: string[] = [];
   let lastPromptRecord: string | null = null;
   for (const o of parseJsonl(raw)) {
     if (o.type === "user") {
       const prompt = userPromptText(isRecord(o.message) ? o.message.content : undefined);
-      if (prompt) lastUser = prompt;
+      if (prompt) prompts.push(prompt);
     } else if (o.type === "last-prompt" && o.lastPrompt) {
       lastPromptRecord = String(o.lastPrompt);
     }
   }
-  return lastUser ?? lastPromptRecord;
+  return { prompts, lastPromptRecord };
+}
+
+// The most recent user-typed prompt in a transcript: the last "user" line with real
+// text, falling back to a "last-prompt" record if there are no user lines.
+export function latestUserPromptFromJsonl(raw: string): string | null {
+  const { prompts, lastPromptRecord } = collectPrompts(raw);
+  return prompts[prompts.length - 1] ?? lastPromptRecord;
+}
+
+// A trivial prompt is an empty/one-word ack or a bare command ("ok", "merge", "はい")
+// that doesn't describe what a session is about. The cell header skips these so a
+// short follow-up doesn't hide the task. Matched case-insensitively after trimming
+// surrounding punctuation/whitespace.
+const TRIVIAL_PROMPT_MIN_LEN = 4; // < this many code points => trivial (catches ok / はい / マージ / yes)
+const TRIVIAL_PROMPT_WORDS = new Set([
+  // English acks / one-word commands (length >= MIN_LEN, so listed explicitly)
+  "okay",
+  "yep",
+  "yeah",
+  "sure",
+  "nope",
+  "next",
+  "done",
+  "stop",
+  "wait",
+  "merge",
+  "commit",
+  "push",
+  "continue",
+  "proceed",
+  "retry",
+  "again",
+  "good",
+  "nice",
+  "thanks",
+  // Japanese acks / one-word commands
+  "いいえ",
+  "マージ",
+  "コミット",
+  "プッシュ",
+  "続けて",
+  "つづけて",
+  "進めて",
+  "すすめて",
+  "やって",
+  "お願い",
+  "おねがい",
+  "お願いします",
+  "それで",
+  "よろしく",
+]);
+
+// Punctuation stripped from a prompt's edges before ack matching, so "ok." / "はい、"
+// match the list.
+const EDGE_PUNCT = new Set([".", "。", "!", "！", "?", "？", ",", "、"]);
+
+// Trim surrounding whitespace, then surrounding punctuation. Done with an explicit
+// edge scan (not a quantified regex) so it's clearly linear-time.
+function normalizeForAck(text: string): string {
+  const chars = [...text.trim().toLowerCase()];
+  let start = 0;
+  let end = chars.length;
+  while (start < end && EDGE_PUNCT.has(chars[start])) start++;
+  while (end > start && EDGE_PUNCT.has(chars[end - 1])) end--;
+  return chars.slice(start, end).join("").trim();
+}
+
+export function isTrivialPrompt(text: string): boolean {
+  const norm = normalizeForAck(text);
+  if (!norm) return true;
+  if (TRIVIAL_PROMPT_WORDS.has(norm)) return true;
+  return [...norm].length < TRIVIAL_PROMPT_MIN_LEN;
+}
+
+// Like latestUserPromptFromJsonl, but skips trivial acks and returns the most recent
+// SUBSTANTIAL prompt, so a resumed session's header shows the task instead of a
+// one-word follow-up. Falls back to the latest prompt (then the record) if every
+// prompt is trivial.
+export function latestMeaningfulUserPromptFromJsonl(raw: string): string | null {
+  const { prompts, lastPromptRecord } = collectPrompts(raw);
+  for (let i = prompts.length - 1; i >= 0; i--) {
+    if (!isTrivialPrompt(prompts[i])) return prompts[i];
+  }
+  return prompts[prompts.length - 1] ?? lastPromptRecord;
 }


### PR DESCRIPTION
## Summary

グリッドセルの header が、直近の **意味のある** user prompt を出すようにします。`ok` / `マージ` / `はい` のような簡素な指示が最後でも、そのセッションの本題が埋もれません。表示側（`TerminalCell.vue`）は変更なし — サーバが渡す `lastPrompt` を「意味のあるもの」にするだけ。

## Items to Confirm / Review
- **trivial 判定の閾値**: コードポイント長 **< 4** ＋ ack denylist（`ok`/`yes`/`merge`/`はい`/`マージ`/`続けて`/`お願いします` 等）。控えめにして `バグ直して`(5) のような短い日本語は残す方針。denylist の語彙が過不足ないか。
- **全部 trivial なセッション**: 最新（trivial）を出す（空表示にはしない）。
- **正規表現を使わない正規化**: sonarjs/slow-regex 回避のため、edge の空白/句読点除去は文字走査で実装（線形時間）。

## User Prompt
> 今、直近の user prompt を header に出しているけど、なにをやっているか要約をだすことはできないよね？
>
> 課題としては `ok` とか `マージ` とかの簡素な命令だとなにしているか分からないという欠点がある。文字数で filter して、短い場合はもっと古いのを参照すれば良い？
>
> → おすすめ（文字数フォールバック＋ack denylist 併用）で実装。

## 実装
- `server/transcript.ts`: `isTrivialPrompt`（ack denylist ＋ 長さ < 4）、`latestMeaningfulUserPromptFromJsonl`（新しい順に最初の非 trivial、無ければ最新→record）、`collectPrompts` に共通化
- `server/index.ts`: resume を meaningful 版に、ライブ UserPromptSubmit フックで trivial 上書き抑止（未設定時は設定）
- `server/transcript.spec.ts`: `isTrivialPrompt` / `latestMeaningfulUserPromptFromJsonl` のテスト

## 検証
- 全ゲート green: format / lint / typecheck(app+server) / build / **test 254 pass**
- **e2e 実測**: 末尾が `ok`/`マージ` のトランスクリプトで `/api/session` が本題（`Fix the parser bug...`）を返すことを確認

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)