### PR TITLE
feat: ターミナルヘッダーに ▶ Run プルダウン（開いているプロジェクトの script）

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ alongside the Claude sessions. Scripts are **per-directory**: the cell reads the
 `script.json` of whatever directory you select, so different cells can offer
 different projects' scripts.
 
+The grid toolbar also has a global **▶ Run ▾** dropdown. It lists the default
+workspace's (`CLAUDE_CWD`) scripts and launches the picked one in a **spare cell**
+(reusing an open launcher, else a new one) — so you can start a script without
+first opening an empty cell. For a different directory's scripts, use the cell
+launcher above.
+
 The list is populated from a **`script.json`** at the chosen directory's root. It's
 optional; a directory without one simply shows no scripts.
 
@@ -508,7 +514,8 @@ src/
     Sidebar.vue       Session list; working dot + waiting bold; pub/sub driven
     Sidebar.spec.ts   Vitest component tests
     Terminal.vue      xterm.js terminal; /ws (or /ws/run) connection, reconnect
-    GridView.vue      Grid toolbar (auto-layout, ＋ Terminal)
+    GridView.vue      Grid toolbar (auto-layout, ＋ Terminal, ▶ Run menu)
+    RunMenu.vue       Toolbar dropdown: run a script.json command in a spare cell
     TerminalCell.vue  A cell: Claude launcher (dir picker + resume + run-a-script)
     TerminalGrid.vue  Grid of cells; auto-sizes by count; zoom lines up every tab
     CommandCell.vue   A grid cell that runs a script.json command (ephemeral)

--- a/README.md
+++ b/README.md
@@ -186,12 +186,14 @@ alongside the Claude sessions. Scripts are **per-directory**: the cell reads the
 `script.json` of whatever directory you select, so different cells can offer
 different projects' scripts.
 
-The single view's terminal header also has a **▶ Run ▾** dropdown (next to the
-connection status). It lists the **open project's** `script.json` — the directory
-the connected session runs in — and launches the picked script in the grid, in a
-**spare cell** (reusing an open launcher, else a new one), switching to the grid so
-you can watch it. So you can start a dev server or tests for the project you're
-working in without leaving the single view.
+Every running terminal's header also has a **▶ Run ▾** dropdown (next to the
+connection status), in both the single view and each grid cell — but **only when the
+open project has scripts** (no `script.json`, no button). It lists the **open
+project's** `script.json` — the directory that terminal runs in — and launches the
+picked script in a **spare grid cell** (reusing an open launcher, else a new one),
+switching to the grid from the single view so you can watch it. So you can start a
+dev server or tests for the project you're working in without disturbing the
+session that's running.
 
 The list is populated from a **`script.json`** at the chosen directory's root. It's
 optional; a directory without one simply shows no scripts.

--- a/README.md
+++ b/README.md
@@ -186,11 +186,12 @@ alongside the Claude sessions. Scripts are **per-directory**: the cell reads the
 `script.json` of whatever directory you select, so different cells can offer
 different projects' scripts.
 
-The grid toolbar also has a global **▶ Run ▾** dropdown. It lists the default
-workspace's (`CLAUDE_CWD`) scripts and launches the picked one in a **spare cell**
-(reusing an open launcher, else a new one) — so you can start a script without
-first opening an empty cell. For a different directory's scripts, use the cell
-launcher above.
+The single view's terminal header also has a **▶ Run ▾** dropdown (next to the
+connection status). It lists the **open project's** `script.json` — the directory
+the connected session runs in — and launches the picked script in the grid, in a
+**spare cell** (reusing an open launcher, else a new one), switching to the grid so
+you can watch it. So you can start a dev server or tests for the project you're
+working in without leaving the single view.
 
 The list is populated from a **`script.json`** at the chosen directory's root. It's
 optional; a directory without one simply shows no scripts.
@@ -513,14 +514,15 @@ src/
   components/
     Sidebar.vue       Session list; working dot + waiting bold; pub/sub driven
     Sidebar.spec.ts   Vitest component tests
-    Terminal.vue      xterm.js terminal; /ws (or /ws/run) connection, reconnect
-    GridView.vue      Grid toolbar (auto-layout, ＋ Terminal, ▶ Run menu)
-    RunMenu.vue       Toolbar dropdown: run a script.json command in a spare cell
+    Terminal.vue      xterm.js terminal; /ws (or /ws/run); single-view ▶ Run menu
+    GridView.vue      Grid toolbar (auto-layout, ＋ Terminal); runs handed-off scripts
+    RunMenu.vue       ▶ Run dropdown: lists a dir's script.json, emits the pick
     TerminalCell.vue  A cell: Claude launcher (dir picker + resume + run-a-script)
     TerminalGrid.vue  Grid of cells; auto-sizes by count; zoom lines up every tab
     CommandCell.vue   A grid cell that runs a script.json command (ephemeral)
   composables/
     usePubSub.ts      socket.io-client pub/sub composable (subscribe/unsubscribe)
