### PR TITLE
feat: send a Web Push when a background task finishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The Settings modal (⚙) persists per-user UI choices to `~/.mulmoterminal/confi
 | `userMcpServers` | `{ id, url }` HTTP MCP servers merged into the **single-view** Claude session's `--mcp-config` (a `localhost` URL is reached over `host.docker.internal` in the Docker sandbox). Takes effect on the next session. |
 | `buttons`    | Header action buttons — see [Header buttons](#header-buttons). Omit to keep the defaults; set to replace them. |
 | `chips`      | Header info chips. Omit to keep the default set; `[]` hides all built-ins. |
+| `pushEnabled` | `true` to send a **Web Push** to your registered devices when a background task finishes. Off by default; only sends while the **RemoteHost** channel is connected (see below). |
 
 #### Header buttons
 
@@ -324,6 +325,14 @@ concerns. To use your own sound, set `soundFile` in Settings (Browse / Test / Us
 chime) or in the config file; the server streams that file at `GET /api/sound` and
 the client decodes it (falling back to the chime if it's missing or not audio). It's
 your own local file referenced by absolute path — nothing is added to the package.
+
+**Web Push on task finish.** Enable `pushEnabled` in Settings to have the server send a
+push (title = the project dir, body = the last prompt) to your registered devices each
+time a **background** task finishes — the same signal as the attention chime, but for the
+panes you're not watching. Delivery is handled by the separate `mulmoserver` `sendPush`
+Cloud Function; MulmoTerminal only makes the call, and only while the **RemoteHost**
+channel is connected (its Google sign-in supplies the notification auth). With RemoteHost
+disconnected, or with no device registered, the toggle is a no-op.
 
 ### Per-directory settings (`<project>/.mulmoterminal.json`)
 

--- a/plans/feat-web-push-on-task-finish.md
+++ b/plans/feat-web-push-on-task-finish.md
@@ -1,0 +1,55 @@
+# feat: Web Push on task finish (#339)
+
+## Goal
+
+Send a Web Push to the user's registered devices when a background task finishes,
+gated by a Settings on/off toggle. MulmoTerminal only *sends* — device registration
+and delivery are the separate `mulmoserver` `sendPush` Cloud Function's job.
+
+## Reference
+
+`mulmoserver/docs/web-push-sending.md`:
+- `POST https://asia-northeast1-<projectId>.cloudfunctions.net/sendPush`
+- `Authorization: Bearer <Firebase Auth ID token>`, `Content-Type: application/json`
+- Body `{ "data": { "title", "body" } }` → response `{ "result": { sent, failed, targets } }`
+- Target devices resolve from the signed-in uid; the caller only needs to be signed in.
+
+## Decisions
+
+- **Server-side send** (not browser-side): works even when the browser tab is closed,
+  as long as the machine/server is up — matching the "tell me when I'm away" value.
+- **Auth** = the RemoteHost channel's Firebase sign-in (`server/backends/remoteHost/firebase.ts`,
+  project `mulmoserver`, same as `sendPush`). `auth.currentUser.getIdToken()`. ⇒ **push only
+  sends while RemoteHost is connected**; otherwise it's a silent no-op.
+- **Trigger** = `handleActivityHook` on `event === "Stop" && !active` — one push per finished
+  *background* turn (the pane the user is viewing is `active` → skipped, like the chime). Hooking
+  the raw publish stream would double-fire, since a background Stop publishes twice (waiting+working).
+- **Toggle** = a new `pushEnabled` global config field, read live at the hook so it takes effect
+  without a restart. Mirrors the existing `soundFile` plumbing end to end.
+
+## Changes
+
+- `server/app-config.ts` — `pushEnabled: boolean` on `AppConfig` (+ `sanitizePushEnabled`, load/save).
+- `server/config-routes.ts` — `pushEnabled` in GET/POST `/api/config`; live `getPushEnabled()`.
+- `server/web-push.ts` (new) — `sendWebPush(title, body)` via the remote-host `auth`, with an
+  `AbortController` timeout; pure `buildSendPushBody` / `parseSendPushResult`. No-ops when not signed in.
+- `server/index.ts` — `notifyTaskFinished(sessionId)` (title = dir basename, body = last prompt),
+  called from `handleActivityHook` on a background `Stop`.
+- `src/composables/useAppConfig.ts` — singleton `pushEnabled` ref + `savePushEnabled` + load.
+- `src/components/SettingsModal.vue` — "Web Push notifications" toggle (+ RemoteHost note).
+- `src/App.vue` — wire `:push-enabled` / `@update-push-enabled`.
+- `README.md` — document `pushEnabled` + the RemoteHost prerequisite.
+
+## Verification
+
+- Unit-tested: `sanitizePushEnabled`, config load/save round-trip with `pushEnabled`,
+  `buildSendPushBody` / `parseSendPushResult`, and `sendWebPush` no-op when not signed in.
+- Gates: format / lint (0 errors) / typecheck / build / test (1070).
+- **Manual (user):** actual push delivery needs a Google sign-in (RemoteHost connected) and a
+  registered device, so the user verifies end-to-end delivery.
+
+## Possible follow-ups
+
+- Also push on `Notification` (blocked / needs-input), not just Stop.
+- Per-directory or per-session push opt-out.
+- Browser-side fallback send when RemoteHost isn't connected.

