### PR TITLE
feat: グリッド表示のターミナル並べ替え（手動 ◀▶ / 自動アテンションソート）

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,9 +534,9 @@ src/
     Sidebar.vue       Session list; working dot + waiting bold; pub/sub driven
     Sidebar.spec.ts   Vitest component tests
     Terminal.vue      xterm.js terminal; /ws (or /ws/run); single-view ▶ Run menu
-    GridView.vue      Grid toolbar (auto-layout, ＋ Terminal); runs handed-off scripts
+    GridView.vue      Grid toolbar (auto-layout, ＋ Terminal, ↔/⇅ cell order); runs handed-off scripts
     RunMenu.vue       ▶ Run dropdown: lists a dir's script.json, emits the pick
-    TerminalCell.vue  A cell: Claude launcher (dir picker + resume + run-a-script)
+    TerminalCell.vue  A cell: Claude launcher (dir picker + resume + run-a-script); ◀▶ to reorder
     TerminalGrid.vue  Grid of cells; auto-sizes by count; zoom lines up every tab
     CommandCell.vue   A grid cell that runs a script.json command (ephemeral)
   composables/

--- a/plans/feat-grid-cell-ordering.md
+++ b/plans/feat-grid-cell-ordering.md
@@ -1,0 +1,76 @@
+# feat: グリッド表示のターミナル並べ替え（手動／自動）
+
+## User Prompt
+
+> grid表示のときにterminalの順番をかえたい。手動モードだと左右をいれかえ、自動モードだと、集中べきもの（完了したもの）を先に、その次はあいているもの、最後に動作中ものかな。動作中でもユーザのinteractionになったものは前に。
+
+（クラリファイ後の確定事項）
+
+- 手動モードの並べ替え操作 … 各セルヘッダの ◀ ▶ ボタンで隣と入れ替え
+- 自動モードの再整列タイミング … 安定優先（status 変化が起きたときだけ整列。同じバケット内は元の手動順を保持する stable sort）
+- モード切替 UI … ツールバーに Auto/Manual トグル。初期値は **手動**（既存ユーザのグリッドが勝手に並び替わらない）
+- 並べ替えのスコープ … **全ページ横断**（10 個以上でも要対応セルが先頭ページへ浮く）
+
+## 背景・現状
+
+- グリッドは 1 本のフラットな順序付き `Cell[]`（`src/components/gridTabs.ts`）で、9 個ずつページ分割。並べ替え機能は無く挿入順固定。
+- ターミナルのステータスはサーバが `working` / `waiting` の 2 フラグで管理し、`sessions` pub/sub で配信。
+  各 `TerminalCell` が購読して `status = waiting ? "waiting" : working ? "working" : "idle"` を算出している。
+- `CommandCell`（script 実行セル）は実行中=working 相当、終了=idle 相当（`finished` フラグ）。
+
+ステータスとユーザ表現の対応：
+
+| ユーザの言葉 | 内部 status |
+| --- | --- |
+| 集中すべき／完了した／ユーザの interaction になった | `waiting`（要対応） |
+| あいている | `idle` |
+| 動作中 | `working` |
+
+→ 自動モードの並び順：**waiting → idle → working → 空ランチャー（末尾）**
+
+## 設計
+
+### 1. `gridTabs.ts`（純粋ロジック）
+
+- `SortMode = "manual" | "auto"`、`CellStatus = "waiting" | "working" | "idle"` を追加。
+- `GridState` に `sortMode: SortMode` を追加（全コンストラクタ／パーサで既定 `"manual"`）。
+- `setSortMode(state, mode)`。
+- `moveCell(state, uid, dir: -1 | 1)` … フラット配列内で隣と swap。両端・末尾の空ランチャーを越える移動は no-op。
+- `orderCells(cells, statusByUid, mode)` … manual は恒等、auto は rank（waiting=0, idle=1, working=2, 空ランチャー=3）で **stable sort**（同 rank は元の index を保持）。
+- `visibleOrdered(state, statusByUid)` … auto は **全件 `orderCells` → ページスライス**（zoom 中は全件）。manual は base 順スライス。
+- `parseGridState` / `migrateLegacy` / 初期生成で `sortMode` を検証・付与。
+
+並べ替えは **表示順のみ**。`cancelableLaunchUid` / `addCell` / ページ数などは base `state.cells` を見るので不変。
+
+### 0. ステータスの解決（全ページ横断のため）
+
+未マウントの他ページのセルも正しい status が要る（emit ベースだけだと off-screen が idle 誤認 → 誤ソート＆チャーン）。そこでサーバ権威の `useSessions()`（全セッションの working/waiting）を **第一ソース（session id キー）**、各セルの emit `statusByUid`（uid キー）を **フォールバック**（コマンドセル＝session id 無し、id 未割当の起動直後）として GridView で `statusForSort` にマージする。status は server truth なのでマウント状態に依存せず、ページ跨ぎでもフィードバックループが起きない。
+
+### 2. コンポーネント
+
+- `TerminalCell.vue` … 任意 prop `reorderable`、emit `move(dir)` / `status(CellStatus)`。
+  ヘッダ actions に ◀ ▶ を追加（`reorderable` 時のみ）。`status` は `watch(status, …, { immediate:true })` で送出。
+- `CommandCell.vue` … 同様に `reorderable` / `move` / `status`。status は running→working, finished→idle。
+- `TerminalGrid.vue` … 任意 prop `reorderable` を各セルへ中継し、`move` / `status` を uid 付きで再 emit。
+- `GridView.vue` …
+  - `useSessions()` の session 状態 ＋ `@status` 由来の `statusByUid` を `statusForSort` にマージ。
+  - `displayCells = visibleOrdered(state, statusForSort)`。
+  - `onMove(uid, dir)` → `moveCell`、`toggleSortMode()` → `setSortMode`。
+  - ツールバーに Auto/Manual トグル。`reorderable = sortMode === "manual"` を TerminalGrid へ。
+
+`sortMode` は `GridState` の一部なので既存の deep-watch 永続化に自動で乗る。`statusByUid` はライブ状態なので永続化しない。
+
+### 3. テスト
+
+- `gridTabs.spec.ts` … `setSortMode` / `moveCell`（端・空ランチャー境界）/ `orderCells`（バケット順・stable・manual 恒等）/ `sortMode` の既定とパース。
+- `TerminalGrid.spec.ts` … `reorderable` の中継、`move` / `status` の uid 付き再 emit。
+
+## 留意点
+
+- 自動モードは status 変化で再計算されるが stable sort なので同バケット内の手動順は保持。要対応が出たら前方へ寄る。
+- 全ページ横断ソートのため、要対応セルがページを跨いで先頭ページへ移ると、押し出されたセルは別ページへ移動しマウント/アンマウント＝PTY 再接続が起きる（既存のページ切替と同じ挙動。背景 PTY は生存しスクロールバックは復元される）。stable sort なので跨ぎは最小限。
+- i18n：本リポジトリのツールバーはハードコード英語のため、それに合わせる（vue-i18n は未導入）。
+
+## ゲート
+
+`yarn format` / `yarn lint` / `yarn build` / `yarn typecheck` / `yarn test`

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -1,20 +1,36 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import TerminalView from "./Terminal.vue";
 import { formatCwd } from "./cwdDisplay";
