### PR TITLE
feat: worktree の push / PR 作成アクション（取り込み Slice 2）

### DIFF
--- a/plans/feat-worktree-pr.md
+++ b/plans/feat-worktree-pr.md
@@ -1,0 +1,27 @@
+# feat: worktree の取り込みアクション（push / PR）— Slice 2 of 取り込み導線
+
+Issue: #110（Umbrella #108 / 取り込み・Slice 2）
+
+## スコープ
+diff パネル（Slice 1, #111 merged）に **outward-facing アクション**を足す。
+
+- **Push branch**: `git push -u origin <worktree branch>`
+- **Open PR**: push してから、**`gh` があれば `gh pr create`**、無ければ **GitHub の compare URL をブラウザで開く**（ユーザー選択 = 両方）。
+
+## サーバ
+- `server/worktree-pr.ts`（新規）:
+  - `pushWorktree(cwd)` → `{ ok, branch }` / `{ ok:false, reason }`（not-worktree / no-branch / no-remote / failed）。
+  - `createOrOpenPR(cwd)` → push 後に `gh pr create --base <base> --head <branch> --fill`、成功なら `{ ok, url, via:"gh" }`。失敗/未インストールなら `resolveGithubUrl` から compare URL を作って `{ ok, url, via:"compare" }`。GitHub でなければ `{ ok:false, reason:"no-github" }`。
+  - 純粋 helper `compareUrl(githubUrl, base, branch)` を切り出してテスト。
+  - `git` ランナーは `worktrees.ts` 再利用、`gh`/`git push` は stderr も取る専用 runner。
+- `server/worktree-routes.ts`: `POST /api/worktrees/push`、`POST /api/worktrees/pr`（origin ガード）。reason → status: 失敗系(failed/push-failed)=500、前提系(not-worktree/no-branch/no-remote/no-github)=409。
+- spec: bare remote を origin にして push 成功、no-remote、not-worktree、compareUrl の URL 形。
+
+## フロント
+- `TerminalCell.vue` diff パネルにフッタ: **[⬆ Push] [⧉ Open PR]** ＋ 結果メッセージ行。
+- `ahead === 0`（コミット無し）なら両ボタン disable（「ターミナルで commit してね」）。
+- Open PR 成功で `window.open(url)`。失敗は reason をメッセージ表示。実行中は disable。
+- spec: ボタン表示/disable、push 成功メッセージ、PR 成功で window.open、no-remote 等のエラー表示。
+
+## 非対象
+マージ / 破棄、node_modules 戦略、自動 cleanup（#108 の別タスク）。

