### PR TITLE
feat: persist terminal connections across UI navigation

### DIFF
--- a/plans/feat-persistent-terminal-connections.md
+++ b/plans/feat-persistent-terminal-connections.md
@@ -1,0 +1,254 @@
+# Plan: Keep PTYs alive by persisting terminal connections client-side
+
+## Problem
+
+When the user navigates away from the terminal UI for a while and comes back,
+Claude Code warns that restoring the session will consume a lot of tokens. This
+happens because:
+
+1. Navigating away (or flipping to an off-page grid tab, or switching the whole
+   view) **unmounts** `Terminal.vue`, whose `onUnmounted` closes the WebSocket.
+2. The server treats a socket close as a detach and arms the reap grace timer
+   (`armReapForDetached`): idle = 30s, waiting = 30min, working = never.
+3. An **idle** session is reaped after 30s. Coming back then spawns
+   `claude --resume <id>`, which replays the transcript from disk and triggers
+   the "restoring old session consumes a lot of tokens" warning.
+
+VS Code never shows this because the terminal process and its connection stay
+alive across tab switches. We want the same: a session stays connected as long
+as it is **logically open**, and only goes cold when explicitly closed or pulled
+from history/resume.
+
+## Goal
+
+The backend Claude PTY stays alive (no `--resume`, no token warning, VS Code
+parity) for as long as a session's terminal UI is **logically open** — i.e. it
+would be re-mounted when the user navigates back, NOT re-opened from the history
+list. Concretely, "logically open" = the union of:
+
+- every grid cell that has a session id (the `grid_v2` roster), regardless of
+  which page is currently rendered, and
+- the single/chat view's currently-active session.
+
+## Key insight (why this is a client-only change)
+
+The server already keeps a PTY alive **for exactly as long as its WebSocket is
+open** — `armReapForDetached` only ever fires from `handleClientClose`, i.e. on
+socket close. So we do not need any server change: if the client keeps the
+socket open while a session is logically open, the server never reaps it, and
+remount becomes a `reattachPty` (buffered-scrollback replay), not a `--resume`.
+
+Today the socket lifetime is tied to the **Vue component lifetime**
+(`Terminal.vue` opens it in `connect()` on mount, closes it in `onUnmounted`).
+The fix is to **decouple socket lifetime from component lifetime** by hoisting
+connection ownership into an App-level manager that survives navigation.
+
+## Non-goals (explicitly out of scope)
+
+- **Dirty disappearance** (laptop sleep / crash / network partition leaving a
+  half-open zombie socket that pins the PTY until TCP keepalive times out, ~2h).
+  This is a **pre-existing** behavior on `main` — it already affects the
+  currently-mounted session today. This change widens its blast radius from
+  "the mounted page" to "all open tabs", but does not introduce a new failure
+  mode. A WS ping/pong heartbeat to tighten that window is a separate, optional
+  follow-up and is NOT part of this plan.
+- No server-side changes. No roster/heartbeat protocol. No reap-policy changes.
+- Command / Run terminals (`/ws/run`, `props.command`) remain ephemeral and
+  component-owned exactly as today (their process is unresumable).
+
+## Current architecture (what moves)
+
+`src/components/Terminal.vue` currently owns, per mounted component:
+
+- the `WebSocket` (`ws`) — opened in `connect()` (line ~112), closed in
+  `onUnmounted` (line ~347)
+- the xterm `Terminal` + `FitAddon` (`term`, `fitAddon`) and the `ResizeObserver`
+- reconnect/backoff state (`knownSessionId`, `sawExit`, `disposed`,
+  `reconnectAttempts`, `reconnectTimer`, `scheduleReconnect`)
+- reactive `status` and `serverCwd`
+- the message protocol handling (`output` -> term, `session`/`cwd` -> emits,
+  `exit`/`superseded`/`error`)
+- input/output plumbing: `term.onData` -> ws, `submitText`, `insertText`,
+  `terminate`, resize -> ws
+
+View-only concerns that **stay** in the component: header, voice input
+(`useVoiceInput`), drag/drop + `pickFile`, `RunMenu`, theme repaint, the DOM
+host element.
+
+Relevant surrounding files:
+
+- `src/components/TerminalCell.vue` — grid cell wrapper; resume picker
+  (`loadResumable`/`resume`), `teardown()` -> `terminate()` on the ✕ button.
+- `src/components/TerminalGrid.vue` — `v-for`s the active page's cells.
+- `src/components/GridView.vue` — owns grid `state`, persists `grid_v2`
+  (`watch(state, persist, {deep:true})`); `onClose` -> `closeCell`.
+- `src/components/gridTabs.ts` — pure grid state (`cells`, `addCell`,
+  `closeCell`, `setSession`, `pageSlice`).
+- `src/App.vue` — single view; `activeId` + `connectKey`; renders **either**
+  `GridView` **or** the single `TerminalView` via `v-if viewMode`.
+
+## Target architecture
+
+Introduce a singleton **terminal connection manager** created once at App root,
+**above** the `v-if` that swaps Grid / single / other views, so it is never
+unmounted by navigation.
+
+`src/composables/useTerminalConnections.ts` (new) owns a
+`Map<sessionKey, ConnectionEntry>` where each entry holds the durable state:
+
+```
+ConnectionEntry {
+  ws: WebSocket | null
+  term: Terminal
+  fitAddon: FitAddon
+  host: HTMLDivElement        // xterm is term.open()'d into this ONCE
+  resizeObserver: ResizeObserver
+  knownSessionId: string | null
+  status: Ref<"connecting"|"connected"|"disconnected">
+  serverCwd: Ref<string|null>
+  // reconnect bookkeeping: attempts, timer, sawExit, superseded
+  refs: number               // how many things consider this logically-open
+}
+```
+
+Manager API (sketch):
+
+- `acquire(opts) -> entry` — create-or-return the entry for a session/cell and
+  start `connect()` if not already connected. Increments `refs`.
+- `attach(key, mountEl)` — `appendChild` the entry's persisted `host` div into
+  the component's mount point and `fit()`. Called from the view component's
+  `onMounted` / `onActivated`.
+- `detach(key)` — re-parent `host` back to an offscreen holder. Called from the
+  view component's `onUnmounted` / `onDeactivated`. **Does NOT close the ws.**
+- `release(key)` — decrement `refs`; when it hits 0, close the ws (let the
+  server's grace reap it) and dispose the xterm. Called when a session leaves
+  the roster (cell closed, or single-mode active session replaced).
+- `terminate(key)` — explicit ✕: send `{type:"terminate"}`, close, dispose
+  (immediate server reap). Keeps today's behavior.
+- `submitText(key, text)`, `insertText(key, text)`, `resize(key)` — route the
+  existing operations through the manager by key.
+
+The xterm instance and its `host` div live for the entry's whole lifetime; the
+view component merely re-parents `host` in/out of the DOM. This preserves
+scrollback, scroll position and selection with **no byte buffering and no
+replay** (chosen variant — see below).
+
+### Lifetime rules (when the ws opens / closes)
+
+- **Open** when a session becomes logically open:
+  - a grid cell with a session id is created / launched / resumed, or
+  - the single view's `activeId` is set to a session.
+- **Stay open** across: page flips (off-page grid cells), zoom/filmstrip,
+  Grid<->single view toggles, and navigation to non-terminal views
+  (e.g. AccountingView). The manager outlives all of these.
+- **Close (-> server grace reap)** when a session leaves the roster:
+  - grid: `closeCell` drops it from `grid_v2` -> `release`.
+  - single: `selectSession`/`newSession` points the active view at a different
+    session -> `release` the previous active session (matches today's
+    `ws.close()`-on-switch, which lets grace reap rather than terminate).
+- **Terminate (-> immediate reap)** on the cell's ✕ button (`teardown`), as today.
+
+### Roster = grid_v2 ∪ single active
+
+The manager does not need a new protocol — the roster is already in the client:
+the grid owns `grid_v2`; the single view owns `activeId`. The manager keeps a
+connection alive while either references it (`refs`). Because grid and single
+views never coexist (App.vue `v-if`), but a session in `grid_v2` is still
+logically open while the user is in single view (toggling back re-mounts it
+without resume), the manager — living above the toggle — keeps grid sessions
+connected regardless of the current view.
+
+## Variant decision: persist the xterm (recommended) vs buffer bytes
+
+**Variant A — persist xterm + its host div in the manager (RECOMMENDED).**
+`term.open(host)` is called once; on remount the component appends the existing
+`host` element into its container (xterm does not support re-`open()` onto a new
+element, so we move the element, not the terminal). Pros: zero replay, preserves
+scrollback / scroll position / selection, no client-side buffer to cap, less
+total logic (the xterm *is* the buffer). Cons: keeps N live xterm instances in
+memory (bounded by scrollback) and requires the DOM re-parenting handoff.
+
+**Variant B — manager owns ws + a capped raw-byte ring buffer; component owns a
+fresh xterm each mount.** On unmount: dispose xterm, keep ws; manager appends
+`output` to the buffer. On remount: new xterm, write the buffer. Pros: simpler
+memory model. Cons: re-implements the server's scrollback replay client-side,
+flicker/cost on every remount, loses scroll position + selection, needs a buffer
+cap. 
+
+Go with **A**. It's better UX and, because the xterm doubles as the scrollback
+store, actually less moving machinery than B.
+
+## Edge cases to preserve
+
+- **`connectKey` / session switch** (`Terminal.vue` watch, line ~255): today a
+  user action resets reconnect state and calls `connect()`. Under the manager,
+  selecting a new session = `release(old)` + `acquire(new)`; same observable
+  behavior.
+- **`superseded`** (same session open in another grid cell or browser tab): the
+  server kicks the older socket. The manager must mark that entry disconnected
+  and NOT reconnect (today's `sawExit` guard). The cell-open-elsewhere warning
+  in `TerminalCell` (`sessionOpenElsewhere`) is unaffected.
+- **`exit` / `error`**: terminal ends; suppress reconnect; the cell offers a
+  re-run. Logic moves to the manager but is unchanged.
+- **Command / Run terminals** (`props.command`, `/ws/run`): NOT persisted —
+  keep the current component-owned, never-reconnect behavior. The manager only
+  persists Claude session terminals.
+- **Resize / fit**: the `ResizeObserver` observes the persisted `host` element,
+  so it keeps firing correctly across re-parents (it observes the element, not
+  its position). On `attach`, call `fit()` + send a `resize` frame.
+- **Theme repaint**: `term.options.theme` update on theme/dir change still works;
+  the manager holds `term`, the component passes the effective theme on attach
+  and on theme-change.
+- **GUI -> LLM `submitText`** (`defineExpose`): callers (e.g. GUI message
+  submit) invoke by session; route through `manager.submitText(key, text)`. The
+  socket-pinning semantics (skip the delayed CR if the socket changed) carry over.
+
+## Implementation steps
+
+1. **Create the manager** `src/composables/useTerminalConnections.ts`: move the
+   ws lifecycle, reconnect/backoff, message protocol, xterm + fitAddon +
+   ResizeObserver, `status`/`serverCwd`, `knownSessionId`, and `submitText` /
+   `insertText` / `terminate` / `resize` out of `Terminal.vue`. Instantiate once
+   (provide/inject from App root, or a module-level singleton).
+2. **Slim `Terminal.vue`** to a view: keep header, voice, drag/drop, `pickFile`,
+   `RunMenu`, theme. On mount, `acquire` + `attach(host into terminalRef)`; on
+   unmount, `detach` (NOT close). Read `status`/`serverCwd` from the entry.
+   Delegate `submitText`/`terminate` to the manager.
+3. **Wire grid lifetime**: `TerminalCell` `acquire`s on launch/resume,
+   `attach`/`detach` on mount/unmount, `terminate` on ✕. `GridView.closeCell`
+   -> `release`/`terminate` for the dropped session so its socket closes.
+4. **Wire single-view lifetime**: `App.vue` `acquire`s the `activeId` session and
+   `release`s the previously-active one on `selectSession`/`newSession`. Ensure
+   the manager survives the Grid<->single `v-if` toggle (it lives at App root).
+5. **Verify off-page persistence**: a grid cell on a non-visible page keeps its
+   socket (no reap on page flip) — this falls out of the manager holding the ws
+   independent of which cells are mounted.
+
+## Testing / verification
+
+- Start a session, let it go idle (finish a turn), navigate away from the
+  terminal view for > 30s, come back: terminal reattaches instantly, **no**
+  "restoring session" token warning, scrollback intact (server log shows
+  reattach, not `--resume`).
+- Grid with > 9 sessions across two pages: sit on page 1 past 30s, flip to
+  page 2: page-2 cells are still connected (no cold resume).
+- Toggle Grid <-> single view and navigate to AccountingView and back: active
+  session stays connected.
+- Close a cell (✕): server reaps immediately (today's behavior preserved).
+- Switch sessions in single mode: previous session's socket closes (grace),
+  new session connects.
+- Same session opened in a second cell/tab: `superseded` handled, no reconnect
+  ping-pong.
+- Command/Run terminal: unchanged — ephemeral, no reconnect.
+
+## Risks / notes
+
+- **Client memory**: N persisted xterm instances + sockets. Bounded by scrollback
+  per terminal; fine for realistic open-tab counts. Re-evaluate if users keep
+  very many cells open.
+- **xterm re-parenting**: moving the `host` element between containers is the
+  load-bearing trick; confirm `fit()` + `scrollToBottom()` behave on re-attach
+  (the existing ResizeObserver already calls these).
+- **Dirty disappearance** (out of scope, see Non-goals): unchanged in mechanism,
+  wider in scope. Optional future WS ping/pong sweep would tighten the ~2h
+  zombie window — tracked separately.

--- a/src/App.vue
+++ b/src/App.vue
@@ -41,14 +41,15 @@ const connectKey = ref(0);
 const terminalRef = ref<InstanceType<typeof TerminalView> | null>(null);
 
 // Confirm before an accidental tab close / reload while a terminal is live. The
-// single view has one live session (when activeId is set); the grid reports its own
-// count. Only act for the single view here — when the grid is mounted it owns the
-// count (App renders one or the other).
+// single view reports its own session (0 or 1) under the "single" key; the grid
+// reports its running-cell count under "grid". They're summed, not overwritten,
+// because persistent connections keep the single PTY alive even after switching to
+// the grid — so a hidden-but-live single terminal must still count toward the guard.
 useUnloadGuard();
 watch(
   [viewMode, activeId],
   () => {
-    if (viewMode.value === "single") reportActiveTerminals(activeId.value ? 1 : 0);
+    if (viewMode.value === "single") reportActiveTerminals("single", activeId.value ? 1 : 0);
   },
   { immediate: true },
 );

--- a/src/App.vue
+++ b/src/App.vue
@@ -295,6 +295,7 @@ function onSession(id: string) {
           ref="terminalRef"
           class="terminal-pane"
           :style="{ flex: `0 0 ${terminalWidth}px` }"
+          persist-key="single"
           :session-id="activeId"
           :connect-key="connectKey"
           :dir-theme="singleDirConfig.theme"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -51,7 +51,11 @@ watch(state, persist, { deep: true });
 
 // Feed the tab-close guard: warn on close/reload while any cell runs a session or
 // command (counts every page, not just the mounted one).
-watch(() => runningCount(state.value.cells), reportActiveTerminals, { immediate: true });
+watch(
+  () => runningCount(state.value.cells),
+  (n) => reportActiveTerminals("grid", n),
+  { immediate: true },
+);
 
 const pages = computed(() => pageCount(state.value.cells.length));
 

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from "vue";
-import { Terminal, type ITheme } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import { WebLinksAddon } from "@xterm/addon-web-links";
-import "@xterm/xterm/css/xterm.css";
-import { buildTerminalWsUrl, buildRunWsUrl } from "./wsUrl";
+import { type ITheme } from "@xterm/xterm";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
 import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
 import { badgeStyleFor } from "./dirBadge";
 import { useVoiceInput } from "../composables/useVoiceInput";
+import * as conn from "../composables/useTerminalConnections";
 import RunMenu from "./RunMenu.vue";
 
 // `null` => start a fresh session; otherwise resume the given session id.
@@ -23,6 +20,10 @@ import RunMenu from "./RunMenu.vue";
 // session, and never auto-reconnects (the ephemeral process can't be resumed).
 // `runMenu` adds a ▶ Run dropdown to the header (the single view) that lists the
 // open project's script.json and emits the picked command for the parent to run.
+// `persistKey` opts this terminal into a durable connection (kept alive across
+// unmount via useTerminalConnections, keyed by this stable slot id — the grid cell's
+// uid or the single view). Absent => an ephemeral slot torn down on unmount (command
+// cells, whose Run process can't be resumed anyway).
 const props = defineProps<{
   sessionId: string | null;
   connectKey: number;
@@ -30,6 +31,7 @@ const props = defineProps<{
   devTerminal?: boolean;
   command?: { index: number } | null;
   runMenu?: boolean;
+  persistKey?: string | null;
   // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
   // terminal's xterm palette (overriding the app-wide theme for this cell only);
   // `dirColors` overrides individual palette keys on top of that; `dirName` /
@@ -45,11 +47,20 @@ const emit = defineEmits<{
   (e: "run", command: { index: number; label: string; cwd: string | null }): void;
 }>();
 
+// The durable runtime (socket + xterm) lives in the manager, keyed by a stable slot
+// id. A persisted slot survives this component's unmount; an ephemeral one is torn
+// down. Captured once — the key is stable for the component's life.
+const slotKey = props.persistKey ?? `ephemeral-${crypto.randomUUID()}`;
+function currentTarget(): conn.ConnTarget {
+  return { sessionId: props.sessionId, cwd: props.cwd ?? null, devTerminal: !!props.devTerminal, command: props.command ?? null };
+}
+
 const terminalRef = ref<HTMLDivElement>();
-const status = ref<"connecting" | "connected" | "disconnected">("connecting");
+// Connection status + server-resolved cwd are projected reactively from the manager.
+const status = computed(() => conn.connView.get(slotKey)?.status ?? "connecting");
 // The server-resolved cwd of the connected session (the open project), used by the
 // Run menu so it lists THAT directory's scripts. Falls back to the requested cwd.
-const serverCwd = ref<string | null>(props.cwd ?? null);
+const serverCwd = computed(() => conn.connView.get(slotKey)?.serverCwd ?? props.cwd ?? null);
 const dragOver = ref(false);
 const { themeId } = useTheme();
 
@@ -81,184 +92,42 @@ function voiceIcon(): string {
   return "mic";
 }
 
-let term: Terminal;
-let fitAddon: FitAddon;
-let ws: WebSocket | null = null;
 let resizeObserver: ResizeObserver;
-
-// Auto-reconnect state. A dropped/failed socket retries with backoff, resuming
-// the KNOWN session id (so we never spawn a duplicate new session per retry).
-// Reconnect is suppressed after an intentional end: the server's `exit` message
-// (claude exited) or the component unmounting.
-let knownSessionId: string | null = props.sessionId;
-let sawExit = false;
-let disposed = false;
-let reconnectAttempts = 0;
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-const RECONNECT_BASE_MS = 500;
-const RECONNECT_MAX_MS = 5000;
-
-function scheduleReconnect() {
-  // A command terminal's process is unique and unresumable — never reconnect it.
-  if (disposed || sawExit || reconnectTimer || props.command) return;
-  const delay = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempts, RECONNECT_MAX_MS);
-  reconnectAttempts++;
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    if (!disposed) connect();
-  }, delay);
-}
-
-function connect() {
-  // Tear down any existing connection. Its handlers are neutralised below by the
-  // `sock !== ws` guards once `ws` is reassigned, so a late event from the old
-  // socket can't flip the status or leak output into the new session.
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
-  }
-  if (ws) ws.close();
-  term.reset();
-  sawExit = false;
-  status.value = "connecting";
-  // Drop the previous session's resolved cwd so the Run menu can't list/launch the
-  // prior project's scripts in the window before the new `session` message arrives.
-  serverCwd.value = props.cwd ?? null;
-
-  // Resume the known id (learned from the server, or the prop) so a reconnect
-  // re-attaches the same session instead of spawning a fresh one each retry.
-  const resumeId = knownSessionId ?? props.sessionId;
-  const url = props.command
-    ? buildRunWsUrl({ host: location.host, secure: location.protocol === "https:", index: props.command.index, cwd: props.cwd })
-    : buildTerminalWsUrl({
-        host: location.host,
-        secure: location.protocol === "https:",
-        sessionId: resumeId,
-        cwd: props.cwd,
-        devTerminal: props.devTerminal,
-      });
-  const sock = new WebSocket(url);
-  ws = sock;
-
-  sock.onopen = () => {
-    if (sock !== ws) return;
-    reconnectAttempts = 0;
-    status.value = "connected";
-    sock.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
-  };
-
-  sock.onmessage = (event) => {
-    if (sock !== ws) return;
-    const msg = JSON.parse(event.data);
-    if (msg.type === "output") {
-      term.write(msg.data);
-    } else if (msg.type === "session") {
-      // Server reports the live session id — remember it so a later reconnect
-      // resumes THIS session (esp. for brand-new sessions that had no id yet) —
-      // and the EFFECTIVE cwd, which the cell adopts (the server may have fallen
-      // back from the requested dir).
-      knownSessionId = msg.id;
-      emit("session", msg.id);
-      if (typeof msg.cwd === "string") {
-        serverCwd.value = msg.cwd;
-        emit("cwd", msg.cwd);
-      }
-    } else if (msg.type === "exit") {
-      // The process exited (claude, or a Run-menu command) — an intentional end;
-      // don't auto-reconnect. The cell uses `exit` to offer a re-run.
-      sawExit = true;
-      term.write(props.command ? "\r\n\x1b[33m[finished]\x1b[0m\r\n" : "\r\n\x1b[33m[session ended]\x1b[0m\r\n");
-      status.value = "disconnected";
-      emit("exit");
-    } else if (msg.type === "superseded") {
-      // Another client (e.g. this session open in another tab/window) took over.
-      // Stop — reconnecting would kick the other one off and ping-pong forever.
-      sawExit = true;
-      term.write("\r\n\x1b[33m[detached — this session is open in another window]\x1b[0m\r\n");
-      status.value = "disconnected";
-    } else if (msg.type === "error") {
-      // Server-declared terminal failure (e.g. the `claude` CLI isn't installed, or
-      // a Run command couldn't be resolved). Not transient — reconnecting would just
-      // re-trigger the failed spawn, so stop and surface a stable error instead of
-      // looping. Emit `exit` too: it's a terminal-end, so a CommandCell can offer a
-      // re-run instead of staying stuck in a non-rerunnable "running" state.
-      sawExit = true;
-      const detail = typeof msg.message === "string" ? msg.message : "failed to start";
-      term.write(`\r\n\x1b[31m[${detail}]\x1b[0m\r\n`);
-      status.value = "disconnected";
-      emit("exit");
-    }
-  };
-
-  sock.onclose = () => {
-    // A newer socket has superseded this one — ignore its close.
-    if (sock !== ws) return;
-    status.value = "disconnected";
-    // Unexpected drop (server restart, transient network) — retry with backoff.
-    scheduleReconnect();
-  };
-
-  sock.onerror = () => {
-    if (sock !== ws) return;
-    // onclose fires after onerror and drives the reconnect; nothing to do here
-    // beyond surfacing the state.
-    status.value = "disconnected";
-  };
-}
 
 onMounted(() => {
   // Probe voice-input capability so the mic button shows only where supported.
   voice.refreshAvailability().catch(() => {});
 
-  term = new Terminal({
-    cursorBlink: true,
-    fontSize: 14,
-    fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
-    theme: effectiveTermTheme(),
-  });
-
-  fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.loadAddon(new WebLinksAddon());
-
   const container = terminalRef.value;
   if (!container) return;
-  term.open(container);
-  fitAddon.fit();
+  // Attach this view to its durable slot: creates + connects the runtime on first
+  // mount, or re-parents the already-live xterm here on a remount (no cold resume).
+  // session/cwd/exit are forwarded so the parent's existing wiring is unchanged.
+  conn.attach(
+    slotKey,
+    currentTarget(),
+    {
+      onSession: (id) => emit("session", id),
+      onCwd: (c) => emit("cwd", c),
+      onExit: () => emit("exit"),
+    },
+    container,
+    effectiveTermTheme(),
+  );
 
-  // Terminal input -> server
-  term.onData((data) => {
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "input", data }));
-    }
-  });
-
-  // Auto-resize
-  resizeObserver = new ResizeObserver(() => {
-    fitAddon.fit();
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
-    }
-    // Reflow after a resize (e.g. restoring a cell from zoom) can leave the
-    // viewport scrolled up; stick to the bottom so the prompt stays in view.
-    term.scrollToBottom();
-  });
+  // Auto-resize: fit the slot's xterm to this container and push the size to the PTY.
+  resizeObserver = new ResizeObserver(() => conn.fit(slotKey));
   resizeObserver.observe(container);
