### PR TITLE
feat: runtime translation service via hidden chat (POST /api/translation)

### DIFF
--- a/scripts/smoke-translation.mjs
+++ b/scripts/smoke-translation.mjs
@@ -1,0 +1,78 @@
+// LOCAL integration smoke for the runtime translation service (POST /api/translation).
+//
+// Unlike scripts/ci-ws-smoke.mjs, this exercises the REAL hidden-chat LLM path
+// (server/index.ts → translateViaHiddenChat spawns a real `claude` background
+// session), so it needs a working `claude` CLI + auth and is NOT part of CI (CI uses
+// a stub claude). Run it by hand against a server you started:
+//
+//   yarn server                                        # terminal 1 (real claude on PATH)
+//   MT_PORT=34567 node scripts/smoke-translation.mjs   # terminal 2
+//
+// CLAUDE_CWD must be a workspace claude already TRUSTS (the default ~/mulmoclaude is
+// fine) — the worker runs there, and claude blocks on its trust dialog in any
+// untrusted dir, so a throwaway `mktemp -d` workspace would hang.
+//
+// Asserts: a non-English target returns same-length, actually-translated strings;
+// the on-disk cache is written under <workspace>/data/translation; and a repeat call
+// is served from cache (fast). Exits non-zero on any failure.
+const port = process.env.MT_PORT ?? "34567";
+const base = `http://127.0.0.1:${port}`;
+const namespace = `smoke-${Date.now()}`; // fresh namespace so we always hit the LLM first
+const sentences = ["Save", "Delete this item", "Welcome, {name}!"];
+
+const fail = (msg) => {
+  console.log(`✗ translation: ${msg}`);
+  process.exit(1);
+};
+const ok = (msg) => console.log(`✓ ${msg}`);
+
+async function post(body) {
+  const res = await fetch(`${base}/api/translation`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, json };
+}
+
+// English short-circuits with no LLM call — should be instant and identity.
+const en = await post({ namespace, targetLanguage: "en", sentences });
+if (en.status !== 200 || JSON.stringify(en.json.translations) !== JSON.stringify(sentences)) {
+  fail(`English short-circuit failed: ${JSON.stringify(en.json)}`);
+}
+ok("English short-circuits to identity (no LLM)");
+
+// Real translation via the hidden chat. Generous wall-clock (cold claude startup).
+console.log(`… translating ${sentences.length} strings to Japanese via hidden chat (may take ~30s)…`);
+const t0 = Date.now();
+const ja = await post({ namespace, targetLanguage: "ja", sentences });
+const elapsed = Date.now() - t0;
+if (ja.status !== 200) fail(`ja request failed (HTTP ${ja.status}): ${JSON.stringify(ja.json)}`);
+const out = ja.json.translations;
+if (!Array.isArray(out) || out.length !== sentences.length) {
+  fail(`expected ${sentences.length} translations, got ${JSON.stringify(out)}`);
+}
+if (!out.every((s) => typeof s === "string" && s.length > 0)) fail(`non-string/empty translation: ${JSON.stringify(out)}`);
+// At least one should differ from the English source (i.e. it actually translated).
+if (!out.some((s, i) => s !== sentences[i])) fail(`output identical to input — did not translate: ${JSON.stringify(out)}`);
+// The placeholder must survive.
+if (!out[2].includes("{name}")) fail(`placeholder {name} not preserved: ${JSON.stringify(out[2])}`);
+ok(`translated in ${(elapsed / 1000).toFixed(1)}s → ${JSON.stringify(out)}`);
+
+// A repeat call must be served from the cache: fast and identical.
+const t1 = Date.now();
+const ja2 = await post({ namespace, targetLanguage: "ja", sentences });
+const cachedElapsed = Date.now() - t1;
+if (JSON.stringify(ja2.json.translations) !== JSON.stringify(out)) {
+  fail(`cached call differs from first: ${JSON.stringify(ja2.json.translations)}`);
+}
+if (cachedElapsed > 2000) fail(`cached call took ${cachedElapsed}ms — expected the LLM to be skipped`);
+ok(`repeat call served from cache in ${cachedElapsed}ms`);
+
+// Invalid input is a 400.
+const bad = await post({ namespace, targetLanguage: "not-a-locale", sentences });
+if (bad.status !== 400) fail(`expected 400 for invalid locale, got ${bad.status}`);
+ok("invalid input rejected with 400");
+
+console.log("✓ translation smoke passed");

