### PR TITLE
feat: /prs ビューに複数リポ横断の open issue 一覧を追加 (#187)

### DIFF
--- a/plans/feat-187-issue-list.md
+++ b/plans/feat-187-issue-list.md
@@ -1,0 +1,24 @@
+# feat-187: /prs ビューに複数リポ横断の open issue 一覧を追加
+
+Issue: #187 / Refs #183
+
+## ゴール
+`/prs` ビューに、`prRepos` と同じリポ群の **open issue 一覧**を PR の下に追加する。
+
+## 決定事項
+- 範囲: 各リポの open issue を最新20件まで。超過分は GitHub の issues ページへのリンクで誘導。
+- リポ: `prRepos` を再利用（別設定なし）。
+- レイアウト: `/prs` ビュー内を2セクション化。上=全リポの PR（既存）、下=全リポの issue（新規）。
+- 取得: `gh issue list --repo R --state open --limit 21`（21件取得→20件表示で truncated 誤検出回避）。
+- クリック: 行クリックで GitHub の issue を新規タブで開く。
+
+## 変更ファイル
+- `server/gh.ts`（新）: `runGh(args)` — `gh` spawn ヘルパを prs.ts から抽出して共有（DRY）。
+- `server/prs.ts`: ローカル `run` を削除し `runGh` を使用。
+- `server/issues.ts`（新）: `IssueItem` / `RepoIssues` / `ISSUE_LIMIT=20` / `normalizeIssue` / `listIssuesAcrossRepos`。
+- `server/index.ts`: `GET /api/issues`（`getPrRepos()` 再利用）。
+- `src/components/PrsOverlay.vue`: `/api/prs` と `/api/issues` を並列 fetch、issue セクション追加、タイトルを "PRs & Issues" に。
+- テスト: `server/issues.spec.ts`（新, normalizeIssue）、`src/components/PrsOverlay.spec.ts`（issue 描画・truncation リンクを追加）。
+
+## ゲート
+typecheck(client/server) / format / lint / build / test を通す。

--- a/server/gh.ts
+++ b/server/gh.ts
@@ -1,0 +1,29 @@
+// Shared `gh` CLI runner for the cross-repo PR / issue views. The GitHub CLI's own
+// login is the auth; args are passed as argv only (no shell). Callers get a per-repo
+// result and decide how to surface errors, so one failing repo never sinks the view.
+import { spawn } from "node:child_process";
+
+export interface GhResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+// `gh` is a fixed local dev tool spawned from PATH — like git/open elsewhere in the
+// server. Passed as a parameter (mirroring worktree-pr.ts) so it isn't a
+// spawn-of-a-string-literal.
+function run(bin: string, args: string[]): Promise<GhResult> {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (c) => (stdout += c.toString()));
+    child.stderr.on("data", (c) => (stderr += c.toString()));
+    child.on("error", () => resolve({ ok: false, stdout: "", stderr: "gh not found (install the GitHub CLI and run `gh auth login`)" }));
+    child.on("close", (code) => resolve({ ok: code === 0, stdout, stderr }));
+  });
+}
+
+export function runGh(args: string[]): Promise<GhResult> {
+  return run("gh", args);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes, getPrRepos } from "./config-routes.js";
 import { listPrsAcrossRepos } from "./prs.js";
