### PR TITLE
feat: worktree セルのヘッダを「⎇ <repo> (<task>)」表示に

### DIFF
--- a/plans/feat-worktree-header-label.md
+++ b/plans/feat-worktree-header-label.md
@@ -1,0 +1,14 @@
+# feat: worktree セルのヘッダを「レポジトリ名（worktree名）」表示に
+
+Umbrella: #108（表示タスク）
+
+## 背景
+worktree セルのヘッダは今 `~/.mulmoterminal/worktrees/<repo>-<hash>/<task>` という管理パスをそのまま出していて長く・意味が薄い。どのリポのどの作業部屋かが一目で分かる表示にする。
+
+## 変更
+- `src/components/cwdDisplay.ts`: 純粋関数 `worktreeLabel(cwd)` を追加。管理 worktree パス（`.../worktrees/<repo>-<8hex>/<task>`）から `{ repo, task }` を取り出す。非該当は `null`。
+- `TerminalCell.vue`: ヘッダの dir スロットを `headerDir` computed に。worktree なら `⎇ <repo> (<task>)`、それ以外は従来の `formatCwd`。hover の title はフルパス（`Open <cwd>`）のまま。
+- テスト: `cwdDisplay.spec.ts`（managed/非managed/Windows/dash入りrepo/task欠落）、`TerminalCell.spec.ts`（worktree セルのヘッダ表示）。
+
+## 非対象
+ブランチ表示（`⎇ agent/<task>`）や ahead/dirty インジケータは #108 の別タスク。ここは「dir → repo(task)」の表示だけ。

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -98,6 +98,12 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-dir").text()).toBe("/var/data/proj");
   });
 
