### PR TITLE
feat(remote-host): support offline-queued startChat (protocol v2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.7.1",
-    "@mulmoclaude/core": "^0.10.0",
+    "@mulmoclaude/core": "^0.12.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -17,6 +17,7 @@ import { auth, firestore, storage } from "./firebase.js";
 import { createRemoteHostHandlers } from "./handlers.js";
 import { createSaveAttachment } from "./attachmentStore.js";
 import { buildIngestAttachments } from "./ingestAttachments.js";
+import { onExpire } from "./onExpire.js";
 
 const HOST_ID = "mulmoterminal";
 const PREFIX = "[remote-host]";
@@ -40,6 +41,9 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
     signOut: authHelpers.signOutHost,
     currentUid: authHelpers.currentUid,
     startRunner: (channel, handlers, options) => startHostRunner(firestore, channel, handlers, options),
+    // Expired offline-queued startChat commands: delete the phone's staged
+    // Storage uploads before the runner removes the doc (protocol v2 offline queue).
+    onExpire,
     handlers: createRemoteHostHandlers({ workspace: deps.workspace, spawnChat: deps.spawnChat, ingest }),
     log: {
       info: (msg) => console.log(PREFIX, msg),

--- a/server/backends/remoteHost/onExpire.ts
+++ b/server/backends/remoteHost/onExpire.ts
@@ -1,0 +1,51 @@
+// onExpire cleanup for the remote-host runner (offline-queue support).
+//
+// When the shared runner (@mulmoclaude/core, protocol v2) drops a command for
+// being past its `expiresAt`, it calls this BEFORE deleting the command doc so an
+// expired `startChat` leaves nothing behind: we delete the full-res attachment
+// bytes the remote staged in Firebase Storage for it
+// (`users/{uid}/uploads/{storage_id}`). The Storage lifecycle TTL is only the
+// last-resort backstop for the one case this can't cover — a host that never
+// reconnects at all.
+//
+// `uid` is the runner's session uid, passed in by the runner (channel.uid) rather
+// than read from a global — a concurrent reconnect as a different account must not
+// point this cleanup at the new user's Storage path.
+//
+// Best-effort throughout: a failed delete logs and leaves the orphan for the TTL
+// sweep, and this must never throw back into the runner (the doc deletion runs
+// regardless). Unlike startChat's strict attachment parsing, extraction here is
+// lenient — this is cleanup, so a malformed entry is skipped, not surfaced.
+import { deleteObject, ref } from "firebase/storage";
+import type { Command, JsonObject } from "@mulmoclaude/core/remote-host";
+
+import { storage } from "./firebase.js";
+
+const PREFIX = "[remote-host]";
+
+// Same safe-token guard ingestAttachments applies before interpolating a
+// storage_id into the Storage path (no `/`, no `..`).
+const STORAGE_ID_RE = /^[A-Za-z0-9-]+$/;
+
+const errorText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
+
+// Pull the staged storage_ids out of a command's `{ attachments: [{ storage_id }] }`
+// params, skipping anything malformed. Absent / wrong-shaped ⇒ [].
+const stagedStorageIds = (params: JsonObject): string[] => {
+  const { attachments } = params;
+  if (!Array.isArray(attachments)) return [];
+  return attachments.flatMap((entry) => {
+    const rawId = entry && typeof entry === "object" && !Array.isArray(entry) ? entry.storage_id : undefined;
+    return typeof rawId === "string" && STORAGE_ID_RE.test(rawId) ? [rawId] : [];
+  });
+};
+
+export const onExpire = async (command: Command, uid: string): Promise<void> => {
+  for (const storageId of stagedStorageIds(command.params)) {
+    try {
+      await deleteObject(ref(storage, `users/${uid}/uploads/${storageId}`));
+    } catch (error) {
+      console.warn(PREFIX, "failed to delete staged upload for expired command; leaving orphan for TTL sweep", { storageId, error: errorText(error) });
+    }
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1410,10 +1410,10 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.10.0.tgz#d8a4baddc9307417640abff213238a5feb02eb5f"
-  integrity sha512-NP+xUfUgCg3D6iY5EjuPlqTVU5fsbxjnMkG0KfUJwNj+MXYDrqdWqPgjuuvKHiib67fHOQiCifmy+Wdx1p2Ftw==
+"@mulmoclaude/core@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.12.0.tgz#fb5147348ca1fc24a6a43cc5fccdba160cb7ed61"
+  integrity sha512-/LjmqwfqVobo1oEKFRT5Rb3nKHOa6H1cnRSf+YiI7++5YuFSoXF69Budozu7WvB5tZhB3wHByDu35NbfvdVtow==
   dependencies:
     fast-xml-parser "^5.9.3"
     js-yaml "^5.2.1"


### PR DESCRIPTION
## What

Brings MulmoClaude's remote-host **offline queueing** to MulmoTerminal: a phone can write a `startChat` command (and stage its image uploads) while this host is asleep, and the host **drains everything on reconnect**. Live-verified working.

The command channel is already a durable Firestore queue — the runner's `onSnapshot` reports every pre-existing `queued` doc as an `added` change the instant it re-attaches, so no flush call or separate channel is needed.

## Changes (3)

1. **Bump `@mulmoclaude/core` `^0.10.0 → ^0.12.0`.** All drain/expiry logic lives in core, so this alone gives:
   - in-memory `createdAt` drain ordering (oldest-first bias)
   - `expiresAt` deletion of stale commands
   - `REMOTE_HOST_PROTOCOL_VERSION` **2** advertised in the presence doc (auto-derived), so remotes gate offline queueing on `protocolVersion >= 2` before issuing.
2. **New `server/backends/remoteHost/onExpire.ts`** — the one host-specific piece. When the runner drops a command past its `expiresAt`, delete the phone's staged Storage uploads (`users/{uid}/uploads/{storage_id}`) before the doc is removed, keyed by the runner-supplied session `uid` (not a global — a concurrent reconnect as a different account must not touch the new user's path). Best-effort: never throws back into the runner; a failed delete logs and leaves the orphan for the Storage TTL backstop.
3. **Wire `onExpire`** into the `createRemoteHost({…})` call.

No handler, route, or frontend changes. Mirrors MulmoClaude's host-side port (commits `546bf53b`, `19f62d0f`).

## Verification

- `yarn typecheck` — clean
- `yarn vitest run server/backends/remoteHost` — 25/25 passing
- ESLint on new + changed files — clean
- Live-verified from the phone client

## Follow-up (not in this PR)

**TTL-below-expiry invariant:** the `expiresAt` horizon (7 days) must stay under the Firebase Storage lifecycle TTL (14 days), or a still-valid queued command could find its staged upload already swept. That's shared-bucket lifecycle config, not host code — flagging so it isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)