### PR TITLE
perf: session transcript summary をキャッシュ＋1回パース化（#368）

### DIFF
--- a/plans/perf-session-summary-cache.md
+++ b/plans/perf-session-summary-cache.md
@@ -1,0 +1,44 @@
+# perf: /api/session/:id の transcript 全読み＆多重パースを解消（Phase 1）（#368）
+
+Issue: #368 / Branch: `perf/session-summary-cache`
+
+## User Prompt
+
+- ターミナルがすごく重い。ひょっとしてログが長くなると全部読んでて重くなる？
+- （調査で原因を特定 → 合意）issue にして Phase 1 を実装。
+
+## 原因（調査結果）
+
+`server/index.ts` の `readSessionSummary`（`GET /api/session/:id` が使用）が呼ばれるたびに:
+
+1. transcript `.jsonl` を**丸ごと** `fs.readFile`
+2. その文字列を **6ヘルパ**が各自 `parseJsonl` → 実質フル解析を最大6回
+3. **キャッシュなし**（mtime 不変でも毎回）
+
+同期CPU処理なので Node のイベントループを止め、PTY を流す WebSocket ごと固まる＝全ターミナルがカクつく。呼び出し頻度が高い（ターン完了ごとに各グリッドセル、ウィンドウフォーカスごと、セッション切替・マウント時）。実データで最大 456 MB / 66,470 行の transcript が存在。
+
+## 対応（Phase 1）
+
+- **1リクエスト1回パース**: `server/transcript.ts` に `*FromParsed(records)` 変種を追加し、`readSessionSummary` は `parseJsonl` を1回だけ実行して6値を導出。既存 `*FromJsonl(raw)` は `*FromParsed(parseJsonl(raw))` の薄いラッパとして維持（既存呼び出し・テストは無改変で通る）。
+- **mtime+size キャッシュ**: 汎用の `server/file-cache.ts`（`createFileCache`、rough-LRU、上限500）を新設。`readSessionSummary` は先に `fs.stat` して `(mtimeMs,size)` が前回と同じなら `readFile`/パースを丸ごとスキップ。append-only な `.jsonl` に対し `(mtime,size)` は十分な鮮度スタンプ。
+
+## 計測（マイクロベンチ、42.8 MB / 8万行）
+
+- OLD（6回パース）: ~483 ms（イベントループ停止）
+- NEW（1回パース）: ~111 ms（約4.4倍）
+- キャッシュヒット（不変ファイル）: ~0 ms（read+parse を丸ごと省略）
+
+実際の 456 MB 級では旧経路は数秒級のフリーズ。フォーカス/他セルの大半は不変ファイルへのアクセスなのでキャッシュでほぼ消える。
+
+## 変更ファイル
+
+- `server/file-cache.ts`（新）/ `server/file-cache.spec.ts`（新）
+- `server/transcript.ts` — `*FromParsed` 変種＋`*FromJsonl` ラッパ化
+- `server/transcript.spec.ts` — parse-once 等価テスト
+- `server/index.ts` — `readSessionSummary` を stat→cache→(miss時)read+parse-once に
+
+## Phase 2（別issue想定・本件対象外）
+
+- 末尾読み（model / 現ターン context / 最終応答・プロンプトはファイル末尾だけで足りる）
+- 累計 usage の増分計算（前回サイズ以降の追記分だけ加算）
+- `sessionTimeline`（TimelineOverlay 用）も同種の全読みだがオンデマンド。必要なら同じ mtime キャッシュを適用。

