### PR TITLE
refactor: state PublicDirConfig explicitly instead of deriving it

### DIFF
--- a/server/config/dir-config.ts
+++ b/server/config/dir-config.ts
@@ -39,10 +39,16 @@ export interface DirConfig extends DirChrome {
 }
 
 // What the browser receives: the raw sound path stays server-side (streamed via
-// /api/dir-sound), so the client only learns whether one exists. Derived from
-// DirConfig rather than restated, so a new appearance field reaches the client
-// without a second edit.
-export type PublicDirConfig = Omit<DirConfig, "sound" | "buttons" | "chips" | "skills"> & { hasSound: boolean };
+// /api/dir-sound), so the client only learns whether one exists.
+//
+// Listed rather than derived from DirConfig, so the wire shape reads in one place
+// instead of as "the server type minus four names" — a reader can see what leaves
+// the server without also holding DirConfig in their head.
+export interface PublicDirConfig extends DirChrome {
+  theme: ThemeId | null;
+  colors: Record<string, string> | null;
+  hasSound: boolean;
+}
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 


### PR DESCRIPTION
## Summary

Reverts the one piece of #460 you flagged: `PublicDirConfig` goes back to a spelled-out interface instead of `Omit<DirConfig, "sound" | "buttons" | "chips" | "skills">`.

It still `extends DirChrome`, so the eight shared name/color fields stay deduplicated across client and server — that part of #460 is untouched.

```ts
export interface PublicDirConfig extends DirChrome {
  theme: ThemeId | null;
  colors: Record<string, string> | null;
  hasSound: boolean;
}
```

## ⚠️ Correction to my rationale in #460 — please read before merging

In #460 I wrote that the `Omit` form would let a newly added server field *"reach the browser silently."* **I tested that claim and it is wrong.** I should have verified it before writing it.

I added a hypothetical private field (`secretToken: string`) to `DirConfig` and ran `tsc` against both forms:

| form | result when a private field is added to `DirConfig` |
|---|---|
| `Omit<...>` (as merged in #460) | **compile error** in `publicDirConfig()` — `Type '{ … }' is not assignable to type 'PublicDirConfig'` |
| explicit interface (this PR) | no error; the field simply isn't public |

So the `Omit` form fails **loud**, not silently. It forces whoever adds a server field to consciously decide whether it's public — which is arguably the *safer* of the two.

And neither form can actually leak data: `publicDirConfig()` constructs its result field by field, so what crosses the wire is governed by the function body, not the type. The security concern I raised does not exist in either version.

**The honest remaining argument for this PR is readability, not safety:** the wire shape reads in one place rather than as "the server type minus four names." That's a legitimate preference, but it is a weaker reason than the one I originally gave you — so if you'd rather keep `Omit` now that the premise has changed, close this and nothing is lost.

## Verification

- `tsc -p tsconfig.server.json` → 0 errors
- `vue-tsc -b --force` → 0 errors
- `yarn test` → **131 files / 1452 tests passing**
- `eslint` clean

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)