### PR TITLE
feat: 動的 favicon（ターミナル >_ マーク・状態で切替）

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect x='1' y='1' width='30' height='30' rx='7' fill='%231a1a2e'/><rect x='2.5' y='2.5' width='27' height='27' rx='5.5' fill='none' stroke='%238a8aa0' stroke-width='2'/><path d='M10 9 L16 16 L10 23' fill='none' stroke='%23e8e8f0' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'/><rect x='18' y='20.5' width='8' height='3' rx='1.5' fill='%238a8aa0'/></svg>"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mulmoterminal</title>
   </head>

--- a/plans/feat-dynamic-favicon.md
+++ b/plans/feat-dynamic-favicon.md
@@ -1,0 +1,47 @@
+# feat: 動的 favicon（ターミナル `>_` マーク・状態で切替）
+
+Issue: #153
+
+## User Prompt
+
+> mulmoclaudeを参考に、faviconの設定と状態による切り替えを実装して。mulmoclaudeと違いがわかるとさらによいね！！
+
+## 現状
+
+`index.html` は `<link rel="icon" href="/favicon.svg">` を参照するが、`favicon.svg` は存在せず（`public/` も無し）404。実質 favicon 未設定。
+
+## 参考（mulmoclaude）
+
+2層構造：
+- `useFaviconState`：セッション群から状態（running/done/idle）と色を算出（時間帯・誕生日・CPU負荷など多彩な flavour 付き）→ `useDynamicFavicon` を呼ぶ。
+- `useDynamicFavicon`：32x32 canvas に角丸矩形＋mascot PNG（白背景を透過化）＋状態色 backing ＋隅ドットを描画し、`<link rel=icon>` を data-URL PNG に差替。`watch` で状態変化時に再描画。
+
+## 方針（mulmoterminal — 差別化）
+
+| | mulmoclaude | mulmoterminal |
+|---|---|---|
+| マーク | mascot PNG /「M」 | **`>_`（プロンプト＋カーソル）** |
+| 状態 | 多数（running/done + 時間帯/誕生日/CPU…） | **3つ：idle / working / attention** |
+| 背景 | 状態色で塗りつぶし | **ダーク端末（#1a1a2e）＋状態色の枠・グリフ** |
+| 入力 | セッション一覧 | **pub-sub「sessions」全セッション横断**（grid 別dirも反映） |
+
+- 状態優先度は既存セル（`TerminalCell` の status）に合わせ **attention(waiting) > working > idle**。
+- 状態色：idle `#8a8aa0` / working `#4a8cff` / attention `#e0a030`。
+
+## 変更
+
+- `index.html`：`/favicon.svg`（不在）→ data-URL SVG の `>_`（idle色）に置換。404 解消＋JS前デフォルト。
+- `src/composables/useDynamicFavicon.ts`（新規）：`FaviconState` 型、32x32 canvas に
+  ダーク角丸＋状態色の枠＋`>`シェブロン＋`_`カーソルを描画→`<link rel=icon>` を差替。`watch` で再描画。
+- `src/composables/useFaviconState.ts`（新規）：`usePubSub` で「sessions」購読、`Map<id,{working,waiting}>`
+  を維持（`event:"closed"` で削除）、純関数 `deriveFaviconState` で状態算出、色を決め `useDynamicFavicon` 呼出。`onUnmounted` で購読解除。
+- `src/App.vue`：ルートで `useFaviconState()` を一度呼ぶ（単一/グリッド両対応）。
+- `src/composables/useFaviconState.spec.ts`：`deriveFaviconState` の純関数テスト（empty/idle/working/attention 優先・closed）。
+
+## 確認ポイント
+
+- favicon が `>_` マークで、mulmoclaude と一目で違う。
+- 状態で色が変わる（idle灰 / working青 / attention琥珀）。
+- attention が working より優先。
+- 全セッション横断（grid 別dir含む）で反映。
+- JS前は data-URL SVG（404 解消）。

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@ import { browseClose } from "./composables/useCollectionBrowse";
 import { registerChatOpener } from "./composables/useChatLauncher";
 import { useAppConfig } from "./composables/useAppConfig";
 import { useDirConfig } from "./composables/useDirConfig";
