### PR TITLE
feat: animate grid cell expand/restore with a FLIP transform

### DIFF
--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, watch, nextTick } from "vue";
 import TerminalCell from "./TerminalCell.vue";
 import CommandCell from "./CommandCell.vue";
 import LauncherCell from "./LauncherCell.vue";
 import { trackStyle, layoutForCount } from "./gridLayout";
+import { flipKeyframes, FLIP_MS, FLIP_EASING } from "./cellFlip";
 import type { Cell, CellStatus } from "./gridTabs";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
@@ -43,6 +44,8 @@ const emit = defineEmits<{
 }>();
 
 const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length), null));
+// Hand the flip's timing to the stylesheet so the fade under it can't drift out of sync.
+const flipVars = { "--flip-ms": `${FLIP_MS}ms`, "--flip-ease": FLIP_EASING };
 
 // The zoomed cell is teleported up here; the target must exist before it moves, so
 // hold off until mounted (covers a reload that restores a zoom).
@@ -50,15 +53,57 @@ const zoomMain = ref<HTMLElement | null>(null);
 const mounted = ref(false);
 onMounted(() => (mounted.value = true));
 const zoomed = computed(() => props.expandedUid !== null && mounted.value);
+
+const stage = ref<HTMLElement | null>(null);
+// The cell currently flying between slots. Also gates the stylesheet: the cells it
+// leaves behind fade in under it, and the stage stops taking clicks until it lands.
+const flippingUid = ref<number | null>(null);
+let running: Animation | null = null;
+
+const cellEl = (uid: number) => stage.value?.querySelector<HTMLElement>(`[data-uid="${uid}"]`) ?? null;
+
+function flipCell(uid: number, first: DOMRect) {
+  const el = cellEl(uid);
+  const frames = el && flipKeyframes(first, el.getBoundingClientRect());
+  if (!el || !frames) return;
+  running?.cancel();
+  flippingUid.value = uid;
+  const anim = el.animate(frames, { duration: FLIP_MS, easing: FLIP_EASING });
+  running = anim;
+  const settle = () => {
+    // A newer flip already took over — it owns `running` and the class now.
+    if (running !== anim) return;
+    running = null;
+    flippingUid.value = null;
+  };
+  anim.finished.then(settle, settle); // cancel() rejects, and a cancelled flip still settles
+}
+
+// Pre-flush, so the cell is still in the slot it is leaving when we measure it. Zooming
+// straight from one cell to another reports `to` — the arriving cell is the one to fly.
+watch(
+  () => props.expandedUid,
+  (to, from) => {
+    const uid = to ?? from;
+    if (uid === null || uid === undefined) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const el = cellEl(uid);
+    if (!el) return;
+    const first = el.getBoundingClientRect();
+    nextTick(() => flipCell(uid, first));
+  },
+);
 </script>
 
 <template>
-  <div class="stage" :class="{ zoomed }">
+  <div ref="stage" class="stage" :class="{ zoomed, flipping: flippingUid !== null }" :style="flipVars">
     <div ref="zoomMain" class="zoom-main" />
     <div class="grid" :style="gridStyle">
       <Teleport v-for="cell in cells" :key="cell.uid" :to="zoomMain" :disabled="!(zoomed && cell.uid === expandedUid)">
         <CommandCell
           v-if="cell.command"
+          :data-uid="cell.uid"
+          :class="{ flipping: cell.uid === flippingUid }"
           :expanded="cell.uid === expandedUid"
           :zoomed="zoomed"
           :command="cell.command"
@@ -72,6 +117,8 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
         <LauncherCell
           v-else-if="cell.launcher"
           :uid="cell.uid"
+          :data-uid="cell.uid"
+          :class="{ flipping: cell.uid === flippingUid }"
           :expanded="cell.uid === expandedUid"
           :zoomed="zoomed"
           :launcher="cell.launcher"
@@ -88,6 +135,8 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
         <TerminalCell
           v-else
           :uid="cell.uid"
+          :data-uid="cell.uid"
+          :class="{ flipping: cell.uid === flippingUid }"
           :expanded="cell.uid === expandedUid"
           :zoomed="zoomed"
           :initial-session-id="cell.session"
@@ -170,5 +219,40 @@ const zoomed = computed(() => props.expandedUid !== null && mounted.value);
   flex: 0 0 260px;
   height: 100%;
   min-width: 0;
