### PR TITLE
feat: configurable cell header chips — toggle/reorder/custom (Phase 4b-2)

### DIFF
--- a/plans/feat-header-chips.md
+++ b/plans/feat-header-chips.md
@@ -1,0 +1,58 @@
+# Phase 4b-2 — configurable cell header chips (toggle / reorder / custom)
+
+Follow-up to #285 / #288. Makes the **grid cell header's** info chips (`TerminalCell.vue` row 1)
+user-configurable via the `chips` field that already flows through the header config. Scope is the
+**cell header only** — `Terminal.vue`'s own header (single view / zoomed small terminal) is untouched
+(user decision).
+
+## Already in place (server + fetch)
+
+- `resolveHeader` returns `chips: ResolvedChip[] | null` — an **ordered** list of
+  `{kind:"builtin", id}` | `{kind:"custom", label, text}`, or `null` when unconfigured.
+- `chips: null` = unconfigured passthrough. `useHeaderButtons` already fetches `{buttons, chips}` from
+  `/api/header`.
+
+The gap: **no client consumes `chips`.** This PR wires `TerminalCell.vue` row 1 to it.
+
+## Cell header row 1 today (the default)
+
+Structural (always, not reorderable): status dot · activity text (`headerText`) · expand/close buttons ·
+project badge (`dirConfig.name`). Filmstrip thumbnails drop the info chips entirely.
+
+Reorderable/toggleable **built-in chips**: `dir` · `git` · `diff` · `ctx` · `usage` — each already has its
+own data-condition (`headerDir`, `gitStatus`, `showDiffBadge`, `context`, `showUsage`).
+
+`status` and `tools` builtin ids are **not** row-1 reorderable here: `status` is the fixed dot+activity,
+`tools` is the row-2 timeline (🕘). They stay structural; documented, not silently dropped.
+
+## Behavior
+
+- **`chips === null` (default): render EXACTLY today.** Hard requirement. The default path uses a fixed
+  order `["dir","git","diff","ctx","usage"]`, which reproduces the current markup 1:1 (guarded by the
+  existing `TerminalCell.spec` badge assertions + manual check).
+- **`chips` configured:** render the built-in chips in the **configured order**, showing only those listed
+  (omission = hide); each still respects its data-condition. **Custom chips** render as read-only text
+  spans (`label`/`text`, already `${var}`-substituted server-side) in their configured position.
+
+## Implementation
+
+- `TerminalCell.vue`
+  - Consume `chips` for this cell's cwd/session/agent (reuse `useHeaderButtons`, ignore `buttons`; the
+    inner Terminal keeps fetching its own buttons — same endpoint).
+  - A computed `chipOrder`: the configured builtin ids in order, or the default order when `chips===null`.
+  - Render row 1's info chips via a `v-for` over `chipOrder` with a switch on chip id → the existing chip
+    markup (dir/git/diff/ctx/usage), each keeping its `v-if` data-condition. Custom chips render as a new
+    `cell-chip` span.
+  - Filmstrip still drops all info chips (unchanged).
+- No server change (resolveHeader/chips already exist). No `Terminal.vue` change.
+
+## Default == today
+
+Guarded three ways: the default `chipOrder` reproduces the current order; the info-chip block stays inside
+the same `!filmstrip` template; existing `TerminalCell.spec` badge tests must stay green unchanged.
+
+## Tests
+
+- `TerminalCell.spec`: with no chip config, the header still shows dir/git/ctx/usage (unchanged).
+- New: a configured `chips` order reorders/hides built-ins; a custom chip renders its substituted text;
+  an omitted built-in is hidden.

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -498,6 +498,42 @@ describe("TerminalCell", () => {
     expect(badge.text()).toBe("Opus · ctx 35%"); // 70k / 200k
   });
 
