### PR TITLE
feat: Docker sandbox for the single-view Claude session (opt-in) — #202 Phase 0+1

### DIFF
--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,0 +1,29 @@
+# MulmoTerminal sandbox image: runs the interactive `claude` CLI inside a container so
+# an untrusted workspace can't touch the host. Deliberately minimal — unlike MulmoClaude
+# this image needs NO in-container MCP broker, because MulmoTerminal's GUI MCP is served
+# over HTTP by the host and reached at host.docker.internal (see docs/spawn-architecture).
+#
+# What's inside: node (for the claude CLI), curl (the activity hooks POST to the host),
+# git + ripgrep + ca-certificates (claude's built-in tools). No secrets, no host FS.
+FROM node:22-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      curl \
+      ca-certificates \
+      ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# The interactive agent CLI. Pin nothing here — a rebuild picks up the latest, matching
+# how the host runs the newest `claude`.
+RUN npm install -g @anthropic-ai/claude-code
+
+# Run as the unprivileged `node` user (uid 1000). On macOS/Windows Docker Desktop the
+# bind-mount ownership is mapped transparently; on Linux, `docker run --user <uid>:<gid>`
+# is added by the host to match (see the sandbox spawn args / Phase 5).
+USER node
+ENV HOME=/home/node
+WORKDIR /home/node/workspace
+
+# The host passes `claude ...` (with a rewritten --mcp-config / --settings) as the
+# command, so no ENTRYPOINT/CMD baked in — the container IS one claude session.

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -18,10 +18,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # how the host runs the newest `claude`.
 RUN npm install -g @anthropic-ai/claude-code
 
-# Run as the unprivileged `node` user (uid 1000). On macOS/Windows Docker Desktop the
-# bind-mount ownership is mapped transparently, so this Just Works. Linux is NOT yet
-# supported: the spawn does not pass `--user`, so bind-mounted files would be created as
-# uid 1000 (a mismatch on non-1000 hosts). Proper Linux uid handling is Phase 5 (#202).
+# Run as the unprivileged `node` user (uid 1000). On macOS Docker Desktop the bind-mount
+# ownership is mapped transparently, so this Just Works. On Linux the spawn does not pass
+# `--user`, so bind-mounted files are created as uid 1000 (a mismatch on non-1000 hosts —
+# proper uid handling is Phase 5, #202). Windows is unsupported (the host `cwd` isn't a
+# valid Linux container path) and the server falls back to the host spawn.
 USER node
 ENV HOME=/home/node
 WORKDIR /home/node/workspace

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -19,8 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN npm install -g @anthropic-ai/claude-code
 
 # Run as the unprivileged `node` user (uid 1000). On macOS/Windows Docker Desktop the
-# bind-mount ownership is mapped transparently; on Linux, `docker run --user <uid>:<gid>`
-# is added by the host to match (see the sandbox spawn args / Phase 5).
+# bind-mount ownership is mapped transparently, so this Just Works. Linux is NOT yet
+# supported: the spawn does not pass `--user`, so bind-mounted files would be created as
+# uid 1000 (a mismatch on non-1000 hosts). Proper Linux uid handling is Phase 5 (#202).
 USER node
 ENV HOME=/home/node
 WORKDIR /home/node/workspace

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -18,11 +18,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # how the host runs the newest `claude`.
 RUN npm install -g @anthropic-ai/claude-code
 
-# Run as the unprivileged `node` user (uid 1000). On macOS Docker Desktop the bind-mount
-# ownership is mapped transparently, so this Just Works. On Linux the spawn does not pass
-# `--user`, so bind-mounted files are created as uid 1000 (a mismatch on non-1000 hosts —
-# proper uid handling is Phase 5, #202). Windows is unsupported (the host `cwd` isn't a
-# valid Linux container path) and the server falls back to the host spawn.
+# Run as the unprivileged `node` user (uid 1000). Phase 1 is macOS-only: Docker Desktop
+# maps bind-mount ownership transparently there. The server gates the sandbox off on Linux
+# (no `--user` yet → uid-1000 ownership mismatch) and Windows (host paths aren't valid
+# Linux container paths), falling back to the host spawn — see Phase 5 (#202).
 USER node
 ENV HOME=/home/node
 WORKDIR /home/node/workspace

--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ and stays logged in, and transcripts interoperate with host sessions), so those 
 paths stay mutable from inside. The sandbox is **non-persistent** (the container is
 `--rm`, tied to the session), **opt-in and single-view only** — the grid keeps its host +
 tmux path, and with the flag unset (or Docker unavailable) everything runs on the host
