### PR TITLE
feat: opt-in host credentials for the Docker sandbox (allowlist) — #202 Phase 5a

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ Windows (host paths aren't valid Linux container paths) it falls back to the hos
 both are follow-ups. Adding arbitrary user MCP servers to the sandbox is in progress
 (see #202).
 
+**Host credentials (opt-in).** By default the sandbox has no host credentials. To let the
+sandboxed Claude use `gh`/`git`, set **`SANDBOX_MOUNT_CONFIGS=gh,gitconfig`** — a **fixed
+allowlist** (you pick names, never arbitrary paths): `gh` mounts `~/.config/gh` read-only
+and passes a `GH_TOKEN` (from `gh auth token`, since macOS keeps it in the Keychain), and
+`gitconfig` mounts `~/.gitconfig` read-only. Set **`SANDBOX_SSH_AGENT_FORWARD=1`** to
+forward the SSH agent socket (the keys never enter the container). Both are read only when
+building the sandbox spawn, so they have no effect unless `MULMOTERMINAL_SANDBOX` is on.
+
 ---
 
 ## Tech stack

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -94,6 +94,9 @@ describe("parseMountConfigNames (credentials allowlist)", () => {
   it("collapses duplicate names (no duplicate -v mount → no docker error)", () => {
     expect(parseMountConfigNames("gh,gh,gitconfig,gh")).toEqual(["gh", "gitconfig"]);
   });
+  it("rejects prototype-chain keys (own-properties only)", () => {
+    expect(parseMountConfigNames("__proto__,constructor,toString,hasOwnProperty,gh")).toEqual(["gh"]);
+  });
 });
 
 describe("resolveSandboxAuthArgs (opt-in, env-gated)", () => {

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -117,7 +117,11 @@ describe("resolveSandboxAuthArgs (opt-in, env-gated)", () => {
     delete process.env.SANDBOX_MOUNT_CONFIGS;
     process.env.SANDBOX_SSH_AGENT_FORWARD = "1";
     const args = resolveSandboxAuthArgs();
-    expect(args).toContain("/run/host-services/ssh-auth.sock:/ssh-agent");
+    expect(args).toContain("/run/host-services/ssh-auth.sock:/ssh-agent:ro"); // read-only, like every credential mount
     expect(args).toContain("SSH_AUTH_SOCK=/ssh-agent");
+    // Every -v this function emits must be read-only.
+    args.forEach((a, i) => {
+      if (args[i - 1] === "-v") expect(a.endsWith(":ro")).toBe(true);
+    });
   });
 });

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -9,6 +9,8 @@ import {
   buildDockerRunArgs,
   writeSandboxClaudeConfig,
   sandboxClaudeConfigPath,
+  parseMountConfigNames,
+  resolveSandboxAuthArgs,
 } from "./sandbox";
 
 describe("rewriteLoopbackForDocker", () => {
@@ -79,5 +81,37 @@ describe("writeSandboxClaudeConfig", () => {
     expect(cfg.hasCompletedOnboarding).toBe(true);
     expect(cfg.projects["/Users/me/proj"]).toMatchObject({ hasTrustDialogAccepted: true, hasCompletedProjectOnboarding: true });
     expect(cfg.installMethod).toBeUndefined(); // no `native` install → no "missing or broken" warning
+  });
+});
+
+describe("parseMountConfigNames (credentials allowlist)", () => {
+  it("keeps only the known names (gh, gitconfig), drops unknown/blank", () => {
+    expect(parseMountConfigNames("gh, gitconfig")).toEqual(["gh", "gitconfig"]);
+    expect(parseMountConfigNames("gh,evil,../etc,gitconfig")).toEqual(["gh", "gitconfig"]);
+    expect(parseMountConfigNames("")).toEqual([]);
+    expect(parseMountConfigNames(undefined)).toEqual([]);
+  });
+});
+
+describe("resolveSandboxAuthArgs (opt-in, env-gated)", () => {
+  const prevConfigs = process.env.SANDBOX_MOUNT_CONFIGS;
+  const prevSsh = process.env.SANDBOX_SSH_AGENT_FORWARD;
+  afterEach(() => {
+    if (prevConfigs === undefined) delete process.env.SANDBOX_MOUNT_CONFIGS;
+    else process.env.SANDBOX_MOUNT_CONFIGS = prevConfigs;
+    if (prevSsh === undefined) delete process.env.SANDBOX_SSH_AGENT_FORWARD;
+    else process.env.SANDBOX_SSH_AGENT_FORWARD = prevSsh;
+  });
+  it("is empty when neither env is set (no impact by default)", () => {
+    delete process.env.SANDBOX_MOUNT_CONFIGS;
+    delete process.env.SANDBOX_SSH_AGENT_FORWARD;
+    expect(resolveSandboxAuthArgs()).toEqual([]);
+  });
+  it("forwards the ssh-agent socket read-only when SANDBOX_SSH_AGENT_FORWARD=1", () => {
+    delete process.env.SANDBOX_MOUNT_CONFIGS;
+    process.env.SANDBOX_SSH_AGENT_FORWARD = "1";
+    const args = resolveSandboxAuthArgs();
+    expect(args).toContain("/run/host-services/ssh-auth.sock:/ssh-agent");
+    expect(args).toContain("SSH_AUTH_SOCK=/ssh-agent");
   });
 });

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -91,6 +91,9 @@ describe("parseMountConfigNames (credentials allowlist)", () => {
     expect(parseMountConfigNames("")).toEqual([]);
     expect(parseMountConfigNames(undefined)).toEqual([]);
   });
+  it("collapses duplicate names (no duplicate -v mount → no docker error)", () => {
+    expect(parseMountConfigNames("gh,gh,gitconfig,gh")).toEqual(["gh", "gitconfig"]);
+  });
 });
 
 describe("resolveSandboxAuthArgs (opt-in, env-gated)", () => {

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -109,7 +109,9 @@ export function parseMountConfigNames(csv: string | undefined): string[] {
   const names = (csv ?? "")
     .split(",")
     .map((s) => s.trim())
-    .filter((s) => s in CONFIG_MOUNTS);
+    // Object.hasOwn, not `in`: `in` would accept prototype keys (__proto__, constructor,
+    // toString) whose CONFIG_MOUNTS[name] has no .host() → a startup crash from env input.
+    .filter((s) => Object.hasOwn(CONFIG_MOUNTS, s));
   return [...new Set(names)];
 }
 

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -144,7 +144,8 @@ export function resolveSandboxAuthArgs(): string[] {
   }
   if (process.env.SANDBOX_SSH_AGENT_FORWARD === "1") {
     // The socket lives inside Docker Desktop's VM, not the host FS — don't existsSync it.
-    args.push("-v", `${DESKTOP_SSH_SOCK}:/ssh-agent`, "-e", "SSH_AUTH_SOCK=/ssh-agent");
+    // `:ro` keeps the read-only guarantee; agent forwarding is socket I/O, not file writes.
+    args.push("-v", `${DESKTOP_SSH_SOCK}:/ssh-agent:ro`, "-e", "SSH_AUTH_SOCK=/ssh-agent");
   }
   return args;
 }

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -103,12 +103,14 @@ const CONFIG_MOUNTS: Record<string, { host: () => string; container: string }> =
   gitconfig: { host: () => path.join(os.homedir(), ".gitconfig"), container: `${CONTAINER_HOME}/.gitconfig` },
 };
 
