### PR TITLE
feat: tint launcher preset chips whose dir has a running session (#258)

### DIFF
--- a/plans/feat-258-highlight-active-dirs.md
+++ b/plans/feat-258-highlight-active-dirs.md
@@ -1,0 +1,25 @@
+# feat #258 — 起動時のディレクトリピッカーで使用中の dir を色で示す
+
+新規セッション起動時、既に他セルでセッションが動いている dir のプリセットチップを色付けし、
+二重起動や使用中の判別をしやすくする。
+
+## 実装
+
+既存の `openSessionIds`（`GridView` → `TerminalGrid` → `TerminalCell`）と同じ経路で
+**`openCwds`**（セッション有りセルの cwd 一覧）を配線し、`TerminalCell` の起動フォームで
+プリセットチップの path が `openCwds` に含まれれば色付け（●ドット + 青系 tint + ツールチップ）。
+
+- `GridView`: `openCwds = state.cells.filter(c => c.session).map(c => c.cwd)`（null 除外）
+- `TerminalGrid`: `openCwds: string[]` prop を中継
+- `TerminalCell`: `openCwds?: string[]` prop、`runningCwds` Set、チップに `is-running` クラス + `.cell-chip-dot`
+
+## 設計判断
+
+- マッチングは path の**完全一致**（symlink / 末尾スラッシュの正規化は follow-up）
+- 自セル（起動フォーム表示中はセッション未起動）は `openCwds`（session 有りセル由来）に入らず自然に除外
+- 色は情報色（青系）。「注意」ではなく「使用中」の意味
+
+## 非スコープ
+
+- path の canonicalize
+- 単一ビュー側の起動導線（本 UI はグリッドセルのランチャー）

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -101,6 +101,14 @@ const launchOpen = computed(() => cancelUid.value !== null);
 // live as background PTYs). A launcher uses this to warn before resuming a
 // session that's already open, since attaching would detach the other cell.
 const openSessionIds = computed(() => state.value.cells.map((c) => c.session).filter((s): s is string => s !== null));
+// Directories that already have a running session (a launched cell), so the launcher
+// can flag preset chips whose dir is in use elsewhere.
+const openCwds = computed(() =>
+  state.value.cells
+    .filter((c) => c.session)
+    .map((c) => c.cwd)
+    .filter((c): c is string => c !== null),
+);
 
 function onAddTerminal() {
   if (runningCount(state.value.cells) >= 81 && !launchOpen.value) return; // surfaced by the disabled button
@@ -181,6 +189,7 @@ function closeSettings() {
       :home="home"
       :reorderable="reorderable"
       :open-session-ids="openSessionIds"
+      :open-cwds="openCwds"
       @session="onSession"
       @agent="onAgent"
       @cwd="onCwd"

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -1243,7 +1243,10 @@ describe("TerminalCell", () => {
     const idle = chips.find((c) => c.text().includes("proj-b"));
     expect(running?.classes()).toContain("is-running");
     expect(running?.find(".cell-chip-dot").exists()).toBe(true);
+    // a11y: the running state is exposed in text, not just color/hover
+    expect(running?.find(".cell-chip-main").attributes("aria-label")).toContain("already running");
     expect(idle?.classes()).not.toContain("is-running");
     expect(idle?.find(".cell-chip-dot").exists()).toBe(false);
+    expect(idle?.find(".cell-chip-main").attributes("aria-label")).toBeUndefined();
   });
 });

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -65,6 +65,7 @@ function mountCell(
     home?: string | null;
     cancellable?: boolean;
     openSessionIds?: string[];
+    openCwds?: string[];
   } = {},
 ) {
   return mount(TerminalCell, {
@@ -78,6 +79,7 @@ function mountCell(
       home: opts.home ?? "/home/me",
       cancellable: opts.cancellable ?? false,
       openSessionIds: opts.openSessionIds ?? [],
+      openCwds: opts.openCwds ?? [],
     },
   });
 }
