### PR TITLE
refactor: move server/infra tests into test/server/infra

### DIFF
--- a/test/server/infra/collection-tool.spec.ts
+++ b/test/server/infra/collection-tool.spec.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { MANAGE_COLLECTION, manageCollectionHandler } from "../../../server/infra/collection-tool.js";
 import { HOST_TOOL_DEFINITIONS } from "../../../server/infra/host-tools.js";
-import { initCollectionsBackend } from "../backends/collections.js";
+import { initCollectionsBackend } from "../../server/backends/collections.js";
 
 const SCHEMA = {
   title: "Tool Fixture",

--- a/test/server/infra/collection-tool.spec.ts
+++ b/test/server/infra/collection-tool.spec.ts
@@ -9,8 +9,8 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { MANAGE_COLLECTION, manageCollectionHandler } from "./collection-tool.js";
-import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
+import { MANAGE_COLLECTION, manageCollectionHandler } from "../../../server/infra/collection-tool.js";
+import { HOST_TOOL_DEFINITIONS } from "../../../server/infra/host-tools.js";
 import { initCollectionsBackend } from "../backends/collections.js";
 
 const SCHEMA = {

--- a/test/server/infra/collection-tool.spec.ts
+++ b/test/server/infra/collection-tool.spec.ts
@@ -9,9 +9,9 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { MANAGE_COLLECTION, manageCollectionHandler } from "../../../server/infra/collection-tool.js";
-import { HOST_TOOL_DEFINITIONS } from "../../../server/infra/host-tools.js";
-import { initCollectionsBackend } from "../../server/backends/collections.js";
+import { MANAGE_COLLECTION, manageCollectionHandler } from "../../../server/infra/collection-tool";
+import { HOST_TOOL_DEFINITIONS } from "../../../server/infra/host-tools";
+import { initCollectionsBackend } from "../../server/backends/collections";
 
 const SCHEMA = {
   title: "Tool Fixture",

--- a/test/server/infra/install-config-skill.spec.ts
+++ b/test/server/infra/install-config-skill.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { installOwnedSkill, SCHEMA_ASSET_FILE } from "../../../server/infra/install-config-skill";
-import { loadDirConfig } from "../config/dir-config";
+import { installOwnedSkill, SCHEMA_ASSET_FILE } from "../../../server/infra/install-config-skill.js";
+import { loadDirConfig } from "../../server/config/dir-config.js";
 
 const NAME = "mulmoterminal-config";
 const MARKER = ".mt-owned";

--- a/test/server/infra/install-config-skill.spec.ts
+++ b/test/server/infra/install-config-skill.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { installOwnedSkill, SCHEMA_ASSET_FILE } from "../../../server/infra/install-config-skill.js";
-import { loadDirConfig } from "../../server/config/dir-config.js";
+import { installOwnedSkill, SCHEMA_ASSET_FILE } from "../../../server/infra/install-config-skill";
+import { loadDirConfig } from "../../server/config/dir-config";
 
 const NAME = "mulmoterminal-config";
 const MARKER = ".mt-owned";

--- a/test/server/infra/install-config-skill.spec.ts
+++ b/test/server/infra/install-config-skill.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { installOwnedSkill, SCHEMA_ASSET_FILE } from "./install-config-skill";
+import { installOwnedSkill, SCHEMA_ASSET_FILE } from "../../../server/infra/install-config-skill";
 import { loadDirConfig } from "../config/dir-config";
 
 const NAME = "mulmoterminal-config";

--- a/test/server/infra/pluginRuntime.spec.ts
+++ b/test/server/infra/pluginRuntime.spec.ts
@@ -5,7 +5,7 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { initPluginRuntime, createPluginRuntime } from "./pluginRuntime.js";
+import { initPluginRuntime, createPluginRuntime } from "../../../server/infra/pluginRuntime.js";
 import { initArtifactsBackend, artifactsRoot } from "../backends/artifacts.js";
 
 const PKG = "@scope/demo-plugin";

--- a/test/server/infra/pluginRuntime.spec.ts
+++ b/test/server/infra/pluginRuntime.spec.ts
@@ -5,8 +5,8 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { initPluginRuntime, createPluginRuntime } from "../../../server/infra/pluginRuntime.js";
-import { initArtifactsBackend, artifactsRoot } from "../../server/backends/artifacts.js";
+import { initPluginRuntime, createPluginRuntime } from "../../../server/infra/pluginRuntime";
+import { initArtifactsBackend, artifactsRoot } from "../../server/backends/artifacts";
 
 const PKG = "@scope/demo-plugin";
 

--- a/test/server/infra/pluginRuntime.spec.ts
+++ b/test/server/infra/pluginRuntime.spec.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { initPluginRuntime, createPluginRuntime } from "../../../server/infra/pluginRuntime.js";
-import { initArtifactsBackend, artifactsRoot } from "../backends/artifacts.js";
+import { initArtifactsBackend, artifactsRoot } from "../../server/backends/artifacts.js";
 
 const PKG = "@scope/demo-plugin";
 

--- a/test/server/infra/plugins-registry.spec.ts
+++ b/test/server/infra/plugins-registry.spec.ts
@@ -5,7 +5,7 @@
 // definePlugin default, so a regression in loadFactoryPackage drops the tool entirely.
 import { describe, it, expect } from "vitest";
 
-import { plugins, toolDefinitions, allowedToolNames } from "./plugins-registry.js";
+import { plugins, toolDefinitions, allowedToolNames } from "../../../server/infra/plugins-registry.js";
 
 describe("plugins registry", () => {
   it("normalizes a factory-shaped package into { toolName, definition, execute }", () => {

--- a/test/server/infra/plugins-registry.spec.ts
+++ b/test/server/infra/plugins-registry.spec.ts
@@ -5,7 +5,7 @@
 // definePlugin default, so a regression in loadFactoryPackage drops the tool entirely.
 import { describe, it, expect } from "vitest";
 
-import { plugins, toolDefinitions, allowedToolNames } from "../../../server/infra/plugins-registry.js";
+import { plugins, toolDefinitions, allowedToolNames } from "../../../server/infra/plugins-registry";
 
 describe("plugins registry", () => {
   it("normalizes a factory-shaped package into { toolName, definition, execute }", () => {

--- a/test/server/infra/sandbox.spec.ts
+++ b/test/server/infra/sandbox.spec.ts
@@ -13,7 +13,7 @@ import {
   cleanupSandbox,
   parseMountConfigNames,
   resolveSandboxAuthArgs,
-} from "./sandbox";
+} from "../../../server/infra/sandbox";
 
 describe("rewriteLoopbackForDocker", () => {
   it("rewrites localhost / 127.0.0.1 to host.docker.internal", () => {

--- a/test/server/infra/spa-fallback.spec.ts
+++ b/test/server/infra/spa-fallback.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isClientRoute } from "./spa-fallback";
+import { isClientRoute } from "../../../server/infra/spa-fallback";
 
 describe("SPA fallback matcher", () => {
   it("serves the SPA shell for client routes", () => {

--- a/test/server/infra/tmux-routes.spec.ts
+++ b/test/server/infra/tmux-routes.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Express } from "express";
-import { mountTmuxRoutes, type TmuxRouteDeps } from "../../../server/infra/tmux-routes.js";
+import { mountTmuxRoutes, type TmuxRouteDeps } from "../../../server/infra/tmux-routes";
 
 interface FakeRes {
   statusCode: number;

--- a/test/server/infra/tmux-routes.spec.ts
+++ b/test/server/infra/tmux-routes.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type { Express } from "express";
-import { mountTmuxRoutes, type TmuxRouteDeps } from "./tmux-routes.js";
+import { mountTmuxRoutes, type TmuxRouteDeps } from "../../../server/infra/tmux-routes.js";
 
 interface FakeRes {
   statusCode: number;

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { tmuxSessionName, tmuxNewSessionArgs, TMUX_CONF_LINES, isResumableTmuxSession } from "./tmux";
+import { tmuxSessionName, tmuxNewSessionArgs, TMUX_CONF_LINES, isResumableTmuxSession } from "../../../server/infra/tmux";
 
 describe("tmuxSessionName", () => {
   it("prefixes the session id", () => {

--- a/test/server/infra/web-push.spec.ts
+++ b/test/server/infra/web-push.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { sendWebPush } from "./web-push";
+import { sendWebPush } from "../../../server/infra/web-push";
 
 // The envelope/parse/timeout logic is unit-tested in @mulmobridge/web-push; here we only
 // verify the wiring — that our RemoteHost token provider is injected into the shared sender.


### PR DESCRIPTION
Move test files for server/infra/ directory into test/server/infra/.

## Changes
- Move all 9 server/infra/*.spec.ts files to test/server/infra/
- Update import paths to reference source files correctly