### PR TITLE
feat: `npx mulmoterminal init` — idempotent first-run setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ npm install -g mulmoterminal
 mulmoterminal
 ```
 
+**First-run setup (optional).** `npx mulmoterminal init` checks your environment (Node ≥ 22.9,
+the `claude` CLI, plus optional `tmux` / `gh` / `codex`), seeds the launcher's **directory
+presets** from the projects in your Claude Code history, and writes `~/.mulmoterminal/config.json`.
+It's **idempotent** — re-run it any time to refresh the presets; it overwrites the managed parts
+and keeps your other settings. When `claude` is installed it can hand off to the
+`/mulmoterminal-config` skill for interactive tweaks.
+
 A global install isn't auto-updated, so on startup MulmoTerminal checks npm and
 prints a one-line notice when a newer version is available (`npm i -g mulmoterminal`
 to update). Disable with `MULMOTERMINAL_NO_UPDATE_CHECK=1` (or `NO_UPDATE_NOTIFIER=1`).

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -11,6 +11,7 @@ import { get as httpGet } from "node:http";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
 import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { fetchLatestVersion, isNewerVersion } from "./update-check.js";
 
@@ -46,16 +47,83 @@ function checkForUpdate() {
     });
 }
 
-function claudeInstalled() {
+// Detect a CLI on the user's PATH by asking for its version. Intentionally resolves from
+// PATH — detecting the user's installed tools is the whole point of the pre-flight /
+// `init` checks.
+function hasCommand(cmd, versionArg = "--version") {
   try {
-    // Intentionally resolves `claude` from the user's PATH — detecting their
-    // Claude Code CLI install is the whole point of this pre-flight check.
     // eslint-disable-next-line sonarjs/no-os-command-from-path
-    execSync("claude --version", { stdio: "pipe" });
+    execSync(`${cmd} ${versionArg}`, { stdio: "pipe" });
     return true;
   } catch {
     return false;
   }
+}
+
+function claudeInstalled() {
+  return hasCommand("claude");
+}
+
+function promptYesNo(question) {
+  return new Promise((res) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (answer) => {
+      rl.close();
+      res(/^y(es)?$/i.test(answer.trim()));
+    });
+  });
+}
+
+// `npx mulmoterminal init` — idempotent first-run setup. Environment/CLI checks + the
+// optional interactive-config launch live here (PATH-command detection); the config
+// derivation + write is the tsx-run server/cli-init.ts.
+async function runInit(initArgs) {
+  log("Setting up MulmoTerminal…\n");
+
+  const [maj, min] = process.versions.node.split(".").map((n) => Number.parseInt(n, 10));
+  const nodeOk = maj > 22 || (maj === 22 && min >= 9);
+  console.log(nodeOk ? `  ✓ Node ${process.versions.node}` : `  ✗ Node ${process.versions.node} — MulmoTerminal needs ≥ 22.9`);
+
+  const hasClaude = claudeInstalled();
+  if (hasClaude) {
+    console.log("  ✓ Claude Code CLI");
+  } else {
+    console.log("  ✗ Claude Code CLI — not found");
+    console.log("      → npm install -g @anthropic-ai/claude-code   (then run `claude` and log in)");
+  }
+
+  for (const [cmd, versionArg, why, hint] of [
+    ["tmux", "-V", "sessions survive a restart", "brew install tmux  ·  apt install tmux"],
+    ["gh", "--version", "PRs & Issues view + one-click PRs", "https://cli.github.com  (then: gh auth login)"],
+    ["codex", "--version", "run OpenAI Codex as an agent", "npm install -g @openai/codex"],
+  ]) {
+    console.log(hasCommand(cmd, versionArg) ? `  ✓ ${cmd} — ${why}` : `  ○ ${cmd} — optional (${why})\n      → ${hint}`);
+  }
+
+  // Config half: derive working-dir presets from Claude history + write config.json.
+  console.log("");
+  await new Promise((res) => {
+    const child = spawn(process.execPath, ["--import", "tsx", join(PKG_DIR, "server", "cli-init.ts"), ...initArgs], {
+      cwd: PKG_DIR,
+      env: { ...process.env },
+      stdio: "inherit",
+    });
+    child.on("exit", (code) => {
+      if (code) process.exitCode = code;
+      res();
+    });
+  });
+
+  if (hasClaude) {
+    if (await promptYesNo("\nConfigure interactively now with the /mulmoterminal-config skill? [y/N] ")) {
+      log("Launching Claude — use  /mulmoterminal-config  (or just ask it to configure MulmoTerminal).");
+      // eslint-disable-next-line sonarjs/no-os-command-from-path
+      spawn("claude", ["Use the mulmoterminal-config skill to configure MulmoTerminal."], { stdio: "inherit" });
+      return;
+    }
+    log("Later: run `claude` in any project and use  /mulmoterminal-config");
+  }
+  log("Setup done. Start MulmoTerminal:  npx mulmoterminal");
 }
 
 function pickOpenCommand() {
@@ -225,12 +293,15 @@ function runServer(port, noOpen, cwd, onChild) {
   });
 }
 
-async function main() {
-  const args = process.argv.slice(2);
+function printHelp() {
+  console.log(`
+Usage: npx mulmoterminal [command] [options]
 
