### PR TITLE
feat: Codex first-class sessions (L1+L2 — server + Claude/Codex toggle)

### DIFF
--- a/server/agents/claude.ts
+++ b/server/agents/claude.ts
@@ -1,8 +1,10 @@
 import type { AgentAdapter } from "./types.js";
 
 // "shift+tab to cycle" is the hint Claude paints once its input box is ready for a paste.
-export const claudeAdapter: AgentAdapter = {
+// `satisfies` (not a `: AgentAdapter` annotation) keeps draftReadyMarker's concrete type so
+// callers that rely on it (the draft-injection scanner) don't see it as possibly-undefined.
+export const claudeAdapter = {
   kind: "claude",
   bin: () => process.env.CLAUDE_BIN || "claude",
   draftReadyMarker: /shift\+tab to cycle/,
-};
+} satisfies AgentAdapter;

--- a/server/agents/codex.ts
+++ b/server/agents/codex.ts
@@ -1,0 +1,7 @@
+import type { AgentAdapter } from "./types.js";
+
+// Draft injection isn't wired for codex yet, so it omits draftReadyMarker.
+export const codexAdapter = {
+  kind: "codex",
+  bin: () => process.env.CODEX_BIN || "codex",
+} satisfies AgentAdapter;

--- a/server/agents/registry.spec.ts
+++ b/server/agents/registry.spec.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { getAgentAdapter } from "./registry.js";
 import { claudeAdapter } from "./claude.js";
