### PR TITLE
feat: セッションの活動状態を Firestore に publish する (#439)

### DIFF
--- a/plans/feat-439-publish-session-activity.md
+++ b/plans/feat-439-publish-session-activity.md
@@ -1,0 +1,69 @@
+# feat #439 — セッションの活動状態を Firestore に publish する
+
+Issue: #439。スマホのターミナル閲覧（#435 split 2）を、ポーリングではなく**変化したときに**
+更新できるようにするためのホスト側。対になるスマホ側は receptron/mulmoserver#74。
+
+## なぜ新しい doc が要るか
+
+調査で確認した事実:
+
+- ホストが Firestore に書くのは **presence doc とコマンド doc の2つだけ**
+- presence doc は5フィールドのみでセッション情報ゼロ。しかも `@mulmoclaude/core` 内で
+  組み立てられ、60秒ごとに `setDoc` で**全上書き**されるため外からは拡張できない
+- `pubsub.ts` はデスクトップのブラウザ向け socket.io で、Firestore には届かない。
+  `publish` しか export しておらず、サーバ側から購読することすらできない
+
+`users/{uid}/hosts/{hostId}/sessions/{sessionId}` なら既存のルール
+`users/{uid}/hosts/{document=**}` で通り、**core の変更もルール変更も不要**。
+
+## 設計
+
+### `server/backends/remoteHost/sessionActivity.ts`（新規）
+
+```
+{ rev: number, working: boolean, waiting: boolean, at: <serverTimestamp> }
+```
+
+`rev` はセッションごとに単調増加。watcher が「また変わった」と「同じ値の再配信」を
+区別できるようにするため。
+
+Firestore の IO を `SessionActivityStore` として分離し、テストでは記録用の fake を注入する。
+
+### 書き込み地点は `publishActivity`
+
+`setWorking` / `setWaiting` の両方がここに合流するので、フックは1箇所で済む。
+
+**ただし `publishActivity` の呼び出し4箇所のうち2つは活動遷移ではない** —
+AI タイトル生成（`server/index.ts:1346`）とヘッダクリア（`:1304`）は working/waiting が
+変わらないまま再 publish する。そのまま Firestore に流すと無駄な write が出るうえ、
+watcher 側が「変わっていない画面」を取りに行ってしまう。
+
+そこで publisher 側で **直近に publish した working/waiting を保持して重複排除**する。
+呼び出し側を選ぶより、publisher が常に正しく振る舞う方が将来の呼び出し追加にも強い。
+
+## 実装上の注意
+
+- **`currentFirestore()` は切断中に throw する**（`session.ts:78` の `requireHandles`）。
+  `currentUid()` は null を返すだけなので、**uid の null チェックを先に置く**ことで
+  throw を回避する。uid が非 null なら handles が存在するので firestore は throw しない
+- **fire-and-forget**。呼び出し元は Claude Code のフックを捌く同期パス上にあるので、
+  Firestore の失敗が絶対に伝播してはいけない。`.catch(onError)` で握る
+- `reap()` で `forget()` を呼び doc を消す。残すとスマホの一覧に幽霊が出る。
+  ローカルの記録は切断中でも消す（同じ id で復活したセッションが古い dedup キーを
+  引き継がないように）
+- `HOST_ID` を export する（doc パスを組むため）
+
+## テスト
+
+`test/server/backends/remoteHost/sessionActivity.spec.ts` — 記録用 store を注入して:
+遷移の書き込み / 同一スナップショットの無視 / 再変化での rev 増加 /
+セッションごとの rev / 切断中の no-op / reap での削除 / id 再利用時のリセット /
+write 失敗が呼び出し元に伝播しないこと。
+
+実サーバでも `/api/hook` に `UserPromptSubmit` と `Stop` を投げ、**未接続状態で**
+200 が返ること・例外が出ないことを確認した。
+
+## スコープ外
+
+- スマホ側の購読（receptron/mulmoserver#74）
+- 一覧ページへの working/waiting 表示。doc には乗るが、まず画面更新に絞る

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -24,7 +24,9 @@ import { onExpire } from "./onExpire.js";
 import { currentFirestore, currentStorage, currentUid, exportSession, reconnectErrorStatus, restore, signIn, signOut } from "./session.js";
 import { mountRemoteHostRoutes as mountRoutes } from "./routes.js";
 
-const HOST_ID = "mulmoterminal";
+// Exported so the session-activity publisher (#439) can address this host's docs; it
+// writes from the hook path, outside the lifecycle this module owns.
+export const HOST_ID = "mulmoterminal";
 const PREFIX = "[remote-host]";
 
 // Module-level singleton — one host runner per process. Null until initialized.

--- a/server/backends/remoteHost/sessionActivity.ts
+++ b/server/backends/remoteHost/sessionActivity.ts
@@ -66,7 +66,16 @@ export function createSessionActivityPublisher(deps: SessionActivityPublisherDep
     published.set(sessionId, key);
     const rev = (revisions.get(sessionId) ?? 0) + 1;
     revisions.set(sessionId, rev);
-    deps.store.write(uid, deps.hostId, sessionId, { ...activity, rev, at: serverTimestamp() }).catch(deps.onError);
+    deps.store.write(uid, deps.hostId, sessionId, { ...activity, rev, at: serverTimestamp() }).catch((error: unknown) => {
+      // The dedup entry is recorded optimistically, so a failed write would otherwise
+      // swallow every later publish of the SAME state and leave the phone stale until
+      // some different transition happened. Release it so the next one retries —
+      // unless a newer state has already superseded this one, which is then the
+      // truth worth keeping. `rev` deliberately still advances: a gap only tells a
+      // watcher a write was lost, which is exactly what happened.
+      if (published.get(sessionId) === key) published.delete(sessionId);
+      deps.onError(error);
+    });
   };
 
   // On teardown, so the phone's picker doesn't accumulate docs for dead sessions. The

--- a/server/backends/remoteHost/sessionActivity.ts
+++ b/server/backends/remoteHost/sessionActivity.ts
@@ -1,0 +1,84 @@
+// Publishes a session's activity to Firestore so the phone can react to it (#439).
+//
+// The phone's terminal viewer can only poll today: the host writes exactly two things
+// to Firestore — the presence doc and command docs — and neither carries per-session
+// state. The presence doc is rebuilt inside @mulmoclaude/core and fully overwritten
+// every heartbeat, so it cannot be extended from here. This adds a per-session doc
+// instead, under the path the existing `users/{uid}/hosts/{document=**}` rule already
+// covers, so no rules change and no core release are involved.
+//
+// Deliberately fire-and-forget: the caller sits on the synchronous hook path that
+// serves Claude Code's own requests, and a Firestore hiccup must never disturb it.
+import { deleteDoc, doc, serverTimestamp, setDoc, type DocumentReference, type Firestore } from "firebase/firestore";
+
+export interface SessionActivity {
+  working: boolean;
+  waiting: boolean;
+}
+
+// `rev` is monotonic per session so a watcher can distinguish "changed again" from a
+// re-delivered snapshot; `at` dates it for staleness checks.
+export interface SessionActivityDoc extends SessionActivity {
+  rev: number;
+  at: unknown;
+}
+
+// Split from the publisher so tests can record writes without a Firestore.
+export interface SessionActivityStore {
+  write: (uid: string, hostId: string, sessionId: string, payload: SessionActivityDoc) => Promise<void>;
+  remove: (uid: string, hostId: string, sessionId: string) => Promise<void>;
+}
+
+// Segments spelled out rather than spread: doc()'s overloads can't tell a string[]
+// from a (reference, ...segments) call, and resolve to the wrong one.
+const sessionDoc = (firestore: Firestore, uid: string, hostId: string, sessionId: string): DocumentReference =>
+  doc(firestore, "users", uid, "hosts", hostId, "sessions", sessionId);
+
+export const firestoreSessionActivityStore = (firestore: () => Firestore): SessionActivityStore => ({
+  write: (uid, hostId, sessionId, payload) => setDoc(sessionDoc(firestore(), uid, hostId, sessionId), payload),
+  remove: (uid, hostId, sessionId) => deleteDoc(sessionDoc(firestore(), uid, hostId, sessionId)),
+});
+
+export interface SessionActivityPublisherDeps {
+  // Null while the remote host is disconnected. A non-null uid implies the session
+  // handles exist, which is what makes the store's currentFirestore() safe to call —
+  // that accessor THROWS when disconnected, unlike this one.
+  uid: () => string | null;
+  hostId: string;
+  store: SessionActivityStore;
+  onError: (error: unknown) => void;
+}
+
+export function createSessionActivityPublisher(deps: SessionActivityPublisherDeps) {
+  const revisions = new Map<string, number>();
+  const published = new Map<string, string>();
+  const stateKey = ({ working, waiting }: SessionActivity): string => `${working}:${waiting}`;
+
+  // Not every caller of the host's publishActivity is a state transition — generating
+  // an AI title or clearing the header republishes an unchanged working/waiting pair.
+  // Those must not bill a write, nor wake a watching phone into refetching a screen
+  // that did not change.
+  const publish = (sessionId: string, activity: SessionActivity): void => {
+    const uid = deps.uid();
+    if (!uid) return;
+    const key = stateKey(activity);
+    if (published.get(sessionId) === key) return;
+    published.set(sessionId, key);
+    const rev = (revisions.get(sessionId) ?? 0) + 1;
+    revisions.set(sessionId, rev);
+    deps.store.write(uid, deps.hostId, sessionId, { ...activity, rev, at: serverTimestamp() }).catch(deps.onError);
+  };
+
+  // On teardown, so the phone's picker doesn't accumulate docs for dead sessions. The
+  // local bookkeeping is dropped even when disconnected — a session that comes back
+  // under the same id starts from a clean slate rather than inheriting a stale key.
+  const forget = (sessionId: string): void => {
+    revisions.delete(sessionId);
+    published.delete(sessionId);
+    const uid = deps.uid();
+    if (!uid) return;
+    deps.store.remove(uid, deps.hostId, sessionId).catch(deps.onError);
+  };
+
+  return { publish, forget };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -107,7 +107,9 @@ import { manageCollectionHandler } from "./infra/collection-tool.js";
 import { mountWikiRoutes } from "./backends/wiki.js";
 import { initAccountingBackend, mountAccountingRoutes } from "./backends/accounting.js";
 import { initFeedsBackend, mountFeedsRoutes } from "./backends/feeds.js";
-import { initRemoteHostBackend, mountRemoteHostRoutes } from "./backends/remoteHost/index.js";
+import { HOST_ID as REMOTE_HOST_ID, initRemoteHostBackend, mountRemoteHostRoutes } from "./backends/remoteHost/index.js";
+import { createSessionActivityPublisher, firestoreSessionActivityStore } from "./backends/remoteHost/sessionActivity.js";
+import { currentFirestore, currentUid } from "./backends/remoteHost/session.js";
 import { feedRefreshTaskDef, type AgentWorkerRunner } from "@mulmoclaude/core/feeds/server";
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { installConfigSkill } from "./infra/install-config-skill.js";
@@ -696,6 +698,7 @@ function reap(id: string) {
   lastPrompts.delete(id); // don't leak prompt text for torn-down sessions
   lastResponses.delete(id); // ditto, and keep this map from growing across closed sessions
   forgetTitle(id);
+  sessionActivityPublisher.forget(id); // drop the phone's copy so its picker has no ghosts
   titleInFlight.delete(id);
   lastTitledUserTurns.delete(id); // teardown only — kept across /clear as the re-title baseline
   lastTitleAttemptMs.delete(id);
@@ -721,12 +724,23 @@ function reap(id: string) {
   pubsub?.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed" });
 }
 
+// Mirrors session activity into Firestore so the phone's terminal viewer can refresh
+// on a real transition instead of polling (#439). Deduped and fire-and-forget inside;
+// a no-op while the remote host is disconnected.
+const sessionActivityPublisher = createSessionActivityPublisher({
+  uid: currentUid,
+  hostId: REMOTE_HOST_ID,
+  store: firestoreSessionActivityStore(currentFirestore),
+  onError: (err) => console.warn("[remote-host] session activity publish failed:", err),
+});
+
 // Publish a session's current activity (working + waiting) to subscribers.
 function publishActivity(id: string) {
   const a = activity.get(id) || {};
   const cwd = ptys.get(id)?.cwd ?? null;
   // A turn just ended (waiting) → capture the reply's tail for the roster.
   if (a.waiting && cwd) refreshLastResponse(id, cwd);
+  sessionActivityPublisher.publish(id, { working: a.working ?? false, waiting: a.waiting ?? false });
   pubsub?.publish(SESSIONS_CHANNEL, {
     id,
     // The session's working dir, so the attention-sound player can pick up that

--- a/test/server/backends/remoteHost/sessionActivity.spec.ts
+++ b/test/server/backends/remoteHost/sessionActivity.spec.ts
@@ -106,4 +106,46 @@ describe("createSessionActivityPublisher", () => {
     expect(() => publisher(failing, () => UID, onError).publish("s1", { working: true, waiting: false })).not.toThrow();
     await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
   });
+
+  // Dedup is recorded optimistically, so without releasing it on failure a lost write
+  // would swallow every later publish of the SAME state and strand the phone until
+  // some different transition happened.
+  it("retries the same state after a failed write", async () => {
+    const onError = vi.fn();
+    const attempts: number[] = [];
+    const flaky: SessionActivityStore = {
+      write: async (_uid, _hostId, _sessionId, payload) => {
+        attempts.push(payload.rev);
+        if (attempts.length === 1) throw new Error("offline");
+      },
+      remove: async () => undefined,
+    };
+    const activity = publisher(flaky, () => UID, onError);
+    activity.publish("s1", { working: true, waiting: false });
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    activity.publish("s1", { working: true, waiting: false });
+    expect(attempts).toEqual([1, 2]);
+  });
+
+  // Rolling back blindly would resurrect a state the session has already left.
+  it("does not resurrect a state a newer publish superseded", async () => {
+    const onError = vi.fn();
+    const written: Array<{ working: boolean; waiting: boolean }> = [];
+    const failFirst: SessionActivityStore = {
+      write: async (_uid, _hostId, _sessionId, payload) => {
+        written.push({ working: payload.working, waiting: payload.waiting });
+        if (written.length === 1) throw new Error("offline");
+      },
+      remove: async () => undefined,
+    };
+    const activity = publisher(failFirst, () => UID, onError);
+    activity.publish("s1", { working: true, waiting: false });
+    activity.publish("s1", { working: false, waiting: true });
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+    activity.publish("s1", { working: false, waiting: true });
+    expect(written).toEqual([
+      { working: true, waiting: false },
+      { working: false, waiting: true },
+    ]);
+  });
 });

--- a/test/server/backends/remoteHost/sessionActivity.spec.ts
+++ b/test/server/backends/remoteHost/sessionActivity.spec.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+
+import { createSessionActivityPublisher, type SessionActivityStore } from "../../../../server/backends/remoteHost/sessionActivity.js";
+
+const UID = "user-1";
+const HOST = "mulmoterminal";
+
+const recorder = () => {
+  const writes: Array<{ sessionId: string; rev: number; working: boolean; waiting: boolean }> = [];
+  const removes: string[] = [];
+  const store: SessionActivityStore = {
+    write: async (_uid, _hostId, sessionId, payload) => {
+      writes.push({ sessionId, rev: payload.rev, working: payload.working, waiting: payload.waiting });
+    },
+    remove: async (_uid, _hostId, sessionId) => {
+      removes.push(sessionId);
+    },
+  };
+  return { writes, removes, store };
+};
+
+const publisher = (store: SessionActivityStore, uid: () => string | null = () => UID, onError = vi.fn()) =>
+  createSessionActivityPublisher({ uid, hostId: HOST, store, onError });
+
+describe("createSessionActivityPublisher", () => {
+  it("writes a transition with the state that changed", () => {
+    const { writes, store } = recorder();
+    publisher(store).publish("s1", { working: true, waiting: false });
+    expect(writes).toEqual([{ sessionId: "s1", rev: 1, working: true, waiting: false }]);
+  });
+
+  // The host's publishActivity is not only called on transitions — generating an AI
+  // title or clearing the header republishes an unchanged pair. Those must not bill a
+  // write, nor wake a watching phone into refetching an unchanged screen.
+  it("ignores a republished snapshot that did not change", () => {
+    const { writes, store } = recorder();
+    const activity = publisher(store);
+    activity.publish("s1", { working: true, waiting: false });
+    activity.publish("s1", { working: true, waiting: false });
+    activity.publish("s1", { working: true, waiting: false });
+    expect(writes).toHaveLength(1);
+  });
+
+  it("writes again once the state really changes", () => {
+    const { writes, store } = recorder();
+    const activity = publisher(store);
+    activity.publish("s1", { working: true, waiting: false });
+    activity.publish("s1", { working: false, waiting: true });
+    expect(writes.map((entry) => entry.rev)).toEqual([1, 2]);
+    expect(writes.at(-1)).toMatchObject({ working: false, waiting: true });
+  });
+
+  it("counts revisions per session, not globally", () => {
+    const { writes, store } = recorder();
+    const activity = publisher(store);
+    activity.publish("s1", { working: true, waiting: false });
+    activity.publish("s2", { working: true, waiting: false });
+    expect(writes.map((entry) => [entry.sessionId, entry.rev])).toEqual([
+      ["s1", 1],
+      ["s2", 1],
+    ]);
+  });
+
+  // currentUid() is null while the remote host is disconnected, and it is the guard
+  // that makes the store's currentFirestore() safe — that accessor throws when there
+  // is no session.
+  it("does nothing while the remote host is disconnected", () => {
+    const { writes, removes, store } = recorder();
+    const activity = publisher(store, () => null);
+    activity.publish("s1", { working: true, waiting: false });
+    activity.forget("s1");
+    expect(writes).toEqual([]);
+    expect(removes).toEqual([]);
+  });
+
+  it("removes the doc when a session is reaped", () => {
+    const { removes, store } = recorder();
+    const activity = publisher(store);
+    activity.publish("s1", { working: true, waiting: false });
+    activity.forget("s1");
+    expect(removes).toEqual(["s1"]);
+  });
+
+  // A reused id must not inherit the previous session's dedup key, or its first real
+  // state would be swallowed as "unchanged".
+  it("starts a reused session id from a clean slate", () => {
+    const { writes, store } = recorder();
+    const activity = publisher(store);
+    activity.publish("s1", { working: true, waiting: false });
+    activity.forget("s1");
+    activity.publish("s1", { working: true, waiting: false });
+    expect(writes).toHaveLength(2);
+    expect(writes.at(-1)?.rev).toBe(1);
+  });
+
+  // The caller sits on the synchronous hook path serving Claude Code's own requests.
+  it("reports a failed write without throwing at the caller", async () => {
+    const onError = vi.fn();
+    const failing: SessionActivityStore = {
+      write: async () => {
+        throw new Error("offline");
+      },
+      remove: async () => undefined,
+    };
+    expect(() => publisher(failing, () => UID, onError).publish("s1", { working: true, waiting: false })).not.toThrow();
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledOnce());
+  });
+});


### PR DESCRIPTION
## Summary

セッションの活動状態を Firestore に publish し、スマホがポーリングではなく**変化したときに**
画面を更新できるようにする（#439）。対になるスマホ側は receptron/mulmoserver#74。

## Items to Confirm / Review

1. **新しい doc を足す判断。** presence doc への相乗りも検討したが、`@mulmoclaude/core` 内で
   組み立てられ60秒ごとに `setDoc` で全上書きされるため、外からフィールドを足しても消える。
   core のリリースが必要になるうえ、ホスト単位の doc なので全セッションの変化が全端末を叩く。
   新 doc なら既存ルール `users/{uid}/hosts/{document=**}` で通り、**core もルールも変更不要**
2. **`publishActivity` でフックし、publisher 側で重複排除した。** 呼び出し4箇所のうち
   AI タイトル生成（`:1346`）とヘッダクリア（`:1304`）は working/waiting が変わらないまま
   再 publish する。呼び出し側を選り分けるより publisher が常に正しく振る舞う方が、
   将来の呼び出し追加に強いと判断した
3. **`rev` の意味づけ。** 単調増加のカウンタで、watcher が「また変わった」と「同じ値の再配信」を
   区別するためのもの。`at` だけでも近いことはできるが、serverTimestamp は書き込み時点で
   確定しないため watcher 側の比較には使いにくい

## 実装

### `server/backends/remoteHost/sessionActivity.ts`（新規）

```
users/{uid}/hosts/{hostId}/sessions/{sessionId}
{ rev, working, waiting, at }
```

Firestore の IO を `SessionActivityStore` として分離。テストは記録用の fake を注入する。

### 落とし穴を2つ回避している

- **`currentFirestore()` は切断中に throw する**（`session.ts:78`）。`currentUid()` は null を
  返すだけなので、uid の null チェックを先に置いて throw を避けている。uid が非 null なら
  handles が存在するので firestore は throw しない
- **呼び出し元は Claude Code のフックを捌く同期パス上**にある。Firestore の失敗が伝播すると
  `/api/hook` が壊れるので fire-and-forget（`.catch(onError)`）

`reap()` で doc を消す。ローカルの記録は切断中でも消しており、同じ id で復活したセッションが
古い dedup キーを引き継いで初回状態を握り潰さないようにしている。

## コスト

| | 1セッション・1時間 |
|---|---|
| 5秒ポーリング（不採用） | 2,160 writes + 3,600 reads |
| 本方式・活発なセッション | 約100 writes + 140 reads |
| 本方式・アイドル | ほぼ 0 |

## 動作確認

- `yarn format` / `lint`（エラー0） / `typecheck` / `typecheck:server` / `build` /
  `test`（1401 passed、うち本 PR で8件追加）
- **実サーバを起動して確認済み**: 未接続状態で `/api/hook` に `UserPromptSubmit` と `Stop` を
  投げ、どちらも 200 を返し例外が出ないこと。`currentFirestore()` の throw を踏んでいれば
  ここで 500 になる
- **Firestore への実書き込みは未確認。** リモートホストに接続した状態での往復は、
  スマホ側（receptron/mulmoserver#74）とあわせて確認したい

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)
