### PR TITLE
refactor: remove duplicate route plumbing in the collections backend

### DIFF
--- a/plans/refactor-jscpd-duplicates.md
+++ b/plans/refactor-jscpd-duplicates.md
@@ -1,0 +1,37 @@
+# refactor: remove jscpd-reported duplicate code
+
+`jscpd` (min 5 lines / 50 tokens) over `src server common plugins test` reports **173 clones**,
+1666 duplicated lines (2.43%). 79 of those clones are in production code; the rest are in
+`*.spec.ts` files.
+
+Goal: eliminate the duplication that represents a real missing abstraction, and leave alone the
+clones that are merely coincidental shape. A false abstraction is worse than the duplication it
+removes.
+
+## Scope
+
+Shipped as several small PRs, one per cluster, so each stays reviewable.
+
+| # | Cluster | Dup lines | Approach |
+|---|---------|-----------|----------|
+| 1 | `server/backends/collections.ts` (self) | 107 | load-or-404 helper, error-guard route wrapper, shared store-failure mapper |
+| 2 | `CommandCell.vue` ↔ `LauncherCell.vue` | 105 CSS + 13 HTML + 11 TS | extract the shared cell-header chrome |
+| 3 | `RunMenu.vue` ↔ `SkillMenu.vue` | 50 CSS + 25 TS | shared dropdown composable + stylesheet |
+| 4 | `GuiPanel.vue` ↔ `ToolsPane.vue`, `NotificationBell.vue` ↔ `RemoteHostControl.vue` | 31+29 CSS, 19+11 TS | shared composable + stylesheet |
+| 5 | `server/config/dir-config.ts` ↔ `src/composables/useDirConfig.ts` | 19 | share the isomorphic part |
+| 6 | `server/index.ts` (self) | 65 | extract the repeated route shapes |
+
+## Out of scope
+
+- **`*.spec.ts` clones (94 of the 173).** Test duplication is usually deliberate: each test reads
+  top-to-bottom without the reader chasing a shared fixture. Not worth collapsing.
+- Clones under ~15 lines between unrelated modules (e.g. two overlays that happen to share a
+  scrollbar rule) — coincidental shape, no shared concept.
+
+## Constraint
+
+Pure refactor: no behavior change. Each PR must keep `yarn lint`, `yarn typecheck` and `yarn test`
+green (baseline: 131 files / 1438 tests).
+
+Note: `yarn typecheck:server` fails on `server/infra/web-push.ts` **on `main` already** — an
+upstream `@mulmobridge/web-push` type drift, unrelated to this work.

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -115,6 +115,25 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+// Route params are caller-controlled — strip CR/LF so a crafted slug/id can't
+// forge log lines.
+function sanitizeLogValues(params: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(params).map(([key, value]) => [key, String(value).replace(/[\r\n]/g, " ")]));
+}
+
+/** Wrap a route so an unexpected throw becomes a logged 500 rather than an
+ *  unhandled rejection. `op` names the endpoint in the log line. */
+function guarded<P extends Record<string, string>>(op: string, handler: RequestHandler<P>): RequestHandler<P> {
+  return async (req, res, next) => {
+    try {
+      await handler(req, res, next);
+    } catch (err) {
+      log.warn("collections", `${op} failed`, { ...sanitizeLogValues(req.params), error: errorMessage(err) });
+      res.status(500).json({ error: errorMessage(err) });
+    }
+  };
+}
+
 /** A request body usable as a record: a non-null, non-array object. */
 function extractRecord(body: unknown): CollectionItem | null {
   if (!body || typeof body !== "object" || Array.isArray(body)) return null;
@@ -124,6 +143,35 @@ function extractRecord(body: unknown): CollectionItem | null {
 // A loaded collection, sans the null that `loadCollection` returns on a miss —
 // derived here so the view-write helper doesn't need a fresh type import.
 type ResolvedCollection = NonNullable<Awaited<ReturnType<typeof loadCollection>>>;
+
+/** Load a collection, answering 404 when the slug is unknown. A null return means
+ *  the response is already sent — the caller must return immediately. */
+async function resolveCollection(res: Response, slug: string): Promise<ResolvedCollection | null> {
+  const collection = await loadCollection(slug);
+  if (!collection) res.status(404).json({ error: `collection '${slug}' not found` });
+  return collection;
+}
+
+/** Locate a declared custom view, answering 404 when it is absent. A null return
+ *  means the response is already sent. */
+function resolveView(res: Response, collection: ResolvedCollection, viewId: string) {
+  const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+  if (!view) res.status(404).json({ error: `custom view '${viewId}' not found on collection '${collection.slug}'` });
+  return view ?? null;
+}
+
+// The two store failures every record route maps identically, shared by the
+// write and delete result unions.
+type CommonStoreFailure = { kind: "invalid-id" | "path-escape"; itemId: string };
+
+function isCommonStoreFailure(result: { kind: string; itemId: string }): result is CommonStoreFailure {
+  return result.kind === "invalid-id" || result.kind === "path-escape";
+}
+
+function respondForStoreFailure(res: Response, slug: string, failure: CommonStoreFailure): void {
+  if (failure.kind === "invalid-id") res.status(400).json({ error: `invalid item id: ${failure.itemId}` });
+  else res.status(403).json({ error: `data directory for '${slug}' escapes the workspace` });
+}
 
 // The write modes a custom view's PUT may request, matching the documented
 // __MC_VIEW contract (@mulmoclaude/core help: custom-view.md).
@@ -203,12 +251,7 @@ function mutateStatus(kind: string): number {
 // Discover tab: the merged curated-registry catalog (every configured registry's
 // index.json, fetched + cached server-side).
 const registryListHandler: RequestHandler = async (_req, res) => {
-  try {
-    res.json(await listRegistry());
-  } catch (err) {
-    log.warn("collections", "registry list failed", { error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  res.json(await listRegistry());
 };
 
 // Discover tab: install a registry collection into the shared workspace.
@@ -224,71 +267,45 @@ const registryImportHandler: RequestHandler = async (req, res) => {
     res.status(400).json({ error: "author and slug are required" });
     return;
   }
-  try {
-    const result = await importRegistry(author, slug, workspaceRoot, registry);
-    if (!result.ok) {
-      res.status(result.status).json({ error: result.error });
-      return;
-    }
-    res.json(result.response);
-  } catch (err) {
-    log.warn("collections", "registry import failed", { error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+  const result = await importRegistry(author, slug, workspaceRoot, registry);
+  if (!result.ok) {
+    res.status(result.status).json({ error: result.error });
+    return;
   }
+  res.json(result.response);
 };
 
 // Delete one custom view: drop it from the schema + unlink its HTML. Refuses
 // user-scope / preset collections (read-only), like collection delete.
 const viewDeleteHandler: RequestHandler<{ slug: string; viewId: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
+  const result = await deleteCustomView(collection, req.params.viewId);
+  if (result.kind !== "ok") {
+    res.status(result.kind === "not-found" ? 404 : 403).json({ error: `view delete refused (${result.kind})` });
     return;
   }
-  try {
-    const result = await deleteCustomView(collection, req.params.viewId);
-    if (result.kind !== "ok") {
-      res.status(result.kind === "not-found" ? 404 : 403).json({ error: `view delete refused (${result.kind})` });
-      return;
-    }
-    res.json({ deleted: true, viewId: result.viewId });
-  } catch (err) {
-    log.warn("collections", "view delete failed", { slug: req.params.slug, viewId: req.params.viewId, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  res.json({ deleted: true, viewId: result.viewId });
 };
 
 // Delete an entire collection (skill + records) after archiving a restorable
 // copy. Only project-scope, non-preset collections are deletable; a refusal
 // (preset / user-scope / unsafe path) comes back as 403 with the reason.
 const collectionDeleteHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
+  const result = await deleteCollection(collection);
+  if (result.kind !== "ok") {
+    res.status(403).json({ error: deleteCollectionRefusalMessage(result) });
     return;
   }
-  try {
-    const result = await deleteCollection(collection);
-    if (result.kind !== "ok") {
-      res.status(403).json({ error: deleteCollectionRefusalMessage(result) });
-      return;
-    }
-    res.json({ deleted: true, slug: result.slug, archivePath: result.archivePath });
-  } catch (err) {
-    log.warn("collections", "collection delete failed", { slug: req.params.slug, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  res.json({ deleted: true, slug: result.slug, archivePath: result.archivePath });
 };
 
 // List skill-backed collections for the index + toolbar.
 const listHandler: RequestHandler = async (_req, res) => {
-  try {
-    const collections = await discoverCollections();
-    res.json({ collections: collections.map(toSummary) });
-  } catch (err) {
-    log.warn("collections", "list failed", { error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  const collections = await discoverCollections();
+  res.json({ collections: collections.map(toSummary) });
 };
 
 // Raw workspace-ontology entries (buildWorkspaceOntology — derived on demand,
@@ -296,51 +313,35 @@ const listHandler: RequestHandler = async (_req, res) => {
 // shared `buildOntologyGraph` client-side. Port of MulmoClaude's
 // GET /api/collections/ontology (mulmoclaude PR #2218).
 const ontologyHandler: RequestHandler = async (_req, res) => {
-  try {
-    res.json({ entries: await buildWorkspaceOntology() });
-  } catch (err) {
-    log.warn("collections", "ontology failed", { error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  res.json({ entries: await buildWorkspaceOntology() });
 };
 
 // A collection's live schema + records by slug. Backs both the card's own load
 // (CollectionView reads `status` for 404 → not-found) and ref/embed resolution.
 const detailHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-    return;
-  }
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
+  const items = await storeFor(collection).list();
+  // Best-effort validation: a malformed record is silently skipped at read
+  // time, so surface the problems here too and let the view offer a Repair
+  // button. Never let validation failure turn a successful detail into a 500.
+  let issues: RecordIssue[] = [];
   try {
-    const items = await storeFor(collection).list();
-    // Best-effort validation: a malformed record is silently skipped at read
-    // time, so surface the problems here too and let the view offer a Repair
-    // button. Never let validation failure turn a successful detail into a 500.
-    let issues: RecordIssue[] = [];
-    try {
-      issues = await validateCollectionRecords(collection);
-    } catch (err) {
-      log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
-    }
-    // Omit `issues` entirely when everything is fine (the "absent when clean"
-    // contract the view relies on).
-    res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
+    issues = await validateCollectionRecords(collection);
   } catch (err) {
-    log.warn("collections", "detail failed", { slug: collection.slug, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+    log.warn("collections", "detail validation skipped", { slug: collection.slug, error: errorMessage(err) });
   }
+  // Omit `issues` entirely when everything is fine (the "absent when clean"
+  // contract the view relies on).
+  res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
 };
 
 // ── Record CRUD (Tier 1: interactive editing — e.g. checking a to-do item) ──
 // Create a record. The id is the schema's primaryKey value from the body, or a
 // generated one; a singleton collection pins every create to its fixed id.
 const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-    return;
-  }
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
   const createStore = storeFor(collection).write;
   if (!createStore) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
@@ -353,35 +354,23 @@ const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => 
   }
   const itemId = resolveCreateItemId(collection.schema, record) ?? generateItemId();
   const recordWithId: CollectionItem = { ...record, [collection.schema.primaryKey]: itemId };
-  try {
-    const result = await createStore(itemId, recordWithId, { refuseOverwrite: true });
-    if (result.kind === "invalid-id") {
-      res.status(400).json({ error: `invalid item id: ${result.itemId}` });
-      return;
-    }
-    if (result.kind === "path-escape") {
-      res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
-      return;
-    }
-    if (result.kind === "conflict") {
-      res.status(409).json({ error: `item '${result.itemId}' already exists` });
-      return;
-    }
-    res.json({ itemId: result.itemId, item: result.item });
-  } catch (err) {
-    log.warn("collections", "item create failed", { slug: collection.slug, itemId, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+  const result = await createStore(itemId, recordWithId, { refuseOverwrite: true });
+  if (isCommonStoreFailure(result)) {
+    respondForStoreFailure(res, collection.slug, result);
+    return;
   }
+  if (result.kind === "conflict") {
+    res.status(409).json({ error: `item '${result.itemId}' already exists` });
+    return;
+  }
+  res.json({ itemId: result.itemId, item: result.item });
 };
 
 // Update a record. The primaryKey is pinned to the URL itemId (the body can't
 // smuggle a different id). Singletons only accept their one fixed id.
 const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-    return;
-  }
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
   const updateStore = storeFor(collection).write;
   if (!updateStore) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
@@ -398,58 +387,37 @@ const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = asyn
     return;
   }
   const recordWithId: CollectionItem = { ...record, [primaryKey]: req.params.itemId };
-  try {
-    const result = await updateStore(req.params.itemId, recordWithId);
-    if (result.kind === "invalid-id") {
-      res.status(400).json({ error: `invalid item id: ${result.itemId}` });
-      return;
-    }
-    if (result.kind === "path-escape") {
-      res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
-      return;
-    }
-    if (result.kind === "conflict") {
-      res.status(500).json({ error: "unexpected conflict on update" });
-      return;
-    }
-    res.json({ itemId: result.itemId, item: result.item });
-  } catch (err) {
-    log.warn("collections", "item update failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+  const result = await updateStore(req.params.itemId, recordWithId);
+  if (isCommonStoreFailure(result)) {
+    respondForStoreFailure(res, collection.slug, result);
+    return;
   }
+  if (result.kind === "conflict") {
+    res.status(500).json({ error: "unexpected conflict on update" });
+    return;
+  }
+  res.json({ itemId: result.itemId, item: result.item });
 };
 
 // Delete a record.
 const itemDeleteHandler: RequestHandler<{ slug: string; itemId: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-    return;
-  }
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
   const deleteStore = storeFor(collection).delete;
   if (!deleteStore) {
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
     return;
   }
-  try {
-    const result = await deleteStore(req.params.itemId);
-    if (result.kind === "invalid-id") {
-      res.status(400).json({ error: `invalid item id: ${result.itemId}` });
-      return;
-    }
-    if (result.kind === "path-escape") {
-      res.status(403).json({ error: `data directory for '${collection.slug}' escapes the workspace` });
-      return;
-    }
-    if (result.kind === "not-found") {
-      res.status(404).json({ error: `item '${result.itemId}' not found` });
-      return;
-    }
-    res.json({ deleted: true, itemId: result.itemId });
-  } catch (err) {
-    log.warn("collections", "item delete failed", { slug: collection.slug, itemId: req.params.itemId, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+  const result = await deleteStore(req.params.itemId);
+  if (isCommonStoreFailure(result)) {
+    respondForStoreFailure(res, collection.slug, result);
+    return;
   }
+  if (result.kind === "not-found") {
+    res.status(404).json({ error: `item '${result.itemId}' not found` });
+    return;
+  }
+  res.json({ deleted: true, itemId: result.itemId });
 };
 
 // ── Actions (kind: "chat") — return a seed prompt + role; the frontend feeds it
@@ -493,68 +461,52 @@ const respondForMutateAction = async (
 
 // Per-record action (e.g. Repair / enrich this record).
 const itemActionHandler: RequestHandler<{ slug: string; itemId: string; actionId: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-    return;
-  }
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
   const action = collection.schema.actions?.find((entry) => entry.id === req.params.actionId);
   if (!action) {
     res.status(404).json({ error: `action '${req.params.actionId}' not found on collection '${collection.slug}'` });
     return;
   }
-  try {
-    const record = await storeFor(collection).read(req.params.itemId);
-    if (!record) {
-      res.status(404).json({ error: `item '${req.params.itemId}' not found` });
-      return;
-    }
-    // The action's `when` predicate is the authorization rule: the client hides
-    // out-of-state buttons, but a stale/crafted request could still target one.
-    if (!actionVisible(action, record)) {
-      res.status(409).json({ error: `action '${action.id}' is not available for item '${req.params.itemId}' in its current state` });
-      return;
-    }
-    // `kind: "mutate"` needs no template / seed / LLM — the host applies the
-    // declarative write itself (`when` was just enforced above, same
-    // visibility-is-authorization rule as the seeded kinds).
-    if (action.kind === "mutate") {
-      // Schema validation already rejects mutate actions on a dataSource
-      // collection; this is the defensive server-side twin.
-      if (!collectionWritable(collection)) {
-        res.status(405).json({ error: readOnlyRefusal(collection.slug) });
-        return;
-      }
-      await respondForMutateAction(res, collection, action, req.params.itemId, req.body as { params?: unknown } | undefined);
-      return;
-    }
-    const template = await readSkillTemplate(collection.skillDir, action.template);
-    if (template === null) {
-      res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
-      return;
-    }
-    // Pass the collection paths so the seed prompt carries the <collection_paths>
-    // block — the skill template needs skillDir/dataPath to find its files.
-    const paths = promptPathsFor(collection, getWorkspaceRoot());
-    res.json({ prompt: buildActionSeedPrompt(record, template, paths), role: action.role });
-  } catch (err) {
-    log.warn("collections", "item action seed failed", {
-      slug: collection.slug,
-      itemId: req.params.itemId,
-      actionId: req.params.actionId,
-      error: errorMessage(err),
-    });
-    res.status(500).json({ error: errorMessage(err) });
+  const record = await storeFor(collection).read(req.params.itemId);
+  if (!record) {
+    res.status(404).json({ error: `item '${req.params.itemId}' not found` });
+    return;
   }
+  // The action's `when` predicate is the authorization rule: the client hides
+  // out-of-state buttons, but a stale/crafted request could still target one.
+  if (!actionVisible(action, record)) {
+    res.status(409).json({ error: `action '${action.id}' is not available for item '${req.params.itemId}' in its current state` });
+    return;
+  }
+  // `kind: "mutate"` needs no template / seed / LLM — the host applies the
+  // declarative write itself (`when` was just enforced above, same
+  // visibility-is-authorization rule as the seeded kinds).
+  if (action.kind === "mutate") {
+    // Schema validation already rejects mutate actions on a dataSource
+    // collection; this is the defensive server-side twin.
+    if (!collectionWritable(collection)) {
+      res.status(405).json({ error: readOnlyRefusal(collection.slug) });
+      return;
+    }
+    await respondForMutateAction(res, collection, action, req.params.itemId, req.body as { params?: unknown } | undefined);
+    return;
+  }
+  const template = await readSkillTemplate(collection.skillDir, action.template);
+  if (template === null) {
+    res.status(500).json({ error: `template '${action.template}' for action '${action.id}' could not be read` });
+    return;
+  }
+  // Pass the collection paths so the seed prompt carries the <collection_paths>
+  // block — the skill template needs skillDir/dataPath to find its files.
+  const paths = promptPathsFor(collection, getWorkspaceRoot());
+  res.json({ prompt: buildActionSeedPrompt(record, template, paths), role: action.role });
 };
 
 // Collection-level action (operates over all records).
 const collectionActionHandler: RequestHandler<{ slug: string; actionId: string }> = async (req, res) => {
-  const collection = await loadCollection(req.params.slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-    return;
-  }
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
   const action = collection.schema.collectionActions?.find((entry) => entry.id === req.params.actionId);
   if (!action) {
     res.status(404).json({ error: `collection action '${req.params.actionId}' not found on collection '${collection.slug}'` });
@@ -589,37 +541,25 @@ const collectionActionHandler: RequestHandler<{ slug: string; actionId: string }
 // The custom view's raw HTML, read from the staging path via the package's
 // path-safe reader. The frontend renders it sandboxed (token injected).
 const viewFileHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  try {
-    const { slug } = req.params;
-    const viewId = typeof req.query.id === "string" ? req.query.id : "";
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      res.status(404).json({ error: `collection '${slug}' not found` });
-      return;
-    }
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) {
-      res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
-      return;
-    }
-    const html = await readCustomViewHtml(collection, view.file);
-    if (html === null) {
-      res.status(404).json({ error: `view file '${view.file}' not found` });
-      return;
-    }
-    // This is LLM-authored HTML. The frontend renders it sandboxed via a
-    // fetch()→srcdoc iframe (not by navigating here), so harden the raw response
-    // against DIRECT navigation: `sandbox` gives it an opaque origin (its scripts
-    // can't reach the app origin's /api/*), and `nosniff` stops re-interpretation.
-    // The iframe path is unaffected — a fetch() reads the body regardless of this
-    // response-level CSP.
-    res.setHeader("X-Content-Type-Options", "nosniff");
-    res.setHeader("Content-Security-Policy", "sandbox");
-    res.type("text/html").send(html);
-  } catch (err) {
-    log.warn("collections", "view-file read failed", { slug: req.params.slug, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+  const viewId = typeof req.query.id === "string" ? req.query.id : "";
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
+  const view = resolveView(res, collection, viewId);
+  if (!view) return;
+  const html = await readCustomViewHtml(collection, view.file);
+  if (html === null) {
+    res.status(404).json({ error: `view file '${view.file}' not found` });
+    return;
   }
+  // This is LLM-authored HTML. The frontend renders it sandboxed via a
+  // fetch()→srcdoc iframe (not by navigating here), so harden the raw response
+  // against DIRECT navigation: `sandbox` gives it an opaque origin (its scripts
+  // can't reach the app origin's /api/*), and `nosniff` stops re-interpretation.
+  // The iframe path is unaffected — a fetch() reads the body regardless of this
+  // response-level CSP.
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Content-Security-Policy", "sandbox");
+  res.type("text/html").send(html);
 };
 
 // Serve a mobile (`target: "mobile"`) custom view wrapped into its sandboxed
@@ -630,23 +570,15 @@ const remoteViewHandler: RequestHandler<{ slug: string }> = async (req, res) => 
   const { slug } = req.params;
   const viewId = typeof req.query.id === "string" ? req.query.id : "";
   const locale = typeof req.query.locale === "string" ? req.query.locale : "";
-  const collection = await loadCollection(slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${slug}' not found` });
+  const collection = await resolveCollection(res, slug);
+  if (!collection) return;
+  const result = await buildRemoteView(collection, viewId, locale);
+  if (result.kind !== "ok") {
+    const notFound = result.kind === "view-not-found" || result.kind === "file-missing";
+    res.status(notFound ? 404 : 400).json({ error: remoteViewFailureMessage(result, slug) });
     return;
   }
-  try {
-    const result = await buildRemoteView(collection, viewId, locale);
-    if (result.kind !== "ok") {
-      const notFound = result.kind === "view-not-found" || result.kind === "file-missing";
-      res.status(notFound ? 404 : 400).json({ error: remoteViewFailureMessage(result, slug) });
-      return;
-    }
-    res.json({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
-  } catch (err) {
-    log.warn("collections", "remote-view build failed", { slug, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  res.json({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
 };
 
 // Apply one update/delete on behalf of a writable mobile view — the desktop
@@ -660,22 +592,14 @@ const remoteViewMutateHandler: RequestHandler<{ slug: string; viewId: string }> 
     res.status(400).json({ error: "invalid mutate request — expected { op: 'update'|'delete', id, patch? }" });
     return;
   }
-  const collection = await loadCollection(slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${slug}' not found` });
+  const collection = await resolveCollection(res, slug);
+  if (!collection) return;
+  const result = await mutateRemoteView(collection, viewId, request);
+  if (result.kind !== "ok") {
+    res.status(mutateStatus(result.kind)).json({ error: mutateRemoteViewFailureMessage(result, slug) });
     return;
   }
-  try {
-    const result = await mutateRemoteView(collection, viewId, request);
-    if (result.kind !== "ok") {
-      res.status(mutateStatus(result.kind)).json({ error: mutateRemoteViewFailureMessage(result, slug) });
-      return;
-    }
-    res.json(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
-  } catch (err) {
-    log.warn("collections", "remote-view mutate failed", { slug, viewId, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  res.json(result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item });
 };
 
 // One page of a mobile view's records, with its declared image fields inlined
@@ -685,55 +609,36 @@ const remoteViewMutateHandler: RequestHandler<{ slug: string; viewId: string }> 
 const remoteViewItemsHandler: RequestHandler<{ slug: string; viewId: string }> = async (req, res) => {
   const { slug, viewId } = req.params;
   const request = { offset: clampViewOffset(req.query.offset), limit: clampViewLimit(req.query.limit), fields: normalizeFields(csvParam(req.query.fields)) };
-  const collection = await loadCollection(slug);
-  if (!collection) {
-    res.status(404).json({ error: `collection '${slug}' not found` });
+  const collection = await resolveCollection(res, slug);
+  if (!collection) return;
+  const result = await remoteViewItems(collection, viewId, request);
+  if (result.kind !== "ok") {
+    res.status(result.kind === "view-not-found" ? 404 : 400).json({ error: remoteViewItemsFailureMessage(result, slug) });
     return;
   }
-  try {
-    const result = await remoteViewItems(collection, viewId, request);
-    if (result.kind !== "ok") {
-      res.status(result.kind === "view-not-found" ? 404 : 400).json({ error: remoteViewItemsFailureMessage(result, slug) });
-      return;
-    }
-    res.json({ page: result.page, inlined: result.inlined, omitted: result.omitted });
-  } catch (err) {
-    log.warn("collections", "remote-view items failed", { slug, viewId, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  res.json({ page: result.page, inlined: result.inlined, omitted: result.omitted });
 };
 
 // Mint a scoped token for a custom view, clamped to what the view declared so a
 // read-only view can never obtain a write token.
 const viewTokenHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  try {
-    const { slug } = req.params;
-    const body = (req.body ?? {}) as { viewId?: unknown; capabilities?: unknown };
-    const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
-    if (!viewId) {
-      res.status(400).json({ error: "`viewId` is required" });
-      return;
-    }
-    const collection = await loadCollection(slug);
-    if (!collection) {
-      res.status(404).json({ error: `collection '${slug}' not found` });
-      return;
-    }
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) {
-      res.status(404).json({ error: `custom view '${viewId}' not found on collection '${slug}'` });
-      return;
-    }
-    // The write tier is wired below (PUT /view-data), so grant exactly what the
-    // view declared. `clampCapabilities` defaults the requested set to the declared
-    // set, so a `["read"]` view still can never obtain a `write` token.
-    const granted = clampCapabilities(view.capabilities as ViewCapability[] | undefined, undefined);
-    const minted = mintViewToken(slug, granted);
-    res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
-  } catch (err) {
-    log.warn("collections", "view-token mint failed", { slug: req.params.slug, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+  const { slug } = req.params;
+  const body = (req.body ?? {}) as { viewId?: unknown; capabilities?: unknown };
+  const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
+  if (!viewId) {
+    res.status(400).json({ error: "`viewId` is required" });
+    return;
   }
+  const collection = await resolveCollection(res, slug);
+  if (!collection) return;
+  const view = resolveView(res, collection, viewId);
+  if (!view) return;
+  // The write tier is wired below (PUT /view-data), so grant exactly what the
+  // view declared. `clampCapabilities` defaults the requested set to the declared
+  // set, so a `["read"]` view still can never obtain a `write` token.
+  const granted = clampCapabilities(view.capabilities as ViewCapability[] | undefined, undefined);
+  const minted = mintViewToken(slug, granted);
+  res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
 };
 
 // CORS for the view-data endpoint: the sandboxed iframe has an opaque origin, so
@@ -750,18 +655,10 @@ const viewDataCors = (_req: Request, res: Response, next: NextFunction): void =>
 // Scoped read: the view's enriched records as `{ items }` — the shape custom views
 // fetch from `window.__MC_VIEW.dataUrl`. Guarded by the view token only.
 const viewDataGetHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  try {
-    const collection = await loadCollection(req.params.slug);
-    if (!collection) {
-      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-      return;
-    }
-    const items = await enrichItems(collection, await storeFor(collection).list());
-    res.json({ items });
-  } catch (err) {
-    log.warn("collections", "view-data read failed", { slug: req.params.slug, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
-  }
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
+  const items = await enrichItems(collection, await storeFor(collection).list());
+  res.json({ items });
 };
 
 // Scoped write: apply per-record updates from a custom view (e.g. the vocabulary
@@ -771,39 +668,31 @@ const viewDataGetHandler: RequestHandler<{ slug: string }> = async (req, res) =>
 // response envelope is `{ written, rejected }` — `written` is the id of each stored
 // record, `rejected` a `{ id, problem }` per row that failed — the shape views read.
 const viewDataPutHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  try {
-    const collection = await loadCollection(req.params.slug);
-    if (!collection) {
-      res.status(404).json({ error: `collection '${req.params.slug}' not found` });
-      return;
-    }
-    if (!collectionWritable(collection)) {
-      res.status(405).json({ error: readOnlyRefusal(collection.slug) });
-      return;
-    }
-    const body = (req.body ?? {}) as { items?: unknown; mode?: unknown };
-    if (!Array.isArray(body.items)) {
-      res.status(400).json({ error: "`items` must be an array" });
-      return;
-    }
-    const mode: ViewWriteMode = body.mode === undefined ? "upsert" : (body.mode as ViewWriteMode);
-    if (!VIEW_WRITE_MODES.includes(mode)) {
-      const modeList = VIEW_WRITE_MODES.map((m) => `"${m}"`).join(", ");
-      res.status(400).json({ error: `\`mode\` must be one of ${modeList}` });
-      return;
-    }
-    const written: string[] = [];
-    const rejected: Array<{ id: string; problem: string }> = [];
-    for (const raw of body.items) {
-      const outcome = await writeViewItem(collection, raw, mode);
-      if ("writtenId" in outcome) written.push(outcome.writtenId);
-      else rejected.push(outcome.rejected);
-    }
-    res.json({ written, rejected });
-  } catch (err) {
-    log.warn("collections", "view-data write failed", { slug: req.params.slug, error: errorMessage(err) });
-    res.status(500).json({ error: errorMessage(err) });
+  const collection = await resolveCollection(res, req.params.slug);
+  if (!collection) return;
+  if (!collectionWritable(collection)) {
+    res.status(405).json({ error: readOnlyRefusal(collection.slug) });
+    return;
   }
+  const body = (req.body ?? {}) as { items?: unknown; mode?: unknown };
+  if (!Array.isArray(body.items)) {
+    res.status(400).json({ error: "`items` must be an array" });
+    return;
+  }
+  const mode: ViewWriteMode = body.mode === undefined ? "upsert" : (body.mode as ViewWriteMode);
+  if (!VIEW_WRITE_MODES.includes(mode)) {
+    const modeList = VIEW_WRITE_MODES.map((m) => `"${m}"`).join(", ");
+    res.status(400).json({ error: `\`mode\` must be one of ${modeList}` });
+    return;
+  }
+  const written: string[] = [];
+  const rejected: Array<{ id: string; problem: string }> = [];
+  for (const raw of body.items) {
+    const outcome = await writeViewItem(collection, raw, mode);
+    if ("writtenId" in outcome) written.push(outcome.writtenId);
+    else rejected.push(outcome.rejected);
+  }
+  res.json({ written, rejected });
 };
 
 /** Per-slug in-flight cap for view-issued aggregation queries — each one
@@ -858,34 +747,34 @@ const viewDataQueryHandler: RequestHandler<{ slug: string }> = async (req, res) 
  *  One app.METHOD(path, handler) per endpoint — the handlers live above. */
 export function mountCollectionRoutes(app: Express): void {
   // Registered before the ":slug" routes so "registry" is never captured as a slug.
-  app.get("/api/collections/registry/list", registryListHandler);
-  app.post("/api/collections/registry/import", registryImportHandler);
+  app.get("/api/collections/registry/list", guarded("registry list", registryListHandler));
+  app.post("/api/collections/registry/import", guarded("registry import", registryImportHandler));
 
-  app.delete("/api/collections/:slug/views/:viewId", viewDeleteHandler);
-  app.delete("/api/collections/:slug", collectionDeleteHandler);
+  app.delete("/api/collections/:slug/views/:viewId", guarded("view delete", viewDeleteHandler));
+  app.delete("/api/collections/:slug", guarded("collection delete", collectionDeleteHandler));
 
-  app.get("/api/collections/list", listHandler);
-  app.get("/api/collections/ontology", ontologyHandler);
-  app.get("/api/collections/:slug/detail", detailHandler);
+  app.get("/api/collections/list", guarded("list", listHandler));
+  app.get("/api/collections/ontology", guarded("ontology", ontologyHandler));
+  app.get("/api/collections/:slug/detail", guarded("detail", detailHandler));
 
-  app.post("/api/collections/:slug/items", itemCreateHandler);
-  app.put("/api/collections/:slug/items/:itemId", itemUpdateHandler);
-  app.delete("/api/collections/:slug/items/:itemId", itemDeleteHandler);
+  app.post("/api/collections/:slug/items", guarded("item create", itemCreateHandler));
+  app.put("/api/collections/:slug/items/:itemId", guarded("item update", itemUpdateHandler));
+  app.delete("/api/collections/:slug/items/:itemId", guarded("item delete", itemDeleteHandler));
 
-  app.post("/api/collections/:slug/items/:itemId/actions/:actionId", itemActionHandler);
-  app.post("/api/collections/:slug/actions/:actionId", collectionActionHandler);
+  app.post("/api/collections/:slug/items/:itemId/actions/:actionId", guarded("item action seed", itemActionHandler));
+  app.post("/api/collections/:slug/actions/:actionId", guarded("collection action seed", collectionActionHandler));
 
-  app.get("/api/collections/:slug/view-file", viewFileHandler);
-  app.get("/api/collections/:slug/remote-view", remoteViewHandler);
-  app.post("/api/collections/:slug/remote-view/:viewId/mutate", remoteViewMutateHandler);
-  app.get("/api/collections/:slug/remote-view/:viewId/items", remoteViewItemsHandler);
+  app.get("/api/collections/:slug/view-file", guarded("view-file read", viewFileHandler));
+  app.get("/api/collections/:slug/remote-view", guarded("remote-view build", remoteViewHandler));
+  app.post("/api/collections/:slug/remote-view/:viewId/mutate", guarded("remote-view mutate", remoteViewMutateHandler));
+  app.get("/api/collections/:slug/remote-view/:viewId/items", guarded("remote-view items", remoteViewItemsHandler));
 
-  app.post("/api/collections/:slug/view-token", viewTokenHandler);
+  app.post("/api/collections/:slug/view-token", guarded("view-token mint", viewTokenHandler));
   app.options("/api/collections/:slug/view-data", viewDataCors, (_req: Request, res: Response) => {
     res.status(204).end();
   });
-  app.get("/api/collections/:slug/view-data", viewDataCors, requireViewToken("read"), viewDataGetHandler);
-  app.put("/api/collections/:slug/view-data", viewDataCors, requireViewToken("write"), viewDataPutHandler);
+  app.get("/api/collections/:slug/view-data", viewDataCors, requireViewToken("read"), guarded("view-data read", viewDataGetHandler));
+  app.put("/api/collections/:slug/view-data", viewDataCors, requireViewToken("write"), guarded("view-data write", viewDataPutHandler));
   app.options("/api/collections/:slug/view-data/query", viewDataCors, (_req: Request, res: Response) => {
     res.status(204).end();
   });


### PR DESCRIPTION
## Summary

`jscpd` reported **13 clones / 107 duplicated lines** inside `server/backends/collections.ts` — all of it repeated Express route plumbing. Three helpers replace it.

Clones in this file: **13 → 2**. Lines: **893 → 782**. Pure refactor, no behavior change.

First PR of several for #452; also adds the shared plan file.

## Items to Confirm / Review

- **`guarded()` changes what gets logged.** Each handler used to log a hand-picked context object; now it logs `req.params`. The one real loss: `item create` used to log the *generated* item id (not a route param), so that id no longer appears in the 500 log line. Everything else is equivalent. Please confirm that's acceptable.
- **`guarded()` now strips CR/LF from logged route params for every route.** Previously only `respondForMutateAction` and `viewDataQueryHandler` did this. This is a deliberate small hardening (log-forging), not just a move — flagging it as an intentional behavior delta.
- **`viewDataQueryHandler` was deliberately left unwrapped.** It answers a *fixed* error message because raw engine errors can carry host paths and a scoped custom view is not a trusted audience. Wrapping it would have been wrong; please sanity-check that reasoning.
- **`isCommonStoreFailure` is a type predicate**, relied on so the `ok` branch still narrows to the variant carrying `item`. `vue-tsc -b` and `tsc -p tsconfig.server.json` both accept it — worth a look that it reads clearly.
- `itemUpdate`'s `conflict` case still maps to **500** (`"unexpected conflict on update"`) while `itemCreate`'s maps to **409**. That asymmetry is pre-existing and intentionally preserved.

## User Prompt

> jscpd ででるduplicat code。できるだけなおせるものはなおしてほしい
>
> こまかくPR

## Implementation

Three helpers absorb the repetition:

| Helper | Replaces |
|---|---|
| `resolveCollection(res, slug)` | the load-or-404 preamble, repeated verbatim in **12** handlers |
| `guarded(op, handler)` | **15** identical `catch → log.warn + 500` tails; applied at the mount site so the op label sits next to its route |
| `isCommonStoreFailure()` / `respondForStoreFailure()` | the `invalid-id` → 400 and `path-escape` → 403 mappings shared by the item create / update / delete routes |

`resolveCollection` and `resolveView` return `null` to mean *the response is already sent* — the docstring says so and every caller returns immediately.

`detailHandler` keeps its inner narrow `try/catch` around `validateCollectionRecords`: that one is intentionally best-effort so a validation failure can't turn a good detail response into a 500.

## Verification

- `yarn test` (collections, collection-tool, viewToken): **67 passed**
- full `yarn test` baseline of 131 files / 1438 tests unaffected — this file's routes are covered by 69 status assertions in `collections.spec.ts`
- `eslint` clean, `prettier` clean, `vue-tsc -b` clean

Note: `yarn typecheck:server` fails on `server/infra/web-push.ts` — that failure is **already on `main`** (upstream `@mulmobridge/web-push` type drift) and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)