### PR TITLE
feat: run collection actions / skills in Codex (explicit launcher + skill mirror)

### DIFF
--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import os from "node:os";
 import { mkdirSync } from "node:fs";
 import { seedHelps, syncPresetSkills, syncActivePresetSkills, presetSkillsAssetDir } from "@mulmoclaude/core/workspace-setup";
+import { syncCodexSkills, codexSkillsRoot } from "../codex-skills.js";
 
 // Console-backed logger, matching the prefix style other backends use.
 const log = {
@@ -84,5 +85,12 @@ export function initWorkspaceSetup(deps: { workspace: string }): void {
     mkdirSync(active, { recursive: true });
     const result = syncActivePresetSkills({ sourceDir: presetSkillsAssetDir(), activeDir: active, onInfo, onWarn });
     log.info("refreshed active preset skills", { updated: result.updated.length, removed: result.removed.length, skipped: result.skipped.length });
+  });
+
+  // Mirror the workspace's skills into codex's own skills dir (~/.codex/skills) so codex loads them
+  // by description — codex has no /<slug> command, so a codex chat seed names the skill instead.
+  safeStep("mirrorCodexSkills", () => {
+    const result = syncCodexSkills(path.join(workspace, ".claude", "skills"), codexSkillsRoot());
+    log.info("mirrored skills to codex", { mirrored: result.mirrored.length, skipped: result.skipped.length });
   });
 }

--- a/server/codex-args.spec.ts
+++ b/server/codex-args.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildCodexArgs } from "./codex-args.js";
 
-const base = { resume: null, model: null, guiMcpUrl: null, initialPrompt: null };
+const base = { resume: null, model: null, guiMcpUrl: null };
 
 describe("buildCodexArgs", () => {
   it("passes no id for a fresh session (codex mints its own)", () => {
@@ -32,18 +32,10 @@ describe("buildCodexArgs", () => {
     ]);
   });
 
-  it("appends the initial prompt as the trailing positional for a fresh session", () => {
-    expect(buildCodexArgs({ ...base, initialPrompt: "fix the login bug" })).toEqual(["fix the login bug"]);
-  });
-
-  it("appends the initial prompt after the resume id (codex resume <id> [PROMPT])", () => {
-    expect(buildCodexArgs({ ...base, resume: "id1", initialPrompt: "do the thing" })).toEqual(["resume", "id1", "do the thing"]);
-  });
-
-  it("orders model, GUI MCP, resume, then the prompt last", () => {
-    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpUrl: "gui-mcp-endpoint", initialPrompt: "seed" });
+  it("orders model, GUI MCP, then the resume subcommand (no positional prompt)", () => {
+    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpUrl: "gui-mcp-endpoint" });
     expect(args.slice(0, 2)).toEqual(["--model", "gpt-5.4"]);
     expect(args).toContain("-c");
-    expect(args.slice(-3)).toEqual(["resume", "id1", "seed"]);
+    expect(args.slice(-2)).toEqual(["resume", "id1"]);
   });
 });

--- a/server/codex-args.spec.ts
+++ b/server/codex-args.spec.ts
@@ -1,31 +1,30 @@
 import { describe, it, expect } from "vitest";
 import { buildCodexArgs } from "./codex-args.js";
 