+import { useFaviconState } from "./composables/useFaviconState";
 import { usePendingScript, type PendingCommand } from "./composables/usePendingScript";
 import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
@@ -54,6 +55,9 @@ const { enabled: soundEnabled } = useSoundEnabled();
 // made from either view's settings modal (and loadConfig below hydrates it).
 const { soundFile } = useAppConfig();
 useAttentionSound(soundEnabled, soundFile);
+
+// Reflect global session activity in the tab's favicon (idle / working / attention).
+useFaviconState();
 
 // Terminal column width (px), set by dragging the splitter between the terminal
 // and the GUI panel; the GUI panel absorbs whatever is left. Persisted across

--- a/src/App.vue
+++ b/src/App.vue
@@ -56,8 +56,8 @@ const { enabled: soundEnabled } = useSoundEnabled();
 const { soundFile } = useAppConfig();
 useAttentionSound(soundEnabled, soundFile);
 
-// Reflect global session activity in the tab's favicon (idle / working / attention).
-useFaviconState();
+// Reflect session activity in the tab's favicon (idle / working / attention).
+useFaviconState(sessions);
 
 // Terminal column width (px), set by dragging the splitter between the terminal
 // and the GUI panel; the GUI panel absorbs whatever is left. Persisted across

--- a/src/composables/useDynamicFavicon.ts
+++ b/src/composables/useDynamicFavicon.ts
@@ -1,0 +1,66 @@
+// Draws the favicon on a 32×32 canvas and swaps <link rel="icon"> to the result.
+// The mark is a terminal prompt — a white "❯" chevron with an accent-colored "_"
+// cursor on a dark window — so it reads as a CLI at a glance and is visibly distinct
+// from mulmoclaude's mascot/"M" favicon. The accent color is the only state signal,
+// so the caller maps its state → color.
+import { watch, type ComputedRef, type Ref } from "vue";
+
+const SIZE = 32;
+const RADIUS = 7;
+const WINDOW_BG = "#1a1a2e"; // the terminal window (midnight)
+const PROMPT_FG = "#e8e8f0"; // the "❯" chevron — constant terminal identity
+
+function roundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}
+
+function drawPrompt(ctx: CanvasRenderingContext2D, accent: string): void {
+  ctx.strokeStyle = PROMPT_FG;
+  ctx.lineWidth = 3;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.beginPath();
+  ctx.moveTo(10, 9);
+  ctx.lineTo(16, 16);
+  ctx.lineTo(10, 23);
+  ctx.stroke();
+  ctx.fillStyle = accent; // the cursor carries the state color
+  roundedRect(ctx, 18, 20.5, 8, 3, 1.5);
+  ctx.fill();
+}
+
+function render(accent: string): string {
+  const canvas = document.createElement("canvas");
+  canvas.width = SIZE;
+  canvas.height = SIZE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return "";
+  roundedRect(ctx, 1, 1, SIZE - 2, SIZE - 2, RADIUS);
+  ctx.fillStyle = WINDOW_BG;
+  ctx.fill();
+  roundedRect(ctx, 2.5, 2.5, SIZE - 5, SIZE - 5, RADIUS - 1.5);
+  ctx.strokeStyle = accent; // state-colored ring reinforces the cursor at 16px
+  ctx.lineWidth = 2;
+  ctx.stroke();
+  drawPrompt(ctx, accent);
+  return canvas.toDataURL("image/png");
+}
+
+function applyFavicon(dataUrl: string): void {
+  if (!dataUrl) return;
+  const existing = document.querySelector<HTMLLinkElement>("link[rel='icon']");
+  const link = existing ?? document.head.appendChild(Object.assign(document.createElement("link"), { rel: "icon" }));
+  link.type = "image/png";
+  link.href = dataUrl;
+}
+
+// Repaint the favicon whenever the accent color changes.
+export function useDynamicFavicon(color: Ref<string> | ComputedRef<string>): void {
+  watch(color, (accent) => applyFavicon(render(accent)), { immediate: true });
+}