+import { codexAdapter } from "./codex.js";
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) Reflect.deleteProperty(process.env, key);
+  else process.env[key] = value;
+}
 
 describe("agent registry", () => {
-  const originalBin = process.env.CLAUDE_BIN;
+  const originalClaudeBin = process.env.CLAUDE_BIN;
+  const originalCodexBin = process.env.CODEX_BIN;
   afterEach(() => {
-    if (originalBin === undefined) delete process.env.CLAUDE_BIN;
-    else process.env.CLAUDE_BIN = originalBin;
+    restoreEnv("CLAUDE_BIN", originalClaudeBin);
+    restoreEnv("CODEX_BIN", originalCodexBin);
   });
 
   it("defaults to the Claude adapter", () => {
@@ -14,15 +21,24 @@ describe("agent registry", () => {
     expect(getAgentAdapter("claude")).toBe(claudeAdapter);
   });
 
-  it("resolves the Claude binary from CLAUDE_BIN, falling back to 'claude'", () => {
-    delete process.env.CLAUDE_BIN;
-    expect(claudeAdapter.bin()).toBe("claude");
-    process.env.CLAUDE_BIN = "/custom/path/claude";
-    expect(claudeAdapter.bin()).toBe("/custom/path/claude");
+  it("resolves the codex adapter", () => {
+    expect(getAgentAdapter("codex").kind).toBe("codex");
+    expect(getAgentAdapter("codex")).toBe(codexAdapter);
   });
 
-  it("matches Claude's draft-ready TUI hint", () => {
+  it("reads each agent's binary from its env override, with a sensible default", () => {
+    delete process.env.CLAUDE_BIN;
+    delete process.env.CODEX_BIN;
+    expect(claudeAdapter.bin()).toBe("claude");
+    expect(codexAdapter.bin()).toBe("codex");
+    process.env.CLAUDE_BIN = "/custom/claude";
+    process.env.CODEX_BIN = "/custom/codex";
+    expect(claudeAdapter.bin()).toBe("/custom/claude");
+    expect(codexAdapter.bin()).toBe("/custom/codex");
+  });
+
+  it("exposes Claude's draft-ready marker but not codex's (not wired yet)", () => {
     expect(claudeAdapter.draftReadyMarker.test("... press shift+tab to cycle modes")).toBe(true);
-    expect(claudeAdapter.draftReadyMarker.test("no hint here")).toBe(false);
+    expect(getAgentAdapter("codex").draftReadyMarker).toBeUndefined();
   });
 });

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -1,8 +1,10 @@
 import type { AgentAdapter, AgentKind } from "./types.js";
 import { claudeAdapter } from "./claude.js";
+import { codexAdapter } from "./codex.js";
 
 const adapters: Record<AgentKind, AgentAdapter> = {
   claude: claudeAdapter,
+  codex: codexAdapter,
 };
 
 // Resolve the adapter for a kind; Claude is the default and the fallback.

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -1,10 +1,11 @@
 // The per-agent surface a hosted coding-agent CLI needs; shared plumbing (PTY, grid, GUI-MCP) stays out.
-export type AgentKind = "claude";
+export type AgentKind = "claude" | "codex";
 
 export interface AgentAdapter {
   readonly kind: AgentKind;
   // Executable to spawn; reads a per-agent env override (e.g. CLAUDE_BIN) at call time.
   bin(): string;
-  // TUI status line signalling the input box is ready for bracketed-paste draft typing.
-  readonly draftReadyMarker: RegExp;
+  // TUI status line signalling the input box is ready for bracketed-paste draft typing;
+  // absent for an agent that doesn't support draft injection yet.
+  readonly draftReadyMarker?: RegExp;
 }

--- a/server/codex-args.spec.ts
+++ b/server/codex-args.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { buildCodexArgs } from "./codex-args.js";
+
+describe("buildCodexArgs", () => {
+  it("passes no id for a fresh session (codex mints its own)", () => {
+    expect(buildCodexArgs({ resume: null, model: null })).toEqual([]);
+  });
+
+  it("adds the model override before the subcommand", () => {
+    expect(buildCodexArgs({ resume: null, model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4"]);
+  });
+
+  it("resumes a known rollout id via the resume subcommand", () => {
+    expect(buildCodexArgs({ resume: "019f251d-001c-7542-b13e-9a627effce52", model: null })).toEqual(["resume", "019f251d-001c-7542-b13e-9a627effce52"]);
+  });
+
+  it("keeps global flags ahead of the resume subcommand", () => {
+    expect(buildCodexArgs({ resume: "abc", model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4", "resume", "abc"]);
+  });
+});

--- a/server/codex-args.ts
+++ b/server/codex-args.ts
@@ -1,0 +1,17 @@
+// Builds the argv for spawning codex as a first-class session. codex mints its own session id
+// (there is no `--session-id` like claude has), so a fresh session passes no id — the id is read
+// back from the rollout file afterwards — while resume replays a known rollout id via the
+// `resume` subcommand. Global flags precede the subcommand (codex's clap layout).
+export interface CodexArgsInput {
+  // A codex rollout id to resume, or null to start a fresh session.
+  resume: string | null;
+  // Model override (--model), or null to use codex's own configured default.
+  model: string | null;
+}
+
+export function buildCodexArgs(input: CodexArgsInput): string[] {
+  const args: string[] = [];
+  if (input.model) args.push("--model", input.model);
+  if (input.resume) args.push("resume", input.resume);
+  return args;
+}

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "./codex-session.js";
@@ -77,24 +77,28 @@ describe("pickFreshSession", () => {
     const before = snapshotSessions(root);
     expect(pickFreshSession(root, before, null)).toBeNull();
   });
-  it("returns the rollout that appeared after the snapshot", () => {
+  it("attributes a single fresh rollout (unambiguous)", () => {
     const before = snapshotSessions(root);
     writeRollout(root, UUID_A, "/a");
-    expect(pickFreshSession(root, before, null)?.id).toBe(UUID_A);
+    expect(pickFreshSession(root, before, "/anything")?.id).toBe(UUID_A);
   });
-  it("prefers the fresh rollout whose cwd matches", () => {
+  it("attributes the unique cwd match when several are fresh", () => {
     const before = snapshotSessions(root);
     writeRollout(root, UUID_A, "/a");
     writeRollout(root, UUID_B, "/b");
     expect(pickFreshSession(root, before, "/b")?.id).toBe(UUID_B);
   });
-  it("falls back to the newest by mtime when no cwd matches", () => {
+  it("refuses to guess when several fresh rollouts share the cwd", () => {
     const before = snapshotSessions(root);
-    const older = writeRollout(root, UUID_A, "/a");
-    const newer = writeRollout(root, UUID_B, "/b");
-    utimesSync(older, new Date(2026, 0, 1, 10), new Date(2026, 0, 1, 10));
-    utimesSync(newer, new Date(2026, 0, 1, 11), new Date(2026, 0, 1, 11));
-    expect(pickFreshSession(root, before, "/other")?.id).toBe(UUID_B);
+    writeRollout(root, UUID_A, "/same");
+    writeRollout(root, UUID_B, "/same");
+    expect(pickFreshSession(root, before, "/same")).toBeNull();
+  });
+  it("refuses to guess when several are fresh and none matches the cwd", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    writeRollout(root, UUID_B, "/b");
+    expect(pickFreshSession(root, before, "/other")).toBeNull();
   });
 });
 

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -100,6 +100,17 @@ describe("pickFreshSession", () => {
     writeRollout(root, UUID_B, "/b");
     expect(pickFreshSession(root, before, "/other")).toBeNull();
   });
+  it("skips a rollout already claimed by another session", () => {
+    const before = snapshotSessions(root);
+    const a = writeRollout(root, UUID_A, "/same");
+    writeRollout(root, UUID_B, "/same");
+    expect(pickFreshSession(root, before, "/same", new Set([a]))?.id).toBe(UUID_B);
+  });
+  it("returns null when the only fresh rollout is already claimed", () => {
+    const before = snapshotSessions(root);
+    const a = writeRollout(root, UUID_A, "/a");
+    expect(pickFreshSession(root, before, null, new Set([a]))).toBeNull();
+  });
 });
 
 describe("watchForCodexSession", () => {

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, findNewRollout, discoverCodexSession } from "./codex-session.js";
+
+const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
+const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";
+
+const pad = (n: number): string => String(n).padStart(2, "0");
+const dayPath = (root: string, d: Date): string => path.join(root, String(d.getFullYear()), pad(d.getMonth() + 1), pad(d.getDate()));
+const metaLine = (id: string, cwd: string | null): string =>
+  JSON.stringify({ timestamp: "2026-07-08T00:00:00Z", type: "session_meta", payload: { id, cwd, originator: "codex-tui", source: "cli" } });
+
+function writeRollout(dir: string, id: string, cwd: string | null, extraLines: string[] = []): string {
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `rollout-2026-07-08T00-00-00-${id}.jsonl`);
+  writeFileSync(file, [metaLine(id, cwd), ...extraLines].join("\n") + "\n");
+  return file;
+}
+
+describe("parseSessionMetaLine", () => {
+  it("extracts id + cwd from a session_meta line", () => {
+    expect(parseSessionMetaLine(metaLine(UUID_A, "/work"))).toEqual({ id: UUID_A, cwd: "/work" });
+  });
+  it("returns null for a non-session_meta record", () => {
+    expect(parseSessionMetaLine(JSON.stringify({ type: "message", payload: { id: UUID_A } }))).toBeNull();
+  });
+  it("returns null for invalid JSON", () => {
+    expect(parseSessionMetaLine("not json{")).toBeNull();
+  });
+  it("returns null when the id is not a uuid", () => {
+    expect(parseSessionMetaLine(metaLine("nope", "/work"))).toBeNull();
+  });
+  it("keeps cwd null when absent", () => {
+    expect(parseSessionMetaLine(JSON.stringify({ type: "session_meta", payload: { id: UUID_A } }))).toEqual({ id: UUID_A, cwd: null });
+  });
+});
+
+describe("readSessionMeta", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reads the meta from the first line of a multi-line rollout", () => {
+    const file = writeRollout(dayPath(root, new Date(2026, 6, 8)), UUID_A, "/work", ['{"type":"message"}', '{"type":"message"}']);
+    expect(readSessionMeta(file)).toEqual({ id: UUID_A, cwd: "/work" });
+  });
+  it("returns null for a missing file", () => {
+    expect(readSessionMeta(path.join(root, "nope.jsonl"))).toBeNull();
+  });
+});
+
+describe("snapshot / findNewRollout", () => {
+  let root: string;
+  const now = new Date(2026, 6, 8, 12, 0, 0);
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("lists rollouts under today's day dir", () => {
+    writeRollout(dayPath(root, now), UUID_A, "/work");
+    expect(listRecentRollouts(root, now)).toHaveLength(1);
+  });
+  it("finds the file that appeared after the snapshot", () => {
+    writeRollout(dayPath(root, now), UUID_A, "/work");
+    const before = snapshotSessions(root, now);
+    const fresh = writeRollout(dayPath(root, now), UUID_B, "/work");
+    expect(findNewRollout(root, before, now)).toBe(fresh);
+  });
+  it("returns null when nothing new appeared", () => {
+    writeRollout(dayPath(root, now), UUID_A, "/work");
+    const before = snapshotSessions(root, now);
+    expect(findNewRollout(root, before, now)).toBeNull();
+  });
+  it("picks the newest by mtime when several are fresh", () => {
+    const older = writeRollout(dayPath(root, now), UUID_A, "/work");
+    const newer = writeRollout(dayPath(root, now), UUID_B, "/work");
+    utimesSync(older, new Date(2026, 6, 8, 10), new Date(2026, 6, 8, 10));
+    utimesSync(newer, new Date(2026, 6, 8, 11), new Date(2026, 6, 8, 11));
+    expect(findNewRollout(root, new Set(), now)).toBe(newer);
+  });
+});
+
+describe("discoverCodexSession", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns the id of a rollout that appears after the snapshot", async () => {
+    const before = snapshotSessions(root);
+    writeRollout(dayPath(root, new Date()), UUID_A, "/work");
+    const found = await discoverCodexSession(root, before, { timeoutMs: 500, intervalMs: 10 });
+    expect(found?.id).toBe(UUID_A);
+    expect(found?.cwd).toBe("/work");
+  });
+  it("resolves null when no new session appears before the timeout", async () => {
+    const before = snapshotSessions(root);
+    const found = await discoverCodexSession(root, before, { timeoutMs: 60, intervalMs: 10 });
+    expect(found).toBeNull();
+  });
+});

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -2,19 +2,23 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, findNewRollout, discoverCodexSession } from "./codex-session.js";
+import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "./codex-session.js";
 
 const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
 const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";
 
 const pad = (n: number): string => String(n).padStart(2, "0");
-const dayPath = (root: string, d: Date): string => path.join(root, String(d.getFullYear()), pad(d.getMonth() + 1), pad(d.getDate()));
+const todayDir = (root: string): string => {
+  const d = new Date();
+  return path.join(root, String(d.getFullYear()), pad(d.getMonth() + 1), pad(d.getDate()));
+};
 const metaLine = (id: string, cwd: string | null): string =>
-  JSON.stringify({ timestamp: "2026-07-08T00:00:00Z", type: "session_meta", payload: { id, cwd, originator: "codex-tui", source: "cli" } });
+  JSON.stringify({ timestamp: "t", type: "session_meta", payload: { id, cwd, originator: "codex-tui", source: "cli" } });
 
-function writeRollout(dir: string, id: string, cwd: string | null, extraLines: string[] = []): string {
+function writeRollout(root: string, id: string, cwd: string | null, extraLines: string[] = []): string {
+  const dir = todayDir(root);
   mkdirSync(dir, { recursive: true });
-  const file = path.join(dir, `rollout-2026-07-08T00-00-00-${id}.jsonl`);
+  const file = path.join(dir, `rollout-x-${id}.jsonl`);
   writeFileSync(file, [metaLine(id, cwd), ...extraLines].join("\n") + "\n");
   return file;
 }
@@ -37,7 +41,7 @@ describe("parseSessionMetaLine", () => {
   });
 });
 
-describe("readSessionMeta", () => {
+describe("codex-session fs helpers", () => {
   let root: string;
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
@@ -47,49 +51,19 @@ describe("readSessionMeta", () => {
   });
 
   it("reads the meta from the first line of a multi-line rollout", () => {
-    const file = writeRollout(dayPath(root, new Date(2026, 6, 8)), UUID_A, "/work", ['{"type":"message"}', '{"type":"message"}']);
+    const file = writeRollout(root, UUID_A, "/work", ['{"type":"message"}', '{"type":"message"}']);
     expect(readSessionMeta(file)).toEqual({ id: UUID_A, cwd: "/work" });
   });
-  it("returns null for a missing file", () => {
+  it("returns null reading a missing file", () => {
     expect(readSessionMeta(path.join(root, "nope.jsonl"))).toBeNull();
   });
-});
-
-describe("snapshot / findNewRollout", () => {
-  let root: string;
-  const now = new Date(2026, 6, 8, 12, 0, 0);
-  beforeEach(() => {
-    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
-  });
-  afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
-  });
-
   it("lists rollouts under today's day dir", () => {
-    writeRollout(dayPath(root, now), UUID_A, "/work");
-    expect(listRecentRollouts(root, now)).toHaveLength(1);
-  });
-  it("finds the file that appeared after the snapshot", () => {
-    writeRollout(dayPath(root, now), UUID_A, "/work");
-    const before = snapshotSessions(root, now);
-    const fresh = writeRollout(dayPath(root, now), UUID_B, "/work");
-    expect(findNewRollout(root, before, now)).toBe(fresh);
-  });
-  it("returns null when nothing new appeared", () => {
-    writeRollout(dayPath(root, now), UUID_A, "/work");
-    const before = snapshotSessions(root, now);
-    expect(findNewRollout(root, before, now)).toBeNull();
-  });
-  it("picks the newest by mtime when several are fresh", () => {
-    const older = writeRollout(dayPath(root, now), UUID_A, "/work");
-    const newer = writeRollout(dayPath(root, now), UUID_B, "/work");
-    utimesSync(older, new Date(2026, 6, 8, 10), new Date(2026, 6, 8, 10));
-    utimesSync(newer, new Date(2026, 6, 8, 11), new Date(2026, 6, 8, 11));
-    expect(findNewRollout(root, new Set(), now)).toBe(newer);
+    writeRollout(root, UUID_A, "/work");
+    expect(listRecentRollouts(root)).toHaveLength(1);
   });
 });
 
-describe("discoverCodexSession", () => {
+describe("pickFreshSession", () => {
   let root: string;
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
@@ -98,16 +72,56 @@ describe("discoverCodexSession", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it("returns the id of a rollout that appears after the snapshot", async () => {
+  it("returns null when nothing appeared after the snapshot", () => {
+    writeRollout(root, UUID_A, "/a");
     const before = snapshotSessions(root);
-    writeRollout(dayPath(root, new Date()), UUID_A, "/work");
-    const found = await discoverCodexSession(root, before, { timeoutMs: 500, intervalMs: 10 });
+    expect(pickFreshSession(root, before, null)).toBeNull();
+  });
+  it("returns the rollout that appeared after the snapshot", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    expect(pickFreshSession(root, before, null)?.id).toBe(UUID_A);
+  });
+  it("prefers the fresh rollout whose cwd matches", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    writeRollout(root, UUID_B, "/b");
+    expect(pickFreshSession(root, before, "/b")?.id).toBe(UUID_B);
+  });
+  it("falls back to the newest by mtime when no cwd matches", () => {
+    const before = snapshotSessions(root);
+    const older = writeRollout(root, UUID_A, "/a");
+    const newer = writeRollout(root, UUID_B, "/b");
+    utimesSync(older, new Date(2026, 0, 1, 10), new Date(2026, 0, 1, 10));
+    utimesSync(newer, new Date(2026, 0, 1, 11), new Date(2026, 0, 1, 11));
+    expect(pickFreshSession(root, before, "/other")?.id).toBe(UUID_B);
+  });
+});
+
+describe("watchForCodexSession", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves the session once its rollout is present", async () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/work");
+    const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 500 });
     expect(found?.id).toBe(UUID_A);
     expect(found?.cwd).toBe("/work");
   });
-  it("resolves null when no new session appears before the timeout", async () => {
+  it("stops immediately when cancelled", async () => {
     const before = snapshotSessions(root);
-    const found = await discoverCodexSession(root, before, { timeoutMs: 60, intervalMs: 10 });
+    const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 5000, isCancelled: () => true });
+    expect(found).toBeNull();
+  });
+  it("resolves null when nothing appears before the timeout", async () => {
+    const before = snapshotSessions(root);
+    const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 40 });
     expect(found).toBeNull();
   });
 });

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -5,8 +5,8 @@ import os from "node:os";
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const DISCOVERY_TIMEOUT_MS = 5000;
-const DISCOVERY_INTERVAL_MS = 150;
+const WATCH_POLL_MS = 1000;
+const WATCH_MAX_WAIT_MS = 30 * 60 * 1000;
 
 export interface CodexSessionMeta {
   id: string;
@@ -54,7 +54,7 @@ function dayDir(root: string, when: Date): string {
 }
 
 // Only today + yesterday can hold a session spawned "now" (covers a spawn racing midnight),
-// so discovery never walks the whole history.
+// so watching never walks the whole history.
 function recentDayDirs(root: string, now: Date): string[] {
   return [dayDir(root, now), dayDir(root, new Date(now.getTime() - ONE_DAY_MS))];
 }
@@ -70,8 +70,8 @@ export function listRecentRollouts(root: string, now: Date = new Date()): string
   return recentDayDirs(root, now).flatMap(listRolloutsIn);
 }
 
-// The rollout files that exist BEFORE spawning codex; the one that appears after is
-// unambiguously this session's — no reliance on clock/mtime alignment.
+// The rollout files that exist BEFORE spawning codex; a file that appears after is this
+// session's (codex only persists its rollout after the first user turn, so this can be minutes).
 export function snapshotSessions(root: string, now: Date = new Date()): Set<string> {
   return new Set(listRecentRollouts(root, now));
 }
@@ -84,34 +84,41 @@ function mtimeMs(file: string): number {
   }
 }
 
-export function findNewRollout(root: string, before: Set<string>, now: Date = new Date()): string | null {
-  const fresh = listRecentRollouts(root, now).filter((file) => !before.has(file));
-  if (fresh.length === 0) return null;
-  return fresh.reduce((newest, file) => (mtimeMs(file) > mtimeMs(newest) ? file : newest));
+interface RolloutMeta extends CodexSessionMeta {
+  file: string;
+}
+
+// The freshest rollout that appeared since the snapshot. `cwd` disambiguates concurrent sessions
+// best-effort (a rollout records the dir codex ran in); otherwise the newest wins.
+export function pickFreshSession(root: string, before: Set<string>, cwd: string | null): RolloutMeta | null {
+  const found = listRecentRollouts(root)
+    .filter((file) => !before.has(file))
+    .map((file) => ({ file, meta: readSessionMeta(file) }))
+    .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
+  if (found.length === 0) return null;
+  const byCwd = cwd ? found.find((x) => x.meta.cwd === cwd) : undefined;
+  const chosen = byCwd ?? found.reduce((a, b) => (mtimeMs(b.file) > mtimeMs(a.file) ? b : a));
+  return { ...chosen.meta, file: chosen.file };
 }
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-// Poll for the rollout codex creates at startup, then read its minted id. Keeps polling past a
-// half-written first line (the file can appear before its JSON is flushed). Null on timeout —
-// e.g. codex failed to launch.
-export async function discoverCodexSession(
+// codex persists a session's rollout only AFTER its first user turn (like claude's transcript),
+// so we watch for the whole session — not just at spawn — until the rollout appears, then read
+// its minted id. Stops early when the session is gone (isCancelled) so it can't outlive the pty.
+export async function watchForCodexSession(
   root: string,
   before: Set<string>,
-  opts: { timeoutMs?: number; intervalMs?: number } = {},
-): Promise<(CodexSessionMeta & { file: string }) | null> {
-  const timeoutMs = opts.timeoutMs ?? DISCOVERY_TIMEOUT_MS;
-  const intervalMs = opts.intervalMs ?? DISCOVERY_INTERVAL_MS;
-  const deadline = Date.now() + timeoutMs;
-  const attempt = (): (CodexSessionMeta & { file: string }) | null => {
-    const file = findNewRollout(root, before);
-    const meta = file ? readSessionMeta(file) : null;
-    return meta && file ? { ...meta, file } : null;
-  };
-  let result = attempt();
-  while (!result && Date.now() < deadline) {
-    await delay(intervalMs);
-    result = attempt();
+  opts: { cwd?: string | null; pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean } = {},
+): Promise<RolloutMeta | null> {
+  const pollMs = opts.pollMs ?? WATCH_POLL_MS;
+  const deadline = Date.now() + (opts.maxWaitMs ?? WATCH_MAX_WAIT_MS);
+  const isCancelled = opts.isCancelled ?? (() => false);
+  const cwd = opts.cwd ?? null;
+  let result = pickFreshSession(root, before, cwd);
+  while (!result && Date.now() < deadline && !isCancelled()) {
+    await delay(pollMs);
+    result = pickFreshSession(root, before, cwd);
   }
   return result;
 }

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -76,29 +76,24 @@ export function snapshotSessions(root: string, now: Date = new Date()): Set<stri
   return new Set(listRecentRollouts(root, now));
 }
 
-function mtimeMs(file: string): number {
-  try {
-    return statSync(file).mtimeMs;
-  } catch {
-    return 0;
-  }
-}
-
 interface RolloutMeta extends CodexSessionMeta {
   file: string;
 }
 
-// The freshest rollout that appeared since the snapshot. `cwd` disambiguates concurrent sessions
-// best-effort (a rollout records the dir codex ran in); otherwise the newest wins.
+// A rollout that appeared since the snapshot, attributed to this session ONLY when unambiguous:
+// exactly one appeared, or exactly one of several matches this session's cwd. Otherwise refuse to
+// guess (return null) — a wrong guess would let a cold resume reopen a *different* concurrent
+// codex conversation. A "newest wins" tiebreak would be exactly that wrong guess, so there isn't
+// one; a session that can't be attributed just stays unresumable-by-id (cold reconnect starts fresh).
 export function pickFreshSession(root: string, before: Set<string>, cwd: string | null): RolloutMeta | null {
   const found = listRecentRollouts(root)
     .filter((file) => !before.has(file))
     .map((file) => ({ file, meta: readSessionMeta(file) }))
     .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
-  if (found.length === 0) return null;
-  const byCwd = cwd ? found.find((x) => x.meta.cwd === cwd) : undefined;
-  const chosen = byCwd ?? found.reduce((a, b) => (mtimeMs(b.file) > mtimeMs(a.file) ? b : a));
-  return { ...chosen.meta, file: chosen.file };
+  if (found.length === 1) return { ...found[0].meta, file: found[0].file };
+  const matches = cwd ? found.filter((x) => x.meta.cwd === cwd) : [];
+  if (matches.length === 1) return { ...matches[0].meta, file: matches[0].file };
+  return null;
 }
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -85,9 +85,11 @@ interface RolloutMeta extends CodexSessionMeta {
 // guess (return null) — a wrong guess would let a cold resume reopen a *different* concurrent
 // codex conversation. A "newest wins" tiebreak would be exactly that wrong guess, so there isn't
 // one; a session that can't be attributed just stays unresumable-by-id (cold reconnect starts fresh).
-export function pickFreshSession(root: string, before: Set<string>, cwd: string | null): RolloutMeta | null {
+// `claimed` holds rollouts already mapped to another session, so a single rollout is never
+// attributed to two keys (which would resume one conversation from both).
+export function pickFreshSession(root: string, before: Set<string>, cwd: string | null, claimed?: Set<string>): RolloutMeta | null {
   const found = listRecentRollouts(root)
-    .filter((file) => !before.has(file))
+    .filter((file) => !before.has(file) && !claimed?.has(file))
     .map((file) => ({ file, meta: readSessionMeta(file) }))
     .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
   if (found.length === 1) return { ...found[0].meta, file: found[0].file };
@@ -104,16 +106,16 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 export async function watchForCodexSession(
   root: string,
   before: Set<string>,
-  opts: { cwd?: string | null; pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean } = {},
+  opts: { cwd?: string | null; pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean; claimed?: Set<string> } = {},
 ): Promise<RolloutMeta | null> {
   const pollMs = opts.pollMs ?? WATCH_POLL_MS;
   const deadline = Date.now() + (opts.maxWaitMs ?? WATCH_MAX_WAIT_MS);
   const isCancelled = opts.isCancelled ?? (() => false);
   const cwd = opts.cwd ?? null;
-  let result = pickFreshSession(root, before, cwd);
+  let result = pickFreshSession(root, before, cwd, opts.claimed);
   while (!result && Date.now() < deadline && !isCancelled()) {
     await delay(pollMs);
-    result = pickFreshSession(root, before, cwd);
+    result = pickFreshSession(root, before, cwd, opts.claimed);
   }
   return result;
 }

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -1,0 +1,117 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DISCOVERY_TIMEOUT_MS = 5000;
+const DISCOVERY_INTERVAL_MS = 150;
+
+export interface CodexSessionMeta {
+  id: string;
+  cwd: string | null;
+}
+
+// codex writes rollout transcripts under $CODEX_HOME/sessions/YYYY/MM/DD/. CODEX_HOME mirrors
+// codex's own env, so a container/config relocation is honored (see the Docker plan).
+export function codexSessionsRoot(): string {
+  const home = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+  return path.join(home, "sessions");
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+// The first line of every rollout is a `session_meta` record carrying the id codex minted for
+// itself (mulmoterminal can't force one) and the cwd it resolved.
+export function parseSessionMetaLine(line: string): CodexSessionMeta | null {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!isRecord(doc) || doc.type !== "session_meta" || !isRecord(doc.payload)) return null;
+  const { id, cwd } = doc.payload;
+  if (typeof id !== "string" || !UUID_RE.test(id)) return null;
+  return { id, cwd: typeof cwd === "string" ? cwd : null };
+}
+
+export function readSessionMeta(rolloutFile: string): CodexSessionMeta | null {
+  try {
+    const content = readFileSync(rolloutFile, "utf8");
+    const newline = content.indexOf("\n");
+    return parseSessionMetaLine(newline === -1 ? content : content.slice(0, newline));
+  } catch {
+    return null;
+  }
+}
+
+function dayDir(root: string, when: Date): string {
+  const month = String(when.getMonth() + 1).padStart(2, "0");
+  const day = String(when.getDate()).padStart(2, "0");
+  return path.join(root, String(when.getFullYear()), month, day);
+}
+
+// Only today + yesterday can hold a session spawned "now" (covers a spawn racing midnight),
+// so discovery never walks the whole history.
+function recentDayDirs(root: string, now: Date): string[] {
+  return [dayDir(root, now), dayDir(root, new Date(now.getTime() - ONE_DAY_MS))];
+}
+
+function listRolloutsIn(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => ROLLOUT_RE.test(name))
+    .map((name) => path.join(dir, name));
+}
+
+export function listRecentRollouts(root: string, now: Date = new Date()): string[] {
+  return recentDayDirs(root, now).flatMap(listRolloutsIn);
+}
+
+// The rollout files that exist BEFORE spawning codex; the one that appears after is
+// unambiguously this session's — no reliance on clock/mtime alignment.
+export function snapshotSessions(root: string, now: Date = new Date()): Set<string> {
+  return new Set(listRecentRollouts(root, now));
+}
+
+function mtimeMs(file: string): number {
+  try {
+    return statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+export function findNewRollout(root: string, before: Set<string>, now: Date = new Date()): string | null {
+  const fresh = listRecentRollouts(root, now).filter((file) => !before.has(file));
+  if (fresh.length === 0) return null;
+  return fresh.reduce((newest, file) => (mtimeMs(file) > mtimeMs(newest) ? file : newest));
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Poll for the rollout codex creates at startup, then read its minted id. Keeps polling past a
+// half-written first line (the file can appear before its JSON is flushed). Null on timeout —
+// e.g. codex failed to launch.
+export async function discoverCodexSession(
+  root: string,
+  before: Set<string>,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<(CodexSessionMeta & { file: string }) | null> {
+  const timeoutMs = opts.timeoutMs ?? DISCOVERY_TIMEOUT_MS;
+  const intervalMs = opts.intervalMs ?? DISCOVERY_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+  const attempt = (): (CodexSessionMeta & { file: string }) | null => {
+    const file = findNewRollout(root, before);
+    const meta = file ? readSessionMeta(file) : null;
+    return meta && file ? { ...meta, file } : null;
+  };
+  let result = attempt();
+  while (!result && Date.now() < deadline) {
+    await delay(intervalMs);
+    result = attempt();
+  }
+  return result;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -37,6 +37,9 @@ import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { claudeAdapter } from "./agents/claude.js";
+import { codexAdapter } from "./agents/codex.js";
+import { buildCodexArgs } from "./codex-args.js";
+import { codexSessionsRoot, snapshotSessions, discoverCodexSession } from "./codex-session.js";
 import {
   isRecord,
   parseJsonl,
@@ -152,6 +155,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.PORT || 34567;
 const CLAUDE_BIN = claudeAdapter.bin();
+const CODEX_BIN = codexAdapter.bin();
+// Model override for codex sessions (--model); null uses codex's own configured default.
+const CODEX_MODEL = process.env.CODEX_MODEL || null;
 // Permission mode for backend-spawned Claude sessions. Defaults to "auto" so
 // the backend runs hands-off; override with CLAUDE_PERMISSION_MODE (e.g.
 // "default" / "acceptEdits" / "bypassPermissions" / "plan") when needed.
@@ -438,6 +444,10 @@ const LAST_PROMPT_CAP = 200;
 // is reaped once the session goes idle (Stop hook) or the process exits. `ws`
 // is null while the session runs in the background.
 const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
+
+// mulmoterminal session key -> the codex rollout id it maps to. codex mints its own id, so we
+// discover it after spawn and keep it here to `codex resume <id>` once the live PTY is gone.
+const codexRolloutIds = new Map<string, string>();
 
 // New sessions started in this process that have no .jsonl on disk yet (Claude
 // only writes the file on the first prompt). Merged into /api/sessions so a
@@ -1392,10 +1402,14 @@ const runWss = new WebSocketServer({ noServer: true });
 // too. Unlike /ws/run these are PERSISTENT & reattachable (they share the /ws session
 // lifecycle — ptys map, reattach, reap grace) but carry no Claude hooks/transcript.
 const runLaunchWss = new WebSocketServer({ noServer: true });
+// First-class codex sessions — persistent + reattachable like /ws/launch, but running codex
+// with session discovery + resume. Its own endpoint so /ws stays claude-only.
+const runCodexWss = new WebSocketServer({ noServer: true });
 function wssForPath(pathname: string): WebSocketServer | null {
   if (pathname === "/ws") return wss;
   if (pathname === "/ws/run") return runWss;
   if (pathname === "/ws/launch") return runLaunchWss;
+  if (pathname === "/ws/codex") return runCodexWss;
   return null; // e.g. /ws/pubsub — left to socket.io's own upgrade handler
 }
 server.on("upgrade", (req, socket, head) => {
@@ -2045,6 +2059,90 @@ runLaunchWss.on("connection", (ws, req) => {
   } catch (err) {
     console.error(`[ws/launch] failed to start ${sessionId}: ${messageOf(err)}`);
     return closeWithError(ws, "Failed to start the launch command.");
+  }
+
+  ws.on("message", (raw) => handleClientFrame(entry, ws, raw, sessionId));
+  ws.on("close", () => handleClientClose(entry, ws, sessionId));
+});
+
+// codex is a first-class agent like claude, but it mints its own session id (no --session-id),
+// so the browser-facing id is a mulmoterminal-minted key; we discover codex's real rollout id
+// after spawn and resume it with `codex resume <id>` once the live PTY is gone. Reattach a live
+// pty / surviving tmux session (running codex picked up, no resume); else cold-resume a known
+// rollout id; else a fresh session (a new minted key).
+function resolveCodexSession(requested: string | null): { sessionId: string; live: PtyEntry | undefined; resumeRolloutId: string | null } {
+  const reattachId = requested && ptys.has(requested) ? requested : null;
+  const live = reattachId ? ptys.get(reattachId) : undefined;
+  const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
+  const resumeRolloutId = !live && !tmuxAlive && requested ? (codexRolloutIds.get(requested) ?? null) : null;
+  const sessionId = reattachId ?? ((tmuxAlive || resumeRolloutId) && requested ? requested : randomUUID());
+  return { sessionId, live, resumeRolloutId };
+}
+
+function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
+  entry.term.onData((data) => {
+    entry.buffer = (entry.buffer + data).slice(-OUTPUT_BUFFER_LIMIT);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) entry.ws.send(JSON.stringify({ type: "output", data }));
+  });
+  entry.term.onExit(({ exitCode, signal }) => {
+    console.log(`[pty] codex exited code=${exitCode} signal=${signal}`);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.send(JSON.stringify({ type: "exit", exitCode, signal }));
+      entry.ws.close();
+    }
+    reap(sessionId);
+  });
+}
+
+// codex writes its rollout (with the minted id) at startup; capture it best-effort so a later
+// cold reconnect can `codex resume <id>`. A fork on resume overwrites the mapping with the new id.
+function rememberCodexRollout(sessionId: string, root: string, before: Set<string>): void {
+  discoverCodexSession(root, before)
+    .then((meta) => {
+      if (meta) codexRolloutIds.set(sessionId, meta.id);
+    })
+    .catch(() => {});
+}
+
+function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string | null, cwd: string): PtyEntry {
+  const root = codexSessionsRoot();
+  const before = snapshotSessions(root);
+  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL });
+  const { term, tmux } = ptySpawn(sessionId, CODEX_BIN, args, cwd, true);
+  const via = tmux ? " via tmux" : "";
+  const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";
+  console.log(`[pty] spawned codex (pid=${term.pid}${via}) in ${cwd}${resumeNote}`);
+  const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux };
+  ptys.set(sessionId, entry);
+  if (resumeRolloutId) codexRolloutIds.set(sessionId, resumeRolloutId);
+  rememberCodexRollout(sessionId, root, before);
+  wireCodexRelay(entry, sessionId);
+  return entry;
+}
+
+function startCodexEntry(sessionId: string, ws: WebSocket, live: PtyEntry | undefined, resumeRolloutId: string | null, cwd: string): PtyEntry {
+  if (live) return reattachPty(live, ws, sessionId);
+  return spawnCodexPty(sessionId, ws, resumeRolloutId, cwd);
+}
+
+// codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume): a first-class codex session,
+// persistent + reattachable, marked a dev terminal so it stays out of the claude chat sidebar.
+runCodexWss.on("connection", (ws, req) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const raw = url.searchParams.get("session");
+  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
+  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+
+  const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
+  markDevTerminalSession(sessionId);
+  ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
+
+  let entry: PtyEntry;
+  try {
+    entry = startCodexEntry(sessionId, ws, live, resumeRolloutId, cwd);
+  } catch (err) {
+    console.error(`[ws/codex] failed to start ${sessionId}: ${messageOf(err)}`);
+    return closeWithError(ws, "Failed to start codex. Is the `codex` CLI installed and on your PATH?");
   }
 
   ws.on("message", (raw) => handleClientFrame(entry, ws, raw, sessionId));

--- a/server/index.ts
+++ b/server/index.ts
@@ -40,6 +40,7 @@ import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./codex-session.js";
+import { stripTerminalQueries } from "./terminal-replay.js";
 import {
   isRecord,
   parseJsonl,
@@ -1443,7 +1444,9 @@ function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntr
   }
   entry.ws = ws;
   if (entry.buffer && ws.readyState === ws.OPEN) {
-    ws.send(JSON.stringify({ type: "output", data: entry.buffer }));
+    // Strip terminal queries from the replay so xterm doesn't re-answer them as stray input
+    // (e.g. a DA reply surfacing as "0;276;0c" in the prompt) — see terminal-replay.ts.
+    ws.send(JSON.stringify({ type: "output", data: stripTerminalQueries(entry.buffer) }));
   }
   return entry;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -449,6 +449,9 @@ const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
 // mulmoterminal session key -> the codex rollout id it maps to. codex mints its own id, so we
 // discover it after spawn and keep it here to `codex resume <id>` once the live PTY is gone.
 const codexRolloutIds = new Map<string, string>();
+// Rollout files already attributed to a session, so a single rollout is never mapped to two keys
+// (which would let both cold-resume the same conversation). Serialized by the single event loop.
+const claimedCodexRollouts = new Set<string>();
 
 // New sessions started in this process that have no .jsonl on disk yet (Claude
 // only writes the file on the first prompt). Merged into /api/sessions so a
@@ -2101,9 +2104,11 @@ function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
 // (stop once its pty is gone) and capture the minted id so a later cold reconnect can
 // `codex resume <id>`. Attribution is unambiguous-only (see pickFreshSession).
 function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
-  watchForCodexSession(root, before, { cwd, isCancelled: () => !ptys.has(sessionId) })
+  watchForCodexSession(root, before, { cwd, claimed: claimedCodexRollouts, isCancelled: () => !ptys.has(sessionId) })
     .then((meta) => {
-      if (meta) codexRolloutIds.set(sessionId, meta.id);
+      if (!meta) return;
+      claimedCodexRollouts.add(meta.file);
+      codexRolloutIds.set(sessionId, meta.id);
     })
     .catch(() => {});
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2097,9 +2097,9 @@ function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
   });
 }
 
-// codex persists its rollout only after the first user turn, so watch for the session's lifetime
+// codex persists its rollout only after the first user turn, so watch a FRESH session's lifetime
 // (stop once its pty is gone) and capture the minted id so a later cold reconnect can
-// `codex resume <id>`. cwd disambiguates concurrent sessions best-effort.
+// `codex resume <id>`. Attribution is unambiguous-only (see pickFreshSession).
 function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
   watchForCodexSession(root, before, { cwd, isCancelled: () => !ptys.has(sessionId) })
     .then((meta) => {
@@ -2118,8 +2118,13 @@ function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string
   console.log(`[pty] spawned codex (pid=${term.pid}${via}) in ${cwd}${resumeNote}`);
   const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux };
   ptys.set(sessionId, entry);
-  if (resumeRolloutId) codexRolloutIds.set(sessionId, resumeRolloutId);
-  rememberCodexRollout(sessionId, root, before, cwd);
+  if (resumeRolloutId) {
+    codexRolloutIds.set(sessionId, resumeRolloutId);
+  } else {
+    // Discover the id only for a FRESH session. On resume we already know it; running the watcher
+    // could overwrite the known id with a mis-attributed concurrent rollout.
+    rememberCodexRollout(sessionId, root, before, cwd);
+  }
   wireCodexRelay(entry, sessionId);
   return entry;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -39,7 +39,7 @@ import { buildClaudeArgs } from "./claude-args.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
-import { codexSessionsRoot, snapshotSessions, discoverCodexSession } from "./codex-session.js";
+import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./codex-session.js";
 import {
   isRecord,
   parseJsonl,
@@ -2094,10 +2094,11 @@ function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
   });
 }
 
-// codex writes its rollout (with the minted id) at startup; capture it best-effort so a later
-// cold reconnect can `codex resume <id>`. A fork on resume overwrites the mapping with the new id.
-function rememberCodexRollout(sessionId: string, root: string, before: Set<string>): void {
-  discoverCodexSession(root, before)
+// codex persists its rollout only after the first user turn, so watch for the session's lifetime
+// (stop once its pty is gone) and capture the minted id so a later cold reconnect can
+// `codex resume <id>`. cwd disambiguates concurrent sessions best-effort.
+function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
+  watchForCodexSession(root, before, { cwd, isCancelled: () => !ptys.has(sessionId) })
     .then((meta) => {
       if (meta) codexRolloutIds.set(sessionId, meta.id);
     })
@@ -2115,7 +2116,7 @@ function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string
   const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux };
   ptys.set(sessionId, entry);
   if (resumeRolloutId) codexRolloutIds.set(sessionId, resumeRolloutId);
-  rememberCodexRollout(sessionId, root, before);
+  rememberCodexRollout(sessionId, root, before, cwd);
   wireCodexRelay(entry, sessionId);
   return entry;
 }

--- a/server/terminal-replay.spec.ts
+++ b/server/terminal-replay.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { stripTerminalQueries } from "./terminal-replay.js";
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+describe("stripTerminalQueries", () => {
+  it("removes a Device Attributes query embedded in output (the 0;276;0c symptom source)", () => {
+    expect(stripTerminalQueries(`abc${ESC}[>c def`)).toBe("abc def");
+    expect(stripTerminalQueries(`${ESC}[c`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[>0c`)).toBe("");
+  });
+
+  it("removes device/cursor status queries", () => {
+    expect(stripTerminalQueries(`${ESC}[6n`)).toBe("");
+    expect(stripTerminalQueries(`x${ESC}[5ny`)).toBe("xy");
+    expect(stripTerminalQueries(`${ESC}[?6n`)).toBe("");
+  });
+
+  it("removes kitty-keyboard and XTVERSION queries", () => {
+    expect(stripTerminalQueries(`${ESC}[?u`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[>q`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[>0q`)).toBe("");
+  });
+
+  it("removes OSC color queries (BEL- or ST-terminated)", () => {
+    expect(stripTerminalQueries(`${ESC}]10;?${BEL}`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}]11;?${ESC}\\`)).toBe("");
+  });
+
+  it("does NOT strip a DA RESPONSE (multi-param) — only queries", () => {
+    const response = `${ESC}[>0;276;0c`;
+    expect(stripTerminalQueries(response)).toBe(response);
+  });
+
+  it("leaves visible text and SGR colour sequences untouched", () => {
+    const styled = `${ESC}[31mhello${ESC}[0m world`;
+    expect(stripTerminalQueries(styled)).toBe(styled);
+    expect(stripTerminalQueries("plain text")).toBe("plain text");
+  });
+});

--- a/server/terminal-replay.ts
+++ b/server/terminal-replay.ts
@@ -1,0 +1,24 @@
+// Terminal "query" control sequences an application writes to probe the emulator — Device
+// Attributes, device/cursor status, OSC color, kitty-keyboard flags, XTVERSION. The emulator
+// auto-REPLIES to each. That's correct live, but when we replay a reattached session's buffered
+// output, xterm re-answers the queries baked into it and the stale replies are sent back as
+// INPUT, surfacing as junk like "0;276;0c" in the app's prompt (codex writes several at startup).
+// Strip them from the replay only: they render nothing, so the visual restore is unchanged, and
+// the app re-queries live if it still needs to.
+//
+// Built via new RegExp so the ESC/BEL control chars stay out of the regex source (satisfies
+// no-control-regex without a disable).
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+const QUERY_PATTERNS: RegExp[] = [
+  new RegExp(ESC + "\\[[>=]?\\d*c", "g"), // Device Attributes (DA1/DA2/DA3) — the "…c" symptom
+  new RegExp(ESC + "\\[\\??\\d*n", "g"), // device / cursor status report (DSR / CPR)
+  new RegExp(ESC + "\\[\\?u", "g"), // kitty keyboard flags query
+  new RegExp(ESC + "\\[>\\d*q", "g"), // XTVERSION
+  new RegExp(ESC + "\\]1[012];\\?(?:" + BEL + "|" + ESC + "\\\\)", "g"), // OSC 10/11/12 fg/bg/cursor color query
+];
+
+export function stripTerminalQueries(data: string): string {
+  return QUERY_PATTERNS.reduce((out, re) => out.replace(re, ""), data);
+}

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -8,6 +8,7 @@ import {
   addCell,
   setSession,
   setCwd,
+  setCellAgent,
   closeCell,
   toggleExpand,
   switchPage,
@@ -107,6 +108,7 @@ function onAddTerminal() {
 }
 const onSession = (uid: number, id: string) => (state.value = setSession(state.value, uid, id));
 const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, uid, cwd));
+const onAgent = (uid: number, agent: "claude" | "codex") => (state.value = setCellAgent(state.value, uid, agent));
 const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
@@ -180,6 +182,7 @@ function closeSettings() {
       :reorderable="reorderable"
       :open-session-ids="openSessionIds"
       @session="onSession"
+      @agent="onAgent"
       @cwd="onCwd"
       @record-cwd="recordPreset"
       @remove-preset="removePreset"

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -34,6 +34,8 @@ const props = defineProps<{
   // A configured launcher (shell/codex/command) — persistent & reattachable, connects
   // to /ws/launch instead of resuming a Claude session.
   launcher?: { index: number } | null;
+  // A first-class codex session — connects to /ws/codex instead of /ws (Claude).
+  codex?: boolean;
   runMenu?: boolean;
   persistKey?: string | null;
   // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
@@ -62,6 +64,7 @@ function currentTarget(): conn.ConnTarget {
     devTerminal: !!props.devTerminal,
     command: props.command ?? null,
     launcher: props.launcher ?? null,
+    codex: !!props.codex,
   };
 }
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -23,6 +23,9 @@ const props = defineProps<{
   expanded: boolean;
   initialSessionId: string | null;
   initialCwd: string | null;
+  // The persisted agent for this cell: "codex" reconnects via /ws/codex on reload; absent
+  // (or "claude") resumes as a normal Claude session.
+  initialAgent?: "codex" | null;
   defaultCwd: string | null;
   presets: CwdPreset[];
   // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
@@ -50,12 +53,17 @@ const emit = defineEmits<{
   (e: "move", dir: -1 | 1): void;
   // Report live activity up so the grid can attention-sort in auto mode.
   (e: "status", value: CellStatus): void;
+  // The agent chosen (Claude/Codex) for this fresh launch, so the grid persists it.
+  (e: "agent", value: "claude" | "codex"): void;
 }>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
 // starts empty and lazy-launches when the user picks a dir and clicks Start.
 const launched = ref(props.initialSessionId !== null);
 const sessionId = ref<string | null>(props.initialSessionId);
+// The agent this cell runs (Claude by default). Fixed once launched; restored from the
+// persisted cell on reload so a codex cell reconnects to /ws/codex.
+const agent = ref<"claude" | "codex">(props.initialAgent === "codex" ? "codex" : "claude");
 const connectKey = ref(0);
 
 // The directory this terminal runs in (shown in the header, sent to the server).
@@ -183,6 +191,7 @@ function launchIn(dir: string | null) {
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
+  emit("agent", agent.value); // let the grid persist which agent this cell launched
   recordNextCwd = true;
   loadDiff(); // no-op for a non-worktree dir
 }
@@ -810,6 +819,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :session-id="sessionId"
         :connect-key="connectKey"
         :cwd="cwd"
+        :codex="agent === 'codex'"
         :dir-theme="dirConfig.theme"
         :dir-colors="dirConfig.colors"
         dev-terminal
@@ -915,6 +925,28 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             ✕
           </button>
         </span>
+      </div>
+      <div class="cell-agent" role="radiogroup" aria-label="Agent">
+        <button
+          type="button"
+          class="cell-agent-btn"
+          :class="{ active: agent === 'claude' }"
+          role="radio"
+          :aria-checked="agent === 'claude'"
+          @click="agent = 'claude'"
+        >
+          Claude
+        </button>
+        <button
+          type="button"
+          class="cell-agent-btn"
+          :class="{ active: agent === 'codex' }"
+          role="radio"
+          :aria-checked="agent === 'codex'"
+          @click="agent = 'codex'"
+        >
+          Codex
+        </button>
       </div>
       <label class="cell-launch-label">
         <span class="cell-launch-caption">Working directory</span>
@@ -1330,6 +1362,34 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.cell-agent {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-deep);
+  align-self: flex-start;
+}
+.cell-agent-btn {
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 14px;
+  border-radius: 5px;
+}
+.cell-agent-btn:hover {
+  color: var(--text);
+}
+.cell-agent-btn.active {
+  background: var(--bg-elevated);
+  color: var(--text);
 }
 .cell-dir-input {
   width: 100%;

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -36,6 +36,7 @@ const emit = defineEmits<{
   (e: "launch", uid: number, pick: LaunchPick): void;
   (e: "move", uid: number, dir: -1 | 1): void;
   (e: "status", uid: number, value: CellStatus): void;
+  (e: "agent", uid: number, value: "claude" | "codex"): void;
   // Shared preset list events — uid-less since they mutate the one config list.
   (e: "record-cwd" | "remove-preset", value: string): void;
 }>();
@@ -87,6 +88,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :expanded="cell.uid === expandedUid"
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"
+          :initial-agent="cell.agent"
           :default-cwd="defaultCwd"
           :presets="presets"
           :launchers="launchers"
@@ -96,6 +98,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @session="(id) => emit('session', cell.uid, id)"
+          @agent="(a) => emit('agent', cell.uid, a)"
           @cwd="(c) => emit('cwd', cell.uid, c)"
           @record-cwd="(c) => emit('record-cwd', c)"
           @remove-preset="(path) => emit('remove-preset', path)"

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -20,6 +20,8 @@ export interface Cell {
   command?: { index: number; label: string; cwd: string | null } | null;
   // A running launcher (shell/codex/custom). Persistent & reattachable like a session.
   launcher?: CellLauncher | null;
+  // The agent this cell runs. "codex" reconnects via /ws/codex; absent = Claude (the default).
+  agent?: "codex";
 }
 // How the grid orders its cells. "manual": the user's hand-arranged order (◀▶);
 // "auto": attention-first, recomputed from each cell's live status.
@@ -96,6 +98,13 @@ export function setSession(state: GridState, uid: number, id: string | null): Gr
 
 export function setCwd(state: GridState, uid: number, cwd: string): GridState {
   return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, cwd } : c)) };
+}
+
+// Record which agent a cell launched (only "codex" is stored; Claude is the default/absent) so a
+// reloaded cell reconnects to the right endpoint.
+export function setCellAgent(state: GridState, uid: number, agent: "claude" | "codex"): GridState {
+  const codex: "codex" | undefined = agent === "codex" ? "codex" : undefined;
+  return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, agent: codex } : c)) };
 }
 
 // A cell's launcher ran a script.json command: attach it, turning the launch cell
