### PR TITLE
fix: insert a newline on Shift+Enter in the terminal (#263)

### DIFF
--- a/plans/fix-263-shift-enter-newline.md
+++ b/plans/fix-263-shift-enter-newline.md
@@ -1,0 +1,18 @@
+# fix #263 — ターミナルで Shift+Enter による改行
+
+## 原因
+`useTerminalConnections.ts` の `term.onData` は xterm の生成バイト列をそのまま PTY に送る。
+xterm は Enter も Shift+Enter も `\r` を送るため区別できず、どちらも送信になる。
+
+## 修正
+`term.attachCustomKeyEventHandler` で Shift+Enter（keydown）を横取りし、改行シーケンスを
+PTY に直接送って xterm 既定の `\r` を抑止（`return false`）。判定は純関数
+`shiftEnterNewline(e)` に切り出してテスト。
+
+## 送るシーケンス（要ライブ検証）
+第一候補 `NEWLINE_SEQUENCE = "\x1b\r"`（Meta/Alt+Enter ＝ claude の改行）。
+実 claude で改行が入らなければ `\n` / CSI-u `\x1b[13;2u` を試す（定数1つの差し替え）。
+
+## 非スコープ
+- Option/Alt+Enter のマップ（必要なら追加）
+- kitty/modifyOtherKeys の有効化

--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// Capture the key handler ensure() registers, so a test can drive it and assert the
+// real wiring (send + suppress-default) — hoisted so the mock factory can write to it.
+// Defaults to a no-op that returns true, so a test that forgot to attach would see the
+// pass-through behavior (and thus fail the Shift+Enter assertion) rather than crash.
+const mockKeyState: { handler: (e: unknown) => boolean } = vi.hoisted(() => ({ handler: () => true }));
+
 // Mock xterm + addons so the manager runs headless (no real DOM terminal / canvas).
 // Factories are hoisted above imports, so the fakes are declared INSIDE them.
 vi.mock("@xterm/xterm", () => ({
@@ -10,7 +16,9 @@ vi.mock("@xterm/xterm", () => ({
     loadAddon() {}
     open() {}
     onData() {}
-    attachCustomKeyEventHandler() {}
+    attachCustomKeyEventHandler(fn: (e: unknown) => boolean) {
+      mockKeyState.handler = fn;
+    }
     write() {}
     reset() {}
     focus() {}
@@ -99,6 +107,24 @@ describe("useTerminalConnections — detached-slot state replay", () => {
     conn.attach("cell-race", target(null), second, el2);
     expect(second.onSession).toHaveBeenCalledWith("sess-123");
     expect(second.onCwd).toHaveBeenCalledWith("/resolved");
+  });
+
+  it("wires Shift+Enter through ensure(): registers a handler that sends \\x1b\\r on the ws and cancels the default", () => {
+    mockKeyState.handler = () => true; // reset (the mock persists across tests)
+    conn.attach("cell-key", target(null), { onSession: vi.fn(), onCwd: vi.fn() }, document.createElement("div"));
+    const ws = FakeWebSocket.instances.at(-1);
+    if (!ws) throw new Error("no socket created");
+    ws.onopen?.(); // open so send() passes the readyState guard
+
+    const shiftEnter = { type: "keydown", key: "Enter", shiftKey: true, altKey: false, ctrlKey: false, metaKey: false };
+    expect(mockKeyState.handler(shiftEnter)).toBe(false); // false => xterm won't also emit \r
+    expect(ws.sent).toContain(JSON.stringify({ type: "input", data: conn.NEWLINE_SEQUENCE }));
+
+    // A plain Enter is left to xterm (returns true, sends nothing extra).
+    ws.sent.length = 0;
+    expect(mockKeyState.handler({ type: "keydown", key: "Enter", shiftKey: false, altKey: false, ctrlKey: false, metaKey: false })).toBe(true);
+    expect(ws.sent).toHaveLength(0);
+    conn.release("cell-key");
   });
 
   it("does not replay a session id before the server has assigned one", () => {

--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -10,6 +10,7 @@ vi.mock("@xterm/xterm", () => ({
     loadAddon() {}
     open() {}
     onData() {}
+    attachCustomKeyEventHandler() {}
     write() {}
     reset() {}
     focus() {}
@@ -125,5 +126,36 @@ describe("isSystemClipboard", () => {
 
   it("ignores primary / select / cut-buffer selections", () => {
     for (const sel of ["p", "s", "0", "7"]) expect(conn.isSystemClipboard(sel)).toBe(false);
+  });
+});
+
+describe("shiftEnterNewline", () => {
+  const ev = (over: Partial<KeyboardEvent>): Pick<KeyboardEvent, "type" | "key" | "shiftKey" | "altKey" | "ctrlKey" | "metaKey"> => ({
+    type: "keydown",
+    key: "Enter",
+    shiftKey: false,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    ...over,
+  });
+
+  it("returns the newline sequence for a Shift+Enter keydown", () => {
+    expect(conn.shiftEnterNewline(ev({ shiftKey: true }))).toBe(conn.NEWLINE_SEQUENCE);
+  });
+
+  it("returns null for a plain Enter (so it still submits)", () => {
+    expect(conn.shiftEnterNewline(ev({}))).toBeNull();
+  });
+
+  it("returns null on keyup and for non-Enter keys", () => {
+    expect(conn.shiftEnterNewline(ev({ shiftKey: true, type: "keyup" }))).toBeNull();
+    expect(conn.shiftEnterNewline(ev({ shiftKey: true, key: "a" }))).toBeNull();
+  });
+
+  it("returns null when another modifier is also held (Ctrl/Alt/Meta+Shift+Enter)", () => {
+    for (const mod of ["altKey", "ctrlKey", "metaKey"] as const) {
+      expect(conn.shiftEnterNewline(ev({ shiftKey: true, [mod]: true }))).toBeNull();
+    }
   });
 });

--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -158,4 +158,18 @@ describe("shiftEnterNewline", () => {
       expect(conn.shiftEnterNewline(ev({ shiftKey: true, [mod]: true }))).toBeNull();
     }
   });
+
+  it("makeShiftEnterHandler sends the newline and cancels the default on Shift+Enter", () => {
+    const send = vi.fn();
+    const handler = conn.makeShiftEnterHandler(send);
+    expect(handler(ev({ shiftKey: true }))).toBe(false); // false => xterm won't also send \r
+    expect(send).toHaveBeenCalledWith(conn.NEWLINE_SEQUENCE);
+  });
+
+  it("makeShiftEnterHandler passes plain Enter through (returns true, sends nothing)", () => {
+    const send = vi.fn();
+    const handler = conn.makeShiftEnterHandler(send);
+    expect(handler(ev({}))).toBe(true);
+    expect(send).not.toHaveBeenCalled();
+  });
 });

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -133,6 +133,10 @@ function ensure(key: string, target: ConnTarget): Conn {
     cursorBlink: true,
     fontSize: 14,
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
+    // Treat macOS Option as Meta so Claude's Alt bindings reach the PTY: Alt+Enter
+    // (newline), Alt+B/F (word nav), Alt+Backspace (delete word). Without this, Option
+    // types accented characters instead — same class of bug as Shift+Enter above.
+    macOptionIsMeta: true,
   });
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -34,6 +34,17 @@ export function shiftEnterNewline(e: ModifierKeyEvent): string | null {
   return isShiftEnter ? NEWLINE_SEQUENCE : null;
 }
 
+// The xterm custom key handler: on Shift+Enter, `send` the newline and return false
+// (cancel xterm's default \r); otherwise return true so xterm handles the key normally.
+export function makeShiftEnterHandler(send: (data: string) => void): (e: ModifierKeyEvent) => boolean {
+  return (e) => {
+    const newline = shiftEnterNewline(e);
+    if (newline === null) return true;
+    send(newline);
+    return false;
+  };
+}
+
 // What a slot connects to. Mirrors the relevant Terminal.vue props; a connectKey
 // change (session switch / relaunch) hands a fresh target to retarget().
 export interface ConnTarget {
@@ -162,12 +173,11 @@ function ensure(key: string, target: ConnTarget): Conn {
   });
   // Shift+Enter → newline (not submit): send the sequence ourselves and suppress the
   // \r xterm would otherwise emit for it (returning false cancels the default).
-  term.attachCustomKeyEventHandler((e) => {
-    const newline = shiftEnterNewline(e);
-    if (newline === null) return true;
-    if (c.ws && c.ws.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "input", data: newline }));
-    return false;
-  });
+  term.attachCustomKeyEventHandler(
+    makeShiftEnterHandler((data) => {
+      if (c.ws && c.ws.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "input", data }));
+    }),
+  );
   return c;
 }
 

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -133,10 +133,6 @@ function ensure(key: string, target: ConnTarget): Conn {
     cursorBlink: true,
     fontSize: 14,
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
-    // Treat macOS Option as Meta so Claude's Alt bindings reach the PTY: Alt+Enter
-    // (newline), Alt+B/F (word nav), Alt+Backspace (delete word). Without this, Option
-    // types accented characters instead — same class of bug as Shift+Enter above.
-    macOptionIsMeta: true,
   });
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -24,6 +24,16 @@ import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } 
 
 export type ConnStatus = "connecting" | "connected" | "disconnected";
 
+// Shift+Enter must insert a NEWLINE in the prompt, not submit. xterm sends "\r" for
+// both Enter and Shift+Enter, so the PTY can't tell them apart — we intercept the key
+// and send the sequence Claude Code reads as a newline (Meta/Alt+Enter = ESC + CR).
+export const NEWLINE_SEQUENCE = "\x1b\r";
+type ModifierKeyEvent = Pick<KeyboardEvent, "type" | "key" | "shiftKey" | "altKey" | "ctrlKey" | "metaKey">;
+export function shiftEnterNewline(e: ModifierKeyEvent): string | null {
+  const isShiftEnter = e.type === "keydown" && e.key === "Enter" && e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey;
+  return isShiftEnter ? NEWLINE_SEQUENCE : null;
+}
+
 // What a slot connects to. Mirrors the relevant Terminal.vue props; a connectKey
 // change (session switch / relaunch) hands a fresh target to retarget().
 export interface ConnTarget {
@@ -149,6 +159,14 @@ function ensure(key: string, target: ConnTarget): Conn {
     if (c.ws && c.ws.readyState === WebSocket.OPEN) {
       c.ws.send(JSON.stringify({ type: "input", data }));
     }
+  });
+  // Shift+Enter → newline (not submit): send the sequence ourselves and suppress the
+  // \r xterm would otherwise emit for it (returning false cancels the default).
+  term.attachCustomKeyEventHandler((e) => {
+    const newline = shiftEnterNewline(e);
+    if (newline === null) return true;
+    if (c.ws && c.ws.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "input", data: newline }));
+    return false;
   });
   return c;
 }


