### PR TITLE
fix: Shift+Enter inserts a newline again (preventDefault stops the keypress \r)

### DIFF
--- a/src/composables/useTerminalConnections.spec.ts
+++ b/src/composables/useTerminalConnections.spec.ts
@@ -121,13 +121,17 @@ describe("useTerminalConnections — detached-slot state replay", () => {
     if (!ws) throw new Error("no socket created");
     ws.onopen?.(); // open so send() passes the readyState guard
 
-    const shiftEnter = { type: "keydown", key: "Enter", shiftKey: true, altKey: false, ctrlKey: false, metaKey: false };
+    const preventDefault = vi.fn();
+    const shiftEnter = { type: "keydown", key: "Enter", shiftKey: true, altKey: false, ctrlKey: false, metaKey: false, preventDefault };
     expect(mockKeyState.handler(shiftEnter)).toBe(false); // false => xterm won't also emit \r
     expect(ws.sent).toContain(JSON.stringify({ type: "input", data: conn.NEWLINE_SEQUENCE }));
+    expect(preventDefault).toHaveBeenCalled(); // cancels the default so no follow-up keypress leaks a \r
 
     // A plain Enter is left to xterm (returns true, sends nothing extra).
     ws.sent.length = 0;
-    expect(mockKeyState.handler({ type: "keydown", key: "Enter", shiftKey: false, altKey: false, ctrlKey: false, metaKey: false })).toBe(true);
+    expect(
+      mockKeyState.handler({ type: "keydown", key: "Enter", shiftKey: false, altKey: false, ctrlKey: false, metaKey: false, preventDefault: vi.fn() }),
+    ).toBe(true);
     expect(ws.sent).toHaveLength(0);
     conn.release("cell-key");
   });
@@ -168,13 +172,14 @@ describe("isSystemClipboard", () => {
 });
 
 describe("shiftEnterNewline", () => {
-  const ev = (over: Partial<KeyboardEvent>): Pick<KeyboardEvent, "type" | "key" | "shiftKey" | "altKey" | "ctrlKey" | "metaKey"> => ({
+  const ev = (over: Partial<KeyboardEvent>): Pick<KeyboardEvent, "type" | "key" | "shiftKey" | "altKey" | "ctrlKey" | "metaKey" | "preventDefault"> => ({
     type: "keydown",
     key: "Enter",
     shiftKey: false,
     altKey: false,
     ctrlKey: false,
     metaKey: false,
+    preventDefault: () => {},
     ...over,
   });
 
@@ -197,11 +202,13 @@ describe("shiftEnterNewline", () => {
     }
   });
 
-  it("makeShiftEnterHandler sends the newline and cancels the default on Shift+Enter", () => {
+  it("makeShiftEnterHandler sends the newline, cancels the default, and preventDefaults on Shift+Enter", () => {
     const send = vi.fn();
+    const preventDefault = vi.fn();
     const handler = conn.makeShiftEnterHandler(send);
-    expect(handler(ev({ shiftKey: true }))).toBe(false); // false => xterm won't also send \r
+    expect(handler(ev({ shiftKey: true, preventDefault }))).toBe(false); // false => xterm won't also send \r
     expect(send).toHaveBeenCalledWith(conn.NEWLINE_SEQUENCE);
+    expect(preventDefault).toHaveBeenCalled(); // else the browser fires a keypress and xterm submits a bare \r
   });
 
   it("makeShiftEnterHandler passes plain Enter through (returns true, sends nothing)", () => {

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -35,12 +35,17 @@ export function shiftEnterNewline(e: ModifierKeyEvent): string | null {
   return isShiftEnter ? NEWLINE_SEQUENCE : null;
 }
 
-// The xterm custom key handler: on Shift+Enter, `send` the newline and return false
-// (cancel xterm's default \r); otherwise return true so xterm handles the key normally.
-export function makeShiftEnterHandler(send: (data: string) => void): (e: ModifierKeyEvent) => boolean {
+// The xterm custom key handler: on Shift+Enter, `send` the newline and return false (cancel xterm's
+// default \r); otherwise return true so xterm handles the key normally. `preventDefault()` is essential:
+// xterm's _keyDown returns early on a false custom handler WITHOUT preventDefault, so the browser fires a
+// follow-up keypress that _keyPress turns into a bare \r — submitting the prompt. Cancelling the default
+// stops that keypress.
+type ShiftEnterEvent = ModifierKeyEvent & { preventDefault: () => void };
+export function makeShiftEnterHandler(send: (data: string) => void): (e: ShiftEnterEvent) => boolean {
   return (e) => {
     const newline = shiftEnterNewline(e);
     if (newline === null) return true;
+    e.preventDefault();
     send(newline);
     return false;
   };


### PR DESCRIPTION
## Summary

Shift+Enter in the terminal had regressed to **submitting** the prompt instead of inserting a newline.

**Root cause (verified against `@xterm/xterm` 6.0.0 source, not guessed):**
- Our custom key handler returns `false` on Shift+Enter to cancel xterm's `\r` and sends `\x1b\r` (the
  newline) itself.
- But xterm's `_keyDown` returns **early** on a `false` custom handler **without** calling
  `preventDefault()` (and without setting `_keyDownHandled`). So the browser fires a follow-up **keypress**;
  `_keyPress` sees `_keyDownHandled === false`, proceeds, and sends a bare `\r` (Enter's charCode) — which
  **submits** (on top of the `\x1b\r` we already sent).

**Fix:** call `e.preventDefault()` in the handler when intercepting Shift+Enter, so the browser never fires
the keypress → no stray `\r`.

## Isolation

Confirmed the newline byte path itself is fine: **Option+Enter** (which sends `\x1b\r` natively via
`macOptionIsMeta`) still inserts a newline. Only Shift+Enter (our intercept path) leaked a `\r`, pinning the
bug to the missing `preventDefault`.

## Items to Confirm / Review

1. Client-only change — verify by restarting **vite** (no Claude session restart needed) and pressing
   Shift+Enter in a terminal: it should insert a newline, not submit.
2. `preventDefault` is safe here: Shift+Enter is fully owned by us (we send `\x1b\r`), so suppressing the
   browser default (and xterm's hidden-textarea keypress) is intended.

## Tests

`useTerminalConnections.spec.ts`: the Shift+Enter handler now asserts `preventDefault()` is called (both the
wiring test and the unit test). 909 tests green.

## User Prompt

> shift + enter で改行が入るように直したはずだけど、今動かない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)