### PR TITLE
feat: show the 5h/7d rate-limit window usage in the header (#387)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ The Settings modal (⚙) persists per-user UI choices to `~/.mulmoterminal/confi
 | `pushEnabled` | `true` to send a **Web Push** to your registered devices when a background task finishes. Off by default; only sends while the **RemoteHost** channel is connected (see below). |
 | `worklogEnabled` | `true` to run the built-in **dev worklog** batch (see below). Off by default (each run spawns an LLM session, so it costs tokens). |
 | `worklogIntervalHours` | Worklog cadence in hours (default `6`, clamped to `1`–`168`). |
+| `rateLimitsEnabled` | `true` to show how much of your subscription's **5-hour / 7-day** rate-limit windows is spent, as a header chip. Off by default — it costs one terminal row per cell (see below). |
 
 #### Header buttons
 
@@ -372,6 +373,21 @@ panes you're not watching. Delivery is handled by the separate `mulmoserver` `se
 Cloud Function; MulmoTerminal only makes the call, and only while the **RemoteHost**
 channel is connected (its Google sign-in supplies the notification auth). With RemoteHost
 disconnected, or with no device registered, the toggle is a no-op.
+
+**Rate-limit windows.** Enable `rateLimitsEnabled` in Settings to show a header chip with
+how much of your Claude subscription's **5-hour** and **7-day** windows is spent — the
+budget every session shares, which is why a grid burns it fastest. The chip reports the
+fuller of the two windows and names both (plus their reset times) on hover.
+
+Those windows are only readable through Claude Code's **status line**, so MulmoTerminal
+injects one into each `claude` it spawns; it prints nothing and just reports the numbers
+back. That is the cost of the feature, and why it's off by default: Claude Code renders a
+row for the status line either way, so enabling it spends **one terminal row per cell**. A
+terminal whose own settings already define a `statusLine` is skipped — Claude Code allows
+one, and yours already shows these numbers. Requires a **Claude Pro/Max** subscription
+(API-key billing has no such window), and the numbers appear only once a session has had
+its first response — only sessions that are working report, which is why every session
+gets the status line rather than one.
 
 **Dev worklog (cross-clone).** Set `worklogEnabled: true` in
 `~/.mulmoterminal/config.json` (and **restart** — the scheduler reads its tasks at boot)

--- a/plans/feat-387-rate-limit-window.md
+++ b/plans/feat-387-rate-limit-window.md
@@ -1,0 +1,68 @@
+# feat #387: 5時間/7日レート制限ウィンドウの消費率をツールバーに表示
+
+## User Prompt
+
+> （Zenn記事 https://zenn.dev/sonicmoov/articles/8712598f532b18 を示して）これでやくにたつものある？ mulmoterminalで。
+>
+> ウィンドウ ってwebだと普通に見えるけど、これってapiでデータ取れるの？
+>
+> （実装するか → ）はい
+
+記事の statusline が出している項目のうち、コンテキスト使用量（`ModelContextBadge`）とコスト（`/api/cost`）は実装済みで、**5時間/7日ウィンドウの消費率だけが無い**と判明。mulmoterminal は Claude を並列に回すため、アカウント共有リソースであるこのウィンドウを一番速く食い潰す＝一番効く指標。
+
+設計判断（対話で確定）:
+1. statusLine は **ユーザが未設定のときだけ注入**（自前 statusLine 持ちは上書きしない）。
+2. 空行の実測を受けて **`rateLimitsEnabled`（既定OFF）の opt-in**。ON時は**全セッションに注入**（新鮮さ優先）、表示は**トップヘッダーに1つ**（アカウント共有の値なのでセル単位に出さない）。
+
+## 背景（実コード / 一次情報）
+
+- 公開 HTTP API は**無い**。Messages API の `x-ratelimit-*` / `retry-after` は API キー従量課金枠（RPM/TPM/TPD）で別物。
+- transcript にも**無い**（`rate_limits` 出現数 0）→ トークンからの逆算は不可（分母が非公開）。
+- **Claude Code の statusLine が stdin で渡す JSON に入っている**（唯一の入手経路）:
+
+```jsonc
+"rate_limits": {
+  "five_hour": { "used_percentage": 23.5, "resets_at": 1738425600 },  // % は float、resets_at は epoch 秒
+  "seven_day": { "used_percentage": 41.2, "resets_at": 1738857600 }
+}
+```
+
+- 制約（ドキュメント明記）: **Pro/Max のみ** / **最初の API レスポンス後**に出現 / `five_hour`・`seven_day` は**独立に欠けうる**。
+- 既存の注入経路に相乗りできる: `hookSettingsJson()`（`server/index.ts:769`）が `claude --settings` で `hooks` を注入し、各フックが `curl -s -X POST /api/hook -H 'x-mt-session: <id>' -d @-` で stdin を POST。statusLine も stdin で JSON を受けるので**同じ形**。
+
+## 変更
+
+- `server/agents/statusline.ts`（新規・純粋関数）
+  - `extractRateLimits(payload)` … statusLine payload から 5h/7d を抽出。欠損・型不正・非数値は `null` に落とす。両方無ければ `null`（「表示しない」と「0%」を区別するため）。
+  - `statusLineConfigured(rawSettings[])` … user (`~/.claude/settings.json`) と project (`<cwd>/.claude/settings.json`, `settings.local.json`) の各レイヤに `statusLine` があるか。壊れた JSON は「有り」に倒して**注入しない**＝安全側。
+  - `statusLineCommand(host, port, sessionId)` … 注入する statusLine コマンド（`curl ... -d @- >/dev/null 2>&1` で出力は空）。
+- `server/config/app-config.ts` / `config-routes.ts`
+  - `rateLimitsEnabled`（既定 false）を型・既定・sanitize・load・**save**・API 応答に追加。
+  - `getRateLimitsEnabled()` を live 参照（次に開くセッションから反映）。
+- `server/index.ts`
+  - `hookSettingsJson()` に、**opt-in が ON かつ** `statusLineConfigured()` が false のときだけ `statusLine` を混ぜる。
+  - `POST /api/rate-limits` … payload を `extractRateLimits` に通して最新値を保持（ウィンドウはアカウント共有なのでグローバルに1件）。
+  - `GET /api/rate-limits` … 最新値を返す（無ければ `null`）。
+- クライアント
+  - `src/composables/useRateLimits.ts` … 取得（AbortController + 8s タイムアウト、ON の間だけ 60s ポーリング、失敗時は前値を保持）。
+  - `AppToolbar.vue` … チップ表示（埋まっている方の % を出し、ツールチップに 5h/7d とリセットまでの残り。75% 以上で警告色）。**セル単位ではなくツールバーに1つ**。
+  - `SettingsModal.vue` / `App.vue` / `GridView.vue` … トグル（`pushEnabled` と同じ経路）。
+- 欠損時（非サブスク / 初回レスポンス前 / 片方欠損）はチップを出さない。
+
+## テスト
+
+- `server/agents/statusline.spec.ts`
+  - `extractRateLimits`: 正常 / `rate_limits` 欠損 / 片方欠損 / `used_percentage` が null・文字列・NaN / payload が非オブジェクト。
+  - `hasStatusLine`: 有り / 無し / 空 / 壊れた JSON（→ 有り扱い）。
+- `server/agents/rate-limit-routes.spec.ts`: 保存 / rate_limits 無しの payload は前値維持 / cross-origin 拒否 / GET 応答（値・null）。
+- 既存 `app-config.spec.ts` の全体形の期待値を更新（新フィールド）。
+
+## 実機検証（実施済み）
+
+- **空行は描画される**（実測）。statusLine 無し / 空出力を tmux で並べて比較したところ、空出力側はフッター直上に空行が1行増えた。→ この結果を受けて **`rateLimitsEnabled`（既定OFF）の opt-in** に変更。ONにした人だけが1セルあたり1行を払う。
+- **データ源は裏付け済み**（実測）。payload をファイルに落とす statusLine で実セッションを走らせ、`rate_limits: { five_hour: { used_percentage: 11, resets_at: … }, seven_day: { used_percentage: 48, … } }` を実際に受信。ドキュメントは float 例だが実値は int も来るため、`extractRateLimits` は有限数なら受ける。
+- **全セッションに注入する理由**: 報告するのは「動いているセッション」だけ（statusLine は会話更新時に再実行され、`rate_limits` は最初のAPIレスポンス後に現れる）。1つに絞るとそのセルがアイドルの間、他セルが燃やした分を取りこぼす。
+
+## ゲート
+
+`yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test`

--- a/server/agents/rate-limit-routes.spec.ts
+++ b/server/agents/rate-limit-routes.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Express } from "express";
+import { mountRateLimitRoutes, type RateLimitRouteDeps } from "./rate-limit-routes.js";
+import type { RateLimits } from "./statusline.js";
+
+interface FakeRes {
+  statusCode: number;
+  payload: unknown;
+  status(code: number): FakeRes;
+  json(body: unknown): FakeRes;
+}
+function makeRes(): FakeRes {
+  return {
+    statusCode: 200,
+    payload: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body) {
+      this.payload = body;
+      return this;
+    },
+  };
+}
+
+type Handler = (req: { headers: { origin?: string }; body?: unknown }, res: FakeRes) => unknown;
+
+// Mount with the given deps and hand back the handlers by method — no HTTP server needed
+// (mirrors tmux-routes.spec's capture pattern).
+function mountAndCapture(deps: RateLimitRouteDeps): { post: Handler; get: Handler } {
+  const posts = new Map<string, Handler>();
+  const gets = new Map<string, Handler>();
+  const app = {
+    post: (p: string, h: Handler) => posts.set(p, h),
+    get: (p: string, h: Handler) => gets.set(p, h),
+  } as unknown as Express;
+  mountRateLimitRoutes(app, deps);
+  const post = posts.get("/api/rate-limits");
+  const get = gets.get("/api/rate-limits");
+  if (!post || !get) throw new Error("routes not mounted");
+  return { post, get };
+}
+
+const limits: RateLimits = { fiveHour: { usedPercentage: 23.5, resetsAt_sec: 1738425600 }, sevenDay: null };
+const payload = { rate_limits: { five_hour: { used_percentage: 23.5, resets_at: 1738425600 } } };
+
+function makeDeps(overrides: Partial<RateLimitRouteDeps> = {}): RateLimitRouteDeps {
+  return {
+    isAllowedOrigin: () => true,
+    setRateLimits: vi.fn(),
+    getRateLimits: () => null,
+    ...overrides,
+  };
+}
+
+describe("POST /api/rate-limits", () => {
+  it("stores the windows extracted from a statusLine payload", () => {
+    const setRateLimits = vi.fn();
+    const { post } = mountAndCapture(makeDeps({ setRateLimits }));
+    const res = makeRes();
+    post({ headers: {}, body: payload }, res);
+    expect(setRateLimits).toHaveBeenCalledWith(limits);
+    expect(res.payload).toEqual({ ok: true });
+  });
+
+  it("keeps the last known windows when a payload carries none", () => {
+    const setRateLimits = vi.fn();
+    const { post } = mountAndCapture(makeDeps({ setRateLimits }));
+    const res = makeRes();
+    post({ headers: {}, body: { model: { display_name: "Opus" } } }, res);
+    expect(setRateLimits).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("rejects a cross-origin write without storing (CSRF guard)", () => {
+    const setRateLimits = vi.fn();
+    const { post } = mountAndCapture(makeDeps({ isAllowedOrigin: () => false, setRateLimits }));
+    const res = makeRes();
+    post({ headers: { origin: "https://evil.example" }, body: payload }, res);
+    expect(res.statusCode).toBe(403);
+    expect(setRateLimits).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/rate-limits", () => {
+  it("serves the stored windows", () => {
+    const { get } = mountAndCapture(makeDeps({ getRateLimits: () => limits }));
+    const res = makeRes();
+    get({ headers: {} }, res);
+    expect(res.payload).toEqual(limits);
+  });
+
+  it("serves null when nothing has been reported yet", () => {
+    const { get } = mountAndCapture(makeDeps());
+    const res = makeRes();
+    get({ headers: {} }, res);
+    expect(res.payload).toBeNull();
+  });
+});

--- a/server/agents/rate-limit-routes.ts
+++ b/server/agents/rate-limit-routes.ts
@@ -1,0 +1,29 @@
+import type { Express } from "express";
+import { extractRateLimits, type RateLimits } from "./statusline.js";
+
+// Deps injected from index.ts so the origin guard and the store boundary are testable
+// without booting the server (mirrors tmux-routes / gitRemote / open-dir).
+export interface RateLimitRouteDeps {
+  isAllowedOrigin: (origin?: string) => boolean;
+  // The windows are an account-wide budget shared by every session, so the store holds
+  // one latest value rather than one per session.
+  setRateLimits: (limits: RateLimits) => void;
+  getRateLimits: () => RateLimits | null;
+}
+
+export function mountRateLimitRoutes(app: Express, deps: RateLimitRouteDeps): void {
+  // Written by the statusLine we inject into `claude --settings`, which pipes Claude
+  // Code's status payload here on every re-render.
+  app.post("/api/rate-limits", (req, res) => {
+    if (!deps.isAllowedOrigin(req.headers.origin)) return res.status(403).json({ error: "forbidden origin" });
+    const limits = extractRateLimits(req.body);
+    // A payload without rate_limits is routine (API-key billing, or before the session's
+    // first API response) — keep the last known windows rather than blanking them.
+    if (limits) deps.setRateLimits(limits);
+    res.json({ ok: true });
+  });
+
+  app.get("/api/rate-limits", (_req, res) => {
+    res.json(deps.getRateLimits());
+  });
+}

--- a/server/agents/statusline.spec.ts
+++ b/server/agents/statusline.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { extractRateLimits, statusLineConfigured, statusLineCommand } from "./statusline";
+
+const payload = (rateLimits: unknown) => ({ model: { display_name: "Opus" }, rate_limits: rateLimits });
+
+describe("extractRateLimits", () => {
+  it("reads both windows, keeping the fractional percentage and epoch reset", () => {
+    expect(
+      extractRateLimits(
+        payload({
+          five_hour: { used_percentage: 23.5, resets_at: 1738425600 },
+          seven_day: { used_percentage: 41.2, resets_at: 1738857600 },
+        }),
+      ),
+    ).toEqual({
+      fiveHour: { usedPercentage: 23.5, resetsAt_sec: 1738425600 },
+      sevenDay: { usedPercentage: 41.2, resetsAt_sec: 1738857600 },
+    });
+  });
+
+  it("keeps a window that is present when the other is absent (they drop independently)", () => {
+    expect(extractRateLimits(payload({ five_hour: { used_percentage: 10, resets_at: 1 } }))).toEqual({
+      fiveHour: { usedPercentage: 10, resetsAt_sec: 1 },
+      sevenDay: null,
+    });
+  });
+
+  it("keeps a window whose resets_at is missing", () => {
+    expect(extractRateLimits(payload({ seven_day: { used_percentage: 0 } }))).toEqual({
+      fiveHour: null,
+      sevenDay: { usedPercentage: 0, resetsAt_sec: null },
+    });
+  });
+
+  it("is null without rate_limits — API-key billing, or before the first API response", () => {
+    expect(extractRateLimits({ model: { display_name: "Opus" } })).toBeNull();
+    expect(extractRateLimits(payload({}))).toBeNull();
+  });
+
+  it("drops a window whose percentage is not a finite number", () => {
+    expect(extractRateLimits(payload({ five_hour: { used_percentage: null }, seven_day: { used_percentage: "41.2" } }))).toBeNull();
+    expect(extractRateLimits(payload({ five_hour: { used_percentage: NaN } }))).toBeNull();
+  });
+
+  it("survives junk input", () => {
+    expect(extractRateLimits(null)).toBeNull();
+    expect(extractRateLimits("not json")).toBeNull();
+    expect(extractRateLimits(payload("nope"))).toBeNull();
+    expect(extractRateLimits(payload({ five_hour: 5 }))).toBeNull();
+  });
+});
+
+describe("statusLineConfigured", () => {
+  it("is false when no layer defines one — the slot is free", () => {
+    expect(statusLineConfigured([""])).toBe(false);
+    expect(statusLineConfigured(["   ", '{"hooks":{}}'])).toBe(false);
+    expect(statusLineConfigured([])).toBe(false);
+  });
+
+  it("is true when any layer defines one (user or project)", () => {
+    expect(statusLineConfigured(['{"statusLine":{"type":"command","command":"~/.claude/statusline.sh"}}'])).toBe(true);
+    expect(statusLineConfigured(['{"hooks":{}}', '{"statusLine":{"type":"command","command":"x"}}'])).toBe(true);
+  });
+
+  it("treats unparseable settings as configured, so we never clobber what we can't read", () => {
+    expect(statusLineConfigured(["not json{"])).toBe(true);
+  });
+});
+
+describe("statusLineCommand", () => {
+  it("posts stdin to /api/rate-limits tagged with the session, printing nothing", () => {
+    const cmd = statusLineCommand("localhost", 34567, "abc-123");
+    expect(cmd).toContain("http://localhost:34567/api/rate-limits");
+    expect(cmd).toContain("-H 'x-mt-session: abc-123'");
+    expect(cmd).toContain("-d @-");
+    expect(cmd).toContain(">/dev/null 2>&1");
+  });
+});

--- a/server/agents/statusline.ts
+++ b/server/agents/statusline.ts
@@ -1,0 +1,59 @@
+// Claude Code pipes a JSON status payload to the configured `statusLine` command on
+// stdin. It is the only source for the subscription rate-limit windows: they are not on
+// the Messages API (whose x-ratelimit-* headers are the API-key RPM/TPM quota, a
+// different budget) and not in the transcript, so they cannot be derived from tokens.
+//
+// `rate_limits` is absent for API-key billing, absent until the session's first API
+// response, and each window can be absent on its own — nothing here is guaranteed.
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const finiteNumber = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+export interface RateLimitWindow {
+  usedPercentage: number; // 0-100, fractional
+  resetsAt_sec: number | null; // Unix epoch seconds
+}
+
+export interface RateLimits {
+  fiveHour: RateLimitWindow | null;
+  sevenDay: RateLimitWindow | null;
+}
+
+function windowFrom(raw: unknown): RateLimitWindow | null {
+  if (!isRecord(raw)) return null;
+  const used = finiteNumber(raw.used_percentage);
+  return used === null ? null : { usedPercentage: used, resetsAt_sec: finiteNumber(raw.resets_at) };
+}
+
+// Null when the payload carries neither window, so a caller can tell "nothing to show"
+// from "0% used".
+export function extractRateLimits(payload: unknown): RateLimits | null {
+  if (!isRecord(payload) || !isRecord(payload.rate_limits)) return null;
+  const fiveHour = windowFrom(payload.rate_limits.five_hour);
+  const sevenDay = windowFrom(payload.rate_limits.seven_day);
+  return fiveHour || sevenDay ? { fiveHour, sevenDay } : null;
+}
+
+// Whether any settings layer already defines a statusLine. Claude Code allows one per
+// session, so injecting ours would silently replace the user's — we only take the slot
+// when it is free. Unparseable JSON counts as configured: never clobber what we failed
+// to read. Callers pass "" for a file that doesn't exist.
+export function statusLineConfigured(rawSettings: readonly string[]): boolean {
+  return rawSettings.some((raw) => {
+    if (!raw.trim()) return false;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      return isRecord(parsed) && parsed.statusLine !== undefined;
+    } catch {
+      return true;
+    }
+  });
+}
+
+// The injected statusLine: POST the payload and print nothing, so the row stays empty
+// and the numbers surface in the GUI instead. Mirrors the hook command's shape.
+export function statusLineCommand(host: string, port: string | number, sessionId: string): string {
+  return (
+    `curl -s -X POST http://${host}:${port}/api/rate-limits ` + `-H 'content-type: application/json' -H 'x-mt-session: ${sessionId}' -d @- >/dev/null 2>&1`
+  );
+}

--- a/server/config/app-config.spec.ts
+++ b/server/config/app-config.spec.ts
@@ -123,6 +123,7 @@ describe("loadAppConfig / saveAppConfig", () => {
     pushEnabled: false,
     worklogEnabled: false,
     worklogIntervalHours: 6,
+    rateLimitsEnabled: false,
   };
   it("round-trips presets + soundFile + prRepos + launchers + userMcpServers through a file", () => {
     const dir = tmp();
@@ -138,6 +139,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       pushEnabled: true,
       worklogEnabled: true,
       worklogIntervalHours: 12,
+      rateLimitsEnabled: true,
     };
     expect(saveAppConfig(file, cfg)).toBe(true);
     expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(cfg);
@@ -178,6 +180,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       pushEnabled: false,
       worklogEnabled: false,
       worklogIntervalHours: 6,
+      rateLimitsEnabled: false,
     });
     rmSync(dir, { recursive: true, force: true });
   });
@@ -211,6 +214,7 @@ describe("mergeConfigUpdate", () => {
     pushEnabled: false,
     worklogEnabled: false,
     worklogIntervalHours: 6,
+    rateLimitsEnabled: false,
     ...over,
   });
 

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -32,6 +32,11 @@ export interface AppConfig {
   // session on each run, so it costs tokens). `worklogIntervalHours` is the cadence.
   worklogEnabled: boolean;
   worklogIntervalHours: number;
+  // Report the subscription's 5h / 7d rate-limit windows to the header. Off by default:
+  // the only source is a statusLine injected into each `claude`, and Claude Code renders
+  // a row for it — so enabling costs one terminal line per cell. Only sessions that are
+  // working report, which is why every session gets the statusLine rather than one.
+  rateLimitsEnabled: boolean;
 }
 
 // `id` becomes an MCP server name + `mcp__<id>` tool prefix, so restrict to a plain
@@ -110,6 +115,10 @@ export function sanitizePushEnabled(input: unknown): boolean {
   return input === true;
 }
 
+export function sanitizeRateLimitsEnabled(input: unknown): boolean {
+  return input === true;
+}
+
 export const DEFAULT_WORKLOG_INTERVAL_HOURS = 6;
 const MIN_WORKLOG_INTERVAL_HOURS = 1;
 const MAX_WORKLOG_INTERVAL_HOURS = 168; // one week
@@ -137,6 +146,7 @@ const emptyConfig = (): AppConfig => ({
   pushEnabled: false,
   worklogEnabled: false,
   worklogIntervalHours: DEFAULT_WORKLOG_INTERVAL_HOURS,
+  rateLimitsEnabled: false,
 });
 
 export function loadAppConfig(file: string): AppConfig {
@@ -154,6 +164,7 @@ export function loadAppConfig(file: string): AppConfig {
       pushEnabled: sanitizePushEnabled(raw?.pushEnabled),
       worklogEnabled: sanitizeWorklogEnabled(raw?.worklogEnabled),
       worklogIntervalHours: sanitizeWorklogIntervalHours(raw?.worklogIntervalHours),
+      rateLimitsEnabled: sanitizeRateLimitsEnabled(raw?.rateLimitsEnabled),
     };
   } catch {
     return emptyConfig();
@@ -177,6 +188,7 @@ export function mergeConfigUpdate(base: AppConfig, body: Record<string, unknown>
     pushEnabled: body.pushEnabled !== undefined ? sanitizePushEnabled(body.pushEnabled) : base.pushEnabled,
     worklogEnabled: body.worklogEnabled !== undefined ? sanitizeWorklogEnabled(body.worklogEnabled) : base.worklogEnabled,
     worklogIntervalHours: body.worklogIntervalHours !== undefined ? sanitizeWorklogIntervalHours(body.worklogIntervalHours) : base.worklogIntervalHours,
+    rateLimitsEnabled: body.rateLimitsEnabled !== undefined ? sanitizeRateLimitsEnabled(body.rateLimitsEnabled) : base.rateLimitsEnabled,
   };
 }
 
@@ -196,6 +208,7 @@ export function saveAppConfig(file: string, config: AppConfig): boolean {
       pushEnabled: config.pushEnabled,
       worklogEnabled: config.worklogEnabled,
       worklogIntervalHours: config.worklogIntervalHours,
+      rateLimitsEnabled: config.rateLimitsEnabled,
     };
     writeFileSync(file, JSON.stringify(payload, null, 2));
     return true;

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -44,6 +44,12 @@ export function getPushEnabled(): boolean {
   return config.pushEnabled;
 }
 
+// Whether to inject the statusLine that reports the 5h / 7d windows — read live at spawn,
+// so a settings toggle applies to the next session opened rather than needing a restart.
+export function getRateLimitsEnabled(): boolean {
+  return config.rateLimitsEnabled;
+}
+
 // The periodic dev-work-log settings — read live so a toggle takes effect on the next
 // scheduler wiring (a restart, currently). Off by default.
 export function getWorklogConfig(): { enabled: boolean; intervalHours: number } {
@@ -84,6 +90,7 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     pushEnabled: config.pushEnabled,
     worklogEnabled: config.worklogEnabled,
     worklogIntervalHours: config.worklogIntervalHours,
+    rateLimitsEnabled: config.rateLimitsEnabled,
   });
 
   app.get("/api/config", (_req, res) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,16 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./infra/plugins
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers, getHeaderConfig, getPushEnabled, getWorklogConfig } from "./config/config-routes.js";
+import {
+  mountConfigRoutes,
+  getPrRepos,
+  getLaunchers,
+  getUserMcpServers,
+  getHeaderConfig,
+  getPushEnabled,
+  getRateLimitsEnabled,
+  getWorklogConfig,
+} from "./config/config-routes.js";
 import { sendWebPush } from "./infra/web-push.js";
 import { buildHeaderContext, loadHeaderConfig } from "./config/header-context.js";
 import { resolveHeader, resolveButtonCommand, headerHasPrButton } from "./config/header-resolve.js";
