### PR TITLE
feat: live-reload .mulmoterminal.json without filesystem watchers

### DIFF
--- a/plans/feat-dir-config-live-reload.md
+++ b/plans/feat-dir-config-live-reload.md
@@ -1,0 +1,63 @@
+# feat — live-reload `.mulmoterminal.json` without filesystem watchers
+
+Issue: #302
+
+## Problem
+
+Editing `<cwd>/.mulmoterminal.json` does nothing until the browser reloads:
+
+```ts
+// src/composables/useDirConfig.ts
+// ...the config is stable for the page's lifetime (changes to the file take
+// effect on the next page load — MVP, no live watch).
+const cache = new Map<string, Promise<DirConfig>>();
+```
+
+The `mulmoterminal-config` skill's colour loop is *apply → look at the real cell → adjust* (there is no
+way to preview colour inside the conversation — Claude Code doesn't render ANSI, and a Bash child has
+no controlling terminal). So the manual reload is the rate limiter of the whole flow.
+
+## Why not `fs.watch`
+
+Working directories are scattered across the disk, so a watcher can't be shared: one per open cwd.
+Instead, make the **writer announce the change** — push, not poll.
+
+## Design — zero watchers, no new endpoint
+
+The server *already* sees every write. Claude's `PreToolUse`/`PostToolUse` hooks POST to `/api/hook`
+with `tool_name` and `tool_input` (used today to build the per-session tool-call timeline, see
+`handleToolHook` in `server/index.ts`). A write to `<dir>/.mulmoterminal.json` is therefore already
+observable — no new machinery.
+
+1. **`server/dir-config.ts`** — pure, testable helper:
+   `dirConfigWriteTarget(toolName, toolInput): string | null` → the directory whose config a
+   file-writing tool (`Write` / `Edit` / `MultiEdit`) just wrote, else null.
+2. **`server/index.ts`** — in `handleToolHook`, on `PostToolUse` only (a `PostToolUseFailure` wrote
+   nothing), publish `pubsub.publish("dir-config", { cwd })`.
+3. **`src/composables/useDirConfig.ts`** — subscribe once to the `dir-config` channel; on a message
+   drop that cwd from `cache`, refetch, and push the result into every live `config` ref bound to it.
+
+Nothing else is needed on the client: `Terminal.vue` already re-applies the xterm palette via
+`watch([themeId, () => props.dirTheme, () => props.dirColors], …)`, and the chrome colours are plain
+reactive props.
+
+## Preserved behaviour
+
+- Channel naming follows the existing convention (plain literal, e.g. `"sessions"`), duplicated
+  client-side like `useSessions` / `useAttentionSound` do.
+- `useDirConfig` keeps its shape (`{ config }`), still dedupes one fetch per cwd across cells, and
+  still ignores a stale resolve after a fast directory switch.
+- Refs unregister on scope dispose, so a closed cell leaks nothing.
+
+## Trade-off (accepted)
+
+Only writes made through Claude's tools are detected; editing the file in vim will not live-reload.
+That covers the skill flow completely, so an explicit `POST /api/dir-config/reload` is not worth the
+extra surface. Revisit if hand-editing turns out to be common.
+
+## Verification
+
+- Unit: `dirConfigWriteTarget` — matching write tool + path, wrong tool, wrong filename, non-record
+  input, relative path, `PostToolUseFailure` not published.
+- Live: drive the app, change a directory's palette, and confirm the terminal recolours **without a
+  reload** (read the xterm background via computed style).

