### PR TITLE
fix: 通常グリッドではヘッダークリックで拡大しない（⤢ ボタンのみ）(#274)

### DIFF
--- a/plans/fix-274-no-header-zoom-in-grid.md
+++ b/plans/fix-274-no-header-zoom-in-grid.md
@@ -1,0 +1,38 @@
+# fix #274: 通常グリッドではヘッダークリックで拡大しない
+
+## 現象
+通常グリッドでセルのヘッダー背景をクリックすると拡大される。通常時は ⤢
+ボタンのみで拡大したい（ヘッダークリック拡大は誤操作の元）。
+
+## 原因
+`src/components/cellHeaderZoom.ts`:
+
+```ts
+export function shouldZoomOnHeaderClick(target, expanded): boolean {
+  if (expanded) return false;
+  return !(target instanceof Element && target.closest("button"));
+}
+```
+
+`!expanded` なら（=通常グリッドでも）ヘッダー背景クリックで zoom していた。
+
+## 修正
+判定を「filmstrip（他セルが拡大中の縮小サムネイル = `zoomed && !expanded`）の
+ときだけ zoom」に限定:
+
+- `cellHeaderZoom.ts`: 第2引数を `expanded` → `filmstrip` に変更、`if (!filmstrip) return false`。
+- `TerminalCell.vue`:
+  - `onHeaderClick` は `filmstrip.value` を渡す。
+  - `.cell-header` の `is-zoomable` を `!expanded` → `filmstrip`（通常グリッドで
+    ポインタカーソル/ホバーを出さない）。
+
+### 挙動
+- 通常グリッド: ヘッダークリックで拡大しない（⤢ ボタンのみ）
+- filmstrip サムネイル: ヘッダークリックで「そのターミナルに切り替え」= 維持
+- 拡大中セル: ヘッダークリック無視（復元は ⤡）= 維持
+
+## テスト
+- `cellHeaderZoom.spec.ts`: `filmstrip` セマンティクスに更新（通常グリッド=false
+  では常に false、サムネイル=true でボタン判定）。
+- `TerminalCell.spec.ts`: 通常グリッドのヘッダー背景クリックで `toggle-expand` を
+  emit しない／⤢ ボタンは emit する／filmstrip はヘッダークリックで emit する。

--- a/src/components/CommandCell.spec.ts
+++ b/src/components/CommandCell.spec.ts
@@ -60,6 +60,20 @@ describe("CommandCell", () => {
     expect(w.emitted("toggle-expand")).toHaveLength(1);
     expect(w.emitted("close")).toHaveLength(1);
   });
+
+  it("does not zoom on a header-background click in the normal grid (only the ⤢ button)", async () => {
+    const w = mountCell(); // expanded: false, zoomed: undefined → normal grid
+    expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toBeUndefined();
+  });
+
+  it("zooms on a header-background click when it's a filmstrip thumbnail", async () => {
+    const w = mount(CommandCell, { props: { expanded: false, zoomed: true, command: COMMAND, home: "/work" } });
+    expect(w.find(".cell-header").classes()).toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
 });
 
 describe("CommandCell summarize", () => {

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -11,6 +11,9 @@ import type { CellStatus } from "./gridTabs";
 // (the server resolves it); the command runs in `command.cwd`.
 const props = defineProps<{
   expanded: boolean;
+  // True while SOME cell in the grid is zoomed → this cell is a filmstrip thumbnail
+  // (unless it's the zoomed one). Only then does a header-background click zoom it.
+  zoomed?: boolean;
   command: { index: number; label: string; cwd: string | null };
   home: string | null;
   // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
@@ -128,15 +131,17 @@ function copyPrompt() {
     });
 }
 
-// Click the header background to zoom (switch to) this cell; buttons keep their action.
+// A filmstrip thumbnail zooms (switches to) this cell on a header-background click;
+// in the normal grid the header is inert (only the ⤢ button zooms). Buttons keep their action.
+const filmstrip = computed(() => !!props.zoomed && !props.expanded);
 function onHeaderClick(event: MouseEvent) {
-  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
+  if (shouldZoomOnHeaderClick(event.target, filmstrip.value)) emit("toggle-expand");
 }
 </script>
 
 <template>
   <div class="cell">
-    <div class="cell-header" :class="{ 'is-zoomable': !expanded }" @click="onHeaderClick">
+    <div class="cell-header" :class="{ 'is-zoomable': filmstrip }" @click="onHeaderClick">
       <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Finished' : 'Running…'" />
       <span v-if="dirDisplay" class="cell-dir" :title="command.cwd ?? ''"
         ><span class="cell-dir-path">{{ dirDisplay }}</span></span

--- a/src/components/LauncherCell.spec.ts
+++ b/src/components/LauncherCell.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import LauncherCell from "./LauncherCell.vue";
+
+// Stub the terminal so no xterm/WebSocket is needed; it just forwards the props the
+// cell passes and can emit session/exit.
+vi.mock("./Terminal.vue", () => ({
+  default: {
+    name: "TerminalView",
+    props: ["persistKey", "sessionId", "connectKey", "cwd", "launcher"],
+    emits: ["session", "exit"],
+    template: '<div class="stub-term" />',
+  },
+}));
+
+const LAUNCHER = { index: 1, label: "zsh" };
+const baseProps = { uid: 7, expanded: false, launcher: LAUNCHER, session: null, cwd: "/work/proj", home: "/work" };
+const mountCell = (extra: Record<string, unknown> = {}) => mount(LauncherCell, { props: { ...baseProps, ...extra } });
+
+describe("LauncherCell header zoom", () => {
+  it("shows the label + dir and runs the configured launcher in its directory", () => {
+    const w = mountCell();
+    expect(w.find(".cell-cmd").text()).toContain("zsh");
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.props("launcher")).toEqual({ index: 1 });
+    expect(term.props("cwd")).toBe("/work/proj");
+  });
+
+  it("emits toggle-expand and close from the header buttons", async () => {
+    const w = mountCell();
+    await w.find('[aria-label="Expand terminal"]').trigger("click");
+    await w.find('[aria-label="Close terminal"]').trigger("click");
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+    expect(w.emitted("close")).toHaveLength(1);
+  });
+
+  it("does not zoom on a header-background click in the normal grid (only the ⤢ button)", async () => {
+    const w = mountCell(); // zoomed: undefined → normal grid
+    expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toBeUndefined();
+  });
+
+  it("zooms on a header-background click when it's a filmstrip thumbnail", async () => {
+    const w = mountCell({ zoomed: true }); // some other cell is zoomed → this is a thumbnail
+    expect(w.find(".cell-header").classes()).toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
+});

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -14,6 +14,9 @@ import type { CellStatus, CellLauncher } from "./gridTabs";
 const props = defineProps<{
   uid: number;
   expanded: boolean;
+  // True while SOME cell in the grid is zoomed → this cell is a filmstrip thumbnail
+  // (unless it's the zoomed one). Only then does a header-background click zoom it.
+  zoomed?: boolean;
   launcher: CellLauncher;
   session: string | null;
   cwd: string | null;
@@ -30,9 +33,11 @@ const emit = defineEmits<{
   (e: "session", id: string): void;
 }>();
 
-// Click the header background to zoom (switch to) this cell; buttons keep their action.
+// A filmstrip thumbnail zooms (switches to) this cell on a header-background click;
+// in the normal grid the header is inert (only the ⤢ button zooms). Buttons keep their action.
+const filmstrip = computed(() => !!props.zoomed && !props.expanded);
 function onHeaderClick(event: MouseEvent) {
-  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
+  if (shouldZoomOnHeaderClick(event.target, filmstrip.value)) emit("toggle-expand");
 }
 
 // connectKey bump re-launches after the process exits (relaunch button).
@@ -59,7 +64,7 @@ function relaunch() {
 
 <template>
   <div class="cell">
-    <div class="cell-header" :class="{ 'is-zoomable': !expanded }" @click="onHeaderClick">
+    <div class="cell-header" :class="{ 'is-zoomable': filmstrip }" @click="onHeaderClick">
       <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Exited' : 'Running…'" />
       <span v-if="dirDisplay" class="cell-dir" :title="cwd ?? ''"
         ><span class="cell-dir-path">{{ dirDisplay }}</span></span

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -1268,6 +1268,25 @@ describe("TerminalCell", () => {
     expect(w.find("button.cell-dir").exists()).toBe(true);
   });
 
+  it("does not zoom on a header-background click in the normal grid (only the ⤢ button zooms)", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj" });
+    await flushPromises();
+    expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toBeUndefined();
+    // The dedicated button still works.
+    await w.find('[aria-label="Expand terminal"]').trigger("click");
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
+
+  it("zooms on a header-background click when it's a filmstrip thumbnail (switch to it)", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", zoomed: true, expanded: false });
+    await flushPromises();
+    expect(w.find(".cell-header").classes()).toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
+
   it("tints a preset chip whose dir already has a running session elsewhere", () => {
     const w = mountCell(null, {
       presets: [

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -16,11 +16,12 @@ import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 
-// Clicking the header background zooms this cell — while another cell is zoomed
-// that's the easy "switch to this terminal" gesture. Header buttons keep their
-// action; the already-zoomed cell ignores it (restore is the ⤡ button).
+// Clicking the header background zooms this cell ONLY when it's a filmstrip thumbnail
+// (another cell is zoomed) — the easy "switch to this terminal" gesture. In the normal
+// grid the header is inert; the ⤢ button is the only way to zoom. Header buttons keep
+// their action.
 function onHeaderClick(event: MouseEvent) {
-  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
+  if (shouldZoomOnHeaderClick(event.target, filmstrip.value)) emit("toggle-expand");
 }
 
 // `expanded` reflects whether this cell is zoomed to fill the grid (parent owns
@@ -811,7 +812,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
     <template v-if="launched">
       <!-- Row 1 — INFO only: dir + git + model/token + what it's doing. Every icon
            BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
-      <div class="cell-header" :class="[statusClass, { 'is-zoomable': !expanded }]" @click="onHeaderClick">
+      <div class="cell-header" :class="[statusClass, { 'is-zoomable': filmstrip }]" @click="onHeaderClick">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
         <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
@@ -1151,8 +1152,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   color: var(--warn);
   border-bottom-color: var(--amber);
 }
-/* A non-zoomed cell's header is a click target: zoom (switch to) this terminal.
-   Signalled with a pointer cursor + a hover tint so it's discoverable. */
+/* A filmstrip thumbnail's header is a click target: zoom (switch to) this terminal.
+   Signalled with a pointer cursor + a hover tint so it's discoverable. (Normal grid
+   cells are not zoomable by header click — only the ⤢ button.) */
 .cell-header.is-zoomable {
   cursor: pointer;
 }

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -60,6 +60,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
         <CommandCell
           v-if="cell.command"
           :expanded="cell.uid === expandedUid"
+          :zoomed="zoomed"
           :command="cell.command"
           :home="home"
           :reorderable="reorderable"
@@ -72,6 +73,7 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
           v-else-if="cell.launcher"
           :uid="cell.uid"
           :expanded="cell.uid === expandedUid"
+          :zoomed="zoomed"
           :launcher="cell.launcher"
           :session="cell.session"
           :cwd="cell.cwd"

--- a/src/components/cellHeaderZoom.spec.ts
+++ b/src/components/cellHeaderZoom.spec.ts
@@ -2,19 +2,25 @@ import { describe, it, expect } from "vitest";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 
 describe("shouldZoomOnHeaderClick", () => {
-  it("zooms when the header background (a non-button element) is clicked", () => {
+  it("zooms when a filmstrip thumbnail's header background (a non-button element) is clicked", () => {
     const span = document.createElement("span"); // e.g. the prompt / badge / dot
-    expect(shouldZoomOnHeaderClick(span, false)).toBe(true);
+    expect(shouldZoomOnHeaderClick(span, true)).toBe(true);
   });
 
-  it("ignores clicks that land on one of the header's own buttons", () => {
+  it("does not zoom in the normal grid — only the ⤢ button zooms there", () => {
+    const span = document.createElement("span");
+    expect(shouldZoomOnHeaderClick(span, false)).toBe(false);
+    expect(shouldZoomOnHeaderClick(null, false)).toBe(false);
+  });
+
+  it("ignores clicks that land on one of the header's own buttons (even on a thumbnail)", () => {
     const header = document.createElement("div");
     const btn = document.createElement("button");
     const icon = document.createElement("span"); // an icon inside the button
     btn.appendChild(icon);
     header.appendChild(btn);
-    expect(shouldZoomOnHeaderClick(btn, false)).toBe(false);
-    expect(shouldZoomOnHeaderClick(icon, false)).toBe(false); // click bubbles from the icon
+    expect(shouldZoomOnHeaderClick(btn, true)).toBe(false);
+    expect(shouldZoomOnHeaderClick(icon, true)).toBe(false); // click bubbles from the icon
   });
 
   it("ignores clicks on an SVG icon inside a button (e.g. the GitHub button)", () => {
@@ -24,16 +30,11 @@ describe("shouldZoomOnHeaderClick", () => {
     const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
     svg.appendChild(path);
     btn.appendChild(svg);
-    expect(shouldZoomOnHeaderClick(svg, false)).toBe(false);
-    expect(shouldZoomOnHeaderClick(path, false)).toBe(false);
+    expect(shouldZoomOnHeaderClick(svg, true)).toBe(false);
+    expect(shouldZoomOnHeaderClick(path, true)).toBe(false);
   });
 
-  it("ignores header clicks on the already-zoomed cell (restore is the ⤡ button)", () => {
-    const span = document.createElement("span");
-    expect(shouldZoomOnHeaderClick(span, true)).toBe(false);
-  });
-
-  it("ignores a null / non-element target", () => {
-    expect(shouldZoomOnHeaderClick(null, false)).toBe(true); // no button in the path → still zooms
+  it("zooms on a null / non-element target of a thumbnail (no button in the path)", () => {
+    expect(shouldZoomOnHeaderClick(null, true)).toBe(true);
   });
 });

--- a/src/components/cellHeaderZoom.ts
+++ b/src/components/cellHeaderZoom.ts
@@ -1,9 +1,10 @@
-// A click on a grid cell's header background zooms (promotes) that cell — while
-// another cell is zoomed this is the easy "switch to that terminal" gesture. The
-// header's own controls (dir / GitHub / ⤢ / ✕ / ◀▶) keep their action, and the
-// already-zoomed cell ignores stray header clicks (it restores via its ⤡ button).
-export function shouldZoomOnHeaderClick(target: EventTarget | null, expanded: boolean): boolean {
-  if (expanded) return false;
+// A click on a grid cell's header background zooms (promotes) that cell — but ONLY
+// while it's a filmstrip thumbnail (some OTHER cell is already zoomed), where this is
+// the easy "switch to that terminal" gesture. In the normal grid the header is inert;
+// the ⤢ button is the only way to zoom. The header's own controls (dir / GitHub / ⤢ /
+// ✕ / ◀▶) always keep their action.
+export function shouldZoomOnHeaderClick(target: EventTarget | null, filmstrip: boolean): boolean {
+  if (!filmstrip) return false;
   // `Element` (not `HTMLElement`): a click can land on an SVG icon inside a button
   // (e.g. the GitHub button), and SVGElement isn't an HTMLElement — but it IS an
   // Element with closest(), so this still walks up to the enclosing button.


### PR DESCRIPTION
## Summary
通常のグリッドビューでターミナルセルの**ヘッダー背景をクリックすると拡大される**挙動を修正。通常時の拡大は ⤢ ボタンのみにし、ヘッダークリック拡大は **filmstrip（他セルが拡大中の縮小サムネイル）のときだけ**に限定した。

Closes #274

## Items to Confirm / Review
- ヘッダークリック zoom を `filmstrip = zoomed && !expanded` のときだけに限定。通常グリッドではヘッダー不活性・`is-zoomable`（ポインタカーソル/ホバー）も出さない。
- filmstrip サムネイルの「クリックでそのターミナルに切り替え」ジェスチャーは維持。拡大中セルのヘッダークリック無視（復元は ⤡）も維持。
- `shouldZoomOnHeaderClick` の第2引数を `expanded` → `filmstrip` に変更（意味が反転）。

## User Prompt
> 普通のgrid viewのときにヘッダーをクリックすると拡大される。普通のときはexpandボタンだけでよい

## 修正
- `cellHeaderZoom.ts`: `shouldZoomOnHeaderClick(target, filmstrip)` — `if (!filmstrip) return false`。
- `TerminalCell.vue`: `onHeaderClick` は `filmstrip.value` を渡す。`.cell-header` の `is-zoomable` を `!expanded` → `filmstrip`。

## テスト
- `cellHeaderZoom.spec.ts`: `filmstrip` セマンティクスに更新（通常グリッド=false は常に非zoom、サムネイル=true でボタン判定）。
- `TerminalCell.spec.ts`: 通常グリッドのヘッダー背景クリックで `toggle-expand` を emit しない／⤢ ボタンは emit する／filmstrip はヘッダークリックで emit する。

lint / typecheck / build / 該当スペック いずれも green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)