### PR TITLE
chore(deps): @mulmoclaude/core@^0.25.1 + port backends to the CollectionStore seam

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.12.0",
-    "@mulmoclaude/core": "^0.23.1",
+    "@mulmoclaude/collection-plugin": "^0.13.1",
+    "@mulmoclaude/core": "^0.25.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/google-plugin": "^0.3.0",
     "@mulmoclaude/html-plugin": "^0.2.5",
@@ -103,7 +103,7 @@
     "zod": "^4.4.3"
   },
   "resolutions": {
-    "@mulmoclaude/core": "^0.23.1"
+    "@mulmoclaude/core": "^0.25.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -22,9 +22,6 @@ import {
   loadCollection,
   enrichItems,
   readCustomViewHtml,
-  writeItem,
-  deleteItem,
-  readItem,
   validateRecordObject,
   generateItemId,
   resolveCreateItemId,
@@ -153,9 +150,14 @@ async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode:
   if (singleton && itemId !== singleton) {
     return { rejected: { id: itemId, problem: `collection '${collection.slug}' is a singleton; the only valid item id is '${singleton}'` } };
   }
+  // Reads and writes go through the collection's STORE (file, sqlite, …);
+  // presence of `write` IS the writability check (core 0.25 storage seam).
+  const store = storeFor(collection);
+  const { write } = store;
+  if (!write) return { rejected: { id: itemId, problem: readOnlyRefusal(collection.slug) } };
   let toWrite: CollectionItem;
   if (mode === "merge") {
-    const existing = await readItem(collection.dataDir, itemId);
+    const existing = await store.read(itemId);
     if (!existing) return { rejected: { id: itemId, problem: `item '${itemId}' not found — use "upsert" or "create" to add it` } };
     toWrite = { ...existing, ...record, [primaryKey]: itemId };
   } else {
@@ -163,7 +165,7 @@ async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode:
   }
   const problem = validateRecordObject(toWrite, itemId, collection.schema);
   if (problem) return { rejected: { id: itemId, problem } };
-  const result = await writeItem(collection.dataDir, itemId, toWrite, { slug: collection.slug, refuseOverwrite: mode === "create" });
+  const result = await write(itemId, toWrite, { refuseOverwrite: mode === "create" });
   // Handle each WriteItemResult kind; the final case (`path-escape`) is the
   // fallthrough return so `result` narrows cleanly instead of hitting a `never`
   // default (mirrors manageCollection.putOneItem in MulmoClaude).
@@ -325,7 +327,8 @@ const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => 
     res.status(404).json({ error: `collection '${req.params.slug}' not found` });
     return;
   }
-  if (!collectionWritable(collection)) {
+  const createStore = storeFor(collection).write;
+  if (!createStore) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
     return;
   }
