### PR TITLE
feat: user-task scheduler — cron tasks spawn chats (PR 4a)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@mulmoclaude/html-plugin": "^0.2.2",
     "@mulmoclaude/markdown-plugin": "^0.1.4",
     "@mulmoclaude/x-plugin": "^0.1.1",
+    "@receptron/task-scheduler": "^0.1.0",
     "@xterm/addon-attach": "^0.12.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/plans/feat-shared-backend-services.md
+++ b/plans/feat-shared-backend-services.md
@@ -249,11 +249,49 @@ versions but are FROZEN — do not add them; use the `core` subpaths.
 - Tests: `parseCollectionTarget` unit tests; an end-to-end notifier smoke (publish → list →
   pubsub event → `active.json` written).
 
-### PR 4 — scheduler (deferred; needs decisions)
-- Engine + adapter are ready; wiring needs (a) a **run-job binding** — MulmoTerminal's
-  analog is `spawnBackgroundChat` (`POST /api/plugin/spawnBackgroundChat`) — and (b) a
-  decision on **which system tasks** make sense in MulmoTerminal (feeds refresh? journal?
-  none yet?). Defer until 1–3 land and the task set is decided.
+### PR 4a — scheduler: user-tasks → spawn chat (the portable half)
+The scheduler splits cleanly: the **engine** (tick loop, daily/interval scheduling) is the
+shared `@mulmoclaude/core/scheduler`; the task **run** logic is app-specific. MulmoClaude's
+two task families differ in portability:
+- **User tasks** (`config/scheduler/tasks.json`) — a record `{id,name,description,schedule,
+  missedRunPolicy,enabled,roleId,prompt}`. MulmoClaude's `registerUserTasks` registers each
+  enabled one on the task-manager with `run = startChat({message: prompt, roleId})`, i.e.
+  the schedule fires and **spawns a new chat seeded with the prompt**. This is how the
+  workout-log "週3回リマインダー" works: a daily 11:00 task whose prompt tells the agent to
+  read `data/workout-log/items/` and nudge. The collection schema has NOTHING to do with it
+  — the only link is the prompt text. **This half is portable**: the run-binding is exactly
+  MulmoTerminal's `spawnBackgroundChat` (`spawnClaudePty`).
+- **System tasks** (journal / chat-index / feed-refresh) — `run` calls MulmoClaude-only
+  functions (`maybeRunJournal`, `backfillAllSessions`, `refreshDueFeeds`) NOT in the shared
+  package. Deferred to **PR 4b** (needs the feed-refresh engine extracted into core, plus a
+  decision on which system tasks map to MulmoTerminal).
+
+**PR 4a scope (this PR):**
+- Add dep `@receptron/task-scheduler@^0.1.0` (a `*` peerDependency of `@mulmoclaude/core`,
+  used by `@mulmoclaude/core/scheduler` — not auto-installed). `@mulmoclaude/core` already present.
+- `server/backends/scheduler.ts`:
+  - Load + validate user tasks from `<ws>/config/scheduler/tasks.json` (mirror MulmoClaude's
+    validation: `schedule` is `{type:"interval",intervalMs>0}` or `{type:"daily",time:"HH:MM"}`
+    — validate HH:MM with **string ops, no regex**; `prompt` non-empty; skip `enabled:false`).
+  - `initUserTaskScheduler({workspace, spawnChat, log?})` → `createTaskManager`, register each
+    enabled task as `{id:"user.<id>", description, schedule, run: async () => spawnChat(prompt)}`,
+    `taskManager.start()`. Registered DIRECTLY on the task-manager (matches MulmoClaude — user
+    tasks don't go through `initScheduler`/`SystemTaskDef`, so no system-task persistence/catch-up;
+    they fire forward on schedule).
+  - `mountSchedulerRoutes(app, {workspace})` → `GET /api/scheduler/tasks` (read-only list from
+    tasks.json). CRUD + a tasks UI is **PR 4c** (not needed to make existing tasks run).
+- `server/index.ts`: define `spawnScheduledChat(message)` (= `randomUUID()` + `spawnClaudePty(id,
+  null, null, message)`, VISIBLE so the user sees the nudge) and pass it as `spawnChat`; call
+  `initUserTaskScheduler` + `mountSchedulerRoutes` near boot, fire-and-forget + non-fatal.
+- Tests: schedule/prompt/enabled validation; registration count; `run` invokes `spawnChat`;
+  malformed/missing `tasks.json` tolerated (no throw); list route shape.
+- **Out of scope (4a):** system tasks (4b), task CRUD + UI (4c), missed-run catch-up across
+  restarts (user tasks fire forward only, matching MulmoClaude).
+
+### PR 4b — scheduler system tasks (deferred; needs core extraction)
+Feed-refresh (RSS/JSON → collections) + journal/chat-index. Needs `refreshDueFeeds` extracted
+into `@mulmoclaude/core` (so both apps share it) and a decision on which system tasks map to
+MulmoTerminal. Until then a MulmoTerminal-alone run does not refresh feeds.
 
 ### PR 5 — skill-bridge (deferred)
 - Needs a `data/skills` convention + a `/api/hook` PostToolUse handler that calls

