### PR TITLE
fix: Files view を閉じたら開いた元のビューに戻す (#271)

### DIFF
--- a/plans/fix-271-files-close-return.md
+++ b/plans/fix-271-files-close-return.md
@@ -1,0 +1,35 @@
+# fix #271: Files view を閉じたら開いた元のビューに戻す
+
+## 現象
+グリッド（`/terminals`）でターミナルヘッダの 📁 から Files view を開き、閉じると
+単一ビュー（`/` chat）に戻ってしまう。開いた元のグリッドに戻るべき。
+
+## 原因
+`src/composables/useFilesView.ts`:
+
+```ts
+export function filesClose(): void {
+  router.push("/"); // 常に chat（単一ビュー）へ
+}
+```
+
+戻り先が `/` にハードコードされている。`usePrsView.prsClose()` も同型。
+
+## 修正
+- 開くとき（`filesGotoIndex`）、`/files` 以外にいる場合のみ現在ルートの
+  `fullPath` を `returnPath` に記録。
+- `filesClose()` は `returnPath` へ戻す。
+- `/files` にいる状態での再オープン（root 変更 / guarded close の revert:
+  `FilesOverlay.vue` の `filesGotoIndex(prevCwd)`）では戻り先を上書きしない。
+- モジュールレベル state。リロードで origin は失われるが、その場合は既定の
+  `/`（chat）にフォールバック（許容）。
+
+## テスト
+`src/composables/useFilesView.spec.ts`（新規、singleton router を駆動）:
+- グリッド起点 → close でグリッドに戻る
+- 単一ビュー起点 → close で chat に戻る
+- Files 内で root 変更しても origin（グリッド）を保持
+- `?cwd=` を browsed root として公開
+
+## スコープ外
+`usePrsView` の同種挙動は今回未対応（報告は Files のみ）。必要なら別途。

--- a/src/composables/useFilesView.spec.ts
+++ b/src/composables/useFilesView.spec.ts
@@ -57,4 +57,23 @@ describe("useFilesView return-to-origin", () => {
     await settle();
     expect(useFilesView().cwd.value).toBe("/work/app");
   });
+
+  // Regression (codex #273, mirrored here): the origin rides the history entry, so a
+  // /files reached WITHOUT filesGotoIndex (browser back/forward, direct load) must fall
+  // back to chat — never a stale origin captured by an earlier open.
+  it("falls back to chat for a history-driven /files, ignoring an earlier open's origin", async () => {
+    await router.push("/terminals");
+    await settle();
+    filesGotoIndex("/proj"); // captures /terminals into that entry's state
+    await settle();
+
+    await router.push("/");
+    await settle();
+    await router.push("/files"); // fresh /files entry, no captured origin
+    await settle();
+
+    filesClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("chat");
+  });
 });

--- a/src/composables/useFilesView.spec.ts
+++ b/src/composables/useFilesView.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { flushPromises } from "@vue/test-utils";
+import { router } from "../router";
+import { filesGotoIndex, filesClose, useFilesView } from "./useFilesView";
+
+// Drives the real singleton router (jsdom web-history) — the composables are bound to
+// it. Each test starts from chat, then navigates to the origin under test.
+const settle = () => flushPromises();
+
+describe("useFilesView return-to-origin", () => {
+  beforeEach(async () => {
+    await router.push("/");
+    await settle();
+  });
+
+  it("returns to the grid when Files was opened from the grid", async () => {
+    await router.push("/terminals");
+    await settle();
+
+    filesGotoIndex("/proj");
+    await settle();
+    expect(router.currentRoute.value.name).toBe("files");
+
+    filesClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("terminals");
+  });
+
+  it("returns to chat when Files was opened from the single view", async () => {
+    filesGotoIndex("/proj");
+    await settle();
+    expect(router.currentRoute.value.name).toBe("files");
+
+    filesClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("chat");
+  });
+
+  it("keeps the grid origin when the root dir changes while already in Files", async () => {
+    await router.push("/terminals");
+    await settle();
+    filesGotoIndex("/proj");
+    await settle();
+
+    // Changing the browsed root re-pushes /files while already open — origin must hold.
+    filesGotoIndex("/proj/sub");
+    await settle();
+    expect(router.currentRoute.value.name).toBe("files");
+
+    filesClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("terminals");
+  });
+
+  it("exposes the ?cwd= query as the browsed root", async () => {
+    filesGotoIndex("/work/app");
+    await settle();
+    expect(useFilesView().cwd.value).toBe("/work/app");
+  });
+});

--- a/src/composables/useFilesView.ts
+++ b/src/composables/useFilesView.ts
@@ -4,23 +4,26 @@
 import { computed, type ComputedRef } from "vue";
 import { router } from "../router";
 
