### PR TITLE
fix: auto-build the sandbox image + ship its Dockerfile (fixes "docker won't connect")

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ survive (tmux itself is gone). Command-cell scripts are ephemeral and not persis
 
 Set **`MULMOTERMINAL_SANDBOX=1`** (and have Docker running) to run the **single-view**
 Claude session inside a container instead of on the host, while Claude still reaches the
-app's GUI MCP + activity hooks over `host.docker.internal`. Build the image first:
-`docker build -f Dockerfile.sandbox -t mulmoterminal-sandbox .` (override the name with
-`MULMOTERMINAL_SANDBOX_IMAGE`).
+app's GUI MCP + activity hooks over `host.docker.internal`. The `mulmoterminal-sandbox`
+image is **built automatically** on first launch from the shipped `Dockerfile.sandbox`
+(~1 min, once; rebuilt only when that file changes). Override the name with
+`MULMOTERMINAL_SANDBOX_IMAGE`. If the image can't be built (e.g. Docker down), the session
+falls back to the host spawn — no cryptic failure.
 
 This **contains** Claude — it can't reach the host filesystem outside the mounts, host
 processes, or arbitrary host ports. It is **not full isolation**: the **workspace** and

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "bin/",
     "dist/",
     "server/",
-    "plugins/"
+    "plugins/",
+    "Dockerfile.sandbox"
   ],
   "engines": {
     "node": ">=22.9"

--- a/plans/fix-sandbox-auto-build-image.md
+++ b/plans/fix-sandbox-auto-build-image.md
@@ -1,0 +1,37 @@
+# fix: sandbox "doesn't connect" when the image isn't built (auto-build + ship Dockerfile)
+
+## Report
+
+"docker 利用で繋がらない" — a tester's Docker sandbox wouldn't connect. Root cause: the
+`mulmoterminal-sandbox` image wasn't present on their machine.
+
+## Diagnosis
+
+- The image IS defined in this repo (`Dockerfile.sandbox`; verified its entrypoint/workdir
+  differ from mulmoclaude's `mulmoclaude-sandbox`, which is NOT interchangeable).
+- But it was **manual-build only** (no auto-build) AND **not shipped** in the npm package
+  (`files` excluded it) — so npm installs couldn't build it at all.
+- `dockerAvailable()` only checked the daemon (`docker info`), not image presence, so the
+  sandbox gate passed and `docker run` failed with a cryptic "Unable to find image …"
+  (`exit 125`) shown raw in the terminal → "doesn't connect", no clear message.
+
+## Fix (`server/sandbox.ts`, `server/index.ts`, `package.json`)
+
+1. Ship `Dockerfile.sandbox` in `package.json` `files`.
+2. `ensureSandboxImage()`: build the image if missing or the Dockerfile changed (sha256
+   tracked in an image label). Runs once at startup; `--load`; tiny secret-free build
+   context (the Dockerfile COPYs nothing). Resolves the Dockerfile relative to the package
+   (`<pkg>/Dockerfile.sandbox`), so it works in dev and npm installs.
+3. Gate: `... && dockerAvailable() && sandboxImageExists()` — a missing image now falls
+   back to the host spawn instead of a cryptic `docker run` error; startup logs the state.
+
+Closes the #202 follow-up "auto-build the sandbox image".
+
+## Verification
+
+- Booted with a throwaway missing image name → auto-built (`679MB`, sha-labelled) →
+  session connects (authenticated Claude UI). Re-boot with the cached image → instant, no
+  rebuild. Throwaway image removed; real image intact.
+- `npm pack --dry-run` now includes `Dockerfile.sandbox`.
+- `format`/`lint`/`typecheck`/`typecheck:server`/`build`/`test` green (+ a test asserting
+  the Dockerfile is in `files`).

--- a/server/index.ts
+++ b/server/index.ts
@@ -22,6 +22,8 @@ import {
   sandboxEnabled,
   sandboxPlatformSupported,
   dockerAvailable,
+  sandboxImageExists,
+  ensureSandboxImage,
   buildDockerRunArgs,
   writeSandboxClaudeConfig,
   writeSandboxCredentials,
@@ -1565,7 +1567,7 @@ function spawnClaudePty(
   // Sandbox only the SINGLE-VIEW interactive session: attachGuiMcp=true excludes grid
   // dev terminals (?gui=0), and ws!==null excludes hidden background/translation workers.
   // Falls back to the host spawn if the Docker daemon isn't reachable.
-  const sandbox = sandboxEnabled() && sandboxPlatformSupported() && attachGuiMcp && ws !== null && dockerAvailable();
+  const sandbox = sandboxEnabled() && sandboxPlatformSupported() && attachGuiMcp && ws !== null && dockerAvailable() && sandboxImageExists();
   const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
   const args = buildClaudeArgs({
     sessionId,
@@ -2010,11 +2012,13 @@ server.listen(PORT, () => {
   if (sandboxEnabled()) {
     if (!sandboxPlatformSupported()) {
       console.log("[sandbox] MULMOTERMINAL_SANDBOX set but only supported on macOS for now — using host spawn");
+    } else if (!dockerAvailable()) {
+      console.log("[sandbox] MULMOTERMINAL_SANDBOX set but Docker daemon unreachable — using host spawn");
+    } else if (ensureSandboxImage()) {
+      console.log("[sandbox] on — single-view Claude runs in a Docker container");
     } else {
       console.log(
-        dockerAvailable()
-          ? "[sandbox] on — single-view Claude runs in a Docker container"
-          : "[sandbox] MULMOTERMINAL_SANDBOX set but Docker daemon unreachable — using host spawn",
+        "[sandbox] sandbox image unavailable (build failed?) — using host spawn. Build it with: docker build -f Dockerfile.sandbox -t mulmoterminal-sandbox .",
       );
     }
   }

--- a/server/sandbox.spec.ts
+++ b/server/sandbox.spec.ts
@@ -74,6 +74,16 @@ describe("buildDockerRunArgs", () => {
   });
 });
 
+describe("sandbox image shipping", () => {
+  // Regression: the auto-build (ensureSandboxImage) resolves <pkg>/Dockerfile.sandbox, so
+  // it MUST be in the npm package `files` — else installs can't build the image and the
+  // sandbox fails with a cryptic `docker run` error.
+  it("ships Dockerfile.sandbox in the package files", () => {
+    const pkg = JSON.parse(readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
+    expect(pkg.files).toContain("Dockerfile.sandbox");
+  });
+});
+
 describe("sandboxCredentialsPath", () => {
   it("names a per-session creds file under the sandbox dir", () => {
     expect(sandboxCredentialsPath("abc-123")).toBe(path.join(os.homedir(), ".mulmoterminal", "sandbox", "creds-abc-123.json"));

--- a/server/sandbox.ts
+++ b/server/sandbox.ts
@@ -10,7 +10,9 @@
 // Verified in Phase 0 (#202): a sandboxed claude authenticates via the mounted ~/.claude
 // and connects to the host GUI MCP over host.docker.internal.
 import { spawnSync } from "node:child_process";
-import { writeFileSync, chmodSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, readFileSync, copyFileSync, chmodSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
 import path from "node:path";
 import os from "node:os";
 
@@ -50,6 +52,11 @@ function run(bin: string, args: string[]): { status: number | null } {
   return { status: spawnSync(bin, args, { stdio: "ignore" }).status };
 }
 
+// Like run(), but inherits stdio so the user sees the (slow, one-time) image build.
+function runInherit(bin: string, args: string[]): { status: number | null } {
+  return { status: spawnSync(bin, args, { stdio: "inherit" }).status };
+}
+
 // Is Docker usable (daemon reachable)? Only a POSITIVE result is cached — a failed check
 // (e.g. the daemon still starting when the server boots) is retried on the next spawn, so
 // transient unavailability doesn't permanently disable sandboxing until a restart.
@@ -57,6 +64,41 @@ let cachedDockerOk = false;
 export function dockerAvailable(): boolean {
   if (!cachedDockerOk) cachedDockerOk = run("docker", ["info"]).status === 0;
   return cachedDockerOk;
+}
+
+// The Dockerfile shipped with the package (package.json `files`), resolved relative to
+// this module like plugins-registry.ts does: <pkg>/server/sandbox.ts → <pkg>/Dockerfile.sandbox.
+// Works in dev and in an npm install.
+const DOCKERFILE = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "Dockerfile.sandbox");
+// The Dockerfile's sha256 is stored as an image label so a changed Dockerfile rebuilds.
+const IMAGE_SHA_LABEL = "mulmoterminal.dockerfile.sha256";
+
+// Is the sandbox image present locally? The gate checks this so a missing image falls
+// back to the host spawn instead of a cryptic `docker run` failure ("Unable to find image").
+export function sandboxImageExists(): boolean {
+  return run("docker", ["image", "inspect", IMAGE]).status === 0;
+}
+
+function builtImageSha(): string {
+  const r = runCapture("docker", ["image", "inspect", IMAGE, "--format", `{{index .Config.Labels "${IMAGE_SHA_LABEL}"}}`]);
+  return r.status === 0 ? r.stdout.trim() : "";
+}
+
+// Build the sandbox image when it's missing or the Dockerfile changed since the last build.
+// Blocking (~1 min on first build) — call ONCE at startup, never per spawn. Returns whether
+// the image is ready afterwards; a failed build (e.g. offline) leaves the gate to fall back
+// to the host spawn. If the Dockerfile isn't shipped, we can't build — report existing state.
+export function ensureSandboxImage(): boolean {
+  if (!existsSync(DOCKERFILE)) return sandboxImageExists();
+  const sha = createHash("sha256").update(readFileSync(DOCKERFILE)).digest("hex");
+  if (sandboxImageExists() && builtImageSha() === sha) return true;
+  console.log("[sandbox] building the sandbox image (first run / Dockerfile changed — takes ~1 min)...");
+  // Tiny, secret-free build context: the Dockerfile COPYs nothing, so hand docker a dir
+  // holding only it — NOT SANDBOX_DIR, which holds credentials. `--load` for the buildx driver.
+  const ctx = path.join(SANDBOX_DIR, "build");
+  mkdirSync(ctx, { recursive: true });
+  copyFileSync(DOCKERFILE, path.join(ctx, "Dockerfile"));
+  return runInherit("docker", ["build", "-t", IMAGE, "--label", `${IMAGE_SHA_LABEL}=${sha}`, "--load", ctx]).status === 0;
 }
 
 // A per-session ~/.claude.json for the container. We deliberately do NOT mount the


### PR DESCRIPTION
## Summary

Fixes a reported "docker で繋がらない" — the Docker sandbox wouldn't connect on machines where the `mulmoterminal-sandbox` image wasn't built.

**Root cause:** `dockerAvailable()` only checked the daemon (`docker info`), not image presence, so the sandbox gate passed and `docker run` failed with a cryptic *"Unable to find image 'mulmoterminal-sandbox'"* (`exit 125`) shown raw in the terminal → the session silently didn't connect. The image was also **manual-build-only** (no auto-build) and **not shipped** in the npm package (`files` excluded it), so npm installs couldn't build it at all.

**Fix:**
1. Ship `Dockerfile.sandbox` in `package.json` `files`.
2. `ensureSandboxImage()` — build the image if missing or the Dockerfile changed (sha256 tracked in an image label). Runs once at startup, `--load`, tiny secret-free build context (the Dockerfile COPYs nothing). Resolves the Dockerfile relative to the package (`<pkg>/Dockerfile.sandbox`, mirroring `plugins-registry.ts`), so it works in dev *and* npm installs.
3. Gate now also requires `sandboxImageExists()` — a missing/unbuildable image falls back to the **host spawn** (with a clear startup log) instead of a cryptic docker error.

Closes the #202 follow-up "auto-build the sandbox image".

## Items to Confirm / Review

- **Answering the original question**: the image *is* this repo's (`Dockerfile.sandbox`); `mulmoclaude-sandbox` is a **different, non-interchangeable** image (entrypoint `/sandbox-entrypoint.sh`, workdir `/home/node/mulmoclaude` vs ours: node-base entrypoint, `/home/node/workspace`). MulmoTerminal must use its own.
- **E2E-verified**: booted with a throwaway missing image → auto-built (`679MB`, sha-labelled) → session connects (authenticated Claude UI, no "Not logged in"); re-boot with the cached image → instant, no rebuild. `npm pack --dry-run` now includes `Dockerfile.sandbox`.
- **Build context**: uses `~/.mulmoterminal/sandbox/build/` holding only a copy of the Dockerfile — deliberately NOT `SANDBOX_DIR` (which holds per-session credential files), so no secrets are sent to the daemon.
- **Startup cost**: the one-time build blocks boot ~1 min (logged clearly). Cached thereafter via the sha label.

## User Prompt

> 別件で・docker利用で繋がらないという戻しが来た。ひょっとして、imageってこのれぽでつくてない? mulmoclaudeのを使うと動かないとかある?

## Verification

| check | result |
|-------|--------|
| missing image → auto-build → connect | ✅ built (679MB, sha-labelled), authenticated UI |
| cached image (sha match) → no rebuild | ✅ instant startup |
| missing/unbuildable → host fallback | ✅ gate `sandboxImageExists()`, clear log |
| Dockerfile.sandbox in `npm pack` | ✅ |
| lint / typecheck / typecheck:server / build / test | ✅ 637 pass (+ files regression test) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)