### PR TITLE
feat: セル本体背景・ボーダー・ドット・ボタン色も .mulmoterminal.json で指定可能に (#281)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,12 +258,12 @@ malformed file is ignored.
 | ------------ | ------- |
 | `name`       | Label shown as a badge in the terminal/cell header. |
 | `badgeColor` | Badge background color (`#rrggbb`); text auto-contrasts. |
-| `headerColor` | Cell header **background** color (`#rrggbb`). While a terminal is working/blocked the status tint still shows; the custom color applies when idle. |
-| `headerTextColor` | Cell header **text** color (`#rrggbb`) — the dir path and prompt. |
+| `headerColor` | Header **background** color (`#rrggbb`) — the grid cell's header row and the terminal's own header row (grid row 2 + single view). While a terminal is working/blocked the status tint still shows; the custom color applies when idle. |
+| `headerTextColor` | Header **text** color (`#rrggbb`) — the dir path, title, and prompt. |
 | `cellColor` | Cell **body background** color (`#rrggbb`) — the frame around the terminal. |
 | `cellBorderColor` | Cell **border** color (`#rrggbb`). The status frame (working/blocked) still overrides it while active. |
 | `dotColor` | **Idle** status-dot color (`#rrggbb`). The working/waiting colors are unchanged so the activity signal stays intact. |
-| `buttonColor` | Header **icon button** color (`#rrggbb`) — expand / close / etc. |
+| `buttonColor` | Header **icon button** color (`#rrggbb`) — expand / close / attach / folder / etc., across both header rows. |
 | `theme`      | xterm palette for terminals in this directory (one of the built-in theme ids). |
 | `colors`     | Per-key xterm palette overrides applied on top of `theme` (or the app theme when `theme` is unset). Keys are xterm `ITheme` names (`background`, `foreground`, `cursor`, `selectionBackground`, the 16 ANSI colors, …); values are hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Unknown keys / bad values are dropped. |
 | `sound`      | Attention sound for this directory's sessions, a path **relative to the directory** (served at `GET /api/dir-sound`). |

--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ malformed file is ignored.
   "badgeColor": "#cf222e",              // badge color (hex #rrggbb)
   "headerColor": "#190a23",             // cell header background (hex #rrggbb)
   "headerTextColor": "#ffffff",         // cell header text color (hex #rrggbb)
+  "cellColor": "#101014",               // cell body background (hex #rrggbb)
+  "cellBorderColor": "#2a2a4e",         // cell border color (hex #rrggbb)
+  "dotColor": "#00e676",                // idle status dot (hex #rrggbb)
+  "buttonColor": "#c7cdf0",             // header icon buttons (hex #rrggbb)
   "theme": "nord",                      // terminal palette: midnight | nord | daylight | solarized
   "colors": { "background": "#190a23", "cursor": "#ff2e63" }, // per-key palette overrides
   "sound": "./.mulmoterminal/alert.mp3" // attention sound, RELATIVE to this directory
@@ -256,6 +260,10 @@ malformed file is ignored.
 | `badgeColor` | Badge background color (`#rrggbb`); text auto-contrasts. |
 | `headerColor` | Cell header **background** color (`#rrggbb`). While a terminal is working/blocked the status tint still shows; the custom color applies when idle. |
 | `headerTextColor` | Cell header **text** color (`#rrggbb`) — the dir path and prompt. |
+| `cellColor` | Cell **body background** color (`#rrggbb`) — the frame around the terminal. |
+| `cellBorderColor` | Cell **border** color (`#rrggbb`). The status frame (working/blocked) still overrides it while active. |
+| `dotColor` | **Idle** status-dot color (`#rrggbb`). The working/waiting colors are unchanged so the activity signal stays intact. |
+| `buttonColor` | Header **icon button** color (`#rrggbb`) — expand / close / etc. |
 | `theme`      | xterm palette for terminals in this directory (one of the built-in theme ids). |
 | `colors`     | Per-key xterm palette overrides applied on top of `theme` (or the app theme when `theme` is unset). Keys are xterm `ITheme` names (`background`, `foreground`, `cursor`, `selectionBackground`, the 16 ANSI colors, …); values are hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Unknown keys / bad values are dropped. |
 | `sound`      | Attention sound for this directory's sessions, a path **relative to the directory** (served at `GET /api/dir-sound`). |

--- a/plans/feat-281-cell-appearance-colors.md
+++ b/plans/feat-281-cell-appearance-colors.md
@@ -18,8 +18,17 @@
   - status frame（`.cell.is-*`）と status dot（`.cell-dot.is-*`）は活動中に上書き＝
     フィードバック維持。custom は idle 時。
 
+## 追加: row 2 / 単一ビューのヘッダーも対応
+QA で 2 行目（`Terminal.vue` のヘッダー = grid row 2 + 単一ビュー）が未対応で白く浮い
+ていたため、既存の `headerColor` / `headerTextColor` / `buttonColor` を同ヘッダーにも
+適用（新フィールドなし、クライアント配線のみ）:
+- `cellHeaderStyle.ts`: `terminalHeaderStyleFor(bg, text, button)` を追加。
+- `Terminal.vue`: `dirHeaderColor` / `dirHeaderTextColor` / `dirButtonColor` props を
+  追加、`.header` に `:style`、`.header` 背景・文字と `.icon-btn` 色を変数参照に。
+- `TerminalCell.vue` / `App.vue`: dirConfig の header 色を props で渡す。
+
 ## テスト
 - `server/dir-config.spec.ts`: 4 フィールドの読み込み（EMPTY / full config / public）。
-- `src/components/cellHeaderStyle.spec.ts`: `cellStyleFor` のマッピング / 一部 / 空 / 非hex。
+- `src/components/cellHeaderStyle.spec.ts`: `cellStyleFor` / `terminalHeaderStyleFor`。
 - `src/components/TerminalCell.spec.ts`: dir-config の 4 色が `.cell` に CSS変数として載る。
-- `README.md`: 表に 4 行追加。
+- `README.md`: 表に 4 行追加 + header 色の説明を両ヘッダー対応に更新。

--- a/plans/feat-281-cell-appearance-colors.md
+++ b/plans/feat-281-cell-appearance-colors.md
@@ -1,0 +1,25 @@
+# feat #281: セル本体背景・ボーダー・ドット・ボタン色を .mulmoterminal.json で指定
+
+#279 / #280（ヘッダー色）に続く追加。ユーザー選択の「セル本体・ボーダー」「細部
+（ドット/ボタン）」を対応。#280 の `feat/cell-header-colors` に stack。
+
+## 追加フィールド（`#rrggbb` / `sanitizeColor`）
+- `cellColor` — セル本体背景（`.cell`）
+- `cellBorderColor` — セル枠線
+- `dotColor` — idle ステータスドット
+- `buttonColor` — ヘッダーのアイコンボタン
+
+## 実装
+- `server/dir-config.ts` / `src/composables/useDirConfig.ts`: 4 フィールド追加。
+- `src/components/cellHeaderStyle.ts`: `cellStyleFor(bg, border, dot, button)` を追加
+  （CSS変数 `--cell-bg`/`--cell-border`/`--cell-dot`/`--cell-btn`、非hexは破棄）。
+- `src/components/TerminalCell.vue`: `.cell` ルートに `:style="cellStyle"`。
+  - `.cell` background/border、`.cell-dot` background、`.cell-btn` color を変数参照に。
+  - status frame（`.cell.is-*`）と status dot（`.cell-dot.is-*`）は活動中に上書き＝
+    フィードバック維持。custom は idle 時。
+
+## テスト
+- `server/dir-config.spec.ts`: 4 フィールドの読み込み（EMPTY / full config / public）。
+- `src/components/cellHeaderStyle.spec.ts`: `cellStyleFor` のマッピング / 一部 / 空 / 非hex。
+- `src/components/TerminalCell.spec.ts`: dir-config の 4 色が `.cell` に CSS変数として載る。
+- `README.md`: 表に 4 行追加。

--- a/server/dir-config.spec.ts
+++ b/server/dir-config.spec.ts
@@ -5,7 +5,19 @@ import path from "node:path";
 import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile } from "./dir-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
