### PR TITLE
feat: グリッドでヘッダー背景クリックでもそのターミナルを zoom してアクティブにする（#378）

### DIFF
--- a/plans/feat-expand-walks-on-close.md
+++ b/plans/feat-expand-walks-on-close.md
@@ -1,0 +1,24 @@
+# feat: expand 中に閉じたら隣のセルへ expand を移す（#376）
+
+Issue: #376 / Branch: `feat/expand-walks-on-close`
+
+## User Prompt
+
+grid view の expand で、expand している terminal を閉じると、普通の view に戻るけど、1つ前の terminal を expand した状態にしてそのままにしてほしい。一番前の terminal を閉じた場合は次を開くとして。
+
+## 挙動
+
+- expand 中のセルを閉じる → フィルムストリップ表示順の**前のセル**を expand（ズーム維持）。
+- 閉じたのが**先頭（一番前）**セル → **次のセル**を expand。
+- 残りセルが無い（最後の1枚を閉じた）→ 通常ビューへ（従来どおり）。
+- expand 中に**非expand セル**を閉じた場合は現在の expand を維持。
+
+## 実装
+
+- `src/components/gridTabs.ts` `closeCell(state, uid, order?)`: `order`（画面表示順の uid 配列）を追加引数に。閉じたのが `state.expanded === uid` のとき、`order` 上の前（`idx-1`）、先頭なら次（`idx+1`）の uid を新しい `expanded` に。隣が無い/`order` 未指定なら `null`（従来の un-zoom）にフォールバック。
+- `src/components/GridView.vue` `onClose`: `displayCells.value.map(c => c.uid)` を渡す。zoom 中は `visibleOrdered` が全件（＝フィルムストリップ順）を返すので、隣は「見えている順」で選ばれる。
+- テスト（`gridTabs.spec.ts`）: 前/次(先頭)/最後の1枚/非expand/`order`未指定フォールバック。
+
+## 検証
+
+- `yarn lint`（0 error）/ `yarn build` / `yarn test`（1147 パス）。純粋関数の単体テストで挙動を担保。

--- a/plans/feat-header-click-zoom.md
+++ b/plans/feat-header-click-zoom.md
@@ -1,0 +1,29 @@
+# feat: グリッドでヘッダー背景クリックでも zoom してアクティブに（#378）
+
+Issue: #378 / Branch: `feat/header-click-zoom`
+
+## User Prompt
+
+- grid view の expand してない状態で、terminal の body 部分をクリックすると terminal が切り替わる（アクティブになる）けど、header は切り替わらない。
+- （明確化）body と同じように header をクリックしてもそのターミナルが zoom してアクティブになるようにしてほしい。
+
+## 現状と変更
+
+現状 `src/components/cellHeaderZoom.ts` の `shouldZoomOnHeaderClick(target, filmstrip)` は `!filmstrip` なら常に `false` ＝ タイル表示（通常グリッド）ではヘッダー背景クリックは無反応で、右上の ⤢ ボタンでしか zoom できなかった。
+
+これを「**expand していないセルなら、ヘッダー背景（ボタン以外）クリックで zoom（`toggle-expand`）**」に変更:
+
+- 第2引数を `filmstrip` → `expanded` に。`if (expanded) return false;`（expand 中のセル自体は誤操作 restore 防止で据え置き。restore は ⤡ ボタン）、それ以外は従来どおりボタン以外なら `true`。
+- タイル表示・フィルムストリップ両方でヘッダー背景クリックが zoom（＝そのターミナルへ切替＝アクティブ）。ヘッダー内のボタン（dir / GitHub / diff / ⤢ / ✕ / ◀▶）は従来動作を維持（`closest("button")` で除外）。
+- `is-zoomable`（ポインタカーソル＋hover 背景）も `filmstrip` → `!expanded` に。クリック可能な afford を通常グリッドでも表示。
+- TerminalCell / CommandCell / LauncherCell 共通（`shouldZoomOnHeaderClick(event.target, props.expanded)`）。CommandCell/LauncherCell は未使用になった `filmstrip` computed を削除。
+
+## テスト
+
+- `cellHeaderZoom.spec.ts`: `expanded=false` で zoom / `expanded=true` で非 zoom / ボタン(SVG含む)除外 に更新。
+- 各 cell の spec: 「通常グリッドで zoom する」「expand 中は zoom しない（⤡ で restore）」「フィルムストリップで zoom」。
+- `yarn lint`（0 error）/ `yarn build` / `yarn test`（1150 パス）。
+
+## 対象外
+
+- expand 中のセルのヘッダークリックで restore する挙動は今回入れない（据え置き）。

