### PR TITLE
feat: warn before resuming a session open in another grid terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,12 @@ Key rules:
 - **Reattach over respawn**: selecting a session that still has a live background
   PTY reattaches to it (replaying a ≤ 64 KB output tail) instead of spawning a
   duplicate `claude`.
+- **One live viewer per session**: a session is bound to a single socket. Opening
+  it in a second place (another tab, or another grid cell pointed at the same dir)
+  reattaches there and **supersedes** the first, which detaches. To avoid doing
+  this by accident, a grid launcher's resume list **flags rows already open in
+  another terminal** (`● open`) and **asks for confirmation** before taking one
+  over.
 - Brand-new sessions appear in the sidebar **immediately** (before their `.jsonl`
   exists) via the in-memory `knownSessions` registry + a `created` push; an
   unused one disappears when its PTY is reaped.

--- a/plans/feat-warn-duplicate-session.md
+++ b/plans/feat-warn-duplicate-session.md
@@ -1,0 +1,52 @@
+# feat: warn before resuming a session already open in another grid terminal
+
+## Problem
+
+In the grid view you can open several terminal cells. When you point a new cell
+at the same directory and pick a session from its "resume here" list, you can
+**accidentally resume a session that is already open in another cell**. The new
+attach silently supersedes the old one (server `reattachPty` sends `superseded`
+and closes the previous socket), so the cell you were working in is detached
+without any heads-up *before* it happens — only the kicked side learns about it,
+after the fact.
+
+## Goal
+
+Before opening such a session, **warn and confirm**:
+
+1. Mark resumable rows that are already open in another terminal so the risk is
+   visible *before* the click.
+2. On click, show a confirm dialog; only attach if the user accepts (which will
+   detach the other terminal, as today).
+
+Scope (confirmed with the user): the in-app grid view, multiple terminals on the
+same dir accidentally sharing a session. Cross-process (a second `mulmoterminal`
+instance on the same cwd) is out of scope here.
+
+## Approach
+
+Detection is client-side and local to the grid — the grid state already knows
+every cell's session id (across all pages; off-page cells stay live as
+background PTYs, so resuming one of them would kick it too).
+
+- **GridView.vue** — compute the in-use session ids from `state.cells` and pass
+  them down.
+- **TerminalGrid.vue** — forward the list to each `TerminalCell`.
+- **TerminalCell.vue**
+  - new optional prop `openSessionIds?: string[]`.
+  - helper `sessionOpenElsewhere(id)` = id is in `openSessionIds` and is not this
+    cell's own current session.
+  - resume list: add an `● open` marker on rows that are open elsewhere.
+  - `resume(s)`: if open elsewhere, `window.confirm(...)` (same pattern already
+    used for the dirty-worktree close) and bail on cancel.
+
+No server change: the supersede behavior stays; we only add a pre-flight warning.
+
+## Tests
+
+- `TerminalCell.spec.ts`
+  - a resumable row whose id is in `openSessionIds` shows the `● open` marker;
+    others don't.
+  - clicking an open-elsewhere row with `window.confirm` stubbed to `false` does
+    **not** launch (no session handed to the terminal); stubbed to `true` does.
+  - a normal (not-open-elsewhere) row resumes without any confirm.

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -54,6 +54,10 @@ const expandedUid = computed(() => zoomedUid(state.value));
 // drives both the toolbar's cancel state and the launcher's in-cell ✕.
 const cancelUid = computed(() => cancelableLaunchUid(state.value));
 const launchOpen = computed(() => cancelUid.value !== null);
