### PR TITLE
feat: zoom the new grid cell when adding a terminal while zoomed

### DIFF
--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -78,6 +78,19 @@ describe("addCell", () => {
     expect(runningCount(s.cells)).toBe(81);
     expect(s.cells).toHaveLength(81);
   });
+  it("zooms the new cell when a cell is currently zoomed", () => {
+    const s = addCell(make(running(3), { expanded: 1 }));
+    expect(s.cells).toHaveLength(4);
+    expect(s.expanded).toBe(s.cells[3].uid); // the freshly appended cell
+  });
+  it("leaves the grid un-zoomed when nothing was zoomed", () => {
+    expect(addCell(make(running(3))).expanded).toBeNull();
+  });
+  it("does not zoom the new cell when `expanded` is stale (points at no cell)", () => {
+    // zoomedUid treats a dangling `expanded` as not-zoomed, so a new cell must not inherit it.
+    const s = addCell(make(running(2), { expanded: 99 }));
+    expect(s.expanded).toBe(99); // unchanged; zoomedUid() still resolves it to null
+  });
 });
 
 describe("cancelableLaunchUid", () => {

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -80,8 +80,12 @@ export function addCell(state: GridState): GridState {
     return clampPage({ ...state, cells: state.cells.slice(0, -1) }); // cancel the open launch cell
   }
   if (runningCount(state.cells) >= MAX_TERMINALS) return state;
-  const cells = [...state.cells, { uid: state.nextUid, session: null, cwd: null }];
-  return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1 };
+  const uid = state.nextUid;
+  const cells = [...state.cells, { uid, session: null, cwd: null }];
+  // While a cell is zoomed, promote the new one into the enlarged view so the user
+  // launches it there rather than hunting for it in the filmstrip.
+  const expanded = zoomedUid(state) !== null ? uid : state.expanded;
+  return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1, expanded };
 }
 
 // The uid of the trailing launch cell that "+ Terminal" (and the launcher's own ✕)


### PR DESCRIPTION
## Summary

grid view で cell を expand（ズーム）している状態で「+ New terminal」を押すと、追加された新しいセルが拡大表示（zoom-main）に昇格するようにしました。従来は新セルがフィルムストリップ（下段の小さい列）に追加されるだけで、そこから探して再度 expand しないと設定・起動できませんでした。今は「見ている拡大表示のところ」に新セッションが出るので、その場で dir を選ぶ／launcher を押すだけで起動できます。

ズームしていない grid の挙動は不変です（勝手にズームしません）。

## Items to Confirm / Review

1. **変更は `addCell` の 4 行のみ**。`zoomedUid(state) !== null`（＝実在セルをズーム中）のときだけ、新セルの uid を `expanded` にします。
2. **stale な `expanded` は昇格しない**: `zoomedUid()` は存在しないセルを指す `expanded` を null 扱いするため、その状態では新セルをズームしません（unit test で担保）。
3. **スコープ**: トリガはツールバーの「New terminal」(= `addCell`)。Run メニュー由来の command セル追加（`runScriptInNewCell`）は対象外にしています（別種の導線・別ページへジャンプ済みのため）。必要なら広げます。

## User Prompt

> grid viewのexpandしているviewで新しいセッションを立ち上げるときに、拡大しているviewのところに表示してほしい

## 実装

`src/components/gridTabs.ts` の `addCell`:

```ts
const uid = state.nextUid;
const cells = [...state.cells, { uid, session: null, cwd: null }];
// While a cell is zoomed, promote the new one into the enlarged view so the user
// launches it there rather than hunting for it in the filmstrip.
const expanded = zoomedUid(state) !== null ? uid : state.expanded;
return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1, expanded };
```

## 検証

隔離 HOME + dev サーバ + puppeteer で実ブラウザ駆動（共有 tmux ソケットには不接触）。

1. bash セル 2 つ → cell0 を expand（`zoomed:true, zoomedUid:"0"`）。
2. ズーム中に「+ New terminal」→ `zoomedUid:"2"`（新セル）、既存 2 セルはフィルムストリップへ。新しい空セルが拡大表示に昇格。
3. 拡大表示の launcher で bash 起動 → そのまま `zoomedUid:"2"` の running セッション（connected）に。
4. 未ズームで + → `zoomed` は false のまま（退行なし）。
5. console error / pageerror ゼロ。

`yarn typecheck` / `yarn build` / `yarn test`（gridTabs 63 本含む、新規 3 ケース追加）すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
