### PR TITLE
feat: grid セルヘッダから GitHub を開くボタン

### DIFF
--- a/plans/feat-open-github.md
+++ b/plans/feat-open-github.md
@@ -1,0 +1,41 @@
+# feat: セルヘッダに GitHub を開くボタン
+
+作成日: 2026-06-22
+
+## User Prompt
+
+- いま、dir名をクリックするとdirが開くけど、githubボタンを追加してgithubも開きたい。githubで管理している場合。
+- ひょっとしたら top/issue/pr が開けるとよいかも。
+
+## ゴール
+
+グリッド表示のセルヘッダで、cwd が GitHub 管理下のリポジトリのとき、GitHub を開くボタンを追加する。
+ボタンから **リポジトリ top / Issues / Pull requests** を開けるようにする。
+
+## 現状
+
+- セルヘッダ（`TerminalCell.vue`）の dir 名ボタンが `POST /api/open-dir` を叩き、OS のファイルマネージャで dir を開く（`server/open-dir.ts`）。
+- 単一表示にはこの dir ボタンは無く、grid 専用。サーバに git 処理は未実装。
+
+## 設計
+
+### サーバ `server/gitRemote.ts`
+- `parseGithubWebUrl(remoteUrl): string | null` — git remote URL を GitHub Web URL に変換する純関数（SSH scp 形式 / ssh:// / https:// / git:// 対応、github.com 以外は null）。単体テストしやすいよう純粋に保つ。
+- `resolveGithubUrl(dir): Promise<string|null>` — `git -C <dir> config --get remote.origin.url` を spawn（シェル無し）して取得し、上記でパース。git 未導入 / 非 git / origin 無し / 非 GitHub は null。
+- `mountGitRemoteRoute(app, { isAllowedOrigin })` — `POST /api/git-remote { path }` → `{ githubUrl }`。`open-dir` と同じ絶対パス検証 + 同一オリジンガード。
+
+### フロント `TerminalCell.vue`
+- `cwd` 変化（launch / サーバ確定 / 復元）を `watch(immediate)` し `/api/git-remote` を取得 → `githubUrl`。
+- `githubUrl` があるとき dir 名の隣に GitHub アイコン（インライン SVG, `currentColor`）ボタンを表示。
+- クリックで小さなポップオーバーを開き、**Repository / Issues / Pull requests** を `window.open`（`/issues`・`/pulls` はフロントで派生）。
+- ポップオーバーは外側クリック / Escape で閉じる。`role=menu` は宣言せず素の button 群（矢印キー契約を過剰宣言しない）。
+
+## 注意点
+- GitHub URL は http(s) なのでブラウザの `window.open` で開く（dir はファイルマネージャ＝サーバ経由だが、URL はブラウザで開ける）。
+- セキュリティ: `git` は固定コマンド、dir は `-C` で argv 渡し（シェル無し）、絶対パス + 実在検証。
+- 配色はテーマトークン（`var(--…)`）で統一（テーマ機能 merge 済み）。
+
+## 確認ポイント
+- GitHub リポジトリの cwd でのみボタンが出るか（非 GitHub・非 git で出ないこと）。
+- top / issues / pulls が正しい URL で開くか。
+- 明/暗テーマでアイコン・ポップオーバーが判読できるか。

--- a/server/gitRemote.spec.ts
+++ b/server/gitRemote.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { parseGithubWebUrl } from "./gitRemote.js";
+import type { Express } from "express";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseGithubWebUrl, resolveGithubUrl, mountGitRemoteRoute } from "./gitRemote.js";
 
 const REPO = "https://github.com/owner/repo";
 
