### PR TITLE
feat: cockpit roster に PR ワークフロー・フェーズを表示（roster phase, split 2/3）

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -35,6 +35,7 @@ import {
   type Cell,
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
+import { isPrPhase, type PrPhase } from "./rosterPhase";
 import { useGridActivity } from "../composables/useGridActivity";
 import { registerNewTerminalHandler, type NewTerminalRequest } from "../composables/useNewTerminal";
 import { usePendingScript } from "../composables/usePendingScript";
@@ -131,6 +132,29 @@ async function seedMeta(id: string, cwd: string | null) {
 }
 const refreshAllMeta = () => state.value.cells.forEach((c) => c.session && void seedMeta(c.session, c.cwd));
 watch(() => state.value.cells.map((c) => c.session ?? "").join(","), refreshAllMeta, { immediate: true });
+
+// The PR workflow phase per directory (GET /api/pr-phase), shown in the roster beside the
+// agent status. Keyed by cwd, not session — the phase is the branch's, so cells sharing a dir
+// share one fetch. Best-effort and cached server-side, so the roster poll can re-fetch cheaply.
+const phaseByCwd = reactive(new Map<string, PrPhase>());
+async function seedPhase(cwd: string) {
+  try {
+    const res = await fetch(`/api/pr-phase?cwd=${encodeURIComponent(cwd)}`);
+    if (!res.ok) return;
+    const d = (await res.json()) as { phase?: unknown };
+    if (isPrPhase(d.phase)) phaseByCwd.set(cwd, d.phase);
+  } catch {
+    // best-effort — the next poll retries
+  }
+}
+const refreshAllPhases = () => {
+  const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
+  cwds.forEach((cwd) => void seedPhase(cwd));
+};
+const refreshRoster = () => {
+  refreshAllMeta();
+  refreshAllPhases();
+};
 const ROSTER_POLL_MS = 4000;
 let rosterTimer: ReturnType<typeof setInterval> | null = null;
 // The roster is the sole consumer of this poll, and it's shown only while zoomed AND in list
@@ -139,8 +163,8 @@ const listModeOn = ref(true);
 const rosterVisible = () => expandedUid.value !== null && listModeOn.value;
 const startPoll = () => {
   if (!rosterVisible() || rosterTimer !== null) return;
-  refreshAllMeta();
-  rosterTimer = setInterval(refreshAllMeta, ROSTER_POLL_MS);
+  refreshRoster();
+  rosterTimer = setInterval(refreshRoster, ROSTER_POLL_MS);
 };
 const stopPoll = () => {
   if (rosterTimer !== null) clearInterval(rosterTimer);
@@ -174,6 +198,7 @@ const listRows = computed(() =>
       prompt: meta?.lastPrompt ?? null,
       response: meta?.lastResponse ?? null,
       fallback: fallbackLabel(c),
+      phase: (c.cwd ? phaseByCwd.get(c.cwd) : undefined) ?? ("none" as PrPhase),
     };
   }),
 );

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -9,6 +9,7 @@ import { flipKeyframes, FLIP_MS, FLIP_EASING } from "./cellFlip";
 import { formatCwd } from "./cwdDisplay";
 import type { Cell, CellStatus } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
