### PR TITLE
fix: forward OSC 52 clipboard through tmux (Claude auto-copy in grid terminals)

### DIFF
--- a/plans/fix-tmux-osc52-clipboard.md
+++ b/plans/fix-tmux-osc52-clipboard.md
@@ -1,0 +1,37 @@
+# fix: OSC 52 clipboard (Claude auto-copy) swallowed by tmux in grid terminals
+
+## Context
+
+Proactive audit after the grid-scroll fix (#214): "他に tmux の影響はない?" — check what
+else the #197 tmux wrapping regressed.
+
+## Finding
+
+Grid terminals run inside tmux. When a program (Claude Code) emits **OSC 52** to copy a
+selection to the system clipboard, tmux intercepts it and, with its default
+`set-clipboard external` and no `Ms` capability for the outer terminal, **does not forward
+it** to the outer web terminal. So the ClipboardAddon (#206) never sees it → Claude's
+auto-copy silently doesn't reach the browser clipboard. Verified: OSC 52 emitted inside
+our tmux config does NOT reach the outer pty.
+
+(Also checked and OK: truecolor 24-bit is preserved through tmux; `default-terminal` is
+`tmux-256color`.)
+
+## Fix (`server/tmux.ts`)
+
+- `set -g set-clipboard on`
+- `set -ag terminal-overrides ",*:Ms=\E]52;%p1%s;%p2%s\007"` — declare that the outer web
+  terminal supports OSC 52 (its terminfo doesn't), so tmux forwards it. Appended so the
+  built-in `linux*:AX@` override survives.
+- Extracted the live-apply into `applyLiveTmuxOptions()` (mouse + set-clipboard +
+  Ms-if-absent), so an already-running server (persisted sessions) gets it without a
+  restart. Idempotent across node restarts.
+
+## Verification
+
+- OSC 52 now reaches the outer pty with the fix (both fresh config and live-applied to a
+  running server) — verified via node-pty.
+- Applied live to the running server; `set-clipboard on` + the Ms override are present,
+  default override preserved, no duplication.
+- `format`/`lint`/`typecheck`/`typecheck:server`/`build`/`test` green; added a regression
+  test asserting the config forwards OSC 52.

--- a/server/tmux.spec.ts
+++ b/server/tmux.spec.ts
@@ -32,4 +32,12 @@ describe("TMUX_CONF_LINES", () => {
   it("enables mouse so the wheel scrolls the program instead of cycling history", () => {
     expect(TMUX_CONF_LINES).toContain("set -g mouse on");
   });
+
+  // Regression: tmux swallows a program's OSC 52 unless set-clipboard is on AND the outer
+  // terminal is known to support it (the Ms override) — else Claude's auto-copy (#206)
+  // never reaches the browser clipboard inside grid terminals.
+  it("forwards OSC 52 to the outer terminal (Claude's auto-copy → browser clipboard)", () => {
+    expect(TMUX_CONF_LINES).toContain("set -g set-clipboard on");
+    expect(TMUX_CONF_LINES.some((l) => l.includes("terminal-overrides") && l.includes("Ms="))).toBe(true);
+  });
 });

--- a/server/tmux.ts
+++ b/server/tmux.ts
@@ -34,13 +34,22 @@ export function tmuxAvailable(): boolean {
   return cachedAvailable;
 }
 
+// The terminfo `Ms` capability (OSC 52 clipboard write). tmux only forwards a program's
+// OSC 52 to the OUTER terminal when it knows the outer terminal supports it — our web
+// xterm does (via the ClipboardAddon, #206), but its terminfo doesn't advertise `Ms`, so
+// we declare it. Without this, tmux swallows Claude Code's auto-copy and it never reaches
+// the browser clipboard. Appended (not set) so tmux's built-in overrides survive.
+const OSC52_MS_OVERRIDE = ",*:Ms=\\E]52;%p1%s;%p2%s\\007";
+
 // Minimal config for our server: no status bar (this is a terminal INSIDE a terminal),
 // instant escape, generous scrollback, follow the latest client's size, never destroy a
-// session just because our client detached (that IS the persistence), and `mouse on`.
-// `mouse on` forwards the wheel to the running program (claude enables mouse tracking)
-// instead of tmux's default alternate-scroll, which turns the wheel into ↑/↓ arrows —
-// inside claude that cycles the input history rather than scrolling (the grid-terminal
-// scroll regression introduced by wrapping each pty in tmux).
+// session just because our client detached (that IS the persistence), plus two fixes for
+// the terminal-in-terminal wrapping:
+//   - `mouse on`: forward the wheel to the program (claude has mouse tracking) instead of
+//     tmux's default alternate-scroll, which turns the wheel into ↑/↓ arrows (cycling
+//     claude's input history rather than scrolling).
+//   - `set-clipboard on` + the `Ms` override: forward OSC 52 clipboard writes to the
+//     outer terminal so Claude's auto-copy reaches the browser clipboard (#206).
 export const TMUX_CONF_LINES: readonly string[] = [
   "set -g status off",
   "set -g escape-time 0",
@@ -48,16 +57,27 @@ export const TMUX_CONF_LINES: readonly string[] = [
   "set -g window-size latest",
   "set -g destroy-unattached off",
   "set -g mouse on",
+  "set -g set-clipboard on",
+  `set -ag terminal-overrides "${OSC52_MS_OVERRIDE}"`,
 ];
+
+// A fresh server sources CONF_FILE via `-f` on its first `new-session`, but a server
+// already running from persisted sessions ignores it — so apply the options that must be
+// live. Idempotent across node restarts: mouse/set-clipboard are plain global sets; the
+// Ms override is appended only when it isn't already present.
+function applyLiveTmuxOptions(): void {
+  tmux(["set", "-g", "mouse", "on"]);
+  tmux(["set", "-g", "set-clipboard", "on"]);
+  if (!tmux(["show", "-g", "terminal-overrides"]).stdout.includes("Ms=")) {
+    tmux(["set", "-ag", "terminal-overrides", OSC52_MS_OVERRIDE]);
+  }
+}
 
 function ensureConf(): void {
   try {
     mkdirSync(path.dirname(CONF_FILE), { recursive: true });
     writeFileSync(CONF_FILE, TMUX_CONF_LINES.join("\n") + "\n");
-    // A fresh server sources CONF_FILE via `-f` on its first `new-session`, but a server
-    // already running from persisted sessions ignores it — so apply `mouse` live too.
-    // No-op when no server is up yet (the config file covers that case on first launch).
-    if (tmux(["list-sessions"]).status === 0) tmux(["set", "-g", "mouse", "on"]);
+    if (tmux(["list-sessions"]).status === 0) applyLiveTmuxOptions();
   } catch {
     // non-fatal — tmux falls back to its defaults (a status bar, etc.)
   }


### PR DESCRIPTION
## Summary

Follow-up audit after #214 ("他に tmux の影響はない?"). Found a second regression from wrapping grid ptys in tmux (#197): **Claude Code's OSC-52 auto-copy no longer reaches the browser clipboard inside grid terminals**, defeating #206.

tmux intercepts a program's OSC 52 clipboard write. With its default `set-clipboard external` and no `Ms` capability declared for the outer web terminal, tmux **doesn't forward** the sequence — so the ClipboardAddon (#206) never sees it. Verified: OSC 52 emitted inside our tmux config does not reach the outer pty.

**Fix** (`server/tmux.ts`):
- `set -g set-clipboard on`
- `set -ag terminal-overrides ",*:Ms=\E]52;%p1%s;%p2%s\007"` — tell tmux the outer terminal supports OSC 52 (its terminfo doesn't advertise it), so tmux forwards it. Appended so tmux's built-in `linux*:AX@` override survives.
- Extracted the live-apply into `applyLiveTmuxOptions()` (mouse + set-clipboard + Ms-if-absent) so a server already running from persisted sessions gets it **without a restart** (idempotent across node restarts).

## Items to Confirm / Review

- **Verified with node-pty**: OSC 52 does NOT reach the outer pty with the old config; WITH the fix it does — both from a fresh config *and* when live-applied to an already-running server. Applied it live to the running server (its 27 persisted sessions), and `set-clipboard on` + the Ms override are present with the default preserved, no duplication.
- **Truecolor checked and OK**: 24-bit color is already preserved through tmux (`tmux-256color` + inherited `COLORTERM`), so no change needed there.
- **Idempotency**: the Ms override is appended only if not already present (avoids accumulation across restarts); mouse/set-clipboard are plain global sets.
- **Side effects**: `set-clipboard on` also keeps a tmux paste buffer — harmless; paste still uses the browser's native Cmd+V. OSC-52 *read* remains disabled at the addon layer (#206), so this is write-only.

## User Prompt

> ありがとう。他にtmuxの影響はない?

## Verification

| check | result |
|-------|--------|
| OSC 52 passthrough (node-pty, fresh + live) | ✅ reaches outer pty with fix |
| live-apply on running server | ✅ applied, default preserved, no dup |
| truecolor 24-bit | ✅ already preserved |
| lint / typecheck / typecheck:server / build | ✅ |
| test (+ OSC-52 config regression) | ✅ 636 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)