### PR TITLE
feat: 拡大時に全タブのターミナルを下のストリップへライブ表示

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ src/
     Terminal.vue      xterm.js terminal; /ws (or /ws/run) connection, reconnect
     GridView.vue      Grid toolbar (auto-layout, ＋ Terminal)
     TerminalCell.vue  A cell: Claude launcher (dir picker + resume + run-a-script)
-    TerminalGrid.vue  Grid of cells; auto-sizes by occupied count
+    TerminalGrid.vue  Grid of cells; auto-sizes by count; zoom lines up every tab
     CommandCell.vue   A grid cell that runs a script.json command (ephemeral)
   composables/
     usePubSub.ts      socket.io-client pub/sub composable (subscribe/unsubscribe)

--- a/plans/feat-zoom-strip-all-tabs.md
+++ b/plans/feat-zoom-strip-all-tabs.md
@@ -1,0 +1,56 @@
+# feat: 拡大(zoom)時に全タブのターミナルを下のストリップへライブ表示
+
+Issue: #95
+
+## 背景 / 現状
+
+- グリッドの cells は **1本のフラット配列**（`gridTabs.ts`）。タブ＝9個ずつの「ページ」slice。
+- 拡大(zoom)すると `TerminalGrid` は filmstrip 表示に切替（上=拡大セル、下=横スクロールのストリップ）。
+- `GridView` は `TerminalGrid` に **現ページの slice (`pageCells`) だけ**を渡すため、ストリップにも **現タブの9セルしか並ばない**。
+- 設計上、**アクティブページのみマウント**、他ページはサーバ側のバックグラウンドPTYとして生存し再表示時に再接続する（省リソース）。
+
+## ゴール
+
+拡大中だけ、下のストリップに **全タブ・全ターミナルをライブ表示**（横スクロール）。非拡大時は従来どおり現ページのみ。
+
+## 設計
+
+「描画するセル集合」を切り替えるだけで実現できる（フラット配列ゆえ単純なソース差し替え）。
+
+### `gridTabs.ts`（純粋関数を追加・テスト対象）
+
+```ts
+// 拡大中のセルの uid（cells に存在する場合）。なければ null。
+export function zoomedUid(state: GridState): number | null
+
+// 描画対象セル: 拡大中は全セル（全タブをストリップに）、非拡大時は現ページの slice。
+export function visibleCells(state: GridState): Cell[]
+```
+
+### `GridView.vue`
+
+- `pageExpanded` を `zoomedUid(state)` に置換。
+- `TerminalGrid` へ `:cells="visibleCells(state)"`、`:expanded-uid="zoomedUid(state)"`。
+- 拡大中はタブ意味が無いので、タブバーを隠す（`v-if="pages > 1 && zoomedUid === null"`）。
+
+### `TerminalGrid.vue`
+
+- ロジック変更なし（渡されたセルを描画。拡大セルは zoom-main へ teleport、残りはストリップ）。
+- `gridStyle` は `layoutForCount` が 9 超でも `Math.min(MAX_CELLS,…)` で安全。拡大中は `.stage.zoomed .grid` のCSSで grid-template が上書きされ未使用。
+- 先頭コメントを「拡大中は全タブのセルを受け取る」旨に更新。
+
+## トレードオフ
+
+- 拡大中は全ターミナル（最大81）の xterm + WebSocket が同時マウントされる。数が多いと重い。要望により上限は設けない（PR に明記）。
+- 拡大解除で `visibleCells` は現ページ slice に戻り、オフページのセルはアンマウント（既存の再接続セマンティクスを再利用）。
+
+## テスト
+
+- `gridTabs.spec.ts` に `zoomedUid` / `visibleCells` のユニットテストを追加
+  - 非拡大: 現ページ slice を返す
+  - 拡大: 全セルを返す / `expanded` が cells に無い場合は null & 現ページ slice
+  - ページ境界（2ページ目を拡大）
+
+## 確認ゲート
+
+`yarn format` / `lint` / `typecheck` / `build` / `test`。UI実機（拡大→全タブが下に並ぶ／横スクロール／クリックで切替）は手元で目視確認。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -12,7 +12,8 @@ import {
   switchPage,
   runCommand,
   pageCount,
-  pageSlice,
+  zoomedUid,
+  visibleCells,
   runningCount,
   STATE_KEY,
   LEGACY_KEY,
@@ -45,10 +46,11 @@ if (init.migrated) {
 watch(state, persist, { deep: true });
 
 const pages = computed(() => pageCount(state.value.cells.length));
-const pageCells = computed(() => pageSlice(state.value.cells, state.value.page));
-const pageExpanded = computed(() =>
-  state.value.expanded !== null && pageCells.value.some((c) => c.uid === state.value.expanded) ? state.value.expanded : null,
-);
+// While a cell is zoomed, render EVERY cell so the filmstrip lines up all tabs'
+// terminals (live); otherwise just the active page. The flat cells array makes
+// this a single source swap (see visibleCells/zoomedUid).
+const displayCells = computed(() => visibleCells(state.value));
+const expandedUid = computed(() => zoomedUid(state.value));
 // A launch cell is open beyond the sole entry cell (so "+ Terminal" cancels it). A
 // trailing command cell is occupied, not an open launcher.
 const launchOpen = computed(() => {
@@ -107,15 +109,15 @@ function closeSettings() {
       <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
       <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
     </header>
-    <nav v-if="pages > 1" class="tabbar" aria-label="Grid tabs">
+    <nav v-if="pages > 1 && expandedUid === null" class="tabbar" aria-label="Grid tabs">
       <button v-for="p in pages" :key="p" :class="['tab', { active: p - 1 === state.page }]" :aria-pressed="p - 1 === state.page" @click="switchTo(p - 1)">
         {{ p }}
       </button>
     </nav>
     <TerminalGrid
       class="main"
-      :cells="pageCells"
-      :expanded-uid="pageExpanded"
+      :cells="displayCells"
+      :expanded-uid="expandedUid"
       :default-cwd="defaultCwd"
       :presets="presets"
       :home="home"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -6,11 +6,12 @@ import { trackStyle, layoutForCount } from "./gridLayout";
 import type { Cell } from "./gridTabs";
 import type { CwdPreset } from "./presets";
 
-// Renders ONE page of the grid (≤9 cells), auto-sized to the cell count. The page
-// is fully controlled by GridView: `cells` is the page's slice and `expandedUid`
-// the zoomed cell (if it is on this page); every change is emitted up by uid.
+// Renders the grid, auto-sized to the cell count, fully controlled by GridView:
+// `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
+// the zoomed cell; every change is emitted up by uid.
 // Expanding a cell switches to a filmstrip — the zoomed cell (teleported to the
-// overlay) fills the top, the rest line up in a scrollable strip below.
+// overlay) fills the top, the rest line up in a scrollable strip below. While
+// zoomed, GridView passes EVERY cell (all tabs), so the strip shows them all live.
 // A cell carrying a `command` renders as a CommandCell (a running script.json
 // command) instead of the Claude launcher/terminal.
 const props = defineProps<{ cells: Cell[]; expandedUid: number | null; defaultCwd: string | null; presets: CwdPreset[]; home: string | null }>();

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -10,6 +10,8 @@ import {
   toggleExpand,
   switchPage,
   runCommand,
+  zoomedUid,
+  visibleCells,
   parseGridState,
   migrateLegacy,
   initialState,
@@ -134,6 +136,29 @@ describe("runCommand (script command cells)", () => {
   it("switchPage keeps a trailing command cell (only abandons an empty launcher)", () => {
     const after = switchPage(make([...running(9), cmdCell(9)], { page: 1 }), 0);
     expect(after.cells).toHaveLength(10);
+  });
+});
+
+describe("zoomedUid / visibleCells", () => {
+  it("zoomedUid returns the expanded uid, or null when nothing is zoomed", () => {
+    expect(zoomedUid(make(running(3)))).toBeNull();
+    expect(zoomedUid(make(running(3), { expanded: 1 }))).toBe(1);
+  });
+  it("zoomedUid is null when expanded points at a missing cell", () => {
+    expect(zoomedUid(make(running(2), { expanded: 99 }))).toBeNull();
+  });
+  it("visibleCells is the active page's slice when nothing is zoomed", () => {
+    const s = make(running(12)); // 2 pages
+    expect(visibleCells(s).map((c) => c.uid)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(visibleCells({ ...s, page: 1 }).map((c) => c.uid)).toEqual([9, 10, 11]);
+  });
+  it("visibleCells is the WHOLE list while a cell is zoomed (all tabs in the strip)", () => {
+    const s = make(running(12), { page: 1, expanded: 10 });
+    expect(visibleCells(s)).toHaveLength(12);
+  });
+  it("visibleCells falls back to the page slice when expanded is stale", () => {
+    const s = make(running(12), { page: 1, expanded: 99 });
+    expect(visibleCells(s).map((c) => c.uid)).toEqual([9, 10, 11]);
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -81,6 +81,15 @@ export function toggleExpand(state: GridState, uid: number): GridState {
   return { ...state, expanded: state.expanded === uid ? null : uid };
 }
 
+// The zoomed cell's uid, or null when nothing is zoomed (or `expanded` is stale —
+// points at a cell no longer in the list).
+export const zoomedUid = (state: GridState): number | null =>
+  state.expanded !== null && state.cells.some((c) => c.uid === state.expanded) ? state.expanded : null;
+
+// Cells to render: while a cell is zoomed, the WHOLE list (so the filmstrip lines
+// up every tab's terminal, live), otherwise just the active page's slice.
+export const visibleCells = (state: GridState): Cell[] => (zoomedUid(state) !== null ? state.cells : pageSlice(state.cells, state.page));
+
 // Switch page: drop an abandoned trailing launch cell first and clear the zoom
 // (zoom is scoped to a page). Selecting the already-active page is a no-op so it
 // doesn't discard the open launch cell or zoom.


### PR DESCRIPTION
## Summary
グリッドの拡大(zoom)時、下の filmstrip に **現在のタブの9セルだけ**でなく **全タブ・全ターミナルをライブ表示**（横スクロール）するようにします。cells は1本のフラット配列なので、拡大中だけ描画ソースを「全セル」に差し替えるだけで実現できます。

- 拡大中: `state.cells` 全体を `TerminalGrid` へ → ストリップに全タブが並ぶ（全ターミナルをマウントしてライブ）
- 非拡大時: 従来どおり現ページの slice のみ（アクティブページだけマウントの省リソース設計を維持）
- 拡大中はタブが無意味になるためタブバーを隠す

## Items to Confirm / Review
- **トレードオフ（要確認）**: 拡大中は全ターミナル（最大81）の xterm + WebSocket が**同時マウント**されます。数が多いと重くなる可能性あり。ご要望どおり上限は設けていません。
- **⚠️ UI実機未確認**: 当セッションでブラウザ自動操作ツールが使えず、`build`/`lint`/`typecheck`/`test` のみで確認。マージ前に「拡大→下に全タブが横並び／横スクロール／クリックで切替／拡大解除で元に戻る」の目視確認をお願いします。
- 拡大解除すると描画ソースが現ページ slice に戻り、オフページのセルはアンマウント（既存の再接続セマンティクスを再利用）。

## User Prompt
> 拡大viewのときにそのタブ内のterminalしか表示されないけど、array管理だから、全部を下にならべられるよね？
>
> （方針確認）拡大時の下ストリップに、どこまで並べる？ → **全タブ・全部ライブ表示**

## 実装
- `gridTabs.ts`: 純粋関数を追加（テスト対象）
  - `zoomedUid(state)` — 拡大中セルの uid（stale な場合は null）
  - `visibleCells(state)` — 拡大中は全セル、非拡大時は現ページ slice
- `GridView.vue`: `pageCells`/`pageExpanded` を `visibleCells`/`zoomedUid` に置換、拡大中はタブバー非表示
- `TerminalGrid.vue`: ロジック変更なし（コメントのみ更新）。`gridStyle` の `layoutForCount` は9超でも安全、拡大中はCSSで grid-template が上書きされ未使用
- テスト: `gridTabs.spec.ts` に `zoomedUid`/`visibleCells` を追加
- プラン: `plans/feat-zoom-strip-all-tabs.md`

Closes #95

## Verification
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`: pass（lint 警告は `server/open-dir.ts` の既存・無関係なもの）
- `yarn test`: **252 passed**（+5: zoomedUid / visibleCells）

🤖 Generated with [Claude Code](https://claude.com/claude-code)