### PR TITLE
ci: add Windows daily gates and Docker sandbox image coverage

### DIFF
--- a/.github/workflows/docker-sandbox-windows.yaml
+++ b/.github/workflows/docker-sandbox-windows.yaml
@@ -1,0 +1,134 @@
+# Builds Dockerfile.sandbox from a WINDOWS checkout, inside WSL2.
+#
+# Scope, stated honestly: the sandbox feature itself is macOS-only. server/index.ts gates
+# on sandboxPlatformSupported() BEFORE dockerAvailable(), and && short-circuits, so on
+# Windows the Docker daemon is never even probed. This job therefore does NOT exercise a
+# container spawn path that Windows users have — that path does not exist. What it does
+# cover:
+#
+#   1. The image still builds when the repo was checked out by git-for-windows. There is
+#      no .gitattributes here, so the default core.autocrlf=true rewrites text files to
+#      CRLF on checkout. (BuildKit tolerates CRLF in a Dockerfile, and this Dockerfile
+#      COPYs nothing, so this is a guard rather than a known break — the line-ending
+#      report below exists to make a future regression legible.)
+#   2. The WSL2 scaffold works in this repo, so enabling Windows sandbox support later
+#      starts from a job that already runs.
+#   3. The platform gate really is closed on Windows.
+#
+# windows-latest ships a Windows-container Docker engine and Docker Desktop needs
+# first-run UI, so neither can build a Linux image here. WSL2 + a headless dockerd is the
+# way through; the technique is mulmoclaude's (see its docs/windows-docker-ci.md).
+name: Docker sandbox image (Windows/WSL2)
+
+on:
+  schedule:
+    - cron: "0 19 * * *" # 19:00 UTC = 04:00 JST, after the ubuntu image job
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-sandbox-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_in_wsl2:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      # The gate this job cannot test from inside a container: on win32 the sandbox must
+      # stay off regardless of Docker. Cheap, and it runs before the slow WSL2 setup.
+      - name: The sandbox platform gate is closed on Windows
+        shell: pwsh
+        run: |
+          $out = node -e "process.stdout.write(String(process.platform === 'darwin'))"
+          if ($out -ne "False") { throw "expected the darwin-only gate to be False on windows-latest, got '$out'" }
+          Write-Host "OK: platform gate is closed on $([System.Environment]::OSVersion.Platform)"
+
+      # Diagnostic, not a gate. Makes it obvious in the log whether the checkout arrived
+      # with CRLF, so a future build failure here is one glance to diagnose.
+      - name: Report Dockerfile line endings as checked out
+        shell: pwsh
+        run: |
+          $bytes = [System.IO.File]::ReadAllBytes("Dockerfile.sandbox")
+          $crlf = 0; $lf = 0
+          for ($i = 0; $i -lt $bytes.Length; $i++) {
+            if ($bytes[$i] -eq 10) { if ($i -gt 0 -and $bytes[$i - 1] -eq 13) { $crlf++ } else { $lf++ } }
+          }
+          Write-Host "Dockerfile.sandbox line endings — CRLF: $crlf, bare LF: $lf"
+
+      - name: Install WSL2 with Ubuntu 22.04
+        shell: pwsh
+        run: |
+          wsl --install -d Ubuntu-22.04 --no-launch
+          wsl --set-default-version 2
+          wsl -l -v
+
+      - name: Install Docker inside WSL2
+        shell: pwsh
+        run: |
+          wsl -d Ubuntu-22.04 -u root -- bash -c "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io"
+
+      # --iptables=false --bridge=none: WSL2's kernel has no iptables_nat, and the build
+      # needs no container networking beyond the default outbound route.
+      - name: Start dockerd headless and wait for it
+        shell: pwsh
+        run: |
+          wsl -d Ubuntu-22.04 -u root -- bash -c "nohup dockerd --iptables=false --bridge=none > /var/log/dockerd.log 2>&1 &"
+          $ready = $false
+          foreach ($attempt in 1..30) {
+            wsl -d Ubuntu-22.04 -u root -- docker info *> $null
+            if ($LASTEXITCODE -eq 0) { $ready = $true; break }
+            Start-Sleep -Seconds 2
+          }
+          if (-not $ready) {
+            Write-Host "--- dockerd.log ---"
+            wsl -d Ubuntu-22.04 -u root -- cat /var/log/dockerd.log
+            throw "dockerd did not become ready within 60s"
+          }
+          wsl -d Ubuntu-22.04 -u root -- docker version
+
+      - name: Build the sandbox image from the Windows checkout
+        shell: pwsh
+        run: |
+          # C:\a\repo\repo -> /mnt/c/a/repo/repo
+          $drive = $env:GITHUB_WORKSPACE.Substring(0, 1).ToLower()
+          $rest = $env:GITHUB_WORKSPACE.Substring(3) -replace '\\', '/'
+          $wsPath = "/mnt/$drive/$rest"
+          Write-Host "workspace in WSL2: $wsPath"
+          wsl -d Ubuntu-22.04 -u root -- bash -c "cd '$wsPath' && docker build --load -f Dockerfile.sandbox -t mulmoterminal-sandbox ."
+          if ($LASTEXITCODE -ne 0) { throw "docker build failed inside WSL2" }
+
+      # The same assertions the ubuntu job makes, so the two can't drift apart silently.
+      - name: Smoke the built image
+        shell: pwsh
+        run: |
+          $script = @'
+          set -euo pipefail
+          IMAGE=mulmoterminal-sandbox
+          docker run --rm "$IMAGE" claude --version
+          for tool in git curl rg; do
+            docker run --rm "$IMAGE" sh -c "command -v $tool >/dev/null" || { echo "missing from the image: $tool"; exit 1; }
+          done
+          uid="$(docker run --rm "$IMAGE" id -u)"
+          [ "$uid" = "1000" ] || { echo "expected uid 1000, got $uid"; exit 1; }
+          home="$(docker run --rm "$IMAGE" sh -c 'printf %s "$HOME"')"
+          [ "$home" = "/home/node" ] || { echo "expected HOME=/home/node, got $home"; exit 1; }
+          workdir="$(docker run --rm "$IMAGE" pwd)"
+          [ "$workdir" = "/home/node/workspace" ] || { echo "expected /home/node/workspace, got $workdir"; exit 1; }
+          echo "✓ sandbox image smoke passed (built from a Windows checkout)"
+          '@
+          $script | Out-File -FilePath smoke.sh -Encoding ascii
+          $drive = $env:GITHUB_WORKSPACE.Substring(0, 1).ToLower()
+          $rest = $env:GITHUB_WORKSPACE.Substring(3) -replace '\\', '/'
+          wsl -d Ubuntu-22.04 -u root -- bash -c "cd '/mnt/$drive/$rest' && sed -i 's/\r$//' smoke.sh && bash smoke.sh"
+          if ($LASTEXITCODE -ne 0) { throw "image smoke failed" }

