### PR TITLE
fix: 複数インスタンスで config.json が相互に上書きされるのを防ぐ（#337）

### DIFF
--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -2,7 +2,16 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, sanitizeUserMcpServers, loadAppConfig, saveAppConfig } from "./app-config";
+import {
+  sanitizeSoundFile,
+  sanitizeRepos,
+  sanitizeLaunchers,
+  sanitizeUserMcpServers,
+  loadAppConfig,
+  saveAppConfig,
+  mergeConfigUpdate,
+  type AppConfig,
+} from "./app-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 
@@ -144,5 +153,44 @@ describe("loadAppConfig / saveAppConfig", () => {
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }] }));
     expect(loadAppConfig(file)).toEqual({ ...base, cwdPresets: [{ label: "a", path: "/a" }] });
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("mergeConfigUpdate", () => {
+  const baseConfig = (over: Partial<AppConfig> = {}): AppConfig => ({
+    cwdPresets: [],
+    soundFile: null,
+    prRepos: [],
+    launchers: [],
+    userMcpServers: [],
+    buttons: [{ id: "reveal", label: "Reveal in the file manager", run: "open", emoji: "📂", open: { reveal: "${dir}" } }],
+    chips: ["git", "diff", "ctx", "usage"],
+    ...over,
+  });
+
+  it("applies a field present in the body", () => {
+    expect(mergeConfigUpdate(baseConfig(), { chips: ["git", "diff"] }).chips).toEqual(["git", "diff"]);
+  });
+
+  it("keeps fields the body omits — a chips-only update must NOT wipe buttons", () => {
+    const base = baseConfig();
+    expect(mergeConfigUpdate(base, { chips: ["git"] }).buttons).toEqual(base.buttons);
+  });
+
+  it("merging on a RE-READ disk base preserves another instance's write (the clobber fix)", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    try {
+      // "Another instance" persisted a full config (buttons + chips) to the shared file.
+      saveAppConfig(file, baseConfig());
+      // A stale instance handles a chips-only POST: base must come from the re-read disk,
+      // not its boot-time memory — so the disk's buttons survive.
+      const disk = loadAppConfig(file);
+      const next = mergeConfigUpdate(disk, { chips: ["git", "diff"] });
+      expect(next.buttons).toEqual(disk.buttons);
+      expect(next.chips).toEqual(["git", "diff"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -120,6 +120,23 @@ export function loadAppConfig(file: string): AppConfig {
   }
 }
 
+// Apply a partial POST /api/config body onto a BASE config: fields the body omits keep
+// the base's value. The caller MUST pass a freshly-loaded-from-disk base (not a cached
+// in-memory config) — multiple mulmoterminal instances share one config.json, and a
+// stale in-memory copy would otherwise write back its boot-time values for the omitted
+// fields, clobbering whatever another instance persisted since (e.g. wiping buttons).
+export function mergeConfigUpdate(base: AppConfig, body: Record<string, unknown>): AppConfig {
+  return {
+    cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : base.cwdPresets,
+    soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : base.soundFile,
+    prRepos: body.prRepos !== undefined ? sanitizeRepos(body.prRepos) : base.prRepos,
+    launchers: body.launchers !== undefined ? sanitizeLaunchers(body.launchers) : base.launchers,
+    userMcpServers: body.userMcpServers !== undefined ? sanitizeUserMcpServers(body.userMcpServers) : base.userMcpServers,
+    buttons: body.buttons !== undefined ? sanitizeButtons(body.buttons) : base.buttons,
+    chips: body.chips !== undefined ? sanitizeChips(body.chips) : base.chips,
+  };
+}
+
 // Persist the whole config; returns false on any write failure so the caller can
 // surface it instead of reporting a false success.
 export function saveAppConfig(file: string, config: AppConfig): boolean {

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -7,9 +7,8 @@ import os from "node:os";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
-import { sanitizePresets } from "./cwd-presets.js";
-import { loadAppConfig, saveAppConfig, sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, sanitizeUserMcpServers, type AppConfig } from "./app-config.js";
-import { sanitizeButtons, sanitizeChips, type HeaderConfig } from "./header-config.js";
+import { loadAppConfig, saveAppConfig, mergeConfigUpdate, type AppConfig } from "./app-config.js";
+import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type UserMcpServer } from "./config-schema.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
@@ -84,15 +83,11 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     if (badField) return res.status(400).json({ error: `${badField} must be an array` });
     const badNullableField = badNullableArrayField(body);
     if (badNullableField) return res.status(400).json({ error: `${badNullableField} must be an array or null` });
-    const next: AppConfig = {
-      cwdPresets: body.cwdPresets !== undefined ? sanitizePresets(body.cwdPresets) : config.cwdPresets,
-      soundFile: body.soundFile !== undefined ? sanitizeSoundFile(body.soundFile) : config.soundFile,
-      prRepos: body.prRepos !== undefined ? sanitizeRepos(body.prRepos) : config.prRepos,
-      launchers: body.launchers !== undefined ? sanitizeLaunchers(body.launchers) : config.launchers,
-      userMcpServers: body.userMcpServers !== undefined ? sanitizeUserMcpServers(body.userMcpServers) : config.userMcpServers,
-      buttons: body.buttons !== undefined ? sanitizeButtons(body.buttons) : config.buttons,
-      chips: body.chips !== undefined ? sanitizeChips(body.chips) : config.chips,
-    };
+    // Merge onto the CURRENT disk config, re-read now — not this instance's cached
+    // `config`, which may be stale (another mulmoterminal instance sharing this file
+    // could have written since we booted). Using the stale copy for omitted fields
+    // would clobber those edits (e.g. a chips-only POST wiping another's buttons).
+    const next = mergeConfigUpdate(loadAppConfig(CONFIG_FILE), body);
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.
     if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });


### PR DESCRIPTION
## Summary

複数の mulmoterminal インスタンスが `~/.mulmoterminal/config.json` を共有する時、**片方の保存が他方の設定を消す**データ消失バグ（#337）の修正。`POST /api/config` の部分更新が、省略フィールドの土台に**起動時の古いメモリ内 config** を使っていたのが原因。**保存前に disk を読み直す read-modify-write** に変更。

実機で発見: 稼働中インスタンスのメモリ内が `buttons=[]` なのに disk には pr ボタンがあり、そのインスタンスで保存すると pr ボタンが消える状態だった。

## Items to Confirm / Review

- **修正の要点**: `mergeConfigUpdate(loadAppConfig(CONFIG_FILE), body)` — 省略フィールドは「最新 disk 値」を土台に。残るのは同一フィールドを2インスタンスがほぼ同時に書く狭い TOCTOU のみ（last-writer-wins で許容）。
- **読み取り側の staleness は対象外**: `getHeaderConfig()` 等は依然メモリ内 config を返す（別インスタンスの変更は再起動まで反映されない）。これは data-loss ではないので本 PR では触らない。必要なら別途 file-watch を検討。
- **同じ共有ファイル clobber パターンが他にもある**（本 PR 対象外、別 issue 候補）: `dev-terminal-sessions.json` / `waiting-state.json`。同じ read-modify-write 化が要る。

## User Prompt

> mulmoterminal の header の global 設定が効いていない（model/context を off にしても見える）。GitHub ボタンが出ないのは default off か？ → デバッグ中に「稼働中インスタンスの古い config が保存時に他を破壊する」バグを発見。**bug はすぐ直したい。**（設定 UI 追加は不要）

## 検証

- ユニット `app-config.spec.ts`: `mergeConfigUpdate` — 省略フィールドが base を保持（chips-only が buttons を消さない）／re-read disk base で clobber されない。
- ライブ（隔離HOME・実 HTTP POST）: 起動時 stale なサーバに別プロセスが disk 更新 → chips-only POST → **disk の buttons が生存**、chips は適用。
- ゲート: format / lint(0 errors) / typecheck / build / 全テスト green。

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)
