### PR TITLE
feat(remote-host): provide listSkills capability

### DIFF
--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -67,6 +67,15 @@ const log = {
   debug: (prefix: string, message: string, data?: Record<string, unknown>) => console.debug(`[${prefix}] ${message}`, data ?? ""),
 };
 
+// Skill roots — the single source of truth for where skills live on disk, shared
+// with the collection engine (below) AND the remote-host listSkills scanner
+// (remoteHost/skills.ts) so both scan the exact same directories and stay
+// consistent about the skill/collection split.
+/** `~/.claude/skills` — user scope (read-only). */
+export const userSkillsDir = (): string => path.join(os.homedir(), ".claude", "skills");
+/** `<root>/.claude/skills` — project scope. */
+export const projectSkillsDir = (root: string): string => path.join(root, ".claude", "skills");
+
 // The shared workspace root, captured at init so the registry import route can pass
 // it to the engine (importRegistry takes it explicitly; the read side reads the host).
 let workspaceRoot: string | null = null;
@@ -80,9 +89,9 @@ export function initCollectionsBackend(deps: { workspace: string }): void {
     log,
     paths: {
       // ~/.claude/skills — user scope (read-only).
-      userSkillsDir: path.join(os.homedir(), ".claude", "skills"),
+      userSkillsDir: userSkillsDir(),
       // <root>/.claude/skills — project scope.
-      projectSkillsDir: (root) => path.join(root, ".claude", "skills"),
+      projectSkillsDir,
       // <root>/feeds — feed registry root.
       feedsRoot: (root) => path.join(root, "feeds"),
       // <root>/data/skills — project-skills staging.

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createRemoteHostHandlers } from "./handlers.js";
+import { initCollectionsBackend } from "../collections.js";
 
 describe("createRemoteHostHandlers", () => {
   let ws: string;
@@ -37,6 +38,7 @@ describe("createRemoteHostHandlers", () => {
       "getCollection",
       "listFeeds",
       "listShortcuts",
+      "listSkills",
       "listAccountingBooks",
       "startChat",
       "getRemoteView",
@@ -85,5 +87,45 @@ describe("createRemoteHostHandlers", () => {
   it("listShortcuts returns an empty list when no shortcuts file exists", async () => {
     const result = (await handlers.listShortcuts({})) as unknown as { shortcuts: unknown[] };
     expect(result.shortcuts).toEqual([]);
+  });
+});
+
+// listSkills leans on the globally-configured collection host (discoverCollections)
+// to subtract collection slugs, so it gets its own block that wires that host at a
+// tmp workspace. Assertions use contains/not-contains because the user scope scans
+// the developer's real ~/.claude/skills, which the test can't control.
+describe("createRemoteHostHandlers · listSkills", () => {
+  let ws: string;
+  let handlers: ReturnType<typeof createRemoteHostHandlers>;
+
+  const COL_SCHEMA = {
+    title: "My Collection",
+    icon: "star",
+    dataPath: "data/mycol/items",
+    primaryKey: "id",
+    fields: { id: { type: "string", label: "ID", primary: true, required: true } },
+  };
+
+  beforeEach(() => {
+    ws = mkdtempSync(path.join(tmpdir(), "mt-rh-skills-"));
+    // A plain skill (SKILL.md only) — should be listed.
+    mkdirSync(path.join(ws, ".claude", "skills", "mt-plain-skill"), { recursive: true });
+    writeFileSync(path.join(ws, ".claude", "skills", "mt-plain-skill", "SKILL.md"), "---\ndescription: a plain skill\n---\n\nbody");
+    // A collection that ALSO ships a SKILL.md — appears in the raw skill scan but
+    // must be subtracted (listCollections serves it), so it should NOT be listed.
+    mkdirSync(path.join(ws, ".claude", "skills", "mt-collection"), { recursive: true });
+    writeFileSync(path.join(ws, ".claude", "skills", "mt-collection", "schema.json"), JSON.stringify(COL_SCHEMA));
+    writeFileSync(path.join(ws, ".claude", "skills", "mt-collection", "SKILL.md"), "---\ndescription: a collection\n---\n\nbody");
+    mkdirSync(path.join(ws, "data", "mycol", "items"), { recursive: true });
+
+    initCollectionsBackend({ workspace: ws });
+    handlers = createRemoteHostHandlers({ workspace: ws, spawnChat: () => ({ chatId: "x" }), ingest: async () => [] });
+  });
+  afterEach(() => rmSync(ws, { recursive: true, force: true }));
+
+  it("lists plain skill ids and subtracts collection slugs", async () => {
+    const { skills } = (await handlers.listSkills({})) as unknown as { skills: string[] };
+    expect(skills).toContain("mt-plain-skill");
+    expect(skills).not.toContain("mt-collection");
   });
 });

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -14,6 +14,7 @@ import { listBooks } from "@mulmoclaude/accounting-plugin/server";
 import type { CommandHandlers, JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
 import { readShortcuts } from "../shortcuts.js";
+import { discoverSkillNames } from "./skills.js";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "./collectionPage.js";
 import {
   buildRemoteView,
@@ -100,6 +101,16 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
 
     // Pinned launcher shortcuts (favorites), read-only.
     listShortcuts: async () => ({ shortcuts: await readShortcuts(workspace) }) as unknown as JsonObject,
+
+    // Discoverable skill ids (~/.claude/skills + <workspace>/.claude/skills),
+    // read-only. Collection slugs are subtracted — a skill dir that ships a
+    // schema.json is a collection served by listCollections, so it must not
+    // double-list here (mirrors MulmoClaude's listSkills).
+    listSkills: async () => {
+      const [names, collections] = await Promise.all([discoverSkillNames({ workspaceRoot: workspace }), discoverCollections()]);
+      const collectionSlugs = new Set(collections.filter((collection) => collection.source !== "feed").map((collection) => collection.slug));
+      return { skills: names.filter((name) => !collectionSlugs.has(name)) } as unknown as JsonObject;
+    },
 
     // { id, name } per accounting book, for a mobile book picker.
     listAccountingBooks: async () => {

--- a/server/backends/remoteHost/skills.spec.ts
+++ b/server/backends/remoteHost/skills.spec.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { discoverSkillNames } from "./skills.js";
+
+// Write `<root>/.claude/skills/<name>/SKILL.md` with the given contents.
+const writeSkill = (root: string, name: string, contents: string): void => {
+  const dir = path.join(root, ".claude", "skills", name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path.join(dir, "SKILL.md"), contents);
+};
+
+const SKILL_MD = "---\ndescription: does a thing\n---\n\nbody";
+
+describe("discoverSkillNames", () => {
+  let userHome: string; // stands in for ~ (its .claude/skills is the user root)
+  let ws: string;
+
+  beforeEach(() => {
+    userHome = mkdtempSync(path.join(tmpdir(), "mt-skills-user-"));
+    ws = mkdtempSync(path.join(tmpdir(), "mt-skills-ws-"));
+  });
+  afterEach(() => {
+    rmSync(userHome, { recursive: true, force: true });
+    rmSync(ws, { recursive: true, force: true });
+  });
+
+  const userDir = () => path.join(userHome, ".claude", "skills");
+
+  it("returns skill ids from both user and project scopes, sorted", async () => {
+    writeSkill(userHome, "zed", SKILL_MD);
+    writeSkill(userHome, "alpha", SKILL_MD);
+    writeSkill(ws, "mid", SKILL_MD);
+    expect(await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).toEqual(["alpha", "mid", "zed"]);
+  });
+
+  it("dedupes a name present in both scopes (project shadows user)", async () => {
+    writeSkill(userHome, "shared", SKILL_MD);
+    writeSkill(ws, "shared", SKILL_MD);
+    writeSkill(ws, "only", SKILL_MD);
+    expect(await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).toEqual(["only", "shared"]);
+  });
+
+  it("skips dirs whose SKILL.md lacks frontmatter or a description", async () => {
+    writeSkill(ws, "no-frontmatter", "# just a heading\n\nbody");
+    writeSkill(ws, "no-description", "---\nroleId: general\n---\n\nbody");
+    writeSkill(ws, "unterminated", "---\ndescription: x\n\nbody");
+    writeSkill(ws, "good", SKILL_MD);
+    expect(await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).toEqual(["good"]);
+  });
+
+  it("skips non-directory and SKILL.md-less entries, and hidden entries", async () => {
+    const skillsRoot = path.join(ws, ".claude", "skills");
+    mkdirSync(skillsRoot, { recursive: true });
+    writeFileSync(path.join(skillsRoot, "loose-file.md"), "not a dir");
+    mkdirSync(path.join(skillsRoot, "empty-dir"));
+    mkdirSync(path.join(skillsRoot, ".hidden"));
+    writeFileSync(path.join(skillsRoot, ".hidden", "SKILL.md"), SKILL_MD);
+    writeSkill(ws, "real", SKILL_MD);
+    expect(await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).toEqual(["real"]);
+  });
+
+  it("follows a symlinked skill directory", async () => {
+    const target = mkdtempSync(path.join(tmpdir(), "mt-skills-ext-"));
+    writeFileSync(path.join(target, "SKILL.md"), SKILL_MD);
+    const skillsRoot = path.join(ws, ".claude", "skills");
+    mkdirSync(skillsRoot, { recursive: true });
+    symlinkSync(target, path.join(skillsRoot, "linked"));
+    try {
+      expect(await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).toEqual(["linked"]);
+    } finally {
+      rmSync(target, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty list when neither root exists", async () => {
+    expect(await discoverSkillNames({ workspaceRoot: ws, userDir: userDir() })).toEqual([]);
+  });
+});

--- a/server/backends/remoteHost/skills.ts
+++ b/server/backends/remoteHost/skills.ts
@@ -1,0 +1,90 @@
+// Skill discovery for the remote-host `listSkills` capability.
+//
+// MulmoTerminal drives `claude` over the same workspace, so the same skills the
+// CLI discovers under `~/.claude/skills/` and `<workspace>/.claude/skills/` are
+// available here. This mirrors MulmoClaude's `listSkills`: it returns the ids
+// (directory names) of discoverable skills as a flat `string[]` — read-only, and
+// the collection slugs are subtracted by the handler (a skill dir that also ships
+// a `schema.json` is a collection, served by `listCollections`, so it must not
+// double-list).
+//
+// The roots come from backends/collections.ts (`userSkillsDir` / `projectSkillsDir`),
+// the SAME directories the collection engine discovers — so the skill/collection
+// split is derived from one source of truth, not two.
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+import { userSkillsDir, projectSkillsDir } from "../collections.js";
+
+const SKILL_FILE = "SKILL.md";
+
+// A directory counts as a skill only when it holds a SKILL.md whose YAML
+// frontmatter declares a `description`. This matches MulmoClaude's
+// `parseSkillFrontmatter`, which returns null (→ the dir is skipped) without a
+// closing fence or a description key — so both hosts advertise the same ids.
+//
+// Scanned line-by-line rather than with a whole-document regex: a lazy
+// `[\s\S]*?` up to a closing fence backtracks super-linearly on a SKILL.md with
+// many newlines and no closing `---` (ReDoS). The line walk is linear.
+const isSkillMarkdown = (raw: string): boolean => {
+  const lines = raw.split(/\r?\n/);
+  if (lines[0] !== "---") return false; // must open with a fence on line 1
+  const close = lines.indexOf("---", 1); // …and be terminated
+  if (close === -1) return false;
+  return lines.slice(1, close).some((line) => /^\s*description\s*:/.test(line));
+};
+
+// True when `dir/SKILL.md` exists and carries usable frontmatter. Any read error
+// (missing file, permissions) means "not a skill" rather than a thrown list.
+const hasSkillMarkdown = async (dir: string): Promise<boolean> => {
+  try {
+    return isSkillMarkdown(await readFile(join(dir, SKILL_FILE), "utf-8"));
+  } catch {
+    return false;
+  }
+};
+
+// Scan one skills root for valid-skill directory names. A missing root is the
+// common case (a workspace with no `.claude/skills/`) → empty list.
+const collectSkillNames = async (root: string): Promise<string[]> => {
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch {
+    return [];
+  }
+  const names: string[] = [];
+  for (const name of entries) {
+    if (name.startsWith(".")) continue; // .DS_Store, .gitkeep, …
+    const dir = resolve(root, name);
+    try {
+      // stat (not lstat) follows symlinks, so `ln -s target skills/name` works.
+      if (!(await stat(dir)).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (await hasSkillMarkdown(dir)) names.push(name);
+  }
+  return names;
+};
+
+export interface DiscoverSkillNamesOptions {
+  /** Workspace root; project skills live at `<workspaceRoot>/.claude/skills/`. */
+  workspaceRoot: string;
+  /** Override `~/.claude/skills/` — for tests that point at a tmp tree so they
+   *  don't leak the developer's real skills into assertions. */
+  userDir?: string;
+}
+
+/**
+ * Every skill id available to this workspace, deduped and sorted. Project-scope
+ * skills shadow user-scope ones of the same name (only the id survives the merge,
+ * so a Set dedup is exact).
+ */
+export const discoverSkillNames = async (opts: DiscoverSkillNamesOptions): Promise<string[]> => {
+  const [userNames, projectNames] = await Promise.all([
+    collectSkillNames(opts.userDir ?? userSkillsDir()),
+    collectSkillNames(projectSkillsDir(opts.workspaceRoot)),
+  ]);
+  return [...new Set([...userNames, ...projectNames])].sort((left, right) => left.localeCompare(right));
+};


### PR DESCRIPTION
## What

Adds the `listSkills` remote-host capability to MulmoTerminal, matching MulmoClaude. MulmoTerminal drives `claude` over the same workspace, so the same skills under `~/.claude/skills/` and `<workspace>/.claude/skills/` are available — the phone (mulmoserver) can now list them, and it's **auto-advertised** in the presence doc (`Object.keys(handlers)`, no second list to maintain).

Returns the same shape as MulmoClaude: `{ skills: string[] }` — just the ids.

## Why local, not shared via core

We first considered extracting a shared `discoverSkills` into `@mulmoclaude/core`. Core exports **no** skills-discovery lister today: MulmoClaude's `discoverSkills` is repo-local, and its `parseSkillFrontmatter` is coupled to MC-only concerns (schedule/`roleId` auto-scheduling via `@receptron/task-scheduler`). Extracting cleanly would mean an MC refactor + core republish for a ~40-line scan. Not worth it — so `listSkills` is reimplemented locally here. If a second consumer ever needs it, that's the moment to extract.

## Changes

- **`collections.ts`** — export `userSkillsDir()` / `projectSkillsDir()`, the single source of truth for the skill roots (already used to configure the collection host), now reused by the scanner so the skill/collection split is derived **once**, not duplicated.
- **`remoteHost/skills.ts`** (new) — scan both roots for `SKILL.md` dirs whose frontmatter declares a `description` (matches MC's `parseSkillFrontmatter` accept rule), dedupe (project shadows user), sort. Follows symlinks; line-based frontmatter check (no super-linear regex).
- **`remoteHost/handlers.ts`** — `listSkills` handler, subtracting non-feed collection slugs so a `schema.json`-bearing skill dir isn't double-listed (it's served by `listCollections`) — mirrors MC exactly.

## Verification

- ✅ `vue-tsc` clean; `eslint` 0 errors (7 pre-existing warnings in unrelated files untouched)
- ✅ Full suite **669 tests / 68 files** pass — remote-host up to **22**, covering dedup, symlinked skill dirs, malformed/description-less frontmatter skips, and collection-slug subtraction

Not covered: a live phone↔host smoke test confirming the mulmoserver client renders the advertised skill list — needs a live connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)