### PR TITLE
mulmoterminal@0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Release 0.3.0 (minor)

Version bump 0.2.0 → 0.3.0 for the npm release. All gates green (typecheck app+server / lint / build / **306 tests**); no `file:` deps, no debugger/TODO.

### Included since 0.2.0 (merged to main)
- **Grid script runner** — run `script.json` commands in a cell (#87), plus a **toolbar Run menu** that launches in a spare cell (#98)
- **Attention sound** — beep/header-tint when a session needs attention (#88), now with a **configurable custom sound file** in Settings (#102)
- **Meaningful prompt in the cell header** — skip trivial acks like `ok`/`merge` (#93)
- **Grid tabs / zoom filmstrip** refinements (#94, #96), **open in GitHub** (#100)
- **Dependency bumps**: puppeteer 25, @google/genai 2.9, material-symbols 0.45.2; dropped the unused js-yaml direct dep (#103)

🤖 Generated with [Claude Code](https://claude.com/claude-code)