### PR TITLE
refactor: extract the shared ToolbarPopover scaffold

### DIFF
--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { useTemplateRef } from "vue";
-import { useDropdownMenu } from "../composables/useDropdownMenu";
+import { computed, useTemplateRef } from "vue";
+import ToolbarPopover from "./ToolbarPopover.vue";
 import { useNotifications, type NotifierEntry, type NotifierSeverity } from "../composables/useNotifications";
 
 // Toolbar bell: a severity-coloured unread badge + a dropdown listing the active
@@ -11,13 +11,18 @@ import { useNotifications, type NotifierEntry, type NotifierSeverity } from "../
 // watcher clears it when the record is done; the ✕ dismisses it explicitly.
 const { count, topSeverity, sorted, dismiss, activate } = useNotifications();
 
-const rootRef = useTemplateRef<HTMLElement>("root");
-const { open, close, toggle } = useDropdownMenu(rootRef);
+const popoverRef = useTemplateRef<InstanceType<typeof ToolbarPopover>>("popover");
+
+const triggerTitle = computed(() => {
+  if (!count.value) return "Notifications";
+  const suffix = count.value === 1 ? "" : "s";
+  return `${count.value} notification${suffix}`;
+});
 
 function onRowClick(entry: NotifierEntry) {
   // Navigate if it's a deep-linkable entry; close either way so the click feels live.
   activate(entry);
-  close();
+  popoverRef.value?.close();
 }
 
 function severityClass(severity: NotifierSeverity): string {
@@ -46,58 +51,44 @@ function relativeTime(iso: string): string {
 </script>
 
 <template>
-  <div ref="root" class="toolbar-popover-root">
-    <button
-      type="button"
-      class="toolbar-popover-btn"
-      :class="{ active: open }"
-      :aria-expanded="open"
-      aria-haspopup="true"
-      :title="count ? `${count} notification${count === 1 ? '' : 's'}` : 'Notifications'"
-      aria-label="Notifications"
-      @click="toggle"
-    >
-      <span class="material-symbols-outlined">notifications</span>
+  <ToolbarPopover ref="popover" icon="notifications" :title="triggerTitle" trigger-label="Notifications" pane-class="notif-pop" pane-label="Notifications">
+    <template #trigger-extra>
       <span v-if="count" class="badge" :class="topSeverity ? severityClass(topSeverity) : ''">{{ count > 99 ? "99+" : count }}</span>
-    </button>
+    </template>
 
-    <div v-if="open" class="toolbar-popover notif-pop" role="group" aria-label="Notifications">
-      <div class="notif-head">Notifications</div>
-      <div class="notif-subhead">Active ({{ sorted.length }})</div>
-      <div v-if="!sorted.length" class="notif-empty">You're all caught up.</div>
-      <ul v-else class="notif-list">
-        <li
-          v-for="entry in sorted"
-          :key="entry.id"
-          class="notif-row"
-          :class="{ clickable: !!entry.navigateTarget }"
-          :role="entry.navigateTarget ? 'button' : undefined"
-          :tabindex="entry.navigateTarget ? 0 : undefined"
-          :aria-label="entry.navigateTarget ? entry.title : undefined"
-          :title="entry.body || undefined"
-          @click="onRowClick(entry)"
-          @keydown.enter.prevent.self="entry.navigateTarget && onRowClick(entry)"
-          @keydown.space.prevent.self="entry.navigateTarget && onRowClick(entry)"
-        >
-          <span class="material-symbols-outlined bell-icon" :class="severityClass(entry.severity)" aria-hidden="true">notifications</span>
-          <span class="notif-text">
-            <span class="notif-title-row">
-              <span class="notif-title">{{ entry.title }}</span>
-              <span v-if="entry.lifecycle" class="notif-lifecycle">{{ entry.lifecycle }}</span>
-            </span>
-            <span v-if="entry.body" class="notif-body">{{ entry.body }}</span>
-            <span class="notif-meta">{{ relativeTime(entry.createdAt) }} · {{ shortPkg(entry.pluginPkg) }}</span>
+    <div class="notif-head">Notifications</div>
+    <div class="notif-subhead">Active ({{ sorted.length }})</div>
+    <div v-if="!sorted.length" class="notif-empty">You're all caught up.</div>
+    <ul v-else class="notif-list">
+      <li
+        v-for="entry in sorted"
+        :key="entry.id"
+        class="notif-row"
+        :class="{ clickable: !!entry.navigateTarget }"
+        :role="entry.navigateTarget ? 'button' : undefined"
+        :tabindex="entry.navigateTarget ? 0 : undefined"
+        :aria-label="entry.navigateTarget ? entry.title : undefined"
+        :title="entry.body || undefined"
+        @click="onRowClick(entry)"
+        @keydown.enter.prevent.self="entry.navigateTarget && onRowClick(entry)"
+        @keydown.space.prevent.self="entry.navigateTarget && onRowClick(entry)"
+      >
+        <span class="material-symbols-outlined bell-icon" :class="severityClass(entry.severity)" aria-hidden="true">notifications</span>
+        <span class="notif-text">
+          <span class="notif-title-row">
+            <span class="notif-title">{{ entry.title }}</span>
+            <span v-if="entry.lifecycle" class="notif-lifecycle">{{ entry.lifecycle }}</span>
           </span>
-          <button type="button" class="notif-dismiss" title="Dismiss" aria-label="Dismiss notification" @click.stop="dismiss(entry.id)">
-            <span class="material-symbols-outlined">close</span>
-          </button>
-        </li>
-      </ul>
-    </div>
-  </div>
+          <span v-if="entry.body" class="notif-body">{{ entry.body }}</span>
+          <span class="notif-meta">{{ relativeTime(entry.createdAt) }} · {{ shortPkg(entry.pluginPkg) }}</span>
+        </span>
+        <button type="button" class="notif-dismiss" title="Dismiss" aria-label="Dismiss notification" @click.stop="dismiss(entry.id)">
+          <span class="material-symbols-outlined">close</span>
+        </button>
+      </li>
+    </ul>
+  </ToolbarPopover>
 </template>
-
-<style scoped src="./toolbarPopover.css"></style>
 
 <style scoped>
 /* Unread badge: severity-coloured pill at the top-right of the bell. */
@@ -127,7 +118,8 @@ function relativeTime(iso: string): string {
   background: #e0533d;
 }
 
-.notif-pop {
+/* The panel div lives inside ToolbarPopover, so its scopeId differs from ours. */
+:deep(.notif-pop) {
   width: 340px;
   max-height: 460px;
   overflow-y: auto;

--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -11,12 +11,12 @@ import { onMounted, onUnmounted, ref, useTemplateRef } from "vue";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { renderSVG } from "uqr";
 
+import ToolbarPopover from "./ToolbarPopover.vue";
 import { auth } from "../config/firebase";
 // Session parking (localStorage) + reconnect-outcome decision live in a plain module
 // so they're unit-testable without mounting this Firebase-importing component.
 import { loadStoredSession, persistSession, reconnectAction, type FetchResult, type RemoteHostStatus } from "./remoteHostSession";
 import { registerRemoteHostSelfHeal } from "./remoteHostSelfHeal";
-import { useDropdownMenu } from "../composables/useDropdownMenu";
 import { usePubSub } from "../composables/usePubSub";
 
 // Mobile companion PWA — shown in the dropdown as help text (not fetched here).
@@ -27,10 +27,11 @@ const qrDataUrl = `data:image/svg+xml;base64,${btoa(renderSVG(MOBILE_URL))}`;
 const busy = ref(false);
 const error = ref<string | null>(null);
 const status = ref<RemoteHostStatus>({ connected: false, uid: null });
-const rootRef = useTemplateRef<HTMLElement>("root");
-const { open, close, toggle } = useDropdownMenu(rootRef, () => {
+const popoverRef = useTemplateRef<InstanceType<typeof ToolbarPopover>>("popover");
+
+function onPopoverOpen() {
   refreshStatus().catch(() => undefined);
-});
+}
 
 const errorText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
@@ -96,7 +97,7 @@ async function onConnect() {
     }
     status.value = res.status;
     persistSession(res.session); // park the session for popup-free reconnect after a restart
-    close();
+    popoverRef.value?.close();
   } catch (err) {
     error.value = errorText(err);
   } finally {
@@ -111,7 +112,7 @@ async function onDisconnect() {
   if (res.ok) {
     status.value = res.status;
     persistSession(null); // forget the parked session on an explicit disconnect
-    close();
+    popoverRef.value?.close();
   } else {
     error.value = res.error;
   }
@@ -139,65 +140,54 @@ onUnmounted(() => stopSelfHeal?.());
 </script>
 
 <template>
-  <div ref="root" class="toolbar-popover-root">
-    <button
-      type="button"
-      class="toolbar-popover-btn"
-      :class="{ active: open, connected: status.connected }"
-      :aria-expanded="open"
-      aria-haspopup="true"
-      :title="status.connected ? 'Remote host connected' : 'Remote host'"
-      aria-label="Remote host"
-      @click="toggle"
-    >
-      <span class="material-symbols-outlined">phonelink</span>
+  <ToolbarPopover
+    ref="popover"
+    icon="phonelink"
+    :title="status.connected ? 'Remote host connected' : 'Remote host'"
+    trigger-label="Remote host"
+    pane-class="rh-pop"
+    pane-label="Remote host"
+    :trigger-class="{ connected: status.connected }"
+    @open="onPopoverOpen"
+  >
+    <div class="rh-head">
+      <span class="material-symbols-outlined rh-dot" :class="{ connected: status.connected }">
+        {{ status.connected ? "check_circle" : "radio_button_unchecked" }}
+      </span>
+      <span class="rh-head-label">{{ status.connected ? "Online" : "Offline" }}</span>
+    </div>
+
+    <p v-if="status.uid" class="rh-uid">Signed in as {{ status.uid }}</p>
+
+    <button v-if="!status.connected" type="button" class="rh-action connect" :disabled="busy" @click="onConnect">
+      <span class="material-symbols-outlined">login</span>
+      {{ busy ? "Connecting…" : "Connect (Google sign-in)" }}
+    </button>
+    <button v-else type="button" class="rh-action disconnect" :disabled="busy" @click="onDisconnect">
+      <span class="material-symbols-outlined">logout</span>
+      {{ busy ? "Disconnecting…" : "Disconnect" }}
     </button>
 
-    <div v-if="open" class="toolbar-popover rh-pop" role="group" aria-label="Remote host">
-      <div class="rh-head">
-        <span class="material-symbols-outlined rh-dot" :class="{ connected: status.connected }">
-          {{ status.connected ? "check_circle" : "radio_button_unchecked" }}
-        </span>
-        <span class="rh-head-label">{{ status.connected ? "Online" : "Offline" }}</span>
-      </div>
+    <p v-if="error" class="rh-error">{{ error }}</p>
 
-      <p v-if="status.uid" class="rh-uid">Signed in as {{ status.uid }}</p>
-
-      <button v-if="!status.connected" type="button" class="rh-action connect" :disabled="busy" @click="onConnect">
-        <span class="material-symbols-outlined">login</span>
-        {{ busy ? "Connecting…" : "Connect (Google sign-in)" }}
-      </button>
-      <button v-else type="button" class="rh-action disconnect" :disabled="busy" @click="onDisconnect">
-        <span class="material-symbols-outlined">logout</span>
-        {{ busy ? "Disconnecting…" : "Disconnect" }}
-      </button>
-
-      <p v-if="error" class="rh-error">{{ error }}</p>
-
-      <div class="rh-help">
-        <p>Drive this terminal from your phone over a Firestore command channel — list collections, browse records, and start a chat.</p>
-        <p>
-          Open
-          <a :href="MOBILE_URL" target="_blank" rel="noopener noreferrer" class="rh-link">{{ MOBILE_URL }}</a>
-          on your phone, signed in with the same Google account.
-        </p>
-        <div class="rh-qr">
-          <img :src="qrDataUrl" alt="" aria-hidden="true" />
-          <p>Or scan this QR code with your phone's camera.</p>
-        </div>
+    <div class="rh-help">
+      <p>Drive this terminal from your phone over a Firestore command channel — list collections, browse records, and start a chat.</p>
+      <p>
+        Open
+        <a :href="MOBILE_URL" target="_blank" rel="noopener noreferrer" class="rh-link">{{ MOBILE_URL }}</a>
+        on your phone, signed in with the same Google account.
+      </p>
+      <div class="rh-qr">
+        <img :src="qrDataUrl" alt="" aria-hidden="true" />
+        <p>Or scan this QR code with your phone's camera.</p>
       </div>
     </div>
-  </div>
+  </ToolbarPopover>
 </template>
 
-<style scoped src="./toolbarPopover.css"></style>
-
 <style scoped>
-.toolbar-popover-btn.connected {
-  color: #35c46a;
-}
-
-.rh-pop {
+/* The panel div lives inside ToolbarPopover, so its scopeId differs from ours. */
+:deep(.rh-pop) {
   width: 300px;
   gap: 8px;
   padding: 10px;

--- a/src/components/ToolbarPopover.vue
+++ b/src/components/ToolbarPopover.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+// Shared scaffold for the toolbar popovers (notifications, remote host): a square
+// icon trigger that toggles an anchored panel. Owns the open/close state and the
+// outside-click / Escape dismissal via useDropdownMenu; each consumer supplies its
+// own trigger extras (slot) and panel body (default slot).
+import { useTemplateRef } from "vue";
+import { useDropdownMenu } from "../composables/useDropdownMenu";
+
+defineProps<{
+  icon: string;
+  title: string;
+  triggerLabel: string;
+  paneClass: string;
+  paneLabel: string;
+  triggerClass?: Record<string, boolean>;
+}>();
+
+const emit = defineEmits<{ open: [] }>();
+
+const rootRef = useTemplateRef<HTMLElement>("root");
+const { open, close, toggle } = useDropdownMenu(rootRef, () => emit("open"));
+
+defineExpose({ close });
+</script>
+
+<template>
+  <div ref="root" class="toolbar-popover-root">
+    <button
+      type="button"
+      class="toolbar-popover-btn"
+      :class="[{ active: open }, triggerClass]"
+      :aria-expanded="open"
+      aria-haspopup="true"
+      :title="title"
+      :aria-label="triggerLabel"
+      @click="toggle"
+    >
+      <span class="material-symbols-outlined">{{ icon }}</span>
+      <slot name="trigger-extra" />
+    </button>
+
+    <div v-if="open" class="toolbar-popover" :class="paneClass" role="group" :aria-label="paneLabel">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped src="./toolbarPopover.css"></style>

--- a/src/components/toolbarPopover.css
+++ b/src/components/toolbarPopover.css
@@ -26,6 +26,11 @@
   background: var(--bg-hover);
   color: var(--text);
 }
+/* Remote-host "online" accent on the trigger; declared after .active so it wins
+   the colour when the panel is also open. */
+.toolbar-popover-btn.connected {
+  color: #35c46a;
+}
 .toolbar-popover-btn .material-symbols-outlined {
   font-size: 19px;
   line-height: 1;


### PR DESCRIPTION
## Summary

`NotificationBell` and `RemoteHostControl` repeated the same toolbar-popover scaffold — the root ref, the `useDropdownMenu` wiring, the icon trigger button with its six attributes, and the `v-if="open"` panel wrapper (**~53 lines of duplicated HTML**, the largest remaining clone jscpd reported). `ToolbarPopover.vue` now owns all of it. These two already shared `useDropdownMenu` + `toolbarPopover.css`; this completes the pattern.

Pure refactor, no behavior change. Part of #452.

## Items to Confirm / Review

- **The CSS scoping is the subtle part — I verified it in the built output, in isolation.** After splitting this change onto its own clean branch (see the note below), I built and checked `dist/assets/*.css`:
  - `.toolbar-popover-btn` → a **single** scopeId (`data-v-0314346c`), no unscoped copy
  - `.toolbar-popover-btn.connected` → same scopeId, and still ordered after `.active`/`:hover` so a connected button stays tinted while open
  - `.notif-pop` / `.rh-pop` → `[data-v-…] .notif-pop` / `.rh-pop`, i.e. `:deep()` scoped to each consumer (their panel div now carries ToolbarPopover's scopeId, so the panel classes had to become `:deep`)
- **Two-hop scopeId forwarding.** `AppToolbar → NotificationBell → ToolbarPopover` is now a 2-hop chain; `AppToolbar`'s `.toolbar-bell { margin-left:auto }` and the `:deep` panel rules rely on Vue forwarding each ancestor's scopeId onto the deepest root element. This works in this Vue 3.5 version, but it's the thing most likely to bite on a Vue upgrade — worth a conscious ✅.
- **`aria-label` is passed as `triggerLabel`/`paneLabel` props, not `ariaLabel`.** `vue-tsc` treats a static `aria-label="…"` as a native DOM attribute rather than a camelCase prop, so the label props are named to avoid that. Minor API wart; flagging it.
- **`close()` is exposed via `defineExpose` and called through a template ref** (`popoverRef.value?.close()`) — NotificationBell's row-click dismissal and RemoteHostControl's close-after-connect both go through it. `open` is emitted so RemoteHostControl keeps refreshing status when the panel opens. Please confirm the ref-based `close` is acceptable vs. an event-based approach.
- **NotificationBell's title moved from an inline template ternary into a `triggerTitle` computed** (to clear a sonarjs nested-ternary warning the extraction surfaced). Logic is identical: `count ? "N notification(s)" : "Notifications"`.

## Note on how this was produced

This change was written by a subagent that ran concurrently with another refactor in the **same working tree**, so its own `yarn build`/`vitest` verification ran against a contaminated tree. I re-split it onto a clean branch containing **only** these four files and re-verified from scratch — that's the verification below.

## Verification (isolated, clean branch)

- `vue-tsc -b --force` → **0 errors**
- `eslint` on the three components → **0 errors**
- `vite build` → succeeds; CSS scoping confirmed as tabled above
- `vitest run test/src/components/` → **396 passed**
- Diffs reviewed line-by-line: the trigger's six attributes, all panel markup, aria attributes, and the close/open/connected wiring are preserved exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)