### PR TITLE
fix: google-plugin ^0.2.1 で npm install 時の core 2コピーを解消（#408 P1）

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@mulmoclaude/collection-plugin": "^0.11.1",
     "@mulmoclaude/core": "^0.22.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
-    "@mulmoclaude/google-plugin": "^0.1.2",
+    "@mulmoclaude/google-plugin": "^0.2.1",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
     "@mulmoclaude/mulmoscript-plugin": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,7 +1660,7 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.20.2", "@mulmoclaude/core@^0.22.1":
+"@mulmoclaude/core@^0.22.0", "@mulmoclaude/core@^0.22.1":
   version "0.22.1"
   resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.22.1.tgz#56eecd90399b8dc3581eb1549beb923fa8504f39"
   integrity sha512-BctuyJQOpCdiiz2z4RhAS6Ky4JDqw3+7R72E4O4x/2iFU1Q03w2pO0xDbU2/Pmbb9J+jhMau7AwXyjIWbiYadw==
@@ -1675,12 +1675,12 @@
   resolved "https://npm.flatt.tech/@mulmoclaude/form-plugin/-/form-plugin-0.1.4.tgz#64e8f9dc0537148156cbfc1235d5a68baf64cdf3"
   integrity sha512-dgqEiAazyMzLgNv0V3ewQxSPU5dI0eXecRYZ5rXe0Fu9CWZkCb1GOwJDjYHKDZnzMyYMQLzXnyt5gwHNW+QD+w==
 
-"@mulmoclaude/google-plugin@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.1.2.tgz#f3611e22c331266bf9e6a5a63ff4a72be6413775"
-  integrity sha512-k3upvsI+6jp70xjjSm7BXW4Xhls0nN2hf40GCII08Rp9ROZ044BUN+5hDdrMA5glumFQf/ZuRy5UXCklhr0HzQ==
+"@mulmoclaude/google-plugin@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.2.1.tgz#60a74fe555ed8ed472a28f028d7fac45ae818f53"
+  integrity sha512-ZHhSsp4/iAFtKNoiZDzRmu2FOokr9lakNp7O7FZi7CcvcJmIMDnOv9XGQ2/a7Clnr4T0Olf7Id+HY6SIBLcAgg==
   dependencies:
-    "@mulmoclaude/core" "^0.20.2"
+    "@mulmoclaude/core" "^0.22.0"
 
 "@mulmoclaude/html-plugin@^0.2.5":
   version "0.2.5"


### PR DESCRIPTION
## Summary

#408 の Codex **P1 指摘（未対応のまま merge）** を修正。`@mulmoclaude/google-plugin` を `^0.1.2` → `^0.2.1` に上げ、**npm 実インストールでも `@mulmoclaude/core` が単一コピーに解決される**ようにする。

## 何が問題だったか（実データで再現）

#408 は core を Yarn `resolutions` で `^0.22.1` に固定したが、**npm は `resolutions` も `yarn.lock` も見ない**。ユーザー導線は `npx mulmoterminal` / `npm i -g mulmoterminal`（= npm）。`google-plugin@0.1.2` は今も `core: ^0.20.2`（`<0.21.0`）を宣言しているため、公開版を npm で入れると core が **2コピー**になる:

```
node_modules/@mulmoclaude/core                     → 0.22.1  (top-level)
node_modules/@mulmoclaude/google-plugin/node_modules/@mulmoclaude/core → 0.20.2  (nested)
```

`@mulmoclaude/core/google` はモジュール状態（`configureGoogleHost` の logger binding）を持つため、コピーが割れると host が設定した logger が plugin の呼ぶ copy に届かず、**先日入れた Google 連携が公開版で壊れる**。dev（Yarn + resolutions）では1コピーに見えるので隠れていた。

## 修正

`google-plugin@0.2.1` は依存を `core: ^0.22.0` に広げており、`0.22.1` がこれを満たすため npm でも単一コピーに collapse する。

## 検証（実 `npm install` で再現・修正の両方を確認）

| deps | npm 実解決の core |
|---|---|
| core ^0.22.1 + google-plugin ^0.1.2（修正前） | **2コピー**（0.22.1 + 0.20.2 nested） |
| core ^0.22.1 + google-plugin ^0.2.1（修正後） | **1コピー**（0.22.1） |

- 0.2.1 は additive（`tasksList`/`driveList` 等の kind 追加）。tool 形状（factory / name `google`）と Calendar 経路は不変なので、ローダ（`plugins-registry.ts`）は無改修
- `yarn format` / `lint`（0 errors）/ `typecheck` / `typecheck:server` / `build` / `test`（**1259 passed**）
- 実アカウント疎通（読み取りのみ）: remoteHost `listEvents` が実データ / `google` ツール `status` が `linked: true`

## Items to Confirm / Review

- **`resolutions` は据え置き**（`core: ^0.22.1`）。dev の単一コピー保証として残す。npm 側は今回の range 修正で担保されるので二重の守り。
- google-plugin 0.1→0.2 は additive と確認したが、Tasks/Drive の実挙動は本PRでは未検証（Calendar のみ疎通確認）。これらは新 kind であり Calendar の回帰ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
