### PR TITLE
feat(remote-host): sendTerminalInput — type a line into a live session (#445)

### DIFF
--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -26,7 +26,7 @@ import {
   remoteViewItemsFailureMessage,
 } from "../remoteView.js";
 import type { Attachment } from "./ingestAttachments.js";
-import { sendTerminalInput } from "./terminalInput.js";
+import { createTerminalInputSender } from "./terminalInput.js";
 import type { TerminalSessionSummary } from "./terminalScreen.js";
 
 export interface RemoteHostHandlerDeps {
@@ -139,25 +139,29 @@ const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (par
 // command-doc ceiling.
 type TerminalScreenDeps = Pick<RemoteHostHandlerDeps, "listTerminalSessions" | "captureTerminalScreen" | "writeToSession">;
 
-const terminalScreenHandlers = ({ listTerminalSessions, captureTerminalScreen, writeToSession }: TerminalScreenDeps): CommandHandlers => ({
-  listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
+const terminalScreenHandlers = ({ listTerminalSessions, captureTerminalScreen, writeToSession }: TerminalScreenDeps): CommandHandlers => {
+  // One sender per host, so its per-session ordering actually spans every command.
+  const sendInput = createTerminalInputSender({ writeToSession });
+  return {
+    listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
 
-  getTerminalScreen: async (params: JsonObject) => {
-    const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
-    if (!sessionId) throw new Error("sessionId is required");
-    return { screen: await captureTerminalScreen(sessionId) };
-  },
+    getTerminalScreen: async (params: JsonObject) => {
+      const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
+      if (!sessionId) throw new Error("sessionId is required");
+      return { screen: await captureTerminalScreen(sessionId) };
+    },
 
-  // Type a line into the session and press Enter, as if the user were at the
-  // keyboard. The phone sends only text; the framing, sanitizing and Enter timing
-  // are terminalInput.ts's job.
-  sendTerminalInput: async (params: JsonObject) => {
-    const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
-    if (!sessionId) throw new Error("sessionId is required");
-    const text = typeof params.text === "string" ? params.text : "";
-    return sendTerminalInput({ writeToSession }, sessionId, text) as unknown as JsonObject;
-  },
-});
+    // Type a line into the session and press Enter, as if the user were at the
+    // keyboard. The phone sends only text; the framing, sanitizing and Enter timing
+    // are terminalInput.ts's job.
+    sendTerminalInput: async (params: JsonObject) => {
+      const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
+      if (!sessionId) throw new Error("sessionId is required");
+      const text = typeof params.text === "string" ? params.text : "";
+      return (await sendInput(sessionId, text)) as unknown as JsonObject;
+    },
+  };
+};
 
 export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHandlers {
   const { workspace, spawnChat, ingest } = deps;

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -26,6 +26,7 @@ import {
   remoteViewItemsFailureMessage,
 } from "../remoteView.js";
 import type { Attachment } from "./ingestAttachments.js";
+import { sendTerminalInput } from "./terminalInput.js";
 import type { TerminalSessionSummary } from "./terminalScreen.js";
 
 export interface RemoteHostHandlerDeps {
@@ -39,6 +40,10 @@ export interface RemoteHostHandlerDeps {
   // current screen. Wired in server/index.ts, where the PTY table lives.
   listTerminalSessions: () => Promise<TerminalSessionSummary[]>;
   captureTerminalScreen: (sessionId: string) => Promise<string>;
+  // Type into one session's live PTY (#445). Returns false when no PTY is attached
+  // in this process — a tmux session that outlived a restart stays viewable but not
+  // writable from here.
+  writeToSession: (sessionId: string, chunk: string) => boolean;
 }
 
 // Parse the optional `attachments` param ([{ storage_id }]) into storage ids. A
@@ -128,18 +133,29 @@ const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (par
   return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
 };
 
-// The phone's remote terminal view (#435), read-only: pick a session, then read its
-// screen. Screens are bounded by the terminal's own geometry (rows x cols), so unlike
-// collections they need no paging to stay under the 1 MiB command-doc ceiling.
-type TerminalScreenDeps = Pick<RemoteHostHandlerDeps, "listTerminalSessions" | "captureTerminalScreen">;
+// The phone's remote terminal view (#435): pick a session, read its screen, and —
+// since #445 — type into it. Screens are bounded by the terminal's own geometry
+// (rows x cols), so unlike collections they need no paging to stay under the 1 MiB
+// command-doc ceiling.
+type TerminalScreenDeps = Pick<RemoteHostHandlerDeps, "listTerminalSessions" | "captureTerminalScreen" | "writeToSession">;
 
-const terminalScreenHandlers = ({ listTerminalSessions, captureTerminalScreen }: TerminalScreenDeps): CommandHandlers => ({
+const terminalScreenHandlers = ({ listTerminalSessions, captureTerminalScreen, writeToSession }: TerminalScreenDeps): CommandHandlers => ({
   listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
 
   getTerminalScreen: async (params: JsonObject) => {
     const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
     if (!sessionId) throw new Error("sessionId is required");
     return { screen: await captureTerminalScreen(sessionId) };
+  },
+
+  // Type a line into the session and press Enter, as if the user were at the
+  // keyboard. The phone sends only text; the framing, sanitizing and Enter timing
+  // are terminalInput.ts's job.
+  sendTerminalInput: async (params: JsonObject) => {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
+    if (!sessionId) throw new Error("sessionId is required");
+    const text = typeof params.text === "string" ? params.text : "";
+    return sendTerminalInput({ writeToSession }, sessionId, text) as unknown as JsonObject;
   },
 });
 

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -37,6 +37,8 @@ export interface RemoteHostBackendDeps {
   spawnChat: (message: string) => { chatId: string };
   listTerminalSessions: () => Promise<TerminalSessionSummary[]>;
   captureTerminalScreen: (sessionId: string) => Promise<string>;
+  // Type into a session's live PTY (#445); false when none is attached here.
+  writeToSession: (sessionId: string, chunk: string) => boolean;
 }
 
 export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
@@ -60,6 +62,7 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
       ingest,
       listTerminalSessions: deps.listTerminalSessions,
       captureTerminalScreen: deps.captureTerminalScreen,
+      writeToSession: deps.writeToSession,
     }),
     log: {
       info: (msg) => console.log(PREFIX, msg),

--- a/server/backends/remoteHost/terminalInput.spec.ts
+++ b/server/backends/remoteHost/terminalInput.spec.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { PASTE_END, PASTE_START, sanitizeTerminalInput, sendTerminalInput } from "./terminalInput.js";
+
+// Collects what would have reached the PTY, and runs the delayed Enter on demand
+// so the tests never wait on real time.
+// ESC and 8-bit CSI are the only two introducers that could turn stripped text back
+// into a control sequence, so "no introducer survived" is the property under test.
+const hasSequenceIntroducer = (text: string): boolean => text.includes("\u001B") || text.includes("\u009B");
+
+const recorder = (writable = true) => {
+  const chunks: string[] = [];
+  let submit: (() => void) | null = null;
+  return {
+    chunks,
+    flushSubmit: () => submit?.(),
+    deps: {
+      writeToSession: (_sessionId: string, chunk: string) => {
+        if (!writable) return false;
+        chunks.push(chunk);
+        return true;
+      },
+      scheduleSubmit: (fn: () => void) => {
+        submit = fn;
+      },
+    },
+  };
+};
+
+describe("sanitizeTerminalInput", () => {
+  it("keeps ordinary text", () => {
+    expect(sanitizeTerminalInput("git status")).toBe("git status");
+  });
+
+  it("collapses whitespace and trims", () => {
+    expect(sanitizeTerminalInput("  ls   -la \n")).toBe("ls -la");
+  });
+
+  // The text comes from a phone, so it is untrusted. What matters is not that the
+  // characters "[201~" disappear but that no ESC (or 8-bit CSI) survives to turn
+  // them back into a sequence: without the introducer they are literal text, and the
+  // paste cannot be terminated early.
+  it("defuses an embedded bracketed-paste terminator", () => {
+    const escaped = sanitizeTerminalInput(`ls${PASTE_END}rm -rf /`);
+    expect(escaped).not.toContain(PASTE_END);
+    expect(hasSequenceIntroducer(escaped)).toBe(false);
+  });
+
+  // 8-bit CSI is a single C1 byte, so stripping ESC alone would not be enough.
+  it("strips an 8-bit CSI terminator too", () => {
+    expect(hasSequenceIntroducer(sanitizeTerminalInput("ls\u009B201~whoami"))).toBe(false);
+  });
+
+  it("strips ESC, Ctrl-C and newlines", () => {
+    expect(sanitizeTerminalInput("a\x1bb\x03c\r\nd")).toBe("a b c d");
+  });
+
+  it("is empty when nothing printable survives", () => {
+    expect(sanitizeTerminalInput("\x03\x1b\r\n")).toBe("");
+  });
+});
+
+describe("sendTerminalInput", () => {
+  it("pastes the text, then presses Enter as a separate write", () => {
+    const { chunks, flushSubmit, deps } = recorder();
+    expect(sendTerminalInput(deps, "s1", "git status")).toEqual({ sent: true });
+    // The paste lands immediately; the CR must NOT ride along with it, or Claude's
+    // TUI drops it while still committing the paste.
+    expect(chunks).toEqual([`${PASTE_START}git status${PASTE_END}`]);
+    flushSubmit();
+    expect(chunks).toEqual([`${PASTE_START}git status${PASTE_END}`, "\r"]);
+  });
+
+  // The property that matters: exactly one paste, closed exactly once at the end.
+  it("cannot be made to close the paste early", () => {
+    const { chunks, deps } = recorder();
+    sendTerminalInput(deps, "s1", `ls${PASTE_END}whoami`);
+    const paste = chunks[0];
+    expect(paste.startsWith(PASTE_START)).toBe(true);
+    expect(paste.endsWith(PASTE_END)).toBe(true);
+    expect(paste.split(PASTE_END)).toHaveLength(2);
+    expect(hasSequenceIntroducer(paste.slice(PASTE_START.length, -PASTE_END.length))).toBe(false);
+  });
+
+  it("refuses text that is empty once sanitized", () => {
+    const { chunks, deps } = recorder();
+    expect(() => sendTerminalInput(deps, "s1", "\x03\r\n")).toThrow(/text is required/);
+    expect(chunks).toEqual([]);
+  });
+
+  // A tmux session that outlived a restart is viewable via capture-pane but has no
+  // PTY here to type into. Saying so beats a silent no-op the phone reads as success.
+  it("reports a session with no live terminal", () => {
+    const { deps } = recorder(false);
+    expect(() => sendTerminalInput(deps, "ghost", "ls")).toThrow(/no live terminal/);
+  });
+
+  it("does not throw when the session ends before the Enter", () => {
+    let submit: (() => void) | null = null;
+    let alive = true;
+    let writes = 0;
+    const deps = {
+      writeToSession: () => {
+        writes += 1;
+        return alive;
+      },
+      scheduleSubmit: (fn: () => void) => {
+        submit = fn;
+      },
+    };
+    sendTerminalInput(deps, "s1", "ls");
+    alive = false;
+    expect(() => submit?.()).not.toThrow();
+    // The Enter was still attempted — it just found the pty gone.
+    expect(writes).toBe(2);
+  });
+});

--- a/server/backends/remoteHost/terminalInput.spec.ts
+++ b/server/backends/remoteHost/terminalInput.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { PASTE_END, PASTE_START, sanitizeTerminalInput, sendTerminalInput } from "./terminalInput.js";
+import { PASTE_END, PASTE_START, createTerminalInputSender, sanitizeTerminalInput } from "./terminalInput.js";
 
 // Collects what would have reached the PTY, and runs the delayed Enter on demand
 // so the tests never wait on real time.
@@ -9,23 +9,25 @@ import { PASTE_END, PASTE_START, sanitizeTerminalInput, sendTerminalInput } from
 // into a control sequence, so "no introducer survived" is the property under test.
 const hasSequenceIntroducer = (text: string): boolean => text.includes("\u001B") || text.includes("\u009B");
 
+// Chaining moved the first write behind a microtask, so tests must let the queue
+// run before asserting on what reached the PTY.
+const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
 const recorder = (writable = true) => {
   const chunks: string[] = [];
-  let submit: (() => void) | null = null;
-  return {
-    chunks,
-    flushSubmit: () => submit?.(),
-    deps: {
-      writeToSession: (_sessionId: string, chunk: string) => {
-        if (!writable) return false;
-        chunks.push(chunk);
-        return true;
-      },
-      scheduleSubmit: (fn: () => void) => {
-        submit = fn;
-      },
+  const submits: Array<() => void> = [];
+  const deps = {
+    writeToSession: (_sessionId: string, chunk: string) => {
+      if (!writable) return false;
+      chunks.push(chunk);
+      return true;
+    },
+    // Queue the Enters instead of timing them, so a test decides when each lands.
+    scheduleSubmit: (fn: () => void) => {
+      submits.push(fn);
     },
   };
+  return { chunks, submits, flushSubmit: () => submits.shift()?.(), send: createTerminalInputSender(deps) };
 };
 
 describe("sanitizeTerminalInput", () => {
@@ -62,20 +64,23 @@ describe("sanitizeTerminalInput", () => {
 });
 
 describe("sendTerminalInput", () => {
-  it("pastes the text, then presses Enter as a separate write", () => {
-    const { chunks, flushSubmit, deps } = recorder();
-    expect(sendTerminalInput(deps, "s1", "git status")).toEqual({ sent: true });
+  it("pastes the text, then presses Enter as a separate write", async () => {
+    const { chunks, flushSubmit, send } = recorder();
+    const sent = send("s1", "git status");
+    await tick();
     // The paste lands immediately; the CR must NOT ride along with it, or Claude's
     // TUI drops it while still committing the paste.
     expect(chunks).toEqual([`${PASTE_START}git status${PASTE_END}`]);
     flushSubmit();
+    await expect(sent).resolves.toEqual({ sent: true });
     expect(chunks).toEqual([`${PASTE_START}git status${PASTE_END}`, "\r"]);
   });
 
   // The property that matters: exactly one paste, closed exactly once at the end.
-  it("cannot be made to close the paste early", () => {
-    const { chunks, deps } = recorder();
-    sendTerminalInput(deps, "s1", `ls${PASTE_END}whoami`);
+  it("cannot be made to close the paste early", async () => {
+    const { chunks, send } = recorder();
+    void send("s1", `ls${PASTE_END}whoami`);
+    await tick();
     const paste = chunks[0];
     expect(paste.startsWith(PASTE_START)).toBe(true);
     expect(paste.endsWith(PASTE_END)).toBe(true);
@@ -83,24 +88,24 @@ describe("sendTerminalInput", () => {
     expect(hasSequenceIntroducer(paste.slice(PASTE_START.length, -PASTE_END.length))).toBe(false);
   });
 
-  it("refuses text that is empty once sanitized", () => {
-    const { chunks, deps } = recorder();
-    expect(() => sendTerminalInput(deps, "s1", "\x03\r\n")).toThrow(/text is required/);
+  it("refuses text that is empty once sanitized", async () => {
+    const { chunks, send } = recorder();
+    await expect(send("s1", "\x03\r\n")).rejects.toThrow(/text is required/);
     expect(chunks).toEqual([]);
   });
 
   // A tmux session that outlived a restart is viewable via capture-pane but has no
   // PTY here to type into. Saying so beats a silent no-op the phone reads as success.
-  it("reports a session with no live terminal", () => {
-    const { deps } = recorder(false);
-    expect(() => sendTerminalInput(deps, "ghost", "ls")).toThrow(/no live terminal/);
+  it("reports a session with no live terminal", async () => {
+    const { send } = recorder(false);
+    await expect(send("ghost", "ls")).rejects.toThrow(/no live terminal/);
   });
 
-  it("does not throw when the session ends before the Enter", () => {
+  it("does not throw when the session ends before the Enter", async () => {
     let submit: (() => void) | null = null;
     let alive = true;
     let writes = 0;
-    const deps = {
+    const send = createTerminalInputSender({
       writeToSession: () => {
         writes += 1;
         return alive;
@@ -108,11 +113,56 @@ describe("sendTerminalInput", () => {
       scheduleSubmit: (fn: () => void) => {
         submit = fn;
       },
-    };
-    sendTerminalInput(deps, "s1", "ls");
+    });
+    const sent = send("s1", "ls");
+    await tick();
     alive = false;
     expect(() => submit?.()).not.toThrow();
+    await expect(sent).resolves.toEqual({ sent: true });
     // The Enter was still attempted — it just found the pty gone.
     expect(writes).toBe(2);
+  });
+
+  // Two sends that overlap would otherwise interleave as paste-A, paste-B, CR, CR:
+  // the terminal runs the two commands merged onto one line, then submits an empty
+  // one. Each session's sends are chained so the next paste waits for the previous
+  // Enter.
+  it("serializes overlapping sends on one session", async () => {
+    const { chunks, flushSubmit, send } = recorder();
+    const first = send("s1", "one");
+    const second = send("s1", "two");
+    await tick();
+    // The second paste must not have gone out while the first is unsubmitted.
+    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`]);
+    flushSubmit();
+    await first;
+    await tick();
+    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`, "\r", `${PASTE_START}two${PASTE_END}`]);
+    flushSubmit();
+    await second;
+    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`, "\r", `${PASTE_START}two${PASTE_END}`, "\r"]);
+  });
+
+  it("does not make one session wait on another", async () => {
+    const { chunks, flushSubmit, send } = recorder();
+    const a = send("s1", "one");
+    const b = send("s2", "two");
+    await tick();
+    // Different sessions are independent, so both pastes go out immediately.
+    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`, `${PASTE_START}two${PASTE_END}`]);
+    flushSubmit();
+    flushSubmit();
+    await Promise.all([a, b]);
+  });
+
+  // A rejected send must not wedge the session's chain for every later one.
+  it("keeps the chain alive after a failed send", async () => {
+    const { chunks, flushSubmit, send } = recorder();
+    await expect(send("s1", "\x03")).rejects.toThrow(/text is required/);
+    const after = send("s1", "ls");
+    await tick();
+    flushSubmit();
+    await expect(after).resolves.toEqual({ sent: true });
+    expect(chunks).toEqual([`${PASTE_START}ls${PASTE_END}`, "\r"]);
   });
 });

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -1,0 +1,59 @@
+// Typing into a live session from the phone (#445). The wire side is one string;
+// everything that makes it land correctly in a TUI lives here so it can be tested
+// without a PTY.
+//
+// Three things matter, and all three are learned behaviour from the spawn paths in
+// server/index.ts:
+//
+//   1. Sanitize first. The text arrives from a phone, so it is untrusted: an
+//      embedded bracketed-paste terminator (\e[201~) or a bare ESC/Ctrl-C would
+//      break out of the paste and run as control input on the host's terminal.
+//   2. Wrap in bracketed paste, so a TUI treats it as pasted text rather than
+//      keystrokes it might interpret one by one.
+//   3. Send the submitting Enter as a SEPARATE write a beat later — Claude's TUI
+//      drops a CR that arrives while it is still committing the paste.
+
+// Strip ALL control bytes (C0/C1 — ESC, Ctrl-C, CR/LF, and an embedded
+// bracketed-paste terminator). Only printable text survives, whitespace collapsed.
+// eslint-disable-next-line no-control-regex -- intentional: match terminal control bytes (C0/C1) to strip them
+const CONTROL_BYTES_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
+
+export const sanitizeTerminalInput = (text: string): string => text.replace(CONTROL_BYTES_RE, " ").replace(/\s+/g, " ").trim();
+
+export const PASTE_START = "\x1b[200~";
+export const PASTE_END = "\x1b[201~";
+
+// Matches DRAFT_SUBMIT_MS in server/index.ts: the same TUI, the same reason.
+export const SUBMIT_DELAY_MS = 150;
+
+export interface TerminalInputDeps {
+  // Write a chunk to the session's live PTY. False when no PTY is attached in this
+  // process — a tmux session that outlived a restart is viewable (capture-pane) but
+  // not writable from here.
+  writeToSession: (sessionId: string, chunk: string) => boolean;
+  // Injected so tests don't wait on real time.
+  scheduleSubmit?: (submit: () => void) => void;
+}
+
+const defaultSchedule = (submit: () => void): void => {
+  setTimeout(submit, SUBMIT_DELAY_MS);
+};
+
+// Type one line into a session and press Enter. Throws when the text is empty
+// after sanitizing, or when the session has no live PTY to write to — the phone
+// surfaces the message, which beats a silent no-op it would read as success.
+export const sendTerminalInput = (deps: TerminalInputDeps, sessionId: string, text: string): { sent: boolean } => {
+  const safe = sanitizeTerminalInput(text);
+  if (!safe) {
+    throw new Error("text is required");
+  }
+  if (!deps.writeToSession(sessionId, `${PASTE_START}${safe}${PASTE_END}`)) {
+    throw new Error(`session ${sessionId} has no live terminal on this host`);
+  }
+  // Best-effort: the session can end between the paste and the Enter, and there is
+  // nothing to report by then — the paste already landed.
+  (deps.scheduleSubmit ?? defaultSchedule)(() => {
+    deps.writeToSession(sessionId, "\r");
+  });
+  return { sent: true };
+};

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -39,21 +39,49 @@ const defaultSchedule = (submit: () => void): void => {
   setTimeout(submit, SUBMIT_DELAY_MS);
 };
 
-// Type one line into a session and press Enter. Throws when the text is empty
-// after sanitizing, or when the session has no live PTY to write to — the phone
-// surfaces the message, which beats a silent no-op it would read as success.
-export const sendTerminalInput = (deps: TerminalInputDeps, sessionId: string, text: string): { sent: boolean } => {
-  const safe = sanitizeTerminalInput(text);
-  if (!safe) {
-    throw new Error("text is required");
-  }
+// Paste, then press Enter a beat later, resolving once the Enter has gone out.
+const typeAndSubmit = (deps: TerminalInputDeps, sessionId: string, safe: string): Promise<void> => {
   if (!deps.writeToSession(sessionId, `${PASTE_START}${safe}${PASTE_END}`)) {
-    throw new Error(`session ${sessionId} has no live terminal on this host`);
+    return Promise.reject(new Error(`session ${sessionId} has no live terminal on this host`));
   }
-  // Best-effort: the session can end between the paste and the Enter, and there is
-  // nothing to report by then — the paste already landed.
-  (deps.scheduleSubmit ?? defaultSchedule)(() => {
-    deps.writeToSession(sessionId, "\r");
+  return new Promise((resolve) => {
+    (deps.scheduleSubmit ?? defaultSchedule)(() => {
+      // Best-effort: the session can end between the paste and the Enter, and there
+      // is nothing to report by then — the paste already landed.
+      deps.writeToSession(sessionId, "\r");
+      resolve();
+    });
   });
-  return { sent: true };
+};
+
+// Types lines into sessions, one at a time per session.
+//
+// The Enter is deliberately a separate, delayed write, which means two sends that
+// overlap would interleave as paste-A, paste-B, CR, CR — the terminal would run the
+// two commands merged into one line, then submit an empty one. So each session gets
+// a chain: a send waits for the previous send's Enter before its own paste.
+// Different sessions never wait on each other.
+export const createTerminalInputSender = (deps: TerminalInputDeps) => {
+  const chains = new Map<string, Promise<void>>();
+
+  return async (sessionId: string, text: string): Promise<{ sent: boolean }> => {
+    const safe = sanitizeTerminalInput(text);
+    if (!safe) {
+      throw new Error("text is required");
+    }
+    // A failed send must not poison the chain for the next one, so the stored link
+    // swallows the error; the caller still sees it through `run`.
+    const previous = chains.get(sessionId) ?? Promise.resolve();
+    const run = previous.then(() => typeAndSubmit(deps, sessionId, safe));
+    const link = run.catch(() => undefined);
+    chains.set(sessionId, link);
+    // Drop the entry once it is the last one, so sessions don't accumulate forever.
+    link.then(() => {
+      if (chains.get(sessionId) === link) {
+        chains.delete(sessionId);
+      }
+    });
+    await run;
+    return { sent: true };
+  };
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -1937,6 +1937,21 @@ const remoteHostListTerminalSessions = async () =>
     }),
   });
 
+// Write a chunk to a session's live PTY for the phone's terminal input (#445).
+// Only sessions attached in THIS process are writable: a tmux session that outlived
+// a restart is still viewable through capture-pane, but we hold no pty to type into.
+const remoteHostWriteToSession = (sessionId: string, chunk: string): boolean => {
+  const entry = ptys.get(sessionId);
+  if (!entry) return false;
+  try {
+    entry.term.write(chunk);
+    return true;
+  } catch {
+    // pty died between the lookup and the write
+    return false;
+  }
+};
+
 const remoteHostCaptureTerminalScreen = (sessionId: string) =>
   captureSessionScreen(sessionId, {
     capturePane: tmuxCapturePane,
@@ -1952,6 +1967,7 @@ initRemoteHostBackend({
   spawnChat: remoteHostSpawnChat,
   listTerminalSessions: remoteHostListTerminalSessions,
   captureTerminalScreen: remoteHostCaptureTerminalScreen,
+  writeToSession: remoteHostWriteToSession,
 });
 
 // Mount per-collection fs.watchers → completion bells via the notifier. After the


### PR DESCRIPTION
## Summary

電話のターミナル画面はこれまで読み取り専用でした。receptron/mulmoserver#83 で入力 UI と契約が確定しているので、**それが呼ぶハンドラ**を実装します。

| | |
|---|---|
| メソッド | `sendTerminalInput` |
| params | `{ sessionId: string, text: string }` |
| 結果 | `{ sent: true }`（失敗は throw） |

## 設計

TUI に正しく届けるための知識を、**PTY 無しでテストできる新モジュール** `server/backends/remoteHost/terminalInput.ts` に置きました。`server/index.ts` は PTY テーブルに触る `writeToSession` だけを提供します。

3点とも `server/index.ts` の spawn 経路から学んだ挙動です:

1. **先にサニタイズ。** テキストは電話から来るので信頼できません。bracketed paste の終端子や裸の ESC が混ざっていると、ペーストから抜け出してホストの端末に制御入力として走ります。**C1 レンジを落とすことが ESC と同じくらい重要**です — 8-bit CSI は1バイトなので、ESC だけ見ていると素通りします
2. **bracketed paste で包む。** TUI が1キーずつ解釈せず、貼り付けとして扱うため
3. **Enter は別の書き込みとして一拍遅らせる。** Claude の TUI はペースト確定中に届いた CR を落とします。理由も遅延値も `server/index.ts` の spawn 経路と同じ

## Items to Confirm / Review

- **tmux で生き残ったセッションには書けません。** `capture-pane` で閲覧はできても、このプロセスに PTY が無いためです。**no-op ではなくエラーを返します** — 電話側は無言の成功を「打ち込めた」と読むので
- **重複を1つ意図的に残しました。** `attachDraftInjection` と `attachCodexAutoRun` は今も自前の paste + 遅延CR を持っています。共通化する価値はありますが、**両者ともテストが無く、チャット起動という load-bearing な経路**なので、無検証の手術をこの PR に混ぜるのは避けました。別 issue にする価値があると思います
- **サニタイザの挙動について。** テストを書いていて自分の思い込みを修正しました: `\e[201~` を渡しても文字列 `[201~` は残ります（ESC だけが落ちる）。ペーストは終端しないので**安全性は保たれています**が、「文字列ごと消える」わけではありません。テストは文字列一致ではなく**性質**（導入子が残らない / ペーストがちょうど1回閉じる）を検証しています

## テスト

新規 `terminalInput.spec.ts` 11件。全体では **130 files / 1421 tests pass**。

- ペーストと Enter が**別の書き込み**になること（同一チャンクだと落ちるため）
- 埋め込み終端子・8-bit CSI・ESC / Ctrl-C / 改行を無害化すること
- サニタイズ後に空なら送らずエラーにすること
- 生きた PTY が無いセッションはエラーになること
- ペースト後にセッションが終了しても throw しないこと

`npm run typecheck` / `lint`（エラー0）/ `build` すべて green。

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
