### PR TITLE
feat: pick the launcher's Working directory via an OS folder dialog (#334)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,9 @@ In dev, open the Vite URL; its proxy forwards `/ws`, `/ws/pubsub`, and `/api` to
 
 ## Scripts (Run menu)
 
-An empty grid cell's launcher (the directory picker) offers a **run a script** row
+An empty grid cell's launcher sets the **Working directory** by typing, by a preset
+chip, or with the **📁 folder button** (a native OS folder dialog). It also offers a
+**run a script** row
 that launches project scripts (a dev server, tests, a build, …) **in that cell, in
 the directory the cell is pointed at** — so a whole workflow lives in one window
 alongside the Claude sessions. Scripts are **per-directory**: the cell reads the
@@ -755,7 +757,7 @@ same-origin-guarded.
 | `POST /api/transcribe`(`/model`…) | Voice-input transcription (Whisper, macOS). |
 | `POST /api/translation` | Runtime UI-string translation. |
 | `GET /api/remote-host/status` · `POST /api/remote-host/{connect,disconnect}` | Companion phone-client link. |
-| `POST /api/open-dir` · `POST /api/pick-file` | Reveal a dir in Finder/Explorer; OS file-picker → path. |
+| `POST /api/open-dir` · `POST /api/pick-file` | Reveal a dir in Finder/Explorer; OS file-picker → path (`{ directory: true }` opens the folder picker — used by the launcher's Working-directory 📁 button). |
 
 ### WebSocket: `/ws` (terminal)
 

--- a/plans/feat-334-pick-working-dir.md
+++ b/plans/feat-334-pick-working-dir.md
@@ -1,0 +1,35 @@
+# feat #334 — Working directory を OS フォルダ選択で指定
+
+New terminal ランチャーの Working directory 入力に、OS ネイティブのフォルダ選択
+ダイアログを開く 📁 ボタンを足す。
+
+## 問題
+
+ランチャーの Working directory はテキスト入力＋プリセットのみ。深いパスを手打ちするより
+OS のフォルダダイアログで選べたほうが速い。ヘッダーの 📎（`pickFile`）はファイル用で、
+フォルダを選べない。
+
+## 設計
+
+### サーバ — `server/pick-file.ts`
+- `pickFileCommand(platform, directory = false)` に directory 分岐を追加：
+  - macOS: `osascript` `choose folder`（単一）。
+  - Windows: `System.Windows.Forms.FolderBrowserDialog`。
+  - Linux: `zenity --file-selection --directory`。
+- `POST /api/pick-file` が body `{ directory: true }` を読んでフォルダモードに（既定＝ファイル、不変）。
+- `parsePickerOutput` は共通（絶対パスのみ）。
+
+### クライアント — `src/components/TerminalCell.vue`
+- `pickDir()`：`POST /api/pick-file {directory:true}` → 最初のパスを `fillDir()` に渡す
+  （入力反映＋resume/scripts/worktrees 更新）。
+- `.cell-dir-row` に 📁 ボタン（`cell-dir-pick`、▶ の左）。既存の launch ボタンは `cell-dir-go`
+  のままなので既存テストのセレクタは不変。CSS は `.cell-dir-go, .cell-dir-pick` で共有。
+
+## ファイル
+- `server/pick-file.ts` / `server/pick-file.spec.ts`（directory コマンド）
+- `src/components/TerminalCell.vue` / `TerminalCell.spec.ts`（📁 ボタン → 入力反映）
+- `README.md`（ランチャーのフォルダ選択）
+
+## 非スコープ
+- 実行中セルの cwd 変更（ランチャーのみ）。
+- 複数フォルダ選択（cwd は単一）。

--- a/server/pick-file.spec.ts
+++ b/server/pick-file.spec.ts
@@ -13,6 +13,25 @@ describe("pickFileCommand", () => {
   });
 });
 
