### PR TITLE
feat(remote-host): chat image attachments from the phone

### DIFF
--- a/server/backends/remoteHost/attachmentStore.spec.ts
+++ b/server/backends/remoteHost/attachmentStore.spec.ts
@@ -1,0 +1,34 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createSaveAttachment } from "./attachmentStore.js";
+
+describe("createSaveAttachment", () => {
+  let ws = "";
+  afterEach(() => ws && rmSync(ws, { recursive: true, force: true }));
+
+  it("saves base64 bytes under data/attachments/YYYY/MM and returns the workspace-relative path", async () => {
+    ws = mkdtempSync(path.join(tmpdir(), "mt-att-"));
+    const fixed = new Date(Date.UTC(2026, 6, 5)); // → 2026/07
+    const save = createSaveAttachment(ws, () => fixed);
+    const bytes = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
+
+    const saved = await save(bytes.toString("base64"), "image/png");
+
+    expect(saved.mimeType).toBe("image/png");
+    expect(saved.relativePath).toMatch(/^data\/attachments\/2026\/07\/[0-9a-f]{8}\.png$/);
+    const abs = path.join(ws, saved.relativePath);
+    expect(existsSync(abs)).toBe(true);
+    expect(readFileSync(abs).equals(bytes)).toBe(true);
+  });
+
+  it("falls back to .bin for an unmapped mime", async () => {
+    ws = mkdtempSync(path.join(tmpdir(), "mt-att-"));
+    const save = createSaveAttachment(ws);
+    const saved = await save(Buffer.from("x").toString("base64"), "application/x-unknown");
+    expect(saved.relativePath.endsWith(".bin")).toBe(true);
+  });
+});

