### PR TITLE
feat(push): notify when a session is blocked on input, not only when it finishes

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -53,7 +53,7 @@ import { publicDirConfig, dirSoundFile, dirConfigWriteTarget, loadDirConfig } fr
 import { loadScripts, resolveScript } from "./files/scripts.js";
 import { buildClaudeArgs } from "./agents/claude-args.js";
 import { resolveSession, type SessionResolution } from "./session/session-resolve.js";
-import { activityHookEffects, resolveHookSessionId, shouldNotifyTaskFinished } from "./session/activity-hook.js";
+import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "./session/activity-hook.js";
 import { buildActivitySnapshot, parseActivityState } from "./session/activity-state.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
@@ -1235,31 +1235,32 @@ app.get(SPA_FALLBACK_RE, (_req, res) => res.sendFile(path.join(__dirname, "../di
 // Activity hooks update a session's working / needs-attention flags. `active` (this
 // session is the user's actively-viewed pane) suppresses the attention flag — see
 // activityHookEffects for why a mere attached socket doesn't count in the grid.
-function handleActivityHook(sessionId: string, event: string, active: boolean) {
+function handleActivityHook(sessionId: string, event: string, active: boolean, message: string) {
   for (const eff of activityHookEffects(event, active)) {
     if (eff.kind === "working") setWorking(sessionId, eff.value, event);
     else setWaiting(sessionId, eff.value, event);
   }
-  // Every finished turn fires a Web Push (see shouldNotifyTaskFinished) — regardless of
-  // whether it's the actively-viewed pane, unlike the attention beep. Stop is one event per
-  // finished turn, so this fires once even though a background Stop publishes twice.
-  if (shouldNotifyTaskFinished(event)) notifyTaskFinished(sessionId);
+  // Push regardless of `active` — the phone is elsewhere, unlike the attention beep.
+  // A finished turn (Stop) and a blocked one (Notification) both reach here; the kind
+  // decides the wording. Stop is one event per finished turn, so this fires once even
+  // though a background Stop publishes twice.
+  const kind = pushKindFor(event);
+  if (kind) notifyTaskFinished(sessionId, kind, message);
 }
 
 const PUSH_TITLE_MAX = 80;
 const PUSH_BODY_MAX = 160;
 // Notify the user's devices that a background task finished, when Web Push is enabled.
 // Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
-function notifyTaskFinished(sessionId: string): void {
+function notifyTaskFinished(sessionId: string, kind: PushKind, message: string): void {
   if (!getPushEnabled()) return;
   // Internal helper turns flow through /api/hook with active=false too — hidden background
   // workers and translation workers aren't real user tasks, so never push for them.
   if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = cwd ? path.basename(cwd) : "session";
-  const what = lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
-  const title = `✅ ${where}`.slice(0, PUSH_TITLE_MAX);
-  const body = (what || "タスクが完了しました").slice(0, PUSH_BODY_MAX);
+  const detail = lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+  const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
   // The session id is what lets the phone open this session from the notification;
   // the host id is what lets it know WHOSE session. Without it the phone opens with
   // no host selected — it never persists one — and can only offer the picker, which
@@ -1431,7 +1432,7 @@ app.post("/api/hook", async (req, res) => {
     const active = !!(entry && entry.active);
     const cwd = typeof body.cwd === "string" ? body.cwd : entry?.cwd;
     await applyHeaderHooks(sessionId, event, body, cwd);
-    handleActivityHook(sessionId, event, active);
+    handleActivityHook(sessionId, event, active, typeof body.message === "string" ? body.message : "");
     await handleToolHook(sessionId, event, body);
     // A hidden translation worker that ends its turn while still pending never called
     // submitTranslation — fail it now rather than hang until the timeout. (When it DID

--- a/server/session/activity-hook.ts
+++ b/server/session/activity-hook.ts
@@ -27,13 +27,47 @@ export function activityHookEffects(event: string, active: boolean): ActivityEff
   return [];
 }
 
-// Whether a finished turn should fire a task-finished Web Push. Unlike the attention beep
-// (activityHookEffects, which stays quiet on the actively-viewed pane), the push fires for
-// EVERY finished turn regardless of `active` — the user wants a phone notification even for
-// the session they're currently looking at. The pushEnabled / hidden / translation gates
-// are applied by the caller.
-export function shouldNotifyTaskFinished(event: string): boolean {
-  return event === "Stop";
+// Which kind of Web Push a hook warrants, or null for none. Two events reach the
+// phone, and they mean different things to a user glancing at a lock screen:
+//   - "finished"  (Stop):         the turn ended, output is waiting to be reviewed.
+//   - "waiting"   (Notification): the agent is blocked on input — a permission
+//                                 prompt or a question — and answering it from the
+//                                 phone actually unblocks work.
+// Only "finished" fired before; "waiting" is the one the user is most likely to want
+// (they cannot know a session is stuck otherwise). Unlike the attention beep, both
+// fire regardless of `active` — the phone is elsewhere. pushEnabled / hidden /
+// translation gates stay with the caller.
+export type PushKind = "finished" | "waiting";
+
+export function pushKindFor(event: string): PushKind | null {
+  if (event === "Stop") return "finished";
+  if (event === "Notification") return "waiting";
+  return null;
+}
+
+// The push title/body for a kind. Pure so the wording is unit-testable without a PTY.
+//   finished: "\u2705 <dir>"        body = the prompt/title, or a done fallback
+//   waiting:  "\u2753 <dir>"        body = the hook's message (e.g. a permission ask), or a fallback
+// `where` is the working-dir basename; `detail` is the session's prompt/title;
+// `message` is the Notification hook's own text (empty for a finished turn).
+export interface PushText {
+  title: string;
+  body: string;
+}
+
+const clip = (text: string, max: number): string => text.slice(0, max);
+
+export function buildPushText(kind: PushKind, where: string, detail: string, message: string, limits: { title: number; body: number }): PushText {
+  if (kind === "waiting") {
+    return {
+      title: clip(`\u2753 ${where}`, limits.title),
+      body: clip(message.trim() || detail.trim() || "\u5165\u529b\u5f85\u3061\u3067\u3059", limits.body),
+    };
+  }
+  return {
+    title: clip(`\u2705 ${where}`, limits.title),
+    body: clip(detail.trim() || "\u30bf\u30b9\u30af\u304c\u5b8c\u4e86\u3057\u307e\u3057\u305f", limits.body),
+  };
 }
 
 // Which session a hook belongs to, or null when neither source names one usably.

--- a/test/server/session/activity-hook.spec.ts
+++ b/test/server/session/activity-hook.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { activityHookEffects, resolveHookSessionId, shouldNotifyTaskFinished } from "../../../server/session/activity-hook.js";
+import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId } from "../../../server/session/activity-hook.js";
 
 describe("activityHookEffects", () => {
   it("UserPromptSubmit sets working regardless of active", () => {
@@ -36,18 +36,49 @@ describe("activityHookEffects", () => {
   });
 });
 
-describe("shouldNotifyTaskFinished", () => {
-  it("fires on every finished turn — unlike the beep, the actively-viewed pane is NOT exempt", () => {
-    // The push takes no `active` argument by design: a Stop notifies whether or not the user
-    // is looking at that pane. This regression-guards against re-adding an active-pane gate.
-    expect(shouldNotifyTaskFinished("Stop")).toBe(true);
+describe("pushKindFor", () => {
+  // A finished turn and a blocked one both reach the phone, and mean different things.
+  it("maps a finished turn to 'finished'", () => {
+    expect(pushKindFor("Stop")).toBe("finished");
   });
 
-  it("does not fire on non-Stop events (a paused turn / prompt / tool use is not a finish)", () => {
-    expect(shouldNotifyTaskFinished("Notification")).toBe(false);
-    expect(shouldNotifyTaskFinished("UserPromptSubmit")).toBe(false);
-    expect(shouldNotifyTaskFinished("PreToolUse")).toBe(false);
-    expect(shouldNotifyTaskFinished("SessionStart")).toBe(false);
+  // The one this feature adds: a paused turn is where the user can actually help.
+  it("maps a paused turn (Notification) to 'waiting'", () => {
+    expect(pushKindFor("Notification")).toBe("waiting");
+  });
+
+  it("is null for events that are neither a finish nor a block", () => {
+    expect(pushKindFor("UserPromptSubmit")).toBeNull();
+    expect(pushKindFor("PreToolUse")).toBeNull();
+    expect(pushKindFor("SessionStart")).toBeNull();
+  });
+});
+
+describe("buildPushText", () => {
+  const limits = { title: 80, body: 160 };
+
+  it("marks a finished turn with a check and shows the prompt", () => {
+    const { title, body } = buildPushText("finished", "myrepo", "fix the parser", "", limits);
+    expect(title).toBe("\u2705 myrepo");
+    expect(body).toBe("fix the parser");
+  });
+
+  it("marks a waiting turn with a question and quotes the hook's message", () => {
+    const { title, body } = buildPushText("waiting", "myrepo", "fix the parser", "Claude needs permission to run Bash", limits);
+    expect(title).toBe("\u2753 myrepo");
+    // The message (what it is blocked ON) beats the prompt — that is what the user answers.
+    expect(body).toBe("Claude needs permission to run Bash");
+  });
+
+  it("falls back to the prompt, then a default, when a waiting hook carries no message", () => {
+    expect(buildPushText("waiting", "myrepo", "fix the parser", "", limits).body).toBe("fix the parser");
+    expect(buildPushText("waiting", "myrepo", "", "  ", limits).body).toBe("\u5165\u529b\u5f85\u3061\u3067\u3059");
+  });
+
+  it("clips title and body to the limits", () => {
+    const { title, body } = buildPushText("finished", "d".repeat(200), "p".repeat(400), "", limits);
+    expect(title).toHaveLength(80);
+    expect(body).toHaveLength(160);
   });
 });
 


### PR DESCRIPTION
## Summary

Web Push が **`Stop`（ターン完了）でしか鳴っていませんでした**。しかし本当にスマホ通知が欲しいのは、エージェントが**入力待ち・許可待ちでブロックした瞬間**です。ユーザーはそれ以外に「詰まっている」ことを知る手段がなく、しかもそこはスマホから答えれば実際に前へ進む場面です。

その状態は既に検知されています（`activity-hook` が `Notification` を "waiting" として扱う）。この PR は**それを通知にも届かせ、完了と入力待ちを一目で区別できる文言**にするだけです:

```
finished  ✅ <dir>   プロンプト（or 完了フォールバック）
waiting   ❓ <dir>   フック自身の message（＝何にブロックされているか）（or フォールバック）
```

## Items to Confirm / Review

- **`Notification` フックは許可待ち以外でも鳴りうる**（手動 `/notification`、長時間アイドル等）。今回はどれも「waiting」として通知します。うるさければ `message` で絞る余地はありますが、まずは全部拾う方針にしました。実機で騒がしければ次で調整します
- **`message` を本文に優先**しています。「何にブロックされているか」がユーザーの答えるべき対象なので、プロンプトより優先しました。無ければプロンプト → 既定文言の順でフォールバック
- **`shouldNotifyTaskFinished` を削除**しました。`Stop` だけを見る薄いラッパーで、kind が要るようになった今は呼び出し元がありません（テスト専用の dead code になっていた）
- **タップ挙動は変わりません** — 通知は従来どおりそのセッションを開きます（#86）。選択肢の抽出・タップ送信は別スコープ（このリポジトリの #472 本体）

## スコープ外（#472 の残り）

「1. Yes / 2. No」のような番号付き選択肢を拾って、通知/画面からタップで答える（タップは入力欄に入れる、送信はしない）。receptron/mulmoserver 側の UI 作業で、TUI 表示への依存の扱いを別途設計します。

## テスト

`pushKindFor` / `buildPushText` を純粋関数として抽出し、PTY なしで配線と文言を検証:

- Stop → finished / Notification → waiting / その他 → null
- waiting は message を引用、無ければプロンプト→既定にフォールバック
- title/body の文字数クリップ

全体 **131 files / 1443 tests pass**。`typecheck` / `typecheck:server` / `lint`（エラー0）/ `format:check` / `build` すべて green。

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
