### PR TITLE
feat: model/context badge in the cell header (#244)

### DIFF
--- a/plans/feat-244-model-context-badge.md
+++ b/plans/feat-244-model-context-badge.md
@@ -1,0 +1,35 @@
+# feat #244 — モデル/コンテキスト・バッジ
+
+親: #241（Terminal + AI 状態管理・可視化・支援レイヤー）／子 C。
+
+## ゴール
+
+セルヘッダのバッジに「どのモデルが動いているか」と「context をどれだけ使っているか」を表示する。
+既存のトークンバッジ `⇡in ⇣out` の隣に `Opus · ctx 35%` のように出す。
+
+## 設計判断
+
+- **モデル名**: transcript の最新 assistant ターンの `message.model`（例 `claude-opus-4-...`）を読む。
+  短ラベルへマップ: Opus / Sonnet / Haiku（部分一致・大小無視）／ それ以外は id の末尾セグメント（codex 等）。
+- **context %**: 現在の context サイズ ÷ モデルの context window。
+  現在の context = **最新** assistant ターンの `input_tokens + cache_read_input_tokens + cache_creation_input_tokens`。
+  累積（`sessionUsageFromJsonl`）はターン間で二重計上になるため使わない。
+- **context window テーブル**: 同梱ハードコード表（Claude Opus/Sonnet/Haiku ≈ 200,000）。
+  未知モデル → ラベルのみ表示し % は非表示（推測しない）。
+- **agent 種別**（claude/codex）はクライアント側で既知（cell の `agent` ref）。tooltip に使用。
+
+## 変更ファイル（スコープ限定）
+
+1. `server/transcript.ts` — 純関数 `latestTurnContextFromJsonl(raw): { model, contextTokens }` を追加。
+2. `server/transcript.spec.ts` — 上記の単体テスト（最新ターン抽出・モデル抽出・複数ターン・空/壊れた行）。
+3. `server/index.ts` — `readSessionSummary` と `/api/session/:id` に `context`（model + contextTokens）を追加（加算的）。
+4. `src/components/ModelContextBadge.vue`（新規）— ラベル + ctx% の描画。window テーブルとラベルマップを保持。
+5. `src/components/ModelContextBadge.spec.ts`（新規）— Opus/Sonnet/Haiku・未知モデルで % 非表示・codex id 末尾。
+6. `src/components/TerminalCell.vue` — `context` を fetch して `ModelContextBadge` を描画。
+
+## 検証
+
+- `yarn format`
+- `node_modules/.bin/eslint server src`（0 errors）
+- `yarn typecheck` / `yarn typecheck:server` / `yarn build`
+- `yarn test`（新規 spec）

--- a/server/index.ts
+++ b/server/index.ts
@@ -50,8 +50,10 @@ import {
   latestMeaningfulUserPromptFromJsonl,
   preferredHeaderPrompt,
   sessionUsageFromJsonl,
+  latestTurnContextFromJsonl,
   timelineFromJsonl,
   type SessionUsage,
+  type LatestTurnContext,
   type TimelineEvent,
 } from "./transcript.js";
 import { mountOpenDirRoute } from "./open-dir.js";
@@ -715,14 +717,20 @@ async function latestUserPrompt(cwd: string, id: string): Promise<string | null>
 }
 
 const EMPTY_USAGE: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
