### PR TITLE
fix: sanitize package-manager launcher env before spawning PTYs

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import {
   isResumableTmuxSession,
 } from "./infra/tmux.js";
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
+import { sanitizePtyEnv } from "./infra/pty-env.js";
 import {
   sandboxEnabled,
   sandboxPlatformSupported,
@@ -2194,8 +2195,10 @@ const PTY_ROWS = 30;
 
 // pty.spawn with the binary as a PARAMETER (never a string literal at the call site),
 // so the tmux/shell/claude spawns aren't flagged as spawn-of-a-string-literal.
+// The env is sanitized: package-manager launcher vars (yarn's PREFIX kills nvm
+// in spawned shells — see infra/pty-env.ts) must not leak into PTYs.
 function spawnPty(bin: string, args: string[], cwd: string): IPty {
-  return pty.spawn(bin, args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env: process.env });
+  return pty.spawn(bin, args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env: sanitizePtyEnv(process.env, path.delimiter) });
 }
 
 // Spawn a terminal, wrapping it in a persistent tmux session when tmux is available and
@@ -2452,7 +2455,7 @@ function spawnCommandPty(command: string, cwd: string, ws: WebSocket): IPty {
   const isWindows = process.platform === "win32";
   const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
   const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", command];
-  const term = pty.spawn(shell, args, { name: "xterm-256color", cols: 120, rows: 30, cwd, env: process.env });
+  const term = pty.spawn(shell, args, { name: "xterm-256color", cols: 120, rows: 30, cwd, env: sanitizePtyEnv(process.env, path.delimiter) });
   console.log(`[pty] spawned command (pid=${term.pid}) in ${cwd}: ${command}`);
 
   term.onData((data) => {

--- a/server/infra/pty-env.ts
+++ b/server/infra/pty-env.ts
@@ -1,0 +1,60 @@
+// Environment sanitization for spawned PTYs.
+//
+// The server is usually started by a package-manager script (`yarn dev`,
+// `npm run dev`, `npx mulmoterminal`), and those launchers leak their context
+// into process.env. The worst offender: Homebrew's yarn wrapper exports
+// PREFIX=/opt/homebrew, and nvm's auto-activation (`nvm use` in .zshrc) strips
+// its bin dir from PATH *before* its compatibility check aborts on PREFIX —
+// leaving the spawned shell with no node/npm/npx at all. The npm_*/INIT_CWD
+// vars and the PATH shim dirs (yarn's temp node wrapper, node_modules/.bin)
+// are the same class of leak: run-script context that a user terminal — or a
+// claude session — should never inherit. Strip it all so spawned PTYs start
+// from an environment a fresh login shell would recognize.
+
+const REMOVED_NAMES = new Set([
+  "PREFIX", // Homebrew yarn wrapper; fatal to nvm (see header comment)
+  "INIT_CWD",
+  "NODE", // npm run points it at the launching node binary
+  "PROJECT_CWD", // yarn berry
+  "BERRY_BIN_FOLDER", // yarn berry
+  "npm_execpath",
+  "npm_node_execpath",
+  "npm_command",
+]);
+
+const REMOVED_PREFIXES = ["npm_config_", "npm_package_", "npm_lifecycle_"];
+
+// Is this env var package-manager launcher context (vs. real user environment)?
+// Deliberately narrow: HOMEBREW_PREFIX / CONDA_PREFIX etc. must survive.
+export function isLauncherEnvVar(name: string): boolean {
+  if (REMOVED_NAMES.has(name)) return true;
+  const lower = name.toLowerCase();
+  return REMOVED_PREFIXES.some((prefix) => lower.startsWith(prefix));
+}
+
+// Is this PATH entry a run-script injection? yarn v1 prepends a temp dir with a
+// `node` shim (…/T/yarn--<ts>-<rand>) that outlives nothing, and both yarn and
+// npm prepend node_modules/.bin + npm's node-gyp-bin dirs.
+export function isLauncherPathEntry(entry: string): boolean {
+  return /[\\/]yarn--\d/.test(entry) || /[\\/]node_modules[\\/]\.bin$/.test(entry) || /[\\/]node-gyp-bin$/.test(entry);
+}
+
+// PATH with the run-script injections removed; everything else (nvm, homebrew,
+// system dirs) kept in order.
+export function sanitizePathEntries(pathValue: string, delimiter: string): string {
+  return pathValue
+    .split(delimiter)
+    .filter((entry) => !isLauncherPathEntry(entry))
+    .join(delimiter);
+}
+
+// A copy of `env` safe to hand to a spawned PTY: launcher vars dropped, PATH
+// (any casing — Windows uses "Path") cleaned. Never mutates the input.
+export function sanitizePtyEnv(env: NodeJS.ProcessEnv, delimiter: string): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(env)) {
+    if (isLauncherEnvVar(name)) continue;
+    out[name] = name.toLowerCase() === "path" && value !== undefined ? sanitizePathEntries(value, delimiter) : value;
+  }
+  return out;
+}

--- a/server/infra/pty-env.ts
+++ b/server/infra/pty-env.ts
@@ -11,12 +11,13 @@
 // claude session — should never inherit. Strip it all so spawned PTYs start
 // from an environment a fresh login shell would recognize.
 
+// All lowercase: matching is case-insensitive, since Windows env names are.
 const REMOVED_NAMES = new Set([
-  "PREFIX", // Homebrew yarn wrapper; fatal to nvm (see header comment)
-  "INIT_CWD",
-  "NODE", // npm run points it at the launching node binary
-  "PROJECT_CWD", // yarn berry
-  "BERRY_BIN_FOLDER", // yarn berry
+  "prefix", // Homebrew yarn wrapper; fatal to nvm (see header comment)
+  "init_cwd",
+  "node", // npm run points it at the launching node binary
+  "project_cwd", // yarn berry
+  "berry_bin_folder", // yarn berry
   "npm_execpath",
   "npm_node_execpath",
   "npm_command",
@@ -27,9 +28,8 @@ const REMOVED_PREFIXES = ["npm_config_", "npm_package_", "npm_lifecycle_"];
 // Is this env var package-manager launcher context (vs. real user environment)?
 // Deliberately narrow: HOMEBREW_PREFIX / CONDA_PREFIX etc. must survive.
 export function isLauncherEnvVar(name: string): boolean {
-  if (REMOVED_NAMES.has(name)) return true;
   const lower = name.toLowerCase();
-  return REMOVED_PREFIXES.some((prefix) => lower.startsWith(prefix));
+  return REMOVED_NAMES.has(lower) || REMOVED_PREFIXES.some((prefix) => lower.startsWith(prefix));
 }
 
 // Is this PATH entry a run-script injection? yarn v1 prepends a temp dir with a

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { isLauncherEnvVar, sanitizePathEntries } from "./pty-env.js";
 
 const SERVER_SOCKET = "mulmoterminal";
 const SESSION_PREFIX = "mt-";
@@ -73,11 +74,34 @@ function applyLiveTmuxOptions(): void {
   }
 }
 
+// Scrub package-manager launcher vars from a RUNNING tmux server's global
+// environment. The tmux server outlives node: one started under `yarn dev`
+// keeps PREFIX/npm_* in its global env and re-injects them into every new
+// pane — where PREFIX makes nvm strip node/npm from PATH (see pty-env.ts) —
+// so restarting node with a clean env isn't enough. `setenv -g -r` flags each
+// var for removal from new pane environments; the global PATH is rewritten
+// with the run-script shim dirs dropped. Existing panes keep their env (a
+// shell's copy can't be edited from outside); new ones start clean.
+function scrubGlobalEnvironment(): void {
+  const r = tmux(["show-environment", "-g"]);
+  if (r.status !== 0) return;
+  for (const line of r.stdout.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const name = line.slice(0, eq);
+    if (isLauncherEnvVar(name)) tmux(["set-environment", "-g", "-r", name]);
+    else if (name === "PATH") tmux(["set-environment", "-g", "PATH", sanitizePathEntries(line.slice(eq + 1), path.delimiter)]);
+  }
+}
+
 function ensureConf(): void {
   try {
     mkdirSync(path.dirname(CONF_FILE), { recursive: true });
     writeFileSync(CONF_FILE, TMUX_CONF_LINES.join("\n") + "\n");
-    if (tmux(["list-sessions"]).status === 0) applyLiveTmuxOptions();
+    if (tmux(["list-sessions"]).status === 0) {
+      applyLiveTmuxOptions();
+      scrubGlobalEnvironment();
+    }
   } catch {
     // non-fatal — tmux falls back to its defaults (a status bar, etc.)
   }

--- a/test/server/infra/pty-env.spec.ts
+++ b/test/server/infra/pty-env.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { isLauncherEnvVar, sanitizePathEntries, sanitizePtyEnv } from "../../../server/infra/pty-env";
+
+describe("isLauncherEnvVar", () => {
+  it("flags the vars package-manager launchers inject", () => {
+    for (const name of [
+      "PREFIX",
+      "INIT_CWD",
+      "NODE",
+      "PROJECT_CWD",
+      "BERRY_BIN_FOLDER",
+      "npm_execpath",
+      "npm_node_execpath",
+      "npm_command",
+      "npm_config_registry",
+      "npm_config_user_agent",
+      "npm_package_name",
+      "npm_package_scripts_dev",
+      "npm_lifecycle_event",
+      "npm_lifecycle_script",
+    ]) {
+      expect(isLauncherEnvVar(name), name).toBe(true);
+    }
+  });
+
+  it("keeps real user environment, including other *_PREFIX vars", () => {
+    for (const name of ["HOMEBREW_PREFIX", "CONDA_PREFIX", "HOME", "SHELL", "PATH", "NVM_DIR", "NODE_ENV", "NODE_OPTIONS"]) {
+      expect(isLauncherEnvVar(name), name).toBe(false);
+    }
+  });
+});
+
+describe("sanitizePathEntries", () => {
+  const NVM_BIN = "/Users/u/.nvm/versions/node/v22.18.0/bin";
+
+  it("drops yarn temp shims, node_modules/.bin and node-gyp-bin, keeps the rest in order", () => {
+    const dirty = [
+      "/Users/u/Library/Caches/yarn--1784555760742-0.153931",
+      "/repo/node_modules/.bin",
+      "/Users/u/.config/yarn/link/node_modules/.bin",
+      "/Users/u/.nvm/versions/node/v22.18.0/lib/node_modules/npm/bin/node-gyp-bin",
+      NVM_BIN,
+      "/opt/homebrew/bin",
+      "/usr/bin",
+    ].join(":");
+    expect(sanitizePathEntries(dirty, ":")).toBe([NVM_BIN, "/opt/homebrew/bin", "/usr/bin"].join(":"));
+  });
+
+  it("does not drop directories that merely contain node_modules", () => {
+    const p = "/repo/node_modules/.bin/tools:/repo/tools/bin";
+    expect(sanitizePathEntries(p, ":")).toBe(p);
+  });
+
+  it("handles windows-style separators and delimiter", () => {
+    const dirty = ["C:\\repo\\node_modules\\.bin", "C:\\yarn-cache\\yarn--123-abc", "C:\\Windows\\system32"].join(";");
+    expect(sanitizePathEntries(dirty, ";")).toBe("C:\\Windows\\system32");
+  });
+});
+
+describe("sanitizePtyEnv", () => {
+  it("returns a clean copy without mutating the input", () => {
+    const env: NodeJS.ProcessEnv = {
+      PREFIX: "/opt/homebrew",
+      npm_config_registry: "https://registry.yarnpkg.com",
+      npm_package_name: "mulmoterminal",
+      HOME: "/Users/u",
+      SHELL: "/bin/zsh",
+      HOMEBREW_PREFIX: "/opt/homebrew",
+      PATH: "/repo/node_modules/.bin:/Users/u/.nvm/versions/node/v22.18.0/bin:/usr/bin",
+    };
+    const out = sanitizePtyEnv(env, ":");
+    expect(out.PREFIX).toBeUndefined();
+    expect(out.npm_config_registry).toBeUndefined();
+    expect(out.npm_package_name).toBeUndefined();
+    expect(out.HOME).toBe("/Users/u");
+    expect(out.SHELL).toBe("/bin/zsh");
+    expect(out.HOMEBREW_PREFIX).toBe("/opt/homebrew");
+    expect(out.PATH).toBe("/Users/u/.nvm/versions/node/v22.18.0/bin:/usr/bin");
+    expect(env.PREFIX).toBe("/opt/homebrew");
+    expect(env.PATH).toContain("/repo/node_modules/.bin");
+  });
+
+  it("cleans a windows-cased Path key", () => {
+    const out = sanitizePtyEnv({ Path: "C:\\repo\\node_modules\\.bin;C:\\Windows" }, ";");
+    expect(out.Path).toBe("C:\\Windows");
+  });
+});

--- a/test/server/infra/pty-env.spec.ts
+++ b/test/server/infra/pty-env.spec.ts
@@ -23,6 +23,12 @@ describe("isLauncherEnvVar", () => {
     }
   });
 
+  it("matches case-insensitively (Windows env names are case-insensitive)", () => {
+    for (const name of ["Prefix", "prefix", "Init_Cwd", "Node", "NPM_CONFIG_REGISTRY", "Npm_Package_Name", "NPM_EXECPATH"]) {
+      expect(isLauncherEnvVar(name), name).toBe(true);
+    }
+  });
+
   it("keeps real user environment, including other *_PREFIX vars", () => {
     for (const name of ["HOMEBREW_PREFIX", "CONDA_PREFIX", "HOME", "SHELL", "PATH", "NVM_DIR", "NODE_ENV", "NODE_OPTIONS"]) {
       expect(isLauncherEnvVar(name), name).toBe(false);


### PR DESCRIPTION
## Problem

Shells opened from the app's "new terminal" button had no `npm`/`npx`. Chain of events:

1. Homebrew's `/opt/homebrew/bin/yarn` wrapper exports `PREFIX=/opt/homebrew`; `yarn dev` passes it (plus `npm_config_*`/`npm_package_*` vars and a temp `node`-shim dir on PATH) into the server.
2. The server spawned every PTY with raw `env: process.env`.
3. In the new zsh, nvm's auto-activation (`nvm use` from `.zshrc`) strips `$NVM_DIR/versions/*/bin` from PATH **first**, then aborts on the incompatible `PREFIX` var — after the strip, before re-adding. Result: no node toolchain on PATH at all.

Restarting the server with a clean launcher demonstrably did **not** fix it: the `tmux -L mulmoterminal` server outlives node, keeps the polluted global environment, and re-injects it into every new pane.

## Fix (two parts, matching the two pollution sites)

- **`server/infra/pty-env.ts` (new):** `sanitizePtyEnv()` returns a copy of the env with launcher vars dropped (`PREFIX`, `npm_config_*`, `npm_package_*`, `npm_lifecycle_*`, `npm_execpath`, `INIT_CWD`, yarn-berry vars) and PATH cleaned of run-script shims (yarn temp `node` wrapper, `node_modules/.bin`, `node-gyp-bin`). Deliberately keeps `HOMEBREW_PREFIX`/`CONDA_PREFIX`; handles Windows `Path` casing. Wired into both `pty.spawn` sites in `server/index.ts`.
- **`server/infra/tmux.ts`:** `scrubGlobalEnvironment()` — when a surviving tmux server is detected at startup, flag each launcher var for removal from new panes (`setenv -g -r`) and rewrite the global PATH. Existing panes keep their env (can't be edited from outside); new ones start clean.

## Verification

- New unit tests in `test/server/infra/pty-env.spec.ts`; full suite passes (131 files / 1437 tests), `tsc -p tsconfig.server.json` and eslint clean.
- Live-verified on a polluted long-lived tmux server: after the scrub, a fresh app-spawned shell (`/bin/zsh -lc 'exec $SHELL'` via tmux) resolves `npm`/`npx`/`node` from nvm and `PREFIX` is unset — with the server running under `yarn dev`, the worst-case launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)