+import { phaseDisplay, type PrPhase } from "./rosterPhase";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 
@@ -29,6 +30,7 @@ export interface CockpitRow {
   prompt: string | null; // current user prompt
   response: string | null; // tail of the agent's latest reply
   fallback: string | null; // label when there's no prompt/summary yet (launcher/command name)
+  phase: PrPhase; // the branch's PR workflow phase (`none` until a PR exists)
 }
 const STATUS_WORD: Record<CellStatus, string> = { working: "running", blocked: "waiting", done: "done", idle: "idle" };
 const props = defineProps<{
@@ -173,6 +175,9 @@ watch(
         <span class="cockpit-head">
           <span class="cockpit-dot" :class="`st-${row.status}`" aria-hidden="true" />
           <span class="cockpit-badge" :class="`st-${row.status}`">{{ STATUS_WORD[row.status] }}</span>
+          <span v-if="phaseDisplay(row.phase)" class="cockpit-phase" :class="`ph-${row.phase}`" :title="phaseDisplay(row.phase)?.title">
+            {{ phaseDisplay(row.phase)?.label }}
+          </span>
           <span v-if="row.agent === 'codex'" class="cockpit-agent">codex</span>
           <span class="cockpit-dir">{{ formatCwd(row.cwd, home, 44) || "—" }}</span>
         </span>
@@ -424,6 +429,34 @@ watch(
 .cockpit-badge.st-blocked {
   background: #f59e0b;
   color: #1f1300;
+}
+/* The PR workflow phase — an OUTLINED pill, so it reads as a distinct signal from the
+   filled agent-status badge next to it. Coloured by lifecycle: blue in-progress, red
+   failing, amber needs-attention, green ready, violet merged, grey draft/closed. */
+.cockpit-phase {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 0 6px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  color: #9aa4b2;
+  white-space: nowrap;
+}
+.cockpit-phase.ph-ci-running {
+  color: #4a9eff;
+}
+.cockpit-phase.ph-ci-failing {
+  color: #f87171;
+}
+.cockpit-phase.ph-changes-requested {
+  color: #f59e0b;
+}
+.cockpit-phase.ph-ready {
+  color: #22c55e;
+}
+.cockpit-phase.ph-merged {
+  color: #a78bfa;
 }
 .cockpit-agent {
   flex: 0 0 auto;

--- a/src/components/rosterPhase.ts
+++ b/src/components/rosterPhase.ts
@@ -1,0 +1,24 @@
+// Display mapping for a cell's PR workflow phase in the cockpit roster. The phase values
+// mirror server/git/prPhase.ts's PrPhase (the /api/pr-phase response) — keep them in sync.
+export type PrPhase = "none" | "draft" | "ci-failing" | "changes-requested" | "ci-running" | "ready" | "merged" | "closed";
+
+export const isPrPhase = (v: unknown): v is PrPhase =>
+  v === "none" || v === "draft" || v === "ci-failing" || v === "changes-requested" || v === "ci-running" || v === "ready" || v === "merged" || v === "closed";
+
+// Short badge text + a fuller tooltip. `none` (no PR yet) renders nothing — the roster just
+// shows the agent status until a PR exists.
+interface PhaseDisplay {
+  label: string;
+  title: string;
+}
+const DISPLAY: Record<Exclude<PrPhase, "none">, PhaseDisplay> = {
+  draft: { label: "draft", title: "Draft PR" },
+  "ci-failing": { label: "CI fail", title: "PR — CI failing" },
+  "changes-requested": { label: "changes", title: "PR — changes requested" },
+  "ci-running": { label: "CI…", title: "PR — CI running" },
+  ready: { label: "ready", title: "PR ready to merge" },
+  merged: { label: "merged", title: "PR merged" },
+  closed: { label: "closed", title: "PR closed" },
+};
+
+export const phaseDisplay = (phase: PrPhase): PhaseDisplay | null => (phase === "none" ? null : DISPLAY[phase]);

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -61,6 +61,7 @@ const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => (
   prompt: null,
   response: null,
   fallback: null,
+  phase: "none",
   ...over,
 });
 const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[]) =>
@@ -236,5 +237,20 @@ describe("grid cockpit (list view)", () => {
     const lines = w.findAll(".cockpit-line").map((l) => l.text());
     expect(lines.some((t) => t.includes("summary"))).toBe(false); // no summary line
     expect(lines.some((t) => t.includes("prompt") && t.includes("bash"))).toBe(true); // fallback in the prompt line
+  });
+
+  it("renders a PR-phase badge with the phase label and class", async () => {
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { phase: "ready" })]);
+    await nextTick();
+    const badge = w.find(".cockpit-phase");
+    expect(badge.exists()).toBe(true);
+    expect(badge.text()).toBe("ready");
+    expect(badge.classes()).toContain("ph-ready");
+  });
+
+  it("shows no phase badge for a cell with no PR yet (phase none)", async () => {
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { phase: "none" })]);
+    await nextTick();
+    expect(w.find(".cockpit-phase").exists()).toBe(false);
   });
 });

