### PR TITLE
fix: don't double-fetch the resume/scripts/worktrees lists on a preset fill

### DIFF
--- a/plans/fix-preset-fill-dedup-load.md
+++ b/plans/fix-preset-fill-dedup-load.md
@@ -1,0 +1,32 @@
+# fix: don't double-fetch the resume/scripts/worktrees lists on a preset fill
+
+Follow-up to #360 / #361 (surfaced in an independent post-merge review).
+
+## Problem
+
+`fillDir(path)` loads the resume / scripts / worktrees lists **immediately**, and also sets
+`dirInput.value = path` — which triggers the `watch([dirInput, …])` that **debounces (300ms)
+and loads the same three lists again**. So every preset main-click / folder pick fetched each
+list twice. Correctness was fine (`resumableReq` request-token guard + idempotent GETs), but it
+was wasteful — and #361 made `fillDir` the primary path (every preset click), so it happened on
+the common flow.
+
+## Fix
+
+A one-shot `skipDirWatch` flag: `fillDir` sets it (only when the value actually changes, so a
+same-value click can't leave a stale flag that swallows the next real reload) and loads
+immediately; the watch consumes the flag and returns without scheduling its debounced reload.
+Typing in the field is unaffected (no flag → normal 300ms debounce).
+
+## Files (client-only)
+
+- `src/components/TerminalCell.vue`: add `skipDirWatch`; set it in `fillDir` on a real change;
+  honor + reset it at the top of the dirInput watch.
+- `src/components/TerminalCell.spec.ts`: fake-timer test — a preset fill loads `/api/sessions`
+  exactly once (immediate), and the 300ms watch does not re-fetch.
+
+## Acceptance
+
+- A preset fill loads each list once (immediate), not twice.
+- Typing still debounce-loads normally.
+- Gates green (format / lint / typecheck / build / test).

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -348,6 +348,32 @@ describe("TerminalCell", () => {
     expect(term.props("cwd")).toBe("/work/proj");
   });
 
+  it("filling a dir from a preset loads its sessions once — the debounced watch doesn't double-fetch", async () => {
+    vi.useFakeTimers();
+    try {
+      const w = mountCell(null, { defaultCwd: "/def", presets: [{ label: "x", path: "/x" }] });
+      await flushPromises(); // settle the mount's own (immediate) load
+      const sessionCalls = () =>
+        (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter((c) => String(c[0]).includes("/api/sessions")).length;
+      const before = sessionCalls();
+
+      const main = w.findAll(".cell-chip-main").find((b) => b.text() === "x");
+      if (!main) throw new Error("preset chip not found");
+      await main.trigger("click"); // fillDir → one immediate /api/sessions load
+      await flushPromises();
+      const immediate = sessionCalls() - before;
+
+      await vi.advanceTimersByTimeAsync(400); // let any debounced watch fire
+      await flushPromises();
+      const total = sessionCalls() - before;
+
+      expect(immediate).toBe(1); // loaded immediately on click
+      expect(total).toBe(1); // and the 300ms watch did NOT re-fetch
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits record-cwd with the server-confirmed cwd of a fresh launch", async () => {
     // A fresh launch + the server confirming the effective cwd asks the parent to
     // auto-record that dir as a preset (the parent persists it to config).

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -374,6 +374,34 @@ describe("TerminalCell", () => {
     }
   });
 
+  it("a preset fill cancels a pending typed-dir debounce (type-then-click doesn't double-fetch)", async () => {
+    vi.useFakeTimers();
+    try {
+      const w = mountCell(null, { defaultCwd: "/def", presets: [{ label: "x", path: "/x" }] });
+      await flushPromises();
+      const sessionCalls = () =>
+        (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter((c) => String(c[0]).includes("/api/sessions")).length;
+
+      await w.find(".cell-dir-input").setValue("/typed"); // schedules a 300ms debounced load
+      const before = sessionCalls();
+
+      const main = w.findAll(".cell-chip-main").find((b) => b.text() === "x");
+      if (!main) throw new Error("preset chip not found");
+      await main.trigger("click"); // fillDir → immediate load + must cancel the pending /typed debounce
+      await flushPromises();
+      const afterClick = sessionCalls() - before;
+
+      await vi.advanceTimersByTimeAsync(400); // the stale /typed debounce would fire here if not cancelled
+      await flushPromises();
+      const total = sessionCalls() - before;
+
+      expect(afterClick).toBe(1); // the fill's own immediate load
+      expect(total).toBe(1); // the pending typed-dir debounce was cancelled — no second fetch
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits record-cwd with the server-confirmed cwd of a fresh launch", async () => {
     // A fresh launch + the server confirming the effective cwd asks the parent to
     // auto-record that dir as a preset (the parent persists it to config).

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -484,11 +484,14 @@ async function removeWorktree(w: Worktree) {
 
 // Refresh the resume list and the runnable scripts when the target dir changes.
 watch([dirInput, () => props.defaultCwd], () => {
+  // Cancel any pending debounced reload FIRST — whether we skip (a fillDir just loaded
+  // immediately) or reschedule (typing), a stale timer from a prior change (e.g. a type
+  // then a preset click) must not fire a duplicate load afterwards.
+  if (resumableTimer) clearTimeout(resumableTimer);
   if (skipDirWatch) {
-    skipDirWatch = false; // a fillDir() already loaded these immediately — don't double-fetch
+    skipDirWatch = false; // a fillDir() already loaded these immediately — don't schedule another
     return;
   }
-  if (resumableTimer) clearTimeout(resumableTimer);
   resumableTimer = setTimeout(() => {
     loadResumable();
     loadScripts();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -290,11 +290,20 @@ function selectPreset(p: CwdPreset) {
   launchIn(p.path);
 }
 
+// A programmatic dir change (fillDir) loads the lists immediately, so the dirInput watch
+// below must skip the debounced reload it would otherwise ALSO fire — or every preset
+// click / folder pick would fetch the lists twice.
+let skipDirWatch = false;
+
 // The chip's main click (and the 📁 folder picker): fill the field WITHOUT launching,
 // and refresh the resume / script / worktree lists for that dir so the user can pick a
 // session to resume — or start fresh — instead of launching immediately.
 function fillDir(path: string) {
   dirTouched.value = true;
+  // Set the skip only when the value actually changes (so the watch will fire and consume
+  // it) — a same-value click doesn't fire the watch and would leave a stale flag that
+  // swallows the next real reload.
+  if (dirInput.value !== path) skipDirWatch = true;
   dirInput.value = path;
   loadResumable();
   loadScripts();
@@ -475,6 +484,10 @@ async function removeWorktree(w: Worktree) {
 
 // Refresh the resume list and the runnable scripts when the target dir changes.
 watch([dirInput, () => props.defaultCwd], () => {
+  if (skipDirWatch) {
+    skipDirWatch = false; // a fillDir() already loaded these immediately — don't double-fetch
+    return;
+  }
   if (resumableTimer) clearTimeout(resumableTimer);
   resumableTimer = setTimeout(() => {
     loadResumable();


### PR DESCRIPTION
## Summary

Follow-up to #360 / #361, surfaced in an independent post-merge review. `fillDir()` loads the resume / scripts / worktrees lists **immediately**, and also sets `dirInput`, which triggers the `dirInput` watch to **debounce (300ms) and load the same three lists again**. So every preset main-click / folder pick fetched each list **twice**. Harmless (request-token guarded, idempotent GETs) but wasteful — and #361 made `fillDir` the primary path (every preset click).

## Fix

A one-shot `skipDirWatch` flag: `fillDir` sets it and loads immediately; the watch consumes it and returns without scheduling the debounced reload.

## Items to Confirm / Review

- **Stale-flag guard:** the flag is set **only when `dirInput` actually changes**, so clicking the *same* preset twice (no change → the watch never fires) can't leave a stale flag that swallows the next real reload.
- **Typing unaffected:** a user typing in the field sets no flag, so the normal 300ms debounce still applies.
- Client-only (`TerminalCell.vue` + spec).
- New fake-timer test asserts a preset fill loads `/api/sessions` exactly once (immediate) and the 300ms watch does not re-fetch — it fails without the flag (the watch would fire a second load).

## User Prompt

> followup

(Fix the redundant double-load flagged in the independent review of #361.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)