### PR TITLE
feat: self-heal the RemoteHost session after a server restart (no manual reload)

### DIFF
--- a/plans/feat-remote-host-self-heal.md
+++ b/plans/feat-remote-host-self-heal.md
@@ -1,0 +1,44 @@
+# feat: self-heal the RemoteHost session after a server restart
+
+Issue: receptron/mulmoterminal#358
+
+## Problem
+
+RemoteHost is case-A' browser-parked: the session blob lives in `localStorage`
+(`remoteHost.session`) and is re-pushed to the server via `POST /api/remote-host/reconnect`
+(`tryAutoReconnect`). But that re-push was only triggered in `onMounted` — **on page load**.
+
+So a server restart (dev `--watch`, crash, redeploy) while the tab stays open leaves the
+server with no in-memory session, the UI still showing "connected", and every Web Push
+silently no-oping (`result: null`) until a manual reload. This recurred repeatedly during
+development. (Sibling mulmoclaude is the same case-A' model and also only restores on mount —
+no live self-heal — so this is net-new here and can be ported back.)
+
+## Fix (client-only — no server change, no server restart to ship)
+
+Trigger the existing `refreshStatus() → tryAutoReconnect()` on the signals that mean
+"the server may have come back / we returned":
+
+- `usePubSub().onReconnect` — the socket.io reconnect event already used by
+  `useSessions`/`useGridActivity`/`useNotifications` as the "server came back" signal.
+- `window 'online'` and `document 'visibilitychange'` (only when becoming visible) — network
+  and sleep/tab-refocus recovery.
+
+No new heal logic — `tryAutoReconnect` already re-pushes the parked blob and drops it only on
+a 401 (genuinely expired). Healing while already connected is a cheap no-op, so over-triggering
+is safe.
+
+## Files
+
+- `src/components/remoteHostSelfHeal.ts` — pure `registerRemoteHostSelfHeal(heal, onReconnect)`
+  returning a cleanup; split out so the wiring is testable without mounting the Firebase component.
+- `src/components/remoteHostSelfHeal.spec.ts` — heals on each trigger; cleanup unregisters all;
+  no heal on visibilitychange while going hidden.
+- `src/components/RemoteHostControl.vue` — add `selfHeal()`, register on mount via `onReconnect`
+  + the DOM listeners, unregister on unmount.
+
+## Acceptance
+
+- After a server restart with the tab open, the client re-pushes the parked session and
+  `connected` returns to true with no manual reload; Web Push resumes.
+- Gates green (format / lint / typecheck / build / test).

--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -15,6 +15,8 @@ import { auth } from "../config/firebase";
 // Session parking (localStorage) + reconnect-outcome decision live in a plain module
 // so they're unit-testable without mounting this Firebase-importing component.
 import { loadStoredSession, persistSession, reconnectAction, type FetchResult, type RemoteHostStatus } from "./remoteHostSession";
+import { registerRemoteHostSelfHeal } from "./remoteHostSelfHeal";
+import { usePubSub } from "../composables/usePubSub";
 
 // Mobile companion PWA — shown in the dropdown as help text (not fetched here).
 const MOBILE_URL = "https://mulmoserver.web.app";
@@ -135,14 +137,27 @@ async function onDisconnect() {
   busy.value = false;
 }
 
