### PR TITLE
feat: セルランチャーで起動コマンドを選べる（シェル / codex / 任意）(#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ The Settings modal (⚙) persists per-user UI choices to `~/.mulmoterminal/confi
 | ------------ | ------- |
 | `cwdPresets` | Quick-pick directories offered when launching a terminal. |
 | `soundFile`  | Absolute path to a custom **attention sound** (played when a session needs attention). Empty/unset uses the built-in synthesized chime. |
+| `prRepos`    | `owner/repo` entries whose open PRs/issues the cross-repo **PRs & Issues** view aggregates (via your `gh` login). |
+| `launchers`  | `{ label, command }` entries offered in a grid cell's launcher besides Claude — a plain shell, `codex`, any interactive command. |
 
 **Attention sound.** The default chime is generated with the Web Audio API — **no
 audio file is bundled**, so the npm package stays light and has no media-licensing
@@ -237,6 +239,13 @@ the directory the cell is pointed at** — so a whole workflow lives in one wind
 alongside the Claude sessions. Scripts are **per-directory**: the cell reads the
 `script.json` of whatever directory you select, so different cells can offer
 different projects' scripts.
+
+The same launcher also has an **or launch** row for your configured **launch commands**
+— a plain interactive shell, `codex`, any command — set in Settings (⚙) → **Launch
+commands** as `{ label, command }` (e.g. `Shell` → `$SHELL`, `Codex` → `codex`). Unlike
+a one-shot script, a launcher runs as a **persistent terminal in the cell's directory**:
+it survives grid page switches and reconnects, and its dot shows running vs. exited (it
+has no Claude hooks, so no blocked/done states).
 
 Every running terminal's header also has a **▶ Run ▾** dropdown (next to the
 connection status), in both the single view and each grid cell — but **only when the

--- a/plans/feat-182-launcher-commands.md
+++ b/plans/feat-182-launcher-commands.md
@@ -1,0 +1,39 @@
+# feat-182: セルランチャーで起動コマンドを選べる
+
+Issue: #182
+
+## 決定事項（ユーザー確認済み）
+- **方式 A**: 設定駆動の「起動ランチャー一覧」（`launchers: [{label, command}]`）を Settings で編集（`prRepos` と同じ要領）。ランチャーに Claude と横並びで表示。
+- **非 Claude セル**: 持続 PTY ＋ 再接続（グリッドのページ切替で生存）。状態は **running / idle のみ**（claude の hook 由来 blocked/done は無し）。
+
+## アーキテクチャ方針
+持続・再接続のライフサイクル（`ptys` map ＋ `reattachPty` ＋ `reap` ＋ `handleClientClose` の grace）は **claude と共通で流用可能**。claude 固有なのは spawn（`buildClaudeArgs`/hooks/resume）だけ。よって launcher 用に **spawn だけ差し替えた並行パス**を足す。
+
+## 変更ファイル
+
+### サーバ
+- `server/app-config.ts`: `Launcher = {label, command}`、`AppConfig.launchers`、`sanitizeLaunchers()`（trim・空除外・長さ/件数上限・label 重複除去）、load/save 反映。
+- `server/config-routes.ts`: GET/POST に `launchers`、`getLaunchers()` live-read。
+- `server/index.ts`:
+  - `resolveLauncher(index)` — `getLaunchers()[index]`（allowlist、browser は index のみ送る）。
+  - `spawnLauncherPty(sessionId, ws, command, cwd)` — 持続 PTY。hook 無し。`$SHELL -lc "exec <command>"`（Windows は powershell）で単一の対話プロセスとして常駐。`ptys` 登録、onData でバッファ＋中継、onExit で exit 送信 → `reap`。
+  - `/ws/launch` WS（`runLaunchWss`）: `?session`（再接続）`?cwd` `?launcher=<index>`。live あれば `reattachPty`、無ければ `spawnLauncherPty`。`markDevTerminalSession`（sidebar 除外）。`handleClientFrame` / `handleClientClose` を流用（grace で持続）。
+
+### クライアント
+- `src/components/wsUrl.ts`: `buildLaunchWsUrl({host, secure, sessionId, cwd, launcher})` → `/ws/launch?session&cwd&launcher`。
+- `src/composables/useTerminalConnections.ts`: `ConnTarget.launcher: {index}|null`、`connect()` の URL 分岐に launcher を追加（`command` と違い**再接続する**＝持続）。
+- `src/components/Terminal.vue`: `launcher` prop、`currentTarget()` に反映。
+- `src/components/LauncherCell.vue`（新）: CommandCell 型だが**持続**（session あり・`persistKey`・再接続）。ヘッダに label・状態ドット（running/idle）・閉じる/拡大/移動。`@session` で id を親に persist、`@exit` で idle。
+- `src/components/gridTabs.ts`: `Cell.launcher: {index, label}|null`、`launchInCell()` transform、`isOccupied`/直列化（launcher セルを persist）、`runningCount` に算入。
+- `src/components/TerminalGrid.vue`: `cell.launcher` のとき `<LauncherCell>` を描画・配線。`launchers` を下流へ。
+- `src/components/TerminalCell.vue`: 空セルランチャーに「or launch」ボタン群（設定 launchers）。クリックで `launch-program({index, label, cwd})` を emit（親が cell.launcher をセット）。
+- `src/composables/useAppConfig.ts`: `launchers` singleton ＋ `saveLaunchers()`。
+- `src/components/SettingsModal.vue` ＋ `App.vue` / `GridView.vue`: launchers 編集の配線。
+
+### テスト
+- `server/app-config.spec.ts`: `sanitizeLaunchers` / launchers 往復。
+- `src/components/wsUrl.spec.ts`: `buildLaunchWsUrl`。
+- `src/components/gridTabs.spec.ts`: `launchInCell` ＋ launcher セルの直列化/復元。
+
+## ゲート / 確認
+typecheck(client/server)/format/lint/build/test。実 PTY で shell / codex 起動と再接続を目視確認。

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizeSoundFile, sanitizeRepos, loadAppConfig, saveAppConfig } from "./app-config";
+import { sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, loadAppConfig, saveAppConfig } from "./app-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 
@@ -30,28 +30,65 @@ describe("sanitizeRepos", () => {
   });
 });
 
