### PR TITLE
feat: scheduled feed refresh (register shared feedRefreshTaskDef)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@mulmoclaude/accounting-plugin": "^0.2.0",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.5.11",
-    "@mulmoclaude/core": "^0.2.6",
+    "@mulmoclaude/core": "^0.2.10",
     "@mulmoclaude/form-plugin": "^0.1.3",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.7",

--- a/server/backends/scheduler.spec.ts
+++ b/server/backends/scheduler.spec.ts
@@ -1,11 +1,20 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import type { Server } from "node:http";
-import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes } from "./scheduler.js";
+import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
+import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, initUserTaskScheduler } from "./scheduler.js";
+
+// Mock the shared task-manager so initUserTaskScheduler's registration + start calls
+// are observable without starting real interval timers.
+const { registerTaskMock, startMock } = vi.hoisted(() => ({ registerTaskMock: vi.fn(), startMock: vi.fn() }));
+vi.mock("@mulmoclaude/core/scheduler", () => ({
+  createTaskManager: () => ({ registerTask: registerTaskMock, start: startMock }),
+}));
 
 const tempDirs: string[] = [];
 
@@ -118,5 +127,49 @@ describe("mountSchedulerRoutes", () => {
     const res = await fetch(`${base}/api/scheduler/tasks`);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ tasks });
