### PR TITLE
feat: dirごとの .mulmoterminal.json で色・サウンド・バッジをカスタマイズ

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,35 @@ chime) or in the config file; the server streams that file at `GET /api/sound` a
 the client decodes it (falling back to the chime if it's missing or not audio). It's
 your own local file referenced by absolute path — nothing is added to the package.
 
+### Per-directory settings (`<project>/.mulmoterminal.json`)
+
+Drop a `.mulmoterminal.json` in a project directory to give terminals opened **in
+that directory** their own look and sound. It applies per terminal (per grid cell) —
+the rest of the app keeps your chosen theme — and a directory's theme overrides your
+manual theme pick for that terminal only. Every field is optional; a missing or
+malformed file is ignored.
+
+```jsonc
+{
+  "name": "PROD · payments",            // badge shown on this directory's terminals
+  "badgeColor": "#cf222e",              // badge color (hex #rrggbb)
+  "theme": "nord",                      // terminal palette: midnight | nord | daylight | solarized
+  "sound": "./.mulmoterminal/alert.mp3" // attention sound, RELATIVE to this directory
+}
+```
+
+| Field        | Meaning |
+| ------------ | ------- |
+| `name`       | Label shown as a badge in the terminal/cell header. |
+| `badgeColor` | Badge background color (`#rrggbb`); text auto-contrasts. |
+| `theme`      | xterm palette for terminals in this directory (one of the built-in theme ids). |
+| `sound`      | Attention sound for this directory's sessions, a path **relative to the directory** (served at `GET /api/dir-sound`). |
+
+**Security.** `sound` is a directory-relative path only — absolute paths and any
+`../` that escapes the directory are rejected, and the path is never taken from the
+HTTP request, so an opened project can't point the player at arbitrary files.
+Changes take effect when the terminal is next opened (no live file watch).
+
 ---
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ malformed file is ignored.
   "name": "PROD · payments",            // badge shown on this directory's terminals
   "badgeColor": "#cf222e",              // badge color (hex #rrggbb)
   "theme": "nord",                      // terminal palette: midnight | nord | daylight | solarized
+  "colors": { "background": "#190a23", "cursor": "#ff2e63" }, // per-key palette overrides
   "sound": "./.mulmoterminal/alert.mp3" // attention sound, RELATIVE to this directory
 }
 ```
@@ -188,6 +189,7 @@ malformed file is ignored.
 | `name`       | Label shown as a badge in the terminal/cell header. |
 | `badgeColor` | Badge background color (`#rrggbb`); text auto-contrasts. |
 | `theme`      | xterm palette for terminals in this directory (one of the built-in theme ids). |
+| `colors`     | Per-key xterm palette overrides applied on top of `theme` (or the app theme when `theme` is unset). Keys are xterm `ITheme` names (`background`, `foreground`, `cursor`, `selectionBackground`, the 16 ANSI colors, …); values are hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Unknown keys / bad values are dropped. |
 | `sound`      | Attention sound for this directory's sessions, a path **relative to the directory** (served at `GET /api/dir-sound`). |
 
 **Security.** `sound` is a directory-relative path only — absolute paths and any

--- a/plans/feat-dir-config.md
+++ b/plans/feat-dir-config.md
@@ -26,9 +26,14 @@ dir単位の層は無い。これを追加する。
   "name": "PROD · payments",            // UIのラベル／バッジ
   "badgeColor": "#cf222e",              // バッジ色＆セルのアクセント（hex #rrggbb）
   "theme": "nord",                      // 端末の xterm パレット（midnight/nord/daylight/solarized）
+  "colors": { "background": "#190a23", "cursor": "#ff2e63" }, // xtermパレットの部分上書き（任意カラー）
   "sound": "./.mulmoterminal/alert.mp3" // 注目サウンド（このdir配下の相対パスのみ）
 }
 ```
+
+`colors` は `theme`（無ければアプリテーマ）をベースに、xterm `ITheme` の各キー
+（`background`/`foreground`/`cursor`/`selectionBackground`/16 ANSI色…）を hex で上書き。
+既知キーかつ妥当な hex のみ採用し、不正は無視。`theme` の4プリセットに縛られず任意配色にできる。
 
 ## 変更
 

--- a/plans/feat-dir-config.md
+++ b/plans/feat-dir-config.md
@@ -1,0 +1,87 @@
+# feat: dirごとの `.mulmoterminal.json`（色・サウンド・バッジ）
+
+Issue: #143
+
+## User Prompt
+
+> dirごとに.mulmoterminal.jsonをおいておくと、色とかサウンドとかカスタムしたいよね！！
+
+スコープ確認の回答:
+
+- **対象**: 端末の色／テーマ・注目サウンド・プロジェクト名／バッジ（自動実行は対象外）
+- **色の適用範囲**: その端末セルの色だけ変える（アプリ全体のクロームは変えない）
+- **優先順位**: dir設定が優先（手動テーマ選択より `theme` を採用）
+- **サウンド参照**: プロジェクトdir内の相対パスのみ（traversal防止）
+
+## 方針
+
+各ディレクトリに `.mulmoterminal.json` を置くと、そのdirで開いた端末にだけ効く新しい設定レイヤを足す。
+現状の設定はすべてグローバル（テーマ＝`localStorage`、サウンド＝`~/.mulmoterminal/config.json`）で、
+dir単位の層は無い。これを追加する。
+
+### スキーマ（`<cwd>/.mulmoterminal.json` / 全フィールド任意）
+
+```jsonc
+{
+  "name": "PROD · payments",            // UIのラベル／バッジ
+  "badgeColor": "#cf222e",              // バッジ色＆セルのアクセント（hex #rrggbb）
+  "theme": "nord",                      // 端末の xterm パレット（midnight/nord/daylight/solarized）
+  "sound": "./.mulmoterminal/alert.mp3" // 注目サウンド（このdir配下の相対パスのみ）
+}
+```
+
+## 変更
+
+### サーバ
+
+- `server/dir-config.ts`（新規・テスト対象）:
+  - `loadDirConfig(cwd)`: `<cwd>/.mulmoterminal.json` を読み、sanitize して
+    `{ name, badgeColor, theme, sound }` を返す（`sound` は cwd 配下に解決した**絶対パス**、
+    範囲外・絶対指定・`..` は `null`）。不在/壊れは全フィールド `null`。
+  - `publicDirConfig(cwd)`: クライアント向けに `{ name, badgeColor, theme, hasSound }`
+    （生のサウンドパスは出さない）。
+  - sanitize: `name` は文字列を長さ上限でトリム、`badgeColor` は `#rrggbb` のみ、
+    `theme` は既知 id のホワイトリスト、`sound` は相対パスのみ→cwd内に解決。
+- `server/dir-config.spec.ts`: sanitize / 範囲外サウンド拒否 / 不正JSON のテスト。
+- ルート（`config-routes.ts` に相乗り、または `dir-config-routes.ts`）:
+  - `GET /api/dir-config?cwd=<path>` → `publicDirConfig`（cwd は `resolveWorkspace` 検証）。
+  - `GET /api/dir-sound?cwd=<path>` → 解決済みサウンドを配信（未設定/不在は 404）。
+    パスはリクエストに乗せず、サーバが `.mulmoterminal.json` から引いて cwd 内に再解決。
+- `server/index.ts`: `publishActivity` の payload に `cwd`（`ptys.get(id)?.cwd`）を追加。
+  注目サウンドのリスナがセッションの dir を引けるようにする。
+
+### フロント
+
+- `composables/useTheme.ts`: `termThemeFor(id): ITheme`（特定テーマのパレット解決）を追加。
+- `composables/useDirConfig.ts`（新規）: cwd ごとに `/api/dir-config` を取得しキャッシュ。
+  `{ name, badgeColor, theme, hasSound }` を返す。
+- `components/Terminal.vue` / `components/TerminalCell.vue`:
+  - dir に `theme` があれば `termThemeFor(theme)` を xterm パレットに使う（手動テーマより優先・このセルのみ）。
+  - `name`/`badgeColor` をセルヘッダ／セッションタブにバッジ表示。
+- `composables/useAttentionSound.ts`: activity の `cwd` を使い、dir にカスタム音があれば
+  `/api/dir-sound?cwd=<cwd>` を Web Audio でデコード（cwd キーでキャッシュ）して再生。
+  無ければグローバル `soundFile`、無ければ合成チャイムにフォールバック。
+
+### ドキュメント
+
+- `README.md`: `.mulmoterminal.json` のセクション（スキーマ・優先順位・サウンドは相対パスのみ）＋サンプル。
+
+## 優先順位
+
+- グローバル手動テーマ → アプリ全体のクローム＋dir設定の無い端末。
+- dir `theme` → その端末のパレットのみ上書き（このセルだけ）。
+- サウンド: dir音 > グローバル `soundFile` > 合成チャイム。
+
+## セキュリティ
+
+- `sound` は相対パスのみ。`path.resolve(cwd, sound)` が cwd 配下に収まることを検証し、
+  絶対指定・`..` 脱出は拒否。`/api/dir-sound` でも cwd を `resolveWorkspace` 検証し再解決（多層防御）。
+- JSON は防御的にパース（try/catch）、各フィールドを型・形検証、不正は無視してデフォルト動作。
+
+## 確認ポイント
+
+- dir 設定はセル単位（アプリ全体のクロームは不変）。
+- 手動テーマより dir `theme` が優先されること（該当セルのみ）。
+- サウンドは dir 内相対パスのみ・traversal 不可。
+- `.mulmoterminal.json` 不在/壊れでも従来動作（無視してデフォルト）。
+- 監視は無し（MVP）。変更は端末の開き直しで反映。

