### PR TITLE
fix: per-model context window in the ctx% badge (1M for current-gen)

### DIFF
--- a/src/components/ModelContextBadge.spec.ts
+++ b/src/components/ModelContextBadge.spec.ts
@@ -19,6 +19,19 @@ describe("ModelContextBadge", () => {
     expect(mountBadge({ model: "claude-haiku-4-20250101", contextTokens: 20_000 }).find(".cell-model").text()).toBe("Haiku · ctx 10%");
   });
 
+  it("uses a 1M window for current-generation models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos)", () => {
+    // Regression: a full opus-4-8 session (~999k ctx) reads as ~100%, not ~500% against a 200k window.
+    expect(mountBadge({ model: "claude-opus-4-8", contextTokens: 999_606 }).find(".cell-model").text()).toBe("Opus · ctx 100%");
+    expect(mountBadge({ model: "claude-sonnet-5", contextTokens: 500_000 }).find(".cell-model").text()).toBe("Sonnet · ctx 50%");
+    expect(mountBadge({ model: "claude-sonnet-4-6", contextTokens: 100_000 }).find(".cell-model").text()).toBe("Sonnet · ctx 10%");
+    expect(mountBadge({ model: "claude-fable-5", contextTokens: 250_000 }).find(".cell-model").text()).toBe("Fable · ctx 25%");
+  });
+
+  it("keeps the 200k window for older Opus/Sonnet (pre-4.6)", () => {
+    expect(mountBadge({ model: "claude-opus-4-5-20251101", contextTokens: 100_000 }).find(".cell-model").text()).toBe("Opus · ctx 50%");
+    expect(mountBadge({ model: "claude-sonnet-4-5-20250929", contextTokens: 100_000 }).find(".cell-model").text()).toBe("Sonnet · ctx 50%");
+  });
+
   it("shows the model tail but NO % for an unknown model (never guesses a window)", () => {
     const w = mountBadge({ agent: "codex", model: "gpt-5-codex", contextTokens: 999_999 });
     expect(w.find(".cell-model").text()).toBe("gpt-5-codex");

--- a/src/components/ModelContextBadge.vue
+++ b/src/components/ModelContextBadge.vue
@@ -16,11 +16,30 @@ const CLAUDE_FAMILIES = [
   { match: "opus", label: "Opus" },
   { match: "sonnet", label: "Sonnet" },
   { match: "haiku", label: "Haiku" },
+  { match: "fable", label: "Fable" },
+  { match: "mythos", label: "Mythos" },
 ];
 
-// Approximate context window per model family, in tokens. A model with no entry
-// here shows its label but no % — we never guess a window.
-const CONTEXT_WINDOW_TOKENS: Record<string, number> = { opus: 200_000, sonnet: 200_000, haiku: 200_000 };
+const MILLION_TOKENS = 1_000_000;
+const K200_TOKENS = 200_000;
+// Context window per model, matched as an ordered substring list (first hit wins) against the
+// lowercased model id. The current Claude generation ships a 1M window — Opus 4.6+, Sonnet 4.6+,
+// Fable, Mythos — so those are listed explicitly; everything else (older Opus/Sonnet, all Haiku)
+// falls through to the 200k default. Add new 1M model ids here when they ship — otherwise a
+// full session over-reports (e.g. a 1M model shown against 200k reads as ~500%). A model matched
+// by neither list (a codex/other-provider id) shows its label but no % — we never guess a window.
+const CONTEXT_WINDOWS: { match: string; tokens: number }[] = [
+  { match: "opus-4-6", tokens: MILLION_TOKENS },
+  { match: "opus-4-7", tokens: MILLION_TOKENS },
+  { match: "opus-4-8", tokens: MILLION_TOKENS },
+  { match: "sonnet-4-6", tokens: MILLION_TOKENS },
+  { match: "sonnet-5", tokens: MILLION_TOKENS },
+  { match: "fable", tokens: MILLION_TOKENS },
+  { match: "mythos", tokens: MILLION_TOKENS },
+  { match: "opus", tokens: K200_TOKENS },
+  { match: "sonnet", tokens: K200_TOKENS },
+  { match: "haiku", tokens: K200_TOKENS },
+];
 const PERCENT = 100;
 
 const AGENT_NAME: Record<"claude" | "codex", string> = { claude: "Claude", codex: "Codex" };
@@ -33,8 +52,8 @@ function shortModelLabel(model: string): string {
 
 function contextWindowTokens(model: string): number | null {
   const lower = model.toLowerCase();
-  const key = Object.keys(CONTEXT_WINDOW_TOKENS).find((k) => lower.includes(k));
-  return key ? CONTEXT_WINDOW_TOKENS[key] : null;
+  const entry = CONTEXT_WINDOWS.find((w) => lower.includes(w.match));
+  return entry ? entry.tokens : null;
 }
 
 const label = computed(() => (props.model ? shortModelLabel(props.model) : null));


### PR DESCRIPTION
## Summary

The single-view header's context badge (`Opus · ctx N%`) showed values like **470–500%**. It divided
every Claude model's context tokens by a **hardcoded 200k window**, but current-generation models ship
a **1M** window — so a nearly-full `claude-opus-4-8` session (~999k tokens) read as ~500% instead of
~100%. This fixes the denominator to be per-model.

## Items to Confirm / Review

- **Window source**: context windows are from the `claude-api` reference — 1M for Opus 4.6+, Sonnet
  4.6+, Fable, Mythos; 200k for Haiku and pre-4.6 Opus/Sonnet. Please confirm this matches your
  expectation for any legacy models you still run.
- **Match strategy**: an ordered substring list against the lowercased model id (first hit wins). The
  current 1M models are listed explicitly; everything else falls through to the 200k default. **New 1M
  model ids must be added to the list** (noted in a code comment) — otherwise a full session
  over-reports again. Older/dated ids (`claude-opus-4-20250514`, bare `claude-opus-4`) are ambiguous
  with `opus-4-8` under substring matching, which is why the default is 200k and 1M is the explicit list.
- **No behavior change for codex / unknown models**: a model matched by neither list shows its label
  but no `%` (we never guess a window) — unchanged.

## User Prompt

> The ctx here shows 470% — isn't that a lot? Research the current model context windows online and
> adjust the badge per model.

## Root cause

`ModelContextBadge.vue` computed `ctx% = contextTokens / windowTokens × 100` with
`windowTokens = 200_000` for opus/sonnet/haiku alike. Confirmed against a real transcript: a
`claude-opus-4-8` turn with `input=2, cache_read=998274, cache_creation=1330` → `contextTokens =
999,606`, which is ~100% of a 1M window but was shown as `999606 / 200000 = 500%`.

## Change

- `CONTEXT_WINDOWS`: ordered `{match, tokens}` list — Opus 4.6/4.7/4.8, Sonnet 4.6/5, Fable, Mythos →
  1M; else (older Opus/Sonnet, all Haiku) → 200k default.
- Added `Fable` / `Mythos` short labels.
- Tests: 1M current-gen (incl. the exact opus-4-8 / 999,606 → 100% regression), 200k pre-4.6; existing
  200k tests unchanged.

## Verification

`yarn format` / `lint` (0 errors) / `typecheck` / `build` / `test` — all green (837 tests, +2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