--- a/test/src/components/rosterPhase.spec.ts
+++ b/test/src/components/rosterPhase.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { isPrPhase, phaseDisplay, type PrPhase } from "../../../src/components/rosterPhase";
+
+describe("isPrPhase", () => {
+  it.each(["none", "draft", "ci-failing", "changes-requested", "ci-running", "ready", "merged", "closed"])("accepts %s", (v) => {
+    expect(isPrPhase(v)).toBe(true);
+  });
+
+  it.each([["unknown"], [""], [null], [undefined], [1]])("rejects %s", (v) => {
+    expect(isPrPhase(v)).toBe(false);
+  });
+});
+
+describe("phaseDisplay", () => {
+  it("renders nothing for none (no PR yet)", () => {
+    expect(phaseDisplay("none")).toBeNull();
+  });
+
+  it.each<[PrPhase, string]>([
+    ["draft", "draft"],
+    ["ci-failing", "CI fail"],
+    ["changes-requested", "changes"],
+    ["ci-running", "CI…"],
+    ["ready", "ready"],
+    ["merged", "merged"],
+    ["closed", "closed"],
+  ])("gives %s the label %s with a fuller tooltip", (phase, label) => {
+    const d = phaseDisplay(phase);
+    expect(d?.label).toBe(label);
+    expect(d?.title).toMatch(/PR|Draft/);
+  });
+});


### PR DESCRIPTION
## Summary

#428 の **split 2/3（UI）**。split 1 で入れた `/api/pr-phase` を使い、grid の zoom + list mode の **cockpit roster** に、各セルのエージェント活動状態（idle/running）の隣に**ブランチの PR フェーズ**を表示する。多数の並列エージェントを俯瞰したとき、「どれが PR レビュー中／merge 待ち／merged か」が一目で分かる。

## 変更

- **`src/components/rosterPhase.ts`**（新規）: `PrPhase` 型（`server/git/prPhase.ts` の PrPhase をミラー）+ `phaseDisplay(phase)` → `{ label, title }`。`none`（PR未作成）は何も出さない。
- **`GridView.vue`**: cwd 単位の `/api/pr-phase` ポーリング（`phaseByCwd`）を既存の roster ポーリングに統合（サーバ側キャッシュ・cwd 重複排除）、`CockpitRow.phase` として供給。
- **`TerminalGrid.vue`**: roster head に**枠線ピル**の phase バッジを描画。ライフサイクルで色分け（青=進行中 / 赤=失敗 / 琥珀=changes / 緑=ready / 紫=merged）。塗りの status バッジと視覚的に区別。

## 表示例

roster の各行:
```
● running  [ready]  ~/proj   ← status（塗り） + phase（枠線） + dir
  summary  …
  prompt   …
```

## 検証

- **@vue/test-utils mount**: 実 `TerminalGrid` をマウントし、`.cockpit-phase` バッジが `ready` で label `ready`・class `ph-ready` を持って**実 DOM に描画**され、`none` では**出ない**ことを確認
- `rosterPhase` の label/title/none/型ガードを単体テスト
- `yarn lint`（0 errors）/ `typecheck` / `build` / `test`（**1328 passed**）/ `knip` クリーン

> ピクセル（色・レイアウト）の目視は headless で roster を populate するのに実セッション起動が要るため、DOM レベルの mount 検証で代替。必要なら `/verify` で実スクショを取ります。

## 次の split

- **3/3**: エージェント側の plan中 vs 実装中（plan mode 検出、既存 hook 活動状態の細分化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
