### PR TITLE
fix: reset the cell header prompt on /clear (stable x-mt-session hook correlation)

### DIFF
--- a/plans/fix-clear-header-prompt.md
+++ b/plans/fix-clear-header-prompt.md
@@ -1,0 +1,46 @@
+# Fix — clear the cell header prompt on `/clear`
+
+## Problem
+
+The grid cell header (`TerminalCell.vue` `.cell-prompt`) shows the session's last user prompt. It comes
+from the server's `lastPrompts` map (set by the `UserPromptSubmit` hook) with the transcript as a
+fallback (`/api/session/:id` → `lastPrompts.get(id) ?? transcriptPrompt`).
+
+When the user runs Claude's **`/clear`**, the conversation restarts but the header keeps showing the
+**pre-clear prompt** — nothing tells the server the conversation was cleared. It only updates once the
+next `UserPromptSubmit` fires.
+
+## Scope (user decision)
+
+Reset **only the header prompt/summary** on `/clear`. Do NOT touch the tool-call history (ToolsPane) or
+anything else. `/compact` is left alone (it keeps the conversation, so the prompt stays relevant).
+
+## Fix
+
+Claude Code fires a `SessionStart` hook with `source: "clear"` on `/clear` (confirmed via docs). The tool
+doesn't register `SessionStart` today.
+
+- **`hookSettingsJson`**: register `SessionStart` (alongside UserPromptSubmit/Stop/…).
+- **`/api/hook`**: when `hook_event_name === "SessionStart"` and `source === "clear"`, blank the header
+  prompt for that `session_id` and publish so the header updates live:
+  - `clearHeaderPrompt(id)` → `lastPrompts.set(id, "")` (empty beats the `?? transcriptPrompt` fallback, so
+    a stale transcript prompt can't resurface) → `publishActivity(id)`.
+- The next `UserPromptSubmit` sets the new query as usual (`preferredHeaderPrompt("", incoming)` returns a
+  meaningful `incoming`), so the header shows the next query. Client shows its neutral fallback (short
+  session id) in between — the same state as a brand-new session.
+
+No client change: `applyActivity` already applies `lastPrompt` (including empty), and `.cell-prompt`
+renders the fallback when it's empty.
+
+## Caveat to verify live
+
+If Claude Code issues a **new `session_id`** on `/clear` (docs report a new `transcript_path` but don't
+confirm whether the id changes when launched with `--session-id`), the hook would fire for the new id and
+the client (keyed by the original id) wouldn't update. mulmoterminal launches with `--session-id`, so the
+id is expected to be stable — but this needs a live `/clear` test. If the id changes, add a remap step.
+
+## Tests
+
+- Unit-test the hook handler path: a `SessionStart`/`source:"clear"` POST blanks `lastPrompts[id]`;
+  `source:"resume"`/`"compact"` and other events don't.
+- `hookSettingsJson` includes `SessionStart`.

--- a/server/index.ts
+++ b/server/index.ts
@@ -645,8 +645,11 @@ function setWaiting(id: string, waiting: boolean, event?: string) {
 // per-session tool-call history that the GUI's tools pane shows. A failed tool
 // fires PostToolUseFailure (NOT PostToolUse), so we register both to complete the
 // entry either way — otherwise a failed call would stay stuck on "running".
-function hookSettingsJson(host: string = "localhost") {
-  const cmd = `curl -s -X POST http://${host}:${PORT}/api/hook ` + `-H 'content-type: application/json' -d @- >/dev/null 2>&1`;
+function hookSettingsJson(host: string, sessionId: string) {
+  // Tag every hook with mulmoterminal's STABLE session id via a header. Claude reissues its own session_id
+  // on /clear and /compact, but the PTY — and the id the client tracks — stays this one, so attributing
+  // hooks by this header keeps activity / header prompt / tool history correlated across a clear.
+  const cmd = `curl -s -X POST http://${host}:${PORT}/api/hook ` + `-H 'content-type: application/json' -H 'x-mt-session: ${sessionId}' -d @- >/dev/null 2>&1`;
   const entry = [{ hooks: [{ type: "command", command: cmd }] }];
   // Tool hooks take a matcher; "" matches all tools.
   const toolEntry = [{ matcher: "", hooks: [{ type: "command", command: cmd }] }];
@@ -1050,7 +1053,11 @@ function clearHeaderPrompt(sessionId: string): void {
 // we can flag which background sessions have new activity / build tool history.
 app.post("/api/hook", async (req, res) => {
   const body = req.body || {};
-  const sessionId = body.session_id;
+  // Prefer the stable mulmoterminal id from the x-mt-session header over Claude's own session_id, which it
+  // reissues on /clear and /compact — the PTY/client id is the one hooks must stay attributed to.
+  const mtHeader = req.headers["x-mt-session"];
+  const mt = typeof mtHeader === "string" && SESSION_ID_RE.test(mtHeader) ? mtHeader : null;
+  const sessionId = mt ?? body.session_id;
   const event = body.hook_event_name;
   if (sessionId) {
     const entry = ptys.get(sessionId);
@@ -1062,11 +1069,7 @@ app.post("/api/hook", async (req, res) => {
       await trackPromptForHeader(sessionId, body.prompt.trim().slice(0, LAST_PROMPT_CAP), cwd);
     }
     // `/clear` fires SessionStart with source "clear" — drop the stale header prompt (not "resume"/"compact").
-    // Log source + whether the id maps to a live PTY, to confirm /clear keeps the launched --session-id.
-    if (event === "SessionStart") {
-      console.log(`[hook] SessionStart source=${body.source} id=${sessionId} livePty=${ptys.has(sessionId)}`);
-      if (body.source === "clear") clearHeaderPrompt(sessionId);
-    }
+    if (event === "SessionStart" && body.source === "clear") clearHeaderPrompt(sessionId);
     handleActivityHook(sessionId, event, foreground);
     await handleToolHook(sessionId, event, body);
     // A hidden translation worker that ends its turn while still pending never called
@@ -1820,7 +1823,7 @@ function spawnClaudePty(
     resume,
     canResume,
     // In the sandbox the hooks + GUI MCP are reached over host.docker.internal.
-    settings: hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost"),
+    settings: hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId),
     permissionMode: CLAUDE_PERMISSION_MODE,
     attachGuiMcp,
     mcpConfig: mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox),

--- a/server/index.ts
+++ b/server/index.ts
@@ -1062,7 +1062,11 @@ app.post("/api/hook", async (req, res) => {
       await trackPromptForHeader(sessionId, body.prompt.trim().slice(0, LAST_PROMPT_CAP), cwd);
     }
     // `/clear` fires SessionStart with source "clear" — drop the stale header prompt (not "resume"/"compact").
-    if (event === "SessionStart" && body.source === "clear") clearHeaderPrompt(sessionId);
+    // Log source + whether the id maps to a live PTY, to confirm /clear keeps the launched --session-id.
+    if (event === "SessionStart") {
+      console.log(`[hook] SessionStart source=${body.source} id=${sessionId} livePty=${ptys.has(sessionId)}`);
+      if (body.source === "clear") clearHeaderPrompt(sessionId);
+    }
     handleActivityHook(sessionId, event, foreground);
     await handleToolHook(sessionId, event, body);
     // A hidden translation worker that ends its turn while still pending never called

--- a/server/index.ts
+++ b/server/index.ts
@@ -655,6 +655,8 @@ function hookSettingsJson(host: string = "localhost") {
       UserPromptSubmit: entry,
       Stop: entry,
       Notification: entry,
+      // SessionStart fires with source "clear" on /clear — we use it to reset the header prompt.
+      SessionStart: entry,
       PreToolUse: toolEntry,
       PostToolUse: toolEntry,
       PostToolUseFailure: toolEntry,
@@ -1036,7 +1038,15 @@ async function trackPromptForHeader(sessionId: string, prompt: string, cwd: stri
   lastPrompts.set(sessionId, preferredHeaderPrompt(lastPrompts.get(sessionId) ?? null, prompt));
 }
 
-// Claude hooks (Stop / Notification / Pre|PostToolUse) POST their payload here so
+// `/clear` restarts the conversation, so the header must stop showing the pre-clear prompt. Blank it
+// (empty string beats the `?? transcriptPrompt` fallback in /api/session, so the old transcript can't
+// resurface) and publish; the next UserPromptSubmit sets the new query.
+function clearHeaderPrompt(sessionId: string): void {
+  lastPrompts.set(sessionId, "");
+  publishActivity(sessionId);
+}
+
+// Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so
 // we can flag which background sessions have new activity / build tool history.
 app.post("/api/hook", async (req, res) => {
   const body = req.body || {};
@@ -1051,6 +1061,8 @@ app.post("/api/hook", async (req, res) => {
       const cwd = typeof body.cwd === "string" ? body.cwd : entry?.cwd;
       await trackPromptForHeader(sessionId, body.prompt.trim().slice(0, LAST_PROMPT_CAP), cwd);
     }
+    // `/clear` fires SessionStart with source "clear" — drop the stale header prompt (not "resume"/"compact").
+    if (event === "SessionStart" && body.source === "clear") clearHeaderPrompt(sessionId);
     handleActivityHook(sessionId, event, foreground);
     await handleToolHook(sessionId, event, body);
     // A hidden translation worker that ends its turn while still pending never called


### PR DESCRIPTION
## Summary

The grid cell header (`.cell-prompt`) showed the session's last user prompt and kept showing the
**pre-clear** prompt after Claude's `/clear` — frozen forever.

**Root cause (confirmed via hook logs):** Claude **reissues its `session_id` on `/clear`** (and `/compact`):
`SessionStart source=clear` fires with a *new* id (`livePty=false`), and every subsequent hook
(UserPromptSubmit/Stop/tools) goes to that new id — which the client, keyed by the original PTY id, never
sees. So the header (and, latently, activity + tool history) drifted.

**Fix — stable hook correlation:** tag every hook with mulmoterminal's stable session id via an
`x-mt-session` header (baked into the hook curl at spawn, the same way the GUI MCP already carries the
session id), and key `/api/hook` off that header instead of Claude's payload `session_id`. Hooks now stay
attributed to the PTY/client id across `/clear` and `/compact`. On top of that, `SessionStart source:"clear"`
blanks the session's header prompt (`lastPrompts[id] = ""`, beating the transcript fallback) and publishes,
so the header clears and the next `UserPromptSubmit` shows the new query.

- Works with **and without tmux** — the hook settings ride `--settings` in both `ptySpawn` branches, and the
  correlation id is mulmoterminal's, not tmux's.
- Scope: header prompt reset on `/clear` only (`/compact` keeps its prompt); tool history is not reset. The
  correlation fix, however, benefits activity/tools across both.

## Verified

- Live `/clear` in a fresh session: header clears and the next query shows (hook log before the fix showed
  `source=clear … livePty=false`, i.e. the id change; after the fix hooks stay on the stable id).
- All gates green (lint / typecheck / typecheck:server / build / 909 tests).

## Note

Server-entry change (`server/index.ts`), which boots on import and isn't unit-tested (unlike the extracted
pure modules) — verified via gates + live test.

## User Prompt

> The header shows the recent command/message/summary. On `/clear` it's a new session, so clear that too and
> show the next user query instead. (And: prefer a header over a URL param for the correlation id.)

Plan: `plans/fix-clear-header-prompt.md`. Closes #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
