### PR TITLE
feat: collection feed refresh via @mulmoclaude/core/feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@mulmoclaude/accounting-plugin": "^0.2.0",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.5.11",
-    "@mulmoclaude/core": "^0.2.2",
+    "@mulmoclaude/core": "^0.2.6",
     "@mulmoclaude/form-plugin": "^0.1.3",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.7",

--- a/server/backends/feeds.ts
+++ b/server/backends/feeds.ts
@@ -1,0 +1,74 @@
+// Server-side backend for @mulmoclaude/core/feeds. MulmoTerminal drives the collection
+// "Refresh" button through the shared feeds engine — the same one MulmoClaude uses:
+//   - declarative feeds (ingest.kind rss/atom/http-json) fetch + parse + upsert records
+//     directly (no agent), and
+//   - agent-ingest collections (ingest.kind:"agent") dispatch a VISIBLE worker session
+//     the user can watch.
+// Mirrors MulmoClaude's server/workspace/feeds/configure.ts + the refresh route. Like the
+// accounting/collection backends, this is a thin host adapter: all logic lives in the
+// package; we supply the workspace, an atomic writer, a logger, and the worker spawner.
+//
+// `spawnWorker` is INJECTED from server/index.ts (where the PTY spawn lives) so this
+// backend never imports the session layer — the same workspace→routes-cycle avoidance
+// MulmoClaude's host shim documents.
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { Express, Request, Response } from "express";
+import { configureFeedsHost, refreshOne, type AgentWorkerRunner, type FeedsLogger } from "@mulmoclaude/core/feeds/server";
+import { loadCollection } from "@mulmoclaude/core/collection/server";
+
+const log: FeedsLogger = {
+  error: (prefix, msg, data) => console.error(`[${prefix}] ${msg}`, data ?? ""),
+  warn: (prefix, msg, data) => console.warn(`[${prefix}] ${msg}`, data ?? ""),
+  info: (prefix, msg, data) => console.log(`[${prefix}] ${msg}`, data ?? ""),
+  debug: (prefix, msg, data) => console.debug(`[${prefix}] ${msg}`, data ?? ""),
+};
+
+// Atomic state-file write (feeds/<slug>/_state.json, data/ingest-state/<slug>.json):
+// write a unique temp then rename, mkdir -p the parent first. Matches the engine's
+// expectation of a plain (filePath, content) atomic writer.
+async function writeFileAtomic(filePath: string, content: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${randomUUID()}.tmp`;
+  await writeFile(tmp, content);
+  await rename(tmp, filePath);
+}
+
+let workspaceRoot = "";
+
+/** Wire the feeds engine to the shared workspace. Call once at boot, after pubsub +
+ *  the collection backend. `spawnWorker` is supplied by server/index.ts. */
+export function initFeedsBackend(deps: { workspace: string; spawnWorker: AgentWorkerRunner }): void {
+  workspaceRoot = deps.workspace;
+  configureFeedsHost({ workspaceRoot: deps.workspace, log, writeFileAtomic, spawnWorker: deps.spawnWorker });
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Mount POST /api/collections/:slug/refresh — generic over ingest.kind (the engine
+ *  dispatches declarative vs agent). Ports MulmoClaude's collections-route refresh
+ *  handler; `hidden:false` so an agent-ingest refresh runs as a visible, watchable
+ *  session. Backs the collection-view Refresh button (collectionUi.refreshCollection). */
+export function mountFeedsRoutes(app: Express): void {
+  app.post("/api/collections/:slug/refresh", async (req: Request<{ slug: string }>, res: Response) => {
+    const collection = await loadCollection(req.params.slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+      return;
+    }
+    if (!collection.schema.ingest) {
+      res.status(400).json({ error: `collection '${collection.slug}' is not a feed (no ingest config)` });
+      return;
+    }
+    try {
+      const result = await refreshOne(workspaceRoot, collection, { hidden: false });
+      res.json({ refreshed: true, written: result.written, errors: result.errors, dispatched: result.dispatched, chatId: result.chatId });
+    } catch (err) {
+      log.warn("feeds", "refresh failed", { slug: collection.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,8 @@ import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { initAccountingBackend, mountAccountingRoutes } from "./backends/accounting.js";
+import { initFeedsBackend, mountFeedsRoutes } from "./backends/feeds.js";
+import type { AgentWorkerRunner } from "@mulmoclaude/core/feeds/server";
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { initFileChangePublisher } from "./backends/fileChange.js";
 import { initNotifier, mountNotificationRoutes } from "./backends/notifier.js";
@@ -640,6 +642,11 @@ mountCollectionRoutes(app);
 // further down, once CLAUDE_CWD + pubsub exist.
 mountAccountingRoutes(app);
 
+// Collection Refresh route (POST /api/collections/:slug/refresh) from
+// @mulmoclaude/core/feeds — fetches declarative feeds or dispatches an agent-ingest
+// worker. Backs the collection-view Refresh button. The engine is configured below.
+mountFeedsRoutes(app);
+
 // Notification REST surface (list active / history, dismiss one) — backs the toolbar
 // bell. The engine is configured below once pubsub + the workspace exist.
 mountNotificationRoutes(app);
@@ -998,6 +1005,24 @@ initCollectionsBackend({ workspace: CLAUDE_CWD });
 // under <workspace>/data/accounting; the publisher drives the View's live-refresh.
 // Single pinned workspace root — exactly what the focused freelance product wants.
 initAccountingBackend({ workspace: CLAUDE_CWD, pubsub });
+
+// Configure the feeds engine (collection Refresh). The agent-ingest worker launcher is
+// MulmoTerminal's own session spawn — adapted to @mulmoclaude/core/feeds' AgentWorkerRunner
+// shape here (where spawnClaudePty lives) and injected, so the feeds backend never imports
+// the session layer. A MANUAL refresh spawns a VISIBLE session (hidden:false) the user can
+// watch; `onComplete` is honoured only for hidden (scheduled) workers, which MulmoTerminal
+// doesn't register yet, so it's unused for now. `roleId` is ignored (no role system).
+const feedsSpawnWorker: AgentWorkerRunner = async ({ message, hidden }) => {
+  try {
+    const sessionId = randomUUID();
+    if (hidden) hiddenSessions.add(sessionId);
+    spawnClaudePty(sessionId, null, null, message);
+    return { ok: true, chatId: sessionId };
+  } catch (err) {
+    return { ok: false, error: messageOf(err) };
+  }
+};
+initFeedsBackend({ workspace: CLAUDE_CWD, spawnWorker: feedsSpawnWorker });
 
 // Mount per-collection fs.watchers → completion bells via the notifier. After the
 // engine host + notifier are configured. Fire-and-forget + non-fatal: a watcher

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -5,9 +5,11 @@
 // instance, no confirm/notifier stores).
 //
 // Wired: data fetch (detail/list), record CRUD, read-only custom views, actions
-// (seed prompt → startChat → a visible chat), favorites (useShortcuts), and
-// state-based navigation (useCollectionBrowse — the toolbar + browse overlay).
-// Still stubbed: feeds, collection/view deletion, feed refresh, and the notifier.
+// (seed prompt → startChat → a visible chat), favorites (useShortcuts), feed/agent
+// refresh (POST /api/collections/:slug/refresh via @mulmoclaude/core/feeds — see
+// server/backends/feeds.ts), and state-based navigation (useCollectionBrowse — the
+// toolbar + browse overlay).
+// Still stubbed: feed listing (listFeeds), collection/view deletion, and the notifier.
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionApiResult, CollectionViewToken, CollectionActionResult } from "@mulmoclaude/collection-plugin/vue";
 import type { CollectionDetailResponse, CollectionsListResponse, CollectionNotifySeverity, ItemMutationResponse } from "@mulmoclaude/core/collection";
@@ -149,7 +151,7 @@ configureCollectionUi({
     ),
   runCollectionAction: (slug, actionId) =>
     apiPost<CollectionActionResult>(`/api/collections/${encodeURIComponent(slug)}/actions/${encodeURIComponent(actionId)}`, {}),
-  refreshCollection: () => Promise.resolve(apiFail),
+  refreshCollection: (slug) => apiPost(`/api/collections/${encodeURIComponent(slug)}/refresh`, {}),
   deleteView: () => Promise.resolve(mutationFail),
   listFeeds: () => Promise.resolve(apiFail),
 

--- a/src/utils/customViewSrcdoc.spec.ts
+++ b/src/utils/customViewSrcdoc.spec.ts
@@ -43,4 +43,23 @@ describe("buildCustomViewSrcdoc", () => {
     expect(out).not.toContain("</script><script>alert(1)");
     expect(out).toContain("\\u003c/script>\\u003cscript>alert(1)");
   });
+
+  // Regression: the view↔host bridge (onChange/openItem/startChat) must be defined, or
+  // LLM-authored custom views throw "__MC_VIEW.openItem is not a function" when an item
+  // is opened. The earlier MT port shipped only { slug, token, dataUrl } and crashed.
+  it("defines the view↔host bridge functions on __MC_VIEW", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    expect(out).toContain("v.onChange=function");
+    expect(out).toContain("v.openItem=function");
+    expect(out).toContain("v.startChat=function");
+  });
+
+  it("includes origin so openItem/startChat can postMessage the known parent", () => {
+    const out = buildCustomViewSrcdoc("<head></head>", boot);
+    expect(out).toContain('"origin":"http://localhost:5173"');
+    // openItem/startChat target v.origin (not "*").
+    expect(out).toContain("'mc-open-item'");
+    expect(out).toContain("'mc-start-chat'");
+    expect(out).toContain("},v.origin)");
+  });
 });

--- a/src/utils/customViewSrcdoc.ts
+++ b/src/utils/customViewSrcdoc.ts
@@ -4,8 +4,11 @@
 // Injected at the START of <head> so the bootstrap runs before the view's own
 // scripts: (1) a CSP <meta> locking connect-src to the server origin (the view may
 // fetch its data endpoint but no third party), and (2)
-// `window.__MC_VIEW = { slug, token, dataUrl }` — the scoped token + absolute data
-// URL the view reads.
+// `window.__MC_VIEW = { slug, token, dataUrl, origin, onChange, openItem, startChat }`
+// — the scoped token + absolute data URL the view reads, PLUS the view↔host bridge
+// (onChange live-refresh + openItem + startChat helpers that postMessage the parent,
+// which @mulmoclaude/collection-plugin's CollectionCustomView consumes). Without the
+// bridge the LLM-authored views throw `__MC_VIEW.openItem is not a function`.
 
 // Curated CDN allowlist the LLM commonly pulls charting/util libs + fonts from.
 const ALLOWED_CDNS: readonly string[] = [
@@ -51,6 +54,21 @@ function absoluteDataUrl(dataUrl: string, origin: string): string {
   return dataUrl.startsWith("/") ? `${origin}${dataUrl}` : dataUrl;
 }
 
+/** Debounce (ms) for the in-iframe live-refresh helper — collapses a burst of parent
+ *  change-pings into a single onChange callback. */
+const ONCHANGE_DEBOUNCE_MS = 150;
+
+/** The in-iframe view↔host bridge appended after `window.__MC_VIEW = {…}`. Ported
+ *  verbatim from MulmoClaude (src/utils/html/customViewSrcdoc.ts). Defines the three
+ *  functions the custom view calls — they postMessage the parent, which
+ *  @mulmoclaude/collection-plugin's CollectionCustomView already handles (mc-open-item /
+ *  mc-start-chat) and pings (mc-collection-changed) for live refresh. No secret crosses
+ *  the boundary; openItem/startChat go to the known parent `v.origin`. Self-contained
+ *  string (no `</script>`, no `<`, no `${`) so it survives inlining into the <script>. */
+function viewBridgeBootstrap(): string {
+  return `(function(){var v=window.__MC_VIEW,cbs=[],t;function fire(){t=undefined;cbs.slice().forEach(function(cb){try{cb()}catch(e){}});}window.addEventListener('message',function(e){if(e.source!==window.parent)return;var d=e.data;if(!d||d.type!=='mc-collection-changed'||d.slug!==v.slug)return;if(t)clearTimeout(t);t=setTimeout(fire,${ONCHANGE_DEBOUNCE_MS});});v.onChange=function(cb){if(typeof cb!=='function')return function(){};cbs.push(cb);return function(){var i=cbs.indexOf(cb);if(i>=0)cbs.splice(i,1);};};v.openItem=function(id,mode){window.parent.postMessage({type:'mc-open-item',slug:v.slug,id:String(id),mode:mode==='edit'?'edit':'view'},v.origin);};v.startChat=function(prompt,role){window.parent.postMessage({type:'mc-start-chat',slug:v.slug,prompt:String(prompt),role:typeof role==='string'?role:undefined},v.origin);};})();`;
+}
+
 export function buildCustomViewSrcdoc(html: string, boot: CustomViewBootstrap): string {
   const cspMeta = `<meta http-equiv="Content-Security-Policy" content="${buildCustomViewCsp(boot.origin)}">`;
   // `<`-escape the JSON so a hostile token/slug value can't break out of <script>.
@@ -58,8 +76,9 @@ export function buildCustomViewSrcdoc(html: string, boot: CustomViewBootstrap): 
     slug: boot.slug,
     token: boot.token,
     dataUrl: absoluteDataUrl(boot.dataUrl, boot.origin),
+    origin: boot.origin, // target origin for openItem/startChat postMessage to the parent
   }).replace(/</g, "\\u003c");
-  const injection = `${cspMeta}<script>window.__MC_VIEW=${json};</script>`;
+  const injection = `${cspMeta}<script>window.__MC_VIEW=${json};${viewBridgeBootstrap()}</script>`;
   if (/<head\b[^>]*>/i.test(html)) {
     return html.replace(/(<head\b[^>]*>)/i, `$1${injection}`);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,11 +534,12 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.2.2.tgz#f3f7d8d12703128651f5696fa4625f50065e0fe9"
-  integrity sha512-QFt8rqHOdNxaSxGn2FlDzb/wc45HkiN3i/2XX+OIBUDkHlBbsFG8izJ1n8WrHdvaT8YXqJgB6dJkwnq34U9lOg==
+"@mulmoclaude/core@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.2.6.tgz#f2bce5dbb891ea3f79c833c821162708116c34b5"
+  integrity sha512-zVHWtjkgM/5ZjpVrW4Knr3dYIiCFeBmFIxcvr5eVRW1FCv7fZ0mxnqSaKNWFUJ5oznkmgdr6a9idPuDycmZS1A==
   dependencies:
+    fast-xml-parser "^5.9.3"
     zod "^4.4.3"
 
 "@mulmoclaude/form-plugin@^0.1.3":
@@ -571,6 +572,11 @@
   integrity sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==
   dependencies:
     "@tybys/wasm-util" "^0.10.2"
+
+"@nodable/entities@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.2.0.tgz#a1d45a992b022591b1c2b03a77935c939375b642"
+  integrity sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==
 
 "@one-ini/wasm@0.1.1":
   version "0.1.1"
@@ -1393,6 +1399,11 @@ ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
+anynum@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.1.tgz#2aac00e08dfad3726c1d462e60dbc2f831659a44"
+  integrity sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -2148,6 +2159,26 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
+fast-xml-builder@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
+  integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
+  dependencies:
+    path-expression-matcher "^1.5.0"
+    xml-naming "^0.1.0"
+
+fast-xml-parser@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz#9db7a6dba7ac6f8dc1ee924d69547b2d4750d60c"
+  integrity sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==
+  dependencies:
+    "@nodable/entities" "^2.2.0"
+    fast-xml-builder "^1.2.0"
+    is-unsafe "^1.0.1"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.4.1"
+    xml-naming "^0.1.0"
+
 fdir@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
@@ -2465,6 +2496,11 @@ is-promise@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
+
+is-unsafe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-1.0.1.tgz#ce89b55dec0034364f5beda41e10481efa8fa317"
+  integrity sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3026,6 +3062,11 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+path-expression-matcher@^1.5.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz#fb190513954875d7e1b05c8caabe7fdd0a4cd75b"
+  integrity sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==
+
 path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
@@ -3537,6 +3578,13 @@ strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   dependencies:
     ansi-regex "^6.2.2"
 
+strnum@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.1.tgz#85417f683113badea0fe7e17227676f889ff7e58"
+  integrity sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==
+  dependencies:
+    anynum "^1.0.1"
+
 supports-color@10.2.2:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-10.2.2.tgz#466c2978cc5cd0052d542a0b576461c2b802ebb4"
@@ -3933,6 +3981,11 @@ xml-name-validator@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
   integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xml-naming@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
+  integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Clicking **Refresh** on a feed / agent-ingest collection (e.g. `world-cup-2026-matches`) failed with *"not supported in MulmoTerminal yet"* — the `refreshCollection` binding was stubbed because the feeds retrieval engine lived host-side in MulmoClaude. That engine is now extracted to **`@mulmoclaude/core/feeds`** (published `0.2.6`), so MulmoTerminal drives the same engine MulmoClaude does.

## Changes
- **Bump `@mulmoclaude/core` → `^0.2.6`** (the `feeds` subpath).
- **`server/backends/feeds.ts`** (new) — `configureFeedsHost({ workspaceRoot: CLAUDE_CWD, log, writeFileAtomic, spawnWorker })` + `mountFeedsRoutes` → `POST /api/collections/:slug/refresh` (`loadCollection` → `refreshOne`, generic over `ingest.kind`). Mirrors MulmoClaude's host shim + refresh route.
- **`server/index.ts`** — mount the route + a `spawnWorker` adapter over the existing `spawnClaudePty` (a manual refresh spawns a **visible** session the user can watch), injected so the backend never imports the session layer (same workspace→routes-cycle avoidance as MulmoClaude).
- **`src/composables/collectionUi.ts`** — unstub `refreshCollection` → POST the refresh route.

## How it works
- **Declarative feeds** (RSS / Atom / HTTP-JSON) fetch + parse + upsert records directly.
- **Agent-ingest** collections (`ingest.kind: "agent"`) dispatch a visible worker session that runs the collection's refresh template.

## Verification
- Typecheck (client + server), production build, full unit suite — all green.
- **E2E** against a copy of the real `world-cup-2026-matches` skill: refresh dispatches a worker (`{ refreshed:true, dispatched:true, chatId }`; log shows `[feeds] agent ingest dispatched → [pty] spawned claude`). Unknown slug → 404.
- Confirmed working on a real collection in the live app.

## Scope: manual refresh only (scheduled is intentionally out)
This PR wires the **manual Refresh button**, not a scheduled refresh, **by design**:
- With the shared `~/mulmoclaude` workspace, MulmoClaude's running scheduler already registers `system:feed-refresh` (hourly `refreshDue`) against that workspace, so due feeds are already refreshed. A second scheduler here would be redundant (and could double-dispatch agent-ingest workers).
- For **standalone MulmoTerminal** (no MulmoClaude running), the `system:feed-refresh` registration should be **exported as shareable logic from `@mulmoclaude/core`** (today it's hand-assembled in MulmoClaude's `server/index.ts`) — tracked as a **separate PR** (plan: `mulmoclaude/plans/feat-shareable-feed-refresh-registration.md`).

## Dependency note
`@mulmoclaude/core@0.2.6` is on npm, but the **MulmoClaude feeds-extraction PR is not yet merged to main**. If its final published version differs from `0.2.6`, re-pin before merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)