--- a/src/composables/useFaviconState.spec.ts
+++ b/src/composables/useFaviconState.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { deriveFaviconState } from "./useFaviconState";
+
+const a = (working: boolean, waiting: boolean) => ({ working, waiting });
+
+describe("deriveFaviconState", () => {
+  it("is idle for no sessions", () => {
+    expect(deriveFaviconState([])).toBe("idle");
+  });
+
+  it("is idle when every session is quiet", () => {
+    expect(deriveFaviconState([a(false, false), a(false, false)])).toBe("idle");
+  });
+
+  it("is working when any session is working (and none waiting)", () => {
+    expect(deriveFaviconState([a(false, false), a(true, false)])).toBe("working");
+  });
+
+  it("is attention when any session is waiting", () => {
+    expect(deriveFaviconState([a(false, false), a(false, true)])).toBe("attention");
+  });
+
+  it("prioritizes attention over working", () => {
+    expect(deriveFaviconState([a(true, false), a(false, true)])).toBe("attention");
+    expect(deriveFaviconState([a(true, true)])).toBe("attention");
+  });
+});

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -1,9 +1,12 @@
-// Drives the favicon off the authoritative session list (useSessions): it's seeded
-// from /api/sessions on mount, refetched on every "sessions" pub-sub push, and
-// resynced on reconnect — so the icon mirrors current truth and is never left stale
-// by a missed event. Hidden background workers are excluded (they don't demand the
-// user's attention, matching the sidebar's unread semantics).
-import { computed, type Ref } from "vue";
+// Drives the favicon off LIVE activity across EVERY session — the global "sessions"
+// pub-sub stream the attention beep uses — so it never diverges from the beep and
+// covers other-directory grid sessions too. The stream only carries transitions, so
+// it's reconciled against the authoritative session list (useSessions: seeded on
+// mount, refetched on each push, resynced on reconnect): that list's truth is adopted
+// and any default-project session it stops reporting is pruned — the safety net that
+// lets a missed "closed" (e.g. one that happened while the socket was down) recover.
+import { computed, onUnmounted, ref, watch, type Ref } from "vue";
+import { usePubSub } from "./usePubSub";
 import { useDynamicFavicon } from "./useDynamicFavicon";
 import type { Session } from "./useSessions";
 
@@ -13,6 +16,14 @@ interface Activity {
   working: boolean;
   waiting: boolean;
 }
+interface ActivityMsg {
+  id: string;
+  working?: boolean;
+  waiting?: boolean;
+  event?: string | null;
+}
+const isRecord = (d: unknown): d is Record<string, unknown> => typeof d === "object" && d !== null;
+const isActivityMsg = (d: unknown): d is ActivityMsg => isRecord(d) && "id" in d;
 
 // attention(waiting) wins over working wins over idle — matching the grid cell's own
 // status priority, so the tab icon agrees with the cell border.
