### PR TITLE
feat: preset dir click fills the field (+ shows sessions) instead of launching immediately

### DIFF
--- a/plans/feat-preset-fills-not-launches.md
+++ b/plans/feat-preset-fills-not-launches.md
@@ -1,0 +1,37 @@
+# feat: preset dir click fills the field (+ shows sessions) instead of launching
+
+Issue: receptron/mulmoterminal#360
+
+## Problem
+
+In the grid new-terminal launch form (`TerminalCell.vue`, empty-cell state), clicking a
+directory **preset chip** immediately started a fresh session in that dir (`cell-chip-main`
+→ `selectPreset` → `launchIn`). The user had no chance to pick an existing session to
+resume (or the agent / a worktree / a script) first. The fill-without-launching behavior
+existed only on a small secondary ✎ button (`cell-chip-fill` → `fillDir`), easy to miss.
+
+## Decision (user-chosen)
+
+Swap the chip's two actions; keep a one-click quick-launch as a secondary button:
+- **Main click** → `fillDir`: fill the working-directory field WITHOUT launching, and load
+  the resume ("or resume here") / scripts / worktrees for that dir — the requested default.
+- **Secondary ▶ button** (was the ✎ fill button; class `cell-chip-fill` → `cell-chip-launch`,
+  icon `edit` → `play_arrow`) → `selectPreset`: the one-click quick launch, preserved.
+- **✕** delete button unchanged.
+
+The running-session warning (`isCwdRunning`) moves to the ▶ launch button (the risky action);
+the main button's title is just the path.
+
+## Files (client-only — no server change)
+
+- `src/components/TerminalCell.vue`: swap the two chip buttons' handlers; rename class + icon;
+  move the running-session title to the launch button; update the `selectPreset` / `fillDir`
+  role comments; rename `.cell-chip-fill` → `.cell-chip-launch` in `<style>`.
+- `src/components/TerminalCell.spec.ts`: main click now fills (no launch); the ▶ button
+  launches; the out-of-order test clicks the main button (now `fillDir`).
+
+## Acceptance
+
+- Clicking a preset chip fills the dir field and shows the resume list — no launch.
+- The chip's ▶ button still one-click launches a fresh session.
+- Gates green (format / lint / typecheck / build / test).

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -303,7 +303,7 @@ describe("TerminalCell", () => {
     await nextTick(); // mount → fetch #1 (dir A) in flight
     const chipB = w.findAll(".cell-chip").find((c) => c.find(".cell-chip-main").text() === "B");
     if (!chipB) throw new Error("preset B not found");
-    await chipB.find(".cell-chip-fill").trigger("click"); // fillDir → fetch #2 (dir B)
+    await chipB.find(".cell-chip-main").trigger("click"); // main click = fillDir → fetch #2 (dir B)
 
     second.resolve({ ok: true, json: async () => ({ cwd: "/B", sessions: [{ id: "b-id", title: "B-sess", mtime: 1 }] }) });
     await flushPromises();
@@ -326,26 +326,26 @@ describe("TerminalCell", () => {
     expect(w.findComponent({ name: "TerminalView" }).props("cwd")).toBe("/resolved");
   });
 
-  it("clicking a preset chip launches a fresh session in its dir", async () => {
+  it("clicking a preset chip's main button fills the dir WITHOUT launching (so the user can resume or start)", async () => {
     const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
     await flushPromises();
     const main = w.findAll(".cell-chip-main").find((b) => b.text() === "proj");
     if (!main) throw new Error("preset chip not found");
     await main.trigger("click");
-    const term = w.findComponent({ name: "TerminalView" });
-    expect(term.exists()).toBe(true);
-    expect(term.props("cwd")).toBe("/work/proj");
+    // No terminal — the main click only selects the directory (fill, not launch).
+    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
+    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/work/proj");
   });
 
-  it("a chip's fill button sets the dir WITHOUT launching (so the user can resume)", async () => {
+  it("the chip's ▶ launch button quick-starts a fresh session in its dir", async () => {
     const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
     await flushPromises();
     const chip = w.findAll(".cell-chip").find((c) => c.find(".cell-chip-main").text() === "proj");
     if (!chip) throw new Error("preset chip not found");
-    await chip.find(".cell-chip-fill").trigger("click");
-    // No terminal — the fill button only selects the directory.
-    expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/work/proj");
+    await chip.find(".cell-chip-launch").trigger("click");
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.exists()).toBe(true);
+    expect(term.props("cwd")).toBe("/work/proj");
   });
 
   it("emits record-cwd with the server-confirmed cwd of a fresh launch", async () => {
@@ -1465,10 +1465,11 @@ describe("TerminalCell", () => {
     const idle = chips.find((c) => c.text().includes("proj-b"));
     expect(running?.classes()).toContain("is-running");
     expect(running?.find(".cell-chip-dot").exists()).toBe(true);
-    // a11y: the running state is exposed in text, not just color/hover
-    expect(running?.find(".cell-chip-main").attributes("aria-label")).toContain("already running");
+    // a11y: the running state is exposed in text (on the ▶ launch button — the action that
+    // would actually double-launch there), not just color/hover.
+    expect(running?.find(".cell-chip-launch").attributes("aria-label")).toContain("already running");
     expect(idle?.classes()).not.toContain("is-running");
     expect(idle?.find(".cell-chip-dot").exists()).toBe(false);
-    expect(idle?.find(".cell-chip-main").attributes("aria-label")).toBeUndefined();
+    expect(idle?.find(".cell-chip-launch").attributes("aria-label")).not.toContain("already running");
   });
 });

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -283,15 +283,16 @@ function launchProgram(index: number, l: Launcher) {
   emit("launch", { index, label: l.label, cwd: dirInput.value.trim() || props.defaultCwd });
 }
 
-// A preset chip is a one-click action: fill the field and jump straight into a
-// fresh session in that dir.
+// The chip's ▶ button: a one-click quick launch — fill the field and jump straight
+// into a fresh session in that dir.
 function selectPreset(p: CwdPreset) {
   dirInput.value = p.path;
   launchIn(p.path);
 }
 
-// The chip's tiny end button: fill the field WITHOUT launching, and refresh the
-// resume / script / worktree lists for that dir so the user can resume there.
+// The chip's main click (and the 📁 folder picker): fill the field WITHOUT launching,
+// and refresh the resume / script / worktree lists for that dir so the user can pick a
+// session to resume — or start fresh — instead of launching immediately.
 function fillDir(path: string) {
   dirTouched.value = true;
   dirInput.value = path;
@@ -1059,20 +1060,22 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <button
             type="button"
             class="cell-chip-main"
-            :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here in another terminal` : p.path"
-            :aria-label="isCwdRunning(p.path) ? `${p.label} — a session is already running here in another terminal` : undefined"
-            @click="selectPreset(p)"
+            :title="p.path"
+            :aria-label="`Use ${p.label} — fill the field to browse / resume here (without launching)`"
+            @click="fillDir(p.path)"
           >
             <span v-if="isCwdRunning(p.path)" class="cell-chip-dot" aria-hidden="true" />{{ p.label }}
           </button>
           <button
             type="button"
-            class="cell-chip-fill"
-            :title="`Use ${p.path} without launching (browse / resume here)`"
-            :aria-label="`Use ${p.path} without launching`"
-            @click="fillDir(p.path)"
+            class="cell-chip-launch"
+            :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here in another terminal` : `Launch a new terminal in ${p.path} now`"
+            :aria-label="
+              isCwdRunning(p.path) ? `${p.label} — a session is already running here in another terminal` : `Launch a new terminal in ${p.label} now`
+            "
+            @click="selectPreset(p)"
           >
-            <span class="material-symbols-outlined">edit</span>
+            <span class="material-symbols-outlined">play_arrow</span>
           </button>
           <button
             type="button"
@@ -1535,7 +1538,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 .cell-chip.is-running .cell-chip-main {
   color: var(--text);
 }
-.cell-chip-fill {
+.cell-chip-launch {
   display: inline-flex;
   align-items: center;
   border: none;
@@ -1545,7 +1548,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   cursor: pointer;
   padding: 0 5px;
 }
-.cell-chip-fill .material-symbols-outlined {
+.cell-chip-launch .material-symbols-outlined {
   font-size: 14px;
 }
 .cell-chip-del {
@@ -1558,7 +1561,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   padding: 0 7px;
 }
 .cell-chip-main:hover,
-.cell-chip-fill:hover {
+.cell-chip-launch:hover {
   background: var(--bg-hover);
   color: var(--text);
 }


### PR DESCRIPTION
## Summary

In the grid new-terminal launch form, clicking a directory **preset chip** used to start a fresh session immediately — so you couldn't first pick an existing session to **resume** (or the agent / a worktree / a script). This swaps the chip's actions so selecting a dir **fills the field and reveals the "or resume here" list** instead, while keeping a one-click quick-launch on a small secondary button.

## Behavior

Preset chip: **`[ label  ▶  ✕ ]`**
- **`label` (main click)** → fills the working-directory field **without launching**, and loads the resume / scripts / worktrees for that dir. (was: launch immediately)
- **`▶` (secondary)** → one-click quick launch of a fresh session there. (was: the ✎ "fill" button; class `cell-chip-fill` → `cell-chip-launch`, icon `edit` → `play_arrow`)
- **`✕`** → remove the preset. (unchanged)

The running-session warning (`isCwdRunning`) moves to the `▶` launch button — the action that would actually double-launch there.

## Items to Confirm / Review

- **Design choice** (picked by the user): keep a one-click quick-launch as the `▶` button rather than dropping it. A fresh launch from a preset is now 2 clicks (fill → `▶`, or fill → the field's ▶ / Enter); the chip's own `▶` keeps it 1 click.
- Client-only (`TerminalCell.vue` + spec) — no server change.
- Tests updated: main click fills (no launch); `▶` launches; the running-session a11y text now asserts on `.cell-chip-launch`.

## Verify

Unit tests cover the swap. In the app: open the grid → add a terminal → click a preset chip → the field fills and "or resume here" appears (no terminal starts); click the chip's `▶` → a fresh session starts.

## User Prompt

> gridで新しいterminaを起動するときに、既存のworkdirを選択するとすぐに起動してsessionを選べない。既存のを選択したらひらかないでtext input部分に入力されて、そこからsessionも選択したい

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)