### PR TITLE
feat: unify markdown+html live-refresh via shared file-change publisher (PR 2)

### DIFF
--- a/server/backends/fileChange.spec.ts
+++ b/server/backends/fileChange.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resetFileChangePublisher } from "@mulmoclaude/core/file-change";
+import { initFileChangePublisher, publishFileChange } from "./fileChange.js";
+
+// Capture every pubsub publish the binding makes.
+interface Published {
+  channel: string;
+  data: unknown;
+}
+let published: Published[] = [];
+let workspace: string;
+const tempDirs: string[] = [];
+
+function seedFile(rel: string, body = "x"): void {
+  const abs = path.join(workspace, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, body);
+}
+
+beforeEach(() => {
+  workspace = mkdtempSync(path.join(tmpdir(), "mt-fc-"));
+  tempDirs.push(workspace);
+  published = [];
+  initFileChangePublisher({
+    workspace,
+    pubsub: { publish: (channel, data) => published.push({ channel, data }) },
+  });
+});
+
+afterEach(() => {
+  resetFileChangePublisher();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("initFileChangePublisher", () => {
+  it("forwards a markdown doc to the markdown plugin channel with its mtime", async () => {
+    const rel = "artifacts/documents/2026/06/note-abc123.md";
+    seedFile(rel);
+
+    await publishFileChange(rel);
+
+    expect(published).toHaveLength(1);
+    expect(published[0].channel).toBe(`plugin:markdown:file:${rel}`);
+    const payload = published[0].data as { path: string; mtimeMs: number };
+    expect(payload.path).toBe(rel);
+    expect(typeof payload.mtimeMs).toBe("number");
+  });
+
+  it("forwards an html artifact to the html plugin channel", async () => {
+    const rel = "artifacts/html/2026/06/page.html";
+    seedFile(rel);
+
+    await publishFileChange(rel);
+
+    expect(published).toHaveLength(1);
+    expect(published[0].channel).toBe(`plugin:html:file:${rel}`);
+  });
+
+  it("does not publish for a path that matches no scope", async () => {
+    const rel = "artifacts/other/data.txt";
+    seedFile(rel);
+
+    await publishFileChange(rel);
+
+    expect(published).toHaveLength(0);
+  });
+
+  it("drops a path that escapes the workspace", async () => {
+    await publishFileChange("../escape.md");
+
+    expect(published).toHaveLength(0);
+  });
+});

--- a/server/backends/fileChange.ts
+++ b/server/backends/fileChange.ts
@@ -1,0 +1,51 @@
+// Workspace file-change publisher, shared with MulmoClaude via @mulmoclaude/core.
+// A write site calls publishFileChange(workspaceRelPath); the publisher stats the
+// post-write mtime and forwards a { path, mtimeMs } payload to every plugin View
+// whose scope matches, on the channel that View's runtime subscribes to
+// (plugin:<scope>:file:<path>). This unifies the markdown + html live-refresh paths
+// that each previously hand-rolled their own pubsub publish.
+//
+// No primaryChannel: MulmoTerminal has no general files-explorer subscriber, so only
+// the plugin-scoped channels are published.
+import path from "node:path";
+import { configureFileChangePublisher, publishFileChange } from "@mulmoclaude/core/file-change";
+import type { createPubSub } from "../pubsub.js";
+
+type PubSub = ReturnType<typeof createPubSub>;
+
+const log = {
+  warn: (message: string, data?: Record<string, unknown>) => console.warn(`[file-change] ${message}`, data ?? ""),
+};
+
+// Scope matchers mirror the host write sites exactly:
+//   markdown — artifacts/documents/**.md (the presentDocument View's isFilePath gate)
+//   html     — **.html                   (the presentHtml View)
+function isMarkdownDoc(posixPath: string): boolean {
+  return posixPath.startsWith("artifacts/documents/") && posixPath.endsWith(".md");
+}
+
+function isHtmlDoc(posixPath: string): boolean {
+  return posixPath.endsWith(".html");
+}
+
+/** Configure the shared publisher against MulmoTerminal's pubsub + workspace. Call
+ *  once at startup, before any write route runs. */
+export function initFileChangePublisher(deps: { workspace: string; pubsub: PubSub | null }): void {
+  const { workspace, pubsub } = deps;
+  configureFileChangePublisher({
+    publish: (channel, payload) => pubsub?.publish(channel, payload),
+    workspaceRoot: workspace,
+    // Normalise to POSIX so payload.path + channel suffix never drift on mixed
+    // separators (our rels are already "/"-joined, so this is a no-op on POSIX).
+    toPosix: (relativePath) => relativePath.split(path.sep).join("/"),
+    pluginScopes: [
+      { scope: "markdown", matches: isMarkdownDoc },
+      { scope: "html", matches: isHtmlDoc },
+    ],
+    warn: (message, data) => log.warn(message, data),
+  });
+}
+
+// Re-export so write backends import the publish from one place (and so they can't
+// reach a differently-configured copy).
+export { publishFileChange };

--- a/server/backends/html.spec.ts
+++ b/server/backends/html.spec.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
 
   const app = express();
   app.use(express.json());
-  mountHtmlDispatchRoute(app, { getPubsub: () => null });
+  mountHtmlDispatchRoute(app);
   mountHtmlPreviewRoute(app, { workspace: ws });
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => resolve());

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -19,9 +19,7 @@ import { createReadStream } from "node:fs";
 import type { Express, Request, Response, NextFunction } from "express";
 import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
 import { artifactsFileOps } from "./artifacts.js";
-import type { createPubSub } from "../pubsub.js";
-
-type PubSub = ReturnType<typeof createPubSub>;
+import { publishFileChange } from "./fileChange.js";
 
 // Curated CDN allowlist (matches the collection custom-view policy) for an
 // LLM-authored page that may pull a charting/util lib or font from a CDN.
@@ -55,9 +53,8 @@ const HTML_PREVIEW_CSP = [
 
 /** Intercept the View's dispatch (loadHtml/saveHtml) on /api/plugin/presentHtml,
  *  before the generic plugin catch-all (which handles the tool-call). MUST be
- *  registered BEFORE mountAllRoutes. `getPubsub` is a thunk because pubsub is
- *  created after routes are mounted; the handler reads it live at request time. */
-export function mountHtmlDispatchRoute(app: Express, deps: { getPubsub: () => PubSub | null }): void {
+ *  registered BEFORE mountAllRoutes. */
+export function mountHtmlDispatchRoute(app: Express): void {
   app.post("/api/plugin/presentHtml", async (req: Request, res: Response, next: NextFunction) => {
     const args = (req.body ?? {}) as { kind?: unknown; path?: unknown };
     // A tool-call (no `kind`) is left to the package execute via the catch-all.
@@ -65,24 +62,15 @@ export function mountHtmlDispatchRoute(app: Express, deps: { getPubsub: () => Pu
     try {
       const result = await executeHtmlDispatch({ files: { artifacts: artifactsFileOps } }, args as never);
       if (args.kind === "saveHtml" && typeof args.path === "string") {
-        // Live-refresh: bump any open View watching this file (channel matches the
-        // frontend runtime scope "html" → plugin:html:file:<path>).
-        try {
-          const stat = await artifactsFileOps.stat(toArtifactsRel(args.path));
-          deps.getPubsub()?.publish(`plugin:html:file:${args.path}`, { mtimeMs: stat.mtimeMs });
-        } catch {
-          // Best-effort; the saver already updated its local state.
-        }
+        // Live-refresh via the shared publisher: the "html" scope forwards to
+        // plugin:html:file:<path>, the channel the open View subscribes to.
+        await publishFileChange(args.path);
       }
       res.json(result);
     } catch (err) {
       res.status(400).json({ error: err instanceof Error ? err.message : String(err) });
     }
   });
-}
-
-function toArtifactsRel(workspaceRel: string): string {
-  return workspaceRel.startsWith("artifacts/") ? workspaceRel.slice("artifacts/".length) : workspaceRel;
 }
 
 /** Serve `GET /artifacts/html/<rest>` — the iframe preview source — from the

--- a/server/backends/markdown.ts
+++ b/server/backends/markdown.ts
@@ -18,21 +18,17 @@ import { randomUUID } from "node:crypto";
 import { marked } from "marked";
 import { renderMarpDeck, fillImagePlaceholders } from "@mulmoclaude/markdown-plugin";
 import type { MarkdownHostApp, ExportPdfOptions } from "@mulmoclaude/markdown-plugin";
-import type { createPubSub } from "../pubsub.js";
+import { publishFileChange } from "./fileChange.js";
 import { generateImage } from "./image-gen.js";
-
-type PubSub = ReturnType<typeof createPubSub>;
 
 const DOCS_DIR = "artifacts/documents";
 
-// Set once at boot (server/index.ts) — workspace = CLAUDE_CWD, pubsub for
-// live-refresh forwarding to the plugin-scoped channel.
+// Set once at boot (server/index.ts) — workspace = CLAUDE_CWD. File-change
+// live-refresh is forwarded by the shared publisher (see fileChange.ts).
 let workspace: string | null = null;
-let pubsub: PubSub | null = null;
 
-export function initMarkdownBackend(deps: { workspace: string; pubsub: PubSub | null }): void {
+export function initMarkdownBackend(deps: { workspace: string }): void {
   workspace = deps.workspace;
-  pubsub = deps.pubsub ?? null;
 }
 
 // Strict gate (matches the package's isFilePath + MulmoClaude's isMarkdownPath):
@@ -67,12 +63,6 @@ function buildNewDocPath(prefix: string): string {
   return `${DOCS_DIR}/${yyyy}/${mm}/${sanitizePrefix(prefix)}-${rand}.md`;
 }
 
-function publishFileChange(rel: string): void {
-  // The package View subscribes via runtime.pubsub "file:<path>" →
-  // "plugin:markdown:file:<path>". Forward self-saves so other tabs refresh.
-  pubsub?.publish(`plugin:markdown:file:${rel}`, { path: rel, mtimeMs: Date.now() });
-}
-
 const MARKDOWN_PDF_CSS = `
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; font-size: 13px; line-height: 1.6; color: #1f2937; max-width: 800px; margin: 0 auto; padding: 32px 48px; }
   h1 { font-size: 1.75rem; } h2 { font-size: 1.25rem; border-bottom: 1px solid #e5e7eb; padding-bottom: .25rem; } h3 { font-size: 1rem; }
@@ -90,7 +80,7 @@ export const markdownHostApp: MarkdownHostApp = {
   async saveDoc(rel, markdown) {
     if (!isDocPath(rel)) throw new Error(`invalid document path: ${rel}`);
     await fs.promises.writeFile(absFor(rel), markdown);
-    publishFileChange(rel);
+    await publishFileChange(rel);
     return { path: rel };
   },
 
@@ -99,6 +89,9 @@ export const markdownHostApp: MarkdownHostApp = {
     const abs = absFor(rel);
     await fs.promises.mkdir(path.dirname(abs), { recursive: true });
     await fs.promises.writeFile(abs, markdown);
+    // Publish the create too (previously an unpublished gap) so a View already
+    // open on this path live-refreshes instead of going stale.
+    await publishFileChange(rel);
     return { path: rel };
   },
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
+import { initFileChangePublisher } from "./backends/fileChange.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
@@ -590,7 +591,7 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
 // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
 // /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
 // catch-all (which handles the tool-call); a request without `kind` falls through.
-mountHtmlDispatchRoute(app, { getPubsub: () => pubsub });
+mountHtmlDispatchRoute(app);
 
 // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
 // POST /api/form). The GUI MCP server dispatches tool calls to these.
@@ -927,10 +928,14 @@ app.get("/api/sessions", async (req, res) => {
 const server = http.createServer(app);
 pubsub = createPubSub(server, isAllowedOrigin);
 
-// Give the markdown host app its workspace (for artifacts/documents storage) +
-// pubsub (to forward file-change events to the plugin-scoped channel so the
-// presentDocument view live-refreshes). Done after pubsub exists (task #6).
-initMarkdownBackend({ workspace: CLAUDE_CWD, pubsub });
+// Wire the shared file-change publisher (markdown + html live-refresh) against
+// pubsub + the workspace. Must run before any write route fires (publishFileChange
+// is a no-op until configured).
+initFileChangePublisher({ workspace: CLAUDE_CWD, pubsub });
+
+// Give the markdown host app its workspace (for artifacts/documents storage).
+// File-change live-refresh is handled by the shared publisher above.
+initMarkdownBackend({ workspace: CLAUDE_CWD });
 
 // Give the artifacts FileOps backend its workspace root (<workspace>/artifacts) so
 // @mulmoclaude/chart-plugin's executeChart can persist chart documents there.


### PR DESCRIPTION
## Why

`markdown.ts` and `html.ts` each hand-rolled their own pubsub publish for live-refresh — duplicated path/mtime/containment logic, and `saveNewDoc` didn't publish at all. This routes both through `@mulmoclaude/core/file-change` so the publish behavior (POSIX normalization, post-write mtime via `stat`, out-of-workspace containment, plugin-scope forwarding) lives in one shared place. **PR 2** of `plans/feat-shared-backend-services.md` (PR 0 #121, PR 1 #122 merged).

## Changes

- **`server/backends/fileChange.ts`** (new) — `initFileChangePublisher({workspace, pubsub})` configures the shared publisher with two scopes: `markdown` → `artifacts/documents/**.md`, `html` → `**.html`. **No `primaryChannel`** (MulmoTerminal has no general files-explorer subscriber). Re-exports `publishFileChange` so write sites import from one place.
- **`server/index.ts`** — init it right after `createPubSub`, before the write backends (so it's configured before any write route fires).
- **`markdown.ts`** — drop the hand-rolled `publishFileChange` + the `pubsub` dep on `initMarkdownBackend`; route `saveDoc` **and** `saveNewDoc` (previously an unpublished gap) through the shared publish.
- **`html.ts`** — drop the `getPubsub` thunk + manual `stat`/publish; route `saveHtml` through the shared publish. `mountHtmlDispatchRoute(app)` no longer needs a pubsub thunk.
- **`fileChange.spec.ts`** (new) — md/html channel correctness (`plugin:<scope>:file:<path>` + mtime), no-publish for an unmatched path, out-of-workspace path dropped.

Channels are unchanged from before (`plugin:markdown:file:<path>` / `plugin:html:file:<path>`), so existing View subscribers keep working.

## Out of scope

Collection live-refresh — `@mulmoclaude/collection-plugin/vue`'s View has no file-change subscriber, so publishing on `writeItem`/`deleteItem` wouldn't refresh anything. Closing it needs a subscriber in the collection plugin (separate effort).

## Verification

- `yarn typecheck`, `yarn lint` (0 errors), `yarn test` (382 passed, +4 new), `yarn build` — all green.
- **Boot smoke**: clean boot with the new wiring; a `saveHtml` dispatch round-trips (HTTP 200, file written) through the shared publisher with zero file-change warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)