### PR TITLE
fix: FileOps の封じ込めガードで symlink を解決（#389 Codex 指摘）

### DIFF
--- a/server/backends/fileOps.ts
+++ b/server/backends/fileOps.ts
@@ -4,44 +4,75 @@
 // caller-supplied `rel` is resolved against the root and rejected if it escapes, so
 // a plugin can never read or write outside the area it was handed.
 //
+// Two layers guard containment: a cheap lexical check rejects `..` / absolute inputs,
+// then a realpath check resolves symlinks in any existing path component and confirms
+// the true target is still inside the root. FileOps exposes no symlink-creation
+// primitive, so a plugin can't plant one itself — the realpath layer is defence against
+// a symlink placed by something else (a dependency, another process) from being followed
+// out of the sandbox.
+//
 // `rootFor` is invoked PER OPERATION rather than captured: the workspace is injected
 // at boot, after these ops are already bound into the plugin registry's closures.
 import fs from "fs/promises";
 import path from "path";
 import type { FileOps } from "gui-chat-protocol";
 
+// realpath, but tolerant of a not-yet-created leaf/dir: resolve the deepest existing
+// ancestor's real path, then re-append the missing tail lexically. A missing tail can't
+// hide a symlink (it doesn't exist yet), so this is enough to catch every symlinked
+// component that DOES exist.
+async function realpathAllowingMissing(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p);
+  } catch {
+    const parent = path.dirname(p);
+    if (parent === p) return p;
+    return path.join(await realpathAllowingMissing(parent), path.basename(p));
+  }
+}
+
 export function createFileOps(rootFor: () => string, label: string): FileOps {
-  const absFor = (rel: string): string => {
+  const lexicalAbs = (rel: string): { root: string; abs: string } => {
     const root = path.resolve(rootFor());
     const abs = path.resolve(root, rel);
     if (abs !== root && !abs.startsWith(root + path.sep)) {
       throw new Error(`${label} path escapes its root: ${rel}`);
     }
+    return { root, abs };
+  };
+
+  const safeAbs = async (rel: string): Promise<string> => {
+    const { root, abs } = lexicalAbs(rel);
+    const [realRoot, realAbs] = await Promise.all([realpathAllowingMissing(root), realpathAllowingMissing(abs)]);
+    if (realAbs !== realRoot && !realAbs.startsWith(realRoot + path.sep)) {
+      throw new Error(`${label} path escapes its root via symlink: ${rel}`);
+    }
     return abs;
   };
+
   return {
     async read(rel) {
-      return fs.readFile(absFor(rel), "utf8");
+      return fs.readFile(await safeAbs(rel), "utf8");
     },
     async readBytes(rel) {
-      return new Uint8Array(await fs.readFile(absFor(rel)));
+      return new Uint8Array(await fs.readFile(await safeAbs(rel)));
     },
     async write(rel, content) {
-      const abs = absFor(rel);
+      const abs = await safeAbs(rel);
       await fs.mkdir(path.dirname(abs), { recursive: true });
       await fs.writeFile(abs, content);
     },
     async readDir(rel) {
-      return fs.readdir(absFor(rel));
+      return fs.readdir(await safeAbs(rel));
     },
     async stat(rel) {
-      const s = await fs.stat(absFor(rel));
+      const s = await fs.stat(await safeAbs(rel));
       return { mtimeMs: s.mtimeMs, size: s.size };
     },
     async exists(rel) {
-      // Resolved outside the try so an escaping path still throws — the catch is
+      // safeAbs runs before the try so an escaping path still throws — the catch is
       // only meant to turn a missing file into `false`.
-      const abs = absFor(rel);
+      const abs = await safeAbs(rel);
       try {
         await fs.access(abs);
         return true;
@@ -50,7 +81,7 @@ export function createFileOps(rootFor: () => string, label: string): FileOps {
       }
     },
     async unlink(rel) {
-      await fs.rm(absFor(rel), { force: true });
+      await fs.rm(await safeAbs(rel), { force: true });
     },
   };
 }

--- a/server/backends/fileOps.ts
+++ b/server/backends/fileOps.ts
@@ -17,17 +17,31 @@ import fs from "fs/promises";
 import path from "path";
 import type { FileOps } from "gui-chat-protocol";
 
+const MAX_SYMLINK_DEPTH = 40;
+
+async function readlinkOrNull(p: string): Promise<string | null> {
+  try {
+    return await fs.readlink(p);
+  } catch {
+    return null;
+  }
+}
+
 // realpath, but tolerant of a not-yet-created leaf/dir: resolve the deepest existing
-// ancestor's real path, then re-append the missing tail lexically. A missing tail can't
-// hide a symlink (it doesn't exist yet), so this is enough to catch every symlinked
-// component that DOES exist.
-async function realpathAllowingMissing(p: string): Promise<string> {
+// ancestor's real path, then re-append the missing tail lexically. `fs.realpath`
+// throws on a BROKEN symlink (existing link, missing target), so that case is handled
+// explicitly by following the link's target — treating it as a plain missing file would
+// let a dangling symlink pointing outside the root slip past the containment check.
+async function realpathAllowingMissing(p: string, depth = 0): Promise<string> {
+  if (depth > MAX_SYMLINK_DEPTH) throw new Error("too many symlink levels");
   try {
     return await fs.realpath(p);
   } catch {
+    const link = await readlinkOrNull(p);
+    if (link !== null) return realpathAllowingMissing(path.resolve(path.dirname(p), link), depth + 1);
     const parent = path.dirname(p);
     if (parent === p) return p;
-    return path.join(await realpathAllowingMissing(parent), path.basename(p));
+    return path.join(await realpathAllowingMissing(parent, depth), path.basename(p));
   }
 }
 

--- a/test/server/backends/fileOps.spec.ts
+++ b/test/server/backends/fileOps.spec.ts
@@ -132,5 +132,19 @@ describe("createFileOps", () => {
       symlinkSync(path.join(root, "real.txt"), path.join(root, "alias.txt"));
       expect(await ops.read("alias.txt")).toBe("inside");
     });
+
+    // Broken (dangling) symlink: fs.realpath throws because the target is missing, so
+    // the guard must follow the link itself — otherwise a write would follow it and
+    // create the file OUTSIDE the root.
+    it("refuses to write through a dangling symlink that points outside the root", async () => {
+      symlinkSync(path.join(base, "does-not-exist-yet.txt"), path.join(root, "dangling.txt"));
+      await expect(ops.write("dangling.txt", "x")).rejects.toThrow(/escapes its root via symlink/);
+    });
+
+    it("allows a dangling symlink whose (missing) target is inside the root", async () => {
+      symlinkSync(path.join(root, "notyet.txt"), path.join(root, "inside-dangling.txt"));
+      await ops.write("inside-dangling.txt", "created");
+      expect(await ops.read("notyet.txt")).toBe("created");
+    });
   });
 });

