### PR TITLE
fix: expand 時の filmstrip サムネイルは dir クリックで拡大に切替（dir を開かない）(#277)

### DIFF
--- a/plans/fix-277-filmstrip-dir-no-open.md
+++ b/plans/fix-277-filmstrip-dir-no-open.md
@@ -1,0 +1,25 @@
+# fix #277: filmstrip サムネイルの dir は開かず拡大に切替
+
+## 現象
+セル拡大時、下部の filmstrip サムネイルの dir 名をクリックすると dir が開く
+(`/api/open-dir`)。filmstrip のヘッダーは「そのターミナルに切替（拡大）」が
+主動作であるべきで、dir を開くのは不要。
+
+## 原因
+`TerminalCell.vue` の `cell-dir` は `<button @click="openDir">`。
+`shouldZoomOnHeaderClick` はボタン上クリックを zoom 対象外にするため、filmstrip
+でも dir クリックは zoom せず openDir が走る。
+（`CommandCell`/`LauncherCell` の dir は既に `<span>` なので対象外。）
+
+## 修正
+`TerminalCell.vue`: dir を filmstrip 有無で出し分け。
+- 通常グリッド / 拡大中の本体（`!filmstrip`）: `<button @click="openDir">`（従来）。
+- filmstrip: `<span class="cell-dir">`（inert text）。非ボタンなので header の
+  zoom ジェスチャー（`shouldZoomOnHeaderClick` が closest("button")=null → zoom）
+  に吸収され、クリックで拡大に切り替わる。
+
+## テスト (`TerminalCell.spec.ts`)
+- filmstrip テスト: `button.cell-dir` は無く `span.cell-dir` がある。
+- 追加: filmstrip の dir クリックで `toggle-expand` を emit し、`/api/open-dir`
+  は呼ばれない。
+- 既存: 通常グリッドの dir クリックは従来どおり `/api/open-dir` を呼ぶ（不変）。

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -1265,7 +1265,25 @@ describe("TerminalCell", () => {
     expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
     // Row 1 keeps dir + prompt + the expand/close actions (row 2 is hidden).
     expect(w.find('[aria-label="Expand terminal"]').exists()).toBe(true);
-    expect(w.find("button.cell-dir").exists()).toBe(true);
+    // The dir stays visible but as inert text (not an "open dir" button).
+    expect(w.find("span.cell-dir").exists()).toBe(true);
+    expect(w.find("button.cell-dir").exists()).toBe(false);
+  });
+
+  it("a filmstrip thumbnail's dir click zooms (switch to it) instead of opening the dir", async () => {
+    const urls: string[] = [];
+    globalThis.fetch = vi.fn((url: string) => {
+      urls.push(String(url));
+      if (String(url).includes("/api/sessions")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", zoomed: true, expanded: false });
+    await flushPromises();
+    await w.find(".cell-dir").trigger("click");
+
+    expect(w.emitted("toggle-expand")).toHaveLength(1); // zoomed instead
+    expect(urls).not.toContain("/api/open-dir"); // dir was NOT opened
   });
 
   it("does not zoom on a header-background click in the normal grid (only the ⤢ button zooms)", async () => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -814,9 +814,15 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
            BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
       <div class="cell-header" :class="[statusClass, { 'is-zoomable': filmstrip }]" @click="onHeaderClick">
         <span class="cell-dot" :class="statusClass" :title="statusLabel" />
-        <button v-if="headerDir" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
+        <!-- Normal grid: the dir is a button that opens it. As a filmstrip thumbnail the
+             header's job is to zoom (switch to this terminal), so the dir is inert text
+             and a click on it falls through to the header's zoom gesture. -->
+        <button v-if="headerDir && !filmstrip" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
           <span class="cell-dir-path">{{ headerDir }}</span>
         </button>
+        <span v-else-if="headerDir" class="cell-dir" :title="cwd ?? ''">
+          <span class="cell-dir-path">{{ headerDir }}</span>
+        </span>
         <!-- Info (dir badge / git / diff / model / tokens) is dropped on a filmstrip
              thumbnail, leaving only dir + what it's doing + a zoom button. -->
         <template v-if="!filmstrip">


### PR DESCRIPTION
## Summary
セル拡大（expand）時、下部 filmstrip サムネイルの **dir 名をクリックすると dir が開いていた**のを、**そのターミナルへ切り替え（拡大）**に変更。filmstrip のヘッダーは「切替が主動作」という方針に合わせた。

Closes #277

## Items to Confirm / Review
- filmstrip（`zoomed && !expanded`）のときだけ `cell-dir` を `<button>` → `<span>`（inert text）に出し分け。非ボタンなので header の zoom ジェスチャー（`shouldZoomOnHeaderClick`）に吸収される。
- 通常グリッド／拡大中の本体セル（`!filmstrip`）は従来どおり `<button @click="openDir">` で dir を開ける（不変）。
- `CommandCell`/`LauncherCell` の dir は元々 `<span>`（openDir 無し）なので対象外。

## User Prompt
> grid viewのexpand時にしたの小さいターミナルのdir名をクリックしてもdirがひらかないように変えたい。headerはexpandさせるのがメイン

## テスト
`TerminalCell.spec.ts`:
- filmstrip サムネイル: `span.cell-dir` があり `button.cell-dir` は無い。
- 追加: filmstrip の dir クリックで `toggle-expand` を emit し、`/api/open-dir` は呼ばれない。
- 既存: 通常グリッドの dir クリックは従来どおり `/api/open-dir` を呼ぶ（不変）。

lint / typecheck / build / 該当スペック いずれも green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)