### PR TITLE
feat: activity timeline of the agent's tool calls (#243)

### DIFF
--- a/plans/feat-243-activity-timeline.md
+++ b/plans/feat-243-activity-timeline.md
@@ -1,0 +1,33 @@
+# feat #243 — アクティビティ・タイムライン（AI の tool 実行履歴）
+
+Umbrella #241 の子（B）。Claude/Codex が実行した tool（Bash/Edit/Read…）を時系列で見えるようにし、
+「結局何をした？」を追えるようにする。C/D/F が再利用する共有基盤（transcript の tool 抽出）。
+
+## スコープ（このPRのMVP）
+
+- **サーバ（純関数）**: `server/transcript.ts` に `timelineFromJsonl(raw): TimelineEvent[]` を追加。
+  `type:"assistant"` の `message.content[]` から `tool_use` ブロックを抽出し、`{ ts, tool, summary }` に整形。
+  `summary` は tool の主要 input（Bash→command、Read/Edit/Write→file_path、Grep/Glob→pattern …）を1行要約（上限140字）。
+- **エンドポイント**: `GET /api/transcript/timeline?session=&cwd=` → `{ events, truncated }`（直近 300 件に cap）。
+- **UI**: グリッドセル（`TerminalCell.vue`）ヘッダに 🕘 ボタン → `TimelineOverlay.vue`（最新が上、時刻＋toolチップ＋要約、Escで閉じる）。
+
+## 設計判断
+
+- **対象 tool**: すべての `tool_use`（Bash/Read/Edit/Write/Grep/Glob/…）。read系も「何を見たか」の手がかりとして含める。
+- **要約**: 主要 input 1つを1行化（140字上限）。command/file_path 等を優先。全文 Undo 等は非スコープ。
+- **表示面**: まずグリッドセル（並列エージェントの「何をした」把握が主用途）。単一ビューは follow-up。
+- **Undo は別 issue**（危険・スコープ大）。本PRは read-only の可視化のみ。
+
+## ファイル
+
+- `server/transcript.ts` — `TimelineEvent` / `summarizeToolInput` / `timelineFromJsonl`
+- `server/transcript.spec.ts` — timeline 抽出のテスト追加
+- `server/index.ts` — `GET /api/transcript/timeline`（`readSessionSummary` と同様に jsonl を読む）
+- `src/components/TimelineOverlay.vue`（+ `.spec.ts`）
+- `src/components/TerminalCell.vue` — 🕘 ボタン + オーバーレイ
+
+## 非スコープ / フォローアップ
+
+- 単一ビュー（`Terminal.vue`）への 🕘 追加
+- Undo / タイムラインからの操作
+- tool_result（出力）の要約表示（E #246 と役割分担）

--- a/server/index.ts
+++ b/server/index.ts
@@ -50,7 +50,9 @@ import {
   latestMeaningfulUserPromptFromJsonl,
   preferredHeaderPrompt,
   sessionUsageFromJsonl,
+  timelineFromJsonl,
   type SessionUsage,
+  type TimelineEvent,
 } from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
 import { mountGitRemoteRoute } from "./gitRemote.js";
@@ -723,6 +725,19 @@ async function readSessionSummary(cwd: string, id: string): Promise<{ lastPrompt
   }
 }
 