+    usePendingScript.ts  Hands a header-picked script to the grid to run
 vite.config.ts    Dev proxy for /ws (covers /ws/run), /ws/pubsub, /api
 vitest.config.ts  jsdom test environment
 ```

--- a/plans/feat-toolbar-run-menu.md
+++ b/plans/feat-toolbar-run-menu.md
@@ -1,46 +1,43 @@
-# feat: グリッドのツールバーに ▶ Run プルダウンを追加
+# feat: ターミナルヘッダーに ▶ Run プルダウン（開いているプロジェクトの script）
 
 Issue: #97
 
 ## 背景 / 現状
-- `script.json` の Run は **空きセルのランチャー内**（`TerminalCell` 未起動時の "or run a script"）にしか出ない。
-- 走っているセルからは script を起動できず、一度 ＋Terminal で空きセルを足す必要がある。
+- `script.json` の Run は「空きセルのランチャー」内にしか出ず、走っているセルからは起動できない。
+- script は **開いているプロジェクトに紐づく**べき（その端末の cwd の `script.json`）。デフォルトワークスペース（`CLAUDE_CWD`）ではない。
 
 ## ゴール
-グリッド上部ツールバーに **「▶ Run ▾」プルダウン** を置き、どの状態からでもデフォルト cwd の script を選んで **新しいセルで起動**できるようにする。
+単一ビューの**ターミナルヘッダー**（「Terminal connected」の隣）に **▶ Run ▾** を置き、**開いているプロジェクトの `script.json`** を一覧。選ぶとグリッドに切替えて**空きセル**でそのコマンドを起動する。
 
 ## 設計
 
-### 新規 `RunMenu.vue`（再利用可能なドロップダウン）
-- props: `cwd: string | null` — script を読むディレクトリ
-- emits: `run { index, label, cwd }` — 解決後 cwd（`/api/scripts` のレスポンス cwd）を載せる
-- 内部: 開いたときに `/api/scripts?cwd=<cwd>` を取得（request token で順序保証）。外側クリック / Esc で閉じる。スクリプト 0 件なら空表示。
-- 「▶ Run ▾」ボタン＋ドロップダウン list。
+### `RunMenu.vue`（再利用ドロップダウン）
+- props `cwd` の `/api/scripts` を開くたび取得し一覧。選択で `run { index, label, cwd }`（解決後 cwd）を emit。外側クリック / Esc で閉じる。
 
-### `gridTabs.ts`（純粋関数を追加・テスト対象）
-```ts
-// 空きセルで script を起動。末尾に空きランチャーがあれば再利用、なければ
-// 新しい command cell を append（上限 MAX_TERMINALS 厳守）。最後のページへ移動。
-export function runScriptInNewCell(state: GridState, command: NonNullable<Cell["command"]>): GridState
-```
+### `Terminal.vue`
+- `serverCwd` ref: 接続時にサーバ解決済み cwd（= 開いているプロジェクト）を保持。
+- prop `runMenu`（単一ビューのみ true）でヘッダーに `<RunMenu :cwd="serverCwd">` を表示。
+- `run` イベントを親へ re-emit。
+
+### `usePendingScript.ts`（単一ビュー → グリッドの受け渡し）
+- command cell はグリッドにしか存在しないため、選択を ref に stash → グリッドが mount 時に取り出して実行。
+- `requestRun(cmd)` / `takePending()`（取り出して clear）。
+
+### `App.vue`（単一ビュー）
+- `<TerminalView run-menu @run="onRunScript">`。
+- `onRunScript(cmd)` → `requestRun(cmd)` ＋ `viewMode = 'grid'`。
 
 ### `GridView.vue`
-- ツールバー（＋Terminal の隣）に `<RunMenu :cwd="defaultCwd" @run="onRunNew" />`。
-- `onRunNew(cmd)` → `state.value = runScriptInNewCell(state.value, cmd)`。
+- ツールバーの RunMenu は撤去（配置をヘッダーへ移動）。
+- onMounted で `takePending()` → あれば `runScriptInNewCell(state, cmd)`。
 
-## 起動先の方針
-- 常に**新しい / 空いているセル**で起動（現在のセルの Claude セッションは潰さない）。
-- 末尾が空きランチャーならそれを command cell に変える。
+### `gridTabs.ts`
+- `runScriptInNewCell(state, command)`: 末尾の空きランチャー再利用 or 新規 command cell を append（上限厳守）→ 最終ページへ。
 
 ## テスト
-- `gridTabs.spec.ts`: `runScriptInNewCell`
-  - 末尾が稼働セル → 新 command cell を append、最後のページへ
-  - 末尾が空きランチャー → それを再利用（append しない）
-  - 上限到達時は no-op
-- `RunMenu.spec.ts`: fetch をモックし、開く→一覧表示→クリックで `run` emit / 外側クリックで閉じる
-
-## ドキュメント
-- `README.md` の「Scripts (Run menu)」に、ツールバーの ▶ Run はデフォルト cwd の script を空きセルで起動する旨を追記。
+- `gridTabs.spec.ts`: `runScriptInNewCell`（append / 空きランチャー再利用 / 上限 no-op / ページ遷移）
+- `RunMenu.spec.ts`: 開く→一覧→選択で emit / 空表示 / 外側クリックで閉じる
+- `usePendingScript.spec.ts`: 受け渡し・1回で消費・最新優先
 
 ## 確認ゲート
-`yarn format` / `lint` / `typecheck` / `build` / `test`。UI実機（ツールバー▶Run→一覧→選択で新セル起動／外側クリックで閉じる）は手元で目視確認。
+`yarn format` / `lint` / `typecheck` / `build` / `test`。UI実機（単一ビューのヘッダー ▶Run → 開いているプロジェクトの script 一覧 → 選択でグリッドに切替＆空きセル起動）は手元で目視確認。

--- a/plans/feat-toolbar-run-menu.md
+++ b/plans/feat-toolbar-run-menu.md
@@ -1,0 +1,46 @@
+# feat: グリッドのツールバーに ▶ Run プルダウンを追加
+
+Issue: #97
+
+## 背景 / 現状
+- `script.json` の Run は **空きセルのランチャー内**（`TerminalCell` 未起動時の "or run a script"）にしか出ない。
+- 走っているセルからは script を起動できず、一度 ＋Terminal で空きセルを足す必要がある。
+
+## ゴール
+グリッド上部ツールバーに **「▶ Run ▾」プルダウン** を置き、どの状態からでもデフォルト cwd の script を選んで **新しいセルで起動**できるようにする。
+
+## 設計
+
+### 新規 `RunMenu.vue`（再利用可能なドロップダウン）
+- props: `cwd: string | null` — script を読むディレクトリ
+- emits: `run { index, label, cwd }` — 解決後 cwd（`/api/scripts` のレスポンス cwd）を載せる
+- 内部: 開いたときに `/api/scripts?cwd=<cwd>` を取得（request token で順序保証）。外側クリック / Esc で閉じる。スクリプト 0 件なら空表示。
+- 「▶ Run ▾」ボタン＋ドロップダウン list。
+
+### `gridTabs.ts`（純粋関数を追加・テスト対象）
+```ts
+// 空きセルで script を起動。末尾に空きランチャーがあれば再利用、なければ
+// 新しい command cell を append（上限 MAX_TERMINALS 厳守）。最後のページへ移動。
+export function runScriptInNewCell(state: GridState, command: NonNullable<Cell["command"]>): GridState
+```
+
+### `GridView.vue`
+- ツールバー（＋Terminal の隣）に `<RunMenu :cwd="defaultCwd" @run="onRunNew" />`。
+- `onRunNew(cmd)` → `state.value = runScriptInNewCell(state.value, cmd)`。
+
+## 起動先の方針
+- 常に**新しい / 空いているセル**で起動（現在のセルの Claude セッションは潰さない）。
+- 末尾が空きランチャーならそれを command cell に変える。
+
+## テスト
+- `gridTabs.spec.ts`: `runScriptInNewCell`
+  - 末尾が稼働セル → 新 command cell を append、最後のページへ
+  - 末尾が空きランチャー → それを再利用（append しない）
+  - 上限到達時は no-op
+- `RunMenu.spec.ts`: fetch をモックし、開く→一覧表示→クリックで `run` emit / 外側クリックで閉じる
+
+## ドキュメント
+- `README.md` の「Scripts (Run menu)」に、ツールバーの ▶ Run はデフォルト cwd の script を空きセルで起動する旨を追記。
+
+## 確認ゲート
+`yarn format` / `lint` / `typecheck` / `build` / `test`。UI実機（ツールバー▶Run→一覧→選択で新セル起動／外側クリックで閉じる）は手元で目視確認。

--- a/plans/feat-toolbar-run-menu.md
+++ b/plans/feat-toolbar-run-menu.md
@@ -12,7 +12,8 @@ Issue: #97
 ## 設計
 
 ### `RunMenu.vue`（再利用ドロップダウン）
-- props `cwd` の `/api/scripts` を開くたび取得し一覧。選択で `run { index, label, cwd }`（解決後 cwd）を emit。外側クリック / Esc で閉じる。
+- props `cwd` の `/api/scripts` を**マウント時／cwd変化時に先読み**し、件数で表示判定。**スクリプト0件（script.json 無し）ならボタン自体を出さない**。選択で `run { index, label, cwd }`（解決後 cwd）を emit。外側クリック / Esc で閉じる。
+- 設置: 単一ビュー（App.vue）＋グリッド各セル（TerminalCell）の端末ヘッダー。グリッドでは走っているセッションを潰さないため、選択は **別イベント `runSpare`** で空きセル起動（ランチャーの `run`＝このセルで起動 とは区別）。
 
 ### `Terminal.vue`
 - `serverCwd` ref: 接続時にサーバ解決済み cwd（= 開いているプロジェクト）を保持。

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ import { useShortcuts } from "./composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
 import { registerChatOpener } from "./composables/useChatLauncher";
 import { useAppConfig } from "./composables/useAppConfig";
+import { usePendingScript, type PendingCommand } from "./composables/usePendingScript";
 import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
 import type { Shortcut } from "./types/shortcuts";
@@ -23,6 +24,14 @@ import type { CwdPreset } from "./components/presets";
 type ViewMode = "single" | "grid";
 const viewMode = ref<ViewMode>(localStorage.getItem("view_mode") === "grid" ? "grid" : "single");
 watch(viewMode, (v) => localStorage.setItem("view_mode", v));
+
+// A script picked from the terminal header's Run menu runs in the grid (command
+// cells live only there): stash it and switch to the grid, which picks it up.
+const { requestRun } = usePendingScript();
+function onRunScript(command: PendingCommand) {
+  requestRun(command);
+  viewMode.value = "grid";
+}
 
 // Shared launcher favorites (pinned collections / feeds), backing the toolbar.
 const { shortcuts } = useShortcuts();
@@ -266,7 +275,9 @@ function onSession(id: string) {
           :style="{ flex: `0 0 ${terminalWidth}px` }"
           :session-id="activeId"
           :connect-key="connectKey"
+          run-menu
           @session="onSession"
+          @run="onRunScript"
         />
         <div
           class="splitter"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -2,7 +2,6 @@
 import { ref, computed, watch, onMounted } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
-import RunMenu from "./RunMenu.vue";
 import {
   initialState,
   addCell,
@@ -22,6 +21,7 @@ import {
   type GridState,
 } from "./gridTabs";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
+import { usePendingScript } from "../composables/usePendingScript";
 import type { CwdPreset } from "./presets";
 import { useAppConfig } from "../composables/useAppConfig";
 
@@ -68,8 +68,15 @@ const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, u
 const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
-const onRunNew = (command: { index: number; label: string; cwd: string | null }) => (state.value = runScriptInNewCell(state.value, command));
 const switchTo = (page: number) => (state.value = switchPage(state.value, page));
+
+// A script the single view's terminal-header Run menu handed off: run it in a spare
+// cell now that the grid (where command cells live) is mounted.
+const { takePending } = usePendingScript();
+onMounted(() => {
+  const command = takePending();
+  if (command) state.value = runScriptInNewCell(state.value, command);
+});
 
 // Server config: the default workspace dir + the user's directory presets.
 const { defaultCwd, home, presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets } = useAppConfig();
@@ -98,7 +105,6 @@ function closeSettings() {
       >
         ＋ Terminal
       </button>
-      <RunMenu :cwd="defaultCwd" @run="onRunNew" />
       <button
         class="tb-btn"
         :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
+import RunMenu from "./RunMenu.vue";
 import {
   initialState,
   addCell,
@@ -11,6 +12,7 @@ import {
   toggleExpand,
   switchPage,
   runCommand,
+  runScriptInNewCell,
   pageCount,
   zoomedUid,
   visibleCells,
@@ -66,6 +68,7 @@ const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, u
 const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
+const onRunNew = (command: { index: number; label: string; cwd: string | null }) => (state.value = runScriptInNewCell(state.value, command));
 const switchTo = (page: number) => (state.value = switchPage(state.value, page));
 
 // Server config: the default workspace dir + the user's directory presets.
@@ -95,6 +98,7 @@ function closeSettings() {
       >
         ＋ Terminal
       </button>
+      <RunMenu :cwd="defaultCwd" @run="onRunNew" />
       <button
         class="tb-btn"
         :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -68,6 +68,8 @@ const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, u
 const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
+// A running cell's header Run menu: launch in a spare cell so the session survives.
+const onRunSpare = (command: { index: number; label: string; cwd: string | null }) => (state.value = runScriptInNewCell(state.value, command));
 const switchTo = (page: number) => (state.value = switchPage(state.value, page));
 
 // A script the single view's terminal-header Run menu handed off: run it in a spare
@@ -134,6 +136,7 @@ function closeSettings() {
       @close="onClose"
       @toggle-expand="onToggleExpand"
       @run="onRun"
+      @run-spare="onRunSpare"
     />
     <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
   </div>

--- a/src/components/RunMenu.spec.ts
+++ b/src/components/RunMenu.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import RunMenu from "./RunMenu.vue";
+
+type Script = { index: number; label: string; command: string };
+
+// /api/scripts echoes back a resolved cwd (the server may fall back from a bad
+// path); the picked command must carry THAT cwd, not the requested one.
+function mockFetch(scripts: Script[], cwd = "/home/me/proj") {
+  globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ cwd, scripts }) })) as unknown as typeof fetch;
+}
+
+const SCRIPTS: Script[] = [
+  { index: 0, label: "Dev server", command: "yarn dev" },
+  { index: 1, label: "Unit tests", command: "yarn test" },
+];
+
+const mountMenu = () => mount(RunMenu, { props: { cwd: "/proj" } });
+
+describe("RunMenu", () => {
+  beforeEach(() => mockFetch(SCRIPTS));
+
+  it("is closed until the trigger is clicked", () => {
+    const w = mountMenu();
+    expect(w.find(".run-pop").exists()).toBe(false);
+  });
+
+  it("opens, fetches, and lists the directory's scripts", async () => {
+    const w = mountMenu();
+    await w.find(".run-trigger").trigger("click");
+    await flushPromises();
+    const items = w.findAll(".run-item");
+    expect(items).toHaveLength(2);
+    expect(items[0].text()).toContain("Dev server");
+  });
+
+  it("emits the picked script with the server-resolved cwd, then closes", async () => {
+    const w = mountMenu();
+    await w.find(".run-trigger").trigger("click");
+    await flushPromises();
+    await w.findAll(".run-item")[1].trigger("click");
+    expect(w.emitted("run")?.[0]?.[0]).toEqual({ index: 1, label: "Unit tests", cwd: "/home/me/proj" });
+    expect(w.find(".run-pop").exists()).toBe(false); // closed after picking
+  });
+
+  it("shows an empty hint when there are no scripts", async () => {
+    mockFetch([]);
+    const w = mountMenu();
+    await w.find(".run-trigger").trigger("click");
+    await flushPromises();
+    expect(w.find(".run-empty").text()).toContain("No scripts");
+    expect(w.findAll(".run-item")).toHaveLength(0);
+  });
+});

--- a/src/components/RunMenu.spec.ts
+++ b/src/components/RunMenu.spec.ts
@@ -15,40 +15,41 @@ const SCRIPTS: Script[] = [
   { index: 1, label: "Unit tests", command: "yarn test" },
 ];
 
-const mountMenu = () => mount(RunMenu, { props: { cwd: "/proj" } });
+const mountMenu = async () => {
+  const w = mount(RunMenu, { props: { cwd: "/proj" } });
+  await flushPromises(); // scripts fetch up front (decides whether the button shows)
+  return w;
+};
 
 describe("RunMenu", () => {
   beforeEach(() => mockFetch(SCRIPTS));
 
-  it("is closed until the trigger is clicked", () => {
-    const w = mountMenu();
-    expect(w.find(".run-pop").exists()).toBe(false);
+  it("shows the trigger once the project's scripts have loaded", async () => {
+    const w = await mountMenu();
+    expect(w.find(".run-trigger").exists()).toBe(true);
+    expect(w.find(".run-pop").exists()).toBe(false); // closed until clicked
   });
 
-  it("opens, fetches, and lists the directory's scripts", async () => {
-    const w = mountMenu();
+  it("renders nothing when the project has no scripts (no file, no button)", async () => {
+    mockFetch([]);
+    const w = await mountMenu();
+    expect(w.find(".run-trigger").exists()).toBe(false);
+    expect(w.find(".run-menu").exists()).toBe(false);
+  });
+
+  it("lists the scripts when opened", async () => {
+    const w = await mountMenu();
     await w.find(".run-trigger").trigger("click");
-    await flushPromises();
     const items = w.findAll(".run-item");
     expect(items).toHaveLength(2);
     expect(items[0].text()).toContain("Dev server");
   });
 
   it("emits the picked script with the server-resolved cwd, then closes", async () => {
-    const w = mountMenu();
+    const w = await mountMenu();
     await w.find(".run-trigger").trigger("click");
-    await flushPromises();
     await w.findAll(".run-item")[1].trigger("click");
     expect(w.emitted("run")?.[0]?.[0]).toEqual({ index: 1, label: "Unit tests", cwd: "/home/me/proj" });
     expect(w.find(".run-pop").exists()).toBe(false); // closed after picking
-  });
-
-  it("shows an empty hint when there are no scripts", async () => {
-    mockFetch([]);
-    const w = mountMenu();
-    await w.find(".run-trigger").trigger("click");
-    await flushPromises();
-    expect(w.find(".run-empty").text()).toContain("No scripts");
-    expect(w.findAll(".run-item")).toHaveLength(0);
   });
 });

--- a/src/components/RunMenu.spec.ts
+++ b/src/components/RunMenu.spec.ts
@@ -37,6 +37,15 @@ describe("RunMenu", () => {
     expect(w.find(".run-menu").exists()).toBe(false);
   });
 
+  it("does not fetch (no button) while cwd is unresolved, avoiding default-workspace scripts", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const w = mount(RunMenu, { props: { cwd: null } });
+    await flushPromises();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(w.find(".run-trigger").exists()).toBe(false);
+  });
+
   it("lists the scripts when opened", async () => {
     const w = await mountMenu();
     await w.find(".run-trigger").trigger("click");

--- a/src/components/RunMenu.spec.ts
+++ b/src/components/RunMenu.spec.ts
@@ -54,6 +54,21 @@ describe("RunMenu", () => {
     expect(items[0].text()).toContain("Dev server");
   });
 
+  it("closes when cwd changes and does not reappear pre-opened", async () => {
+    const w = await mountMenu();
+    await w.find(".run-trigger").trigger("click");
+    expect(w.find(".run-pop").exists()).toBe(true);
+
+    await w.setProps({ cwd: null }); // unresolved → cleared + closed
+    await flushPromises();
+    expect(w.find(".run-menu").exists()).toBe(false);
+
+    await w.setProps({ cwd: "/proj2" }); // resolves again
+    await flushPromises();
+    expect(w.find(".run-trigger").exists()).toBe(true);
+    expect(w.find(".run-pop").exists()).toBe(false); // not pre-opened
+  });
+
   it("emits the picked script with the server-resolved cwd, then closes", async () => {
     const w = await mountMenu();
     await w.find(".run-trigger").trigger("click");

--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -24,8 +24,16 @@ const rootRef = useTemplateRef<HTMLElement>("root");
 
 async function loadScripts() {
   const reqId = ++req;
+  const dir = props.cwd;
+  // No resolved project dir yet (e.g. a single-view reconnect before the session
+  // message arrives): show nothing rather than fetching with an empty cwd, which the
+  // server would resolve to the DEFAULT workspace — the wrong project's scripts.
+  if (!dir) {
+    scripts.value = [];
+    scriptsCwd.value = null;
+    return;
+  }
   try {
-    const dir = props.cwd ?? "";
     const res = await fetch(`/api/scripts?cwd=${encodeURIComponent(dir)}`);
     const data = res.ok ? await res.json() : { scripts: [], cwd: dir };
     if (reqId !== req) return;

--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { ref, onUnmounted, useTemplateRef } from "vue";
+
+// A toolbar dropdown that lists a directory's script.json entries and emits the one
+// picked, so the grid can launch it in a spare cell. Scripts are (re)fetched each
+// time the menu opens (the endpoint is cheap) so the list stays current.
+interface RunnableScript {
+  index: number;
+  label: string;
+  command: string;
+}
+const props = defineProps<{ cwd: string | null }>();
+const emit = defineEmits<{ (e: "run", command: { index: number; label: string; cwd: string | null }): void }>();
+
+const open = ref(false);
+const scripts = ref<RunnableScript[]>([]);
+const loading = ref(false);
+// The resolved dir the listed scripts belong to (the server may fall back from a
+// bad path); the picked command runs there.
+const scriptsCwd = ref<string | null>(null);
+let req = 0; // request token: drop out-of-order responses
+
+const rootRef = useTemplateRef<HTMLElement>("root");
+
+async function loadScripts() {
+  const reqId = ++req;
+  loading.value = true;
+  try {
+    const dir = props.cwd ?? "";
+    const res = await fetch(`/api/scripts?cwd=${encodeURIComponent(dir)}`);
+    const data = res.ok ? await res.json() : { scripts: [], cwd: dir };
+    if (reqId !== req) return;
+    scripts.value = Array.isArray(data.scripts) ? data.scripts : [];
+    scriptsCwd.value = data.cwd ?? dir;
+  } catch {
+    if (reqId === req) {
+      scripts.value = [];
+      scriptsCwd.value = null;
+    }
+  } finally {
+    if (reqId === req) loading.value = false;
+  }
+}
+
+function onOutside(e: PointerEvent) {
+  if (rootRef.value && !rootRef.value.contains(e.target as Node)) close();
+}
+function onEscape(e: KeyboardEvent) {
+  if (e.key === "Escape") close();
+}
+
+function openMenu() {
+  open.value = true;
+  loadScripts();
+  window.addEventListener("pointerdown", onOutside);
+  window.addEventListener("keydown", onEscape);
+}
+function close() {
+  open.value = false;
+  window.removeEventListener("pointerdown", onOutside);
+  window.removeEventListener("keydown", onEscape);
+}
+function toggle() {
+  if (open.value) close();
+  else openMenu();
+}
+
+function pick(s: RunnableScript) {
+  emit("run", { index: s.index, label: s.label, cwd: scriptsCwd.value ?? props.cwd });
+  close();
+}
+
+onUnmounted(close);
+</script>
+
+<template>
+  <div ref="root" class="run-menu">
+    <button class="run-trigger" :class="{ active: open }" :aria-expanded="open" aria-haspopup="menu" title="Run a script in a spare terminal" @click="toggle">
+      ▶ Run ▾
+    </button>
+    <div v-if="open" class="run-pop" role="menu">
+      <div v-if="loading" class="run-empty">Loading…</div>
+      <div v-else-if="!scripts.length" class="run-empty">No scripts (add a script.json)</div>
+      <button v-for="s in scripts" :key="s.index" class="run-item" role="menuitem" :title="s.command" @click="pick(s)">▶ {{ s.label }}</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.run-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Matches the grid toolbar buttons (.tb-btn lives in GridView's scoped styles). */
+.run-trigger {
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.run-trigger:hover,
+.run-trigger.active {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.run-pop {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  min-width: 180px;
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.run-item {
+  text-align: left;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.run-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.run-empty {
+  padding: 6px 8px;
+  color: var(--text-muted);
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, onUnmounted, useTemplateRef } from "vue";
+import { ref, onUnmounted, watch, useTemplateRef } from "vue";
 
-// A toolbar dropdown that lists a directory's script.json entries and emits the one
-// picked, so the grid can launch it in a spare cell. Scripts are (re)fetched each
-// time the menu opens (the endpoint is cheap) so the list stays current.
+// A header dropdown that lists a directory's script.json entries and emits the one
+// picked, so the parent can launch it. Scripts are fetched up front (and on cwd
+// change) so the button only appears when the open project actually has scripts —
+// no file, no button.
 interface RunnableScript {
   index: number;
   label: string;
@@ -14,7 +15,6 @@ const emit = defineEmits<{ (e: "run", command: { index: number; label: string; c
 
 const open = ref(false);
 const scripts = ref<RunnableScript[]>([]);
-const loading = ref(false);
 // The resolved dir the listed scripts belong to (the server may fall back from a
 // bad path); the picked command runs there.
 const scriptsCwd = ref<string | null>(null);
@@ -24,7 +24,6 @@ const rootRef = useTemplateRef<HTMLElement>("root");
 
 async function loadScripts() {
   const reqId = ++req;
-  loading.value = true;
   try {
     const dir = props.cwd ?? "";
     const res = await fetch(`/api/scripts?cwd=${encodeURIComponent(dir)}`);
@@ -37,10 +36,9 @@ async function loadScripts() {
       scripts.value = [];
       scriptsCwd.value = null;
     }
-  } finally {
-    if (reqId === req) loading.value = false;
   }
 }
+watch(() => props.cwd, loadScripts, { immediate: true });
 
 function onOutside(e: PointerEvent) {
   if (rootRef.value && !rootRef.value.contains(e.target as Node)) close();
@@ -51,7 +49,6 @@ function onEscape(e: KeyboardEvent) {
 
 function openMenu() {
   open.value = true;
-  loadScripts();
   window.addEventListener("pointerdown", onOutside);
   window.addEventListener("keydown", onEscape);
 }
@@ -74,13 +71,11 @@ onUnmounted(close);
 </script>
 
 <template>
-  <div ref="root" class="run-menu">
+  <div v-if="scripts.length" ref="root" class="run-menu">
     <button class="run-trigger" :class="{ active: open }" :aria-expanded="open" aria-haspopup="menu" title="Run a script in a spare terminal" @click="toggle">
       ▶ Run ▾
     </button>
     <div v-if="open" class="run-pop" role="menu">
-      <div v-if="loading" class="run-empty">Loading…</div>
-      <div v-else-if="!scripts.length" class="run-empty">No scripts (add a script.json)</div>
       <button v-for="s in scripts" :key="s.index" class="run-item" role="menuitem" :title="s.command" @click="pick(s)">▶ {{ s.label }}</button>
     </div>
   </div>
@@ -142,13 +137,5 @@ onUnmounted(close);
 .run-item:hover {
   background: var(--bg-hover);
   color: var(--text);
-}
-
-.run-empty {
-  padding: 6px 8px;
-  color: var(--text-muted);
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  white-space: nowrap;
 }
 </style>

--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -23,6 +23,10 @@ let req = 0; // request token: drop out-of-order responses
 const rootRef = useTemplateRef<HTMLElement>("root");
 
 async function loadScripts() {
+  // Close first: a cwd change invalidates the open dropdown (and would otherwise
+  // leave the global listeners attached and the menu re-appearing pre-opened on a
+  // later cwd, since the button can unmount while `open` stays true).
+  close();
   const reqId = ++req;
   const dir = props.cwd;
   // No resolved project dir yet (e.g. a single-view reconnect before the session

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -7,6 +7,7 @@ import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl, buildRunWsUrl } from "./wsUrl";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
 import { useTheme, currentTermTheme } from "../composables/useTheme";
+import RunMenu from "./RunMenu.vue";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
@@ -18,11 +19,27 @@ import { useTheme, currentTermTheme } from "../composables/useTheme";
 // `command` switches the terminal to a plain shell command (the grid's Run menu):
 // it connects to /ws/run with the script index instead of resuming a Claude
 // session, and never auto-reconnects (the ephemeral process can't be resumed).
-const props = defineProps<{ sessionId: string | null; connectKey: number; cwd?: string | null; devTerminal?: boolean; command?: { index: number } | null }>();
-const emit = defineEmits<{ (e: "session" | "cwd", value: string): void; (e: "exit"): void }>();
+// `runMenu` adds a ▶ Run dropdown to the header (the single view) that lists the
+// open project's script.json and emits the picked command for the parent to run.
+const props = defineProps<{
+  sessionId: string | null;
+  connectKey: number;
+  cwd?: string | null;
+  devTerminal?: boolean;
+  command?: { index: number } | null;
+  runMenu?: boolean;
+}>();
+const emit = defineEmits<{
+  (e: "session" | "cwd", value: string): void;
+  (e: "exit"): void;
+  (e: "run", command: { index: number; label: string; cwd: string | null }): void;
+}>();
 
 const terminalRef = ref<HTMLDivElement>();
 const status = ref<"connecting" | "connected" | "disconnected">("connecting");
+// The server-resolved cwd of the connected session (the open project), used by the
+// Run menu so it lists THAT directory's scripts. Falls back to the requested cwd.
+const serverCwd = ref<string | null>(props.cwd ?? null);
 const dragOver = ref(false);
 const { themeId } = useTheme();
 
@@ -101,7 +118,10 @@ function connect() {
       // back from the requested dir).
       knownSessionId = msg.id;
       emit("session", msg.id);
-      if (typeof msg.cwd === "string") emit("cwd", msg.cwd);
+      if (typeof msg.cwd === "string") {
+        serverCwd.value = msg.cwd;
+        emit("cwd", msg.cwd);
+      }
     } else if (msg.type === "exit") {
       // The process exited (claude, or a Run-menu command) — an intentional end;
       // don't auto-reconnect. The cell uses `exit` to offer a re-run.
@@ -293,6 +313,7 @@ onUnmounted(() => {
     <div class="header">
       <span class="title">Terminal</span>
       <span :class="['status', status]">{{ status }}</span>
+      <RunMenu v-if="runMenu" :cwd="serverCwd" @run="(c) => emit('run', c)" />
       <button type="button" class="pick-file" title="Insert a file path" aria-label="Insert a file path" @click="pickFile">
         <span class="material-symbols-outlined">attach_file</span>
       </button>

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -83,6 +83,9 @@ function connect() {
   term.reset();
   sawExit = false;
   status.value = "connecting";
+  // Drop the previous session's resolved cwd so the Run menu can't list/launch the
+  // prior project's scripts in the window before the new `session` message arrives.
+  serverCwd.value = props.cwd ?? null;
 
   // Resume the known id (learned from the server, or the prop) so a reconnect
   // re-attaches the same session instead of spawning a fresh one each retry.

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -23,7 +23,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "toggle-expand" | "close"): void;
   (e: "session" | "cwd", value: string): void;
-  (e: "run", value: { index: number; label: string; cwd: string | null }): void;
+  // `run` launches in THIS (empty) cell from the launcher; `runSpare` is the running
+  // terminal's header menu, which must NOT replace the session — it runs in a new cell.
+  (e: "run" | "runSpare", value: { index: number; label: string; cwd: string | null }): void;
 }>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
@@ -316,8 +318,10 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
         :connect-key="connectKey"
         :cwd="cwd"
         dev-terminal
+        run-menu
         @session="onSession"
         @cwd="onServerCwd"
+        @run="(cmd) => emit('runSpare', cmd)"
       />
     </template>
     <div v-else class="cell-launch">

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -19,6 +19,7 @@ const emit = defineEmits<{
   (e: "session" | "cwd", uid: number, value: string): void;
   (e: "close" | "toggle-expand", uid: number): void;
   (e: "run", uid: number, command: { index: number; label: string; cwd: string | null }): void;
+  (e: "runSpare", command: { index: number; label: string; cwd: string | null }): void;
 }>();
 
 const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length), null));
@@ -56,6 +57,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           @session="(id) => emit('session', cell.uid, id)"
           @cwd="(c) => emit('cwd', cell.uid, c)"
           @run="(cmd) => emit('run', cell.uid, cmd)"
+          @run-spare="(cmd) => emit('runSpare', cmd)"
           @close="emit('close', cell.uid)"
         />
       </Teleport>

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -10,6 +10,7 @@ import {
   toggleExpand,
   switchPage,
   runCommand,
+  runScriptInNewCell,
   zoomedUid,
   visibleCells,
   parseGridState,
@@ -136,6 +137,36 @@ describe("runCommand (script command cells)", () => {
   it("switchPage keeps a trailing command cell (only abandons an empty launcher)", () => {
     const after = switchPage(make([...running(9), cmdCell(9)], { page: 1 }), 0);
     expect(after.cells).toHaveLength(10);
+  });
+});
+
+describe("runScriptInNewCell (toolbar Run menu)", () => {
+  const CMD = { index: 1, label: "Dev server", cwd: "/x" };
+
+  it("appends a new command cell and jumps to its page when all cells are occupied", () => {
+    const s = runScriptInNewCell(make(running(2)), CMD);
+    expect(s.cells).toHaveLength(3);
+    expect(s.cells[2]).toMatchObject({ session: null, command: CMD });
+    expect(s.page).toBe(0); // 3 cells -> still page 1
+  });
+  it("overflows onto a new page when the current page is full", () => {
+    const s = runScriptInNewCell(make(running(9)), CMD);
+    expect(s.cells).toHaveLength(10);
+    expect(s.page).toBe(1); // jumped to the new cell's page
+  });
+  it("reuses a trailing empty launcher instead of appending", () => {
+    const s = runScriptInNewCell(make([...running(2), cell(2)]), CMD); // trailing launch cell
+    expect(s.cells).toHaveLength(3);
+    expect(s.cells[2].command).toEqual(CMD);
+  });
+  it("turns the sole entry launch cell into a command cell", () => {
+    const s = runScriptInNewCell(make([cell(0)]), CMD);
+    expect(s.cells).toHaveLength(1);
+    expect(s.cells[0].command).toEqual(CMD);
+  });
+  it("is a no-op at the terminal cap (no trailing launcher to reuse)", () => {
+    const s = runScriptInNewCell(make(running(81)), CMD);
+    expect(s.cells).toHaveLength(81);
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -69,6 +69,20 @@ export function runCommand(state: GridState, uid: number, command: Cell["command
   return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, command } : c)) };
 }
 
+// The toolbar Run menu ran a script with no target cell: reuse a trailing empty
+// launcher if there is one, otherwise append a fresh command cell (respecting the
+// cap), and jump to its page so it's visible.
+export function runScriptInNewCell(state: GridState, command: NonNullable<Cell["command"]>): GridState {
+  const last = state.cells[state.cells.length - 1];
+  if (isLaunchCell(last)) {
+    const cells = state.cells.map((c, i) => (i === state.cells.length - 1 ? { ...c, command } : c));
+    return { ...state, cells, page: pageCount(cells.length) - 1 };
+  }
+  if (runningCount(state.cells) >= MAX_TERMINALS) return state;
+  const cells = [...state.cells, { uid: state.nextUid, session: null, cwd: null, command }];
+  return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1 };
+}
+
 // Close a cell: drop it and reflow the list (later cells pack forward across
 // pages), un-zoom if it was zoomed, keep an entry cell, and clamp the page.
 export function closeCell(state: GridState, uid: number): GridState {

--- a/src/composables/usePendingScript.spec.ts
+++ b/src/composables/usePendingScript.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { usePendingScript } from "./usePendingScript";
+
+const CMD = { index: 1, label: "Build", cwd: "/proj" };
+
+describe("usePendingScript", () => {
+  it("hands the requested command to the next taker, then clears it", () => {
+    const { requestRun, takePending } = usePendingScript();
+    requestRun(CMD);
+    expect(takePending()).toEqual(CMD);
+    expect(takePending()).toBeNull(); // consumed — not delivered twice
+  });
+
+  it("returns null when nothing is pending", () => {
+    const { takePending } = usePendingScript();
+    expect(takePending()).toBeNull();
+  });
+
+  it("keeps only the latest request when called repeatedly", () => {
+    const { requestRun, takePending } = usePendingScript();
+    requestRun(CMD);
+    requestRun({ ...CMD, label: "Test" });
+    expect(takePending()?.label).toBe("Test");
+  });
+});

--- a/src/composables/usePendingScript.ts
+++ b/src/composables/usePendingScript.ts
@@ -1,0 +1,22 @@
+import { ref } from "vue";
+
+export interface PendingCommand {
+  index: number;
+  label: string;
+  cwd: string | null;
+}
+
+// Hands a script picked from the single view's terminal header over to the grid
+// view: command cells live only in the grid, so the single view stashes the pick
+// here, switches to the grid, and the grid runs it in a spare cell on mount.
+const pending = ref<PendingCommand | null>(null);
+
+export function usePendingScript() {
+  const requestRun = (command: PendingCommand) => (pending.value = command);
+  const takePending = (): PendingCommand | null => {
+    const command = pending.value;
+    pending.value = null;
+    return command;
+  };
+  return { requestRun, takePending };
+}


### PR DESCRIPTION
## Summary
**走っている各ターミナルのヘッダー**（「Terminal connected」の隣）に **▶ Run ▾** プルダウンを追加します。単一ビューでも**グリッドの各セル**でも表示。**開いているプロジェクトの `script.json`**（その端末＝セッションの cwd）を一覧し、選んだスクリプトをグリッドの**空きセル**で起動します（単一ビューからはグリッドへ自動切替して出力を確認）。

**`script.json` が無い（スクリプト0件）の場合はボタン自体を出しません**（no file, no button）。

> 経緯: 初期はグリッド上部ツールバーのグローバルメニューでしたが、レビューで「script は開いているプロジェクトに紐づくべき／Terminal connected の横／各セルにも／ファイルが無ければボタン無し」とのフィードバックを反映し、配置と挙動を変更しました。

## Items to Confirm / Review
- **dir連動**: メニューは `Terminal.vue` がサーバから受け取る解決済み cwd（開いているプロジェクト）の `script.json` を読みます。例: このリポジトリを開いていれば `~/ss/llm/mulmoterminal/script.json`。`CLAUDE_CWD` ではありません。
- **表示条件**: スクリプトを先読みし、**0件ならボタン非表示**。接続後に cwd が確定してから出ます（接続前は cwd 未確定なので出ないことがあります）。
- **実行先**: command cell はグリッド専用。
  - 単一ビュー: `usePendingScript` でグリッドに受け渡し→空きセルで起動し、グリッドへ自動切替。
  - グリッドの走っているセル: `runSpare` イベントで**空きセル**起動（走っているセッションは潰さない。ランチャーの「or run a script」＝このセルで起動 とは別経路）。
- 適用範囲: TerminalCell（Claudeセッションのセル）＋単一ビュー。CommandCell（スクリプト実行セル）の内側ヘッダーには出していません。
- **⚠️ UI実機未確認**: ブラウザ自動操作ツールが使えず `build`/`lint`/`typecheck`/`test` のみ。マージ前に「各端末ヘッダーの ▶Run → 開いているプロジェクトの script 一覧 → 空きセル起動 / ファイル無しのプロジェクトではボタンが出ない」を目視確認お願いします。

## User Prompt
> Scripts (Run menu)って、terminalのheaderからpull downのメニューで呼び出せると便利だよね
> Terminal connected の横だよね？
> runのファイルは、開いているprojectに結びつくから、~/ss/llm/mulmoterminal/script.json をみてメニューに出すのが正しい
> グリッドの各セルヘッダーにも追加
> ファイルがない場合はボタンなしで良い

## 実装
- `RunMenu.vue`: cwd の `/api/scripts` を**先読み（mount/cwd変化時）**、0件ならボタン非表示。選択で `run {index,label,cwd}`（解決後cwd）を emit。外側クリック / Esc で閉じる。
- `Terminal.vue`: `serverCwd`（接続時のサーバ解決cwd）保持、`runMenu` prop でヘッダーに `<RunMenu>`、`run` を re-emit。
- `App.vue`（単一ビュー）: `run-menu` ＋ `@run` → `usePendingScript.requestRun` ＋ `viewMode='grid'`。
- `TerminalCell.vue`: 内側 `<TerminalView run-menu @run>` → `runSpare` で上へ。
- `TerminalGrid.vue`: `runSpare` を中継。
- `GridView.vue`: `onRunSpare` → `runScriptInNewCell`。onMounted で `usePendingScript.takePending` を消費。
- `gridTabs.ts`: `runScriptInNewCell`（空きランチャー再利用 or 新規 append、上限厳守）。
- `usePendingScript.ts`: 単一ビュー→グリッドの受け渡し。
- テスト: `gridTabs.spec.ts`(+5)、`RunMenu.spec.ts`(4)、`usePendingScript.spec.ts`(3)
- `README.md` 更新、プラン `plans/feat-toolbar-run-menu.md`

Closes #97

## Verification
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build`: pass（lint 警告は既存・無関係）
- `yarn test`: **264 passed**