### PR TITLE
feat: グリッド状態サマリーをツールバーに表示 (#178)

### DIFF
--- a/plans/feat-178-grid-status-summary.md
+++ b/plans/feat-178-grid-status-summary.md
@@ -1,0 +1,18 @@
+# feat #178: グリッド状態サマリー（ツールバー集計）
+
+## User Prompt
+> 次のissue → （#173 は見送り）他はない？ → 「集計バッジ（推奨・最軽）」
+
+多数エージェント運用で「別ページに手が要るセルがあるか」を一目で。既存 `statusForSort` を集計するだけ。#174 の blocked/done 状態に直結。
+
+## 変更
+- `gridTabs.ts`: `StatusCounts`（Record<CellStatus, number>）と `countByStatus(cells, statusByUid)`（占有セルのみ集計、空ランチャーは除外）。
+- `GridView.vue`: `statusCounts = countByStatus(cells, statusForSort)` を computed し、`AppToolbar` に `:status-counts` で渡す。
+- `AppToolbar.vue`: `statusCounts` prop、grid 時のみ（`inGrid`）「🔴blocked ⚪working 🔵done」の色ドット＋件数チップ、tooltip に内訳。何も動いていなければ非表示。App.vue（single）は渡さない＝非表示。
+- 色: blocked=amber（要対応）、done=accent青（レビュー）、working=text-muted（ただ busy）。
+
+## テスト
+- `gridTabs.spec.ts`: `countByStatus`（占有集計 / 未報告=idle / command セル）。
+
+## ゲート
+typecheck / format / lint / build / test（565 通過）

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -9,6 +9,7 @@ import { useAccountingView, accountingViewOpen } from "../composables/useAccount
 import { useWikiBrowse, wikiGotoIndex } from "../composables/useWikiBrowse";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
 import type { Shortcut } from "../types/shortcuts";
+import type { StatusCounts } from "./gridTabs";
 
 // The standard header, shared by the single (App.vue) and grid (GridView.vue) views so
 // both show one identical toolbar. Every launcher button now just pushes a route — the
@@ -17,10 +18,23 @@ import type { Shortcut } from "../types/shortcuts";
 // active states re-derive from route.name (via the route-backed browse/accounting
 // stores). Grid-only state (`addTerminalActive`, `autoSort`) is still passed in, and
 // the grid-only actions (add-terminal / toggle-sort) and settings stay emits.
-defineProps<{ addTerminalActive?: boolean; autoSort?: boolean }>();
+const props = defineProps<{ addTerminalActive?: boolean; autoSort?: boolean; statusCounts?: StatusCounts }>();
 const emit = defineEmits<{ (e: "add-terminal" | "toggle-sort" | "settings"): void }>();
 
 const route = useRoute();
+// Grid-wide, at-a-glance tally: how many cells are blocked (need input) / done
+// (review) / working, across every page. Shown only when something is running.
+const summaryTitle = computed(() => {
+  const c = props.statusCounts;
+  if (!c) return "";
+  const parts: string[] = [];
+  if (c.blocked) parts.push(`${c.blocked} need input`);
+  if (c.done) parts.push(`${c.done} done (review)`);
+  if (c.working) parts.push(`${c.working} working`);
+  if (c.idle) parts.push(`${c.idle} idle`);
+  return parts.join(" · ");
+});
+const hasSummary = computed(() => !!props.statusCounts && props.statusCounts.blocked + props.statusCounts.done + props.statusCounts.working > 0);
 const { shortcuts } = useShortcuts();
 const { view: browseView } = useCollectionBrowse();
 const { isOpen: accountingOpen } = useAccountingView();
@@ -115,6 +129,11 @@ function showWiki(): void {
       >
         <span class="material-symbols-outlined">{{ autoSort ? "sort" : "swap_horiz" }}</span>
       </button>
+      <span v-if="inGrid && hasSummary && statusCounts" class="grid-summary" :title="summaryTitle" aria-label="Grid status summary">
+        <span v-if="statusCounts.blocked" class="gs gs-blocked">{{ statusCounts.blocked }}</span>
+        <span v-if="statusCounts.done" class="gs gs-done">{{ statusCounts.done }}</span>
+        <span v-if="statusCounts.working" class="gs gs-working">{{ statusCounts.working }}</span>
+      </span>
     </nav>
     <NotificationBell class="toolbar-bell" />
     <button
@@ -192,5 +211,41 @@ function showWiki(): void {
 .launcher-btn .material-symbols-outlined {
   font-size: 19px;
   line-height: 1;
+}
+
+/* Grid-wide status tally: blocked (amber, needs you) · done (blue, review) · working
+   (dim, just busy). A colored dot + count each; grouped after the grid controls. */
+.grid-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  margin-left: 6px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border);
+}
+.gs {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  line-height: 1;
+}
+.gs::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.gs-blocked {
+  color: var(--amber);
+}
+.gs-done {
+  color: var(--accent);
+}
+.gs-working {
+  color: var(--text-muted);
 }
 </style>

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -129,10 +129,10 @@ function showWiki(): void {
       >
         <span class="material-symbols-outlined">{{ autoSort ? "sort" : "swap_horiz" }}</span>
       </button>
-      <span v-if="inGrid && hasSummary && statusCounts" class="grid-summary" :title="summaryTitle" aria-label="Grid status summary">
-        <span v-if="statusCounts.blocked" class="gs gs-blocked">{{ statusCounts.blocked }}</span>
-        <span v-if="statusCounts.done" class="gs gs-done">{{ statusCounts.done }}</span>
-        <span v-if="statusCounts.working" class="gs gs-working">{{ statusCounts.working }}</span>
+      <span v-if="inGrid && hasSummary && statusCounts" class="grid-summary" role="img" :aria-label="`Grid status — ${summaryTitle}`" :title="summaryTitle">
+        <span v-if="statusCounts.blocked" class="gs gs-blocked" aria-hidden="true">{{ statusCounts.blocked }}</span>
+        <span v-if="statusCounts.done" class="gs gs-done" aria-hidden="true">{{ statusCounts.done }}</span>
+        <span v-if="statusCounts.working" class="gs gs-working" aria-hidden="true">{{ statusCounts.working }}</span>
       </span>
     </nav>
     <NotificationBell class="toolbar-bell" />

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -17,6 +17,7 @@ import {
   moveCell,
   visibleOrdered,
   activityStatus,
+  countByStatus,
   cancelableLaunchUid,
   pageCount,
   zoomedUid,
@@ -82,6 +83,8 @@ const statusForSort = computed<Record<number, CellStatus>>(() => {
   }
   return out;
 });
+// At-a-glance tally across ALL pages, for the toolbar summary.
+const statusCounts = computed(() => countByStatus(state.value.cells, statusForSort.value));
 const reorderable = computed(() => state.value.sortMode === "manual");
 // In "auto" mode the whole list is attention-sorted then paged (a waiting cell from
 // any page floats to the front); "manual" keeps the hand-arranged order. While a cell
@@ -135,6 +138,7 @@ function closeSettings() {
     <AppToolbar
       :add-terminal-active="launchOpen"
       :auto-sort="state.sortMode === 'auto'"
+      :status-counts="statusCounts"
       @add-terminal="onAddTerminal"
       @toggle-sort="toggleSortMode"
       @settings="showSettings = true"

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -16,6 +16,7 @@ import {
   orderCells,
   visibleOrdered,
   activityStatus,
+  countByStatus,
   cancelableLaunchUid,
   zoomedUid,
   visibleCells,
@@ -232,6 +233,21 @@ describe("activityStatus", () => {
   });
   it("waiting wins over working (a permission pause mid-turn is blocked)", () => {
     expect(activityStatus(true, true, "Notification")).toBe("blocked");
+  });
+});
+
+describe("countByStatus", () => {
+  it("tallies occupied cells by status, skipping empty launchers", () => {
+    const cells = [...running(4), cell(4)]; // uid 4 = empty launcher
+    const counts = countByStatus(cells, { 0: "blocked", 1: "blocked", 2: "done", 3: "working" });
+    expect(counts).toEqual({ blocked: 2, done: 1, working: 1, idle: 0 });
+  });
+  it("treats an unreported occupied cell as idle", () => {
+    expect(countByStatus(running(2), { 0: "working" })).toEqual({ blocked: 0, done: 0, working: 1, idle: 1 });
+  });
+  it("counts a command cell (occupied, no session)", () => {
+    const cmd = { uid: 0, session: null, cwd: null, command: { index: 0, label: "Build", cwd: "/x" } };
+    expect(countByStatus([cmd], { 0: "working" })).toEqual({ blocked: 0, done: 0, working: 1, idle: 0 });
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -177,6 +177,19 @@ export const visibleOrdered = (state: GridState, statusByUid: Record<number, Cel
   return zoomedUid(state) !== null ? ordered : pageSlice(ordered, state.page);
 };
 
+export type StatusCounts = Record<CellStatus, number>;
+
+// Tally occupied cells (a running session or command) by status — empty launchers are
+// skipped. Powers the toolbar's at-a-glance "N need you" summary across ALL pages.
+export function countByStatus(cells: Cell[], statusByUid: Record<number, CellStatus>): StatusCounts {
+  const counts: StatusCounts = { blocked: 0, done: 0, working: 0, idle: 0 };
+  for (const c of cells) {
+    if (isLaunchCell(c)) continue;
+    counts[statusByUid[c.uid] ?? "idle"]++;
+  }
+  return counts;
+}
+
 // Switch page: drop an abandoned trailing launch cell first and clear the zoom
 // (zoom is scoped to a page). Selecting the already-active page is a no-op so it
 // doesn't discard the open launch cell or zoom.


### PR DESCRIPTION
## Summary
グリッド表示のツールバーに、**全ページ横断の状態集計**（🔴要対応 blocked ・🔵完了 done ・⚪動作中 working の件数）をグランス表示。別ページに手が要るセルがあっても一目で分かる。既存の `statusForSort` を集計するだけの軽量追加で、#174 の状態区分に直結。何も動いていなければ非表示、single ビューでは出ない。

## Items to Confirm / Review
- **表示内容/色**: blocked=amber（要対応）・done=accent青（レビュー）・working=text-muted（ただ busy）。idle は tooltip のみ。この粒度/色で良いか。
- **配置**: ツールバーの grid-only 群（＋Terminal / 並べ替えトグル）の隣に色ドット＋件数。
- 目視未実施（稼働中サーバは 0.6.0 の旧コードのため）。ロジックは `countByStatus` をユニットテスト、テンプレートは build で検証。

## User Prompt
> 次のissue → （#173 プッシュ通知は見送り）他はない？ → 集計バッジ（推奨）

（返信が途切れたため、推奨の最軽・低リスク案を best judgment で実装。別候補が良ければ差し替えます。）

## Implementation
- `gridTabs.ts`: `StatusCounts` + `countByStatus(cells, statusByUid)`（占有セルのみ、空ランチャー除外）。
- `GridView.vue`: `statusCounts` を computed し `AppToolbar` に `:status-counts`。
- `AppToolbar.vue`: `statusCounts` prop、`inGrid` 時のみ色ドット＋件数チップ＋内訳 tooltip。
- テスト: `gridTabs.spec`（countByStatus）。

ゲート: typecheck / format / lint / build / **test 565** 通過。

Closes #178