@@ -24,6 +33,8 @@ import { mountFilesBrowseRoutes } from "./files/files-browse.js";
 import { gitStatus } from "./git/git-status.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxHasSession, tmuxKillSession, tmuxListSessionIds, isResumableTmuxSession } from "./infra/tmux.js";
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
+import { statusLineConfigured, statusLineCommand, type RateLimits } from "./agents/statusline.js";
+import { mountRateLimitRoutes } from "./agents/rate-limit-routes.js";
 import {
   sandboxEnabled,
   sandboxPlatformSupported,
@@ -766,7 +777,34 @@ function setWaiting(id: string, waiting: boolean, event?: string) {
 // per-session tool-call history that the GUI's tools pane shows. A failed tool
 // fires PostToolUseFailure (NOT PostToolUse), so we register both to complete the
 // entry either way — otherwise a failed call would stay stuck on "running".
-function hookSettingsJson(host: string, sessionId: string) {
+// The settings layers Claude Code merges for a session, user first then project. Read
+// best-effort: an unreadable layer simply contributes no statusLine.
+function claudeSettingsLayers(cwd: string): string[] {
+  const files = [
+    path.join(os.homedir(), ".claude", "settings.json"),
+    path.join(cwd, ".claude", "settings.json"),
+    path.join(cwd, ".claude", "settings.local.json"),
+  ];
+  return files.map((file) => {
+    try {
+      return readFileSync(file, "utf8");
+    } catch {
+      return "";
+    }
+  });
+}
+
+// Claude Code allows one statusLine per session, and it is the only source for the
+// subscription rate-limit windows (see agents/statusline.ts). Opt-in, because Claude Code
+// renders a row for it and ours prints nothing — every cell pays a blank line. Take the
+// slot only when it is free: a user with their own statusLine already sees those numbers
+// there, and replacing it would cost them the rest of their status line.
+function statusLineSetting(host: string, sessionId: string, cwd: string) {
+  if (!getRateLimitsEnabled() || statusLineConfigured(claudeSettingsLayers(cwd))) return {};
+  return { statusLine: { type: "command", command: statusLineCommand(host, PORT, sessionId) } };
+}
+
+function hookSettingsJson(host: string, sessionId: string, cwd: string) {
   // Tag every hook with mulmoterminal's STABLE session id via a header. Claude reissues its own session_id
   // on /clear and /compact, but the PTY — and the id the client tracks — stays this one, so attributing
   // hooks by this header keeps activity / header prompt / tool history correlated across a clear.
@@ -785,6 +823,7 @@ function hookSettingsJson(host: string, sessionId: string) {
       PostToolUse: toolEntry,
       PostToolUseFailure: toolEntry,
     },
+    ...statusLineSetting(host, sessionId, cwd),
   });
 }
 
@@ -1742,6 +1781,18 @@ mountTmuxRoutes(app, {
   },
 });
 
