### PR TITLE
refactor: share the side-pane and toolbar-popover chrome

### DIFF
--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, watch, onUnmounted, computed } from "vue";
-import { usePubSub } from "../composables/usePubSub";
+import { ref, computed } from "vue";
+import { useSessionFeed } from "../composables/useSessionFeed";
 import { getPlugin } from "../plugins-registry";
 import PluginFrame from "./PluginFrame.vue";
 
@@ -28,54 +28,14 @@ const emit = defineEmits<{ toggleTools: [] }>();
 
 const results = ref<ToolResult[]>([]);
 
-const sessionChannel = (id: string) => `session:${id}`;
-
-// Insert or update a result, deduped by uuid (a re-emitted result — e.g. a form
-// whose viewState changed — updates in place). Mirrors applyToolResultToSession.
-function upsert(result: ToolResult) {
-  const idx = results.value.findIndex((r) => r.uuid === result.uuid);
-  if (idx >= 0) results.value[idx] = result;
-  else results.value = [...results.value, result];
-}
-
-async function loadHistory(id: string) {
-  try {
-    const res = await fetch(`/api/agent/toolResults/${encodeURIComponent(id)}`);
-    // Guard against a session-switch race: a slow response for an old session must
-    // not clobber the pane after the user has switched to a newer one.
-    if (id !== props.sessionId) return;
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    if (id !== props.sessionId) return;
-    results.value = data.toolResults ?? [];
-  } catch {
-    if (id === props.sessionId) results.value = [];
-  }
-}
-
-const { subscribe } = usePubSub();
-let unsubscribe: (() => void) | undefined;
-
-function subscribeTo(id: string | null) {
-  unsubscribe?.();
-  unsubscribe = undefined;
-  if (!id) return;
-  unsubscribe = subscribe(sessionChannel(id), (data) => upsert(data as ToolResult));
-}
-
-// Reload history + re-subscribe whenever the active session changes (and clear
-// for a fresh, not-yet-identified session).
-watch(
-  () => props.sessionId,
-  (id) => {
-    if (id) loadHistory(id);
-    else results.value = [];
-    subscribeTo(id);
-  },
-  { immediate: true },
-);
-
-onUnmounted(() => unsubscribe?.());
+// Deduping by uuid mirrors applyToolResultToSession.
+const { upsert } = useSessionFeed(results, {
+  sessionId: () => props.sessionId,
+  historyUrl: (id) => `/api/agent/toolResults/${encodeURIComponent(id)}`,
+  historyKey: "toolResults",
+  channel: (id) => `session:${id}`,
+  identify: (result) => result.uuid,
+});
 
 // A plugin view changed its state (e.g. a form field edited / submitted). Per the
 // gui-chat-protocol contract the view may emit a PARTIAL ToolResult (e.g. just
@@ -108,10 +68,17 @@ const hasContent = computed(() => results.value.length > 0);
 </script>
 
 <template>
-  <section class="gui-panel">
-    <div class="header">
-      <span class="title">Canvas</span>
-      <button v-if="!toolsOpen" type="button" class="gear" title="Tools & tool-call history" aria-label="Open tools pane" @click="emit('toggleTools')">
+  <section class="gui-panel side-pane">
+    <div class="side-pane-header">
+      <span class="side-pane-title">Canvas</span>
+      <button
+        v-if="!toolsOpen"
+        type="button"
+        class="side-pane-action"
+        title="Tools & tool-call history"
+        aria-label="Open tools pane"
+        @click="emit('toggleTools')"
+      >
         <span class="material-symbols-outlined">build</span>
       </button>
     </div>
@@ -134,42 +101,12 @@ const hasContent = computed(() => results.value.length > 0);
   </section>
 </template>
 