+const base = { resume: null, model: null, guiMcpUrl: null, initialPrompt: null };
+
 describe("buildCodexArgs", () => {
   it("passes no id for a fresh session (codex mints its own)", () => {
-    expect(buildCodexArgs({ resume: null, model: null, guiMcpUrl: null })).toEqual([]);
+    expect(buildCodexArgs({ ...base })).toEqual([]);
   });
 
   it("adds the model override before the subcommand", () => {
-    expect(buildCodexArgs({ resume: null, model: "gpt-5.4", guiMcpUrl: null })).toEqual(["--model", "gpt-5.4"]);
+    expect(buildCodexArgs({ ...base, model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4"]);
   });
 
   it("resumes a known rollout id via the resume subcommand", () => {
-    expect(buildCodexArgs({ resume: "019f251d-001c-7542-b13e-9a627effce52", model: null, guiMcpUrl: null })).toEqual([
-      "resume",
-      "019f251d-001c-7542-b13e-9a627effce52",
-    ]);
+    expect(buildCodexArgs({ ...base, resume: "019f251d-001c-7542-b13e-9a627effce52" })).toEqual(["resume", "019f251d-001c-7542-b13e-9a627effce52"]);
   });
 
   it("keeps global flags ahead of the resume subcommand", () => {
-    expect(buildCodexArgs({ resume: "abc", model: "gpt-5.4", guiMcpUrl: null })).toEqual(["--model", "gpt-5.4", "resume", "abc"]);
+    expect(buildCodexArgs({ ...base, resume: "abc", model: "gpt-5.4" })).toEqual(["--model", "gpt-5.4", "resume", "abc"]);
   });
 
   it("injects the GUI MCP server + auto-approval via -c when a url is given", () => {
     // Opaque endpoint token — buildCodexArgs embeds it verbatim (the real value is an
     // interpolated loopback URL; a static http literal here trips no-clear-text-protocols).
     const url = "gui-mcp-endpoint";
-    expect(buildCodexArgs({ resume: null, model: null, guiMcpUrl: url })).toEqual([
+    expect(buildCodexArgs({ ...base, guiMcpUrl: url })).toEqual([
       "-c",
       `mcp_servers.mulmoterminal-gui.url="${url}"`,
       "-c",
@@ -33,10 +32,18 @@ describe("buildCodexArgs", () => {
     ]);
   });
 
-  it("orders model, GUI MCP, then the resume subcommand", () => {
-    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpUrl: "gui-mcp-endpoint" });
+  it("appends the initial prompt as the trailing positional for a fresh session", () => {
+    expect(buildCodexArgs({ ...base, initialPrompt: "fix the login bug" })).toEqual(["fix the login bug"]);
+  });
+
+  it("appends the initial prompt after the resume id (codex resume <id> [PROMPT])", () => {
+    expect(buildCodexArgs({ ...base, resume: "id1", initialPrompt: "do the thing" })).toEqual(["resume", "id1", "do the thing"]);
+  });
+
+  it("orders model, GUI MCP, resume, then the prompt last", () => {
+    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpUrl: "gui-mcp-endpoint", initialPrompt: "seed" });
     expect(args.slice(0, 2)).toEqual(["--model", "gpt-5.4"]);
     expect(args).toContain("-c");
-    expect(args.slice(-2)).toEqual(["resume", "id1"]);
+    expect(args.slice(-3)).toEqual(["resume", "id1", "seed"]);
   });
 });

--- a/server/codex-args.ts
+++ b/server/codex-args.ts
@@ -9,12 +9,11 @@ export interface CodexArgsInput {
   model: string | null;
   // The in-process GUI MCP endpoint to attach (single view), or null (grid dev terminal / no GUI).
   guiMcpUrl: string | null;
-  // A prompt to auto-run as the session's first turn (codex's positional [PROMPT]), or null for an
-  // interactive session with no seed. codex has no --system-prompt, so any instructions must already
-  // be part of this text.
-  initialPrompt: string | null;
 }
 
+// NOTE: a seed prompt is NOT passed here as a positional [PROMPT] — a long collection-action prompt
+// overflows tmux's new-session command-length limit ("command too long"). It is typed into codex's
+// input box after startup instead (see attachCodexAutoRun in index.ts).
 export function buildCodexArgs(input: CodexArgsInput): string[] {
   const args: string[] = [];
   if (input.model) args.push("--model", input.model);
@@ -27,7 +26,5 @@ export function buildCodexArgs(input: CodexArgsInput): string[] {
     args.push("-c", `mcp_servers.mulmoterminal-gui.default_tools_approval_mode="approve"`);
   }
   if (input.resume) args.push("resume", input.resume);
-  // The positional PROMPT goes last — for `codex [OPTS] [PROMPT]` and `codex resume <id> [PROMPT]`.
-  if (input.initialPrompt) args.push(input.initialPrompt);
   return args;
 }

--- a/server/codex-args.ts
+++ b/server/codex-args.ts
@@ -9,6 +9,10 @@ export interface CodexArgsInput {
   model: string | null;
   // The in-process GUI MCP endpoint to attach (single view), or null (grid dev terminal / no GUI).
   guiMcpUrl: string | null;
+  // A prompt to auto-run as the session's first turn (codex's positional [PROMPT]), or null for an
+  // interactive session with no seed. codex has no --system-prompt, so any instructions must already
+  // be part of this text.
+  initialPrompt: string | null;
 }
 
 export function buildCodexArgs(input: CodexArgsInput): string[] {
@@ -23,5 +27,7 @@ export function buildCodexArgs(input: CodexArgsInput): string[] {
     args.push("-c", `mcp_servers.mulmoterminal-gui.default_tools_approval_mode="approve"`);
   }
   if (input.resume) args.push("resume", input.resume);
+  // The positional PROMPT goes last — for `codex [OPTS] [PROMPT]` and `codex resume <id> [PROMPT]`.
+  if (input.initialPrompt) args.push(input.initialPrompt);
   return args;
 }

--- a/server/codex-skills.spec.ts
+++ b/server/codex-skills.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { syncCodexSkills, codexifySkillSeed } from "./codex-skills.js";
+
+describe("codexifySkillSeed", () => {
+  it("rewrites a /<slug> <msg> chat seed to name the skill in natural language", () => {
+    expect(codexifySkillSeed("/art-exhibitions はろー")).toBe('Use the "art-exhibitions" skill.\n\nはろー');
+  });
+  it("handles a slug with no message", () => {
+    expect(codexifySkillSeed("/books")).toBe('Use the "books" skill.');
+  });
+  it("preserves the record id + message in the rest", () => {
+    expect(codexifySkillSeed("/movies id=42 mark as seen")).toBe('Use the "movies" skill.\n\nid=42 mark as seen');
+  });
+  it("leaves a non-slash prompt unchanged (a collection action's natural-language seed)", () => {
+    expect(codexifySkillSeed("Repair this record's fields")).toBe("Repair this record's fields");
+  });
+});
+
+describe("syncCodexSkills", () => {
+  let src: string;
+  let dst: string;
+  const skillDir = (root: string, name: string): string => path.join(root, name);
+  function writeSkill(root: string, name: string, body: string): void {
+    mkdirSync(skillDir(root, name), { recursive: true });
+    writeFileSync(path.join(skillDir(root, name), "SKILL.md"), body);
+  }
+  beforeEach(() => {
+    src = mkdtempSync(path.join(tmpdir(), "mt-skills-src-"));
+    dst = mkdtempSync(path.join(tmpdir(), "mt-skills-dst-"));
+  });
+  afterEach(() => {
+    rmSync(src, { recursive: true, force: true });
+    rmSync(dst, { recursive: true, force: true });
+  });
+
+  it("mirrors workspace skills into the codex dir with an ownership marker", () => {
+    writeSkill(src, "art-exhibitions", "# skill");
+    const res = syncCodexSkills(src, dst);
+    expect(res.mirrored).toEqual(["art-exhibitions"]);
+    expect(existsSync(path.join(dst, "art-exhibitions", "SKILL.md"))).toBe(true);
+    expect(existsSync(path.join(dst, "art-exhibitions", ".mt-mirror"))).toBe(true);
+  });
+
+  it("does NOT clobber a codex-owned skill of the same name (no marker)", () => {
+    writeSkill(src, "wrangler", "# ours");
+    writeSkill(dst, "wrangler", "# codex original"); // pre-existing, unmarked = codex's own
+    const res = syncCodexSkills(src, dst);
+    expect(res.skipped).toEqual(["wrangler"]);
+    expect(readFileSync(path.join(dst, "wrangler", "SKILL.md"), "utf8")).toBe("# codex original");
+  });
+
+  it("re-copies a previously-mirrored skill (drops files removed from source)", () => {
+    writeSkill(src, "books", "# v2");
+    // simulate a prior mirror: marked dir with a stale extra file
+    mkdirSync(path.join(dst, "books"), { recursive: true });
+    writeFileSync(path.join(dst, "books", ".mt-mirror"), "x");
+    writeFileSync(path.join(dst, "books", "stale.txt"), "old");
+    const res = syncCodexSkills(src, dst);
+    expect(res.mirrored).toEqual(["books"]);
+    expect(readFileSync(path.join(dst, "books", "SKILL.md"), "utf8")).toBe("# v2");
+    expect(existsSync(path.join(dst, "books", "stale.txt"))).toBe(false);
+  });
+
+  it("no-ops when the source doesn't exist", () => {
+    expect(syncCodexSkills(path.join(src, "nope"), dst)).toEqual({ mirrored: [], skipped: [] });
+  });
+});

--- a/server/codex-skills.ts
+++ b/server/codex-skills.ts
@@ -1,0 +1,54 @@
+import { existsSync, readdirSync, mkdirSync, cpSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+// Marks a codex skill dir mulmoterminal owns, so a re-sync overwrites OURS but never clobbers
+// codex's own curated/system skills.
+const MIRROR_MARKER = ".mt-mirror";
+const SLUG_RE = /^[a-z0-9][\w-]*$/i;
+
+export function codexSkillsRoot(): string {
+  const home = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
+  return path.join(home, "skills");
+}
+
+const isOurs = (dir: string): boolean => existsSync(path.join(dir, MIRROR_MARKER));
+
+// Mirror each skill dir from the workspace's .claude/skills into codex's skills dir (same SKILL.md
+// format), so codex loads them by description like claude does. Skips any name codex already owns
+// (no marker) to avoid clobbering codex's own skills; re-copies ours fresh so edits/removals in the
+// workspace propagate.
+export function syncCodexSkills(sourceDir: string, destDir: string): { mirrored: string[]; skipped: string[] } {
+  const mirrored: string[] = [];
+  const skipped: string[] = [];
+  if (!existsSync(sourceDir)) return { mirrored, skipped };
+  mkdirSync(destDir, { recursive: true });
+  const names = readdirSync(sourceDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+  for (const name of names) {
+    const dst = path.join(destDir, name);
+    if (existsSync(dst) && !isOurs(dst)) {
+      skipped.push(name);
+      continue;
+    }
+    rmSync(dst, { recursive: true, force: true });
+    cpSync(path.join(sourceDir, name), dst, { recursive: true });
+    writeFileSync(path.join(dst, MIRROR_MARKER), "managed by mulmoterminal\n");
+    mirrored.push(name);
+  }
+  return { mirrored, skipped };
+}
+
+// codex has no /<slug> command (skills auto-load by description), so a collection chat seed
+// "/<slug> <msg>" is rewritten to NAME the skill in natural language — which makes codex load the
+// mirrored skill. A non-slash seed (a collection action's natural-language prompt) is unchanged.
+export function codexifySkillSeed(message: string): string {
+  const trimmed = message.trim();
+  if (!trimmed.startsWith("/")) return message;
+  const space = trimmed.search(/\s/);
+  const slug = space === -1 ? trimmed.slice(1) : trimmed.slice(1, space);
+  if (!SLUG_RE.test(slug)) return message; // not a /<slug> seed — leave it alone
+  const rest = space === -1 ? "" : trimmed.slice(space + 1).trim();
+  return rest ? `Use the "${slug}" skill.\n\n${rest}` : `Use the "${slug}" skill.`;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -776,26 +776,29 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
     return res.json({ message: "spawnBackgroundChat: `message` is required (non-empty string)." });
   }
   const draft = body.draft === true;
+  const agent = body.agent === "codex" ? "codex" : "claude";
   const sessionId = randomUUID();
   if (body.hidden === true) hiddenSessions.add(sessionId);
-  // ws is null: the session runs headless until the user opens it (reattach
-  // replays the buffered output). The "created" pubsub event in spawnClaudePty
-  // surfaces it in the sidebar right away. A draft spawns with NO initial prompt
-  // (so claude doesn't auto-run) and gets the text typed into its input box instead.
+  // ws is null: the session runs headless until the user opens it (reattach replays the buffered
+  // output). A claude draft spawns with NO initial prompt (so it doesn't auto-run) and gets the text
+  // typed into its input box. codex has no editable-draft path (no stable TUI ready-marker), so its
+  // seed always auto-runs as codex's positional first-turn prompt, with the GUI MCP attached.
   try {
-    if (draft) spawnClaudePty(sessionId, null, null, undefined, CLAUDE_CWD, true, message);
+    if (agent === "codex") spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, message);
+    else if (draft) spawnClaudePty(sessionId, null, null, undefined, CLAUDE_CWD, true, message);
     else spawnClaudePty(sessionId, null, null, message);
   } catch (err) {
     console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);
     return res.json({ message: `Failed to spawn a new session: ${messageOf(err)}` });
   }
-  return res.json({
-    message: draft
-      ? `Opened a new terminal session (chatId ${sessionId}) with the text prefilled in the input for the user to review and send.`
-      : `Spawned a new terminal session (chatId ${sessionId}). It runs in parallel; the user can open it from the sidebar.`,
-    jsonData: { chatId: sessionId },
-  });
+  return res.json({ message: backgroundChatMessage(agent, draft, sessionId), jsonData: { chatId: sessionId, agent } });
 });
+
+function backgroundChatMessage(agent: "claude" | "codex", draft: boolean, sessionId: string): string {
+  if (agent === "codex") return `Spawned a new codex session (chatId ${sessionId}) auto-running the prompt.`;
+  if (draft) return `Opened a new terminal session (chatId ${sessionId}) with the text prefilled in the input for the user to review and send.`;
+  return `Spawned a new terminal session (chatId ${sessionId}). It runs in parallel; the user can open it from the sidebar.`;
+}
 
 // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
 // /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
@@ -2145,13 +2148,20 @@ function rememberCodexRollout(sessionId: string, root: string, before: Set<strin
     .catch(() => {});
 }
 
-function spawnCodexPty(sessionId: string, ws: WebSocket, resumeRolloutId: string | null, cwd: string, attachGuiMcp: boolean): PtyEntry {
+function spawnCodexPty(
+  sessionId: string,
+  ws: WebSocket | null,
+  resumeRolloutId: string | null,
+  cwd: string,
+  attachGuiMcp: boolean,
+  initialPrompt: string | null,
+): PtyEntry {
   const root = codexSessionsRoot();
   const before = snapshotSessions(root);
   // Single view: point codex at the in-process GUI MCP (same per-session URL as claude's) so it
   // can drive the GUI panel. Grid dev terminals pass gui=0 → no MCP.
   const guiMcpUrl = attachGuiMcp ? `http://127.0.0.1:${PORT}/api/mcp/${sessionId}` : null;
-  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL, guiMcpUrl });
+  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL, guiMcpUrl, initialPrompt });
   const { term, tmux } = ptySpawn(sessionId, CODEX_BIN, args, cwd, true);
   const via = tmux ? " via tmux" : "";
   const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";
@@ -2178,7 +2188,7 @@ function startCodexEntry(
   attachGuiMcp: boolean,
 ): PtyEntry {
   if (live) return reattachPty(live, ws, sessionId);
-  return spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp);
+  return spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp, null); // interactive: no seed
 }
 
 // codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume). ?gui=0 (grid dev terminal) runs