+// The tool-activity timeline for a session, capped to the most recent events so the
+// payload stays bounded on a long session. A missing transcript is an empty list.
+const TIMELINE_MAX_EVENTS = 300;
+async function sessionTimeline(cwd: string, id: string): Promise<{ events: TimelineEvent[]; truncated: boolean }> {
+  try {
+    const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
+    const all = timelineFromJsonl(raw);
+    return { events: all.slice(-TIMELINE_MAX_EVENTS), truncated: all.length > TIMELINE_MAX_EVENTS };
+  } catch {
+    return { events: [], truncated: false };
+  }
+}
+
 // Scan a session JSONL for a human-friendly title and last activity.
 async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> {
   const full = path.join(dir, file);
@@ -1200,6 +1215,15 @@ app.get("/api/dir-config", (req, res) => {
 app.get("/api/git-status", async (req, res) => {
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   res.json(await gitStatus(cwd));
+});
+
+// The tool-activity timeline for a session (what the agent ran, newest last), so a
+// cell can show "what did it do?" without scrolling the raw transcript.
+app.get("/api/transcript/timeline", async (req, res) => {
+  const { session } = req.query;
+  if (typeof session !== "string" || !SESSION_ID_RE.test(session)) return res.status(400).json({ error: "invalid session id" });
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  res.json(await sessionTimeline(cwd, session));
 });
 
 // Stream a directory's custom attention sound. The path never comes from the

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -7,6 +7,7 @@ import {
   userPromptText,
   parseJsonl,
   sessionUsageFromJsonl,
+  timelineFromJsonl,
 } from "./transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
@@ -158,5 +159,51 @@ describe("sessionUsageFromJsonl", () => {
   });
   it("is all-zero for an empty / promptless transcript", () => {
     expect(sessionUsageFromJsonl("")).toEqual({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+});
+
+describe("timelineFromJsonl", () => {
+  const toolTurn = (ts: string, blocks: unknown[]) => line({ type: "assistant", timestamp: ts, message: { content: blocks } });
+  const bash = (command: string) => ({ type: "tool_use", name: "Bash", input: { command, description: "d" } });
+  const read = (file_path: string) => ({ type: "tool_use", name: "Read", input: { file_path } });
+
+  it("returns [] for an empty transcript", () => {
+    expect(timelineFromJsonl("")).toEqual([]);
+  });
+
+  it("extracts tool_use events with tool name + a summary of the key input", () => {
+    const raw = [
+      line({ type: "user", message: { content: "go" } }),
+      toolTurn("2026-06-29T04:42:01.468Z", [bash("git status")]),
+      toolTurn("2026-06-29T04:42:12.806Z", [read("/a/b/GridView.vue")]),
+    ].join("\n");
+    expect(timelineFromJsonl(raw)).toEqual([
+      { ts: "2026-06-29T04:42:01.468Z", tool: "Bash", summary: "git status" },
+      { ts: "2026-06-29T04:42:12.806Z", tool: "Read", summary: "/a/b/GridView.vue" },
+    ]);
+  });
+
+  it("emits one event per tool_use block in a turn and ignores text blocks", () => {
+    const raw = toolTurn("2026-06-29T04:42:01.468Z", [{ type: "text", text: "thinking" }, bash("ls"), read("/x.ts")]);
+    const events = timelineFromJsonl(raw);
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.tool)).toEqual(["Bash", "Read"]);
+  });
+
+  it("collapses whitespace and truncates a long summary", () => {
+    const long = "echo " + "x".repeat(200);
+    const [ev] = timelineFromJsonl(toolTurn("2026-06-29T04:42:01.468Z", [bash(long)]));
+    expect(ev.summary).toHaveLength(141); // 140 chars + the ellipsis
+    expect(ev.summary.endsWith("…")).toBe(true);
+  });
+
+  it("ignores non-assistant records and malformed lines", () => {
+    const raw = [line({ type: "user", message: { content: "hi" } }), "not json", line({ type: "assistant", message: {} })].join("\n");
+    expect(timelineFromJsonl(raw)).toEqual([]);
+  });
+
+  it("uses an empty ts when the record has no timestamp", () => {
+    const raw = line({ type: "assistant", message: { content: [bash("pwd")] } });
+    expect(timelineFromJsonl(raw)[0].ts).toBe("");
   });
 });

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -189,3 +189,43 @@ export function sessionUsageFromJsonl(raw: string): SessionUsage {
   }
   return total;
 }
+
+// A single tool the agent ran, for the activity timeline. `summary` is a 1-line
+// description drawn from the tool's most salient input (a command, a file path, …).
+export interface TimelineEvent {
+  ts: string; // ISO timestamp of the assistant turn that issued the tool_use
+  tool: string; // tool name: Bash / Read / Edit / Write / Grep / …
+  summary: string;
+}
+
+const SUMMARY_MAX_CHARS = 140;
+
+const firstString = (...vals: unknown[]): string => {
+  for (const v of vals) if (typeof v === "string" && v.trim()) return v.trim();
+  return "";
+};
+
+// The most salient input field per tool, collapsed to one line and capped. Falls
+// back across the common input keys so an unknown tool still gets a useful summary.
+function summarizeToolInput(input: unknown): string {
+  const i = isRecord(input) ? input : {};
+  const raw = firstString(i.command, i.file_path, i.path, i.pattern, i.url, i.query, i.prompt, i.description);
+  const oneLine = raw.replace(/\s+/g, " ").trim();
+  return oneLine.length > SUMMARY_MAX_CHARS ? `${oneLine.slice(0, SUMMARY_MAX_CHARS)}…` : oneLine;
+}
+
+// Chronological tool_use events from a transcript, for the activity timeline. Each
+// assistant turn may carry several tool_use blocks; text blocks are ignored.
+export function timelineFromJsonl(raw: string): TimelineEvent[] {
+  const events: TimelineEvent[] = [];
+  for (const o of parseJsonl(raw)) {
+    if (o.type !== "assistant" || !isRecord(o.message) || !Array.isArray(o.message.content)) continue;
+    const ts = typeof o.timestamp === "string" ? o.timestamp : "";
+    for (const block of o.message.content) {
+      if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") {
+        events.push({ ts, tool: block.name, summary: summarizeToolInput(block.input) });
+      }
+    }
+  }
+  return events;
+}

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -809,7 +809,15 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
         <span class="cell-actions">
-          <button v-if="sessionId" class="cell-btn" title="Activity timeline" aria-label="Show activity timeline" @click="timelineOpen = true">🕘</button>
+          <button
+            v-if="sessionId && agent !== 'codex'"
+            class="cell-btn"
+            title="Activity timeline"
+            aria-label="Show activity timeline"
+            @click="timelineOpen = true"
+          >
+            🕘
+          </button>
           <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
           <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
           <button

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -7,6 +7,7 @@ import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
 import GitBranchChip from "./GitBranchChip.vue";
+import TimelineOverlay from "./TimelineOverlay.vue";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { activityStatus, type CellStatus } from "./gridTabs";
@@ -77,6 +78,8 @@ const dirBadgeStyle = computed(() => badgeStyleFor(dirConfig.value.badgeColor));
 // Live git status (branch/dirty/ahead·behind) for the header chip. `refreshGit`
 // is called alongside loadDiff() so a finished turn's changes show immediately.
 const { status: gitStatus, refresh: refreshGit } = useGitStatus(cwd);
+// Activity timeline overlay (the header 🕘) — only meaningful for a Claude session.
+const timelineOpen = ref(false);
 // The launch form's editable dir. Prefer this cell's persisted dir, then the most
 // recent preset, then the server default. Both `presets` and `defaultCwd` arrive
 // async from /api/config, so the watcher upgrades a still-pristine field once they
@@ -806,6 +809,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
         <span class="cell-actions">
+          <button v-if="sessionId" class="cell-btn" title="Activity timeline" aria-label="Show activity timeline" @click="timelineOpen = true">🕘</button>
           <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
           <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
           <button
@@ -819,6 +823,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
         </span>
       </div>
+      <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
       <TerminalView
         ref="termRef"
         class="cell-term"

--- a/src/components/TimelineOverlay.spec.ts
+++ b/src/components/TimelineOverlay.spec.ts
@@ -85,6 +85,20 @@ describe("TimelineOverlay", () => {
     w.unmount();
   });
 
+  it("clears the truncated flag on a later error (no stale '+')", async () => {
+    const okTrunc = { ok: true, json: () => Promise.resolve({ events, truncated: true }) };
+    const fail = { ok: false, json: () => Promise.resolve({}) };
+    const fetchMock = vi.fn().mockResolvedValueOnce(okTrunc).mockResolvedValueOnce(fail);
+    vi.stubGlobal("fetch", fetchMock);
+    const w = mount(TimelineOverlay, { props: { sessionId: "a", cwd: "/x", open: true } });
+    await flushPromises();
+    expect(w.find(".tl-count").text()).toContain("+");
+    await w.setProps({ sessionId: "b" }); // reload → error
+    await flushPromises();
+    expect(w.find(".tl-count").text()).not.toContain("+");
+    w.unmount();
+  });
+
   it("reloads when the session changes while the overlay stays open", async () => {
     const fetchMock = mockFetch({ events, truncated: false });
     vi.stubGlobal("fetch", fetchMock);

--- a/src/components/TimelineOverlay.spec.ts
+++ b/src/components/TimelineOverlay.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import TimelineOverlay from "./TimelineOverlay.vue";
+
+const events = [
+  { ts: "2026-06-29T04:42:01.468Z", tool: "Bash", summary: "git status" },
+  { ts: "2026-06-29T04:42:12.806Z", tool: "Read", summary: "/a/b.ts" },
+];
+
+const mockFetch = (payload: unknown, ok = true) => vi.fn().mockResolvedValue({ ok, json: () => Promise.resolve(payload) });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("TimelineOverlay", () => {
+  it("renders nothing when closed", () => {
+    const w = mount(TimelineOverlay, { props: { sessionId: "s", cwd: "/x", open: false } });
+    expect(w.find(".tl-modal").exists()).toBe(false);
+  });
+
+  it("loads and lists tool events newest-first when opened", async () => {
+    vi.stubGlobal("fetch", mockFetch({ events, truncated: false }));
+    const w = mount(TimelineOverlay, { props: { sessionId: "s", cwd: "/x", open: true } });
+    await flushPromises();
+    const rows = w.findAll(".tl-row");
+    expect(rows).toHaveLength(2);
+    // newest (Read) first
+    expect(rows[0].find(".tl-tool").text()).toBe("Read");
+    expect(rows[1].find(".tl-tool").text()).toBe("Bash");
+    expect(w.find(".tl-count").text()).toContain("2 steps");
+  });
+
+  it("shows an empty state when there is no activity", async () => {
+    vi.stubGlobal("fetch", mockFetch({ events: [], truncated: false }));
+    const w = mount(TimelineOverlay, { props: { sessionId: "s", cwd: "/x", open: true } });
+    await flushPromises();
+    expect(w.find(".tl-empty").text()).toContain("No tool activity");
+  });
+
+  it("shows an error state when the fetch fails", async () => {
+    vi.stubGlobal("fetch", mockFetch({}, false));
+    const w = mount(TimelineOverlay, { props: { sessionId: "s", cwd: "/x", open: true } });
+    await flushPromises();
+    expect(w.find(".tl-empty").text()).toContain("Couldn't load");
+  });
+
+  it("emits close from the ✕ button", async () => {
+    vi.stubGlobal("fetch", mockFetch({ events, truncated: false }));
+    const w = mount(TimelineOverlay, { props: { sessionId: "s", cwd: "/x", open: true } });
+    await flushPromises();
+    await w.find(".tl-close").trigger("click");
+    expect(w.emitted("close")).toBeTruthy();
+  });
+});

--- a/src/components/TimelineOverlay.spec.ts
+++ b/src/components/TimelineOverlay.spec.ts
@@ -61,4 +61,27 @@ describe("TimelineOverlay", () => {
     expect(w.emitted("close")).toBeTruthy();
     w.unmount();
   });
+
+  it("ignores a stale response superseded by a newer open", async () => {
+    const resp = (payload: unknown) => ({ ok: true, json: () => Promise.resolve(payload) });
+    let resolveStale: (v: unknown) => void = () => {};
+    const stale = new Promise((r) => {
+      resolveStale = r;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(stale) // first open (session a) resolves LAST
+      .mockResolvedValueOnce(resp({ events: [{ ts: "t", tool: "Read", summary: "B" }], truncated: false }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const w = mount(TimelineOverlay, { props: { sessionId: "a", cwd: "/x", open: true } });
+    await w.setProps({ open: false });
+    await w.setProps({ sessionId: "b", open: true }); // second open supersedes the first
+    await flushPromises();
+    resolveStale(resp({ events: [{ ts: "t", tool: "Bash", summary: "A" }], truncated: false }));
+    await flushPromises();
+
+    expect(w.findAll(".tl-row .tl-tool").map((n) => n.text())).toEqual(["Read"]); // newest wins, stale ignored
+    w.unmount();
+  });
 });

--- a/src/components/TimelineOverlay.spec.ts
+++ b/src/components/TimelineOverlay.spec.ts
@@ -52,4 +52,13 @@ describe("TimelineOverlay", () => {
     await w.find(".tl-close").trigger("click");
     expect(w.emitted("close")).toBeTruthy();
   });
+
+  it("closes on a document-level Escape keydown (focus-independent)", async () => {
+    vi.stubGlobal("fetch", mockFetch({ events, truncated: false }));
+    const w = mount(TimelineOverlay, { attachTo: document.body, props: { sessionId: "s", cwd: "/x", open: true } });
+    await flushPromises();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(w.emitted("close")).toBeTruthy();
+    w.unmount();
+  });
 });

--- a/src/components/TimelineOverlay.spec.ts
+++ b/src/components/TimelineOverlay.spec.ts
@@ -84,4 +84,16 @@ describe("TimelineOverlay", () => {
     expect(w.findAll(".tl-row .tl-tool").map((n) => n.text())).toEqual(["Read"]); // newest wins, stale ignored
     w.unmount();
   });
+
+  it("reloads when the session changes while the overlay stays open", async () => {
+    const fetchMock = mockFetch({ events, truncated: false });
+    vi.stubGlobal("fetch", fetchMock);
+    const w = mount(TimelineOverlay, { props: { sessionId: "a", cwd: "/x", open: true } });
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await w.setProps({ sessionId: "b" });
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    w.unmount();
+  });
 });

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -1,0 +1,171 @@
+<script setup lang="ts">
+// A read-only activity timeline for one session: the tools the agent ran (newest
+// first), fetched from GET /api/transcript/timeline. Opened from the cell header's
+// 🕘 button so you can see "what did it do?" without scrolling the raw transcript.
+import { ref, watch } from "vue";
+
+interface TimelineEvent {
+  ts: string;
+  tool: string;
+  summary: string;
+}
+
+const props = defineProps<{ sessionId: string | null; cwd: string | null; open: boolean }>();
+const emit = defineEmits<{ (e: "close"): void }>();
+
+const events = ref<TimelineEvent[]>([]);
+const truncated = ref(false);
+const loading = ref(false);
+const error = ref(false);
+
+const isTimeline = (v: unknown): v is { events: TimelineEvent[]; truncated: boolean } =>
+  typeof v === "object" && v !== null && Array.isArray((v as { events?: unknown }).events);
+
+async function load(): Promise<void> {
+  if (!props.sessionId) return;
+  loading.value = true;
+  error.value = false;
+  try {
+    const params = new URLSearchParams({ session: props.sessionId });
+    if (props.cwd) params.set("cwd", props.cwd);
+    const res = await fetch(`/api/transcript/timeline?${params.toString()}`);
+    if (!res.ok) throw new Error(String(res.status));
+    const data: unknown = await res.json();
+    events.value = isTimeline(data) ? data.events : [];
+    truncated.value = isTimeline(data) && data.truncated;
+  } catch {
+    error.value = true;
+    events.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+// Newest first for scanning recent activity.
+const reversed = () => [...events.value].reverse();
+
+const formatTime = (iso: string): string => {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? "" : d.toLocaleTimeString();
+};
+
+watch(
+  () => props.open,
+  (open) => {
+    if (open) load();
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <div v-if="open" class="tl-backdrop" @click.self="emit('close')" @keydown.escape="emit('close')">
+    <div class="tl-modal" role="dialog" aria-label="Activity timeline" tabindex="-1">
+      <div class="tl-head">
+        <span class="tl-title">Activity</span>
+        <span class="tl-count">{{ events.length }} step{{ events.length === 1 ? "" : "s" }}{{ truncated ? "+" : "" }}</span>
+        <button type="button" class="tl-close" aria-label="Close timeline" @click="emit('close')">✕</button>
+      </div>
+      <div class="tl-body">
+        <p v-if="loading" class="tl-empty">Loading…</p>
+        <p v-else-if="error" class="tl-empty">Couldn't load the timeline.</p>
+        <p v-else-if="events.length === 0" class="tl-empty">No tool activity yet.</p>
+        <ol v-else class="tl-list">
+          <li v-for="(ev, idx) in reversed()" :key="idx" class="tl-row">
+            <span class="tl-time">{{ formatTime(ev.ts) }}</span>
+            <span class="tl-tool">{{ ev.tool }}</span>
+            <span class="tl-summary" :title="ev.summary">{{ ev.summary }}</span>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tl-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+.tl-modal {
+  width: min(640px, 92vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel, #1e1e2e);
+  color: var(--text, #e6e6e6);
+  border-radius: 8px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+.tl-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+}
+.tl-title {
+  font-weight: 600;
+}
+.tl-count {
+  font-size: 0.8rem;
+  opacity: 0.6;
+}
+.tl-close {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+.tl-body {
+  overflow-y: auto;
+  padding: 6px 0;
+}
+.tl-empty {
+  padding: 24px 14px;
+  text-align: center;
+  opacity: 0.6;
+}
+.tl-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.tl-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 5px 14px;
+  font-size: 0.82rem;
+}
+.tl-row:nth-child(odd) {
+  background: color-mix(in srgb, currentColor 5%, transparent);
+}
+.tl-time {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.55;
+  font-size: 0.75rem;
+}
+.tl-tool {
+  flex: 0 0 auto;
+  font-weight: 600;
+  min-width: 4.5em;
+}
+.tl-summary {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, monospace;
+  opacity: 0.85;
+}
+</style>

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -42,6 +42,7 @@ async function load(): Promise<void> {
     if (my === req) {
       error.value = true;
       events.value = [];
+      truncated.value = false; // don't leak a prior load's "+"
     }
   } finally {
     if (my === req) loading.value = false;

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -2,7 +2,7 @@
 // A read-only activity timeline for one session: the tools the agent ran (newest
 // first), fetched from GET /api/transcript/timeline. Opened from the cell header's
 // 🕘 button so you can see "what did it do?" without scrolling the raw transcript.
-import { ref, watch, onUnmounted } from "vue";
+import { ref, watch, onUnmounted, nextTick } from "vue";
 
 interface TimelineEvent {
   ts: string;
@@ -56,20 +56,46 @@ const formatTime = (iso: string): string => {
   return Number.isNaN(d.getTime()) ? "" : d.toLocaleTimeString();
 };
 
-// Document-level Escape so dismissal works regardless of focus (the backdrop isn't
-// focused). Attached only while open; always removed on unmount.
+const modalEl = ref<HTMLElement | null>(null);
+
+// Modal keyboard behavior (mirrors SettingsModal): Escape closes; Tab is trapped in
+// the dialog so focus can't reach background controls. Document-level so it works
+// regardless of where focus lands. Attached only while open; removed on close/unmount.
 const onKeydown = (e: KeyboardEvent) => {
-  if (e.key === "Escape") emit("close");
+  if (e.key === "Escape") {
+    emit("close");
+    return;
+  }
+  if (e.key !== "Tab" || !modalEl.value) return;
+  const focusable = [...modalEl.value.querySelectorAll<HTMLElement>('button, [tabindex]:not([tabindex="-1"])')].filter((el) => !el.hasAttribute("disabled"));
+  if (focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
 };
 
+// One watch over open + identity: (re)load whenever the overlay is open — covering
+// both the open transition and a session/cwd change while it stays open (so it never
+// shows a previous session's activity) — and manage the key listener + initial focus
+// only on the open transition.
 watch(
-  () => props.open,
-  (open) => {
-    if (open) {
-      load();
-      document.addEventListener("keydown", onKeydown);
-    } else {
+  [() => props.open, () => props.sessionId, () => props.cwd],
+  (vals, oldVals) => {
+    const open = vals[0];
+    if (!open) {
       document.removeEventListener("keydown", onKeydown);
+      return;
+    }
+    load();
+    if (!oldVals?.[0]) {
+      document.addEventListener("keydown", onKeydown);
+      nextTick(() => modalEl.value?.focus());
     }
   },
   { immediate: true },
@@ -80,7 +106,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 
 <template>
   <div v-if="open" class="tl-backdrop" @click.self="emit('close')">
-    <div class="tl-modal" role="dialog" aria-modal="true" aria-label="Activity timeline" tabindex="-1">
+    <div ref="modalEl" class="tl-modal" role="dialog" aria-modal="true" aria-label="Activity timeline" tabindex="-1">
       <div class="tl-head">
         <span class="tl-title">Activity</span>
         <span class="tl-count">{{ events.length }} step{{ events.length === 1 ? "" : "s" }}{{ truncated ? "+" : "" }}</span>

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -2,7 +2,7 @@
 // A read-only activity timeline for one session: the tools the agent ran (newest
 // first), fetched from GET /api/transcript/timeline. Opened from the cell header's
 // 🕘 button so you can see "what did it do?" without scrolling the raw transcript.
-import { ref, watch } from "vue";
+import { ref, watch, onUnmounted } from "vue";
 
 interface TimelineEvent {
   ts: string;
@@ -49,17 +49,30 @@ const formatTime = (iso: string): string => {
   return Number.isNaN(d.getTime()) ? "" : d.toLocaleTimeString();
 };
 
+// Document-level Escape so dismissal works regardless of focus (the backdrop isn't
+// focused). Attached only while open; always removed on unmount.
+const onKeydown = (e: KeyboardEvent) => {
+  if (e.key === "Escape") emit("close");
+};
+
 watch(
   () => props.open,
   (open) => {
-    if (open) load();
+    if (open) {
+      load();
+      document.addEventListener("keydown", onKeydown);
+    } else {
+      document.removeEventListener("keydown", onKeydown);
+    }
   },
   { immediate: true },
 );
+
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 </script>
 
 <template>
-  <div v-if="open" class="tl-backdrop" @click.self="emit('close')" @keydown.escape="emit('close')">
+  <div v-if="open" class="tl-backdrop" @click.self="emit('close')">
     <div class="tl-modal" role="dialog" aria-label="Activity timeline" tabindex="-1">
       <div class="tl-head">
         <span class="tl-title">Activity</span>

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -18,11 +18,15 @@ const truncated = ref(false);
 const loading = ref(false);
 const error = ref(false);
 
-const isTimeline = (v: unknown): v is { events: TimelineEvent[]; truncated: boolean } =>
-  typeof v === "object" && v !== null && Array.isArray((v as { events?: unknown }).events);
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const isTimeline = (v: unknown): v is { events: TimelineEvent[]; truncated: boolean } => isRecord(v) && Array.isArray(v.events);
 
+// Bumped per load so a slow fetch for a previously-opened session can't overwrite the
+// state of a newer open (reopening quickly for a different session/cwd).
+let req = 0;
 async function load(): Promise<void> {
   if (!props.sessionId) return;
+  const my = ++req;
   loading.value = true;
   error.value = false;
   try {
@@ -31,13 +35,16 @@ async function load(): Promise<void> {
     const res = await fetch(`/api/transcript/timeline?${params.toString()}`);
     if (!res.ok) throw new Error(String(res.status));
     const data: unknown = await res.json();
+    if (my !== req) return; // superseded by a newer open
     events.value = isTimeline(data) ? data.events : [];
     truncated.value = isTimeline(data) && data.truncated;
   } catch {
-    error.value = true;
-    events.value = [];
+    if (my === req) {
+      error.value = true;
+      events.value = [];
+    }
   } finally {
-    loading.value = false;
+    if (my === req) loading.value = false;
   }
 }
 
@@ -73,7 +80,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 
 <template>
   <div v-if="open" class="tl-backdrop" @click.self="emit('close')">
-    <div class="tl-modal" role="dialog" aria-label="Activity timeline" tabindex="-1">
+    <div class="tl-modal" role="dialog" aria-modal="true" aria-label="Activity timeline" tabindex="-1">
       <div class="tl-head">
         <span class="tl-title">Activity</span>
         <span class="tl-count">{{ events.length }} step{{ events.length === 1 ? "" : "s" }}{{ truncated ? "+" : "" }}</span>


### PR DESCRIPTION
## Summary

Umbrella #241 の子 **B (#243)**。Claude/Codex が実行した tool（Bash/Read/Edit/…）を**時系列**で見えるようにし、「結局何をした？」を生トランスクリプトを追わずに把握できるようにする。**Additive** — 既存フローに変更なし。

- `transcript.ts`: `timelineFromJsonl()` がセッション JSONL の `tool_use` ブロックを `{ ts, tool, summary }` に抽出（`summary` は主要 input を1行・140字に要約）
- `GET /api/transcript/timeline?session=&cwd=` → 直近 300 件（`truncated` フラグ）
- `TimelineOverlay.vue`: グリッドセルヘッダの新 🕘 ボタン（Claude セッションのみ）から開くモーダル。最新が上、空/エラー状態あり

**この PR は C/D/F の共有基盤**（transcript の tool 抽出）でもある。

## Items to Confirm / Review

- **表示面**: まずグリッドセルのみ（並列エージェントの「何をした」把握が主用途）。単一ビュー（`Terminal.vue`）の 🕘 は follow-up。
- **要約の粒度**: 全 `tool_use` を対象、主要 input 1つを1行140字に。read 系も含める判断でよいか。
- **cap**: 直近 300 件。長時間セッションでの上限として妥当か。
- **Undo / tool_result の出力表示**は非スコープ（Undo は別 issue、出力要約は E #246 と役割分担）。

## Verification

- `GET /api/transcript/timeline` をライブ確認：実セッションで 300 件（`truncated:true`）を正しく抽出、不正 session id → 400
- `server/transcript.spec.ts`（timeline 抽出：複数ブロック / text 無視 / 140字切り詰め / 不正行 / ts 欠落）+ `TimelineOverlay.spec.ts`（開閉・newest-first・空・エラー・close emit）追加
- `typecheck` / `typecheck:server` / `build` 通過。lint はローカルでは並列エージェントの worktree（`.claude/worktrees/**`）を `eslint .` が拾って誤検知するため、対象ディレクトリに絞って確認：`eslint server src` → 0 errors（意図的な spawnClaudePty max-params warn のみ）。CI はクリーンチェックアウトのため影響なし
- 対象テスト（transcript + timeline）59 passed

## User Prompt

> 順次対応していこう / merge ok そして、並列ですすめて（Umbrella #241 の子issueを並列で実装。本PRは B / #243）

## Plan

`plans/feat-243-activity-timeline.md`。

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)