### PR TITLE
feat: グリッド拡大時にヘッダ余白クリックで別ターミナルへ切替

### DIFF
--- a/plans/feat-click-header-to-zoom.md
+++ b/plans/feat-click-header-to-zoom.md
@@ -1,0 +1,42 @@
+# feat: グリッド拡大時にヘッダ余白クリックで別ターミナルへ切替
+
+Issue: #252
+
+## User Prompt
+
+> single viewの拡大時に、下にあるターミナルって簡単に切り替えできる？
+> （…toggleExpand で別セルの ⤢ を押せば直接切り替わる、と説明）
+> あ、ここで切り替わるのか。このボタンが見えないようだ。
+> ヘッダ地の余白クリック → そのセルをズーム（＝切替）。でいこう
+
+## 背景 / 問題
+
+グリッドでセルをズームすると、そのセルが上に teleport され残りは下のフィルムストリップに並ぶ。
+別ターミナルへ切り替えるにはストリップ各セルのヘッダの ⤢ ボタンを押す必要があるが、狭いセル
+（260px）ではヘッダ内容で右端のアクション（⤢/✕）が押し出され **⤢ が見えず切り替えに気づけない**。
+
+## 方針
+
+**ヘッダ地（余白）クリックでそのセルをズーム（＝切替）**。`toggleExpand` は未拡大セルを指定すると
+直接そのセルへ差し替えるので、ストリップセルのヘッダクリック＝切替になる。
+
+- 共有純関数 `shouldZoomOnHeaderClick(target, expanded)`（`src/components/cellHeaderZoom.ts`）:
+  - 拡大中セルは `false`（誤解除しない。解除は ⤡ ボタン）
+  - クリックがヘッダ内ボタン（`closest("button")`）なら `false`（dir/GitHub/⤢/✕/◀▶ は従来動作）
+  - それ以外（余白・prompt・badge・dot）は `true` → `toggle-expand`
+- Terminal / Launcher / Command の3セルに配線（`@click` ＋ 未拡大時 `is-zoomable` クラス）。
+- カーソル pointer ＋ hover 背景で押せることを可視化。
+- 端末本体は不変（選択・入力と競合しない）。
+
+## 変更
+
+- `src/components/cellHeaderZoom.ts`（新規・純関数）＋ `cellHeaderZoom.spec.ts`。
+- `TerminalCell.vue` / `LauncherCell.vue` / `CommandCell.vue`: import ＋ `onHeaderClick` ＋ ヘッダ
+  `@click`/`is-zoomable` ＋ CSS。
+
+## 確認ポイント
+
+- ズーム中、下のストリップセルのヘッダ余白クリックで即そのセルへ切替。
+- ヘッダ内ボタン（dir/GitHub/⤢/✕）はクリックしてもズーム切替せず従来動作。
+- 拡大中セルのヘッダクリックは no-op。
+- 端末本体クリックは端末操作（切替しない）。

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from "vue";
 import TerminalView from "./Terminal.vue";
 import { formatCwd } from "./cwdDisplay";
+import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import type { CellStatus } from "./gridTabs";
 
 // A grid cell that runs a `script.json` command (a cell launcher's Run) instead of
@@ -40,11 +41,16 @@ function rerun() {
   finished.value = false;
   connectKey.value++;
 }
+
+// Click the header background to zoom (switch to) this cell; buttons keep their action.
+function onHeaderClick(event: MouseEvent) {
+  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
+}
 </script>
 
 <template>
   <div class="cell">
-    <div class="cell-header">
+    <div class="cell-header" :class="{ 'is-zoomable': !expanded }" @click="onHeaderClick">
       <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Finished' : 'Running…'" />
       <span v-if="dirDisplay" class="cell-dir" :title="command.cwd ?? ''"
         ><span class="cell-dir-path">{{ dirDisplay }}</span></span