--- a/server/file-cache.spec.ts
+++ b/server/file-cache.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { createFileCache } from "./file-cache.js";
+
+const stamp = (mtimeMs: number, size: number) => ({ mtimeMs, size });
+
+describe("createFileCache", () => {
+  it("returns undefined on a cold key", () => {
+    const c = createFileCache<number>();
+    expect(c.get("a", stamp(1, 10))).toBeUndefined();
+  });
+
+  it("returns the cached value while (mtime, size) is unchanged", () => {
+    const c = createFileCache<string>();
+    c.set("a", stamp(1, 10), "v1");
+    expect(c.get("a", stamp(1, 10))).toBe("v1");
+  });
+
+  it("misses when mtime changes", () => {
+    const c = createFileCache<string>();
+    c.set("a", stamp(1, 10), "v1");
+    expect(c.get("a", stamp(2, 10))).toBeUndefined();
+  });
+
+  it("misses when size changes at the same mtime (sub-tick rewrite)", () => {
+    const c = createFileCache<string>();
+    c.set("a", stamp(1, 10), "v1");
+    expect(c.get("a", stamp(1, 11))).toBeUndefined();
+  });
+
+  it("overwrites a key's value+stamp on re-set", () => {
+    const c = createFileCache<string>();
+    c.set("a", stamp(1, 10), "v1");
+    c.set("a", stamp(2, 20), "v2");
+    expect(c.get("a", stamp(2, 20))).toBe("v2");
+    expect(c.get("a", stamp(1, 10))).toBeUndefined();
+  });
+
+  it("evicts the least-recently-used key past the cap", () => {
+    const c = createFileCache<string>(2);
+    c.set("a", stamp(1, 1), "va");
+    c.set("b", stamp(1, 1), "vb");
+    c.get("a", stamp(1, 1)); // touch a → b is now LRU
+    c.set("c", stamp(1, 1), "vc"); // over cap → evict b
+    expect(c.get("a", stamp(1, 1))).toBe("va");
+    expect(c.get("c", stamp(1, 1))).toBe("vc");
+    expect(c.get("b", stamp(1, 1))).toBeUndefined();
+  });
+});

