### PR TITLE
feat: add local voice input to the terminal toolbar

### DIFF
--- a/server/backends/whisper.ts
+++ b/server/backends/whisper.ts
@@ -1,0 +1,197 @@
+// Local voice-input transcription, shared with MulmoClaude via @mulmoclaude/core.
+// The reusable core (whisper-server sidecar + GGML model download + ffmpeg→WAV)
+// lives in `@mulmoclaude/core/whisper`; this file owns only the host glue:
+// capability gating (macOS + the whisper-server / ffmpeg binaries), the three
+// REST routes, and a single process-wide service pointed at the shared workspace
+// models dir. All transcription happens on this machine; no audio leaves it.
+//
+//   POST /api/transcribe                  audio dataUrl → { text }
+//   GET  /api/transcribe/model            capability + model download status
+//   POST /api/transcribe/model/download   start the model download (opt-in)
+//
+// Model selection / a settings toggle are a follow-up; this first cut always uses
+// the default model and treats "binaries present" as the opt-in (clicking the mic
+// downloads the model on demand).
+import path from "node:path";
+import { existsSync } from "node:fs";
+import type { Express, Request, Response } from "express";
+import { createWhisper, DEFAULT_WHISPER_MODEL, type WhisperLogger, type WhisperModelName } from "@mulmoclaude/core/whisper";
+
+const log: WhisperLogger = {
+  info: (message, data) => console.log(`[whisper] ${message}`, data ?? ""),
+  warn: (message, data) => console.warn(`[whisper] ${message}`, data ?? ""),
+  error: (message, data) => console.error(`[whisper] ${message}`, data ?? ""),
+};
+
+// One service instance for the process, pointed at <workspace>/models — the same
+// dir MulmoClaude uses, so a model downloaded by either app is shared.
+let whisper: ReturnType<typeof createWhisper> | null = null;
+function service(): ReturnType<typeof createWhisper> {
+  if (!whisper) throw new Error("whisper backend not mounted");
+  return whisper;
+}
+
+// 10 MB decoded audio is ~60 s of opus; the cap just bounds resource use against a
+// bypassed client. The raw data-URL cap (base64 ~+33%) is applied before decoding
+// so an oversized payload is rejected without first allocating the decoded buffer.
+const MAX_AUDIO_BYTES = 10 * 1024 * 1024;
+const MAX_DATAURL_CHARS = MAX_AUDIO_BYTES * 3;
+
+// Probe a binary once (memoized) by scanning PATH for an executable of that name —
+// no child process. Binaries don't appear mid-session, so caching is safe and keeps
+// GET /api/transcribe/model cheap.
+const binaryCache = new Map<string, boolean>();
+function hasBinary(bin: string): boolean {
+  const cached = binaryCache.get(bin);
+  if (cached !== undefined) return cached;
+  const dirs = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  const present = dirs.some((dir) => existsSync(path.join(dir, bin)));
+  binaryCache.set(bin, present);
+  return present;
+}
+
+// whisper.cpp transcription needs macOS (Metal) + the whisper-server binary AND
+// ffmpeg on PATH — every transcription shells out to ffmpeg (webm→WAV) before the
+// sidecar, so both must be in the gate or the mic shows available and each request
+// 500s.
+function isVoiceInputCapable(): boolean {
+  return process.platform === "darwin" && hasBinary("whisper-server") && hasBinary("ffmpeg");
+}
+
+// Model selection is a follow-up; always the default for now.
+function selectedModel(): WhisperModelName {
+  return DEFAULT_WHISPER_MODEL;
+}
+
+interface VoiceInputStatus {
+  capable: boolean;
+  model: { name: WhisperModelName; state: string; progress?: number; error?: string };
+}
+
+function getVoiceInputStatus(): VoiceInputStatus {
+  const name = selectedModel();
+  return { capable: isVoiceInputCapable(), model: { name, ...service().getModelStatus(name) } };
+}
+
+// The mic gates on both: capable + the model downloaded.
+function isVoiceInputReady(): boolean {
+  return isVoiceInputCapable() && service().isModelReady(selectedModel());
+}
+
+// Start downloading the selected model (fire-and-forget; idempotent). Once it lands
+// and the feature is usable, pre-warm the sidecar so the first transcription is fast.
+function startModelDownload(): void {
+  const name = selectedModel();
+  service()
+    .ensureModelDownloaded(name)
+    .then(() => warmupVoiceInput())
+    .catch(() => undefined);
+}
+
+/** Pre-spawn the sidecar when the model is already on disk, so the first
+ *  transcription of the session doesn't pay the model-load cost in-request. */
+export function warmupVoiceInput(): void {
+  if (!isVoiceInputReady()) return;
+  service()
+    .warmup(selectedModel())
+    .catch(() => undefined);
+}
+
+/** Kill the warm sidecar — call on server shutdown so no whisper-server leaks. */
+export function stopWhisperSidecar(): void {
+  whisper?.shutdown();
+}
+
+interface DataUrlParts {
+  mimeType: string;
+  base64: string;
+}
+
+/** Parse a `data:<mime>;base64,<payload>` URL. Returns null for anything else.
+ *  Hand-parsed (no regex) to sidestep catastrophic-backtracking concerns. */
+function parseDataUrl(dataUrl: string): DataUrlParts | null {
+  if (!dataUrl.startsWith("data:")) return null;
+  const comma = dataUrl.indexOf(",");
+  if (comma === -1) return null;
+  const header = dataUrl.slice("data:".length, comma);
+  if (!header.includes(";base64")) return null;
+  const mimeType = header.split(";")[0] || "application/octet-stream";
+  return { mimeType, base64: dataUrl.slice(comma + 1) };
+}
+
+/** Whisper language code or "auto". Keep short codes; anything else falls back to
+ *  auto-detection from the audio. */
+function normalizeLanguage(language: unknown): string {
+  if (typeof language === "string" && language.length > 0 && language.length <= 5) return language;
+  return "auto";
+}
+
+function approxBytes(base64: string): number {
+  return Math.floor((base64.length * 3) / 4);
+}
+
+interface TranscribeBody {
+  dataUrl?: string;
+  language?: string;
+}
+
+async function handleTranscribe(req: Request<object, unknown, TranscribeBody>, res: Response): Promise<void> {
+  if (!isVoiceInputReady()) {
+    res.status(503).json({ error: "voice input is not available (unsupported platform or model not ready)" });
+    return;
+  }
+  const { dataUrl, language } = req.body ?? {};
+  if (typeof dataUrl !== "string" || !dataUrl) {
+    res.status(400).json({ error: "dataUrl is required" });
+    return;
+  }
+  // Bound the raw payload BEFORE decoding so a giant data URL can't be expanded
+  // into memory ahead of the post-decode cap.
+  if (dataUrl.length > MAX_DATAURL_CHARS) {
+    res.status(413).json({ error: "audio clip exceeds the size limit" });
+    return;
+  }
+  const parsed = parseDataUrl(dataUrl);
+  if (!parsed) {
+    res.status(400).json({ error: "dataUrl must be a base64 data: URI" });
+    return;
+  }
+  if (approxBytes(parsed.base64) > MAX_AUDIO_BYTES) {
+    res.status(413).json({ error: "audio clip exceeds the size limit" });
+    return;
+  }
+  try {
+    const { text } = await service().transcribe({
+      base64: parsed.base64,
+      mimeType: parsed.mimeType,
+      language: normalizeLanguage(language),
+      model: selectedModel(),
+    });
+    res.json({ text });
+  } catch (err) {
+    log.error("transcribe failed", { error: err instanceof Error ? err.message : String(err) });
+    res.status(500).json({ error: "transcription failed" });
+  }
+}
+
+/** Mount the voice-input routes and pre-warm if the model is already present. */
+export function mountWhisperRoutes(app: Express, deps: { workspace: string }): void {
+  whisper = createWhisper({ modelsDir: path.join(deps.workspace, "models"), logger: log });
+
+  app.post("/api/transcribe", handleTranscribe);
+
+  app.get("/api/transcribe/model", (_req: Request, res: Response) => {
+    res.json(getVoiceInputStatus());
+  });
+
+  app.post("/api/transcribe/model/download", (_req: Request, res: Response) => {
+    if (!isVoiceInputCapable()) {
+      res.status(503).json({ error: "voice input is not supported on this machine" });
+      return;
+    }
+    startModelDownload();
+    res.json(getVoiceInputStatus());
+  });
+
+  warmupVoiceInput();
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -30,6 +30,7 @@ import { feedRefreshTaskDef, type AgentWorkerRunner } from "@mulmoclaude/core/fe
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { initFileChangePublisher } from "./backends/fileChange.js";
 import { initNotifier, mountNotificationRoutes } from "./backends/notifier.js";
+import { mountWhisperRoutes, stopWhisperSidecar } from "./backends/whisper.js";
 import { startCollectionCompletionWatchers } from "./backends/collectionWatchers.js";
 import { initUserTaskScheduler, mountSchedulerRoutes } from "./backends/scheduler.js";
 import { mountFilesRoutes } from "./backends/files.js";
@@ -666,6 +667,11 @@ mountHtmlPreviewRoute(app, { workspace: CLAUDE_CWD });
 // Shared launcher favorites (GET/PUT /api/shortcuts) over the same
 // <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.
 mountShortcutsRoutes(app, { workspace: CLAUDE_CWD });
+
+// Local voice input (POST /api/transcribe + model status/download) — macOS only,
+// whisper.cpp via @mulmoclaude/core/whisper. Models live in the shared
+// <workspace>/models dir, so a download by either app is reused.
+mountWhisperRoutes(app, { workspace: CLAUDE_CWD });
 
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in
@@ -1412,3 +1418,14 @@ server.on("error", (err) => {
 server.listen(PORT, () => {
   console.log(`mulmoterminal running at http://localhost:${PORT}`);
 });
+
+// The whisper sidecar is a spawned child that won't die with the parent on a
+// signal. Adding a signal listener suppresses Node's default termination, so we
+// kill the sidecar and exit explicitly. `exit` covers the normal-return path.
+process.once("exit", stopWhisperSidecar);
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    stopWhisperSidecar();
+    process.exit(0);
+  });
+}

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -48,7 +48,9 @@ const { themeId } = useTheme();
 // and inserts it at the prompt for the user to review and submit — same channel as
 // a typed path. `insertText` is hoisted (function declaration), so referencing it
 // here before its definition is fine; it only runs at transcript time.