@@ -245,7 +254,13 @@ export function parseGridState(raw: string | null): GridState | null {
       .filter(isCell)
       .filter((c: Cell) => c.session !== null)
       .slice(0, MAX_TERMINALS);
-    const cells: Cell[] = running.map((c: Cell, i: number) => ({ uid: i, session: c.session, cwd: c.cwd, launcher: asLauncher(c.launcher) }));
+    const cells: Cell[] = running.map((c: Cell, i: number) => ({
+      uid: i,
+      session: c.session,
+      cwd: c.cwd,
+      launcher: asLauncher(c.launcher),
+      agent: c.agent === "codex" ? "codex" : undefined,
+    }));
     const expandedIdx = running.findIndex((c: Cell) => c.uid === parsed.expanded);
     const expanded = typeof parsed.expanded === "number" && expandedIdx >= 0 ? expandedIdx : null;
     const page = Number.isSafeInteger(parsed.page) && parsed.page >= 0 ? parsed.page : 0;

--- a/src/components/wsUrl.spec.ts
+++ b/src/components/wsUrl.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl } from "./wsUrl";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } from "./wsUrl";
 
 describe("buildTerminalWsUrl", () => {
   it("single view: session only, no gui=0", () => {
@@ -71,5 +71,24 @@ describe("buildLaunchWsUrl", () => {
   it("uses wss when secure", () => {
     const url = buildLaunchWsUrl({ host: "h", secure: true, sessionId: null, launcher: 1 });
     expect(url.startsWith("wss://")).toBe(true);
+  });
+});
+
+describe("buildCodexWsUrl", () => {
+  it("targets /ws/codex with the reattach session + cwd", () => {
+    const u = new URL(buildCodexWsUrl({ host: "h", secure: false, sessionId: "abc", cwd: "/work/proj" }));
+    expect(u.pathname).toBe("/ws/codex");
+    expect(u.searchParams.get("session")).toBe("abc");
+    expect(u.searchParams.get("cwd")).toBe("/work/proj");
+  });
+
+  it("fresh codex (null id): no session param", () => {
+    const u = new URL(buildCodexWsUrl({ host: "h", secure: false, sessionId: null }));
+    expect(u.pathname).toBe("/ws/codex");
+    expect(u.searchParams.has("session")).toBe(false);
+  });
+
+  it("uses wss when secure", () => {
+    expect(buildCodexWsUrl({ host: "h", secure: true, sessionId: null }).startsWith("wss://")).toBe(true);
   });
 });

--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -58,3 +58,23 @@ export function buildLaunchWsUrl({ host, secure, sessionId, cwd, launcher }: Lau
   const proto = secure ? "wss:" : "ws:";
   return `${proto}//${host}/ws/launch?${params.toString()}`;
 }
+
+export interface CodexWsUrlInput {
+  host: string;
+  secure: boolean;
+  sessionId: string | null; // reattach/resume this codex session; null => fresh
+  cwd?: string | null;
+}
+
+// The codex-terminal endpoint (a first-class codex session). Persistent & reattachable like
+// /ws; the browser sends the mulmoterminal session id to reattach/resume — the server maps it
+// to codex's own rollout id.
+export function buildCodexWsUrl({ host, secure, sessionId, cwd }: CodexWsUrlInput): string {
+  const params = new URLSearchParams();
+  if (sessionId) params.set("session", sessionId);
+  if (cwd) params.set("cwd", cwd);
+  const qs = params.toString();
+  const suffix = qs ? `?${qs}` : "";
+  const proto = secure ? "wss:" : "ws:";
+  return `${proto}//${host}/ws/codex${suffix}`;
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -20,7 +20,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard";
 import "@xterm/xterm/css/xterm.css";
-import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl } from "../components/wsUrl";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } from "../components/wsUrl";
 
 export type ConnStatus = "connecting" | "connected" | "disconnected";
 
@@ -34,6 +34,9 @@ export interface ConnTarget {
   // A configured launcher (shell/codex/command). Unlike `command` this is a PERSISTENT
   // session — it reconnects on drop and reattaches by session id, like a Claude cell.
   launcher: { index: number } | null;
+  // A first-class codex session (/ws/codex) instead of a Claude one. Persistent &
+  // reattachable like a Claude cell; the server discovers + resumes codex's own id.
+  codex?: boolean;
 }
 
 // Forwarded to whatever component is currently attached, so the parent's existing
@@ -168,6 +171,7 @@ function connUrl(target: ConnTarget, resumeId: string | null, secure: boolean): 
   const host = location.host;
   if (target.command) return buildRunWsUrl({ host, secure, index: target.command.index, cwd: target.cwd });
   if (target.launcher) return buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
+  if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd });
   return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
 }
 


