### PR TITLE
fix: treat macOS Option as Meta so Claude's Alt bindings work (#265)

### DIFF
--- a/plans/fix-265-option-as-meta.md
+++ b/plans/fix-265-option-as-meta.md
@@ -1,0 +1,15 @@
+# fix #265 — macOS Option を Meta として扱う
+
+## 決定
+ユーザー判断「é（Option アクセント入力）は不要」→ `macOptionIsMeta: true` を既定 on。
+
+## 修正
+`useTerminalConnections.ts` の `new Terminal({...})` に `macOptionIsMeta: true` を追加。
+これで Option/Alt が Meta（ESC 前置）として PTY に届き、Claude の Alt バインドが有効化:
+Alt+Enter（改行）/ Alt+B・F（単語移動）/ Alt+Backspace（単語削除）。
+
+## トレードオフ
+Option+文字のデッドキー（é 等）入力は無効化（コーディング/claude ターミナルでは不要）。
+
+## テスト
+mock で `new Terminal` に渡る options を捕捉し、`macOptionIsMeta === true` を検証。

--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -5,6 +5,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // Defaults to a no-op that returns true, so a test that forgot to attach would see the
 // pass-through behavior (and thus fail the Shift+Enter assertion) rather than crash.
 const mockKeyState: { handler: (e: unknown) => boolean } = vi.hoisted(() => ({ handler: () => true }));
+// The options ensure() passes to `new Terminal({...})`, captured for assertions.
+const mockTermState: { options: Record<string, unknown> } = vi.hoisted(() => ({ options: {} }));
 
 // Mock xterm + addons so the manager runs headless (no real DOM terminal / canvas).
 // Factories are hoisted above imports, so the fakes are declared INSIDE them.
@@ -13,6 +15,9 @@ vi.mock("@xterm/xterm", () => ({
     options: Record<string, unknown> = {};
     cols = 80;
     rows = 24;
+    constructor(opts: Record<string, unknown>) {
+      mockTermState.options = opts;
+    }
     loadAddon() {}
     open() {}
     onData() {}
@@ -125,6 +130,13 @@ describe("useTerminalConnections — detached-slot state replay", () => {
     expect(mockKeyState.handler({ type: "keydown", key: "Enter", shiftKey: false, altKey: false, ctrlKey: false, metaKey: false })).toBe(true);
     expect(ws.sent).toHaveLength(0);
     conn.release("cell-key");
+  });
+
+  it("configures xterm with macOptionIsMeta so macOS Option acts as Meta (Alt bindings reach the PTY)", () => {
+    mockTermState.options = {};
+    conn.attach("cell-opt", target(null), { onSession: vi.fn(), onCwd: vi.fn() }, document.createElement("div"));
+    expect(mockTermState.options.macOptionIsMeta).toBe(true);
+    conn.release("cell-opt");
   });
 
   it("does not replay a session id before the server has assigned one", () => {

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -133,6 +133,10 @@ function ensure(key: string, target: ConnTarget): Conn {
     cursorBlink: true,
     fontSize: 14,
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
+    // Treat macOS Option as Meta so Claude's Alt bindings reach the PTY — Alt+Enter
+    // (newline), Alt+B/F (word nav), Alt+Backspace (delete word). The cost is Option
+    // dead-key accent entry (é etc.), which a coding terminal doesn't need.
+    macOptionIsMeta: true,
   });
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);


### PR DESCRIPTION
## Summary

macOS で **Option/Alt キーが Meta として PTY に届かない**問題の修正（#263/#264 の Shift+Enter と同系統）。`useTerminalConnections.ts` の `new Terminal({...})` に **`macOptionIsMeta: true`** を追加。

これで Claude / readline の Alt バインドが有効化:
- **Option+Enter** → 改行
- **Option+B / Option+F** → 単語単位で前後移動
- **Option+Backspace** → 単語削除

## Items to Confirm / Review

- **トレードオフ**: Option+文字のデッドキー入力（é / © 等）は無効化されます。→ **ユーザー判断「é は不要」**により既定 on にしています。
- macOS 限定オプション（Windows/Linux は無影響）。

## Verification

- mock で `new Terminal` に渡る options を捕捉し、`macOptionIsMeta === true` を検証
- `eslint server src` 0 errors、typecheck / build 通過、spec 12 passing

## User Prompt

> （Shift+Enter の監査で）これって他に同様の問題ない？ → macOS Option/Alt が Meta にならない件を発見 ／ é は不要で（→ macOptionIsMeta を既定 on に）

## Plan

`plans/fix-265-option-as-meta.md`

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)