### PR TITLE
chore(deps): @mulmoclaude/collection-plugin@^0.13.2 — shadow-DOM-safe menu dismiss

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.13.1",
+    "@mulmoclaude/collection-plugin": "^0.13.2",
     "@mulmoclaude/core": "^0.25.1",
     "@mulmoclaude/form-plugin": "^0.1.4",
     "@mulmoclaude/google-plugin": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,10 +1730,10 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.3.tgz#933121a1720b2b68c62082048fe9df278466445e"
   integrity sha512-13oTtFLQgS7uiM/K6bxOKH7nKSs7Muhcg+PIsfl0ThyaINuu57LuktLf09XoRLDWouhUlL0gBZXDFSwuw+k6qA==
 
-"@mulmoclaude/collection-plugin@^0.13.1":
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.13.1.tgz#fde9099b251cd9c2981f13604e7b393c9a32c05b"
-  integrity sha512-0U5jS5gUBZ5cuuJskSyuun1z1H6HcSu746ra+mcmfW2CroUverEfMrzAByVraREndEXvJlIT8HHtiBV0tPMqCQ==
+"@mulmoclaude/collection-plugin@^0.13.2":
+  version "0.13.2"
+  resolved "https://registry.npmjs.org/@mulmoclaude/collection-plugin/-/collection-plugin-0.13.2.tgz#0b968efc1f2d376604cd2394125968c3b2b09795"
+  integrity sha512-RWTp5xa3OPjQGu432S0WlAXRoZIChtUslSByqnkW6vihurICrqz68rnwBAgWthYa+coP3NS0zd8n2oKSjgq1hw==
   dependencies:
     vuedraggable "^4.1.0"
     zod "^4.4.3"


### PR DESCRIPTION
Follow-up to #433 — the 0.13.2 bump commit was pushed to that branch after the squash merge snapshot, so main still locks collection-plugin 0.13.1.

0.13.2 (mulmoclaude#2212) fixes the dropdown menus' outside-click dismiss for shadow-DOM hosts: `ref.contains(event.target)` is always false at document level inside PluginFrame's shadow root (the event target is retargeted to the shadow host), so the flag/boolean filter menu and the "+" add-view menu closed on mousedown before any chip's click could fire. Replaced with a `composedPath()` membership test.

Live-verified in MulmoTerminal 2026-07-19: the flag filter now narrows the table inside the shadow root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)