### PR TITLE
chore: change default port from 3456 to 34567

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Requires the [`claude`](https://claude.com/claude-code) CLI on your `PATH` and
 **Node ≥ 22.9**.
 
 ```bash
-npx mulmoterminal           # start on http://localhost:3456 and open the browser
+npx mulmoterminal           # start on http://localhost:34567 and open the browser
 # or install globally:
 npm install -g mulmoterminal
 mulmoterminal
@@ -36,7 +36,7 @@ prints a one-line notice when a newer version is available (`npm i -g mulmotermi
 to update). Disable with `MULMOTERMINAL_NO_UPDATE_CHECK=1` (or `NO_UPDATE_NOTIFIER=1`).
 
 Options: `--cwd <dir>` (working directory — relative paths allowed; defaults to the
-directory you run the command from), `--port <n>` (default 3456), `--no-open`,
+directory you run the command from), `--port <n>` (default 34567), `--no-open`,
 `--version`, `--help`.
 
 ```bash
@@ -139,7 +139,7 @@ the server runs without one.
 
 | Variable     | Default        | Description |
 | ------------ | -------------- | ----------- |
-| `PORT`       | `3456`         | HTTP/WebSocket port. |
+| `PORT`       | `34567`        | HTTP/WebSocket port. |
 | `CLAUDE_BIN` | `claude`       | The Claude Code binary to spawn. |
 | `CLAUDE_CWD` | current dir    | Working directory each `claude` PTY runs in; determines which project's sessions the sidebar lists. Via `npx mulmoterminal` it defaults to the directory you ran the command from (override with `--cwd <dir>`, relative allowed); when the server is run directly it falls back to `~/mulmoclaude`. A value read from `.env` must be an absolute path (`~` is not expanded). |
 
@@ -173,14 +173,14 @@ your own local file referenced by absolute path — nothing is added to the pack
 ```bash
 yarn install            # postinstall fixes node-pty prebuilt binary perms
 
-yarn dev                # server (:3456) + Vite dev server, concurrently
+yarn dev                # server (:34567) + Vite dev server, concurrently
 # or individually:
 yarn dev:server         # backend only  (node --import tsx --env-file-if-exists=.env server/index.ts)
 yarn dev:client         # Vite dev server only
 
 yarn build              # type-check (vue-tsc) + vite build -> dist/
 yarn typecheck:server   # type-check the server (tsconfig.server.json)
-yarn server             # run backend; serves dist/ + the APIs on :3456
+yarn server             # run backend; serves dist/ + the APIs on :34567
 yarn test               # vitest run
 ```
 
@@ -189,8 +189,8 @@ type-checked separately through `tsconfig.server.json` (`strict`), kept out of
 the main `build` so the two type-check independently.
 
 In dev, open the Vite URL; its proxy forwards `/ws`, `/ws/pubsub`, and `/api` to
-`:3456`. In production, run `yarn build` then `yarn server` and open
-`http://localhost:3456`.
+`:34567`. In production, run `yarn build` then `yarn server` and open
+`http://localhost:34567`.
 
 ---
 
@@ -245,7 +245,7 @@ command, so the file is the allowlist of what can run.
 
 ## Server API specification
 
-Base URL: `http://localhost:$PORT` (default `http://localhost:3456`).
+Base URL: `http://localhost:$PORT` (default `http://localhost:34567`).
 
 ### HTTP: `GET /api/sessions`
 

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -17,7 +17,7 @@ import { fetchLatestVersion, isNewerVersion } from "./update-check.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = join(__dirname, "..");
 const SERVER_ENTRY = join(PKG_DIR, "server", "index.ts");
-const DEFAULT_PORT = 3456;
+const DEFAULT_PORT = 34567;
 const READY_TIMEOUT_MS = 15_000;
 const MAX_BIND_RETRIES = 5;
 // Server exit code meaning "port taken at bind time" — keep in sync with

--- a/server/index.ts
+++ b/server/index.ts
@@ -109,7 +109,7 @@ const messageOf = (e: unknown): string => (e instanceof Error ? e.message : Stri
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const PORT = process.env.PORT || 3456;
+const PORT = process.env.PORT || 34567;
 const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude";
 // Permission mode for backend-spawned Claude sessions. Defaults to "auto" so
 // the backend runs hands-off; override with CLAUDE_PERMISSION_MODE (e.g.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,21 +39,21 @@ export default defineConfig({
     proxy: {
       // socket.io pub/sub (sidebar activity). Must precede the "/ws" rule.
       "/ws/pubsub": {
-        target: "ws://localhost:3456",
+        target: "ws://localhost:34567",
         ws: true,
       },
       "/ws": {
-        target: "ws://localhost:3456",
+        target: "ws://localhost:34567",
         ws: true,
       },
       "/api": {
-        target: "http://localhost:3456",
+        target: "http://localhost:34567",
         changeOrigin: true,
       },
       // presentHtml page serving (the View's iframe src). Without this, the dev
       // Vite catch-all returns index.html instead of the HTML artifact.
       "/artifacts": {
-        target: "http://localhost:3456",
+        target: "http://localhost:34567",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

Changes the default startup port from `3456` to **`34567`**. `3456` sits in a crowded dev-port band and was colliding with other local servers. The new value extends the existing `3-4-5-6` pattern (easy to remember), avoids the common dev-port range, and stays below the OS ephemeral range (49152+) so it won't clash with random OS allocations.

The existing busy-port fallback is **unchanged**: if the default is taken, the launcher's `choosePort` → `findEphemeralPort` still picks a free port automatically (`Port 34567 busy → using <n> instead`). Pinning with `--port <n>` / `PORT=<n>` still works.

## Items to Confirm / Review

- **Port number choice (`34567`)** — picked for memorability + low collision likelihood. Change if you'd prefer a different value.
- Fallback behavior relies on the launcher (`bin/mulmoterminal.js`); the server-direct path (`PORT` env) still exits with code 75 on `EADDRINUSE` as before.
- `wsUrl.spec.ts` keeps `localhost:3456` literals on purpose — they test URL building and are independent of the default port. `plans/fix-port-in-use.md` left as a historical record.

## Changed files

| File | Change |
| --- | --- |
| `bin/mulmoterminal.js` | launcher `DEFAULT_PORT` |
| `server/index.ts` | server `PORT` default |
| `vite.config.ts` | 4 dev proxy targets |
| `README.md` | docs |

## Verification

- `yarn lint` ✅ (0 errors; 2 pre-existing unrelated warnings)
- `yarn build` (includes `vue-tsc` typecheck) ✅
- `yarn test` ✅ 407 passed
- Runtime: server binds `34567`, `GET / → 200` confirmed

## User Prompt

> pull して最新にする。そして、起動時の port を変えて。今は他とかぶるからできるかぎりかぶらなそうなのにして、それでもかぶったら今と同様に空いているポートで。
> （= 最新を pull し、起動ポートを衝突しにくい値に変更。それでも衝突する場合は現状と同様に空きポートを使う。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)