+describe("sanitizeLaunchers", () => {
+  it("keeps trimmed label+command pairs, drops incomplete/dup, caps count", () => {
+    expect(
+      sanitizeLaunchers([
+        { label: "  Shell ", command: " $SHELL " },
+        { label: "Codex", command: "codex" },
+        { label: "Shell", command: "zsh" }, // dup label — dropped
+        { label: "NoCmd", command: "" }, // no command — dropped
+        { label: "", command: "x" }, // no label — dropped
+        "junk",
+      ]),
+    ).toEqual([
+      { label: "Shell", command: "$SHELL" },
+      { label: "Codex", command: "codex" },
+    ]);
+    expect(sanitizeLaunchers("nope")).toEqual([]);
+    expect(sanitizeLaunchers(undefined)).toEqual([]);
+  });
+  it("caps the number of launchers", () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({ label: `L${i}`, command: `c${i}` }));
+    expect(sanitizeLaunchers(many).length).toBeLessThanOrEqual(20);
+  });
+});
+
 describe("loadAppConfig / saveAppConfig", () => {
-  it("round-trips presets + soundFile + prRepos through a file", () => {
+  it("round-trips presets + soundFile + prRepos + launchers through a file", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
-    const cfg = { cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav", prRepos: ["o/r"] };
+    const cfg = { cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav", prRepos: ["o/r"], launchers: [{ label: "Shell", command: "$SHELL" }] };
     expect(saveAppConfig(file, cfg)).toBe(true);
     expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(cfg);
     expect(loadAppConfig(file)).toEqual(cfg);
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("defaults to empty presets + null sound + empty repos for a missing file", () => {
+  it("defaults to empty presets + null sound + empty repos/launchers for a missing file", () => {
     const dir = tmp();
-    expect(loadAppConfig(path.join(dir, "none.json"))).toEqual({ cwdPresets: [], soundFile: null, prRepos: [] });
+    expect(loadAppConfig(path.join(dir, "none.json"))).toEqual({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [] });
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("sanitizes junk presets, a non-string sound, and bad repos on load", () => {
+  it("sanitizes junk presets, a non-string sound, bad repos, and bad launchers on load", () => {
     const dir = tmp();
     const file = path.join(dir, "config.json");
-    writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }, "junk"], soundFile: 5, prRepos: ["o/r", "bad"] }));
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null, prRepos: ["o/r"] });
+    writeFileSync(
+      file,
+      JSON.stringify({
+        cwdPresets: [{ label: "a", path: "/a" }, "junk"],
+        soundFile: 5,
+        prRepos: ["o/r", "bad"],
+        launchers: [{ label: "S", command: "sh" }, "x"],
+      }),
+    );
+    expect(loadAppConfig(file)).toEqual({
+      cwdPresets: [{ label: "a", path: "/a" }],
+      soundFile: null,
+      prRepos: ["o/r"],
+      launchers: [{ label: "S", command: "sh" }],
+    });
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -59,15 +96,15 @@ describe("loadAppConfig / saveAppConfig", () => {
     const dir = tmp();
     const file = path.join(dir, "bad.json");
     writeFileSync(file, "{ not json");
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [], soundFile: null, prRepos: [] });
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [] });
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("preserves the legacy presets-only shape (soundFile / prRepos absent => defaults)", () => {
+  it("preserves the legacy presets-only shape (soundFile / prRepos / launchers absent => defaults)", () => {
     const dir = tmp();
     const file = path.join(dir, "config.json");
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }] }));
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null, prRepos: [] });
+    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null, prRepos: [], launchers: [] });
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -6,6 +6,14 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets, type CwdPreset } from "./cwd-presets.js";
 
+// A named program a grid cell can launch instead of Claude (a plain shell, codex,
+// any interactive command). `command` is run on the user's own machine as an
+// interactive persistent PTY — it's their own config, so it's an intentional allowlist.
+export interface Launcher {
+  label: string;
+  command: string;
+}
+
 export interface AppConfig {
   cwdPresets: CwdPreset[];
   // Absolute path to a user-supplied audio file played as the attention sound, or
@@ -13,6 +21,32 @@ export interface AppConfig {
   soundFile: string | null;
   // GitHub repos ("owner/repo") whose open PRs the cross-repo PR view aggregates.
   prRepos: string[];
+  // User-defined launch commands offered in the grid cell launcher (label + command).
+  launchers: Launcher[];
+}
+
+const LAUNCHER_LABEL_MAX = 40;
+const LAUNCHER_COMMAND_MAX = 500;
+const LAUNCHERS_MAX = 20;
+
+// Keep entries with a non-empty label AND command (trimmed, length-capped), drop
+// duplicate labels, cap the count. Labels are what the UI shows and what a persisted
+// cell resolves back to, so they must be unique.
+export function sanitizeLaunchers(input: unknown): Launcher[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: Launcher[] = [];
+  for (const v of input) {
+    if (!v || typeof v !== "object") continue;
+    const o = v as Record<string, unknown>;
+    const label = typeof o.label === "string" ? o.label.trim().slice(0, LAUNCHER_LABEL_MAX) : "";
+    const command = typeof o.command === "string" ? o.command.trim().slice(0, LAUNCHER_COMMAND_MAX) : "";
+    if (!label || !command || seen.has(label)) continue;
+    seen.add(label);
+    out.push({ label, command });
+    if (out.length >= LAUNCHERS_MAX) break;
+  }
+  return out;
 }
 
 // "owner/repo" only — the value is passed to `gh pr list --repo`, so reject anything
@@ -38,13 +72,22 @@ export function sanitizeSoundFile(input: unknown): string | null {
   return trimmed && path.isAbsolute(trimmed) ? trimmed : null;
 }
 
+// Fresh object each call — callers hold and mutate the returned config in place, so a
+// shared default constant would be corrupted across loads.
+const emptyConfig = (): AppConfig => ({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [] });
+
 export function loadAppConfig(file: string): AppConfig {
   try {
-    if (!existsSync(file)) return { cwdPresets: [], soundFile: null, prRepos: [] };
+    if (!existsSync(file)) return emptyConfig();
     const raw = JSON.parse(readFileSync(file, "utf8"));
-    return { cwdPresets: sanitizePresets(raw?.cwdPresets), soundFile: sanitizeSoundFile(raw?.soundFile), prRepos: sanitizeRepos(raw?.prRepos) };
+    return {
+      cwdPresets: sanitizePresets(raw?.cwdPresets),
+      soundFile: sanitizeSoundFile(raw?.soundFile),
+      prRepos: sanitizeRepos(raw?.prRepos),
+      launchers: sanitizeLaunchers(raw?.launchers),
+    };
   } catch {
-    return { cwdPresets: [], soundFile: null, prRepos: [] };
+    return emptyConfig();
   }
 }
 
@@ -53,7 +96,8 @@ export function loadAppConfig(file: string): AppConfig {
 export function saveAppConfig(file: string, config: AppConfig): boolean {
   try {
     mkdirSync(path.dirname(file), { recursive: true });
-    writeFileSync(file, JSON.stringify({ cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos }, null, 2));
+    const payload = { cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos, launchers: config.launchers };
+    writeFileSync(file, JSON.stringify(payload, null, 2));
     return true;
   } catch {
     return false;

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
 import { sanitizePresets } from "./cwd-presets.js";
-import { loadAppConfig, saveAppConfig, sanitizeSoundFile, sanitizeRepos, type AppConfig } from "./app-config.js";
+import { loadAppConfig, saveAppConfig, sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, type AppConfig, type Launcher } from "./app-config.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -19,9 +19,22 @@ export function getPrRepos(): string[] {
   return config.prRepos;
 }
 
+// The launch commands a grid cell offers — read live so /ws/launch resolves a launcher
+// index against the current list without a restart.
+export function getLaunchers(): Launcher[] {
+  return config.launchers;
+}
+
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   app.get("/api/config", (_req, res) => {
-    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos, home: os.homedir() });
+    res.json({
+      cwd: claudeCwd,
+      cwdPresets: config.cwdPresets,
+      soundFile: config.soundFile,
+      prRepos: config.prRepos,
+      launchers: config.launchers,
+      home: os.homedir(),
+    });
   });
 
   app.post("/api/config", (req, res) => {
@@ -34,16 +47,20 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     if (body.prRepos !== undefined && !Array.isArray(body.prRepos)) {
       return res.status(400).json({ error: "prRepos must be an array" });
     }
+    if (body.launchers !== undefined && !Array.isArray(body.launchers)) {
+      return res.status(400).json({ error: "launchers must be an array" });
+    }
     const next: AppConfig = {
       cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : config.cwdPresets,
       soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : config.soundFile,
       prRepos: body.prRepos !== undefined ? sanitizeRepos(body.prRepos) : config.prRepos,
+      launchers: body.launchers !== undefined ? sanitizeLaunchers(body.launchers) : config.launchers,
     };
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.
     if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });
     config = next;
-    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos });
+    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos, launchers: config.launchers });
   });
 
   // Stream the user's custom attention sound (their own file, set in config). The

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getPrRepos } from "./config-routes.js";
+import { mountConfigRoutes, getPrRepos, getLaunchers } from "./config-routes.js";
 import { listPrsAcrossRepos } from "./prs.js";
 import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
