### PR TITLE
feat: command output AI summary / Explain on Run cells (#246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ server, and opens the browser. For local development from a clone, see
 - [Server API specification](#server-api-specification)
   - [HTTP: `GET /api/sessions`](#http-get-apisessions)
   - [HTTP: `GET /api/scripts`](#http-get-apiscripts)
+  - [HTTP: `POST /api/command/summarize`](#http-post-apicommandsummarize)
   - [HTTP: `POST /api/hook`](#http-post-apihook)
   - [WebSocket: `/ws` (terminal)](#websocket-ws-terminal)
   - [WebSocket: `/ws/run` (command terminal)](#websocket-wsrun-command-terminal)
@@ -342,6 +343,13 @@ offers a **↻ re-run**. The browser only ever sends the script's **index** + it
 directory; the server reads that directory's `script.json` and resolves the
 command, so the file is the allowlist of what can run.
 
+Each command cell also has a **✦ Summarize** button: click it to send the cell's
+captured output to `claude -p` (headless) and get a short **Errors / Warnings /
+likely cause / suggested fix** note in a panel — handy when a build or install
+buries the one failing line in thousands. It's manual (never auto-runs) and analyzes
+the last 32 KB of output. See
+[`POST /api/command/summarize`](#http-post-apicommandsummarize).
+
 ---
 
 ## Files view (browse & edit)
@@ -417,6 +425,33 @@ position the client sends back to `/ws/run`).
 
 A missing or invalid `script.json` is **not** an error — it yields an empty
 `scripts` array.
+
+### HTTP: `POST /api/command/summarize`
+
+Runs `claude -p` **headless** over a command cell's captured terminal output and
+returns a short summary (Errors / Warnings / likely cause / suggested fix). Backs the
+**✦ Summarize** button on a Run cell (see [Scripts (Run menu)](#scripts-run-menu)).
+The browser sends the cell's xterm buffer as `log`; the server truncates it to the
+last **32 KB** (the tail, where errors + the exit line live), runs the CLI with the
+log piped on stdin (argv — no shell), and returns its answer. Same-origin guarded.
+
+**Request `application/json`**:
+
+```jsonc
+{ "log": "npm ERR! cannot find module 'foo'\n..." }
+```
+
+**Response `200 application/json`**:
+
+```jsonc
+{
+  "summary": "Errors: cannot find module 'foo'\nSuggested fix: run `yarn add foo`",
+  "truncated": false // true when the log exceeded 32 KB and only the tail was analyzed
+}
+```
+
+Empty output returns a `{ summary }` note rather than calling the CLI. Errors:
+`400` (missing `log`), `403` (disallowed origin), `502` (the `claude` run failed).
 
 ### HTTP: `POST /api/hook`
 

--- a/plans/feat-246-command-output-summary.md
+++ b/plans/feat-246-command-output-summary.md
@@ -1,0 +1,65 @@
+# feat #246 — Command output AI summary / Explain (Run cell)
+
+Parent umbrella: #241 (Terminal + AI state/visualisation/assist layer). This is
+child **E**.
+
+## Problem
+
+`npm install` / `cargo build` / `docker logs` produce thousands of lines. The user
+usually only wants the **failure reason or the warnings**, plus a likely cause and a
+fix — but those are buried, and the log must be read by hand.
+
+## Scope (MVP)
+
+A **manual** "Summarize / Explain" action on a **command cell** (the `/ws/run`
+script cells — NOT Claude sessions). Clicking it sends the cell's captured terminal
+output to a new server endpoint that runs `claude -p` (headless, non-interactive) and
+returns a short structured summary (Errors / Warnings / likely cause / suggested fix).
+The result renders in a small panel inside the cell.
+
+## Design decisions
+
+- **Trigger — manual button.** The ✦ Summarize button lives in the command cell
+  header and is shown at all times (a manual action; the user decides when the output
+  is worth explaining). It never auto-runs. Empty output is handled gracefully
+  server-side.
+- **Capture — client sends the xterm buffer.** The xterm buffer already lives on the
+  client, so the cell reads it (via a new `readOutput()` exposed from `Terminal.vue`
+  → `useTerminalConnections.readBuffer`) and POSTs the text. No new server-side
+  capture path is needed.
+- **Truncation — last 32 KB.** Capped client-side (cheap) AND server-side (defence in
+  depth) via a pure `truncateLog(log, maxKb)` that keeps the **tail** (errors/exit live
+  there) and drops a leading partial line.
+- **Endpoint — `POST /api/command/summarize`** in a new module
+  `server/command-summary.ts` exposing `mountCommandSummaryRoute(app, { isAllowedOrigin })`
+  (mirrors `mountPickFileRoute`: same-origin guarded like the other local-action
+  routes). It spawns `claude -p "<prompt>"` via `node:child_process` (argv, no shell),
+  feeding the truncated log on **stdin** (`cat log | claude -p "explain"`), and returns
+  `{ summary, truncated }`.
+- **Spawn isolated for testing.** The child spawn is a small `runClaudeHeadless`
+  helper injected into `summarizeLog(log, { runClaude })` so tests mock it — no CLI /
+  API key needed. Pure helpers `truncateLog`, `buildSummaryPrompt`, `parseSummaryOutput`
+  are unit-tested directly.
+- **Prompt.** Asks claude to report only Errors / Warnings / Likely cause / Suggested
+  fix, concisely (< ~120 words), and to omit sections that don't apply.
+
+## Files
+
+- `server/command-summary.ts` (new) — route + pure helpers + spawn helper.
+- `server/command-summary.spec.ts` (new) — truncation boundary, prompt, parse, happy
+  path, empty output, spawn failure.
+- `server/index.ts` — one import + one `mountCommandSummaryRoute(app, { isAllowedOrigin })`.
+- `src/composables/useTerminalConnections.ts` — `readBuffer(key)` reads the xterm buffer.
+- `src/components/Terminal.vue` — expose `readOutput()`.
+- `src/components/CommandCell.vue` — Summarize button + result panel + fetch.
+- `src/components/CommandCell.spec.ts` — button/panel/fetch behaviour (mocked).
+- `README.md` — document the endpoint + the cell action.
+
+## Non-scope (deferred)
+
+- Auto-run on `exit != 0` (#246 option 2) — kept manual for the MVP.
+- `error|warn` grep pre-extraction to compress the payload (#246 option 3) — plain
+  tail-truncation for now.
+- Counting the summary's own token spend into the #245 (#D) cost roll-up.
+- Structured JSON sections in the response — returns a single `summary` string.
+- Summarizing Claude sessions (only `/ws/run` command cells are in scope).

--- a/server/command-summary.spec.ts
+++ b/server/command-summary.spec.ts
@@ -23,6 +23,16 @@ describe("truncateLog", () => {
     expect(text.startsWith("OLD-HEAD-LINE")).toBe(false);
   });
 
+  it("keeps the first line intact when the cut lands exactly on a line boundary", () => {
+    const firstLine = "KEEP-FIRST-LINE\n";
+    const tail = firstLine + "y".repeat(2 * KB - firstLine.length); // exactly 2 KB of whole lines
+    const log = "PRECEDING-DROPPED-LINE\n" + tail; // the byte before the cut is the '\n'
+    const { text, truncated } = truncateLog(log, 2);
+    expect(truncated).toBe(true);
+    expect(text.startsWith("KEEP-FIRST-LINE")).toBe(true); // NOT dropped at a boundary cut
+    expect(text).not.toContain("PRECEDING-DROPPED-LINE");
+  });
+
   it("just-over-the-cap by one byte truncates", () => {
     const log = "h\n" + "y".repeat(KB);
     expect(truncateLog(log, 1).truncated).toBe(true);

--- a/server/command-summary.spec.ts
+++ b/server/command-summary.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { truncateLog, buildSummaryPrompt, parseSummaryOutput, summarizeLog, MAX_LOG_KB, type RunClaude } from "./command-summary.js";
+import { truncateLog, buildSummaryPrompt, normalizeLocale, parseSummaryOutput, summarizeLog, MAX_LOG_KB, type RunClaude } from "./command-summary.js";
 
 const KB = 1024;
 const ok = (stdout: string): RunClaude => vi.fn(async () => ({ stdout, stderr: "", code: 0 }));
@@ -48,9 +48,23 @@ describe("truncateLog", () => {
 });
 
 describe("buildSummaryPrompt", () => {
-  it("asks for the four labelled sections", () => {
-    const p = buildSummaryPrompt();
-    for (const label of ["Errors:", "Warnings:", "Likely cause:", "Suggested fix:"]) expect(p).toContain(label);
+  it("names the four things to report and defaults to English", () => {
+    const p = buildSummaryPrompt().toLowerCase();
+    for (const s of ["error", "warning", "cause", "fix"]) expect(p).toContain(s);
+    expect(buildSummaryPrompt()).toContain('"en"');
+  });
+  it("instructs the reply language from the given locale", () => {
+    expect(buildSummaryPrompt("ja")).toContain('"ja"');
+  });
+});
+
+describe("normalizeLocale", () => {
+  it("reduces a full tag to its base language", () => {
+    expect(normalizeLocale("ja-JP")).toBe("ja");
+    expect(normalizeLocale("en-US")).toBe("en");
+  });
+  it("falls back to en for missing / malformed input", () => {
+    for (const bad of [undefined, "", "../evil", 123, "toolonglanguagecode"]) expect(normalizeLocale(bad)).toBe("en");
   });
 });
 
@@ -70,6 +84,12 @@ describe("summarizeLog", () => {
     expect(res).toEqual({ summary: "Errors: missing module\nSuggested fix: yarn add foo", truncated: false });
     expect(runClaude).toHaveBeenCalledOnce();
     expect(runClaude.mock.calls[0][0].input).toContain("npm ERR!");
+  });
+
+  it("threads the locale into the prompt so claude replies in that language", async () => {
+    const runClaude = ok("要約: モジュール不足");
+    await summarizeLog("npm ERR!", { runClaude, locale: "ja" });
+    expect(runClaude.mock.calls[0][0].prompt).toContain('"ja"');
   });
 
   it("short-circuits empty output without spawning claude", async () => {

--- a/server/command-summary.spec.ts
+++ b/server/command-summary.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { truncateLog, buildSummaryPrompt, parseSummaryOutput, summarizeLog, MAX_LOG_KB, type RunClaude } from "./command-summary.js";
+
+const KB = 1024;
+const ok = (stdout: string): RunClaude => vi.fn(async () => ({ stdout, stderr: "", code: 0 }));
+
+describe("truncateLog", () => {
+  it("returns short logs unchanged and not truncated", () => {
+    expect(truncateLog("hello\nworld")).toEqual({ text: "hello\nworld", truncated: false });
+  });
+
+  it("keeps a log exactly at the cap unchanged (boundary)", () => {
+    const exact = "a".repeat(2 * KB);
+    expect(truncateLog(exact, 2)).toEqual({ text: exact, truncated: false });
+  });
+
+  it("keeps the TAIL and drops the leading partial line when over the cap", () => {
+    const log = "OLD-HEAD-LINE\n" + "x".repeat(2 * KB) + "\nTAIL-ERROR";
+    const { text, truncated } = truncateLog(log, 2);
+    expect(truncated).toBe(true);
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(2 * KB);
+    expect(text).toContain("TAIL-ERROR");
+    expect(text.startsWith("OLD-HEAD-LINE")).toBe(false);
+  });
+
+  it("just-over-the-cap by one byte truncates", () => {
+    const log = "h\n" + "y".repeat(KB);
+    expect(truncateLog(log, 1).truncated).toBe(true);
+  });
+
+  it("defaults to MAX_LOG_KB", () => {
+    expect(truncateLog("z".repeat(MAX_LOG_KB * KB + 1)).truncated).toBe(true);
+  });
+
+  it("handles an empty log", () => {
+    expect(truncateLog("")).toEqual({ text: "", truncated: false });
+  });
+});
+
+describe("buildSummaryPrompt", () => {
+  it("asks for the four labelled sections", () => {
+    const p = buildSummaryPrompt();
+    for (const label of ["Errors:", "Warnings:", "Likely cause:", "Suggested fix:"]) expect(p).toContain(label);
+  });
+});
+
+describe("parseSummaryOutput", () => {
+  it("trims surrounding whitespace", () => {
+    expect(parseSummaryOutput("\n  Errors: boom\n")).toBe("Errors: boom");
+  });
+  it("returns empty for whitespace-only output", () => {
+    expect(parseSummaryOutput("   \n")).toBe("");
+  });
+});
+
+describe("summarizeLog", () => {
+  it("runs claude on the truncated log and returns its summary (happy path)", async () => {
+    const runClaude = ok("Errors: missing module\nSuggested fix: yarn add foo");
+    const res = await summarizeLog("npm ERR! cannot find module foo", { runClaude });
+    expect(res).toEqual({ summary: "Errors: missing module\nSuggested fix: yarn add foo", truncated: false });
+    expect(runClaude).toHaveBeenCalledOnce();
+    expect(runClaude.mock.calls[0][0].input).toContain("npm ERR!");
+  });
+
+  it("short-circuits empty output without spawning claude", async () => {
+    const runClaude = ok("unused");
+    const res = await summarizeLog("   \n\t", { runClaude });
+    expect(res.summary).toMatch(/No command output/i);
+    expect(runClaude).not.toHaveBeenCalled();
+  });
+
+  it("passes the truncated tail (not the head) to claude when over the cap", async () => {
+    const runClaude = ok("Errors: fail");
+    const log = "HEAD\n" + "x".repeat(2 * KB) + "\nDEEP-TAIL";
+    await summarizeLog(log, { runClaude, maxLogKb: 2 });
+    const input = runClaude.mock.calls[0][0].input;
+    expect(input).toContain("DEEP-TAIL");
+    expect(input.startsWith("HEAD")).toBe(false);
+  });
+
+  it("throws when claude produces no output (failure)", async () => {
+    const runClaude: RunClaude = vi.fn(async () => ({ stdout: "", stderr: "not logged in", code: 1 }));
+    await expect(summarizeLog("some log", { runClaude })).rejects.toThrow(/not logged in/);
+  });
+
+  it("propagates a spawn failure", async () => {
+    const runClaude: RunClaude = vi.fn(async () => {
+      throw new Error("spawn claude ENOENT");
+    });
+    await expect(summarizeLog("some log", { runClaude })).rejects.toThrow(/ENOENT/);
+  });
+});

--- a/server/command-summary.ts
+++ b/server/command-summary.ts
@@ -40,16 +40,28 @@ export function truncateLog(log: string, maxKb: number = MAX_LOG_KB): TruncatedL
   return { text: startsMidLine && firstNewline >= 0 ? tail.slice(firstNewline + 1) : tail, truncated: true };
 }
 
+export const DEFAULT_LOCALE = "en";
+
+// Reduce a client-supplied locale to a safe base language code (e.g. "ja-JP" -> "ja").
+// The value is interpolated into the claude prompt, so anything unexpected falls back
+// to the default rather than injecting a free-form string.
+export function normalizeLocale(v: unknown): string {
+  const base = typeof v === "string" ? v.split("-")[0].toLowerCase() : "";
+  return /^[a-z]{2,8}$/.test(base) ? base : DEFAULT_LOCALE;
+}
+
 // The headless instruction passed as `claude -p <prompt>`; the log rides on stdin.
-export function buildSummaryPrompt(): string {
+// The reply (including its section labels) is written in the caller's language.
+export function buildSummaryPrompt(locale: string = DEFAULT_LOCALE): string {
   return [
     "You are given the captured terminal output of a single shell command on stdin.",
-    "Reply CONCISELY in plain text (no markdown), under ~120 words, using only these",
-    "labelled lines and OMITTING any that do not apply:",
-    "Errors: the concrete error(s)",
-    "Warnings: notable warnings",
-    "Likely cause: the most probable root cause",
-    "Suggested fix: the smallest actionable next step",
+    `Write your ENTIRE reply — including the section labels — in the language of IETF locale code "${locale}" (e.g. "ja" = Japanese, "en" = English).`,
+    "Reply CONCISELY in plain text (no markdown), under ~120 words, using short labelled",
+    "lines for each of the following and OMITTING any that do not apply:",
+    "- the concrete error(s)",
+    "- notable warnings",
+    "- the most probable root cause",
+    "- the smallest actionable next step (the fix)",
     "Do not echo the log back.",
   ].join("\n");
 }
@@ -102,6 +114,7 @@ export interface SummarizeDeps {
   runClaude?: RunClaude;
   claudeBin?: string;
   maxLogKb?: number;
+  locale?: string;
 }
 
 // Truncate the log, then (unless it's empty) run claude headless for a summary.
@@ -110,7 +123,12 @@ export async function summarizeLog(log: string, deps: SummarizeDeps = {}): Promi
   const bin = deps.claudeBin ?? claudeAdapter.bin();
   const { text, truncated } = truncateLog(log, deps.maxLogKb ?? MAX_LOG_KB);
   if (!text.trim()) return { summary: EMPTY_OUTPUT_SUMMARY, truncated };
-  const { stdout, stderr, code } = await runClaude({ bin, prompt: buildSummaryPrompt(), input: text, timeoutMs: SUMMARY_TIMEOUT_MS });
+  const { stdout, stderr, code } = await runClaude({
+    bin,
+    prompt: buildSummaryPrompt(deps.locale ?? DEFAULT_LOCALE),
+    input: text,
+    timeoutMs: SUMMARY_TIMEOUT_MS,
+  });
   const summary = parseSummaryOutput(stdout);
   if (!summary) throw new Error(stderr.trim() || `claude produced no summary (exit ${code})`);
   return { summary, truncated };
@@ -129,7 +147,7 @@ export function mountCommandSummaryRoute(app: Express, { isAllowedOrigin }: Comm
     const body = isRecord(req.body) ? req.body : {};
     if (typeof body.log !== "string") return res.status(400).json({ error: "body.log (string) required" });
     try {
-      res.json(await summarizeLog(body.log));
+      res.json(await summarizeLog(body.log, { locale: normalizeLocale(body.locale) }));
     } catch (e) {
       res.status(502).json({ error: `summary failed: ${messageOf(e)}` });
     }

--- a/server/command-summary.ts
+++ b/server/command-summary.ts
@@ -24,13 +24,20 @@ export interface TruncatedLog {
 
 // Keep the LAST maxKb of the log. When it overflows, drop the leading partial line so
 // a half-line (or a codepoint split by the byte cut) doesn't head the excerpt.
+const NEWLINE_BYTE = 0x0a;
 export function truncateLog(log: string, maxKb: number = MAX_LOG_KB): TruncatedLog {
   const maxBytes = maxKb * BYTES_PER_KB;
   const buf = Buffer.from(log, "utf8");
   if (buf.length <= maxBytes) return { text: log, truncated: false };
-  const tail = buf.subarray(buf.length - maxBytes).toString("utf8");
+  const cut = buf.length - maxBytes;
+  const tail = buf.subarray(cut).toString("utf8");
+  // Only drop the leading line when the cut landed MID-line (the byte before the tail
+  // isn't a newline) — that partial line, and any codepoint split by the byte cut,
+  // is noise. At an exact line boundary the tail already starts with a whole line, so
+  // dropping it would discard a valid line (possibly the key error).
+  const startsMidLine = buf[cut - 1] !== NEWLINE_BYTE;
   const firstNewline = tail.indexOf("\n");
-  return { text: firstNewline >= 0 ? tail.slice(firstNewline + 1) : tail, truncated: true };
+  return { text: startsMidLine && firstNewline >= 0 ? tail.slice(firstNewline + 1) : tail, truncated: true };
 }
 
 // The headless instruction passed as `claude -p <prompt>`; the log rides on stdin.

--- a/server/command-summary.ts
+++ b/server/command-summary.ts
@@ -1,0 +1,130 @@
+// AI summary / Explain for a Run-menu command cell (issue #246). The browser sends
+// the cell's captured terminal output; we run `claude -p` headless (non-interactive)
+// and return a short Errors / Warnings / cause / fix summary. Extracted from index.ts
+// so the pure logic (truncate / prompt / parse) and the spawn helper are unit-testable
+// without an HTTP server or the `claude` CLI.
+import type { Express, Request } from "express";
+import { spawn } from "node:child_process";
+import { claudeAdapter } from "./agents/claude.js";
+
+const BYTES_PER_KB = 1024;
+// Cap the log we send to claude. The tail is what matters (errors + the exit line
+// live there), and this bounds both the request body and the summary's token cost.
+export const MAX_LOG_KB = 32;
+const SUMMARY_TIMEOUT_MS = 60_000;
+const EMPTY_OUTPUT_SUMMARY = "No command output to summarize yet.";
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const messageOf = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+export interface TruncatedLog {
+  text: string;
+  truncated: boolean;
+}
+
+// Keep the LAST maxKb of the log. When it overflows, drop the leading partial line so
+// a half-line (or a codepoint split by the byte cut) doesn't head the excerpt.
+export function truncateLog(log: string, maxKb: number = MAX_LOG_KB): TruncatedLog {
+  const maxBytes = maxKb * BYTES_PER_KB;
+  const buf = Buffer.from(log, "utf8");
+  if (buf.length <= maxBytes) return { text: log, truncated: false };
+  const tail = buf.subarray(buf.length - maxBytes).toString("utf8");
+  const firstNewline = tail.indexOf("\n");
+  return { text: firstNewline >= 0 ? tail.slice(firstNewline + 1) : tail, truncated: true };
+}
+
+// The headless instruction passed as `claude -p <prompt>`; the log rides on stdin.
+export function buildSummaryPrompt(): string {
+  return [
+    "You are given the captured terminal output of a single shell command on stdin.",
+    "Reply CONCISELY in plain text (no markdown), under ~120 words, using only these",
+    "labelled lines and OMITTING any that do not apply:",
+    "Errors: the concrete error(s)",
+    "Warnings: notable warnings",
+    "Likely cause: the most probable root cause",
+    "Suggested fix: the smallest actionable next step",
+    "Do not echo the log back.",
+  ].join("\n");
+}
+
+// `claude -p` prints the answer to stdout; trim the surrounding whitespace.
+export function parseSummaryOutput(stdout: string): string {
+  return stdout.trim();
+}
+
+export interface ClaudeRunResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+}
+
+export type RunClaude = (params: { bin: string; prompt: string; input: string; timeoutMs: number }) => Promise<ClaudeRunResult>;
+
+// Default spawn: run `claude -p <prompt>`, feed the log on stdin, collect stdout.
+// Argv (no shell), so nothing in the log or prompt is re-interpreted by a shell. A
+// timeout kills a hung CLI so the request can't wait forever. Injected into
+// summarizeLog so tests mock it — no `claude` binary needed.
+export const runClaudeHeadless: RunClaude = ({ bin, prompt, input, timeoutMs }) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(bin, ["-p", prompt], { stdio: ["pipe", "pipe", "pipe"] });
+    const out: Buffer[] = [];
+    const err: Buffer[] = [];
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`claude summary timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    child.on("error", (e) => {
+      clearTimeout(timer);
+      reject(new Error(`failed to spawn claude: ${messageOf(e)}`));
+    });
+    child.stdout.on("data", (c: Buffer) => out.push(c));
+    child.stderr.on("data", (c: Buffer) => err.push(c));
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ stdout: Buffer.concat(out).toString("utf8"), stderr: Buffer.concat(err).toString("utf8"), code });
+    });
+    child.stdin.end(input);
+  });
+
+export interface SummaryResult {
+  summary: string;
+  truncated: boolean;
+}
+
+export interface SummarizeDeps {
+  runClaude?: RunClaude;
+  claudeBin?: string;
+  maxLogKb?: number;
+}
+
+// Truncate the log, then (unless it's empty) run claude headless for a summary.
+export async function summarizeLog(log: string, deps: SummarizeDeps = {}): Promise<SummaryResult> {
+  const runClaude = deps.runClaude ?? runClaudeHeadless;
+  const bin = deps.claudeBin ?? claudeAdapter.bin();
+  const { text, truncated } = truncateLog(log, deps.maxLogKb ?? MAX_LOG_KB);
+  if (!text.trim()) return { summary: EMPTY_OUTPUT_SUMMARY, truncated };
+  const { stdout, stderr, code } = await runClaude({ bin, prompt: buildSummaryPrompt(), input: text, timeoutMs: SUMMARY_TIMEOUT_MS });
+  const summary = parseSummaryOutput(stdout);
+  if (!summary) throw new Error(stderr.trim() || `claude produced no summary (exit ${code})`);
+  return { summary, truncated };
+}
+
+interface CommandSummaryDeps {
+  isAllowedOrigin: (origin?: string) => boolean;
+}
+
+// POST /api/command/summarize { log } -> { summary, truncated }. Same-origin guarded
+// like the other local-action routes so a random site the user visits can't drive the
+// local `claude` binary. Mirrors mountPickFileRoute's shape.
+export function mountCommandSummaryRoute(app: Express, { isAllowedOrigin }: CommandSummaryDeps): void {
+  app.post("/api/command/summarize", async (req: Request, res) => {
+    if (!isAllowedOrigin(req.headers.origin)) return res.status(403).json({ error: "forbidden origin" });
+    const body = isRecord(req.body) ? req.body : {};
+    if (typeof body.log !== "string") return res.status(400).json({ error: "body.log (string) required" });
+    try {
+      res.json(await summarizeLog(body.log));
+    } catch (e) {
+      res.status(502).json({ error: `summary failed: ${messageOf(e)}` });
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -56,6 +56,7 @@ import { mountOpenDirRoute } from "./open-dir.js";
 import { mountGitRemoteRoute } from "./gitRemote.js";
 import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
+import { mountCommandSummaryRoute } from "./command-summary.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountWikiRoutes } from "./backends/wiki.js";
 import { initAccountingBackend, mountAccountingRoutes } from "./backends/accounting.js";
@@ -1157,6 +1158,11 @@ mountWorktreeRoutes(app, { isAllowedOrigin });
 // path(s) — how a browser tab inserts a real filesystem path into the terminal
 // (the browser hides paths from drag/drop and <input type=file>).
 mountPickFileRoute(app, { isAllowedOrigin });
+
+// POST /api/command/summarize runs `claude -p` headless over a Run cell's captured
+// terminal output and returns a short Errors/Warnings/cause/fix summary (issue #246).
+// Same-origin guarded like the other local-action routes.
+mountCommandSummaryRoute(app, { isAllowedOrigin });
 
 // POST /api/remote-host/connect|disconnect + GET /status — start/stop the
 // Firestore host loop from the toolbar Connect control. Same-origin guarded like

--- a/src/components/CommandCell.spec.ts
+++ b/src/components/CommandCell.spec.ts
@@ -84,7 +84,9 @@ describe("CommandCell summarize", () => {
     expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe("/api/command/summarize");
-    expect(JSON.parse(String(init?.body)).log).toContain("npm ERR!");
+    const sent = JSON.parse(String(init?.body));
+    expect(sent.log).toContain("npm ERR!");
+    expect(typeof sent.locale).toBe("string"); // browser locale forwarded for the reply language
     expect(w.find(".cell-summary-text").text()).toContain("missing module foo");
   });
 

--- a/src/components/CommandCell.spec.ts
+++ b/src/components/CommandCell.spec.ts
@@ -72,7 +72,7 @@ describe("CommandCell summarize", () => {
   });
 
   it("posts the captured output and renders the returned summary", async () => {
-    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(() =>
       Promise.resolve(jsonResponse({ summary: "Errors: missing module foo\nSuggested fix: yarn add foo", truncated: false })),
     );
     vi.stubGlobal("fetch", fetchMock);

--- a/src/components/CommandCell.spec.ts
+++ b/src/components/CommandCell.spec.ts
@@ -1,24 +1,34 @@
-import { describe, it, expect, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import CommandCell from "./CommandCell.vue";
 
-// Stub the terminal so no xterm/WebSocket is needed; it just forwards the props the
-// cell passes (command/connectKey) and can emit "exit" to drive the re-run UI.
+// Stub the terminal so no xterm/WebSocket is needed; it forwards the props the cell
+// passes (command/connectKey), can emit "exit" to drive the re-run UI, and exposes
+// readOutput() so the summarize action has captured output to send.
+const CAPTURED_OUTPUT = "npm ERR! cannot find module foo";
 vi.mock("./Terminal.vue", () => ({
   default: {
     name: "TerminalView",
     props: ["sessionId", "connectKey", "cwd", "command"],
     emits: ["exit"],
     template: '<div class="stub-term" />',
+    methods: {
+      readOutput() {
+        return CAPTURED_OUTPUT;
+      },
+    },
   },
 }));
 
 const COMMAND = { index: 2, label: "Dev server", cwd: "/work/proj" };
 const mountCell = () => mount(CommandCell, { props: { expanded: false, command: COMMAND, home: "/work" } });
 const term = (w: ReturnType<typeof mount>) => w.findComponent({ name: "TerminalView" });
+const jsonResponse = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status });
 
 describe("CommandCell", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it("shows the label + dir and runs the command in its directory", () => {
     const w = mountCell();
     expect(w.find(".cell-cmd").text()).toContain("Dev server");
@@ -49,5 +59,68 @@ describe("CommandCell", () => {
     await w.find('[aria-label="Close terminal"]').trigger("click");
     expect(w.emitted("toggle-expand")).toHaveLength(1);
     expect(w.emitted("close")).toHaveLength(1);
+  });
+});
+
+describe("CommandCell summarize", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("has no summary panel until the button is clicked", () => {
+    const w = mountCell();
+    expect(w.find('[aria-label="Summarize command output"]').exists()).toBe(true);
+    expect(w.find(".cell-summary").exists()).toBe(false);
+  });
+
+  it("posts the captured output and renders the returned summary", async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(jsonResponse({ summary: "Errors: missing module foo\nSuggested fix: yarn add foo", truncated: false })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const w = mountCell();
+    await w.find('[aria-label="Summarize command output"]').trigger("click");
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/command/summarize");
+    expect(JSON.parse(String(init?.body)).log).toContain("npm ERR!");
+    expect(w.find(".cell-summary-text").text()).toContain("missing module foo");
+  });
+
+  it("shows the truncation note when the server truncated the log", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ summary: "Errors: boom", truncated: true })),
+    );
+    const w = mountCell();
+    await w.find('[aria-label="Summarize command output"]').trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-summary-note").exists()).toBe(true);
+  });
+
+  it("surfaces the server error message on failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ error: "summary failed: not logged in" }, 502)),
+    );
+    const w = mountCell();
+    await w.find('[aria-label="Summarize command output"]').trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-summary-error").text()).toContain("not logged in");
+    expect(w.find(".cell-summary-text").exists()).toBe(false);
+  });
+
+  it("dismisses the summary panel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ summary: "ok", truncated: false })),
+    );
+    const w = mountCell();
+    await w.find('[aria-label="Summarize command output"]').trigger("click");
+    await flushPromises();
+    expect(w.find(".cell-summary").exists()).toBe(true);
+    await w.find('[aria-label="Dismiss summary"]').trigger("click");
+    expect(w.find(".cell-summary").exists()).toBe(false);
   });
 });

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -26,6 +26,7 @@ const emit = defineEmits<{
 // connectKey forces Terminal.vue to (re)connect — bumped to re-run after exit.
 const connectKey = ref(0);
 const finished = ref(false);
+const termRef = ref<InstanceType<typeof TerminalView>>();
 
 const dirDisplay = computed(() => formatCwd(props.command.cwd, props.home));
 
@@ -39,6 +40,65 @@ function onExit() {
 function rerun() {
   finished.value = false;
   connectKey.value++;
+}
+
+// AI "Summarize / Explain": send the cell's captured terminal output to the server,
+// which runs `claude -p` headless and returns a short Errors/Warnings/cause/fix note.
+type SummaryState = "idle" | "loading" | "done" | "error";
+const summaryState = ref<SummaryState>("idle");
+const summaryText = ref("");
+const summaryError = ref("");
+const summaryTruncated = ref(false);
+const showSummary = ref(false);
+
+// A local terminal request, but still bounded: don't wait forever on a hung CLI.
+const SUMMARY_FETCH_TIMEOUT_MS = 90_000;
+// Client-side cap on the bytes sent (the server re-caps to its own tail limit).
+const MAX_SEND_CHARS = 64 * 1024;
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+async function postSummary(log: string): Promise<{ summary: string; truncated: boolean }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SUMMARY_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch("/api/command/summarize", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ log }),
+      signal: controller.signal,
+    });
+    const data: unknown = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(isRecord(data) && typeof data.error === "string" ? data.error : `request failed (${res.status})`);
+    return {
+      summary: isRecord(data) && typeof data.summary === "string" ? data.summary : "",
+      truncated: isRecord(data) && data.truncated === true,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function summarize() {
+  summaryState.value = "loading";
+  showSummary.value = true;
+  summaryError.value = "";
+  summaryText.value = "";
+  try {
+    const { summary, truncated } = await postSummary((termRef.value?.readOutput() ?? "").slice(-MAX_SEND_CHARS));
+    summaryText.value = summary;
+    summaryTruncated.value = truncated;
+    summaryState.value = "done";
+  } catch (e) {
+    summaryError.value = e instanceof Error ? e.message : String(e);
+    summaryState.value = "error";
+  }
+}
+
+function closeSummary() {
+  showSummary.value = false;
 }
 </script>
 
@@ -55,6 +115,16 @@ function rerun() {
         <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move command right" @click="emit('move', 1)">▶</button>
         <button v-if="finished" class="cell-btn" title="Re-run" aria-label="Re-run command" @click="rerun">↻</button>
         <button
+          class="cell-btn cell-summarize"
+          :class="{ 'is-busy': summaryState === 'loading' }"
+          title="Summarize output (AI)"
+          aria-label="Summarize command output"
+          :disabled="summaryState === 'loading'"
+          @click="summarize"
+        >
+          {{ summaryState === "loading" ? "⋯" : "✦" }}
+        </button>
+        <button
           class="cell-btn"
           :title="expanded ? 'Restore' : 'Expand'"
           :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
@@ -65,7 +135,21 @@ function rerun() {
         <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
       </span>
     </div>
-    <TerminalView class="cell-term" :session-id="null" :connect-key="connectKey" :cwd="command.cwd" :command="command" @exit="onExit" />
+    <TerminalView ref="termRef" class="cell-term" :session-id="null" :connect-key="connectKey" :cwd="command.cwd" :command="command" @exit="onExit" />
+    <div v-if="showSummary" class="cell-summary">
+      <div class="cell-summary-head">
+        <span class="cell-summary-title">✦ Summary</span>
+        <button class="cell-btn cell-summary-close" title="Dismiss summary" aria-label="Dismiss summary" @click="closeSummary">✕</button>
+      </div>
+      <div class="cell-summary-body">
+        <span v-if="summaryState === 'loading'" class="cell-summary-loading">Summarizing…</span>
+        <p v-else-if="summaryState === 'error'" class="cell-summary-error">{{ summaryError }}</p>
+        <template v-else>
+          <pre class="cell-summary-text">{{ summaryText }}</pre>
+          <p v-if="summaryTruncated" class="cell-summary-note">(long output — summarized the tail only)</p>
+        </template>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -172,8 +256,85 @@ function rerun() {
   color: #ff6b6b;
 }
 
+.cell-summarize {
+  color: #9db4ff;
+}
+.cell-summarize:hover {
+  background: #24305c;
+  color: #cdd8ff;
+}
+.cell-summarize.is-busy {
+  color: #7f88ad;
+  cursor: default;
+}
+
 .cell-term {
   flex: 1;
   min-height: 0;
+}
+
+/* Result panel: a short, scrollable strip below the terminal (never steals more than
+   ~40% of the cell). */
+.cell-summary {
+  flex: 0 0 auto;
+  max-height: 40%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: #141b33;
+  border-top: 1px solid #2a2a4e;
+}
+.cell-summary-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 6px 2px 10px;
+  border-bottom: 1px solid #232a48;
+}
+.cell-summary-title {
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  color: #9db4ff;
+}
+.cell-summary-close {
+  width: 22px;
+  height: 22px;
+  font-size: 13px;
+}
+.cell-summary-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 6px 10px 8px;
+}
+.cell-summary-loading {
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  color: #7f88ad;
+}
+.cell-summary-error {
+  margin: 0;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: #ff8a8a;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.cell-summary-text {
+  margin: 0;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #d6dcf5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.cell-summary-note {
+  margin: 6px 0 0;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  color: #7f88ad;
 }
 </style>

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -60,6 +60,10 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
 }
 
+// The summary language follows the browser's base language — MulmoTerminal has no
+// locale picker (same signal as useVoiceInput / accountingUi / App.vue).
+const browserLocale = (): string => (navigator.language || "en").split("-")[0];
+
 async function postSummary(log: string): Promise<{ summary: string; truncated: boolean }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), SUMMARY_FETCH_TIMEOUT_MS);
@@ -67,7 +71,7 @@ async function postSummary(log: string): Promise<{ summary: string; truncated: b
     const res = await fetch("/api/command/summarize", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ log }),
+      body: JSON.stringify({ log, locale: browserLocale() }),
       signal: controller.signal,
     });
     const data: unknown = await res.json().catch(() => ({}));

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -165,7 +165,12 @@ function submitText(text: string): boolean {
 function terminate() {
   conn.terminate(slotKey);
 }
-defineExpose({ submitText, terminate });
+// The current xterm buffer as plain text, so a command cell can send its captured
+// output to the AI summariser.
+function readOutput(): string {
+  return conn.readBuffer(slotKey);
+}
+defineExpose({ submitText, terminate, readOutput });
 
 // Insert text (a path, or space-joined paths) at the terminal cursor via the
 // normal input channel — no trailing CR, so the user reviews and submits.

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -388,6 +388,17 @@ export function focus(key: string) {
   conns.get(key)?.term.focus();
 }
 
+// Read a slot's xterm buffer (scrollback + viewport) as plain text — used to hand a
+// command cell's captured output to the AI summariser. Each line is trailing-trimmed
+// by translateToString; trailing blank lines are dropped. "" for an unknown slot.
+export function readBuffer(key: string): string {
+  const c = conns.get(key);
+  if (!c) return "";
+  const buf = c.term.buffer.active;
+  const lines = Array.from({ length: buf.length }, (_, i) => buf.getLine(i)?.translateToString(true) ?? "");
+  return lines.join("\n").trimEnd();
+}
+
 // Refit to the current host size and push the new dimensions to the PTY.
 export function fit(key: string) {
   const c = conns.get(key);


### PR DESCRIPTION
## Summary

Adds a manual **✦ Summarize / Explain** action to Run-menu command cells (the `/ws/run` script cells — not Claude sessions). Clicking it sends the cell's captured terminal output to a new server endpoint that runs `claude -p` headless and returns a short **Errors / Warnings / likely cause / suggested fix** note, rendered in a small panel inside the cell. Helps when a build/install buries the one failing line in thousands.

- **New endpoint** `POST /api/command/summarize` in `server/command-summary.ts` (`mountCommandSummaryRoute(app, { isAllowedOrigin })`), mirroring `mountPickFileRoute`: same-origin guarded, spawns `claude -p "<prompt>"` via `node:child_process` (argv, no shell) with the log piped on stdin.
- **Pure, tested logic**: `truncateLog` (keep the last 32 KB tail, drop a leading partial line), `buildSummaryPrompt`, `parseSummaryOutput`; the spawn is a small injectable `runClaudeHeadless` helper so tests mock the CLI.
- **Client**: `useTerminalConnections.readBuffer` reads the xterm buffer, exposed via `Terminal.readOutput()`; `CommandCell.vue` gets the button + result panel and a bounded (AbortController) fetch.

## Items to Confirm / Review

- **Trigger is manual, and the button is always shown** (not gated on exit / non-zero). I judged "offer it once the command has produced output / exited" is best served by an always-available manual button — it works for both exited commands and long-running ones (`docker logs`) where the user wants the current output explained. Empty output is handled gracefully server-side (returns a note without calling the CLI). Flag if you'd prefer it shown only after `finished`.
- **Response shape** is `{ summary: string, truncated: boolean }` (a single string, not structured JSON sections) — matches the MVP's "or a small structured object" leeway.
- **Truncation** keeps the tail and drops one leading partial line to avoid a split UTF-8 codepoint heading the excerpt; client also caps the sent body to 64 KB as defence in depth. Cap constant is 32 KB server-side.
- **No live end-to-end run** against a real `claude` binary was performed here (subagent env); covered by unit + component tests with the spawn/fetch mocked, plus `build`. Worth a manual smoke test that `claude -p` returns a sensible summary in your environment.
- `claude -p` uses the user's default model/auth; the summary's token spend is **not** yet counted into the #245 cost roll-up (deferred — see below).

## User Prompt

Implement the children of umbrella issue #241 (Terminal + AI state management / visualisation / assist layer) in parallel. This PR is **child E / #246 — コマンド出力の AI 要約・Explain (Run セル)**: a manual "Summarize / Explain" action on a command cell that sends the captured output to `claude -p` (headless) and returns a short structured summary (Errors / Warnings / likely cause / suggested fix), shown in a small panel in the cell. Trigger is a manual button; capture is the client's xterm buffer capped to ~32 KB; the endpoint is `POST /api/command/summarize` in a new `server/command-summary.ts`; pure logic (truncation, prompt building, output parsing) lives in testable functions; tests mock the claude spawn.

## Implementation notes

- `server/command-summary.ts`: `truncateLog` / `buildSummaryPrompt` / `parseSummaryOutput` (pure) + `runClaudeHeadless` (default spawn, injectable) + `summarizeLog(log, deps)` + `mountCommandSummaryRoute`. Empty output short-circuits without spawning; a claude run that yields no output surfaces as a 502.
- `server/index.ts`: one import + one `mountCommandSummaryRoute(app, { isAllowedOrigin })` next to `mountPickFileRoute`.
- `src/composables/useTerminalConnections.ts`: `readBuffer(key)` joins the active xterm buffer lines and trims trailing blank lines.
- `src/components/Terminal.vue`: `defineExpose({ …, readOutput })`.
- `src/components/CommandCell.vue`: button in the header + a scrollable summary panel (loading / error / result + truncation note) below the terminal.
- `README.md`: documents the endpoint and the cell action; TOC + Scripts section updated.

### Deferred (non-scope)

- Auto-run on `exit != 0` (#246 option 2) — kept manual for the MVP.
- `error|warn` grep pre-extraction to compress the payload (#246 option 3) — plain tail-truncation for now.
- Counting the summary's own token spend into the #245 (#D) cost roll-up.
- Structured JSON sections in the response.
- Summarizing Claude sessions (only `/ws/run` command cells are in scope).

## Verification

- `yarn format` — clean
- `yarn lint` — 0 errors (only the pre-existing `spawnClaudePty` max-params WARNING)
- `yarn typecheck` / `yarn typecheck:server` — pass
- `yarn build` — pass
- `yarn test` — 753 passed (77 files); new: 6 server + 8 component summarize tests (happy path, empty output, truncation boundary, claude failure, spawn failure, button/panel/dismiss/error).

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)