+import type { CellStatus } from "./gridTabs";
 
 // A grid cell that runs a `script.json` command (a cell launcher's Run) instead of
 // a Claude session. Ephemeral: it has no session id and isn't persisted — a reload
 // drops it. `command.index` is the script's position in `<command.cwd>/script.json`
 // (the server resolves it); the command runs in `command.cwd`.
-const props = defineProps<{ expanded: boolean; command: { index: number; label: string; cwd: string | null }; home: string | null }>();
-const emit = defineEmits<{ (e: "toggle-expand" | "close"): void }>();
+const props = defineProps<{
+  expanded: boolean;
+  command: { index: number; label: string; cwd: string | null };
+  home: string | null;
+  // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+  reorderable?: boolean;
+}>();
+const emit = defineEmits<{
+  (e: "toggle-expand" | "close"): void;
+  // Swap this cell left (-1) or right (+1) in manual sort mode.
+  (e: "move", dir: -1 | 1): void;
+  // Report activity up so the grid can attention-sort in auto mode.
+  (e: "status", value: CellStatus): void;
+}>();
 
 // connectKey forces Terminal.vue to (re)connect — bumped to re-run after exit.
 const connectKey = ref(0);
 const finished = ref(false);
 
 const dirDisplay = computed(() => formatCwd(props.command.cwd, props.home));
