### PR TITLE
feat: fire Web Push on every finished turn (drop the active-pane exemption)

### DIFF
--- a/plans/feat-push-on-every-turn.md
+++ b/plans/feat-push-on-every-turn.md
@@ -1,0 +1,43 @@
+# feat: Web Push fires on every finished turn (drop the active-pane exemption)
+
+## Problem
+
+Web Push only fired for a finished turn on a session the user was NOT actively viewing
+(`event === "Stop" && !active`) — the same suppression the attention beep uses. So the
+session the user is driving in the single view (or the zoomed grid cell) never pushed,
+because it is always `active` (see `terminalViewActive`: single view is active whenever
+shown; a grid cell is active while zoomed). `active` is pane-selection based, not window
+focus based, so even backgrounding the browser did not fire it.
+
+Diagnosed live via temporary hook instrumentation: a real Stop for the viewed session
+logged `active=true` → suppressed; an eligible background Stop logged `active=false` and
+reached the sender. (The dominant real-world cause of "no push" was a *separate* issue —
+the server-side RemoteHost session dropping on restart while the browser UI still showed
+"connected" — tracked separately.)
+
+## Decision
+
+Per the user: **notify on every finished turn, regardless of active.** The attention beep
+keeps its active-pane suppression (you are looking at it); only the phone push ignores it.
+
+## Change
+
+- `server/activity-hook.ts`: add pure `shouldNotifyTaskFinished(event) => event === "Stop"`
+  (deliberately takes no `active` — documents/locks in that the push is not pane-gated).
+- `server/index.ts` `handleActivityHook`: replace `event === "Stop" && !active` with
+  `shouldNotifyTaskFinished(event)`. `notifyTaskFinished` keeps its pushEnabled / hidden /
+  translation-worker gates and its single-fire-per-turn guarantee.
+- `server/activity-hook.spec.ts`: cover the new predicate (Stop → true; non-Stop → false).
+
+## Trade-off (accepted by the user)
+
+Every finished turn of every non-hidden session now pushes — including the session being
+watched. With multiple registered devices, each push lands on all of them. If this proves
+noisy, a follow-up could gate on window focus/visibility ("notify only when you're away")
+instead of pane selection, or add a per-session opt-out.
+
+## Acceptance
+
+- A Stop on the actively-viewed session now sends a push (was suppressed).
+- The attention beep is unchanged (`activityHookEffects` untouched).
+- Gates green (format / lint / typecheck / typecheck:server / build / test).

