### PR TITLE
chore: release 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

minor リリース **0.3.0 → 0.4.0**。本リリースの目玉は **git worktree によるエージェント隔離と取り込みワークフロー一式**。

## Highlights（0.3.0 以降）
- **worktree 隔離**: セルごとに使い捨ての作業部屋（worktree＋ブランチ）で claude を起動・再利用・撤去（#107）
- **ヘッダ表示**: worktree セルは `⎇ <repo> (<task>)` 表示（#109）
- **差分の可視化**: `+ahead ●dirty` バッジ＋ diff パネル（変更ファイル＋patch）（#111）
- **取り込み**: ⬆ Push / ⧉ Open PR（push → gh、無ければ compare URL）（#112）
- **Commit**: ✓ Commit で Claude にコミットさせて diff→PR を繋ぐ（#114）
- **close 時 cleanup**: 部屋を残す/撤去を選択、未保存は警告（#119）

完成フロー: **isolate → diff → ✓ commit → ⬆ push → ⧉ PR → close（keep / remove）**

## Items to Confirm / Review
- バージョンは `package.json` のみ（依存変更なし、yarn.lock 不変）。
- マージ後に `npm publish` → タグ `mulmoterminal@0.4.0` → GitHub release（`--latest=false`）を行います。

373 tests pass / lint 0 errors / typecheck・build OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)