--- a/server/worktree-pr.spec.ts
+++ b/server/worktree-pr.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { createWorktree } from "./worktrees.js";
+import { compareUrl, pushWorktree, createOrOpenPR } from "./worktree-pr.js";
+
+describe("compareUrl", () => {
+  it("builds the GitHub compare/open-PR url, keeping the branch slash raw", () => {
+    expect(compareUrl("https://github.com/owner/repo", "main", "agent/fix-login")).toBe(
+      "https://github.com/owner/repo/compare/main...agent/fix-login?expand=1",
+    );
+  });
+});
+
+describe("push / PR actions", () => {
+  let repo: string;
+  let home: string;
+  let remote: string;
+  const hasGit = (() => {
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+      execFileSync("git", ["--version"], { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  const g = (dir: string, ...a: string[]) =>
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    execFileSync("git", ["-C", dir, ...a], { stdio: "ignore" });
+
+  beforeEach(() => {
+    home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-home-")));
+    process.env.MULMOTERMINAL_HOME = home;
+    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-repo-")));
+    remote = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-remote-")));
+    if (!hasGit) return;
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    execFileSync("git", ["init", "--bare", "-b", "main", remote], { stdio: "ignore" });
+    g(repo, "init", "-b", "main");
+    g(repo, "config", "user.email", "t@t.t");
+    g(repo, "config", "user.name", "t");
+    writeFileSync(path.join(repo, "README.md"), "hi\n");
+    g(repo, "add", "-A");
+    g(repo, "commit", "-m", "init");
+  });
+  afterEach(() => {
+    delete process.env.MULMOTERMINAL_HOME;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(remote, { recursive: true, force: true });
+  });
+
+  it.skipIf(!hasGit)("pushes the worktree branch to origin", async () => {
+    g(repo, "remote", "add", "origin", remote);
+    const wt = await createWorktree(repo, "fix login");
+    if (!wt) throw new Error("expected a worktree");
+    writeFileSync(path.join(wt.path, "a.txt"), "x");
+    g(wt.path, "add", "-A");
+    g(wt.path, "commit", "-m", "work");
+
+    const res = await pushWorktree(wt.path);
+    expect(res).toEqual({ ok: true, branch: "agent/fix-login" });
+    // the branch now exists on the bare remote
+    const refs = execFileSync("git", ["-C", remote, "branch", "--list", "agent/fix-login"], { encoding: "utf8" }); // eslint-disable-line sonarjs/no-os-command-from-path
+    expect(refs).toContain("agent/fix-login");
+  });
+
+  it.skipIf(!hasGit)("refuses to push when there is no origin remote", async () => {
+    const wt = await createWorktree(repo, "no-remote");
+    if (!wt) throw new Error("expected a worktree");
+    expect(await pushWorktree(wt.path)).toEqual({ ok: false, reason: "no-remote" });
+  });
+
+  it.skipIf(!hasGit)("refuses a path that isn't a managed worktree", async () => {
+    expect(await pushWorktree(repo)).toEqual({ ok: false, reason: "not-worktree" });
+  });
+
+  it.skipIf(!hasGit)("createOrOpenPR pushes, then reports no-github for a non-GitHub remote", async () => {
+    g(repo, "remote", "add", "origin", remote); // a local bare remote, not github.com
+    const wt = await createWorktree(repo, "feature");
+    if (!wt) throw new Error("expected a worktree");
+    writeFileSync(path.join(wt.path, "a.txt"), "x");
+    g(wt.path, "add", "-A");
+    g(wt.path, "commit", "-m", "work");
+
+    const res = await createOrOpenPR(wt.path);
+    // gh can't make a PR (no GitHub) and the remote isn't github.com → no compare url
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("no-github");
+    // but the push half still landed the branch on the remote
+    const refs = execFileSync("git", ["-C", remote, "branch", "--list", "agent/feature"], { encoding: "utf8" }); // eslint-disable-line sonarjs/no-os-command-from-path
+    expect(refs).toContain("agent/feature");
+    // (the compare-url SUCCESS path can't be exercised locally — origin can't be
+    // both a pushable bare repo and github.com — so compareUrl() is unit-tested
+    // above and the gh→fallback wiring is covered by this no-github case.)
+  });
+});

--- a/server/worktree-pr.ts
+++ b/server/worktree-pr.ts
@@ -1,0 +1,107 @@
+// Outward-facing worktree actions (the "取り込み" half): push the worktree's branch
+// and open/create a PR. PR creation prefers `gh pr create`; when gh is missing or
+// unauthed it falls back to opening the GitHub compare URL in the browser. Guarded
+// upstream by origin checks; here every command is argv-only (no shell).
+import { spawn } from "node:child_process";
+import { repoRoot, defaultBaseBranch, isManagedWorktree, git } from "./worktrees.js";
+import { resolveGithubUrl } from "./gitRemote.js";
+
+type Reason = "not-worktree" | "no-branch" | "no-remote" | "no-github" | "push-failed" | "failed";
+
+export interface PushResult {
+  ok: boolean;
+  branch?: string;
+  reason?: Reason;
+  detail?: string;
+}
+export interface PrResult {
+  ok: boolean;
+  url?: string;
+  via?: "gh" | "compare";
+  reason?: Reason;
+  detail?: string;
+}
+
+const DETAIL_LIMIT = 500;
+
+interface ExecResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+// Like worktrees.ts' git(), but captures stderr too (push/gh errors land there) and
+// runs an arbitrary local tool (git / gh) — both fixed names from PATH, argv only.
+function run(cmd: "git" | "gh", args: string[], cwd: string): Promise<ExecResult> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("error", () => resolve({ ok: false, stdout: "", stderr: "spawn failed" }));
+    child.on("close", (code) => resolve({ ok: code === 0, stdout, stderr }));
+  });
+}
+
+async function currentBranch(cwd: string): Promise<string | null> {
+  const res = await git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  const branch = res.stdout.trim();
+  return res.ok && branch && branch !== "HEAD" ? branch : null;
+}
+
+async function hasOrigin(cwd: string): Promise<boolean> {
+  const res = await git(["remote"], cwd);
+  return (
+    res.ok &&
+    res.stdout
+      .split("\n")
+      .map((r) => r.trim())
+      .includes("origin")
+  );
+}
+
+// The GitHub "open a PR" page for base...branch. Branch names keep their slash
+// (agent/<task>) — GitHub's compare path takes them raw, not percent-encoded.
+export function compareUrl(githubUrl: string, base: string, branch: string): string {
+  return `${githubUrl}/compare/${base}...${branch}?expand=1`;
+}
+
+// Push the worktree's branch to origin (so it can be turned into a PR).
+export async function pushWorktree(cwd: string): Promise<PushResult> {
+  const repo = await repoRoot(cwd);
+  if (!repo || !isManagedWorktree(repo, cwd)) return { ok: false, reason: "not-worktree" };
+  const branch = await currentBranch(cwd);
+  if (!branch) return { ok: false, reason: "no-branch" };
+  if (!(await hasOrigin(cwd))) return { ok: false, reason: "no-remote" };
+  const pushed = await run("git", ["push", "-u", "origin", branch], cwd);
+  return pushed.ok ? { ok: true, branch } : { ok: false, reason: "push-failed", detail: pushed.stderr.trim().slice(0, DETAIL_LIMIT) };
+}
+
+// The last http(s) line of gh's output — `gh pr create` prints the PR URL last.
+function lastUrl(stdout: string): string | null {
+  const urls = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith("http"));
+  return urls.length ? urls[urls.length - 1] : null;
+}
+
+// Push, then create a PR via gh — falling back to the GitHub compare URL when gh is
+// absent/unauthed/errors. Returns the URL to open and which path produced it.
+export async function createOrOpenPR(cwd: string): Promise<PrResult> {
+  const pushed = await pushWorktree(cwd);
+  if (!pushed.ok || !pushed.branch) return { ok: false, reason: pushed.reason, detail: pushed.detail };
+  const branch = pushed.branch;
+  const repo = await repoRoot(cwd);
+  if (!repo) return { ok: false, reason: "not-worktree" };
+  const base = await defaultBaseBranch(repo);
+
+  const gh = await run("gh", ["pr", "create", "--base", base, "--head", branch, "--fill"], cwd);
+  const ghUrl = gh.ok ? lastUrl(gh.stdout) : null;
+  if (ghUrl) return { ok: true, url: ghUrl, via: "gh" };
+
+  const githubUrl = await resolveGithubUrl(cwd);
+  if (!githubUrl) return { ok: false, reason: "no-github", detail: gh.stderr.trim().slice(0, DETAIL_LIMIT) };
+  return { ok: true, url: compareUrl(githubUrl, base, branch), via: "compare" };
+}

