### PR TITLE
feat: unify the header toolbar across single and grid views

### DIFF
--- a/plans/feat-unify-header-toolbar.md
+++ b/plans/feat-unify-header-toolbar.md
@@ -1,0 +1,57 @@
+# feat: unify the header toolbar across single and grid views
+
+## Problem
+
+The header menu differs between the single (classic) view and the grid (multi-terminal)
+view:
+
+- **single** (`src/App.vue`): icon-based launcher (Material Symbols) — Chat / Grid /
+  Collections / Accounting / pinned favorites, plus `NotificationBell`, a sound toggle
+  and Settings on the right.
+- **grid** (`src/components/GridView.vue`): a simpler text/emoji bar — `＋ Terminal`,
+  🔔 sound, `▢ Single`, ⚙ Settings. No launcher, no notification bell.
+
+The user wants the grid view to use the *standard* (single-view) header so both views
+share one identical toolbar.
+
+## Approach (full unification)
+
+Extract the standard toolbar into a shared `src/components/AppToolbar.vue` and render it
+in both views.
+
+- The toolbar reads the global singleton stores directly (`useShortcuts`,
+  `useCollectionBrowse`, `useAccountingView`, `useSoundEnabled`) and takes `viewMode`
+  as a prop.
+- Launcher buttons that target single-view surfaces (Chat / Collections / Accounting /
+  favorites) mutate the global browse/accounting state and emit `go-single`; the parent
+  switches to the single view, where the overlay is already rendered. The Grid button
+  emits `go-grid`.
+- Active-state highlighting is gated on `viewMode === 'single'` so that in the grid view
+  only the Grid button reads as active.
+- The grid-specific `＋ Terminal` action becomes an icon button (`add`) shown only when
+  `viewMode === 'grid'`; it emits `add-terminal`. Settings emits `settings`. Sound is
+  toggled inside the toolbar via the shared singleton.
+
+### Wiring
+
+- `App.vue` single shell: `<AppToolbar :view-mode="viewMode" @go-grid="viewMode='grid'"
+  @settings="showSettings = true" />`. Drops its inline `<header>` and the now-unused
+  launcher state/handlers/styles (`shortcuts`, `browseView`, `favActive`, `showChat`,
+  `showCollections`, `showFavorite`, `showAccounting`, `NotificationBell`, sound toggle).
+- `GridView.vue`: `<AppToolbar :view-mode="'grid'" :add-terminal-active="launchOpen"
+  @go-single="emit('exit')" @add-terminal="onAddTerminal" @settings="showSettings=true" />`.
+  Drops its inline `<header>`, `useSoundEnabled`, and the `.tb-btn`/`.tb-add` styles. The
+  page tab bar stays below the shared toolbar.
+
+## Files
+
+- **new** `src/components/AppToolbar.vue`
+- `src/App.vue`
+- `src/components/GridView.vue`
+
+## Verification
+
+- `yarn format`, `yarn lint`, `yarn build`, `yarn typecheck`
+- Manual: in both views the toolbar is identical; Grid highlights in grid mode; `＋`
+  appears only in grid; Chat/Collections/Accounting/favorite from grid switch to single
+  and open the right surface; sound + settings + bell work in both.

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,17 +9,14 @@ import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue"
 import AccountingOverlay from "./components/AccountingOverlay.vue";
 import GridView from "./components/GridView.vue";
 import SettingsModal from "./components/SettingsModal.vue";
-import NotificationBell from "./components/NotificationBell.vue";
+import AppToolbar from "./components/AppToolbar.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
-import { useShortcuts } from "./composables/useShortcuts";
-import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "./composables/useCollectionBrowse";
-import { useAccountingView, accountingViewOpen, accountingViewClose } from "./composables/useAccountingView";
+import { browseClose } from "./composables/useCollectionBrowse";
 import { registerChatOpener } from "./composables/useChatLauncher";
 import { useAppConfig } from "./composables/useAppConfig";
 import { usePendingScript, type PendingCommand } from "./composables/usePendingScript";
 import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
