### PR TITLE
feat: notifier + collection-watchers + toolbar bell (PR 3)

### DIFF
--- a/server/backends/collectionWatchers.ts
+++ b/server/backends/collectionWatchers.ts
@@ -1,51 +1,72 @@
 // Collection completion bells, shared with MulmoClaude via @mulmoclaude/core. The
-// watcher fs.watches each collection's data dir; when a record that the schema marks
-// as "pending completion" lands (or its file/done-state changes), the reconciler
-// drives the notifier: publish an "action" bell while pending, clear it when done.
+// watcher fs.watches each collection's data dir; when a record the schema marks as
+// "pending completion" lands (or its file/done-state changes), the reconciler drives
+// the notifier: publish an "action" bell while pending, clear it when done.
 //
-// The reconciler owns an internal `legacyId` (slug+itemId) round-tripped through the
-// entry's pluginData. This adapter is the MulmoTerminal-specific delivery sink: it
-// chooses the bell's plugin namespace, severity mapping, deep-link target, and the
-// pluginData shape that lets the reconciler recognise its own entries on a rescan.
+// CROSS-APP PARITY: MulmoTerminal and MulmoClaude share ONE notifier file
+// (<ws>/data/notifier/active.json) and never run simultaneously. For a record to
+// carry exactly ONE bell regardless of which app published it, this adapter MUST be
+// byte-identical to MulmoClaude's (server/workspace/collections/notifications.ts):
+// the same pluginPkg, the same `LegacyNotifierPluginData` shape, and a `readEntry`
+// that recognises ANY legacy entry by its marker. Then MulmoTerminal's reconciler
+// recognises a bell MulmoClaude already published (same legacyId) and won't add a
+// duplicate — and vice-versa. Diverging here is what produced double bells.
+//
+// The legacy types live in MulmoClaude's app source (not the published package), so
+// the small shape is mirrored locally rather than imported.
 import { configureCollectionWatchers, startCollectionWatchers } from "@mulmoclaude/core/collection-watchers";
 import type { CollectionNotificationAdapter, CompletionPriority } from "@mulmoclaude/core/collection-watchers";
 
 const log = {
   info: (message: string, data?: Record<string, unknown>) => console.log(`[collection-watchers] ${message}`, data ?? ""),
   warn: (message: string, data?: Record<string, unknown>) => console.warn(`[collection-watchers] ${message}`, data ?? ""),
-  error: (message: string, data?: Record<string, unknown>) => console.error(`[collection-watchers] ${message}`, data ?? ""),
 };
 
