### PR TITLE
chore(eslint): add function size + complexity guards as warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,28 @@ export default [
     },
   },
   {
+    // Complexity / size guards. All `warn` so they surface long or gnarly functions
+    // without failing the build (lint runs `eslint .` with no --max-warnings). Cognitive
+    // complexity is already covered by sonarjs (error@15); these add cyclomatic complexity,
+    // function length, nesting depth, params, and callback nesting.
+    rules: {
+      "max-lines-per-function": ["warn", { max: 80, skipBlankLines: true, skipComments: true, IIFEs: true }],
+      complexity: ["warn", 20],
+      "max-depth": ["warn", 4],
+      "max-params": ["warn", 6],
+      "max-nested-callbacks": ["warn", 4],
+    },
+  },
+  {
+    // Test files: a describe/it suite is one big (nested) callback by design, so the
+    // length + callback-nesting guards are noise here. Keep the logic-complexity guards on.
+    files: ["**/*.spec.{ts,js}", "**/*.test.{ts,js}"],
+    rules: {
+      "max-lines-per-function": "off",
+      "max-nested-callbacks": "off",
+    },
+  },
+  {
     // eslint-plugin-security tuning (mirrors mulmoclaude): these three rules fire
     // on safe, intentional patterns here — workspace-relative fs paths (session
     // files keyed by validated UUIDs), dynamic `obj[key]` lookups, and regexps —


### PR DESCRIPTION
## Summary

Adds `max-lines-per-function` (requested) plus complementary complexity guards to the ESLint config, all at **`warn`** level so they surface long / complex functions without failing the build (`yarn lint` = `eslint .`, no `--max-warnings`). `sonarjs/cognitive-complexity` already covers the cognitive axis (error@15); these add the missing axes:

| rule | threshold |
|------|-----------|
| `max-lines-per-function` | 80 (skip blank/comments, count IIFEs) |
| `complexity` (cyclomatic) | 20 |
| `max-depth` | 4 |
| `max-params` | 6 |
| `max-nested-callbacks` | 4 |

**Test files** are exempted from `max-lines-per-function` + `max-nested-callbacks` — a `describe`/`it` suite is one big nested callback by design (the initial run flagged a 982-line `describe` block, pure noise).

## Threshold tuning

Tuned against the real codebase → **5 production warnings, 0 errors** (lint/build/CI stay green):

- `server/backends/collections.ts` — `mountCollectionRoutes` (415 lines)
- `src/composables/useAppConfig.ts` — `useAppConfig` (162 lines)
- `server/index.ts` — `spawnClaudePty` (complexity 23, 7 params)
- `server/index.ts:1976` — arrow fn (complexity 24)

All are genuine complexity outliers worth revisiting later (not addressed here — this PR only adds the guards). Easy to tighten the thresholds over time since they're warnings.

## Items to Confirm / Review

- **No CI impact**: warnings don't fail `eslint .`; verified `yarn lint` exits 0.
- Threshold choice (80/20/4/6/4) is a "getting long / complex" line, not the 20-line ideal — picked so it flags outliers without drowning the signal. Happy to tighten if you'd prefer more pressure.

## User Prompt

> max-lines-per-functionをwarnでいれて、適当な長さに調整してみよう。後複雑さとかもチェック抜けあったら入れておいてね

🤖 Generated with [Claude Code](https://claude.com/claude-code)