-
-  connect();
-  term.focus();
 });
 
 // Reconnect (resume a different session / start fresh) on every user action.
-// A user action picks a new target, so reset the reconnect bookkeeping and adopt
-// the new selection as the session to (re)connect to.
+// A user action picks a new target, so point the slot at the new session/cwd and
+// reconnect (closing the previous socket, which falls back to the server's grace).
 watch(
   () => props.connectKey,
   () => {
-    knownSessionId = props.sessionId;
-    reconnectAttempts = 0;
-    connect();
-    term.focus();
+    conn.retarget(slotKey, currentTarget());
+    conn.focus(slotKey);
   },
 );
 
@@ -266,44 +135,23 @@ watch(
 // changes (keeps an already-open terminal in sync with the rest of the app). A
 // dir-pinned theme ignores the app-wide change; a change to the pin itself repaints.
 watch([themeId, () => props.dirTheme, () => props.dirColors], () => {
-  if (term) term.options.theme = effectiveTermTheme();
+  conn.setTheme(slotKey, effectiveTermTheme());
 });
 
-// Submit a GUI-originated message into the PTY (same channel as keyboard input).
-// This is the GUI->LLM feedback path. We type the text, then send a SEPARATE
-// delayed carriage return — a same-burst text+CR is treated as a paste by Claude
-// Code's TUI, so the CR becomes a newline instead of submitting.
-//
-// Both writes are pinned to the socket captured *now*: if the session switches or
-// reconnects before the CR fires, that socket is no longer `ws`, so we skip the CR
-// rather than submit a stray turn in whatever session is current. Returns whether
-// the text was delivered, so the caller (e.g. a form) only locks on success.
+// Submit a GUI-originated message into the PTY (the GUI->LLM feedback path) and the
+// explicit ✕ close. Both delegate to the slot's durable runtime.
 function submitText(text: string): boolean {
-  const sock = ws;
-  if (!sock || sock.readyState !== WebSocket.OPEN) return false;
-  sock.send(JSON.stringify({ type: "input", data: text }));
-  setTimeout(() => {
-    if (sock === ws && sock.readyState === WebSocket.OPEN) {
-      sock.send(JSON.stringify({ type: "input", data: "\r" }));
-    }
-  }, 60);
-  return true;
+  return conn.submitText(slotKey, text);
 }
-// Explicit close (the cell's ✕): tell the server to reap this session now
-// instead of holding it through the disconnect grace window. Suppress reconnect
-// since the imminent unmount closes the socket.
 function terminate() {
-  sawExit = true;
-  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: "terminate" }));
+  conn.terminate(slotKey);
 }
 defineExpose({ submitText, terminate });
 
 // Insert text (a path, or space-joined paths) at the terminal cursor via the
 // normal input channel — no trailing CR, so the user reviews and submits.
 function insertText(text: string) {
-  if (!text) return;
-  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: "input", data: text }));
-  term.focus();
+  conn.insertText(slotKey, text);
 }
 
 // Drop a file onto the terminal to insert its absolute path, like a native
