### PR TITLE
chore: let no-unused-vars ignore rest siblings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,9 @@ export default [
       "max-depth": ["error", 4],
       "max-params": ["warn", 6],
       "max-nested-callbacks": ["error", 4],
+      // `const { secret, ...rest } = obj` is how you drop a field by construction —
+      // the named siblings are the point, not dead code.
+      "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,8 +47,14 @@ export default [
       "max-depth": ["error", 4],
       "max-params": ["warn", 6],
       "max-nested-callbacks": ["error", 4],
-      // `const { secret, ...rest } = obj` is how you drop a field by construction —
-      // the named siblings are the point, not dead code.
+    },
+  },
+  {
+    // `const { secret, ...rest } = obj` is how you drop a field by construction —
+    // the named siblings are the point, not dead code. Scoped to where the
+    // typescript-eslint rule owns unused-vars; plain .js keeps the plugin default.
+    files: ["**/*.{ts,tsx,mts,cts}", "**/*.vue"],
+    rules: {
       "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
     },
   },


### PR DESCRIPTION
## Summary

Adds `ignoreRestSiblings: true` to `@typescript-eslint/no-unused-vars`.

`const { secret, ...rest } = obj` is the idiomatic way to drop a field by construction — the named siblings exist precisely to be *excluded* from `rest`, not used. Without this option, the rule flags them, and the only two escapes are re-listing every remaining field by hand or an `eslint-disable`.

This is the small lint-policy follow-up noted on #452. It unblocks the cleaner form of `publicDirConfig()` (which currently spells out all 11 fields to avoid the error), though that cleanup is left for a separate PR.

## Verification

- **Confirmed the rule actually changes behavior**, tested against the exact case that motivated it:
  ```ts
  const { secret, other, ...rest } = source;
  ```
  → **2 errors** on the current `main` config, **0** with this change.
- `yarn lint` on the full tree: **0 errors** (the 4 pre-existing warnings are unrelated).

No source code changed — config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)