--- a/server/app-config.spec.ts
+++ b/server/app-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, sanitizeUserMcpServers, loadAppConfig, saveAppConfig } from "./app-config";
+import { sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, sanitizeUserMcpServers, sanitizePushEnabled, loadAppConfig, saveAppConfig } from "./app-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 
@@ -19,6 +19,17 @@ describe("sanitizeSoundFile", () => {
     expect(sanitizeSoundFile("relative/path.wav")).toBeNull();
     expect(sanitizeSoundFile("./a.wav")).toBeNull();
     expect(sanitizeSoundFile("../a.wav")).toBeNull();
+  });
+});
+
+describe("sanitizePushEnabled", () => {
+  it("is true only for the boolean true; everything else is false", () => {
+    expect(sanitizePushEnabled(true)).toBe(true);
+    expect(sanitizePushEnabled(false)).toBe(false);
+    expect(sanitizePushEnabled("true")).toBe(false);
+    expect(sanitizePushEnabled(1)).toBe(false);
+    expect(sanitizePushEnabled(null)).toBe(false);
+    expect(sanitizePushEnabled(undefined)).toBe(false);
   });
 });
 
@@ -77,7 +88,7 @@ describe("sanitizeUserMcpServers", () => {
 });
 
 describe("loadAppConfig / saveAppConfig", () => {
-  const base = { cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [], buttons: null, chips: null };
+  const base = { cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [], buttons: null, chips: null, pushEnabled: false };
   it("round-trips presets + soundFile + prRepos + launchers + userMcpServers through a file", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
@@ -89,6 +100,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       userMcpServers: [{ id: "weather", url: "http://localhost:9000/mcp" }],
       buttons: [{ id: "pr", label: "PR", run: "shell" as const, cmd: "gh pr create" }],
       chips: ["dir", "git"],
+      pushEnabled: true,
     };
     expect(saveAppConfig(file, cfg)).toBe(true);
     expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(cfg);
@@ -126,6 +138,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       userMcpServers: [{ id: "ok", url: "https://x/mcp" }],
       buttons: null,
       chips: null,
+      pushEnabled: false,
     });
     rmSync(dir, { recursive: true, force: true });
   });

--- a/server/app-config.ts
+++ b/server/app-config.ts
@@ -24,6 +24,9 @@ export interface AppConfig {
   buttons: HeaderButton[] | null;
   // Global header display chips, or null when unconfigured (the client keeps its default set).
   chips: HeaderChip[] | null;
+  // Send a Web Push (sendPush Cloud Function) when a task finishes. Off by default; only
+  // fires while the RemoteHost channel is connected (that's what supplies the Firebase auth).
+  pushEnabled: boolean;
 }
 
 // `id` becomes an MCP server name + `mcp__<id>` tool prefix, so restrict to a plain
@@ -98,9 +101,22 @@ export function sanitizeSoundFile(input: unknown): string | null {
   return trimmed && path.isAbsolute(trimmed) ? trimmed : null;
 }
 
+export function sanitizePushEnabled(input: unknown): boolean {
+  return input === true;
+}
+
 // Fresh object each call — callers hold and mutate the returned config in place, so a
 // shared default constant would be corrupted across loads.