--- a/.github/workflows/docker-sandbox.yaml
+++ b/.github/workflows/docker-sandbox.yaml
@@ -1,0 +1,85 @@
+# Builds and smoke-tests Dockerfile.sandbox. Nothing else in CI builds this image, and it
+# pins nothing on purpose ("a rebuild picks up the latest, matching how the host runs the
+# newest claude") — so a base-image bump, an apt package rename, or a broken
+# `npm install -g @anthropic-ai/claude-code` breaks it with no code change on our side.
+# Without this job the first person to find out is a macOS user at spawn time.
+#
+# Runs on ubuntu: the image is a Linux image and building it needs no macOS/Windows
+# specifics. The sandbox FEATURE is macOS-only (see sandboxPlatformSupported), but the
+# image build is platform-independent.
+name: Docker sandbox image
+
+on:
+  schedule:
+    - cron: "0 17 * * *" # 17:00 UTC = 02:00 JST
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile.sandbox"
+      - "server/infra/sandbox.ts"
+      - "scripts/ci-sandbox-image.ts"
+      - ".github/workflows/docker-sandbox.yaml"
+  pull_request:
+    paths:
+      - "Dockerfile.sandbox"
+      - "server/infra/sandbox.ts"
+      - "scripts/ci-sandbox-image.ts"
+      - ".github/workflows/docker-sandbox.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-sandbox-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      # Exercises the REAL ensureSandboxImage(): builds when missing, no-ops when the
+      # Dockerfile is unchanged, rebuilds and re-labels when it changed. That cache
+      # contract is what unit tests cannot reach.
+      - name: ensureSandboxImage() contract
+        run: node --import tsx scripts/ci-sandbox-image.ts
+
+      # What the image has to provide for a claude session to work at all. Each assertion
+      # maps to a line in Dockerfile.sandbox, so a silent drop there fails here.
+      - name: Smoke the built image
+        run: |
+          set -euo pipefail
+          IMAGE=mulmoterminal-sandbox
+
+          echo "--- the agent CLI is installed and runnable ---"
+          docker run --rm "$IMAGE" claude --version
+
+          echo "--- claude's built-in tools are present ---"
+          for tool in git curl rg; do
+            docker run --rm "$IMAGE" sh -c "command -v $tool >/dev/null" \
+              || { echo "missing from the image: $tool"; exit 1; }
+          done
+
+          echo "--- runs unprivileged as uid 1000, not root ---"
+          uid="$(docker run --rm "$IMAGE" id -u)"
+          [ "$uid" = "1000" ] || { echo "expected uid 1000, got $uid"; exit 1; }
+
+          echo "--- HOME and WORKDIR match what buildDockerRunArgs mounts into ---"
+          home="$(docker run --rm "$IMAGE" sh -c 'printf %s "$HOME"')"
+          [ "$home" = "/home/node" ] || { echo "expected HOME=/home/node, got $home"; exit 1; }
+          workdir="$(docker run --rm "$IMAGE" pwd)"
+          [ "$workdir" = "/home/node/workspace" ] || { echo "expected /home/node/workspace, got $workdir"; exit 1; }
+
+          echo "✓ sandbox image smoke passed"