--- a/server/worktree-routes.spec.ts
+++ b/server/worktree-routes.spec.ts
@@ -81,6 +81,21 @@ describe("worktree routes: origin guard + validation", () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it("403s push and pr from a disallowed origin, 400s when cwd is missing", async () => {
+    const denied = routes(deny);
+    for (const route of ["POST /api/worktrees/push", "POST /api/worktrees/pr"] as const) {
+      const r403 = makeRes();
+      await denied[route]({ headers: { origin: "https://evil.example" }, body: { cwd: "/x" } }, r403);
+      expect(r403.statusCode).toBe(403);
+    }
+    const allowed = routes(allow);
+    for (const route of ["POST /api/worktrees/push", "POST /api/worktrees/pr"] as const) {
+      const r400 = makeRes();
+      await allowed[route]({ headers: {}, body: {} }, r400);
+      expect(r400.statusCode).toBe(400);
+    }
+  });
+
   it("reports isGit:false for a non-git dir", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "wt-routes-plain-"));
     try {
@@ -201,5 +216,37 @@ describe("worktree routes: create → list → remove lifecycle", () => {
     await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: ghost } }, res);
     expect(res.statusCode).toBe(500);
     expect(res.payload).toEqual({ ok: false, reason: "failed" });
+  });
+
+  it.skipIf(!hasGit)("POST /api/worktrees/push 200s with the branch (and 409s with no remote)", async () => {
+    const r = routes(allow);
+    const created = makeRes();
+    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "ship it" } }, created);
+    const wt = created.payload as { path: string };
+    writeFileSync(path.join(wt.path, "a.txt"), "x");
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    execFileSync("git", ["-C", wt.path, "add", "-A"], { stdio: "ignore" });
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    execFileSync("git", ["-C", wt.path, "commit", "-m", "work"], { stdio: "ignore" });
+
+    const noRemote = makeRes();
+    await r["POST /api/worktrees/push"]({ headers: {}, body: { cwd: wt.path } }, noRemote);
+    expect(noRemote.statusCode).toBe(409);
+    expect(noRemote.payload).toMatchObject({ ok: false, reason: "no-remote" });
+
+    const remote = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-remote-")));
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+      execFileSync("git", ["init", "--bare", "-b", "main", remote], { stdio: "ignore" });
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+      execFileSync("git", ["-C", repo, "remote", "add", "origin", remote], { stdio: "ignore" });
+
+      const pushed = makeRes();
+      await r["POST /api/worktrees/push"]({ headers: {}, body: { cwd: wt.path } }, pushed);
+      expect(pushed.statusCode).toBe(200);
+      expect(pushed.payload).toEqual({ ok: true, branch: "agent/ship-it" });
+    } finally {
+      rmSync(remote, { recursive: true, force: true });
+    }
   });
 });

