### PR TITLE
feat: セル別トークン使用量バッジ (#175)

### DIFF
--- a/plans/feat-175-token-usage.md
+++ b/plans/feat-175-token-usage.md
@@ -1,0 +1,34 @@
+# feat #175: セル別トークン使用量のインライン表示
+
+## User Prompt
+> 174/175は比較的簡単にできると思うので、すすめて。
+
+（Issue #175）Accounting オーバーレイ（全体）はあるが、セル単位のトークン表示が無い。各セルにそのセッションの消費トークンをグランス表示したい。
+
+## 背景（実コード）
+- Claude の transcript(.jsonl) の `type:"assistant"` 行の `message.usage` に `input_tokens` / `output_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` がある。
+- `accounting`（@mulmoclaude/accounting-plugin）は帳簿システムで、**Claude のトークンとは別物**。なので transcript を集計する。
+- 各ターンの usage を合算＝セッションで実際に消費したトークン（毎ターン context を再送するので input は積み上がる。cache read は割引扱いで別集計）。サブスクなので $ ではなく**トークン数**を表示。
+
+## 変更
+### `server/transcript.ts`
+- `SessionUsage`（inputTokens / outputTokens / cacheReadTokens / cacheCreationTokens）と `sessionUsageFromJsonl(raw)` を追加（assistant 行の usage を合算、非 assistant / usage 欠落 / 不正行は無視）。
+
+### `server/index.ts`
+- `/api/session/:id` を transcript の**単一読み込み**に変更し、`lastPrompt` と `usage` を同時に返す（`readSessionSummary`）。二重 read を避ける。
+
+### `TerminalCell.vue`
+- `usage` を `/api/session/:id`（`loadInitial`）から取得。**ターン終了（working→idle）で再取得**して最新化。teardown でリセット。
+- ヘッダーに `⇡{入力合計} ⇣{出力}`（k/M 整形）のバッジ。tooltip で input/cache/output の内訳。トークン0のときは非表示。
+
+## テスト
+- `transcript.spec.ts`: `sessionUsageFromJsonl`（合算 / 無視 / 空）。
+- `TerminalCell.spec.ts`: `/api/session/:id` の usage からバッジ表示・整形。
+
+## 留意点
+- 表示はトークン数（サブスクは $ 課金でないため）。
+- transcript を毎回 read するが、既存の lastPrompt 取得と同コスト（endpoint は mount + ターン終了時のみ）。
+- 常時表示（設定でのオン/オフは follow-up 候補）。
+
+## ゲート
+typecheck(client/server) / format / lint / build / test

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,15 @@ import { mountConfigRoutes } from "./config-routes.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
-import { isRecord, parseJsonl, userPromptText, latestMeaningfulUserPromptFromJsonl, preferredHeaderPrompt } from "./transcript.js";
+import {
+  isRecord,
+  parseJsonl,
+  userPromptText,
+  latestMeaningfulUserPromptFromJsonl,
+  preferredHeaderPrompt,
+  sessionUsageFromJsonl,
+  type SessionUsage,
+} from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
 import { mountGitRemoteRoute } from "./gitRemote.js";
 import { mountWorktreeRoutes } from "./worktree-routes.js";
@@ -653,6 +661,18 @@ async function latestUserPrompt(cwd: string, id: string): Promise<string | null>
   }
 }
 