-const emptyConfig = (): AppConfig => ({ cwdPresets: [], soundFile: null, prRepos: [], launchers: [], userMcpServers: [], buttons: null, chips: null });
+const emptyConfig = (): AppConfig => ({
+  cwdPresets: [],
+  soundFile: null,
+  prRepos: [],
+  launchers: [],
+  userMcpServers: [],
+  buttons: null,
+  chips: null,
+  pushEnabled: false,
+});
 
 export function loadAppConfig(file: string): AppConfig {
   try {
@@ -114,6 +130,7 @@ export function loadAppConfig(file: string): AppConfig {
       userMcpServers: sanitizeUserMcpServers(raw?.userMcpServers),
       buttons: sanitizeButtons(raw?.buttons),
       chips: sanitizeChips(raw?.chips),
+      pushEnabled: sanitizePushEnabled(raw?.pushEnabled),
     };
   } catch {
     return emptyConfig();
@@ -133,6 +150,7 @@ export function saveAppConfig(file: string, config: AppConfig): boolean {
       userMcpServers: config.userMcpServers,
       buttons: config.buttons,
       chips: config.chips,
+      pushEnabled: config.pushEnabled,
     };
     writeFileSync(file, JSON.stringify(payload, null, 2));
     return true;

--- a/server/config-routes.ts
+++ b/server/config-routes.ts
@@ -8,7 +8,16 @@ import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
 import { sanitizePresets } from "./cwd-presets.js";
-import { loadAppConfig, saveAppConfig, sanitizeSoundFile, sanitizeRepos, sanitizeLaunchers, sanitizeUserMcpServers, type AppConfig } from "./app-config.js";
+import {
+  loadAppConfig,
+  saveAppConfig,
+  sanitizeSoundFile,
+  sanitizeRepos,
+  sanitizeLaunchers,
+  sanitizeUserMcpServers,
+  sanitizePushEnabled,
+  type AppConfig,
+} from "./app-config.js";
 import { sanitizeButtons, sanitizeChips, type HeaderConfig } from "./header-config.js";
 import { type Launcher, type UserMcpServer } from "./config-schema.js";
 
@@ -37,6 +46,12 @@ export function getUserMcpServers(): UserMcpServer[] {
 // change on the next fetch without a restart.
 export function getHeaderConfig(): HeaderConfig {
   return { buttons: config.buttons, chips: config.chips };
+}
+
+// Whether to send a Web Push when a task finishes — read live at the Stop hook so a
+// settings toggle takes effect without a restart.
+export function getPushEnabled(): boolean {
+  return config.pushEnabled;
 }
 
 // Body fields that must be an array when present (a partial POST /api/config may omit any).
@@ -70,6 +85,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     userMcpServers: config.userMcpServers,
     buttons: config.buttons,
     chips: config.chips,
+    pushEnabled: config.pushEnabled,
   });
 
   app.get("/api/config", (_req, res) => {
@@ -92,6 +108,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
       userMcpServers: body.userMcpServers !== undefined ? sanitizeUserMcpServers(body.userMcpServers) : config.userMcpServers,
       buttons: body.buttons !== undefined ? sanitizeButtons(body.buttons) : config.buttons,
       chips: body.chips !== undefined ? sanitizeChips(body.chips) : config.chips,
+      pushEnabled: body.pushEnabled !== undefined ? sanitizePushEnabled(body.pushEnabled) : config.pushEnabled,
     };
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,8 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./plugins-regis
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers, getHeaderConfig } from "./config-routes.js";
+import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers, getHeaderConfig, getPushEnabled } from "./config-routes.js";
+import { sendWebPush } from "./web-push.js";
 import { buildHeaderContext, loadHeaderConfig } from "./header-context.js";
 import { resolveHeader, resolveButtonCommand, headerHasPrButton } from "./header-resolve.js";
 import { prUrlForBranch } from "./pr-for-branch.js";
@@ -1107,6 +1108,24 @@ function handleActivityHook(sessionId: string, event: string, active: boolean) {
     if (eff.kind === "working") setWorking(sessionId, eff.value, event);
     else setWaiting(sessionId, eff.value, event);
   }