--- a/server/file-cache.ts
+++ b/server/file-cache.ts
@@ -1,0 +1,44 @@
+// A tiny memo keyed by a file's (mtime, size): reuse a derived value while the file is
+// unchanged, recompute only when it's written. Purpose-built for the session-transcript
+// summary, whose input `.jsonl` is append-only and can be hundreds of MB — re-reading and
+// re-parsing it on every window focus / grid-cell refresh stalls the event loop.
+//
+// `size` guards the sub-millisecond case where a file is rewritten within the same mtime
+// tick; together (mtime, size) is a cheap, good-enough freshness stamp (a full content hash
+// would defeat the point — we're avoiding reading the file at all on a hit).
+
+export interface FileStamp {
+  mtimeMs: number;
+  size: number;
+}
+
+const sameStamp = (a: FileStamp, b: FileStamp): boolean => a.mtimeMs === b.mtimeMs && a.size === b.size;
+
+export interface FileCache<T> {
+  get(key: string, stamp: FileStamp): T | undefined;
+  set(key: string, stamp: FileStamp, value: T): void;
+}
+
+// Bounded by `max` entries with rough-LRU eviction (a hit/refresh moves the key to the end,
+// so the oldest untouched key is evicted first), so a machine that has opened thousands of
+// sessions doesn't retain every summary forever.
+export function createFileCache<T>(max = 500): FileCache<T> {
+  const entries = new Map<string, { stamp: FileStamp; value: T }>();
+  return {
+    get(key, stamp) {
+      const hit = entries.get(key);
+      if (!hit || !sameStamp(hit.stamp, stamp)) return undefined;
+      entries.delete(key); // move to end (most-recently used)
+      entries.set(key, hit);
+      return hit.value;
+    },
+    set(key, stamp, value) {
+      entries.delete(key);
+      entries.set(key, { stamp, value });
+      if (entries.size > max) {
+        const oldest = entries.keys().next().value;
+        if (oldest !== undefined) entries.delete(oldest);
+      }
+    },
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -57,18 +57,22 @@ import {
   parseJsonl,
   userPromptText,
   isTrivialPrompt,
-  aiTitleFromJsonl,
+  aiTitleFromParsed,
   countUserTurnsFromJsonl,
+  countUserTurnsFromParsed,
   latestMeaningfulUserPromptFromJsonl,
+  latestMeaningfulUserPromptFromParsed,
   latestAssistantTextFromJsonl,
+  latestAssistantTextFromParsed,
   preferredHeaderPrompt,
-  sessionUsageFromJsonl,
-  latestTurnContextFromJsonl,
+  sessionUsageFromParsed,
+  latestTurnContextFromParsed,
   timelineFromJsonl,
   type SessionUsage,
   type LatestTurnContext,
   type TimelineEvent,
 } from "./transcript.js";
+import { createFileCache, type FileStamp } from "./file-cache.js";
 import { mountOpenDirRoute } from "./open-dir.js";
 import { mountGitRemoteRoute } from "./gitRemote.js";
 import { mountWorktreeRoutes } from "./worktree-routes.js";
@@ -845,23 +849,42 @@ interface SessionSummary {
   usage: SessionUsage;
   context: LatestTurnContext;
 }
-// One read of a session's transcript → its latest prompt, any on-disk AI title,
-// cumulative token usage, and current-turn context, so /api/session/:id doesn't parse
-// the .jsonl more than once.
+const EMPTY_SUMMARY: SessionSummary = { lastPrompt: null, aiTitle: null, lastResponse: null, userTurns: 0, usage: EMPTY_USAGE, context: EMPTY_CONTEXT };
+
+// Transcripts are append-only and can be hundreds of MB; /api/session/:id is hit on every
+// window focus and by each grid cell as turns finish, so re-reading + re-parsing the whole
+// .jsonl each time blocked the event loop and janked the terminals. Memoize by (mtime,size):
+// an unchanged transcript returns instantly, and a changed one is read + parsed ONCE (the six
+// derived values share one parse pass, vs. one parse per helper before).
+const sessionSummaryCache = createFileCache<SessionSummary>();
+
 async function readSessionSummary(cwd: string, id: string): Promise<SessionSummary> {
+  const file = path.join(projectSessionsDir(cwd), `${id}.jsonl`);
+  let stamp: FileStamp;
   try {
-    const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
-    return {
-      lastPrompt: latestMeaningfulUserPromptFromJsonl(raw),
-      aiTitle: aiTitleFromJsonl(raw),
-      lastResponse: latestAssistantTextFromJsonl(raw)?.slice(0, LAST_RESPONSE_MAX) ?? null,
-      userTurns: countUserTurnsFromJsonl(raw),
-      usage: sessionUsageFromJsonl(raw),
-      context: latestTurnContextFromJsonl(raw),
-    };
+    const st = await fs.stat(file);
+    stamp = { mtimeMs: st.mtimeMs, size: st.size };
   } catch {
-    return { lastPrompt: null, aiTitle: null, lastResponse: null, userTurns: 0, usage: EMPTY_USAGE, context: EMPTY_CONTEXT };
+    return EMPTY_SUMMARY; // no transcript on disk yet
   }
+  const cached = sessionSummaryCache.get(file, stamp);
+  if (cached) return cached;
+  let records: Record<string, unknown>[];
+  try {
+    records = parseJsonl(await fs.readFile(file, "utf8"));
+  } catch {
+    return EMPTY_SUMMARY;
+  }
+  const summary: SessionSummary = {
+    lastPrompt: latestMeaningfulUserPromptFromParsed(records),
+    aiTitle: aiTitleFromParsed(records),
+    lastResponse: latestAssistantTextFromParsed(records)?.slice(0, LAST_RESPONSE_MAX) ?? null,
+    userTurns: countUserTurnsFromParsed(records),
+    usage: sessionUsageFromParsed(records),
+    context: latestTurnContextFromParsed(records),
+  };
+  sessionSummaryCache.set(file, stamp, summary);
+  return summary;
 }
 
 // The tool-activity timeline for a session, capped to the most recent events so the

--- a/server/transcript.spec.ts
+++ b/server/transcript.spec.ts
@@ -13,6 +13,12 @@ import {
   conversationTurnsFromJsonl,
   countUserTurnsFromJsonl,
   latestAssistantTextFromJsonl,
+  latestMeaningfulUserPromptFromParsed,
+  aiTitleFromParsed,
+  latestAssistantTextFromParsed,
+  countUserTurnsFromParsed,
+  sessionUsageFromParsed,
+  latestTurnContextFromParsed,
 } from "./transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
@@ -189,6 +195,45 @@ describe("sessionUsageFromJsonl", () => {
   });
   it("is all-zero for an empty / promptless transcript", () => {
     expect(sessionUsageFromJsonl("")).toEqual({ inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 });
+  });
+});
+
+// readSessionSummary parses the transcript ONCE and derives every field from that single
+// array; these lock the *FromParsed variants to their *FromJsonl wrappers so the shared
+// parse can't silently drift from the per-helper parse.
+describe("*FromParsed matches *FromJsonl on one shared parse", () => {
+  const raw = [
+    line({ type: "user", message: { content: "Build the thing" } }),
+    line({
+      type: "assistant",
+      message: {
+        model: "claude-opus-4-8",
+        usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 5, cache_creation_input_tokens: 3 },
+        content: [{ type: "text", text: "On it." }],
+      },
+    }),
+    line({ type: "user", message: { content: "ok" } }),
+    line({ type: "ai-title", aiTitle: "Thing builder" }),
+    line({
+      type: "assistant",
+      message: {
+        model: "claude-opus-4-8",
+        usage: { input_tokens: 200, output_tokens: 40, cache_read_input_tokens: 50, cache_creation_input_tokens: 0 },
+        content: [{ type: "text", text: "Done." }],
+      },
+    }),
+  ].join("\n");
+  const records = parseJsonl(raw);
+
+  it("derives the same six summary fields from the parsed array", () => {
+    expect(latestMeaningfulUserPromptFromParsed(records)).toBe(latestMeaningfulUserPromptFromJsonl(raw));
+    expect(latestMeaningfulUserPromptFromParsed(records)).toBe("Build the thing"); // "ok" is trivial → skipped
+    expect(aiTitleFromParsed(records)).toBe(aiTitleFromJsonl(raw));
+    expect(latestAssistantTextFromParsed(records)).toBe(latestAssistantTextFromJsonl(raw));
+    expect(countUserTurnsFromParsed(records)).toBe(countUserTurnsFromJsonl(raw));
+    expect(sessionUsageFromParsed(records)).toEqual(sessionUsageFromJsonl(raw));
+    expect(latestTurnContextFromParsed(records)).toEqual(latestTurnContextFromJsonl(raw));
+    expect(latestTurnContextFromParsed(records)).toEqual({ model: "claude-opus-4-8", contextTokens: 250 }); // last turn: 200+50+0
   });
 });
 

