### PR TITLE
feat: add broker support to Google authentication

### DIFF
--- a/server/backends/google.ts
+++ b/server/backends/google.ts
@@ -14,6 +14,7 @@
 // (server/cli-google.ts) covers the setups where it can't — a remote/phone browser.
 import type { Express, Request, Response } from "express";
 import {
+  brokerBaseUrl,
   clientSecretPresence,
   configureGoogleHost,
   googleAuthFlow,
@@ -32,6 +33,7 @@ export interface GoogleStatus {
   linked: boolean;
   pending: boolean;
   clientSecret: ClientSecretPresence;
+  brokerAvailable: boolean;
   lastError: string | null;
 }
 
@@ -66,7 +68,13 @@ const failed = (res: Response, cause: unknown, fallback: string): void => {
 async function readStatus(deps: GoogleRouteDeps): Promise<GoogleStatus> {
   const [tokens, clientSecret] = await Promise.all([deps.loadTokens(), deps.secretPresence()]);
   const flow = deps.authFlow.status();
-  return { linked: Boolean(tokens?.refresh_token), pending: flow.pending, clientSecret, lastError: flow.lastError };
+  return {
+    linked: Boolean(tokens?.refresh_token),
+    pending: flow.pending,
+    clientSecret,
+    brokerAvailable: Boolean(brokerBaseUrl()),
+    lastError: flow.lastError,
+  };
 }
 
 // Same-origin guarded like the other local-action routes (files/pick-file.ts): without

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -169,11 +169,13 @@ const googleStatusText = computed(() => {
   return googleStatus.value.linked ? "Linked" : "Not linked";
 });
 
-// Consent can't start without an OAuth client secret on disk, and the two bad
-// states need different fixes, so they're reported separately.
+// Broker (GCP settings-free link) removes the client secret requirement. When a broker is available,
+// consent can flow through it; otherwise, a Desktop client's secret on disk is needed.
 const googleSecretHint = computed(() => {
+  if (googleStatus.value?.brokerAvailable) return "";
   const presence = googleStatus.value?.clientSecret;
-  if (presence === "missing") return "No OAuth client secret found in ~/.secrets. Add a Desktop client's client_secret_*.json there to enable sign-in.";
+  if (presence === "missing")
+    return "No OAuth client secret found in ~/.secrets. Add a Desktop client's client_secret_*.json there to enable sign-in, or use the GCP-settings-free broker link if available.";
   if (presence === "ambiguous") return "Multiple client_secret_*.json files in ~/.secrets — keep exactly one.";
   return "";
 });
@@ -325,7 +327,7 @@ onUnmounted(() => {
           v-if="!googleStatus?.linked"
           class="btn"
           type="button"
-          :disabled="googleBusy || googleStatus?.pending || googleStatus?.clientSecret !== 'found'"
+          :disabled="googleBusy || googleStatus?.pending || (googleStatus?.clientSecret !== 'found' && !googleStatus?.brokerAvailable)"
           @click="connectGoogle"
         >
           Sign in with Google

--- a/src/composables/useGoogleLink.ts
+++ b/src/composables/useGoogleLink.ts
@@ -9,6 +9,7 @@ export interface GoogleStatus {
   linked: boolean;
   pending: boolean;
   clientSecret: ClientSecretPresence;
+  brokerAvailable: boolean;
   lastError: string | null;
 }
 
@@ -26,6 +27,7 @@ function parseStatus(data: unknown): GoogleStatus | null {
     linked: data.linked === true,
     pending: data.pending === true,
     clientSecret: isPresence(data.clientSecret) ? data.clientSecret : "found",
+    brokerAvailable: data.brokerAvailable === true,
     lastError: typeof data.lastError === "string" ? data.lastError : null,
   };
 }

--- a/test/server/backends/google.spec.ts
+++ b/test/server/backends/google.spec.ts
@@ -38,7 +38,7 @@ describe("mountGoogleRoutes", () => {
     it("reports linked when a refresh token is stored, without leaking it", async () => {
       const res = await request(appWith(deps)).get("/api/google/status");
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ linked: true, pending: false, clientSecret: "found", lastError: null });
+      expect(res.body).toEqual({ linked: true, pending: false, clientSecret: "found", brokerAvailable: true, lastError: null });
       expect(JSON.stringify(res.body)).not.toContain("secret-refresh-token");
     });
 

--- a/test/src/composables/useGoogleLink.spec.ts
+++ b/test/src/composables/useGoogleLink.spec.ts
@@ -5,8 +5,8 @@ import { useGoogleLink } from "../../../src/composables/useGoogleLink";
 
 const jsonResponse = (body: unknown, ok = true, status = 200) => ({ ok, status, json: async () => body }) as Response;
 
-const LINKED = { linked: true, pending: false, clientSecret: "found", lastError: null };
-const PENDING = { linked: false, pending: true, clientSecret: "found", lastError: null };
+const LINKED = { linked: true, pending: false, clientSecret: "found", brokerAvailable: false, lastError: null };
+const PENDING = { linked: false, pending: true, clientSecret: "found", brokerAvailable: false, lastError: null };
 
 describe("useGoogleLink", () => {
   beforeEach(() => {
@@ -36,7 +36,7 @@ describe("useGoogleLink", () => {
     );
     const link = useGoogleLink();
     await link.refresh();
-    expect(link.status.value).toEqual({ linked: false, pending: false, clientSecret: "found", lastError: null });
+    expect(link.status.value).toEqual({ linked: false, pending: false, clientSecret: "found", brokerAvailable: false, lastError: null });
     link.dispose();
   });
 
@@ -121,7 +121,7 @@ describe("useGoogleLink", () => {
       vi.stubGlobal("open", open);
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(jsonResponse({ linked: false, pending: false, clientSecret: "found", lastError: null }))
+        .mockResolvedValueOnce(jsonResponse({ linked: false, pending: false, clientSecret: "found", brokerAvailable: false, lastError: null }))
         .mockResolvedValueOnce(jsonResponse({ authUrl: "https://accounts.google.com/o/oauth2/v2/auth?x=1" }))
         .mockResolvedValue(jsonResponse(PENDING));
       vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
## Summary

Implement broker (GCP-settings-free) support for Google authentication in MulmoTerminal. Users can now sign in without requiring a Desktop client OAuth secret when the broker is available.

## Implementation

- **GoogleStatus API**: Added `brokerAvailable` flag to indicate broker availability
- **Settings UI**: Removed client secret requirement when broker is available
  - Sign-in button now enables without client secret if broker is accessible
  - Warning hint updated to mention broker as alternative to Desktop client secret
- **Composable**: Updated `useGoogleLink` to track broker availability

## Testing

✅ Broker authentication tested:
- Authenticated via GCP-settings-free broker
- Token saved with `issuedVia: "broker"` marker

✅ Tool integration verified:
- Tasks API tools: taskListsList, tasksList, tasksCreate, tasksComplete
- Drive API tools: driveList, driveCreate, driveRead
- Calendar tools still working: calendarListEvents, calendarCreateEvent

## Next Steps

- Cloud Console: Ensure Tasks API and Drive API are enabled in project settings
- Full E2E test with actual broker flow in production environment

## Related

- Issue #399: Google plugin upgrade to core 0.22.0 + google-plugin 0.2.1
- PR #417: Dependency upgrades (merged after main sync)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>