-// Where to return when the Files view closes. Captured when opening from a normal
-// view (the grid or chat) so Close restores it instead of always dropping to chat.
-// Reopening while already in Files (changing the root dir, or reverting a guarded
-// close) must NOT overwrite it, or the origin would be lost.
-let returnPath = "/";
+// The view to return to when the Files view closes rides on the history entry (router
+// state), NOT a module variable — so entering /files via browser back/forward restores
+// that entry's own origin instead of a stale one, and a fresh/direct load falls back to
+// chat. Reopening while already in Files (root change, or the guarded-close revert)
+// carries the same origin forward.
+const originFromHistory = (): string => {
+  const origin = router.options.history.state.returnPath;
+  return typeof origin === "string" ? origin : "/";
+};
 
 /** Open the Files view rooted at `cwd` (the terminal's project dir). */
 export function filesGotoIndex(cwd: string | null): void {
-  if (router.currentRoute.value.name !== "files") {
-    returnPath = router.currentRoute.value.fullPath;
-  }
-  router.push({ name: "files", query: cwd ? { cwd } : {} });
+  const alreadyOpen = router.currentRoute.value.name === "files";
+  const returnPath = alreadyOpen ? originFromHistory() : router.currentRoute.value.fullPath;
+  router.push({ name: "files", query: cwd ? { cwd } : {}, state: { returnPath } });
 }
 
 /** Close the Files view → back to the view it was opened from. */
 export function filesClose(): void {
-  router.push(returnPath);
+  router.push(originFromHistory());
 }
 
 export function useFilesView(): { isOpen: ComputedRef<boolean>; cwd: ComputedRef<string | null>; close: () => void } {

--- a/src/composables/useFilesView.ts
+++ b/src/composables/useFilesView.ts
@@ -4,14 +4,23 @@
 import { computed, type ComputedRef } from "vue";
 import { router } from "../router";
 
+// Where to return when the Files view closes. Captured when opening from a normal
+// view (the grid or chat) so Close restores it instead of always dropping to chat.
+// Reopening while already in Files (changing the root dir, or reverting a guarded
+// close) must NOT overwrite it, or the origin would be lost.
+let returnPath = "/";
+
 /** Open the Files view rooted at `cwd` (the terminal's project dir). */
 export function filesGotoIndex(cwd: string | null): void {
+  if (router.currentRoute.value.name !== "files") {
+    returnPath = router.currentRoute.value.fullPath;
+  }
   router.push({ name: "files", query: cwd ? { cwd } : {} });
 }
 
-/** Close the Files view → back to chat. */
+/** Close the Files view → back to the view it was opened from. */
 export function filesClose(): void {
-  router.push("/");
+  router.push(returnPath);
 }
 
 export function useFilesView(): { isOpen: ComputedRef<boolean>; cwd: ComputedRef<string | null>; close: () => void } {


### PR DESCRIPTION
## Summary
グリッド（`/terminals`）からファイルエクスプローラー（Files view）を開いて閉じると、単一ビュー（`/` chat）に落ちてしまうバグの修正。開いた元のビューに戻すようにした。

Closes #271

## Items to Confirm / Review
- 戻り先は**モジュールレベル state**（`returnPath`）で保持。`/files` にいる状態でリロードすると origin は失われ、既定の `/`（chat）にフォールバックする — 許容範囲という判断。URL クエリに埋める案もあるが今回は不採用。
- `/files` 内での再オープン（root 変更 / guarded close の revert = `FilesOverlay.vue` の `filesGotoIndex(prevCwd)`）で戻り先を上書きしないガードが効いているか。
- `usePrsView.prsClose()` も同じく `router.push("/")` 固定で**同種の挙動**。報告は Files のみのため今回は未対応（必要なら別 PR）。

## User Prompt
> grid view -> file エクスプローラー -> 閉じる -> single viewになる

（グリッドビューでファイルエクスプローラーを開いて閉じると、単一ビューになってしまう＝グリッドに戻ってほしい、というバグ報告）

## 原因
`src/composables/useFilesView.ts` の `filesClose()` が戻り先を `router.push("/")` にハードコードしていた。開いた元が `/terminals`（グリッド）でも常に `/`（chat）へ戻していた。

## 修正
- `filesGotoIndex`：`/files` 以外にいる場合のみ現在ルートの `fullPath` を `returnPath` に記録。
- `filesClose`：`returnPath` へ戻す。

## テスト
`src/composables/useFilesView.spec.ts`（新規）:
- グリッド起点 → close でグリッドに戻る
- 単一ビュー起点 → close で chat に戻る
- Files 内で root 変更しても origin を保持
- `?cwd=` を browsed root として公開

lint / typecheck / build / 該当スペック いずれも green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)