### PR TITLE
fix: PR view を閉じたら開いた元のビューに戻す

### DIFF
--- a/src/composables/usePrsView.spec.ts
+++ b/src/composables/usePrsView.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { flushPromises } from "@vue/test-utils";
+import { router } from "../router";
+import { prsGotoIndex, prsClose } from "./usePrsView";
+
+// Drives the real singleton router (jsdom web-history) — the composables are bound to
+// it. Each test starts from chat, then navigates to the origin under test.
+const settle = () => flushPromises();
+
+describe("usePrsView return-to-origin", () => {
+  beforeEach(async () => {
+    await router.push("/");
+    await settle();
+  });
+
+  it("returns to the grid when the PR view was opened from the grid", async () => {
+    await router.push("/terminals");
+    await settle();
+
+    prsGotoIndex();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("prs");
+
+    prsClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("terminals");
+  });
+
+  it("returns to chat when the PR view was opened from the single view", async () => {
+    prsGotoIndex();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("prs");
+
+    prsClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("chat");
+  });
+
+  it("keeps the grid origin when re-opened while already in the PR view", async () => {
+    await router.push("/terminals");
+    await settle();
+    prsGotoIndex();
+    await settle();
+
+    prsGotoIndex(); // re-push /prs while already open — origin must hold
+    await settle();
+
+    prsClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("terminals");
+  });
+});

--- a/src/composables/usePrsView.spec.ts
+++ b/src/composables/usePrsView.spec.ts
@@ -42,11 +42,30 @@ describe("usePrsView return-to-origin", () => {
     prsGotoIndex();
     await settle();
 
-    prsGotoIndex(); // re-push /prs while already open — origin must hold
+    prsGotoIndex(); // re-push /prs while already open — origin must ride along
     await settle();
 
     prsClose();
     await settle();
     expect(router.currentRoute.value.name).toBe("terminals");
+  });
+
+  // Regression (codex #273): the origin rides the history entry, so a /prs reached
+  // WITHOUT prsGotoIndex (browser back/forward, direct load) must fall back to chat —
+  // never a stale origin captured by an earlier open.
+  it("falls back to chat for a history-driven /prs, ignoring an earlier open's origin", async () => {
+    await router.push("/terminals");
+    await settle();
+    prsGotoIndex(); // captures /terminals into that entry's state
+    await settle();
+
+    await router.push("/");
+    await settle();
+    await router.push("/prs"); // fresh /prs entry, no captured origin
+    await settle();
+
+    prsClose();
+    await settle();
+    expect(router.currentRoute.value.name).toBe("chat");
   });
 });

--- a/src/composables/usePrsView.ts
+++ b/src/composables/usePrsView.ts
@@ -4,21 +4,25 @@
 import { computed, type ComputedRef } from "vue";
 import { router } from "../router";
 
-// Where to return when the PR view closes. Captured when opening from a normal view
-// (the grid or chat) so Close restores it instead of always dropping to chat.
-let returnPath = "/";
+// The view to return to when the PR view closes rides on the history entry (router
+// state), NOT a module variable — so entering /prs via browser back/forward restores
+// that entry's own origin instead of a stale one, and a fresh/direct load falls back
+// to chat.
+const originFromHistory = (): string => {
+  const origin = router.options.history.state.returnPath;
+  return typeof origin === "string" ? origin : "/";
+};
 
-/** Open the cross-repo PR list. */
+/** Open the cross-repo PR list, remembering the view it was opened from. */
 export function prsGotoIndex(): void {
-  if (router.currentRoute.value.name !== "prs") {
-    returnPath = router.currentRoute.value.fullPath;
-  }
-  router.push("/prs");
+  const alreadyOpen = router.currentRoute.value.name === "prs";
+  const returnPath = alreadyOpen ? originFromHistory() : router.currentRoute.value.fullPath;
+  router.push({ path: "/prs", state: { returnPath } });
 }
 
 /** Close the PR view → back to the view it was opened from. */
 export function prsClose(): void {
-  router.push(returnPath);
+  router.push(originFromHistory());
 }
 
 export function usePrsView(): { isOpen: ComputedRef<boolean>; close: () => void } {

--- a/src/composables/usePrsView.ts
+++ b/src/composables/usePrsView.ts
@@ -4,14 +4,21 @@
 import { computed, type ComputedRef } from "vue";
 import { router } from "../router";
 
+// Where to return when the PR view closes. Captured when opening from a normal view
+// (the grid or chat) so Close restores it instead of always dropping to chat.
+let returnPath = "/";
+
 /** Open the cross-repo PR list. */
 export function prsGotoIndex(): void {
+  if (router.currentRoute.value.name !== "prs") {
+    returnPath = router.currentRoute.value.fullPath;
+  }
   router.push("/prs");
 }
 
-/** Close the PR view → back to chat. */
+/** Close the PR view → back to the view it was opened from. */
 export function prsClose(): void {
-  router.push("/");
+  router.push(returnPath);
 }
 
 export function usePrsView(): { isOpen: ComputedRef<boolean>; close: () => void } {


### PR DESCRIPTION
## Summary
#272（Files view）と同種のバグ修正。クロスリポジトリの PR 一覧ビューをグリッド（`/terminals`）から開いて閉じると、単一ビュー（`/` chat）に落ちてしまう。開いた元のビューに戻すようにした。

`usePrsView.prsClose()` も `filesClose()` と同じく `router.push("/")` を固定していたのが原因。#272 のパターンをそのままミラー。

## Items to Confirm / Review
- 実装は #272 と対称（`returnPath` をモジュールレベルで保持、`/prs` 以外からの `prsGotoIndex` でのみ origin を記録）。リロードで origin は失われ既定 `/` にフォールバックする点も同じ。
- `useFilesView` / `usePrsView` で returnPath ロジックが重複しているが、共有ヘルパー抽出は #272 の対象ファイルにも触れる cross-PR 依存を避けるため今回は見送り。両方マージ後に別途 DRY 化する余地あり。

## User Prompt
> （#272 のレビュー時に）PRビューも直しますか？ → ok

Files view の戻り先バグ（#271 / #272）と同じ挙動が PR 一覧ビューにもあることを指摘し、ユーザーが修正を承認した。

## テスト
`src/composables/usePrsView.spec.ts`（新規）:
- グリッド起点 → close でグリッドに戻る
- 単一ビュー起点 → close で chat に戻る
- PR view 内で再オープンしても origin を保持

lint / typecheck / build / 該当スペック いずれも green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)