--- a/server/backends/scheduler.spec.ts
+++ b/server/backends/scheduler.spec.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, type PersistedUserTask } from "./scheduler.js";
+
+const tempDirs: string[] = [];
+
+function makeWorkspace(tasks?: unknown): string {
+  const workspace = mkdtempSync(path.join(tmpdir(), "mt-sched-"));
+  tempDirs.push(workspace);
+  if (tasks !== undefined) {
+    const dir = path.join(workspace, "config", "scheduler");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "tasks.json"), typeof tasks === "string" ? tasks : JSON.stringify(tasks));
+  }
+  return workspace;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("buildUserTaskDefinitions", () => {
+  let spawned: string[];
+  const spawnChat = (message: string) => spawned.push(message);
+
+  beforeEach(() => {
+    spawned = [];
+  });
+
+  it("registers only enabled tasks with a valid id, prompt, and schedule", () => {
+    const tasks = [
+      { id: "a", name: "Daily", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "  do A  " },
+      { id: "b", schedule: { type: "interval", intervalMs: 60000 }, enabled: true, prompt: "do B" },
+      { id: "c", schedule: { type: "daily", time: "09:00" }, enabled: false, prompt: "disabled" },
+      { id: "d", schedule: { type: "daily", time: "25:00" }, enabled: true, prompt: "bad hour" },
+      { id: "e", schedule: { type: "daily", time: "9:00" }, enabled: true, prompt: "unpadded" },
+      { id: "f", schedule: { type: "interval", intervalMs: 0 }, enabled: true, prompt: "bad interval" },
+      { id: "", schedule: { type: "daily", time: "10:00" }, enabled: true, prompt: "no id" },
+      { id: "g", schedule: { type: "daily", time: "10:00" }, enabled: true, prompt: "   " },
+    ] as PersistedUserTask[];
+
+    const definitions = buildUserTaskDefinitions(tasks, spawnChat);
+
+    expect(definitions.map((definition) => definition.id)).toEqual(["user.a", "user.b"]);
+    expect(definitions[0].schedule).toEqual({ type: "daily", time: "11:00" });
+  });
+
+  it("a task's run spawns a chat seeded with the trimmed prompt", async () => {
+    const tasks = [{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "  nudge me  " }] as PersistedUserTask[];
+
+    const definitions = buildUserTaskDefinitions(tasks, spawnChat);
+    await definitions[0].run({ taskId: "user.a", now: new Date(0) });
+
+    expect(spawned).toEqual(["nudge me"]);
+  });
+});
+
+describe("loadUserTasks", () => {
+  it("returns [] when the file is missing", () => {
+    expect(loadUserTasks(makeWorkspace())).toEqual([]);
+  });
+
+  it("returns [] for malformed JSON (never throws)", () => {
+    expect(loadUserTasks(makeWorkspace("{ not json"))).toEqual([]);
+  });
+
+  it("returns [] when the JSON is not an array", () => {
+    expect(loadUserTasks(makeWorkspace({ tasks: [] }))).toEqual([]);
+  });
+
+  it("parses a valid task array", () => {
+    const tasks = [{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "go" }];
+    expect(loadUserTasks(makeWorkspace(tasks))).toEqual(tasks);
+  });
+});
+
+describe("mountSchedulerRoutes", () => {
+  let server: Server;
+  let base: string;
+
+  afterEach(() => server?.close());
+
+  it("GET /api/scheduler/tasks lists the persisted tasks", async () => {
+    const tasks = [{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "go" }];
+    const workspace = makeWorkspace(tasks);
+    const app = express();
+    mountSchedulerRoutes(app, { workspace });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => resolve());
+    });
+    const addr = server.address();
+    base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+
+    const res = await fetch(`${base}/api/scheduler/tasks`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ tasks });
+  });
+});

