### PR TITLE
feat: header "new terminal" button opens a $SHELL cell adjacent (#319, part 2/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ Setting `buttons` (at either level) **replaces** the defaults with your list, so
 or swap them — e.g. add the in-app **📁 file explorer** with `"open": { "files": "${dir}" }`.
 A button has an `id`, `label`, and a `run` of `"shell"` (run a command), `"input"` (send text to the
 agent), or `"open"`. An `open` button targets one of `url` / `reveal` (OS file manager) / `files`
-(in-app explorer) / `view` (a built-in overlay) / `pickFile: true` (OS file dialog → insert the path).
+(in-app explorer) / `view` (a built-in overlay) / `terminal` (a dir → a new cell running `$SHELL`,
+opened next to the current one) / `pickFile: true` (OS file dialog → insert the path).
 `${dir}`, `${branch}`, `${repo}`, … substitute live context, and `when` (e.g. `"isGitRepo"`) gates
 visibility. The `/mulmoterminal-config` skill writes a valid config interactively; per-dir buttons
 merge over the global ones by `id`.

--- a/server/config-schema.ts
+++ b/server/config-schema.ts
@@ -88,6 +88,8 @@ const openTargetShape = {
   reveal: z.string().optional(),
   files: z.string().optional(),
   view: viewTargetSchema.optional(),
+  // A directory: open a NEW terminal cell there, running the OS default shell ($SHELL).
+  terminal: z.string().optional(),
   // No target string: open the OS file dialog and insert the chosen path(s) into the session.
   pickFile: z.boolean().optional(),
 };
@@ -175,15 +177,17 @@ const writableOpenTargetShape = {
   reveal: nonEmptyText.optional(),
   files: nonEmptyText.optional(),
   view: viewTargetSchema.optional(),
+  terminal: nonEmptyText.optional(),
   pickFile: z.literal(true).optional(),
 };
 
-// `open` requires at least one target (url/reveal/files/view/pickFile), mirroring sanitizeOpen.
+// `open` requires at least one target (url/reveal/files/view/terminal/pickFile), mirroring sanitizeOpen.
 const writableOpenTargetSchema = z.union([
   z.object({ ...writableOpenTargetShape, url: nonEmptyText }),
   z.object({ ...writableOpenTargetShape, reveal: nonEmptyText }),
   z.object({ ...writableOpenTargetShape, files: nonEmptyText }),
   z.object({ ...writableOpenTargetShape, view: viewTargetSchema }),
+  z.object({ ...writableOpenTargetShape, terminal: nonEmptyText }),
   z.object({ ...writableOpenTargetShape, pickFile: z.literal(true) }),
 ]);
 

--- a/server/header-config.spec.ts
+++ b/server/header-config.spec.ts
@@ -136,4 +136,9 @@ describe("sanitizeButtons open.pickFile", () => {
   it("drops pickFile when not exactly true, leaving no valid target", () => {
     expect(sanitizeButtons([{ id: "p", label: "P", run: "open", open: { pickFile: "yes" } }])).toEqual([]);
   });
+  it("keeps a run:open button whose target is a terminal dir", () => {
+    expect(sanitizeButtons([{ id: "t", label: "T", run: "open", open: { terminal: "${dir}" } }])).toEqual([
+      { id: "t", label: "T", run: "open", open: { terminal: "${dir}" } },
+    ]);
+  });
 });

--- a/server/header-config.ts
+++ b/server/header-config.ts
@@ -94,6 +94,8 @@ function sanitizeOpen(input: unknown): OpenTarget | undefined {
   if (reveal) target.reveal = reveal;
   if (files) target.files = files;
   if (view && isViewTarget(view)) target.view = view;
+  const terminal = str(input.terminal);
+  if (terminal) target.terminal = terminal;
   if (input.pickFile === true) target.pickFile = true;
   return Object.keys(target).length ? target : undefined;
 }

--- a/server/header-resolve.spec.ts
+++ b/server/header-resolve.spec.ts
@@ -147,4 +147,9 @@ describe("resolveHeader defaults + pickFile", () => {
     const config: HeaderConfig = { buttons: [{ id: "p", label: "P", run: "open", open: { pickFile: true } }], chips: null };
     expect(resolveHeader(config, ctx()).buttons[0].open).toEqual({ pickFile: true });
   });
+
+  it("substitutes ${dir} in a terminal open target", () => {
+    const config: HeaderConfig = { buttons: [{ id: "t", label: "T", run: "open", open: { terminal: "${dir}" } }], chips: null };
+    expect(resolveHeader(config, ctx()).buttons[0].open).toEqual({ terminal: "/Users/x/myrepo" });
+  });
 });

