### PR TITLE
chore(deps): @mulmoclaude/core@^0.22.1, @mulmoclaude/mulmoscript-plugin@^0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.11.1",
-    "@mulmoclaude/core": "^0.20.2",
+    "@mulmoclaude/core": "^0.22.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/google-plugin": "^0.1.2",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
-    "@mulmoclaude/mulmoscript-plugin": "^0.2.0",
+    "@mulmoclaude/mulmoscript-plugin": "^0.2.1",
     "@mulmoclaude/x-plugin": "^0.1.2",
     "@receptron/task-scheduler": "^0.1.0",
     "@xterm/addon-attach": "^0.12.0",
@@ -99,6 +99,9 @@
     "vue-router": "^5.2.0",
     "ws": "^8.21.1",
     "zod": "^4.4.3"
+  },
+  "resolutions": {
+    "@mulmoclaude/core": "^0.22.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,10 +1660,10 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.20.2.tgz#b3a7016668250c324e70d624588e5072d3ed9501"
-  integrity sha512-1GOeXcmRFWR+Wlrz336TbE0ece18IstBeBiY/a68UW2e56qTZr+YqsoK/D8U/3XbgYvBIKIXioK8k7eCXPay+Q==
+"@mulmoclaude/core@^0.20.2", "@mulmoclaude/core@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.22.1.tgz#56eecd90399b8dc3581eb1549beb923fa8504f39"
+  integrity sha512-BctuyJQOpCdiiz2z4RhAS6Ky4JDqw3+7R72E4O4x/2iFU1Q03w2pO0xDbU2/Pmbb9J+jhMau7AwXyjIWbiYadw==
   dependencies:
     fast-xml-parser "^5.10.1"
     google-auth-library "^10.9.0"
@@ -1697,10 +1697,10 @@
     marked "^18.0.5"
     mermaid "^11.16.0"
 
-"@mulmoclaude/mulmoscript-plugin@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/mulmoscript-plugin/-/mulmoscript-plugin-0.2.0.tgz#27e27ac3416c50b6e7fcbd43023e14092e167aa3"
-  integrity sha512-WdRPTacBlEhmMI3xp58ezKpxDvJy2mTWzV32l9lq3fiY9E8rjm+ITS3HeIwehH8QXIVX3OnPIxksbgu12+57HA==
+"@mulmoclaude/mulmoscript-plugin@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/mulmoscript-plugin/-/mulmoscript-plugin-0.2.1.tgz#a3ed4f4590b6942f976e28566c5257476b005b79"
+  integrity sha512-kLNMM9llVMlxmbXHVVNF+pFugfgSvdOtYpCgYfL1SRg505c4fDCAPjXbin04Rcidbmm9PFwmlbmhULIIemBVsw==
 
 "@mulmoclaude/x-plugin@^0.1.2":
   version "0.1.2"


### PR DESCRIPTION
## Why

Picks up the presentMulmoScript `filePath`-base fix (receptron/mulmoclaude#2139): the corrected tool schema (the wire path resolves against the workspace's `artifacts/` directory — the old description wrongly said "workspace-relative"), alias-tolerant path resolution (`artifacts/stories/<rel>` is accepted and canonicalized to `stories/<rel>`), and the `helps/mulmoscript.md` note on where relative `{ "kind": "path" }` media sources resolve from.

Keeping MulmoTerminal on the same shared-package versions as MulmoClaude matters because both apps operate on the same workspace data — version skew in path handling is a cross-app data bug.

## What

- `@mulmoclaude/core`: `^0.20.2` → `^0.22.1`
- `@mulmoclaude/mulmoscript-plugin`: `^0.2.0` → `^0.2.1`
- NEW `resolutions` entry forcing a single `@mulmoclaude/core` copy: `google-plugin@0.1.2` hard-depends on `core@^0.20.2`, which would otherwise nest a stale second core instance next to the host's 0.22.1. The entry can be dropped once a google-plugin ships with core widened or moved to a peer dependency.

Known non-blocking warning: `collection-plugin@0.11.1` peers on `core@^0.19.0`, so yarn warns "incorrect peer dependency" — it uses the host's copy regardless; goes away when collection-plugin is republished with a widened peer range.

## Testing

- `yarn typecheck` (client) and `yarn typecheck:server` — clean
- `yarn build` — clean
- `yarn test` — 1264/1264 pass
- Verified the lockfile collapses both core ranges to a single `0.22.1` entry and no nested copy remains under `node_modules/@mulmoclaude/google-plugin/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)