+import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
@@ -1062,6 +1063,15 @@ mountConfigRoutes(app, CLAUDE_CWD);
 app.get("/api/prs", async (_req, res) => {
   try {
     res.json({ repos: await listPrsAcrossRepos(getPrRepos()) });
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
+});
+
+// Sibling of /api/prs: the same configured repos' open issues (capped per repo).
+app.get("/api/issues", async (_req, res) => {
+  try {
+    res.json({ repos: await listIssuesAcrossRepos(getPrRepos()) });
   } catch (err) {
     res.status(500).json({ error: String(err) });
   }

--- a/server/issues.spec.ts
+++ b/server/issues.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { normalizeIssue, ISSUE_LIMIT } from "./issues";
+
+describe("normalizeIssue", () => {
+  it("normalizes a gh issue json object", () => {
+    expect(
+      normalizeIssue({
+        number: 42,
+        title: "flaky test",
+        author: { login: "bob" },
+        updatedAt: "2026-07-03T00:00:00Z",
+        url: "https://github.com/o/r/issues/42",
+      }),
+    ).toEqual({
+      number: 42,
+      title: "flaky test",
+      author: "bob",
+      updatedAt: "2026-07-03T00:00:00Z",
+      url: "https://github.com/o/r/issues/42",
+    });
+  });
+  it("returns null for a malformed entry (no number / url)", () => {
+    expect(normalizeIssue({ title: "x" })).toBeNull();
+    expect(normalizeIssue(null)).toBeNull();
+  });
+  it("defaults missing optional fields (author/title/updatedAt)", () => {
+    expect(normalizeIssue({ number: 1, url: "u" })).toEqual({
+      number: 1,
+      title: "",
+      author: "",
+      updatedAt: "",
+      url: "u",
+    });
+  });
+  it("keeps the per-repo cap small enough to stay a glanceable digest", () => {
+    expect(ISSUE_LIMIT).toBeLessThanOrEqual(50);
+  });
+});

--- a/server/issues.ts
+++ b/server/issues.ts
@@ -1,0 +1,67 @@
+// Aggregate open issues across the user's configured repos via the `gh` CLI, mirroring
+// prs.ts. One `gh issue list` per repo in parallel; a failing repo yields a per-repo
+// error instead of sinking the view. The pure normalize helper is unit-tested.
+import { runGh } from "./gh";
+
+export interface IssueItem {
+  number: number;
+  title: string;
+  author: string;
+  updatedAt: string;
+  url: string;
+}
+
+export interface RepoIssues {
+  repo: string;
+  issues?: IssueItem[];
+  error?: string;
+  // True when the repo has more than ISSUE_LIMIT open issues, so the list is capped —
+  // the UI then links to the repo's issues page for the rest.
+  truncated?: boolean;
+  // The repo's GitHub issues page, used as the "see the rest" target when truncated.
+  url?: string;
+}
+
+// Per-repo cap. Small on purpose: this is a glanceable digest, and overflow is one
+// click away on GitHub (unlike the PR view, which is the primary place PRs are read).
+export const ISSUE_LIMIT = 20;
+
+export function normalizeIssue(raw: unknown): IssueItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.number !== "number" || typeof o.url !== "string") return null;
+  const authorObj = o.author && typeof o.author === "object" ? (o.author as Record<string, unknown>) : null;
+  return {
+    number: o.number,
+    title: typeof o.title === "string" ? o.title : "",
+    author: authorObj && typeof authorObj.login === "string" ? authorObj.login : "",
+    updatedAt: typeof o.updatedAt === "string" ? o.updatedAt : "",
+    url: o.url,
+  };
+}
+
+const GH_FIELDS = "number,title,author,updatedAt,url";
+
+export async function listIssuesAcrossRepos(repos: string[]): Promise<RepoIssues[]> {
+  return Promise.all(
+    repos.map(async (repo): Promise<RepoIssues> => {
+      const issuesUrl = `https://github.com/${repo}/issues`;
+      // Fetch one MORE than we display so `truncated` is a real observation
+      // (rows > ISSUE_LIMIT), never a false positive at exactly ISSUE_LIMIT.
+      const res = await runGh(["issue", "list", "--repo", repo, "--state", "open", "--limit", String(ISSUE_LIMIT + 1), "--json", GH_FIELDS]);
+      if (!res.ok) return { repo, error: (res.stderr.trim() || "gh issue list failed").slice(0, 300) };
+      try {
+        const parsed: unknown = JSON.parse(res.stdout);
+        const rows = Array.isArray(parsed) ? parsed : [];
+        const truncated = rows.length > ISSUE_LIMIT;
+        const issues = rows
+          .slice(0, ISSUE_LIMIT)
+          .map(normalizeIssue)
+          .filter((i): i is IssueItem => i !== null);
+        return { repo, issues, truncated, url: issuesUrl };
+      } catch {
+        return { repo, error: "could not parse gh output" };
+      }
+    }),
+  );
+}

--- a/server/prs.ts
+++ b/server/prs.ts
@@ -2,7 +2,7 @@
 // login is the auth). One `gh pr list` per repo, run in parallel; a repo that errors
 // (missing, no access, gh not installed) yields a per-repo error instead of failing
 // the whole view. The pure normalize/rollup helpers are unit-tested without gh.
-import { spawn } from "node:child_process";
+import { runGh } from "./gh";
 
 export type CiState = "passing" | "failing" | "pending" | "none";
 
@@ -69,27 +69,12 @@ export function normalizePr(raw: unknown): PrItem | null {
 
 const GH_FIELDS = "number,title,author,updatedAt,isDraft,url,reviewDecision,statusCheckRollup";
 
-// The binary ("gh") is a fixed local dev tool spawned from PATH — like git/open
-// elsewhere in the server — with args as argv only (no shell). Passed as a parameter
-// (mirroring worktree-pr.ts) so it isn't a spawn-of-a-string-literal.
-function run(bin: string, args: string[]): Promise<{ ok: boolean; stdout: string; stderr: string }> {
-  return new Promise((resolve) => {
-    const child = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (c) => (stdout += c.toString()));
-    child.stderr.on("data", (c) => (stderr += c.toString()));
-    child.on("error", () => resolve({ ok: false, stdout: "", stderr: "gh not found (install the GitHub CLI and run `gh auth login`)" }));
-    child.on("close", (code) => resolve({ ok: code === 0, stdout, stderr }));
-  });
-}
-
 export async function listPrsAcrossRepos(repos: string[]): Promise<RepoPrs[]> {
   return Promise.all(
     repos.map(async (repo): Promise<RepoPrs> => {
       // Fetch one MORE than we display so "there are more" is a real observation
       // (rows > PR_LIMIT), never a false positive at exactly PR_LIMIT.
-      const res = await run("gh", ["pr", "list", "--repo", repo, "--state", "open", "--limit", String(PR_LIMIT + 1), "--json", GH_FIELDS]);
+      const res = await runGh(["pr", "list", "--repo", repo, "--state", "open", "--limit", String(PR_LIMIT + 1), "--json", GH_FIELDS]);
       if (!res.ok) return { repo, error: (res.stderr.trim() || "gh pr list failed").slice(0, 300) };
       try {
         const parsed: unknown = JSON.parse(res.stdout);

--- a/src/components/PrsOverlay.spec.ts
+++ b/src/components/PrsOverlay.spec.ts
@@ -9,13 +9,20 @@ vi.mock("../composables/usePrsView", () => ({
 }));
 
 type Repo = { repo: string; prs?: unknown[]; error?: string; truncated?: boolean };
-function mockPrs(repos: Repo[]) {
-  globalThis.fetch = vi.fn(async () => ({ ok: true, json: async () => ({ repos }) })) as unknown as typeof fetch;
+type IssueRepo = { repo: string; issues?: unknown[]; error?: string; truncated?: boolean; url?: string };
+
+// The overlay fetches /api/prs and /api/issues in parallel; route the mock by path.
+function mockFetch(prs: Repo[], issues: IssueRepo[] = []) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const repos = url.includes("/api/issues") ? issues : prs;
+    return { ok: true, json: async () => ({ repos }) };
+  }) as unknown as typeof fetch;
 }
 
 describe("PrsOverlay", () => {
   it("groups repos and lists their open PRs", async () => {
-    mockPrs([
+    mockFetch([
       {
         repo: "octo/hello",
         prs: [
@@ -44,15 +51,39 @@ describe("PrsOverlay", () => {
     expect(w.text()).toContain("No open PRs"); // octo/empty
   });
 
+  it("lists open issues below the PRs and links to GitHub when truncated", async () => {
+    mockFetch(
+      [{ repo: "octo/hello", prs: [] }],
+      [
+        {
+          repo: "octo/hello",
+          issues: [{ number: 42, title: "flaky test", author: "bob", updatedAt: new Date().toISOString(), url: "https://github.com/octo/hello/issues/42" }],
+          truncated: true,
+          url: "https://github.com/octo/hello/issues",
+        },
+        { repo: "octo/quiet", issues: [] },
+      ],
+    );
+    const w = mount(PrsOverlay);
+    await flushPromises();
+    expect(w.text()).toContain("Issues");
+    expect(w.text()).toContain("#42");
+    expect(w.text()).toContain("flaky test");
+    expect(w.text()).toContain("No open issues"); // octo/quiet
+    const seeAll = w.get("a.prs-link");
+    expect(seeAll.attributes("href")).toBe("https://github.com/octo/hello/issues");
+    expect(seeAll.text()).toContain("see all open issues");
+  });
+
   it("shows a per-repo error", async () => {
-    mockPrs([{ repo: "octo/x", error: "no access" }]);
+    mockFetch([{ repo: "octo/x", error: "no access" }]);
     const w = mount(PrsOverlay);
     await flushPromises();
     expect(w.text()).toContain("no access");
   });
 
   it("hints to configure repos when none are set", async () => {
-    mockPrs([]);
+    mockFetch([]);
     const w = mount(PrsOverlay);
     await flushPromises();
     expect(w.text()).toContain("No repositories configured");

--- a/src/components/PrsOverlay.spec.ts
+++ b/src/components/PrsOverlay.spec.ts
@@ -12,12 +12,19 @@ type Repo = { repo: string; prs?: unknown[]; error?: string; truncated?: boolean
 type IssueRepo = { repo: string; issues?: unknown[]; error?: string; truncated?: boolean; url?: string };
 
 // The overlay fetches /api/prs and /api/issues in parallel; route the mock by path.
-function mockFetch(prs: Repo[], issues: IssueRepo[] = []) {
+// opts.failPrs / opts.failIssues make that endpoint return a non-ok response.
+function mockFetch(prs: Repo[], issues: IssueRepo[] = [], opts: { failPrs?: boolean; failIssues?: boolean } = {}) {
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
-    const url = String(input);
-    const repos = url.includes("/api/issues") ? issues : prs;
-    return { ok: true, json: async () => ({ repos }) };
+    const isIssues = String(input).includes("/api/issues");
+    if ((isIssues && opts.failIssues) || (!isIssues && opts.failPrs)) {
+      return { ok: false, status: 500, json: async () => ({}) };
+    }
+    return { ok: true, json: async () => ({ repos: isIssues ? issues : prs }) };
   }) as unknown as typeof fetch;
+}
+
+function pr(number: number, title: string) {
+  return { number, title, author: "alice", updatedAt: new Date().toISOString(), isDraft: false, url: `u${number}`, review: null, ci: "none" };
 }
 
 describe("PrsOverlay", () => {
@@ -73,6 +80,24 @@ describe("PrsOverlay", () => {
     const seeAll = w.get("a.prs-link");
     expect(seeAll.attributes("href")).toBe("https://github.com/octo/hello/issues");
     expect(seeAll.text()).toContain("see all open issues");
+  });
+
+  it("keeps rendering one section when the other endpoint fails", async () => {
+    // /api/issues fails → PRs must still render, issue section shows its own error.
+    mockFetch([{ repo: "octo/hello", prs: [pr(3, "still visible")] }], [], { failIssues: true });
+    const w1 = mount(PrsOverlay);
+    await flushPromises();
+    expect(w1.text()).toContain("still visible"); // PR dashboard not blanked
+    expect(w1.text()).toContain("HTTP 500"); // issue section error
+
+    // Reverse: /api/prs fails → issues still render.
+    mockFetch([], [{ repo: "octo/hello", issues: [{ number: 9, title: "issue shows", author: "bob", updatedAt: new Date().toISOString(), url: "u9" }] }], {
+      failPrs: true,
+    });
+    const w2 = mount(PrsOverlay);
+    await flushPromises();
+    expect(w2.text()).toContain("issue shows");
+    expect(w2.text()).toContain("HTTP 500");
   });
 
   it("shows a per-repo error", async () => {

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -43,31 +43,35 @@ const { isOpen, close } = usePrsView();
 const repos = ref<RepoPrs[]>([]);
 const issueRepos = ref<RepoIssues[]>([]);
 const loading = ref(false);
-const error = ref<string | null>(null);
+const prsError = ref<string | null>(null);
+const issuesError = ref<string | null>(null);
 let reqId = 0;
 
-async function fetchRepos(path: string): Promise<unknown[]> {
-  const res = await fetch(path);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const data = await res.json();
-  return Array.isArray(data.repos) ? data.repos : [];
+// Each section loads independently so one endpoint failing (e.g. a transient
+// /api/issues error) never blanks the other — the PR dashboard keeps rendering.
+async function loadSection(path: string): Promise<{ rows: unknown[]; error: string | null }> {
+  try {
+    const res = await fetch(path);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    return { rows: Array.isArray(data.repos) ? data.repos : [], error: null };
+  } catch (e) {
+    return { rows: [], error: e instanceof Error ? e.message : String(e) };
+  }
 }
 
 async function load(): Promise<void> {
   const id = ++reqId;
   loading.value = true;
-  error.value = null;
-  try {
-    const [prs, issues] = await Promise.all([fetchRepos("/api/prs"), fetchRepos("/api/issues")]);
-    if (id === reqId) {
-      repos.value = prs as RepoPrs[];
-      issueRepos.value = issues as RepoIssues[];
-    }
-  } catch (e) {
-    if (id === reqId) error.value = e instanceof Error ? e.message : String(e);
-  } finally {
-    if (id === reqId) loading.value = false;
-  }
+  prsError.value = null;
+  issuesError.value = null;
+  const [prs, issues] = await Promise.all([loadSection("/api/prs"), loadSection("/api/issues")]);
+  if (id !== reqId) return;
+  repos.value = prs.rows as RepoPrs[];
+  prsError.value = prs.error;
+  issueRepos.value = issues.rows as RepoIssues[];
+  issuesError.value = issues.error;
+  loading.value = false;
 }
 
 // Re-fetch each time the view is entered (open PRs change as work lands elsewhere).
@@ -104,12 +108,12 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       <span v-if="loading" class="prs-status">Loading…</span>
     </header>
     <div class="prs-content">
-      <p v-if="error" class="prs-msg prs-error">{{ error }}</p>
-      <p v-else-if="!loading && repos.length === 0" class="prs-msg">
+      <p v-if="!loading && !prsError && !issuesError && repos.length === 0 && issueRepos.length === 0" class="prs-msg">
         No repositories configured. Add <code>owner/repo</code> entries under Settings (⚙) → Pull request repos.
       </p>
       <template v-else>
         <h2 class="prs-section">Pull requests</h2>
+        <p v-if="prsError" class="prs-msg prs-error">{{ prsError }}</p>
         <section v-for="r in repos" :key="`pr-${r.repo}`" class="prs-repo">
           <h3 class="prs-repo-name">
             {{ r.repo }}
@@ -133,6 +137,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
         </section>
 
         <h2 class="prs-section">Issues</h2>
+        <p v-if="issuesError" class="prs-msg prs-error">{{ issuesError }}</p>
         <section v-for="r in issueRepos" :key="`iss-${r.repo}`" class="prs-repo">
           <h3 class="prs-repo-name">
             {{ r.repo }}

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-// Full-screen cross-repo PR list, a sibling of WikiBrowseOverlay / AccountingOverlay.
-// Driven by usePrsView (the /prs route). Fetches /api/prs (open PRs for the repos set
-// in Settings, aggregated server-side via `gh`) on open and on the reload button, and
-// groups them by repo. Read-only: a row click opens the PR on GitHub in a new tab.
+// Full-screen cross-repo PR + issue list, a sibling of WikiBrowseOverlay /
+// AccountingOverlay. Driven by usePrsView (the /prs route). Fetches /api/prs and
+// /api/issues (the repos set in Settings, aggregated server-side via `gh`) on open and
+// on the reload button, grouped by repo. Read-only: a row click opens it on GitHub.
 import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { usePrsView } from "../composables/usePrsView";
 
@@ -23,23 +23,46 @@ interface RepoPrs {
   error?: string;
   truncated?: boolean;
 }
+interface IssueItem {
+  number: number;
+  title: string;
+  author: string;
+  updatedAt: string;
+  url: string;
+}
+interface RepoIssues {
+  repo: string;
+  issues?: IssueItem[];
+  error?: string;
+  truncated?: boolean;
+  url?: string;
+}
 
 const { isOpen, close } = usePrsView();
 
 const repos = ref<RepoPrs[]>([]);
+const issueRepos = ref<RepoIssues[]>([]);
 const loading = ref(false);
 const error = ref<string | null>(null);
 let reqId = 0;
+
+async function fetchRepos(path: string): Promise<unknown[]> {
+  const res = await fetch(path);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return Array.isArray(data.repos) ? data.repos : [];
+}
 
 async function load(): Promise<void> {
   const id = ++reqId;
   loading.value = true;
   error.value = null;
   try {
-    const res = await fetch("/api/prs");
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    if (id === reqId) repos.value = Array.isArray(data.repos) ? data.repos : [];
+    const [prs, issues] = await Promise.all([fetchRepos("/api/prs"), fetchRepos("/api/issues")]);
+    if (id === reqId) {
+      repos.value = prs as RepoPrs[];
+      issueRepos.value = issues as RepoIssues[];
+    }
   } catch (e) {
     if (id === reqId) error.value = e instanceof Error ? e.message : String(e);
   } finally {
@@ -63,7 +86,7 @@ function relativeTime(iso: string): string {
 const CI_TITLE: Record<CiState, string> = { passing: "Checks passing", failing: "Checks failing", pending: "Checks running", none: "No checks" };
 const REVIEW_LABEL: Record<string, string> = { APPROVED: "approved", CHANGES_REQUESTED: "changes requested", REVIEW_REQUIRED: "review required" };
 
-function openPr(url: string): void {
+function openUrl(url: string): void {
   window.open(url, "_blank", "noopener,noreferrer");
 }
 function onKeydown(e: KeyboardEvent): void {
@@ -74,10 +97,10 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
 </script>
 
 <template>
-  <div v-if="isOpen" class="prs-overlay" role="region" aria-label="Pull requests">
+  <div v-if="isOpen" class="prs-overlay" role="region" aria-label="Pull requests and issues">
     <header class="prs-head">
-      <span class="prs-title">Pull requests</span>
-      <button type="button" class="prs-reload" :disabled="loading" title="Reload" aria-label="Reload PR list" @click="load">↻</button>
+      <span class="prs-title">PRs &amp; Issues</span>
+      <button type="button" class="prs-reload" :disabled="loading" title="Reload" aria-label="Reload PR and issue list" @click="load">↻</button>
       <span v-if="loading" class="prs-status">Loading…</span>
     </header>
     <div class="prs-content">
@@ -85,27 +108,53 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
       <p v-else-if="!loading && repos.length === 0" class="prs-msg">
         No repositories configured. Add <code>owner/repo</code> entries under Settings (⚙) → Pull request repos.
       </p>
-      <section v-for="r in repos" :key="r.repo" class="prs-repo">
-        <h2 class="prs-repo-name">
-          {{ r.repo }}
-          <span v-if="r.prs" class="prs-count">{{ r.prs.length }}</span>
-        </h2>
-        <p v-if="r.error" class="prs-msg prs-error">{{ r.error }}</p>
-        <p v-else-if="r.prs && r.prs.length === 0" class="prs-msg prs-empty">No open PRs</p>
-        <ul v-else-if="r.prs" class="prs-list">
-          <li v-for="pr in r.prs" :key="pr.number">
-            <button type="button" class="prs-row" @click="openPr(pr.url)">
-              <span class="prs-ci" :class="`ci-${pr.ci}`" role="img" :aria-label="CI_TITLE[pr.ci]" :title="CI_TITLE[pr.ci]" />
-              <span class="prs-num">#{{ pr.number }}</span>
-              <span class="prs-name">{{ pr.title }}</span>
-              <span v-if="pr.isDraft" class="prs-tag prs-draft">draft</span>
-              <span v-if="pr.review" class="prs-tag" :class="`rev-${pr.review}`">{{ REVIEW_LABEL[pr.review] ?? pr.review.toLowerCase() }}</span>
-              <span class="prs-meta">{{ pr.author }} · {{ relativeTime(pr.updatedAt) }}</span>
-            </button>
-          </li>
-        </ul>
-        <p v-if="r.truncated" class="prs-msg prs-empty">Showing the first {{ r.prs?.length ?? 0 }} — this repo has more open PRs.</p>
-      </section>
+      <template v-else>
+        <h2 class="prs-section">Pull requests</h2>
+        <section v-for="r in repos" :key="`pr-${r.repo}`" class="prs-repo">
+          <h3 class="prs-repo-name">
+            {{ r.repo }}
+            <span v-if="r.prs" class="prs-count">{{ r.prs.length }}</span>
+          </h3>
+          <p v-if="r.error" class="prs-msg prs-error">{{ r.error }}</p>
+          <p v-else-if="r.prs && r.prs.length === 0" class="prs-msg prs-empty">No open PRs</p>
+          <ul v-else-if="r.prs" class="prs-list">
+            <li v-for="pr in r.prs" :key="pr.number">
+              <button type="button" class="prs-row" @click="openUrl(pr.url)">
+                <span class="prs-ci" :class="`ci-${pr.ci}`" role="img" :aria-label="CI_TITLE[pr.ci]" :title="CI_TITLE[pr.ci]" />
+                <span class="prs-num">#{{ pr.number }}</span>
+                <span class="prs-name">{{ pr.title }}</span>
+                <span v-if="pr.isDraft" class="prs-tag prs-draft">draft</span>
+                <span v-if="pr.review" class="prs-tag" :class="`rev-${pr.review}`">{{ REVIEW_LABEL[pr.review] ?? pr.review.toLowerCase() }}</span>
+                <span class="prs-meta">{{ pr.author }} · {{ relativeTime(pr.updatedAt) }}</span>
+              </button>
+            </li>
+          </ul>
+          <p v-if="r.truncated" class="prs-msg prs-empty">Showing the first {{ r.prs?.length ?? 0 }} — this repo has more open PRs.</p>
+        </section>
+
+        <h2 class="prs-section">Issues</h2>
+        <section v-for="r in issueRepos" :key="`iss-${r.repo}`" class="prs-repo">
+          <h3 class="prs-repo-name">
+            {{ r.repo }}
+            <span v-if="r.issues" class="prs-count">{{ r.issues.length }}</span>
+          </h3>
+          <p v-if="r.error" class="prs-msg prs-error">{{ r.error }}</p>
+          <p v-else-if="r.issues && r.issues.length === 0" class="prs-msg prs-empty">No open issues</p>
+          <ul v-else-if="r.issues" class="prs-list">
+            <li v-for="iss in r.issues" :key="iss.number">
+              <button type="button" class="prs-row" @click="openUrl(iss.url)">
+                <span class="prs-num">#{{ iss.number }}</span>
+                <span class="prs-name">{{ iss.title }}</span>
+                <span class="prs-meta">{{ iss.author }} · {{ relativeTime(iss.updatedAt) }}</span>
+              </button>
+            </li>
+          </ul>
+          <p v-if="r.truncated" class="prs-msg prs-empty">
+            Showing the latest {{ r.issues?.length ?? 0 }} —
+            <a :href="r.url" target="_blank" rel="noopener noreferrer" class="prs-link">see all open issues on GitHub</a>.
+          </p>
+        </section>
+      </template>
     </div>
   </div>
 </template>
@@ -173,6 +222,23 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
 }
 .prs-empty {
   padding: 8px 4px;
+}
+.prs-section {
+  margin: 4px 0 12px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+.prs-section:not(:first-child) {
+  margin-top: 28px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.prs-link {
+  color: var(--accent, #3b82f6);
+  text-decoration: underline;
 }
 .prs-repo {
   margin-bottom: 20px;


### PR DESCRIPTION
## Summary
#183 の全画面 `/prs` ビューに、**同じ設定リポ（`prRepos`）の open issue 一覧**を PR の下に追加。`gh issue list` を `gh pr list` と対称に叩き、リポ別に表示する。

- **サーバ**: 共通の `gh` spawn ヘルパを `server/gh.ts`（`runGh`）に切り出し（prs.ts と共有）。`server/issues.ts` が `listIssuesAcrossRepos()` でリポごとに `gh issue list` を並列実行 → 正規化。`GET /api/issues`（`getPrRepos()` 再利用）。
- **フロント**: `PrsOverlay` が `/api/prs` と `/api/issues` を並列 fetch。ビュー内を2セクション化（上=全リポの PR、下=全リポの issue、各リポでグルーピング）。タイトルを "PRs & Issues" に。
- **範囲**: 各リポの open issue を最新20件まで。超過分は各リポの GitHub issues ページへのリンク（`truncated` 判定は `ISSUE_LIMIT+1` 取得で誤検出回避、#185 の PR 側と同手法）。

## Items to Confirm / Review
- **仕様（回答どおり実装）**: issue=各リポ open 最新20件・超過は web へ / レイアウト=PR全部の下に issue全部 / リポ=`prRepos` 再利用。
- **並び順**: `gh issue list` 既定（created 降順＝新しい順）。実 gh で確認済み（新規 #187 が先頭に来る）。
- **DRY リファクタ**: `run` を `server/gh.ts` に移して prs.ts と共有。prs.ts の挙動は不変（テスト継続 pass）。
- **目視**: サーバロジックは実 gh で end-to-end 確認済み（実リポ→5件・URL正、存在しないリポ→per-repo error で全体は落ちない）。UI 描画・truncation リンク・空/エラー状態はユニットテストでカバー。

## User Prompt
> あ、さっきのだけど、Pull requests 一覧の下に issue もほしいかも。

（範囲・レイアウトの確認）
> - 範囲: open の最新20件くらい。それ以降は web に飛ばす
> - レイアウト: PR 全部の下に issue 全部

## Implementation
- `server/gh.ts`(新): `runGh(args)`。`server/prs.ts`: ローカル `run` を削除し `runGh` を使用（挙動不変）。
- `server/issues.ts`(新): `IssueItem` / `RepoIssues` / `ISSUE_LIMIT=20` / `normalizeIssue` / `listIssuesAcrossRepos`。`server/index.ts`: `GET /api/issues`。
- `src/components/PrsOverlay.vue`: 並列 fetch＋2セクション描画＋ truncation リンク。
- テスト: `server/issues.spec.ts`(新)、`PrsOverlay.spec.ts`(issue 描画・リンク追加)。ゲート: typecheck(client/server)/format/lint/build/**test 581** 通過。

Refs #183
Closes #187