--- a/server/header-resolve.ts
+++ b/server/header-resolve.ts
@@ -71,6 +71,7 @@ function resolveOpen(open: OpenTarget, ctx: HeaderContext): OpenTarget {
   if (open.reveal) out.reveal = substitute(open.reveal, ctx);
   if (open.files) out.files = substitute(open.files, ctx);
   if (open.view) out.view = open.view;
+  if (open.terminal) out.terminal = substitute(open.terminal, ctx);
   if (open.pickFile) out.pickFile = true;
   return out;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2294,14 +2294,20 @@ function startLaunchEntry(sessionId: string, ws: WebSocket, live: PtyEntry | und
 // session (id kept, running program picked up via `tmux new-session -A`, command ignored),
 // or a fresh spawn of the indexed launcher command. Returns null when there's nothing to
 // reattach AND the index isn't a configured launcher.
-function resolveLaunchSession(requested: string | null, index: number): { sessionId: string; live: PtyEntry | undefined; command: string } | null {
+function resolveLaunchSession(
+  requested: string | null,
+  index: number,
+  shell: boolean,
+): { sessionId: string; live: PtyEntry | undefined; command: string } | null {
   const reattachId = requested && ptys.has(requested) ? requested : null;
   const live = reattachId ? ptys.get(reattachId) : undefined;
   const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
   // A live PTY / surviving tmux session reattaches regardless of the index; only a fresh
   // spawn needs the launcher resolved (the pty already IS the chosen program on reattach).
   const launcher = live || tmuxAlive ? null : resolveLauncher(index);
-  if (!live && !tmuxAlive && !launcher) return null;
+  // `shell` (the header "new terminal" button) runs the OS default shell with no configured
+  // index, so a fresh spawn is allowed without a resolvable launcher.
+  if (!live && !tmuxAlive && !launcher && !shell) return null;
   const sessionId = reattachId ?? (tmuxAlive && requested ? requested : randomUUID());
   return { sessionId, live, command: launcher?.command ?? DEFAULT_LAUNCH_CMD };
 }
@@ -2317,8 +2323,9 @@ runLaunchWss.on("connection", (ws, req) => {
   const cwd = resolveWorkspace(url.searchParams.get("cwd"));
   const indexRaw = url.searchParams.get("launcher");
   const index = indexRaw !== null && /^\d+$/.test(indexRaw) ? Number(indexRaw) : NaN;
+  const shell = url.searchParams.get("shell") === "1";
 
-  const resolved = resolveLaunchSession(requested, index);
+  const resolved = resolveLaunchSession(requested, index, shell);
   if (!resolved) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
   const { sessionId, live, command } = resolved;
   markDevTerminalSession(sessionId);

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -172,6 +172,7 @@ or the in-app file explorer with `{ "run": "open", "open": { "files": "${dir}" }
     - `reveal` — a directory path → the OS file manager (Finder/Explorer/xdg-open),
     - `files` — a directory path → the in-app file explorer,
     - `view` — an in-app overlay: `"diff"` / `"prs"` / `"wiki"` / `"collections"` / `"accounting"`,
+    - `terminal` — a directory → open a NEW grid cell running the OS default shell (`$SHELL`) there, next to the current cell,
     - `pickFile: true` — open the OS file dialog and insert the chosen path(s) into the session.
 - `when` (optional) visibility condition, `order` (optional) sort key (lower first, unset last).
 

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from "vue";
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount, onActivated, onDeactivated } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
 import AppToolbar from "./AppToolbar.vue";
@@ -35,7 +35,7 @@ import {
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import { useSessions } from "../composables/useSessions";
-import { registerNewTerminalHandler } from "../composables/useNewTerminal";
+import { registerNewTerminalHandler, type NewTerminalRequest } from "../composables/useNewTerminal";
 import { usePendingScript } from "../composables/usePendingScript";
 import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
@@ -146,14 +146,23 @@ onMounted(() => {
 });
 
 // The header "new terminal" button ($SHELL) opens a cell next to the one that triggered it.
-// Registered at setup scope (a plain callback, no DOM needed) so onBeforeUnmount attaches correctly.
+// GridView is cached by <KeepAlive>, so register the opener only while ACTIVE and drop it on
+// deactivate — otherwise a button press from the single view would silently mutate this hidden
+// grid instead of routing here. openTerminalAt then queues + navigates while we're deactivated.
 const SLOT_UID_RE = /^cell-(\d+)$/;
-const offNewTerminal = registerNewTerminalHandler(({ cwd, afterSlotKey }) => {
+let offNewTerminal: (() => void) | null = null;
+const openNewTerminal = ({ cwd, afterSlotKey }: NewTerminalRequest) => {
   const match = afterSlotKey?.match(SLOT_UID_RE);
   const afterUid = match ? Number(match[1]) : NO_ORIGIN_UID;
   state.value = insertCellAfter(state.value, afterUid, shellCell(cwd));
-});
-onBeforeUnmount(offNewTerminal);
+};
+const detachNewTerminal = () => {
+  offNewTerminal?.();
+  offNewTerminal = null;
+};
+onActivated(() => (offNewTerminal = registerNewTerminalHandler(openNewTerminal)));
+onDeactivated(detachNewTerminal);
+onBeforeUnmount(detachNewTerminal);
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.
 const {

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -146,15 +146,14 @@ onMounted(() => {
 });
 
 // The header "new terminal" button ($SHELL) opens a cell next to the one that triggered it.
+// Registered at setup scope (a plain callback, no DOM needed) so onBeforeUnmount attaches correctly.
 const SLOT_UID_RE = /^cell-(\d+)$/;
-onMounted(() => {
-  const off = registerNewTerminalHandler(({ cwd, afterSlotKey }) => {
-    const match = afterSlotKey?.match(SLOT_UID_RE);
-    const afterUid = match ? Number(match[1]) : NO_ORIGIN_UID;
-    state.value = insertCellAfter(state.value, afterUid, shellCell(cwd));
-  });
-  onBeforeUnmount(off);
+const offNewTerminal = registerNewTerminalHandler(({ cwd, afterSlotKey }) => {
+  const match = afterSlotKey?.match(SLOT_UID_RE);
+  const afterUid = match ? Number(match[1]) : NO_ORIGIN_UID;
+  state.value = insertCellAfter(state.value, afterUid, shellCell(cwd));
 });
+onBeforeUnmount(offNewTerminal);
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.
 const {

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, computed, watch, onMounted } from "vue";
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
 import AppToolbar from "./AppToolbar.vue";
@@ -16,6 +16,8 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  insertCellAfter,
+  shellCell,
   launchInCell,
   setSortMode,
   moveCell,
@@ -33,6 +35,7 @@ import {
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import { useSessions } from "../composables/useSessions";
+import { registerNewTerminalHandler } from "../composables/useNewTerminal";
 import { usePendingScript } from "../composables/usePendingScript";
 import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
@@ -123,8 +126,8 @@ const onAgent = (uid: number, agent: "claude" | "codex") => (state.value = setCe
 const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: RunCommand) => (state.value = runCommand(state.value, uid, command));
-// A running cell's header Run menu: launch in a spare cell so the session survives.
-const onRunSpare = (command: RunCommand) => (state.value = runScriptInNewCell(state.value, command));
+// A running cell's header Run menu: launch in a spare cell (next to it) so the session survives.
+const onRunSpare = (uid: number, command: RunCommand) => (state.value = runScriptInNewCell(state.value, uid, command));
 // The empty cell launcher picked a configured program (shell/codex/…): turn it into a
 // persistent launcher cell. Its session id arrives later via onSession.
 const onLaunch = (uid: number, pick: { index: number; label: string; cwd: string | null }) =>
@@ -136,9 +139,21 @@ const switchTo = (page: number) => (state.value = switchPage(state.value, page))
 // A script the single view's terminal-header Run menu handed off: run it in a spare
 // cell now that the grid (where command cells live) is mounted.
 const { takePending } = usePendingScript();
+const NO_ORIGIN_UID = -1; // no triggering cell (uids are >= 0) → insertCellAfter appends at the end
 onMounted(() => {
   const command = takePending();
-  if (command) state.value = runScriptInNewCell(state.value, command);
+  if (command) state.value = runScriptInNewCell(state.value, NO_ORIGIN_UID, command);
+});
+
+// The header "new terminal" button ($SHELL) opens a cell next to the one that triggered it.
+const SLOT_UID_RE = /^cell-(\d+)$/;
+onMounted(() => {
+  const off = registerNewTerminalHandler(({ cwd, afterSlotKey }) => {
+    const match = afterSlotKey?.match(SLOT_UID_RE);
+    const afterUid = match ? Number(match[1]) : NO_ORIGIN_UID;
+    state.value = insertCellAfter(state.value, afterUid, shellCell(cwd));
+  });
+  onBeforeUnmount(off);
 });
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from "vue";
 import TerminalView from "./Terminal.vue";
 import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
-import type { CellStatus, CellLauncher } from "./gridTabs";
+import { isShellLauncher, type CellStatus, type CellLauncher } from "./gridTabs";
 
 // A grid cell running a configured launch command (a plain shell, codex, any
 // interactive program) instead of Claude. Unlike CommandCell this is PERSISTENT: it
@@ -45,7 +45,7 @@ const connectKey = ref(0);
 const finished = ref(false);
 
 const dirDisplay = computed(() => formatCwd(props.cwd, props.home));
-const target = computed(() => ({ index: props.launcher.index }));
+const target = computed(() => (isShellLauncher(props.launcher) ? { shell: true as const } : { index: props.launcher.index }));
 
 // Running counts as "working"; once the process exits it's idle (never "waiting").
 watch(finished, (done) => emit("status", done ? "idle" : "working"), { immediate: true });

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -38,9 +38,10 @@ const props = defineProps<{
   cwd?: string | null;
   devTerminal?: boolean;
   command?: RunCommand | null;
-  // A configured launcher (shell/codex/command) — persistent & reattachable, connects
-  // to /ws/launch instead of resuming a Claude session.
-  launcher?: { index: number } | null;
+  // A configured launcher (shell/codex/command) by index, or the OS default shell
+  // (`{ shell: true }`) — persistent & reattachable, connects to /ws/launch instead of
+  // resuming a Claude session.
+  launcher?: { index: number } | { shell: true } | null;
   // A first-class codex session — connects to /ws/codex instead of /ws (Claude).
   codex?: boolean;
   runMenu?: boolean;
@@ -99,9 +100,9 @@ const { context: sessionContext } = useSessionContext(
   computed(() => props.sessionId),
   serverCwd,
 );
-// User-configured header action buttons for this session's dir (GET /api/header). Additive: with no
-// config the list is empty so the header is unchanged. They target the running agent session, so they're
-// suppressed on a command/launcher terminal — those embed Terminal without a session and don't handle `run`.
+// Resolved header action buttons for this session's dir (GET /api/header) — the user's config, or the
+// built-in defaults when unconfigured. They target the running agent session, so they're suppressed on a
+// command/launcher terminal — those embed Terminal without a session and don't handle `run`.
 const headerButtonsCwd = computed(() => (props.command || props.launcher ? null : serverCwd.value));
 const { buttons: headerButtons } = useHeaderButtons({
   cwd: headerButtonsCwd,

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -35,8 +35,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "session" | "cwd", uid: number, value: string): void;
   (e: "close" | "toggle-expand", uid: number): void;
-  (e: "run", uid: number, command: RunCommand): void;
-  (e: "runSpare", command: RunCommand): void;
+  (e: "run" | "runSpare", uid: number, command: RunCommand): void;
   (e: "launch", uid: number, pick: LaunchPick): void;
   (e: "move", uid: number, dir: -1 | 1): void;
   (e: "status", uid: number, value: CellStatus): void;
@@ -187,7 +186,7 @@ watch(
           @record-cwd="(c) => emit('record-cwd', c)"
           @remove-preset="(path) => emit('remove-preset', path)"
           @run="(cmd) => emit('run', cell.uid, cmd)"
-          @run-spare="(cmd) => emit('runSpare', cmd)"
+          @run-spare="(cmd) => emit('runSpare', cell.uid, cmd)"
           @launch="(pick) => emit('launch', cell.uid, pick)"
           @close="emit('close', cell.uid)"
           @move="(dir) => emit('move', cell.uid, dir)"

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -12,6 +12,8 @@ import {
   switchPage,
   runCommand,
   runScriptInNewCell,
+  insertCellAfter,
+  shellCell,
   launchInCell,
   setSortMode,
   moveCell,
@@ -211,33 +213,49 @@ describe("launchInCell (persistent launcher cells)", () => {
   });
 });
 
-describe("runScriptInNewCell (toolbar Run menu)", () => {
+describe("insertCellAfter", () => {
+  it("inserts a new cell right after the given uid, minting the next uid", () => {
+    const s = insertCellAfter(make(running(3)), 1, { session: null, cwd: "/x" });
+    expect(s.cells).toHaveLength(4);
+    expect(s.cells.map((c) => c.uid)).toEqual([0, 1, 3, 2]); // NEW (uid 3) lands after uid 1
+    expect(s.cells[2]).toMatchObject({ session: null, cwd: "/x", uid: 3 });
+  });
+  it("appends when the uid is not found (e.g. no triggering cell)", () => {
+    const s = insertCellAfter(make(running(2)), -1, { session: null, cwd: null });
+    expect(s.cells).toHaveLength(3);
+    expect(s.cells[2].uid).toBe(2);
+  });
+  it("jumps to the new cell's page when it lands on a later page", () => {
+    const s = insertCellAfter(make(running(9)), 8, { session: null, cwd: null }); // after index 8 -> index 9 -> page 1
+    expect(s.cells).toHaveLength(10);
+    expect(s.page).toBe(1);
+  });
+  it("is a no-op at the terminal cap", () => {
+    expect(insertCellAfter(make(running(81)), 0, { session: null, cwd: null }).cells).toHaveLength(81);
+  });
+});
+
+describe("runScriptInNewCell (Run button → adjacent spare cell)", () => {
   const CMD: RunCommand = { source: "script", index: 1, label: "Dev server", cwd: "/x" };
 
-  it("appends a new command cell and jumps to its page when all cells are occupied", () => {
-    const s = runScriptInNewCell(make(running(2)), CMD);
-    expect(s.cells).toHaveLength(3);
-    expect(s.cells[2]).toMatchObject({ session: null, command: CMD });
-    expect(s.page).toBe(0); // 3 cells -> still page 1
+  it("opens the command in a new cell right after the triggering cell", () => {
+    const s = runScriptInNewCell(make(running(3)), 0, CMD);
+    expect(s.cells).toHaveLength(4);
+    expect(s.cells[1]).toMatchObject({ session: null, command: CMD }); // after uid 0 (index 0)
   });
-  it("overflows onto a new page when the current page is full", () => {
-    const s = runScriptInNewCell(make(running(9)), CMD);
-    expect(s.cells).toHaveLength(10);
-    expect(s.page).toBe(1); // jumped to the new cell's page
-  });
-  it("reuses a trailing empty launcher instead of appending", () => {
-    const s = runScriptInNewCell(make([...running(2), cell(2)]), CMD); // trailing launch cell
+  it("appends when there is no triggering cell (afterUid -1)", () => {
+    const s = runScriptInNewCell(make(running(2)), -1, CMD);
     expect(s.cells).toHaveLength(3);
     expect(s.cells[2].command).toEqual(CMD);
   });
-  it("turns the sole entry launch cell into a command cell", () => {
-    const s = runScriptInNewCell(make([cell(0)]), CMD);
-    expect(s.cells).toHaveLength(1);
-    expect(s.cells[0].command).toEqual(CMD);
+  it("is a no-op at the terminal cap", () => {
+    expect(runScriptInNewCell(make(running(81)), 0, CMD).cells).toHaveLength(81);
   });
-  it("is a no-op at the terminal cap (no trailing launcher to reuse)", () => {
-    const s = runScriptInNewCell(make(running(81)), CMD);
-    expect(s.cells).toHaveLength(81);
+});
+
+describe("shellCell", () => {
+  it("is a launcher cell for the OS default shell ($SHELL)", () => {
+    expect(shellCell("/proj")).toEqual({ session: null, cwd: "/proj", launcher: { shell: true, label: "shell" } });
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -9,9 +9,13 @@ import type { RunCommand } from "./runCommand";
 
 // A configured launch command (shell/codex/…) running in a cell. `index` is its
 // position in the user's launcher list (the server's allowlist); `label` is kept for
-// display and to re-launch after a server restart. Unlike a command, a launcher cell
-// IS persisted (it has a session and reconnects).
-export type CellLauncher = { index: number; label: string };
+// display and to re-launch after a server restart. `{ shell: true }` is the OS default
+// shell ($SHELL) opened by the header "new terminal" button — no configured index.
+// Unlike a command, a launcher cell IS persisted (it has a session and reconnects).
+export type CellLauncher = { index: number; label: string } | { shell: true; label: string };
+export const isShellLauncher = (l: CellLauncher): l is { shell: true; label: string } => "shell" in l;
+// A fresh OS-default-shell cell (session arrives from the server, then it persists/reconnects).
+export const shellCell = (cwd: string, label = "shell"): Omit<Cell, "uid"> => ({ session: null, cwd, launcher: { shell: true, label } });
 
 export interface Cell {
   uid: number;
@@ -126,18 +130,22 @@ export function launchInCell(state: GridState, uid: number, launcher: CellLaunch
   return { ...state, cells: state.cells.map((c) => (c.uid === uid ? { ...c, launcher, cwd } : c)) };
 }
 
-// The toolbar Run menu ran a script with no target cell: reuse a trailing empty
-// launcher if there is one, otherwise append a fresh command cell (respecting the
-// cap), and jump to its page so it's visible.
-export function runScriptInNewCell(state: GridState, command: NonNullable<Cell["command"]>): GridState {
-  const last = state.cells[state.cells.length - 1];
-  if (isLaunchCell(last)) {
-    const cells = state.cells.map((c, i) => (i === state.cells.length - 1 ? { ...c, command } : c));
-    return { ...state, cells, page: pageCount(cells.length) - 1 };
-  }
+// Insert a brand-new cell immediately AFTER the cell that triggered it, so the header
+// "new terminal" button and the Run button open next to the current cell rather than at
+// the end. Falls back to appending when `afterUid` is gone. Jumps to the new cell's page.
+export function insertCellAfter(state: GridState, afterUid: number, cell: Omit<Cell, "uid">): GridState {
   if (runningCount(state.cells) >= MAX_TERMINALS) return state;
-  const cells = [...state.cells, { uid: state.nextUid, session: null, cwd: null, command }];
-  return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1 };
+  const idx = state.cells.findIndex((c) => c.uid === afterUid);
+  const at = idx >= 0 ? idx + 1 : state.cells.length;
+  const uid = state.nextUid;
+  const cells = [...state.cells.slice(0, at), { ...cell, uid }, ...state.cells.slice(at)];
+  const expanded = zoomedUid(state) !== null ? uid : state.expanded;
+  return { ...state, cells, nextUid: state.nextUid + 1, page: Math.floor(at / PAGE_SIZE), expanded };
+}
+
+// The Run button opened a script in a spare cell next to the cell that triggered it.
+export function runScriptInNewCell(state: GridState, afterUid: number, command: NonNullable<Cell["command"]>): GridState {
+  return insertCellAfter(state, afterUid, { session: null, cwd: null, command });
 }
 
 // Close a cell: drop it and reflow the list (later cells pack forward across
@@ -234,11 +242,11 @@ const isUuid = (s: unknown): s is string => typeof s === "string" && UUID_RE.tes
 const asSortMode = (v: unknown): SortMode => (v === "auto" ? "auto" : "manual");
 // Keep a persisted launcher only if well-formed; anything else drops to null so a
 // reloaded cell reconnects as a plain (Claude) session instead of a broken launcher.
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const asLauncher = (v: unknown): CellLauncher | null => {
-  const o = v as CellLauncher | null;
-  return o && typeof o.index === "number" && Number.isInteger(o.index) && o.index >= 0 && typeof o.label === "string"
-    ? { index: o.index, label: o.label }
-    : null;
+  if (!isRecord(v) || typeof v.label !== "string") return null;
+  if (v.shell === true) return { shell: true, label: v.label };
+  return typeof v.index === "number" && Number.isInteger(v.index) && v.index >= 0 ? { index: v.index, label: v.label } : null;
 };
 // A cell entry is kept if its session/cwd are well-formed; uid is validated only to
 // match the persisted `expanded` (it is renumbered below regardless).

--- a/src/components/wsUrl.spec.ts
+++ b/src/components/wsUrl.spec.ts
@@ -91,6 +91,13 @@ describe("buildLaunchWsUrl", () => {
     const url = buildLaunchWsUrl({ host: "h", secure: true, sessionId: null, launcher: 1 });
     expect(url.startsWith("wss://")).toBe(true);
   });
+
+  it("shell: sends shell=1 and no launcher index (the OS default shell)", () => {
+    const q = new URL(buildLaunchWsUrl({ host: "h", secure: false, sessionId: null, cwd: "/proj", shell: true })).searchParams;
+    expect(q.get("shell")).toBe("1");
+    expect(q.has("launcher")).toBe(false);
+    expect(q.get("cwd")).toBe("/proj");
+  });
 });
 
 describe("buildCodexWsUrl", () => {

--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -50,17 +50,19 @@ export interface LaunchWsUrlInput {
   secure: boolean;
   sessionId: string | null; // reattach this persistent launcher session; null => fresh
   cwd?: string | null;
-  launcher: number; // position in the configured launcher list (the server resolves it)
+  launcher?: number; // position in the configured launcher list (the server resolves it)
+  shell?: boolean; // run the OS default shell ($SHELL) — no configured index (the header "new terminal" button)
 }
 
-// The launcher-terminal endpoint (a configured shell/codex/command). Persistent &
-// reattachable like /ws: the browser sends the launcher INDEX (config is the allowlist)
-// plus the session id to reattach. On a cold spawn the server resolves the index.
-export function buildLaunchWsUrl({ host, secure, sessionId, cwd, launcher }: LaunchWsUrlInput): string {
+// The launcher-terminal endpoint (a configured shell/codex/command, or the OS default shell).
+// Persistent & reattachable like /ws: the browser sends the launcher INDEX (config is the allowlist)
+// — or `shell=1` for the OS default shell, which needs no index — plus the session id to reattach.
+export function buildLaunchWsUrl({ host, secure, sessionId, cwd, launcher, shell }: LaunchWsUrlInput): string {
   const params = new URLSearchParams();
   if (sessionId) params.set("session", sessionId);
   if (cwd) params.set("cwd", cwd);
-  params.set("launcher", String(launcher));
+  if (shell) params.set("shell", "1");
+  else params.set("launcher", String(launcher));
   const proto = secure ? "wss:" : "ws:";
   return `${proto}//${host}/ws/launch?${params.toString()}`;
 }

--- a/src/composables/useHeaderAction.spec.ts
+++ b/src/composables/useHeaderAction.spec.ts
@@ -8,6 +8,7 @@ const m = vi.hoisted(() => ({
   accountingViewOpen: vi.fn(),
   submitText: vi.fn(),
   insertText: vi.fn(),
+  openTerminalAt: vi.fn(),
 }));
 vi.mock("./useFilesView", () => ({ filesGotoIndex: m.filesGotoIndex }));
 vi.mock("./usePrsView", () => ({ prsGotoIndex: m.prsGotoIndex }));
@@ -15,6 +16,7 @@ vi.mock("./useWikiBrowse", () => ({ wikiGotoIndex: m.wikiGotoIndex }));
 vi.mock("./useCollectionBrowse", () => ({ browseGotoIndex: m.browseGotoIndex }));
 vi.mock("./useAccountingView", () => ({ accountingViewOpen: m.accountingViewOpen }));
 vi.mock("./useTerminalConnections", () => ({ submitText: m.submitText, insertText: m.insertText }));
+vi.mock("./useNewTerminal", () => ({ openTerminalAt: m.openTerminalAt }));
 
 import { runHeaderButton } from "./useHeaderAction";
 import type { HeaderButton } from "./useHeaderButtons";
@@ -59,6 +61,11 @@ describe("runHeaderButton", () => {
     expect(m.prsGotoIndex).toHaveBeenCalled();
     runHeaderButton(btn({ run: "open", open: { view: "diff" } }), null, "/c");
     expect(m.filesGotoIndex).toHaveBeenLastCalledWith("/c");
+  });
+
+  it("open terminal → openTerminalAt with the dir and the triggering cell's slot key", () => {
+    runHeaderButton(btn({ run: "open", open: { terminal: "/proj" } }), "cell-4", "/proj");
+    expect(m.openTerminalAt).toHaveBeenCalledWith("/proj", "cell-4");
   });
 
   it("open pickFile → POST /api/pick-file, inserts the chosen path(s) into the slot", async () => {

--- a/src/composables/useHeaderAction.ts
+++ b/src/composables/useHeaderAction.ts
@@ -8,6 +8,7 @@ import { wikiGotoIndex } from "./useWikiBrowse";
 import { browseGotoIndex } from "./useCollectionBrowse";
 import { accountingViewOpen } from "./useAccountingView";
 import { submitText, insertText } from "./useTerminalConnections";
+import { openTerminalAt } from "./useNewTerminal";
 import { toInsertText } from "../components/dropPaths";
 import type { HeaderButton, OpenTarget } from "./useHeaderButtons";
 
@@ -55,6 +56,7 @@ function dispatchOpen(open: OpenTarget, cwd: string | null, slotKey: string | nu
   else if (open.reveal) revealDir(open.reveal);
   else if (open.files) filesGotoIndex(open.files);
   else if (open.view) openView(open.view, cwd);
+  else if (open.terminal) openTerminalAt(open.terminal, slotKey);
   else if (open.pickFile) void pickFileInto(slotKey);
 }
 

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -10,6 +10,7 @@ export interface OpenTarget {
   reveal?: string;
   files?: string;
   view?: string;
+  terminal?: string;
   pickFile?: boolean;
 }
 export interface HeaderButton {

--- a/src/composables/useNewTerminal.spec.ts
+++ b/src/composables/useNewTerminal.spec.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { defineComponent, h, KeepAlive, ref, nextTick, onActivated, onDeactivated } from "vue";
+import { mount } from "@vue/test-utils";
 
 const { push } = vi.hoisted(() => ({ push: vi.fn(() => Promise.resolve()) }));
 vi.mock("../router", () => ({ router: { push } }));
@@ -39,5 +41,40 @@ describe("useNewTerminal", () => {
     expect(h2).toHaveBeenCalled();
     expect(h1).not.toHaveBeenCalled();
     off2();
+  });
+
+  // Regression for the KeepAlive case (GridView is cached): while DEACTIVATED the opener must be
+  // unregistered so a single-view button press navigates to the grid instead of mutating hidden state.
+  it("register-on-activate / unregister-on-deactivate: deactivated → queue + navigate, reactivated → drain", async () => {
+    const handler = vi.fn();
+    const active = ref(true);
+    const Probe = defineComponent({
+      setup() {
+        let off: (() => void) | null = null;
+        onActivated(() => (off = registerNewTerminalHandler(handler)));
+        onDeactivated(() => {
+          off?.();
+          off = null;
+        });
+        return () => h("div");
+      },
+    });
+    const Host = defineComponent({ setup: () => () => h(KeepAlive, () => (active.value ? h(Probe) : null)) });
+    const wrapper = mount(Host);
+    await nextTick();
+
+    openTerminalAt("/a", "cell-1"); // active → handler runs, no navigation
+    expect(handler).toHaveBeenCalledWith({ cwd: "/a", afterSlotKey: "cell-1" });
+    expect(push).not.toHaveBeenCalled();
+
+    active.value = false; // KeepAlive deactivates the probe (not unmounted)
+    await nextTick();
+    openTerminalAt("/b", "single"); // no live handler → queue + navigate
+    expect(push).toHaveBeenCalledWith("/terminals");
+
+    active.value = true; // reactivate → re-register drains the queued request
+    await nextTick();
+    expect(handler).toHaveBeenCalledWith({ cwd: "/b", afterSlotKey: "single" });
+    wrapper.unmount();
   });
 });

--- a/src/composables/useNewTerminal.spec.ts
+++ b/src/composables/useNewTerminal.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { push } = vi.hoisted(() => ({ push: vi.fn(() => Promise.resolve()) }));
+vi.mock("../router", () => ({ router: { push } }));
+
+import { registerNewTerminalHandler, openTerminalAt } from "./useNewTerminal";
+
+describe("useNewTerminal", () => {
+  beforeEach(() => {
+    registerNewTerminalHandler(() => {})(); // drain any leftover pending + clear the handler
+    push.mockClear();
+  });
+
+  it("calls the registered handler directly when the grid is mounted", () => {
+    const h = vi.fn();
+    const off = registerNewTerminalHandler(h);
+    openTerminalAt("/proj", "cell-3");
+    expect(h).toHaveBeenCalledWith({ cwd: "/proj", afterSlotKey: "cell-3" });
+    expect(push).not.toHaveBeenCalled();
+    off();
+  });
+
+  it("queues + navigates to /terminals with no grid, then drains on register (single-view path)", () => {
+    openTerminalAt("/proj", "single");
+    expect(push).toHaveBeenCalledWith("/terminals");
+    const h = vi.fn();
+    const off = registerNewTerminalHandler(h); // GridView mounts and registers
+    expect(h).toHaveBeenCalledWith({ cwd: "/proj", afterSlotKey: "single" });
+    off();
+  });
+
+  it("a stale unregister does not clear a newer handler", () => {
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    const off1 = registerNewTerminalHandler(h1);
+    const off2 = registerNewTerminalHandler(h2); // h2 is current now
+    off1(); // stale — must NOT detach h2
+    openTerminalAt("/x", null);
+    expect(h2).toHaveBeenCalled();
+    expect(h1).not.toHaveBeenCalled();
+    off2();
+  });
+});

--- a/src/composables/useNewTerminal.ts
+++ b/src/composables/useNewTerminal.ts
@@ -1,0 +1,26 @@
+// A seam for opening a new grid terminal cell from anywhere — the header "new terminal" button
+// (open.terminal). The new cell runs the OS default shell ($SHELL) in `cwd`. GridView owns the grid
+// state, so it REGISTERS a handler here; the button just calls openTerminalAt(). The new cell opens
+// next to the cell identified by `afterSlotKey` (the durable slot key "cell-<uid>"), or at the end when
+// that can't be resolved (e.g. the single view, whose slot key isn't a grid cell).
+
+export interface NewTerminalRequest {
+  cwd: string;
+  afterSlotKey: string | null;
+}
+type Handler = (req: NewTerminalRequest) => void;
+
+let handler: Handler | null = null;
+
+// GridView registers its opener; the returned function unregisters it (call in onBeforeUnmount).
+export function registerNewTerminalHandler(h: Handler): () => void {
+  handler = h;
+  return () => {
+    if (handler === h) handler = null;
+  };
+}
+
+// Open a new terminal cell running $SHELL in `cwd`, next to `afterSlotKey`'s cell.
+export function openTerminalAt(cwd: string, afterSlotKey: string | null): void {
+  handler?.({ cwd, afterSlotKey });
+}

--- a/src/composables/useNewTerminal.ts
+++ b/src/composables/useNewTerminal.ts
@@ -3,6 +3,11 @@
 // state, so it REGISTERS a handler here; the button just calls openTerminalAt(). The new cell opens
 // next to the cell identified by `afterSlotKey` (the durable slot key "cell-<uid>"), or at the end when
 // that can't be resolved (e.g. the single view, whose slot key isn't a grid cell).
+//
+// When the grid isn't mounted (the button pressed from the single view), the request is QUEUED and the
+// app switches to /terminals; GridView drains the queue when it registers on mount — mirroring
+// usePendingScript for the single view's Run menu.
+import { router } from "../router";
 
 export interface NewTerminalRequest {
   cwd: string;
@@ -11,16 +16,30 @@ export interface NewTerminalRequest {
 type Handler = (req: NewTerminalRequest) => void;
 
 let handler: Handler | null = null;
+let pending: NewTerminalRequest | null = null;
 
-// GridView registers its opener; the returned function unregisters it (call in onBeforeUnmount).
+// GridView registers its opener; a queued request (from before it mounted) drains immediately.
+// The returned function unregisters it (call in onBeforeUnmount).
 export function registerNewTerminalHandler(h: Handler): () => void {
   handler = h;
+  if (pending) {
+    const req = pending;
+    pending = null;
+    h(req);
+  }
   return () => {
     if (handler === h) handler = null;
   };
 }
 
-// Open a new terminal cell running $SHELL in `cwd`, next to `afterSlotKey`'s cell.
+// Open a new terminal cell running $SHELL in `cwd`, next to `afterSlotKey`'s cell. If the grid isn't
+// mounted yet, queue the request and switch to it.
 export function openTerminalAt(cwd: string, afterSlotKey: string | null): void {
-  handler?.({ cwd, afterSlotKey });
+  const req: NewTerminalRequest = { cwd, afterSlotKey };
+  if (handler) {
+    handler(req);
+    return;
+  }
+  pending = req;
+  router.push("/terminals").catch(() => {});
 }

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -59,9 +59,10 @@ export interface ConnTarget {
   cwd: string | null;
   devTerminal: boolean;
   command: RunCommand | null;
-  // A configured launcher (shell/codex/command). Unlike `command` this is a PERSISTENT
-  // session — it reconnects on drop and reattaches by session id, like a Claude cell.
-  launcher: { index: number } | null;
+  // A configured launcher (shell/codex/command) by index, or the OS default shell
+  // (`{ shell: true }`, the header "new terminal" button). Unlike `command` this is a
+  // PERSISTENT session — it reconnects on drop and reattaches by session id, like a Claude cell.
+  launcher: { index: number } | { shell: true } | null;
   // A first-class codex session (/ws/codex) instead of a Claude one. Persistent &
   // reattachable like a Claude cell; the server discovers + resumes codex's own id.
   codex?: boolean;
@@ -226,7 +227,10 @@ function runCommandUrl(command: RunCommand, host: string, secure: boolean): stri
 function connUrl(target: ConnTarget, resumeId: string | null, secure: boolean): string {
   const host = location.host;
   if (target.command) return runCommandUrl(target.command, host, secure);
-  if (target.launcher) return buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
+  if (target.launcher)
+    return "shell" in target.launcher
+      ? buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, shell: true })
+      : buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
   if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
   return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
 }


### PR DESCRIPTION
## Summary

**Part 2 of 3** for #319. Adds a new **`open.terminal`** header-button action: open a **new grid cell
running the OS default shell (`$SHELL`)** in a given directory, inserted **right next to the cell that
triggered it**. The **Run button's** spare cell now opens adjacent too (previously appended at the end).

- **Server**: `/ws/launch?shell=1` spawns `$SHELL` with **no configured launcher index** —
  `resolveLaunchSession` gains a `shell` flag and falls back to `DEFAULT_LAUNCH_CMD` (`process.env.SHELL`).
  Reuses the existing persistent/reattach/tmux launcher path. **Verified live** (WS → session + shell output).
- **Schema/resolve**: `open.terminal` (a dir, `${dir}`-substituted) across config-schema / header-config /
  header-resolve / client `OpenTarget`.
- **Grid**: `Cell.launcher` is now `{ index } | { shell: true }`; `insertCellAfter(state, afterUid, cell)`
  places a new cell after a uid; `runScriptInNewCell` and the Run button take the triggering uid;
  `shellCell()` builds the `$SHELL` cell; `LauncherCell` renders it via `/ws/launch` shell mode.
- **Dispatch**: `open.terminal` → `useNewTerminal.openTerminalAt(cwd, slotKey)`; `GridView` registers the
  opener and parses the `"cell-<uid>"` slot key to insert adjacent (appends when it can't resolve one).

## Items to Confirm / Review

- **Behavior change**: the **Run button** (a running cell's ▶ Run menu) now opens its spare command cell
  **adjacent** to the triggering cell instead of at the end / reusing a trailing launcher. Intended (user
  asked for this), but it changes existing behavior — flagging.
- **`Cell.launcher` union**: persisted shell cells reconnect via `/ws/launch?shell=1` on reload
  (`asLauncher` keeps the `{ shell: true }` shape). Please sanity-check the persistence path.
- **`$SHELL` spawn**: runs `process.env.SHELL || "/bin/sh"` via the same `spawnLauncherPty` used by
  configured launchers (`$SHELL -lc "exec $SHELL"`). No new command-execution surface beyond that.
- **Adjacent insert page jump**: `insertCellAfter` jumps to the new cell's page; unit-tested for
  mid-list, not-found (append), later-page, and the terminal cap.

## User Prompt

> 現在の cwd でターミナルを開くボタンを追加してほしい。ターミナルはすぐに開いてほしい。開くシェルはユーザが OS で指定しているもの（`$SHELL`）を使う。
> 新しいセルは現在のセルの横（右）に開いてほしい。Run ボタンも同じ挙動が良い。

(Umbrella feature; PR 1 shipped the config-driven defaults + the OS-reveal default button. PR 3 will add
the "open this branch's PR" button, shown only when an open PR exists.)

## Implementation

Files: `server/{config-schema,header-config,header-resolve,index}.ts`; `src/composables/{useHeaderButtons,
useHeaderAction,useNewTerminal(new),useTerminalConnections}.ts`; `src/components/{wsUrl,gridTabs,LauncherCell,
Terminal,TerminalGrid,GridView}.*`; tests for gridTabs (`insertCellAfter` / adjacent Run / `shellCell`),
wsUrl (`shell=1`), useHeaderAction (`open.terminal` dispatch), header-config / header-resolve (`terminal`
target); README `#header-buttons` + config skill docs.

Umbrella: #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
