### PR TITLE
feat: user MCP servers for the single-view Claude session — #202 Phase 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The Settings modal (⚙) persists per-user UI choices to `~/.mulmoterminal/confi
 | `soundFile`  | Absolute path to a custom **attention sound** (played when a session needs attention). Empty/unset uses the built-in synthesized chime. |
 | `prRepos`    | `owner/repo` entries whose open PRs/issues the cross-repo **PRs & Issues** view aggregates (via your `gh` login). |
 | `launchers`  | `{ label, command }` entries offered in a grid cell's launcher besides Claude — a plain shell, `codex`, any interactive command. |
+| `userMcpServers` | `{ id, url }` HTTP MCP servers merged into the **single-view** Claude session's `--mcp-config` (a `localhost` URL is reached over `host.docker.internal` in the Docker sandbox). Takes effect on the next session. |
 
 **Attention sound.** The default chime is generated with the Web Audio API — **no
 audio file is bundled**, so the npm package stays light and has no media-licensing

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, loadAppConfig, saveAppConfig } from "./app-config";
+import { sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, sanitizeUserMcpServers, loadAppConfig, saveAppConfig } from "./app-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 
@@ -54,24 +54,50 @@ describe("sanitizeLaunchers", () => {
   });
 });
 
+describe("sanitizeUserMcpServers", () => {
+  it("keeps valid id + http(s) url, drops bad id/url/dup", () => {
+    expect(
+      sanitizeUserMcpServers([
+        { id: " weather ", url: " http://localhost:9000/mcp " },
+        { id: "docs", url: "https://example.com/mcp" },
+        { id: "weather", url: "https://x/mcp" }, // dup id — dropped
+        { id: "bad id", url: "https://x/mcp" }, // space in id — dropped
+        { id: "noscheme", url: "example.com/mcp" }, // not http(s) — dropped
+        "junk",
+      ]),
+    ).toEqual([
+      { id: "weather", url: "http://localhost:9000/mcp" },
+      { id: "docs", url: "https://example.com/mcp" },
+    ]);
+    expect(sanitizeUserMcpServers("nope")).toEqual([]);
+  });
+});
+
 describe("loadAppConfig / saveAppConfig", () => {
-  it("round-trips presets + soundFile + prRepos + launchers through a file", () => {
+  const base = { cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [] };
+  it("round-trips presets + soundFile + prRepos + launchers + userMcpServers through a file", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
-    const cfg = { cwdPresets: [{ label: "x", path: "/x" }], soundFile: "/s.wav", prRepos: ["o/r"], launchers: [{ label: "Shell", command: "$SHELL" }] };
+    const cfg = {
+      cwdPresets: [{ label: "x", path: "/x" }],
+      soundFile: "/s.wav",
+      prRepos: ["o/r"],
+      launchers: [{ label: "Shell", command: "$SHELL" }],
+      userMcpServers: [{ id: "weather", url: "http://localhost:9000/mcp" }],
+    };
     expect(saveAppConfig(file, cfg)).toBe(true);
     expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(cfg);
     expect(loadAppConfig(file)).toEqual(cfg);
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("defaults to empty presets + null sound + empty repos/launchers for a missing file", () => {
+  it("defaults to empty presets + null sound + empty repos/launchers/mcp for a missing file", () => {
     const dir = tmp();
-    expect(loadAppConfig(path.join(dir, "none.json"))).toEqual({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [] });
+    expect(loadAppConfig(path.join(dir, "none.json"))).toEqual(base);
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("sanitizes junk presets, a non-string sound, bad repos, and bad launchers on load", () => {
+  it("sanitizes junk presets, a non-string sound, bad repos/launchers/mcp on load", () => {
     const dir = tmp();
     const file = path.join(dir, "config.json");
     writeFileSync(
@@ -81,6 +107,10 @@ describe("loadAppConfig / saveAppConfig", () => {
         soundFile: 5,
         prRepos: ["o/r", "bad"],
         launchers: [{ label: "S", command: "sh" }, "x"],
+        userMcpServers: [
+          { id: "ok", url: "https://x/mcp" },
+          { id: "bad url", url: "nope" },
+        ],
       }),
     );
     expect(loadAppConfig(file)).toEqual({
@@ -88,6 +118,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       soundFile: null,
       prRepos: ["o/r"],
       launchers: [{ label: "S", command: "sh" }],
+      userMcpServers: [{ id: "ok", url: "https://x/mcp" }],
     });
     rmSync(dir, { recursive: true, force: true });
   });
@@ -96,15 +127,15 @@ describe("loadAppConfig / saveAppConfig", () => {
     const dir = tmp();
     const file = path.join(dir, "bad.json");
     writeFileSync(file, "{ not json");
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [] });
+    expect(loadAppConfig(file)).toEqual(base);
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("preserves the legacy presets-only shape (soundFile / prRepos / launchers absent => defaults)", () => {
+  it("preserves the legacy presets-only shape (other fields absent => defaults)", () => {
     const dir = tmp();
     const file = path.join(dir, "config.json");
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }] }));
-    expect(loadAppConfig(file)).toEqual({ cwdPresets: [{ label: "a", path: "/a" }], soundFile: null, prRepos: [], launchers: [] });
+    expect(loadAppConfig(file)).toEqual({ ...base, cwdPresets: [{ label: "a", path: "/a" }] });
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -71,6 +71,9 @@ describe("sanitizeUserMcpServers", () => {
     ]);
     expect(sanitizeUserMcpServers("nope")).toEqual([]);
   });
+  it("reserves the built-in GUI MCP id (a user entry can't shadow it)", () => {
+    expect(sanitizeUserMcpServers([{ id: "mulmoterminal-gui", url: "https://evil/mcp" }])).toEqual([]);
+  });
 });
 
 describe("loadAppConfig / saveAppConfig", () => {

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -14,6 +14,15 @@ export interface Launcher {
   command: string;
 }
 
+// A user-added HTTP MCP server the single-view Claude session should load. `id` becomes
+// the server name in --mcp-config (and the `mcp__<id>__*` tool prefix), `url` its
+// streamable-HTTP endpoint. In the Docker sandbox the URL's loopback host is rewritten
+// to host.docker.internal (see server/sandbox.ts).
+export interface UserMcpServer {
+  id: string;
+  url: string;
+}
+
 export interface AppConfig {
   cwdPresets: CwdPreset[];
   // Absolute path to a user-supplied audio file played as the attention sound, or
@@ -23,6 +32,30 @@ export interface AppConfig {
   prRepos: string[];
   // User-defined launch commands offered in the grid cell launcher (label + command).
   launchers: Launcher[];
+  // User-added HTTP MCP servers merged into the single-view session's --mcp-config.
+  userMcpServers: UserMcpServer[];
+}
+
+// `id` becomes an MCP server name + `mcp__<id>` tool prefix, so restrict to a plain
+// slug. `url` must be an http(s) endpoint. Dedupe by id, cap the count.
+const MCP_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_URL_RE = /^https?:\/\/\S+$/;
+const MCP_SERVERS_MAX = 20;
+export function sanitizeUserMcpServers(input: unknown): UserMcpServer[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: UserMcpServer[] = [];
+  for (const v of input) {
+    if (!v || typeof v !== "object") continue;
+    const o = v as Record<string, unknown>;
+    const id = typeof o.id === "string" ? o.id.trim() : "";
+    const url = typeof o.url === "string" ? o.url.trim() : "";
+    if (!MCP_ID_RE.test(id) || !MCP_URL_RE.test(url) || seen.has(id)) continue;
+    seen.add(id);
+    out.push({ id, url });
+    if (out.length >= MCP_SERVERS_MAX) break;
+  }
+  return out;
 }
 
 const LAUNCHER_LABEL_MAX = 40;
@@ -74,7 +107,7 @@ export function sanitizeSoundFile(input: unknown): string | null {
 
 // Fresh object each call — callers hold and mutate the returned config in place, so a
 // shared default constant would be corrupted across loads.
-const emptyConfig = (): AppConfig => ({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [] });
+const emptyConfig = (): AppConfig => ({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [] });
 
 export function loadAppConfig(file: string): AppConfig {
   try {
@@ -85,6 +118,7 @@ export function loadAppConfig(file: string): AppConfig {
       soundFile: sanitizeSoundFile(raw?.soundFile),
       prRepos: sanitizeRepos(raw?.prRepos),
       launchers: sanitizeLaunchers(raw?.launchers),
+      userMcpServers: sanitizeUserMcpServers(raw?.userMcpServers),
     };
   } catch {
     return emptyConfig();
@@ -96,7 +130,13 @@ export function loadAppConfig(file: string): AppConfig {
 export function saveAppConfig(file: string, config: AppConfig): boolean {
   try {
     mkdirSync(path.dirname(file), { recursive: true });
-    const payload = { cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos, launchers: config.launchers };
+    const payload = {
+      cwdPresets: config.cwdPresets,
+      soundFile: config.soundFile,
+      prRepos: config.prRepos,
+      launchers: config.launchers,
+      userMcpServers: config.userMcpServers,
+    };
     writeFileSync(file, JSON.stringify(payload, null, 2));
     return true;
   } catch {

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -41,6 +41,9 @@ export interface AppConfig {
 const MCP_ID_RE = /^[A-Za-z0-9_-]+$/;
 const MCP_URL_RE = /^https?:\/\/\S+$/;
 const MCP_SERVERS_MAX = 20;
+// The built-in GUI MCP server name — reserved so a user entry can't shadow it and
+// break mcp__mulmoterminal-gui__* tool routing.
+const RESERVED_MCP_IDS = new Set(["mulmoterminal-gui"]);
 export function sanitizeUserMcpServers(input: unknown): UserMcpServer[] {
   if (!Array.isArray(input)) return [];
   const seen = new Set<string>();
@@ -50,7 +53,7 @@ export function sanitizeUserMcpServers(input: unknown): UserMcpServer[] {
     const o = v as Record<string, unknown>;
     const id = typeof o.id === "string" ? o.id.trim() : "";
     const url = typeof o.url === "string" ? o.url.trim() : "";
-    if (!MCP_ID_RE.test(id) || !MCP_URL_RE.test(url) || seen.has(id)) continue;
+    if (!MCP_ID_RE.test(id) || RESERVED_MCP_IDS.has(id) || !MCP_URL_RE.test(url) || seen.has(id)) continue;
     seen.add(id);
     out.push({ id, url });
     if (out.length >= MCP_SERVERS_MAX) break;

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -8,7 +8,17 @@ import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
 import { sanitizePresets } from "./cwd-presets.js";
-import { loadAppConfig, saveAppConfig, sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, type AppConfig, type Launcher } from "./app-config.js";
+import {
+  loadAppConfig,
+  saveAppConfig,
+  sanitizeSoundFile,
+  sanitizeRepos,
+  sanitizeLaunchers,
+  sanitizeUserMcpServers,
+  type AppConfig,
+  type Launcher,
+  type UserMcpServer,
+} from "./app-config.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -25,6 +35,12 @@ export function getLaunchers(): Launcher[] {
   return config.launchers;
 }
 
+// User-added HTTP MCP servers — read live so a config change is picked up by the next
+// Claude spawn without a restart.
+export function getUserMcpServers(): UserMcpServer[] {
+  return config.userMcpServers;
+}
+
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   app.get("/api/config", (_req, res) => {
     res.json({
@@ -33,6 +49,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
       soundFile: config.soundFile,
       prRepos: config.prRepos,
       launchers: config.launchers,
+      userMcpServers: config.userMcpServers,
       home: os.homedir(),
     });
   });
@@ -50,17 +67,28 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     if (body.launchers !== undefined && !Array.isArray(body.launchers)) {
       return res.status(400).json({ error: "launchers must be an array" });
     }
+    if (body.userMcpServers !== undefined && !Array.isArray(body.userMcpServers)) {
+      return res.status(400).json({ error: "userMcpServers must be an array" });
+    }
     const next: AppConfig = {
       cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : config.cwdPresets,
       soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : config.soundFile,
       prRepos: body.prRepos !== undefined ? sanitizeRepos(body.prRepos) : config.prRepos,
       launchers: body.launchers !== undefined ? sanitizeLaunchers(body.launchers) : config.launchers,
+      userMcpServers: body.userMcpServers !== undefined ? sanitizeUserMcpServers(body.userMcpServers) : config.userMcpServers,
     };
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.
     if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });
     config = next;
-    res.json({ cwd: claudeCwd, cwdPresets: config.cwdPresets, soundFile: config.soundFile, prRepos: config.prRepos, launchers: config.launchers });
+    res.json({
+      cwd: claudeCwd,
+      cwdPresets: config.cwdPresets,
+      soundFile: config.soundFile,
+      prRepos: config.prRepos,
+      launchers: config.launchers,
+      userMcpServers: config.userMcpServers,
+    });
   });
 
   // Stream the user's custom attention sound (their own file, set in config). The

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getPrRepos, getLaunchers } from "./config-routes.js";
+import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers } from "./config-routes.js";
 import { mountFilesBrowseRoutes } from "./files-browse.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "./tmux.js";
 import {
@@ -25,6 +25,7 @@ import {
   buildDockerRunArgs,
   writeSandboxClaudeConfig,
   cleanupSandbox,
+  rewriteLoopbackForDocker,
   SANDBOX_HOST,
 } from "./sandbox.js";
 import { listPrsAcrossRepos } from "./prs.js";
@@ -637,15 +638,16 @@ function hookSettingsJson(host: string = "localhost") {
 // needed — the agent just makes an HTTP call back to this server. Using
 // 127.0.0.1 (not localhost) avoids an IPv6/IPv4 resolution mismatch against the
 // server's listen address.
-function mcpConfigJson(sessionId: string, host: string = "127.0.0.1") {
-  return JSON.stringify({
-    mcpServers: {
-      "mulmoterminal-gui": {
-        type: "http",
-        url: `http://${host}:${PORT}/api/mcp/${sessionId}`,
-      },
-    },
-  });
+function mcpConfigJson(sessionId: string, host: string = "127.0.0.1", sandbox: boolean = false) {
+  const mcpServers: Record<string, { type: string; url: string }> = {
+    "mulmoterminal-gui": { type: "http", url: `http://${host}:${PORT}/api/mcp/${sessionId}` },
+  };
+  // User-added HTTP MCP servers (Settings). In the sandbox their loopback host is
+  // rewritten so the container can reach a server running on the host.
+  for (const s of getUserMcpServers()) {
+    mcpServers[s.id] = { type: "http", url: sandbox ? rewriteLoopbackForDocker(s.url) : s.url };
+  }
+  return JSON.stringify({ mcpServers });
 }
 
 // Claude stores each project's sessions under ~/.claude/projects/<encoded-cwd>/,
@@ -1557,8 +1559,10 @@ function spawnClaudePty(
     settings: hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost"),
     permissionMode: CLAUDE_PERMISSION_MODE,
     attachGuiMcp,
-    mcpConfig: mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1"),
-    guiMcpTools: GUI_MCP_TOOLS,
+    mcpConfig: mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox),
+    // Auto-allow the GUI tools + the user's own configured MCP servers (mcp__<id>), so
+    // their tools don't trip a permission prompt on every call.
+    guiMcpTools: [GUI_MCP_TOOLS, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(","),
     initialPrompt,
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -639,14 +639,15 @@ function hookSettingsJson(host: string = "localhost") {
 // 127.0.0.1 (not localhost) avoids an IPv6/IPv4 resolution mismatch against the
 // server's listen address.
 function mcpConfigJson(sessionId: string, host: string = "127.0.0.1", sandbox: boolean = false) {
-  const mcpServers: Record<string, { type: string; url: string }> = {
-    "mulmoterminal-gui": { type: "http", url: `http://${host}:${PORT}/api/mcp/${sessionId}` },
-  };
+  const mcpServers: Record<string, { type: string; url: string }> = {};
   // User-added HTTP MCP servers (Settings). In the sandbox their loopback host is
-  // rewritten so the container can reach a server running on the host.
+  // rewritten so the container can reach a server running on the host. Added FIRST so
+  // the built-in GUI entry below always wins (sanitizeUserMcpServers already reserves
+  // its id, this is defense in depth).
   for (const s of getUserMcpServers()) {
     mcpServers[s.id] = { type: "http", url: sandbox ? rewriteLoopbackForDocker(s.url) : s.url };
   }
+  mcpServers["mulmoterminal-gui"] = { type: "http", url: `http://${host}:${PORT}/api/mcp/${sessionId}` };
   return JSON.stringify({ mcpServers });
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -147,7 +147,7 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (theme + notification sound), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { defaultCwd, loadConfig, saveSound, prRepos, savePrRepos, launchers, saveLaunchers } = useAppConfig();
+const { defaultCwd, loadConfig, saveSound, prRepos, savePrRepos, launchers, saveLaunchers, userMcpServers, saveUserMcpServers } = useAppConfig();
 // Drive the single view's dir overrides off the dir the terminal ACTUALLY runs in
 // (reported by the server, which may resolve/fall back), not the static default — so
 // the badge/theme/colors always track the active session. Falls back to the default
@@ -344,9 +344,11 @@ function onSession(id: string) {
       :sound-file="soundFile"
       :pr-repos="prRepos"
       :launchers="launchers"
+      :user-mcp-servers="userMcpServers"
       @update-sound="saveSound"
       @update-repos="savePrRepos"
       @update-launchers="saveLaunchers"
+      @update-user-mcp="saveUserMcpServers"
       @close="closeSettings"
     />
   </div>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -129,8 +129,22 @@ onMounted(() => {
 });
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.
-const { defaultCwd, home, presets, soundFile, prRepos, launchers, loadConfig, recordPreset, removePreset, saveSound, savePrRepos, saveLaunchers } =
-  useAppConfig();
+const {
+  defaultCwd,
+  home,
+  presets,
+  soundFile,
+  prRepos,
+  launchers,
+  userMcpServers,
+  loadConfig,
+  recordPreset,
+  removePreset,
+  saveSound,
+  savePrRepos,
+  saveLaunchers,
+  saveUserMcpServers,
+} = useAppConfig();
 const showSettings = ref(false);
 onMounted(loadConfig);
 
@@ -182,9 +196,11 @@ function closeSettings() {
       :sound-file="soundFile"
       :pr-repos="prRepos"
       :launchers="launchers"
+      :user-mcp-servers="userMcpServers"
       @update-sound="saveSound"
       @update-repos="savePrRepos"
       @update-launchers="saveLaunchers"
+      @update-user-mcp="saveUserMcpServers"
       @close="closeSettings"
     />
   </div>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -3,12 +3,14 @@ import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { useTheme } from "../composables/useTheme";
 import { previewAttention } from "../composables/useAttentionSound";
 import type { Launcher } from "./launchers";
+import type { UserMcpServer } from "./userMcp";
 
-const props = defineProps<{ soundFile?: string | null; prRepos?: string[]; launchers?: Launcher[] }>();
+const props = defineProps<{ soundFile?: string | null; prRepos?: string[]; launchers?: Launcher[]; userMcpServers?: UserMcpServer[] }>();
 const emit = defineEmits<{
   (e: "update-sound", file: string | null): void;
   (e: "update-repos", repos: string[]): void;
   (e: "update-launchers", launchers: Launcher[]): void;
+  (e: "update-user-mcp", servers: UserMcpServer[]): void;
   (e: "close"): void;
 }>();
 
@@ -63,6 +65,35 @@ function addLauncher() {
 function removeLauncher(label: string) {
   launcherList.value = launcherList.value.filter((l) => l.label !== label);
   emit("update-launchers", launcherList.value);
+}
+
+// User HTTP MCP servers (id + url) merged into the single-view Claude session. Editable
+// list mirroring the saved value; add/remove emits the new list up.
+const MCP_ID_RE = /^[A-Za-z0-9_-]+$/;
+const mcpServers = ref<UserMcpServer[]>([...(props.userMcpServers ?? [])]);
+watch(
+  () => props.userMcpServers,
+  (s) => (mcpServers.value = [...(s ?? [])]),
+);
+const newMcpId = ref("");
+const newMcpUrl = ref("");
+const newMcpValid = computed(() => {
+  const id = newMcpId.value.trim();
+  const url = newMcpUrl.value.trim();
+  return MCP_ID_RE.test(id) && /^https?:\/\/\S+$/.test(url) && !mcpServers.value.some((s) => s.id === id);
+});
+function addMcpServer() {
+  const id = newMcpId.value.trim();
+  const url = newMcpUrl.value.trim();
+  if (!newMcpValid.value) return;
+  mcpServers.value = [...mcpServers.value, { id, url }];
+  newMcpId.value = "";
+  newMcpUrl.value = "";
+  emit("update-user-mcp", mcpServers.value);
+}
+function removeMcpServer(id: string) {
+  mcpServers.value = mcpServers.value.filter((s) => s.id !== id);
+  emit("update-user-mcp", mcpServers.value);
 }
 
 // Custom attention sound, applied immediately (like the theme) — empty => the
@@ -254,6 +285,41 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           @keydown.enter="addLauncher"
         />
         <button class="btn" type="button" :disabled="!newLauncherValid" @click="addLauncher">Add</button>
+      </div>
+
+      <h3 class="section-title">MCP servers</h3>
+      <p class="hint">
+        HTTP MCP servers the <strong>single-view</strong> Claude session loads (in addition to the built-in GUI tools). <code>id</code> is the server name;
+        <code>url</code> is its streamable-HTTP endpoint. In the Docker sandbox, a <code>localhost</code> URL is reached over <code>host.docker.internal</code>
+        automatically. Takes effect on the next Claude session.
+      </p>
+      <ul v-if="mcpServers.length" class="repo-list">
+        <li v-for="s in mcpServers" :key="s.id" class="repo-item">
+          <span class="repo-name">{{ s.id }}</span>
+          <code class="launcher-cmd">{{ s.url }}</code>
+          <button class="icon-btn" type="button" :title="`Remove ${s.id}`" :aria-label="`Remove ${s.id}`" @click="removeMcpServer(s.id)">✕</button>
+        </li>
+      </ul>
+      <div class="sound-row launcher-add">
+        <input
+          v-model="newMcpId"
+          class="field launcher-label"
+          type="text"
+          placeholder="id (e.g. weather)"
+          aria-label="MCP server id"
+          spellcheck="false"
+          @keydown.enter="addMcpServer"
+        />
+        <input
+          v-model="newMcpUrl"
+          class="field repo-field"
+          type="text"
+          placeholder="https://… or http://localhost:PORT/mcp"
+          aria-label="MCP server URL"
+          spellcheck="false"
+          @keydown.enter="addMcpServer"
+        />
+        <button class="btn" type="button" :disabled="!newMcpValid" @click="addMcpServer">Add</button>
       </div>
 
       <div class="modal-foot">

--- a/src/components/userMcp.ts
+++ b/src/components/userMcp.ts
@@ -1,0 +1,8 @@
+// A user-added HTTP MCP server the single-view Claude session loads (mirrors the
+// server's UserMcpServer in app-config.ts). `id` is the server name (and `mcp__<id>`
+// tool prefix); `url` its streamable-HTTP endpoint. In the Docker sandbox the URL's
+// loopback host is rewritten to host.docker.internal server-side.
+export interface UserMcpServer {
+  id: string;
+  url: string;
+}

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -1,6 +1,7 @@
 import { ref } from "vue";
 import { presetLabel, type CwdPreset } from "../components/presets";
 import type { Launcher } from "../components/launchers";
+import type { UserMcpServer } from "../components/userMcp";
 
 // The custom attention-sound file is a SINGLETON ref shared across every
 // useAppConfig() caller — the beep player lives in the single view while the
@@ -16,6 +17,10 @@ const prRepos = ref<string[]>([]);
 // Cell-launcher commands (shell/codex/…) — SINGLETON so the grid's cell launchers and
 // the settings editor (openable from either view) share one list.
 const launchers = ref<Launcher[]>([]);
+
+// User-added HTTP MCP servers merged into the single-view session's --mcp-config —
+// SINGLETON like the others.
+const userMcpServers = ref<UserMcpServer[]>([]);
 
 // Pre-#163 recent dirs lived in localStorage (the removed useRecentDirs). They are
 // imported once into the server-side preset list on load — see migrateLegacyRecents.
@@ -59,6 +64,7 @@ export function useAppConfig() {
       soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
       prRepos.value = Array.isArray(c.prRepos) ? c.prRepos : [];
       launchers.value = Array.isArray(c.launchers) ? c.launchers : [];
+      userMcpServers.value = Array.isArray(c.userMcpServers) ? c.userMcpServers : [];
       await migrateLegacyRecents();
     } catch {
       // the app still works; presets are just unavailable
@@ -205,12 +211,29 @@ export function useAppConfig() {
     }
   }
 
+  // Persist the user MCP servers. POSTs only userMcpServers (partial update).
+  async function saveUserMcpServers(next: UserMcpServer[]): Promise<boolean> {
+    try {
+      const res = await fetch("/api/config", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userMcpServers: next }),
+      });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      userMcpServers.value = (await res.json()).userMcpServers ?? [];
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   return {
     defaultCwd,
     home,
     presets,
     prRepos,
     launchers,
+    userMcpServers,
     soundFile,
     saving,
     error,
@@ -221,5 +244,6 @@ export function useAppConfig() {
     saveSound,
     savePrRepos,
     saveLaunchers,
+    saveUserMcpServers,
   };
 }


### PR DESCRIPTION
## Summary
Settings → **MCP servers** で HTTP MCP サーバ（`{id, url}`）を追加すると、**single view の Claude セッションの `--mcp-config`** に GUI MCP と並べてマージされる（＋ `mcp__<id>` を `--allowedTools` に自動許可）。**Docker sandbox 時は URL の loopback を `host.docker.internal` に rewrite**するので、host で動く MCP にコンテナから到達できる。#202 Phase 2。

**リスト空（デフォルト）なら `--mcp-config` は今と同一（GUI MCP のみ）＝影響ゼロ**。追加した時だけ効く。

## Items to Confirm / Review
- **影響ゼロの担保**: `userMcpServers` が空なら `mcpConfigJson` の出力も `--allowedTools` も従来と完全一致（server 側の merge はリストを for で回すだけ）。
- **sandbox rewrite**: `mcpConfigJson(sessionId, host, sandbox)` が sandbox 時のみ user URL を `rewriteLoopbackForDocker` で書き換え。GUI MCP は従来どおり `host` 引数で処理。
- **allowedTools**: `[GUI_MCP_TOOLS, ...userServers.map(s => "mcp__"+s.id)].join(",")` — user MCP tool を毎回許可プロンプトにしない（MulmoClaude と同方針）。
- **バリデーション**: `id` は slug（`[A-Za-z0-9_-]+`＝MCP サーバ名/`mcp__<id>` プレフィックスに使うため）、`url` は http(s)、dedupe、上限 20。
- **適用タイミング**: 追加は**次の Claude セッション**から反映（`getUserMcpServers()` を spawn 時に読む）。稼働中セッションのライブ reload は **Phase 3**。
- host モードでも user MCP は使える（rewrite 無し）。grid（`gui=0`）は従来どおり `--mcp-config`/strict を使わないので対象外（ユーザーの `~/.claude.json` MCP がそのまま効く）。

## User Prompt
> 影響ない範囲で進められるだけ進めよう（#202 の続き）。

## Implementation
- `server/app-config.ts`: `UserMcpServer` ＋ `sanitizeUserMcpServers`、load/save。`config-routes.ts`: GET/POST ＋ `getUserMcpServers()`。
- `server/index.ts`: `mcpConfigJson` に user servers マージ（sandbox で rewrite）、`--allowedTools` に `mcp__<id>`。
- client: `src/components/userMcp.ts`（型）、`useAppConfig` singleton ＋ `saveUserMcpServers`、`SettingsModal` の「MCP servers」エディタ、App/GridView 配線。
- tests: `sanitizeUserMcpServers` ＋ config 往復。

## テスト手順
### 自動
`yarn typecheck && yarn typecheck:server && yarn lint && yarn build && yarn test`（**test 624**）。config 往復は実サーバの POST/GET でも確認済み（valid 永続・junk 破棄・ファイル保存）。

### 手動
1. `yarn dev` → Settings（⚙）→ **MCP servers** に `id` + `url` を追加（例: `id=weather`, `url=http://localhost:9000/mcp`）
2. **single view** で Claude を開始（or 既存を開き直す）→ REPL で `/mcp` に `mulmoterminal-gui` と **`weather`** が connected
3. Claude にその MCP の tool を使わせる → 動く（tool は自動許可）
4. sandbox（`MULMOTERMINAL_SANDBOX=1`）でも同様。host の `localhost` MCP にコンテナから到達（`host.docker.internal` rewrite）
5. リストを空にすれば従来どおり（GUI MCP のみ）

## スコープ外（別 PR）
Phase 3（稼働中セッションへの反映＝`--resume` 再 spawn）、Phase 4（stdio MCP shim）、Phase 5（credentials / Linux uid）、token 認証。

Refs #202