### PR TITLE
fix: resume on-disk sessions even when a tmux session is alive

### DIFF
--- a/plans/fix-session-already-in-use.md
+++ b/plans/fix-session-already-in-use.md
@@ -1,0 +1,64 @@
+# fix: "Session ID … is already in use." when opening a past session
+
+## Symptom
+
+Opening a past session from the single-view tab list sometimes shows, in the terminal:
+
+```
+Error: Session ID <uuid> is already in use.
+```
+
+Reported by multiple users. Appeared with the tmux-backed session-persistence release.
+
+## Root cause (verified against real claude 2.1.206)
+
+The error is emitted by the `claude` CLI itself. Verified rule, by probing real claude
+with node-pty:
+
+- `claude --session-id X` → **"Session ID X is already in use."** iff a transcript for X
+  already exists on disk (`~/.claude/projects/<cwd>/X.jsonl`). It's a transcript-exists
+  check, not a live-process lock.
+- `claude --resume X` → resumes an existing transcript; two concurrent `--resume X` both
+  succeed. `--resume` never emits the error.
+- Concurrent `--session-id X` on an id with **no** transcript is fine.
+
+So the bug is: the server launches `claude --session-id X` for an id whose transcript
+exists — where it should use `--resume X`.
+
+`server/index.ts` `resolveClaudeSession` gated resume on `!tmuxAlive`:
+
+```
+const resume = !reattachId && !tmuxAlive && requested && sessionExistsOnDisk(...) ? requested : null;
+```
+
+When a tmux session for X is alive, `resume` was forced to null, so the spawn used
+`--session-id X`. That is harmless **only if** `tmux new-session -A -s mt-X` attaches to
+the live session (the arg is ignored). But if `mt-X` died between the `tmuxHasSession`
+check and the spawn — a reap, a `/exit`, or another MulmoTerminal instance on the shared
+`-L mulmoterminal` server (the user runs several) — `new-session -A` **re-creates** the
+session and RUNS `claude --session-id X` → the error.
+
+tmux itself is transparent; what the persistence feature introduced is long-lived tmux
+sessions that outlive a tab/instance and can vanish out from under a check.
+
+### Reproduction (side-effect-free, isolated socket + stub claude)
+
+- `tmux new-session -A -s mt-X -- <stub> --session-id X` with mt-X absent + transcript on
+  disk → "already in use". (before)
+- same with `--resume X` → resumes cleanly. (after)
+
+## Fix
+
+`resume` is set whenever a transcript exists on disk, regardless of tmux liveness. An
+on-disk id is now always launched under `--resume`, never `--session-id`:
+
+- tmux session alive → `new-session -A` still attaches; the `--resume` arg is ignored
+  (no behavior change on the happy path).
+- tmux session gone at spawn → `new-session` re-creates and runs `--resume X`, which is
+  safe, instead of the fatal `--session-id X`.
+- Idle session with a live tmux session but no transcript yet → unchanged (`--session-id`
+  attaches; safe because no transcript exists).
+
+The flag decision is extracted into `server/session-resolve.ts` (`resolveSession`, pure)
+with `server/session-resolve.spec.ts` covering the matrix, including the regression case
+(on-disk **and** tmux alive → `resume` set).

