### PR TITLE
feat: Google カレンダー拡張（非Primary + 色）に追従（core 0.23.0 / google-plugin 0.3.0, #425)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,18 @@ and keeps your other settings. When `claude` is installed it can hand off to the
 `/mulmoterminal-config` skill for interactive tweaks.
 
 **Google account (optional).** Link a Google account to enable the chat's `google` tool and the
-phone's `google.calendar.*` commands (read and create Calendar events). Sign in from
+phone's `google.calendar.*` commands: read/create events on any calendar (not just your primary),
+list the calendars you've subscribed to, and read the colour palettes. Sign in from
 **Settings → Google account**, or run `npx mulmoterminal google login` — the CLI is the fallback
 for when you're driving MulmoTerminal from another machine, since consent finishes on a loopback
 listener and needs a browser **on the host**. Either way it needs a Desktop OAuth client JSON saved
 as `~/.secrets/client_secret_*.json`; the refresh token lands in `~/.config/mulmo/google-token.json`
 and is **shared with MulmoClaude**, so one link per machine covers both apps.
+
+> **Already linked before the calendar-list / colour features?** They need a read scope your existing
+> link doesn't have, so `listCalendars` (and, in practice, `colors`) fail with an insufficient-scope
+> 403 until you re-authorize: **Settings → Google account → Unlink**, then sign in again (or re-run
+> `google login`). Reading/creating events on your primary calendar keeps working without re-linking.
 
 A global install isn't auto-updated, so on startup MulmoTerminal checks npm and
 prints a one-line notice when a newer version is available (`npm i -g mulmoterminal`

--- a/docs/mulmoclaude-parity.md
+++ b/docs/mulmoclaude-parity.md
@@ -6,7 +6,7 @@ the two hosts can't drift. This doc records where that effort stands: which
 subsystems are shared today, which are deliberately **not**, and what picking
 up each remaining item would involve.
 
-Status date: **2026-07-17** (core `0.20.1`, collection-plugin `0.11.1`).
+Status date: **2026-07-18** (core `0.23.0`, collection-plugin `0.11.1`).
 
 ---
 
@@ -23,7 +23,7 @@ Each of these runs the same engine as MulmoClaude, with host specifics injected:
 | Notifier + collection completion watchers (bell UI) | `@mulmoclaude/core/notifier`, `/collection-watchers` | `server/backends/notifier.ts`, `collectionWatchers.ts` (#124) |
 | Scheduler engine + user cron tasks (`config/scheduler/tasks.json` → spawn a visible chat) | `@mulmoclaude/core/scheduler` | `server/backends/scheduler.ts` (#125) |
 | RSS/JSON feed refresh (system task) | `@mulmoclaude/core/feeds(/server)` | `server/backends/feeds.ts` + `feedRefreshTaskDef` registration in `server/index.ts` |
-| Google account (loopback OAuth) + Calendar, incl. the settings-UI link routes | `@mulmoclaude/core/google` | `server/backends/google.ts` (shim + `/api/google/*`), `remoteHost/googleCalendar.ts`, `server/cli-google.ts` (#386) |
+| Google account (loopback OAuth) + Calendar (events, non-primary calendars, colours) incl. the settings-UI link routes | `@mulmoclaude/core/google` | `server/backends/google.ts` (shim + `/api/google/*`), `remoteHost/googleCalendar.ts` (`createEvent`/`listEvents` w/ `calendarId`+`colorId`, `listCalendars`, `colors`), `server/cli-google.ts` (#386, #425) |
 
 The two workspaces are interchangeable: both apps read and write the same
 on-disk layout (`data/`, `.claude/skills/`, `config/`), and cross-app invariants

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
     "@mulmoclaude/collection-plugin": "^0.11.1",
-    "@mulmoclaude/core": "^0.22.1",
+    "@mulmoclaude/core": "^0.23.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
-    "@mulmoclaude/google-plugin": "^0.2.1",
+    "@mulmoclaude/google-plugin": "^0.3.0",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
     "@mulmoclaude/mulmoscript-plugin": "^0.2.1",
@@ -103,7 +103,7 @@
     "zod": "^4.4.3"
   },
   "resolutions": {
-    "@mulmoclaude/core": "^0.22.1"
+    "@mulmoclaude/core": "^0.23.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/plans/feat-google-calendar-nonprimary-colors.md
+++ b/plans/feat-google-calendar-nonprimary-colors.md
@@ -1,0 +1,50 @@
+# feat #425 — Google カレンダー拡張（非Primary + 色）に追従
+
+Issue: #425。mulmoclaude v1.3.0（`@mulmoclaude/core@0.23.0` / `@mulmoclaude/google-plugin@0.3.0`、
+実装 PR mulmoclaude#2164）で入った「非Primary カレンダー + 色」に mulmoterminal を追従させる。
+
+## ゴール
+
+- チャットの `google` ツールと phone の `google.calendar.*` コマンドで、primary 以外のカレンダーの
+  イベント読み書き・カレンダー一覧・色パレット取得ができるようにする。
+
+## 設計判断
+
+- **core `^0.22`→`^0.23.0` / google-plugin `^0.2.1`→`^0.3.0`**。google-plugin 0.3.0 は core `^0.23.0` を
+  要求するため、core を上げないと npm 実インストールで **core が 2 コピー**（google-plugin 配下に旧 core）に
+  なる。`configureGoogleHost` のモジュール状態が割れるので、両方上げる（#408/#415 と同じ罠）。
+  実 `npm install` で単一コピー（0.23.0）を確認済み。
+- **`yarn add` が `Invariant Violation: expected manifest`（yarn v1 の linking バグ）で失敗**したため、
+  package.json のレンジを直接編集 → `yarn install` で解決（install だと通る既知の癖）。
+- **remote-host ハンドラは mulmoclaude と shape 完全一致**（同じ phone クライアントが両ホストを叩く）。
+  mulmoclaude#2164 が追加した通り:
+  - `createEvent` / `listEvents` に `calendarId`（既定 primary）、create に `colorId` を透過
+  - 新規 `google.calendar.listCalendars`（`{ calendars }`）/ `google.calendar.colors`（`{ colors: { event, calendar } }`）
+  - `calendarId`/`colorId` は trim して空文字は拒否（plugin の Zod `.trim()` に一致）
+- **`google` チャットツールは google-plugin 0.3.0 で自動追従**（factory ローダは args を透過するのでホスト無改修）。
+  新 kinds: `calendarListCalendars` / `calendarColors`、既存 kind に `calendarId`/`colorId`。
+- **新スコープ `calendar.calendarlist.readonly`** は core 0.23.0 の `GOOGLE_SCOPES` に含まれるため、
+  `authorizeGoogle` が自動要求 → **CLI `google login` 再実行・設定画面の Unlink→Sign in で再連携すれば取得**。
+  ホスト側のスコープ配線は不要。broker（mulmoserver）も対応済み。
+- **既存ユーザは再連携が必要**（旧トークンに新スコープが無い）。README に案内を追記。実データでは
+  `listCalendars` も `colors` も旧トークンで 403 insufficient scope（issue は colors を calendar.events で
+  カバーとするが、実測に合わせ両方 re-link 要と記載）。イベント読み書き（primary）は再連携なしで継続動作。
+
+## 変更ファイル
+
+1. `package.json` / `yarn.lock` — core `^0.23.0`、google-plugin `^0.3.0`、resolutions.core `^0.23.0`。
+2. `server/backends/remoteHost/googleCalendar.ts` — `optionalString`（trim+空拒否）、create/list に
+   `calendarId`/`colorId`、新 `listCalendars`/`colors` ハンドラ + `toColorMapJson`。
+3. `server/backends/remoteHost/handlers.ts` — `google.calendar.listCalendars` / `google.calendar.colors` 登録。
+4. `server/backends/remoteHost/googleCalendar.spec.ts` — sampleEvent に `colorId`、stub に `listCalendars`/`getColors`、
+   calendarId/colorId 透過・新 2 ハンドラのテスト。
+5. `server/backends/remoteHost/handlers.spec.ts` — registration ガードに新 2 コマンド。
+6. `README.md` / `docs/mulmoclaude-parity.md` — 新機能と再連携案内、版数更新。
+
+## 検証
+
+- `yarn format` / `lint`（0 errors）/ `typecheck` / `typecheck:server` / `build` / `test`（**1272 passed**、+7）。
+- `google` ツールに `calendarListCalendars` / `calendarColors` が出ることを確認。
+- **npm 実解決で core 単一コピー（0.23.0）** を確認（2コピー罠なし）。
+- 実アカウント疎通（読み取りのみ）: `listEvents` は 0.23 でも動作（`colorId` 付与）、`listCalendars`/`colors` は
+  再連携前トークンで 403 insufficient scope（再連携要求を実証）。実際の再連携（consent）は未実施。

--- a/server/backends/remoteHost/googleCalendar.spec.ts
+++ b/server/backends/remoteHost/googleCalendar.spec.ts
@@ -3,10 +3,16 @@
 // clamping, and wiring — the Google engine is stubbed (no network, no token).
 import { describe, it, expect } from "vitest";
 import { DEFAULT_LIST_MAX_RESULTS, MAX_LIST_RESULTS } from "@mulmoclaude/core/google";
-import type { CalendarEventInput, CalendarEventSummary, ListEventsInput } from "@mulmoclaude/core/google";
+import type { CalendarColors, CalendarEventInput, CalendarEventSummary, CalendarSummary, ListEventsInput } from "@mulmoclaude/core/google";
 import type { JsonObject } from "@mulmoclaude/core/remote-host";
 
-import { createGoogleCalendarCreateEvent, createGoogleCalendarListEvents, type GoogleCalendarDeps } from "./googleCalendar.js";
+import {
+  createGoogleCalendarColors,
+  createGoogleCalendarCreateEvent,
+  createGoogleCalendarListCalendars,
+  createGoogleCalendarListEvents,
+  type GoogleCalendarDeps,
+} from "./googleCalendar.js";
 
 const sampleEvent: CalendarEventSummary = {
   id: "ev1",
@@ -15,16 +21,35 @@ const sampleEvent: CalendarEventSummary = {
   end: "2026-07-17T09:15:00+09:00",
   htmlLink: "https://calendar.google.com/event?eid=ev1",
   status: "confirmed",
+  colorId: "",
+};
+
+const sampleCalendar: CalendarSummary = {
+  id: "team@group.calendar.google.com",
+  summary: "Team",
+  description: "shared",
+  primary: false,
+  accessRole: "reader",
+  backgroundColor: "#16a765",
+  foregroundColor: "#1d1d1d",
+  colorId: "8",
+};
+
+const sampleColors: CalendarColors = {
+  event: { "1": { background: "#a4bdfc", foreground: "#1d1d1d" } },
+  calendar: { "8": { background: "#16a765", foreground: "#1d1d1d" } },
 };
 
 interface StubCalls {
   createInputs: CalendarEventInput[];
   listInputs: ListEventsInput[];
   tokenRequests: number;
+  listCalendarsCalls: number;
+  getColorsCalls: number;
 }
 
 const stubDeps = (): { deps: GoogleCalendarDeps; calls: StubCalls } => {
-  const calls: StubCalls = { createInputs: [], listInputs: [], tokenRequests: 0 };
+  const calls: StubCalls = { createInputs: [], listInputs: [], tokenRequests: 0, listCalendarsCalls: 0, getColorsCalls: 0 };
   const deps: GoogleCalendarDeps = {
     getAccessToken: async () => {
       calls.tokenRequests += 1;
@@ -37,6 +62,14 @@ const stubDeps = (): { deps: GoogleCalendarDeps; calls: StubCalls } => {
     listEvents: async (_token, input = {}) => {
       calls.listInputs.push(input);
       return [sampleEvent];
+    },
+    listCalendars: async () => {
+      calls.listCalendarsCalls += 1;
+      return [sampleCalendar];
+    },
+    getColors: async () => {
+      calls.getColorsCalls += 1;
+      return sampleColors;
     },
   };
   return { deps, calls };
@@ -98,6 +131,30 @@ describe("createGoogleCalendarCreateEvent", () => {
     await expect(Promise.resolve(createGoogleCalendarCreateEvent(deps)({}))).rejects.toThrow();
     expect(calls.tokenRequests).toBe(0);
   });
+
+  it("passes calendarId and colorId through when given (trimmed)", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarCreateEvent(deps)({ ...validParams, calendarId: "  team@group.calendar.google.com  ", colorId: "5" });
+    expect(calls.createInputs[0]?.calendarId).toBe("team@group.calendar.google.com");
+    expect(calls.createInputs[0]?.colorId).toBe("5");
+  });
+
+  it("leaves calendarId and colorId undefined when omitted", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarCreateEvent(deps)({ ...validParams });
+    expect(calls.createInputs[0]?.calendarId).toBeUndefined();
+    expect(calls.createInputs[0]?.colorId).toBeUndefined();
+  });
+
+  it.each([
+    ["a blank calendarId", "calendarId", "   "],
+    ["a non-string colorId", "colorId", 5],
+  ])("rejects %s", async (_label, key, given) => {
+    const { deps } = stubDeps();
+    await expect(Promise.resolve(createGoogleCalendarCreateEvent(deps)({ ...validParams, [key]: given }))).rejects.toThrow(
+      new RegExp(`${key} must be a non-empty string`),
+    );
+  });
 });
 
 describe("createGoogleCalendarListEvents", () => {
@@ -139,5 +196,32 @@ describe("createGoogleCalendarListEvents", () => {
     const params: JsonObject = given === undefined ? {} : { maxResults: given };
     await createGoogleCalendarListEvents(deps)(params);
     expect(calls.listInputs[0]?.maxResults).toBe(expected);
+  });
+
+  it("passes calendarId through (default primary when omitted)", async () => {
+    const { deps, calls } = stubDeps();
+    await createGoogleCalendarListEvents(deps)({ calendarId: "team@group.calendar.google.com" });
+    expect(calls.listInputs[0]?.calendarId).toBe("team@group.calendar.google.com");
+    await createGoogleCalendarListEvents(deps)({});
+    expect(calls.listInputs[1]?.calendarId).toBeUndefined();
+  });
+});
+
+describe("createGoogleCalendarListCalendars", () => {
+  it("returns the user's calendars under { calendars }", async () => {
+    const { deps, calls } = stubDeps();
+    const result = await createGoogleCalendarListCalendars(deps)({});
+    expect(result).toEqual({ calendars: [sampleCalendar] });
+    expect(calls.listCalendarsCalls).toBe(1);
+    expect(calls.tokenRequests).toBe(1);
+  });
+});
+
+describe("createGoogleCalendarColors", () => {
+  it("returns the event/calendar colour palettes under { colors }", async () => {
+    const { deps, calls } = stubDeps();
+    const result = await createGoogleCalendarColors(deps)({});
+    expect(result).toEqual({ colors: sampleColors });
+    expect(calls.getColorsCalls).toBe(1);
   });
 });

--- a/server/backends/remoteHost/googleCalendar.ts
+++ b/server/backends/remoteHost/googleCalendar.ts
@@ -10,17 +10,22 @@
 import {
   createCalendarEvent,
   DEFAULT_LIST_MAX_RESULTS,
+  getCalendarColors,
   getGoogleAccessToken,
   isIsoDateTimeWithOffset,
   listCalendarEvents,
+  listCalendars,
   MAX_LIST_RESULTS,
+  type CalendarColorEntry,
 } from "@mulmoclaude/core/google";
-import type { CommandHandler, JsonObject } from "@mulmoclaude/core/remote-host";
+import type { CommandHandler, JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
 export interface GoogleCalendarDeps {
   getAccessToken: typeof getGoogleAccessToken;
   createEvent: typeof createCalendarEvent;
   listEvents: typeof listCalendarEvents;
+  listCalendars: typeof listCalendars;
+  getColors: typeof getCalendarColors;
 }
 
 const MIN_LIST_RESULTS = 1;
@@ -31,6 +36,23 @@ const requiredString = (params: JsonObject, key: string): string => {
   if (typeof value !== "string" || value.trim() === "") throw new Error(`${key} must be a non-empty string`);
   return value;
 };
+
+// Optional string param, trimmed so whitespace can't reach the Google API (matches the
+// plugin's Zod .trim()). A present-but-non-string / blank value is a hard error, not a
+// silent fallback — an intended calendarId/colorId that's malformed should surface.
+const optionalString = (params: JsonObject, key: string): string | undefined => {
+  const value = params[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`${key} must be a non-empty string`);
+  return value.trim();
+};
+
+// Spread rebuilds an anonymous object type — the named CalendarColorEntry interface (no
+// index signature) can't satisfy the channel's structural JsonValue directly.
+const toColorMapJson = (map: Record<string, CalendarColorEntry>): JsonObject =>
+  Object.fromEntries(
+    Object.entries(map).map(([colorId, entry]): [string, JsonValue] => [colorId, { background: entry.background, foreground: entry.foreground }]),
+  );
 
 // Calendar rejects date-only or offset-less values with an opaque 400, so the
 // offset is enforced here where the remote still gets an actionable message.
@@ -59,6 +81,8 @@ export const createGoogleCalendarCreateEvent =
       startDateTime: asDateTime(requiredString(params, "start"), "start"),
       endDateTime: asDateTime(requiredString(params, "end"), "end"),
       description: typeof params.description === "string" ? params.description : undefined,
+      calendarId: optionalString(params, "calendarId"),
+      colorId: optionalString(params, "colorId"),
     };
     const event = await deps.createEvent(await deps.getAccessToken(), input);
     // Spread rebuilds an anonymous object type — CalendarEventSummary has no
@@ -71,10 +95,37 @@ export const createGoogleCalendarListEvents =
   async (params: JsonObject) => {
     const timeMin = optionalDateTime(params, "timeMin");
     const maxResults = clampMaxResults(params.maxResults);
-    const events = await deps.listEvents(await deps.getAccessToken(), { timeMin, maxResults });
+    const calendarId = optionalString(params, "calendarId");
+    const events = await deps.listEvents(await deps.getAccessToken(), { timeMin, maxResults, calendarId });
     return { events: events.map((event) => ({ ...event })) };
   };
 
-const liveDeps: GoogleCalendarDeps = { getAccessToken: getGoogleAccessToken, createEvent: createCalendarEvent, listEvents: listCalendarEvents };
+// The calendars the user has added/subscribed to (primary + secondary + shared). Needs the
+// calendar-list read scope, which existing links lack until the user re-authorizes.
+export const createGoogleCalendarListCalendars =
+  (deps: GoogleCalendarDeps): CommandHandler =>
+  async () => {
+    const calendars = await deps.listCalendars(await deps.getAccessToken());
+    return { calendars: calendars.map((calendar) => ({ ...calendar })) };
+  };
+
+// The event/calendar colour palettes (colorId → hex), so the phone can render the colours
+// an event or calendar references.
+export const createGoogleCalendarColors =
+  (deps: GoogleCalendarDeps): CommandHandler =>
+  async () => {
+    const colors = await deps.getColors(await deps.getAccessToken());
+    return { colors: { event: toColorMapJson(colors.event), calendar: toColorMapJson(colors.calendar) } };
+  };
+
+const liveDeps: GoogleCalendarDeps = {
+  getAccessToken: getGoogleAccessToken,
+  createEvent: createCalendarEvent,
+  listEvents: listCalendarEvents,
+  listCalendars,
+  getColors: getCalendarColors,
+};
 export const googleCalendarCreateEvent = createGoogleCalendarCreateEvent(liveDeps);
 export const googleCalendarListEvents = createGoogleCalendarListEvents(liveDeps);
+export const googleCalendarListCalendars = createGoogleCalendarListCalendars(liveDeps);
+export const googleCalendarColors = createGoogleCalendarColors(liveDeps);

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -47,6 +47,8 @@ describe("createRemoteHostHandlers", () => {
       "mutateRemoteViewItem",
       "google.calendar.createEvent",
       "google.calendar.listEvents",
+      "google.calendar.listCalendars",
+      "google.calendar.colors",
     ]) {
       expect(typeof handlers[name]).toBe("function");
     }

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -14,7 +14,7 @@ import { listBooks } from "@mulmoclaude/accounting-plugin/server";
 import type { CommandHandlers, JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
 import { readShortcuts } from "../shortcuts.js";
-import { googleCalendarCreateEvent, googleCalendarListEvents } from "./googleCalendar.js";
+import { googleCalendarColors, googleCalendarCreateEvent, googleCalendarListCalendars, googleCalendarListEvents } from "./googleCalendar.js";
 import { discoverSkillNames } from "./skills.js";
 import { clampLimit, clampOffset, deriveItems, pageResult } from "./collectionPage.js";
 import {
@@ -139,6 +139,10 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
     // way the phone can learn it needs to be run.
     "google.calendar.createEvent": googleCalendarCreateEvent,
     "google.calendar.listEvents": googleCalendarListEvents,
+    // Non-primary calendars + colour palettes (core 0.23). listCalendars needs the
+    // calendar-list read scope, so an existing link errors until the user re-authorizes.
+    "google.calendar.listCalendars": googleCalendarListCalendars,
+    "google.calendar.colors": googleCalendarColors,
 
     // Feed registry with retrieval kind / schedule / last-fetch time (read-only).
     listFeeds: async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -321,6 +321,69 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz#037817b574262134cabd68fc4ec1a454f168407b"
   integrity sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==
 
+"@duckdb/node-api@^1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-api/-/node-api-1.5.4-r.1.tgz#1c6a6c3e0c11243be97f74d02bfa2e153c28265b"
+  integrity sha512-3PYk/4//svuYmb9RYVM71cCoNa6ngoYWwrMhJaqbm010txzIMWbJCbxrFeqDl+krdIug+Hc/MNCeS0gHsTXSIw==
+  dependencies:
+    "@duckdb/node-bindings" "1.5.4-r.1"
+
+"@duckdb/node-bindings-darwin-arm64@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.4-r.1.tgz#751a9ae637b626a3aaf8116f72a185fb106dc0bb"
+  integrity sha512-fl8EC5xdmI7VAI7bX4W6D7lOGNtxyLvSxGjOY8Ov7viVEKwIcBXXKlMPgh3sw+PiVlwZhKlknuCI8BL5xXpSDg==
+
+"@duckdb/node-bindings-darwin-x64@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.4-r.1.tgz#26d5a7aa1b7789a13189c12cc0e417d28568b615"
+  integrity sha512-E8bECZ6abJqunPqVR1NA0Zho7qxanfDWWFuJrKMsU1NCUqyGLyhXqZwsRHAx7J6jrM+lhQ7wOZj1x/N4OVml3A==
+
+"@duckdb/node-bindings-linux-arm64-musl@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.4-r.1.tgz#3160ebbdfb178877465eacc902f30d64ccfa8ba7"
+  integrity sha512-96Pyk5Syy18S5DSN0CKkOQ7/CsyVGRML8ewox1qpFDjYvPH1VsULlQoIRwbpw7mkFEy17wuWmbwzb7oKu/nGMw==
+
+"@duckdb/node-bindings-linux-arm64@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.4-r.1.tgz#5c38d6cc5ecac687d9dacfe9bd28f00d9efd4c3f"
+  integrity sha512-4EsB+cgRqOE++mdPQ2ZoGJCg4ylmuqdbLDtmo3L19B+C5OzGmrhxlKD4o75eGEtfO52M+w+TdL0qhy0H5XvaKQ==
+
+"@duckdb/node-bindings-linux-x64-musl@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.4-r.1.tgz#e6a9a72c6479bc6620ed38838dbeb7a1a23cadd1"
+  integrity sha512-tWgnttlKfWTktyv+m9YbxaedKBon5wmUoJ9DaIbE3D98KhhUaqmJhnjzso9O8hp6WUeRmwXR//hpT/X6Ft9nYA==
+
+"@duckdb/node-bindings-linux-x64@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.4-r.1.tgz#22d83876cde13ab52cd2159d21d068da9101b7a1"
+  integrity sha512-IldapRydno5kf4VkPCe8yK+j4pCg+j6Qs46UmLnKex/mtIdJa7ifhMYRkvdc5KIAFEC0eEL5c830QeuwcUROyg==
+
+"@duckdb/node-bindings-win32-arm64@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.4-r.1.tgz#6e74798265e75abb2d16bac0ddac5b8f49a2fcee"
+  integrity sha512-77apmuNo51bPZzv8xjdeCp+hlU6JLwMPtS1CMViy83ONTsah+CGnpBx1lCnEqPL5Va0meufZyjSdZCVCijLdDA==
+
+"@duckdb/node-bindings-win32-x64@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.4-r.1.tgz#c97638bcbcc472a4428d844ca94d4b8d3fcd918e"
+  integrity sha512-Wme7dScBGqjn2PUJ+RLFiFAblW1qQRBraX7SJc4uKtftZiUJJWZapEUh+doGfb68Qxvw8JhlMBSdaUsSUDJYsw==
+
+"@duckdb/node-bindings@1.5.4-r.1":
+  version "1.5.4-r.1"
+  resolved "https://registry.yarnpkg.com/@duckdb/node-bindings/-/node-bindings-1.5.4-r.1.tgz#1dd1e6389b580721b9e23d0afbdb3003731318cb"
+  integrity sha512-v834OZZKQ59yAvh8GOEmM+R1foPNgdMGL0VTBgHywgblgQNyq11HvWgT4QGJIUFfo/cQ9WFyf1MFhK0+hV1aiA==
+  dependencies:
+    detect-libc "^2.1.2"
+  optionalDependencies:
+    "@duckdb/node-bindings-darwin-arm64" "1.5.4-r.1"
+    "@duckdb/node-bindings-darwin-x64" "1.5.4-r.1"
+    "@duckdb/node-bindings-linux-arm64" "1.5.4-r.1"
+    "@duckdb/node-bindings-linux-arm64-musl" "1.5.4-r.1"
+    "@duckdb/node-bindings-linux-x64" "1.5.4-r.1"
+    "@duckdb/node-bindings-linux-x64-musl" "1.5.4-r.1"
+    "@duckdb/node-bindings-win32-arm64" "1.5.4-r.1"
+    "@duckdb/node-bindings-win32-x64" "1.5.4-r.1"
+
 "@emnapi/core@1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
@@ -1675,13 +1738,15 @@
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.22.0", "@mulmoclaude/core@^0.22.1":
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.22.1.tgz#56eecd90399b8dc3581eb1549beb923fa8504f39"
-  integrity sha512-BctuyJQOpCdiiz2z4RhAS6Ky4JDqw3+7R72E4O4x/2iFU1Q03w2pO0xDbU2/Pmbb9J+jhMau7AwXyjIWbiYadw==
+"@mulmoclaude/core@^0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.23.0.tgz#58701680a519a0c092aeb81f03621f3307ef72fc"
+  integrity sha512-IRwm2VETiCe6RDU7bsTxdYWcx9pUKZWm9RvXLzoDa5sYy3VegiouhzDeMIseuFCCrCUoQZOl6koO69lHvPidBQ==
   dependencies:
+    "@duckdb/node-api" "^1.5.4-r.1"
     fast-xml-parser "^5.10.1"
     google-auth-library "^10.9.0"
+    iconv-lite "^0.7.3"
     js-yaml "^5.2.1"
     zod "^4.4.3"
 
@@ -1690,12 +1755,12 @@
   resolved "https://npm.flatt.tech/@mulmoclaude/form-plugin/-/form-plugin-0.1.4.tgz#64e8f9dc0537148156cbfc1235d5a68baf64cdf3"
   integrity sha512-dgqEiAazyMzLgNv0V3ewQxSPU5dI0eXecRYZ5rXe0Fu9CWZkCb1GOwJDjYHKDZnzMyYMQLzXnyt5gwHNW+QD+w==
 
-"@mulmoclaude/google-plugin@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.2.1.tgz#60a74fe555ed8ed472a28f028d7fac45ae818f53"
-  integrity sha512-ZHhSsp4/iAFtKNoiZDzRmu2FOokr9lakNp7O7FZi7CcvcJmIMDnOv9XGQ2/a7Clnr4T0Olf7Id+HY6SIBLcAgg==
+"@mulmoclaude/google-plugin@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.3.0.tgz#d01dc860503b98e99b922b99b52f6f948aefc051"
+  integrity sha512-qb4fvnWYUH/F44iMd988ld0RMRT3fj3v82Gog9KB08nc5jrkH6kHU3n7wP4RZMAHkOX31CjWcUAoLu7umt+k+A==
   dependencies:
-    "@mulmoclaude/core" "^0.22.0"
+    "@mulmoclaude/core" "^0.23.0"
 
 "@mulmoclaude/html-plugin@^0.2.5":
   version "0.2.5"
@@ -5270,6 +5335,13 @@ iconv-lite@^0.7.0, iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
   integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.3.tgz#84ee12f963e7de50bc01a13e160a078b3b0f415f"
+  integrity sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 


### PR DESCRIPTION
## Summary

Issue #425。mulmoclaude v1.3.0（`@mulmoclaude/core@0.23.0` / `@mulmoclaude/google-plugin@0.3.0`、実装 mulmoclaude#2164）の **Google カレンダー拡張（非Primary カレンダー + 色）** に mulmoterminal を追従。

- チャットの `google` ツールと phone の `google.calendar.*` で、**primary 以外のカレンダー**のイベント読み書き・**カレンダー一覧**・**色パレット**取得が可能に。

## 変更

| ファイル | 内容 |
|---|---|
| `package.json` / `yarn.lock` | core `^0.22.1`→`^0.23.0`、google-plugin `^0.2.1`→`^0.3.0`（resolutions.core も） |
| `remoteHost/googleCalendar.ts` | `createEvent`/`listEvents` に `calendarId`（既定 primary）+ create に `colorId`、新規 `listCalendars` / `colors` ハンドラ |
| `remoteHost/handlers.ts` | `google.calendar.listCalendars` / `google.calendar.colors` を登録 |
| spec × 2 | 新ハンドラ + calendarId/colorId 透過のテスト、registration ガード更新 |
| `README.md` / `docs/mulmoclaude-parity.md` | 新機能 + 再連携案内、版数更新 |

remote-host ハンドラは **mulmoclaude と shape 完全一致**（同じ phone クライアントが両ホストを叩く）。`google` チャットツールは google-plugin 0.3.0 で**自動追従**（factory ローダは args を透過するのでホスト無改修）— 新 kinds `calendarListCalendars`/`calendarColors` が出ることを確認。

## Items to Confirm / Review

- **2コピー罠を回避**: google-plugin@0.3.0 は core `^0.23.0` 要求。core を据え置くと npm 実インストールで core が 2 コピーに割れ `configureGoogleHost` のモジュール状態が壊れる。**実 `npm install` で単一コピー（0.23.0）を確認済み**。
- **`yarn add` が失敗**（yarn v1 の `Invariant Violation: expected manifest` linking バグ）→ package.json のレンジ直接編集 + `yarn install` で解決（install だと通る既知の癖）。依存の中身自体に問題はない。
- **既存ユーザは再連携が必要**（新スコープ `calendar.calendarlist.readonly` は旧トークンに無い）。core の `GOOGLE_SCOPES` に含まれるので `google login` 再実行 / 設定画面 Unlink→Sign in で取得＝ホスト側スコープ配線は不要。README に案内。
- **実データの相違**: issue は「`/colors` は `calendar.events` でカバー」とするが、**実測では旧トークンで `listCalendars` も `colors` も 403 insufficient scope**。README は実挙動に合わせ両方 re-link 要と記載。primary のイベント読み書きは再連携なしで継続動作。

## 検証

- `yarn lint`（0 errors）/ `typecheck` / `typecheck:server` / `build` / `test`（**1272 passed**、+7）
- `google` ツールに `calendarListCalendars`/`calendarColors` が出ることを確認
- **npm 実解決で core 単一コピー（0.23.0）**
- **実アカウント疎通（読み取りのみ）**: `listEvents` は 0.23 でも動作（`colorId` 付与）、`listCalendars`/`colors` は再連携前トークンで 403 insufficient scope（再連携要求を実証）。実際の consent（再連携）は未実施。

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
