### PR TITLE
fix: keep the cwd tail visible in cell headers

### DIFF
--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -30,7 +30,9 @@ function rerun() {
   <div class="cell">
     <div class="cell-header">
       <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Finished' : 'Running…'" />
-      <span v-if="dirDisplay" class="cell-dir" :title="command.cwd ?? ''">{{ dirDisplay }}</span>
+      <span v-if="dirDisplay" class="cell-dir" :title="command.cwd ?? ''"
+        ><span class="cell-dir-path">{{ dirDisplay }}</span></span
+      >
       <span class="cell-cmd">▶ {{ command.label }}</span>
       <span class="cell-actions">
         <button v-if="finished" class="cell-btn" title="Re-run" aria-label="Re-run command" @click="rerun">↻</button>
@@ -102,6 +104,11 @@ function rerun() {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* Truncate from the FRONT so the tail (the project dir) stays visible. */
+  direction: rtl;
+}
+.cell-dir-path {
+  unicode-bidi: plaintext;
 }
 .cell-cmd {
   flex: 1 1 auto;

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -97,6 +97,9 @@ function rerun() {
 
 .cell-dir {
   flex: 0 1 auto;
+  /* Floor the width at ~15 chars of the path so the current dir stays readable
+     even on a narrow cell (1ch ≈ one monospace char; the leading … takes one). */
+  min-width: 16ch;
   max-width: 45%;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 11px;
@@ -106,6 +109,8 @@ function rerun() {
   text-overflow: ellipsis;
   /* Truncate from the FRONT so the tail (the project dir) stays visible. */
   direction: rtl;
+  /* Left-align so a short path hugs the dot instead of floating right (rtl). */
+  text-align: left;
 }
 .cell-dir-path {
   unicode-bidi: plaintext;

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -293,7 +293,9 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
     <template v-if="launched">
       <div class="cell-header" :class="statusClass">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
-        <button v-if="dirDisplay" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">{{ dirDisplay }}</button>
+        <button v-if="dirDisplay" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
+          <span class="cell-dir-path">{{ dirDisplay }}</span>
+        </button>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <span class="cell-actions">
           <button
@@ -429,6 +431,13 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  /* Truncate from the FRONT so the tail (the project dir) stays visible: in an
+     rtl box the ellipsis falls on the left. The inner span keeps the path itself
+     in natural left-to-right order (plaintext base direction). */
+  direction: rtl;
+}
+.cell-dir-path {
+  unicode-bidi: plaintext;
 }
 .cell-dir:hover {
   color: var(--text-muted);

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -419,6 +419,9 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 
 .cell-dir {
   flex: 0 1 auto;
+  /* Floor the width at ~15 chars of the path so the current dir stays readable
+     even on a narrow cell (1ch ≈ one monospace char; the leading … takes one). */
+  min-width: 16ch;
   max-width: 60%;
   border: none;
   background: none;


### PR DESCRIPTION
## Summary
セルヘッダーの作業ディレクトリ表示が幅で切れるとき、`text-overflow: ellipsis`（末尾切り）のため肝心の最終ディレクトリ（プロジェクト名）が消えていました。`…` を先頭側に出すよう変更し、**suffix（どのディレクトリか）が常に見える**ようにします。

Before: `~/ss/llm/mulmot…` → After: `…/llm/mulmoterminal`

## Items to Confirm / Review
- **手法**: 切り詰める `.cell-dir` に `direction: rtl` を付けて `…` を行の論理末尾＝視覚的に左へ移動。さらに内側 `.cell-dir-path` に `unicode-bidi: plaintext` を付け、パス文字列自体は自然なLTR順で描画（これが無いと先頭の `~/` がbidiで末尾へ飛び `ss/llm/mulmoterminal~/` のように崩れる）。
- **⚠️ 実ブラウザでの描画確認が未実施**: 当セッションでPlaywright/ブラウザ自動操作ツールが使えず、`build`/`lint`/`typecheck`/`test` のみで確認しています。マージ前に実機リロードで、狭い幅のセルヘッダーがパスの末尾優先で表示されるか目視確認をお願いします（特に Safari でのbidi挙動）。
- 適用箇所: `TerminalCell.vue`（Claudeセッションのセル）と `CommandCell.vue`（script.json 実行セル）の両ヘッダー。

## User Prompt
> （スクリーンショット添付）header の file path、prefix が出ているけど suffix のどの dir かが重要。更新して直せる？
> text-overflow: ellipsis（末尾切り）の逆パターンがあればよいのだね。あるのかな。

## Verification
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`: pass（lint の警告は `server/open-dir.ts` の既存・無関係なもの）
- `yarn test`: 247 passed (27 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)