### PR TITLE
fix(remote-host): match MulmoClaude's toolbar icon (phonelink)

### DIFF
--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -139,7 +139,7 @@ onUnmounted(close);
       aria-label="Remote host"
       @click="toggle"
     >
-      <span class="material-symbols-outlined">smartphone</span>
+      <span class="material-symbols-outlined">phonelink</span>
     </button>
 
     <div v-if="open" class="rh-pop" role="group" aria-label="Remote host">


### PR DESCRIPTION
## Summary
The remote-connection toolbar button in MulmoTerminal used the `smartphone` Material Symbols icon, while MulmoClaude uses `phonelink`. This aligns MulmoTerminal to use the same icon.

- `src/components/RemoteHostControl.vue:142` — `smartphone` → `phonelink`

The `login`/`logout` icons inside the connect popover were already identical between the two apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)