### PR TITLE
feat: 複数リポ横断の GitHub PR 一覧ビュー (#183)

### DIFF
--- a/plans/feat-183-pr-list-view.md
+++ b/plans/feat-183-pr-list-view.md
@@ -1,0 +1,37 @@
+# feat #183: 複数リポ横断の GitHub PR 一覧ビュー
+
+## User Prompt
+> 183欲しい
+
+（Issue #183）別 view（全画面）で、設定で指定した複数リポの PR を串刺し表示。
+
+## 設計判断（デフォルト確定）
+- リポ指定: config.json の `prRepos: ["owner/repo", …]` 明示リスト（Settings で編集）。
+- 認証: サーバの `gh` CLI（既ログイン。`worktree-pr.ts` の `run("gh", …)` を踏襲）。
+- 表示: 全 author の open PR（draft 含む・印付き）、リポ別グルーピング、CI/レビュー状態。
+- 更新: 手動リロード＋ビューを開いた時。ポーリングなし。
+- クリック: GitHub を新規タブで開く。
+
+## 変更
+### サーバ
+- `app-config.ts`: `AppConfig.prRepos: string[]` 追加、`sanitizeRepos()`（`owner/repo` 形のみ）、load/save 反映。
+- `config-routes.ts`: GET に `prRepos`、POST で受理（配列・sanitize）、`getPrRepos()` を export。
+- `prs.ts`(新): `listPrsAcrossRepos(repos)` — 各リポを `gh pr list --repo <r> --json number,title,author,updatedAt,isDraft,url,reviewDecision,statusCheckRollup --state open` で取得→正規化。純関数 `rollupCiState(statusCheckRollup)`（passing/failing/pending/none）をテスト可能に。リポ単位のエラーは握って `{repo, error}` として返す（全体は落とさない）。
+- `index.ts`: `GET /api/prs` を mount（`listPrsAcrossRepos(getPrRepos())`）。
+
+### クライアント
+- `router/index.ts`: `{ path: "/prs", name: "prs" }`。
+- `usePrsView.ts`(新): `useWikiBrowse` を踏襲（`prsGotoIndex`/`prsClose`/`usePrsView`）。
+- `PrsOverlay.vue`(新): 全画面オーバーレイ。`/api/prs` を取得しリポ別に表示（#・title・author・draft・updated・CI・review）、行クリックで GitHub、リロードボタン、loading/error/empty（未設定は Settings 誘導）。
+- `App.vue`: `<PrsOverlay />` を mount。
+- `AppToolbar.vue`: PRs ランチャーボタン（Material Symbol `call_merge`）。route `prs` で active、クリックで `prsGotoIndex()`。
+- `useAppConfig.ts`: `prRepos` を load/save で公開（`savePrRepos`）。
+- `SettingsModal.vue`: `prRepos` の最小編集（owner/repo 追加・削除）。
+
+## テスト
+- `app-config.spec.ts`: prRepos の round-trip / sanitize。
+- `prs.spec.ts`(新): `rollupCiState` と正規化。
+- `PrsOverlay.spec.ts`(新): fetch モックで描画・グルーピング・空表示。
+
+## ゲート
+typecheck(client/server) / format / lint / build / test

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizeSoundFile, loadAppConfig, saveAppConfig } from "./app-config";
+import { sanitizeSoundFile, sanitizeRepos, loadAppConfig, saveAppConfig } from "./app-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 
@@ -22,27 +22,36 @@ describe("sanitizeSoundFile", () => {
   });
 });
 
+describe("sanitizeRepos", () => {
+  it("keeps trimmed owner/repo slugs, drops junk, de-dupes", () => {
+    expect(sanitizeRepos(["  a/b ", "c/d", "a/b", "no-slash", "x/y/z", 5, "bad name/repo"])).toEqual(["a/b", "c/d"]);
+    expect(sanitizeRepos("nope")).toEqual([]);
+    expect(sanitizeRepos(undefined)).toEqual([]);
+  });
+});
+
 describe("loadAppConfig / saveAppConfig", () => {
-  it("round-trips presets + soundFile through a file", () => {
+  it("round-trips presets + soundFile + prRepos through a file", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
-    expect(saveAppConfig(file, { cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav" })).toBe(true);
-    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav" });
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav" });
+    const cfg = { cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav", prRepos: ["o/r"] };
+    expect(saveAppConfig(file, cfg)).toBe(true);
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(cfg);
+    expect(loadAppConfig(file)).toEqual(cfg);
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("defaults to empty presets + null sound for a missing file", () => {
+  it("defaults to empty presets + null sound + empty repos for a missing file", () => {
     const dir = tmp();
-    expect(loadAppConfig(path.join(dir, "none.json"))).toEqual({ cwdPresets: [], soundFile: null });
+    expect(loadAppConfig(path.join(dir, "none.json"))).toEqual({ cwdPresets: [], soundFile: null, prRepos: [] });
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("sanitizes junk presets and a non-string sound on load", () => {
+  it("sanitizes junk presets, a non-string sound, and bad repos on load", () => {
     const dir = tmp();
     const file = path.join(dir, "config.json");
-    writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }, "junk"], soundFile: 5 }));
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null });
+    writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }, "junk"], soundFile: 5, prRepos: ["o/r", "bad"] }));
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null, prRepos: ["o/r"] });
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -50,15 +59,15 @@ describe("loadAppConfig / saveAppConfig", () => {
     const dir = tmp();
     const file = path.join(dir, "bad.json");
     writeFileSync(file, "{ not json");
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [], soundFile: null });
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [], soundFile: null, prRepos: [] });
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("preserves the legacy presets-only shape (soundFile absent => null)", () => {
+  it("preserves the legacy presets-only shape (soundFile / prRepos absent => defaults)", () => {
     const dir = tmp();
     const file = path.join(dir, "config.json");
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }] }));
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null });
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null, prRepos: [] });
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -11,6 +11,22 @@ export interface AppConfig {
   // Absolute path to a user-supplied audio file played as the attention sound, or
   // null to use the built-in synthesized chime (the default — no bundled asset).
   soundFile: string | null;
+  // GitHub repos ("owner/repo") whose open PRs the cross-repo PR view aggregates.
+  prRepos: string[];
+}
+
+// "owner/repo" only — the value is passed to `gh pr list --repo`, so reject anything
+// that isn't a plain slug (no spaces, flags, or paths). Trimmed, de-duplicated.
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+export function sanitizeRepos(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  for (const v of input) {
+    if (typeof v !== "string") continue;
+    const r = v.trim();
+    if (REPO_RE.test(r)) seen.add(r);
+  }
+  return [...seen];
 }
 
 // Keep only a non-empty ABSOLUTE path; anything else (relative, blank, non-string)