--- a/server/activity-hook.spec.ts
+++ b/server/activity-hook.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { activityHookEffects } from "./activity-hook.js";
+import { activityHookEffects, shouldNotifyTaskFinished } from "./activity-hook.js";
 
 describe("activityHookEffects", () => {
   it("UserPromptSubmit sets working regardless of active", () => {
@@ -33,5 +33,20 @@ describe("activityHookEffects", () => {
   it("ignores unrelated events", () => {
     expect(activityHookEffects("PreToolUse", false)).toEqual([]);
     expect(activityHookEffects("SessionStart", true)).toEqual([]);
+  });
+});
+
+describe("shouldNotifyTaskFinished", () => {
+  it("fires on every finished turn — unlike the beep, the actively-viewed pane is NOT exempt", () => {
+    // The push takes no `active` argument by design: a Stop notifies whether or not the user
+    // is looking at that pane. This regression-guards against re-adding an active-pane gate.
+    expect(shouldNotifyTaskFinished("Stop")).toBe(true);
+  });
+
+  it("does not fire on non-Stop events (a paused turn / prompt / tool use is not a finish)", () => {
+    expect(shouldNotifyTaskFinished("Notification")).toBe(false);
+    expect(shouldNotifyTaskFinished("UserPromptSubmit")).toBe(false);
+    expect(shouldNotifyTaskFinished("PreToolUse")).toBe(false);
+    expect(shouldNotifyTaskFinished("SessionStart")).toBe(false);
   });
 });

--- a/server/activity-hook.ts
+++ b/server/activity-hook.ts
@@ -26,3 +26,12 @@ export function activityHookEffects(event: string, active: boolean): ActivityEff
   if (event === "Notification") return active ? [] : [{ kind: "waiting", value: true }];
   return [];
 }
+
+// Whether a finished turn should fire a task-finished Web Push. Unlike the attention beep
+// (activityHookEffects, which stays quiet on the actively-viewed pane), the push fires for
+// EVERY finished turn regardless of `active` — the user wants a phone notification even for
+// the session they're currently looking at. The pushEnabled / hidden / translation gates
+// are applied by the caller.
+export function shouldNotifyTaskFinished(event: string): boolean {
+  return event === "Stop";
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -42,7 +42,7 @@ import { publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "./dir-confi
 import { loadScripts, resolveScript } from "./scripts.js";
 import { buildClaudeArgs } from "./claude-args.js";
 import { resolveSession, type SessionResolution } from "./session-resolve.js";
-import { activityHookEffects } from "./activity-hook.js";
+import { activityHookEffects, shouldNotifyTaskFinished } from "./activity-hook.js";
 import { buildActivitySnapshot, parseActivityState } from "./activity-state.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
@@ -1113,10 +1113,10 @@ function handleActivityHook(sessionId: string, event: string, active: boolean) {
     if (eff.kind === "working") setWorking(sessionId, eff.value, event);
     else setWaiting(sessionId, eff.value, event);
   }
-  // A background turn just ended (same attention-flag semantics as the beep: not the pane
-  // the user is viewing) → push once. Stop is one event per finished turn, so this fires
-  // once even though a background Stop publishes twice (waiting + working).
-  if (event === "Stop" && !active) notifyTaskFinished(sessionId);
+  // Every finished turn fires a Web Push (see shouldNotifyTaskFinished) — regardless of
+  // whether it's the actively-viewed pane, unlike the attention beep. Stop is one event per
+  // finished turn, so this fires once even though a background Stop publishes twice.
+  if (shouldNotifyTaskFinished(event)) notifyTaskFinished(sessionId);
 }
 
 const PUSH_TITLE_MAX = 80;


### PR DESCRIPTION
## Summary

Web Push now fires on **every** finished turn (`Stop`), not just turns on sessions the user isn't looking at. Previously the trigger was `event === "Stop" && !active`, so the session the user is actively driving (single view, or a zoomed grid cell) never pushed — it is always `active`, and `active` is pane-selection based (`terminalViewActive`), not window-focus based, so even backgrounding the browser didn't help.

The attention **beep** keeps its active-pane suppression (`activityHookEffects` is untouched); only the **push** now ignores `active`.

## Items to Confirm / Review

- **Intended trade-off:** every finished turn of every non-hidden session now pushes — *including the session you're watching* — and lands on every registered device. This was explicitly requested ("どんなときでも飛ばせば良い"). If it turns out noisy, a follow-up can gate on window focus/visibility instead of pane selection, or add a per-session opt-out.
- `notifyTaskFinished` still gates on `pushEnabled`, `hiddenSessions`, and `translationWorkerIds`, and still fires once per finished turn.
- `shouldNotifyTaskFinished(event)` deliberately takes **no** `active` argument, so the pane-gate can't silently creep back in; a regression test locks this.

## Change

- `server/activity-hook.ts`: pure `shouldNotifyTaskFinished(event) => event === "Stop"`.
- `server/index.ts` `handleActivityHook`: use it in place of `event === "Stop" && !active`.
- `server/activity-hook.spec.ts`: predicate tests (Stop → true; Notification / UserPromptSubmit / PreToolUse / SessionStart → false).
- Plan: `plans/feat-push-on-every-turn.md`.

Gates green: format / lint / typecheck / typecheck:server / build / test (1109 pass).

## Context

Found while diagnosing "the test push arrives but real task completions don't." Two causes surfaced: (1) the session being watched is `active` → suppressed (this PR), and (2) — the dominant real-world one — the server-side RemoteHost session silently dropping on a server restart while the browser UI still shows "connected", so pushes no-op with `result: null`. (2) is a separate reconnect-gap issue to be addressed on its own.

## User Prompt

> この会話の完了時にはこないよ。 … どんなときでも飛ばせば良いよ

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)