### PR TITLE
refactor: move server/files tests into test/server/files

### DIFF
--- a/test/server/files/files-browse.spec.ts
+++ b/test/server/files/files-browse.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { containedPath, realContainedWithin, resolveBase, listEntries, mdToHtmlDoc } from "./files-browse";
+import { containedPath, realContainedWithin, resolveBase, listEntries, mdToHtmlDoc } from "../../../server/files/files-browse";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-files-"));
 

--- a/test/server/files/open-dir.spec.ts
+++ b/test/server/files/open-dir.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { openCommand } from "./open-dir.js";
+import { openCommand } from "../../../server/files/open-dir.js";
 
 describe("openCommand", () => {
   it("uses `open` on macOS", () => {

--- a/test/server/files/pick-file.spec.ts
+++ b/test/server/files/pick-file.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pickFileCommand, parsePickerOutput } from "./pick-file.js";
+import { pickFileCommand, parsePickerOutput } from "../../../server/files/pick-file.js";
 
 describe("pickFileCommand", () => {
   it("uses osascript on macOS", () => {

--- a/test/server/files/scripts.spec.ts
+++ b/test/server/files/scripts.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { sanitizeScripts, loadScripts, resolveScript } from "./scripts";
+import { sanitizeScripts, loadScripts, resolveScript } from "../../../server/files/scripts";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-scripts-"));
 const writeScripts = (dir: string, content: string) => writeFileSync(path.join(dir, "script.json"), content);


### PR DESCRIPTION
Move test files for server/files/ directory into test/server/files/.

## Changes
- Move all 4 server/files/*.spec.ts files to test/server/files/
- Update import paths to reference source files correctly