### PR TITLE
feat: git status chip in the terminal header (#242)

### DIFF
--- a/plans/feat-242-status-header.md
+++ b/plans/feat-242-status-header.md
@@ -1,0 +1,35 @@
+# feat #242 — 常時ステータスヘッダ（git branch / dirty / ahead·behind）
+
+Umbrella #241 の子。ターミナルヘッダに git の状態を常時表示し、`git status` の打ち直しを減らす。
+
+## スコープ（このPRのMVP）
+
+- **サーバ**: `GET /api/git-status?cwd=` → `{ repo, branch, detached, dirty, ahead, behind, upstream }`。
+  非 git dir は `repo:false`（エラーにしない）。`server/worktrees.ts` の共有 `git()` ランナーを再利用。
+- **クライアント**: 単一ビュー（`Terminal.vue`）とグリッドセル（`TerminalCell.vue`）のヘッダに
+  ブランチチップ（`⎇ branch ●dirty ↑ahead ↓behind`）を表示。
+- 取得タイミング: マウント時 / cwd 変更時 / ウィンドウ focus 時 / 一定間隔（10s, 可視時のみ）。
+  さらにグリッドセルはターン完了で `loadDiff()` を呼ぶ箇所に相乗りして即時更新。
+
+## 設計判断（issue の要判断への回答）
+
+- **更新トリガ**: focus + 可視時の 10s ポーリング + cwd 変更。軽量なので許容。将来 file-watch に置換可。
+- **表示項目**: branch / dirty / ahead·behind（upstream 有時）。**venv / container / ssh は本PRでは対象外**（フォローアップ）。
+- **worktree セルとの重複回避**: worktree セルには既存の diff バッジ（ahead/dirty vs base）があるため、
+  チップは **dirty を出さず branch 名のみ**（`hideDirty`）。ahead/behind は upstream 基準なので
+  新規 agent ブランチでは通常 0 → 何も出ない。
+
+## ファイル
+
+- `server/git-status.ts` — `gitStatus(cwd): Promise<GitStatus>`（純関数、テスト可能）
+- `server/git-status.spec.ts` — 一時 git repo で branch/dirty/ahead を検証（`worktree-diff.spec.ts` 準拠）
+- `server/index.ts` — `GET /api/git-status`（`resolveWorkspace` で cwd 解決、既存 GET 群に倣う）
+- `src/composables/useGitStatus.ts` — `useGitStatus(cwd: Ref)` → `{ status, refresh }`
+- `src/components/GitBranchChip.vue` — チップ表示（両ビューで再利用、props: `status`, `hideDirty`）
+- `Terminal.vue` / `TerminalCell.vue` — ヘッダにチップを差し込み
+
+## 非スコープ / フォローアップ
+
+- venv / container / ssh インジケータ
+- ファイル変更 watch への置換（現状はポーリング）
+- 非worktree dir の「ライブ diff」統合（#242 とは別、既存 worktree-diff の一般化）

--- a/server/git-status.spec.ts
+++ b/server/git-status.spec.ts
@@ -52,6 +52,17 @@ describe("gitStatus", () => {
     expect(s.upstream).toBe(false); // no remote in the test repo
   });
 
+  it("shows the branch on an unborn branch (git init, no commit yet)", async () => {
+    if (!hasGit) return;
+    const fresh = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-unborn-")));
+    g(fresh, "init", "-b", "main"); // no commit — unborn HEAD
+    const s = await gitStatus(fresh);
+    expect(s.repo).toBe(true);
+    expect(s.branch).toBe("main");
+    expect(s.detached).toBe(false);
+    rmSync(fresh, { recursive: true, force: true });
+  });
+
   it("counts dirty entries (modified + untracked)", async () => {
     if (!hasGit) return;
     writeFileSync(path.join(repo, "README.md"), "changed\n"); // modify tracked

--- a/server/git-status.spec.ts
+++ b/server/git-status.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gitStatus } from "./git-status.js";
+
+describe("gitStatus", () => {
+  let repo: string;
+  const hasGit = (() => {
+    try {
+      // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+      execFileSync("git", ["--version"], { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  const g = (dir: string, ...a: string[]) =>
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+    execFileSync("git", ["-C", dir, ...a], { stdio: "ignore" });
+
+  beforeEach(() => {
+    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-gitstatus-")));
+    if (!hasGit) return;
+    g(repo, "init", "-b", "main");
+    g(repo, "config", "user.email", "t@t.t");
+    g(repo, "config", "user.name", "t");
+    writeFileSync(path.join(repo, "README.md"), "hi\n");
+    g(repo, "add", "-A");
+    g(repo, "commit", "-m", "init");
+  });
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("reports repo:false for a non-git dir", async () => {
+    const outside = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-nogit-")));
+    const s = await gitStatus(outside);
+    expect(s.repo).toBe(false);
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it("reports branch and a clean tree", async () => {
+    if (!hasGit) return;
+    const s = await gitStatus(repo);
+    expect(s.repo).toBe(true);
+    expect(s.branch).toBe("main");
+    expect(s.detached).toBe(false);
+    expect(s.dirty).toBe(0);
+    expect(s.upstream).toBe(false); // no remote in the test repo
+  });
+
+  it("counts dirty entries (modified + untracked)", async () => {
+    if (!hasGit) return;
+    writeFileSync(path.join(repo, "README.md"), "changed\n"); // modify tracked
+    writeFileSync(path.join(repo, "new.txt"), "new\n"); // untracked
+    const s = await gitStatus(repo);
+    expect(s.dirty).toBe(2);
+  });
+
+  it("reports detached HEAD", async () => {
+    if (!hasGit) return;
+    writeFileSync(path.join(repo, "b.txt"), "b\n");
+    g(repo, "add", "-A");
+    g(repo, "commit", "-m", "second");
+    g(repo, "checkout", "--detach", "HEAD");
+    const s = await gitStatus(repo);
+    expect(s.detached).toBe(true);
+    expect(s.branch).toBeNull();
+  });
+
+  it("reports ahead vs a local upstream", async () => {
+    if (!hasGit) return;
+    // A second clone acting as the "remote" so HEAD has an upstream to be ahead of.
+    const remote = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-remote-")));
+    g(repo, "clone", "--bare", repo, remote);
+    g(repo, "remote", "add", "origin", remote);
+    g(repo, "push", "-u", "origin", "main");
+    writeFileSync(path.join(repo, "c.txt"), "c\n");
+    g(repo, "add", "-A");
+    g(repo, "commit", "-m", "ahead by one");
+    const s = await gitStatus(repo);
+    expect(s.upstream).toBe(true);
+    expect(s.ahead).toBe(1);
+    expect(s.behind).toBe(0);
+    rmSync(remote, { recursive: true, force: true });
+  });
+});

--- a/server/git-status.ts
+++ b/server/git-status.ts
@@ -1,0 +1,50 @@
+// Read-only git status for a terminal's working dir, so the header can always show
+// branch / dirty / ahead·behind without the user running `git status`. Reuses the
+// shared git runner and never throws — a non-repo dir is just `repo:false`.
+import { git, gitTopLevel } from "./worktrees.js";
+
+export interface GitStatus {
+  repo: boolean;
+  branch: string | null; // null when detached or non-repo
+  detached: boolean;
+  dirty: number; // uncommitted entries (incl. untracked)
+  ahead: number; // commits on HEAD not on the upstream
+  behind: number; // commits on the upstream not on HEAD
+  upstream: boolean; // HEAD has a tracking branch (ahead/behind are meaningful)
+}
+
+const NOT_REPO: GitStatus = { repo: false, branch: null, detached: false, dirty: 0, ahead: 0, behind: 0, upstream: false };
+
+const toCount = (s: string): number => {
+  const n = parseInt(s.trim(), 10);
+  return Number.isFinite(n) ? n : 0;
+};
+
+// The current branch, or detached when HEAD isn't on a branch (git prints "HEAD").
+async function currentBranch(cwd: string): Promise<{ branch: string | null; detached: boolean }> {
+  const res = await git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  const name = res.ok ? res.stdout.trim() : "";
+  if (!name || name === "HEAD") return { branch: null, detached: name === "HEAD" };
+  return { branch: name, detached: false };
+}
+
+async function dirtyCount(cwd: string): Promise<number> {
+  const res = await git(["status", "--porcelain"], cwd);
+  return res.ok ? res.stdout.split("\n").filter((l) => l.trim()).length : 0;
+}
+
+// ahead/behind vs the tracking branch. `--left-right @{upstream}...HEAD` prints
+// "<behind>\t<ahead>"; a missing upstream makes the command fail → upstream:false.
+async function aheadBehind(cwd: string): Promise<{ ahead: number; behind: number; upstream: boolean }> {
+  const res = await git(["rev-list", "--left-right", "--count", "@{upstream}...HEAD"], cwd);
+  if (!res.ok) return { ahead: 0, behind: 0, upstream: false };
+  const [behind, ahead] = res.stdout.trim().split(/\s+/);
+  return { ahead: toCount(ahead ?? ""), behind: toCount(behind ?? ""), upstream: true };
+}
+
+export async function gitStatus(cwd: string): Promise<GitStatus> {
+  const top = await gitTopLevel(cwd);
+  if (!top) return NOT_REPO;
+  const [head, dirty, ab] = await Promise.all([currentBranch(cwd), dirtyCount(cwd), aheadBehind(cwd)]);
+  return { repo: true, branch: head.branch, detached: head.detached, dirty, ahead: ab.ahead, behind: ab.behind, upstream: ab.upstream };
+}

--- a/server/git-status.ts
+++ b/server/git-status.ts
@@ -20,12 +20,16 @@ const toCount = (s: string): number => {
   return Number.isFinite(n) ? n : 0;
 };
 
-// The current branch, or detached when HEAD isn't on a branch (git prints "HEAD").
+// The current branch, or detached when HEAD isn't on a branch. `symbolic-ref`
+// resolves the branch even on an UNBORN branch (fresh `git init` before the first
+// commit), where `rev-parse --abbrev-ref HEAD` fails; it also fails cleanly on a
+// detached HEAD, which we then confirm by whether HEAD resolves to a commit.
 async function currentBranch(cwd: string): Promise<{ branch: string | null; detached: boolean }> {
-  const res = await git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
-  const name = res.ok ? res.stdout.trim() : "";
-  if (!name || name === "HEAD") return { branch: null, detached: name === "HEAD" };
-  return { branch: name, detached: false };
+  const sym = await git(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd);
+  const name = sym.ok ? sym.stdout.trim() : "";
+  if (name) return { branch: name, detached: false };
+  const head = await git(["rev-parse", "--verify", "--quiet", "HEAD"], cwd);
+  return { branch: null, detached: head.ok };
 }
 
 async function dirtyCount(cwd: string): Promise<number> {

--- a/server/index.ts
+++ b/server/index.ts
@@ -17,6 +17,7 @@ import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers } from "./config-routes.js";
 import { mountFilesBrowseRoutes } from "./files-browse.js";
+import { gitStatus } from "./git-status.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "./tmux.js";
 import {
   sandboxEnabled,
@@ -1190,6 +1191,14 @@ app.get("/api/session/:id", async (req, res) => {
 app.get("/api/dir-config", (req, res) => {
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   res.json(publicDirConfig(cwd));
+});
+
+// Live git status (branch / dirty / ahead·behind) for a terminal's dir, so the
+// header can show it without the user typing `git status`. A non-git dir is
+// `repo:false`, not an error.
+app.get("/api/git-status", async (req, res) => {
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  res.json(await gitStatus(cwd));
 });
 
 // Stream a directory's custom attention sound. The path never comes from the

--- a/src/components/GitBranchChip.spec.ts
+++ b/src/components/GitBranchChip.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import GitBranchChip from "./GitBranchChip.vue";
+import type { GitStatus } from "../composables/useGitStatus";
+
+const base: GitStatus = { repo: true, branch: "main", detached: false, dirty: 0, ahead: 0, behind: 0, upstream: false };
+
+const render = (status: GitStatus | null, hideDirty = false) => mount(GitBranchChip, { props: { status, hideDirty } });
+
+describe("GitBranchChip", () => {
+  it("renders nothing when status is null", () => {
+    expect(render(null).find(".git-chip").exists()).toBe(false);
+  });
+
+  it("renders nothing for a non-git dir (repo:false)", () => {
+    expect(
+      render({ ...base, repo: false, branch: null })
+        .find(".git-chip")
+        .exists(),
+    ).toBe(false);
+  });
+
+  it("shows the branch name on a clean repo", () => {
+    const w = render(base);
+    expect(w.find(".git-chip").exists()).toBe(true);
+    expect(w.find(".git-branch").text()).toContain("main");
+    expect(w.find(".git-dirty").exists()).toBe(false);
+  });
+
+  it("shows the dirty count when there are uncommitted changes", () => {
+    const w = render({ ...base, dirty: 3 });
+    expect(w.find(".git-dirty").text()).toBe("●3");
+  });
+
+  it("hides the dirty count when hideDirty is set (worktree cell)", () => {
+    const w = render({ ...base, dirty: 3 }, true);
+    expect(w.find(".git-dirty").exists()).toBe(false);
+    expect(w.find(".git-branch").text()).toContain("main");
+  });
+
+  it("shows ahead/behind only when an upstream exists", () => {
+    const noUpstream = render({ ...base, ahead: 2, behind: 1, upstream: false });
+    expect(noUpstream.findAll(".git-ab")).toHaveLength(0);
+    const withUpstream = render({ ...base, ahead: 2, behind: 1, upstream: true });
+    const abs = withUpstream.findAll(".git-ab").map((n) => n.text());
+    expect(abs).toEqual(["↑2", "↓1"]);
+  });
+
+  it("labels a detached HEAD", () => {
+    const w = render({ ...base, branch: null, detached: true });
+    expect(w.find(".git-branch").text()).toContain("detached");
+  });
+});

--- a/src/components/GitBranchChip.vue
+++ b/src/components/GitBranchChip.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { GitStatus } from "../composables/useGitStatus";
+
+// `hideDirty` suppresses the dirty count for worktree cells, which already show
+// ahead/dirty vs their base branch in the diff badge next to this chip.
+const props = defineProps<{ status: GitStatus | null; hideDirty?: boolean }>();
+
+const label = computed(() => (props.status?.detached ? "detached" : (props.status?.branch ?? "")));
+
+const title = computed(() => {
+  const s = props.status;
+  if (!s?.repo) return "";
+  const parts = [s.detached ? "detached HEAD" : `branch ${s.branch}`];
+  if (s.dirty > 0) parts.push(`${s.dirty} uncommitted`);
+  if (s.upstream && s.ahead > 0) parts.push(`${s.ahead} ahead`);
+  if (s.upstream && s.behind > 0) parts.push(`${s.behind} behind`);
+  return parts.join(" · ");
+});
+</script>
+
+<template>
+  <span v-if="status?.repo && (status.branch || status.detached)" class="git-chip" :class="{ detached: status.detached }" :title="title">
+    <span class="git-branch">⎇ {{ label }}</span>
+    <span v-if="!hideDirty && status.dirty > 0" class="git-dirty">●{{ status.dirty }}</span>
+    <span v-if="status.upstream && status.ahead > 0" class="git-ab">↑{{ status.ahead }}</span>
+    <span v-if="status.upstream && status.behind > 0" class="git-ab">↓{{ status.behind }}</span>
+  </span>
+</template>
+
+<style scoped>
+.git-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  padding: 0 0.4em;
+  height: 1.5em;
+  border-radius: 0.75em;
+  font-size: 0.72rem;
+  line-height: 1.5em;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  color: inherit;
+  opacity: 0.85;
+  white-space: nowrap;
+  max-width: 16ch;
+  overflow: hidden;
+}
+.git-branch {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.git-chip.detached {
+  color: #d19a66;
+}
+.git-dirty {
+  color: #e5c07b;
+}
+.git-ab {
+  opacity: 0.8;
+}
+</style>

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -5,8 +5,10 @@ import { dropTextFromUriList, toInsertText } from "./dropPaths";
 import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
 import { badgeStyleFor } from "./dirBadge";
 import { useVoiceInput } from "../composables/useVoiceInput";
+import { useGitStatus } from "../composables/useGitStatus";
 import * as conn from "../composables/useTerminalConnections";
 import RunMenu from "./RunMenu.vue";
+import GitBranchChip from "./GitBranchChip.vue";
 import { filesGotoIndex } from "../composables/useFilesView";
 
 // `null` => start a fresh session; otherwise resume the given session id.
@@ -74,6 +76,10 @@ const status = computed(() => conn.connView.get(slotKey)?.status ?? "connecting"
 // The server-resolved cwd of the connected session (the open project), used by the
 // Run menu so it lists THAT directory's scripts. Falls back to the requested cwd.
 const serverCwd = computed(() => conn.connView.get(slotKey)?.serverCwd ?? props.cwd ?? null);
+// Git status chip — single view only. In the grid the embedding TerminalCell shows
+// its own chip, so null the cwd here to skip redundant polling (status stays null).
+const gitCwd = computed(() => (props.devTerminal ? null : serverCwd.value));
+const { status: gitStatus } = useGitStatus(gitCwd);
 const dragOver = ref(false);
 const { themeId } = useTheme();
 
@@ -220,6 +226,7 @@ onUnmounted(() => {
     <div class="header">
       <span class="title">Terminal</span>
       <span v-if="dirName" class="dir-badge" :style="dirBadgeStyle" :title="dirName">{{ dirName }}</span>
+      <GitBranchChip :status="gitStatus" />
       <span :class="['status', status]">{{ status }}</span>
       <RunMenu v-if="runMenu" :cwd="serverCwd" @run="(c) => emit('run', c)" />
       <div class="header-actions">

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -3,8 +3,10 @@ import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vu
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
 import { useDirConfig } from "../composables/useDirConfig";
+import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
+import GitBranchChip from "./GitBranchChip.vue";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { activityStatus, type CellStatus } from "./gridTabs";
@@ -72,6 +74,9 @@ const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
 // palette and shows a project badge. Re-fetched when the effective cwd changes.
 const { config: dirConfig } = useDirConfig(cwd);
 const dirBadgeStyle = computed(() => badgeStyleFor(dirConfig.value.badgeColor));
+// Live git status (branch/dirty/ahead·behind) for the header chip. `refreshGit`
+// is called alongside loadDiff() so a finished turn's changes show immediately.
+const { status: gitStatus, refresh: refreshGit } = useGitStatus(cwd);
 // The launch form's editable dir. Prefer this cell's persisted dir, then the most
 // recent preset, then the server default. Both `presets` and `defaultCwd` arrive
 // async from /api/config, so the watcher upgrades a still-pristine field once they
@@ -739,6 +744,7 @@ watch(working, (now, prev) => {
   if (prev && !now) {
     loadDiff();
     refreshUsage();
+    refreshGit(); // branch/dirty may have changed (commit, checkout, edits)
   }
 });
 
@@ -769,6 +775,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <span class="cell-dir-path">{{ headerDir }}</span>
         </button>
         <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
+        <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
         <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
           <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
           <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>

--- a/src/composables/useGitStatus.ts
+++ b/src/composables/useGitStatus.ts
@@ -1,0 +1,60 @@
+// Polls GET /api/git-status for a terminal's dir so the header can always show
+// branch / dirty / ahead·behind. Refreshes on mount, on cwd change, on window
+// focus, and on a light interval (only while the tab is visible). `refresh` is
+// exposed so a caller can force an update right after a turn finishes.
+import { ref, watch, onMounted, onUnmounted, type Ref } from "vue";
+
+export interface GitStatus {
+  repo: boolean;
+  branch: string | null;
+  detached: boolean;
+  dirty: number;
+  ahead: number;
+  behind: number;
+  upstream: boolean;
+}
+
+const POLL_MS = 10_000;
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const isGitStatus = (v: unknown): v is GitStatus => isRecord(v) && typeof v.repo === "boolean";
+
+export function useGitStatus(cwd: Ref<string | null>) {
+  const status = ref<GitStatus | null>(null);
+  let req = 0;
+
+  async function refresh(): Promise<void> {
+    const dir = cwd.value;
+    if (!dir) {
+      status.value = null;
+      return;
+    }
+    const my = ++req;
+    try {
+      const res = await fetch(`/api/git-status?cwd=${encodeURIComponent(dir)}`);
+      if (!res.ok) return;
+      const data: unknown = await res.json();
+      if (my === req) status.value = isGitStatus(data) ? data : null;
+    } catch {
+      // leave the last value; the next tick retries
+    }
+  }
+
+  const refreshIfVisible = () => {
+    if (document.visibilityState === "visible") refresh();
+  };
+
+  let timer: ReturnType<typeof setInterval> | undefined;
+  onMounted(() => {
+    refresh();
+    window.addEventListener("focus", refreshIfVisible);
+    timer = setInterval(refreshIfVisible, POLL_MS);
+  });
+  onUnmounted(() => {
+    window.removeEventListener("focus", refreshIfVisible);
+    if (timer) clearInterval(timer);
+  });
+  watch(cwd, refresh);
+
+  return { status, refresh };
+}


### PR DESCRIPTION
## Summary

Umbrella #241 の子 **#242**（順次対応の1本目）。ターミナルヘッダに git の状態を**常時表示**し、`git status` の打ち直しを減らす。**No behavior change** to existing flows — additive UI + one read-only endpoint.

- `GET /api/git-status?cwd=` → `{ repo, branch, detached, dirty, ahead, behind, upstream }`（共有 `git()` ランナー利用、非 git dir は `repo:false`）
- `GitBranchChip.vue` を単一ビュー（`Terminal.vue`）と各グリッドセル（`TerminalCell.vue`）のヘッダに表示：`⎇ branch ●dirty ↑ahead ↓behind`
- 取得: マウント / cwd 変更 / window focus / 10s（可視時のみ）ポーリング。グリッドは working→settled でも即時更新
- worktree セルは既存 diff バッジと重複しないよう `hideDirty`（branch 名のみ）

## Items to Confirm / Review

- **重複回避**: `Terminal.vue` のヘッダはグリッドセル内にも描画されるため、grid では `gitCwd=null` にしてポーリングとチップ表示を抑止（セル側の `TerminalCell` チップに一本化）。この判定でよいか。
- **ポーリング方式**: focus + 可視時 10s。file-watch ではなくポーリング（軽量・単純を優先）。間隔/方式の妥当性。
- **スコープ**: venv / container / ssh インジケータは本PR対象外（issue の要判断どおりフォローアップ）。
- **既知の軽微な重複**: `toCount` / `dirtyCount` 相当が `worktree-diff.ts` にもある（private）。共有化は別PRでの整理候補。

## Verification

- `GET /api/git-status` をライブ確認: 本リポジトリ → `branch: feat/242-status-header, dirty: 9, upstream: false` / `/tmp` → `repo: false`
- `server/git-status.spec.ts`（一時 git repo で branch/dirty/detached/ahead を検証）+ `GitBranchChip.spec.ts`（レンダリング分岐）追加
- `yarn lint`（0 errors・意図的な spawnClaudePty max-params warn のみ）/ `typecheck` / `typecheck:server` / `build` 通過、`yarn test` 719 passed
- ブラウザ MCP が本セッション未ロードのため、UI 検証はコンポーネントテスト（jsdom + @vue/test-utils, 既存 `Sidebar.spec.ts` と同方式）で代替

## User Prompt

> 順次対応していこう（Umbrella #241 の子issueを番号順に。まず A = #242 常時ステータスヘッダ）

## Plan

`plans/feat-242-status-header.md` に設計判断・非スコープを記載。

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)