### PR TITLE
feat: タブを閉じる/リロード前に確認ダイアログ（ターミナルがあるときのみ）

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ src/
   composables/
     usePubSub.ts      socket.io-client pub/sub composable (subscribe/unsubscribe)
     usePendingScript.ts  Hands a header-picked script to the grid to run
+    useUnloadGuard.ts  Confirm before closing/reloading the tab while a terminal is live
 vite.config.ts    Dev proxy for /ws (covers /ws/run), /ws/pubsub, /api
 vitest.config.ts  jsdom test environment
 ```

--- a/plans/feat-confirm-before-close.md
+++ b/plans/feat-confirm-before-close.md
@@ -1,0 +1,35 @@
+# feat: タブを閉じる/リロード前の確認ダイアログ
+
+## User Prompt
+
+> うっかりmulmoterminal閉じないように、タブ閉じそうなときにアラート出せる？
+
+（クラリファイ結果）警告は **ターミナル（起動中のセッション/コマンドセル）が1つでもあるときだけ** 出す。空の画面・ランチャーのみなら出さない。
+
+## 背景
+
+- `claude` の PTY はサーバ側に存在し、WebSocket が切れると **アイドルなセッションは猶予後に reap**（`server/index.ts` の `handleClientClose`、トランスクリプトは残り `--resume` 可）、**working は生存**。なので「うっかり閉じ」には実害があり、ガードは有意義。
+- ブラウザ仕様の制約: `beforeunload` は **閉じる・リロード・遷移すべてで発火**し区別不可。表示は **ブラウザ標準ダイアログ**で文面はカスタム不可。
+
+## 設計
+
+- `src/composables/useUnloadGuard.ts`（モジュール singleton、本リポジトリの既存流儀に合わせる）
+  - `activeTerminals`(ref) … マウント中のビューが報告するライブ端末数。
+  - `reportActiveTerminals(n)` … 各ビューが自分の権威データで更新。
+  - `useUnloadGuard()` … `beforeunload` を1回だけ登録し、`activeTerminals > 0` のとき `preventDefault()`＋`returnValue=""` で標準ダイアログを出す。`onMounted`/`onUnmounted` で着脱。
+- ビューは排他マウントなので、マウント中の1つが値を所有:
+  - `App.vue`（single）… `useUnloadGuard()` を設置。`watch([viewMode, activeId])` で single のとき `activeId ? 1 : 0` を報告。
+  - `GridView.vue`（grid）… `watch(() => runningCount(state.cells))` を報告（全ページ分をカウント）。
+
+## テスト
+
+- `useUnloadGuard.spec.ts` … 端末0で非ブロック / 端末ありでブロック / 0に戻ると非ブロック / unmount でリスナ解除。
+
+## 留意点
+
+- 文面はブラウザ依存（カスタム不可）、リロードでも発火（仕様）。
+- single ビューは接続時に `activeId` が付くため、実質「セッション接続後は確認あり」。
+
+## ゲート
+
+`yarn format` / `yarn lint` / `yarn build` / `yarn typecheck` / `yarn test`

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@ import { useAppConfig } from "./composables/useAppConfig";
 import { usePendingScript, type PendingCommand } from "./composables/usePendingScript";
 import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
+import { useUnloadGuard, reportActiveTerminals } from "./composables/useUnloadGuard";
 import type { CwdPreset } from "./components/presets";
 
 // View mode: the classic single-terminal view (default) or the multi-terminal
@@ -36,6 +37,19 @@ function onRunScript(command: PendingCommand) {
 const activeId = ref<string | null>(null);
 const connectKey = ref(0);
 const terminalRef = ref<InstanceType<typeof TerminalView> | null>(null);
+
+// Confirm before an accidental tab close / reload while a terminal is live. The
+// single view has one live session (when activeId is set); the grid reports its own
+// count. Only act for the single view here — when the grid is mounted it owns the
+// count (App renders one or the other).
+useUnloadGuard();
+watch(
+  [viewMode, activeId],
+  () => {
+    if (viewMode.value === "single") reportActiveTerminals(activeId.value ? 1 : 0);
+  },
+  { immediate: true },
+);
 
 // Single source of truth for the session list, owned here (not inside the
 // layout components) so toggling vertical/horizontal — which swaps Sidebar and

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -23,6 +23,7 @@ import {
   type GridState,
 } from "./gridTabs";
 import { usePendingScript } from "../composables/usePendingScript";
+import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import type { CwdPreset } from "./presets";
 import { useAppConfig } from "../composables/useAppConfig";
 
@@ -43,6 +44,10 @@ if (init.migrated) {
   localStorage.removeItem(LEGACY_KEY);
 }
 watch(state, persist, { deep: true });
+
+// Feed the tab-close guard: warn on close/reload while any cell runs a session or
+// command (counts every page, not just the mounted one).
+watch(() => runningCount(state.value.cells), reportActiveTerminals, { immediate: true });
 
 const pages = computed(() => pageCount(state.value.cells.length));
 // While a cell is zoomed, render EVERY cell so the filmstrip lines up all tabs'

--- a/src/composables/useUnloadGuard.spec.ts
+++ b/src/composables/useUnloadGuard.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { defineComponent } from "vue";
+import { mount } from "@vue/test-utils";
+import { useUnloadGuard, reportActiveTerminals } from "./useUnloadGuard";
+
+// Mount a bare host so the composable's onMounted/onUnmounted run (and the
+// beforeunload listener is registered/removed) on a real lifecycle.
+const Host = defineComponent({
+  setup() {
+    useUnloadGuard();
+    return () => null;
+  },
+});
+
+const fireBeforeUnload = (): boolean => {
+  const e = new Event("beforeunload", { cancelable: true });
+  window.dispatchEvent(e);
+  return e.defaultPrevented;
+};
+
+describe("useUnloadGuard", () => {
+  let wrapper: ReturnType<typeof mount> | null = null;
+  beforeEach(() => reportActiveTerminals(0));
+  // Unmount between tests so no host's listener lingers and skews the next case.
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = null;
+  });
+
+  it("does not block the unload when no terminal is live", () => {
+    wrapper = mount(Host);
+    expect(fireBeforeUnload()).toBe(false);
+  });
+
+  it("blocks the unload while a terminal is live", () => {
+    wrapper = mount(Host);
+    reportActiveTerminals(2);
+    expect(fireBeforeUnload()).toBe(true);
+  });
+
+  it("stops blocking again once the count drops to zero", () => {
+    wrapper = mount(Host);
+    reportActiveTerminals(1);
+    expect(fireBeforeUnload()).toBe(true);
+    reportActiveTerminals(0);
+    expect(fireBeforeUnload()).toBe(false);
+  });
+
+  it("removes the listener on unmount (no lingering guard)", () => {
+    wrapper = mount(Host);
+    reportActiveTerminals(3);
+    wrapper.unmount();
+    wrapper = null;
+    expect(fireBeforeUnload()).toBe(false);
+  });
+});

--- a/src/composables/useUnloadGuard.ts
+++ b/src/composables/useUnloadGuard.ts
@@ -1,0 +1,27 @@
+import { onMounted, onUnmounted, ref } from "vue";
+
+// How many live terminals the mounted view reports: the single view reports its
+// active session (0 or 1), the grid reports its running-cell count. Module-level so
+// the guard reads it without prop threading; the two views are mutually exclusive
+// (only one is mounted), so whichever is on screen owns the value.
+const activeTerminals = ref(0);
+
+export function reportActiveTerminals(count: number): void {
+  activeTerminals.value = count;
+}
+
+// Warn before the tab closes / reloads / navigates away while a terminal is live,
+// so an accidental close doesn't drop sessions (an idle PTY is reaped shortly after
+// the socket closes; a working one keeps going, but either way the live view is
+// lost). With nothing running, the page closes without a prompt. Install once at the
+// app root. The browser shows its own generic confirm dialog — the message text is
+// fixed by the browser and can't be customised.
+export function useUnloadGuard(): void {
+  const onBeforeUnload = (e: BeforeUnloadEvent) => {
+    if (activeTerminals.value <= 0) return;
+    e.preventDefault();
+    e.returnValue = ""; // legacy Chrome/Edge still need returnValue assigned to prompt
+  };
+  onMounted(() => window.addEventListener("beforeunload", onBeforeUnload));
+  onUnmounted(() => window.removeEventListener("beforeunload", onBeforeUnload));
+}


### PR DESCRIPTION
## Summary

うっかり MulmoTerminal のタブを閉じてしまわないよう、**ターミナル（起動中のセッション/コマンドセル）が1つでもあるとき**にタブを閉じる/リロードしようとすると、ブラウザ標準の確認ダイアログを出します。何も動いていない（空のグリッド / ランチャーのみ）ときは出ません。

- 新規 `src/composables/useUnloadGuard.ts`（本リポジトリの composable singleton 流儀）。`beforeunload` を1か所で監視し、ライブ端末数 > 0 のとき `preventDefault()`。
- `reportActiveTerminals(n)` を各ビューが自分の権威データで報告：**single = `activeId` の有無**、**grid = `runningCount(state.cells)`（全ページ分）**。両ビューは排他マウントなので競合しません。

## Items to Confirm / Review

- **ブラウザ仕様の制約**: ダイアログ文面は**カスタム不可**（ブラウザ標準）。`beforeunload` は**閉じる/リロード/遷移すべてで発火**し区別できません（リロードでも確認が出ます）。この挙動で問題ないか。
- **警告条件**: 「ターミナルがあるとき」を、single は `activeId !== null`、grid は `runningCount > 0` と定義。single ビューは接続時に `activeId` が付くため、実質「セッション接続後は常に確認あり」になります（空の起動直後のみ無し）。意図と合っているか。
- **目視未確認**: 当セッションにブラウザ MCP が無く、ダイアログの実表示は未確認です（ロジックはユニットテスト4件でカバー、`vite build`/`vue-tsc` で SFC コンパイル確認済み）。お手元で `yarn dev` → ターミナル起動 → タブを閉じる、で確認いただけると確実です。

## User Prompt

> うっかりmulmoterminal閉じないように、タブ閉じそうなときにアラート出せる？

クラリファイ結果: 警告は**ターミナルがあるときだけ**出す（空の画面では出さない）。

## Implementation

- `useUnloadGuard.ts`: `activeTerminals`(ref) + `reportActiveTerminals(n)` + `useUnloadGuard()`（`onMounted`/`onUnmounted` で `beforeunload` を着脱、`returnValue=""` は旧 Chrome 互換）。
- `App.vue`: `useUnloadGuard()` 設置 + `watch([viewMode, activeId])` で single 時に件数報告。
- `GridView.vue`: `watch(() => runningCount(state.cells))` で報告。
- テスト `useUnloadGuard.spec.ts`（4件：端末0で非ブロック / ありでブロック / 0復帰 / unmount でリスナ解除）。
- README コンポーネントマップ更新、計画書 `plans/feat-confirm-before-close.md`。

ゲート: format / lint / typecheck / build / **test 420** すべて通過。

## 補足

サーバ側挙動として、WebSocket が切れるとアイドルセッションは猶予後に reap（トランスクリプトは残り resume 可）、working は生存。なので本ガードは実害のある誤操作を防ぎます。

Closes #148
