### PR TITLE
feat: worktree セルの close 時に「残す/撤去」を選べる（未保存は警告）

### DIFF
--- a/plans/feat-worktree-close-cleanup.md
+++ b/plans/feat-worktree-close-cleanup.md
@@ -1,0 +1,22 @@
+# feat: worktree セルの close 時クリーンアップ
+
+Issue: #118（Umbrella #108 / 自動 cleanup）
+
+## スコープ（close 時のみ）
+worktree セルを ✕ で閉じるとき、**部屋を残す / 撤去** を選べる確認オーバーレイを出す。未保存（dirty/ahead）があれば警告し、黙って消さない。
+
+## 実装（`TerminalCell.vue`）
+- `close()` のテアダウン本体を `teardown()` に分離。
+- `close()`: worktree セル（`isWorktreeCell`）なら `closeConfirm=true`＋`loadDiff()`（警告用に dirty/ahead 更新）。非 worktree は即 `teardown()`（従来どおり）。
+- 確認オーバーレイ `.cell-close-confirm`:
+  - **Keep worktree** → `teardown()`（部屋は残る、ランチャから再利用可）。
+  - **Remove worktree / Discard & remove** → `removeAndClose()`: terminate（Windows の cwd ロック対策）→ `POST /api/worktrees/remove {repoDir:cwd, path:cwd, deleteBranch:true, force:true}` → `teardown()`。
+  - **Cancel** → オーバーレイを閉じてセッション継続。
+- 未保存（`dirty>0 || ahead>0`）で警告文＋ボタンを **Discard & remove**、clean なら **Remove worktree**。
+- remove は cwd（worktree パス）を repoDir/path 両方に渡す（サーバが `repoRoot` で本体解決）。サーバ変更なし。
+
+## テスト（`TerminalCell.spec.ts`）
+worktree close で確認表示／非 worktree は即 close／Keep は remove せず／Remove は force remove を POST／Cancel でセッション継続／未保存警告と Discard ラベル。
+
+## 非対象（フォロー）
+マージ/PR 検知後の自動撤去、stash、node_modules 戦略。

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -896,12 +896,67 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await w.find(".cell-close").trigger("click");
+    await flushPromises(); // the close() diff refresh enables the Remove button
     await w.find(".ccx-remove").trigger("click");
     await flushPromises();
     const rm = posts.find((p) => p.url.includes("/api/worktrees/remove"));
     if (!rm) throw new Error("remove not called");
     expect(JSON.parse(rm.body)).toMatchObject({ repoDir: WT_CWD, path: WT_CWD, deleteBranch: true, force: true });
     expect(w.find(".cell-launch").exists()).toBe(true);