-// One read of a session's transcript → its latest prompt AND cumulative token usage,
-// so /api/session/:id doesn't parse the .jsonl twice.
-async function readSessionSummary(cwd: string, id: string): Promise<{ lastPrompt: string | null; usage: SessionUsage }> {
+const EMPTY_CONTEXT: LatestTurnContext = { model: null, contextTokens: 0 };
+interface SessionSummary {
+  lastPrompt: string | null;
+  usage: SessionUsage;
+  context: LatestTurnContext;
+}
+// One read of a session's transcript → its latest prompt, cumulative token usage, and
+// current-turn context, so /api/session/:id doesn't parse the .jsonl more than once.
+async function readSessionSummary(cwd: string, id: string): Promise<SessionSummary> {
   try {
     const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
-    return { lastPrompt: latestMeaningfulUserPromptFromJsonl(raw), usage: sessionUsageFromJsonl(raw) };
+    return { lastPrompt: latestMeaningfulUserPromptFromJsonl(raw), usage: sessionUsageFromJsonl(raw), context: latestTurnContextFromJsonl(raw) };
   } catch {
-    return { lastPrompt: null, usage: EMPTY_USAGE };
+    return { lastPrompt: null, usage: EMPTY_USAGE, context: EMPTY_CONTEXT };
   }
 }
 
@@ -1194,7 +1202,7 @@ app.get("/api/session/:id", async (req, res) => {
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   const a = activity.get(id) || {};
-  const { lastPrompt: transcriptPrompt, usage } = await readSessionSummary(cwd, id);
+  const { lastPrompt: transcriptPrompt, usage, context } = await readSessionSummary(cwd, id);
   const lastPrompt = lastPrompts.get(id) ?? transcriptPrompt;
   res.json({
     id,
@@ -1204,6 +1212,7 @@ app.get("/api/session/:id", async (req, res) => {
     event: a.event ?? null,
     lastPrompt,
     usage,
+    context,
   });
 });
 

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -7,6 +7,7 @@ import {
   userPromptText,
   parseJsonl,
   sessionUsageFromJsonl,
+  latestTurnContextFromJsonl,
   timelineFromJsonl,
 } from "./transcript.js";
 
@@ -159,6 +160,45 @@ describe("sessionUsageFromJsonl", () => {
   });
   it("is all-zero for an empty / promptless transcript", () => {
     expect(sessionUsageFromJsonl("")).toEqual({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+});
+
+describe("latestTurnContextFromJsonl", () => {
+  const assistant = (model: string, usage: Record<string, number>) => line({ type: "assistant", message: { model, usage } });
+
+  it("returns the LAST turn's input + both cache buckets (not the cumulative sum)", () => {
+    const raw = [
+      line({ type: "user", message: { content: "hi" } }),
+      assistant("claude-opus-4-20250101", { input_tokens: 100, cache_read_input_tokens: 5, cache_creation_input_tokens: 3 }),
+      assistant("claude-opus-4-20250101", { input_tokens: 200, cache_read_input_tokens: 50_000, cache_creation_input_tokens: 1_000 }),
+    ].join("\n");
+    // Only the final turn: 200 + 50000 + 1000 (NOT summed with the first turn).
+    expect(latestTurnContextFromJsonl(raw)).toEqual({ model: "claude-opus-4-20250101", contextTokens: 51_200 });
+  });
+
+  it("tracks the most recent model across turns", () => {
+    const raw = [assistant("claude-sonnet-4-20250101", { input_tokens: 10 }), assistant("claude-opus-4-20250101", { input_tokens: 20 })].join("\n");
+    expect(latestTurnContextFromJsonl(raw).model).toBe("claude-opus-4-20250101");
+  });
+
+  it("treats missing cache buckets as zero", () => {
+    const raw = assistant("claude-haiku-4", { input_tokens: 42 });
+    expect(latestTurnContextFromJsonl(raw)).toEqual({ model: "claude-haiku-4", contextTokens: 42 });
+  });
+
+  it("keeps a model even when the final turn carries no usage", () => {
+    const raw = [assistant("claude-opus-4", { input_tokens: 300 }), line({ type: "assistant", message: { model: "claude-opus-4" } })].join("\n");
+    // model still resolves; contextTokens holds the last turn that HAD usage.
+    expect(latestTurnContextFromJsonl(raw)).toEqual({ model: "claude-opus-4", contextTokens: 300 });
+  });
+
+  it("is empty for an empty / promptless transcript", () => {
+    expect(latestTurnContextFromJsonl("")).toEqual({ model: null, contextTokens: 0 });
+  });
+
+  it("ignores non-assistant and malformed lines", () => {
+    const raw = [line({ type: "user", message: { content: "hi" } }), "not json", assistant("gpt-5-codex", { input_tokens: 7 })].join("\n");
+    expect(latestTurnContextFromJsonl(raw)).toEqual({ model: "gpt-5-codex", contextTokens: 7 });
   });
 });
 

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -186,10 +186,11 @@ describe("latestTurnContextFromJsonl", () => {
     expect(latestTurnContextFromJsonl(raw)).toEqual({ model: "claude-haiku-4", contextTokens: 42 });
   });
 
-  it("keeps a model even when the final turn carries no usage", () => {
+  it("zeroes context when the final turn carries no usage (no stale value from a prior turn)", () => {
     const raw = [assistant("claude-opus-4", { input_tokens: 300 }), line({ type: "assistant", message: { model: "claude-opus-4" } })].join("\n");
-    // model still resolves; contextTokens holds the last turn that HAD usage.
-    expect(latestTurnContextFromJsonl(raw)).toEqual({ model: "claude-opus-4", contextTokens: 300 });
+    // Both fields come from the SAME final turn: the model resolves, but with no usage
+    // on that turn we report 0 rather than the previous turn's stale 300.
+    expect(latestTurnContextFromJsonl(raw)).toEqual({ model: "claude-opus-4", contextTokens: 0 });
   });
 
   it("is empty for an empty / promptless transcript", () => {

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -204,13 +204,16 @@ const contextTokensOf = (u: Record<string, unknown>): number =>
   usageNum(u, "input_tokens") + usageNum(u, "cache_read_input_tokens") + usageNum(u, "cache_creation_input_tokens");
 
 export function latestTurnContextFromJsonl(raw: string): LatestTurnContext {
-  const latest: LatestTurnContext = { model: null, contextTokens: 0 };
+  // Both fields come from the SAME final assistant turn, so a new model is never
+  // shown with a prior turn's context tokens. Usage absent on that turn → 0.
+  let lastMessage: Record<string, unknown> | null = null;
   for (const o of parseJsonl(raw)) {
-    if (o.type !== "assistant" || !isRecord(o.message)) continue;
-    if (typeof o.message.model === "string" && o.message.model) latest.model = o.message.model;
-    if (isRecord(o.message.usage)) latest.contextTokens = contextTokensOf(o.message.usage);
+    if (o.type === "assistant" && isRecord(o.message)) lastMessage = o.message;
   }
-  return latest;
+  if (!lastMessage) return { model: null, contextTokens: 0 };
+  const model = typeof lastMessage.model === "string" && lastMessage.model ? lastMessage.model : null;
+  const contextTokens = isRecord(lastMessage.usage) ? contextTokensOf(lastMessage.usage) : 0;
+  return { model, contextTokens };
 }
 
 // A single tool the agent ran, for the activity timeline. `summary` is a 1-line

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -190,6 +190,29 @@ export function sessionUsageFromJsonl(raw: string): SessionUsage {
   return total;
 }
 
+// The CURRENT context size + running model for a session, from the LAST assistant
+// turn. `contextTokens` is that turn's fresh input plus both cache buckets — the
+// tokens re-sent as context for the next turn. This is NOT the cumulative
+// sessionUsageFromJsonl sum, which counts every turn's re-sent context and so
+// double-counts. `model` is the most recent assistant turn's declared model.
+export interface LatestTurnContext {
+  model: string | null;
+  contextTokens: number;
+}
+
+const contextTokensOf = (u: Record<string, unknown>): number =>
+  usageNum(u, "input_tokens") + usageNum(u, "cache_read_input_tokens") + usageNum(u, "cache_creation_input_tokens");
+
+export function latestTurnContextFromJsonl(raw: string): LatestTurnContext {
+  const latest: LatestTurnContext = { model: null, contextTokens: 0 };
+  for (const o of parseJsonl(raw)) {
+    if (o.type !== "assistant" || !isRecord(o.message)) continue;
+    if (typeof o.message.model === "string" && o.message.model) latest.model = o.message.model;
+    if (isRecord(o.message.usage)) latest.contextTokens = contextTokensOf(o.message.usage);
+  }
+  return latest;
+}
+
 // A single tool the agent ran, for the activity timeline. `summary` is a 1-line
 // description drawn from the tool's most salient input (a command, a file path, …).
 export interface TimelineEvent {

--- a/src/components/ModelContextBadge.spec.ts
+++ b/src/components/ModelContextBadge.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import ModelContextBadge from "./ModelContextBadge.vue";
+
+function mountBadge(props: { agent?: "claude" | "codex"; model: string | null; contextTokens?: number }) {
+  return mount(ModelContextBadge, {
+    props: { agent: props.agent ?? "claude", model: props.model, contextTokens: props.contextTokens ?? 0 },
+  });
+}
+
+describe("ModelContextBadge", () => {
+  it("shows the short family label + ctx% for a known Claude model (70k / 200k = 35%)", () => {
+    const w = mountBadge({ model: "claude-opus-4-20250514", contextTokens: 70_000 });
+    expect(w.find(".cell-model").text()).toBe("Opus · ctx 35%");
+  });
+
+  it("maps sonnet and haiku ids to their short labels", () => {
+    expect(mountBadge({ model: "claude-3-5-sonnet-20241022", contextTokens: 0 }).find(".cell-model").text()).toBe("Sonnet · ctx 0%");
+    expect(mountBadge({ model: "claude-haiku-4-20250101", contextTokens: 20_000 }).find(".cell-model").text()).toBe("Haiku · ctx 10%");
+  });
+
+  it("shows the model tail but NO % for an unknown model (never guesses a window)", () => {
+    const w = mountBadge({ agent: "codex", model: "gpt-5-codex", contextTokens: 999_999 });
+    expect(w.find(".cell-model").text()).toBe("gpt-5-codex");
+    expect(w.find(".cell-model").text()).not.toContain("ctx");
+  });
+
+  it("uses the last path segment for a provider-prefixed unknown id", () => {
+    const w = mountBadge({ agent: "codex", model: "openai/o3-pro", contextTokens: 1000 });
+    expect(w.find(".cell-model").text()).toBe("o3-pro");
+  });
+
+  it("renders nothing when the model is unknown/null (no transcript model yet)", () => {
+    expect(mountBadge({ model: null, contextTokens: 1000 }).find(".cell-model").exists()).toBe(false);
+  });
+
+  it("rounds the percentage", () => {
+    // 51,234 / 200,000 = 25.617% → 26%
+    expect(mountBadge({ model: "claude-opus-4", contextTokens: 51_234 }).find(".cell-model").text()).toBe("Opus · ctx 26%");
+  });
+
+  it("puts the agent name, full model id and raw token counts in the tooltip", () => {
+    const w = mountBadge({ agent: "claude", model: "claude-opus-4-20250514", contextTokens: 70_000 });
+    const title = w.find(".cell-model").attributes("title");
+    expect(title).toContain("Claude");
+    expect(title).toContain("claude-opus-4-20250514");
+    expect(title).toContain("70,000 / 200,000 (35%)");
+  });
+});

--- a/src/components/ModelContextBadge.vue
+++ b/src/components/ModelContextBadge.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+// Which model is running + how full its context is, e.g. `Opus · ctx 35%`. Model
+// and contextTokens come from the transcript (server /api/session/:id); the agent
+// kind is known client-side. Unknown models keep the label but hide the %.
+const props = defineProps<{
+  agent: "claude" | "codex";
+  model: string | null;
+  contextTokens: number;
+}>();
+
+// Substring → short label for Claude's model families; matched case-insensitively.
+// Anything else (a codex model, a future provider) falls back to the id's tail.
+const CLAUDE_FAMILIES = [
+  { match: "opus", label: "Opus" },
+  { match: "sonnet", label: "Sonnet" },
+  { match: "haiku", label: "Haiku" },
+];
+
+// Approximate context window per model family, in tokens. A model with no entry
+// here shows its label but no % — we never guess a window.
+const CONTEXT_WINDOW_TOKENS: Record<string, number> = { opus: 200_000, sonnet: 200_000, haiku: 200_000 };
+const PERCENT = 100;
+
+const AGENT_NAME: Record<"claude" | "codex", string> = { claude: "Claude", codex: "Codex" };
+
+function shortModelLabel(model: string): string {
+  const lower = model.toLowerCase();
+  const family = CLAUDE_FAMILIES.find((f) => lower.includes(f.match));
+  return family ? family.label : (model.split("/").pop() ?? model);
+}
+
+function contextWindowTokens(model: string): number | null {
+  const lower = model.toLowerCase();
+  const key = Object.keys(CONTEXT_WINDOW_TOKENS).find((k) => lower.includes(k));
+  return key ? CONTEXT_WINDOW_TOKENS[key] : null;
+}
+
+const label = computed(() => (props.model ? shortModelLabel(props.model) : null));
+const windowTokens = computed(() => (props.model ? contextWindowTokens(props.model) : null));
+const ctxPercent = computed(() => (windowTokens.value ? Math.round((props.contextTokens / windowTokens.value) * PERCENT) : null));
+const badgeText = computed(() => (ctxPercent.value !== null ? `${label.value} · ctx ${ctxPercent.value}%` : label.value));
+
+const title = computed(() => {
+  if (!props.model) return "";
+  const used = props.contextTokens.toLocaleString();
+  const window = windowTokens.value ? ` / ${windowTokens.value.toLocaleString()} (${ctxPercent.value}%)` : "";
+  return `${AGENT_NAME[props.agent]} · ${props.model} · context ${used}${window} tokens`;
+});
+</script>
+
+<template>
+  <span v-if="label" class="cell-model" :title="title">{{ badgeText }}</span>
+</template>
+
+<style scoped>
+/* Mirrors .cell-usage: dim, monospace metadata that reads as a quiet header badge. */
+.cell-model {
+  flex: 0 0 auto;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+</style>

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -472,6 +472,36 @@ describe("TerminalCell", () => {
     expect(badge.text()).toContain("3.4k"); // output 3400
   });
 
+  it("shows the model/context badge from /api/session/:id context", async () => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return {
+        ok: true,
+        json: async () => ({ working: false, waiting: false, lastPrompt: null, context: { model: "claude-opus-4-20250514", contextTokens: 70_000 } }),
+      };
+    }) as unknown as typeof fetch;
+    const w = mountCell(id);
+    await flushPromises();
+    const badge = w.find(".cell-model");
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe("Opus · ctx 35%"); // 70k / 200k
+  });
+
+  it("shows no model badge when the session has no model yet", async () => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, context: { model: null, contextTokens: 0 } }) };
+    }) as unknown as typeof fetch;
+    const w = mountCell(id);
+    await flushPromises();
+    expect(w.find(".cell-model").exists()).toBe(false);
+  });
+
   it("clears a stale prompt when the server sends lastPrompt: null", async () => {
     const id = "33333333-3333-3333-3333-333333333333";
     const w = mountCell(id);

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -7,6 +7,7 @@ import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
 import GitBranchChip from "./GitBranchChip.vue";
+import ModelContextBadge from "./ModelContextBadge.vue";
 import TimelineOverlay from "./TimelineOverlay.vue";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
@@ -120,6 +121,16 @@ interface Usage {
 const usage = ref<Usage | null>(null);
 const isUsage = (u: unknown): u is Usage => typeof u === "object" && u !== null && "outputTokens" in u;
 
+// The running model + current-turn context size (from /api/session/:id), for the
+// model/context badge. Null until first fetched; model may be null with no assistant
+// turn yet, which hides the badge.
+interface SessionContext {
+  model: string | null;
+  contextTokens: number;
+}
+const context = ref<SessionContext | null>(null);
+const isContext = (c: unknown): c is SessionContext => typeof c === "object" && c !== null && "contextTokens" in c;
+
 const { subscribe } = usePubSub();
 let unsubscribe: (() => void) | null = null;
 
@@ -154,6 +165,7 @@ async function loadInitial(id: string) {
     if (id === sessionId.value) {
       applyActivity(data);
       if (isUsage(data.usage)) usage.value = data.usage;
+      if (isContext(data.context)) context.value = data.context;
     }
   } catch {
     // best-effort — pub/sub will fill it in on the next event
@@ -170,7 +182,9 @@ async function refreshUsage() {
     const res = await fetch(`/api/session/${id}${q}`);
     if (!res.ok) return;
     const data = await res.json();
-    if (id === sessionId.value && isUsage(data.usage)) usage.value = data.usage;
+    if (id !== sessionId.value) return;
+    if (isUsage(data.usage)) usage.value = data.usage;
+    if (isContext(data.context)) context.value = data.context;
   } catch {
     // best-effort
   }
@@ -521,6 +535,7 @@ function teardown() {
   activityEvent.value = null;
   lastPrompt.value = null;
   usage.value = null;
+  context.value = null;
   cwd.value = props.defaultCwd;
   dirInput.value = props.defaultCwd ?? "";
   dirTouched.value = false; // fresh launcher again — let a late preset sync re-prefill
@@ -815,6 +830,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           </div>
         </span>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
+        <ModelContextBadge v-if="context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
         <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
         <span class="cell-actions">
           <button


### PR DESCRIPTION
## Summary

Extends the per-session cell header badge to show **which model is running** and **how full its context is** — e.g. `Opus · ctx 35%` next to the existing `⇡in ⇣out` token badge.

- **Model**: read from the transcript's most recent assistant turn `message.model`, mapped to a short label (Opus / Sonnet / Haiku, or the raw id's tail for codex / other providers).
- **Context %**: the **current** context size ÷ the model's context window. Current context = the **last** assistant turn's `input_tokens + cache_read_input_tokens + cache_creation_input_tokens` (NOT the cumulative `sessionUsageFromJsonl` sum, which double-counts re-sent context across turns).
- **Window table**: a small hardcoded map (Claude Opus/Sonnet/Haiku ≈ 200,000). **Unknown model → show the label, hide the %** (never guess a window).
- Additive only: `/api/session/:id` gains a `context: { model, contextTokens }` field; the agent kind (claude/codex) is already known client-side.

## Items to Confirm / Review

- **Context% definition** — I used the *last turn's* context tokens (input + both cache buckets), per the issue's "直近ターン" guidance, since cache-read/creation are what actually re-fill the window each turn. Please confirm this matches the intended semantics vs. plain `input_tokens` only.
- **Window table** — hardcoded 200k for Opus/Sonnet/Haiku (matched by substring, case-insensitive). Codex / unknown models intentionally show the label with no %. Extend the table as needed.
- **Model label fallback** — unknown ids show the last `/`-segment of the id (e.g. `openai/o3-pro` → `o3-pro`, `gpt-5-codex` → `gpt-5-codex`).
- **Codex** — codex transcripts are stored outside the Claude project sessions dir, so `context.model` will usually be null for codex cells and the badge hides gracefully. No codex-specific parsing was added.

## User Prompt

順次対応の umbrella #241 の子。C/D を並行実装。本PRは C / #244（モデル/コンテキスト・バッジ）。

セルヘッダの既存トークンバッジを拡張し、実行中のエージェント/モデル名と context 使用率（%）を表示する。model は transcript の assistant レコード（`message.model`）から、ctx% は直近ターンの context トークン ÷ モデル別 context window（同梱ハードコード表）から算出。未知モデルは名前のみ表示し % は非表示。

## Implementation

- `server/transcript.ts` — new pure `latestTurnContextFromJsonl(raw): { model, contextTokens }` (last assistant turn's model + context tokens). Reuses `parseJsonl` / `isRecord` / `usageNum`.
- `server/index.ts` — `readSessionSummary` now also returns `context`; `/api/session/:id` surfaces it (one transcript read, no extra parse pass).
- `src/components/ModelContextBadge.vue` (new) — holds the family→label map, the context-window table, and the %/label/tooltip computeds. Hidden when `model` is null.
- `src/components/TerminalCell.vue` — fetches `context` in `loadInitial` / `refreshUsage`, resets it in `teardown`, and renders `<ModelContextBadge>` in the header.

## Verification

- `node_modules/.bin/eslint server src` → **0 errors** (only the pre-existing `spawnClaudePty` max-params warning).
- `yarn typecheck`, `yarn typecheck:server`, `yarn build` → all pass.
- `yarn test` → **793 passed** (80 files), including new tests for `latestTurnContextFromJsonl` (last-turn context, model tracking, multi-turn, missing cache buckets, empty/malformed), `ModelContextBadge` (Opus/Sonnet/Haiku labels, unknown → no %, provider-prefixed tail, rounding, tooltip), and `TerminalCell` badge wiring.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