-const voice = useVoiceInput({ onTranscript: (text) => insertText(text) });
+// Append a trailing space so consecutive VAD segments stay separated ("hello
+// world", not "helloworld") when dictating multiple phrases into the prompt.
+const voice = useVoiceInput({ onTranscript: (text) => insertText(`${text} `) });
 function voiceTitle(): string {
   if (voice.listening.value) return "Stop voice input";
   if (voice.downloading.value) return "Downloading speech model…";

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -7,6 +7,7 @@ import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl, buildRunWsUrl } from "./wsUrl";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
 import { useTheme, currentTermTheme } from "../composables/useTheme";
+import { useVoiceInput } from "../composables/useVoiceInput";
 import RunMenu from "./RunMenu.vue";
 
 // `null` => start a fresh session; otherwise resume the given session id.
@@ -42,6 +43,23 @@ const status = ref<"connecting" | "connected" | "disconnected">("connecting");
 const serverCwd = ref<string | null>(props.cwd ?? null);
 const dragOver = ref(false);
 const { themeId } = useTheme();
+
+// Voice input: a mic in the header transcribes speech (locally, via whisper.cpp)
+// and inserts it at the prompt for the user to review and submit — same channel as
+// a typed path. `insertText` is hoisted (function declaration), so referencing it
+// here before its definition is fine; it only runs at transcript time.
+const voice = useVoiceInput({ onTranscript: (text) => insertText(text) });
+function voiceTitle(): string {
+  if (voice.listening.value) return "Stop voice input";
+  if (voice.downloading.value) return "Downloading speech model…";
+  if (!voice.available.value) return "Enable voice input (downloads the speech model)";
+  return "Start voice input";
+}
+function voiceIcon(): string {
+  if (voice.listening.value) return "stop";
+  if (voice.downloading.value || voice.transcribing.value) return "progress_activity";
+  return "mic";
+}
 
 let term: Terminal;
 let fitAddon: FitAddon;
