### PR TITLE
feat: Codex sessions in the single-view sidebar (list + resume)

### DIFF
--- a/server/codex-sessions.spec.ts
+++ b/server/codex-sessions.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseCodexRolloutHead, listCodexSessions, codexRolloutExists } from "./codex-sessions.js";
+
+const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
+const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";
+
+const metaLine = (id: string, cwd: string | null): string => JSON.stringify({ type: "session_meta", payload: { id, cwd, originator: "codex-tui" } });
+const userMsgLine = (message: string): string => JSON.stringify({ type: "event_msg", payload: { type: "user_message", message } });
+// The environment context codex injects first is a response_item/message (role user), NOT an
+// event_msg/user_message — the parser must skip it and use the real prompt.
+const envContextLine = (): string =>
+  JSON.stringify({
+    type: "response_item",
+    payload: { type: "message", role: "user", content: [{ type: "input_text", text: "<environment_context>…</environment_context>" }] },
+  });
+
+describe("parseCodexRolloutHead", () => {
+  it("extracts id, cwd, and the first real user message as title", () => {
+    const head = [metaLine(UUID_A, "/work"), envContextLine(), userMsgLine("fix the login bug")].join("\n");
+    expect(parseCodexRolloutHead(head)).toEqual({ id: UUID_A, cwd: "/work", title: "fix the login bug" });
+  });
+  it("falls back to a generic title when there's no user message yet", () => {
+    expect(parseCodexRolloutHead(metaLine(UUID_A, "/work"))).toEqual({ id: UUID_A, cwd: "/work", title: "Codex session" });
+  });
+  it("returns null without a session_meta", () => {
+    expect(parseCodexRolloutHead(userMsgLine("hi"))).toBeNull();
+  });
+  it("ignores a truncated trailing line", () => {
+    const head = `${metaLine(UUID_A, "/work")}\n${userMsgLine("do a thing")}\n{"type":"event_ms`;
+    expect(parseCodexRolloutHead(head)?.title).toBe("do a thing");
+  });
+  it("collapses whitespace and caps the title length", () => {
+    const long = "a".repeat(200);
+    const head = [metaLine(UUID_A, "/work"), userMsgLine(`  multi\n  line\t${long}`)].join("\n");
+    const title = parseCodexRolloutHead(head)?.title ?? "";
+    expect(title).toHaveLength(60);
+    expect(title.startsWith("multi line a")).toBe(true);
+  });
+});
+
+describe("listCodexSessions", () => {
+  let root: string;
+  const dayDir = (r: string): string => path.join(r, "2026", "07", "08");
+  function writeSession(id: string, cwd: string, msg: string, mtime: Date): void {
+    const dir = dayDir(root);
+    mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `rollout-2026-07-08T00-00-00-${id}.jsonl`);
+    writeFileSync(file, [metaLine(id, cwd), userMsgLine(msg)].join("\n") + "\n");
+    utimesSync(file, mtime, mtime);
+  }
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-sess-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("lists sessions for the cwd, newest first", async () => {
+    writeSession(UUID_A, "/work", "older", new Date(2026, 6, 8, 10));
+    writeSession(UUID_B, "/work", "newer", new Date(2026, 6, 8, 11));
+    const list = await listCodexSessions(root, "/work", 10);
+    expect(list.map((s) => s.id)).toEqual([UUID_B, UUID_A]);
+    expect(list[0].title).toBe("newer");
+  });
+  it("excludes sessions from other cwds", async () => {
+    writeSession(UUID_A, "/work", "mine", new Date(2026, 6, 8, 10));
+    writeSession(UUID_B, "/other", "theirs", new Date(2026, 6, 8, 11));
+    const list = await listCodexSessions(root, "/work", 10);
+    expect(list.map((s) => s.id)).toEqual([UUID_A]);
+  });
+  it("returns nothing for an empty store", async () => {
+    expect(await listCodexSessions(root, "/work", 10)).toEqual([]);
+  });
+});
+
+describe("codexRolloutExists", () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "mt-codex-ex-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("finds a rollout by its id, rejects unknown ids and non-uuids", () => {
+    const dir = path.join(root, "2026", "07", "08");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, `rollout-2026-07-08T00-00-00-${UUID_A}.jsonl`), metaLine(UUID_A, "/work") + "\n");
+    expect(codexRolloutExists(root, UUID_A)).toBe(true);
+    expect(codexRolloutExists(root, UUID_B)).toBe(false);
+    expect(codexRolloutExists(root, "not-a-uuid")).toBe(false);
+  });
+});

