### PR TITLE
feat: seed helps + preset skills at boot (workspace-setup, PR 1)

### DIFF
--- a/server/backends/workspaceSetup.spec.ts
+++ b/server/backends/workspaceSetup.spec.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import path from "node:path";
+import { isManagedWorkspace, initWorkspaceSetup } from "./workspaceSetup.js";
+
+// Save/restore MULMOCLAUDE_WORKSPACE_PATH so a test can mark a temp dir as the
+// managed workspace without leaking into sibling tests.
+const ENV_KEY = "MULMOCLAUDE_WORKSPACE_PATH";
+let savedEnv: string | undefined;
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "ws-setup-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  savedEnv = process.env[ENV_KEY];
+  Reflect.deleteProperty(process.env, ENV_KEY);
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) Reflect.deleteProperty(process.env, ENV_KEY);
+  else process.env[ENV_KEY] = savedEnv;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("isManagedWorkspace", () => {
+  it("treats ~/mulmoclaude as managed by default", () => {
+    expect(isManagedWorkspace(path.join(homedir(), "mulmoclaude"))).toBe(true);
+  });
+
+  it("treats an arbitrary project dir as not managed", () => {
+    expect(isManagedWorkspace(makeTempDir())).toBe(false);
+  });
+
+  it("honors MULMOCLAUDE_WORKSPACE_PATH (resolved compare)", () => {
+    const dir = makeTempDir();
+    process.env[ENV_KEY] = dir;
+    expect(isManagedWorkspace(dir)).toBe(true);
+    // A trailing-segment variant resolves to the same path.
+    expect(isManagedWorkspace(path.join(dir, "sub", ".."))).toBe(true);
+    expect(isManagedWorkspace(makeTempDir())).toBe(false);
+  });
+});
+
+describe("initWorkspaceSetup", () => {
+  it("seeds helps + preset-skills catalog into a managed workspace", () => {
+    const workspace = makeTempDir();
+    process.env[ENV_KEY] = workspace;
+
+    initWorkspaceSetup({ workspace });
+
+    // Help docs land under config/helps.
+    expect(existsSync(path.join(workspace, "config", "helps", "index.md"))).toBe(true);
+    // Preset skills land in the catalog half (UI-visible, not Claude-visible).
+    const presetDir = path.join(workspace, "data", "skills", "catalog", "preset");
+    expect(existsSync(path.join(presetDir, "mc-library", "SKILL.md"))).toBe(true);
+    expect(readdirSync(presetDir).every((slug) => slug.startsWith("mc-"))).toBe(true);
+  });
+
+  it("writes nothing into a non-managed workspace", () => {
+    const workspace = makeTempDir();
+    // No MULMOCLAUDE_WORKSPACE_PATH → an arbitrary dir is not managed.
+
+    initWorkspaceSetup({ workspace });
+
+    expect(existsSync(path.join(workspace, "config"))).toBe(false);
+    expect(existsSync(path.join(workspace, "data"))).toBe(false);
+    expect(existsSync(path.join(workspace, ".claude"))).toBe(false);
+    expect(readdirSync(workspace)).toHaveLength(0);
+  });
+});

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -1,0 +1,85 @@
+// Boot-time workspace seeding, shared with MulmoClaude via @mulmoclaude/core. On a
+// MulmoTerminal-alone run the workspace would otherwise be empty: no help docs and
+// no preset skills. This seeds both so the workspace experience matches a run that
+// booted MulmoClaude first.
+//
+// Seeding is GATED to the managed mulmoclaude workspace (~/mulmoclaude, or
+// MULMOCLAUDE_WORKSPACE_PATH). The launcher often runs the terminal in an arbitrary
+// project directory (bin/mulmoterminal.js defaults CLAUDE_CWD to the cwd it ran
+// from), and we must NOT write mulmoclaude presets/helps there — especially into
+// .claude/skills, which many dev repos already own.
+//
+// Destinations match MulmoClaude's WORKSPACE_DIRS exactly so both apps share one
+// on-disk layout:
+//   <ws>/config/helps                 — seeded help docs
+//   <ws>/data/skills/catalog/preset   — preset skills catalog (UI-visible)
+//   <ws>/.claude/skills               — active (starred) preset skills (Claude-visible)
+import path from "node:path";
+import os from "node:os";
+import { mkdirSync } from "node:fs";
+import { seedHelps, syncPresetSkills, syncActivePresetSkills, presetSkillsAssetDir } from "@mulmoclaude/core/workspace-setup";
+
+// Console-backed logger, matching the prefix style other backends use.
+const log = {
+  info: (message: string, data?: Record<string, unknown>) => console.log(`[workspace-setup] ${message}`, data ?? ""),
+  warn: (message: string, data?: Record<string, unknown>) => console.warn(`[workspace-setup] ${message}`, data ?? ""),
+  error: (message: string, data?: Record<string, unknown>) => console.error(`[workspace-setup] ${message}`, data ?? ""),
+};
+
+/** The managed mulmoclaude workspace: MULMOCLAUDE_WORKSPACE_PATH if set, else
+ *  ~/mulmoclaude. */
+function managedWorkspacePath(): string {
+  return process.env.MULMOCLAUDE_WORKSPACE_PATH || path.join(os.homedir(), "mulmoclaude");
+}
+
+/** True only when `workspace` resolves to the managed mulmoclaude workspace. Seeding
+ *  is confined to it so launching the terminal in an arbitrary project dir never
+ *  writes mulmoclaude presets/helps there. */
+export function isManagedWorkspace(workspace: string): boolean {
+  return path.resolve(workspace) === path.resolve(managedWorkspacePath());
+}
+
+// Run one seeding step in isolation: a filesystem edge case (EACCES/ENOSPC/path
+// collision) must log and continue, never abort server startup or skip later steps.
+function safeStep(label: string, run: () => void): void {
+  try {
+    run();
+  } catch (err) {
+    log.error(`${label} failed — continuing`, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+/** Seed help docs + preset skills into the workspace, but only when it is the
+ *  managed mulmoclaude workspace. Each step is fault-isolated so a single FS failure
+ *  cannot abort boot. */
+export function initWorkspaceSetup(deps: { workspace: string }): void {
+  const { workspace } = deps;
+  if (!isManagedWorkspace(workspace)) {
+    log.info("skipping seed — not the managed mulmoclaude workspace", { workspace });
+    return;
+  }
+
+  const source = presetSkillsAssetDir();
+  const onInfo = (message: string, data?: Record<string, unknown>) => log.info(message, data);
+  const onWarn = (message: string, data?: Record<string, unknown>) => log.warn(message, data);
+
+  safeStep("seedHelps", () => {
+    const dest = path.join(workspace, "config", "helps");
+    seedHelps({ destDir: dest });
+    log.info("seeded help docs", { dest });
+  });
+
+  safeStep("syncPresetSkills", () => {
+    const dest = path.join(workspace, "data", "skills", "catalog", "preset");
+    mkdirSync(dest, { recursive: true });
+    const result = syncPresetSkills({ sourceDir: source, destDir: dest, onInfo, onWarn });
+    log.info("synced preset skills catalog", { copied: result.copied.length, removed: result.removed.length, skipped: result.skipped.length });
+  });
+
+  safeStep("syncActivePresetSkills", () => {
+    const active = path.join(workspace, ".claude", "skills");
+    mkdirSync(active, { recursive: true });
+    const result = syncActivePresetSkills({ sourceDir: source, activeDir: active, onInfo, onWarn });
+    log.info("refreshed active preset skills", { updated: result.updated.length, removed: result.removed.length, skipped: result.skipped.length });
+  });
+}

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -59,7 +59,6 @@ export function initWorkspaceSetup(deps: { workspace: string }): void {
     return;
   }
 
-  const source = presetSkillsAssetDir();
   const onInfo = (message: string, data?: Record<string, unknown>) => log.info(message, data);
   const onWarn = (message: string, data?: Record<string, unknown>) => log.warn(message, data);
 
@@ -69,17 +68,21 @@ export function initWorkspaceSetup(deps: { workspace: string }): void {
     log.info("seeded help docs", { dest });
   });
 
+  // Resolve the bundled preset source INSIDE each step that needs it, not once
+  // up front: presetSkillsAssetDir() can throw if core's assets are missing /
+  // mispackaged, and that must log + continue like any other step rather than
+  // abort boot before fault isolation engages.
   safeStep("syncPresetSkills", () => {
     const dest = path.join(workspace, "data", "skills", "catalog", "preset");
     mkdirSync(dest, { recursive: true });
-    const result = syncPresetSkills({ sourceDir: source, destDir: dest, onInfo, onWarn });
+    const result = syncPresetSkills({ sourceDir: presetSkillsAssetDir(), destDir: dest, onInfo, onWarn });
     log.info("synced preset skills catalog", { copied: result.copied.length, removed: result.removed.length, skipped: result.skipped.length });
   });
 
   safeStep("syncActivePresetSkills", () => {
     const active = path.join(workspace, ".claude", "skills");
     mkdirSync(active, { recursive: true });
-    const result = syncActivePresetSkills({ sourceDir: source, activeDir: active, onInfo, onWarn });
+    const result = syncActivePresetSkills({ sourceDir: presetSkillsAssetDir(), activeDir: active, onInfo, onWarn });
     log.info("refreshed active preset skills", { updated: result.updated.length, removed: result.removed.length, skipped: result.skipped.length });
   });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ import { mountGitRemoteRoute } from "./gitRemote.js";
 import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
+import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
@@ -111,6 +112,11 @@ const CLAUDE_CWD = process.env.CLAUDE_CWD || path.join(os.homedir(), "mulmoclaud
 // CLAUDE_CWD is the workspace used as the PTY cwd and as the root for persisted
 // session state, so it must exist before we spawn anything into it.
 await fs.mkdir(CLAUDE_CWD, { recursive: true });
+
+// Seed help docs + preset skills so a MulmoTerminal-alone run gets the full
+// workspace experience. Gated to the managed mulmoclaude workspace and
+// fault-isolated per step, so it never aborts boot (see workspaceSetup.ts).
+initWorkspaceSetup({ workspace: CLAUDE_CWD });
 
 // MulmoTerminal's own per-session GUI state (tool-result render data + tool-call
 // history) lives here, keyed by sessionId (a global UUID) — NOT under the


### PR DESCRIPTION
## Why

On a **MulmoTerminal-alone run** (the user never boots MulmoClaude) the shared workspace starts empty — no help docs, no preset skills. This wires `@mulmoclaude/core/workspace-setup` so boot seeds both, matching a run that booted MulmoClaude first. This is **PR 1** of `plans/feat-shared-backend-services.md` (PR 0 landed in #121).

## Changes

- **`server/backends/workspaceSetup.ts`** — `initWorkspaceSetup({workspace})`:
  - **Gated** by `isManagedWorkspace`: seeds only when the workspace resolves to the managed mulmoclaude workspace (`~/mulmoclaude`, or `MULMOCLAUDE_WORKSPACE_PATH`). The launcher often runs the terminal in an arbitrary project dir, and we must NOT write mulmoclaude presets/helps there — especially into `.claude/skills`, which many dev repos already own.
  - Three steps, matching MulmoClaude's `WORKSPACE_DIRS` exactly: `seedHelps` → `config/helps`, `syncPresetSkills` → `data/skills/catalog/preset`, `syncActivePresetSkills` → `.claude/skills`.
  - Each step runs through `safeStep` — an FS edge case (EACCES/ENOSPC/path collision) **logs + continues** and never aborts server startup.
- **`server/index.ts`** — call it right after the workspace `mkdir`.
- **`workspaceSetup.spec.ts`** — managed-vs-arbitrary detection (incl. `MULMOCLAUDE_WORKSPACE_PATH`); happy-path seeding into a managed workspace (helps `index.md` + `mc-*` presets land); **no** writes into a non-managed cwd.

## Verification

- `yarn typecheck`, `yarn lint` (0 errors), `yarn test` (378 passed), `yarn build` — all green.
- **Boot smoke** against a managed temp workspace: seeds 9 preset skills + help docs with no errors; active-skills sync correctly no-ops (nothing starred yet). A non-managed dir is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)