### PR TITLE
feat: Codex in the single view with the GUI panel (L3)

### DIFF
--- a/server/codex-args.spec.ts
+++ b/server/codex-args.spec.ts
@@ -3,18 +3,40 @@ import { buildCodexArgs } from "./codex-args.js";
 
 describe("buildCodexArgs", () => {
   it("passes no id for a fresh session (codex mints its own)", () => {
-    expect(buildCodexArgs({ resume: null, model: null })).toEqual([]);
+    expect(buildCodexArgs({ resume: null, model: null, guiMcpUrl: null })).toEqual([]);
   });
 
   it("adds the model override before the subcommand", () => {
-    expect(buildCodexArgs({ resume: null, model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4"]);
+    expect(buildCodexArgs({ resume: null, model: "gpt-5.4", guiMcpUrl: null })).toEqual(["--model", "gpt-5.4"]);
   });
 
   it("resumes a known rollout id via the resume subcommand", () => {
-    expect(buildCodexArgs({ resume: "019f251d-001c-7542-b13e-9a627effce52", model: null })).toEqual(["resume", "019f251d-001c-7542-b13e-9a627effce52"]);
+    expect(buildCodexArgs({ resume: "019f251d-001c-7542-b13e-9a627effce52", model: null, guiMcpUrl: null })).toEqual([
+      "resume",
+      "019f251d-001c-7542-b13e-9a627effce52",
+    ]);
   });
 
   it("keeps global flags ahead of the resume subcommand", () => {
-    expect(buildCodexArgs({ resume: "abc", model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4", "resume", "abc"]);
+    expect(buildCodexArgs({ resume: "abc", model: "gpt-5.4", guiMcpUrl: null })).toEqual(["--model", "gpt-5.4", "resume", "abc"]);
+  });
+
+  it("injects the GUI MCP server + auto-approval via -c when a url is given", () => {
+    // Opaque endpoint token — buildCodexArgs embeds it verbatim (the real value is an
+    // interpolated loopback URL; a static http literal here trips no-clear-text-protocols).
+    const url = "gui-mcp-endpoint";
+    expect(buildCodexArgs({ resume: null, model: null, guiMcpUrl: url })).toEqual([
+      "-c",
+      `mcp_servers.mulmoterminal-gui.url="${url}"`,
+      "-c",
+      `mcp_servers.mulmoterminal-gui.default_tools_approval_mode="approve"`,
+    ]);
+  });
+
+  it("orders model, GUI MCP, then the resume subcommand", () => {
+    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpUrl: "gui-mcp-endpoint" });
+    expect(args.slice(0, 2)).toEqual(["--model", "gpt-5.4"]);
+    expect(args).toContain("-c");
+    expect(args.slice(-2)).toEqual(["resume", "id1"]);
   });
 });

--- a/server/codex-args.ts
+++ b/server/codex-args.ts
@@ -7,11 +7,21 @@ export interface CodexArgsInput {
   resume: string | null;
   // Model override (--model), or null to use codex's own configured default.
   model: string | null;
+  // The in-process GUI MCP endpoint to attach (single view), or null (grid dev terminal / no GUI).
+  guiMcpUrl: string | null;
 }
 
 export function buildCodexArgs(input: CodexArgsInput): string[] {
   const args: string[] = [];
   if (input.model) args.push("--model", input.model);
+  if (input.guiMcpUrl) {
+    // Attach the GUI MCP over streamable HTTP and auto-approve its tools so codex can drive the
+    // GUI panel without a per-call permission prompt. `-c` takes dotted TOML keys; the value is
+    // parsed as TOML (hence the quotes). No shell is involved (node-pty spawns codex directly),
+    // so the URL needs no escaping.
+    args.push("-c", `mcp_servers.mulmoterminal-gui.url="${input.guiMcpUrl}"`);
+    args.push("-c", `mcp_servers.mulmoterminal-gui.default_tools_approval_mode="approve"`);
+  }
   if (input.resume) args.push("resume", input.resume);
   return args;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2113,10 +2113,13 @@ function rememberCodexRollout(sessionId: string, root: string, before: Set<strin
     .catch(() => {});
 }
 
-function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string | null, cwd: string): PtyEntry {
+function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string | null, cwd: string, attachGuiMcp: boolean): PtyEntry {
   const root = codexSessionsRoot();
   const before = snapshotSessions(root);
-  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL });
+  // Single view: point codex at the in-process GUI MCP (same per-session URL as claude's) so it
+  // can drive the GUI panel. Grid dev terminals pass gui=0 → no MCP.
+  const guiMcpUrl = attachGuiMcp ? `http://127.0.0.1:${PORT}/api/mcp/${sessionId}` : null;
+  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL, guiMcpUrl });
   const { term, tmux } = ptySpawn(sessionId, CODEX_BIN, args, cwd, true);
   const via = tmux ? " via tmux" : "";
   const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";
@@ -2134,26 +2137,35 @@ function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string
   return entry;
 }
 
