### PR TITLE
refactor: move server/agents tests into test/server/agents

### DIFF
--- a/test/server/agents/claude-args.spec.ts
+++ b/test/server/agents/claude-args.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildClaudeArgs, type ClaudeArgsInput } from "../../../../server/../../server/agents/claude-args.js";
+import { buildClaudeArgs, type ClaudeArgsInput } from "../../../server/agents/claude-args.js";
 
 const base: ClaudeArgsInput = {
   sessionId: "11111111-1111-1111-1111-111111111111",

--- a/test/server/agents/claude-args.spec.ts
+++ b/test/server/agents/claude-args.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildClaudeArgs, type ClaudeArgsInput } from "./claude-args.js";
+import { buildClaudeArgs, type ClaudeArgsInput } from "../../../../server/../../server/agents/claude-args.js";
 
 const base: ClaudeArgsInput = {
   sessionId: "11111111-1111-1111-1111-111111111111",

--- a/test/server/agents/codex-args.spec.ts
+++ b/test/server/agents/codex-args.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildCodexArgs } from "../../../../server/../../server/agents/codex-args.js";
+import { buildCodexArgs } from "../../../server/agents/codex-args.js";
 
 const base = { resume: null, model: null, guiMcpUrl: null };
 

--- a/test/server/agents/codex-args.spec.ts
+++ b/test/server/agents/codex-args.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildCodexArgs } from "./codex-args.js";
+import { buildCodexArgs } from "../../../../server/../../server/agents/codex-args.js";
 
 const base = { resume: null, model: null, guiMcpUrl: null };
 

--- a/test/server/agents/codex-session.spec.ts
+++ b/test/server/agents/codex-session.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "../../../../server/../../server/agents/codex-session.js";
+import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "../../../server/agents/codex-session.js";
 
 const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
 const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";

--- a/test/server/agents/codex-session.spec.ts
+++ b/test/server/agents/codex-session.spec.ts
@@ -2,7 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "../../../server/agents/codex-session.js";
+import {
+  parseSessionMetaLine,
+  readSessionMeta,
+  listRecentRollouts,
+  snapshotSessions,
+  pickFreshSession,
+  watchForCodexSession,
+} from "../../../server/agents/codex-session.js";
 
 const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
 const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";

--- a/test/server/agents/codex-session.spec.ts
+++ b/test/server/agents/codex-session.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "./codex-session.js";
+import { parseSessionMetaLine, readSessionMeta, listRecentRollouts, snapshotSessions, pickFreshSession, watchForCodexSession } from "../../../../server/../../server/agents/codex-session.js";
 
 const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
 const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";

--- a/test/server/agents/codex-sessions.spec.ts
+++ b/test/server/agents/codex-sessions.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseCodexRolloutHead, listCodexSessions, codexRolloutExists } from "../../../../server/../../server/agents/codex-sessions.js";
+import { parseCodexRolloutHead, listCodexSessions, codexRolloutExists } from "../../../server/agents/codex-sessions.js";
 
 const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
 const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";

--- a/test/server/agents/codex-sessions.spec.ts
+++ b/test/server/agents/codex-sessions.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { parseCodexRolloutHead, listCodexSessions, codexRolloutExists } from "./codex-sessions.js";
+import { parseCodexRolloutHead, listCodexSessions, codexRolloutExists } from "../../../../server/../../server/agents/codex-sessions.js";
 
 const UUID_A = "019f251d-001c-7542-b13e-9a627effce52";
 const UUID_B = "019db01d-aaa3-7ba2-b597-b29a7fca488f";

--- a/test/server/agents/codex-skills.spec.ts
+++ b/test/server/agents/codex-skills.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { syncCodexSkills, codexifySkillSeed } from "./codex-skills.js";
+import { syncCodexSkills, codexifySkillSeed } from "../../../../server/../../server/agents/codex-skills.js";
 
 describe("codexifySkillSeed", () => {
   it("rewrites a /<slug> <msg> chat seed to name the skill in natural language", () => {

--- a/test/server/agents/codex-skills.spec.ts
+++ b/test/server/agents/codex-skills.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { syncCodexSkills, codexifySkillSeed } from "../../../../server/../../server/agents/codex-skills.js";
+import { syncCodexSkills, codexifySkillSeed } from "../../../server/agents/codex-skills.js";
 
 describe("codexifySkillSeed", () => {
   it("rewrites a /<slug> <msg> chat seed to name the skill in natural language", () => {

--- a/test/server/agents/registry.spec.ts
+++ b/test/server/agents/registry.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { getAgentAdapter } from "../../../../server/../../server/agents/registry.js";
-import { claudeAdapter } from "../../../../server/../../server/agents/claude.js";
-import { codexAdapter } from "../../../../server/../../server/agents/codex.js";
+import { getAgentAdapter } from "../../../server/agents/registry.js";
+import { claudeAdapter } from "../../../server/agents/claude.js";
+import { codexAdapter } from "../../../server/agents/codex.js";
 
 function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) Reflect.deleteProperty(process.env, key);

--- a/test/server/agents/registry.spec.ts
+++ b/test/server/agents/registry.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { getAgentAdapter } from "./registry.js";
-import { claudeAdapter } from "./claude.js";
-import { codexAdapter } from "./codex.js";
+import { getAgentAdapter } from "../../../../server/../../server/agents/registry.js";
+import { claudeAdapter } from "../../../../server/../../server/agents/claude.js";
+import { codexAdapter } from "../../../../server/../../server/agents/codex.js";
 
 function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) Reflect.deleteProperty(process.env, key);


### PR DESCRIPTION
Move test files for server/agents/ directory into test/server/agents/.

## Changes
- Move all 6 server/agents/*.spec.ts files to test/server/agents/
- Update import paths to reference source files correctly

This is one of three parallel refactors to reorganize test files by directory.