@@ -24,11 +40,11 @@ export function sanitizeSoundFile(input: unknown): string | null {
 
 export function loadAppConfig(file: string): AppConfig {
   try {
-    if (!existsSync(file)) return { cwdPresets: [], soundFile: null };
+    if (!existsSync(file)) return { cwdPresets: [], soundFile: null, prRepos: [] };
     const raw = JSON.parse(readFileSync(file, "utf8"));
-    return { cwdPresets: sanitizePresets(raw?.cwdPresets), soundFile: sanitizeSoundFile(raw?.soundFile) };
+    return { cwdPresets: sanitizePresets(raw?.cwdPresets), soundFile: sanitizeSoundFile(raw?.soundFile), prRepos: sanitizeRepos(raw?.prRepos) };
   } catch {
-    return { cwdPresets: [], soundFile: null };
+    return { cwdPresets: [], soundFile: null, prRepos: [] };
   }
 }
 
@@ -37,7 +53,7 @@ export function loadAppConfig(file: string): AppConfig {
 export function saveAppConfig(file: string, config: AppConfig): boolean {
   try {
     mkdirSync(path.dirname(file), { recursive: true });
-    writeFileSync(file, JSON.stringify({ cwdPresets: config.cwdPresets, soundFile: config.soundFile }, null, 2));
+    writeFileSync(file, JSON.stringify({ cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos }, null, 2));
     return true;
   } catch {
     return false;

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -8,14 +8,20 @@ import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
 import { sanitizePresets } from "./cwd-presets.js";
-import { loadAppConfig, saveAppConfig, sanitizeSoundFile, type AppConfig } from "./app-config.js";
+import { loadAppConfig, saveAppConfig, sanitizeSoundFile, sanitizeRepos, type AppConfig } from "./app-config.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
 
+// The repos the cross-repo PR view aggregates — read live so a POST /api/config that
+// changes them takes effect on the next /api/prs without a restart.
+export function getPrRepos(): string[] {
+  return config.prRepos;
+}
+
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   app.get("/api/config", (_req, res) => {
-    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, home: os.homedir() });
+    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos, home: os.homedir() });
   });
 
   app.post("/api/config", (req, res) => {
@@ -25,15 +31,19 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     if (body.cwdPresets !== undefined && !Array.isArray(body.cwdPresets)) {
       return res.status(400).json({ error: "cwdPresets must be an array" });
     }
+    if (body.prRepos !== undefined && !Array.isArray(body.prRepos)) {
+      return res.status(400).json({ error: "prRepos must be an array" });
+    }
     const next: AppConfig = {
       cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : config.cwdPresets,
       soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : config.soundFile,
+      prRepos: body.prRepos !== undefined ? sanitizeRepos(body.prRepos) : config.prRepos,
     };
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.
     if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });
     config = next;
