### PR TITLE
refactor: THEME_COLOR_KEYS を common/ で共有（server/client のビルド境界越え）

### DIFF
--- a/common/themeColors.ts
+++ b/common/themeColors.ts
@@ -1,0 +1,30 @@
+// The xterm ITheme keys a `.mulmoterminal.json` `colors` block may override. Shared across
+// the build boundary: the server config schema validates/strips a config against this set,
+// and the client dir-config parser re-checks the server-sanitized response against the same
+// set. Kept in common/ so the two can't drift — a key in one list but not the other would be
+// silently accepted on one side and dropped on the other.
+export const THEME_COLOR_KEYS = [
+  "foreground",
+  "background",
+  "cursor",
+  "cursorAccent",
+  "selectionBackground",
+  "selectionForeground",
+  "selectionInactiveBackground",
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+  "brightBlack",
+  "brightRed",
+  "brightGreen",
+  "brightYellow",
+  "brightBlue",
+  "brightMagenta",
+  "brightCyan",
+  "brightWhite",
+] as const;

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": ["server/cli-init.ts", "server/cli-google.ts", "bin/update-check.js", "test/**/*.spec.ts", "*.config.ts"],
-  "project": ["server/**/*.ts", "src/**/*.{ts,vue}", "bin/**/*.js"],
+  "project": ["server/**/*.ts", "src/**/*.{ts,vue}", "bin/**/*.js", "common/**/*.ts"],
   "ignore": ["**/dist/**", "**/*.d.ts", "**/logs/**"],
   "ignoreDependencies": [".*"],
   "ignoreExportsUsedInFile": true,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "bin/",
+    "common/",
     "dist/",
     "server/",
     "plugins/",

--- a/server/config/config-schema.ts
+++ b/server/config/config-schema.ts
@@ -11,6 +11,8 @@
 //   2. The `sound` path confinement (a filesystem realpath check) stays in dir-config.ts — it
 //      touches the disk, which does not belong in a pure schema.
 import { z } from "zod";
+// Shared with the client dir-config parser so the two can't drift — see common/themeColors.ts.
+import { THEME_COLOR_KEYS } from "../../common/themeColors.js";
 
 // ---- shared constants ---------------------------------------------------------------------
 
@@ -18,34 +20,6 @@ export const THEME_IDS = ["midnight", "nord", "daylight", "solarized"] as const;
 export const VIEW_TARGETS = ["diff", "prs", "wiki", "collections", "accounting"] as const;
 export const RUN_TYPES = ["shell", "input", "open"] as const;
 export const BUILTIN_CHIPS = ["dir", "git", "ctx", "usage", "status", "diff", "tools"] as const;
