### PR TITLE
fix(210): pass collection paths to action seed prompts

### DIFF
--- a/plans/fix-210-collection-action-paths.md
+++ b/plans/fix-210-collection-action-paths.md
@@ -1,0 +1,26 @@
+# fix #210 — collection actions send seed prompt without `<collection_paths>`
+
+## Problem
+
+Collection action buttons (e.g. jma-weather の「初期設定」/「使い方」) send the seed
+prompt to chat, but the skill can't run: the two action routes in
+`server/backends/collections.ts` call the shared seed builders **without the optional
+`paths` argument**, so the prompt lacks the `<collection_paths>` block. The skill
+template needs `skillDir` / `dataPath` from that block to locate its files.
+
+- item-level route (`POST /api/collections/:slug/items/:itemId/actions/:actionId`)
+- collection-level route (`POST /api/collections/:slug/actions/:actionId`)
+
+## Fix (MT-only, no package bump)
+
+`@mulmoclaude/core/collection/server` already exports `promptPathsFor(collection,
+workspaceRoot)` and `getWorkspaceRoot()` (dep is `@mulmoclaude/core@^0.8.2`), and MT
+already calls `configureCollectionHost({ workspaceRoot })` at init so `getWorkspaceRoot()`
+resolves. Pass `promptPathsFor(collection, getWorkspaceRoot())` as the last arg to both
+builders. Mirrors MulmoClaude's `server/api/routes/collections.ts`.
+
+## Verification
+
+- `yarn format/lint/typecheck/typecheck:server/build/test` — all green (634 tests).
+- Ran the server and `POST /api/collections/jma-weather/actions/setup`: response prompt
+  now contains the `<collection_paths>` block (`slug` / `dataPath` / `skillDir`).

--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -439,20 +439,35 @@ describe("record CRUD", () => {
 describe("action routes (seed prompts)", () => {
   const post = (url: string) => fetch(`${base}${url}`, { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
 
-  it("returns a per-record action's seed prompt + role", async () => {
+  // #210 regression: the seed prompt must embed the <collection_paths> block so the skill
+  // can resolve skillDir/dataPath. Both routes silently dropped it before the fix.
+  const expectCollectionPaths = (prompt: string) => {
+    // The prompt's preamble literally names the tag ("<collection_paths> block carries…")
+    // before the real block, so anchor on the JSON object to skip that prose.
+    const block = prompt.match(/<collection_paths>\s*(\{[\s\S]*?\})\s*<\/collection_paths>/);
+    expect(block).not.toBeNull();
+    const paths = JSON.parse(block?.[1] ?? "{}");
+    expect(paths.slug).toBe("testcol");
+    expect(typeof paths.skillDir).toBe("string");
+    expect(typeof paths.dataPath).toBe("string");
+  };
+
+  it("returns a per-record action's seed prompt + role (with collection paths)", async () => {
     const res = await post("/api/collections/testcol/items/item1/actions/enrich");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { prompt: string; role: string };
     expect(body.role).toBe("general");
     expect(body.prompt).toContain("ENRICH_TEMPLATE");
+    expectCollectionPaths(body.prompt);
   });
 
-  it("returns a collection-level action's seed prompt + role", async () => {
+  it("returns a collection-level action's seed prompt + role (with collection paths)", async () => {
     const res = await post("/api/collections/testcol/actions/audit");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { prompt: string; role: string };
     expect(body.role).toBe("general");
     expect(body.prompt).toContain("AUDIT_TEMPLATE");
+    expectCollectionPaths(body.prompt);
   });
 
   it("404s an unknown action id", async () => {

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -31,6 +31,8 @@ import {
   readSkillTemplate,
   buildActionSeedPrompt,
   buildCollectionActionSeedPrompt,
+  promptPathsFor,
+  getWorkspaceRoot,
   toSummary,
   toDetail,
   validateCollectionRecords,
@@ -410,7 +412,10 @@ export function mountCollectionRoutes(app: Express): void {
           res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
           return;
         }
-        res.json({ prompt: buildActionSeedPrompt(record, template), role: action.role });
+        // Pass the collection paths so the seed prompt carries the <collection_paths>
+        // block — the skill template needs skillDir/dataPath to find its files.
+        const paths = promptPathsFor(collection, getWorkspaceRoot());
+        res.json({ prompt: buildActionSeedPrompt(record, template, paths), role: action.role });
       } catch (err) {
         log.warn("collections", "item action seed failed", {
           slug: collection.slug,
@@ -442,7 +447,8 @@ export function mountCollectionRoutes(app: Express): void {
         return;
       }
       const allItems = await listItems(collection.dataDir);
-      res.json({ prompt: buildCollectionActionSeedPrompt(allItems, collection.schema, template), role: action.role });
+      const paths = promptPathsFor(collection, getWorkspaceRoot());
+      res.json({ prompt: buildCollectionActionSeedPrompt(allItems, collection.schema, template, paths), role: action.role });
     } catch (err) {
       log.warn("collections", "collection action seed failed", { slug: collection.slug, actionId: req.params.actionId, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });


### PR DESCRIPTION
## Summary

Fixes #210. Collection **action buttons** (e.g. jma-weather の「初期設定」/「使い方」) sent the seed prompt to chat, but the skill couldn't run — the prompt was missing the `<collection_paths>` block that tells the skill where `skillDir` / `dataPath` are.

Root cause: the two action routes in `server/backends/collections.ts` called the shared seed builders **without their optional `paths` argument**:
- item-level: `buildActionSeedPrompt(record, template)` — missing 3rd arg
- collection-level: `buildCollectionActionSeedPrompt(allItems, schema, template)` — missing 4th arg

Fix: pass `promptPathsFor(collection, getWorkspaceRoot())` as the last arg to both. Both helpers are already exported by `@mulmoclaude/core@^0.8.2`, and MT already calls `configureCollectionHost({ workspaceRoot })` at init so `getWorkspaceRoot()` resolves — **no package bump, MT-only**. Mirrors MulmoClaude's `server/api/routes/collections.ts`.

## Items to Confirm / Review

- **Verified against the codebase** (not blind-applied): confirmed the installed `@mulmoclaude/core@0.8.2` `.d.ts` signatures — `promptPathsFor(collection: Pick<LoadedCollection,"slug"|"schema"|"skillDir">, workspaceRoot: string)`, both builders take a trailing optional `paths?`; confirmed the barrel re-exports both (`export * from './io'` + `getWorkspaceRoot` from './host'); confirmed `configureCollectionHost` is called in `initCollectionsBackend`.
- **Chose `getWorkspaceRoot()`** (definite `string`, the engine's canonical source) over the file's local `workspaceRoot: string | null` — avoids null-guards and matches the issue/MC.
- **Runtime-verified** the collection-level route: `POST /api/collections/jma-weather/actions/setup` now returns a prompt containing the `<collection_paths>` block (`slug`/`dataPath`/`skillDir`). The item-level route is the identical change (jma-weather has no item actions to POST against).

## User Prompt

> 次 https://github.com/receptron/mulmoterminal/issues/210

(Implement issue #210.)

## Verification

| check | result |
|-------|--------|
| format / lint / typecheck / typecheck:server / build | ✅ |
| test | ✅ 634 pass |
| `POST …/jma-weather/actions/setup` → `<collection_paths>` present | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)