### PR DESCRIPTION
## Summary

ターミナルで **Shift+Enter が改行を入れず送信になってしまう**問題の修正。原因は `useTerminalConnections.ts` の `term.onData` が xterm の生成バイト列をそのまま送るが、xterm は **Enter も Shift+Enter も `\r`** を送るため PTY 側で区別できないこと。

`term.attachCustomKeyEventHandler` で Shift+Enter を横取りし、**claude が改行と解釈するシーケンス（`\x1b\r` ＝ Meta/Alt+Enter）** を送って xterm 既定の `\r` を抑止。判定は純関数 `shiftEnterNewline` に切り出してテスト。

## ⚠️ Items to Confirm / Review（要ライブ検証）

- **送るシーケンスは要実機確認**。第一候補 `\x1b\r`（Meta/Alt+Enter）にしていますが、**実 claude で改行が入るか**テストしてください。入らなければ `NEWLINE_SEQUENCE` 定数を `\n` または CSI-u `\x1b[13;2u` に差し替えます（1行）。
- Option/Alt+Enter のマップは非スコープ（必要なら追加）。
- 単一ビュー・グリッド両方に自動適用（同じ `useTerminalConnections` 経由）。

## Verification

- `shiftEnterNewline` の単体テスト（Shift+Enter keydown → シーケンス、plain Enter → null で送信維持、keyup/他キー → null、他modifier併用 → null）
- xterm モックに `attachCustomKeyEventHandler` を追加（既存テスト維持）
- `eslint server src` 0 errors、typecheck / build 通過、spec 通過

## User Prompt

> ターミナルで shift enter などで改行入れられないね

## Plan

`plans/fix-263-shift-enter-newline.md`

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)