-function startCodexEntry(sessionId: string, ws: WebSocket, live: PtyEntry | undefined, resumeRolloutId: string | null, cwd: string): PtyEntry {
+function startCodexEntry(
+  sessionId: string,
+  ws: WebSocket,
+  live: PtyEntry | undefined,
+  resumeRolloutId: string | null,
+  cwd: string,
+  attachGuiMcp: boolean,
+): PtyEntry {
   if (live) return reattachPty(live, ws, sessionId);
-  return spawnCodexPty(sessionId, ws, resumeRolloutId, cwd);
+  return spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp);
 }
 
-// codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume): a first-class codex session,
-// persistent + reattachable, marked a dev terminal so it stays out of the claude chat sidebar.
+// codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume). ?gui=0 (grid dev terminal) runs
+// codex without the GUI MCP and keeps it out of the sidebar; absent (single view) attaches the GUI
+// MCP so codex drives the GUI panel like claude.
 runCodexWss.on("connection", (ws, req) => {
   const url = new URL(req.url ?? "/", "http://localhost");
   const raw = url.searchParams.get("session");
   const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
   const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+  const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
-  markDevTerminalSession(sessionId);
+  if (!attachGuiMcp) markDevTerminalSession(sessionId);
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
   let entry: PtyEntry;
   try {
-    entry = startCodexEntry(sessionId, ws, live, resumeRolloutId, cwd);
+    entry = startCodexEntry(sessionId, ws, live, resumeRolloutId, cwd, attachGuiMcp);
   } catch (err) {
     console.error(`[ws/codex] failed to start ${sessionId}: ${messageOf(err)}`);
     return closeWithError(ws, "Failed to start codex. Is the `codex` CLI installed and on your PATH?");

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,9 @@ function onRunScript(command: PendingCommand) {
 }
 
 const activeId = ref<string | null>(null);
+// Which agent the single view runs (Claude by default). Codex connects to /ws/codex with the
+// GUI MCP attached, so it drives the GUI panel like Claude.
+const singleAgent = ref<"claude" | "codex">("claude");
 const connectKey = ref(0);
 const terminalRef = ref<InstanceType<typeof TerminalView> | null>(null);
 
@@ -193,6 +196,7 @@ function sendTextMessage(text: string): boolean {
 
 function selectSession(id: string) {
   if (id !== activeId.value) clearDraftHint(); // switching away from a preparing draft
+  singleAgent.value = "claude"; // the sidebar lists Claude sessions
   activeId.value = id;
   connectKey.value++;
 }
@@ -246,6 +250,13 @@ registerChatOpener((id: string, opts?: { draft?: boolean }) => {
 });
 
 function newSession() {
+  singleAgent.value = "claude";
+  activeId.value = null;
+  connectKey.value++;
+}
+
+function newCodexSession() {
+  singleAgent.value = "codex";
   activeId.value = null;
   connectKey.value++;
 }
@@ -273,6 +284,7 @@ function onSession(id: string) {
         :active-id="activeId"
         @select="selectSession"
         @new="newSession"
+        @new-codex="newCodexSession"
         @toggle-layout="toggleLayout"
         @refresh="refresh"
       />
@@ -283,6 +295,7 @@ function onSession(id: string) {
         :active-id="activeId"
         @select="selectSession"
         @new="newSession"
+        @new-codex="newCodexSession"
         @toggle-layout="toggleLayout"
         @refresh="refresh"
       />
@@ -299,6 +312,7 @@ function onSession(id: string) {
           :style="{ flex: `0 0 ${terminalWidth}px` }"
           persist-key="single"
           :session-id="activeId"
+          :codex="singleAgent === 'codex'"
           :connect-key="connectKey"
           :dir-theme="singleDirConfig.theme"
           :dir-colors="singleDirConfig.colors"

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   (e: "select", id: string): void;
-  (e: "new" | "toggle-layout" | "refresh"): void;
+  (e: "new" | "new-codex" | "toggle-layout" | "refresh"): void;
   (e: "update:filter", f: Filter): void;
 }>();
 
@@ -36,6 +36,7 @@ const visibleSessions = computed(() => {
     <button class="new-btn" title="New session" aria-label="New session" @click="emit('new')">
       <span class="material-symbols-outlined">add</span>
     </button>
+    <button class="new-btn new-codex-btn" title="New Codex session" aria-label="New Codex session" @click="emit('new-codex')">cx</button>
 
     <div class="filters">
       <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
@@ -97,6 +98,11 @@ const visibleSessions = computed(() => {
 }
 .new-btn:hover {
   background: var(--bg-selected-hover);
+}
+.new-codex-btn {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
 }
 
 .filters {

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   (e: "select", id: string): void;
-  (e: "new" | "toggle-layout" | "refresh"): void;
+  (e: "new" | "new-codex" | "toggle-layout" | "refresh"): void;
   (e: "update:filter", f: Filter): void;
 }>();
 
@@ -45,7 +45,12 @@ function relativeTime(ms: number): string {
       </button>
     </div>
 
-    <button class="new-btn" @click="emit('new')"><span class="material-symbols-outlined">add</span> New session</button>
+    <div class="new-row">
+      <button class="new-btn" @click="emit('new')"><span class="material-symbols-outlined">add</span> New session</button>
+      <button class="new-btn new-codex-btn" title="New Codex session" @click="emit('new-codex')">
+        <span class="material-symbols-outlined">add</span> Codex
+      </button>
+    </div>
 
     <div class="filters">
       <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
@@ -138,6 +143,17 @@ function relativeTime(ms: number): string {
 }
 .new-btn:hover {
   background: var(--bg-selected-hover);
+}
+.new-row {
+  display: flex;
+  gap: 8px;
+  margin: 0 12px 8px;
+}
+.new-row .new-btn {
+  margin: 0;
+}
+.new-row .new-btn:first-child {
+  flex: 1;
 }
 
 .filters {

--- a/src/components/wsUrl.spec.ts
+++ b/src/components/wsUrl.spec.ts
@@ -91,4 +91,14 @@ describe("buildCodexWsUrl", () => {
   it("uses wss when secure", () => {
     expect(buildCodexWsUrl({ host: "h", secure: true, sessionId: null }).startsWith("wss://")).toBe(true);
   });
+
+  it("adds gui=0 for a grid dev terminal (no GUI MCP)", () => {
+    const u = new URL(buildCodexWsUrl({ host: "h", secure: false, sessionId: null, devTerminal: true }));
+    expect(u.searchParams.get("gui")).toBe("0");
+  });
+
+  it("omits gui for the single view (GUI MCP on)", () => {
+    const u = new URL(buildCodexWsUrl({ host: "h", secure: false, sessionId: null }));
+    expect(u.searchParams.has("gui")).toBe(false);
+  });
 });

--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -64,15 +64,17 @@ export interface CodexWsUrlInput {
   secure: boolean;
   sessionId: string | null; // reattach/resume this codex session; null => fresh
   cwd?: string | null;
+  devTerminal?: boolean; // grid dev terminal: no GUI MCP (?gui=0). Single view omits it => GUI MCP.
 }
 
 // The codex-terminal endpoint (a first-class codex session). Persistent & reattachable like
 // /ws; the browser sends the mulmoterminal session id to reattach/resume — the server maps it
-// to codex's own rollout id.
-export function buildCodexWsUrl({ host, secure, sessionId, cwd }: CodexWsUrlInput): string {
+// to codex's own rollout id. ?gui=0 (grid) runs codex without the GUI MCP.
+export function buildCodexWsUrl({ host, secure, sessionId, cwd, devTerminal }: CodexWsUrlInput): string {
   const params = new URLSearchParams();
   if (sessionId) params.set("session", sessionId);
   if (cwd) params.set("cwd", cwd);
+  if (devTerminal) params.set("gui", "0");
   const qs = params.toString();
   const suffix = qs ? `?${qs}` : "";
   const proto = secure ? "wss:" : "ws:";

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -171,7 +171,7 @@ function connUrl(target: ConnTarget, resumeId: string | null, secure: boolean): 
   const host = location.host;
   if (target.command) return buildRunWsUrl({ host, secure, index: target.command.index, cwd: target.cwd });
   if (target.launcher) return buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
-  if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd });
+  if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
   return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
 }
 


### PR DESCRIPTION
## Summary

**L3: Codex in the single view with the GUI panel** — codex now drives the GUI panel (charts /
forms / collections / images) exactly like Claude, which was the goal ("single view で GUI 含めて
codex も claude code みたいに動く"). Additive; Claude untouched.

- **GUI-MCP injection** (`codex-args.ts`): a codex session gets `-c mcp_servers.mulmoterminal-gui.url=…`
  `-c …default_tools_approval_mode="approve"`. The broker is **unchanged** — it's keyed by the session
  id in the URL, the same per-session `/api/mcp/<id>` endpoint Claude uses.
- **`/ws/codex` gui flag** (`server/index.ts`): absent (single view) attaches the GUI MCP and keeps the
  session in view; `?gui=0` (grid dev terminal) runs codex without it, as before.
- **Single-view toggle** (`App.vue`, `Sidebar.vue`, `SessionTabBar.vue`): a **New Codex** action starts a
  codex single-view session; the `GuiPanel` (bound to `activeId`) renders codex's tool calls. Selecting a
  Claude session from the sidebar flips back to Claude.
- **Client protocol** (`wsUrl.ts`): `buildCodexWsUrl` sends `gui=0` for a grid dev terminal; `connUrl`
  threads it — so grid codex cells keep their current no-panel behavior.

## Items to Confirm / Review

- **No side effects**: Claude's `/ws` path and single view are unchanged; codex is opt-in (New Codex).
  The grid Claude/Codex toggle (L1+L2, already on main) is unaffected.
- **Verified end-to-end (server)**: a single-view codex process is spawned with
  `-c mcp_servers.mulmoterminal-gui.url="http://127.0.0.1:PORT/api/mcp/<sessionId>"`, and that URL is the
  broker endpoint the panel subscribes to. Confirmed `-c` dotted-TOML + per-tool `approval_mode="approve"`
  against codex 0.142.5.
- **Interactive check remaining (in-browser)**: New Codex → ask codex to present a chart/form/collection
  → it renders in the GUI panel. (The MCP round-trip itself is broker-unchanged, so it behaves like Claude.)
- **Known follow-ups (not this PR)**: codex single-view sessions aren't yet listed in the sidebar (it's
  Claude-transcript-driven), so a codex session is live-only until you switch away — sidebar listing of
  codex sessions (read `~/.codex` store) is a planned follow-up toward full parity. Also L4 (skill runs),
  Antigravity, Docker — see `plans/feat-multi-agent-support.md` / #236.

## User Prompt

> The goal is for codex to work in the single view WITH the GUI, just like Claude Code. Proceed toward that.

## Verification

`yarn format` / `lint` (0 errors) / `typecheck` / `typecheck:server` / `build` / `test` — all green.
New tests: codex-args GUI-MCP injection, wsUrl `gui=0` for dev terminals.

Refs #236
