### PR TITLE
fix: name the sending host in the task-finished push

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1260,8 +1260,11 @@ function notifyTaskFinished(sessionId: string): void {
   const what = lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
   const title = `✅ ${where}`.slice(0, PUSH_TITLE_MAX);
   const body = (what || "タスクが完了しました").slice(0, PUSH_BODY_MAX);
-  // The session id is what lets the phone open this session from the notification.
-  void sendWebPush(title, body, { sessionId });
+  // The session id is what lets the phone open this session from the notification;
+  // the host id is what lets it know WHOSE session. Without it the phone opens with
+  // no host selected — it never persists one — and can only offer the picker, which
+  // is where every notification tap used to land (receptron/mulmoserver#86).
+  void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID });
 }
 
 interface HookToolPayload {


### PR DESCRIPTION
## Summary

スマホで通知をタップすると、該当セッションではなく**必ずホスト選択画面に着く**という報告への対応です。

通知は `sessionId` を運んでいますが、**どのホストのセッションかを伝えていません**。電話側はホスト選択を永続化しません（黙って繋がないための意図的な設計）。そのため通知から開いたアプリは未選択で起動し、セッション画面は選択 UI を出すしかありません。**どちらも設計どおりに動いた結果、組み合わせで詰んでいます。**

`HOST_ID` は既に定数としてあるので、push に載せるだけです:

```ts
void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID });
```

## Items to Confirm / Review

- **電話側は receptron/mulmoserver#86** です。タップ先 URL の `?host=` を読み、描画前にそのホストを選択します。**あちらが入るまではこの変更単体では症状が変わりません**（データが増えるだけで無害）
- **「自動接続しない」方針とは矛盾しません** — ユーザーが*そのホストからの通知を自分でタップした*ことが起点で、ホストを名指ししているのはユーザーの行為です。電話側も未知の id は catalog 照合で弾きます

## 環境について（このチェックアウト特有）

作業に使ったチェックアウトの依存が古く（`@mulmoclaude/core` 0.15.0）、最初 `npm install` を試したところ peer の衝突で失敗しました（`collection-plugin@0.14.1` が `core@^0.29.0` を要求）。**これはこのリポジトリが yarn プロジェクトなのに npm を使った私の誤り**で、`yarn install --frozen-lockfile` では `core@0.27.0` / `collection-plugin@0.14.0` が正しく入り、以後は問題ありません。main 側の問題ではないので、記録だけ残します。

## テスト

変更は1行なので新規テストはありません。CI と同じチェックを一通り実行済み:

- `yarn typecheck` / `yarn typecheck:server`
- `yarn lint`（エラー0）
- `yarn format:check`
- `yarn test` — **131 files / 1438 tests pass**
- `yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
