### PR TITLE
chore(remote-host): bump @mulmoclaude/core to 0.10.0 for capability advertisement

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.1",
-    "@mulmoclaude/core": "^0.9.0",
+    "@mulmoclaude/core": "^0.10.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,10 +1410,10 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.9.0.tgz#5e2a1e2ce11909473cabe96e5b28bfd1cc11cf1a"
-  integrity sha512-lQzuGDCyK+9f3WmGal/WKkJloJUbLpkOT2ms1wi81L2QXUUrARQxGECSv+CgvGkaDaDbVlkKk/S1rTReWvUySg==
+"@mulmoclaude/core@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.10.0.tgz#d8a4baddc9307417640abff213238a5feb02eb5f"
+  integrity sha512-NP+xUfUgCg3D6iY5EjuPlqTVU5fsbxjnMkG0KfUJwNj+MXYDrqdWqPgjuuvKHiib67fHOQiCifmy+Wdx1p2Ftw==
   dependencies:
     fast-xml-parser "^5.9.3"
     js-yaml "^5.2.1"


### PR DESCRIPTION
## What

Bumps `@mulmoclaude/core` `^0.9.0` → `^0.10.0`, bringing MulmoTerminal to parity with MulmoClaude's remote-host **capability advertisement**.

MulmoClaude's host now writes `capabilities` + `protocolVersion` into the presence doc (`users/{uid}/hosts/{hostId}`), so the phone client can gate its UI on which methods a host serves — and gate on wire compatibility — *before* firing a command, instead of discovering `unknown_method` by trying. See `../mulmoclaude/docs/remote-host.md` ("Capability advertisement").

## Why it's a pure version bump

`startHostRunner`'s signature is **identical** between 0.9.0 and 0.10.0. The advertisement is written internally by the runner's `writePresence`, which in 0.10.0 spreads `buildHostPresence(channel, handlers, online)`:

- `capabilities = Object.keys(handlers)` — derived from the handler table MulmoTerminaI already passes at `server/backends/remoteHost/index.ts:42`
- `protocolVersion = REMOTE_HOST_PROTOCOL_VERSION` (currently `1`)

Derive-don't-duplicate: registering a handler is the only step to advertise it — no second list to keep in sync. No wiring changes were needed.

## What MulmoTerminal now advertises

`listCollections`, `getCollection`, `listFeeds`, `listShortcuts`, `listAccountingBooks`, `getRemoteView`, `getRemoteViewItems`, `mutateRemoteViewItem`, `startChat` + `protocolVersion: 1`.

New browser-safe core exports also become available (`HostPresence`, `REMOTE_HOST_PROTOCOL_VERSION`, `buildHostPresence`) for any code that wants to compile against the contract.

## Verification

- ✅ `yarn typecheck` (vue-tsc) clean — confirms no other 0.9→0.10 core subpath usages (collections, remote-view, etc.) broke
- ✅ Full suite: **662 tests / 67 files pass** (remote-host: 15/3)
- ✅ Confirmed installed 0.10.0's `writePresence` spreads `buildHostPresence`

Not covered: a live phone↔host smoke test confirming the mulmoserver client reads the advertised set. Static + test verification is solid; end-to-end would need a live connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)