+
+// A running command counts as "working"; once it exits it's idle (never "waiting").
+watch(finished, (done) => emit("status", done ? "idle" : "working"), { immediate: true });
 
 function onExit() {
   finished.value = true;
@@ -35,6 +51,8 @@ function rerun() {
       >
       <span class="cell-cmd">▶ {{ command.label }}</span>
       <span class="cell-actions">
+        <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move command left" @click="emit('move', -1)">◀</button>
+        <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move command right" @click="emit('move', 1)">▶</button>
         <button v-if="finished" class="cell-btn" title="Re-run" aria-label="Re-run command" @click="rerun">↻</button>
         <button
           class="cell-btn"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from "vue";
+import { ref, reactive, computed, watch, onMounted } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
 import {
@@ -12,16 +12,20 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  setSortMode,
+  moveCell,
+  visibleOrdered,
   cancelableLaunchUid,
   pageCount,
   zoomedUid,
-  visibleCells,
   runningCount,
   STATE_KEY,
   LEGACY_KEY,
   type GridState,
+  type CellStatus,
 } from "./gridTabs";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
+import { useSessions } from "../composables/useSessions";
 import { usePendingScript } from "../composables/usePendingScript";
 import type { CwdPreset } from "./presets";
 import { useAppConfig } from "../composables/useAppConfig";
@@ -48,10 +52,40 @@ if (init.migrated) {
 watch(state, persist, { deep: true });
 
 const pages = computed(() => pageCount(state.value.cells.length));
-// While a cell is zoomed, render EVERY cell so the filmstrip lines up all tabs'
-// terminals (live); otherwise just the active page. The flat cells array makes
-// this a single source swap (see visibleCells/zoomedUid).
-const displayCells = computed(() => visibleCells(state.value));
+
+// The "auto" order needs every cell's status, including cells on pages that aren't
+// mounted. The server's session list is the authority for that (it covers all
+// sessions regardless of which page is on screen), so it drives the sort by session
+// id. The per-cell `statusByUid` (reported up while a cell is mounted) is the
+// fallback for cells the session list can't key: command cells (no session id) and a
+// just-launched cell before its id arrives.
+const { sessions } = useSessions();
+const statusByUid = reactive<Record<number, CellStatus>>({});
+const onStatus = (uid: number, s: CellStatus) => (statusByUid[uid] = s);
+// Attention (waiting) wins over working wins over idle — mirrors TerminalCell's dot.
+const toStatus = (working: boolean, waiting: boolean): CellStatus => {
+  if (waiting) return "waiting";
+  if (working) return "working";
+  return "idle";
+};
+const sessionStatus = computed(() => {
+  const m = new Map<string, CellStatus>();
+  for (const s of sessions.value) m.set(s.id, toStatus(s.working, s.waiting));
+  return m;
+});
+const statusForSort = computed<Record<number, CellStatus>>(() => {
+  const out: Record<number, CellStatus> = {};
+  for (const c of state.value.cells) {
+    const fromSession = c.session ? sessionStatus.value.get(c.session) : undefined;
+    out[c.uid] = fromSession ?? statusByUid[c.uid] ?? "idle";
+  }
+  return out;
+});
+const reorderable = computed(() => state.value.sortMode === "manual");
+// In "auto" mode the whole list is attention-sorted then paged (a waiting cell from
+// any page floats to the front); "manual" keeps the hand-arranged order. While a cell
+// is zoomed, render EVERY cell so the filmstrip lines up all tabs' terminals (live).
+const displayCells = computed(() => visibleOrdered(state.value, statusForSort.value));
 const expandedUid = computed(() => zoomedUid(state.value));
 // The cancelable trailing launch cell's uid (null when there's nothing to cancel):
 // drives both the toolbar's cancel state and the launcher's in-cell ✕.
@@ -69,6 +103,8 @@ const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value,
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
 // A running cell's header Run menu: launch in a spare cell so the session survives.
 const onRunSpare = (command: { index: number; label: string; cwd: string | null }) => (state.value = runScriptInNewCell(state.value, command));
+const onMove = (uid: number, dir: -1 | 1) => (state.value = moveCell(state.value, uid, dir));
+const toggleSortMode = () => (state.value = setSortMode(state.value, state.value.sortMode === "auto" ? "manual" : "auto"));
 const switchTo = (page: number) => (state.value = switchPage(state.value, page));
 
 // A script the single view's terminal-header Run menu handed off: run it in a spare
@@ -118,6 +154,15 @@ function closeSettings() {
       </button>
       <button
         class="tb-btn"
+        :class="{ active: state.sortMode === 'auto' }"
+        :title="state.sortMode === 'auto' ? 'Auto order: attention-first (click for manual)' : 'Manual order: reorder with ◀▶ (click for auto)'"
+        :aria-pressed="state.sortMode === 'auto'"
+        @click="toggleSortMode"
+      >
+        {{ state.sortMode === "auto" ? "⇅ Auto" : "↔ Manual" }}
+      </button>
+      <button
+        class="tb-btn"
         :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
         :aria-label="soundEnabled ? 'Attention sound on' : 'Attention sound off'"
         :aria-pressed="soundEnabled"
@@ -141,12 +186,15 @@ function closeSettings() {
       :default-cwd="defaultCwd"
       :presets="presets"
       :home="home"
+      :reorderable="reorderable"
       @session="onSession"
       @cwd="onCwd"
       @close="onClose"
       @toggle-expand="onToggleExpand"
       @run="onRun"
       @run-spare="onRunSpare"
+      @move="onMove"
+      @status="onStatus"
     />
     <SettingsModal
       v-if="showSettings"
@@ -211,6 +259,11 @@ function closeSettings() {
 .tb-btn:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+.tb-btn.active {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--accent);
 }
 
 .tabbar {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -4,6 +4,7 @@ import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import type { CwdPreset } from "./presets";
+import type { CellStatus } from "./gridTabs";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 
@@ -21,6 +22,8 @@ const props = defineProps<{
   home: string | null;
   // An added (not the sole entry) launcher: show a ✕ to dismiss it before launching.
   cancellable?: boolean;
+  // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+  reorderable?: boolean;
 }>();
 const emit = defineEmits<{
   (e: "toggle-expand" | "close"): void;
@@ -28,6 +31,10 @@ const emit = defineEmits<{
   // `run` launches in THIS (empty) cell from the launcher; `runSpare` is the running
   // terminal's header menu, which must NOT replace the session — it runs in a new cell.
   (e: "run" | "runSpare", value: { index: number; label: string; cwd: string | null }): void;
+  // Swap this cell left (-1) or right (+1) in manual sort mode.
+  (e: "move", dir: -1 | 1): void;
+  // Report live activity up so the grid can attention-sort in auto mode.
+  (e: "status", value: CellStatus): void;
 }>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
@@ -499,6 +506,7 @@ const STATUS_CLASS = { waiting: "is-waiting", working: "is-working", idle: "is-i
 const STATUS_LABEL = { waiting: "Needs attention", working: "Working…", idle: "Idle" } as const;
 const statusClass = computed(() => STATUS_CLASS[status.value]);
 const statusLabel = computed(() => STATUS_LABEL[status.value]);
+watch(status, (s) => emit("status", s), { immediate: true });
 
 const headerText = computed(() => lastPrompt.value || (sessionId.value ? sessionId.value.slice(0, 8) : "starting…"));
 
@@ -668,6 +676,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         </span>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <span class="cell-actions">
+          <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
+          <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
           <button
             class="cell-btn"
             :title="expanded ? 'Restore' : 'Expand'"

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -8,24 +8,24 @@ import type { Cell } from "./gridTabs";
 vi.mock("./TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
-    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home", "cancellable"],
-    emits: ["toggle-expand", "session", "cwd", "run", "close"],
+    props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home", "cancellable", "reorderable"],
+    emits: ["toggle-expand", "session", "cwd", "run", "close", "move", "status"],
     template: '<div class="stub-cell" />',
   },
 }));
 vi.mock("./CommandCell.vue", () => ({
   default: {
     name: "CommandCell",
-    props: ["expanded", "command", "home"],
-    emits: ["toggle-expand", "close"],
+    props: ["expanded", "command", "home", "reorderable"],
+    emits: ["toggle-expand", "close", "move", "status"],
     template: '<div class="stub-command-cell" />',
   },
 }));
 
 const cell = (uid: number, session: string | null = null, cwd: string | null = null): Cell => ({ uid, session, cwd });
 const cmdCell = (uid: number, command: NonNullable<Cell["command"]>): Cell => ({ uid, session: null, cwd: null, command });
-const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null) =>
-  mount(TerminalGrid, { props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], home: "/work" } });
+const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null, reorderable = false) =>
+  mount(TerminalGrid, { props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], home: "/work", reorderable } });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });
 
