### PR TITLE
refactor: move server/backends tests into test/server/backends

### DIFF
--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { initCollectionsBackend, mountCollectionRoutes } from "./collections.js";
+import { initCollectionsBackend, mountCollectionRoutes } from "../../../../server/../../server/backends/collections.js";
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
 
 // The registry engine fetches remote index.json / bundles — mock it so the route

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -6,7 +6,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { initCollectionsBackend, mountCollectionRoutes } from "../../../../server/../../server/backends/collections.js";
+import { initCollectionsBackend, mountCollectionRoutes } from "../../../server/backends/collections.js";
 import { listRegistry, importRegistry } from "@mulmoclaude/core/collection/registry/server";
 
 // The registry engine fetches remote index.json / bundles — mock it so the route

--- a/test/server/backends/feeds.spec.ts
+++ b/test/server/backends/feeds.spec.ts
@@ -4,7 +4,7 @@ import express from "express";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { initFeedsBackend, mountFeedsRoutes } from "./feeds.js";
+import { initFeedsBackend, mountFeedsRoutes } from "../../../../server/../../server/backends/feeds.js";
 import { listFeeds, readFeedState, removeFeed } from "@mulmoclaude/core/feeds/server";
 
 // The feeds engine reads the workspace + fetches sources — mock it so the route

--- a/test/server/backends/feeds.spec.ts
+++ b/test/server/backends/feeds.spec.ts
@@ -4,7 +4,7 @@ import express from "express";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { initFeedsBackend, mountFeedsRoutes } from "../../../../server/../../server/backends/feeds.js";
+import { initFeedsBackend, mountFeedsRoutes } from "../../../server/backends/feeds.js";
 import { listFeeds, readFeedState, removeFeed } from "@mulmoclaude/core/feeds/server";
 
 // The feeds engine reads the workspace + fetches sources — mock it so the route