@@ -345,11 +193,12 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 onUnmounted(() => {
-  disposed = true;
-  if (reconnectTimer) clearTimeout(reconnectTimer);
   resizeObserver?.disconnect();
-  ws?.close();
-  term?.dispose();
+  // Persisted slot: detach the view but KEEP the connection alive (the whole point —
+  // navigating away / off-page paging doesn't reap the PTY). Ephemeral slot (command
+  // cells, whose process is unresumable): tear it down as before.
+  if (props.persistKey) conn.detach(slotKey, terminalRef.value ?? null);
+  else conn.release(slotKey);
 });
 </script>
 

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -74,6 +74,7 @@ function mountCell(
 ) {
   return mount(TerminalCell, {
     props: {
+      uid: 1,
       expanded: false,
       initialSessionId,
       initialCwd: opts.initialCwd ?? null,

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -17,6 +17,9 @@ const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 // default used to prefill the launch form; `presets` are quick-pick dirs; `home`
 // is the server home dir (to anchor the header path on ~).
 const props = defineProps<{
+  // The grid cell's stable uid — the durable-connection slot key for this cell's
+  // terminal, so flipping to an off-page tab detaches the view without reaping the PTY.
+  uid: number;
   expanded: boolean;
   initialSessionId: string | null;
   initialCwd: string | null;
@@ -740,6 +743,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
       <TerminalView
         ref="termRef"
         class="cell-term"
+        :persist-key="`cell-${uid}`"
         :session-id="sessionId"
         :connect-key="connectKey"
         :cwd="cwd"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -62,6 +62,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
         />
         <TerminalCell
           v-else
+          :uid="cell.uid"
           :expanded="cell.uid === expandedUid"
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"

--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock xterm + addons so the manager runs headless (no real DOM terminal / canvas).
+// Factories are hoisted above imports, so the fakes are declared INSIDE them.
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    options: Record<string, unknown> = {};
+    cols = 80;
+    rows = 24;
+    loadAddon() {}
+    open() {}
+    onData() {}
+    write() {}
+    reset() {}
+    focus() {}
+    scrollToBottom() {}
+    dispose() {}
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit() {}
+  },
+}));
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: class {
+    activate() {}
+  },
+}));
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+// A WebSocket double the test drives by hand (fire onopen / onmessage when it wants).
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static readonly instances: FakeWebSocket[] = [];
+  url: string;
+  readyState = FakeWebSocket.OPEN; // treat as open immediately for send() guards
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+  send(d: string) {
+    this.sent.push(d);
+  }
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+}
+
+import * as conn from "./useTerminalConnections";
+
+const target = (sessionId: string | null) => ({ sessionId, cwd: "/typed", devTerminal: false, command: null });
+
+describe("useTerminalConnections — detached-slot state replay", () => {
+  beforeEach(() => {
+    FakeWebSocket.instances.length = 0;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+  afterEach(() => {
+    conn.release("cell-race"); // tear the slot down so it can't leak into the next test
+  });
+
+  it("replays a session id learned WHILE DETACHED to the handlers bound on reattach", () => {
+    const first = { onSession: vi.fn(), onCwd: vi.fn() };
+    const el1 = document.createElement("div");
+    conn.attach("cell-race", target(null), first, el1); // fresh launch, no id yet
+    const ws = FakeWebSocket.instances.at(-1);
+    if (!ws) throw new Error("no socket created");
+    ws.onopen?.();
+
+    // User navigates away BEFORE the server reports the session id.
+    conn.detach("cell-race", el1);
+    expect(conn.connView.get("cell-race")).toBeTruthy(); // socket/slot still alive
+
+    // Server NOW assigns the id + resolves the cwd — handlers are detached, so the
+    // first view's callbacks must NOT fire (it's gone).
+    ws.onmessage?.({ data: JSON.stringify({ type: "session", id: "sess-123", cwd: "/resolved" }) });
+    expect(first.onSession).not.toHaveBeenCalled();
+
+    // Coming back must catch the parent up: the freshly-bound handlers receive the
+    // id/cwd that arrived while detached — without this the cell stays session:null
+    // and is unrestorable on reload.
+    const second = { onSession: vi.fn(), onCwd: vi.fn() };
+    const el2 = document.createElement("div");
+    conn.attach("cell-race", target(null), second, el2);
+    expect(second.onSession).toHaveBeenCalledWith("sess-123");
+    expect(second.onCwd).toHaveBeenCalledWith("/resolved");
+  });
+
+  it("does not replay a session id before the server has assigned one", () => {
+    const first = { onSession: vi.fn(), onCwd: vi.fn() };
+    const el1 = document.createElement("div");
+    conn.attach("cell-race", target(null), first, el1);
+    FakeWebSocket.instances.at(-1)?.onopen?.();
+    conn.detach("cell-race", el1);
+
+    // No `session` message yet — reattaching must not synthesize a bogus id.
+    const second = { onSession: vi.fn(), onCwd: vi.fn() };
+    conn.attach("cell-race", target(null), second, document.createElement("div"));
+    expect(second.onSession).not.toHaveBeenCalled();
+    expect(second.onCwd).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -1,0 +1,358 @@
+// A module-singleton manager that owns each terminal's durable runtime — its
+// WebSocket, xterm instance, reconnect/backoff state — independent of the Vue
+// component lifecycle. This is what lets a session's PTY stay alive (and its
+// socket stay open) while its Terminal.vue is unmounted: navigating away, flipping
+// to an off-page grid tab, or toggling Grid<->single only DETACHES the view (the
+// xterm's host element is re-parented out of the DOM), it does not close the socket.
+//
+// Why this matters: the server keeps a PTY alive for exactly as long as its
+// WebSocket is open (it only arms the reap grace timer on socket close). So holding
+// the socket open here means coming back reattaches an already-live session — no
+// `claude --resume`, no "restoring session" token cost — instead of a cold resume.
+//
+// Each terminal "slot" is addressed by a stable key: the grid cell's uid
+// (`cell-<uid>`), the single view's `single`, or an ephemeral id for command/Run
+// terminals (which are NOT persisted — their process is unresumable, so their slot
+// is released on unmount like before).
+import { reactive } from "vue";
+import { Terminal, type ITheme } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import "@xterm/xterm/css/xterm.css";
+import { buildTerminalWsUrl, buildRunWsUrl } from "../components/wsUrl";
+
+export type ConnStatus = "connecting" | "connected" | "disconnected";
+
+// What a slot connects to. Mirrors the relevant Terminal.vue props; a connectKey
+// change (session switch / relaunch) hands a fresh target to retarget().
+export interface ConnTarget {
+  sessionId: string | null;
+  cwd: string | null;
+  devTerminal: boolean;
+  command: { index: number } | null;
+}
+
+// Forwarded to whatever component is currently attached, so the parent's existing
+// session/cwd/exit wiring (grid_v2 persistence, recent-dir recording, re-run UI)
+// keeps working unchanged. Cleared on detach; a detached slot still tracks its
+// knownSessionId internally for a later reattach.
+export interface ConnHandlers {
+  onSession?: (id: string) => void;
+  onCwd?: (cwd: string) => void;
+  onExit?: () => void;
+}
+
+interface Conn {
+  key: string;
+  term: Terminal;
+  fitAddon: FitAddon;
+  host: HTMLDivElement; // term.open()'d into this ONCE; re-parented on attach/detach
+  ws: WebSocket | null;
+  knownSessionId: string | null;
+  target: ConnTarget;
+  handlers: ConnHandlers;
+  sawExit: boolean; // an intentional end (exit/superseded/error) — suppress reconnect
+  released: boolean; // torn down — suppress reconnect and stray socket events
+  reconnectAttempts: number;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  attachedEl: HTMLElement | null;
+}
+
+const RECONNECT_BASE_MS = 500;
+const RECONNECT_MAX_MS = 5000;
+
+// The heavy per-slot runtime (non-reactive — Vue never needs to track these).
+const conns = new Map<string, Conn>();
+
+// The reactive projection the view binds to (status pill, RunMenu cwd). Keyed by
+// the same slot key; a slot that hasn't connected yet (or was released) is absent.
+export const connView = reactive(new Map<string, { status: ConnStatus; serverCwd: string | null }>());
+
+function setStatus(c: Conn, s: ConnStatus) {
+  const v = connView.get(c.key);
+  if (v) v.status = s;
+}
+
+function ensure(key: string, target: ConnTarget): Conn {
+  const existing = conns.get(key);
+  if (existing) {
+    existing.target = target;
+    return existing;
+  }
+  const term = new Terminal({
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
+  });
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.loadAddon(new WebLinksAddon());
+  const host = document.createElement("div");
+  host.style.width = "100%";
+  host.style.height = "100%";
+  term.open(host);
+
+  const c: Conn = {
+    key,
+    term,
+    fitAddon,
+    host,
+    ws: null,
+    knownSessionId: target.sessionId,
+    target,
+    handlers: {},
+    sawExit: false,
+    released: false,
+    reconnectAttempts: 0,
+    reconnectTimer: null,
+    attachedEl: null,
+  };
+  conns.set(key, c);
+  connView.set(key, { status: "connecting", serverCwd: target.cwd });
+
+  // Terminal input -> the slot's CURRENT socket (survives reconnects: `c.ws` is
+  // re-read each keystroke, so input always targets the live socket).
+  term.onData((data) => {
+    if (c.ws && c.ws.readyState === WebSocket.OPEN) {
+      c.ws.send(JSON.stringify({ type: "input", data }));
+    }
+  });
+  return c;
+}
+
+function scheduleReconnect(c: Conn) {
+  // A command/Run process is unique and unresumable — never reconnect it. A
+  // released or intentionally-ended slot stays down too.
+  if (c.released || c.sawExit || c.reconnectTimer || c.target.command) return;
+  const delay = Math.min(RECONNECT_BASE_MS * 2 ** c.reconnectAttempts, RECONNECT_MAX_MS);
+  c.reconnectAttempts++;
+  c.reconnectTimer = setTimeout(() => {
+    c.reconnectTimer = null;
+    if (!c.released) connect(c);
+  }, delay);
+}
+
+function connect(c: Conn) {
+  if (c.released) return;
+  if (c.reconnectTimer) {
+    clearTimeout(c.reconnectTimer);
+    c.reconnectTimer = null;
+  }
+  // Neutralise the old socket's late events via the `sock !== c.ws` guards below.
+  if (c.ws) c.ws.close();
+  c.term.reset();
+  c.sawExit = false;
+  setStatus(c, "connecting");
+  // Drop the previous session's resolved cwd so the Run menu can't list/launch the
+  // prior project's scripts before the new `session` message arrives.
+  const v = connView.get(c.key);
+  if (v) v.serverCwd = c.target.cwd;
+
+  // Resume the known id (server-learned, or the prop) so a reconnect re-attaches the
+  // same session instead of spawning a fresh one each retry.
+  const resumeId = c.knownSessionId ?? c.target.sessionId;
+  const secure = location.protocol === "https:";
+  const url = c.target.command
+    ? buildRunWsUrl({ host: location.host, secure, index: c.target.command.index, cwd: c.target.cwd })
+    : buildTerminalWsUrl({ host: location.host, secure, sessionId: resumeId, cwd: c.target.cwd, devTerminal: c.target.devTerminal });
+  const sock = new WebSocket(url);
+  c.ws = sock;
+
+  sock.onopen = () => {
+    if (sock !== c.ws) return;
+    c.reconnectAttempts = 0;
+    setStatus(c, "connected");
+    sock.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
+  };
+  sock.onmessage = (event) => {
+    if (sock !== c.ws) return;
+    handleMessage(c, event);
+  };
+  sock.onclose = () => {
+    if (sock !== c.ws) return;
+    setStatus(c, "disconnected");
+    scheduleReconnect(c);
+  };
+  sock.onerror = () => {
+    if (sock !== c.ws) return;
+    setStatus(c, "disconnected");
+  };
+}
+
+function handleMessage(c: Conn, event: MessageEvent) {
+  const msg = JSON.parse(event.data);
+  if (msg.type === "output") {
+    c.term.write(msg.data);
+  } else if (msg.type === "session") {
+    // Server reports the live session id — remember it so a later reconnect resumes
+    // THIS session (esp. brand-new sessions that had no id yet) and the effective cwd.
+    c.knownSessionId = msg.id;
+    c.handlers.onSession?.(msg.id);
+    if (typeof msg.cwd === "string") {
+      const v = connView.get(c.key);
+      if (v) v.serverCwd = msg.cwd;
+      c.handlers.onCwd?.(msg.cwd);
+    }
+  } else if (msg.type === "exit") {
+    // The process exited (claude, or a Run command) — an intentional end; don't
+    // auto-reconnect. The cell uses `exit` to offer a re-run.
+    c.sawExit = true;
+    c.term.write(c.target.command ? "\r\n\x1b[33m[finished]\x1b[0m\r\n" : "\r\n\x1b[33m[session ended]\x1b[0m\r\n");
+    setStatus(c, "disconnected");
+    c.handlers.onExit?.();
+  } else if (msg.type === "superseded") {
+    // Another client (this session open in another tab/cell) took over. Stop —
+    // reconnecting would kick the other one off and ping-pong forever.
+    c.sawExit = true;
+    c.term.write("\r\n\x1b[33m[detached — this session is open in another window]\x1b[0m\r\n");
+    setStatus(c, "disconnected");
+  } else if (msg.type === "error") {
+    // Server-declared terminal failure (CLI missing, command unresolvable). Not
+    // transient — reconnecting would re-trigger the failed spawn, so stop and
+    // surface a stable error. Emit `exit` so a CommandCell can offer a re-run.
+    c.sawExit = true;
+    const detail = typeof msg.message === "string" ? msg.message : "failed to start";
+    c.term.write(`\r\n\x1b[31m[${detail}]\x1b[0m\r\n`);
+    setStatus(c, "disconnected");
+    c.handlers.onExit?.();
+  }
+}
+
+// Mount a view onto a slot: create the runtime on first acquire (and connect),
+// otherwise reattach the persisted xterm to the new DOM host. Never reconnects an
+// already-live slot — that's the whole point (no cold resume on remount).
+export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, el: HTMLElement, theme?: ITheme) {
+  const created = !conns.has(key);
+  const c = ensure(key, target);
+  c.released = false;
+  c.handlers = handlers;
+  c.attachedEl = el;
+  el.appendChild(c.host);
+  if (theme) c.term.options.theme = theme;
+  if (created) connect(c);
+  // Fit to the (now on-screen) host, sync the PTY size, and stick to the bottom.
+  try {
+    c.fitAddon.fit();
+  } catch {
+    // host not laid out yet — the ResizeObserver fit() will follow
+  }
+  if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
+  c.term.scrollToBottom();
+  c.term.focus();
+}
+
+// Unmount a view but KEEP the slot alive (socket stays open, PTY stays alive). The
+// xterm's host is re-parented out of the DOM; the buffer/scrollback are preserved.
+export function detach(key: string, el: HTMLElement | null) {
+  const c = conns.get(key);
+  if (!c) return;
+  if (el && c.attachedEl !== el) return; // a newer attach already took over this slot
+  c.handlers = {};
+  if (c.host.parentElement) c.host.remove();
+  c.attachedEl = null;
+}
+
+// connectKey changed (session switch / relaunch in the same slot): point the slot
+// at the new target and reconnect. Closes the previous socket, so the previous
+// session falls back to the server's reap grace.
+export function retarget(key: string, target: ConnTarget) {
+  const c = conns.get(key);
+  if (!c) return;
+  c.target = target;
+  c.knownSessionId = target.sessionId;
+  c.reconnectAttempts = 0;
+  c.sawExit = false;
+  c.released = false;
+  connect(c);
+}
+
+// Permanently tear the slot down (close socket, dispose xterm). Used for ephemeral
+// (command) slots on unmount, and as the back end of terminate().
+export function release(key: string) {
+  const c = conns.get(key);
+  if (!c) return;
+  c.released = true;
+  if (c.reconnectTimer) {
+    clearTimeout(c.reconnectTimer);
+    c.reconnectTimer = null;
+  }
+  try {
+    c.ws?.close();
+  } catch {
+    // already closing
+  }
+  c.ws = null;
+  try {
+    c.host.remove();
+  } catch {
+    // not in the DOM
+  }
+  try {
+    c.term.dispose();
+  } catch {
+    // already disposed
+  }
+  conns.delete(key);
+  connView.delete(key);
+}
+
+// Explicit close (the cell's ✕): tell the server to reap this session NOW instead
+// of holding it through the disconnect grace window, then tear the slot down.
+export function terminate(key: string) {
+  const c = conns.get(key);
+  if (!c) return;
+  c.sawExit = true;
+  if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "terminate" }));
+  release(key);
+}
+
+// Submit a GUI-originated message into the PTY (text + a SEPARATE delayed CR — a
+// same-burst text+CR reads as a paste in Claude's TUI). Both writes pin to the
+// socket captured now; if the slot reconnects before the CR fires we skip it rather
+// than submit a stray turn. Returns whether the text was delivered.
+export function submitText(key: string, text: string): boolean {
+  const c = conns.get(key);
+  if (!c) return false;
+  const sock = c.ws;
+  if (!sock || sock.readyState !== WebSocket.OPEN) return false;
+  sock.send(JSON.stringify({ type: "input", data: text }));
+  setTimeout(() => {
+    if (c.ws === sock && sock.readyState === WebSocket.OPEN) {
+      sock.send(JSON.stringify({ type: "input", data: "\r" }));
+    }
+  }, 60);
+  return true;
+}
+
+// Insert text (a path, or space-joined paths) at the cursor via the normal input
+// channel — no trailing CR, so the user reviews and submits.
+export function insertText(key: string, text: string) {
+  if (!text) return;
+  const c = conns.get(key);
+  if (!c) return;
+  if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "input", data: text }));
+  c.term.focus();
+}
+
+export function focus(key: string) {
+  conns.get(key)?.term.focus();
+}
+
+// Refit to the current host size and push the new dimensions to the PTY.
+export function fit(key: string) {
+  const c = conns.get(key);
+  if (!c || !c.attachedEl) return;
+  try {
+    c.fitAddon.fit();
+  } catch {
+    // host has no size yet
+  }
+  if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
+  // Reflow after a resize can leave the viewport scrolled up; stick to the bottom.
+  c.term.scrollToBottom();
+}
+
+export function setTheme(key: string, theme: ITheme) {
+  const c = conns.get(key);
+  if (c) c.term.options.theme = theme;
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -49,6 +49,7 @@ interface Conn {
   host: HTMLDivElement; // term.open()'d into this ONCE; re-parented on attach/detach
   ws: WebSocket | null;
   knownSessionId: string | null;
+  knownCwd: string | null; // server-resolved cwd, replayed on (re)attach
   target: ConnTarget;
   handlers: ConnHandlers;
   sawExit: boolean; // an intentional end (exit/superseded/error) — suppress reconnect
@@ -99,6 +100,7 @@ function ensure(key: string, target: ConnTarget): Conn {
     host,
     ws: null,
     knownSessionId: target.sessionId,
+    knownCwd: null,
     target,
     handlers: {},
     sawExit: false,
@@ -189,6 +191,7 @@ function handleMessage(c: Conn, event: MessageEvent) {
     c.knownSessionId = msg.id;
     c.handlers.onSession?.(msg.id);
     if (typeof msg.cwd === "string") {
+      c.knownCwd = msg.cwd;
       const v = connView.get(c.key);
       if (v) v.serverCwd = msg.cwd;
       c.handlers.onCwd?.(msg.cwd);
@@ -227,6 +230,13 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   c.released = false;
   c.handlers = handlers;
   c.attachedEl = el;
+  // Replay server-learned session/cwd to the freshly-bound handlers. Without this,
+  // a slot that learned its id/cwd WHILE DETACHED (handlers were cleared) would
+  // never forward them, leaving the parent persisted as `session: null` and the
+  // session unrestorable on reload. Only the new-vs-known case actually fires a
+  // useful update; the parent's setters are idempotent for already-known values.
+  if (c.knownSessionId) handlers.onSession?.(c.knownSessionId);
+  if (c.knownCwd) handlers.onCwd?.(c.knownCwd);
   el.appendChild(c.host);
   if (theme) c.term.options.theme = theme;
   if (created) connect(c);
@@ -260,6 +270,7 @@ export function retarget(key: string, target: ConnTarget) {
   if (!c) return;
   c.target = target;
   c.knownSessionId = target.sessionId;
+  c.knownCwd = null;
   c.reconnectAttempts = 0;
   c.sawExit = false;
   c.released = false;

--- a/src/composables/useUnloadGuard.spec.ts
+++ b/src/composables/useUnloadGuard.spec.ts
@@ -20,7 +20,10 @@ const fireBeforeUnload = (): boolean => {
 
 describe("useUnloadGuard", () => {
   let wrapper: ReturnType<typeof mount> | null = null;
-  beforeEach(() => reportActiveTerminals(0));
+  beforeEach(() => {
+    reportActiveTerminals("single", 0);
+    reportActiveTerminals("grid", 0);
+  });
   // Unmount between tests so no host's listener lingers and skews the next case.
   afterEach(() => {
     wrapper?.unmount();
@@ -34,21 +37,42 @@ describe("useUnloadGuard", () => {
 
   it("blocks the unload while a terminal is live", () => {
     wrapper = mount(Host);
-    reportActiveTerminals(2);
+    reportActiveTerminals("grid", 2);
     expect(fireBeforeUnload()).toBe(true);
   });
 
   it("stops blocking again once the count drops to zero", () => {
     wrapper = mount(Host);
-    reportActiveTerminals(1);
+    reportActiveTerminals("grid", 1);
     expect(fireBeforeUnload()).toBe(true);
-    reportActiveTerminals(0);
+    reportActiveTerminals("grid", 0);
+    expect(fireBeforeUnload()).toBe(false);
+  });
+
+  // The persistent-connection case: a single session stays live (its socket is kept
+  // open) after switching to the grid, where the grid reports 0 running cells. The
+  // hidden single terminal must still count, so the two sources are summed.
+  it("still blocks when only the hidden single terminal is live", () => {
+    wrapper = mount(Host);
+    reportActiveTerminals("single", 1);
+    reportActiveTerminals("grid", 0);
+    expect(fireBeforeUnload()).toBe(true);
+  });
+
+  it("blocks while either source is live and clears only when both are zero", () => {
+    wrapper = mount(Host);
+    reportActiveTerminals("single", 1);
+    reportActiveTerminals("grid", 2);
+    expect(fireBeforeUnload()).toBe(true);
+    reportActiveTerminals("grid", 0);
+    expect(fireBeforeUnload()).toBe(true); // single still live
+    reportActiveTerminals("single", 0);
     expect(fireBeforeUnload()).toBe(false);
   });
 
   it("removes the listener on unmount (no lingering guard)", () => {
     wrapper = mount(Host);
-    reportActiveTerminals(3);
+    reportActiveTerminals("grid", 3);
     wrapper.unmount();
     wrapper = null;
     expect(fireBeforeUnload()).toBe(false);

--- a/src/composables/useUnloadGuard.ts
+++ b/src/composables/useUnloadGuard.ts
@@ -1,13 +1,24 @@
 import { onMounted, onUnmounted, ref } from "vue";
 
-// How many live terminals the mounted view reports: the single view reports its
-// active session (0 or 1), the grid reports its running-cell count. Module-level so
-// the guard reads it without prop threading; the two views are mutually exclusive
-// (only one is mounted), so whichever is on screen owns the value.
-const activeTerminals = ref(0);
+// How many live terminals each view reports, keyed by source ("single", "grid").
+// Keyed — not a single shared counter — because persistent connections mean the
+// single view's PTY and the grid's PTYs can be alive AT THE SAME TIME: switching
+// from the single view to the grid no longer closes the single socket. A single
+// overwritten ref would let whichever view mounted last hide the other's live
+// terminals from the close warning. Each source keeps its last reported count until
+// its own view updates it, which mirrors the connections actually staying alive.
+const counts = ref(new Map<string, number>());
 
-export function reportActiveTerminals(count: number): void {
-  activeTerminals.value = count;
+export function reportActiveTerminals(source: string, count: number): void {
+  counts.value.set(source, count);
+  // Reassign to trip reactivity (Map mutation alone isn't tracked by a plain ref).
+  counts.value = new Map(counts.value);
+}
+
+function totalActive(): number {
+  let total = 0;
+  for (const n of counts.value.values()) total += n;
+  return total;
 }
 
 // Warn before the tab closes / reloads / navigates away while a terminal is live,
@@ -18,7 +29,7 @@ export function reportActiveTerminals(count: number): void {
 // fixed by the browser and can't be customised.
 export function useUnloadGuard(): void {
   const onBeforeUnload = (e: BeforeUnloadEvent) => {
-    if (activeTerminals.value <= 0) return;
+    if (totalActive() <= 0) return;
     e.preventDefault();
     e.returnValue = ""; // legacy Chrome/Edge still need returnValue assigned to prompt
   };


### PR DESCRIPTION
## Problem

When you leave a terminal in multi-terminal (grid) mode — or switch away from the chat view — the Vue component unmounts, its WebSocket closes, and the server reaps the Claude PTY after a grace period. Coming back re-mounts the component, which cold-restarts the session via `claude --resume`. Because the Anthropic prompt cache has only a 5-minute TTL, this reprocesses the full context at the uncached rate and triggers Claude Code's "restoring this session will consume a lot of tokens" warning.

VS Code doesn't have this problem because its terminal apps keep running while hidden.

## Approach (client-only, zero server change)

Decouple the WebSocket + xterm lifetime from the Vue component lifetime. A module-singleton **connection manager** (`useTerminalConnections.ts`) owns each terminal's `Terminal` + `FitAddon` + a once-`open()`'d host `<div>` + `WebSocket`, keyed by a stable slot id:

- `attach(key, …, el)` — on first acquire, creates the terminal and connects; on later acquires, **re-parents the existing host div** into the new mount point (Variant A) instead of reconnecting a live slot.
- `detach(key, el)` — re-parents the host out of the DOM but keeps the socket alive.
- `release(key)` / `terminate(key)` — for ephemeral and command slots, fully tears down on unmount.

Because an open WebSocket keeps the server PTY alive indefinitely, navigating away no longer reaps it. `Terminal.vue` is slimmed to a thin view over the manager; its public props/emits/exposed methods are unchanged.

Persist keys:
- single chat view → `"single"`
- grid cells → `"cell-<uid>"`
- ephemeral / command terminals → released on unmount (unchanged behavior)

## Backstop

Closing the browser tab still tears down the TCP socket cleanly, so the server's existing reap grace tiers (`working`=never, `waiting`=30 min, `idle`=30 s) remain the backstop. "Dirty disappearance" (laptop sleep / crash leaving a zombie socket) is a pre-existing condition and explicitly out of scope.

See `plans/feat-persistent-terminal-connections.md` for the full design.

## Testing

- `yarn lint`, `yarn format:check` — clean
- `yarn typecheck` + `yarn typecheck:server` — clean
- `yarn build` — succeeds
- `yarn test` — 477 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)