+// Session ids currently held by cells (across all pages — off-page cells stay
+// live as background PTYs). A launcher uses this to warn before resuming a
+// session that's already open, since attaching would detach the other cell.
+const openSessionIds = computed(() => state.value.cells.map((c) => c.session).filter((s): s is string => s !== null));
 
 function onAddTerminal() {
   if (runningCount(state.value.cells) >= 81 && !launchOpen.value) return; // surfaced by the disabled button
@@ -117,6 +121,7 @@ function closeSettings() {
       :default-cwd="defaultCwd"
       :presets="presets"
       :home="home"
+      :open-session-ids="openSessionIds"
       @session="onSession"
       @cwd="onCwd"
       @close="onClose"

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -64,6 +64,7 @@ function mountCell(
     presets?: { label: string; path: string }[];
     home?: string | null;
     cancellable?: boolean;
+    openSessionIds?: string[];
   } = {},
 ) {
   return mount(TerminalCell, {
@@ -75,6 +76,7 @@ function mountCell(
       presets: opts.presets ?? [],
       home: opts.home ?? "/home/me",
       cancellable: opts.cancellable ?? false,
+      openSessionIds: opts.openSessionIds ?? [],
     },
   });
 }
@@ -150,6 +152,57 @@ describe("TerminalCell", () => {
     expect(term.exists()).toBe(true);
     expect(term.props("sessionId")).toBe("77777777-7777-7777-7777-777777777777");
     expect(term.props("cwd")).toBe("/home/me/proj");
+  });
+
+  it("flags a resumable row that's already open in another terminal", async () => {
+    const openId = "88888888-8888-8888-8888-888888888888";
+    mockFetch([
+      { id: openId, title: "running over there", mtime: Date.now() },
+      { id: "99999999-9999-9999-9999-999999999999", title: "idle elsewhere", mtime: Date.now() },
+    ]);
+    const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: [openId] });
+    await flushPromises();
+    const items = w.findAll(".cell-resume-item");
+    expect(items[0].classes()).toContain("is-open");
+    expect(items[0].find(".ri-open").exists()).toBe(true);
+    expect(items[1].classes()).not.toContain("is-open");
+    expect(items[1].find(".ri-open").exists()).toBe(false);
+  });
+
+  it("confirms before resuming a session open elsewhere, and bails on cancel", async () => {
+    const openId = "88888888-8888-8888-8888-888888888888";
+    mockFetch([{ id: openId, title: "running over there", mtime: Date.now() }]);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: [openId] });
+    await flushPromises();
+    await w.find(".cell-resume-item").trigger("click");
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
+    confirmSpy.mockRestore();
+  });
+
+  it("resumes a session open elsewhere once the confirm is accepted", async () => {
+    const openId = "88888888-8888-8888-8888-888888888888";
+    mockFetch([{ id: openId, title: "running over there", mtime: Date.now() }]);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: [openId] });
+    await flushPromises();
+    await w.find(".cell-resume-item").trigger("click");
+    expect(confirmSpy).toHaveBeenCalledOnce();
+    expect(w.findComponent({ name: "TerminalView" }).props("sessionId")).toBe(openId);
+    confirmSpy.mockRestore();
+  });
+
+  it("resumes a not-open-elsewhere session without any confirm", async () => {
+    const id = "77777777-7777-7777-7777-777777777777";
+    mockFetch([{ id, title: "fix the parser", mtime: Date.now() }]);
+    const confirmSpy = vi.spyOn(window, "confirm");
+    const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: ["other-id"] });
+    await flushPromises();
+    await w.find(".cell-resume-item").trigger("click");
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(w.findComponent({ name: "TerminalView" }).props("sessionId")).toBe(id);
+    confirmSpy.mockRestore();
   });
 
   it("lists script.json scripts for the dir and emits run with the resolved cwd", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -19,6 +19,9 @@ const props = defineProps<{
   defaultCwd: string | null;
   presets: CwdPreset[];
   home: string | null;
+  // Session ids open in other grid cells. Resuming one of them would detach that
+  // cell, so the launcher flags such rows and confirms before opening.
+  openSessionIds?: string[];
   // An added (not the sole entry) launcher: show a ✕ to dismiss it before launching.
   cancellable?: boolean;
 }>();
@@ -297,7 +300,13 @@ watch([dirInput, () => props.defaultCwd], () => {
   }, 300);
 });
 
+// A session already live in another grid cell. Resuming it here detaches that
+// cell (the server supersedes the prior socket), so we warn before doing so.
+const sessionOpenElsewhere = (id: string): boolean => id !== sessionId.value && (props.openSessionIds ?? []).includes(id);
+
 function resume(s: ResumableSession) {
+  if (sessionOpenElsewhere(s.id) && !window.confirm(`"${s.title}" is already open in another terminal. Opening it here will detach that one. Continue?`))
+    return;
   // Use the cwd those rows were fetched for, not the (possibly-changed) input.
   cwd.value = resumableCwd.value ?? (dirInput.value.trim() || props.defaultCwd);
   sessionId.value = s.id;
@@ -806,8 +815,15 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
       <div v-if="resumable.length" class="cell-resume">
         <span class="cell-launch-caption">or resume here</span>
         <div class="cell-resume-list">
-          <button v-for="s in resumable" :key="s.id" class="cell-resume-item" :title="s.title" @click="resume(s)">
+          <button
+            v-for="s in resumable"
+            :key="s.id"
+            :class="['cell-resume-item', { 'is-open': sessionOpenElsewhere(s.id) }]"
+            :title="sessionOpenElsewhere(s.id) ? `${s.title} — already open in another terminal` : s.title"
+            @click="resume(s)"
+          >
             <span class="ri-title">{{ s.title }}</span>
+            <span v-if="sessionOpenElsewhere(s.id)" class="ri-open" title="Already open in another terminal">● open</span>
             <span class="ri-time">{{ relativeTime(s.mtime) }}</span>
           </button>
         </div>
@@ -1261,6 +1277,15 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   flex: 0 0 auto;
   color: var(--text-dim);
   font-size: 11px;
+}
+.cell-resume-item.is-open {
+  border-color: var(--amber);
+}
+.ri-open {
+  flex: 0 0 auto;
+  color: var(--amber);
+  font-size: 11px;
+  white-space: nowrap;
 }
 
 /* Worktree diff badge in the header (ahead / uncommitted), opens the diff panel. */

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -8,7 +8,7 @@ import type { Cell } from "./gridTabs";
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
-    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home", "cancellable"],
+    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home", "openSessionIds", "cancellable"],
     emits: ["toggle-expand", "session", "cwd", "run", "close"],
     template: '<div class="stub-cell" />',
   },
