### PR TITLE
feat(wiki): read-only Wiki browser on MulmoTerminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@mulmoclaude/accounting-plugin": "^0.2.0",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.5.21",
-    "@mulmoclaude/core": "^0.2.15",
+    "@mulmoclaude/core": "^0.5.0",
     "@mulmoclaude/form-plugin": "^0.1.3",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.7",

--- a/plans/feat-wiki.md
+++ b/plans/feat-wiki.md
@@ -1,0 +1,171 @@
+# feat: Wiki on MulmoTerminal (shared engine + shared UI via core)
+
+> **Status (updated):**
+> - **Phase 1 (pure engine → core): DONE & merged** — MulmoClaude PR #1875. `core@0.4.0`.
+> - **vue-router adoption in MT: DONE** — `/wiki` routes exist (see `feat-vue-router.md`).
+> - **Phase 1.5 (server read-engine → core): DONE & merged** — MulmoClaude PR #1876.
+>   `core@0.5.0` (`./wiki/server` + `./wiki/paths`).
+> - **MT-native read-only overlay (old Phase 2/3): SUPERSEDED — to be removed.** The
+>   bespoke MT overlay (`useWikiBrowse`, `WikiBrowseOverlay`, Index/Page/Graph/Lint
+>   views, `wikiImageSrc.ts`, `wiki.spec.ts`) is **abandoned** in favor of sharing
+>   MulmoClaude's full wiki Vue component (decision below).
+> - **New direction (Phases A–C): NOT STARTED** — extract MC's wiki UI into a shared,
+>   capability-gated `@mulmoclaude/wiki-plugin/vue`; both apps render it (editable).
+
+## User Prompt
+
+> What does it take to provide the same Wiki feature on MulmoTerminal? We will
+> obviously share the workspace.
+
+…then: **make MT's wiki UI editable**, and **share MulmoClaude's full wiki UI** rather
+than maintain a separate MT-native overlay.
+
+## Decision (supersedes the earlier read-only / MT-native plan)
+
+Earlier this plan built a lean **MT-native, read-only** overlay (old Phase 2/3). The
+user has reversed both calls:
+
+1. **Editable**, not read-only (save + task-checkbox toggle, at least).
+2. **One shared UI**, not two — extract MulmoClaude's wiki Vue into
+   `@mulmoclaude/wiki-plugin/vue` (mirroring `@mulmoclaude/collection-plugin/vue`),
+   capability-gated, and render it in **both** apps.
+
+Rationale: with MT going editable, the per-feature cost of re-implementing MC's UI in
+MT compounds, and divergence between two wiki UIs over the same workspace becomes a
+maintenance/UX liability. A single shared component (with host-injected seams) is the
+better long-run shape — the same precedent Collections already follows.
+
+The MT-native overlay code from old Phase 2/3 is **removed** as part of this work.
+
+## What's already shared (reused as-is)
+
+- **`@mulmoclaude/core/wiki`** (browser-safe pure engine) — link/slug/index-parse/lint/
+  graph/route/render. The shared component imports these directly.
+- **`@mulmoclaude/core/wiki/server`** (read engine) — `readWikiIndex` / `readWikiPage` /
+  `loadWikiGraph` / `collectLintIssues` / `resolvePagePath` / `getPageIndex` /
+  `parseFrontmatter(Tags)` / `wikiDirs`. Each host mounts a thin route over this.
+
+## Architecture (target)
+
+Three shared layers + per-host glue (the Collections shape, extended to the UI):
+
+1. **Shared pure engine** — `@mulmoclaude/core/wiki` ✅ done.
+2. **Shared server engine** — `@mulmoclaude/core/wiki/server`: read ✅ done; **write
+   added in Phase A**.
+3. **Shared Vue UI** — `@mulmoclaude/wiki-plugin/vue` (**Phase B**): the View +
+   WikiPageBody + WikiGraphView + history/* components, with every host seam turned
+   into an injected capability.
+4. **Per-host glue** — each host mounts a thin `/api/wiki` route over the core engine
+   and provides a **binding** (data fetch, save, image-URL resolution, navigation,
+   locale, optional history/PDF/composer) that wires the shared component to it.
+   MulmoClaude provides the full binding; MulmoTerminal provides a reduced one.
+
+## Capability gating — the crux
+
+MulmoClaude's `View.vue` is welded to host seams; each becomes an injected capability
+so MT can supply a subset:
+
+| MC host seam | Becomes | MC provides | MT provides |
+|---|---|---|---|
+| `apiPost` / `useFreshPluginData` (data fetch) | injected fetch/save | MC `/api/wiki` | MT `/api/wiki` |
+| `useAppApi.navigateToWorkspacePath` / wiki-link nav | injected `navigate(target)` | real | router push |
+| image-ref rewriting | injected `resolveImageSrc(ref)` | MC image resolver | MT `/api/files/raw` |
+| vue-i18n (`t`) | injected `t` / label set | vue-i18n | plain strings (MT has no vue-i18n) |
+| `usePdfDownload` | optional capability | provided | **omitted** (no PDF button) |
+| `PageChatComposer` (spawns a chat session) | optional capability/slot | provided | **omitted** (MT has no chat sessions) |
+| version history (snapshots) | optional capability | provided | **omitted initially** (deferred) |
+| save / task-checkbox toggle | injected `save(slug, content)` | MC save route | MT `POST /api/wiki` |
+
+When a capability is absent the component hides that affordance (e.g. no History tab,
+no PDF button) — so MT renders an editable browse/save UI, MC keeps its full feature
+set, from one component.
+
+## Phase A — MulmoClaude: promote the write side into core (`core@0.6.0`)
+
+Same anti-drift move as the read engine. Move `writeWikiPage` from
+`server/workspace/wiki-pages/io.ts` into `@mulmoclaude/core/wiki/server` (mirrors
+`collection/server`'s `writeItem`): atomic write (core gains an atomic-write helper,
+precedented by `collection/server/atomic.ts`) + frontmatter stamping (`created` /
+`updated` / `editor` via write-side `serializeWithFrontmatter` / `mergeFrontmatter`,
+js-yaml dump). **Snapshots stay host-injected** — core `writeWikiPage` takes an optional
+`onWritten`/`snapshot` hook; MC passes `appendSnapshot`, MT passes nothing. Bump
+`core` → **0.6.0**, publish; bump consumers + MT to `^0.6.0`. ⚠️ `smoke` red until
+0.6.0 is on npm (CLI imports the new write export).
+
+## Phase B — Extract MC's wiki Vue into `@mulmoclaude/wiki-plugin/vue`
+
+- New package `packages/plugins/wiki-plugin` (Vue-only, mirrors `collection-plugin`):
+  move `src/plugins/wiki/{View,Preview}.vue`, `components/{WikiPageBody,WikiGraphView}`,
+  `history/*`, `helpers.ts`, and consume `route.ts` from core (already there).
+- Replace host imports with an injected **host binding** (a `configureWikiHost(...)` /
+  provider, the pattern `collectionUi.ts` uses): data fetch/save, `navigate`,
+  `resolveImageSrc`, `t`, and optional `history` / `pdf` / `composer` capabilities.
+- Drop the hard vue-i18n / `useAppApi` / `PageChatComposer` / `usePdfDownload` imports;
+  gate each behind the binding.
+- **MulmoClaude refactor**: MC consumes the component from `@mulmoclaude/wiki-plugin/vue`
+  instead of `src/plugins/wiki/`, supplying the full binding (history, PDF, composer,
+  snapshots). This is surgery on a shipped app — keep behavior identical; lean on the
+  existing wiki e2e/unit tests. Publish `@mulmoclaude/wiki-plugin`.
+
+## Phase C — MulmoTerminal integration
+
+- Add `@mulmoclaude/wiki-plugin` (+ `/vue`) to MT deps and `plugins.json`.
+- **Mount a thin `/api/wiki` route** over `@mulmoclaude/core/wiki/server` (read GET +
+  `POST` save from Phase A). This is the shared component's data source. (If the old
+  Phase-2 `server/backends/wiki.ts` exists, repurpose it; otherwise add it.)
+- **`src/composables/wikiUi.ts`** — MT's host binding (mirror `collectionUi.ts`):
+  fetch/save → `/api/wiki`; `resolveImageSrc` → `/api/files/raw`; `navigate` → router
+  push to `/wiki/pages/:slug`; `t` → plain strings; **omit** history/PDF/composer.
+- **`WikiBrowseOverlay.vue`** — render the shared component (via `PluginFrame` / shadow
+  DOM, like `CollectionsBrowseOverlay`) on the existing `/wiki` routes, opened from the
+  `menu_book` toolbar button.
+- **Remove** the abandoned MT-native overlay (`useWikiBrowse`, the bespoke
+  `WikiBrowseOverlay` views, `wikiImageSrc.ts`, `wiki.spec.ts`) — superseded.
+
+## Snapshots / history (still deferred)
+
+The core writer leaves a snapshot injection point; MT passes none, so MT saves without
+history and the component's History tab is hidden (capability absent). Settle the
+shared-workspace **snapshot-ownership** question (who snapshots when both apps edit the
+same files?) before wiring MT's.
+
+## Out of scope
+
+- **MT version-history / PDF / chat-composer** — MC-only capabilities the shared
+  component renders only when the host provides them.
+- **Snapshots in MT** — deferred (see above).
+
+## Tests
+
+- Core: read-engine tests ✅ + Phase A `writeWikiPage` tests (atomic write, stamping,
+  injected snapshot hook fires).
+- `@mulmoclaude/wiki-plugin`: component renders with a stub binding; capability-absent
+  → affordance hidden (no History tab when `history` capability omitted).
+- MT: `/api/wiki` route (GET + POST save round-trip, unsafe slug rejected); binding
+  wiring smoke.
+- MulmoClaude: existing wiki e2e/unit suites must stay green through the Phase B refactor.
+
+## Gates
+
+`yarn format` / `yarn lint` / `yarn build` / `yarn typecheck` / `yarn test`
+
+## Sequence
+
+1. ~~mulmoclaude: pure engine → core~~ ✅ (`core@0.4.0`, PR #1875).
+2. ~~MT: adopt vue-router~~ ✅.
+3. ~~mulmoclaude: server read-engine → core~~ ✅ (`core@0.5.0`, PR #1876).
+4. **mulmoclaude: Phase A — write side → core, bump + publish `core@0.6.0`.**
+5. **mulmoclaude: Phase B — extract wiki Vue → `@mulmoclaude/wiki-plugin/vue`
+   (capability-gated), refactor MC to consume it, publish the plugin.**
+6. **MT: Phase C — `/api/wiki` route + `wikiUi.ts` binding + `WikiBrowseOverlay`
+   rendering the shared component; remove the old MT-native overlay.**
+
+## Open decisions
+
+- **Which MC features the shared component exposes** vs. keeps internal — confirm the
+  capability list above (esp. whether MT ever wants history/PDF).
+- **Create-new-pages from the UI?** MC's save route refuses creation (new pages come
+  from Claude). Default: match MC.
+- **Phase B sequencing risk** — refactoring MC to consume its own extracted component
+  is the riskiest step; consider landing it behind the existing wiki test suite first,
+  before MT consumes it.

--- a/server/backends/wiki.spec.ts
+++ b/server/backends/wiki.spec.ts
@@ -65,6 +65,12 @@ describe("GET /api/wiki?slug=", () => {
   it("400s an unsafe slug", async () => {
     expect((await fetch(`${base}/api/wiki?slug=${encodeURIComponent("../../etc/passwd")}`)).status).toBe(400);
   });
+
+  it("400s a repeated (array) slug query rather than 500ing", async () => {
+    // `?slug=a&slug=b` parses to a string[], which the typeof guard must reject before
+    // it ever reaches readWikiPage.
+    expect((await fetch(`${base}/api/wiki?slug=a&slug=b`)).status).toBe(400);
+  });
 });
 
 describe("GET /api/wiki/graph", () => {

--- a/server/backends/wiki.spec.ts
+++ b/server/backends/wiki.spec.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Server } from "node:http";
+import { mountWikiRoutes } from "./wiki.js";
+
+// A minimal wiki laid out at core's canonical location (wikiDirs):
+//   <ws>/data/wiki/index.md       — the index (two bullet [[links]])
+//   <ws>/data/wiki/pages/*.md     — the page files (alpha links to beta)
+//   <ws>/data/wiki/log.md         — the activity log
+// alpha → beta gives one graph edge; both pages are indexed so lint is clean.
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  const ws = mkdtempSync(path.join(tmpdir(), "mt-wiki-"));
+  const wikiDir = path.join(ws, "data", "wiki");
+  mkdirSync(path.join(wikiDir, "pages"), { recursive: true });
+  writeFileSync(path.join(wikiDir, "index.md"), "# Index\n\n- [[alpha]]\n- [[beta]]\n");
+  writeFileSync(path.join(wikiDir, "pages", "alpha.md"), "# Alpha\n\nLinks to [[beta]].\n");
+  writeFileSync(path.join(wikiDir, "pages", "beta.md"), "# Beta\n\nNo links.\n");
+  writeFileSync(path.join(wikiDir, "log.md"), "log line\n");
+
+  const app = express();
+  mountWikiRoutes(app, { workspace: ws });
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => resolve());
+  });
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+describe("GET /api/wiki", () => {
+  it("returns the index content + parsed entries", async () => {
+    const res = await fetch(`${base}/api/wiki`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string; entries: Array<{ slug: string; title: string }> };
+    expect(body.content).toContain("[[alpha]]");
+    expect(body.entries.map((e) => e.slug)).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("GET /api/wiki?slug=", () => {
+  it("returns an existing page", async () => {
+    const res = await fetch(`${base}/api/wiki?slug=alpha`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { exists: boolean; content: string; resolvedTitle: string };
+    expect(body.exists).toBe(true);
+    expect(body.content).toContain("[[beta]]");
+    expect(body.resolvedTitle).toBe("alpha");
+  });
+
+  it("404s a missing page", async () => {
+    const res = await fetch(`${base}/api/wiki?slug=ghost`);
+    expect(res.status).toBe(404);
+  });
+
+  it("400s an unsafe slug", async () => {
+    expect((await fetch(`${base}/api/wiki?slug=${encodeURIComponent("../../etc/passwd")}`)).status).toBe(400);
+  });
+});
+
+describe("GET /api/wiki/graph", () => {
+  it("returns nodes + the resolved alpha→beta edge", async () => {
+    const res = await fetch(`${base}/api/wiki/graph`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { nodes: Array<{ slug: string }>; edges: Array<{ from: string; to: string }> };
+    expect(body.nodes.map((n) => n.slug).sort()).toEqual(["alpha", "beta"]);
+    expect(body.edges).toEqual([{ from: "alpha", to: "beta" }]);
+  });
+});
+
+describe("GET /api/wiki/lint", () => {
+  it("returns issues + a rendered report (healthy fixture)", async () => {
+    const res = await fetch(`${base}/api/wiki/lint`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { issues: string[]; report: string };
+    expect(body.issues).toEqual([]);
+    expect(typeof body.report).toBe("string");
+    expect(body.report.length).toBeGreaterThan(0);
+  });
+});

--- a/server/backends/wiki.ts
+++ b/server/backends/wiki.ts
@@ -31,9 +31,11 @@ export function mountWikiRoutes(app: Express, deps: { workspace: string }): void
   app.get("/api/wiki", async (req: Request, res: Response) => {
     const slug = req.query.slug;
     if (slug !== undefined) {
-      // A crafted slug must never escape `data/wiki/pages` — guard before the read.
-      // Containment is also enforced inside the core engine, but reject early here.
-      if (!isSafeWikiSlug(slug)) {
+      // Reject non-string query shapes (`?slug[a]=x` → object, `?slug=a&slug=b` →
+      // array) with a deterministic 400 before any other handling, then guard the
+      // value so a crafted slug can never escape `data/wiki/pages` (containment is also
+      // enforced inside the core engine, but reject early here).
+      if (typeof slug !== "string" || !isSafeWikiSlug(slug)) {
         res.status(400).json({ error: `invalid wiki slug: ${String(slug)}` });
         return;
       }

--- a/server/backends/wiki.ts
+++ b/server/backends/wiki.ts
@@ -1,0 +1,82 @@
+// Read-only wiki routes over the SHARED workspace (CLAUDE_CWD, default ~/mulmoclaude).
+// MulmoTerminal is a second live view over the same `<workspace>/data/wiki/` that
+// MulmoClaude writes — Claude authors the wiki via the real CLI in the terminal
+// (Write/Edit), and this surface only browses. No POST: writes/snapshots stay
+// host-side in MulmoClaude until MT grows a write tier.
+//
+// Every route is a thin pass-through to @mulmoclaude/core/wiki/server — the single
+// shared reader (slug resolution, page index, graph, lint, frontmatter). MT does NOT
+// reimplement any file-walking or YAML parsing, so the two apps cannot drift over the
+// same files. The canonical on-disk layout lives in core's wikiDirs(), so both hosts
+// agree on where the wiki sits.
+import type { Express, Request, Response } from "express";
+import { readWikiIndex, readWikiPage, loadWikiGraph, collectLintIssues } from "@mulmoclaude/core/wiki/server";
+import { isSafeWikiSlug, formatLintReport } from "@mulmoclaude/core/wiki";
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+const log = {
+  warn: (message: string, data?: Record<string, unknown>) => console.warn(`[wiki] ${message}`, data ?? ""),
+};
+
+/** Mount the read-only wiki REST surface, rooted at the shared workspace.
+ *  Mirrors mountCollectionRoutes — call once at boot, before the /api SPA fallback. */
+export function mountWikiRoutes(app: Express, deps: { workspace: string }): void {
+  const { workspace } = deps;
+
+  // The index, or a single page when `?slug=` is present. The page path is the same
+  // route so the client can fetch index vs page through one endpoint.
+  app.get("/api/wiki", async (req: Request, res: Response) => {
+    const slug = req.query.slug;
+    if (slug !== undefined) {
+      // A crafted slug must never escape `data/wiki/pages` — guard before the read.
+      // Containment is also enforced inside the core engine, but reject early here.
+      if (!isSafeWikiSlug(slug)) {
+        res.status(400).json({ error: `invalid wiki slug: ${String(slug)}` });
+        return;
+      }
+      try {
+        const page = await readWikiPage(workspace, slug);
+        if (!page.exists) {
+          res.status(404).json({ error: `wiki page '${slug}' not found` });
+          return;
+        }
+        res.json(page);
+      } catch (err) {
+        log.warn("page read failed", { slug, error: errorMessage(err) });
+        res.status(500).json({ error: errorMessage(err) });
+      }
+      return;
+    }
+    try {
+      res.json(await readWikiIndex(workspace));
+    } catch (err) {
+      log.warn("index read failed", { error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // The page→page link graph (nodes + edges), for the graph view and backlinks.
+  app.get("/api/wiki/graph", async (_req: Request, res: Response) => {
+    try {
+      res.json(await loadWikiGraph(workspace));
+    } catch (err) {
+      log.warn("graph read failed", { error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // The lint report (orphans, missing files, broken links, tag drift) as rendered
+  // markdown — same report MulmoClaude writes, built from the shared rules.
+  app.get("/api/wiki/lint", async (_req: Request, res: Response) => {
+    try {
+      const issues = await collectLintIssues(workspace);
+      res.json({ issues, report: formatLintReport(issues) });
+    } catch (err) {
+      log.warn("lint failed", { error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import { mountGitRemoteRoute } from "./gitRemote.js";
 import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
+import { mountWikiRoutes } from "./backends/wiki.js";
 import { initAccountingBackend, mountAccountingRoutes } from "./backends/accounting.js";
 import { initFeedsBackend, mountFeedsRoutes } from "./backends/feeds.js";
 import { feedRefreshTaskDef, type AgentWorkerRunner } from "@mulmoclaude/core/feeds/server";
@@ -713,6 +714,12 @@ mountAllRoutes(app);
 // card and (later) the collections toolbar. The engine itself is configured below
 // once CLAUDE_CWD is the confirmed workspace.
 mountCollectionRoutes(app);
+
+// Read-only wiki routes (GET /api/wiki[?slug=] + /graph + /lint) over the shared
+// workspace, thin consumers of @mulmoclaude/core/wiki/server. Claude authors the wiki
+// via the real CLI in the terminal; MT's overlay only browses. Mounted before the /api
+// SPA fallback.
+mountWikiRoutes(app, { workspace: CLAUDE_CWD });
 
 // Accounting dispatch route (POST /api/accounting) from @mulmoclaude/accounting-plugin.
 // Drives BOTH the AccountingView (configureAccountingHost.apiCall) and the

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import GuiPanel from "./components/GuiPanel.vue";
 import ToolsPane from "./components/ToolsPane.vue";
 import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
 import AccountingOverlay from "./components/AccountingOverlay.vue";
+import WikiBrowseOverlay from "./components/WikiBrowseOverlay.vue";
 import GridView from "./components/GridView.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import AppToolbar from "./components/AppToolbar.vue";
@@ -334,6 +335,9 @@ function onSession(id: string) {
     <!-- Full-screen accounting view; opened by the toolbar's account_balance button
          (driven by useAccountingView). Mutually exclusive with the browser above. -->
     <AccountingOverlay />
+    <!-- Full-screen read-only wiki browser; opened by the toolbar's menu_book button
+         (driven by useWikiBrowse). Mutually exclusive with the overlays above. -->
+    <WikiBrowseOverlay />
     <SettingsModal
       v-if="showSettings"
       :presets="presets"

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -6,6 +6,7 @@ import NotificationBell from "./NotificationBell.vue";
 import { useShortcuts } from "../composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail } from "../composables/useCollectionBrowse";
 import { useAccountingView, accountingViewOpen } from "../composables/useAccountingView";
+import { useWikiBrowse, wikiGotoIndex } from "../composables/useWikiBrowse";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
 import type { Shortcut } from "../types/shortcuts";
 
@@ -23,13 +24,15 @@ const route = useRoute();
 const { shortcuts } = useShortcuts();
 const { view: browseView } = useCollectionBrowse();
 const { isOpen: accountingOpen } = useAccountingView();
+const { isOpen: wikiOpen } = useWikiBrowse();
 const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
 
 const inGrid = computed(() => route.name === "terminals");
 const inSingle = computed(() => !inGrid.value);
-const chatActive = computed(() => inSingle.value && browseView.value.mode === "closed" && !accountingOpen.value);
+const chatActive = computed(() => inSingle.value && browseView.value.mode === "closed" && !accountingOpen.value && !wikiOpen.value);
 const collectionsActive = computed(() => browseView.value.mode === "index" && browseView.value.kind === "collection");
 const accountingActive = computed(() => accountingOpen.value);
+const wikiActive = computed(() => wikiOpen.value);
 function favActive(s: Shortcut): boolean {
   return browseView.value.mode === "detail" && browseView.value.kind === s.kind && browseView.value.slug === s.slug;
 }
@@ -49,6 +52,9 @@ function showFavorite(s: Shortcut): void {
 function showAccounting(): void {
   accountingViewOpen();
 }
+function showWiki(): void {
+  wikiGotoIndex();
+}
 </script>
 
 <template>
@@ -66,6 +72,9 @@ function showAccounting(): void {
       </button>
       <button type="button" class="launcher-btn" :class="{ active: accountingActive }" title="Accounting" aria-label="Accounting" @click="showAccounting">
         <span class="material-symbols-outlined">account_balance</span>
+      </button>
+      <button type="button" class="launcher-btn" :class="{ active: wikiActive }" title="Wiki" aria-label="Wiki" @click="showWiki">
+        <span class="material-symbols-outlined">menu_book</span>
       </button>
       <button
         v-for="s in shortcuts"

--- a/src/components/WikiBrowseOverlay.vue
+++ b/src/components/WikiBrowseOverlay.vue
@@ -1,0 +1,200 @@
+<script setup lang="ts">
+// Full-screen read-only wiki browser, the no-router-content sibling of
+// CollectionsBrowseOverlay / AccountingOverlay. Driven by useWikiBrowse: the URL picks
+// the view (index / page / graph / lint) and this overlay fetches the matching data
+// from the read-only /api/wiki surface and renders the native sub-view. No writes, no
+// snapshots — Claude authors the wiki in the terminal; this only browses.
+//
+// Data is re-fetched on every view entry (the shared workspace changes underfoot as
+// the terminal Claude edits pages), so the browser never shows a stale page/graph.
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import type { WikiGraph } from "@mulmoclaude/core/wiki";
+import { useWikiBrowse, wikiGotoIndex, wikiGotoGraph, wikiGotoLint, type WikiView } from "../composables/useWikiBrowse";
+import { fetchWikiIndex, fetchWikiGraph, fetchWikiPage, fetchWikiLint, type WikiIndex, type WikiPage, type WikiLint } from "../wikiApi";
+import { renderWikiHtml } from "../wikiMarkdown";
+import WikiIndexView from "./WikiIndexView.vue";
+import WikiPageView from "./WikiPageView.vue";
+import WikiGraphView from "./WikiGraphView.vue";
+
+const { view, isOpen, close } = useWikiBrowse();
+
+const index = ref<WikiIndex | null>(null);
+const graph = ref<WikiGraph | null>(null);
+const page = ref<WikiPage | null>(null);
+const lint = ref<WikiLint | null>(null);
+const lintHtml = ref("");
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+// A monotonic token guards against out-of-order responses when the user navigates
+// faster than fetches resolve — only the latest request gets to commit its result.
+let reqId = 0;
+
+// Per-mode fetchers. Each does its async work, then returns a `commit` closure that
+// writes the result into the refs — the watcher runs the commit ONLY if this is still
+// the latest request, so a slow response from an abandoned view can never overwrite a
+// newer one. Splitting them out also keeps the watcher a flat dispatch (low complexity).
+type Commit = () => void;
+async function loadIndex(): Promise<Commit> {
+  const res = await fetchWikiIndex();
+  return () => (index.value = res);
+}
+async function loadPage(slug: string): Promise<Commit> {
+  const [p, g] = await Promise.all([fetchWikiPage(slug), fetchWikiGraph()]);
+  return () => {
+    page.value = p;
+    graph.value = g;
+  };
+}
+async function loadGraph(): Promise<Commit> {
+  const g = await fetchWikiGraph();
+  return () => (graph.value = g);
+}
+async function loadLint(): Promise<Commit> {
+  const l = await fetchWikiLint();
+  return () => {
+    lint.value = l;
+    lintHtml.value = renderWikiHtml(l.report);
+  };
+}
+
+function fetchForView(v: WikiView): Promise<Commit> {
+  switch (v.mode) {
+    case "index":
+      return loadIndex();
+    case "page":
+      return loadPage(v.slug);
+    case "graph":
+      return loadGraph();
+    case "lint":
+      return loadLint();
+    default:
+      return Promise.resolve(() => {});
+  }
+}
+
+watch(
+  view,
+  async (v) => {
+    if (v.mode === "closed") return;
+    const id = ++reqId;
+    error.value = null;
+    loading.value = true;
+    try {
+      const commit = await fetchForView(v);
+      if (id === reqId) commit();
+    } catch (e) {
+      if (id === reqId) error.value = e instanceof Error ? e.message : String(e);
+    } finally {
+      if (id === reqId) loading.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === "Escape" && isOpen.value) close();
+}
+onMounted(() => window.addEventListener("keydown", onKeydown));
+onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
+</script>
+
+<template>
+  <div v-if="isOpen" class="wiki-overlay" role="region" aria-label="Wiki">
+    <nav class="wiki-tabs" aria-label="Wiki sections">
+      <button type="button" :class="{ active: view.mode === 'index' }" @click="wikiGotoIndex">Index</button>
+      <button v-if="view.mode === 'page'" type="button" class="active" aria-current="page" disabled>
+        {{ page?.resolvedTitle ?? "Page" }}
+      </button>
+      <button type="button" :class="{ active: view.mode === 'graph' }" @click="wikiGotoGraph">Graph</button>
+      <button type="button" :class="{ active: view.mode === 'lint' }" @click="wikiGotoLint">Lint</button>
+    </nav>
+    <div class="wiki-content">
+      <p v-if="error" class="wiki-msg wiki-error">{{ error }}</p>
+      <p v-else-if="loading" class="wiki-msg">Loading…</p>
+      <template v-else>
+        <WikiIndexView v-if="view.mode === 'index' && index" :entries="index.entries" />
+        <WikiPageView v-else-if="view.mode === 'page' && page" :slug="view.slug" :page="page" :graph="graph" />
+        <WikiGraphView v-else-if="view.mode === 'graph' && graph" :graph="graph" />
+        <!-- eslint-disable-next-line vue/no-v-html -- sanitized in renderWikiHtml -->
+        <div v-else-if="view.mode === 'lint'" class="wiki-lint" v-html="lintHtml"></div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Fills the page BELOW the toolbar (40px) — the toolbar stays visible + clickable so
+   the user can switch back to Chat. Matches the other overlays. */
+.wiki-overlay {
+  position: fixed;
+  top: 40px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: var(--bg-deep);
+  display: flex;
+  flex-direction: column;
+}
+.wiki-tabs {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel);
+}
+.wiki-tabs button {
+  padding: 4px 12px;
+  font-size: 13px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wiki-tabs button:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.wiki-tabs button.active {
+  background: var(--accent-bg);
+  color: var(--on-accent);
+  cursor: default;
+}
+.wiki-content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.wiki-msg {
+  padding: 48px 28px;
+  text-align: center;
+  color: var(--text-muted);
+}
+.wiki-error {
+  color: var(--err);
+}
+.wiki-lint {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 24px 28px 64px;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.6;
+}
+.wiki-lint :deep(h1),
+.wiki-lint :deep(h2) {
+  font-weight: 650;
+  margin: 1.2em 0 0.4em;
+}
+.wiki-lint :deep(code) {
+  background: var(--bg-subtle);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+</style>

--- a/src/components/WikiGraphView.vue
+++ b/src/components/WikiGraphView.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+// A small, read-only view of the wiki link graph: one row per page with its outgoing
+// links as clickable chips and an incoming-link count. Deliberately a textual list
+// (not a force-directed canvas) — "a small graph view" per plans/feat-wiki.md, and it
+// stays useful at any size without a layout engine.
+import { computed } from "vue";
+import type { WikiGraph } from "@mulmoclaude/core/wiki";
+import { wikiGotoPage } from "../composables/useWikiBrowse";
+
+const props = defineProps<{ graph: WikiGraph }>();
+
+const titleBySlug = computed(() => new Map(props.graph.nodes.map((n) => [n.slug, n.title])));
+const incomingCount = computed(() => {
+  const counts = new Map<string, number>();
+  for (const e of props.graph.edges) counts.set(e.to, (counts.get(e.to) ?? 0) + 1);
+  return counts;
+});
+const outgoing = computed(() => {
+  const map = new Map<string, string[]>();
+  for (const e of props.graph.edges) {
+    const list = map.get(e.from) ?? [];
+    list.push(e.to);
+    map.set(e.from, list);
+  }
+  return map;
+});
+
+// Most-referenced pages first, so the graph reads as "what's central".
+const rows = computed(() => [...props.graph.nodes].sort((a, b) => (incomingCount.value.get(b.slug) ?? 0) - (incomingCount.value.get(a.slug) ?? 0)));
+
+function title(slug: string): string {
+  return titleBySlug.value.get(slug) ?? slug;
+}
+</script>
+
+<template>
+  <div class="wiki-graph">
+    <p v-if="!graph.nodes.length" class="wiki-empty">No pages yet.</p>
+    <ul v-else class="graph-list">
+      <li v-for="node in rows" :key="node.slug" class="graph-row">
+        <div class="graph-head">
+          <button type="button" class="graph-node" @click="wikiGotoPage(node.slug)">{{ node.title }}</button>
+          <span v-if="incomingCount.get(node.slug)" class="graph-incoming" :title="`${incomingCount.get(node.slug)} incoming link(s)`">
+            ← {{ incomingCount.get(node.slug) }}
+          </span>
+        </div>
+        <div v-if="outgoing.get(node.slug)?.length" class="graph-edges">
+          <button v-for="to in outgoing.get(node.slug)" :key="to" type="button" class="graph-chip" @click="wikiGotoPage(to)">
+            {{ title(to) }}
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.wiki-graph {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 24px 28px 64px;
+}
+.graph-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.graph-row {
+  padding: 12px 14px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.graph-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.graph-node {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  cursor: pointer;
+}
+.graph-node:hover {
+  color: var(--accent);
+}
+.graph-incoming {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.graph-edges {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.graph-chip {
+  font-size: 12px;
+  padding: 2px 8px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.graph-chip:hover {
+  color: var(--text);
+  border-color: var(--accent);
+}
+.wiki-empty {
+  padding: 48px 28px;
+  text-align: center;
+  color: var(--text-muted);
+}
+</style>

--- a/src/components/WikiIndexView.vue
+++ b/src/components/WikiIndexView.vue
@@ -11,11 +11,35 @@ const props = defineProps<{ entries: WikiPageEntry[] }>();
 
 const selected = ref<Set<string>>(new Set());
 
-// All tags with their page counts, most-used first (stable for display).
-const allTags = computed(() => {
+// Full per-tag page counts.
+const tagCounts = computed(() => {
   const counts = new Map<string, number>();
   for (const e of props.entries) for (const t of e.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
-  return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([tag, count]) => ({ tag, count }));
+  return counts;
+});
+
+// Filter-bar chips, mirroring MulmoClaude's wiki View: drop singletons (a tag on one
+// page adds no filtering value, just visual noise — it stays clickable from the card),
+// sort by count desc then name asc, and raise the cutoff adaptively so the row stays
+// around TARGET_FILTER_CHIPS even on big wikis. The cutoff is the count at the target
+// position, so equally-popular tags are kept together rather than sliced arbitrarily.
+const TARGET_FILTER_CHIPS = 20;
+const meaningfulTags = computed(() => [...tagCounts.value.entries()].filter(([, c]) => c > 1).sort(([ta, ca], [tb, cb]) => cb - ca || ta.localeCompare(tb)));
+const cutoffTags = computed<[string, number][]>(() => {
+  const m = meaningfulTags.value;
+  if (m.length <= TARGET_FILTER_CHIPS) return m;
+  const cutoff = m[TARGET_FILTER_CHIPS - 1][1];
+  return m.filter(([, c]) => c >= cutoff);
+});
+// Keep any selected tag the cutoff hides (e.g. a singleton picked from a card) visible
+// in the bar so it stays removable.
+const visibleTags = computed<[string, number][]>(() => {
+  const shown = new Set(cutoffTags.value.map(([t]) => t));
+  const extra = [...selected.value]
+    .filter((t) => !shown.has(t))
+    .sort((a, b) => a.localeCompare(b))
+    .map((t): [string, number] => [t, tagCounts.value.get(t) ?? 1]);
+  return [...cutoffTags.value, ...extra];
 });
 
 const filtered = computed(() => {
@@ -36,19 +60,29 @@ function toggleTag(tag: string): void {
 
 <template>
   <div class="wiki-index">
-    <div v-if="allTags.length" class="tag-filter">
-      <FilterChip v-for="{ tag, count } in allTags" :key="tag" :label="`#${tag}`" :count="count" :active="selected.has(tag)" @click="toggleTag(tag)" />
+    <div v-if="visibleTags.length" class="tag-filter">
+      <FilterChip v-for="[tag, count] in visibleTags" :key="tag" :label="`#${tag}`" :count="count" :active="selected.has(tag)" @click="toggleTag(tag)" />
     </div>
     <p v-if="!entries.length" class="wiki-empty">The wiki is empty.</p>
     <ul v-else class="card-grid">
       <li v-for="entry in filtered" :key="entry.slug">
-        <button type="button" class="page-card" @click="wikiGotoPage(entry.slug)">
+        <!-- A div (not button) so the per-tag filter chips can be real buttons. -->
+        <div
+          class="page-card"
+          role="button"
+          tabindex="0"
+          @click="wikiGotoPage(entry.slug)"
+          @keydown.enter="wikiGotoPage(entry.slug)"
+          @keydown.space.prevent="wikiGotoPage(entry.slug)"
+        >
           <span class="card-title">{{ entry.title }}</span>
           <span v-if="entry.description" class="card-desc">{{ entry.description }}</span>
           <span v-if="entry.tags.length" class="card-tags">
-            <span v-for="t in entry.tags" :key="t" class="card-tag">#{{ t }}</span>
+            <button v-for="t in entry.tags" :key="t" type="button" class="card-tag" :class="{ active: selected.has(t) }" @click.stop="toggleTag(t)">
+              #{{ t }}
+            </button>
           </span>
-        </button>
+        </div>
       </li>
     </ul>
   </div>
@@ -108,7 +142,18 @@ function toggleTag(tag: string): void {
 }
 .card-tag {
   font-size: 11px;
+  padding: 0;
+  border: none;
+  background: none;
   color: var(--text-muted);
+  cursor: pointer;
+}
+.card-tag:hover {
+  color: var(--accent);
+}
+.card-tag.active {
+  color: var(--accent);
+  font-weight: 600;
 }
 .wiki-empty {
   padding: 48px 28px;

--- a/src/components/WikiIndexView.vue
+++ b/src/components/WikiIndexView.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+// The wiki page catalog: a tag filter + one card per page, parsed from index.md by the
+// shared core engine (entries come straight from GET /api/wiki). Clicking a card opens
+// the page; clicking a tag chip filters the list (AND across selected tags). Read-only.
+import { computed, ref } from "vue";
+import type { WikiPageEntry } from "@mulmoclaude/core/wiki";
+import FilterChip from "./FilterChip.vue";
+import { wikiGotoPage } from "../composables/useWikiBrowse";
+
+const props = defineProps<{ entries: WikiPageEntry[] }>();
+
+const selected = ref<Set<string>>(new Set());
+
+// All tags with their page counts, most-used first (stable for display).
+const allTags = computed(() => {
+  const counts = new Map<string, number>();
+  for (const e of props.entries) for (const t of e.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]).map(([tag, count]) => ({ tag, count }));
+});
+
+const filtered = computed(() => {
+  if (selected.value.size === 0) return props.entries;
+  return props.entries.filter((e) => {
+    const tags = new Set(e.tags);
+    return [...selected.value].every((t) => tags.has(t));
+  });
+});
+
+function toggleTag(tag: string): void {
+  const next = new Set(selected.value);
+  if (next.has(tag)) next.delete(tag);
+  else next.add(tag);
+  selected.value = next;
+}
+</script>
+
+<template>
+  <div class="wiki-index">
+    <div v-if="allTags.length" class="tag-filter">
+      <FilterChip v-for="{ tag, count } in allTags" :key="tag" :label="`#${tag}`" :count="count" :active="selected.has(tag)" @click="toggleTag(tag)" />
+    </div>
+    <p v-if="!entries.length" class="wiki-empty">The wiki is empty.</p>
+    <ul v-else class="card-grid">
+      <li v-for="entry in filtered" :key="entry.slug">
+        <button type="button" class="page-card" @click="wikiGotoPage(entry.slug)">
+          <span class="card-title">{{ entry.title }}</span>
+          <span v-if="entry.description" class="card-desc">{{ entry.description }}</span>
+          <span v-if="entry.tags.length" class="card-tags">
+            <span v-for="t in entry.tags" :key="t" class="card-tag">#{{ t }}</span>
+          </span>
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.wiki-index {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px 28px 64px;
+}
+.tag-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+.card-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+.page-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  height: 100%;
+  text-align: left;
+  padding: 14px 16px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+}
+.page-card:hover {
+  border-color: var(--accent);
+}
+.card-title {
+  font-size: 14px;
+  font-weight: 650;
+  color: var(--text);
+}
+.card-desc {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+.card-tag {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.wiki-empty {
+  padding: 48px 28px;
+  text-align: center;
+  color: var(--text-muted);
+}
+</style>

--- a/src/components/WikiPageView.vue
+++ b/src/components/WikiPageView.vue
@@ -13,25 +13,42 @@ const props = defineProps<{ slug: string; page: WikiPage; graph: WikiGraph | nul
 
 const html = computed(() => (props.page.exists ? renderWikiHtml(props.page.content) : ""));
 
-// Title→slug map (lowercased keys) lets resolveLinkTarget map non-ASCII `[[titles]]`
-// back to their ASCII file slug, exactly as the server engine does.
+// Title→slug map keyed by the EXACT graph title: core's resolveLinkTarget looks up
+// `slugByTitle.get(target.trim())` with the raw (non-lowercased) target after slug
+// matching, so the keys must match the server graph's titles verbatim — otherwise a
+// mixed-case title whose slug differs from its slugified form (e.g. "Foo Bar" →
+// meeting-notes-2026) would fail to resolve on click.
 const fileSlugs = computed(() => new Set((props.graph?.nodes ?? []).map((n) => n.slug)));
-const slugByTitle = computed(() => new Map((props.graph?.nodes ?? []).map((n) => [n.title.toLowerCase(), n.slug])));
+const slugByTitle = computed(() => new Map((props.graph?.nodes ?? []).map((n) => [n.title, n.slug])));
 const backlinks = computed(() => (props.graph ? incomingLinks(props.graph, props.slug) : []));
 
-// Event-delegated `[[link]]` clicks: resolve the raw target to a file slug (graph
-// first, then a plain slugify fallback) and navigate.
-function onBodyClick(e: MouseEvent): void {
-  const el = (e.target as HTMLElement).closest<HTMLElement>(".wiki-link");
+// Resolve a `[[link]]` span's raw target to a file slug (graph first, then a plain
+// slugify fallback) and navigate.
+function activateLink(el: HTMLElement | null): void {
   const target = el?.getAttribute("data-page");
   if (!target) return;
-  e.preventDefault();
   let slug = props.graph ? resolveLinkTarget(target, fileSlugs.value, slugByTitle.value) : null;
   if (!slug) {
     const fallback = wikiSlugify(target);
     slug = isSafeWikiSlug(fallback) ? fallback : null;
   }
   if (slug) wikiGotoPage(slug);
+}
+
+// Mouse + keyboard activation, both event-delegated over the rendered body. The spans
+// carry role="link" + tabindex="0" (added in renderWikiHtml) so they're focusable.
+function onBodyClick(e: MouseEvent): void {
+  const el = (e.target as HTMLElement).closest<HTMLElement>(".wiki-link");
+  if (!el) return;
+  e.preventDefault();
+  activateLink(el);
+}
+function onBodyKeydown(e: KeyboardEvent): void {
+  if (e.key !== "Enter" && e.key !== " ") return;
+  const el = (e.target as HTMLElement).closest<HTMLElement>(".wiki-link");
+  if (!el) return;
+  e.preventDefault();
+  activateLink(el);
 }
 </script>
 
@@ -40,7 +57,7 @@ function onBodyClick(e: MouseEvent): void {
     <template v-if="page.exists">
       <h1 class="wiki-page-title">{{ page.resolvedTitle }}</h1>
       <!-- eslint-disable-next-line vue/no-v-html -- LLM-authored, sanitized in renderWikiHtml -->
-      <div class="wiki-body" @click="onBodyClick" v-html="html"></div>
+      <div class="wiki-body" @click="onBodyClick" @keydown="onBodyKeydown" v-html="html"></div>
       <section v-if="backlinks.length" class="wiki-backlinks">
         <h2>Linked references</h2>
         <ul>

--- a/src/components/WikiPageView.vue
+++ b/src/components/WikiPageView.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+// Read-only render of one wiki page: sanitized markdown body with clickable
+// `[[wiki links]]`, rewritten image refs, and a "Linked references" (backlinks)
+// section derived from the shared graph. Navigation is delegated up via the
+// useWikiBrowse helpers — clicking a link/backlink pushes /wiki/pages/<slug>.
+import { computed } from "vue";
+import { resolveLinkTarget, wikiSlugify, isSafeWikiSlug, incomingLinks, type WikiGraph } from "@mulmoclaude/core/wiki";
+import { renderWikiHtml } from "../wikiMarkdown";
+import { wikiGotoPage } from "../composables/useWikiBrowse";
+import type { WikiPage } from "../wikiApi";
+
+const props = defineProps<{ slug: string; page: WikiPage; graph: WikiGraph | null }>();
+
+const html = computed(() => (props.page.exists ? renderWikiHtml(props.page.content) : ""));
+
+// Title→slug map (lowercased keys) lets resolveLinkTarget map non-ASCII `[[titles]]`
+// back to their ASCII file slug, exactly as the server engine does.
+const fileSlugs = computed(() => new Set((props.graph?.nodes ?? []).map((n) => n.slug)));
+const slugByTitle = computed(() => new Map((props.graph?.nodes ?? []).map((n) => [n.title.toLowerCase(), n.slug])));
+const backlinks = computed(() => (props.graph ? incomingLinks(props.graph, props.slug) : []));
+
+// Event-delegated `[[link]]` clicks: resolve the raw target to a file slug (graph
+// first, then a plain slugify fallback) and navigate.
+function onBodyClick(e: MouseEvent): void {
+  const el = (e.target as HTMLElement).closest<HTMLElement>(".wiki-link");
+  const target = el?.getAttribute("data-page");
+  if (!target) return;
+  e.preventDefault();
+  let slug = props.graph ? resolveLinkTarget(target, fileSlugs.value, slugByTitle.value) : null;
+  if (!slug) {
+    const fallback = wikiSlugify(target);
+    slug = isSafeWikiSlug(fallback) ? fallback : null;
+  }
+  if (slug) wikiGotoPage(slug);
+}
+</script>
+
+<template>
+  <article class="wiki-page">
+    <template v-if="page.exists">
+      <h1 class="wiki-page-title">{{ page.resolvedTitle }}</h1>
+      <!-- eslint-disable-next-line vue/no-v-html -- LLM-authored, sanitized in renderWikiHtml -->
+      <div class="wiki-body" @click="onBodyClick" v-html="html"></div>
+      <section v-if="backlinks.length" class="wiki-backlinks">
+        <h2>Linked references</h2>
+        <ul>
+          <li v-for="node in backlinks" :key="node.slug">
+            <button type="button" class="wiki-ref" @click="wikiGotoPage(node.slug)">{{ node.title }}</button>
+          </li>
+        </ul>
+      </section>
+    </template>
+    <p v-else class="wiki-empty">Page “{{ slug }}” not found.</p>
+  </article>
+</template>
+
+<style scoped>
+.wiki-page {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 24px 28px 64px;
+  color: var(--text);
+}
+.wiki-page-title {
+  margin: 0 0 16px;
+  font-size: 24px;
+  font-weight: 700;
+}
+/* Markdown body — readable defaults over the app theme. :deep reaches the v-html. */
+.wiki-body {
+  font-size: 14px;
+  line-height: 1.65;
+}
+.wiki-body :deep(h1),
+.wiki-body :deep(h2),
+.wiki-body :deep(h3) {
+  margin: 1.4em 0 0.5em;
+  font-weight: 650;
+}
+.wiki-body :deep(a) {
+  color: var(--accent);
+}
+.wiki-body :deep(code) {
+  background: var(--bg-subtle);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+.wiki-body :deep(pre) {
+  background: var(--bg-subtle);
+  padding: 12px 14px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.wiki-body :deep(img) {
+  max-width: 100%;
+  height: auto;
+}
+.wiki-body :deep(blockquote) {
+  margin: 1em 0;
+  padding-left: 12px;
+  border-left: 3px solid var(--border);
+  color: var(--text-secondary);
+}
+/* Clickable [[wiki links]] (spans from core's renderWikiLinks). */
+.wiki-body :deep(.wiki-link) {
+  color: var(--accent);
+  cursor: pointer;
+  border-bottom: 1px dotted var(--accent);
+}
+.wiki-backlinks {
+  margin-top: 40px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.wiki-backlinks h2 {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin: 0 0 8px;
+}
+.wiki-backlinks ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.wiki-ref {
+  background: none;
+  border: none;
+  padding: 2px 0;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 14px;
+}
+.wiki-ref:hover {
+  text-decoration: underline;
+}
+.wiki-empty {
+  padding: 48px 28px;
+  text-align: center;
+  color: var(--text-muted);
+}
+</style>

--- a/src/composables/useWikiBrowse.spec.ts
+++ b/src/composables/useWikiBrowse.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { createApp, defineComponent } from "vue";
+import { flushPromises } from "@vue/test-utils";
+import { router } from "../router";
+import { useWikiBrowse, wikiGotoIndex, wikiGotoPage, wikiGotoGraph, wikiGotoLint, wikiRouteSlug, wikiClose } from "./useWikiBrowse";
+
+// Install the singleton router into a throwaway app so currentRoute tracks pushes.
+beforeAll(async () => {
+  createApp(defineComponent({ render: () => null })).use(router);
+  await router.isReady();
+});
+
+beforeEach(async () => {
+  await router.replace("/");
+  await flushPromises();
+});
+
+describe("useWikiBrowse over the router", () => {
+  it("nav helpers push the right paths", async () => {
+    wikiGotoIndex();
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/wiki");
+
+    wikiGotoPage("alpha");
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/wiki/pages/alpha");
+    expect(wikiRouteSlug()).toBe("alpha");
+
+    wikiGotoGraph();
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/wiki/graph");
+
+    wikiGotoLint();
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/wiki/lint");
+  });
+
+  it("view computed reflects currentRoute", async () => {
+    const { view, isOpen } = useWikiBrowse();
+    expect(view.value).toEqual({ mode: "closed" });
+    expect(isOpen.value).toBe(false);
+
+    wikiGotoIndex();
+    await flushPromises();
+    expect(view.value).toEqual({ mode: "index" });
+    expect(isOpen.value).toBe(true);
+
+    wikiGotoPage("beta");
+    await flushPromises();
+    expect(view.value).toEqual({ mode: "page", slug: "beta" });
+
+    wikiGotoGraph();
+    await flushPromises();
+    expect(view.value).toEqual({ mode: "graph" });
+
+    wikiGotoLint();
+    await flushPromises();
+    expect(view.value).toEqual({ mode: "lint" });
+  });
+
+  it("a [[link]] click (wikiGotoPage) pushes /wiki/pages/:slug", async () => {
+    wikiGotoIndex();
+    await flushPromises();
+    wikiGotoPage("attention-mechanism");
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/wiki/pages/attention-mechanism");
+    expect(useWikiBrowse().view.value).toEqual({ mode: "page", slug: "attention-mechanism" });
+  });
+
+  it("an unsafe slug is coerced to the index rather than pushing a rejectable route", async () => {
+    wikiGotoPage("../../etc/passwd");
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/wiki");
+    expect(useWikiBrowse().view.value).toEqual({ mode: "index" });
+  });
+
+  it("close returns to chat", async () => {
+    wikiGotoPage("alpha");
+    await flushPromises();
+    wikiClose();
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/");
+    expect(useWikiBrowse().view.value).toEqual({ mode: "closed" });
+  });
+});

--- a/src/composables/useWikiBrowse.ts
+++ b/src/composables/useWikiBrowse.ts
@@ -1,0 +1,79 @@
+// Navigation seam for the read-only wiki browser — a thin derivation over vue-router,
+// mirroring useCollectionBrowse / useAccountingView. The open VIEW is entirely the URL
+// (no retained state): /wiki = index, /wiki/pages/:slug = a page, /wiki/graph = graph,
+// /wiki/lint = lint. The exported nav helpers are what the toolbar, the overlay tabs,
+// and in-page [[link]] / backlink / graph-node clicks call.
+//
+// Read-only: there is no record/modal state to retain (that was Collections'
+// complication), so this is purely view-state + push helpers.
+import { computed, type ComputedRef } from "vue";
+import { isSafeWikiSlug } from "@mulmoclaude/core/wiki";
+import { router } from "../router";
+
+export type WikiView = { mode: "closed" } | { mode: "index" } | { mode: "page"; slug: string } | { mode: "graph" } | { mode: "lint" };
+
+/** Open the wiki index (the page catalog). */
+export function wikiGotoIndex(): void {
+  router.push("/wiki");
+}
+
+/** Open one page by slug. Unsafe slugs are coerced to the index rather than pushing a
+ *  route the API would reject — the guard mirrors the server's isSafeWikiSlug. */
+export function wikiGotoPage(slug: string): void {
+  if (!isSafeWikiSlug(slug)) {
+    router.push("/wiki");
+    return;
+  }
+  router.push(`/wiki/pages/${encodeURIComponent(slug)}`);
+}
+
+/** Open the link graph. */
+export function wikiGotoGraph(): void {
+  router.push("/wiki/graph");
+}
+
+/** Open the lint report. */
+export function wikiGotoLint(): void {
+  router.push("/wiki/lint");
+}
+
+/** Close the wiki overlay → back to chat. */
+export function wikiClose(): void {
+  router.push("/");
+}
+
+/** Current page slug when on a page route, else undefined. */
+export function wikiRouteSlug(): string | undefined {
+  const slug = router.currentRoute.value.params.slug;
+  return typeof slug === "string" && slug.length > 0 ? slug : undefined;
+}
+
+/** Derive the view from the current route. */
+function currentView(): WikiView {
+  switch (router.currentRoute.value.name) {
+    case "wiki":
+      return { mode: "index" };
+    case "wikiPage": {
+      const slug = wikiRouteSlug();
+      return slug ? { mode: "page", slug } : { mode: "index" };
+    }
+    case "wikiGraph":
+      return { mode: "graph" };
+    case "wikiLint":
+      return { mode: "lint" };
+    default:
+      return { mode: "closed" };
+  }
+}
+
+export function useWikiBrowse(): {
+  view: ComputedRef<WikiView>;
+  isOpen: ComputedRef<boolean>;
+  close: () => void;
+} {
+  return {
+    view: computed(currentView),
+    isOpen: computed(() => currentView().mode !== "closed"),
+    close: wikiClose,
+  };
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,6 +20,12 @@ export const routes: RouteRecordRaw[] = [
   { path: "/feeds", name: "feeds", component: Stub },
   { path: "/feeds/:slug", name: "feedDetail", component: Stub },
   { path: "/accounting", name: "accounting", component: Stub },
+  // Read-only wiki browser (Phase 3 of plans/feat-wiki.md). The open PAGE is the URL;
+  // graph + lint are their own sub-routes, mirroring MulmoClaude's /wiki paths.
+  { path: "/wiki", name: "wiki", component: Stub },
+  { path: "/wiki/pages/:slug", name: "wikiPage", component: Stub },
+  { path: "/wiki/graph", name: "wikiGraph", component: Stub },
+  { path: "/wiki/lint", name: "wikiLint", component: Stub },
   // Unknown URLs land on chat.
   { path: "/:pathMatch(.*)*", redirect: "/" },
 ];

--- a/src/wikiApi.ts
+++ b/src/wikiApi.ts
@@ -1,0 +1,54 @@
+// Typed client for the read-only wiki REST surface (server/backends/wiki.ts). Thin
+// fetch wrappers — the heavy lifting (slug resolution, graph, lint) all lives in the
+// shared @mulmoclaude/core engine the server calls; the browser only renders the
+// shapes it returns. Types mirror @mulmoclaude/core/wiki(/server) so the views stay
+// in lockstep with the engine.
+import type { WikiPageEntry, WikiGraph } from "@mulmoclaude/core/wiki";
+
+/** index.md raw content + its parsed page entries (GET /api/wiki). */
+export interface WikiIndex {
+  content: string;
+  entries: WikiPageEntry[];
+}
+
+/** A single resolved page (GET /api/wiki?slug=). `exists: false` is returned for a
+ *  404 so callers can render the not-found state without a throw. */
+export interface WikiPage {
+  filePath: string | null;
+  content: string;
+  exists: boolean;
+  resolvedTitle: string;
+}
+
+/** Lint issues + the rendered markdown report (GET /api/wiki/lint). */
+export interface WikiLint {
+  issues: string[];
+  report: string;
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${url} → ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export function fetchWikiIndex(): Promise<WikiIndex> {
+  return getJson<WikiIndex>("/api/wiki");
+}
+
+/** Fetch one page. A 404 resolves to an `exists: false` page rather than throwing,
+ *  so the view can show "page not found"; other errors still throw. */
+export async function fetchWikiPage(slug: string): Promise<WikiPage> {
+  const res = await fetch(`/api/wiki?slug=${encodeURIComponent(slug)}`);
+  if (res.status === 404) return { filePath: null, content: "", exists: false, resolvedTitle: slug };
+  if (!res.ok) throw new Error(`/api/wiki?slug=${slug} → ${res.status}`);
+  return (await res.json()) as WikiPage;
+}
+
+export function fetchWikiGraph(): Promise<WikiGraph> {
+  return getJson<WikiGraph>("/api/wiki/graph");
+}
+
+export function fetchWikiLint(): Promise<WikiLint> {
+  return getJson<WikiLint>("/api/wiki/lint");
+}

--- a/src/wikiImageSrc.spec.ts
+++ b/src/wikiImageSrc.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { rewriteWikiImageSrc } from "./wikiImageSrc";
+
+describe("rewriteWikiImageSrc", () => {
+  it("leaves external + inlined refs untouched", () => {
+    for (const src of ["https://x.test/a.png", "http://x.test/a.png", "//cdn.test/a.png", "data:image/png;base64,AAA", "blob:abc", "/api/files/raw?path=x"]) {
+      expect(rewriteWikiImageSrc(src)).toBe(src);
+    }
+  });
+
+  it("resolves a page-relative ref against data/wiki/pages", () => {
+    expect(rewriteWikiImageSrc("img.png")).toBe("/api/files/raw?path=data%2Fwiki%2Fpages%2Fimg.png");
+    expect(rewriteWikiImageSrc("./img.png")).toBe("/api/files/raw?path=data%2Fwiki%2Fpages%2Fimg.png");
+  });
+
+  it("climbs out of pages/ with ..", () => {
+    expect(rewriteWikiImageSrc("../sources/fig.png")).toBe("/api/files/raw?path=data%2Fwiki%2Fsources%2Ffig.png");
+  });
+
+  it("treats a leading slash as workspace-root-relative", () => {
+    expect(rewriteWikiImageSrc("/data/assets/logo.png")).toBe("/api/files/raw?path=data%2Fassets%2Flogo.png");
+  });
+
+  it("never climbs above the workspace root", () => {
+    expect(rewriteWikiImageSrc("../../../../../etc/passwd")).toBe("/api/files/raw?path=etc%2Fpasswd");
+  });
+});

--- a/src/wikiImageSrc.ts
+++ b/src/wikiImageSrc.ts
@@ -1,0 +1,39 @@
+// Workspace-relative image rewriter for wiki page bodies. Core deliberately does NOT
+// ship one (image-ref rewriting is tied to each host's file-serving scheme — see
+// Phase 1.5 of plans/feat-wiki.md), so MulmoTerminal owns this small mapping to its
+// own raw-file route, GET /api/files/raw?path=<workspace-relative>.
+//
+// Wiki pages live at `data/wiki/pages/<slug>.md`, so a relative image ref (`./img.png`,
+// `../sources/fig.png`) resolves against that directory; a root-relative ref (`/x.png`)
+// resolves against the workspace root. Absolute URLs (http(s), protocol-relative, data:,
+// blob:) and already-rewritten `/api/` paths are passed through untouched.
+
+const PAGES_BASE = ["data", "wiki", "pages"];
+
+/** True for refs that must NOT be rewritten (already absolute / external / inlined). */
+function isExternal(src: string): boolean {
+  const lower = src.toLowerCase();
+  return /^https?:\/\//.test(lower) || lower.startsWith("//") || lower.startsWith("data:") || lower.startsWith("blob:") || src.startsWith("/api/");
+}
+
+/** Map an image ref found in a wiki page body to a URL the browser can load, or return
+ *  it unchanged when it's external / already absolute. Pure string math — collapses
+ *  `.`/`..` segments and never climbs above the workspace root. */
+export function rewriteWikiImageSrc(src: string): string {
+  const ref = src.trim();
+  if (!ref || isExternal(ref)) return src;
+
+  // Root-relative (`/foo.png`) resolves from the workspace root; everything else from
+  // the page directory.
+  const rootRelative = ref.startsWith("/");
+  const segs = rootRelative ? [] : [...PAGES_BASE];
+  for (const part of ref.replace(/^\/+/, "").split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (segs.length > 0) segs.pop();
+      continue;
+    }
+    segs.push(part);
+  }
+  return `/api/files/raw?path=${encodeURIComponent(segs.join("/"))}`;
+}

--- a/src/wikiMarkdown.spec.ts
+++ b/src/wikiMarkdown.spec.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { renderWikiHtml, stripFrontmatter } from "./wikiMarkdown";
+
+function parse(html: string): Document {
+  return new DOMParser().parseFromString(html, "text/html");
+}
+
+describe("stripFrontmatter", () => {
+  it("drops a leading YAML frontmatter block (and BOM)", () => {
+    expect(stripFrontmatter("---\ntitle: X\n---\n# Body\n")).toBe("# Body\n");
+    expect(stripFrontmatter("﻿---\ntitle: X\n---\nhi")).toBe("hi");
+  });
+  it("leaves a body without frontmatter untouched", () => {
+    expect(stripFrontmatter("# Body\n")).toBe("# Body\n");
+  });
+});
+
+describe("renderWikiHtml", () => {
+  it("renders a prose [[link]] as a focusable wiki-link", () => {
+    const doc = parse(renderWikiHtml("See [[beta]] for more."));
+    const link = doc.querySelector(".wiki-link");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("data-page")).toBe("beta");
+    expect(link?.getAttribute("role")).toBe("link");
+    expect(link?.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("does NOT turn [[links]] inside code into live links", () => {
+    // Both an inline code span and a fenced block: the link pass runs before marked,
+    // so the bracket text ends up inert (escaped) inside <code>, never a clickable span.
+    const doc = parse(renderWikiHtml("inline `[[x]]` and\n\n```\n[[y]]\n```\n"));
+    expect(doc.querySelector(".wiki-link")).toBeNull();
+    expect(doc.querySelectorAll("code").length).toBeGreaterThan(0);
+  });
+
+  it("rewrites a page-relative image ref to the raw-file route", () => {
+    const doc = parse(renderWikiHtml("![alt](fig.png)"));
+    expect(doc.querySelector("img")?.getAttribute("src")).toBe("/api/files/raw?path=data%2Fwiki%2Fpages%2Ffig.png");
+  });
+
+  it("sanitizes scripts out of the body", () => {
+    const doc = parse(renderWikiHtml("ok <script>alert(1)</script>"));
+    expect(doc.querySelector("script")).toBeNull();
+  });
+});

--- a/src/wikiMarkdown.ts
+++ b/src/wikiMarkdown.ts
@@ -1,0 +1,37 @@
+// Render a wiki page body to safe HTML for v-html. Pipeline:
+//   1. strip YAML frontmatter (the page format leads with a `---` block).
+//   2. marked → HTML. `[[wiki links]]` are plain text to marked, so they survive.
+//   3. renderWikiLinks → turns the surviving `[[links]]` into
+//      `<span class="wiki-link" data-page="…">` (shared core impl, so MT and
+//      MulmoClaude resolve identically).
+//   4. DOMPurify → sanitize (LLM-authored content over a shared workspace).
+//   5. rewrite <img> srcs to MT's raw-file route (core ships no rewriter).
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+import { renderWikiLinks } from "@mulmoclaude/core/wiki";
+import { rewriteWikiImageSrc } from "./wikiImageSrc";
+
+// Leading YAML frontmatter delimited by `---` lines (page format in helps/wiki.md).
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n/;
+// A leading byte-order mark, stripped before frontmatter detection.
+const BOM_RE = /^\uFEFF/;
+
+/** Drop a leading BOM + the frontmatter block so neither renders as stray content. */
+export function stripFrontmatter(content: string): string {
+  return content.replace(BOM_RE, "").replace(FRONTMATTER_RE, "");
+}
+
+/** Render a page body to sanitized HTML with `[[links]]` and rewritten image refs. */
+export function renderWikiHtml(content: string): string {
+  const md = marked.parse(stripFrontmatter(content), { async: false }) as string;
+  const linked = renderWikiLinks(md);
+  // Keep the data-page hook on wiki-link spans (DOMPurify allows data-* by default).
+  const clean = DOMPurify.sanitize(linked, { ADD_ATTR: ["target"] });
+  // Rewrite image refs on the sanitized DOM, then re-serialize.
+  const doc = new DOMParser().parseFromString(clean, "text/html");
+  for (const img of Array.from(doc.querySelectorAll("img"))) {
+    const src = img.getAttribute("src");
+    if (src) img.setAttribute("src", rewriteWikiImageSrc(src));
+  }
+  return doc.body.innerHTML;
+}

--- a/src/wikiMarkdown.ts
+++ b/src/wikiMarkdown.ts
@@ -1,11 +1,16 @@
-// Render a wiki page body to safe HTML for v-html. Pipeline:
+// Render a wiki page body to safe HTML for v-html. Pipeline (order matches
+// MulmoClaude's helpers.ts so both hosts render identically):
 //   1. strip YAML frontmatter (the page format leads with a `---` block).
-//   2. marked → HTML. `[[wiki links]]` are plain text to marked, so they survive.
-//   3. renderWikiLinks → turns the surviving `[[links]]` into
-//      `<span class="wiki-link" data-page="…">` (shared core impl, so MT and
-//      MulmoClaude resolve identically).
+//   2. renderWikiLinks → turn `[[links]]` into
+//      `<span class="wiki-link" data-page="…">` BEFORE marked (it HTML-escapes the
+//      surrounding text itself). Running before marked means a `[[x]]` inside a fenced
+//      code block / code span ends up as inert escaped text after marked, NOT a live
+//      link — running it on marked's HTML output would instead inject a clickable link
+//      inside `<code>` and corrupt the snippet.
+//   3. marked → HTML.
 //   4. DOMPurify → sanitize (LLM-authored content over a shared workspace).
-//   5. rewrite <img> srcs to MT's raw-file route (core ships no rewriter).
+//   5. rewrite <img> srcs to MT's raw-file route (core ships no rewriter); make
+//      `.wiki-link` spans keyboard-focusable (activated in WikiPageView).
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { renderWikiLinks } from "@mulmoclaude/core/wiki";
@@ -23,15 +28,22 @@ export function stripFrontmatter(content: string): string {
 
 /** Render a page body to sanitized HTML with `[[links]]` and rewritten image refs. */
 export function renderWikiHtml(content: string): string {
-  const md = marked.parse(stripFrontmatter(content), { async: false }) as string;
-  const linked = renderWikiLinks(md);
-  // Keep the data-page hook on wiki-link spans (DOMPurify allows data-* by default).
-  const clean = DOMPurify.sanitize(linked, { ADD_ATTR: ["target"] });
-  // Rewrite image refs on the sanitized DOM, then re-serialize.
+  // renderWikiLinks first (it escapes the text), then marked — see the file header.
+  const linked = renderWikiLinks(stripFrontmatter(content));
+  const html = marked.parse(linked, { async: false }) as string;
+  // DOMPurify keeps class + data-* by default (so the data-page hook survives).
+  const clean = DOMPurify.sanitize(html, { ADD_ATTR: ["target"] });
   const doc = new DOMParser().parseFromString(clean, "text/html");
+  // Rewrite image refs to MT's raw-file route.
   for (const img of Array.from(doc.querySelectorAll("img"))) {
     const src = img.getAttribute("src");
     if (src) img.setAttribute("src", rewriteWikiImageSrc(src));
+  }
+  // Make [[wiki links]] reachable + activatable without a mouse (the delegated
+  // click/keydown handler in WikiPageView reads data-page).
+  for (const link of Array.from(doc.querySelectorAll(".wiki-link"))) {
+    link.setAttribute("role", "link");
+    link.setAttribute("tabindex", "0");
   }
   return doc.body.innerHTML;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,12 +571,13 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.2.15":
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.2.15.tgz#94ddd92cbfdbe9a30b2635525b658dfe2ab2c450"
-  integrity sha512-vo/0d0AFBTJFbfzUzdJzQJq542ezIDWUCdo3IzN6/coAloZor/DzEIXYLz0NrOugn12Tbp4tLxfJVKKExCOoXQ==
+"@mulmoclaude/core@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.5.0.tgz#dc1b5a3a7e8266eac61e142dc20082b22cbc146e"
+  integrity sha512-0IIBN9e4M8GrZyexdj8FKHiXvTa0/DPgTG4Ocyf7x8lUB5GopEN8s6DG/nEMAzp6AVmTzFKW1tXAZ6HCbwjV3g==
   dependencies:
     fast-xml-parser "^5.9.3"
+    js-yaml "^5.2.0"
     zod "^4.4.3"
 
 "@mulmoclaude/form-plugin@^0.1.3":
@@ -2661,6 +2662,13 @@ js-yaml@^4.1.1, js-yaml@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
   integrity sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.0.tgz#b559a892cae3e32fc5afecc9f18e1672378ddb68"
+  integrity sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary

Brings MulmoClaude's **Wiki** to MulmoTerminal as a **read-only browser**, sharing the engine via `@mulmoclaude/core` so neither app drifts on how it reads the shared `<workspace>/data/wiki/`. Claude authors/edits the wiki via the real CLI in the terminal; MT's UI only browses. See `plans/feat-wiki.md` for the full design (Phases 1 & 1.5 already shipped in MulmoClaude `core@0.5.0`).

### Phase 2 — server (read-only, thin consumer of `core/wiki/server`)
- Bump `@mulmoclaude/core` → `^0.5.0`.
- `server/backends/wiki.ts` → `mountWikiRoutes(app, { workspace })`, wired in `server/index.ts` before the `/api` SPA fallback. Routes:
  - `GET /api/wiki` → index (`{ content, entries }`)
  - `GET /api/wiki?slug=` → page (`isSafeWikiSlug` guard, 400/404 shapes)
  - `GET /api/wiki/graph` → `{ nodes, edges }`
  - `GET /api/wiki/lint` → `{ issues, report }`
- No POST — writes/snapshots stay host-side in MulmoClaude.

### Phase 3 — client (read-only overlay)
- `/wiki[/pages/:slug|/graph|/lint]` routes + `useWikiBrowse` (view-state over the router).
- `WikiBrowseOverlay` with **Index / Page / Graph / Lint** tabs; `menu_book` toolbar launcher.
- `WikiPageView`: `marked` + `DOMPurify` + core's `renderWikiLinks`; clickable `[[links]]` (resolved via the graph, ASCII + non-ASCII), backlinks via `incomingLinks`.
- `WikiIndexView`: tag filter + page cards. Tag bar **mirrors MulmoClaude** — drops singleton tags and applies an adaptive ~20-chip cutoff; per-card `#tag` chips stay clickable so rare tags remain filterable.
- `WikiGraphView`: small textual link graph (centrality-ordered).
- `wikiImageSrc.ts`: workspace-relative image rewriter → `/api/files/raw` (core ships none by design — host-specific).
- Agent-side `config/helps/wiki.md` already seeded by MT's `seedHelps` (no work needed).

## Tests
- `server/backends/wiki.spec.ts` — index/page/graph/lint over a temp workspace; unsafe slug rejected; missing-page shape.
- `useWikiBrowse.spec.ts` — route ↔ view-state, `[[link]]` push, unsafe-slug coercion.
- `wikiImageSrc.spec.ts` — external pass-through, page/root-relative resolution, `..` containment.

## Gates
`format` ✅ · `lint` ✅ · `typecheck` ✅ · `build` ✅ · `test` ✅ (512 passed / 51 files)

Not yet live-smoke-tested in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)