### PR TITLE
refactor: share the per-directory chrome fields across the build boundary

### DIFF
--- a/common/dirChrome.ts
+++ b/common/dirChrome.ts
@@ -1,0 +1,20 @@
+// The name + fixed-color fields a `.mulmoterminal.json` may set. Shared across the
+// build boundary: the server's DirConfig/PublicDirConfig and the client's DirConfig
+// all extend this, so a field added on one side can't go missing on the other.
+// `theme` and `colors` stay out of it — each side declares them with its own type
+// (the server keeps the validated strings, the client narrows them to xterm's ITheme).
+export interface DirChrome {
+  name: string | null;
+  badgeColor: string | null;
+  // The cell header's own background / text color (grid cell + single view). Hex
+  // #rrggbb, or null to keep the theme default. Distinct from `colors` (the xterm
+  // palette) — these tint the chrome around the terminal, not the terminal itself.
+  headerColor: string | null;
+  headerTextColor: string | null;
+  // The cell frame + accents (grid cell): body background, border, the idle status
+  // dot, and the header's icon buttons. Hex #rrggbb or null for the theme default.
+  cellColor: string | null;
+  cellBorderColor: string | null;
+  dotColor: string | null;
+  buttonColor: string | null;
+}

--- a/server/config/dir-config.ts
+++ b/server/config/dir-config.ts
@@ -7,6 +7,7 @@
 import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
+import type { DirChrome } from "../../common/dirChrome.js";
 import {
   dirNameField,
   dirColorField,
@@ -20,20 +21,7 @@ import {
 
 const DIR_CONFIG_FILE = ".mulmoterminal.json";
 
-export interface DirConfig {
-  name: string | null;
-  badgeColor: string | null;
-  // The cell header's own background / text color (grid cell + single view). Hex
-  // #rrggbb, or null to keep the theme default. Distinct from `colors` (the xterm
-  // palette) — these tint the chrome around the terminal, not the terminal itself.
-  headerColor: string | null;
-  headerTextColor: string | null;
-  // The cell frame + accents (grid cell): body background, border, the idle status
-  // dot, and the header's icon buttons. Hex #rrggbb or null for the theme default.
-  cellColor: string | null;
-  cellBorderColor: string | null;
-  dotColor: string | null;
-  buttonColor: string | null;
+export interface DirConfig extends DirChrome {
   theme: ThemeId | null;
   // Per-key xterm palette overrides (on top of `theme`), or null when none are valid.
   colors: Record<string, string> | null;
@@ -51,20 +39,10 @@ export interface DirConfig {
 }
 
 // What the browser receives: the raw sound path stays server-side (streamed via
-// /api/dir-sound), so the client only learns whether one exists.
-export interface PublicDirConfig {
-  name: string | null;
-  badgeColor: string | null;
-  headerColor: string | null;
-  headerTextColor: string | null;
-  cellColor: string | null;
-  cellBorderColor: string | null;
-  dotColor: string | null;
-  buttonColor: string | null;
-  theme: ThemeId | null;
-  colors: Record<string, string> | null;
-  hasSound: boolean;
-}
+// /api/dir-sound), so the client only learns whether one exists. Derived from
+// DirConfig rather than restated, so a new appearance field reaches the client
+// without a second edit.
+export type PublicDirConfig = Omit<DirConfig, "sound" | "buttons" | "chips" | "skills"> & { hasSound: boolean };
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -4,22 +4,12 @@ import type { ITheme } from "@xterm/xterm";
 import { isThemeId, type ThemeId } from "./useTheme";
 // Shared with the server config schema so the two can't drift — see common/themeColors.ts.
 import { THEME_COLOR_KEYS } from "../../common/themeColors";
+import type { DirChrome } from "../../common/dirChrome";
 
 // The per-directory overrides a terminal adopts when its cwd holds a
 // `.mulmoterminal.json` (served by GET /api/dir-config). The raw sound path stays
 // server-side; `hasSound` says whether GET /api/dir-sound has something to stream.
-export interface DirConfig {
-  name: string | null;
-  badgeColor: string | null;
-  // The cell header's own background / text color (grid cell + single view), or null
-  // to keep the theme default. Distinct from `colors` (the xterm palette).
-  headerColor: string | null;
-  headerTextColor: string | null;
-  // The cell frame + accents (body background, border, idle status dot, header buttons).
-  cellColor: string | null;
-  cellBorderColor: string | null;
-  dotColor: string | null;
-  buttonColor: string | null;
+export interface DirConfig extends DirChrome {
   theme: ThemeId | null;
   // Per-key xterm palette overrides applied on top of `theme` (or the app theme).
   colors: Partial<ITheme> | null;


### PR DESCRIPTION
## Summary

The eight name/color fields of a `.mulmoterminal.json` were declared **three times**: server `DirConfig`, server `PublicDirConfig`, and the client's own `DirConfig`. They now extend a single `DirChrome` in `common/` — alongside `THEME_COLOR_KEYS`, which already lives there for exactly this reason.

`PublicDirConfig` is now derived from `DirConfig` via `Omit` rather than restated.

Pure refactor, no behavior change. Part of #452.

## Items to Confirm / Review

- **`PublicDirConfig` changed from an interface to a derived type**: `Omit<DirConfig, "sound" | "buttons" | "chips" | "skills"> & { hasSound: boolean }`. This is the part worth a careful look — it means *any* field added to `DirConfig` is now automatically public unless explicitly added to that omit list. That's the intended direction (appearance fields should reach the client without a second edit), but it does invert the default from opt-in to opt-out for a type that gates what leaves the server. If you'd rather it stayed explicit, say so and I'll restate it.
- **`theme` and `colors` were deliberately NOT moved into `DirChrome`.** They legitimately differ per side: the server keeps validated strings (`Record<string, string>`), the client narrows to xterm's `Partial<ITheme>`. Forcing them into the shared type would have needed generics for no real gain.
- **I tried and reverted a cleaner `publicDirConfig` body.** Rest-destructuring (`const { sound, buttons, chips, skills, ...appearance }`) would have removed the remaining field list, but this repo's eslint has `no-unused-vars` without `ignoreRestSiblings`, so it errors on the three discarded names — and CLAUDE.md forbids silencing it with a disable comment. I left the explicit projection rather than paper over it. **Enabling `ignoreRestSiblings` would be a reasonable small config change if you want it** — happy to do that separately, but it's a lint-policy decision, not mine to make inside a refactor PR.

## Noticed but out of scope

`ThemeId` is **also** duplicated: the server derives it from a zod schema (`config-schema.ts`), the client hardcodes the union `"midnight" | "nord" | "daylight" | "solarized"` (`useTheme.ts`). jscpd doesn't flag it (too short), but it's a genuine drift risk of exactly the kind `common/` exists to prevent — adding a theme means editing both. Worth a follow-up; I didn't fold it in because it touches theme loading rather than just type declarations.

## User Prompt

> jscpd ででるduplicat code。できるだけなおせるものはなおしてほしい
>
> こまかくPR

## Verification

- `yarn test` — **131 files / 1438 tests**, baseline exactly preserved
- `eslint` clean on all three files; `prettier` clean
- `vue-tsc -b --force` — no errors beyond the pre-existing `collectionUi.ts` pair
- `tsc -p tsconfig.server.json` — no errors beyond the pre-existing `web-push.ts` one

Both pre-existing failures were verified against a clean `main` worktree (stale `@mulmoclaude/core` / `@mulmobridge/web-push` installs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)