+<style scoped src="./sidePane.css"></style>
+
 <style scoped>
 .gui-panel {
-  display: flex;
-  flex-direction: column;
   flex: 1;
   min-width: 0;
-  height: 100%;
-  background: var(--bg-deep);
-  border-left: 1px solid var(--border);
-}
-
-.header {
-  padding: 8px 16px;
-  background: var(--bg-panel);
-  color: var(--text);
-  font-family: system-ui, sans-serif;
-  font-size: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.title {
-  font-weight: 600;
-}
-.gear {
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  font-size: 15px;
-  line-height: 1;
-  padding: 2px 4px;
-  cursor: pointer;
-  border-radius: 4px;
-}
-.gear:hover {
-  color: var(--text);
 }
 
 .content {

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, onUnmounted, useTemplateRef } from "vue";
+import { useTemplateRef } from "vue";
+import { useDropdownMenu } from "../composables/useDropdownMenu";
 import { useNotifications, type NotifierEntry, type NotifierSeverity } from "../composables/useNotifications";
 
 // Toolbar bell: a severity-coloured unread badge + a dropdown listing the active
@@ -10,29 +11,8 @@ import { useNotifications, type NotifierEntry, type NotifierSeverity } from "../
 // watcher clears it when the record is done; the ✕ dismisses it explicitly.
 const { count, topSeverity, sorted, dismiss, activate } = useNotifications();
 
-const open = ref(false);
 const rootRef = useTemplateRef<HTMLElement>("root");
-
-function onOutside(e: PointerEvent) {
-  if (rootRef.value && !rootRef.value.contains(e.target as Node)) close();
-}
-function onEscape(e: KeyboardEvent) {
-  if (e.key === "Escape") close();
-}
-function openPanel() {
-  open.value = true;
-  window.addEventListener("pointerdown", onOutside);
-  window.addEventListener("keydown", onEscape);
-}
-function close() {
-  open.value = false;
-  window.removeEventListener("pointerdown", onOutside);
-  window.removeEventListener("keydown", onEscape);
-}
-function toggle() {
-  if (open.value) close();
-  else openPanel();
-}
+const { open, close, toggle } = useDropdownMenu(rootRef);
 
 function onRowClick(entry: NotifierEntry) {
   // Navigate if it's a deep-linkable entry; close either way so the click feels live.
@@ -63,15 +43,13 @@ function relativeTime(iso: string): string {
   const days = Math.round(hours / 24);
   return `${days}d`;
 }
-
-onUnmounted(close);
 </script>
 
 <template>
-  <div ref="root" class="notif-bell">
+  <div ref="root" class="toolbar-popover-root">
     <button
       type="button"
-      class="bell-btn"
+      class="toolbar-popover-btn"
       :class="{ active: open }"
       :aria-expanded="open"
       aria-haspopup="true"
@@ -83,7 +61,7 @@ onUnmounted(close);
       <span v-if="count" class="badge" :class="topSeverity ? severityClass(topSeverity) : ''">{{ count > 99 ? "99+" : count }}</span>
     </button>
 
-    <div v-if="open" class="notif-pop" role="group" aria-label="Notifications">
+    <div v-if="open" class="toolbar-popover notif-pop" role="group" aria-label="Notifications">
       <div class="notif-head">Notifications</div>
       <div class="notif-subhead">Active ({{ sorted.length }})</div>
       <div v-if="!sorted.length" class="notif-empty">You're all caught up.</div>
@@ -119,38 +97,9 @@ onUnmounted(close);
   </div>
 </template>
 
+<style scoped src="./toolbarPopover.css"></style>
+
 <style scoped>
-.notif-bell {
-  position: relative;
-  display: inline-flex;
-}
-
-/* Mirrors App.vue's .launcher-btn (scoped styles don't cross component boundaries). */
-.bell-btn {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  height: 30px;
-  width: 30px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  border-radius: 6px;
-  cursor: pointer;
-}
-.bell-btn:hover,
-.bell-btn.active {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.bell-btn .material-symbols-outlined {
-  font-size: 19px;
-  line-height: 1;
-}
-
 /* Unread badge: severity-coloured pill at the top-right of the bell. */
 .badge {
   position: absolute;
@@ -179,22 +128,10 @@ onUnmounted(close);
 }
 
 .notif-pop {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  /* Above the collections browse overlay (z-index 50, fills below the toolbar) so
-     the dropdown stays visible when a navigation has opened it. */
-  z-index: 60;
   width: 340px;
   max-height: 460px;
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
   padding: 4px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
 }
 
 .notif-head {

--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -5,8 +5,8 @@
 // Google sign-in popup (browser Firebase) → extract the Google OAuth idToken →
 // POST it to /api/remote-host/connect, where the server signs in as the user and
 // starts the Firestore command loop + presence heartbeat. The dropdown shows
-// online/offline + the connected uid and offers Connect / Disconnect. Styling
-// mirrors NotificationBell (dark palette, material-symbols-outlined, dropdown).
+// online/offline + the connected uid and offers Connect / Disconnect. Trigger and
+// panel chrome are shared with NotificationBell via toolbarPopover.css.
 import { onMounted, onUnmounted, ref, useTemplateRef } from "vue";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { renderSVG } from "uqr";
@@ -16,6 +16,7 @@ import { auth } from "../config/firebase";
 // so they're unit-testable without mounting this Firebase-importing component.
 import { loadStoredSession, persistSession, reconnectAction, type FetchResult, type RemoteHostStatus } from "./remoteHostSession";
 import { registerRemoteHostSelfHeal } from "./remoteHostSelfHeal";
+import { useDropdownMenu } from "../composables/useDropdownMenu";
 import { usePubSub } from "../composables/usePubSub";
 
 // Mobile companion PWA — shown in the dropdown as help text (not fetched here).
@@ -23,11 +24,13 @@ const MOBILE_URL = "https://mulmoserver.web.app";
 // Rendered to a data URL (uqr output is ASCII-only SVG) so no v-html is needed.
 const qrDataUrl = `data:image/svg+xml;base64,${btoa(renderSVG(MOBILE_URL))}`;
 
-const open = ref(false);
 const busy = ref(false);
 const error = ref<string | null>(null);
 const status = ref<RemoteHostStatus>({ connected: false, uid: null });
 const rootRef = useTemplateRef<HTMLElement>("root");
+const { open, close, toggle } = useDropdownMenu(rootRef, () => {
+  refreshStatus().catch(() => undefined);
+});
 
 const errorText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
@@ -74,28 +77,6 @@ async function tryAutoReconnect() {
   const action = reconnectAction(res);
   if (action === "park" && res.ok) persistSession(res.session);
   else if (action === "drop") persistSession(null);
-}
-
-function onOutside(event: PointerEvent) {
-  if (rootRef.value && !rootRef.value.contains(event.target as Node)) close();
-}
-function onEscape(event: KeyboardEvent) {
-  if (event.key === "Escape") close();
-}
-function openPanel() {
-  open.value = true;
-  window.addEventListener("pointerdown", onOutside);
-  window.addEventListener("keydown", onEscape);
-  refreshStatus().catch(() => undefined);
-}
-function close() {
-  open.value = false;
-  window.removeEventListener("pointerdown", onOutside);
-  window.removeEventListener("keydown", onEscape);
-}
-function toggle() {
-  if (open.value) close();
-  else openPanel();
 }
 
 async function onConnect() {
@@ -154,17 +135,14 @@ onMounted(() => {
   void selfHeal();
   stopSelfHeal = registerRemoteHostSelfHeal(() => void selfHeal(), pubsub.onReconnect);
 });
-onUnmounted(() => {
-  close();
-  stopSelfHeal?.();
-});
+onUnmounted(() => stopSelfHeal?.());
 </script>
 
 <template>
-  <div ref="root" class="remote-host">
+  <div ref="root" class="toolbar-popover-root">
     <button
       type="button"
-      class="rh-btn"
+      class="toolbar-popover-btn"
       :class="{ active: open, connected: status.connected }"
       :aria-expanded="open"
       aria-haspopup="true"
@@ -175,7 +153,7 @@ onUnmounted(() => {
       <span class="material-symbols-outlined">phonelink</span>
     </button>
 
-    <div v-if="open" class="rh-pop" role="group" aria-label="Remote host">
+    <div v-if="open" class="toolbar-popover rh-pop" role="group" aria-label="Remote host">
       <div class="rh-head">
         <span class="material-symbols-outlined rh-dot" :class="{ connected: status.connected }">
           {{ status.connected ? "check_circle" : "radio_button_unchecked" }}
@@ -212,55 +190,17 @@ onUnmounted(() => {
   </div>
 </template>
 
-<style scoped>
-.remote-host {
-  position: relative;
-  display: inline-flex;
-}
+<style scoped src="./toolbarPopover.css"></style>
 
-/* Mirrors App.vue's .launcher-btn (scoped styles don't cross component boundaries). */
-.rh-btn {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  height: 30px;
-  width: 30px;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  border-radius: 6px;
-  cursor: pointer;
-}
-.rh-btn:hover,
-.rh-btn.active {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.rh-btn.connected {
+<style scoped>
+.toolbar-popover-btn.connected {
   color: #35c46a;
-}
-.rh-btn .material-symbols-outlined {
-  font-size: 19px;
-  line-height: 1;
 }
 
 .rh-pop {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 60;
   width: 300px;
-  display: flex;
-  flex-direction: column;
   gap: 8px;
   padding: 10px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
   font-family: system-ui, sans-serif;
 }
 

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, watch, onUnmounted } from "vue";
-import { usePubSub } from "../composables/usePubSub";
+import { ref, onUnmounted } from "vue";
+import { useSessionFeed } from "../composables/useSessionFeed";
 
 // The tools pane mirrors MulmoClaude's right sidebar: an "Available Tools" list
 // (the GUI plugin tools, with collapsible descriptions) and a "Tool Call History"
@@ -47,52 +47,18 @@ function callKey(c: ToolCall, i: number): string {
   return c.toolUseId ?? `${c.toolName}-${i}`;
 }
 
-// Insert or update a call, keyed by tool_use_id (a PostToolUse completes the
-// "running" entry its PreToolUse created).
-function upsert(call: ToolCall) {
-  const list = toolCalls.value;
-  const idx = call.toolUseId ? list.findIndex((c) => c.toolUseId === call.toolUseId) : -1;
-  if (idx >= 0) list[idx] = call;
-  else toolCalls.value = [...list, call];
-}
-
-async function loadHistory(id: string) {
-  try {
-    const res = await fetch(`/api/tool-calls/${encodeURIComponent(id)}`);
-    // Guard against a session-switch race: if the user moved on while this was in
-    // flight, drop the stale response instead of clobbering the new session's pane.
-    if (id !== props.sessionId) return;
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
-    if (id !== props.sessionId) return;
-    toolCalls.value = data.toolCalls ?? [];
-  } catch {
-    if (id === props.sessionId) toolCalls.value = [];
-  }
-}
-
-const { subscribe } = usePubSub();
-let unsubscribe: (() => void) | undefined;
-
-function subscribeTo(id: string | null) {
-  unsubscribe?.();
-  unsubscribe = undefined;
-  if (!id) return;
-  unsubscribe = subscribe(`toolcalls:${id}`, (data) => upsert(data as ToolCall));
-}
-
-watch(
-  () => props.sessionId,
-  (id) => {
+// Keying by tool_use_id lets a PostToolUse complete the "running" entry its
+// PreToolUse created.
+useSessionFeed(toolCalls, {
+  sessionId: () => props.sessionId,
+  historyUrl: (id) => `/api/tool-calls/${encodeURIComponent(id)}`,
+  historyKey: "toolCalls",
+  channel: (id) => `toolcalls:${id}`,
+  identify: (call) => call.toolUseId,
+  onSessionChange: () => {
     expandedCalls.value = new Set();
-    if (id) loadHistory(id);
-    else toolCalls.value = [];
-    subscribeTo(id);
   },
-  { immediate: true },
-);
-
-onUnmounted(() => unsubscribe?.());
+});
 
 function toggleTool(name: string) {
   const next = new Set(expandedTools.value);
@@ -144,10 +110,10 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
 </script>
 
 <template>
-  <section class="tools-pane">
-    <div class="header">
-      <span class="title">Tools</span>
-      <button type="button" class="close-btn" title="Close tools pane" aria-label="Close tools pane" @click="emit('close')">
+  <section class="tools-pane side-pane">
+    <div class="side-pane-header">
+      <span class="side-pane-title">Tools</span>
+      <button type="button" class="side-pane-action" title="Close tools pane" aria-label="Close tools pane" @click="emit('close')">
         <span class="material-symbols-outlined">close</span>
       </button>
     </div>
@@ -211,42 +177,12 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
   </section>
 </template>
 
+<style scoped src="./sidePane.css"></style>
+
 <style scoped>
 .tools-pane {
-  display: flex;
-  flex-direction: column;
   width: 340px;
   flex-shrink: 0;
-  height: 100%;
-  background: var(--bg-deep);
-  border-left: 1px solid var(--border);
-}
-
-.header {
-  padding: 8px 16px;
-  background: var(--bg-panel);
-  color: var(--text);
-  font-family: system-ui, sans-serif;
-  font-size: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.title {
-  font-weight: 600;
-}
-.close-btn {
-  background: none;
-  border: none;
-  color: var(--text-dim);
-  font-size: 15px;
-  line-height: 1;
-  padding: 2px 4px;
-  cursor: pointer;
-  border-radius: 4px;
-}
-.close-btn:hover {
-  color: var(--text);
 }
 
 .content {

--- a/src/components/sidePane.css
+++ b/src/components/sidePane.css
@@ -1,0 +1,36 @@
+/* Chrome shared by the right-hand panes (Canvas, Tools): the pane shell and its
+   title bar. Each pane keeps its own sizing rules. */
+.side-pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-deep);
+  border-left: 1px solid var(--border);
+}
+
+.side-pane-header {
+  padding: 8px 16px;
+  background: var(--bg-panel);
+  color: var(--text);
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.side-pane-title {
+  font-weight: 600;
+}
+.side-pane-action {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 15px;
+  line-height: 1;
+  padding: 2px 4px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.side-pane-action:hover {
+  color: var(--text);
+}

--- a/src/components/toolbarPopover.css
+++ b/src/components/toolbarPopover.css
@@ -1,0 +1,47 @@
+/* Chrome shared by the toolbar popovers (notifications, remote host): a square
+   icon trigger plus the panel it anchors. Each popover keeps its own sizing rules. */
+.toolbar-popover-root {
+  position: relative;
+  display: inline-flex;
+}
+
+/* Mirrors App.vue's .launcher-btn (scoped styles don't cross component boundaries). */
+.toolbar-popover-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  height: 30px;
+  width: 30px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.toolbar-popover-btn:hover,
+.toolbar-popover-btn.active {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.toolbar-popover-btn .material-symbols-outlined {
+  font-size: 19px;
+  line-height: 1;
+}
+
+.toolbar-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  /* Above the collections browse overlay (z-index 50, fills below the toolbar) so
+     the dropdown stays visible when a navigation has opened it. */
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -1,0 +1,65 @@
+// A session-scoped live list: history is replayed from an endpoint whenever the
+// active session changes, then pushes on that session's pub/sub channel are merged
+// in, deduped by each item's identity (a re-emitted item updates in place).
+import { onUnmounted, watch, type Ref } from "vue";
+import { usePubSub } from "./usePubSub";
+
+interface SessionFeedOptions<T> {
+  sessionId: () => string | null;
+  historyUrl: (id: string) => string;
+  historyKey: string;
+  channel: (id: string) => string;
+  identify: (item: T) => string | undefined;
+  onSessionChange?: () => void;
+}
+
+export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T>) {
+  const { sessionId, historyUrl, historyKey, channel, identify, onSessionChange } = options;
+
+  function upsert(item: T) {
+    const id = identify(item);
+    const index = id === undefined ? -1 : items.value.findIndex((existing) => identify(existing) === id);
+    if (index >= 0) items.value[index] = item;
+    else items.value = [...items.value, item];
+  }
+
+  async function loadHistory(id: string) {
+    try {
+      const res = await fetch(historyUrl(id));
+      // Guard against a session-switch race: a slow response for an old session must
+      // not clobber the pane after the user has switched to a newer one.
+      if (id !== sessionId()) return;
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if (id !== sessionId()) return;
+      items.value = data[historyKey] ?? [];
+    } catch {
+      if (id === sessionId()) items.value = [];
+    }
+  }
+
+  const { subscribe } = usePubSub();
+  let unsubscribe: (() => void) | undefined;
+
+  function subscribeTo(id: string | null) {
+    unsubscribe?.();
+    unsubscribe = undefined;
+    if (!id) return;
+    unsubscribe = subscribe(channel(id), (data) => upsert(data as T));
+  }
+
+  watch(
+    sessionId,
+    (id) => {
+      onSessionChange?.();
+      if (id) loadHistory(id);
+      else items.value = [];
+      subscribeTo(id);
+    },
+    { immediate: true },
+  );
+
+  onUnmounted(() => unsubscribe?.());
+
+  return { upsert };
+}


### PR DESCRIPTION
## Summary

Two more jscpd-flagged pairs, plus the composable overlap that emerged between them.

| Pair | Was duplicated | Now shares |
|---|---|---|
| `GuiPanel` / `ToolsPane` | 31 CSS + 19 TS | `useSessionFeed.ts`, `sidePane.css` |
| `NotificationBell` / `RemoteHostControl` | 29 CSS + 11 TS | `useDropdownMenu` (extended), `toolbarPopover.css` |

Pure refactor, no behavior change. Part of #452.

> ⚠️ **Stacked on #454** — based on `refactor/452-dedupe-dropdown-menus`, not `main`, because it extends the `useDropdownMenu` composable that PR introduces. Merge #454 first, then this retargets to `main` cleanly.

## Items to Confirm / Review

- **The most important review point: two agents independently wrote the *same* composable.** The work on `NotificationBell`/`RemoteHostControl` produced a `useDismissiblePopover` that was line-for-line the same pattern as #454's `useDropdownMenu`. Shipping both would have re-created exactly the duplication this issue is about, so I **deleted it and extended `useDropdownMenu`** with an optional `onOpen` hook instead. Please sanity-check that one composable genuinely serves all four call sites (two header dropdowns, two toolbar popovers) and that `useDropdownMenu` is the right name now that it also backs popovers.
- **#454 was amended (force-pushed) as part of this.** `useDropdownMenu` picked up two changes there: the optional `onOpen`, and `event.target instanceof Node` replacing an `as Node` cast (CLAUDE.md forbids `as` casts). If you already looked at #454, re-pull it.
- **`onOpen` fires *after* the listeners are attached**, matching where `RemoteHostControl.openPanel` previously called `refreshStatus()` — same position in the sequence, so no ordering change.
- **CSS ordering matters here and is load-bearing.** The `src` block is emitted *before* the local block in every case, so local rules still win on specificity ties. Concretely: `.toolbar-popover-btn.connected` still comes after `:hover`/`.active`, which is what keeps a connected button green while hovered. Worth a visual check on the RemoteHost button.
- **`useSessionFeed` takes the caller's own `ref<T[]>`** rather than creating one. That avoids a `ref<T[]>([]) as Ref<T[]>` cast while keeping deep reactivity — `shallowRef` would have changed what plugin views receive. Slightly unusual shape; flagging it deliberately.
- **`data as T`** was left in `useSessionFeed`'s pub/sub handler — one assertion at the untyped network boundary, exactly as both originals had. Replacing it with a type predicate would silently drop malformed pushes, i.e. a behavior change.

## Deliberately left duplicated

- **`.content` in GuiPanel/ToolsPane** — outside the flagged clone and genuinely divergent (padding + `font-size: 14px`/line-height vs a bare `font-size: 13px`); only ~4 lines actually overlap.
- **`App.vue`'s `.launcher-btn`** — a *third* copy of the same 30px icon-button styles (both components already carry a comment saying so). Out of scope here; a good follow-up to fold into `toolbarPopover.css`.

## User Prompt

> jscpd ででるduplicat code。できるだけなおせるものはなおしてほしい
>
> こまかくPR

## Verification

- `yarn test` — **131 files / 1438 tests, baseline exactly preserved**
- `yarn lint` clean on all changed files; `prettier` clean
- `vue-tsc -b --force` — no errors outside the pre-existing `collectionUi.ts` pair (verified against a clean `main` worktree: stale `@mulmoclaude/core` install)
- Scoping verified in `dist/assets/*.css`: every shared selector carries a `data-v` hash, emitted once per consuming component (`.side-pane[data-v-62e345fb]` + `.side-pane[data-v-c153cae9]`), with **zero** unscoped occurrences of `.side-pane*` or `.toolbar-popover*`
- `jscpd` over the four targets plus the new shared files: **0 clones**

🤖 Generated with [Claude Code](https://claude.com/claude-code)