--- a/.github/workflows/windows-daily.yaml
+++ b/.github/workflows/windows-daily.yaml
@@ -1,0 +1,83 @@
+# The Windows half of the CI gates. Kept OUT of pull_request on purpose: the Windows
+# runner is slow (NTFS tar extraction, Defender, a second tsc pass) and every PR paying
+# that cost buys little — the Windows-specific surface here is narrow. It runs daily and
+# on main instead, which is early enough to catch a regression before a release.
+#
+# What it actually guards: server/infra/pty-env.ts branches on PATH casing ("Path"),
+# the ";" delimiter and "\" separators; server/index.ts spawns powershell.exe; and the
+# postinstall (server/fix-pty-perms.js) runs on every install. None of that had ever
+# executed on Windows before this workflow.
+name: Windows (daily)
+
+on:
+  schedule:
+    - cron: "0 18 * * *" # 18:00 UTC = 03:00 JST
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "plans/**"
+      - "**/*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-daily-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint_test_windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Deliberately no `cache: yarn`: restoring the yarn cache tar onto NTFS is slower
+      # than a fresh install. node_modules is cached directly instead (below).
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # Realtime scanning makes yarn's atomic renames fail with EPERM mid-install.
+      - name: Disable Defender realtime monitoring
+        shell: powershell
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+
+      - uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: win-node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            win-node-modules-${{ matrix.node-version }}-
+
+      # Restored BEFORE install so puppeteer's postinstall skips its ~120 MB download.
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/puppeteer
+          key: puppeteer-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      # Also exercises the postinstall (server/fix-pty-perms.js) on Windows.
+      - run: yarn install --frozen-lockfile --network-timeout 120000
+
+      - name: Lint
+        run: yarn lint
+
+      - name: Typecheck
+        run: yarn typecheck
+
+      - name: Typecheck (server)
+        run: yarn typecheck:server
+
+      - name: Build
+        run: yarn build
+
+      - name: Test
+        run: yarn test

