### PR TITLE
refactor: gh normalize の重複除去 + jscpd で .vue も走査（local sweep の後始末）

### DIFF
--- a/.github/workflows/duplication-scan.yaml
+++ b/.github/workflows/duplication-scan.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           set -euo pipefail
           jscpd . \
-            --format typescript \
+            --format "typescript,vue" \
             --ignore "**/node_modules/**,**/dist/**,**/*.d.ts,**/*.spec.ts" \
             --reporters console,sarif \
             --output report

--- a/server/git/ghItem.ts
+++ b/server/git/ghItem.ts
@@ -1,0 +1,24 @@
+// The fields every `gh` list row shares (issues and PRs alike): identity (number, url),
+// display text (title, author, updatedAt). issues.ts / prs.ts layer their own extra
+// fields on top of this base.
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+const asString = (v: unknown): string => (typeof v === "string" ? v : "");
+
+export interface GhItemBase {
+  number: number;
+  title: string;
+  author: string;
+  updatedAt: string;
+  url: string;
+}
+
+// Returns null when the row lacks the identity fields (number + url) — a row we can't
+// link to or key on is not worth rendering. Missing text fields degrade to "".
+export function normalizeGhItemBase(raw: unknown): GhItemBase | null {
+  if (!isRecord(raw)) return null;
+  if (typeof raw.number !== "number" || typeof raw.url !== "string") return null;
+  const author = isRecord(raw.author) && typeof raw.author.login === "string" ? raw.author.login : "";
+  return { number: raw.number, title: asString(raw.title), author, updatedAt: asString(raw.updatedAt), url: raw.url };
+}
+
+export { isRecord };

--- a/server/git/issues.ts
+++ b/server/git/issues.ts
@@ -2,14 +2,9 @@
 // prs.ts. One `gh issue list` per repo in parallel; a failing repo yields a per-repo
 // error instead of sinking the view. The pure normalize helper is unit-tested.
 import { runGh } from "./gh";
+import { normalizeGhItemBase, type GhItemBase } from "./ghItem";
 
