### PR TITLE
fix: 端末のコピー(OSC 52)がブラウザのクリップボードに届かない

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@mulmoclaude/x-plugin": "^0.1.2",
     "@receptron/task-scheduler": "^0.1.0",
     "@xterm/addon-attach": "^0.12.0",
+    "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/plans/fix-xterm-clipboard-osc52.md
+++ b/plans/fix-xterm-clipboard-osc52.md
@@ -1,0 +1,40 @@
+# fix: xterm がクリップボード(OSC 52)を処理せず端末のコピーが効かない
+
+Issue: #204
+
+## User Prompt
+
+> single viewでxtermの文字をコピペしようと思ったらできなかった。grid viewは確かめてない。原因わかる？
+
+## 原因（実機再現で確定）
+
+Claude Code は選択テキストを **OSC 52**（クリップボード書き込みエスケープ）で自動コピーする（TUI に
+`copied N chars to clipboard · disable auto-copy in /config` と表示）。mulmoterminal の xterm.js は
+**`@xterm/addon-clipboard` を未ロード**で OSC 52 を無視するため、Claude Code は「コピーした」と表示するのに
+ブラウザのクリップボードには何も入らない。single / grid 両方同構成。
+
+- puppeteer 再現：選択はハイライトされるが Cmd+C 後もクリップボード空（`clipboardLen: 0`）。
+- Claude Code はマウストラッキングモード → ドラッグは Claude Code 側の選択に消費され、xterm 側 native
+  選択が無いので素の Cmd+C でもコピーされない。
+
+## 修正
+
+- `@xterm/addon-clipboard`（v0.2.0）を `yarn add`。
+- `src/composables/useTerminalConnections.ts` の xterm 生成時に `term.loadAddon(new ClipboardAddon(undefined, clipboardProvider))`。
+
+**要点（実装で判明）**: Claude Code は OSC 52 を **空セレクタ**で送る（`ESC ] 52 ; ; <base64>`）。
+addon の既定 `BrowserClipboardProvider` は **`selection !== "c"` だと書き込まない**ため、空セレクタが落ちる。
+そこで **空（と `c`）をシステムクリップボード扱いにするカスタム `IClipboardProvider`** を渡す
+（`isSystemClipboard(selection)` = `"" || "c"`）。これで OSC 52 → `navigator.clipboard.writeText` に渡り、
+Claude Code の自動コピーが実際にクリップボードへ入る（`localhost` は secure context のため利用可）。single / grid 両方に効く。
+
+## 検証
+
+- puppeteer：端末で選択（Claude Code 自動コピー）後に `navigator.clipboard.readText()` が非空になること。
+- `yarn format` / `lint` / `typecheck` / `build` / `test`。
+
+## メモ
+
+- 主因は OSC 52。マウスモードOFFの素シェルで Cmd+C も効かせたい場合は別途 `attachCustomKeyEventHandler` で
+  xterm 選択をコピーする配線も可能だが、本 issue の症状（Claude Code のコピー）はアドオン導入で解決する。
+- OSC 52 は端末プログラムがクリップボードへ書ける経路。ここでは Claude Code を信頼する前提で許可。