@@ -90,6 +96,13 @@ function rerun() {
   padding: 0 8px;
   background: #16213e;
   border-bottom: 1px solid #2a2a4e;
+}
+/* Header background is a click target: zoom (switch to) this cell. */
+.cell-header.is-zoomable {
+  cursor: pointer;
+}
+.cell-header.is-zoomable:hover {
+  background: #1c2a4e;
 }
 
 .cell-dot {

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from "vue";
 import TerminalView from "./Terminal.vue";
 import { formatCwd } from "./cwdDisplay";
+import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import type { CellStatus, CellLauncher } from "./gridTabs";
 
 // A grid cell running a configured launch command (a plain shell, codex, any
@@ -29,6 +30,11 @@ const emit = defineEmits<{
   (e: "session", id: string): void;
 }>();
 
+// Click the header background to zoom (switch to) this cell; buttons keep their action.
+function onHeaderClick(event: MouseEvent) {
+  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
+}
+
 // connectKey bump re-launches after the process exits (relaunch button).
 const connectKey = ref(0);
 const finished = ref(false);
@@ -53,7 +59,7 @@ function relaunch() {
 
 <template>
   <div class="cell">
-    <div class="cell-header">
+    <div class="cell-header" :class="{ 'is-zoomable': !expanded }" @click="onHeaderClick">
       <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Exited' : 'Running…'" />
       <span v-if="dirDisplay" class="cell-dir" :title="cwd ?? ''"
         ><span class="cell-dir-path">{{ dirDisplay }}</span></span
@@ -107,6 +113,13 @@ function relaunch() {
   padding: 0 8px;
   background: #16213e;
   border-bottom: 1px solid #2a2a4e;
+}
+/* Header background is a click target: zoom (switch to) this cell. */
+.cell-header.is-zoomable {
+  cursor: pointer;
+}
+.cell-header.is-zoomable:hover {
+  background: #1c2a4e;
 }
 .cell-dot {
   flex: 0 0 auto;

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -10,8 +10,16 @@ import GitBranchChip from "./GitBranchChip.vue";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { activityStatus, type CellStatus } from "./gridTabs";
+import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
+
+// Clicking the header background zooms this cell — while another cell is zoomed
+// that's the easy "switch to this terminal" gesture. Header buttons keep their
+// action; the already-zoomed cell ignores it (restore is the ⤡ button).
+function onHeaderClick(event: MouseEvent) {
+  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
+}
 
 // `expanded` reflects whether this cell is zoomed to fill the grid (parent owns
 // the state). `initialSessionId` resumes a session on mount (reload restore).
@@ -769,7 +777,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 <template>
   <div class="cell" :class="statusClass">
     <template v-if="launched">
-      <div class="cell-header" :class="statusClass">
+      <div class="cell-header" :class="[statusClass, { 'is-zoomable': !expanded }]" @click="onHeaderClick">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
         <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
@@ -1078,6 +1086,14 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   background: var(--warn-bg-subtle);
   color: var(--warn);
   border-bottom-color: var(--amber);
+}
+/* A non-zoomed cell's header is a click target: zoom (switch to) this terminal.
+   Signalled with a pointer cursor + a hover tint so it's discoverable. */
+.cell-header.is-zoomable {
+  cursor: pointer;
+}
+.cell-header.is-zoomable:hover {
+  background: var(--bg-hover);
 }
 
 /* Status dot: idle / working (pulsing blue) / done (static blue) / blocked (amber). */

--- a/src/components/cellHeaderZoom.spec.ts
+++ b/src/components/cellHeaderZoom.spec.ts
@@ -17,6 +17,17 @@ describe("shouldZoomOnHeaderClick", () => {
     expect(shouldZoomOnHeaderClick(icon, false)).toBe(false); // click bubbles from the icon
   });
 
+  it("ignores clicks on an SVG icon inside a button (e.g. the GitHub button)", () => {
+    // SVGElement is not an HTMLElement — the target must still resolve to its button.
+    const btn = document.createElement("button");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    svg.appendChild(path);
+    btn.appendChild(svg);
+    expect(shouldZoomOnHeaderClick(svg, false)).toBe(false);
+    expect(shouldZoomOnHeaderClick(path, false)).toBe(false);
+  });
+
   it("ignores header clicks on the already-zoomed cell (restore is the ⤡ button)", () => {
     const span = document.createElement("span");
     expect(shouldZoomOnHeaderClick(span, true)).toBe(false);

--- a/src/components/cellHeaderZoom.spec.ts
+++ b/src/components/cellHeaderZoom.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
+
+describe("shouldZoomOnHeaderClick", () => {
+  it("zooms when the header background (a non-button element) is clicked", () => {
+    const span = document.createElement("span"); // e.g. the prompt / badge / dot
+    expect(shouldZoomOnHeaderClick(span, false)).toBe(true);
+  });
+
+  it("ignores clicks that land on one of the header's own buttons", () => {
+    const header = document.createElement("div");
+    const btn = document.createElement("button");
+    const icon = document.createElement("span"); // an icon inside the button
+    btn.appendChild(icon);
+    header.appendChild(btn);
+    expect(shouldZoomOnHeaderClick(btn, false)).toBe(false);
+    expect(shouldZoomOnHeaderClick(icon, false)).toBe(false); // click bubbles from the icon
+  });
+
+  it("ignores header clicks on the already-zoomed cell (restore is the ⤡ button)", () => {
+    const span = document.createElement("span");
+    expect(shouldZoomOnHeaderClick(span, true)).toBe(false);
+  });
+
+  it("ignores a null / non-element target", () => {
+    expect(shouldZoomOnHeaderClick(null, false)).toBe(true); // no button in the path → still zooms
+  });
+});

--- a/src/components/cellHeaderZoom.ts
+++ b/src/components/cellHeaderZoom.ts
@@ -4,5 +4,8 @@
 // already-zoomed cell ignores stray header clicks (it restores via its ⤡ button).
 export function shouldZoomOnHeaderClick(target: EventTarget | null, expanded: boolean): boolean {
   if (expanded) return false;
-  return !(target instanceof HTMLElement && target.closest("button"));
+  // `Element` (not `HTMLElement`): a click can land on an SVG icon inside a button
+  // (e.g. the GitHub button), and SVGElement isn't an HTMLElement — but it IS an
+  // Element with closest(), so this still walks up to the enclosing button.
+  return !(target instanceof Element && target.closest("button"));
 }

--- a/src/components/cellHeaderZoom.ts
+++ b/src/components/cellHeaderZoom.ts
@@ -1,0 +1,8 @@
+// A click on a grid cell's header background zooms (promotes) that cell — while
+// another cell is zoomed this is the easy "switch to that terminal" gesture. The
+// header's own controls (dir / GitHub / ⤢ / ✕ / ◀▶) keep their action, and the
+// already-zoomed cell ignores stray header clicks (it restores via its ⤡ button).
+export function shouldZoomOnHeaderClick(target: EventTarget | null, expanded: boolean): boolean {
+  if (expanded) return false;
+  return !(target instanceof HTMLElement && target.closest("button"));
+}


### PR DESCRIPTION
## Summary

グリッド拡大（ズーム）中に、下のフィルムストリップの別ターミナルへ**ヘッダ余白クリックで切り替え**られるようにしました。

これまでは切替に各ストリップセルの ⤢（拡大）ボタンを押す必要がありましたが、狭いセル(260px)ではヘッダ内容で ⤢/✕ が右端へ押し出され**そもそもボタンが見えない**問題がありました。ヘッダ地をクリックするだけでそのセルをズーム（＝切替）できます。

## Items to Confirm / Review

- **判定は純関数 `shouldZoomOnHeaderClick(target, expanded)`**（`cellHeaderZoom.ts`・ユニットテスト有り）:
  - 拡大中セルは `false`（誤って解除しない。解除は ⤡ ボタン）。
  - クリックがヘッダ内ボタン（`closest("button")`）なら `false` → dir / GitHub / ⤢ / ✕ / ◀▶ は従来動作のまま。
  - それ以外（余白・prompt・badge・dot）→ `true` で `toggle-expand`。`toggleExpand` は未拡大セル指定で直接そのセルへ差し替えるため、ストリップセルのヘッダクリック＝切替になる。
- **3セル（Terminal/Launcher/Command）**に配線。未拡大時のみ `is-zoomable`（cursor pointer＋hover）で押せることを可視化。
- 端末本体は不変（選択・入力と競合しない）。

## User Prompt

> single viewの拡大時に、下にあるターミナルって簡単に切り替えできる？
> （⤢ ボタンで切り替わる、と説明）→ あ、ここで切り替わるのか。このボタンが見えないようだ。
> ヘッダ地の余白クリック → そのセルをズーム（＝切替）。でいこう

## 検証

- `format` / `lint`(0 errors) / `typecheck` / `build` / `test`（`shouldZoomOnHeaderClick` 4件追加）。
- puppeteer 実機：ヘッダ背景クリックでズーム、⤡ で復元、⤢ は1回で確実にズーム（ヘッダ handler と二重発火しないことを確認）。

Closes #252