--- a/server/dir-config.spec.ts
+++ b/server/dir-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile } from "./dir-config";
+import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "./dir-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
 const EMPTY = {
@@ -179,6 +179,37 @@ describe("loadDirConfig", () => {
     const arr = withConfig([1, 2, 3]);
     expect(loadDirConfig(arr.dir)).toEqual(EMPTY);
     arr.cleanup();
+  });
+});
+
+describe("dirConfigWriteTarget", () => {
+  const file = "/Users/me/proj/.mulmoterminal.json";
+
+  it("returns the directory for each file-writing tool", () => {
+    for (const tool of ["Write", "Edit", "MultiEdit"]) {
+      expect(dirConfigWriteTarget(tool, { file_path: file })).toBe("/Users/me/proj");
+    }
+  });
+
+  it("resolves a relative path to an absolute directory", () => {
+    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" })).toBe(path.resolve("."));
+  });
+
+  it("ignores tools that don't write the file", () => {
+    expect(dirConfigWriteTarget("Read", { file_path: file })).toBeNull();
+    expect(dirConfigWriteTarget("Bash", { command: `echo x > ${file}` })).toBeNull();
+  });
+
+  it("ignores writes to any other file", () => {
+    expect(dirConfigWriteTarget("Write", { file_path: "/Users/me/proj/package.json" })).toBeNull();
+    expect(dirConfigWriteTarget("Write", { file_path: "/Users/me/.mulmoterminal.json.bak" })).toBeNull();
+  });
+
+  it("returns null for malformed payloads", () => {
+    expect(dirConfigWriteTarget("Write", null)).toBeNull();
+    expect(dirConfigWriteTarget("Write", {})).toBeNull();
+    expect(dirConfigWriteTarget("Write", { file_path: 42 })).toBeNull();
+    expect(dirConfigWriteTarget(undefined, { file_path: file })).toBeNull();
   });
 });
 

--- a/server/dir-config.spec.ts
+++ b/server/dir-config.spec.ts
@@ -191,8 +191,19 @@ describe("dirConfigWriteTarget", () => {
     }
   });
 