--- a/server/index.ts
+++ b/server/index.ts
@@ -1678,6 +1678,47 @@ function attachDraftInjection(entry: PtyEntry, initialPrompt: string | undefined
   };
 }
 
+// codex's TUI has no stable "input ready" marker (its placeholder rotates), so instead of matching
+// a string we wait for its startup output to SETTLE — the boot banner + MCP-boot spinner keep
+// emitting until the input prompt is ready, so a quiet gap means codex is waiting for input. Then
+// paste the seed + Enter to auto-run it. Same reason as attachDraftInjection: a long prompt can't go
+// through tmux's new-session command-length limit ("command too long"). Returns a scanner fed the
+// pty output.
+const CODEX_READY_QUIET_MS = 1000;
+const CODEX_AUTORUN_MAX_WAIT_MS = 15_000;
+function attachCodexAutoRun(entry: PtyEntry, prompt: string): (data: string) => void {
+  const text = sanitizeDraftText(prompt);
+  if (!text) return () => {};
+  let done = false;
+  let quiet: ReturnType<typeof setTimeout> | null = null;
+  const type = () => {
+    if (done) return;
+    done = true;
+    if (quiet) clearTimeout(quiet);
+    try {
+      entry.term.write(`\x1b[200~${text}\x1b[201~`);
+      setTimeout(() => {
+        try {
+          entry.term.write("\r");
+        } catch {
+          // pty already gone — nothing to submit
+        }
+      }, DRAFT_SUBMIT_MS);
+    } catch {
+      // pty already gone — nothing to type into
+    }
+  };
+  const cap = setTimeout(type, CODEX_AUTORUN_MAX_WAIT_MS);
+  return () => {
+    if (done) return;
+    if (quiet) clearTimeout(quiet);
+    quiet = setTimeout(() => {
+      clearTimeout(cap);
+      type();
+    }, CODEX_READY_QUIET_MS);
+  };
+}
+
 function spawnClaudePty(
   sessionId: string,
   resume: string | null,
@@ -2120,10 +2161,11 @@ function resolveCodexSession(requested: string | null): { sessionId: string; liv
   return { sessionId, live, resumeRolloutId };
 }
 
-function wireCodexRelay(entry: PtyEntry, sessionId: string): void {
+function wireCodexRelay(entry: PtyEntry, sessionId: string, onOutput?: (data: string) => void): void {
   entry.term.onData((data) => {
     entry.buffer = (entry.buffer + data).slice(-OUTPUT_BUFFER_LIMIT);
     if (entry.ws && entry.ws.readyState === entry.ws.OPEN) entry.ws.send(JSON.stringify({ type: "output", data }));
+    onOutput?.(data);
   });
   entry.term.onExit(({ exitCode, signal }) => {
     console.log(`[pty] codex exited code=${exitCode} signal=${signal}`);
@@ -2161,7 +2203,7 @@ function spawnCodexPty(
   // Single view: point codex at the in-process GUI MCP (same per-session URL as claude's) so it
   // can drive the GUI panel. Grid dev terminals pass gui=0 → no MCP.
   const guiMcpUrl = attachGuiMcp ? `http://127.0.0.1:${PORT}/api/mcp/${sessionId}` : null;
-  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL, guiMcpUrl, initialPrompt });
+  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL, guiMcpUrl });
   const { term, tmux } = ptySpawn(sessionId, CODEX_BIN, args, cwd, true);
   const via = tmux ? " via tmux" : "";
   const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";
@@ -2175,7 +2217,10 @@ function spawnCodexPty(
     // could overwrite the known id with a mis-attributed concurrent rollout.
     rememberCodexRollout(sessionId, root, before, cwd);
   }
-  wireCodexRelay(entry, sessionId);
+  // A seed prompt is typed into codex's input box after it settles (not a CLI arg — see
+  // attachCodexAutoRun), so a long collection-action prompt can't overflow tmux's command limit.
+  const autoRun = initialPrompt ? attachCodexAutoRun(entry, initialPrompt) : undefined;
+  wireCodexRelay(entry, sessionId, autoRun);
   return entry;
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./codex-session.js";
 import { listCodexSessions, codexRolloutExists } from "./codex-sessions.js";
+import { codexifySkillSeed } from "./codex-skills.js";
 import { stripTerminalQueries } from "./terminal-replay.js";
 import {
   isRecord,
@@ -784,7 +785,7 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   // typed into its input box. codex has no editable-draft path (no stable TUI ready-marker), so its
   // seed always auto-runs as codex's positional first-turn prompt, with the GUI MCP attached.
   try {
-    if (agent === "codex") spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, message);
+    if (agent === "codex") spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, codexifySkillSeed(message));
     else if (draft) spawnClaudePty(sessionId, null, null, undefined, CLAUDE_CWD, true, message);
     else spawnClaudePty(sessionId, null, null, message);
   } catch (err) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@ import SettingsModal from "./components/SettingsModal.vue";
 import AppToolbar from "./components/AppToolbar.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
 import { browseClose } from "./composables/useCollectionBrowse";
-import { registerChatOpener, setActiveChatAgent } from "./composables/useChatLauncher";
+import { registerChatOpener } from "./composables/useChatLauncher";
 import { useAppConfig } from "./composables/useAppConfig";
 import { useDirConfig } from "./composables/useDirConfig";
 import { useFaviconState } from "./composables/useFaviconState";
@@ -248,10 +248,6 @@ registerChatOpener((id, opts) => {
   selectSession(id, opts?.agent ?? "claude");
   if (opts?.draft) showDraftHint();
 });
-
-// Keep the chat launcher's agent in sync so a collection action spawns the SAME agent the single
-// view is on (a codex action runs in codex, seeded as its auto-run first turn).
-watch(singleAgent, (a) => setActiveChatAgent(a), { immediate: true });
 
 function newSession() {
   singleAgent.value = "claude";

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@ import SettingsModal from "./components/SettingsModal.vue";
 import AppToolbar from "./components/AppToolbar.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
 import { browseClose } from "./composables/useCollectionBrowse";
-import { registerChatOpener } from "./composables/useChatLauncher";
+import { registerChatOpener, setActiveChatAgent } from "./composables/useChatLauncher";
 import { useAppConfig } from "./composables/useAppConfig";
 import { useDirConfig } from "./composables/useDirConfig";
 import { useFaviconState } from "./composables/useFaviconState";
@@ -243,11 +243,15 @@ onUnmounted(() => clearTimeout(draftHintTimer));
 // A collection action spawned a new chat and wants it shown: close the browse overlay
 // (if open) and select the session so the terminal displays it. A draft also shows the
 // preparing hint until claude is ready for the prefilled text.
-registerChatOpener((id: string, opts?: { draft?: boolean }) => {
+registerChatOpener((id, opts) => {
   browseClose();
-  selectSession(id);
+  selectSession(id, opts?.agent ?? "claude");
   if (opts?.draft) showDraftHint();
 });
+
+// Keep the chat launcher's agent in sync so a collection action spawns the SAME agent the single
+// view is on (a codex action runs in codex, seeded as its auto-run first turn).
+watch(singleAgent, (a) => setActiveChatAgent(a), { immediate: true });
 
 function newSession() {
   singleAgent.value = "claude";

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -11,6 +11,7 @@ import PluginFrame from "./PluginFrame.vue";
 import { collectionShadowCss } from "../collectionShadowCss";
 import { useCollectionBrowse } from "../composables/useCollectionBrowse";
 import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
+import { launchAgent } from "../composables/useChatLauncher";
 
 // Navigation is the toolbar's job (the Chat tab closes this; Collections / favorite
 // tabs switch what it shows), so the overlay itself carries no chrome — it just fills
@@ -51,12 +52,39 @@ onMounted(() => window.addEventListener("keydown", onKeydown));
 
 <template>
   <div v-if="isOpen" class="browse-overlay" role="region" aria-label="Collections">
-    <PluginFrame :css="collectionShadowCss" height="100%">
-      <div ref="probe" style="height: 100%">
-        <CollectionsIndexView v-if="view.mode === 'index'" />
-        <CollectionView v-else-if="view.mode === 'detail'" />
+    <div class="browse-bar">
+      <span class="browse-bar-label">Launch with</span>
+      <div class="agent-toggle" role="radiogroup" aria-label="Launch agent">
+        <button
+          type="button"
+          class="agent-btn"
+          :class="{ active: launchAgent === 'claude' }"
+          role="radio"
+          :aria-checked="launchAgent === 'claude'"
+          @click="launchAgent = 'claude'"
+        >
+          Claude
+        </button>
+        <button
+          type="button"
+          class="agent-btn"
+          :class="{ active: launchAgent === 'codex' }"
+          role="radio"
+          :aria-checked="launchAgent === 'codex'"
+          @click="launchAgent = 'codex'"
+        >
+          Codex
+        </button>
       </div>
-    </PluginFrame>
+    </div>
+    <div class="browse-body">
+      <PluginFrame :css="collectionShadowCss" height="100%">
+        <div ref="probe" style="height: 100%">
+          <CollectionsIndexView v-if="view.mode === 'index'" />
+          <CollectionView v-else-if="view.mode === 'detail'" />
+        </div>
+      </PluginFrame>
+    </div>
   </div>
 </template>
 
@@ -70,5 +98,55 @@ onMounted(() => window.addEventListener("keydown", onKeydown));
   bottom: 0;
   z-index: 50;
   background: var(--bg-deep);
+  display: flex;
+  flex-direction: column;
+}
+
+/* A thin bar picking which agent a collection action / chat launches. */
+.browse-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  font-family: system-ui, sans-serif;
+}
+.browse-bar-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+}
+.agent-toggle {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-panel);
+}
+.agent-btn {
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  font:
+    500 12px system-ui,
+    sans-serif;
+  padding: 3px 14px;
+  border-radius: 5px;
+}
+.agent-btn:hover {
+  color: var(--text);
+}
+.agent-btn.active {
+  background: var(--bg-elevated);
+  color: var(--text);
+}
+
+.browse-body {
+  flex: 1;
+  min-height: 0;
 }
 </style>

--- a/src/composables/useChatLauncher.spec.ts
+++ b/src/composables/useChatLauncher.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nextTick } from "vue";
 import { registerChatOpener, startCollectionChat, launchAgent } from "./useChatLauncher";
 
 function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; json: () => unknown }) {
@@ -79,5 +80,11 @@ describe("startCollectionChat", () => {
     await startCollectionChat("oops");
 
     expect(opener).not.toHaveBeenCalled();
+  });
+
+  it("persists the launch agent to localStorage", async () => {
+    launchAgent.value = "codex";
+    await nextTick();
+    expect(localStorage.getItem("mt-launch-agent")).toBe("codex");
   });
 });

