### PR TITLE
fix: re-sync the sandbox credential from the Keychain on reconnect

### DIFF
--- a/plans/fix-sandbox-refresh-cred-on-reconnect.md
+++ b/plans/fix-sandbox-refresh-cred-on-reconnect.md
@@ -1,0 +1,41 @@
+# fix: re-sync the sandbox credential from the Keychain on reconnect
+
+## Motivation
+
+A sandbox (single-view Docker) session's Claude credential is snapshotted at spawn onto a
+**read-only** mount (#211). Claude Code rotates its OAuth token over time; a long-running
+sandbox therefore drifts stale and eventually shows **"Not logged in"**, currently
+requiring a full re-spawn (restart server + fresh session).
+
+## Why not just make the mount writable
+
+Verified with node-pty: a **read-write bind-mounted file** allows in-place writes but
+**rejects atomic rename** ("Permission denied") — and Claude persists a refreshed token via
+atomic rename, so a RW file overlay wouldn't let it self-refresh. (Atomic rename works only
+inside a directory mount.) So the minimal, low-risk fix is to re-sync the mounted credential
+whenever the user reconnects.
+
+## Fix (`server/index.ts`)
+
+On reattach to a **sandbox** session, call `writeSandboxCredentials(sessionId)` again — it
+overwrites the mounted per-session creds file in place from the current Keychain, so a token
+that rotated since spawn is picked up on the next reconnect.
+
+```ts
+if (live?.sandbox) writeSandboxCredentials(sessionId);
+entry = live ? reattachPty(...) : spawnClaudePty(...);
+```
+
+## Scope / limitation
+
+This is a **preventive** refresh on reconnect: reconnecting re-syncs the credential. A
+session already stuck at "Not logged in" (Claude at the login screen doesn't re-poll the
+file) still needs a fresh session; a long-idle session that's never reconnected also won't
+refresh until the next reconnect. A fuller self-refresh would require moving the credential
+into the RW `~/.claude` dir mount (mutating the host file) — deferred.
+
+## Verification
+
+- `format`/`lint`/`typecheck`/`typecheck:server`/`build`/`test` green.
+- Mount-write behavior verified with node-pty (file rename fails; dir rename works),
+  informing why reconnect-refresh (not a RW overlay) is the chosen approach.

--- a/server/index.ts
+++ b/server/index.ts
@@ -1883,6 +1883,11 @@ wss.on("connection", (ws, req) => {
 
   let entry: PtyEntry;
   try {
+    // A sandbox session's credential is snapshotted at spawn onto its read-only mount. On
+    // reconnect, re-sync it from the Keychain (overwrites the mounted per-session file in
+    // place) so a token that rotated since spawn doesn't leave the reattached session stuck
+    // at "Not logged in".
+    if (live?.sandbox) writeSandboxCredentials(sessionId);
     entry = live ? reattachPty(live, ws, sessionId) : spawnClaudePty(sessionId, resume, ws, undefined, cwd, attachGuiMcp);
   } catch (err) {
     // A failed spawn (claude missing, or node-pty's spawn-helper not executable)


### PR DESCRIPTION
## Summary

A sandbox (single-view Docker) session's Claude credential is snapshotted at spawn onto a **read-only** mount (#211). Claude rotates its OAuth token over time, so a long-running sandbox drifts stale and eventually shows **"Not logged in"** — currently needing a full re-spawn (restart server + fresh session).

**Fix:** on reattach to a **sandbox** session, re-run `writeSandboxCredentials(sessionId)` — it overwrites the mounted per-session creds file in place from the current Keychain, so a token that rotated since spawn is picked up on reconnect.

```ts
if (live?.sandbox) writeSandboxCredentials(sessionId);
entry = live ? reattachPty(...) : spawnClaudePty(...);
```

## Items to Confirm / Review

- **Why not just make the mount writable so Claude self-refreshes?** Verified with node-pty: a read-write bind-mounted **file** allows in-place writes but **rejects atomic rename** (`Permission denied`), and Claude persists a refreshed token via atomic rename — which only works inside a *directory* mount. So a RW file overlay wouldn't enable self-refresh; reconnect-refresh is the minimal, low-risk fix that keeps #211's model.
- **Scope / limitation (intentional)**: this is a *preventive* refresh on reconnect. A session already stuck at "Not logged in" (Claude at the login screen doesn't re-poll the file) still needs a fresh session; a long-idle session that's never reconnected won't refresh until the next reconnect. A fuller self-refresh (move the credential into the RW `~/.claude` dir mount, mutating the host file — MulmoClaude's `sandbox:login` model) is deferred.
- **Safety**: only fires for `live.sandbox` sessions; `writeSandboxCredentials` returns null (no-op) if the Keychain read fails or on non-macOS.

## User Prompt

> ✻ Worked for 0s ってなるけどセッション、引き継がれている？サーバ再起動しないと引き継がれない？ … （"Not logged in" を自動で直したい） → はい

## Verification

| check | result |
|-------|--------|
| RW file mount: atomic rename | ✅ confirmed FAILS (informs the design) |
| lint / typecheck / typecheck:server / build / test | ✅ 647 pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)