### PR TITLE
chore: Vite dev ポートを変更可能に（CLIENT_PORT, 既定 6856）

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,11 @@ server, and opens the browser. For local development from a clone, see
 - **Script commands** (`yarn dev`, tests, …), launched from a cell's directory
   picker, run in their own ephemeral PTY over a separate WebSocket (`/ws/run`);
   they are not Claude sessions. See [Scripts (Run menu)](#scripts-run-menu).
-- The Vite dev server proxies `/ws` (covers `/ws/run`), `/ws/pubsub`, and `/api` to
-  the backend; in production the backend serves the built client from `dist/`.
+- In dev (`yarn dev`) the Vite dev server runs on its own port (`CLIENT_PORT`,
+  default `6856`) and proxies `/ws` (covers `/ws/run`), `/ws/pubsub`, and `/api` to
+  the backend (`PORT`, default `34567`) — so you open the Vite port (e.g.
+  `http://localhost:6856`). In production the backend serves the built client from
+  `dist/` on `PORT`, and you open that.
 
 ---
 
@@ -139,7 +142,8 @@ the server runs without one.
 
 | Variable     | Default        | Description |
 | ------------ | -------------- | ----------- |
-| `PORT`       | `34567`        | HTTP/WebSocket port. |
+| `PORT`        | `34567`        | Backend HTTP/WebSocket port (prod: the URL you open). |
+| `CLIENT_PORT` | `6856`         | Vite dev-server port (dev only: the URL you open with `yarn dev`). |
 | `CLAUDE_BIN` | `claude`       | The Claude Code binary to spawn. |
 | `CLAUDE_CWD` | current dir    | Working directory each `claude` PTY runs in; determines which project's sessions the sidebar lists. Via `npx mulmoterminal` it defaults to the directory you ran the command from (override with `--cwd <dir>`, relative allowed); when the server is run directly it falls back to `~/mulmoclaude`. A value read from `.env` must be an absolute path (`~` is not expanded). |
 
@@ -173,7 +177,7 @@ your own local file referenced by absolute path — nothing is added to the pack
 ```bash
 yarn install            # postinstall fixes node-pty prebuilt binary perms
 
-yarn dev                # server (:34567) + Vite dev server, concurrently
+yarn dev                # backend (:34567) + Vite UI (:6856), concurrently — open http://localhost:6856
 # or individually:
 yarn dev:server         # backend only  (node --import tsx --env-file-if-exists=.env server/index.ts)
 yarn dev:client         # Vite dev server only

--- a/plans/chore-vite-dev-port.md
+++ b/plans/chore-vite-dev-port.md
@@ -1,0 +1,18 @@
+# chore: configurable Vite dev-server port (CLIENT_PORT)
+
+## 背景
+#134 で backend ポートを 3456 → 34567 に変更したが、`yarn dev` で開くのは **Vite の dev ポート（既定 5173）** で、ここは変わっていなかった。フロント（Vue）はポートをハードコードせず `location.host` で相対接続するため、変えるべきは Vite の `server.port` のみ。
+
+## 変更（`vite.config.ts`）
+- `BACKEND_PORT = process.env.PORT || "34567"` を導入し、proxy ターゲット4箇所を単一ソース化（backend ポートと一致）。
+- `CLIENT_PORT = Number(process.env.CLIENT_PORT) || 6856` を導入し、`server.port` に設定。
+  - 6856 = 電話キーパッドの **M-U-L-M**（"MULMO" = 68566 は 65535 を超えるため頭4文字）。
+  - backend(34567) とは別ポート必須（dev で同時起動）。env `CLIENT_PORT` で上書き可。
+- `yarn dev` で開く URL は **http://localhost:6856**。
+
+## README
+- env 表に `CLIENT_PORT`（既定 6856）を追加。
+- 「Vite dev server proxies …」の説明と `yarn dev` の注記を更新（開く先＝Vite ポート）。
+
+## 非対象
+prod 起動（`yarn server` / `npx`）は従来どおり PORT（34567）で UI＋API 配信。

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import tailwindcss from "@tailwindcss/vite";
 
+// Dev ports. The backend (Express) listens on PORT (default 34567, see
+// server/index.ts); Vite's own dev server uses CLIENT_PORT — a SEPARATE port, since
+// both run at once under `yarn dev` and can't share one. Both are env-overridable.
+const BACKEND_PORT = process.env.PORT || "34567";
+const CLIENT_PORT = Number(process.env.CLIENT_PORT) || 6856;
+
 export default defineConfig({
   // Tailwind is used ONLY to compile the plugin-utilities sheet
   // (src/plugin-tailwind.css), which GuiPanel injects into the per-plugin Shadow
@@ -24,8 +30,9 @@ export default defineConfig({
     __INTLIFY_PROD_DEVTOOLS__: "false",
   },
   server: {
+    port: CLIENT_PORT,
     // Disable Vite's dev CORS middleware. The app is same-origin in dev (the page
-    // and the proxied `/api` both live on :5173), so it needs no CORS headers from
+    // and the proxied `/api` both live on the Vite dev port), so it needs no CORS headers from
     // Vite. The one cross-origin consumer is a custom collection view: it renders in
     // a sandboxed (opaque-origin) iframe whose fetch to
     // `/api/collections/:slug/view-data` is cross-origin and preflighted. With Vite's
@@ -39,21 +46,21 @@ export default defineConfig({
     proxy: {
       // socket.io pub/sub (sidebar activity). Must precede the "/ws" rule.
       "/ws/pubsub": {
-        target: "ws://localhost:34567",
+        target: `ws://localhost:${BACKEND_PORT}`,
         ws: true,
       },
       "/ws": {
-        target: "ws://localhost:34567",
+        target: `ws://localhost:${BACKEND_PORT}`,
         ws: true,
       },
       "/api": {
-        target: "http://localhost:34567",
+        target: `http://localhost:${BACKEND_PORT}`,
         changeOrigin: true,
       },
       // presentHtml page serving (the View's iframe src). Without this, the dev
       // Vite catch-all returns index.html instead of the HTML artifact.
       "/artifacts": {
-        target: "http://localhost:34567",
+        target: `http://localhost:${BACKEND_PORT}`,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

`yarn dev` で開く **Vite の dev ポート**を変更（＆設定可能に）します。#134 で backend を 3456→34567 にしたとき、`yarn dev` で実際に開く **Vite 側のポート（既定 5173）は変わっていなかった**ため。

- フロント（Vue）はポートを**ハードコードせず `location.host` で相対接続**（`wsUrl.ts` / `/api`）。なので変えるべきは **Vite の `server.port` だけ**で、Vue 側のコード変更は不要。
- `CLIENT_PORT`（既定 **6856**）を `server.port` に設定。**6856 = 電話キーパッドの M-U-L-M**（"MULMO" = 68566 はポート上限 65535 超のため頭4文字）。
- ついでに proxy ターゲット4箇所を **`PORT`（既定 34567）から単一ソース化**（backend と一致、env で可変）。
- 両方 env で上書き可（`PORT` / `CLIENT_PORT`）。

`yarn dev` で開く URL: **http://localhost:6856**。

## Items to Confirm / Review
- **dev/prod の住み分け**: dev は Vite(:6856)→proxy→backend(:34567)。prod（`yarn server` / `npx`）は従来どおり backend が UI＋API を :34567 で配信（変更なし）。
- **6856 の由来**: 「まるも〜な数字で」というリクエストに対し、keypad の MULMO=68566 が 65535 を超えるため MULM=6856 を採用。気に入らなければ `CLIENT_PORT` で即上書き可。
- backend と別ポート必須（dev で同時起動）。

## User Prompt
> 5173です。vue のポートもかえるように修正して。（ポート番号は「まるも〜な感じの数字で」）

## Implementation
- `vite.config.ts`: `BACKEND_PORT = process.env.PORT || "34567"`（proxy 4箇所）、`CLIENT_PORT = Number(process.env.CLIENT_PORT) || 6856`（`server.port`）。
- `README.md`: env 表に `CLIENT_PORT` 追加、dev の開く先（:6856）を明記。
- `plans/chore-vite-dev-port.md`。

typecheck・build OK、lint 0 errors（changed files）。

> 補足: ローカルに別機能の未コミット作業（unify-header-toolbar）があり working tree を汚さないため、本変更は origin/main から切った一時 worktree で作成・検証しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)