### PR TITLE
feat: per-agent git worktree isolation (作成/再利用/掃除を自然に)

### DIFF
--- a/plans/feat-worktree-isolation.md
+++ b/plans/feat-worktree-isolation.md
@@ -1,0 +1,29 @@
+# feat: git worktree によるエージェント隔離（MVP=隔離）
+
+Issue: #106
+
+## 背景
+同一リポに複数セルを当てると作業ツリーを取り合って壊れる。ユーザーは今まで同一リポを手で複数 clone（重い・手で rm）。worktree 初体験でも自然に使えるよう、git 用語を出さず後始末を自動化する。
+
+## MVP スコープ（このPR）
+「隔離」だけ。diff→PR レビュー・node_modules戦略・自動cleanup（セルclose連動）・ブランチ表示は子issue。
+
+### サーバ
+- `server/worktrees.ts`（新規）: 純粋 helper（`slugify` / `parseWorktreeList` / `worktreesRoot` / `isManagedWorktree`）＋ git exec（`gitTopLevel` / `repoRoot` / `defaultBaseBranch` / `listWorktrees` / `createWorktree` / `removeWorktree` / `isDirty`）。
+  - 作成先は管理ディレクトリ `~/.mulmoterminal/worktrees/<repo>-<hash>/<task>`（リポ直下を汚さない）。`MULMOTERMINAL_HOME` で差し替え可（テストが実ホームを汚さないため）。
+  - **削除は管理ルート配下のパスのみ**許可（任意パス削除の防止）。dirty は force なしで拒否。手動削除は `worktree prune` で吸収。
+- `server/worktrees.spec.ts`: 純粋 helper＋一時 git リポでの作成/一覧/削除/dirty。
+- `server/worktree-routes.ts`（新規, index.ts に mount）: API。
+  - `GET /api/worktrees?cwd=<dir>`（isGit/base/一覧＋各 worktree の dirty）
+  - `POST /api/worktrees/create {repoDir, task}`（作成）
+  - `POST /api/worktrees/remove {repoDir, path, deleteBranch, force}`（削除＋prune。dirty/管理外は 409）
+  - DELETE ではなく POST：body をプロキシ越しでも確実に届けるため。mutation は origin チェック。
+- `server/worktree-routes.spec.ts`: origin ガード／バリデーション／作成→一覧→削除のライフサイクル。
+
+### フロント
+- `TerminalCell.vue` ランチャ: 選択 dir が git リポなら **「新規 worktree（タスク名）」** ＋ **既存作業部屋一覧（再利用 / 🗑削除：dirty は確認）**。
+- 起動: 既存 launch 経路で worktree パスを cwd に。表示はタスク名（部屋名）。
+
+## 確認ポイント
+- 用語は「作業部屋」。未コミットを黙って消さない。
+- 削除は管理ルート配下限定。git 未インストールでも他機能は動く（worktree UI は出さないだけ）。

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,6 +21,7 @@ import { buildClaudeArgs } from "./claude-args.js";
 import { isRecord, parseJsonl, userPromptText, latestMeaningfulUserPromptFromJsonl, preferredHeaderPrompt } from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
 import { mountGitRemoteRoute } from "./gitRemote.js";
+import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
@@ -810,6 +811,11 @@ mountOpenDirRoute(app, { isAllowedOrigin });
 // GRID-ONLY (dev_tool): POST /api/git-remote reports a cell dir's GitHub repository
 // URL (null if it isn't a GitHub repo), so the header can offer an "open on GitHub" link.
 mountGitRemoteRoute(app, { isAllowedOrigin });
+
+// GRID-ONLY (dev_tool): /api/worktrees — detect a git repo, list/create/remove the
+// per-agent worktrees a cell launches into, so several agents work one repo in
+// isolated working trees.
+mountWorktreeRoutes(app, { isAllowedOrigin });
 
 // POST /api/pick-file opens the OS file dialog and returns the chosen absolute
 // path(s) — how a browser tab inserts a real filesystem path into the terminal

--- a/server/worktree-routes.spec.ts
+++ b/server/worktree-routes.spec.ts
@@ -170,6 +170,20 @@ describe("worktree routes: create → list → remove lifecycle", () => {
     expect(res.payload).toEqual({ ok: false, reason: "not-managed" });
   });
 
