### PR TITLE
fix: refocus the grid terminal after expand/collapse

### DIFF
--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -173,7 +173,17 @@ function onHeaderClick(event: MouseEvent) {
         <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
       </span>
     </div>
-    <TerminalView ref="termRef" class="cell-term" :session-id="null" :connect-key="connectKey" :cwd="command.cwd" :command="command" @exit="onExit" />
+    <TerminalView
+      ref="termRef"
+      class="cell-term"
+      :session-id="null"
+      :connect-key="connectKey"
+      :cwd="command.cwd"
+      :command="command"
+      :expanded="expanded"
+      :zoomed="zoomed"
+      @exit="onExit"
+    />
     <div v-if="showSummary" class="cell-summary">
       <div class="cell-summary-head">
         <span class="cell-summary-title">✦ Summary</span>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -92,6 +92,8 @@ function relaunch() {
       :connect-key="connectKey"
       :cwd="cwd"
       :launcher="target"
+      :expanded="expanded"
+      :zoomed="zoomed"
       @session="onSession"
       @exit="onExit"
     />

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -216,15 +216,21 @@ watch([themeId, () => props.dirTheme, () => props.dirColors], () => {
 // big (expanded), or the one returning to the grid on a full collapse (`!zoomed`). On a switch to
 // ANOTHER cell (still zoomed) we skip, letting the newly-big cell claim focus. Refocus once after the
 // teleport (nextTick, covers reduced-motion) and again once the FLIP animation lands.
+let refocusTimer: ReturnType<typeof setTimeout> | undefined;
 watch(
   () => props.expanded,
   (expanded) => {
     if (!shouldRefocusOnZoomChange(!!expanded, props.zoomed)) return;
-    const refocus = () => conn.focus(slotKey);
-    nextTick(refocus);
-    setTimeout(refocus, FLIP_MS + 30);
+    nextTick(() => conn.focus(slotKey));
+    // A rapid zoom change (A → B → C) can leave an older cell's timer pending; cancel the previous
+    // one and re-check state when it fires, so a stale timer never steals focus back to an old cell.
+    clearTimeout(refocusTimer);
+    refocusTimer = setTimeout(() => {
+      if (shouldRefocusOnZoomChange(!!props.expanded, props.zoomed)) conn.focus(slotKey);
+    }, FLIP_MS + 30);
   },
 );
+onUnmounted(() => clearTimeout(refocusTimer));
 
 // Submit a GUI-originated message into the PTY (the GUI->LLM feedback path) and the
 // explicit ✕ close. Both delegate to the slot's durable runtime.

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -220,14 +220,13 @@ let refocusTimer: ReturnType<typeof setTimeout> | undefined;
 watch(
   () => props.expanded,
   (expanded) => {
+    // Cancel this cell's pending refocus FIRST, before the early return: a cell that just shrank
+    // (A → B) must drop its stale timer, or it fires ~FLIP_MS later and steals focus back. Clearing
+    // here means a surviving timer only ever reflects the cell's current, unchanged state.
+    clearTimeout(refocusTimer);
     if (!shouldRefocusOnZoomChange(!!expanded, props.zoomed)) return;
     nextTick(() => conn.focus(slotKey));
-    // A rapid zoom change (A → B → C) can leave an older cell's timer pending; cancel the previous
-    // one and re-check state when it fires, so a stale timer never steals focus back to an old cell.
-    clearTimeout(refocusTimer);
-    refocusTimer = setTimeout(() => {
-      if (shouldRefocusOnZoomChange(!!props.expanded, props.zoomed)) conn.focus(slotKey);
-    }, FLIP_MS + 30);
+    refocusTimer = setTimeout(() => conn.focus(slotKey), FLIP_MS + 30);
   },
 );
 onUnmounted(() => clearTimeout(refocusTimer));

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch, nextTick } from "vue";
 import { type ITheme } from "@xterm/xterm";
+import { FLIP_MS, shouldRefocusOnZoomChange } from "./cellFlip";
 import { dropTextFromUriList, toInsertText } from "./dropPaths";
 import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
 import { badgeStyleFor } from "./dirBadge";
@@ -47,6 +48,10 @@ const props = defineProps<{
   // Hide this terminal's own header row (used when a grid cell is zoomed: the cell's
   // header already shows dir + activity, so the embedded header would just be clutter).
   hideHeader?: boolean;
+  // Grid zoom state, so the terminal can grab keyboard focus after an expand/collapse teleport
+  // (which blurs it). `expanded` = this cell is the big one; `zoomed` = SOME cell is expanded.
+  expanded?: boolean;
+  zoomed?: boolean;
   persistKey?: string | null;
   // Per-directory overrides from <cwd>/.mulmoterminal.json. `dirTheme` pins this
   // terminal's xterm palette (overriding the app-wide theme for this cell only);
@@ -205,6 +210,21 @@ watch(
 watch([themeId, () => props.dirTheme, () => props.dirColors], () => {
   conn.setTheme(slotKey, effectiveTermTheme());
 });
+
+// Expanding/collapsing a grid cell teleports it in the DOM, which blurs the xterm textarea — so the
+// user has to click before typing. Refocus the cell that should now be active: the one that became
+// big (expanded), or the one returning to the grid on a full collapse (`!zoomed`). On a switch to
+// ANOTHER cell (still zoomed) we skip, letting the newly-big cell claim focus. Refocus once after the
+// teleport (nextTick, covers reduced-motion) and again once the FLIP animation lands.
+watch(
+  () => props.expanded,
+  (expanded) => {
+    if (!shouldRefocusOnZoomChange(!!expanded, props.zoomed)) return;
+    const refocus = () => conn.focus(slotKey);
+    nextTick(refocus);
+    setTimeout(refocus, FLIP_MS + 30);
+  },
+);
 
 // Submit a GUI-originated message into the PTY (the GUI->LLM feedback path) and the
 // explicit ✕ close. Both delegate to the slot's durable runtime.

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -912,6 +912,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :dir-header-text-color="dirConfig.headerTextColor"
         :dir-button-color="dirConfig.buttonColor"
         :hide-header="filmstrip"
+        :expanded="expanded"
+        :zoomed="zoomed"
         dev-terminal
         run-menu
         @session="onSession"

--- a/src/components/cellFlip.spec.ts
+++ b/src/components/cellFlip.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { flipKeyframes, FLIP_MS, FLIP_EASING } from "./cellFlip";
+import { flipKeyframes, FLIP_MS, FLIP_EASING, shouldRefocusOnZoomChange } from "./cellFlip";
 
 const rect = (left: number, top: number, width: number, height: number) => ({ left, top, width, height });
 
@@ -53,5 +53,18 @@ describe("cellFlip", () => {
   it("survives a destination larger than the viewport without losing precision", () => {
     const frames = flipKeyframes(rect(-50, -50, 260, 150), rect(0, 0, 2600, 1500));
     expect(frames?.[0].transform).toBe("translate(-50px, -50px) scale(0.1, 0.1)");
+  });
+
+  describe("shouldRefocusOnZoomChange (which cell grabs focus after an expand/collapse)", () => {
+    it("refocuses the cell that just became big", () => {
+      expect(shouldRefocusOnZoomChange(true, true)).toBe(true);
+    });
+    it("refocuses the cell returning to the grid on a full collapse", () => {
+      expect(shouldRefocusOnZoomChange(false, false)).toBe(true);
+      expect(shouldRefocusOnZoomChange(false, undefined)).toBe(true);
+    });
+    it("does NOT refocus a cell that shrank because another cell became big", () => {
+      expect(shouldRefocusOnZoomChange(false, true)).toBe(false);
+    });
   });
 });

--- a/src/components/cellFlip.ts
+++ b/src/components/cellFlip.ts
@@ -11,6 +11,14 @@ export type Rect = Pick<DOMRect, "left" | "top" | "width" | "height">;
 export const FLIP_MS = 180;
 export const FLIP_EASING = "cubic-bezier(0.2, 0, 0, 1)";
 
+// After an expand/collapse teleports a cell (which blurs its xterm), should THIS cell grab keyboard
+// focus? Yes when it became the big one (`expanded`), or when the grid fully collapsed (`!zoomed`) so
+// it's the one returning to view. No when another cell is now the big one (still `zoomed`) — that
+// cell claims focus instead. `expanded` is the cell's new state; `zoomed` = some cell is expanded.
+export function shouldRefocusOnZoomChange(expanded: boolean, zoomed: boolean | undefined): boolean {
+  return expanded || !zoomed;
+}
+
 // Under these thresholds the move reads as static, and animating it would buy a repaint
 // and nothing else.
 const MIN_SHIFT_PX = 1;


### PR DESCRIPTION
## Summary

Expanding (⤢) or restoring (⤡) a grid cell left the terminal **without keyboard focus** — you had to click before you could type. Now the terminal that should be active grabs focus automatically, so you can type immediately.

## Root cause

Expand/collapse teleports the cell in the DOM (`<Teleport>` to the zoom overlay and back), which blurs the xterm textarea; the ⤢ button had also taken focus. Nothing put focus back.

## Fix

`Terminal.vue` now receives the cell's `expanded` / `zoomed` state and, when it changes, refocuses via the lightweight `conn.focus(slotKey)` — deliberately **not** `connectKey`, which does a full retarget + socket reconnect. It refocuses only the cell that should now be active:

- became the big one (`expanded`) → focus it
- grid fully collapsed (`!zoomed`) → focus the cell returning to the grid
- switched to *another* cell (still `zoomed`) → skip, let that cell claim focus

Runs after the teleport (`nextTick`) and again once the FLIP animation lands. All three cell types (terminal / launcher / command) forward the two props, so it works for every kind of cell.

## Items to Confirm / Review

- **`conn.focus`, not `connectKey`** — the existing connectKey path reconnects the socket; refocus must not. Please sanity-check that choice.
- **The decision of which cell refocuses** is extracted as a pure `shouldRefocusOnZoomChange(expanded, zoomed)` with unit tests; the switch-to-another-cell case is the subtle one.
- Props added to `Terminal.vue` are optional, so the single view (which passes neither) is unaffected — the watch never fires there.

## User Prompt

> expand したり、戻したときに active であるはずのターミナルが入力にあたってない。再度クリックする必要ある。これを直して。すぐに入力したい

## Verification

Unit (`cellFlip.spec.ts`): `shouldRefocusOnZoomChange` — became-big → yes, full-collapse → yes, shrank-because-another-grew → no.

Live (Puppeteer, two `zsh` cells) — because the real bug is DOM focus after a teleport, which a unit test can't prove:

```
after EXPAND  -> activeElement = xterm textarea (inZoom: true)
                 typed "ZOOMTYPE123" with NO click -> appears in the expanded terminal ✅
after COLLAPSE-> activeElement = xterm textarea (inZoom: false)
                 typed "BACKINGRID456" with NO click -> appears in the grid terminal ✅
no console errors
```

Local: 969 tests pass, typecheck 0, lint 0 errors, build ok.

Closes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)