### PR TITLE
feat: 端末ヘッダーに 📁 Files ブラウザ（プロジェクト配下を参照）

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ Project-scoped file browsing for the [📁 Files](#files--browser) menu. All tak
 
 - **`GET /api/files/browse/raw?cwd=&path=`** → the file's bytes (MIME by extension,
   `Content-Security-Policy: sandbox`, `nosniff`, Range support). Shares the serving
-  logic with `/api/files/raw`.
+  logic with `/api/files/raw`. An unknown extension that sniffs as text (no NUL byte)
+  is served as `text/plain` so source/config files display inline instead of
+  downloading.
 
 - **`GET /api/files/browse/md?cwd=&path=`** → the file rendered from Markdown to an
   HTML document (`marked`), served under a sandbox CSP.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,23 @@ command, so the file is the allowlist of what can run.
 
 ---
 
+## Files (📁 browser)
+
+Every running terminal's header has a **📁 Files** dropdown (next to ▶ Run) that
+browses the **open project's** files — the directory that terminal's session runs in.
+Click a folder to descend (↑ to go up); click a file to **open it in a new browser
+tab**, read-only:
+
+- **Markdown** (`.md` / `.markdown`) → rendered to HTML (`marked`)
+- **Images / PDF / text / code** → served raw (images inline, text as `text/plain`)
+
+There's no in-app editing — it's for quick reference. The button is hidden until the
+terminal's project directory is known. Paths are contained within that project root,
+and bytes/markdown are served under a sandbox CSP. See
+[`GET /api/files/browse/*`](#http-get-apifilesbrowse).
+
+---
+
 ## Server API specification
 
 Base URL: `http://localhost:$PORT` (default `http://localhost:3456`).
@@ -300,6 +317,32 @@ position the client sends back to `/ws/run`).
 
 A missing or invalid `script.json` is **not** an error — it yields an empty
 `scripts` array.
+
+### HTTP: `GET /api/files/browse/*`
+
+Project-scoped file browsing for the [📁 Files](#files--browser) menu. All take
+`?cwd=<project dir>` (absolute, existing; falls back to `CLAUDE_CWD`) and a
+`?path=<rel>` contained within it (`..` / absolute escapes → `403`).
+
+- **`GET /api/files/browse/list?cwd=&path=`** → directory listing. `path` empty =
+  project root.
+
+  ```jsonc
+  { "cwd": "/Users/me/proj", "path": "src", "entries": [
+    { "name": "components", "dir": true,  "size": 0 },
+    { "name": "App.vue",    "dir": false, "size": 4096 }
+  ] }
+  ```
+
+  Entries are sorted directories-first, then by name. `404` if `path` isn't a
+  directory.
+
+- **`GET /api/files/browse/raw?cwd=&path=`** → the file's bytes (MIME by extension,
+  `Content-Security-Policy: sandbox`, `nosniff`, Range support). Shares the serving
+  logic with `/api/files/raw`.
+
+- **`GET /api/files/browse/md?cwd=&path=`** → the file rendered from Markdown to an
+  HTML document (`marked`), served under a sandbox CSP.
 
 ### HTTP: `POST /api/hook`
 
@@ -533,9 +576,10 @@ src/
   components/
     Sidebar.vue       Session list; working dot + waiting bold; pub/sub driven
     Sidebar.spec.ts   Vitest component tests
-    Terminal.vue      xterm.js terminal; /ws (or /ws/run); single-view ▶ Run menu
+    Terminal.vue      xterm.js terminal; /ws (or /ws/run); header ▶ Run + 📁 Files
     GridView.vue      Grid toolbar (auto-layout, ＋ Terminal); runs handed-off scripts
     RunMenu.vue       ▶ Run dropdown: lists a dir's script.json, emits the pick
+    FileBrowser.vue   📁 dropdown: browse the project's files, open in a new tab
     TerminalCell.vue  A cell: Claude launcher (dir picker + resume + run-a-script)
     TerminalGrid.vue  Grid of cells; auto-sizes by count; zoom lines up every tab
     CommandCell.vue   A grid cell that runs a script.json command (ephemeral)