@@ -1328,9 +1328,14 @@ const wss = new WebSocketServer({ noServer: true });
 // Command terminals (the grid's Run menu) get their own WS so the plain-command
 // PTY relay stays clear of the session/hook/transcript machinery on /ws.
 const runWss = new WebSocketServer({ noServer: true });
+// Launcher terminals (a plain shell / codex / any configured command) get their own WS
+// too. Unlike /ws/run these are PERSISTENT & reattachable (they share the /ws session
+// lifecycle — ptys map, reattach, reap grace) but carry no Claude hooks/transcript.
+const runLaunchWss = new WebSocketServer({ noServer: true });
 function wssForPath(pathname: string): WebSocketServer | null {
   if (pathname === "/ws") return wss;
   if (pathname === "/ws/run") return runWss;
+  if (pathname === "/ws/launch") return runLaunchWss;
   return null; // e.g. /ws/pubsub — left to socket.io's own upgrade handler
 }
 server.on("upgrade", (req, socket, head) => {
@@ -1644,6 +1649,45 @@ function spawnCommandPty(command: string, cwd: string, ws: WebSocket): IPty {
   return term;
 }
 
+// Resolve a launcher by its position in the user's configured list — the browser
+// sends only an INDEX (the config is the allowlist), never a raw command.
+function resolveLauncher(index: number): { label: string; command: string } | null {
+  const list = getLaunchers();
+  return Number.isInteger(index) && index >= 0 && index < list.length ? list[index] : null;
+}
+
+// Spawn a configured launcher command as a PERSISTENT, reattachable PTY that shares
+// the Claude session lifecycle (ptys map, reattach, reap grace) but has NO hooks,
+// transcript, or resume. The command is run via the login shell with `exec` so it
+// becomes the single foreground process ($SHELL, codex, etc.) — env vars in the
+// command (e.g. $SHELL) expand, and the process stays interactive in the PTY.
+function spawnLauncherPty(sessionId: string, ws: WebSocket, command: string, cwd: string): PtyEntry {
+  const isWindows = process.platform === "win32";
+  const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
+  const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", `exec ${command}`];
+  const term = pty.spawn(shell, args, { name: "xterm-256color", cols: 120, rows: 30, cwd, env: process.env });
+  console.log(`[pty] spawned launcher (pid=${term.pid}) in ${cwd}: ${command}`);
+
+  const entry: PtyEntry = { term, ws, buffer: "", cwd };
+  ptys.set(sessionId, entry);
+
+  term.onData((data) => {
+    entry.buffer = (entry.buffer + data).slice(-OUTPUT_BUFFER_LIMIT);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.send(JSON.stringify({ type: "output", data }));
+    }
+  });
+  term.onExit(({ exitCode, signal }) => {
+    console.log(`[pty] launcher exited code=${exitCode} signal=${signal}`);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.send(JSON.stringify({ type: "exit", exitCode, signal }));
+      entry.ws.close();
+    }
+    reap(sessionId);
+  });
+  return entry;
+}
+
 // browser -> command PTY. Like handleClientFrame but for the session-less command
 // terminal: only input/resize (no terminate/session machinery).
 function handleCommandFrame(term: IPty, raw: RawData) {
@@ -1794,6 +1838,57 @@ runWss.on("connection", (ws, req) => {
       // already exited — nothing to kill
     }
   });
+});
+
+// Send a terminal error to the socket and close it (no reconnect on the client side).
+function closeWithError(ws: WebSocket, message: string): void {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify({ type: "error", message }));
+    ws.close();
+  }
+}
+
+// Fresh spawn or reattach for a launcher session. Exactly one of `launcher`/`live` is
+// set by the caller's guard; the final throw is unreachable and narrows both.
+function startLaunchEntry(sessionId: string, ws: WebSocket, live: PtyEntry | undefined, launcher: { command: string } | null, cwd: string): PtyEntry {
+  if (launcher) return spawnLauncherPty(sessionId, ws, launcher.command, cwd);
+  if (live) return reattachPty(live, ws, sessionId);
+  throw new Error("no launcher or live pty");
+}
+
+// Launcher terminal (?launcher=<index>&cwd=<dir>, ?session=<id> to reattach): run a
+// configured launch command as a persistent, reattachable PTY. Reuses the /ws session
+// lifecycle (reattach + reap grace + handleClientClose) but with no hooks/transcript,
+// and is marked a dev-terminal session so it stays out of the chat sidebar.
+runLaunchWss.on("connection", (ws, req) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const raw = url.searchParams.get("session");
+  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
+  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+  const indexRaw = url.searchParams.get("launcher");
+  const index = indexRaw !== null && /^\d+$/.test(indexRaw) ? Number(indexRaw) : NaN;
+
+  const reattachId = requested && ptys.has(requested) ? requested : null;
+  const live = reattachId ? ptys.get(reattachId) : undefined;
+  // A live PTY reattaches regardless of the index; only a fresh spawn needs the
+  // launcher resolved (the pty already IS the chosen program on reattach).
+  const launcher = live ? null : resolveLauncher(index);
+  if (!live && !launcher) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
+
+  const sessionId = reattachId ?? randomUUID();
+  markDevTerminalSession(sessionId);
+  ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
+
+  let entry: PtyEntry;
+  try {
+    entry = startLaunchEntry(sessionId, ws, live, launcher, cwd);
+  } catch (err) {
+    console.error(`[ws/launch] failed to start ${sessionId}: ${messageOf(err)}`);
+    return closeWithError(ws, "Failed to start the launch command.");
+  }
+
+  ws.on("message", (raw) => handleClientFrame(entry, ws, raw, sessionId));
+  ws.on("close", () => handleClientClose(entry, ws, sessionId));
 });
 
 // Exit code the launcher (bin/mulmoterminal.js) treats as "port was taken at

--- a/src/App.vue
+++ b/src/App.vue
@@ -146,7 +146,7 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (theme + notification sound), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { defaultCwd, loadConfig, saveSound, prRepos, savePrRepos } = useAppConfig();
+const { defaultCwd, loadConfig, saveSound, prRepos, savePrRepos, launchers, saveLaunchers } = useAppConfig();
 // Drive the single view's dir overrides off the dir the terminal ACTUALLY runs in
 // (reported by the server, which may resolve/fall back), not the static default — so
 // the badge/theme/colors always track the active session. Falls back to the default