--- a/server/index.ts
+++ b/server/index.ts
@@ -39,6 +39,7 @@ import { listIssuesAcrossRepos } from "./issues.js";
 import { publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "./dir-config.js";
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
+import { resolveSession, type SessionResolution } from "./session-resolve.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
@@ -2043,14 +2044,14 @@ function handleClientClose(entry: PtyEntry, ws: WebSocket, sessionId: string) {
 }
 
 // Pick the effective session id for a /ws connection: reattach a same-process live pty,
-// else a tmux session that outlived a restart (warm, no --resume), else `--resume` an
-// on-disk transcript (cold), else a fresh id. `resume` is set only for the cold case.
-function resolveClaudeSession(requested: string | null, cwd: string): { reattachId: string | null; resume: string | null; sessionId: string } {
-  const reattachId = requested && ptys.has(requested) ? requested : null;
-  const tmuxAlive = !reattachId && !!requested && tmuxHasSession(requested);
-  const resume = !reattachId && !tmuxAlive && requested && sessionExistsOnDisk(requested, cwd) ? requested : null;
-  const sessionId = reattachId ?? (requested && (tmuxAlive || resume) ? requested : randomUUID());
-  return { reattachId, resume, sessionId };
+// resume an on-disk transcript, attach a live tmux session, else a fresh id. The flag
+// decision lives in resolveSession (pure/tested); this only gathers the live facts —
+// lazily, so a live pty short-circuits the tmux + disk probes.
+function resolveClaudeSession(requested: string | null, cwd: string): SessionResolution {
+  const hasLivePty = !!requested && ptys.has(requested);
+  const tmuxAlive = !hasLivePty && !!requested && tmuxHasSession(requested);
+  const onDisk = !hasLivePty && !!requested && sessionExistsOnDisk(requested, cwd);
+  return resolveSession(requested, { hasLivePty, tmuxAlive, onDisk }, randomUUID);
 }
 
 wss.on("connection", (ws, req) => {

--- a/server/session-resolve.spec.ts
+++ b/server/session-resolve.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { resolveSession, type SessionFacts } from "./session-resolve.js";
+
+const FIXED = "fresh-minted-id";
+const mint = () => FIXED;
+const facts = (over: Partial<SessionFacts> = {}): SessionFacts => ({ hasLivePty: false, tmuxAlive: false, onDisk: false, ...over });
+
+describe("resolveSession", () => {
+  it("mints a fresh id when nothing is requested", () => {
+    expect(resolveSession(null, facts(), mint)).toEqual({ reattachId: null, resume: null, sessionId: FIXED });
+  });
+
+  it("mints a fresh id when the requested session can't be served (not live, tmux, or on disk)", () => {
+    // e.g. reloading an idle session claude never persisted — reusing its id under
+    // --session-id would abort, so we start fresh and the browser adopts the new id.
+    expect(resolveSession("s1", facts(), mint)).toEqual({ reattachId: null, resume: null, sessionId: FIXED });
+  });
+
+  it("reattaches a same-process live pty (no resume, id preserved)", () => {
+    expect(resolveSession("s1", facts({ hasLivePty: true }), mint)).toEqual({ reattachId: "s1", resume: null, sessionId: "s1" });
+  });
+
+  it("resumes an on-disk transcript", () => {
+    expect(resolveSession("s1", facts({ onDisk: true }), mint)).toEqual({ reattachId: null, resume: "s1", sessionId: "s1" });
+  });
+
+  it("reuses the id for a live tmux session with no transcript yet (idle, --session-id attaches)", () => {
+    expect(resolveSession("s1", facts({ tmuxAlive: true }), mint)).toEqual({ reattachId: null, resume: null, sessionId: "s1" });
+  });
+
+  it("resumes an on-disk transcript EVEN when a tmux session is alive (the fix)", () => {
+    // Regression: the old logic gated resume on !tmuxAlive, so this yielded resume:null
+    // and a --session-id launch that aborts with "already in use" if the tmux session
+    // died between the check and the spawn.
+    expect(resolveSession("s1", facts({ tmuxAlive: true, onDisk: true }), mint)).toEqual({ reattachId: null, resume: "s1", sessionId: "s1" });
+  });
+
+  it("prefers a live pty over tmux/disk", () => {
+    expect(resolveSession("s1", facts({ hasLivePty: true, tmuxAlive: true, onDisk: true }), mint)).toEqual({ reattachId: "s1", resume: null, sessionId: "s1" });
+  });
+});

--- a/server/session-resolve.ts
+++ b/server/session-resolve.ts
@@ -1,0 +1,37 @@
+// Pure decision for how a /ws connection should (re)connect a requested session id.
+// Split out from index.ts so the flag choice — the one that decides `--resume` vs
+// `--session-id` — is unit-testable without a pty, tmux, or the filesystem.
+
+export interface SessionFacts {
+  // A live pty for this id in THIS server process (reattach without respawning claude).
+  hasLivePty: boolean;
+  // A persistent tmux session for this id is alive (survived a restart / another cell).
+  tmuxAlive: boolean;
+  // An on-disk transcript exists in the target workspace (claude writes it after the
+  // first prompt) — the only id claude will `--resume`.
+  onDisk: boolean;
+}
+
+export interface SessionResolution {
+  reattachId: string | null; // reattach this same-process pty (no new claude)
+  resume: string | null; // `--resume` this on-disk transcript
+  sessionId: string; // the id claude effectively runs as
+}
+
+// `resume` is set whenever a transcript exists on disk — REGARDLESS of tmux liveness.
+// An on-disk id must never be launched under `--session-id`: claude refuses it with
+// "Session ID <id> is already in use." When a tmux session is alive the arg is ignored
+// (tmux attaches to the running claude), but if that session died since we checked it
+// (reap, /exit, or another instance on the shared tmux server), `tmux new-session -A`
+// re-creates it and RUNS the command — and there `--resume <id>` reattaches the
+// conversation where `--session-id <id>` would abort. Gating `resume` on `!tmuxAlive`
+// (the old behavior) left that window fatal.
+export function resolveSession(requested: string | null, facts: SessionFacts, mintId: () => string): SessionResolution {
+  const reattachId = requested && facts.hasLivePty ? requested : null;
+  const resume = !reattachId && requested && facts.onDisk ? requested : null;
+  // Reuse the requested id when we can actually serve it (reattach, a live tmux
+  // session, or an on-disk transcript to resume); otherwise it can't be reused —
+  // mint a fresh one.
+  const sessionId = reattachId ?? (requested && (facts.tmuxAlive || resume) ? requested : mintId());
+  return { reattachId, resume, sessionId };
+}


### PR DESCRIPTION
Closes #306

## Summary

過去のセッションをタブから開くと、ターミナルに `Error: Session ID <uuid> is already in use.` が出ることがある不具合を修正します（複数ユーザーから報告あり、tmux 永続化リリース以降に発生）。

原因は、サーバが「ディスクに転写のある id」に `--resume` ではなく `--session-id` を渡してしまうことでした。`resolveClaudeSession` が `resume` を `!tmuxAlive` で潰していたため、tmux セッションが生きているとみなすと転写があっても `--session-id X` を渡していました。`resume` を「ディスクに転写があれば tmux の生死に関わらず必ず立てる」に変え、フラグ決定を純関数 `resolveSession` に切り出しました。

## Items to Confirm / Review

1. **エラーの真因は claude CLI 自身の挙動**です。`claude --session-id X` は X の転写がディスクに存在すると `already in use` を出します（生プロセスのロックではなく転写の有無判定）。claude 2.1.206 に対し node-pty で実証しました。`--resume X` はこのエラーを出さず、同じ id の二重 `--resume` も両方成功します。
2. **修正の要点**: `resume = onDisk ? requested : null`（`!tmuxAlive` 依存を撤廃）。tmux セッションが生きていれば `new-session -A` がアタッチして引数は無視されるので happy path は不変。tmux セッションが消えていて `new-session` が作成側に回っても、`--resume X` なら安全（`--session-id X` は致命的）。
3. **idle セッション（tmux 生存・転写なし）は不変**: `resume` は立たず `--session-id X` のままだが、転写が無い id なので claude はエラーを出さない（実証済み）。
4. **副作用ゼロで検証**: 共有 `-L mulmoterminal` ソケットには一切触れず、使い捨てソケット＋スタブ claude で前後比較しました。

## 発生条件（なぜ tmux 永続化で出るようになったか）

tmux 自体は claude の起動に透明で、`tmux new-session -- claude --resume X` は普通のターミナルで打つのと同一です。tmux が変えたのは **claude プロセスの寿命**で、タブを閉じても claude が `mt-X` の中で生き続けるようになりました。

正常時は再選択で `tmuxHasSession(X)` が生きた `mt-X` を見つけ `new-session -A` がアタッチします。問題は `resolveClaudeSession` が `--session-id X` を選ぶのに、**チェックから spawn までの間に `mt-X` が消える**ケース（reap / `/exit` / 共有 `-L mulmoterminal` 上の別インスタンス）。このとき `new-session -A` が作成側に回り `claude --session-id X` を転写のある id に対して実行 → エラー。tmux 永続化以前は、この分岐も長寿命の共有 tmux セッションも存在しませんでした。

## 再現（副作用ゼロ・使い捨てソケット + スタブ claude）

スタブは実 claude で確認した挙動を忠実に再現します（`--session-id X` は転写があれば「already in use」、`--resume X` は転写があれば再開）。

- 変更前: `tmux new-session -A -s mt-X -- claude --session-id X`（mt-X 不在 + 転写あり）→ `Error: Session ID … is already in use.`
- 変更後: 同条件で `--resume X` → 正常に resume、エラーなし

## 変更内容

- `server/session-resolve.ts`（新規）— フラグ決定の純関数 `resolveSession`。`--resume` vs `--session-id` を決める箇所を pty/tmux/fs 抜きでテスト可能に。
- `server/session-resolve.spec.ts`（新規）— 判定マトリクス。退行ケース（onDisk かつ tmuxAlive → `resume` が立つ）を含む。
- `server/index.ts` — `resolveClaudeSession` は live/tmux/disk の事実収集だけに縮小し（live pty があれば tmux・disk のプローブを短絡）、判定を `resolveSession` に委譲。実変更 9 行。
- `plans/fix-session-already-in-use.md` — 調査と修正方針。

## 検証

- `yarn typecheck` / `yarn lint`（既存の無関係警告 1 件のみ）/ `yarn build` すべて通過。
- `yarn test` — **963 tests / 97 files すべて通過**（新規 7）。
- claude 2.1.206 に対する挙動の実証、および前後比較の tmux レベル再現（上記）。

## 補足（このPRの範囲外）

念のための belt-and-suspenders として「万一 claude が `already in use` を吐いたら新しい id で 1 回張り直す自己修復」も考えられますが、stdout 文字列依存で脆く、今回の構造的修正で該当経路は塞げているため入れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

