### PR TITLE
refactor: drop trackStyle's dead zoom argument

### DIFF
--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
   (e: "record-cwd" | "remove-preset", value: string): void;
 }>();
 
-const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length), null));
+const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length)));
 // Hand the flip's timing to the stylesheet so the fade under it can't drift out of sync.
 const flipVars = { "--flip-ms": `${FLIP_MS}ms`, "--flip-ease": FLIP_EASING };
 

--- a/src/components/gridLayout.spec.ts
+++ b/src/components/gridLayout.spec.ts
@@ -42,26 +42,30 @@ describe("gridLayout", () => {
     expect(layoutForCount(12)).toBe("3x3");
   });
 
-  it("trackStyle: full even tracks when nothing is zoomed", () => {
-    expect(trackStyle("3x2", null)).toEqual({
+  it("trackStyle: one equal track per cell", () => {
+    expect(trackStyle("3x2")).toEqual({
       gridTemplateColumns: "1fr 1fr 1fr",
       gridTemplateRows: "1fr 1fr",
       gap: "6px",
     });
+    expect(trackStyle("1")).toEqual({
+      gridTemplateColumns: "1fr",
+      gridTemplateRows: "1fr",
+      gap: "6px",
+    });
+    expect(trackStyle("3x3")).toEqual({
+      gridTemplateColumns: "1fr 1fr 1fr",
+      gridTemplateRows: "1fr 1fr 1fr",
+      gap: "6px",
+    });
   });
 
-  it("trackStyle: collapses other tracks around the zoomed cell", () => {
-    // 3x3, expand index 4 (center): col 1, row 1.
-    expect(trackStyle("3x3", 4)).toEqual({
-      gridTemplateColumns: "0fr 1fr 0fr",
-      gridTemplateRows: "0fr 1fr 0fr",
-      gap: "0px",
-    });
-    // index 0 (top-left): col 0, row 0.
-    expect(trackStyle("3x3", 0)).toEqual({
-      gridTemplateColumns: "1fr 0fr 0fr",
-      gridTemplateRows: "1fr 0fr 0fr",
-      gap: "0px",
+  it("trackStyle: covers every layout", () => {
+    LAYOUTS.forEach((layout) => {
+      const { cols, rows } = dims(layout);
+      const style = trackStyle(layout);
+      expect(style.gridTemplateColumns.split(" ")).toHaveLength(cols);
+      expect(style.gridTemplateRows.split(" ")).toHaveLength(rows);
     });
   });
 });

--- a/src/components/gridLayout.ts
+++ b/src/components/gridLayout.ts
@@ -32,17 +32,9 @@ export function layoutForCount(count: number): Layout {
   return LAYOUTS.find((l) => dims(l).cellCount >= n) ?? "3x3";
 }
 
-// CSS grid track template for the layout, or — when a cell is zoomed — collapse
-// every other track to 0fr so that cell fills the area (animated by the caller).
-export function trackStyle(layout: Layout, expanded: number | null) {
+// CSS grid track template for the layout: equal tracks, one per cell.
+export function trackStyle(layout: Layout) {
   const { cols, rows } = dims(layout);
-  const tracks = (count: number, active: number) => Array.from({ length: count }, (_, n) => (active < 0 || n === active ? "1fr" : "0fr")).join(" ");
-  if (expanded === null) {
-    return { gridTemplateColumns: tracks(cols, -1), gridTemplateRows: tracks(rows, -1), gap: "6px" };
-  }
-  return {
-    gridTemplateColumns: tracks(cols, expanded % cols),
-    gridTemplateRows: tracks(rows, Math.floor(expanded / cols)),
-    gap: "0px",
-  };
+  const tracks = (count: number) => Array.from({ length: count }, () => "1fr").join(" ");
+  return { gridTemplateColumns: tracks(cols), gridTemplateRows: tracks(rows), gap: "6px" };
 }


### PR DESCRIPTION
## Summary

`gridLayout.ts` の `trackStyle(layout, expanded)` から、到達不能になっていた第2引数と `0fr` 分岐を削除します。**挙動の変更はありません。**

```diff
-export function trackStyle(layout: Layout, expanded: number | null) {
+export function trackStyle(layout: Layout) {
   const { cols, rows } = dims(layout);
-  const tracks = (count: number, active: number) => Array.from({ length: count }, (_, n) => (active < 0 || n === active ? "1fr" : "0fr")).join(" ");
-  if (expanded === null) {
-    return { gridTemplateColumns: tracks(cols, -1), gridTemplateRows: tracks(rows, -1), gap: "6px" };
-  }
-  return {
-    gridTemplateColumns: tracks(cols, expanded % cols),
-    gridTemplateRows: tracks(rows, Math.floor(expanded / cols)),
-    gap: "0px",
-  };
+  const tracks = (count: number) => Array.from({ length: count }, () => "1fr").join(" ");
+  return { gridTemplateColumns: tracks(cols), gridTemplateRows: tracks(rows), gap: "6px" };
 }
```

## Items to Confirm / Review

1. **本番の呼び出し元は 1 箇所だけで、常に `null` を渡していました。** `TerminalGrid.vue:47` の `trackStyle(layoutForCount(props.cells.length), null)` のみ。`0fr` を返す分岐に到達できるのは `gridLayout.spec.ts` だけで、テストは通っていても何も保証していない状態でした。
2. **削除した spec の代わりに、等分トラックのテストを追加しています。** `trackStyle: one equal track per cell`（`1` / `3x2` / `3x3` の境界を明示）と `trackStyle: covers every layout`（全レイアウトで cols/rows 本数が `dims()` と一致することを検証）。カバレッジは実質増えています。
3. **挙動が同一であることの確認方法**: `trackStyle` は `expanded === null` のとき常に `1fr` 等分 + `gap: "6px"` を返していました。新実装も同じオブジェクトを返します。呼び出し元は `null` しか渡していなかったため、レンダリング結果は 1 ピクセルも変わりません。ブラウザでの再検証は不要と判断しました。

## User Prompt

> PR 本文の末尾に書いた gridLayout.ts の trackStyle(layout, expanded) の死にコード　これってなに？詳しく教えて
>
> （調査の結果を受けて）はい。すすめて

#298 の PR 本文末尾で「別 PR に回す」と書いた死にコードの削除です。

## なぜ死んだのか（履歴）

この引数は、**今回 #298 で作り直したズームアニメーションの前任者**の遺物でした。

**2026-06-19 `709419a` feat(grid): animated zoom** — 最初のズームアニメーションが入る。セルをグリッドの中に置いたまま、CSS グリッドのトラック幅を伸縮させる方式だった。

```js
const gridStyle = computed(() => trackStyle(props.layout, expanded.value));  // ← 非 null が渡っていた
```

```css
.grid {
  /* Mac-like zoom: animate the track sizes (and gap) as a cell expands/restores. */
  transition:
    grid-template-columns 0.24s cubic-bezier(0.22, 1, 0.36, 1),
    grid-template-rows 0.24s cubic-bezier(0.22, 1, 0.36, 1),
    gap 0.24s cubic-bezier(0.22, 1, 0.36, 1);
}
```

`trackStyle` のコメントにあった **"(animated by the caller)"** の "caller" とは、この CSS の `transition` を指していました。関数は値を返すだけで、補間は呼び出し側が担当する分業。

**2026-06-21 `99e171c` feat(grid): filmstrip zoom** — わずか 2 日後に設計が置き換わる。ズームセルは `Teleport` で `.zoom-main` へ移り、`.grid` は `display: flex` の横スクロールストリップになった。`transition` は削除され、呼び出しは `trackStyle(layout, null)` に固定。

このとき `expanded !== null` の分岐と、それを叩く spec だけが取り残されました。以来 `display: grid → flex` の切り替えは CSS transition の補間対象外なので、当時の方式に戻る道はありません。

**2026-07-09 #298** — FLIP transform でズームアニメーションが復活。transform ベースなので、この分岐を将来使う見込みも消えました。

## なぜ今消すのか

コメントの `(animated by the caller)` が**存在しない caller** を指しており、読んだ人が「どこかに transition があるはずだ」と探しに行きます。テストがあるせいで死にコードに見えないのも、たちが悪いところでした。

#298 で FLIP がマージされ、前任のアプローチが不要であることが確定したので、今が消し時です。

## 検証

- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn build` すべて通過
- `yarn test` — **918 tests / 93 files すべて通過**
- `git grep` で `0fr` および grid-track の `transition` がコードベースから消えたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