-exactly as before. **macOS/Windows Docker Desktop only** for now (Linux uid mapping is not
-yet handled). Adding arbitrary user MCP servers to the sandbox is in progress (see #202).
+exactly as before. Verified on **macOS**; Linux should work but bind-mounted files are
+owned by the container's uid (uid mapping is a follow-up); **Windows is unsupported** (the
+same-path bind mount yields a non-POSIX container path) and falls back to the host spawn.
+Adding arbitrary user MCP servers to the sandbox is in progress (see #202).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ and stays logged in, and transcripts interoperate with host sessions), so those 
 paths stay mutable from inside. The sandbox is **non-persistent** (the container is
 `--rm`, tied to the session), **opt-in and single-view only** — the grid keeps its host +
 tmux path, and with the flag unset (or Docker unavailable) everything runs on the host
-exactly as before. Verified on **macOS**; Linux should work but bind-mounted files are
-owned by the container's uid (uid mapping is a follow-up); **Windows is unsupported** (the
-same-path bind mount yields a non-POSIX container path) and falls back to the host spawn.
-Adding arbitrary user MCP servers to the sandbox is in progress (see #202).
+exactly as before. **macOS only** for now — on Linux (bind-mount uid ownership) and
+Windows (host paths aren't valid Linux container paths) it falls back to the host spawn;
+both are follow-ups. Adding arbitrary user MCP servers to the sandbox is in progress
+(see #202).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,23 @@ survive (tmux itself is gone). Command-cell scripts are ephemeral and not persis
 
 ---
 
+## Docker sandbox (experimental, single view)
+
+Set **`MULMOTERMINAL_SANDBOX=1`** (and have Docker running) to run the **single-view**
+Claude session inside a container instead of on the host — an untrusted workspace can't
+touch the host, while Claude still reaches the app's GUI MCP + activity hooks over
+`host.docker.internal`. Build the image first: `docker build -f Dockerfile.sandbox -t
+mulmoterminal-sandbox .` (override the name with `MULMOTERMINAL_SANDBOX_IMAGE`).
+
+The workspace and `~/.claude` are bind-mounted (so Claude is logged in and transcripts
+interoperate with host sessions); the sandbox is **non-persistent** (the container is
+`--rm`, tied to the session). It's **opt-in and single-view only** — the grid keeps its
+host + tmux path, and with the flag unset (or Docker unavailable) everything runs on the
+host exactly as before. Adding arbitrary user MCP servers to the sandbox is in progress
+(see #202).
+
+---
+
 ## Tech stack
 
 | Layer    | Technology |

--- a/README.md
+++ b/README.md
@@ -139,17 +139,20 @@ survive (tmux itself is gone). Command-cell scripts are ephemeral and not persis
 ## Docker sandbox (experimental, single view)
 
 Set **`MULMOTERMINAL_SANDBOX=1`** (and have Docker running) to run the **single-view**
-Claude session inside a container instead of on the host — an untrusted workspace can't
-touch the host, while Claude still reaches the app's GUI MCP + activity hooks over
-`host.docker.internal`. Build the image first: `docker build -f Dockerfile.sandbox -t
-mulmoterminal-sandbox .` (override the name with `MULMOTERMINAL_SANDBOX_IMAGE`).
+Claude session inside a container instead of on the host, while Claude still reaches the
+app's GUI MCP + activity hooks over `host.docker.internal`. Build the image first:
+`docker build -f Dockerfile.sandbox -t mulmoterminal-sandbox .` (override the name with
+`MULMOTERMINAL_SANDBOX_IMAGE`).
 
-The workspace and `~/.claude` are bind-mounted (so Claude is logged in and transcripts
-interoperate with host sessions); the sandbox is **non-persistent** (the container is
-`--rm`, tied to the session). It's **opt-in and single-view only** — the grid keeps its
-host + tmux path, and with the flag unset (or Docker unavailable) everything runs on the
-host exactly as before. Adding arbitrary user MCP servers to the sandbox is in progress
-(see #202).
+This **contains** Claude — it can't reach the host filesystem outside the mounts, host
+processes, or arbitrary host ports. It is **not full isolation**: the **workspace** and
+**`~/.claude`** are bind-mounted **read-write** by design (so Claude edits your project
+and stays logged in, and transcripts interoperate with host sessions), so those specific
+paths stay mutable from inside. The sandbox is **non-persistent** (the container is
+`--rm`, tied to the session), **opt-in and single-view only** — the grid keeps its host +
+tmux path, and with the flag unset (or Docker unavailable) everything runs on the host
+exactly as before. **macOS/Windows Docker Desktop only** for now (Linux uid mapping is not
+yet handled). Adding arbitrary user MCP servers to the sandbox is in progress (see #202).
 
 ---
 

--- a/plans/feat-202-docker-sandbox-mcp.md
+++ b/plans/feat-202-docker-sandbox-mcp.md
@@ -1,0 +1,47 @@
+# feat-202: 対話しながら任意 MCP を追加して sandbox で動かす（MulmoClaude 相当）
+
+Issue: #202
+
+## 決定スコープ（ユーザー確認済み）
+- **Docker sandbox + user-MCP は single view の Claude セッション専用**（`attachGuiMcp=true`）。grid（`?gui=0` dev terminal / launcher）は対象外。
+- **tmux 永続化は grid 専用**。docker と tmux は**排他**な spawn ラッパ。single-view sandbox は docker（`--rm`・**非永続**、pty に紐づく）。
+- 会話中の MCP 追加の反映 = **同 session id で `--resume` 再 spawn**。
+- **opt-in・既定 OFF**（未設定なら現状どおり host で claude 起動）。まず対象 CLI は `claude` のみ。
+
+## 現状把握（両リポ精読済み）
+- 追い風: spawn 抽象 `ptySpawn`(`index.ts:1510`) が既にある（tmux を差し込んだのと同じ挿入点に docker を追加）。GUI MCP は既に **HTTP**（`/api/mcp/<id>`, `broker.ts:23` が「後で docker から到達できるように HTTP」と明記）＝ stdio broker 不要、**URL rewrite だけ**。config 追加型（`prRepos`/`launchers`）が確立。
+- host 前提の loopback は2箇所: hook `curl http://localhost:PORT/api/hook`(`index.ts:603`) と MCP `http://127.0.0.1:PORT/api/mcp/<id>`(`index.ts:630`) → sandbox 時 `host.docker.internal` に rewrite。`~/.claude`(resume/transcript, `index.ts:638`) と cwd を bind mount。
+- MulmoClaude 参照: `docker run --rm -i`(headless stream-json, 1msg1spawn) / stdio broker→host `/api/*` / `rewriteLocalhostForDocker`(`config.ts:116`) / stdio は既定 drop・opt-in `hostExecInDocker`(supergateway) / per-session mcp-config を workspace 直下に書く / credentials allowlist（gh/gitconfig, SSH agent）。
+
+## 段階タスク（各段で動作確認）
+
+### Phase 0 — 手動再現スパイク（低リスク・de-risk）※Docker daemon 要
+- `Dockerfile.sandbox`（`node:22-slim` + `claude` + `curl`(hook) + `git`/`ripgrep`）。MulmoTerminal は GUI MCP が host の HTTP なので broker source 不要＝MulmoClaude より小さい。
+- `scripts/sandbox-repro.sh`: image build → host で MulmoTerminal 起動想定 → `.session-token`/PORT を用意 → cwd + `~/.claude` を mount して `docker run --rm -it mulmoterminal-sandbox claude --mcp-config <host.docker.internal に rewrite> --settings <hook rewrite>` を起動。
+- **完了条件**: container の claude REPL で `/mcp` に mulmoterminal-gui = connected、UI の状態ドットが hook で更新。
+
+### Phase 1 — sandbox spawn（opt-in・single view）
+- `server/sandbox.ts`(新): `sandboxEnabled()`(env/config), `buildDockerRunArgs(sessionId, claudeArgs, cwd, token, port)`（mounts / env / `--add-host`(linux) / image / `claude` ...）, `rewriteLoopbackForDocker(url)`（`localhost|127.0.0.1`→`host.docker.internal`）。
+- `ptySpawn` に sandbox 分岐: `spawnClaudePty` が `sandbox = sandboxEnabled() && attachGuiMcp`（=single view）を判定 → docker ラッパ（tmux はスキップ）。
+- `mcpConfigJson`/`hookSettingsJson` を sandbox 時 rewrite。session token を mount/env で container に渡し `/api/*`・`/api/hook`・`/api/mcp` を認証（既存 token 機構に合わせる）。
+- **完了条件**: 対話 Claude セルがコンテナ内で動き、GUI MCP・状態・`--resume` が動作。
+
+### Phase 2 — user HTTP MCP 管理
+- `app-config.ts`: `userMcpServers: {id,url,headers?}[]` ＋ `sanitizeUserMcp`（launchers と同型）。`config-routes.ts` GET/POST ＋ `getUserMcpServers()`。
+- `mcpConfigJson` に GUI MCP と並べてマージ（`--strict-mcp-config` は維持）。sandbox 時 URL rewrite。
+- Settings UI に「MCP servers」エディタ（追加/削除）。
+- **完了条件**: HTTP MCP を追加 → sandbox の Claude がその tool を呼べる。
+
+### Phase 3 — 会話中の追加＋reload
+- 追加/削除 → session の mcp-config 書換 → **同 id で `--resume` 再 spawn**（tmux/docker ラッパ経由）。UI に「Apply / Reload MCP」。
+- **完了条件**: 会話中に MCP を足す → 次ターンで使える（会話継続）。
+
+### Phase 4 —（後回し可）user stdio MCP: `hostExecInDocker` 相当 + supergateway shim。
+### Phase 5 —（後回し可）credentials allowlist（gh/gitconfig, SSH agent forward）。
+
+MVP = Phase 0→1→2→3。
+
+## 要判断（Phase 1 着手時）
+- session token 機構の詳細（既存の `.session-token`/認証があるか要確認）。
+- image のビルド/配布（初回 `docker build` か publish/pull か）。
+- non-docker（sandbox OFF）は現状 host 起動を完全維持。

--- a/scripts/sandbox-repro.sh
+++ b/scripts/sandbox-repro.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Phase 0 manual reproduction for feat-202 (#202): run the interactive `claude` CLI
+# inside the MulmoTerminal sandbox image and confirm it reaches the HOST's GUI MCP +
+# activity hooks over host.docker.internal — the exact boundary the full feature
+# automates. This lets us debug the container/host wiring before touching server code.
+#
+# Prereqs:
+#   - Docker running.
+#   - The MulmoTerminal server running on the host at $PORT (e.g. `yarn dev` or a build).
+#
+# Usage: PORT=34567 WORKSPACE="$PWD" scripts/sandbox-repro.sh
+set -euo pipefail
+
+PORT="${PORT:-34567}"
+WORKSPACE="${WORKSPACE:-$PWD}"
+SESSION_ID="${SESSION_ID:-00000000-0000-4000-8000-000000000000}"
+IMAGE="mulmoterminal-sandbox"
+HOST="host.docker.internal"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# 1. Build the sandbox image if it isn't present.
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "[repro] building $IMAGE ..."
+  docker build -f "$REPO_ROOT/Dockerfile.sandbox" -t "$IMAGE" "$REPO_ROOT"
+fi
+
+# 2. Rewrite the two host-loopback configs (MCP + hooks) to reach the host from inside
+#    the container. These mirror mcpConfigJson()/hookSettingsJson() in server/index.ts,
+#    with localhost/127.0.0.1 → host.docker.internal.
+CFG_DIR="$(mktemp -d)"
+trap 'rm -rf "$CFG_DIR"' EXIT
+
+cat > "$CFG_DIR/mcp.json" <<JSON
+{ "mcpServers": { "mulmoterminal-gui": { "type": "http", "url": "http://$HOST:$PORT/api/mcp/$SESSION_ID" } } }
+JSON
+
+HOOK_CMD="curl -s -X POST http://$HOST:$PORT/api/hook -H 'content-type: application/json' -d @- >/dev/null 2>&1"
+ENTRY="$(jq -n --arg c "$HOOK_CMD" '[{hooks:[{type:"command",command:$c}]}]')"
+TOOL="$(jq -n --arg c "$HOOK_CMD" '[{matcher:"",hooks:[{type:"command",command:$c}]}]')"
+jq -n --argjson e "$ENTRY" --argjson t "$TOOL" \
+  '{hooks:{UserPromptSubmit:$e,Stop:$e,Notification:$e,PreToolUse:$t,PostToolUse:$t,PostToolUseFailure:$t}}' \
+  > "$CFG_DIR/settings.json"
+
+# 3. claude auth/config lives on the host — mount it read/write so the sandboxed CLI is
+#    logged in and writes its transcript back. ~/.claude.json is optional (version-dependent).
+CLAUDE_JSON_MOUNT=()
+[ -f "$HOME/.claude.json" ] && CLAUDE_JSON_MOUNT=(-v "$HOME/.claude.json:/home/node/.claude.json")
+
+echo "[repro] MCP    → http://$HOST:$PORT/api/mcp/$SESSION_ID"
+echo "[repro] hooks  → http://$HOST:$PORT/api/hook"
+echo "[repro] mounts: $WORKSPACE → /home/node/workspace ; ~/.claude ; configs (ro)"
+echo "[repro] In the REPL: run '/mcp' and confirm mulmoterminal-gui shows 'connected',"
+echo "[repro] then send a message and watch the host UI's activity dot update via hooks."
+
+# 4. Run interactive claude in the sandbox. --add-host is required on Linux and harmless
+#    on macOS/Windows Docker Desktop (where host.docker.internal already resolves).
+docker run --rm -it \
+  --add-host "host.docker.internal:host-gateway" \
+  -e HOME=/home/node \
+  -v "$WORKSPACE:/home/node/workspace" \
+  -v "$HOME/.claude:/home/node/.claude" \
+  "${CLAUDE_JSON_MOUNT[@]}" \
+  -v "$CFG_DIR:/home/node/.mt-cfg:ro" \
+  -w /home/node/workspace \
+  "$IMAGE" \
+  claude \
+    --session-id "$SESSION_ID" \
+    --settings /home/node/.mt-cfg/settings.json \
+    --mcp-config /home/node/.mt-cfg/mcp.json \
+    --strict-mcp-config \
+    --allowedTools "mcp__mulmoterminal-gui" \
+    --permission-mode "${CLAUDE_PERMISSION_MODE:-auto}"

--- a/scripts/sandbox-repro.sh
+++ b/scripts/sandbox-repro.sh
@@ -21,7 +21,9 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # 1. Build the sandbox image if it isn't present.
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
   echo "[repro] building $IMAGE ..."
-  docker build -f "$REPO_ROOT/Dockerfile.sandbox" -t "$IMAGE" "$REPO_ROOT"
+  # --load: with the buildx container driver (Docker's default) the result otherwise
+  # stays in the build cache and never lands in the local image store.
+  docker build --load -f "$REPO_ROOT/Dockerfile.sandbox" -t "$IMAGE" "$REPO_ROOT"
 fi
 
 # 2. Rewrite the two host-loopback configs (MCP + hooks) to reach the host from inside

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,6 +18,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes, getPrRepos, getLaunchers } from "./config-routes.js";
 import { mountFilesBrowseRoutes } from "./files-browse.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "./tmux.js";
+import { sandboxEnabled, dockerAvailable, buildDockerRunArgs, removeSandboxContainer, SANDBOX_HOST } from "./sandbox.js";
 import { listPrsAcrossRepos } from "./prs.js";
 import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
@@ -70,6 +71,9 @@ interface PtyEntry {
   // True when `term` is a tmux client (persistent): killing it only detaches, so reap
   // must kill the tmux session to actually end the program.
   tmux?: boolean;
+  // True when `term` is a `docker run` client (single-view sandbox): reap force-removes
+  // the container, since killing the client alone can leave it running.
+  sandbox?: boolean;
 }
 
 interface KnownSession {
@@ -543,6 +547,8 @@ function reap(id: string) {
   // explicit close / idle reap actually stops the program (no orphan within a live
   // server). A server crash never runs this, so sessions survive that (the point).
   if (entry.tmux) tmuxKillSession(id);
+  // A sandbox container likewise outlives its killed `docker run` client — force-remove it.
+  if (entry.sandbox) removeSandboxContainer(id);
   pubsub?.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed" });
 }
 
@@ -599,8 +605,8 @@ function setWaiting(id: string, waiting: boolean, event?: string) {
 // per-session tool-call history that the GUI's tools pane shows. A failed tool
 // fires PostToolUseFailure (NOT PostToolUse), so we register both to complete the
 // entry either way — otherwise a failed call would stay stuck on "running".
-function hookSettingsJson() {
-  const cmd = `curl -s -X POST http://localhost:${PORT}/api/hook ` + `-H 'content-type: application/json' -d @- >/dev/null 2>&1`;
+function hookSettingsJson(host: string = "localhost") {
+  const cmd = `curl -s -X POST http://${host}:${PORT}/api/hook ` + `-H 'content-type: application/json' -d @- >/dev/null 2>&1`;
   const entry = [{ hooks: [{ type: "command", command: cmd }] }];
   // Tool hooks take a matcher; "" matches all tools.
   const toolEntry = [{ matcher: "", hooks: [{ type: "command", command: cmd }] }];
@@ -622,12 +628,12 @@ function hookSettingsJson() {
 // needed — the agent just makes an HTTP call back to this server. Using
 // 127.0.0.1 (not localhost) avoids an IPv6/IPv4 resolution mismatch against the
 // server's listen address.
-function mcpConfigJson(sessionId: string) {
+function mcpConfigJson(sessionId: string, host: string = "127.0.0.1") {
   return JSON.stringify({
     mcpServers: {
       "mulmoterminal-gui": {
         type: "http",
-        url: `http://127.0.0.1:${PORT}/api/mcp/${sessionId}`,
+        url: `http://${host}:${PORT}/api/mcp/${sessionId}`,
       },
     },
   });
@@ -1529,27 +1535,39 @@ function spawnClaudePty(
   // Only --resume when the session has an on-disk transcript — claude doesn't write
   // a session's .jsonl until its first prompt, so a started-but-unused session can't
   // be resumed; we restart fresh (reusing the id via --session-id) instead.
+  // Sandbox only the SINGLE-VIEW interactive session: attachGuiMcp=true excludes grid
+  // dev terminals (?gui=0), and ws!==null excludes hidden background/translation workers.
+  // Falls back to the host spawn if the Docker daemon isn't reachable.
+  const sandbox = sandboxEnabled() && attachGuiMcp && ws !== null && dockerAvailable();
   const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
   const args = buildClaudeArgs({
     sessionId,
     resume,
     canResume,
-    settings: hookSettingsJson(),
+    // In the sandbox the hooks + GUI MCP are reached over host.docker.internal.
+    settings: hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost"),
     permissionMode: CLAUDE_PERMISSION_MODE,
     attachGuiMcp,
-    mcpConfig: mcpConfigJson(sessionId),
+    mcpConfig: mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1"),
     guiMcpTools: GUI_MCP_TOOLS,
     initialPrompt,
   });
 
   console.log(`[ws] client connected (${canResume ? "resume" : "new"} ${sessionId})`);
 
-  // Persistent: a live tmux session for this id (survived a restart) is reattached and
-  // the args above are ignored; otherwise it's created running claude with them.
-  const { term, tmux } = ptySpawn(sessionId, CLAUDE_BIN, args, cwd, true);
-  console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);
-
-  const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux };
+  // Sandbox → run claude inside a fresh container (no tmux). Otherwise the host path:
+  // a live tmux session for this id (survived a restart) reattaches; else create it.
+  let entry: PtyEntry;
+  if (sandbox) {
+    removeSandboxContainer(sessionId); // clear any stale container with this name
+    const term = spawnPty("docker", buildDockerRunArgs(sessionId, args, cwd), cwd);
+    console.log(`[pty] spawned claude (pid=${term.pid} via docker sandbox) in ${cwd}`);
+    entry = { term, ws, buffer: "", cwd, sandbox: true };
+  } else {
+    const { term, tmux } = ptySpawn(sessionId, CLAUDE_BIN, args, cwd, true);
+    console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);
+    entry = { term, ws, buffer: "", cwd, tmux };
+  }
   ptys.set(sessionId, entry);
 
   if (!canResume) {
@@ -1586,7 +1604,7 @@ function spawnClaudePty(
   if (draftText) setTimeout(typeDraft, DRAFT_FALLBACK_MS);
 
   // PTY -> browser (buffering a bounded tail for reattach).
-  term.onData((data) => {
+  entry.term.onData((data) => {
     entry.buffer = (entry.buffer + data).slice(-OUTPUT_BUFFER_LIMIT);
     if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
       entry.ws.send(JSON.stringify({ type: "output", data }));
@@ -1602,7 +1620,7 @@ function spawnClaudePty(
     }
   });
 
-  term.onExit(({ exitCode, signal }) => {
+  entry.term.onExit(({ exitCode, signal }) => {
     console.log(`[pty] exited code=${exitCode} signal=${signal}`);
     if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
       entry.ws.send(JSON.stringify({ type: "exit", exitCode, signal }));
@@ -1961,6 +1979,13 @@ server.listen(PORT, () => {
     console.log(`[tmux] persistence on${detail}`);
   } else {
     console.log("[tmux] not found — terminals are not persistent across a server restart");
+  }
+  if (sandboxEnabled()) {
+    console.log(
+      dockerAvailable()
+        ? "[sandbox] on — single-view Claude runs in a Docker container"
+        : "[sandbox] MULMOTERMINAL_SANDBOX set but Docker daemon unreachable — using host spawn",
+    );
   }
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,7 +18,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes, getPrRepos, getLaunchers } from "./config-routes.js";
 import { mountFilesBrowseRoutes } from "./files-browse.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "./tmux.js";
-import { sandboxEnabled, dockerAvailable, buildDockerRunArgs, removeSandboxContainer, SANDBOX_HOST } from "./sandbox.js";
+import { sandboxEnabled, dockerAvailable, buildDockerRunArgs, writeSandboxClaudeConfig, cleanupSandbox, SANDBOX_HOST } from "./sandbox.js";
 import { listPrsAcrossRepos } from "./prs.js";
 import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
@@ -547,8 +547,9 @@ function reap(id: string) {
   // explicit close / idle reap actually stops the program (no orphan within a live
   // server). A server crash never runs this, so sessions survive that (the point).
   if (entry.tmux) tmuxKillSession(id);
-  // A sandbox container likewise outlives its killed `docker run` client — force-remove it.
-  if (entry.sandbox) removeSandboxContainer(id);
+  // A sandbox container likewise outlives its killed `docker run` client — force-remove
+  // it (and drop the throwaway per-session config).
+  if (entry.sandbox) cleanupSandbox(id);
   pubsub?.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed" });
 }
 
@@ -1559,8 +1560,9 @@ function spawnClaudePty(
   // a live tmux session for this id (survived a restart) reattaches; else create it.
   let entry: PtyEntry;
   if (sandbox) {
-    removeSandboxContainer(sessionId); // clear any stale container with this name
-    const term = spawnPty("docker", buildDockerRunArgs(sessionId, args, cwd), cwd);
+    cleanupSandbox(sessionId); // clear any stale container/config with this name
+    const claudeConfig = writeSandboxClaudeConfig(sessionId, cwd);
+    const term = spawnPty("docker", buildDockerRunArgs(sessionId, args, cwd, claudeConfig), cwd);
     console.log(`[pty] spawned claude (pid=${term.pid} via docker sandbox) in ${cwd}`);
     entry = { term, ws, buffer: "", cwd, sandbox: true };
   } else {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1992,7 +1992,7 @@ server.listen(PORT, () => {
   }
   if (sandboxEnabled()) {
     if (!sandboxPlatformSupported()) {
-      console.log("[sandbox] MULMOTERMINAL_SANDBOX set but Windows is unsupported — using host spawn");
+      console.log("[sandbox] MULMOTERMINAL_SANDBOX set but only supported on macOS for now — using host spawn");
     } else {
       console.log(
         dockerAvailable()

--- a/server/index.ts
+++ b/server/index.ts
@@ -18,7 +18,15 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes, getPrRepos, getLaunchers } from "./config-routes.js";
 import { mountFilesBrowseRoutes } from "./files-browse.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "./tmux.js";
-import { sandboxEnabled, dockerAvailable, buildDockerRunArgs, writeSandboxClaudeConfig, cleanupSandbox, SANDBOX_HOST } from "./sandbox.js";
+import {
+  sandboxEnabled,
+  sandboxPlatformSupported,
+  dockerAvailable,
+  buildDockerRunArgs,
+  writeSandboxClaudeConfig,
+  cleanupSandbox,
+  SANDBOX_HOST,
+} from "./sandbox.js";
 import { listPrsAcrossRepos } from "./prs.js";
 import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
@@ -1539,7 +1547,7 @@ function spawnClaudePty(
   // Sandbox only the SINGLE-VIEW interactive session: attachGuiMcp=true excludes grid
   // dev terminals (?gui=0), and ws!==null excludes hidden background/translation workers.
   // Falls back to the host spawn if the Docker daemon isn't reachable.
-  const sandbox = sandboxEnabled() && attachGuiMcp && ws !== null && dockerAvailable();
+  const sandbox = sandboxEnabled() && sandboxPlatformSupported() && attachGuiMcp && ws !== null && dockerAvailable();
   const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
   const args = buildClaudeArgs({
     sessionId,
@@ -1983,11 +1991,15 @@ server.listen(PORT, () => {
     console.log("[tmux] not found — terminals are not persistent across a server restart");
   }
   if (sandboxEnabled()) {
-    console.log(
-      dockerAvailable()
-        ? "[sandbox] on — single-view Claude runs in a Docker container"
-        : "[sandbox] MULMOTERMINAL_SANDBOX set but Docker daemon unreachable — using host spawn",
-    );
+    if (!sandboxPlatformSupported()) {
+      console.log("[sandbox] MULMOTERMINAL_SANDBOX set but Windows is unsupported — using host spawn");
+    } else {
+      console.log(
+        dockerAvailable()
+          ? "[sandbox] on — single-view Claude runs in a Docker container"
+          : "[sandbox] MULMOTERMINAL_SANDBOX set but Docker daemon unreachable — using host spawn",
+      );
+    }
   }
 });
 

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { rewriteLoopbackForDocker, sandboxContainerName, sandboxEnabled, buildDockerRunArgs } from "./sandbox";
+import {
+  rewriteLoopbackForDocker,
+  sandboxContainerName,
+  sandboxEnabled,
+  buildDockerRunArgs,
+  writeSandboxClaudeConfig,
+  sandboxClaudeConfigPath,
+} from "./sandbox";
 
 describe("rewriteLoopbackForDocker", () => {
   it("rewrites localhost / 127.0.0.1 to host.docker.internal", () => {
@@ -10,8 +18,8 @@ describe("rewriteLoopbackForDocker", () => {
     expect(rewriteLoopbackForDocker("https://localhost/x")).toBe("https://host.docker.internal/x");
   });
   it("leaves non-loopback hosts untouched", () => {
-    expect(rewriteLoopbackForDocker("http://example.com:34567/x")).toBe("http://example.com:34567/x");
-    expect(rewriteLoopbackForDocker("http://localhostfoo.com/x")).toBe("http://localhostfoo.com/x"); // lookahead guard
+    expect(rewriteLoopbackForDocker("https://example.com:34567/x")).toBe("https://example.com:34567/x");
+    expect(rewriteLoopbackForDocker("https://localhostfoo.com/x")).toBe("https://localhostfoo.com/x"); // lookahead guard
   });
 });
 
@@ -40,22 +48,36 @@ describe("sandboxEnabled", () => {
 });
 
 describe("buildDockerRunArgs", () => {
-  const args = buildDockerRunArgs("sid1", ["--session-id", "sid1", "--mcp-config", "/x.json"], "/Users/me/proj");
+  const args = buildDockerRunArgs("sid1", ["--session-id", "sid1", "--mcp-config", "/x.json"], "/Users/me/proj", "/cfg/x.json");
 
   it("runs the sandbox image with claude + its args after the image", () => {
     const img = args.indexOf("mulmoterminal-sandbox");
     expect(img).toBeGreaterThan(0);
     expect(args.slice(img + 1)).toEqual(["claude", "--session-id", "sid1", "--mcp-config", "/x.json"]);
   });
-  it("is an --rm -it named container with host-gateway and HOME", () => {
+  it("is an --rm -it named container with host-gateway, HOME, and DISABLE_AUTOUPDATER", () => {
     expect(args.slice(0, 3)).toEqual(["run", "--rm", "-it"]);
     expect(args[args.indexOf("--name") + 1]).toBe("mulmoterminal-sid1");
     expect(args).toContain("host.docker.internal:host-gateway");
-    expect(args[args.indexOf("-e") + 1]).toBe("HOME=/home/node");
+    expect(args).toContain("HOME=/home/node");
+    expect(args).toContain("DISABLE_AUTOUPDATER=1");
   });
-  it("bind-mounts cwd at its SAME path (transcript encoding parity) + ~/.claude, and -w cwd", () => {
+  it("mounts cwd at its SAME path + ~/.claude (auth) + the generated config, and -w cwd", () => {
     expect(args).toContain("/Users/me/proj:/Users/me/proj");
     expect(args).toContain(`${path.join(os.homedir(), ".claude")}:/home/node/.claude`);
+    expect(args).toContain("/cfg/x.json:/home/node/.claude.json"); // the generated config, NOT host ~/.claude.json
     expect(args[args.indexOf("-w") + 1]).toBe("/Users/me/proj");
+  });
+});
+
+describe("writeSandboxClaudeConfig", () => {
+  const sid = "cfg-test-1";
+  afterEach(() => rmSync(sandboxClaudeConfigPath(sid), { force: true }));
+  it("writes onboarding-done + the cwd pre-trusted (no host ~/.claude.json needed)", () => {
+    const file = writeSandboxClaudeConfig(sid, "/Users/me/proj");
+    const cfg = JSON.parse(readFileSync(file, "utf8"));
+    expect(cfg.hasCompletedOnboarding).toBe(true);
+    expect(cfg.projects["/Users/me/proj"]).toMatchObject({ hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true });
+    expect(cfg.installMethod).toBeUndefined(); // no `native` install → no "missing or broken" warning
   });
 });

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { rewriteLoopbackForDocker, sandboxContainerName, sandboxEnabled, buildDockerRunArgs } from "./sandbox";
+
+describe("rewriteLoopbackForDocker", () => {
+  it("rewrites localhost / 127.0.0.1 to host.docker.internal", () => {
+    expect(rewriteLoopbackForDocker("http://localhost:34567/api/hook")).toBe("http://host.docker.internal:34567/api/hook");
+    expect(rewriteLoopbackForDocker("http://127.0.0.1:34567/api/mcp/x")).toBe("http://host.docker.internal:34567/api/mcp/x");
+    expect(rewriteLoopbackForDocker("https://localhost/x")).toBe("https://host.docker.internal/x");
+  });
+  it("leaves non-loopback hosts untouched", () => {
+    expect(rewriteLoopbackForDocker("http://example.com:34567/x")).toBe("http://example.com:34567/x");
+    expect(rewriteLoopbackForDocker("http://localhostfoo.com/x")).toBe("http://localhostfoo.com/x"); // lookahead guard
+  });
+});
+
+describe("sandboxContainerName", () => {
+  it("prefixes the session id", () => {
+    expect(sandboxContainerName("abc-123")).toBe("mulmoterminal-abc-123");
+  });
+});
+
+describe("sandboxEnabled", () => {
+  const prev = process.env.MULMOTERMINAL_SANDBOX;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.MULMOTERMINAL_SANDBOX;
+    else process.env.MULMOTERMINAL_SANDBOX = prev;
+  });
+  it("is off by default, on for 1/true", () => {
+    delete process.env.MULMOTERMINAL_SANDBOX;
+    expect(sandboxEnabled()).toBe(false);
+    process.env.MULMOTERMINAL_SANDBOX = "1";
+    expect(sandboxEnabled()).toBe(true);
+    process.env.MULMOTERMINAL_SANDBOX = "true";
+    expect(sandboxEnabled()).toBe(true);
+    process.env.MULMOTERMINAL_SANDBOX = "0";
+    expect(sandboxEnabled()).toBe(false);
+  });
+});
+
+describe("buildDockerRunArgs", () => {
+  const args = buildDockerRunArgs("sid1", ["--session-id", "sid1", "--mcp-config", "/x.json"], "/Users/me/proj");
+
+  it("runs the sandbox image with claude + its args after the image", () => {
+    const img = args.indexOf("mulmoterminal-sandbox");
+    expect(img).toBeGreaterThan(0);
+    expect(args.slice(img + 1)).toEqual(["claude", "--session-id", "sid1", "--mcp-config", "/x.json"]);
+  });
+  it("is an --rm -it named container with host-gateway and HOME", () => {
+    expect(args.slice(0, 3)).toEqual(["run", "--rm", "-it"]);
+    expect(args[args.indexOf("--name") + 1]).toBe("mulmoterminal-sid1");
+    expect(args).toContain("host.docker.internal:host-gateway");
+    expect(args[args.indexOf("-e") + 1]).toBe("HOME=/home/node");
+  });
+  it("bind-mounts cwd at its SAME path (transcript encoding parity) + ~/.claude, and -w cwd", () => {
+    expect(args).toContain("/Users/me/proj:/Users/me/proj");
+    expect(args).toContain(`${path.join(os.homedir(), ".claude")}:/home/node/.claude`);
+    expect(args[args.indexOf("-w") + 1]).toBe("/Users/me/proj");
+  });
+});

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -6,7 +6,7 @@
 // Verified in Phase 0 (#202): a sandboxed claude authenticates via the mounted ~/.claude
 // and connects to the host GUI MCP over host.docker.internal.
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { writeFileSync, rmSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -44,21 +44,50 @@ export function dockerAvailable(): boolean {
   return cachedDockerOk;
 }
 
-// Best-effort remove a sandbox container (clear a stale one before spawn, or on reap —
-// killing the `docker run` client alone can leave the container behind).
-export function removeSandboxContainer(sessionId: string): void {
+// A per-session ~/.claude.json for the container. We deliberately do NOT mount the
+// host's ~/.claude.json: it records a `native` install at ~/.local/bin (which doesn't
+// exist in the container, so claude warns "missing or broken"), and mounting it
+// read-write would let the container mutate the user's global config. Instead we mount
+// auth via ~/.claude/.credentials.json (the dir) and a minimal generated config that
+// marks onboarding done and pre-trusts the workspace (so no theme / trust prompts).
+// Under the app's own (user-owned) home, not a world-writable temp dir.
+const SANDBOX_DIR = path.join(os.homedir(), ".mulmoterminal", "sandbox");
+export function sandboxClaudeConfigPath(sessionId: string): string {
+  return path.join(SANDBOX_DIR, `claude-${sessionId}.json`);
+}
+
+export function writeSandboxClaudeConfig(sessionId: string, cwd: string): string {
+  mkdirSync(SANDBOX_DIR, { recursive: true });
+  const file = sandboxClaudeConfigPath(sessionId);
+  const config = {
+    hasCompletedOnboarding: true,
+    theme: "dark",
+    hasSeenAutoModeEntryWarning: true,
+    // cwd is mounted at its SAME path in the container, so this key matches there.
+    projects: {
+      [cwd]: { hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true, projectOnboardingSeenCount: 1, allowedTools: [] },
+    },
+  };
+  writeFileSync(file, JSON.stringify(config));
+  return file;
+}
+
+// Best-effort teardown: force-remove the container (killing the `docker run` client
+// alone can leave it behind) and delete the throwaway per-session config. Used before a
+// spawn (clear stale) and on reap.
+export function cleanupSandbox(sessionId: string): void {
   run("docker", ["rm", "-f", sandboxContainerName(sessionId)]);
+  rmSync(sandboxClaudeConfigPath(sessionId), { force: true });
 }
 
 // The `docker run` argv that runs interactive `claude` in the sandbox. The workspace is
 // bind-mounted at its SAME absolute path so claude's transcript encodes identically to
 // the host (~/.claude/projects/<encoded-cwd>) — resume interoperates with host sessions.
-// ~/.claude (+ .claude.json) is mounted for auth + transcripts. `claudeArgs` already have
-// their --settings/--mcp-config URLs rewritten to host.docker.internal by the caller.
-export function buildDockerRunArgs(sessionId: string, claudeArgs: string[], cwd: string): string[] {
+// ~/.claude (dir) is mounted for auth + transcripts; `claudeConfigPath` is the generated
+// per-session ~/.claude.json. `claudeArgs` already have their --settings/--mcp-config
+// URLs rewritten to host.docker.internal by the caller.
+export function buildDockerRunArgs(sessionId: string, claudeArgs: string[], cwd: string, claudeConfigPath: string): string[] {
   const claudeDir = path.join(os.homedir(), ".claude");
-  const claudeJson = path.join(os.homedir(), ".claude.json");
-  const jsonMount = existsSync(claudeJson) ? ["-v", `${claudeJson}:${CONTAINER_HOME}/.claude.json`] : [];
   return [
     "run",
     "--rm",
@@ -69,11 +98,14 @@ export function buildDockerRunArgs(sessionId: string, claudeArgs: string[], cwd:
     "host.docker.internal:host-gateway",
     "-e",
     `HOME=${CONTAINER_HOME}`,
+    "-e",
+    "DISABLE_AUTOUPDATER=1", // ephemeral container — never self-update the CLI
     "-v",
     `${cwd}:${cwd}`,
     "-v",
     `${claudeDir}:${CONTAINER_HOME}/.claude`,
-    ...jsonMount,
+    "-v",
+    `${claudeConfigPath}:${CONTAINER_HOME}/.claude.json`,
     "-w",
     cwd,
     IMAGE,

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -27,6 +27,13 @@ export function sandboxEnabled(): boolean {
   return v === "1" || v === "true";
 }
 
+// Windows is unsupported: the same-path bind mount (`-v <cwd>:<cwd>`, which keeps the
+// transcript encoding identical to the host) yields a non-POSIX container path (`C:\...`)
+// that Docker rejects for Linux containers. macOS + Linux hosts only.
+export function sandboxPlatformSupported(): boolean {
+  return process.platform !== "win32";
+}
+
 // Rewrite a host-loopback URL so it's reachable from inside the container. Same regex
 // MulmoClaude uses: anchored at the scheme, only localhost/127.0.0.1 followed by :/ or end.
 export function rewriteLoopbackForDocker(url: string): string {

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -27,11 +27,14 @@ export function sandboxEnabled(): boolean {
   return v === "1" || v === "true";
 }
 
-// Windows is unsupported: the same-path bind mount (`-v <cwd>:<cwd>`, which keeps the
-// transcript encoding identical to the host) yields a non-POSIX container path (`C:\...`)
-// that Docker rejects for Linux containers. macOS + Linux hosts only.
+// macOS only for Phase 1 (the only platform verified). Docker Desktop maps bind-mount
+// ownership transparently there, so running as the image's uid 1000 Just Works. Linux is
+// gated off because the spawn passes no `--user`, so bind-mounted host files would be
+// written as uid 1000 (ownership failures on non-1000 hosts — proper uid mapping is a
+// follow-up, #202). Windows is gated off because the same-path mount (`-v <cwd>:<cwd>`)
+// isn't a valid Linux container path. Both fall back to the host spawn.
 export function sandboxPlatformSupported(): boolean {
-  return process.platform !== "win32";
+  return process.platform === "darwin";
 }
 
 // Rewrite a host-loopback URL so it's reachable from inside the container. Same regex

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -1,7 +1,11 @@
 // Docker sandbox for the SINGLE-VIEW interactive Claude session (opt-in, default off).
-// Runs `claude` inside a container so an untrusted workspace can't touch the host; the
-// container reaches the host's GUI MCP + activity hooks over host.docker.internal. The
-// grid keeps its host + tmux path — sandbox and tmux are alternative spawn wrappers.
+// Runs `claude` inside a container to CONTAIN it: it can't reach the host filesystem
+// outside the bind-mounts, host processes, or arbitrary host ports. It is NOT full
+// isolation — the project directory and ~/.claude are bind-mounted READ-WRITE by design
+// (Claude edits your code and writes its transcript/auth), so those specific host paths
+// stay mutable from inside. The container reaches the host's GUI MCP + activity hooks
+// over host.docker.internal. The grid keeps its host + tmux path — sandbox and tmux are
+// alternative spawn wrappers.
 //
 // Verified in Phase 0 (#202): a sandboxed claude authenticates via the mounted ~/.claude
 // and connects to the host GUI MCP over host.docker.internal.
@@ -36,11 +40,12 @@ function run(bin: string, args: string[]): { status: number | null } {
   return { status: spawnSync(bin, args, { stdio: "ignore" }).status };
 }
 
-// Is Docker usable (daemon reachable)? Cached — a missing/stopped daemon means the
-// caller should fall back to the host spawn rather than hang.
-let cachedDockerOk: boolean | null = null;
+// Is Docker usable (daemon reachable)? Only a POSITIVE result is cached — a failed check
+// (e.g. the daemon still starting when the server boots) is retried on the next spawn, so
+// transient unavailability doesn't permanently disable sandboxing until a restart.
+let cachedDockerOk = false;
 export function dockerAvailable(): boolean {
-  if (cachedDockerOk === null) cachedDockerOk = run("docker", ["info"]).status === 0;
+  if (!cachedDockerOk) cachedDockerOk = run("docker", ["info"]).status === 0;
   return cachedDockerOk;
 }
 

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -1,0 +1,83 @@
+// Docker sandbox for the SINGLE-VIEW interactive Claude session (opt-in, default off).
+// Runs `claude` inside a container so an untrusted workspace can't touch the host; the
+// container reaches the host's GUI MCP + activity hooks over host.docker.internal. The
+// grid keeps its host + tmux path — sandbox and tmux are alternative spawn wrappers.
+//
+// Verified in Phase 0 (#202): a sandboxed claude authenticates via the mounted ~/.claude
+// and connects to the host GUI MCP over host.docker.internal.
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const IMAGE = process.env.MULMOTERMINAL_SANDBOX_IMAGE || "mulmoterminal-sandbox";
+const CONTAINER_HOME = "/home/node";
+
+// The hostname a container uses to reach the host (Docker Desktop provides it natively;
+// Linux gets it via `--add-host host.docker.internal:host-gateway`).
+export const SANDBOX_HOST = "host.docker.internal";
+
+// Opt-in, default off. Enable with MULMOTERMINAL_SANDBOX=1.
+export function sandboxEnabled(): boolean {
+  const v = process.env.MULMOTERMINAL_SANDBOX;
+  return v === "1" || v === "true";
+}
+
+// Rewrite a host-loopback URL so it's reachable from inside the container. Same regex
+// MulmoClaude uses: anchored at the scheme, only localhost/127.0.0.1 followed by :/ or end.
+export function rewriteLoopbackForDocker(url: string): string {
+  return url.replace(/^(https?:\/\/)(localhost|127\.0\.0\.1)(?=[:/]|$)/, `$1${SANDBOX_HOST}`);
+}
+
+export const sandboxContainerName = (sessionId: string): string => `mulmoterminal-${sessionId}`;
+
+// Bin as a parameter (not a spawn-of-a-string-literal), mirroring server/gh.ts + tmux.ts.
+function run(bin: string, args: string[]): { status: number | null } {
+  return { status: spawnSync(bin, args, { stdio: "ignore" }).status };
+}
+
+// Is Docker usable (daemon reachable)? Cached — a missing/stopped daemon means the
+// caller should fall back to the host spawn rather than hang.
+let cachedDockerOk: boolean | null = null;
+export function dockerAvailable(): boolean {
+  if (cachedDockerOk === null) cachedDockerOk = run("docker", ["info"]).status === 0;
+  return cachedDockerOk;
+}
+
+// Best-effort remove a sandbox container (clear a stale one before spawn, or on reap —
+// killing the `docker run` client alone can leave the container behind).
+export function removeSandboxContainer(sessionId: string): void {
+  run("docker", ["rm", "-f", sandboxContainerName(sessionId)]);
+}
+
+// The `docker run` argv that runs interactive `claude` in the sandbox. The workspace is
+// bind-mounted at its SAME absolute path so claude's transcript encodes identically to
+// the host (~/.claude/projects/<encoded-cwd>) — resume interoperates with host sessions.
+// ~/.claude (+ .claude.json) is mounted for auth + transcripts. `claudeArgs` already have
+// their --settings/--mcp-config URLs rewritten to host.docker.internal by the caller.
+export function buildDockerRunArgs(sessionId: string, claudeArgs: string[], cwd: string): string[] {
+  const claudeDir = path.join(os.homedir(), ".claude");
+  const claudeJson = path.join(os.homedir(), ".claude.json");
+  const jsonMount = existsSync(claudeJson) ? ["-v", `${claudeJson}:${CONTAINER_HOME}/.claude.json`] : [];
+  return [
+    "run",
+    "--rm",
+    "-it",
+    "--name",
+    sandboxContainerName(sessionId),
+    "--add-host",
+    "host.docker.internal:host-gateway",
+    "-e",
+    `HOME=${CONTAINER_HOME}`,
+    "-v",
+    `${cwd}:${cwd}`,
+    "-v",
+    `${claudeDir}:${CONTAINER_HOME}/.claude`,
+    ...jsonMount,
+    "-w",
+    cwd,
+    IMAGE,
+    "claude",
+    ...claudeArgs,
+  ];
+}


### PR DESCRIPTION
## Summary
`MULMOTERMINAL_SANDBOX=1`（＋Docker 起動）で、**single view の対話 Claude セッションを Docker container 内で起動**する土台。container 内の Claude は `host.docker.internal` 経由で host の GUI MCP ＋ activity hook にそのまま到達する（Phase 0 で実証済み）。#202 の Phase 0（境界実証）＋ Phase 1（sandbox spawn）。**opt-in・既定 OFF** なので、フラグ無し／Docker 無し／grid／隠しワーカーは**従来と完全に同じ**。

- **Phase 0**: `Dockerfile.sandbox`（`node:22-slim` + claude/curl/git/ripgrep。GUI MCP は host の HTTP なので in-container broker 不要）＋ `scripts/sandbox-repro.sh`（手動再現）。
- **Phase 1**: `server/sandbox.ts` ＋ `spawnClaudePty` の docker 分岐。MCP/hook URL を `host.docker.internal` に rewrite、cwd を**同一絶対パス**で bind mount（transcript encoding をホストと一致＝resume 相互運用）、`~/.claude`（`.credentials.json`）を mount で認証。tmux（grid）とは排他、非永続（`--rm`）。

## Items to Confirm / Review（レビュー観点）
- **opt-in の限定**: `sandbox = sandboxEnabled() && attachGuiMcp && ws!==null && dockerAvailable()`。`attachGuiMcp`＝single view（grid の `?gui=0` を除外）、`ws!==null`＝隠し翻訳/背景ワーカーを除外。この条件で「single view の対話セッションのみ」になっているか。
- **loopback rewrite**: `hookSettingsJson`/`mcpConfigJson` が sandbox 時のみ `host.docker.internal` を使う。それ以外は従来の `localhost`/`127.0.0.1` のまま。
- **生成 `~/.claude.json`**: ホストの `~/.claude.json` は **mount しない**（`installMethod:native`→`~/.local/bin` 不在で "missing or broken" 警告、かつ rw mount はホスト設定を container が書き換える）。代わりに per-session の最小 config を `~/.mulmoterminal/sandbox/` に生成（onboarding done ＋ cwd を `hasTrustDialogAccepted` で pre-trust）。認証は `~/.claude` dir から。→ **警告なし・onboarding/trust なしのクリーン REPL**（node-pty ＋ docker inspect で確認）。
- **後始末**: reap で `docker rm -f` ＋ 生成 config 削除（`cleanupSandbox`）。spawn 前にも stale を掃除。
- **セキュリティ（既知・follow-up）**: `/api/hook`・`/api/mcp` は現状**無認証**（サーバは元々 0.0.0.0 bind なので sandbox で新たに露出が増えるわけではない）。**session token 認証は次段の hardening**として別途入れる想定。
- **プラットフォーム**: 動作確認は macOS（Docker Desktop の uid マッピング前提）。Linux の uid 一致は後段（Phase 5 の credentials/uid モデル）。
- 対象は `claude` のみ、非永続、docker/tmux 排他 ＝ ユーザー確認済みのスコープ。

## User Prompt
> （#202 を読んで）できそうか検討し、できるなら step を踏んで進めるのでタスク分解して。
>
> 決定スコープ: sandbox は opt-in・既定 OFF / Docker sandbox + MCP は **single view のみ**（tmux 永続化は grid のみ・docker と排他）/ 非永続 / 会話中の MCP 追加は `--resume` 再 spawn / まず `claude` のみ。
>
> （動作検証したい → 検証の過程で "claude command ... missing or broken" 警告を発見 → 修正）

## Implementation
- `Dockerfile.sandbox`, `scripts/sandbox-repro.sh`, `plans/feat-202-docker-sandbox-mcp.md`。
- `server/sandbox.ts`: `sandboxEnabled`/`dockerAvailable`/`rewriteLoopbackForDocker`/`buildDockerRunArgs`（`--rm -it --name`, `--add-host host-gateway`, `DISABLE_AUTOUPDATER=1`, mount cwd:cwd + `~/.claude` + 生成 config, `-w cwd`）/`writeSandboxClaudeConfig`/`cleanupSandbox`。
- `server/index.ts`: `spawnClaudePty` の docker 分岐、`hookSettingsJson(host)`/`mcpConfigJson(id, host)`、`PtyEntry.sandbox`、reap 掃除、起動 log。
- テスト: `server/sandbox.spec.ts`（rewrite / arg builder / 生成 config）。README にサンドボックス節。

## テスト手順

### 自動
- `yarn typecheck && yarn typecheck:server && yarn lint && yarn build && yarn test`（**test 621 passed**）。`server/sandbox.spec.ts` が rewrite・docker argv・生成 config を検証。

### 手動（要 Docker 起動）
1. イメージ build: `docker build -f Dockerfile.sandbox -t mulmoterminal-sandbox .`
2. sandbox ON で起動: `MULMOTERMINAL_SANDBOX=1 yarn dev` → http://localhost:6856
   - サーバログに `[sandbox] on — single-view Claude runs in a Docker container`
3. **single view**（既定の Chat）で Claude を開始（dir 例: `~/mulmoclaude`）
   - **警告・テーマ/信頼プロンプトなしでクリーンに REPL** に入る
4. 別ターミナル: `docker ps --filter name=mulmoterminal- --format '{{.Names}} {{.Image}} {{.Status}}'` → `mulmoterminal-<id> mulmoterminal-sandbox Up ...`
5. Claude の REPL で `/mcp` → `mulmoterminal-gui` が **connected**
6. GUI 機能を試す（例: Claude に画像/ドキュメント生成を依頼）→ パネルに描画＝host 側の MCP 実装が動いている
7. **対比**: (a) フラグ無し `yarn dev` → 全部 host（コンテナ増えない）、(b) grid view でセルを開く → コンテナ増えない（single view 限定）
8. クローズ（セルの ✕ / タブ閉じ）→ しばらくして `docker ps` からコンテナが消える（reap で `docker rm -f`）

### デバッグ用（境界だけ確認）
- `PORT=<port> scripts/sandbox-repro.sh` — MCP/hook URL を rewrite して container で対話 claude を起動（`/mcp connected` を目視）。

## スコープ外（別 PR）
Phase 2（user MCP を Settings で追加 → `--mcp-config` にマージ）、Phase 3（会話中の追加＝`--resume` 再 spawn）、Phase 4（stdio MCP の host-exec shim）、Phase 5（credentials allowlist / Linux uid）、session token 認証。

Refs #202