### PR TITLE
refactor(remote-host): split createRemoteHostHandlers + flip max-lines to error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,13 +38,11 @@ export default [
   },
   {
     // Complexity / size guards. Cognitive complexity is already covered by sonarjs
-    // (error@15). cyclomatic complexity, nesting depth, and callback nesting have zero
-    // offenders, so they're ERRORS — enforced going forward. Function length and param
-    // count stay WARN because two intentional offenders remain: createRemoteHostHandlers
-    // (92 lines, being reworked in an open PR) and spawnClaudePty's 7 params (hot path,
-    // not worth churning 5 call sites) — flip these two to error once those are resolved.
+    // (error@15). All ERRORS (enforced going forward) except max-params, which stays WARN
+    // for its one intentional offender: spawnClaudePty's 7 params (hot path, not worth
+    // churning 5 call sites into an options object) — flip it to error once resolved.
     rules: {
-      "max-lines-per-function": ["warn", { max: 80, skipBlankLines: true, skipComments: true, IIFEs: true }],
+      "max-lines-per-function": ["error", { max: 80, skipBlankLines: true, skipComments: true, IIFEs: true }],
       complexity: ["error", 20],
       "max-depth": ["error", 4],
       "max-params": ["warn", 6],

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -57,28 +57,80 @@ const composeMessage = (message: string, attachments: Attachment[]): string => {
   return `${message}\n\nAttached file(s) — read them from the workspace:\n${paths}`;
 };
 
+// ── Deps-free command handlers (params + engine imports only) ──
+// Extracted to module scope so createRemoteHostHandlers stays small; the deps-using
+// handlers (workspace / spawnChat / ingest) stay in the factory below.
+
+// Mirrors GET /api/collections/list → { collections: CollectionSummary[] }. Feeds
+// (source "feed") are excluded — they are served by listFeeds.
+const listCollections: CommandHandlers["listCollections"] = async () => {
+  const collections = (await discoverCollections()).filter((collection) => collection.source !== "feed").map(toSummary);
+  return { collections } as unknown as JsonObject;
+};
+
+// One collection's detail + a PAGE of its records (pagination mandatory — the result
+// rides inside a 1 MiB Firestore command doc).
+const getCollection: CommandHandlers["getCollection"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const offset = clampOffset(params.offset);
+  const limit = clampLimit(params.limit);
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const all = deriveItems(collection.schema, await listItems(collection.dataDir));
+  return pageResult(toDetail(collection), all, offset, limit);
+};
+
+// One mobile custom view, wrapped host-side into its sandboxed srcdoc (CSP +
+// postMessage bootstrap) — the phone renders the artifact verbatim.
+const getRemoteView: CommandHandlers["getRemoteView"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const viewId = String(params.viewId ?? "");
+  const locale = typeof params.locale === "string" ? params.locale : "";
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const result = await buildRemoteView(collection, viewId, locale);
+  if (result.kind !== "ok") throw new Error(remoteViewFailureMessage(result, slug));
+  return { view: result.view, srcdoc: result.srcdoc, bytes: result.bytes } as unknown as JsonObject;
+};
+
+// One page of a mobile view's records, projected to the view's fields. Image fields are
+// NOT inlined on this host yet (no thumbnail store) — they come back as workspace paths
+// (unrenderable on the phone) and count as `omitted`.
+const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const viewId = String(params.viewId ?? "");
+  const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), fields: normalizeFields(params.fields) };
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const result = await remoteViewItems(collection, viewId, request);
+  if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
+  return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
+};
+
+// Apply one update/delete requested by a writable mobile view, authorized by that view's
+// declared surface (editableFields / allowDelete) and enforced HOST-side — the sandboxed
+// view is never trusted.
+const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const viewId = String(params.viewId ?? "");
+  const request = normalizeMutate({ op: params.op, id: params.id, patch: params.patch });
+  if (!request) throw new Error("invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const result = await mutateRemoteView(collection, viewId, request);
+  if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
+  return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
+};
+
 export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHandlers {
   const { workspace, spawnChat, ingest } = deps;
 
   return {
-    // Mirrors GET /api/collections/list → { collections: CollectionSummary[] }.
-    // Feeds (source "feed") are excluded — they are served by listFeeds.
-    listCollections: async () => {
-      const collections = (await discoverCollections()).filter((collection) => collection.source !== "feed").map(toSummary);
-      return { collections } as unknown as JsonObject;
-    },
-
-    // One collection's detail + a PAGE of its records (pagination mandatory — the
-    // result rides inside a 1 MiB Firestore command doc).
-    getCollection: async (params: JsonObject) => {
-      const slug = String(params.slug ?? "");
-      const offset = clampOffset(params.offset);
-      const limit = clampLimit(params.limit);
-      const collection = await loadCollection(slug);
-      if (!collection) throw new Error(`collection '${slug}' not found`);
-      const all = deriveItems(collection.schema, await listItems(collection.dataDir));
-      return pageResult(toDetail(collection), all, offset, limit);
-    },
+    listCollections,
+    getCollection,
+    getRemoteView,
+    getRemoteViewItems,
+    mutateRemoteViewItem,
 
     // Feed registry with retrieval kind / schedule / last-fetch time (read-only).
     listFeeds: async () => {
@@ -131,48 +183,6 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
     listAccountingBooks: async () => {
       const { books } = await listBooks(workspace);
       return { books: books.map((book) => ({ id: book.id, name: book.name })) } as unknown as JsonObject;
-    },
-
-    // One mobile custom view, wrapped host-side into its sandboxed srcdoc (CSP +
-    // postMessage bootstrap) — the phone renders the artifact verbatim.
-    getRemoteView: async (params: JsonObject) => {
-      const slug = String(params.slug ?? "");
-      const viewId = String(params.viewId ?? "");
-      const locale = typeof params.locale === "string" ? params.locale : "";
-      const collection = await loadCollection(slug);
-      if (!collection) throw new Error(`collection '${slug}' not found`);
-      const result = await buildRemoteView(collection, viewId, locale);
-      if (result.kind !== "ok") throw new Error(remoteViewFailureMessage(result, slug));
-      return { view: result.view, srcdoc: result.srcdoc, bytes: result.bytes } as unknown as JsonObject;
-    },
-
-    // One page of a mobile view's records, projected to the view's fields. Image
-    // fields are NOT inlined on this host yet (no thumbnail store) — they come
-    // back as workspace paths (unrenderable on the phone) and count as `omitted`.
-    getRemoteViewItems: async (params: JsonObject) => {
-      const slug = String(params.slug ?? "");
-      const viewId = String(params.viewId ?? "");
-      const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), fields: normalizeFields(params.fields) };
-      const collection = await loadCollection(slug);
-      if (!collection) throw new Error(`collection '${slug}' not found`);
-      const result = await remoteViewItems(collection, viewId, request);
-      if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
-      return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
-    },
-
-    // Apply one update/delete requested by a writable mobile view, authorized by
-    // that view's declared surface (editableFields / allowDelete) and enforced
-    // HOST-side — the sandboxed view is never trusted.
-    mutateRemoteViewItem: async (params: JsonObject) => {
-      const slug = String(params.slug ?? "");
-      const viewId = String(params.viewId ?? "");
-      const request = normalizeMutate({ op: params.op, id: params.id, patch: params.patch });
-      if (!request) throw new Error("invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
-      const collection = await loadCollection(slug);
-      if (!collection) throw new Error(`collection '${slug}' not found`);
-      const result = await mutateRemoteView(collection, viewId, request);
-      if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
-      return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
     },
 
     // Start a visible chat from the phone, seeded with `message`. This host has


### PR DESCRIPTION
## Summary

PR #220 (which was actively reworking `remoteHost/handlers.ts`) merged, so `createRemoteHostHandlers` is unblocked. Hoist its **5 deps-free command handlers** (`listCollections`, `getCollection`, `getRemoteView`, `getRemoteViewItems`, `mutateRemoteViewItem` — params + engine imports only) to module-level consts typed via `CommandHandlers[...]`; the `deps`-using handlers (`workspace` / `spawnChat` / `ingest`) stay in the factory. Behavior identical.

With that 92-line function cleared, **`max-lines-per-function` has zero offenders → promoted from `warn` to `error`**. The only rule still `warn` is `max-params` (spawnClaudePty's 7 params, hot path — not worth churning 5 call sites).

## Status of the complexity guards

| rule | now |
|------|-----|
| `complexity` / `max-depth` / `max-nested-callbacks` / **`max-lines-per-function`** | **error** ✅ |
| `max-params` | warn (spawnClaudePty, 7) |

## Items to Confirm / Review

- **Pure move**: the 5 hoisted handlers are byte-identical (typed `CommandHandlers["x"]` instead of inline); the returned object references them by shorthand + keeps the 6 deps-using handlers inline. Order-independent (it's a command map).
- Verified: `handlers.ts` clears the warning; `typecheck:server` green; `handlers.spec` **8/8** and the full suite **672** pass; `yarn lint` exits **0** (0 errors, 1 warning).

## User Prompt

> main最新にして、createRemoteHostHandlersもできるかな？

🤖 Generated with [Claude Code](https://claude.com/claude-code)