### PR TITLE
chore: bump @mulmoclaude/core to ^0.29.0 — sectioned schemaDocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,10 +64,10 @@
     "@mulmochat-plugin/ui-image": "^0.4.1",
     "@mulmoclaude/accounting-plugin": "^0.3.2",
     "@mulmoclaude/chart-plugin": "^0.1.3",
-    "@mulmoclaude/collection-plugin": "^0.14.0",
-    "@mulmoclaude/core": "^0.27.0",
+    "@mulmoclaude/collection-plugin": "^0.14.1",
+    "@mulmoclaude/core": "^0.29.0",
     "@mulmoclaude/form-plugin": "^0.1.4",
-    "@mulmoclaude/google-plugin": "^0.3.2",
+    "@mulmoclaude/google-plugin": "^0.3.3",
     "@mulmoclaude/html-plugin": "^0.2.5",
     "@mulmoclaude/markdown-plugin": "^0.1.10",
     "@mulmoclaude/mulmoscript-plugin": "^0.2.2",
@@ -104,7 +104,7 @@
     "zod": "^4.4.3"
   },
   "resolutions": {
-    "@mulmoclaude/core": "^0.27.0"
+    "@mulmoclaude/core": "^0.29.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1730,18 +1730,18 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/chart-plugin/-/chart-plugin-0.1.3.tgz#933121a1720b2b68c62082048fe9df278466445e"
   integrity sha512-13oTtFLQgS7uiM/K6bxOKH7nKSs7Muhcg+PIsfl0ThyaINuu57LuktLf09XoRLDWouhUlL0gBZXDFSwuw+k6qA==
 
-"@mulmoclaude/collection-plugin@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.14.0.tgz#ee8b3a96d261e66290c64b2d481e9f7feef74d57"
-  integrity sha512-Mk2fV+r58HcT4bjaIRflBKm2usIsZf+dXPTXcbeh/m3CPvrTGFvAALd+HdzsrCKWUM9sjOZqEHe4VGtCFlThbQ==
+"@mulmoclaude/collection-plugin@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/collection-plugin/-/collection-plugin-0.14.1.tgz#ac4fb5e8e2e1fcfaeaf9b732c93d50f0f8c246a1"
+  integrity sha512-83quIsJj5pqCO43iiGjFcqB4sj7rtU5pVxOkU/RUEuisVZwgncUNHMDosvTH+dTEEiWppMPoHIJ842Yt/aCSJw==
   dependencies:
     vuedraggable "^4.1.0"
     zod "^4.4.3"
 
-"@mulmoclaude/core@^0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.27.0.tgz#a3e661545205e858d8a3b1084b43fb1220d167e4"
-  integrity sha512-Ca0LCoQ91JbKRdl5npNHURg4/wzLgPNrYqP1basH/KhVCKTSU/QfVk8NIJlxBAiMmrOY3+Deg/tUb2NDvipFKg==
+"@mulmoclaude/core@^0.29.0":
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-0.29.0.tgz#e5107e92852f71f136f0bd4905eeeb08ce4ad7a9"
+  integrity sha512-n46WyXrH3+f0NLPvr4BIcxWQh37d9/J3A/Fb//ifGlJ9r8yjlubh/jZjZRviWW7cEQLYgBtE9rzrUT/dqi48vg==
   dependencies:
     "@duckdb/node-api" "^1.5.4-r.1"
     fast-xml-parser "^5.10.1"
@@ -1755,12 +1755,12 @@
   resolved "https://npm.flatt.tech/@mulmoclaude/form-plugin/-/form-plugin-0.1.4.tgz#64e8f9dc0537148156cbfc1235d5a68baf64cdf3"
   integrity sha512-dgqEiAazyMzLgNv0V3ewQxSPU5dI0eXecRYZ5rXe0Fu9CWZkCb1GOwJDjYHKDZnzMyYMQLzXnyt5gwHNW+QD+w==
 
-"@mulmoclaude/google-plugin@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.3.2.tgz#c75fa9b0f0ac09281b16dd91be45cefe78c44a7d"
-  integrity sha512-trIIStfLX1O0bDj4W4ZZYDxjXPUAymwmjfeB/tm8tDT6q/qzLgTWySvFHYxl1xdcfMXWqOS/OZwNRIPSX+oW6A==
+"@mulmoclaude/google-plugin@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/google-plugin/-/google-plugin-0.3.3.tgz#7c33804034c5cb94f75880c77eec67090c6a5e2e"
+  integrity sha512-dUa+gMZ/feqG9oq7QL+c1jiVM660j/mCnT/5cT3u021sWpXw3TYwdVUPy+WkRt+UyFNDWaBaV5Cv73nEnqhIaw==
   dependencies:
-    "@mulmoclaude/core" "^0.27.0"
+    "@mulmoclaude/core" "^0.29.0"
 
 "@mulmoclaude/html-plugin@^0.2.5":
   version "0.2.5"


### PR DESCRIPTION
Picks up [mulmoclaude#2249](https://github.com/receptron/mulmoclaude/pull/2249): `manageCollection`'s `schemaDocs` action no longer dumps the whole ~75KB collection-authoring reference (which overflowed the agent's per-tool-result limit and pushed it back to copying example schemas). The default reply is now the core authoring guide + a table of contents (~33KB); the new `topic` arg fetches individual sections; `topic: "all"` keeps the full dump.

**Zero MT code changes** — `server/infra/collection-tool.ts` binds the shared core tool, so the new `topic` parameter flows through the tool definition automatically.

Lockstep bumps riding along: `collection-plugin ^0.14.1` + `google-plugin ^0.3.3` (their core peer range moved to `^0.29.0` — leaving them behind would resolve a duplicate core and break type identity, the same failure mode mulmoclaude's CI hit).

## Verification

- typecheck / lint / build clean; full suite 1430/1430 pass on the bumped install
- Smoke-tested against the **published** package through MT's exact binding (`bundledHelpsDir` fallback): `topic` present in the tool definition; default → 33,237 chars with TOC; `topic: "kanban"` → 2,136 chars; `topic: "all"` → the full 74,869-char dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)