### PR TITLE
chore(eslint): promote cleared complexity rules from warn to error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,16 +37,18 @@ export default [
     },
   },
   {
-    // Complexity / size guards. All `warn` so they surface long or gnarly functions
-    // without failing the build (lint runs `eslint .` with no --max-warnings). Cognitive
-    // complexity is already covered by sonarjs (error@15); these add cyclomatic complexity,
-    // function length, nesting depth, params, and callback nesting.
+    // Complexity / size guards. Cognitive complexity is already covered by sonarjs
+    // (error@15). cyclomatic complexity, nesting depth, and callback nesting have zero
+    // offenders, so they're ERRORS — enforced going forward. Function length and param
+    // count stay WARN because two intentional offenders remain: createRemoteHostHandlers
+    // (92 lines, being reworked in an open PR) and spawnClaudePty's 7 params (hot path,
+    // not worth churning 5 call sites) — flip these two to error once those are resolved.
     rules: {
       "max-lines-per-function": ["warn", { max: 80, skipBlankLines: true, skipComments: true, IIFEs: true }],
-      complexity: ["warn", 20],
-      "max-depth": ["warn", 4],
+      complexity: ["error", 20],
+      "max-depth": ["error", 4],
       "max-params": ["warn", 6],
-      "max-nested-callbacks": ["warn", 4],
+      "max-nested-callbacks": ["error", 4],
     },
   },
   {


### PR DESCRIPTION
## Summary

Now that the offenders are cleared (#230 collections, #231 useAppConfig, #232 index.ts), promote the fully-cleared complexity guards from `warn` to **`error`**:

| rule | before | after | offenders |
|------|--------|-------|-----------|
| `complexity` (20) | warn | **error** | 0 |
| `max-depth` (4) | warn | **error** | 0 |
| `max-nested-callbacks` (4) | warn | **error** | 0 |
| `max-lines-per-function` (80) | warn | warn | 1 — `createRemoteHostHandlers` |
| `max-params` (6) | warn | warn | 1 — `spawnClaudePty` |

**`max-lines-per-function` + `max-params` stay `warn`** because two intentional offenders remain:
- `createRemoteHostHandlers` (92 lines) — its file (`remoteHost/handlers.ts`) is being actively reworked in **open PR #220**; refactoring now would conflict.
- `spawnClaudePty` (7 params) — hot path; bundling into an options object would churn 5 call sites for little gain.

Flip these two to `error` once those are resolved (noted in the config comment).

## Items to Confirm / Review

- **No CI impact**: `yarn lint` exits **0** (0 errors, 2 warnings); build green. The three error rules have zero violations so nothing fails.

## User Prompt

> 副作用がなそうなのは順次進めて。 で、問題なくなったらwarn -> errorに変更を。

🤖 Generated with [Claude Code](https://claude.com/claude-code)