### PR TITLE
feat: diff パネルに「✓ Commit」ボタン（Claude にコミットさせて diff→PR を繋ぐ）

### DIFF
--- a/plans/feat-worktree-commit.md
+++ b/plans/feat-worktree-commit.md
@@ -1,0 +1,18 @@
+# feat: diff パネルの「Commit」ボタン（Claude にコミットさせる）
+
+Issue: #113（Umbrella #108 / 取り込みの続き #110）
+
+## ねらい
+diff パネルに未コミット変更（`dirty>0`）があるとき **[✓ Commit]** で Claude にコミットさせ、取り込みフローを繋ぐ。
+完成フロー: **dirty → [✓ Commit] → Claude がコミット → ahead↑/dirty↓ → [⬆ Push] → [⧉ Open PR]**
+
+## 実装（サーバ変更なし）
+- `Terminal.vue` の既存 `submitText(text)`（PTY にプロンプト投入＋送信、paste 対策の遅延 CR）を再利用。
+- `TerminalCell.vue`:
+  - フッタ先頭に **[✓ Commit]**。`dirty>0` かつ `!working`（作業中は割り込まない）かつ `!prBusy` で有効。
+  - click → `termRef.submitText(COMMIT_PROMPT)`。送信できたら "Asked Claude to commit…"、ws 不通なら "Couldn't reach the session"。
+  - コミット後の diff 更新は既存の `watch(working)`→`loadDiff()` が担う（追加処理なし）。
+- テスト: dirty>0 で有効・click で `submitText` をプロンプト付きで呼ぶ／dirty=0 や working 中は disable／submitText が false のときのメッセージ。
+
+## 非対象
+コミットメッセージの GUI 入力、マージ/破棄、node_modules 戦略。

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -22,7 +22,12 @@ vi.mock("./Terminal.vue", () => ({
     props: ["sessionId", "connectKey", "cwd"],
     emits: ["session", "cwd"],
     template: '<div class="stub-term" />',
-    methods: { terminate() {} },
+    methods: {
+      terminate() {},
+      submitText() {
+        return true;
+      },
+    },
   },
 }));
 
