### PR TITLE
feat(remote-view): inline image-field thumbnails in mobile views

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "material-symbols": "^0.45.5",
     "node-pty": "^1.1.0",
     "puppeteer": "^25.3.0",
+    "sharp": "^0.35.3",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
     "tsx": "^4.23.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.7.0",
+    "@mulmoclaude/collection-plugin": "^0.7.1",
     "@mulmoclaude/core": "^0.9.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",

--- a/server/backends/collections.spec.ts
+++ b/server/backends/collections.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
 import express from "express";
+import sharp from "sharp";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -85,6 +86,33 @@ beforeAll(async () => {
   writeFileSync(path.join(ws, "data", "singletoncol", "items", "me.json"), JSON.stringify({ id: "me", name: "Owner" }));
   mkdirSync(path.join(ws, "data", "skills", "singletoncol", "views"), { recursive: true });
   writeFileSync(path.join(ws, "data", "skills", "singletoncol", "views", "sv.html"), "<head></head><body>editable</body>");
+
+  // A collection with a mobile view that declares an image field, so the
+  // remote-view items route can inline a real thumbnail (isolated from testcol so
+  // its record counts don't perturb the detail/view-data tests above).
+  const PHOTOS_SCHEMA = {
+    title: "Photos",
+    icon: "image",
+    dataPath: "data/photoscol/items",
+    primaryKey: "id",
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      name: { type: "string", label: "Name" },
+      photo: { type: "image", label: "Photo" },
+    },
+    views: [{ id: "gallery", file: "views/gallery.html", label: "Gallery", target: "mobile", imageFields: ["photo"] }],
+  };
+  mkdirSync(path.join(ws, ".claude", "skills", "photoscol"), { recursive: true });
+  writeFileSync(path.join(ws, ".claude", "skills", "photoscol", "schema.json"), JSON.stringify(PHOTOS_SCHEMA));
+  mkdirSync(path.join(ws, "data", "skills", "photoscol", "views"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "skills", "photoscol", "views", "gallery.html"), "<head></head><body>gallery</body>");
+  mkdirSync(path.join(ws, "data", "photoscol", "images"), { recursive: true });
+  const pic = await sharp({ create: { width: 40, height: 24, channels: 3, background: { r: 200, g: 30, b: 90 } } })
+    .png()
+    .toBuffer();
+  writeFileSync(path.join(ws, "data", "photoscol", "images", "pic.png"), pic);
+  mkdirSync(path.join(ws, "data", "photoscol", "items"), { recursive: true });
+  writeFileSync(path.join(ws, "data", "photoscol", "items", "p1.json"), JSON.stringify({ id: "p1", name: "First", photo: "data/photoscol/images/pic.png" }));
 
   // Point the (singleton) collection host at the fixture. vitest isolates modules
   // per test file, so this configure is fresh for this worker.
@@ -617,5 +645,18 @@ describe("mobile custom views (phone-frame preview)", () => {
       body: JSON.stringify({ nonsense: true }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("GET /:slug/remote-view/:viewId/items inlines the view's image field as a data URL thumbnail", async () => {
+    const res = await fetch(`${base}/api/collections/photoscol/remote-view/gallery/items`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.inlined).toBeGreaterThanOrEqual(1);
+    const record = body.page.items.find((item: { id: string }) => item.id === "p1");
+    expect(record.photo).toMatch(/^data:image\/jpeg;base64,/); // the path was replaced by a thumbnail
+  });
+
+  it("GET /:slug/remote-view/:viewId/items 404s an unknown view", async () => {
+    expect((await fetch(`${base}/api/collections/photoscol/remote-view/nope/items`)).status).toBe(404);
   });
 });

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -45,10 +45,17 @@ import {
 import { actionVisible, type CollectionItem } from "@mulmoclaude/core/collection";
 // Curated-registry engine (Discover tab): merged catalog fetch + bundle import.
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
-import { normalizeMutate } from "@mulmoclaude/core/remote-view";
+import { clampLimit as clampViewLimit, clampOffset as clampViewOffset, normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
 // Mobile custom-view builder — shared with the remote-host channel handlers so
 // the desktop phone-frame preview renders the EXACT artifact the phone receives.
-import { buildRemoteView, mutateRemoteView, remoteViewFailureMessage, mutateRemoteViewFailureMessage } from "./remoteView.js";
+import {
+  buildRemoteView,
+  mutateRemoteView,
+  remoteViewFailureMessage,
+  mutateRemoteViewFailureMessage,
+  remoteViewItems,
+  remoteViewItemsFailureMessage,
+} from "./remoteView.js";
 import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
@@ -150,6 +157,14 @@ async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode:
   if (result.kind === "conflict")
     return { rejected: { id: itemId, problem: `'${itemId}' already exists — mode "create" refuses overwrite; use "upsert" to update it` } };
   return { rejected: { id: itemId, problem: "write refused: the collection's data dir escapes the workspace" } };
+}
+
+/** A `fields` projection arrives as a CSV query (`?fields=title,photo`) or
+ *  repeated params; hand `normalizeFields` an array either way. */
+function csvParam(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) return value.map((entry) => String(entry));
+  if (typeof value === "string" && value.length > 0) return value.split(",");
+  return undefined;
 }
 
 /** HTTP status for a non-ok remote-view mutate (message via
@@ -561,6 +576,31 @@ export function mountCollectionRoutes(app: Express): void {
       res.json(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
     } catch (err) {
       log.warn("collections", "remote-view mutate failed", { slug, viewId, error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  });
+
+  // One page of a mobile view's records, with its declared image fields inlined
+  // as `data:` thumbnails — the desktop phone-frame preview's paging source. Same
+  // builder as the channel's getRemoteViewItems, so the preview pages the exact
+  // data (real thumbnails) the phone gets.
+  app.get("/api/collections/:slug/remote-view/:viewId/items", async (req: Request<{ slug: string; viewId: string }>, res: Response) => {
+    const { slug, viewId } = req.params;
+    const request = { offset: clampViewOffset(req.query.offset), limit: clampViewLimit(req.query.limit), fields: normalizeFields(csvParam(req.query.fields)) };
+    const collection = await loadCollection(slug);
+    if (!collection) {
+      res.status(404).json({ error: `collection '${slug}' not found` });
+      return;
+    }
+    try {
+      const result = await remoteViewItems(collection, viewId, request);
+      if (result.kind !== "ok") {
+        res.status(result.kind === "view-not-found" ? 404 : 400).json({ error: remoteViewItemsFailureMessage(result, slug) });
+        return;
+      }
+      res.json({ page: result.page, inlined: result.inlined, omitted: result.omitted });
+    } catch (err) {
+      log.warn("collections", "remote-view items failed", { slug, viewId, error: errorMessage(err) });
       res.status(500).json({ error: errorMessage(err) });
     }
   });

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -10,11 +10,7 @@
 // Also serves a view's record pages (getItems) and its writable-view mutates,
 // with the same host-side policy enforcement MulmoClaude uses.
 //
-// Ported from MulmoClaude's server/workspace/collections/remoteView.ts. The one
-// difference: MulmoTerminal has no thumbnail store, so image fields are never
-// inlined — they stay as workspace paths (unrenderable on the phone) and count
-// as `omitted`. Swap `noThumbnails` for a real resolver when a thumbnail store
-// lands (the rest of the contract is identical, so the phone client is unchanged).
+// Ported from MulmoClaude's server/workspace/collections/remoteView.ts.
 //
 // Discriminated results (not throws) so the channel handlers can map each
 // failure to an actionable message; factories keep the mapping unit-testable.
@@ -42,10 +38,11 @@ import {
 } from "@mulmoclaude/core/collection/server";
 import type { CollectionCustomView, CollectionItem, CollectionSchema } from "@mulmoclaude/core/collection";
 
-// Resolves a workspace image path to a downscaled `data:` URL, or null when it
-// can't (or won't). MulmoTerminal has no thumbnail store yet, so it never does.
+import { resolveThumbnail } from "./thumbnailStore.js";
+
+// Resolves a workspace image path to a downscaled JPEG `data:` URL, or null when
+// it can't (path escapes the workspace, missing, or undecodable).
 type ThumbnailResolver = (imagePath: string, maxEdge: number) => Promise<string | null>;
-const noThumbnails: ThumbnailResolver = async () => null;
 
 export interface RemoteViewInfo {
   id: string;
@@ -192,7 +189,7 @@ async function updateViaView(
   return { kind: "ok", op: "update", item: item as CollectionItem };
 }
 
-export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem, enrichItems, resolveThumbnail: noThumbnails });
+export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem, enrichItems, resolveThumbnail });
 
 // ── Item pages (getItems) ──
 // A mobile view's record page: derive computed fields → slice/project (the same
@@ -271,7 +268,7 @@ export const createRemoteViewItems =
     return { kind: "ok", page, inlined, omitted };
   };
 
-export const remoteViewItems = createRemoteViewItems({ listItems, enrichItems, resolveThumbnail: noThumbnails });
+export const remoteViewItems = createRemoteViewItems({ listItems, enrichItems, resolveThumbnail });
 
 /** Message per non-ok item-page kind, thrown by the channel handler. */
 export function remoteViewItemsFailureMessage(result: Exclude<RemoteViewItemsResult, { kind: "ok" }>, slug: string): string {

--- a/server/backends/thumbnailStore.spec.ts
+++ b/server/backends/thumbnailStore.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -13,9 +13,10 @@ const stubResize = async (input: Buffer, maxEdge: number) => Buffer.from(`RESIZE
 
 describe("thumbnail resolver", () => {
   const resolve = createThumbnailResolver(stubResize);
+  let ws = "";
 
   beforeAll(() => {
-    const ws = mkdtempSync(path.join(tmpdir(), "mt-thumb-"));
+    ws = mkdtempSync(path.join(tmpdir(), "mt-thumb-"));
     mkdirSync(path.join(ws, "data"), { recursive: true });
     writeFileSync(path.join(ws, "data", "pic.png"), Buffer.from([1, 2, 3, 4]));
     // Sets the workspace root the resolver reads via getWorkspaceRoot().
@@ -34,6 +35,16 @@ describe("thumbnail resolver", () => {
     expect(await resolve("data/nope.png", 512)).toBeNull();
     expect(await resolve("../outside.png", 512)).toBeNull();
     expect(await resolve("", 512)).toBeNull();
+  });
+
+  it("refuses a symlink under the workspace that points OUTSIDE it (no exfiltration)", async () => {
+    // A file outside the workspace, and a symlink under it that targets the file.
+    const outside = mkdtempSync(path.join(tmpdir(), "mt-outside-"));
+    const secret = path.join(outside, "secret.png");
+    writeFileSync(secret, Buffer.from([9, 9, 9, 9]));
+    symlinkSync(secret, path.join(ws, "data", "link.png"));
+    // Lexically "data/link.png" is contained; the real target escapes → null.
+    expect(await resolve("data/link.png", 512)).toBeNull();
   });
 
   it("caches by (path, mtime, maxEdge) so a repeated page doesn't re-decode", async () => {

--- a/server/backends/thumbnailStore.spec.ts
+++ b/server/backends/thumbnailStore.spec.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { initCollectionsBackend } from "./collections.js";
+import { createThumbnailResolver, clearThumbnailCache } from "./thumbnailStore.js";
+
+// A stub resize so the test needs no native sharp binary — echoes a marker
+// derived from the input so we can assert the pipeline ran.
+const stubResize = async (input: Buffer, maxEdge: number) => Buffer.from(`RESIZED:${maxEdge}:${input.length}`);
+
+describe("thumbnail resolver", () => {
+  const resolve = createThumbnailResolver(stubResize);
+
+  beforeAll(() => {
+    const ws = mkdtempSync(path.join(tmpdir(), "mt-thumb-"));
+    mkdirSync(path.join(ws, "data"), { recursive: true });
+    writeFileSync(path.join(ws, "data", "pic.png"), Buffer.from([1, 2, 3, 4]));
+    // Sets the workspace root the resolver reads via getWorkspaceRoot().
+    initCollectionsBackend({ workspace: ws });
+  });
+
+  it("resolves a workspace image to a JPEG data URL", async () => {
+    clearThumbnailCache();
+    const url = await resolve("data/pic.png", 512);
+    expect(url).toMatch(/^data:image\/jpeg;base64,/);
+    const base64 = (url ?? "").split(",")[1];
+    expect(Buffer.from(base64, "base64").toString()).toBe("RESIZED:512:4");
+  });
+
+  it("returns null for a missing file, an escaping path, and empty input", async () => {
+    expect(await resolve("data/nope.png", 512)).toBeNull();
+    expect(await resolve("../outside.png", 512)).toBeNull();
+    expect(await resolve("", 512)).toBeNull();
+  });
+
+  it("caches by (path, mtime, maxEdge) so a repeated page doesn't re-decode", async () => {
+    clearThumbnailCache();
+    let calls = 0;
+    const counting = createThumbnailResolver(async (_buf, edge) => {
+      calls += 1;
+      return Buffer.from(`X:${edge}`);
+    });
+    await counting("data/pic.png", 256);
+    await counting("data/pic.png", 256);
+    expect(calls).toBe(1);
+  });
+});

--- a/server/backends/thumbnailStore.ts
+++ b/server/backends/thumbnailStore.ts
@@ -1,0 +1,98 @@
+// Downscaled `data:` URL thumbnails for mobile custom views. A phone can't reach
+// the host, so an `image`-type field's workspace path is unrenderable there; a
+// view that lists the field in `imageFields` gets it inlined as a small JPEG data
+// URL the host produces here (used by server/backends/remoteView.ts for both the
+// remote-host channel and the desktop phone-frame preview).
+//
+// Ported from MulmoClaude's server/utils/files/thumbnail-store.ts. Adaptations:
+// the workspace root comes from the configured collection host
+// (getWorkspaceRoot) rather than a MulmoClaude paths module, and containment
+// uses MulmoTerminal's containedPath. Results are cached by (path, mtime,
+// maxEdge) so repeated pages / "load more" scrolls never re-decode the source.
+import { readFile, realpath, stat } from "node:fs/promises";
+
+import { getWorkspaceRoot } from "@mulmoclaude/core/collection/server";
+
+import { containedPath } from "../files-browse.js";
+
+/** Decode → downscale to fit `maxEdge` (never enlarge) → re-encode JPEG.
+ *  Injected so tests exercise the resolver without the native `sharp` binary. */
+export type ResizeToJpeg = (input: Buffer, maxEdge: number) => Promise<Buffer>;
+
+// JPEG quality for inlined thumbnails — a size/fidelity knob; 72 keeps a 512px
+// thumbnail in the low tens of KB, well within the page budget.
+const THUMBNAIL_JPEG_QUALITY = 72;
+
+const sharpResize: ResizeToJpeg = async (input, maxEdge) => {
+  // Dynamic import: only the default resolver pulls the native binary, so tests
+  // (which inject their own resize) and code paths that never make a thumbnail
+  // don't load it.
+  const sharp = (await import("sharp")).default;
+  // `.rotate()` bakes in EXIF orientation so portrait phone photos aren't sideways.
+  return sharp(input).rotate().resize(maxEdge, maxEdge, { fit: "inside", withoutEnlargement: true }).jpeg({ quality: THUMBNAIL_JPEG_QUALITY }).toBuffer();
+};
+
+interface CacheEntry {
+  mtimeMs: number;
+  maxEdge: number;
+  dataUrl: string;
+}
+
+// In-memory, per host process. Bounded LRU (Map keeps insertion order; a get
+// re-inserts to mark recency, a set past the cap evicts the oldest).
+const MAX_CACHE_ENTRIES = 256;
+const cache = new Map<string, CacheEntry>();
+
+function cacheGet(relPath: string, mtimeMs: number, maxEdge: number): string | null {
+  const entry = cache.get(relPath);
+  if (!entry || entry.mtimeMs !== mtimeMs || entry.maxEdge !== maxEdge) return null;
+  cache.delete(relPath);
+  cache.set(relPath, entry);
+  return entry.dataUrl;
+}
+
+function cacheSet(relPath: string, entry: CacheEntry): void {
+  cache.set(relPath, entry);
+  if (cache.size > MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+}
+
+/** Test-only: drop the cache so a spy on the resize fn sees a fresh encode. */
+export function clearThumbnailCache(): void {
+  cache.clear();
+}
+
+/** Resolve a workspace-relative image path to a downscaled JPEG `data:` URL, or
+ *  `null` when the path escapes the workspace, is missing, or can't be decoded —
+ *  the caller then leaves the field as its original path (a placeholder in the
+ *  view). `maxEdge` should already be clamped by the caller (`clampImageMaxEdge`). */
+export function createThumbnailResolver(resize: ResizeToJpeg = sharpResize) {
+  return async function resolveThumbnail(relPath: string, maxEdge: number): Promise<string | null> {
+    if (typeof relPath !== "string" || relPath.length === 0) return null;
+    let root: string;
+    try {
+      root = await realpath(getWorkspaceRoot());
+    } catch {
+      return null;
+    }
+    const abs = containedPath(root, relPath);
+    if (!abs) return null;
+    const info = await stat(abs).catch(() => null);
+    if (!info?.isFile()) return null;
+    const cached = cacheGet(relPath, info.mtimeMs, maxEdge);
+    if (cached) return cached;
+    try {
+      const out = await resize(await readFile(abs), maxEdge);
+      const dataUrl = `data:image/jpeg;base64,${out.toString("base64")}`;
+      cacheSet(relPath, { mtimeMs: info.mtimeMs, maxEdge, dataUrl });
+      return dataUrl;
+    } catch (err) {
+      console.warn("[thumbnail] resolve failed", relPath, String(err));
+      return null;
+    }
+  };
+}
+
+export const resolveThumbnail = createThumbnailResolver();

--- a/server/backends/thumbnailStore.ts
+++ b/server/backends/thumbnailStore.ts
@@ -13,7 +13,7 @@ import { readFile, realpath, stat } from "node:fs/promises";
 
 import { getWorkspaceRoot } from "@mulmoclaude/core/collection/server";
 
-import { containedPath } from "../files-browse.js";
+import { containedPath, realContainedWithin } from "../files-browse.js";
 
 /** Decode → downscale to fit `maxEdge` (never enlarge) → re-encode JPEG.
  *  Injected so tests exercise the resolver without the native `sharp` binary. */
@@ -79,12 +79,18 @@ export function createThumbnailResolver(resize: ResizeToJpeg = sharpResize) {
     }
     const abs = containedPath(root, relPath);
     if (!abs) return null;
-    const info = await stat(abs).catch(() => null);
+    // Lexical containment can be defeated by a symlink UNDER the workspace that
+    // points outside it (e.g. data/link.jpg -> /etc/passwd); resolve the real
+    // target and re-check before we stat/read it, so a symlinked path can't
+    // exfiltrate an out-of-workspace file to the phone.
+    const real = realContainedWithin(root, abs);
+    if (!real) return null;
+    const info = await stat(real).catch(() => null);
     if (!info?.isFile()) return null;
     const cached = cacheGet(relPath, info.mtimeMs, maxEdge);
     if (cached) return cached;
     try {
-      const out = await resize(await readFile(abs), maxEdge);
+      const out = await resize(await readFile(real), maxEdge);
       const dataUrl = `data:image/jpeg;base64,${out.toString("base64")}`;
       cacheSet(relPath, { mtimeMs: info.mtimeMs, maxEdge, dataUrl });
       return dataUrl;

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -19,6 +19,7 @@ import type {
   CollectionActionResult,
   CollectionRemoteViewResult,
   CollectionRemoteViewMutateResult,
+  CollectionRemoteViewItemsResult,
 } from "@mulmoclaude/collection-plugin/vue";
 import type {
   CollectionDetailResponse,
@@ -197,6 +198,19 @@ configureCollectionUi({
     ),
   mutateRemoteView: (slug, viewId, request) =>
     apiPost<CollectionRemoteViewMutateResult>(`/api/collections/${encodeURIComponent(slug)}/remote-view/${encodeURIComponent(viewId)}/mutate`, request),
+  // Page a mobile view's records the way the phone does — via getRemoteViewItems,
+  // so the host projects to `fields` and inlines the view's declared image fields
+  // as `data:` thumbnails. Without this the preview would page raw (CSP-blocked)
+  // paths and show broken images.
+  fetchRemoteViewItems: (slug, viewId, request) => {
+    const query = new URLSearchParams();
+    if (request.offset != null) query.set("offset", String(request.offset));
+    if (request.limit != null) query.set("limit", String(request.limit));
+    if (request.fields?.length) query.set("fields", request.fields.join(","));
+    const qs = query.toString();
+    const suffix = qs ? `?${qs}` : "";
+    return apiGet<CollectionRemoteViewItemsResult>(`/api/collections/${encodeURIComponent(slug)}/remote-view/${encodeURIComponent(viewId)}/items${suffix}`);
+  },
 
   // MulmoTerminal serves no per-view translations — return the documented
   // "no i18n" shape ({ locale: "", dict: {} }) so the iframe's __MC_VIEW.t(key)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,167 @@
     "@iconify/types" "^2.0.0"
     import-meta-resolve "^4.2.0"
 
+"@img/colour@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.1.0.tgz#b0c2c2fa661adf75effd6b4964497cd80010bb9d"
+  integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
+
+"@img/sharp-darwin-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz#8b2740884bc58b127fc3020479a01294fa1095cb"
+  integrity sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-arm64" "1.3.2"
+
+"@img/sharp-darwin-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz#92df91320faf57cc54b331185770d5a93d510049"
+  integrity sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.3.2"
+
+"@img/sharp-freebsd-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz#48018c1379a8f507d681d6cd8dbe43d9795dc809"
+  integrity sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==
+  dependencies:
+    "@img/sharp-wasm32" "0.35.3"
+
+"@img/sharp-libvips-darwin-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz#227b41ffc6c99612bceaba56f994a1933d779573"
+  integrity sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==
+
+"@img/sharp-libvips-darwin-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz#694903ec410c00945ce5b0c26dac83d7184c8b86"
+  integrity sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==
+
+"@img/sharp-libvips-linux-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz#49ddf156728666a21deed0716f3bb72bb351179e"
+  integrity sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==
+
+"@img/sharp-libvips-linux-arm@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz#e60e088c806bde1ac28be648b60c3465f41c18a7"
+  integrity sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==
+
+"@img/sharp-libvips-linux-ppc64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz#be3161aafd659417b3e26374dfbbcd2da2bfb62c"
+  integrity sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==
+
+"@img/sharp-libvips-linux-riscv64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz#bf008a6779d9be2b56a4df67b753941f767c957d"
+  integrity sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==
+
+"@img/sharp-libvips-linux-s390x@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz#9583814b8db58889c85bad9e5e0b7825257ff394"
+  integrity sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==
+
+"@img/sharp-libvips-linux-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz#abc9a3114495b705ba20b7c1568b9eecd62aebbb"
+  integrity sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==
+
+"@img/sharp-libvips-linuxmusl-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz#e58fb14a7879f15d9e70a982870f384f39a832a2"
+  integrity sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==
+
+"@img/sharp-libvips-linuxmusl-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz#5611480fcb7465dd5316044db53ad7a843ed4af8"
+  integrity sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==
+
+"@img/sharp-linux-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz#44b65823ecc977d4585b308070fff3947256de04"
+  integrity sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm64" "1.3.2"
+
+"@img/sharp-linux-arm@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz#c8da500c4016893a89d46e9832d08a06eef77f27"
+  integrity sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.3.2"
+
+"@img/sharp-linux-ppc64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz#ea1d7db818f52af1e1e057e82d55f23b2de3864c"
+  integrity sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.3.2"
+
+"@img/sharp-linux-riscv64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz#722bd7994658791b02d1037ea09ca5cb78030d8d"
+  integrity sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-riscv64" "1.3.2"
+
+"@img/sharp-linux-s390x@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz#e8294817d7da495541a4a870f56e6b5d0f8643cd"
+  integrity sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-s390x" "1.3.2"
+
+"@img/sharp-linux-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz#9843c32f39aeac4b60dd60f9e3416520a4e4de46"
+  integrity sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.3.2"
+
+"@img/sharp-linuxmusl-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz#9cfee4ecc3d41ab9a274e019dfe7b4062840510c"
+  integrity sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
+
+"@img/sharp-linuxmusl-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz#204d0678c8c3b15300d9a26ecb9c0dcda11ca5de"
+  integrity sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
+
+"@img/sharp-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz#42f8979bdbe1a541a2e9b99d3b5be07e6b71c7c0"
+  integrity sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==
+  dependencies:
+    "@emnapi/runtime" "^1.11.1"
+
+"@img/sharp-webcontainers-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz#823aaa93d14db84999d5b5dc967ff56cf1966d9f"
+  integrity sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==
+  dependencies:
+    "@img/sharp-wasm32" "0.35.3"
+
+"@img/sharp-win32-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz#f3554d45cbe24532a0adea736ec57658f74a2911"
+  integrity sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==
+
+"@img/sharp-win32-ia32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz#0942b2643bcb57e48419fe4119de84078ae0ac74"
+  integrity sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==
+
+"@img/sharp-win32-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz#8a25cacdc75a8c26077c07fba51e8056aae474f1"
+  integrity sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==
+
 "@intlify/core-base@11.4.6":
   version "11.4.6"
   resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.4.6.tgz#7402cd6f7e1c813e7a8370afa3654d2d9034783a"
@@ -3075,7 +3236,7 @@ depd@^2.0.0, depd@~2.0.0:
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-detect-libc@^2.0.3:
+detect-libc@^2.0.3, detect-libc@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
@@ -5018,7 +5179,7 @@ scule@^1.3.0:
   resolved "https://registry.yarnpkg.com/scule/-/scule-1.3.0.tgz#6efbd22fd0bb801bdcc585c89266a7d2daa8fbd3"
   integrity sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==
 
-semver@^7.5.3, semver@^7.6.3, semver@^7.7.3, semver@^7.8.4:
+semver@^7.5.3, semver@^7.6.3, semver@^7.7.3, semver@^7.8.4, semver@^7.8.5:
   version "7.8.5"
   resolved "https://npm.flatt.tech/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
@@ -5054,6 +5215,41 @@ setprototypeof@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+sharp@^0.35.3:
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.35.3.tgz#41ed21a46406be163eacd0be7b364b42fcf2885f"
+  integrity sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==
+  dependencies:
+    "@img/colour" "^1.1.0"
+    detect-libc "^2.1.2"
+    semver "^7.8.5"
+  optionalDependencies:
+    "@img/sharp-darwin-arm64" "0.35.3"
+    "@img/sharp-darwin-x64" "0.35.3"
+    "@img/sharp-freebsd-wasm32" "0.35.3"
+    "@img/sharp-libvips-darwin-arm64" "1.3.2"
+    "@img/sharp-libvips-darwin-x64" "1.3.2"
+    "@img/sharp-libvips-linux-arm" "1.3.2"
+    "@img/sharp-libvips-linux-arm64" "1.3.2"
+    "@img/sharp-libvips-linux-ppc64" "1.3.2"
+    "@img/sharp-libvips-linux-riscv64" "1.3.2"
+    "@img/sharp-libvips-linux-s390x" "1.3.2"
+    "@img/sharp-libvips-linux-x64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
+    "@img/sharp-linux-arm" "0.35.3"
+    "@img/sharp-linux-arm64" "0.35.3"
+    "@img/sharp-linux-ppc64" "0.35.3"
+    "@img/sharp-linux-riscv64" "0.35.3"
+    "@img/sharp-linux-s390x" "0.35.3"
+    "@img/sharp-linux-x64" "0.35.3"
+    "@img/sharp-linuxmusl-arm64" "0.35.3"
+    "@img/sharp-linuxmusl-x64" "0.35.3"
+    "@img/sharp-webcontainers-wasm32" "0.35.3"
+    "@img/sharp-win32-arm64" "0.35.3"
+    "@img/sharp-win32-ia32" "0.35.3"
+    "@img/sharp-win32-x64" "0.35.3"
 
 shebang-command@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,10 +1402,10 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.3.tgz#933121a1720b2b68c62082048fe9df278466445e"
   integrity sha512-13oTtFLQgS7uiM/K6bxOKH7nKSs7Muhcg+PIsfl0ThyaINuu57LuktLf09XoRLDWouhUlL0gBZXDFSwuw+k6qA==
 
-"@mulmoclaude/collection-plugin@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.7.0.tgz#80cdcfed8b851c43d25920c20480d3b7af8799b4"
-  integrity sha512-MpGxzzAmR6wsNvy3a3EwdLwxZ07qShMQx1hrSOYWWwvl14RsCQpvg07RlW5Ks8+SSoB6f3PrlWr6BuwCLYhrHA==
+"@mulmoclaude/collection-plugin@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.7.1.tgz#241f03df5379dc858a2716ca3dfa1c4d3ccf9db1"
+  integrity sha512-2QefMaQzeTP6RpIjtrk6IrRfHQTwUuTHtK2Ct1b/8h/hSsftstwsPVjzPMdcQ49w8H3O4MwPCgfPUxpRQHBoRg==
   dependencies:
     vuedraggable "^4.1.0"
     zod "^4.4.3"


### PR DESCRIPTION
## Summary

First of the two deferred image features. A mobile view's declared `imageFields` were coming back as raw workspace paths — unrenderable on the phone (it can't reach the host) and in the sandboxed preview (its CSP forbids `localhost`) — so they counted as `omitted`. Now the host inlines them as downscaled JPEG `data:` URLs.

## What changed

- **`server/backends/thumbnailStore.ts`** (port of MulmoClaude's): `sharp` decode → downscale to the view's `imageMaxEdge` (EXIF-rotated, never enlarged) → JPEG `data:` URL, with an mtime-keyed LRU cache so repeated pages / "load more" scrolls don't re-decode. The workspace root comes from the configured collection host (`getWorkspaceRoot`); reads are containment-guarded (`containedPath`) against `..` escapes.
- **`remoteView.ts`**: swapped the `noThumbnails` stub for the real resolver, so **both** the remote-host channel (`getRemoteViewItems` + the mutate-update response) and the **desktop phone-frame preview** now show thumbnails.
- **`sharp@^0.35.3`**, dynamic-imported so non-thumbnail code paths never load the native binary.

## Verification

- `thumbnailStore.spec` (injected stub resize, no native binary): data-URL output, missing / path-escape / empty → `null`, and the mtime cache (a repeat doesn't re-decode).
- Smoke with **real sharp**: a 200×120 PNG → a 64×38 JPEG `data:` URL (aspect preserved, capped to `maxEdge`).
- `yarn typecheck` / `lint` / `build` green; **649 tests pass** (+3).

Next: chat image attachments from the phone (`ingestAttachments`) — the second deferred feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)