--- a/plans/feat-file-browser.md
+++ b/plans/feat-file-browser.md
@@ -1,0 +1,42 @@
+# feat: 端末ヘッダーに 📁 Files ブラウザ
+
+Issue: #116
+
+## ゴール
+各端末ヘッダーに **📁 Files** ボタン（diff/Run と同型）。開いているプロジェクト(`serverCwd`)配下を一覧し、ファイルクリックで種類別に**ブラウザ新規タブ**で開く（参照のみ）。
+
+- 画像 → そのまま表示 / md → レンダリング / text・コード → text/plain
+- エディタ起動は今回なし。cwd 未確定ならボタン非表示。
+
+## サーバ
+新規 `server/files-browse.ts` — `mountFilesBrowseRoutes(app, { defaultCwd })`。
+- 純粋関数（テスト対象）:
+  - `resolveBase(cwd, defaultCwd)` — 絶対・実在 dir ならそれ、さもなくば defaultCwd（`resolveWorkspace` と同等）。
+  - `containedPath(base, rel)` — `path.resolve(base, rel)` が base 配下なら abs、外なら null。
+  - `mdToHtmlDoc(html, title)` — `marked` 出力を最小 HTML ドキュメントに包む。
+- エンドポイント:
+  - `GET /api/files/browse/list?cwd=&path=` → `{ cwd, path, entries: [{ name, dir, size }] }`（dir 優先・名前順）。
+  - `GET /api/files/browse/raw?cwd=&path=` → バイト配信（files.ts の `sendRawFile` を再利用、MIME＋nosniff＋sandbox CSP＋Range）。
+  - `GET /api/files/browse/md?cwd=&path=` → `marked` で HTML 化し sandbox CSP で配信。
+
+`server/backends/files.ts` を小リファクタ: `MIME_BY_EXT` と封じ込め後の配信処理を `sendRawFile(req,res,abs)` として export し、既存 `/api/files/raw` と browse/raw で共用（DRY）。
+
+## フロント
+新規 `src/components/FileBrowser.vue`（RunMenu と同型の自己完結ドロップダウン）。
+- props `cwd`。cwd 未解決ならボタン非表示。
+- 📁 ボタン＋パネル（パンくず＋Up＋一覧）。フォルダはパネル内ナビ、ファイルは拡張子で判定し `window.open`:
+  - `.md`/`.markdown` → `/api/files/browse/md?...`
+  - それ以外 → `/api/files/browse/raw?...`
+- 外側クリック / Esc で閉じる。cwd 変化で閉じてリセット（RunMenu と同様）。
+
+`Terminal.vue` ヘッダーに `<FileBrowser :cwd="serverCwd" />` を設置（RunMenu の隣）。単一ビュー＋グリッド各セル両方に出る。
+
+## テスト
+- `files-browse.spec.ts`（サーバ純粋関数: resolveBase / containedPath / mdToHtmlDoc）。
+- `FileBrowser.spec.ts`（fetch モック: 一覧表示・フォルダナビ・cwd null で非表示・cwd 変化で閉じる）。
+
+## ドキュメント
+README に「📁 Files」節と `/api/files/browse/*` を追記。
+
+## 確認ゲート
+`yarn format` / `lint` / `typecheck` / `build` / `test`。UI実機（📁→一覧→フォルダ移動→画像/md/text を新規タブで開く・cwd 無しで非表示）は手元で目視確認。

--- a/server/backends/files.spec.ts
+++ b/server/backends/files.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { mountFilesRoutes } from "./files.js";
+import { mountFilesRoutes, isProbablyTextSample } from "./files.js";
 
 let server: Server;
 let base: string;
@@ -63,5 +63,15 @@ describe("GET /api/files/raw", () => {
     expect(res.status).toBe(206);
     expect(res.headers.get("content-range")).toBe("bytes 0-1/4");
     expect((await res.arrayBuffer()).byteLength).toBe(2);
+  });
+});
+
+describe("isProbablyTextSample", () => {
+  it("treats NUL-free bytes as text", () => {
+    expect(isProbablyTextSample(Buffer.from("const x = 1;\nexport {};", "utf8"))).toBe(true);
+    expect(isProbablyTextSample(Buffer.from(""))).toBe(true);
+  });
+  it("treats a NUL byte as binary", () => {
+    expect(isProbablyTextSample(Buffer.from([0x89, 0x50, 0x00, 0x47]))).toBe(false);
   });
 });

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -49,6 +49,27 @@ function isMedia(mime: string): boolean {
   return mime.startsWith("audio/") || mime.startsWith("video/");
 }
 
