### PR TITLE
feat: worktree の差分可視化（ahead/dirty バッジ＋diff パネル / 取り込み Slice 1）

### DIFF
--- a/plans/feat-worktree-diff.md
+++ b/plans/feat-worktree-diff.md
@@ -1,0 +1,24 @@
+# feat: worktree 差分の可視化（Slice 1 of 取り込み導線）
+
+Issue: #110（Umbrella #108 / 取り込み・最優先）
+
+## スコープ（このPR = read-only）
+worktree セルが「base ブランチに対してどれだけ変わったか」を見せる。**push / PR などの mutation は Slice 2（別PR）**。
+
+## サーバ
+- `server/worktree-diff.ts`（新規）: `worktreeDiff(cwd)` → `{ isWorktree, base, ahead, dirty, files, patch, truncated }`。
+  - `git` ランナーは `worktrees.ts` から再利用（DRY のため export 化）。
+  - base = `defaultBaseBranch(repo)`（作成時に fork した元）。非 worktree / 非 git は `isWorktree:false`。
+  - `ahead` = `rev-list --count base..HEAD` / `dirty` = porcelain 行数 / `files` = `diff --numstat base` ＋ untracked（`ls-files --others`）/ `patch` = `git diff base`（200k 文字で truncate）。
+- `server/worktree-routes.ts`: `GET /api/worktrees/diff?cwd=` を追加（read-only なので origin ガード無し、list と同じ）。
+- spec: `worktree-diff.spec.ts`（engine）, `worktree-routes.spec.ts`（route の非worktree応答）。
+
+## フロント
+- `TerminalCell.vue`:
+  - launch / resume / 作業が settle（working→false）したタイミングで `loadDiff()`。
+  - ヘッダに `+<ahead> ●<dirty>` バッジ（counts>0 のとき）。クリックで diff パネル。
+  - diff パネル = ターミナル領域へのオーバーレイ。変更ファイル一覧（+/-、untracked は `new`）＋ `git diff` パッチ（`<pre>`）。read-only。✕/Esc で閉じる。
+- spec: `TerminalCell.spec.ts`（バッジ表示・パネル開閉・clean/非worktree で非表示）。
+
+## 非対象（Slice 2）
+ブランチ push / PR作成（gh）/ remote・gh 無しのフォールバック。