+// The subscription's 5h / 7d rate-limit windows, reported by the statusLine we inject.
+// One value for the whole app: the budget is per-account, shared by every session — which
+// is exactly why running a grid of them burns it fastest.
+let latestRateLimits: RateLimits | null = null;
+mountRateLimitRoutes(app, {
+  isAllowedOrigin,
+  setRateLimits: (limits) => {
+    latestRateLimits = limits;
+  },
+  getRateLimits: () => latestRateLimits,
+});
+
 // codex's own sessions for a workspace (?cwd=, default CLAUDE_CWD), read from ~/.codex rollouts —
 // the single view's sidebar lists these so past codex conversations are switchable + resumable.
 app.get("/api/codex/sessions", async (req, res) => {
@@ -2176,7 +2227,7 @@ function spawnClaudePty(
     resume,
     canResume,
     // In the sandbox the hooks + GUI MCP are reached over host.docker.internal.
-    settings: hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId),
+    settings: hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, cwd),
     permissionMode: CLAUDE_PERMISSION_MODE,
     attachGuiMcp,
     mcpConfig: mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox),

--- a/src/App.vue
+++ b/src/App.vue
@@ -150,8 +150,21 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (theme + notification sound), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { defaultCwd, loadConfig, saveSound, pushEnabled, savePushEnabled, prRepos, savePrRepos, launchers, saveLaunchers, userMcpServers, saveUserMcpServers } =
-  useAppConfig();
+const {
+  defaultCwd,
+  loadConfig,
+  saveSound,
+  pushEnabled,
+  savePushEnabled,
+  rateLimitsEnabled,
+  saveRateLimitsEnabled,
+  prRepos,
+  savePrRepos,
+  launchers,
+  saveLaunchers,
+  userMcpServers,
+  saveUserMcpServers,
+} = useAppConfig();
 // Drive the single view's dir overrides off the dir the terminal ACTUALLY runs in
 // (reported by the server, which may resolve/fall back), not the static default — so
 // the badge/theme/colors always track the active session. Falls back to the default