--- a/server/worktree-routes.ts
+++ b/server/worktree-routes.ts
@@ -5,9 +5,18 @@
 import type { Express } from "express";
 import { repoRoot, defaultBaseBranch, listWorktrees, createWorktree, removeWorktree, isDirty } from "./worktrees.js";
 import { worktreeDiff } from "./worktree-diff.js";
+import { pushWorktree, createOrOpenPR } from "./worktree-pr.js";
 
 interface WorktreeRouteOptions {
   isAllowedOrigin: (origin?: string) => boolean;
+}
+
+// A failed git/gh command is a 500; a precondition the user can fix (no remote, not
+// a GitHub repo, …) is a 409. Mirrors the create/remove status convention.
+const SERVER_ERROR_REASONS = new Set(["failed", "push-failed"]);
+function statusFor(result: { ok: boolean; reason?: string }): number {
+  if (result.ok) return 200;
+  return SERVER_ERROR_REASONS.has(result.reason ?? "") ? 500 : 409;
 }
 
 export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeRouteOptions): void {
@@ -57,5 +66,24 @@ export function mountWorktreeRoutes(app: Express, { isAllowedOrigin }: WorktreeR
     const result = await removeWorktree(repoDir, worktreePath, { deleteBranch: deleteBranch === true, force: force === true });
     if (result.ok) return res.json(result);
     res.status(result.reason === "failed" ? 500 : 409).json(result);
+  });
+
+  // Push the worktree's branch to origin (the first half of "取り込み").
+  app.post("/api/worktrees/push", async (req, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).end();
+    const { cwd } = req.body ?? {};
+    if (typeof cwd !== "string") return res.status(400).json({ error: "cwd is required" });
+    const result = await pushWorktree(cwd);
+    res.status(statusFor(result)).json(result);
+  });
+
+  // Push, then create a PR via gh — or fall back to the GitHub compare URL. The body
+  // returns the URL for the client to open and which path produced it (`via`).
+  app.post("/api/worktrees/pr", async (req, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).end();
+    const { cwd } = req.body ?? {};
+    if (typeof cwd !== "string") return res.status(400).json({ error: "cwd is required" });
+    const result = await createOrOpenPR(cwd);
+    res.status(statusFor(result)).json(result);
   });
 }

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -729,4 +729,30 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(w.find(".cell-diff-msg").text()).toContain("No git remote");
   });
