### PR TITLE
fix: enable tmux mouse so grid-terminal wheel scrolls instead of cycling history

### DIFF
--- a/plans/fix-tmux-grid-terminal-scroll.md
+++ b/plans/fix-tmux-grid-terminal-scroll.md
@@ -1,0 +1,34 @@
+# fix: grid terminal 2-finger scroll cycles history instead of scrolling
+
+## Symptom
+
+In multi-terminal (grid) mode, 2-finger / wheel scroll no longer scrolls the terminal —
+instead claude's input history cycles (↑/↓).
+
+## Root cause
+
+Not the OSC-52 clipboard PR (#206 — that only added `ClipboardAddon`, no scroll code).
+The regression came from **#197 (tmux persistence)**: each grid pty now runs inside tmux.
+Claude enables mouse tracking (`?1000h`/`?1003h`/`?1006h`), but our tmux config set no
+mouse option, so tmux used its default `alternate-scroll on` — which, for a full-screen
+app with mouse mode off, **converts the wheel into ↑/↓ arrow keys**. Claude receives
+arrows → input-history cycling.
+
+Verified: the grid session spawns "via tmux"; claude emits the mouse-tracking DECSETs;
+`tmux -L mulmoterminal set -g mouse on` (applied live) fixes it (user-confirmed).
+
+## Fix (`server/tmux.ts`)
+
+Add `set -g mouse on` to the isolated server's config so tmux forwards the wheel to the
+program (claude scrolls) — restoring the pre-tmux behavior. Because a tmux server already
+running from persisted sessions ignores `-f` config on `new-session`, also apply the
+option **live** (`set -g mouse on`) when a server is already up; it's a no-op otherwise
+(the config file covers fresh starts).
+
+- Extracted the config to an exported `TMUX_CONF_LINES` for a regression test.
+
+## Verification
+
+- `format`/`lint`/`typecheck`/`typecheck:server`/`build`/`test` green; added a test
+  asserting `TMUX_CONF_LINES` contains `set -g mouse on`.
+- Live-applied to the running server and the user confirmed 2-finger scroll works again.

--- a/server/tmux.spec.ts
+++ b/server/tmux.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { tmuxSessionName, tmuxNewSessionArgs } from "./tmux";
+import { tmuxSessionName, tmuxNewSessionArgs, TMUX_CONF_LINES } from "./tmux";
 
 describe("tmuxSessionName", () => {
   it("prefixes the session id", () => {
@@ -23,5 +23,13 @@ describe("tmuxNewSessionArgs", () => {
     const dashdash = args.indexOf("--");
     expect(dashdash).toBeGreaterThan(0);
     expect(args.slice(dashdash + 1)).toEqual(["/bin/zsh", "-lc", "exec codex"]);
+  });
+});
+
+describe("TMUX_CONF_LINES", () => {
+  // Regression: without `mouse on`, tmux's default alternate-scroll turns the wheel into
+  // ↑/↓ arrows inside claude — cycling input history instead of scrolling the terminal.
+  it("enables mouse so the wheel scrolls the program instead of cycling history", () => {
+    expect(TMUX_CONF_LINES).toContain("set -g mouse on");
   });
 });

--- a/server/tmux.ts
+++ b/server/tmux.ts
@@ -35,13 +35,29 @@ export function tmuxAvailable(): boolean {
 }
 
 // Minimal config for our server: no status bar (this is a terminal INSIDE a terminal),
-// instant escape, generous scrollback, follow the latest client's size, and never
-// destroy a session just because our client detached (that IS the persistence).
+// instant escape, generous scrollback, follow the latest client's size, never destroy a
+// session just because our client detached (that IS the persistence), and `mouse on`.
+// `mouse on` forwards the wheel to the running program (claude enables mouse tracking)
+// instead of tmux's default alternate-scroll, which turns the wheel into ↑/↓ arrows —
+// inside claude that cycles the input history rather than scrolling (the grid-terminal
+// scroll regression introduced by wrapping each pty in tmux).
+export const TMUX_CONF_LINES: readonly string[] = [
+  "set -g status off",
+  "set -g escape-time 0",
+  "set -g history-limit 20000",
+  "set -g window-size latest",
+  "set -g destroy-unattached off",
+  "set -g mouse on",
+];
+
 function ensureConf(): void {
   try {
     mkdirSync(path.dirname(CONF_FILE), { recursive: true });
-    const conf = ["set -g status off", "set -g escape-time 0", "set -g history-limit 20000", "set -g window-size latest", "set -g destroy-unattached off"];
-    writeFileSync(CONF_FILE, conf.join("\n") + "\n");
+    writeFileSync(CONF_FILE, TMUX_CONF_LINES.join("\n") + "\n");
+    // A fresh server sources CONF_FILE via `-f` on its first `new-session`, but a server
+    // already running from persisted sessions ignores it — so apply `mouse` live too.
+    // No-op when no server is up yet (the config file covers that case on first launch).
+    if (tmux(["list-sessions"]).status === 0) tmux(["set", "-g", "mouse", "on"]);
   } catch {
     // non-fatal — tmux falls back to its defaults (a status bar, etc.)
   }


### PR DESCRIPTION
## Summary

In multi-terminal (grid) mode, 2-finger / wheel scroll stopped scrolling the terminal and instead cycled claude's input history (↑/↓).

**Not #206** (that only added the OSC-52 `ClipboardAddon` — no scroll/mouse code). The regression is from **#197 (tmux persistence)**: each grid pty now runs inside tmux. Claude enables mouse tracking (`?1000h`/`?1003h`/`?1006h`), but our isolated tmux config set no mouse option, so tmux used its default **`alternate-scroll on`** — which, for a full-screen app with mouse off, **converts the wheel into ↑/↓ arrows**. Claude gets arrows → history cycling.

**Fix** (`server/tmux.ts`): add `set -g mouse on` so tmux forwards the wheel to the program (claude scrolls), restoring the pre-tmux behavior. A tmux server already running from persisted sessions ignores `-f` config on `new-session`, so the option is **also applied live** when a server is up (no-op otherwise — the config file covers fresh starts).

## Items to Confirm / Review

- **Root-cause verified**, not guessed: confirmed the grid session spawns "via tmux", captured claude's mouse-tracking DECSETs, and confirmed `tmux ... set -g mouse on` fixes it. Applied it **live to the running server and the user confirmed 2-finger scroll works again**.
- **tmux reload semantics**: verified empirically that `-f <conf>` on `new-session` is ignored by an already-running server (mouse stayed off), while a live `set -g mouse on` applies immediately — hence the two-pronged fix.
- **Side effect**: with `mouse on`, plain drag goes to the program (claude handles selection; Shift+drag = native selection) — this matches the *pre-tmux* behavior (claude already had mouse tracking), so it's a restoration, not a new change. OSC-52 copy (#206) is unaffected.
- Extracted the config to an exported `TMUX_CONF_LINES` + added a regression test asserting it contains `set -g mouse on`.

## User Prompt

> MulmoTerminal の multi-terminal モードで、terminal のスクロール(2本指)が出来なくなっています。スクロールの代わりにコマンドヒストリーがクルクルします。これって206のPRの影響?

## Verification

| check | result |
|-------|--------|
| live-apply on running server → 2-finger scroll | ✅ user-confirmed "なおった" |
| lint / typecheck / typecheck:server / build | ✅ |
| test (+ `TMUX_CONF_LINES` regression) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)