### PR TITLE
feat: zoom the active grid cell in place on focus

### DIFF
--- a/plans/feat-grid-active-zoom.md
+++ b/plans/feat-grid-active-zoom.md
@@ -1,0 +1,38 @@
+# feat — in-place zoom for the active grid cell
+
+## Goal
+
+In the grid view, the terminal you're focused on lifts and grows slightly **in place**, so the active
+cell is obvious at a glance — without the heavy filmstrip zoom (⤢) and without reflowing the grid.
+
+## Constraint that shaped the design
+
+The grid uses equal `1fr` CSS-grid tracks (`gridLayout.ts`). Enlarging one cell's track enlarges its
+whole row+column, not just the cell. The clean single-cell effect is `transform: scale`, which the
+user confirmed is what they want ("その場でzooming"). Because this app renders xterm with the **DOM
+renderer** (no canvas), scaling real DOM text stays crisp — and `transform` doesn't change the cell's
+layout box, so **xterm is not refit and the PTY is not resized** (no SIGWINCH churn on focus changes).
+
+## Implementation (`src/components/TerminalGrid.vue` only)
+
+- Track the focused cell: one delegated `@focusin` on `.grid`. `focusin` bubbles from the xterm
+  textarea up, so `e.target.closest('[data-uid]')` gives the cell. Sticky — focus moving to the
+  toolbar doesn't reset it; only another cell taking focus moves the emphasis.
+- `cellClass(uid)` adds `focused` when `uid === focusedUid && expandedUid === null && uid !== flippingUid`,
+  so it never fights the expand-FLIP or the filmstrip. Applied to all three cell types.
+- CSS, scoped to the tiled grid (`.stage:not(.zoomed) .grid > .focused`): `transform: scale(1.045)`,
+  `z-index: 5`, a soft shadow, a 140ms transition. Honours `prefers-reduced-motion`.
+
+## Verification
+
+- Unit (`TerminalGrid.spec.ts`): focus marks only that cell; a second focus moves the mark; focus
+  leaving the grid is sticky; no zoom while expanded.
+- Live (Puppeteer, two zsh cells): focusing cell A → `scale(1.045)`, `focused`; focusing B moves it.
+  Critically, `offsetWidth` stayed constant (741px) in every state while the painted width grew to
+  ~774px — proving the visual zoom with **no layout resize**.
+
+## Notes / possible follow-ups
+
+- Scale is subtle (1.045) per "若干"; trivially tunable if a stronger lift is wanted.
+- The focused cell overflows its neighbours by ~2% each side; `z-index` + shadow make that read as a
+  lift. Edge cells overflow the grid padding slightly — fine at this scale.

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -122,3 +122,38 @@ describe("TerminalGrid command cells", () => {
     expect(w.emitted("toggle-expand")?.[0]).toEqual([4]);
   });
 });
+
+describe("active-cell focus zoom", () => {
+  const focus = (w: ReturnType<typeof mount>, uid: number) => w.get(`[data-uid="${uid}"]`).element.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+  const cls = (w: ReturnType<typeof mount>, uid: number) => w.get(`[data-uid="${uid}"]`).classes();
+
+  it("marks only the focused cell, and moves the mark when another cell takes focus", async () => {
+    const w = mountGrid([cell(0, "s0"), cell(1, "s1")]);
+    focus(w, 0);
+    await nextTick();
+    expect(cls(w, 0)).toContain("focused");
+    expect(cls(w, 1)).not.toContain("focused");
+
+    focus(w, 1);
+    await nextTick();
+    expect(cls(w, 0)).not.toContain("focused"); // the emphasis is single-source-of-truth
+    expect(cls(w, 1)).toContain("focused");
+  });
+
+  it("stays sticky: focus leaving the grid does not clear it", async () => {
+    const w = mountGrid([cell(0, "s0"), cell(1, "s1")]);
+    focus(w, 0);
+    await nextTick();
+    // A focusin whose target is outside any cell (e.g. the toolbar) must not move the mark.
+    document.body.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    await nextTick();
+    expect(cls(w, 0)).toContain("focused");
+  });
+
+  it("does not zoom while a cell is expanded (filmstrip owns the emphasis)", async () => {
+    const w = mountGrid([cell(0, "s0"), cell(1, "s1")], 0);
+    focus(w, 1);
+    await nextTick();
+    expect(cls(w, 1)).not.toContain("focused");
+  });
+});

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -45,6 +45,25 @@ const emit = defineEmits<{
 }>();
 
 const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length)));
+
+// The keyboard-focused cell, so it can lift + zoom slightly in place. `focusin` bubbles from the
+// xterm textarea up to the grid, so one delegated listener suffices. It's sticky: focus moving to
+// the toolbar doesn't reset it — only another cell taking focus moves the emphasis.
+const focusedUid = ref<number | null>(null);
+function onFocusIn(e: FocusEvent) {
+  const target = e.target;
+  if (!(target instanceof HTMLElement)) return;
+  const el = target.closest<HTMLElement>("[data-uid]");
+  if (el?.dataset.uid) focusedUid.value = Number(el.dataset.uid);
+}
+// Per-cell class: `flipping` drives the zoom FLIP, `focused` the in-place lift of the active cell —
+// suppressed while expanded or mid-flip so it never fights those animations.
+function cellClass(uid: number) {
+  return {
+    flipping: uid === flippingUid.value,
+    focused: uid === focusedUid.value && props.expandedUid === null && uid !== flippingUid.value,
+  };
+}
 // Hand the flip's timing to the stylesheet so the fade under it can't drift out of sync.
 const flipVars = { "--flip-ms": `${FLIP_MS}ms`, "--flip-ease": FLIP_EASING };
 
