### PR TITLE
feat(ci): add jscpd duplication detection to Code Scanning

### DIFF
--- a/.github/workflows/duplication-scan.yaml
+++ b/.github/workflows/duplication-scan.yaml
@@ -1,0 +1,58 @@
+name: duplication-scan
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'plans/**'
+      - '**/*.md'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  duplication-scan:
+    name: Duplication Scan (jscpd)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write   # SARIF アップロードに必須
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install jscpd
+        env:
+          JSCPD_VERSION: 5.0.12
+          # jscpd-linux-x64-gnu.tar.gz の SHA256（jscpd は checksums.txt を
+          # 配布していないので自分で算出）。VERSION bump 時は同時更新すること。
+          JSCPD_SHA256: c1107547ee52bc83131d6e62d1fc9c156d194c593a4532876cdb1584b4e1dc3b
+        run: |
+          set -euo pipefail
+          ARCHIVE="jscpd-linux-x64-gnu.tar.gz"
+          curl -sSfL -o "$ARCHIVE" \
+            "https://github.com/kucherenko/jscpd/releases/download/v${JSCPD_VERSION}/${ARCHIVE}"
+          echo "${JSCPD_SHA256}  ${ARCHIVE}" | sha256sum -c -
+          sudo tar -xz -C /usr/local/bin -f "$ARCHIVE" jscpd
+          rm -f "$ARCHIVE"
+          jscpd --version
+
+      - name: Run jscpd
+        run: |
+          set -euo pipefail
+          jscpd . \
+            --format typescript \
+            --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts" \
+            --reporters console,sarif \
+            --output report
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@b7351df727350dca84cb9d725d57dcf5bc82ba26  # v3.37.1
+        with:
+          sarif_file: report/jscpd-report.sarif
+          category: jscpd


### PR DESCRIPTION
Add GitHub Actions workflow to detect duplicate code patterns and report to Code Scanning.

## Changes
- New workflow: .github/workflows/duplication-scan.yaml
- Installs jscpd v5.0.12 with SHA256 verification
- Excludes test files (`**/*.spec.ts`) and generated code
- Uploads SARIF to GitHub Code Scanning
- Reports only (doesn't block PR)

## Configuration
- Format: TypeScript
- Ignores: `**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts`
- Expected: ~36 clones / 1.97% duplicated code

Closes #391