+  });
+
+  it("holds Remove (Checking…) until the fresh diff load completes", async () => {
+    const gate = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    let diffCalls = 0;
+    globalThis.fetch = vi.fn((url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/diff")) {
+        diffCalls += 1;
+        // first call (on mount) resolves; the close() refresh (2nd) is gated
+        return diffCalls >= 2 ? gate.promise : Promise.resolve({ ok: true, json: async () => cleanWtDiff });
+      }
+      if (u.includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click"); // close() refresh is pending on `gate`
+    await nextTick();
+    expect(w.find(".ccx-remove").attributes("disabled")).toBeDefined(); // held while checking
+    gate.resolve({ ok: true, json: async () => cleanWtDiff });
+    await flushPromises();
+    expect(w.find(".ccx-remove").attributes("disabled")).toBeUndefined(); // released
+  });
+
+  it("keeps the confirm open with an error when the remove fails (no false success)", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/worktrees/remove")) return { ok: false, status: 500, json: async () => ({ ok: false, reason: "failed" }) };
+      if (u.includes("/api/worktrees/diff")) return { ok: true, json: async () => cleanWtDiff };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await flushPromises();
+    await w.find(".ccx-remove").trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-close-confirm").exists()).toBe(true); // NOT torn down
+    expect(w.find(".cell-launch").exists()).toBe(false);
+    expect(w.find(".ccx-warn").text()).toContain("Couldn't remove");
+  });
+
+  it("Escape dismisses the close confirmation", async () => {
+    mockFetchCloseCleanup(cleanWtDiff);
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    expect(w.find(".cell-close-confirm").exists()).toBe(true);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await nextTick();
+    expect(w.find(".cell-close-confirm").exists()).toBe(false);
+    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true);
   });
 
   it("Cancel keeps the session running", async () => {

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -846,4 +846,92 @@ describe("TerminalCell", () => {
     expect(msg).not.toBe("Pushing…");
     expect(msg).toContain("Not allowed");
   });
+
+  // Close-time cleanup: closing a worktree cell asks to keep or remove the room.
+  function mockFetchCloseCleanup(diff: Record<string, unknown>) {
+    const posts: { url: string; body: string }[] = [];
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      if (init?.method === "POST") posts.push({ url: u, body: String(init.body ?? "") });
+      if (u.includes("/api/worktrees/remove")) return { ok: true, json: async () => ({ ok: true }) };
+      if (u.includes("/api/worktrees/diff")) return { ok: true, json: async () => diff };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+    return posts;
+  }
+  const cleanWtDiff = { isWorktree: true, base: "main", ahead: 0, dirty: 0, files: [], patch: "", truncated: false };
+
+  it("closing a worktree cell asks to keep or remove the room (no immediate teardown)", async () => {
+    mockFetchCloseCleanup(cleanWtDiff);
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    expect(w.find(".cell-close-confirm").exists()).toBe(true);
+    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true); // session not torn down yet
+  });
+
+  it("a NON-worktree cell still closes immediately (no confirm)", async () => {
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: "/home/me/plain-proj" });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await nextTick();
+    expect(w.find(".cell-close-confirm").exists()).toBe(false);
+    expect(w.find(".cell-launch").exists()).toBe(true); // torn down to the launcher
+  });
+
+  it("Keep worktree tears the cell down WITHOUT removing the room", async () => {
+    const posts = mockFetchCloseCleanup(cleanWtDiff);
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await w.find(".ccx-keep").trigger("click");
+    await flushPromises();
+    expect(posts.some((p) => p.url.includes("/api/worktrees/remove"))).toBe(false);
+    expect(w.find(".cell-launch").exists()).toBe(true);
+  });
+
+  it("Remove worktree posts a forced remove (path+repoDir = the worktree) then closes", async () => {
+    const posts = mockFetchCloseCleanup(cleanWtDiff);
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await w.find(".ccx-remove").trigger("click");
+    await flushPromises();
+    const rm = posts.find((p) => p.url.includes("/api/worktrees/remove"));
+    if (!rm) throw new Error("remove not called");
+    expect(JSON.parse(rm.body)).toMatchObject({ repoDir: WT_CWD, path: WT_CWD, deleteBranch: true, force: true });
+    expect(w.find(".cell-launch").exists()).toBe(true);
+  });
+
+  it("Cancel keeps the session running", async () => {
+    mockFetchCloseCleanup(cleanWtDiff);
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await w.find(".ccx-cancel").trigger("click");
+    expect(w.find(".cell-close-confirm").exists()).toBe(false);
+    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true);
+  });
+
+  it("warns about unsaved work (unpushed + uncommitted) and labels the button Discard", async () => {
+    mockFetchCloseCleanup({
+      isWorktree: true,
+      base: "main",
+      ahead: 2,
+      dirty: 1,
+      files: [{ path: "a.ts", additions: 1, deletions: 0, status: "changed" }],
+      patch: "x",
+      truncated: false,
+    });
+    const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
+    await flushPromises();
+    await w.find(".cell-close").trigger("click");
+    await flushPromises(); // the close() diff refresh
+    const warn = w.find(".ccx-warn");
+    expect(warn.exists()).toBe(true);
+    expect(warn.text()).toContain("2 unpushed");
+    expect(warn.text()).toContain("1 uncommitted");
+    expect(w.find(".ccx-remove").text()).toContain("Discard");
+  });
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -408,6 +408,8 @@ function teardown() {
 // Closing a WORKTREE cell offers to keep or remove the room first (never silently
 // discards uncommitted/unpushed work); other cells just tear down.
 const closeConfirm = ref(false);
+const closeChecking = ref(false); // refreshing dirty/ahead — the destructive action is held until it's accurate
+const closeError = ref<string | null>(null);
 const hasUnsaved = computed(() => (diff.value?.dirty ?? 0) > 0 || (diff.value?.ahead ?? 0) > 0);
 const unsavedSummary = computed(() => {
   const ahead = diff.value?.ahead ?? 0;
@@ -418,32 +420,56 @@ const unsavedSummary = computed(() => {
   return parts.join(" + ");
 });
 
-function close() {
-  if (isWorktreeCell.value) {
-    closeConfirm.value = true;
-    loadDiff(); // refresh dirty/ahead so the warning is accurate
-  } else {
+async function close() {
+  if (!isWorktreeCell.value) {
     teardown();
+    return;
   }
+  closeError.value = null;
+  closeConfirm.value = true;
+  // Refresh dirty/ahead before the Remove button is enabled, so a fast click can't
+  // discard work that became newly dirty/ahead since the last refresh.
+  closeChecking.value = true;
+  await loadDiff();
+  closeChecking.value = false;
 }
-const cancelClose = () => (closeConfirm.value = false);
+function cancelClose() {
+  closeConfirm.value = false;
+  closeChecking.value = false;
+  closeError.value = null;
+}
 
 async function removeAndClose() {
   const dir = cwd.value;
-  termRef.value?.terminate(); // free the worktree dir before removing (Windows locks a process's cwd)
-  if (dir) {
-    try {
-      await fetch("/api/worktrees/remove", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ repoDir: dir, path: dir, deleteBranch: true, force: true }),
-      });
-    } catch {
-      // best-effort — an orphaned worktree is pruned on the next list
-    }
+  if (!dir) {
+    teardown();
+    return;
   }
-  teardown();
+  closeError.value = null;
+  termRef.value?.terminate(); // free the worktree dir first (Windows locks a process's cwd)
+  try {
+    const res = await fetch("/api/worktrees/remove", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ repoDir: dir, path: dir, deleteBranch: true, force: true }),
+    });
+    if (res.ok) return teardown();
+    closeError.value = "Couldn't remove the worktree — it may need manual cleanup.";
+  } catch {
+    closeError.value = "Couldn't reach the server to remove the worktree.";
+  }
 }
