### PR TITLE
fix(collections): open HTML artifact file fields in a new tab

### DIFF
--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -86,6 +86,21 @@ function rawFileUrl(value: unknown): string {
   return `/api/files/raw?path=${encodeURIComponent(String(value))}`;
 }
 
+// A `file` field holding an `artifacts/html/*.html` path points at an
+// LLM-authored page. The raw-file route serves it as octet-stream (no `.html`
+// in its MIME map) so the browser downloads it; the dedicated preview route
+// (server/backends/html.ts → mountHtmlPreviewRoute) serves it as text/html
+// with the sandboxed preview CSP, so it renders in a new tab. Detect that
+// shape and return the preview URL; everything else falls back to rawFileUrl.
+const HTML_PREVIEW_DIR_PREFIX = "artifacts/html/";
+function htmlPreviewUrl(value: string): string | null {
+  if (!value.toLowerCase().endsWith(".html")) return null;
+  if (!value.startsWith(HTML_PREVIEW_DIR_PREFIX)) return null;
+  const rest = value.slice(HTML_PREVIEW_DIR_PREFIX.length);
+  if (rest.length === 0) return null;
+  return `/artifacts/html/${rest.split("/").map(encodeURIComponent).join("/")}`;
+}
+
 // Shared "not supported yet" results for the write/feeds/view capabilities.
 const UNSUPPORTED = "not supported in MulmoTerminal yet";
 const apiFail = { ok: false as const, error: UNSUPPORTED, status: 501 };
@@ -108,7 +123,7 @@ configureCollectionUi({
   //    else resolves to /api/files/raw?path=<workspace-relative>. fileRoutePath
   //    (in-app File Explorer nav) stays null — MulmoTerminal has no file explorer. ──
   imageSrc: (imageData) => (typeof imageData === "string" && imageData.startsWith("data:") ? imageData : rawFileUrl(imageData)),
-  fileAssetUrl: (value) => (typeof value === "string" && value.length > 0 ? rawFileUrl(value) : null),
+  fileAssetUrl: (value) => (typeof value === "string" && value.length > 0 ? (htmlPreviewUrl(value) ?? rawFileUrl(value)) : null),
   fileRoutePath: () => null,
 
   // ── navigation: no router — map onto useCollectionBrowse's view-state, which


### PR DESCRIPTION
## Problem

Clicking a collection `file`-field link that points at an `artifacts/html/*.html` artifact (e.g. a lesson in the **量子コンピューター** collection) **downloads the HTML** instead of opening the rendered page in a new tab. The same mechanism works in MulmoClaude.

## Root cause

The collection plugin renders a `file` field as a native `<a target="_blank" href="fileAssetUrl(value)">`. MulmoTerminal's `fileAssetUrl` routed **every** path — including HTML artifacts — to `/api/files/raw`. That route (`server/backends/files.ts`) has no `.html` entry in its MIME map, so it serves the file as `application/octet-stream` + `nosniff` → the browser downloads it.

Meanwhile MulmoTerminal already has the correct route, `GET /artifacts/html/<rest>` (`mountHtmlPreviewRoute`, `server/backends/html.ts`), which serves `text/html` with the sandboxed preview CSP — it was just never used by the collection link. (No router involved; the link is a plain native anchor.)

## Fix

Client-only, in `src/composables/collectionUi.ts`: detect the `artifacts/html/*.html` shape in `fileAssetUrl` and return the dedicated preview URL (`/artifacts/html/<per-segment-encoded-rest>`), falling back to the raw-file route for everything else (images, etc.). Mirrors MulmoClaude's `htmlPreviewUrlFor`.

## Verify

`yarn dev`, open the 量子コンピューター collection table, click a lesson → it now opens the rendered lesson HTML in a new tab (previously downloaded). Image/other `file` fields unchanged.

## Checks

`yarn format`, `yarn lint` (0 errors — 2 pre-existing unrelated warnings), `yarn typecheck`, `yarn build` all pass.

## Follow-ups (not in this PR)

- SVG `file` fields still won't render in-tab — MulmoTerminal has no `/artifacts/svg` route. Add only if SVG fields get used.
- The detection logic now exists in both apps (~17 lines, dependency-free). Kept duplicated for now; lift into `@mulmoclaude/core` only if it grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)