-  it("resolves a relative path to an absolute directory", () => {
-    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" })).toBe(path.resolve("."));
+  it("resolves a relative path against the SESSION cwd, not the server's", () => {
+    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" }, "/Users/me/proj")).toBe("/Users/me/proj");
+    expect(dirConfigWriteTarget("Write", { file_path: "sub/.mulmoterminal.json" }, "/Users/me/proj")).toBe("/Users/me/proj/sub");
+  });
+
+  it("publishes nothing for a relative path when the session cwd is unknown", () => {
+    // Resolving against process.cwd() would invalidate the wrong dir AND miss the real one.
+    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" })).toBeNull();
+    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" }, null)).toBeNull();
+  });
+
+  it("ignores the session cwd for an absolute path", () => {
+    expect(dirConfigWriteTarget("Write", { file_path: file }, "/somewhere/else")).toBe("/Users/me/proj");
   });
 
   it("ignores tools that don't write the file", () => {

--- a/server/dir-config.ts
+++ b/server/dir-config.ts
@@ -59,13 +59,17 @@ const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "obj
 // filesystem watchers (cwds are scattered, so a watcher can't be shared across terminals).
 const WRITE_TOOLS: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit"]);
 
-/** The directory whose `.mulmoterminal.json` a tool call just wrote, or null for anything else. */
-export function dirConfigWriteTarget(toolName: unknown, toolInput: unknown): string | null {
+/** The directory whose `.mulmoterminal.json` a tool call just wrote, or null for anything else.
+ *  A relative `file_path` is relative to the SESSION's cwd, never the server process's — resolving
+ *  it against `process.cwd()` would invalidate a directory nobody is looking at AND miss the real
+ *  one, so without a known session cwd we publish nothing. */
+export function dirConfigWriteTarget(toolName: unknown, toolInput: unknown, sessionCwd: string | null = null): string | null {
   if (typeof toolName !== "string" || !WRITE_TOOLS.has(toolName)) return null;
   if (!isRecord(toolInput) || typeof toolInput.file_path !== "string") return null;
   const file = toolInput.file_path;
   if (path.basename(file) !== DIR_CONFIG_FILE) return null;
-  return path.dirname(path.resolve(file));
+  if (path.isAbsolute(file)) return path.dirname(path.resolve(file));
+  return sessionCwd ? path.dirname(path.resolve(sessionCwd, file)) : null;
 }
 
 const isInside = (base: string, target: string): boolean => target === base || target.startsWith(base + path.sep);

--- a/server/dir-config.ts
+++ b/server/dir-config.ts
@@ -55,6 +55,19 @@ export interface PublicDirConfig {
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
+// Claude's tool hooks already report every write, so they double as the live-reload signal — no
+// filesystem watchers (cwds are scattered, so a watcher can't be shared across terminals).
+const WRITE_TOOLS: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit"]);
+
+/** The directory whose `.mulmoterminal.json` a tool call just wrote, or null for anything else. */
+export function dirConfigWriteTarget(toolName: unknown, toolInput: unknown): string | null {
+  if (typeof toolName !== "string" || !WRITE_TOOLS.has(toolName)) return null;
+  if (!isRecord(toolInput) || typeof toolInput.file_path !== "string") return null;
+  const file = toolInput.file_path;
+  if (path.basename(file) !== DIR_CONFIG_FILE) return null;
+  return path.dirname(path.resolve(file));
+}
+
 const isInside = (base: string, target: string): boolean => target === base || target.startsWith(base + path.sep);
 
 // Confine the configured sound to a real file INSIDE cwd. Relative paths only;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1037,7 +1037,7 @@ async function handleToolHook(sessionId: string, event: string, p: HookToolPaylo
   // A SUCCESSFUL write to <dir>/.mulmoterminal.json is the live-reload signal: the hook that already
   // reports every tool call tells the client to re-read that directory's config, so no fs watchers.
   if (event === "PostToolUse") {
-    const cwd = dirConfigWriteTarget(p.tool_name, p.tool_input);
+    const cwd = dirConfigWriteTarget(p.tool_name, p.tool_input, ptys.get(sessionId)?.cwd ?? null);
     if (cwd) pubsub?.publish(DIR_CONFIG_CHANNEL, { cwd });
   }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,7 +36,7 @@ import {
 } from "./sandbox.js";
 import { listPrsAcrossRepos } from "./prs.js";
 import { listIssuesAcrossRepos } from "./issues.js";
-import { publicDirConfig, dirSoundFile } from "./dir-config.js";
+import { publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { claudeAdapter } from "./agents/claude.js";
@@ -280,6 +280,10 @@ function isAllowedOrigin(origin?: string) {
 
 // Pub/sub channel the sidebar subscribes to for live session-activity changes.
 const SESSIONS_CHANNEL = "sessions";
+
+// Pub/sub channel telling the client a directory's .mulmoterminal.json changed, so it re-reads that
+// dir's config and recolours its cells without a page reload. Fed by the tool hooks, not a watcher.
+const DIR_CONFIG_CHANNEL = "dir-config";
 
 // Per-session pub/sub channel the GUI panel subscribes to. The MCP broker POSTs a
 // toolResult to /api/agent/toolResult, which stores it keyed by session id and
@@ -1029,6 +1033,12 @@ async function handleToolHook(sessionId: string, event: string, p: HookToolPaylo
       durationMs: p.duration_ms,
       status: event === "PostToolUseFailure" ? "failed" : "completed",
     });
+  }
+  // A SUCCESSFUL write to <dir>/.mulmoterminal.json is the live-reload signal: the hook that already
+  // reports every tool call tells the client to re-read that directory's config, so no fs watchers.
+  if (event === "PostToolUse") {
+    const cwd = dirConfigWriteTarget(p.tool_name, p.tool_input);
+    if (cwd) pubsub?.publish(DIR_CONFIG_CHANNEL, { cwd });
   }
 }
 

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -18,8 +18,8 @@ Two files ship next to this one:
 ## How to run this conversation
 
 **Ask one decision at a time, and always offer concrete options** — use `AskUserQuestion`, not open
-prose questions. A beginner should never have to invent a hex code. Show, don't describe: preview
-real colour in the terminal before asking them to commit to it.
+prose questions. A beginner should never have to invent a hex code. Show, don't describe: apply a
+preset and let them look at the real cell, which recolours the moment you write the file.
 
 ### 1. Pick the target directories — with checkboxes
 
@@ -62,17 +62,17 @@ What to do instead:
 1. **Name the colours.** For each candidate give its hex values and one line on how it feels
    ("terracotta on near-black — cosy, low glare"). Optionally add a rough emoji swatch (🟫 🟦 🟩 ⬛)
    so there's something to look at.
-2. **Apply, then look at the real thing.** Write the config and tell the user to **reload the browser
-   page** (⌘R / F5). MulmoTerminal reads `.mulmoterminal.json` once per page load — there is no live
-   watch — so a reload is what makes the colours appear. A **server restart is not needed.**
-3. Ask what to change, adjust, reload again. Two or three rounds is plenty.
+2. **Apply, then look at the real thing.** Write the config — the cells for that directory recolour
+   **immediately**, no page reload and no server restart. (Writing the file with your Write/Edit tool
+   is what tells MulmoTerminal to re-read it, so always write it rather than asking the user to.)
+3. Ask what to change, adjust, look again. Two or three rounds is plenty.
 
 The cell they're looking at IS the preview, and it's exact — better than any approximation.
 
 ### 5. Refine, one axis at a time
 
-After the preset, offer small, concrete choices — never "what colour do you want?". Apply and reload
-after each:
+After the preset, offer small, concrete choices — never "what colour do you want?". Apply and look
+after each — the change lands live:
 
 - **Background** — darker / as-is / lighter
 - **Accent** (cursor, badge, status dot) — keep / warmer / cooler
@@ -103,8 +103,8 @@ means "configured, hide every builtin", which is rarely what someone wants.
 ### 8. Write, then confirm
 
 For each target directory: **read the existing `.mulmoterminal.json` first and merge** — never drop
-fields the user didn't ask to change. Write the file, self-check it against the schema below, list the
-files you wrote, and **tell the user to reload the page to see it** (no live watch; no server restart).
+fields the user didn't ask to change. Write the file, self-check it against the schema below, and list
+the files you wrote. The cells recolour as soon as you write — nothing to reload.
 
 Configuring **several** directories? Give each a visually distinct hue from the same vibe, so they're
 easy to tell apart at a glance in the grid — that's the whole point of colour-coding.

--- a/src/composables/useDirConfig.spec.ts
+++ b/src/composables/useDirConfig.spec.ts
@@ -71,6 +71,36 @@ describe("useDirConfig live reload", () => {
     expect(config?.value.name).toBe("first");
   });
 
+  // Two writes in quick succession start overlapping requests; if the older response lands last it
+  // must not overwrite the newer config.
+  it("never lets a slow older response overwrite a newer one", async () => {
+    const plan = [
+      { name: "first", delay: 0 },
+      { name: "older", delay: 60 },
+      { name: "newer", delay: 5 },
+    ];
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        const { name, delay } = plan[call++];
+        return Promise.resolve({ ok: true, json: () => new Promise((r) => setTimeout(() => r({ name }), delay)) });
+      }),
+    );
+
+    const scope = effectScope();
+    const config = scope.run(() => useDirConfig(ref("/proj/race")).config);
+    await flush();
+    expect(config?.value.name).toBe("first");
+
+    invalidateDirConfig("/proj/race"); // write A -> slow response "older"
+    invalidateDirConfig("/proj/race"); // write B -> fast response "newer"
+    await new Promise((r) => setTimeout(r, 120)); // let BOTH settle, slow one last
+
+    expect(config?.value.name).toBe("newer");
+    scope.stop();
+  });
+
   it("releases the old directory when a cell switches cwd", async () => {
     const before = boundDirCount();
     const cwd = ref("/proj/one");

--- a/src/composables/useDirConfig.spec.ts
+++ b/src/composables/useDirConfig.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ref, effectScope, nextTick } from "vue";
+
+// Capture the `dir-config` subscriber the composable registers, so a test can play the server.
+let publish: ((data: unknown) => void) | null = null;
+vi.mock("./usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (_channel: string, callback: (data: unknown) => void) => {
+      publish = callback;
+      return () => {};
+    },
+  }),
+}));
+
+import { useDirConfig, boundDirCount, invalidateDirConfig } from "./useDirConfig";
+
+let served = "first";
+const flush = async () => {
+  await nextTick();
+  await new Promise((r) => setTimeout(r, 0));
+};
+
+beforeEach(() => {
+  served = "first";
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ name: served }) })),
+  );
+});
+
+describe("useDirConfig live reload", () => {
+  it("re-reads the directory when the server announces a change, without remounting", async () => {
+    const scope = effectScope();
+    const config = scope.run(() => useDirConfig(ref("/proj/a")).config);
+    await flush();
+    expect(config?.value.name).toBe("first");
+
+    served = "second";
+    publish?.({ cwd: "/proj/a" }); // the server saw a write to /proj/a/.mulmoterminal.json
+    await flush();
+    expect(config?.value.name).toBe("second");
+    scope.stop();
+  });
+
+  // Each test uses its own directory: the per-cwd fetch cache is module-level and outlives a test.
+  it("ignores an announcement for a directory nothing is showing", async () => {
+    const scope = effectScope();
+    const config = scope.run(() => useDirConfig(ref("/proj/b")).config);
+    await flush();
+
+    served = "second";
+    publish?.({ cwd: "/proj/other" });
+    await flush();
+    expect(config?.value.name).toBe("first"); // untouched
+    scope.stop();
+  });
+
+  it("unbinds on scope dispose and leaves no empty entry behind", async () => {
+    const before = boundDirCount();
+    const scope = effectScope();
+    const config = scope.run(() => useDirConfig(ref("/proj/leaky")).config);
+    await flush();
+    expect(boundDirCount()).toBe(before + 1);
+
+    scope.stop();
+    expect(boundDirCount()).toBe(before); // the key is gone, not just the callback
+
+    served = "second";
+    invalidateDirConfig("/proj/leaky"); // a closed cell must not keep receiving updates
+    await flush();
+    expect(config?.value.name).toBe("first");
+  });
+
+  it("releases the old directory when a cell switches cwd", async () => {
+    const before = boundDirCount();
+    const cwd = ref("/proj/one");
+    const scope = effectScope();
+    scope.run(() => useDirConfig(cwd).config);
+    await flush();
+    expect(boundDirCount()).toBe(before + 1);
+
+    cwd.value = "/proj/two";
+    await flush();
+    expect(boundDirCount()).toBe(before + 1); // one released, one acquired — not two
+
+    scope.stop();
+    expect(boundDirCount()).toBe(before);
+  });
+});

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -86,6 +86,12 @@ const cache = new Map<string, Promise<DirConfig>>();
 // every cell showing that directory.
 const bound = new Map<string, Set<(config: DirConfig) => void>>();
 