-export interface IssueItem {
-  number: number;
-  title: string;
-  author: string;
-  updatedAt: string;
-  url: string;
-}
+export type IssueItem = GhItemBase;
 
 export interface RepoIssues {
   repo: string;
@@ -26,19 +21,8 @@ export interface RepoIssues {
 // click away on GitHub (unlike the PR view, which is the primary place PRs are read).
 export const ISSUE_LIMIT = 20;
 
-export function normalizeIssue(raw: unknown): IssueItem | null {
-  if (!raw || typeof raw !== "object") return null;
-  const o = raw as Record<string, unknown>;
-  if (typeof o.number !== "number" || typeof o.url !== "string") return null;
-  const authorObj = o.author && typeof o.author === "object" ? (o.author as Record<string, unknown>) : null;
-  return {
-    number: o.number,
-    title: typeof o.title === "string" ? o.title : "",
-    author: authorObj && typeof authorObj.login === "string" ? authorObj.login : "",
-    updatedAt: typeof o.updatedAt === "string" ? o.updatedAt : "",
-    url: o.url,
-  };
-}
+// An issue row carries exactly the shared base fields.
+export const normalizeIssue = normalizeGhItemBase;
 
 const GH_FIELDS = "number,title,author,updatedAt,url";
 

--- a/server/git/prs.ts
+++ b/server/git/prs.ts
@@ -3,16 +3,12 @@
 // (missing, no access, gh not installed) yields a per-repo error instead of failing
 // the whole view. The pure normalize/rollup helpers are unit-tested without gh.
 import { runGh } from "./gh";
+import { isRecord, normalizeGhItemBase, type GhItemBase } from "./ghItem";
 
 export type CiState = "passing" | "failing" | "pending" | "none";
 
-export interface PrItem {
-  number: number;
-  title: string;
-  author: string;
-  updatedAt: string;
+export interface PrItem extends GhItemBase {
   isDraft: boolean;
-  url: string;
   review: string | null; // gh reviewDecision (APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED / null)
   ci: CiState;
 }
@@ -51,19 +47,15 @@ export function rollupCiState(checks: unknown): CiState {
 }
 
 export function normalizePr(raw: unknown): PrItem | null {
-  if (!raw || typeof raw !== "object") return null;
-  const o = raw as Record<string, unknown>;
-  if (typeof o.number !== "number" || typeof o.url !== "string") return null;
-  const authorObj = o.author && typeof o.author === "object" ? (o.author as Record<string, unknown>) : null;
+  const base = normalizeGhItemBase(raw);
+  // isRecord(raw) is implied by a non-null base; it re-narrows raw for the extra fields
+  // without an `as` cast.
+  if (!base || !isRecord(raw)) return null;
   return {
-    number: o.number,
-    title: typeof o.title === "string" ? o.title : "",
-    author: authorObj && typeof authorObj.login === "string" ? authorObj.login : "",
-    updatedAt: typeof o.updatedAt === "string" ? o.updatedAt : "",
-    isDraft: o.isDraft === true,
-    url: o.url,
-    review: typeof o.reviewDecision === "string" && o.reviewDecision ? o.reviewDecision : null,
-    ci: rollupCiState(o.statusCheckRollup),
+    ...base,
+    isDraft: raw.isDraft === true,
+    review: typeof raw.reviewDecision === "string" && raw.reviewDecision ? raw.reviewDecision : null,
+    ci: rollupCiState(raw.statusCheckRollup),
   };
 }
 


### PR DESCRIPTION
## Summary

local で **knip（デッドコード）** と **jscpd（重複）** を一通り走らせた結果の後始末。**knip は検出ゼロ、jscpd の TS 重複は 1.84%（健全）** で、その中から**リスク無しでできる2件**だけ対応。

## 対応した2件（リスク無し）

### A. `normalizeIssue` / `normalizePr` の共通化
両者は `unknown → 型` のガード（number/url 必須・author 抽出・共通5フィールド）が完全に同一だった。共有 `server/git/ghItem.ts`（`normalizeGhItemBase`）に抽出:
- `IssueItem` = base、`PrItem extends GhItemBase` に `isDraft`/`review`/`ci` を追加
- 既存の `as Record` キャストを**型ガードに置換**（CLAUDE.md 準拠）
- **同一ビルドターゲット（server）** なので境界リスク無し。既存ユニットテスト（11件）で挙動保存を確認

### ③ jscpd の CI が `.vue` を全く見ていなかった死角を修正
`duplication-scan.yaml` は `--format typescript` のみで、**`.vue` が丸ごと走査対象外**だった（#405 で Codex が指摘済みの死角）。実際 `.vue` には約 **42件の重複**（CSS 26・script 13・template 3）が眠っている。`--format "typescript,vue"` に変更。
- jscpd は `--threshold` 未設定なので **exit 0 のまま**（可視化を広げるだけで、CI を fail させない）。ローカルで exit 0・SARIF 2.1.0 valid（78 results）を確認

## 意図的に見送った項目（「リスク無く」に該当しないため）

- **`THEME_COLOR_KEYS` の server↔client 共有**（最大の TS 重複・25行完全一致）: client(`tsconfig.app`=src のみ)と server(`tsconfig.server`=server のみ)に**共通ディレクトリが無く**、共有には両 tsconfig とバンドル境界を触る必要がある。ビルドを壊すリスクがあるため見送り。
- **`collections.ts` / `index.ts` の route handler 反復**（内部重複の大半）: `loadCollection→404→try/catch` 等の構造的反復で、DRY するとかえって読みにくくなる。2700行ファイルの多数ハンドラ改変はリスクもある。明示のまま残す方が良いと判断。

## 検証

- `yarn lint`（0 errors）/ `typecheck` / `typecheck:server` / `build` / `test`（**1265 passed**）
- git テスト（`issues.spec.ts` / `prs.spec.ts`）11件 pass = normalize の挙動保存
- jscpd 再走査: issues↔prs 間の重複が **0 件**に
- `yarn knip` クリーン（新規 `ghItem.ts` は孤立せず）
- jscpd+vue+sarif: exit 0・SARIF valid をローカル確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