--- a/server/transcript.ts
+++ b/server/transcript.ts
@@ -30,11 +30,15 @@ export function parseJsonl(raw: string): Record<string, unknown>[] {
   return out;
 }
 
+// Every `*FromParsed` helper takes an already-parsed transcript so a caller that needs
+// several of them (readSessionSummary) parses the .jsonl ONCE. The `*FromJsonl` wrappers
+// (parse-then-derive) stay for one-off callers and existing tests.
+
 // Ordered user-typed prompts in a transcript + the "last-prompt" fallback record.
-function collectPrompts(raw: string): { prompts: string[]; lastPromptRecord: string | null } {
+function collectPrompts(records: Record<string, unknown>[]): { prompts: string[]; lastPromptRecord: string | null } {
   const prompts: string[] = [];
   let lastPromptRecord: string | null = null;
-  for (const o of parseJsonl(raw)) {
+  for (const o of records) {
     if (o.type === "user") {
       const prompt = userPromptText(isRecord(o.message) ? o.message.content : undefined);
       if (prompt) prompts.push(prompt);
@@ -47,20 +51,22 @@ function collectPrompts(raw: string): { prompts: string[]; lastPromptRecord: str
 
 // The most recent user-typed prompt in a transcript: the last "user" line with real
 // text, falling back to a "last-prompt" record if there are no user lines.
-export function latestUserPromptFromJsonl(raw: string): string | null {
-  const { prompts, lastPromptRecord } = collectPrompts(raw);
+export function latestUserPromptFromParsed(records: Record<string, unknown>[]): string | null {
+  const { prompts, lastPromptRecord } = collectPrompts(records);
   return prompts[prompts.length - 1] ?? lastPromptRecord;
 }
+export const latestUserPromptFromJsonl = (raw: string): string | null => latestUserPromptFromParsed(parseJsonl(raw));
 
 // The externally-generated (MulmoClaude) session title record, if the transcript carries
 // one. Only READ here — this repo never writes "ai-title" lines into Claude's own file.
-export function aiTitleFromJsonl(raw: string): string | null {
+export function aiTitleFromParsed(records: Record<string, unknown>[]): string | null {
   let title: string | null = null;
-  for (const o of parseJsonl(raw)) {
+  for (const o of records) {
     if (o.type === "ai-title" && o.aiTitle) title = String(o.aiTitle);
   }
   return title;
 }
+export const aiTitleFromJsonl = (raw: string): string | null => aiTitleFromParsed(parseJsonl(raw));
 
 export interface ConversationTurn {
   role: "user" | "assistant";
@@ -82,9 +88,9 @@ function assistantText(content: unknown): string | null {
 
 // Ordered user/assistant turns as plain text, skipping slash/local-command wrappers and
 // tool-only assistant turns. Feeds the header-title summarizer.
-export function conversationTurnsFromJsonl(raw: string): ConversationTurn[] {
+export function conversationTurnsFromParsed(records: Record<string, unknown>[]): ConversationTurn[] {
   const turns: ConversationTurn[] = [];
-  for (const o of parseJsonl(raw)) {
+  for (const o of records) {
     const content = isRecord(o.message) ? o.message.content : undefined;
     if (o.type === "user") {
       const text = userPromptText(content);
@@ -96,22 +102,24 @@ export function conversationTurnsFromJsonl(raw: string): ConversationTurn[] {
   }
   return turns;
 }
+export const conversationTurnsFromJsonl = (raw: string): ConversationTurn[] => conversationTurnsFromParsed(parseJsonl(raw));
 
 // How many user turns the transcript holds, so the roster can tell whether a session has
 // advanced far enough since its last summary to be worth re-titling.
-export function countUserTurnsFromJsonl(raw: string): number {
-  return conversationTurnsFromJsonl(raw).filter((t) => t.role === "user").length;
-}
+export const countUserTurnsFromParsed = (records: Record<string, unknown>[]): number =>
+  conversationTurnsFromParsed(records).filter((t) => t.role === "user").length;
+export const countUserTurnsFromJsonl = (raw: string): number => countUserTurnsFromParsed(parseJsonl(raw));
 
 // The most recent assistant prose turn (tool-only turns skipped), for the grid roster's
 // "what did the agent just say" line. Null when the session has no assistant text yet.
-export function latestAssistantTextFromJsonl(raw: string): string | null {
-  const turns = conversationTurnsFromJsonl(raw);
+export function latestAssistantTextFromParsed(records: Record<string, unknown>[]): string | null {
+  const turns = conversationTurnsFromParsed(records);
   for (let i = turns.length - 1; i >= 0; i--) {
     if (turns[i].role === "assistant") return turns[i].text;
   }
   return null;
 }
+export const latestAssistantTextFromJsonl = (raw: string): string | null => latestAssistantTextFromParsed(parseJsonl(raw));
 
 // A trivial prompt is an empty ack or a bare command ("ok", "merge", "はい") that
 // doesn't describe what a session is about. The cell header skips these so a short
@@ -216,13 +224,14 @@ export function preferredHeaderPrompt(current: string | null, incoming: string):
 // SUBSTANTIAL prompt, so a resumed session's header shows the task instead of a
 // one-word follow-up. Falls back to the latest prompt (then the record) if every
 // prompt is trivial.
-export function latestMeaningfulUserPromptFromJsonl(raw: string): string | null {
-  const { prompts, lastPromptRecord } = collectPrompts(raw);
+export function latestMeaningfulUserPromptFromParsed(records: Record<string, unknown>[]): string | null {
+  const { prompts, lastPromptRecord } = collectPrompts(records);
   for (let i = prompts.length - 1; i >= 0; i--) {
     if (!isTrivialPrompt(prompts[i])) return prompts[i];
   }
   return prompts[prompts.length - 1] ?? lastPromptRecord;
 }
+export const latestMeaningfulUserPromptFromJsonl = (raw: string): string | null => latestMeaningfulUserPromptFromParsed(parseJsonl(raw));
 
 // Cumulative token usage for a session — summed across every assistant turn's
 // `message.usage`. Each turn re-sends the growing context, so summing reflects the
@@ -237,9 +246,9 @@ export interface SessionUsage {
 
 const usageNum = (u: Record<string, unknown>, key: string): number => (typeof u[key] === "number" ? (u[key] as number) : 0);
 
-export function sessionUsageFromJsonl(raw: string): SessionUsage {
+export function sessionUsageFromParsed(records: Record<string, unknown>[]): SessionUsage {
   const total: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
-  for (const o of parseJsonl(raw)) {
+  for (const o of records) {
     if (o.type !== "assistant" || !isRecord(o.message)) continue;
     const u = o.message.usage;
     if (!isRecord(u)) continue;
@@ -250,6 +259,7 @@ export function sessionUsageFromJsonl(raw: string): SessionUsage {
   }
   return total;
 }
+export const sessionUsageFromJsonl = (raw: string): SessionUsage => sessionUsageFromParsed(parseJsonl(raw));
 
 // The CURRENT context size + running model for a session, from the LAST assistant
 // turn. `contextTokens` is that turn's fresh input plus both cache buckets — the
@@ -264,11 +274,11 @@ export interface LatestTurnContext {
 const contextTokensOf = (u: Record<string, unknown>): number =>
   usageNum(u, "input_tokens") + usageNum(u, "cache_read_input_tokens") + usageNum(u, "cache_creation_input_tokens");
 
-export function latestTurnContextFromJsonl(raw: string): LatestTurnContext {
+export function latestTurnContextFromParsed(records: Record<string, unknown>[]): LatestTurnContext {
   // Both fields come from the SAME final assistant turn, so a new model is never
   // shown with a prior turn's context tokens. Usage absent on that turn → 0.
   let lastMessage: Record<string, unknown> | null = null;
-  for (const o of parseJsonl(raw)) {
+  for (const o of records) {
     if (o.type === "assistant" && isRecord(o.message)) lastMessage = o.message;
   }
   if (!lastMessage) return { model: null, contextTokens: 0 };
@@ -276,6 +286,7 @@ export function latestTurnContextFromJsonl(raw: string): LatestTurnContext {
   const contextTokens = isRecord(lastMessage.usage) ? contextTokensOf(lastMessage.usage) : 0;
   return { model, contextTokens };
 }
+export const latestTurnContextFromJsonl = (raw: string): LatestTurnContext => latestTurnContextFromParsed(parseJsonl(raw));
 
 // A single tool the agent ran, for the activity timeline. `summary` is a 1-line
 // description drawn from the tool's most salient input (a command, a file path, …).


### PR DESCRIPTION
## Summary

ターミナルがログ増加に比例して重くなる問題（#368）の Phase 1。`GET /api/session/:id`（`readSessionSummary`）が毎回 transcript `.jsonl` を丸読みし、6ヘルパが各自 `parseJsonl` して**最大6回フル解析**、しかもキャッシュ無し。同期処理なので Node のイベントループを止め、PTY を流す WebSocket ごと固まる＝全ターミナルがカクつく。呼び出しは**ターン完了ごと（各グリッドセル）・ウィンドウフォーカスごと・セッション切替**と高頻度。実データで最大 **456 MB / 66,470 行** の transcript が存在。

- **1回パース**: `transcript.ts` に `*FromParsed(records)` を追加、`readSessionSummary` は `parseJsonl` を1回だけ。既存 `*FromJsonl` は薄いラッパとして維持（既存呼び出し・テスト無改変）。
- **mtime+size キャッシュ**: 汎用 `createFileCache`（rough-LRU、上限500）。`fs.stat` して `(mtime,size)` 不変なら read+parse を丸ごとスキップ。

**マイクロベンチ（42.8 MB / 8万行）**: 6回パース ~483ms → 1回パース ~111ms（約4.4倍）／キャッシュヒット ~0ms。

Closes #368

## Items to Confirm / Review

- **キャッシュ鮮度スタンプ**: `.jsonl` は追記専用なので `(mtimeMs, size)` で十分と判断。同一 mtime tick 内の書換えは `size` で検出。フルハッシュはファイルを読む必要があり本末転倒なので不採用。
- **共有参照**: キャッシュはヒット時に同じ `SessionSummary` オブジェクトを返す。ハンドラは読むだけ（`res.json`）で変更しないため安全。`EMPTY_SUMMARY` 定数も同様。
- **`*FromParsed` == `*FromJsonl`**: ラッパ委譲なので既存テストが等価性を担保。加えて parse-once 経路の等価テストを追加。
- **範囲**: 本 PR は `readSessionSummary`（ホットパス）のみ。`sessionTimeline`（TimelineOverlay 用）も同種の全読みだがオンデマンドなので Phase 2 に回した。

## User Prompt

- ターミナルがすごく重い。ひょっとしてログが長くなると全部読んでて重くなる？
- （調査で原因特定・合意）→ issue 化して Phase 1 を実装。

## Phase 2（別途 #368 に記載・本PR対象外）

- 末尾読み（model / 現ターン context / 最終応答・プロンプトはファイル末尾だけで足りる）
- 累計 usage の増分計算（前回サイズ以降の追記分だけ加算）→ 稼働中の巨大セッションも O(差分) に

## テスト

- `file-cache.spec.ts`（cold/hit/mtime変化/size変化/上書き/LRU evict）、`transcript.spec.ts`（parse-once 等価）。
- `yarn format` / `yarn lint`（0 error）/ `yarn typecheck:server`（クリーン）/ `yarn build` / `yarn test`（1135 パス）。
- 実測ベンチで parse 回数削減とキャッシュ効果を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)