+  });
+});
+
+describe("initUserTaskScheduler", () => {
+  const sysTask = (id: string): TaskDefinition => ({
+    id,
+    schedule: { type: SCHEDULE_TYPES.interval, intervalMs: 60 * 60 * 1000 },
+    run: async () => {},
+  });
+
+  beforeEach(() => {
+    registerTaskMock.mockClear();
+    startMock.mockClear();
+  });
+
+  it("registers system tasks and starts the tick loop even with zero user tasks", () => {
+    // makeWorkspace() with no tasks.json → zero user tasks (the standalone feed-refresh case).
+    const count = initUserTaskScheduler({
+      workspace: makeWorkspace(),
+      spawnChat: () => {},
+      systemTasks: [sysTask("system:feed-refresh")],
+    });
+    expect(count).toBe(0); // zero USER tasks
+    expect(registerTaskMock).toHaveBeenCalledTimes(1);
+    expect(registerTaskMock).toHaveBeenCalledWith(expect.objectContaining({ id: "system:feed-refresh" }));
+    expect(startMock).toHaveBeenCalledTimes(1); // started despite zero user tasks
+  });
+
+  it("does not start the tick loop when there are no tasks at all", () => {
+    initUserTaskScheduler({ workspace: makeWorkspace(), spawnChat: () => {} });
+    expect(registerTaskMock).not.toHaveBeenCalled();
+    expect(startMock).not.toHaveBeenCalled();
+  });
+
+  it("registers both system and user tasks on the one manager", () => {
+    const count = initUserTaskScheduler({
+      workspace: makeWorkspace([{ id: "a", schedule: { type: "daily", time: "11:00" }, enabled: true, prompt: "go" }]),
+      spawnChat: () => {},
+      systemTasks: [sysTask("system:feed-refresh")],
+    });
+    expect(count).toBe(1); // one user task
+    const ids = registerTaskMock.mock.calls.map((call) => (call[0] as TaskDefinition).id);
+    expect(ids).toEqual(expect.arrayContaining(["system:feed-refresh", "user.a"]));
+    expect(startMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -10,8 +10,11 @@
 // Tasks are registered directly on the task-manager (matching MulmoClaude's user
 // tasks) — they fire forward on schedule, with no system-task persistence/catch-up.
 //
-// System tasks (journal / chat-index / feed-refresh) are NOT wired here: their run
-// logic is MulmoClaude-app-specific and not in the shared package (see plan PR 4b).
+// System tasks may be passed in via `systemTasks` and are registered alongside the
+// user tasks on the same task-manager (one tick loop). feed-refresh now IS wired this
+// way — its def comes from the shared @mulmoclaude/core/feeds (`feedRefreshTaskDef`),
+// supplied by server/index.ts. journal / chat-index stay MulmoClaude-only (their run
+// logic isn't in the shared package).
 import path from "node:path";
 import { readFileSync } from "node:fs";
 import type { Express, Request, Response } from "express";
@@ -131,16 +134,19 @@ export function buildUserTaskDefinitions(tasks: readonly unknown[], spawnChat: (
   return definitions;
 }
 
-/** Wire the user-task scheduler: load tasks, register the enabled+valid ones on a
- *  task-manager, and start the tick loop. `spawnChat` is the run-binding (spawns a
- *  visible chat seeded with the prompt). Returns the number registered. */
-export function initUserTaskScheduler(deps: { workspace: string; spawnChat: (message: string) => void }): number {
-  const definitions = buildUserTaskDefinitions(loadUserTasks(deps.workspace), deps.spawnChat);
+/** Wire the scheduler: load user tasks, register the enabled+valid ones plus any
+ *  host `systemTasks` (e.g. feed-refresh) on one task-manager, and start the tick loop.
+ *  `spawnChat` is the user-task run-binding (spawns a visible chat seeded with the
+ *  prompt). The tick loop starts whenever ANY task is registered — so a system task
+ *  alone (no user tasks) still drives its schedule. Returns the user-task count. */
+export function initUserTaskScheduler(deps: { workspace: string; spawnChat: (message: string) => void; systemTasks?: TaskDefinition[] }): number {
+  const userDefs = buildUserTaskDefinitions(loadUserTasks(deps.workspace), deps.spawnChat);
+  const systemTasks = deps.systemTasks ?? [];
   const taskManager = createTaskManager({ log });
-  for (const definition of definitions) taskManager.registerTask(definition);
-  if (definitions.length > 0) taskManager.start();
-  log.info("user-task scheduler started", { registered: definitions.length });
-  return definitions.length;
+  for (const definition of [...systemTasks, ...userDefs]) taskManager.registerTask(definition);
+  if (systemTasks.length + userDefs.length > 0) taskManager.start();
+  log.info("scheduler started", { userTasks: userDefs.length, systemTasks: systemTasks.length });
+  return userDefs.length;
 }
 
 /** Read-only REST surface: list the user tasks (backs a future tasks UI). CRUD is a

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,7 +26,7 @@ import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { initAccountingBackend, mountAccountingRoutes } from "./backends/accounting.js";
 import { initFeedsBackend, mountFeedsRoutes } from "./backends/feeds.js";
-import type { AgentWorkerRunner } from "@mulmoclaude/core/feeds/server";
+import { feedRefreshTaskDef, type AgentWorkerRunner } from "@mulmoclaude/core/feeds/server";
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { initFileChangePublisher } from "./backends/fileChange.js";
 import { initNotifier, mountNotificationRoutes } from "./backends/notifier.js";
@@ -1044,7 +1044,16 @@ function spawnScheduledChat(message: string): void {
   }
 }
 try {
-  initUserTaskScheduler({ workspace: CLAUDE_CWD, spawnChat: spawnScheduledChat });
+  // Register the shared hourly feed-refresh system task so a STANDALONE MulmoTerminal
+  // (no MulmoClaude running) still refreshes due feed/agent-ingest collections. The feeds
+  // host is already configured above (initFeedsBackend), so refreshDue can run. When both
+  // apps run on the shared workspace, the engine's shared `lastFetchedAt` soft-dedups —
+  // whoever refreshes first stamps it, the other's isFeedDue skips (plan: soft-dedup v1).
+  initUserTaskScheduler({
+    workspace: CLAUDE_CWD,
+    spawnChat: spawnScheduledChat,
+    systemTasks: [feedRefreshTaskDef({ workspaceRoot: CLAUDE_CWD })],
+  });
 } catch (err) {
   console.error("[scheduler] init failed (non-fatal)", err);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,10 +534,10 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.2.6":
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.2.6.tgz#f2bce5dbb891ea3f79c833c821162708116c34b5"
-  integrity sha512-zVHWtjkgM/5ZjpVrW4Knr3dYIiCFeBmFIxcvr5eVRW1FCv7fZ0mxnqSaKNWFUJ5oznkmgdr6a9idPuDycmZS1A==
+"@mulmoclaude/core@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.2.10.tgz#201d83fca725d897bfa4974aa87037d7944a5326"
+  integrity sha512-Za+vzA73s7Ue/az0qqaSkqzUBUdBhAyzpAO7+1oy0Yd4e0RS4BDHybMy/3WjffaEoM9IIObfWJ/HJ+hwk4/Q1w==
   dependencies:
     fast-xml-parser "^5.9.3"
     zod "^4.4.3"


### PR DESCRIPTION
Follow-up to #129 (manual refresh). **Standalone MulmoTerminal** (no MulmoClaude running) now refreshes due feed / agent-ingest collections **on schedule**, using the shared `feedRefreshTaskDef` exported from `@mulmoclaude/core/feeds` (`0.2.10`, MulmoClaude PR #1843) — no host-duplicated task definition.

## Changes
- **Bump `@mulmoclaude/core` → `^0.2.10`**.
- **`server/backends/scheduler.ts`** — `initUserTaskScheduler` now accepts an optional `systemTasks?: TaskDefinition[]`, registers them alongside user tasks on the same task-manager, and starts the tick loop whenever **any** task exists (so a system task alone drives its schedule).
- **`server/index.ts`** — pass `systemTasks: [feedRefreshTaskDef({ workspaceRoot: CLAUDE_CWD })]`. The feeds host is configured earlier at boot (`initFeedsBackend`), so `refreshDue` can run.

## Double-scheduling (shared workspace)
When both apps run against `~/mulmoclaude`, dedup relies on the engine's shared `lastFetchedAt` (per the plan's decision — **soft dedup, no lock**): whoever refreshes first stamps it; the other host's `isFeedDue` skips. The standalone case (the actual target) has no conflict at all.

## Verification
- Typecheck (client + server), production build, 177 server tests — all green.
- Boot smoke test against an empty workspace: `[scheduler] scheduler started { userTasks: 0, systemTasks: 1 }` — confirms the task registers and the tick loop starts with zero user tasks.

## Notes
- The hourly tick is the **polling cadence**; each feed's own `schedule` (hourly/daily/weekly) is still enforced by `isFeedDue`.
- **Forward-firing** (no catch-up): the first scheduled refresh is up to an hour after boot; the manual Refresh button covers immediate needs.
- Carry-over (plan open-Q4): scheduled **agent-ingest** dispatches hidden workers but doesn't yet invoke the `onComplete` failure-reconciliation — declarative feeds are fully correct. Flagged as a follow-up, not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)