### PR TITLE
fix: keep expand/restore + close on the header's first row (#269)

### DIFF
--- a/plans/fix-269-row1-expand-close.md
+++ b/plans/fix-269-row1-expand-close.md
@@ -1,0 +1,8 @@
+# fix #269 — expand/restore + close を1行目に
+
+#260 で2行目に寄せたアクションのうち、**expand/restore と close だけ1行目**に戻す。
+
+## 実装
+- `TerminalCell.vue` cell-header（1行目）末尾に `.cell-actions`（expand/restore + close、`@click.stop`）。
+- 2行目スロット（#header-actions）から expand/close を削除（GitHub / 🕘 / 並べ替えは据え置き）。
+- フィルムストリップ専用の zoom ボタンは一般 expand に統合（1行目に常設）。

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -1236,17 +1236,17 @@ describe("TerminalCell", () => {
     expect(w.find(".ccx-remove").text()).toContain("Discard");
   });
 
-  it("row 1 is info-only; the icon actions live on row 2 (the terminal header slot)", async () => {
+  it("keeps expand + close on row 1 (cell-header); the other icons live on row 2", async () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj" });
     await flushPromises();
-    // Row 1 (cell-header) holds info: dir (clickable) + prompt, but NOT the action buttons.
+    // Row 1 (cell-header): dir + prompt + expand/close.
     const header = w.find(".cell-header");
     expect(header.find("button.cell-dir").exists()).toBe(true);
-    expect(header.find(".cell-close").exists()).toBe(false);
-    expect(header.find('[aria-label="Expand terminal"]').exists()).toBe(false);
-    // Row 2 (rendered via the TerminalView header-actions slot) holds the icon buttons.
-    expect(w.find(".cell-close").exists()).toBe(true);
-    expect(w.find('[aria-label="Expand terminal"]').exists()).toBe(true);
+    expect(header.find(".cell-close").exists()).toBe(true);
+    expect(header.find('[aria-label="Expand terminal"]').exists()).toBe(true);
+    // The timeline / reorder / GitHub icons stay on row 2 (the TerminalView slot).
+    expect(header.find('[aria-label="Show activity timeline"]').exists()).toBe(false);
+    expect(w.find('[aria-label="Show activity timeline"]').exists()).toBe(true);
   });
 
   it("shows the restore label + icon when the cell is expanded", async () => {
@@ -1263,8 +1263,8 @@ describe("TerminalCell", () => {
     expect(w.find(".git-chip").exists()).toBe(false);
     expect(w.find(".cell-usage").exists()).toBe(false);
     expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
-    // Only the zoom button + dir + prompt remain.
-    expect(w.find(".cell-zoom-thumb").exists()).toBe(true);
+    // Row 1 keeps dir + prompt + the expand/close actions (row 2 is hidden).
+    expect(w.find('[aria-label="Expand terminal"]').exists()).toBe(true);
     expect(w.find("button.cell-dir").exists()).toBe(true);
   });
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -829,8 +829,19 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
         </template>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
-        <!-- Filmstrip: the only action is to zoom into this cell (row 2 is hidden). -->
-        <button v-if="filmstrip" class="cell-btn cell-zoom-thumb" title="Expand" aria-label="Expand terminal" @click.stop="emit('toggle-expand')">⤢</button>
+        <!-- Expand/restore + close stay on row 1 (the info row); the other icons live on
+             row 2. `.stop` so they don't trigger the header's click-to-zoom. -->
+        <span class="cell-actions">
+          <button
+            class="cell-btn"
+            :title="expanded ? 'Restore' : 'Expand'"
+            :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
+            @click.stop="emit('toggle-expand')"
+          >
+            {{ expanded ? "⤡" : "⤢" }}
+          </button>
+          <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click.stop="close">✕</button>
+        </span>
       </div>
       <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
       <TerminalView
@@ -886,15 +897,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           </button>
           <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
           <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
-          <button
-            class="cell-btn"
-            :title="expanded ? 'Restore' : 'Expand'"
-            :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
-            @click="emit('toggle-expand')"
-          >
-            {{ expanded ? "⤡" : "⤢" }}
-          </button>
-          <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="close">✕</button>
         </template>
       </TerminalView>
       <div v-if="diffOpen && diff" class="cell-diff">


### PR DESCRIPTION
## Summary

#260 で全アクションアイコンを2行目に寄せたが、**expand/restore（⤢/⤡）と close（✕）は1行目**（情報行）に戻す。GitHub / 🕘 / 並べ替えは2行目のまま。

- `TerminalCell.vue` cell-header（1行目）末尾に expand/restore + close を配置（`@click.stop` でクリック→ズームを抑止）
- 2行目スロットから expand/close を削除
- フィルムストリップ専用の zoom ボタンは一般の expand ボタンに統合（1行目に常設）

## Verification

- `TerminalCell.spec.ts`: expand + close が cell-header（1行目）にあり、🕘 は2行目、を検証。フィルムストリップも expand が1行目に出ることを確認
- `eslint server src` 0 errors、typecheck / build 通過、TerminalCell spec 79 passing

## User Prompt

> 細かいところだけど、expand/restore と close terminal のボタンは1行目にして！！

## Plan

`plans/fix-269-row1-expand-close.md`

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)