+const EMPTY_USAGE: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+// One read of a session's transcript → its latest prompt AND cumulative token usage,
+// so /api/session/:id doesn't parse the .jsonl twice.
+async function readSessionSummary(cwd: string, id: string): Promise<{ lastPrompt: string | null; usage: SessionUsage }> {
+  try {
+    const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
+    return { lastPrompt: latestMeaningfulUserPromptFromJsonl(raw), usage: sessionUsageFromJsonl(raw) };
+  } catch {
+    return { lastPrompt: null, usage: EMPTY_USAGE };
+  }
+}
+
 // Scan a session JSONL for a human-friendly title and last activity.
 async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> {
   const full = path.join(dir, file);
@@ -1074,7 +1094,8 @@ app.get("/api/session/:id", async (req, res) => {
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   const a = activity.get(id) || {};
-  const lastPrompt = lastPrompts.get(id) ?? (await latestUserPrompt(cwd, id));
+  const { lastPrompt: transcriptPrompt, usage } = await readSessionSummary(cwd, id);
+  const lastPrompt = lastPrompts.get(id) ?? transcriptPrompt;
   res.json({
     id,
     cwd,
@@ -1082,6 +1103,7 @@ app.get("/api/session/:id", async (req, res) => {
     waiting: a.waiting ?? false,
     event: a.event ?? null,
     lastPrompt,
+    usage,
   });
 });
 

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -6,6 +6,7 @@ import {
   preferredHeaderPrompt,
   userPromptText,
   parseJsonl,
+  sessionUsageFromJsonl,
 } from "./transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
@@ -133,5 +134,29 @@ describe("userPromptText", () => {
 describe("parseJsonl", () => {
   it("keeps valid object lines and skips blank / malformed ones", () => {
     expect(parseJsonl(['{"a":1}', "", "oops", '{"b":2}'].join("\n"))).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+});
+
+describe("sessionUsageFromJsonl", () => {
+  const assistant = (usage: Record<string, number>) => line({ type: "assistant", message: { usage } });
+  it("sums usage across every assistant turn", () => {
+    const raw = [
+      line({ type: "user", message: { content: "hi" } }),
+      assistant({ input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5, cache_creation_input_tokens: 3 }),
+      assistant({ input_tokens: 200, output_tokens: 40, cache_read_input_tokens: 50, cache_creation_input_tokens: 0 }),
+    ].join("\n");
+    expect(sessionUsageFromJsonl(raw)).toEqual({ inputTokens: 300, outputTokens: 60, cacheReadTokens: 55, cacheCreationTokens: 3 });
+  });
+  it("ignores non-assistant lines and assistant lines without usage", () => {
+    const raw = [
+      line({ type: "user", message: { content: "hi" } }),
+      line({ type: "assistant", message: {} }), // no usage
+      assistant({ input_tokens: 10, output_tokens: 2 }), // missing cache fields default to 0
+      "malformed",
+    ].join("\n");
+    expect(sessionUsageFromJsonl(raw)).toEqual({ inputTokens: 10, outputTokens: 2, cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+  it("is all-zero for an empty / promptless transcript", () => {
+    expect(sessionUsageFromJsonl("")).toEqual({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
   });
 });

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -162,3 +162,30 @@ export function latestMeaningfulUserPromptFromJsonl(raw: string): string | null 
   }
   return prompts[prompts.length - 1] ?? lastPromptRecord;
 }
+
+// Cumulative token usage for a session — summed across every assistant turn's
+// `message.usage`. Each turn re-sends the growing context, so summing reflects the
+// tokens actually consumed over the session (cache reads are counted separately, as
+// they're discounted). Fresh input, output, and the two cache buckets are kept apart.
+export interface SessionUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+
+const usageNum = (u: Record<string, unknown>, key: string): number => (typeof u[key] === "number" ? (u[key] as number) : 0);
+
+export function sessionUsageFromJsonl(raw: string): SessionUsage {
+  const total: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+  for (const o of parseJsonl(raw)) {
+    if (o.type !== "assistant" || !isRecord(o.message)) continue;
+    const u = o.message.usage;
+    if (!isRecord(u)) continue;
+    total.inputTokens += usageNum(u, "input_tokens");
+    total.outputTokens += usageNum(u, "output_tokens");
+    total.cacheReadTokens += usageNum(u, "cache_read_input_tokens");
+    total.cacheCreationTokens += usageNum(u, "cache_creation_input_tokens");
+  }
+  return total;
+}

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -448,6 +448,30 @@ describe("TerminalCell", () => {
     expect(dotClass(w)).toContain("is-done");
   });
 
+  it("shows a token-usage badge from /api/session/:id", async () => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return {
+        ok: true,
+        json: async () => ({
+          working: false,
+          waiting: false,
+          lastPrompt: null,
+          usage: { inputTokens: 1200, outputTokens: 3400, cacheReadTokens: 800, cacheCreationTokens: 0 },
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const w = mountCell(id);
+    await flushPromises();
+    const badge = w.find(".cell-usage");
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toContain("2.0k"); // input 1200 + cacheRead 800 = 2000
+    expect(badge.text()).toContain("3.4k"); // output 3400
+  });
+
   it("clears a stale prompt when the server sends lastPrompt: null", async () => {
     const id = "33333333-3333-3333-3333-333333333333";
     const w = mountCell(id);

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -80,6 +80,17 @@ const waiting = ref(false);
 const activityEvent = ref<string | null>(null);
 const lastPrompt = ref<string | null>(null);
 
+// Cumulative token usage for this session (from /api/session/:id, refreshed when a
+// turn finishes). Null until first fetched.
+interface Usage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+}
+const usage = ref<Usage | null>(null);
+const isUsage = (u: unknown): u is Usage => typeof u === "object" && u !== null && "outputTokens" in u;
+
 const { subscribe } = usePubSub();
 let unsubscribe: (() => void) | null = null;
 
@@ -111,9 +122,28 @@ async function loadInitial(id: string) {
     const data = await res.json();
     // Guard against a stale response: the cell may have closed / switched session
     // while the fetch was in flight — don't leak old status into the new state.
-    if (id === sessionId.value) applyActivity(data);
+    if (id === sessionId.value) {
+      applyActivity(data);
+      if (isUsage(data.usage)) usage.value = data.usage;
+    }
   } catch {
     // best-effort — pub/sub will fill it in on the next event
+  }
+}
+
+// Refresh ONLY the token usage (not the live activity — that's pub/sub's job). Called
+// when a turn finishes, so the badge reflects the just-completed turn.
+async function refreshUsage() {
+  const id = sessionId.value;
+  if (!id) return;
+  try {
+    const q = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
+    const res = await fetch(`/api/session/${id}${q}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    if (id === sessionId.value && isUsage(data.usage)) usage.value = data.usage;
+  } catch {
+    // best-effort
   }
 }
 
@@ -453,6 +483,7 @@ function teardown() {
   waiting.value = false;
   activityEvent.value = null;
   lastPrompt.value = null;
+  usage.value = null;
   cwd.value = props.defaultCwd;
   dirInput.value = props.defaultCwd ?? "";
   dirTouched.value = false; // fresh launcher again — let a late preset sync re-prefill
@@ -558,6 +589,22 @@ const statusLabel = computed(() => STATUS_LABEL[status.value]);
 watch(status, (s) => emit("status", s), { immediate: true });
 
 const headerText = computed(() => lastPrompt.value || (sessionId.value ? sessionId.value.slice(0, 8) : "starting…"));
+
+// Per-cell token usage badge: ⇡ total input (fresh + cache) · ⇣ output generated.
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return String(n);
+}
+const usageIn = computed(() => (usage.value ? usage.value.inputTokens + usage.value.cacheReadTokens + usage.value.cacheCreationTokens : 0));
+const usageOut = computed(() => usage.value?.outputTokens ?? 0);
+const showUsage = computed(() => usageIn.value + usageOut.value > 0);
+const usageLabel = computed(() => `⇡${fmtTokens(usageIn.value)} ⇣${fmtTokens(usageOut.value)}`);
+const usageTitle = computed(() =>
+  usage.value
+    ? `Tokens — input ${usage.value.inputTokens.toLocaleString()} · cache ${(usage.value.cacheReadTokens + usage.value.cacheCreationTokens).toLocaleString()} · output ${usage.value.outputTokens.toLocaleString()}`
+    : "",
+);
 
 // Worktree diff (read-only): for a launched worktree cell, show how much the agent
 // changed vs the base branch — a header badge (ahead/dirty) and a panel (changed
@@ -665,9 +712,13 @@ async function openPR() {
 }
 
 // Refresh when the agent transitions from working → settled: that's when the diff
-// is stable and worth re-reading (avoids churn while it's actively editing).
+// is stable and worth re-reading (avoids churn while it's actively editing), and the
+// turn's token usage is final.
 watch(working, (now, prev) => {
-  if (prev && !now) loadDiff();
+  if (prev && !now) {
+    loadDiff();
+    refreshUsage();
+  }
 });
 
 // Re-read (or clear) the diff when the effective cwd changes — e.g. the server
@@ -725,6 +776,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           </div>
         </span>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
+        <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
         <span class="cell-actions">
           <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
           <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
@@ -1107,6 +1159,16 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Per-cell token usage: ⇡ input · ⇣ output. Dim + monospace so it reads as metadata. */
+.cell-usage {
+  flex: 0 0 auto;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  letter-spacing: 0.02em;
 }
 
 .cell-actions {


### PR DESCRIPTION
> ⚠️ **#174 の上に積んだ stacked PR**（base = `feat/174-agent-states`）。#176 をマージ後、base は自動で main になります。単独の差分だけ見たい場合はこの base 指定のままレビューしてください。

## Summary
各グリッドセルのヘッダに、そのセッションの累積トークン使用量を **⇡入力(cache込) ⇣出力**（k/M 整形・内訳 tooltip）で表示。transcript の各ターンの `message.usage` を合算（`sessionUsageFromJsonl`）し、`/api/session/:id` が **単一 read** で lastPrompt と一緒に返す。ターン終了時に再取得して最新化。サブスク運用なので $ ではなく**トークン数**。

## Items to Confirm / Review
- **表示内容**: `⇡{input+cacheRead+cacheCreation} ⇣{output}`。入力は cache 込みの総量、tooltip で fresh/cache/output の内訳。この粒度で良いか（例: cache を除外 / 出力のみ、等）。
- **常時表示**（トークン>0 のとき）。Issue の「設定でオン/オフ」は follow-up 候補（今回は未実装）。
- **性能**: `/api/session/:id` が transcript を1回 read（既存の lastPrompt 取得と同コスト。endpoint は mount＋ターン終了時のみ）。
- **数値の意味**: 各ターンで context を再送するため input は積み上がる＝実消費（billing 相当）。cache read は割引扱いなので別集計。
- 目視未実施。ロジックは `sessionUsageFromJsonl`（合算/無視/空）と TerminalCell のバッジ表示・整形をユニットテストでカバー。

## User Prompt
> 174/175は比較的簡単にできると思うので、すすめて。

## Implementation
- `server/transcript.ts`: `SessionUsage` + `sessionUsageFromJsonl(raw)`。
- `server/index.ts`: `readSessionSummary`（transcript を1回読んで lastPrompt+usage）、`/api/session/:id` に `usage`。
- `TerminalCell.vue`: `usage` を loadInitial で取得、`refreshUsage()` を working→idle で呼ぶ（activity は pub/sub に任せ usage のみ更新）、ヘッダーにバッジ + k/M 整形。
- テスト: `transcript.spec`（sessionUsageFromJsonl）、`TerminalCell.spec`（バッジ表示）。

ゲート: typecheck(client/server) / format / lint / build / **test 562** すべて通過。

Closes #175