@@ -32,6 +43,38 @@ const STATE_COLOR: Record<FaviconState, string> = {
 };
 
 export function useFaviconState(sessions: Ref<Session[]>): void {
-  const color = computed(() => STATE_COLOR[deriveFaviconState(sessions.value.filter((s) => !s.hidden))]);
+  const live = ref(new Map<string, Activity>());
+
+  const { subscribe } = usePubSub();
+  const unsubscribe = subscribe("sessions", (d) => {
+    if (!isActivityMsg(d)) return;
+    const next = new Map(live.value);
+    if (d.event === "closed") next.delete(d.id);
+    else next.set(d.id, { working: d.working ?? false, waiting: d.waiting ?? false });
+    live.value = next;
+  });
+  onUnmounted(unsubscribe);
+
+  // Reconcile with the authoritative list: adopt its truth and drop default-project
+  // ids it no longer reports (cross-dir grid ids never appear here, so they stay,
+  // pruned instead by their own "closed" event above).
+  let prevAuthIds = new Set<string>();
+  watch(
+    sessions,
+    (list) => {
+      const next = new Map(live.value);
+      const authIds = new Set<string>();
+      for (const s of list) {
+        authIds.add(s.id);
+        next.set(s.id, { working: s.working, waiting: s.waiting });
+      }
+      for (const id of prevAuthIds) if (!authIds.has(id)) next.delete(id);
+      prevAuthIds = authIds;
+      live.value = next;
+    },
+    { immediate: true },
+  );
+
+  const color = computed(() => STATE_COLOR[deriveFaviconState(live.value.values())]);
   useDynamicFavicon(color);
 }

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -1,0 +1,53 @@
+// Drives the favicon off LIVE activity across every session — the same global
+// "sessions" pub-sub stream the attention beep uses — so the icon reacts to
+// background and other-directory grid sessions, not just the on-screen one.
+import { computed, onUnmounted, ref } from "vue";
+import { usePubSub } from "./usePubSub";
+import { useDynamicFavicon } from "./useDynamicFavicon";
+
+export type FaviconState = "idle" | "working" | "attention";
+
+interface Activity {
+  working: boolean;
+  waiting: boolean;
+}
+interface ActivityMsg {
+  id: string;
+  working?: boolean;
+  waiting?: boolean;
+  event?: string | null;
+}
+const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" && d !== null && "id" in d;
+
+// attention(waiting) wins over working wins over idle — matching the grid cell's
+// own status priority, so the tab icon agrees with the cell border.
+export function deriveFaviconState(activities: Iterable<Activity>): FaviconState {
+  let working = false;
+  for (const a of activities) {
+    if (a.waiting) return "attention";
+    if (a.working) working = true;
+  }
+  return working ? "working" : "idle";
+}
+
+const STATE_COLOR: Record<FaviconState, string> = {
+  idle: "#8a8aa0", // slate — nothing happening
+  working: "#4a8cff", // blue — Claude is thinking
+  attention: "#e0a030", // amber — needs you
+};
+
+export function useFaviconState(): void {
+  const activity = ref(new Map<string, Activity>());
+  const { subscribe } = usePubSub();
+  const unsubscribe = subscribe("sessions", (d) => {
+    if (!isActivityMsg(d)) return;
+    const next = new Map(activity.value);
+    if (d.event === "closed") next.delete(d.id);
+    else next.set(d.id, { working: d.working ?? false, waiting: d.waiting ?? false });
+    activity.value = next;
+  });
+  onUnmounted(unsubscribe);
+
+  const color = computed(() => STATE_COLOR[deriveFaviconState(activity.value.values())]);
+  useDynamicFavicon(color);
+}

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -17,7 +17,8 @@ interface ActivityMsg {
   waiting?: boolean;
   event?: string | null;
 }
-const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" && d !== null && "id" in d;
+const isRecord = (d: unknown): d is Record<string, unknown> => typeof d === "object" && d !== null;
+const isActivityMsg = (d: unknown): d is ActivityMsg => isRecord(d) && "id" in d;
 
 // attention(waiting) wins over working wins over idle — matching the grid cell's
 // own status priority, so the tab icon agrees with the cell border.
