### PR TITLE
feat: 全画面ファイルエクスプローラー＋Markdown編集ビュー (#184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,22 @@ command, so the file is the allowlist of what can run.
 
 ---
 
+## Files view (browse & edit)
+
+Every terminal header has a **📁 Files** button that opens a full-screen file explorer
+rooted at **that terminal's project directory** — so after Claude says "wrote `foo.md`"
+you can jump straight there to read or edit it. The left pane is a lazy-loaded directory
+tree; clicking a file opens it in a **CodeMirror** editor (Markdown / JS-TS / JSON
+highlighting, everything else as plain text). Markdown files get a **Preview** toggle
+that renders via the server's sandboxed `…/md` HTML. **Save** (or ⌘/Ctrl-S) writes back.
+
+All reads and writes go through `GET/PUT /api/files/browse/*?cwd=&path=`, and every
+`path` is **contained within the project root** (server-side) — `..`/absolute escapes
+are rejected for reads and writes alike, so editing can't reach outside the directory
+the terminal is pointed at.
+
+---
+
 ## Server API specification
 
 Base URL: `http://localhost:$PORT` (default `http://localhost:34567`).

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     "postinstall": "node server/fix-pty-perms.js"
   },
   "dependencies": {
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/state": "^6.7.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@google/genai": "^2.10.0",
     "@marp-team/marp-core": "^4.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -64,6 +69,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "codemirror": "^6.0.2",
     "dompurify": "^3.4.11",
     "echarts": "^6.0.0",
     "express": "^5.2.1",

--- a/plans/feat-184-file-explorer.md
+++ b/plans/feat-184-file-explorer.md
@@ -1,0 +1,41 @@
+# feat-184: 全画面ファイルエクスプローラー＋Markdown編集ビュー
+
+Issue: #184（Supersedes #116 / #117）
+
+## 決定事項（ユーザー確認済み）
+- エディタ: **CodeMirror 6**（`codemirror` + lang-markdown/javascript/json + theme-one-dark）。
+- terminal→ファイル導線: **ヘッダの Files ボタン**（そのセルの cwd をルートに `/files` を開く）。
+- md プレビュー: 既存の **sandboxed iframe**（`/api/files/browse/md`）を流用（`v-html` は使わない）。
+
+## アーキテクチャ方針
+旧 `feat/file-browser` の browse ロジック（`files-browse.ts`: `resolveBase` / `containedPath` / `mdToHtmlDoc` / `listEntries`）を **自己完結で main に取り込み**、書き込み API とテキスト読み取りを足す。全画面ビューは `/prs`（#183）と同じ overlay パターン。
+
+## 変更ファイル
+
+### サーバ
+- `server/files-browse.ts`（新, 旧ブランチ流用）: `resolveBase` / `containedPath`（書き込みのパス封じ込めにも使用）/ `mdToHtmlDoc` / `listEntries`。
+  - `GET /api/files/browse/list?cwd=&path=` — ディレクトリ一覧（dir 優先）。
+  - `GET /api/files/browse/text?cwd=&path=` — テキスト内容 `{ text, truncated }`（サイズ上限・utf8）。
+  - `GET /api/files/browse/md?cwd=&path=` — marked→HTML を sandbox CSP で（プレビュー iframe 用）。
+  - `PUT /api/files/browse/write?cwd=&path=` — `{ text }` を封じ込めパスに書き込み（cwd 外禁止・サイズ上限）。
+- `server/index.ts`: `mountFilesBrowseRoutes(app, { defaultCwd: CLAUDE_CWD })`。
+- `server/files-browse.spec.ts`（新）: `containedPath` / `resolveBase` / list・write の封じ込め。
+
+### クライアント
+- `src/router/index.ts`: `/files` ルート（Stub）。
+- `src/composables/useFilesView.ts`（新）: `useFilesView()`（isOpen=route.name==="files", close, targetCwd=route.query.cwd）＋ `filesGotoIndex(cwd)`。
+- `src/components/FilesOverlay.vue`（新）: 左=階層ツリー（遅延展開）、右=CodeMirror エディタ＋保存、md は プレビュー(iframe)トグル。dirty 管理・保存・リロード・閉じる。
+- `src/components/cmEditor.ts`（新）: CodeMirror 6 の生成/破棄/ドキュメント差し替え/言語 Compartment（拡張子→md/js/json）を薄くラップ（テスト可能な純ロジックは分離）。
+- `src/components/Terminal.vue`（ヘッダ）: 📁 Files ボタン → `filesGotoIndex(serverCwd)`。
+- `src/App.vue`: `<FilesOverlay />` をマウント。
+
+### テスト
+- `server/files-browse.spec.ts`: 封じ込め・write の cwd 外禁止。
+- `src/components/cmEditor.spec.ts`: 拡張子→言語判定など純ロジック。
+- `src/composables/useFilesView.spec.ts` or FilesOverlay 描画（ツリー/エディタ）。
+
+## セキュリティ
+書き込みは `containedPath` で cwd 外を 403。サイズ上限。プレビューは sandbox CSP の iframe（app オリジンで script 実行不可）。
+
+## ゲート / 確認
+typecheck(client/server)/format/lint/build/test。実サーバで list/text/write/md を e2e（封じ込め含む）。

--- a/server/files-browse.spec.ts
+++ b/server/files-browse.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { containedPath, resolveBase, listEntries, mdToHtmlDoc } from "./files-browse";
+import { containedPath, realContainedWithin, resolveBase, listEntries, mdToHtmlDoc } from "./files-browse";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-files-"));
 
@@ -19,6 +19,29 @@ describe("containedPath (write/read containment)", () => {
   });
   it("does not treat a sibling with the same prefix as contained", () => {
     expect(containedPath("/proj/root", "../root-evil/x")).toBeNull();
+  });
+});
+
+describe("realContainedWithin (symlink-safe containment)", () => {
+  it("accepts a real path inside the project (existing and new)", () => {
+    const root = realpathSync(tmp());
+    mkdirSync(path.join(root, "docs"));
+    writeFileSync(path.join(root, "docs", "a.md"), "x");
+    expect(realContainedWithin(root, path.join(root, "docs", "a.md"))).toBe(path.join(root, "docs", "a.md")); // existing
+    expect(realContainedWithin(root, path.join(root, "docs", "new.md"))).toBe(path.join(root, "docs", "new.md")); // not-yet-created write target
+    rmSync(root, { recursive: true, force: true });
+  });
+  it("rejects a symlink inside the project that points outside it (read AND write escape)", () => {
+    const root = realpathSync(tmp());
+    const outside = realpathSync(tmp());
+    writeFileSync(path.join(outside, "secret.txt"), "s");
+    symlinkSync(outside, path.join(root, "link")); // link -> outside dir
+    // lexical containment passes (no `..`), but the real path escapes:
+    expect(containedPath(root, "link/secret.txt")).not.toBeNull();
+    expect(realContainedWithin(root, path.join(root, "link", "secret.txt"))).toBeNull(); // read escape blocked
+    expect(realContainedWithin(root, path.join(root, "link", "new.txt"))).toBeNull(); // write escape blocked
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
   });
 });
 