-import type { Shortcut } from "./types/shortcuts";
 import type { CwdPreset } from "./components/presets";
 
 // View mode: the classic single-terminal view (default) or the multi-terminal
@@ -34,36 +31,6 @@ const { requestRun } = usePendingScript();
 function onRunScript(command: PendingCommand) {
   requestRun(command);
   viewMode.value = "grid";
-}
-
-// Shared launcher favorites (pinned collections / feeds), backing the toolbar.
-const { shortcuts } = useShortcuts();
-// Toolbar tabs reflect the browse view-state: Chat (overlay closed) | Collections
-// (index open) | a favorite (its detail open).
-const { view: browseView, isOpen: browseOpen } = useCollectionBrowse();
-function favActive(s: Shortcut): boolean {
-  return browseView.value.mode === "detail" && browseView.value.kind === s.kind && browseView.value.slug === s.slug;
-}
-
-// The accounting overlay (toolbar account_balance) and the collection browse overlay
-// both fill the page below the toolbar, so they're mutually exclusive — each toolbar
-// action closes the other. Chat is the "neither open" state.
-const { isOpen: accountingOpen } = useAccountingView();
-function showChat(): void {
-  browseClose();
-  accountingViewClose();
-}
-function showCollections(): void {
-  accountingViewClose();
-  browseGotoIndex("collection");
-}
-function showFavorite(s: Shortcut): void {
-  accountingViewClose();
-  browseGotoDetail(s.kind, s.slug);
-}
-function showAccounting(): void {
-  browseClose();
-  accountingViewOpen();
 }
 
 const activeId = ref<string | null>(null);
@@ -81,7 +48,7 @@ const filter = ref<Filter>("all");
 // views, including terminals on background grid pages. Listens to the "sessions"
 // activity stream directly (same source as the cell status), independent of the
 // fetched list above.
-const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
+const { enabled: soundEnabled } = useSoundEnabled();
 // soundFile is a shared singleton in useAppConfig, so the player here sees changes
 // made from either view's settings modal (and loadConfig below hydrates it).
 const { soundFile } = useAppConfig();
