### PR TITLE
feat: configurable terminal header — action buttons (input/open) + /api/header

### DIFF
--- a/plans/feat-header-toolbar-config.md
+++ b/plans/feat-header-toolbar-config.md
@@ -1,0 +1,204 @@
+# Feature: Configurable terminal header — action buttons + display chips
+
+Status: **spec (for review)**. This document is the design; implementation follows once it's approved.
+
+## User Prompt (consolidated)
+
+> The two terminal headers show various data. I'd like to make that data manageable — via JSON,
+> and via a simple DSL so a user can add things. For example a button = an emoji + a command to run
+> + arguments (dir name, git branch, git repo, LLM model, codex-or-claude, …).
+>
+> By "header" I mean the **terminal's** header — dir name, the context amount, opening the dir, the
+> tools-history part. This is about the **already-running** terminal, not session launch. So a button
+> runs a command using the running session's context as variables (not spawning a new session).
+>
+> There is already a `.mulmoterminal.json` — merge the settings into that rather than a new file.
+> For "open" actions, don't miss the OS/open features that already exist (reveal in Finder, in-app
+> file explorer, in-app views), not just URLs.
+
+## Goal
+
+Let users **configure and extend the running terminal's header** through config files (JSON, canonical)
+and a **1-line DSL** (sugar). Two parts:
+
+- **(A) Action buttons** — emoji + an action (run in dir / send to session / open something), templated
+  with the running session's context.
+- **(B) Display chips** — read-only info in the header: toggle / reorder the built-ins, and define custom
+  chips that show a value.
+
+Session **launch** (agent/model/worktree at spawn time) is explicitly **out of scope** — this is about a
+terminal that is already running.
+
+## Current state (grounding)
+
+**Terminal header (`Terminal.vue .header`, all views):** `Terminal` label · dir badge (name/color) ·
+`GitBranchChip` (branch/dirty) · connection status · `RunMenu` (▶, from `script.json`) · 🎤 voice · 📎
+insert-file-path · 📂 `folder_open` (in-app file explorer).
+
+**Grid cell header (`TerminalCell .cell-header`, overlaid in grid):** status dot · dir badge · worktree
+diff (`+ahead ●dirty`) · **`ModelContextBadge` (model · ctx%)** · usage (`$`/tokens) · Run · Files ·
+zoom · close.
+
+**Tools history:** `ToolsPane.vue` (right pane, toggled) — Tool Call History (every tool call) + Available
+Tools.
+
+All of the above is **hardcoded** — no user toggle / reorder / add.
+
+**Existing config files (reused, not replaced):**
+
+| Scope | File | Loader | Holds today |
+|---|---|---|---|
+| Project (per-dir) | `<cwd>/.mulmoterminal.json` | `server/dir-config.ts` (`DirConfig`) | `name`, `badgeColor`, `theme`, `colors`, `sound` |
+| Global | `~/.mulmoterminal/config.json` | `server/app-config.ts` (`AppConfig`) | `cwdPresets`, `soundFile`, `prRepos`, `launchers`, `userMcpServers` |
+| Project (per-dir) | `<cwd>/script.json` | `server/scripts.ts` | `scripts: [{label, command, cwd?}]` → Run menu |
+
+**Existing "open" capabilities (reused by `run:open`, see below):** reveal a dir in Finder/OS
+(`server/open-dir.ts`), in-app file explorer (`filesGotoIndex` → `FilesOverlay`), URL in browser
+(`pluginRuntime.openUrl`, http/https allowlist), in-app views (diff / PRs / wiki / collections /
+accounting).
+
+**Existing launch-arg builders (referenced by the run:input security note):** `server/claude-args.ts`,
+`server/codex-args.ts`.
+
+---
+
+## Design
+
+### (A) Action buttons
+
+```jsonc
+// run: "shell" — run a command in this terminal's dir, as a separate process (like today's Run menu)
+{ "id": "pr", "emoji": "🔀", "label": "PR",
+  "run": "shell", "cmd": "gh pr create --head ${branch}", "when": "isGitRepo" }
+
+// run: "input" — type/send text into the RUNNING claude/codex session (like the draft/paste path)
+{ "id": "compact", "emoji": "🗜", "label": "Compact",
+  "run": "input", "text": "/compact", "when": "agent == claude" }
+
+// run: "open" — open something (targets below); NOT just URLs
+{ "id": "gh",     "emoji": "🌐", "label": "GitHub", "run": "open", "open": { "url": "https://github.com/${repo}" }, "when": "isGitRepo" }
+{ "id": "reveal", "emoji": "📁", "label": "Finder", "run": "open", "open": { "reveal": "${dir}" } }
+{ "id": "files",  "emoji": "🗂",  "label": "Files",  "run": "open", "open": { "files":  "${dir}" } }
+{ "id": "diff",   "emoji": "±",  "label": "Diff",   "run": "open", "open": { "view":   "diff" }, "when": "isGitRepo" }
+```
+
+**Fields:** `id` (stable merge key) · `emoji` (or `icon` for a material-symbol) · `label` (tooltip / visible
+text) · `run` (`shell` | `input` | `open`) · payload by run type (`cmd` / `text` / `open`) · `when`
+(visibility) · optional `order`.
+
+**`run: "open"` targets** (all reuse existing code — no new OS integration for v1):
+
+| target | opens | reuses |
+|---|---|---|
+| `{ "url": "…" }` | URL in the browser (http/https only) | `pluginRuntime.openUrl` |
+| `{ "reveal": "path" }` | the dir in Finder / OS file manager | `server/open-dir.ts` |
+| `{ "files": "path" }` | the in-app file explorer / editor | `filesGotoIndex` / `FilesOverlay` |
+| `{ "view": "diff\|prs\|wiki\|collections\|accounting" }` | an in-app view | existing overlays / routes |
+
+(External-editor launch, e.g. `vscode://`, is **v2** — the current URL allowlist is http/https only.)
+
+**`when` (visibility, v1):** `isGitRepo` · `agent == claude|codex` · `repo == owner/name`, combinable with
+`&&` / `||`. Evaluated per session from its live context; a button whose `when` is false is not shown.
+
+### (B) Display chips
+
+```jsonc
+"chips": [
+  "dir", "git", "ctx",                                        // built-in ids, in this order (usage/status dropped)
+  { "label": "↑↓",   "text": "↑${ahead} ↓${behind}", "when": "isGitRepo" },   // custom, display-only
+  { "label": "repo", "text": "${repo}" }
+]
+```
+
+- **Built-in chip ids:** `dir` · `git` · `ctx` · `usage` · `status` · `diff` · `tools`.
+- **Toggle + reorder:** the array picks which built-ins show and in what order.
+- **Custom chips:** `{ label, text, when? }` render a substituted string. Display-only (not clickable) —
+  this is the difference from a button.
+
+### Variables (v1)
+
+Substituted from the **running session's context** (server-resolved — the values are trusted app state,
+not user input, so v1 has no injection surface from `${input}`):
+
+`${dir}` · `${dirName}` · `${branch}` · `${repo}` · `${model}` · `${agent}` · `${session}` ·
+`${remoteUrl}` · `${dirty}` · `${ahead}` · `${behind}` · `${task}`
+
+### Simple DSL (1-line sugar → expands to the JSON above)
+
+```
+# button:  <emoji> <label> = [prefix]<spec>   [when <cond>]
+#   prefix: (none)=shell   > =input   @ =open
+🔀 PR      = gh pr create --head ${branch}     when isGitRepo
+🗜 Compact = > /compact                         when agent==claude
+🌐 GitHub  = @ https://github.com/${repo}       when isGitRepo
+📁 Finder  = @ reveal:${dir}
+🧹 Lint    = yarn lint
+
+# chips:
+chips: dir git ctx
+chip ↑↓ = ↑${ahead} ↓${behind}   when isGitRepo
+```
+
+The DSL is stored/edited as text and parsed to the JSON model; the settings UI can round-trip either form.
+
+### Storage & merge (extend existing files — no new files)
+
+- **Project:** add `buttons` / `chips` to `<cwd>/.mulmoterminal.json` (`DirConfig`) — sits next to the
+  existing per-dir `name`/`badgeColor`/`theme`/`sound`, and is commit-shareable.
+- **Global:** add `buttons` / `chips` to `~/.mulmoterminal/config.json` (`AppConfig`) — alongside
+  `launchers`/`presets`/…, applies to all terminals (use `when` to scope).
+- **Merge:** buttons merge by `id` (project overrides/adds over global); if a scope defines `chips`, it
+  replaces the other's chip list (last-wins: project over global).
+
+### `script.json` absorption
+
+`<cwd>/script.json` is per-dir shell commands — the same shape as a `run:"shell"` button. Consolidate:
+
+- Migrate `{label, command, cwd?}` → `{emoji?, label, run:"shell", cmd, dir?}` under
+  `.mulmoterminal.json.buttons`, so **per-dir config is one file**.
+- Transition: keep reading `script.json` and auto-bridge its entries to `run:"shell"` buttons; the ▶ Run
+  menu is replaced by those buttons and `script.json` is deprecated (removed after migration).
+
+### Security
+
+- `run:"shell"` / `run:"input"` go through the existing sanitize path (`sanitizeScripts`, the flag-smuggle
+  guards in `server/index.ts`). `run:"input"` injects into the PTY via the existing draft/paste mechanism.
+- `run:"open"` `url` keeps the http/https scheme allowlist; `reveal`/`files` resolve paths **inside the
+  session's cwd** (same confinement as `dir-config`/`FilesOverlay`).
+- Variables are server-resolved from trusted session state; v1 has no `${input}`, so no user-supplied
+  substitution.
+
+### v1 / v2
+
+- **v1:** buttons (`shell`/`input`/`open` with url/reveal/files/view targets) · extended variables ·
+  `when` · chips (toggle/reorder/custom) · global + project merge · `script.json` absorption.
+- **v2:** `${input:label}` interactive prompt on click · richer `when` operators · dynamic chips (chip
+  whose text is a command's output) · external-editor `open` (`vscode://` allowlist).
+
+---
+
+## Implementation sketch (affected areas)
+
+**Server**
+- `dir-config.ts`, `app-config.ts`: extend schemas with `buttons`/`chips` + sanitizers (validate `run`,
+  targets, `when`, cap counts, reject unknown fields).
+- New `header-config.ts`: merge global+project, parse/emit the DSL, and **resolve** a session's buttons/chips
+  (evaluate `when`, substitute variables) from its live context (cwd, git status, model, agent, session id).
+- `script.json` bridge in the resolver.
+- Endpoints: extend `config-routes.ts` (global) + the dir-config API; a per-session "resolved header" endpoint
+  or field so the client just renders + dispatches.
+- Reuse: `open-dir.ts` (reveal), `/ws/run`-style exec (shell), PTY input (input), git status source (`when`).
+
+**Client**
+- Render `buttons`/`chips` in `Terminal.vue` `.header` (and `TerminalCell .cell-header`), keeping the built-in
+  icons; dispatch on click: shell → run-in-dir, input → session input, open → `openUrl`/`filesGotoIndex`/route/
+  reveal.
+- Settings UI to edit buttons/chips (emoji picker, run-type dropdown, when field) with raw JSON + DSL editing.
+
+## Open questions (for review feedback)
+
+1. DSL grammar details (prefix set, `when` syntax) — OK as sketched, or prefer explicit keys?
+2. Chip merge: replace vs. append when both scopes define `chips`?
+3. Built-in chip id names (`dir`/`git`/`ctx`/`usage`/`status`/`diff`/`tools`) — good, or rename?
+4. Where the "resolved header" is computed — per-session server endpoint vs. client-side from data it already has?
+5. `script.json` removal timeline — auto-migrate on first read, or leave both until a manual migration?

--- a/plans/feat-header-toolbar-config.md
+++ b/plans/feat-header-toolbar-config.md
@@ -167,12 +167,21 @@ The DSL is stored/edited as text and parsed to the JSON model; the settings UI c
 - Transition: keep reading `script.json` and auto-bridge its entries to `run:"shell"` buttons; the ▶ Run
   menu is replaced by those buttons and `script.json` is deprecated (removed after migration).
 
-### Security
+### Security & trust boundary
 
-- `run:"shell"` / `run:"input"` go through the existing sanitize path (`sanitizeScripts`, the flag-smuggle
-  guards in `server/index.ts`). `run:"input"` injects into the PTY via the existing draft/paste mechanism.
-- `run:"open"` `url` keeps the http/https scheme allowlist; `reveal`/`files` resolve paths **inside the
-  session's cwd** (same confinement as `dir-config`/`FilesOverlay`).
+- `run:"shell"` is **not dispatched yet**: resolved shell buttons are dropped server-side until an
+  id-based, **argv-based** exec route lands (templated `${var}` values are never interpolated into
+  `shell -lc`). `run:"input"` injects into the PTY via the existing draft/paste mechanism.
+- `run:"open"` `url` keeps the http/https scheme allowlist. `/api/open-dir` (reveal) already enforces
+  same-origin + absolute path + `isDirectory` + argv (no shell).
+- **`reveal`/`files` paths are intentionally NOT confined to the session cwd** (accepted trust boundary).
+  Per-project `.mulmoterminal.json` is the same trust surface as `script.json`, which already runs
+  arbitrary shell from `<cwd>`; revealing/listing a folder is strictly weaker, and revealing a sibling
+  worktree or related repo (`${dir}` is only the default) is a legitimate workflow. Opening an untrusted
+  repo in mulmoterminal already trusts its `script.json` — the header adds no capability beyond that.
+- Hardening against untrusted-repo config, if wanted, belongs in a **cross-cutting "trusted directories"
+  gate that also covers `script.json`**, not a header-only lexical/realpath check that would regress
+  worktree reveal while `script.json` stays open. Tracked as a separate follow-up.
 - Variables are server-resolved from trusted session state; v1 has no `${input}`, so no user-supplied
   substitution.
 

--- a/plans/feat-header-toolbar-config.md
+++ b/plans/feat-header-toolbar-config.md
@@ -29,6 +29,14 @@ and a **1-line DSL** (sugar). Two parts:
 Session **launch** (agent/model/worktree at spawn time) is explicitly **out of scope** — this is about a
 terminal that is already running.
 
+### Hard requirement: default (no config) == today
+
+With **no `buttons`/`chips` config anywhere**, the header must render and behave **exactly as it does
+today** — same built-in chips in the same order, same built-in buttons (🎤/📎/📂), same ▶ Run menu. Config
+is **purely additive/overriding**: `chips` absent ⇒ the client uses its current hardcoded default set;
+`buttons` absent ⇒ only the current built-in buttons show; `script.json` still works until migrated. The
+resolver signals "unconfigured" (`chips: null`, `buttons: []`) so the client falls back to today's UI.
+
 ## Current state (grounding)
 
 **Terminal header (`Terminal.vue .header`, all views):** `Terminal` label · dir badge (name/color) ·

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -77,7 +77,7 @@ describe("sanitizeUserMcpServers", () => {
 });
 
 describe("loadAppConfig / saveAppConfig", () => {
-  const base = { cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [] };
+  const base = { cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [], buttons: [], chips: null };
   it("round-trips presets + soundFile + prRepos + launchers + userMcpServers through a file", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
@@ -87,6 +87,8 @@ describe("loadAppConfig / saveAppConfig", () => {
       prRepos: ["o/r"],
       launchers: [{ label: "Shell", command: "$SHELL" }],
       userMcpServers: [{ id: "weather", url: "http://localhost:9000/mcp" }],
+      buttons: [{ id: "pr", label: "PR", run: "shell" as const, cmd: "gh pr create" }],
+      chips: ["dir", "git"],
     };
     expect(saveAppConfig(file, cfg)).toBe(true);
     expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(cfg);
@@ -122,6 +124,8 @@ describe("loadAppConfig / saveAppConfig", () => {
       prRepos: ["o/r"],
       launchers: [{ label: "S", command: "sh" }],
       userMcpServers: [{ id: "ok", url: "https://x/mcp" }],
+      buttons: [],
+      chips: null,
     });
     rmSync(dir, { recursive: true, force: true });
   });

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -5,6 +5,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets, type CwdPreset } from "./cwd-presets.js";
+import { sanitizeButtons, sanitizeChips, type HeaderButton, type HeaderChip } from "./header-config.js";
 
 // A named program a grid cell can launch instead of Claude (a plain shell, codex,
 // any interactive command). `command` is run on the user's own machine as an
@@ -34,6 +35,10 @@ export interface AppConfig {
   launchers: Launcher[];
   // User-added HTTP MCP servers merged into the single-view session's --mcp-config.
   userMcpServers: UserMcpServer[];
+  // Global terminal-header action buttons; applied to every terminal (scoped with `when`).
+  buttons: HeaderButton[];
+  // Global header display chips, or null when unconfigured (the client keeps its default set).
+  chips: HeaderChip[] | null;
 }
 
 // `id` becomes an MCP server name + `mcp__<id>` tool prefix, so restrict to a plain
@@ -110,7 +115,7 @@ export function sanitizeSoundFile(input: unknown): string | null {
 
 // Fresh object each call — callers hold and mutate the returned config in place, so a
 // shared default constant would be corrupted across loads.
-const emptyConfig = (): AppConfig => ({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [] });
+const emptyConfig = (): AppConfig => ({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [], buttons: [], chips: null });
 
 export function loadAppConfig(file: string): AppConfig {
   try {
@@ -122,6 +127,8 @@ export function loadAppConfig(file: string): AppConfig {
       prRepos: sanitizeRepos(raw?.prRepos),
       launchers: sanitizeLaunchers(raw?.launchers),
       userMcpServers: sanitizeUserMcpServers(raw?.userMcpServers),
+      buttons: sanitizeButtons(raw?.buttons),
+      chips: sanitizeChips(raw?.chips),
     };
   } catch {
     return emptyConfig();
@@ -139,6 +146,8 @@ export function saveAppConfig(file: string, config: AppConfig): boolean {
       prRepos: config.prRepos,
       launchers: config.launchers,
       userMcpServers: config.userMcpServers,
+      buttons: config.buttons,
+      chips: config.chips,
     };
     writeFileSync(file, JSON.stringify(payload, null, 2));
     return true;

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -64,16 +64,21 @@ function badChipsField(body: Record<string, unknown>): boolean {
 }
 
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
+  // The live config as the API exposes it, so a client (e.g. a settings UI) can read back
+  // everything it can write — buttons/chips included — and round-trip it.
+  const configResponse = () => ({
+    cwd: claudeCwd,
+    cwdPresets: config.cwdPresets,
+    soundFile: config.soundFile,
+    prRepos: config.prRepos,
+    launchers: config.launchers,
+    userMcpServers: config.userMcpServers,
+    buttons: config.buttons,
+    chips: config.chips,
+  });
+
   app.get("/api/config", (_req, res) => {
-    res.json({
-      cwd: claudeCwd,
-      cwdPresets: config.cwdPresets,
-      soundFile: config.soundFile,
-      prRepos: config.prRepos,
-      launchers: config.launchers,
-      userMcpServers: config.userMcpServers,
-      home: os.homedir(),
-    });
+    res.json({ ...configResponse(), home: os.homedir() });
   });
 
   app.post("/api/config", (req, res) => {
@@ -96,14 +101,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     // leave GET exposing values that won't survive a restart.
     if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });
     config = next;
-    res.json({
-      cwd: claudeCwd,
-      cwdPresets: config.cwdPresets,
-      soundFile: config.soundFile,
-      prRepos: config.prRepos,
-      launchers: config.launchers,
-      userMcpServers: config.userMcpServers,
-    });
+    res.json(configResponse());
   });
 
   // Stream the user's custom attention sound (their own file, set in config). The

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -57,6 +57,12 @@ function badArrayField(body: Record<string, unknown>): string | null {
   return null;
 }
 
+// `chips` is nullable (null = unconfigured), so it can't join ARRAY_FIELDS: reject any present value that
+// is neither an array nor null instead of letting sanitizeChips silently coerce it to null (erasing config).
+function badChipsField(body: Record<string, unknown>): boolean {
+  return body.chips !== undefined && body.chips !== null && !Array.isArray(body.chips);
+}
+
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   app.get("/api/config", (_req, res) => {
     res.json({
@@ -76,6 +82,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     // wipe the presets (and vice-versa). cwdPresets, when present, must be an array.
     const badField = badArrayField(body);
     if (badField) return res.status(400).json({ error: `${badField} must be an array` });
+    if (badChipsField(body)) return res.status(400).json({ error: "chips must be an array or null" });
     const next: AppConfig = {
       cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : config.cwdPresets,
       soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : config.soundFile,

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -19,6 +19,7 @@ import {
   type Launcher,
   type UserMcpServer,
 } from "./app-config.js";
+import { sanitizeButtons, sanitizeChips, type HeaderConfig } from "./header-config.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -41,6 +42,21 @@ export function getUserMcpServers(): UserMcpServer[] {
   return config.userMcpServers;
 }
 
+// The global terminal-header buttons/chips — read live so /api/header reflects a config
+// change on the next fetch without a restart.
+export function getHeaderConfig(): HeaderConfig {
+  return { buttons: config.buttons, chips: config.chips };
+}
+
+// Body fields that must be an array when present (a partial POST /api/config may omit any).
+const ARRAY_FIELDS = ["cwdPresets", "prRepos", "launchers", "userMcpServers", "buttons"] as const;
+function badArrayField(body: Record<string, unknown>): string | null {
+  for (const field of ARRAY_FIELDS) {
+    if (body[field] !== undefined && !Array.isArray(body[field])) return field;
+  }
+  return null;
+}
+
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   app.get("/api/config", (_req, res) => {
     res.json({
@@ -58,24 +74,16 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     const body = req.body ?? {};
     // Partial update: keep the field the request omits so saving the sound doesn't
     // wipe the presets (and vice-versa). cwdPresets, when present, must be an array.
-    if (body.cwdPresets !== undefined && !Array.isArray(body.cwdPresets)) {
-      return res.status(400).json({ error: "cwdPresets must be an array" });
-    }
-    if (body.prRepos !== undefined && !Array.isArray(body.prRepos)) {
-      return res.status(400).json({ error: "prRepos must be an array" });
-    }
-    if (body.launchers !== undefined && !Array.isArray(body.launchers)) {
-      return res.status(400).json({ error: "launchers must be an array" });
-    }
-    if (body.userMcpServers !== undefined && !Array.isArray(body.userMcpServers)) {
-      return res.status(400).json({ error: "userMcpServers must be an array" });
-    }
+    const badField = badArrayField(body);
+    if (badField) return res.status(400).json({ error: `${badField} must be an array` });
     const next: AppConfig = {
       cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : config.cwdPresets,
       soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : config.soundFile,
       prRepos: body.prRepos !== undefined ? sanitizeRepos(body.prRepos) : config.prRepos,
       launchers: body.launchers !== undefined ? sanitizeLaunchers(body.launchers) : config.launchers,
       userMcpServers: body.userMcpServers !== undefined ? sanitizeUserMcpServers(body.userMcpServers) : config.userMcpServers,
+      buttons: body.buttons !== undefined ? sanitizeButtons(body.buttons) : config.buttons,
+      chips: body.chips !== undefined ? sanitizeChips(body.chips) : config.chips,
     };
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.

--- a/server/dir-config.spec.ts
+++ b/server/dir-config.spec.ts
@@ -17,6 +17,8 @@ const EMPTY = {
   theme: null,
   colors: null,
   sound: null,
+  buttons: [],
+  chips: null,
 };
 
 function withConfig(body: unknown): { dir: string; cleanup: () => void } {
@@ -124,6 +126,8 @@ describe("loadDirConfig", () => {
       theme: "nord",
       colors: null,
       sound: path.join(dir, "a.mp3"),
+      buttons: [],
+      chips: null,
     });
     cleanup();
   });

--- a/server/dir-config.ts
+++ b/server/dir-config.ts
@@ -6,6 +6,7 @@
 // clear home.
 import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import path from "node:path";
+import { sanitizeButtons, sanitizeChips, type HeaderButton, type HeaderChip } from "./header-config.js";
 
 // Mirrors the theme ids in src/composables/useTheme.ts. The server can't import the
 // Vue composable, so the whitelist is duplicated here — keep the two in sync.
@@ -67,6 +68,10 @@ export interface DirConfig {
   // Absolute path to the attention sound, resolved within cwd; null when unset or the
   // configured path is absolute / escapes the directory / doesn't exist.
   sound: string | null;
+  // Per-project terminal-header action buttons (merged over the global ones by id).
+  buttons: HeaderButton[];
+  // Per-project header display chips, or null when this dir doesn't configure them.
+  chips: HeaderChip[] | null;
 }
 
 // What the browser receives: the raw sound path stays server-side (streamed via
@@ -145,6 +150,8 @@ const EMPTY: DirConfig = {
   theme: null,
   colors: null,
   sound: null,
+  buttons: [],
+  chips: null,
 };
 
 export function loadDirConfig(cwd: string): DirConfig {
@@ -166,6 +173,8 @@ export function loadDirConfig(cwd: string): DirConfig {
       theme: isThemeId(raw.theme) ? raw.theme : null,
       colors: sanitizeColors(raw.colors),
       sound: resolveDirSound(base, raw.sound),
+      buttons: sanitizeButtons(raw.buttons),
+      chips: sanitizeChips(raw.chips),
     };
   } catch {
     return EMPTY;

--- a/server/header-config.spec.ts
+++ b/server/header-config.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeButtons, sanitizeChips, sanitizeHeaderConfig, mergeHeaderConfig, type HeaderConfig } from "./header-config.js";
+
+describe("sanitizeButtons", () => {
+  it("keeps a valid shell/input/open button with its matching payload", () => {
+    const out = sanitizeButtons([
+      { id: "lint", label: "Lint", run: "shell", cmd: "yarn lint" },
+      { id: "c", label: "Compact", run: "input", text: "/compact" },
+      { id: "gh", label: "GH", run: "open", open: { url: "https://x" } },
+    ]);
+    expect(out.map((b) => b.id)).toEqual(["lint", "c", "gh"]);
+    expect(out[2].open).toEqual({ url: "https://x" });
+  });
+
+  it("drops a button missing id/label/run or with a mismatched payload", () => {
+    expect(sanitizeButtons([{ label: "x", run: "shell", cmd: "y" }])).toEqual([]); // no id
+    expect(sanitizeButtons([{ id: "a", label: "x", run: "shell" }])).toEqual([]); // shell without cmd
+    expect(sanitizeButtons([{ id: "a", label: "x", run: "input" }])).toEqual([]); // input without text
+    expect(sanitizeButtons([{ id: "a", label: "x", run: "nope", cmd: "y" }])).toEqual([]); // bad run
+  });
+
+  it("dedupes by id (first wins) and only keeps known open view targets", () => {
+    const out = sanitizeButtons([
+      { id: "a", label: "A", run: "shell", cmd: "1" },
+      { id: "a", label: "A2", run: "shell", cmd: "2" },
+      { id: "v", label: "V", run: "open", open: { view: "bogus" } },
+      { id: "w", label: "W", run: "open", open: { view: "diff" } },
+    ]);
+    expect(out.map((b) => b.id)).toEqual(["a", "w"]); // dup 'a' collapsed, bogus-view 'v' dropped
+    expect(out[0].label).toBe("A");
+  });
+
+  it("returns [] for non-array input", () => {
+    expect(sanitizeButtons(undefined)).toEqual([]);
+    expect(sanitizeButtons({})).toEqual([]);
+  });
+});
+
+describe("sanitizeChips", () => {
+  it("returns null when chips is absent or not an array (unconfigured = use default)", () => {
+    expect(sanitizeChips(undefined)).toBeNull();
+    expect(sanitizeChips("dir")).toBeNull();
+  });
+
+  it("keeps built-in ids, drops unknown strings, keeps custom {label,text}", () => {
+    expect(sanitizeChips(["dir", "git", "bogus", { label: "↑↓", text: "${ahead}" }])).toEqual(["dir", "git", { label: "↑↓", text: "${ahead}" }]);
+  });
+
+  it("keeps an empty array as configured-but-empty (hide all built-ins)", () => {
+    expect(sanitizeChips([])).toEqual([]);
+  });
+
+  it("drops a custom chip missing label, missing text, or with empty text", () => {
+    expect(sanitizeChips([{ label: "x" }, { text: "y" }, { label: "z", text: "" }])).toEqual([]);
+  });
+});
+
+describe("sanitizeHeaderConfig", () => {
+  it("assembles buttons + chips, defaulting a non-object to empty/null", () => {
+    expect(sanitizeHeaderConfig(null)).toEqual({ buttons: [], chips: null });
+    expect(sanitizeHeaderConfig({ buttons: [{ id: "a", label: "A", run: "shell", cmd: "x" }], chips: ["dir"] })).toEqual({
+      buttons: [{ id: "a", label: "A", run: "shell", cmd: "x" }],
+      chips: ["dir"],
+    });
+  });
+});
+
+describe("mergeHeaderConfig", () => {
+  const g: HeaderConfig = {
+    buttons: [
+      { id: "shared", label: "G", run: "shell", cmd: "g" },
+      { id: "gonly", label: "GO", run: "shell", cmd: "go" },
+    ],
+    chips: ["dir", "git"],
+  };
+
+  it("lets the project override a button by id and add its own", () => {
+    const p: HeaderConfig = {
+      buttons: [
+        { id: "shared", label: "P", run: "shell", cmd: "p" },
+        { id: "ponly", label: "PO", run: "shell", cmd: "po" },
+      ],
+      chips: null,
+    };
+    const out = mergeHeaderConfig(g, p);
+    expect(out.buttons.map((b) => `${b.id}:${b.label}`).sort()).toEqual(["gonly:GO", "ponly:PO", "shared:P"]);
+  });
+
+  it("orders by `order` (undefined last), stable within equal order", () => {
+    const out = mergeHeaderConfig(
+      {
+        buttons: [
+          { id: "a", label: "A", run: "shell", cmd: "x", order: 20 },
+          { id: "b", label: "B", run: "shell", cmd: "x" },
+        ],
+        chips: null,
+      },
+      { buttons: [{ id: "c", label: "C", run: "shell", cmd: "x", order: 10 }], chips: null },
+    );
+    expect(out.buttons.map((b) => b.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("takes the project's chips when set, else the global's, and passes null through", () => {
+    expect(mergeHeaderConfig(g, { buttons: [], chips: ["ctx"] }).chips).toEqual(["ctx"]);
+    expect(mergeHeaderConfig(g, { buttons: [], chips: null }).chips).toEqual(["dir", "git"]);
+    expect(mergeHeaderConfig({ buttons: [], chips: null }, { buttons: [], chips: null }).chips).toBeNull();
+  });
+});

--- a/server/header-config.ts
+++ b/server/header-config.ts
@@ -1,0 +1,188 @@
+// The user-configurable terminal header: action buttons + display chips. Read from the global
+// AppConfig (~/.mulmoterminal/config.json) and the per-dir DirConfig (<cwd>/.mulmoterminal.json),
+// merged, then RESOLVED per session (evaluate `when`, substitute ${vars}) before the client renders.
+//
+// Hard rule: absent config == today's header. `sanitizeChips` returns null when unconfigured, and the
+// resolver passes that through so the client keeps its hardcoded default chips; empty `buttons` means
+// only the built-in buttons show.
+
+export type RunType = "shell" | "input" | "open";
+export const VIEW_TARGETS = ["diff", "prs", "wiki", "collections", "accounting"] as const;
+export type ViewTarget = (typeof VIEW_TARGETS)[number];
+
+export interface OpenTarget {
+  url?: string; // browser (http/https)
+  reveal?: string; // dir path → Finder/OS file manager
+  files?: string; // dir path → in-app file explorer
+  view?: ViewTarget; // in-app overlay/route
+}
+
+export interface HeaderButton {
+  id: string;
+  emoji?: string;
+  icon?: string; // material-symbol, alternative to emoji
+  label: string;
+  run: RunType;
+  cmd?: string; // run: shell
+  text?: string; // run: input
+  open?: OpenTarget; // run: open
+  when?: string;
+  order?: number;
+}
+
+// A bare string is a built-in chip id; an object is a custom display-only chip.
+export type HeaderChip = string | { label: string; text: string; when?: string };
+
+export interface HeaderConfig {
+  buttons: HeaderButton[];
+  chips: HeaderChip[] | null; // null = unconfigured (client uses its default)
+}
+
+// The live context a header is resolved against — all trusted server-side session state.
+export interface HeaderContext {
+  dir: string;
+  dirName: string;
+  branch: string | null;
+  repo: string | null;
+  model: string | null;
+  agent: "claude" | "codex";
+  session: string | null;
+  remoteUrl: string | null;
+  dirty: number;
+  ahead: number;
+  behind: number;
+  task: string | null;
+  isGitRepo: boolean;
+}
+
+export const BUILTIN_CHIPS = ["dir", "git", "ctx", "usage", "status", "diff", "tools"] as const;
+export type BuiltinChip = (typeof BUILTIN_CHIPS)[number];
+
+export type ResolvedChip = { kind: "builtin"; id: BuiltinChip } | { kind: "custom"; label: string; text: string };
+export interface ResolvedButton {
+  id: string;
+  emoji?: string;
+  icon?: string;
+  label: string;
+  run: RunType;
+  cmd?: string;
+  text?: string;
+  open?: OpenTarget;
+}
+export interface ResolvedHeader {
+  buttons: ResolvedButton[];
+  chips: ResolvedChip[] | null;
+}
+
+export const EMPTY_HEADER_CONFIG: HeaderConfig = { buttons: [], chips: null };
+
+const MAX_BUTTONS = 32;
+const MAX_CHIPS = 16;
+const RUN_TYPES = new Set<string>(["shell", "input", "open"]);
+const VIEWS = new Set<string>(VIEW_TARGETS);
+const BUILTINS = new Set<string>(BUILTIN_CHIPS);
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
+const str = (v: unknown): string | undefined => (typeof v === "string" && v.trim() ? v.trim() : undefined);
+const isRunType = (s: string): s is RunType => RUN_TYPES.has(s);
+const isViewTarget = (s: string): s is ViewTarget => VIEWS.has(s);
+
+function sanitizeOpen(input: unknown): OpenTarget | undefined {
+  if (!isRecord(input)) return undefined;
+  const url = str(input.url);
+  const reveal = str(input.reveal);
+  const files = str(input.files);
+  const view = str(input.view);
+  const target: OpenTarget = {};
+  if (url) target.url = url;
+  if (reveal) target.reveal = reveal;
+  if (files) target.files = files;
+  if (view && isViewTarget(view)) target.view = view;
+  return Object.keys(target).length ? target : undefined;
+}
+
+// A button needs an id, a label, and a payload matching its run type; anything short of that is dropped.
+function sanitizeButton(input: unknown): HeaderButton | null {
+  if (!isRecord(input)) return null;
+  const id = str(input.id);
+  const label = str(input.label);
+  const run = str(input.run);
+  if (!id || !label || !run || !isRunType(run)) return null;
+  const button: HeaderButton = { id, label, run };
+  const emoji = str(input.emoji);
+  const icon = str(input.icon);
+  const when = str(input.when);
+  if (emoji) button.emoji = emoji;
+  if (icon) button.icon = icon;
+  if (when) button.when = when;
+  if (typeof input.order === "number" && Number.isFinite(input.order)) button.order = input.order;
+  return withPayload(button, input);
+}
+
+function withPayload(button: HeaderButton, input: Record<string, unknown>): HeaderButton | null {
+  if (button.run === "shell") return str(input.cmd) ? { ...button, cmd: str(input.cmd) } : null;
+  if (button.run === "input") return str(input.text) ? { ...button, text: str(input.text) } : null;
+  const open = sanitizeOpen(input.open);
+  return open ? { ...button, open } : null;
+}
+
+export function sanitizeButtons(input: unknown): HeaderButton[] {
+  if (!Array.isArray(input)) return [];
+  const seen = new Set<string>();
+  const out: HeaderButton[] = [];
+  for (const raw of input) {
+    const button = sanitizeButton(raw);
+    if (!button || seen.has(button.id)) continue;
+    seen.add(button.id);
+    out.push(button);
+    if (out.length >= MAX_BUTTONS) break;
+  }
+  return out;
+}
+
+function sanitizeChip(input: unknown): HeaderChip | null {
+  if (typeof input === "string") return BUILTINS.has(input.trim()) ? input.trim() : null;
+  if (!isRecord(input)) return null;
+  const label = str(input.label);
+  const text = str(input.text);
+  if (!label || !text) return null;
+  const when = str(input.when);
+  return when ? { label, text, when } : { label, text };
+}
+
+// Returns null when `chips` is absent/malformed — the signal for "unconfigured, use the default".
+export function sanitizeChips(input: unknown): HeaderChip[] | null {
+  if (!Array.isArray(input)) return null;
+  const out: HeaderChip[] = [];
+  for (const raw of input) {
+    const chip = sanitizeChip(raw);
+    if (chip === null) continue;
+    out.push(chip);
+    if (out.length >= MAX_CHIPS) break;
+  }
+  return out;
+}
+
+export function sanitizeHeaderConfig(raw: unknown): HeaderConfig {
+  const record = isRecord(raw) ? raw : {};
+  return { buttons: sanitizeButtons(record.buttons), chips: sanitizeChips(record.chips) };
+}
+
+// Merge global under project: buttons keyed by id (project overrides/adds), then ordered by `order`
+// (undefined last), stable within equal order. Chips: project wins outright; null passes through.
+export function mergeHeaderConfig(globalConfig: HeaderConfig, projectConfig: HeaderConfig): HeaderConfig {
+  const byId = new Map<string, HeaderButton>();
+  for (const b of globalConfig.buttons) byId.set(b.id, b);
+  for (const b of projectConfig.buttons) byId.set(b.id, b);
+  const buttons = [...byId.values()]
+    .map((b, i) => ({ b, i }))
+    .sort(byOrderThenInsertion)
+    .map((x) => x.b);
+  return { buttons, chips: projectConfig.chips ?? globalConfig.chips };
+}
+
+const orderOf = (b: HeaderButton): number => (typeof b.order === "number" ? b.order : Number.POSITIVE_INFINITY);
+function byOrderThenInsertion(a: { b: HeaderButton; i: number }, b: { b: HeaderButton; i: number }): number {
+  const delta = orderOf(a.b) - orderOf(b.b);
+  return delta !== 0 ? delta : a.i - b.i;
+}

--- a/server/header-context.spec.ts
+++ b/server/header-context.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { repoFromWebUrl } from "./header-context.js";
+
+describe("repoFromWebUrl", () => {
+  it("extracts owner/repo from a github web url", () => {
+    expect(repoFromWebUrl("https://github.com/receptron/mulmoterminal")).toBe("receptron/mulmoterminal");
+  });
+  it("strips a trailing .git and slashes", () => {
+    expect(repoFromWebUrl("https://github.com/o/r.git")).toBe("o/r");
+    expect(repoFromWebUrl("https://github.com/o/r/")).toBe("o/r");
+  });
+  it("returns null for a null input or a non-github url", () => {
+    expect(repoFromWebUrl(null)).toBeNull();
+    expect(repoFromWebUrl("https://gitlab.com/o/r")).toBeNull();
+  });
+});

--- a/server/header-context.ts
+++ b/server/header-context.ts
@@ -1,0 +1,68 @@
+// Gather a session's live HeaderContext (cwd, git status, model, agent, …) so a merged HeaderConfig
+// can be resolved for it, and merge the global (AppConfig) + per-dir (.mulmoterminal.json) configs.
+
+import path from "node:path";
+import os from "node:os";
+import { gitStatus } from "./git-status.js";
+import { git } from "./worktrees.js";
+import { parseGithubWebUrl } from "./gitRemote.js";
+import { mergeHeaderConfig, type HeaderConfig, type HeaderContext } from "./header-config.js";
+import { loadDirConfig } from "./dir-config.js";
+
+const WORKTREES_ROOT = path.join(os.homedir(), ".mulmoterminal", "worktrees");
+
+// The GitHub web URL is "https://github.com/owner/repo" — take the "owner/repo" tail for ${repo}.
+export function repoFromWebUrl(webUrl: string | null): string | null {
+  if (!webUrl) return null;
+  const parts = webUrl.split("github.com/");
+  if (parts.length < 2) return null;
+  let repo = parts[1];
+  if (repo.endsWith(".git")) repo = repo.slice(0, -".git".length);
+  while (repo.endsWith("/")) repo = repo.slice(0, -1);
+  return repo || null;
+}
+
+// A managed worktree lives at ~/.mulmoterminal/worktrees/<repo>-<hash>/<task>; its dir name is the task.
+function worktreeTask(cwd: string): string | null {
+  const resolved = path.resolve(cwd);
+  return resolved.startsWith(WORKTREES_ROOT + path.sep) ? path.basename(resolved) : null;
+}
+
+async function remoteInfo(cwd: string): Promise<{ remoteUrl: string | null; repo: string | null }> {
+  const res = await git(["remote", "get-url", "origin"], cwd);
+  const remoteUrl = res.ok && res.stdout.trim() ? res.stdout.trim() : null;
+  const repo = remoteUrl ? repoFromWebUrl(parseGithubWebUrl(remoteUrl)) : null;
+  return { remoteUrl, repo };
+}
+
+export interface SessionMeta {
+  session: string | null;
+  agent: "claude" | "codex";
+  model: string | null;
+}
+
+export async function buildHeaderContext(cwd: string, meta: SessionMeta): Promise<HeaderContext> {
+  const status = await gitStatus(cwd);
+  const remote = status.repo ? await remoteInfo(cwd) : { remoteUrl: null, repo: null };
+  return {
+    dir: cwd,
+    dirName: path.basename(cwd),
+    branch: status.branch,
+    repo: remote.repo,
+    model: meta.model,
+    agent: meta.agent,
+    session: meta.session,
+    remoteUrl: remote.remoteUrl,
+    dirty: status.dirty,
+    ahead: status.ahead,
+    behind: status.behind,
+    task: worktreeTask(cwd),
+    isGitRepo: status.repo,
+  };
+}
+
+// Merge the global header config (from AppConfig) under the per-dir one (<cwd>/.mulmoterminal.json).
+export function loadHeaderConfig(cwd: string, globalConfig: HeaderConfig): HeaderConfig {
+  const dir = loadDirConfig(cwd);
+  return mergeHeaderConfig(globalConfig, { buttons: dir.buttons, chips: dir.chips });
+}

--- a/server/header-resolve.spec.ts
+++ b/server/header-resolve.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { substitute, evalWhen, resolveHeader } from "./header-resolve.js";
+import type { HeaderConfig, HeaderContext } from "./header-config.js";
+
+const ctx = (over: Partial<HeaderContext> = {}): HeaderContext => ({
+  dir: "/Users/x/myrepo",
+  dirName: "myrepo",
+  branch: "feat/foo",
+  repo: "receptron/mulmoterminal",
+  model: "claude-opus-4-8",
+  agent: "claude",
+  session: "sess-1",
+  remoteUrl: "git@github.com:receptron/mulmoterminal.git",
+  dirty: 3,
+  ahead: 2,
+  behind: 0,
+  task: "foo",
+  isGitRepo: true,
+  ...over,
+});
+
+describe("substitute", () => {
+  it("replaces known vars, renders null as empty, numbers as strings", () => {
+    expect(substitute("↑${ahead} ↓${behind} on ${branch}", ctx())).toBe("↑2 ↓0 on feat/foo");
+    expect(substitute("[${branch}]", ctx({ branch: null }))).toBe("[]");
+  });
+  it("leaves an unknown ${var} literal so a typo is visible", () => {
+    expect(substitute("${nope}", ctx())).toBe("${nope}");
+  });
+});
+
+describe("evalWhen", () => {
+  it("treats an empty/absent condition as always visible", () => {
+    expect(evalWhen(undefined, ctx())).toBe(true);
+    expect(evalWhen("  ", ctx())).toBe(true);
+  });
+  it("evaluates isGitRepo / !isGitRepo", () => {
+    expect(evalWhen("isGitRepo", ctx())).toBe(true);
+    expect(evalWhen("isGitRepo", ctx({ isGitRepo: false }))).toBe(false);
+    expect(evalWhen("!isGitRepo", ctx({ isGitRepo: false }))).toBe(true);
+  });
+  it("evaluates == / != against context values", () => {
+    expect(evalWhen("agent == claude", ctx())).toBe(true);
+    expect(evalWhen("agent == codex", ctx())).toBe(false);
+    expect(evalWhen("agent != codex", ctx())).toBe(true);
+    expect(evalWhen("repo == receptron/mulmoterminal", ctx())).toBe(true);
+  });
+  it("&& binds tighter than || ; unknown atoms are false", () => {
+    expect(evalWhen("isGitRepo && agent==claude", ctx())).toBe(true);
+    expect(evalWhen("isGitRepo && agent==codex", ctx())).toBe(false);
+    expect(evalWhen("agent==codex || repo==receptron/mulmoterminal", ctx())).toBe(true);
+    expect(evalWhen("mystery", ctx())).toBe(false);
+  });
+});
+
+describe("resolveHeader", () => {
+  it("passes chips:null through unchanged (unconfigured = client default)", () => {
+    expect(resolveHeader({ buttons: [], chips: null }, ctx()).chips).toBeNull();
+  });
+
+  it("filters buttons by `when` and substitutes their payloads", () => {
+    const config: HeaderConfig = {
+      buttons: [
+        { id: "pr", emoji: "🔀", label: "PR", run: "shell", cmd: "gh pr create --head ${branch}", when: "isGitRepo" },
+        { id: "cx", label: "Codex-only", run: "input", text: "hi", when: "agent == codex" },
+        { id: "gh", label: "GH", run: "open", open: { url: "https://github.com/${repo}" } },
+      ],
+      chips: null,
+    };
+    const out = resolveHeader(config, ctx());
+    expect(out.buttons.map((b) => b.id)).toEqual(["pr", "gh"]); // codex-only hidden for a claude session
+    expect(out.buttons[0].cmd).toBe("gh pr create --head feat/foo");
+    expect(out.buttons[1].open).toEqual({ url: "https://github.com/receptron/mulmoterminal" });
+  });
+
+  it("resolves built-in and custom chips, dropping a custom chip whose when is false", () => {
+    const config: HeaderConfig = {
+      buttons: [],
+      chips: ["dir", "bogus", { label: "↑↓", text: "↑${ahead}", when: "isGitRepo" }, { label: "no", text: "x", when: "isGitRepo" }],
+    };
+    const out = resolveHeader(config, ctx({ isGitRepo: false }));
+    // 'bogus' was dropped at sanitize time in real use; here resolveChip also drops unknown builtin strings,
+    // and both custom chips are hidden because isGitRepo is false.
+    expect(out.chips).toEqual([{ kind: "builtin", id: "dir" }]);
+  });
+
+  it("keeps custom chips and substitutes their text when visible", () => {
+    const out = resolveHeader({ buttons: [], chips: [{ label: "↑↓", text: "↑${ahead} ↓${behind}" }] }, ctx());
+    expect(out.chips).toEqual([{ kind: "custom", label: "↑↓", text: "↑2 ↓0" }]);
+  });
+});

--- a/server/header-resolve.spec.ts
+++ b/server/header-resolve.spec.ts
@@ -51,6 +51,10 @@ describe("evalWhen", () => {
     expect(evalWhen("agent==codex || repo==receptron/mulmoterminal", ctx())).toBe(true);
     expect(evalWhen("mystery", ctx())).toBe(false);
   });
+  it("fails closed for an unknown key on both == and != (a typo hides, never exposes)", () => {
+    expect(evalWhen("agnet == claude", ctx())).toBe(false);
+    expect(evalWhen("agnet != codex", ctx())).toBe(false);
+  });
 });
 
 describe("resolveHeader", () => {
@@ -58,7 +62,7 @@ describe("resolveHeader", () => {
     expect(resolveHeader({ buttons: [], chips: null }, ctx()).chips).toBeNull();
   });
 
-  it("filters buttons by `when` and substitutes their payloads", () => {
+  it("filters buttons by `when`, drops shell buttons (not wired yet), and substitutes payloads", () => {
     const config: HeaderConfig = {
       buttons: [
         { id: "pr", emoji: "🔀", label: "PR", run: "shell", cmd: "gh pr create --head ${branch}", when: "isGitRepo" },
@@ -68,9 +72,9 @@ describe("resolveHeader", () => {
       chips: null,
     };
     const out = resolveHeader(config, ctx());
-    expect(out.buttons.map((b) => b.id)).toEqual(["pr", "gh"]); // codex-only hidden for a claude session
-    expect(out.buttons[0].cmd).toBe("gh pr create --head feat/foo");
-    expect(out.buttons[1].open).toEqual({ url: "https://github.com/receptron/mulmoterminal" });
+    // "pr" is dropped (run:"shell" not dispatchable yet); "cx" hidden for a claude session; only "gh" remains.
+    expect(out.buttons.map((b) => b.id)).toEqual(["gh"]);
+    expect(out.buttons[0].open).toEqual({ url: "https://github.com/receptron/mulmoterminal" });
   });
 
   it("resolves built-in and custom chips, dropping a custom chip whose when is false", () => {

--- a/server/header-resolve.ts
+++ b/server/header-resolve.ts
@@ -61,8 +61,8 @@ function evalAtom(atom: string, ctx: HeaderContext): boolean {
   const value = trimmed.slice(idx + op.length).trim();
   if (!KEY_RE.test(key)) return false;
   const actual = varValue(ctx, key);
-  const equal = actual !== undefined && actual === value;
-  return op === "==" ? equal : !equal;
+  if (actual === undefined) return false; // unknown key → fail closed, so a `when` typo hides rather than exposes
+  return op === "==" ? actual === value : actual !== value;
 }
 
 // `&&` binds tighter than `||`; no parentheses in v1. Empty/absent condition → always visible.
@@ -96,7 +96,9 @@ function resolveChip(chip: HeaderChip, ctx: HeaderContext): ResolvedChip | null 
 }
 
 export function resolveHeader(config: HeaderConfig, ctx: HeaderContext): ResolvedHeader {
-  const buttons = config.buttons.filter((b) => evalWhen(b.when, ctx)).map((b) => resolveButton(b, ctx));
+  // `run:"shell"` dispatch is not wired yet (it needs an id-based exec route); suppress those buttons so a
+  // configured shell button never renders as actionable-but-inert. Drop this `run !== "shell"` clause when shell lands.
+  const buttons = config.buttons.filter((b) => b.run !== "shell" && evalWhen(b.when, ctx)).map((b) => resolveButton(b, ctx));
   const chips = config.chips === null ? null : config.chips.map((c) => resolveChip(c, ctx)).filter((c): c is ResolvedChip => c !== null);
   return { buttons, chips };
 }

--- a/server/header-resolve.ts
+++ b/server/header-resolve.ts
@@ -1,0 +1,102 @@
+// Resolve a merged HeaderConfig against a session's live context: drop items whose `when` is false,
+// and substitute ${vars} in commands / text / open targets / custom chip text. Pure — the caller
+// gathers the HeaderContext (cwd, git status, model, agent, …) from server state.
+
+import type {
+  BuiltinChip,
+  HeaderButton,
+  HeaderChip,
+  HeaderConfig,
+  HeaderContext,
+  OpenTarget,
+  ResolvedButton,
+  ResolvedChip,
+  ResolvedHeader,
+} from "./header-config.js";
+import { BUILTIN_CHIPS } from "./header-config.js";
+
+const VAR_RE = /\$\{(\w+)\}/g;
+const BUILTINS = new Set<string>(BUILTIN_CHIPS);
+const isBuiltinChip = (s: string): s is BuiltinChip => BUILTINS.has(s);
+
+const varValue = (ctx: HeaderContext, name: string): string | undefined => {
+  const table: Record<string, string | number | null> = {
+    dir: ctx.dir,
+    dirName: ctx.dirName,
+    branch: ctx.branch,
+    repo: ctx.repo,
+    model: ctx.model,
+    agent: ctx.agent,
+    session: ctx.session,
+    remoteUrl: ctx.remoteUrl,
+    dirty: ctx.dirty,
+    ahead: ctx.ahead,
+    behind: ctx.behind,
+    task: ctx.task,
+  };
+  if (!(name in table)) return undefined;
+  const value = table[name];
+  return value === null ? "" : String(value);
+};
+
+// Replace known ${vars}; leave an unknown ${x} literal so a typo is visible rather than silently blank.
+export function substitute(text: string, ctx: HeaderContext): string {
+  return text.replace(VAR_RE, (whole, name: string) => varValue(ctx, name) ?? whole);
+}
+
+const KEY_RE = /^\w+$/;
+function comparisonOp(atom: string): "==" | "!=" | null {
+  if (atom.includes("!=")) return "!=";
+  if (atom.includes("==")) return "==";
+  return null;
+}
+function evalAtom(atom: string, ctx: HeaderContext): boolean {
+  const trimmed = atom.trim();
+  if (trimmed === "isGitRepo") return ctx.isGitRepo;
+  if (trimmed === "!isGitRepo") return !ctx.isGitRepo;
+  const op = comparisonOp(trimmed);
+  if (!op) return false; // unknown atom → hide (safe default)
+  const idx = trimmed.indexOf(op);
+  const key = trimmed.slice(0, idx).trim();
+  const value = trimmed.slice(idx + op.length).trim();
+  if (!KEY_RE.test(key)) return false;
+  const actual = varValue(ctx, key);
+  const equal = actual !== undefined && actual === value;
+  return op === "==" ? equal : !equal;
+}
+
+// `&&` binds tighter than `||`; no parentheses in v1. Empty/absent condition → always visible.
+export function evalWhen(expr: string | undefined, ctx: HeaderContext): boolean {
+  if (!expr || !expr.trim()) return true;
+  return expr.split("||").some((group) => group.split("&&").every((atom) => evalAtom(atom, ctx)));
+}
+
+function resolveOpen(open: OpenTarget, ctx: HeaderContext): OpenTarget {
+  const out: OpenTarget = {};
+  if (open.url) out.url = substitute(open.url, ctx);
+  if (open.reveal) out.reveal = substitute(open.reveal, ctx);
+  if (open.files) out.files = substitute(open.files, ctx);
+  if (open.view) out.view = open.view;
+  return out;
+}
+
+function resolveButton(button: HeaderButton, ctx: HeaderContext): ResolvedButton {
+  const resolved: ResolvedButton = { id: button.id, label: button.label, run: button.run };
+  if (button.emoji) resolved.emoji = button.emoji;
+  if (button.icon) resolved.icon = button.icon;
+  if (button.cmd) resolved.cmd = substitute(button.cmd, ctx);
+  if (button.text) resolved.text = substitute(button.text, ctx);
+  if (button.open) resolved.open = resolveOpen(button.open, ctx);
+  return resolved;
+}
+
+function resolveChip(chip: HeaderChip, ctx: HeaderContext): ResolvedChip | null {
+  if (typeof chip === "string") return isBuiltinChip(chip) ? { kind: "builtin", id: chip } : null;
+  return evalWhen(chip.when, ctx) ? { kind: "custom", label: chip.label, text: substitute(chip.text, ctx) } : null;
+}
+
+export function resolveHeader(config: HeaderConfig, ctx: HeaderContext): ResolvedHeader {
+  const buttons = config.buttons.filter((b) => evalWhen(b.when, ctx)).map((b) => resolveButton(b, ctx));
+  const chips = config.chips === null ? null : config.chips.map((c) => resolveChip(c, ctx)).filter((c): c is ResolvedChip => c !== null);
+  return { buttons, chips };
+}

--- a/server/header-resolve.ts
+++ b/server/header-resolve.ts
@@ -74,6 +74,10 @@ export function evalWhen(expr: string | undefined, ctx: HeaderContext): boolean 
 function resolveOpen(open: OpenTarget, ctx: HeaderContext): OpenTarget {
   const out: OpenTarget = {};
   if (open.url) out.url = substitute(open.url, ctx);
+  // `reveal`/`files` are intentionally NOT confined to the session cwd (accepted trust boundary): per-project
+  // config is the same trust surface as script.json (which already runs arbitrary shell from <cwd>), and
+  // revealing a sibling worktree/related repo is a real workflow. Any hardening should be a cross-cutting
+  // "trusted directories" gate that also covers script.json, not a header-only path check. See the spec.
   if (open.reveal) out.reveal = substitute(open.reveal, ctx);
   if (open.files) out.files = substitute(open.files, ctx);
   if (open.view) out.view = open.view;

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,9 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers } from "./config-routes.js";
+import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers, getHeaderConfig } from "./config-routes.js";
+import { buildHeaderContext, loadHeaderConfig } from "./header-context.js";
+import { resolveHeader } from "./header-resolve.js";
 import { mountFilesBrowseRoutes } from "./files-browse.js";
 import { gitStatus } from "./git-status.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "./tmux.js";
@@ -1239,6 +1241,19 @@ app.get("/api/dir-config", (req, res) => {
 app.get("/api/git-status", async (req, res) => {
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   res.json(await gitStatus(cwd));
+});
+
+// The resolved terminal-header config (buttons + chips) for a session: global config merged with the
+// dir's, with `when` evaluated and ${vars} substituted for this session's live context. `chips:null`
+// means unconfigured, so the client keeps its default header (see plans/feat-header-toolbar-config.md).
+app.get("/api/header", async (req, res) => {
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  const session = typeof req.query.session === "string" && SESSION_ID_RE.test(req.query.session) ? req.query.session : null;
+  const agent = req.query.agent === "codex" ? "codex" : "claude";
+  const model = typeof req.query.model === "string" ? req.query.model : null;
+  const config = loadHeaderConfig(cwd, getHeaderConfig());
+  const context = await buildHeaderContext(cwd, { session, agent, model });
+  res.json(resolveHeader(config, context));
 });
 
 // The tool-activity timeline for a session (what the agent ran, newest last), so a

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -11,6 +11,8 @@ import * as conn from "../composables/useTerminalConnections";
 import RunMenu from "./RunMenu.vue";
 import GitBranchChip from "./GitBranchChip.vue";
 import { filesGotoIndex } from "../composables/useFilesView";
+import { useHeaderButtons } from "../composables/useHeaderButtons";
+import { runHeaderButton } from "../composables/useHeaderAction";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
@@ -85,6 +87,15 @@ const status = computed(() => conn.connView.get(slotKey)?.status ?? "connecting"
 // The server-resolved cwd of the connected session (the open project), used by the
 // Run menu so it lists THAT directory's scripts. Falls back to the requested cwd.
 const serverCwd = computed(() => conn.connView.get(slotKey)?.serverCwd ?? props.cwd ?? null);
+
+// User-configured header action buttons for this session's dir (GET /api/header). Additive: with no
+// config the list is empty so the header is unchanged. `input`/`open` run client-side; `shell` is
+// wired in a later phase.
+const { buttons: headerButtons } = useHeaderButtons({
+  cwd: serverCwd,
+  session: computed(() => props.sessionId),
+  agent: computed<"claude" | "codex">(() => (props.codex ? "codex" : "claude")),
+});
 // Git status chip — single view only. In the grid the embedding TerminalCell shows
 // its own chip, so null the cwd here to skip redundant polling (status stays null).
 const gitCwd = computed(() => (props.devTerminal ? null : serverCwd.value));
@@ -246,6 +257,18 @@ onUnmounted(() => {
       <RunMenu v-if="runMenu" :cwd="serverCwd" @run="(c) => emit('run', c)" />
       <div class="header-actions">
         <button
+          v-for="b in headerButtons"
+          :key="b.id"
+          type="button"
+          class="icon-btn hdr-action"
+          :title="b.label"
+          :aria-label="b.label"
+          @click="runHeaderButton(b, slotKey, serverCwd)"
+        >
+          <span v-if="b.emoji" class="hdr-emoji">{{ b.emoji }}</span>
+          <span v-else class="material-symbols-outlined">{{ b.icon || "bolt" }}</span>
+        </button>
+        <button
           v-if="voice.capable.value"
           type="button"
           :class="['icon-btn', 'voice', { listening: voice.listening.value, busy: voice.downloading.value || voice.transcribing.value }]"
@@ -342,6 +365,11 @@ onUnmounted(() => {
 
 .icon-btn .material-symbols-outlined {
   font-size: 18px;
+}
+/* A configured action button's emoji glyph, sized to sit with the icon buttons. */
+.hdr-emoji {
+  font-size: 15px;
+  line-height: 1;
 }
 
 /* Recording: solid red, gently pulsing. Busy (download/transcribe): the spinner

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -12,6 +12,7 @@ import RunMenu from "./RunMenu.vue";
 import GitBranchChip from "./GitBranchChip.vue";
 import { filesGotoIndex } from "../composables/useFilesView";
 import { useHeaderButtons } from "../composables/useHeaderButtons";
+import { useSessionContext } from "../composables/useSessionContext";
 import { runHeaderButton } from "../composables/useHeaderAction";
 
 // `null` => start a fresh session; otherwise resume the given session id.
@@ -88,6 +89,11 @@ const status = computed(() => conn.connView.get(slotKey)?.status ?? "connecting"
 // Run menu so it lists THAT directory's scripts. Falls back to the requested cwd.
 const serverCwd = computed(() => conn.connView.get(slotKey)?.serverCwd ?? props.cwd ?? null);
 
+// The running model, so header buttons/chips can substitute `${model}`.
+const { context: sessionContext } = useSessionContext(
+  computed(() => props.sessionId),
+  serverCwd,
+);
 // User-configured header action buttons for this session's dir (GET /api/header). Additive: with no
 // config the list is empty so the header is unchanged. `input`/`open` run client-side; `shell` is
 // wired in a later phase.
@@ -95,6 +101,7 @@ const { buttons: headerButtons } = useHeaderButtons({
   cwd: serverCwd,
   session: computed(() => props.sessionId),
   agent: computed<"claude" | "codex">(() => (props.codex ? "codex" : "claude")),
+  model: computed(() => sessionContext.value?.model ?? null),
 });
 // Git status chip — single view only. In the grid the embedding TerminalCell shows
 // its own chip, so null the cwd here to skip redundant polling (status stays null).

--- a/src/composables/useHeaderAction.spec.ts
+++ b/src/composables/useHeaderAction.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const m = vi.hoisted(() => ({
+  filesGotoIndex: vi.fn(),
+  prsGotoIndex: vi.fn(),
+  wikiGotoIndex: vi.fn(),
+  browseGotoIndex: vi.fn(),
+  accountingViewOpen: vi.fn(),
+  submitText: vi.fn(),
+}));
+vi.mock("./useFilesView", () => ({ filesGotoIndex: m.filesGotoIndex }));
+vi.mock("./usePrsView", () => ({ prsGotoIndex: m.prsGotoIndex }));
+vi.mock("./useWikiBrowse", () => ({ wikiGotoIndex: m.wikiGotoIndex }));
+vi.mock("./useCollectionBrowse", () => ({ browseGotoIndex: m.browseGotoIndex }));
+vi.mock("./useAccountingView", () => ({ accountingViewOpen: m.accountingViewOpen }));
+vi.mock("./useTerminalConnections", () => ({ submitText: m.submitText }));
+
+import { runHeaderButton } from "./useHeaderAction";
+import type { HeaderButton } from "./useHeaderButtons";
+
+const btn = (over: Partial<HeaderButton>): HeaderButton => ({ id: "x", label: "X", run: "open", ...over });
+
+describe("runHeaderButton", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("input → submitText into the session's slot", () => {
+    runHeaderButton(btn({ run: "input", text: "/compact" }), "single", "/x");
+    expect(m.submitText).toHaveBeenCalledWith("single", "/compact");
+  });
+
+  it("input without a slot key is a no-op", () => {
+    runHeaderButton(btn({ run: "input", text: "/compact" }), null, "/x");
+    expect(m.submitText).not.toHaveBeenCalled();
+  });
+
+  it("open url → window.open for http(s), ignores other schemes", () => {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    runHeaderButton(btn({ run: "open", open: { url: "https://x" } }), null, null);
+    expect(open).toHaveBeenCalledWith("https://x", "_blank", "noopener,noreferrer");
+    open.mockClear();
+    runHeaderButton(btn({ run: "open", open: { url: "javascript:alert(1)" } }), null, null);
+    expect(open).not.toHaveBeenCalled();
+    open.mockRestore();
+  });
+
+  it("open reveal → POST /api/open-dir", () => {
+    const f = vi.fn(() => Promise.resolve({ ok: true } as Response));
+    vi.stubGlobal("fetch", f);
+    runHeaderButton(btn({ run: "open", open: { reveal: "/dir" } }), null, null);
+    expect(f).toHaveBeenCalledWith("/api/open-dir", expect.objectContaining({ method: "POST" }));
+    vi.unstubAllGlobals();
+  });
+
+  it("open files → filesGotoIndex; open view routes to the matching nav (else files)", () => {
+    runHeaderButton(btn({ run: "open", open: { files: "/dir" } }), null, null);
+    expect(m.filesGotoIndex).toHaveBeenCalledWith("/dir");
+    runHeaderButton(btn({ run: "open", open: { view: "prs" } }), null, null);
+    expect(m.prsGotoIndex).toHaveBeenCalled();
+    runHeaderButton(btn({ run: "open", open: { view: "diff" } }), null, "/c");
+    expect(m.filesGotoIndex).toHaveBeenLastCalledWith("/c");
+  });
+
+  it("shell → no-op warn until the command-cell phase", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    runHeaderButton(btn({ run: "shell", cmd: "yarn lint" }), "single", "/x");
+    expect(m.submitText).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/src/composables/useHeaderAction.ts
+++ b/src/composables/useHeaderAction.ts
@@ -1,6 +1,7 @@
 // Dispatch a header action button. `input` types text into the running session; `open` opens a
 // url / reveals a dir / opens the in-app file explorer or a view. `shell` (run an arbitrary command
-// in the dir) needs a command-cell handoff and lands in a later phase — for now it's a no-op warn.
+// in the dir) needs a command-cell handoff and lands in a later phase; the server already drops shell
+// buttons from /api/header, so the branch below is only a defensive fallback (no-op warn).
 import { filesGotoIndex } from "./useFilesView";
 import { prsGotoIndex } from "./usePrsView";
 import { wikiGotoIndex } from "./useWikiBrowse";
@@ -47,6 +48,7 @@ export function runHeaderButton(button: HeaderButton, slotKey: string | null, cw
     dispatchOpen(button.open, cwd);
     return;
   }
-  // run === "shell": deferred to the command-cell phase (see plans/feat-header-toolbar-config.md).
+  // run === "shell": suppressed server-side until the command-cell phase (see plans/feat-header-toolbar-config.md);
+  // this only fires if a shell button somehow reaches the client.
   console.warn(`[header] shell button "${button.id}" runs in a later update`);
 }

--- a/src/composables/useHeaderAction.ts
+++ b/src/composables/useHeaderAction.ts
@@ -1,0 +1,52 @@
+// Dispatch a header action button. `input` types text into the running session; `open` opens a
+// url / reveals a dir / opens the in-app file explorer or a view. `shell` (run an arbitrary command
+// in the dir) needs a command-cell handoff and lands in a later phase — for now it's a no-op warn.
+import { filesGotoIndex } from "./useFilesView";
+import { prsGotoIndex } from "./usePrsView";
+import { wikiGotoIndex } from "./useWikiBrowse";
+import { browseGotoIndex } from "./useCollectionBrowse";
+import { accountingViewOpen } from "./useAccountingView";
+import { submitText } from "./useTerminalConnections";
+import type { HeaderButton, OpenTarget } from "./useHeaderButtons";
+
+const OPEN_URL_SCHEMES: ReadonlySet<string> = new Set(["http:", "https:"]);
+
+function openUrl(url: string): void {
+  try {
+    if (OPEN_URL_SCHEMES.has(new URL(url).protocol)) window.open(url, "_blank", "noopener,noreferrer");
+  } catch {
+    // malformed url — ignore
+  }
+}
+
+function revealDir(dirPath: string): void {
+  fetch("/api/open-dir", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ path: dirPath }) }).catch(() => {});
+}
+
+function openView(view: string, cwd: string | null): void {
+  if (view === "prs") prsGotoIndex();
+  else if (view === "wiki") wikiGotoIndex();
+  else if (view === "collections") browseGotoIndex("collection");
+  else if (view === "accounting") accountingViewOpen();
+  else filesGotoIndex(cwd); // "files" and (until a dedicated route) "diff"
+}
+
+function dispatchOpen(open: OpenTarget, cwd: string | null): void {
+  if (open.url) openUrl(open.url);
+  else if (open.reveal) revealDir(open.reveal);
+  else if (open.files) filesGotoIndex(open.files);
+  else if (open.view) openView(open.view, cwd);
+}
+
+export function runHeaderButton(button: HeaderButton, slotKey: string | null, cwd: string | null): void {
+  if (button.run === "input" && button.text && slotKey) {
+    submitText(slotKey, button.text);
+    return;
+  }
+  if (button.run === "open" && button.open) {
+    dispatchOpen(button.open, cwd);
+    return;
+  }
+  // run === "shell": deferred to the command-cell phase (see plans/feat-header-toolbar-config.md).
+  console.warn(`[header] shell button "${button.id}" runs in a later update`);
+}

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -1,0 +1,73 @@
+// Fetches a terminal's resolved header (action buttons + display chips) from GET /api/header —
+// the server merges global + per-dir config and substitutes this session's live context (branch,
+// dirty, model, …). Re-fetches when the dir/session/agent change or the window regains focus, so
+// ${branch}/${dirty} etc. stay current. `chips: null` means unconfigured (the client keeps its
+// default header); an empty `buttons` array means nothing extra is shown.
+import { ref, watch, onMounted, onBeforeUnmount, type Ref } from "vue";
+
+export interface OpenTarget {
+  url?: string;
+  reveal?: string;
+  files?: string;
+  view?: string;
+}
+export interface HeaderButton {
+  id: string;
+  emoji?: string;
+  icon?: string;
+  label: string;
+  run: "shell" | "input" | "open";
+  cmd?: string;
+  text?: string;
+  open?: OpenTarget;
+}
+export type ResolvedChip = { kind: "builtin"; id: string } | { kind: "custom"; label: string; text: string };
+
+interface Params {
+  cwd: Ref<string | null>;
+  session: Ref<string | null>;
+  agent: Ref<"claude" | "codex">;
+  model?: Ref<string | null>;
+}
+
+export function useHeaderButtons(params: Params) {
+  const buttons = ref<HeaderButton[]>([]);
+  const chips = ref<ResolvedChip[] | null>(null);
+  let requestSeq = 0;
+
+  async function refresh(): Promise<void> {
+    const cwd = params.cwd.value;
+    if (!cwd) {
+      buttons.value = [];
+      chips.value = null;
+      return;
+    }
+    const query = new URLSearchParams({ cwd, agent: params.agent.value });
+    if (params.session.value) query.set("session", params.session.value);
+    if (params.model?.value) query.set("model", params.model.value);
+    const seq = ++requestSeq;
+    try {
+      const res = await fetch(`/api/header?${query.toString()}`);
+      if (seq !== requestSeq) return;
+      const data = res.ok ? await res.json() : { buttons: [], chips: null };
+      if (seq !== requestSeq) return;
+      buttons.value = Array.isArray(data.buttons) ? data.buttons : [];
+      chips.value = Array.isArray(data.chips) ? data.chips : null;
+    } catch {
+      if (seq === requestSeq) {
+        buttons.value = [];
+        chips.value = null;
+      }
+    }
+  }
+
+  const onFocus = () => void refresh();
+  onMounted(() => {
+    void refresh();
+    window.addEventListener("focus", onFocus);
+  });
+  onBeforeUnmount(() => window.removeEventListener("focus", onFocus));
+  watch([params.cwd, params.session, params.agent], () => void refresh());
+
+  return { buttons, chips, refresh };
+}

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -67,7 +67,7 @@ export function useHeaderButtons(params: Params) {
     window.addEventListener("focus", onFocus);
   });
   onBeforeUnmount(() => window.removeEventListener("focus", onFocus));
-  watch([params.cwd, params.session, params.agent], () => void refresh());
+  watch([params.cwd, params.session, params.agent, () => params.model?.value], () => void refresh());
 
   return { buttons, chips, refresh };
 }

--- a/src/composables/useSessionContext.spec.ts
+++ b/src/composables/useSessionContext.spec.ts
@@ -34,4 +34,20 @@ describe("useSessionContext", () => {
     expect(result.context.value).toBeNull();
     unmount();
   });
+
+  it("drops the old model when the session switches, even if the new fetch fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ context: { model: "claude-opus-4-8", contextTokens: 1 } }))
+      .mockResolvedValueOnce({ ok: false } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    const id = ref<string | null>("sess-1");
+    const { result, unmount } = withSetup(() => useSessionContext(id, ref<string | null>(null)));
+    await flushPromises();
+    expect(result.context.value?.model).toBe("claude-opus-4-8");
+    id.value = "sess-2"; // switch session; the refetch fails (ok:false)
+    await flushPromises();
+    expect(result.context.value).toBeNull(); // no stale sess-1 model
+    unmount();
+  });
 });

--- a/src/composables/useSessionContext.spec.ts
+++ b/src/composables/useSessionContext.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createApp, defineComponent, ref } from "vue";
+import { flushPromises } from "@vue/test-utils";
+import { useSessionContext } from "./useSessionContext";
+
+function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
+  let result!: T;
+  const app = createApp(defineComponent({ setup: () => ((result = composable()), () => null) }));
+  app.mount(document.createElement("div"));
+  return { result, unmount: () => app.unmount() };
+}
+
+const jsonResponse = (body: unknown) => ({ ok: true, json: () => Promise.resolve(body) }) as unknown as Response;
+
+describe("useSessionContext", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("fetches /api/session/:id (with cwd) and exposes the running model", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({ context: { model: "claude-opus-4-8", contextTokens: 42 } })));
+    vi.stubGlobal("fetch", fetchMock);
+    const { result, unmount } = withSetup(() => useSessionContext(ref<string | null>("sess-1"), ref<string | null>("/proj")));
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledWith("/api/session/sess-1?cwd=%2Fproj");
+    expect(result.context.value?.model).toBe("claude-opus-4-8");
+    unmount();
+  });
+
+  it("does not fetch and stays null when there is no session id", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { result, unmount } = withSetup(() => useSessionContext(ref<string | null>(null), ref<string | null>(null)));
+    await flushPromises();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.context.value).toBeNull();
+    unmount();
+  });
+});

--- a/src/composables/useSessionContext.ts
+++ b/src/composables/useSessionContext.ts
@@ -13,12 +13,20 @@ const isContext = (c: unknown): c is SessionContext => typeof c === "object" && 
 export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string | null>) {
   const context = ref<SessionContext | null>(null);
   let requestSeq = 0;
+  let loadedFor: string | null = null; // the session id `context` currently reflects
 
   async function refresh(): Promise<void> {
     const id = sessionId.value;
     if (!id) {
       context.value = null;
+      loadedFor = null;
       return;
+    }
+    // Switched to a different session: drop the old model now, so a slow/failed fetch can't keep
+    // showing the previous session's model. A same-session refresh keeps the last value (no flicker).
+    if (loadedFor !== id) {
+      context.value = null;
+      loadedFor = null;
     }
     const query = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
     const seq = ++requestSeq;
@@ -27,7 +35,10 @@ export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string
       if (seq !== requestSeq || !res.ok) return;
       const data = await res.json();
       // Guard against a stale response: the terminal may have switched session mid-flight.
-      if (seq === requestSeq && id === sessionId.value && isContext(data.context)) context.value = data.context;
+      if (seq === requestSeq && id === sessionId.value && isContext(data.context)) {
+        context.value = data.context;
+        loadedFor = id;
+      }
     } catch {
       // best-effort — `${model}` just renders empty until a later fetch succeeds
     }

--- a/src/composables/useSessionContext.ts
+++ b/src/composables/useSessionContext.ts
@@ -1,0 +1,45 @@
+// Fetches a session's running model + current-turn context size from /api/session/:id.
+// Used where only the model/context is needed (e.g. header `${model}` substitution). Components that
+// also need live activity/usage (TerminalCell) fetch the same endpoint alongside those concerns.
+import { ref, watch, onMounted, onBeforeUnmount, type Ref } from "vue";
+
+export interface SessionContext {
+  model: string | null;
+  contextTokens: number;
+}
+
+const isContext = (c: unknown): c is SessionContext => typeof c === "object" && c !== null && "contextTokens" in c;
+
+export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string | null>) {
+  const context = ref<SessionContext | null>(null);
+  let requestSeq = 0;
+
+  async function refresh(): Promise<void> {
+    const id = sessionId.value;
+    if (!id) {
+      context.value = null;
+      return;
+    }
+    const query = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
+    const seq = ++requestSeq;
+    try {
+      const res = await fetch(`/api/session/${id}${query}`);
+      if (seq !== requestSeq || !res.ok) return;
+      const data = await res.json();
+      // Guard against a stale response: the terminal may have switched session mid-flight.
+      if (seq === requestSeq && id === sessionId.value && isContext(data.context)) context.value = data.context;
+    } catch {
+      // best-effort — `${model}` just renders empty until a later fetch succeeds
+    }
+  }
+
+  const onFocus = () => void refresh();
+  onMounted(() => {
+    void refresh();
+    window.addEventListener("focus", onFocus);
+  });
+  onBeforeUnmount(() => window.removeEventListener("focus", onFocus));
+  watch([sessionId, cwd], () => void refresh());
+
+  return { context, refresh };
+}


### PR DESCRIPTION
## Summary

Makes the **running terminal's header** user-configurable through the existing config files (no new
files), and ships the first working slice: custom **action buttons** that use the running session's live
context. This PR started as a spec (`plans/feat-header-toolbar-config.md`, kept) and now includes the
implementation for the server core, wiring, and client rendering of the `input` / `open` button kinds.

**Hard requirement honored:** with **no config**, the header renders and behaves exactly as today
(`buttons: []`, `chips: null` = unconfigured passthrough — nothing extra shown, built-in chips untouched).

Config shape (canonical JSON), merged from global `~/.mulmoterminal/config.json` (`AppConfig`) +
project `<cwd>/.mulmoterminal.json` (`DirConfig`):

```json
{
  "buttons": [
    { "id": "compact", "emoji": "🗜️", "label": "Compact", "run": "input", "text": "/compact", "when": "agent == claude" },
    { "id": "gh", "emoji": "🌐", "label": "Open on GitHub", "run": "open", "open": { "url": "https://github.com/${repo}" }, "when": "isGitRepo" },
    { "id": "reveal", "emoji": "📁", "label": "Reveal in Finder", "run": "open", "open": { "reveal": "${dir}" } }
  ]
}
```

- `${var}` substitution from the live session context: `dir`, `branch`, `repo`, `ahead`, `behind`,
  `dirty`, `agent`, `model`, `task`.
- `when` mini-language: `isGitRepo` / `agent == …` / `repo == …`, combined with `&&` / `||`
  (`&&` binds tighter). Unknown `${var}` → left literal.

## What's implemented in this PR

- **Server core** (`header-config.ts`, `header-resolve.ts`): types + sanitize + global/project merge;
  `${var}` substitution and `when` evaluation; `resolveHeader()`. Fully unit-tested.
- **Server wiring** (`header-context.ts`, `app-config.ts`, `dir-config.ts`, `config-routes.ts`,
  `index.ts`): builds the live per-session context (dir/branch/repo/ahead/behind/dirty/agent/model/task);
  `AppConfig`/`DirConfig` gain `buttons`/`chips`; `GET /api/header?cwd&session&agent&model` returns the
  resolved header.
- **Client** (`useHeaderButtons.ts`, `useHeaderAction.ts`, `Terminal.vue`): fetches the resolved header
  (refetch on dir/session/agent change + window focus) and renders emoji/icon buttons in the terminal
  header. Dispatch:
  - `run: "input"` → types text into the running claude/codex session (e.g. `/compact`).
  - `run: "open"` → **url** (browser, http/https only) / **reveal** (POST `/api/open-dir`) / **files**
    (in-app explorer) / **view** (prs/wiki/collections/accounting, else files).

## Deferred (follow-ups, not in this PR)

- **`run: "shell"`** — running an arbitrary command in the terminal's dir. `/ws/run` is intentionally
  index-based ("browser never sends a raw command"), so this needs an id-based secure exec route + a
  command-cell handoff. Currently a **no-op with a console warn**, so a `shell` button is inert (not
  dangerous) if configured early.
- **Display chips** — toggle/reorder built-ins + custom display-only chips. The resolver already passes
  `chips` through; the client does not consume them yet (keeps its default header).
- **DSL** (1-line text ⇄ JSON) and a **settings UI** to edit buttons/chips.

## Items to Confirm / Review

1. **Default passthrough** — no config ⇒ `buttons: []`, `chips: null` ⇒ header identical to today.
   Please sanity-check there's no regression when a dir has no `buttons`/`chips`.
2. **`run:open` url safety** — restricted to `http:`/`https:` (e.g. `javascript:` is ignored).
3. **`run:shell` shipping inert** — OK to merge as a no-op-warn now, or hold the whole PR until the secure
   exec route lands?
4. **Per-request context cost** — `/api/header` runs `git status` / `remote get-url` per call
   (refetched on focus/session-change). Acceptable, or should it be cached/debounced?
5. **`when` precedence** — `&&` binds tighter than `||`; unknown `${var}` left literal. Grammar OK?

## User Prompt (consolidated)

> The terminal headers show various data — make it manageable via JSON and a simple DSL so a user can add
> things (a button = emoji + command + args using the running session's context: dir name, git branch, git
> repo, LLM model, codex-or-claude). "Header" = the **running terminal's** header (dir name, context amount,
> open-dir, tools history), **not** session launch. There's already a `.mulmoterminal.json` — merge the
> settings into it rather than a new file. For "open" actions, don't miss the OS/open features that already
> exist (reveal in Finder, in-app file explorer, in-app views), not just URLs. Also: chips should be
> toggle/reorder-able plus allow custom chips; and default (no config) must look exactly like today.

## Notes

- Grounded in the current code: `Terminal.vue` header, `ToolsPane.vue`, `dir-config.ts`, `app-config.ts`,
  `config-routes.ts`, `open-dir.ts`, git-status/worktrees helpers.
- Spec retained as `plans/feat-header-toolbar-config.md`.

Refs #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)
