### PR TITLE
ci: fix Windows CI — .gitattributes for LF, drop --load in WSL2 build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Normalize line endings so a Windows checkout doesn't rewrite text to CRLF.
+# Without this, git-for-windows' default core.autocrlf=true checks every file out with
+# CRLF, and prettier (via eslint) then flags every line — which is exactly how the
+# windows-daily CI job first failed. Keep the repo LF-only everywhere; let git decide
+# which files are text.
+* text=auto eol=lf
+
+# Files that MUST stay LF regardless of guesswork: a CRLF here breaks a shebang, a
+# Docker build, or a shell parser on the runner.
+*.sh text eol=lf
+*.mjs text eol=lf
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+Dockerfile* text eol=lf
+
+# Binary assets git must never touch.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary

--- a/.github/workflows/docker-sandbox-windows.yaml
+++ b/.github/workflows/docker-sandbox-windows.yaml
@@ -105,7 +105,9 @@ jobs:
           $rest = $env:GITHUB_WORKSPACE.Substring(3) -replace '\\', '/'
           $wsPath = "/mnt/$drive/$rest"
           Write-Host "workspace in WSL2: $wsPath"
-          wsl -d Ubuntu-22.04 -u root -- bash -c "cd '$wsPath' && docker build --load -f Dockerfile.sandbox -t mulmoterminal-sandbox ."
+          # No --load: WSL2's apt `docker.io` is the legacy builder (no buildx), where
+          # --load is an unknown flag and a plain build already lands in the local store.
+          wsl -d Ubuntu-22.04 -u root -- bash -c "cd '$wsPath' && docker build -f Dockerfile.sandbox -t mulmoterminal-sandbox ."
           if ($LASTEXITCODE -ne 0) { throw "docker build failed inside WSL2" }
 
       # The same assertions the ubuntu job makes, so the two can't drift apart silently.


### PR DESCRIPTION
## Summary

#467 でマージした Windows 系ワークフロー 2 つを main 上で `workflow_dispatch` 起動したところ、**両方とも実際に失敗**しました。その 2 件の設定バグを修正します（どちらも新規ワークフローがマージ後に初めて走って判明したもの。`workflow_dispatch` は新規ワークフローが default branch に存在するまで起動できないため、マージ前には検出できませんでした）。

## 見つかった 2 件の実バグ

### 1. `windows-daily` の lint が `Delete ␍` × 44421 で失敗

`.gitattributes` が無いため、git-for-windows が既定の `core.autocrlf=true` で全ファイルを CRLF に変換してチェックアウトし、prettier(eslint 経由)が全行を弾いていました。

→ `.gitattributes` を追加し、リポジトリ全体で `eol=lf` を強制します。既存の blob は既に LF（`git add --renormalize .` でステージされる変更ゼロを確認済み）なので、**既存ファイルは無変更**で、今後の Windows チェックアウトだけに効きます。皮肉にも、これは `docker-sandbox-windows.yaml` のヘッダコメントで私自身が「`.gitattributes` が無い」と指摘していた当の罠でした。

### 2. `docker-sandbox-windows` のビルドが `unknown flag: --load` で失敗

WSL2 の apt 版 `docker.io` は**レガシービルダー**（buildx 非同梱）で、`--load` は buildx 専用フラグのため使えません。レガシービルダーでは plain build がそのままローカルイメージストアに入るので `--load` は不要です。

→ WSL2 ジョブの `docker build` から `--load` を外します。

**なお WSL2 の足回り自体は全ステップ成功していました**（WSL2 導入・Docker 導入・`dockerd --iptables=false` のヘッドレス起動・`docker info` の readiness poll・`C:\`→`/mnt/c/` パス変換）。診断用の行末レポートも機能し、`CRLF: 30, bare LF: 0` を出力してバグ 1 を可視化していました。誤っていたのはビルドフラグ 1 つだけです。

## User Prompt

（#467 の続き）windows の CI を daily で実行、docker + windows の CI も作る、という依頼で #467 をマージ後、Windows 系ジョブを手動起動して検証したところ失敗したため、その修正。

## 検証

- `.gitattributes` 追加後 `git add --renormalize .` → ステージ変更ゼロ（既存ファイルは LF のまま）
- `yarn lint`（error 0）/ `yarn format:check`（clean）/ YAML 妥当性 OK
- マージ後、両ワークフローを再度 `workflow_dispatch` で起動して green を確認する予定

## 次段

このマージ後、`windows-daily` と `docker-sandbox-windows` を再起動して緑を確認します。

Refs #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