-// The pluginData this reconciler stores on each completion bell. `kind` lets readEntry
-// recognise our entries on a listAll() scan and skip foreign ones.
-interface CompletionPluginData {
-  kind: "collection-completion";
+// Mirror of MulmoClaude's LegacyNotifierPluginData (the subset collection bells use).
+// `legacy: true` + a string `legacyId` + a string `kind` is the marker both apps'
+// readEntry recognise; the navigate `action` preserves the bell's icon/routing.
+interface LegacyNotifierPluginData {
+  legacy: true;
   legacyId: string;
-  slug: string;
-  itemId: string;
-  priority: CompletionPriority;
-  navigateTarget: string;
+  kind: "todo";
+  priority: "normal" | "high";
+  action: { type: "navigate"; target: { view: "collections"; slug: string; itemId: string } };
 }
 
-/** Deep-link the bell row navigates to: the collections browse overlay focused on the
- *  pending record. The frontend parses this back to (slug, itemId). */
+function isLegacyNotifierPluginData(value: unknown): value is LegacyNotifierPluginData {
+  if (value === null || typeof value !== "object") return false;
+  const rec = value as Record<string, unknown>;
+  return rec.legacy === true && typeof rec.legacyId === "string" && typeof rec.kind === "string";
+}
+
+/** Deep-link the bell row navigates to: `/collections/<slug>?selected=<itemId>` (the
+ *  documented record permalink). Dot-segment slugs would normalise out of the route,
+ *  so fall back to the index — matches MulmoClaude's builder. */
 function buildNavigateTarget(slug: string, itemId: string): string {
-  return `/collections/${encodeURIComponent(slug)}?selected=${encodeURIComponent(itemId)}`;
+  if (slug === "." || slug === "..") return "/collections";
+  const base = `/collections/${encodeURIComponent(slug)}`;
+  return itemId ? `${base}?selected=${encodeURIComponent(itemId)}` : base;
 }
 
 const adapter: CollectionNotificationAdapter = {
-  pluginPkg: "collections",
-  // A high-priority pending record is a real obligation (red); anything else nudges
-  // (amber). Never "info" — the engine forbids info-severity action entries.
+  // MulmoClaude's collection bells publish under its legacy namespace; match it so
+  // the shared notifier treats both apps' bells as the same entry.
+  pluginPkg: "todo",
+  // high → urgent (red), normal → nudge (amber). Never "info" — the engine forbids
+  // info-severity action entries.
   priorityToSeverity: (priority) => (priority === "high" ? "urgent" : "nudge"),
   buildNavigateTarget,
-  buildPluginData: ({ legacyId, slug, itemId, priority, navigateTarget }) =>
-    ({ kind: "collection-completion", legacyId, slug, itemId, priority, navigateTarget }) satisfies CompletionPluginData,
+  buildPluginData: ({ legacyId, slug, itemId, priority }): LegacyNotifierPluginData => ({
+    legacy: true,
+    legacyId,
+    kind: "todo",
+    priority: priority === "high" ? "high" : "normal",
+    action: { type: "navigate", target: { view: "collections", slug, itemId } },
+  }),
   readEntry: (pluginData) => {
-    if (typeof pluginData !== "object" || pluginData === null) return null;
-    const data = pluginData as Partial<CompletionPluginData>;
-    if (data.kind !== "collection-completion" || typeof data.legacyId !== "string") return null;
-    return { legacyId: data.legacyId, priority: data.priority === "high" ? "high" : "normal" };
+    if (!isLegacyNotifierPluginData(pluginData)) return null;
+    const priority: CompletionPriority = pluginData.priority === "high" ? "high" : "normal";
+    return { legacyId: pluginData.legacyId, priority };
   },
 };
 

--- a/server/backends/collectionWatchers.ts
+++ b/server/backends/collectionWatchers.ts
@@ -1,0 +1,59 @@
+// Collection completion bells, shared with MulmoClaude via @mulmoclaude/core. The
+// watcher fs.watches each collection's data dir; when a record that the schema marks
+// as "pending completion" lands (or its file/done-state changes), the reconciler
+// drives the notifier: publish an "action" bell while pending, clear it when done.
+//
+// The reconciler owns an internal `legacyId` (slug+itemId) round-tripped through the
+// entry's pluginData. This adapter is the MulmoTerminal-specific delivery sink: it
+// chooses the bell's plugin namespace, severity mapping, deep-link target, and the
+// pluginData shape that lets the reconciler recognise its own entries on a rescan.
+import { configureCollectionWatchers, startCollectionWatchers } from "@mulmoclaude/core/collection-watchers";
+import type { CollectionNotificationAdapter, CompletionPriority } from "@mulmoclaude/core/collection-watchers";
+
+const log = {
+  info: (message: string, data?: Record<string, unknown>) => console.log(`[collection-watchers] ${message}`, data ?? ""),
+  warn: (message: string, data?: Record<string, unknown>) => console.warn(`[collection-watchers] ${message}`, data ?? ""),
+  error: (message: string, data?: Record<string, unknown>) => console.error(`[collection-watchers] ${message}`, data ?? ""),
+};
+
+// The pluginData this reconciler stores on each completion bell. `kind` lets readEntry
+// recognise our entries on a listAll() scan and skip foreign ones.
+interface CompletionPluginData {
+  kind: "collection-completion";
+  legacyId: string;
+  slug: string;
+  itemId: string;
+  priority: CompletionPriority;
+  navigateTarget: string;
+}
+
+/** Deep-link the bell row navigates to: the collections browse overlay focused on the
+ *  pending record. The frontend parses this back to (slug, itemId). */
+function buildNavigateTarget(slug: string, itemId: string): string {
+  return `/collections/${encodeURIComponent(slug)}?selected=${encodeURIComponent(itemId)}`;
+}
+
+const adapter: CollectionNotificationAdapter = {
+  pluginPkg: "collections",
+  // A high-priority pending record is a real obligation (red); anything else nudges
+  // (amber). Never "info" — the engine forbids info-severity action entries.
+  priorityToSeverity: (priority) => (priority === "high" ? "urgent" : "nudge"),
+  buildNavigateTarget,
+  buildPluginData: ({ legacyId, slug, itemId, priority, navigateTarget }) =>
+    ({ kind: "collection-completion", legacyId, slug, itemId, priority, navigateTarget }) satisfies CompletionPluginData,
+  readEntry: (pluginData) => {
+    if (typeof pluginData !== "object" || pluginData === null) return null;
+    const data = pluginData as Partial<CompletionPluginData>;
+    if (data.kind !== "collection-completion" || typeof data.legacyId !== "string") return null;
+    return { legacyId: data.legacyId, priority: data.priority === "high" ? "high" : "normal" };
+  },
+};
+
+/** Configure the adapter + mount the watchers. Fire-and-forget at boot AFTER
+ *  initCollectionsBackend (the engine host) + initNotifier (the delivery sink); a
+ *  watcher failure must not abort startup, so the caller attaches `.catch`. */
+export async function startCollectionCompletionWatchers(): Promise<void> {
+  configureCollectionWatchers({ adapter, log });
+  await startCollectionWatchers();
+  log.info("collection completion watchers started");
+}

--- a/server/backends/notifier.spec.ts
+++ b/server/backends/notifier.spec.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { publish, resetNotifier } from "@mulmoclaude/core/notifier";
+import { initNotifier, mountNotificationRoutes, NOTIFIER_CHANNEL } from "./notifier.js";
+
+interface Published {
+  channel: string;
+  data: unknown;
+}
+let events: Published[] = [];
+let workspace: string;
+let server: Server;
+let base: string;
+const tempDirs: string[] = [];
+
+function activeFile(): string {
+  return path.join(workspace, "data", "notifier", "active.json");
+}
+
+beforeEach(async () => {
+  resetNotifier();
+  workspace = mkdtempSync(path.join(tmpdir(), "mt-notif-"));
+  tempDirs.push(workspace);
+  events = [];
+  await initNotifier({
+    workspace,
+    pubsub: { publish: (channel, data) => events.push({ channel, data }) },
+  });
+
+  const app = express();
+  app.use(express.json());
+  mountNotificationRoutes(app);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterEach(() => {
+  server?.close();
+  resetNotifier();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("notifier backend", () => {
+  it("publishes → lists → fans out an event → persists active.json → clears", async () => {
+    const { id } = await publish({ pluginPkg: "test", severity: "nudge", title: "Heads up", body: "something happened" });
+
+    // Fan-out: a "published" event landed on the notifier channel.
+    expect(events).toHaveLength(1);
+    expect(events[0].channel).toBe(NOTIFIER_CHANNEL);
+    expect(events[0].data).toMatchObject({ type: "published", entry: { id, title: "Heads up" } });
+
+    // REST list returns the active entry.
+    const listRes = await fetch(`${base}/api/notifications`);
+    expect(listRes.status).toBe(200);
+    const { active } = (await listRes.json()) as { active: Array<{ id: string; title: string }> };
+    expect(active).toHaveLength(1);
+    expect(active[0]).toMatchObject({ id, title: "Heads up" });
+
+    // Persisted to the shared workspace file.
+    expect(existsSync(activeFile())).toBe(true);
+    const onDisk = JSON.parse(readFileSync(activeFile(), "utf8")) as { entries: Record<string, unknown> };
+    expect(Object.keys(onDisk.entries)).toContain(id);
+
+    // Dismiss via REST → 204, removed from the active list, "cleared" event fired.
+    const clearRes = await fetch(`${base}/api/notifications/${encodeURIComponent(id)}/clear`, { method: "POST" });
+    expect(clearRes.status).toBe(204);
+
+    const afterRes = await fetch(`${base}/api/notifications`);
+    expect(((await afterRes.json()) as { active: unknown[] }).active).toHaveLength(0);
+    expect(events.some((event) => (event.data as { type?: string }).type === "cleared")).toBe(true);
+  });
+});

--- a/server/backends/notifier.ts
+++ b/server/backends/notifier.ts
@@ -1,0 +1,78 @@
+// Notification engine wiring, shared with MulmoClaude via @mulmoclaude/core. The
+// engine holds an active set + a capped history, persisted to the SHARED workspace
+// (<ws>/data/notifier/{active,history}.json — the same files MulmoClaude uses; both
+// apps never run simultaneously, so no locking). Every state change fans out a
+// NotifierEvent on the pubsub NOTIFIER_CHANNEL so the bell UI updates live.
+import path from "node:path";
+import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import type { Express, Request, Response } from "express";
+import { configureNotifier, setNotifierFilePaths, listAll, listHistory, clear } from "@mulmoclaude/core/notifier";
+import type { createPubSub } from "../pubsub.js";
+
+type PubSub = ReturnType<typeof createPubSub>;
+
+/** Pubsub channel the engine fans out on; the frontend bell subscribes to the same
+ *  string (mirrored in src/composables/useNotifications.ts). */
+export const NOTIFIER_CHANNEL = "notifications";
+
+const log = {
+  warn: (message: string, data?: Record<string, unknown>) => console.warn(`[notifier] ${message}`, data ?? ""),
+  error: (message: string, data?: Record<string, unknown>) => console.error(`[notifier] ${message}`, data ?? ""),
+};
+
+// Atomic JSON writer (temp file + rename), matching the pattern in shortcuts.ts so a
+// reader never sees a half-written file. The engine serialises its own mutations.
+async function writeJsonAtomic(filePath: string, data: unknown): Promise<void> {
+  const tmp = `${filePath}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+    await fs.rename(tmp, filePath);
+  } catch (err) {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+/** Configure the engine against MulmoTerminal's pubsub + the shared workspace files.
+ *  Call once at startup, before any publish/clear (and before the collection
+ *  watchers start). */
+export async function initNotifier(deps: { workspace: string; pubsub: PubSub | null }): Promise<void> {
+  const { workspace, pubsub } = deps;
+  const dir = path.join(workspace, "data", "notifier");
+  await fs.mkdir(dir, { recursive: true });
+  configureNotifier({
+    writeJson: writeJsonAtomic,
+    publishEvent: (event) => pubsub?.publish(NOTIFIER_CHANNEL, event),
+    log,
+  });
+  setNotifierFilePaths({ active: path.join(dir, "active.json"), history: path.join(dir, "history.json") });
+}
+
+/** REST surface for the bell: list active, list history, dismiss one. */
+export function mountNotificationRoutes(app: Express): void {
+  app.get("/api/notifications", async (_req: Request, res: Response) => {
+    try {
+      res.json({ active: await listAll() });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  app.get("/api/notifications/history", async (_req: Request, res: Response) => {
+    try {
+      res.json({ history: await listHistory() });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  app.post("/api/notifications/:id/clear", async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      await clear(req.params.id);
+      res.status(204).end();
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,6 +26,8 @@ import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { initFileChangePublisher } from "./backends/fileChange.js";
+import { initNotifier, mountNotificationRoutes } from "./backends/notifier.js";
+import { startCollectionCompletionWatchers } from "./backends/collectionWatchers.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
@@ -603,6 +605,10 @@ mountAllRoutes(app);
 // once CLAUDE_CWD is the confirmed workspace.
 mountCollectionRoutes(app);
 
+// Notification REST surface (list active / history, dismiss one) — backs the toolbar
+// bell. The engine is configured below once pubsub + the workspace exist.
+mountNotificationRoutes(app);
+
 // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
 // fields and custom-view <img> URLs. Rooted at the shared workspace.
 mountFilesRoutes(app, { workspace: CLAUDE_CWD });
@@ -933,6 +939,10 @@ pubsub = createPubSub(server, isAllowedOrigin);
 // is a no-op until configured).
 initFileChangePublisher({ workspace: CLAUDE_CWD, pubsub });
 
+// Wire the notification engine against pubsub + the shared workspace files. Must run
+// before any publish/clear and before the collection watchers start.
+await initNotifier({ workspace: CLAUDE_CWD, pubsub });
+
 // Give the markdown host app its workspace (for artifacts/documents storage).
 // File-change live-refresh is handled by the shared publisher above.
 initMarkdownBackend({ workspace: CLAUDE_CWD });
@@ -944,6 +954,13 @@ initArtifactsBackend({ workspace: CLAUDE_CWD });
 // Configure the collection engine against the shared workspace (CLAUDE_CWD). The
 // path layout matches MulmoClaude's so discovery sees the same collection skills.
 initCollectionsBackend({ workspace: CLAUDE_CWD });
+
+// Mount per-collection fs.watchers → completion bells via the notifier. After the
+// engine host + notifier are configured. Fire-and-forget + non-fatal: a watcher
+// failure must never abort startup.
+startCollectionCompletionWatchers().catch((err) => {
+  console.error("[collection-watchers] failed to start — completion bells disabled", err);
+});
 
 // Terminal WebSocket. Uses noServer + manual upgrade routing so it shares the
 // HTTP server with socket.io (the pub/sub at /ws/pubsub) without the two

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,7 @@ import ToolsPane from "./components/ToolsPane.vue";
 import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
 import GridView from "./components/GridView.vue";
 import SettingsModal from "./components/SettingsModal.vue";
+import NotificationBell from "./components/NotificationBell.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
 import { useShortcuts } from "./composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
@@ -233,6 +234,7 @@ function onSession(id: string) {
           <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
         </button>
       </nav>
+      <NotificationBell class="toolbar-bell" />
       <button
         type="button"
         class="launcher-btn sound-toggle"
@@ -373,8 +375,8 @@ function onSession(id: string) {
   background: var(--accent-bg);
   color: var(--on-accent);
 }
-/* Push the action buttons (sound, settings) to the far right as a group. */
-.sound-toggle {
+/* Push the action buttons (bell, sound, settings) to the far right as a group. */
+.toolbar-bell {
   margin-left: auto;
 }
 .launcher-btn .material-symbols-outlined {

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -146,7 +146,9 @@ onUnmounted(close);
   position: absolute;
   top: calc(100% + 6px);
   right: 0;
-  z-index: 30;
+  /* Above the collections browse overlay (z-index 50, fills below the toolbar) so
+     the dropdown stays visible when a navigation has opened it. */
+  z-index: 60;
   width: 320px;
   max-height: 420px;
   overflow-y: auto;

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -3,9 +3,11 @@ import { ref, onUnmounted, useTemplateRef } from "vue";
 import { useNotifications, type NotifierEntry, type NotifierSeverity } from "../composables/useNotifications";
 
 // Toolbar bell: a severity-coloured unread badge + a dropdown listing the active
-// notifications. A row click navigates to the entry's target (a completion bell's
-// pending record) WITHOUT clearing it — the watcher clears it when the record is
-// done; the ✕ dismisses it explicitly. Mirrors MulmoClaude's bell.
+// notifications. Mirrors MulmoClaude's bell structure (severity-coloured bell icon
+// per row, title + lifecycle tag, a "relative-time · source" meta line, an
+// "Active (N)" header) in MulmoTerminal's dark palette. A row click navigates to the
+// entry's target (a completion bell's pending record) WITHOUT clearing it — the
+// watcher clears it when the record is done; the ✕ dismisses it explicitly.
 const { count, topSeverity, sorted, dismiss, activate } = useNotifications();
 
 const open = ref(false);
@@ -42,6 +44,26 @@ function severityClass(severity: NotifierSeverity): string {
   return `sev-${severity}`;
 }
 
+// Strip a leading `@scope/` from a package name for the meta line (matches
+// MulmoClaude's shortPkg) — unscoped legacy pluginPkgs pass through unchanged.
+function shortPkg(pluginPkg: string): string {
+  return pluginPkg.startsWith("@") ? pluginPkg.split("/").slice(1).join("/") || pluginPkg : pluginPkg;
+}
+
+// Compact relative time ("just now", "5m", "3h", "2d") from an ISO timestamp.
+function relativeTime(iso: string): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 45) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  return `${days}d`;
+}
+
 onUnmounted(close);
 </script>
 
@@ -63,13 +85,26 @@ onUnmounted(close);
 
     <div v-if="open" class="notif-pop" role="menu">
       <div class="notif-head">Notifications</div>
+      <div class="notif-subhead">Active ({{ sorted.length }})</div>
       <div v-if="!sorted.length" class="notif-empty">You're all caught up.</div>
       <ul v-else class="notif-list">
-        <li v-for="entry in sorted" :key="entry.id" class="notif-row" :class="{ clickable: !!entry.navigateTarget }" role="menuitem" @click="onRowClick(entry)">
-          <span class="dot" :class="severityClass(entry.severity)" aria-hidden="true"></span>
+        <li
+          v-for="entry in sorted"
+          :key="entry.id"
+          class="notif-row"
+          :class="{ clickable: !!entry.navigateTarget }"
+          role="menuitem"
+          :title="entry.body || undefined"
+          @click="onRowClick(entry)"
+        >
+          <span class="material-symbols-outlined bell-icon" :class="severityClass(entry.severity)" aria-hidden="true">notifications</span>
           <span class="notif-text">
-            <span class="notif-title">{{ entry.title }}</span>
+            <span class="notif-title-row">
+              <span class="notif-title">{{ entry.title }}</span>
+              <span v-if="entry.lifecycle" class="notif-lifecycle">{{ entry.lifecycle }}</span>
+            </span>
             <span v-if="entry.body" class="notif-body">{{ entry.body }}</span>
+            <span class="notif-meta">{{ relativeTime(entry.createdAt) }} · {{ shortPkg(entry.pluginPkg) }}</span>
           </span>
           <button type="button" class="notif-dismiss" title="Dismiss" aria-label="Dismiss notification" @click.stop="dismiss(entry.id)">
             <span class="material-symbols-outlined">close</span>
@@ -102,10 +137,7 @@ onUnmounted(close);
   border-radius: 6px;
   cursor: pointer;
 }
-.bell-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
+.bell-btn:hover,
 .bell-btn.active {
   background: var(--bg-hover);
   color: var(--text);
@@ -149,8 +181,8 @@ onUnmounted(close);
   /* Above the collections browse overlay (z-index 50, fills below the toolbar) so
      the dropdown stays visible when a navigation has opened it. */
   z-index: 60;
-  width: 320px;
-  max-height: 420px;
+  width: 340px;
+  max-height: 460px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -166,7 +198,15 @@ onUnmounted(close);
   font-family: system-ui, sans-serif;
   font-size: 12px;
   font-weight: 600;
+  color: var(--text);
+}
+.notif-subhead {
+  padding: 4px 8px;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 500;
   color: var(--text-muted);
+  border-top: 1px solid var(--border);
 }
 
 .notif-empty {
@@ -199,22 +239,23 @@ onUnmounted(close);
   background: var(--bg-hover);
 }
 
-.dot {
+/* Per-row severity-coloured bell icon — MulmoClaude's "this is a notification"
+   at-a-glance signal (replaces a generic coloured dot). */
+.bell-icon {
   flex: 0 0 auto;
-  width: 8px;
-  height: 8px;
-  margin-top: 5px;
-  border-radius: 50%;
-  background: #9aa6cc;
+  margin-top: 1px;
+  font-size: 18px;
+  line-height: 1;
+  color: #9aa6cc;
 }
-.dot.sev-info {
-  background: #9aa6cc;
+.bell-icon.sev-info {
+  color: #9aa6cc;
 }
-.dot.sev-nudge {
-  background: #e0a526;
+.bell-icon.sev-nudge {
+  color: #e0a526;
 }
-.dot.sev-urgent {
-  background: #e0533d;
+.bell-icon.sev-urgent {
+  color: #e0533d;
 }
 
 .notif-text {
@@ -224,16 +265,38 @@ onUnmounted(close);
   flex-direction: column;
   gap: 2px;
 }
+.notif-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
 .notif-title {
   font-family: system-ui, sans-serif;
   font-size: 13px;
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.notif-lifecycle {
+  flex: 0 0 auto;
+  font-family: system-ui, sans-serif;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 .notif-body {
   font-family: system-ui, sans-serif;
   font-size: 12px;
   color: var(--text-muted);
   overflow-wrap: anywhere;
+}
+.notif-meta {
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--text-muted);
 }
 
 .notif-dismiss {

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -93,9 +93,13 @@ onUnmounted(close);
           :key="entry.id"
           class="notif-row"
           :class="{ clickable: !!entry.navigateTarget }"
-          role="menuitem"
+          :role="entry.navigateTarget ? 'button' : undefined"
+          :tabindex="entry.navigateTarget ? 0 : undefined"
+          :aria-label="entry.navigateTarget ? entry.title : undefined"
           :title="entry.body || undefined"
           @click="onRowClick(entry)"
+          @keydown.enter.prevent.self="entry.navigateTarget && onRowClick(entry)"
+          @keydown.space.prevent.self="entry.navigateTarget && onRowClick(entry)"
         >
           <span class="material-symbols-outlined bell-icon" :class="severityClass(entry.severity)" aria-hidden="true">notifications</span>
           <span class="notif-text">
@@ -237,6 +241,10 @@ onUnmounted(close);
 }
 .notif-row.clickable:hover {
   background: var(--bg-hover);
+}
+.notif-row:focus-visible {
+  outline: 2px solid var(--accent-bg);
+  outline-offset: -2px;
 }
 
 /* Per-row severity-coloured bell icon — MulmoClaude's "this is a notification"

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -1,0 +1,259 @@
+<script setup lang="ts">
+import { ref, onUnmounted, useTemplateRef } from "vue";
+import { useNotifications, type NotifierEntry, type NotifierSeverity } from "../composables/useNotifications";
+
+// Toolbar bell: a severity-coloured unread badge + a dropdown listing the active
+// notifications. A row click navigates to the entry's target (a completion bell's
+// pending record) WITHOUT clearing it — the watcher clears it when the record is
+// done; the ✕ dismisses it explicitly. Mirrors MulmoClaude's bell.
+const { count, topSeverity, sorted, dismiss, activate } = useNotifications();
+
+const open = ref(false);
+const rootRef = useTemplateRef<HTMLElement>("root");
+
+function onOutside(e: PointerEvent) {
+  if (rootRef.value && !rootRef.value.contains(e.target as Node)) close();
+}
+function onEscape(e: KeyboardEvent) {
+  if (e.key === "Escape") close();
+}
+function openPanel() {
+  open.value = true;
+  window.addEventListener("pointerdown", onOutside);
+  window.addEventListener("keydown", onEscape);
+}
+function close() {
+  open.value = false;
+  window.removeEventListener("pointerdown", onOutside);
+  window.removeEventListener("keydown", onEscape);
+}
+function toggle() {
+  if (open.value) close();
+  else openPanel();
+}
+
+function onRowClick(entry: NotifierEntry) {
+  // Navigate if it's a deep-linkable entry; close either way so the click feels live.
+  activate(entry);
+  close();
+}
+
+function severityClass(severity: NotifierSeverity): string {
+  return `sev-${severity}`;
+}
+
+onUnmounted(close);
+</script>
+
+<template>
+  <div ref="root" class="notif-bell">
+    <button
+      type="button"
+      class="bell-btn"
+      :class="{ active: open }"
+      :aria-expanded="open"
+      aria-haspopup="menu"
+      :title="count ? `${count} notification${count === 1 ? '' : 's'}` : 'Notifications'"
+      aria-label="Notifications"
+      @click="toggle"
+    >
+      <span class="material-symbols-outlined">notifications</span>
+      <span v-if="count" class="badge" :class="topSeverity ? severityClass(topSeverity) : ''">{{ count > 99 ? "99+" : count }}</span>
+    </button>
+
+    <div v-if="open" class="notif-pop" role="menu">
+      <div class="notif-head">Notifications</div>
+      <div v-if="!sorted.length" class="notif-empty">You're all caught up.</div>
+      <ul v-else class="notif-list">
+        <li v-for="entry in sorted" :key="entry.id" class="notif-row" :class="{ clickable: !!entry.navigateTarget }" role="menuitem" @click="onRowClick(entry)">
+          <span class="dot" :class="severityClass(entry.severity)" aria-hidden="true"></span>
+          <span class="notif-text">
+            <span class="notif-title">{{ entry.title }}</span>
+            <span v-if="entry.body" class="notif-body">{{ entry.body }}</span>
+          </span>
+          <button type="button" class="notif-dismiss" title="Dismiss" aria-label="Dismiss notification" @click.stop="dismiss(entry.id)">
+            <span class="material-symbols-outlined">close</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.notif-bell {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Mirrors App.vue's .launcher-btn (scoped styles don't cross component boundaries). */
+.bell-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  height: 30px;
+  width: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.bell-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.bell-btn.active {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.bell-btn .material-symbols-outlined {
+  font-size: 19px;
+  line-height: 1;
+}
+
+/* Unread badge: severity-coloured pill at the top-right of the bell. */
+.badge {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  box-sizing: border-box;
+  border-radius: 7px;
+  font-family: system-ui, sans-serif;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  color: #fff;
+  background: #9aa6cc;
+}
+.badge.sev-info {
+  background: #9aa6cc;
+}
+.badge.sev-nudge {
+  background: #e0a526;
+}
+.badge.sev-urgent {
+  background: #e0533d;
+}
+
+.notif-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  width: 320px;
+  max-height: 420px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.notif-head {
+  padding: 6px 8px;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.notif-empty {
+  padding: 14px 8px;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.notif-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.notif-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 6px;
+}
+.notif-row.clickable {
+  cursor: pointer;
+}
+.notif-row.clickable:hover {
+  background: var(--bg-hover);
+}
+
+.dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: #9aa6cc;
+}
+.dot.sev-info {
+  background: #9aa6cc;
+}
+.dot.sev-nudge {
+  background: #e0a526;
+}
+.dot.sev-urgent {
+  background: #e0533d;
+}
+
+.notif-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.notif-title {
+  font-family: system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--text);
+}
+.notif-body {
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.notif-dismiss {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.notif-dismiss:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.notif-dismiss .material-symbols-outlined {
+  font-size: 16px;
+  line-height: 1;
+}
+</style>

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -74,7 +74,7 @@ onUnmounted(close);
       class="bell-btn"
       :class="{ active: open }"
       :aria-expanded="open"
-      aria-haspopup="menu"
+      aria-haspopup="true"
       :title="count ? `${count} notification${count === 1 ? '' : 's'}` : 'Notifications'"
       aria-label="Notifications"
       @click="toggle"
@@ -83,7 +83,7 @@ onUnmounted(close);
       <span v-if="count" class="badge" :class="topSeverity ? severityClass(topSeverity) : ''">{{ count > 99 ? "99+" : count }}</span>
     </button>
 
-    <div v-if="open" class="notif-pop" role="menu">
+    <div v-if="open" class="notif-pop" role="group" aria-label="Notifications">
       <div class="notif-head">Notifications</div>
       <div class="notif-subhead">Active ({{ sorted.length }})</div>
       <div v-if="!sorted.length" class="notif-empty">You're all caught up.</div>

--- a/src/composables/useNotifications.spec.ts
+++ b/src/composables/useNotifications.spec.ts
@@ -18,6 +18,12 @@ describe("parseCollectionTarget", () => {
     expect(parseCollectionTarget("/collections/todo?selected=x&notificationId=y")).toEqual({ slug: "todo", itemId: "x" });
   });
 
+  it("does not double-decode a selected id containing a literal percent", () => {
+    // URLSearchParams already decodes %25%20 → "% ". A second decodeURIComponent
+    // would throw "URI malformed" on the resulting "100% done".
+    expect(parseCollectionTarget("/collections/annual?selected=100%25%20done")).toEqual({ slug: "annual", itemId: "100% done" });
+  });
+
   it("returns itemId undefined when there is a query but no selected", () => {
     expect(parseCollectionTarget("/collections/todo?foo=bar")).toEqual({ slug: "todo", itemId: undefined });
   });

--- a/src/composables/useNotifications.spec.ts
+++ b/src/composables/useNotifications.spec.ts
@@ -28,6 +28,11 @@ describe("parseCollectionTarget", () => {
     expect(parseCollectionTarget("/collections/todo?foo=bar")).toEqual({ slug: "todo", itemId: undefined });
   });
 
+  it("returns null for a slug with malformed percent-encoding (non-actionable, no throw)", () => {
+    expect(parseCollectionTarget("/collections/%E0%A4%A")).toBeNull();
+    expect(parseCollectionTarget("/collections/%E0%A4%A?selected=x")).toBeNull();
+  });
+
   it("returns null for a non-collection target", () => {
     expect(parseCollectionTarget("/documents/abc")).toBeNull();
   });

--- a/src/composables/useNotifications.spec.ts
+++ b/src/composables/useNotifications.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { parseCollectionTarget } from "./useNotifications";
+
+describe("parseCollectionTarget", () => {
+  it("parses slug + selected itemId", () => {
+    expect(parseCollectionTarget("/collections/todo?selected=item-1")).toEqual({ slug: "todo", itemId: "item-1" });
+  });
+
+  it("parses a bare slug with no record", () => {
+    expect(parseCollectionTarget("/collections/todo")).toEqual({ slug: "todo", itemId: undefined });
+  });
+
+  it("decodes percent-encoded slug + itemId", () => {
+    expect(parseCollectionTarget("/collections/my%20col?selected=a%2Fb")).toEqual({ slug: "my col", itemId: "a/b" });
+  });
+
+  it("ignores unrelated query params and keeps selected", () => {
+    expect(parseCollectionTarget("/collections/todo?selected=x&notificationId=y")).toEqual({ slug: "todo", itemId: "x" });
+  });
+
+  it("returns itemId undefined when there is a query but no selected", () => {
+    expect(parseCollectionTarget("/collections/todo?foo=bar")).toEqual({ slug: "todo", itemId: undefined });
+  });
+
+  it("returns null for a non-collection target", () => {
+    expect(parseCollectionTarget("/documents/abc")).toBeNull();
+  });
+
+  it("returns null for an empty slug", () => {
+    expect(parseCollectionTarget("/collections/")).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(parseCollectionTarget(undefined)).toBeNull();
+  });
+});

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -53,9 +53,12 @@ export function parseCollectionTarget(target: string | undefined): { slug: strin
   if (!rawSlug) return null;
   let itemId: string | undefined;
   if (queryAt !== -1) {
+    // URLSearchParams.get() returns an already-decoded value — decoding again would
+    // throw "URI malformed" on a valid id containing a literal "%" (e.g. "100% done").
     const selected = new URLSearchParams(rest.slice(queryAt + 1)).get("selected");
-    if (selected) itemId = decodeURIComponent(selected);
+    if (selected) itemId = selected;
   }
+  // The slug was string-sliced (not via URLSearchParams), so it is still encoded.
   return { slug: decodeURIComponent(rawSlug), itemId };
 }
 
@@ -100,7 +103,11 @@ async function fetchActive(): Promise<void> {
 function ensureInit(): void {
   if (initialized) return;
   initialized = true;
-  usePubSub().subscribe(NOTIFIER_CHANNEL, (data) => applyEvent(data as NotifierEvent));
+  const pubsub = usePubSub();
+  pubsub.subscribe(NOTIFIER_CHANNEL, (data) => applyEvent(data as NotifierEvent));
+  // pubsub only replays room membership on reconnect, not the events missed while
+  // disconnected — re-fetch the authoritative list so the bell can't go stale.
+  pubsub.onReconnect(() => void fetchActive());
   void fetchActive();
 }
 

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -1,0 +1,156 @@
+// Toolbar notification state. Mirrors MulmoClaude's useNotifications: a module-level
+// singleton that fetches the active set once, then keeps it live by subscribing to
+// the notifier pubsub channel. The bell (NotificationBell.vue) reads count /
+// topSeverity / sorted and calls dismiss / activate.
+//
+// Server-only @mulmoclaude/core/notifier types are NOT imported here (that would pull
+// node code into the browser bundle); the small value types are mirrored locally,
+// matching the wire shape the server's /api/notifications + NotifierEvent emit.
+import { ref, computed } from "vue";
+import { usePubSub } from "./usePubSub";
+import { browseNavigateToRecord } from "./useCollectionBrowse";
+
+// Must match server/backends/notifier.ts NOTIFIER_CHANNEL.
+const NOTIFIER_CHANNEL = "notifications";
+
+export type NotifierSeverity = "info" | "nudge" | "urgent";
+export type NotifierLifecycle = "fyi" | "action";
+
+export interface NotifierEntry {
+  id: string;
+  pluginPkg: string;
+  severity: NotifierSeverity;
+  lifecycle?: NotifierLifecycle;
+  title: string;
+  body?: string;
+  navigateTarget?: string;
+  pluginData?: unknown;
+  createdAt: string;
+}
+
+// Discriminated union mirroring the server's NotifierEvent.
+type NotifierEvent =
+  | { type: "published"; entry: NotifierEntry }
+  | { type: "updated"; entry: NotifierEntry }
+  | { type: "cleared"; id: string }
+  | { type: "cancelled"; id: string };
+
+const SEVERITY_RANK: Record<NotifierSeverity, number> = { info: 0, nudge: 1, urgent: 2 };
+
+const active = ref<NotifierEntry[]>([]);
+let initialized = false;
+
+/** Parse a collection deep-link (`/collections/<slug>?selected=<itemId>`) into its
+ *  parts. String ops + URLSearchParams only — no regex (lint bans backtracking-prone
+ *  patterns). Returns null for anything that isn't a collection target. */
+export function parseCollectionTarget(target: string | undefined): { slug: string; itemId?: string } | null {
+  if (!target) return null;
+  const prefix = "/collections/";
+  if (!target.startsWith(prefix)) return null;
+  const rest = target.slice(prefix.length);
+  const queryAt = rest.indexOf("?");
+  const rawSlug = queryAt === -1 ? rest : rest.slice(0, queryAt);
+  if (!rawSlug) return null;
+  let itemId: string | undefined;
+  if (queryAt !== -1) {
+    const selected = new URLSearchParams(rest.slice(queryAt + 1)).get("selected");
+    if (selected) itemId = decodeURIComponent(selected);
+  }
+  return { slug: decodeURIComponent(rawSlug), itemId };
+}
+
+function upsert(entry: NotifierEntry): void {
+  const idx = active.value.findIndex((existing) => existing.id === entry.id);
+  if (idx === -1) active.value.push(entry);
+  else active.value.splice(idx, 1, entry);
+}
+
+function remove(id: string): void {
+  const idx = active.value.findIndex((existing) => existing.id === id);
+  if (idx !== -1) active.value.splice(idx, 1);
+}
+
+function applyEvent(event: NotifierEvent): void {
+  switch (event.type) {
+    case "published":
+    case "updated":
+      upsert(event.entry);
+      break;
+    case "cleared":
+    case "cancelled":
+      remove(event.id);
+      break;
+  }
+}
+
+async function fetchActive(): Promise<void> {
+  try {
+    const res = await fetch("/api/notifications");
+    if (!res.ok) {
+      console.error(`[notifications] list failed: HTTP ${res.status}`);
+      return;
+    }
+    const data = (await res.json()) as { active?: NotifierEntry[] };
+    active.value = Array.isArray(data.active) ? data.active : [];
+  } catch (err) {
+    console.error("[notifications] list failed", err);
+  }
+}
+
+function ensureInit(): void {
+  if (initialized) return;
+  initialized = true;
+  usePubSub().subscribe(NOTIFIER_CHANNEL, (data) => applyEvent(data as NotifierEvent));
+  void fetchActive();
+}
+
+export function useNotifications() {
+  ensureInit();
+
+  const count = computed(() => active.value.length);
+
+  const topSeverity = computed<NotifierSeverity | null>(() => {
+    let top: NotifierSeverity | null = null;
+    for (const entry of active.value) {
+      if (top === null || SEVERITY_RANK[entry.severity] > SEVERITY_RANK[top]) top = entry.severity;
+    }
+    return top;
+  });
+
+  // Worst-severity first, then newest first within a severity.
+  const sorted = computed(() =>
+    [...active.value].sort((left, right) => {
+      const bySeverity = SEVERITY_RANK[right.severity] - SEVERITY_RANK[left.severity];
+      if (bySeverity !== 0) return bySeverity;
+      return right.createdAt.localeCompare(left.createdAt);
+    }),
+  );
+
+  /** Dismiss (clear) a notification: the ✕ action. Optimistically drops it, then
+   *  asks the server to clear; on failure we resync from the server. */
+  async function dismiss(id: string): Promise<void> {
+    remove(id);
+    try {
+      const res = await fetch(`/api/notifications/${encodeURIComponent(id)}/clear`, { method: "POST" });
+      if (!res.ok) {
+        console.error(`[notifications] clear failed: HTTP ${res.status}`);
+        await fetchActive();
+      }
+    } catch (err) {
+      console.error("[notifications] clear failed", err);
+      await fetchActive();
+    }
+  }
+
+  /** Row click: navigate to the entry's target if it's a collection record. Does NOT
+   *  clear — completion bells are action obligations the watcher clears when the
+   *  record is done. Returns true if it navigated. */
+  function activate(entry: NotifierEntry): boolean {
+    const parsed = parseCollectionTarget(entry.navigateTarget);
+    if (!parsed) return false;
+    browseNavigateToRecord(parsed.slug, parsed.itemId);
+    return true;
+  }
+
+  return { active, count, topSeverity, sorted, dismiss, activate };
+}

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -59,7 +59,14 @@ export function parseCollectionTarget(target: string | undefined): { slug: strin
     if (selected) itemId = selected;
   }
   // The slug was string-sliced (not via URLSearchParams), so it is still encoded.
-  return { slug: decodeURIComponent(rawSlug), itemId };
+  // A malformed escape (e.g. "%E0%A4%A") makes decodeURIComponent throw; since this
+  // runs from the row-click handler, treat a bad slug as non-actionable (return null)
+  // rather than letting it crash activation.
+  try {
+    return { slug: decodeURIComponent(rawSlug), itemId };
+  } catch {
+    return null;
+  }
 }
 
 function upsert(entry: NotifierEntry): void {

--- a/src/composables/usePubSub.ts
+++ b/src/composables/usePubSub.ts
@@ -12,6 +12,11 @@ type Unsubscribe = () => void;
 
 let socket: Socket | null = null;
 const listeners = new Map<string, Set<Callback>>();
+// Fired on every RE-connect (not the first connect). A subscriber that holds derived
+// state — e.g. the notification list — re-syncs here, since pubsub only replays room
+// membership on reconnect, not the events missed while disconnected.
+const reconnectListeners = new Set<() => void>();
+let hasConnected = false;
 
 function connect(): Socket {
   if (socket) return socket;
@@ -21,6 +26,8 @@ function connect(): Socket {
   // Re-emit every live subscription so rooms survive a reconnect.
   sock.on("connect", () => {
     for (const channel of listeners.keys()) sock.emit("subscribe", channel);
+    if (hasConnected) for (const cb of reconnectListeners) cb();
+    hasConnected = true;
   });
 
   sock.on("data", (msg: PubSubMessage) => {
@@ -55,5 +62,13 @@ export function usePubSub() {
     };
   }
 
-  return { subscribe };
+  // Register a callback fired on every reconnect (not the first connect). Returns an
+  // unsubscribe. Lets a consumer re-fetch authoritative state after a dropped socket.
+  function onReconnect(callback: () => void): Unsubscribe {
+    reconnectListeners.add(callback);
+    connect();
+    return () => reconnectListeners.delete(callback);
+  }
+
+  return { subscribe, onReconnect };
 }


### PR DESCRIPTION
## Why

A MulmoTerminal-alone run had no notification surface. This wires the shared `@mulmoclaude/core` **notifier** + **collection-watchers** and adds a toolbar **bell** so collection-completion obligations (and any future fyi pings) reach the user. **PR 3** of `plans/feat-shared-backend-services.md` (PR 0 #121, PR 1 #122, PR 2 #123 merged).

## Server

- **`server/backends/notifier.ts`** — `initNotifier` configures the engine with an atomic `writeJson` (temp + rename), `publishEvent → pubsub.publish(NOTIFIER_CHANNEL, event)` (channel `"notifications"`), and the **shared** `<ws>/data/notifier/{active,history}.json` (same files MulmoClaude uses; the apps never run simultaneously, so no locking). REST: `GET /api/notifications`, `GET …/history`, `POST …/:id/clear`.
- **`server/backends/collectionWatchers.ts`** — a MulmoTerminal `CollectionNotificationAdapter`: `pluginPkg "collections"`, `priorityToSeverity` high→`urgent` / else→`nudge`, deep-link `/collections/<slug>?selected=<itemId>`, and a `{kind:"collection-completion", legacyId, slug, itemId, priority}` pluginData round-trip so the reconciler recognises its own entries on rescan. `startCollectionCompletionWatchers()` runs at boot **after** the engine host + notifier, **fire-and-forget + non-fatal** (`.catch`, no `void` operator).
- **`server/index.ts`** — `initNotifier` right after `createPubSub`; `mountNotificationRoutes` with the other mounts; start the watchers after `initCollectionsBackend`.

## Frontend

- **`src/composables/useNotifications.ts`** — module-singleton: fetch `/api/notifications`, subscribe `NOTIFIER_CHANNEL`, apply `published`/`updated`/`cleared`/`cancelled`; expose `count` / `topSeverity` / `sorted` / `dismiss` / `activate`. A **row click navigates** (parse `/collections/<slug>?selected=<itemId>` via string ops + `URLSearchParams` — no regex — → `browseNavigateToRecord`) but does **not** clear (completion bells are action obligations the watcher clears when the record is done); the **✕** calls `clear`. Server-only types are mirrored locally so no node code enters the browser bundle.
- **`src/components/NotificationBell.vue`** — toolbar bell + severity-coloured unread badge + dropdown panel (title/body, severity dot, dismiss ✕, click-away + Escape). Mounted at the right of the `App.vue` toolbar; dark palette + Material Symbols, matching the `RunMenu` dropdown convention.

## Tests

- `parseCollectionTarget` unit tests (8 cases: slug/itemId, encoding, extra params, non-collection, empty, undefined).
- Notifier end-to-end smoke: publish → fan-out event on the channel → REST list → `active.json` persisted → REST clear → 204 + `cleared` event.

## Out of scope (deferred)

- **Scheduler** (PR 4) — needs a run-job binding (`spawnBackgroundChat`) + a decision on which system tasks make sense in MulmoTerminal.
- **skill-bridge** (PR 5) — needs a `data/skills` convention + a `/api/hook` PostToolUse handler.

## Verification

- `yarn typecheck`, `yarn lint` (0 errors), `yarn test` (391 passed, +9), `yarn build` — all green.
- **Boot smoke**: `GET /api/notifications` → `{active:[]}` 200, `/history` 200, `[collection-watchers] collection completion watchers started`, `data/notifier/` created, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)