### PR TITLE
fix: グリッドの注目信号 #2 別ページ配信 + #5 再起動永続化（#321）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -462,6 +462,9 @@ async function recordToolCallEnd(
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
 const SESSION_LIST_LIMIT = 50;
+// Cap on ids per /api/activity request — a grid can't show more cells than this, and
+// it bounds the query string a client can make us parse.
+const ACTIVITY_IDS_LIMIT = 200;
 
 // Per-session "working" state, driven by Claude hooks (see /api/hook):
 // UserPromptSubmit => Claude started thinking; Stop => it finished.
@@ -1373,6 +1376,24 @@ app.get("/api/session/:id", async (req, res) => {
     usage,
     context,
   });
+});
+
+// Attention state (working / waiting / event) for an explicit set of session ids.
+// The grid uses this to seed the status of its OFF-PAGE cells, which /api/sessions
+// can't serve: it hides dev-terminal sessions and is capped by the list limit. Reads
+// only the in-memory activity map (no disk), so it's cheap to call per grid render.
+app.get("/api/activity", (req, res) => {
+  const raw = typeof req.query.ids === "string" ? req.query.ids : "";
+  const ids = raw
+    .split(",")
+    .filter((id) => SESSION_ID_RE.test(id))
+    .slice(0, ACTIVITY_IDS_LIMIT);
+  const out: Record<string, { working: boolean; waiting: boolean; event: string | null }> = {};
+  for (const id of ids) {
+    const a = activity.get(id) || {};
+    out[id] = { working: a.working ?? false, waiting: a.waiting ?? false, event: a.event ?? null };
+  }
+  res.json(out);
 });
 
 // Per-directory overrides (<cwd>/.mulmoterminal.json): the badge/name/theme a

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,6 +42,7 @@ import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { resolveSession, type SessionResolution } from "./session-resolve.js";
 import { activityHookEffects } from "./activity-hook.js";
+import { buildWaitingSnapshot, parseWaitingState } from "./waiting-state.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./codex-args.js";
@@ -470,6 +471,36 @@ const ACTIVITY_IDS_LIMIT = 200;
 // UserPromptSubmit => Claude started thinking; Stop => it finished.
 const activity = new Map<string, Activity>(); // id -> { working, event, at }
 
+// Restore the blocked/done (`waiting`) flags across a server restart, so a session
+// blocked on a permission prompt before the restart doesn't reattach as idle (Claude
+// won't re-fire Notification while already sitting at the prompt). `working` is NOT
+// persisted — a turn may have finished during downtime, so a restored working=true
+// could stick; the live hooks re-derive it. Keyed to `event` so blocked (Notification)
+// vs done (Stop) survives. Mirrors the dev-terminal-sessions persist/hydrate pattern.
+const WAITING_STATE_FILE = path.join(MULMOTERMINAL_HOME, "waiting-state.json");
+const waitingStateHydrated: Promise<void> = (async () => {
+  try {
+    const parsed = JSON.parse(await fs.readFile(WAITING_STATE_FILE, "utf8"));
+    for (const { id, event } of parseWaitingState(parsed, (x) => SESSION_ID_RE.test(x))) {
+      // Don't clobber a live update that already landed while hydration was in flight.
+      if (!activity.has(id)) activity.set(id, { waiting: true, working: false, event, at: Date.now() });
+    }
+  } catch {
+    // no file yet / unreadable => nothing to restore
+  }
+})();
+
+// Serialize writes into one chain (like persistDevTerminalSessions) and snapshot the
+// CURRENT waiting entries at write time, so the last link always writes the complete set.
+let waitingPersist: Promise<void> = Promise.resolve();
+function persistWaitingState(): void {
+  waitingPersist = waitingPersist
+    .then(() => waitingStateHydrated)
+    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+    .then(() => fs.writeFile(WAITING_STATE_FILE, JSON.stringify(buildWaitingSnapshot(activity, (id) => hiddenSessions.has(id)))))
+    .catch((e) => console.error(`[waiting-state] failed to persist: ${messageOf(e)}`));
+}
+
 // Latest MEANINGFUL user prompt per session (from the UserPromptSubmit hook), shown
 // on the grid cell header so you can tell at a glance what each terminal is about. A
 // trivial ack ("ok", "merge") doesn't replace it (see the hook handler), so a short
