### PR TITLE
fix(202): authenticate the sandbox from the macOS Keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,15 +146,24 @@ app's GUI MCP + activity hooks over `host.docker.internal`. Build the image firs
 
 This **contains** Claude — it can't reach the host filesystem outside the mounts, host
 processes, or arbitrary host ports. It is **not full isolation**: the **workspace** and
-**`~/.claude`** are bind-mounted **read-write** by design (so Claude edits your project
-and stays logged in, and transcripts interoperate with host sessions), so those specific
-paths stay mutable from inside. The sandbox is **non-persistent** (the container is
+**`~/.claude`** are bind-mounted **read-write** by design (so Claude edits your project,
+and transcripts interoperate with host sessions), so those specific paths stay mutable
+from inside. The sandbox is **non-persistent** (the container is
 `--rm`, tied to the session), **opt-in and single-view only** — the grid keeps its host +
 tmux path, and with the flag unset (or Docker unavailable) everything runs on the host
 exactly as before. **macOS only** for now — on Linux (bind-mount uid ownership) and
 Windows (host paths aren't valid Linux container paths) it falls back to the host spawn;
 both are follow-ups. Adding arbitrary user MCP servers to the sandbox is in progress
 (see #202).
+
+**Authentication (macOS).** Claude's live login token lives in the macOS **Keychain**,
+which the container can't read (mounting `~/.claude` alone isn't enough — its
+`.credentials.json` is often absent or stale). On each sandbox spawn MulmoTerminal exports
+the current credential to a per-session `~/.mulmoterminal/sandbox/creds-<id>.json`
+(mode `0600`, removed when the session ends) and mounts it **read-only** over the
+container's `~/.claude/.credentials.json`; your host `~/.claude` is never modified. If
+you've never logged in on the host, run `claude` once first — otherwise the server logs a
+warning and the container shows "Not logged in".
 
 **Host credentials (opt-in).** By default the sandbox has no host credentials. To let the
 sandboxed Claude use `gh`/`git`, set **`SANDBOX_MOUNT_CONFIGS=gh,gitconfig`** — a **fixed

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ import {
   dockerAvailable,
   buildDockerRunArgs,
   writeSandboxClaudeConfig,
+  writeSandboxCredentials,
   cleanupSandbox,
   rewriteLoopbackForDocker,
   SANDBOX_HOST,
@@ -1532,6 +1533,20 @@ function ptySpawn(sessionId: string, file: string, args: string[], cwd: string, 
   return { term: spawnPty(file, args, cwd), tmux: false };
 }
 
+// Spawn the single-view session inside a Docker container (the sandbox path). Exports the
+// host's live Keychain credential so the containerized claude is authenticated — without
+// it the container reads a stale/absent ~/.claude/.credentials.json and shows "Not logged in".
+function spawnSandboxEntry(sessionId: string, claudeArgs: string[], cwd: string, ws: WebSocket | null): PtyEntry {
+  cleanupSandbox(sessionId); // clear any stale container/config/credential with this name
+  const claudeConfig = writeSandboxClaudeConfig(sessionId, cwd);
+  const credentials = writeSandboxCredentials(sessionId);
+  if (credentials === null)
+    console.warn("[sandbox] no Claude credential found in the macOS Keychain — the container may be unauthenticated. Run `claude` on the host to log in.");
+  const term = spawnPty("docker", buildDockerRunArgs(sessionId, claudeArgs, cwd, claudeConfig, credentials), cwd);
+  console.log(`[pty] spawned claude (pid=${term.pid} via docker sandbox) in ${cwd}`);
+  return { term, ws, buffer: "", cwd, sandbox: true };
+}
+
 function spawnClaudePty(
   sessionId: string,
   resume: string | null,
@@ -1573,11 +1588,7 @@ function spawnClaudePty(
   // a live tmux session for this id (survived a restart) reattaches; else create it.
   let entry: PtyEntry;
   if (sandbox) {
-    cleanupSandbox(sessionId); // clear any stale container/config with this name
-    const claudeConfig = writeSandboxClaudeConfig(sessionId, cwd);
-    const term = spawnPty("docker", buildDockerRunArgs(sessionId, args, cwd, claudeConfig), cwd);
-    console.log(`[pty] spawned claude (pid=${term.pid} via docker sandbox) in ${cwd}`);
-    entry = { term, ws, buffer: "", cwd, sandbox: true };
+    entry = spawnSandboxEntry(sessionId, args, cwd, ws);
   } else {
     const { term, tmux } = ptySpawn(sessionId, CLAUDE_BIN, args, cwd, true);
     console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { readFileSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -9,6 +9,8 @@ import {
   buildDockerRunArgs,
   writeSandboxClaudeConfig,
   sandboxClaudeConfigPath,
+  sandboxCredentialsPath,
+  cleanupSandbox,
   parseMountConfigNames,
   resolveSandboxAuthArgs,
 } from "./sandbox";
@@ -69,6 +71,39 @@ describe("buildDockerRunArgs", () => {
     expect(args).toContain(`${path.join(os.homedir(), ".claude")}:/home/node/.claude`);
     expect(args).toContain("/cfg/x.json:/home/node/.claude.json"); // the generated config, NOT host ~/.claude.json
     expect(args[args.indexOf("-w") + 1]).toBe("/Users/me/proj");
+  });
+});
+
+describe("sandboxCredentialsPath", () => {
+  it("names a per-session creds file under the sandbox dir", () => {
+    expect(sandboxCredentialsPath("abc-123")).toBe(path.join(os.homedir(), ".mulmoterminal", "sandbox", "creds-abc-123.json"));
+  });
+});
+
+describe("buildDockerRunArgs credential overlay", () => {
+  it("overlays the creds file read-only, AFTER the ~/.claude dir mount so it shadows the stale one", () => {
+    const args = buildDockerRunArgs("sid1", ["--x"], "/Users/me/proj", "/cfg/x.json", "/creds/y.json");
+    expect(args).toContain("/creds/y.json:/home/node/.claude/.credentials.json:ro"); // read-only, host file untouched
+    const dirMount = args.indexOf(`${path.join(os.homedir(), ".claude")}:/home/node/.claude`);
+    const overlay = args.indexOf("/creds/y.json:/home/node/.claude/.credentials.json:ro");
+    expect(dirMount).toBeGreaterThan(-1);
+    expect(overlay).toBeGreaterThan(dirMount); // a deeper target only shadows when mounted after its parent
+  });
+  it("adds NO credential overlay when credentialsPath is omitted/null", () => {
+    const args = buildDockerRunArgs("sid1", ["--x"], "/Users/me/proj", "/cfg/x.json");
+    expect(args.some((a) => a.includes("/.claude/.credentials.json"))).toBe(false);
+  });
+});
+
+describe("cleanupSandbox", () => {
+  it("unlinks the per-session credential file (no leaked token after reap)", () => {
+    const sid = "cleanup-creds-1";
+    const file = sandboxCredentialsPath(sid);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, "dummy");
+    expect(existsSync(file)).toBe(true);
+    cleanupSandbox(sid);
+    expect(existsSync(file)).toBe(false);
   });
 });
 

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -10,7 +10,7 @@
 // Verified in Phase 0 (#202): a sandboxed claude authenticates via the mounted ~/.claude
 // and connects to the host GUI MCP over host.docker.internal.
 import { spawnSync } from "node:child_process";
-import { writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, chmodSync, rmSync, mkdirSync, existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -63,9 +63,10 @@ export function dockerAvailable(): boolean {
 // host's ~/.claude.json: it records a `native` install at ~/.local/bin (which doesn't
 // exist in the container, so claude warns "missing or broken"), and mounting it
 // read-write would let the container mutate the user's global config. Instead we mount
-// auth via ~/.claude/.credentials.json (the dir) and a minimal generated config that
-// marks onboarding done and pre-trusts the workspace (so no theme / trust prompts).
-// Under the app's own (user-owned) home, not a world-writable temp dir.
+// auth via ~/.claude (the dir) — overlaid with the live Keychain credential (see
+// writeSandboxCredentials) — plus a minimal generated config that marks onboarding done
+// and pre-trusts the workspace (so no theme / trust prompts). Under the app's own
+// (user-owned) home, not a world-writable temp dir.
 const SANDBOX_DIR = path.join(os.homedir(), ".mulmoterminal", "sandbox");
 export function sandboxClaudeConfigPath(sessionId: string): string {
   return path.join(SANDBOX_DIR, `claude-${sessionId}.json`);
@@ -87,12 +88,42 @@ export function writeSandboxClaudeConfig(sessionId: string, cwd: string): string
   return file;
 }
 
+// The macOS Keychain service Claude Code stores its OAuth credential under. On macOS
+// the LIVE token lives here — NOT in ~/.claude/.credentials.json, which is often absent
+// or stale. The container can't read the Keychain, so we export the current credential
+// to a per-session file and overlay it read-only onto the mounted
+// ~/.claude/.credentials.json (see buildDockerRunArgs). The host's own file is never
+// touched. macOS-only: `security` doesn't exist elsewhere, and the sandbox is
+// darwin-gated anyway.
+const KEYCHAIN_CREDENTIAL_SERVICE = "Claude Code-credentials";
+
+export function sandboxCredentialsPath(sessionId: string): string {
+  return path.join(SANDBOX_DIR, `creds-${sessionId}.json`);
+}
+
+// Export the host's live Claude credential from the macOS Keychain to a 0600 per-session
+// file for the container to mount. Returns the path, or null when the Keychain has no
+// entry (never logged in) or on a non-macOS host — the caller then spawns without the
+// overlay, falling back to whatever ~/.claude/.credentials.json holds.
+export function writeSandboxCredentials(sessionId: string): string | null {
+  if (process.platform !== "darwin") return null;
+  const r = runCapture("security", ["find-generic-password", "-s", KEYCHAIN_CREDENTIAL_SERVICE, "-w"]);
+  const credential = r.status === 0 ? r.stdout.trim() : "";
+  if (!credential) return null;
+  mkdirSync(SANDBOX_DIR, { recursive: true });
+  const file = sandboxCredentialsPath(sessionId);
+  writeFileSync(file, credential, { mode: 0o600 });
+  chmodSync(file, 0o600); // writeFileSync's mode only applies on creation; enforce it if the file pre-existed
+  return file;
+}
+
 // Best-effort teardown: force-remove the container (killing the `docker run` client
-// alone can leave it behind) and delete the throwaway per-session config. Used before a
-// spawn (clear stale) and on reap.
+// alone can leave it behind) and delete the throwaway per-session config + credential.
+// Used before a spawn (clear stale) and on reap.
 export function cleanupSandbox(sessionId: string): void {
   run("docker", ["rm", "-f", sandboxContainerName(sessionId)]);
   rmSync(sandboxClaudeConfigPath(sessionId), { force: true });
+  rmSync(sandboxCredentialsPath(sessionId), { force: true });
 }
 
 // --- Opt-in host credentials for the sandbox ---
@@ -153,10 +184,17 @@ export function resolveSandboxAuthArgs(): string[] {
 // The `docker run` argv that runs interactive `claude` in the sandbox. The workspace is
 // bind-mounted at its SAME absolute path so claude's transcript encodes identically to
 // the host (~/.claude/projects/<encoded-cwd>) — resume interoperates with host sessions.
-// ~/.claude (dir) is mounted for auth + transcripts; `claudeConfigPath` is the generated
-// per-session ~/.claude.json. `claudeArgs` already have their --settings/--mcp-config
-// URLs rewritten to host.docker.internal by the caller.
-export function buildDockerRunArgs(sessionId: string, claudeArgs: string[], cwd: string, claudeConfigPath: string): string[] {
+// ~/.claude (dir) is mounted for auth + transcripts; `credentialsPath` (when set)
+// overlays the live Keychain credential onto ~/.claude/.credentials.json; `claudeConfigPath`
+// is the generated per-session ~/.claude.json. `claudeArgs` already have their
+// --settings/--mcp-config URLs rewritten to host.docker.internal by the caller.
+export function buildDockerRunArgs(
+  sessionId: string,
+  claudeArgs: string[],
+  cwd: string,
+  claudeConfigPath: string,
+  credentialsPath: string | null = null,
+): string[] {
   const claudeDir = path.join(os.homedir(), ".claude");
   return [
     "run",
@@ -174,6 +212,10 @@ export function buildDockerRunArgs(sessionId: string, claudeArgs: string[], cwd:
     `${cwd}:${cwd}`,
     "-v",
     `${claudeDir}:${CONTAINER_HOME}/.claude`,
+    // Overlay the live Keychain credential over the dir mount's possibly-stale
+    // ~/.claude/.credentials.json — a deeper bind-mount target shadows the file inside
+    // the dir mount. Read-only; the host file is never modified. Absent → no overlay.
+    ...(credentialsPath ? ["-v", `${credentialsPath}:${CONTAINER_HOME}/.claude/.credentials.json:ro`] : []),
     "-v",
     `${claudeConfigPath}:${CONTAINER_HOME}/.claude.json`,
     // Opt-in host credentials (gh / gitconfig / SSH agent) — empty unless env-enabled.


### PR DESCRIPTION
## Summary

The single-view Docker sandbox (`MULMOTERMINAL_SANDBOX=1`) started `claude` **"Not logged in"** — so a new single-view session appeared to "not connect". Root cause: on macOS the **live** Claude token lives in the **Keychain**, but the sandbox only mounted `~/.claude`, whose `.credentials.json` is often **absent or stale**. The container can't read the Keychain.

**Fix:** on each sandbox spawn (macOS), export the current Keychain credential to a `0600` per-session `~/.mulmoterminal/sandbox/creds-<id>.json` and overlay it **read-only** onto the container's `~/.claude/.credentials.json` (a deeper bind-mount target shadows the dir-mounted file). The host `~/.claude` is never modified; the file is removed on reap. Non-macOS or never-logged-in → `null`, no overlay, a warning is logged (previous behavior preserved).

Adopted from MulmoClaude's `sandbox:login` (`security find-generic-password -s 'Claude Code-credentials' -w`), but done **automatically at spawn** (option A) so there's no manual step.

## Items to Confirm / Review

- **Diagnosis path**: I reproduced it directly — `claude -p` inside the container returned `Not logged in`; mounting the fresh Keychain export returned `SANDBOX_OK`. Then verified the **server-driven** path renders the authenticated Claude Code UI (`HAS_NOT_LOGGED_IN: false`, `HAS_CLAUDE_UI: true`), the creds file is `-rw-------`, and the overlay mount is read-only.
- **Security**: the creds file holds the OAuth token → written `0600` under the user-owned `~/.mulmoterminal/sandbox/`, mounted `:ro`, unlinked on reap and before each spawn. Please sanity-check that lifecycle.
- **Keychain read** (`writeSandboxCredentials`) is not unit-tested (it does real Keychain I/O; on Linux CI it returns `null`). It's integration-verified above. The pure parts — path naming, the overlay in `buildDockerRunArgs` (present/read-only/ordered after the dir mount), and `cleanupSandbox` unlinking the file — are unit-tested (+4).
- **Complexity refactor**: extracted `spawnSandboxEntry()` from `spawnClaudePty` to stay under the cognitive-complexity limit; behavior unchanged.

## User Prompt

- (デバッグの流れ) 「single view で新しいセッションでも繋がらない」→ 原因調査。「これ、claude code の認証どうしてる? host のをコピー? mount? 内側で認証?」→ mount だが macOS Keychain の現行トークンが渡っていないと判明。
- 「A」= sandbox spawn 時に Keychain→per-session creds を自動書き出し・コンテナへ read-only mount・host の `~/.claude` は非破壊・reap で削除、という自動方式で実装する。

## Verification

| check | result |
|-------|--------|
| container auth (server-driven single view) | ✅ authenticated Claude UI, no "Not logged in" |
| creds file perms | ✅ `-rw-------` (0600) |
| overlay mount | ✅ read-only (`RW=false`) |
| lint / typecheck / typecheck:server / build | ✅ |
| tests | ✅ 634 pass (+4) |

Source: adopted from `receptron/mulmoclaude` (`sandbox:login` mechanism) at 2026-07-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)