@@ -685,8 +690,10 @@ describe("TerminalCell", () => {
     await flushPromises();
     await openPanel(w);
     const btns = w.findAll(".cell-diff-btn");
-    expect(btns).toHaveLength(2);
-    expect(btns.every((b) => b.attributes("disabled") !== undefined)).toBe(true);
+    const labelled = (text: string) => btns.find((b) => b.text().includes(text));
+    expect(labelled("Push")?.attributes("disabled")).toBeDefined(); // no commits ahead
+    expect(labelled("Open PR")?.attributes("disabled")).toBeDefined();
+    expect(labelled("Commit")?.attributes("disabled")).toBeUndefined(); // but there ARE uncommitted changes to commit
   });
 
   it("Push posts to /api/worktrees/push and shows the pushed branch", async () => {
@@ -728,6 +735,90 @@ describe("TerminalCell", () => {
     await push?.trigger("click");
     await flushPromises();
     expect(w.find(".cell-diff-msg").text()).toContain("No git remote");
+  });
+
+  const commitBtn = (w: ReturnType<typeof mountCell>) => w.findAll(".cell-diff-btn").find((b) => b.text().includes("Commit"));
+
+  it("Commit asks the Claude session to commit when there are uncommitted changes", async () => {
+    // ahead 0, dirty 2 → the badge shows (dirty) and the Commit button is enabled
+    mockFetchWithPr(
+      {
+        isWorktree: true,
+        base: "main",
+        ahead: 0,
+        dirty: 2,
+        files: [{ path: "a.ts", additions: 1, deletions: 0, status: "changed" }],
+        patch: "x",
+        truncated: false,
+      },
+      { body: { ok: true } },
+    );
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    const term = w.findComponent({ name: "TerminalView" });
+    const submit = vi.spyOn(term.vm as unknown as { submitText: (t: string) => boolean }, "submitText");
+
+    const commit = commitBtn(w);
+    if (!commit) throw new Error("Commit button not found");
+    expect(commit.attributes("disabled")).toBeUndefined(); // enabled (dirty>0, not working)
+    await commit.trigger("click");
+    await flushPromises();
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0][0]).toContain("Commit all current changes");
+    expect(w.find(".cell-diff-msg").text()).toContain("Asked Claude to commit");
+  });
+
+  it("disables Commit when there are no uncommitted changes (dirty=0)", async () => {
+    mockFetchWithPr(aheadDiff(2), { body: { ok: true } }); // ahead 2, dirty 0
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    expect(commitBtn(w)?.attributes("disabled")).toBeDefined();
+  });
+
+  it("disables Commit while the session is working (don't interrupt the agent)", async () => {
+    mockFetchWithPr(
+      {
+        isWorktree: true,
+        base: "main",
+        ahead: 0,
+        dirty: 2,
+        files: [{ path: "a.ts", additions: 1, deletions: 0, status: "changed" }],
+        patch: "x",
+        truncated: false,
+      },
+      { body: { ok: true } },
+    );
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    captured?.({ id: "66666666-6666-6666-6666-666666666666", working: true, waiting: false }); // agent starts working
+    await nextTick();
+    expect(commitBtn(w)?.attributes("disabled")).toBeDefined();
+  });
+
+  it("shows a fallback message when the session can't be reached", async () => {
+    mockFetchWithPr(
+      {
+        isWorktree: true,
+        base: "main",
+        ahead: 0,
+        dirty: 2,
+        files: [{ path: "a.ts", additions: 1, deletions: 0, status: "changed" }],
+        patch: "x",
+        truncated: false,
+      },
+      { body: { ok: true } },
+    );
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await openPanel(w);
+    const term = w.findComponent({ name: "TerminalView" });
+    vi.spyOn(term.vm as unknown as { submitText: (t: string) => boolean }, "submitText").mockReturnValue(false);
+    await commitBtn(w)?.trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-diff-msg").text()).toContain("Couldn't reach the session");
   });
 
   it("does not get stuck on 'Pushing…' when the response has no JSON body (403)", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -480,6 +480,15 @@ function openDiff() {
 // disables the buttons during a request; `prMsg` shows the result inline.
 const prBusy = ref(false);
 const prMsg = ref<string | null>(null);
+
+// Ask the cell's own Claude session to commit the uncommitted changes (so it writes
+// a sensible message). After it commits and settles, the working→idle watch
+// refreshes the diff: `ahead` rises, `dirty` drops, and Push/PR light up.
+const COMMIT_PROMPT = "Commit all current changes in this worktree with a concise, descriptive commit message.";
+function commitViaClaude() {
+  const delivered = termRef.value?.submitText(COMMIT_PROMPT);
+  prMsg.value = delivered ? "Asked Claude to commit…" : "Couldn't reach the session";
+}
 const REASON_MSG: Record<string, string> = {
   "not-worktree": "Not a worktree",
   "no-branch": "No branch to push",
@@ -635,8 +644,16 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <div class="cell-diff-actions">
           <button
             class="cell-diff-btn"
+            :disabled="prBusy || working || (diff?.dirty ?? 0) === 0"
+            :title="(diff?.dirty ?? 0) === 0 ? 'No uncommitted changes' : working ? 'Wait for the session to finish' : 'Ask Claude to commit the changes'"
+            @click="commitViaClaude"
+          >
+            ✓ Commit
+          </button>
+          <button
+            class="cell-diff-btn"
             :disabled="prBusy || (diff?.ahead ?? 0) === 0"
-            :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'git push -u origin'"
+            :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes first' : 'git push -u origin'"
             @click="pushBranch"
           >
             ⬆ Push


### PR DESCRIPTION
## Summary

diff パネルに **[✓ Commit]** ボタンを追加し、取り込みフローを最後まで繋ぎます。これまで Push / Open PR は**コミット済み**しか扱えず、未コミット変更（dirty）が宙に浮いていました。

- 未コミット変更があるとき（`dirty>0`、かつ agent が idle）に **✓ Commit** が有効
- click → ターミナル既存の **`submitText()`** で、そのセルの **Claude セッションに「コミットして」と依頼**（＝Claude が良いメッセージを書く）
- コミット後は既存の `working→settle` → `loadDiff()` が走り、`ahead` が増えて `dirty` が減る → **Push / Open PR が自動で有効化**

完成フロー: **dirty → ✓ Commit → Claude がコミット → ahead↑ → ⬆ Push → ⧉ Open PR**

**サーバ変更なし**（既存の PTY input 経路を再利用）。

Closes #113 / Refs #110, #108

## Items to Confirm / Review

- **Claude に委譲**: ユーザー要望どおり、GUI で直接 `git commit` せず **Claude にコミットさせる**設計（メッセージは Claude が決める）。送信プロンプトは `COMMIT_PROMPT`（"Commit all current changes … concise, descriptive commit message."）。
- **割り込み防止**: agent が `working` の間は Commit を **disable**（実行中のターンに割り込まない）。`dirty=0` でも disable。
- **配送失敗**: ws が開いていなければ `submitText()` が false → "Couldn't reach the session" を表示。
- **既存フローの再利用**: コミット検知のための追加ポーリングは無し。`watch(working)` の既存リフレッシュに乗るだけ。

## User Prompt

> diff があって commit できる状態なら commit ボタンを作って claude に commit させて、PR への流れがつくれるとよいね

## Implementation

- `src/components/TerminalCell.vue`: `commitViaClaude()`（`termRef.submitText(COMMIT_PROMPT)` ＋ 結果メッセージ）、フッタ先頭に `[✓ Commit]`（`dirty>0 && !working && !prBusy` で有効）。
- `src/components/TerminalCell.spec.ts`: Commit 有効/click で submitText をプロンプト付き呼び出し・dirty=0 で disable・working 中 disable・配送失敗メッセージ。Terminal stub に `submitText` を追加。
- 364 tests pass / lint 0 errors / typecheck・build OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)