@@ -57,6 +57,15 @@ describe("TerminalGrid (page renderer)", () => {
     const cs = cellsOf(mountGrid([cell(0, "s0"), cell(1)], null, 1));
     expect(cs[0].props("cancellable")).toBe(false);
     expect(cs[1].props("cancellable")).toBe(true);
+  });
+
+  it("passes reorderable through and re-emits move/status tagged with uid", () => {
+    const w = mountGrid([cell(7, "s")], null, null, true);
+    expect(cellsOf(w)[0].props("reorderable")).toBe(true);
+    cellsOf(w)[0].vm.$emit("move", 1);
+    cellsOf(w)[0].vm.$emit("status", "waiting");
+    expect(w.emitted("move")?.[0]).toEqual([7, 1]);
+    expect(w.emitted("status")?.[0]).toEqual([7, "waiting"]);
   });
 
   it("adds the zoomed class only when a cell is expanded", async () => {

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -3,7 +3,7 @@ import { ref, computed, onMounted } from "vue";
 import TerminalCell from "./TerminalCell.vue";
 import CommandCell from "./CommandCell.vue";
 import { trackStyle, layoutForCount } from "./gridLayout";
-import type { Cell } from "./gridTabs";
+import type { Cell, CellStatus } from "./gridTabs";
 import type { CwdPreset } from "./presets";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
@@ -21,12 +21,16 @@ const props = defineProps<{
   defaultCwd: string | null;
   presets: CwdPreset[];
   home: string | null;
+  // Manual sort mode: each cell shows ◀▶ to reorder.
+  reorderable?: boolean;
 }>();
 const emit = defineEmits<{
   (e: "session" | "cwd", uid: number, value: string): void;
   (e: "close" | "toggle-expand", uid: number): void;
   (e: "run", uid: number, command: { index: number; label: string; cwd: string | null }): void;
   (e: "runSpare", command: { index: number; label: string; cwd: string | null }): void;
+  (e: "move", uid: number, dir: -1 | 1): void;
+  (e: "status", uid: number, value: CellStatus): void;
 }>();
 
 const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length), null));