@@ -25,7 +25,7 @@ vi.mock("./CommandCell.vue", () => ({
 const cell = (uid: number, session: string | null = null, cwd: string | null = null): Cell => ({ uid, session, cwd });
 const cmdCell = (uid: number, command: NonNullable<Cell["command"]>): Cell => ({ uid, session: null, cwd: null, command });
 const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null) =>
-  mount(TerminalGrid, { props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], home: "/work" } });
+  mount(TerminalGrid, { props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], home: "/work", openSessionIds: [] } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });
 

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   defaultCwd: string | null;
   presets: CwdPreset[];
   home: string | null;
+  openSessionIds: string[];
 }>();
 const emit = defineEmits<{
   (e: "session" | "cwd", uid: number, value: string): void;
@@ -60,6 +61,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :default-cwd="defaultCwd"
           :presets="presets"
           :home="home"
+          :open-session-ids="openSessionIds"
           :cancellable="cell.uid === cancelUid"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @session="(id) => emit('session', cell.uid, id)"


### PR DESCRIPTION
## Summary

In the grid view, opening a Claude session that is **already live in another cell** silently superseded (detached) that cell — and only the kicked side found out, after the fact. This adds a **pre-flight warning + confirmation** so it no longer happens by accident:

- A launcher's **resume list flags rows already open in another terminal** with an amber `● open` marker (and amber border).
- Clicking such a row shows a **confirm dialog** (`"…title…" is already open in another terminal. Opening it here will detach that one. Continue?`); on cancel, nothing connects.

Detection is entirely client-side — the grid state already knows every cell's session id across all pages (off-page cells stay live as background PTYs, so resuming one of them would kick it too). **No server change**: the supersede behavior is unchanged; we only added the warning in front of it.

## Items to Confirm / Review

- **UI language**: strings are English to match the existing host UI (which has no i18n; e.g. `[detached — this session is open in another window]`). OK?
- **Confirm mechanism**: `window.confirm` — same pattern already used in `TerminalCell.vue` for the dirty-worktree close. Acceptable, or do you want an inline in-cell confirm UI instead?
- **Scope of detection**: all cells across all grid pages (not just the visible page), since background PTYs on other pages are live and would also be detached.
- **Marker styling**: amber `● open` badge + amber border on the row — reusing the `--amber` attention color.

## User Prompt

> 同じ dir でターミナルを起動して同じセッションを使うことがあるよね。その場合はアラートが欲しいよね。
>
> （スコープの確認）mulmoterminal が起動している状態で grid view で、ターミナルを複数ひらくときに同じ dir を指定してセッションをうっかり共有するケース。アラートは「開く前に警告して確認」してほしい。
>
> コミット、PR で。もう1つの穴（同じ dir で別プロセス起動）は次の作業で進めよう。

## Implementation

- **`GridView.vue`** — compute `openSessionIds` from `state.cells` and pass it down.
- **`TerminalGrid.vue`** — forward `openSessionIds` to each `TerminalCell`.
- **`TerminalCell.vue`**
  - new optional prop `openSessionIds?: string[]`.
  - `sessionOpenElsewhere(id)` = id is in `openSessionIds` and isn't this cell's own session.
  - resume list rows: amber `● open` marker + `is-open` border when open elsewhere.
  - `resume(s)`: `window.confirm(...)` and bail on cancel when open elsewhere.

## Tests

`TerminalCell.spec.ts` (4 new): row flagged when open elsewhere (and not otherwise); confirm cancelled → no launch; confirm accepted → resumes; not-open-elsewhere → resumes with no confirm. `TerminalGrid.spec.ts` updated to pass/forward the new prop.

All gates green: `format` / `lint` (only pre-existing unrelated warnings, 0 errors) / `build` / `typecheck` / `test` (416 passed).

## Out of scope (follow-up)

A second `mulmoterminal` **process** on the same cwd (two app instances fighting over the same on-disk sessions) — no lock/detection today. Will be handled separately.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
