### PR TITLE
chore: release 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Release 0.5.0

Version bump `0.4.0` → `0.5.0` for npm publish.

### Highlights
- **Per-directory `.mulmoterminal.json`** (#144): a project directory can pin its terminals' xterm palette (`theme` + per-key `colors`), an attention `sound` (directory-relative, traversal-safe), and a `name`/`badgeColor` badge — applied per terminal cell.
- **Grid terminal ordering** (#142): manual/auto ordering for grid cells.
- **Duplicate-session guard** (#140), **unified header toolbar** (#138), configurable **Vite dev port** (#137).

Full changelog is auto-generated on the GitHub release.

Tag (on merge): `mulmoterminal@0.5.0`.