### PR TITLE
feat(collections): render mobile custom views in the desktop UI

### DIFF
--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -44,6 +44,7 @@ const SCHEMA = {
   views: [
     { id: "v1", file: "views/v1.html", label: "Custom", capabilities: ["read"] },
     { id: "v2", file: "views/v2.html", label: "Editable", capabilities: ["read", "write"] },
+    { id: "phone", file: "views/phone.html", label: "Phone", target: "mobile", editableFields: ["name"] },
   ],
   actions: [{ id: "enrich", label: "Enrich", kind: "chat", role: "general", template: "templates/enrich.md" }],
   collectionActions: [{ id: "audit", label: "Audit", kind: "chat", role: "general", template: "templates/audit.md" }],
@@ -65,6 +66,7 @@ beforeAll(async () => {
   mkdirSync(path.join(ws, "data", "skills", "testcol", "views"), { recursive: true });
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v1.html"), "<head></head><body>view</body>");
   writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "v2.html"), "<head></head><body>editable</body>");
+  writeFileSync(path.join(ws, "data", "skills", "testcol", "views", "phone.html"), "<head></head><body>phone-view</body>");
 
   // A singleton collection with a write-capable view, to prove PUT /view-data
   // enforces the singleton invariant (only the fixed id is writable).
@@ -568,5 +570,52 @@ describe("collection / view delete routes", () => {
     expect((await fetch(`${base}/api/collections/testcol/views/v1`, { method: "DELETE" })).status).toBe(403);
     vi.mocked(deleteCustomView).mockResolvedValueOnce({ kind: "not-found", viewId: "v1" } as never);
     expect((await fetch(`${base}/api/collections/testcol/views/v1`, { method: "DELETE" })).status).toBe(404);
+  });
+});
+
+// The desktop phone-frame preview's data source: a target:"mobile" view built
+// host-side into its sandboxed srcdoc, plus its writable-view mutate channel.
+describe("mobile custom views (phone-frame preview)", () => {
+  it("GET /:slug/remote-view builds a mobile view into a sandboxed srcdoc", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/remote-view?id=phone&locale=en`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.view).toMatchObject({ id: "phone", target: "mobile" });
+    expect(body.srcdoc).toContain("phone-view"); // the authored HTML body
+    expect(body.srcdoc).toContain("connect-src 'none'"); // the stricter mobile CSP
+    expect(typeof body.bytes).toBe("number");
+  });
+
+  it("GET /:slug/remote-view refuses a desktop view (400) and 404s an unknown view/collection", async () => {
+    expect((await fetch(`${base}/api/collections/testcol/remote-view?id=v1`)).status).toBe(400); // not target:mobile
+    expect((await fetch(`${base}/api/collections/testcol/remote-view?id=nope`)).status).toBe(404);
+    expect((await fetch(`${base}/api/collections/nope/remote-view?id=phone`)).status).toBe(404);
+  });
+
+  it("POST /:slug/remote-view/:viewId/mutate updates an editable field, forbids a non-editable one", async () => {
+    const ok = await fetch(`${base}/api/collections/testcol/remote-view/phone/mutate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ op: "update", id: "item1", patch: { name: "Renamed" } }),
+    });
+    expect(ok.status).toBe(200);
+    expect((await ok.json()).item.name).toBe("Renamed");
+
+    // `status` is not in the view's editableFields → host-side policy refuses it.
+    const forbidden = await fetch(`${base}/api/collections/testcol/remote-view/phone/mutate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ op: "update", id: "item1", patch: { status: "closed" } }),
+    });
+    expect(forbidden.status).toBe(403);
+  });
+
+  it("POST /:slug/remote-view/:viewId/mutate 400s a malformed request", async () => {
+    const res = await fetch(`${base}/api/collections/testcol/remote-view/phone/mutate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ nonsense: true }),
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -45,6 +45,10 @@ import {
 import { actionVisible, type CollectionItem } from "@mulmoclaude/core/collection";
 // Curated-registry engine (Discover tab): merged catalog fetch + bundle import.
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
+import { normalizeMutate } from "@mulmoclaude/core/remote-view";
+// Mobile custom-view builder — shared with the remote-host channel handlers so
+// the desktop phone-frame preview renders the EXACT artifact the phone receives.
+import { buildRemoteView, mutateRemoteView, remoteViewFailureMessage, mutateRemoteViewFailureMessage } from "./remoteView.js";
 import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
@@ -146,6 +150,15 @@ async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode:
   if (result.kind === "conflict")
     return { rejected: { id: itemId, problem: `'${itemId}' already exists — mode "create" refuses overwrite; use "upsert" to update it` } };
   return { rejected: { id: itemId, problem: "write refused: the collection's data dir escapes the workspace" } };
+}
+
+/** HTTP status for a non-ok remote-view mutate (message via
+ *  mutateRemoteViewFailureMessage): 404 for a missing view/record, 403 for a
+ *  policy refusal, 400 otherwise. */
+function mutateStatus(kind: string): number {
+  if (kind === "view-not-found" || kind === "item-not-found") return 404;
+  if (kind === "not-writable" || kind === "delete-not-allowed" || kind === "field-not-editable" || kind === "path-escape") return 403;
+  return 400;
 }
 
 /** Mount the read-side REST surface. Mirrors MulmoClaude's
@@ -492,6 +505,62 @@ export function mountCollectionRoutes(app: Express): void {
       res.type("text/html").send(html);
     } catch (err) {
       log.warn("collections", "view-file read failed", { slug: req.params.slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Serve a mobile (`target: "mobile"`) custom view wrapped into its sandboxed
+  // srcdoc — the desktop phone-frame preview's data source. Same builder as the
+  // remote-host channel's `getRemoteView`, so the preview renders the exact
+  // artifact the phone receives (preview === phone).
+  app.get("/api/collections/:slug/remote-view", async (req: Request<{ slug: string }>, res: Response) => {
+    const { slug } = req.params;
+    const viewId = typeof req.query.id === "string" ? req.query.id : "";
+    const locale = typeof req.query.locale === "string" ? req.query.locale : "";
+    const collection = await loadCollection(slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${slug}' not found` });
+      return;
+    }
+    try {
+      const result = await buildRemoteView(collection, viewId, locale);
+      if (result.kind !== "ok") {
+        const notFound = result.kind === "view-not-found" || result.kind === "file-missing";
+        res.status(notFound ? 404 : 400).json({ error: remoteViewFailureMessage(result, slug) });
+        return;
+      }
+      res.json({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
+    } catch (err) {
+      log.warn("collections", "remote-view build failed", { slug, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // Apply one update/delete on behalf of a writable mobile view — the desktop
+  // preview's write channel. Same builder + host-side policy as the channel's
+  // `mutateRemoteViewItem`, so a preview mutation runs the exact enforcement the
+  // phone will.
+  app.post("/api/collections/:slug/remote-view/:viewId/mutate", async (req: Request<{ slug: string; viewId: string }>, res: Response) => {
+    const { slug, viewId } = req.params;
+    const request = normalizeMutate((req.body ?? {}) as { op?: unknown; id?: unknown; patch?: unknown });
+    if (!request) {
+      res.status(400).json({ error: "invalid mutate request — expected { op: 'update'|'delete', id, patch? }" });
+      return;
+    }
+    const collection = await loadCollection(slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${slug}' not found` });
+      return;
+    }
+    try {
+      const result = await mutateRemoteView(collection, viewId, request);
+      if (result.kind !== "ok") {
+        res.status(mutateStatus(result.kind)).json({ error: mutateRemoteViewFailureMessage(result, slug) });
+        return;
+      }
+      res.json(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
+    } catch (err) {
+      log.warn("collections", "remote-view mutate failed", { slug, viewId, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   });

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -24,7 +24,7 @@ import {
   remoteViewFailureMessage,
   remoteViewItems,
   remoteViewItemsFailureMessage,
-} from "./remoteView.js";
+} from "../remoteView.js";
 
 export interface RemoteHostHandlerDeps {
   workspace: string;

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -1,3 +1,8 @@
+// Shared mobile custom-view builder, used by BOTH the remote-host command
+// channel (remoteHost/handlers.ts → the phone) and the desktop collection routes
+// (collections.ts → the phone-frame preview), so both render the identical
+// artifact (preview === phone).
+//
 // Assemble one mobile (`target: "mobile"`) custom view for the remote client:
 // find the view entry, read its HTML, pick its i18n dict for the requested
 // locale, wrap it into the sandboxed srcdoc (CSP + postMessage bootstrap —

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -4,7 +4,8 @@
 // src/composables/collections/uiHost.ts — a leaner host (no router, no vue-i18n host
 // instance, no confirm/notifier stores).
 //
-// Wired: data fetch (detail/list), record CRUD, read-only custom views, actions
+// Wired: data fetch (detail/list), record CRUD, custom views (read-only desktop +
+// read/write mobile phone-frame preview via fetchRemoteView/mutateRemoteView), actions
 // (seed prompt → startChat → a visible chat), favorites (useShortcuts), feed/agent
 // refresh + feed listing (via @mulmoclaude/core/feeds — see server/backends/feeds.ts),
 // collection/feed/view deletion and the Discover registry tab (listRegistry/importRegistry
@@ -12,7 +13,13 @@
 // navigation (useCollectionBrowse — the toolbar + browse overlay).
 // Still stubbed: the notifier.
 import { configureCollectionUi } from "@mulmoclaude/collection-plugin/vue";
-import type { CollectionApiResult, CollectionViewToken, CollectionActionResult } from "@mulmoclaude/collection-plugin/vue";
+import type {
+  CollectionApiResult,
+  CollectionViewToken,
+  CollectionActionResult,
+  CollectionRemoteViewResult,
+  CollectionRemoteViewMutateResult,
+} from "@mulmoclaude/collection-plugin/vue";
 import type {
   CollectionDetailResponse,
   CollectionsListResponse,
@@ -177,6 +184,20 @@ configureCollectionUi({
     }
   },
   buildViewSrcdoc: (html, boot) => buildCustomViewSrcdoc(html, boot),
+
+  // ── mobile custom views (phone-frame preview): a `target: "mobile"` view is
+  //    built HOST-side into its sandboxed srcdoc (server/backends/remoteView.ts,
+  //    shared with the remote-host channel), so the desktop preview renders the
+  //    exact artifact the phone gets. Optional + paired: providing both makes the
+  //    view selector surface mobile views. Image thumbnails aren't inlined (no
+  //    thumbnail store yet) — image fields render as placeholders, like the phone. ──
+  fetchRemoteView: (slug, viewId, locale) =>
+    apiGet<CollectionRemoteViewResult>(
+      `/api/collections/${encodeURIComponent(slug)}/remote-view?id=${encodeURIComponent(viewId)}&locale=${encodeURIComponent(locale)}`,
+    ),
+  mutateRemoteView: (slug, viewId, request) =>
+    apiPost<CollectionRemoteViewMutateResult>(`/api/collections/${encodeURIComponent(slug)}/remote-view/${encodeURIComponent(viewId)}/mutate`, request),
+
   // MulmoTerminal serves no per-view translations — return the documented
   // "no i18n" shape ({ locale: "", dict: {} }) so the iframe's __MC_VIEW.t(key)
   // echoes keys instead of failing.


### PR DESCRIPTION
## Summary

Fixes the gap you hit: **MulmoTerminal's desktop collection view didn't show `target: "mobile"` custom views** (the phone-frame preview never appeared), unlike MulmoClaude's.

The cause wasn't a missing dependency — `collection-plugin@0.7.0` already ships the preview component. The host just never **backed** it: MulmoTerminal provided neither the `CollectionUi.fetchRemoteView` / `mutateRemoteView` bindings nor the `/api/collections/:slug/remote-view` routes the plugin's preview calls. (When those are absent, the plugin hides mobile views from the selector — "purely additive.")

## What this wires

- **Move the builder** to a shared `server/backends/remoteView.ts` (was under `remoteHost/`) — now used by **both** the remote-host channel handlers (the phone) and the desktop routes (the preview), so both render the identical artifact.
- **Server**: `GET /api/collections/:slug/remote-view` (builds the sandboxed srcdoc) + `POST /api/collections/:slug/remote-view/:viewId/mutate` (host-enforced writable view), reusing that builder + `@mulmoclaude/core/remote-view`.
- **Frontend**: `fetchRemoteView` + `mutateRemoteView` in `collectionUi.ts`, so the plugin's view selector surfaces mobile views and the phone-frame preview renders them.

## Scope notes

- **No dependency bump** — `core@0.9.0` already has everything.
- **Image thumbnails** stay un-inlined (no thumbnail store on this host yet) — image fields render as placeholders, exactly like the phone.
- `collection-plugin@0.7.0` has no `fetchRemoteViewItems` (a later-version feature), so the preview pages from the already-loaded detail items — matching its capability.

## Verification

- 4 new `collections.spec` route tests against the **real builder**: srcdoc build (asserts `connect-src 'none'` + the authored body), desktop-view refusal (400), unknown view/collection (404), editable-field update (200) + non-editable field refusal (403) + malformed request (400).
- `yarn typecheck` / `lint` / `build` green; **646 tests pass** (+4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)