--- a/src/composables/useChatLauncher.spec.ts
+++ b/src/composables/useChatLauncher.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { registerChatOpener, startCollectionChat } from "./useChatLauncher";
+import { registerChatOpener, startCollectionChat, setActiveChatAgent } from "./useChatLauncher";
 
 function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; json: () => unknown }) {
   const fn = vi.fn((url: string, init?: RequestInit) => {
@@ -12,7 +12,10 @@ function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; jso
 
 describe("startCollectionChat", () => {
   beforeEach(() => registerChatOpener(vi.fn()));
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setActiveChatAgent("claude"); // reset module state so the codex test doesn't leak
+  });
 
   it("spawns a chat seeded with the prompt and selects it (hidden=false)", async () => {
     const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-1" } }) }));
@@ -25,8 +28,20 @@ describe("startCollectionChat", () => {
     const [url, init] = fetchFn.mock.calls[0];
     expect(url).toBe("/api/plugin/spawnBackgroundChat");
     expect(init?.method).toBe("POST");
-    expect(JSON.parse(String(init?.body))).toEqual({ message: "fix my records", draft: false });
-    expect(opener).toHaveBeenCalledWith("sess-1", { draft: false });
+    expect(JSON.parse(String(init?.body))).toEqual({ message: "fix my records", draft: false, agent: "claude" });
+    expect(opener).toHaveBeenCalledWith("sess-1", { draft: false, agent: "claude" });
+  });
+
+  it("spawns a codex chat (auto-run, draft forced off) when the active agent is codex", async () => {
+    setActiveChatAgent("codex");
+    const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "cx-1", agent: "codex" } }) }));
+    const opener = vi.fn();
+    registerChatOpener(opener);
+
+    await startCollectionChat("summarize this", { draft: true }); // codex ignores draft — it auto-runs
+
+    expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({ message: "summarize this", draft: false, agent: "codex" });
+    expect(opener).toHaveBeenCalledWith("cx-1", { draft: false, agent: "codex" });
   });
 
   it("sends draft:true so the prompt is prefilled but not auto-sent", async () => {
@@ -36,8 +51,8 @@ describe("startCollectionChat", () => {
 
     await startCollectionChat("track my tasks", { hidden: false, draft: true });
 
-    expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({ message: "track my tasks", draft: true });
-    expect(opener).toHaveBeenCalledWith("sess-3", { draft: true }); // surfaced + flagged for the preparing hint
+    expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({ message: "track my tasks", draft: true, agent: "claude" });
+    expect(opener).toHaveBeenCalledWith("sess-3", { draft: true, agent: "claude" }); // surfaced + flagged for the preparing hint
   });
 
   it("does NOT select when hidden=true (stays in the sidebar)", async () => {

--- a/src/composables/useChatLauncher.spec.ts
+++ b/src/composables/useChatLauncher.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { registerChatOpener, startCollectionChat, setActiveChatAgent } from "./useChatLauncher";
+import { registerChatOpener, startCollectionChat, launchAgent } from "./useChatLauncher";
 
 function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; json: () => unknown }) {
   const fn = vi.fn((url: string, init?: RequestInit) => {
@@ -14,7 +14,7 @@ describe("startCollectionChat", () => {
   beforeEach(() => registerChatOpener(vi.fn()));
   afterEach(() => {
     vi.unstubAllGlobals();
-    setActiveChatAgent("claude"); // reset module state so the codex test doesn't leak
+    launchAgent.value = "claude"; // reset shared state so the codex test doesn't leak
   });
 
   it("spawns a chat seeded with the prompt and selects it (hidden=false)", async () => {
@@ -32,8 +32,8 @@ describe("startCollectionChat", () => {
     expect(opener).toHaveBeenCalledWith("sess-1", { draft: false, agent: "claude" });
   });
 
-  it("spawns a codex chat (auto-run, draft forced off) when the active agent is codex", async () => {
-    setActiveChatAgent("codex");
+  it("spawns a codex chat (auto-run, draft forced off) when the launch agent is codex", async () => {
+    launchAgent.value = "codex";
     const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "cx-1", agent: "codex" } }) }));
     const opener = vi.fn();
     registerChatOpener(opener);

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -12,16 +12,16 @@
 // submitting, so the user can review / edit before pressing Enter; without it the
 // prompt is auto-sent as claude's first turn (startChat / actions).
 
-type Agent = "claude" | "codex";
+import { ref } from "vue";
+
+export type Agent = "claude" | "codex";
 type OpenSessionFn = (sessionId: string, opts?: { draft?: boolean; agent?: Agent }) => void;
 let openSessionFn: OpenSessionFn | null = null;
 
-// The single view's current agent, so a collection action spawns the SAME agent (codex actions
-// run in codex). App.vue keeps this in sync.
-let activeAgent: Agent = "claude";
-export function setActiveChatAgent(agent: Agent): void {
-  activeAgent = agent;
-}
+// Which agent a collection action / chat spawns. Bound to the Claude/Codex toggle in the
+// collection browser (CollectionsBrowseOverlay); persists across opens. Reactive so the toggle
+// reflects it.
+export const launchAgent = ref<Agent>("claude");
 
 /** App.vue registers how to make a session visible (close the overlay + select it).
  *  `opts.draft` lets it show a "preparing draft…" hint while claude boots + the text
@@ -35,14 +35,15 @@ export function registerChatOpener(fn: OpenSessionFn): void {
 export async function startCollectionChat(prompt: string, opts: { hidden?: boolean; draft?: boolean } = {}): Promise<void> {
   const message = prompt.trim();
   if (!message) return;
+  const agent = launchAgent.value;
   // codex has no editable-draft path (it auto-runs the seed), so a draft only applies to claude.
-  const draft = activeAgent === "claude" && opts.draft === true;
+  const draft = agent === "claude" && opts.draft === true;
   let chatId: string | undefined;
   try {
     const res = await fetch("/api/plugin/spawnBackgroundChat", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ message, draft, agent: activeAgent }),
+      body: JSON.stringify({ message, draft, agent }),
     });
     if (!res.ok) {
       console.error(`[startChat] spawn failed: HTTP ${res.status}`);
@@ -55,5 +56,5 @@ export async function startCollectionChat(prompt: string, opts: { hidden?: boole
     return;
   }
   // hidden=false → bring the new terminal session into view for the user (as the right agent).
-  if (chatId && !opts.hidden) openSessionFn?.(chatId, { draft, agent: activeAgent });
+  if (chatId && !opts.hidden) openSessionFn?.(chatId, { draft, agent });
 }

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -12,8 +12,16 @@
 // submitting, so the user can review / edit before pressing Enter; without it the
 // prompt is auto-sent as claude's first turn (startChat / actions).
 
-type OpenSessionFn = (sessionId: string, opts?: { draft?: boolean }) => void;
+type Agent = "claude" | "codex";
+type OpenSessionFn = (sessionId: string, opts?: { draft?: boolean; agent?: Agent }) => void;
 let openSessionFn: OpenSessionFn | null = null;
+
+// The single view's current agent, so a collection action spawns the SAME agent (codex actions
+// run in codex). App.vue keeps this in sync.
+let activeAgent: Agent = "claude";
+export function setActiveChatAgent(agent: Agent): void {
+  activeAgent = agent;
+}
 
 /** App.vue registers how to make a session visible (close the overlay + select it).
  *  `opts.draft` lets it show a "preparing draft…" hint while claude boots + the text
@@ -27,12 +35,14 @@ export function registerChatOpener(fn: OpenSessionFn): void {
 export async function startCollectionChat(prompt: string, opts: { hidden?: boolean; draft?: boolean } = {}): Promise<void> {
   const message = prompt.trim();
   if (!message) return;
+  // codex has no editable-draft path (it auto-runs the seed), so a draft only applies to claude.
+  const draft = activeAgent === "claude" && opts.draft === true;
   let chatId: string | undefined;
   try {
     const res = await fetch("/api/plugin/spawnBackgroundChat", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ message, draft: opts.draft === true }),
+      body: JSON.stringify({ message, draft, agent: activeAgent }),
     });
     if (!res.ok) {
       console.error(`[startChat] spawn failed: HTTP ${res.status}`);
@@ -44,6 +54,6 @@ export async function startCollectionChat(prompt: string, opts: { hidden?: boole
     console.error("[startChat] spawn failed", err);
     return;
   }
-  // hidden=false → bring the new terminal session into view for the user.
-  if (chatId && !opts.hidden) openSessionFn?.(chatId, { draft: opts.draft === true });
+  // hidden=false → bring the new terminal session into view for the user (as the right agent).
+  if (chatId && !opts.hidden) openSessionFn?.(chatId, { draft, agent: activeAgent });
 }

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -12,16 +12,17 @@
 // submitting, so the user can review / edit before pressing Enter; without it the
 // prompt is auto-sent as claude's first turn (startChat / actions).
 
-import { ref } from "vue";
+import { ref, watch } from "vue";
 
 export type Agent = "claude" | "codex";
 type OpenSessionFn = (sessionId: string, opts?: { draft?: boolean; agent?: Agent }) => void;
 let openSessionFn: OpenSessionFn | null = null;
 
-// Which agent a collection action / chat spawns. Bound to the Claude/Codex toggle in the
-// collection browser (CollectionsBrowseOverlay); persists across opens. Reactive so the toggle
-// reflects it.
-export const launchAgent = ref<Agent>("claude");
+// Which agent a collection action / chat spawns. Bound to the Claude/Codex toggle in the collection
+// browser (CollectionsBrowseOverlay); persisted in localStorage so the choice survives reloads.
+const LAUNCH_AGENT_KEY = "mt-launch-agent";
+export const launchAgent = ref<Agent>(localStorage.getItem(LAUNCH_AGENT_KEY) === "codex" ? "codex" : "claude");
+watch(launchAgent, (agent) => localStorage.setItem(LAUNCH_AGENT_KEY, agent));
 
 /** App.vue registers how to make a session visible (close the overlay + select it).
  *  `opts.draft` lets it show a "preparing draft…" hint while claude boots + the text


### PR DESCRIPTION
## Summary

**Run collection actions / skills in Codex** from the single view — the collection browser gets an
explicit Claude/Codex launcher, and mulmoclaude skills work in Codex too. Additive; Claude unchanged.

### Design (final — supersedes the "run the active single-view agent" idea)

A collection action / chat launches whichever agent the user **explicitly picks** in the collection
browser's **"Launch with" [Claude|Codex]** toggle — a reactive `launchAgent`, **decoupled** from the
single view's `singleAgent` and **persisted in localStorage** (so the choice is remembered, not reset
to the terminal's state each open). This replaced the earlier implicit "follow the single-view agent"
routing at the author's request — an explicit, visible, remembered choice.

### What it does

- **Codex seed injection** (`spawnBackgroundChat` gains an `agent` field): a codex launch spawns a
  codex session and **auto-runs the seed by typing it into the input box** — NOT as a CLI arg. A
  collection-action prompt is multi-KB and a positional `[PROMPT]` overflowed tmux's new-session
  command-length limit ("command too long"); `attachCodexAutoRun` waits for codex's startup output to
  settle (no stable ready-marker — its placeholder rotates), then bracketed-pastes + Enter.
- **Skills in codex** (`codex-skills.ts`): codex has skills too (`~/.codex/skills`, same SKILL.md
  format) but no `/<slug>` command — they auto-load by description. So boot **mirrors
  `<ws>/.claude/skills/*` into `~/.codex/skills/*`** (marker-protected, never clobbering codex's own
  curated/system skills), and a codex chat seed `/<slug> <msg>` is **rewritten to `Use the "<slug>"
  skill. <msg>`** so codex loads the mirrored skill by name. `/art-exhibitions …` now works in codex.
- **GUI panel**: a codex launch attaches the GUI MCP (reuses L3), so it drives the panel like Claude.

### Commits

1. Codex seed injection + `spawnBackgroundChat` `agent` field.
2. Explicit **Claude/Codex "Launch with" toggle** in the collection browser (`launchAgent`).
3. Fix **"command too long"** — inject the seed via PTY input, not argv.
4. **Mirror workspace skills to `~/.codex/skills`** + rewrite `/<slug>` codex seeds.
5. **Persist** the launch-agent choice in localStorage.

## Items to Confirm / Review

- **No side effects on Claude**: `agent` absent / `"claude"` behaves exactly as before.
- **`launchAgent` is intentionally NOT synced to `singleAgent`** — the explicit-toggle design is the
  requested behavior (see the reply on the review thread). Not a routing-drift bug.
- **`~/.codex/skills` is written to** at boot (mirror). Marker-protected so codex's own skills are
  never overwritten; only mulmoterminal-mirrored dirs are re-synced. Verified: 20 workspace skills
  mirrored, codex's own (wrangler, .system, …) untouched.
- **Verified end-to-end**: a 4KB seed spawns codex without "command too long" (text absent from argv);
  the mirror + `/art-exhibitions` seed rewrite work; author confirmed it runs in-browser.

## User Prompt

> Run collection actions / skills in Codex from the single view. Let me choose Claude vs Codex
> explicitly when launching (not tied to the terminal's agent), and remember that choice. Make
> mulmoclaude skills (e.g. /art-exhibitions) work in Codex too. PR only for now.

## Verification

`yarn format` / `lint` (0 errors) / `typecheck` / `typecheck:server` / `build` / `test` — all green
(744 tests). New tests: `buildCodexArgs`, `codexifySkillSeed`, `syncCodexSkills`, `useChatLauncher`
codex spawn + localStorage persistence.

Refs #236, #254
