### PR TITLE
feat: 通知音を設定で変えられるようにする（任意の音声ファイル・npm配布セーフ）

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ Example `.env` (gitignored):
 CLAUDE_CWD=/Users/you/my-project
 ```
 
+### UI settings (`~/.mulmoterminal/config.json`)
+
+The Settings modal (⚙) persists per-user UI choices to `~/.mulmoterminal/config.json`
+(read/written via `GET`/`POST /api/config`):
+
+| Field        | Meaning |
+| ------------ | ------- |
+| `cwdPresets` | Quick-pick directories offered when launching a terminal. |
+| `soundFile`  | Absolute path to a custom **attention sound** (played when a session needs attention). Empty/unset uses the built-in synthesized chime. |
+
+**Attention sound.** The default chime is generated with the Web Audio API — **no
+audio file is bundled**, so the npm package stays light and has no media-licensing
+concerns. To use your own sound, set `soundFile` in Settings (Browse / Test / Use
+chime) or in the config file; the server streams that file at `GET /api/sound` and
+the client decodes it (falling back to the chime if it's missing or not audio). It's
+your own local file referenced by absolute path — nothing is added to the package.
+
 ---
 
 ## Running

--- a/plans/feat-configurable-attention-sound.md
+++ b/plans/feat-configurable-attention-sound.md
@@ -1,0 +1,38 @@
+# feat: 通知音を設定で変えられるようにする（任意の音声ファイルパス）
+
+## User Prompt
+
+> terminal のサウンド、設定で変えられるようにしたい。npm での配布も気をつけてね。オーディオファイルなら同梱必要になるから。
+>
+> 設定ファイルで任意のファイルのパスを指定して、鳴らしてもよいけどね。
+
+## 方針
+
+現状の通知音は Web Audio で合成した2音チャイム（**アセットファイル無し**、`useAttentionSound.ts`）。
+これを**デフォルトのまま残し**、設定で**任意の音声ファイルのパス**を指定したらそれを鳴らす。
+
+- **npm 配布**: 音源を同梱しない（デフォルト＝合成、カスタム＝ユーザー自身のファイルの絶対パス）。
+  `package.json` の `files` 等は変更不要。バンドルもライセンスも無問題。
+
+## 変更
+
+### サーバ
+- `server/app-config.ts`（新規・テスト対象）: `~/.mulmoterminal/config.json` を `{ cwdPresets, soundFile }`
+  として読み書き（`sanitizePresets` 再利用、`sanitizeSoundFile`）。
+- `server/config-routes.ts`: app-config を使用。`GET /api/config` が `soundFile` を返す。`POST /api/config`
+  は `cwdPresets` / `soundFile` を部分更新。`GET /api/sound` … 設定された音声ファイルを配信（未設定/不在は 404）。
+- `server/app-config.spec.ts`: sanitize / load / save のテスト。
+
+### フロント
+- `composables/useAppConfig.ts`: `soundFile` ref を追加、保存を `cwdPresets` と `soundFile` 両対応に。
+- `composables/useAttentionSound.ts`: `soundFile` があれば `/api/sound?v=<path>` を Web Audio でデコードして再生
+  （unlock 済み AudioContext を流用、バッファをキャッシュ、パス変更で再読込）。失敗時は合成チャイムにフォールバック。
+- `App.vue`: `useAppConfig` の `soundFile` を `useAttentionSound` に渡す。
+- `components/SettingsModal.vue`: 「Notification sound」欄（パス入力＋ `/api/pick-file` で参照＋テスト再生＋クリア）。
+
+### ドキュメント
+- `README.md`: カスタム通知音（`soundFile`）の設定方法と「同梱なし＝npm 軽量」を明記。
+
+## 確認ポイント
+- デフォルトは合成チャイム（音源同梱なし）。カスタムはユーザーの絶対パス。
+- `/api/sound` はサーバ設定の path のみ配信（リクエストからパスを受け取らない＝traversal なし）。

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -7,12 +7,18 @@ import { sanitizeSoundFile, loadAppConfig, saveAppConfig } from "./app-config";
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 
 describe("sanitizeSoundFile", () => {
-  it("keeps a non-empty trimmed string, else null", () => {
+  it("keeps a non-empty trimmed ABSOLUTE path, else null", () => {
     expect(sanitizeSoundFile("  /a/b.wav ")).toBe("/a/b.wav");
     expect(sanitizeSoundFile("")).toBeNull();
     expect(sanitizeSoundFile("   ")).toBeNull();
     expect(sanitizeSoundFile(null)).toBeNull();
     expect(sanitizeSoundFile(42)).toBeNull();
+  });
+  it("rejects relative paths (absolute-only contract)", () => {
+    expect(sanitizeSoundFile("sound.wav")).toBeNull();
+    expect(sanitizeSoundFile("relative/path.wav")).toBeNull();
+    expect(sanitizeSoundFile("./a.wav")).toBeNull();
+    expect(sanitizeSoundFile("../a.wav")).toBeNull();
   });
 });
 

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { sanitizeSoundFile, loadAppConfig, saveAppConfig } from "./app-config";
+
+const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
+
+describe("sanitizeSoundFile", () => {
+  it("keeps a non-empty trimmed string, else null", () => {
+    expect(sanitizeSoundFile("  /a/b.wav ")).toBe("/a/b.wav");
+    expect(sanitizeSoundFile("")).toBeNull();
+    expect(sanitizeSoundFile("   ")).toBeNull();
+    expect(sanitizeSoundFile(null)).toBeNull();
+    expect(sanitizeSoundFile(42)).toBeNull();
+  });
+});
+
+describe("loadAppConfig / saveAppConfig", () => {
+  it("round-trips presets + soundFile through a file", () => {
+    const dir = tmp();
+    const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
+    expect(saveAppConfig(file, { cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav" })).toBe(true);
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav" });
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav" });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to empty presets + null sound for a missing file", () => {
+    const dir = tmp();
+    expect(loadAppConfig(path.join(dir, "none.json"))).toEqual({ cwdPresets: [], soundFile: null });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("sanitizes junk presets and a non-string sound on load", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }, "junk"], soundFile: 5 }));
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns defaults for invalid JSON", () => {
+    const dir = tmp();
+    const file = path.join(dir, "bad.json");
+    writeFileSync(file, "{ not json");
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [], soundFile: null });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("preserves the legacy presets-only shape (soundFile absent => null)", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }] }));
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -1,0 +1,41 @@
+// The app config persisted at ~/.mulmoterminal/config.json: the user's directory
+// presets plus an optional custom attention-sound file. Unified read/write so a
+// partial update (e.g. just the sound) never clobbers the other field. Extracted
+// from config-routes.ts so the sanitize/load/save logic is unit-testable.
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { sanitizePresets, type CwdPreset } from "./cwd-presets.js";
+
+export interface AppConfig {
+  cwdPresets: CwdPreset[];
+  // Absolute path to a user-supplied audio file played as the attention sound, or
+  // null to use the built-in synthesized chime (the default — no bundled asset).
+  soundFile: string | null;
+}
+
+// Keep only a non-empty string path; anything else clears the custom sound.
+export function sanitizeSoundFile(input: unknown): string | null {
+  return typeof input === "string" && input.trim() ? input.trim() : null;
+}
+
+export function loadAppConfig(file: string): AppConfig {
+  try {
+    if (!existsSync(file)) return { cwdPresets: [], soundFile: null };
+    const raw = JSON.parse(readFileSync(file, "utf8"));
+    return { cwdPresets: sanitizePresets(raw?.cwdPresets), soundFile: sanitizeSoundFile(raw?.soundFile) };
+  } catch {
+    return { cwdPresets: [], soundFile: null };
+  }
+}
+
+// Persist the whole config; returns false on any write failure so the caller can
+// surface it instead of reporting a false success.
+export function saveAppConfig(file: string, config: AppConfig): boolean {
+  try {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ cwdPresets: config.cwdPresets, soundFile: config.soundFile }, null, 2));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -13,9 +13,13 @@ export interface AppConfig {
   soundFile: string | null;
 }
 
-// Keep only a non-empty string path; anything else clears the custom sound.
+// Keep only a non-empty ABSOLUTE path; anything else (relative, blank, non-string)
+// clears the custom sound. Absolute-only matches the documented contract and stops
+// /api/sound from resolving a relative value against the server's cwd.
 export function sanitizeSoundFile(input: unknown): string | null {
-  return typeof input === "string" && input.trim() ? input.trim() : null;
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  return trimmed && path.isAbsolute(trimmed) ? trimmed : null;
 }
 
 export function loadAppConfig(file: string): AppConfig {

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -1,28 +1,48 @@
-// GET/POST /api/config — the default workspace dir + the user's directory presets
-// (persisted at ~/.mulmoterminal/config.json), shown/edited in the UI. Kept in its
-// own module (mounted from index.ts) so grid/preset work doesn't churn index.ts
-// and collide with unrelated server changes.
+// GET/POST /api/config — the default workspace dir, the user's directory presets,
+// and an optional custom attention-sound file (persisted at ~/.mulmoterminal/
+// config.json), shown/edited in the UI. GET /api/sound streams that sound file.
+// Kept in its own module (mounted from index.ts) so grid/preset work doesn't churn
+// index.ts and collide with unrelated server changes.
 import os from "node:os";
 import path from "node:path";
+import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
-import { loadPresets, savePresets, sanitizePresets, type CwdPreset } from "./cwd-presets.js";
+import { sanitizePresets } from "./cwd-presets.js";
+import { loadAppConfig, saveAppConfig, sanitizeSoundFile, type AppConfig } from "./app-config.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
-let cwdPresets: CwdPreset[] = loadPresets(CONFIG_FILE);
+let config: AppConfig = loadAppConfig(CONFIG_FILE);
 
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   app.get("/api/config", (_req, res) => {
-    res.json({ cwd: claudeCwd, cwdPresets, home: os.homedir() });
+    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, home: os.homedir() });
   });
 
   app.post("/api/config", (req, res) => {
     const body = req.body ?? {};
-    if (!Array.isArray(body.cwdPresets)) return res.status(400).json({ error: "cwdPresets must be an array" });
+    // Partial update: keep the field the request omits so saving the sound doesn't
+    // wipe the presets (and vice-versa). cwdPresets, when present, must be an array.
+    if (body.cwdPresets !== undefined && !Array.isArray(body.cwdPresets)) {
+      return res.status(400).json({ error: "cwdPresets must be an array" });
+    }
+    const next: AppConfig = {
+      cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : config.cwdPresets,
+      soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : config.soundFile,
+    };
     // Stage, persist, commit in-memory only on success — a failed write must not
-    // leave GET exposing presets that won't survive a restart.
-    const next = sanitizePresets(body.cwdPresets);
-    if (!savePresets(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist presets" });
-    cwdPresets = next;
-    res.json({ cwd: claudeCwd, cwdPresets });
+    // leave GET exposing values that won't survive a restart.
+    if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });
+    config = next;
+    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile });
+  });
+
+  // Stream the user's custom attention sound (their own file, set in config). The
+  // path comes from server-side config — never from the request — so there's no
+  // traversal surface. 404 when unset or the file is gone (the client then falls
+  // back to the built-in chime).
+  app.get("/api/sound", (_req, res) => {
+    const file = config.soundFile;
+    if (!file || !existsSync(file) || !statSync(file).isFile()) return res.status(404).end();
+    res.sendFile(path.resolve(file));
   });
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -49,7 +49,10 @@ const filter = ref<Filter>("all");
 // activity stream directly (same source as the cell status), independent of the
 // fetched list above.
 const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
-useAttentionSound(soundEnabled);
+// soundFile is a shared singleton in useAppConfig, so the player here sees changes
+// made from either view's settings modal (and loadConfig below hydrates it).
+const { soundFile } = useAppConfig();
+useAttentionSound(soundEnabled, soundFile);
 
 // Terminal column width (px), set by dragging the splitter between the terminal
 // and the GUI panel; the GUI panel absorbs whatever is left. Persisted across
@@ -119,7 +122,7 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (directory presets + theme), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets } = useAppConfig();
+const { presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets, saveSound } = useAppConfig();
 const showSettings = ref(false);
 onMounted(loadConfig);
 async function savePresets(next: CwdPreset[]) {
@@ -288,7 +291,16 @@ function onSession(id: string) {
     <!-- Full-screen collection browser; shown when the launcher / an index card / a
          ref hop opens it (driven by useCollectionBrowse). -->
     <CollectionsBrowseOverlay />
-    <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
+    <SettingsModal
+      v-if="showSettings"
+      :presets="presets"
+      :sound-file="soundFile"
+      :saving="savingSettings"
+      :error="settingsError"
+      @save="savePresets"
+      @update-sound="saveSound"
+      @close="closeSettings"
+    />
   </div>
 </template>
 

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -68,8 +68,18 @@ const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value,
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
 const switchTo = (page: number) => (state.value = switchPage(state.value, page));
 
-// Server config: the default workspace dir + the user's directory presets.
-const { defaultCwd, home, presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets } = useAppConfig();
+// Server config: the default workspace dir + the user's directory presets + sound.
+const {
+  defaultCwd,
+  home,
+  presets,
+  soundFile,
+  saving: savingSettings,
+  error: settingsError,
+  loadConfig,
+  savePresets: persistPresets,
+  saveSound,
+} = useAppConfig();
 const showSettings = ref(false);
 onMounted(loadConfig);
 
@@ -125,7 +135,16 @@ function closeSettings() {
       @toggle-expand="onToggleExpand"
       @run="onRun"
     />
-    <SettingsModal v-if="showSettings" :presets="presets" :saving="savingSettings" :error="settingsError" @save="savePresets" @close="closeSettings" />
+    <SettingsModal
+      v-if="showSettings"
+      :presets="presets"
+      :sound-file="soundFile"
+      :saving="savingSettings"
+      :error="settingsError"
+      @save="savePresets"
+      @update-sound="saveSound"
+      @close="closeSettings"
+    />
   </div>
 </template>
 

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -90,6 +90,28 @@ describe("SettingsModal", () => {
     expect(presets).toHaveLength(1); // edits are on a local copy
   });
 
+  it("shows the configured custom sound and emits update-sound on edit / clear", async () => {
+    const w = mount(SettingsModal, { props: { presets: [], soundFile: "/snd/alert.wav" } });
+    const field = w.find(".sound-field");
+    expect((field.element as HTMLInputElement).value).toBe("/snd/alert.wav");
+
+    await field.setValue("  /snd/new.mp3  ");
+    await field.trigger("change");
+    expect(w.emitted("update-sound")?.at(-1)?.[0]).toBe("/snd/new.mp3"); // trimmed
+
+    await clickBtn(w, (t) => t.includes("chime"));
+    expect(w.emitted("update-sound")?.at(-1)?.[0]).toBeNull(); // back to the chime
+  });
+
+  it("Browse fills the sound path from the OS file picker and applies it", async () => {
+    globalThis.fetch = (async () => ({ ok: true, json: async () => ({ paths: ["/picked/sound.ogg"] }) })) as unknown as typeof fetch;
+    const w = mount(SettingsModal, { props: { presets: [], soundFile: null } });
+    await clickBtn(w, (t) => t.includes("Browse"));
+    await Promise.resolve();
+    expect((w.find(".sound-field").element as HTMLInputElement).value).toBe("/picked/sound.ogg");
+    expect(w.emitted("update-sound")?.at(-1)?.[0]).toBe("/picked/sound.ogg");
+  });
+
   it("theme picker honors the radiogroup keyboard contract (arrows + roving tabindex)", async () => {
     const w = mountModal();
     const cards = () => w.findAll(".theme-card");

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -2,9 +2,46 @@
 import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
 import type { CwdPreset } from "./presets";
 import { useTheme } from "../composables/useTheme";
+import { previewAttention } from "../composables/useAttentionSound";
 
-const props = defineProps<{ presets: CwdPreset[]; saving?: boolean; error?: string | null }>();
-const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "close"): void }>();
+const props = defineProps<{ presets: CwdPreset[]; soundFile?: string | null; saving?: boolean; error?: string | null }>();
+const emit = defineEmits<{ (e: "save", presets: CwdPreset[]): void; (e: "update-sound", file: string | null): void; (e: "close"): void }>();
+
+// Custom attention sound, applied immediately (like the theme) — empty => the
+// built-in chime. The text box mirrors the saved value; Browse / typing apply it.
+const soundPath = ref(props.soundFile ?? "");
+watch(
+  () => props.soundFile,
+  (f) => (soundPath.value = f ?? ""),
+);
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+function applySound() {
+  emit("update-sound", soundPath.value.trim() || null);
+}
+function clearSound() {
+  soundPath.value = "";
+  emit("update-sound", null);
+}
+async function browseSound() {
+  try {
+    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" } });
+    if (!res.ok) return;
+    const data: unknown = await res.json();
+    const picked = isRecord(data) && Array.isArray(data.paths) && typeof data.paths[0] === "string" ? data.paths[0] : "";
+    if (picked) {
+      soundPath.value = picked;
+      applySound();
+    }
+  } catch {
+    // native dialog unavailable / canceled — leave the field as-is
+  }
+}
+// Preview the SAVED sound (apply first via Browse / blur), so it plays the file the
+// server actually serves at /api/sound; null plays the chime.
+function testSound() {
+  previewAttention(props.soundFile ?? null);
+}
 
 // Theme is applied immediately on click (independent of the Save button, which
 // only commits the directory presets).
@@ -110,6 +147,25 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           </span>
           <span class="theme-label">{{ t.label }}</span>
         </button>
+      </div>
+
+      <h3 class="section-title">Notification sound</h3>
+      <p class="hint">Played when a session needs attention. Leave empty for the built-in chime, or point to your own audio file.</p>
+      <div class="sound-row">
+        <input
+          v-model="soundPath"
+          class="field sound-field"
+          type="text"
+          placeholder="/absolute/path/to/sound.wav"
+          aria-label="Custom notification sound file"
+          spellcheck="false"
+          @change="applySound"
+        />
+        <button class="btn" type="button" @click="browseSound">Browse…</button>
+      </div>
+      <div class="sound-actions">
+        <button class="btn" type="button" title="Play the current sound" @click="testSound">▶ Test</button>
+        <button class="btn" type="button" :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</button>
       </div>
 
       <h3 class="section-title">Directory presets</h3>
@@ -281,6 +337,20 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 .empty {
   font-size: 12px;
   color: var(--text-dim);
+}
+.sound-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.sound-field {
+  flex: 1 1 auto;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+}
+.sound-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
 }
 .error {
   margin: 12px 0 0;

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -1,9 +1,15 @@
 import { ref } from "vue";
 import type { CwdPreset } from "../components/presets";
 
-// Server config (default workspace dir, home, directory presets) shared by both
-// the single view and the grid view so each can open the settings modal without
-// duplicating the fetch/save logic.
+// The custom attention-sound file is a SINGLETON ref shared across every
+// useAppConfig() caller — the beep player lives in the single view while the
+// settings modal can be opened from either view, so a change in one must reach the
+// other (each useAppConfig() otherwise has its own local refs).
+const soundFile = ref<string | null>(null);
+
+// Server config (default workspace dir, home, directory presets, custom sound)
+// shared by both the single view and the grid view so each can open the settings
+// modal without duplicating the fetch/save logic.
 export function useAppConfig() {
   const defaultCwd = ref<string | null>(null);
   const home = ref<string | null>(null);
@@ -19,13 +25,15 @@ export function useAppConfig() {
       defaultCwd.value = c.cwd ?? null;
       home.value = c.home ?? null;
       presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
+      soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
     } catch {
       // the app still works; presets are just unavailable
     }
   }
 
   // Returns whether the save succeeded so the caller can close the modal only on
-  // success (and keep the user's edits otherwise).
+  // success (and keep the user's edits otherwise). Posts only cwdPresets — the
+  // server keeps the other fields (the sound), so this never clobbers it.
   async function savePresets(next: CwdPreset[]): Promise<boolean> {
     saving.value = true;
     error.value = null;
@@ -46,5 +54,23 @@ export function useAppConfig() {
     }
   }
 
-  return { defaultCwd, home, presets, saving, error, loadConfig, savePresets };
+  // Persist just the custom attention sound (a file path, or null to use the chime).
+  // Applied immediately (like the theme), independent of the presets Save button.
+  async function saveSound(file: string | null): Promise<boolean> {
+    try {
+      const res = await fetch("/api/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ soundFile: file }),
+      });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      const c = await res.json();
+      soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return { defaultCwd, home, presets, soundFile, saving, error, loadConfig, savePresets, saveSound };
 }

--- a/src/composables/useAttentionSound.ts
+++ b/src/composables/useAttentionSound.ts
@@ -94,13 +94,16 @@ function loadCustomSound(soundFile: string): Promise<void> {
   customLoading = (async () => {
     const ctx = getCtx();
     if (!ctx) return;
+    let decoded: AudioBuffer | null = null;
     try {
       const res = await fetch(`/api/sound?v=${encodeURIComponent(soundFile)}`);
-      if (!res.ok) return;
-      customBuffer = await ctx.decodeAudioData(await res.arrayBuffer());
+      if (res.ok) decoded = await ctx.decodeAudioData(await res.arrayBuffer());
     } catch {
-      customBuffer = null; // unreadable / not audio — fall back to the chime
+      decoded = null; // unreadable / not audio — fall back to the chime
     }
+    // Only assign if this is still the selected sound: a slower load for a now-stale
+    // path (A→B switch) must not overwrite B's buffer.
+    if (customLoadedFor === soundFile) customBuffer = decoded;
   })();
   return customLoading;
 }

--- a/src/composables/useAttentionSound.ts
+++ b/src/composables/useAttentionSound.ts
@@ -1,4 +1,4 @@
-import { onUnmounted, type Ref } from "vue";
+import { onUnmounted, watch, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
 
 interface ActivityMsg {
@@ -80,15 +80,82 @@ function playAttentionSound() {
   }
 }
 
+// The user's custom sound, decoded once into an AudioBuffer (keyed by its path so a
+// settings change reloads it). The server streams the configured file at /api/sound;
+// a 404 / decode failure leaves the buffer null and we use the chime.
+let customBuffer: AudioBuffer | null = null;
+let customLoadedFor: string | null = null;
+let customLoading: Promise<void> | null = null;
+
+function loadCustomSound(soundFile: string): Promise<void> {
+  if (customLoadedFor === soundFile) return customLoading ?? Promise.resolve();
+  customLoadedFor = soundFile;
+  customBuffer = null;
+  customLoading = (async () => {
+    const ctx = getCtx();
+    if (!ctx) return;
+    try {
+      const res = await fetch(`/api/sound?v=${encodeURIComponent(soundFile)}`);
+      if (!res.ok) return;
+      customBuffer = await ctx.decodeAudioData(await res.arrayBuffer());
+    } catch {
+      customBuffer = null; // unreadable / not audio — fall back to the chime
+    }
+  })();
+  return customLoading;
+}
+
+function playBuffer(buf: AudioBuffer) {
+  const ctx = getCtx();
+  if (!ctx) return;
+  if (ctx.state === "suspended") ctx.resume().catch(() => {});
+  const src = ctx.createBufferSource();
+  const gain = ctx.createGain();
+  gain.gain.value = 0.6;
+  src.buffer = buf;
+  src.connect(gain).connect(ctx.destination);
+  src.start();
+}
+
+// Play the attention sound: the user's custom file when configured AND already
+// loaded, otherwise the built-in chime. A newly-configured file is loaded in the
+// background, so the first beep uses the chime and later ones the custom sound.
+export function playAttention(soundFile: string | null) {
+  if (soundFile) {
+    if (customLoadedFor !== soundFile) loadCustomSound(soundFile);
+    if (customBuffer && customLoadedFor === soundFile) {
+      playBuffer(customBuffer);
+      return;
+    }
+  }
+  playAttentionSound();
+}
+
+// Test-button variant: AWAIT the custom file's load so a just-configured sound is
+// actually heard (the live beep path stays synchronous and chime-first).
+export async function previewAttention(soundFile: string | null) {
+  if (soundFile) {
+    await loadCustomSound(soundFile);
+    if (customBuffer && customLoadedFor === soundFile) {
+      playBuffer(customBuffer);
+      return;
+    }
+  }
+  playAttentionSound();
+}
+
 // Beep when any session transitions into `waiting` (needs attention), across every
 // page/view, by listening to the same "sessions" activity stream the cells use — so
-// the beep tracks the amber header exactly. `enabled` gates it (the 🔔 toggle).
-export function useAttentionSound(enabled: Ref<boolean>) {
+// the beep tracks the amber header exactly. `enabled` gates it (the 🔔 toggle);
+// `soundFile`, when set, plays the user's chosen file instead of the chime.
+export function useAttentionSound(enabled: Ref<boolean>, soundFile?: Ref<string | null>) {
   armUnlock();
+  // Preload the custom sound whenever it's set/changed, so the first beep can use it.
+  if (soundFile) watch(soundFile, (f) => f && loadCustomSound(f), { immediate: true });
   const prev = new Map<string, ActivityState>();
   const { subscribe } = usePubSub();
   const unsubscribe = subscribe("sessions", (d) => {
-    if (isActivityMsg(d) && needsAttention(prev, d) && enabled.value) playAttentionSound();
+    if (isActivityMsg(d) && needsAttention(prev, d) && enabled.value) playAttention(soundFile?.value ?? null);
   });
   onUnmounted(unsubscribe);
 }


### PR DESCRIPTION
## Summary

通知音（attention sound）を**ユーザー任意の音声ファイル**にできるようにします。デフォルトは今までの Web Audio 合成チャイムのままなので、**音源は一切同梱しません** — npm パッケージは軽量のまま、メディアのライセンス問題もなし。カスタム音は「ユーザー自身のローカルファイルを絶対パスで参照」する方式です。

## Items to Confirm / Review

- **npm 配布**: バンドル音源ゼロ（`package.json` の `files` 変更なし）。デフォルト＝合成、カスタム＝ユーザーの絶対パス。
- **セキュリティ**: `GET /api/sound` が配信するパスは**サーバ設定（config.json）のみ**から取得し、リクエストからは受け取らない＝パストラバーサル面なし。未設定/不在は 404。
- **設定の保存**: `POST /api/config` を部分更新化（`cwdPresets` / `soundFile` の一方だけ送っても他方を保持）。`soundFile` は theme と同様**即時反映**。
- **再生経路**: 既存の unlock 済み AudioContext を流用して `/api/sound` をデコード再生（パスでキャッシュ、変更で再読込）。失敗時は合成チャイムにフォールバック。`soundFile` は両ビュー共有の singleton（grid 設定の変更が single view の再生にも届く）。
- **main マージ済み**: `feat/toolbar-run-menu`(#98) / `feat/open-github`(#100) 取り込み後のコンフリクト（GridView.vue 1ファイル）を解消済み。

## User Prompt

> terminal のサウンド、設定で変えられるようにしたい。npm での配布も気をつけてね。オーディオファイルなら同梱必要になるから。
>
> 設定ファイルで任意のファイルのパスを指定して、鳴らしてもよいけどね。

## 実装

**サーバ**
- `server/app-config.ts`（新規・テスト対象）: `{ cwdPresets, soundFile }` の統合 load/save（部分更新で他方を壊さない）、`sanitizeSoundFile`
- `server/config-routes.ts`: `GET/POST /api/config` が `soundFile` を扱う。`GET /api/sound` … 設定ファイルを配信（未設定/不在は 404）

**フロント**
- `composables/useAttentionSound.ts`: カスタム音をデコード再生（`playAttention` / Test 用 `previewAttention`）、失敗時チャイム
- `composables/useAppConfig.ts`: 共有 singleton `soundFile` ＋ 即時保存 `saveSound`
- `App.vue` / `GridView.vue`: `soundFile` を player と SettingsModal に配線
- `components/SettingsModal.vue`: 「Notification sound」欄（パス＋ Browse(`/api/pick-file`)＋ Test ＋ Use chime）

**テスト/ドキュメント**: `app-config.spec.ts`、`SettingsModal.spec.ts`（音 UI）、README に設定方法と「同梱なし」を明記。

## 検証
- 全ゲート green: format / lint / typecheck(app+server) / build / **test 305 pass**
- **e2e 実測**: config soundFile 往復・`/api/sound` 配信・部分更新で presets 保持・未設定 404
- **実機**: 実 mp3（`sound_gong.mp3`, 5.19s/48kHz）を設定 → ブラウザでデコード→再生成功、Settings 欄反映、**実音も確認済み**

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)