+  it("shows '⎇ <repo> (<task>)' instead of the managed path for a worktree cell", async () => {
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: "/home/me/.mulmoterminal/worktrees/myrepo-1a2b3c4d/fix-login" });
+    await flushPromises();
+    expect(w.find(".cell-dir").text()).toBe("⎇ myrepo (fix-login)");
+  });
+
   it("launches in the dir typed in the form and sends it to the terminal", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vue";
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
-import { formatCwd } from "./cwdDisplay";
+import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import type { CwdPreset } from "./presets";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
@@ -406,8 +406,13 @@ function onSession(id: string) {
   loadInitial(id);
 }
 
-// ~-anchored, front-truncated path for the header (keeps the tail).
+// ~-anchored, front-truncated path for the header (keeps the tail). For a managed
+// worktree cell, show "⎇ <repo> (<task>)" instead — the managed path is just noise.
 const dirDisplay = computed(() => formatCwd(cwd.value, props.home));
+const headerDir = computed(() => {
+  const wt = worktreeLabel(cwd.value);
+  return wt ? `⎇ ${wt.repo} (${wt.task})` : dirDisplay.value;
+});
 
 // Attention (waiting) wins over working wins over idle.
 const status = computed<"waiting" | "working" | "idle">(() => {
@@ -428,8 +433,8 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
     <template v-if="launched">
       <div class="cell-header" :class="statusClass">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
-        <button v-if="dirDisplay" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
-          <span class="cell-dir-path">{{ dirDisplay }}</span>
+        <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
+          <span class="cell-dir-path">{{ headerDir }}</span>
         </button>
         <span v-if="githubUrl" ref="ghWrap" class="cell-gh-wrap">
           <button

--- a/src/components/cwdDisplay.spec.ts
+++ b/src/components/cwdDisplay.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { homeRelative, truncateFront, formatCwd } from "./cwdDisplay";
+import { homeRelative, truncateFront, formatCwd, worktreeLabel } from "./cwdDisplay";
 
 describe("homeRelative", () => {
   it("anchors a path under home on ~", () => {
@@ -43,5 +43,23 @@ describe("formatCwd", () => {
   });
   it("returns empty for a null cwd", () => {
     expect(formatCwd(null, "/Users/me")).toBe("");
+  });
+});
+
+describe("worktreeLabel", () => {
+  it("extracts <repo> and <task> from a managed worktree path", () => {
+    expect(worktreeLabel("/Users/me/.mulmoterminal/worktrees/myrepo-1a2b3c4d/fix-login")).toEqual({ repo: "myrepo", task: "fix-login" });
+  });
+  it("keeps a repo name that itself contains dashes", () => {
+    expect(worktreeLabel("/x/worktrees/my-cool-repo-deadbeef/task-2")).toEqual({ repo: "my-cool-repo", task: "task-2" });
+  });
+  it("handles Windows separators", () => {
+    expect(worktreeLabel("C:\\Users\\me\\.mulmoterminal\\worktrees\\app-0badf00d\\wip")).toEqual({ repo: "app", task: "wip" });
+  });
+  it("returns null for non-worktree paths", () => {
+    expect(worktreeLabel(null)).toBeNull();
+    expect(worktreeLabel("/Users/me/ss/proj")).toBeNull();
+    expect(worktreeLabel("/x/worktrees/no-hash-here/task")).toBeNull(); // dir lacks the -<8hex> suffix
+    expect(worktreeLabel("/x/worktrees/app-1a2b3c4d")).toBeNull(); // no task segment
   });
 });

--- a/src/components/cwdDisplay.ts
+++ b/src/components/cwdDisplay.ts
@@ -26,3 +26,18 @@ export function formatCwd(cwd: string | null, home: string | null, max = 30): st
   if (!cwd) return "";
   return truncateFront(homeRelative(cwd, home), max);
 }
+
+// A managed worktree's cwd looks like .../worktrees/<repo>-<8hex>/<task> (see the
+// server's worktreesRoot). For those, the long managed path is noise in the header
+// — surface "<repo> (<task>)" instead. Returns null for any non-worktree path.
+const MANAGED_DIR = /^(.+)-[0-9a-f]{8}$/;
+export function worktreeLabel(cwd: string | null): { repo: string; task: string } | null {
+  if (!cwd) return null;
+  const parts = cwd.split(/[/\\]/).filter(Boolean);
+  const i = parts.indexOf("worktrees");
+  const dir = parts[i + 1];
+  const task = parts[i + 2];
+  if (i < 0 || !dir || !task) return null;
+  const m = MANAGED_DIR.exec(dir);
+  return m ? { repo: m[1], task } : null;
+}


### PR DESCRIPTION
## Summary

worktree セルのヘッダが管理パス（`~/.mulmoterminal/worktrees/<repo>-<hash>/<task>`）をそのまま出していて長く意味が薄かったのを、**`⎇ <repo> (<task>)`**（例: `⎇ mulmoterminal (fix-login)`）に変更します。どのリポのどの作業部屋かが一目で分かるようにする小さな表示改善です。非 worktree セルは従来どおり（パス表示）。hover の title はフルパスのまま。

Umbrella: #108（表示タスクの1つ）

## Items to Confirm / Review

- **worktree 判定**: `worktreeLabel()` は `.../worktrees/<repo>-<8hex>/<task>` というパス形だけで判定する純粋関数（サーバ往復なし＝reload 後も効く）。`-<8hex>` サフィックスが十分に固有なので誤判定はほぼ無いが、ユーザーが偶然同形のパスを使うと repo(task) 表示になる点だけ確認してください。
- **glyph**: ランチャの既存 worktree 行（`⎇ <task>`）に合わせて `⎇` を前置。括弧表記はリクエストどおり。

## User Prompt

> worktree の場合、header に dir を出すより、レポジトリ名＋worktree名のほうがよいね。()つきでも。

## Implementation

- `src/components/cwdDisplay.ts`: 純粋関数 `worktreeLabel(cwd)` を追加。管理 worktree パスから `{ repo, task }` を抽出、非該当は `null`。
- `src/components/TerminalCell.vue`: ヘッダ dir スロットを `headerDir` computed に。worktree なら `⎇ <repo> (<task>)`、それ以外は従来の `formatCwd`。
- テスト: `cwdDisplay.spec.ts`（managed / 非managed / Windows 区切り / dash 入り repo 名 / task 欠落）、`TerminalCell.spec.ts`（worktree セルのヘッダ表示）。335 tests pass / lint 0 errors / build OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)