### PR TITLE
fix: グリッドの「new ターミナル」起動セルをキャンセル(✕)で閉じられるように

### DIFF
--- a/plans/fix-cancel-new-terminal.md
+++ b/plans/fix-cancel-new-terminal.md
@@ -1,0 +1,47 @@
+# fix: マルチビューの「new ターミナル」起動セルを閉じられるようにする
+
+作成日: 2026-06-29
+
+## User Prompt
+
+- マルチビューのターミナルで、new ターミナルを起動しようとしてやめたいとき閉じれない。
+
+## 現状（バグ）
+
+- ツールバーの「＋ Terminal」を押すと、空の起動フォーム（`TerminalCell.vue` の `cell-launch`）を持つセルが追加される。
+- この空セルには閉じる（✕）ボタンが無い。閉じる（✕）は `launched === true`（起動済み）のヘッダー内にしか描画されない。
+- 唯一のキャンセル手段はツールバーの「＋ Terminal」を再度押すこと（`launchOpen` 時に `addCell()` が末尾の空セルを削除する仕様）だが、ボタンの見た目では分からず気付けない → 「やめたいのに閉じられない」。
+
+## ゴール
+
+空の「new ターミナル」起動セルに、その場で破棄できるキャンセル（✕）ボタンを追加する。
+ただしグリッドが空のときの唯一の「エントリーセル」は閉じる対象にしない（ツールバーの挙動と一致）。
+
+## 設計
+
+### `gridTabs.ts`
+- `cancelableLaunchUid(state): number | null` を追加。末尾セルが launch cell かつエントリーセル以外（`cells.length > 1`）のときその uid を返す純関数。エントリーセルは常に `null`。
+
+### `GridView.vue`
+- `cancelUid = computed(() => cancelableLaunchUid(state))` を導入し、重複していた `launchOpen` のインラインロジックを `launchOpen = cancelUid !== null` に整理。
+- `:cancel-uid="cancelUid"` を `TerminalGrid` に渡す。
+
+### `TerminalGrid.vue`
+- `cancelUid: number | null` prop を受け取り、各 `TerminalCell` に `:cancellable="cell.uid === cancelUid"` を渡す。
+
+### `TerminalCell.vue`
+- `cancellable?: boolean` prop を追加（任意・既定 false）。
+- `cell-launch` の先頭に、`v-if="cancellable"` の ✕ ボタンを追加。クリックで `close` を emit（親の `closeCell` がセルを削除）。
+- セル右上にアンカーする `.cell-launch-cancel` スタイル（`.cell` が `position: relative` のため、フォームのスクロールに追従せず固定）。
+
+## 注意点
+
+- 空の起動セルにはまだセッション/worktree が無いため、`close()` の重い後始末は不要。✕ は単に親へ `close` を emit するだけにする。
+- 末尾の launch cell は常に1つだけ（`addCell` は末尾が launch cell なら追加しない）なので、cancellable なセルは高々1つ。
+- エントリーセル（`cells.length <= 1`）は ✕ を出さない＝ツールバーの「sole entry cell は cancel 不可」と一貫。
+
+## 確認ポイント
+
+- 「＋ Terminal」で追加した空セルに ✕ が出て、押すとセルが消えるか。
+- グリッドが空（エントリーセルのみ）のときは ✕ が出ないか。
+- 起動済みターミナル / コマンドセルでは従来どおりヘッダーの ✕ のみで、起動フォームの ✕ は出ないこと。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -12,6 +12,7 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  cancelableLaunchUid,
   pageCount,
   zoomedUid,
   visibleCells,
@@ -52,12 +53,10 @@ const pages = computed(() => pageCount(state.value.cells.length));
 // this a single source swap (see visibleCells/zoomedUid).
 const displayCells = computed(() => visibleCells(state.value));
 const expandedUid = computed(() => zoomedUid(state.value));