-    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile });
+    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos });
   });
 
   // Stream the user's custom attention sound (their own file, set in config). The

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,8 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes } from "./config-routes.js";
+import { mountConfigRoutes, getPrRepos } from "./config-routes.js";
+import { listPrsAcrossRepos } from "./prs.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
@@ -1055,6 +1056,16 @@ app.get("/api/tool-calls/:sessionId", async (req, res) => {
 // GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
 // modal's directory presets. The single view never calls it.
 mountConfigRoutes(app, CLAUDE_CWD);
+
+// Cross-repo PR list (the /prs view): aggregate open PRs for the configured repos via
+// the server's `gh` login. Repos come from config (never the request).
+app.get("/api/prs", async (_req, res) => {
+  try {
+    res.json({ repos: await listPrsAcrossRepos(getPrRepos()) });
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
 
 // GRID-ONLY (dev_tool): the `script.json` entries a cell's launcher offers for its
 // chosen directory (?cwd=<dir>, falling back to CLAUDE_CWD). The browser shows

--- a/server/prs.spec.ts
+++ b/server/prs.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { rollupCiState, normalizePr } from "./prs";
+
+describe("rollupCiState", () => {
+  it("is none for an empty / non-array rollup", () => {
+    expect(rollupCiState([])).toBe("none");
+    expect(rollupCiState(null)).toBe("none");
+    expect(rollupCiState(undefined)).toBe("none");
+  });
+  it("is passing when every check succeeded (CheckRun conclusion + StatusContext state)", () => {
+    expect(rollupCiState([{ conclusion: "SUCCESS" }, { state: "SUCCESS" }, { conclusion: "SKIPPED" }])).toBe("passing");
+  });
+  it("is failing if any check failed (conclusion or state)", () => {
+    expect(rollupCiState([{ conclusion: "SUCCESS" }, { conclusion: "FAILURE" }])).toBe("failing");
+    expect(rollupCiState([{ state: "ERROR" }])).toBe("failing");
+    expect(rollupCiState([{ conclusion: "SUCCESS" }, { conclusion: "TIMED_OUT" }])).toBe("failing");
+  });
+  it("is pending when a non-failing check is not yet successful", () => {
+    expect(rollupCiState([{ status: "IN_PROGRESS", conclusion: "" }, { conclusion: "SUCCESS" }])).toBe("pending");
+    expect(rollupCiState([{ state: "PENDING" }])).toBe("pending");
+  });
+});
+
+describe("normalizePr", () => {
+  it("normalizes a gh pr json object and rolls up CI", () => {
+    expect(
+      normalizePr({
+        number: 7,
+        title: "fix things",
+        author: { login: "alice" },
+        updatedAt: "2026-07-03T00:00:00Z",
+        isDraft: true,
+        url: "https://github.com/o/r/pull/7",
+        reviewDecision: "APPROVED",
+        statusCheckRollup: [{ conclusion: "SUCCESS" }],
+      }),
+    ).toEqual({
+      number: 7,
+      title: "fix things",
+      author: "alice",
+      updatedAt: "2026-07-03T00:00:00Z",
+      isDraft: true,
+      url: "https://github.com/o/r/pull/7",
+      review: "APPROVED",
+      ci: "passing",
+    });
+  });
+  it("returns null for a malformed entry (no number / url)", () => {
+    expect(normalizePr({ title: "x" })).toBeNull();
+    expect(normalizePr(null)).toBeNull();
+  });
+  it("defaults missing optional fields (author/review/draft)", () => {
+    expect(normalizePr({ number: 1, url: "u" })).toEqual({
+      number: 1,
+      title: "",
+      author: "",
+      updatedAt: "",
+      isDraft: false,
+      url: "u",
+      review: null,
+      ci: "none",
+    });
+  });
+});

--- a/server/prs.ts
+++ b/server/prs.ts
@@ -1,0 +1,94 @@
+// Aggregate open PRs across the user's configured repos via the `gh` CLI (its own
+// login is the auth). One `gh pr list` per repo, run in parallel; a repo that errors
+// (missing, no access, gh not installed) yields a per-repo error instead of failing
+// the whole view. The pure normalize/rollup helpers are unit-tested without gh.
+import { spawn } from "node:child_process";
+
+export type CiState = "passing" | "failing" | "pending" | "none";
+
+export interface PrItem {
+  number: number;
+  title: string;
+  author: string;
+  updatedAt: string;
+  isDraft: boolean;
+  url: string;
+  review: string | null; // gh reviewDecision (APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED / null)
+  ci: CiState;
+}
+
+export interface RepoPrs {
+  repo: string;
+  prs?: PrItem[];
+  error?: string;
+}
+
+const FAIL = new Set(["FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE"]);
+const OK = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
+
+// Collapse a PR's statusCheckRollup (mixed CheckRun {status,conclusion} + StatusContext
+// {state}) into one glanceable state: any failure wins, else any not-yet-successful
+// check → pending, else passing. Empty rollup → none.
+export function rollupCiState(checks: unknown): CiState {
+  if (!Array.isArray(checks) || checks.length === 0) return "none";
+  let anyPending = false;
+  for (const c of checks) {
+    if (!c || typeof c !== "object") continue;
+    const o = c as Record<string, unknown>;
+    const conclusion = String(o.conclusion ?? "").toUpperCase();
+    const state = String(o.state ?? "").toUpperCase();
+    if (FAIL.has(conclusion) || state === "FAILURE" || state === "ERROR") return "failing";
+    if (!(OK.has(conclusion) || state === "SUCCESS")) anyPending = true;
+  }
+  return anyPending ? "pending" : "passing";
+}
+
+export function normalizePr(raw: unknown): PrItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.number !== "number" || typeof o.url !== "string") return null;
+  const authorObj = o.author && typeof o.author === "object" ? (o.author as Record<string, unknown>) : null;
+  return {
+    number: o.number,
+    title: typeof o.title === "string" ? o.title : "",
+    author: authorObj && typeof authorObj.login === "string" ? authorObj.login : "",
+    updatedAt: typeof o.updatedAt === "string" ? o.updatedAt : "",
+    isDraft: o.isDraft === true,
+    url: o.url,
+    review: typeof o.reviewDecision === "string" && o.reviewDecision ? o.reviewDecision : null,
+    ci: rollupCiState(o.statusCheckRollup),
+  };
+}
+
+const GH_FIELDS = "number,title,author,updatedAt,isDraft,url,reviewDecision,statusCheckRollup";
+
+// The binary ("gh") is a fixed local dev tool spawned from PATH — like git/open
+// elsewhere in the server — with args as argv only (no shell). Passed as a parameter
+// (mirroring worktree-pr.ts) so it isn't a spawn-of-a-string-literal.
+function run(bin: string, args: string[]): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("error", () => resolve({ ok: false, stdout: "", stderr: "gh not found (install the GitHub CLI and run `gh auth login`)" }));
+    child.on("close", (code) => resolve({ ok: code === 0, stdout, stderr }));
+  });
+}
+
+export async function listPrsAcrossRepos(repos: string[]): Promise<RepoPrs[]> {
+  return Promise.all(
+    repos.map(async (repo): Promise<RepoPrs> => {
+      const res = await run("gh", ["pr", "list", "--repo", repo, "--state", "open", "--limit", "50", "--json", GH_FIELDS]);
+      if (!res.ok) return { repo, error: (res.stderr.trim() || "gh pr list failed").slice(0, 300) };
+      try {
+        const parsed: unknown = JSON.parse(res.stdout);
+        const prs = Array.isArray(parsed) ? parsed.map(normalizePr).filter((p): p is PrItem => p !== null) : [];
+        return { repo, prs };
+      } catch {
+        return { repo, error: "could not parse gh output" };
+      }
+    }),
+  );
+}