+  it.skipIf(!hasGit)("treats a non-boolean force as false (no accidental force-delete of a dirty worktree)", async () => {
+    const r = routes(allow);
+    const created = makeRes();
+    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "wip" } }, created);
+    const wt = created.payload as { path: string };
+    writeFileSync(path.join(wt.path, "dirty.txt"), "x"); // make it dirty
+
+    // the string "false" is truthy in JS — strict validation must NOT force-remove
+    const res = makeRes();
+    await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path, force: "false", deleteBranch: "false" } }, res);
+    expect(res.statusCode).toBe(409);
+    expect(res.payload).toEqual({ ok: false, reason: "dirty" });
+  });
+
   it.skipIf(!hasGit)("500s an internal git failure (managed path, but not a registered worktree)", async () => {
     await createWorktree(repo, "real"); // makes the managed root dir exist
     const ghost = path.join(worktreesRoot(repo), "ghost"); // under the root, but no worktree there

--- a/server/worktree-routes.spec.ts
+++ b/server/worktree-routes.spec.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Express } from "express";
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { mountWorktreeRoutes } from "./worktree-routes.js";
+
+interface FakeRes {
+  statusCode: number;
+  payload: unknown;
+  status(code: number): FakeRes;
+  json(body: unknown): FakeRes;
+  end(): FakeRes;
+}
+function makeRes(): FakeRes {
+  return {
+    statusCode: 200,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+    end() {
+      return this;
+    },
+  };
+}
+
+type Handler = (req: { headers: { origin?: string }; query?: Record<string, unknown>; body?: unknown }, res: FakeRes) => unknown;
+
+// Capture the mounted handlers keyed by "METHOD path" so each can be invoked with
+// a mock req/res — no HTTP server needed (mirrors gitRemote.spec).
+function routes(isAllowedOrigin: (o?: string) => boolean): Record<string, Handler> {
+  const map: Record<string, Handler> = {};
+  const app = {
+    get(p: string, h: Handler) {
+      map[`GET ${p}`] = h;
+    },
+    post(p: string, h: Handler) {
+      map[`POST ${p}`] = h;
+    },
+  } as unknown as Express;
+  mountWorktreeRoutes(app, { isAllowedOrigin });
+  return map;
+}
+
+const allow = () => true;
+const deny = () => false;
+
+describe("worktree routes: origin guard + validation", () => {
+  it("rejects create and remove from a disallowed origin (403)", async () => {
+    const r = routes(deny);
+    const c = makeRes();
+    await r["POST /api/worktrees/create"]({ headers: { origin: "https://evil.example" }, body: { repoDir: "/x", task: "t" } }, c);
+    expect(c.statusCode).toBe(403);
+    const d = makeRes();
+    await r["POST /api/worktrees/remove"]({ headers: { origin: "https://evil.example" }, body: { repoDir: "/x", path: "/y" } }, d);
+    expect(d.statusCode).toBe(403);
+  });
+
+  it("400s create when the task is missing or blank", async () => {
+    const r = routes(allow);
+    const a = makeRes();
+    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: "/x" } }, a);
+    expect(a.statusCode).toBe(400);
+    const b = makeRes();
+    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: "/x", task: "   " } }, b);
+    expect(b.statusCode).toBe(400);
+  });
+
+  it("400s remove when repoDir or path is missing", async () => {
+    const r = routes(allow);
+    const res = makeRes();
+    await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: "/x" } }, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("reports isGit:false for a non-git dir", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wt-routes-plain-"));
+    try {
+      const res = makeRes();
+      await routes(allow)["GET /api/worktrees"]({ headers: {}, query: { cwd: dir } }, res);
+      expect(res.payload).toEqual({ isGit: false, base: null, worktrees: [] });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// Drive the real create → list → remove lifecycle through the HTTP handlers,
+// against a temp git repo with the managed root redirected to a temp dir.
+describe("worktree routes: create → list → remove lifecycle", () => {
+  let repo: string;
+  let home: string;
+  const hasGit = (() => {
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+      execFileSync("git", ["--version"], { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  beforeEach(() => {
+    home = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-home-")));
+    process.env.MULMOTERMINAL_HOME = home;
+    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-repo-")));
+    if (!hasGit) return;
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    const g = (...a: string[]) => execFileSync("git", ["-C", repo, ...a], { stdio: "ignore" });
+    g("init", "-b", "main");
+    g("config", "user.email", "t@t.t");
+    g("config", "user.name", "t");
+    writeFileSync(path.join(repo, "README.md"), "hi");
+    g("add", "-A");
+    g("commit", "-m", "init");
+  });
+  afterEach(() => {
+    delete process.env.MULMOTERMINAL_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it.skipIf(!hasGit)("creates, lists (with dirty), refuses a dirty remove, then force-removes", async () => {
+    const r = routes(allow);
+
+    const created = makeRes();
+    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "Fix Login" } }, created);
+    expect(created.statusCode).toBe(200);
+    const wt = created.payload as { path: string; branch: string };
+    expect(wt.branch).toBe("agent/fix-login");
+
+    const listed = makeRes();
+    await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, listed);
+    const body = listed.payload as { isGit: boolean; base: string; worktrees: { task: string; dirty: boolean }[] };
+    expect(body.isGit).toBe(true);
+    expect(body.worktrees).toEqual([{ path: wt.path, branch: "agent/fix-login", head: expect.any(String), task: "fix-login", dirty: false }]);
+
+    writeFileSync(path.join(wt.path, "new.txt"), "x");
+    const listed2 = makeRes();
+    await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, listed2);
+    expect((listed2.payload as { worktrees: { dirty: boolean }[] }).worktrees[0].dirty).toBe(true);
+
+    const refused = makeRes();
+    await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path } }, refused);
+    expect(refused.statusCode).toBe(409);
+    expect(refused.payload).toEqual({ ok: false, reason: "dirty" });
+
+    const removed = makeRes();
+    await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path, force: true, deleteBranch: true } }, removed);
+    expect(removed.statusCode).toBe(200);
+    expect(removed.payload).toEqual({ ok: true });
+
+    const empty = makeRes();
+    await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, empty);
+    expect((empty.payload as { worktrees: unknown[] }).worktrees).toEqual([]);
+  });
+
+  it.skipIf(!hasGit)("409s a remove of the main checkout (not under the managed root)", async () => {
+    const res = makeRes();
+    await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: repo } }, res);
+    expect(res.statusCode).toBe(409);
+    expect(res.payload).toEqual({ ok: false, reason: "not-managed" });
+  });
+});

--- a/server/worktree-routes.spec.ts
+++ b/server/worktree-routes.spec.ts
@@ -5,6 +5,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { mountWorktreeRoutes } from "./worktree-routes.js";
+import { createWorktree, worktreesRoot } from "./worktrees.js";
 
 interface FakeRes {
   statusCode: number;
@@ -167,5 +168,14 @@ describe("worktree routes: create → list → remove lifecycle", () => {
     await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: repo } }, res);
     expect(res.statusCode).toBe(409);
     expect(res.payload).toEqual({ ok: false, reason: "not-managed" });
+  });
+
+  it.skipIf(!hasGit)("500s an internal git failure (managed path, but not a registered worktree)", async () => {
+    await createWorktree(repo, "real"); // makes the managed root dir exist
+    const ghost = path.join(worktreesRoot(repo), "ghost"); // under the root, but no worktree there
+    const res = makeRes();
+    await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: ghost } }, res);
+    expect(res.statusCode).toBe(500);
+    expect(res.payload).toEqual({ ok: false, reason: "failed" });
   });
 });

--- a/server/worktree-routes.ts
+++ b/server/worktree-routes.ts
@@ -42,7 +42,10 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
     if (typeof repoDir !== "string" || typeof worktreePath !== "string") {
       return res.status(400).json({ error: "repoDir and path are required" });
     }
-    const result = await removeWorktree(repoDir, worktreePath, { deleteBranch: !!deleteBranch, force: !!force });
+    // Strict `=== true` (not `!!`) for the destructive flags: a mistyped truthy
+    // payload (e.g. the string "false") must fall back to the SAFE default — never
+    // force-remove a dirty worktree or delete a branch on a malformed request.
+    const result = await removeWorktree(repoDir, worktreePath, { deleteBranch: deleteBranch === true, force: force === true });
     if (result.ok) return res.json(result);
     res.status(result.reason === "failed" ? 500 : 409).json(result);
   });

--- a/server/worktree-routes.ts
+++ b/server/worktree-routes.ts
@@ -33,8 +33,9 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
     res.json(wt);
   });
 
-  // Remove a managed worktree. 409 when it's dirty (no force) or not under our root,
-  // so the UI can re-confirm with `force`.
+  // Remove a managed worktree. 409 for a client-resolvable conflict (dirty → the UI
+  // re-confirms with `force`; not-managed → a bad path), 500 for an internal git
+  // failure the client can't fix by retrying.
   app.post("/api/worktrees/remove", async (req, res) => {
     if (!isAllowedOrigin(req.headers.origin)) return res.status(403).end();
     const { repoDir, path: worktreePath, deleteBranch, force } = req.body ?? {};
@@ -42,6 +43,7 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
       return res.status(400).json({ error: "repoDir and path are required" });
     }
     const result = await removeWorktree(repoDir, worktreePath, { deleteBranch: !!deleteBranch, force: !!force });
-    res.status(result.ok ? 200 : 409).json(result);
+    if (result.ok) return res.json(result);
+    res.status(result.reason === "failed" ? 500 : 409).json(result);
   });
 }