+
+// Esc dismisses the close confirmation (document-scoped: focus may be on the
+// terminal, not the overlay), matching the diff panel's Escape handling.
+function onCloseKey(e: KeyboardEvent) {
+  if (e.key === "Escape") cancelClose();
+}
+watch(closeConfirm, (open) => {
+  if (open) document.addEventListener("keydown", onCloseKey);
+  else document.removeEventListener("keydown", onCloseKey);
+});
+onUnmounted(() => document.removeEventListener("keydown", onCloseKey));
 
 // Adopt the server-assigned id (esp. for new sessions), bubble it up for
 // persistence, and load its initial activity.
@@ -710,16 +736,27 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <span v-if="prMsg" class="cell-diff-msg">{{ prMsg }}</span>
         </div>
       </div>
-      <div v-if="closeConfirm" class="cell-close-confirm">
+      <div v-if="closeConfirm" class="cell-close-confirm" role="dialog" aria-modal="true" :aria-label="`Close worktree ${headerDir}`">
         <div class="ccx-box">
           <p class="ccx-title">Close {{ headerDir }}</p>
-          <p v-if="hasUnsaved" class="ccx-warn">{{ unsavedSummary }} will be discarded if you remove the worktree.</p>
-          <p v-else class="ccx-sub">Keep the worktree to reuse it later, or remove it.</p>
-          <div class="ccx-actions">
-            <button class="ccx-btn ccx-keep" @click="teardown">Keep worktree</button>
-            <button class="ccx-btn ccx-remove" @click="removeAndClose">{{ hasUnsaved ? "Discard &amp; remove" : "Remove worktree" }}</button>
-            <button class="ccx-btn ccx-cancel" @click="cancelClose">Cancel</button>
-          </div>
+          <template v-if="!closeError">
+            <p v-if="hasUnsaved" class="ccx-warn">{{ unsavedSummary }} will be discarded if you remove the worktree.</p>
+            <p v-else class="ccx-sub">Keep the worktree to reuse it later, or remove it.</p>
+            <div class="ccx-actions">
+              <button class="ccx-btn ccx-keep" @click="teardown">Keep worktree</button>
+              <button class="ccx-btn ccx-remove" :disabled="closeChecking" @click="removeAndClose">
+                {{ closeChecking ? "Checking…" : hasUnsaved ? "Discard &amp; remove" : "Remove worktree" }}
+              </button>
+              <button class="ccx-btn ccx-cancel" @click="cancelClose">Cancel</button>
+            </div>
+          </template>
+          <template v-else>
+            <p class="ccx-warn">{{ closeError }}</p>
+            <div class="ccx-actions">
+              <button class="ccx-btn ccx-remove" @click="removeAndClose">Retry</button>
+              <button class="ccx-btn" @click="teardown">Close cell</button>
+            </div>
+          </template>
         </div>
       </div>
     </template>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -383,25 +383,66 @@ watch(ghMenuOpen, (open) => {
 });
 onUnmounted(() => document.removeEventListener("mousedown", onGhOutside));
 