--- a/server/prs.ts
+++ b/server/prs.ts
@@ -21,7 +21,14 @@ export interface RepoPrs {
   repo: string;
   prs?: PrItem[];
   error?: string;
+  // True when the repo has at least PR_LIMIT open PRs, so the list may be incomplete —
+  // surfaced in the UI so a truncated view isn't mistaken for full coverage.
+  truncated?: boolean;
 }
+
+// Per-repo cap. High enough for a review dashboard; a repo that hits it is flagged
+// `truncated` rather than silently cut.
+export const PR_LIMIT = 100;
 
 const FAIL = new Set(["FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE"]);
 const OK = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
@@ -80,12 +87,13 @@ function run(bin: string, args: string[]): Promise<{ ok: boolean; stdout: string
 export async function listPrsAcrossRepos(repos: string[]): Promise<RepoPrs[]> {
   return Promise.all(
     repos.map(async (repo): Promise<RepoPrs> => {
-      const res = await run("gh", ["pr", "list", "--repo", repo, "--state", "open", "--limit", "50", "--json", GH_FIELDS]);
+      const res = await run("gh", ["pr", "list", "--repo", repo, "--state", "open", "--limit", String(PR_LIMIT), "--json", GH_FIELDS]);
       if (!res.ok) return { repo, error: (res.stderr.trim() || "gh pr list failed").slice(0, 300) };
       try {
         const parsed: unknown = JSON.parse(res.stdout);
-        const prs = Array.isArray(parsed) ? parsed.map(normalizePr).filter((p): p is PrItem => p !== null) : [];
-        return { repo, prs };
+        const rows = Array.isArray(parsed) ? parsed : [];
+        const prs = rows.map(normalizePr).filter((p): p is PrItem => p !== null);
+        return { repo, prs, truncated: rows.length >= PR_LIMIT };
       } catch {
         return { repo, error: "could not parse gh output" };
       }

--- a/server/prs.ts
+++ b/server/prs.ts
@@ -87,13 +87,19 @@ function run(bin: string, args: string[]): Promise<{ ok: boolean; stdout: string
 export async function listPrsAcrossRepos(repos: string[]): Promise<RepoPrs[]> {
   return Promise.all(
     repos.map(async (repo): Promise<RepoPrs> => {
-      const res = await run("gh", ["pr", "list", "--repo", repo, "--state", "open", "--limit", String(PR_LIMIT), "--json", GH_FIELDS]);
+      // Fetch one MORE than we display so "there are more" is a real observation
+      // (rows > PR_LIMIT), never a false positive at exactly PR_LIMIT.
+      const res = await run("gh", ["pr", "list", "--repo", repo, "--state", "open", "--limit", String(PR_LIMIT + 1), "--json", GH_FIELDS]);
       if (!res.ok) return { repo, error: (res.stderr.trim() || "gh pr list failed").slice(0, 300) };
       try {
         const parsed: unknown = JSON.parse(res.stdout);
         const rows = Array.isArray(parsed) ? parsed : [];
-        const prs = rows.map(normalizePr).filter((p): p is PrItem => p !== null);
-        return { repo, prs, truncated: rows.length >= PR_LIMIT };
+        const truncated = rows.length > PR_LIMIT;
+        const prs = rows
+          .slice(0, PR_LIMIT)
+          .map(normalizePr)
+          .filter((p): p is PrItem => p !== null);
+        return { repo, prs, truncated };
       } catch {
         return { repo, error: "could not parse gh output" };
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import ToolsPane from "./components/ToolsPane.vue";
 import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue";
 import AccountingOverlay from "./components/AccountingOverlay.vue";
 import WikiBrowseOverlay from "./components/WikiBrowseOverlay.vue";
+import PrsOverlay from "./components/PrsOverlay.vue";
 import GridView from "./components/GridView.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import AppToolbar from "./components/AppToolbar.vue";
@@ -145,7 +146,7 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (theme + notification sound), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { defaultCwd, loadConfig, saveSound } = useAppConfig();
+const { defaultCwd, loadConfig, saveSound, prRepos, savePrRepos } = useAppConfig();
 // Drive the single view's dir overrides off the dir the terminal ACTUALLY runs in
 // (reported by the server, which may resolve/fall back), not the static default — so
 // the badge/theme/colors always track the active session. Falls back to the default
@@ -333,7 +334,16 @@ function onSession(id: string) {
     <!-- Full-screen read-only wiki browser; opened by the toolbar's menu_book button
          (driven by useWikiBrowse). Mutually exclusive with the overlays above. -->
     <WikiBrowseOverlay />
-    <SettingsModal v-if="showSettings" :sound-file="soundFile" @update-sound="saveSound" @close="closeSettings" />
+    <!-- Full-screen cross-repo PR list; opened by the toolbar's call_merge button. -->
+    <PrsOverlay />
+    <SettingsModal
+      v-if="showSettings"
+      :sound-file="soundFile"
+      :pr-repos="prRepos"
+      @update-sound="saveSound"
+      @update-repos="savePrRepos"
+      @close="closeSettings"
+    />
   </div>
 </template>
 

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -7,6 +7,7 @@ import { useShortcuts } from "../composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail } from "../composables/useCollectionBrowse";
 import { useAccountingView, accountingViewOpen } from "../composables/useAccountingView";
 import { useWikiBrowse, wikiGotoIndex } from "../composables/useWikiBrowse";
+import { usePrsView, prsGotoIndex } from "../composables/usePrsView";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
 import type { Shortcut } from "../types/shortcuts";
 import type { StatusCounts } from "./gridTabs";
@@ -39,14 +40,16 @@ const { shortcuts } = useShortcuts();
 const { view: browseView } = useCollectionBrowse();
 const { isOpen: accountingOpen } = useAccountingView();
 const { isOpen: wikiOpen } = useWikiBrowse();
+const { isOpen: prsOpen } = usePrsView();
 const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
 
 const inGrid = computed(() => route.name === "terminals");
 const inSingle = computed(() => !inGrid.value);
-const chatActive = computed(() => inSingle.value && browseView.value.mode === "closed" && !accountingOpen.value && !wikiOpen.value);
+const chatActive = computed(() => inSingle.value && browseView.value.mode === "closed" && !accountingOpen.value && !wikiOpen.value && !prsOpen.value);
 const collectionsActive = computed(() => browseView.value.mode === "index" && browseView.value.kind === "collection");
 const accountingActive = computed(() => accountingOpen.value);
 const wikiActive = computed(() => wikiOpen.value);
+const prsActive = computed(() => prsOpen.value);
 function favActive(s: Shortcut): boolean {
   return browseView.value.mode === "detail" && browseView.value.kind === s.kind && browseView.value.slug === s.slug;
 }
@@ -69,6 +72,9 @@ function showAccounting(): void {
 function showWiki(): void {
   wikiGotoIndex();
 }
+function showPrs(): void {
+  prsGotoIndex();
+}
 </script>
 
 <template>
@@ -86,6 +92,9 @@ function showWiki(): void {
       </button>
       <button type="button" class="launcher-btn" :class="{ active: accountingActive }" title="Accounting" aria-label="Accounting" @click="showAccounting">
         <span class="material-symbols-outlined">account_balance</span>
+      </button>
+      <button type="button" class="launcher-btn" :class="{ active: prsActive }" title="Pull requests" aria-label="Pull requests" @click="showPrs">
+        <span class="material-symbols-outlined">call_merge</span>
       </button>
       <button type="button" class="launcher-btn" :class="{ active: wikiActive }" title="Wiki" aria-label="Wiki" @click="showWiki">
         <span class="material-symbols-outlined">menu_book</span>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -124,7 +124,7 @@ onMounted(() => {
 });
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.
-const { defaultCwd, home, presets, soundFile, loadConfig, recordPreset, removePreset, saveSound } = useAppConfig();
+const { defaultCwd, home, presets, soundFile, prRepos, loadConfig, recordPreset, removePreset, saveSound, savePrRepos } = useAppConfig();
 const showSettings = ref(false);
 onMounted(loadConfig);
 
@@ -169,7 +169,14 @@ function closeSettings() {
       @move="onMove"
       @status="onStatus"
     />
-    <SettingsModal v-if="showSettings" :sound-file="soundFile" @update-sound="saveSound" @close="closeSettings" />
+    <SettingsModal
+      v-if="showSettings"
+      :sound-file="soundFile"
+      :pr-repos="prRepos"
+      @update-sound="saveSound"
+      @update-repos="savePrRepos"
+      @close="closeSettings"
+    />
   </div>
 </template>
 

--- a/src/components/PrsOverlay.spec.ts
+++ b/src/components/PrsOverlay.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { ref } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import PrsOverlay from "./PrsOverlay.vue";
+
+// The view is route-driven; stub usePrsView so the overlay is "open" without a router.
+vi.mock("../composables/usePrsView", () => ({
+  usePrsView: () => ({ isOpen: ref(true), close: vi.fn() }),
+}));
+
+type Repo = { repo: string; prs?: unknown[]; error?: string };
+function mockPrs(repos: Repo[]) {
+  globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ repos }) })) as unknown as typeof fetch;
+}
+
+describe("PrsOverlay", () => {
+  it("groups repos and lists their open PRs", async () => {
+    mockPrs([
+      {
+        repo: "octo/hello",
+        prs: [
+          {
+            number: 3,
+            title: "fix the bug",
+            author: "alice",
+            updatedAt: new Date().toISOString(),
+            isDraft: false,
+            url: "u3",
+            review: "APPROVED",
+            ci: "passing",
+          },
+        ],
+      },
+      { repo: "octo/empty", prs: [] },
+    ]);
+    const w = mount(PrsOverlay);
+    await flushPromises();
+    expect(w.text()).toContain("octo/hello");
+    expect(w.text()).toContain("#3");
+    expect(w.text()).toContain("fix the bug");
+    expect(w.text()).toContain("approved");
+    expect(w.text()).toContain("No open PRs"); // octo/empty
+  });
+
+  it("shows a per-repo error", async () => {
+    mockPrs([{ repo: "octo/x", error: "no access" }]);
+    const w = mount(PrsOverlay);
+    await flushPromises();
+    expect(w.text()).toContain("no access");
+  });
+
+  it("hints to configure repos when none are set", async () => {
+    mockPrs([]);
+    const w = mount(PrsOverlay);
+    await flushPromises();
+    expect(w.text()).toContain("No repositories configured");
+  });
+});

--- a/src/components/PrsOverlay.spec.ts
+++ b/src/components/PrsOverlay.spec.ts
@@ -8,7 +8,7 @@ vi.mock("../composables/usePrsView", () => ({
   usePrsView: () => ({ isOpen: ref(true), close: vi.fn() }),
 }));
 
-type Repo = { repo: string; prs?: unknown[]; error?: string };
+type Repo = { repo: string; prs?: unknown[]; error?: string; truncated?: boolean };
 function mockPrs(repos: Repo[]) {
   globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ repos }) })) as unknown as typeof fetch;
 }
@@ -30,6 +30,7 @@ describe("PrsOverlay", () => {
             ci: "passing",
           },
         ],
+        truncated: true,
       },
       { repo: "octo/empty", prs: [] },
     ]);
@@ -39,6 +40,7 @@ describe("PrsOverlay", () => {
     expect(w.text()).toContain("#3");
     expect(w.text()).toContain("fix the bug");
     expect(w.text()).toContain("approved");
+    expect(w.text()).toContain("more open PRs"); // truncation note
     expect(w.text()).toContain("No open PRs"); // octo/empty
   });
 

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -1,0 +1,270 @@
+<script setup lang="ts">
+// Full-screen cross-repo PR list, a sibling of WikiBrowseOverlay / AccountingOverlay.
+// Driven by usePrsView (the /prs route). Fetches /api/prs (open PRs for the repos set
+// in Settings, aggregated server-side via `gh`) on open and on the reload button, and
+// groups them by repo. Read-only: a row click opens the PR on GitHub in a new tab.
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { usePrsView } from "../composables/usePrsView";
+
+type CiState = "passing" | "failing" | "pending" | "none";
+interface PrItem {
+  number: number;
+  title: string;
+  author: string;
+  updatedAt: string;
+  isDraft: boolean;
+  url: string;
+  review: string | null;
+  ci: CiState;
+}
+interface RepoPrs {
+  repo: string;
+  prs?: PrItem[];
+  error?: string;
+}
+
+const { isOpen, close } = usePrsView();
+
+const repos = ref<RepoPrs[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
+let reqId = 0;
+
+async function load(): Promise<void> {
+  const id = ++reqId;
+  loading.value = true;
+  error.value = null;
+  try {
+    const res = await fetch("/api/prs");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (id === reqId) repos.value = Array.isArray(data.repos) ? data.repos : [];
+  } catch (e) {
+    if (id === reqId) error.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    if (id === reqId) loading.value = false;
+  }
+}
+
+// Re-fetch each time the view is entered (open PRs change as work lands elsewhere).
+watch(isOpen, (open) => open && load(), { immediate: true });
+
+function relativeTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const min = Math.floor((Date.now() - t) / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}
+const CI_TITLE: Record<CiState, string> = { passing: "Checks passing", failing: "Checks failing", pending: "Checks running", none: "No checks" };
+const REVIEW_LABEL: Record<string, string> = { APPROVED: "approved", CHANGES_REQUESTED: "changes requested", REVIEW_REQUIRED: "review required" };
+
+function openPr(url: string): void {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === "Escape" && isOpen.value) close();
+}
+onMounted(() => window.addEventListener("keydown", onKeydown));
+onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
+</script>
+
+<template>
+  <div v-if="isOpen" class="prs-overlay" role="region" aria-label="Pull requests">
+    <header class="prs-head">
+      <span class="prs-title">Pull requests</span>
+      <button type="button" class="prs-reload" :disabled="loading" title="Reload" aria-label="Reload PR list" @click="load">↻</button>
+      <span v-if="loading" class="prs-status">Loading…</span>
+    </header>
+    <div class="prs-content">
+      <p v-if="error" class="prs-msg prs-error">{{ error }}</p>
+      <p v-else-if="!loading && repos.length === 0" class="prs-msg">
+        No repositories configured. Add <code>owner/repo</code> entries under Settings (⚙) → Pull request repos.
+      </p>
+      <section v-for="r in repos" :key="r.repo" class="prs-repo">
+        <h2 class="prs-repo-name">
+          {{ r.repo }}
+          <span v-if="r.prs" class="prs-count">{{ r.prs.length }}</span>
+        </h2>
+        <p v-if="r.error" class="prs-msg prs-error">{{ r.error }}</p>
+        <p v-else-if="r.prs && r.prs.length === 0" class="prs-msg prs-empty">No open PRs</p>
+        <ul v-else-if="r.prs" class="prs-list">
+          <li v-for="pr in r.prs" :key="pr.number">
+            <button type="button" class="prs-row" @click="openPr(pr.url)">
+              <span class="prs-ci" :class="`ci-${pr.ci}`" :title="CI_TITLE[pr.ci]" />
+              <span class="prs-num">#{{ pr.number }}</span>
+              <span class="prs-name">{{ pr.title }}</span>
+              <span v-if="pr.isDraft" class="prs-tag prs-draft">draft</span>
+              <span v-if="pr.review" class="prs-tag" :class="`rev-${pr.review}`">{{ REVIEW_LABEL[pr.review] ?? pr.review.toLowerCase() }}</span>
+              <span class="prs-meta">{{ pr.author }} · {{ relativeTime(pr.updatedAt) }}</span>
+            </button>
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.prs-overlay {
+  position: fixed;
+  top: 40px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: var(--bg-deep);
+  display: flex;
+  flex-direction: column;
+}
+.prs-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel);
+}
+.prs-title {
+  font-weight: 650;
+  font-size: 14px;
+  color: var(--text);
+}
+.prs-reload {
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: 6px;
+  width: 26px;
+  height: 24px;
+  font-size: 14px;
+}
+.prs-reload:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.prs-reload:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.prs-status {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.prs-content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 12px 16px 64px;
+}
+.prs-msg {
+  padding: 24px 4px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.prs-error {
+  color: var(--err);
+}
+.prs-empty {
+  padding: 8px 4px;
+}
+.prs-repo {
+  margin-bottom: 20px;
+}
+.prs-repo-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 6px 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+.prs-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+.prs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.prs-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 7px 8px;
+  border-radius: 6px;
+  font-size: 13px;
+}
+.prs-row:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.prs-ci {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+.ci-passing {
+  background: #3fae6b;
+}
+.ci-failing {
+  background: var(--err-text, #e0556b);
+}
+.ci-pending {
+  background: var(--amber, #e0a030);
+}
+.prs-num {
+  flex: 0 0 auto;
+  font-family: ui-monospace, monospace;
+  color: var(--text-dim);
+}
+.prs-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.prs-tag {
+  flex: 0 0 auto;
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+.prs-draft {
+  color: var(--text-dim);
+}
+.rev-APPROVED {
+  color: #3fae6b;
+  border-color: #3fae6b;
+}
+.rev-CHANGES_REQUESTED {
+  color: var(--err-text, #e0556b);
+  border-color: var(--err-text, #e0556b);
+}
+.prs-meta {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+</style>

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -21,6 +21,7 @@ interface RepoPrs {
   repo: string;
   prs?: PrItem[];
   error?: string;
+  truncated?: boolean;
 }
 
 const { isOpen, close } = usePrsView();
@@ -94,7 +95,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
         <ul v-else-if="r.prs" class="prs-list">
           <li v-for="pr in r.prs" :key="pr.number">
             <button type="button" class="prs-row" @click="openPr(pr.url)">
-              <span class="prs-ci" :class="`ci-${pr.ci}`" :title="CI_TITLE[pr.ci]" />
+              <span class="prs-ci" :class="`ci-${pr.ci}`" role="img" :aria-label="CI_TITLE[pr.ci]" :title="CI_TITLE[pr.ci]" />
               <span class="prs-num">#{{ pr.number }}</span>
               <span class="prs-name">{{ pr.title }}</span>
               <span v-if="pr.isDraft" class="prs-tag prs-draft">draft</span>
@@ -103,6 +104,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
             </button>
           </li>
         </ul>
+        <p v-if="r.truncated" class="prs-msg prs-empty">Showing the first {{ r.prs?.length ?? 0 }} — this repo has more open PRs.</p>
       </section>
     </div>
   </div>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,10 +1,39 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { useTheme } from "../composables/useTheme";
 import { previewAttention } from "../composables/useAttentionSound";
 
-const props = defineProps<{ soundFile?: string | null }>();
-const emit = defineEmits<{ (e: "update-sound", file: string | null): void; (e: "close"): void }>();
+const props = defineProps<{ soundFile?: string | null; prRepos?: string[] }>();
+const emit = defineEmits<{
+  (e: "update-sound", file: string | null): void;
+  (e: "update-repos", repos: string[]): void;
+  (e: "close"): void;
+}>();
+
+// Cross-repo PR view's repos ("owner/repo"). Editable list mirroring the saved value;
+// add/remove emits the new list up (App persists it).
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+const repos = ref<string[]>([...(props.prRepos ?? [])]);
+watch(
+  () => props.prRepos,
+  (r) => (repos.value = [...(r ?? [])]),
+);
+const newRepo = ref("");
+const newRepoValid = computed(() => {
+  const r = newRepo.value.trim();
+  return REPO_RE.test(r) && !repos.value.includes(r);
+});
+function addRepo() {
+  const r = newRepo.value.trim();
+  if (!REPO_RE.test(r) || repos.value.includes(r)) return;
+  repos.value = [...repos.value, r];
+  newRepo.value = "";
+  emit("update-repos", repos.value);
+}
+function removeRepo(r: string) {
+  repos.value = repos.value.filter((x) => x !== r);
+  emit("update-repos", repos.value);
+}
 
 // Custom attention sound, applied immediately (like the theme) — empty => the
 // built-in chime. The text box mirrors the saved value; Browse / typing apply it.
@@ -140,6 +169,29 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
         <button class="btn" type="button" :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</button>
       </div>
 
+      <h3 class="section-title">Pull request repos</h3>
+      <p class="hint">
+        Repos whose open PRs the cross-repo <strong>Pull requests</strong> view lists. Uses your <code>gh</code> login. Format: <code>owner/repo</code>.
+      </p>
+      <ul v-if="repos.length" class="repo-list">
+        <li v-for="r in repos" :key="r" class="repo-item">
+          <span class="repo-name">{{ r }}</span>
+          <button class="icon-btn" type="button" :title="`Remove ${r}`" :aria-label="`Remove ${r}`" @click="removeRepo(r)">✕</button>
+        </li>
+      </ul>
+      <div class="sound-row">
+        <input
+          v-model="newRepo"
+          class="field repo-field"
+          type="text"
+          placeholder="owner/repo"
+          aria-label="Add a repository (owner/repo)"
+          spellcheck="false"
+          @keydown.enter="addRepo"
+        />
+        <button class="btn" type="button" :disabled="!newRepoValid" @click="addRepo">Add</button>
+      </div>
+
       <div class="modal-foot">
         <span class="spacer" />
         <button class="btn btn-primary" @click="emit('close')">Close</button>
@@ -264,6 +316,33 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 .sound-field {
   flex: 1 1 auto;
   font-family: ui-monospace, "JetBrains Mono", monospace;
+}
+.repo-field {
+  flex: 1 1 auto;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+}
+.repo-list {
+  list-style: none;
+  margin: 0 0 8px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.repo-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px 4px 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.repo-name {
+  flex: 1 1 auto;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: var(--text-secondary);
 }
 .sound-actions {
   display: flex;

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -7,6 +7,11 @@ import { presetLabel, type CwdPreset } from "../components/presets";
 // other (each useAppConfig() otherwise has its own local refs).
 const soundFile = ref<string | null>(null);
 
+// Cross-repo PR list's repos — also a SINGLETON, so the settings modal (openable from
+// either view) and any future reader share one list; a save in one view is seen by the
+// other instead of each useAppConfig() keeping a divergent copy.
+const prRepos = ref<string[]>([]);
+
 // Pre-#163 recent dirs lived in localStorage (the removed useRecentDirs). They are
 // imported once into the server-side preset list on load — see migrateLegacyRecents.
 const LEGACY_RECENTS_KEY = "recent_dirs_v1";
@@ -29,7 +34,6 @@ export function useAppConfig() {
   const defaultCwd = ref<string | null>(null);
   const home = ref<string | null>(null);
   const presets = ref<CwdPreset[]>([]);
-  const prRepos = ref<string[]>([]);
   const saving = ref(false);
   const error = ref<string | null>(null);
   // Bumped by every local preset write (savePresets). loadConfig captures it before

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -29,6 +29,7 @@ export function useAppConfig() {
   const defaultCwd = ref<string | null>(null);
   const home = ref<string | null>(null);
   const presets = ref<CwdPreset[]>([]);
+  const prRepos = ref<string[]>([]);
   const saving = ref(false);
   const error = ref<string | null>(null);
   // Bumped by every local preset write (savePresets). loadConfig captures it before
@@ -47,6 +48,7 @@ export function useAppConfig() {
       home.value = c.home ?? null;
       if (presetsVersion === version) presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
       soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
+      prRepos.value = Array.isArray(c.prRepos) ? c.prRepos : [];
       await migrateLegacyRecents();
     } catch {
       // the app still works; presets are just unavailable
@@ -159,5 +161,22 @@ export function useAppConfig() {
     }
   }
 
-  return { defaultCwd, home, presets, soundFile, saving, error, loadConfig, savePresets, recordPreset, removePreset, saveSound };
+  // Persist the cross-repo PR list's repos. POSTs only prRepos so the other fields
+  // (presets, sound) are untouched by the server-side partial update.
+  async function savePrRepos(next: string[]): Promise<boolean> {
+    try {
+      const res = await fetch("/api/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prRepos: next }),
+      });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      prRepos.value = (await res.json()).prRepos ?? [];
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return { defaultCwd, home, presets, prRepos, soundFile, saving, error, loadConfig, savePresets, recordPreset, removePreset, saveSound, savePrRepos };
 }

--- a/src/composables/usePrsView.ts
+++ b/src/composables/usePrsView.ts
@@ -1,0 +1,22 @@
+// Navigation seam for the cross-repo PR list view — a thin derivation over vue-router,
+// mirroring useWikiBrowse / useAccountingView. The open view is entirely the URL:
+// /prs = the PR list. The toolbar button and App's overlay read these.
+import { computed, type ComputedRef } from "vue";
+import { router } from "../router";
+
+/** Open the cross-repo PR list. */
+export function prsGotoIndex(): void {
+  router.push("/prs");
+}
+
+/** Close the PR view → back to chat. */
+export function prsClose(): void {
+  router.push("/");
+}
+
+export function usePrsView(): { isOpen: ComputedRef<boolean>; close: () => void } {
+  return {
+    isOpen: computed(() => router.currentRoute.value.name === "prs"),
+    close: prsClose,
+  };
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -20,6 +20,7 @@ export const routes: RouteRecordRaw[] = [
   { path: "/feeds", name: "feeds", component: Stub },
   { path: "/feeds/:slug", name: "feedDetail", component: Stub },
   { path: "/accounting", name: "accounting", component: Stub },
+  { path: "/prs", name: "prs", component: Stub },
   // Read-only wiki browser (Phase 3 of plans/feat-wiki.md). The open PAGE is the URL;
   // graph + lint are their own sub-routes, mirroring MulmoClaude's /wiki paths.
   { path: "/wiki", name: "wiki", component: Stub },


### PR DESCRIPTION
## Summary
全画面の **`/prs` ビュー**（ツールバーの `call_merge` ボタン）で、**設定した複数リポの open PR を串刺し表示**。サーバの `gh` ログインで集約する。

- **サーバ**: `GET /api/prs` が設定リポごとに `gh pr list` を並列実行 → 各 PR を正規化（author / draft / reviewDecision / CI ロールアップ）。リポ単位のエラーは `{repo, error}` として返し、**全体は落とさない**。リポは config.json の `prRepos`（`owner/repo`、Settings で編集、リクエストからは受け取らない）。
- **フロント**: 新ルート `/prs` ＋ `PrsOverlay`（リポ別グルーピング、CI/レビュー/draft バッジ、更新時刻、行クリックで GitHub、リロードボタン、空/エラー/未設定の各状態）。`SettingsModal` に「Pull request repos」編集を追加。

## Items to Confirm / Review
- **設計判断（デフォルトで実装）**: リポ=設定の明示リスト / 認証=`gh` CLI / 表示=全 author の open（draft 含む）/ 更新=手動＋開いた時（ポーリング無し）/ クリック=GitHub を開く。変更したい軸があれば教えてください。
- **CI ロールアップ**（`rollupCiState`）: 失敗優先→未完了は pending→全成功で passing→空は none。この分類で良いか。
- **a11y**: 状態サマリー系（#178）の指摘を踏まえ、CI ドットには `title`（"Checks passing" 等）を付与。行はボタン。
- **`gh` 前提**: サーバに `gh`（ログイン済み）が無い環境では各リポが error 表示になる（メッセージで導線）。
- 目視未実施（稼働サーバは旧コード）。ロジック（`rollupCiState`/`normalizePr`/`sanitizeRepos`）と `PrsOverlay` 描画・config 往復をユニットテストでカバー。

## User Prompt
> 183欲しい

## Implementation
- `app-config.ts`: `prRepos` + `sanitizeRepos()`（owner/repo のみ・dedup）。`config-routes.ts`: GET/POST に反映＋`getPrRepos()` export。`prs.ts`(新): `listPrsAcrossRepos` ＋純関数 `rollupCiState`/`normalizePr`。`index.ts`: `GET /api/prs`。
- `router`: `/prs`。`usePrsView.ts`(新)。`PrsOverlay.vue`(新)＋`App.vue` mount。`AppToolbar.vue`: PRs ボタン。`useAppConfig.ts`: `prRepos`/`savePrRepos`。`SettingsModal.vue`＋App/GridView: リポ編集の配線。
- テスト: `app-config.spec`（prRepos/sanitize）、`prs.spec`（rollup/normalize）、`PrsOverlay.spec`（描画・グルーピング・エラー・空）。

ゲート: typecheck(client/server) / format / lint / build / **test 576** 通過。

Closes #183