@@ -45,5 +49,109 @@ describe("parseGithubWebUrl", () => {
     expect(parseGithubWebUrl("not a url")).toBeNull();
     expect(parseGithubWebUrl("https://github.com/owner")).toBeNull(); // no repo segment
     expect(parseGithubWebUrl("https://github.com/")).toBeNull();
+  });
+});
+
+describe("resolveGithubUrl", () => {
+  it("maps this repo's origin to its github.com URL", async () => {
+    expect(await resolveGithubUrl(process.cwd())).toMatch(/^https:\/\/github\.com\/[^/]+\/[^/]+$/);
+  });
+
+  it("returns null for a non-git directory", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "gitremote-"));
+    try {
+      expect(await resolveGithubUrl(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+interface FakeRes {
+  statusCode: number;
+  payload: unknown;
+  status(code: number): FakeRes;
+  json(body: unknown): FakeRes;
+}
+function makeRes(): FakeRes {
+  return {
+    statusCode: 200,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+  };
+}
+
+type RouteHandler = (req: { headers: { origin?: string }; body: unknown }, res: FakeRes) => unknown;
+
+// Capture the route's handler so it can be invoked with mock req/res — no HTTP
+// server needed (mirrors how the other server specs exercise units directly).
+function captureHandler(isAllowedOrigin: (o?: string) => boolean): RouteHandler {
+  let handler: RouteHandler | undefined;
+  const app = {
+    post(_path: string, h: RouteHandler) {
+      handler = h;
+    },
+  } as unknown as Express;
+  mountGitRemoteRoute(app, { isAllowedOrigin });
+  if (!handler) throw new Error("route was not mounted");
+  return handler;
+}
+
+function githubUrlOf(payload: unknown): string | null {
+  return payload && typeof payload === "object" && "githubUrl" in payload ? (payload as { githubUrl: string | null }).githubUrl : null;
+}
+
+const allow = () => true;
+const deny = () => false;
+
+describe("mountGitRemoteRoute (POST /api/git-remote)", () => {
+  it("rejects a disallowed origin with 403", async () => {
+    const res = makeRes();
+    await captureHandler(deny)({ headers: { origin: "https://evil.example" }, body: { path: process.cwd() } }, res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("requires an absolute path (400)", async () => {
+    const res = makeRes();
+    await captureHandler(allow)({ headers: {}, body: { path: "relative/dir" } }, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("404s a non-existent directory", async () => {
+    const res = makeRes();
+    await captureHandler(allow)({ headers: {}, body: { path: path.join(os.tmpdir(), "no-such-dir-xyz-123456") } }, res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("400s a path that exists but isn't a directory", async () => {
+    const res = makeRes();
+    await captureHandler(allow)({ headers: {}, body: { path: path.join(process.cwd(), "package.json") } }, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("returns the GitHub URL for a git repo", async () => {
+    const res = makeRes();
+    await captureHandler(allow)({ headers: {}, body: { path: process.cwd() } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(githubUrlOf(res.payload)).toMatch(/^https:\/\/github\.com\//);
+  });
+
+  it("returns githubUrl: null for a non-git directory", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "gitremote-"));
+    try {
+      const res = makeRes();
+      await captureHandler(allow)({ headers: {}, body: { path: dir } }, res);
+      expect(res.statusCode).toBe(200);
+      expect(githubUrlOf(res.payload)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/server/gitRemote.spec.ts
+++ b/server/gitRemote.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { parseGithubWebUrl } from "./gitRemote.js";
+
+const REPO = "https://github.com/owner/repo";
+
+describe("parseGithubWebUrl", () => {
+  it("maps scp-like SSH remotes", () => {
+    expect(parseGithubWebUrl("git@github.com:owner/repo.git")).toBe(REPO);
+    expect(parseGithubWebUrl("git@github.com:owner/repo")).toBe(REPO);
+  });
+
+  it("maps SSH URL remotes, including a port", () => {
+    expect(parseGithubWebUrl("ssh://git@github.com/owner/repo.git")).toBe(REPO);
+    expect(parseGithubWebUrl("ssh://git@github.com:22/owner/repo.git")).toBe(REPO);
+  });
+
+  it("maps HTTPS remotes, with or without .git and credentials", () => {
+    expect(parseGithubWebUrl("https://github.com/owner/repo.git")).toBe(REPO);
+    expect(parseGithubWebUrl("https://github.com/owner/repo")).toBe(REPO);
+    expect(parseGithubWebUrl("https://user:token@github.com/owner/repo.git")).toBe(REPO);
+  });
+
+  it("maps the git:// protocol", () => {
+    expect(parseGithubWebUrl("git://github.com/owner/repo.git")).toBe(REPO);
+  });
+
+  it("trims surrounding whitespace / trailing newline (git output)", () => {
+    expect(parseGithubWebUrl("  git@github.com:owner/repo.git\n")).toBe(REPO);
+  });
+
+  it("is case-insensitive on the host and strips only a trailing .git", () => {
+    expect(parseGithubWebUrl("git@GitHub.com:owner/repo.GIT")).toBe(REPO);
+    expect(parseGithubWebUrl("https://github.com/owner/repo.github.git")).toBe("https://github.com/owner/repo.github");
+  });
+
+  it("returns null for non-GitHub hosts", () => {
+    expect(parseGithubWebUrl("git@gitlab.com:owner/repo.git")).toBeNull();
+    expect(parseGithubWebUrl("https://bitbucket.org/owner/repo.git")).toBeNull();
+    expect(parseGithubWebUrl("git@github.example.com:owner/repo.git")).toBeNull(); // not github.com
+  });
+
+  it("returns null for empty, malformed, or under-specified remotes", () => {
+    expect(parseGithubWebUrl("")).toBeNull();
+    expect(parseGithubWebUrl("   ")).toBeNull();
+    expect(parseGithubWebUrl("not a url")).toBeNull();
+    expect(parseGithubWebUrl("https://github.com/owner")).toBeNull(); // no repo segment
+    expect(parseGithubWebUrl("https://github.com/")).toBeNull();
+  });
+});

--- a/server/gitRemote.ts
+++ b/server/gitRemote.ts
@@ -1,0 +1,79 @@
+import type { Express, Request } from "express";
+import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
+import path from "node:path";
+
+// Convert a git remote URL to its GitHub repository web URL, or null when the
+// remote isn't on github.com. Pure (no I/O) so it's exhaustively unit-tested.
+// Handles the common remote forms:
+//   git@github.com:owner/repo.git           (scp-like SSH)
+//   ssh://git@github.com[:port]/owner/repo  (SSH URL)
+//   https://[user[:token]@]github.com/owner/repo.git
+//   git://github.com/owner/repo.git
+export function parseGithubWebUrl(remoteUrl: string): string | null {
+  const url = remoteUrl.trim();
+  if (!url) return null;
+
+  // scp-like form has no scheme: user@host:path. Everything else (https/ssh/git
+  // URLs, with optional creds/port) is handled by the standard URL parser.
+  const scp = /^[^/@]+@([^/:]+):([^:]+)$/.exec(url);
+  const { host, rawPath } = scp ? { host: scp[1], rawPath: scp[2] } : fromUrl(url);
+  if (!host || host.toLowerCase() !== "github.com") return null;
+
+  const segments = rawPath
+    .replace(/\.git$/i, "")
+    .split("/")
+    .filter(Boolean);
+  if (segments.length < 2) return null;
+  return `https://github.com/${segments[0]}/${segments[1]}`;
+}
+
+function fromUrl(url: string): { host: string; rawPath: string } {
+  try {
+    const parsed = new URL(url);
+    return { host: parsed.hostname, rawPath: parsed.pathname.replace(/^\/+/, "") };
+  } catch {
+    return { host: "", rawPath: "" };
+  }
+}
+
+// Read the dir's `origin` remote and map it to a GitHub web URL (null if the dir
+// isn't a git repo, has no origin, git is missing, or origin isn't GitHub).
+export function resolveGithubUrl(dir: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' is a standard tool resolved from PATH in this local dev server; dir is passed via -C as a separate argv (no shell)
+    const child = spawn("git", ["-C", dir, "config", "--get", "remote.origin.url"], { stdio: ["ignore", "pipe", "ignore"] });
+    let out = "";
+    child.stdout.on("data", (chunk) => (out += chunk.toString()));
+    child.on("error", () => resolve(null)); // git not installed
+    child.on("close", () => resolve(parseGithubWebUrl(out)));
+  });
+}
+
+interface GitRemoteOptions {
+  isAllowedOrigin: (origin?: string) => boolean;
+}
+
+// POST /api/git-remote { path } -> { githubUrl: string | null }. Lets the browser
+// (which can't read the filesystem) learn whether a cell's working dir is a
+// GitHub repo, and where its repository page is. Same-origin guarded like the
+// other local-only routes.
+export function mountGitRemoteRoute(app: Express, { isAllowedOrigin }: GitRemoteOptions) {
+  app.post("/api/git-remote", async (req: Request, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).json({ error: "forbidden origin" });
+
+    const dir = isRecord(req.body) && typeof req.body.path === "string" ? req.body.path : "";
+    if (!dir || !path.isAbsolute(dir)) return res.status(400).json({ error: "absolute path required" });
+    try {
+      if (!statSync(dir).isDirectory()) return res.status(400).json({ error: "not a directory" });
+    } catch {
+      return res.status(404).json({ error: "directory not found" });
+    }
+
+    res.json({ githubUrl: await resolveGithubUrl(dir) });
+  });
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,7 @@ import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { isRecord, parseJsonl, userPromptText, latestUserPromptFromJsonl } from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
+import { mountGitRemoteRoute } from "./gitRemote.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
@@ -787,6 +788,10 @@ app.get("/api/scripts", (req, res) => {
 // GRID-ONLY (dev_tool): POST /api/open-dir reveals a cell's working directory in the
 // OS file manager (a browser tab can't, but this local server can).
 mountOpenDirRoute(app, { isAllowedOrigin });
+
+// GRID-ONLY (dev_tool): POST /api/git-remote reports a cell dir's GitHub repository
+// URL (null if it isn't a GitHub repo), so the header can offer an "open on GitHub" link.
+mountGitRemoteRoute(app, { isAllowedOrigin });
 
 // POST /api/pick-file opens the OS file dialog and returns the chosen absolute
 // path(s) — how a browser tab inserts a real filesystem path into the terminal

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -20,7 +20,7 @@ vi.mock("./Terminal.vue", () => ({
   default: {
     name: "TerminalView",
     props: ["sessionId", "connectKey", "cwd"],
-    emits: ["session"],
+    emits: ["session", "cwd"],
     template: '<div class="stub-term" />',
     methods: { terminate() {} },
   },
@@ -340,5 +340,36 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-gh-menu").exists()).toBe(true);
     await w.find(".cell-gh-menu").trigger("keydown", { key: "Escape" });
     expect(w.find(".cell-gh-menu").exists()).toBe(false);
+  });
+
+  it("ignores an out-of-order /api/git-remote response after a fast cwd change", async () => {
+    // dir A's lookup is in flight when the effective cwd switches to dir B; A
+    // then resolves LAST. The request-token guard must keep B's repo, not A's.
+    const repoA = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    const repoB = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    globalThis.fetch = vi.fn((url: string, init?: { body?: string }) => {
+      const u = String(url);
+      if (u.includes("/api/git-remote")) return String(init?.body ?? "").includes("/home/me/repoA") ? repoA.promise : repoB.promise;
+      if (u.includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+
+    const w = mountCell("33333333-3333-3333-3333-333333333333", { initialCwd: "/home/me/repoA" });
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/repoB"); // server confirms a different dir
+    await nextTick();
+
+    repoB.resolve({ ok: true, json: async () => ({ githubUrl: "https://github.com/owner/repoB" }) }); // newer resolves first
+    await flushPromises();
+    repoA.resolve({ ok: true, json: async () => ({ githubUrl: "https://github.com/owner/repoA" }) }); // older resolves last
+    await flushPromises();
+
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    await w.find(".cell-gh").trigger("click");
+    await w
+      .findAll(".cell-gh-item")
+      .find((b) => b.text() === "Repository")
+      ?.trigger("click");
+    expect(openSpy.mock.calls.at(-1)?.[0]).toBe("https://github.com/owner/repoB");
+    openSpy.mockRestore();
   });
 });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -277,4 +277,68 @@ describe("TerminalCell", () => {
     expect(promptText(w)).not.toBe("not mine");
     expect(dotClass(w)).toContain("is-idle");
   });
+
+  // The header's "open on GitHub" control: shown only when /api/git-remote
+  // reports a repository URL for the cell's dir.
+  function mockFetchWithGithub(githubUrl: string | null, ok = true) {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/git-remote")) return { ok, json: async () => ({ githubUrl }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+  }
+
+  it("shows the GitHub button when the dir is a GitHub repo", async () => {
+    mockFetchWithGithub("https://github.com/owner/repo");
+    const w = mountCell("33333333-3333-3333-3333-333333333333", { initialCwd: "/home/me/repo" });
+    await flushPromises();
+    expect(w.find(".cell-gh").exists()).toBe(true);
+  });
+
+  it("hides the GitHub button for a non-GitHub repo (null) and on lookup failure", async () => {
+    mockFetchWithGithub(null);
+    const a = mountCell("33333333-3333-3333-3333-333333333333", { initialCwd: "/home/me/repo" });
+    await flushPromises();
+    expect(a.find(".cell-gh").exists()).toBe(false);
+
+    mockFetchWithGithub("https://github.com/owner/repo", false); // res.ok = false
+    const b = mountCell("33333333-3333-3333-3333-333333333333", { initialCwd: "/home/me/repo" });
+    await flushPromises();
+    expect(b.find(".cell-gh").exists()).toBe(false);
+  });
+
+  it("opens repository / issues / pull requests from the popover", async () => {
+    mockFetchWithGithub("https://github.com/owner/repo");
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const w = mountCell("33333333-3333-3333-3333-333333333333", { initialCwd: "/home/me/repo" });
+    await flushPromises();
+
+    const openItem = async (label: string) => {
+      await w.find(".cell-gh").trigger("click");
+      const item = w.findAll(".cell-gh-item").find((b) => b.text() === label);
+      await item?.trigger("click");
+    };
+    await openItem("Repository");
+    await openItem("Issues");
+    await openItem("Pull requests");
+
+    expect(openSpy.mock.calls.map((c) => c[0])).toEqual([
+      "https://github.com/owner/repo",
+      "https://github.com/owner/repo/issues",
+      "https://github.com/owner/repo/pulls",
+    ]);
+    openSpy.mockRestore();
+  });
+
+  it("toggles the popover and closes it on Escape", async () => {
+    mockFetchWithGithub("https://github.com/owner/repo");
+    const w = mountCell("33333333-3333-3333-3333-333333333333", { initialCwd: "/home/me/repo" });
+    await flushPromises();
+    expect(w.find(".cell-gh-menu").exists()).toBe(false);
+    await w.find(".cell-gh").trigger("click");
+    expect(w.find(".cell-gh-menu").exists()).toBe(true);
+    await w.find(".cell-gh-menu").trigger("keydown", { key: "Escape" });
+    expect(w.find(".cell-gh-menu").exists()).toBe(false);
+  });
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -252,9 +252,11 @@ function onServerCwd(c: string) {
 const githubUrl = ref<string | null>(null);
 const ghMenuOpen = ref(false);
 const ghWrap = useTemplateRef<HTMLElement>("ghWrap");
+let githubReq = 0; // request token: drop out-of-order responses (cwd can change fast)
 
 async function refreshGithubUrl() {
   ghMenuOpen.value = false;
+  const reqId = ++githubReq;
   if (!cwd.value) {
     githubUrl.value = null;
     return;
@@ -265,10 +267,12 @@ async function refreshGithubUrl() {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ path: cwd.value }),
     });
+    if (reqId !== githubReq) return; // a newer cwd superseded this lookup
     const data = res.ok ? await res.json() : null;
+    if (reqId !== githubReq) return; // re-check after awaiting the body
     githubUrl.value = data && typeof data.githubUrl === "string" ? data.githubUrl : null;
   } catch {
-    githubUrl.value = null; // best-effort — the link just won't appear
+    if (reqId === githubReq) githubUrl.value = null; // best-effort — the link just won't appear
   }
 }
 watch(cwd, refreshGithubUrl, { immediate: true });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -245,6 +245,50 @@ function onServerCwd(c: string) {
   emit("cwd", c);
 }
 
+// "Open on GitHub": when this cell's dir is a GitHub repo, the server returns its
+// repository URL (null otherwise) and the header shows a popover linking to the
+// repo top page / Issues / Pull requests. Refreshed whenever the effective cwd
+// changes (launch, server-confirmed cwd, restore).
+const githubUrl = ref<string | null>(null);
+const ghMenuOpen = ref(false);
+const ghWrap = useTemplateRef<HTMLElement>("ghWrap");
+
+async function refreshGithubUrl() {
+  ghMenuOpen.value = false;
+  if (!cwd.value) {
+    githubUrl.value = null;
+    return;
+  }
+  try {
+    const res = await fetch("/api/git-remote", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: cwd.value }),
+    });
+    const data = res.ok ? await res.json() : null;
+    githubUrl.value = data && typeof data.githubUrl === "string" ? data.githubUrl : null;
+  } catch {
+    githubUrl.value = null; // best-effort — the link just won't appear
+  }
+}
+watch(cwd, refreshGithubUrl, { immediate: true });
+
+// Repository top page (""), Issues, or Pull requests — opened in a new tab.
+function openGithub(suffix: string) {
+  if (!githubUrl.value) return;
+  window.open(githubUrl.value + suffix, "_blank", "noopener,noreferrer");
+  ghMenuOpen.value = false;
+}
+
+function onGhOutside(e: MouseEvent) {
+  if (ghWrap.value && !ghWrap.value.contains(e.target as Node)) ghMenuOpen.value = false;
+}
+watch(ghMenuOpen, (open) => {
+  if (open) document.addEventListener("mousedown", onGhOutside);
+  else document.removeEventListener("mousedown", onGhOutside);
+});
+onUnmounted(() => document.removeEventListener("mousedown", onGhOutside));
+
 function close() {
   // Ask the server to reap this session immediately (don't hold it through the
   // disconnect grace window), then tear the cell down.
@@ -296,6 +340,29 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
         <button v-if="dirDisplay" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ dirDisplay }}</span>
         </button>
+        <span v-if="githubUrl" ref="ghWrap" class="cell-gh-wrap">
+          <button
+            type="button"
+            class="cell-gh"
+            title="Open on GitHub"
+            aria-label="Open on GitHub"
+            aria-haspopup="true"
+            :aria-expanded="ghMenuOpen"
+            @click="ghMenuOpen = !ghMenuOpen"
+          >
+            <svg class="cell-gh-icon" viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                fill-rule="evenodd"
+                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 4.6c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+              />
+            </svg>
+          </button>
+          <div v-if="ghMenuOpen" class="cell-gh-menu" @keydown.escape="ghMenuOpen = false">
+            <button type="button" class="cell-gh-item" @click="openGithub('')">Repository</button>
+            <button type="button" class="cell-gh-item" @click="openGithub('/issues')">Issues</button>
+            <button type="button" class="cell-gh-item" @click="openGithub('/pulls')">Pull requests</button>
+          </div>
+        </span>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <span class="cell-actions">
           <button
@@ -445,6 +512,63 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 .cell-dir:hover {
   color: var(--text-muted);
   text-decoration: underline;
+}
+.cell-gh-wrap {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+}
+.cell-gh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  border-radius: 4px;
+}
+.cell-gh:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.cell-gh-icon {
+  display: block;
+  width: 14px;
+  height: 14px;
+}
+.cell-gh-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 20;
+  margin-top: 4px;
+  min-width: 132px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+.cell-gh-item {
+  text-align: left;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.cell-gh-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
 }
 .cell-prompt {
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary

グリッド表示のセルヘッダで、cwd が GitHub リポジトリのとき **GitHub アイコン**を dir 名の隣に表示し、クリックで小ポップオーバーから **Repository / Issues / Pull requests** を新規タブで開けるようにしました。非 GitHub・非 git の dir ではボタンは出ません。

## Items to Confirm / Review

- **判定ロジック**: `parseGithubWebUrl`（純関数）が SSH(scp形式) / `ssh://` / `https://`(creds・port含む) / `git://` を GitHub Web URL に変換、`github.com` 以外は null。`server/gitRemote.spec.ts` に9ケース。
- **セキュリティ**: `git` は固定コマンド、dir は `-C <dir>` で argv 渡し（シェル無し）、絶対パス＋実在検証、同一オリジンガード（`/api/open-dir` と同作法）。
- **開く手段**: GitHub は http(s) なのでブラウザの `window.open`（dir はファイルマネージャ＝サーバ経由だが URL はブラウザで開ける）。Issues/PR は frontend で `/issues`・`/pulls` を派生。
- **ポップオーバーの a11y**: `role=menu` は宣言せず素の button 群（外側クリック / Escape で閉じる）。
- 配色はテーマトークン（`var(--…)`）に統一。

## User Prompt

- いま、dir名をクリックするとdirが開くけど、githubボタンを追加してgithubも開きたい。githubで管理している場合。
- ひょっとしたら top/issue/pr が開けるとよいかも。

## Implementation

- **`server/gitRemote.ts`**（新規）: `parseGithubWebUrl()`（純・テスト容易）、`resolveGithubUrl(dir)`（`git -C <dir> config --get remote.origin.url` を spawn してパース）、`mountGitRemoteRoute()`（`POST /api/git-remote { path }` → `{ githubUrl }`）。`server/index.ts` に登録。
- **`src/components/TerminalCell.vue`**: 実効 cwd 変化（launch / サーバ確定 / 復元）を watch して URL 取得。`githubUrl` があるとき GitHub アイコン（インライン SVG, `currentColor`）＋ポップオーバーを表示。

## Verification

- 単体: `parseGithubWebUrl` 9ケース（各URL形式・空・非GitHub・不正）。
- E2E(サーバ): 実リポジトリ → 正しい URL、非gitの `/tmp` → null。
- 実機(Puppeteer): grid で本リポジトリのセルを起動 → アイコン表示＋ポップオーバー3項目を確認。非GitHub cwd では非表示も確認。
- ゲート: `format / lint / typecheck(client+server) / build / test(255)` 全グリーン。

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)