--- a/plans/fix-xterm-clipboard-osc52.md
+++ b/plans/fix-xterm-clipboard-osc52.md
@@ -37,4 +37,6 @@ Claude Code の自動コピーが実際にクリップボードへ入る（`loca
 
 - 主因は OSC 52。マウスモードOFFの素シェルで Cmd+C も効かせたい場合は別途 `attachCustomKeyEventHandler` で
   xterm 選択をコピーする配線も可能だが、本 issue の症状（Claude Code のコピー）はアドオン導入で解決する。
-- OSC 52 は端末プログラムがクリップボードへ書ける経路。ここでは Claude Code を信頼する前提で許可。
+- OSC 52 は端末プログラムがクリップボードを読み書きできる経路。**write のみ許可し read は無効化**
+  （`readText` は常に `""`）。OSC 52 read（`ESC ] 52 ; <sel> ; ?`）はユーザーのクリップボードを端末側へ
+  返す漏洩経路であり、コピー機能に read は不要（貼り付けはブラウザの Cmd+V）。（Codex レビュー指摘）

--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -27,6 +27,11 @@ vi.mock("@xterm/addon-web-links", () => ({
     activate() {}
   },
 }));
+vi.mock("@xterm/addon-clipboard", () => ({
+  ClipboardAddon: class {
+    activate() {}
+  },
+}));
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 
 // A WebSocket double the test drives by hand (fire onopen / onmessage when it wants).
@@ -107,5 +112,18 @@ describe("useTerminalConnections — detached-slot state replay", () => {
     conn.attach("cell-race", target(null), second, document.createElement("div"));
     expect(second.onSession).not.toHaveBeenCalled();
     expect(second.onCwd).not.toHaveBeenCalled();
+  });
+});
+
+// Claude Code emits OSC 52 with an EMPTY selection; the clipboard addon's default
+// provider only writes for "c", so the empty case must also route to the clipboard.
+describe("isSystemClipboard", () => {
+  it("routes the empty selection (Claude Code's OSC 52) and explicit 'c' to the clipboard", () => {
+    expect(conn.isSystemClipboard("")).toBe(true);
+    expect(conn.isSystemClipboard("c")).toBe(true);
+  });
+
+  it("ignores primary / select / cut-buffer selections", () => {
+    for (const sel of ["p", "s", "0", "7"]) expect(conn.isSystemClipboard(sel)).toBe(false);
   });
 });

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -18,6 +18,7 @@ import { reactive } from "vue";
 import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard";
 import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl } from "../components/wsUrl";
 
@@ -77,6 +78,29 @@ function setStatus(c: Conn, s: ConnStatus) {
   if (v) v.status = s;
 }
 
+// Claude Code emits OSC 52 with an EMPTY selection (`ESC ] 52 ; ; <base64>`), which
+// the addon's default provider silently drops (it only writes for selection "c").
+// Route the empty (and "c") selection to the system clipboard so the auto-copy lands.
+export const isSystemClipboard = (selection: string): boolean => selection === "" || selection === "c";
+const clipboardProvider: IClipboardProvider = {
+  async readText(selection) {
+    if (!isSystemClipboard(selection)) return "";
+    try {
+      return await navigator.clipboard.readText();
+    } catch {
+      return ""; // clipboard blocked (no focus / permission)
+    }
+  },
+  async writeText(selection, text) {
+    if (!isSystemClipboard(selection)) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // clipboard blocked (no focus / permission) — best effort
+    }
+  },
+};
+
 function ensure(key: string, target: ConnTarget): Conn {
   const existing = conns.get(key);
   if (existing) {
@@ -91,6 +115,9 @@ function ensure(key: string, target: ConnTarget): Conn {
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
   term.loadAddon(new WebLinksAddon());
+  // OSC 52 clipboard: Claude Code auto-copies the selection via OSC 52 — without this
+  // addon xterm ignores it, so the copy silently never reaches the browser clipboard.
+  term.loadAddon(new ClipboardAddon(undefined, clipboardProvider));
   const host = document.createElement("div");
   host.style.width = "100%";
   host.style.height = "100%";

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -83,13 +83,11 @@ function setStatus(c: Conn, s: ConnStatus) {
 // Route the empty (and "c") selection to the system clipboard so the auto-copy lands.
 export const isSystemClipboard = (selection: string): boolean => selection === "" || selection === "c";
 const clipboardProvider: IClipboardProvider = {
-  async readText(selection) {
-    if (!isSystemClipboard(selection)) return "";
-    try {
-      return await navigator.clipboard.readText();
-    } catch {
-      return ""; // clipboard blocked (no focus / permission)
-    }
+  // OSC 52 clipboard READ is disabled: letting a terminal program read the user's
+  // clipboard (`ESC ] 52 ; <sel> ; ?`) is an exfiltration vector, and nothing here
+  // needs it (paste uses the browser's native Cmd+V). This is write-only.
+  readText() {
+    return "";
   },
   async writeText(selection, text) {
     if (!isSystemClipboard(selection)) return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,7 +763,7 @@
   resolved "https://registry.yarnpkg.com/@marp-team/marpit-svg-polyfill/-/marpit-svg-polyfill-2.1.0.tgz#40e7ce3a2aa7496748541cc7053e6779d2f866ac"
   integrity sha512-VqCoAKwv1HJdzZp36dDPxznz2JZgRjkVSSPHpCzk72G2N753F0HPKXjevdjxmzN6gir9bUGBgMD1SguWJIi11A==
 
-"@marp-team/marpit@^3.2.1", "@marp-team/marpit@^3.2.2":
+"@marp-team/marpit@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@marp-team/marpit/-/marpit-3.2.2.tgz#291c8fb76758cde6a63afcb43fa1f3ed97c7f91f"
   integrity sha512-7LJ6vuAA1jovkTMso2MLyhdjqtJAzjievCAF2PpIqHGH7CFG0e3a0hXQ++zMXinUggKt0pbhqa/q8UEdcYq5Pw==
@@ -1860,6 +1860,13 @@
   resolved "https://registry.yarnpkg.com/@xterm/addon-attach/-/addon-attach-0.12.0.tgz#58d9b1feb8e9e7b5403ccc1491623497c522e704"
   integrity sha512-1lxvXM4JYSm60lbFmE8WMOy2oF2ip3Ye8jWorSAmwy7x8FiC53netEJ5RguL8+FSRj79MUQsNCb2hprY2QA2ig==
 
+"@xterm/addon-clipboard@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz#8f2027b141e78f70fc76ba56aacf467250c284a3"
+  integrity sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==
+  dependencies:
+    js-base64 "^3.7.5"
+
 "@xterm/addon-fit@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@xterm/addon-fit/-/addon-fit-0.11.0.tgz#ba4778b69fcc9044a060c2176bbe077657d7b37e"
@@ -2768,7 +2775,7 @@ enhanced-resolve@5.21.6:
     graceful-fs "^4.2.4"
     tapable "^2.3.3"
 
-entities@^4.4.0, entities@^4.5.0:
+entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -3506,6 +3513,11 @@ jose@^6.1.3:
   resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
   integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
 
+js-base64@^3.7.5:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.8.0.tgz#cfc7b3d0f15dc6f69403c50df8ff2decca1a23ad"
+  integrity sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==
+
 js-beautify@^1.14.9:
   version "1.15.4"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.15.4.tgz#f579f977ed4c930cef73af8f98f3f0a608acd51e"
@@ -3522,7 +3534,7 @@ js-cookie@^3.0.5:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.8.tgz#444e6f4b27a5d844594fef61c9d6bca5f0787688"
   integrity sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==
 
-js-yaml@^4.1.1, js-yaml@^4.3.0:
+js-yaml@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
   integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
@@ -3627,7 +3639,7 @@ jws@^4.0.0:
     jwa "^2.0.1"
     safe-buffer "^5.0.1"
 
-katex@^0.16.33, katex@^0.16.45:
+katex@^0.16.45:
   version "0.16.47"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.47.tgz#0a13a42c2deb4f74e61f162d440b9165a548030f"
   integrity sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
@@ -3750,7 +3762,7 @@ lilconfig@^3.1.3:
   resolved "https://npm.flatt.tech/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
   integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
 
-linkify-it@^5.0.1, linkify-it@^5.0.2:
+linkify-it@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
   integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
@@ -3822,7 +3834,7 @@ markdown-it-front-matter@^0.2.4:
   resolved "https://registry.yarnpkg.com/markdown-it-front-matter/-/markdown-it-front-matter-0.2.4.tgz#cf29bc8222149b53575699357b1ece697bf39507"
   integrity sha512-25GUs0yjS2hLl8zAemVndeEzThB1p42yxuDEKbd4JlL3jiz+jsm6e56Ya8B0VREOkNxLYB4TTwaoPJ3ElMmW+w==
 
-markdown-it@^14.1.1, markdown-it@^14.2.0:
+markdown-it@^14.2.0:
   version "14.3.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-14.3.0.tgz#8542fa5506e3530f7e2b08dc3885630135c5620e"
   integrity sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==
@@ -4242,7 +4254,7 @@ postcss-nesting@^13.0.2:
     "@csstools/selector-specificity" "^5.0.0"
     postcss-selector-parser "^7.0.0"
 
-postcss-selector-parser@^7.0.0, postcss-selector-parser@^7.1.0, postcss-selector-parser@^7.1.1, postcss-selector-parser@^7.1.4:
+postcss-selector-parser@^7.0.0, postcss-selector-parser@^7.1.0, postcss-selector-parser@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz#69dc7a526517572ff6b150e352b36a016017b485"
   integrity sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==
@@ -4250,7 +4262,7 @@ postcss-selector-parser@^7.0.0, postcss-selector-parser@^7.1.0, postcss-selector
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss@^8.5.15, postcss@^8.5.6:
+postcss@^8.5.15:
   version "8.5.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
   integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==


### PR DESCRIPTION
## Summary

端末の文字をコピーしてもクリップボードに入らない問題を修正。原因は **xterm.js が OSC 52（クリップボード書き込みのエスケープ）を処理していなかった**こと。Claude Code は選択を OSC 52 で自動コピーする（TUI に `copied N chars to clipboard` と表示）が、xterm 側にクリップボードアドオンが無いため OSC 52 が無視され、実際にはブラウザのクリップボードへ届いていなかった。single / grid 両方で発生。

`@xterm/addon-clipboard` を導入し、**Claude Code が送る空セレクタ OSC 52** に対応するカスタムプロバイダを渡すことで解決。

## Items to Confirm / Review

- **空セレクタが肝**: Claude Code は OSC 52 を `Pc`（セレクタ）空で送る（`ESC ] 52 ; ; <base64>`）。addon の既定 `BrowserClipboardProvider` は `selection !== "c"` だと**書き込まない**ため、単に addon を足すだけでは直らなかった（実測: writeText 呼ばれず）。→ **空（と `c`）をシステムクリップボード扱いにするカスタム `IClipboardProvider`** を渡して解決。
- **secure context**: `navigator.clipboard.writeText` は secure context 必須だが、`npx mulmoterminal` は `localhost` なので可。
- **セキュリティ**: OSC 52 は端末プログラムがクリップボードへ書ける経路。ここでは端末で走る Claude Code を信頼する前提で許可（書き込みのみ／失敗は best-effort で握りつぶし）。
- **検証の制約**: headless Chrome は `overridePermissions` を与えても clipboard 書き込みを拒否する（roundtrip も "Write permission denied"）。そのため **`navigator.clipboard.writeText` をフックして「addon が正しい text で writeText を呼ぶ」ことを実機再現で確認**（`copiedLen: 410`、内容＝選択したテキスト）。実ブラウザ localhost では書き込みも成功する。

## User Prompt

> single viewでxtermの文字をコピペしようと思ったらできなかった。grid viewは確かめてない。原因わかる？

## 原因（実機 puppeteer で確定）

1. WebSocket 出力に OSC 52 が流れている（base64 で "Claude Code…"）→ Claude Code は自動コピーを送っている。
2. しかし xterm はアドオン未ロードで OSC 52 を無視 → クリップボード空。
3. マウストラッキングモードのためドラッグは Claude Code 側の選択に消費され、xterm 側 native 選択が無い → 素の Cmd+C でもコピー不可。

## 実装

- `@xterm/addon-clipboard@0.2.0` を追加。
- `src/composables/useTerminalConnections.ts`: `term.loadAddon(new ClipboardAddon(undefined, clipboardProvider))`。`clipboardProvider` は空/`c` セレクタを `navigator.clipboard` に流す（`isSystemClipboard`）。
- `useTerminalConnections.spec.ts`: `isSystemClipboard` の回帰テスト（空・`c` → true、`p`/`s`/`0`/`7` → false）。

## 検証

- `yarn format` / `lint`(0 errors) / `typecheck` / `build` / `test` パス。
- puppeteer 実機：選択 → addon が `navigator.clipboard.writeText` を **410 chars の正しい内容で呼ぶ**ことを確認。

Closes #204
