### PR TITLE
fix: render the terminal with the canvas renderer to stop CJK drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@mulmoclaude/x-plugin": "^0.1.2",
     "@receptron/task-scheduler": "^0.1.0",
     "@xterm/addon-attach": "^0.12.0",
+    "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -19,6 +19,7 @@ import { Terminal, type ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard";
+import { CanvasAddon } from "@xterm/addon-canvas";
 import "@xterm/xterm/css/xterm.css";
 import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } from "../components/wsUrl";
 import type { RunCommand } from "../components/runCommand";
@@ -154,6 +155,15 @@ function ensure(key: string, target: ConnTarget): Conn {
   host.style.width = "100%";
   host.style.height = "100%";
   term.open(host);
+  // Render each glyph in its own cell (canvas) instead of the default DOM renderer, which flows text
+  // as inline runs. A full-width CJK glyph that isn't exactly 2× the Latin cell would otherwise let a
+  // long Japanese line drift right and spill its tail past the terminal's edge into the hidden area.
+  // Best-effort: if the canvas renderer can't initialise, xterm keeps the DOM renderer.
+  try {
+    term.loadAddon(new CanvasAddon());
+  } catch (err) {
+    console.warn("[terminal] canvas renderer unavailable — falling back to the DOM renderer", err);
+  }
 
   const c: Conn = {
     key,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2433,6 +2433,11 @@
   resolved "https://registry.yarnpkg.com/@xterm/addon-attach/-/addon-attach-0.12.0.tgz#58d9b1feb8e9e7b5403ccc1491623497c522e704"
   integrity sha512-1lxvXM4JYSm60lbFmE8WMOy2oF2ip3Ye8jWorSAmwy7x8FiC53netEJ5RguL8+FSRj79MUQsNCb2hprY2QA2ig==
 
+"@xterm/addon-canvas@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@xterm/addon-canvas/-/addon-canvas-0.7.0.tgz#d3a3835f3634e0106e108661315ae14da23e8dd7"
+  integrity sha512-LF5LYcfvefJuJ7QotNRdRSPc9YASAVDeoT5uyXS/nZshZXjYplGXRECBGiznwvhNL2I8bq1Lf5MzRwstsYQ2Iw==
+
 "@xterm/addon-clipboard@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz#8f2027b141e78f70fc76ba56aacf467250c284a3"


### PR DESCRIPTION
## Summary

Long **Japanese lines drifted past the terminal's right edge** into the hidden area (English lines wrap and were fine). Switching xterm from its default DOM renderer to the **canvas renderer** fixes it: every glyph is drawn in its own cell on a fixed grid, so drift is structurally impossible.

## Root cause

xterm's DOM renderer lays out each row as inline text runs. When a full-width CJK glyph isn't exactly 2× the Latin cell — common once **JetBrains Mono** is installed and the OS CJK fallback font's advance width doesn't match — the small per-glyph excess accumulates across a line and the tail spills off the right edge.

## ⚠️ Please verify in your environment

**I could not reproduce the drift headlessly** — with the default fallback fonts here, CJK aligns to 2× and doesn't drift. That's the tell that it's font-environment-specific (your machine has JetBrains Mono). The canvas renderer removes drift *by construction* (per-cell positioning), but the before/after can only be seen where the bug reproduces, so please confirm on your machine.

## Items to Confirm / Review

- **Canvas, not WebGL** (your choice): per-cell positioning, no WebGL context limit (safe with a full 9-cell grid). Loaded best-effort — if `new CanvasAddon()` throws, xterm keeps the DOM renderer.
- **Trade-off:** the active-cell zoom (`transform: scale(1.045)`) now scales a canvas, so the focused cell's text is very slightly softer while zoomed. Acceptable vs. correct CJK.
- **No regression to dir-config live-reload:** that relies on `setTheme` (`term.options.theme = …`) repainting — verified it still repaints under canvas (theme switch changed the terminal background).
- `readOutput()` (CommandCell summarize) reads the buffer model, not the DOM, so canvas doesn't affect it.

## User Prompt

> [screenshots] な感じで terminal のサイズに入らないケースが有る。2枚目は文字が右側の見えない部分に飛び出しているよ

## Verification (headless)

```
canvas elements: 4 | DOM .xterm-rows present: false  -> ✅ CANVAS renderer active (xterm 6.0)
Japanese echo renders correctly, input works, no console/page errors
theme switch midnight -> daylight: terminal bg rgb(26,26,46) -> rgb(244,246,251)  ✅ repaint OK
```

969 tests pass, typecheck 0, lint 0 errors, build ok.

Closes #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)