### PR TITLE
fix: Web Push toggle isn't saved in the grid view

### DIFF
--- a/plans/fix-grid-view-push-toggle.md
+++ b/plans/fix-grid-view-push-toggle.md
@@ -1,0 +1,41 @@
+# fix: Web Push toggle isn't saved in the grid view (#347)
+
+## Symptom
+
+Settings → "Notify my devices when a task finishes" (Web Push, `pushEnabled`) is not
+saved **in the grid view**: the checkbox reads unchecked even when the server has
+`pushEnabled: true`, and toggling it does not persist (no `POST /api/config`).
+
+## Root cause
+
+There are TWO `<SettingsModal>` instances:
+- App.vue's (single view) — wired for push in #340.
+- **GridView.vue's (grid view) — never wired for push.**
+
+GridView's `<SettingsModal>` was missing `:push-enabled` and `@update-push-enabled`, so
+in the grid view the checkbox has no prop (renders `false` regardless of the saved
+value via `:checked="props.pushEnabled ?? false"`) and toggling emits an event nothing
+handles (no save). The user was in the grid view, so it looked "not saved".
+
+## Fix
+
+`src/components/GridView.vue`:
+- Pull `pushEnabled` + `savePushEnabled` from `useAppConfig()`.
+- Wire `:push-enabled="pushEnabled"` + `@update-push-enabled="savePushEnabled"` on
+  `<SettingsModal>`, matching App.vue.
+
+## Verification
+
+- Puppeteer (current source, vite): before → grid checkbox `false` while `/api/config`
+  `pushEnabled: true`, toggling fired no POST. After → checkbox reflects config, toggling
+  POSTs `{ pushEnabled }` and persists (verified across close/reopen).
+- Added `SettingsModal.spec` coverage: the push checkbox reflects the `pushEnabled` prop
+  and emits `update-push-enabled` on toggle.
+- Gates: format / lint / typecheck / build / test.
+
+## Out of scope (noted on the issue)
+
+An old mulmoterminal instance (pre-#340) sharing `~/.mulmoterminal/config.json` drops
+`pushEnabled` on any config write because its schema doesn't know the field — restart /
+update such instances. A forward-compat "preserve unknown config keys" change could
+harden future version-skew but is separate.

--- a/src/components/GridView.spec.ts
+++ b/src/components/GridView.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// The grid subscribes to the pub/sub socket on mount — stub it so no real socket opens.
+vi.mock("../composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+
+// Config GET hydrates pushEnabled=true; capture POSTs so we can assert the toggle saves.
+const posts: Array<{ url: string; body: unknown }> = [];
+beforeEach(() => {
+  posts.length = 0;
+  globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes("/api/config")) {
+      if (init?.method === "POST") posts.push({ url: u, body: init.body });
+      return {
+        ok: true,
+        json: async () => ({
+          cwd: "/w",
+          home: "/w",
+          cwdPresets: [],
+          soundFile: null,
+          pushEnabled: true,
+          prRepos: [],
+          launchers: [],
+          userMcpServers: [],
+          buttons: null,
+          chips: null,
+        }),
+      } as Response;
+    }
+    return { ok: true, json: async () => ({}) } as Response;
+  }) as typeof fetch;
+});
+
+// A SettingsModal stub whose props we can inspect + whose emits we can drive.
+const SettingsStub = {
+  name: "SettingsModal",
+  props: ["soundFile", "pushEnabled", "prRepos", "launchers", "userMcpServers", "cwd", "sessionId"],
+  emits: ["update-push-enabled", "close"],
+  template: '<div class="settings-stub" />',
+};
+// A toolbar stub that lets us open the settings modal (GridView: @settings="showSettings = true").
+const ToolbarStub = { name: "AppToolbar", emits: ["settings"], template: '<button class="open-settings" @click="$emit(\'settings\')" />' };
+
+const mountGrid = async () => {
+  const w = mount((await import("./GridView.vue")).default, {
+    global: { stubs: { TerminalGrid: true, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
+  });
+  await flushPromises(); // onMounted loadConfig
+  return w;
+};
+
+describe("GridView settings wiring", () => {
+  it("passes pushEnabled to SettingsModal and saves it on update-push-enabled (regression #347)", async () => {
+    const w = await mountGrid();
+    await w.find(".open-settings").trigger("click"); // open the settings modal
+    const modal = w.findComponent(SettingsStub);
+    expect(modal.exists()).toBe(true);
+    // The grid view must reflect the saved config, not a default false.
+    expect(modal.props("pushEnabled")).toBe(true);
+
+    // Toggling in the grid view must persist via POST /api/config.
+    modal.vm.$emit("update-push-enabled", false);
+    await flushPromises();
+    const pushPost = posts.find((p) => String(p.body).includes("pushEnabled"));
+    expect(pushPost, "toggling push should POST /api/config").toBeTruthy();
+    expect(String(pushPost?.body)).toContain('"pushEnabled":false');
+  });
+});

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -248,6 +248,7 @@ const {
   home,
   presets,
   soundFile,
+  pushEnabled,
   prRepos,
   launchers,
   userMcpServers,
@@ -255,6 +256,7 @@ const {
   recordPreset,
   removePreset,
   saveSound,
+  savePushEnabled,
   savePrRepos,
   saveLaunchers,
   saveUserMcpServers,
@@ -320,10 +322,12 @@ function configureAppearance() {
     <SettingsModal
       v-if="showSettings"
       :sound-file="soundFile"
+      :push-enabled="pushEnabled"
       :pr-repos="prRepos"
       :launchers="launchers"
       :user-mcp-servers="userMcpServers"
       @update-sound="saveSound"
+      @update-push-enabled="savePushEnabled"
       @update-repos="savePrRepos"
       @update-launchers="saveLaunchers"
       @update-user-mcp="saveUserMcpServers"

--- a/src/components/SettingsModal.spec.ts
+++ b/src/components/SettingsModal.spec.ts
@@ -45,6 +45,21 @@ describe("SettingsModal", () => {
     expect(w.emitted("update-sound")?.at(-1)?.[0]).toBeNull(); // back to the chime
   });
 
+  it("reflects pushEnabled and emits update-push-enabled on toggle", async () => {
+    const w = mountModal({ pushEnabled: true });
+    const box = w.find<HTMLInputElement>(".push-row input");
+    expect(box.element.checked).toBe(true);
+    await box.setValue(false);
+    expect(w.emitted("update-push-enabled")?.at(-1)?.[0]).toBe(false);
+
+    // Defaults to unchecked when the prop is unset, and emits true when toggled on.
+    const w2 = mountModal({});
+    const box2 = w2.find<HTMLInputElement>(".push-row input");
+    expect(box2.element.checked).toBe(false);
+    await box2.setValue(true);
+    expect(w2.emitted("update-push-enabled")?.at(-1)?.[0]).toBe(true);
+  });
+
   it("Browse fills the sound path from the OS file picker and applies it", async () => {
     globalThis.fetch = (async () => ({ ok: true, json: async () => ({ paths: ["/picked/sound.ogg"] }) })) as unknown as typeof fetch;
     const w = mountModal({ soundFile: null });


### PR DESCRIPTION
## Summary

The Settings **"Notify my devices when a task finishes"** (Web Push) toggle wasn't saved **in the grid view**: the checkbox showed unchecked even when the server had `pushEnabled: true`, and toggling it didn't persist.

**Root cause:** `GridView.vue` renders its **own** `<SettingsModal>` (App.vue has the single-view copy). When the Web Push toggle shipped (#340), only App.vue's copy was wired — GridView's was never given `:push-enabled` / `@update-push-enabled`. So in the grid view the checkbox had no prop (rendered `false` via `:checked="props.pushEnabled ?? false"`) and toggling emitted an event nothing handled (no save). The single view worked; the grid view didn't.

**Fix:** wire `:push-enabled="pushEnabled"` + `@update-push-enabled="savePushEnabled"` on GridView's `<SettingsModal>` (pulling `pushEnabled` / `savePushEnabled` from `useAppConfig`), matching App.vue.

## Verification

- **Puppeteer (current source via vite):** before the fix, the grid checkbox read `false` while `/api/config` had `pushEnabled: true`, and toggling fired **no** `POST /api/config`. After the fix, the checkbox reflects the config, toggling POSTs `{ pushEnabled }` and persists across close/reopen.
- Added `SettingsModal.spec` coverage: the push checkbox reflects the `pushEnabled` prop and emits `update-push-enabled` on toggle.
- Gates: format / lint (0 errors) / typecheck / build / test (1079).

## Note (separate issue)

An **old** mulmoterminal instance (pre-#340) sharing `~/.mulmoterminal/config.json` also drops `pushEnabled` on any config write (its schema doesn't know the field) — restart/update such instances. A forward-compat "preserve unknown config keys" change could harden future version-skew but is out of scope here.

## User Prompt

> Notify my devices when a task finishesは保存されないね

Plan: `plans/fix-grid-view-push-toggle.md`. Closes #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)