-function close() {
-  // Ask the server to reap this session immediately (don't hold it through the
-  // disconnect grace window), then tear the cell down.
+// Reap the session and reset the cell back to the empty launcher. The cell isn't
+// remounted (stable key), so the dir/diff state is reset explicitly — otherwise the
+// launch form would still show the closed session's directory.
+function teardown() {
   termRef.value?.terminate();
   launched.value = false;
   sessionId.value = null;
   working.value = false;
   waiting.value = false;
   lastPrompt.value = null;
-  // The cell isn't remounted (stable key), so reset the dir state too — otherwise
-  // the empty launch form would still show the closed session's directory.
   cwd.value = props.defaultCwd;
   dirInput.value = props.defaultCwd ?? "";
   diff.value = null;
   diffOpen.value = false;
+  closeConfirm.value = false;
+  prMsg.value = null;
   emit("close");
   loadResumable();
   loadScripts();
   loadWorktrees();
+}
+
+// Closing a WORKTREE cell offers to keep or remove the room first (never silently
+// discards uncommitted/unpushed work); other cells just tear down.
+const closeConfirm = ref(false);
+const hasUnsaved = computed(() => (diff.value?.dirty ?? 0) > 0 || (diff.value?.ahead ?? 0) > 0);
+const unsavedSummary = computed(() => {
+  const ahead = diff.value?.ahead ?? 0;
+  const dirty = diff.value?.dirty ?? 0;
+  const parts: string[] = [];
+  if (ahead) parts.push(`${ahead} unpushed commit${ahead > 1 ? "s" : ""}`);
+  if (dirty) parts.push(`${dirty} uncommitted change${dirty > 1 ? "s" : ""}`);
+  return parts.join(" + ");
+});
+
+function close() {
+  if (isWorktreeCell.value) {
+    closeConfirm.value = true;
+    loadDiff(); // refresh dirty/ahead so the warning is accurate
+  } else {
+    teardown();
+  }
+}
+const cancelClose = () => (closeConfirm.value = false);
+
+async function removeAndClose() {
+  const dir = cwd.value;
+  termRef.value?.terminate(); // free the worktree dir before removing (Windows locks a process's cwd)
+  if (dir) {
+    try {
+      await fetch("/api/worktrees/remove", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repoDir: dir, path: dir, deleteBranch: true, force: true }),
+      });
+    } catch {
+      // best-effort — an orphaned worktree is pruned on the next list
+    }
+  }
+  teardown();
 }
 
 // Adopt the server-assigned id (esp. for new sessions), bubble it up for
@@ -667,6 +708,18 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             ⧉ Open PR
           </button>
           <span v-if="prMsg" class="cell-diff-msg">{{ prMsg }}</span>