@@ -49,8 +53,11 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :expanded="cell.uid === expandedUid"
           :command="cell.command"
           :home="home"
+          :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @close="emit('close', cell.uid)"
+          @move="(dir) => emit('move', cell.uid, dir)"
+          @status="(s) => emit('status', cell.uid, s)"
         />
         <TerminalCell
           v-else
@@ -61,12 +68,15 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :presets="presets"
           :home="home"
           :cancellable="cell.uid === cancelUid"
+          :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @session="(id) => emit('session', cell.uid, id)"
           @cwd="(c) => emit('cwd', cell.uid, c)"
           @run="(cmd) => emit('run', cell.uid, cmd)"
           @run-spare="(cmd) => emit('runSpare', cmd)"
           @close="emit('close', cell.uid)"
+          @move="(dir) => emit('move', cell.uid, dir)"
+          @status="(s) => emit('status', cell.uid, s)"
         />
       </Teleport>
     </div>

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -11,12 +11,17 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  setSortMode,
+  moveCell,
+  orderCells,
+  visibleOrdered,
   cancelableLaunchUid,
   zoomedUid,
   visibleCells,
   parseGridState,
   migrateLegacy,
   initialState,
+  type CellStatus,
   type GridState,
   type Cell,
 } from "./gridTabs";