--- a/plans/ci-459-windows-and-docker.md
+++ b/plans/ci-459-windows-and-docker.md
@@ -1,0 +1,123 @@
+# ci: Windows daily + Docker sandbox CI
+
+Issue: #459
+
+## 背景
+
+mulmoterminal の CI は `ci.yml` の **ubuntu-latest / Node 22 のみ**で、matrix が無い。
+そのため次の 2 つが一度も CI で実行されていない。
+
+1. **Windows のコードパス**。`server/infra/pty-env.ts` は `Path` のケーシング差、`;` デリミタ、
+   `\` セパレータを扱い、`server/index.ts` は Windows で `powershell.exe` を spawn する。
+   いずれも Windows 上で走ったことがない。
+2. **`Dockerfile.sandbox` のビルド**。CI で一度も build されていない。しかもこの Dockerfile は
+   意図的に何もピン留めしていない（"Pin nothing here — a rebuild picks up the latest"）ため、
+   ベースイメージ更新・apt パッケージ改名・`npm install -g @anthropic-ai/claude-code` の失敗で
+   静かに壊れる。壊れても macOS ユーザーが実行時に初めて気づく。
+
+## 設計上の前提（コードを読んで確認した事実）
+
+`server/index.ts:2338` のゲート:
+
+```ts
+const sandbox = sandboxEnabled() && sandboxPlatformSupported() && attachGuiMcp && ws !== null && dockerAvailable() && sandboxImageExists();
+```
+
+`sandboxPlatformSupported()` は `process.platform === "darwin"` のみ true（`server/infra/sandbox.ts`）。
+`&&` の短絡により **Windows では `dockerAvailable()` が probe すらされない**。
+
+したがって「Docker on Windows」を動かしても、製品側にそれを使う経路は無い。Windows×Docker ジョブで
+検証できるのは次の 2 点であって、コンテナ実行経路そのものではない。
+
+- **Windows チェックアウトから `Dockerfile.sandbox` がビルドできること**。リポジトリに
+  `.gitattributes` が無いため、git-for-windows の既定（`core.autocrlf=true`）でテキストファイルは
+  CRLF に変換される。CRLF は Dockerfile の行継続やシェルスクリプトの shebang を壊す既知の罠であり、
+  **これは Windows でしか検出できない実際の回帰リスク**。
+- 将来 Windows sandbox を有効化する際の WSL2 足場が動作すること。
+
+## 追加するもの
+
+### 1. `.github/workflows/windows-daily.yaml`
+
+`windows-latest` / Node 22.x・24.x の matrix で、`ci.yml` と同じゲート
+（lint / typecheck / typecheck:server / build / test）を回す。
+
+トリガは **daily cron + workflow_dispatch + main への push**（PR ごとには回さない）。
+Windows runner は遅く、PR CI の待ち時間を増やす価値が無いため。
+
+Windows 固有の実装ノウハウ（mulmoclaude の `lint_test_windows.yaml` から採用）:
+
+- **Defender のリアルタイム保護を切る** — `yarn install` の atomic rename が EPERM になる
+- **`setup-node` の `cache: yarn` を使わず `actions/cache` で `node_modules` を持つ** — NTFS 上の
+  tar 展開が fresh install より遅い
+- **Puppeteer キャッシュを install 前に復元** — `puppeteer` は直依存で、postinstall が ~120MB 落とす
+
+mulmoclaude 固有で**移植しない**もの: `build:packages`（monorepo でない）、`plugins:codegen:check`、
+`test:coverage`（このリポジトリの runner は vitest）、`test:csrf-wiring`、committed esbuild バンドルの
+`git diff` チェック（該当パスが無い）。
+
+要注意点として、このリポジトリには mulmoclaude に無い `postinstall`
+（`node server/fix-pty-perms.js` — node-pty の spawn-helper chmod）がある。Windows で無害に通ることを
+このジョブ自体が検証することになる。
+
+### 2. `.github/workflows/docker-sandbox.yaml`（ubuntu）
+
+`Dockerfile.sandbox` を実ビルドし、コンテナ内を検証する。
+
+- `claude --version` が動く（`npm install -g @anthropic-ai/claude-code` が生きている）
+- `git` / `curl` / `rg` / `ca-certificates` が入っている（claude の内蔵ツールの前提）
+- 非 root（uid 1000）で動く
+- `HOME=/home/node`、`WORKDIR=/home/node/workspace`
+
+さらに `scripts/ci-sandbox-image.ts` で**実際の `ensureSandboxImage()` を実行**し、キャッシュ契約を
+e2e で検証する:
+
+1. 1 回目の呼び出しでイメージができる
+2. イメージのラベル `mulmoterminal.dockerfile.sha256` が `Dockerfile.sandbox` の sha256 と一致する
+3. 変更なしの 2 回目は再ビルドせず true を返す（イメージ ID が変わらない）
+4. **Dockerfile を変更すると再ビルドされ、ラベルが更新される**（この分岐が本命）
+
+トリガは daily cron + workflow_dispatch + `Dockerfile.sandbox` / `server/infra/sandbox.ts` /
+このワークフロー自身が変わった PR・push。
+
+### 3. `.github/workflows/docker-sandbox-windows.yaml`（Windows × WSL2）
+
+`windows-latest` には Windows コンテナ用の Docker しか無く、Docker Desktop は初回起動に UI を要する。
+そのため mulmoclaude と同じ WSL2 手法を使う: `wsl --install -d Ubuntu-22.04 --no-launch` →
+`apt-get install docker.io` → `dockerd --iptables=false --bridge=none` をヘッドレス起動
+（WSL2 のカーネルに `iptables_nat` が無いため）→ `docker info` を polling。
+
+その上で **Windows チェックアウトのまま**（＝ CRLF 変換された可能性のあるファイルで）
+`Dockerfile.sandbox` を WSL2 内でビルドし、ubuntu ジョブと同じスモークを流す。
+パス変換は `C:\...` → `/mnt/c/...`。
+
+daily cron + workflow_dispatch のみ。WSL2 セットアップに時間がかかり不安定なため、PR には出さない。
+
+## コード変更
+
+`sandboxPlatformSupported()` に省略可能な `platform` 引数を足し、テスト可能にする。
+
+```ts
+export function sandboxPlatformSupported(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "darwin";
+}
+```
+
+現状この関数は**テストが 1 つも無い**。引数化することで、`process.platform` をモックせずに
+「darwin のみ true」を明示的に固定できる。Linux / Windows を意図せず有効化する変更が入れば
+テストが落ちる（`server/infra/sandbox.ts` のコメントが述べる uid マッピング未対応・パス非互換の
+前提を、コメントではなくテストで守る）。
+
+呼び出し側は無変更。
+
+## テスト
+
+`test/server/infra/sandbox.spec.ts` に `sandboxPlatformSupported` の parameterized テストを追加
+（darwin → true、win32 / linux / freebsd → false、引数省略時は実プラットフォームに一致）。
+
+イメージのスモークは vitest ではなく CI 側で行う（Docker を要するため）。
+
+## スコープ外
+
+- macOS runner の追加。#459 では「安い最初の一歩」として挙げたが、本 PR は Windows と Docker に絞る。
+- Windows での sandbox 有効化そのもの。ゲートは `darwin` のみのままで、本 PR は変更しない。

--- a/scripts/ci-sandbox-image.ts
+++ b/scripts/ci-sandbox-image.ts
@@ -1,0 +1,64 @@
+// CI check for the sandbox image build path. Exercises the REAL ensureSandboxImage()
+// against a real Docker daemon — the one part of the sandbox that unit tests can't reach,
+// and the one most likely to rot silently: Dockerfile.sandbox pins nothing, so a base-image
+// or apt/npm change breaks it without any code change.
+//
+// The contract under test is the sha256-label cache: build when missing or when the
+// Dockerfile changed, no-op otherwise. Run from the repo root with tsx.
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync, appendFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ensureSandboxImage, sandboxImageExists } from "../server/infra/sandbox.js";
+
+// Same override sandbox.ts honours, so a local run can point at a throwaway tag instead
+// of clobbering the developer's real image.
+const IMAGE = process.env.MULMOTERMINAL_SANDBOX_IMAGE || "mulmoterminal-sandbox";
+const SHA_LABEL = "mulmoterminal.dockerfile.sha256";
+const DOCKERFILE = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "Dockerfile.sandbox");
+
+// Bin as a parameter (not a spawn-of-a-string-literal), mirroring server/infra/tmux.ts.
+function run(bin: string, args: string[]): string {
+  return execFileSync(bin, args, { encoding: "utf8" }).trim();
+}
+const docker = (args: string[]): string => run("docker", args);
+const dockerfileSha = (): string => createHash("sha256").update(readFileSync(DOCKERFILE)).digest("hex");
+const imageLabel = (): string => docker(["image", "inspect", IMAGE, "--format", `{{index .Config.Labels "${SHA_LABEL}"}}`]);
+const imageId = (): string => docker(["image", "inspect", IMAGE, "--format", "{{.Id}}"]);
+
+const checks: string[] = [];
+function check(what: string, actual: unknown, expected: unknown): void {
+  if (actual !== expected) {
+    console.error(`✗ ${what}\n  expected: ${String(expected)}\n  actual:   ${String(actual)}`);
+    process.exit(1);
+  }
+  checks.push(what);
+}
+
+// 1. A missing image gets built, and carries the Dockerfile's sha as its label.
+check("ensureSandboxImage() builds the image", ensureSandboxImage(), true);
+check("the image exists afterwards", sandboxImageExists(), true);
+check("the image is labelled with the Dockerfile sha256", imageLabel(), dockerfileSha());
+
+// 2. Called again with an unchanged Dockerfile it must NOT rebuild — same image id.
+const idAfterFirstBuild = imageId();
+check("a second call succeeds", ensureSandboxImage(), true);
+check("an unchanged Dockerfile does not rebuild (same image id)", imageId(), idAfterFirstBuild);
+
+// 3. A CHANGED Dockerfile must rebuild and re-label. This is the branch that actually
+//    protects users: without it a stale image would outlive an edited Dockerfile forever.
+//    A trailing comment changes the file (so the sha) without adding a layer, so the
+//    rebuild is cache-fast. Restored afterwards so the checkout is left as found.
+const original = readFileSync(DOCKERFILE);
+try {
+  appendFileSync(DOCKERFILE, "\n# ci-sandbox-image.ts: temporary edit to force a rebuild\n");
+  const editedSha = dockerfileSha();
+  check("the edit changed the Dockerfile sha", editedSha === original.toString() ? "unchanged" : "changed", "changed");
+  check("a changed Dockerfile rebuilds", ensureSandboxImage(), true);
+  check("the label follows the changed Dockerfile", imageLabel(), editedSha);
+} finally {
+  writeFileSync(DOCKERFILE, original);
+}
+
+console.log(checks.map((c) => `✓ ${c}`).join("\n"));

--- a/server/infra/sandbox.ts
+++ b/server/infra/sandbox.ts
@@ -35,8 +35,8 @@ export function sandboxEnabled(): boolean {
 // written as uid 1000 (ownership failures on non-1000 hosts — proper uid mapping is a
 // follow-up, #202). Windows is gated off because the same-path mount (`-v <cwd>:<cwd>`)
 // isn't a valid Linux container path. Both fall back to the host spawn.
-export function sandboxPlatformSupported(): boolean {
-  return process.platform === "darwin";
+export function sandboxPlatformSupported(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "darwin";
 }
 
 // Rewrite a host-loopback URL so it's reachable from inside the container. Same regex

--- a/test/server/infra/sandbox.spec.ts
+++ b/test/server/infra/sandbox.spec.ts
@@ -13,6 +13,7 @@ import {
   cleanupSandbox,
   parseMountConfigNames,
   resolveSandboxAuthArgs,
+  sandboxPlatformSupported,
 } from "../../../server/infra/sandbox";
 
 describe("rewriteLoopbackForDocker", () => {
@@ -48,6 +49,23 @@ describe("sandboxEnabled", () => {
     expect(sandboxEnabled()).toBe(true);
     process.env.MULMOTERMINAL_SANDBOX = "0";
     expect(sandboxEnabled()).toBe(false);
+  });
+});
+
+// Locks the gate the module comment describes: Linux is off until the spawn maps uids
+// (bind-mounted files would land as uid 1000), Windows is off because `-v <cwd>:<cwd>`
+// isn't a valid Linux container path. Enabling either needs that work done deliberately,
+// so it should break a test rather than pass silently.
+describe("sandboxPlatformSupported", () => {
+  it("is macOS only", () => {
+    expect(sandboxPlatformSupported("darwin")).toBe(true);
+    for (const platform of ["win32", "linux", "freebsd", "aix"] as const) {
+      expect(sandboxPlatformSupported(platform), platform).toBe(false);
+    }
+  });
+
+  it("reads the running platform when none is given", () => {
+    expect(sandboxPlatformSupported()).toBe(sandboxPlatformSupported(process.platform));
   });
 });
 


### PR DESCRIPTION
## Summary

CI が **ubuntu-latest / Node 22 / matrix なし** だったため、一度も CI で実行されていなかった 2 領域をカバーします。

- **Windows のコードパス** — `server/infra/pty-env.ts` は `Path` のケーシング差・`;` デリミタ・`\` セパレータを扱い、`server/index.ts` は `powershell.exe` を spawn し、`postinstall`（`server/fix-pty-perms.js`）は毎回の install で走ります。いずれも Windows で走ったことがありません。
- **`Dockerfile.sandbox` のビルド** — CI で一度も build されていません。この Dockerfile は意図的に何もピン留めしていない（"a rebuild picks up the latest"）ため、ベースイメージ更新・apt パッケージ改名・`npm install -g @anthropic-ai/claude-code` の失敗で静かに壊れ、**macOS ユーザーが実行時に初めて気づく**状態でした。

## Items to Confirm / Review

1. **Windows × Docker ジョブのスコープ**（`docker-sandbox-windows.yaml`）。設計上の事実として、`server/index.ts:2338` のゲートは `sandboxPlatformSupported()`（darwin のみ）を `dockerAvailable()` より**前**に評価し、`&&` の短絡で **Windows では Docker が probe すらされません**。よってこのジョブはコンテナ実行経路を検証**できません**。検証しているのは (a) Windows チェックアウトから `Dockerfile.sandbox` がビルドできること（`.gitattributes` が無いため git-for-windows が CRLF に変換する。実際の回帰リスク）、(b) 将来 Windows sandbox を有効化する際の WSL2 足場が動くこと、(c) プラットフォームゲートが Windows で閉じていること、の 3 点です。ファイル冒頭にこの但し書きを明記しています。**この割り切りに同意いただけるか**確認してください。

2. **Windows 系 2 ジョブは PR では自動実行されません**（cron + `workflow_dispatch` + main push のみ。runner が遅く不安定なため PR には出さない設計）。マージ前に `gh workflow run` でブランチ指定の手動起動を行い、green を確認してからマージする予定です。特に WSL2 ジョブは初回なので実際に通るか要確認です。

3. **`docker-sandbox.yaml` は PR で走ります**（対象ファイルがこの PR で変わっているため）。CI 上で実際にイメージがビルドされる様子を、この PR で確認できます。

## User Prompt

- windows の CI を daily で実行するように追加して
- そのうえで、ここ独自に docker + windows の CI も作って、必要なテストを入れてほしい

## 実装

### `.github/workflows/windows-daily.yaml`

`ci.yml` と同じゲート（lint / typecheck / typecheck:server / build / test）を `windows-latest` × Node 22.x・24.x で。トリガは **daily cron + `workflow_dispatch` + main push**。

Windows 固有のノウハウ（mulmoclaude の `lint_test_windows.yaml` から採用）:
- Defender のリアルタイム保護を切る（`yarn install` の atomic rename が EPERM になる）
- `setup-node` の `cache: yarn` を使わず `actions/cache` で `node_modules` を持つ（NTFS 上の tar 展開が遅い）
- Puppeteer キャッシュを install 前に復元（`puppeteer` 直依存、postinstall が ~120MB 落とす）

mulmoclaude 固有で**移植しなかった**もの: `build:packages`（monorepo でない）・`plugins:codegen:check`・`test:coverage`・`test:csrf-wiring`・committed esbuild バンドルの `git diff` チェック（いずれも該当なし）。

### `.github/workflows/docker-sandbox.yaml`（ubuntu）

`Dockerfile.sandbox` を実ビルドし、コンテナ内を検証: `claude --version` が動く / `git`・`curl`・`rg` が入っている / 非 root（uid 1000）/ `HOME=/home/node` / `WORKDIR=/home/node/workspace`。各アサーションは Dockerfile の各行に対応します。

`scripts/ci-sandbox-image.ts` が**実際の `ensureSandboxImage()`** を駆動し、sha ラベルのキャッシュ契約（初回ビルド → ラベル一致 → 変更なしで再ビルドしない → **Dockerfile 変更で再ビルド + ラベル更新**）を e2e で検証します。最後の分岐はユニットテストでは到達できない本命です。

### `.github/workflows/docker-sandbox-windows.yaml`（Windows × WSL2）

`windows-latest` には Windows コンテナ用 Docker しか無く Docker Desktop は初回起動に UI を要するため、WSL2 手法（Ubuntu-22.04 + `dockerd --iptables=false --bridge=none` をヘッドレス起動、`docker info` を polling、`C:\`→`/mnt/c/` 変換）を使います（mulmoclaude の手法）。Windows チェックアウトのまま `Dockerfile.sandbox` をビルドし、ubuntu と同じスモークを流します。daily + `workflow_dispatch` のみ。

### コード変更

`sandboxPlatformSupported()` に省略可能な `platform` 引数を追加（テスト可能化。この関数は従来テストが 1 つも無かった）。呼び出し側は無変更。`test/server/infra/sandbox.spec.ts` に「darwin のみ true」を固定する parameterized テストを追加。

## テスト / ローカル検証

- `scripts/ci-sandbox-image.ts` をローカルの実 Docker で実行 → 8 チェック全通過（使い捨てタグ使用、ユーザーの実イメージは無傷）
- ワークフローのスモークアサーションを実イメージで手動確認 → `claude 2.1.215` / tools 全present / uid=1000 / HOME・WORKDIR 一致
- 3 つの YAML を parser で妥当性確認
- `yarn format` / `yarn lint`（error 0、warning 4 は既存）/ `yarn build` / `yarn typecheck` / `yarn typecheck:server` / `yarn test`（131 files / 1454 tests）すべて green

## スコープ外

- **macOS runner の追加** — #459 で「安い最初の一歩」として挙げたが、本 PR は Windows と Docker に絞る（別 PR で `ci.yml` の matrix に `macos-latest` を足す形を想定）。
- **Windows での sandbox 有効化そのもの** — ゲートは `darwin` のみのまま。本 PR は変更しない。

Refs #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