--- a/server/files-browse.spec.ts
+++ b/server/files-browse.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { containedPath, resolveBase, listEntries, mdToHtmlDoc } from "./files-browse";
+
+const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-files-"));
+
+describe("containedPath (write/read containment)", () => {
+  const base = "/proj/root";
+  it("resolves a relative path within the base", () => {
+    expect(containedPath(base, "docs/a.md")).toBe(path.resolve(base, "docs/a.md"));
+    expect(containedPath(base, "")).toBe(path.resolve(base)); // the root itself
+  });
+  it("rejects traversal and absolute escapes", () => {
+    expect(containedPath(base, "../secret")).toBeNull();
+    expect(containedPath(base, "docs/../../etc/passwd")).toBeNull();
+    expect(containedPath(base, "/etc/passwd")).toBeNull();
+  });
+  it("does not treat a sibling with the same prefix as contained", () => {
+    expect(containedPath("/proj/root", "../root-evil/x")).toBeNull();
+  });
+});
+
+describe("resolveBase", () => {
+  it("uses an absolute existing dir, else the default", () => {
+    const dir = tmp();
+    expect(resolveBase(dir, "/default")).toBe(dir);
+    expect(resolveBase("relative/x", "/default")).toBe("/default");
+    expect(resolveBase(null, "/default")).toBe("/default");
+    expect(resolveBase(path.join(dir, "missing"), "/default")).toBe("/default");
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("listEntries", () => {
+  it("lists directories first, then files, each alphabetical, with sizes", () => {
+    const dir = tmp();
+    mkdirSync(path.join(dir, "zsub"));
+    mkdirSync(path.join(dir, "asub"));
+    writeFileSync(path.join(dir, "b.txt"), "hello");
+    writeFileSync(path.join(dir, "a.md"), "# hi");
+    const entries = listEntries(dir);
+    expect(entries.map((e) => e.name)).toEqual(["asub", "zsub", "a.md", "b.txt"]);
+    expect(entries.find((e) => e.name === "b.txt")).toMatchObject({ dir: false, size: 5 });
+    expect(entries.find((e) => e.name === "asub")).toMatchObject({ dir: true });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("mdToHtmlDoc", () => {
+  it("wraps body HTML and escapes the title", () => {
+    const doc = mdToHtmlDoc("<p>x</p>", "a<b>.md");
+    expect(doc).toContain("<p>x</p>");
+    expect(doc).toContain("<title>a&lt;b&gt;.md</title>");
+    expect(doc.startsWith("<!doctype html>")).toBe(true);
+  });
+});

--- a/server/files-browse.ts
+++ b/server/files-browse.ts
@@ -37,6 +37,33 @@ export function containedPath(base: string, rel: string): string | null {
   return abs;
 }
 
+function realpathOr(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p; // doesn't exist yet (a new file being written) — use the lexical path
+  }
+}
+
+// Lexical containment (containedPath) can be defeated by a SYMLINK inside the project
+// that points outside it. This resolves symlinks in the path's existing portion (a
+// not-yet-created write target has none) and confirms the real path still lands within
+// `base`. Returns the real absolute path, or null if it escapes.
+export function realContainedWithin(base: string, absLexical: string): string | null {
+  const root = realpathOr(path.resolve(base));
+  const rest: string[] = [];
+  let existing = absLexical;
+  while (!fs.existsSync(existing)) {
+    rest.unshift(path.basename(existing));
+    const parent = path.dirname(existing);
+    if (parent === existing) break; // reached the filesystem root
+    existing = parent;
+  }
+  const real = rest.length ? path.resolve(realpathOr(existing), ...rest) : realpathOr(existing);
+  if (real !== root && !real.startsWith(root + path.sep)) return null;
+  return real;
+}
+
 // Wrap marked's HTML output in a minimal, self-contained document (served sandboxed).
 export function mdToHtmlDoc(bodyHtml: string, title: string): string {
   const esc = (s: string) => s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c] ?? c);
@@ -80,10 +107,13 @@ export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string 
   const baseOf = (req: Request) => resolveBase(typeof req.query.cwd === "string" ? req.query.cwd : null, deps.defaultCwd);
   const relOf = (req: Request) => (typeof req.query.path === "string" ? req.query.path : "");
 
-  // Resolve `path` under the request's project base; 403 if it escapes. Centralises the
-  // containment check so every route (read AND write) shares one gate.
+  // Resolve `path` under the request's project base; 403 if it escapes — lexically OR
+  // through a symlink. Centralises the containment check so every route (read AND write)
+  // shares one gate.
   const contained = (req: Request, res: Response): string | null => {
-    const abs = containedPath(baseOf(req), relOf(req));
+    const base = baseOf(req);
+    const lexical = containedPath(base, relOf(req));
+    const abs = lexical ? realContainedWithin(base, lexical) : null;
     if (!abs) {
       res.status(403).json({ error: "path escapes the project root" });
       return null;
@@ -121,6 +151,10 @@ export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string 
     if (!abs) return;
     let text: string;
     try {
+      const stat = fs.statSync(abs);
+      if (stat.isDirectory()) return res.status(400).json({ error: "not a file" });
+      // Same cap as /text and /write, so a huge file can't be read+parsed by marked.
+      if (stat.size > MAX_EDIT_BYTES) return res.status(413).json({ error: "file too large" });
       text = fs.readFileSync(abs, "utf8");
     } catch {
       return res.status(404).json({ error: "not found" });

--- a/server/files-browse.ts
+++ b/server/files-browse.ts
@@ -1,0 +1,148 @@
+// Project-scoped file browsing + editing for the full-screen Files view. Takes a
+// `?cwd=` project dir (the directory a terminal's session runs in) so each terminal
+// browses/edits ITS OWN project. list/text/md are read-only GETs; write is a PUT.
+//
+// Security: the same loopback/trusted-local-user posture as the worktree/session
+// endpoints — any absolute existing dir is an allowed base — but `path` is always
+// contained within that base (no `..`/absolute escape), for reads AND writes. Rendered
+// markdown is served under a sandbox CSP so embedded scripts can't run in the app origin.
+import path from "node:path";
+import fs from "node:fs";
+import { marked } from "marked";
+import type { Express, Request, Response } from "express";
+
+// Cap on the bytes served to the editor / accepted on write — a text editor, not a
+// blob store. Large/binary files are refused rather than streamed into a textarea.
+export const MAX_EDIT_BYTES = 2 * 1024 * 1024;
+
+// Resolve a client-supplied project dir: absolute + existing dir, else the default
+// workspace (mirrors index.ts resolveWorkspace).
+export function resolveBase(cwd: string | null, defaultCwd: string): string {
+  if (cwd && path.isAbsolute(cwd)) {
+    try {
+      if (fs.statSync(cwd).isDirectory()) return cwd;
+    } catch {
+      // not a dir / missing — fall through to the default
+    }
+  }
+  return defaultCwd;
+}
+
+// Resolve `rel` under `base`; return the absolute path only if it stays within base
+// (reject `..` / absolute escapes). null = escapes the root.
+export function containedPath(base: string, rel: string): string | null {
+  const root = path.resolve(base);
+  const abs = path.resolve(root, rel);
+  if (abs !== root && !abs.startsWith(root + path.sep)) return null;
+  return abs;
+}
+
+// Wrap marked's HTML output in a minimal, self-contained document (served sandboxed).
+export function mdToHtmlDoc(bodyHtml: string, title: string): string {
+  const esc = (s: string) => s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c] ?? c);
+  const style =
+    "body{max-width:48rem;margin:2rem auto;padding:0 1rem;font-family:system-ui,sans-serif;line-height:1.6;color:#1a1a2e}" +
+    "pre{background:#f4f4f4;padding:1rem;overflow:auto}code{font-family:ui-monospace,monospace}img{max-width:100%}";
+  return `<!doctype html><html><head><meta charset="utf-8"><title>${esc(title)}</title><style>${style}</style></head><body>${bodyHtml}</body></html>`;
+}
+
+export interface BrowseEntry {
+  name: string;
+  dir: boolean;
+  size: number;
+}
+
+// Directory listing, directories first then files, each alphabetical. Dotfiles are
+// kept (a project's config often lives in them) but node_modules/.git are noisy —
+// still listed; the UI can collapse them.
+export function listEntries(absDir: string): BrowseEntry[] {
+  return fs
+    .readdirSync(absDir, { withFileTypes: true })
+    .map((d) => {
+      const dir = d.isDirectory();
+      let size = 0;
+      if (!dir) {
+        try {
+          size = fs.statSync(path.join(absDir, d.name)).size;
+        } catch {
+          size = 0;
+        }
+      }
+      return { name: d.name, dir, size };
+    })
+    .sort((a, b) => {
+      if (a.dir !== b.dir) return a.dir ? -1 : 1; // directories first
+      return a.name.localeCompare(b.name);
+    });
+}
+
+export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string }): void {
+  const baseOf = (req: Request) => resolveBase(typeof req.query.cwd === "string" ? req.query.cwd : null, deps.defaultCwd);
+  const relOf = (req: Request) => (typeof req.query.path === "string" ? req.query.path : "");
+
+  // Resolve `path` under the request's project base; 403 if it escapes. Centralises the
+  // containment check so every route (read AND write) shares one gate.
+  const contained = (req: Request, res: Response): string | null => {
+    const abs = containedPath(baseOf(req), relOf(req));
+    if (!abs) {
+      res.status(403).json({ error: "path escapes the project root" });
+      return null;
+    }
+    return abs;
+  };
+
+  app.get("/api/files/browse/list", (req, res) => {
+    const root = baseOf(req);
+    const abs = contained(req, res);
+    if (!abs) return;
+    try {
+      if (!fs.statSync(abs).isDirectory()) return res.status(400).json({ error: "not a directory" });
+      res.json({ cwd: path.resolve(root), path: relOf(req), entries: listEntries(abs) });
+    } catch {
+      res.status(404).json({ error: "not found" });
+    }
+  });
+
+  app.get("/api/files/browse/text", (req, res) => {
+    const abs = contained(req, res);
+    if (!abs) return;
+    try {
+      const stat = fs.statSync(abs);
+      if (stat.isDirectory()) return res.status(400).json({ error: "not a file" });
+      if (stat.size > MAX_EDIT_BYTES) return res.status(413).json({ error: "file too large to edit" });
+      res.json({ text: fs.readFileSync(abs, "utf8") });
+    } catch {
+      res.status(404).json({ error: "not found" });
+    }
+  });
+
+  app.get("/api/files/browse/md", async (req, res) => {
+    const abs = contained(req, res);
+    if (!abs) return;
+    let text: string;
+    try {
+      text = fs.readFileSync(abs, "utf8");
+    } catch {
+      return res.status(404).json({ error: "not found" });
+    }
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Content-Security-Policy", "sandbox");
+    res.send(mdToHtmlDoc(await marked.parse(text), path.basename(abs)));
+  });
+
+  app.put("/api/files/browse/write", (req, res) => {
+    const abs = contained(req, res);
+    if (!abs) return;
+    const text = req.body?.text;
+    if (typeof text !== "string") return res.status(400).json({ error: "body.text (string) required" });
+    if (Buffer.byteLength(text, "utf8") > MAX_EDIT_BYTES) return res.status(413).json({ error: "content too large" });
+    try {
+      if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) return res.status(400).json({ error: "path is a directory" });
+      fs.writeFileSync(abs, text, "utf8");
+      res.json({ ok: true });
+    } catch {
+      res.status(500).json({ error: "failed to write file" });
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes, getPrRepos, getLaunchers } from "./config-routes.js";
+import { mountFilesBrowseRoutes } from "./files-browse.js";
 import { listPrsAcrossRepos } from "./prs.js";
 import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
@@ -1057,6 +1058,11 @@ app.get("/api/tool-calls/:sessionId", async (req, res) => {
 // GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
 // modal's directory presets. The single view never calls it.
 mountConfigRoutes(app, CLAUDE_CWD);
+
+// Project-scoped file browsing + editing for the full-screen Files view
+// (GET /api/files/browse/{list,text,md}, PUT .../write — all ?cwd=&path=). Each
+// terminal browses its own session's project dir; paths are contained within it.
+mountFilesBrowseRoutes(app, { defaultCwd: CLAUDE_CWD });
 
 // Cross-repo PR list (the /prs view): aggregate open PRs for the configured repos via
 // the server's `gh` login. Repos come from config (never the request).

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@ import CollectionsBrowseOverlay from "./components/CollectionsBrowseOverlay.vue"
 import AccountingOverlay from "./components/AccountingOverlay.vue";
 import WikiBrowseOverlay from "./components/WikiBrowseOverlay.vue";
 import PrsOverlay from "./components/PrsOverlay.vue";
+import FilesOverlay from "./components/FilesOverlay.vue";
 import GridView from "./components/GridView.vue";
 import SettingsModal from "./components/SettingsModal.vue";
 import AppToolbar from "./components/AppToolbar.vue";
@@ -336,6 +337,8 @@ function onSession(id: string) {
     <WikiBrowseOverlay />
     <!-- Full-screen cross-repo PR list; opened by the toolbar's call_merge button. -->
     <PrsOverlay />
+    <!-- Full-screen file explorer + editor; opened by a terminal header's Files button. -->
+    <FilesOverlay />
     <SettingsModal
       v-if="showSettings"
       :sound-file="soundFile"

--- a/src/components/FilesOverlay.spec.ts
+++ b/src/components/FilesOverlay.spec.ts
@@ -5,14 +5,20 @@ import FilesOverlay from "./FilesOverlay.vue";
 // The view is route-driven; stub useFilesView so the overlay is "open" without a router.
 // A shared cwd ref lets a test drive a route-root change; filesGotoIndex mutates it too
 // (the component uses it to revert a declined root switch).
-const hoisted = vi.hoisted(() => ({ setCwd: (() => {}) as (v: string | null) => void }));
+const hoisted = vi.hoisted(() => ({
+  setCwd: (() => {}) as (v: string | null) => void,
+  setOpen: (() => {}) as (v: boolean) => void,
+}));
 vi.mock("../composables/useFilesView", async () => {
   const { ref: r } = await import("vue");
   const cwd = r<string | null>("/proj");
+  const isOpen = r(true);
   hoisted.setCwd = (v) => (cwd.value = v);
+  hoisted.setOpen = (v) => (isOpen.value = v);
   return {
-    useFilesView: () => ({ isOpen: r(true), cwd, close: vi.fn() }),
-    filesGotoIndex: (v: string | null) => (cwd.value = v),
+    useFilesView: () => ({ isOpen, cwd, close: () => (isOpen.value = false) }),
+    // Revert re-opens /files at the restored root (isOpen back to true).
+    filesGotoIndex: (v: string | null) => ((cwd.value = v), (isOpen.value = true)),
   };
 });
 
@@ -64,6 +70,7 @@ describe("FilesOverlay", () => {
   beforeEach(() => {
     fakeEditor.setDoc.mockClear();
     hoisted.setCwd("/proj");
+    hoisted.setOpen(true);
     mockFs();
   });
   afterEach(() => wrappers.splice(0).forEach((w) => w.unmount()));
@@ -154,6 +161,27 @@ describe("FilesOverlay", () => {
     expect(confirmSpy).toHaveBeenCalled();
     expect(fakeEditor.destroy).not.toHaveBeenCalled(); // declined → no teardown, buffer kept
     expect(w.text()).toContain("README.md"); // still showing the old root's tree
+    confirmSpy.mockRestore();
+  });
+
+  it("guards an external close (isOpen=false) with a dirty buffer", async () => {
+    const w = mountOverlay();
+    await flushPromises();
+    await must(
+      w.findAll("button.files-row").find((b) => b.text().includes("README.md")),
+      "readme",
+    ).trigger("click");
+    await flushPromises();
+    onChange(); // mark dirty
+    await flushPromises();
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    fakeEditor.destroy.mockClear();
+    hoisted.setOpen(false); // external navigation (Back / another view) closes the overlay
+    await flushPromises();
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(fakeEditor.destroy).not.toHaveBeenCalled(); // declined → reverted, buffer kept
+    expect(w.text()).toContain("README.md"); // overlay still open
     confirmSpy.mockRestore();
   });
 

--- a/src/components/FilesOverlay.spec.ts
+++ b/src/components/FilesOverlay.spec.ts
@@ -1,13 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ref } from "vue";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import FilesOverlay from "./FilesOverlay.vue";
 
 // The view is route-driven; stub useFilesView so the overlay is "open" without a router.
-vi.mock("../composables/useFilesView", () => ({
-  useFilesView: () => ({ isOpen: ref(true), cwd: ref("/proj"), close: vi.fn() }),
-  filesGotoIndex: vi.fn(),
-}));
+// A shared cwd ref lets a test drive a route-root change; filesGotoIndex mutates it too
+// (the component uses it to revert a declined root switch).
+const hoisted = vi.hoisted(() => ({ setCwd: (() => {}) as (v: string | null) => void }));
+vi.mock("../composables/useFilesView", async () => {
+  const { ref: r } = await import("vue");
+  const cwd = r<string | null>("/proj");
+  hoisted.setCwd = (v) => (cwd.value = v);
+  return {
+    useFilesView: () => ({ isOpen: r(true), cwd, close: vi.fn() }),
+    filesGotoIndex: (v: string | null) => (cwd.value = v),
+  };
+});
 
 // Don't instantiate real CodeMirror (needs a full DOM); capture the change callback so
 // we can simulate a user edit, and record setDoc/getDoc.
@@ -44,14 +51,25 @@ function must<T>(v: T | undefined, msg: string): T {
   return v;
 }
 
+// The mocked cwd ref and fakeEditor are module singletons, so an un-unmounted overlay
+// from a prior test would also react to a later test's cwd change. Track and unmount.
+const wrappers: ReturnType<typeof mount>[] = [];
+const mountOverlay = () => {
+  const w = mount(FilesOverlay);
+  wrappers.push(w);
+  return w;
+};
+
 describe("FilesOverlay", () => {
   beforeEach(() => {
     fakeEditor.setDoc.mockClear();
+    hoisted.setCwd("/proj");
     mockFs();
   });
+  afterEach(() => wrappers.splice(0).forEach((w) => w.unmount()));
 
   it("loads the root tree, opens a file, edits, and saves", async () => {
-    const w = mount(FilesOverlay);
+    const w = mountOverlay();
     await flushPromises();
     // Root entries rendered (directories first).
     expect(w.text()).toContain("src");
@@ -90,7 +108,7 @@ describe("FilesOverlay", () => {
   });
 
   it("guards against discarding unsaved edits when switching files", async () => {
-    const w = mount(FilesOverlay);
+    const w = mountOverlay();
     await flushPromises();
     const open = (name: string) =>
       must(
@@ -118,8 +136,29 @@ describe("FilesOverlay", () => {
     confirmSpy.mockRestore();
   });
 
+  it("guards a route root (cwd) change with a dirty buffer", async () => {
+    const w = mountOverlay();
+    await flushPromises();
+    await must(
+      w.findAll("button.files-row").find((b) => b.text().includes("README.md")),
+      "readme",
+    ).trigger("click");
+    await flushPromises();
+    onChange(); // mark dirty
+    await flushPromises();
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    fakeEditor.destroy.mockClear();
+    hoisted.setCwd("/other-project"); // simulate the Files route changing roots
+    await flushPromises();
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(fakeEditor.destroy).not.toHaveBeenCalled(); // declined → no teardown, buffer kept
+    expect(w.text()).toContain("README.md"); // still showing the old root's tree
+    confirmSpy.mockRestore();
+  });
+
   it("lazy-loads a directory's children on expand", async () => {
-    const w = mount(FilesOverlay);
+    const w = mountOverlay();
     await flushPromises();
     const srcRow = must(
       w.findAll("button.files-row").find((b) => b.text().includes("src")),
@@ -132,7 +171,7 @@ describe("FilesOverlay", () => {
 
   it("surfaces a tree load error", async () => {
     globalThis.fetch = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof fetch;
-    const w = mount(FilesOverlay);
+    const w = mountOverlay();
     await flushPromises();
     expect(w.text()).toContain("HTTP 500");
   });

--- a/src/components/FilesOverlay.spec.ts
+++ b/src/components/FilesOverlay.spec.ts
@@ -28,6 +28,7 @@ function mockFs() {
           ? [
               { name: "src", dir: true, size: 0 },
               { name: "README.md", dir: false, size: 10 },
+              { name: "notes.txt", dir: false, size: 4 },
             ]
           : [{ name: "app.ts", dir: false, size: 5 }];
       return { ok: true, json: async () => ({ entries }) };
@@ -86,6 +87,35 @@ describe("FilesOverlay", () => {
     );
     expect(putCall[1]).toMatchObject({ method: "PUT" });
     expect(JSON.parse(putCall[1].body)).toEqual({ text: "edited text" });
+  });
+
+  it("guards against discarding unsaved edits when switching files", async () => {
+    const w = mount(FilesOverlay);
+    await flushPromises();
+    const open = (name: string) =>
+      must(
+        w.findAll("button.files-row").find((b) => b.text().includes(name)),
+        name,
+      ).trigger("click");
+    await open("README.md");
+    await flushPromises();
+    onChange(); // mark dirty
+    await flushPromises();
+
+    // Declining the confirm aborts the switch — the new file is not loaded.
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    fakeEditor.setDoc.mockClear();
+    await open("notes.txt");
+    await flushPromises();
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(fakeEditor.setDoc).not.toHaveBeenCalled(); // buffer kept
+
+    // Accepting the confirm proceeds with the switch.
+    confirmSpy.mockReturnValue(true);
+    await open("notes.txt");
+    await flushPromises();
+    expect(fakeEditor.setDoc).toHaveBeenCalledWith("# hello", "notes.txt");
+    confirmSpy.mockRestore();
   });
 
   it("lazy-loads a directory's children on expand", async () => {

--- a/src/components/FilesOverlay.spec.ts
+++ b/src/components/FilesOverlay.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import FilesOverlay from "./FilesOverlay.vue";
+
+// The view is route-driven; stub useFilesView so the overlay is "open" without a router.
+vi.mock("../composables/useFilesView", () => ({
+  useFilesView: () => ({ isOpen: ref(true), cwd: ref("/proj"), close: vi.fn() }),
+  filesGotoIndex: vi.fn(),
+}));
+
+// Don't instantiate real CodeMirror (needs a full DOM); capture the change callback so
+// we can simulate a user edit, and record setDoc/getDoc.
+let onChange: () => void = () => {};
+const fakeEditor = { setDoc: vi.fn(), getDoc: vi.fn(() => "edited text"), destroy: vi.fn() };
+vi.mock("./cmEditor", async (orig) => {
+  const actual = await orig<typeof import("./cmEditor")>();
+  return { ...actual, createEditor: (_host: HTMLElement, cb: () => void) => ((onChange = cb), fakeEditor) };
+});
+
+function mockFs() {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes("/list")) {
+      const p = new URL(url, "https://x").searchParams.get("path");
+      const entries =
+        p === ""
+          ? [
+              { name: "src", dir: true, size: 0 },
+              { name: "README.md", dir: false, size: 10 },
+            ]
+          : [{ name: "app.ts", dir: false, size: 5 }];
+      return { ok: true, json: async () => ({ entries }) };
+    }
+    if (url.includes("/text")) return { ok: true, json: async () => ({ text: "# hello" }) };
+    if (url.includes("/write")) return { ok: true, json: async () => ({ ok: true }), _init: init };
+    return { ok: false, status: 404, json: async () => ({}) };
+  }) as unknown as typeof fetch;
+}
+
+function must<T>(v: T | undefined, msg: string): T {
+  if (v === undefined) throw new Error(msg);
+  return v;
+}
+
+describe("FilesOverlay", () => {
+  beforeEach(() => {
+    fakeEditor.setDoc.mockClear();
+    mockFs();
+  });
+
+  it("loads the root tree, opens a file, edits, and saves", async () => {
+    const w = mount(FilesOverlay);
+    await flushPromises();
+    // Root entries rendered (directories first).
+    expect(w.text()).toContain("src");
+    expect(w.text()).toContain("README.md");
+
+    // Open the markdown file → text fetched and pushed into the editor.
+    const readmeRow = must(
+      w.findAll("button.files-row").find((b) => b.text().includes("README.md")),
+      "README row",
+    );
+    await readmeRow.trigger("click");
+    await flushPromises();
+    expect(fakeEditor.setDoc).toHaveBeenCalledWith("# hello", "README.md");
+    expect(w.text()).toContain("Preview"); // md preview toggle offered
+
+    // No unsaved edits yet → Save disabled. Simulate an edit → Save enables.
+    const saveBtn = () =>
+      must(
+        w.findAll("button").find((b) => b.text().startsWith("Save")),
+        "save btn",
+      );
+    expect(saveBtn().attributes("disabled")).toBeDefined();
+    onChange();
+    await flushPromises();
+    expect(saveBtn().attributes("disabled")).toBeUndefined();
+
+    await saveBtn().trigger("click");
+    await flushPromises();
+    const calls = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const putCall = must(
+      calls.find((c) => String(c[0]).includes("/write")),
+      "write call",
+    );
+    expect(putCall[1]).toMatchObject({ method: "PUT" });
+    expect(JSON.parse(putCall[1].body)).toEqual({ text: "edited text" });
+  });
+
+  it("lazy-loads a directory's children on expand", async () => {
+    const w = mount(FilesOverlay);
+    await flushPromises();
+    const srcRow = must(
+      w.findAll("button.files-row").find((b) => b.text().includes("src")),
+      "src row",
+    );
+    await srcRow.trigger("click");
+    await flushPromises();
+    expect(w.text()).toContain("app.ts"); // child loaded
+  });
+
+  it("surfaces a tree load error", async () => {
+    globalThis.fetch = vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })) as unknown as typeof fetch;
+    const w = mount(FilesOverlay);
+    await flushPromises();
+    expect(w.text()).toContain("HTTP 500");
+  });
+});

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -38,6 +38,11 @@ const isMarkdown = computed(() => langKindForFilename(openName.value) === "markd
 const editorHost = ref<HTMLDivElement>();
 let editor: CmEditor | null = null;
 let reqId = 0;
+// `reverting`: a route change WE triggered to undo a declined leave/root-switch — skip
+// its own watcher fire. `bypassGuard`: the close was already confirmed (requestClose),
+// so the watcher must not prompt again.
+let reverting = false;
+let bypassGuard = false;
 
 function qs(pathRel: string): string {
   const p = new URLSearchParams();
@@ -141,7 +146,9 @@ async function save(): Promise<void> {
 }
 
 function requestClose(): void {
-  if (confirmDiscard()) close();
+  if (!confirmDiscard()) return;
+  bypassGuard = true; // already confirmed — don't let the isOpen watcher prompt again
+  close();
 }
 
 function onKeydown(e: KeyboardEvent): void {
@@ -162,9 +169,6 @@ function teardown(): void {
   dirty.value = false;
   showPreview.value = false;
 }
-// `reverting` marks a route change WE triggered to undo a declined root switch, so its
-// own watcher fire is ignored instead of re-prompting.
-let reverting = false;
 watch(
   [isOpen, cwd],
   async ([open, curCwd], prev) => {
@@ -172,14 +176,20 @@ watch(
       reverting = false;
       return;
     }
-    // Root (?cwd=) changed mid-edit with unsaved changes → confirm before discarding;
-    // declining restores the previous root so the editor + buffer stay put.
+    // Leaving the view (external nav / Back) OR changing root (?cwd=) mid-edit with
+    // unsaved changes → confirm before discarding; declining restores the previous
+    // route (re-opens /files at prevCwd) so the editor + buffer stay put. An explicit
+    // Close already confirmed (bypassGuard), so don't prompt twice.
+    const wasOpen = prev?.[0] ?? false;
     const prevCwd = prev?.[1] ?? null;
-    if (open && curCwd !== prevCwd && !confirmDiscard()) {
+    const leaving = wasOpen && !open;
+    const rootChanged = open && curCwd !== prevCwd;
+    if (!bypassGuard && (leaving || rootChanged) && !confirmDiscard()) {
       reverting = true;
       filesGotoIndex(prevCwd);
       return;
     }
+    bypassGuard = false;
     teardown();
     if (!open) return;
     await nextTick();

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -95,8 +95,16 @@ const rows = computed(() => {
   return out;
 });
 
+// Guard any action that would drop the open buffer's unsaved edits (switching files,
+// closing the view). Returns true to proceed.
+function confirmDiscard(): boolean {
+  return !dirty.value || window.confirm("Discard unsaved changes?");
+}
+
 async function openFile(node: Node): Promise<void> {
   if (node.dir) return toggleDir(node);
+  if (node.path === openPath.value) return; // already open — no reload, no prompt
+  if (!confirmDiscard()) return;
   const id = ++reqId;
   fileError.value = null;
   showPreview.value = false;
@@ -133,8 +141,7 @@ async function save(): Promise<void> {
 }
 
 function requestClose(): void {
-  if (dirty.value && !window.confirm("Discard unsaved changes?")) return;
-  close();
+  if (confirmDiscard()) close();
 }
 
 function onKeydown(e: KeyboardEvent): void {

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -1,0 +1,370 @@
+<script setup lang="ts">
+// Full-screen file explorer + editor, a sibling of PrsOverlay. Driven by useFilesView
+// (the /files?cwd= route). Left: a lazy-loaded directory tree rooted at the project dir.
+// Right: a CodeMirror editor for the opened file, with a Markdown preview toggle that
+// reuses the server's sandboxed md→HTML iframe. Writes go through PUT .../write, which
+// contains the path within the project root.
+import { onBeforeUnmount, onMounted, ref, computed, nextTick, watch } from "vue";
+import { useFilesView } from "../composables/useFilesView";
+import { createEditor, langKindForFilename, type CmEditor } from "./cmEditor";
+
+interface Node {
+  name: string;
+  path: string; // relative to the project root
+  dir: boolean;
+  size: number;
+  expanded: boolean;
+  loaded: boolean;
+  children: Node[];
+}
+interface Entry {
+  name: string;
+  dir: boolean;
+  size: number;
+}
+
+const { isOpen, cwd, close } = useFilesView();
+
+const roots = ref<Node[]>([]);
+const treeError = ref<string | null>(null);
+const openPath = ref<string | null>(null);
+const openName = computed(() => (openPath.value ? (openPath.value.split("/").pop() ?? "") : ""));
+const dirty = ref(false);
+const saving = ref(false);
+const fileError = ref<string | null>(null);
+const showPreview = ref(false);
+const isMarkdown = computed(() => langKindForFilename(openName.value) === "markdown");
+
+const editorHost = ref<HTMLDivElement>();
+let editor: CmEditor | null = null;
+let reqId = 0;
+
+function qs(pathRel: string): string {
+  const p = new URLSearchParams();
+  if (cwd.value) p.set("cwd", cwd.value);
+  p.set("path", pathRel);
+  return p.toString();
+}
+const previewSrc = computed(() => (openPath.value ? `/api/files/browse/md?${qs(openPath.value)}` : ""));
+
+function makeNode(e: Entry, parentPath: string): Node {
+  return { name: e.name, path: parentPath ? `${parentPath}/${e.name}` : e.name, dir: e.dir, size: e.size, expanded: false, loaded: false, children: [] };
+}
+
+async function fetchEntries(pathRel: string): Promise<Entry[]> {
+  const res = await fetch(`/api/files/browse/list?${qs(pathRel)}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return Array.isArray(data.entries) ? data.entries : [];
+}
+
+async function loadRoot(): Promise<void> {
+  const id = ++reqId;
+  treeError.value = null;
+  try {
+    const entries = await fetchEntries("");
+    if (id === reqId) roots.value = entries.map((e) => makeNode(e, ""));
+  } catch (e) {
+    if (id === reqId) treeError.value = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function toggleDir(node: Node): Promise<void> {
+  node.expanded = !node.expanded;
+  if (node.expanded && !node.loaded) {
+    try {
+      node.children = (await fetchEntries(node.path)).map((e) => makeNode(e, node.path));
+      node.loaded = true;
+    } catch {
+      node.expanded = false; // couldn't read — collapse again
+    }
+  }
+}
+
+// Depth-first flatten of the currently-visible rows (only descending into expanded
+// dirs), so the template renders a flat list without a recursive component.
+const rows = computed(() => {
+  const out: { node: Node; depth: number }[] = [];
+  const walk = (nodes: Node[], depth: number) => {
+    for (const node of nodes) {
+      out.push({ node, depth });
+      if (node.dir && node.expanded) walk(node.children, depth + 1);
+    }
+  };
+  walk(roots.value, 0);
+  return out;
+});
+
+async function openFile(node: Node): Promise<void> {
+  if (node.dir) return toggleDir(node);
+  const id = ++reqId;
+  fileError.value = null;
+  showPreview.value = false;
+  try {
+    const res = await fetch(`/api/files/browse/text?${qs(node.path)}`);
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || `HTTP ${res.status}`);
+    const data = await res.json();
+    if (id !== reqId) return;
+    openPath.value = node.path;
+    editor?.setDoc(typeof data.text === "string" ? data.text : "", node.name);
+    dirty.value = false;
+  } catch (e) {
+    if (id === reqId) fileError.value = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function save(): Promise<void> {
+  if (!openPath.value || !editor || saving.value) return;
+  saving.value = true;
+  fileError.value = null;
+  try {
+    const res = await fetch(`/api/files/browse/write?${qs(openPath.value)}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: editor.getDoc() }),
+    });
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || `HTTP ${res.status}`);
+    dirty.value = false;
+  } catch (e) {
+    fileError.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    saving.value = false;
+  }
+}
+
+function requestClose(): void {
+  if (dirty.value && !window.confirm("Discard unsaved changes?")) return;
+  close();
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (!isOpen.value) return;
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+    e.preventDefault();
+    save();
+  }
+}
+
+// The editor host only exists while the overlay is open (v-if), so create/destroy the
+// CodeMirror instance and (re)load the tree as the view opens/closes or its root changes.
+function teardown(): void {
+  editor?.destroy();
+  editor = null;
+  roots.value = [];
+  openPath.value = null;
+  dirty.value = false;
+  showPreview.value = false;
+}
+watch(
+  [isOpen, cwd],
+  async ([open]) => {
+    teardown();
+    if (!open) return;
+    await nextTick();
+    if (editorHost.value) editor = createEditor(editorHost.value, () => (dirty.value = true));
+    loadRoot();
+  },
+  { immediate: true },
+);
+
+onMounted(() => window.addEventListener("keydown", onKeydown));
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onKeydown);
+  teardown();
+});
+</script>
+
+<template>
+  <div v-if="isOpen" class="files-overlay" role="region" aria-label="Files">
+    <header class="files-head">
+      <span class="files-title">Files</span>
+      <span class="files-root" :title="cwd ?? ''">{{ cwd ?? "(default workspace)" }}</span>
+      <span class="files-spacer" />
+      <span v-if="openPath" class="files-open" :class="{ dirty }">{{ openName }}<span v-if="dirty" class="files-dot" title="Unsaved">●</span></span>
+      <button v-if="openPath && isMarkdown" type="button" class="files-btn" @click="showPreview = !showPreview">
+        {{ showPreview ? "Edit" : "Preview" }}
+      </button>
+      <button v-if="openPath" type="button" class="files-btn files-save" :disabled="!dirty || saving" @click="save">
+        {{ saving ? "Saving…" : "Save" }}
+      </button>
+      <button type="button" class="files-btn" title="Reload tree" aria-label="Reload tree" @click="loadRoot">↻</button>
+      <button type="button" class="files-btn" title="Close" aria-label="Close files" @click="requestClose">✕</button>
+    </header>
+    <div class="files-body">
+      <nav class="files-tree" aria-label="File tree">
+        <p v-if="treeError" class="files-msg files-error">{{ treeError }}</p>
+        <p v-else-if="roots.length === 0" class="files-msg">Empty directory.</p>
+        <button
+          v-for="{ node, depth } in rows"
+          :key="node.path"
+          type="button"
+          class="files-row"
+          :class="{ 'is-open': node.path === openPath }"
+          :style="{ paddingLeft: `${8 + depth * 14}px` }"
+          @click="openFile(node)"
+        >
+          <span class="files-caret">{{ node.dir ? (node.expanded ? "▾" : "▸") : "" }}</span>
+          <span class="files-icon">{{ node.dir ? "📁" : "📄" }}</span>
+          <span class="files-name">{{ node.name }}</span>
+        </button>
+      </nav>
+      <section class="files-main">
+        <p v-if="fileError" class="files-msg files-error">{{ fileError }}</p>
+        <p v-if="!openPath" class="files-msg files-empty">Select a file to view or edit.</p>
+        <iframe v-show="openPath && showPreview" class="files-preview" :src="previewSrc" sandbox="" title="Markdown preview" />
+        <div v-show="openPath && !showPreview" ref="editorHost" class="files-editor" />
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.files-overlay {
+  position: fixed;
+  top: 40px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: var(--bg-deep);
+  display: flex;
+  flex-direction: column;
+}
+.files-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-panel);
+}
+.files-title {
+  font-weight: 650;
+  font-size: 14px;
+  color: var(--text);
+}
+.files-root {
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 40%;
+}
+.files-spacer {
+  flex: 1 1 auto;
+}
+.files-open {
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.files-open.dirty {
+  color: var(--text);
+}
+.files-dot {
+  color: var(--amber, #e0a030);
+  margin-left: 4px;
+}
+.files-btn {
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 4px 10px;
+  height: 26px;
+  font-size: 12px;
+}
+.files-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.files-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.files-save {
+  border-color: var(--accent);
+  color: var(--on-accent, #fff);
+  background: var(--accent-bg, var(--accent));
+}
+.files-body {
+  flex: 1 1 auto;
+  display: flex;
+  min-height: 0;
+}
+.files-tree {
+  flex: 0 0 clamp(200px, 24%, 340px);
+  overflow: auto;
+  border-right: 1px solid var(--border);
+  padding: 6px 0;
+}
+.files-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 3px 8px;
+  font-size: 12px;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  text-align: left;
+  white-space: nowrap;
+}
+.files-row:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.files-row.is-open {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.files-caret {
+  flex: 0 0 auto;
+  width: 10px;
+  color: var(--text-dim);
+}
+.files-icon {
+  flex: 0 0 auto;
+}
+.files-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.files-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  position: relative;
+  display: flex;
+}
+.files-editor {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+.files-editor :deep(.cm-editor) {
+  height: 100%;
+}
+.files-preview {
+  flex: 1 1 auto;
+  border: none;
+  background: #fff;
+}
+.files-msg {
+  padding: 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.files-error {
+  color: var(--err, #e0556b);
+}
+.files-empty {
+  margin: auto;
+}
+</style>

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -5,7 +5,7 @@
 // reuses the server's sandboxed md→HTML iframe. Writes go through PUT .../write, which
 // contains the path within the project root.
 import { onBeforeUnmount, onMounted, ref, computed, nextTick, watch } from "vue";
-import { useFilesView } from "../composables/useFilesView";
+import { useFilesView, filesGotoIndex } from "../composables/useFilesView";
 import { createEditor, langKindForFilename, type CmEditor } from "./cmEditor";
 
 interface Node {
@@ -162,9 +162,24 @@ function teardown(): void {
   dirty.value = false;
   showPreview.value = false;
 }
+// `reverting` marks a route change WE triggered to undo a declined root switch, so its
+// own watcher fire is ignored instead of re-prompting.
+let reverting = false;
 watch(
   [isOpen, cwd],
-  async ([open]) => {
+  async ([open, curCwd], prev) => {
+    if (reverting) {
+      reverting = false;
+      return;
+    }
+    // Root (?cwd=) changed mid-edit with unsaved changes → confirm before discarding;
+    // declining restores the previous root so the editor + buffer stay put.
+    const prevCwd = prev?.[1] ?? null;
+    if (open && curCwd !== prevCwd && !confirmDiscard()) {
+      reverting = true;
+      filesGotoIndex(prevCwd);
+      return;
+    }
     teardown();
     if (!open) return;
     await nextTick();

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -7,6 +7,7 @@ import { badgeStyleFor } from "./dirBadge";
 import { useVoiceInput } from "../composables/useVoiceInput";
 import * as conn from "../composables/useTerminalConnections";
 import RunMenu from "./RunMenu.vue";
+import { filesGotoIndex } from "../composables/useFilesView";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
@@ -231,6 +232,15 @@ onUnmounted(() => {
         </button>
         <button type="button" class="icon-btn" title="Insert a file path" aria-label="Insert a file path" @click="pickFile">
           <span class="material-symbols-outlined">attach_file</span>
+        </button>
+        <button
+          type="button"
+          class="icon-btn"
+          title="Browse & edit this project's files"
+          aria-label="Open the file explorer"
+          @click="filesGotoIndex(serverCwd)"
+        >
+          <span class="material-symbols-outlined">folder_open</span>
         </button>
       </div>
     </div>

--- a/src/components/cmEditor.spec.ts
+++ b/src/components/cmEditor.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { langKindForFilename } from "./cmEditor";
+
+describe("langKindForFilename", () => {
+  it("maps markdown extensions", () => {
+    expect(langKindForFilename("README.md")).toBe("markdown");
+    expect(langKindForFilename("notes.markdown")).toBe("markdown");
+    expect(langKindForFilename("doc.MDX")).toBe("markdown");
+  });
+  it("maps javascript/typescript extensions", () => {
+    for (const f of ["a.js", "a.jsx", "a.ts", "a.tsx", "a.mjs", "a.cjs"]) {
+      expect(langKindForFilename(f)).toBe("javascript");
+    }
+  });
+  it("maps json", () => {
+    expect(langKindForFilename("package.json")).toBe("json");
+  });
+  it("falls back to text for unknown or extension-less files", () => {
+    expect(langKindForFilename("Makefile")).toBe("text");
+    expect(langKindForFilename("LICENSE")).toBe("text");
+    expect(langKindForFilename("data.csv")).toBe("text");
+    expect(langKindForFilename(".gitignore")).toBe("text");
+  });
+});

--- a/src/components/cmEditor.ts
+++ b/src/components/cmEditor.ts
@@ -1,0 +1,71 @@
+// Thin CodeMirror 6 wrapper for the Files view's editor: build/destroy an EditorView,
+// swap the document + language when a different file is opened, and read it back on
+// save. Kept out of the .vue file so the language-by-extension logic is unit-testable
+// without a DOM.
+import { EditorView, basicSetup } from "codemirror";
+import { EditorState, Compartment, type Extension } from "@codemirror/state";
+import { markdown } from "@codemirror/lang-markdown";
+import { javascript } from "@codemirror/lang-javascript";
+import { json } from "@codemirror/lang-json";
+import { oneDark } from "@codemirror/theme-one-dark";
+
+export type LangKind = "markdown" | "javascript" | "json" | "text";
+
+// Pick a syntax mode from a filename's extension. Only the modes we bundle are
+// recognised; everything else edits as plain text.
+export function langKindForFilename(name: string): LangKind {
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return "text"; // no extension (Makefile, LICENSE, …)
+  const ext = name.slice(dot + 1).toLowerCase();
+  if (["md", "markdown", "mdx"].includes(ext)) return "markdown";
+  if (["js", "jsx", "ts", "tsx", "mjs", "cjs"].includes(ext)) return "javascript";
+  if (ext === "json") return "json";
+  return "text";
+}
+
+function langExtension(kind: LangKind): Extension {
+  if (kind === "markdown") return markdown();
+  if (kind === "javascript") return javascript({ typescript: true });
+  if (kind === "json") return json();
+  return [];
+}
+
+export interface CmEditor {
+  setDoc(text: string, filename: string): void;
+  getDoc(): string;
+  destroy(): void;
+}
+
+// `onChange` fires only on USER edits — loading a file (setDoc) is programmatic and
+// must not mark the buffer dirty, so it's suppressed with a flag.
+export function createEditor(parent: HTMLElement, onChange: () => void): CmEditor {
+  const lang = new Compartment();
+  let loading = false;
+  const view = new EditorView({
+    parent,
+    state: EditorState.create({
+      doc: "",
+      extensions: [
+        basicSetup,
+        oneDark,
+        lang.of([]),
+        EditorView.lineWrapping,
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged && !loading) onChange();
+        }),
+      ],
+    }),
+  });
+  return {
+    setDoc(text, filename) {
+      loading = true;
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: text },
+        effects: lang.reconfigure(langExtension(langKindForFilename(filename))),
+      });
+      loading = false;
+    },
+    getDoc: () => view.state.doc.toString(),
+    destroy: () => view.destroy(),
+  };
+}

--- a/src/composables/useFilesView.ts
+++ b/src/composables/useFilesView.ts
@@ -1,0 +1,27 @@
+// Navigation seam for the full-screen file explorer + editor, a thin derivation over
+// vue-router (mirrors usePrsView). The open view is the URL: /files?cwd=<project dir>.
+// A terminal header's Files button opens it rooted at that terminal's directory.
+import { computed, type ComputedRef } from "vue";
+import { router } from "../router";
+
+/** Open the Files view rooted at `cwd` (the terminal's project dir). */
+export function filesGotoIndex(cwd: string | null): void {
+  router.push({ name: "files", query: cwd ? { cwd } : {} });
+}
+
+/** Close the Files view → back to chat. */
+export function filesClose(): void {
+  router.push("/");
+}
+
+export function useFilesView(): { isOpen: ComputedRef<boolean>; cwd: ComputedRef<string | null>; close: () => void } {
+  return {
+    isOpen: computed(() => router.currentRoute.value.name === "files"),
+    // The project dir to browse — the ?cwd= query (a single string; arrays/absent => null).
+    cwd: computed(() => {
+      const q = router.currentRoute.value.query.cwd;
+      return typeof q === "string" ? q : null;
+    }),
+    close: filesClose,
+  };
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,6 +21,9 @@ export const routes: RouteRecordRaw[] = [
   { path: "/feeds/:slug", name: "feedDetail", component: Stub },
   { path: "/accounting", name: "accounting", component: Stub },
   { path: "/prs", name: "prs", component: Stub },
+  // Full-screen file explorer + editor, rooted at a project dir (?cwd=). Opened from a
+  // terminal header's Files button.
+  { path: "/files", name: "files", component: Stub },
   // Read-only wiki browser (Phase 3 of plans/feat-wiki.md). The open PAGE is the URL;
   // graph + lint are their own sub-routes, mirroring MulmoClaude's /wiki paths.
   { path: "/wiki", name: "wiki", component: Stub },

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,143 @@
   resolved "https://npm.flatt.tech/@chevrotain/types/-/types-11.1.2.tgz#e83a1a2704f0c5e49e7592b214031a0f4a34d7e5"
   integrity sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==
 
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.7.1":
+  version "6.20.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz#696b740312c6a962e14567b49a3661b5924bc5ae"
+  integrity sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.0.0":
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.10.4.tgz#64dec1bd043976eb344e3cc9d15af13b6f724bfd"
+  integrity sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.7.0"
+    "@codemirror/view" "^6.27.0"
+    "@lezer/common" "^1.1.0"
+
+"@codemirror/lang-css@^6.0.0":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.3.1.tgz#763ca41aee81bb2431be55e3cfcc7cc8e91421a3"
+  integrity sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/common" "^1.0.2"
+    "@lezer/css" "^1.1.7"
+
+"@codemirror/lang-html@^6.0.0":
+  version "6.4.11"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.11.tgz#c46ba46ae642fd567cf05c4129005d2913ac248d"
+  integrity sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.12"
+
+"@codemirror/lang-javascript@^6.0.0", "@codemirror/lang-javascript@^6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz#b9ea6b2f0383ed6895fae7888c0322541538f10a"
+  integrity sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.17.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/lang-json@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-json/-/lang-json-6.0.2.tgz#054b160671306667e25d80385286049841836179"
+  integrity sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/json" "^1.0.0"
+
+"@codemirror/lang-markdown@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz#29df87310a555b007beba8e12893363956a26e8e"
+  integrity sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.7.1"
+    "@codemirror/lang-html" "^6.0.0"
+    "@codemirror/language" "^6.3.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.2.1"
+    "@lezer/markdown" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.3.0", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0":
+  version "6.12.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.12.4.tgz#01e70fd5aa3a8a067ff1dfec75d5b6394cdfa058"
+  integrity sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.23.0"
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.9.7.tgz#841fc733674389d91fe49a1c34027ad3babdf105"
+  integrity sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.42.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.0.0":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.7.1.tgz#2523a762871d18ad982edc2d4b2fa1da483b0392"
+  integrity sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.37.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.7.0":
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.7.0.tgz#624c3504dc3d04e727dd49711fb75244e675e8e7"
+  integrity sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==
+  dependencies:
+    "@marijn/find-cluster-break" "^1.0.0"
+
+"@codemirror/theme-one-dark@^6.1.3":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz#1dbb73f6e73c53c12ad2aed9f48c263c4e63ea37"
+  integrity sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/highlight" "^1.0.0"
+
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.17.0", "@codemirror/view@^6.23.0", "@codemirror/view@^6.27.0", "@codemirror/view@^6.37.0", "@codemirror/view@^6.42.0":
+  version "6.43.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.43.4.tgz#a903200d489aa0e14406435c08e836680951ed5a"
+  integrity sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==
+  dependencies:
+    "@codemirror/state" "^6.7.0"
+    crelt "^1.0.6"
+    style-mod "^4.1.0"
+    w3c-keyname "^2.2.4"
+
 "@csstools/color-helpers@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-6.0.2.tgz#82c59fd30649cf0b4d3c82160489748666e6550b"
@@ -539,6 +676,74 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@lezer/common@^1.0.0", "@lezer/common@^1.0.2", "@lezer/common@^1.1.0", "@lezer/common@^1.2.0", "@lezer/common@^1.2.1", "@lezer/common@^1.3.0", "@lezer/common@^1.5.0":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.5.2.tgz#d6840db13779e3f1b42e70c9a97c4086d12fae22"
+  integrity sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==
+
+"@lezer/css@^1.1.0", "@lezer/css@^1.1.7":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.3.4.tgz#ba05a03d5ca114ad523aa3c0e93aff8d1e26ed70"
+  integrity sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.2.3.tgz#a20f324b71148a2ea9ba6ff42e58bbfaec702857"
+  integrity sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==
+  dependencies:
+    "@lezer/common" "^1.3.0"
+
+"@lezer/html@^1.3.12":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.13.tgz#6a1305ae3bd2c9c01f877f8a8dc1e15ec652d01c"
+  integrity sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.5.4.tgz#11746955f957d33c0933f17d7594db54a8b4beea"
+  integrity sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@lezer/json/-/json-1.0.3.tgz#e773a012ad0088fbf07ce49cfba875cc9e5bc05f"
+  integrity sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==
+  dependencies:
+    "@lezer/common" "^1.2.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.3.0":
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.4.10.tgz#b3acc36e5ad049b74ddb7719594e7e74d9161ff5"
+  integrity sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/markdown@^1.0.0":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@lezer/markdown/-/markdown-1.6.4.tgz#250d54e1c4e59e89be9329884141f76165d66327"
+  integrity sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA==
+  dependencies:
+    "@lezer/common" "^1.5.0"
+    "@lezer/highlight" "^1.0.0"
+
+"@marijn/find-cluster-break@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz#bdbe907e00c17c84e33fc51b1519d9aa211e7e8e"
+  integrity sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==
 
 "@marp-team/marp-core@^4.3.0":
   version "4.3.0"
@@ -1928,6 +2133,19 @@ cliui@^9.0.1:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
+codemirror@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.2.tgz#4d3fea1ad60b6753f97ca835f2f48c6936a8946e"
+  integrity sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -2046,6 +2264,11 @@ cose-base@^2.2.0:
   integrity sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
   dependencies:
     layout-base "^2.0.0"
+
+crelt@^1.0.5, crelt@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.7.tgz#3b441b2ddfa73161d6a2770aa4cd677f895eaf28"
+  integrity sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==
 
 cross-spawn@^7.0.5, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -4520,6 +4743,11 @@ strnum@^2.4.1:
   dependencies:
     anynum "^1.0.1"
 
+style-mod@^4.0.0, style-mod@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.3.tgz#6e9012255bb799bdac37e288f7671b5d71bf9f73"
+  integrity sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==
+
 stylis@^4.3.6:
   version "4.4.0"
   resolved "https://npm.flatt.tech/stylis/-/stylis-4.4.0.tgz#c5846c9345f4bfc51bd0cbd7ca35a0744f485a5d"
@@ -4859,6 +5087,11 @@ vuedraggable@^4.1.0:
   integrity sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==
   dependencies:
     sortablejs "1.14.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz#7b17c8c6883d4e8b86ac8aba79d39e880f8869c5"
+  integrity sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
各ターミナルヘッダの **📁 Files ボタン**から、そのターミナルの**プロジェクトディレクトリをルート**に全画面のファイルエクスプローラー（`/files?cwd=`）を開く。「claude が『〜.md ができました』の後にすぐ編集/確認」の導線。

- 左: 遅延読み込みの**階層ツリー**。右: **CodeMirror 6** エディタ（md / js・ts / json ハイライト、他はプレーンテキスト）。md は**プレビュー**トグル（サーバの sandboxed md→HTML iframe）。**Save**（⌘/Ctrl-S）で書き戻し。
- **サーバ**: `files-browse.ts`（旧 read-only ブラウザの browse ロジックを流用 ＋ 書き込み）。`GET .../list|text|md`・`PUT .../write`（すべて `?cwd=&path=`）。**全 path をプロジェクトルート内に封じ込め**（`..`/絶対パス脱出を read/write とも 403）。2 MB 上限。

## Items to Confirm / Review
- **仕様（回答どおり実装）**: エディタ=CodeMirror 6 / 導線=ヘッダの Files ボタン（cwd をルート）/ md プレビュー=既存 sandboxed iframe（`v-html` 不使用）。
- **セキュリティ**: `containedPath` で read/write とも cwd 外を 403。実サーバ e2e で `../` の list/write が 403、書き込み→読み戻し一致、md が CSP `sandbox` で配信を確認。
- **依存追加**: `codemirror` ＋ `@codemirror/{state,lang-markdown,lang-javascript,lang-json,theme-one-dark}`（ユーザー選択）。既存の巨大チャンク（mermaid/marp/katex）に比べれば小さい。
- **未対応/v1 範囲**: 外部変更の競合検知は無し（保存は上書き）。ファイル作成/削除/リネームは無し（既存ファイルの編集のみ）。バイナリ/2MB 超は編集不可（413）。
- **supersede**: 旧 read-only ヘッダーブラウザ（#116/#117・`feat/file-browser`）を置き換え。

## 目視確認（実サーバ e2e）
分離 HOME で実サーバを起動し実 HTTP で検証:
- `list`（dir 優先）→ `text` 読み取り → `write` → 読み戻し一致
- `../` の list/write → **403**（封じ込め）
- `md` → `Content-Type: text/html` ＋ `Content-Security-Policy: sandbox`、`<h1>` を含む

## User Prompt
> 182、184 を順次。（#184: 全画面ファイルエクスプローラー＋Markdown編集ビュー・terminal 連携）

決定事項（本 PR 前のやり取り）:
> - エディタ: CodeMirror 6
> - terminal→ファイル導線: ヘッダの Files ボタン（そのセルの cwd をルート）

## Tests
`files-browse.spec`（containment/list/resolveBase/mdToHtmlDoc）、`cmEditor.spec`（拡張子→言語）、`FilesOverlay.spec`（ツリー読込・ファイル open・編集→保存 PUT・ディレクトリ遅延展開・エラー）。ゲート: typecheck(client/server)/format/lint/build/**test 604** 通過。

Closes #184