### PR TITLE
feat: AgentAdapter seam + plan for multi-agent support (PR#0)

### DIFF
--- a/plans/feat-multi-agent-support.md
+++ b/plans/feat-multi-agent-support.md
@@ -1,0 +1,152 @@
+# feat: multi-agent support — Codex (then Antigravity) as first-class agents
+
+Tracking issue: receptron/mulmoterminal#236
+Integration branch: `feat/multi-agent` (off `main`). PRs stack onto it; final PR merges to `main`.
+
+## Goal
+
+Let a MulmoTerminal session run a non-Claude agent CLI **as a first-class agent**, equal to Claude:
+session resume across reload, single-mode GUI panel over MCP, and skill/collection runs.
+Target order: **Codex first**, then **Antigravity (`agy`)**. Design so a third agent is additive.
+
+## What already exists (seams to build on)
+
+- **Three spawn paths** in `server/index.ts`: `/ws` → `spawnClaudePty` (Claude, first-class),
+  `/ws/launch` → `spawnLauncherPty` (arbitrary command, persistent+reattachable),
+  `/ws/run` → `spawnCommandPty` (ephemeral). All funnel through `spawnPty()` (`server/index.ts:1503`).
+- **Single binary choke point**: `CLAUDE_BIN = process.env.CLAUDE_BIN || "claude"` (`server/index.ts:136`),
+  consumed only at `server/index.ts:1549`.
+- **Argv builder**: `buildClaudeArgs` (`server/claude-args.ts:23`) — Claude-specific flags
+  (`--session-id`/`--resume`/`--settings`/`--permission-mode`/`--mcp-config`/`--strict-mcp-config`/`--allowedTools`).
+- **Session id**: the server MINTS it and forces it via `--session-id`; it is NOT parsed from output.
+  Reported to the client as `{type:"session", id, cwd}` (`server/index.ts:1817`).
+- **GUI-MCP is agent-agnostic**: `mcpConfigJson(sessionId)` points the agent at
+  `http://127.0.0.1:PORT/api/mcp/<sessionId>` (`server/index.ts:625`); the broker
+  (`server/mcp/broker.ts`, `buildGuiMcpServer`) keys everything by the URL's sessionId and publishes
+  tool results on `session:<id>` (`sessionChannel`, `server/index.ts:245`) → `GuiPanel.vue` renders.
+  The broker comment already anticipates a Docker sandbox (`server/mcp/broker.ts:23`).
+- **Launcher config**: `Launcher {label, command}` in `~/.mulmoterminal/config.json`
+  (`server/app-config.ts:12`), editable in `SettingsModal.vue`.
+- **Skill run**: a collection IS a skill; the plugin seeds `/<slug> …` and injects it 3 ways —
+  initial argv prompt, bracketed-paste **draft** after `DRAFT_READY_MARKER=/shift+tab to cycle/`
+  (`server/index.ts:1476`), or `input` frames into a live PTY. Skill dirs hardcoded to
+  `.claude/skills` / `data/skills` (`server/backends/collections.ts:70-76`).
+- **Docker sandbox already exists** (`server/sandbox.ts` + `Dockerfile.sandbox`, opt-in
+  `MULMOTERMINAL_SANDBOX=1`, single-view + macOS only, verified in #202). It wraps `claude` in
+  `docker run`, mounts the cwd at its same path + `~/.claude` (auth/transcripts) + a per-session
+  `~/.claude.json`, overlays the macOS Keychain credential, and — the key part — the container
+  reaches the host GUI-MCP + hooks over `host.docker.internal`. `server.listen(PORT)` binds all
+  interfaces; `rewriteLoopbackForDocker()` (`sandbox.ts:44`) rewrites the MCP/hook URLs
+  `127.0.0.1`→`host.docker.internal` (`server/index.ts:652,1661`). `buildDockerRunArgs`
+  (`sandbox.ts:233`) hardcodes `"claude", ...claudeArgs` at the tail (`:268`) — the one spot that
+  is agent-specific.
+
+## Target design: `AgentAdapter`
+
+One interface owning everything agent-specific; all shared plumbing (PTY persistence, reattach, grid,
+pubsub, broker, GuiPanel) stays untouched.
+
+```
+type AgentKind = "claude" | "codex" | "antigravity";
+type Runtime = "host" | "docker";
+
+interface AgentAdapter {
+  kind: AgentKind;
+  bin(): string;                                   // env override per agent
+  buildArgs(ctx): string[];                        // session/resume, model, approval, MCP inject
+  captureSessionId(ctx): Promise<string> | string; // claude: minted; codex/agy: discover/parse
+  resumeArgs(id): string[];                         // codex resume <id> / agy --conversation <id>
+  mcpInject(url): string[] | ConfigWrite;          // point at GUI-MCP + auto-approve its tools
+  draftReadyMarker: RegExp;                          // TUI status line for draft typing
+  skillSeed(seed): Injection;                        // how a skill/collection prompt enters the agent
+  paths: { userSkills; projectSkills; sessions; };
+}
+```
+
+Claude becomes the first adapter with a **no-behavior-change** refactor.
+The `Runtime` dimension already exists for Claude as the single-view Docker sandbox
+(`server/sandbox.ts`): it wraps `bin()`/args in `docker run …` and the MCP-URL host swap is done by
+`rewriteLoopbackForDocker()`. Generalizing it = parametrizing the hardcoded `claude` tail + per-agent
+auth mounts (see Docker section under PR#5).
+
+## Client protocol change
+
+Add an **agent kind** alongside the existing launcher index in `ConnTarget`
+(`useTerminalConnections.ts:28`) and the `/ws` query (`wsUrl.ts`), plus the grid cell model
+(`gridTabs.ts`) and a way to pick the agent for a cell / single view.
+
+---
+
+## PR stack
+
+### PR#0 — scaffolding + CI
+- Add `feat/multi-agent` to `push` + `pull_request` branch triggers in `.github/workflows/ci.yml`
+  and `.github/workflows/codex_review.yaml` (both currently `[main, dev_tool]` only).
+- Introduce `AgentAdapter` + a registry; move Claude's bin/args/marker/paths behind the Claude adapter.
+- (GUI-MCP URL host is already parametrized via `mcpConfigJson(id, host, sandbox)` + `rewriteLoopbackForDocker`
+  — no new work needed here; just keep it adapter-reachable.)
+- **Acceptance**: no behavior change; `yarn lint/build/typecheck/test` green; CI runs on the branch.
+
+### PR#1 — Codex L1+L2 (first-class session + resume)
+- `CODEX_BIN = process.env.CODEX_BIN || "codex"`; `server/codex-args.ts` (model `-m`, `--ask-for-approval`,
+  `--sandbox`, resume).
+- **Session id discovery**: after spawn, find the newest `~/.codex/sessions/**/rollout-*.jsonl` created
+  after launch; read `session_meta.payload.id` (+ `cwd`); store; emit `{type:"session", id}`. Poll briefly
+  if the file lags spawn.
+- Resume via `codex resume <id>` (or `-c experimental_resume=<path>`).
+- Client: agent kind in `ConnTarget` / `wsUrl` / grid cell + agent picker.
+- **Acceptance**: pick Codex for a cell → runs; reload/restart → same codex conversation resumes.
+
+### PR#2 — Codex L3 (GUI-MCP in single mode)
+- Inject GUI-MCP per session: `-c 'mcp_servers.mulmoterminal-gui.url="http://<host>:PORT/api/mcp/<id>"'`
+  `-c 'mcp_servers.mulmoterminal-gui.default_tools_approval_mode="approve"'` (broker unchanged).
+- Ensure the mulmoterminal session key (GUI channel + MCP URL) matches the GuiPanel binding for a codex
+  single-mode session (mulmoterminal-minted key is fine; codex's rollout id is only for resume).
+- **Acceptance**: from a codex single-mode session, `presentChart`/`presentForm`/`presentCollection`/
+  `generateImage` render in the GUI panel.
+
+### PR#3 — Codex L4 (skill / collection run)
+- Codex-specific `draftReadyMarker` (its TUI status line).
+- Map collection/skill seed → codex invocation; per-agent skill paths (`~/.codex/skills`) in
+  `configureCollectionHost`.
+- **Acceptance**: running a collection action / chat seed against a codex session injects correctly.
+
+### PR#4 — Antigravity (`agy`)
+- `ANTIGRAVITY_BIN`; adapter: argv (`--model`, `--dangerously-skip-permissions`, `--conversation <id>`),
+  session capture (parse the resume line agy prints on exit / scan `~/.gemini` store), MCP via
+  `mcp_config.json` `url` server, skills via `/skills`.
+- Resolve open unknowns on a machine with `agy` installed.
+- **Acceptance**: same L1–L4 checks for Antigravity.
+
+### PR#5 — Docker sandbox (generalize existing) + docs + integration tests + merge
+- **Generalize `server/sandbox.ts`** (the container→host GUI-MCP path is already #202-verified for Claude):
+  - Parametrize `buildDockerRunArgs` tail (`sandbox.ts:268`, hardcoded `"claude", ...`) by adapter.
+  - Per-agent auth mounts: Codex → mount `~/.codex` r/w (plain `auth.json`, no Keychain — simpler than
+    Claude); Antigravity → mount `~/.gemini` incl. `antigravity-cli/`.
+  - Mounting `~/.codex` r/w also surfaces the rollout sessions dir on the host → **L2 id discovery works
+    in-container** (auth mount doubles as id source).
+  - Extend `Dockerfile.sandbox` to carry `codex` / `agy`.
+  - Codex in-container: `--sandbox danger-full-access`. Consider Linux support (no Keychain dep; needs the
+    `--user` uid-mapping #202 follow-up).
+- README.md + CLAUDE.md: agent selection, `CODEX_BIN`/`ANTIGRAVITY_BIN`, `MULMOTERMINAL_SANDBOX` per agent.
+- Codex stub integration test mirroring the Claude `/ws` stub in `ci.yml`.
+- Merge `feat/multi-agent` → `main`.
+
+## Open questions (need a working binary)
+
+- Codex: `-c mcp_servers.x.url` per-session injection actually registers the server; rollout-file timing
+  for id capture; codex TUI marker string; first-turn skill/slash invocation UX.
+- Antigravity: on-disk session path + programmatic id capture; per-session MCP injection vs config file;
+  agy TUI markers.
+
+## Environment prerequisites
+
+- Repair local `codex` (`@openai/codex` reinstall; vendor binary `ENOENT` after a Node upgrade).
+- Install `agy` for Antigravity work.
+- Unit tests + build need neither; CI stubs the CLIs.
+
+## Constraints / conventions
+
+- Follow repo git rules: feature branch per PR onto `feat/multi-agent`; no `git add .`; merge commits;
+  `feat:`/`refactor:`/`fix:` prefixes; PR body carries Summary + Items-to-Confirm first, then the user prompt.
+- `script.json` in the working tree is a local, untracked convenience file — never commit it.

--- a/server/agents/claude.ts
+++ b/server/agents/claude.ts
@@ -1,7 +1,6 @@
 import type { AgentAdapter } from "./types.js";
 
-// "shift+tab to cycle" is the permission-mode hint Claude Code paints once its input box
-// is ready — the cue the draft-typing flow waits for before pasting a seed.
+// "shift+tab to cycle" is the hint Claude paints once its input box is ready for a paste.
 export const claudeAdapter: AgentAdapter = {
   kind: "claude",
   bin: () => process.env.CLAUDE_BIN || "claude",

--- a/server/agents/claude.ts
+++ b/server/agents/claude.ts
@@ -1,0 +1,9 @@
+import type { AgentAdapter } from "./types.js";
+
+// "shift+tab to cycle" is the permission-mode hint Claude Code paints once its input box
+// is ready — the cue the draft-typing flow waits for before pasting a seed.
+export const claudeAdapter: AgentAdapter = {
+  kind: "claude",
+  bin: () => process.env.CLAUDE_BIN || "claude",
+  draftReadyMarker: /shift\+tab to cycle/,
+};

--- a/server/agents/registry.spec.ts
+++ b/server/agents/registry.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getAgentAdapter } from "./registry.js";
+import { claudeAdapter } from "./claude.js";
+
+describe("agent registry", () => {
+  const originalBin = process.env.CLAUDE_BIN;
+  afterEach(() => {
+    if (originalBin === undefined) delete process.env.CLAUDE_BIN;
+    else process.env.CLAUDE_BIN = originalBin;
+  });
+
+  it("defaults to the Claude adapter", () => {
+    expect(getAgentAdapter().kind).toBe("claude");
+    expect(getAgentAdapter("claude")).toBe(claudeAdapter);
+  });
+
+  it("resolves the Claude binary from CLAUDE_BIN, falling back to 'claude'", () => {
+    delete process.env.CLAUDE_BIN;
+    expect(claudeAdapter.bin()).toBe("claude");
+    process.env.CLAUDE_BIN = "/custom/path/claude";
+    expect(claudeAdapter.bin()).toBe("/custom/path/claude");
+  });
+
+  it("matches Claude's draft-ready TUI hint", () => {
+    expect(claudeAdapter.draftReadyMarker.test("... press shift+tab to cycle modes")).toBe(true);
+    expect(claudeAdapter.draftReadyMarker.test("no hint here")).toBe(false);
+  });
+});

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -1,0 +1,12 @@
+import type { AgentAdapter, AgentKind } from "./types.js";
+import { claudeAdapter } from "./claude.js";
+
+const adapters: Record<AgentKind, AgentAdapter> = {
+  claude: claudeAdapter,
+};
+
+// Resolve the adapter for an agent kind. Defaults to Claude — the only agent today and
+// the fallback for any session that doesn't name one.
+export function getAgentAdapter(kind: AgentKind = "claude"): AgentAdapter {
+  return adapters[kind];
+}

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -5,8 +5,7 @@ const adapters: Record<AgentKind, AgentAdapter> = {
   claude: claudeAdapter,
 };
 
-// Resolve the adapter for an agent kind. Defaults to Claude — the only agent today and
-// the fallback for any session that doesn't name one.
+// Resolve the adapter for a kind; Claude is the default and the fallback.
 export function getAgentAdapter(kind: AgentKind = "claude"): AgentAdapter {
   return adapters[kind];
 }

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -1,21 +1,10 @@
-// A coding-agent CLI that a terminal session can host. Claude is the only agent today;
-// Codex and Antigravity are added in later PRs (see plans/feat-multi-agent-support.md).
-//
-// This interface owns ONLY the parts that genuinely differ per agent. Everything else —
-// PTY persistence, reattach, the grid, pubsub, and the GUI-MCP broker — stays shared,
-// because the broker is keyed by the session id in its URL and doesn't care which CLI
-// is talking to it. The interface starts deliberately small (the fields Claude already
-// needs); argv construction, session-id capture, resume, MCP injection, and skill seeding
-// join it in the PRs that introduce the agents that force their shape.
-
+// The per-agent surface a hosted coding-agent CLI needs; shared plumbing (PTY, grid, GUI-MCP) stays out.
 export type AgentKind = "claude";
 
 export interface AgentAdapter {
   readonly kind: AgentKind;
-  // The executable to spawn. Each agent reads its own env override (CLAUDE_BIN today,
-  // CODEX_BIN / ANTIGRAVITY_BIN later), resolved at call time so the env can change per boot.
+  // Executable to spawn; reads a per-agent env override (e.g. CLAUDE_BIN) at call time.
   bin(): string;
-  // The TUI status line that signals the input box is ready for bracketed-paste draft
-  // typing. Each agent's TUI paints a different hint, so this cue is per-agent.
+  // TUI status line signalling the input box is ready for bracketed-paste draft typing.
   readonly draftReadyMarker: RegExp;
 }

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -1,0 +1,21 @@
+// A coding-agent CLI that a terminal session can host. Claude is the only agent today;
+// Codex and Antigravity are added in later PRs (see plans/feat-multi-agent-support.md).
+//
+// This interface owns ONLY the parts that genuinely differ per agent. Everything else —
+// PTY persistence, reattach, the grid, pubsub, and the GUI-MCP broker — stays shared,
+// because the broker is keyed by the session id in its URL and doesn't care which CLI
+// is talking to it. The interface starts deliberately small (the fields Claude already
+// needs); argv construction, session-id capture, resume, MCP injection, and skill seeding
+// join it in the PRs that introduce the agents that force their shape.
+
+export type AgentKind = "claude";
+
+export interface AgentAdapter {
+  readonly kind: AgentKind;
+  // The executable to spawn. Each agent reads its own env override (CLAUDE_BIN today,
+  // CODEX_BIN / ANTIGRAVITY_BIN later), resolved at call time so the env can change per boot.
+  bin(): string;
+  // The TUI status line that signals the input box is ready for bracketed-paste draft
+  // typing. Each agent's TUI paints a different hint, so this cue is per-agent.
+  readonly draftReadyMarker: RegExp;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
+import { claudeAdapter } from "./agents/claude.js";
 import {
   isRecord,
   parseJsonl,
@@ -150,7 +151,7 @@ const messageOf = (e: unknown): string => (e instanceof Error ? e.message : Stri
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.PORT || 34567;
-const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude";
+const CLAUDE_BIN = claudeAdapter.bin();
 // Permission mode for backend-spawned Claude sessions. Defaults to "auto" so
 // the backend runs hands-off; override with CLAUDE_PERMISSION_MODE (e.g.
 // "default" / "acceptEdits" / "bypassPermissions" / "plan") when needed.
@@ -1518,7 +1519,7 @@ async function translateViaHiddenChat(targetLanguage: string, sentences: readonl
 // typed `draft`; too early and the bytes are echoed into the scrollback instead. We
 // wait for its status line to paint (the "shift+tab to cycle" mode hint), settle
 // briefly, then type. A fallback fires if that marker never shows (UI string drift).
-const DRAFT_READY_MARKER = /shift\+tab to cycle/;
+const DRAFT_READY_MARKER = claudeAdapter.draftReadyMarker;
 const DRAFT_SETTLE_MS = 250;
 const DRAFT_FALLBACK_MS = 6000;
 // Claude's TUI commits a bracketed paste to its input box asynchronously; a CR glued


### PR DESCRIPTION
## Summary

**PR#0 of the multi-agent stack (tracking issue #236).** Establishes the ground the rest of the
work stacks on, with no user-visible behavior change:

- **Plan** — `plans/feat-multi-agent-support.md`: the full design + PR breakdown for hosting non-Claude
  agent CLIs (Codex first, then Antigravity) as first-class sessions.
- **`AgentAdapter` seam** — a small `server/agents/` interface + registry that owns the per-agent bits.
  Claude is the first adapter; `CLAUDE_BIN` and `DRAFT_READY_MARKER` now read from it. Nothing else moves.
- **CI** — `feat/multi-agent` was added to the `ci.yml` + `codex_review.yaml` triggers (committed to the
  integration branch directly so this and every stacked PR gets CI). Not part of this PR's diff.

Base is the integration branch **`feat/multi-agent`**, not `main`. The stack merges to `main` at the end.

## Items to Confirm / Review

- **Is this the right seam?** The interface (`server/agents/types.ts`) is deliberately minimal — only the
  two things that are agent-specific *today* (`bin()`, `draftReadyMarker`). The bigger per-agent surface
  (argv builder, session-id capture, resume, MCP injection, skill seeding) is intentionally deferred to
  the PRs that introduce the agents forcing their shape, to avoid abstracting before the second case.
  If you'd rather see the full interface sketched now, say so.
- **Branch/CI strategy**: stacked PRs onto `feat/multi-agent`; CI enabled by adding the branch to both
  workflows. OK, or prefer a different integration approach (e.g. reuse `dev_tool`)?
- **Pre-existing lint warning** (`spawnClaudePty has too many parameters (7)`) is untouched here — it
  becomes agent-aware in PR#1, which is the natural place to address it.

## User Prompt

Consolidated from the discussion that produced this plan:

> I want MulmoTerminal to be able to use Codex and Antigravity, not just Claude — Codex first.
> Judge whether it's feasible and, if so, give me the steps. It's not enough to run Codex in a raw TTY:
> I also need the single-mode MCP integration (the GUI panel) and skill runs to work. Antigravity has a
> CLI too — investigate whether it's feasible, Docker support included, and if so break the work into
> fine-grained plans. Create a separate branch and stack PRs onto it; CI config may need changes.
> Proceed from the latest `main`. Re-verify with Docker support folded in, create a tracking issue, and
> prepare. The key Docker point is the agent calling out from inside the container to the host over HTTP
> for MCP — confirm that works. I'll review on the PR.

## Feasibility outcome (detail in #236)

Both Codex and Antigravity are feasible across all four layers (TTY → session resume → GUI-MCP → skill run).
Two findings shaped the plan:

1. **The GUI-MCP broker is agent-agnostic** — it's keyed only by the session id in its URL, so any MCP
   client pointed at it with tools auto-approved drives the GUI panel. Codex/Antigravity L3 is mostly
   config injection, not new server code.
2. **The container→host GUI-MCP-over-HTTP path already exists and is #202-verified for Claude**
   (`server/sandbox.ts` + `Dockerfile.sandbox`, `host.docker.internal` + `rewriteLoopbackForDocker`). So
   Docker for the new agents is *generalizing the existing sandbox*, not a new subsystem.

The one genuinely new pattern vs. Claude: Codex/Antigravity mint their own session id (Claude lets the
server force one), so resume is "launch → discover id → resume `<id>`".

## What this PR changes

| File | Change |
|---|---|
| `plans/feat-multi-agent-support.md` | New: master plan + PR breakdown. |
| `server/agents/types.ts` | New: `AgentKind` + `AgentAdapter` interface. |
| `server/agents/claude.ts` | New: `claudeAdapter` (bin via `CLAUDE_BIN`, draft marker). |
| `server/agents/registry.ts` | New: `getAgentAdapter(kind)`, defaults to Claude. |
| `server/agents/registry.spec.ts` | New: unit tests for the registry + Claude adapter. |
| `server/index.ts` | `CLAUDE_BIN` and `DRAFT_READY_MARKER` now sourced from `claudeAdapter`. |

## Verification

`yarn format` / `yarn lint` (0 errors) / `yarn build` / `yarn typecheck:server` / `yarn test` — all green
(675 tests, incl. the 3 new registry tests). No live behavior change; the two constants resolve to exactly
the same values as before.

Refs #236