@@ -337,7 +340,7 @@ const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => 
   const itemId = resolveCreateItemId(collection.schema, record) ?? generateItemId();
   const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
   try {
-    const result = await writeItem(collection.dataDir, itemId, recordWithId, { refuseOverwrite: true });
+    const result = await createStore(itemId, recordWithId, { refuseOverwrite: true });
     if (result.kind === "invalid-id") {
       res.status(400).json({ error: `invalid item id: ${result.itemId}` });
       return;
@@ -365,7 +368,8 @@ const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = asyn
     res.status(404).json({ error: `collection '${req.params.slug}' not found` });
     return;
   }
-  if (!collectionWritable(collection)) {
+  const updateStore = storeFor(collection).write;
+  if (!updateStore) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
     return;
   }
@@ -381,7 +385,7 @@ const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = asyn
   }
   const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
   try {
-    const result = await writeItem(collection.dataDir, req.params.itemId, recordWithId);
+    const result = await updateStore(req.params.itemId, recordWithId);
     if (result.kind === "invalid-id") {
       res.status(400).json({ error: `invalid item id: ${result.itemId}` });
       return;
@@ -408,12 +412,13 @@ const itemDeleteHandler: RequestHandler<{ slug: string; itemId: string }> = asyn
     res.status(404).json({ error: `collection '${req.params.slug}' not found` });
     return;
   }
-  if (!collectionWritable(collection)) {
+  const deleteStore = storeFor(collection).delete;
+  if (!deleteStore) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
     return;
   }
   try {
-    const result = await deleteItem(collection.dataDir, req.params.itemId);
+    const result = await deleteStore(req.params.itemId);
     if (result.kind === "invalid-id") {
       res.status(400).json({ error: `invalid item id: ${result.itemId}` });
       return;

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -26,15 +26,12 @@ import {
   type RemoteViewPageRequest,
 } from "@mulmoclaude/core/remote-view";
 import {
-  deleteItem,
   enrichItems,
   readCustomViewHtml,
   readCustomViewI18n,
-  readItem,
   safeRecordId,
-  writeItem,
+  type CollectionStore,
   type LoadedCollection,
-  collectionWritable,
   storeFor,
 } from "@mulmoclaude/core/collection/server";
 import type { CollectionCustomView, CollectionItem, CollectionSchema } from "@mulmoclaude/core/collection";
@@ -121,9 +118,7 @@ export type MutateRemoteViewResult =
   | { kind: "path-escape" };
 
 export interface MutateRemoteViewDeps {
-  readItem: typeof readItem;
-  writeItem: typeof writeItem;
-  deleteItem: typeof deleteItem;
+  storeFor: (collection: LoadedCollection) => CollectionStore;
   enrichItems: typeof enrichItems;
   resolveThumbnail: ThumbnailResolver;
 }
@@ -135,16 +130,18 @@ export const createMutateRemoteView =
     if (!view) return { kind: "view-not-found", viewId };
     if (view.target !== "mobile") return { kind: "not-mobile", viewId };
     // A dataSource collection is read-only regardless of what write surface
-    // the view declares — the collection-level rule outranks the view's.
-    if (!collectionWritable(collection)) return { kind: "read-only-collection" };
+    // the view declares — the collection-level rule outranks the view's. The
+    // store encodes it as absent write/delete methods (core 0.25 storage seam).
+    const store = deps.storeFor(collection);
+    if (!store.write || !store.delete) return { kind: "read-only-collection" };
     if (!isWritableView(view)) return { kind: "not-writable", viewId };
-    if (request.op === "delete") return deleteViaView(deps, collection, view.allowDelete === true, request.id);
-    return updateViaView(deps, collection, view, request);
+    if (request.op === "delete") return deleteViaView(store.delete, view.allowDelete === true, request.id);
+    return updateViaView(deps, store, collection, view, request);
   };
 
-async function deleteViaView(deps: MutateRemoteViewDeps, collection: LoadedCollection, allowDelete: boolean, itemId: string): Promise<MutateRemoteViewResult> {
+async function deleteViaView(remove: NonNullable<CollectionStore["delete"]>, allowDelete: boolean, itemId: string): Promise<MutateRemoteViewResult> {
   if (!allowDelete) return { kind: "delete-not-allowed" };
-  const result = await deps.deleteItem(collection.dataDir, itemId, { slug: collection.slug });
+  const result = await remove(itemId);
   if (result.kind === "invalid-id") return { kind: "invalid-id", id: result.itemId };
   if (result.kind === "path-escape") return { kind: "path-escape" };
   if (result.kind === "not-found") return { kind: "item-not-found", id: result.itemId };
@@ -164,20 +161,24 @@ function checkPatch(view: CollectionCustomView, primaryKey: string, patchKeys: s
 
 async function updateViaView(
   deps: MutateRemoteViewDeps,
+  store: CollectionStore,
   collection: LoadedCollection,
   view: CollectionCustomView,
   request: Extract<RemoteViewMutateRequest, { op: "update" }>,
 ): Promise<MutateRemoteViewResult> {
+  const { write } = store;
+  if (!write) return { kind: "read-only-collection" }; // unreachable: caller guards presence
   const { primaryKey } = collection.schema;
   const rejection = checkPatch(view, primaryKey, Object.keys(request.patch));
   if (rejection) return rejection;
-  // Classify a bad id BEFORE readItem (which returns null for unsafe/escape/
-  // missing alike) so update reports the same explicit invalid-id delete does.
+  // Classify a bad id BEFORE the store read (which returns null for unsafe/
+  // escape/missing alike) so update reports the same explicit invalid-id
+  // delete does.
   if (safeRecordId(request.id) === null) return { kind: "invalid-id", id: request.id };
-  const existing = await deps.readItem(collection.dataDir, request.id, { slug: collection.slug });
+  const existing = await store.read(request.id);
   if (!existing) return { kind: "item-not-found", id: request.id };
   const merged: CollectionItem = { ...existing, ...request.patch, [primaryKey]: request.id };
-  const result = await deps.writeItem(collection.dataDir, request.id, merged, { slug: collection.slug });
+  const result = await write(request.id, merged);
   if (result.kind === "invalid-id") return { kind: "invalid-id", id: result.itemId };
   if (result.kind === "path-escape") return { kind: "path-escape" };
   if (result.kind === "conflict") return { kind: "item-not-found", id: result.itemId }; // unreachable: refuseOverwrite is false
@@ -194,7 +195,7 @@ async function updateViaView(
   return { kind: "ok", op: "update", item: item as CollectionItem };
 }
 
-export const mutateRemoteView = createMutateRemoteView({ readItem, writeItem, deleteItem, enrichItems, resolveThumbnail });
+export const mutateRemoteView = createMutateRemoteView({ storeFor, enrichItems, resolveThumbnail });
 
 // ── Item pages (getItems) ──
 // A mobile view's record page: derive computed fields → slice/project (the same

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,18 +1730,18 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.3.tgz#933121a1720b2b68c62082048fe9df278466445e"
   integrity sha512-13oTtFLQgS7uiM/K6bxOKH7nKSs7Muhcg+PIsfl0ThyaINuu57LuktLf09XoRLDWouhUlL0gBZXDFSwuw+k6qA==
 
-"@mulmoclaude/collection-plugin@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.12.0.tgz#cf2945bb53dde4acedc565d4ab1d350461d7ce84"
-  integrity sha512-y4jeTiwV3yJ9Iiu8IaMZntoboj7utCpDiYk5/jXnJJTsf4Goe5mKydxoxHGNlDAsFFVCb4+981hgZVRT/BeAoA==
+"@mulmoclaude/collection-plugin@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.13.1.tgz#fde9099b251cd9c2981f13604e7b393c9a32c05b"
+  integrity sha512-0U5jS5gUBZ5cuuJskSyuun1z1H6HcSu746ra+mcmfW2CroUverEfMrzAByVraREndEXvJlIT8HHtiBV0tPMqCQ==
   dependencies:
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.23.0", "@mulmoclaude/core@^0.23.1":
-  version "0.23.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.23.1.tgz#49080a78374f2412f1673e5d3c85450043e5dda1"
-  integrity sha512-PDUFrRebpqp9R5GhuRgmLClh+7BC7aaI6hhHd0/8vKdgV3aljsea72c7oztkGrQmKULqWzaH8PyqyM8rPcUu5g==
+"@mulmoclaude/core@^0.23.0", "@mulmoclaude/core@^0.25.1":
+  version "0.25.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.25.1.tgz#7a8537438f3b8713f7a211517a6021c82bad627e"
+  integrity sha512-ybFVaYNZtRKxGT6PK4rZ1KMIBbe6T4dhzgPUAPqCvS5lEBchE+5lsYaBk+iCQaK3NkuYDGj8biA5AcA7HiKOng==
   dependencies:
     "@duckdb/node-api" "^1.5.4-r.1"
     fast-xml-parser "^5.10.1"


### PR DESCRIPTION
## Summary

Ratchets `@mulmoclaude/core` 0.23.1 → **0.25.1** (deps + `resolutions`; `@mulmoclaude/collection-plugin` → ^0.13.1 so one core copy resolves) and ports the record I/O to the storage seam core 0.25 introduced (receptron/mulmoclaude#2203 / #2204).

## Why

MulmoClaude can now create `storage: sqlite` collections — records live in a single SQLite db file, not per-record JSON. The raw `readItem`/`writeItem`/`deleteItem` calls these backends used write to the (phantom) `dataDir`, so a sqlite collection would have looked **empty** here and writes would have grown phantom `.json` files beside the real rows — the cross-app data-skew bug class. Routing through `storeFor(collection)` picks the right backend everywhere.

## Changes

- `server/backends/collections.ts` — item create/update/delete routes + `writeViewItem` go through the store; writability is encoded by the **presence** of `store.write` / `store.delete` (absence ⇒ the same 405 `readOnlyRefusal`). Side fix: these raw `writeItem` calls passed no `slug`, so writes from MulmoTerminal never fired live-view change events — the store auto-threads the slug, so they do now.
- `server/backends/remoteView.ts` — mutate deps are `storeFor`-shaped (`{ storeFor, enrichItems, resolveThumbnail }`), matching upstream's Stage-2 shape.
- Watchers unaffected (`configureCollectionWatchers` / `startCollectionWatchers` signatures unchanged in 0.25.1).

## Test plan

- `yarn typecheck` clean / `yarn lint` 0 errors / `yarn build` green
- **vitest 1352/1352 pass**
- `yarn why @mulmoclaude/core` → single copy @ 0.25.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)