### PR TITLE
fix(chat): auto-run collection chats actually submit (separate CR after paste)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1514,6 +1514,11 @@ async function translateViaHiddenChat(targetLanguage: string, sentences: readonl
 const DRAFT_READY_MARKER = /shift\+tab to cycle/;
 const DRAFT_SETTLE_MS = 250;
 const DRAFT_FALLBACK_MS = 6000;
+// Claude's TUI commits a bracketed paste to its input box asynchronously; a CR glued
+// onto the same write can arrive before the paste lands and be dropped — leaving an
+// auto-run prompt typed-but-unsent. Send the submitting Enter as a SEPARATE chunk a
+// beat after the paste so it actually registers.
+const DRAFT_SUBMIT_MS = 150;
 
 // Sanitize a draft before typing it into a PTY: strip ALL control bytes (C0/C1 —
 // ESC, Ctrl-C, CR/LF, and an embedded bracketed-paste terminator) so untrusted draft
@@ -1641,7 +1646,19 @@ function spawnClaudePty(
     if (draftDone) return;
     draftDone = true;
     try {
-      entry.term.write(`\x1b[200~${draftText}\x1b[201~${autoSubmit ? "\r" : ""}`);
+      // Type the paste first; for an auto-run, submit with a CR in a SEPARATE write a
+      // beat later (see DRAFT_SUBMIT_MS) so the Enter isn't dropped while Claude's TUI
+      // is still committing the paste. A draft gets no CR — the user reviews + sends.
+      entry.term.write(`\x1b[200~${draftText}\x1b[201~`);
+      if (autoSubmit) {
+        setTimeout(() => {
+          try {
+            entry.term.write("\r");
+          } catch {
+            // pty already gone — nothing to submit
+          }
+        }, DRAFT_SUBMIT_MS);
+      }
     } catch {
       // pty already gone — nothing to draft into
     }


### PR DESCRIPTION
## Problem

Starting a chat from the collection UI prefilled the prompt into Claude's input box but **never hit Enter**, so the chat sat there unsent.

This only looked like a routing difference from MulmoClaude. Both apps share `@mulmoclaude/collection-plugin@0.7.1` and make the identical decision per surface: `startChat` = auto-send, `startNewChatDraft` = editable draft. The difference is *how each host performs a send*:

- **MulmoClaude** (web) → `sendMessage()` POSTs the agent run directly.
- **MulmoTerminal** (terminal) → types the prompt into Claude's PTY and appends a submitting `\r`.

In `spawnClaudePty` the CR was glued onto the **same write** as the bracketed paste:

```ts
entry.term.write(`\x1b[200~${draftText}\x1b[201~${autoSubmit ? "\r" : ""}`);
```

Claude's Ink TUI commits a bracketed paste to its input box **asynchronously**, so the `\r` arriving in that same chunk raced the paste and was dropped — the prompt was typed but never submitted. This hit every `startChat` surface (index create, collection/record actions like Repair, add-collection / contribute / add-feed).

## Fix

Decouple the Enter from the paste: write the bracketed paste, then for an auto-run send `\r` as a **separate** write a beat later (`DRAFT_SUBMIT_MS = 150ms`).

The draft path (`startNewChatDraft` — custom views + new-collection starter cards) is untouched: it still gets no CR, so those stay editable drafts, matching MulmoClaude.

## Notes

- Diagnosed from code, not a live repro. The 150ms settle is a first estimate — if a fast machine still drops the Enter, nudge it toward `DRAFT_SETTLE_MS` (250ms).
- `yarn typecheck:server` and `yarn lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)