+        </div>
+      </div>
+      <div v-if="closeConfirm" class="cell-close-confirm">
+        <div class="ccx-box">
+          <p class="ccx-title">Close {{ headerDir }}</p>
+          <p v-if="hasUnsaved" class="ccx-warn">{{ unsavedSummary }} will be discarded if you remove the worktree.</p>
+          <p v-else class="ccx-sub">Keep the worktree to reuse it later, or remove it.</p>
+          <div class="ccx-actions">
+            <button class="ccx-btn ccx-keep" @click="teardown">Keep worktree</button>
+            <button class="ccx-btn ccx-remove" @click="removeAndClose">{{ hasUnsaved ? "Discard &amp; remove" : "Remove worktree" }}</button>
+            <button class="ccx-btn ccx-cancel" @click="cancelClose">Cancel</button>
+          </div>
         </div>
       </div>
     </template>
@@ -1294,5 +1347,75 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   font-family: system-ui, sans-serif;
   font-size: 11px;
   color: var(--text-dim);
+}
+
+/* Close confirmation: keep or remove the worktree before tearing the cell down. */
+.cell-close-confirm {
+  position: absolute;
+  inset: 0;
+  z-index: 25;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: color-mix(in srgb, var(--bg-base) 82%, transparent);
+}
+.ccx-box {
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.ccx-title {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.ccx-sub {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.ccx-warn {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  color: var(--warn-text, #e0a030);
+}
+.ccx-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.ccx-btn {
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 6px;
+}
+.ccx-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.ccx-keep {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.ccx-remove:hover {
+  background: var(--err-hover-bg);
+  color: var(--err-text);
+  border-color: var(--err-text, #e0556b);
 }
 </style>


### PR DESCRIPTION
## Summary

worktree セルを ✕ で閉じるとき、**部屋（worktree）を残すか撤去するか**を選べる確認オーバーレイを出します。未コミット/未push があれば警告し、黙って消しません。#108 の「自動 cleanup」の中核（close 時）です。

- **Keep worktree**: セルだけ閉じる（部屋は残り、ランチャ一覧から再利用可）＝従来挙動。
- **Remove worktree / Discard & remove**: セッション終了 → `POST /api/worktrees/remove`（force, deleteBranch）→ セルリセット。
- **Cancel**: セッションに戻る。
- 未保存（`dirty>0 || ahead>0`）があれば「N unpushed + M uncommitted を破棄します」と警告し、ボタンを **Discard &amp; remove** に。
- **非 worktree セルは従来どおり即 close**（確認なし）。

サーバ変更なし（既存 remove ルートを再利用）。

Closes #118 / Refs #108

## Items to Confirm / Review

- **黙って消さない**: 未保存があれば警告＋Discard ラベル。clean なら通常 Remove。
- **remove の引数**: `repoDir` と `path` の両方に **cwd（worktree パス）**を渡す（サーバが `repoRoot` で本体を解決、`isManagedWorktree` ガードあり）。`force:true` は strict boolean（Slice2 の検証に合致）。
- **Windows 対策**: remove 前にセッション terminate（実行中プロセスの cwd dir はロックされるため）。Unix では不要だが無害。
- **警告の正確性**: `close()` で `loadDiff()` を呼び直して dirty/ahead を最新化してから警告表示。

## User Prompt

> （worktree umbrella の次として）自動 cleanup。

## Implementation

- `src/components/TerminalCell.vue`: テアダウンを `teardown()` に分離。`close()` は worktree セルなら確認オーバーレイ（`closeConfirm`）＋`loadDiff()`、非 worktree は即 teardown。`removeAndClose()`（terminate→remove→teardown）/ `cancelClose()`。`hasUnsaved` / `unsavedSummary` computed。`.cell-close-confirm` オーバーレイ＋スタイル。
- `src/components/TerminalCell.spec.ts`: worktree close で確認表示 / 非 worktree 即 close / Keep は remove せず / Remove は force remove を POST（repoDir=path=cwd）/ Cancel でセッション継続 / 未保存警告＋Discard ラベル。
- 370 tests pass / lint 0 errors / typecheck・build OK。

## 非対象（フォロー）
マージ/PR 検知後の自動撤去、stash オプション、node_modules 戦略。

🤖 Generated with [Claude Code](https://claude.com/claude-code)