@@ -340,8 +340,10 @@ function onSession(id: string) {
       v-if="showSettings"
       :sound-file="soundFile"
       :pr-repos="prRepos"
+      :launchers="launchers"
       @update-sound="saveSound"
       @update-repos="savePrRepos"
+      @update-launchers="saveLaunchers"
       @close="closeSettings"
     />
   </div>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -13,6 +13,7 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  launchInCell,
   setSortMode,
   moveCell,
   visibleOrdered,
@@ -111,6 +112,10 @@ const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value,
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
 // A running cell's header Run menu: launch in a spare cell so the session survives.
 const onRunSpare = (command: { index: number; label: string; cwd: string | null }) => (state.value = runScriptInNewCell(state.value, command));
+// The empty cell launcher picked a configured program (shell/codex/…): turn it into a
+// persistent launcher cell. Its session id arrives later via onSession.
+const onLaunch = (uid: number, pick: { index: number; label: string; cwd: string | null }) =>
+  (state.value = launchInCell(state.value, uid, { index: pick.index, label: pick.label }, pick.cwd));
 const onMove = (uid: number, dir: -1 | 1) => (state.value = moveCell(state.value, uid, dir));
 const toggleSortMode = () => (state.value = setSortMode(state.value, state.value.sortMode === "auto" ? "manual" : "auto"));
 const switchTo = (page: number) => (state.value = switchPage(state.value, page));
@@ -124,7 +129,8 @@ onMounted(() => {
 });
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.
-const { defaultCwd, home, presets, soundFile, prRepos, loadConfig, recordPreset, removePreset, saveSound, savePrRepos } = useAppConfig();
+const { defaultCwd, home, presets, soundFile, prRepos, launchers, loadConfig, recordPreset, removePreset, saveSound, savePrRepos, saveLaunchers } =
+  useAppConfig();
 const showSettings = ref(false);
 onMounted(loadConfig);
 
@@ -155,6 +161,7 @@ function closeSettings() {
       :cancel-uid="cancelUid"
       :default-cwd="defaultCwd"
       :presets="presets"
+      :launchers="launchers"
       :home="home"
       :reorderable="reorderable"
       :open-session-ids="openSessionIds"
@@ -166,6 +173,7 @@ function closeSettings() {
       @toggle-expand="onToggleExpand"
       @run="onRun"
       @run-spare="onRunSpare"
+      @launch="onLaunch"
       @move="onMove"
       @status="onStatus"
     />
@@ -173,8 +181,10 @@ function closeSettings() {
       v-if="showSettings"
       :sound-file="soundFile"
       :pr-repos="prRepos"
+      :launchers="launchers"
       @update-sound="saveSound"
       @update-repos="savePrRepos"
+      @update-launchers="saveLaunchers"
       @close="closeSettings"
     />
   </div>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import TerminalView from "./Terminal.vue";
+import { formatCwd } from "./cwdDisplay";
+import type { CellStatus, CellLauncher } from "./gridTabs";
+
+// A grid cell running a configured launch command (a plain shell, codex, any
+// interactive program) instead of Claude. Unlike CommandCell this is PERSISTENT: it
+// carries a session id and a durable connection (persistKey), so it survives page
+// switches and reconnects — but it has no Claude hooks, so its status is only
+// running (working) / exited (idle). `launcher.index` is the command's position in the
+// configured launcher list (the server's allowlist); it runs in `cwd`.
+const props = defineProps<{
+  uid: number;
+  expanded: boolean;
+  launcher: CellLauncher;
+  session: string | null;
+  cwd: string | null;
+  home: string | null;
+  // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+  reorderable?: boolean;
+}>();
+const emit = defineEmits<{
+  (e: "toggle-expand" | "close"): void;
+  (e: "move", dir: -1 | 1): void;
+  // Report activity up so the grid can attention-sort in auto mode.
+  (e: "status", value: CellStatus): void;
+  // The server-assigned session id, so the parent persists it for reconnect.
+  (e: "session", id: string): void;
+}>();
+
+// connectKey bump re-launches after the process exits (relaunch button).
+const connectKey = ref(0);
+const finished = ref(false);
+
+const dirDisplay = computed(() => formatCwd(props.cwd, props.home));
+const target = computed(() => ({ index: props.launcher.index }));
+
+// Running counts as "working"; once the process exits it's idle (never "waiting").
+watch(finished, (done) => emit("status", done ? "idle" : "working"), { immediate: true });
+
+function onSession(id: string) {
+  emit("session", id);
+}
+function onExit() {
+  finished.value = true;
+}
+function relaunch() {
+  finished.value = false;
+  connectKey.value++;
+}
+</script>
+
+<template>
+  <div class="cell">
+    <div class="cell-header">
+      <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Exited' : 'Running…'" />
+      <span v-if="dirDisplay" class="cell-dir" :title="cwd ?? ''"
+        ><span class="cell-dir-path">{{ dirDisplay }}</span></span
+      >
+      <span class="cell-cmd">⌘ {{ launcher.label }}</span>
+      <span class="cell-actions">
+        <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">◀</button>
+        <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move launcher right" @click="emit('move', 1)">▶</button>
+        <button v-if="finished" class="cell-btn" title="Relaunch" aria-label="Relaunch" @click="relaunch">↻</button>
+        <button
+          class="cell-btn"
+          :title="expanded ? 'Restore' : 'Expand'"
+          :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
+          @click="emit('toggle-expand')"
+        >
+          {{ expanded ? "⤡" : "⤢" }}
+        </button>
+        <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
+      </span>
+    </div>
+    <TerminalView
+      class="cell-term"
+      :persist-key="`cell-${uid}`"
+      :session-id="session"
+      :connect-key="connectKey"
+      :cwd="cwd"
+      :launcher="target"
+      @session="onSession"
+      @exit="onExit"
+    />
+  </div>
+</template>
+
+<style scoped>
+.cell {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  background: #1a1a2e;
+  border: 1px solid #2a2a4e;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.cell-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 8px;
+  background: #16213e;
+  border-bottom: 1px solid #2a2a4e;
+}
+.cell-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #4a5070;
+}
+.cell-dot.is-working {
+  background: #4a8cff;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+.cell-dir {
+  flex: 0 1 auto;
+  min-width: 16ch;
+  max-width: 45%;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: #7f88ad;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+}
+.cell-dir-path {
+  unicode-bidi: plaintext;
+}
+.cell-cmd {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: #c7cdf0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cell-actions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+}
+.cell-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 26px;
+  border: none;
+  background: transparent;
+  color: #c7cdf0;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  border-radius: 6px;
+}
+.cell-btn:hover {
+  background: #2a3b66;
+  color: #e6e6f0;
+}
+.cell-close:hover {
+  background: #3a2030;
+  color: #ff6b6b;
+}
+.cell-term {
+  flex: 1;
+  min-height: 0;
+}
+</style>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -2,11 +2,13 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { useTheme } from "../composables/useTheme";
 import { previewAttention } from "../composables/useAttentionSound";
+import type { Launcher } from "./launchers";
 
-const props = defineProps<{ soundFile?: string | null; prRepos?: string[] }>();
+const props = defineProps<{ soundFile?: string | null; prRepos?: string[]; launchers?: Launcher[] }>();
 const emit = defineEmits<{
   (e: "update-sound", file: string | null): void;
   (e: "update-repos", repos: string[]): void;
+  (e: "update-launchers", launchers: Launcher[]): void;
   (e: "close"): void;
 }>();
 
@@ -33,6 +35,34 @@ function addRepo() {
 function removeRepo(r: string) {
   repos.value = repos.value.filter((x) => x !== r);
   emit("update-repos", repos.value);
+}
+
+// Cell-launcher commands (label + command). Editable list mirroring the saved value;
+// add/remove emits the new list up (App persists it).
+const launcherList = ref<Launcher[]>([...(props.launchers ?? [])]);
+watch(
+  () => props.launchers,
+  (l) => (launcherList.value = [...(l ?? [])]),
+);
+const newLauncherLabel = ref("");
+const newLauncherCommand = ref("");
+const newLauncherValid = computed(() => {
+  const label = newLauncherLabel.value.trim();
+  const command = newLauncherCommand.value.trim();
+  return !!label && !!command && !launcherList.value.some((l) => l.label === label);
+});
+function addLauncher() {
+  const label = newLauncherLabel.value.trim();
+  const command = newLauncherCommand.value.trim();
+  if (!label || !command || launcherList.value.some((l) => l.label === label)) return;
+  launcherList.value = [...launcherList.value, { label, command }];
+  newLauncherLabel.value = "";
+  newLauncherCommand.value = "";
+  emit("update-launchers", launcherList.value);
+}
+function removeLauncher(label: string) {
+  launcherList.value = launcherList.value.filter((l) => l.label !== label);
+  emit("update-launchers", launcherList.value);
 }
 
 // Custom attention sound, applied immediately (like the theme) — empty => the
@@ -192,6 +222,40 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
         <button class="btn" type="button" :disabled="!newRepoValid" @click="addRepo">Add</button>
       </div>
 
+      <h3 class="section-title">Launch commands</h3>
+      <p class="hint">
+        Programs a grid cell can launch besides Claude — a plain shell, <code>codex</code>, any interactive command. They run in the cell's directory as a
+        persistent terminal. Example: <code>Shell</code> → <code>$SHELL</code>, <code>Codex</code> → <code>codex</code>.
+      </p>
+      <ul v-if="launcherList.length" class="repo-list">
+        <li v-for="l in launcherList" :key="l.label" class="repo-item">
+          <span class="repo-name">{{ l.label }}</span>
+          <code class="launcher-cmd">{{ l.command }}</code>
+          <button class="icon-btn" type="button" :title="`Remove ${l.label}`" :aria-label="`Remove ${l.label}`" @click="removeLauncher(l.label)">✕</button>
+        </li>
+      </ul>
+      <div class="sound-row launcher-add">
+        <input
+          v-model="newLauncherLabel"
+          class="field launcher-label"
+          type="text"
+          placeholder="Label"
+          aria-label="Launcher label"
+          spellcheck="false"
+          @keydown.enter="addLauncher"
+        />
+        <input
+          v-model="newLauncherCommand"
+          class="field repo-field"
+          type="text"
+          placeholder="command (e.g. $SHELL)"
+          aria-label="Launcher command"
+          spellcheck="false"
+          @keydown.enter="addLauncher"
+        />
+        <button class="btn" type="button" :disabled="!newLauncherValid" @click="addLauncher">Add</button>
+      </div>
+
       <div class="modal-foot">
         <span class="spacer" />
         <button class="btn btn-primary" @click="emit('close')">Close</button>
@@ -320,6 +384,23 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 .repo-field {
   flex: 1 1 auto;
   font-family: ui-monospace, "JetBrains Mono", monospace;
+}
+.launcher-label {
+  flex: 0 0 30%;
+  min-width: 0;
+}
+.launcher-add {
+  flex-wrap: wrap;
+}
+.launcher-cmd {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .repo-list {
   list-style: none;

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -30,6 +30,9 @@ const props = defineProps<{
   cwd?: string | null;
   devTerminal?: boolean;
   command?: { index: number } | null;
+  // A configured launcher (shell/codex/command) — persistent & reattachable, connects
+  // to /ws/launch instead of resuming a Claude session.
+  launcher?: { index: number } | null;
   runMenu?: boolean;
   persistKey?: string | null;
   // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
@@ -52,7 +55,13 @@ const emit = defineEmits<{
 // down. Captured once — the key is stable for the component's life.
 const slotKey = props.persistKey ?? `ephemeral-${crypto.randomUUID()}`;
 function currentTarget(): conn.ConnTarget {
-  return { sessionId: props.sessionId, cwd: props.cwd ?? null, devTerminal: !!props.devTerminal, command: props.command ?? null };
+  return {
+    sessionId: props.sessionId,
+    cwd: props.cwd ?? null,
+    devTerminal: !!props.devTerminal,
+    command: props.command ?? null,
+    launcher: props.launcher ?? null,
+  };
 }
 
 const terminalRef = ref<HTMLDivElement>();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -6,6 +6,7 @@ import { useDirConfig } from "../composables/useDirConfig";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
 import type { CwdPreset } from "./presets";
+import type { Launcher, LaunchPick } from "./launchers";
 import { activityStatus, type CellStatus } from "./gridTabs";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
@@ -24,6 +25,8 @@ const props = defineProps<{
   initialCwd: string | null;
   defaultCwd: string | null;
   presets: CwdPreset[];
+  // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
+  launchers?: Launcher[];
   home: string | null;
   // Session ids open in other grid cells. Resuming one of them would detach that
   // cell, so the launcher flags such rows and confirms before opening.
@@ -41,6 +44,8 @@ const emit = defineEmits<{
   // `run` launches in THIS (empty) cell from the launcher; `runSpare` is the running
   // terminal's header menu, which must NOT replace the session — it runs in a new cell.
   (e: "run" | "runSpare", value: { index: number; label: string; cwd: string | null }): void;
+  // The user picked a configured launcher (shell/codex/…) to run in this empty cell.
+  (e: "launch", value: LaunchPick): void;
   // Swap this cell left (-1) or right (+1) in manual sort mode.
   (e: "move", dir: -1 | 1): void;
   // Report live activity up so the grid can attention-sort in auto mode.
@@ -183,6 +188,13 @@ function launchIn(dir: string | null) {
 }
 function launch() {
   launchIn(dirInput.value.trim() || props.defaultCwd);
+}
+
+// Launch a configured program (shell/codex/…) in this cell's chosen dir. The parent
+// turns the empty cell into a persistent launcher cell (index is the server allowlist
+// position); this cell is then replaced by a LauncherCell.
+function launchProgram(index: number, l: Launcher) {
+  emit("launch", { index, label: l.label, cwd: dirInput.value.trim() || props.defaultCwd });
 }
 
 // A preset chip is a one-click action: fill the field and jump straight into a
@@ -953,6 +965,12 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <span class="cell-launch-caption">or run a script</span>
         <div class="cell-script-list">
           <button v-for="s in scripts" :key="s.index" class="cell-script-item" :title="s.command" @click="runScript(s)">▶ {{ s.label }}</button>
+        </div>
+      </div>
+      <div v-if="launchers && launchers.length" class="cell-scripts">
+        <span class="cell-launch-caption">or launch</span>
+        <div class="cell-script-list">
+          <button v-for="(l, i) in launchers" :key="l.label" class="cell-script-item" :title="l.command" @click="launchProgram(i, l)">⌘ {{ l.label }}</button>
         </div>
       </div>
       <div v-if="resumable.length" class="cell-resume">

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -21,11 +21,21 @@ vi.mock("./CommandCell.vue", () => ({
     template: '<div class="stub-command-cell" />',
   },
 }));
+vi.mock("./LauncherCell.vue", () => ({
+  default: {
+    name: "LauncherCell",
+    props: ["uid", "expanded", "launcher", "session", "cwd", "home", "reorderable"],
+    emits: ["toggle-expand", "close", "move", "status", "session"],
+    template: '<div class="stub-launcher-cell" />',
+  },
+}));
 
 const cell = (uid: number, session: string | null = null, cwd: string | null = null): Cell => ({ uid, session, cwd });
 const cmdCell = (uid: number, command: NonNullable<Cell["command"]>): Cell => ({ uid, session: null, cwd: null, command });
 const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null, reorderable = false) =>
-  mount(TerminalGrid, { props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], home: "/work", openSessionIds: [], reorderable } });
+  mount(TerminalGrid, {
+    props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], launchers: [], home: "/work", openSessionIds: [], reorderable },
+  });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });
 

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -2,9 +2,11 @@
 import { ref, computed, onMounted } from "vue";
 import TerminalCell from "./TerminalCell.vue";
 import CommandCell from "./CommandCell.vue";
+import LauncherCell from "./LauncherCell.vue";
 import { trackStyle, layoutForCount } from "./gridLayout";
 import type { Cell, CellStatus } from "./gridTabs";
 import type { CwdPreset } from "./presets";
+import type { Launcher, LaunchPick } from "./launchers";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -20,6 +22,7 @@ const props = defineProps<{
   cancelUid: number | null;
   defaultCwd: string | null;
   presets: CwdPreset[];
+  launchers: Launcher[];
   home: string | null;
   // Manual sort mode: each cell shows ◀▶ to reorder.
   reorderable?: boolean;
@@ -30,6 +33,7 @@ const emit = defineEmits<{
   (e: "close" | "toggle-expand", uid: number): void;
   (e: "run", uid: number, command: { index: number; label: string; cwd: string | null }): void;
   (e: "runSpare", command: { index: number; label: string; cwd: string | null }): void;
+  (e: "launch", uid: number, pick: LaunchPick): void;
   (e: "move", uid: number, dir: -1 | 1): void;
   (e: "status", uid: number, value: CellStatus): void;
   // Shared preset list events — uid-less since they mutate the one config list.
@@ -62,6 +66,21 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           @move="(dir) => emit('move', cell.uid, dir)"
           @status="(s) => emit('status', cell.uid, s)"
         />
+        <LauncherCell
+          v-else-if="cell.launcher"
+          :uid="cell.uid"
+          :expanded="cell.uid === expandedUid"
+          :launcher="cell.launcher"
+          :session="cell.session"
+          :cwd="cell.cwd"
+          :home="home"
+          :reorderable="reorderable"
+          @toggle-expand="emit('toggle-expand', cell.uid)"
+          @close="emit('close', cell.uid)"
+          @move="(dir) => emit('move', cell.uid, dir)"
+          @status="(s) => emit('status', cell.uid, s)"
+          @session="(id) => emit('session', cell.uid, id)"
+        />
         <TerminalCell
           v-else
           :uid="cell.uid"
@@ -70,6 +89,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :initial-cwd="cell.cwd"
           :default-cwd="defaultCwd"
           :presets="presets"
+          :launchers="launchers"
           :home="home"
           :open-session-ids="openSessionIds"
           :cancellable="cell.uid === cancelUid"
@@ -81,6 +101,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           @remove-preset="(path) => emit('remove-preset', path)"
           @run="(cmd) => emit('run', cell.uid, cmd)"
           @run-spare="(cmd) => emit('runSpare', cmd)"
+          @launch="(pick) => emit('launch', cell.uid, pick)"
           @close="emit('close', cell.uid)"
           @move="(dir) => emit('move', cell.uid, dir)"
           @status="(s) => emit('status', cell.uid, s)"

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -11,6 +11,7 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  launchInCell,
   setSortMode,
   moveCell,
   orderCells,
@@ -166,6 +167,33 @@ describe("runCommand (script command cells)", () => {
   it("switchPage keeps a trailing command cell (only abandons an empty launcher)", () => {
     const after = switchPage(make([...running(9), cmdCell(9)], { page: 1 }), 0);
     expect(after.cells).toHaveLength(10);
+  });
+});
+
+describe("launchInCell (persistent launcher cells)", () => {
+  const L = { index: 1, label: "Shell" };
+
+  it("attaches a launcher + cwd to a launch cell", () => {
+    const s = launchInCell(make([cell(0)]), 0, L, "/proj");
+    expect(s.cells[0].launcher).toEqual(L);
+    expect(s.cells[0].cwd).toBe("/proj");
+    expect(s.cells[0].session).toBeNull(); // id arrives later via setSession
+  });
+  it("counts a launcher cell as running, and it's not a cancellable launch cell", () => {
+    const withLauncher = launchInCell(make([cell(0), cell(1)]), 0, L, "/p");
+    expect(runningCount(withLauncher.cells)).toBe(1);
+    // A trailing launcher cell must not read as an empty (cancellable) launch cell.
+    const s = addCell(make([launchInCell(make([cell(0)]), 0, L, "/p").cells[0]]));
+    expect(s.cells).toHaveLength(2);
+  });
+  it("persists a launcher cell (session + launcher) across parseGridState", () => {
+    const withId = setSession(launchInCell(make([cell(0)]), 0, L, "/p"), 0, U(3));
+    const restored = parseGridState(JSON.stringify(withId));
+    expect(restored?.cells[0]).toMatchObject({ session: U(3), cwd: "/p", launcher: L });
+  });
+  it("drops a malformed persisted launcher to null", () => {
+    const raw = JSON.stringify({ cells: [{ session: U(4), cwd: "/p", launcher: { label: "x" } }], page: 0, sortMode: "manual" });
+    expect(parseGridState(raw)?.cells[0].launcher).toBeNull();
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -5,6 +5,12 @@
 // owns a single GridState ref and drives it through these pure transforms;
 // TerminalGrid just renders the active page's slice.
 
+// A configured launch command (shell/codex/…) running in a cell. `index` is its
+// position in the user's launcher list (the server's allowlist); `label` is kept for
+// display and to re-launch after a server restart. Unlike a command, a launcher cell
+// IS persisted (it has a session and reconnects).
+export type CellLauncher = { index: number; label: string };
+
 export interface Cell {
   uid: number;
   session: string | null;
@@ -12,6 +18,8 @@ export interface Cell {
   // A running script.json command (from the cell launcher's "run a script"), with
   // the directory it runs in. Ephemeral — command cells are never persisted.
   command?: { index: number; label: string; cwd: string | null } | null;
+  // A running launcher (shell/codex/custom). Persistent & reattachable like a session.
+  launcher?: CellLauncher | null;
 }
 // How the grid orders its cells. "manual": the user's hand-arranged order (◀▶);
 // "auto": attention-first, recomputed from each cell's live status.
@@ -47,10 +55,10 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 export const pageCount = (cellCount: number) => Math.max(1, Math.ceil(cellCount / PAGE_SIZE));
 export const pageSlice = <T>(cells: T[], page: number) => cells.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
-// A cell occupies a slot when it runs a Claude session OR a command; only those
-// count toward the cap. A launch cell is empty: no session AND no command.
-const isOccupied = (c: Cell) => c.session !== null || c.command != null;
-const isLaunchCell = (c: Cell | undefined) => !!c && c.session === null && c.command == null;
+// A cell occupies a slot when it runs a Claude session, a command, OR a launcher; only
+// those count toward the cap. A launch cell is empty: no session, command, or launcher.
+const isOccupied = (c: Cell) => c.session !== null || c.command != null || c.launcher != null;
+const isLaunchCell = (c: Cell | undefined) => !!c && c.session === null && c.command == null && c.launcher == null;
 export const runningCount = (cells: Cell[]) => cells.filter(isOccupied).length;
 
 const clampPage = (s: GridState): GridState => ({ ...s, page: Math.min(Math.max(0, Math.floor(s.page)), pageCount(s.cells.length) - 1) });
@@ -94,6 +102,13 @@ export function setCwd(state: GridState, uid: number, cwd: string): GridState {
 // into a command terminal. Ephemeral — command cells aren't persisted.
 export function runCommand(state: GridState, uid: number, command: Cell["command"]): GridState {
   return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, command } : c)) };
+}
+
+// A cell launched a configured program (shell/codex/…): attach the launcher and its
+// directory, turning the launch cell into a persistent launcher terminal. Its session
+// id arrives later from the server (setSession), so it persists and reconnects.
+export function launchInCell(state: GridState, uid: number, launcher: CellLauncher, cwd: string | null): GridState {
+  return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, launcher, cwd } : c)) };
 }
 
 // The toolbar Run menu ran a script with no target cell: reuse a trailing empty
@@ -202,6 +217,14 @@ export function switchPage(state: GridState, page: number): GridState {
 
 const isUuid = (s: unknown): s is string => typeof s === "string" && UUID_RE.test(s);
 const asSortMode = (v: unknown): SortMode => (v === "auto" ? "auto" : "manual");
+// Keep a persisted launcher only if well-formed; anything else drops to null so a
+// reloaded cell reconnects as a plain (Claude) session instead of a broken launcher.
+const asLauncher = (v: unknown): CellLauncher | null => {
+  const o = v as CellLauncher | null;
+  return o && typeof o.index === "number" && Number.isInteger(o.index) && o.index >= 0 && typeof o.label === "string"
+    ? { index: o.index, label: o.label }
+    : null;
+};
 // A cell entry is kept if its session/cwd are well-formed; uid is validated only to
 // match the persisted `expanded` (it is renumbered below regardless).
 const isCell = (c: unknown): c is Cell => {
@@ -222,7 +245,7 @@ export function parseGridState(raw: string | null): GridState | null {
       .filter(isCell)
       .filter((c: Cell) => c.session !== null)
       .slice(0, MAX_TERMINALS);
-    const cells: Cell[] = running.map((c: Cell, i: number) => ({ uid: i, session: c.session, cwd: c.cwd }));
+    const cells: Cell[] = running.map((c: Cell, i: number) => ({ uid: i, session: c.session, cwd: c.cwd, launcher: asLauncher(c.launcher) }));
     const expandedIdx = running.findIndex((c: Cell) => c.uid === parsed.expanded);
     const expanded = typeof parsed.expanded === "number" && expandedIdx >= 0 ? expandedIdx : null;
     const page = Number.isSafeInteger(parsed.page) && parsed.page >= 0 ? parsed.page : 0;

--- a/src/components/launchers.ts
+++ b/src/components/launchers.ts
@@ -1,0 +1,15 @@
+// A user-configured launch command offered in the grid cell launcher (mirrors the
+// server's Launcher in app-config.ts). `command` runs as an interactive persistent
+// PTY; `label` is what the launcher button and the cell header show.
+export interface Launcher {
+  label: string;
+  command: string;
+}
+
+// What a cell launcher emits when the user picks a program to launch: the launcher's
+// position in the configured list (the server's allowlist) + its label, plus the dir.
+export interface LaunchPick {
+  index: number;
+  label: string;
+  cwd: string | null;
+}

--- a/src/components/wsUrl.spec.ts
+++ b/src/components/wsUrl.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTerminalWsUrl, buildRunWsUrl } from "./wsUrl";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl } from "./wsUrl";
 
 describe("buildTerminalWsUrl", () => {
   it("single view: session only, no gui=0", () => {
@@ -48,5 +48,28 @@ describe("buildRunWsUrl", () => {
     const url = buildRunWsUrl({ host: "h", secure: true, index: 0 });
     expect(url.startsWith("wss://")).toBe(true);
     expect(new URL(url).searchParams.get("index")).toBe("0");
+  });
+});
+
+describe("buildLaunchWsUrl", () => {
+  it("targets /ws/launch with the launcher index + reattach session", () => {
+    const url = buildLaunchWsUrl({ host: "h", secure: false, sessionId: "abc", cwd: "/work/proj", launcher: 2 });
+    const u = new URL(url);
+    expect(u.pathname).toBe("/ws/launch");
+    expect(u.searchParams.get("launcher")).toBe("2");
+    expect(u.searchParams.get("session")).toBe("abc");
+    expect(u.searchParams.get("cwd")).toBe("/work/proj");
+  });
+
+  it("fresh launch (null id): no session param, still sends the launcher index", () => {
+    const url = buildLaunchWsUrl({ host: "h", secure: false, sessionId: null, launcher: 0 });
+    const q = new URL(url).searchParams;
+    expect(q.has("session")).toBe(false);
+    expect(q.get("launcher")).toBe("0");
+  });
+
+  it("uses wss when secure", () => {
+    const url = buildLaunchWsUrl({ host: "h", secure: true, sessionId: null, launcher: 1 });
+    expect(url.startsWith("wss://")).toBe(true);
   });
 });

--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -38,3 +38,23 @@ export function buildRunWsUrl({ host, secure, index, cwd }: RunWsUrlInput): stri
   const proto = secure ? "wss:" : "ws:";
   return `${proto}//${host}/ws/run?${params.toString()}`;
 }
+
+export interface LaunchWsUrlInput {
+  host: string;
+  secure: boolean;
+  sessionId: string | null; // reattach this persistent launcher session; null => fresh
+  cwd?: string | null;
+  launcher: number; // position in the configured launcher list (the server resolves it)
+}
+
+// The launcher-terminal endpoint (a configured shell/codex/command). Persistent &
+// reattachable like /ws: the browser sends the launcher INDEX (config is the allowlist)
+// plus the session id to reattach. On a cold spawn the server resolves the index.
+export function buildLaunchWsUrl({ host, secure, sessionId, cwd, launcher }: LaunchWsUrlInput): string {
+  const params = new URLSearchParams();
+  if (sessionId) params.set("session", sessionId);
+  if (cwd) params.set("cwd", cwd);
+  params.set("launcher", String(launcher));
+  const proto = secure ? "wss:" : "ws:";
+  return `${proto}//${host}/ws/launch?${params.toString()}`;
+}

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -1,5 +1,6 @@
 import { ref } from "vue";
 import { presetLabel, type CwdPreset } from "../components/presets";
+import type { Launcher } from "../components/launchers";
 
 // The custom attention-sound file is a SINGLETON ref shared across every
 // useAppConfig() caller — the beep player lives in the single view while the
@@ -11,6 +12,10 @@ const soundFile = ref<string | null>(null);
 // either view) and any future reader share one list; a save in one view is seen by the
 // other instead of each useAppConfig() keeping a divergent copy.
 const prRepos = ref<string[]>([]);
+
+// Cell-launcher commands (shell/codex/…) — SINGLETON so the grid's cell launchers and
+// the settings editor (openable from either view) share one list.
+const launchers = ref<Launcher[]>([]);
 
 // Pre-#163 recent dirs lived in localStorage (the removed useRecentDirs). They are
 // imported once into the server-side preset list on load — see migrateLegacyRecents.
@@ -53,6 +58,7 @@ export function useAppConfig() {
       if (presetsVersion === version) presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
       soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
       prRepos.value = Array.isArray(c.prRepos) ? c.prRepos : [];
+      launchers.value = Array.isArray(c.launchers) ? c.launchers : [];
       await migrateLegacyRecents();
     } catch {
       // the app still works; presets are just unavailable
@@ -182,5 +188,38 @@ export function useAppConfig() {
     }
   }
 
-  return { defaultCwd, home, presets, prRepos, soundFile, saving, error, loadConfig, savePresets, recordPreset, removePreset, saveSound, savePrRepos };
+  // Persist the cell-launcher commands. POSTs only launchers so the other fields are
+  // untouched by the server-side partial update.
+  async function saveLaunchers(next: Launcher[]): Promise<boolean> {
+    try {
+      const res = await fetch("/api/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ launchers: next }),
+      });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      launchers.value = (await res.json()).launchers ?? [];
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return {
+    defaultCwd,
+    home,
+    presets,
+    prRepos,
+    launchers,
+    soundFile,
+    saving,
+    error,
+    loadConfig,
+    savePresets,
+    recordPreset,
+    removePreset,
+    saveSound,
+    savePrRepos,
+    saveLaunchers,
+  };
 }

--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -57,7 +57,7 @@ class FakeWebSocket {
 
 import * as conn from "./useTerminalConnections";
 
-const target = (sessionId: string | null) => ({ sessionId, cwd: "/typed", devTerminal: false, command: null });
+const target = (sessionId: string | null) => ({ sessionId, cwd: "/typed", devTerminal: false, command: null, launcher: null });
 
 describe("useTerminalConnections — detached-slot state replay", () => {
   beforeEach(() => {

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -19,7 +19,7 @@ import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
-import { buildTerminalWsUrl, buildRunWsUrl } from "../components/wsUrl";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl } from "../components/wsUrl";
 
 export type ConnStatus = "connecting" | "connected" | "disconnected";
 
@@ -30,6 +30,9 @@ export interface ConnTarget {
   cwd: string | null;
   devTerminal: boolean;
   command: { index: number } | null;
+  // A configured launcher (shell/codex/command). Unlike `command` this is a PERSISTENT
+  // session — it reconnects on drop and reattaches by session id, like a Claude cell.
+  launcher: { index: number } | null;
 }
 
 // Forwarded to whatever component is currently attached, so the parent's existing
@@ -134,6 +137,15 @@ function scheduleReconnect(c: Conn) {
   }, delay);
 }
 
+// Pick the endpoint for a target: a Run command (ephemeral), a launcher (persistent
+// shell/codex), or a Claude session (default). Kept flat to avoid a nested ternary.
+function connUrl(target: ConnTarget, resumeId: string | null, secure: boolean): string {
+  const host = location.host;
+  if (target.command) return buildRunWsUrl({ host, secure, index: target.command.index, cwd: target.cwd });
+  if (target.launcher) return buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
+  return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
+}
+
 function connect(c: Conn) {
   if (c.released) return;
   if (c.reconnectTimer) {
@@ -154,9 +166,7 @@ function connect(c: Conn) {
   // same session instead of spawning a fresh one each retry.
   const resumeId = c.knownSessionId ?? c.target.sessionId;
   const secure = location.protocol === "https:";
-  const url = c.target.command
-    ? buildRunWsUrl({ host: location.host, secure, index: c.target.command.index, cwd: c.target.cwd })
-    : buildTerminalWsUrl({ host: location.host, secure, sessionId: resumeId, cwd: c.target.cwd, devTerminal: c.target.devTerminal });
+  const url = connUrl(c.target, resumeId, secure);
   const sock = new WebSocket(url);
   c.ws = sock;
 


### PR DESCRIPTION
## Summary
グリッドの空きセルランチャーに、**Claude 以外の起動コマンド**（プレーンシェル / `codex` / 任意の対話コマンド）を並べて選べるようにした。ランチャーセルは**持続 PTY**（ページ切替で生存・再接続）で、Claude の hook は無いので状態は **起動中 / 終了** のみ。

- **サーバ**: `AppConfig.launchers`（`{label, command}`）＋ `sanitizeLaunchers`、`GET/POST /api/config`、`getLaunchers()`。`spawnLauncherPty` が `$SHELL -lc "exec <cmd>"` で単一の対話プロセスとして常駐（env 展開・持続）。**セッションのライフサイクル（ptys map・reattach・reap grace）を Claude と共通で流用**、hook/transcript は無し。新 WS `GET /ws/launch`（`?launcher=<index>&cwd`、`?session` で再接続）。browser は **index のみ**送り、config を allowlist にする。共通の `gh` spawn ヘルパは既存どおり。
- **フロント**: `ConnTarget.launcher` ＋ `/ws/launch` URL ビルダ、`Cell.launcher` ＋ `launchInCell` transform ＋ 直列化（launcher セルを persist）、`LauncherCell.vue`（持続・running/idle）、空セルランチャーの「or launch」ボタン、Settings の「Launch commands」エディタ、config 配線。
- **ドキュメント**: README の config テーブル（`launchers`/`prRepos`）＋ ランチャー説明を更新。

## Items to Confirm / Review
- **仕様（回答どおり実装）**: 方式=設定駆動の一覧 / 非 Claude セル=持続＋再接続・状態は起動中/終了のみ。
- **起動方法**: `$SHELL -lc "exec <command>"`（Windows は `powershell -NoLogo -Command`）。`exec` で単一プロセス常駐、`$SHELL` 等の env が展開。コマンドはユーザー自身の設定（allowlist）。
- **持続/再接続**: `/ws/launch` は Claude の `reattachPty`/`reap`/`handleClientClose` を流用。live PTY があれば index に関係なく再接続、無ければ index を解決して spawn。dev-terminal 扱いで chat サイドバーには出ない。
- **永続化**: launcher セルは session を持つので localStorage に永続。サーバ再起動後は index から再 spawn（一覧を編集していると index がずれ得る＝script.json と同じ制約、要判断だった点。live 再接続時は index 非依存）。
- **状態**: 持続シェルは生存中ずっと "working"（running）。hook が無いので blocked/done は出ない（decision どおり）。

## 目視確認（実サーバ e2e）
分離 HOME で実サーバを起動し `/ws/launch` を実 WebSocket で検証:
- ランチャー登録 → `?launcher=0` で `$SHELL` を spawn、`{type:session,id,cwd}` を返す
- `echo <marker>` 入力 → 出力に marker（`exec $SHELL` で対話シェルが動作）
- `?session=<id>` で再接続 → **同一 pid に reattach**・バッファ再送
- 不正 index → エラーメッセージで close

## User Prompt
> 182、184 を順次。（#182: セルランチャーで起動コマンドを選べる — プレーンシェル / codex / 任意エージェント）

決定事項（本 PR 前のやり取り）:
> - 方式: 設定駆動の一覧（Settings で編集、prRepos と同じ要領）
> - 非 Claude セル: 持続＋再接続、状態は起動中/終了のみ

## Tests
`sanitizeLaunchers`（往復/上限/重複）、`buildLaunchWsUrl`、`launchInCell` ＋ launcher 永続化。ゲート: typecheck(client/server)/format/lint/build/**test 591** 通過。

Closes #182