@@ -225,57 +192,7 @@ function onSession(id: string) {
 <template>
   <GridView v-if="viewMode === 'grid'" @exit="viewMode = 'single'" />
   <div v-else class="shell">
-    <header class="toolbar">
-      <span class="toolbar-title">MulmoTerminal</span>
-      <nav class="launcher" aria-label="Views">
-        <button type="button" class="launcher-btn" :class="{ active: !browseOpen && !accountingOpen }" title="Chat" aria-label="Chat" @click="showChat">
-          <span class="material-symbols-outlined">chat</span>
-        </button>
-        <button type="button" class="launcher-btn" title="Grid (multiple terminals)" aria-label="Grid view" @click="viewMode = 'grid'">
-          <span class="material-symbols-outlined">grid_view</span>
-        </button>
-        <button
-          type="button"
-          class="launcher-btn"
-          :class="{ active: browseView.mode === 'index' }"
-          title="Collections"
-          aria-label="Collections"
-          @click="showCollections"
-        >
-          <span class="material-symbols-outlined">apps</span>
-        </button>
-        <button type="button" class="launcher-btn" :class="{ active: accountingOpen }" title="Accounting" aria-label="Accounting" @click="showAccounting">
-          <span class="material-symbols-outlined">account_balance</span>
-        </button>
-        <button
-          v-for="s in shortcuts"
-          :key="`${s.kind}:${s.slug}`"
-          type="button"
-          class="launcher-btn"
-          :class="{ active: favActive(s) }"
-          :title="s.title"
-          :aria-label="s.title"
-          @click="showFavorite(s)"
-        >
-          <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
-        </button>
-      </nav>
-      <NotificationBell class="toolbar-bell" />
-      <button
-        type="button"
-        class="launcher-btn sound-toggle"
-        :class="{ active: soundEnabled }"
-        :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
-        :aria-label="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
-        :aria-pressed="soundEnabled"
-        @click="toggleSound"
-      >
-        <span class="material-symbols-outlined">{{ soundEnabled ? "notifications_active" : "notifications_off" }}</span>
-      </button>
-      <button type="button" class="launcher-btn settings-btn" title="Settings" aria-label="Settings" @click="showSettings = true">
-        <span class="material-symbols-outlined">settings</span>
-      </button>
-    </header>
+    <AppToolbar :view-mode="viewMode" @go-grid="viewMode = 'grid'" @settings="showSettings = true" />
     <div :class="['app', layout === 'horizontal' ? 'app-horizontal' : 'app-vertical']">
       <Sidebar
         v-if="layout === 'vertical'"
@@ -353,64 +270,6 @@ function onSession(id: string) {
   height: 100vh;
   width: 100vw;
   overflow: hidden;
-}
-
-/* Top toolbar with the app title. */
-.toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  height: 40px;
-  padding: 0 16px;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--border);
-}
-.toolbar-title {
-  font-family: system-ui, sans-serif;
-  font-weight: 600;
-  font-size: 14px;
-  color: var(--text);
-  letter-spacing: 0.02em;
-}
-
-/* Toolbar tabs: Chat + Collections + one per pinned favorite. Icon-only. */
-.launcher {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  margin-left: 16px;
-  min-width: 0;
-  overflow-x: auto;
-}
-.launcher-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  height: 30px;
-  width: 30px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  border-radius: 6px;
-  cursor: pointer;
-}
-.launcher-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.launcher-btn.active {
-  background: var(--accent-bg);
-  color: var(--on-accent);
-}
-/* Push the action buttons (bell, sound, settings) to the far right as a group. */
-.toolbar-bell {
-  margin-left: auto;
-}
-.launcher-btn .material-symbols-outlined {
-  font-size: 19px;
-  line-height: 1;
 }
 
 .app {

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import NotificationBell from "./NotificationBell.vue";
+import { useShortcuts } from "../composables/useShortcuts";
+import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } from "../composables/useCollectionBrowse";
+import { useAccountingView, accountingViewOpen, accountingViewClose } from "../composables/useAccountingView";
+import { useSoundEnabled } from "../composables/useSoundEnabled";
+import type { Shortcut } from "../types/shortcuts";
+
+// The standard header, shared by the single (App.vue) and grid (GridView.vue) views so
+// both show one identical toolbar. The launcher targets single-view surfaces (the
+// collection browser / accounting overlay live in App.vue), so from the grid view those
+// buttons set the global browse/accounting state and emit `go-single` to switch back —
+// the overlay is then already open. Grid-only state (`addTerminalActive`) is passed in.
+type ViewMode = "single" | "grid";
+
+const props = defineProps<{ viewMode: ViewMode; addTerminalActive?: boolean }>();
+const emit = defineEmits<{ (e: "go-single" | "go-grid" | "add-terminal" | "settings"): void }>();
+
+const { shortcuts } = useShortcuts();
+const { view: browseView } = useCollectionBrowse();
+const { isOpen: accountingOpen } = useAccountingView();
+const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
+
+// Highlight reflects the single-view surfaces, so in the grid view only the Grid button
+// reads as active.
+const inSingle = computed(() => props.viewMode === "single");
+const chatActive = computed(() => inSingle.value && browseView.value.mode === "closed" && !accountingOpen.value);
+const collectionsActive = computed(() => inSingle.value && browseView.value.mode === "index");
+const accountingActive = computed(() => inSingle.value && accountingOpen.value);
+function favActive(s: Shortcut): boolean {
+  return inSingle.value && browseView.value.mode === "detail" && browseView.value.kind === s.kind && browseView.value.slug === s.slug;
+}
+
+function showChat(): void {
+  browseClose();
+  accountingViewClose();
+  emit("go-single");
+}
+function showCollections(): void {
+  accountingViewClose();
+  browseGotoIndex("collection");
+  emit("go-single");
+}
+function showFavorite(s: Shortcut): void {
+  accountingViewClose();
+  browseGotoDetail(s.kind, s.slug);
+  emit("go-single");
+}
+function showAccounting(): void {
+  browseClose();
+  accountingViewOpen();
+  emit("go-single");
+}
+</script>
+
+<template>
+  <header class="toolbar">
+    <span class="toolbar-title">MulmoTerminal</span>
+    <nav class="launcher" aria-label="Views">
+      <button type="button" class="launcher-btn" :class="{ active: chatActive }" title="Chat" aria-label="Chat" @click="showChat">
+        <span class="material-symbols-outlined">chat</span>
+      </button>
+      <button
+        type="button"
+        class="launcher-btn"
+        :class="{ active: viewMode === 'grid' }"
+        title="Grid (multiple terminals)"
+        aria-label="Grid view"
+        @click="emit('go-grid')"
+      >
+        <span class="material-symbols-outlined">grid_view</span>
+      </button>
+      <button type="button" class="launcher-btn" :class="{ active: collectionsActive }" title="Collections" aria-label="Collections" @click="showCollections">
+        <span class="material-symbols-outlined">apps</span>
+      </button>
+      <button type="button" class="launcher-btn" :class="{ active: accountingActive }" title="Accounting" aria-label="Accounting" @click="showAccounting">
+        <span class="material-symbols-outlined">account_balance</span>
+      </button>
+      <button
+        v-for="s in shortcuts"
+        :key="`${s.kind}:${s.slug}`"
+        type="button"
+        class="launcher-btn"
+        :class="{ active: favActive(s) }"
+        :title="s.title"
+        :aria-label="s.title"
+        @click="showFavorite(s)"
+      >
+        <span class="material-symbols-outlined">{{ s.icon || "bookmark" }}</span>
+      </button>
+      <button
+        v-if="viewMode === 'grid'"
+        type="button"
+        class="launcher-btn"
+        :class="{ active: addTerminalActive }"
+        :title="addTerminalActive ? 'Cancel adding a terminal' : 'New terminal (overflows to a new tab when full)'"
+        aria-label="New terminal"
+        @click="emit('add-terminal')"
+      >
+        <span class="material-symbols-outlined">add</span>
+      </button>
+    </nav>
+    <NotificationBell class="toolbar-bell" />
+    <button
+      type="button"
+      class="launcher-btn sound-toggle"
+      :class="{ active: soundEnabled }"
+      :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
+      :aria-label="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
+      :aria-pressed="soundEnabled"
+      @click="toggleSound"
+    >
+      <span class="material-symbols-outlined">{{ soundEnabled ? "notifications_active" : "notifications_off" }}</span>
+    </button>
+    <button type="button" class="launcher-btn settings-btn" title="Settings" aria-label="Settings" @click="emit('settings')">
+      <span class="material-symbols-outlined">settings</span>
+    </button>
+  </header>
+</template>
+
+<style scoped>
+/* Top toolbar with the app title. */
+.toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 16px;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
+}
+.toolbar-title {
+  font-family: system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+/* Toolbar tabs: Chat + Grid + Collections + Accounting + one per pinned favorite
+   (+ the grid-only New terminal button). Icon-only. */
+.launcher {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: 16px;
+  min-width: 0;
+  overflow-x: auto;
+}
+.launcher-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  height: 30px;
+  width: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.launcher-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.launcher-btn.active {
+  background: var(--accent-bg);
+  color: var(--on-accent);
+}
+/* Push the action buttons (bell, sound, settings) to the far right as a group. */
+.toolbar-bell {
+  margin-left: auto;
+}
+.launcher-btn .material-symbols-outlined {
+  font-size: 19px;
+  line-height: 1;
+}
+</style>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
+import AppToolbar from "./AppToolbar.vue";
 import {
   initialState,
   addCell,
@@ -20,16 +21,12 @@ import {
   LEGACY_KEY,
   type GridState,
 } from "./gridTabs";
-import { useSoundEnabled } from "../composables/useSoundEnabled";
 import { usePendingScript } from "../composables/usePendingScript";
 import type { CwdPreset } from "./presets";
 import { useAppConfig } from "../composables/useAppConfig";
 
 // The multi-terminal grid view. Toggled with the classic single view from App.vue.
 const emit = defineEmits<{ (e: "exit"): void }>();
-
-// Attention-sound toggle (shared singleton with the single view's toolbar).
-const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
 
 // One flat list of terminal cells; tabs are just pages (9 each) over it. Closing a
 // cell reflows the list so terminals flow across page boundaries. Only the active
@@ -107,28 +104,7 @@ function closeSettings() {
 
 <template>
   <div class="shell">
-    <header class="toolbar">
-      <span class="toolbar-title">MulmoTerminal</span>
-      <button
-        class="tb-btn tb-add"
-        :class="{ active: launchOpen }"
-        :title="launchOpen ? 'Cancel adding a terminal' : 'New terminal (overflows to a new tab when full)'"
-        @click="onAddTerminal"
-      >
-        ＋ Terminal
-      </button>
-      <button
-        class="tb-btn"
-        :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
-        :aria-label="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
-        :aria-pressed="soundEnabled"
-        @click="toggleSound"
-      >
-        {{ soundEnabled ? "🔔" : "🔕" }}
-      </button>
-      <button class="tb-btn" title="Single view" aria-label="Switch to single view" @click="emit('exit')">▢ Single</button>
-      <button class="tb-btn" title="Settings" aria-label="Settings" @click="showSettings = true">⚙</button>
-    </header>
+    <AppToolbar view-mode="grid" :add-terminal-active="launchOpen" @go-single="emit('exit')" @add-terminal="onAddTerminal" @settings="showSettings = true" />
     <nav v-if="pages > 1 && expandedUid === null" class="tabbar" aria-label="Grid tabs">
       <button v-for="p in pages" :key="p" :class="['tab', { active: p - 1 === state.page }]" :aria-pressed="p - 1 === state.page" @click="switchTo(p - 1)">
         {{ p }}
@@ -168,49 +144,6 @@ function closeSettings() {
   height: 100vh;
   width: 100vw;
   overflow: hidden;
-}
-
-.toolbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  height: 40px;
-  padding: 0 16px;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--border);
-}
-.toolbar-title {
-  font-family: system-ui, sans-serif;
-  font-weight: 600;
-  font-size: 14px;
-  color: var(--text);
-  letter-spacing: 0.02em;
-}
-
-.tb-add {
-  margin-left: auto;
-}
-.tb-add.active {
-  background: var(--bg-hover);
-  color: var(--text);
-  border-color: var(--accent);
-}
-
-.tb-btn {
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-  color: var(--text-secondary);
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  line-height: 1;
-  padding: 5px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.tb-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text);
 }
 
 .tabbar {


### PR DESCRIPTION
Extract the standard (single-view) header into a shared AppToolbar.vue and use it in both the single and grid (multi-terminal) views, so both show one identical toolbar instead of the previous icon launcher vs. text/emoji bar.

- AppToolbar reads the global singleton stores (shortcuts / browse / accounting / sound) and takes viewMode as a prop.
- Launcher buttons targeting single-view surfaces (Chat / Collections / Accounting / favorites) set the global state and emit go-single; the grid view switches back so the overlay is shown.
- Active highlighting is gated on the single view, so the grid view only highlights the Grid button.
- The grid-only "+ Terminal" action becomes an icon button shown only in the grid view.