### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release **mulmoterminal@0.6.0** — version bump only (package.json 0.5.0 → 0.6.0). 41 commits have landed since the `mulmoterminal@0.5.0` tag.

### Highlights since 0.5.0
- 動的 favicon（セッション状態でマーク切替）
- vue-router によるトップレベルナビゲーション
- 読み取り専用 Wiki ブラウザ
- 起動ディレクトリを自動プリセット記録（Settings のエディタ廃止、MRU 順）
- コレクションレジストリのインポート（Discover タブ）
- ランタイム翻訳サービス（hidden chat 経由）
- UI ナビゲーション横断でターミナル接続を維持
- タブを閉じる/リロード前の確認ガード（ターミナルがあるときのみ）
- 各種 Codex レビュー対応・修正

## Items to Confirm / Review
- バージョン番号 0.6.0（マイナー）でよいか。
- マージ後、`main` から `npm publish` → タグ `mulmoterminal@0.6.0` → GitHub リリース作成、の順で公開します。

Gates: yarn install / typecheck / lint / build 通過、`npm publish --dry-run` で tarball 確認済み。