--- a/test/server/backends/fileChange.spec.ts
+++ b/test/server/backends/fileChange.spec.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { resetFileChangePublisher } from "@mulmoclaude/core/file-change";
-import { initFileChangePublisher, publishFileChange } from "./fileChange.js";
+import { initFileChangePublisher, publishFileChange } from "../../../../server/../../server/backends/fileChange.js";
 
 // Capture every pubsub publish the binding makes.
 interface Published {

--- a/test/server/backends/fileChange.spec.ts
+++ b/test/server/backends/fileChange.spec.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { resetFileChangePublisher } from "@mulmoclaude/core/file-change";
-import { initFileChangePublisher, publishFileChange } from "../../../../server/../../server/backends/fileChange.js";
+import { initFileChangePublisher, publishFileChange } from "../../../server/backends/fileChange.js";
 
 // Capture every pubsub publish the binding makes.
 interface Published {

--- a/test/server/backends/fileOps.spec.ts
+++ b/test/server/backends/fileOps.spec.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { createFileOps } from "./fileOps.js";
+import { createFileOps } from "../../../../server/../../server/backends/fileOps.js";
 
 describe("createFileOps", () => {
   let base: string;

--- a/test/server/backends/fileOps.spec.ts
+++ b/test/server/backends/fileOps.spec.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { createFileOps } from "../../../../server/../../server/backends/fileOps.js";
+import { createFileOps } from "../../../server/backends/fileOps.js";
 
 describe("createFileOps", () => {
   let base: string;

--- a/test/server/backends/files.spec.ts
+++ b/test/server/backends/files.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { mountFilesRoutes } from "./files.js";
+import { mountFilesRoutes } from "../../../../server/../../server/backends/files.js";
 
 let server: Server;
 let base: string;

--- a/test/server/backends/files.spec.ts
+++ b/test/server/backends/files.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { mountFilesRoutes } from "../../../../server/../../server/backends/files.js";
+import { mountFilesRoutes } from "../../../server/backends/files.js";
 
 let server: Server;
 let base: string;

--- a/test/server/backends/google.spec.ts
+++ b/test/server/backends/google.spec.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import express from "express";
 import request from "supertest";
 
-import { mountGoogleRoutes, type GoogleRouteDeps } from "../../../../server/../../server/backends/google.js";
+import { mountGoogleRoutes, type GoogleRouteDeps } from "../../../server/backends/google.js";
 
 const stubDeps = (over: Partial<GoogleRouteDeps> = {}) => {
   const deps: GoogleRouteDeps = {

--- a/test/server/backends/google.spec.ts
+++ b/test/server/backends/google.spec.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import express from "express";
 import request from "supertest";
 
-import { mountGoogleRoutes, type GoogleRouteDeps } from "./google.js";
+import { mountGoogleRoutes, type GoogleRouteDeps } from "../../../../server/../../server/backends/google.js";
 
 const stubDeps = (over: Partial<GoogleRouteDeps> = {}) => {
   const deps: GoogleRouteDeps = {

--- a/test/server/backends/html.spec.ts
+++ b/test/server/backends/html.spec.ts
@@ -5,8 +5,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { initArtifactsBackend } from "./artifacts.js";
-import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./html.js";
+import { initArtifactsBackend } from "../../../../server/../../server/backends/artifacts.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "../../../../server/../../server/backends/html.js";
 
 let server: Server;
 let base: string;

--- a/test/server/backends/html.spec.ts
+++ b/test/server/backends/html.spec.ts
@@ -5,8 +5,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { initArtifactsBackend } from "../../../../server/../../server/backends/artifacts.js";
-import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "../../../../server/../../server/backends/html.js";
+import { initArtifactsBackend } from "../../../server/backends/artifacts.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "../../../server/backends/html.js";
 
 let server: Server;
 let base: string;

--- a/test/server/backends/notifier.spec.ts
+++ b/test/server/backends/notifier.spec.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
 import { publish, resetNotifier } from "@mulmoclaude/core/notifier";
-import { initNotifier, mountNotificationRoutes, NOTIFIER_CHANNEL } from "../../../../server/../../server/backends/notifier.js";
+import { initNotifier, mountNotificationRoutes, NOTIFIER_CHANNEL } from "../../../server/backends/notifier.js";
 
 interface Published {
   channel: string;

--- a/test/server/backends/notifier.spec.ts
+++ b/test/server/backends/notifier.spec.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
 import { publish, resetNotifier } from "@mulmoclaude/core/notifier";
-import { initNotifier, mountNotificationRoutes, NOTIFIER_CHANNEL } from "./notifier.js";
+import { initNotifier, mountNotificationRoutes, NOTIFIER_CHANNEL } from "../../../../server/../../server/backends/notifier.js";
 
 interface Published {
   channel: string;

--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import type { Server } from "node:http";
 import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
-import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, initUserTaskScheduler } from "./scheduler.js";
+import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, initUserTaskScheduler } from "../../../../server/../../server/backends/scheduler.js";
 
 // Mock the shared task-manager so initUserTaskScheduler's registration + start calls
 // are observable without starting real interval timers.

--- a/test/server/backends/scheduler.spec.ts
+++ b/test/server/backends/scheduler.spec.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import type { Server } from "node:http";
 import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
-import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, initUserTaskScheduler } from "../../../../server/../../server/backends/scheduler.js";
+import { buildUserTaskDefinitions, loadUserTasks, mountSchedulerRoutes, initUserTaskScheduler } from "../../../server/backends/scheduler.js";
 
 // Mock the shared task-manager so initUserTaskScheduler's registration + start calls
 // are observable without starting real interval timers.

--- a/test/server/backends/shortcuts.spec.ts
+++ b/test/server/backends/shortcuts.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { normalizeShortcuts, mountShortcutsRoutes } from "../../../../server/../../server/backends/shortcuts.js";
+import { normalizeShortcuts, mountShortcutsRoutes } from "../../../server/backends/shortcuts.js";
 
 describe("normalizeShortcuts", () => {
   it("drops malformed entries and dedupes on (kind, slug)", () => {

--- a/test/server/backends/shortcuts.spec.ts
+++ b/test/server/backends/shortcuts.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "nod
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { normalizeShortcuts, mountShortcutsRoutes } from "./shortcuts.js";
+import { normalizeShortcuts, mountShortcutsRoutes } from "../../../../server/../../server/backends/shortcuts.js";
 
 describe("normalizeShortcuts", () => {
   it("drops malformed entries and dedupes on (kind, slug)", () => {

--- a/test/server/backends/thumbnailStore.spec.ts
+++ b/test/server/backends/thumbnailStore.spec.ts
@@ -4,8 +4,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { initCollectionsBackend } from "./collections.js";
-import { createThumbnailResolver, clearThumbnailCache } from "./thumbnailStore.js";
+import { initCollectionsBackend } from "../../../../server/../../server/backends/collections.js";
+import { createThumbnailResolver, clearThumbnailCache } from "../../../../server/../../server/backends/thumbnailStore.js";
 
 // A stub resize so the test needs no native sharp binary — echoes a marker
 // derived from the input so we can assert the pipeline ran.

--- a/test/server/backends/thumbnailStore.spec.ts
+++ b/test/server/backends/thumbnailStore.spec.ts
@@ -4,8 +4,8 @@ import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { initCollectionsBackend } from "../../../../server/../../server/backends/collections.js";
-import { createThumbnailResolver, clearThumbnailCache } from "../../../../server/../../server/backends/thumbnailStore.js";
+import { initCollectionsBackend } from "../../../server/backends/collections.js";
+import { createThumbnailResolver, clearThumbnailCache } from "../../../server/backends/thumbnailStore.js";
 
 // A stub resize so the test needs no native sharp binary — echoes a marker
 // derived from the input so we can assert the pipeline ran.

--- a/test/server/backends/translation.spec.ts
+++ b/test/server/backends/translation.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { splitHitMiss, mergeTranslations, assembleResult, validateRequest, TranslationInputError, mountTranslationRoutes } from "../../../../server/../../server/backends/translation.js";
+import { splitHitMiss, mergeTranslations, assembleResult, validateRequest, TranslationInputError, mountTranslationRoutes } from "../../../server/backends/translation.js";
 
 describe("splitHitMiss", () => {
   const dict = { sentences: { Hello: { ja: "こんにちは" }, Bye: { ja: "さようなら" } } };

--- a/test/server/backends/translation.spec.ts
+++ b/test/server/backends/translation.spec.ts
@@ -5,7 +5,14 @@ import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { splitHitMiss, mergeTranslations, assembleResult, validateRequest, TranslationInputError, mountTranslationRoutes } from "../../../server/backends/translation.js";
+import {
+  splitHitMiss,
+  mergeTranslations,
+  assembleResult,
+  validateRequest,
+  TranslationInputError,
+  mountTranslationRoutes,
+} from "../../../server/backends/translation.js";
 
 describe("splitHitMiss", () => {
   const dict = { sentences: { Hello: { ja: "こんにちは" }, Bye: { ja: "さようなら" } } };

--- a/test/server/backends/translation.spec.ts
+++ b/test/server/backends/translation.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { splitHitMiss, mergeTranslations, assembleResult, validateRequest, TranslationInputError, mountTranslationRoutes } from "./translation.js";
+import { splitHitMiss, mergeTranslations, assembleResult, validateRequest, TranslationInputError, mountTranslationRoutes } from "../../../../server/../../server/backends/translation.js";
 
 describe("splitHitMiss", () => {
   const dict = { sentences: { Hello: { ja: "こんにちは" }, Bye: { ja: "さようなら" } } };

--- a/test/server/backends/viewToken.spec.ts
+++ b/test/server/backends/viewToken.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
-import { mintViewToken, verifyViewToken, clampCapabilities, requireViewToken, VIEW_TOKEN_TTL_MS, type ViewCapability } from "../../../../server/../../server/backends/viewToken.js";
+import { mintViewToken, verifyViewToken, clampCapabilities, requireViewToken, VIEW_TOKEN_TTL_MS, type ViewCapability } from "../../../server/backends/viewToken.js";
 import type { Request, Response, NextFunction } from "express";
 
 describe("viewToken mint/verify", () => {

--- a/test/server/backends/viewToken.spec.ts
+++ b/test/server/backends/viewToken.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
-import { mintViewToken, verifyViewToken, clampCapabilities, requireViewToken, VIEW_TOKEN_TTL_MS, type ViewCapability } from "./viewToken.js";
+import { mintViewToken, verifyViewToken, clampCapabilities, requireViewToken, VIEW_TOKEN_TTL_MS, type ViewCapability } from "../../../../server/../../server/backends/viewToken.js";
 import type { Request, Response, NextFunction } from "express";
 
 describe("viewToken mint/verify", () => {

--- a/test/server/backends/viewToken.spec.ts
+++ b/test/server/backends/viewToken.spec.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from "vitest";
-import { mintViewToken, verifyViewToken, clampCapabilities, requireViewToken, VIEW_TOKEN_TTL_MS, type ViewCapability } from "../../../server/backends/viewToken.js";
+import {
+  mintViewToken,
+  verifyViewToken,
+  clampCapabilities,
+  requireViewToken,
+  VIEW_TOKEN_TTL_MS,
+  type ViewCapability,
+} from "../../../server/backends/viewToken.js";
 import type { Request, Response, NextFunction } from "express";
 
 describe("viewToken mint/verify", () => {

--- a/test/server/backends/wiki.spec.ts
+++ b/test/server/backends/wiki.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { mountWikiRoutes } from "../../../../server/../../server/backends/wiki.js";
+import { mountWikiRoutes } from "../../../server/backends/wiki.js";
 
 // A minimal wiki laid out at core's canonical location (wikiDirs):
 //   <ws>/data/wiki/index.md       — the index (two bullet [[links]])

--- a/test/server/backends/wiki.spec.ts
+++ b/test/server/backends/wiki.spec.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Server } from "node:http";
-import { mountWikiRoutes } from "./wiki.js";
+import { mountWikiRoutes } from "../../../../server/../../server/backends/wiki.js";
 
 // A minimal wiki laid out at core's canonical location (wikiDirs):
 //   <ws>/data/wiki/index.md       — the index (two bullet [[links]])

--- a/test/server/backends/worklog.spec.ts
+++ b/test/server/backends/worklog.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
-import { worklogSystemTask, WORKLOG_PROMPT } from "../../../../server/../../server/backends/worklog.js";
+import { worklogSystemTask, WORKLOG_PROMPT } from "../../../server/backends/worklog.js";
 
 const HOUR_MS = 3_600_000;
 

--- a/test/server/backends/worklog.spec.ts
+++ b/test/server/backends/worklog.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
-import { worklogSystemTask, WORKLOG_PROMPT } from "./worklog.js";
+import { worklogSystemTask, WORKLOG_PROMPT } from "../../../../server/../../server/backends/worklog.js";
 
 const HOUR_MS = 3_600_000;
 

--- a/test/server/backends/workspaceSetup.spec.ts
+++ b/test/server/backends/workspaceSetup.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import path from "node:path";
-import { isManagedWorkspace, initWorkspaceSetup } from "../../../../server/../../server/backends/workspaceSetup.js";
+import { isManagedWorkspace, initWorkspaceSetup } from "../../../server/backends/workspaceSetup.js";
 
 // Save/restore MULMOCLAUDE_WORKSPACE_PATH so a test can mark a temp dir as the
 // managed workspace without leaking into sibling tests.

--- a/test/server/backends/workspaceSetup.spec.ts
+++ b/test/server/backends/workspaceSetup.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, existsSync, readdirSync } from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import path from "node:path";
-import { isManagedWorkspace, initWorkspaceSetup } from "./workspaceSetup.js";
+import { isManagedWorkspace, initWorkspaceSetup } from "../../../../server/../../server/backends/workspaceSetup.js";
 
 // Save/restore MULMOCLAUDE_WORKSPACE_PATH so a test can mark a temp dir as the
 // managed workspace without leaking into sibling tests.


### PR DESCRIPTION
Move test files for server/backends/ directory into test/server/backends/.

## Changes
- Move all 16 server/backends/*.spec.ts files to test/server/backends/
- Update import paths to reference source files correctly

This is one of three parallel refactors to reorganize test files by directory.