@@ -24,7 +29,14 @@ import {
 const U = (n: number) => `${String(n % 10).repeat(8)}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`;
 const cell = (uid: number, session: string | null = null, cwd: string | null = null): Cell => ({ uid, session, cwd });
 const running = (count: number): Cell[] => Array.from({ length: count }, (_, i) => cell(i, U(i)));
-const make = (cells: Cell[], extra: Partial<GridState> = {}): GridState => ({ cells, expanded: null, page: 0, nextUid: cells.length, ...extra });
+const make = (cells: Cell[], extra: Partial<GridState> = {}): GridState => ({
+  cells,
+  expanded: null,
+  page: 0,
+  nextUid: cells.length,
+  sortMode: "manual",
+  ...extra,
+});
 
 describe("pagination helpers", () => {
   it("pageCount is 1..n in chunks of 9", () => {
@@ -185,6 +197,72 @@ describe("runScriptInNewCell (toolbar Run menu)", () => {
   });
 });
 
+describe("setSortMode / moveCell (manual reorder)", () => {
+  it("setSortMode flips between manual and auto", () => {
+    expect(setSortMode(make(running(2)), "auto").sortMode).toBe("auto");
+    expect(setSortMode(make(running(2), { sortMode: "auto" }), "manual").sortMode).toBe("manual");
+  });
+  it("moveCell swaps a cell with its right/left neighbour", () => {
+    const s = make(running(3));
+    expect(moveCell(s, 0, 1).cells.map((c) => c.uid)).toEqual([1, 0, 2]); // 0 right
+    expect(moveCell(s, 2, -1).cells.map((c) => c.uid)).toEqual([0, 2, 1]); // 2 left
+  });
+  it("moveCell is a no-op past either end", () => {
+    const s = make(running(3));
+    expect(moveCell(s, 0, -1)).toBe(s); // already leftmost
+    expect(moveCell(s, 2, 1)).toBe(s); // already rightmost
+    expect(moveCell(s, 99, 1)).toBe(s); // unknown uid
+  });
+  it("moveCell won't push a cell past the trailing launch cell (it stays last)", () => {
+    const s = make([...running(2), cell(2)]); // cell 2 is the trailing launcher
+    expect(moveCell(s, 1, 1)).toBe(s);
+  });
+});
+
+describe("orderCells (auto attention sort)", () => {
+  const status = (m: Record<number, CellStatus>) => m;
+  it("manual mode returns the list unchanged", () => {
+    const cells = running(3);
+    expect(orderCells(cells, status({ 0: "working", 1: "waiting", 2: "idle" }), "manual")).toBe(cells);
+  });
+  it("auto sorts waiting -> idle -> working, launch cells last", () => {
+    const cells = [...running(3), cell(3)]; // uid 3 is an empty launch cell
+    const ordered = orderCells(cells, status({ 0: "working", 1: "waiting", 2: "idle" }), "auto");
+    expect(ordered.map((c) => c.uid)).toEqual([1, 2, 0, 3]);
+  });
+  it("is stable within a bucket (equal status keeps manual order)", () => {
+    const cells = running(4);
+    const ordered = orderCells(cells, status({ 0: "working", 1: "working", 2: "working", 3: "working" }), "auto");
+    expect(ordered.map((c) => c.uid)).toEqual([0, 1, 2, 3]);
+  });
+  it("treats an unreported uid as idle", () => {
+    const cells = running(2);
+    const ordered = orderCells(cells, status({ 0: "working" }), "auto");
+    expect(ordered.map((c) => c.uid)).toEqual([1, 0]); // uid 1 (idle) before uid 0 (working)
+  });
+});
+
+describe("visibleOrdered (attention-sort the whole list, then page)", () => {
+  it("floats a waiting cell from any page onto the first page", () => {
+    // 12 cells over 2 pages. uid 10 starts on page 2; once waiting it sorts to the
+    // front and lands on page 1, while the working uid 0 sinks off page 1.
+    const s = make(running(12), { page: 0, sortMode: "auto" });
+    const statusByUid: Record<number, CellStatus> = { 0: "working", 1: "waiting", 10: "waiting" };
+    const page1 = visibleOrdered(s, statusByUid).map((c) => c.uid);
+    expect(page1.slice(0, 2)).toEqual([1, 10]); // both waiting cells, base order, up front
+    expect(page1).not.toContain(0); // working uid 0 sank to page 2
+    expect(page1).toHaveLength(9);
+  });
+  it("manual mode leaves the on-screen order untouched", () => {
+    const s = make(running(4), { sortMode: "manual" });
+    expect(visibleOrdered(s, { 0: "working", 3: "waiting" }).map((c) => c.uid)).toEqual([0, 1, 2, 3]);
+  });
+  it("orders the whole list (the filmstrip) while zoomed", () => {
+    const s = make(running(12), { page: 0, expanded: 11, sortMode: "auto" });
+    expect(visibleOrdered(s, { 11: "waiting" }).map((c) => c.uid)[0]).toBe(11);
+  });
+});
+
 describe("zoomedUid / visibleCells", () => {
   it("zoomedUid returns the expanded uid, or null when nothing is zoomed", () => {
     expect(zoomedUid(make(running(3)))).toBeNull();
@@ -220,6 +298,12 @@ describe("parseGridState / migrateLegacy / initialState", () => {
   it("returns null for missing/corrupt input", () => {
     expect(parseGridState(null)).toBeNull();
     expect(parseGridState("not json{")).toBeNull();
+  });
+  it("round-trips a persisted sortMode and defaults to manual", () => {
+    const cells = [cell(0, U(0))];
+    expect(parseGridState(JSON.stringify({ cells, sortMode: "auto" }))?.sortMode).toBe("auto");
+    expect(parseGridState(JSON.stringify({ cells }))?.sortMode).toBe("manual"); // absent -> manual
+    expect(parseGridState(JSON.stringify({ cells, sortMode: "bogus" }))?.sortMode).toBe("manual"); // invalid -> manual
   });
   it("constrains a malformed persisted page to a valid integer", () => {
     const cells = Array.from({ length: 18 }, (_, i) => cell(i, U(i))); // 2 pages

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -13,11 +13,19 @@ export interface Cell {
   // the directory it runs in. Ephemeral — command cells are never persisted.
   command?: { index: number; label: string; cwd: string | null } | null;
 }
+// How the grid orders its cells. "manual": the user's hand-arranged order (◀▶);
+// "auto": attention-first, recomputed from each cell's live status.
+export type SortMode = "manual" | "auto";
+// A cell's live activity, reported up from the cell (the server's working/waiting
+// flags). Drives the "auto" order; absent uids are treated as idle.
+export type CellStatus = "waiting" | "working" | "idle";
+
 export interface GridState {
   cells: Cell[];
   expanded: number | null; // uid of the zoomed cell, or null
   page: number;
   nextUid: number;
+  sortMode: SortMode;
 }
 
 export const PAGE_SIZE = 9;
@@ -103,14 +111,59 @@ export function toggleExpand(state: GridState, uid: number): GridState {
   return { ...state, expanded: state.expanded === uid ? null : uid };
 }
 
+export function setSortMode(state: GridState, sortMode: SortMode): GridState {
+  return { ...state, sortMode };
+}
+
+// Manual reorder: swap a cell with its neighbour (dir -1 = left, +1 = right) in the
+// flat list. No-op at the ends, and never swaps a cell past the trailing launch
+// cell (it stays last so "+ Terminal"/cancel keep working on it).
+export function moveCell(state: GridState, uid: number, dir: -1 | 1): GridState {
+  const i = state.cells.findIndex((c) => c.uid === uid);
+  const j = i + dir;
+  if (i < 0 || j < 0 || j >= state.cells.length) return state;
+  if (isLaunchCell(state.cells[j]) && j === state.cells.length - 1) return state;
+  const cells = state.cells.slice();
+  [cells[i], cells[j]] = [cells[j], cells[i]];
+  return { ...state, cells };
+}
+
 // The zoomed cell's uid, or null when nothing is zoomed (or `expanded` is stale —
 // points at a cell no longer in the list).
 export const zoomedUid = (state: GridState): number | null =>
   state.expanded !== null && state.cells.some((c) => c.uid === state.expanded) ? state.expanded : null;
 
-// Cells to render: while a cell is zoomed, the WHOLE list (so the filmstrip lines
-// up every tab's terminal, live), otherwise just the active page's slice.
+// Attention-first rank for the "auto" order: cells needing the user (waiting) come
+// first, then idle, then working, with empty launch cells last. Lower sorts earlier.
+const RANK: Record<CellStatus, number> = { waiting: 0, idle: 1, working: 2 };
+const LAUNCH_RANK = 3;
+const cellRank = (c: Cell, statusByUid: Record<number, CellStatus>): number => (isLaunchCell(c) ? LAUNCH_RANK : RANK[statusByUid[c.uid] ?? "idle"]);
+
+// Display order. "manual": the hand-arranged list as-is. "auto": a STABLE sort by
+// attention rank — equal-rank cells keep their manual order, so a status change
+// only floats that one cell to its bucket and doesn't reshuffle the rest.
+export function orderCells(cells: Cell[], statusByUid: Record<number, CellStatus>, mode: SortMode): Cell[] {
+  if (mode !== "auto") return cells;
+  return cells
+    .map((c, i) => ({ c, i }))
+    .sort((a, b) => cellRank(a.c, statusByUid) - cellRank(b.c, statusByUid) || a.i - b.i)
+    .map((x) => x.c);
+}
+
+// Cells in the on-screen view, in manual (base) order: while a cell is zoomed, the
+// WHOLE list (so the filmstrip lines up every tab's terminal, live), otherwise just
+// the active page's slice.
 export const visibleCells = (state: GridState): Cell[] => (zoomedUid(state) !== null ? state.cells : pageSlice(state.cells, state.page));
+
+// The cells to render. "auto" attention-sorts the WHOLE list first, then pages — so a
+// waiting cell from any page floats onto the first page. This needs a status map that
+// covers EVERY cell (incl. unmounted pages), or a status change on an off-screen page
+// would (mis)read as idle; GridView feeds it the server's full session status. While
+// zoomed the whole ordered list is shown (the filmstrip).
+export const visibleOrdered = (state: GridState, statusByUid: Record<number, CellStatus>): Cell[] => {
+  const ordered = orderCells(state.cells, statusByUid, state.sortMode);
+  return zoomedUid(state) !== null ? ordered : pageSlice(ordered, state.page);
+};
 
 // Switch page: drop an abandoned trailing launch cell first and clear the zoom
 // (zoom is scoped to a page). Selecting the already-active page is a no-op so it
@@ -123,6 +176,7 @@ export function switchPage(state: GridState, page: number): GridState {
 }
 
 const isUuid = (s: unknown): s is string => typeof s === "string" && UUID_RE.test(s);
+const asSortMode = (v: unknown): SortMode => (v === "auto" ? "auto" : "manual");
 // A cell entry is kept if its session/cwd are well-formed; uid is validated only to
 // match the persisted `expanded` (it is renumbered below regardless).
 const isCell = (c: unknown): c is Cell => {
@@ -147,7 +201,7 @@ export function parseGridState(raw: string | null): GridState | null {
     const expandedIdx = running.findIndex((c: Cell) => c.uid === parsed.expanded);
     const expanded = typeof parsed.expanded === "number" && expandedIdx >= 0 ? expandedIdx : null;
     const page = Number.isSafeInteger(parsed.page) && parsed.page >= 0 ? parsed.page : 0;
-    return clampPage(ensureEntry({ cells, expanded, page, nextUid: cells.length }));
+    return clampPage(ensureEntry({ cells, expanded, page, nextUid: cells.length, sortMode: asSortMode(parsed.sortMode) }));
   } catch {
     return null;
   }
@@ -163,7 +217,7 @@ export function migrateLegacy(raw: string | null): GridState | null {
       if (isUuid(s)) cells.push({ uid: cells.length, session: s, cwd: typeof parsed.cwds?.[i] === "string" ? parsed.cwds[i] : null });
     });
     const expanded = typeof parsed.expanded === "number" && parsed.expanded >= 0 && parsed.expanded < cells.length ? cells[parsed.expanded].uid : null;
-    return clampPage(ensureEntry({ cells, expanded, page: 0, nextUid: cells.length }));
+    return clampPage(ensureEntry({ cells, expanded, page: 0, nextUid: cells.length, sortMode: "manual" }));
   } catch {
     return null;
   }
@@ -174,5 +228,5 @@ export function initialState(curRaw: string | null, legacyRaw: string | null): {
   if (cur) return { state: cur, migrated: false };
   const migrated = migrateLegacy(legacyRaw);
   if (migrated) return { state: migrated, migrated: true };
-  return { state: ensureEntry({ cells: [], expanded: null, page: 0, nextUid: 0 }), migrated: false };
+  return { state: ensureEntry({ cells: [], expanded: null, page: 0, nextUid: 0, sortMode: "manual" }), migrated: false };
 }


### PR DESCRIPTION
## Summary

グリッド表示でターミナルセルの並び順を変更できるようにしました。ツールバーに **`↔ Manual` / `⇅ Auto`** トグルを追加（初期 = 手動）。

- **手動モード**: 各セルヘッダの **◀ ▶** ボタンで隣のセルと入れ替え（順序は localStorage に永続化）。
- **自動モード**: 注目すべきセルを前方へ寄せる stable sort。並び順は
  **要対応 (waiting) → アイドル (idle) → 動作中 (working) → 空ランチャー**。
  - 「完了した / 集中すべき / ユーザ操作待ち」はすべて内部ステータス `waiting` に対応。
  - **全ページ横断**: 10 個以上でも要対応セルが先頭ページへ浮く。サーバ権威のセッション状態（`useSessions`）でソートするので未表示ページのセルも正しく扱える。各セルの emit `status` は、コマンドセル（session id 無し）と起動直後（id 未割当）のフォールバック。
  - 安定優先（同バケット内は手動順を保持する stable sort）。並べ替え中もターミナルは再マウントされない（`v-for :key="uid"`）。ページ跨ぎ移動のみ、既存のページ切替と同様に PTY 再接続が起きる（背景 PTY は生存）。

## Items to Confirm / Review

- **ステータス対応の解釈**: サーバは `working` / `waiting` の 2 フラグのみ。「完了した・集中すべき・ユーザの interaction になった」を **すべて `waiting`（要対応）** に対応させた解釈で良いか。
- **全ページ横断の挙動**: 要対応セルがページを跨いで先頭ページへ移ると、押し出されたセルは別ページへ移り **PTY 再接続** が起きます（既存のページ切替と同じ。背景 PTY は生存・スクロールバック復元）。stable sort で跨ぎは最小限。この挙動で問題ないか。
- **UI の見た目**: ◀▶ ボタンはセルヘッダに追加（手動モード時のみ表示）。3×3 の狭いセルでヘッダが窮屈にならないか目視で確認したい（本セッションにブラウザ MCP が無く Playwright 検証は未実施。`vite build` + `vue-tsc` で全 SFC コンパイル確認済み、ロジックと配線は 425 件のユニットテストでカバー）。
- **`useSessions` の二重購読**: GridView でも `useSessions()` を呼ぶため /api/sessions のフェッチが増えます（GridView と単一ビューの Sidebar は基本同時マウントされないので実害は小さい想定）。

## User Prompt

> grid表示のときにterminalの順番をかえたい。手動モードだと左右をいれかえ、自動モードだと、集中べきもの（完了したもの）を先に、その次はあいているもの、最後に動作中ものかな。動作中でもユーザのinteractionになったものは前に。

確認した設計判断（クラリファイ結果）:
- 手動の入れ替え操作 … 各セルの ◀▶ ボタン
- 自動の再整列タイミング … 安定優先
- モード切替 … ツールバーのトグル、初期 = 手動
- 並べ替えスコープ … 全ページ横断

## Implementation

- `gridTabs.ts`（純粋ロジック）: `SortMode` / `CellStatus` 型、`GridState.sortMode`、`setSortMode` / `moveCell`（端・末尾ランチャー保護）/ `orderCells`（rank の stable sort）/ `visibleOrdered`（全件ソート→ページスライス、zoom 時は全件）。`parseGridState` 等で `sortMode` を検証・永続化（既定 manual）。
- `TerminalCell.vue` / `CommandCell.vue`: `reorderable` prop、`move` / `status` emit、ヘッダに ◀▶。
- `TerminalGrid.vue`: それらを uid 付きで中継。
- `GridView.vue`: `useSessions` の session 状態 ＋ emit の `statusByUid` を `statusForSort` にマージ、ツールバートグル、`moveCell` 配線。
- テスト: `gridTabs.spec.ts`（setSortMode / moveCell / orderCells / visibleOrdered / sortMode 永続化）、`TerminalGrid.spec.ts`（reorderable 中継・move/status 再 emit）。
- 計画書 `plans/feat-grid-cell-ordering.md`、README コンポーネントマップ更新。

Closes #141