--- a/src/components/CommandCell.spec.ts
+++ b/src/components/CommandCell.spec.ts
@@ -62,11 +62,11 @@ describe("CommandCell", () => {
     expect(w.emitted("close")).toHaveLength(1);
   });
 
-  it("does not zoom on a header-background click in the normal grid (only the ⤢ button)", async () => {
-    const w = mountCell(); // expanded: false, zoomed: undefined → normal grid
-    expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
+  it("zooms on a header-background click in the normal grid (mirrors clicking the body)", async () => {
+    const w = mountCell(); // expanded: false, zoomed: undefined → tiled grid
+    expect(w.find(".cell-header").classes()).toContain("is-zoomable");
     await w.find(".cell-header").trigger("click");
-    expect(w.emitted("toggle-expand")).toBeUndefined();
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
   });
 
   it("zooms on a header-background click when it's a filmstrip thumbnail", async () => {
@@ -74,6 +74,13 @@ describe("CommandCell", () => {
     expect(w.find(".cell-header").classes()).toContain("is-zoomable");
     await w.find(".cell-header").trigger("click");
     expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
+
+  it("does not zoom on a header-background click while expanded (restore via the ⤡ button)", async () => {
+    const w = mount(CommandCell, { props: { expanded: true, command: COMMAND, home: "/work" } });
+    expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toBeUndefined();
   });
 });
 

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -132,17 +132,16 @@ function copyPrompt() {
     });
 }
 
-// A filmstrip thumbnail zooms (switches to) this cell on a header-background click;
-// in the normal grid the header is inert (only the ⤢ button zooms). Buttons keep their action.
-const filmstrip = computed(() => !!props.zoomed && !props.expanded);
+// Clicking the header background zooms (switches to) this cell, except the already-
+// expanded one. Buttons keep their action.
 function onHeaderClick(event: MouseEvent) {
-  if (shouldZoomOnHeaderClick(event.target, filmstrip.value)) emit("toggle-expand");
+  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
 }
 </script>
 
 <template>
   <div class="cell">
-    <div class="cell-header" :class="{ 'is-zoomable': filmstrip }" @click="onHeaderClick">
+    <div class="cell-header" :class="{ 'is-zoomable': !expanded }" @click="onHeaderClick">
       <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Finished' : 'Running…'" />
       <span v-if="dirDisplay" class="cell-dir" :title="command.cwd ?? ''"
         ><span class="cell-dir-path">{{ dirDisplay }}</span></span

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -201,7 +201,14 @@ function onAddTerminal() {
 const onSession = (uid: number, id: string) => (state.value = setSession(state.value, uid, id));
 const onCwd = (uid: number, cwd: string) => (state.value = setCwd(state.value, uid, cwd));
 const onAgent = (uid: number, agent: "claude" | "codex") => (state.value = setCellAgent(state.value, uid, agent));
-const onClose = (uid: number) => (state.value = closeCell(state.value, uid));
+// Pass the on-screen order so closing the zoomed cell stays zoomed on its filmstrip
+// neighbour (previous, or next when it was the first) instead of collapsing the grid.
+const onClose = (uid: number) =>
+  (state.value = closeCell(
+    state.value,
+    uid,
+    displayCells.value.map((c) => c.uid),
+  ));
 const onToggleExpand = (uid: number) => (state.value = toggleExpand(state.value, uid));
 const onRun = (uid: number, command: RunCommand) => (state.value = runCommand(state.value, uid, command));
 // A running cell's header Run menu: launch in a spare cell (next to it) so the session survives.

--- a/src/components/LauncherCell.spec.ts
+++ b/src/components/LauncherCell.spec.ts
@@ -34,11 +34,11 @@ describe("LauncherCell header zoom", () => {
     expect(w.emitted("close")).toHaveLength(1);
   });
 
-  it("does not zoom on a header-background click in the normal grid (only the ⤢ button)", async () => {
-    const w = mountCell(); // zoomed: undefined → normal grid
-    expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
+  it("zooms on a header-background click in the normal grid (mirrors clicking the body)", async () => {
+    const w = mountCell(); // expanded: false, zoomed: undefined → tiled grid
+    expect(w.find(".cell-header").classes()).toContain("is-zoomable");
     await w.find(".cell-header").trigger("click");
-    expect(w.emitted("toggle-expand")).toBeUndefined();
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
   });
 
   it("zooms on a header-background click when it's a filmstrip thumbnail", async () => {
@@ -46,5 +46,12 @@ describe("LauncherCell header zoom", () => {
     expect(w.find(".cell-header").classes()).toContain("is-zoomable");
     await w.find(".cell-header").trigger("click");
     expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
+
+  it("does not zoom on a header-background click while expanded (restore via the ⤡ button)", async () => {
+    const w = mountCell({ expanded: true });
+    expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toBeUndefined();
   });
 });

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -33,11 +33,10 @@ const emit = defineEmits<{
   (e: "session", id: string): void;
 }>();
 
-// A filmstrip thumbnail zooms (switches to) this cell on a header-background click;
-// in the normal grid the header is inert (only the ⤢ button zooms). Buttons keep their action.
-const filmstrip = computed(() => !!props.zoomed && !props.expanded);
+// Clicking the header background zooms (switches to) this cell, except the already-
+// expanded one. Buttons keep their action.
 function onHeaderClick(event: MouseEvent) {
-  if (shouldZoomOnHeaderClick(event.target, filmstrip.value)) emit("toggle-expand");
+  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
 }
 
 // connectKey bump re-launches after the process exits (relaunch button).
@@ -64,7 +63,7 @@ function relaunch() {
 
 <template>
   <div class="cell">
-    <div class="cell-header" :class="{ 'is-zoomable': filmstrip }" @click="onHeaderClick">
+    <div class="cell-header" :class="{ 'is-zoomable': !expanded }" @click="onHeaderClick">
       <span class="cell-dot" :class="finished ? 'is-idle' : 'is-working'" :title="finished ? 'Exited' : 'Running…'" />
       <span v-if="dirDisplay" class="cell-dir" :title="cwd ?? ''"
         ><span class="cell-dir-path">{{ dirDisplay }}</span></span

--- a/src/components/TerminalCell.spec.ts
+++ b/src/components/TerminalCell.spec.ts
@@ -1455,14 +1455,22 @@ describe("TerminalCell", () => {
     expect(urls).not.toContain("/api/open-dir"); // dir was NOT opened
   });
 
-  it("does not zoom on a header-background click in the normal grid (only the ⤢ button zooms)", async () => {
+  it("zooms on a header-background click in the normal grid (mirrors clicking the body)", async () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj" });
+    await flushPromises();
+    expect(w.find(".cell-header").classes()).toContain("is-zoomable");
+    await w.find(".cell-header").trigger("click");
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+  });
+
+  it("does not zoom on a header-background click while expanded (restore via the ⤡ button)", async () => {
+    const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", expanded: true });
     await flushPromises();
     expect(w.find(".cell-header").classes()).not.toContain("is-zoomable");
     await w.find(".cell-header").trigger("click");
     expect(w.emitted("toggle-expand")).toBeUndefined();
-    // The dedicated button still works.
-    await w.find('[aria-label="Expand terminal"]').trigger("click");
+    // The dedicated restore button still works.
+    await w.find('[aria-label="Restore terminal"]').trigger("click");
     expect(w.emitted("toggle-expand")).toHaveLength(1);
   });
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -19,12 +19,11 @@ import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 
 const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 
-// Clicking the header background zooms this cell ONLY when it's a filmstrip thumbnail
-// (another cell is zoomed) — the easy "switch to this terminal" gesture. In the normal
-// grid the header is inert; the ⤢ button is the only way to zoom. Header buttons keep
-// their action.
+// Clicking the header background zooms this cell (mirrors clicking the terminal body) —
+// in the tiled grid and as a filmstrip thumbnail alike. Only the already-expanded cell
+// stays inert (restore via the ⤡ button). Header buttons keep their action.
 function onHeaderClick(event: MouseEvent) {
-  if (shouldZoomOnHeaderClick(event.target, filmstrip.value)) emit("toggle-expand");
+  if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
 }
 
 // `expanded` reflects whether this cell is zoomed to fill the grid (parent owns
@@ -885,7 +884,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
     <template v-if="launched">
       <!-- Row 1 — INFO only: dir + git + model/token + what it's doing. Every icon
            BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
-      <div class="cell-header" :class="[statusClass, { 'is-zoomable': filmstrip }]" :style="headerStyle" @click="onHeaderClick">
+      <div class="cell-header" :class="[statusClass, { 'is-zoomable': !expanded }]" :style="headerStyle" @click="onHeaderClick">
         <!-- All the info lives in one shrinkable, clipping track. The chips (badge / git /
              model / tokens / custom) don't shrink, so without this they would overflow and
              push the actions past the cell's `overflow: hidden` edge — the buttons must

--- a/src/components/cellHeaderZoom.spec.ts
+++ b/src/components/cellHeaderZoom.spec.ts
@@ -2,25 +2,25 @@ import { describe, it, expect } from "vitest";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 
 describe("shouldZoomOnHeaderClick", () => {
-  it("zooms when a filmstrip thumbnail's header background (a non-button element) is clicked", () => {
+  it("zooms when a non-expanded cell's header background (a non-button element) is clicked", () => {
     const span = document.createElement("span"); // e.g. the prompt / badge / dot
-    expect(shouldZoomOnHeaderClick(span, true)).toBe(true);
+    expect(shouldZoomOnHeaderClick(span, false)).toBe(true); // tiled grid or filmstrip thumbnail
   });
 
-  it("does not zoom in the normal grid — only the ⤢ button zooms there", () => {
+  it("does not zoom on the already-expanded cell — its header is inert (restore via ⤡)", () => {
     const span = document.createElement("span");
-    expect(shouldZoomOnHeaderClick(span, false)).toBe(false);
-    expect(shouldZoomOnHeaderClick(null, false)).toBe(false);
+    expect(shouldZoomOnHeaderClick(span, true)).toBe(false);
+    expect(shouldZoomOnHeaderClick(null, true)).toBe(false);
   });
 
-  it("ignores clicks that land on one of the header's own buttons (even on a thumbnail)", () => {
+  it("ignores clicks that land on one of the header's own buttons", () => {
     const header = document.createElement("div");
     const btn = document.createElement("button");
     const icon = document.createElement("span"); // an icon inside the button
     btn.appendChild(icon);
     header.appendChild(btn);
-    expect(shouldZoomOnHeaderClick(btn, true)).toBe(false);
-    expect(shouldZoomOnHeaderClick(icon, true)).toBe(false); // click bubbles from the icon
+    expect(shouldZoomOnHeaderClick(btn, false)).toBe(false);
+    expect(shouldZoomOnHeaderClick(icon, false)).toBe(false); // click bubbles from the icon
   });
 
   it("ignores clicks on an SVG icon inside a button (e.g. the GitHub button)", () => {
@@ -30,11 +30,11 @@ describe("shouldZoomOnHeaderClick", () => {
     const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
     svg.appendChild(path);
     btn.appendChild(svg);
-    expect(shouldZoomOnHeaderClick(svg, true)).toBe(false);
-    expect(shouldZoomOnHeaderClick(path, true)).toBe(false);
+    expect(shouldZoomOnHeaderClick(svg, false)).toBe(false);
+    expect(shouldZoomOnHeaderClick(path, false)).toBe(false);
   });
 
-  it("zooms on a null / non-element target of a thumbnail (no button in the path)", () => {
-    expect(shouldZoomOnHeaderClick(null, true)).toBe(true);
+  it("zooms on a null / non-element target of a non-expanded cell (no button in the path)", () => {
+    expect(shouldZoomOnHeaderClick(null, false)).toBe(true);
   });
 });

--- a/src/components/cellHeaderZoom.ts
+++ b/src/components/cellHeaderZoom.ts
@@ -1,10 +1,11 @@
-// A click on a grid cell's header background zooms (promotes) that cell — but ONLY
-// while it's a filmstrip thumbnail (some OTHER cell is already zoomed), where this is
-// the easy "switch to that terminal" gesture. In the normal grid the header is inert;
-// the ⤢ button is the only way to zoom. The header's own controls (dir / GitHub / ⤢ /
-// ✕ / ◀▶) always keep their action.
-export function shouldZoomOnHeaderClick(target: EventTarget | null, filmstrip: boolean): boolean {
-  if (!filmstrip) return false;
+// A click on a grid cell's header background zooms (promotes) that cell to fill the
+// grid — in BOTH the tiled grid and while it's a filmstrip thumbnail (some other cell
+// is already zoomed), the easy "switch to this terminal" gesture that mirrors clicking
+// the terminal body. The EXPANDED cell itself is excluded: its header stays inert so a
+// stray click while reading the big terminal doesn't restore it (use the ⤡ button).
+// The header's own controls (dir / GitHub / ⤢ / ✕ / ◀▶) always keep their action.
+export function shouldZoomOnHeaderClick(target: EventTarget | null, expanded: boolean): boolean {
+  if (expanded) return false;
   // `Element` (not `HTMLElement`): a click can land on an SVG icon inside a button
   // (e.g. the GitHub button), and SVGElement isn't an HTMLElement — but it IS an
   // Element with closest(), so this still walks up to the enclosing button.

--- a/src/components/gridTabs.spec.ts
+++ b/src/components/gridTabs.spec.ts
@@ -128,9 +128,25 @@ describe("closeCell reflows across pages", () => {
     expect(after.cells).toHaveLength(1);
     expect(after.cells[0].session).toBeNull();
   });
-  it("un-zooms when the zoomed cell is closed", () => {
+  it("un-zooms when the zoomed cell is closed with no on-screen order (fallback)", () => {
     const after = closeCell(make(running(2), { expanded: 0 }), 0);
     expect(after.expanded).toBeNull();
+  });
+  it("stays zoomed on the PREVIOUS cell when the zoomed cell is closed", () => {
+    const after = closeCell(make(running(3), { expanded: 1 }), 1, [0, 1, 2]);
+    expect(after.expanded).toBe(0);
+  });
+  it("stays zoomed on the NEXT cell when the FIRST (front) cell is closed", () => {
+    const after = closeCell(make(running(3), { expanded: 0 }), 0, [0, 1, 2]);
+    expect(after.expanded).toBe(1);
+  });
+  it("un-zooms when the last remaining cell is closed (no neighbour)", () => {
+    const after = closeCell(make(running(1), { expanded: 0 }), 0, [0]);
+    expect(after.expanded).toBeNull();
+  });
+  it("leaves the zoom untouched when a NON-zoomed cell is closed", () => {
+    const after = closeCell(make(running(3), { expanded: 2 }), 0, [0, 1, 2]);
+    expect(after.expanded).toBe(2);
   });
 });
 

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -149,11 +149,26 @@ export function runScriptInNewCell(state: GridState, afterUid: number, command: 
 }
 
 // Close a cell: drop it and reflow the list (later cells pack forward across
-// pages), un-zoom if it was zoomed, keep an entry cell, and clamp the page.
-export function closeCell(state: GridState, uid: number): GridState {
+// pages), keep an entry cell, and clamp the page. If the CLOSED cell was the zoomed
+// one, STAY zoomed on its neighbour in the on-screen `order` — the previous cell, or
+// the next one when the closed cell was first — so closing walks the expand along the
+// filmstrip instead of collapsing to the grid. Falls back to un-zooming when there's
+// no surviving neighbour (the last cell) or no `order` is supplied.
+export function closeCell(state: GridState, uid: number, order?: number[]): GridState {
   const cells = state.cells.filter((c) => c.uid !== uid);
-  const expanded = state.expanded === uid ? null : state.expanded;
+  const expanded = state.expanded === uid ? expandNeighbour(order, uid, cells) : state.expanded;
   return ensureEntry(clampPage({ ...state, cells, expanded }));
+}
+
+// The uid to keep zoomed after closing the zoomed `uid`: the cell before it in the
+// on-screen `order`, or the one after when it was first. null (collapse to the grid)
+// when there's no surviving neighbour or no order was given.
+function expandNeighbour(order: number[] | undefined, uid: number, remaining: Cell[]): number | null {
+  if (!order) return null;
+  const idx = order.indexOf(uid);
+  if (idx < 0) return null;
+  const neighbour = idx > 0 ? order[idx - 1] : order[idx + 1];
+  return neighbour !== undefined && remaining.some((c) => c.uid === neighbour) ? neighbour : null;
 }
 
 export function toggleExpand(state: GridState, uid: number): GridState {


### PR DESCRIPTION
## Summary

タイル表示のグリッドで、ターミナルの **body クリックはそのターミナルをアクティブにする**のに、**ヘッダーをクリックしても無反応**だった（⤢ ボタンでしか zoom できない）。body と同じ感覚で、**ヘッダー背景クリックでそのターミナルを zoom（expand）してアクティブに**するように変更。

- タイル表示・フィルムストリップ両方で、ヘッダー背景（ボタン以外）クリック → `toggle-expand`。
- **expand 中のセル自体は据え置き**（誤操作 restore 防止。restore は ⤡ ボタン）。
- ヘッダー内のボタン（dir / GitHub / diff / ⤢ / ✕ / ◀▶）は従来動作を維持。
- `is-zoomable`（ポインタカーソル）も通常グリッドで表示。

Closes #378

## Items to Confirm / Review

- **判定関数の意味変更**: `shouldZoomOnHeaderClick(target, expanded)`（第2引数 `filmstrip`→`expanded`）。`expanded` なら false、それ以外は `!closest("button")`。純粋関数＋単体テストで担保。
- **ボタン除外**: dir/GitHub/⤢/✕ 等はボタンなので zoom せず自分の動作。SVG アイコン内クリックも `closest("button")` で解決。
- **3セル共通**: TerminalCell / CommandCell / LauncherCell。後2つは未使用になった `filmstrip` computed を削除。
- **expand 中の restore を header クリックに割り当てるかは対象外**（今回は ⤡ のみ）。

## User Prompt

- grid view の expand してない状態で、terminal の body 部分をクリックすると terminal が切り替わるけど、header は切り替わらない。
- body と同じように header をクリックしてもそのターミナルが zoom してアクティブになるようにしてほしい。

## テスト

- `cellHeaderZoom.spec.ts` ＋ 各 cell の spec を新挙動に更新（通常グリッドで zoom / expand 中は非 zoom / フィルムストリップで zoom / ボタン除外）。
- `yarn lint`（0 error）/ `yarn build` / `yarn test`（**1150 パス**）。
- 設計: `plans/feat-header-click-zoom.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)