+// Per-cwd generation counter. Two writes in quick succession start two overlapping
+// requests, and HTTP responses can land out of order — an older one must never
+// overwrite a newer config, so a fetch only applies while its generation is current.
+const generation = new Map<string, number>();
+const generationOf = (cwd: string): number => generation.get(cwd) ?? 0;
+
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 function parse(c: unknown): DirConfig {
@@ -131,7 +137,12 @@ export function invalidateDirConfig(cwd: string): void {
   cache.delete(cwd);
   const targets = bound.get(cwd);
   if (!targets?.size) return;
-  fetchDirConfig(cwd).then((config) => targets.forEach((apply) => apply(config)));
+  const seq = generationOf(cwd) + 1;
+  generation.set(cwd, seq);
+  fetchDirConfig(cwd).then((config) => {
+    if (generationOf(cwd) !== seq) return; // a newer invalidation superseded this response
+    targets.forEach((apply) => apply(config));
+  });
 }
 
 // One process-wide subscription, established by the first cell that asks for a dir config.
@@ -156,7 +167,11 @@ export function useDirConfig(cwd: Ref<string | null | undefined>) {
     const targets = bound.get(boundCwd);
     if (targets) {
       targets.delete(apply);
-      if (!targets.size) bound.delete(boundCwd); // drop the key too, or dir switches grow it forever
+      if (!targets.size) {
+        // Drop the keys too, or opening many directories grows both maps forever.
+        bound.delete(boundCwd);
+        generation.delete(boundCwd);
+      }
     }
     boundCwd = null;
   };
@@ -176,8 +191,11 @@ export function useDirConfig(cwd: Ref<string | null | undefined>) {
       }
       targets.add(apply);
       boundCwd = c;
+      const seq = generationOf(c);
       const resolved = await fetchDirConfig(c);
-      if (cwd.value === c) config.value = resolved; // ignore a stale resolve after a fast switch
+      // Ignore a stale resolve after a fast directory switch, or after an invalidation
+      // that raced this fetch — its own response is the newer one.
+      if (cwd.value === c && generationOf(c) === seq) config.value = resolved;
     },
     { immediate: true },
   );

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -121,6 +121,11 @@ export function fetchDirConfig(cwd: string): Promise<DirConfig> {
 }
 
 // Reactive dir config for a (possibly changing) cwd. Resets to empty while no cwd is