-  if (args.includes("--help") || args.includes("-h")) {
-    console.log(`
-Usage: npx mulmoterminal [options]
+Commands:
+  (none)            Start the server (default)
+  init              First-run setup: check your environment, seed working-directory
+                    presets from your Claude Code history, and write
+                    ~/.mulmoterminal/config.json (idempotent — safe to re-run)
 
 Options:
   --cwd <dir>       Working directory claude runs in (default: current directory; relative paths allowed)
@@ -239,6 +310,18 @@ Options:
   --version         Show version
   --help            Show this help
 `);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args[0] === "init") {
+    await runInit(args.slice(1));
+    return;
+  }
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
     return;
   }
   if (args.includes("--version")) {

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -102,27 +102,29 @@ async function runInit(initArgs) {
 
   // Config half: derive working-dir presets from Claude history + write config.json.
   console.log("");
-  await new Promise((res) => {
+  const initExit = await new Promise((res) => {
     const child = spawn(process.execPath, ["--import", "tsx", join(PKG_DIR, "server", "cli-init.ts"), ...initArgs], {
       cwd: PKG_DIR,
       env: { ...process.env },
       stdio: "inherit",
     });
-    child.on("exit", (code) => {
-      if (code) process.exitCode = code;
-      res();
-    });
+    child.on("exit", (code) => res(code ?? 0));
   });
-
-  if (hasClaude) {
-    if (await promptYesNo("\nConfigure interactively now with the /mulmoterminal-config skill? [y/N] ")) {
-      log("Launching Claude — use  /mulmoterminal-config  (or just ask it to configure MulmoTerminal).");
-      // eslint-disable-next-line sonarjs/no-os-command-from-path
-      spawn("claude", ["Use the mulmoterminal-config skill to configure MulmoTerminal."], { stdio: "inherit" });
-      return;
-    }
-    log("Later: run `claude` in any project and use  /mulmoterminal-config");
+  if (initExit) {
+    process.exitCode = initExit;
+    error("Setup did not complete — see the error above.");
+    return;
   }
+
+  // Offer the interactive skill only in a real terminal; a non-TTY run (CI / piped input)
+  // must never block waiting on stdin.
+  if (hasClaude && process.stdin.isTTY && (await promptYesNo("\nConfigure interactively now with the /mulmoterminal-config skill? [y/N] "))) {
+    log("Launching Claude — use  /mulmoterminal-config  (or just ask it to configure MulmoTerminal).");
+    // eslint-disable-next-line sonarjs/no-os-command-from-path
+    spawn("claude", ["Use the mulmoterminal-config skill to configure MulmoTerminal."], { stdio: "inherit" });
+    return;
+  }
+  if (hasClaude) log("Later: run `claude` in any project and use  /mulmoterminal-config");
   log("Setup done. Start MulmoTerminal:  npx mulmoterminal");
 }
 

--- a/plans/feat-cli-init.md
+++ b/plans/feat-cli-init.md
@@ -1,0 +1,38 @@
+# feat: `npx mulmoterminal init` — idempotent first-run setup
+
+Issue: receptron/mulmoterminal#380
+
+## Goal
+
+One command that takes a new user from zero to a configured MulmoTerminal, safely
+re-runnable (overwrites the managed parts, preserves user-set fields).
+
+## What `init` does
+
+1. **Preflight checks** (report ✓/✗/○ + guidance):
+   - Node ≥ 22.9 (the engine requirement).
+   - `claude` CLI — if missing, **print** `npm i -g @anthropic-ai/claude-code` (never auto-install, per the user's choice).
+   - Optional: `tmux` / `gh` / `codex` — check + print install hints.
+2. **Derive working-dir presets from Claude history** — scan `~/.claude/projects/`, read each
+   project's newest transcript for its recorded `cwd` (the dir NAME can't be decoded — `/`, `.`,
+   and literal `-` all encode to `-`), keep dirs that still exist, dedupe by path (newest mtime),
+   rank by recency, take the top 10.
+3. **Write / merge `~/.mulmoterminal/config.json`** — `mergeConfigUpdate(loadAppConfig(...),
+   { cwdPresets })` + `saveAppConfig` (creates the dir, preserves `soundFile` / `launchers` / …).
+4. **Offer interactive config** — if `claude` is installed, prompt to launch it on the existing
+   `/mulmoterminal-config` skill.
+
+Idempotent: re-running re-derives + overwrites `cwdPresets`; user fields survive.
+
+## Layout (server/ was reorganized into role subdirs)
+
+- `server/config/cwd-presets.ts`: add pure `extractCwdFromTranscript(raw)` + `deriveCwdPresets(records, exists, max)` (+ `CwdRecord`). Tests in `cwd-presets.spec.ts`.
+- `server/cli-init.ts`: I/O orchestration (scan projects → records → derive → write config → print). Run via `tsx` from the bin. Reuses `app-config` (no CLI detection here → cleanly linted).
+- `bin/mulmoterminal.js`: dispatch `init` — env/CLI checks (Node + claude/tmux/gh/codex, the existing PATH-command-detection exception) + report, spawn `cli-init.ts`, then the skill prompt + `claude` launch. `--help` updated.
+- `README.md`: document `npx mulmoterminal init`.
+
+## Acceptance
+
+- `npx mulmoterminal init` prints the check report, sets `cwdPresets` from real Claude dirs, is re-runnable.
+- Never writes a bogus preset (only existing dirs); never clobbers user config fields.
+- Gates green (format / lint / typecheck / typecheck:server / build / test).

--- a/server/cli-init.ts
+++ b/server/cli-init.ts
@@ -32,15 +32,19 @@ function isDir(p: string): boolean {
   }
 }
 
-// Read just the head of a (possibly large) transcript.
+// Read just the head of a (possibly large) transcript. Best-effort: an unreadable file
+// yields "" (→ no cwd) instead of aborting the whole scan.
 function readHead(file: string): string {
-  const fd = openSync(file, "r");
+  let fd: number | undefined;
   try {
+    fd = openSync(file, "r");
     const buf = Buffer.alloc(HEAD_BYTES);
     const n = readSync(fd, buf, 0, HEAD_BYTES, 0);
     return buf.subarray(0, n).toString("utf8");
+  } catch {
+    return "";
   } finally {
-    closeSync(fd);
+    if (fd !== undefined) closeSync(fd);
   }
 }
 

--- a/server/cli-init.ts
+++ b/server/cli-init.ts
@@ -1,0 +1,97 @@
+// `npx mulmoterminal init` — config half (spawned via tsx by bin/mulmoterminal.js).
+// Derives working-directory presets from the user's Claude Code history and writes them
+// into ~/.mulmoterminal/config.json, preserving every other field. Idempotent: re-running
+// re-derives and overwrites the managed presets. The environment/CLI checks + the optional
+// interactive-config launch live in the bin (where PATH-command detection is intentional).
+import { statSync, readdirSync, openSync, readSync, closeSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadAppConfig, mergeConfigUpdate, saveAppConfig } from "./config/app-config.js";
+import { deriveCwdPresets, extractCwdFromTranscript, type CwdRecord } from "./config/cwd-presets.js";
+
+const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
+const PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
+const MAX_PRESETS = 10;
+const HEAD_BYTES = 16384; // cwd is on an early transcript line — read only the head
+
+const log = (m: string) => console.log(`\x1b[36m[init]\x1b[0m ${m}`);
+
+function safeReaddir(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function isDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// Read just the head of a (possibly large) transcript.
+function readHead(file: string): string {
+  const fd = openSync(file, "r");
+  try {
+    const buf = Buffer.alloc(HEAD_BYTES);
+    const n = readSync(fd, buf, 0, HEAD_BYTES, 0);
+    return buf.subarray(0, n).toString("utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// The newest *.jsonl in a project dir (its mtime is our recency signal for the dir's cwd).
+function newestTranscript(dir: string): { file: string; mtimeMs: number } | null {
+  let best: { file: string; mtimeMs: number } | null = null;
+  for (const name of safeReaddir(dir)) {
+    if (!name.endsWith(".jsonl")) continue;
+    try {
+      const s = statSync(path.join(dir, name));
+      if (!best || s.mtimeMs > best.mtimeMs) best = { file: path.join(dir, name), mtimeMs: s.mtimeMs };
+    } catch {
+      // unreadable file — skip
+    }
+  }
+  return best;
+}
+
+function collectCwdRecords(): CwdRecord[] {
+  const records: CwdRecord[] = [];
+  for (const project of safeReaddir(PROJECTS_DIR)) {
+    const dir = path.join(PROJECTS_DIR, project);
+    if (!isDir(dir)) continue;
+    const newest = newestTranscript(dir);
+    if (!newest) continue;
+    const cwd = extractCwdFromTranscript(readHead(newest.file));
+    if (cwd) records.push({ cwd, mtimeMs: newest.mtimeMs });
+  }
+  return records;
+}
+
+function main(): void {
+  const dryRun = process.argv.includes("--dry-run");
+  const presets = deriveCwdPresets(collectCwdRecords(), isDir, MAX_PRESETS);
+  if (presets.length === 0) {
+    log("No existing Claude working directories found — leaving presets unchanged.");
+    return;
+  }
+  if (dryRun) {
+    log(`[dry-run] Would set ${presets.length} working-directory preset(s) (no changes written):`);
+    for (const p of presets) console.log(`    • ${p.path}`);
+    return;
+  }
+  const next = mergeConfigUpdate(loadAppConfig(CONFIG_FILE), { cwdPresets: presets });
+  if (!saveAppConfig(CONFIG_FILE, next)) {
+    console.error(`\x1b[31m[init]\x1b[0m Failed to write ${CONFIG_FILE}`);
+    process.exit(1);
+  }
+  log(`Working-directory presets set from your Claude history (${presets.length}):`);
+  for (const p of presets) console.log(`    • ${p.path}`);
+  log(`Saved to ${CONFIG_FILE}`);
+}
+
+main();

--- a/server/config/cwd-presets.spec.ts
+++ b/server/config/cwd-presets.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizePresets, loadPresets, savePresets } from "./cwd-presets";
+import { sanitizePresets, loadPresets, savePresets, extractCwdFromTranscript, deriveCwdPresets } from "./cwd-presets";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-presets-"));
 
@@ -50,5 +50,47 @@ describe("savePresets / loadPresets", () => {
     // mkdir(`<file>/sub`) fails because the parent is a file → save reports false.
     expect(savePresets(path.join(asFile, "sub", "config.json"), [{ label: "x", path: "/x" }])).toBe(false);
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("extractCwdFromTranscript", () => {
+  it("returns the first cwd found across JSONL lines", () => {
+    const raw = ['{"type":"summary"}', '{"cwd":"/Users/me/proj","role":"user"}', '{"cwd":"/other"}'].join("\n");
+    expect(extractCwdFromTranscript(raw)).toBe("/Users/me/proj");
+  });
+
+  it("skips blank / non-JSON / partial lines", () => {
+    expect(extractCwdFromTranscript(["", "not json {", '{"role":"user"}', '{"cwd":"/p"}'].join("\n"))).toBe("/p");
+  });
+
+  it("returns null when no line carries a cwd", () => {
+    expect(extractCwdFromTranscript('{"a":1}\n{"b":2}')).toBeNull();
+    expect(extractCwdFromTranscript("")).toBeNull();
+  });
+});
+
+describe("deriveCwdPresets", () => {
+  const exists = (p: string) => p !== "/gone";
+
+  it("keeps existing dirs, newest first, deduped by path, capped", () => {
+    const records = [
+      { cwd: "/a", mtimeMs: 100 },
+      { cwd: "/b", mtimeMs: 300 },
+      { cwd: "/a", mtimeMs: 200 }, // newer duplicate of /a
+      { cwd: "/gone", mtimeMs: 999 }, // filtered — doesn't exist
+      { cwd: "/c", mtimeMs: 50 },
+    ];
+    expect(deriveCwdPresets(records, exists, 2)).toEqual([
+      { label: "b", path: "/b" }, // 300
+      { label: "a", path: "/a" }, // duplicate collapsed to its newest (200)
+    ]);
+  });
+
+  it("labels with the trailing segment (handles hyphenated dir names)", () => {
+    expect(deriveCwdPresets([{ cwd: "/x/my-app", mtimeMs: 1 }], () => true)).toEqual([{ label: "my-app", path: "/x/my-app" }]);
+  });
+
+  it("is empty when nothing exists", () => {
+    expect(deriveCwdPresets([{ cwd: "/gone", mtimeMs: 1 }], () => false)).toEqual([]);
   });
 });

--- a/server/config/cwd-presets.ts
+++ b/server/config/cwd-presets.ts
@@ -38,3 +38,41 @@ export function savePresets(file: string, presets: CwdPreset[]): boolean {
     return false;
   }
 }
+
+// A working dir discovered from a Claude session, with the session's mtime for recency.
+export interface CwdRecord {
+  cwd: string;
+  mtimeMs: number;
+}
+
+// The working directory a session ran in, read from its transcript. Claude records `cwd`
+// on its JSONL lines — return the first one found. (The project-dir NAME can't be decoded:
+// `/`, `.`, and a literal `-` all encode to `-`, so `my-app` would decode to `my/app`.)
+export function extractCwdFromTranscript(raw: string): string | null {
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    try {
+      const cwd = (JSON.parse(line) as { cwd?: unknown }).cwd;
+      if (typeof cwd === "string" && cwd) return cwd;
+    } catch {
+      // a partial / non-JSON line (e.g. a truncated head read) — keep scanning
+    }
+  }
+  return null;
+}
+
+// Turn discovered session cwds into launch-form presets, newest first: drop dirs that no
+// longer exist (via `exists`, so no bogus preset ever lands), dedupe by path keeping the
+// newest mtime, then cap at `max`. Pure so the derivation rule is unit-testable.
+export function deriveCwdPresets(records: readonly CwdRecord[], exists: (dir: string) => boolean, max = 10): CwdPreset[] {
+  const newestByPath = new Map<string, number>();
+  for (const { cwd, mtimeMs } of records) {
+    if (!cwd || !exists(cwd)) continue;
+    const prev = newestByPath.get(cwd);
+    if (prev === undefined || mtimeMs > prev) newestByPath.set(cwd, mtimeMs);
+  }
+  return [...newestByPath.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, max)
+    .map(([dir]) => ({ label: path.basename(dir) || dir, path: dir }));
+}


### PR DESCRIPTION
## Summary

Adds an `init` subcommand so a new user goes from zero to a configured MulmoTerminal in one command — and can safely re-run it any time.

```
$ npx mulmoterminal init
[mulmoterminal] Setting up MulmoTerminal…

  ✓ Node 24.12.0
  ✓ Claude Code CLI
  ✓ tmux — sessions survive a restart
  ✓ gh — PRs & Issues view + one-click PRs
  ✓ codex — run OpenAI Codex as an agent

[init] Working-directory presets set from your Claude history (10):
    • /Users/you/ss/llm/mulmoterminal3
    • /Users/you/ss/llm/mulmocast-cli
    • …
[init] Saved to /Users/you/.mulmoterminal/config.json

Configure interactively now with the /mulmoterminal-config skill? [y/N]
```

## What it does

1. **Preflight checks** — Node ≥ 22.9, `claude` CLI (missing → *print* `npm i -g @anthropic-ai/claude-code`, never auto-install), optional `tmux` / `gh` / `codex` (✓/○ + install hint). tmux is probed with `-V` (it doesn't accept `--version`).
2. **Seed working-dir presets from Claude history** — reads each `~/.claude/projects/*` project's newest transcript for its recorded `cwd` (the dir *name* can't be decoded — `/`, `.`, and a literal `-` all encode to `-`), keeps dirs that still exist, dedupes by path (newest mtime), ranks by recency, takes the top 10.
3. **Write `~/.mulmoterminal/config.json`** — `loadAppConfig` + `mergeConfigUpdate({ cwdPresets })` + `saveAppConfig`, so `soundFile` / `launchers` / … survive. **Idempotent** — re-run overwrites the managed presets.
4. **Offer interactive config** — if `claude` is installed, prompt to launch it on the shipped `/mulmoterminal-config` skill.
5. `npx mulmoterminal init --dry-run` previews the presets without writing.

## Items to Confirm / Review

- **Design choices (per the user):** missing `claude` is *reported only* (no auto-install); the skill hand-off launches the existing `/mulmoterminal-config`.
- **Never writes a bogus preset** — derivation reads the real `cwd` from transcripts and filters to existing dirs, so hyphenated dir names (`mulmocast-cli`) are correct (decoding the dir name would mangle them).
- **Layout:** pure `deriveCwdPresets` / `extractCwdFromTranscript` in `server/config/cwd-presets.ts` (unit-tested); I/O orchestration in `server/cli-init.ts` (run via `tsx`, reuses `app-config`); env/CLI detection + the `claude` launch in `bin/mulmoterminal.js` (the PATH-command-detection exception the bin already uses).
- Verified end-to-end with `--dry-run` (no config mutation): all checks correct, 10 real dirs derived. Gates green (format / lint / typecheck / typecheck:server / build / test — 115 files).

## User Prompt

> `npx mulmoterminal@latest init` で、初期設定できると良いね。既存の claude code のログをみて、working dir をセットしたり、claude code ないなら入れたり、node のバージョンチェックしたり。他、初期設定や設定で必要なものを抽出して、そういうのを作ってほしい。で、claude code が入っている場合は、skill を起動して設定できると楽かな。冪等性を考慮して、何度も設定できるように上書きするようになるとよい

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)