-// Known allowlist names from the csv; unknown names are dropped (pure — for tests).
+// Known allowlist names from the csv; unknown names dropped and duplicates collapsed
+// (a repeated name would otherwise emit a duplicate -v mount and fail `docker run`).
 export function parseMountConfigNames(csv: string | undefined): string[] {
-  return (csv ?? "")
+  const names = (csv ?? "")
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s in CONFIG_MOUNTS);
+  return [...new Set(names)];
 }
 
 function runCapture(bin: string, args: string[]): { status: number | null; stdout: string } {

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -10,7 +10,7 @@
 // Verified in Phase 0 (#202): a sandboxed claude authenticates via the mounted ~/.claude
 // and connects to the host GUI MCP over host.docker.internal.
 import { spawnSync } from "node:child_process";
-import { writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -95,6 +95,56 @@ export function cleanupSandbox(sessionId: string): void {
   rmSync(sandboxClaudeConfigPath(sessionId), { force: true });
 }
 
+// --- Opt-in host credentials for the sandbox ---
+// A FIXED allowlist: the user picks names via SANDBOX_MOUNT_CONFIGS (comma-separated),
+// never arbitrary paths, and each is mounted READ-ONLY. macOS-scoped like the sandbox.
+const CONFIG_MOUNTS: Record<string, { host: () => string; container: string }> = {
+  gh: { host: () => path.join(os.homedir(), ".config", "gh"), container: `${CONTAINER_HOME}/.config/gh` },
+  gitconfig: { host: () => path.join(os.homedir(), ".gitconfig"), container: `${CONTAINER_HOME}/.gitconfig` },
+};
+
+// Known allowlist names from the csv; unknown names are dropped (pure — for tests).
+export function parseMountConfigNames(csv: string | undefined): string[] {
+  return (csv ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s in CONFIG_MOUNTS);
+}
+
+function runCapture(bin: string, args: string[]): { status: number | null; stdout: string } {
+  const r = spawnSync(bin, args, { encoding: "utf8" });
+  return { status: r.status, stdout: r.stdout ?? "" };
+}
+
+// gh on macOS keeps its token in the Keychain (not ~/.config/gh/hosts.yml), so mounting
+// the config dir alone won't authenticate gh / git-over-https. Best-effort: pass the
+// token as GH_TOKEN so it works inside the container.
+function ghTokenArgs(): string[] {
+  const r = runCapture("gh", ["auth", "token"]);
+  const token = r.status === 0 ? r.stdout.trim() : "";
+  return token ? ["-e", `GH_TOKEN=${token}`] : [];
+}
+
+// Docker Desktop (macOS) exposes the host ssh-agent at this fixed in-VM socket path.
+const DESKTOP_SSH_SOCK = "/run/host-services/ssh-auth.sock";
+
+// Extra `docker run` args for opt-in host credentials (all env-gated + read-only). Only
+// reached from buildDockerRunArgs (the sandbox path), so it has no effect otherwise.
+export function resolveSandboxAuthArgs(): string[] {
+  const args: string[] = [];
+  for (const name of parseMountConfigNames(process.env.SANDBOX_MOUNT_CONFIGS)) {
+    const m = CONFIG_MOUNTS[name];
+    const host = m.host();
+    if (existsSync(host)) args.push("-v", `${host}:${m.container}:ro`);
+    if (name === "gh") args.push(...ghTokenArgs());
+  }
+  if (process.env.SANDBOX_SSH_AGENT_FORWARD === "1") {
+    // The socket lives inside Docker Desktop's VM, not the host FS — don't existsSync it.
+    args.push("-v", `${DESKTOP_SSH_SOCK}:/ssh-agent`, "-e", "SSH_AUTH_SOCK=/ssh-agent");
+  }
+  return args;
+}
+
 // The `docker run` argv that runs interactive `claude` in the sandbox. The workspace is
 // bind-mounted at its SAME absolute path so claude's transcript encodes identically to
 // the host (~/.claude/projects/<encoded-cwd>) — resume interoperates with host sessions.
@@ -121,6 +171,8 @@ export function buildDockerRunArgs(sessionId: string, claudeArgs: string[], cwd:
     `${claudeDir}:${CONTAINER_HOME}/.claude`,
     "-v",
     `${claudeConfigPath}:${CONTAINER_HOME}/.claude.json`,
+    // Opt-in host credentials (gh / gitconfig / SSH agent) — empty unless env-enabled.
+    ...resolveSandboxAuthArgs(),
     "-w",
     cwd,
     IMAGE,


### PR DESCRIPTION
## Summary
sandbox の Claude が **gh / git を使える**ように、host 認証を**opt-in の固定 allowlist**で渡す（MulmoClaude の設計を移植）。
- `SANDBOX_MOUNT_CONFIGS=gh,gitconfig` → 固定 allowlist を **read-only** mount。`gh`=`~/.config/gh`（＋macOS は Keychain 保管なので `gh auth token` から `GH_TOKEN` を注入）、`gitconfig`=`~/.gitconfig`。
- `SANDBOX_SSH_AGENT_FORWARD=1` → Docker Desktop の ssh-agent socket を forward（**鍵はコンテナに入らない**）。

**デフォルト影響ゼロ**: どちらの env も `buildDockerRunArgs`（＝sandbox spawn パス）でしか読まれないので、`MULMOTERMINAL_SANDBOX` が OFF（＝docker 不使用）なら一切評価されない。sandbox ON でも env 未設定ならマウントは増えない（二重 opt-in）。

## Items to Confirm / Review
- **allowlist**: `parseMountConfigNames` が既知名（`gh`/`gitconfig`）だけ通す。ユーザーは**任意パスを渡せない**（コード側固定）。全マウント **read-only**。
- **gh token**: macOS は Keychain なので `~/.config/gh` mount だけでは gh が未認証 → `gh auth token` の結果を `GH_TOKEN` env で渡す（MulmoClaude と同方針）。token は `docker inspect` の env に見える（自分のマシン・自分の sandbox なので許容）。best-effort（gh 未ログインなら付けない）。
- **ssh socket**: `/run/host-services/ssh-auth.sock` は Docker Desktop の VM 内パスなので host で `existsSync` しない（フラグのみで gate）。
- **影響ゼロ**: `resolveSandboxAuthArgs()` は sandbox 起動時のみ呼ばれる。env 未設定で `[]`（テスト有）。
- 対象は macOS（Phase 1 と同じ）。

## User Prompt
> 推奨で順次（credentials から）。これも docker 使わない場合は副作用無いよね？（→ はい、sandbox パス限定で二重 opt-in）

## Implementation
- `server/sandbox.ts`: `parseMountConfigNames`（allowlist）、`resolveSandboxAuthArgs`（env-gated の read-only mount ＋ gh token ＋ ssh forward）を `buildDockerRunArgs` に splice。
- tests: allowlist parse / ssh-forward args / 既定空。実マシンで gh・gitconfig・ssh の実 args を確認。README に env を追記。

## テスト手順
### 自動
`yarn typecheck(:server) && lint && build && test`（**test 626**）。
### 手動（macOS + Docker + sandbox）
1. `SANDBOX_MOUNT_CONFIGS=gh,gitconfig SANDBOX_SSH_AGENT_FORWARD=1 MULMOTERMINAL_SANDBOX=1 yarn dev`
2. single view の Claude に `gh auth status` / `git config user.name` / `gh repo view` を実行させる → 通る
3. `docker inspect mulmoterminal-<id>` の Mounts が `~/.config/gh`・`~/.gitconfig`・ssh socket（すべて `:ro`）、Env に `GH_TOKEN`・`SSH_AUTH_SOCK`
4. env を外す → マウントが消える（＝完全 opt-in）

## スコープ外
Linux uid（Phase 5b）、user stdio MCP（Phase 4）、Phase 3（会話中反映）、token 認証。

Refs #202