### PR TITLE
feat: grid cockpit — text roster beside the expanded terminal

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import path from "path";
 import os from "os";
 import fs from "fs/promises";
 import { randomUUID } from "crypto";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, statSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "url";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createPubSub } from "./pubsub.js";
@@ -54,6 +54,7 @@ import {
   isTrivialPrompt,
   aiTitleFromJsonl,
   latestMeaningfulUserPromptFromJsonl,
+  latestAssistantTextFromJsonl,
   preferredHeaderPrompt,
   sessionUsageFromJsonl,
   latestTurnContextFromJsonl,
@@ -471,6 +472,19 @@ const LAST_PROMPT_CAP = 200;
 // model, it takes precedence over lastPrompt in the cell header. Kept in memory (never
 // written into Claude's transcript); a resumed session falls back to any on-disk title.
 const aiTitles = new Map<string, string>(); // id -> AI title
+// PROTO (grid roster): the last few lines of the agent's most recent reply, refreshed when
+// a turn ends (waiting), so the roster can show "what it just said" without the terminal open.
+const lastResponses = new Map<string, string>(); // id -> last assistant text (truncated)
+const LAST_RESPONSE_MAX = 400;
+function refreshLastResponse(id: string, cwd: string): void {
+  try {
+    const raw = readFileSync(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
+    const text = latestAssistantTextFromJsonl(raw);
+    if (text) lastResponses.set(id, text.slice(0, LAST_RESPONSE_MAX));
+  } catch {
+    // no transcript yet / unreadable — leave any prior value
+  }
+}
 const titleTurnCounts = new Map<string, number>(); // id -> user turns since last title
 const titlePending = new Set<string>(); // ids whose next Stop should (re)generate a title
 const titleInFlight = new Set<string>(); // ids currently generating, to avoid overlap
@@ -622,17 +636,21 @@ function reap(id: string) {
 // Publish a session's current activity (working + waiting) to subscribers.
 function publishActivity(id: string) {
   const a = activity.get(id) || {};
+  const cwd = ptys.get(id)?.cwd ?? null;
+  // A turn just ended (waiting) → capture the reply's tail for the roster.
+  if (a.waiting && cwd) refreshLastResponse(id, cwd);
   pubsub?.publish(SESSIONS_CHANNEL, {
     id,
     // The session's working dir, so the attention-sound player can pick up that
     // directory's custom sound (<cwd>/.mulmoterminal.json). Null for a session with
     // no live PTY (a reaped background worker).
-    cwd: ptys.get(id)?.cwd ?? null,
+    cwd,
     working: a.working ?? false,
     waiting: a.waiting ?? false,
     event: a.event ?? null,
     lastPrompt: lastPrompts.get(id) ?? null,
     aiTitle: aiTitles.get(id) ?? null,
+    lastResponse: lastResponses.get(id) ?? null,
   });
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -776,6 +776,7 @@ const EMPTY_CONTEXT: LatestTurnContext = { model: null, contextTokens: 0 };
 interface SessionSummary {
   lastPrompt: string | null;
   aiTitle: string | null;
+  lastResponse: string | null;
   usage: SessionUsage;
   context: LatestTurnContext;
 }
@@ -788,11 +789,12 @@ async function readSessionSummary(cwd: string, id: string): Promise<SessionSumma
     return {
       lastPrompt: latestMeaningfulUserPromptFromJsonl(raw),
       aiTitle: aiTitleFromJsonl(raw),
+      lastResponse: latestAssistantTextFromJsonl(raw)?.slice(0, LAST_RESPONSE_MAX) ?? null,
       usage: sessionUsageFromJsonl(raw),
       context: latestTurnContextFromJsonl(raw),
     };
   } catch {
-    return { lastPrompt: null, aiTitle: null, usage: EMPTY_USAGE, context: EMPTY_CONTEXT };
+    return { lastPrompt: null, aiTitle: null, lastResponse: null, usage: EMPTY_USAGE, context: EMPTY_CONTEXT };
   }
 }
 
@@ -1350,9 +1352,10 @@ app.get("/api/session/:id", async (req, res) => {
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   const a = activity.get(id) || {};
-  const { lastPrompt: transcriptPrompt, aiTitle: transcriptTitle, usage, context } = await readSessionSummary(cwd, id);
+  const { lastPrompt: transcriptPrompt, aiTitle: transcriptTitle, lastResponse: transcriptResponse, usage, context } = await readSessionSummary(cwd, id);
   const lastPrompt = lastPrompts.get(id) ?? transcriptPrompt;
   const aiTitle = aiTitles.get(id) ?? transcriptTitle;
+  const lastResponse = lastResponses.get(id) ?? transcriptResponse;
   res.json({
     id,
     cwd,
@@ -1361,6 +1364,7 @@ app.get("/api/session/:id", async (req, res) => {
     event: a.event ?? null,
     lastPrompt,
     aiTitle,
+    lastResponse,
     usage,
     context,
   });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1108,9 +1108,11 @@ async function trackPromptForHeader(sessionId: string, prompt: string, cwd: stri
 // `/clear` restarts the conversation, so the header must stop showing the pre-clear prompt. Blank it
 // (empty string beats the `?? transcriptPrompt` fallback in /api/session, so the old transcript can't
 // resurface) and publish; the next UserPromptSubmit sets the new query. The AI title is dropped too so
-// the freshly-cleared session doesn't keep summarizing the old conversation.
+// the freshly-cleared session doesn't keep summarizing the old conversation, and the cockpit's last
+// reply is blanked the same way (empty beats `?? transcriptResponse`) so it can't show the pre-clear answer.
 function clearHeaderPrompt(sessionId: string): void {
   lastPrompts.set(sessionId, "");
+  lastResponses.set(sessionId, "");
   forgetTitle(sessionId);
   publishActivity(sessionId);
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -610,6 +610,7 @@ function reap(id: string) {
   // visible via its on-disk record.
   knownSessions.delete(id);
   lastPrompts.delete(id); // don't leak prompt text for torn-down sessions
+  lastResponses.delete(id); // ditto, and keep this map from growing across closed sessions
   forgetTitle(id);
   titleInFlight.delete(id);
   const a = activity.get(id);

--- a/server/index.ts
+++ b/server/index.ts
@@ -472,7 +472,7 @@ const LAST_PROMPT_CAP = 200;
 // model, it takes precedence over lastPrompt in the cell header. Kept in memory (never
 // written into Claude's transcript); a resumed session falls back to any on-disk title.
 const aiTitles = new Map<string, string>(); // id -> AI title
-// PROTO (grid roster): the last few lines of the agent's most recent reply, refreshed when
+// the last few lines of the agent's most recent reply, refreshed when
 // a turn ends (waiting), so the roster can show "what it just said" without the terminal open.
 const lastResponses = new Map<string, string>(); // id -> last assistant text (truncated)
 const LAST_RESPONSE_MAX = 400;

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -11,9 +11,35 @@ import {
   timelineFromJsonl,
   aiTitleFromJsonl,
   conversationTurnsFromJsonl,
+  latestAssistantTextFromJsonl,
 } from "./transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
+
+describe("latestAssistantTextFromJsonl", () => {
+  it("returns the most recent assistant prose turn", () => {
+    const raw = [
+      line({ type: "user", message: { content: "do X" } }),
+      line({ type: "assistant", message: { content: [{ type: "text", text: "first reply" }] } }),
+      line({ type: "user", message: { content: "then Y" } }),
+      line({ type: "assistant", message: { content: [{ type: "text", text: "second reply" }] } }),
+    ].join("\n");
+    expect(latestAssistantTextFromJsonl(raw)).toBe("second reply");
+  });
+
+  it("skips a tool-only assistant turn (no prose)", () => {
+    const raw = [
+      line({ type: "assistant", message: { content: [{ type: "text", text: "here goes" }] } }),
+      line({ type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: {} }] } }),
+    ].join("\n");
+    expect(latestAssistantTextFromJsonl(raw)).toBe("here goes");
+  });
+
+  it("is null when there's no assistant text yet", () => {
+    expect(latestAssistantTextFromJsonl(line({ type: "user", message: { content: "hi" } }))).toBeNull();
+    expect(latestAssistantTextFromJsonl("")).toBeNull();
+  });
+});
 
 describe("latestUserPromptFromJsonl", () => {
   it("returns the last user-typed prompt (string content)", () => {

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -97,6 +97,16 @@ export function conversationTurnsFromJsonl(raw: string): ConversationTurn[] {
   return turns;
 }
 
+// The most recent assistant prose turn (tool-only turns skipped), for the grid roster's
+// "what did the agent just say" line. Null when the session has no assistant text yet.
+export function latestAssistantTextFromJsonl(raw: string): string | null {
+  const turns = conversationTurnsFromJsonl(raw);
+  for (let i = turns.length - 1; i >= 0; i--) {
+    if (turns[i].role === "assistant") return turns[i].text;
+  }
+  return null;
+}
+
 // A trivial prompt is an empty ack or a bare command ("ok", "merge", "はい") that
 // doesn't describe what a session is about. The cell header skips these so a short
 // follow-up doesn't hide the task. The explicit ack list is the primary signal —

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -98,10 +98,9 @@ const reorderable = computed(() => state.value.sortMode === "manual");
 const displayCells = computed(() => visibleOrdered(state.value, statusForSort.value));
 const expandedUid = computed(() => zoomedUid(state.value));
 
-// PROTO (list-view): a central text list of every cell — dir + AI summary + last prompt +
-// status — so you can supervise past the 9-thumbnail grid and jump the expanded terminal
-// by picking a row. The server publishes lastPrompt/aiTitle on the "sessions" channel for
-// EVERY session (grid cells included, unlike /api/sessions), so subscribe here directly.
+// The zoomed grid's cockpit roster: a text row per cell — status + dir + AI summary +
+// current prompt + the agent's latest reply — so many parallel agents can be supervised
+// past the 9-thumbnail grid, and the enlarged terminal is switched by picking a row.
 type SessionMeta = { lastPrompt: string | null; aiTitle: string | null; lastResponse: string | null };
 const sessionMeta = reactive(new Map<string, SessionMeta>());
 // Single source of truth for the roster's prompt / summary / reply: each cell's on-disk

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -33,6 +33,7 @@ import {
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import { useSessions } from "../composables/useSessions";
+import { usePubSub } from "../composables/usePubSub";
 import { usePendingScript } from "../composables/usePendingScript";
 import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
@@ -96,6 +97,34 @@ const reorderable = computed(() => state.value.sortMode === "manual");
 // is zoomed, render EVERY cell so the filmstrip lines up all tabs' terminals (live).
 const displayCells = computed(() => visibleOrdered(state.value, statusForSort.value));
 const expandedUid = computed(() => zoomedUid(state.value));
+
+// PROTO (list-view): a central text list of every cell — dir + AI summary + last prompt +
+// status — so you can supervise past the 9-thumbnail grid and jump the expanded terminal
+// by picking a row. The server publishes lastPrompt/aiTitle on the "sessions" channel for
+// EVERY session (grid cells included, unlike /api/sessions), so subscribe here directly.
+const sessionMeta = reactive(new Map<string, { lastPrompt: string | null; aiTitle: string | null }>());
+onMounted(() =>
+  usePubSub().subscribe("sessions", (d: unknown) => {
+    if (!d || typeof d !== "object" || !("id" in d)) return;
+    const m = d as { id: string; lastPrompt?: string | null; aiTitle?: string | null };
+    const prev = sessionMeta.get(m.id) ?? { lastPrompt: null, aiTitle: null };
+    if ("lastPrompt" in m) prev.lastPrompt = m.lastPrompt ?? null;
+    if ("aiTitle" in m) prev.aiTitle = m.aiTitle ?? null;
+    sessionMeta.set(m.id, prev);
+  }),
+);
+const listRows = computed(() =>
+  state.value.cells.map((c) => {
+    const meta = c.session ? sessionMeta.get(c.session) : undefined;
+    return {
+      uid: c.uid,
+      cwd: c.cwd,
+      title: meta?.aiTitle || meta?.lastPrompt || (c.session ? c.session.slice(0, 8) : "new terminal"),
+      prompt: meta?.lastPrompt ?? null,
+      status: statusForSort.value[c.uid] ?? ("idle" as CellStatus),
+    };
+  }),
+);
 // The cancelable trailing launch cell's uid (null when there's nothing to cancel):
 // drives both the toolbar's cancel state and the launcher's in-cell ✕.
 const cancelUid = computed(() => cancelableLaunchUid(state.value));
@@ -193,6 +222,7 @@ function configureAppearance() {
       class="main"
       :cells="displayCells"
       :expanded-uid="expandedUid"
+      :list-rows="listRows"
       :cancel-uid="cancelUid"
       :default-cwd="defaultCwd"
       :presets="presets"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -116,6 +116,38 @@ onMounted(() =>
     sessionMeta.set(m.id, prev);
   }),
 );
+// The "sessions" channel only pushes FUTURE changes, so a resumed / already-running cell
+// would show nothing until its next turn. Seed each session once from its transcript.
+const seededIds = new Set<string>();
+async function seedMeta(id: string, cwd: string | null) {
+  try {
+    const query = cwd ? `?cwd=${encodeURIComponent(cwd)}` : "";
+    const res = await fetch(`/api/session/${id}${query}`);
+    if (!res.ok) return;
+    const d = (await res.json()) as Partial<SessionMeta>;
+    const prev = sessionMeta.get(id) ?? { lastPrompt: null, aiTitle: null, lastResponse: null };
+    sessionMeta.set(id, {
+      lastPrompt: d.lastPrompt ?? prev.lastPrompt,
+      aiTitle: d.aiTitle ?? prev.aiTitle,
+      lastResponse: d.lastResponse ?? prev.lastResponse,
+    });
+  } catch {
+    // best-effort — the pub/sub still fills this in on the next turn
+  }
+}
+watch(
+  () => state.value.cells.map((c) => c.session ?? "").join(","),
+  () => {
+    for (const c of state.value.cells) {
+      if (c.session && !seededIds.has(c.session)) {
+        seededIds.add(c.session);
+        void seedMeta(c.session, c.cwd);
+      }
+    }
+  },
+  { immediate: true },
+);
+
 // A cell with no session/prompt yet still gets a human label from what it IS running.
 const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "起動直後…" : "空きセル");
 const listRows = computed(() =>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -132,24 +132,23 @@ const refreshAllMeta = () => state.value.cells.forEach((c) => c.session && void 
 watch(() => state.value.cells.map((c) => c.session ?? "").join(","), refreshAllMeta, { immediate: true });
 const ROSTER_POLL_MS = 4000;
 let rosterTimer: ReturnType<typeof setInterval> | null = null;
+const startPoll = () => {
+  if (expandedUid.value === null || rosterTimer !== null) return;
+  refreshAllMeta();
+  rosterTimer = setInterval(refreshAllMeta, ROSTER_POLL_MS);
+};
 const stopPoll = () => {
   if (rosterTimer !== null) clearInterval(rosterTimer);
   rosterTimer = null;
 };
-// immediate: a reload that restores a zoomed grid sets expandedUid up front (no "change" to
-// react to), so start the poll here too, or the roster would only ever show its first snapshot.
-watch(
-  expandedUid,
-  (uid) => {
-    if (uid !== null && rosterTimer === null) {
-      refreshAllMeta();
-      rosterTimer = setInterval(refreshAllMeta, ROSTER_POLL_MS);
-    } else if (uid === null) {
-      stopPoll();
-    }
-  },
-  { immediate: true },
-);
+// Poll only while the roster is actually on screen — zoomed AND this view is active.
+// immediate: a reload that restores a zoomed grid sets expandedUid up front (no "change"
+// to react to), so start here too, or the roster would freeze at its first snapshot.
+watch(expandedUid, (uid) => (uid !== null ? startPoll() : stopPoll()), { immediate: true });
+// Under <KeepAlive>, leaving /terminals deactivates (doesn't unmount) this view — pause the
+// poll so it doesn't keep fetching in the background, and resume it on return.
+onActivated(startPoll);
+onDeactivated(stopPoll);
 onBeforeUnmount(stopPoll);
 
 // A cell with no session/prompt yet still gets a human label from what it IS running.

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -132,8 +132,12 @@ const refreshAllMeta = () => state.value.cells.forEach((c) => c.session && void 
 watch(() => state.value.cells.map((c) => c.session ?? "").join(","), refreshAllMeta, { immediate: true });
 const ROSTER_POLL_MS = 4000;
 let rosterTimer: ReturnType<typeof setInterval> | null = null;
+// The roster is the sole consumer of this poll, and it's shown only while zoomed AND in list
+// mode (the grid can be zoomed into the thumbnail strip instead). Poll exactly when it's visible.
+const listModeOn = ref(true);
+const rosterVisible = () => expandedUid.value !== null && listModeOn.value;
 const startPoll = () => {
-  if (expandedUid.value === null || rosterTimer !== null) return;
+  if (!rosterVisible() || rosterTimer !== null) return;
   refreshAllMeta();
   rosterTimer = setInterval(refreshAllMeta, ROSTER_POLL_MS);
 };
@@ -141,10 +145,14 @@ const stopPoll = () => {
   if (rosterTimer !== null) clearInterval(rosterTimer);
   rosterTimer = null;
 };
-// Poll only while the roster is actually on screen — zoomed AND this view is active.
+const syncPoll = () => (rosterVisible() ? startPoll() : stopPoll());
 // immediate: a reload that restores a zoomed grid sets expandedUid up front (no "change"
 // to react to), so start here too, or the roster would freeze at its first snapshot.
-watch(expandedUid, (uid) => (uid !== null ? startPoll() : stopPoll()), { immediate: true });
+watch(expandedUid, syncPoll, { immediate: true });
+const onListMode = (on: boolean) => {
+  listModeOn.value = on;
+  syncPoll();
+};
 // Under <KeepAlive>, leaving /terminals deactivates (doesn't unmount) this view — pause the
 // poll so it doesn't keep fetching in the background, and resume it on return.
 onActivated(startPoll);
@@ -306,6 +314,7 @@ function configureAppearance() {
       @launch="onLaunch"
       @move="onMove"
       @status="onStatus"
+      @list-mode="onListMode"
     />
     <SettingsModal
       v-if="showSettings"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -30,6 +30,7 @@ import {
   LEGACY_KEY,
   type GridState,
   type CellStatus,
+  type Cell,
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import { useSessions } from "../composables/useSessions";
@@ -102,26 +103,33 @@ const expandedUid = computed(() => zoomedUid(state.value));
 // status — so you can supervise past the 9-thumbnail grid and jump the expanded terminal
 // by picking a row. The server publishes lastPrompt/aiTitle on the "sessions" channel for
 // EVERY session (grid cells included, unlike /api/sessions), so subscribe here directly.
-const sessionMeta = reactive(new Map<string, { lastPrompt: string | null; aiTitle: string | null }>());
+type SessionMeta = { lastPrompt: string | null; aiTitle: string | null; lastResponse: string | null };
+const sessionMeta = reactive(new Map<string, SessionMeta>());
 onMounted(() =>
   usePubSub().subscribe("sessions", (d: unknown) => {
     if (!d || typeof d !== "object" || !("id" in d)) return;
-    const m = d as { id: string; lastPrompt?: string | null; aiTitle?: string | null };
-    const prev = sessionMeta.get(m.id) ?? { lastPrompt: null, aiTitle: null };
+    const m = d as { id: string } & Partial<SessionMeta>;
+    const prev = sessionMeta.get(m.id) ?? { lastPrompt: null, aiTitle: null, lastResponse: null };
     if ("lastPrompt" in m) prev.lastPrompt = m.lastPrompt ?? null;
     if ("aiTitle" in m) prev.aiTitle = m.aiTitle ?? null;
+    if ("lastResponse" in m) prev.lastResponse = m.lastResponse ?? null;
     sessionMeta.set(m.id, prev);
   }),
 );
+// A cell with no session/prompt yet still gets a human label from what it IS running.
+const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "起動直後…" : "空きセル");
 const listRows = computed(() =>
   state.value.cells.map((c) => {
     const meta = c.session ? sessionMeta.get(c.session) : undefined;
     return {
       uid: c.uid,
       cwd: c.cwd,
-      title: meta?.aiTitle || meta?.lastPrompt || (c.session ? c.session.slice(0, 8) : "new terminal"),
-      prompt: meta?.lastPrompt ?? null,
+      agent: c.agent ?? "claude",
       status: statusForSort.value[c.uid] ?? ("idle" as CellStatus),
+      summary: meta?.aiTitle ?? null,
+      prompt: meta?.lastPrompt ?? null,
+      response: meta?.lastResponse ?? null,
+      fallback: fallbackLabel(c),
     };
   }),
 );

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -117,36 +117,34 @@ onMounted(() =>
   }),
 );
 // The "sessions" channel only pushes FUTURE changes, so a resumed / already-running cell
-// would show nothing until its next turn. Seed each session once from its transcript.
-const seededIds = new Set<string>();
+// would show nothing until its next turn — and a session NOT managed by this MulmoTerminal
+// (e.g. a plain `claude` you resumed) never emits at all. So read each cell's meta straight
+// from its on-disk transcript (always current): once on appearance, then on a poll while the
+// roster is on screen (zoomed), since pub/sub can't be relied on to keep it fresh.
 async function seedMeta(id: string, cwd: string | null) {
   try {
     const query = cwd ? `?cwd=${encodeURIComponent(cwd)}` : "";
     const res = await fetch(`/api/session/${id}${query}`);
     if (!res.ok) return;
     const d = (await res.json()) as Partial<SessionMeta>;
-    const prev = sessionMeta.get(id) ?? { lastPrompt: null, aiTitle: null, lastResponse: null };
-    sessionMeta.set(id, {
-      lastPrompt: d.lastPrompt ?? prev.lastPrompt,
-      aiTitle: d.aiTitle ?? prev.aiTitle,
-      lastResponse: d.lastResponse ?? prev.lastResponse,
-    });
+    sessionMeta.set(id, { lastPrompt: d.lastPrompt ?? null, aiTitle: d.aiTitle ?? null, lastResponse: d.lastResponse ?? null });
   } catch {
     // best-effort — the pub/sub still fills this in on the next turn
   }
 }
-watch(
-  () => state.value.cells.map((c) => c.session ?? "").join(","),
-  () => {
-    for (const c of state.value.cells) {
-      if (c.session && !seededIds.has(c.session)) {
-        seededIds.add(c.session);
-        void seedMeta(c.session, c.cwd);
-      }
-    }
-  },
-  { immediate: true },
-);
+const refreshAllMeta = () => state.value.cells.forEach((c) => c.session && void seedMeta(c.session, c.cwd));
+watch(() => state.value.cells.map((c) => c.session ?? "").join(","), refreshAllMeta, { immediate: true });
+const ROSTER_POLL_MS = 4000;
+let rosterTimer: ReturnType<typeof setInterval> | null = null;
+watch(expandedUid, (uid) => {
+  if (uid !== null && rosterTimer === null) {
+    refreshAllMeta();
+    rosterTimer = setInterval(refreshAllMeta, ROSTER_POLL_MS);
+  } else if (uid === null && rosterTimer !== null) {
+    clearInterval(rosterTimer);
+    rosterTimer = null;
+  }
+});
 
 // A cell with no session/prompt yet still gets a human label from what it IS running.
 const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "起動直後…" : "空きセル");

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -153,7 +153,7 @@ watch(
 onBeforeUnmount(stopPoll);
 
 // A cell with no session/prompt yet still gets a human label from what it IS running.
-const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "起動直後…" : "空きセル");
+const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "starting…" : "empty");
 const listRows = computed(() =>
   state.value.cells.map((c) => {
     const meta = c.session ? sessionMeta.get(c.session) : undefined;

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive, computed, watch, onMounted } from "vue";
+import { ref, reactive, computed, watch, onMounted, onBeforeUnmount } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
 import SettingsModal from "./SettingsModal.vue";
 import AppToolbar from "./AppToolbar.vue";
@@ -34,7 +34,6 @@ import {
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import { useSessions } from "../composables/useSessions";
-import { usePubSub } from "../composables/usePubSub";
 import { usePendingScript } from "../composables/usePendingScript";
 import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
@@ -105,31 +104,18 @@ const expandedUid = computed(() => zoomedUid(state.value));
 // EVERY session (grid cells included, unlike /api/sessions), so subscribe here directly.
 type SessionMeta = { lastPrompt: string | null; aiTitle: string | null; lastResponse: string | null };
 const sessionMeta = reactive(new Map<string, SessionMeta>());
-onMounted(() =>
-  usePubSub().subscribe("sessions", (d: unknown) => {
-    if (!d || typeof d !== "object" || !("id" in d)) return;
-    const m = d as { id: string } & Partial<SessionMeta>;
-    const prev = sessionMeta.get(m.id) ?? { lastPrompt: null, aiTitle: null, lastResponse: null };
-    if ("lastPrompt" in m) prev.lastPrompt = m.lastPrompt ?? null;
-    if ("aiTitle" in m) prev.aiTitle = m.aiTitle ?? null;
-    if ("lastResponse" in m) prev.lastResponse = m.lastResponse ?? null;
-    sessionMeta.set(m.id, prev);
-  }),
-);
-// The "sessions" channel only pushes FUTURE changes, so a resumed / already-running cell
-// would show nothing until its next turn — and a session NOT managed by this MulmoTerminal
-// (e.g. a plain `claude` you resumed) never emits at all. So read each cell's meta straight
-// from its on-disk transcript (always current): once on appearance, then on a poll while the
-// roster is on screen (zoomed), since pub/sub can't be relied on to keep it fresh.
+// Single source of truth for the roster's prompt / summary / reply: each cell's on-disk
+// transcript, read via GET /api/session/:id (always current, and works for sessions this
+// MulmoTerminal doesn't manage — a plain `claude` you resumed emits nothing over pub/sub).
+// Seed on appearance, then poll while the roster is on screen. Merge, never overwrite: a
+// fetch that can't find the transcript (absent/mismatched cwd) returns nulls that must not
+// wipe a value already shown. (The status badge is separate — it rides `statusForSort`.)
 async function seedMeta(id: string, cwd: string | null) {
   try {
     const query = cwd ? `?cwd=${encodeURIComponent(cwd)}` : "";
     const res = await fetch(`/api/session/${id}${query}`);
     if (!res.ok) return;
     const d = (await res.json()) as Partial<SessionMeta>;
-    // Merge, don't overwrite: a fetch that can't find the transcript (wrong/absent cwd for
-    // a session this instance doesn't manage) returns nulls, which must NOT wipe a value the
-    // pub/sub already delivered.
     const prev = sessionMeta.get(id) ?? { lastPrompt: null, aiTitle: null, lastResponse: null };
     sessionMeta.set(id, {
       lastPrompt: d.lastPrompt ?? prev.lastPrompt,
@@ -137,22 +123,32 @@ async function seedMeta(id: string, cwd: string | null) {
       lastResponse: d.lastResponse ?? prev.lastResponse,
     });
   } catch {
-    // best-effort — the pub/sub still fills this in on the next turn
+    // best-effort — the next poll retries
   }
 }
 const refreshAllMeta = () => state.value.cells.forEach((c) => c.session && void seedMeta(c.session, c.cwd));
 watch(() => state.value.cells.map((c) => c.session ?? "").join(","), refreshAllMeta, { immediate: true });
 const ROSTER_POLL_MS = 4000;
 let rosterTimer: ReturnType<typeof setInterval> | null = null;
-watch(expandedUid, (uid) => {
-  if (uid !== null && rosterTimer === null) {
-    refreshAllMeta();
-    rosterTimer = setInterval(refreshAllMeta, ROSTER_POLL_MS);
-  } else if (uid === null && rosterTimer !== null) {
-    clearInterval(rosterTimer);
-    rosterTimer = null;
-  }
-});
+const stopPoll = () => {
+  if (rosterTimer !== null) clearInterval(rosterTimer);
+  rosterTimer = null;
+};
+// immediate: a reload that restores a zoomed grid sets expandedUid up front (no "change" to
+// react to), so start the poll here too, or the roster would only ever show its first snapshot.
+watch(
+  expandedUid,
+  (uid) => {
+    if (uid !== null && rosterTimer === null) {
+      refreshAllMeta();
+      rosterTimer = setInterval(refreshAllMeta, ROSTER_POLL_MS);
+    } else if (uid === null) {
+      stopPoll();
+    }
+  },
+  { immediate: true },
+);
+onBeforeUnmount(stopPoll);
 
 // A cell with no session/prompt yet still gets a human label from what it IS running.
 const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "起動直後…" : "空きセル");

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -127,7 +127,15 @@ async function seedMeta(id: string, cwd: string | null) {
     const res = await fetch(`/api/session/${id}${query}`);
     if (!res.ok) return;
     const d = (await res.json()) as Partial<SessionMeta>;
-    sessionMeta.set(id, { lastPrompt: d.lastPrompt ?? null, aiTitle: d.aiTitle ?? null, lastResponse: d.lastResponse ?? null });
+    // Merge, don't overwrite: a fetch that can't find the transcript (wrong/absent cwd for
+    // a session this instance doesn't manage) returns nulls, which must NOT wipe a value the
+    // pub/sub already delivered.
+    const prev = sessionMeta.get(id) ?? { lastPrompt: null, aiTitle: null, lastResponse: null };
+    sessionMeta.set(id, {
+      lastPrompt: d.lastPrompt ?? prev.lastPrompt,
+      aiTitle: d.aiTitle ?? prev.aiTitle,
+      lastResponse: d.lastResponse ?? prev.lastResponse,
+    });
   } catch {
     // best-effort — the pub/sub still fills this in on the next turn
   }

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -211,6 +211,15 @@ describe("grid cockpit (list view)", () => {
     expect(w.find(".stage").classes()).not.toContain("listmode"); // filmstrip mode
   });
 
+  it("emits list-mode as the roster is toggled off then on, so the parent can pause its poll", async () => {
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0)]);
+    await nextTick();
+    await w.get(".view-toggle").trigger("click"); // roster -> strip
+    expect(w.emitted("list-mode")?.[0]).toEqual([false]);
+    await w.get(".view-toggle").trigger("click"); // strip -> roster
+    expect(w.emitted("list-mode")?.[1]).toEqual([true]);
+  });
+
   it("emits toggle-expand when a NON-active row is clicked, and not for the active one", async () => {
     const w = mountCockpit([cell(0, "s0"), cell(1, "s1")], 0, [rosterRow(0), rosterRow(1)]);
     await nextTick();

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
-import TerminalGrid from "./TerminalGrid.vue";
+import TerminalGrid, { type CockpitRow } from "./TerminalGrid.vue";
 import type { Cell } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 
@@ -51,6 +51,34 @@ const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: 
   });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });
+
+const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => ({
+  uid,
+  cwd: "/work",
+  agent: "claude",
+  status: "idle",
+  summary: null,
+  prompt: null,
+  response: null,
+  fallback: null,
+  ...over,
+});
+const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[]) =>
+  mount(TerminalGrid, {
+    props: {
+      cells,
+      expandedUid,
+      listRows,
+      cancelUid: null,
+      defaultCwd: "/work",
+      presets: [],
+      launchers: [],
+      home: "/work",
+      openSessionIds: [],
+      openCwds: [],
+      reorderable: false,
+    },
+  });
 
 describe("TerminalGrid (page renderer)", () => {
   it("renders one TerminalCell per cell", () => {
@@ -167,5 +195,37 @@ describe("active-cell focus zoom", () => {
     focus(w, 1);
     await nextTick();
     expect(cls(w, 1)).not.toContain("focused");
+  });
+});
+
+describe("grid cockpit (list view)", () => {
+  it("toggles between the text roster and the thumbnail strip", async () => {
+    const w = mountCockpit([cell(0, "s0"), cell(1, "s1")], 0, [rosterRow(0), rosterRow(1)]);
+    await nextTick();
+    expect(w.find(".cockpit").exists()).toBe(true);
+    expect(w.find(".stage").classes()).toContain("listmode");
+    expect(w.findAll(".cockpit-row")).toHaveLength(2);
+
+    await w.get(".view-toggle").trigger("click");
+    expect(w.find(".cockpit").exists()).toBe(false); // roster gone
+    expect(w.find(".stage").classes()).not.toContain("listmode"); // filmstrip mode
+  });
+
+  it("emits toggle-expand when a NON-active row is clicked, and not for the active one", async () => {
+    const w = mountCockpit([cell(0, "s0"), cell(1, "s1")], 0, [rosterRow(0), rosterRow(1)]);
+    await nextTick();
+    const rows = w.findAll(".cockpit-row");
+    await rows[1].trigger("click"); // uid 1, not the expanded (0)
+    expect(w.emitted("toggle-expand")?.[0]).toEqual([1]);
+    await rows[0].trigger("click"); // uid 0 IS the expanded one — no-op
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
+
+  it("falls back to the running program's label when a row has no prompt or summary", async () => {
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { summary: null, prompt: null, fallback: "bash" })]);
+    await nextTick();
+    const lines = w.findAll(".cockpit-line").map((l) => l.text());
+    expect(lines.some((t) => t.includes("summary"))).toBe(false); // no summary line
+    expect(lines.some((t) => t.includes("prompt") && t.includes("bash"))).toBe(true); // fallback in the prompt line
   });
 });

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -35,7 +35,7 @@ const cell = (uid: number, session: string | null = null, cwd: string | null = n
 const cmdCell = (uid: number, command: NonNullable<Cell["command"]>): Cell => ({ uid, session: null, cwd: null, command });
 const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null, reorderable = false) =>
   mount(TerminalGrid, {
-    props: { cells, expandedUid, cancelUid, defaultCwd: "/work", presets: [], launchers: [], home: "/work", openSessionIds: [], openCwds: [], reorderable },
+    props: { cells, expandedUid, listRows: [], cancelUid, defaultCwd: "/work", presets: [], launchers: [], home: "/work", openSessionIds: [], openCwds: [], reorderable },
   });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });

--- a/src/components/TerminalGrid.spec.ts
+++ b/src/components/TerminalGrid.spec.ts
@@ -35,7 +35,19 @@ const cell = (uid: number, session: string | null = null, cwd: string | null = n
 const cmdCell = (uid: number, command: NonNullable<Cell["command"]>): Cell => ({ uid, session: null, cwd: null, command });
 const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: number | null = null, reorderable = false) =>
   mount(TerminalGrid, {
-    props: { cells, expandedUid, listRows: [], cancelUid, defaultCwd: "/work", presets: [], launchers: [], home: "/work", openSessionIds: [], openCwds: [], reorderable },
+    props: {
+      cells,
+      expandedUid,
+      listRows: [],
+      cancelUid,
+      defaultCwd: "/work",
+      presets: [],
+      launchers: [],
+      home: "/work",
+      openSessionIds: [],
+      openCwds: [],
+      reorderable,
+    },
   });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
 const commandCellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "CommandCell" });

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -34,7 +34,7 @@ const STATUS_WORD: Record<CellStatus, string> = { working: "実行中", blocked:
 const props = defineProps<{
   cells: Cell[];
   expandedUid: number | null;
-  // PROTO: a text row per cell for the cockpit list shown beside the expanded terminal.
+  // A text row per cell for the cockpit list shown beside the expanded terminal.
   listRows: CockpitRow[];
   cancelUid: number | null;
   defaultCwd: string | null;
@@ -97,7 +97,7 @@ const zoomMain = ref<HTMLElement | null>(null);
 const mounted = ref(false);
 onMounted(() => (mounted.value = true));
 const zoomed = computed(() => props.expandedUid !== null && mounted.value);
-// PROTO: while zoomed, show the cockpit roster (true) or the old thumbnail filmstrip (false).
+// While zoomed, show the cockpit roster (true) or the old thumbnail filmstrip (false).
 const listMode = ref(true);
 
 const stage = ref<HTMLElement | null>(null);
@@ -132,7 +132,7 @@ watch(
   (to, from) => {
     const uid = to ?? from;
     if (uid === null || uid === undefined) return;
-    // PROTO: swapping between two already-zoomed cells (cockpit list click) has no on-screen
+    // swapping between two already-zoomed cells (cockpit list click) has no on-screen
     // source to fly from — the incoming cell sits off-screen in `.grid` — so skip the FLIP.
     if (to !== null && from !== null) return;
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
@@ -146,11 +146,11 @@ watch(
 
 <template>
   <div ref="stage" class="stage" :class="{ zoomed, listmode: listMode, flipping: flippingUid !== null }" :style="flipVars" @focusin="onFocusIn">
-    <!-- PROTO: toggle the zoomed side panel between the text roster and the old thumbnail strip. -->
+    <!-- toggle the zoomed side panel between the text roster and the old thumbnail strip. -->
     <button v-if="zoomed" type="button" class="view-toggle" :title="listMode ? 'サムネイル表示に切替' : 'リスト表示に切替'" @click="listMode = !listMode">
       {{ listMode ? "▤" : "☰" }}
     </button>
-    <!-- PROTO cockpit roster: a tall text row per cell (status / dir / summary / prompt / latest
+    <!-- Cockpit roster: a tall text row per cell (status / dir / summary / prompt / latest
          reply). Click a row to swap which terminal is enlarged. -->
     <aside v-if="zoomed && listMode" class="cockpit">
       <button
@@ -278,7 +278,7 @@ watch(
   min-width: 0;
 }
 
-/* PROTO list mode: text roster on the left, the expanded terminal on the right. */
+/* List mode: text roster on the left, the expanded terminal on the right. */
 .stage.zoomed.listmode {
   flex-direction: row;
 }

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -6,6 +6,7 @@ import LauncherCell from "./LauncherCell.vue";
 import * as conn from "../composables/useTerminalConnections";
 import { trackStyle, layoutForCount } from "./gridLayout";
 import { flipKeyframes, FLIP_MS, FLIP_EASING } from "./cellFlip";
+import { formatCwd } from "./cwdDisplay";
 import type { Cell, CellStatus } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import type { CwdPreset } from "./presets";
@@ -19,9 +20,18 @@ import type { Launcher, LaunchPick } from "./launchers";
 // zoomed, GridView passes EVERY cell (all tabs), so the strip shows them all live.
 // A cell carrying a `command` renders as a CommandCell (a running script.json
 // command) instead of the Claude launcher/terminal.
+export interface CockpitRow {
+  uid: number;
+  cwd: string | null;
+  title: string;
+  prompt: string | null;
+  status: CellStatus;
+}
 const props = defineProps<{
   cells: Cell[];
   expandedUid: number | null;
+  // PROTO: a text row per cell for the cockpit list shown beside the expanded terminal.
+  listRows: CockpitRow[];
   cancelUid: number | null;
   defaultCwd: string | null;
   presets: CwdPreset[];
@@ -116,6 +126,9 @@ watch(
   (to, from) => {
     const uid = to ?? from;
     if (uid === null || uid === undefined) return;
+    // PROTO: swapping between two already-zoomed cells (cockpit list click) has no on-screen
+    // source to fly from — the incoming cell sits off-screen in `.grid` — so skip the FLIP.
+    if (to !== null && from !== null) return;
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     const el = cellEl(uid);
     if (!el) return;
@@ -127,6 +140,25 @@ watch(
 
 <template>
   <div ref="stage" class="stage" :class="{ zoomed, flipping: flippingUid !== null }" :style="flipVars" @focusin="onFocusIn">
+    <!-- PROTO cockpit list: a dense text roster of every cell shown beside the expanded
+         terminal (only while zoomed). Click a row to swap which terminal is enlarged. -->
+    <aside v-if="zoomed" class="cockpit">
+      <button
+        v-for="row in listRows"
+        :key="row.uid"
+        type="button"
+        :class="['cockpit-row', `st-${row.status}`, { active: row.uid === expandedUid }]"
+        :title="row.prompt ?? row.title"
+        @click="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
+      >
+        <span class="cockpit-dot" :class="`st-${row.status}`" aria-hidden="true" />
+        <span class="cockpit-body">
+          <span class="cockpit-dir">{{ formatCwd(row.cwd, home, 40) || "—" }}</span>
+          <span class="cockpit-title">{{ row.title }}</span>
+          <span v-if="row.prompt && row.prompt !== row.title" class="cockpit-prompt">{{ row.prompt }}</span>
+        </span>
+      </button>
+    </aside>
     <div ref="zoomMain" class="zoom-main" />
     <div class="grid" :style="gridStyle">
       <Teleport v-for="cell in cells" :key="cell.uid" :to="zoomMain" :disabled="!(zoomed && cell.uid === expandedUid)">
@@ -222,13 +254,16 @@ watch(
   display: none;
 }
 
-/* Filmstrip: the zoomed cell (teleported here) fills the top. */
+/* PROTO cockpit layout: text roster on the left, the expanded terminal on the right. */
+.stage.zoomed {
+  flex-direction: row;
+}
 .stage.zoomed .zoom-main {
   display: flex;
   flex: 1;
   min-height: 0;
   min-width: 0;
-  padding: 6px 6px 0;
+  padding: 6px 6px 6px 0;
 }
 .zoom-main > * {
   flex: 1;
@@ -236,19 +271,99 @@ watch(
   min-height: 0;
 }
 
-/* The grid itself becomes the bottom strip: the remaining cells in a single row
-   that scrolls horizontally when they overflow. */
+/* Keep the non-expanded cells mounted (connections stay live, metadata keeps flowing) but
+   OFF the visible layout — the roster replaces the thumbnail filmstrip. A real off-screen
+   box means xterm never fits to zero. */
 .stage.zoomed .grid {
-  flex: 0 0 150px;
-  display: flex;
-  gap: 6px;
-  overflow-x: auto;
-  overflow-y: hidden;
+  position: absolute;
+  left: -99999px;
+  top: 0;
+  width: 900px;
+  height: 600px;
+  display: block;
+  overflow: hidden;
+  padding: 0;
 }
 .stage.zoomed .grid > * {
-  flex: 0 0 260px;
-  height: 100%;
+  width: 900px;
+  height: 600px;
+}
+
+.cockpit {
+  flex: 0 0 320px;
   min-width: 0;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--bg-deep);
+}
+.cockpit-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  text-align: left;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-left: 3px solid transparent;
+  border-radius: 8px;
+  background: var(--bg-panel);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+}
+.cockpit-row:hover {
+  filter: brightness(1.15);
+}
+.cockpit-row.active {
+  border-color: var(--accent, #4a9eff);
+  border-left-color: var(--accent, #4a9eff);
+}
+.cockpit-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: #666;
+}
+.cockpit-dot.st-working {
+  background: #4a9eff;
+}
+.cockpit-dot.st-done {
+  background: #22c55e;
+}
+.cockpit-dot.st-blocked {
+  background: #f59e0b;
+}
+.cockpit-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.cockpit-dir {
+  font-size: 11px;
+  color: var(--text-dim, #9ab);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cockpit-title {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cockpit-prompt {
+  font-size: 11px;
+  color: var(--text-dim, #9ab);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 /* The keyboard-focused cell lifts and grows slightly, in place — tiled grid only, so it never

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -30,7 +30,7 @@ export interface CockpitRow {
   response: string | null; // tail of the agent's latest reply
   fallback: string | null; // label when there's no prompt/summary yet (launcher/command name)
 }
-const STATUS_WORD: Record<CellStatus, string> = { working: "実行中", blocked: "入力待ち", done: "完了", idle: "待機" };
+const STATUS_WORD: Record<CellStatus, string> = { working: "running", blocked: "waiting", done: "done", idle: "idle" };
 const props = defineProps<{
   cells: Cell[];
   expandedUid: number | null;
@@ -146,7 +146,14 @@ watch(
 <template>
   <div ref="stage" class="stage" :class="{ zoomed, listmode: listMode, flipping: flippingUid !== null }" :style="flipVars" @focusin="onFocusIn">
     <!-- toggle the zoomed side panel between the text roster and the old thumbnail strip. -->
-    <button v-if="zoomed" type="button" class="view-toggle" :title="listMode ? 'サムネイル表示に切替' : 'リスト表示に切替'" @click="listMode = !listMode">
+    <button
+      v-if="zoomed"
+      type="button"
+      class="view-toggle"
+      :title="listMode ? 'Show thumbnails' : 'Show list'"
+      :aria-label="listMode ? 'Switch to thumbnail strip' : 'Switch to list'"
+      @click="listMode = !listMode"
+    >
       {{ listMode ? "▤" : "☰" }}
     </button>
     <!-- Cockpit roster: a tall text row per cell (status / dir / summary / prompt / latest
@@ -165,9 +172,9 @@ watch(
           <span v-if="row.agent === 'codex'" class="cockpit-agent">codex</span>
           <span class="cockpit-dir">{{ formatCwd(row.cwd, home, 44) || "—" }}</span>
         </span>
-        <span v-if="row.summary" class="cockpit-line"><b>要約</b> {{ row.summary }}</span>
-        <span class="cockpit-line"><b>入力</b> {{ row.prompt || row.fallback || "—" }}</span>
-        <span v-if="row.response" class="cockpit-line cockpit-response"><b>応答</b> {{ row.response }}</span>
+        <span v-if="row.summary" class="cockpit-line"><b>summary</b> {{ row.summary }}</span>
+        <span class="cockpit-line"><b>prompt</b> {{ row.prompt || row.fallback || "—" }}</span>
+        <span v-if="row.response" class="cockpit-line cockpit-response"><b>reply</b> {{ row.response }}</span>
       </button>
     </aside>
     <div ref="zoomMain" class="zoom-main" />

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -23,10 +23,14 @@ import type { Launcher, LaunchPick } from "./launchers";
 export interface CockpitRow {
   uid: number;
   cwd: string | null;
-  title: string;
-  prompt: string | null;
+  agent: string;
   status: CellStatus;
+  summary: string | null; // AI title
+  prompt: string | null; // current user prompt
+  response: string | null; // tail of the agent's latest reply
+  fallback: string | null; // label when there's no prompt/summary yet (launcher/command name)
 }
+const STATUS_WORD: Record<CellStatus, string> = { working: "実行中", blocked: "入力待ち", done: "完了", idle: "待機" };
 const props = defineProps<{
   cells: Cell[];
   expandedUid: number | null;
@@ -93,6 +97,8 @@ const zoomMain = ref<HTMLElement | null>(null);
 const mounted = ref(false);
 onMounted(() => (mounted.value = true));
 const zoomed = computed(() => props.expandedUid !== null && mounted.value);
+// PROTO: while zoomed, show the cockpit roster (true) or the old thumbnail filmstrip (false).
+const listMode = ref(true);
 
 const stage = ref<HTMLElement | null>(null);
 // The cell currently flying between slots. Also gates the stylesheet: the cells it
@@ -139,24 +145,30 @@ watch(
 </script>
 
 <template>
-  <div ref="stage" class="stage" :class="{ zoomed, flipping: flippingUid !== null }" :style="flipVars" @focusin="onFocusIn">
-    <!-- PROTO cockpit list: a dense text roster of every cell shown beside the expanded
-         terminal (only while zoomed). Click a row to swap which terminal is enlarged. -->
-    <aside v-if="zoomed" class="cockpit">
+  <div ref="stage" class="stage" :class="{ zoomed, listmode: listMode, flipping: flippingUid !== null }" :style="flipVars" @focusin="onFocusIn">
+    <!-- PROTO: toggle the zoomed side panel between the text roster and the old thumbnail strip. -->
+    <button v-if="zoomed" type="button" class="view-toggle" :title="listMode ? 'サムネイル表示に切替' : 'リスト表示に切替'" @click="listMode = !listMode">
+      {{ listMode ? "▤" : "☰" }}
+    </button>
+    <!-- PROTO cockpit roster: a tall text row per cell (status / dir / summary / prompt / latest
+         reply). Click a row to swap which terminal is enlarged. -->
+    <aside v-if="zoomed && listMode" class="cockpit">
       <button
         v-for="row in listRows"
         :key="row.uid"
         type="button"
         :class="['cockpit-row', `st-${row.status}`, { active: row.uid === expandedUid }]"
-        :title="row.prompt ?? row.title"
         @click="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
       >
-        <span class="cockpit-dot" :class="`st-${row.status}`" aria-hidden="true" />
-        <span class="cockpit-body">
-          <span class="cockpit-dir">{{ formatCwd(row.cwd, home, 40) || "—" }}</span>
-          <span class="cockpit-title">{{ row.title }}</span>
-          <span v-if="row.prompt && row.prompt !== row.title" class="cockpit-prompt">{{ row.prompt }}</span>
+        <span class="cockpit-head">
+          <span class="cockpit-dot" :class="`st-${row.status}`" aria-hidden="true" />
+          <span class="cockpit-badge" :class="`st-${row.status}`">{{ STATUS_WORD[row.status] }}</span>
+          <span v-if="row.agent === 'codex'" class="cockpit-agent">codex</span>
+          <span class="cockpit-dir">{{ formatCwd(row.cwd, home, 44) || "—" }}</span>
         </span>
+        <span v-if="row.summary" class="cockpit-line"><b>要約</b> {{ row.summary }}</span>
+        <span class="cockpit-line"><b>入力</b> {{ row.prompt || row.fallback || "—" }}</span>
+        <span v-if="row.response" class="cockpit-line cockpit-response"><b>応答</b> {{ row.response }}</span>
       </button>
     </aside>
     <div ref="zoomMain" class="zoom-main" />
@@ -254,27 +266,28 @@ watch(
   display: none;
 }
 
-/* PROTO cockpit layout: text roster on the left, the expanded terminal on the right. */
-.stage.zoomed {
-  flex-direction: row;
+.zoom-main > * {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
 }
 .stage.zoomed .zoom-main {
   display: flex;
   flex: 1;
   min-height: 0;
   min-width: 0;
-  padding: 6px 6px 6px 0;
-}
-.zoom-main > * {
-  flex: 1;
-  min-width: 0;
-  min-height: 0;
 }
 
-/* Keep the non-expanded cells mounted (connections stay live, metadata keeps flowing) but
-   OFF the visible layout — the roster replaces the thumbnail filmstrip. A real off-screen
-   box means xterm never fits to zero. */
-.stage.zoomed .grid {
+/* PROTO list mode: text roster on the left, the expanded terminal on the right. */
+.stage.zoomed.listmode {
+  flex-direction: row;
+}
+.stage.zoomed.listmode .zoom-main {
+  padding: 6px 6px 6px 0;
+}
+/* Keep the non-expanded cells mounted (connections + metadata stay live) but OFF the visible
+   layout. A real off-screen box means xterm never fits to zero. */
+.stage.zoomed.listmode .grid {
   position: absolute;
   left: -99999px;
   top: 0;
@@ -284,25 +297,61 @@ watch(
   overflow: hidden;
   padding: 0;
 }
-.stage.zoomed .grid > * {
+.stage.zoomed.listmode .grid > * {
   width: 900px;
   height: 600px;
 }
 
+/* Strip mode (toggle): the original filmstrip — expanded terminal on top, thumbnails below. */
+.stage.zoomed:not(.listmode) {
+  flex-direction: column;
+}
+.stage.zoomed:not(.listmode) .zoom-main {
+  padding: 6px 6px 0;
+}
+.stage.zoomed:not(.listmode) .grid {
+  flex: 0 0 150px;
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.stage.zoomed:not(.listmode) .grid > * {
+  flex: 0 0 260px;
+  height: 100%;
+  min-width: 0;
+}
+
+.view-toggle {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 10;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+}
+
 .cockpit {
-  flex: 0 0 320px;
+  flex: 0 0 360px;
   min-width: 0;
   overflow-y: auto;
   padding: 6px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
   background: var(--bg-deep);
 }
 .cockpit-row {
   display: flex;
-  gap: 8px;
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 4px;
   text-align: left;
   padding: 8px 10px;
   border: 1px solid var(--border);
@@ -317,53 +366,80 @@ watch(
   filter: brightness(1.15);
 }
 .cockpit-row.active {
-  border-color: var(--accent, #4a9eff);
-  border-left-color: var(--accent, #4a9eff);
+  border-color: #4a9eff;
+  border-left-color: #4a9eff;
+}
+.cockpit-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
 }
 .cockpit-dot {
   flex: 0 0 auto;
   width: 8px;
   height: 8px;
-  margin-top: 5px;
   border-radius: 50%;
   background: #666;
 }
-.cockpit-dot.st-working {
+.cockpit-badge {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: #333;
+  color: #ddd;
+}
+.cockpit-dot.st-working,
+.cockpit-badge.st-working {
   background: #4a9eff;
+  color: #04121f;
 }
-.cockpit-dot.st-done {
+.cockpit-dot.st-done,
+.cockpit-badge.st-done {
   background: #22c55e;
+  color: #04120a;
 }
-.cockpit-dot.st-blocked {
+.cockpit-dot.st-blocked,
+.cockpit-badge.st-blocked {
   background: #f59e0b;
+  color: #1f1300;
 }
-.cockpit-body {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.cockpit-agent {
+  flex: 0 0 auto;
+  font-size: 10px;
+  color: #9ab;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 4px;
 }
 .cockpit-dir {
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 11px;
   color: var(--text-dim, #9ab);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.cockpit-title {
-  font-size: 13px;
-  font-weight: 600;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.cockpit-prompt {
-  font-size: 11px;
-  color: var(--text-dim, #9ab);
+.cockpit-line {
+  font-size: 12px;
+  line-height: 1.35;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+}
+.cockpit-line b {
+  font-size: 10px;
+  font-weight: 700;
+  color: #7a8aa0;
+  margin-right: 4px;
+}
+.cockpit-response {
+  color: var(--text-dim, #9ab);
+  -webkit-line-clamp: 3;
 }
 
 /* The keyboard-focused cell lifts and grows slightly, in place — tiled grid only, so it never

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -54,6 +54,8 @@ const emit = defineEmits<{
   (e: "move", uid: number, dir: -1 | 1): void;
   (e: "status", uid: number, value: CellStatus): void;
   (e: "agent", uid: number, value: "claude" | "codex"): void;
+  // Roster shown (true) / thumbnail strip (false), so the parent can pause the roster-only poll.
+  (e: "list-mode", on: boolean): void;
   // Shared preset list events — uid-less since they mutate the one config list.
   (e: "record-cwd" | "remove-preset", value: string): void;
 }>();
@@ -98,6 +100,8 @@ onMounted(() => (mounted.value = true));
 const zoomed = computed(() => props.expandedUid !== null && mounted.value);
 // While zoomed, show the cockpit roster (true) or the old thumbnail filmstrip (false).
 const listMode = ref(true);
+// The roster is the only consumer of the parent's /api/session poll — tell it when we hide it.
+watch(listMode, (on) => emit("list-mode", on));
 
 const stage = ref<HTMLElement | null>(null);
 // The cell currently flying between slots. Also gates the stylesheet: the cells it


### PR DESCRIPTION
## Summary

grid view の一覧性の限界（9枚のサムネイル/ページ、小さくて中身が読めない）を解消するため、**セルを拡大（zoom）したときの下部フィルムストリップを「左の密なテキスト一覧（cockpit）＋右に拡大ターミナル」**に置き換えます（single view 風）。多数の並列エージェントを、GitHub の PRs ページのように一覧で監督し、行クリックで拡大ターミナルを切り替えられます。

各行に表示: **ステータス（実行中／入力待ち／完了、色バッジ）／dir／要約(AIタイトル)／入力(現在プロンプト)／応答(最新LLM応答の末尾)**。右上のトグル（▤/☰）で**従来のサムネイル filmstrip 表示にも戻せます**。

## Items to Confirm / Review

1. **データ源は transcript（`/api/session/:id`）＋4秒ポーリング**にしました。pubsub は「未来のイベントしか流さない・管理外セッションでは来ない・null で既存値を潰す」ため roster には使わず撤去。transcript はディスク上で常に最新なので、**MulmoTerminal 管理外の resume した `claude` でも current な値**が出ます。ステータスバッジは従来の `statusForSort` 経路のまま（別管理）。**ポーリングは zoom 表示中のみ**動き、un-zoom / unmount で停止します。
2. **要約(aiTitle) は管理セッションでのみ再生成**（フックが5ターンごと）。外部 resume したセッションでは lag します（今回はこのまま許容）。live なのは 入力／応答。
3. **非拡大セルは list mode 中オフスクリーンでマウント維持**（接続とメタが生きたまま／0サイズ resize も回避）。拡大切替は `toggle-expand`。zoom セル同士の切替は、飛ぶ元がオフスクリーンなので **FLIP をスキップ**しています。
4. **新規サーバAPI**: `latestAssistantTextFromJsonl`（最後のアシスタント発話を抽出、tool-only ターンはスキップ）を追加し、`/api/session/:id` と `sessions` pubsub payload に `lastResponse` を追加。読み取りは既存の `readSessionSummary`（元々 transcript 全読み）に相乗り。
5. **ID表記の解消**: プロンプト/要約が無いセルは、ID断片ではなく launcher/command 名や「起動直後…」「空きセル」を表示。

## User Prompt

> gridのときって結局一覧で網羅できないよね。テキストだけのview(githubのprsのページみたいに)みたいに、起動しているdirと、プロンプト＋要約（両方）とステータスがあって、それを元にexpandしているターミナルを切り替えられるとよいのかな。single viewのセッションみたいなレイアウトになりそう。expandのviewをかえるのかなー
>
> （反復で）左の情報を増やす／expand時に従来表示と新表示を切り替え／情報は現在プロンプト・要約・最新のllm応答数行・running/wait/done を文字で／ターミナル起動時等でプロンプトが無くID表記になるのを直す／サイドバーは高さをとってよいので何をしているか分かるように

## 実装メモ

- `TerminalGrid.vue`: zoom 時レイアウトを list/strip 2モードに（`.stage.zoomed.listmode` vs `:not(.listmode)`）。cockpit 一覧の描画＋トグル。非拡大セルはオフスクリーン `.grid` で維持。
- `GridView.vue`: `listRows`（cells × sessionMeta）を算出。`seedMeta`（`/api/session/:id` をマージ取得）＋ zoom 中の4秒ポーリング（`immediate` 付きでリロード復元時も開始）。
- `server/index.ts` / `server/transcript.ts`: `lastResponse` の抽出・配信。ユニットテスト3件。

## 検証

隔離サーバ＋puppeteer、実 transcript でも確認。
- resume したセッションで **要約／入力／応答** が正しく表示（実 transcript の直接 curl でも3フィールド確認）。
- zoom 中に transcript へ応答を追記 → **~5秒で応答欄が更新**（ポーリング）。
- null 上書き回帰の修正（fetch が null を返しても既存値を保持）。
- 一覧行クリックで拡大ターミナルが切替（zoomUid 0→2）、トグルで filmstrip に復帰。

`yarn typecheck` / `yarn lint`（既存の無関係警告のみ）/ `yarn build` / `yarn test`（**999 通過**、新規3件）すべてグリーン。

## 既知の割り切り（プロトタイプ由来）

- 要約(aiTitle) は外部セッションで lag（②）。
- ポーリング4秒間隔・zoom 中のみ。多数セルでは 4秒ごとに N 件の transcript 読み（`readSessionSummary` 相当、既存 `/api/session/:id` と同コスト）。
- リロード直後の zoom 復元での自動起動は `immediate:true` のロジックで担保（puppeteer のリロード自動化はフレーキーで未自動化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