--- a/server/dir-config.spec.ts
+++ b/server/dir-config.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile } from "./dir-config";
+
+const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
+const EMPTY = { name: null, badgeColor: null, theme: null, sound: null };
+
+function withConfig(body: unknown): { dir: string; cleanup: () => void } {
+  const dir = tmp();
+  writeFileSync(path.join(dir, ".mulmoterminal.json"), typeof body === "string" ? body : JSON.stringify(body));
+  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("resolveDirSound", () => {
+  it("resolves a relative path to an existing file inside cwd", () => {
+    const { dir, cleanup } = withConfig({});
+    writeFileSync(path.join(dir, "alert.mp3"), "x");
+    expect(resolveDirSound(dir, "./alert.mp3")).toBe(path.join(dir, "alert.mp3"));
+    expect(resolveDirSound(dir, "alert.mp3")).toBe(path.join(dir, "alert.mp3"));
+    cleanup();
+  });
+
+  it("allows a file in a subdirectory of cwd", () => {
+    const { dir, cleanup } = withConfig({});
+    mkdirSync(path.join(dir, "sounds"));
+    writeFileSync(path.join(dir, "sounds", "a.wav"), "x");
+    expect(resolveDirSound(dir, "sounds/a.wav")).toBe(path.join(dir, "sounds", "a.wav"));
+    cleanup();
+  });
+
+  it("rejects absolute paths", () => {
+    const { dir, cleanup } = withConfig({});
+    writeFileSync(path.join(dir, "a.mp3"), "x");
+    expect(resolveDirSound(dir, path.join(dir, "a.mp3"))).toBeNull();
+    cleanup();
+  });
+
+  it("rejects traversal that escapes cwd even when the target exists", () => {
+    const parent = tmp();
+    const dir = path.join(parent, "project");
+    mkdirSync(dir);
+    writeFileSync(path.join(parent, "secret.mp3"), "x"); // exists, but OUTSIDE the dir
+    expect(resolveDirSound(dir, "../secret.mp3")).toBeNull();
+    rmSync(parent, { recursive: true, force: true });
+  });
+
+  it("rejects a sibling dir sharing a name prefix (no boundary bypass)", () => {
+    const parent = tmp();
+    const dir = path.join(parent, "app");
+    const sibling = path.join(parent, "app-evil");
+    mkdirSync(dir);
+    mkdirSync(sibling);
+    writeFileSync(path.join(sibling, "a.mp3"), "x");
+    expect(resolveDirSound(dir, "../app-evil/a.mp3")).toBeNull();
+    rmSync(parent, { recursive: true, force: true });
+  });
+
+  it("returns null for a missing file or non-string input", () => {
+    const { dir, cleanup } = withConfig({});
+    expect(resolveDirSound(dir, "./missing.mp3")).toBeNull();
+    expect(resolveDirSound(dir, "")).toBeNull();
+    expect(resolveDirSound(dir, 42)).toBeNull();
+    expect(resolveDirSound(dir, null)).toBeNull();
+    cleanup();
+  });
+});
+
+describe("loadDirConfig", () => {
+  it("loads and sanitizes a full config", () => {
+    const { dir, cleanup } = withConfig({ name: "  PROD  ", badgeColor: "#CF222E", theme: "nord", sound: "./a.mp3" });
+    writeFileSync(path.join(dir, "a.mp3"), "x");
+    expect(loadDirConfig(dir)).toEqual({ name: "PROD", badgeColor: "#cf222e", theme: "nord", sound: path.join(dir, "a.mp3") });
+    cleanup();
+  });
+
+  it("caps an overlong name", () => {
+    const { dir, cleanup } = withConfig({ name: "x".repeat(100) });
+    expect(loadDirConfig(dir).name).toHaveLength(40);
+    cleanup();
+  });
+
+  it("drops an unknown theme and a malformed color", () => {
+    const { dir, cleanup } = withConfig({ theme: "neon", badgeColor: "red" });
+    expect(loadDirConfig(dir)).toEqual(EMPTY);
+    cleanup();
+  });
+
+  it("returns all-null for a missing file", () => {
+    const dir = tmp();
+    expect(loadDirConfig(dir)).toEqual(EMPTY);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns all-null for invalid JSON or a non-object", () => {
+    const bad = withConfig("{ not json");
+    expect(loadDirConfig(bad.dir)).toEqual(EMPTY);
+    bad.cleanup();
+    const arr = withConfig([1, 2, 3]);
+    expect(loadDirConfig(arr.dir)).toEqual(EMPTY);
+    arr.cleanup();
+  });
+});
+
+describe("publicDirConfig / dirSoundFile", () => {
+  it("exposes hasSound but not the raw path", () => {
+    const { dir, cleanup } = withConfig({ name: "x", sound: "./a.mp3" });
+    writeFileSync(path.join(dir, "a.mp3"), "x");
+    expect(publicDirConfig(dir)).toEqual({ name: "x", badgeColor: null, theme: null, hasSound: true });
+    expect(dirSoundFile(dir)).toBe(path.join(dir, "a.mp3"));
+    cleanup();
+  });
+
+  it("reports hasSound false when the sound is missing", () => {
+    const { dir, cleanup } = withConfig({ sound: "./gone.mp3" });
+    expect(publicDirConfig(dir).hasSound).toBe(false);
+    expect(dirSoundFile(dir)).toBeNull();
+    cleanup();
+  });
+});

--- a/server/dir-config.spec.ts
+++ b/server/dir-config.spec.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile } from "./dir-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
-const EMPTY = { name: null, badgeColor: null, theme: null, sound: null };
+const EMPTY = { name: null, badgeColor: null, theme: null, colors: null, sound: null };
 
 function withConfig(body: unknown): { dir: string; cleanup: () => void } {
   const dir = tmp();
@@ -71,7 +71,21 @@ describe("loadDirConfig", () => {
   it("loads and sanitizes a full config", () => {
     const { dir, cleanup } = withConfig({ name: "  PROD  ", badgeColor: "#CF222E", theme: "nord", sound: "./a.mp3" });
     writeFileSync(path.join(dir, "a.mp3"), "x");
-    expect(loadDirConfig(dir)).toEqual({ name: "PROD", badgeColor: "#cf222e", theme: "nord", sound: path.join(dir, "a.mp3") });
+    expect(loadDirConfig(dir)).toEqual({ name: "PROD", badgeColor: "#cf222e", theme: "nord", colors: null, sound: path.join(dir, "a.mp3") });
+    cleanup();
+  });
+
+  it("keeps known palette colors and drops unknown keys / bad values", () => {
+    const { dir, cleanup } = withConfig({
+      colors: { background: "#190A23", cursor: "#FFF", foreground: "rgb(1,2,3)", bogus: "#000000", red: "# abc" },
+    });
+    expect(loadDirConfig(dir).colors).toEqual({ background: "#190a23", cursor: "#fff" });
+    cleanup();
+  });
+
+  it("nulls a colors block with nothing valid", () => {
+    const { dir, cleanup } = withConfig({ colors: { nope: "#fff", foreground: "red" } });
+    expect(loadDirConfig(dir).colors).toBeNull();
     cleanup();
   });
 
@@ -107,7 +121,7 @@ describe("publicDirConfig / dirSoundFile", () => {
   it("exposes hasSound but not the raw path", () => {
     const { dir, cleanup } = withConfig({ name: "x", sound: "./a.mp3" });
     writeFileSync(path.join(dir, "a.mp3"), "x");
-    expect(publicDirConfig(dir)).toEqual({ name: "x", badgeColor: null, theme: null, hasSound: true });
+    expect(publicDirConfig(dir)).toEqual({ name: "x", badgeColor: null, theme: null, colors: null, hasSound: true });
     expect(dirSoundFile(dir)).toBe(path.join(dir, "a.mp3"));
     cleanup();
   });

--- a/server/dir-config.spec.ts
+++ b/server/dir-config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile } from "./dir-config";
@@ -55,6 +55,24 @@ describe("resolveDirSound", () => {
     writeFileSync(path.join(sibling, "a.mp3"), "x");
     expect(resolveDirSound(dir, "../app-evil/a.mp3")).toBeNull();
     rmSync(parent, { recursive: true, force: true });
+  });
+
+  it("rejects a symlink inside cwd that points outside it", () => {
+    const parent = tmp();
+    const dir = path.join(parent, "project");
+    mkdirSync(dir);
+    writeFileSync(path.join(parent, "outside.mp3"), "x"); // target lives OUTSIDE the dir
+    symlinkSync(path.join(parent, "outside.mp3"), path.join(dir, "link.mp3"));
+    expect(resolveDirSound(dir, "./link.mp3")).toBeNull();
+    rmSync(parent, { recursive: true, force: true });
+  });
+
+  it("allows a symlink that still resolves inside cwd", () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, "real.mp3"), "x");
+    symlinkSync(path.join(dir, "real.mp3"), path.join(dir, "link.mp3"));
+    expect(resolveDirSound(dir, "./link.mp3")).toBe(path.join(dir, "link.mp3"));
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("returns null for a missing file or non-string input", () => {

--- a/server/dir-config.ts
+++ b/server/dir-config.ts
@@ -4,7 +4,7 @@
 // terminal falls back to the global theme/sound. Extracted so the sanitize/confine
 // logic is unit-testable and the path-confinement check (the security surface) has a
 // clear home.
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import path from "node:path";
 
 // Mirrors the theme ids in src/composables/useTheme.ts. The server can't import the
@@ -93,19 +93,27 @@ function sanitizeColors(input: unknown): Record<string, string> | null {
   return Object.keys(out).length ? out : null;
 }
 
+const isInside = (base: string, target: string): boolean => target === base || target.startsWith(base + path.sep);
+
 // Confine the configured sound to a real file INSIDE cwd. Relative paths only;
 // anything absolute or escaping via "../" is rejected so an opened project can't
-// point the player at arbitrary files on disk. (path.resolve doesn't follow
-// symlinks — acceptable here: cwd is the user's own project dir, not hostile input.)
+// point the player at arbitrary files on disk. The lexical check only constrains the
+// path string, so we ALSO canonicalize with realpath and re-check — otherwise a file
+// inside cwd that is a symlink to a target outside it would slip through.
 export function resolveDirSound(cwd: string, input: unknown): string | null {
   if (typeof input !== "string") return null;
   const rel = input.trim();
   if (!rel || path.isAbsolute(rel)) return null;
   const base = path.resolve(cwd);
   const resolved = path.resolve(base, rel);
-  const withinBase = resolved === base || resolved.startsWith(base + path.sep);
-  if (!withinBase) return null;
-  return existsSync(resolved) && statSync(resolved).isFile() ? resolved : null;
+  if (!isInside(base, resolved)) return null;
+  if (!existsSync(resolved) || !statSync(resolved).isFile()) return null;
+  try {
+    if (!isInside(realpathSync(base), realpathSync(resolved))) return null;
+  } catch {
+    return null;
+  }
+  return resolved;
 }
 
 const EMPTY: DirConfig = { name: null, badgeColor: null, theme: null, colors: null, sound: null };

--- a/server/dir-config.ts
+++ b/server/dir-config.ts
@@ -1,0 +1,92 @@
+// Per-directory overrides read from <cwd>/.mulmoterminal.json: a terminal opened in
+// a directory can carry its own xterm palette, a badge label/color, and an attention
+// sound. Every field is optional; a missing or malformed file yields all-null so the
+// terminal falls back to the global theme/sound. Extracted so the sanitize/confine
+// logic is unit-testable and the path-confinement check (the security surface) has a
+// clear home.
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+// Mirrors the theme ids in src/composables/useTheme.ts. The server can't import the
+// Vue composable, so the whitelist is duplicated here — keep the two in sync.
+export type ThemeId = "midnight" | "nord" | "daylight" | "solarized";
+const THEME_IDS: readonly ThemeId[] = ["midnight", "nord", "daylight", "solarized"];
+
+const DIR_CONFIG_FILE = ".mulmoterminal.json";
+const NAME_MAX_CHARS = 40;
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export interface DirConfig {
+  name: string | null;
+  badgeColor: string | null;
+  theme: ThemeId | null;
+  // Absolute path to the attention sound, resolved within cwd; null when unset or the
+  // configured path is absolute / escapes the directory / doesn't exist.
+  sound: string | null;
+}
+
+// What the browser receives: the raw sound path stays server-side (streamed via
+// /api/dir-sound), so the client only learns whether one exists.
+export interface PublicDirConfig {
+  name: string | null;
+  badgeColor: string | null;
+  theme: ThemeId | null;
+  hasSound: boolean;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const isThemeId = (v: unknown): v is ThemeId => typeof v === "string" && THEME_IDS.some((id) => id === v);
+
+function sanitizeName(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  return trimmed ? trimmed.slice(0, NAME_MAX_CHARS) : null;
+}
+
+function sanitizeColor(input: unknown): string | null {
+  return typeof input === "string" && HEX_COLOR_RE.test(input.trim()) ? input.trim().toLowerCase() : null;
+}
+
+// Confine the configured sound to a real file INSIDE cwd. Relative paths only;
+// anything absolute or escaping via "../" is rejected so an opened project can't
+// point the player at arbitrary files on disk. (path.resolve doesn't follow
+// symlinks — acceptable here: cwd is the user's own project dir, not hostile input.)
+export function resolveDirSound(cwd: string, input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const rel = input.trim();
+  if (!rel || path.isAbsolute(rel)) return null;
+  const base = path.resolve(cwd);
+  const resolved = path.resolve(base, rel);
+  const withinBase = resolved === base || resolved.startsWith(base + path.sep);
+  if (!withinBase) return null;
+  return existsSync(resolved) && statSync(resolved).isFile() ? resolved : null;
+}
+
+const EMPTY: DirConfig = { name: null, badgeColor: null, theme: null, sound: null };
+
+export function loadDirConfig(cwd: string): DirConfig {
+  try {
+    const base = path.resolve(cwd);
+    const file = path.join(base, DIR_CONFIG_FILE);
+    if (!existsSync(file)) return EMPTY;
+    const raw: unknown = JSON.parse(readFileSync(file, "utf8"));
+    if (!isRecord(raw)) return EMPTY;
+    return {
+      name: sanitizeName(raw.name),
+      badgeColor: sanitizeColor(raw.badgeColor),
+      theme: isThemeId(raw.theme) ? raw.theme : null,
+      sound: resolveDirSound(base, raw.sound),
+    };
+  } catch {
+    return EMPTY;
+  }
+}
+
+export function publicDirConfig(cwd: string): PublicDirConfig {
+  const { name, badgeColor, theme, sound } = loadDirConfig(cwd);
+  return { name, badgeColor, theme, hasSound: sound !== null };
+}
+
+export function dirSoundFile(cwd: string): string | null {
+  return loadDirConfig(cwd).sound;
+}

--- a/server/dir-config.ts
+++ b/server/dir-config.ts
@@ -15,11 +15,44 @@ const THEME_IDS: readonly ThemeId[] = ["midnight", "nord", "daylight", "solarize
 const DIR_CONFIG_FILE = ".mulmoterminal.json";
 const NAME_MAX_CHARS = 40;
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+// xterm accepts #rgb / #rgba / #rrggbb / #rrggbbaa for palette colors.
+const PALETTE_COLOR_RE = /^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+// The xterm ITheme keys a `colors` block may override (mirrors @xterm/xterm's
+// ITheme). Anything outside this set is dropped so an arbitrary JSON object can't
+// inject unexpected keys into the terminal options.
+const THEME_COLOR_KEYS: readonly string[] = [
+  "foreground",
+  "background",
+  "cursor",
+  "cursorAccent",
+  "selectionBackground",
+  "selectionForeground",
+  "selectionInactiveBackground",
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+  "brightBlack",
+  "brightRed",
+  "brightGreen",
+  "brightYellow",
+  "brightBlue",
+  "brightMagenta",
+  "brightCyan",
+  "brightWhite",
+];
 
 export interface DirConfig {
   name: string | null;
   badgeColor: string | null;
   theme: ThemeId | null;
+  // Per-key xterm palette overrides (on top of `theme`), or null when none are valid.
+  colors: Record<string, string> | null;
   // Absolute path to the attention sound, resolved within cwd; null when unset or the
   // configured path is absolute / escapes the directory / doesn't exist.
   sound: string | null;
@@ -31,6 +64,7 @@ export interface PublicDirConfig {
   name: string | null;
   badgeColor: string | null;
   theme: ThemeId | null;
+  colors: Record<string, string> | null;
   hasSound: boolean;
 }
 
@@ -45,6 +79,18 @@ function sanitizeName(input: unknown): string | null {
 
 function sanitizeColor(input: unknown): string | null {
   return typeof input === "string" && HEX_COLOR_RE.test(input.trim()) ? input.trim().toLowerCase() : null;
+}
+
+// Keep only known ITheme keys whose value is a valid palette color; drop the rest.
+// null when nothing valid remains, so an empty/garbage block behaves like "unset".
+function sanitizeColors(input: unknown): Record<string, string> | null {
+  if (!isRecord(input)) return null;
+  const out: Record<string, string> = {};
+  for (const key of THEME_COLOR_KEYS) {
+    const value = input[key];
+    if (typeof value === "string" && PALETTE_COLOR_RE.test(value.trim())) out[key] = value.trim().toLowerCase();
+  }
+  return Object.keys(out).length ? out : null;
 }
 
 // Confine the configured sound to a real file INSIDE cwd. Relative paths only;
@@ -62,7 +108,7 @@ export function resolveDirSound(cwd: string, input: unknown): string | null {
   return existsSync(resolved) && statSync(resolved).isFile() ? resolved : null;
 }
 
-const EMPTY: DirConfig = { name: null, badgeColor: null, theme: null, sound: null };
+const EMPTY: DirConfig = { name: null, badgeColor: null, theme: null, colors: null, sound: null };
 
 export function loadDirConfig(cwd: string): DirConfig {
   try {
@@ -75,6 +121,7 @@ export function loadDirConfig(cwd: string): DirConfig {
       name: sanitizeName(raw.name),
       badgeColor: sanitizeColor(raw.badgeColor),
       theme: isThemeId(raw.theme) ? raw.theme : null,
+      colors: sanitizeColors(raw.colors),
       sound: resolveDirSound(base, raw.sound),
     };
   } catch {
@@ -83,8 +130,8 @@ export function loadDirConfig(cwd: string): DirConfig {
 }
 
 export function publicDirConfig(cwd: string): PublicDirConfig {
-  const { name, badgeColor, theme, sound } = loadDirConfig(cwd);
-  return { name, badgeColor, theme, hasSound: sound !== null };
+  const { name, badgeColor, theme, colors, sound } = loadDirConfig(cwd);
+  return { name, badgeColor, theme, colors, hasSound: sound !== null };
 }
 
 export function dirSoundFile(cwd: string): string | null {

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes } from "./config-routes.js";
+import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { isRecord, parseJsonl, userPromptText, latestMeaningfulUserPromptFromJsonl, preferredHeaderPrompt } from "./transcript.js";
@@ -413,6 +414,10 @@ function publishActivity(id: string) {
   const a = activity.get(id) || {};
   pubsub?.publish(SESSIONS_CHANNEL, {
     id,
+    // The session's working dir, so the attention-sound player can pick up that
+    // directory's custom sound (<cwd>/.mulmoterminal.json). Null for a session with
+    // no live PTY (a reaped background worker).
+    cwd: ptys.get(id)?.cwd ?? null,
     working: a.working ?? false,
     waiting: a.waiting ?? false,
     event: a.event ?? null,
@@ -904,6 +909,30 @@ app.get("/api/session/:id", async (req, res) => {
     working: a.working ?? false,
     waiting: a.waiting ?? false,
     lastPrompt,
+  });
+});
+
+// Per-directory overrides (<cwd>/.mulmoterminal.json): the badge/name/theme a
+// terminal opened in this directory should use. cwd is validated like every other
+// cwd-scoped route; the raw sound path stays server-side (see /api/dir-sound).
+app.get("/api/dir-config", (req, res) => {
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  res.json(publicDirConfig(cwd));
+});
+
+// Stream a directory's custom attention sound. The path never comes from the
+// request — it's read from that dir's .mulmoterminal.json and confined to the dir —
+// so there's no traversal surface. 404 when unset/missing (the client falls back to
+// the global sound, then the built-in chime).
+app.get("/api/dir-sound", (req, res) => {
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  const file = dirSoundFile(cwd);
+  if (!file) return res.status(404).end();
+  // dotfiles:"allow" — the conventional location is a hidden <cwd>/.mulmoterminal/
+  // dir, which send() would otherwise 404. The path is already confined to cwd, so
+  // serving from a dot-segment is safe here.
+  res.sendFile(file, { dotfiles: "allow" }, (err) => {
+    if (err && !res.headersSent) res.status(404).end();
   });
 });
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,7 @@ import { useCollectionBrowse, browseGotoIndex, browseGotoDetail, browseClose } f
 import { useAccountingView, accountingViewOpen, accountingViewClose } from "./composables/useAccountingView";
 import { registerChatOpener } from "./composables/useChatLauncher";
 import { useAppConfig } from "./composables/useAppConfig";
+import { useDirConfig } from "./composables/useDirConfig";
 import { usePendingScript, type PendingCommand } from "./composables/usePendingScript";
 import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
@@ -155,7 +156,10 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (directory presets + theme), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets, saveSound } = useAppConfig();
+const { defaultCwd, presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets, saveSound } = useAppConfig();
+// The single view runs in the server's default project dir; pick up that dir's
+// .mulmoterminal.json so its theme/badge match the grid cells for the same dir.
+const { config: singleDirConfig } = useDirConfig(defaultCwd);
 const showSettings = ref(false);
 onMounted(loadConfig);
 async function savePresets(next: CwdPreset[]) {
@@ -306,6 +310,9 @@ function onSession(id: string) {
           :style="{ flex: `0 0 ${terminalWidth}px` }"
           :session-id="activeId"
           :connect-key="connectKey"
+          :dir-theme="singleDirConfig.theme"
+          :dir-name="singleDirConfig.name"
+          :dir-badge-color="singleDirConfig.badgeColor"
           run-menu
           @session="onSession"
           @run="onRunScript"

--- a/src/App.vue
+++ b/src/App.vue
@@ -157,9 +157,13 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 // Settings (directory presets + theme), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
 const { defaultCwd, presets, saving: savingSettings, error: settingsError, loadConfig, savePresets: persistPresets, saveSound } = useAppConfig();
-// The single view runs in the server's default project dir; pick up that dir's
-// .mulmoterminal.json so its theme/badge match the grid cells for the same dir.
-const { config: singleDirConfig } = useDirConfig(defaultCwd);
+// Drive the single view's dir overrides off the dir the terminal ACTUALLY runs in
+// (reported by the server, which may resolve/fall back), not the static default — so
+// the badge/theme/colors always track the active session. Falls back to the default
+// until the terminal reports its cwd.
+const activeCwd = ref<string | null>(null);
+const effectiveCwd = computed(() => activeCwd.value ?? defaultCwd.value);
+const { config: singleDirConfig } = useDirConfig(effectiveCwd);
 const showSettings = ref(false);
 onMounted(loadConfig);
 async function savePresets(next: CwdPreset[]) {
@@ -316,6 +320,7 @@ function onSession(id: string) {
           :dir-badge-color="singleDirConfig.badgeColor"
           run-menu
           @session="onSession"
+          @cwd="(c) => (activeCwd = c)"
           @run="onRunScript"
         />
         <div

--- a/src/App.vue
+++ b/src/App.vue
@@ -311,6 +311,7 @@ function onSession(id: string) {
           :session-id="activeId"
           :connect-key="connectKey"
           :dir-theme="singleDirConfig.theme"
+          :dir-colors="singleDirConfig.colors"
           :dir-name="singleDirConfig.name"
           :dir-badge-color="singleDirConfig.badgeColor"
           run-menu

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from "vue";
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
@@ -32,8 +32,10 @@ const props = defineProps<{
   runMenu?: boolean;
   // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
   // terminal's xterm palette (overriding the app-wide theme for this cell only);
-  // `dirName` / `dirBadgeColor` render a project badge in the header.
+  // `dirColors` overrides individual palette keys on top of that; `dirName` /
+  // `dirBadgeColor` render a project badge in the header.
   dirTheme?: ThemeId | null;
+  dirColors?: Partial<ITheme> | null;
   dirName?: string | null;
   dirBadgeColor?: string | null;
 }>();
@@ -51,9 +53,12 @@ const serverCwd = ref<string | null>(props.cwd ?? null);
 const dragOver = ref(false);
 const { themeId } = useTheme();
 
-// A dir-pinned theme wins over the app-wide selection for this terminal's canvas.
-function effectiveTermTheme() {
-  return props.dirTheme ? termThemeFor(props.dirTheme) : currentTermTheme();
+// A dir-pinned theme wins over the app-wide selection for this terminal's canvas,
+// then per-key `dirColors` override on top (so a dir can tweak just the background
+// without restating a whole palette).
+function effectiveTermTheme(): ITheme {
+  const base = props.dirTheme ? termThemeFor(props.dirTheme) : currentTermTheme();
+  return props.dirColors ? { ...base, ...props.dirColors } : base;
 }
 const dirBadgeStyle = computed(() => badgeStyleFor(props.dirBadgeColor));
 
@@ -260,7 +265,7 @@ watch(
 // xterm can't read CSS variables, so repaint its canvas palette when the theme
 // changes (keeps an already-open terminal in sync with the rest of the app). A
 // dir-pinned theme ignores the app-wide change; a change to the pin itself repaints.
-watch([themeId, () => props.dirTheme], () => {
+watch([themeId, () => props.dirTheme, () => props.dirColors], () => {
   if (term) term.options.theme = effectiveTermTheme();
 });
 

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl, buildRunWsUrl } from "./wsUrl";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
-import { useTheme, currentTermTheme } from "../composables/useTheme";
+import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
+import { badgeStyleFor } from "./dirBadge";
 import { useVoiceInput } from "../composables/useVoiceInput";
 import RunMenu from "./RunMenu.vue";
 
@@ -29,6 +30,12 @@ const props = defineProps<{
   devTerminal?: boolean;
   command?: { index: number } | null;
   runMenu?: boolean;
+  // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
+  // terminal's xterm palette (overriding the app-wide theme for this cell only);
+  // `dirName` / `dirBadgeColor` render a project badge in the header.
+  dirTheme?: ThemeId | null;
+  dirName?: string | null;
+  dirBadgeColor?: string | null;
 }>();
 const emit = defineEmits<{
   (e: "session" | "cwd", value: string): void;
@@ -43,6 +50,12 @@ const status = ref<"connecting" | "connected" | "disconnected">("connecting");
 const serverCwd = ref<string | null>(props.cwd ?? null);
 const dragOver = ref(false);
 const { themeId } = useTheme();
+
+// A dir-pinned theme wins over the app-wide selection for this terminal's canvas.
+function effectiveTermTheme() {
+  return props.dirTheme ? termThemeFor(props.dirTheme) : currentTermTheme();
+}
+const dirBadgeStyle = computed(() => badgeStyleFor(props.dirBadgeColor));
 
 // Voice input: a mic in the header transcribes speech (locally, via whisper.cpp)
 // and inserts it at the prompt for the user to review and submit — same channel as
@@ -196,7 +209,7 @@ onMounted(() => {
     cursorBlink: true,
     fontSize: 14,
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
-    theme: currentTermTheme(),
+    theme: effectiveTermTheme(),
   });
 
   fitAddon = new FitAddon();
@@ -245,9 +258,10 @@ watch(
 );
 
 // xterm can't read CSS variables, so repaint its canvas palette when the theme
-// changes (keeps an already-open terminal in sync with the rest of the app).
-watch(themeId, () => {
-  if (term) term.options.theme = currentTermTheme();
+// changes (keeps an already-open terminal in sync with the rest of the app). A
+// dir-pinned theme ignores the app-wide change; a change to the pin itself repaints.
+watch([themeId, () => props.dirTheme], () => {
+  if (term) term.options.theme = effectiveTermTheme();
 });
 
 // Submit a GUI-originated message into the PTY (same channel as keyboard input).
@@ -338,6 +352,7 @@ onUnmounted(() => {
   <div class="terminal-wrapper">
     <div class="header">
       <span class="title">Terminal</span>
+      <span v-if="dirName" class="dir-badge" :style="dirBadgeStyle" :title="dirName">{{ dirName }}</span>
       <span :class="['status', status]">{{ status }}</span>
       <RunMenu v-if="runMenu" :cwd="serverCwd" @run="(c) => emit('run', c)" />
       <div class="header-actions">
@@ -384,6 +399,19 @@ onUnmounted(() => {
 
 .title {
   font-weight: 600;
+}
+
+/* Project badge from <cwd>/.mulmoterminal.json — a per-directory identity chip. */
+.dir-badge {
+  max-width: 16ch;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .header-actions {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -693,6 +693,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :connect-key="connectKey"
         :cwd="cwd"
         :dir-theme="dirConfig.theme"
+        :dir-colors="dirConfig.colors"
         dev-terminal
         run-menu
         @session="onSession"

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -2,7 +2,9 @@
 import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vue";
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
+import { useDirConfig } from "../composables/useDirConfig";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
+import { badgeStyleFor } from "./dirBadge";
 import type { CwdPreset } from "./presets";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
@@ -38,6 +40,10 @@ const connectKey = ref(0);
 
 // The directory this terminal runs in (shown in the header, sent to the server).
 const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
+// Per-directory overrides (<cwd>/.mulmoterminal.json): pins this cell's terminal
+// palette and shows a project badge. Re-fetched when the effective cwd changes.
+const { config: dirConfig } = useDirConfig(cwd);
+const dirBadgeStyle = computed(() => badgeStyleFor(dirConfig.value.badgeColor));
 // The launch form's editable dir; prefilled with the default once it's fetched.
 const dirInput = ref(props.initialCwd ?? props.defaultCwd ?? "");
 watch(
@@ -639,6 +645,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
         </button>
+        <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
         <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
           <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
           <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
@@ -685,6 +692,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :session-id="sessionId"
         :connect-key="connectKey"
         :cwd="cwd"
+        :dir-theme="dirConfig.theme"
         dev-terminal
         run-menu
         @session="onSession"
@@ -908,6 +916,19 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 }
 .cell-dir-path {
   unicode-bidi: plaintext;
+}
+/* Project badge from <cwd>/.mulmoterminal.json — a per-directory identity chip. */
+.cell-badge {
+  flex: 0 0 auto;
+  max-width: 14ch;
+  padding: 1px 7px;
+  border-radius: 10px;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .cell-dir:hover {
   color: var(--text-muted);

--- a/src/components/dirBadge.ts
+++ b/src/components/dirBadge.ts
@@ -1,0 +1,20 @@
+// Inline style for a directory's name badge: the configured color as the
+// background, with black or white text picked for contrast. Shared by the single
+// view (Terminal header) and the grid (cell header) so the badge looks the same in
+// both. A null/missing color falls back to a neutral panel chip.
+
+// sRGB relative luminance (WCAG): bright backgrounds get dark text, dark ones light.
+function isLight(hex: string): boolean {
+  const n = parseInt(hex.slice(1), 16);
+  const [r, g, b] = [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  return 0.299 * r + 0.587 * g + 0.114 * b > 150;
+}
+
+const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
+
+export function badgeStyleFor(color: string | null | undefined): Record<string, string> {
+  if (!color || !HEX_COLOR_RE.test(color)) {
+    return { background: "var(--bg-elevated)", color: "var(--text-secondary)" };
+  }
+  return { background: color, color: isLight(color) ? "#000" : "#fff" };
+}

--- a/src/composables/useAttentionSound.ts
+++ b/src/composables/useAttentionSound.ts
@@ -5,6 +5,8 @@ interface ActivityMsg {
   id: string;
   working?: boolean;
   waiting?: boolean;
+  // The session's working dir, so a beep can use that directory's custom sound.
+  cwd?: string | null;
 }
 interface ActivityState {
   working: boolean;
@@ -120,6 +122,50 @@ function playBuffer(buf: AudioBuffer) {
   src.start();
 }
 
+// A directory's own attention sound (<cwd>/.mulmoterminal.json), decoded once and
+// cached by cwd. `undefined` = not checked yet; `null` = checked, no sound (so we
+// never refetch a dir that has none). Streamed from /api/dir-sound?cwd=<cwd>.
+const dirBuffers = new Map<string, AudioBuffer | null>();
+const dirLoading = new Map<string, Promise<void>>();
+
+function loadDirSound(cwd: string): Promise<void> {
+  if (dirBuffers.has(cwd)) return Promise.resolve();
+  const existing = dirLoading.get(cwd);
+  if (existing) return existing;
+  const loading = (async () => {
+    const ctx = getCtx();
+    if (!ctx) return; // can't decode without an AudioContext — leave unknown to retry
+    let decoded: AudioBuffer | null = null;
+    try {
+      const res = await fetch(`/api/dir-sound?cwd=${encodeURIComponent(cwd)}`);
+      if (res.ok) decoded = await ctx.decodeAudioData(await res.arrayBuffer());
+    } catch {
+      decoded = null; // 404 / unreadable / not audio — the dir has no usable sound
+    }
+    dirBuffers.set(cwd, decoded);
+  })();
+  dirLoading.set(
+    cwd,
+    loading.finally(() => dirLoading.delete(cwd)),
+  );
+  return loading;
+}
+
+// Play the attention sound, preferring the session directory's own sound, then the
+// user's global custom file, then the chime. A dir sound not yet decoded is loaded in
+// the background (this beep falls back), so later beeps for that dir use it.
+export function playAttentionFor(cwd: string | null, soundFile: string | null) {
+  if (cwd) {
+    const buf = dirBuffers.get(cwd);
+    if (buf) {
+      playBuffer(buf);
+      return;
+    }
+    if (buf === undefined) loadDirSound(cwd);
+  }
+  playAttention(soundFile);
+}
+
 // Play the attention sound: the user's custom file when configured AND already
 // loaded, otherwise the built-in chime. A newly-configured file is loaded in the
 // background, so the first beep uses the chime and later ones the custom sound.
@@ -158,7 +204,7 @@ export function useAttentionSound(enabled: Ref<boolean>, soundFile?: Ref<string 
   const prev = new Map<string, ActivityState>();
   const { subscribe } = usePubSub();
   const unsubscribe = subscribe("sessions", (d) => {
-    if (isActivityMsg(d) && needsAttention(prev, d) && enabled.value) playAttention(soundFile?.value ?? null);
+    if (isActivityMsg(d) && needsAttention(prev, d) && enabled.value) playAttentionFor(d.cwd ?? null, soundFile?.value ?? null);
   });
   onUnmounted(unsubscribe);
 }

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -1,4 +1,5 @@
 import { ref, watch, type Ref } from "vue";
+import type { ITheme } from "@xterm/xterm";
 import { isThemeId, type ThemeId } from "./useTheme";
 
 // The per-directory overrides a terminal adopts when its cwd holds a
@@ -8,10 +9,50 @@ export interface DirConfig {
   name: string | null;
   badgeColor: string | null;
   theme: ThemeId | null;
+  // Per-key xterm palette overrides applied on top of `theme` (or the app theme).
+  colors: Partial<ITheme> | null;
   hasSound: boolean;
 }
 
-const EMPTY: DirConfig = { name: null, badgeColor: null, theme: null, hasSound: false };
+const EMPTY: DirConfig = { name: null, badgeColor: null, theme: null, colors: null, hasSound: false };
+
+// The ITheme keys a dir may override; values arrive server-sanitized but are
+// re-checked here so a hand-rolled response can't widen the terminal options.
+const THEME_COLOR_KEYS = [
+  "foreground",
+  "background",
+  "cursor",
+  "cursorAccent",
+  "selectionBackground",
+  "selectionForeground",
+  "selectionInactiveBackground",
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+  "brightBlack",
+  "brightRed",
+  "brightGreen",
+  "brightYellow",
+  "brightBlue",
+  "brightMagenta",
+  "brightCyan",
+  "brightWhite",
+] as const;
+
+function parseColors(input: unknown): Partial<ITheme> | null {
+  if (!isRecord(input)) return null;
+  const out: Partial<ITheme> = {};
+  for (const key of THEME_COLOR_KEYS) {
+    const value = input[key];
+    if (typeof value === "string") out[key] = value;
+  }
+  return Object.keys(out).length ? out : null;
+}
 
 // One fetch per cwd, shared across cells: several terminals in the same directory
 // resolve to one request, and the config is stable for the page's lifetime (changes
@@ -26,6 +67,7 @@ function parse(c: unknown): DirConfig {
     name: typeof c.name === "string" ? c.name : null,
     badgeColor: typeof c.badgeColor === "string" ? c.badgeColor : null,
     theme: isThemeId(c.theme) ? c.theme : null,
+    colors: parseColors(c.colors),
     hasSound: c.hasSound === true,
   };
 }

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -1,0 +1,65 @@
+import { ref, watch, type Ref } from "vue";
+import { isThemeId, type ThemeId } from "./useTheme";
+
+// The per-directory overrides a terminal adopts when its cwd holds a
+// `.mulmoterminal.json` (served by GET /api/dir-config). The raw sound path stays
+// server-side; `hasSound` says whether GET /api/dir-sound has something to stream.
+export interface DirConfig {
+  name: string | null;
+  badgeColor: string | null;
+  theme: ThemeId | null;
+  hasSound: boolean;
+}
+
+const EMPTY: DirConfig = { name: null, badgeColor: null, theme: null, hasSound: false };
+
+// One fetch per cwd, shared across cells: several terminals in the same directory
+// resolve to one request, and the config is stable for the page's lifetime (changes
+// to the file take effect on the next page load — MVP, no live watch).
+const cache = new Map<string, Promise<DirConfig>>();
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+function parse(c: unknown): DirConfig {
+  if (!isRecord(c)) return EMPTY;
+  return {
+    name: typeof c.name === "string" ? c.name : null,
+    badgeColor: typeof c.badgeColor === "string" ? c.badgeColor : null,
+    theme: isThemeId(c.theme) ? c.theme : null,
+    hasSound: c.hasSound === true,
+  };
+}
+
+export function fetchDirConfig(cwd: string): Promise<DirConfig> {
+  const cached = cache.get(cwd);
+  if (cached) return cached;
+  const pending = (async () => {
+    try {
+      const res = await fetch(`/api/dir-config?cwd=${encodeURIComponent(cwd)}`);
+      return res.ok ? parse(await res.json()) : EMPTY;
+    } catch {
+      return EMPTY;
+    }
+  })();
+  cache.set(cwd, pending);
+  return pending;
+}
+
+// Reactive dir config for a (possibly changing) cwd. Resets to empty while no cwd is
+// set so a cell that switches directories never shows a stale badge/theme.
+export function useDirConfig(cwd: Ref<string | null | undefined>) {
+  const config = ref<DirConfig>(EMPTY);
+  watch(
+    cwd,
+    async (c) => {
+      if (!c) {
+        config.value = EMPTY;
+        return;
+      }
+      const resolved = await fetchDirConfig(c);
+      if (cwd.value === c) config.value = resolved; // ignore a stale resolve after a fast switch
+    },
+    { immediate: true },
+  );
+  return { config };
+}

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -87,8 +87,8 @@ export const THEMES: Theme[] = [
 const STORAGE_KEY = "theme";
 const DEFAULT_THEME: ThemeId = "midnight";
 
-function isThemeId(value: string | null): value is ThemeId {
-  return value !== null && THEMES.some((t) => t.id === value);
+export function isThemeId(value: unknown): value is ThemeId {
+  return typeof value === "string" && THEMES.some((t) => t.id === value);
 }
 
 // Storage access can throw (private mode / sandboxed contexts with storage
@@ -113,6 +113,12 @@ function applyTheme(id: ThemeId) {
 // terminal's `theme` option and refreshes it whenever the theme changes.
 export function currentTermTheme(): Theme["term"] {
   return (THEMES.find((t) => t.id === themeId.value) ?? THEMES[0]).term;
+}
+
+// The xterm palette for a specific theme — used by a terminal whose directory pins a
+// theme via .mulmoterminal.json (overriding the user's app-wide choice for that cell).
+export function termThemeFor(id: ThemeId): Theme["term"] {
+  return (THEMES.find((t) => t.id === id) ?? THEMES[0]).term;
 }
 
 // Called from main.ts before mount so the persisted theme is on <html> before


### PR DESCRIPTION
## Summary

各ディレクトリに `.mulmoterminal.json` を置くと、そのdirで開いた端末の **色（テーマ）・注目サウンド・プロジェクト名／バッジ** をカスタマイズできるようにする per-directory 設定レイヤを追加。色は**その端末セルのみ**に適用（アプリ全体のクロームは不変）、dir の `theme` は手動テーマ選択より優先（該当セルのみ）。

```jsonc
// <project>/.mulmoterminal.json （全フィールド任意）
{
  "name": "PROD · payments",            // UIに出すバッジ
  "badgeColor": "#cf222e",              // バッジ色（hex #rrggbb・テキストは自動コントラスト）
  "theme": "nord",                      // 端末パレット（midnight | nord | daylight | solarized）
  "sound": "./.mulmoterminal/alert.mp3" // 注目サウンド（このdir配下の相対パスのみ）
}
```

## Items to Confirm / Review

- **セキュリティ（最重要）**: サウンドは **dir内相対パスのみ**。`path.resolve(cwd, sound)` が cwd 配下に収まることを検証し、絶対パス・`..` 脱出・接頭辞一致のすり抜け（`app` → `app-evil`）を拒否（`server/dir-config.spec.ts` でテスト）。配信パスはHTTPリクエストに乗せず、サーバが `.mulmoterminal.json` から引く。
- **dotfile配信**: 慣例的な置き場所 `<cwd>/.mulmoterminal/` は隠しディレクトリのため、Express `sendFile` が既定で 404 になる問題を実機検証で発見。`dotfiles:"allow"`（＋エラー時404フォールバック）で対応。cwd内に confine 済みのため安全。妥当か確認ください。
- **テーマidの二重定義**: サーバは Vue composable を import できないため、テーマidのホワイトリストを `server/dir-config.ts` にも持っています（`useTheme.ts` と要同期）。
- **優先順位**: dir `theme` > 手動選択（該当セルのみ）。サウンドは dir音 > グローバル `soundFile` > 合成チャイム。
- **適用粒度**: 端末セル単位（グリッドで複数dirが同時に並んでも矛盾しない）。アプリ全体のクロームは変えない。
- **MVP範囲**: ファイル監視なし。変更は端末の開き直しで反映。
- **ブラウザ未検証**: バッジ・パレットの見た目は `claude` セッション起動が必要なため目視確認は未実施。サーバー側の疎通・セキュリティは実機で確認済み（`/api/dir-config`・`/api/dir-sound`・トラバーサル拒否）。

## User Prompt

> dirごとに.mulmoterminal.jsonをおいておくと、色とかサウンドとかカスタムしたいよね！！

スコープ確認の回答:
- 対象: 端末の色／テーマ・注目サウンド・プロジェクト名／バッジ（自動実行は対象外）
- 色の適用範囲: その端末セルの色だけ変える
- 優先順位: dir設定が優先（手動テーマより `theme`）
- サウンド参照: プロジェクトdir内の相対パスのみ

## 実装

### サーバ
- `server/dir-config.ts`（新規・テスト）: `loadDirConfig` / `publicDirConfig`（`hasSound` のみ公開・生パス非公開）/ `dirSoundFile` / `resolveDirSound`（cwd内confine）。
- `server/index.ts`: `GET /api/dir-config?cwd=`・`GET /api/dir-sound?cwd=`（cwd は既存 `resolveWorkspace` で検証）。`publishActivity` の payload に `cwd` を追加。

### フロント
- `src/composables/useDirConfig.ts`（新規）: cwd ごとに取得・キャッシュ。
- `src/components/dirBadge.ts`（新規）: バッジ色→可読テキスト色（輝度判定）。
- `Terminal.vue` / `TerminalCell.vue` / `App.vue`: セル単位のパレット上書き（`termThemeFor`）＋名前バッジ（単一ビュー・グリッド両対応）。
- `useAttentionSound.ts`: セッションの `cwd` 別カスタム音（デコードを cwd でキャッシュ、未取得dirは当該ビープでフォールバックし次回以降に使用）。
- `useTheme.ts`: `termThemeFor` / `isThemeId` を公開。

### ドキュメント
- `README.md`: `.mulmoterminal.json` のスキーマ・優先順位・セキュリティ（相対パスのみ）を追記。

## 検証

- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck`（client+server）/ `yarn build` / `yarn test`（**425件全パス**）
- 実サーバーで `/api/dir-config` が正しい JSON を返すこと、`/api/dir-sound` がファイル配信（200）すること、`../secret.mp3` のトラバーサルが `hasSound:false`／404 で拒否されることを確認。

Closes #143
