### PR TITLE
feat: エージェント状態を blocked / done / working / idle に細分化 (#174)

### DIFF
--- a/plans/feat-174-agent-states.md
+++ b/plans/feat-174-agent-states.md
@@ -1,0 +1,47 @@
+# feat #174: エージェント状態の細分化（blocked / done / working / idle）
+
+## User Prompt
+> 174/175は比較的簡単にできると思うので、すすめて。
+
+（Issue #174）`waiting` が「承認・入力待ち」と「完了して未レビュー」を混同している。両者を分離して色分け＋Auto並べ替えの優先度を精緻化する。
+
+## 背景（実コード）
+- サーバは Claude hook から状態を導出: `UserPromptSubmit→working`、`Stop→waiting(完了未読)`、`Notification→waiting(承認/入力待ち)`。
+- どのイベントで waiting になったかは `activity.event` に記録され、**pub/sub では既に配信済み**（`publishActivity`）。REST（`/api/sessions`・`/api/session/:id`）には未載。
+- つまり **サーバの状態ロジックは変えない**。`event`（生の Stop/Notification）を REST にも通し、クライアントで意味付けする＝低リスク。
+
+## 状態マッピング（クライアント）
+```
+waiting && event === "Notification" → "blocked" (承認/入力待ち・最優先)
+waiting (それ以外, 実質 Stop)        → "done"    (完了・未レビュー)
+working                              → "working"
+それ以外                             → "idle"
+```
+Auto並べ替え優先度: `blocked(0) > done(1) > idle(2) > working(3)`、空ランチャー(4)。
+
+## 変更
+### サーバ `server/index.ts`（`event` を REST に通すだけ）
+- `SessionMeta` に `event: string | null` を追加。
+- `readSessionMeta` の返り値に `event: a?.event ?? null`。
+- pending セッション object と `/api/sessions` の pending 直列化に `event`。
+- `/api/session/:id` 応答に `event: a.event ?? null`。
+
+### クライアント
+- `gridTabs.ts`: `CellStatus = "blocked" | "done" | "working" | "idle"`、`RANK` 更新、純粋関数 `activityStatus(working, waiting, event)` を追加（TerminalCell と GridView で共用）。
+- `useSessions.ts`: `Session.event?: string | null`。
+- `TerminalCell.vue`: `event` を購読/保持し、`activityStatus` で status 算出。`is-waiting` → `is-blocked` / `is-done` に分割（枠色・ドット・ヘッダー tint・ラベル）。
+- `GridView.vue`: `toStatus` を `activityStatus` に置換、`sessionStatus` も event 込みで算出。
+- `CommandCell.vue`: 変更なし（working/idle のまま、CellStatus に含まれる）。
+
+### 色/ラベル
+- blocked: 琥珀＋glow（従来の is-waiting）/「Needs input」
+- done: 青（静的、脈動なし）/「Done — review」
+- working: accent 青・脈動（従来）/「Working…」
+- idle: dim（従来）/「Idle」
+
+## テスト
+- `gridTabs.spec.ts`: `activityStatus`（4分岐）、`orderCells`（新RANK: blocked→done→idle→working）。
+- `TerminalCell.spec.ts`: pub/sub で event=Notification→blocked, event=Stop→done, working, idle のクラス/ラベル。
+
+## ゲート
+format / lint / typecheck / build / test

--- a/server/index.ts
+++ b/server/index.ts
@@ -86,6 +86,10 @@ interface SessionMeta {
   mtime: number;
   working: boolean;
   waiting: boolean;
+  /** The hook that set the current state (e.g. "Stop" | "Notification"), or null.
+   *  Lets the client split `waiting` into "done, unreviewed" (Stop) vs "blocked on
+   *  input" (Notification). */
+  event: string | null;
   /** Spawned as a hidden background worker (spawnBackgroundChat hidden:true). The
    *  tab still lists, but it never renders bold/unread — a background helper
    *  finishing shouldn't pull the user's attention. */
@@ -675,6 +679,7 @@ async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> 
     mtime: stat.mtimeMs,
     working: a?.working ?? false,
     waiting: a?.waiting ?? false,
+    event: a?.event ?? null,
     hidden: hiddenSessions.has(id),
   };
 }
@@ -1075,6 +1080,7 @@ app.get("/api/session/:id", async (req, res) => {
     cwd,
     working: a.working ?? false,
     waiting: a.waiting ?? false,
+    event: a.event ?? null,
     lastPrompt,
   });
 });