@@ -690,6 +721,8 @@ function setWaiting(id: string, waiting: boolean, event?: string) {
   if ((prev.waiting ?? false) === waiting) return;
   activity.set(id, { ...prev, waiting, event: event ?? prev.event ?? null, at: Date.now() });
   publishActivity(id);
+  // Persist the blocked/done set so it survives a server restart (see WAITING_STATE_FILE).
+  persistWaitingState();
 
   // A detached session that just started needing the user escalates from the short
   // idle grace to the long one — re-arm so it isn't reaped before they can return.

--- a/server/waiting-state.spec.ts
+++ b/server/waiting-state.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { buildWaitingSnapshot, parseWaitingState } from "./waiting-state.js";
+
+const never = () => false;
+const anyId = () => true;
+
+describe("buildWaitingSnapshot", () => {
+  it("keeps only waiting sessions, mapping id -> event", () => {
+    const entries: Array<[string, { waiting?: boolean; event?: string | null }]> = [
+      ["a", { waiting: true, event: "Notification" }],
+      ["b", { waiting: true, event: "Stop" }],
+      ["c", { waiting: false, event: "UserPromptSubmit" }],
+    ];
+    expect(buildWaitingSnapshot(entries, never)).toEqual({ a: "Notification", b: "Stop" });
+  });
+
+  it("excludes hidden sessions (translation workers)", () => {
+    const entries: Array<[string, { waiting?: boolean; event?: string | null }]> = [
+      ["a", { waiting: true, event: "Notification" }],
+      ["hidden", { waiting: true, event: "Stop" }],
+    ];
+    expect(buildWaitingSnapshot(entries, (id) => id === "hidden")).toEqual({ a: "Notification" });
+  });
+
+  it("defaults a missing event to null", () => {
+    expect(buildWaitingSnapshot([["a", { waiting: true }]], never)).toEqual({ a: null });
+  });
+});
+
+describe("parseWaitingState", () => {
+  it("parses id/event pairs", () => {
+    expect(parseWaitingState({ a: "Notification", b: "Stop" }, anyId)).toEqual([
+      { id: "a", event: "Notification" },
+      { id: "b", event: "Stop" },
+    ]);
+  });
+
+  it("drops ids that fail validation", () => {
+    expect(parseWaitingState({ good: "Stop", "../bad": "Notification" }, (id) => id === "good")).toEqual([{ id: "good", event: "Stop" }]);
+  });
+
+  it("coerces a non-string event to null", () => {
+    expect(parseWaitingState({ a: 5 }, anyId)).toEqual([{ id: "a", event: null }]);
+  });
+
+  it("returns [] for non-object input", () => {
+    expect(parseWaitingState(null, anyId)).toEqual([]);
+    expect(parseWaitingState("x", anyId)).toEqual([]);
+  });
+});

--- a/server/waiting-state.ts
+++ b/server/waiting-state.ts
@@ -1,0 +1,29 @@
+// Pure transforms for the restart-persisted attention state (see WAITING_STATE_FILE in
+// index.ts). Split out so the snapshot/restore rules are unit-testable.
+
+export interface WaitingActivity {
+  waiting?: boolean;
+  event?: string | null;
+}
+
+// The set of blocked/done sessions to persist: waiting ones, minus hidden translation
+// workers (they can flag waiting internally but must never surface, and their activity
+// is deleted on cleanup without a re-persist).
+export function buildWaitingSnapshot(entries: Iterable<readonly [string, WaitingActivity]>, isHidden: (id: string) => boolean): Record<string, string | null> {
+  const snapshot: Record<string, string | null> = {};
+  for (const [id, a] of entries) {
+    if (a.waiting && !isHidden(id)) snapshot[id] = a.event ?? null;
+  }
+  return snapshot;
+}
+
+// Parse a persisted snapshot back into id/event pairs, dropping anything that isn't a
+// valid session id (a corrupt/tampered file must not smuggle entries into the map).
+export function parseWaitingState(raw: unknown, isValidId: (id: string) => boolean): Array<{ id: string; event: string | null }> {
+  if (!raw || typeof raw !== "object") return [];
+  const out: Array<{ id: string; event: string | null }> = [];
+  for (const [id, event] of Object.entries(raw as Record<string, unknown>)) {
+    if (isValidId(id)) out.push({ id, event: typeof event === "string" ? event : null });
+  }
+  return out;
+}

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -35,7 +35,7 @@ import {
   type Cell,
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
-import { useSessions } from "../composables/useSessions";
+import { useGridActivity } from "../composables/useGridActivity";
 import { registerNewTerminalHandler, type NewTerminalRequest } from "../composables/useNewTerminal";
 import { usePendingScript } from "../composables/usePendingScript";
 import { reportActiveTerminals } from "../composables/useUnloadGuard";
@@ -71,17 +71,18 @@ watch(
 const pages = computed(() => pageCount(state.value.cells.length));
 
 // The "auto" order needs every cell's status, including cells on pages that aren't
-// mounted. The server's session list is the authority for that (it covers all
-// sessions regardless of which page is on screen), so it drives the sort by session
-// id. The per-cell `statusByUid` (reported up while a cell is mounted) is the
-// fallback for cells the session list can't key: command cells (no session id) and a
-// just-launched cell before its id arrives.
-const { sessions } = useSessions();
+// mounted. useGridActivity tracks each cell session's live attention state by id —
+// including OFF-PAGE, dev-terminal cells that the /api/sessions list drops and its
+// limit would cap — so a waiting cell on any page floats forward. The per-cell
+// `statusByUid` (reported up while a cell is mounted) is the fallback for cells with
+// no session id (command cells) and a just-launched cell before its id arrives.
+const cellSessionIds = computed(() => state.value.cells.map((c) => c.session).filter((s): s is string => !!s));
+const { activity: gridActivity } = useGridActivity(cellSessionIds);
 const statusByUid = reactive<Record<number, CellStatus>>({});
 const onStatus = (uid: number, s: CellStatus) => (statusByUid[uid] = s);
 const sessionStatus = computed(() => {
   const m = new Map<string, CellStatus>();
-  for (const s of sessions.value) m.set(s.id, activityStatus(s.working, s.waiting, s.event));
+  for (const [id, a] of gridActivity) m.set(id, activityStatus(a.working, a.waiting, a.event));
   return m;
 });
 const statusForSort = computed<Record<number, CellStatus>>(() => {

--- a/src/composables/sessionActivity.spec.ts
+++ b/src/composables/sessionActivity.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { parseSessionActivityPayload } from "./sessionActivity";
+
+describe("parseSessionActivityPayload", () => {
+  it("parses a normal activity push", () => {
+    expect(parseSessionActivityPayload({ id: "a", working: true, waiting: false, event: "UserPromptSubmit" })).toEqual({
+      id: "a",
+      activity: { working: true, waiting: false, event: "UserPromptSubmit" },
+    });
+  });
+
+  it("parses a blocked (Notification) push", () => {
+    expect(parseSessionActivityPayload({ id: "a", working: false, waiting: true, event: "Notification" })).toEqual({
+      id: "a",
+      activity: { working: false, waiting: true, event: "Notification" },
+    });
+  });
+
+  it("treats a closed push as a removal", () => {
+    expect(parseSessionActivityPayload({ id: "a", working: false, event: "closed" })).toEqual({ id: "a", closed: true });
+  });
+
+  it("defaults missing flags to false / null", () => {
+    expect(parseSessionActivityPayload({ id: "a" })).toEqual({ id: "a", activity: { working: false, waiting: false, event: null } });
+  });
+
+  it("rejects payloads without a string id", () => {
+    expect(parseSessionActivityPayload({ working: true })).toBeNull();
+    expect(parseSessionActivityPayload(null)).toBeNull();
+    expect(parseSessionActivityPayload("nope")).toBeNull();
+    expect(parseSessionActivityPayload({ id: 42 })).toBeNull();
+  });
+});

--- a/src/composables/sessionActivity.ts
+++ b/src/composables/sessionActivity.ts
@@ -1,0 +1,28 @@
+// Pure parse of a "sessions" pub/sub payload into an attention-state update, so the
+// grid can track a cell's blocked/done even while the cell is OFF-PAGE (unmounted).
+// The payload carries dev-terminal (grid) activity that the /api/sessions list drops,
+// and isn't capped by the list limit. Kept pure + separate for unit testing.
+
+export interface CellActivity {
+  working: boolean;
+  waiting: boolean;
+  event: string | null;
+}
+
+export type SessionActivityUpdate = { id: string; closed: true } | { id: string; activity: CellActivity };
+
+export function parseSessionActivityPayload(data: unknown): SessionActivityUpdate | null {
+  if (!data || typeof data !== "object") return null;
+  const d = data as Record<string, unknown>;
+  if (typeof d.id !== "string") return null;
+  // A "closed" push means the session's PTY was reaped — drop it (no attention).
+  if (d.event === "closed") return { id: d.id, closed: true };
+  return {
+    id: d.id,
+    activity: {
+      working: !!d.working,
+      waiting: !!d.waiting,
+      event: typeof d.event === "string" ? d.event : null,
+    },
+  };
+}

--- a/src/composables/useGridActivity.ts
+++ b/src/composables/useGridActivity.ts
@@ -1,0 +1,53 @@
+import { reactive, watch, onMounted, onUnmounted, type Ref } from "vue";
+import { usePubSub } from "./usePubSub";
+import { parseSessionActivityPayload, type CellActivity } from "./sessionActivity";
+
+// Live attention state (working / waiting / event) for a set of grid cell sessions,
+// keyed by session id. Unlike the sidebar's /api/sessions list this includes
+// dev-terminal (grid) sessions and is NOT capped by the list limit, so an OFF-PAGE
+// (unmounted) cell still reports blocked/done — the fix for the grid's cross-page
+// attention routing. Seeded from /api/activity (current in-memory state) and kept
+// live from the "sessions" pub/sub payload.
+export function useGridActivity(sessionIds: Ref<string[]>) {
+  const activity = reactive(new Map<string, CellActivity>());
+
+  function apply(data: unknown): void {
+    const update = parseSessionActivityPayload(data);
+    if (!update) return;
+    if ("closed" in update) activity.delete(update.id);
+    else activity.set(update.id, update.activity);
+  }
+
+  async function seed(): Promise<void> {
+    const ids = [...new Set(sessionIds.value.filter(Boolean))];
+    if (ids.length === 0) return;
+    try {
+      const res = await fetch(`/api/activity?ids=${encodeURIComponent(ids.join(","))}`);
+      if (!res.ok) return;
+      const data: Record<string, CellActivity> = await res.json();
+      for (const [id, a] of Object.entries(data)) {
+        activity.set(id, { working: !!a.working, waiting: !!a.waiting, event: a.event ?? null });
+      }
+    } catch {
+      // Transient — the pub/sub stream catches up on the next activity change.
+    }
+  }
+
+  const { subscribe, onReconnect } = usePubSub();
+  let unsubscribe: (() => void) | undefined;
+  let offReconnect: (() => void) | undefined;
+  onMounted(() => {
+    void seed();
+    unsubscribe = subscribe("sessions", apply);
+    // A dropped socket misses pushes; re-seed the authoritative state on reconnect.
+    offReconnect = onReconnect(() => void seed());
+  });
+  onUnmounted(() => {
+    unsubscribe?.();
+    offReconnect?.();
+  });
+  // New cells (or a fresh session id after relaunch) need their current state seeded.
+  watch(sessionIds, () => void seed());
+
+  return { activity };
+}


### PR DESCRIPTION
## Summary

#321 注目信号バグ系統の残り2件（#1 は #322 でマージ済み）。どちらも実サーバで計測・ライブ検証済み。

- **#2 別ページのセルが idle 固定** — off-page(未マウント)のグリッドセルは `/api/sessions`（dev-terminal除外＋件数上限）から状態を引けず idle 固定だった。新エンドポイント `GET /api/activity?ids=`（in-memory activity、除外なし・上限なし・ディスク不使用）＋ `useGridActivity`（seed + "sessions" pub/sub payload でライブ追跡）で、全ページのセルの blocked/done を把握。
- **#5 再起動で注目状態が消える** — `activity` はメモリのみで、承認待ちセッションが再起動後 idle 化していた（Claude はプロンプト待機中で Notification を再発火しない）。`waiting`/`event` を `~/.mulmoterminal/waiting-state.json` に永続化＋起動時復元（`working` は復元しない）。

## Items to Confirm / Review

- **#5 で `working` を復元しない設計**：再起動中にターンが完了していた場合 `working=true` が stuck するのを避けるため、`waiting`/`event`（blocked/done）のみ復元。妥当か。
- **#2 の状態源を pub/sub payload 駆動にした点**：`/api/sessions` を grid込みで再fetchする案は `SESSION_LIST_LIMIT`(50) で取りこぼす（ユーザーは多数セッション運用）ため、payload駆動＋軽量seedを採用。
- **`/api/activity` の露出**：任意の session id 群の working/waiting/event を返す（in-memoryのみ、SESSION_ID_RE 検証、200件上限）。情報露出面の妥当性。
- hidden 翻訳ワーカーを永続スナップショットから除外（cleanup で activity 削除され再persistされないため phantom 復元を防止）。

## User Prompt

（#321 の続き）バグ的挙動だけ先に issue 化する方針で、注目信号バグ系統（#1/#2/#5）を実測で確定。#1 をまず #322 でマージし、本PRで残る #2（別ページ配信）と #5（再起動永続化）を実装。各症状に回帰テストを付ける。

## テスト・検証

- 純関数ユニット：`sessionActivity.spec.ts`（payload解析）/ `waiting-state.spec.ts`（snapshot/restore）
- ライブ検証（実サーバ・合成フック）：
  - #2：`/api/sessions` から除外される2つのグリッドセルが `/api/activity` で正しく blocked / working を返す。
  - #5：blocked セッションが再起動後も blocked（隔離HOMEで実施、実 `~/.mulmoterminal` は無傷）。
- ゲート：format / lint(0 errors) / typecheck / build / 全テスト green

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
