### PR TITLE
feat(collections): port the ontology route for the /collections Map tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.13.2",
-    "@mulmoclaude/core": "^0.25.1",
+    "@mulmoclaude/collection-plugin": "^0.14.0",
+    "@mulmoclaude/core": "^0.27.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
-    "@mulmoclaude/google-plugin": "^0.3.0",
+    "@mulmoclaude/google-plugin": "^0.3.2",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
     "@mulmoclaude/mulmoscript-plugin": "^0.2.2",
@@ -104,7 +104,7 @@
     "zod": "^4.4.3"
   },
   "resolutions": {
-    "@mulmoclaude/core": "^0.25.1"
+    "@mulmoclaude/core": "^0.27.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -17,6 +17,7 @@ import path from "node:path";
 import os from "node:os";
 import type { Express, Request, Response, NextFunction, RequestHandler } from "express";
 import {
+  buildWorkspaceOntology,
   configureCollectionHost,
   discoverCollections,
   loadCollection,
@@ -286,6 +287,19 @@ const listHandler: RequestHandler = async (_req, res) => {
     res.json({ collections: collections.map(toSummary) });
   } catch (err) {
     log.warn("collections", "list failed", { error: errorMessage(err) });
+    res.status(500).json({ error: errorMessage(err) });
+  }
+};
+
+// Raw workspace-ontology entries (buildWorkspaceOntology — derived on demand,
+// never stored); the /collections Map tab builds its graph from these with the
+// shared `buildOntologyGraph` client-side. Port of MulmoClaude's
+// GET /api/collections/ontology (mulmoclaude PR #2218).
+const ontologyHandler: RequestHandler = async (_req, res) => {
+  try {
+    res.json({ entries: await buildWorkspaceOntology() });
+  } catch (err) {
+    log.warn("collections", "ontology failed", { error: errorMessage(err) });
     res.status(500).json({ error: errorMessage(err) });
   }
 };
@@ -851,6 +865,7 @@ export function mountCollectionRoutes(app: Express): void {
   app.delete("/api/collections/:slug", collectionDeleteHandler);
 
   app.get("/api/collections/list", listHandler);
+  app.get("/api/collections/ontology", ontologyHandler);
   app.get("/api/collections/:slug/detail", detailHandler);
 
   app.post("/api/collections/:slug/items", itemCreateHandler);

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -24,6 +24,7 @@ import type {
 import type {
   CollectionDetailResponse,
   CollectionsListResponse,
+  CollectionOntologyResponse,
   CollectionNotifySeverity,
   ItemMutationResponse,
   FeedsListResponse,
@@ -146,6 +147,10 @@ configureCollectionUi({
   // ── real (read side) ──
   fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
   listCollections: () => apiGet<CollectionsListResponse>("/api/collections/list"),
+  // Map tab: raw workspace-ontology entries; the plugin builds the graph
+  // client-side via the shared buildOntologyGraph (optional binding — omitting
+  // it would just hide the tab).
+  fetchOntology: () => apiGet<CollectionOntologyResponse>("/api/collections/ontology"),
   confirm: (options) => Promise.resolve(window.confirm(options.message)),
   // MulmoTerminal has no host i18n; the plugin runs its own. Pick the browser's
   // base language, defaulting to English.

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -23,10 +23,18 @@ vi.mock("@mulmoclaude/core/collection/registry/server", () => ({
 // inject a crafted collection: a collection-level `kind: "mutate"` action can't
 // exist on disk (the schema refine rejects it), yet the route's defensive 400
 // must still be covered.
-import { deleteCollection, deleteCustomView, loadCollection } from "@mulmoclaude/core/collection/server";
+import { buildWorkspaceOntology, deleteCollection, deleteCustomView, loadCollection } from "@mulmoclaude/core/collection/server";
 vi.mock("@mulmoclaude/core/collection/server", async (importOriginal) => {
   const orig = await importOriginal<typeof import("@mulmoclaude/core/collection/server")>();
-  return { ...orig, deleteCollection: vi.fn(), deleteCustomView: vi.fn(), loadCollection: vi.fn(orig.loadCollection) };
+  return {
+    ...orig,
+    deleteCollection: vi.fn(),
+    deleteCustomView: vi.fn(),
+    loadCollection: vi.fn(orig.loadCollection),
+    // Wrapped (default = real) so the ontology route's 500 mapping can be
+    // covered — the real engine over the fixture workspace never throws.
+    buildWorkspaceOntology: vi.fn(orig.buildWorkspaceOntology),
+  };
 });
 
 // A minimal project-scope collection skill + one record + one read-only custom
@@ -142,6 +150,25 @@ describe("GET /api/collections/list", () => {
     const body = (await res.json()) as { collections: Array<{ slug: string; title: string; source: string }> };
     const testcol = body.collections.find((c) => c.slug === "testcol");
     expect(testcol).toMatchObject({ slug: "testcol", title: "Test Collection", source: "project" });
+  });
+});
+
+describe("GET /api/collections/ontology", () => {
+  it("returns one entry per discovered collection with counts + relations", async () => {
+    const res = await fetch(`${base}/api/collections/ontology`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      entries: Array<{ slug: string; title: string; primaryKey: string; displayField: string; recordCount: number; relations: unknown[] }>;
+    };
+    const testcol = body.entries.find((entry) => entry.slug === "testcol");
+    expect(testcol).toMatchObject({ slug: "testcol", title: "Test Collection", primaryKey: "id", displayField: "id", recordCount: 1, relations: [] });
+  });
+
+  it("maps an engine failure to 500 with the error message", async () => {
+    vi.mocked(buildWorkspaceOntology).mockRejectedValueOnce(new Error("ontology boom"));
+    const res = await fetch(`${base}/api/collections/ontology`);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "ontology boom" });
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,18 +1730,18 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.3.tgz#933121a1720b2b68c62082048fe9df278466445e"
   integrity sha512-13oTtFLQgS7uiM/K6bxOKH7nKSs7Muhcg+PIsfl0ThyaINuu57LuktLf09XoRLDWouhUlL0gBZXDFSwuw+k6qA==
 
-"@mulmoclaude/collection-plugin@^0.13.2":
-  version "0.13.2"
-  resolved "https://registry.npmjs.org/@mulmoclaude/collection-plugin/-/collection-plugin-0.13.2.tgz#0b968efc1f2d376604cd2394125968c3b2b09795"
-  integrity sha512-RWTp5xa3OPjQGu432S0WlAXRoZIChtUslSByqnkW6vihurICrqz68rnwBAgWthYa+coP3NS0zd8n2oKSjgq1hw==
+"@mulmoclaude/collection-plugin@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.14.0.tgz#ee8b3a96d261e66290c64b2d481e9f7feef74d57"
+  integrity sha512-Mk2fV+r58HcT4bjaIRflBKm2usIsZf+dXPTXcbeh/m3CPvrTGFvAALd+HdzsrCKWUM9sjOZqEHe4VGtCFlThbQ==
   dependencies:
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.23.0", "@mulmoclaude/core@^0.25.1":
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.25.1.tgz#7a8537438f3b8713f7a211517a6021c82bad627e"
-  integrity sha512-ybFVaYNZtRKxGT6PK4rZ1KMIBbe6T4dhzgPUAPqCvS5lEBchE+5lsYaBk+iCQaK3NkuYDGj8biA5AcA7HiKOng==
+"@mulmoclaude/core@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.27.0.tgz#a3e661545205e858d8a3b1084b43fb1220d167e4"
+  integrity sha512-Ca0LCoQ91JbKRdl5npNHURg4/wzLgPNrYqP1basH/KhVCKTSU/QfVk8NIJlxBAiMmrOY3+Deg/tUb2NDvipFKg==
   dependencies:
     "@duckdb/node-api" "^1.5.4-r.1"
     fast-xml-parser "^5.10.1"
@@ -1755,12 +1755,12 @@
   resolved "https://npm.flatt.tech/@mulmoclaude/form-plugin/-/form-plugin-0.1.4.tgz#64e8f9dc0537148156cbfc1235d5a68baf64cdf3"
   integrity sha512-dgqEiAazyMzLgNv0V3ewQxSPU5dI0eXecRYZ5rXe0Fu9CWZkCb1GOwJDjYHKDZnzMyYMQLzXnyt5gwHNW+QD+w==
 
-"@mulmoclaude/google-plugin@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.3.0.tgz#d01dc860503b98e99b922b99b52f6f948aefc051"
-  integrity sha512-qb4fvnWYUH/F44iMd988ld0RMRT3fj3v82Gog9KB08nc5jrkH6kHU3n7wP4RZMAHkOX31CjWcUAoLu7umt+k+A==
+"@mulmoclaude/google-plugin@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.3.2.tgz#c75fa9b0f0ac09281b16dd91be45cefe78c44a7d"
+  integrity sha512-trIIStfLX1O0bDj4W4ZZYDxjXPUAymwmjfeB/tm8tDT6q/qzLgTWySvFHYxl1xdcfMXWqOS/OZwNRIPSX+oW6A==
   dependencies:
-    "@mulmoclaude/core" "^0.23.0"
+    "@mulmoclaude/core" "^0.27.0"
 
 "@mulmoclaude/html-plugin@^0.2.5":
   version "0.2.5"


### PR DESCRIPTION
## Summary

Ports MulmoClaude's new workspace-ontology surface (receptron/mulmoclaude#2218) so the **Map tab** on the collections index works here too. `@mulmoclaude/collection-plugin@0.14` renders the workspace ontology — collections as nodes, `ref`/`backlinks`/`rollup` relations as edges, ghost nodes for dangling targets — through an optional `fetchOntology` host binding; without this port the tab is simply hidden (the binding is additive by design).

## Changes

- **server** (`server/backends/collections.ts`): `GET /api/collections/ontology` → `buildWorkspaceOntology()` passthrough from `@mulmoclaude/core/collection/server`, registered beside `/list` ahead of the `:slug` routes. Same fail-soft shape as MulmoClaude's route; the client builds the graph with the shared `buildOntologyGraph` so both hosts render identically.
- **client** (`src/composables/collectionUi.ts`): `fetchOntology` binding over the new route.
- **deps**: `@mulmoclaude/core` `^0.25.1 → ^0.27.0`, `@mulmoclaude/collection-plugin` `^0.13.2 → ^0.14.0`, `@mulmoclaude/google-plugin` `^0.3.0 → ^0.3.2` (all three published). Core 0.27 also carries the `errorMessage`/`truncate` consolidation from mulmoclaude #2217/#2219 — no host-side call-pattern changes beyond this route. `echarts` (the plugin's new peer dep for the graph) was already a direct dependency here.

## Testing

- `yarn typecheck` + `yarn typecheck:server` clean
- `yarn lint` 0 errors (4 pre-existing warnings in untouched files)
- `yarn test` — 1428 tests / 130 files, all pass
- `yarn build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)