### PR TITLE
fix: make the command/launcher grid cells follow the app theme

### DIFF
--- a/src/components/cellChrome.css
+++ b/src/components/cellChrome.css
@@ -1,14 +1,15 @@
 /* Chrome shared by the non-Claude grid cells (CommandCell, LauncherCell): the
-   frame, the header strip, and its status dot / path / label / buttons.
-   TerminalCell deliberately does NOT use this — it draws the same shapes from
-   theme variables, while these two are still on fixed colors. */
+   frame, the header strip, and its status dot / path / label / buttons. Colors are
+   the same theme tokens TerminalCell uses, so all three cell kinds recolor together
+   when the app theme changes — and pick up a directory's .mulmoterminal.json tint
+   through the same override vars the moment one is set. */
 .cell {
   display: flex;
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-  background: #1a1a2e;
-  border: 1px solid #2a2a4e;
+  background: var(--cell-bg, var(--bg-base));
+  border: 1px solid var(--cell-border, var(--border));
   border-radius: 6px;
   overflow: hidden;
 }
@@ -20,15 +21,15 @@
   gap: 8px;
   height: 34px;
   padding: 0 8px;
-  background: #16213e;
-  border-bottom: 1px solid #2a2a4e;
+  background: var(--cell-header-bg, var(--bg-panel));
+  border-bottom: 1px solid var(--border);
 }
 /* Header background is a click target: zoom (switch to) this cell. */
 .cell-header.is-zoomable {
   cursor: pointer;
 }
 .cell-header.is-zoomable:hover {
-  background: #1c2a4e;
+  background: var(--bg-hover);
 }
 
 .cell-dot {
@@ -36,10 +37,10 @@
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  background: #4a5070;
+  background: var(--cell-dot, var(--text-dim));
 }
 .cell-dot.is-working {
-  background: #4a8cff;
+  background: var(--accent);
   animation: pulse 1.2s ease-in-out infinite;
 }
 @keyframes pulse {
@@ -60,7 +61,7 @@
   max-width: 45%;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 11px;
-  color: #7f88ad;
+  color: var(--cell-header-fg, var(--text-dim));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -77,7 +78,7 @@
   min-width: 0;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 12px;
-  color: #c7cdf0;
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -96,19 +97,19 @@
   height: 26px;
   border: none;
   background: transparent;
-  color: #c7cdf0;
+  color: var(--cell-btn, var(--text-secondary));
   cursor: pointer;
   font-size: 16px;
   line-height: 1;
   border-radius: 6px;
 }
 .cell-btn:hover {
-  background: #2a3b66;
-  color: #e6e6f0;
+  background: var(--bg-hover);
+  color: var(--text);
 }
 .cell-close:hover {
-  background: #3a2030;
-  color: #ff6b6b;
+  background: var(--err-hover-bg);
+  color: var(--err-text);
 }
 
 .cell-term {


### PR DESCRIPTION
## Summary

`CommandCell` and `LauncherCell` drew their chrome from **fixed hex that only matched the midnight theme**. On daylight/solarized a Run or Launcher cell stayed dark inside an otherwise light grid; on nord it didn't match the slate panels. `TerminalCell` (the Claude cell) already used the theme tokens — so a mixed grid looked half-themed.

`cellChrome.css` now uses the same `var()` expressions `TerminalCell` does, so all three cell kinds recolor together.

This is the "unifying is a visual change, not a refactor" follow-up from #452 — so unlike the earlier PRs, **this one intentionally changes pixels.**

## Items to Confirm / Review

**This is a visual change — please look at the screenshots before merging.** Before/after across all four themes (rendered from the real `cellChrome.css` + the real `style.css` theme tokens in a standalone harness):

- **BEFORE**: on `daylight` and `solarized`, the Run/Launcher cells are **black boxes inside a light panel**. That's the bug.
- **AFTER**: they take the theme's surface colors and match `TerminalCell`.

| element | midnight (before → after) | why it changed |
|---|---|---|
| cell bg, border, header bg, working dot, button colors, btn/close hover | **identical** (`#1a1a2e`=`--bg-base`, etc.) | exact token matches — midnight users see no change here |
| idle status dot | `#4a5070` → `--text-dim` (`#7c87a8`) | now matches TerminalCell's idle dot |
| zoomable-header hover | `#1c2a4e` → `--bg-hover` (`#2a3b66`) | now matches TerminalCell's hover |

So **even on midnight, two elements shift slightly** (idle dot, header hover) — both moving *toward* TerminalCell's rendering, which is the point. Everything else on midnight is byte-identical. Please confirm you're OK with those two.

- **No per-directory tint was wired in.** I used the full `var(--cell-bg, var(--bg-base))` form, but `CommandCell`/`LauncherCell` don't set those override vars, so they cleanly fall back to the theme. This means the door is open to give these cells the same `.mulmoterminal.json` `cellColor`/`headerColor` tint TerminalCell has — but that's a separate feature (needs the dir-config colors threaded into these two components), deliberately not in this PR.
- **All 10 referenced tokens are defined in every theme** — I checked. `--err-hover-bg`/`--err-text` come from the unconditional `:root {}` block (with the two light themes overriding), same mechanism TerminalCell already relies on, so no theme resolves them to empty.
- **The screenshots are from a harness**, not the running app — it inlines the actual `cellChrome.css` rules and the actual theme tokens under each `data-theme`, which is exactly what changed. Flagging it so you know it's not a live-app capture.

## User Prompt

> TerminalCell の色をテーマ変数に寄せる […] 進めよう

## Verification

- `yarn test` — CommandCell / LauncherCell specs: **18 passed**
- `eslint` clean; `prettier` clean
- visual: before/after harness across all 4 themes (see the review section above / linked artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)