### PR TITLE
fix: deliver auto-run prompts by typing, not a tmux-overflowing CLI arg

### DIFF
--- a/plans/fix-collection-action-prompt-tmux-length.md
+++ b/plans/fix-collection-action-prompt-tmux-length.md
@@ -1,0 +1,46 @@
+# fix: collection action chats die on large prompts ("command too long")
+
+## Symptom
+
+Pressing a collection action button (e.g. jma-weather 初期設定/使い方) opens a chat, but
+"起動するだけで prompt が入力されない" — the session launches then nothing runs.
+
+## Root cause
+
+Action buttons auto-run the seed prompt via the `initialPrompt` path
+(`spawnBackgroundChat` draft:false → `spawnClaudePty(id, null, null, message)`), which
+passed the prompt to claude as a positional CLI arg (`claude … -- "<prompt>"`). But
+sessions are **tmux-wrapped** for persistence (#197), and a collection seed prompt is
+large (~20KB). `tmux new-session … claude … -- "<20KB>"` exceeds **tmux's command-length
+limit** → tmux prints "command too long" and the session dies on spawn (`exit code 1`).
+
+Verified: `tmux new-session … <20KB arg>` → "command too long"; a small arg or a direct
+(non-tmux) spawn with the same 20KB arg is fine.
+
+## Fix
+
+Deliver the auto-run prompt by **typing it into claude's input box after it's ready**
+(the existing draft-injection path: bracketed paste once the input-box marker paints),
+then press Enter to submit. `initialPrompt` no longer goes through `buildClaudeArgs` as a
+positional, so the tmux command stays short. Drafts keep their no-Enter (review) behavior;
+`initialPrompt` gets the Enter (auto-run). tmux persistence is preserved.
+
+- `server/claude-args.ts`: drop `initialPrompt` (+ the `--` positional) entirely.
+- `server/index.ts`: `pendingText = draft ?? initialPrompt`; `autoSubmit` only for
+  `initialPrompt`; append `\r` to the bracketed paste when auto-submitting.
+
+## Verification
+
+- Reproduced the exact action path (draft:false, real 20KB jma-weather prompt): before →
+  "command too long" + exit 1; after → no error, claude runs the skill (reads files, runs
+  `ls`/`python3 fetch.py`), spawned "via tmux" (persistence kept).
+- Confirmed paste + `\r` auto-submits in claude v2.1.201 (a short prompt computed its
+  answer).
+- `format`/`lint`/`typecheck`/`typecheck:server`/`build`/`test` green; added a
+  `claude-args` regression test asserting the argv never carries a bare `--` positional.
+
+## Related
+
+Complements #210/#212 (the `<collection_paths>` block): both are needed for collection
+actions to fully work — #212 so the skill can resolve its paths, this so the session
+doesn't die before running.

--- a/server/claude-args.spec.ts
+++ b/server/claude-args.spec.ts
@@ -52,8 +52,12 @@ describe("buildClaudeArgs", () => {
     expect(args).not.toContain("--resume");
   });
 
-  it("appends the initial prompt as a positional after -- (option terminator)", () => {
-    const args = buildClaudeArgs({ ...base, initialPrompt: "-rf danger" });
-    expect(args.slice(-2)).toEqual(["--", "-rf danger"]);
+  // Regression: an auto-run prompt must NOT be a `-- <prompt>` positional. A large seed
+  // prompt (e.g. a 20KB collection-action prompt) as a tmux `new-session` command arg
+  // overflows tmux's length limit ("command too long", killing the session); it's typed
+  // into the input box after spawn instead. So the argv must never carry a bare `--`.
+  it("never emits a `--` positional (auto-run text is typed in, not passed as an arg)", () => {
+    expect(buildClaudeArgs(base)).not.toContain("--");
+    expect(buildClaudeArgs({ ...base, canResume: true, resume: "44444444-4444-4444-4444-444444444444" })).not.toContain("--");
   });
 });

--- a/server/claude-args.ts
+++ b/server/claude-args.ts
@@ -17,7 +17,6 @@ export interface ClaudeArgsInput {
   attachGuiMcp: boolean;
   mcpConfig: string; // GUI MCP config JSON (--mcp-config), used only when attachGuiMcp
   guiMcpTools: string; // comma-joined GUI tool names (--allowedTools), used only when attachGuiMcp
-  initialPrompt?: string;
 }
 
 export function buildClaudeArgs(input: ClaudeArgsInput): string[] {
@@ -26,12 +25,10 @@ export function buildClaudeArgs(input: ClaudeArgsInput): string[] {
     guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config", "--allowedTools", input.guiMcpTools);
   }
 
-  const baseArgs =
-    input.canResume && input.resume !== null
-      ? ["--resume", input.resume, "--settings", input.settings, ...guiArgs]
-      : ["--session-id", input.sessionId, "--settings", input.settings, ...guiArgs];
-
-  // The initial prompt goes last as a positional arg; "--" ends option parsing so a
-  // prompt starting with "-" can't be reinterpreted as a flag.
-  return input.initialPrompt ? [...baseArgs, "--", input.initialPrompt] : baseArgs;
+  // No initial-prompt positional: an auto-run prompt is TYPED into the input box after
+  // claude is ready (see spawnClaudePty), not passed as an arg — a large prompt as a
+  // tmux `new-session` command arg overflows tmux's length limit ("command too long").
+  return input.canResume && input.resume !== null
+    ? ["--resume", input.resume, "--settings", input.settings, ...guiArgs]
+    : ["--session-id", input.sessionId, "--settings", input.settings, ...guiArgs];
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1579,7 +1579,6 @@ function spawnClaudePty(
     // Auto-allow the GUI tools + the user's own configured MCP servers (mcp__<id>), so
     // their tools don't trip a permission prompt on every call.
     guiMcpTools: [GUI_MCP_TOOLS, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(","),
-    initialPrompt,
   });
 
   console.log(`[ws] client connected (${canResume ? "resume" : "new"} ${sessionId})`);
@@ -1606,22 +1605,24 @@ function spawnClaudePty(
     pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" });
   }
 
-  // A draft is typed into the input box once claude is ready for input. ALL control
-  // bytes are stripped first — C0/C1, including ESC, Ctrl-C, CR/LF and an embedded
-  // bracketed-paste terminator (\e[201~) — so untrusted draft content (collection /
-  // custom-view text) can't inject terminal control sequences that break out of the
-  // paste and submit/interrupt. Only printable text is typed, wrapped in bracketed
-  // paste (\e[200~…\e[201~), with NO trailing Enter, so it can never auto-submit — the
-  // user reviews and presses Enter.
-
-  const draftText = draft ? sanitizeDraftText(draft) : "";
+  // The auto-run prompt (initialPrompt) and the editable draft are both delivered by
+  // TYPING into claude's input box once it's ready — NOT as a `claude` CLI arg, which a
+  // large prompt would overflow tmux's `new-session` command-length limit with ("command
+  // too long", killing the session). ALL control bytes are stripped first — C0/C1,
+  // including ESC, Ctrl-C, CR/LF and an embedded bracketed-paste terminator (\e[201~) —
+  // so untrusted text (collection / custom-view) can't inject sequences that break out
+  // of the paste. It's wrapped in bracketed paste (\e[200~…\e[201~); initialPrompt then
+  // presses Enter to run it, while a draft gets NO Enter so the user reviews + sends.
+  const pendingText = draft ?? initialPrompt;
+  const autoSubmit = draft === undefined && initialPrompt !== undefined;
+  const draftText = pendingText ? sanitizeDraftText(pendingText) : "";
   let draftDone = !draftText;
   let draftScan = "";
   const typeDraft = () => {
     if (draftDone) return;
     draftDone = true;
     try {
-      entry.term.write(`\x1b[200~${draftText}\x1b[201~`);
+      entry.term.write(`\x1b[200~${draftText}\x1b[201~${autoSubmit ? "\r" : ""}`);
     } catch {
       // pty already gone — nothing to draft into
     }


### PR DESCRIPTION
## Summary

Fixes the actual blocker behind "collection action buttons open a chat but nothing runs / the prompt isn't entered." (Companion to #212, which fixed the `<collection_paths>` block — **both** are needed for collection actions to work.)

**Root cause:** action buttons auto-run the seed prompt via the `initialPrompt` path (`spawnBackgroundChat` draft:false → `spawnClaudePty(id,null,null,message)`), which passed the prompt to claude as a **positional CLI arg** (`claude … -- "<prompt>"`). Sessions are **tmux-wrapped** for persistence (#197), and a collection seed prompt is **~20KB** — `tmux new-session … claude … -- "<20KB>"` exceeds **tmux's command-length limit**, so tmux prints `command too long` and the session dies on spawn (`exit 1`).

**Fix:** deliver the auto-run prompt by **typing it into claude's input box after it's ready** (reusing the existing draft bracketed-paste path), then press Enter to submit — so the tmux command stays short. Drafts keep their no-Enter (review) behavior; `initialPrompt` gets the Enter (auto-run). **tmux persistence is preserved.**

- `server/claude-args.ts` — drop `initialPrompt` (and the `-- <prompt>` positional).
- `server/index.ts` — `pendingText = draft ?? initialPrompt`; `autoSubmit` only for `initialPrompt`; append `\r` to the bracketed paste when auto-submitting.

## Items to Confirm / Review

- **Verified end-to-end** (not just unit): reproduced the exact action path (draft:false, the real 20KB jma-weather `setup` prompt). Before → `command too long` + `exit 1`. After → no error; claude runs the skill (`[Pasted text #1]` → "I'll follow the JMA weather setup template…" → reads files, runs `ls …/jma-weather/items`, `python3 fetch.py …`), spawned **via tmux** (persistence kept).
- **Auto-submit** (paste + `\r`) confirmed to submit + run in claude v2.1.201 (a short prompt computed its answer).
- **Delivery-timing change**: `initialPrompt` used to run as claude's first arg (before any UI); it now types in after the input-box marker (~1s) then submits. The marker is reliable (matches v2.1.201) with a 6s fallback. This affects **all** `initialPrompt` callers (spawnBackgroundChat auto-run + plugin spawns), which all previously shared the same tmux-overflow risk.
- **Draft sanitizer** (`sanitizeDraftText`) strips CR/LF, so a multi-line prompt is pasted as one logical line — semantically fine for claude (verified it runs the skill), and it keeps the anti-injection guarantee.

## User Prompt

> チャットは起動するけど、起動するだけで prompt が入力されない。チャット起動まで時間がかかるからかなー。

(Collection action opens a chat but the prompt is never entered / the skill doesn't run.)

## Verification

| check | result |
|-------|--------|
| repro: 20KB action prompt | ✅ before "command too long"→exit1; after claude runs the skill |
| tmux persistence | ✅ still "via tmux" |
| lint / typecheck / typecheck:server / build | ✅ |
| test (+ new `claude-args` regression: no bare `--` positional) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)