### PR TITLE
feat: grid の expand 中に閉じたら隣のセルを expand したままにする（#376）

### DIFF
--- a/plans/feat-expand-walks-on-close.md
+++ b/plans/feat-expand-walks-on-close.md
@@ -1,0 +1,24 @@
+# feat: expand 中に閉じたら隣のセルへ expand を移す（#376）
+
+Issue: #376 / Branch: `feat/expand-walks-on-close`
+
+## User Prompt
+
+grid view の expand で、expand している terminal を閉じると、普通の view に戻るけど、1つ前の terminal を expand した状態にしてそのままにしてほしい。一番前の terminal を閉じた場合は次を開くとして。
+
+## 挙動
+
+- expand 中のセルを閉じる → フィルムストリップ表示順の**前のセル**を expand（ズーム維持）。
+- 閉じたのが**先頭（一番前）**セル → **次のセル**を expand。
+- 残りセルが無い（最後の1枚を閉じた）→ 通常ビューへ（従来どおり）。
+- expand 中に**非expand セル**を閉じた場合は現在の expand を維持。
+
+## 実装
+
+- `src/components/gridTabs.ts` `closeCell(state, uid, order?)`: `order`（画面表示順の uid 配列）を追加引数に。閉じたのが `state.expanded === uid` のとき、`order` 上の前（`idx-1`）、先頭なら次（`idx+1`）の uid を新しい `expanded` に。隣が無い/`order` 未指定なら `null`（従来の un-zoom）にフォールバック。
+- `src/components/GridView.vue` `onClose`: `displayCells.value.map(c => c.uid)` を渡す。zoom 中は `visibleOrdered` が全件（＝フィルムストリップ順）を返すので、隣は「見えている順」で選ばれる。
+- テスト（`gridTabs.spec.ts`）: 前/次(先頭)/最後の1枚/非expand/`order`未指定フォールバック。
+
+## 検証
+
+- `yarn lint`（0 error）/ `yarn build` / `yarn test`（1147 パス）。純粋関数の単体テストで挙動を担保。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -201,7 +201,14 @@ function onAddTerminal() {
 const onSession = (uid: number, id: string) => (state.value = setSession(state.value, uid, id));
 const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, uid, cwd));
 const onAgent = (uid: number, agent: "claude" | "codex") => (state.value = setCellAgent(state.value, uid, agent));
-const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
+// Pass the on-screen order so closing the zoomed cell stays zoomed on its filmstrip
+// neighbour (previous, or next when it was the first) instead of collapsing the grid.
+const onClose = (uid: number) =>
+  (state.value = closeCell(
+    state.value,
+    uid,
+    displayCells.value.map((c) => c.uid),
+  ));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: RunCommand) => (state.value = runCommand(state.value, uid, command));
 // A running cell's header Run menu: launch in a spare cell (next to it) so the session survives.

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -128,9 +128,25 @@ describe("closeCell reflows across pages", () => {
     expect(after.cells).toHaveLength(1);
     expect(after.cells[0].session).toBeNull();
   });