--- a/server/codex-sessions.ts
+++ b/server/codex-sessions.ts
@@ -1,0 +1,140 @@
+import { existsSync, readdirSync } from "node:fs";
+import { open } from "node:fs/promises";
+import path from "node:path";
+
+const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const HEAD_BYTES = 64 * 1024; // enough for session_meta + the first user turn
+const TITLE_MAX = 60;
+const SCAN_LIMIT = 200; // newest rollout files to inspect per request
+
+export interface CodexSessionSummary {
+  id: string;
+  title: string;
+  mtime: number;
+}
+
+interface RolloutHead {
+  id: string;
+  cwd: string | null;
+  title: string;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+function parseJsonRecord(line: string): Record<string, unknown> | null {
+  if (!line) return null;
+  try {
+    const doc: unknown = JSON.parse(line);
+    return isRecord(doc) ? doc : null;
+  } catch {
+    return null; // a truncated final line, or a non-JSON row
+  }
+}
+
+const isSessionMeta = (d: Record<string, unknown>): boolean =>
+  d.type === "session_meta" && isRecord(d.payload) && typeof d.payload.id === "string" && UUID_RE.test(d.payload.id);
+
+// codex records the first real prompt as an event_msg/user_message — distinct from the
+// environment_context it injects first (a response_item/message).
+const isUserMessage = (d: Record<string, unknown>): boolean =>
+  d.type === "event_msg" && isRecord(d.payload) && d.payload.type === "user_message" && typeof d.payload.message === "string";
+
+function stringField(doc: Record<string, unknown> | undefined, key: string): string | null {
+  const payload = doc?.payload;
+  return isRecord(payload) && typeof payload[key] === "string" ? payload[key] : null;
+}
+
+function cleanTitle(raw: string | null): string {
+  const t = (raw ?? "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX);
+  return t || "Codex session";
+}
+
+// From a rollout's head, pull the minted id + cwd (session_meta) and a title (first user message).
+// Returns null if there's no valid session_meta.
+export function parseCodexRolloutHead(head: string): RolloutHead | null {
+  const docs = head
+    .split("\n")
+    .map(parseJsonRecord)
+    .filter((d): d is Record<string, unknown> => d !== null);
+  const meta = docs.find(isSessionMeta);
+  const id = stringField(meta, "id");
+  if (!id) return null;
+  return { id, cwd: stringField(meta, "cwd"), title: cleanTitle(stringField(docs.find(isUserMessage), "message")) };
+}
+
+function subdirsDesc(dir: string): string[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort()
+      .reverse();
+  } catch {
+    return [];
+  }
+}
+
+// Every YYYY/MM/DD directory under the sessions root, newest first.
+function dayDirsDesc(root: string): string[] {
+  return subdirsDesc(root).flatMap((year) =>
+    subdirsDesc(path.join(root, year)).flatMap((month) => subdirsDesc(path.join(root, year, month)).map((day) => path.join(root, year, month, day))),
+  );
+}
+
+function rolloutsInDay(dayDir: string): string[] {
+  return readdirSync(dayDir)
+    .filter((n) => ROLLOUT_RE.test(n))
+    .sort()
+    .reverse()
+    .map((f) => path.join(dayDir, f));
+}
+
+// Rollout paths newest-first (the filename embeds an ISO timestamp), capped to `scan` so a long
+// history stays cheap — only these get their heads read.
+function recentRolloutPaths(root: string, scan: number): string[] {
+  if (!existsSync(root)) return [];
+  return dayDirsDesc(root).flatMap(rolloutsInDay).slice(0, scan);
+}
+
+async function readRolloutSummary(file: string): Promise<(RolloutHead & { mtime: number }) | null> {
+  let fh;
+  try {
+    fh = await open(file, "r");
+    const buf = Buffer.alloc(HEAD_BYTES);
+    const { bytesRead } = await fh.read(buf, 0, HEAD_BYTES, 0);
+    const head = parseCodexRolloutHead(buf.subarray(0, bytesRead).toString("utf8"));
+    if (!head) return null;
+    const { mtimeMs } = await fh.stat();
+    return { ...head, mtime: mtimeMs };
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}
+
+// Does a rollout with this id exist? The id is the filename suffix, so this checks names only (no
+// reads). Lets a sidebar-listed codex session be resumed by its rollout id (`codex resume <id>`).
+export function codexRolloutExists(root: string, id: string): boolean {
+  if (!UUID_RE.test(id) || !existsSync(root)) return false;
+  const suffix = `-${id}.jsonl`;
+  return dayDirsDesc(root).some((dayDir) => {
+    try {
+      return readdirSync(dayDir).some((n) => ROLLOUT_RE.test(n) && n.endsWith(suffix));
+    } catch {
+      return false;
+    }
+  });
+}
+
+// codex sessions for a workspace, newest first — the single view's sidebar list. Scans the most
+// recent rollout files, keeps those whose recorded cwd matches, and returns the top `limit`.
+export async function listCodexSessions(root: string, cwd: string, limit: number): Promise<CodexSessionSummary[]> {
+  const summaries = await Promise.all(recentRolloutPaths(root, SCAN_LIMIT).map(readRolloutSummary));
+  return summaries
+    .filter((s): s is RolloutHead & { mtime: number } => s !== null && s.cwd === cwd)
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, limit)
+    .map((s) => ({ id: s.id, title: s.title, mtime: s.mtime }));
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -40,6 +40,7 @@ import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./codex-session.js";
+import { listCodexSessions, codexRolloutExists } from "./codex-sessions.js";
 import { stripTerminalQueries } from "./terminal-replay.js";
 import {
   isRecord,
@@ -1303,6 +1304,20 @@ app.get("/api/sessions", async (req, res) => {
   }
 });
 
+// codex's own sessions for a workspace (?cwd=, default CLAUDE_CWD), read from ~/.codex rollouts —
+// the single view's sidebar lists these so past codex conversations are switchable + resumable.
+app.get("/api/codex/sessions", async (req, res) => {
+  try {
+    const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
+    const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
+    const sessions = await listCodexSessions(codexSessionsRoot(), cwd, SESSION_LIST_LIMIT);
+    res.json({ cwd, sessions });
+  } catch (err) {
+    console.error("[api] /api/codex/sessions failed:", err);
+    res.status(500).json({ error: String(err) });
+  }
+});
+
 const server = http.createServer(app);
 pubsub = createPubSub(server, isAllowedOrigin);
 
@@ -2076,11 +2091,19 @@ runLaunchWss.on("connection", (ws, req) => {
 // after spawn and resume it with `codex resume <id>` once the live PTY is gone. Reattach a live
 // pty / surviving tmux session (running codex picked up, no resume); else cold-resume a known
 // rollout id; else a fresh session (a new minted key).
+// A rollout id to cold-resume for a requested session key: one we started here (key -> rollout id),
+// or a rollout id straight from the sidebar (its own id), or null (start fresh).
+function codexResumeIdFor(requested: string): string | null {
+  const mapped = codexRolloutIds.get(requested);
+  if (mapped) return mapped;
+  return codexRolloutExists(codexSessionsRoot(), requested) ? requested : null;
+}
+
 function resolveCodexSession(requested: string | null): { sessionId: string; live: PtyEntry | undefined; resumeRolloutId: string | null } {
   const reattachId = requested && ptys.has(requested) ? requested : null;
   const live = reattachId ? ptys.get(reattachId) : undefined;
   const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
-  const resumeRolloutId = !live && !tmuxAlive && requested ? (codexRolloutIds.get(requested) ?? null) : null;
+  const resumeRolloutId = !live && !tmuxAlive && requested ? codexResumeIdFor(requested) : null;
   const sessionId = reattachId ?? ((tmuxAlive || resumeRolloutId) && requested ? requested : randomUUID());
   return { sessionId, live, resumeRolloutId };
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -194,9 +194,9 @@ function sendTextMessage(text: string): boolean {
   return terminalRef.value?.submitText(text) ?? false;
 }
 
-function selectSession(id: string) {
+function selectSession(id: string, agent: "claude" | "codex" = "claude") {
   if (id !== activeId.value) clearDraftHint(); // switching away from a preparing draft
-  singleAgent.value = "claude"; // the sidebar lists Claude sessions
+  singleAgent.value = agent; // resume the row's agent (codex rows reconnect via /ws/codex)
   activeId.value = id;
   connectKey.value++;
 }

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
   filter: Filter;
 }>();
 const emit = defineEmits<{
-  (e: "select", id: string): void;
+  (e: "select", id: string, agent: "claude" | "codex"): void;
   (e: "new" | "new-codex" | "toggle-layout" | "refresh"): void;
   (e: "update:filter", f: Filter): void;
 }>();
@@ -53,9 +53,10 @@ const visibleSessions = computed(() => {
         :class="['tab', { active: s.id === props.activeId, waiting: isUnread(s) }]"
         :title="s.title"
         :aria-current="s.id === props.activeId ? 'page' : undefined"
-        @click="emit('select', s.id)"
+        @click="emit('select', s.id, s.agent ?? 'claude')"
       >
         <span v-if="s.working && !s.waiting && s.id !== props.activeId" class="spinner" title="Claude is working" aria-label="Claude is working" />
+        <span v-if="s.agent === 'codex'" class="agent-badge">cx</span>
         <span class="tab-title">{{ s.title }}</span>
         <span v-if="isUnread(s) && s.id !== props.activeId" class="unread-dot" aria-label="Unread" />
       </button>
@@ -102,6 +103,16 @@ const visibleSessions = computed(() => {
 .new-codex-btn {
   font-size: 12px;
   font-weight: 600;
+  text-transform: uppercase;
+}
+.agent-badge {
+  flex-shrink: 0;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--bg-selected);
+  color: var(--text-dim);
+  font-size: 9px;
+  font-weight: 700;
   text-transform: uppercase;
 }
 

--- a/src/components/Sidebar.spec.ts
+++ b/src/components/Sidebar.spec.ts
@@ -89,9 +89,16 @@ describe("Sidebar", () => {
     expect(wrapper.emitted("refresh")).toHaveLength(1);
   });
 
-  it("emits select with the session id on click", async () => {
+  it("emits select with the session id + agent on click", async () => {
     const wrapper = mountSidebar({ sessions: [row({ id: "a", title: "Alpha" })] });
     await wrapper.find(".item").trigger("click");
-    expect(wrapper.emitted("select")?.[0]).toEqual(["a"]);
+    expect(wrapper.emitted("select")?.[0]).toEqual(["a", "claude"]);
+  });
+
+  it("emits the codex agent + shows a badge for a codex row", async () => {
+    const wrapper = mountSidebar({ sessions: [row({ id: "c", title: "Cx", agent: "codex" })] });
+    expect(wrapper.find(".agent-badge").exists()).toBe(true);
+    await wrapper.find(".item").trigger("click");
+    expect(wrapper.emitted("select")?.[0]).toEqual(["c", "codex"]);
   });
 });

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
   filter: Filter;
 }>();
 const emit = defineEmits<{
-  (e: "select", id: string): void;
+  (e: "select", id: string, agent: "claude" | "codex"): void;
   (e: "new" | "new-codex" | "toggle-layout" | "refresh"): void;
   (e: "update:filter", f: Filter): void;
 }>();
@@ -73,10 +73,11 @@ function relativeTime(ms: number): string {
         :key="s.id"
         :class="['item', { active: s.id === props.activeId, waiting: isUnread(s) }]"
         :title="s.title"
-        @click="emit('select', s.id)"
+        @click="emit('select', s.id, s.agent ?? 'claude')"
       >
         <span class="item-title">
           <span v-if="s.working && !s.waiting && s.id !== props.activeId" class="spinner" title="Claude is working" aria-label="Claude is working" />
+          <span v-if="s.agent === 'codex'" class="agent-badge">codex</span>
           {{ s.title }}
         </span>
         <span class="item-time">{{ relativeTime(s.mtime) }}</span>
@@ -207,6 +208,19 @@ function relativeTime(ms: number): string {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.agent-badge {
+  display: inline-block;
+  margin-right: 5px;
+  padding: 0 5px;
+  border-radius: 4px;
+  background: var(--bg-selected);
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  vertical-align: middle;
 }
 
 /* Background session waiting for input (Notification); cleared on foreground. */

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -13,6 +13,9 @@ export interface Session {
   /** A hidden background worker (spawnBackgroundChat hidden:true) — listed, but
    *  never treated as unread/bold. */
   hidden?: boolean;
+  /** "codex" for a codex session (from ~/.codex); absent = a Claude session. Drives the
+   *  row badge and which agent the single view resumes as. */
+  agent?: "codex";
 }
 
 // "unread" = a session whose `waiting` flag is set, EXCEPT hidden background
@@ -49,12 +52,33 @@ export function useSessions() {
   const loading = ref(true);
   const error = ref<string | null>(null);
 
+  // codex sessions (~/.codex) merged alongside Claude's — best-effort, so a codex-endpoint
+  // failure never blocks the Claude list. codex activity isn't tracked, so they read as idle.
+  async function fetchCodexSessions(): Promise<Session[]> {
+    try {
+      const res = await fetch("/api/codex/sessions");
+      if (!res.ok) return [];
+      const data = await res.json();
+      return (data.sessions ?? []).map((s: { id: string; title: string; mtime: number }): Session => ({
+        id: s.id,
+        title: s.title,
+        mtime: s.mtime,
+        working: false,
+        waiting: false,
+        agent: "codex",
+      }));
+    } catch {
+      return [];
+    }
+  }
+
   async function load(resort = false) {
     try {
-      const res = await fetch("/api/sessions");
+      const [res, codex] = await Promise.all([fetch("/api/sessions"), fetchCodexSessions()]);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      sessions.value = mergeStable(sessions.value, data.sessions ?? [], resort);
+      const incoming = [...(data.sessions ?? []), ...codex].sort((a: Session, b: Session) => b.mtime - a.mtime);
+      sessions.value = mergeStable(sessions.value, incoming, resort);
       error.value = null;
     } catch (e) {
       // load() runs on every pub/sub push; a transient refetch failure must not


### PR DESCRIPTION
## Summary

**Codex sessions in the single-view sidebar** — the last piece of single-view parity. Past codex
conversations are now listed, switchable, and resumable alongside Claude's, so codex behaves like
Claude Code in the single view end to end.

- **Server** `/api/codex/sessions?cwd=` (`server/codex-sessions.ts`): lists codex sessions for a
  workspace by reading `~/.codex` rollout files — id + a title (the first real user message) + mtime.
  **Dependency-free** (no sqlite): `node:sqlite` is experimental and would need a flag on the min
  engine, and reading rollouts is robust to codex's storage version.
- **Resume by rollout id**: `resolveCodexSession` accepts a rollout id straight from the sidebar
  (`codexRolloutExists`) and resumes it via `codex resume <id>` — reusing that id as the session key
  so reloads/reattach keep working.
- **Client**: `useSessions` merges `/api/codex/sessions` alongside Claude's (best-effort — a
  codex-endpoint failure never blocks the Claude list). Codex rows show a **`codex` badge**; clicking
  one resumes it as codex (`selectSession` threads the agent → the single view reconnects via
  `/ws/codex` with the GUI panel).

## Items to Confirm / Review

- **No side effects on Claude**: `/api/sessions` and Claude rows are unchanged; codex rows are additive
  and best-effort. `mergeStable` dedupes by id, so the two lists interleave by recency cleanly.
- **Verified end-to-end**: `/api/codex/sessions` returns real sessions with real titles; connecting
  `/ws/codex?session=<rolloutId>` echoes that id back and streams output → `codex resume <id>` fired.
- **Perf note**: the listing scans up to 200 recent rollout files and reads a bounded 64 KB head of
  each; no caching yet (Claude's list caches stats) — fine for typical histories, a caching pass is a
  follow-up if it ever shows up.
- **Codex activity isn't tracked** (no hooks like Claude), so codex rows read as idle (no working /
  unread state). Acceptable; live status for codex is a possible later enhancement.

## User Prompt

> The goal is for codex to work in the single view WITH the GUI, just like Claude Code — including being
> a first-class citizen in the sidebar (switch to / resume past codex sessions). Proceed toward that.

## Verification

`yarn format` / `lint` (0 errors) / `typecheck` / `typecheck:server` / `build` / `test` — all green
(721 tests). New tests: `parseCodexRolloutHead`, `listCodexSessions`, `codexRolloutExists`, the Sidebar
codex-row badge + agent emit.

Refs #236