+// Heuristic: a sample with no NUL byte is treated as text (git uses the same test).
+// Lets unknown source/config files (.ts, .vue, .env, no-extension) display inline as
+// text instead of downloading as octet-stream.
+export function isProbablyTextSample(buf: Buffer): boolean {
+  return !buf.includes(0);
+}
+
+function looksLikeText(abs: string): boolean {
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(abs, "r");
+    const buf = Buffer.alloc(4096);
+    const read = fs.readSync(fd, buf, 0, buf.length, 0);
+    return isProbablyTextSample(buf.subarray(0, read));
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
+
 function parseRange(header: string, size: number): { start: number; end: number } | null {
   const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
   if (!match) return null;
@@ -64,7 +85,9 @@ function parseRange(header: string, size: number): { start: number; end: number 
 // Serve an already-contained absolute file path: MIME by extension, size caps,
 // sandbox/nosniff headers, and Range support (for <video>/<audio> seeking). The
 // CALLER is responsible for path containment — this only touches `abs`.
-export function sendRawFile(req: Request, res: Response, abs: string): void {
+// `textFallback` makes an unknown extension that sniffs as text serve as text/plain
+// (so source/config files display inline) instead of downloading as octet-stream.
+export function sendRawFile(req: Request, res: Response, abs: string, opts: { textFallback?: boolean } = {}): void {
   let stat: fs.Stats;
   try {
     stat = fs.statSync(abs);
@@ -78,7 +101,8 @@ export function sendRawFile(req: Request, res: Response, abs: string): void {
   }
 
   const ext = path.extname(abs).toLowerCase();
-  const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
+  const unknownMime = opts.textFallback && looksLikeText(abs) ? "text/plain; charset=utf-8" : "application/octet-stream";
+  const mime = MIME_BY_EXT[ext] ?? unknownMime;
   const cap = isMedia(mime) ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
   if (stat.size > cap) {
     res.status(413).json({ error: `file too large (${stat.size} bytes, limit ${cap})` });

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -22,7 +22,7 @@ import type { Express, Request, Response } from "express";
 const MAX_RAW_BYTES = 25 * 1024 * 1024; // images / text / generic
 const MAX_MEDIA_BYTES = 500 * 1024 * 1024; // audio / video (streamed via Range)
 
-const MIME_BY_EXT: Record<string, string> = {
+export const MIME_BY_EXT: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -61,6 +61,57 @@ function parseRange(header: string, size: number): { start: number; end: number 
   return { start, end };
 }
 
+// Serve an already-contained absolute file path: MIME by extension, size caps,
+// sandbox/nosniff headers, and Range support (for <video>/<audio> seeking). The
+// CALLER is responsible for path containment — this only touches `abs`.
+export function sendRawFile(req: Request, res: Response, abs: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    res.status(404).json({ error: "not found" });
+    return;
+  }
+  if (!stat.isFile()) {
+    res.status(404).json({ error: "not a file" });
+    return;
+  }
+
+  const ext = path.extname(abs).toLowerCase();
+  const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
+  const cap = isMedia(mime) ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
+  if (stat.size > cap) {
+    res.status(413).json({ error: `file too large (${stat.size} bytes, limit ${cap})` });
+    return;
+  }
+
+  res.setHeader("Content-Type", mime);
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  // Sandbox the response so an SVG/HTML with embedded JS can't escape into the app
+  // origin. PDFs skip it (WebKit won't render sandbox-opaque PDFs).
+  if (mime !== "application/pdf") res.setHeader("Content-Security-Policy", "sandbox");
+  res.setHeader("Accept-Ranges", "bytes");
+
+  // Range support (required for <video>/<audio> seeking in Safari).
+  const rangeHeader = req.headers.range;
+  if (rangeHeader) {
+    const range = parseRange(rangeHeader, stat.size);
+    if (!range) {
+      res.status(416).setHeader("Content-Range", `bytes */${stat.size}`);
+      res.json({ error: "invalid range" });
+      return;
+    }
+    res.status(206);
+    res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
+    res.setHeader("Content-Length", String(range.end - range.start + 1));
+    createReadStream(abs, { start: range.start, end: range.end }).pipe(res);
+    return;
+  }
+
+  res.setHeader("Content-Length", String(stat.size));
+  createReadStream(abs).pipe(res);
+}
+
 export function mountFilesRoutes(app: Express, deps: { workspace: string }): void {
   const root = path.resolve(deps.workspace);
 
@@ -77,50 +128,6 @@ export function mountFilesRoutes(app: Express, deps: { workspace: string }): voi
       res.status(403).json({ error: "path escapes the workspace root" });
       return;
     }
-    let stat: fs.Stats;
-    try {
-      stat = fs.statSync(abs);
-    } catch {
-      res.status(404).json({ error: "not found" });
-      return;
-    }
-    if (!stat.isFile()) {
-      res.status(404).json({ error: "not a file" });
-      return;
-    }
-
-    const ext = path.extname(abs).toLowerCase();
-    const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
-    const cap = isMedia(mime) ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
-    if (stat.size > cap) {
-      res.status(413).json({ error: `file too large (${stat.size} bytes, limit ${cap})` });
-      return;
-    }
-
-    res.setHeader("Content-Type", mime);
-    res.setHeader("X-Content-Type-Options", "nosniff");
-    // Sandbox the response so an SVG/HTML with embedded JS can't escape into the app
-    // origin. PDFs skip it (WebKit won't render sandbox-opaque PDFs).
-    if (mime !== "application/pdf") res.setHeader("Content-Security-Policy", "sandbox");
-    res.setHeader("Accept-Ranges", "bytes");
-
-    // Range support (required for <video>/<audio> seeking in Safari).
-    const rangeHeader = req.headers.range;
-    if (rangeHeader) {
-      const range = parseRange(rangeHeader, stat.size);
-      if (!range) {
-        res.status(416).setHeader("Content-Range", `bytes */${stat.size}`);
-        res.json({ error: "invalid range" });
-        return;
-      }
-      res.status(206);
-      res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
-      res.setHeader("Content-Length", String(range.end - range.start + 1));
-      createReadStream(abs, { start: range.start, end: range.end }).pipe(res);
-      return;
-    }
-
-    res.setHeader("Content-Length", String(stat.size));
-    createReadStream(abs).pipe(res);
+    sendRawFile(req, res, abs);
   });
 }

--- a/server/files-browse.spec.ts
+++ b/server/files-browse.spec.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { resolveBase, containedPath, mdToHtmlDoc } from "./files-browse";
+
+const EXISTING_DIR = process.cwd(); // an absolute, existing directory
+const DEFAULT = "/default-workspace-fallback";
+
+describe("resolveBase", () => {
+  it("returns an absolute, existing directory as-is", () => {
+    expect(resolveBase(EXISTING_DIR, DEFAULT)).toBe(EXISTING_DIR);
+  });
+  it("falls back to the default for null / relative / missing dirs", () => {
+    expect(resolveBase(null, DEFAULT)).toBe(DEFAULT);
+    expect(resolveBase("relative/path", DEFAULT)).toBe(DEFAULT);
+    expect(resolveBase("/no/such/dir/xyz-123", DEFAULT)).toBe(DEFAULT);
+  });
+});
+
+describe("containedPath", () => {
+  const base = "/home/me/proj";
+  it("resolves a relative path under the base", () => {
+    expect(containedPath(base, "src/App.vue")).toBe(path.resolve(base, "src/App.vue"));
+  });
+  it("returns the root itself for an empty path", () => {
+    expect(containedPath(base, "")).toBe(path.resolve(base));
+  });
+  it("rejects traversal and absolute escapes", () => {
+    expect(containedPath(base, "../secret")).toBeNull();
+    expect(containedPath(base, "/etc/passwd")).toBeNull();
+  });
+  it("does not treat a sibling prefix as contained", () => {
+    expect(containedPath("/home/me/proj", "../proj-evil/x")).toBeNull();
+  });
+});
+
+describe("mdToHtmlDoc", () => {
+  it("wraps the body and escapes the title", () => {
+    const doc = mdToHtmlDoc("<h1>Hi</h1>", "a<b>&c");
+    expect(doc.startsWith("<!doctype html>")).toBe(true);
+    expect(doc).toContain("<h1>Hi</h1>");
+    expect(doc).toContain("<title>a&lt;b&gt;&amp;c</title>");
+  });
+});

--- a/server/files-browse.ts
+++ b/server/files-browse.ts
@@ -1,0 +1,132 @@
+// Project-scoped file browsing for the terminal header's 📁 Files menu. Unlike
+// /api/files/raw (rooted at the single workspace, for the collection plugin), these
+// take a `?cwd=` project dir — the directory the terminal's session runs in — so
+// each terminal browses ITS OWN project. Read-only; GET-only (no mutation).
+//
+// Security: the same loopback/trusted-local-user posture as the worktree and session
+// endpoints — any absolute existing dir is an allowed base — but `path` is always
+// contained within that base (no `..`/absolute escape). Bytes are served sandboxed
+// (see sendRawFile); rendered markdown is served under a sandbox CSP so embedded
+// scripts can't run in the app origin.
+import path from "node:path";
+import fs from "node:fs";
+import { marked } from "marked";
+import type { Express, Request, Response } from "express";
+import { sendRawFile } from "./backends/files.js";
+
+// Resolve a client-supplied project dir: absolute + existing dir, else the default
+// workspace (mirrors index.ts resolveWorkspace).
+export function resolveBase(cwd: string | null, defaultCwd: string): string {
+  if (cwd && path.isAbsolute(cwd)) {
+    try {
+      if (fs.statSync(cwd).isDirectory()) return cwd;
+    } catch {
+      // not a dir / missing — fall through to the default
+    }
+  }
+  return defaultCwd;
+}
+
+// Resolve `rel` under `base`; return the absolute path only if it stays within base
+// (reject `..` / absolute escapes). null = escapes the root.
+export function containedPath(base: string, rel: string): string | null {
+  const root = path.resolve(base);
+  const abs = path.resolve(root, rel);
+  if (abs !== root && !abs.startsWith(root + path.sep)) return null;
+  return abs;
+}
+
+// Wrap marked's HTML output in a minimal, self-contained document.
+export function mdToHtmlDoc(bodyHtml: string, title: string): string {
+  const esc = (s: string) => s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c] ?? c);
+  const style =
+    "body{max-width:48rem;margin:2rem auto;padding:0 1rem;font-family:system-ui,sans-serif;line-height:1.6}" +
+    "pre{background:#f4f4f4;padding:1rem;overflow:auto}code{font-family:ui-monospace,monospace}img{max-width:100%}";
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${esc(title)}</title><style>${style}</style></head><body>${bodyHtml}</body></html>`;
+}
+
+export interface BrowseEntry {
+  name: string;
+  dir: boolean;
+  size: number;
+}
+
+function listEntries(absDir: string): BrowseEntry[] {
+  return fs
+    .readdirSync(absDir, { withFileTypes: true })
+    .map((d) => {
+      const dir = d.isDirectory();
+      let size = 0;
+      if (!dir) {
+        try {
+          size = fs.statSync(path.join(absDir, d.name)).size;
+        } catch {
+          size = 0;
+        }
+      }
+      return { name: d.name, dir, size };
+    })
+    .sort((a, b) => {
+      if (a.dir !== b.dir) return a.dir ? -1 : 1; // directories first
+      return a.name.localeCompare(b.name);
+    });
+}
+
+export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string }): void {
+  const baseOf = (req: Request) => resolveBase(typeof req.query.cwd === "string" ? req.query.cwd : null, deps.defaultCwd);
+  const relOf = (req: Request) => (typeof req.query.path === "string" ? req.query.path : "");
+
+  app.get("/api/files/browse/list", (req: Request, res: Response) => {
+    const root = baseOf(req);
+    const abs = containedPath(root, relOf(req));
+    if (!abs) {
+      res.status(403).json({ error: "path escapes the project root" });
+      return;
+    }
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(abs);
+    } catch {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    if (!stat.isDirectory()) {
+      res.status(400).json({ error: "not a directory" });
+      return;
+    }
+    try {
+      res.json({ cwd: path.resolve(root), path: relOf(req), entries: listEntries(abs) });
+    } catch {
+      res.status(500).json({ error: "failed to read directory" });
+    }
+  });
+
+  app.get("/api/files/browse/raw", (req: Request, res: Response) => {
+    const abs = containedPath(baseOf(req), relOf(req));
+    if (!abs) {
+      res.status(403).json({ error: "path escapes the project root" });
+      return;
+    }
+    sendRawFile(req, res, abs);
+  });
+
+  app.get("/api/files/browse/md", async (req: Request, res: Response) => {
+    const abs = containedPath(baseOf(req), relOf(req));
+    if (!abs) {
+      res.status(403).json({ error: "path escapes the project root" });
+      return;
+    }
+    let text: string;
+    try {
+      text = fs.readFileSync(abs, "utf8");
+    } catch {
+      res.status(404).json({ error: "not found" });
+      return;
+    }
+    const html = mdToHtmlDoc(await marked.parse(text), path.basename(abs));
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Content-Security-Policy", "sandbox");
+    res.send(html);
+  });
+}

--- a/server/files-browse.ts
+++ b/server/files-browse.ts
@@ -107,7 +107,9 @@ export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string 
       res.status(403).json({ error: "path escapes the project root" });
       return;
     }
-    sendRawFile(req, res, abs);
+    // Unknown-extension files that sniff as text display inline (source/config), not
+    // download — the whole point of browsing a project's files.
+    sendRawFile(req, res, abs, { textFallback: true });
   });
 
   app.get("/api/files/browse/md", async (req: Request, res: Response) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountFilesRoutes } from "./backends/files.js";
+import { mountFilesBrowseRoutes } from "./files-browse.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
 
@@ -599,6 +600,11 @@ mountCollectionRoutes(app);
 // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
 // fields and custom-view <img> URLs. Rooted at the shared workspace.
 mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
+// Project-scoped file browsing for the terminal header's 📁 Files menu
+// (GET /api/files/browse/{list,raw,md}?cwd=&path=). Each terminal browses its own
+// session's project dir; falls back to CLAUDE_CWD for an unresolved cwd.
+mountFilesBrowseRoutes(app, { defaultCwd: CLAUDE_CWD });
 
 // Serve presentHtml pages for the View's iframe (GET /artifacts/html/<rest>) with an
 // HTML preview CSP. The View navigates the iframe to this URL (htmlArtifactPreviewUrl).

--- a/src/components/FileBrowser.spec.ts
+++ b/src/components/FileBrowser.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import FileBrowser from "./FileBrowser.vue";
+
+type Entry = { name: string; dir: boolean; size: number };
+
+// /api/files/browse/list returns entries for the requested dir; route by the `path`
+// query so folder navigation can return a different listing.
+function mockList(byPath: Record<string, Entry[]>) {
+  globalThis.fetch = vi.fn(async (url: string) => {
+    const u = new URL(String(url), "https://x");
+    const p = u.searchParams.get("path") ?? "";
+    return { ok: true, json: async () => ({ entries: byPath[p] ?? [] }) };
+  }) as unknown as typeof fetch;
+}
+
+const ROOT: Entry[] = [
+  { name: "src", dir: true, size: 0 },
+  { name: "README.md", dir: false, size: 10 },
+  { name: "logo.png", dir: false, size: 20 },
+];
+
+const openMenu = async (w: ReturnType<typeof mount>) => {
+  await w.find(".file-trigger").trigger("click");
+  await flushPromises();
+};
+
+describe("FileBrowser", () => {
+  beforeEach(() => mockList({ "": ROOT, src: [{ name: "App.vue", dir: false, size: 5 }] }));
+
+  it("renders nothing when there is no resolved project cwd", () => {
+    const w = mount(FileBrowser, { props: { cwd: null } });
+    expect(w.find(".file-menu").exists()).toBe(false);
+  });
+
+  it("lists the project root when opened (dirs and files)", async () => {
+    const w = mount(FileBrowser, { props: { cwd: "/proj" } });
+    await openMenu(w);
+    const names = w.findAll(".file-item").map((b) => b.find(".file-name").text());
+    expect(names).toEqual(["src", "README.md", "logo.png"]);
+  });
+
+  it("navigates into a folder and back up", async () => {
+    const w = mount(FileBrowser, { props: { cwd: "/proj" } });
+    await openMenu(w);
+    await w.findAll(".file-item")[0].trigger("click"); // src/
+    await flushPromises();
+    expect(w.find(".file-path").text()).toBe("src");
+    expect(w.findAll(".file-item").map((b) => b.find(".file-name").text())).toEqual(["App.vue"]);
+    await w.find(".file-up").trigger("click");
+    await flushPromises();
+    expect(w.find(".file-path").text()).toBe("/");
+  });
+
+  it("opens markdown via the md route and other files raw, in a new tab", async () => {
+    const openSpy = vi.fn();
+    vi.stubGlobal("open", openSpy);
+    const w = mount(FileBrowser, { props: { cwd: "/proj" } });
+    await openMenu(w);
+    const items = w.findAll(".file-item");
+    await items[1].trigger("click"); // README.md
+    await items[2].trigger("click"); // logo.png
+    expect(openSpy.mock.calls[0][0]).toContain("/api/files/browse/md?cwd=%2Fproj&path=README.md");
+    expect(openSpy.mock.calls[1][0]).toContain("/api/files/browse/raw?cwd=%2Fproj&path=logo.png");
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/components/FileBrowser.vue
+++ b/src/components/FileBrowser.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { ref, onUnmounted, watch, useTemplateRef } from "vue";
+
+// A header dropdown that browses the open project's files (the terminal's resolved
+// cwd) and opens a picked file in a new browser tab — markdown rendered, everything
+// else served raw (images inline, text as text/plain). Read-only; no editing.
+interface BrowseEntry {
+  name: string;
+  dir: boolean;
+  size: number;
+}
+const props = defineProps<{ cwd: string | null }>();
+
+const open = ref(false);
+const relPath = ref(""); // dir being listed, relative to the project root
+const entries = ref<BrowseEntry[]>([]);
+const loading = ref(false);
+let req = 0; // request token: drop out-of-order responses
+
+const rootRef = useTemplateRef<HTMLElement>("root");
+
+const MD_RE = /\.(md|markdown)$/i;
+const fileUrl = (name: string) => {
+  const p = relPath.value ? `${relPath.value}/${name}` : name;
+  const kind = MD_RE.test(name) ? "md" : "raw";
+  return `/api/files/browse/${kind}?cwd=${encodeURIComponent(props.cwd ?? "")}&path=${encodeURIComponent(p)}`;
+};
+
+async function loadDir() {
+  if (!props.cwd) return;
+  const reqId = ++req;
+  loading.value = true;
+  try {
+    const res = await fetch(`/api/files/browse/list?cwd=${encodeURIComponent(props.cwd)}&path=${encodeURIComponent(relPath.value)}`);
+    const data = res.ok ? await res.json() : { entries: [] };
+    if (reqId !== req) return;
+    entries.value = Array.isArray(data.entries) ? data.entries : [];
+  } catch {
+    if (reqId === req) entries.value = [];
+  } finally {
+    if (reqId === req) loading.value = false;
+  }
+}
+
+function enter(entry: BrowseEntry) {
+  if (entry.dir) {
+    relPath.value = relPath.value ? `${relPath.value}/${entry.name}` : entry.name;
+    loadDir();
+  } else {
+    window.open(fileUrl(entry.name), "_blank", "noopener");
+  }
+}
+function goUp() {
+  relPath.value = relPath.value.split("/").slice(0, -1).join("/");
+  loadDir();
+}
+
+function onOutside(e: PointerEvent) {
+  if (rootRef.value && !rootRef.value.contains(e.target as Node)) close();
+}
+function onEscape(e: KeyboardEvent) {
+  if (e.key === "Escape") close();
+}
+function openMenu() {
+  open.value = true;
+  loadDir();
+  window.addEventListener("pointerdown", onOutside);
+  window.addEventListener("keydown", onEscape);
+}
+function close() {
+  open.value = false;
+  window.removeEventListener("pointerdown", onOutside);
+  window.removeEventListener("keydown", onEscape);
+}
+function toggle() {
+  if (open.value) close();
+  else openMenu();
+}
+
+// A cwd change (session switch) invalidates the listing: close and reset to root so
+// the next open browses the new project from the top.
+watch(
+  () => props.cwd,
+  () => {
+    close();
+    relPath.value = "";
+    entries.value = [];
+  },
+);
+
+onUnmounted(close);
+</script>
+
+<template>
+  <div v-if="cwd" ref="root" class="file-menu">
+    <button class="file-trigger" :class="{ active: open }" :aria-expanded="open" aria-haspopup="menu" title="Browse project files" @click="toggle">
+      📁 Files ▾
+    </button>
+    <div v-if="open" class="file-pop" role="menu">
+      <div class="file-crumb">
+        <button class="file-up" :disabled="!relPath" title="Up" @click="goUp">↑</button>
+        <span class="file-path">{{ relPath || "/" }}</span>
+      </div>
+      <div v-if="loading" class="file-empty">Loading…</div>
+      <div v-else-if="!entries.length" class="file-empty">Empty</div>
+      <button v-for="e in entries" :key="e.name" class="file-item" role="menuitem" :title="e.name" @click="enter(e)">
+        <span class="file-icon">{{ e.dir ? "📁" : "📄" }}</span>
+        <span class="file-name">{{ e.name }}</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.file-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Matches the terminal-header buttons. */
+.file-trigger {
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.file-trigger:hover,
+.file-trigger.active {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.file-pop {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  width: 320px;
+  max-height: 60vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.file-crumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  position: sticky;
+  top: 0;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
+}
+.file-up {
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 1px 7px;
+}
+.file-up:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.file-path {
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.file-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.file-icon {
+  flex: 0 0 auto;
+}
+.file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-empty {
+  padding: 8px;
+  color: var(--text-muted);
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+}
+</style>

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -8,6 +8,7 @@ import { buildTerminalWsUrl, buildRunWsUrl } from "./wsUrl";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
 import { useTheme, currentTermTheme } from "../composables/useTheme";
 import RunMenu from "./RunMenu.vue";
+import FileBrowser from "./FileBrowser.vue";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
@@ -317,6 +318,7 @@ onUnmounted(() => {
       <span class="title">Terminal</span>
       <span :class="['status', status]">{{ status }}</span>
       <RunMenu v-if="runMenu" :cwd="serverCwd" @run="(c) => emit('run', c)" />
+      <FileBrowser v-if="runMenu" :cwd="serverCwd" />
       <button type="button" class="pick-file" title="Insert a file path" aria-label="Insert a file path" @click="pickFile">
         <span class="material-symbols-outlined">attach_file</span>
       </button>


### PR DESCRIPTION
## Summary
各端末ヘッダー（▶ Run の隣）に **📁 Files** ドロップダウンを追加。**開いているプロジェクト**（その端末＝セッションの解決済み cwd）配下のファイルを一覧し、フォルダはパネル内で移動、**ファイルはブラウザの新規タブで開く**（参照のみ・編集なし）。

- **md / markdown** → `marked` でHTMLレンダリングして表示
- **画像 / PDF / text / コード** → raw 配信（画像はインライン、テキストは text/plain）
- エディタ起動・PTY・編集は今回なし（ご要望どおり見送り）。プロジェクト未確定（cwd null）ならボタン非表示。

## Items to Confirm / Review
- **配置**: diff/Run と同じく `Terminal.vue` ヘッダー → 単一ビュー＋グリッド各セル両方に出ます（`runMenu` フラグと同条件。CommandCell には出しません）。
- **dir連動**: `serverCwd`（接続時のサーバ解決cwd）を基点に `/api/files/browse/list|raw|md?cwd=&path=`。パスはプロジェクトroot配下に封じ込め（`..`/絶対は403）。raw/md は sandbox CSP＋nosniff。
- **セキュリティ姿勢**: GET読み取り専用。`cwd` は worktree/sessions 同様「絶対・実在dirなら採用、さもなくば CLAUDE_CWD」。ローカル loopback・信頼ユーザ前提（端末から元々全ファイル読める）。
- **⚠️ UI実機未確認**: ブラウザ自動操作ツールが無く `build`/`lint`/`typecheck(client+server)`/`test` のみ。マージ前に「📁→一覧→フォルダ移動→画像/md/text を新規タブ表示・cwd 無しで非表示」を目視確認お願いします。
- **lint 補足**: ローカル `yarn lint` で `server/worktrees.ts:48`（sha1）と `server/open-dir.ts:37` が出ますが、**いずれも本PRの変更外（main既存）**で、main の CI は green です（ローカル sonarjs のバージョン差による過剰報告）。本PRの追加ファイルは lint クリーンです。

## User Prompt
> git の pr するモードなど追加した。そんな感じで dir 以下のファイルを参照する仕組みがあるとよいのかな？ 私は emacs でみるんだけど、一般的なターミナルでファイル参照をサポートし、text や md ならそこで参照（基本的なeditor…は今回見送り）、画像ならブラウザ開いたり、md も md のままブラウザで見えると良い。
>
> （方針確認）配置 = 各端末ヘッダーの📁ボタン（diffと同じ） / エディタ起動 = 今回はやめる

## 実装
- `server/files-browse.ts`（新規）: `mountFilesBrowseRoutes` ＋純粋関数 `resolveBase` / `containedPath` / `mdToHtmlDoc`。
- `server/backends/files.ts`: 封じ込め後の配信を `sendRawFile` として export 化し `/api/files/raw` と browse/raw で共用（DRY）。
- `server/index.ts`: ルート mount。
- `src/components/FileBrowser.vue`（新規）＋ `Terminal.vue` ヘッダーに設置。
- テスト: `server/files-browse.spec.ts`（純粋関数）、`src/components/FileBrowser.spec.ts`（一覧/ナビ/新規タブ/cwd null 非表示）。
- `README.md`（📁 Files 節＋`/api/files/browse/*`）、プラン `plans/feat-file-browser.md`。

Closes #116

## Verification
- `yarn typecheck` / `yarn typecheck:server` / `yarn build`: pass
- `yarn test`: **371 passed**（追加分含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)