### PR TITLE
feat: コスト($)表示と日次/月次ロールアップ (#245)

### DIFF
--- a/plans/feat-245-cost-rollup.md
+++ b/plans/feat-245-cost-rollup.md
@@ -1,0 +1,57 @@
+# feat #245 — Cost ($) display + daily / monthly roll-up
+
+Child of umbrella #241 ("Terminal + AI 状態管理・可視化・支援レイヤー"). Candidate D.
+
+## Problem
+
+Token counts are already surfaced (session usage badge), but the dollar **cost** —
+and today / this-month totals across the project's sessions — are not. Users get
+surprised by the monthly bill.
+
+## Design
+
+### Pricing (`server/cost.ts`, new pure module)
+- Hardcoded per-model rate table, `$ / 1M tokens` for input / output, from
+  Anthropic's public pricing (see the source note in the file). cache-read and
+  cache-write are **derived** from the input rate: `0.1×` for cache reads,
+  `1.25×` for cache writes (the default 5-minute ephemeral cache that Claude Code
+  uses).
+- Models keyed by id **prefix** so dated snapshots (`…-20260101`) resolve to their
+  family. Unknown model → **unpriced** (rate absent), never guessed.
+
+### Cost calculation (per turn)
+- `costForUsage(usage, model)` prices ONE assistant turn using that turn's own
+  `message.model` — a session can switch models mid-way, so we never assume one
+  rate for the whole file.
+- `costFromJsonl(raw) → { usd, unpricedTurns }` sums every assistant turn's
+  `message.usage`, counting turns whose model has no known price as `unpricedTurns`
+  (excluded from the total).
+
+### Aggregation (`GET /api/cost`, mounted from `cost.ts`)
+- `mountCostRoute(app, { resolveCwd })`; one import + one mount in `index.ts`.
+- Response: `{ session?, today, month, currency: "USD", unpricedTurns }`.
+- `session` (optional `?session=<uuid>`): cost of that session's transcript.
+- today / month: **stat-first** scan of `~/.claude/projects/<encoded-cwd>/*.jsonl`,
+  bucketed by file **mtime** (local day / month) — the whole file's cost is
+  attributed to its mtime day. Files within the month window are sorted newest-first
+  and **capped** at `MAX_COST_FILES` (read); a `log()`-style note fires if capped.
+- Never throws: missing dir / unreadable file → zeros.
+
+### UI (`src/components/SettingsModal.vue` + `src/composables/useCost.ts`)
+- Read-only "Cost (estimated)" block: Session / Today / Month in `$`, with a tooltip
+  that these are estimates from public per-model pricing.
+- Fetches `/api/cost?cwd=&session=` when the modal opens (via `useCost`, with an
+  `AbortController` timeout). Errors are swallowed (block just shows `—`).
+
+## Scope / follow-ups (MVP)
+- Covers only the **current project's** sessions. Cross-project roll-up and a live
+  per-cell cost badge are follow-ups.
+- Flat-plan (Max) users may want to hide `$` — noted in the UI hint; the ON/OFF
+  toggle is deliberately **not** built here.
+- Cost is bucketed by file mtime (approximation), not by per-turn timestamp.
+
+## File scope
+- new: `server/cost.ts`, `server/cost.spec.ts`, `src/composables/useCost.ts`,
+  `src/composables/useCost.spec.ts`, this plan.
+- edit: `server/index.ts` (1 import + 1 mount), `src/components/SettingsModal.vue`,
+  `src/App.vue` (pass `cwd` / `session-id` to the modal).

--- a/server/cost.spec.ts
+++ b/server/cost.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { rateForModel, costForUsage, costFromJsonl } from "./cost.js";
+
+const line = (o: unknown) => JSON.stringify(o);
+const assistant = (model: string, usage: Record<string, number>) => line({ type: "assistant", message: { model, usage } });
+
+describe("rateForModel", () => {
+  it("prices current Opus / Sonnet / Haiku models", () => {
+    expect(rateForModel("claude-opus-4-8")).toEqual({
+      inputPerMillion_usd: 5,
+      outputPerMillion_usd: 25,
+      cacheReadPerMillion_usd: 0.5,
+      cacheWritePerMillion_usd: 6.25,
+    });
+    expect(rateForModel("claude-sonnet-5")?.inputPerMillion_usd).toBe(3);
+    expect(rateForModel("claude-haiku-4-5")?.outputPerMillion_usd).toBe(5);
+    expect(rateForModel("claude-fable-5")?.inputPerMillion_usd).toBe(10);
+  });
+
+  it("matches dated snapshots by family prefix", () => {
+    expect(rateForModel("claude-sonnet-4-5-20250929")?.inputPerMillion_usd).toBe(3);
+    expect(rateForModel("claude-opus-4-5-20251101")?.outputPerMillion_usd).toBe(25);
+  });
+
+  it("does not confuse sonnet-5 with sonnet-4-5", () => {
+    expect(rateForModel("claude-sonnet-5")?.outputPerMillion_usd).toBe(15);
+    expect(rateForModel("claude-sonnet-4-5")?.outputPerMillion_usd).toBe(15);
+  });
+
+  it("returns null for unknown / empty models", () => {
+    expect(rateForModel("gpt-4o")).toBeNull();
+    expect(rateForModel("claude-opus-4-0")).toBeNull(); // not in the table → unpriced
+    expect(rateForModel("")).toBeNull();
+  });
+});
+
+describe("costForUsage", () => {
+  it("prices input, output, cache-read and cache-write separately", () => {
+    const usage = {
+      input_tokens: 1_000_000,
+      output_tokens: 1_000_000,
+      cache_read_input_tokens: 1_000_000,
+      cache_creation_input_tokens: 1_000_000,
+    };
+    const { usd, priced } = costForUsage(usage, "claude-opus-4-8");
+    // 5 + 25 + 0.5 + 6.25
+    expect(priced).toBe(true);
+    expect(usd).toBeCloseTo(36.75, 10);
+  });
+
+  it("charges cache reads at 0.1x and writes at 1.25x the input rate", () => {
+    const read = costForUsage({ cache_read_input_tokens: 1_000_000 }, "claude-sonnet-5").usd;
+    const write = costForUsage({ cache_creation_input_tokens: 1_000_000 }, "claude-sonnet-5").usd;
+    expect(read).toBeCloseTo(0.3, 10); // 3 * 0.1
+    expect(write).toBeCloseTo(3.75, 10); // 3 * 1.25
+  });
+
+  it("is unpriced (usd 0) for an unknown model", () => {
+    expect(costForUsage({ input_tokens: 1_000_000 }, "some-other-model")).toEqual({ usd: 0, priced: false });
+  });
+
+  it("treats missing / negative / non-number token fields as zero", () => {
+    expect(costForUsage({}, "claude-opus-4-8").usd).toBe(0);
+    expect(costForUsage({ input_tokens: -50, output_tokens: "10" }, "claude-opus-4-8").usd).toBe(0);
+  });
+});
+
+describe("costFromJsonl", () => {
+  it("sums cost across assistant turns, per turn's own model (model switch)", () => {
+    const raw = [
+      assistant("claude-opus-4-8", { output_tokens: 1_000_000 }), // $25
+      line({ type: "user", message: { content: "hi" } }),
+      assistant("claude-sonnet-5", { output_tokens: 1_000_000 }), // $15
+    ].join("\n");
+    const { usd, unpricedTurns } = costFromJsonl(raw);
+    expect(usd).toBeCloseTo(40, 10);
+    expect(unpricedTurns).toBe(0);
+  });
+
+  it("counts turns on unpriced models and excludes them from the total", () => {
+    const raw = [
+      assistant("claude-opus-4-8", { output_tokens: 1_000_000 }), // $25
+      assistant("mystery-model", { output_tokens: 1_000_000 }), // unpriced
+    ].join("\n");
+    const { usd, unpricedTurns } = costFromJsonl(raw);
+    expect(usd).toBeCloseTo(25, 10);
+    expect(unpricedTurns).toBe(1);
+  });
+
+  it("treats an assistant turn missing its model as unpriced", () => {
+    const raw = line({ type: "assistant", message: { usage: { output_tokens: 1_000_000 } } });
+    expect(costFromJsonl(raw)).toEqual({ usd: 0, unpricedTurns: 1 });
+  });
+
+  it("ignores non-assistant lines and assistant lines without usage", () => {
+    const raw = [
+      line({ type: "user", message: { content: "hi" } }),
+      line({ type: "assistant", message: { model: "claude-opus-4-8" } }), // no usage → skipped
+    ].join("\n");
+    expect(costFromJsonl(raw)).toEqual({ usd: 0, unpricedTurns: 0 });
+  });
+
+  it("returns zeros for empty or malformed input", () => {
+    expect(costFromJsonl("")).toEqual({ usd: 0, unpricedTurns: 0 });
+    expect(costFromJsonl("not json\n{broken")).toEqual({ usd: 0, unpricedTurns: 0 });
+  });
+});

--- a/server/cost.ts
+++ b/server/cost.ts
@@ -1,0 +1,205 @@
+// Dollar-cost estimation for Claude sessions: a hardcoded per-model rate table +
+// per-turn cost from a transcript's `message.usage`, plus a project-scoped
+// today/month roll-up served at GET /api/cost. Pricing is a public-list estimate
+// (see MODEL_PRICING); unknown models are left unpriced rather than guessed.
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
+import type { Express } from "express";
+import { isRecord, parseJsonl } from "./transcript.js";
+
+const TOKENS_PER_MILLION = 1_000_000;
+// Cache reads bill at ~0.1x the base input rate; cache writes at 1.25x for the
+// default 5-minute ephemeral cache (the TTL Claude Code uses). Both are derived
+// from each model's input rate rather than listed separately.
+const CACHE_READ_MULTIPLIER = 0.1;
+const CACHE_WRITE_MULTIPLIER = 1.25;
+
+// $ per 1M tokens (input / output) for current Claude models, from Anthropic's
+// public pricing. Matched by model-id PREFIX so dated snapshots (…-20260101)
+// resolve to their family. A model with no entry is treated as unpriced.
+interface ModelPricing {
+  prefix: string;
+  inputPerMillion_usd: number;
+  outputPerMillion_usd: number;
+}
+
+const MODEL_PRICING: ModelPricing[] = [
+  { prefix: "claude-fable-5", inputPerMillion_usd: 10, outputPerMillion_usd: 50 },
+  { prefix: "claude-opus-4-8", inputPerMillion_usd: 5, outputPerMillion_usd: 25 },
+  { prefix: "claude-opus-4-7", inputPerMillion_usd: 5, outputPerMillion_usd: 25 },
+  { prefix: "claude-opus-4-6", inputPerMillion_usd: 5, outputPerMillion_usd: 25 },
+  { prefix: "claude-opus-4-5", inputPerMillion_usd: 5, outputPerMillion_usd: 25 },
+  { prefix: "claude-sonnet-5", inputPerMillion_usd: 3, outputPerMillion_usd: 15 },
+  { prefix: "claude-sonnet-4-6", inputPerMillion_usd: 3, outputPerMillion_usd: 15 },
+  { prefix: "claude-sonnet-4-5", inputPerMillion_usd: 3, outputPerMillion_usd: 15 },
+  { prefix: "claude-haiku-4-5", inputPerMillion_usd: 1, outputPerMillion_usd: 5 },
+];
+
+export interface ModelRate {
+  inputPerMillion_usd: number;
+  outputPerMillion_usd: number;
+  cacheReadPerMillion_usd: number;
+  cacheWritePerMillion_usd: number;
+}
+
+// The rate for a model id, or null when it isn't in the table (→ unpriced).
+export function rateForModel(model: string): ModelRate | null {
+  const pricing = MODEL_PRICING.find((p) => model.startsWith(p.prefix));
+  if (!pricing) return null;
+  return {
+    inputPerMillion_usd: pricing.inputPerMillion_usd,
+    outputPerMillion_usd: pricing.outputPerMillion_usd,
+    cacheReadPerMillion_usd: pricing.inputPerMillion_usd * CACHE_READ_MULTIPLIER,
+    cacheWritePerMillion_usd: pricing.inputPerMillion_usd * CACHE_WRITE_MULTIPLIER,
+  };
+}
+
+// A non-negative token count for a usage key (missing / negative / NaN → 0).
+const tokenCount = (usage: Record<string, unknown>, key: string): number => {
+  const value = usage[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+};
+
+// The dollar cost of a single assistant turn, using that turn's own model's rates.
+// `priced` is false (and usd 0) when the model has no known price.
+export function costForUsage(usage: Record<string, unknown>, model: string): { usd: number; priced: boolean } {
+  const rate = rateForModel(model);
+  if (!rate) return { usd: 0, priced: false };
+  const usd =
+    (tokenCount(usage, "input_tokens") * rate.inputPerMillion_usd +
+      tokenCount(usage, "output_tokens") * rate.outputPerMillion_usd +
+      tokenCount(usage, "cache_read_input_tokens") * rate.cacheReadPerMillion_usd +
+      tokenCount(usage, "cache_creation_input_tokens") * rate.cacheWritePerMillion_usd) /
+    TOKENS_PER_MILLION;
+  return { usd, priced: true };
+}
+
+export interface JsonlCost {
+  usd: number;
+  unpricedTurns: number;
+}
+
+interface UsageTurn {
+  usage: Record<string, unknown>;
+  model: string;
+}
+
+// One assistant turn's usage + model, or null for any other line. A session can
+// switch models, so each turn keeps its own model for per-turn pricing.
+function assistantUsageTurn(o: Record<string, unknown>): UsageTurn | null {
+  if (o.type !== "assistant" || !isRecord(o.message) || !isRecord(o.message.usage)) return null;
+  const model = typeof o.message.model === "string" ? o.message.model : "";
+  return { usage: o.message.usage, model };
+}
+
+// Total dollar cost of a transcript, summed per assistant turn. Turns whose model
+// has no known price are excluded from usd and counted in `unpricedTurns`.
+export function costFromJsonl(raw: string): JsonlCost {
+  const turns = parseJsonl(raw)
+    .map(assistantUsageTurn)
+    .filter((t): t is UsageTurn => t !== null);
+  return turns.reduce<JsonlCost>(
+    (acc, turn) => {
+      const { usd, priced } = costForUsage(turn.usage, turn.model);
+      return priced ? { usd: acc.usd + usd, unpricedTurns: acc.unpricedTurns } : { usd: acc.usd, unpricedTurns: acc.unpricedTurns + 1 };
+    },
+    { usd: 0, unpricedTurns: 0 },
+  );
+}
+
+// ── project-scoped aggregation (today / month) ─────────────────────────────────
+
+// Cap on session files read per /api/cost call, so a project with a huge history
+// stays bounded. Files within the month window are read newest-first up to this.
+const MAX_COST_FILES = 200;
+const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Claude stores each project's transcripts under ~/.claude/projects/<encoded-cwd>/
+// (mirrors index.ts projectSessionsDir; kept here so this module has no server deps).
+function projectSessionsDir(cwd: string): string {
+  const encoded = path.resolve(cwd).replace(/[/.]/g, "-");
+  return path.join(os.homedir(), ".claude", "projects", encoded);
+}
+
+const startOfToday_ms = (now: Date): number => new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+const startOfMonth_ms = (now: Date): number => new Date(now.getFullYear(), now.getMonth(), 1).getTime();
+
+interface FileStat {
+  file: string;
+  mtime_ms: number;
+}
+
+// Cheap stat-only pass: every *.jsonl's mtime, so files can be bucketed by day
+// without reading them. Files that vanish between readdir and stat are skipped.
+async function statJsonlFiles(dir: string): Promise<FileStat[]> {
+  const names = (await fs.readdir(dir)).filter((f) => f.endsWith(".jsonl"));
+  const stats = await Promise.all(
+    names.map(async (file): Promise<FileStat | null> => {
+      try {
+        const st = await fs.stat(path.join(dir, file));
+        return { file, mtime_ms: st.mtimeMs };
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return stats.filter((s): s is FileStat => s !== null);
+}
+
+async function readFileCost(dir: string, file: string): Promise<JsonlCost> {
+  try {
+    return costFromJsonl(await fs.readFile(path.join(dir, file), "utf8"));
+  } catch {
+    return { usd: 0, unpricedTurns: 0 };
+  }
+}
+
+export interface CostRollup {
+  today: number;
+  month: number;
+  unpricedTurns: number;
+}
+
+const EMPTY_ROLLUP: CostRollup = { today: 0, month: 0, unpricedTurns: 0 };
+
+// Sum this-month and today costs across the project's sessions, bucketed by file
+// mtime. Never throws: a missing dir or unreadable file yields zeros.
+async function rollupProjectCost(cwd: string): Promise<CostRollup> {
+  const dir = projectSessionsDir(cwd);
+  const now = new Date();
+  const monthStart_ms = startOfMonth_ms(now);
+  const todayStart_ms = startOfToday_ms(now);
+  const all = await statJsonlFiles(dir).catch(() => [] as FileStat[]);
+  const inMonth = all.filter((s) => s.mtime_ms >= monthStart_ms).sort((a, b) => b.mtime_ms - a.mtime_ms);
+  const capped = inMonth.slice(0, MAX_COST_FILES);
+  if (inMonth.length > capped.length) {
+    console.log(`[api] /api/cost: capped at ${MAX_COST_FILES} of ${inMonth.length} session files for ${dir}`);
+  }
+  const perFile = await Promise.all(capped.map(async (s) => ({ mtime_ms: s.mtime_ms, cost: await readFileCost(dir, s.file) })));
+  return perFile.reduce<CostRollup>(
+    (acc, f) => ({
+      today: acc.today + (f.mtime_ms >= todayStart_ms ? f.cost.usd : 0),
+      month: acc.month + f.cost.usd,
+      unpricedTurns: acc.unpricedTurns + f.cost.unpricedTurns,
+    }),
+    EMPTY_ROLLUP,
+  );
+}
+
+// GET /api/cost?cwd=&session= → { session?, today, month, currency, unpricedTurns }.
+// today/month roll up the project's sessions; session (optional) is one transcript.
+export function mountCostRoute(app: Express, deps: { resolveCwd: (cwd: string | null) => string }): void {
+  app.get("/api/cost", async (req, res) => {
+    const cwd = deps.resolveCwd(typeof req.query.cwd === "string" ? req.query.cwd : null);
+    const sessionParam = typeof req.query.session === "string" ? req.query.session : null;
+    try {
+      const rollup = await rollupProjectCost(cwd);
+      const session = sessionParam && SESSION_ID_RE.test(sessionParam) ? (await readFileCost(projectSessionsDir(cwd), `${sessionParam}.jsonl`)).usd : undefined;
+      res.json({ session, today: rollup.today, month: rollup.month, currency: "USD", unpricedTurns: rollup.unpricedTurns });
+    } catch (err) {
+      console.error("[api] /api/cost failed:", err);
+      res.json({ today: 0, month: 0, currency: "USD", unpricedTurns: 0 });
+    }
+  });
+}

--- a/server/cost.ts
+++ b/server/cost.ts
@@ -170,7 +170,7 @@ async function rollupProjectCost(cwd: string): Promise<CostRollup> {
   const now = new Date();
   const monthStart_ms = startOfMonth_ms(now);
   const todayStart_ms = startOfToday_ms(now);
-  const all = await statJsonlFiles(dir).catch(() => [] as FileStat[]);
+  const all: FileStat[] = await statJsonlFiles(dir).catch(() => []);
   const inMonth = all.filter((s) => s.mtime_ms >= monthStart_ms).sort((a, b) => b.mtime_ms - a.mtime_ms);
   const capped = inMonth.slice(0, MAX_COST_FILES);
   if (inMonth.length > capped.length) {
@@ -187,19 +187,29 @@ async function rollupProjectCost(cwd: string): Promise<CostRollup> {
   );
 }
 
-// GET /api/cost?cwd=&session= → { session?, today, month, currency, unpricedTurns }.
-// today/month roll up the project's sessions; session (optional) is one transcript.
+// GET /api/cost?cwd=&session= → { session?, sessionUnpricedTurns, today, month,
+// currency, unpricedTurns }. today/month roll up the project's sessions; session
+// (optional) is one transcript. The session's OWN unpriced-turn count is reported
+// separately, since that session may fall outside the month window / file cap and so
+// isn't reflected in `unpricedTurns` (which covers the roll-up only).
 export function mountCostRoute(app: Express, deps: { resolveCwd: (cwd: string | null) => string }): void {
   app.get("/api/cost", async (req, res) => {
     const cwd = deps.resolveCwd(typeof req.query.cwd === "string" ? req.query.cwd : null);
     const sessionParam = typeof req.query.session === "string" ? req.query.session : null;
     try {
       const rollup = await rollupProjectCost(cwd);
-      const session = sessionParam && SESSION_ID_RE.test(sessionParam) ? (await readFileCost(projectSessionsDir(cwd), `${sessionParam}.jsonl`)).usd : undefined;
-      res.json({ session, today: rollup.today, month: rollup.month, currency: "USD", unpricedTurns: rollup.unpricedTurns });
+      const sessionCost = sessionParam && SESSION_ID_RE.test(sessionParam) ? await readFileCost(projectSessionsDir(cwd), `${sessionParam}.jsonl`) : null;
+      res.json({
+        session: sessionCost?.usd,
+        sessionUnpricedTurns: sessionCost?.unpricedTurns ?? 0,
+        today: rollup.today,
+        month: rollup.month,
+        currency: "USD",
+        unpricedTurns: rollup.unpricedTurns,
+      });
     } catch (err) {
       console.error("[api] /api/cost failed:", err);
-      res.json({ today: 0, month: 0, currency: "USD", unpricedTurns: 0 });
+      res.json({ today: 0, month: 0, currency: "USD", unpricedTurns: 0, sessionUnpricedTurns: 0 });
     }
   });
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -59,6 +59,7 @@ import { mountGitRemoteRoute } from "./gitRemote.js";
 import { mountWorktreeRoutes } from "./worktree-routes.js";
 import { mountPickFileRoute } from "./pick-file.js";
 import { mountCommandSummaryRoute } from "./command-summary.js";
+import { mountCostRoute } from "./cost.js";
 import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
 import { mountWikiRoutes } from "./backends/wiki.js";
 import { initAccountingBackend, mountAccountingRoutes } from "./backends/accounting.js";
@@ -1178,6 +1179,10 @@ mountPickFileRoute(app, { isAllowedOrigin });
 // terminal output and returns a short Errors/Warnings/cause/fix summary (issue #246).
 // Same-origin guarded like the other local-action routes.
 mountCommandSummaryRoute(app, { isAllowedOrigin });
+
+// GET /api/cost — estimated $ cost (session + today/month roll-up) for a project's
+// sessions, from public per-model pricing. Read-only; shown in the Settings modal (#245).
+mountCostRoute(app, { resolveCwd: resolveWorkspace });
 
 // POST /api/remote-host/connect|disconnect + GET /status — start/stop the
 // Firestore host loop from the toolbar Connect control. Same-origin guarded like

--- a/src/App.vue
+++ b/src/App.vue
@@ -359,6 +359,8 @@ function onSession(id: string) {
       :pr-repos="prRepos"
       :launchers="launchers"
       :user-mcp-servers="userMcpServers"
+      :cwd="effectiveCwd"
+      :session-id="activeId"
       @update-sound="saveSound"
       @update-repos="savePrRepos"
       @update-launchers="saveLaunchers"

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -2,10 +2,18 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { useTheme } from "../composables/useTheme";
 import { previewAttention } from "../composables/useAttentionSound";
+import { useCost } from "../composables/useCost";
 import type { Launcher } from "./launchers";
 import type { UserMcpServer } from "./userMcp";
 
-const props = defineProps<{ soundFile?: string | null; prRepos?: string[]; launchers?: Launcher[]; userMcpServers?: UserMcpServer[] }>();
+const props = defineProps<{
+  soundFile?: string | null;
+  prRepos?: string[];
+  launchers?: Launcher[];
+  userMcpServers?: UserMcpServer[];
+  cwd?: string | null;
+  sessionId?: string | null;
+}>();
 const emit = defineEmits<{
   (e: "update-sound", file: string | null): void;
   (e: "update-repos", repos: string[]): void;
@@ -149,6 +157,14 @@ function onThemeKey(e: KeyboardEvent, index: number) {
   themesEl.value?.querySelectorAll<HTMLElement>(".theme-card")[next]?.focus();
 }
 
+// Read-only estimated cost (Session / Today / Month), loaded when the modal opens.
+const { cost, error: costError, load: loadCost } = useCost();
+function formatUsd(value: number | undefined): string {
+  if (value === undefined) return "—";
+  if (value > 0 && value < 0.01) return "<$0.01";
+  return `$${value.toFixed(2)}`;
+}
+
 const modalEl = ref<HTMLElement>();
 
 // Modal keyboard behavior: Escape closes; Tab is trapped within the dialog.
@@ -176,6 +192,7 @@ function onKeydown(e: KeyboardEvent) {
 onMounted(() => {
   document.addEventListener("keydown", onKeydown);
   nextTick(() => modalEl.value?.querySelector<HTMLElement>("input, button")?.focus());
+  if (props.cwd) loadCost(props.cwd, props.sessionId);
 });
 onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 </script>
@@ -321,6 +338,30 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
         />
         <button class="btn" type="button" :disabled="!newMcpValid" @click="addMcpServer">Add</button>
       </div>
+
+      <h3 class="section-title">Cost (estimated)</h3>
+      <p class="hint">
+        Estimated spend for this project from <strong>public per-model pricing</strong> (input, output, and cache tokens) — actual billing may differ, and
+        flat-plan (Max) usage isn't reflected. Today / Month roll up this project's sessions.
+      </p>
+      <div class="cost-grid" role="group" aria-label="Estimated cost" title="Estimated from public per-model pricing; actual billing may differ.">
+        <div class="cost-cell">
+          <span class="cost-label">Session</span>
+          <span class="cost-value">{{ formatUsd(cost?.session) }}</span>
+        </div>
+        <div class="cost-cell">
+          <span class="cost-label">Today</span>
+          <span class="cost-value">{{ formatUsd(cost?.today) }}</span>
+        </div>
+        <div class="cost-cell">
+          <span class="cost-label">Month</span>
+          <span class="cost-value">{{ formatUsd(cost?.month) }}</span>
+        </div>
+      </div>
+      <p v-if="costError" class="hint cost-note">Couldn't load cost estimate.</p>
+      <p v-else-if="cost && cost.unpricedTurns > 0" class="hint cost-note">
+        {{ cost.unpricedTurns }} turn(s) used a model with no known price and are excluded.
+      </p>
 
       <div class="modal-foot">
         <span class="spacer" />
@@ -498,6 +539,35 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
   display: flex;
   gap: 8px;
   margin-top: 8px;
+}
+.cost-grid {
+  display: flex;
+  gap: 8px;
+}
+.cost-cell {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.cost-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.cost-value {
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+.cost-note {
+  margin: 8px 0 0;
 }
 .modal-foot {
   display: flex;

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -359,8 +359,8 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
         </div>
       </div>
       <p v-if="costError" class="hint cost-note">Couldn't load cost estimate.</p>
-      <p v-else-if="cost && cost.unpricedTurns > 0" class="hint cost-note">
-        {{ cost.unpricedTurns }} turn(s) used a model with no known price and are excluded.
+      <p v-else-if="cost && (cost.unpricedTurns > 0 || cost.sessionUnpricedTurns > 0)" class="hint cost-note">
+        Some turns used a model with no known price and are excluded from these estimates.
       </p>
 
       <div class="modal-foot">

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -189,11 +189,16 @@ function onKeydown(e: KeyboardEvent) {
   }
 }
 
+// Load cost unconditionally — the server falls back to the workspace when no cwd is
+// passed, so Today/Month still populate in the grid view (no active single-view
+// session ⇒ no cwd/sessionId). Re-fetch if cwd/sessionId arrive or change while open.
+const refreshCost = () => loadCost(props.cwd ?? null, props.sessionId ?? null);
 onMounted(() => {
   document.addEventListener("keydown", onKeydown);
   nextTick(() => modalEl.value?.querySelector<HTMLElement>("input, button")?.focus());
-  if (props.cwd) loadCost(props.cwd, props.sessionId);
+  refreshCost();
 });
+watch([() => props.cwd, () => props.sessionId], refreshCost);
 onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 </script>
 

--- a/src/composables/useCost.spec.ts
+++ b/src/composables/useCost.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { useCost } from "./useCost";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+const stubFetch = (impl: (url: string) => { ok: boolean; json: () => Promise<unknown> }) => {
+  globalThis.fetch = vi.fn((url: unknown) => Promise.resolve(impl(String(url)))) as unknown as typeof fetch;
+};
+
+describe("useCost", () => {
+  it("loads and parses a cost payload", async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ session: 0.42, today: 1.5, month: 12.3, currency: "USD", unpricedTurns: 2 }) }));
+    const { cost, error, loading, load } = useCost();
+    await load("/proj", "11111111-2222-3333-4444-555555555555");
+    expect(error.value).toBe(false);
+    expect(loading.value).toBe(false);
+    expect(cost.value).toEqual({ session: 0.42, today: 1.5, month: 12.3, currency: "USD", unpricedTurns: 2 });
+  });
+
+  it("passes cwd and session as query params", async () => {
+    const seen: string[] = [];
+    stubFetch((url) => {
+      seen.push(url);
+      return { ok: true, json: async () => ({ today: 0, month: 0, currency: "USD", unpricedTurns: 0 }) };
+    });
+    const { load } = useCost();
+    await load("/my/proj", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    expect(seen[0]).toContain("cwd=%2Fmy%2Fproj");
+    expect(seen[0]).toContain("session=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+  });
+
+  it("defaults missing numeric fields to 0 and session to undefined", async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({ currency: "USD" }) }));
+    const { cost, load } = useCost();
+    await load("/proj");
+    expect(cost.value).toEqual({ session: undefined, today: 0, month: 0, currency: "USD", unpricedTurns: 0 });
+  });
+
+  it("flags an error on a non-ok response", async () => {
+    stubFetch(() => ({ ok: false, json: async () => ({}) }));
+    const { cost, error, load } = useCost();
+    await load("/proj");
+    expect(error.value).toBe(true);
+    expect(cost.value).toBeNull();
+  });
+
+  it("flags an error when fetch rejects", async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error("network"))) as unknown as typeof fetch;
+    const { cost, error, load } = useCost();
+    await load("/proj");
+    expect(error.value).toBe(true);
+    expect(cost.value).toBeNull();
+  });
+});

--- a/src/composables/useCost.spec.ts
+++ b/src/composables/useCost.spec.ts
@@ -13,12 +13,12 @@ const stubFetch = (impl: (url: string) => { ok: boolean; json: () => Promise<unk
 
 describe("useCost", () => {
   it("loads and parses a cost payload", async () => {
-    stubFetch(() => ({ ok: true, json: async () => ({ session: 0.42, today: 1.5, month: 12.3, currency: "USD", unpricedTurns: 2 }) }));
+    stubFetch(() => ({ ok: true, json: async () => ({ session: 0.42, today: 1.5, month: 12.3, currency: "USD", unpricedTurns: 2, sessionUnpricedTurns: 1 }) }));
     const { cost, error, loading, load } = useCost();
     await load("/proj", "11111111-2222-3333-4444-555555555555");
     expect(error.value).toBe(false);
     expect(loading.value).toBe(false);
-    expect(cost.value).toEqual({ session: 0.42, today: 1.5, month: 12.3, currency: "USD", unpricedTurns: 2 });
+    expect(cost.value).toEqual({ session: 0.42, today: 1.5, month: 12.3, currency: "USD", unpricedTurns: 2, sessionUnpricedTurns: 1 });
   });
 
   it("passes cwd and session as query params", async () => {
@@ -37,7 +37,7 @@ describe("useCost", () => {
     stubFetch(() => ({ ok: true, json: async () => ({ currency: "USD" }) }));
     const { cost, load } = useCost();
     await load("/proj");
-    expect(cost.value).toEqual({ session: undefined, today: 0, month: 0, currency: "USD", unpricedTurns: 0 });
+    expect(cost.value).toEqual({ session: undefined, today: 0, month: 0, currency: "USD", unpricedTurns: 0, sessionUnpricedTurns: 0 });
   });
 
   it("flags an error on a non-ok response", async () => {

--- a/src/composables/useCost.ts
+++ b/src/composables/useCost.ts
@@ -1,0 +1,57 @@
+import { ref } from "vue";
+
+// The /api/cost payload: estimated $ spend for the current session plus today /
+// month roll-ups. `session` is absent when no session id was requested.
+export interface CostRollup {
+  session?: number;
+  today: number;
+  month: number;
+  currency: string;
+  unpricedTurns: number;
+}
+
+const COST_FETCH_TIMEOUT_MS = 8000;
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const finiteNumber = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
+
+function parseCost(data: unknown): CostRollup | null {
+  if (!isRecord(data)) return null;
+  return {
+    session: finiteNumber(data.session),
+    today: finiteNumber(data.today) ?? 0,
+    month: finiteNumber(data.month) ?? 0,
+    currency: typeof data.currency === "string" ? data.currency : "USD",
+    unpricedTurns: finiteNumber(data.unpricedTurns) ?? 0,
+  };
+}
+
+// Fetch estimated cost for a project (and optional session). Errors — including a
+// timeout — leave `cost` null and set `error`, so the caller can show a fallback.
+export function useCost() {
+  const cost = ref<CostRollup | null>(null);
+  const loading = ref(false);
+  const error = ref(false);
+
+  async function load(cwd?: string | null, sessionId?: string | null): Promise<void> {
+    loading.value = true;
+    error.value = false;
+    const params = new URLSearchParams();
+    if (cwd) params.set("cwd", cwd);
+    if (sessionId) params.set("session", sessionId);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), COST_FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(`/api/cost?${params.toString()}`, { signal: controller.signal });
+      if (!res.ok) throw new Error(`cost request failed: ${res.status}`);
+      cost.value = parseCost(await res.json());
+    } catch {
+      error.value = true;
+    } finally {
+      clearTimeout(timer);
+      loading.value = false;
+    }
+  }
+
+  return { cost, loading, error, load };
+}

--- a/src/composables/useCost.ts
+++ b/src/composables/useCost.ts
@@ -7,7 +7,8 @@ export interface CostRollup {
   today: number;
   month: number;
   currency: string;
-  unpricedTurns: number;
+  unpricedTurns: number; // in the today/month roll-up
+  sessionUnpricedTurns: number; // in the requested session (may be outside the roll-up window)
 }
 
 const COST_FETCH_TIMEOUT_MS = 8000;
@@ -23,6 +24,7 @@ function parseCost(data: unknown): CostRollup | null {
     month: finiteNumber(data.month) ?? 0,
     currency: typeof data.currency === "string" ? data.currency : "USD",
     unpricedTurns: finiteNumber(data.unpricedTurns) ?? 0,
+    sessionUnpricedTurns: finiteNumber(data.sessionUnpricedTurns) ?? 0,
   };
 }
 


### PR DESCRIPTION
## Summary

Shows the user their **estimated \$ cost** in the Settings modal: current **Session**, plus **Today** and **This-month** roll-ups across the current project's Claude sessions. Tokens were already tracked; this adds pricing + aggregation + a read-only display.

- **`server/cost.ts`** (new, pure + route): hardcoded per-model rate table, per-turn cost calc, and a `GET /api/cost` project roll-up.
- **`src/composables/useCost.ts`** (new): fetches `/api/cost` with an `AbortController` timeout; errors leave the block showing `—`.
- **`SettingsModal.vue`**: a read-only "Cost (estimated)" block (Session / Today / Month) with an estimate tooltip.
- `server/index.ts`: one import + one `mountCostRoute(app, { resolveCwd: resolveWorkspace })`.

## Items to Confirm / Review

- **Pricing is a hardcoded public-list estimate and will drift.** `server/cost.ts` `MODEL_PRICING` holds `\$ / 1M tokens` (input/output) for current models: Fable 5 (10/50), Opus 4.8/4.7/4.6/4.5 (5/25), Sonnet 5/4.6/4.5 (3/15), Haiku 4.5 (1/5). **cache-read** is derived as `0.1×` input and **cache-write** as `1.25×` input (the default 5-minute ephemeral cache Claude Code uses). Please sanity-check these values and the cache multipliers.
- **Unknown models are left unpriced** (not guessed) and reported as `unpricedTurns`; the UI notes when turns were excluded. Confirm that's the desired behavior vs. a best-guess.
- **Today/month are bucketed by file mtime**, not per-turn timestamp — a whole transcript's cost is attributed to its file's mtime day. This is the MVP approximation the issue calls for (stat-first, `\$0`-safe, capped at 200 files/read).
- Model matching is by **id prefix** so dated snapshots (`…-20250929`) resolve to their family; `claude-sonnet-5` vs `claude-sonnet-4-5` is covered by a test.

## User Prompt

順次対応の umbrella #241 の子。C/D を並行実装。本PRは **D / #245**（コスト(\$)表示と日次/月次ロールアップ）。

## Implementation notes

- **Per-turn pricing**: `costForUsage(usage, model)` prices one assistant turn by its own `message.model` (a session can switch models); `costFromJsonl(raw)` sums turns and counts `unpricedTurns`. `cost.ts` reuses `isRecord`/`parseJsonl` from `transcript.ts` (no new exports added there).
- **Aggregation**: `mountCostRoute` scans `~/.claude/projects/<encoded-cwd>/*.jsonl` stat-first, filters to the month window, sorts newest-first, caps at `MAX_COST_FILES` (200; logs a note if capped), and never throws (missing dir → zeros). `session` reads one transcript (uuid-validated to avoid path traversal).
- **UI**: `SettingsModal` gains `cwd` / `sessionId` props (passed from `App.vue` as `effectiveCwd` / `activeId`) and fetches on open; the block is read-only text, so the modal's focus-trap is unaffected.

## Scope / follow-ups (MVP)

- Current project only — cross-project roll-up and a live per-cell cost badge are follow-ups.
- Flat-plan (Max) users may want to hide \$ — flagged in the UI hint; the ON/OFF toggle is **not** built here.
- Did **not** touch `TerminalCell.vue`'s usage badge (issue #244 is editing it concurrently).

## Verification

- `eslint server src`: **0 errors** (only the pre-existing `spawnClaudePty` max-params warning).
- `yarn typecheck`, `yarn typecheck:server`, `yarn build`: pass.
- `yarn test server/cost.spec.ts src/composables/useCost.spec.ts`: **18 passed** (per-model rates, prefix match, model switch, cache pricing, unknown/empty/malformed). Existing `SettingsModal.spec.ts`: 6 passed.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)