### PR TITLE
docs: add 0.6.1 to docs/ChangeLog.md

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -2,6 +2,24 @@
 
 Release notes for MulmoTerminal, mirrored from the [GitHub Releases](https://github.com/receptron/mulmoterminal/releases). Newest first. Versions before `0.6.0` are on GitHub Releases only.
 
+## mulmoterminal@0.6.1 — 2026-07-03
+
+Patch release: the three grid features merged since `mulmoterminal@0.6.0`.
+
+### Highlights
+- **Agent state split** (#174): grid cells now distinguish **blocked** (waiting on a permission/question), **done** (finished a turn, output unreviewed), **working**, and **idle** — each with its own color (blocked = amber glow, done = blue glow, working = pulsing blue), and the auto-order is refined to `blocked > done > idle > working`.
+- **Per-cell token usage badge** (#175): each cell's header shows its session's cumulative tokens (⇡ input incl. cache · ⇣ output), k/M-formatted with a breakdown tooltip, refreshed when a turn finishes.
+- **Grid status summary** (#178): the toolbar shows an at-a-glance tally across all pages — how many cells are blocked (need input) / done (review) / working — so you can tell something needs you even when it's on an off-screen page.
+
+### What's Changed
+* docs: add docs/ChangeLog.md (mirror of the 0.6.0 release notes) by @isamu in https://github.com/receptron/mulmoterminal/pull/172
+* feat: エージェント状態を blocked / done / working / idle に細分化 (#174) by @isamu in https://github.com/receptron/mulmoterminal/pull/176
+* feat: セル別トークン使用量バッジ (#175) by @isamu in https://github.com/receptron/mulmoterminal/pull/177
+* feat: グリッド状態サマリーをツールバーに表示 (#178) by @isamu in https://github.com/receptron/mulmoterminal/pull/179
+* chore: bump version to 0.6.1 by @isamu in https://github.com/receptron/mulmoterminal/pull/180
+
+**Full Changelog**: https://github.com/receptron/mulmoterminal/compare/mulmoterminal@0.6.0...mulmoterminal@0.6.1
+
 ## mulmoterminal@0.6.0 — 2026-07-02
 
 This release lands 41 commits since `mulmoterminal@0.5.0`, focused on navigation, session/terminal persistence, the launcher, content browsing (collections + wiki), runtime translation, and a set of safety guards.


### PR DESCRIPTION
## Summary
`docs/ChangeLog.md` に **mulmoterminal@0.6.1** のエントリを追記（newest-first で 0.6.0 の上）。内容は [0.6.1 GitHub Release](https://github.com/receptron/mulmoterminal/releases/tag/mulmoterminal%400.6.1)（英語）と一致。

- #174 Agent state split / #175 Per-cell token usage badge / #178 Grid status summary