@@ -1226,5 +1228,22 @@ describe("TerminalCell", () => {
     expect(warn.text()).toContain("2 unpushed");
     expect(warn.text()).toContain("1 uncommitted");
     expect(w.find(".ccx-remove").text()).toContain("Discard");
+  });
+
+  it("tints a preset chip whose dir already has a running session elsewhere", () => {
+    const w = mountCell(null, {
+      presets: [
+        { label: "proj-a", path: "/home/me/a" },
+        { label: "proj-b", path: "/home/me/b" },
+      ],
+      openCwds: ["/home/me/a"],
+    });
+    const chips = w.findAll(".cell-chip");
+    const running = chips.find((c) => c.text().includes("proj-a"));
+    const idle = chips.find((c) => c.text().includes("proj-b"));
+    expect(running?.classes()).toContain("is-running");
+    expect(running?.find(".cell-chip-dot").exists()).toBe(true);
+    expect(idle?.classes()).not.toContain("is-running");
+    expect(idle?.find(".cell-chip-dot").exists()).toBe(false);
   });
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -961,6 +961,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             type="button"
             class="cell-chip-main"
             :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here in another terminal` : p.path"
+            :aria-label="isCwdRunning(p.path) ? `${p.label} — a session is already running here in another terminal` : undefined"
             @click="selectPreset(p)"
           >
             <span v-if="isCwdRunning(p.path)" class="cell-chip-dot" aria-hidden="true" />{{ p.label }}

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -46,6 +46,9 @@ const props = defineProps<{
   // Session ids open in other grid cells. Resuming one of them would detach that
   // cell, so the launcher flags such rows and confirms before opening.
   openSessionIds?: string[];
+  // Dirs with a running session in another cell, so the launcher can tint preset
+  // chips whose dir is already in use.
+  openCwds?: string[];
   // An added (not the sole entry) launcher: show a ✕ to dismiss it before launching.
   cancellable?: boolean;
   // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
@@ -424,6 +427,11 @@ watch([dirInput, () => props.defaultCwd], () => {
 // A session already live in another grid cell. Resuming it here detaches that
 // cell (the server supersedes the prior socket), so we warn before doing so.
 const sessionOpenElsewhere = (id: string): boolean => id !== sessionId.value && (props.openSessionIds ?? []).includes(id);
+
+// A preset dir that already has a running session in another cell — the launcher
+// tints its chip so the user can tell it's in use before double-launching there.
+const runningCwds = computed(() => new Set(props.openCwds ?? []));
+const isCwdRunning = (path: string): boolean => runningCwds.value.has(path);
 
 function resume(s: ResumableSession) {
   if (sessionOpenElsewhere(s.id) && !window.confirm(`"${s.title}" is already open in another terminal. Opening it here will detach that one. Continue?`))
@@ -948,8 +956,15 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         ✕
       </button>
       <div v-if="presets.length" class="cell-presets">
-        <span v-for="p in presets" :key="p.label + p.path" class="cell-chip">
-          <button type="button" class="cell-chip-main" :title="p.path" @click="selectPreset(p)">{{ p.label }}</button>
+        <span v-for="p in presets" :key="p.label + p.path" :class="['cell-chip', { 'is-running': isCwdRunning(p.path) }]">
+          <button
+            type="button"
+            class="cell-chip-main"
+            :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here in another terminal` : p.path"
+            @click="selectPreset(p)"
+          >
+            <span v-if="isCwdRunning(p.path)" class="cell-chip-dot" aria-hidden="true" />{{ p.label }}
+          </button>
           <button
             type="button"
             class="cell-chip-fill"
@@ -1360,6 +1375,20 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   overflow: hidden;
   background: var(--bg-elevated);
 }
+/* A dir already running a session in another cell: tint the chip + show a dot. */
+.cell-chip.is-running {
+  border-color: color-mix(in srgb, #3b82f6 55%, var(--border));
+  background: color-mix(in srgb, #3b82f6 14%, var(--bg-elevated));
+}
+.cell-chip-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 5px;
+  border-radius: 50%;
+  background: #3b82f6;
+  vertical-align: middle;
+}
 .cell-chip-main {
   border: none;
   background: transparent;
@@ -1368,6 +1397,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   font-family: system-ui, sans-serif;
   font-size: 12px;
   padding: 4px 10px;
+}
+.cell-chip.is-running .cell-chip-main {
+  color: var(--text);
 }
 .cell-chip-fill {
   display: inline-flex;

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -34,7 +34,7 @@ const cell = (uid: number, session: string | null = null, cwd: string | null = n
 const cmdCell = (uid: number, command: NonNullable<Cell["command"]>): Cell => ({ uid, session: null, cwd: null, command });
 const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null, reorderable = false) =>
   mount(TerminalGrid, {
-    props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], launchers: [], home: "/work", openSessionIds: [], reorderable },
+    props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], launchers: [], home: "/work", openSessionIds: [], openCwds: [], reorderable },
   });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -27,6 +27,7 @@ const props = defineProps<{
   // Manual sort mode: each cell shows ◀▶ to reorder.
   reorderable?: boolean;
   openSessionIds: string[];
+  openCwds: string[];
 }>();
 const emit = defineEmits<{
   (e: "session" | "cwd", uid: number, value: string): void;
@@ -94,6 +95,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           :launchers="launchers"
           :home="home"
           :open-session-ids="openSessionIds"
+          :open-cwds="openCwds"
           :cancellable="cell.uid === cancelUid"
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"


### PR DESCRIPTION
## Summary

グリッドのランチャー（ディレクトリピッカー）で、**既に他セルでセッションが動いている dir のプリセットチップを色付け**（青●ドット + tint + ツールチップ）。二重起動や使用中の判別がしやすくなる。

既存の `openSessionIds`（`GridView` → `TerminalGrid` → `TerminalCell`）と同じ経路で **`openCwds`**（セッション有りセルの cwd 一覧）を配線し、`TerminalCell` の起動フォームでチップの path が一致すれば `is-running` クラスを付与。

## Items to Confirm / Review

- **マッチング**は path の完全一致（symlink / 末尾スラッシュの正規化は follow-up）。実運用でズレが出るか。
- **色**は情報色（青系）＝「使用中」。「注意」色にすべきか。
- 自セル（起動フォーム表示中はセッション未起動）は `openCwds`（session 有りセル由来）に入らず自然に除外。
- 対象はグリッドセルのランチャー（`command.cwd` を持つコマンドセルではない）。

## Verification

- `TerminalCell.spec.ts`: 使用中 dir のチップに `.is-running` + `.cell-chip-dot`、非使用 dir には付かないことを検証
- `TerminalGrid.spec.ts`: 新 `openCwds` prop を配線
- `eslint server src` 0 errors、`typecheck` / `build` 通過、対象テスト 86 passed

## User Prompt

> 新しくセッションを起動するときに、すでに他でセッションが動いている dir は色でわかると嬉しい（起動時のディレクトリピッカーのスクリーンショット添付）

## Plan

`plans/feat-258-highlight-active-dirs.md`

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)