### PR TITLE
refactor: tighten max-lines-per-function to 60 and split the offenders

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,7 @@ export default [
     // for its one intentional offender: spawnClaudePty's 7 params (hot path, not worth
     // churning 5 call sites into an options object) — flip it to error once resolved.
     rules: {
-      "max-lines-per-function": ["error", { max: 80, skipBlankLines: true, skipComments: true, IIFEs: true }],
+      "max-lines-per-function": ["error", { max: 60, skipBlankLines: true, skipComments: true, IIFEs: true }],
       complexity: ["error", 20],
       "max-depth": ["error", 4],
       "max-params": ["warn", 6],

--- a/server/files-browse.ts
+++ b/server/files-browse.ts
@@ -103,38 +103,41 @@ export function listEntries(absDir: string): BrowseEntry[] {
     });
 }
 
-export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string }): void {
-  const baseOf = (req: Request) => resolveBase(typeof req.query.cwd === "string" ? req.query.cwd : null, deps.defaultCwd);
-  const relOf = (req: Request) => (typeof req.query.path === "string" ? req.query.path : "");
+// Project base + relative path from a browse request's query. browseBase falls back to
+// the server's default cwd; browseRel defaults to "" (the base itself).
+const browseBase = (req: Request, defaultCwd: string): string => resolveBase(typeof req.query.cwd === "string" ? req.query.cwd : null, defaultCwd);
+const browseRel = (req: Request): string => (typeof req.query.path === "string" ? req.query.path : "");
 
-  // Resolve `path` under the request's project base; 403 if it escapes — lexically OR
-  // through a symlink. Centralises the containment check so every route (read AND write)
-  // shares one gate.
-  const contained = (req: Request, res: Response): string | null => {
-    const base = baseOf(req);
-    const lexical = containedPath(base, relOf(req));
-    const abs = lexical ? realContainedWithin(base, lexical) : null;
-    if (!abs) {
-      res.status(403).json({ error: "path escapes the project root" });
-      return null;
-    }
-    return abs;
-  };
+// Resolve `path` under the request's project base; 403 (and returns null) if it escapes —
+// lexically OR through a symlink. One containment gate shared by every route (read + write).
+function containedFor(req: Request, res: Response, defaultCwd: string): string | null {
+  const base = browseBase(req, defaultCwd);
+  const lexical = containedPath(base, browseRel(req));
+  const abs = lexical ? realContainedWithin(base, lexical) : null;
+  if (!abs) {
+    res.status(403).json({ error: "path escapes the project root" });
+    return null;
+  }
+  return abs;
+}
+
+export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string }): void {
+  const { defaultCwd } = deps;
 
   app.get("/api/files/browse/list", (req, res) => {
-    const root = baseOf(req);
-    const abs = contained(req, res);
+    const root = browseBase(req, defaultCwd);
+    const abs = containedFor(req, res, defaultCwd);
     if (!abs) return;
     try {
       if (!fs.statSync(abs).isDirectory()) return res.status(400).json({ error: "not a directory" });
-      res.json({ cwd: path.resolve(root), path: relOf(req), entries: listEntries(abs) });
+      res.json({ cwd: path.resolve(root), path: browseRel(req), entries: listEntries(abs) });
     } catch {
       res.status(404).json({ error: "not found" });
     }
   });
 
   app.get("/api/files/browse/text", (req, res) => {
-    const abs = contained(req, res);
+    const abs = containedFor(req, res, defaultCwd);
     if (!abs) return;
     try {
       const stat = fs.statSync(abs);
@@ -147,7 +150,7 @@ export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string 
   });
 
   app.get("/api/files/browse/md", async (req, res) => {
-    const abs = contained(req, res);
+    const abs = containedFor(req, res, defaultCwd);
     if (!abs) return;
     let text: string;
     try {
@@ -166,7 +169,7 @@ export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string 
   });
 
   app.put("/api/files/browse/write", (req, res) => {
-    const abs = contained(req, res);
+    const abs = containedFor(req, res, defaultCwd);
     if (!abs) return;
     const text = req.body?.text;
     if (typeof text !== "string") return res.status(400).json({ error: "body.text (string) required" });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1193,6 +1193,45 @@ app.get("/api/dir-sound", (req, res) => {
   });
 });
 
+// Cheap recency pass: stat (don't read) every session file just for its mtime, so the
+// list can be ranked by recency. Files that vanished between readdir and stat are skipped.
+async function collectOnDiskSessionStats(dir: string, files: string[]): Promise<DiskStat[]> {
+  const stats = await Promise.all(
+    files.map(async (file): Promise<DiskStat | null> => {
+      try {
+        const st = await fs.stat(path.join(dir, file));
+        return { kind: "disk", id: path.basename(file, ".jsonl"), file, mtime: st.mtimeMs };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return stats.filter((s): s is DiskStat => s !== null);
+}
+
+// In-memory sessions not yet written to disk. Prune (delete from knownSessions) any that
+// have since been persisted — the on-disk record (with its real title) wins.
+function collectPendingSessions(onDisk: Set<string>, includePending: boolean): PendingSession[] {
+  const pending: PendingSession[] = [];
+  for (const [id, meta] of includePending ? knownSessions : []) {
+    if (onDisk.has(id)) {
+      knownSessions.delete(id);
+      continue;
+    }
+    pending.push({
+      kind: "pending",
+      id,
+      title: meta.title,
+      mtime: meta.createdAt,
+      working: activity.get(id)?.working ?? false,
+      waiting: activity.get(id)?.waiting ?? false,
+      event: activity.get(id)?.event ?? null,
+      hidden: hiddenSessions.has(id),
+    });
+  }
+  return pending;
+}
+
 // List the chat sessions for the current project (CLAUDE_CWD), including
 // newly-created sessions that aren't persisted to disk yet.
 app.get("/api/sessions", async (req, res) => {
@@ -1214,42 +1253,10 @@ app.get("/api/sessions", async (req, res) => {
       if (!hasErrnoCode(err) || err.code !== "ENOENT") throw err;
     }
 
-    // Cheap pass: stat (don't read) every file just for its mtime, so we can
-    // rank by recency. Skip any that vanished between readdir and stat.
-    const onDiskStats = (
-      await Promise.all(
-        files.map(async (file): Promise<DiskStat | null> => {
-          try {
-            const st = await fs.stat(path.join(dir, file));
-            return { kind: "disk", id: path.basename(file, ".jsonl"), file, mtime: st.mtimeMs };
-          } catch {
-            return null;
-          }
-        }),
-      )
-    ).filter((s): s is DiskStat => s !== null);
+    const onDiskStats = await collectOnDiskSessionStats(dir, files);
     const onDisk = new Set(onDiskStats.map((s) => s.id));
-
-    // In-memory sessions not yet written to disk. Prune any that have since
-    // been persisted — the on-disk record (with its real title) wins. Skipped for
-    // a cwd-scoped query (pending sessions aren't tracked per directory).
-    const pending: PendingSession[] = [];
-    for (const [id, meta] of includePending ? knownSessions : []) {
-      if (onDisk.has(id)) {
-        knownSessions.delete(id);
-        continue;
-      }
-      pending.push({
-        kind: "pending",
-        id,
-        title: meta.title,
-        mtime: meta.createdAt,
-        working: activity.get(id)?.working ?? false,
-        waiting: activity.get(id)?.waiting ?? false,
-        event: activity.get(id)?.event ?? null,
-        hidden: hiddenSessions.has(id),
-      });
-    }
+    // Pending is skipped for a cwd-scoped query (pending sessions aren't tracked per dir).
+    const pending = collectPendingSessions(onDisk, includePending);
 
     // Keep only the most-recent N, then read & parse contents for just those
     // on-disk files (a deleted/corrupt file is dropped, not fatal). Hidden translation

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -51,13 +51,11 @@ async function postConfigField<T>(field: string, value: unknown): Promise<{ ok: 
   }
 }
 
-// The record/remove/migrate preset mutations. Extracted so useAppConfig stays small; they
-// all funnel through the caller's `savePresets` (which owns the presetsVersion coordination
-// with loadConfig). Each preset write POSTs the whole array, so concurrent record/remove
-// calls (two grid cells launching at once) must not each derive `next` from the same stale
-// snapshot — the later POST would clobber the earlier one (last-write-wins, dropping a
-// just-launched dir). `serialize` runs the writes in order so every mutation reads the
-// freshly-saved list before computing its own.
+// The record/remove/migrate preset mutations. Each preset write POSTs the whole array, so
+// concurrent record/remove calls (two grid cells launching at once) must not each derive
+// `next` from the same stale snapshot — the later POST would clobber the earlier one
+// (last-write-wins, dropping a just-launched dir). `serialize` runs the writes in order so
+// every mutation reads the freshly-saved list before computing its own.
 function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: CwdPreset[]) => Promise<boolean>) {
   let presetWrite: Promise<unknown> = Promise.resolve();
   function serialize(mutate: () => Promise<void>): Promise<void> {
@@ -120,6 +118,41 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
   return { recordPreset, removePreset, migrateLegacyRecents };
 }
 
+// The directory-preset subsystem: savePresets + the mutations above, owning the version
+// coordination with loadConfig. `version` is bumped by every local preset write; loadConfig
+// captures it (snapshotVersion) before its GET and adoptServerPresets skips the server list
+// if it changed meanwhile — else a dir the user launched before the initial /api/config
+// resolves would be dropped by the stale GET.
+function createPresetManager(presets: Ref<CwdPreset[]>, saving: Ref<boolean>, error: Ref<string | null>) {
+  let version = 0;
+
+  // Persist the directory presets. Posts only cwdPresets — the server keeps the other fields,
+  // so this never clobbers them. Returns whether the save succeeded.
+  async function savePresets(next: CwdPreset[]): Promise<boolean> {
+    saving.value = true;
+    error.value = null;
+    try {
+      const res = await fetch("/api/config", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ cwdPresets: next }) });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      presets.value = (await res.json()).cwdPresets ?? [];
+      version++;
+      return true;
+    } catch {
+      error.value = "Couldn't save presets. Check the server and try again.";
+      return false;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  const snapshotVersion = (): number => version;
+  const adoptServerPresets = (list: unknown, capturedVersion: number): void => {
+    if (version === capturedVersion) presets.value = Array.isArray(list) ? list : [];
+  };
+
+  return { savePresets, ...createPresetMutations(presets, savePresets), snapshotVersion, adoptServerPresets };
+}
+
 // The single-field savers each persist ONE config field and update its SINGLETON ref, so
 // they're module-level (no per-composable state) — useAppConfig just re-exports them.
 // Persist just the custom attention sound (a file path, or null to use the chime).
@@ -156,42 +189,18 @@ export function useAppConfig() {
   const presets = ref<CwdPreset[]>([]);
   const saving = ref(false);
   const error = ref<string | null>(null);
-  // Bumped by every local preset write (savePresets). loadConfig captures it before
-  // its GET and skips adopting the server list if it changed meanwhile — otherwise a
-  // dir the user launched before the initial /api/config resolves would be dropped by
-  // the slower, stale GET snapshot.
-  let presetsVersion = 0;
 
-  // Persist the directory presets. Posts only cwdPresets — the server keeps the other
-  // fields, so this never clobbers them. Returns whether the save succeeded.
-  async function savePresets(next: CwdPreset[]): Promise<boolean> {
-    saving.value = true;
-    error.value = null;
-    try {
-      const res = await fetch("/api/config", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ cwdPresets: next }) });
-      if (!res.ok) throw new Error(`save failed (${res.status})`);
-      presets.value = (await res.json()).cwdPresets ?? [];
-      presetsVersion++; // mark local state as newer than any in-flight loadConfig GET
-      return true;
-    } catch {
-      error.value = "Couldn't save presets. Check the server and try again.";
-      return false;
-    } finally {
-      saving.value = false;
-    }
-  }
-
-  const { recordPreset, removePreset, migrateLegacyRecents } = createPresetMutations(presets, savePresets);
+  const { savePresets, recordPreset, removePreset, migrateLegacyRecents, snapshotVersion, adoptServerPresets } = createPresetManager(presets, saving, error);
 
   async function loadConfig() {
-    const version = presetsVersion;
+    const version = snapshotVersion();
     try {
       const res = await fetch("/api/config");
       if (!res.ok) return;
       const c = await res.json();
       defaultCwd.value = c.cwd ?? null;
       home.value = c.home ?? null;
-      if (presetsVersion === version) presets.value = Array.isArray(c.cwdPresets) ? c.cwdPresets : [];
+      adoptServerPresets(c.cwdPresets, version);
       soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
       prRepos.value = Array.isArray(c.prRepos) ? c.prRepos : [];
       launchers.value = Array.isArray(c.launchers) ? c.launchers : [];

--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -54,15 +54,10 @@ async function fetchModelStatus(): Promise<VoiceModelStatusResponse | null> {
   }
 }
 
-export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
-  const capable = ref(false);
-  const available = ref(false);
-  const downloading = ref(false);
-  const listening = ref(false);
-  const transcribing = ref(false);
-  const error = ref<string | null>(null);
-
-  const transport: VoiceCaptureTransport = {
+// The controller's transport: plain fetch for transcription + a status poll that doubles
+// as our capability/downloading refresh (keeps `capable`/`downloading` in sync).
+function createVoiceTransport(capable: Ref<boolean>, downloading: Ref<boolean>): VoiceCaptureTransport {
+  return {
     async transcribe(dataUrl, language) {
       const res = await fetch("/api/transcribe", {
         method: "POST",
@@ -72,22 +67,27 @@ export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
       if (!res.ok) throw new Error(`transcription failed (HTTP ${res.status})`);
       return (await res.json()) as { text: string };
     },
-    // Also keeps `capable`/`downloading` in sync — this is the controller's poll
-    // loop, so it doubles as our status refresh.
+    // `status` is null on a transient fetch/non-OK; `model` may be absent on a partial
+    // response. Optional-chain throughout so a status blip degrades to "not ready" instead
+    // of throwing and wedging the controller's poll loop.
     async getStatus() {
-      // `status` is null on a transient fetch/non-OK; `model` may be absent on a
-      // partial response. Optional-chain throughout so a status blip degrades to
-      // "not ready" instead of throwing and wedging the controller's poll loop.
       const status = await fetchModelStatus();
       capable.value = status?.capable ?? false;
       downloading.value = status?.model?.state === "downloading";
-      return {
-        ready: status?.capable === true && status?.model?.state === "ready",
-        downloading: downloading.value,
-      };
+      return { ready: status?.capable === true && status?.model?.state === "ready", downloading: downloading.value };
     },
   };
+}
 
+export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
+  const capable = ref(false);
+  const available = ref(false);
+  const downloading = ref(false);
+  const listening = ref(false);
+  const transcribing = ref(false);
+  const error = ref<string | null>(null);
+
+  const transport = createVoiceTransport(capable, downloading);
   const capture = createVoiceCapture(transport, () => localeToWhisperLanguage(browserLocale()), {
     onTranscript: (text) => {
       error.value = null;


### PR DESCRIPTION
## Summary

Drops the `max-lines-per-function` ESLint threshold from **80 → 60** and splits the four functions that exceeded the stricter limit into focused helpers. **No behavior change** — pure structural refactor to fit the tighter limit.

## Items to Confirm / Review

- **`useAppConfig` preset split** — `savePresets` + the `presetsVersion`↔`loadConfig` coordination now live in `createPresetManager`, which wraps the existing `createPresetMutations`. The load-race guard is preserved verbatim: `snapshotVersion()` captures the version before the GET, `adoptServerPresets()` only adopts the server list if no local write raced. Covered by `useAppConfig.spec.ts` (11 tests, all green).
- The remaining `max-params` **warning** on `spawnClaudePty` (7 params) is intentional and untouched — flagged in the config comment.

## What changed

| Function | Split |
|---|---|
| `useVoiceInput` | extract `createVoiceTransport` to module scope |
| `/api/sessions` handler | extract `collectOnDiskSessionStats` + `collectPendingSessions` |
| `mountFilesBrowseRoutes` | hoist `browseBase` / `browseRel` / `containedFor` |
| `useAppConfig` | extract `createPresetManager` (savePresets + version coord) wrapping `createPresetMutations` |

## Verification

- `yarn lint` → 0 errors (only the intentional `spawnClaudePty` max-params warn)
- `yarn typecheck`, `yarn typecheck:server`, `yarn build` → pass
- `yarn test` → 672/672 pass

## User Prompt

> fix lint error

(The user had locally tightened `max-lines-per-function` from `max: 80` to `max: 60` in `eslint.config.js`, which flipped four functions to lint errors.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)