### PR TITLE
chore: bump version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Patch release **mulmoterminal@0.6.1**（package.json 0.6.0 → 0.6.1）。0.6.0 以降のマージ済み機能を公開する。

### Included since 0.6.0
- #174 エージェント状態の細分化（blocked / done / working / idle）
- #175 セル別トークン使用量バッジ
- #178 グリッド状態サマリー（ツールバー集計）

## Items to Confirm
- パッチ 0.6.1（ユーザ指定）。
- マージ後、main から npm publish → タグ `mulmoterminal@0.6.1` → GitHub リリース（Latest, 既存慣習）。

Gates: install / typecheck / lint / build 通過、`npm publish --dry-run` 確認済み。