@@ -99,12 +118,12 @@ watch(
 <template>
   <div ref="stage" class="stage" :class="{ zoomed, flipping: flippingUid !== null }" :style="flipVars">
     <div ref="zoomMain" class="zoom-main" />
-    <div class="grid" :style="gridStyle">
+    <div class="grid" :style="gridStyle" @focusin="onFocusIn">
       <Teleport v-for="cell in cells" :key="cell.uid" :to="zoomMain" :disabled="!(zoomed && cell.uid === expandedUid)">
         <CommandCell
           v-if="cell.command"
           :data-uid="cell.uid"
-          :class="{ flipping: cell.uid === flippingUid }"
+          :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
           :zoomed="zoomed"
           :command="cell.command"
@@ -119,7 +138,7 @@ watch(
           v-else-if="cell.launcher"
           :uid="cell.uid"
           :data-uid="cell.uid"
-          :class="{ flipping: cell.uid === flippingUid }"
+          :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
           :zoomed="zoomed"
           :launcher="cell.launcher"
@@ -137,7 +156,7 @@ watch(
           v-else
           :uid="cell.uid"
           :data-uid="cell.uid"
-          :class="{ flipping: cell.uid === flippingUid }"
+          :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
           :zoomed="zoomed"
           :initial-session-id="cell.session"
@@ -220,6 +239,25 @@ watch(
   flex: 0 0 260px;
   height: 100%;
   min-width: 0;
+}
+
+/* The keyboard-focused cell lifts and grows slightly, in place — tiled grid only, so it never
+   applies to a filmstrip thumbnail (.stage.zoomed) or a cell mid-FLIP. The transform doesn't change
+   the cell's layout size, so xterm isn't refit and the PTY isn't resized. */
+.stage:not(.zoomed) .grid > *:not(.flipping) {
+  transition:
+    transform 140ms ease,
+    box-shadow 140ms ease;
+}
+.stage:not(.zoomed) .grid > .focused {
+  transform: scale(1.045);
+  z-index: 5;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+}
+@media (prefers-reduced-motion: reduce) {
+  .stage:not(.zoomed) .grid > *:not(.flipping) {
+    transition: none;
+  }
 }
 
 /* A second click landing mid-flight would measure a transformed cell and flip from the


### PR DESCRIPTION
## Summary

The keyboard-focused terminal in the grid now **lifts and grows slightly, in place**, so the active cell is obvious at a glance — without the heavy filmstrip zoom (⤢) and without reflowing the grid.

Because the app renders xterm with the **DOM renderer**, a CSS `transform: scale` keeps the text crisp, and — the key property — it doesn't change the cell's layout box, so **xterm is never refit and the PTY is never resized** when focus moves between cells.

## Items to Confirm / Review

- **`transform` chosen deliberately, not grid-track resizing.** Equal `1fr` tracks mean "enlarge one cell" would enlarge its whole row+column. `transform: scale` isolates it to the one cell; verified it does **not** trigger the cell's `ResizeObserver` → no PTY `SIGWINCH` on focus changes.
- **Sticky focus** (my call): focus leaving to the toolbar keeps the last cell emphasized; only another cell taking focus moves it. Rationale: clicking a header button shouldn't snap everything back to flat. Easy to make it reset-on-blur if preferred.
- **Applies to all three cell types** (terminal / command / launcher), i.e. any focused cell. Say the word to restrict it to running terminals only.
- **Interaction with the existing FLIP + filmstrip:** `focused` is suppressed while `expandedUid !== null` or the cell is mid-flip, and the CSS is scoped to `.stage:not(.zoomed)`, so it can't fight those animations.
- Scale is subtle (**1.045**) per "若干" — trivially tunable.

## User Prompt

> grid view で terminal のとき、active なターミナルだけ若干拡大するような zooming UI にできる？ … イメージ違うな、その場で zooming

## Implementation (`src/components/TerminalGrid.vue` only)

- One delegated `@focusin` on `.grid` tracks the focused cell (`focusin` bubbles from the xterm textarea; `e.target.closest('[data-uid]')` gives the cell).
- `cellClass(uid)` adds `focused` when `uid === focusedUid && expandedUid === null && uid !== flippingUid`.
- CSS scoped to the tiled grid: `transform: scale(1.045)`, `z-index: 5`, soft shadow, 140ms transition, `prefers-reduced-motion` respected.

## Verification

Unit (`TerminalGrid.spec.ts`): the mark lands on only the focused cell, moves on a second focus, is sticky when focus leaves the grid, and is suppressed while expanded.

Live (Puppeteer, two `zsh` cells) — because unit tests don't prove the CSS/transform actually renders:

```
focus cell #1 -> uid 0: focused, scale 1.045, layoutW 741, paintW 774
                 uid 1:           scale 1,     layoutW 741, paintW 741
focus cell #2 -> uid 0:           scale 1,     layoutW 741, paintW 741
                 uid 1: focused, scale 1.045, layoutW 741, paintW 774
```

`layoutW` (offsetWidth) is constant at 741px in every state while the painted width grows to ~774px — the visual zoom with **no layout resize**. No console errors.

Local: 966 tests pass, typecheck 0, lint 0 errors, build ok.

Plan: `plans/feat-grid-active-zoom.md`. Closes #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)