@@ -374,6 +387,7 @@ function onSession(id: string) {
       v-if="showSettings"
       :sound-file="soundFile"
       :push-enabled="pushEnabled"
+      :rate-limits-enabled="rateLimitsEnabled"
       :pr-repos="prRepos"
       :launchers="launchers"
       :user-mcp-servers="userMcpServers"
@@ -381,6 +395,7 @@ function onSession(id: string) {
       :session-id="activeId"
       @update-sound="saveSound"
       @update-push-enabled="savePushEnabled"
+      @update-rate-limits-enabled="saveRateLimitsEnabled"
       @update-repos="savePrRepos"
       @update-launchers="saveLaunchers"
       @update-user-mcp="saveUserMcpServers"

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch, onUnmounted } from "vue";
 import { useRoute } from "vue-router";
 import { router } from "../router";
 import NotificationBell from "./NotificationBell.vue";
@@ -10,6 +10,8 @@ import { useAccountingView, accountingViewOpen } from "../composables/useAccount
 import { useWikiBrowse, wikiGotoIndex } from "../composables/useWikiBrowse";
 import { usePrsView, prsGotoIndex } from "../composables/usePrsView";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
+import { useRateLimits } from "../composables/useRateLimits";
+import { useAppConfig } from "../composables/useAppConfig";
 import type { Shortcut } from "../types/shortcuts";
 import type { StatusCounts } from "./gridTabs";
 
@@ -43,6 +45,43 @@ const { isOpen: accountingOpen } = useAccountingView();
 const { isOpen: wikiOpen } = useWikiBrowse();
 const { isOpen: prsOpen } = usePrsView();
 const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
+
+// The subscription's 5h / 7d windows. Account-wide (every session draws on the same
+// budget), so one chip serves both views — that's why it lives here and not in a cell.
+// Opt-in: reporting them costs a terminal row per cell, so poll only while enabled.
+const { rateLimitsEnabled } = useAppConfig();
+const { limits: rateLimits, start: startRateLimits, stop: stopRateLimits } = useRateLimits();
+watch(rateLimitsEnabled, (on) => (on ? startRateLimits() : stopRateLimits()), { immediate: true });
+onUnmounted(() => stopRateLimits());
+
+// Percent for the fuller of the two windows — the one that will bite first.
+const rateLimitPeak = computed(() => {
+  const l = rateLimits.value;
+  if (!l) return null;
+  return Math.max(l.fiveHour?.usedPercentage ?? 0, l.sevenDay?.usedPercentage ?? 0);
+});
+const RATE_LIMIT_WARN_PCT = 75;
+const rateLimitTitle = computed(() => {
+  const l = rateLimits.value;
+  if (!l) return "";
+  const parts: string[] = [];
+  if (l.fiveHour) parts.push(`5h ${Math.round(l.fiveHour.usedPercentage)}% used${resetSuffix(l.fiveHour.resetsAt_sec)}`);
+  if (l.sevenDay) parts.push(`7d ${Math.round(l.sevenDay.usedPercentage)}% used${resetSuffix(l.sevenDay.resetsAt_sec)}`);
+  return `Rate limit — ${parts.join(" · ")}`;
+});
+
+const MS_PER_SEC = 1000;
+const SEC_PER_MIN = 60;
+const MIN_PER_HOUR = 60;
+function resetSuffix(resetsAt_sec: number | null): string {
+  if (resetsAt_sec === null) return "";
+  const remaining_min = Math.round((resetsAt_sec * MS_PER_SEC - Date.now()) / MS_PER_SEC / SEC_PER_MIN);
+  if (remaining_min <= 0) return "";
+  const h = Math.floor(remaining_min / MIN_PER_HOUR);
+  const m = remaining_min % MIN_PER_HOUR;
+  const hours = h ? `${h}h ` : "";
+  return `, resets in ${hours}${m}m`;
+}
 
 const inGrid = computed(() => route.name === "terminals");
 const inSingle = computed(() => !inGrid.value);
@@ -144,6 +183,17 @@ function showPrs(): void {
         <span v-if="statusCounts.done" class="gs gs-done" aria-hidden="true">{{ statusCounts.done }}</span>
         <span v-if="statusCounts.working" class="gs gs-working" aria-hidden="true">{{ statusCounts.working }}</span>
       </span>
+      <span
+        v-if="rateLimitPeak !== null"
+        class="rate-limits"
+        :class="{ 'rl-warn': rateLimitPeak >= RATE_LIMIT_WARN_PCT }"
+        role="img"
+        :aria-label="rateLimitTitle"
+        :title="rateLimitTitle"
+      >
+        <span class="material-symbols-outlined rl-icon" aria-hidden="true">avg_pace</span>
+        <span aria-hidden="true">{{ Math.round(rateLimitPeak) }}%</span>
+      </span>
     </nav>
     <NotificationBell class="toolbar-bell" />
     <RemoteHostControl />
@@ -234,6 +284,26 @@ function showPrs(): void {
   margin-left: 6px;
   padding-left: 10px;
   border-left: 1px solid var(--border);
+}
+/* The account-wide 5h/7d budget: informational until it's nearly spent, so it stays muted
+   and only takes a warning colour near the cap. */
+.rate-limits {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  margin-left: 6px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border);
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  color: var(--muted);
+}
+.rl-icon {
+  font-size: 14px;
+}
+.rate-limits.rl-warn {
+  color: var(--warning, #d29922);
 }
 .gs {
   display: inline-flex;

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -264,6 +264,8 @@ const {
   removePreset,
   saveSound,
   savePushEnabled,
+  rateLimitsEnabled,
+  saveRateLimitsEnabled,
   savePrRepos,
   saveLaunchers,
   saveUserMcpServers,
@@ -330,11 +332,13 @@ function configureAppearance() {
       v-if="showSettings"
       :sound-file="soundFile"
       :push-enabled="pushEnabled"
+      :rate-limits-enabled="rateLimitsEnabled"
       :pr-repos="prRepos"
       :launchers="launchers"
       :user-mcp-servers="userMcpServers"
       @update-sound="saveSound"
       @update-push-enabled="savePushEnabled"
+      @update-rate-limits-enabled="saveRateLimitsEnabled"
       @update-repos="savePrRepos"
       @update-launchers="saveLaunchers"
       @update-user-mcp="saveUserMcpServers"

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -9,6 +9,7 @@ import type { UserMcpServer } from "./userMcp";
 const props = defineProps<{
   soundFile?: string | null;
   pushEnabled?: boolean;
+  rateLimitsEnabled?: boolean;
   prRepos?: string[];
   launchers?: Launcher[];
   userMcpServers?: UserMcpServer[];
@@ -17,7 +18,7 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{
   (e: "update-sound", file: string | null): void;
-  (e: "update-push-enabled", on: boolean): void;
+  (e: "update-push-enabled" | "update-rate-limits-enabled", on: boolean): void;
   (e: "update-repos", repos: string[]): void;
   (e: "update-launchers", launchers: Launcher[]): void;
   (e: "update-user-mcp", servers: UserMcpServer[]): void;
@@ -125,6 +126,10 @@ function clearSound() {
 // Web Push toggle — stateless: reflects props.pushEnabled, emits the new value up (App persists it).
 function onPushToggle(e: Event) {
   if (e.target instanceof HTMLInputElement) emit("update-push-enabled", e.target.checked);
+}
+// Rate-limit windows toggle — stateless like the push one; App persists it.
+function onRateLimitsToggle(e: Event) {
+  if (e.target instanceof HTMLInputElement) emit("update-rate-limits-enabled", e.target.checked);
 }
 async function browseSound() {
   try {
@@ -273,6 +278,17 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
       <label class="push-row">
         <input type="checkbox" :checked="props.pushEnabled ?? false" aria-label="Send a Web Push when a task finishes" @change="onPushToggle" />
         <span>Notify my devices when a task finishes</span>
+      </label>
+
+      <h3 class="section-title">Rate limit windows</h3>
+      <p class="hint">
+        Show how much of your Claude subscription's <strong>5-hour</strong> and <strong>7-day</strong> windows is spent — the budget every session shares, so a
+        grid burns it fastest. Claude Pro/Max only; the numbers appear once a session gets its first response. Costs one terminal row per cell: the windows are
+        only readable through a status line, which Claude Code renders. Skipped for terminals whose settings already define one.
+      </p>
+      <label class="push-row">
+        <input type="checkbox" :checked="props.rateLimitsEnabled ?? false" aria-label="Show rate limit window usage" @change="onRateLimitsToggle" />
+        <span>Show 5h / 7d window usage in the header</span>
       </label>
 
       <h3 class="section-title">Pull request repos</h3>

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -14,6 +14,10 @@ const soundFile = ref<string | null>(null);
 // The actual sending is server-side; the client only reads/writes this flag.
 const pushEnabled = ref(false);
 
+// Report the subscription's 5h / 7d rate-limit windows in the header. SINGLETON like
+// pushEnabled; the reporting is server-side, the client only reads/writes the flag.
+const rateLimitsEnabled = ref(false);
+
 // Cross-repo PR list's repos — also a SINGLETON, so the settings modal (openable from
 // either view) and any future reader share one list; a save in one view is seen by the
 // other instead of each useAppConfig() keeping a divergent copy.
@@ -172,6 +176,14 @@ async function savePushEnabled(on: boolean): Promise<boolean> {
   if (r.ok) pushEnabled.value = r.value === true;
   return r.ok;
 }
+// Persist the "report the rate-limit windows" toggle (partial update). Applies to the
+// next session opened — the statusLine that reports them is injected at spawn.
+async function saveRateLimitsEnabled(on: boolean): Promise<boolean> {
+  const r = await postConfigField<unknown>("rateLimitsEnabled", on);
+  if (r.ok) rateLimitsEnabled.value = r.value === true;
+  return r.ok;
+}
+
 // Persist the cross-repo PR list's repos (partial update, other fields untouched).
 async function savePrRepos(next: string[]): Promise<boolean> {
   const r = await postConfigField<string[]>("prRepos", next);
@@ -214,6 +226,7 @@ export function useAppConfig() {
       adoptServerPresets(c.cwdPresets, version);
       soundFile.value = typeof c.soundFile === "string" ? c.soundFile : null;
       pushEnabled.value = c.pushEnabled === true;
+      rateLimitsEnabled.value = c.rateLimitsEnabled === true;
       prRepos.value = Array.isArray(c.prRepos) ? c.prRepos : [];
       launchers.value = Array.isArray(c.launchers) ? c.launchers : [];
       userMcpServers.value = Array.isArray(c.userMcpServers) ? c.userMcpServers : [];
@@ -232,6 +245,7 @@ export function useAppConfig() {
     userMcpServers,
     soundFile,
     pushEnabled,
+    rateLimitsEnabled,
     saving,
     error,
     loadConfig,
@@ -240,6 +254,7 @@ export function useAppConfig() {
     removePreset,
     saveSound,
     savePushEnabled,
+    saveRateLimitsEnabled,
     savePrRepos,
     saveLaunchers,
     saveUserMcpServers,

--- a/src/composables/useRateLimits.ts
+++ b/src/composables/useRateLimits.ts
@@ -1,0 +1,70 @@
+import { ref } from "vue";
+
+// The subscription's 5h / 7d rate-limit windows, served by GET /api/rate-limits from
+// whatever the injected statusLine last reported. Account-wide, so this is a SINGLETON:
+// every view shows the same budget.
+export interface RateLimitWindow {
+  usedPercentage: number;
+  resetsAt_sec: number | null;
+}
+export interface RateLimits {
+  fiveHour: RateLimitWindow | null;
+  sevenDay: RateLimitWindow | null;
+}
+
+const FETCH_TIMEOUT_MS = 8000;
+// The windows move as sessions work, but slowly — a 5h budget doesn't need second-level
+// tracking, and polling only runs while the feature is enabled.
+const REFRESH_MS = 60_000;
+
+const limits = ref<RateLimits | null>(null);
+let timer: ReturnType<typeof setInterval> | null = null;
+
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const finiteNumber = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+
+function parseWindow(raw: unknown): RateLimitWindow | null {
+  if (!isRecord(raw)) return null;
+  const used = finiteNumber(raw.usedPercentage);
+  return used === null ? null : { usedPercentage: used, resetsAt_sec: finiteNumber(raw.resetsAt_sec) };
+}
+
+function parseLimits(data: unknown): RateLimits | null {
+  if (!isRecord(data)) return null;
+  const fiveHour = parseWindow(data.fiveHour);
+  const sevenDay = parseWindow(data.sevenDay);
+  return fiveHour || sevenDay ? { fiveHour, sevenDay } : null;
+}
+
+// A failure leaves the last known windows in place: a blanked gauge reads as "0% used",
+// which is the opposite of the truth we'd be failing to fetch.
+async function load(): Promise<void> {
+  const controller = new AbortController();
+  const abort = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch("/api/rate-limits", { signal: controller.signal });
+    if (!res.ok) throw new Error(`rate-limits request failed: ${res.status}`);
+    limits.value = parseLimits(await res.json());
+  } catch {
+    // keep the previous value
+  } finally {
+    clearTimeout(abort);
+  }
+}
+
+export function useRateLimits() {
+  // Idempotent: the toolbar mounts once per view, and start() may be re-entered when the
+  // settings toggle flips.
+  function start(): void {
+    void load();
+    if (timer === null) timer = setInterval(() => void load(), REFRESH_MS);
+  }
+
+  function stop(): void {
+    if (timer !== null) clearInterval(timer);
+    timer = null;
+    limits.value = null;
+  }
+
+  return { limits, start, stop, load };
+}


### PR DESCRIPTION
## Summary

Adds an opt-in header chip showing how much of your Claude subscription's **5-hour / 7-day** rate-limit windows is spent. Those windows are an **account-wide budget every session shares** — which is exactly why a grid of agents burns them fastest — and nothing in the app surfaced them. Context % (`ModelContextBadge`) and cost (`/api/cost`) already existed; this was the missing one.

The only way to read them is Claude Code's **statusLine payload**, so MulmoTerminal injects a statusLine (via the `--settings` it already injects for hooks) that prints nothing and POSTs the payload to `/api/rate-limits`.

**Off by default.** Claude Code renders a row for the statusLine whether or not it prints, so enabling costs **one terminal row per cell**.

## Items to Confirm / Review

- **The row cost is real and measured, not assumed.** I ran `claude` in tmux with and without an empty-output statusLine and diffed the panes: the empty one adds a blank row above the footer. That measurement is what turned this from always-on into opt-in — please sanity-check that trade (1 row/cell ↔ the gauge) is the one you want.
- **Injecting into every session, not one.** A single reporter would be cheaper (one row), but `rate_limits` only appears after a session's first API response and the statusLine only re-runs on conversation updates — so **only a working session reports**. One reporter goes stale exactly when other cells are burning the budget. Verify you agree with trading rows for freshness.
- **We take the statusLine slot only when it's free.** Claude Code allows one per session; a user with their own would otherwise lose it (and they already see these numbers there). `statusLineConfigured()` checks user + project layers and treats **unparseable settings as configured** (never clobber what we can't read).
- **Polling**: 60s while enabled only, `null` on failure keeps the last value (a blanked gauge would read as "0% used" — the opposite of the truth).
- **A pre-existing bug this surfaced**: `saveAppConfig()` enumerates the fields it writes, so a new flag silently wouldn't persist. Caught by the existing round-trip test; fixed. Worth knowing the same trap waits for the next field.

## User Prompt

- （Zenn記事 https://zenn.dev/sonicmoov/articles/8712598f532b18 を示して）これでやくにたつものある？ mulmoterminalで。
- ウィンドウ ってwebだと普通に見えるけど、これってapiでデータ取れるの？
- （実装するか →）はい
- ちょっと、よく考えるとこれってterminalごとに出す必要ない？設定でonになっていたらtopのheaderに表示する？
- （空行の実測を受けた選択 →）A（設定ON時に全セッションへ注入・トップヘッダーに1つ表示）

## Data source (investigated, not guessed)

There is **no public HTTP API** for the subscription windows:

- The Messages API's `x-ratelimit-*` / `retry-after` headers are the **API-key** RPM/TPM/TPD quota — a different budget.
- The transcript has no `rate_limits` (0 occurrences), so they can't be back-derived from tokens (the denominator isn't public).
- Claude Code's statusLine payload has them, and it's the only source:

```jsonc
"rate_limits": {
  "five_hour": { "used_percentage": 23.5, "resets_at": 1738425600 },
  "seven_day": { "used_percentage": 41.2, "resets_at": 1738857600 }
}
```

Documented constraints, all handled: **Pro/Max only**, appears **only after the first API response**, and each window **can be absent independently**.

**Verified live**: ran a real session with a statusLine that dumps the payload — received `five_hour: {used_percentage: 11, …}`, `seven_day: {used_percentage: 48, …}`. Note real values arrive as ints where the docs show floats; the extractor accepts any finite number.

## Implementation

- `server/agents/statusline.ts` (new, pure) — `extractRateLimits()` (null unless a window survives, so "nothing to show" ≠ "0%"), `statusLineConfigured()` (user + project layers), `statusLineCommand()`.
- `server/agents/rate-limit-routes.ts` (new) — `POST` (origin-guarded; a payload without `rate_limits` keeps the last value) / `GET`. DI'd like `tmux-routes` so the guard and store boundary are testable.
- `server/index.ts` — inject the statusLine only when **enabled AND the slot is free**; hold the latest windows (one value; the budget is account-wide).
- `server/config/*` — `rateLimitsEnabled` through type/default/sanitize/load/**save**/API response, read live at spawn.
- Client — `useRateLimits` (AbortController + 8s timeout), a toolbar chip (fuller window; both + reset times on hover; warns at ≥75%), and a Settings toggle on the `pushEnabled` path.

## Tests

`server/agents/statusline.spec.ts` (10) and `rate-limit-routes.spec.ts` cover the happy path, `rate_limits` absent, one window absent, missing `resets_at`, non-finite/string percentages, junk payloads, unparseable settings, and the cross-origin reject. Full suite: **1171 passed**.

Gates: `yarn format` / `lint` / `typecheck` / `typecheck:server` / `build` / `test` all pass.

Plan: `plans/feat-387-rate-limit-window.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)