### PR TITLE
chore: adopt CI security checks from mulmoclaude (gitleaks + actionlint/zizmor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,19 @@ on:
   pull_request:
     branches: [main, dev_tool]
 
+# Least privilege: every job here only reads the checked-out repo
+# (lint / build / test / pack-and-boot). No pushes, no PR/issue writes.
+permissions:
+  contents: read
+
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Read-only CI; don't persist the token in .git/config (zizmor artipacked).
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -42,6 +50,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Read-only CI; don't persist the token in .git/config (zizmor artipacked).
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -57,7 +68,14 @@ jobs:
       - name: Stub Claude Code CLI
         run: |
           mkdir -p "$HOME/.local/bin"
-          printf '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo "claude 0.0.0 (smoke-stub)"; exit 0; fi\necho "smoke-stub claude started"\nexit 0\n' > "$HOME/.local/bin/claude"
+          # Quoted heredoc (<<'STUB') = pure literal: $1 / $HOME are the STUB's
+          # own runtime references and must reach the file unexpanded.
+          cat > "$HOME/.local/bin/claude" <<'STUB'
+          #!/usr/bin/env bash
+          if [ "$1" = "--version" ]; then echo "claude 0.0.0 (smoke-stub)"; exit 0; fi
+          echo "smoke-stub claude started"
+          exit 0
+          STUB
           chmod +x "$HOME/.local/bin/claude"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,48 @@
+name: secret-scan
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  # Least privilege: gitleaks only needs to read the checked-out
+  # repo. No issues / PRs / packages access.
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history scan needs every commit
+          persist-credentials: false  # read-only scan; don't persist the token
+
+      # gitleaks-action@v2 は Organization 配下だとライセンスキー必須になったため、
+      # MIT ライセンスの gitleaks CLI バイナリを直接実行する。
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          # SHA256 of gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz from
+          # https://github.com/gitleaks/gitleaks/releases — refresh
+          # alongside any GITLEAKS_VERSION bump.
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          set -euo pipefail
+          ARCHIVE="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${ARCHIVE}"
+          echo "${GITLEAKS_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f "$ARCHIVE" gitleaks
+          rm -f "$ARCHIVE"
+          gitleaks version
+
+      - name: Run gitleaks (full history scan)
+        # `detect` scans the full git log by default; `--source .`
+        # just sets the working dir. `.gitleaksignore` at repo root
+        # is honoured automatically. exit-code 1 fails the job on
+        # any unallowlisted finding.
+        run: gitleaks detect --source . --redact --verbose --exit-code 1

--- a/.github/workflows/workflow-lint.yaml
+++ b/.github/workflows/workflow-lint.yaml
@@ -1,0 +1,87 @@
+name: workflow-lint
+
+# Static analysis for the GitHub Actions workflows themselves:
+#   - actionlint: YAML / ${{ }} expression syntax + embedded shellcheck
+#                 on `run:` blocks
+#   - zizmor:     workflow security (template injection, excessive
+#                 permissions, artifact poisoning); complements CodeQL
+#
+# Follows the repo's supply-chain posture (see secret-scan.yml): pull a
+# version-pinned CLI binary and SHA256-verify it rather than depending
+# on a third-party GitHub Action. Refresh VERSION + SHA256 together
+# when bumping (checksums: actionlint ships a checksums.txt; zizmor's
+# is computed from the linux x86_64 tarball).
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/**'
+
+permissions:
+  # Least privilege: both tools only read the checked-out workflows.
+  contents: read
+
+jobs:
+  workflow-lint:
+    name: workflow-lint (actionlint + zizmor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # No git pushes from this job; don't leave the token in
+          # .git/config (zizmor artipacked).
+          persist-credentials: false
+
+      - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          # sha256 of actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz
+          # from the release's actionlint_<v>_checksums.txt.
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ARCHIVE}"
+          echo "${ACTIONLINT_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f "$ARCHIVE" actionlint
+          rm -f "$ARCHIVE"
+          actionlint --version
+
+      - name: Run actionlint
+        # Lints every workflow under .github/workflows. Embedded
+        # shellcheck (run: blocks) and pyflakes run automatically when
+        # those tools are on PATH — ubuntu-latest ships shellcheck.
+        run: actionlint -color
+
+      - name: Install zizmor
+        env:
+          ZIZMOR_VERSION: 1.25.2
+          # sha256 of zizmor-x86_64-unknown-linux-gnu.tar.gz computed
+          # from the release tarball (zizmor publishes no checksums
+          # file — recompute on every version bump).
+          ZIZMOR_SHA256: aa1facd105f0d83fe5c55b1adcd9d7417de5d83aa27471f91dc0b66cf3803577
+        run: |
+          set -euo pipefail
+          ARCHIVE="zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/${ARCHIVE}"
+          echo "${ZIZMOR_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f "$ARCHIVE" zizmor
+          rm -f "$ARCHIVE"
+          zizmor --version
+
+      - name: Run zizmor
+        # Offline, default ("regular") persona — low false-positive.
+        # .github/zizmor.yml relaxes unpinned-uses for first-party
+        # actions/* (tag pins accepted) while still requiring a hash
+        # pin for any future third-party action. GITHUB_TOKEN lets the
+        # few online audits resolve refs; read-only per the job perms.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: zizmor --persona=regular .github/workflows

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,16 @@
+# zizmor configuration. See https://docs.zizmor.sh/configuration/
+#
+# unpinned-uses: this repo deliberately tag-pins the first-party
+# `actions/*` actions (checkout / setup-node / cache / upload-artifact)
+# rather than SHA-pinning them — official actions, low supply-chain
+# risk, and SHA pins force constant Dependabot churn. So allow a plain
+# ref (tag) pin for `actions/*`, but still require a full hash pin for
+# anything else, so a future third-party / community action can't slip
+# in tag-pinned unnoticed. Revisit if non-first-party actions are
+# introduced. (#1423)
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "*": hash-pin

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,13 @@
+# gitleaks fingerprints we deliberately allow.
+#
+# Format: <commit-sha>:<file>:<rule>:<line>
+# Each entry silences exactly that one finding — the same file at a
+# different line, or the same line in a NEW commit, gets re-scanned.
+#
+# This file is ALSO scanned by gitleaks. Do NOT paste a literal
+# secret-shaped string into any rationale comment — gitleaks would
+# flag the rationale itself. Describe the shape, don't reproduce it.
+#
+# Empty today: the full-history scan (see .github/workflows/secret-scan.yml)
+# reports no findings. Add a fingerprint here only for a verified
+# false positive (e.g. a test fixture with a fake token shape).


### PR DESCRIPTION
## Summary

Adopts two proven, self-contained CI jobs from the sibling repo **receptron/mulmoclaude** (as of 2026-07-05), plus the minimal hardening to `ci.yml` needed to pass them cleanly:

- **`secret-scan.yml`** — gitleaks full-history secret scan. Pulls a version-pinned CLI binary and SHA256-verifies it (no third-party Action). Honours `.gitleaksignore` automatically.
- **`workflow-lint.yaml`** — actionlint (+ embedded shellcheck) and zizmor (workflow supply-chain) on the workflow YAML itself, only when `.github/**` changes. `.github/zizmor.yml` relaxes `unpinned-uses` to `ref-pin` for first-party `actions/*` only (tag pins OK), still requiring a hash pin for any future third-party action.
- **`ci.yml` hardening** (so zizmor/actionlint stay green): top-level `permissions: contents: read`, `persist-credentials: false` on both checkouts, and the smoke-stub `printf` rewritten as a quoted heredoc (root-cause fix for the SC2016 false positive — the generated stub is byte-equivalent).
- **`.gitleaksignore`** — header-only template documenting the fingerprint format (MT has no findings today).

All three checks were run **locally at the pinned tool versions** and pass before pushing:

| check | result |
|-------|--------|
| gitleaks 8.30.1 (full history) | ✅ 0 leaks / 375 commits |
| actionlint 1.7.12 | ✅ 0 issues |
| zizmor 1.25.2 (regular, offline) | ✅ 0 findings (13 suppressed = actions/* ref-pin policy) |

## Items to Confirm / Review

- **Zero runtime impact** — CI-only. No app/server/client code changed; default behavior is untouched.
- **Smoke-stub rewrite** (`ci.yml`): please sanity-check the quoted-heredoc form. I verified it functionally (both `claude --version` and a bare invocation behave identically to the old `printf`), but it's the one behavioral line in the diff.
- **zizmor online audits**: I verified locally with `--offline` (no token). CI runs it with `GITHUB_TOKEN` for the few online ref-resolution audits — same config mulmoclaude runs in CI, so low risk, but the PR's own `workflow-lint` run is the real proof.
- **secret-scan triggers**: kept mulmoclaude's `pull_request` (unfiltered) + `push: [main]`. Every PR is scanned regardless of target branch; pushes are scanned on main.

## User Prompt

> 他、mulmoclaudeで使っているもので問題なく取り込めるものは進めて
> (From MulmoClaude, find and adopt whatever can be brought in without problems.)

This is the first, clearly-safe batch. Deferred as follow-ups (need a real run / would be disruptive): a Windows/multi-OS CI matrix (tests may need path fixes first) and `eslint-plugin-import` (would flag existing code).

## Source

Adopted from `receptron/mulmoclaude` at 2026-07-05. Tool versions and pinned SHAs copied verbatim; refresh them alongside any upstream bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)