### PR TITLE
refactor: move server/git tests into test/server/git

### DIFF
--- a/test/server/git/git-status.spec.ts
+++ b/test/server/git/git-status.spec.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { gitStatus } from "./git-status.js";
+import { gitStatus } from "../../../server/git/git-status.js";
 
 describe("gitStatus", () => {
   let repo: string;

--- a/test/server/git/gitRemote.spec.ts
+++ b/test/server/git/gitRemote.spec.ts
@@ -3,7 +3,7 @@ import type { Express } from "express";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { parseGithubWebUrl, resolveGithubUrl, mountGitRemoteRoute } from "./gitRemote.js";
+import { parseGithubWebUrl, resolveGithubUrl, mountGitRemoteRoute } from "../../../server/git/gitRemote.js";
 
 const REPO = "https://github.com/owner/repo";
 

--- a/test/server/git/issues.spec.ts
+++ b/test/server/git/issues.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeIssue, ISSUE_LIMIT } from "./issues";
+import { normalizeIssue, ISSUE_LIMIT } from "../../../server/git/issues";
 
 describe("normalizeIssue", () => {
   it("normalizes a gh issue json object", () => {

--- a/test/server/git/pr-for-branch.spec.ts
+++ b/test/server/git/pr-for-branch.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { parsePrUrl, prUrlForBranch, clearPrUrlCache } from "./pr-for-branch.js";
+import { parsePrUrl, prUrlForBranch, clearPrUrlCache } from "../../../server/git/pr-for-branch.js";
 
 const ok = (stdout: string) => vi.fn(async () => ({ ok: true, stdout, stderr: "", code: 0 }));
 

--- a/test/server/git/prs.spec.ts
+++ b/test/server/git/prs.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { rollupCiState, normalizePr } from "./prs";
+import { rollupCiState, normalizePr } from "../../../server/git/prs";
 
 describe("rollupCiState", () => {
   it("is none for an empty / non-array rollup", () => {

--- a/test/server/git/worktree-diff.spec.ts
+++ b/test/server/git/worktree-diff.spec.ts
@@ -3,8 +3,8 @@ import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { createWorktree } from "./worktrees.js";
-import { worktreeDiff } from "./worktree-diff.js";
+import { createWorktree } from "../../../server/git/worktrees.js";
+import { worktreeDiff } from "../../../server/git/worktree-diff.js";
 
 describe("worktreeDiff", () => {
   let repo: string;

--- a/test/server/git/worktree-pr.spec.ts
+++ b/test/server/git/worktree-pr.spec.ts
@@ -3,8 +3,8 @@ import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { createWorktree } from "./worktrees.js";
-import { compareUrl, pushWorktree, createOrOpenPR } from "./worktree-pr.js";
+import { createWorktree } from "../../../server/git/worktrees.js";
+import { compareUrl, pushWorktree, createOrOpenPR } from "../../../server/git/worktree-pr.js";
 
 describe("compareUrl", () => {
   it("builds the GitHub compare/open-PR url, keeping the branch slash raw", () => {

--- a/test/server/git/worktree-routes.spec.ts
+++ b/test/server/git/worktree-routes.spec.ts
@@ -4,8 +4,8 @@ import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { mountWorktreeRoutes } from "./worktree-routes.js";
-import { createWorktree, worktreesRoot } from "./worktrees.js";
+import { mountWorktreeRoutes } from "../../../server/git/worktree-routes.js";
+import { createWorktree, worktreesRoot } from "../../../server/git/worktrees.js";
 
 interface FakeRes {
   statusCode: number;

--- a/test/server/git/worktrees.spec.ts
+++ b/test/server/git/worktrees.spec.ts
@@ -3,7 +3,17 @@ import { mkdtempSync, rmSync, writeFileSync, existsSync, realpathSync, symlinkSy
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { slugify, parseWorktreeList, worktreesRoot, isManagedWorktree, gitTopLevel, createWorktree, listWorktrees, isDirty, removeWorktree } from "./worktrees";
+import {
+  slugify,
+  parseWorktreeList,
+  worktreesRoot,
+  isManagedWorktree,
+  gitTopLevel,
+  createWorktree,
+  listWorktrees,
+  isDirty,
+  removeWorktree,
+} from "../../../server/git/worktrees";
 
 describe("slugify", () => {
   it("makes a filesystem-safe slug, with a fallback", () => {


### PR DESCRIPTION
Move test files for server/git/ directory into test/server/git/.

## Changes
- Move all 9 server/git/*.spec.ts files to test/server/git/
- Update import paths to reference source files correctly