--- a/server/worktree-diff.spec.ts
+++ b/server/worktree-diff.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createWorktree } from "./worktrees.js";
+import { worktreeDiff } from "./worktree-diff.js";
+
+describe("worktreeDiff", () => {
+  let repo: string;
+  let home: string;
+  const hasGit = (() => {
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+      execFileSync("git", ["--version"], { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  const g = (dir: string, ...a: string[]) =>
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    execFileSync("git", ["-C", dir, ...a], { stdio: "ignore" });
+
+  beforeEach(() => {
+    home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-diff-home-")));
+    process.env.MULMOTERMINAL_HOME = home;
+    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-diff-repo-")));
+    if (!hasGit) return;
+    g(repo, "init", "-b", "main");
+    g(repo, "config", "user.email", "t@t.t");
+    g(repo, "config", "user.name", "t");
+    writeFileSync(path.join(repo, "README.md"), "hi\n");
+    g(repo, "add", "-A");
+    g(repo, "commit", "-m", "init");
+  });
+  afterEach(() => {
+    delete process.env.MULMOTERMINAL_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("returns isWorktree:false for a non-worktree dir (the main repo)", async () => {
+    const d = await worktreeDiff(repo);
+    expect(d.isWorktree).toBe(false);
+    expect(d).toMatchObject({ base: null, ahead: 0, dirty: 0, files: [], patch: "" });
+  });
+
+  it.skipIf(!hasGit)("reports ahead/dirty, changed + untracked files, and a patch vs base", async () => {
+    const wt = await createWorktree(repo, "feature");
+    if (!wt) throw new Error("expected a worktree");
+
+    // one commit ahead of base: edit a tracked file and commit it
+    writeFileSync(path.join(wt.path, "README.md"), "hi\nfrom the worktree\n");
+    g(wt.path, "commit", "-am", "edit readme");
+    // plus uncommitted work: a tracked edit and a brand-new untracked file
+    writeFileSync(path.join(wt.path, "README.md"), "hi\nfrom the worktree\nuncommitted\n");
+    writeFileSync(path.join(wt.path, "new.txt"), "added\n");
+
+    const d = await worktreeDiff(wt.path);
+    expect(d.isWorktree).toBe(true);
+    expect(d.base).toBe("main");
+    expect(d.ahead).toBe(1); // one commit not on main
+    expect(d.dirty).toBe(2); // README (modified) + new.txt (untracked)
+
+    const readme = d.files.find((f) => f.path === "README.md");
+    expect(readme).toMatchObject({ status: "changed" });
+    expect(readme?.additions).toBeGreaterThan(0);
+    expect(d.files.find((f) => f.path === "new.txt")).toMatchObject({ status: "untracked", additions: 0, deletions: 0 });
+
+    expect(d.patch).toContain("README.md"); // unified diff vs base
+    expect(d.patch).toContain("from the worktree");
+    expect(d.truncated).toBe(false);
+  });
+
+  it.skipIf(!hasGit)("reports zero ahead/dirty for a freshly-created (clean) worktree", async () => {
+    const wt = await createWorktree(repo, "clean");
+    if (!wt) throw new Error("expected a worktree");
+    const d = await worktreeDiff(wt.path);
+    expect(d).toMatchObject({ isWorktree: true, base: "main", ahead: 0, dirty: 0, files: [], patch: "" });
+  });
+});

--- a/server/worktree-diff.ts
+++ b/server/worktree-diff.ts
@@ -1,0 +1,71 @@
+// Read-only diff of a managed worktree against the branch it was forked from, so a
+// cell can show how much the agent changed (ahead/dirty badge) and what changed
+// (file list + patch). Mutations (push / PR) live elsewhere. All git calls reuse
+// the shared runner and never throw — a non-worktree dir is just `isWorktree:false`.
+import { git, repoRoot, defaultBaseBranch, isManagedWorktree } from "./worktrees.js";
+
+export interface WorktreeFile {
+  path: string;
+  additions: number; // -1 for binary (git reports "-")
+  deletions: number;
+  status: "changed" | "untracked";
+}
+
+export interface WorktreeDiff {
+  isWorktree: boolean;
+  base: string | null;
+  ahead: number; // commits on the worktree branch not on base
+  dirty: number; // uncommitted entries (incl. untracked)
+  files: WorktreeFile[];
+  patch: string; // `git diff <base>` (tracked changes vs base), capped
+  truncated: boolean;
+}
+
+const PATCH_LIMIT_CHARS = 200_000;
+const EMPTY: WorktreeDiff = { isWorktree: false, base: null, ahead: 0, dirty: 0, files: [], patch: "", truncated: false };
+
+const toCount = (s: string): number => {
+  const n = parseInt(s.trim(), 10);
+  return Number.isFinite(n) ? n : 0;
+};
+
+async function aheadOf(cwd: string, base: string): Promise<number> {
+  const res = await git(["rev-list", "--count", `${base}..HEAD`], cwd);
+  return res.ok ? toCount(res.stdout) : 0;
+}
+
+async function dirtyCount(cwd: string): Promise<number> {
+  const res = await git(["status", "--porcelain"], cwd);
+  return res.ok ? res.stdout.split("\n").filter((l) => l.trim()).length : 0;
+}
+
+// Tracked changes vs base, with +/- counts (numstat: "<add>\t<del>\t<path>", "-"
+// for binary). Untracked files aren't in `git diff`, so add them from status.
+async function changedFiles(cwd: string, base: string): Promise<WorktreeFile[]> {
+  const tracked = await git(["diff", "--numstat", base], cwd);
+  const files: WorktreeFile[] = tracked.ok ? tracked.stdout.split("\n").filter(Boolean).map(parseNumstat) : [];
+  const untracked = await git(["ls-files", "--others", "--exclude-standard"], cwd);
+  const news = untracked.ok ? untracked.stdout.split("\n").filter(Boolean) : [];
+  return [...files, ...news.map((path): WorktreeFile => ({ path, additions: 0, deletions: 0, status: "untracked" }))];
+}
+
+function parseNumstat(line: string): WorktreeFile {
+  const [add, del, ...rest] = line.split("\t");
+  const toNum = (s: string) => (s === "-" ? -1 : toCount(s));
+  return { path: rest.join("\t"), additions: toNum(add), deletions: toNum(del), status: "changed" };
+}
+
+async function diffPatch(cwd: string, base: string): Promise<{ patch: string; truncated: boolean }> {
+  const res = await git(["diff", base], cwd);
+  if (!res.ok) return { patch: "", truncated: false };
+  const full = res.stdout;
+  return full.length > PATCH_LIMIT_CHARS ? { patch: full.slice(0, PATCH_LIMIT_CHARS), truncated: true } : { patch: full, truncated: false };
+}
+
+export async function worktreeDiff(cwd: string): Promise<WorktreeDiff> {
+  const repo = await repoRoot(cwd);
+  if (!repo || !isManagedWorktree(repo, cwd)) return EMPTY;
+  const base = await defaultBaseBranch(repo);
+  const [ahead, dirty, files, patch] = await Promise.all([aheadOf(cwd, base), dirtyCount(cwd), changedFiles(cwd, base), diffPatch(cwd, base)]);
+  return { isWorktree: true, base, ahead, dirty, files, patch: patch.patch, truncated: patch.truncated };
+}

--- a/server/worktree-routes.spec.ts
+++ b/server/worktree-routes.spec.ts
@@ -91,6 +91,16 @@ describe("worktree routes: origin guard + validation", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("GET /api/worktrees/diff returns isWorktree:false for a missing/non-worktree cwd", async () => {
+    const r = routes(allow);
+    const a = makeRes();
+    await r["GET /api/worktrees/diff"]({ headers: {}, query: {} }, a); // no cwd
+    expect(a.payload).toMatchObject({ isWorktree: false, files: [], patch: "" });
+    const b = makeRes();
+    await r["GET /api/worktrees/diff"]({ headers: {}, query: { cwd: "/no/such/dir" } }, b);
+    expect(b.payload).toMatchObject({ isWorktree: false });
+  });
 });
 
 // Drive the real create → list → remove lifecycle through the HTTP handlers,

--- a/server/worktree-routes.ts
+++ b/server/worktree-routes.ts
@@ -4,6 +4,7 @@
 // uses POST (not DELETE) so a request body survives every proxy.
 import type { Express } from "express";
 import { repoRoot, defaultBaseBranch, listWorktrees, createWorktree, removeWorktree, isDirty } from "./worktrees.js";
+import { worktreeDiff } from "./worktree-diff.js";
 
 interface WorktreeRouteOptions {
   isAllowedOrigin: (origin?: string) => boolean;
@@ -20,6 +21,14 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
     const list = await listWorktrees(repo);
     const worktrees = await Promise.all(list.map(async (w) => ({ ...w, dirty: await isDirty(w.path) })));
     res.json({ isGit: true, base: await defaultBaseBranch(repo), worktrees });
+  });
+
+  // Read-only diff of a worktree vs its base branch (ahead/dirty counts + changed
+  // files + patch), so a cell can show what the agent changed. A non-worktree dir
+  // is `isWorktree:false`, not an error.
+  app.get("/api/worktrees/diff", async (req, res) => {
+    const cwd = typeof req.query.cwd === "string" ? req.query.cwd : "";
+    res.json(cwd ? await worktreeDiff(cwd) : { isWorktree: false, base: null, ahead: 0, dirty: 0, files: [], patch: "", truncated: false });
   });
 
   app.post("/api/worktrees/create", async (req, res) => {

--- a/server/worktrees.ts
+++ b/server/worktrees.ts
@@ -101,7 +101,7 @@ export function parseWorktreeList(porcelain: string): { path: string; head: stri
 
 // Run git with argv (no shell) in `cwd`; resolve { ok, stdout } — never reject, so
 // a missing git / non-repo dir is just `ok:false` and the caller falls back.
-function git(args: string[], cwd?: string): Promise<{ ok: boolean; stdout: string }> {
+export function git(args: string[], cwd?: string): Promise<{ ok: boolean; stdout: string }> {
   return new Promise((resolve) => {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' is a standard tool from PATH in this local dev server; all inputs go through argv (no shell)
     const child = spawn("git", cwd ? ["-C", cwd, ...args] : args, { stdio: ["ignore", "pipe", "pipe"] });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -480,4 +480,63 @@ describe("TerminalCell", () => {
     expect(posts.some((p) => p.url.includes("/api/worktrees/remove"))).toBe(false);
     confirmSpy.mockRestore();
   });
+
+  // Read-only worktree diff: a launched worktree cell shows an ahead/dirty badge
+  // and opens a panel with the changed files + patch.
+  const WT_CWD = "/home/me/.mulmoterminal/worktrees/repo-1a2b3c4d/fix";
+  function mockFetchWithDiff(diff: Record<string, unknown>) {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/diff")) return { ok: true, json: async () => diff };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+  }
+
+  it("shows the ahead/dirty badge for a worktree cell and opens the diff panel", async () => {
+    mockFetchWithDiff({
+      isWorktree: true,
+      base: "main",
+      ahead: 3,
+      dirty: 2,
+      truncated: false,
+      files: [
+        { path: "src/a.ts", additions: 10, deletions: 2, status: "changed" },
+        { path: "new.txt", additions: 0, deletions: 0, status: "untracked" },
+      ],
+      patch: "diff --git a/src/a.ts b/src/a.ts\n+hello\n",
+    });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+
+    const badge = w.find(".cell-wt-badge");
+    expect(badge.exists()).toBe(true);
+    expect(badge.find(".wt-ahead").text()).toBe("+3");
+    expect(badge.find(".wt-dirty-count").text()).toBe("●2");
+
+    expect(w.find(".cell-diff").exists()).toBe(false); // panel closed initially
+    await badge.trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-diff").exists()).toBe(true);
+    expect(w.findAll(".cell-diff-file")).toHaveLength(2);
+    expect(w.find(".df-new").exists()).toBe(true); // the untracked file
+    expect(w.find(".cell-diff-patch").text()).toContain("hello");
+
+    await w.find(".cell-diff .cell-btn").trigger("click"); // ✕ closes it
+    expect(w.find(".cell-diff").exists()).toBe(false);
+  });
+
+  it("shows no diff badge for a clean worktree (0 ahead / 0 dirty)", async () => {
+    mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 0, dirty: 0, files: [], patch: "", truncated: false });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+  });
+
+  it("never shows the diff badge for a non-worktree cell", async () => {
+    mockFetchWithDiff({ isWorktree: false, base: null, ahead: 9, dirty: 9, files: [], patch: "", truncated: false });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: "/home/me/regular-proj" });
+    await flushPromises();
+    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+  });
 });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -539,4 +539,31 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(w.find(".cell-wt-badge").exists()).toBe(false);
   });
+
+  it("bootstraps the diff badge when RESUMING an idle worktree session", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/diff"))
+        return { ok: true, json: async () => ({ isWorktree: true, base: "main", ahead: 2, dirty: 0, files: [], patch: "", truncated: false }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ cwd: WT_CWD, sessions: [{ id: "wt-sess", title: "t", mtime: 1 }] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+    const w = mountCell(null, { defaultCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-resume-item").trigger("click"); // resume the idle worktree session
+    await flushPromises();
+    expect(w.find(".cell-wt-badge").exists()).toBe(true);
+    expect(w.find(".wt-ahead").text()).toBe("+2");
+  });
+
+  it("clears the diff badge when the cwd falls back to a non-worktree dir", async () => {
+    mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 3, dirty: 1, files: [], patch: "", truncated: false });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    expect(w.find(".cell-wt-badge").exists()).toBe(true);
+    // server confirms a different, non-worktree dir → badge must not linger
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/plain-proj");
+    await flushPromises();
+    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+  });
 });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -588,6 +588,25 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-diff").exists()).toBe(false);
   });
 
+  it("does not auto-reopen the diff panel after leaving and re-entering a worktree", async () => {
+    mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 2, dirty: 0, files: [], patch: "x", truncated: false });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-wt-badge").trigger("click"); // user opens the panel
+    await flushPromises();
+    expect(w.find(".cell-diff").exists()).toBe(true);
+
+    const term = w.findComponent({ name: "TerminalView" });
+    term.vm.$emit("cwd", "/home/me/plain-proj"); // leave the worktree → panel closes
+    await flushPromises();
+    expect(w.find(".cell-diff").exists()).toBe(false);
+
+    term.vm.$emit("cwd", WT_CWD); // re-enter a worktree
+    await flushPromises();
+    expect(w.find(".cell-wt-badge").exists()).toBe(true); // badge returns…
+    expect(w.find(".cell-diff").exists()).toBe(false); // …but the panel stays closed until clicked
+  });
+
   it("closes the diff panel on Escape (document-level handler)", async () => {
     mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 1, dirty: 0, files: [], patch: "x", truncated: false });
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -566,4 +566,25 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(w.find(".cell-wt-badge").exists()).toBe(false);
   });
