### PR TITLE
fix: Settings モーダルがスクロールできず崩れる（Launch commands 追加で溢れる）

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -276,7 +276,10 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 }
 .modal {
   width: min(560px, 92vw);
-  max-height: 80vh;
+  max-height: 85vh;
+  /* Sections (theme, sound, PR repos, launch commands) can exceed the viewport —
+     scroll inside the modal so the top stays reachable instead of overflowing. */
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   background: var(--bg-base);
@@ -386,11 +389,11 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
   font-family: ui-monospace, "JetBrains Mono", monospace;
 }
 .launcher-label {
-  flex: 0 0 30%;
+  flex: 1 1 30%;
   min-width: 0;
 }
-.launcher-add {
-  flex-wrap: wrap;
+.launcher-add .repo-field {
+  min-width: 0; /* let the command field shrink instead of overflowing the row */
 }
 .launcher-cmd {
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
Settings モーダルが `max-height: 80vh` なのに **スクロール（overflow-y）が無く**、#182 の「Launch commands」セクション追加でモーダルが画面高を超え、**上部（Settings タイトル / Theme / Notification sound）が見切れて操作不能**になっていた。

- `.modal` に `overflow-y: auto`（`max-height: 85vh`）を追加 → 全セクションがモーダル内でスクロール可能に。
- Launch commands の入力行: command フィールドが縮むように（`min-width: 0`）して行の横溢れを防止。

## 目視確認（実ブラウザ / Playwright）
- 修正後の Settings モーダル: タイトル〜Launch commands まで全セクションがモーダル内に収まり操作可能（スクショ確認、modal 高 612px < viewport）。
- ランチャー e2e: Settings で `Shell`→`$SHELL` を追加 → グリッド空きセルの「⌘ Shell」ボタンで起動 → 対話 zsh が立ち上がり `echo` が動作（#182 を実 UI で初めて通し確認）。

## User Prompt
> ランチャーテストしてない。ただ、UI が崩れてた（Settings の Launch commands セクションでモーダルが崩れる）。

Refs #182