### PR TITLE
refactor: move server/session tests into test/server/session

### DIFF
--- a/test/server/session/activity-hook.spec.ts
+++ b/test/server/session/activity-hook.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { activityHookEffects, shouldNotifyTaskFinished } from "./activity-hook.js";
+import { activityHookEffects, shouldNotifyTaskFinished } from "../../../server/session/activity-hook.js";
 
 describe("activityHookEffects", () => {
   it("UserPromptSubmit sets working regardless of active", () => {

--- a/test/server/session/activity-state.spec.ts
+++ b/test/server/session/activity-state.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildActivitySnapshot, parseActivityState, type RestartActivity } from "./activity-state.js";
+import { buildActivitySnapshot, parseActivityState, type RestartActivity } from "../../../server/session/activity-state.js";
 
 const never = () => false;
 const anyId = () => true;

--- a/test/server/session/command-summary.spec.ts
+++ b/test/server/session/command-summary.spec.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
-import { truncateLog, buildSummaryPrompt, normalizeLocale, parseSummaryOutput, summarizeLog, MAX_LOG_KB, type RunClaude } from "./command-summary.js";
+import {
+  truncateLog,
+  buildSummaryPrompt,
+  normalizeLocale,
+  parseSummaryOutput,
+  summarizeLog,
+  MAX_LOG_KB,
+  type RunClaude,
+} from "../../../server/session/command-summary.js";
 
 const KB = 1024;
 const ok = (stdout: string): RunClaude => vi.fn(async () => ({ stdout, stderr: "", code: 0 }));

--- a/test/server/session/cost.spec.ts
+++ b/test/server/session/cost.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { rateForModel, costForUsage, costFromJsonl } from "./cost.js";
+import { rateForModel, costForUsage, costFromJsonl } from "../../../server/session/cost.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 const assistant = (model: string, usage: Record<string, number>) => line({ type: "assistant", message: { model, usage } });

--- a/test/server/session/file-cache.spec.ts
+++ b/test/server/session/file-cache.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createFileCache } from "./file-cache.js";
+import { createFileCache } from "../../../server/session/file-cache.js";
 
 const stamp = (mtimeMs: number, size: number) => ({ mtimeMs, size });
 

--- a/test/server/session/session-resolve.spec.ts
+++ b/test/server/session/session-resolve.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSession, type SessionFacts } from "./session-resolve.js";
+import { resolveSession, type SessionFacts } from "../../../server/session/session-resolve.js";
 
 const FIXED = "fresh-minted-id";
 const mint = () => FIXED;

--- a/test/server/session/terminal-replay.spec.ts
+++ b/test/server/session/terminal-replay.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { stripTerminalQueries } from "./terminal-replay.js";
+import { stripTerminalQueries } from "../../../server/session/terminal-replay.js";
 
 const ESC = String.fromCharCode(0x1b);
 const BEL = String.fromCharCode(0x07);

--- a/test/server/session/transcript.spec.ts
+++ b/test/server/session/transcript.spec.ts
@@ -19,7 +19,7 @@ import {
   countUserTurnsFromParsed,
   sessionUsageFromParsed,
   latestTurnContextFromParsed,
-} from "./transcript.js";
+} from "../../../server/session/transcript.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 


### PR DESCRIPTION
Move test files for server/session/ directory into test/server/session/.

## Changes
- Move all 8 server/session/*.spec.ts files to test/server/session/
- Update import paths to reference source files correctly