+}
+
+/* A second click landing mid-flight would measure a transformed cell and flip from the
+   wrong rect, so the stage stays inert until the cell lands. */
+.stage.flipping {
+  pointer-events: none;
+}
+
+/* Restoring shrinks the cell from the overlay's rect back into its grid slot, so it
+   starts out overflowing its siblings — it has to paint above them the whole way. */
+.stage.flipping .flipping {
+  z-index: 1;
+}
+
+/* Only the zoomed cell has two rects to fly between. The cells it leaves behind are
+   arriving in (or vanishing from) a strip that has no counterpart in the other layout,
+   so they cross-fade under it instead. */
+.stage.flipping .grid > *:not(.flipping) {
+  animation: cell-in var(--flip-ms) var(--flip-ease);
+}
+.stage.flipping.zoomed .grid > *:not(.flipping) {
+  animation-name: strip-in;
+}
+
+@keyframes cell-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes strip-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
 }
 </style>

--- a/src/components/cellFlip.spec.ts
+++ b/src/components/cellFlip.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { flipKeyframes, FLIP_MS, FLIP_EASING } from "./cellFlip";
+
+const rect = (left: number, top: number, width: number, height: number) => ({ left, top, width, height });
+
+describe("cellFlip", () => {
+  it("exposes the timing the stylesheet and the animation share", () => {
+    expect(FLIP_MS).toBe(180);
+    expect(FLIP_EASING).toBe("cubic-bezier(0.2, 0, 0, 1)");
+  });
+
+  it("inverts an expand: starts at the old slot, ends at identity", () => {
+    // A 100x50 cell at (10, 20) grows to fill a 400x200 overlay at the origin.
+    const frames = flipKeyframes(rect(10, 20, 100, 50), rect(0, 0, 400, 200));
+    expect(frames).toEqual([
+      { transformOrigin: "top left", transform: "translate(10px, 20px) scale(0.25, 0.25)" },
+      { transformOrigin: "top left", transform: "none" },
+    ]);
+  });
+
+  it("inverts a restore: the same move read backwards", () => {
+    const frames = flipKeyframes(rect(0, 0, 400, 200), rect(10, 20, 100, 50));
+    expect(frames).toEqual([
+      { transformOrigin: "top left", transform: "translate(-10px, -20px) scale(4, 4)" },
+      { transformOrigin: "top left", transform: "none" },
+    ]);
+  });
+
+  it("keeps the axes independent when the aspect ratio changes", () => {
+    const frames = flipKeyframes(rect(0, 0, 100, 100), rect(0, 0, 400, 200));
+    expect(frames?.[0].transform).toBe("translate(0px, 0px) scale(0.25, 0.5)");
+  });
+
+  it("skips a cell that has not been laid out (zero-area destination)", () => {
+    expect(flipKeyframes(rect(0, 0, 100, 50), rect(0, 0, 0, 0))).toBeNull();
+    expect(flipKeyframes(rect(0, 0, 100, 50), rect(0, 0, 400, 0))).toBeNull();
+    expect(flipKeyframes(rect(0, 0, 100, 50), rect(0, 0, 0, 200))).toBeNull();
+  });
+
+  it("skips a move that would be invisible", () => {
+    expect(flipKeyframes(rect(0, 0, 400, 200), rect(0, 0, 400, 200))).toBeNull();
+    // Sub-pixel drift and a sub-percent resize both stay under the threshold.
+    expect(flipKeyframes(rect(0.4, -0.6, 400, 200), rect(0, 0, 400.5, 200.5))).toBeNull();
+  });
+
+  it("animates once any single axis crosses the threshold", () => {
+    expect(flipKeyframes(rect(2, 0, 400, 200), rect(0, 0, 400, 200))).not.toBeNull();
+    expect(flipKeyframes(rect(0, 2, 400, 200), rect(0, 0, 400, 200))).not.toBeNull();
+    expect(flipKeyframes(rect(0, 0, 440, 200), rect(0, 0, 400, 200))).not.toBeNull();
+    expect(flipKeyframes(rect(0, 0, 400, 220), rect(0, 0, 400, 200))).not.toBeNull();
+  });
+
+  it("survives a destination larger than the viewport without losing precision", () => {
+    const frames = flipKeyframes(rect(-50, -50, 260, 150), rect(0, 0, 2600, 1500));
+    expect(frames?.[0].transform).toBe("translate(-50px, -50px) scale(0.1, 0.1)");
+  });
+});

