### PR TITLE
refactor: move bin tests into test/bin directory

### DIFF
--- a/test/bin/update-check.spec.ts
+++ b/test/bin/update-check.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { isNewerVersion, fetchLatestVersion } from "./update-check.js";
+import { isNewerVersion, fetchLatestVersion } from "../../bin/update-check.js";
 
 describe("isNewerVersion", () => {
   const cases: [string, string, boolean][] = [


### PR DESCRIPTION
Move test files for bin/ directory into test/bin/.

## Changes
- Move bin/update-check.spec.ts to test/bin/
- Update all import paths (./update-check → ../../bin/update-check)

## Test Results
✅ All 13 tests in test/bin/update-check.spec.ts pass

This is a minimal, single-directory refactor to validate the approach before scaling to other directories.