-// A launch cell is open beyond the sole entry cell (so "+ Terminal" cancels it). A
-// trailing command cell is occupied, not an open launcher.
-const launchOpen = computed(() => {
-  const last = state.value.cells[state.value.cells.length - 1];
-  return !!last && last.session === null && last.command == null && state.value.cells.length > 1;
-});
+// The cancelable trailing launch cell's uid (null when there's nothing to cancel):
+// drives both the toolbar's cancel state and the launcher's in-cell ✕.
+const cancelUid = computed(() => cancelableLaunchUid(state.value));
+const launchOpen = computed(() => cancelUid.value !== null);
 
 function onAddTerminal() {
   if (runningCount(state.value.cells) >= 81 && !launchOpen.value) return; // surfaced by the disabled button
@@ -138,6 +137,7 @@ function closeSettings() {
       class="main"
       :cells="displayCells"
       :expanded-uid="expandedUid"
+      :cancel-uid="cancelUid"
       :default-cwd="defaultCwd"
       :presets="presets"
       :home="home"

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -58,7 +58,13 @@ beforeEach(() => {
 
 function mountCell(
   initialSessionId: string | null,
-  opts: { initialCwd?: string | null; defaultCwd?: string | null; presets?: { label: string; path: string }[]; home?: string | null } = {},
+  opts: {
+    initialCwd?: string | null;
+    defaultCwd?: string | null;
+    presets?: { label: string; path: string }[];
+    home?: string | null;
+    cancellable?: boolean;
+  } = {},
 ) {
   return mount(TerminalCell, {
     props: {
@@ -68,6 +74,7 @@ function mountCell(
       defaultCwd: opts.defaultCwd ?? "/home/me/my-project",
       presets: opts.presets ?? [],
       home: opts.home ?? "/home/me",
+      cancellable: opts.cancellable ?? false,
     },
   });
 }
@@ -118,6 +125,17 @@ describe("TerminalCell", () => {
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/home/me/picked");
+  });
+
+  it("shows a cancel ✕ on a cancellable launcher that emits close, but not otherwise", async () => {
+    const plain = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    expect(plain.find(".cell-launch-cancel").exists()).toBe(false);
+
+    const w = mountCell(null, { defaultCwd: "/home/me/default", cancellable: true });
+    await flushPromises();
+    await w.find(".cell-launch-cancel").trigger("click");
+    expect(w.emitted("close")).toHaveLength(1);
   });
 
   it("lists existing sessions for the dir and resumes one on click", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -19,6 +19,8 @@ const props = defineProps<{
   defaultCwd: string | null;
   presets: CwdPreset[];
   home: string | null;
+  // An added (not the sole entry) launcher: show a ✕ to dismiss it before launching.
+  cancellable?: boolean;
 }>();
 const emit = defineEmits<{
   (e: "toggle-expand" | "close"): void;
@@ -761,6 +763,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
       </div>
     </template>
     <div v-else class="cell-launch">
+      <button v-if="cancellable" type="button" class="cell-launch-cancel" title="Cancel new terminal" aria-label="Cancel new terminal" @click="emit('close')">
+        ✕
+      </button>
       <div v-if="presets.length" class="cell-presets">
         <button v-for="p in presets" :key="p.label + p.path" :class="['cell-preset', { active: dirInput === p.path }]" :title="p.path" @click="selectPreset(p)">
           {{ p.label }}
@@ -1023,6 +1028,29 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   gap: 8px;
   padding: 16px;
   overflow-y: auto;
+}
+/* Dismiss an added launcher (anchored to the cell, so it stays put while the form
+   scrolls). */
+.cell-launch-cancel {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 26px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  border-radius: 6px;
+}
+.cell-launch-cancel:hover {
+  background: var(--err-hover-bg);
+  color: var(--err-text);
 }
 .cell-presets {
   display: flex;

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -8,7 +8,7 @@ import type { Cell } from "./gridTabs";
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
-    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home"],
+    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home", "cancellable"],
     emits: ["toggle-expand", "session", "cwd", "run", "close"],
     template: '<div class="stub-cell" />',
   },
@@ -24,8 +24,8 @@ vi.mock("./CommandCell.vue", () => ({
 
 const cell = (uid: number, session: string | null = null, cwd: string | null = null): Cell => ({ uid, session, cwd });
 const cmdCell = (uid: number, command: NonNullable<Cell["command"]>): Cell => ({ uid, session: null, cwd: null, command });
-const mountGrid = (cells: Cell[], expandedUid: number | null = null) =>
-  mount(TerminalGrid, { props: { cells, expandedUid, defaultCwd: "/work", presets: [], home: "/work" } });
+const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null) =>
+  mount(TerminalGrid, { props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], home: "/work" } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });
 
@@ -51,6 +51,12 @@ describe("TerminalGrid (page renderer)", () => {
     expect(w.emitted("cwd")?.[0]).toEqual([7, "/x"]);
     expect(w.emitted("close")?.[0]).toEqual([7]);
     expect(w.emitted("toggle-expand")?.[0]).toEqual([7]);
+  });
+
+  it("marks only the cell matching cancelUid as cancellable", () => {
+    const cs = cellsOf(mountGrid([cell(0, "s0"), cell(1)], null, 1));
+    expect(cs[0].props("cancellable")).toBe(false);
+    expect(cs[1].props("cancellable")).toBe(true);
   });
 
   it("adds the zoomed class only when a cell is expanded", async () => {

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -14,7 +14,14 @@ import type { CwdPreset } from "./presets";
 // zoomed, GridView passes EVERY cell (all tabs), so the strip shows them all live.
 // A cell carrying a `command` renders as a CommandCell (a running script.json
 // command) instead of the Claude launcher/terminal.
-const props = defineProps<{ cells: Cell[]; expandedUid: number | null; defaultCwd: string | null; presets: CwdPreset[]; home: string | null }>();
+const props = defineProps<{
+  cells: Cell[];
+  expandedUid: number | null;
+  cancelUid: number | null;
+  defaultCwd: string | null;
+  presets: CwdPreset[];
+  home: string | null;
+}>();
 const emit = defineEmits<{
   (e: "session" | "cwd", uid: number, value: string): void;
   (e: "close" | "toggle-expand", uid: number): void;
@@ -53,6 +60,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :default-cwd="defaultCwd"
           :presets="presets"
           :home="home"
+          :cancellable="cell.uid === cancelUid"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @session="(id) => emit('session', cell.uid, id)"
           @cwd="(c) => emit('cwd', cell.uid, c)"

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -11,6 +11,7 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  cancelableLaunchUid,
   zoomedUid,
   visibleCells,
   parseGridState,
@@ -60,6 +61,20 @@ describe("addCell", () => {
     const s = addCell(make(running(81)));
     expect(runningCount(s.cells)).toBe(81);
     expect(s.cells).toHaveLength(81);
+  });
+});
+
+describe("cancelableLaunchUid", () => {
+  const CMD = { index: 0, label: "Build", cwd: "/x" };
+  it("is the trailing launch cell's uid when one is open beyond the entry cell", () => {
+    expect(cancelableLaunchUid(make([...running(2), cell(7)]))).toBe(7);
+  });
+  it("is null for the sole entry cell (nothing to cancel)", () => {
+    expect(cancelableLaunchUid(make([cell(0)]))).toBeNull();
+  });
+  it("is null when the last cell is occupied (running session or command)", () => {
+    expect(cancelableLaunchUid(make(running(2)))).toBeNull();
+    expect(cancelableLaunchUid(make([...running(1), { uid: 1, session: null, cwd: null, command: CMD }]))).toBeNull();
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -53,6 +53,14 @@ export function addCell(state: GridState): GridState {
   return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1 };
 }
 
+// The uid of the trailing launch cell that "+ Terminal" (and the launcher's own ✕)
+// cancels, or null when there's nothing to cancel. The sole entry cell is never
+// cancelable, so it's excluded.
+export function cancelableLaunchUid(state: GridState): number | null {
+  const last = state.cells[state.cells.length - 1];
+  return state.cells.length > 1 && isLaunchCell(last) ? last.uid : null;
+}
+
 export function setSession(state: GridState, uid: number, id: string | null): GridState {
   const cells = state.cells.map((c) => (c.uid === uid ? { ...c, session: id } : c));
   const expanded = id === null && state.expanded === uid ? null : state.expanded;


### PR DESCRIPTION
## Summary

グリッド表示で「＋ Terminal」を押して追加される**空の起動フォームのセル**に、その場で破棄できる**キャンセル（✕）ボタン**を追加しました。これまで ✕ は起動済みヘッダーにしか無く、間違って開いた空セルを閉じる手段が（再度「＋ Terminal」を押す以外に）無く気付きにくい状態でした。

## Items to Confirm / Review

- **対象の判定**: `gridTabs.cancelableLaunchUid()`（純関数・テスト済み）が「末尾の launch セル かつ 唯一のエントリーセルでない（`cells.length > 1`）」場合のみその uid を返す。エントリーセルは常に非キャンセル＝ツールバー挙動と一致。
- **重複ロジックの整理**: 旧 `launchOpen` のインライン判定を `cancelUid !== null` に集約（単一ソース化）。
- **後始末不要**: 空起動セルはまだ session/worktree が無いので、✕ は親へ `close` emit のみ（既存 `closeCell` が削除）。
- 配色はテーマトークン（`var(--err-hover-bg)` 等）。

## User Prompt

- マルチビューのターミナルで、new ターミナルを起動しようとしてやめたいとき閉じれない。

## Implementation

- **`gridTabs.ts`**: `cancelableLaunchUid(state)` を追加。
- **`GridView.vue`**: `cancelUid` computed を導入し `launchOpen` を整理、`:cancel-uid` を `TerminalGrid` に渡す。
- **`TerminalGrid.vue`**: `cancelUid` prop を受け、各セルへ `:cancellable="cell.uid === cancelUid"`。
- **`TerminalCell.vue`**: `cancellable` prop を追加。`cell-launch` 先頭に ✕ ボタン（クリックで `close` emit）＋セル右上アンカーの `.cell-launch-cancel` スタイル。

## Verification

- `gridTabs.spec.ts` / `TerminalGrid.spec.ts` / `TerminalCell.spec.ts` にテスト追加。
- ゲート: `format / lint / typecheck / build / test(412)` 全グリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)