### PR DESCRIPTION
## Summary

**PR#1a of the multi-agent stack (tracking issue #236) — the SERVER half of "Codex L1+L2".**
Makes MulmoTerminal able to host **codex as a first-class session** (like Claude): spawn it,
learn its session id, and resume it. Claude's `/ws` path is **untouched**.

New `/ws/codex` endpoint, mirroring the launcher's persistent + reattachable lifecycle, but:
- **Fresh spawn** snapshots `$CODEX_HOME/sessions`, runs `codex`, then discovers the rollout
  file codex creates at startup and reads the **id codex minted for itself** (codex has no
  `--session-id`, so the server can't force one). The id is kept in a `key → rolloutId` map.
- **Reconnect** reattaches a live PTY / surviving tmux session (running codex picked up, no
  resume); otherwise **cold-resumes** a known rollout id via `codex resume <id>`.

The browser-facing session id is a mulmoterminal-minted key (stable across reload); codex's own
rollout id is internal, used only to build `codex resume`.

**Split note:** the client half (agent picker UI + `ConnTarget`/wsUrl wiring + grid-cell
persistence) is **PR#1b**, kept separate because it's UI I want to live-verify once the local
`codex` binary is repaired. This PR is reachable/reviewable via a manual `/ws/codex?cwd=…`
connection and is fully unit-tested at the logic layer.

## Items to Confirm / Review

- **Session model** — browser key ↔ codex rollout id mapping (in-memory), reattach-vs-cold-resume
  decision in `resolveCodexSession`. In-memory map means **cold-resume after a full server
  restart** falls back to fresh (tmux still reattaches a surviving live codex); persisting the
  map is a deliberate follow-up. OK for L2's primary "hot reload" goal?
- **Isolation choice** — codex is a separate `/ws/codex` endpoint (not a branch inside `/ws`), so
  Claude carries zero regression risk. Agree with that over unifying the handlers?
- **NEEDS LIVE VERIFICATION** (local `codex` is currently broken — vendor `ENOENT` after a Node
  upgrade; unit tests + build don't need it, but these do):
  - `codex resume <id>` behavior: does it continue the same rollout or fork to a new id? The code
    handles both (discovery overwrites the mapping on a fork), but the real behavior is unconfirmed.
  - Arg order `codex [--model x] resume <id>` (global flag before subcommand — codex's clap layout).
  - Rollout-file appears fast enough after spawn for discovery (5s timeout, 150ms poll).

## User Prompt

> I want MulmoTerminal to use Codex (then Antigravity), not just Claude — Codex first. Running it
> in a raw TTY isn't enough; I need first-class sessions (resume across reload), the single-mode
> MCP/GUI panel, and skill runs. Merge PR#0 and proceed to PR#1 (Codex L1+L2). I'll review on the PR.

(Full plan + PR breakdown: #236 and `plans/feat-multi-agent-support.md`.)

## What this PR changes

| File | Change |
|---|---|
| `server/codex-args.ts` (+spec) | Pure argv builder: fresh vs `resume <id>`, optional `--model`. |
| `server/codex-session.ts` (+spec) | Snapshot `$CODEX_HOME/sessions`, find the rollout that appears after spawn, parse `session_meta` (id + cwd). |
| `server/agents/{types,claude,codex,registry}.ts` (+spec) | `AgentKind` gains `codex`; `codexAdapter` (CODEX_BIN); `draftReadyMarker` now optional (codex omits it); adapters use `satisfies`. |
| `server/index.ts` | `/ws/codex` endpoint + `spawnCodexPty`/`resolveCodexSession`/discovery wiring; `codexRolloutIds` map; `CODEX_BIN`/`CODEX_MODEL`. Claude path unchanged. |

## Verification

`yarn format` / `yarn lint` (0 errors) / `yarn typecheck:server` / `yarn build` / `yarn test` — all
green (**693 tests**, +18: codex-args 4, codex-session 13, registry codex +1). The two pure modules
are the tested core; the `/ws/codex` handler mirrors the already-proven launcher path. A codex-stub
integration test (like the Claude `/ws` stub in `package-smoke`) is planned for PR#5.

Refs #236