--- a/server/worktree-routes.ts
+++ b/server/worktree-routes.ts
@@ -1,0 +1,47 @@
+// HTTP routes for per-agent git worktree isolation (see worktrees.ts). The launcher
+// uses these to detect a git repo, list/reuse existing worktrees, and create/remove
+// them. Mutations are same-origin guarded like the other local-only routes; remove
+// uses POST (not DELETE) so a request body survives every proxy.
+import type { Express } from "express";
+import { repoRoot, defaultBaseBranch, listWorktrees, createWorktree, removeWorktree, isDirty } from "./worktrees.js";
+
+interface WorktreeRouteOptions {
+  isAllowedOrigin: (origin?: string) => boolean;
+}
+
+export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeRouteOptions): void {
+  // Repo status + the managed worktrees for a cell's chosen dir (each with `dirty`
+  // so the UI can confirm before deleting). A non-git dir is `isGit:false`, not an
+  // error — the launcher just hides the worktree UI.
+  app.get("/api/worktrees", async (req, res) => {
+    const cwd = typeof req.query.cwd === "string" ? req.query.cwd : "";
+    const repo = cwd ? await repoRoot(cwd) : null;
+    if (!repo) return res.json({ isGit: false, base: null, worktrees: [] });
+    const list = await listWorktrees(repo);
+    const worktrees = await Promise.all(list.map(async (w) => ({ ...w, dirty: await isDirty(w.path) })));
+    res.json({ isGit: true, base: await defaultBaseBranch(repo), worktrees });
+  });
+
+  app.post("/api/worktrees/create", async (req, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).end();
+    const { repoDir, task } = req.body ?? {};
+    if (typeof repoDir !== "string" || typeof task !== "string" || !task.trim()) {
+      return res.status(400).json({ error: "repoDir and a non-empty task are required" });
+    }
+    const wt = await createWorktree(repoDir, task);
+    if (!wt) return res.status(500).json({ error: "could not create the worktree (is this a git repo?)" });
+    res.json(wt);
+  });
+
+  // Remove a managed worktree. 409 when it's dirty (no force) or not under our root,
+  // so the UI can re-confirm with `force`.
+  app.post("/api/worktrees/remove", async (req, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).end();
+    const { repoDir, path: worktreePath, deleteBranch, force } = req.body ?? {};
+    if (typeof repoDir !== "string" || typeof worktreePath !== "string") {
+      return res.status(400).json({ error: "repoDir and path are required" });
+    }
+    const result = await removeWorktree(repoDir, worktreePath, { deleteBranch: !!deleteBranch, force: !!force });
+    res.status(result.ok ? 200 : 409).json(result);
+  });
+}