--- a/src/components/cellFlip.ts
+++ b/src/components/cellFlip.ts
@@ -1,0 +1,36 @@
+// Zooming re-parents a cell between the grid slot and the zoom overlay in a single Vue
+// patch — a move no CSS transition can interpolate. So we FLIP it: measure the cell
+// before the patch and after it, then play the move backwards, starting from the
+// transform that puts it back where it looked and animating to identity.
+//
+// Transform-only on purpose. It never touches the layout box, so xterm's ResizeObserver
+// refits once (when the patch lands) rather than on every animation frame.
+
+export type Rect = Pick<DOMRect, "left" | "top" | "width" | "height">;
+
+export const FLIP_MS = 180;
+export const FLIP_EASING = "cubic-bezier(0.2, 0, 0, 1)";
+
+// Under these thresholds the move reads as static, and animating it would buy a repaint
+// and nothing else.
+const MIN_SHIFT_PX = 1;
+const MIN_SCALE_DELTA = 0.01;
+
+const isImperceptible = (dx: number, dy: number, sx: number, sy: number) =>
+  Math.abs(dx) < MIN_SHIFT_PX && Math.abs(dy) < MIN_SHIFT_PX && Math.abs(sx - 1) < MIN_SCALE_DELTA && Math.abs(sy - 1) < MIN_SCALE_DELTA;
+
+// Null when there is nothing worth animating: a `last` of zero area means the cell isn't
+// laid out yet, and scaling by its reciprocal would blank the cell for the whole flight.
+export function flipKeyframes(first: Rect, last: Rect): Keyframe[] | null {
+  if (last.width <= 0 || last.height <= 0) return null;
+  const dx = first.left - last.left;
+  const dy = first.top - last.top;
+  const sx = first.width / last.width;
+  const sy = first.height / last.height;
+  if (isImperceptible(dx, dy, sx, sy)) return null;
+  const origin = "top left";
+  return [
+    { transformOrigin: origin, transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})` },
+    { transformOrigin: origin, transform: "none" },
+  ];
+}


### PR DESCRIPTION
## Summary

Grid view のセルを expand / restore するときに、元のグリッド枠と拡大枠のあいだをアニメーションで繋ぐようにしました。

expand はセルを `Teleport` で `.zoom-main` へ再配置しつつ、グリッドを `display: grid` → `display: flex`（フィルムストリップ）に切り替えます。これは CSS transition で補間できないレイアウト変更なので、**FLIP**（patch 前後で矩形を測り、「元の位置に戻す transform」から `none` へアニメーション）で実装しました。ズームされるセルだけが飛び、残りのセルはその下でフェードインします。

transform のみを使うため、xterm の `ResizeObserver` は patch 時に一度だけ refit され、毎フレーム走ることはありません。

- `src/components/cellFlip.ts`（新規）— 2つの矩形から逆変換キーフレームを組み立てる純関数。`gridLayout.ts` / `cellHeaderZoom.ts` と同じ「純関数 + spec」構成。
- `src/components/cellFlip.spec.ts`（新規）— spec 8件。
- `src/components/TerminalGrid.vue` — `expandedUid` の pre-flush watch で矩形を測り、`nextTick` 後に WAAPI で再生。フェードと click ロックの CSS。

## Items to Confirm / Review

レビューで特に見てほしい点です。

1. **⚠️ 飛行中の文字の歪みを許容できるか。** FLIP は「着地サイズでレイアウトしてから縮める」ため、開始フレームの内容は `scale(sx, sy)` で歪みます。2列1行のレイアウトでは `scale(0.498, 1.205)` となり、**横は縮み・縦は伸びる**ので文字が細長く潰れます。イージングが前寄り（90ms 時点で約88%進行）なので実時間では一瞬ですが、ターミナルは文字が主役なので `FLIP_MS` を 180 → 140 に下げる余地はあります。

2. **⚠️ `pointer-events: none` はキーボード起動を止めない。** ⤢ にフォーカスがある状態で Enter を連打すると、hit-test を経由しないので飛行中の `flipCell` に再入します。`flipCell` の識別子ガード（`running !== anim` なら settle をスキップ）が唯一の防波堤で、実測では破綻しませんでした（下記検証 step 5）。**「連打は CSS ロックで防げている」という前提でこのガードを外すと壊れます。**

3. **展開時に、飛翔セルが伸びていく先の領域が一瞬空白になる。** 他セルが即座にストリップへ退避してフェードインするためです。意図した絵かどうかは実際に触って判断してください。フェードと FLIP は `--flip-ms` / `--flip-ease` を共有しているので必ず同時に着地します。

4. **`data-uid` / `:class` のフォールスルー。** 3つのセルコンポーネント（`TerminalCell` / `LauncherCell` / `CommandCell`）はいずれも単一ルートで `inheritAttrs` を無効化していないため、ルート要素に落ちます。`TerminalCell` はルートに既存の `:class="statusClass"` があり、実行時に `"cell is-idle flipping"` と正しくマージされることを確認済みです。`CommandCell`（`script.json` 実行セル）経路だけは実行環境を用意できず未検証ですが、付与の仕方は他2つと同一です。

## User Prompt

> expandするときに、アニメーションがあったほうがよいかも。
>
> grid view の terminal の話ね

## 実装方針と主な判断

### なぜ FLIP か

`.stage.zoomed` クラスが付くと `.grid` が `display: grid` から `display: flex` に変わり、ズームセルは `Teleport` で `.zoom-main` へ移ります。この2つはどちらも CSS transition の補間対象外です。一方 `Teleport` は DOM ノードを**移動するだけで再生成しない**ため、xterm の状態を保ったまま同一ノードに FLIP をかけられます。

`transform` のみを触るのでレイアウトボックスは動かず、`ResizeObserver` は patch 時の1回だけ発火します。つまりアニメーション中に xterm の refit が走りません。

### スコープ

「ズームセルだけ FLIP、残りはフェード」を選びました。全セルを FLIP させる案もありましたが、zoom 中は GridView が全タブのセルを渡すため「移動元の矩形が存在しないセル」のフォールバックが必要になり、複雑さに見合いません。

### 実装の細部

- **pre-flush watch**: `watch(() => props.expandedUid)` はデフォルトで子の再レンダリング前に走るので、そこで「移動前」の矩形を測れます。`nextTick` 後に「移動後」を測って逆変換を組み立てます。
- **`to ?? from`**: expand は `to`、restore は `from` がズームセル。ズーム中に別セルのヘッダをクリックして直接切り替えた場合（`A → B`）は `to` が返り、**到着側**のセルが飛びます。
- **識別子ガード**: `anim.finished` の settle は `running === anim` のときだけ状態を片付けます。`cancel()` の reject はマイクロタスクで遅れて届くため、これが無いと後発のアニメーションが立てた `flippingUid` を先発が消してしまいます。
- **`z-index: 1`**: restore ではセルが拡大枠から縮んで戻るので、開始時は兄弟セルにはみ出します。飛行中ずっと上に描く必要があります。
- **`prefers-reduced-motion`**: `matchMedia` で判定し、アニメーションを1本も生成しません（トグル機能自体は残ります）。
- **タイミングの単一情報源**: `FLIP_MS` / `FLIP_EASING` を `--flip-ms` / `--flip-ease` として `.stage` に流し込み、CSS 側のフェードとズレないようにしています。

## 検証

ローカルで実ブラウザ（puppeteer）を駆動して確認しました。`HOME` を隔離し、`bash` launcher を仕込んだ dev サーバに対して実施しています。

1. 左上でないセルを expand → キーフレームは `translate(697px, 0px) scale(0.4978, 0.5980)` → `none`、`duration: 180`, `easing: cubic-bezier(0.2, 0, 0, 1)`。
2. `currentTime = 0` に固定して描画矩形を実測 → 展開前のグリッド枠と**誤差ゼロ**（dx=dy=dw=dh=0）。t=180ms でズーム枠に着地。
3. 飛行中に**実マウスで6連打** → 生成アニメは1本のみ、最終状態 `zoomed: false`。ロックが5発を飲み込んだ（効いていなければ偶数回トグルで `zoomed: true` に戻る）。
4. **キーボードで飛行中に9回トグル（25ms間隔）** → `zoomed: true`（奇数回で整合）、`.flipping` 残留 0、stale transform 0。識別子ガードが持ちこたえた。
5. expand / restore 後にターミナルへ入力 → `verify-ok-42` を確認。PTY 生存、xterm は再描画・入力とも正常。
6. `prefers-reduced-motion: reduce` → 生成アニメ **0本**、トグル機能は成立。
7. ズーム中に別セルのヘッダをクリック → 到着側セルが FLIP（`zoomedUid` が `0` → `2`）。
8. `TerminalCell`（Claude エージェント）経路でも開始フレームが旧枠と誤差ゼロ、着地後 `transform: none`。
9. 全ドライブ通じて console error / pageerror **ゼロ**。

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn build` / `yarn test`（872件）すべて通過。

## 補足（このPRの範囲外）

- `node_modules` に TypeScript **7.0.2** が入っている一方 `yarn.lock` は **6.0.3** を指しており、TS7 が `./lib/tsc` の subpath export を廃止したため、**クリーンな `origin/main` でも** `yarn lint` と `yarn build` / `yarn typecheck` が落ちる状態でした。`yarn install --frozen-lockfile` で解消します。この変更とは無関係です。
- `gridLayout.ts` の `trackStyle(layout, expanded)` の `expanded` 分岐（他トラックを `0fr` に潰す、コメントに "animated by the caller"）は spec からしか呼ばれていない死にコードです。今回の FLIP は transform ベースでこの分岐を使いません。以前のアニメーション案の名残と思われますが、スコープを混ぜないため別PRに回しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