--- a/server/backends/remoteHost/attachmentStore.ts
+++ b/server/backends/remoteHost/attachmentStore.ts
@@ -1,0 +1,61 @@
+// Persist a chat attachment (a photo / PDF the phone staged to Firebase Storage)
+// into the workspace at data/attachments/YYYY/MM/<id>.<ext>, so the spawned
+// `claude` session can Read it by path.
+//
+// A lean port of MulmoClaude's server/utils/files/attachment-store.ts — no hooks,
+// companions, or loaders (the terminal only needs the bytes on disk at a
+// referenceable workspace-relative path). Writes atomically (temp + rename), the
+// same pattern the other MulmoTerminal backends use.
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+const ATTACHMENTS_DIR = "data/attachments";
+
+// MIME → extension. Narrow on purpose (covers phone photos + PDFs + a few text
+// types); anything unmapped falls back to `.bin` so we never guess.
+const MIME_EXT: Readonly<Record<string, string>> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/heic": ".heic", // iOS default capture format
+  "image/heif": ".heif",
+  "image/tiff": ".tif",
+  "application/pdf": ".pdf",
+  "text/plain": ".txt",
+  "text/markdown": ".md",
+  "text/csv": ".csv",
+};
+
+const extensionForMime = (mimeType: string): string => MIME_EXT[mimeType.toLowerCase()] ?? ".bin";
+
+// UTC YYYY/MM partition so a workspace with many uploads stays browsable.
+const yearMonthUtc = (when: Date): string => `${when.getUTCFullYear()}/${String(when.getUTCMonth() + 1).padStart(2, "0")}`;
+
+export interface SavedAttachment {
+  relativePath: string;
+  mimeType: string;
+}
+
+// A saver bound to the workspace root. `now` is injected so a test gets a stable
+// partition directory.
+export function createSaveAttachment(workspaceRoot: string, now: () => Date = () => new Date()) {
+  return async function saveAttachment(base64Data: string, mimeType: string): Promise<SavedAttachment> {
+    const partition = yearMonthUtc(now());
+    const filename = `${randomUUID().slice(0, 8)}${extensionForMime(mimeType)}`;
+    const relativePath = path.posix.join(ATTACHMENTS_DIR, partition, filename);
+    const absPath = path.join(workspaceRoot, ATTACHMENTS_DIR, partition, filename);
+    await mkdir(path.dirname(absPath), { recursive: true });
+    const tmp = `${absPath}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(tmp, Buffer.from(base64Data, "base64"));
+      await rename(tmp, absPath);
+    } catch (err) {
+      await rm(tmp, { force: true }).catch(() => undefined);
+      throw err;
+    }
+    return { relativePath, mimeType };
+  };
+}

--- a/server/backends/remoteHost/firebase.ts
+++ b/server/backends/remoteHost/firebase.ts
@@ -22,4 +22,7 @@ const firebaseConfig = {
   measurementId: "G-Y75JGK1G4T",
 } as const;
 
-export const { firestore, auth } = createRemoteHostFirebase(firebaseConfig);
+// storage: the phone stages full-res chat attachments (photos/PDFs the 1 MiB
+// command doc can't carry) to `users/{uid}/uploads/{id}`; the host — signed in as
+// the same user — pulls them from there (see remoteHost/ingestAttachments.ts).
+export const { firestore, auth, storage } = createRemoteHostFirebase(firebaseConfig);

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -9,16 +9,23 @@ import { createRemoteHostHandlers } from "./handlers.js";
 describe("createRemoteHostHandlers", () => {
   let ws: string;
   let spawned: string[];
+  let ingested: string[][];
   let handlers: ReturnType<typeof createRemoteHostHandlers>;
 
   beforeEach(() => {
     ws = mkdtempSync(path.join(tmpdir(), "mt-rh-"));
     spawned = [];
+    ingested = [];
     handlers = createRemoteHostHandlers({
       workspace: ws,
       spawnChat: (message) => {
         spawned.push(message);
         return { chatId: `chat-${spawned.length}` };
+      },
+      // Fake ingest: record the storage ids, echo a saved path per file.
+      ingest: async (storageIds) => {
+        ingested.push(storageIds);
+        return storageIds.map((id) => ({ path: `data/attachments/${id}.jpg`, mimeType: "image/jpeg" }));
       },
     });
   });
@@ -51,8 +58,17 @@ describe("createRemoteHostHandlers", () => {
     expect(spawned).toEqual([]);
   });
 
-  it("startChat rejects attachments (not supported on this host yet)", async () => {
-    await expect(handlers.startChat({ message: "hi", attachments: [{ storage_id: "abc" }] })).rejects.toThrow(/attachments/);
+  it("startChat ingests attachments and references their saved paths in the prompt", async () => {
+    const result = await handlers.startChat({ message: "look at this", attachments: [{ storage_id: "abc" }, { storage_id: "def" }] });
+    expect(ingested).toEqual([["abc", "def"]]);
+    expect(spawned[0]).toContain("look at this");
+    expect(spawned[0]).toContain("data/attachments/abc.jpg");
+    expect(spawned[0]).toContain("data/attachments/def.jpg");
+    expect(result).toEqual({ started: true, chatId: "chat-1" });
+  });
+
+  it("startChat rejects a malformed attachments param without spawning", async () => {
+    await expect(handlers.startChat({ message: "hi", attachments: [{ nope: 1 }] })).rejects.toThrow(/storage_id/);
     expect(spawned).toEqual([]);
   });
 

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -5,15 +5,13 @@
 // match MulmoClaude's handlers exactly, so one phone client (mulmoserver) drives
 // either host.
 //
-// Covers read-only lists, text startChat, and mobile custom views (getRemoteView
-// / getRemoteViewItems / mutateRemoteViewItem). Still deferred: chat image
-// attachments (ingestAttachments) and view image thumbnails — both need an
-// attachment/thumbnail store this host lacks. See plans/feat-remote-host.md.
+// Covers read-only lists, startChat (text + image attachments), and mobile
+// custom views (getRemoteView / getRemoteViewItems / mutateRemoteViewItem).
 import { discoverCollections, listItems, loadCollection, toDetail, toSummary } from "@mulmoclaude/core/collection/server";
 import { listFeeds, readFeedState } from "@mulmoclaude/core/feeds/server";
 import { normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
 import { listBooks } from "@mulmoclaude/accounting-plugin/server";
-import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
+import type { CommandHandlers, JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
 import { readShortcuts } from "../shortcuts.js";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "./collectionPage.js";
@@ -25,15 +23,41 @@ import {
   remoteViewItems,
   remoteViewItemsFailureMessage,
 } from "../remoteView.js";
+import type { Attachment } from "./ingestAttachments.js";
 
 export interface RemoteHostHandlerDeps {
   workspace: string;
   // Start a visible chat seeded with `message`; returns the new session id.
   spawnChat: (message: string) => { chatId: string };
+  // Download the phone's staged uploads (by storage_id) into the workspace and
+  // return path-only attachments (remoteHost/ingestAttachments.ts).
+  ingest: (storageIds: string[]) => Promise<Attachment[]>;
 }
 
+// Parse the optional `attachments` param ([{ storage_id }]) into storage ids. A
+// malformed shape rejects the whole command: the remote already uploaded the
+// bytes and is waiting, so a surfaced error beats a chat missing its file.
+const readStorageIds = (attachments: JsonValue | undefined): string[] => {
+  if (attachments == null) return [];
+  if (!Array.isArray(attachments)) throw new Error("attachments must be an array of { storage_id }");
+  return attachments.map((entry) => {
+    const storageId = entry && typeof entry === "object" && !Array.isArray(entry) ? entry.storage_id : undefined;
+    if (typeof storageId !== "string" || storageId.length === 0) throw new Error("each attachments entry must be { storage_id: string }");
+    return storageId;
+  });
+};
+
+// The PTY-driven `claude` can't take image content blocks, so reference the
+// saved files by their workspace path in the seeded prompt — claude reads them
+// with its Read tool (its cwd is the workspace).
+const composeMessage = (message: string, attachments: Attachment[]): string => {
+  if (attachments.length === 0) return message;
+  const paths = attachments.map((file) => file.path).join("\n");
+  return `${message}\n\nAttached file(s) — read them from the workspace:\n${paths}`;
+};
+
 export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHandlers {
-  const { workspace, spawnChat } = deps;
+  const { workspace, spawnChat, ingest } = deps;
 
   return {
     // Mirrors GET /api/collections/list → { collections: CollectionSummary[] }.
@@ -125,17 +149,17 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
       return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
     },
 
-    // Start a visible chat from the phone, seeded verbatim with `message`. This
-    // host has no roles, so a `role` param is ignored. Attachments are not
-    // supported yet — reject rather than silently drop them (the remote already
-    // uploaded the bytes and would otherwise get a chat missing its files).
+    // Start a visible chat from the phone, seeded with `message`. This host has
+    // no roles, so a `role` param is ignored. Optional `attachments`
+    // ([{ storage_id }]) are downloaded into the workspace and referenced by path
+    // in the seeded prompt (the PTY claude reads them via its Read tool). Ingest
+    // BEFORE spawning so a download failure rejects the command instead of
+    // starting a chat missing its files.
     startChat: async (params: JsonObject) => {
       const message = (typeof params.message === "string" ? params.message : "").trim();
       if (!message) throw new Error("message is required");
-      if (Array.isArray(params.attachments) && params.attachments.length > 0) {
-        throw new Error("attachments are not supported on this host yet");
-      }
-      const { chatId } = spawnChat(message);
+      const attachments = await ingest(readStorageIds(params.attachments));
+      const { chatId } = spawnChat(composeMessage(message, attachments));
       return { started: true, chatId };
     },
   };

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -13,8 +13,10 @@
 import type { Express, Request } from "express";
 import { createRemoteHost, createRemoteHostAuth, startHostRunner, type RemoteHostLifecycle } from "@mulmoclaude/core/remote-host/server";
 
-import { auth, firestore } from "./firebase.js";
+import { auth, firestore, storage } from "./firebase.js";
 import { createRemoteHostHandlers } from "./handlers.js";
+import { createSaveAttachment } from "./attachmentStore.js";
+import { buildIngestAttachments } from "./ingestAttachments.js";
 
 const HOST_ID = "mulmoterminal";
 const PREFIX = "[remote-host]";
@@ -29,13 +31,16 @@ export interface RemoteHostBackendDeps {
 
 export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
   const authHelpers = createRemoteHostAuth(auth);
+  // Ingest pulls the phone's staged uploads (Firebase Storage, signed in as the
+  // user) into data/attachments/ and hands startChat path-only attachments.
+  const ingest = buildIngestAttachments({ storage, uid: authHelpers.currentUid, saveAttachment: createSaveAttachment(deps.workspace) });
   lifecycle = createRemoteHost({
     hostId: HOST_ID,
     signIn: authHelpers.signInHost,
     signOut: authHelpers.signOutHost,
     currentUid: authHelpers.currentUid,
     startRunner: (channel, handlers, options) => startHostRunner(firestore, channel, handlers, options),
-    handlers: createRemoteHostHandlers({ workspace: deps.workspace, spawnChat: deps.spawnChat }),
+    handlers: createRemoteHostHandlers({ workspace: deps.workspace, spawnChat: deps.spawnChat, ingest }),
     log: {
       info: (msg) => console.log(PREFIX, msg),
       warn: (msg) => console.warn(PREFIX, msg),

--- a/server/backends/remoteHost/ingestAttachments.spec.ts
+++ b/server/backends/remoteHost/ingestAttachments.spec.ts
@@ -60,6 +60,24 @@ describe("createIngestAttachments", () => {
     await expect(ingest(["a/b"])).rejects.toThrow(/invalid storage_id/);
   });
 
+  it("deletes NO staged object when a later attachment fails (a same-ids retry stays possible)", async () => {
+    const deleted: string[] = [];
+    let call = 0;
+    const ingest = createIngestAttachments({
+      ...baseDeps(),
+      fetchObject: async () => {
+        call += 1;
+        if (call === 2) throw new Error("fetch b failed");
+        return { base64: "AAAA", contentType: "image/jpeg" };
+      },
+      deleteObject: async (storagePath) => {
+        deleted.push(storagePath);
+      },
+    });
+    await expect(ingest(["a1", "b2"])).rejects.toThrow(/fetch b failed/);
+    expect(deleted).toEqual([]); // a1 was saved but not reaped → the remote can retry with the same ids
+  });
+
   it("tolerates a failed staging delete — the file is already ingested", async () => {
     const ingest = createIngestAttachments({
       ...baseDeps(),

--- a/server/backends/remoteHost/ingestAttachments.spec.ts
+++ b/server/backends/remoteHost/ingestAttachments.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { createIngestAttachments, type IngestDeps } from "./ingestAttachments.js";
+
+// Base stub deps: signed in as u1, fetch returns a jpeg, save echoes a path.
+const baseDeps = (): IngestDeps => ({
+  uid: () => "u1",
+  fetchObject: async () => ({ base64: "AAAA", contentType: "image/jpeg" }),
+  saveAttachment: async (base64, mimeType) => ({ relativePath: `data/attachments/${base64}.jpg`, mimeType }),
+  deleteObject: async () => undefined,
+});
+
+describe("createIngestAttachments", () => {
+  it("returns [] for no ids without touching storage", async () => {
+    let touched = false;
+    const ingest = createIngestAttachments({
+      ...baseDeps(),
+      fetchObject: async () => {
+        touched = true;
+        return { base64: "", contentType: "" };
+      },
+    });
+    expect(await ingest([])).toEqual([]);
+    expect(touched).toBe(false);
+  });
+
+  it("downloads each id, saves it, deletes staging, and returns path-only attachments in order", async () => {
+    const fetched: string[] = [];
+    const deleted: string[] = [];
+    const ingest = createIngestAttachments({
+      ...baseDeps(),
+      fetchObject: async (storagePath) => {
+        fetched.push(storagePath);
+        return { base64: "AAAA", contentType: "image/jpeg" };
+      },
+      deleteObject: async (storagePath) => {
+        deleted.push(storagePath);
+      },
+    });
+
+    const out = await ingest(["a1", "b2"]);
+
+    expect(fetched).toEqual(["users/u1/uploads/a1", "users/u1/uploads/b2"]);
+    expect(deleted).toEqual(["users/u1/uploads/a1", "users/u1/uploads/b2"]);
+    expect(out).toEqual([
+      { path: "data/attachments/AAAA.jpg", mimeType: "image/jpeg" },
+      { path: "data/attachments/AAAA.jpg", mimeType: "image/jpeg" },
+    ]);
+  });
+
+  it("throws when the host is not signed in", async () => {
+    const ingest = createIngestAttachments({ ...baseDeps(), uid: () => null });
+    await expect(ingest(["a1"])).rejects.toThrow(/not signed in/);
+  });
+
+  it("rejects a malformed storage_id before it can reshape the Storage path", async () => {
+    const ingest = createIngestAttachments(baseDeps());
+    await expect(ingest(["../evil"])).rejects.toThrow(/invalid storage_id/);
+    await expect(ingest(["a/b"])).rejects.toThrow(/invalid storage_id/);
+  });
+
+  it("tolerates a failed staging delete — the file is already ingested", async () => {
+    const ingest = createIngestAttachments({
+      ...baseDeps(),
+      deleteObject: async () => {
+        throw new Error("delete boom");
+      },
+    });
+    const out = await ingest(["a1"]);
+    expect(out).toHaveLength(1);
+  });
+});

--- a/server/backends/remoteHost/ingestAttachments.ts
+++ b/server/backends/remoteHost/ingestAttachments.ts
@@ -37,32 +37,42 @@ export interface IngestDeps {
   deleteObject: (storagePath: string) => Promise<void>;
 }
 
-// storage_ids -> path-only Attachments, in order. Rejects the whole batch on the
-// first failure to get bytes INTO the workspace (host not signed in, malformed
-// id, or a download/save that fails): the remote already uploaded and is waiting,
-// so a surfaced error beats silently starting a chat with a missing file. The
-// Storage delete is best-effort — the bytes are already safe in the workspace, so
-// a failed delete only logs and leaves an orphan for a Storage TTL sweep.
+// storage_ids -> path-only Attachments, in order. Two phases:
+//
+//  1. Fetch + save EVERY attachment into the workspace. Rejects the whole batch
+//     on the first hard failure (host not signed in, malformed id, or a
+//     download/save that fails) — WITHOUT deleting any staged object. So a remote
+//     retry with the same storage_ids still finds every upload: earlier files
+//     aren't reaped just because a later one failed.
+//  2. Only once all bytes are safely in the workspace, best-effort delete the
+//     staged objects. A failed delete only logs and leaves an orphan for a
+//     Storage TTL sweep — it never drops an already-ingested attachment.
 export const createIngestAttachments =
   (deps: IngestDeps) =>
   async (storageIds: string[]): Promise<Attachment[]> => {
     if (storageIds.length === 0) return [];
     const uid = deps.uid();
     if (!uid) throw new Error("remote host is not signed in");
-    const attachments: Attachment[] = [];
+
+    // Phase 1 — fetch + save all. A failure here throws before any delete.
+    const staged: Array<{ storagePath: string; attachment: Attachment }> = [];
     for (const storageId of storageIds) {
       if (!STORAGE_ID_RE.test(storageId)) throw new Error(`invalid storage_id: ${storageId}`);
       const storagePath = `users/${uid}/uploads/${storageId}`;
       const { base64, contentType } = await deps.fetchObject(storagePath);
       const saved = await deps.saveAttachment(base64, contentType);
+      staged.push({ storagePath, attachment: { path: saved.relativePath, mimeType: saved.mimeType } });
+    }
+
+    // Phase 2 — every file is now in the workspace; best-effort clean up staging.
+    for (const { storagePath } of staged) {
       try {
         await deps.deleteObject(storagePath);
       } catch (error) {
         console.warn("[remote-host] failed to delete staged upload after ingest; leaving orphan for TTL sweep", storagePath, String(error));
       }
-      attachments.push({ path: saved.relativePath, mimeType: saved.mimeType });
     }
-    return attachments;
+    return staged.map((entry) => entry.attachment);
   };
 
 // Wire the real Firebase-Storage deps to createIngestAttachments. `getBytes`

--- a/server/backends/remoteHost/ingestAttachments.ts
+++ b/server/backends/remoteHost/ingestAttachments.ts
@@ -1,0 +1,88 @@
+// Attachment ingest for remote chat (the phone → this host).
+//
+// The phone can't carry full-res attachment bytes over the Firestore command
+// channel (a command doc caps at ~1 MiB), so it uploads each file to Firebase
+// Storage at `users/{uid}/uploads/{storage_id}` and sends only the `storage_id`
+// on startChat. This module — signed in as the same user — pulls each staged
+// object, persists it into the workspace attachment store (data/attachments/…),
+// deletes the Storage object (staging only), and returns a path-only Attachment
+// per file for startChat to reference in the seeded prompt.
+//
+// Ported from MulmoClaude's server/remoteHost/handlers/ingestAttachments.ts.
+// Factory (createIngestAttachments) keeps the flow unit-testable with the Storage
+// + attachment-store deps stubbed.
+import { deleteObject, getBytes, getMetadata, ref } from "firebase/storage";
+import type { FirebaseStorage } from "firebase/storage";
+
+// A workspace-relative file path handed to the spawned chat.
+export interface Attachment {
+  path: string;
+  mimeType: string;
+}
+
+// `storage_id` is a bare UUID minted by the remote. Accept only a safe token so
+// it can never reshape the Storage path (no `/`, no `..`) before it is
+// interpolated into `users/{uid}/uploads/{storage_id}`. Simple char class — no
+// backtracking risk.
+const STORAGE_ID_RE = /^[A-Za-z0-9-]+$/;
+
+// Belt-and-suspenders cap matching the remote's ~100 MiB upload rule, so a
+// mis-sized object can't balloon host memory on download.
+const MAX_DOWNLOAD_BYTES = 110 * 1024 * 1024;
+
+export interface IngestDeps {
+  uid: () => string | null;
+  fetchObject: (storagePath: string) => Promise<{ base64: string; contentType: string }>;
+  saveAttachment: (base64: string, mimeType: string) => Promise<{ relativePath: string; mimeType: string }>;
+  deleteObject: (storagePath: string) => Promise<void>;
+}
+
+// storage_ids -> path-only Attachments, in order. Rejects the whole batch on the
+// first failure to get bytes INTO the workspace (host not signed in, malformed
+// id, or a download/save that fails): the remote already uploaded and is waiting,
+// so a surfaced error beats silently starting a chat with a missing file. The
+// Storage delete is best-effort — the bytes are already safe in the workspace, so
+// a failed delete only logs and leaves an orphan for a Storage TTL sweep.
+export const createIngestAttachments =
+  (deps: IngestDeps) =>
+  async (storageIds: string[]): Promise<Attachment[]> => {
+    if (storageIds.length === 0) return [];
+    const uid = deps.uid();
+    if (!uid) throw new Error("remote host is not signed in");
+    const attachments: Attachment[] = [];
+    for (const storageId of storageIds) {
+      if (!STORAGE_ID_RE.test(storageId)) throw new Error(`invalid storage_id: ${storageId}`);
+      const storagePath = `users/${uid}/uploads/${storageId}`;
+      const { base64, contentType } = await deps.fetchObject(storagePath);
+      const saved = await deps.saveAttachment(base64, contentType);
+      try {
+        await deps.deleteObject(storagePath);
+      } catch (error) {
+        console.warn("[remote-host] failed to delete staged upload after ingest; leaving orphan for TTL sweep", storagePath, String(error));
+      }
+      attachments.push({ path: saved.relativePath, mimeType: saved.mimeType });
+    }
+    return attachments;
+  };
+
+// Wire the real Firebase-Storage deps to createIngestAttachments. `getBytes`
+// (not the browser-only `getBlob`) returns an ArrayBuffer that works on Node.
+export interface StorageIngestDeps {
+  storage: FirebaseStorage;
+  uid: () => string | null;
+  saveAttachment: (base64: string, mimeType: string) => Promise<{ relativePath: string; mimeType: string }>;
+}
+
+export function buildIngestAttachments(deps: StorageIngestDeps) {
+  const fetchObject = async (storagePath: string) => {
+    const objectRef = ref(deps.storage, storagePath);
+    const [bytes, metadata] = await Promise.all([getBytes(objectRef, MAX_DOWNLOAD_BYTES), getMetadata(objectRef)]);
+    return { base64: Buffer.from(bytes).toString("base64"), contentType: metadata.contentType ?? "application/octet-stream" };
+  };
+  return createIngestAttachments({
+    uid: deps.uid,
+    fetchObject,
+    saveAttachment: deps.saveAttachment,
+    deleteObject: (storagePath) => deleteObject(ref(deps.storage, storagePath)),
+  });
+}


### PR DESCRIPTION
## Summary

The second deferred image feature: the phone can now **attach photos / PDFs to a chat**. Full-res bytes go to Firebase Storage (the 1 MiB Firestore command doc can't carry them); the phone sends only `storage_id`s on `startChat`, and the host — signed in as the same user — ingests them.

## What changed (all under `server/backends/remoteHost/`)

- **`firebase.ts`**: expose `storage` (dropped in phase 1).
- **`attachmentStore.ts`**: a lean `saveAttachment` — base64 → `data/attachments/YYYY/MM/<id>.<ext>` (atomic temp+rename), returns the workspace-relative path. (A trimmed port of MulmoClaude's — no hooks/companions/loaders.)
- **`ingestAttachments.ts`**: download each staged object from `users/{uid}/uploads/{storage_id}` → `saveAttachment` → best-effort delete staging → path-only `Attachment[]`. `storage_id` is regex-guarded (no `/` or `..`); the batch rejects on the first hard failure so the remote never gets a chat missing a file.
- **`handlers.ts` `startChat`**: ingest **before** spawning, then reference the saved paths in the seeded prompt.

## The delivery wrinkle

MulmoTerminal drives `claude` through an **interactive PTY** (typed input), which can't carry image *content blocks* the way MulmoClaude's stream-json spawn does. So instead the seeded prompt **names the saved files** and `claude` reads them with its Read tool (its cwd is the workspace):

```
what is in this photo?

Attached file(s) — read them from the workspace:
data/attachments/2026/07/d78a5b38.png
```

Text-only `startChat` is unchanged — `ingest([])` short-circuits before any Storage/auth touch. Result shapes match MulmoClaude's, so the same mulmoserver client drives either host.

## Verification

- `attachmentStore.spec` (real save): partitioned path + exact bytes on disk, `.bin` fallback.
- `ingestAttachments.spec`: download/save/delete order, not-signed-in, malformed `storage_id`, delete-failure tolerance.
- `handlers.spec`: `startChat` ingests + references paths, rejects a malformed `attachments` param.
- **Integration smoke** (real `saveAttachment` inside ingest inside `startChat`): the image landed on disk with correct bytes and the prompt referenced its path.
- `yarn typecheck` / `lint` / `build` green; **654 tests pass** (+8).

> Note: the actual Firebase Storage download requires a real phone upload + the bucket's read/delete rules for `users/{uid}/uploads/*` (same rules MulmoClaude relies on) — that boundary is exercised manually, like the connect flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)