+
+  it("does not get stuck on 'Pushing…' when the response has no JSON body (403)", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/push"))
+        return {
+          ok: false,
+          status: 403,
+          json: async () => {
+            throw new Error("empty body");
+          },
+        };
+      if (u.includes("/api/worktrees/diff")) return { ok: true, json: async () => aheadDiff(2) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    const push = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Push"));
+    await push?.trigger("click");
+    await flushPromises();
+    const msg = w.find(".cell-diff-msg").text();
+    expect(msg).not.toBe("Pushing…");
+    expect(msg).toContain("Not allowed");
+  });
 });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -638,4 +638,95 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(w.find(".cell-wt-badge").exists()).toBe(false);
   });
+
+  // Slice 2 — push / open-PR actions in the diff panel footer.
+  function mockFetchWithPr(diff: Record<string, unknown>, action: { url?: string; status?: number; body: Record<string, unknown> }) {
+    const posts: { url: string; body: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      if (init?.method === "POST") posts.push({ url: u, body: String(init.body ?? "") });
+      if (u.includes("/api/worktrees/push") || u.includes("/api/worktrees/pr"))
+        return { ok: (action.status ?? 200) < 400, status: action.status ?? 200, json: async () => action.body };
+      if (u.includes("/api/worktrees/diff")) return { ok: true, json: async () => diff };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+    return posts;
+  }
+  const aheadDiff = (ahead: number) => ({
+    isWorktree: true,
+    base: "main",
+    ahead,
+    dirty: 0,
+    files: [{ path: "a.ts", additions: 1, deletions: 0, status: "changed" }],
+    patch: "x",
+    truncated: false,
+  });
+  const openPanel = async (w: ReturnType<typeof mountCell>) => {
+    await w.find(".cell-wt-badge").trigger("click");
+    await flushPromises();
+  };
+
+  it("disables Push / Open PR when there are no commits ahead (only uncommitted changes)", async () => {
+    // ahead 0 but dirty 2 → badge shows (via dirty), but nothing is committed to push
+    mockFetchWithPr(
+      {
+        isWorktree: true,
+        base: "main",
+        ahead: 0,
+        dirty: 2,
+        files: [{ path: "a.ts", additions: 1, deletions: 0, status: "changed" }],
+        patch: "x",
+        truncated: false,
+      },
+      { body: { ok: true } },
+    );
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    const btns = w.findAll(".cell-diff-btn");
+    expect(btns).toHaveLength(2);
+    expect(btns.every((b) => b.attributes("disabled") !== undefined)).toBe(true);
+  });
+
+  it("Push posts to /api/worktrees/push and shows the pushed branch", async () => {
+    const posts = mockFetchWithPr(aheadDiff(2), { body: { ok: true, branch: "agent/fix-login" } });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    const push = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Push"));
+    if (!push) throw new Error("Push button not found");
+    await push.trigger("click");
+    await flushPromises();
+    const req = posts.find((p) => p.url.includes("/api/worktrees/push"));
+    if (!req) throw new Error("push not called");
+    expect(JSON.parse(req.body)).toEqual({ cwd: WT_CWD });
+    expect(w.find(".cell-diff-msg").text()).toBe("Pushed agent/fix-login");
+  });
+
+  it("Open PR opens the returned url in a new tab", async () => {
+    mockFetchWithPr(aheadDiff(2), { body: { ok: true, url: "https://github.com/owner/repo/pull/9", via: "gh" } });
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    const pr = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Open PR"));
+    if (!pr) throw new Error("Open PR button not found");
+    await pr.trigger("click");
+    await flushPromises();
+    expect(openSpy).toHaveBeenCalledWith("https://github.com/owner/repo/pull/9", "_blank", "noopener,noreferrer");
+    expect(w.find(".cell-diff-msg").text()).toBe("PR created");
+    openSpy.mockRestore();
+  });
+
+  it("shows a friendly message when push fails with no remote (409)", async () => {
+    mockFetchWithPr(aheadDiff(2), { status: 409, body: { ok: false, reason: "no-remote" } });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    const push = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Push"));
+    await push?.trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-diff-msg").text()).toContain("No git remote");
+  });
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -472,7 +472,57 @@ async function loadDiff() {
 
 function openDiff() {
   diffOpen.value = true;
+  prMsg.value = null;
   loadDiff(); // refresh on open
+}
+
+// Outward-facing actions (push / open PR) for the worktree's branch. `prBusy`
+// disables the buttons during a request; `prMsg` shows the result inline.
+const prBusy = ref(false);
+const prMsg = ref<string | null>(null);
+const REASON_MSG: Record<string, string> = {
+  "not-worktree": "Not a worktree",
+  "no-branch": "No branch to push",
+  "no-remote": "No git remote (origin) configured",
+  "no-github": "Not a GitHub repo — push succeeded; open the PR manually",
+  "push-failed": "Push failed",
+  failed: "Failed",
+};
+const reasonMsg = (reason?: string) => REASON_MSG[reason ?? ""] ?? "Failed";
+
+async function worktreeAction(endpoint: "push" | "pr"): Promise<Record<string, unknown> | null> {
+  if (!cwd.value || prBusy.value) return null;
+  prBusy.value = true;
+  prMsg.value = endpoint === "push" ? "Pushing…" : "Creating PR…";
+  try {
+    const res = await fetch(`/api/worktrees/${endpoint}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cwd: cwd.value }),
+    });
+    return await res.json().catch(() => null);
+  } catch {
+    prMsg.value = endpoint === "push" ? "Push failed" : "PR failed";
+    return null;
+  } finally {
+    prBusy.value = false;
+  }
+}
+
+async function pushBranch() {
+  const data = await worktreeAction("push");
+  if (data) prMsg.value = data.ok ? `Pushed ${data.branch}` : reasonMsg(data.reason as string);
+}
+
+async function openPR() {
+  const data = await worktreeAction("pr");
+  if (!data) return;
+  if (data.ok && typeof data.url === "string") {
+    window.open(data.url, "_blank", "noopener,noreferrer");
+    prMsg.value = data.via === "gh" ? "PR created" : "Opened PR page";
+  } else {
+    prMsg.value = reasonMsg(data.reason as string);
+  }
 }
 
 // Refresh when the agent transitions from working → settled: that's when the diff
@@ -578,6 +628,25 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <pre v-if="diff && diff.patch" class="cell-diff-patch">{{ diff.patch }}</pre>
         <p v-if="diff && diff.truncated" class="cell-diff-note">Diff truncated — open the worktree to see the rest.</p>
         <p v-if="diff && !diff.files.length" class="cell-diff-empty">No changes yet.</p>
+        <div class="cell-diff-actions">
+          <button
+            class="cell-diff-btn"
+            :disabled="prBusy || (diff?.ahead ?? 0) === 0"
+            :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'git push -u origin'"
+            @click="pushBranch"
+          >
+            ⬆ Push
+          </button>
+          <button
+            class="cell-diff-btn"
+            :disabled="prBusy || (diff?.ahead ?? 0) === 0"
+            :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'Push and open a pull request'"
+            @click="openPR"
+          >
+            ⧉ Open PR
+          </button>
+          <span v-if="prMsg" class="cell-diff-msg">{{ prMsg }}</span>
+        </div>
       </div>
     </template>
     <div v-else class="cell-launch">
@@ -1164,6 +1233,43 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 .cell-diff-empty {
   margin: 0;
   padding: 8px;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.cell-diff-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-panel);
+}
+.cell-diff-btn {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  padding: 4px 12px;
+  border-radius: 6px;
+}
+.cell-diff-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.cell-diff-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.cell-diff-msg {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   font-family: system-ui, sans-serif;
   font-size: 11px;
   color: var(--text-dim);

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -500,7 +500,11 @@ async function worktreeAction(endpoint: "push" | "pr"): Promise<Record<string, u
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ cwd: cwd.value }),
     });
-    return await res.json().catch(() => null);
+    const data = await res.json().catch(() => null);
+    // A non-JSON / empty-body response (e.g. a 403 from the origin guard) must not
+    // leave the UI stuck on the optimistic "Pushing…" text.
+    if (!data) prMsg.value = res.status === 403 ? "Not allowed (origin)" : "Request failed";
+    return data;
   } catch {
     prMsg.value = endpoint === "push" ? "Push failed" : "PR failed";
     return null;


### PR DESCRIPTION
## Summary

diff パネル（Slice 1, #111）に **outward-facing アクション**を追加します。worktree の成果をそのまま本流へ取り込むための最初の一歩です。

- **⬆ Push**: `git push -u origin <worktree branch>`
- **⧉ Open PR**: push してから **`gh` があれば `gh pr create`**、無ければ **GitHub の compare URL（PR作成画面）をブラウザで開く**（ユーザー選択 = 両方）。
- どちらも **commit が base より進んでいない時（ahead=0）は disable**（「ターミナルで commit してね」）。

Refs #110（取り込み Slice 2）, #108

## Items to Confirm / Review

- **push 先 / ブランチ**: `origin` に worktree の現在ブランチ（`agent/<task>`）を `-u` で push。remote が無ければ `no-remote`（409）。
- **gh → compare のフォールバック**: `gh pr create --base <base> --head <branch> --fill` を worktree dir で実行 → 成功なら PR URL を開く。失敗/未インストール時は `resolveGithubUrl`（既存）から `…/compare/<base>...<branch>?expand=1` を作って開く。GitHub でなければ `no-github`（push は成功済み）。
- **ステータス規約**: 失敗系（`failed`/`push-failed`）= **500**、前提系（`no-remote`/`not-worktree`/`no-github`…）= **409**。create/remove と揃えています。
- **compare URL のブランチ slash**: `agent/<task>` の `/` は GitHub の compare パスでは生のまま（percent-encode しない）。`compareUrl()` を純粋関数化して単体テスト。
- **テスト範囲の割り切り**: gh の成功パスは gh+auth+GitHub が要るので CI では検証不可。`compareUrl()` 単体・`gh→fallback` 配線（no-github）・push（bare remote へ実push）・origin/validation はカバー。

## User Prompt

> （worktree umbrella の次として）差分可視化＋取り込み入口。Slice 2 の「PR作成」は **両方**（gh があれば gh、無ければ compare URL をブラウザで開く）で。

## Implementation

### サーバ
- `server/worktree-pr.ts`（新規）: `pushWorktree(cwd)` / `createOrOpenPR(cwd)` / `compareUrl()`。`git` は worktrees.ts のランナー再利用、`git push` / `gh` は stderr も取る専用 runner。
- `server/worktree-routes.ts`: `POST /api/worktrees/push`、`POST /api/worktrees/pr`（origin ガード、reason→status マッピング）。
- spec: bare remote へ実 push、no-remote、not-worktree、no-github、`compareUrl` の URL 形、ルートの 403/400/409/200。

### フロント
- `src/components/TerminalCell.vue`: diff パネルのフッタに **[⬆ Push] [⧉ Open PR]** ＋結果メッセージ。実行中 disable、ahead=0 で disable、PR 成功で `window.open`。
- spec: ボタン disable（ahead=0）、push 成功メッセージ、PR で window.open、no-remote のエラー表示。

359 tests pass / lint 0 errors / typecheck・build OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)