### PR TITLE
feat(remote-host): provide getFeed capability

### DIFF
--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+//
+// getFeed reuses the collection page path (listItems + toDetail + pageResult)
+// over a feed located in the feed registry. This exercises it end-to-end with a
+// real on-disk dataDir, mocking only listFeeds so the test needn't stand up the
+// full feed-discovery/host stack. Kept in its own file so the module-level
+// listFeeds mock can't reach handlers.spec's real-collection-host listSkills test.
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { listFeeds } from "@mulmoclaude/core/feeds/server";
+import { createRemoteHostHandlers } from "./handlers.js";
+import { initCollectionsBackend } from "../collections.js";
+
+// Only listFeeds is stubbed; listItems/toDetail/deriveItems/pageResult stay real.
+vi.mock("@mulmoclaude/core/feeds/server", () => ({ listFeeds: vi.fn(), readFeedState: vi.fn() }));
+
+// A feed is a LoadedCollection with an `ingest` block. dataDir points at a real
+// temp dir so the real listItems reads the records off disk.
+const feedFixture = (dataDir: string) => ({
+  slug: "news",
+  source: "feed" as const,
+  schema: {
+    title: "News",
+    icon: "rss",
+    dataPath: "data/feeds/news",
+    primaryKey: "id",
+    ingest: { kind: "rss", schedule: "hourly" },
+    fields: {
+      id: { type: "string", label: "ID", primary: true, required: true },
+      title: { type: "string", label: "Title" },
+    },
+  },
+  dataDir,
+  skillDir: path.join(dataDir, "..", "skill"),
+});
+
+describe("createRemoteHostHandlers · getFeed", () => {
+  let ws: string;
+  let dataDir: string;
+  let handlers: ReturnType<typeof createRemoteHostHandlers>;
+
+  // The collection host is a process-global that refuses re-config with a
+  // different workspace, so configure it once for the whole block.
+  beforeAll(() => {
+    ws = mkdtempSync(path.join(tmpdir(), "mt-rh-feed-"));
+    // listItems resolves against the configured collection host's workspace root.
+    initCollectionsBackend({ workspace: ws });
+    // Records live at the real feed layout, <ws>/data/feeds/<slug>.
+    dataDir = path.join(ws, "data", "feeds", "news");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(path.join(dataDir, "item1.json"), JSON.stringify({ id: "1", title: "First" }));
+    writeFileSync(path.join(dataDir, "item2.json"), JSON.stringify({ id: "2", title: "Second" }));
+    handlers = createRemoteHostHandlers({ workspace: ws, spawnChat: () => ({ chatId: "x" }), ingest: async () => [] });
+  });
+  afterEach(() => vi.mocked(listFeeds).mockReset());
+  afterAll(() => rmSync(ws, { recursive: true, force: true }));
+
+  it("returns the feed detail + a page of its records", async () => {
+    vi.mocked(listFeeds).mockResolvedValue([feedFixture(dataDir)] as never);
+    const result = (await handlers.getFeed({ slug: "news" })) as unknown as {
+      collection: { title: string };
+      items: Array<{ id: string }>;
+      total: number;
+      offset: number;
+      limit: number;
+    };
+    expect(vi.mocked(listFeeds)).toHaveBeenCalledWith(ws);
+    expect(result.collection.title).toBe("News");
+    expect(result.total).toBe(2);
+    expect(result.items.map((item) => item.id).sort()).toEqual(["1", "2"]);
+  });
+
+  it("honors offset/limit paging", async () => {
+    vi.mocked(listFeeds).mockResolvedValue([feedFixture(dataDir)] as never);
+    const result = (await handlers.getFeed({ slug: "news", offset: 1, limit: 1 })) as unknown as {
+      items: unknown[];
+      total: number;
+      offset: number;
+      limit: number;
+    };
+    expect(result.total).toBe(2);
+    expect(result.items).toHaveLength(1);
+    expect(result.offset).toBe(1);
+    expect(result.limit).toBe(1);
+  });
+
+  it("throws when the feed slug is not registered", async () => {
+    vi.mocked(listFeeds).mockResolvedValue([feedFixture(dataDir)] as never);
+    await expect(handlers.getFeed({ slug: "missing" })).rejects.toThrow(/feed 'missing' not found/);
+  });
+});

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -37,6 +37,7 @@ describe("createRemoteHostHandlers", () => {
       "listCollections",
       "getCollection",
       "listFeeds",
+      "getFeed",
       "listShortcuts",
       "listSkills",
       "listAccountingBooks",

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -99,6 +99,21 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
       return { feeds: summaries } as unknown as JsonObject;
     },
 
+    // One feed's detail + a PAGE of its records. A feed IS a LoadedCollection
+    // with an `ingest` block, located via the feed registry (feeds live under
+    // their own registry, not the collections dir), so this reuses the exact
+    // collection page path and returns the SAME shape as getCollection — the
+    // phone renders feed records with the same card view.
+    getFeed: async (params: JsonObject) => {
+      const slug = String(params.slug ?? "");
+      const offset = clampOffset(params.offset);
+      const limit = clampLimit(params.limit);
+      const feed = (await listFeeds(workspace)).find((entry) => entry.slug === slug);
+      if (!feed) throw new Error(`feed '${slug}' not found`);
+      const all = deriveItems(feed.schema, await listItems(feed.dataDir));
+      return pageResult(toDetail(feed), all, offset, limit);
+    },
+
     // Pinned launcher shortcuts (favorites), read-only.
     listShortcuts: async () => ({ shortcuts: await readShortcuts(workspace) }) as unknown as JsonObject,
 


### PR DESCRIPTION
## What

Adds the `getFeed` remote-host capability to MulmoTerminal, matching MulmoClaude. This closes the last remote-host capability gap after `listSkills` (#227).

MulmoTerminal already served `listFeeds` (the feed index). `getFeed` returns **one feed's detail + a PAGE of its records**, so the phone (mulmoserver) can drill into a feed and render its records with the same card view it uses for collections. Auto-advertised in the presence doc via `Object.keys(handlers)`.

## How

A feed **is** a `LoadedCollection` with an `ingest` block, located via the feed registry (`listFeeds(workspace)`) rather than the collections dir. So the handler reuses the exact collection page path already in this file — `listItems` + `toDetail` + `deriveItems` + `pageResult` — and returns the **same shape as `getCollection`** (`{ collection, items, total, offset, limit }`). It's a one-for-one mirror of MulmoClaude's `getFeed`; all helpers were already imported, so the handler is 8 lines.

## Test

Lives in its own `getFeed.spec.ts` so its module-level `listFeeds` mock can't reach `handlers.spec`'s real-collection-host `listSkills` test. The collection host (needed by the real `listItems`) is configured once against a stable workspace with records at the real `data/feeds/<slug>` layout. Covers:
- paged happy path (detail title + both records)
- `offset`/`limit` paging
- not-found rejection (`feed 'missing' not found`)

## Verification

- ✅ `vue-tsc` clean; `eslint` 0 errors (7 pre-existing warnings in unrelated files untouched)
- ✅ Full suite **672 tests / 69 files** pass — remote-host up to **25**

Not covered: a live phone↔host smoke test confirming the mulmoserver client renders the feed detail — needs a live connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)