### PR TITLE
feat: Codex as a first-class agent (L1+L2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, dev_tool]
+    branches: [main, dev_tool, feat/multi-agent]
   pull_request:
-    branches: [main, dev_tool]
+    branches: [main, dev_tool, feat/multi-agent]
 
 jobs:
   lint-and-build:

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -43,7 +43,7 @@ on:
   # take is wanted on draft promotion, use `workflow_dispatch` instead.
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main, dev_tool]
+    branches: [main, dev_tool, feat/multi-agent]
   # Manual escalation: run on demand against any PR (re-review,
   # one-off check on a closed PR, etc.).
   workflow_dispatch:

--- a/plans/feat-multi-agent-support.md
+++ b/plans/feat-multi-agent-support.md
@@ -1,0 +1,152 @@
+# feat: multi-agent support — Codex (then Antigravity) as first-class agents
+
+Tracking issue: receptron/mulmoterminal#236
+Integration branch: `feat/multi-agent` (off `main`). PRs stack onto it; final PR merges to `main`.
+
+## Goal
+
+Let a MulmoTerminal session run a non-Claude agent CLI **as a first-class agent**, equal to Claude:
+session resume across reload, single-mode GUI panel over MCP, and skill/collection runs.
+Target order: **Codex first**, then **Antigravity (`agy`)**. Design so a third agent is additive.
+
+## What already exists (seams to build on)
+
+- **Three spawn paths** in `server/index.ts`: `/ws` → `spawnClaudePty` (Claude, first-class),
+  `/ws/launch` → `spawnLauncherPty` (arbitrary command, persistent+reattachable),
+  `/ws/run` → `spawnCommandPty` (ephemeral). All funnel through `spawnPty()` (`server/index.ts:1503`).
+- **Single binary choke point**: `CLAUDE_BIN = process.env.CLAUDE_BIN || "claude"` (`server/index.ts:136`),
+  consumed only at `server/index.ts:1549`.
+- **Argv builder**: `buildClaudeArgs` (`server/claude-args.ts:23`) — Claude-specific flags
+  (`--session-id`/`--resume`/`--settings`/`--permission-mode`/`--mcp-config`/`--strict-mcp-config`/`--allowedTools`).
+- **Session id**: the server MINTS it and forces it via `--session-id`; it is NOT parsed from output.
+  Reported to the client as `{type:"session", id, cwd}` (`server/index.ts:1817`).
+- **GUI-MCP is agent-agnostic**: `mcpConfigJson(sessionId)` points the agent at
+  `http://127.0.0.1:PORT/api/mcp/<sessionId>` (`server/index.ts:625`); the broker
+  (`server/mcp/broker.ts`, `buildGuiMcpServer`) keys everything by the URL's sessionId and publishes
+  tool results on `session:<id>` (`sessionChannel`, `server/index.ts:245`) → `GuiPanel.vue` renders.
+  The broker comment already anticipates a Docker sandbox (`server/mcp/broker.ts:23`).
+- **Launcher config**: `Launcher {label, command}` in `~/.mulmoterminal/config.json`
+  (`server/app-config.ts:12`), editable in `SettingsModal.vue`.
+- **Skill run**: a collection IS a skill; the plugin seeds `/<slug> …` and injects it 3 ways —
+  initial argv prompt, bracketed-paste **draft** after `DRAFT_READY_MARKER=/shift+tab to cycle/`
+  (`server/index.ts:1476`), or `input` frames into a live PTY. Skill dirs hardcoded to
+  `.claude/skills` / `data/skills` (`server/backends/collections.ts:70-76`).
+- **Docker sandbox already exists** (`server/sandbox.ts` + `Dockerfile.sandbox`, opt-in
+  `MULMOTERMINAL_SANDBOX=1`, single-view + macOS only, verified in #202). It wraps `claude` in
+  `docker run`, mounts the cwd at its same path + `~/.claude` (auth/transcripts) + a per-session
+  `~/.claude.json`, overlays the macOS Keychain credential, and — the key part — the container
+  reaches the host GUI-MCP + hooks over `host.docker.internal`. `server.listen(PORT)` binds all
+  interfaces; `rewriteLoopbackForDocker()` (`sandbox.ts:44`) rewrites the MCP/hook URLs
+  `127.0.0.1`→`host.docker.internal` (`server/index.ts:652,1661`). `buildDockerRunArgs`
+  (`sandbox.ts:233`) hardcodes `"claude", ...claudeArgs` at the tail (`:268`) — the one spot that
+  is agent-specific.
+
+## Target design: `AgentAdapter`
+
+One interface owning everything agent-specific; all shared plumbing (PTY persistence, reattach, grid,
+pubsub, broker, GuiPanel) stays untouched.
+
+```
+type AgentKind = "claude" | "codex" | "antigravity";
+type Runtime = "host" | "docker";
+
+interface AgentAdapter {
+  kind: AgentKind;
+  bin(): string;                                   // env override per agent
+  buildArgs(ctx): string[];                        // session/resume, model, approval, MCP inject
+  captureSessionId(ctx): Promise<string> | string; // claude: minted; codex/agy: discover/parse
+  resumeArgs(id): string[];                         // codex resume <id> / agy --conversation <id>
+  mcpInject(url): string[] | ConfigWrite;          // point at GUI-MCP + auto-approve its tools
+  draftReadyMarker: RegExp;                          // TUI status line for draft typing
+  skillSeed(seed): Injection;                        // how a skill/collection prompt enters the agent
+  paths: { userSkills; projectSkills; sessions; };
+}
+```
+
+Claude becomes the first adapter with a **no-behavior-change** refactor.
+The `Runtime` dimension already exists for Claude as the single-view Docker sandbox
+(`server/sandbox.ts`): it wraps `bin()`/args in `docker run …` and the MCP-URL host swap is done by
+`rewriteLoopbackForDocker()`. Generalizing it = parametrizing the hardcoded `claude` tail + per-agent
+auth mounts (see Docker section under PR#5).
+
+## Client protocol change
+
+Add an **agent kind** alongside the existing launcher index in `ConnTarget`
+(`useTerminalConnections.ts:28`) and the `/ws` query (`wsUrl.ts`), plus the grid cell model
+(`gridTabs.ts`) and a way to pick the agent for a cell / single view.
+
+---
+
+## PR stack
+
+### PR#0 — scaffolding + CI
+- Add `feat/multi-agent` to `push` + `pull_request` branch triggers in `.github/workflows/ci.yml`
+  and `.github/workflows/codex_review.yaml` (both currently `[main, dev_tool]` only).
+- Introduce `AgentAdapter` + a registry; move Claude's bin/args/marker/paths behind the Claude adapter.
+- (GUI-MCP URL host is already parametrized via `mcpConfigJson(id, host, sandbox)` + `rewriteLoopbackForDocker`
+  — no new work needed here; just keep it adapter-reachable.)
+- **Acceptance**: no behavior change; `yarn lint/build/typecheck/test` green; CI runs on the branch.
+
+### PR#1 — Codex L1+L2 (first-class session + resume)
+- `CODEX_BIN = process.env.CODEX_BIN || "codex"`; `server/codex-args.ts` (model `-m`, `--ask-for-approval`,
+  `--sandbox`, resume).
+- **Session id discovery**: after spawn, find the newest `~/.codex/sessions/**/rollout-*.jsonl` created
+  after launch; read `session_meta.payload.id` (+ `cwd`); store; emit `{type:"session", id}`. Poll briefly
+  if the file lags spawn.
+- Resume via `codex resume <id>` (or `-c experimental_resume=<path>`).
+- Client: agent kind in `ConnTarget` / `wsUrl` / grid cell + agent picker.
+- **Acceptance**: pick Codex for a cell → runs; reload/restart → same codex conversation resumes.
+
+### PR#2 — Codex L3 (GUI-MCP in single mode)
+- Inject GUI-MCP per session: `-c 'mcp_servers.mulmoterminal-gui.url="http://<host>:PORT/api/mcp/<id>"'`
+  `-c 'mcp_servers.mulmoterminal-gui.default_tools_approval_mode="approve"'` (broker unchanged).
+- Ensure the mulmoterminal session key (GUI channel + MCP URL) matches the GuiPanel binding for a codex
+  single-mode session (mulmoterminal-minted key is fine; codex's rollout id is only for resume).
+- **Acceptance**: from a codex single-mode session, `presentChart`/`presentForm`/`presentCollection`/
+  `generateImage` render in the GUI panel.
+
+### PR#3 — Codex L4 (skill / collection run)
+- Codex-specific `draftReadyMarker` (its TUI status line).
+- Map collection/skill seed → codex invocation; per-agent skill paths (`~/.codex/skills`) in
+  `configureCollectionHost`.
+- **Acceptance**: running a collection action / chat seed against a codex session injects correctly.
+
+### PR#4 — Antigravity (`agy`)
+- `ANTIGRAVITY_BIN`; adapter: argv (`--model`, `--dangerously-skip-permissions`, `--conversation <id>`),
+  session capture (parse the resume line agy prints on exit / scan `~/.gemini` store), MCP via
+  `mcp_config.json` `url` server, skills via `/skills`.
+- Resolve open unknowns on a machine with `agy` installed.
+- **Acceptance**: same L1–L4 checks for Antigravity.
+
+### PR#5 — Docker sandbox (generalize existing) + docs + integration tests + merge
+- **Generalize `server/sandbox.ts`** (the container→host GUI-MCP path is already #202-verified for Claude):
+  - Parametrize `buildDockerRunArgs` tail (`sandbox.ts:268`, hardcoded `"claude", ...`) by adapter.
+  - Per-agent auth mounts: Codex → mount `~/.codex` r/w (plain `auth.json`, no Keychain — simpler than
+    Claude); Antigravity → mount `~/.gemini` incl. `antigravity-cli/`.
+  - Mounting `~/.codex` r/w also surfaces the rollout sessions dir on the host → **L2 id discovery works
+    in-container** (auth mount doubles as id source).
+  - Extend `Dockerfile.sandbox` to carry `codex` / `agy`.
+  - Codex in-container: `--sandbox danger-full-access`. Consider Linux support (no Keychain dep; needs the
+    `--user` uid-mapping #202 follow-up).
+- README.md + CLAUDE.md: agent selection, `CODEX_BIN`/`ANTIGRAVITY_BIN`, `MULMOTERMINAL_SANDBOX` per agent.
+- Codex stub integration test mirroring the Claude `/ws` stub in `ci.yml`.
+- Merge `feat/multi-agent` → `main`.
+
+## Open questions (need a working binary)
+
+- Codex: `-c mcp_servers.x.url` per-session injection actually registers the server; rollout-file timing
+  for id capture; codex TUI marker string; first-turn skill/slash invocation UX.
+- Antigravity: on-disk session path + programmatic id capture; per-session MCP injection vs config file;
+  agy TUI markers.
+
+## Environment prerequisites
+
+- Repair local `codex` (`@openai/codex` reinstall; vendor binary `ENOENT` after a Node upgrade).
+- Install `agy` for Antigravity work.
+- Unit tests + build need neither; CI stubs the CLIs.
+
+## Constraints / conventions
+
+- Follow repo git rules: feature branch per PR onto `feat/multi-agent`; no `git add .`; merge commits;
+  `feat:`/`refactor:`/`fix:` prefixes; PR body carries Summary + Items-to-Confirm first, then the user prompt.
+- `script.json` in the working tree is a local, untracked convenience file — never commit it.

--- a/server/agents/claude.ts
+++ b/server/agents/claude.ts
@@ -1,7 +1,6 @@
 import type { AgentAdapter } from "./types.js";
 
-// "shift+tab to cycle" is the permission-mode hint Claude Code paints once its input box
-// is ready — the cue the draft-typing flow waits for before pasting a seed.
+// "shift+tab to cycle" is the hint Claude paints once its input box is ready for a paste.
 export const claudeAdapter: AgentAdapter = {
   kind: "claude",
   bin: () => process.env.CLAUDE_BIN || "claude",

--- a/server/agents/claude.ts
+++ b/server/agents/claude.ts
@@ -1,0 +1,9 @@
+import type { AgentAdapter } from "./types.js";
+
+// "shift+tab to cycle" is the permission-mode hint Claude Code paints once its input box
+// is ready — the cue the draft-typing flow waits for before pasting a seed.
+export const claudeAdapter: AgentAdapter = {
+  kind: "claude",
+  bin: () => process.env.CLAUDE_BIN || "claude",
+  draftReadyMarker: /shift\+tab to cycle/,
+};

--- a/server/agents/claude.ts
+++ b/server/agents/claude.ts
@@ -1,8 +1,10 @@
 import type { AgentAdapter } from "./types.js";
 
 // "shift+tab to cycle" is the hint Claude paints once its input box is ready for a paste.
-export const claudeAdapter: AgentAdapter = {
+// `satisfies` (not a `: AgentAdapter` annotation) keeps draftReadyMarker's concrete type so
+// callers that rely on it (the draft-injection scanner) don't see it as possibly-undefined.
+export const claudeAdapter = {
   kind: "claude",
   bin: () => process.env.CLAUDE_BIN || "claude",
   draftReadyMarker: /shift\+tab to cycle/,
-};
+} satisfies AgentAdapter;

--- a/server/agents/codex.ts
+++ b/server/agents/codex.ts
@@ -1,0 +1,7 @@
+import type { AgentAdapter } from "./types.js";
+
+// Draft injection isn't wired for codex yet, so it omits draftReadyMarker.
+export const codexAdapter = {
+  kind: "codex",
+  bin: () => process.env.CODEX_BIN || "codex",
+} satisfies AgentAdapter;

--- a/server/agents/registry.spec.ts
+++ b/server/agents/registry.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getAgentAdapter } from "./registry.js";
+import { claudeAdapter } from "./claude.js";
+
+describe("agent registry", () => {
+  const originalBin = process.env.CLAUDE_BIN;
+  afterEach(() => {
+    if (originalBin === undefined) delete process.env.CLAUDE_BIN;
+    else process.env.CLAUDE_BIN = originalBin;
+  });
+
+  it("defaults to the Claude adapter", () => {
+    expect(getAgentAdapter().kind).toBe("claude");
+    expect(getAgentAdapter("claude")).toBe(claudeAdapter);
+  });
+
+  it("resolves the Claude binary from CLAUDE_BIN, falling back to 'claude'", () => {
+    delete process.env.CLAUDE_BIN;
+    expect(claudeAdapter.bin()).toBe("claude");
+    process.env.CLAUDE_BIN = "/custom/path/claude";
+    expect(claudeAdapter.bin()).toBe("/custom/path/claude");
+  });
+
+  it("matches Claude's draft-ready TUI hint", () => {
+    expect(claudeAdapter.draftReadyMarker.test("... press shift+tab to cycle modes")).toBe(true);
+    expect(claudeAdapter.draftReadyMarker.test("no hint here")).toBe(false);
+  });
+});

--- a/server/agents/registry.spec.ts
+++ b/server/agents/registry.spec.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { getAgentAdapter } from "./registry.js";
 import { claudeAdapter } from "./claude.js";
+import { codexAdapter } from "./codex.js";
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) Reflect.deleteProperty(process.env, key);
+  else process.env[key] = value;
+}
 
 describe("agent registry", () => {
-  const originalBin = process.env.CLAUDE_BIN;
+  const originalClaudeBin = process.env.CLAUDE_BIN;
+  const originalCodexBin = process.env.CODEX_BIN;
   afterEach(() => {
-    if (originalBin === undefined) delete process.env.CLAUDE_BIN;
-    else process.env.CLAUDE_BIN = originalBin;
+    restoreEnv("CLAUDE_BIN", originalClaudeBin);
+    restoreEnv("CODEX_BIN", originalCodexBin);
   });
 
   it("defaults to the Claude adapter", () => {
@@ -14,15 +21,24 @@ describe("agent registry", () => {
     expect(getAgentAdapter("claude")).toBe(claudeAdapter);
   });
 
-  it("resolves the Claude binary from CLAUDE_BIN, falling back to 'claude'", () => {
-    delete process.env.CLAUDE_BIN;
-    expect(claudeAdapter.bin()).toBe("claude");
-    process.env.CLAUDE_BIN = "/custom/path/claude";
-    expect(claudeAdapter.bin()).toBe("/custom/path/claude");
+  it("resolves the codex adapter", () => {
+    expect(getAgentAdapter("codex").kind).toBe("codex");
+    expect(getAgentAdapter("codex")).toBe(codexAdapter);
   });
 
-  it("matches Claude's draft-ready TUI hint", () => {
+  it("reads each agent's binary from its env override, with a sensible default", () => {
+    delete process.env.CLAUDE_BIN;
+    delete process.env.CODEX_BIN;
+    expect(claudeAdapter.bin()).toBe("claude");
+    expect(codexAdapter.bin()).toBe("codex");
+    process.env.CLAUDE_BIN = "/custom/claude";
+    process.env.CODEX_BIN = "/custom/codex";
+    expect(claudeAdapter.bin()).toBe("/custom/claude");
+    expect(codexAdapter.bin()).toBe("/custom/codex");
+  });
+
+  it("exposes Claude's draft-ready marker but not codex's (not wired yet)", () => {
     expect(claudeAdapter.draftReadyMarker.test("... press shift+tab to cycle modes")).toBe(true);
-    expect(claudeAdapter.draftReadyMarker.test("no hint here")).toBe(false);
+    expect(getAgentAdapter("codex").draftReadyMarker).toBeUndefined();
   });
 });

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -1,8 +1,10 @@
 import type { AgentAdapter, AgentKind } from "./types.js";
 import { claudeAdapter } from "./claude.js";
+import { codexAdapter } from "./codex.js";
 
 const adapters: Record<AgentKind, AgentAdapter> = {
   claude: claudeAdapter,
+  codex: codexAdapter,
 };
 
 // Resolve the adapter for a kind; Claude is the default and the fallback.

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -1,0 +1,12 @@
+import type { AgentAdapter, AgentKind } from "./types.js";
+import { claudeAdapter } from "./claude.js";
+
+const adapters: Record<AgentKind, AgentAdapter> = {
+  claude: claudeAdapter,
+};
+
+// Resolve the adapter for an agent kind. Defaults to Claude — the only agent today and
+// the fallback for any session that doesn't name one.
+export function getAgentAdapter(kind: AgentKind = "claude"): AgentAdapter {
+  return adapters[kind];
+}

--- a/server/agents/registry.ts
+++ b/server/agents/registry.ts
@@ -5,8 +5,7 @@ const adapters: Record<AgentKind, AgentAdapter> = {
   claude: claudeAdapter,
 };
 
-// Resolve the adapter for an agent kind. Defaults to Claude — the only agent today and
-// the fallback for any session that doesn't name one.
+// Resolve the adapter for a kind; Claude is the default and the fallback.
 export function getAgentAdapter(kind: AgentKind = "claude"): AgentAdapter {
   return adapters[kind];
 }

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -1,10 +1,11 @@
 // The per-agent surface a hosted coding-agent CLI needs; shared plumbing (PTY, grid, GUI-MCP) stays out.
-export type AgentKind = "claude";
+export type AgentKind = "claude" | "codex";
 
 export interface AgentAdapter {
   readonly kind: AgentKind;
   // Executable to spawn; reads a per-agent env override (e.g. CLAUDE_BIN) at call time.
   bin(): string;
-  // TUI status line signalling the input box is ready for bracketed-paste draft typing.
-  readonly draftReadyMarker: RegExp;
+  // TUI status line signalling the input box is ready for bracketed-paste draft typing;
+  // absent for an agent that doesn't support draft injection yet.
+  readonly draftReadyMarker?: RegExp;
 }

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -1,21 +1,10 @@
-// A coding-agent CLI that a terminal session can host. Claude is the only agent today;
-// Codex and Antigravity are added in later PRs (see plans/feat-multi-agent-support.md).
-//
-// This interface owns ONLY the parts that genuinely differ per agent. Everything else —
-// PTY persistence, reattach, the grid, pubsub, and the GUI-MCP broker — stays shared,
-// because the broker is keyed by the session id in its URL and doesn't care which CLI
-// is talking to it. The interface starts deliberately small (the fields Claude already
-// needs); argv construction, session-id capture, resume, MCP injection, and skill seeding
-// join it in the PRs that introduce the agents that force their shape.
-
+// The per-agent surface a hosted coding-agent CLI needs; shared plumbing (PTY, grid, GUI-MCP) stays out.
 export type AgentKind = "claude";
 
 export interface AgentAdapter {
   readonly kind: AgentKind;
-  // The executable to spawn. Each agent reads its own env override (CLAUDE_BIN today,
-  // CODEX_BIN / ANTIGRAVITY_BIN later), resolved at call time so the env can change per boot.
+  // Executable to spawn; reads a per-agent env override (e.g. CLAUDE_BIN) at call time.
   bin(): string;
-  // The TUI status line that signals the input box is ready for bracketed-paste draft
-  // typing. Each agent's TUI paints a different hint, so this cue is per-agent.
+  // TUI status line signalling the input box is ready for bracketed-paste draft typing.
   readonly draftReadyMarker: RegExp;
 }

--- a/server/agents/types.ts
+++ b/server/agents/types.ts
@@ -1,0 +1,21 @@
+// A coding-agent CLI that a terminal session can host. Claude is the only agent today;
+// Codex and Antigravity are added in later PRs (see plans/feat-multi-agent-support.md).
+//
+// This interface owns ONLY the parts that genuinely differ per agent. Everything else —
+// PTY persistence, reattach, the grid, pubsub, and the GUI-MCP broker — stays shared,
+// because the broker is keyed by the session id in its URL and doesn't care which CLI
+// is talking to it. The interface starts deliberately small (the fields Claude already
+// needs); argv construction, session-id capture, resume, MCP injection, and skill seeding
+// join it in the PRs that introduce the agents that force their shape.
+
+export type AgentKind = "claude";
+
+export interface AgentAdapter {
+  readonly kind: AgentKind;
+  // The executable to spawn. Each agent reads its own env override (CLAUDE_BIN today,
+  // CODEX_BIN / ANTIGRAVITY_BIN later), resolved at call time so the env can change per boot.
+  bin(): string;
+  // The TUI status line that signals the input box is ready for bracketed-paste draft
+  // typing. Each agent's TUI paints a different hint, so this cue is per-agent.
+  readonly draftReadyMarker: RegExp;
+}

--- a/server/codex-args.spec.ts
+++ b/server/codex-args.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { buildCodexArgs } from "./codex-args.js";
+
+describe("buildCodexArgs", () => {
+  it("passes no id for a fresh session (codex mints its own)", () => {
+    expect(buildCodexArgs({ resume: null, model: null })).toEqual([]);
+  });
+
+  it("adds the model override before the subcommand", () => {
+    expect(buildCodexArgs({ resume: null, model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4"]);
+  });
+
+  it("resumes a known rollout id via the resume subcommand", () => {
+    expect(buildCodexArgs({ resume: "019f251d-001c-7542-b13e-9a627effce52", model: null })).toEqual(["resume", "019f251d-001c-7542-b13e-9a627effce52"]);
+  });
+
+  it("keeps global flags ahead of the resume subcommand", () => {
+    expect(buildCodexArgs({ resume: "abc", model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4", "resume", "abc"]);
+  });
+});

--- a/server/codex-args.ts
+++ b/server/codex-args.ts
@@ -1,0 +1,17 @@
+// Builds the argv for spawning codex as a first-class session. codex mints its own session id
+// (there is no `--session-id` like claude has), so a fresh session passes no id — the id is read
+// back from the rollout file afterwards — while resume replays a known rollout id via the
+// `resume` subcommand. Global flags precede the subcommand (codex's clap layout).
+export interface CodexArgsInput {
+  // A codex rollout id to resume, or null to start a fresh session.
+  resume: string | null;
+  // Model override (--model), or null to use codex's own configured default.
+  model: string | null;
+}
+
+export function buildCodexArgs(input: CodexArgsInput): string[] {
+  const args: string[] = [];
+  if (input.model) args.push("--model", input.model);
+  if (input.resume) args.push("resume", input.resume);
+  return args;
+}

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "./codex-session.js";
@@ -77,24 +77,28 @@ describe("pickFreshSession", () => {
     const before = snapshotSessions(root);
     expect(pickFreshSession(root, before, null)).toBeNull();
   });
-  it("returns the rollout that appeared after the snapshot", () => {
+  it("attributes a single fresh rollout (unambiguous)", () => {
     const before = snapshotSessions(root);
     writeRollout(root, UUID_A, "/a");
-    expect(pickFreshSession(root, before, null)?.id).toBe(UUID_A);
+    expect(pickFreshSession(root, before, "/anything")?.id).toBe(UUID_A);
   });
-  it("prefers the fresh rollout whose cwd matches", () => {
+  it("attributes the unique cwd match when several are fresh", () => {
     const before = snapshotSessions(root);
     writeRollout(root, UUID_A, "/a");
     writeRollout(root, UUID_B, "/b");
     expect(pickFreshSession(root, before, "/b")?.id).toBe(UUID_B);
   });
-  it("falls back to the newest by mtime when no cwd matches", () => {
+  it("refuses to guess when several fresh rollouts share the cwd", () => {
     const before = snapshotSessions(root);
-    const older = writeRollout(root, UUID_A, "/a");
-    const newer = writeRollout(root, UUID_B, "/b");
-    utimesSync(older, new Date(2026, 0, 1, 10), new Date(2026, 0, 1, 10));
-    utimesSync(newer, new Date(2026, 0, 1, 11), new Date(2026, 0, 1, 11));
-    expect(pickFreshSession(root, before, "/other")?.id).toBe(UUID_B);
+    writeRollout(root, UUID_A, "/same");
+    writeRollout(root, UUID_B, "/same");
+    expect(pickFreshSession(root, before, "/same")).toBeNull();
+  });
+  it("refuses to guess when several are fresh and none matches the cwd", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    writeRollout(root, UUID_B, "/b");
+    expect(pickFreshSession(root, before, "/other")).toBeNull();
   });
 });
 

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -100,6 +100,17 @@ describe("pickFreshSession", () => {
     writeRollout(root, UUID_B, "/b");
     expect(pickFreshSession(root, before, "/other")).toBeNull();
   });
+  it("skips a rollout already claimed by another session", () => {
+    const before = snapshotSessions(root);
+    const a = writeRollout(root, UUID_A, "/same");
+    writeRollout(root, UUID_B, "/same");
+    expect(pickFreshSession(root, before, "/same", new Set([a]))?.id).toBe(UUID_B);
+  });
+  it("returns null when the only fresh rollout is already claimed", () => {
+    const before = snapshotSessions(root);
+    const a = writeRollout(root, UUID_A, "/a");
+    expect(pickFreshSession(root, before, null, new Set([a]))).toBeNull();
+  });
 });
 
 describe("watchForCodexSession", () => {

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, findNewRollout, discoverCodexSession } from "./codex-session.js";
+
+const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
+const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";
+
+const pad = (n: number): string => String(n).padStart(2, "0");
+const dayPath = (root: string, d: Date): string => path.join(root, String(d.getFullYear()), pad(d.getMonth() + 1), pad(d.getDate()));
+const metaLine = (id: string, cwd: string | null): string =>
+  JSON.stringify({ timestamp: "2026-07-08T00:00:00Z", type: "session_meta", payload: { id, cwd, originator: "codex-tui", source: "cli" } });
+
+function writeRollout(dir: string, id: string, cwd: string | null, extraLines: string[] = []): string {
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `rollout-2026-07-08T00-00-00-${id}.jsonl`);
+  writeFileSync(file, [metaLine(id, cwd), ...extraLines].join("\n") + "\n");
+  return file;
+}
+
+describe("parseSessionMetaLine", () => {
+  it("extracts id + cwd from a session_meta line", () => {
+    expect(parseSessionMetaLine(metaLine(UUID_A, "/work"))).toEqual({ id: UUID_A, cwd: "/work" });
+  });
+  it("returns null for a non-session_meta record", () => {
+    expect(parseSessionMetaLine(JSON.stringify({ type: "message", payload: { id: UUID_A } }))).toBeNull();
+  });
+  it("returns null for invalid JSON", () => {
+    expect(parseSessionMetaLine("not json{")).toBeNull();
+  });
+  it("returns null when the id is not a uuid", () => {
+    expect(parseSessionMetaLine(metaLine("nope", "/work"))).toBeNull();
+  });
+  it("keeps cwd null when absent", () => {
+    expect(parseSessionMetaLine(JSON.stringify({ type: "session_meta", payload: { id: UUID_A } }))).toEqual({ id: UUID_A, cwd: null });
+  });
+});
+
+describe("readSessionMeta", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("reads the meta from the first line of a multi-line rollout", () => {
+    const file = writeRollout(dayPath(root, new Date(2026, 6, 8)), UUID_A, "/work", ['{"type":"message"}', '{"type":"message"}']);
+    expect(readSessionMeta(file)).toEqual({ id: UUID_A, cwd: "/work" });
+  });
+  it("returns null for a missing file", () => {
+    expect(readSessionMeta(path.join(root, "nope.jsonl"))).toBeNull();
+  });
+});
+
+describe("snapshot / findNewRollout", () => {
+  let root: string;
+  const now = new Date(2026, 6, 8, 12, 0, 0);
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("lists rollouts under today's day dir", () => {
+    writeRollout(dayPath(root, now), UUID_A, "/work");
+    expect(listRecentRollouts(root, now)).toHaveLength(1);
+  });
+  it("finds the file that appeared after the snapshot", () => {
+    writeRollout(dayPath(root, now), UUID_A, "/work");
+    const before = snapshotSessions(root, now);
+    const fresh = writeRollout(dayPath(root, now), UUID_B, "/work");
+    expect(findNewRollout(root, before, now)).toBe(fresh);
+  });
+  it("returns null when nothing new appeared", () => {
+    writeRollout(dayPath(root, now), UUID_A, "/work");
+    const before = snapshotSessions(root, now);
+    expect(findNewRollout(root, before, now)).toBeNull();
+  });
+  it("picks the newest by mtime when several are fresh", () => {
+    const older = writeRollout(dayPath(root, now), UUID_A, "/work");
+    const newer = writeRollout(dayPath(root, now), UUID_B, "/work");
+    utimesSync(older, new Date(2026, 6, 8, 10), new Date(2026, 6, 8, 10));
+    utimesSync(newer, new Date(2026, 6, 8, 11), new Date(2026, 6, 8, 11));
+    expect(findNewRollout(root, new Set(), now)).toBe(newer);
+  });
+});
+
+describe("discoverCodexSession", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns the id of a rollout that appears after the snapshot", async () => {
+    const before = snapshotSessions(root);
+    writeRollout(dayPath(root, new Date()), UUID_A, "/work");
+    const found = await discoverCodexSession(root, before, { timeoutMs: 500, intervalMs: 10 });
+    expect(found?.id).toBe(UUID_A);
+    expect(found?.cwd).toBe("/work");
+  });
+  it("resolves null when no new session appears before the timeout", async () => {
+    const before = snapshotSessions(root);
+    const found = await discoverCodexSession(root, before, { timeoutMs: 60, intervalMs: 10 });
+    expect(found).toBeNull();
+  });
+});

--- a/server/codex-session.spec.ts
+++ b/server/codex-session.spec.ts
@@ -2,19 +2,23 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, findNewRollout, discoverCodexSession } from "./codex-session.js";
+import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "./codex-session.js";
 
 const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
 const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";
 
 const pad = (n: number): string => String(n).padStart(2, "0");
-const dayPath = (root: string, d: Date): string => path.join(root, String(d.getFullYear()), pad(d.getMonth() + 1), pad(d.getDate()));
+const todayDir = (root: string): string => {
+  const d = new Date();
+  return path.join(root, String(d.getFullYear()), pad(d.getMonth() + 1), pad(d.getDate()));
+};
 const metaLine = (id: string, cwd: string | null): string =>
-  JSON.stringify({ timestamp: "2026-07-08T00:00:00Z", type: "session_meta", payload: { id, cwd, originator: "codex-tui", source: "cli" } });
+  JSON.stringify({ timestamp: "t", type: "session_meta", payload: { id, cwd, originator: "codex-tui", source: "cli" } });
 
-function writeRollout(dir: string, id: string, cwd: string | null, extraLines: string[] = []): string {
+function writeRollout(root: string, id: string, cwd: string | null, extraLines: string[] = []): string {
+  const dir = todayDir(root);
   mkdirSync(dir, { recursive: true });
-  const file = path.join(dir, `rollout-2026-07-08T00-00-00-${id}.jsonl`);
+  const file = path.join(dir, `rollout-x-${id}.jsonl`);
   writeFileSync(file, [metaLine(id, cwd), ...extraLines].join("\n") + "\n");
   return file;
 }
@@ -37,7 +41,7 @@ describe("parseSessionMetaLine", () => {
   });
 });
 
-describe("readSessionMeta", () => {
+describe("codex-session fs helpers", () => {
   let root: string;
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
@@ -47,49 +51,19 @@ describe("readSessionMeta", () => {
   });
 
   it("reads the meta from the first line of a multi-line rollout", () => {
-    const file = writeRollout(dayPath(root, new Date(2026, 6, 8)), UUID_A, "/work", ['{"type":"message"}', '{"type":"message"}']);
+    const file = writeRollout(root, UUID_A, "/work", ['{"type":"message"}', '{"type":"message"}']);
     expect(readSessionMeta(file)).toEqual({ id: UUID_A, cwd: "/work" });
   });
-  it("returns null for a missing file", () => {
+  it("returns null reading a missing file", () => {
     expect(readSessionMeta(path.join(root, "nope.jsonl"))).toBeNull();
   });
-});
-
-describe("snapshot / findNewRollout", () => {
-  let root: string;
-  const now = new Date(2026, 6, 8, 12, 0, 0);
-  beforeEach(() => {
-    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
-  });
-  afterEach(() => {
-    rmSync(root, { recursive: true, force: true });
-  });
-
   it("lists rollouts under today's day dir", () => {
-    writeRollout(dayPath(root, now), UUID_A, "/work");
-    expect(listRecentRollouts(root, now)).toHaveLength(1);
-  });
-  it("finds the file that appeared after the snapshot", () => {
-    writeRollout(dayPath(root, now), UUID_A, "/work");
-    const before = snapshotSessions(root, now);
-    const fresh = writeRollout(dayPath(root, now), UUID_B, "/work");
-    expect(findNewRollout(root, before, now)).toBe(fresh);
-  });
-  it("returns null when nothing new appeared", () => {
-    writeRollout(dayPath(root, now), UUID_A, "/work");
-    const before = snapshotSessions(root, now);
-    expect(findNewRollout(root, before, now)).toBeNull();
-  });
-  it("picks the newest by mtime when several are fresh", () => {
-    const older = writeRollout(dayPath(root, now), UUID_A, "/work");
-    const newer = writeRollout(dayPath(root, now), UUID_B, "/work");
-    utimesSync(older, new Date(2026, 6, 8, 10), new Date(2026, 6, 8, 10));
-    utimesSync(newer, new Date(2026, 6, 8, 11), new Date(2026, 6, 8, 11));
-    expect(findNewRollout(root, new Set(), now)).toBe(newer);
+    writeRollout(root, UUID_A, "/work");
+    expect(listRecentRollouts(root)).toHaveLength(1);
   });
 });
 
-describe("discoverCodexSession", () => {
+describe("pickFreshSession", () => {
   let root: string;
   beforeEach(() => {
     root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
@@ -98,16 +72,56 @@ describe("discoverCodexSession", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it("returns the id of a rollout that appears after the snapshot", async () => {
+  it("returns null when nothing appeared after the snapshot", () => {
+    writeRollout(root, UUID_A, "/a");
     const before = snapshotSessions(root);
-    writeRollout(dayPath(root, new Date()), UUID_A, "/work");
-    const found = await discoverCodexSession(root, before, { timeoutMs: 500, intervalMs: 10 });
+    expect(pickFreshSession(root, before, null)).toBeNull();
+  });
+  it("returns the rollout that appeared after the snapshot", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    expect(pickFreshSession(root, before, null)?.id).toBe(UUID_A);
+  });
+  it("prefers the fresh rollout whose cwd matches", () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/a");
+    writeRollout(root, UUID_B, "/b");
+    expect(pickFreshSession(root, before, "/b")?.id).toBe(UUID_B);
+  });
+  it("falls back to the newest by mtime when no cwd matches", () => {
+    const before = snapshotSessions(root);
+    const older = writeRollout(root, UUID_A, "/a");
+    const newer = writeRollout(root, UUID_B, "/b");
+    utimesSync(older, new Date(2026, 0, 1, 10), new Date(2026, 0, 1, 10));
+    utimesSync(newer, new Date(2026, 0, 1, 11), new Date(2026, 0, 1, 11));
+    expect(pickFreshSession(root, before, "/other")?.id).toBe(UUID_B);
+  });
+});
+
+describe("watchForCodexSession", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves the session once its rollout is present", async () => {
+    const before = snapshotSessions(root);
+    writeRollout(root, UUID_A, "/work");
+    const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 500 });
     expect(found?.id).toBe(UUID_A);
     expect(found?.cwd).toBe("/work");
   });
-  it("resolves null when no new session appears before the timeout", async () => {
+  it("stops immediately when cancelled", async () => {
     const before = snapshotSessions(root);
-    const found = await discoverCodexSession(root, before, { timeoutMs: 60, intervalMs: 10 });
+    const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 5000, isCancelled: () => true });
+    expect(found).toBeNull();
+  });
+  it("resolves null when nothing appears before the timeout", async () => {
+    const before = snapshotSessions(root);
+    const found = await watchForCodexSession(root, before, { pollMs: 10, maxWaitMs: 40 });
     expect(found).toBeNull();
   });
 });

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -5,8 +5,8 @@ import os from "node:os";
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const DISCOVERY_TIMEOUT_MS = 5000;
-const DISCOVERY_INTERVAL_MS = 150;
+const WATCH_POLL_MS = 1000;
+const WATCH_MAX_WAIT_MS = 30 * 60 * 1000;
 
 export interface CodexSessionMeta {
   id: string;
@@ -54,7 +54,7 @@ function dayDir(root: string, when: Date): string {
 }
 
 // Only today + yesterday can hold a session spawned "now" (covers a spawn racing midnight),
-// so discovery never walks the whole history.
+// so watching never walks the whole history.
 function recentDayDirs(root: string, now: Date): string[] {
   return [dayDir(root, now), dayDir(root, new Date(now.getTime() - ONE_DAY_MS))];
 }
@@ -70,8 +70,8 @@ export function listRecentRollouts(root: string, now: Date = new Date()): string
   return recentDayDirs(root, now).flatMap(listRolloutsIn);
 }
 
-// The rollout files that exist BEFORE spawning codex; the one that appears after is
-// unambiguously this session's — no reliance on clock/mtime alignment.
+// The rollout files that exist BEFORE spawning codex; a file that appears after is this
+// session's (codex only persists its rollout after the first user turn, so this can be minutes).
 export function snapshotSessions(root: string, now: Date = new Date()): Set<string> {
   return new Set(listRecentRollouts(root, now));
 }
@@ -84,34 +84,41 @@ function mtimeMs(file: string): number {
   }
 }
 
-export function findNewRollout(root: string, before: Set<string>, now: Date = new Date()): string | null {
-  const fresh = listRecentRollouts(root, now).filter((file) => !before.has(file));
-  if (fresh.length === 0) return null;
-  return fresh.reduce((newest, file) => (mtimeMs(file) > mtimeMs(newest) ? file : newest));
+interface RolloutMeta extends CodexSessionMeta {
+  file: string;
+}
+
+// The freshest rollout that appeared since the snapshot. `cwd` disambiguates concurrent sessions
+// best-effort (a rollout records the dir codex ran in); otherwise the newest wins.
+export function pickFreshSession(root: string, before: Set<string>, cwd: string | null): RolloutMeta | null {
+  const found = listRecentRollouts(root)
+    .filter((file) => !before.has(file))
+    .map((file) => ({ file, meta: readSessionMeta(file) }))
+    .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
+  if (found.length === 0) return null;
+  const byCwd = cwd ? found.find((x) => x.meta.cwd === cwd) : undefined;
+  const chosen = byCwd ?? found.reduce((a, b) => (mtimeMs(b.file) > mtimeMs(a.file) ? b : a));
+  return { ...chosen.meta, file: chosen.file };
 }
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-// Poll for the rollout codex creates at startup, then read its minted id. Keeps polling past a
-// half-written first line (the file can appear before its JSON is flushed). Null on timeout —
-// e.g. codex failed to launch.
-export async function discoverCodexSession(
+// codex persists a session's rollout only AFTER its first user turn (like claude's transcript),
+// so we watch for the whole session — not just at spawn — until the rollout appears, then read
+// its minted id. Stops early when the session is gone (isCancelled) so it can't outlive the pty.
+export async function watchForCodexSession(
   root: string,
   before: Set<string>,
-  opts: { timeoutMs?: number; intervalMs?: number } = {},
-): Promise<(CodexSessionMeta & { file: string }) | null> {
-  const timeoutMs = opts.timeoutMs ?? DISCOVERY_TIMEOUT_MS;
-  const intervalMs = opts.intervalMs ?? DISCOVERY_INTERVAL_MS;
-  const deadline = Date.now() + timeoutMs;
-  const attempt = (): (CodexSessionMeta & { file: string }) | null => {
-    const file = findNewRollout(root, before);
-    const meta = file ? readSessionMeta(file) : null;
-    return meta && file ? { ...meta, file } : null;
-  };
-  let result = attempt();
-  while (!result && Date.now() < deadline) {
-    await delay(intervalMs);
-    result = attempt();
+  opts: { cwd?: string | null; pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean } = {},
+): Promise<RolloutMeta | null> {
+  const pollMs = opts.pollMs ?? WATCH_POLL_MS;
+  const deadline = Date.now() + (opts.maxWaitMs ?? WATCH_MAX_WAIT_MS);
+  const isCancelled = opts.isCancelled ?? (() => false);
+  const cwd = opts.cwd ?? null;
+  let result = pickFreshSession(root, before, cwd);
+  while (!result && Date.now() < deadline && !isCancelled()) {
+    await delay(pollMs);
+    result = pickFreshSession(root, before, cwd);
   }
   return result;
 }

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
@@ -76,29 +76,24 @@ export function snapshotSessions(root: string, now: Date = new Date()): Set<stri
   return new Set(listRecentRollouts(root, now));
 }
 
-function mtimeMs(file: string): number {
-  try {
-    return statSync(file).mtimeMs;
-  } catch {
-    return 0;
-  }
-}
-
 interface RolloutMeta extends CodexSessionMeta {
   file: string;
 }
 
-// The freshest rollout that appeared since the snapshot. `cwd` disambiguates concurrent sessions
-// best-effort (a rollout records the dir codex ran in); otherwise the newest wins.
+// A rollout that appeared since the snapshot, attributed to this session ONLY when unambiguous:
+// exactly one appeared, or exactly one of several matches this session's cwd. Otherwise refuse to
+// guess (return null) — a wrong guess would let a cold resume reopen a *different* concurrent
+// codex conversation. A "newest wins" tiebreak would be exactly that wrong guess, so there isn't
+// one; a session that can't be attributed just stays unresumable-by-id (cold reconnect starts fresh).
 export function pickFreshSession(root: string, before: Set<string>, cwd: string | null): RolloutMeta | null {
   const found = listRecentRollouts(root)
     .filter((file) => !before.has(file))
     .map((file) => ({ file, meta: readSessionMeta(file) }))
     .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
-  if (found.length === 0) return null;
-  const byCwd = cwd ? found.find((x) => x.meta.cwd === cwd) : undefined;
-  const chosen = byCwd ?? found.reduce((a, b) => (mtimeMs(b.file) > mtimeMs(a.file) ? b : a));
-  return { ...chosen.meta, file: chosen.file };
+  if (found.length === 1) return { ...found[0].meta, file: found[0].file };
+  const matches = cwd ? found.filter((x) => x.meta.cwd === cwd) : [];
+  if (matches.length === 1) return { ...matches[0].meta, file: matches[0].file };
+  return null;
 }
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -85,9 +85,11 @@ interface RolloutMeta extends CodexSessionMeta {
 // guess (return null) — a wrong guess would let a cold resume reopen a *different* concurrent
 // codex conversation. A "newest wins" tiebreak would be exactly that wrong guess, so there isn't
 // one; a session that can't be attributed just stays unresumable-by-id (cold reconnect starts fresh).
-export function pickFreshSession(root: string, before: Set<string>, cwd: string | null): RolloutMeta | null {
+// `claimed` holds rollouts already mapped to another session, so a single rollout is never
+// attributed to two keys (which would resume one conversation from both).
+export function pickFreshSession(root: string, before: Set<string>, cwd: string | null, claimed?: Set<string>): RolloutMeta | null {
   const found = listRecentRollouts(root)
-    .filter((file) => !before.has(file))
+    .filter((file) => !before.has(file) && !claimed?.has(file))
     .map((file) => ({ file, meta: readSessionMeta(file) }))
     .filter((x): x is { file: string; meta: CodexSessionMeta } => x.meta !== null);
   if (found.length === 1) return { ...found[0].meta, file: found[0].file };
@@ -104,16 +106,16 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 export async function watchForCodexSession(
   root: string,
   before: Set<string>,
-  opts: { cwd?: string | null; pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean } = {},
+  opts: { cwd?: string | null; pollMs?: number; maxWaitMs?: number; isCancelled?: () => boolean; claimed?: Set<string> } = {},
 ): Promise<RolloutMeta | null> {
   const pollMs = opts.pollMs ?? WATCH_POLL_MS;
   const deadline = Date.now() + (opts.maxWaitMs ?? WATCH_MAX_WAIT_MS);
   const isCancelled = opts.isCancelled ?? (() => false);
   const cwd = opts.cwd ?? null;
-  let result = pickFreshSession(root, before, cwd);
+  let result = pickFreshSession(root, before, cwd, opts.claimed);
   while (!result && Date.now() < deadline && !isCancelled()) {
     await delay(pollMs);
-    result = pickFreshSession(root, before, cwd);
+    result = pickFreshSession(root, before, cwd, opts.claimed);
   }
   return result;
 }

--- a/server/codex-session.ts
+++ b/server/codex-session.ts
@@ -1,0 +1,117 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const DISCOVERY_TIMEOUT_MS = 5000;
+const DISCOVERY_INTERVAL_MS = 150;
+
+export interface CodexSessionMeta {
+  id: string;
+  cwd: string | null;
+}
+
+// codex writes rollout transcripts under $CODEX_HOME/sessions/YYYY/MM/DD/. CODEX_HOME mirrors
+// codex's own env, so a container/config relocation is honored (see the Docker plan).
+export function codexSessionsRoot(): string {
+  const home = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+  return path.join(home, "sessions");
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+// The first line of every rollout is a `session_meta` record carrying the id codex minted for
+// itself (mulmoterminal can't force one) and the cwd it resolved.
+export function parseSessionMetaLine(line: string): CodexSessionMeta | null {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!isRecord(doc) || doc.type !== "session_meta" || !isRecord(doc.payload)) return null;
+  const { id, cwd } = doc.payload;
+  if (typeof id !== "string" || !UUID_RE.test(id)) return null;
+  return { id, cwd: typeof cwd === "string" ? cwd : null };
+}
+
+export function readSessionMeta(rolloutFile: string): CodexSessionMeta | null {
+  try {
+    const content = readFileSync(rolloutFile, "utf8");
+    const newline = content.indexOf("\n");
+    return parseSessionMetaLine(newline === -1 ? content : content.slice(0, newline));
+  } catch {
+    return null;
+  }
+}
+
+function dayDir(root: string, when: Date): string {
+  const month = String(when.getMonth() + 1).padStart(2, "0");
+  const day = String(when.getDate()).padStart(2, "0");
+  return path.join(root, String(when.getFullYear()), month, day);
+}
+
+// Only today + yesterday can hold a session spawned "now" (covers a spawn racing midnight),
+// so discovery never walks the whole history.
+function recentDayDirs(root: string, now: Date): string[] {
+  return [dayDir(root, now), dayDir(root, new Date(now.getTime() - ONE_DAY_MS))];
+}
+
+function listRolloutsIn(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => ROLLOUT_RE.test(name))
+    .map((name) => path.join(dir, name));
+}
+
+export function listRecentRollouts(root: string, now: Date = new Date()): string[] {
+  return recentDayDirs(root, now).flatMap(listRolloutsIn);
+}
+
+// The rollout files that exist BEFORE spawning codex; the one that appears after is
+// unambiguously this session's — no reliance on clock/mtime alignment.
+export function snapshotSessions(root: string, now: Date = new Date()): Set<string> {
+  return new Set(listRecentRollouts(root, now));
+}
+
+function mtimeMs(file: string): number {
+  try {
+    return statSync(file).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+export function findNewRollout(root: string, before: Set<string>, now: Date = new Date()): string | null {
+  const fresh = listRecentRollouts(root, now).filter((file) => !before.has(file));
+  if (fresh.length === 0) return null;
+  return fresh.reduce((newest, file) => (mtimeMs(file) > mtimeMs(newest) ? file : newest));
+}
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Poll for the rollout codex creates at startup, then read its minted id. Keeps polling past a
+// half-written first line (the file can appear before its JSON is flushed). Null on timeout —
+// e.g. codex failed to launch.
+export async function discoverCodexSession(
+  root: string,
+  before: Set<string>,
+  opts: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<(CodexSessionMeta & { file: string }) | null> {
+  const timeoutMs = opts.timeoutMs ?? DISCOVERY_TIMEOUT_MS;
+  const intervalMs = opts.intervalMs ?? DISCOVERY_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+  const attempt = (): (CodexSessionMeta & { file: string }) | null => {
+    const file = findNewRollout(root, before);
+    const meta = file ? readSessionMeta(file) : null;
+    return meta && file ? { ...meta, file } : null;
+  };
+  let result = attempt();
+  while (!result && Date.now() < deadline) {
+    await delay(intervalMs);
+    result = attempt();
+  }
+  return result;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -37,6 +37,9 @@ import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { claudeAdapter } from "./agents/claude.js";
+import { codexAdapter } from "./agents/codex.js";
+import { buildCodexArgs } from "./codex-args.js";
+import { codexSessionsRoot, snapshotSessions, discoverCodexSession } from "./codex-session.js";
 import {
   isRecord,
   parseJsonl,
@@ -152,6 +155,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.PORT || 34567;
 const CLAUDE_BIN = claudeAdapter.bin();
+const CODEX_BIN = codexAdapter.bin();
+// Model override for codex sessions (--model); null uses codex's own configured default.
+const CODEX_MODEL = process.env.CODEX_MODEL || null;
 // Permission mode for backend-spawned Claude sessions. Defaults to "auto" so
 // the backend runs hands-off; override with CLAUDE_PERMISSION_MODE (e.g.
 // "default" / "acceptEdits" / "bypassPermissions" / "plan") when needed.
@@ -438,6 +444,10 @@ const LAST_PROMPT_CAP = 200;
 // is reaped once the session goes idle (Stop hook) or the process exits. `ws`
 // is null while the session runs in the background.
 const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
+
+// mulmoterminal session key -> the codex rollout id it maps to. codex mints its own id, so we
+// discover it after spawn and keep it here to `codex resume <id>` once the live PTY is gone.
+const codexRolloutIds = new Map<string, string>();
 
 // New sessions started in this process that have no .jsonl on disk yet (Claude
 // only writes the file on the first prompt). Merged into /api/sessions so a
@@ -1392,10 +1402,14 @@ const runWss = new WebSocketServer({ noServer: true });
 // too. Unlike /ws/run these are PERSISTENT & reattachable (they share the /ws session
 // lifecycle — ptys map, reattach, reap grace) but carry no Claude hooks/transcript.
 const runLaunchWss = new WebSocketServer({ noServer: true });
+// First-class codex sessions — persistent + reattachable like /ws/launch, but running codex
+// with session discovery + resume. Its own endpoint so /ws stays claude-only.
+const runCodexWss = new WebSocketServer({ noServer: true });
 function wssForPath(pathname: string): WebSocketServer | null {
   if (pathname === "/ws") return wss;
   if (pathname === "/ws/run") return runWss;
   if (pathname === "/ws/launch") return runLaunchWss;
+  if (pathname === "/ws/codex") return runCodexWss;
   return null; // e.g. /ws/pubsub — left to socket.io's own upgrade handler
 }
 server.on("upgrade", (req, socket, head) => {
@@ -2045,6 +2059,90 @@ runLaunchWss.on("connection", (ws, req) => {
   } catch (err) {
     console.error(`[ws/launch] failed to start ${sessionId}: ${messageOf(err)}`);
     return closeWithError(ws, "Failed to start the launch command.");
+  }
+
+  ws.on("message", (raw) => handleClientFrame(entry, ws, raw, sessionId));
+  ws.on("close", () => handleClientClose(entry, ws, sessionId));
+});
+
+// codex is a first-class agent like claude, but it mints its own session id (no --session-id),
+// so the browser-facing id is a mulmoterminal-minted key; we discover codex's real rollout id
+// after spawn and resume it with `codex resume <id>` once the live PTY is gone. Reattach a live
+// pty / surviving tmux session (running codex picked up, no resume); else cold-resume a known
+// rollout id; else a fresh session (a new minted key).
+function resolveCodexSession(requested: string | null): { sessionId: string; live: PtyEntry | undefined; resumeRolloutId: string | null } {
+  const reattachId = requested && ptys.has(requested) ? requested : null;
+  const live = reattachId ? ptys.get(reattachId) : undefined;
+  const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
+  const resumeRolloutId = !live && !tmuxAlive && requested ? (codexRolloutIds.get(requested) ?? null) : null;
+  const sessionId = reattachId ?? ((tmuxAlive || resumeRolloutId) && requested ? requested : randomUUID());
+  return { sessionId, live, resumeRolloutId };
+}
+
+function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
+  entry.term.onData((data) => {
+    entry.buffer = (entry.buffer + data).slice(-OUTPUT_BUFFER_LIMIT);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) entry.ws.send(JSON.stringify({ type: "output", data }));
+  });
+  entry.term.onExit(({ exitCode, signal }) => {
+    console.log(`[pty] codex exited code=${exitCode} signal=${signal}`);
+    if (entry.ws && entry.ws.readyState === entry.ws.OPEN) {
+      entry.ws.send(JSON.stringify({ type: "exit", exitCode, signal }));
+      entry.ws.close();
+    }
+    reap(sessionId);
+  });
+}
+
+// codex writes its rollout (with the minted id) at startup; capture it best-effort so a later
+// cold reconnect can `codex resume <id>`. A fork on resume overwrites the mapping with the new id.
+function rememberCodexRollout(sessionId: string, root: string, before: Set<string>): void {
+  discoverCodexSession(root, before)
+    .then((meta) => {
+      if (meta) codexRolloutIds.set(sessionId, meta.id);
+    })
+    .catch(() => {});
+}
+
+function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string | null, cwd: string): PtyEntry {
+  const root = codexSessionsRoot();
+  const before = snapshotSessions(root);
+  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL });
+  const { term, tmux } = ptySpawn(sessionId, CODEX_BIN, args, cwd, true);
+  const via = tmux ? " via tmux" : "";
+  const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";
+  console.log(`[pty] spawned codex (pid=${term.pid}${via}) in ${cwd}${resumeNote}`);
+  const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux };
+  ptys.set(sessionId, entry);
+  if (resumeRolloutId) codexRolloutIds.set(sessionId, resumeRolloutId);
+  rememberCodexRollout(sessionId, root, before);
+  wireCodexRelay(entry, sessionId);
+  return entry;
+}
+
+function startCodexEntry(sessionId: string, ws: WebSocket, live: PtyEntry | undefined, resumeRolloutId: string | null, cwd: string): PtyEntry {
+  if (live) return reattachPty(live, ws, sessionId);
+  return spawnCodexPty(sessionId, ws, resumeRolloutId, cwd);
+}
+
+// codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume): a first-class codex session,
+// persistent + reattachable, marked a dev terminal so it stays out of the claude chat sidebar.
+runCodexWss.on("connection", (ws, req) => {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const raw = url.searchParams.get("session");
+  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
+  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+
+  const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
+  markDevTerminalSession(sessionId);
+  ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
+
+  let entry: PtyEntry;
+  try {
+    entry = startCodexEntry(sessionId, ws, live, resumeRolloutId, cwd);
+  } catch (err) {
+    console.error(`[ws/codex] failed to start ${sessionId}: ${messageOf(err)}`);
+    return closeWithError(ws, "Failed to start codex. Is the `codex` CLI installed and on your PATH?");
   }
 
   ws.on("message", (raw) => handleClientFrame(entry, ws, raw, sessionId));

--- a/server/index.ts
+++ b/server/index.ts
@@ -40,6 +40,7 @@ import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./codex-session.js";
+import { stripTerminalQueries } from "./terminal-replay.js";
 import {
   isRecord,
   parseJsonl,
@@ -1443,7 +1444,9 @@ function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntr
   }
   entry.ws = ws;
   if (entry.buffer && ws.readyState === ws.OPEN) {
-    ws.send(JSON.stringify({ type: "output", data: entry.buffer }));
+    // Strip terminal queries from the replay so xterm doesn't re-answer them as stray input
+    // (e.g. a DA reply surfacing as "0;276;0c" in the prompt) — see terminal-replay.ts.
+    ws.send(JSON.stringify({ type: "output", data: stripTerminalQueries(entry.buffer) }));
   }
   return entry;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -449,6 +449,9 @@ const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
 // mulmoterminal session key -> the codex rollout id it maps to. codex mints its own id, so we
 // discover it after spawn and keep it here to `codex resume <id>` once the live PTY is gone.
 const codexRolloutIds = new Map<string, string>();
+// Rollout files already attributed to a session, so a single rollout is never mapped to two keys
+// (which would let both cold-resume the same conversation). Serialized by the single event loop.
+const claimedCodexRollouts = new Set<string>();
 
 // New sessions started in this process that have no .jsonl on disk yet (Claude
 // only writes the file on the first prompt). Merged into /api/sessions so a
@@ -2101,9 +2104,11 @@ function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
 // (stop once its pty is gone) and capture the minted id so a later cold reconnect can
 // `codex resume <id>`. Attribution is unambiguous-only (see pickFreshSession).
 function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
-  watchForCodexSession(root, before, { cwd, isCancelled: () => !ptys.has(sessionId) })
+  watchForCodexSession(root, before, { cwd, claimed: claimedCodexRollouts, isCancelled: () => !ptys.has(sessionId) })
     .then((meta) => {
-      if (meta) codexRolloutIds.set(sessionId, meta.id);
+      if (!meta) return;
+      claimedCodexRollouts.add(meta.file);
+      codexRolloutIds.set(sessionId, meta.id);
     })
     .catch(() => {});
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2097,9 +2097,9 @@ function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
   });
 }
 
-// codex persists its rollout only after the first user turn, so watch for the session's lifetime
+// codex persists its rollout only after the first user turn, so watch a FRESH session's lifetime
 // (stop once its pty is gone) and capture the minted id so a later cold reconnect can
-// `codex resume <id>`. cwd disambiguates concurrent sessions best-effort.
+// `codex resume <id>`. Attribution is unambiguous-only (see pickFreshSession).
 function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
   watchForCodexSession(root, before, { cwd, isCancelled: () => !ptys.has(sessionId) })
     .then((meta) => {
@@ -2118,8 +2118,13 @@ function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string
   console.log(`[pty] spawned codex (pid=${term.pid}${via}) in ${cwd}${resumeNote}`);
   const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux };
   ptys.set(sessionId, entry);
-  if (resumeRolloutId) codexRolloutIds.set(sessionId, resumeRolloutId);
-  rememberCodexRollout(sessionId, root, before, cwd);
+  if (resumeRolloutId) {
+    codexRolloutIds.set(sessionId, resumeRolloutId);
+  } else {
+    // Discover the id only for a FRESH session. On resume we already know it; running the watcher
+    // could overwrite the known id with a mis-attributed concurrent rollout.
+    rememberCodexRollout(sessionId, root, before, cwd);
+  }
   wireCodexRelay(entry, sessionId);
   return entry;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -39,7 +39,7 @@ import { buildClaudeArgs } from "./claude-args.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
-import { codexSessionsRoot, snapshotSessions, discoverCodexSession } from "./codex-session.js";
+import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./codex-session.js";
 import {
   isRecord,
   parseJsonl,
@@ -2094,10 +2094,11 @@ function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
   });
 }
 
-// codex writes its rollout (with the minted id) at startup; capture it best-effort so a later
-// cold reconnect can `codex resume <id>`. A fork on resume overwrites the mapping with the new id.
-function rememberCodexRollout(sessionId: string, root: string, before: Set<string>): void {
-  discoverCodexSession(root, before)
+// codex persists its rollout only after the first user turn, so watch for the session's lifetime
+// (stop once its pty is gone) and capture the minted id so a later cold reconnect can
+// `codex resume <id>`. cwd disambiguates concurrent sessions best-effort.
+function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
+  watchForCodexSession(root, before, { cwd, isCancelled: () => !ptys.has(sessionId) })
     .then((meta) => {
       if (meta) codexRolloutIds.set(sessionId, meta.id);
     })
@@ -2115,7 +2116,7 @@ function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string
   const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux };
   ptys.set(sessionId, entry);
   if (resumeRolloutId) codexRolloutIds.set(sessionId, resumeRolloutId);
-  rememberCodexRollout(sessionId, root, before);
+  rememberCodexRollout(sessionId, root, before, cwd);
   wireCodexRelay(entry, sessionId);
   return entry;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
+import { claudeAdapter } from "./agents/claude.js";
 import {
   isRecord,
   parseJsonl,
@@ -150,7 +151,7 @@ const messageOf = (e: unknown): string => (e instanceof Error ? e.message : Stri
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const PORT = process.env.PORT || 34567;
-const CLAUDE_BIN = process.env.CLAUDE_BIN || "claude";
+const CLAUDE_BIN = claudeAdapter.bin();
 // Permission mode for backend-spawned Claude sessions. Defaults to "auto" so
 // the backend runs hands-off; override with CLAUDE_PERMISSION_MODE (e.g.
 // "default" / "acceptEdits" / "bypassPermissions" / "plan") when needed.
@@ -1518,7 +1519,7 @@ async function translateViaHiddenChat(targetLanguage: string, sentences: readonl
 // typed `draft`; too early and the bytes are echoed into the scrollback instead. We
 // wait for its status line to paint (the "shift+tab to cycle" mode hint), settle
 // briefly, then type. A fallback fires if that marker never shows (UI string drift).
-const DRAFT_READY_MARKER = /shift\+tab to cycle/;
+const DRAFT_READY_MARKER = claudeAdapter.draftReadyMarker;
 const DRAFT_SETTLE_MS = 250;
 const DRAFT_FALLBACK_MS = 6000;
 // Claude's TUI commits a bracketed paste to its input box asynchronously; a CR glued

--- a/server/terminal-replay.spec.ts
+++ b/server/terminal-replay.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { stripTerminalQueries } from "./terminal-replay.js";
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+describe("stripTerminalQueries", () => {
+  it("removes a Device Attributes query embedded in output (the 0;276;0c symptom source)", () => {
+    expect(stripTerminalQueries(`abc${ESC}[>c def`)).toBe("abc def");
+    expect(stripTerminalQueries(`${ESC}[c`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[>0c`)).toBe("");
+  });
+
+  it("removes device/cursor status queries", () => {
+    expect(stripTerminalQueries(`${ESC}[6n`)).toBe("");
+    expect(stripTerminalQueries(`x${ESC}[5ny`)).toBe("xy");
+    expect(stripTerminalQueries(`${ESC}[?6n`)).toBe("");
+  });
+
+  it("removes kitty-keyboard and XTVERSION queries", () => {
+    expect(stripTerminalQueries(`${ESC}[?u`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[>q`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}[>0q`)).toBe("");
+  });
+
+  it("removes OSC color queries (BEL- or ST-terminated)", () => {
+    expect(stripTerminalQueries(`${ESC}]10;?${BEL}`)).toBe("");
+    expect(stripTerminalQueries(`${ESC}]11;?${ESC}\\`)).toBe("");
+  });
+
+  it("does NOT strip a DA RESPONSE (multi-param) — only queries", () => {
+    const response = `${ESC}[>0;276;0c`;
+    expect(stripTerminalQueries(response)).toBe(response);
+  });
+
+  it("leaves visible text and SGR colour sequences untouched", () => {
+    const styled = `${ESC}[31mhello${ESC}[0m world`;
+    expect(stripTerminalQueries(styled)).toBe(styled);
+    expect(stripTerminalQueries("plain text")).toBe("plain text");
+  });
+});

--- a/server/terminal-replay.ts
+++ b/server/terminal-replay.ts
@@ -1,0 +1,24 @@
+// Terminal "query" control sequences an application writes to probe the emulator — Device
+// Attributes, device/cursor status, OSC color, kitty-keyboard flags, XTVERSION. The emulator
+// auto-REPLIES to each. That's correct live, but when we replay a reattached session's buffered
+// output, xterm re-answers the queries baked into it and the stale replies are sent back as
+// INPUT, surfacing as junk like "0;276;0c" in the app's prompt (codex writes several at startup).
+// Strip them from the replay only: they render nothing, so the visual restore is unchanged, and
+// the app re-queries live if it still needs to.
+//
+// Built via new RegExp so the ESC/BEL control chars stay out of the regex source (satisfies
+// no-control-regex without a disable).
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+const QUERY_PATTERNS: RegExp[] = [
+  new RegExp(ESC + "\\[[>=]?\\d*c", "g"), // Device Attributes (DA1/DA2/DA3) — the "…c" symptom
+  new RegExp(ESC + "\\[\\??\\d*n", "g"), // device / cursor status report (DSR / CPR)
+  new RegExp(ESC + "\\[\\?u", "g"), // kitty keyboard flags query
+  new RegExp(ESC + "\\[>\\d*q", "g"), // XTVERSION
+  new RegExp(ESC + "\\]1[012];\\?(?:" + BEL + "|" + ESC + "\\\\)", "g"), // OSC 10/11/12 fg/bg/cursor color query
+];
+
+export function stripTerminalQueries(data: string): string {
+  return QUERY_PATTERNS.reduce((out, re) => out.replace(re, ""), data);
+}

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -8,6 +8,7 @@ import {
   addCell,
   setSession,
   setCwd,
+  setCellAgent,
   closeCell,
   toggleExpand,
   switchPage,
@@ -107,6 +108,7 @@ function onAddTerminal() {
 }
 const onSession = (uid: number, id: string) => (state.value = setSession(state.value, uid, id));
 const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, uid, cwd));
+const onAgent = (uid: number, agent: "claude" | "codex") => (state.value = setCellAgent(state.value, uid, agent));
 const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: { index: number; label: string; cwd: string | null }) => (state.value = runCommand(state.value, uid, command));
@@ -180,6 +182,7 @@ function closeSettings() {
       :reorderable="reorderable"
       :open-session-ids="openSessionIds"
       @session="onSession"
+      @agent="onAgent"
       @cwd="onCwd"
       @record-cwd="recordPreset"
       @remove-preset="removePreset"

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -34,6 +34,8 @@ const props = defineProps<{
   // A configured launcher (shell/codex/command) — persistent & reattachable, connects
   // to /ws/launch instead of resuming a Claude session.
   launcher?: { index: number } | null;
+  // A first-class codex session — connects to /ws/codex instead of /ws (Claude).
+  codex?: boolean;
   runMenu?: boolean;
   persistKey?: string | null;
   // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
@@ -62,6 +64,7 @@ function currentTarget(): conn.ConnTarget {
     devTerminal: !!props.devTerminal,
     command: props.command ?? null,
     launcher: props.launcher ?? null,
+    codex: !!props.codex,
   };
 }
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -23,6 +23,9 @@ const props = defineProps<{
   expanded: boolean;
   initialSessionId: string | null;
   initialCwd: string | null;
+  // The persisted agent for this cell: "codex" reconnects via /ws/codex on reload; absent
+  // (or "claude") resumes as a normal Claude session.
+  initialAgent?: "codex" | null;
   defaultCwd: string | null;
   presets: CwdPreset[];
   // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
@@ -50,12 +53,17 @@ const emit = defineEmits<{
   (e: "move", dir: -1 | 1): void;
   // Report live activity up so the grid can attention-sort in auto mode.
   (e: "status", value: CellStatus): void;
+  // The agent chosen (Claude/Codex) for this fresh launch, so the grid persists it.
+  (e: "agent", value: "claude" | "codex"): void;
 }>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
 // starts empty and lazy-launches when the user picks a dir and clicks Start.
 const launched = ref(props.initialSessionId !== null);
 const sessionId = ref<string | null>(props.initialSessionId);
+// The agent this cell runs (Claude by default). Fixed once launched; restored from the
+// persisted cell on reload so a codex cell reconnects to /ws/codex.
+const agent = ref<"claude" | "codex">(props.initialAgent === "codex" ? "codex" : "claude");
 const connectKey = ref(0);
 
 // The directory this terminal runs in (shown in the header, sent to the server).
@@ -183,6 +191,7 @@ function launchIn(dir: string | null) {
   sessionId.value = null; // new session — the server generates the id
   connectKey.value++;
   launched.value = true;
+  emit("agent", agent.value); // let the grid persist which agent this cell launched
   recordNextCwd = true;
   loadDiff(); // no-op for a non-worktree dir
 }
@@ -810,6 +819,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :session-id="sessionId"
         :connect-key="connectKey"
         :cwd="cwd"
+        :codex="agent === 'codex'"
         :dir-theme="dirConfig.theme"
         :dir-colors="dirConfig.colors"
         dev-terminal
@@ -915,6 +925,28 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             ✕
           </button>
         </span>
+      </div>
+      <div class="cell-agent" role="radiogroup" aria-label="Agent">
+        <button
+          type="button"
+          class="cell-agent-btn"
+          :class="{ active: agent === 'claude' }"
+          role="radio"
+          :aria-checked="agent === 'claude'"
+          @click="agent = 'claude'"
+        >
+          Claude
+        </button>
+        <button
+          type="button"
+          class="cell-agent-btn"
+          :class="{ active: agent === 'codex' }"
+          role="radio"
+          :aria-checked="agent === 'codex'"
+          @click="agent = 'codex'"
+        >
+          Codex
+        </button>
       </div>
       <label class="cell-launch-label">
         <span class="cell-launch-caption">Working directory</span>
@@ -1330,6 +1362,34 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   color: var(--text-dim);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+
+.cell-agent {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-deep);
+  align-self: flex-start;
+}
+.cell-agent-btn {
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 14px;
+  border-radius: 5px;
+}
+.cell-agent-btn:hover {
+  color: var(--text);
+}
+.cell-agent-btn.active {
+  background: var(--bg-elevated);
+  color: var(--text);
 }
 .cell-dir-input {
   width: 100%;

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -36,6 +36,7 @@ const emit = defineEmits<{
   (e: "launch", uid: number, pick: LaunchPick): void;
   (e: "move", uid: number, dir: -1 | 1): void;
   (e: "status", uid: number, value: CellStatus): void;
+  (e: "agent", uid: number, value: "claude" | "codex"): void;
   // Shared preset list events — uid-less since they mutate the one config list.
   (e: "record-cwd" | "remove-preset", value: string): void;
 }>();
@@ -87,6 +88,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :expanded="cell.uid === expandedUid"
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"
+          :initial-agent="cell.agent"
           :default-cwd="defaultCwd"
           :presets="presets"
           :launchers="launchers"
@@ -96,6 +98,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @session="(id) => emit('session', cell.uid, id)"
+          @agent="(a) => emit('agent', cell.uid, a)"
           @cwd="(c) => emit('cwd', cell.uid, c)"
           @record-cwd="(c) => emit('record-cwd', c)"
           @remove-preset="(path) => emit('remove-preset', path)"

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -20,6 +20,8 @@ export interface Cell {
   command?: { index: number; label: string; cwd: string | null } | null;
   // A running launcher (shell/codex/custom). Persistent & reattachable like a session.
   launcher?: CellLauncher | null;
+  // The agent this cell runs. "codex" reconnects via /ws/codex; absent = Claude (the default).
+  agent?: "codex";
 }
 // How the grid orders its cells. "manual": the user's hand-arranged order (◀▶);
 // "auto": attention-first, recomputed from each cell's live status.
@@ -96,6 +98,13 @@ export function setSession(state: GridState, uid: number, id: string | null): Gr
 
 export function setCwd(state: GridState, uid: number, cwd: string): GridState {
   return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, cwd } : c)) };
+}
+
+// Record which agent a cell launched (only "codex" is stored; Claude is the default/absent) so a
+// reloaded cell reconnects to the right endpoint.
+export function setCellAgent(state: GridState, uid: number, agent: "claude" | "codex"): GridState {
+  const codex: "codex" | undefined = agent === "codex" ? "codex" : undefined;
+  return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, agent: codex } : c)) };
 }
 
 // A cell's launcher ran a script.json command: attach it, turning the launch cell
@@ -245,7 +254,13 @@ export function parseGridState(raw: string | null): GridState | null {
       .filter(isCell)
       .filter((c: Cell) => c.session !== null)
       .slice(0, MAX_TERMINALS);
-    const cells: Cell[] = running.map((c: Cell, i: number) => ({ uid: i, session: c.session, cwd: c.cwd, launcher: asLauncher(c.launcher) }));
+    const cells: Cell[] = running.map((c: Cell, i: number) => ({
+      uid: i,
+      session: c.session,
+      cwd: c.cwd,
+      launcher: asLauncher(c.launcher),
+      agent: c.agent === "codex" ? "codex" : undefined,
+    }));
     const expandedIdx = running.findIndex((c: Cell) => c.uid === parsed.expanded);
     const expanded = typeof parsed.expanded === "number" && expandedIdx >= 0 ? expandedIdx : null;
     const page = Number.isSafeInteger(parsed.page) && parsed.page >= 0 ? parsed.page : 0;

--- a/src/components/wsUrl.spec.ts
+++ b/src/components/wsUrl.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl } from "./wsUrl";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } from "./wsUrl";
 
 describe("buildTerminalWsUrl", () => {
   it("single view: session only, no gui=0", () => {
@@ -71,5 +71,24 @@ describe("buildLaunchWsUrl", () => {
   it("uses wss when secure", () => {
     const url = buildLaunchWsUrl({ host: "h", secure: true, sessionId: null, launcher: 1 });
     expect(url.startsWith("wss://")).toBe(true);
+  });
+});
+
+describe("buildCodexWsUrl", () => {
+  it("targets /ws/codex with the reattach session + cwd", () => {
+    const u = new URL(buildCodexWsUrl({ host: "h", secure: false, sessionId: "abc", cwd: "/work/proj" }));
+    expect(u.pathname).toBe("/ws/codex");
+    expect(u.searchParams.get("session")).toBe("abc");
+    expect(u.searchParams.get("cwd")).toBe("/work/proj");
+  });
+
+  it("fresh codex (null id): no session param", () => {
+    const u = new URL(buildCodexWsUrl({ host: "h", secure: false, sessionId: null }));
+    expect(u.pathname).toBe("/ws/codex");
+    expect(u.searchParams.has("session")).toBe(false);
+  });
+
+  it("uses wss when secure", () => {
+    expect(buildCodexWsUrl({ host: "h", secure: true, sessionId: null }).startsWith("wss://")).toBe(true);
   });
 });

--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -58,3 +58,23 @@ export function buildLaunchWsUrl({ host, secure, sessionId, cwd, launcher }: Lau
   const proto = secure ? "wss:" : "ws:";
   return `${proto}//${host}/ws/launch?${params.toString()}`;
 }
+
+export interface CodexWsUrlInput {
+  host: string;
+  secure: boolean;
+  sessionId: string | null; // reattach/resume this codex session; null => fresh
+  cwd?: string | null;
+}
+
+// The codex-terminal endpoint (a first-class codex session). Persistent & reattachable like
+// /ws; the browser sends the mulmoterminal session id to reattach/resume — the server maps it
+// to codex's own rollout id.
+export function buildCodexWsUrl({ host, secure, sessionId, cwd }: CodexWsUrlInput): string {
+  const params = new URLSearchParams();
+  if (sessionId) params.set("session", sessionId);
+  if (cwd) params.set("cwd", cwd);
+  const qs = params.toString();
+  const suffix = qs ? `?${qs}` : "";
+  const proto = secure ? "wss:" : "ws:";
+  return `${proto}//${host}/ws/codex${suffix}`;
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -20,7 +20,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard";
 import "@xterm/xterm/css/xterm.css";
-import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl } from "../components/wsUrl";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } from "../components/wsUrl";
 
 export type ConnStatus = "connecting" | "connected" | "disconnected";
 
@@ -34,6 +34,9 @@ export interface ConnTarget {
   // A configured launcher (shell/codex/command). Unlike `command` this is a PERSISTENT
   // session — it reconnects on drop and reattaches by session id, like a Claude cell.
   launcher: { index: number } | null;
+  // A first-class codex session (/ws/codex) instead of a Claude one. Persistent &
+  // reattachable like a Claude cell; the server discovers + resumes codex's own id.
+  codex?: boolean;
 }
 
 // Forwarded to whatever component is currently attached, so the parent's existing
@@ -168,6 +171,7 @@ function connUrl(target: ConnTarget, resumeId: string | null, secure: boolean): 
   const host = location.host;
   if (target.command) return buildRunWsUrl({ host, secure, index: target.command.index, cwd: target.cwd });
   if (target.launcher) return buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
+  if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd });
   return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
 }
 


### PR DESCRIPTION
## Summary

Ships **Codex as a first-class agent (L1 + L2)** from the `feat/multi-agent` integration branch to
`main`. Entirely **additive** — Claude's existing behavior is untouched:

- **AgentAdapter seam** (`server/agents/`): Claude + Codex adapters behind one interface + registry.
- **`/ws/codex` endpoint**: persistent, reattachable codex sessions (mirrors the launcher lifecycle).
  codex mints its own session id, so the server discovers it from `$CODEX_HOME/sessions` rollouts and
  cold-resumes via `codex resume <id>`; live reload continuity is reattach + tmux (no id needed).
- **Client**: `buildCodexWsUrl` + `ConnTarget.codex`, and a **Claude / Codex toggle** in the grid cell's
  new-session form. The choice persists (`Cell.agent`) so a reload reconnects as codex.
- **Reattach hardening** (`terminal-replay.ts`): strips terminal-query sequences from the replay so
  xterm doesn't re-answer them as stray input (fixes codex's `0;276;0c`) — helps claude/launcher too.

**Verified in-browser** by the author: launch codex, chat, reload → session continues, no junk.

## Items to Confirm / Review

- **No side effects**: `/ws` (Claude) is unchanged; codex is a separate endpoint + opt-in toggle
  (defaults to Claude). The only shared change is the reattach replay strip, which removes invisible
  query sequences only (visual restore identical).
- **Known limitation (deferred, tracked in #236)**: two codex cells in the *identical* cwd launched
  before either's first turn can't be told apart from the rollout files alone, so neither gets a
  cold-resume id (degrades to fresh — never a wrong resume; reattach + tmux unaffected). A true fix
  needs a codex-side spawn↔session correlation (rollout + its sqlite thread row are both written
  lazily at the first turn).
- **Deferred to follow-up PRs**: L3 (single-mode GUI-MCP for codex) and L4 (skill/collection runs),
  plus Antigravity and the Docker sandbox generalization — see `plans/feat-multi-agent-support.md`.

## User Prompt

Consolidated:

> Make MulmoTerminal able to use Codex (then Antigravity), not just Claude — Codex first. Running it in
> a raw TTY isn't enough; I need first-class sessions (resume across reload), the single-mode MCP/GUI
> panel, and skill runs. Investigate feasibility (Docker included), break it into fine-grained PRs on a
> separate branch, and keep CI working. Proceed from the latest main; create a tracking issue. This L1+L2
> work has no side effects, so take it into main, then continue to the GUI-MCP (L3) PR.

Tracking issue: #236.

## Contents (PRs #237, #238 merged into `feat/multi-agent`)

- #237 — AgentAdapter seam + plan + CI triggers.
- #238 — Codex L1+L2: `codex-args`, `codex-session` (lifetime rollout watch, unambiguous+claimed
  attribution), `/ws/codex`, client protocol + toggle, `terminal-replay` fix.

## Verification

`yarn format` / `lint` (0 errors) / `typecheck` / `typecheck:server` / `build` / `test` — all green
(704 tests). CI (lint-and-build, package-smoke, codex-review) green on the merged commits; codex-review
findings triaged and addressed.
