### PR TITLE
chore: add MCP/Playwright config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 .env
+.mcp.json
+.playwright-mcp/


### PR DESCRIPTION
## Summary

ローカル環境固有の設定ファイル（`.mcp.json`, `.playwright-mcp/`）を `.gitignore` に追加し、リポジトリに混入しないようにした。