--- a/test/server/backends/fileOps.spec.ts
+++ b/test/server/backends/fileOps.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -96,6 +96,41 @@ describe("createFileOps", () => {
 
     it("allows the root itself", async () => {
       await expect(ops.readDir("")).resolves.toEqual([]);
+    });
+  });
+
+  // FileOps can't create a symlink itself, but one planted by another process or a
+  // dependency must not become an escape hatch out of the sandbox.
+  describe("symlink guard", () => {
+    it("refuses to read through a symlink that points outside the root", async () => {
+      const secret = path.join(base, "secret.txt");
+      writeFileSync(secret, "top secret");
+      symlinkSync(secret, path.join(root, "leak.txt"));
+      await expect(ops.read("leak.txt")).rejects.toThrow(/escapes its root via symlink/);
+    });
+
+    it("refuses to write through a symlinked directory that points outside the root", async () => {
+      const outside = path.join(base, "outside");
+      mkdirSync(outside);
+      symlinkSync(outside, path.join(root, "escape"));
+      await expect(ops.write(path.join("escape", "planted.txt"), "x")).rejects.toThrow(/escapes its root via symlink/);
+    });
+
+    it("applies the symlink guard to every operation", async () => {
+      const secret = path.join(base, "secret.txt");
+      writeFileSync(secret, "s");
+      symlinkSync(secret, path.join(root, "leak.txt"));
+      const rel = "leak.txt";
+      await expect(ops.readBytes(rel)).rejects.toThrow(/via symlink/);
+      await expect(ops.stat(rel)).rejects.toThrow(/via symlink/);
+      await expect(ops.unlink(rel)).rejects.toThrow(/via symlink/);
+      await expect(ops.exists(rel)).rejects.toThrow(/via symlink/);
+    });
+
+    it("allows a symlink that stays inside the root", async () => {
+      await ops.write("real.txt", "inside");
+      symlinkSync(path.join(root, "real.txt"), path.join(root, "alias.txt"));
+      expect(await ops.read("alias.txt")).toBe("inside");
     });
   });
 });


### PR DESCRIPTION
## Summary

#389 で Codex が指摘した **symlink escape**（未対応のまま merge）を修正。`server/backends/fileOps.ts` の封じ込めガードに realpath レイヤーを追加。

## 何が問題だったか

rooted `FileOps` のガードは lexical チェック（`path.resolve` + prefix）のみだった。プラグインの root 内に symlink が存在すると、それを辿って**サンドボックス外に読み書きできてしまう** — ファイル冒頭に明記した「プラグインは渡された領域の外に読み書きできない」という invariant を破る。

**深刻度は低い**: `FileOps` は symlink 作成プリミティブを公開していない（`write` は `writeFile` で通常ファイルのみ）ので、プラグインが FileOps 経由で symlink を張ることはできない。脅威は「依存パッケージや別プロセスが植えた既存 symlink を辿る」ケースに限られる。それでも defense-in-depth として塞ぐ。

## 修正

lexical チェックの後に realpath チェックを追加:
- root と対象の**存在する最深祖先**をそれぞれ realpath し、実パスで再度 containment を検証
- 未作成の leaf/dir は symlink を隠せない（存在しないから）ので、存在プレフィックスの解決で十分
- 高速な lexical チェックは fast reject として先頭に残す（`..`/絶対パスは realpath せず即拒否）

## 検証

- 追加テスト（`test/server/backends/fileOps.spec.ts`）:
  - root 内の symlink が外を指す場合、read/readBytes/stat/unlink/exists が `escapes its root via symlink` で拒否
  - symlink されたディレクトリ経由の write も拒否
  - **root 内に留まる symlink は許可**（正常系を壊さない）
- `yarn lint`（0 errors）/ `typecheck:server` / `test`（**1263 passed**、+4）
- realpath 化は `artifacts` / `pluginRuntime` の FileOps にも波及するが、全テスト green で回帰なし

## Items to Confirm / Review

- realpath を毎操作で呼ぶ（プラグインのファイル操作はホットパスではないので許容と判断）。
- macOS の `/tmp`→`/private/tmp` のような**環境側 symlink**では、root と対象の両方を同じロジックで realpath するため実パスが揃い、誤検出しない（テストの tmpdir で確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