+  // A background turn just ended (same attention-flag semantics as the beep: not the pane
+  // the user is viewing) → push once. Stop is one event per finished turn, so this fires
+  // once even though a background Stop publishes twice (waiting + working).
+  if (event === "Stop" && !active) notifyTaskFinished(sessionId);
+}
+
+const PUSH_TITLE_MAX = 80;
+const PUSH_BODY_MAX = 160;
+// Notify the user's devices that a background task finished, when Web Push is enabled.
+// Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
+function notifyTaskFinished(sessionId: string): void {
+  if (!getPushEnabled()) return;
+  const cwd = ptys.get(sessionId)?.cwd ?? null;
+  const where = cwd ? path.basename(cwd) : "session";
+  const what = lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+  const title = `✅ ${where}`.slice(0, PUSH_TITLE_MAX);
+  const body = (what || "タスクが完了しました").slice(0, PUSH_BODY_MAX);
+  void sendWebPush(title, body);
 }
 
 interface HookToolPayload {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1120,6 +1120,9 @@ const PUSH_BODY_MAX = 160;
 // Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
 function notifyTaskFinished(sessionId: string): void {
   if (!getPushEnabled()) return;
+  // Internal helper turns flow through /api/hook with active=false too — hidden background
+  // workers and translation workers aren't real user tasks, so never push for them.
+  if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = cwd ? path.basename(cwd) : "session";
   const what = lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";

--- a/server/web-push.spec.ts
+++ b/server/web-push.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildSendPushBody, parseSendPushResult, sendWebPush } from "./web-push";
+
+describe("buildSendPushBody", () => {
+  it("wraps title/body in the onCall `data` envelope", () => {
+    expect(JSON.parse(buildSendPushBody("✅ proj", "done"))).toEqual({ data: { title: "✅ proj", body: "done" } });
+  });
+});
+
+describe("parseSendPushResult", () => {
+  it("reads sent/failed/targets from the onCall `result` envelope", () => {
+    expect(parseSendPushResult({ result: { sent: 1, failed: 0, targets: 2 } })).toEqual({ sent: 1, failed: 0, targets: 2 });
+  });
+
+  it("treats missing / non-number counts as 0", () => {
+    expect(parseSendPushResult({ result: {} })).toEqual({ sent: 0, failed: 0, targets: 0 });
+    expect(parseSendPushResult({ result: { sent: "x", targets: null } })).toEqual({ sent: 0, failed: 0, targets: 0 });
+  });
+
+  it("returns null when the shape isn't a result envelope", () => {
+    expect(parseSendPushResult(null)).toBeNull();
+    expect(parseSendPushResult({})).toBeNull();
+    expect(parseSendPushResult({ result: 5 })).toBeNull();
+    expect(parseSendPushResult("nope")).toBeNull();
+  });
+});
+
+describe("sendWebPush", () => {
+  it("no-ops (returns null, never fetches) when RemoteHost isn't signed in", async () => {
+    // In tests the remote-host Firebase auth has no currentUser (never connected), so a
+    // push must be skipped entirely — a failed/absent auth must not throw or hit the network.
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    expect(await sendWebPush("✅ proj", "done")).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+});

--- a/server/web-push.ts
+++ b/server/web-push.ts
@@ -1,0 +1,57 @@
+// Send a Web Push via the mulmoserver `sendPush` Cloud Function when a task finishes
+// (see mulmoserver docs/web-push-sending.md). We only POST { title, body }; the target
+// devices are resolved server-side from the signed-in user's uid, and registration /
+// delivery / dead-token pruning are the server's job. Auth comes from the RemoteHost
+// channel's Firebase sign-in, so this no-ops whenever RemoteHost isn't connected.
+import { auth } from "./backends/remoteHost/firebase.js";
+
+// asia-northeast1 onCall endpoint for the `mulmoserver` project. Mirrors the firebase
+// config in backends/remoteHost/firebase.ts — keep in sync if the project id changes.
+export const SEND_PUSH_URL = "https://asia-northeast1-mulmoserver.cloudfunctions.net/sendPush";
+const SEND_PUSH_TIMEOUT_MS = 8000;
+
+export interface SendPushResult {
+  sent: number;
+  failed: number;
+  targets: number;
+}
+
+// The onCall wire shape wraps the payload in `data`.
+export function buildSendPushBody(title: string, body: string): string {
+  return JSON.stringify({ data: { title, body } });
+}
+
+// The onCall response wraps the payload in `result`. Missing/!number counts read as 0.
+export function parseSendPushResult(json: unknown): SendPushResult | null {
+  if (typeof json !== "object" || json === null) return null;
+  const result = (json as { result?: unknown }).result;
+  if (typeof result !== "object" || result === null) return null;
+  const r = result as Record<string, unknown>;
+  const num = (v: unknown): number => (typeof v === "number" ? v : 0);
+  return { sent: num(r.sent), failed: num(r.failed), targets: num(r.targets) };
+}
+
+// POST { title, body } to sendPush as the RemoteHost-signed-in user. Returns the delivery
+// result, or null when nothing was sent (not signed in / network / timeout / non-2xx).
+// Never throws — a failed push must not disturb the hook that triggered it.
+export async function sendWebPush(title: string, body: string): Promise<SendPushResult | null> {
+  const user = auth.currentUser;
+  if (!user) return null; // RemoteHost not connected → no auth → nothing to send with
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SEND_PUSH_TIMEOUT_MS);
+  try {
+    const idToken = await user.getIdToken();
+    const res = await fetch(SEND_PUSH_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${idToken}` },
+      body: buildSendPushBody(title, body),
+      signal: controller.signal,
+    });
+    if (!res.ok) return null;
+    return parseSendPushResult(await res.json());
+  } catch {
+    return null; // offline / aborted / bad JSON — silently skip; the beep still fired
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -150,7 +150,8 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (theme + notification sound), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { defaultCwd, loadConfig, saveSound, prRepos, savePrRepos, launchers, saveLaunchers, userMcpServers, saveUserMcpServers } = useAppConfig();
+const { defaultCwd, loadConfig, saveSound, pushEnabled, savePushEnabled, prRepos, savePrRepos, launchers, saveLaunchers, userMcpServers, saveUserMcpServers } =
+  useAppConfig();
 // Drive the single view's dir overrides off the dir the terminal ACTUALLY runs in
 // (reported by the server, which may resolve/fall back), not the static default — so
 // the badge/theme/colors always track the active session. Falls back to the default
@@ -372,12 +373,14 @@ function onSession(id: string) {
     <SettingsModal
       v-if="showSettings"
       :sound-file="soundFile"
+      :push-enabled="pushEnabled"
       :pr-repos="prRepos"
       :launchers="launchers"
       :user-mcp-servers="userMcpServers"
       :cwd="effectiveCwd"
       :session-id="activeId"
       @update-sound="saveSound"
+      @update-push-enabled="savePushEnabled"
       @update-repos="savePrRepos"
       @update-launchers="saveLaunchers"
       @update-user-mcp="saveUserMcpServers"

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -8,6 +8,7 @@ import type { UserMcpServer } from "./userMcp";
 
 const props = defineProps<{
   soundFile?: string | null;
+  pushEnabled?: boolean;
   prRepos?: string[];
   launchers?: Launcher[];
   userMcpServers?: UserMcpServer[];
@@ -16,6 +17,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   (e: "update-sound", file: string | null): void;
+  (e: "update-push-enabled", on: boolean): void;
   (e: "update-repos", repos: string[]): void;
   (e: "update-launchers", launchers: Launcher[]): void;
   (e: "update-user-mcp", servers: UserMcpServer[]): void;
@@ -119,6 +121,10 @@ function applySound() {
 function clearSound() {
   soundPath.value = "";
   emit("update-sound", null);
+}
+// Web Push toggle — stateless: reflects props.pushEnabled, emits the new value up (App persists it).
+function onPushToggle(e: Event) {
+  if (e.target instanceof HTMLInputElement) emit("update-push-enabled", e.target.checked);
 }
 async function browseSound() {
   try {
@@ -258,6 +264,16 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
         <button class="btn" type="button" title="Play the current sound" @click="testSound">▶ Test</button>
         <button class="btn" type="button" :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</button>
       </div>
+
+      <h3 class="section-title">Web Push notifications</h3>
+      <p class="hint">
+        Send a push to your registered devices when a background task finishes. Requires the <strong>RemoteHost</strong> connection — its sign-in provides the
+        notification auth, so pushes only send while it's connected.
+      </p>
+      <label class="push-row">
+        <input type="checkbox" :checked="props.pushEnabled ?? false" aria-label="Send a Web Push when a task finishes" @change="onPushToggle" />
+        <span>Notify my devices when a task finishes</span>
+      </label>
 
       <h3 class="section-title">Pull request repos</h3>
       <p class="hint">
@@ -551,6 +567,15 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
   display: flex;
   gap: 8px;
   margin-top: 8px;
+}
+.push-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+.push-row input {
+  cursor: pointer;
 }
 .cost-grid {
   display: flex;

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -9,6 +9,11 @@ import type { UserMcpServer } from "../components/userMcp";
 // other (each useAppConfig() otherwise has its own local refs).
 const soundFile = ref<string | null>(null);
 
+// Whether the server sends a Web Push when a task finishes — a SINGLETON like the
+// others so the settings toggle (openable from either view) reflects the saved state.
+// The actual sending is server-side; the client only reads/writes this flag.
+const pushEnabled = ref(false);
+
 // Cross-repo PR list's repos — also a SINGLETON, so the settings modal (openable from
 // either view) and any future reader share one list; a save in one view is seen by the
 // other instead of each useAppConfig() keeping a divergent copy.
@@ -161,6 +166,12 @@ async function saveSound(file: string | null): Promise<boolean> {
   if (r.ok) soundFile.value = typeof r.value === "string" ? r.value : null;
   return r.ok;
 }
+// Persist the "send a Web Push on task finish" toggle (partial update).
+async function savePushEnabled(on: boolean): Promise<boolean> {
+  const r = await postConfigField<unknown>("pushEnabled", on);
+  if (r.ok) pushEnabled.value = r.value === true;
+  return r.ok;
+}
 // Persist the cross-repo PR list's repos (partial update, other fields untouched).
 async function savePrRepos(next: string[]): Promise<boolean> {
   const r = await postConfigField<string[]>("prRepos", next);
@@ -202,6 +213,7 @@ export function useAppConfig() {
       home.value = c.home ?? null;
       adoptServerPresets(c.cwdPresets, version);
       soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
+      pushEnabled.value = c.pushEnabled === true;
       prRepos.value = Array.isArray(c.prRepos) ? c.prRepos : [];
       launchers.value = Array.isArray(c.launchers) ? c.launchers : [];
       userMcpServers.value = Array.isArray(c.userMcpServers) ? c.userMcpServers : [];
@@ -219,6 +231,7 @@ export function useAppConfig() {
     launchers,
     userMcpServers,
     soundFile,
+    pushEnabled,
     saving,
     error,
     loadConfig,
@@ -226,6 +239,7 @@ export function useAppConfig() {
     recordPreset,
     removePreset,
     saveSound,
+    savePushEnabled,
     savePrRepos,
     saveLaunchers,
     saveUserMcpServers,


### PR DESCRIPTION
## Summary

Opt-in **Web Push on task finish**. When enabled in Settings, the server calls the separate `mulmoserver` `sendPush` Cloud Function each time a **background** task finishes, so the user's phone/devices are notified for the panes they aren't watching. MulmoTerminal only makes the send call — device registration, delivery, and dead-token pruning are the server's job.

- **Server-side send** (chosen over browser-side) so it works even with the browser tab closed, as long as the machine is up.
- **Auth** = the RemoteHost channel's Firebase sign-in (project `mulmoserver`, same as `sendPush`). `auth.currentUser.getIdToken()` → `sendPush`. ⇒ push only fires **while RemoteHost is connected**; otherwise a silent no-op.
- **Trigger** = `handleActivityHook` on `event === "Stop" && !active` — one push per finished background turn (the viewed pane is `active` → skipped, like the attention chime; also avoids the double-publish a background Stop causes on the raw stream).
- **Toggle** = new `pushEnabled` global config field, read live at the hook (no restart), persisted via `POST /api/config`. Mirrors the existing `soundFile` plumbing.
- **New `server/web-push.ts`** calls `sendPush` with an `AbortController` timeout; pure `buildSendPushBody` / `parseSendPushResult`; no-ops (returns null, never throws/fetches) when not signed in.

## Items to Confirm / Review

- **Prerequisite is intentional:** push requires **RemoteHost connected** + at least one registered device. With either missing, the toggle is a no-op. Confirm that's acceptable for v1 (browser-side fallback is a listed follow-up).
- **Trigger scope:** fires on `Stop` for **background** panes only (not the pane you're actively viewing, and not on `Notification`/blocked-on-input). Matches the attention-chime semantics and "notify me about the ones I'm not watching". Confirm this is the intended "タスクが終わるたび".
- **Notification content:** title = project dir basename, body = the last prompt (falls back to "タスクが完了しました"). Tune if you'd prefer the AI summary or a different shape.

## Verification

- **Unit-tested:** `sanitizePushEnabled`; config load/save round-trip incl. `pushEnabled`; `buildSendPushBody` / `parseSendPushResult`; and `sendWebPush` **no-ops without fetching when not signed in**.
- Gates: format / lint (0 errors) / typecheck / build / test (**1070**).
- **Manual (you):** actual push delivery needs your Google sign-in (RemoteHost connected) + a registered device — please verify a real push arrives after connecting RemoteHost and enabling the toggle.

## User Prompt

> [mulmoserver docs/web-push-sending.md] これ、web pushの実装方法。サーバは別途あるのでここでは送信だけしたい。送信するかどうかは、設定画面でon/offしたい。とりあえず通知は、タスクが終わるたびに送りたい。できる?

Plan: `plans/feat-web-push-on-task-finish.md`. Closes #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)