@@ -169,6 +187,9 @@ function connect() {
 }
 
 onMounted(() => {
+  // Probe voice-input capability so the mic button shows only where supported.
+  voice.refreshAvailability().catch(() => {});
+
   term = new Terminal({
     cursorBlink: true,
     fontSize: 14,
@@ -317,9 +338,21 @@ onUnmounted(() => {
       <span class="title">Terminal</span>
       <span :class="['status', status]">{{ status }}</span>
       <RunMenu v-if="runMenu" :cwd="serverCwd" @run="(c) => emit('run', c)" />
-      <button type="button" class="pick-file" title="Insert a file path" aria-label="Insert a file path" @click="pickFile">
-        <span class="material-symbols-outlined">attach_file</span>
-      </button>
+      <div class="header-actions">
+        <button
+          v-if="voice.capable.value"
+          type="button"
+          :class="['icon-btn', 'voice', { listening: voice.listening.value, busy: voice.downloading.value || voice.transcribing.value }]"
+          :title="voiceTitle()"
+          :aria-label="voiceTitle()"
+          @click="voice.toggle()"
+        >
+          <span class="material-symbols-outlined">{{ voiceIcon() }}</span>
+        </button>
+        <button type="button" class="icon-btn" title="Insert a file path" aria-label="Insert a file path" @click="pickFile">
+          <span class="material-symbols-outlined">attach_file</span>
+        </button>
+      </div>
     </div>
     <div ref="terminalRef" :class="['terminal-container', { 'drag-over': dragOver }]" @dragover="onDragOver" @dragleave="dragOver = false" @drop="onDrop" />
   </div>
@@ -351,8 +384,14 @@ onUnmounted(() => {
   font-weight: 600;
 }
 
-.pick-file {
+.header-actions {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.icon-btn {
   display: inline-flex;
   align-items: center;
   padding: 2px;
@@ -363,13 +402,40 @@ onUnmounted(() => {
   cursor: pointer;
 }
 
-.pick-file:hover {
+.icon-btn:hover {
   background: var(--bg-selected);
   color: var(--text);
 }
 
-.pick-file .material-symbols-outlined {
+.icon-btn .material-symbols-outlined {
   font-size: 18px;
+}
+
+/* Recording: solid red, gently pulsing. Busy (download/transcribe): the spinner
+   icon rotates. */
+.icon-btn.voice.listening {
+  color: #e5484d;
+  animation: voice-pulse 1.2s ease-in-out infinite;
+}
+
+.icon-btn.voice.busy .material-symbols-outlined {
+  animation: voice-spin 1s linear infinite;
+}
+
+@keyframes voice-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+@keyframes voice-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .status {

--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -75,11 +75,14 @@ export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
     // Also keeps `capable`/`downloading` in sync — this is the controller's poll
     // loop, so it doubles as our status refresh.
     async getStatus() {
+      // `status` is null on a transient fetch/non-OK; `model` may be absent on a
+      // partial response. Optional-chain throughout so a status blip degrades to
+      // "not ready" instead of throwing and wedging the controller's poll loop.
       const status = await fetchModelStatus();
       capable.value = status?.capable ?? false;
-      downloading.value = status?.model.state === "downloading";
+      downloading.value = status?.model?.state === "downloading";
       return {
-        ready: status?.capable === true && status.model.state === "ready",
+        ready: status?.capable === true && status?.model?.state === "ready",
         downloading: downloading.value,
       };
     },

--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -1,0 +1,144 @@
+// Thin Vue wrapper over the framework-neutral capture controller in
+// `@mulmoclaude/core/whisper/client` (shared with MulmoClaude). This file supplies
+// MulmoTerminal's transport (plain fetch — there is no shared api client) and
+// locale mapping, and mirrors the controller's pushed state into Vue refs. The
+// capture logic (MediaRecorder + VAD + segment queue) lives in the package.
+//
+// Capability vs availability:
+//   capable   — macOS + whisper-server/ffmpeg present (controls button visibility)
+//   available — capable AND the model is downloaded (controls recording)
+// Clicking the mic while capable-but-not-available downloads the model on demand.
+
+import { onScopeDispose, ref, type Ref } from "vue";
+import { createVoiceCapture, localeToWhisperLanguage, type VoiceCaptureTransport } from "@mulmoclaude/core/whisper/client";
+
+interface VoiceModelStatusResponse {
+  capable: boolean;
+  model: { name: string; state: "idle" | "downloading" | "ready" | "error"; progress?: number; error?: string };
+}
+
+export interface UseVoiceInput {
+  /** Platform + binaries present — gate the mic button's visibility on this. */
+  capable: Ref<boolean>;
+  /** Capable AND model ready — recording can start. */
+  available: Ref<boolean>;
+  /** The model is being fetched (after the first mic click). */
+  downloading: Ref<boolean>;
+  listening: Ref<boolean>;
+  transcribing: Ref<boolean>;
+  error: Ref<string | null>;
+  refreshAvailability: () => Promise<void>;
+  /** One-button UX: download → start → stop depending on current state. */
+  toggle: () => Promise<void>;
+  stop: () => void;
+}
+
+export interface UseVoiceInputOptions {
+  /** Called with each segment's transcript once recognized (never empty). */
+  onTranscript: (text: string) => void;
+}
+
+// Browser UI language is a strong prior for the spoken language. No vue-i18n here,
+// so derive it from the browser like the collection composables do.
+function browserLocale(): string {
+  return (navigator.language || "en").split("-")[0];
+}
+
+async function fetchModelStatus(): Promise<VoiceModelStatusResponse | null> {
+  try {
+    const res = await fetch("/api/transcribe/model");
+    if (!res.ok) return null;
+    return (await res.json()) as VoiceModelStatusResponse;
+  } catch {
+    return null;
+  }
+}
+
+export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
+  const capable = ref(false);
+  const available = ref(false);
+  const downloading = ref(false);
+  const listening = ref(false);
+  const transcribing = ref(false);
+  const error = ref<string | null>(null);
+
+  const transport: VoiceCaptureTransport = {
+    async transcribe(dataUrl, language) {
+      const res = await fetch("/api/transcribe", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ dataUrl, language }),
+      });
+      if (!res.ok) throw new Error(`transcription failed (HTTP ${res.status})`);
+      return (await res.json()) as { text: string };
+    },
+    // Also keeps `capable`/`downloading` in sync — this is the controller's poll
+    // loop, so it doubles as our status refresh.
+    async getStatus() {
+      const status = await fetchModelStatus();
+      capable.value = status?.capable ?? false;
+      downloading.value = status?.model.state === "downloading";
+      return {
+        ready: status?.capable === true && status.model.state === "ready",
+        downloading: downloading.value,
+      };
+    },
+  };
+
+  const capture = createVoiceCapture(transport, () => localeToWhisperLanguage(browserLocale()), {
+    onTranscript: (text) => {
+      error.value = null;
+      opts.onTranscript(text);
+    },
+    onError: (message) => {
+      error.value = message;
+    },
+    onState: (state) => {
+      available.value = state.available;
+      listening.value = state.listening;
+      transcribing.value = state.transcribing;
+    },
+  });
+
+  // Start the (one-time) model download, then let the controller's poll flip
+  // `available` to true once it lands.
+  async function requestDownload(): Promise<void> {
+    downloading.value = true;
+    try {
+      const res = await fetch("/api/transcribe/model/download", { method: "POST" });
+      if (!res.ok) throw new Error(`download failed (HTTP ${res.status})`);
+    } catch (err) {
+      downloading.value = false;
+      error.value = err instanceof Error ? err.message : String(err);
+      return;
+    }
+    await capture.refreshAvailability();
+  }
+
+  async function toggle(): Promise<void> {
+    if (listening.value) {
+      capture.stop();
+      return;
+    }
+    if (available.value) {
+      error.value = null;
+      await capture.start();
+      return;
+    }
+    if (!downloading.value) await requestDownload();
+  }
+
+  onScopeDispose(() => capture.dispose());
+
+  return {
+    capable,
+    available,
+    downloading,
+    listening,
+    transcribing,
+    error,
+    refreshAvailability: capture.refreshAvailability,
+    toggle,
+    stop: capture.stop,
+  };
+}


### PR DESCRIPTION
## What

Adds a **microphone button** next to the existing attach-file button in the terminal header. It records speech, transcribes it **locally via whisper.cpp**, and inserts the text at the prompt for the user to review and submit — the same input channel a dropped file path uses (`insertText`). No audio leaves the machine; no transcription API or key.

## How it's built

The heavy lifting already lives in `@mulmoclaude/core/whisper` (server engine: sidecar + GGML model download + ffmpeg→WAV) and `@mulmoclaude/core/whisper/client` (framework-neutral MediaRecorder + VAD capture), which MulmoTerminal already depends on. So only thin host glue is new — **no core changes, no republish**.

| File | Role |
|---|---|
| `server/backends/whisper.ts` *(new)* | Capability gate (macOS + `whisper-server`/`ffmpeg` on `PATH`) + the 3 REST routes: `POST /api/transcribe`, `GET /api/transcribe/model`, `POST /api/transcribe/model/download`. Models live in the shared `<workspace>/models` dir — a download by either app is reused. |
| `src/composables/useVoiceInput.ts` *(new)* | Vue wrapper over the capture controller; plain-`fetch` transport, browser-derived locale, one-button **download → start → stop** toggle. |
| `src/components/Terminal.vue` | Mic button (shown only when `capable`) wired to the already-exposed `insertText`. State-reflecting icon: mic / pulsing-red while listening / spinning while downloading or transcribing. |
| `server/index.ts` | Mount the routes; kill the warm sidecar on `SIGINT`/`SIGTERM`/`exit`. |

## Behavior

macOS + `brew install whisper-cpp ffmpeg` → the mic appears. First click downloads the default model (`large-v3-turbo`, progress shown), then click to talk; VAD auto-segments and inserts each segment at the prompt for review (never auto-sent). On Windows/Linux or without the binaries, `capable:false` hides the mic — clean degradation for this cross-platform app.

## Scoped-out follow-ups

- A **Settings UI** for the enable toggle + model picker (`small`/`base`). This first cut treats "binaries present + click to download" as the opt-in and always uses the default model, so no `AppConfig` changes were needed.
- A `submitText`-based **hands-free** mode (auto-send) — currently insert-and-review only.

## Verification

`yarn format`, `yarn typecheck` (client + server), `yarn lint` (0 errors on new files), `yarn build`, `yarn test` (407 passing). Manually confirmed end-to-end recording + insertion on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)