-  it("un-zooms when the zoomed cell is closed", () => {
+  it("un-zooms when the zoomed cell is closed with no on-screen order (fallback)", () => {
     const after = closeCell(make(running(2), { expanded: 0 }), 0);
     expect(after.expanded).toBeNull();
+  });
+  it("stays zoomed on the PREVIOUS cell when the zoomed cell is closed", () => {
+    const after = closeCell(make(running(3), { expanded: 1 }), 1, [0, 1, 2]);
+    expect(after.expanded).toBe(0);
+  });
+  it("stays zoomed on the NEXT cell when the FIRST (front) cell is closed", () => {
+    const after = closeCell(make(running(3), { expanded: 0 }), 0, [0, 1, 2]);
+    expect(after.expanded).toBe(1);
+  });
+  it("un-zooms when the last remaining cell is closed (no neighbour)", () => {
+    const after = closeCell(make(running(1), { expanded: 0 }), 0, [0]);
+    expect(after.expanded).toBeNull();
+  });
+  it("leaves the zoom untouched when a NON-zoomed cell is closed", () => {
+    const after = closeCell(make(running(3), { expanded: 2 }), 0, [0, 1, 2]);
+    expect(after.expanded).toBe(2);
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -149,11 +149,26 @@ export function runScriptInNewCell(state: GridState, afterUid: number, command: 
 }
 
 // Close a cell: drop it and reflow the list (later cells pack forward across
-// pages), un-zoom if it was zoomed, keep an entry cell, and clamp the page.
-export function closeCell(state: GridState, uid: number): GridState {
+// pages), keep an entry cell, and clamp the page. If the CLOSED cell was the zoomed
+// one, STAY zoomed on its neighbour in the on-screen `order` — the previous cell, or
+// the next one when the closed cell was first — so closing walks the expand along the
+// filmstrip instead of collapsing to the grid. Falls back to un-zooming when there's
+// no surviving neighbour (the last cell) or no `order` is supplied.
+export function closeCell(state: GridState, uid: number, order?: number[]): GridState {
   const cells = state.cells.filter((c) => c.uid !== uid);
-  const expanded = state.expanded === uid ? null : state.expanded;
+  const expanded = state.expanded === uid ? expandNeighbour(order, uid, cells) : state.expanded;
   return ensureEntry(clampPage({ ...state, cells, expanded }));
+}
+
+// The uid to keep zoomed after closing the zoomed `uid`: the cell before it in the
+// on-screen `order`, or the one after when it was first. null (collapse to the grid)
+// when there's no surviving neighbour or no order was given.
+function expandNeighbour(order: number[] | undefined, uid: number, remaining: Cell[]): number | null {
+  if (!order) return null;
+  const idx = order.indexOf(uid);
+  if (idx < 0) return null;
+  const neighbour = idx > 0 ? order[idx - 1] : order[idx + 1];
+  return neighbour !== undefined && remaining.some((c) => c.uid === neighbour) ? neighbour : null;
 }
 
 export function toggleExpand(state: GridState, uid: number): GridState {


### PR DESCRIPTION
## Summary

グリッドで端末を expand（全面ズーム）中にその端末を閉じると、通常のグリッドに戻ってしまっていた。これを、**ズームを維持したまま隣のセルへ expand を移す**ように変更:

- expand 中のセルを閉じる → フィルムストリップ表示順の **前のセル**を expand。
- 閉じたのが **先頭（一番前）** → **次のセル**を expand。
- 残りが無い（最後の1枚）→ 通常ビューへ（従来どおり）。
- expand 中に **非expand セル**を閉じた場合は現在の expand を維持。

Closes #376

## Items to Confirm / Review

- **並び順は「見えている順」**: `closeCell` に `GridView` の `displayCells`（zoom 中は `visibleOrdered` が全件を返す＝フィルムストリップ順）の uid 配列を渡し、その順で隣を選ぶ。auto ソート時も画面と一致。
- **フォールバック**: `order` 未指定 or 隣が無い（最後の1枚）→ `expanded=null`（従来 un-zoom）。既存挙動は温存。
- **純粋関数＋単体テスト**: `closeCell` の変更は純粋関数。前/次(先頭)/最後の1枚/非expand/`order`未指定 をテスト追加。

## User Prompt

grid view の expand で、expand している terminal を閉じると、普通の view に戻るけど、1つ前の terminal を expand した状態にしてそのままにしてほしい。一番前の terminal を閉じた場合は次を開くとして。

## テスト

- `src/components/gridTabs.spec.ts` に5ケース追加。`yarn lint`（0 error）/ `yarn build` / `yarn test`（**1147 パス**）。

## 実装メモ

- `src/components/gridTabs.ts` — `closeCell(state, uid, order?)` ＋ `expandNeighbour` ヘルパ。
- `src/components/GridView.vue` — `onClose` が表示順を渡す。
- 設計: `plans/feat-expand-walks-on-close.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)