+describe("pickFileCommand (directory mode)", () => {
+  it("macOS: osascript 'choose folder'", () => {
+    const { cmd, args } = pickFileCommand("darwin", true);
+    expect(cmd).toBe("osascript");
+    expect(args.join(" ")).toContain("choose folder");
+  });
+  it("Windows: FolderBrowserDialog", () => {
+    expect(pickFileCommand("win32", true).args.join(" ")).toContain("FolderBrowserDialog");
+  });
+  it("Linux: zenity --directory", () => {
+    expect(pickFileCommand("linux", true).args).toContain("--directory");
+  });
+  it("file mode (default) is unchanged", () => {
+    expect(pickFileCommand("darwin").args.join(" ")).toContain("choose file");
+    expect(pickFileCommand("win32").args.join(" ")).toContain("OpenFileDialog");
+    expect(pickFileCommand("linux").args).toContain("--multiple");
+  });
+});
+
 describe("parsePickerOutput", () => {
   it("splits newline-separated absolute paths", () => {
     expect(parsePickerOutput("/a/b.txt\n/c/d.txt")).toEqual(["/a/b.txt", "/c/d.txt"]);

--- a/server/pick-file.ts
+++ b/server/pick-file.ts
@@ -2,44 +2,50 @@ import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
 import path from "node:path";
 
-// A native "open file" dialog per platform whose stdout is the selection's
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+// A native "open file/folder" dialog per platform whose stdout is the selection's
 // absolute path(s), newline-separated. Browsers can't hand the terminal a real
 // filesystem path, but the local server can ask the OS. Fixed command + literal
-// argv (the prompt is a constant) — no shell, no input interpolation.
-const PICK_PROMPT = "Select file(s)";
+// argv (the prompts are constants) — no shell, no input interpolation.
+const FILE_PROMPT = "Select file(s)";
+const DIR_PROMPT = "Select folder";
 
-export function pickFileCommand(platform: NodeJS.Platform): { cmd: string; args: string[] } {
-  if (platform === "darwin")
-    return {
-      cmd: "osascript",
-      args: [
-        "-e",
-        `set chosen to choose file with prompt "${PICK_PROMPT}" with multiple selections allowed`,
-        "-e",
-        "set text item delimiters to linefeed",
-        "-e",
-        "set out to {}",
-        "-e",
-        "repeat with f in chosen",
-        "-e",
-        "set end of out to POSIX path of f",
-        "-e",
-        "end repeat",
-        "-e",
-        "return out as text",
-      ],
-    };
-  if (platform === "win32")
-    return {
-      cmd: "powershell",
-      args: [
-        "-NoProfile",
-        "-STA",
-        "-Command",
-        "Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join \"`n\" }",
-      ],
-    };
-  return { cmd: "zenity", args: ["--file-selection", "--multiple", "--separator=\n", `--title=${PICK_PROMPT}`] };
+// macOS: `choose file` (multi) vs `choose folder` (single — a working directory is one dir).
+function macArgs(directory: boolean): string[] {
+  if (directory) return ["-e", `return POSIX path of (choose folder with prompt "${DIR_PROMPT}")`];
+  return [
+    "-e",
+    `set chosen to choose file with prompt "${FILE_PROMPT}" with multiple selections allowed`,
+    "-e",
+    "set text item delimiters to linefeed",
+    "-e",
+    "set out to {}",
+    "-e",
+    "repeat with f in chosen",
+    "-e",
+    "set end of out to POSIX path of f",
+    "-e",
+    "end repeat",
+    "-e",
+    "return out as text",
+  ];
+}
+
+function winArgs(directory: boolean): string[] {
+  const dialog = directory
+    ? "$d = New-Object System.Windows.Forms.FolderBrowserDialog; if ($d.ShowDialog() -eq 'OK') { $d.SelectedPath }"
+    : "$d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join \"`n\" }";
+  return ["-NoProfile", "-STA", "-Command", `Add-Type -AssemblyName System.Windows.Forms; ${dialog}`];
+}
+
+export function pickFileCommand(platform: NodeJS.Platform, directory = false): { cmd: string; args: string[] } {
+  if (platform === "darwin") return { cmd: "osascript", args: macArgs(directory) };
+  if (platform === "win32") return { cmd: "powershell", args: winArgs(directory) };
+  const zenity = directory
+    ? ["--file-selection", "--directory", `--title=${DIR_PROMPT}`]
+    : ["--file-selection", "--multiple", "--separator=\n", `--title=${FILE_PROMPT}`];
+  return { cmd: "zenity", args: zenity };
 }
 
 export function parsePickerOutput(stdout: string): string[] {
@@ -54,12 +60,14 @@ interface PickFileOptions {
 }
 
 // POST /api/pick-file — open the OS file dialog and return the chosen absolute
-// path(s). A user cancel yields empty stdout, so the response is { paths: [] }.
-// Same-origin guarded like the other local-action routes.
+// path(s). Body `{ directory: true }` opens a FOLDER picker instead (for the launcher's
+// Working-directory field). A user cancel yields empty stdout, so the response is
+// { paths: [] }. Same-origin guarded like the other local-action routes.
 export function mountPickFileRoute(app: Express, { isAllowedOrigin }: PickFileOptions) {
   app.post("/api/pick-file", (req: Request, res) => {
     if (!isAllowedOrigin(req.headers.origin)) return res.status(403).json({ error: "forbidden origin" });
-    const { cmd, args } = pickFileCommand(process.platform);
+    const directory = isRecord(req.body) && req.body.directory === true;
+    const { cmd, args } = pickFileCommand(process.platform, directory);
     const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
     const out: Buffer[] = [];
     child.stdout.on("data", (chunk: Buffer) => out.push(chunk));

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -157,6 +157,24 @@ describe("TerminalCell", () => {
     expect((w.find(".cell-dir-go").element as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("the folder button opens the OS folder picker and fills the working directory", async () => {
+    const w = mountCell(null, { defaultCwd: "/home/me/default" });
+    await flushPromises();
+    let body: string | undefined;
+    globalThis.fetch = vi.fn((url: string, init?: { body?: string }) => {
+      const u = String(url);
+      if (u.includes("/api/pick-file")) {
+        body = init?.body;
+        return Promise.resolve({ ok: true, json: async () => ({ paths: ["/picked/dir"] }) });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) });
+    }) as unknown as typeof fetch;
+    await w.find(".cell-dir-pick").trigger("click");
+    await flushPromises();
+    expect(body).toContain('"directory":true');
+    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/picked/dir");
+  });
+
   it("shows a cancel ✕ on a cancellable launcher that emits close, but not otherwise", async () => {
     const plain = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -300,6 +300,20 @@ function fillDir(path: string) {
   loadWorktrees();
 }
 
+// The 📁 button: the browser can't open a native folder chooser, so the local server does
+// (POST /api/pick-file { directory: true }). Fill the Working-directory field with the pick.
+async function pickDir() {
+  try {
+    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ directory: true }) });
+    if (!res.ok) return;
+    const data = await res.json();
+    const dir = Array.isArray(data?.paths) ? data.paths.find((p: unknown): p is string => typeof p === "string") : undefined;
+    if (dir) fillDir(dir);
+  } catch {
+    // best-effort — the native dialog is unavailable or the user canceled
+  }
+}
+
 // Existing sessions for the dir in the form, so an empty cell can resume one
 // instead of starting fresh.
 interface ResumableSession {
@@ -1105,6 +1119,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             @input="dirTouched = true"
             @keydown.enter="launch"
           />
+          <button type="button" class="cell-dir-pick" title="Choose a folder…" aria-label="Choose the working directory" @click="pickDir">
+            <span class="material-symbols-outlined">folder_open</span>
+          </button>
           <button
             type="button"
             class="cell-dir-go"
@@ -1617,7 +1634,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   flex: 1 1 auto;
   min-width: 0;
 }
-.cell-dir-go {
+.cell-dir-go,
+.cell-dir-pick {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
@@ -1629,7 +1647,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   color: var(--text-secondary);
   cursor: pointer;
 }
-.cell-dir-go:hover:not(:disabled) {
+.cell-dir-go:hover:not(:disabled),
+.cell-dir-pick:hover {
   background: var(--bg-hover);
   color: var(--text);
   border-color: var(--accent);
@@ -1638,7 +1657,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   opacity: 0.4;
   cursor: default;
 }
-.cell-dir-go .material-symbols-outlined {
+.cell-dir-go .material-symbols-outlined,
+.cell-dir-pick .material-symbols-outlined {
   font-size: 18px;
 }
 .cell-start {


### PR DESCRIPTION
## Summary

Add a **📁 folder button** to the New-terminal launcher's **Working directory** row that opens the
**native OS folder dialog** and fills the field — a folder-pick companion to the header's 📎 file picker.

- **Server**: `POST /api/pick-file` gains a `{ directory: true }` mode — macOS `osascript … choose folder`,
  Windows `FolderBrowserDialog`, Linux `zenity --file-selection --directory`. Default (file) mode is
  unchanged, so the header 📎 pickFile action is untouched.
- **Client**: `pickDir()` posts `{ directory: true }` and passes the chosen dir through the existing
  `fillDir()` (fills the input + refreshes the resume/scripts/worktrees lists for that dir). The launch
  (▶) button keeps its `cell-dir-go` class; the new button is `cell-dir-pick`, so existing selectors/tests
  are unaffected (CSS is shared).

## Items to Confirm / Review

- **Route reuse**: the folder picker rides on `/api/pick-file` with a `directory` flag rather than a new
  route — DRY, same-origin-guarded, same `parsePickerOutput`. OK?
- **Single dir**: the folder dialog is single-select (a working directory is one dir). macOS uses
  `choose folder` (no "multiple"), Linux `--directory` without `--multiple`.
- **Selector safety**: the launch button stays `.cell-dir-go` (existing tests use that); the new folder
  button is `.cell-dir-pick`.

## User Prompt

> Working directory を開くときに OS の機能で dir を指定できても良いね。

## Implementation

Files: `server/pick-file.ts` (+ spec: directory command per platform), `src/components/TerminalCell.vue`
(`pickDir()` + 📁 button, shared CSS) (+ spec: button → `{ directory: true }` → input filled), README.

Closes #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