-const EMPTY = { name: null, badgeColor: null, headerColor: null, headerTextColor: null, theme: null, colors: null, sound: null };
+const EMPTY = {
+  name: null,
+  badgeColor: null,
+  headerColor: null,
+  headerTextColor: null,
+  cellColor: null,
+  cellBorderColor: null,
+  dotColor: null,
+  buttonColor: null,
+  theme: null,
+  colors: null,
+  sound: null,
+};
 
 function withConfig(body: unknown): { dir: string; cleanup: () => void } {
   const dir = tmp();
@@ -92,6 +104,10 @@ describe("loadDirConfig", () => {
       badgeColor: "#CF222E",
       headerColor: "#190A23",
       headerTextColor: "#FFFFFF",
+      cellColor: "#101014",
+      cellBorderColor: "#2A2A4E",
+      dotColor: "#00E676",
+      buttonColor: "#C7CDF0",
       theme: "nord",
       sound: "./a.mp3",
     });
@@ -101,6 +117,10 @@ describe("loadDirConfig", () => {
       badgeColor: "#cf222e",
       headerColor: "#190a23",
       headerTextColor: "#ffffff",
+      cellColor: "#101014",
+      cellBorderColor: "#2a2a4e",
+      dotColor: "#00e676",
+      buttonColor: "#c7cdf0",
       theme: "nord",
       colors: null,
       sound: path.join(dir, "a.mp3"),
@@ -162,7 +182,19 @@ describe("publicDirConfig / dirSoundFile", () => {
   it("exposes hasSound but not the raw path", () => {
     const { dir, cleanup } = withConfig({ name: "x", sound: "./a.mp3" });
     writeFileSync(path.join(dir, "a.mp3"), "x");
-    expect(publicDirConfig(dir)).toEqual({ name: "x", badgeColor: null, headerColor: null, headerTextColor: null, theme: null, colors: null, hasSound: true });
+    expect(publicDirConfig(dir)).toEqual({
+      name: "x",
+      badgeColor: null,
+      headerColor: null,
+      headerTextColor: null,
+      cellColor: null,
+      cellBorderColor: null,
+      dotColor: null,
+      buttonColor: null,
+      theme: null,
+      colors: null,
+      hasSound: true,
+    });
     expect(dirSoundFile(dir)).toBe(path.join(dir, "a.mp3"));
     cleanup();
   });

--- a/server/dir-config.ts
+++ b/server/dir-config.ts
@@ -55,6 +55,12 @@ export interface DirConfig {
   // palette) — these tint the chrome around the terminal, not the terminal itself.
   headerColor: string | null;
   headerTextColor: string | null;
+  // The cell frame + accents (grid cell): body background, border, the idle status
+  // dot, and the header's icon buttons. Hex #rrggbb or null for the theme default.
+  cellColor: string | null;
+  cellBorderColor: string | null;
+  dotColor: string | null;
+  buttonColor: string | null;
   theme: ThemeId | null;
   // Per-key xterm palette overrides (on top of `theme`), or null when none are valid.
   colors: Record<string, string> | null;
@@ -70,6 +76,10 @@ export interface PublicDirConfig {
   badgeColor: string | null;
   headerColor: string | null;
   headerTextColor: string | null;
+  cellColor: string | null;
+  cellBorderColor: string | null;
+  dotColor: string | null;
+  buttonColor: string | null;
   theme: ThemeId | null;
   colors: Record<string, string> | null;
   hasSound: boolean;
@@ -123,7 +133,19 @@ export function resolveDirSound(cwd: string, input: unknown): string | null {
   return resolved;
 }
 
-const EMPTY: DirConfig = { name: null, badgeColor: null, headerColor: null, headerTextColor: null, theme: null, colors: null, sound: null };
+const EMPTY: DirConfig = {
+  name: null,
+  badgeColor: null,
+  headerColor: null,
+  headerTextColor: null,
+  cellColor: null,
+  cellBorderColor: null,
+  dotColor: null,
+  buttonColor: null,
+  theme: null,
+  colors: null,
+  sound: null,
+};
 
 export function loadDirConfig(cwd: string): DirConfig {
   try {
@@ -137,6 +159,10 @@ export function loadDirConfig(cwd: string): DirConfig {
       badgeColor: sanitizeColor(raw.badgeColor),
       headerColor: sanitizeColor(raw.headerColor),
       headerTextColor: sanitizeColor(raw.headerTextColor),
+      cellColor: sanitizeColor(raw.cellColor),
+      cellBorderColor: sanitizeColor(raw.cellBorderColor),
+      dotColor: sanitizeColor(raw.dotColor),
+      buttonColor: sanitizeColor(raw.buttonColor),
       theme: isThemeId(raw.theme) ? raw.theme : null,
       colors: sanitizeColors(raw.colors),
       sound: resolveDirSound(base, raw.sound),
@@ -147,8 +173,8 @@ export function loadDirConfig(cwd: string): DirConfig {
 }
 
 export function publicDirConfig(cwd: string): PublicDirConfig {
-  const { name, badgeColor, headerColor, headerTextColor, theme, colors, sound } = loadDirConfig(cwd);
-  return { name, badgeColor, headerColor, headerTextColor, theme, colors, hasSound: sound !== null };
+  const { name, badgeColor, headerColor, headerTextColor, cellColor, cellBorderColor, dotColor, buttonColor, theme, colors, sound } = loadDirConfig(cwd);
+  return { name, badgeColor, headerColor, headerTextColor, cellColor, cellBorderColor, dotColor, buttonColor, theme, colors, hasSound: sound !== null };
 }
 
 export function dirSoundFile(cwd: string): string | null {

--- a/src/App.vue
+++ b/src/App.vue
@@ -318,6 +318,9 @@ function onSession(id: string) {
           :dir-colors="singleDirConfig.colors"
           :dir-name="singleDirConfig.name"
           :dir-badge-color="singleDirConfig.badgeColor"
+          :dir-header-color="singleDirConfig.headerColor"
+          :dir-header-text-color="singleDirConfig.headerTextColor"
+          :dir-button-color="singleDirConfig.buttonColor"
           run-menu
           @session="onSession"
           @cwd="(c) => (activeCwd = c)"

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -4,6 +4,7 @@ import { type ITheme } from "@xterm/xterm";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
 import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
 import { badgeStyleFor } from "./dirBadge";
+import { terminalHeaderStyleFor } from "./cellHeaderStyle";
 import { useVoiceInput } from "../composables/useVoiceInput";
 import { useGitStatus } from "../composables/useGitStatus";
 import * as conn from "../composables/useTerminalConnections";
@@ -51,6 +52,11 @@ const props = defineProps<{
   dirColors?: Partial<ITheme> | null;
   dirName?: string | null;
   dirBadgeColor?: string | null;
+  // The header row's own colors (matches the grid cell's row-1 header): background,
+  // text, and the icon buttons. Hex #rrggbb or null for the theme default.
+  dirHeaderColor?: string | null;
+  dirHeaderTextColor?: string | null;
+  dirButtonColor?: string | null;
 }>();
 const emit = defineEmits<{
   (e: "session" | "cwd", value: string): void;
@@ -94,6 +100,7 @@ function effectiveTermTheme(): ITheme {
   return props.dirColors ? { ...base, ...props.dirColors } : base;
 }
 const dirBadgeStyle = computed(() => badgeStyleFor(props.dirBadgeColor));
+const headerStyle = computed(() => terminalHeaderStyleFor(props.dirHeaderColor, props.dirHeaderTextColor, props.dirButtonColor));
 
 // Voice input: a mic in the header transcribes speech (locally, via whisper.cpp)
 // and inserts it at the prompt for the user to review and submit — same channel as
@@ -231,7 +238,7 @@ onUnmounted(() => {
 
 <template>
   <div class="terminal-wrapper">
-    <div v-if="!hideHeader" class="header">
+    <div v-if="!hideHeader" class="header" :style="headerStyle">
       <span class="title">Terminal</span>
       <span v-if="dirName" class="dir-badge" :style="dirBadgeStyle" :title="dirName">{{ dirName }}</span>
       <GitBranchChip :status="gitStatus" />
@@ -282,8 +289,10 @@ onUnmounted(() => {
 
 .header {
   padding: 8px 16px;
-  background: var(--bg-panel);
-  color: var(--text);
+  /* Per-dir overrides via .mulmoterminal.json (headerColor/headerTextColor); matches
+     the grid cell's row-1 header so both header rows share the look. */
+  background: var(--cell-header-bg, var(--bg-panel));
+  color: var(--cell-header-fg, var(--text));
   font-family: system-ui, sans-serif;
   font-size: 14px;
   display: flex;
@@ -322,7 +331,7 @@ onUnmounted(() => {
   background: transparent;
   border: none;
   border-radius: 4px;
-  color: var(--text-muted);
+  color: var(--cell-btn, var(--text-muted));
   cursor: pointer;
 }
 

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -1302,6 +1302,23 @@ describe("TerminalCell", () => {
     expect(style).toContain("--cell-header-fg: #ffffff");
   });
 
+  it("applies cellColor/cellBorderColor/dotColor/buttonColor as cell-root CSS vars", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/dir-config"))
+        return { ok: true, json: async () => ({ cellColor: "#101014", cellBorderColor: "#2a2a4e", dotColor: "#00e676", buttonColor: "#c7cdf0" }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/cell-accent" });
+    await flushPromises();
+    const style = w.find(".cell").attributes("style") ?? "";
+    expect(style).toContain("--cell-bg: #101014");
+    expect(style).toContain("--cell-border: #2a2a4e");
+    expect(style).toContain("--cell-dot: #00e676");
+    expect(style).toContain("--cell-btn: #c7cdf0");
+  });
+
   it("tints a preset chip whose dir already has a running session elsewhere", () => {
     const w = mountCell(null, {
       presets: [

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -860,6 +860,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :codex="agent === 'codex'"
         :dir-theme="dirConfig.theme"
         :dir-colors="dirConfig.colors"
+        :dir-header-color="dirConfig.headerColor"
+        :dir-header-text-color="dirConfig.headerTextColor"
+        :dir-button-color="dirConfig.buttonColor"
         :hide-header="filmstrip"
         dev-terminal
         run-menu

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -6,7 +6,7 @@ import { useDirConfig } from "../composables/useDirConfig";
 import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
-import { headerStyleFor } from "./cellHeaderStyle";
+import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 import GitBranchChip from "./GitBranchChip.vue";
 import ModelContextBadge from "./ModelContextBadge.vue";
 import TimelineOverlay from "./TimelineOverlay.vue";
@@ -93,6 +93,9 @@ const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
 const { config: dirConfig } = useDirConfig(cwd);
 const dirBadgeStyle = computed(() => badgeStyleFor(dirConfig.value.badgeColor));
 const headerStyle = computed(() => headerStyleFor(dirConfig.value.headerColor, dirConfig.value.headerTextColor));
+const cellStyle = computed(() =>
+  cellStyleFor(dirConfig.value.cellColor, dirConfig.value.cellBorderColor, dirConfig.value.dotColor, dirConfig.value.buttonColor),
+);
 // Live git status (branch/dirty/ahead·behind) for the header chip. `refreshGit`
 // is called alongside loadDiff() so a finished turn's changes show immediately.
 const { status: gitStatus, refresh: refreshGit } = useGitStatus(cwd);
@@ -810,7 +813,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 </script>
 
 <template>
-  <div class="cell" :class="statusClass">
+  <div class="cell" :class="statusClass" :style="cellStyle">
     <template v-if="launched">
       <!-- Row 1 — INFO only: dir + git + model/token + what it's doing. Every icon
            BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
@@ -1114,8 +1117,10 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  background: var(--bg-base);
-  border: 1px solid var(--border);
+  /* Per-dir overrides via .mulmoterminal.json (cellColor/cellBorderColor); the status
+     frame below still wins the border while working/blocked. */
+  background: var(--cell-bg, var(--bg-base));
+  border: 1px solid var(--cell-border, var(--border));
   border-radius: 6px;
   overflow: hidden;
 }
@@ -1173,7 +1178,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  background: var(--text-dim);
+  /* Custom color tints the idle dot; the status classes below override it while
+     working/waiting so the activity signal stays intact. */
+  background: var(--cell-dot, var(--text-dim));
 }
 .cell-dot.is-working {
   background: var(--accent);
@@ -1328,7 +1335,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   height: 26px;
   border: none;
   background: transparent;
-  color: var(--text-secondary);
+  color: var(--cell-btn, var(--text-secondary));
   cursor: pointer;
   font-size: 16px;
   line-height: 1;

--- a/src/components/cellHeaderStyle.spec.ts
+++ b/src/components/cellHeaderStyle.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { headerStyleFor } from "./cellHeaderStyle";
+import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 
 describe("headerStyleFor", () => {
   it("maps a background + text color to the header CSS variables", () => {
@@ -22,5 +22,29 @@ describe("headerStyleFor", () => {
     expect(headerStyleFor("red", "rgb(1,2,3)")).toEqual({});
     expect(headerStyleFor("#fff", "#12345")).toEqual({}); // wrong length
     expect(headerStyleFor("javascript:alert(1)", "#000000")).toEqual({ "--cell-header-fg": "#000000" });
+  });
+});
+
+describe("cellStyleFor", () => {
+  it("maps body / border / dot / button colors to the cell CSS variables", () => {
+    expect(cellStyleFor("#101014", "#2a2a4e", "#00e676", "#c7cdf0")).toEqual({
+      "--cell-bg": "#101014",
+      "--cell-border": "#2a2a4e",
+      "--cell-dot": "#00e676",
+      "--cell-btn": "#c7cdf0",
+    });
+  });
+
+  it("emits only the variables that are set", () => {
+    expect(cellStyleFor(null, "#2a2a4e", null, null)).toEqual({ "--cell-border": "#2a2a4e" });
+    expect(cellStyleFor("#101014", null, null, null)).toEqual({ "--cell-bg": "#101014" });
+  });
+
+  it("returns an empty style when nothing is configured", () => {
+    expect(cellStyleFor(null, undefined, null, undefined)).toEqual({});
+  });
+
+  it("drops non-hex values", () => {
+    expect(cellStyleFor("blue", "#12", "rgb(0,0,0)", "#abcdef")).toEqual({ "--cell-btn": "#abcdef" });
   });
 });

--- a/src/components/cellHeaderStyle.spec.ts
+++ b/src/components/cellHeaderStyle.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
+import { headerStyleFor, cellStyleFor, terminalHeaderStyleFor } from "./cellHeaderStyle";
 
 describe("headerStyleFor", () => {
   it("maps a background + text color to the header CSS variables", () => {
@@ -46,5 +46,20 @@ describe("cellStyleFor", () => {
 
   it("drops non-hex values", () => {
     expect(cellStyleFor("blue", "#12", "rgb(0,0,0)", "#abcdef")).toEqual({ "--cell-btn": "#abcdef" });
+  });
+});
+
+describe("terminalHeaderStyleFor", () => {
+  it("reuses the header bg/fg vars and adds the button var", () => {
+    expect(terminalHeaderStyleFor("#241640", "#ffd166", "#4dd0e1")).toEqual({
+      "--cell-header-bg": "#241640",
+      "--cell-header-fg": "#ffd166",
+      "--cell-btn": "#4dd0e1",
+    });
+  });
+
+  it("emits only the set + valid vars", () => {
+    expect(terminalHeaderStyleFor("#241640", null, "nope")).toEqual({ "--cell-header-bg": "#241640" });
+    expect(terminalHeaderStyleFor(null, null, null)).toEqual({});
   });
 });

--- a/src/components/cellHeaderStyle.ts
+++ b/src/components/cellHeaderStyle.ts
@@ -13,3 +13,21 @@ export function headerStyleFor(background: string | null | undefined, text: stri
   if (isHex(text)) style["--cell-header-fg"] = text;
   return style;
 }
+
+// Inline CSS custom properties for the cell frame + accents, set on the cell root so
+// descendants inherit them: body background, border, the idle status dot, and the
+// header's icon buttons. Like the header vars, the status frame/dot still override
+// their targets while working/blocked so activity feedback is preserved.
+export function cellStyleFor(
+  background: string | null | undefined,
+  border: string | null | undefined,
+  dot: string | null | undefined,
+  button: string | null | undefined,
+): Record<string, string> {
+  const style: Record<string, string> = {};
+  if (isHex(background)) style["--cell-bg"] = background;
+  if (isHex(border)) style["--cell-border"] = border;
+  if (isHex(dot)) style["--cell-dot"] = dot;
+  if (isHex(button)) style["--cell-btn"] = button;
+  return style;
+}

--- a/src/components/cellHeaderStyle.ts
+++ b/src/components/cellHeaderStyle.ts
@@ -31,3 +31,16 @@ export function cellStyleFor(
   if (isHex(button)) style["--cell-btn"] = button;
   return style;
 }
+
+// The Terminal component's own header row (the grid cell's row 2 and the single view's
+// header) reuses the same header colors + button color, via the same CSS vars, so both
+// header rows match. Emitted on that header element.
+export function terminalHeaderStyleFor(
+  background: string | null | undefined,
+  text: string | null | undefined,
+  button: string | null | undefined,
+): Record<string, string> {
+  const style = headerStyleFor(background, text);
+  if (isHex(button)) style["--cell-btn"] = button;
+  return style;
+}

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -12,13 +12,30 @@ export interface DirConfig {
   // to keep the theme default. Distinct from `colors` (the xterm palette).
   headerColor: string | null;
   headerTextColor: string | null;
+  // The cell frame + accents (body background, border, idle status dot, header buttons).
+  cellColor: string | null;
+  cellBorderColor: string | null;
+  dotColor: string | null;
+  buttonColor: string | null;
   theme: ThemeId | null;
   // Per-key xterm palette overrides applied on top of `theme` (or the app theme).
   colors: Partial<ITheme> | null;
   hasSound: boolean;
 }
 
-const EMPTY: DirConfig = { name: null, badgeColor: null, headerColor: null, headerTextColor: null, theme: null, colors: null, hasSound: false };
+const EMPTY: DirConfig = {
+  name: null,
+  badgeColor: null,
+  headerColor: null,
+  headerTextColor: null,
+  cellColor: null,
+  cellBorderColor: null,
+  dotColor: null,
+  buttonColor: null,
+  theme: null,
+  colors: null,
+  hasSound: false,
+};
 
 // The ITheme keys a dir may override; values arrive server-sanitized but are
 // re-checked here so a hand-rolled response can't widen the terminal options.
@@ -72,6 +89,10 @@ function parse(c: unknown): DirConfig {
     badgeColor: typeof c.badgeColor === "string" ? c.badgeColor : null,
     headerColor: typeof c.headerColor === "string" ? c.headerColor : null,
     headerTextColor: typeof c.headerTextColor === "string" ? c.headerTextColor : null,
+    cellColor: typeof c.cellColor === "string" ? c.cellColor : null,
+    cellBorderColor: typeof c.cellBorderColor === "string" ? c.cellBorderColor : null,
+    dotColor: typeof c.dotColor === "string" ? c.dotColor : null,
+    buttonColor: typeof c.buttonColor === "string" ? c.buttonColor : null,
     theme: isThemeId(c.theme) ? c.theme : null,
     colors: parseColors(c.colors),
     hasSound: c.hasSound === true,


### PR DESCRIPTION
## Summary
#280（ヘッダー色）に続く追加。`.mulmoterminal.json` に **`cellColor`（セル本体背景）**・**`cellBorderColor`（枠線）**・**`dotColor`（idle ドット）**・**`buttonColor`（ヘッダーのアイコンボタン）** を追加し、grid セルの見た目を dir ごとに色付けできるようにした。

> **Note**: base は `feat/cell-header-colors`（#280）に stack。#280 が main にマージされたら本PRの base は自動で main に更新されます。

Closes #281 / 親 #279

## Items to Confirm / Review
- **status との関係**: セルの枠線は working/blocked の status frame が活動中に上書き、ドットも working/waiting は据え置き。**カスタムの枠線・ドットは idle 時のみ**（活動フィードバックを優先）。この挙動でよいか。
- `dotColor` は idle ドットのみ変更。`buttonColor` はヘッダーアイコン全体。
- CSS変数（`--cell-bg` / `--cell-border` / `--cell-dot` / `--cell-btn`）を `.cell` ルートに inline 適用、子孫が継承。

## User Prompt
> 他、いろんなところをできるだけカスタマイズできるようにしてね。
>（選択: セル本体・ボーダー / 細部（ドット・ボタン））

## テスト
- `server/dir-config.spec.ts`: 4 フィールドの読み込み（EMPTY / full config / public）。
- `src/components/cellHeaderStyle.spec.ts`: `cellStyleFor` のマッピング / 一部 / 空 / 非hex破棄。
- `src/components/TerminalCell.spec.ts`: dir-config の 4 色が `.cell` に CSS変数として載る。
- README 更新。lint / typecheck / build / 該当スペック green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)