+  it("renders configured chips: hides an omitted built-in, keeps a listed one, and shows custom text", async () => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      // chips lists usage + a custom chip, but NOT ctx — so the model badge must be hidden even though context is set.
+      if (u.includes("/api/header"))
+        return {
+          ok: true,
+          json: async () => ({
+            buttons: [],
+            chips: [
+              { kind: "builtin", id: "usage" },
+              { kind: "custom", label: "env", text: "prod" },
+            ],
+          }),
+        };
+      return {
+        ok: true,
+        json: async () => ({
+          working: false,
+          waiting: false,
+          lastPrompt: null,
+          usage: { inputTokens: 100, outputTokens: 200, cacheReadTokens: 0, cacheCreationTokens: 0 },
+          context: { model: "claude-opus-4-8", contextTokens: 70_000 },
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const w = mountCell(id, { initialCwd: "/home/me/proj" });
+    await flushPromises();
+    expect(w.find(".cell-hdr-chip").text()).toBe("prod"); // custom chip renders its substituted text
+    expect(w.find(".cell-usage").exists()).toBe(true); // usage is listed
+    expect(w.find(".cell-model").exists()).toBe(false); // ctx omitted from the list → hidden despite context set
+  });
+
   it("shows no model badge when the session has no model yet", async () => {
     const id = "55555555-5555-5555-5555-555555555555";
     globalThis.fetch = vi.fn(async (url: string) => {

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -534,6 +534,39 @@ describe("TerminalCell", () => {
     expect(w.find(".cell-model").exists()).toBe(false); // ctx omitted from the list → hidden despite context set
   });
 
+  it("renders duplicate built-in chips without key collisions", async () => {
+    const id = "55555555-5555-5555-5555-555555555555";
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      if (u.includes("/api/header"))
+        return {
+          ok: true,
+          json: async () => ({
+            buttons: [],
+            chips: [
+              { kind: "builtin", id: "usage" },
+              { kind: "builtin", id: "usage" },
+            ],
+          }),
+        };
+      return {
+        ok: true,
+        json: async () => ({
+          working: false,
+          waiting: false,
+          lastPrompt: null,
+          usage: { inputTokens: 100, outputTokens: 200, cacheReadTokens: 0, cacheCreationTokens: 0 },
+          context: { model: "claude-opus-4-8", contextTokens: 1 },
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const w = mountCell(id, { initialCwd: "/home/me/proj" });
+    await flushPromises();
+    expect(w.findAll(".cell-usage")).toHaveLength(2); // both duplicates render, unique keys → no collision
+  });
+
   it("shows no model badge when the session has no model yet", async () => {
     const id = "55555555-5555-5555-5555-555555555555";
     globalThis.fetch = vi.fn(async (url: string) => {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -164,9 +164,10 @@ const cellChips = computed<CellChipView[]>(() => {
   const configured = headerChips.value;
   if (configured === null) return DEFAULT_CELL_CHIP_IDS.map((id) => ({ key: `b-${id}`, builtin: id, custom: null }));
   const views: CellChipView[] = [];
+  // Key by index so a config that repeats a built-in (sanitizeChips allows duplicates) can't collide.
   configured.forEach((chip, i) => {
     if (chip.kind === "custom") views.push({ key: `c-${i}`, builtin: null, custom: { label: chip.label, text: chip.text } });
-    else if (ROW1_BUILTIN_CHIPS.has(chip.id)) views.push({ key: `b-${chip.id}`, builtin: chip.id, custom: null });
+    else if (ROW1_BUILTIN_CHIPS.has(chip.id)) views.push({ key: `b-${i}-${chip.id}`, builtin: chip.id, custom: null });
   });
   return views;
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -10,6 +10,7 @@ import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 import GitBranchChip from "./GitBranchChip.vue";
 import ModelContextBadge from "./ModelContextBadge.vue";
 import type { RunCommand } from "./runCommand";
+import { useHeaderButtons } from "../composables/useHeaderButtons";
 import TimelineOverlay from "./TimelineOverlay.vue";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
@@ -146,6 +147,29 @@ interface SessionContext {
 }
 const context = ref<SessionContext | null>(null);
 const isContext = (c: unknown): c is SessionContext => typeof c === "object" && c !== null && "contextTokens" in c;
+
+// Configurable row-1 info chips (GET /api/header `chips`). `null` = unconfigured ⇒ the default order/set
+// below, so with no config the header is exactly as before. When configured, the built-ins listed here
+// (git/diff/ctx/usage) render in that order — others are hidden — and custom chips render as text. `dir`,
+// the project badge, the status dot/activity, and the row-2 tools timeline stay structural.
+const { chips: headerChips } = useHeaderButtons({ cwd, session: sessionId, agent, model: computed(() => context.value?.model ?? null) });
+const ROW1_BUILTIN_CHIPS = new Set(["git", "diff", "ctx", "usage"]);
+const DEFAULT_CELL_CHIP_IDS = ["git", "diff", "ctx", "usage"];
+interface CellChipView {
+  key: string;
+  builtin: string | null;
+  custom: { label: string; text: string } | null;
+}
+const cellChips = computed<CellChipView[]>(() => {
+  const configured = headerChips.value;
+  if (configured === null) return DEFAULT_CELL_CHIP_IDS.map((id) => ({ key: `b-${id}`, builtin: id, custom: null }));
+  const views: CellChipView[] = [];
+  configured.forEach((chip, i) => {
+    if (chip.kind === "custom") views.push({ key: `c-${i}`, builtin: null, custom: { label: chip.label, text: chip.text } });
+    else if (ROW1_BUILTIN_CHIPS.has(chip.id)) views.push({ key: `b-${chip.id}`, builtin: chip.id, custom: null });
+  });
+  return views;
+});
 
 const { subscribe } = usePubSub();
 let unsubscribe: (() => void) | null = null;
@@ -833,13 +857,22 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
              thumbnail, leaving only dir + what it's doing + a zoom button. -->
         <template v-if="!filmstrip">
           <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
-          <GitBranchChip :status="gitStatus" :hide-dirty="isWorktreeCell" />
-          <button v-if="showDiffBadge && diff" type="button" class="cell-wt-badge" :title="`View changes vs ${diff.base ?? 'base'}`" @click="openDiff">
-            <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
-            <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
-          </button>
-          <ModelContextBadge v-if="context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
-          <span v-if="showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
+          <template v-for="chip in cellChips" :key="chip.key">
+            <GitBranchChip v-if="chip.builtin === 'git'" :status="gitStatus" :hide-dirty="isWorktreeCell" />
+            <button
+              v-else-if="chip.builtin === 'diff' && showDiffBadge && diff"
+              type="button"
+              class="cell-wt-badge"
+              :title="`View changes vs ${diff.base ?? 'base'}`"
+              @click="openDiff"
+            >
+              <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
+              <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
+            </button>
+            <ModelContextBadge v-else-if="chip.builtin === 'ctx' && context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
+            <span v-else-if="chip.builtin === 'usage' && showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
+            <span v-else-if="chip.custom" class="cell-hdr-chip" :title="chip.custom.label || chip.custom.text">{{ chip.custom.text }}</span>
+          </template>
         </template>
         <span class="cell-prompt" :title="lastPrompt ?? ''">{{ headerText }}</span>
         <!-- Expand/restore + close stay on row 1 (the info row); the other icons live on
@@ -1330,6 +1363,17 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   color: var(--text-dim);
   white-space: nowrap;
   letter-spacing: 0.02em;
+}
+
+/* A user-defined display-only chip (from the `chips` config). */
+.cell-hdr-chip {
+  flex: 0 0 auto;
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
 }
 
 .cell-actions {


### PR DESCRIPTION
## Summary

Phase 4b-2 (follow-up to #285/#288). The **grid cell header** (`TerminalCell.vue` row 1) info chips are
now user-configurable via the `chips` field that already flows through the header config. Scope is the
**cell header only** — `Terminal.vue`'s own header (single view / zoomed small terminal) is untouched
(user decision).

- **`chips: null` (default) → renders exactly as before.** Hard requirement. The default path uses a fixed
  order `git/diff/ctx/usage`, reproducing today's markup 1:1 (the existing `TerminalCell.spec` badge tests
  stay green, unchanged).
- **`chips` configured →** the built-ins (`git`/`diff`/`ctx`/`usage`) render in the **listed order**;
  a built-in **omitted** from the list is **hidden**; **custom** chips render as read-only text spans
  (`label`/`text`, already `${var}`-substituted server-side) in their configured position.

`dir`, the project badge, the status dot + activity text, the expand/close buttons, and the row-2 tools
timeline (🕘) stay **structural** (not part of the reorderable chip list) — documented, not silently dropped.

## Items to Confirm / Review

1. **Default == today** — with no `chips`, row 1 is unchanged. Guarded by the fixed default order + the
   untouched `TerminalCell.spec` badge assertions.
2. **Scope** — reorder/hide/custom applies to `git`/`diff`/`ctx`/`usage` + custom chips. `dir`/status/tools
   are structural. OK, or should `dir` be toggleable too (it's outside the filmstrip gate, so more involved)?
3. **No server change** — `resolveHeader` already returns the ordered `chips`; this only wires
   `TerminalCell` to consume them (reuses `useHeaderButtons`, ignoring `buttons`).
4. **Class rename** — the custom chip uses `.cell-hdr-chip` (the launch-cell dir presets already own
   `.cell-chip`).

## Try it

```json
"chips": ["ctx", "git", { "label": "env", "text": "⎇ ${branch}", "when": "isGitRepo" }]
```
In a **grid** cell: shows ctx, then git, then a custom "⎇ <branch>" chip; hides diff/usage.

## User Prompt

> Continue with Phase 4b-2 (chip management). Apply it to the cell (TerminalCell) header only; leave
> Terminal.vue's header as-is. Keep default (no config) exactly as today.

Plan: `plans/feat-header-chips.md`. Closes #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