--- a/server/backends/scheduler.spec.ts
+++ b/server/backends/scheduler.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, type PersistedUserTask } from "./scheduler.js";
+import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes } from "./scheduler.js";
 
 const tempDirs: string[] = [];
 
@@ -42,7 +42,7 @@ describe("buildUserTaskDefinitions", () => {
       { id: "f", schedule: { type: "interval", intervalMs: 0 }, enabled: true, prompt: "bad interval" },
       { id: "", schedule: { type: "daily", time: "10:00" }, enabled: true, prompt: "no id" },
       { id: "g", schedule: { type: "daily", time: "10:00" }, enabled: true, prompt: "   " },
-    ] as PersistedUserTask[];
+    ];
 
     const definitions = buildUserTaskDefinitions(tasks, spawnChat);
 
@@ -50,8 +50,16 @@ describe("buildUserTaskDefinitions", () => {
     expect(definitions[0].schedule).toEqual({ type: "daily", time: "11:00" });
   });
 
+  it("skips non-object array elements without throwing (non-fatal)", () => {
+    const tasks = [null, 42, "nope", { id: "ok", schedule: { type: "daily", time: "08:00" }, enabled: true, prompt: "go" }];
+
+    const definitions = buildUserTaskDefinitions(tasks, spawnChat);
+
+    expect(definitions.map((definition) => definition.id)).toEqual(["user.ok"]);
+  });
+
   it("a task's run spawns a chat seeded with the trimmed prompt", async () => {
-    const tasks = [{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "  nudge me  " }] as PersistedUserTask[];
+    const tasks = [{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "  nudge me  " }];
 
     const definitions = buildUserTaskDefinitions(tasks, spawnChat);
     await definitions[0].run({ taskId: "user.a", now: new Date(0) });

--- a/server/backends/scheduler.spec.ts
+++ b/server/backends/scheduler.spec.ts
@@ -50,6 +50,17 @@ describe("buildUserTaskDefinitions", () => {
     expect(definitions[0].schedule).toEqual({ type: "daily", time: "11:00" });
   });
 
+  it("treats an omitted enabled field as enabled (only explicit false disables)", () => {
+    const tasks = [
+      { id: "noflag", schedule: { type: "daily", time: "07:00" }, prompt: "go" },
+      { id: "off", schedule: { type: "daily", time: "07:00" }, enabled: false, prompt: "x" },
+    ];
+
+    const definitions = buildUserTaskDefinitions(tasks, spawnChat);
+
+    expect(definitions.map((definition) => definition.id)).toEqual(["user.noflag"]);
+  });
+
   it("skips non-object array elements without throwing (non-fatal)", () => {
     const tasks = [null, 42, "nope", { id: "ok", schedule: { type: "daily", time: "08:00" }, enabled: true, prompt: "go" }];
 

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -1,0 +1,141 @@
+// User-task scheduler, shared with MulmoClaude via @mulmoclaude/core/scheduler. Users
+// (or the agent) persist cron-style tasks in <ws>/config/scheduler/tasks.json; each
+// enabled task fires on its schedule and SPAWNS A NEW CHAT seeded with the task's
+// prompt. That is how the workout-log "週3回リマインダー" works — a daily task whose
+// prompt tells the agent to read data/workout-log/items/ and nudge. The collection
+// schema is uninvolved; the only link is the prompt text.
+//
+// The tick/scheduling ENGINE is the shared package; the run-binding is
+// MulmoTerminal-specific: spawnChat = spawnClaudePty (a visible background session).
+// Tasks are registered directly on the task-manager (matching MulmoClaude's user
+// tasks) — they fire forward on schedule, with no system-task persistence/catch-up.
+//
+// System tasks (journal / chat-index / feed-refresh) are NOT wired here: their run
+// logic is MulmoClaude-app-specific and not in the shared package (see plan PR 4b).
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import type { Express, Request, Response } from "express";
+import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
+import { createTaskManager } from "@mulmoclaude/core/scheduler";
+import type { TaskDefinition, TaskSchedule } from "@mulmoclaude/core/scheduler";
+
+const log = {
+  info: (message: string, data?: Record<string, unknown>) => console.log(`[scheduler] ${message}`, data ?? ""),
+  warn: (message: string, data?: Record<string, unknown>) => console.warn(`[scheduler] ${message}`, data ?? ""),
+  error: (message: string, data?: Record<string, unknown>) => console.error(`[scheduler] ${message}`, data ?? ""),
+};
+
+/** On-disk shape of a user scheduled task (mirror of MulmoClaude's PersistedUserTask;
+ *  only the fields this host reads). */
+export interface PersistedUserTask {
+  id: string;
+  name?: string;
+  description?: string;
+  schedule: TaskSchedule;
+  enabled?: boolean;
+  roleId?: string;
+  prompt: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function allDigits(value: string): boolean {
+  if (value.length === 0) return false;
+  for (const char of value) {
+    if (char < "0" || char > "9") return false;
+  }
+  return true;
+}
+
+// Validate "HH:MM" with string ops (no regex — lint bans backtracking-prone patterns).
+function isValidDailyTime(value: string): boolean {
+  const parts = value.split(":");
+  if (parts.length !== 2) return false;
+  const [hourStr, minStr] = parts;
+  if (hourStr.length !== 2 || minStr.length !== 2 || !allDigits(hourStr) || !allDigits(minStr)) return false;
+  return Number(hourStr) <= 23 && Number(minStr) <= 59;
+}
+
+function isValidSchedule(value: unknown): value is TaskSchedule {
+  if (!isRecord(value)) return false;
+  if (value.type === SCHEDULE_TYPES.interval) return typeof value.intervalMs === "number" && value.intervalMs > 0;
+  if (value.type === SCHEDULE_TYPES.daily) return typeof value.time === "string" && isValidDailyTime(value.time);
+  return false;
+}
+
+function tasksFilePath(workspace: string): string {
+  return path.join(workspace, "config", "scheduler", "tasks.json");
+}
+
+/** Read the user tasks file. Returns [] for a missing file or malformed JSON (a bad
+ *  file must not abort scheduling — it just means no user tasks). */
+export function loadUserTasks(workspace: string): PersistedUserTask[] {
+  let raw: string;
+  try {
+    raw = readFileSync(tasksFilePath(workspace), "utf8");
+  } catch {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as PersistedUserTask[]) : [];
+  } catch (err) {
+    log.warn("tasks.json is malformed — ignoring", { error: err instanceof Error ? err.message : String(err) });
+    return [];
+  }
+}
+
+/** Map persisted user tasks to task-manager definitions. Pure + exported for tests:
+ *  drops disabled tasks and ones missing a valid id / prompt / schedule, and binds
+ *  each surviving task's run to a fresh chat seeded with its prompt. */
+export function buildUserTaskDefinitions(tasks: PersistedUserTask[], spawnChat: (message: string) => void): TaskDefinition[] {
+  const definitions: TaskDefinition[] = [];
+  for (const task of tasks) {
+    if (!task.enabled) continue;
+    if (typeof task.id !== "string" || task.id.length === 0) {
+      log.warn("skipping task: missing id");
+      continue;
+    }
+    if (typeof task.prompt !== "string" || task.prompt.trim().length === 0) {
+      log.warn("skipping task: empty prompt", { id: task.id });
+      continue;
+    }
+    if (!isValidSchedule(task.schedule)) {
+      log.warn("skipping task: invalid schedule", { id: task.id });
+      continue;
+    }
+    const prompt = task.prompt.trim();
+    definitions.push({
+      id: `user.${task.id}`,
+      description: `User task: ${task.name ?? task.id}`,
+      schedule: task.schedule,
+      run: async () => {
+        log.info("running user task", { id: task.id, name: task.name });
+        spawnChat(prompt);
+      },
+    });
+  }
+  return definitions;
+}
+
+/** Wire the user-task scheduler: load tasks, register the enabled+valid ones on a
+ *  task-manager, and start the tick loop. `spawnChat` is the run-binding (spawns a
+ *  visible chat seeded with the prompt). Returns the number registered. */
+export function initUserTaskScheduler(deps: { workspace: string; spawnChat: (message: string) => void }): number {
+  const definitions = buildUserTaskDefinitions(loadUserTasks(deps.workspace), deps.spawnChat);
+  const taskManager = createTaskManager({ log });
+  for (const definition of definitions) taskManager.registerTask(definition);
+  if (definitions.length > 0) taskManager.start();
+  log.info("user-task scheduler started", { registered: definitions.length });
+  return definitions.length;
+}
+
+/** Read-only REST surface: list the user tasks (backs a future tasks UI). CRUD is a
+ *  later PR; existing tasks run without it. */
+export function mountSchedulerRoutes(app: Express, deps: { workspace: string }): void {
+  app.get("/api/scheduler/tasks", (_req: Request, res: Response) => {
+    res.json({ tasks: loadUserTasks(deps.workspace) });
+  });
+}

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -99,7 +99,9 @@ export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: (
       log.warn("skipping task: not an object");
       continue;
     }
-    if (!entry.enabled) continue;
+    // `enabled` is optional — only an explicit `false` disables a task; an omitted
+    // field means enabled (so a hand-authored task without the flag still runs).
+    if (entry.enabled === false) continue;
     const id = entry.id;
     if (typeof id !== "string" || id.length === 0) {
       log.warn("skipping task: missing id");

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -88,31 +88,40 @@ export function loadUserTasks(workspace: string): PersistedUserTask[] {
 }
 
 /** Map persisted user tasks to task-manager definitions. Pure + exported for tests:
- *  drops disabled tasks and ones missing a valid id / prompt / schedule, and binds
- *  each surviving task's run to a fresh chat seeded with its prompt. */
-export function buildUserTaskDefinitions(tasks: PersistedUserTask[], spawnChat: (message: string) => void): TaskDefinition[] {
+ *  drops non-object / disabled entries and ones missing a valid id / prompt /
+ *  schedule, and binds each surviving task's run to a fresh chat seeded with its
+ *  prompt. Takes `unknown[]` because the array comes straight from JSON.parse — a
+ *  bad element (`null`, a primitive) must be skipped, not throw (non-fatal). */
+export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: (message: string) => void): TaskDefinition[] {
   const definitions: TaskDefinition[] = [];
-  for (const task of tasks) {
-    if (!task.enabled) continue;
-    if (typeof task.id !== "string" || task.id.length === 0) {
+  for (const entry of tasks) {
+    if (!isRecord(entry)) {
+      log.warn("skipping task: not an object");
+      continue;
+    }
+    if (!entry.enabled) continue;
+    const id = entry.id;
+    if (typeof id !== "string" || id.length === 0) {
       log.warn("skipping task: missing id");
       continue;
     }
-    if (typeof task.prompt !== "string" || task.prompt.trim().length === 0) {
-      log.warn("skipping task: empty prompt", { id: task.id });
+    const rawPrompt = entry.prompt;
+    if (typeof rawPrompt !== "string" || rawPrompt.trim().length === 0) {
+      log.warn("skipping task: empty prompt", { id });
       continue;
     }
-    if (!isValidSchedule(task.schedule)) {
-      log.warn("skipping task: invalid schedule", { id: task.id });
+    if (!isValidSchedule(entry.schedule)) {
+      log.warn("skipping task: invalid schedule", { id });
       continue;
     }
-    const prompt = task.prompt.trim();
+    const prompt = rawPrompt.trim();
+    const name = typeof entry.name === "string" ? entry.name : id;
     definitions.push({
-      id: `user.${task.id}`,
-      description: `User task: ${task.name ?? task.id}`,
-      schedule: task.schedule,
+      id: `user.${id}`,
+      description: `User task: ${name}`,
+      schedule: entry.schedule,
       run: async () => {
-        log.info("running user task", { id: task.id, name: task.name });
+        log.info("running user task", { id, name });
         spawnChat(prompt);
       },
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,6 +28,7 @@ import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { initFileChangePublisher } from "./backends/fileChange.js";
 import { initNotifier, mountNotificationRoutes } from "./backends/notifier.js";
 import { startCollectionCompletionWatchers } from "./backends/collectionWatchers.js";
+import { initUserTaskScheduler, mountSchedulerRoutes } from "./backends/scheduler.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
@@ -609,6 +610,10 @@ mountCollectionRoutes(app);
 // bell. The engine is configured below once pubsub + the workspace exist.
 mountNotificationRoutes(app);
 
+// Scheduler REST surface (read-only list of user cron tasks) — backs a future tasks
+// UI. The tasks themselves are loaded + started below, once the spawn infra exists.
+mountSchedulerRoutes(app, { workspace: CLAUDE_CWD });
+
 // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
 // fields and custom-view <img> URLs. Rooted at the shared workspace.
 mountFilesRoutes(app, { workspace: CLAUDE_CWD });
@@ -961,6 +966,24 @@ initCollectionsBackend({ workspace: CLAUDE_CWD });
 startCollectionCompletionWatchers().catch((err) => {
   console.error("[collection-watchers] failed to start — completion bells disabled", err);
 });
+
+// User-task scheduler: cron tasks from config/scheduler/tasks.json fire on schedule
+// and spawn a NEW chat seeded with the task's prompt (e.g. the workout-log weekly
+// nudge). The run-binding spawns a VISIBLE session so the user sees the result.
+// Non-fatal: a scheduler failure must never abort startup.
+function spawnScheduledChat(message: string): void {
+  const sessionId = randomUUID();
+  try {
+    spawnClaudePty(sessionId, null, null, message);
+  } catch (err) {
+    console.error(`[scheduler] failed to spawn chat for a scheduled task: ${messageOf(err)}`);
+  }
+}
+try {
+  initUserTaskScheduler({ workspace: CLAUDE_CWD, spawnChat: spawnScheduledChat });
+} catch (err) {
+  console.error("[scheduler] init failed (non-fatal)", err);
+}
 
 // Terminal WebSocket. Uses noServer + manual upgrade routing so it shares the
 // HTTP server with socket.io (the pub/sub at /ws/pubsub) without the two

--- a/yarn.lock
+++ b/yarn.lock
@@ -642,6 +642,11 @@
     modern-tar "^0.7.6"
     yargs "^17.7.2"
 
+"@receptron/task-scheduler@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@receptron/task-scheduler/-/task-scheduler-0.1.0.tgz#10f06daee16954cdd0660f3de3d8512c9fd9ab30"
+  integrity sha512-OmK0eBoIVZK+WqyV7F7BLE3T8VuS6OiwgoS9HDpG9C9UqEeUtt/kngKlh00Wan/8tQkJMdlrXnWxDZcxjdYe1A==
+
 "@rolldown/binding-android-arm64@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz#54ce8f8382213f4a314a0c2f7ba83f81ffeae592"


### PR DESCRIPTION
## Why

The scheduler splits cleanly: the **engine** (tick loop, daily/interval scheduling) is the shared `@mulmoclaude/core/scheduler`; the task **run** logic is app-specific. MulmoClaude has two task families — **user tasks** (portable) and **system tasks** (MulmoClaude-only). This PR wires the portable half.

**User tasks** (`config/scheduler/tasks.json`) fire on schedule and **spawn a new chat seeded with the task's prompt**. That's how the workout-log "週3回リマインダー" works: a daily 11:00 task whose prompt tells the agent to read `data/workout-log/items/` and nudge — the collection schema is uninvolved; the only link is the prompt text. The run-binding is exactly MulmoTerminal's `spawnBackgroundChat`. So a MulmoTerminal-alone run can now run these tasks.

## Changes

- **dep**: `@receptron/task-scheduler@^0.1.0` — a `*` peerDependency of `@mulmoclaude/core` (used by `@mulmoclaude/core/scheduler`), not auto-installed.
- **`server/backends/scheduler.ts`**:
  - `loadUserTasks(workspace)` — read `config/scheduler/tasks.json`; `[]` for a missing/malformed file (a bad file must not abort scheduling).
  - `buildUserTaskDefinitions(tasks, spawnChat)` — **pure, exported for tests**: drop disabled tasks and ones missing a valid id / non-empty prompt / valid schedule (`{interval, intervalMs>0}` or `{daily, "HH:MM"}` — HH:MM validated with **string ops, no regex**); bind each survivor's `run` to a chat seeded with its prompt.
  - `initUserTaskScheduler({workspace, spawnChat})` — `createTaskManager`, register the defs, `start()` the tick loop. Registered directly on the task-manager (matches MulmoClaude — user tasks fire forward on schedule, no system-task catch-up).
  - `mountSchedulerRoutes` — `GET /api/scheduler/tasks` (read-only list).
- **`server/index.ts`**: `spawnScheduledChat` (`randomUUID` + `spawnClaudePty`, a **visible** session so the user sees the nudge) as the run-binding; wire init + routes, fire-and-forget + non-fatal.

## Out of scope (deferred)

- **PR 4b — system tasks** (journal / chat-index / **feed-refresh**): their `run` logic (`refreshDueFeeds`, …) is MulmoClaude-only, not in the shared package. Needs the feed-refresh engine extracted into `@mulmoclaude/core` first. Until then a MulmoTerminal-alone run doesn't refresh feeds.
- **PR 4c — task CRUD + a tasks UI**: existing tasks run without it.
- **Missed-run catch-up across restarts**: user tasks fire forward only (matches MulmoClaude).

## Verification

- `yarn typecheck`, `yarn lint` (0 errors), `yarn test` (400 passed, +7), `yarn build` — all green.
- **Boot smoke**: with a `tasks.json` holding one enabled + one disabled daily task — registers `user.demo-nudge`, skips the disabled one, starts the tick loop (`tickMs 60000`), and `GET /api/scheduler/tasks` returns the list. No errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)