-// On mount, reflect the real connection state (not the default "disconnected"),
-// then auto-reconnect popup-free from a parked session if the server restarted.
-onMounted(() => {
-  refreshStatus()
+// Re-check the real connection state and, if the server dropped our parked session
+// (e.g. it restarted while this tab stayed open), re-push it popup-free.
+function selfHeal() {
+  return refreshStatus()
     .then(tryAutoReconnect)
     .catch(() => undefined);
+}
+
+// On mount: heal once. Then keep healing on the signals that mean the server may
+// have come back or we returned to the tab — without this a server restart leaves
+// the UI showing "connected" while every Web Push silently no-ops.
+const pubsub = usePubSub();
+let stopSelfHeal: (() => void) | null = null;
+onMounted(() => {
+  void selfHeal();
+  stopSelfHeal = registerRemoteHostSelfHeal(() => void selfHeal(), pubsub.onReconnect);
 });
-onUnmounted(close);
+onUnmounted(() => {
+  close();
+  stopSelfHeal?.();
+});
 </script>
 
 <template>

--- a/src/components/remoteHostSelfHeal.spec.ts
+++ b/src/components/remoteHostSelfHeal.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { registerRemoteHostSelfHeal } from "./remoteHostSelfHeal";
+
+describe("registerRemoteHostSelfHeal", () => {
+  it("heals on socket reconnect, window online, and return-to-visible; cleanup stops all", () => {
+    const heal = vi.fn();
+    const unsubscribe = vi.fn();
+    const registered: Array<() => void> = [];
+    const onReconnect = (cb: () => void) => {
+      registered.push(cb);
+      return unsubscribe;
+    };
+
+    const stop = registerRemoteHostSelfHeal(heal, onReconnect);
+    expect(registered).toHaveLength(1);
+
+    registered[0]?.(); // server came back
+    window.dispatchEvent(new Event("online")); // network restored
+    document.dispatchEvent(new Event("visibilitychange")); // visible (jsdom default)
+    expect(heal).toHaveBeenCalledTimes(3);
+
+    stop();
+    expect(unsubscribe).toHaveBeenCalledTimes(1); // socket reconnect listener removed
+    window.dispatchEvent(new Event("online"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(heal).toHaveBeenCalledTimes(3); // DOM listeners removed too
+  });
+
+  it("does NOT heal when a visibilitychange fires while the tab is going hidden", () => {
+    const heal = vi.fn();
+    const original = Object.getOwnPropertyDescriptor(Document.prototype, "visibilityState");
+    Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true });
+
+    const stop = registerRemoteHostSelfHeal(heal, () => () => undefined);
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(heal).not.toHaveBeenCalled();
+
+    stop();
+    if (original) Object.defineProperty(document, "visibilityState", original);
+  });
+});

--- a/src/components/remoteHostSelfHeal.ts
+++ b/src/components/remoteHostSelfHeal.ts
@@ -1,0 +1,24 @@
+// Wire the "the server may have come back / we returned to the tab" signals to a
+// self-heal callback, returning a cleanup that unregisters every listener. Kept out
+// of RemoteHostControl.vue so the trigger wiring is unit-testable without mounting
+// the Firebase-importing component (mirrors the remoteHostSession.ts split).
+//
+// The heal itself is a no-op when already connected, so firing a trigger spuriously
+// only costs one status check — safe to over-trigger, never under-trigger.
+type OnReconnect = (cb: () => void) => () => void;
+
+export function registerRemoteHostSelfHeal(heal: () => void, onReconnect: OnReconnect): () => void {
+  const onOnline = () => heal();
+  // A tab going hidden ALSO fires visibilitychange; only a return to visible warrants a heal.
+  const onVisible = () => {
+    if (document.visibilityState === "visible") heal();
+  };
+  const stopReconnect = onReconnect(heal);
+  window.addEventListener("online", onOnline);
+  document.addEventListener("visibilitychange", onVisible);
+  return () => {
+    stopReconnect();
+    window.removeEventListener("online", onOnline);
+    document.removeEventListener("visibilitychange", onVisible);
+  };
+}


### PR DESCRIPTION
## Summary

RemoteHost is case-A' browser-parked: the session blob lives in `localStorage` (`remoteHost.session`) and is re-pushed to the server via `POST /api/remote-host/reconnect` (`tryAutoReconnect`). But that re-push only fired in `onMounted` — **on page load**. So when the server process restarts (dev `--watch`, crash, redeploy) while the tab stays open, the server loses its in-memory session, the UI keeps showing "connected", and every Web Push silently no-ops (`result: null`) until a manual reload.

This PR triggers the **existing** self-heal on the signals that mean "the server may have come back / we returned to the tab", so it recovers on its own — no popup, no reload.

## Items to Confirm / Review

- **No new heal logic.** `tryAutoReconnect()` already does the right thing (re-push the parked blob; drop it only on a 401 = genuinely expired). This PR only adds *triggers*.
- **Triggers:** `usePubSub().onReconnect` (the socket.io reconnect event already consumed by `useSessions`/`useGridActivity`/`useNotifications` as the "server came back" signal) + `window 'online'` + `document 'visibilitychange'` (only when becoming visible).
- **Over-triggering is safe:** the heal is a no-op when already connected (one status check).
- **Client-only** (`src/`) — no server change, so shipping it doesn't restart the backend.
- Trigger wiring is a pure module (`remoteHostSelfHeal.ts`) so it's unit-testable without mounting the Firebase-importing `RemoteHostControl.vue` (mirrors the existing `remoteHostSession.ts` split).

## Context

Confirmed sibling behavior via investigation: **mulmoclaude** is also case-A' browser-parked and *also* only restores on mount — it has no live self-heal either. So this is net-new here and is a good candidate to port back to mulmoclaude (near-identical `RemoteHostControl.vue`).

## Files

- `src/components/remoteHostSelfHeal.ts` — `registerRemoteHostSelfHeal(heal, onReconnect)` → cleanup.
- `src/components/remoteHostSelfHeal.spec.ts` — heals on each trigger; cleanup unregisters all; no heal on visibilitychange while going hidden.
- `src/components/RemoteHostControl.vue` — `selfHeal()` wired on mount, torn down on unmount.
- `plans/feat-remote-host-self-heal.md`.

Gates green: format / lint / typecheck / typecheck:server / build / test (1107 pass).

## User Prompt

> 34567（--watch）が再起動 → RemoteHost セッションが落ちる、で「ログイン切れた」を何度も起こしてしまいました　って対策できる？
> … 永続化したいというのが出発点だよね … mulmoclaudeにあわせると、ブラウザ保持＋自己修復？

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)