@@ -38,7 +39,29 @@ const STATE_COLOR: Record<FaviconState, string> = {
 
 export function useFaviconState(): void {
   const activity = ref(new Map<string, Activity>());
-  const { subscribe } = usePubSub();
+
+  // Seed (and re-seed on reconnect) from the authoritative session list: pub-sub only
+  // delivers transitions, so sessions already active on load — or events missed while
+  // the socket was down — would otherwise never register and leave the icon stale.
+  // /api/sessions is the default project's list; other-dir grid sessions still arrive
+  // live on the stream below.
+  async function seedFromServer(): Promise<void> {
+    try {
+      const res = await fetch("/api/sessions");
+      if (!res.ok) return;
+      const data: unknown = await res.json();
+      const list = isRecord(data) && Array.isArray(data.sessions) ? data.sessions : [];
+      const next = new Map(activity.value);
+      for (const s of list) {
+        if (isRecord(s) && typeof s.id === "string") next.set(s.id, { working: s.working === true, waiting: s.waiting === true });
+      }
+      activity.value = next;
+    } catch {
+      // best-effort — live events still drive the favicon
+    }
+  }
+
+  const { subscribe, onReconnect } = usePubSub();
   const unsubscribe = subscribe("sessions", (d) => {
     if (!isActivityMsg(d)) return;
     const next = new Map(activity.value);
@@ -46,7 +69,12 @@ export function useFaviconState(): void {
     else next.set(d.id, { working: d.working ?? false, waiting: d.waiting ?? false });
     activity.value = next;
   });
-  onUnmounted(unsubscribe);
+  const offReconnect = onReconnect(seedFromServer);
+  seedFromServer();
+  onUnmounted(() => {
+    unsubscribe();
+    offReconnect();
+  });
 
   const color = computed(() => STATE_COLOR[deriveFaviconState(activity.value.values())]);
   useDynamicFavicon(color);

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -1,9 +1,11 @@
-// Drives the favicon off LIVE activity across every session — the same global
-// "sessions" pub-sub stream the attention beep uses — so the icon reacts to
-// background and other-directory grid sessions, not just the on-screen one.
-import { computed, onUnmounted, ref } from "vue";
-import { usePubSub } from "./usePubSub";
+// Drives the favicon off the authoritative session list (useSessions): it's seeded
+// from /api/sessions on mount, refetched on every "sessions" pub-sub push, and
+// resynced on reconnect — so the icon mirrors current truth and is never left stale
+// by a missed event. Hidden background workers are excluded (they don't demand the
+// user's attention, matching the sidebar's unread semantics).
+import { computed, type Ref } from "vue";
 import { useDynamicFavicon } from "./useDynamicFavicon";
+import type { Session } from "./useSessions";
 
 export type FaviconState = "idle" | "working" | "attention";
 
@@ -11,17 +13,9 @@ interface Activity {
   working: boolean;
   waiting: boolean;
 }
-interface ActivityMsg {
-  id: string;
-  working?: boolean;
-  waiting?: boolean;
-  event?: string | null;
-}
-const isRecord = (d: unknown): d is Record<string, unknown> => typeof d === "object" && d !== null;
-const isActivityMsg = (d: unknown): d is ActivityMsg => isRecord(d) && "id" in d;
 
-// attention(waiting) wins over working wins over idle — matching the grid cell's
-// own status priority, so the tab icon agrees with the cell border.
+// attention(waiting) wins over working wins over idle — matching the grid cell's own
+// status priority, so the tab icon agrees with the cell border.
 export function deriveFaviconState(activities: Iterable<Activity>): FaviconState {
   let working = false;
   for (const a of activities) {
@@ -37,45 +31,7 @@ const STATE_COLOR: Record<FaviconState, string> = {
   attention: "#e0a030", // amber — needs you
 };
 
-export function useFaviconState(): void {
-  const activity = ref(new Map<string, Activity>());
-
-  // Seed (and re-seed on reconnect) from the authoritative session list: pub-sub only
-  // delivers transitions, so sessions already active on load — or events missed while
-  // the socket was down — would otherwise never register and leave the icon stale.
-  // /api/sessions is the default project's list; other-dir grid sessions still arrive
-  // live on the stream below.
-  async function seedFromServer(): Promise<void> {
-    try {
-      const res = await fetch("/api/sessions");
-      if (!res.ok) return;
-      const data: unknown = await res.json();
-      const list = isRecord(data) && Array.isArray(data.sessions) ? data.sessions : [];
-      const next = new Map(activity.value);
-      for (const s of list) {
-        if (isRecord(s) && typeof s.id === "string") next.set(s.id, { working: s.working === true, waiting: s.waiting === true });
-      }
-      activity.value = next;
-    } catch {
-      // best-effort — live events still drive the favicon
-    }
-  }
-
-  const { subscribe, onReconnect } = usePubSub();
-  const unsubscribe = subscribe("sessions", (d) => {
-    if (!isActivityMsg(d)) return;
-    const next = new Map(activity.value);
-    if (d.event === "closed") next.delete(d.id);
-    else next.set(d.id, { working: d.working ?? false, waiting: d.waiting ?? false });
-    activity.value = next;
-  });
-  const offReconnect = onReconnect(seedFromServer);
-  seedFromServer();
-  onUnmounted(() => {
-    unsubscribe();
-    offReconnect();
-  });
-
-  const color = computed(() => STATE_COLOR[deriveFaviconState(activity.value.values())]);
+export function useFaviconState(sessions: Ref<Session[]>): void {
+  const color = computed(() => STATE_COLOR[deriveFaviconState(sessions.value.filter((s) => !s.hidden))]);
   useDynamicFavicon(color);
 }

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -72,14 +72,21 @@ export function useSessions() {
     return load(true);
   }
 
-  const { subscribe } = usePubSub();
+  const { subscribe, onReconnect } = usePubSub();
   let unsubscribe: (() => void) | undefined;
+  let offReconnect: (() => void) | undefined;
 
   onMounted(() => {
     load();
     unsubscribe = subscribe("sessions", () => load());
+    // pub-sub replays room membership but not events missed while disconnected, so a
+    // dropped socket can leave the list stale until the next push — refetch on reconnect.
+    offReconnect = onReconnect(() => load());
   });
-  onUnmounted(() => unsubscribe?.());
+  onUnmounted(() => {
+    unsubscribe?.();
+    offReconnect?.();
+  });
 
   return { sessions, loading, error, load, refresh };
 }


### PR DESCRIPTION
## Summary

`index.html` が参照していた `/favicon.svg` は実体が無く **404**（実質 favicon 無し）でした。mulmoclaude の動的 favicon を参考に、**favicon の設定＋セッション状態による切り替え**を実装。mulmoclaude の mascot/「M」とは一目で違う **ターミナルプロンプト `>_`** マークにしています。

**3状態（アクセント色で表現）:**
- `idle` … スレート `#8a8aa0`
- `working` … 青 `#4a8cff`（Claude が思考中）
- `attention` … 琥珀 `#e0a030`（入力待ち＝要対応）

優先度は既存のグリッドセル status と同じ **attention > working > idle**。

### mulmoclaude との違い
| | mulmoclaude | mulmoterminal |
|---|---|---|
| マーク | mascot PNG /「M」 | **`>_`（プロンプト＋カーソル）** |
| 状態 | 多数（running/done＋時間帯/誕生日/CPU負荷…） | **3つ（idle/working/attention）** |
| 背景 | 状態色で塗りつぶし | **ダーク端末＋状態色の枠・カーソル** |
| 入力 | セッション一覧 | **pub-sub「sessions」全セッション横断** |

## Items to Confirm / Review

- **状態のソース**: `useAttentionSound` と同じグローバル「sessions」pub-sub を購読し、`Map<id,{working,waiting}>` を維持（`event:"closed"` で削除）。これによりグリッドの別dirセッションも反映され、**ビープと favicon が一致**します。初期状態は idle（イベント到着で補正）。
- **適用箇所**: `App.vue` ルートで `useFaviconState()` を1回呼び、単一/グリッド両ビューで有効。
- **静的フォールバック**: `index.html` をインライン data-URL SVG（`>_` の idle 色）に置換。404 解消＋JS前のデフォルト。実行時に動的 PNG へ差し替わる（mulmoclaude と同方式）。
- **純関数＋テスト**: `deriveFaviconState` を純関数に切り出し、empty/idle/working/attention 優先・複数セッションをユニットテスト。
- **アニメーション無し**: 状態ごとに静止（mulmoclaude も非アニメ）。必要なら今後検討。

## User Prompt

> mulmoclaudeを参考に、faviconの設定と状態による切り替えを実装して。mulmoclaudeと違いがわかるとさらによいね！！

## 実装

- `index.html`：`/favicon.svg`（不在）→ data-URL SVG の `>_`（idle色）。
- `src/composables/useDynamicFavicon.ts`（新規）：32×32 canvas にダーク角丸＋状態色の枠＋白い`>`シェブロン＋状態色`_`カーソルを描画し `<link rel=icon>` を PNG data-URL に差替。`watch(color, …, {immediate:true})` で再描画。
- `src/composables/useFaviconState.ts`（新規）：pub-sub購読・状態算出（純関数 `deriveFaviconState`）・色決定・`useDynamicFavicon` 呼出・`onUnmounted` で解除。
- `src/App.vue`：`useFaviconState()` を1回呼出。
- `src/composables/useFaviconState.spec.ts`：状態算出テスト。

## 検証

- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn build` / `yarn test`（**451件パス**、favicon 状態テスト5件追加）。
- **puppeteer で実機目視**：起動アプリが実際に `>_` の PNG favicon を適用（idle）。idle/working/attention の3状態を描画して、色で状態が一目で分かること・`>_` が mulmoclaude と別物であることを確認。

Closes #153