+
+  it("auto-closes the open diff panel when the cwd leaves the worktree (no empty overlay)", async () => {
+    mockFetchWithDiff({
+      isWorktree: true,
+      base: "main",
+      ahead: 3,
+      dirty: 1,
+      files: [{ path: "a.ts", additions: 1, deletions: 0, status: "changed" }],
+      patch: "x",
+      truncated: false,
+    });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-wt-badge").trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-diff").exists()).toBe(true);
+    // leaving the worktree clears `diff`; the panel must not linger as an empty overlay
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/plain-proj");
+    await flushPromises();
+    expect(w.find(".cell-diff").exists()).toBe(false);
+  });
 });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -588,6 +588,18 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-diff").exists()).toBe(false);
   });
 
+  it("closes the diff panel on Escape (document-level handler)", async () => {
+    mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 1, dirty: 0, files: [], patch: "x", truncated: false });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-wt-badge").trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-diff").exists()).toBe(true);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })); // focus may be on the badge/terminal
+    await flushPromises();
+    expect(w.find(".cell-diff").exists()).toBe(false);
+  });
+
   it("ignores an in-flight diff fetch that resolves after the cwd left the worktree", async () => {
     const diffFetch = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
     globalThis.fetch = vi.fn((url: string) => {

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -587,4 +587,24 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(w.find(".cell-diff").exists()).toBe(false);
   });
+
+  it("ignores an in-flight diff fetch that resolves after the cwd left the worktree", async () => {
+    const diffFetch = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    globalThis.fetch = vi.fn((url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/diff")) return diffFetch.promise;
+      if (u.includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises(); // the worktree diff fetch is in flight (pending)
+    // leave the worktree BEFORE it resolves — the clear path must invalidate the token
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/plain-proj");
+    await flushPromises();
+    // the stale worktree diff now resolves — it must not repopulate the badge
+    diffFetch.resolve({ ok: true, json: async () => ({ isWorktree: true, base: "main", ahead: 5, dirty: 5, files: [], patch: "", truncated: false }) });
+    await flushPromises();
+    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+  });
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -91,8 +91,10 @@ onMounted(() => {
   unsubscribe = subscribe("sessions", (d) => {
     if (isActivityMsg(d) && d.id === sessionId.value) applyActivity(d);
   });
-  if (sessionId.value) loadInitial(sessionId.value);
-  else {
+  if (sessionId.value) {
+    loadInitial(sessionId.value);
+    loadDiff(); // a resumed worktree cell shows its diff on restore
+  } else {
     loadResumable();
     loadScripts();
     loadWorktrees();
@@ -110,6 +112,7 @@ function launchIn(dir: string | null) {
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
+  loadDiff(); // no-op for a non-worktree dir
 }
 function launch() {
   launchIn(dirInput.value.trim() || props.defaultCwd);
@@ -392,6 +395,8 @@ function close() {
   // the empty launch form would still show the closed session's directory.
   cwd.value = props.defaultCwd;
   dirInput.value = props.defaultCwd ?? "";
+  diff.value = null;
+  diffOpen.value = false;
   emit("close");
   loadResumable();
   loadScripts();
@@ -426,6 +431,52 @@ const statusClass = computed(() => STATUS_CLASS[status.value]);
 const statusLabel = computed(() => STATUS_LABEL[status.value]);
 
 const headerText = computed(() => lastPrompt.value || (sessionId.value ? sessionId.value.slice(0, 8) : "starting…"));
+
+// Worktree diff (read-only): for a launched worktree cell, show how much the agent
+// changed vs the base branch — a header badge (ahead/dirty) and a panel (changed
+// files + patch). Refreshed when the agent pauses (the change set is then stable).
+interface WorktreeDiffData {
+  isWorktree: boolean;
+  base: string | null;
+  ahead: number;
+  dirty: number;
+  files: { path: string; additions: number; deletions: number; status: "changed" | "untracked" }[];
+  patch: string;
+  truncated: boolean;
+}
+const diff = ref<WorktreeDiffData | null>(null);
+const diffOpen = ref(false);
+const isWorktreeCell = computed(() => worktreeLabel(cwd.value) !== null);
+const showDiffBadge = computed(() => !!diff.value?.isWorktree && (diff.value.ahead > 0 || diff.value.dirty > 0));
+let diffReq = 0;
+
+async function loadDiff() {
+  if (!launched.value || !isWorktreeCell.value || !cwd.value) {
+    diff.value = null;
+    return;
+  }
+  const reqId = ++diffReq;
+  try {
+    const res = await fetch(`/api/worktrees/diff?cwd=${encodeURIComponent(cwd.value)}`);
+    if (reqId !== diffReq) return;
+    const data = res.ok ? await res.json() : null;
+    if (reqId !== diffReq) return;
+    diff.value = data && data.isWorktree ? data : null;
+  } catch {
+    if (reqId === diffReq) diff.value = null;
+  }
+}
+
+function openDiff() {
+  diffOpen.value = true;
+  loadDiff(); // refresh on open
+}
+
+// Refresh when the agent transitions from working → settled: that's when the diff
+// is stable and worth re-reading (avoids churn while it's actively editing).
+watch(working, (now, prev) => {
+  if (prev && !now) loadDiff();
+});
 </script>
 
 <template>
@@ -435,6 +486,10 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
         <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
+        </button>
+        <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
+          <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
+          <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
         </button>
         <span v-if="githubUrl" ref="ghWrap" class="cell-gh-wrap">
           <button
@@ -484,6 +539,26 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
         @cwd="onServerCwd"
         @run="(cmd) => emit('runSpare', cmd)"
       />
+      <div v-if="diffOpen" class="cell-diff" tabindex="-1" @keydown.escape="diffOpen = false">
+        <div class="cell-diff-head">
+          <span class="cell-diff-title">Changes vs {{ diff?.base ?? "base" }}</span>
+          <span class="cell-diff-sum">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>
+          <button class="cell-btn" title="Close diff" aria-label="Close diff" @click="diffOpen = false">✕</button>
+        </div>
+        <div v-if="diff && diff.files.length" class="cell-diff-files">
+          <div v-for="f in diff.files" :key="f.path" class="cell-diff-file">
+            <span class="df-path">{{ f.path }}</span>
+            <span v-if="f.status === 'untracked'" class="df-new">new</span>
+            <span v-else class="df-nums">
+              <span class="df-add">+{{ f.additions < 0 ? "bin" : f.additions }}</span>
+              <span class="df-del">−{{ f.deletions < 0 ? "bin" : f.deletions }}</span>
+            </span>
+          </div>
+        </div>
+        <pre v-if="diff && diff.patch" class="cell-diff-patch">{{ diff.patch }}</pre>
+        <p v-if="diff && diff.truncated" class="cell-diff-note">Diff truncated — open the worktree to see the rest.</p>
+        <p v-if="diff && !diff.files.length" class="cell-diff-empty">No changes yet.</p>
+      </div>
     </template>
     <div v-else class="cell-launch">
       <div v-if="presets.length" class="cell-presets">
@@ -538,6 +613,7 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
 
 <style scoped>
 .cell {
+  position: relative; /* anchors the diff overlay */
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -957,5 +1033,119 @@ const headerText = computed(() => lastPrompt.value || (sessionId.value ? session
   flex: 0 0 auto;
   color: var(--text-dim);
   font-size: 11px;
+}
+
+/* Worktree diff badge in the header (ahead / uncommitted), opens the diff panel. */
+.cell-wt-badge {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1px 7px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  cursor: pointer;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11px;
+}
+.cell-wt-badge:hover {
+  background: var(--bg-hover);
+}
+.wt-ahead {
+  color: var(--accent);
+}
+.wt-dirty-count {
+  color: var(--warn-text, #e0a030);
+}
+
+/* Read-only diff panel: overlays the terminal area of the cell. */
+.cell-diff {
+  position: absolute;
+  inset: 34px 0 0 0; /* below the 34px header */
+  z-index: 15;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-base);
+  border-top: 1px solid var(--border);
+  overflow: hidden;
+}
+.cell-diff-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel);
+}
+.cell-diff-title {
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+}
+.cell-diff-sum {
+  flex: 1 1 auto;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.cell-diff-files {
+  flex: 0 0 auto;
+  max-height: 35%;
+  overflow-y: auto;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
+.cell-diff-file {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11px;
+  padding: 1px 0;
+}
+.df-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  direction: rtl;
+  color: var(--text-secondary);
+}
+.df-nums {
+  flex: 0 0 auto;
+}
+.df-add {
+  color: #3fae6b;
+}
+.df-del {
+  color: var(--err-text, #e0556b);
+}
+.df-new {
+  flex: 0 0 auto;
+  color: #3fae6b;
+}
+.cell-diff-patch {
+  flex: 1 1 auto;
+  margin: 0;
+  overflow: auto;
+  padding: 8px;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  white-space: pre;
+  tab-size: 2;
+}
+.cell-diff-note,
+.cell-diff-empty {
+  margin: 0;
+  padding: 8px;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  color: var(--text-dim);
 }
 </style>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -301,6 +301,7 @@ function resume(s: ResumableSession) {
   sessionId.value = s.id;
   connectKey.value++;
   launched.value = true;
+  loadDiff(); // an already-idle worktree session shows its badge right away
 }
 
 function relativeTime(ms: number): string {
@@ -477,6 +478,11 @@ function openDiff() {
 watch(working, (now, prev) => {
   if (prev && !now) loadDiff();
 });
+
+// Re-read (or clear) the diff when the effective cwd changes — e.g. the server
+// confirmed a fallback dir. loadDiff() clears it synchronously for a non-worktree
+// dir, so the badge never lingers with a previous worktree's counts.
+watch(cwd, () => loadDiff());
 </script>
 
 <template>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -455,6 +455,7 @@ async function loadDiff() {
   if (!launched.value || !isWorktreeCell.value || !cwd.value) {
     diffReq++; // invalidate any in-flight fetch so its (now stale) response can't land
     diff.value = null;
+    diffOpen.value = false; // fully close — don't auto-reopen on a later worktree re-entry
     return;
   }
   const reqId = ++diffReq;

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -545,7 +545,7 @@ watch(cwd, () => loadDiff());
         @cwd="onServerCwd"
         @run="(cmd) => emit('runSpare', cmd)"
       />
-      <div v-if="diffOpen" class="cell-diff" tabindex="-1" @keydown.escape="diffOpen = false">
+      <div v-if="diffOpen && diff" class="cell-diff" tabindex="-1" @keydown.escape="diffOpen = false">
         <div class="cell-diff-head">
           <span class="cell-diff-title">Changes vs {{ diff?.base ?? "base" }}</span>
           <span class="cell-diff-sum">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -453,6 +453,7 @@ let diffReq = 0;
 
 async function loadDiff() {
   if (!launched.value || !isWorktreeCell.value || !cwd.value) {
+    diffReq++; // invalidate any in-flight fetch so its (now stale) response can't land
     diff.value = null;
     return;
   }

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -484,6 +484,18 @@ watch(working, (now, prev) => {
 // confirmed a fallback dir. loadDiff() clears it synchronously for a non-worktree
 // dir, so the badge never lingers with a previous worktree's counts.
 watch(cwd, () => loadDiff());
+
+// Esc closes the diff panel. Listen at document scope while it's open: focus is
+// usually on the badge or the terminal, so a handler on the panel element itself
+// wouldn't reliably receive the keydown.
+function onDiffKey(e: KeyboardEvent) {
+  if (e.key === "Escape") diffOpen.value = false;
+}
+watch(diffOpen, (open) => {
+  if (open) document.addEventListener("keydown", onDiffKey);
+  else document.removeEventListener("keydown", onDiffKey);
+});
+onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 </script>
 
 <template>
@@ -546,7 +558,7 @@ watch(cwd, () => loadDiff());
         @cwd="onServerCwd"
         @run="(cmd) => emit('runSpare', cmd)"
       />
-      <div v-if="diffOpen && diff" class="cell-diff" tabindex="-1" @keydown.escape="diffOpen = false">
+      <div v-if="diffOpen && diff" class="cell-diff">
         <div class="cell-diff-head">
           <span class="cell-diff-title">Changes vs {{ diff?.base ?? "base" }}</span>
           <span class="cell-diff-sum">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>


### PR DESCRIPTION
## Summary

worktree セルが「fork 元の base ブランチに対してどれだけ変わったか」を見せる **read-only** な差分可視化です。取り込み導線（#110）の Slice 1。

- ヘッダに **`+<ahead> ●<dirty>` バッジ**（ahead=base からのコミット数 / dirty=未コミット数）。エージェントの作業が落ち着いた（working→idle）タイミングで更新。
- バッジクリックで **diff パネル**（変更ファイル一覧＋`git diff` パッチ）をターミナル領域にオーバーレイ。✕/Esc で閉じる。
- **mutation は無し**（push / PR作成 は Slice 2 = 別PR）。

## Items to Confirm / Review

- **diff の基準**: base = `defaultBaseBranch(repo)`（作成時に fork した元）。`patch` は `git diff <base>`（作業ツリー vs base＝コミット済み＋未コミットのトラッキング変更）。`ahead` は `rev-list --count base..HEAD`、`dirty` は porcelain 行数。
- **untracked**: 新規ファイルは `files` に `status:"untracked"` で出すが **patch には含めない**（slice 1 の割り切り。`git diff` に出ないため）。一覧では `new` 表示。
- **patch 上限**: 200k 文字で truncate し `truncated:true` ＋注記表示（巨大 diff の payload 抑制）。
- **更新トリガ**: launch / resume / `working` が false に戻った時に再取得（アクティブ編集中の連打を避ける）。手動 push/PR は付けていないので、ここでの「取り込み入口」はパネルまで。
- **`git` ランナーの export**: DRY のため `worktrees.ts` の内部 `git()` を export して `worktree-diff.ts` で再利用しています。

## User Prompt

> （worktree umbrella の次の実装として）差分可視化＋取り込み入口。worktree セルに ahead/dirty バッジ → 押すと diff 表示 →「ブランチ push / PR作成」。まず diff 表示まで、push/PR は段階的に。

## Implementation

### サーバ
- `server/worktree-diff.ts`（新規）: `worktreeDiff(cwd)` → `{ isWorktree, base, ahead, dirty, files, patch, truncated }`。
- `server/worktree-routes.ts`: `GET /api/worktrees/diff?cwd=`（read-only、origin ガード無し＝list と同様）。
- `server/worktrees.ts`: 内部 `git()` を export（再利用のため）。
- spec: `worktree-diff.spec.ts`（一時 git リポで ahead/dirty/files/untracked/patch）、`worktree-routes.spec.ts`（非 worktree 応答）。

### フロント
- `src/components/TerminalCell.vue`: `loadDiff()`＋`working` 監視、ヘッダバッジ、diff オーバーレイパネル。
- spec: `TerminalCell.spec.ts`（バッジ表示・パネル開閉・clean/非 worktree で非表示）。

342 tests pass / lint 0 errors / typecheck・build OK。

## 次（Slice 2 / #110）
ブランチ push・PR作成（gh）と remote/gh 無し時のフォールバック。

🤖 Generated with [Claude Code](https://claude.com/claude-code)