--- a/server/backends/translation.spec.ts
+++ b/server/backends/translation.spec.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import express from "express";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { splitHitMiss, mergeTranslations, assembleResult, validateRequest, TranslationInputError, mountTranslationRoutes } from "./translation.js";
+
+describe("splitHitMiss", () => {
+  const dict = { sentences: { Hello: { ja: "こんにちは" }, Bye: { ja: "さようなら" } } };
+
+  it("partitions hits from distinct misses, preserving miss order", () => {
+    const { cached, misses } = splitHitMiss(dict, ["Hello", "New", "Other", "New"], "ja");
+    expect(cached.get("Hello")).toBe("こんにちは");
+    expect(misses).toEqual(["New", "Other"]); // deduped, in first-seen order
+  });
+
+  it("treats a different language as a full miss", () => {
+    const { cached, misses } = splitHitMiss(dict, ["Hello"], "fr");
+    expect(cached.size).toBe(0);
+    expect(misses).toEqual(["Hello"]);
+  });
+});
+
+describe("mergeTranslations", () => {
+  it("adds a new language without dropping existing ones", () => {
+    const dict = { sentences: { Hello: { ja: "こんにちは" } } };
+    const next = mergeTranslations(dict, "fr", new Map([["Hello", "Bonjour"]]));
+    expect(next.sentences.Hello).toEqual({ ja: "こんにちは", fr: "Bonjour" });
+  });
+
+  it("does not mutate the input dictionary", () => {
+    const dict = { sentences: { Hello: { ja: "こんにちは" } } };
+    mergeTranslations(dict, "fr", new Map([["Hello", "Bonjour"]]));
+    expect(dict.sentences.Hello).toEqual({ ja: "こんにちは" });
+  });
+
+  it("safely handles a __proto__ source key (no prototype pollution)", () => {
+    const next = mergeTranslations({ sentences: {} }, "ja", new Map([["__proto__", "x"]]));
+    expect(Object.hasOwn(next.sentences, "__proto__")).toBe(true);
+    expect(({} as Record<string, unknown>).ja).toBeUndefined();
+  });
+});
+
+describe("assembleResult", () => {
+  it("reassembles input order from cache hits + fresh translations", () => {
+    const cached = new Map([["A", "a"]]);
+    const fresh = new Map([["B", "b"]]);
+    expect(assembleResult(["A", "B", "A"], cached, fresh)).toEqual(["a", "b", "a"]);
+  });
+
+  it("throws when a sentence has no translation", () => {
+    expect(() => assembleResult(["A"], new Map(), new Map())).toThrow();
+  });
+});
+
+describe("validateRequest", () => {
+  it("accepts a well-formed request", () => {
+    const req = validateRequest({ namespace: "ui", targetLanguage: "ja", sentences: ["Hi"] });
+    expect(req.namespace).toBe("ui");
+  });
+
+  it("rejects a bad namespace / language / empty sentences", () => {
+    expect(() => validateRequest({ namespace: "../etc", targetLanguage: "ja", sentences: ["Hi"] })).toThrow(TranslationInputError);
+    expect(() => validateRequest({ namespace: "ui", targetLanguage: "japanese", sentences: ["Hi"] })).toThrow(TranslationInputError);
+    expect(() => validateRequest({ namespace: "ui", targetLanguage: "ja", sentences: [] })).toThrow(TranslationInputError);
+  });
+});
+
+describe("POST /api/translation", () => {
+  let ws: string;
+  let server: Server;
+  let base: string;
+  let calls: Array<{ targetLanguage: string; sentences: readonly string[] }>;
+
+  // Fake LLM: deterministic, records its calls so we can assert caching skips it.
+  const fakeBatch = async (targetLanguage: string, sentences: readonly string[]) => {
+    calls.push({ targetLanguage, sentences });
+    return sentences.map((s) => `${s}-${targetLanguage}`);
+  };
+
+  beforeEach(async () => {
+    calls = [];
+    ws = mkdtempSync(path.join(tmpdir(), "mt-tr-"));
+    const app = express();
+    app.use(express.json());
+    mountTranslationRoutes(app, { workspace: ws, translateBatch: fakeBatch });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        base = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  const post = (body: unknown) =>
+    fetch(`${base}/api/translation`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+  it("short-circuits English without invoking the LLM or writing a cache", async () => {
+    const res = await post({ namespace: "ui", targetLanguage: "en", sentences: ["Hello", "Bye"] });
+    expect(await res.json()).toEqual({ translations: ["Hello", "Bye"] });
+    expect(calls).toHaveLength(0);
+    expect(existsSync(path.join(ws, "data", "translation", "ui.json"))).toBe(false);
+  });
+
+  it("translates misses, persists the shared-schema cache, and serves the next call from it", async () => {
+    const first = await post({ namespace: "ui", targetLanguage: "ja", sentences: ["Hello", "Bye"] });
+    expect(await first.json()).toEqual({ translations: ["Hello-ja", "Bye-ja"] });
+    expect(calls).toHaveLength(1);
+
+    const cacheFile = path.join(ws, "data", "translation", "ui.json");
+    expect(JSON.parse(readFileSync(cacheFile, "utf8"))).toEqual({
+      sentences: { Hello: { ja: "Hello-ja" }, Bye: { ja: "Bye-ja" } },
+    });
+
+    // Second call is fully cached → LLM not called again, only the new miss is.
+    const second = await post({ namespace: "ui", targetLanguage: "ja", sentences: ["Hello", "New"] });
+    expect(await second.json()).toEqual({ translations: ["Hello-ja", "New-ja"] });
+    expect(calls).toHaveLength(2);
+    expect(calls[1].sentences).toEqual(["New"]); // only the miss reached the LLM
+  });
+
+  it("400s on invalid input", async () => {
+    const res = await post({ namespace: "ui", targetLanguage: "nope", sentences: ["Hi"] });
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/backends/translation.ts
+++ b/server/backends/translation.ts
@@ -1,0 +1,273 @@
+// Runtime UI-string translation over `POST /api/translation`. This is
+// MulmoTerminal's OWN implementation of the contract MulmoClaude defines, so the
+// shared `@mulmoclaude/core/translation/client` works against either host:
+//
+//   POST /api/translation  { namespace, targetLanguage, sentences } → { translations }
+//
+// Two things are deliberately identical to MulmoClaude so the apps interoperate:
+//   1. The HTTP request/response shape (the client is host-agnostic).
+//   2. The on-disk cache schema — `<workspace>/data/translation/<namespace>.json`
+//      = `{ sentences: { [source]: { [lang]: translation } } }`. Both apps default
+//      to the same workspace, the cache is keyed by source sentence + language, and
+//      the English source strings are identical, so whichever app translates a
+//      sentence first, the other reuses it. NO schema divergence is allowed here.
+//
+// What's MulmoTerminal-specific is the LLM step. MulmoTerminal must NEVER use
+// `claude -p` / `claude --print` (eliminating print mode is the whole point of the
+// app), so the translation is done by MulmoTerminal's own hidden chat mechanism,
+// injected as `translateBatch`. Only the HTTP contract + cache format are shared
+// with MulmoClaude; the LLM path is ours.
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
+import type { Express, Request, Response } from "express";
+
+// ── On-disk cache schema (SHARED with MulmoClaude — do not diverge) ───────────
+
+/** `{ sentences: { [sourceSentence]: { [lang]: translation } } }`. */
+interface DictionaryFile {
+  sentences: Record<string, Record<string, string>>;
+}
+
+function emptyDictionary(): DictionaryFile {
+  return { sentences: {} };
+}
+
+// Cache files live under the user's workspace and may be hand-edited or shared
+// with the other app; treat the disk shape as untrusted and fall back to an empty
+// dictionary on anything unrecognized, so a `{}` / `{ sentences: null }` file can't
+// turn every request for the namespace into a 500.
+function isValidDictionary(value: unknown): value is DictionaryFile {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const { sentences } = value as { sentences?: unknown };
+  if (typeof sentences !== "object" || sentences === null || Array.isArray(sentences)) return false;
+  for (const inner of Object.values(sentences)) {
+    if (typeof inner !== "object" || inner === null || Array.isArray(inner)) return false;
+    for (const translated of Object.values(inner as Record<string, unknown>)) {
+      if (typeof translated !== "string") return false;
+    }
+  }
+  return true;
+}
+
+function dictionaryPath(workspace: string, namespace: string): string {
+  return path.join(workspace, "data", "translation", `${namespace}.json`);
+}
+
+async function loadDictionary(workspace: string, namespace: string): Promise<DictionaryFile> {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await fs.readFile(dictionaryPath(workspace, namespace), "utf8"));
+  } catch {
+    return emptyDictionary(); // missing / unreadable / malformed → start empty
+  }
+  return isValidDictionary(raw) ? raw : emptyDictionary();
+}
+
+// Atomic write (unique temp + rename) so a concurrent writer — including the other
+// app on the shared workspace — can never observe a half-written cache file.
+async function saveDictionary(workspace: string, namespace: string, dict: DictionaryFile): Promise<void> {
+  const file = dictionaryPath(workspace, namespace);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(tmp, `${JSON.stringify(dict, null, 2)}\n`, "utf8");
+    await fs.rename(tmp, file);
+  } catch (err) {
+    await fs.rm(tmp, { force: true });
+    throw err;
+  }
+}
+
+// ── Pure cache logic (exported for tests) ─────────────────────────────────────
+
+// `obj[userKey] = value` with `userKey === "__proto__"` hits the inherited setter
+// on Object.prototype instead of creating an own property — losing the entry and
+// polluting the object's shape. `Object.defineProperty` bypasses the setter.
+function safeAssign<V>(target: Record<string, V>, key: string, value: V): void {
+  Object.defineProperty(target, key, { value, enumerable: true, writable: true, configurable: true });
+}
+
+export interface SplitResult {
+  /** input sentence → cached translation. */
+  cached: Map<string, string>;
+  /** distinct sentences needing a fresh translation. */
+  misses: string[];
+}
+
+/** Partition the requested sentences into cache hits and the distinct misses. */
+export function splitHitMiss(dict: DictionaryFile, sentences: readonly string[], lang: string): SplitResult {
+  const cached = new Map<string, string>();
+  const missesSet = new Set<string>();
+  for (const sentence of sentences) {
+    const hit = dict.sentences[sentence]?.[lang];
+    if (hit !== undefined) cached.set(sentence, hit);
+    else missesSet.add(sentence);
+  }
+  return { cached, misses: Array.from(missesSet) };
+}
+
+/** Return a new dictionary with `fresh` (source→translation) merged in under `lang`. */
+export function mergeTranslations(dict: DictionaryFile, lang: string, fresh: ReadonlyMap<string, string>): DictionaryFile {
+  const next: Record<string, Record<string, string>> = {};
+  for (const [source, langs] of Object.entries(dict.sentences)) {
+    safeAssign(next, source, { ...langs });
+  }
+  for (const [source, translated] of fresh) {
+    const existing = Object.hasOwn(next, source) ? next[source] : {};
+    // `lang` is regex-validated upstream so it can't be a dangerous key; the only
+    // unsafe site is the user-supplied `source`, handled by safeAssign.
+    existing[lang] = translated;
+    safeAssign(next, source, existing);
+  }
+  return { sentences: next };
+}
+
+/** Reassemble the caller's input order from the cache hits + fresh translations. */
+export function assembleResult(sentences: readonly string[], cached: ReadonlyMap<string, string>, fresh: ReadonlyMap<string, string>): string[] {
+  return sentences.map((sentence) => {
+    const translated = cached.get(sentence) ?? fresh.get(sentence);
+    if (translated === undefined) {
+      throw new Error(`[translation] missing translation for ${JSON.stringify(sentence)}`);
+    }
+    return translated;
+  });
+}
+
+// ── Request validation (mirrors MulmoClaude's bounds) ─────────────────────────
+
+const NAMESPACE_RE = /^[a-zA-Z0-9_-]+$/;
+// Fixed-length alternation, no nested quantifiers — safe from ReDoS. Matches a 2-
+// or 5-char BCP-47 short code (e.g. `ja`, `pt-BR`).
+// eslint-disable-next-line security/detect-unsafe-regex -- single-pass match against a 2- or 5-char locale code, no backtracking.
+const LANGUAGE_RE = /^[a-z]{2}(?:-[A-Z]{2})?$/;
+
+// Bound the request so one call can't blow past the `claude -p <json>` argv limit
+// (POSIX E2BIG, ~128 KiB) or balloon cost. UI-string callers stay well inside these.
+const MAX_SENTENCES = 256;
+const MAX_SENTENCE_CHARS = 1024;
+const MAX_TOTAL_CHARS = 32 * 1024;
+
+export class TranslationInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TranslationInputError";
+  }
+}
+
+interface TranslateRequest {
+  namespace: string;
+  targetLanguage: string;
+  sentences: string[];
+}
+
+/** Validate + narrow the request body. Throws TranslationInputError on bad input. */
+export function validateRequest(body: unknown): TranslateRequest {
+  const req = (body ?? {}) as Record<string, unknown>;
+  if (typeof req.namespace !== "string" || !NAMESPACE_RE.test(req.namespace)) {
+    throw new TranslationInputError(`invalid namespace: ${JSON.stringify(req.namespace)}`);
+  }
+  if (typeof req.targetLanguage !== "string" || !LANGUAGE_RE.test(req.targetLanguage)) {
+    throw new TranslationInputError(`invalid targetLanguage: ${JSON.stringify(req.targetLanguage)}`);
+  }
+  if (!Array.isArray(req.sentences) || req.sentences.length === 0) {
+    throw new TranslationInputError("sentences must be a non-empty array");
+  }
+  if (req.sentences.length > MAX_SENTENCES) {
+    throw new TranslationInputError(`sentences exceeds ${MAX_SENTENCES} entries`);
+  }
+  let totalChars = 0;
+  for (const sentence of req.sentences) {
+    if (typeof sentence !== "string" || sentence.length === 0) {
+      throw new TranslationInputError("sentences must contain non-empty strings");
+    }
+    if (sentence.length > MAX_SENTENCE_CHARS) {
+      throw new TranslationInputError(`sentence exceeds ${MAX_SENTENCE_CHARS} characters`);
+    }
+    totalChars += sentence.length;
+    if (totalChars > MAX_TOTAL_CHARS) {
+      throw new TranslationInputError(`total sentence length exceeds ${MAX_TOTAL_CHARS} characters`);
+    }
+  }
+  return { namespace: req.namespace, targetLanguage: req.targetLanguage, sentences: req.sentences as string[] };
+}
+
+// ── LLM step (injected) ───────────────────────────────────────────────────────
+
+/**
+ * Translate the distinct cache MISSES, returning one string per input sentence in
+ * the SAME order. This is the only LLM seam, injected by the host so the mechanism
+ * stays out of this module. MulmoTerminal wires its OWN hidden interactive chat
+ * here (NOT `claude -p` — print mode is banned in MulmoTerminal); tests inject a
+ * deterministic fake. The return array length MUST equal `sentences.length`.
+ */
+export type TranslateBatchFn = (targetLanguage: string, sentences: readonly string[]) => Promise<string[]>;
+
+// ── Orchestration + route ─────────────────────────────────────────────────────
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface TranslationDeps {
+  workspace: string;
+  /** The LLM step — MulmoTerminal's hidden chat in production, a fake in tests. */
+  translateBatch: TranslateBatchFn;
+}
+
+export function mountTranslationRoutes(app: Express, deps: TranslationDeps): void {
+  const llm = deps.translateBatch;
+
+  // Per-namespace serialization. Two concurrent requests on the same namespace
+  // would otherwise race the read-merge-write of the shared cache file; chaining
+  // makes the second see the first's persisted output.
+  const chains = new Map<string, Promise<unknown>>();
+  function serialize<T>(namespace: string, runner: () => Promise<T>): Promise<T> {
+    const prev = chains.get(namespace) ?? Promise.resolve();
+    const next = prev.catch(() => undefined).then(runner);
+    const tracked = next.catch(() => undefined);
+    chains.set(namespace, tracked);
+    tracked.then(() => {
+      if (chains.get(namespace) === tracked) chains.delete(namespace);
+    });
+    return next;
+  }
+
+  async function runOnce(req: TranslateRequest): Promise<string[]> {
+    const dict = await loadDictionary(deps.workspace, req.namespace);
+    const { cached, misses } = splitHitMiss(dict, req.sentences, req.targetLanguage);
+    if (misses.length === 0) {
+      return assembleResult(req.sentences, cached, new Map());
+    }
+    const translated = await llm(req.targetLanguage, misses);
+    if (translated.length !== misses.length) {
+      throw new Error(`[translation] LLM returned ${translated.length} translations for ${misses.length} sentences`);
+    }
+    const fresh = new Map<string, string>();
+    misses.forEach((sentence, index) => fresh.set(sentence, translated[index]));
+    await saveDictionary(deps.workspace, req.namespace, mergeTranslations(dict, req.targetLanguage, fresh));
+    return assembleResult(req.sentences, cached, fresh);
+  }
+
+  app.post("/api/translation", async (httpReq: Request, res: Response) => {
+    let req: TranslateRequest;
+    try {
+      req = validateRequest(httpReq.body);
+    } catch (err) {
+      res.status(400).json({ error: errorMessage(err) });
+      return;
+    }
+    // English is the source language — no translation, no cache, no LLM.
+    if (req.targetLanguage === "en") {
+      res.json({ translations: [...req.sentences] });
+      return;
+    }
+    try {
+      const translations = await serialize(req.namespace, () => runOnce(req));
+      res.json({ translations });
+    } catch (err) {
+      console.error(`[translation] ${req.namespace}/${req.targetLanguage} failed:`, err);
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -35,6 +35,7 @@ import { startCollectionCompletionWatchers } from "./backends/collectionWatchers
 import { initUserTaskScheduler, mountSchedulerRoutes } from "./backends/scheduler.js";
 import { mountFilesRoutes } from "./backends/files.js";
 import { mountShortcutsRoutes } from "./backends/shortcuts.js";
+import { mountTranslationRoutes } from "./backends/translation.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
@@ -131,6 +132,20 @@ initWorkspaceSetup({ workspace: CLAUDE_CWD });
 // workspace dir, so it stays valid regardless of which directory is active.
 const MULMOTERMINAL_HOME = path.join(os.homedir(), ".mulmoterminal");
 
+// Hidden translation-worker sessions run in CLAUDE_CWD — the workspace the user has
+// already trusted — because claude blocks on its workspace-trust dialog in any
+// untrusted dir (no input ever comes, so the worker would hang). Their session ids
+// are tracked here so they're FILTERED OUT of /api/sessions: a translation worker is
+// a transient internal helper, not a chat the user should see in the sidebar.
+const translationWorkerIds = new Set<string>();
+
+// sessionId → settlers for a hidden translation worker's in-flight request.
+// `resolve` is called from POST /api/translation/submit when the worker reports its
+// answer (via the submitTranslation GUI tool); `reject` from the Stop hook if the
+// worker ends its turn WITHOUT submitting (a misbehaved turn), so we fail fast
+// instead of waiting out the full timeout.
+const pendingTranslations = new Map<string, { resolve: (translations: string[]) => void; reject: (err: Error) => void }>();
+
 // A session id is always a UUID (server-generated, or a .jsonl basename). Reject
 // anything else so a client can't smuggle CLI flags (e.g. "--resume" followed by
 // a value that claude re-parses as a flag) into the spawned process.
@@ -166,7 +181,10 @@ const sessionChannel = (id: string) => `session:${id}`;
 // MCP tool names claude uses, in the mcp__<server>__<tool> form, one per enabled
 // plugin. Auto-allowed via --allowedTools so the spike doesn't trip the permission
 // prompt (permissions stay terminal-native). Comma-joined into one --allowedTools.
-const GUI_MCP_TOOLS = allowedToolNames().join(",");
+// The worker-only `submitTranslation` tool is allowed for every session (harmless —
+// only hidden translation workers are actually shown it, see the /mcp route) so the
+// worker can call it without a permission prompt.
+const GUI_MCP_TOOLS = [...allowedToolNames(), "mcp__mulmoterminal-gui__submitTranslation"].join(",");
 
 // A per-session list store mirrored to disk so it survives a server reboot — one
 // JSON file per session under <workspace>/<dirName>/<sessionId>.json
@@ -673,6 +691,32 @@ mountShortcutsRoutes(app, { workspace: CLAUDE_CWD });
 // <workspace>/models dir, so a download by either app is reused.
 mountWhisperRoutes(app, { workspace: CLAUDE_CWD });
 
+// Runtime UI-string translation (POST /api/translation), backing the shared
+// @mulmoclaude/core/translation/client. The HTTP contract + on-disk cache schema
+// match MulmoClaude (so the <workspace>/data/translation cache is shared between the
+// apps), but the LLM step is MulmoTerminal's own: translateViaHiddenChat spawns a
+// hidden background claude session (NEVER `claude -p`) and is filtered from the
+// sidebar. translateViaHiddenChat is a hoisted function declaration defined alongside
+// spawnClaudePty below.
+mountTranslationRoutes(app, { workspace: CLAUDE_CWD, translateBatch: translateViaHiddenChat });
+
+// The hidden translation worker reports its answer here, via the broker's worker-only
+// submitTranslation GUI tool (which POSTs { sessionId, translations }). We hand the
+// array to the waiting request and let translateViaHiddenChat validate it.
+app.post("/api/translation/submit", (req, res) => {
+  const { sessionId, translations } = isRecord(req.body) ? req.body : {};
+  if (typeof sessionId !== "string" || !SESSION_ID_RE.test(sessionId)) {
+    return res.status(400).json({ error: "invalid sessionId" });
+  }
+  const pending = pendingTranslations.get(sessionId);
+  if (!pending) {
+    // No in-flight request for this id (already settled / timed out / not a worker).
+    return res.status(404).json({ error: "no pending translation for this session" });
+  }
+  pending.resolve(Array.isArray(translations) ? (translations as string[]) : []);
+  return res.json({ ok: true });
+});
+
 // In-process GUI MCP server, served over Streamable HTTP. claude (wired up via
 // mcpConfigJson) POSTs JSON-RPC here; the session id is in the URL path. We run in
 // STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
@@ -684,7 +728,9 @@ app.post("/mcp/:sessionId", async (req, res) => {
   if (!SESSION_ID_RE.test(sessionId)) {
     return res.status(400).json({ error: "invalid sessionId" });
   }
-  const server = buildGuiMcpServer(sessionId, `http://127.0.0.1:${PORT}`);
+  // Hidden translation workers (and only they) get the worker-only submitTranslation
+  // tool, so a normal chat's tool list stays clean.
+  const server = buildGuiMcpServer(sessionId, `http://127.0.0.1:${PORT}`, { submitTranslationTool: translationWorkerIds.has(sessionId) });
   const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
   res.on("close", () => {
     transport.close();
@@ -779,6 +825,10 @@ app.post("/api/hook", async (req, res) => {
     }
     handleActivityHook(sessionId, event, foreground);
     await handleToolHook(sessionId, event, body);
+    // A hidden translation worker that ends its turn while still pending never called
+    // submitTranslation — fail it now rather than hang until the timeout. (When it DID
+    // submit, the entry is already resolved and this reject is a no-op.)
+    if (event === "Stop") pendingTranslations.get(sessionId)?.reject(new Error("[translation] worker ended its turn without calling submitTranslation"));
     console.log(`[hook] ${event} for ${sessionId}`);
   }
   res.json({ ok: true });
@@ -962,8 +1012,12 @@ app.get("/api/sessions", async (req, res) => {
     }
 
     // Keep only the most-recent N, then read & parse contents for just those
-    // on-disk files (a deleted/corrupt file is dropped, not fatal).
-    const top = [...onDiskStats, ...pending].sort((a, b) => b.mtime - a.mtime).slice(0, SESSION_LIST_LIMIT);
+    // on-disk files (a deleted/corrupt file is dropped, not fatal). Hidden translation
+    // workers are dropped first — they're transient internal helpers, not user chats.
+    const top = [...onDiskStats, ...pending]
+      .filter((s) => !translationWorkerIds.has(s.id))
+      .sort((a, b) => b.mtime - a.mtime)
+      .slice(0, SESSION_LIST_LIMIT);
     const sessions = (
       await Promise.all(
         top.map((s) =>
@@ -1110,6 +1164,68 @@ function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntr
     ws.send(JSON.stringify({ type: "output", data: entry.buffer }));
   }
   return entry;
+}
+
+// How long to wait for a hidden translation worker to call submitTranslation before
+// giving up (cold claude startup + one short turn). Generous; the result is cached.
+const TRANSLATION_TIMEOUT_MS = 120_000;
+
+// Tear down a finished/failed translation worker: kill any lingering pty and drop its
+// bookkeeping + transcript so the activity maps and the workspace don't accumulate
+// throwaway translation sessions.
+function cleanupTranslationWorker(sessionId: string): void {
+  reap(sessionId); // idempotent — already reaped if Stop fired
+  activity.delete(sessionId);
+  hiddenSessions.delete(sessionId);
+  translationWorkerIds.delete(sessionId);
+  lastPrompts.delete(sessionId);
+  pendingTranslations.delete(sessionId);
+  fs.rm(path.join(projectSessionsDir(CLAUDE_CWD), `${sessionId}.jsonl`), { force: true }).catch(() => {});
+}
+
+// The injected LLM step for /api/translation. Drives MulmoTerminal's EXISTING hidden
+// background chat (spawnClaudePty) — explicitly NOT `claude -p`, which is banned in
+// MulmoTerminal. It seeds a headless worker that translates the strings and reports
+// them by calling the worker-only `submitTranslation` GUI tool, which resolves the
+// promise below (via POST /api/translation/submit). Runs in CLAUDE_CWD (the trusted
+// workspace, else claude blocks on its trust dialog); the worker's session id is
+// filtered from /api/sessions so it never shows in the sidebar.
+async function translateViaHiddenChat(targetLanguage: string, sentences: readonly string[]): Promise<string[]> {
+  const sessionId = randomUUID();
+  const expected = sentences.length;
+  hiddenSessions.add(sessionId);
+  translationWorkerIds.add(sessionId);
+  const prompt =
+    `You are a translation service. Translate each of the ${expected} English strings in the JSON ` +
+    `array below into the target language (BCP-47 code: ${targetLanguage}). Preserve placeholders ` +
+    `like {name}, {count}, %s and any HTML tags verbatim. Then report your result by calling the ` +
+    `submitTranslation tool EXACTLY ONCE with a "translations" array of the ${expected} translated ` +
+    `strings, in the same order. Do not call any other tool and do not print the translations as ` +
+    `text.\n\nInput: ${JSON.stringify(sentences)}`;
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const submitted = new Promise<string[]>((resolve, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`[translation] hidden chat timed out after ${TRANSLATION_TIMEOUT_MS}ms`)), TRANSLATION_TIMEOUT_MS);
+    pendingTranslations.set(sessionId, { resolve, reject });
+  });
+
+  try {
+    // ws=null → headless; the worker buffers output nobody reads. Default cwd =
+    // CLAUDE_CWD (trusted). submitTranslation (or the Stop hook) settles `submitted`.
+    spawnClaudePty(sessionId, null, null, prompt);
+    // spawnClaudePty registers a pending session + emits a "created" event; drop the
+    // pending entry now so this internal worker never surfaces as a sidebar row (the
+    // /api/sessions filter on translationWorkerIds covers its on-disk transcript).
+    knownSessions.delete(sessionId);
+    const translations = await submitted;
+    if (translations.length !== expected || !translations.every((s) => typeof s === "string")) {
+      throw new Error(`[translation] submitTranslation returned ${translations.length} strings for ${expected} inputs`);
+    }
+    return translations;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    cleanupTranslationWorker(sessionId);
+  }
 }
 
 // Spawn a fresh claude PTY for this session, register it, and wire its output /

--- a/server/index.ts
+++ b/server/index.ts
@@ -1183,25 +1183,17 @@ function cleanupTranslationWorker(sessionId: string): void {
   fs.rm(path.join(projectSessionsDir(CLAUDE_CWD), `${sessionId}.jsonl`), { force: true }).catch(() => {});
 }
 
-// The injected LLM step for /api/translation. Drives MulmoTerminal's EXISTING hidden
-// background chat (spawnClaudePty) — explicitly NOT `claude -p`, which is banned in
-// MulmoTerminal. It seeds a headless worker that translates the strings and reports
-// them by calling the worker-only `submitTranslation` GUI tool, which resolves the
-// promise below (via POST /api/translation/submit). Runs in CLAUDE_CWD (the trusted
-// workspace, else claude blocks on its trust dialog); the worker's session id is
-// filtered from /api/sessions so it never shows in the sidebar.
-async function translateViaHiddenChat(targetLanguage: string, sentences: readonly string[]): Promise<string[]> {
+// Most a worker request retries before failing. The model occasionally answers in
+// text instead of calling submitTranslation (caught fast by the Stop hook); a fresh
+// worker almost always succeeds. Misses are cached, so retries are rare in practice.
+const TRANSLATION_MAX_ATTEMPTS = 3;
+
+// Run ONE hidden translation worker: spawn it, wait for it to call submitTranslation
+// (or fail via the Stop hook / timeout), validate, and tear it down.
+async function runTranslationWorkerOnce(prompt: string, expected: number): Promise<string[]> {
   const sessionId = randomUUID();
-  const expected = sentences.length;
   hiddenSessions.add(sessionId);
   translationWorkerIds.add(sessionId);
-  const prompt =
-    `You are a translation service. Translate each of the ${expected} English strings in the JSON ` +
-    `array below into the target language (BCP-47 code: ${targetLanguage}). Preserve placeholders ` +
-    `like {name}, {count}, %s and any HTML tags verbatim. Then report your result by calling the ` +
-    `submitTranslation tool EXACTLY ONCE with a "translations" array of the ${expected} translated ` +
-    `strings, in the same order. Do not call any other tool and do not print the translations as ` +
-    `text.\n\nInput: ${JSON.stringify(sentences)}`;
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const submitted = new Promise<string[]>((resolve, reject) => {
@@ -1226,6 +1218,33 @@ async function translateViaHiddenChat(targetLanguage: string, sentences: readonl
     if (timeoutId) clearTimeout(timeoutId);
     cleanupTranslationWorker(sessionId);
   }
+}
+
+// The injected LLM step for /api/translation. Drives MulmoTerminal's EXISTING hidden
+// background chat (spawnClaudePty) — explicitly NOT `claude -p`, which is banned in
+// MulmoTerminal. It seeds a headless worker that translates the strings and reports
+// them by calling the worker-only `submitTranslation` GUI tool (POST
+// /api/translation/submit). Retries a fresh worker if one answers without submitting.
+async function translateViaHiddenChat(targetLanguage: string, sentences: readonly string[]): Promise<string[]> {
+  const expected = sentences.length;
+  const prompt =
+    `You are an automated translation service. Translate each of the ${expected} English strings in ` +
+    `the JSON array below into the target language (BCP-47 code: ${targetLanguage}), preserving ` +
+    `placeholders like {name}, {count}, %s and any HTML tags verbatim. You MUST deliver the result by ` +
+    `calling the submitTranslation tool with a "translations" array of exactly ${expected} strings in ` +
+    `the same order — that tool call is the ONLY way to return the result; a text reply is discarded. ` +
+    `Do not call any other tool.\n\nInput: ${JSON.stringify(sentences)}`;
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= TRANSLATION_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await runTranslationWorkerOnce(prompt, expected);
+    } catch (err) {
+      lastErr = err;
+      console.warn(`[translation] attempt ${attempt}/${TRANSLATION_MAX_ATTEMPTS} failed: ${messageOf(err)}`);
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error("[translation] hidden chat failed");
 }
 
 // Spawn a fresh claude PTY for this session, register it, and wire its output /

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -88,15 +88,18 @@ const SUBMIT_TRANSLATION_TOOL = {
 export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { submitTranslationTool?: boolean } = {}): Server {
   const server = new Server({ name: "mulmoterminal-gui", version: "0.0.0" }, { capabilities: { tools: {} } });
 
+  // A hidden translation worker processes UNTRUSTED sentence content with its tools
+  // auto-allowed, so a prompt-injected string must not be able to reach the regular
+  // GUI/plugin tools. Such sessions are therefore exposed ONLY submitTranslation —
+  // every other tool is hidden AND refused below (defense in depth).
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [
-      ...toolDefinitions.map((def) => ({
-        name: def.name,
-        description: describe(def),
-        inputSchema: def.parameters ?? { type: "object", properties: {} },
-      })),
-      ...(opts.submitTranslationTool ? [SUBMIT_TRANSLATION_TOOL] : []),
-    ],
+    tools: opts.submitTranslationTool
+      ? [SUBMIT_TRANSLATION_TOOL]
+      : toolDefinitions.map((def) => ({
+          name: def.name,
+          description: describe(def),
+          inputSchema: def.parameters ?? { type: "object", properties: {} },
+        })),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -107,6 +110,12 @@ export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { su
     if (name === SUBMIT_TRANSLATION_TOOL.name) {
       await postJson(`${baseUrl}/api/translation/submit`, { sessionId, translations: isRecord(args) ? args.translations : undefined });
       return { content: [{ type: "text", text: "Translation received. You are done." }] };
+    }
+
+    // Translation workers may call NOTHING else — refuse any other tool even if the
+    // model is steered toward it by injected sentence content.
+    if (opts.submitTranslationTool) {
+      return { content: [{ type: "text", text: `Tool "${name}" is not available; call submitTranslation with the translations.` }], isError: true };
     }
 
     // 1. Dispatch to the plugin's server-side handler.

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -57,6 +57,24 @@ function describe(def: { description?: string; prompt?: string }) {
   return [def.description, def.prompt].filter(Boolean).join("\n\n");
 }
 
+// The worker-only result tool used by the hidden translation chat (see
+// translateViaHiddenChat in server/index.ts). It is NOT a plugin: the worker calls it
+// to hand its structured answer straight back, so the broker special-cases it (POST
+// to /api/translation/submit WITH the session id) instead of the /api/plugin path.
+// Advertised only when `submitTranslationTool` is set, so normal chats never see it.
+const SUBMIT_TRANSLATION_TOOL = {
+  name: "submitTranslation",
+  description:
+    "Report the finished translation. Call this EXACTLY ONCE with a `translations` array of the " +
+    "translated strings, in the same order and length as the input. This is the only way to return " +
+    "the result — do not print it as text.",
+  inputSchema: {
+    type: "object",
+    properties: { translations: { type: "array", items: { type: "string" } } },
+    required: ["translations"],
+  },
+} as const;
+
 /**
  * Build a fresh GUI MCP server bound to one chat session. Stateless: create one
  * per request (Streamable HTTP in stateless mode forbids reusing a transport, and
@@ -64,20 +82,32 @@ function describe(def: { description?: string; prompt?: string }) {
  *
  * @param sessionId  the chat session whose GUI panel should render tool results
  * @param baseUrl    the mulmoterminal host origin to POST plugin dispatch + results to
+ * @param opts.submitTranslationTool  expose the worker-only `submitTranslation` tool
+ *                                    (set only for hidden translation-worker sessions)
  */
-export function buildGuiMcpServer(sessionId: string, baseUrl: string): Server {
+export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { submitTranslationTool?: boolean } = {}): Server {
   const server = new Server({ name: "mulmoterminal-gui", version: "0.0.0" }, { capabilities: { tools: {} } });
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: toolDefinitions.map((def) => ({
-      name: def.name,
-      description: describe(def),
-      inputSchema: def.parameters ?? { type: "object", properties: {} },
-    })),
+    tools: [
+      ...toolDefinitions.map((def) => ({
+        name: def.name,
+        description: describe(def),
+        inputSchema: def.parameters ?? { type: "object", properties: {} },
+      })),
+      ...(opts.submitTranslationTool ? [SUBMIT_TRANSLATION_TOOL] : []),
+    ],
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
+
+    // Worker-only result tool: deliver the structured translations back to the
+    // waiting request (keyed by session id), bypassing the plugin dispatch path.
+    if (name === SUBMIT_TRANSLATION_TOOL.name) {
+      await postJson(`${baseUrl}/api/translation/submit`, { sessionId, translations: isRecord(args) ? args.translations : undefined });
+      return { content: [{ type: "text", text: "Translation received. You are done." }] };
+    }
 
     // 1. Dispatch to the plugin's server-side handler.
     const parsed = await (await postJson(`${baseUrl}/api/plugin/${name}`, args ?? {})).json();


### PR DESCRIPTION
## What

Adds MulmoTerminal's own **runtime UI-string translation service** at `POST /api/translation`, implementing the same contract MulmoClaude defines so the shared `@mulmoclaude/core/translation/client` works against either host.

- **HTTP contract** — `{ namespace, targetLanguage, sentences } → { translations }` — and the **on-disk cache schema** (`<workspace>/data/translation/<namespace>.json` = `{ sentences: { [source]: { [lang]: translation } } }`) match MulmoClaude **exactly**, so the cache is **shared** between the two apps on the common workspace.
- The **LLM step is MulmoTerminal's own**. It must never use `claude -p` — eliminating print mode is the whole point of the app. Instead it drives the **existing hidden background chat** (`spawnClaudePty`).

## How the hidden-chat LLM step works

`translateViaHiddenChat` spawns a headless background `claude` worker seeded with a translate prompt. The worker reports its answer by calling a **worker-only `submitTranslation` GUI MCP tool** (auto-allowed, so no permission prompt), which hands the structured array straight back to the waiting request via `POST /api/translation/submit`. A tool call lands *before* the turn's `Stop` hook, so the Stop hook is just a fail-fast fallback if the worker never submits.

Why the MCP-tool channel (not the session transcript): claude does **not** write the session `.jsonl` for these short headless turns, so transcript-scraping was unreliable. The worker runs in `CLAUDE_CWD` (the workspace the user already trusts — claude blocks on its trust dialog in any untrusted dir) and its session id is **filtered out of `/api/sessions`**, so it never appears in the sidebar; it's reaped and its transcript deleted on completion.

## Files

- `server/backends/translation.ts` — cache (shared schema, atomic writes, prototype-pollution-safe merge), per-namespace serialization, English short-circuit, MulmoClaude's input bounds; LLM step injected as `TranslateBatchFn` (fully unit-testable).
- `server/mcp/broker.ts` — worker-only `submitTranslation` tool, advertised only to translation-worker sessions.
- `server/index.ts` — `translateViaHiddenChat` + `POST /api/translation/submit` + sidebar filtering + worker cleanup.
- `scripts/smoke-translation.mjs` — local end-to-end smoke (real `claude`; **not** part of CI, which uses a stub claude).

## Testing

- **Unit** (`yarn test`, runs in CI with a fake LLM): cache logic, validation, route — English short-circuit, cache persistence + hit-skips-LLM, 400 on bad input.
- **Live end-to-end** (local, real claude): ✅ EN short-circuit · ✅ JA translation `["保存","この項目を削除","ようこそ、{name}さん!"]` in ~12s with the `{name}` placeholder preserved · ✅ cache hit in 3ms · ✅ 400 on invalid input · ✅ worker never leaked into the sidebar.
- `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn build` all green.

> Note: this is the **server side only**. It's consumed once MulmoClaude ships `@mulmoclaude/core/translation/client` and core is bumped here — tracked separately (see `../mulmoclaude/plans/feat-collection-starters-modal.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)