### PR TITLE
fix: /prs の PR/issue 行を実際のリンクにする (#190)

### DIFF
--- a/src/components/PrsOverlay.spec.ts
+++ b/src/components/PrsOverlay.spec.ts
@@ -56,6 +56,11 @@ describe("PrsOverlay", () => {
     expect(w.text()).toContain("approved");
     expect(w.text()).toContain("more open PRs"); // truncation note
     expect(w.text()).toContain("No open PRs"); // octo/empty
+    // Rows are real links (right-click / new-tab / ⌘-click work), not JS buttons.
+    const row = w.get("a.prs-row");
+    expect(row.attributes("href")).toBe("u3");
+    expect(row.attributes("target")).toBe("_blank");
+    expect(row.attributes("rel")).toContain("noopener");
   });
 
   it("lists open issues below the PRs and links to GitHub when truncated", async () => {
@@ -77,6 +82,7 @@ describe("PrsOverlay", () => {
     expect(w.text()).toContain("#42");
     expect(w.text()).toContain("flaky test");
     expect(w.text()).toContain("No open issues"); // octo/quiet
+    expect(w.get("a.prs-row").attributes("href")).toBe("https://github.com/octo/hello/issues/42"); // issue row is a real link
     const seeAll = w.get("a.prs-link");
     expect(seeAll.attributes("href")).toBe("https://github.com/octo/hello/issues");
     expect(seeAll.text()).toContain("see all open issues");

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -90,9 +90,6 @@ function relativeTime(iso: string): string {
 const CI_TITLE: Record<CiState, string> = { passing: "Checks passing", failing: "Checks failing", pending: "Checks running", none: "No checks" };
 const REVIEW_LABEL: Record<string, string> = { APPROVED: "approved", CHANGES_REQUESTED: "changes requested", REVIEW_REQUIRED: "review required" };
 
-function openUrl(url: string): void {
-  window.open(url, "_blank", "noopener,noreferrer");
-}
 function onKeydown(e: KeyboardEvent): void {
   if (e.key === "Escape" && isOpen.value) close();
 }
@@ -123,14 +120,14 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
           <p v-else-if="r.prs && r.prs.length === 0" class="prs-msg prs-empty">No open PRs</p>
           <ul v-else-if="r.prs" class="prs-list">
             <li v-for="pr in r.prs" :key="pr.number">
-              <button type="button" class="prs-row" @click="openUrl(pr.url)">
+              <a class="prs-row" :href="pr.url" target="_blank" rel="noopener noreferrer">
                 <span class="prs-ci" :class="`ci-${pr.ci}`" role="img" :aria-label="CI_TITLE[pr.ci]" :title="CI_TITLE[pr.ci]" />
                 <span class="prs-num">#{{ pr.number }}</span>
                 <span class="prs-name">{{ pr.title }}</span>
                 <span v-if="pr.isDraft" class="prs-tag prs-draft">draft</span>
                 <span v-if="pr.review" class="prs-tag" :class="`rev-${pr.review}`">{{ REVIEW_LABEL[pr.review] ?? pr.review.toLowerCase() }}</span>
                 <span class="prs-meta">{{ pr.author }} · {{ relativeTime(pr.updatedAt) }}</span>
-              </button>
+              </a>
             </li>
           </ul>
           <p v-if="r.truncated" class="prs-msg prs-empty">Showing the first {{ r.prs?.length ?? 0 }} — this repo has more open PRs.</p>
@@ -147,11 +144,11 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
           <p v-else-if="r.issues && r.issues.length === 0" class="prs-msg prs-empty">No open issues</p>
           <ul v-else-if="r.issues" class="prs-list">
             <li v-for="iss in r.issues" :key="iss.number">
-              <button type="button" class="prs-row" @click="openUrl(iss.url)">
+              <a class="prs-row" :href="iss.url" target="_blank" rel="noopener noreferrer">
                 <span class="prs-num">#{{ iss.number }}</span>
                 <span class="prs-name">{{ iss.title }}</span>
                 <span class="prs-meta">{{ iss.author }} · {{ relativeTime(iss.updatedAt) }}</span>
-              </button>
+              </a>
             </li>
           </ul>
           <p v-if="r.truncated" class="prs-msg prs-empty">
@@ -276,9 +273,8 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
   gap: 10px;
   width: 100%;
   text-align: left;
-  border: none;
-  background: transparent;
   color: var(--text-secondary);
+  text-decoration: none;
   cursor: pointer;
   padding: 7px 8px;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
`/prs` ビューの PR / issue 行が `<button @click="window.open()">` で実装されており、**実リンクになっていなかった**。右クリック「新規タブで開く」・⌘/Ctrl+クリック・中クリック・リンクのコピーが効かない不具合を修正。

行を素の `<a :href="url" target="_blank" rel="noopener noreferrer">` に変更（PR 行・issue 行とも）。ネイティブのリンク挙動になり、左クリックでの新規タブは JS 無しで動作。`openUrl`（`window.open`）は削除。

## Items to Confirm / Review
- 見た目は不変（`.prs-row` の button 由来スタイルを anchor 用に調整、`text-decoration: none` 追加）。
- 回帰テスト追加: PR / issue 行が `a.prs-row` で `href` / `target=_blank` / `rel=noopener` を持つことを検証。
- キーボード操作: `<a href>` はネイティブでフォーカス可・Enter で開くため button より素直。

## User Prompt
> 細かいところだけど183について。GitHub へのリンクが、リンクになってないようで、右クリックで開けない。

Refs #183
Closes #190