+/** Test-only: how many directories currently have a bound cell (must not grow without bound). */
+export function boundDirCount(): number {
+  return bound.size;
+}
+
 /** Drop `cwd`'s cached config, re-read it, and push the result into every cell showing that dir. */
 export function invalidateDirConfig(cwd: string): void {
   cache.delete(cwd);
@@ -147,7 +152,12 @@ export function useDirConfig(cwd: Ref<string | null | undefined>) {
   let boundCwd: string | null = null;
   const apply = (next: DirConfig) => (config.value = next);
   const unbind = () => {
-    if (boundCwd) bound.get(boundCwd)?.delete(apply);
+    if (!boundCwd) return;
+    const targets = bound.get(boundCwd);
+    if (targets) {
+      targets.delete(apply);
+      if (!targets.size) bound.delete(boundCwd); // drop the key too, or dir switches grow it forever
+    }
     boundCwd = null;
   };
 

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -1,4 +1,5 @@
-import { ref, watch, type Ref } from "vue";
+import { ref, watch, onScopeDispose, type Ref } from "vue";
+import { usePubSub } from "./usePubSub";
 import type { ITheme } from "@xterm/xterm";
 import { isThemeId, type ThemeId } from "./useTheme";
 
@@ -76,9 +77,14 @@ function parseColors(input: unknown): Partial<ITheme> | null {
 }
 
 // One fetch per cwd, shared across cells: several terminals in the same directory
-// resolve to one request, and the config is stable for the page's lifetime (changes
-// to the file take effect on the next page load — MVP, no live watch).
+// resolve to one request. Invalidated by the `dir-config` channel, which the server
+// publishes when a tool hook reports a write to that dir's .mulmoterminal.json — so a
+// config change recolours the cells live, with no filesystem watchers.
 const cache = new Map<string, Promise<DirConfig>>();
+
+// Live `config` refs, keyed by the cwd they're bound to, so an invalidation reaches
+// every cell showing that directory.
+const bound = new Map<string, Set<(config: DirConfig) => void>>();
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
@@ -115,20 +121,56 @@ export function fetchDirConfig(cwd: string): Promise<DirConfig> {
 }
 
 // Reactive dir config for a (possibly changing) cwd. Resets to empty while no cwd is
+/** Drop `cwd`'s cached config, re-read it, and push the result into every cell showing that dir. */
+export function invalidateDirConfig(cwd: string): void {
+  cache.delete(cwd);
+  const targets = bound.get(cwd);
+  if (!targets?.size) return;
+  fetchDirConfig(cwd).then((config) => targets.forEach((apply) => apply(config)));
+}
+
+// One process-wide subscription, established by the first cell that asks for a dir config.
+let subscribed = false;
+function subscribeToDirConfigChanges(): void {
+  if (subscribed) return;
+  subscribed = true;
+  usePubSub().subscribe("dir-config", (data) => {
+    if (isRecord(data) && typeof data.cwd === "string") invalidateDirConfig(data.cwd);
+  });
+}
+
 // set so a cell that switches directories never shows a stale badge/theme.
 export function useDirConfig(cwd: Ref<string | null | undefined>) {
   const config = ref<DirConfig>(EMPTY);
+  subscribeToDirConfigChanges();
+
+  let boundCwd: string | null = null;
+  const apply = (next: DirConfig) => (config.value = next);
+  const unbind = () => {
+    if (boundCwd) bound.get(boundCwd)?.delete(apply);
+    boundCwd = null;
+  };
+
   watch(
     cwd,
     async (c) => {
+      unbind();
       if (!c) {
         config.value = EMPTY;
         return;
       }
+      let targets = bound.get(c);
+      if (!targets) {
+        targets = new Set();
+        bound.set(c, targets);
+      }
+      targets.add(apply);
+      boundCwd = c;
       const resolved = await fetchDirConfig(c);
       if (cwd.value === c) config.value = resolved; // ignore a stale resolve after a fast switch
     },
     { immediate: true },
   );
+  onScopeDispose(unbind); // a closed cell must not keep receiving invalidations
   return { config };
 }


### PR DESCRIPTION
## Summary

Changing a directory's `.mulmoterminal.json` now recolours its terminals **immediately** — no page reload, no server restart, and **not a single filesystem watcher**.

The trick: the server already sees every write. Claude's `PostToolUse` hook reports `tool_name` + `tool_input` (it builds the tool-call timeline today), so a write to `<dir>/.mulmoterminal.json` is already observable. The writer announces the change; nothing polls.

## Items to Confirm / Review

- **The hook is now load-bearing for a second purpose.** `handleToolHook` publishes on `PostToolUse` only — a `PostToolUseFailure` wrote nothing and must not trigger a re-read. Worth a look that this is the right seam.
- **Tool-name allowlist** is `Write` / `Edit` / `MultiEdit`. If Claude renames a tool we silently lose live-reload (graceful — you just reload the page). Gating on `tool_input.file_path` alone would also fire on `Read`, which is why it's an allowlist.
- **Trade-off, deliberate:** a `vim` edit is not detected. That covers the skill flow completely, so `POST /api/dir-config/reload` was **not** added — it's surface for a case we don't have. Say the word if hand-editing turns out to be common.
- **Ref lifetime:** `useDirConfig` registers each `config` ref in a module-level `Map` keyed by cwd and unbinds on `onScopeDispose`, so a closed cell can't keep receiving invalidations.

## User Prompt

> live reload ほしいけど、これって watch が terminal の数だけ増えるよね。skill のあとに呼び出す関数とかで出来ない？

Correct on both counts — working directories are scattered, so a watcher can't be shared across terminals. It turned out we don't even need the skill to call anything: the tool hook already fires on the write.

## Implementation

| File | Change |
|---|---|
| `server/dir-config.ts` | pure, testable `dirConfigWriteTarget(toolName, toolInput) -> dir \| null` |
| `server/index.ts` | on `PostToolUse`, `pubsub.publish("dir-config", { cwd })` |
| `src/composables/useDirConfig.ts` | subscribe once; invalidate that cwd's cache, refetch, push into every bound ref |
| `SKILL.md` | drop the now-stale "tell the user to reload the page" |

No client rendering work was needed — `Terminal.vue` already repaints the xterm palette via `watch([themeId, () => props.dirTheme, () => props.dirColors], …)`.

## Verification

Unit tests cover `dirConfigWriteTarget` (each write tool, relative path, wrong tool, wrong filename, malformed payload).

Then **driven in a real browser**, because unit tests don't prove the pubsub → client → xterm path:

```
STEP1 initial xterm bg: rgb(23, 18, 16)    (= the configured #171210)
STEP3 bg WITHOUT reload: rgb(11, 61, 11)   ✅ live-reloaded
STEP5 second change:     rgb(122, 31, 162) ✅ again
🔍 unrelated file write      -> ignored     ✅
🔍 PostToolUseFailure        -> ignored     ✅
page navigations (0 = never reloaded): 0 | page errors: none
```

(The background lands on `.xterm-scrollable-element`, not `.xterm-viewport` — my first probe read the wrong element and reported a false negative.)

Local: 949 tests pass, typecheck 0, lint 0 errors, build ok.

Plan: `plans/feat-dir-config-live-reload.md`. Closes #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)