@@ -1156,6 +1162,7 @@ app.get("/api/sessions", async (req, res) => {
         mtime: meta.createdAt,
         working: activity.get(id)?.working ?? false,
         waiting: activity.get(id)?.waiting ?? false,
+        event: activity.get(id)?.event ?? null,
         hidden: hiddenSessions.has(id),
       });
     }
@@ -1175,7 +1182,7 @@ app.get("/api/sessions", async (req, res) => {
       await Promise.all(
         top.map((s) =>
           s.kind === "pending"
-            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, hidden: s.hidden }
+            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, event: s.event, hidden: s.hidden }
             : readSessionMeta(dir, s.file).catch(() => null),
         ),
       )

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -16,6 +16,7 @@ import {
   setSortMode,
   moveCell,
   visibleOrdered,
+  activityStatus,
   cancelableLaunchUid,
   pageCount,
   zoomedUid,
@@ -68,15 +69,9 @@ const pages = computed(() => pageCount(state.value.cells.length));
 const { sessions } = useSessions();
 const statusByUid = reactive<Record<number, CellStatus>>({});
 const onStatus = (uid: number, s: CellStatus) => (statusByUid[uid] = s);
-// Attention (waiting) wins over working wins over idle — mirrors TerminalCell's dot.
-const toStatus = (working: boolean, waiting: boolean): CellStatus => {
-  if (waiting) return "waiting";
-  if (working) return "working";
-  return "idle";
-};
 const sessionStatus = computed(() => {
   const m = new Map<string, CellStatus>();
-  for (const s of sessions.value) m.set(s.id, toStatus(s.working, s.waiting));
+  for (const s of sessions.value) m.set(s.id, activityStatus(s.working, s.waiting, s.event));
   return m;
 });
 const statusForSort = computed<Record<number, CellStatus>>(() => {

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -429,7 +429,7 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-dir").text()).toBe("~/default");
   });
 
-  it("reflects working/waiting/lastPrompt pushed for its own session", async () => {
+  it("reflects working / blocked / done pushed for its own session", async () => {
     const id = "22222222-2222-2222-2222-222222222222";
     const w = mountCell(id);
     await flushPromises();
@@ -438,9 +438,14 @@ describe("TerminalCell", () => {
     expect(promptText(w)).toBe("refactor the parser");
     expect(dotClass(w)).toContain("is-working");
 
-    captured?.({ id, working: false, waiting: true, lastPrompt: "refactor the parser" });
+    // waiting + Notification => blocked (needs input); + Stop => done (unreviewed).
+    captured?.({ id, working: false, waiting: true, event: "Notification", lastPrompt: "refactor the parser" });
     await nextTick();
-    expect(dotClass(w)).toContain("is-waiting");
+    expect(dotClass(w)).toContain("is-blocked");
+
+    captured?.({ id, working: false, waiting: true, event: "Stop", lastPrompt: "refactor the parser" });
+    await nextTick();
+    expect(dotClass(w)).toContain("is-done");
   });
 
   it("clears a stale prompt when the server sends lastPrompt: null", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -6,7 +6,7 @@ import { useDirConfig } from "../composables/useDirConfig";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
 import type { CwdPreset } from "./presets";
-import type { CellStatus } from "./gridTabs";
+import { activityStatus, type CellStatus } from "./gridTabs";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 
@@ -75,6 +75,9 @@ watch([() => props.presets, () => props.defaultCwd], () => {
 // Live activity for this session, from the "sessions" pub/sub channel.
 const working = ref(false);
 const waiting = ref(false);
+// The hook that set the current state ("Stop" | "Notification" | …). Splits `waiting`
+// into done (Stop) vs blocked (Notification) — see activityStatus.
+const activityEvent = ref<string | null>(null);
 const lastPrompt = ref<string | null>(null);
 
 const { subscribe } = usePubSub();
@@ -84,6 +87,7 @@ interface ActivityMsg {
   id: string;
   working?: boolean;
   waiting?: boolean;
+  event?: string | null;
   lastPrompt?: string | null;
 }
 const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" && d !== null && "id" in d;
@@ -91,6 +95,7 @@ const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" &&
 function applyActivity(d: ActivityMsg) {
   working.value = d.working ?? false;
   waiting.value = d.waiting ?? false;
+  if (d.event !== undefined) activityEvent.value = d.event;
   // Apply lastPrompt whenever the field is present — including an explicit null,
   // so a cleared/new session doesn't keep showing the previous prompt.
   if (d.lastPrompt !== undefined) lastPrompt.value = d.lastPrompt;
@@ -446,6 +451,7 @@ function teardown() {
   sessionId.value = null;
   working.value = false;
   waiting.value = false;
+  activityEvent.value = null;
   lastPrompt.value = null;
   cwd.value = props.defaultCwd;
   dirInput.value = props.defaultCwd ?? "";
@@ -542,14 +548,11 @@ const headerDir = computed(() => {
   return wt ? `⎇ ${wt.repo} (${wt.task})` : dirDisplay.value;
 });
 
-// Attention (waiting) wins over working wins over idle.
-const status = computed<"waiting" | "working" | "idle">(() => {
-  if (waiting.value) return "waiting";
-  if (working.value) return "working";
-  return "idle";
-});
-const STATUS_CLASS = { waiting: "is-waiting", working: "is-working", idle: "is-idle" } as const;
-const STATUS_LABEL = { waiting: "Needs attention", working: "Working…", idle: "Idle" } as const;
+// blocked (needs input) / done (finished, unreviewed) / working / idle — split from
+// the server's working+waiting+event (see activityStatus).
+const status = computed<CellStatus>(() => activityStatus(working.value, waiting.value, activityEvent.value));
+const STATUS_CLASS = { blocked: "is-blocked", done: "is-done", working: "is-working", idle: "is-idle" } as const;
+const STATUS_LABEL = { blocked: "Needs input", done: "Done — review", working: "Working…", idle: "Idle" } as const;
 const statusClass = computed(() => STATUS_CLASS[status.value]);
 const statusLabel = computed(() => STATUS_LABEL[status.value]);
 watch(status, (s) => emit("status", s), { immediate: true });
@@ -932,12 +935,16 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   border-radius: 6px;
   overflow: hidden;
 }
-/* Frame the whole cell by status so it's obvious at a glance which terminal is
-   busy (blue) or needs you (amber glow). */
+/* Frame the whole cell by status: blocked = amber glow (needs you NOW), done = blue
+   glow (finished a turn, review it), working = blue border (busy). */
 .cell.is-working {
   border-color: var(--accent);
 }
-.cell.is-waiting {
+.cell.is-done {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+.cell.is-blocked {
   border-color: var(--amber);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--amber) 55%, transparent);
 }
@@ -952,18 +959,19 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border);
 }
-/* The header also tints by status (working = blue, waiting = amber). */
-.cell-header.is-working {
+/* The header also tints by status (working/done = blue, blocked = amber). */
+.cell-header.is-working,
+.cell-header.is-done {
   background: var(--bg-selected);
   border-bottom-color: var(--accent);
 }
-.cell-header.is-waiting {
+.cell-header.is-blocked {
   background: var(--warn-bg-subtle);
   color: var(--warn);
   border-bottom-color: var(--amber);
 }
 
-/* Status dot: idle / working (pulsing) / waiting (attention). */
+/* Status dot: idle / working (pulsing blue) / done (static blue) / blocked (amber). */
 .cell-dot {
   flex: 0 0 auto;
   width: 9px;
@@ -975,7 +983,10 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   background: var(--accent);
   animation: pulse 1.2s ease-in-out infinite;
 }
-.cell-dot.is-waiting {
+.cell-dot.is-done {
+  background: var(--accent);
+}
+.cell-dot.is-blocked {
   background: var(--amber);
 }
 @keyframes pulse {

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -15,6 +15,7 @@ import {
   moveCell,
   orderCells,
   visibleOrdered,
+  activityStatus,
   cancelableLaunchUid,
   zoomedUid,
   visibleCells,
@@ -219,16 +220,31 @@ describe("setSortMode / moveCell (manual reorder)", () => {
   });
 });
 
+describe("activityStatus", () => {
+  it("splits waiting into blocked (Notification) vs done (Stop)", () => {
+    expect(activityStatus(false, true, "Notification")).toBe("blocked");
+    expect(activityStatus(false, true, "Stop")).toBe("done");
+    expect(activityStatus(false, true, null)).toBe("done"); // any non-Notification waiting -> done
+  });
+  it("is working when only working, idle when neither", () => {
+    expect(activityStatus(true, false, "UserPromptSubmit")).toBe("working");
+    expect(activityStatus(false, false, null)).toBe("idle");
+  });
+  it("waiting wins over working (a permission pause mid-turn is blocked)", () => {
+    expect(activityStatus(true, true, "Notification")).toBe("blocked");
+  });
+});
+
 describe("orderCells (auto attention sort)", () => {
   const status = (m: Record<number, CellStatus>) => m;
   it("manual mode returns the list unchanged", () => {
     const cells = running(3);
-    expect(orderCells(cells, status({ 0: "working", 1: "waiting", 2: "idle" }), "manual")).toBe(cells);
+    expect(orderCells(cells, status({ 0: "working", 1: "blocked", 2: "idle" }), "manual")).toBe(cells);
   });
-  it("auto sorts waiting -> idle -> working, launch cells last", () => {
-    const cells = [...running(3), cell(3)]; // uid 3 is an empty launch cell
-    const ordered = orderCells(cells, status({ 0: "working", 1: "waiting", 2: "idle" }), "auto");
-    expect(ordered.map((c) => c.uid)).toEqual([1, 2, 0, 3]);
+  it("auto sorts blocked -> done -> idle -> working, launch cells last", () => {
+    const cells = [...running(4), cell(4)]; // uid 4 is an empty launch cell
+    const ordered = orderCells(cells, status({ 0: "working", 1: "blocked", 2: "done", 3: "idle" }), "auto");
+    expect(ordered.map((c) => c.uid)).toEqual([1, 2, 3, 0, 4]);
   });
   it("is stable within a bucket (equal status keeps manual order)", () => {
     const cells = running(4);
@@ -243,23 +259,23 @@ describe("orderCells (auto attention sort)", () => {
 });
 
 describe("visibleOrdered (attention-sort the whole list, then page)", () => {
-  it("floats a waiting cell from any page onto the first page", () => {
-    // 12 cells over 2 pages. uid 10 starts on page 2; once waiting it sorts to the
+  it("floats a blocked cell from any page onto the first page", () => {
+    // 12 cells over 2 pages. uid 10 starts on page 2; once blocked it sorts to the
     // front and lands on page 1, while the working uid 0 sinks off page 1.
     const s = make(running(12), { page: 0, sortMode: "auto" });
-    const statusByUid: Record<number, CellStatus> = { 0: "working", 1: "waiting", 10: "waiting" };
+    const statusByUid: Record<number, CellStatus> = { 0: "working", 1: "blocked", 10: "blocked" };
     const page1 = visibleOrdered(s, statusByUid).map((c) => c.uid);
-    expect(page1.slice(0, 2)).toEqual([1, 10]); // both waiting cells, base order, up front
+    expect(page1.slice(0, 2)).toEqual([1, 10]); // both blocked cells, base order, up front
     expect(page1).not.toContain(0); // working uid 0 sank to page 2
     expect(page1).toHaveLength(9);
   });
   it("manual mode leaves the on-screen order untouched", () => {
     const s = make(running(4), { sortMode: "manual" });
-    expect(visibleOrdered(s, { 0: "working", 3: "waiting" }).map((c) => c.uid)).toEqual([0, 1, 2, 3]);
+    expect(visibleOrdered(s, { 0: "working", 3: "blocked" }).map((c) => c.uid)).toEqual([0, 1, 2, 3]);
   });
   it("orders the whole list (the filmstrip) while zoomed", () => {
     const s = make(running(12), { page: 0, expanded: 11, sortMode: "auto" });
-    expect(visibleOrdered(s, { 11: "waiting" }).map((c) => c.uid)[0]).toBe(11);
+    expect(visibleOrdered(s, { 11: "blocked" }).map((c) => c.uid)[0]).toBe(11);
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -16,9 +16,20 @@ export interface Cell {
 // How the grid orders its cells. "manual": the user's hand-arranged order (◀▶);
 // "auto": attention-first, recomputed from each cell's live status.
 export type SortMode = "manual" | "auto";
-// A cell's live activity, reported up from the cell (the server's working/waiting
-// flags). Drives the "auto" order; absent uids are treated as idle.
-export type CellStatus = "waiting" | "working" | "idle";
+// A cell's live activity, reported up from the cell. Drives the "auto" order and the
+// cell's color/label. `blocked` (needs input/permission) and `done` (finished a turn,
+// output unreviewed) both come from the server's `waiting` flag, split by which hook
+// set it. Absent uids are treated as idle.
+export type CellStatus = "blocked" | "done" | "working" | "idle";
+
+// Map the server's raw activity to a CellStatus. `waiting` means "needs the user";
+// the `event` that set it distinguishes a permission/question pause ("Notification"
+// → blocked, most urgent) from a finished-but-unreviewed turn ("Stop" → done).
+export function activityStatus(working: boolean, waiting: boolean, event: string | null | undefined): CellStatus {
+  if (waiting) return event === "Notification" ? "blocked" : "done";
+  if (working) return "working";
+  return "idle";
+}
 
 export interface GridState {
   cells: Cell[];
@@ -133,10 +144,11 @@ export function moveCell(state: GridState, uid: number, dir: -1 | 1): GridState 
 export const zoomedUid = (state: GridState): number | null =>
   state.expanded !== null && state.cells.some((c) => c.uid === state.expanded) ? state.expanded : null;
 
-// Attention-first rank for the "auto" order: cells needing the user (waiting) come
-// first, then idle, then working, with empty launch cells last. Lower sorts earlier.
-const RANK: Record<CellStatus, number> = { waiting: 0, idle: 1, working: 2 };
-const LAUNCH_RANK = 3;
+// Attention-first rank for the "auto" order: blocked (needs input now) first, then
+// done (finished, review it), then idle, then working, with empty launch cells last.
+// Lower sorts earlier.
+const RANK: Record<CellStatus, number> = { blocked: 0, done: 1, idle: 2, working: 3 };
+const LAUNCH_RANK = 4;
 const cellRank = (c: Cell, statusByUid: Record<number, CellStatus>): number => (isLaunchCell(c) ? LAUNCH_RANK : RANK[statusByUid[c.uid] ?? "idle"]);
 
 // Display order. "manual": the hand-arranged list as-is. "auto": a STABLE sort by

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -7,6 +7,9 @@ export interface Session {
   mtime: number;
   working: boolean;
   waiting: boolean;
+  /** The hook that set the current state ("Stop" | "Notification" | …), or null —
+   *  splits `waiting` into done (Stop) vs blocked (Notification). */
+  event?: string | null;
   /** A hidden background worker (spawnBackgroundChat hidden:true) — listed, but
    *  never treated as unread/bold. */
   hidden?: boolean;


### PR DESCRIPTION
## Summary
`waiting`（要対応）が「承認・入力待ち」と「完了して未レビュー」を混同していた問題を解消。サーバは**どのフックで waiting になったか**を `activity.event` に既に記録し pub/sub でも配信済みなので、**サーバの状態ロジックは変えず**、`event` を REST 2箇所に通してクライアントで4状態に意味付けする（＝低リスク・presentational＋sort のみ）。

- `waiting + Notification` → **blocked**（琥珀グロー・今すぐ手が要る）
- `waiting + Stop` → **done**（青グロー・完了、レビューして）
- `working` → **working**（青・脈動）
- それ以外 → **idle**

Auto並べ替えの優先度も **blocked > done > idle > working** に精緻化。

## Items to Confirm / Review
- **色設計**: blocked=琥珀グロー、done=青グロー、working=青(脈動)、idle=dim。done を working と区別するため青グローを付けています（好みで調整可）。
- **状態判定の前提**: `Notification`=承認/質問/idle待ち→blocked、`Stop`=応答完了→done。Claude hook の意味付けがこの2択で妥当か。
- **サウンド/favicon は据え置き**（従来通り `waiting` で発火）。「done ではサウンドを鳴らさない」等は #174 のスコープ外＝別issue候補。
- 目視未実施（blocked/done を実機で再現するには権限プロンプト等が要るため）。ロジックは activityStatus / orderCells(4状態) / TerminalCell の pub/sub 反映をユニットテストでカバー。

## User Prompt
> 174/175は比較的簡単にできると思うので、すすめて。

## Implementation
- サーバ `server/index.ts`: `SessionMeta.event` 追加、`readSessionMeta` / pending / `/api/sessions` / `/api/session/:id` に `event` を通すだけ。
- `gridTabs.ts`: `CellStatus` を4値化、`RANK` 更新、純粋関数 `activityStatus(working, waiting, event)` 追加。
- `useSessions.ts`: `Session.event`。
- `TerminalCell.vue`: `event` を購読・保持し `activityStatus` で status 算出、`is-waiting`→`is-blocked`/`is-done` の枠色・ドット・ヘッダー tint・ラベル。
- `GridView.vue`: `toStatus`→`activityStatus`（event込み）。
- テスト: `gridTabs.spec`（activityStatus / 4状態 orderCells / visibleOrdered）、`TerminalCell.spec`（blocked/done の pub/sub 反映）。

ゲート: typecheck(client/server) / format / lint / build / **test 558** すべて通過。

Closes #174