### PR TITLE
feat: remember recent working directories in the cell launcher

### DIFF
--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -134,6 +134,25 @@ describe("TerminalCell", () => {
     expect(term.props("cwd")).toBe("/home/me/picked");
   });
 
+  it("launches via the go button next to the field (alternative to Enter)", async () => {
+    const w = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    await w.find(".cell-dir-input").setValue("/home/me/picked");
+    await w.find(".cell-dir-go").trigger("click");
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.exists()).toBe(true);
+    expect(term.props("cwd")).toBe("/home/me/picked");
+  });
+
+  it("disables the go button when the field is empty", async () => {
+    const w = mountCell(null, { defaultCwd: null });
+    await flushPromises();
+    await w.find(".cell-dir-input").setValue("   ");
+    expect((w.find(".cell-dir-go").element as HTMLButtonElement).disabled).toBe(true);
+    await w.find(".cell-dir-input").setValue("/home/me/picked");
+    expect((w.find(".cell-dir-go").element as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it("shows a cancel ✕ on a cancellable launcher that emits close, but not otherwise", async () => {
     const plain = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -367,6 +367,22 @@ describe("TerminalCell", () => {
     expect(useRecentDirs().recentDirs.value).toEqual([]);
   });
 
+  it("clears the pending-record flag when a fresh launch is torn down before its cwd arrives", async () => {
+    // Race: launch sets the record-next flag, but the user closes before the server
+    // reports a cwd; a subsequent resume must NOT inherit that pending record.
+    mockFetch([{ id: "77777777-7777-7777-7777-777777777777", title: "t", mtime: Date.now() }]);
+    const w = mountCell(null, { defaultCwd: "/home/me/proj" });
+    await flushPromises();
+    await w.find(".cell-dir-input").setValue("/home/me/fresh");
+    await w.find(".cell-dir-input").trigger("keydown.enter"); // flag = true, no cwd yet
+    await w.find(".cell-close").trigger("click"); // teardown must clear the flag
+    await flushPromises();
+    await w.find(".cell-resume-item").trigger("click"); // resume an existing session
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/proj");
+    await flushPromises();
+    expect(useRecentDirs().recentDirs.value).toEqual([]);
+  });
+
   it("prefills the launch field with the most recent location (not the server default)", async () => {
     useRecentDirs().recordDir("/home/me/last-used");
     const w = mountCell(null, { defaultCwd: "/home/me/default" });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -347,6 +347,26 @@ describe("TerminalCell", () => {
     expect(w2.findComponent({ name: "TerminalView" }).props("cwd")).toBe("/home/me/alpha");
   });
 
+  it("does NOT record a recent when a restored session reports its cwd (only fresh launches)", async () => {
+    // A cell restoring a persisted session also gets a server cwd report on connect;
+    // that must not rewrite the recents (else reload reorders them by mount order).
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/restored" });
+    await flushPromises();
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/restored");
+    await flushPromises();
+    expect(useRecentDirs().recentDirs.value).toEqual([]);
+  });
+
+  it("does NOT record a recent when resuming an existing session from the resume list", async () => {
+    mockFetch([{ id: "77777777-7777-7777-7777-777777777777", title: "fix the parser", mtime: Date.now() }]);
+    const w = mountCell(null, { defaultCwd: "/home/me/proj" });
+    await flushPromises();
+    await w.find(".cell-resume-item").trigger("click");
+    w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/proj");
+    await flushPromises();
+    expect(useRecentDirs().recentDirs.value).toEqual([]);
+  });
+
   it("prefills the launch field with the most recent location (not the server default)", async () => {
     useRecentDirs().recordDir("/home/me/last-used");
     const w = mountCell(null, { defaultCwd: "/home/me/default" });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalCell from "./TerminalCell.vue";
+import { useRecentDirs } from "../composables/useRecentDirs";
 
 // Capture the "sessions" pub/sub callback so tests can push activity directly.
 let captured: ((data: unknown) => void) | null = null;
@@ -53,6 +54,10 @@ function deferred<T>() {
 
 beforeEach(() => {
   captured = null;
+  // Recent dirs live in a module-level singleton backed by localStorage; reset both
+  // so a server cwd recorded by one test doesn't prefill the launcher in the next.
+  localStorage.clear();
+  useRecentDirs().recentDirs.value = [];
   mockFetch();
 });
 
@@ -123,7 +128,7 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(w.find(".cell-launch").exists()).toBe(true);
     await w.find(".cell-dir-input").setValue("/home/me/picked");
-    await w.find(".cell-start").trigger("click");
+    await w.find(".cell-dir-input").trigger("keydown.enter");
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/home/me/picked");
@@ -255,9 +260,9 @@ describe("TerminalCell", () => {
 
     const w = mountCell(null, { defaultCwd: "/A", presets: [{ label: "B", path: "/B" }] });
     await nextTick(); // mount → fetch #1 (dir A) in flight
-    const presetB = w.findAll(".cell-preset").find((b) => b.text() === "B");
-    if (!presetB) throw new Error("preset B not found");
-    await presetB.trigger("click"); // selectPreset → fetch #2 (dir B)
+    const chipB = w.findAll(".cell-chip").find((c) => c.find(".cell-chip-main").text() === "B");
+    if (!chipB) throw new Error("preset B not found");
+    await chipB.find(".cell-chip-fill").trigger("click"); // fillDir → fetch #2 (dir B)
 
     second.resolve({ ok: true, json: async () => ({ cwd: "/B", sessions: [{ id: "b-id", title: "B-sess", mtime: 1 }] }) });
     await flushPromises();
@@ -280,28 +285,67 @@ describe("TerminalCell", () => {
     expect(w.findComponent({ name: "TerminalView" }).props("cwd")).toBe("/resolved");
   });
 
-  it("selecting a preset sets the dir (doesn't launch); New then launches in it", async () => {
+  it("clicking a preset chip launches a fresh session in its dir", async () => {
     const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
     await flushPromises();
-    const btn = w.findAll(".cell-preset").find((b) => b.text() === "proj");
-    if (!btn) throw new Error("preset button not found");
-    await btn.trigger("click");
-    // No terminal yet — the preset only selects the directory.
-    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/work/proj");
-    expect(btn.classes()).toContain("active");
-    // New terminal launches in the selected dir.
-    await w.find(".cell-start").trigger("click");
+    const main = w.findAll(".cell-chip-main").find((b) => b.text() === "proj");
+    if (!main) throw new Error("preset chip not found");
+    await main.trigger("click");
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/work/proj");
+  });
+
+  it("a chip's fill button sets the dir WITHOUT launching (so the user can resume)", async () => {
+    const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
+    await flushPromises();
+    const chip = w.findAll(".cell-chip").find((c) => c.find(".cell-chip-main").text() === "proj");
+    if (!chip) throw new Error("preset chip not found");
+    await chip.find(".cell-chip-fill").trigger("click");
+    // No terminal — the fill button only selects the directory.
+    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
+    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/work/proj");
+  });
+
+  it("records the server-confirmed cwd and offers it as a recent chip that launches on click", async () => {
+    // Launch + let the server confirm the effective cwd: that records a recent.
+    const w1 = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    await w1.find(".cell-dir-input").setValue("/home/me/alpha");
+    await w1.find(".cell-dir-input").trigger("keydown.enter");
+    w1.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/alpha");
+    await flushPromises();
+
+    // A fresh cell now shows /home/me/alpha as a recent chip (path label).
+    const w2 = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    const recent = w2.find(".cell-recents");
+    expect(recent.exists()).toBe(true);
+    const main = recent.find(".cell-chip-main");
+    expect(main.text()).toBe("~/alpha");
+    // Clicking the chip launches a new session there.
+    await main.trigger("click");
+    expect(w2.findComponent({ name: "TerminalView" }).props("cwd")).toBe("/home/me/alpha");
+  });
+
+  it("prefills the launch field with the most recent location (not the server default)", async () => {
+    useRecentDirs().recordDir("/home/me/last-used");
+    const w = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/last-used");
+  });
+
+  it("keeps only the most recent four locations", async () => {
+    const { recordDir, recentDirs } = useRecentDirs();
+    for (const d of ["/a", "/b", "/c", "/d", "/e"]) recordDir(d);
+    expect(recentDirs.value).toEqual(["/e", "/d", "/c", "/b"]);
   });
 
   it("resets the launch form to the default dir after close", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
     await w.find(".cell-dir-input").setValue("/home/me/picked");
-    await w.find(".cell-start").trigger("click");
+    await w.find(".cell-dir-input").trigger("keydown.enter");
     await w.find(".cell-close").trigger("click");
     await nextTick();
     expect(w.find(".cell-launch").exists()).toBe(true);
@@ -312,7 +356,7 @@ describe("TerminalCell", () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
     await w.find(".cell-dir-input").setValue("relative/bad/path");
-    await w.find(".cell-start").trigger("click");
+    await w.find(".cell-dir-input").trigger("keydown.enter");
     // Server rejected the bad path and fell back; it reports the real cwd.
     w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/default");
     await nextTick();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -822,7 +822,18 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
       </div>
       <label class="cell-launch-label">
         <span class="cell-launch-caption">Working directory</span>
-        <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
+        <span class="cell-dir-row">
+          <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
+          <button
+            class="cell-dir-go"
+            :disabled="!dirInput.trim()"
+            title="Start a new terminal here (or press Enter)"
+            aria-label="Start a new terminal here"
+            @click="launch"
+          >
+            <span class="material-symbols-outlined">play_arrow</span>
+          </button>
+        </span>
       </label>
       <div v-if="recentDirs.length" class="cell-recents">
         <span class="cell-launch-caption">recent</span>
@@ -1216,6 +1227,40 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 .cell-dir-input:focus {
   outline: none;
   border-color: var(--accent);
+}
+.cell-dir-row {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  width: 100%;
+}
+.cell-dir-row .cell-dir-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.cell-dir-go {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.cell-dir-go:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--accent);
+}
+.cell-dir-go:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.cell-dir-go .material-symbols-outlined {
+  font-size: 18px;
 }
 .cell-start {
   border: 1px solid var(--border);

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vu
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
 import { useDirConfig } from "../composables/useDirConfig";
+import { useRecentDirs } from "../composables/useRecentDirs";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
 import type { CwdPreset } from "./presets";
@@ -54,8 +55,14 @@ const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
 // palette and shows a project badge. Re-fetched when the effective cwd changes.
 const { config: dirConfig } = useDirConfig(cwd);
 const dirBadgeStyle = computed(() => badgeStyleFor(dirConfig.value.badgeColor));
-// The launch form's editable dir; prefilled with the default once it's fetched.
-const dirInput = ref(props.initialCwd ?? props.defaultCwd ?? "");
+// The last few dirs the user launched in, offered as one-click chips. Shown as-is
+// (not filtered against presets) so the user always sees their true recent four —
+// even when those happen to also be preset folders.
+const { recentDirs, recordDir } = useRecentDirs();
+// The launch form's editable dir. Prefer this cell's persisted dir, then the most
+// recent location the user launched in, then the server default (fetched async, so
+// the watch below fills it in if we had nothing yet).
+const dirInput = ref(props.initialCwd ?? recentDirs.value[0] ?? props.defaultCwd ?? "");
 watch(
   () => props.defaultCwd,
   (d) => {
@@ -136,10 +143,20 @@ function launch() {
   launchIn(dirInput.value.trim() || props.defaultCwd);
 }
 
-// Pick a preset directory: fill the field and refresh the resume list for it, so
-// the user can then start fresh OR resume one of that dir's sessions.
+// A preset or recent-locations chip is a one-click action: fill the field and jump
+// straight into a fresh session in that dir.
+function selectRecent(path: string) {
+  dirInput.value = path;
+  launchIn(path);
+}
 function selectPreset(p: CwdPreset) {
-  dirInput.value = p.path;
+  selectRecent(p.path);
+}
+
+// The chip's tiny end button: fill the field WITHOUT launching, and refresh the
+// resume / script / worktree lists for that dir so the user can resume there.
+function fillDir(path: string) {
+  dirInput.value = path;
   loadResumable();
   loadScripts();
   loadWorktrees();
@@ -356,6 +373,7 @@ async function openDir() {
 // requested dir). Adopt it as the truth — display and persist the effective cwd.
 function onServerCwd(c: string) {
   cwd.value = c;
+  recordDir(c); // remember this dir for the launcher's recent-locations chips
   emit("cwd", c);
 }
 
@@ -795,15 +813,28 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         ✕
       </button>
       <div v-if="presets.length" class="cell-presets">
-        <button v-for="p in presets" :key="p.label + p.path" :class="['cell-preset', { active: dirInput === p.path }]" :title="p.path" @click="selectPreset(p)">
-          {{ p.label }}
-        </button>
+        <span v-for="p in presets" :key="p.label + p.path" class="cell-chip">
+          <button class="cell-chip-main" :title="p.path" @click="selectPreset(p)">{{ p.label }}</button>
+          <button class="cell-chip-fill" :title="`Use ${p.path} without launching (browse / resume here)`" @click="fillDir(p.path)">
+            <span class="material-symbols-outlined">edit</span>
+          </button>
+        </span>
       </div>
       <label class="cell-launch-label">
         <span class="cell-launch-caption">Working directory</span>
         <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
       </label>
-      <button class="cell-start" @click="launch">＋ New terminal</button>
+      <div v-if="recentDirs.length" class="cell-recents">
+        <span class="cell-launch-caption">recent</span>
+        <div class="cell-recent-list">
+          <span v-for="r in recentDirs" :key="r" class="cell-chip">
+            <button class="cell-chip-main" :title="r" @click="selectRecent(r)">{{ formatCwd(r, home, 28) }}</button>
+            <button class="cell-chip-fill" :title="`Use ${r} without launching (browse / resume here)`" @click="fillDir(r)">
+              <span class="material-symbols-outlined">edit</span>
+            </button>
+          </span>
+        </div>
+      </div>
       <div v-if="isGitRepo" class="cell-worktrees">
         <span class="cell-launch-caption">or isolate in a worktree (git repo)</span>
         <div class="wt-new">
@@ -1069,10 +1100,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* `safe` centers when it fits but falls back to top-aligned (so nothing is
-     clipped past the scroll origin) when the form is taller than a short cell —
-     e.g. a 3x3 cell with a long resume list. overflow-y makes it reachable. */
-  justify-content: safe center;
+  /* Top-aligned: the form anchors to the top of the cell rather than floating in
+     the vertical middle (which looks adrift when there are few/no resume rows). */
+  justify-content: flex-start;
   gap: 8px;
   padding: 16px;
   overflow-y: auto;
@@ -1107,24 +1137,55 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   gap: 6px;
   max-width: 360px;
 }
-.cell-preset {
+/* A chip is a segmented pill: the main button launches; the tiny end button just
+   fills the working-directory field (so the user can resume a session there). */
+.cell-chip {
+  display: inline-flex;
+  align-items: stretch;
   border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
   background: var(--bg-elevated);
+}
+.cell-chip-main {
+  border: none;
+  background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
   font-family: system-ui, sans-serif;
   font-size: 12px;
   padding: 4px 10px;
-  border-radius: 14px;
 }
-.cell-preset:hover {
+.cell-chip-fill {
+  display: inline-flex;
+  align-items: center;
+  border: none;
+  border-left: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0 5px;
+}
+.cell-chip-fill .material-symbols-outlined {
+  font-size: 14px;
+}
+.cell-chip-main:hover,
+.cell-chip-fill:hover {
   background: var(--bg-hover);
   color: var(--text);
 }
-.cell-preset.active {
-  background: var(--bg-hover);
-  color: var(--text);
-  border-color: var(--accent);
+.cell-recents {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+.cell-recent-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  max-width: 360px;
 }
 .cell-launch-label {
   display: flex;

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -130,6 +130,12 @@ onUnmounted(() => {
   if (resumableTimer) clearTimeout(resumableTimer);
 });
 
+// Set when the user starts a FRESH session from the launcher, so the next server
+// cwd report is recorded as a recent dir — but a reconnect/restore of an existing
+// session (which also reports a cwd) is not, or recents would be rewritten in mount
+// order on reload instead of reflecting what the user actually launched last.
+let recordNextCwd = false;
+
 // Start a fresh session in `dir`. Optimistic display only; the persisted/displayed
 // truth is the EFFECTIVE cwd the server confirms (onServerCwd), which may fall back.
 function launchIn(dir: string | null) {
@@ -137,6 +143,7 @@ function launchIn(dir: string | null) {
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
+  recordNextCwd = true;
   loadDiff(); // no-op for a non-worktree dir
 }
 function launch() {
@@ -373,7 +380,12 @@ async function openDir() {
 // requested dir). Adopt it as the truth — display and persist the effective cwd.
 function onServerCwd(c: string) {
   cwd.value = c;
-  recordDir(c); // remember this dir for the launcher's recent-locations chips
+  // Only a user-initiated fresh launch updates the recent-locations chips — not a
+  // reconnect/restore of an already-running session (see recordNextCwd).
+  if (recordNextCwd) {
+    recordNextCwd = false;
+    recordDir(c);
+  }
   emit("cwd", c);
 }
 
@@ -814,8 +826,14 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
       </button>
       <div v-if="presets.length" class="cell-presets">
         <span v-for="p in presets" :key="p.label + p.path" class="cell-chip">
-          <button class="cell-chip-main" :title="p.path" @click="selectPreset(p)">{{ p.label }}</button>
-          <button class="cell-chip-fill" :title="`Use ${p.path} without launching (browse / resume here)`" @click="fillDir(p.path)">
+          <button type="button" class="cell-chip-main" :title="p.path" @click="selectPreset(p)">{{ p.label }}</button>
+          <button
+            type="button"
+            class="cell-chip-fill"
+            :title="`Use ${p.path} without launching (browse / resume here)`"
+            :aria-label="`Use ${p.path} without launching`"
+            @click="fillDir(p.path)"
+          >
             <span class="material-symbols-outlined">edit</span>
           </button>
         </span>
@@ -825,6 +843,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <span class="cell-dir-row">
           <input v-model="dirInput" class="cell-dir-input" type="text" placeholder="/path/to/project" spellcheck="false" @keydown.enter="launch" />
           <button
+            type="button"
             class="cell-dir-go"
             :disabled="!dirInput.trim()"
             title="Start a new terminal here (or press Enter)"
@@ -839,8 +858,14 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <span class="cell-launch-caption">recent</span>
         <div class="cell-recent-list">
           <span v-for="r in recentDirs" :key="r" class="cell-chip">
-            <button class="cell-chip-main" :title="r" @click="selectRecent(r)">{{ formatCwd(r, home, 28) }}</button>
-            <button class="cell-chip-fill" :title="`Use ${r} without launching (browse / resume here)`" @click="fillDir(r)">
+            <button type="button" class="cell-chip-main" :title="r" @click="selectRecent(r)">{{ formatCwd(r, home, 28) }}</button>
+            <button
+              type="button"
+              class="cell-chip-fill"
+              :title="`Use ${r} without launching (browse / resume here)`"
+              :aria-label="`Use ${r} without launching`"
+              @click="fillDir(r)"
+            >
               <span class="material-symbols-outlined">edit</span>
             </button>
           </span>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -349,6 +349,7 @@ function resume(s: ResumableSession) {
   sessionId.value = s.id;
   connectKey.value++;
   launched.value = true;
+  recordNextCwd = false; // resuming isn't a fresh launch — don't record its cwd
   loadDiff(); // an already-idle worktree session shows its badge right away
 }
 
@@ -443,6 +444,7 @@ onUnmounted(() => document.removeEventListener("mousedown", onGhOutside));
 function teardown() {
   termRef.value?.terminate();
   launched.value = false;
+  recordNextCwd = false; // drop any pending fresh-launch record from a torn-down session
   sessionId.value = null;
   working.value = false;
   waiting.value = false;

--- a/src/composables/useRecentDirs.ts
+++ b/src/composables/useRecentDirs.ts
@@ -1,0 +1,42 @@
+import { ref } from "vue";
+
+// Recently used working directories, persisted in localStorage so the cell
+// launcher can offer the user's last few folders as quick-pick chips (separate
+// from the manually-curated presets in config.json). Most-recent-first.
+//
+// The ref is a module-scoped SINGLETON so every launcher cell shares one list:
+// launching in one cell records the dir and the chip appears in all the others.
+
+const STORAGE_KEY = "recent_dirs_v1";
+const MAX_RECENTS = 4;
+
+function load(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((d): d is string => typeof d === "string" && d.length > 0).slice(0, MAX_RECENTS);
+  } catch {
+    return [];
+  }
+}
+
+const recentDirs = ref<string[]>(load());
+
+export function useRecentDirs() {
+  // Push `dir` to the front, dedup, cap the list, and persist. Called with the
+  // server-confirmed (effective) cwd so we only remember dirs that actually ran.
+  function recordDir(dir: string | null) {
+    if (!dir) return;
+    const next = [dir, ...recentDirs.value.filter((d) => d !== dir)].slice(0, MAX_RECENTS);
+    recentDirs.value = next;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // best-effort — recents are a convenience, not load-bearing
+    }
+  }
+
+  return { recentDirs, recordDir };
+}


### PR DESCRIPTION
## Summary

The multi-terminal launcher can now **remember the last few working directories** you started sessions in. They appear as one-click chips under the curated preset chips, so you don't have to retype paths.

Built on the request: *"The multi-terminal mode allows me to specify the current folder … It would be great if it can remember last few locations."*

## What changed

- **Recents (last 4 dirs)** — recorded from the **server-confirmed (effective) cwd**, so only directories that actually ran are remembered. Persisted in `localStorage` via a module-level singleton, so every empty cell shares one list. New composable: `src/composables/useRecentDirs.ts`.
- **One-click chips, consistent behavior** — both preset and recent chips are now segmented pills:
  - **Main button** → launches a fresh session in that dir.
  - **Tiny end button** (pencil) → only *fills* the field and loads the resume / script / worktree lists, so you can resume an existing session there without launching.
- **Removed the redundant "＋ New terminal" button** — chips launch on click, and the path field launches on Enter.
- **Prefill from history** — a fresh launcher prefills the Working-directory field with your most recent location instead of the server default (`~/mulmoclaude`).
- **Top-aligned the launch form** — was vertically centered, which looked adrift with few/no resume rows.

## Testing

- `npm run test` — **463 passed**. Added coverage for: recording on server cwd, chip launch, the fill-without-launch button, prefill-from-recent, and the 4-item cap. Also reset the recents singleton + `localStorage` in `beforeEach` to prevent cross-test pollution (one test emits a server cwd that previously leaked into later cells' prefill).
- `npm run lint` — clean.
- `npm run typecheck` — clean.
- `npm run build` — succeeds (the >500 kB chunk warning is pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)