--- a/server/worktrees.spec.ts
+++ b/server/worktrees.spec.ts
@@ -1,9 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, realpathSync, symlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { symlinkSync } from "node:fs";
 import { slugify, parseWorktreeList, worktreesRoot, isManagedWorktree, gitTopLevel, createWorktree, listWorktrees, isDirty, removeWorktree } from "./worktrees";
 
 describe("slugify", () => {
@@ -102,6 +101,16 @@ describe("git worktree lifecycle", () => {
     if (!a || !b) throw new Error("expected two worktrees");
     expect(a.branch).toBe("agent/task");
     expect(b.branch).toBe("agent/task-2");
+  });
+
+  it.skipIf(!hasGit)("allocates distinct branches for CONCURRENT creates of the same task (no TOCTOU collision)", async () => {
+    const isWt = (r: { path: string; branch: string } | null): r is { path: string; branch: string } => r !== null;
+    const results = (
+      await Promise.all([createWorktree(repo, "race"), createWorktree(repo, "race"), createWorktree(repo, "race"), createWorktree(repo, "race")])
+    ).filter(isWt);
+    expect(results).toHaveLength(4); // none failed with a branch-already-exists 500
+    expect(new Set(results.map((r) => r.branch)).size).toBe(4); // all distinct
+    expect(new Set(results.map((r) => r.path)).size).toBe(4);
   });
 
   it.skipIf(!hasGit)("refuses to remove a path outside the managed root", async () => {

--- a/server/worktrees.spec.ts
+++ b/server/worktrees.spec.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync, realpathSync } from "no
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { symlinkSync } from "node:fs";
 import { slugify, parseWorktreeList, worktreesRoot, isManagedWorktree, gitTopLevel, createWorktree, listWorktrees, isDirty, removeWorktree } from "./worktrees";
 
 describe("slugify", () => {
@@ -106,6 +107,22 @@ describe("git worktree lifecycle", () => {
   it.skipIf(!hasGit)("refuses to remove a path outside the managed root", async () => {
     expect(await removeWorktree(repo, repo)).toEqual({ ok: false, reason: "not-managed" });
     expect(await removeWorktree(repo, path.join(home, "outside-managed"))).toEqual({ ok: false, reason: "not-managed" });
+  });
+
+  it.skipIf(!hasGit)("rejects a symlink under the managed root that escapes it (no string-prefix bypass)", async () => {
+    const wt = await createWorktree(repo, "real"); // creates the managed root dir
+    if (!wt) throw new Error("expected a worktree");
+    const root = worktreesRoot(repo);
+    const outside = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-outside-")));
+    const link = path.join(root, "escape");
+    symlinkSync(outside, link); // <root>/escape -> /outside (canonicalizes out of the root)
+    try {
+      expect(isManagedWorktree(repo, link)).toBe(false);
+      expect(isManagedWorktree(repo, path.join(link, "wt"))).toBe(false); // symlinked ancestor, absent leaf
+      expect(await removeWorktree(repo, link)).toEqual({ ok: false, reason: "not-managed" });
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it("gitTopLevel returns null for a non-repo dir", async () => {

--- a/server/worktrees.spec.ts
+++ b/server/worktrees.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, realpathSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { slugify, parseWorktreeList, worktreesRoot, isManagedWorktree, gitTopLevel, createWorktree, listWorktrees, isDirty, removeWorktree } from "./worktrees";
+
+describe("slugify", () => {
+  it("makes a filesystem-safe slug, with a fallback", () => {
+    expect(slugify("  Fix Login Bug! ")).toBe("fix-login-bug");
+    expect(slugify("Fix: ログイン bug")).toBe("fix-bug"); // non-ascii dropped
+    expect(slugify("")).toBe("task");
+    expect(slugify("***")).toBe("task");
+    expect(slugify("a".repeat(80))).toHaveLength(40);
+  });
+});
+
+describe("parseWorktreeList", () => {
+  it("parses porcelain blocks (path/head/branch, detached)", () => {
+    const raw = ["worktree /repo", "HEAD aaa", "branch refs/heads/main", "", "worktree /repo/wt", "HEAD bbb", "detached", ""].join("\n");
+    expect(parseWorktreeList(raw)).toEqual([
+      { path: "/repo", head: "aaa", branch: "main" },
+      { path: "/repo/wt", head: "bbb", branch: null },
+    ]);
+  });
+});
+
+describe("worktreesRoot / isManagedWorktree", () => {
+  it("keys the root by basename + a stable hash and guards membership", () => {
+    const root = worktreesRoot("/work/myapp");
+    expect(path.basename(root)).toMatch(/^myapp-[0-9a-f]{8}$/);
+    expect(worktreesRoot("/other/myapp")).not.toBe(root); // same basename, different path
+    expect(isManagedWorktree("/work/myapp", path.join(root, "fix"))).toBe(true);
+    expect(isManagedWorktree("/work/myapp", "/work/myapp")).toBe(false); // the main checkout
+    expect(isManagedWorktree("/work/myapp", "/etc/passwd")).toBe(false);
+  });
+});
+
+// Integration: a real temp git repo, with the managed root redirected to a temp dir.
+describe("git worktree lifecycle", () => {
+  let repo: string;
+  let home: string;
+  const hasGit = (() => {
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+      execFileSync("git", ["--version"], { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  beforeEach(() => {
+    // realpath: git resolves symlinks (macOS /tmp -> /private/var), and the engine
+    // keys the managed root off git's toplevel, so the test dirs must match that.
+    home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-home-")));
+    process.env.MULMOTERMINAL_HOME = home;
+    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-repo-")));
+    if (!hasGit) return;
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    const g = (...a: string[]) => execFileSync("git", ["-C", repo, ...a], { stdio: "ignore" });
+    g("init", "-b", "main");
+    g("config", "user.email", "t@t.t");
+    g("config", "user.name", "t");
+    writeFileSync(path.join(repo, "README.md"), "hi");
+    g("add", "-A");
+    g("commit", "-m", "init");
+  });
+  afterEach(() => {
+    delete process.env.MULMOTERMINAL_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it.skipIf(!hasGit)("creates, lists, detects dirty, and removes a worktree", async () => {
+    expect(await gitTopLevel(repo)).toBe(repo);
+
+    const wt = await createWorktree(repo, "Fix Login");
+    if (!wt) throw new Error("expected a worktree");
+    expect(wt.branch).toBe("agent/fix-login");
+    expect(existsSync(wt.path)).toBe(true);
+    expect(isManagedWorktree(repo, wt.path)).toBe(true);
+
+    const list = await listWorktrees(repo);
+    expect(list.map((w) => w.branch)).toEqual(["agent/fix-login"]); // excludes the main checkout
+
+    expect(await isDirty(wt.path)).toBe(false);
+    writeFileSync(path.join(wt.path, "new.txt"), "x");
+    expect(await isDirty(wt.path)).toBe(true);
+
+    // a dirty worktree is refused without force, then removed with force + branch
+    expect(await removeWorktree(repo, wt.path)).toEqual({ ok: false, reason: "dirty" });
+    expect(await removeWorktree(repo, wt.path, { force: true, deleteBranch: true })).toEqual({ ok: true });
+    expect(existsSync(wt.path)).toBe(false);
+    expect(await listWorktrees(repo)).toEqual([]);
+  });
+
+  it.skipIf(!hasGit)("forks a unique branch on a name clash", async () => {
+    const a = await createWorktree(repo, "task");
+    const b = await createWorktree(repo, "task");
+    if (!a || !b) throw new Error("expected two worktrees");
+    expect(a.branch).toBe("agent/task");
+    expect(b.branch).toBe("agent/task-2");
+  });
+
+  it.skipIf(!hasGit)("refuses to remove a path outside the managed root", async () => {
+    expect(await removeWorktree(repo, repo)).toEqual({ ok: false, reason: "not-managed" });
+    expect(await removeWorktree(repo, path.join(home, "outside-managed"))).toEqual({ ok: false, reason: "not-managed" });
+  });
+
+  it("gitTopLevel returns null for a non-repo dir", async () => {
+    const plain = mkdtempSync(path.join(tmpdir(), "mt-wt-plain-"));
+    expect(await gitTopLevel(plain)).toBeNull();
+    rmSync(plain, { recursive: true, force: true });
+  });
+});

--- a/server/worktrees.ts
+++ b/server/worktrees.ts
@@ -158,12 +158,27 @@ export async function isDirty(worktreePath: string): Promise<boolean> {
 }
 
 // A branch name for `task` that isn't already taken (agent/<slug>, then -2, -3…).
+const MAX_BRANCH_SUFFIX = 99;
 async function uniqueBranch(repo: string, slug: string): Promise<string> {
-  for (let n = 1; n <= 99; n++) {
+  for (let n = 1; n <= MAX_BRANCH_SUFFIX; n++) {
     const name = n === 1 ? `agent/${slug}` : `agent/${slug}-${n}`;
     if (!(await git(["rev-parse", "--verify", "--quiet", name], repo)).ok) return name;
   }
   return `agent/${slug}-${Date.now()}`;
+}
+
+// Serialize worktree creation process-wide so the uniqueBranch → `worktree add`
+// sequence is atomic. Otherwise two concurrent creates for the same task can both
+// pick `agent/<slug>` (TOCTOU) and one add fails, and our parallel adds would also
+// contend on git's index lock. Runs each task after the prior settles (ok or not).
+let createQueue: Promise<unknown> = Promise.resolve();
+function serializeCreate<T>(task: () => Promise<T>): Promise<T> {
+  const run = createQueue.then(task, task);
+  createQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
 }
 
 // Create a fresh worktree + branch for `task`, forked from the repo's base branch.
@@ -173,11 +188,13 @@ export async function createWorktree(repoDir: string, task: string): Promise<{ p
   const repo = await repoRoot(repoDir);
   if (!repo) return null;
   const slug = slugify(task);
-  const branch = await uniqueBranch(repo, slug);
-  const dir = path.join(worktreesRoot(repo), branch.replace(/^agent\//, ""));
   const base = await defaultBaseBranch(repo);
-  const res = await git(["worktree", "add", "-b", branch, dir, base], repo);
-  return res.ok ? { path: dir, branch } : null;
+  return serializeCreate(async () => {
+    const branch = await uniqueBranch(repo, slug);
+    const dir = path.join(worktreesRoot(repo), branch.replace(/^agent\//, ""));
+    const res = await git(["worktree", "add", "-b", branch, dir, base], repo);
+    return res.ok ? { path: dir, branch } : null;
+  });
 }
 
 // Remove a managed worktree (and prune), optionally deleting its branch. Refuses a

--- a/server/worktrees.ts
+++ b/server/worktrees.ts
@@ -1,0 +1,179 @@
+// Per-agent git worktree isolation: each cell can run claude in its own throwaway
+// worktree (a separate working tree sharing the repo's single .git), so several
+// agents work the same repo without clobbering each other. Worktrees live under a
+// managed root (~/.mulmoterminal/worktrees/<repo>-<hash>/<task>) so the repo dir
+// stays clean and we only ever remove paths WE created. The pure helpers (slug /
+// parse / paths) are split out for unit tests; the rest shell out to git.
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Read lazily so MULMOTERMINAL_HOME can redirect the managed root (used by tests to
+// avoid touching the real home dir; defaults to ~/.mulmoterminal). Resolved to its
+// realpath so it matches the realpaths `git worktree list` reports (e.g. macOS
+// /tmp -> /private/tmp), which the isManagedWorktree filter relies on.
+function worktreesBase(): string {
+  const base = process.env.MULMOTERMINAL_HOME || path.join(os.homedir(), ".mulmoterminal");
+  try {
+    return path.join(realpathSync(base), "worktrees");
+  } catch {
+    return path.join(base, "worktrees"); // doesn't exist yet — first run
+  }
+}
+
+export interface WorktreeInfo {
+  path: string;
+  branch: string | null;
+  head: string;
+  task: string; // the managed worktree's directory name (its task slug)
+}
+
+// A filesystem-safe, readable slug for a branch/dir segment. Empty/garbage input
+// falls back to "task" so we never produce an empty branch or path component.
+export function slugify(task: string): string {
+  const slug = task
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") // single edge dash only: the line above collapsed runs
+    .slice(0, 40);
+  return slug || "task";
+}
+
+// The managed worktree root for a repo. Keyed by basename + a short hash of the
+// absolute path so two repos with the same basename don't collide.
+export function worktreesRoot(repoToplevel: string): string {
+  const hash = createHash("sha1").update(repoToplevel).digest("hex").slice(0, 8);
+  return path.join(worktreesBase(), `${path.basename(repoToplevel)}-${hash}`);
+}
+
+// Whether `p` is inside the managed root for `repoToplevel` — the guard that stops
+// a delete request from touching anything we didn't create.
+export function isManagedWorktree(repoToplevel: string, p: string): boolean {
+  const root = worktreesRoot(repoToplevel) + path.sep;
+  return path.resolve(p).startsWith(root);
+}
+
+// Parse `git worktree list --porcelain` into entries (blocks split by blank lines).
+export function parseWorktreeList(porcelain: string): { path: string; head: string; branch: string | null }[] {
+  const out: { path: string; head: string; branch: string | null }[] = [];
+  let cur: { path: string; head: string; branch: string | null } | null = null;
+  for (const line of porcelain.split("\n")) {
+    if (line.startsWith("worktree ")) cur = { path: line.slice(9).trim(), head: "", branch: null };
+    else if (line.startsWith("HEAD ") && cur) cur.head = line.slice(5).trim();
+    else if (line.startsWith("branch ") && cur)
+      cur.branch = line
+        .slice(7)
+        .trim()
+        .replace(/^refs\/heads\//, "");
+    else if (line.trim() === "" && cur) {
+      out.push(cur);
+      cur = null;
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+// Run git with argv (no shell) in `cwd`; resolve { ok, stdout } — never reject, so
+// a missing git / non-repo dir is just `ok:false` and the caller falls back.
+function git(args: string[], cwd?: string): Promise<{ ok: boolean; stdout: string }> {
+  return new Promise((resolve) => {
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' is a standard tool from PATH in this local dev server; all inputs go through argv (no shell)
+    const child = spawn("git", cwd ? ["-C", cwd, ...args] : args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.on("error", () => resolve({ ok: false, stdout: "" }));
+    child.on("close", (code) => resolve({ ok: code === 0, stdout }));
+  });
+}
+
+// The current working tree's root, or null if `dir` isn't inside a git work tree.
+export async function gitTopLevel(dir: string): Promise<string | null> {
+  const res = await git(["rev-parse", "--show-toplevel"], dir);
+  return res.ok && res.stdout.trim() ? res.stdout.trim() : null;
+}
+
+// The MAIN repo's root (the first entry of `worktree list`), so the managed root is
+// keyed off the repo even when `dir` is itself one of our worktrees. null if not a
+// git repo.
+export async function repoRoot(dir: string): Promise<string | null> {
+  const res = await git(["worktree", "list", "--porcelain"], dir);
+  if (!res.ok) return null;
+  return parseWorktreeList(res.stdout)[0]?.path ?? null;
+}
+
+// The branch new worktrees should fork from: origin's default (HEAD), else main /
+// master if present, else the repo's current branch.
+export async function defaultBaseBranch(repo: string): Promise<string> {
+  const head = await git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], repo);
+  if (head.ok && head.stdout.trim()) return head.stdout.trim().replace(/^origin\//, "");
+  for (const b of ["main", "master"]) {
+    if ((await git(["rev-parse", "--verify", "--quiet", b], repo)).ok) return b;
+  }
+  const cur = await git(["rev-parse", "--abbrev-ref", "HEAD"], repo);
+  return cur.ok && cur.stdout.trim() ? cur.stdout.trim() : "main";
+}
+
+// The managed worktrees for a repo (excludes the main checkout and any worktrees
+// outside our root), each tagged with its task = directory name.
+export async function listWorktrees(repoDir: string): Promise<WorktreeInfo[]> {
+  const repo = await repoRoot(repoDir);
+  if (!repo) return [];
+  const res = await git(["worktree", "list", "--porcelain"], repo);
+  if (!res.ok) return [];
+  return parseWorktreeList(res.stdout)
+    .filter((w) => isManagedWorktree(repo, w.path))
+    .map((w) => ({ path: w.path, branch: w.branch, head: w.head, task: path.basename(w.path) }));
+}
+
+// Whether a worktree has uncommitted changes (so we don't delete it silently).
+export async function isDirty(worktreePath: string): Promise<boolean> {
+  const res = await git(["status", "--porcelain"], worktreePath);
+  return res.ok && res.stdout.trim().length > 0;
+}
+
+// A branch name for `task` that isn't already taken (agent/<slug>, then -2, -3…).
+async function uniqueBranch(repo: string, slug: string): Promise<string> {
+  for (let n = 1; n <= 99; n++) {
+    const name = n === 1 ? `agent/${slug}` : `agent/${slug}-${n}`;
+    if (!(await git(["rev-parse", "--verify", "--quiet", name], repo)).ok) return name;
+  }
+  return `agent/${slug}-${Date.now()}`;
+}
+
+// Create a fresh worktree + branch for `task`, forked from the repo's base branch.
+// Returns the worktree path + branch, or null if `repoDir` isn't a git repo / the
+// worktree add fails.
+export async function createWorktree(repoDir: string, task: string): Promise<{ path: string; branch: string } | null> {
+  const repo = await repoRoot(repoDir);
+  if (!repo) return null;
+  const slug = slugify(task);
+  const branch = await uniqueBranch(repo, slug);
+  const dir = path.join(worktreesRoot(repo), branch.replace(/^agent\//, ""));
+  const base = await defaultBaseBranch(repo);
+  const res = await git(["worktree", "add", "-b", branch, dir, base], repo);
+  return res.ok ? { path: dir, branch } : null;
+}
+
+// Remove a managed worktree (and prune), optionally deleting its branch. Refuses a
+// path outside the managed root, or a dirty worktree unless `force`. Returns the
+// outcome so the UI can surface "has uncommitted changes — confirm".
+export async function removeWorktree(
+  repoDir: string,
+  worktreePath: string,
+  opts: { force?: boolean; deleteBranch?: boolean } = {},
+): Promise<{ ok: boolean; reason?: "not-managed" | "dirty" | "failed" }> {
+  const repo = await repoRoot(repoDir);
+  if (!repo || !isManagedWorktree(repo, worktreePath)) return { ok: false, reason: "not-managed" };
+  if (!opts.force && (await isDirty(worktreePath))) return { ok: false, reason: "dirty" };
+
+  const branch = (await listWorktrees(repo)).find((w) => w.path === path.resolve(worktreePath))?.branch ?? null;
+  const removed = await git(["worktree", "remove", ...(opts.force ? ["--force"] : []), worktreePath], repo);
+  if (!removed.ok) return { ok: false, reason: "failed" };
+  await git(["worktree", "prune"], repo);
+  if (opts.deleteBranch && branch) await git(["branch", "-D", branch], repo);
+  return { ok: true };
+}

--- a/server/worktrees.ts
+++ b/server/worktrees.ts
@@ -49,11 +49,33 @@ export function worktreesRoot(repoToplevel: string): string {
   return path.join(worktreesBase(), `${path.basename(repoToplevel)}-${hash}`);
 }
 
+// Canonicalize a path by realpath-resolving its deepest EXISTING ancestor and
+// re-attaching the missing leaf segments. So a symlink anywhere along the path
+// (even when the leaf itself doesn't exist) is resolved before containment checks.
+function canonicalPath(p: string): string {
+  const resolved = path.resolve(p);
+  const missing: string[] = [];
+  let cur = resolved;
+  for (;;) {
+    try {
+      const real = realpathSync(cur);
+      return missing.length ? path.join(real, ...missing) : real;
+    } catch {
+      const parent = path.dirname(cur);
+      if (parent === cur) return resolved; // reached the fs root, nothing resolved
+      missing.unshift(path.basename(cur));
+      cur = parent;
+    }
+  }
+}
+
 // Whether `p` is inside the managed root for `repoToplevel` — the guard that stops
-// a delete request from touching anything we didn't create.
+// a delete request from touching anything we didn't create. Both sides are
+// canonicalized so a symlink under the root can't escape it (string-prefix alone
+// would let `<root>/link -> /outside` slip through).
 export function isManagedWorktree(repoToplevel: string, p: string): boolean {
-  const root = worktreesRoot(repoToplevel) + path.sep;
-  return path.resolve(p).startsWith(root);
+  const root = canonicalPath(worktreesRoot(repoToplevel)) + path.sep;
+  return canonicalPath(p).startsWith(root);
 }
 
 // Parse `git worktree list --porcelain` into entries (blocks split by blank lines).

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -372,4 +372,106 @@ describe("TerminalCell", () => {
     expect(openSpy.mock.calls.at(-1)?.[0]).toBe("https://github.com/owner/repoB");
     openSpy.mockRestore();
   });
+
+  // Per-agent worktree isolation: when the launcher's dir is a git repo, the cell
+  // can start claude in its own managed worktree (create / reuse / remove).
+  interface Wt {
+    path: string;
+    branch: string | null;
+    task: string;
+    dirty: boolean;
+  }
+  function mockFetchWithWorktrees(worktrees: Wt[] = [], created: { path: string; branch: string } = { path: "/wt/fix-login", branch: "agent/fix-login" }) {
+    const posts: { url: string; body: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      if (init?.method === "POST") posts.push({ url: u, body: String(init.body ?? "") });
+      if (u.includes("/api/worktrees/create")) return { ok: true, json: async () => created };
+      if (u.includes("/api/worktrees/remove")) return { ok: true, json: async () => ({ ok: true }) };
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: true, base: "main", worktrees }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+    return posts;
+  }
+
+  it("shows the worktree section and lists existing worktrees when the dir is a git repo", async () => {
+    mockFetchWithWorktrees([{ path: "/wt/fix-login", branch: "agent/fix-login", task: "fix-login", dirty: false }]);
+    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    await flushPromises();
+    expect(w.find(".cell-worktrees").exists()).toBe(true);
+    const rows = w.findAll(".wt-reuse");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain("fix-login");
+  });
+
+  it("hides the worktree section for a non-git dir", async () => {
+    mockFetch(); // default mock reports no isGit
+    const w = mountCell(null, { defaultCwd: "/home/me/proj" });
+    await flushPromises();
+    expect(w.find(".cell-worktrees").exists()).toBe(false);
+  });
+
+  it("creates a worktree for the typed task and launches claude in it", async () => {
+    const posts = mockFetchWithWorktrees([], { path: "/wt/fix-login", branch: "agent/fix-login" });
+    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    await flushPromises();
+    await w.find(".wt-task").setValue("fix login");
+    await w.find(".wt-start").trigger("click");
+    await flushPromises();
+    const create = posts.find((p) => p.url.includes("/api/worktrees/create"));
+    if (!create) throw new Error("create not called");
+    expect(JSON.parse(create.body)).toEqual({ repoDir: "/home/me/repo", task: "fix login" });
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.exists()).toBe(true);
+    expect(term.props("cwd")).toBe("/wt/fix-login");
+  });
+
+  it("reuses an existing worktree by launching claude in its path", async () => {
+    mockFetchWithWorktrees([{ path: "/wt/old-task", branch: "agent/old-task", task: "old-task", dirty: false }]);
+    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    await flushPromises();
+    await w.find(".wt-reuse").trigger("click");
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.exists()).toBe(true);
+    expect(term.props("cwd")).toBe("/wt/old-task");
+  });
+
+  it("removes a clean worktree (deleteBranch, no force) without confirming", async () => {
+    const posts = mockFetchWithWorktrees([{ path: "/wt/done", branch: "agent/done", task: "done", dirty: false }]);
+    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    await flushPromises();
+    await w.find(".wt-del").trigger("click");
+    await flushPromises();
+    const remove = posts.find((p) => p.url.includes("/api/worktrees/remove"));
+    if (!remove) throw new Error("remove not called");
+    expect(JSON.parse(remove.body)).toEqual({ repoDir: "/home/me/repo", path: "/wt/done", deleteBranch: true, force: false });
+  });
+
+  it("confirms before removing a DIRTY worktree, and forces when confirmed", async () => {
+    const posts = mockFetchWithWorktrees([{ path: "/wt/wip", branch: "agent/wip", task: "wip", dirty: true }]);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    await flushPromises();
+    expect(w.find(".wt-dirty").exists()).toBe(true); // the ● uncommitted-changes marker
+    await w.find(".wt-del").trigger("click");
+    await flushPromises();
+    expect(confirmSpy).toHaveBeenCalled();
+    const remove = posts.find((p) => p.url.includes("/api/worktrees/remove"));
+    if (!remove) throw new Error("remove not called");
+    expect(JSON.parse(remove.body).force).toBe(true);
+    confirmSpy.mockRestore();
+  });
+
+  it("does NOT remove a dirty worktree when the user cancels the confirm", async () => {
+    const posts = mockFetchWithWorktrees([{ path: "/wt/wip", branch: "agent/wip", task: "wip", dirty: true }]);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    await flushPromises();
+    await w.find(".wt-del").trigger("click");
+    await flushPromises();
+    expect(posts.some((p) => p.url.includes("/api/worktrees/remove"))).toBe(false);
+    confirmSpy.mockRestore();
+  });
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -95,6 +95,7 @@ onMounted(() => {
   else {
     loadResumable();
     loadScripts();
+    loadWorktrees();
   }
 });
 onUnmounted(() => {
@@ -102,13 +103,16 @@ onUnmounted(() => {
   if (resumableTimer) clearTimeout(resumableTimer);
 });
 
-function launch() {
-  // Optimistic display only; the persisted/displayed truth is the EFFECTIVE cwd
-  // the server confirms (onServerCwd), since it may fall back from a bad path.
-  cwd.value = dirInput.value.trim() || props.defaultCwd;
+// Start a fresh session in `dir`. Optimistic display only; the persisted/displayed
+// truth is the EFFECTIVE cwd the server confirms (onServerCwd), which may fall back.
+function launchIn(dir: string | null) {
+  cwd.value = dir;
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
+}
+function launch() {
+  launchIn(dirInput.value.trim() || props.defaultCwd);
 }
 
 // Pick a preset directory: fill the field and refresh the resume list for it, so
@@ -117,6 +121,7 @@ function selectPreset(p: CwdPreset) {
   dirInput.value = p.path;
   loadResumable();
   loadScripts();
+  loadWorktrees();
 }
 
 // Existing sessions for the dir in the form, so an empty cell can resume one
@@ -199,12 +204,91 @@ function runScript(s: RunnableScript) {
   emit("run", { index: s.index, label: s.label, cwd: scriptsCwd.value ?? (dirInput.value.trim() || props.defaultCwd) });
 }
 
+// Per-agent isolation: when the dir is a git repo, the launcher can start claude in
+// its own throwaway worktree (separate working tree, shared .git) so several agents
+// work the repo without clobbering each other. Managed by the server (/api/worktrees).
+interface Worktree {
+  path: string;
+  branch: string | null;
+  task: string;
+  dirty: boolean;
+}
+const isGitRepo = ref(false);
+const worktrees = ref<Worktree[]>([]);
+const worktreeTask = ref("");
+let worktreesReq = 0;
+
+async function loadWorktrees() {
+  const dir = dirInput.value.trim() || props.defaultCwd;
+  const reqId = ++worktreesReq;
+  if (launched.value || !dir) {
+    isGitRepo.value = false;
+    worktrees.value = [];
+    return;
+  }
+  try {
+    const res = await fetch(`/api/worktrees?cwd=${encodeURIComponent(dir)}`);
+    if (reqId !== worktreesReq) return;
+    const data = res.ok ? await res.json() : { isGit: false, worktrees: [] };
+    if (reqId !== worktreesReq) return;
+    isGitRepo.value = !!data.isGit;
+    worktrees.value = Array.isArray(data.worktrees) ? data.worktrees : [];
+  } catch {
+    if (reqId === worktreesReq) {
+      isGitRepo.value = false;
+      worktrees.value = [];
+    }
+  }
+}
+
+// Create a fresh worktree for the typed task and launch claude in it.
+async function createWorktreeAndLaunch() {
+  const repoDir = dirInput.value.trim() || props.defaultCwd;
+  const task = worktreeTask.value.trim();
+  if (!repoDir || !task) return;
+  try {
+    const res = await fetch("/api/worktrees/create", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repoDir, task }),
+    });
+    if (!res.ok) return;
+    const wt = await res.json();
+    if (typeof wt.path === "string") {
+      worktreeTask.value = "";
+      launchIn(wt.path);
+    }
+  } catch {
+    // best-effort — the launcher stays open so the user can retry
+  }
+}
+
+const reuseWorktree = (w: Worktree) => launchIn(w.path);
+
+// Remove a managed worktree (＋ its branch). A dirty one is confirmed first so work
+// is never discarded silently.
+async function removeWorktree(w: Worktree) {
+  const repoDir = dirInput.value.trim() || props.defaultCwd;
+  if (w.dirty && !window.confirm(`"${w.task}" has uncommitted changes. Discard and remove it?`)) return;
+  try {
+    await fetch("/api/worktrees/remove", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repoDir, path: w.path, deleteBranch: true, force: w.dirty }),
+    });
+    loadWorktrees();
+  } catch {
+    // best-effort
+  }
+}
+
 // Refresh the resume list and the runnable scripts when the target dir changes.
 watch([dirInput, () => props.defaultCwd], () => {
   if (resumableTimer) clearTimeout(resumableTimer);
   resumableTimer = setTimeout(() => {
     loadResumable();
     loadScripts();
+    loadWorktrees();
   }, 300);
 });
 
@@ -311,6 +395,7 @@ function close() {
   emit("close");
   loadResumable();
   loadScripts();
+  loadWorktrees();
 }
 
 // Adopt the server-assigned id (esp. for new sessions), bubble it up for
@@ -406,6 +491,27 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
         <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
       </label>
       <button class="cell-start" @click="launch">＋ New terminal</button>
+      <div v-if="isGitRepo" class="cell-worktrees">
+        <span class="cell-launch-caption">or isolate in a worktree (git repo)</span>
+        <div class="wt-new">
+          <input
+            v-model="worktreeTask"
+            class="cell-dir-input wt-task"
+            type="text"
+            placeholder="task name (e.g. fix-login)"
+            aria-label="Worktree task name"
+            spellcheck="false"
+            @keydown.enter="createWorktreeAndLaunch"
+          />
+          <button class="cell-start wt-start" :disabled="!worktreeTask.trim()" @click="createWorktreeAndLaunch">＋ New worktree</button>
+        </div>
+        <div v-for="w in worktrees" :key="w.path" class="wt-row">
+          <button class="wt-reuse" :title="w.branch ?? w.path" @click="reuseWorktree(w)">
+            ⎇ {{ w.task }}<span v-if="w.dirty" class="wt-dirty" title="uncommitted changes">●</span>
+          </button>
+          <button class="wt-del" title="Remove worktree" aria-label="Remove worktree" @click="removeWorktree(w)">🗑</button>
+        </div>
+      </div>
       <div v-if="scripts.length" class="cell-scripts">
         <span class="cell-launch-caption">or run a script</span>
         <div class="cell-script-list">
@@ -707,6 +813,69 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 .cell-start:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+
+.cell-worktrees {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  width: 100%;
+  max-width: 360px;
+}
+.wt-new {
+  display: flex;
+  gap: 6px;
+}
+.wt-task {
+  flex: 1 1 auto;
+  min-width: 0; /* let the input shrink so the button keeps its width */
+  width: auto;
+}
+.wt-start {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+.wt-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.wt-reuse {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: left;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.wt-reuse:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.wt-dirty {
+  margin-left: 6px;
+  color: var(--warn-text, #e0a030);
+}
+.wt-del {
+  flex: 0 0 auto;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 4px 6px;
+  border-radius: 6px;
+}
+.wt-del:hover {
+  background: var(--err-hover-bg);
 }
 
 .cell-scripts {


### PR DESCRIPTION
## Summary

同一リポに複数セルを当てると作業ツリーを取り合って壊れる問題に対し、**エージェントごとの git worktree 隔離**を入れます（MVP=隔離のみ）。git リポの dir を選んだセルのランチャに「作業部屋（worktree）」UI が出て、タスク名を打つだけで使い捨ての worktree＋ブランチが立ち、その中で claude が起動します。git 用語は表に出さず、後始末も安全側に倒しています。

- 作成先は管理ディレクトリ `~/.mulmoterminal/worktrees/<repo>-<hash>/<task>`（リポ直下を汚さない／`MULMOTERMINAL_HOME` で差し替え可）
- **削除は管理ルート配下のパスのみ**許可（任意パス削除の防止）。dirty な部屋は force なしで拒否し、UI 側は確認ダイアログを出してから force 削除
- 手で消えた部屋は `git worktree prune` で吸収。git 未インストールでも他機能は無影響（worktree UI が出ないだけ）

Closes #106

## Items to Confirm / Review

- **削除の安全性**: `removeWorktree` は `isManagedWorktree`（管理ルート配下）を通らないパスを `not-managed` で拒否します。任意パス削除が起きないか確認してください（`server/worktrees.ts` / `worktrees.spec.ts` の該当テスト）。
- **dirty の扱い**: dirty な worktree は API が 409 を返し、UI は `window.confirm` で確認 → force 削除（`deleteBranch:true`）。未コミットを黙って消さない設計で良いか。
- **管理ルートの realpath 解決**: git は worktree パスを realpath で返すため、macOS の `/tmp -> /private/tmp` 等に合わせて managed root も realpath 解決しています（`worktreesBase()`）。この前提で問題ないか。
- **API が POST /remove（DELETE ではない）**: body をプロキシ越しでも確実に届けるため remove も POST にしています。
- **ブランチ命名**: `agent/<slug>`、衝突時は `-2, -3…`。slug は ascii 英数のみ（非 ascii は落として `task` にフォールバック）。

## User Prompt

- worktree をサポートする場合、どういうユーザ体験かシナリオを簡素に教えてほしい。
- すでにある worktree の使い回しや cleanup なども自然にできるか？ 自分は今まで手動で同一レポを複数 clone していて worktree は初めて使うので、自然に使えるようにしてほしい。
- issue 化して実装してほしい。

## Implementation

### サーバ
- `server/worktrees.ts`（新規）: 純粋 helper（`slugify` / `parseWorktreeList` / `worktreesRoot` / `isManagedWorktree`）＋ git exec（`gitTopLevel` / `repoRoot` / `defaultBaseBranch` / `listWorktrees` / `createWorktree` / `removeWorktree` / `isDirty`）。git は argv 直叩き（シェル不使用）。
- `server/worktree-routes.ts`（新規, `index.ts` に mount）:
  - `GET /api/worktrees?cwd=<dir>` … isGit / base / 一覧（各 worktree の `dirty` 付き）
  - `POST /api/worktrees/create {repoDir, task}` … 作成
  - `POST /api/worktrees/remove {repoDir, path, deleteBranch, force}` … 削除＋prune（dirty / 管理外は 409）
  - mutation は origin チェック。

### フロント
- `src/components/TerminalCell.vue`: 選択 dir が git リポなら **「＋ New worktree（タスク名）」** と **既存の作業部屋一覧（再利用 / 🗑 削除：dirty は確認）** を表示。起動は既存 launch 経路で worktree パスを cwd に流すだけ（`launch()` を `launchIn(dir)` に分離）。

### テスト
- `server/worktrees.spec.ts`（7）: 純粋 helper＋一時 git リポでの作成/一覧/dirty/削除/管理外拒否。
- `server/worktree-routes.spec.ts`（6）: origin ガード／バリデーション／作成→一覧→削除のライフサイクル。
- `src/components/TerminalCell.spec.ts`（+7）: git リポ時の section 表示、作成→起動、再利用→起動、clean 削除、dirty 削除の確認/force、キャンセル時に削除しない。
- 合計 **326 tests pass**。format / lint(0 errors) / typecheck / typecheck:server / build すべて green。

## 子issue（このPRの対象外・フォロー）
取り込み（差分→PR導線）、node_modules 戦略、自動 cleanup（セル close 連動）、ブランチ表示、デスクトップ通知。

🤖 Generated with [Claude Code](https://claude.com/claude-code)