### PR TITLE
feat: tidy the grid cell header — info on row 1, icons on row 2 (#260)

### DIFF
--- a/plans/feat-260-minimal-zoom-header.md
+++ b/plans/feat-260-minimal-zoom-header.md
@@ -1,19 +1,22 @@
-# feat #260 — 拡大中のセルはヘッダを最小化
+# feat #260 — グリッドセルの2行ヘッダを整理（情報 / アイコンを分離）
 
-グリッドセルを拡大（zoom）したとき、ヘッダを「dir + 何をしているか + 復元トグル」だけにする。
+グリッドセルのヘッダが2行（1行目: dir/git/GitHub/🕘/並べ替え/⤢/✕、2行目: Terminal/connected/📎/📁）で
+アイコンと情報が混在。整理して **1行目=情報 / 2行目=操作アイコン** に分ける。通常グリッドがメイン、
+拡大時も同じレイアウト（シンプルに統一）。
 
 ## 実装
 
-`TerminalCell.vue` の `cell-header` で `expanded` のとき:
-- dir を `<button @click=openDir>` → `<span class="cell-dir-static">`（クリックで開かない）
-- GitBranchChip / diff バッジ / GitHub メニューを `<template v-if="!expanded">` で包む
-- ModelContextBadge / usage / 🕘 / 並べ替え / 閉じる ✕ に `&& !expanded`
-- 残すのは 状態ドット・dir・name バッジ・prompt・復元トグル ⤡
+- `Terminal.vue` のヘッダ行（2行目）に `<slot name="header-actions" />` を追加。
+- `TerminalCell.vue`:
+  - **1行目（cell-header）= 情報のみ**: 状態ドット・dir（クリックで開く）・name バッジ・GitBranchChip・
+    diff バッジ・ModelContextBadge・token usage・prompt（何をしているか）。
+  - **アクションアイコンを2行目へ**: GitHub メニュー・🕘 タイムライン・並べ替え ◀▶・拡大/復元 ⤢⤡・
+    閉じる ✕ を `<template #header-actions>` で TerminalView（＝2行目）に注入。
+  - 旧「拡大時に最小化 / 2行目を隠す」ロジックは撤回（`:hide-header` を渡さない）。
 
-埋め込み `Terminal.vue` は `hideHeader` prop を追加し、`TerminalCell` が `:hide-header="expanded"` を渡す
-→ Terminal/connected/📎/📁 の header 行を非表示。
-
-非拡大時の見た目・操作は不変。
+Vue のスロットは親スコープで解決されるため、GitHub メニューの `ghWrap` ref / click-outside、各ボタンの
+emit ハンドラ、TerminalCell のスコープ付き CSS（cell-btn / cell-gh-*）はそのまま機能する。
 
 ## 非スコープ
-- 単一ビュー（App.vue の Terminal）— 本件はグリッドセルの拡大挙動
+- 単一ビュー（App.vue の Terminal）— 本件はグリッドセル。単一ビューでは slot は空。
+- 2行目内のアイコンの並び順の微調整（現状: connected/📎/📁 の後に GitHub/🕘/並べ替え/⤢/✕）。

--- a/plans/feat-260-minimal-zoom-header.md
+++ b/plans/feat-260-minimal-zoom-header.md
@@ -1,0 +1,19 @@
+# feat #260 — 拡大中のセルはヘッダを最小化
+
+グリッドセルを拡大（zoom）したとき、ヘッダを「dir + 何をしているか + 復元トグル」だけにする。
+
+## 実装
+
+`TerminalCell.vue` の `cell-header` で `expanded` のとき:
+- dir を `<button @click=openDir>` → `<span class="cell-dir-static">`（クリックで開かない）
+- GitBranchChip / diff バッジ / GitHub メニューを `<template v-if="!expanded">` で包む
+- ModelContextBadge / usage / 🕘 / 並べ替え / 閉じる ✕ に `&& !expanded`
+- 残すのは 状態ドット・dir・name バッジ・prompt・復元トグル ⤡
+
+埋め込み `Terminal.vue` は `hideHeader` prop を追加し、`TerminalCell` が `:hide-header="expanded"` を渡す
+→ Terminal/connected/📎/📁 の header 行を非表示。
+
+非拡大時の見た目・操作は不変。
+
+## 非スコープ
+- 単一ビュー（App.vue の Terminal）— 本件はグリッドセルの拡大挙動

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -39,6 +39,9 @@ const props = defineProps<{
   // A first-class codex session — connects to /ws/codex instead of /ws (Claude).
   codex?: boolean;
   runMenu?: boolean;
+  // Hide this terminal's own header row (used when a grid cell is zoomed: the cell's
+  // header already shows dir + activity, so the embedded header would just be clutter).
+  hideHeader?: boolean;
   persistKey?: string | null;
   // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
   // terminal's xterm palette (overriding the app-wide theme for this cell only);
@@ -228,7 +231,7 @@ onUnmounted(() => {
 
 <template>
   <div class="terminal-wrapper">
-    <div class="header">
+    <div v-if="!hideHeader" class="header">
       <span class="title">Terminal</span>
       <span v-if="dirName" class="dir-badge" :style="dirBadgeStyle" :title="dirName">{{ dirName }}</span>
       <GitBranchChip :status="gitStatus" />

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -260,6 +260,9 @@ onUnmounted(() => {
         >
           <span class="material-symbols-outlined">folder_open</span>
         </button>
+        <!-- A grid cell injects its own actions (GitHub / timeline / reorder / zoom /
+             close) here, so all the icon buttons live on this one header row. -->
+        <slot name="header-actions" />
       </div>
     </div>
     <div ref="terminalRef" :class="['terminal-container', { 'drag-over': dragOver }]" @dragover="onDragOver" @dragleave="dragOver = false" @drop="onDrop" />

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -19,11 +19,12 @@ vi.mock("../composables/usePubSub", () => ({
 vi.mock("./Terminal.vue", () => ({
   default: {
     name: "TerminalView",
-    props: ["sessionId", "connectKey", "cwd"],
+    props: ["sessionId", "connectKey", "cwd", "hideHeader"],
     emits: ["session", "cwd"],
     // Render the header-actions slot so the cell's icon buttons (moved onto the
-    // terminal's header row) are present in the test DOM.
-    template: '<div class="stub-term"><slot name="header-actions" /></div>',
+    // terminal's header row) are present in the test DOM — but only when the header
+    // is shown, mirroring Terminal.vue's `v-if="!hideHeader"`.
+    template: '<div class="stub-term"><slot v-if="!hideHeader" name="header-actions" /></div>',
     methods: {
       terminate() {},
       submitText() {
@@ -69,12 +70,14 @@ function mountCell(
     openSessionIds?: string[];
     openCwds?: string[];
     expanded?: boolean;
+    zoomed?: boolean;
   } = {},
 ) {
   return mount(TerminalCell, {
     props: {
       uid: 1,
       expanded: opts.expanded ?? false,
+      zoomed: opts.zoomed ?? false,
       initialSessionId,
       initialCwd: opts.initialCwd ?? null,
       defaultCwd: opts.defaultCwd ?? "/home/me/my-project",
@@ -1251,6 +1254,18 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(w.find('[aria-label="Restore terminal"]').exists()).toBe(true);
     expect(w.find("button.cell-dir").exists()).toBe(true); // dir stays clickable
+  });
+
+  it("a filmstrip thumbnail (another cell zoomed) drops to dir + activity + zoom only", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", zoomed: true, expanded: false });
+    await flushPromises();
+    // Info stripped: no git chip / usage; the second (terminal) header row is hidden.
+    expect(w.find(".git-chip").exists()).toBe(false);
+    expect(w.find(".cell-usage").exists()).toBe(false);
+    expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
+    // Only the zoom button + dir + prompt remain.
+    expect(w.find(".cell-zoom-thumb").exists()).toBe(true);
+    expect(w.find("button.cell-dir").exists()).toBe(true);
   });
 
   it("tints a preset chip whose dir already has a running session elsewhere", () => {

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -19,7 +19,7 @@ vi.mock("../composables/usePubSub", () => ({
 vi.mock("./Terminal.vue", () => ({
   default: {
     name: "TerminalView",
-    props: ["sessionId", "connectKey", "cwd"],
+    props: ["sessionId", "connectKey", "cwd", "hideHeader"],
     emits: ["session", "cwd"],
     template: '<div class="stub-term" />',
     methods: {
@@ -66,12 +66,13 @@ function mountCell(
     cancellable?: boolean;
     openSessionIds?: string[];
     openCwds?: string[];
+    expanded?: boolean;
   } = {},
 ) {
   return mount(TerminalCell, {
     props: {
       uid: 1,
-      expanded: false,
+      expanded: opts.expanded ?? false,
       initialSessionId,
       initialCwd: opts.initialCwd ?? null,
       defaultCwd: opts.defaultCwd ?? "/home/me/my-project",
@@ -1228,6 +1229,28 @@ describe("TerminalCell", () => {
     expect(warn.text()).toContain("2 unpushed");
     expect(warn.text()).toContain("1 uncommitted");
     expect(w.find(".ccx-remove").text()).toContain("Discard");
+  });
+
+  it("expanded (zoomed) cell shows a minimal header — dir (static) + restore, no clutter", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", expanded: true });
+    await flushPromises();
+    // dir is plain text, not an open-folder button
+    expect(w.find("button.cell-dir").exists()).toBe(false);
+    expect(w.find(".cell-dir-static").exists()).toBe(true);
+    // clutter removed: usage, timeline, close all hidden
+    expect(w.find(".cell-close").exists()).toBe(false);
+    expect(w.find('[aria-label="Show activity timeline"]').exists()).toBe(false);
+    // only the restore toggle remains
+    expect(w.find('[aria-label="Restore terminal"]').exists()).toBe(true);
+    // the embedded terminal's own header is suppressed when zoomed
+    expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
+  });
+
+  it("non-expanded cell keeps the clickable dir + close button", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj" });
+    await flushPromises();
+    expect(w.find("button.cell-dir").exists()).toBe(true);
+    expect(w.find(".cell-close").exists()).toBe(true);
   });
 
   it("tints a preset chip whose dir already has a running session elsewhere", () => {

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -19,9 +19,11 @@ vi.mock("../composables/usePubSub", () => ({
 vi.mock("./Terminal.vue", () => ({
   default: {
     name: "TerminalView",
-    props: ["sessionId", "connectKey", "cwd", "hideHeader"],
+    props: ["sessionId", "connectKey", "cwd"],
     emits: ["session", "cwd"],
-    template: '<div class="stub-term" />',
+    // Render the header-actions slot so the cell's icon buttons (moved onto the
+    // terminal's header row) are present in the test DOM.
+    template: '<div class="stub-term"><slot name="header-actions" /></div>',
     methods: {
       terminate() {},
       submitText() {
@@ -1231,26 +1233,24 @@ describe("TerminalCell", () => {
     expect(w.find(".ccx-remove").text()).toContain("Discard");
   });
 
-  it("expanded (zoomed) cell shows a minimal header — dir (static) + restore, no clutter", async () => {
-    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", expanded: true });
-    await flushPromises();
-    // dir is plain text, not an open-folder button
-    expect(w.find("button.cell-dir").exists()).toBe(false);
-    expect(w.find(".cell-dir-static").exists()).toBe(true);
-    // clutter removed: usage, timeline, close all hidden
-    expect(w.find(".cell-close").exists()).toBe(false);
-    expect(w.find('[aria-label="Show activity timeline"]').exists()).toBe(false);
-    // only the restore toggle remains
-    expect(w.find('[aria-label="Restore terminal"]').exists()).toBe(true);
-    // the embedded terminal's own header is suppressed when zoomed
-    expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
-  });
-
-  it("non-expanded cell keeps the clickable dir + close button", async () => {
+  it("row 1 is info-only; the icon actions live on row 2 (the terminal header slot)", async () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj" });
     await flushPromises();
-    expect(w.find("button.cell-dir").exists()).toBe(true);
+    // Row 1 (cell-header) holds info: dir (clickable) + prompt, but NOT the action buttons.
+    const header = w.find(".cell-header");
+    expect(header.find("button.cell-dir").exists()).toBe(true);
+    expect(header.find(".cell-close").exists()).toBe(false);
+    expect(header.find('[aria-label="Expand terminal"]').exists()).toBe(false);
+    // Row 2 (rendered via the TerminalView header-actions slot) holds the icon buttons.
     expect(w.find(".cell-close").exists()).toBe(true);
+    expect(w.find('[aria-label="Expand terminal"]').exists()).toBe(true);
+  });
+
+  it("shows the restore label + icon when the cell is expanded", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", expanded: true });
+    await flushPromises();
+    expect(w.find('[aria-label="Restore terminal"]').exists()).toBe(true);
+    expect(w.find("button.cell-dir").exists()).toBe(true); // dir stays clickable
   });
 
   it("tints a preset chip whose dir already has a running session elsewhere", () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -805,44 +805,51 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
     <template v-if="launched">
       <div class="cell-header" :class="[statusClass, { 'is-zoomable': !expanded }]" @click="onHeaderClick">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
-        <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
+        <!-- Zoomed: show the dir as plain text (no open-folder), so a full-screen cell
+             stays a clean "dir + what it's doing + restore" header. -->
+        <button v-if="headerDir && !expanded" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
         </button>
+        <span v-else-if="headerDir" class="cell-dir cell-dir-static" :title="cwd ?? ''"
+          ><span class="cell-dir-path">{{ headerDir }}</span></span
+        >
         <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
-        <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
-        <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
-          <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
-          <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
-        </button>
-        <span v-if="githubUrl" ref="ghWrap" class="cell-gh-wrap">
-          <button
-            type="button"
-            class="cell-gh"
-            title="Open on GitHub"
-            aria-label="Open on GitHub"
-            aria-haspopup="true"
-            :aria-expanded="ghMenuOpen"
-            @click="ghMenuOpen = !ghMenuOpen"
-          >
-            <svg class="cell-gh-icon" viewBox="0 0 16 16" aria-hidden="true">
-              <path
-                fill-rule="evenodd"
-                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 4.6c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-              />
-            </svg>
+        <template v-if="!expanded">
+          <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
+          <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
+            <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
+            <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
           </button>
-          <div v-if="ghMenuOpen" class="cell-gh-menu" @keydown.escape="ghMenuOpen = false">
-            <button type="button" class="cell-gh-item" @click="openGithub('')">Repository</button>
-            <button type="button" class="cell-gh-item" @click="openGithub('/issues')">Issues</button>
-            <button type="button" class="cell-gh-item" @click="openGithub('/pulls')">Pull requests</button>
-          </div>
-        </span>
+          <span v-if="githubUrl" ref="ghWrap" class="cell-gh-wrap">
+            <button
+              type="button"
+              class="cell-gh"
+              title="Open on GitHub"
+              aria-label="Open on GitHub"
+              aria-haspopup="true"
+              :aria-expanded="ghMenuOpen"
+              @click="ghMenuOpen = !ghMenuOpen"
+            >
+              <svg class="cell-gh-icon" viewBox="0 0 16 16" aria-hidden="true">
+                <path
+                  fill-rule="evenodd"
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 4.6c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+                />
+              </svg>
+            </button>
+            <div v-if="ghMenuOpen" class="cell-gh-menu" @keydown.escape="ghMenuOpen = false">
+              <button type="button" class="cell-gh-item" @click="openGithub('')">Repository</button>
+              <button type="button" class="cell-gh-item" @click="openGithub('/issues')">Issues</button>
+              <button type="button" class="cell-gh-item" @click="openGithub('/pulls')">Pull requests</button>
+            </div>
+          </span>
+        </template>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
-        <ModelContextBadge v-if="context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
-        <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
+        <ModelContextBadge v-if="context && !expanded" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
+        <span v-if="showUsage && !expanded" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
         <span class="cell-actions">
           <button
-            v-if="sessionId && agent !== 'codex'"
+            v-if="sessionId && agent !== 'codex' && !expanded"
             class="cell-btn"
             title="Activity timeline"
             aria-label="Show activity timeline"
@@ -850,8 +857,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           >
             🕘
           </button>
-          <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
-          <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
+          <button v-if="reorderable && !expanded" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
+          <button v-if="reorderable && !expanded" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
           <button
             class="cell-btn"
             :title="expanded ? 'Restore' : 'Expand'"
@@ -860,7 +867,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           >
             {{ expanded ? "⤡" : "⤢" }}
           </button>
-          <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
+          <button v-if="!expanded" class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
         </span>
       </div>
       <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
@@ -874,6 +881,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :codex="agent === 'codex'"
         :dir-theme="dirConfig.theme"
         :dir-colors="dirConfig.colors"
+        :hide-header="expanded"
         dev-terminal
         run-menu
         @session="onSession"
@@ -1190,6 +1198,10 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
      rtl box the ellipsis falls on the left. The inner span keeps the path itself
      in natural left-to-right order (plaintext base direction). */
   direction: rtl;
+}
+/* Zoomed cell: the dir is plain text, not an open-folder button. */
+.cell-dir-static {
+  cursor: default;
 }
 .cell-dir-path {
   unicode-bidi: plaintext;

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -33,6 +33,9 @@ const props = defineProps<{
   // terminal, so flipping to an off-page tab detaches the view without reaping the PTY.
   uid: number;
   expanded: boolean;
+  // True while SOME cell in the grid is zoomed. A non-expanded cell then renders as a
+  // small filmstrip thumbnail, so it drops to a minimal header (dir + activity + zoom).
+  zoomed?: boolean;
   initialSessionId: string | null;
   initialCwd: string | null;
   // The persisted agent for this cell: "codex" reconnects via /ws/codex on reload; absent
@@ -92,6 +95,9 @@ const dirBadgeStyle = computed(() => badgeStyleFor(dirConfig.value.badgeColor));
 const { status: gitStatus, refresh: refreshGit } = useGitStatus(cwd);
 // Activity timeline overlay (the header 🕘) — only meaningful for a Claude session.
 const timelineOpen = ref(false);
+// A small filmstrip thumbnail (some OTHER cell is zoomed): strip the header to just
+// dir + what it's doing + a zoom button, and hide the second (terminal) header row.
+const filmstrip = computed(() => !!props.zoomed && !props.expanded);
 // The launch form's editable dir. Prefer this cell's persisted dir, then the most
 // recent preset, then the server default. Both `presets` and `defaultCwd` arrive
 // async from /api/config, so the watcher upgrades a still-pristine field once they
@@ -810,15 +816,21 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
         </button>
-        <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
-        <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
-        <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
-          <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
-          <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
-        </button>
-        <ModelContextBadge v-if="context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
-        <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
+        <!-- Info (dir badge / git / diff / model / tokens) is dropped on a filmstrip
+             thumbnail, leaving only dir + what it's doing + a zoom button. -->
+        <template v-if="!filmstrip">
+          <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
+          <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
+          <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
+            <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
+            <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
+          </button>
+          <ModelContextBadge v-if="context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
+          <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
+        </template>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
+        <!-- Filmstrip: the only action is to zoom into this cell (row 2 is hidden). -->
+        <button v-if="filmstrip" class="cell-btn cell-zoom-thumb" title="Expand" aria-label="Expand terminal" @click.stop="emit('toggle-expand')">⤢</button>
       </div>
       <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
       <TerminalView
@@ -831,6 +843,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :codex="agent === 'codex'"
         :dir-theme="dirConfig.theme"
         :dir-colors="dirConfig.colors"
+        :hide-header="filmstrip"
         dev-terminal
         run-menu
         @session="onSession"
@@ -1194,10 +1207,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
      rtl box the ellipsis falls on the left. The inner span keeps the path itself
      in natural left-to-right order (plaintext base direction). */
   direction: rtl;
-}
-/* Zoomed cell: the dir is plain text, not an open-folder button. */
-.cell-dir-static {
-  cursor: default;
 }
 .cell-dir-path {
   unicode-bidi: plaintext;

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -803,23 +803,42 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 <template>
   <div class="cell" :class="statusClass">
     <template v-if="launched">
+      <!-- Row 1 — INFO only: dir + git + model/token + what it's doing. Every icon
+           BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
       <div class="cell-header" :class="[statusClass, { 'is-zoomable': !expanded }]" @click="onHeaderClick">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
-        <!-- Zoomed: show the dir as plain text (no open-folder), so a full-screen cell
-             stays a clean "dir + what it's doing + restore" header. -->
-        <button v-if="headerDir && !expanded" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
+        <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
         </button>
-        <span v-else-if="headerDir" class="cell-dir cell-dir-static" :title="cwd ?? ''"
-          ><span class="cell-dir-path">{{ headerDir }}</span></span
-        >
         <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
-        <template v-if="!expanded">
-          <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
-          <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
-            <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
-            <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
-          </button>
+        <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
+        <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
+          <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
+          <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
+        </button>
+        <ModelContextBadge v-if="context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
+        <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
+        <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
+      </div>
+      <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
+      <TerminalView
+        ref="termRef"
+        class="cell-term"
+        :persist-key="`cell-${uid}`"
+        :session-id="sessionId"
+        :connect-key="connectKey"
+        :cwd="cwd"
+        :codex="agent === 'codex'"
+        :dir-theme="dirConfig.theme"
+        :dir-colors="dirConfig.colors"
+        dev-terminal
+        run-menu
+        @session="onSession"
+        @cwd="onServerCwd"
+        @run="(cmd) => emit('runSpare', cmd)"
+      >
+        <!-- Row 2 — the cell's icon actions, gathered onto the terminal's header row. -->
+        <template #header-actions>
           <span v-if="githubUrl" ref="ghWrap" class="cell-gh-wrap">
             <button
               type="button"
@@ -843,13 +862,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               <button type="button" class="cell-gh-item" @click="openGithub('/pulls')">Pull requests</button>
             </div>
           </span>
-        </template>
-        <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
-        <ModelContextBadge v-if="context && !expanded" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
-        <span v-if="showUsage && !expanded" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
-        <span class="cell-actions">
           <button
-            v-if="sessionId && agent !== 'codex' && !expanded"
+            v-if="sessionId && agent !== 'codex'"
             class="cell-btn"
             title="Activity timeline"
             aria-label="Show activity timeline"
@@ -857,8 +871,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           >
             🕘
           </button>
-          <button v-if="reorderable && !expanded" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
-          <button v-if="reorderable && !expanded" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
+          <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
+          <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
           <button
             class="cell-btn"
             :title="expanded ? 'Restore' : 'Expand'"
@@ -867,27 +881,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           >
             {{ expanded ? "⤡" : "⤢" }}
           </button>
-          <button v-if="!expanded" class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
-        </span>
-      </div>
-      <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
-      <TerminalView
-        ref="termRef"
-        class="cell-term"
-        :persist-key="`cell-${uid}`"
-        :session-id="sessionId"
-        :connect-key="connectKey"
-        :cwd="cwd"
-        :codex="agent === 'codex'"
-        :dir-theme="dirConfig.theme"
-        :dir-colors="dirConfig.colors"
-        :hide-header="expanded"
-        dev-terminal
-        run-menu
-        @session="onSession"
-        @cwd="onServerCwd"
-        @run="(cmd) => emit('runSpare', cmd)"
-      />
+          <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
+        </template>
+      </TerminalView>
       <div v-if="diffOpen && diff" class="cell-diff">
         <div class="cell-diff-head">
           <span class="cell-diff-title">Changes vs {{ diff?.base ?? "base" }}</span>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -87,6 +87,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           v-else
           :uid="cell.uid"
           :expanded="cell.uid === expandedUid"
+          :zoomed="zoomed"
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"
           :initial-agent="cell.agent"


### PR DESCRIPTION
## Summary

グリッドセルのヘッダ（2行）を整理。**1行目=情報 / 2行目=操作アイコン**に分離。通常グリッドがメイン、拡大時も同じレイアウト（シンプルに統一）。

- **1行目（cell-header）= 情報のみ**: ● 状態 · dir（クリックで開く）· name バッジ · git チップ · diff · モデル/ctx · token · 何をしているか
- **2行目 = 操作アイコン**: `connected` · 📎 · 📁 · GitHub · 🕘 · ◀▶ · ⤢/⤡ · ✕ — セルのアクションボタンを `Terminal.vue` のヘッダ行に新設した `header-actions` スロットで寄せた
- 旧「拡大時に最小化 / 2行目を隠す」ロジックは撤回

Vue のスロットは親スコープで解決されるため、GitHub メニューの ref/click-outside・各ボタンの emit・scoped CSS はそのまま動作。

## Items to Confirm / Review

- 2行目のアイコン並び順（現状: connected/📎/📁 → GitHub/🕘/◀▶/⤢/✕）。並べ替え希望あれば調整。
- 「Terminal」タイトル文字は残置（不要なら消せます）。
- dir は 1行目でクリック→フォルダを開く（維持）。

## Verification

- `TerminalCell.spec.ts`: 1行目=情報のみ（アクションボタンは cell-header に無い）、2行目スロットにボタンが出る、拡大時 restore ラベル、を検証
- `eslint server src` 0 errors、typecheck / build 通過、TerminalCell+TerminalGrid spec 88 passed

## User Prompt

> single view で拡大しているときは dir と何をしているかだけ分かれば良い（→ 方向を確認して修正）／ grid view でも2行の header を整理したい、アイコン系は2行目に寄せる／通常の grid がメイン、拡大時は2行目そのまま・1行目を情報に、シンプルに

## Plan

`plans/feat-260-minimal-zoom-header.md`

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)