### PR TITLE
refactor: adopt @mulmobridge/web-push for the sendPush send core

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@google/genai": "^2.10.0",
     "@marp-team/marp-core": "^4.3.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@mulmobridge/web-push": "^0.1.0",
     "@mulmochat-plugin/generate-image": "^0.5.0",
     "@mulmochat-plugin/ui-image": "^0.4.0",
     "@mulmoclaude/accounting-plugin": "^0.3.2",

--- a/plans/refactor-adopt-mulmobridge-web-push.md
+++ b/plans/refactor-adopt-mulmobridge-web-push.md
@@ -1,0 +1,40 @@
+# refactor: adopt `@mulmobridge/web-push` for the sendPush send core
+
+Issue: receptron/mulmoterminal#354
+
+## Goal
+
+Make one package the single source of truth for the mulmoserver `sendPush` wire contract
+(`{ data: { title, body } }` → `{ result: { sent, failed, targets } }`) so MulmoClaude and
+MulmoTerminal can't drift when the contract changes. Pure refactor — no behavior change.
+
+## What changes
+
+- Add dep `@mulmobridge/web-push@^0.1.0` (first `@mulmobridge/*` dep in this repo).
+- `server/web-push.ts`: delete the local `SEND_PUSH_URL` / `SEND_PUSH_TIMEOUT_MS` /
+  `SendPushResult` / `buildSendPushBody` / `parseSendPushResult` / `sendWebPush` bodies;
+  re-implement `sendWebPush(title, body)` as a thin wrapper over the package's
+  `sendWebPush`, injecting the existing `currentIdToken` provider so **callers stay
+  unchanged** (`server/index.ts:1134` still calls `void sendWebPush(title, body)`).
+- `server/web-push.spec.ts`: the pure `buildSendPushBody` / `parseSendPushResult` unit
+  tests now live in the package; keep only the wiring test (`sendWebPush` no-ops / never
+  fetches when RemoteHost isn't signed in).
+
+## What stays
+
+- `notifyTaskFinished`, `pushEnabled`, and the `handleActivityHook` `Stop && !active`
+  trigger in `server/index.ts` — untouched.
+- RemoteHost auth (`currentIdToken` from `backends/remoteHost/session.ts`) — untouched.
+
+## Verified against the installed package (0.1.0)
+
+`sendWebPush(title, body, { getIdToken, url?, timeoutMs?, fetchImpl? }): Promise<SendPushResult | null>`,
+`SendPushResult { sent, failed, targets }`, `buildSendPushBody`, `parseSendPushResult`,
+`DEFAULT_SEND_PUSH_URL`. No-op (never fetches) when `getIdToken` yields null; 8 s
+AbortController timeout; never throws — same guarantees as the code being removed.
+
+## Acceptance
+
+- `sendPush` still fires on a background task finish with a device registered.
+- Local envelope/parse/URL logic removed; only the package is used.
+- Gates green (format / lint / typecheck / typecheck:server / build / test).

--- a/server/web-push.spec.ts
+++ b/server/web-push.spec.ts
@@ -1,34 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
-import { buildSendPushBody, parseSendPushResult, sendWebPush } from "./web-push";
+import { sendWebPush } from "./web-push";
 
-describe("buildSendPushBody", () => {
-  it("wraps title/body in the onCall `data` envelope", () => {
-    expect(JSON.parse(buildSendPushBody("✅ proj", "done"))).toEqual({ data: { title: "✅ proj", body: "done" } });
-  });
-});
-
-describe("parseSendPushResult", () => {
-  it("reads sent/failed/targets from the onCall `result` envelope", () => {
-    expect(parseSendPushResult({ result: { sent: 1, failed: 0, targets: 2 } })).toEqual({ sent: 1, failed: 0, targets: 2 });
-  });
-
-  it("treats missing / non-number counts as 0", () => {
-    expect(parseSendPushResult({ result: {} })).toEqual({ sent: 0, failed: 0, targets: 0 });
-    expect(parseSendPushResult({ result: { sent: "x", targets: null } })).toEqual({ sent: 0, failed: 0, targets: 0 });
-  });
-
-  it("returns null when the shape isn't a result envelope", () => {
-    expect(parseSendPushResult(null)).toBeNull();
-    expect(parseSendPushResult({})).toBeNull();
-    expect(parseSendPushResult({ result: 5 })).toBeNull();
-    expect(parseSendPushResult("nope")).toBeNull();
-  });
-});
-
-describe("sendWebPush", () => {
+// The envelope/parse/timeout logic is unit-tested in @mulmobridge/web-push; here we only
+// verify the wiring — that our RemoteHost token provider is injected into the shared sender.
+describe("sendWebPush (wiring)", () => {
   it("no-ops (returns null, never fetches) when RemoteHost isn't signed in", async () => {
-    // In tests the remote-host Firebase auth has no currentUser (never connected), so a
-    // push must be skipped entirely — a failed/absent auth must not throw or hit the network.
+    // With no RemoteHost session, currentIdToken yields null, so the shared sender must skip
+    // the network entirely — a failed/absent auth must not throw or hit the wire.
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     expect(await sendWebPush("✅ proj", "done")).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();

--- a/server/web-push.ts
+++ b/server/web-push.ts
@@ -1,56 +1,8 @@
-// Send a Web Push via the mulmoserver `sendPush` Cloud Function when a task finishes
-// (see mulmoserver docs/web-push-sending.md). We only POST { title, body }; the target
-// devices are resolved server-side from the signed-in user's uid, and registration /
-// delivery / dead-token pruning are the server's job. Auth comes from the RemoteHost
-// channel's Firebase sign-in, so this no-ops whenever RemoteHost isn't connected.
+// Fire a Web Push via mulmoserver's `sendPush` when a task finishes. The wire contract and
+// send core live in @mulmobridge/web-push (shared with MulmoClaude so the two can't drift);
+// here we inject the RemoteHost Firebase sign-in as the token provider, so this no-ops
+// whenever RemoteHost isn't connected (currentIdToken yields null → no network call, no throw).
+import { sendWebPush as sendPush, type SendPushResult } from "@mulmobridge/web-push";
 import { currentIdToken } from "./backends/remoteHost/session.js";
 
-// asia-northeast1 onCall endpoint for the `mulmoserver` project. Mirrors the firebase
-// config in backends/remoteHost/firebase.ts — keep in sync if the project id changes.
-export const SEND_PUSH_URL = "https://asia-northeast1-mulmoserver.cloudfunctions.net/sendPush";
-const SEND_PUSH_TIMEOUT_MS = 8000;
-
-export interface SendPushResult {
-  sent: number;
-  failed: number;
-  targets: number;
-}
-
-// The onCall wire shape wraps the payload in `data`.
-export function buildSendPushBody(title: string, body: string): string {
-  return JSON.stringify({ data: { title, body } });
-}
-
-// The onCall response wraps the payload in `result`. Missing/!number counts read as 0.
-export function parseSendPushResult(json: unknown): SendPushResult | null {
-  if (typeof json !== "object" || json === null) return null;
-  const result = (json as { result?: unknown }).result;
-  if (typeof result !== "object" || result === null) return null;
-  const r = result as Record<string, unknown>;
-  const num = (v: unknown): number => (typeof v === "number" ? v : 0);
-  return { sent: num(r.sent), failed: num(r.failed), targets: num(r.targets) };
-}
-
-// POST { title, body } to sendPush as the RemoteHost-signed-in user. Returns the delivery
-// result, or null when nothing was sent (not signed in / network / timeout / non-2xx).
-// Never throws — a failed push must not disturb the hook that triggered it.
-export async function sendWebPush(title: string, body: string): Promise<SendPushResult | null> {
-  const idToken = await currentIdToken();
-  if (!idToken) return null; // RemoteHost not connected → no auth → nothing to send with
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), SEND_PUSH_TIMEOUT_MS);
-  try {
-    const res = await fetch(SEND_PUSH_URL, {
-      method: "POST",
-      headers: { "content-type": "application/json", authorization: `Bearer ${idToken}` },
-      body: buildSendPushBody(title, body),
-      signal: controller.signal,
-    });
-    if (!res.ok) return null;
-    return parseSendPushResult(await res.json());
-  } catch {
-    return null; // offline / aborted / bad JSON — silently skip; the beep still fired
-  } finally {
-    clearTimeout(timeout);
-  }
-}
+export const sendWebPush = (title: string, body: string): Promise<SendPushResult | null> => sendPush(title, body, { getIdToken: currentIdToken });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,6 +1380,11 @@
     zod "^3.25 || ^4.0"
     zod-to-json-schema "^3.25.1"
 
+"@mulmobridge/web-push@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mulmobridge/web-push/-/web-push-0.1.0.tgz#c7a6ec6dd0362b85facd460d87c54e331dfda2fe"
+  integrity sha512-pbNptXumkQuK68Hy91MDrvoQ4+CgdjM/MIOyfkEfXj65yyxMi6XtkNAWjnRwI/f6fNmbiZnWeM3QOAso6zw55w==
+
 "@mulmochat-plugin/generate-image@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@mulmochat-plugin/generate-image/-/generate-image-0.5.0.tgz#520ab5342c4c71d6c4adc7bceabf9a19829f0c92"


### PR DESCRIPTION
## Summary

Replaces MulmoTerminal's local `sendPush` send core in `server/web-push.ts` with the shared **[`@mulmobridge/web-push`](https://www.npmjs.com/package/@mulmobridge/web-push)** (`@0.1.0`, published from MulmoClaude). One package is now the single source of truth for the `sendPush` wire contract (`{ data: { title, body } }` → `{ result: { sent, failed, targets } }`), so MulmoClaude and MulmoTerminal can't drift when mulmoserver changes it.

**Pure refactor — no behavior change.** `pushEnabled`, `notifyTaskFinished`, the `Stop && !active` trigger, and RemoteHost auth are all untouched.

## Items to Confirm / Review

- **Thin wrapper, callers unchanged.** `sendWebPush(title, body)` keeps its 2-arg signature; the only caller (`server/index.ts` → `void sendWebPush(title, body)`) is untouched. The RemoteHost token provider (`currentIdToken`) is injected into the package's sender.
- **Same guarantees as the removed code** (verified against the installed `0.1.0` `.d.ts`): no-op / never fetches when `getIdToken` yields null (RemoteHost disconnected), 8 s `AbortController` timeout, never throws.
- **Spec trimmed intentionally.** The pure `buildSendPushBody` / `parseSendPushResult` unit tests now live in the package; MulmoTerminal keeps only the wiring test (no-ops / never fetches when not signed in).
- First `@mulmobridge/*` dependency in this repo.

## Implementation

- `yarn add @mulmobridge/web-push@^0.1.0`
- `server/web-push.ts`: deleted local `SEND_PUSH_URL` / `SEND_PUSH_TIMEOUT_MS` / `SendPushResult` / `buildSendPushBody` / `parseSendPushResult` / `sendWebPush` bodies; re-implemented `sendWebPush` as a one-line wrapper over the package (56 → 8 lines).
- `server/web-push.spec.ts`: dropped the pure build/parse tests; kept the wiring test.
- Plan: `plans/refactor-adopt-mulmobridge-web-push.md`.

Gates green: format / lint / typecheck / typecheck:server / build / test (1103 pass).

## User Prompt

> 354を。

(Implement issue #354 — refactor: adopt `@mulmobridge/web-push` for the sendPush send core.)

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)