### PR TITLE
fix: repaint terminal on reattach/reactivation so grid cells aren't blank (#344)

### DIFF
--- a/plans/fix-344-grid-terminal-blank.md
+++ b/plans/fix-344-grid-terminal-blank.md
@@ -1,0 +1,32 @@
+# fix #344 — grid で放置→復活/reload 時にターミナルが空表示
+
+## 症状
+grid view で、放置してセッションが切れた後、復活や reload でターミナルが何も表示されない。
+スクロール／reload で直ることがある。
+
+## 根本原因
+xterm は `host` div に一度だけ `open()` され、再アタッチ時に host を DOM 上で re-parent する
+（`useTerminalConnections`）。レンダラは **canvas**（CJK ずれ対策）。canvas renderer は
+re-parent 後や「サイズ不変の fit（no-op）」では自動再描画しない：
+
+- grid は `<KeepAlive>` 配下 → 離脱→復帰で `Terminal.vue` の `onActivated` が `conn.fit()` を呼ぶが
+  サイズ不変だと no-op → canvas が空のまま。
+- `attach()`（再アタッチ）も host を re-parent → 同様。
+- バッファは保持されるので、**スクロールで再描画されて直る**（＝データ喪失ではなく repaint 問題）。
+
+## 修正 — `src/composables/useTerminalConnections.ts`
+- `fit()` の末尾に `if (rows>0) term.refresh(0, rows-1)` を追加。fit が no-op でも canvas を強制再描画。
+  これで onActivated / ResizeObserver / 初回 RO 経由の全 fit が repaint を伴う。
+- `attach()`：re-parent 後、`requestAnimationFrame(() => fit(key))` で次フレームに再 fit+再描画
+  （sync fit が未レイアウトや no-op でも確実に repaint）。`attachedEl === el` ガードで
+  detach/再attach 済みスロットは触らない。
+
+## 非スコープ
+- WebGL レンダラへの切替（CJK 対策で canvas 採用のため）。
+- reload 直後の遅延バッファに対する追加 refresh（初回 ResizeObserver の fit で概ねカバー、
+  必要なら追随）。
+
+## テスト
+- レンダリング（xterm+DOM+rAF）のため単体テストは困難。手動確認：放置→復活/reload/タブ切替で空表示にならないこと。
+EOF
+echo "plan written"

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -348,6 +348,12 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
   c.term.scrollToBottom();
   c.term.focus();
+  // The persisted xterm was just re-parented into a new host. The sync fit() above can no-op (same size)
+  // or run before layout, leaving the canvas renderer blank until a scroll. Re-fit + force a repaint next
+  // frame, once the host is laid out. Guarded so a slot that detached/re-attached meanwhile is left alone.
+  requestAnimationFrame(() => {
+    if (c.attachedEl === el) fit(key);
+  });
 }
 
 // Unmount a view but KEEP the slot alive (socket stays open, PTY stays alive). The
@@ -480,6 +486,10 @@ export function fit(key: string) {
   if (c.ws?.readyState === WebSocket.OPEN) c.ws.send(JSON.stringify({ type: "resize", cols: c.term.cols, rows: c.term.rows }));
   // Reflow after a resize can leave the viewport scrolled up; stick to the bottom.
   c.term.scrollToBottom();
+  // Force the canvas renderer to repaint. `fit()` only redraws when cols/rows actually change, so a
+  // re-parent / KeepAlive reactivation with the SAME size (attach, onActivated) would otherwise leave
+  // the viewport blank until a scroll. The buffer is intact — this just repaints it.
+  if (c.term.rows > 0) c.term.refresh(0, c.term.rows - 1);
 }
 
 export function setTheme(key: string, theme: ITheme) {


### PR DESCRIPTION
## Summary

In **grid view**, reviving a dropped/idle session or reloading sometimes left a cell's terminal **blank**
until you scrolled (or reloaded again). The buffer was intact — it just wasn't being repainted.

**Root cause**: the persisted xterm is `open()`'d into a `host` div once and **re-parented** into a new
DOM host on attach. The renderer is the **canvas** addon (chosen to fix CJK drift), which doesn't repaint
on a DOM re-parent, and `FitAddon.fit()` only redraws when cols/rows actually change. The grid is under
`<KeepAlive>`, so navigating away/back fires `Terminal.vue`'s `onActivated → conn.fit()` with an
**unchanged** size — a no-op that never repaints — leaving the canvas blank. A scroll forces a redraw,
which is why scrolling "fixed" it.

**Fix** (`useTerminalConnections.ts`):
- `fit()` now calls `term.refresh(0, rows-1)` after fitting, so a same-size fit still repaints (covers
  `onActivated`, the ResizeObserver, and the initial observe).
- `attach()` schedules `requestAnimationFrame(() => fit(key))` after re-parenting, so a not-yet-laid-out
  or no-op sync fit still repaints next frame. Guarded by `attachedEl === el` so a slot that
  detached/re-attached in the meantime is left alone.

## Items to Confirm / Review

- **Repaint cost**: `term.refresh(0, rows-1)` is a full-viewport redraw, now run on every `fit()` (resize /
  reactivation) and once per attach frame — cheap and infrequent, but flagging.
- **Not unit-tested**: this is an xterm+canvas+rAF rendering path with no headless harness. Needs manual
  verification — please drive: leave a grid session idle until it drops, then revive / reload / switch
  tabs and confirm the terminal renders without a scroll.
- **Data-safe**: only forces a repaint of the existing buffer; no writes, no resize semantics changed.

## User Prompt

> しばらく放置したりするとセッションが切れていることがあるんだけど、それを復活したときや reload したときにターミナルが何も表示されないことがある。スクロールしたり reload すると直ることもある。grid view で。

## Implementation

`src/composables/useTerminalConnections.ts` — `fit()` refresh + `attach()` deferred re-fit. Plan:
`plans/fix-344-grid-terminal-blank.md`.

Closes #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