-
-// The xterm ITheme keys a `colors` block may override. Anything outside this set is dropped so
-// an arbitrary JSON object can't inject unexpected keys into the terminal options.
-export const THEME_COLOR_KEYS = [
-  "foreground",
-  "background",
-  "cursor",
-  "cursorAccent",
-  "selectionBackground",
-  "selectionForeground",
-  "selectionInactiveBackground",
-  "black",
-  "red",
-  "green",
-  "yellow",
-  "blue",
-  "magenta",
-  "cyan",
-  "white",
-  "brightBlack",
-  "brightRed",
-  "brightGreen",
-  "brightYellow",
-  "brightBlue",
-  "brightMagenta",
-  "brightCyan",
-  "brightWhite",
-] as const;
 
 export const NAME_MAX_CHARS = 40;
 // Runtime caps (sanitizeButtons / sanitizeChips truncate past these), mirrored by the JSON Schema

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -2,6 +2,8 @@ import { ref, watch, onScopeDispose, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
 import type { ITheme } from "@xterm/xterm";
 import { isThemeId, type ThemeId } from "./useTheme";
+// Shared with the server config schema so the two can't drift — see common/themeColors.ts.
+import { THEME_COLOR_KEYS } from "../../common/themeColors";
 
 // The per-directory overrides a terminal adopts when its cwd holds a
 // `.mulmoterminal.json` (served by GET /api/dir-config). The raw sound path stays
@@ -37,34 +39,6 @@ const EMPTY: DirConfig = {
   colors: null,
   hasSound: false,
 };
-
-// The ITheme keys a dir may override; values arrive server-sanitized but are
-// re-checked here so a hand-rolled response can't widen the terminal options.
-const THEME_COLOR_KEYS = [
-  "foreground",
-  "background",
-  "cursor",
-  "cursorAccent",
-  "selectionBackground",
-  "selectionForeground",
-  "selectionInactiveBackground",
-  "black",
-  "red",
-  "green",
-  "yellow",
-  "blue",
-  "magenta",
-  "cyan",
-  "white",
-  "brightBlack",
-  "brightRed",
-  "brightGreen",
-  "brightYellow",
-  "brightBlue",
-  "brightMagenta",
-  "brightCyan",
-  "brightWhite",
-] as const;
 
 function parseColors(input: unknown): Partial<ITheme> | null {
   if (!isRecord(input)) return null;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,5 +11,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "plugins/**/*.ts", "plugins/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "plugins/**/*.ts", "plugins/**/*.vue", "common/**/*.ts"]
 }

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -19,6 +19,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["server/**/*.ts"],
+  "include": ["server/**/*.ts", "common/**/*.ts"],
   "exclude": ["server/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

repo 最大の重複（25行・完全一致）だった `THEME_COLOR_KEYS`（`.mulmoterminal.json` の `colors` が上書きできる xterm ITheme キー24個）を、**共有ディレクトリ `common/`** に一本化。

server の config schema と client の dir-config パーサで verbatim コピーされていた。両ビルドに共通ディレクトリが無い（`tsconfig.server`=`server/**` / `tsconfig.app`=`src/**`）ことがコピーの原因で、片方のリストにだけキーを足すと**一方で受理・他方で破棄**され得る drift 源だった。

## 変更

- **`common/themeColors.ts`** — single source of truth。
- 両 tsconfig の `include` に `common/**`、**`package.json` の `files` に `common/` を追加**（server は tsx でソースのまま実行されるため、公開版は bundle 済み client だけでなく common/ の同梱が必要）。
- `knip.json` の project に `common/` を追加（デッドコード監視の対象に）。
- server 側 import は `.js` 指定子（`verbatimModuleSyntax`）、client 側は拡張子なし（既存の各ビルド慣習どおり）。

## npm 配布の検証（ユーザー指摘対応）

**実際に tarball を作って隔離環境にインストールし、公開レイアウトで動作確認済み**:

- `npm pack` の Tarball Contents に `common/themeColors.ts` が同梱（909B）
- 隔離ディレクトリに `npm install ./mulmoterminal-1.2.0.tgz`（839 パッケージ）→ **インストール済みパッケージの `server/config/config-schema.ts` を tsx で実 import → `../../common/themeColors.js` が公開レイアウトで解決** → `dirColorsField.parse` が THEME_COLOR_KEYS を適用（`foreground` 残し・`bogusKey` 破棄）
- `tsx` は runtime dependency（`^4.23.1`）で公開版でも server 起動可能
- **client**: `dist/assets/index-*.js` に色キーが**インライン化**済み（ブラウザは common/ を実行時 import しない＝配布に FS 依存なし）

## ビルド境界の end-to-end 検証

- `yarn typecheck:server`（server, `.js`→common 解決）/ `yarn typecheck`（client, vue-tsc）/ `yarn build`（vite が common をバンドル）すべて通過
- ランタイム: tsx が dev・公開版の両方で common を解決
- `yarn lint`（0 errors）/ `test`（**1265 passed**）/ `knip` クリーン
- jscpd: config-schema↔useDirConfig の THEME_COLOR_KEYS 重複が**消滅**（総 clones 37→36、1.84%→1.70%）

## 意図的に共有しなかったもの

**server と client の `DirConfig` 型**（jscpd が先頭13フィールドを clone 判定）は**意図的に異なる** — server は生の `sound` パス + buttons/chips/skills を持ち、client は `hasSound`（boolean）のみ（サウンドパスはサーバ側に留める設計）。共有するとこの security 境界を壊すため、統合しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
