### PR TITLE
refactor: move server/config tests into test/server/config

### DIFF
--- a/test/server/config/app-config.spec.ts
+++ b/test/server/config/app-config.spec.ts
@@ -13,7 +13,7 @@ import {
   saveAppConfig,
   mergeConfigUpdate,
   type AppConfig,
-} from "../../../../server/../../server/config/app-config";
+} from "../../../server/config/app-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 

--- a/test/server/config/app-config.spec.ts
+++ b/test/server/config/app-config.spec.ts
@@ -13,7 +13,7 @@ import {
   saveAppConfig,
   mergeConfigUpdate,
   type AppConfig,
-} from "./app-config";
+} from "../../../../server/../../server/config/app-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-appcfg-"));
 

--- a/test/server/config/config-schema.spec.ts
+++ b/test/server/config/config-schema.spec.ts
@@ -12,7 +12,7 @@ import {
   MAX_BUTTONS,
   MAX_CHIPS,
   MAX_SKILL_FILTER,
-} from "./config-schema";
+} from "../../../../server/../../server/config/config-schema";
 
 describe("dirNameField", () => {
   it("trims and caps at NAME_MAX_CHARS", () => {

--- a/test/server/config/config-schema.spec.ts
+++ b/test/server/config/config-schema.spec.ts
@@ -12,7 +12,7 @@ import {
   MAX_BUTTONS,
   MAX_CHIPS,
   MAX_SKILL_FILTER,
-} from "../../../../server/../../server/config/config-schema";
+} from "../../../server/config/config-schema";
 
 describe("dirNameField", () => {
   it("trims and caps at NAME_MAX_CHARS", () => {

--- a/test/server/config/cwd-presets.spec.ts
+++ b/test/server/config/cwd-presets.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizePresets, loadPresets, savePresets, extractCwdFromTranscript, deriveCwdPresets } from "./cwd-presets";
+import { sanitizePresets, loadPresets, savePresets, extractCwdFromTranscript, deriveCwdPresets } from "../../../../server/../../server/config/cwd-presets";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-presets-"));
 

--- a/test/server/config/cwd-presets.spec.ts
+++ b/test/server/config/cwd-presets.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizePresets, loadPresets, savePresets, extractCwdFromTranscript, deriveCwdPresets } from "../../../../server/../../server/config/cwd-presets";
+import { sanitizePresets, loadPresets, savePresets, extractCwdFromTranscript, deriveCwdPresets } from "../../../server/config/cwd-presets";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-presets-"));
 

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "./dir-config";
+import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "../../../../server/../../server/config/dir-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
 const EMPTY = {

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "../../../../server/../../server/config/dir-config";
+import { resolveDirSound, loadDirConfig, publicDirConfig, dirSoundFile, dirConfigWriteTarget } from "../../../server/config/dir-config";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
 const EMPTY = {

--- a/test/server/config/header-config.spec.ts
+++ b/test/server/config/header-config.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeButtons, sanitizeChips, sanitizeHeaderConfig, mergeHeaderConfig, DEFAULT_BUTTONS, type HeaderConfig } from "../../../server/config/header-config.js";
+import {
+  sanitizeButtons,
+  sanitizeChips,
+  sanitizeHeaderConfig,
+  mergeHeaderConfig,
+  DEFAULT_BUTTONS,
+  type HeaderConfig,
+} from "../../../server/config/header-config.js";
 
 describe("sanitizeButtons", () => {
   it("keeps a valid shell/input/open button with its matching payload", () => {

--- a/test/server/config/header-config.spec.ts
+++ b/test/server/config/header-config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeButtons, sanitizeChips, sanitizeHeaderConfig, mergeHeaderConfig, DEFAULT_BUTTONS, type HeaderConfig } from "../../../../server/../../server/config/header-config.js";
+import { sanitizeButtons, sanitizeChips, sanitizeHeaderConfig, mergeHeaderConfig, DEFAULT_BUTTONS, type HeaderConfig } from "../../../server/config/header-config.js";
 
 describe("sanitizeButtons", () => {
   it("keeps a valid shell/input/open button with its matching payload", () => {

--- a/test/server/config/header-config.spec.ts
+++ b/test/server/config/header-config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { sanitizeButtons, sanitizeChips, sanitizeHeaderConfig, mergeHeaderConfig, DEFAULT_BUTTONS, type HeaderConfig } from "./header-config.js";
+import { sanitizeButtons, sanitizeChips, sanitizeHeaderConfig, mergeHeaderConfig, DEFAULT_BUTTONS, type HeaderConfig } from "../../../../server/../../server/config/header-config.js";
 
 describe("sanitizeButtons", () => {
   it("keeps a valid shell/input/open button with its matching payload", () => {

--- a/test/server/config/header-context.spec.ts
+++ b/test/server/config/header-context.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { repoFromWebUrl } from "./header-context.js";
+import { repoFromWebUrl } from "../../../../server/../../server/config/header-context.js";
 
 describe("repoFromWebUrl", () => {
   it("extracts owner/repo from a github web url", () => {

--- a/test/server/config/header-context.spec.ts
+++ b/test/server/config/header-context.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { repoFromWebUrl } from "../../../../server/../../server/config/header-context.js";
+import { repoFromWebUrl } from "../../../server/config/header-context.js";
 
 describe("repoFromWebUrl", () => {
   it("extracts owner/repo from a github web url", () => {

--- a/test/server/config/header-resolve.spec.ts
+++ b/test/server/config/header-resolve.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { substitute, substituteShell, evalWhen, resolveHeader, resolveButtonCommand, headerHasPrButton } from "../../../../server/../../server/config/header-resolve.js";
-import type { HeaderConfig, HeaderContext } from "../../../../server/../../server/config/header-config.js";
+import { substitute, substituteShell, evalWhen, resolveHeader, resolveButtonCommand, headerHasPrButton } from "../../../server/config/header-resolve.js";
+import type { HeaderConfig, HeaderContext } from "../../../server/config/header-config.js";
 
 // POSIX single-quote escaping, matching the server's shellQuoteFor(non-win32).
 const posixQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;

--- a/test/server/config/header-resolve.spec.ts
+++ b/test/server/config/header-resolve.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { substitute, substituteShell, evalWhen, resolveHeader, resolveButtonCommand, headerHasPrButton } from "./header-resolve.js";
-import type { HeaderConfig, HeaderContext } from "./header-config.js";
+import { substitute, substituteShell, evalWhen, resolveHeader, resolveButtonCommand, headerHasPrButton } from "../../../../server/../../server/config/header-resolve.js";
+import type { HeaderConfig, HeaderContext } from "../../../../server/../../server/config/header-config.js";
 
 // POSIX single-quote escaping, matching the server's shellQuoteFor(non-win32).
 const posixQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;

--- a/test/server/config/header-title.spec.ts
+++ b/test/server/config/header-title.spec.ts
@@ -10,7 +10,7 @@ import {
   TITLE_REGEN_EVERY_TURNS,
   VIEW_TITLE_REGEN_TURNS,
   MAX_TITLE_CHARS,
-} from "../../../../server/../../server/config/header-title.js";
+} from "../../../server/config/header-title.js";
 import type { RunClaude } from "../../../../server/session/command-summary.js";
 import type { ConversationTurn } from "../../../../server/session/transcript.js";
 

--- a/test/server/config/header-title.spec.ts
+++ b/test/server/config/header-title.spec.ts
@@ -10,9 +10,9 @@ import {
   TITLE_REGEN_EVERY_TURNS,
   VIEW_TITLE_REGEN_TURNS,
   MAX_TITLE_CHARS,
-} from "./header-title.js";
-import type { RunClaude } from "../session/command-summary.js";
-import type { ConversationTurn } from "../session/transcript.js";
+} from "../../../../server/../../server/config/header-title.js";
+import type { RunClaude } from "../../../../server/session/command-summary.js";
+import type { ConversationTurn } from "../../../../server/session/transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 const ok = (stdout: string): RunClaude => vi.fn(async () => ({ stdout, stderr: "", code: 0 }));


### PR DESCRIPTION
Move test files for server/config/ directory into test/server/config/.

## Changes
- Move all 8 server/config/*.spec.ts files to test/server/config/
- Update import paths to reference source files correctly

This is one of three parallel refactors to reorganize test files by directory.