### PR TITLE
refactor: share the dropdown controller and header-menu styles

### DIFF
--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onUnmounted, watch, useTemplateRef } from "vue";
+import { ref, watch, useTemplateRef } from "vue";
+import { useDropdownMenu } from "../composables/useDropdownMenu";
 import type { RunCommand } from "./runCommand";
 
 // A header dropdown that lists a directory's script.json entries and emits the one
@@ -14,7 +15,6 @@ interface RunnableScript {
 const props = defineProps<{ cwd: string | null }>();
 const emit = defineEmits<{ (e: "run", command: RunCommand): void }>();
 
-const open = ref(false);
 const scripts = ref<RunnableScript[]>([]);
 // The resolved dir the listed scripts belong to (the server may fall back from a
 // bad path); the picked command runs there.
@@ -22,6 +22,7 @@ const scriptsCwd = ref<string | null>(null);
 let req = 0; // request token: drop out-of-order responses
 
 const rootRef = useTemplateRef<HTMLElement>("root");
+const { open, close, toggle } = useDropdownMenu(rootRef);
 
 async function loadScripts() {
   // Close first: a cwd change invalidates the open dropdown (and would otherwise
@@ -53,102 +54,21 @@ async function loadScripts() {
 }
 watch(() => props.cwd, loadScripts, { immediate: true });
 
-function onOutside(e: PointerEvent) {
-  if (rootRef.value && !rootRef.value.contains(e.target as Node)) close();
-}
-function onEscape(e: KeyboardEvent) {
-  if (e.key === "Escape") close();
-}
-
-function openMenu() {
-  open.value = true;
-  window.addEventListener("pointerdown", onOutside);
-  window.addEventListener("keydown", onEscape);
-}
-function close() {
-  open.value = false;
-  window.removeEventListener("pointerdown", onOutside);
-  window.removeEventListener("keydown", onEscape);
-}
-function toggle() {
-  if (open.value) close();
-  else openMenu();
-}
-
 function pick(s: RunnableScript) {
   emit("run", { source: "script", index: s.index, label: s.label, cwd: scriptsCwd.value ?? props.cwd });
   close();
 }
-
-onUnmounted(close);
 </script>
 
 <template>
-  <div v-if="scripts.length" ref="root" class="run-menu">
-    <button class="run-trigger" :class="{ active: open }" :aria-expanded="open" aria-haspopup="menu" title="Run a script in a spare terminal" @click="toggle">
+  <div v-if="scripts.length" ref="root" class="menu-root">
+    <button class="menu-trigger" :class="{ active: open }" :aria-expanded="open" aria-haspopup="menu" title="Run a script in a spare terminal" @click="toggle">
       ▶ Run ▾
     </button>
-    <div v-if="open" class="run-pop" role="menu">
-      <button v-for="s in scripts" :key="s.index" class="run-item" role="menuitem" :title="s.command" @click="pick(s)">▶ {{ s.label }}</button>
+    <div v-if="open" class="menu-pop" role="menu">
+      <button v-for="s in scripts" :key="s.index" class="menu-item" role="menuitem" :title="s.command" @click="pick(s)">▶ {{ s.label }}</button>
     </div>
   </div>
 </template>
 
-<style scoped>
-.run-menu {
-  position: relative;
-  display: inline-flex;
-}
-
-/* Matches the grid toolbar buttons (.tb-btn lives in GridView's scoped styles). */
-.run-trigger {
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-  color: var(--text-secondary);
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  line-height: 1;
-  padding: 5px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.run-trigger:hover,
-.run-trigger.active {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.run-pop {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 20;
-  min-width: 180px;
-  max-height: 320px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  padding: 4px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
-}
-
-.run-item {
-  text-align: left;
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 12px;
-  padding: 6px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  white-space: nowrap;
-}
-.run-item:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-</style>
+<style scoped src="./headerMenu.css"></style>

--- a/src/components/SkillMenu.vue
+++ b/src/components/SkillMenu.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onUnmounted, watch, useTemplateRef } from "vue";
+import { ref, watch, useTemplateRef } from "vue";
+import { useDropdownMenu } from "../composables/useDropdownMenu";
 
 // A header dropdown that lists the open project's discoverable skills (user +
 // project `.claude/skills`) and emits the slug picked, so the parent can invoke it
@@ -14,11 +15,11 @@ interface DiscoveredSkill {
 const props = defineProps<{ cwd: string | null }>();
 const emit = defineEmits<{ (e: "skill", slug: string): void }>();
 
-const open = ref(false);
 const skills = ref<DiscoveredSkill[]>([]);
 let req = 0; // request token: drop out-of-order responses
 
 const rootRef = useTemplateRef<HTMLElement>("root");
+const { open, close, toggle } = useDropdownMenu(rootRef);
 
 async function loadSkills() {
   // Close first: a cwd change invalidates the open dropdown (and would otherwise
@@ -45,40 +46,16 @@ async function loadSkills() {
 }
 watch(() => props.cwd, loadSkills, { immediate: true });
 
-function onOutside(e: PointerEvent) {
-  if (rootRef.value && !rootRef.value.contains(e.target as Node)) close();
-}
-function onEscape(e: KeyboardEvent) {
-  if (e.key === "Escape") close();
-}
-
-function openMenu() {
-  open.value = true;
-  window.addEventListener("pointerdown", onOutside);
-  window.addEventListener("keydown", onEscape);
-}
-function close() {
-  open.value = false;
-  window.removeEventListener("pointerdown", onOutside);
-  window.removeEventListener("keydown", onEscape);
-}
-function toggle() {
-  if (open.value) close();
-  else openMenu();
-}
-
 function pick(s: DiscoveredSkill) {
   emit("skill", s.slug);
   close();
 }
-
-onUnmounted(close);
 </script>
 
 <template>
-  <div v-if="skills.length" ref="root" class="skill-menu">
+  <div v-if="skills.length" ref="root" class="menu-root">
     <button
-      class="skill-trigger"
+      class="menu-trigger"
       :class="{ active: open }"
       :aria-expanded="open"
       aria-haspopup="menu"
@@ -87,67 +64,10 @@ onUnmounted(close);
     >
       ⚡ Skill ▾
     </button>
-    <div v-if="open" class="skill-pop" role="menu">
-      <button v-for="s in skills" :key="s.slug" class="skill-item" role="menuitem" :title="s.description" @click="pick(s)">⚡ {{ s.slug }}</button>
+    <div v-if="open" class="menu-pop" role="menu">
+      <button v-for="s in skills" :key="s.slug" class="menu-item" role="menuitem" :title="s.description" @click="pick(s)">⚡ {{ s.slug }}</button>
     </div>
   </div>
 </template>
 
-<style scoped>
-.skill-menu {
-  position: relative;
-  display: inline-flex;
-}
-
-/* Matches the grid toolbar buttons (.tb-btn lives in GridView's scoped styles). */
-.skill-trigger {
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-  color: var(--text-secondary);
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  line-height: 1;
-  padding: 5px 10px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.skill-trigger:hover,
-.skill-trigger.active {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.skill-pop {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  z-index: 20;
-  min-width: 180px;
-  max-height: 320px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  padding: 4px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
-}
-
-.skill-item {
-  text-align: left;
-  border: none;
-  background: none;
-  color: var(--text-secondary);
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 12px;
-  padding: 6px 8px;
-  border-radius: 4px;
-  cursor: pointer;
-  white-space: nowrap;
-}
-.skill-item:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-</style>
+<style scoped src="./headerMenu.css"></style>

--- a/src/components/headerMenu.css
+++ b/src/components/headerMenu.css
@@ -1,0 +1,56 @@
+.menu-root {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Matches the grid toolbar buttons (.tb-btn lives in GridView's scoped styles). */
+.menu-trigger {
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.menu-trigger:hover,
+.menu-trigger.active {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.menu-pop {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 20;
+  min-width: 180px;
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.menu-item {
+  text-align: left;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.menu-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}

--- a/src/composables/useDropdownMenu.ts
+++ b/src/composables/useDropdownMenu.ts
@@ -1,0 +1,38 @@
+// Open/close state for a header dropdown, dismissed by a pointerdown outside the
+// menu's root element or by Escape. The window listeners are attached only while
+// open and are dropped on unmount, so a menu whose trigger disappears (e.g. its list
+// emptied by a cwd change) cannot leave them attached.
+import { ref, onUnmounted, type ShallowRef } from "vue";
+
+export function useDropdownMenu(rootRef: Readonly<ShallowRef<HTMLElement | null>>, onOpen?: () => void) {
+  const open = ref(false);
+
+  function onOutside(event: PointerEvent) {
+    const root = rootRef.value;
+    const target = event.target instanceof Node ? event.target : null;
+    if (root && !root.contains(target)) close();
+  }
+  function onEscape(event: KeyboardEvent) {
+    if (event.key === "Escape") close();
+  }
+
+  function openMenu() {
+    open.value = true;
+    window.addEventListener("pointerdown", onOutside);
+    window.addEventListener("keydown", onEscape);
+    onOpen?.();
+  }
+  function close() {
+    open.value = false;
+    window.removeEventListener("pointerdown", onOutside);
+    window.removeEventListener("keydown", onEscape);
+  }
+  function toggle() {
+    if (open.value) close();
+    else openMenu();
+  }
+
+  onUnmounted(close);
+
+  return { open, close, toggle };
+}

--- a/test/src/components/RunMenu.spec.ts
+++ b/test/src/components/RunMenu.spec.ts
@@ -26,15 +26,15 @@ describe("RunMenu", () => {
 
   it("shows the trigger once the project's scripts have loaded", async () => {
     const w = await mountMenu();
-    expect(w.find(".run-trigger").exists()).toBe(true);
-    expect(w.find(".run-pop").exists()).toBe(false); // closed until clicked
+    expect(w.find(".menu-trigger").exists()).toBe(true);
+    expect(w.find(".menu-pop").exists()).toBe(false); // closed until clicked
   });
 
   it("renders nothing when the project has no scripts (no file, no button)", async () => {
     mockFetch([]);
     const w = await mountMenu();
-    expect(w.find(".run-trigger").exists()).toBe(false);
-    expect(w.find(".run-menu").exists()).toBe(false);
+    expect(w.find(".menu-trigger").exists()).toBe(false);
+    expect(w.find(".menu-root").exists()).toBe(false);
   });
 
   it("does not fetch (no button) while cwd is unresolved, avoiding default-workspace scripts", async () => {
@@ -43,37 +43,37 @@ describe("RunMenu", () => {
     const w = mount(RunMenu, { props: { cwd: null } });
     await flushPromises();
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(w.find(".run-trigger").exists()).toBe(false);
+    expect(w.find(".menu-trigger").exists()).toBe(false);
   });
 
   it("lists the scripts when opened", async () => {
     const w = await mountMenu();
-    await w.find(".run-trigger").trigger("click");
-    const items = w.findAll(".run-item");
+    await w.find(".menu-trigger").trigger("click");
+    const items = w.findAll(".menu-item");
     expect(items).toHaveLength(2);
     expect(items[0].text()).toContain("Dev server");
   });
 
   it("closes when cwd changes and does not reappear pre-opened", async () => {
     const w = await mountMenu();
-    await w.find(".run-trigger").trigger("click");
-    expect(w.find(".run-pop").exists()).toBe(true);
+    await w.find(".menu-trigger").trigger("click");
+    expect(w.find(".menu-pop").exists()).toBe(true);
 
     await w.setProps({ cwd: null }); // unresolved → cleared + closed
     await flushPromises();
-    expect(w.find(".run-menu").exists()).toBe(false);
+    expect(w.find(".menu-root").exists()).toBe(false);
 
     await w.setProps({ cwd: "/proj2" }); // resolves again
     await flushPromises();
-    expect(w.find(".run-trigger").exists()).toBe(true);
-    expect(w.find(".run-pop").exists()).toBe(false); // not pre-opened
+    expect(w.find(".menu-trigger").exists()).toBe(true);
+    expect(w.find(".menu-pop").exists()).toBe(false); // not pre-opened
   });
 
   it("emits the picked script with the server-resolved cwd, then closes", async () => {
     const w = await mountMenu();
-    await w.find(".run-trigger").trigger("click");
-    await w.findAll(".run-item")[1].trigger("click");
+    await w.find(".menu-trigger").trigger("click");
+    await w.findAll(".menu-item")[1].trigger("click");
     expect(w.emitted("run")?.[0]?.[0]).toEqual({ source: "script", index: 1, label: "Unit tests", cwd: "/home/me/proj" });
-    expect(w.find(".run-pop").exists()).toBe(false); // closed after picking
+    expect(w.find(".menu-pop").exists()).toBe(false); // closed after picking
   });
 });

--- a/test/src/components/SkillMenu.spec.ts
+++ b/test/src/components/SkillMenu.spec.ts
@@ -24,15 +24,15 @@ describe("SkillMenu", () => {
 
   it("shows the trigger once the project's skills have loaded", async () => {
     const w = await mountMenu();
-    expect(w.find(".skill-trigger").exists()).toBe(true);
-    expect(w.find(".skill-pop").exists()).toBe(false); // closed until clicked
+    expect(w.find(".menu-trigger").exists()).toBe(true);
+    expect(w.find(".menu-pop").exists()).toBe(false); // closed until clicked
   });
 
   it("renders nothing when the project has no skills (no skills, no button)", async () => {
     mockFetch([]);
     const w = await mountMenu();
-    expect(w.find(".skill-trigger").exists()).toBe(false);
-    expect(w.find(".skill-menu").exists()).toBe(false);
+    expect(w.find(".menu-trigger").exists()).toBe(false);
+    expect(w.find(".menu-root").exists()).toBe(false);
   });
 
   it("does not fetch (no button) while cwd is unresolved, avoiding default-workspace skills", async () => {
@@ -41,13 +41,13 @@ describe("SkillMenu", () => {
     const w = mount(SkillMenu, { props: { cwd: null } });
     await flushPromises();
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(w.find(".skill-trigger").exists()).toBe(false);
+    expect(w.find(".menu-trigger").exists()).toBe(false);
   });
 
   it("lists the skills when opened, with the description as tooltip", async () => {
     const w = await mountMenu();
-    await w.find(".skill-trigger").trigger("click");
-    const items = w.findAll(".skill-item");
+    await w.find(".menu-trigger").trigger("click");
+    const items = w.findAll(".menu-item");
     expect(items).toHaveLength(2);
     expect(items[0].text()).toContain("commit");
     expect(items[0].attributes("title")).toBe("Write a commit message");
@@ -55,24 +55,24 @@ describe("SkillMenu", () => {
 
   it("closes when cwd changes and does not reappear pre-opened", async () => {
     const w = await mountMenu();
-    await w.find(".skill-trigger").trigger("click");
-    expect(w.find(".skill-pop").exists()).toBe(true);
+    await w.find(".menu-trigger").trigger("click");
+    expect(w.find(".menu-pop").exists()).toBe(true);
 
     await w.setProps({ cwd: null }); // unresolved → cleared + closed
     await flushPromises();
-    expect(w.find(".skill-menu").exists()).toBe(false);
+    expect(w.find(".menu-root").exists()).toBe(false);
 
     await w.setProps({ cwd: "/proj2" }); // resolves again
     await flushPromises();
-    expect(w.find(".skill-trigger").exists()).toBe(true);
-    expect(w.find(".skill-pop").exists()).toBe(false); // not pre-opened
+    expect(w.find(".menu-trigger").exists()).toBe(true);
+    expect(w.find(".menu-pop").exists()).toBe(false); // not pre-opened
   });
 
   it("emits the picked skill's slug, then closes", async () => {
     const w = await mountMenu();
-    await w.find(".skill-trigger").trigger("click");
-    await w.findAll(".skill-item")[1].trigger("click");
+    await w.find(".menu-trigger").trigger("click");
+    await w.findAll(".menu-item")[1].trigger("click");
     expect(w.emitted("skill")?.[0]?.[0]).toBe("review");
-    expect(w.find(".skill-pop").exists()).toBe(false); // closed after picking
+    expect(w.find(".menu-pop").exists()).toBe(false); // closed after picking
   });
 });


### PR DESCRIPTION
## Summary

`RunMenu.vue` and `SkillMenu.vue` carried a **byte-identical** outside-click/Escape dropdown controller and near-identical scoped CSS that differed only in a `run-`/`skill-` class prefix — jscpd flagged **50 duplicated CSS lines + 25 TS lines**.

- `useDropdownMenu(rootRef)` — owns `open`/`close`/`toggle` and the document-listener lifecycle
- `headerMenu.css` — the shared chrome, consumed via `<style scoped src="./headerMenu.css">`
- classes renamed to `menu-root` / `menu-trigger` / `menu-pop` / `menu-item`

Each component shrank by ~96 lines. Pure refactor, no behavior change. Part of #452.

## Items to Confirm / Review

- **`<style scoped src>` was verified, not assumed.** `vite build` emits two *separately scoped* copies — `.menu-trigger[data-v-20171171]` and `.menu-trigger[data-v-8f4617e0]` — so each component keeps its own scope ID and the shared file does not leak styles across components. Worth confirming you're happy with this mechanism, since it's new to the codebase and it does duplicate the rules in the built CSS (by design — that's what preserves scoping).
- **The class rename touches the two spec files.** I grepped the whole tree for the old names; nothing else referenced them. Note `run-menu` appears in `App.vue` and `TerminalCell.vue` but as a **prop on `Terminal`**, not a CSS class — deliberately left alone. Please double-check that call.
- **`loadScripts` / `loadSkills` were deliberately NOT merged.** They look parallel (request token, null-cwd guard, try/catch) but hit different endpoints with different response shapes, and RunMenu alone tracks a server-resolved `scriptsCwd` that its emitted command must carry. Merging would need a generic fetcher plus a per-caller response mapper — more machinery than the duplication costs.
- **Follow-up available:** `NotificationBell.vue` and `RemoteHostControl.vue` carry this same dropdown pattern (RemoteHostControl adds a `refreshStatus()` side effect on open). They're ready-made consumers for `useDropdownMenu` — out of scope here, tracked under #452.

## User Prompt

> jscpd ででるduplicat code。できるだけなおせるものはなおしてほしい
>
> こまかくPR

## Verification

- `yarn test` on the affected specs: **59 passed** (RunMenu, SkillMenu, collections)
- `eslint` clean on all changed files
- `prettier --check .` clean repo-wide
- `vite build` succeeds; scoping confirmed in the emitted CSS as described above

Pre-existing failures on `main`, **not** introduced here (verified against a clean `main` worktree):
- `vue-tsc` reports 2 errors in `src/composables/collectionUi.ts` (`CollectionOntologyResponse` missing from the installed `@mulmoclaude/core` — stale dep)
- `tsc -p tsconfig.server.json` reports 1 error in `server/infra/web-push.ts` (upstream `@mulmobridge/web-push` type drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)