### PR TITLE
fix: keep the grid focus-zoom on screen so edge characters aren't clipped

### DIFF
--- a/plans/fix-grid-focus-zoom-overflow.md
+++ b/plans/fix-grid-focus-zoom-overflow.md
@@ -1,0 +1,48 @@
+# fix: grid focus-zoom clips characters at the browser edge (#331)
+
+## Symptom
+
+In the grid view, when a cell is "enlarged" the outermost characters run past the
+browser edge and can't be read (「拡大したときにブラウザの端を超えて一部字が読めない」).
+
+## Root cause (reproduced, not guessed)
+
+Driving the app with puppeteer and walking the DOM from the xterm canvas up:
+
+- The **⤢ expand** (`.stage.zoomed`) terminal fits fine at every width (measured
+  27px of margin) — it is **not** the culprit.
+- The culprit is the **focus-zoom** (#310): the keyboard-focused cell grows via
+  `.stage:not(.zoomed) .grid > .focused { transform: scale(1.045) }`. A `scale`
+  grows the element from its centre by a fraction of its own size. For a wide/edge
+  cell (worst case: a single full-width cell) that pushes the left/right edges
+  ~8–13px **past** the viewport at 1280–2200px wide (and ~7px past the bottom).
+  The grid's `6px` padding can't absorb it, and the viewport's `overflow: hidden`
+  clips the overflowing characters.
+
+Because the growth is proportional to the cell (hence to the window) size, a
+**fixed** padding cannot cover it across window sizes.
+
+## Fix
+
+`src/components/TerminalGrid.vue`:
+
+1. Inset the **non-zoomed tiled grid** by an amount that tracks the cell size on
+   each axis so it always matches the scale:
+   `.stage:not(.zoomed) .grid { padding: calc(6px + 1.5vh) calc(6px + 1.6%); }`
+   - `%` (width-relative) horizontally, `vh` (height-relative) vertically.
+   - Scoped to `:not(.zoomed)` so the zoomed filmstrip keeps its own padding.
+2. Trim the scale `1.045` → `1.03` so the reserved inset stays modest while the
+   emphasis (scale + shadow + brighter header) remains clearly visible.
+
+## Verification (puppeteer, real xterm)
+
+- Single full-width cell (worst case): focused edges land **inside** the viewport
+  at every tested size — 1280×800, 1366×768, 1440×900, 1600×900, 1920×1080,
+  1920×1200, 2200×1000, 1280×1440 (0 clipping cases).
+- 4-cell grid, right-most cell focused: right edge 19px inside the viewport,
+  emphasis still clearly readable.
+
+## Out of scope
+
+The `min-width: 0` horizontal analog on `.terminal-container` was investigated and
+reverted — the expand path was already correct, so it was an unrelated change.

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -270,6 +270,15 @@ watch(
   padding: 6px;
   box-sizing: border-box;
 }
+/* The focused cell grows via `transform: scale` (see `.focused`). That growth is a fraction
+   of the cell's size, which for a wide/tall edge cell can push its edge past the viewport's
+   `overflow:hidden` and clip the outermost characters. Inset the tiled grid by an amount that
+   tracks the cell size on each axis — % of width horizontally, vh vertically — so the reserved
+   room matches the scale at any window size and the zoom always stays on screen. (Scoped to the
+   non-zoomed grid so the zoomed filmstrip keeps its own padding.) */
+.stage:not(.zoomed) .grid {
+  padding: calc(6px + 1.5vh) calc(6px + 1.6%);
+}
 
 /* Inert until a cell is zoomed. */
 .zoom-main {
@@ -461,7 +470,7 @@ watch(
     box-shadow 140ms ease;
 }
 .stage:not(.zoomed) .grid > .focused {
-  transform: scale(1.045);
+  transform: scale(1.03);
   z-index: 5;
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
## Summary

In the grid view, the keyboard-focused cell grows via `transform: scale` (#310). That growth is a fraction of the cell's size, so a wide/edge cell's scaled edge was pushed past the grid's `6px` padding and clipped by the viewport's `overflow: hidden` — the outermost characters became unreadable.

Fix (`TerminalGrid.vue`): inset the **non-zoomed tiled grid** by an amount that tracks the cell size on each axis — `%` of width horizontally, `vh` vertically — so the reserved room always matches the scale at any window size, and trim the scale `1.045` → `1.03`. Scoped to `.stage:not(.zoomed) .grid` so the zoomed filmstrip is unaffected.

## Items to Confirm / Review

- **Diagnosis:** the ⤢ **expand** was verified to already fit (27px margin); the clipping is the **focus-zoom** (the active cell lifting/growing in place), not expand. Please confirm that matches what you saw.
- **Proportional inset:** `calc(6px + 1.5vh) calc(6px + 1.6%)` slightly increases the grid's resting inset (a bit more breathing room around the cells). Confirm the extra margin is acceptable vs. maximizing terminal area.
- **Scale trim** `1.045` → `1.03`: the focus emphasis (scale + shadow + brighter header) is still clearly visible in the multi-cell screenshot; confirm it's still prominent enough.

## Verification (puppeteer, real xterm terminals)

- Single full-width cell (worst case): focused edges land **inside** the viewport at every tested size — 1280×800, 1366×768, 1440×900, 1600×900, 1920×1080, 1920×1200, 2200×1000, 1280×1440 → **0 clipping cases** (was overflowing by 8–13px before).
- 4-cell grid, right-most cell focused: right edge 19px inside the viewport; emphasis still reads clearly.

Gates: `yarn format` / `lint` (0 errors) / `typecheck` / `build` / `test` (1064 passed).

## User Prompt

> grid viewで拡大したときにブラウザの端を超えるケースが有って一部字が読めない。もともとのpadding or marginを調整して拡大してもおさまるようにして。

Plan: `plans/fix-grid-focus-zoom-overflow.md`. Closes #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)