### PR TITLE
feat(unload-guard): skip the close confirm for Vite HMR reloads

### DIFF
--- a/src/composables/useUnloadGuard.spec.ts
+++ b/src/composables/useUnloadGuard.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { defineComponent } from "vue";
 import { mount } from "@vue/test-utils";
-import { useUnloadGuard, reportActiveTerminals } from "./useUnloadGuard";
+import { useUnloadGuard, reportActiveTerminals, suppressNextUnloadGuard } from "./useUnloadGuard";
 
 // Mount a bare host so the composable's onMounted/onUnmounted run (and the
 // beforeunload listener is registered/removed) on a real lifecycle.
@@ -68,6 +68,25 @@ describe("useUnloadGuard", () => {
     expect(fireBeforeUnload()).toBe(true); // single still live
     reportActiveTerminals("single", 0);
     expect(fireBeforeUnload()).toBe(false);
+  });
+
+  // A reload we initiate (Vite HMR full-reload on a source change) must not prompt,
+  // even with a terminal live — otherwise every save during dev pops the dialog.
+  it("skips the prompt for one initiated reload while a terminal is live", () => {
+    wrapper = mount(Host);
+    reportActiveTerminals("grid", 1);
+    suppressNextUnloadGuard();
+    expect(fireBeforeUnload()).toBe(false);
+  });
+
+  // The suppression is one-shot: it covers only the reload we asked for, so a later
+  // genuine close while still live is guarded again.
+  it("guards again on the next unload after one initiated reload is consumed", () => {
+    wrapper = mount(Host);
+    reportActiveTerminals("grid", 1);
+    suppressNextUnloadGuard();
+    expect(fireBeforeUnload()).toBe(false);
+    expect(fireBeforeUnload()).toBe(true);
   });
 
   it("removes the listener on unmount (no lingering guard)", () => {

--- a/src/composables/useUnloadGuard.ts
+++ b/src/composables/useUnloadGuard.ts
@@ -21,6 +21,24 @@ function totalActive(): number {
   return total;
 }
 
+// Suppress the guard for the NEXT unload only — for reloads WE initiate, where the
+// session isn't being lost by accident. The flag is one-shot: the handler consumes
+// it, so it can never linger and silence a later genuine close.
+let skipNextUnload = false;
+export function suppressNextUnloadGuard(): void {
+  skipNextUnload = true;
+}
+
+// Vite does a full page reload when source it can't hot-swap changes. That fires
+// beforeunload like any close would, so without this the guard would prompt on every
+// save during development. Vite emits `vite:beforeFullReload` just before it reloads,
+// so we suppress the imminent prompt for that one unload. `import.meta.hot` is
+// undefined in production, so this branch tree-shakes away — prod prompts on every
+// real close as before.
+if (import.meta.hot) {
+  import.meta.hot.on("vite:beforeFullReload", suppressNextUnloadGuard);
+}
+
 // Warn before the tab closes / reloads / navigates away while a terminal is live,
 // so an accidental close doesn't drop sessions (an idle PTY is reaped shortly after
 // the socket closes; a working one keeps going, but either way the live view is
@@ -29,6 +47,10 @@ function totalActive(): number {
 // fixed by the browser and can't be customised.
 export function useUnloadGuard(): void {
   const onBeforeUnload = (e: BeforeUnloadEvent) => {
+    if (skipNextUnload) {
+      skipNextUnload = false; // one-shot: consume so it never silences a later close
+      return; // a reload we initiated (e.g. Vite HMR) — see suppressNextUnloadGuard
+    }
     if (totalActive() <= 0) return;
     e.preventDefault();
     e.returnValue = ""; // legacy Chrome/Edge still need returnValue assigned to prompt


### PR DESCRIPTION
## What

The `beforeunload` guard added in #148 pops the browser's native confirm dialog whenever the tab closes/reloads while a terminal is live, to prevent an accidental close from dropping a session. The side effect: Vite does a **full page reload** when it can't hot-swap a source change, which fires `beforeunload` just like a real close — so **every save during development pops the dialog**.

## How

Vite's HMR client emits `vite:beforeFullReload` right before it reloads. We hook it to suppress the guard for **that one unload**:

- A one-shot `skipNextUnload` flag, set via the exported `suppressNextUnloadGuard()`, which the Vite hook calls.
- The `beforeunload` handler **consumes** the flag (resets it) before returning, so the suppression can never linger into a later genuine close.
- `import.meta.hot` is `undefined` in production builds, so the whole branch tree-shakes away — **prod behavior is byte-identical**: every real close still prompts.

This is a dev-ergonomics refinement, **not** a reversal of #148 — accidental-close protection stays fully intact for real closes and manual reloads.

## Why not just distinguish close vs reload?

`beforeunload` carries no field telling close from reload (web-platform design), so we can't branch inside the handler. `vite:beforeFullReload` gives advance notice of exactly the one sub-case we care about, which sidesteps the problem.

## Tests

Added two cases to `useUnloadGuard.spec.ts`:
- an HMR-initiated reload skips the prompt even while a terminal is live;
- the suppression is one-shot — the next unload guards again.

Gates: `yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test` all pass (8/8 in the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)