### PR TITLE
refactor: share the session-list filter logic and chrome

### DIFF
--- a/src/components/SessionFilters.vue
+++ b/src/components/SessionFilters.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { Filter } from "../composables/useSessions";
+import FilterChip from "./FilterChip.vue";
+
+// The All / Unread chips + recency re-sort button, shared by the vertical
+// Sidebar and the horizontal SessionTabBar. `alignRefreshEnd` pushes the sort
+// button to the far end of the row (the vertical sidebar's full-width layout).
+defineProps<{
+  filter: Filter;
+  unreadCount: number;
+  alignRefreshEnd?: boolean;
+}>();
+const emit = defineEmits<{
+  (e: "update:filter", f: Filter): void;
+  (e: "refresh"): void;
+}>();
+</script>
+
+<template>
+  <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
+  <FilterChip label="Unread" :count="unreadCount" :active="filter === 'unread'" @click="emit('update:filter', 'unread')" />
+  <button
+    class="icon-btn sort-btn"
+    :class="{ 'push-end': alignRefreshEnd }"
+    title="Sort by most recent"
+    aria-label="Sort by most recent"
+    @click="emit('refresh')"
+  >
+    <span class="material-symbols-outlined">refresh</span>
+  </button>
+</template>
+
+<style scoped src="./sessionList.css"></style>
+<style scoped>
+.sort-btn {
+  font-size: 14px;
+}
+.sort-btn.push-end {
+  margin-left: auto;
+}
+</style>

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { isUnread, type Session, type Filter } from "../composables/useSessions";
-import FilterChip from "./FilterChip.vue";
+import { useSessionFilter, type SessionListEmits } from "../composables/sessionList";
+import SessionFilters from "./SessionFilters.vue";
 
 // Presentational: list + filter are owned by App.vue and shared with the
 // vertical Sidebar, so switching layouts preserves them (no refetch/reset).
@@ -10,25 +11,16 @@ const props = defineProps<{
   activeId: string | null;
   filter: Filter;
 }>();
-const emit = defineEmits<{
-  (e: "select", id: string, agent: "claude" | "codex"): void;
-  (e: "new" | "new-codex" | "toggle-layout" | "refresh"): void;
-  (e: "update:filter", f: Filter): void;
-}>();
+const emit = defineEmits<SessionListEmits>();
 
-// Same "unread" mapping as the vertical sidebar (waiting, excluding hidden
-// background workers); the filter applies to the horizontal tabs too.
-const unreadCount = computed(() => props.sessions.filter(isUnread).length);
+const { unreadCount, filteredSessions } = useSessionFilter(props);
 
 // The horizontal bar never scrolls — tabs flex to share the available width.
 // Cap to the most-recent N (sessions are already sorted by recency) so they
 // don't shrink to unreadable slivers when there are many. The unread filter
 // applies before the cap.
 const MAX_TABS = 8;
-const visibleSessions = computed(() => {
-  const list = props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions;
-  return list.slice(0, MAX_TABS);
-});
+const visibleSessions = computed(() => filteredSessions.value.slice(0, MAX_TABS));
 </script>
 
 <template>
@@ -39,11 +31,7 @@ const visibleSessions = computed(() => {
     <button class="new-btn new-codex-btn" title="New Codex session" aria-label="New Codex session" @click="emit('new-codex')">cx</button>
 
     <div class="filters">
-      <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
-      <FilterChip label="Unread" :count="unreadCount" :active="filter === 'unread'" @click="emit('update:filter', 'unread')" />
-      <button class="icon-btn sort-btn" title="Sort by most recent" aria-label="Sort by most recent" @click="emit('refresh')">
-        <span class="material-symbols-outlined">refresh</span>
-      </button>
+      <SessionFilters :filter="filter" :unread-count="unreadCount" @update:filter="emit('update:filter', $event)" @refresh="emit('refresh')" />
     </div>
 
     <div class="tabs">
@@ -121,10 +109,6 @@ const visibleSessions = computed(() => {
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
-}
-
-.sort-btn {
-  font-size: 14px;
 }
 
 .tabs {
@@ -205,16 +189,5 @@ const visibleSessions = computed(() => {
   gap: 8px;
   flex-shrink: 0;
 }
-
-.icon-btn {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 16px;
-  cursor: pointer;
-  line-height: 1;
-}
-.icon-btn:hover {
-  color: var(--text);
-}
 </style>
+<style scoped src="./sessionList.css"></style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed } from "vue";
 import { isUnread, type Session, type Filter } from "../composables/useSessions";
-import FilterChip from "./FilterChip.vue";
+import { useSessionFilter, type SessionListEmits } from "../composables/sessionList";
+import SessionFilters from "./SessionFilters.vue";
 
 // Presentational: the session list + filter are owned by App.vue (a single
 // useSessions instance shared across layouts) so toggling vertical/horizontal
@@ -13,17 +13,9 @@ const props = defineProps<{
   activeId: string | null;
   filter: Filter;
 }>();
-const emit = defineEmits<{
-  (e: "select", id: string, agent: "claude" | "codex"): void;
-  (e: "new" | "new-codex" | "toggle-layout" | "refresh"): void;
-  (e: "update:filter", f: Filter): void;
-}>();
+const emit = defineEmits<SessionListEmits>();
 
-// A session that is `waiting` for the user's attention is what mulmoclaude calls
-// "unread" — render it bold and let the user filter to just those rows. Hidden
-// background workers are excluded (see isUnread).
-const unreadCount = computed(() => props.sessions.filter(isUnread).length);
-const visibleSessions = computed(() => (props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions));
+const { unreadCount, filteredSessions } = useSessionFilter(props);
 
 function relativeTime(ms: number): string {
   const diff = Date.now() - ms;
@@ -53,11 +45,13 @@ function relativeTime(ms: number): string {
     </div>
 
     <div class="filters">
-      <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
-      <FilterChip label="Unread" :count="unreadCount" :active="filter === 'unread'" @click="emit('update:filter', 'unread')" />
-      <button class="icon-btn sort-btn" title="Sort by most recent" aria-label="Sort by most recent" @click="emit('refresh')">
-        <span class="material-symbols-outlined">refresh</span>
-      </button>
+      <SessionFilters
+        :filter="filter"
+        :unread-count="unreadCount"
+        align-refresh-end
+        @update:filter="emit('update:filter', $event)"
+        @refresh="emit('refresh')"
+      />
     </div>
 
     <div v-if="loading" class="state">Loading…</div>
@@ -65,11 +59,11 @@ function relativeTime(ms: number): string {
       {{ error }}
     </div>
     <div v-else-if="sessions.length === 0" class="state">No sessions yet</div>
-    <div v-else-if="visibleSessions.length === 0" class="state">No unread sessions</div>
+    <div v-else-if="filteredSessions.length === 0" class="state">No unread sessions</div>
 
     <ul v-else class="list">
       <li
-        v-for="s in visibleSessions"
+        v-for="s in filteredSessions"
         :key="s.id"
         :class="['item', { active: s.id === props.activeId, waiting: isUnread(s) }]"
         :title="s.title"
@@ -113,18 +107,6 @@ function relativeTime(ms: number): string {
   color: var(--text-muted);
 }
 
-.icon-btn {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 16px;
-  cursor: pointer;
-  line-height: 1;
-}
-.icon-btn:hover {
-  color: var(--text);
-}
-
 .new-btn {
   display: flex;
   align-items: center;
@@ -162,12 +144,6 @@ function relativeTime(ms: number): string {
   align-items: center;
   gap: 6px;
   padding: 0 12px 8px;
-}
-
-/* Recency re-sort sits with the list controls, pushed to the far right. */
-.sort-btn {
-  margin-left: auto;
-  font-size: 14px;
 }
 
 .state {
@@ -254,3 +230,4 @@ function relativeTime(ms: number): string {
   color: var(--text-dim);
 }
 </style>
+<style scoped src="./sessionList.css"></style>

--- a/src/components/sessionList.css
+++ b/src/components/sessionList.css
@@ -1,0 +1,11 @@
+.icon-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  line-height: 1;
+}
+.icon-btn:hover {
+  color: var(--text);
+}

--- a/src/composables/sessionList.ts
+++ b/src/composables/sessionList.ts
@@ -1,0 +1,18 @@
+import { computed } from "vue";
+import { isUnread, type Session, type Filter } from "./useSessions";
+
+// The event contract App.vue wires to both session-list layouts (the vertical
+// Sidebar and the horizontal SessionTabBar); v-model:filter drives update:filter.
+export type SessionListEmits = {
+  (e: "select", id: string, agent: "claude" | "codex"): void;
+  (e: "new" | "new-codex" | "toggle-layout" | "refresh"): void;
+  (e: "update:filter", f: Filter): void;
+};
+
+// The Unread chip's count and the filter-applied list, shared by both layouts.
+// The horizontal bar caps `filteredSessions` to its most-recent tabs itself.
+export function useSessionFilter(props: { sessions: Session[]; filter: Filter }) {
+  const unreadCount = computed(() => props.sessions.filter(isUnread).length);
+  const filteredSessions = computed(() => (props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions));
+  return { unreadCount, filteredSessions };
+}


### PR DESCRIPTION
## Summary

`SessionTabBar` (horizontal tabs) and `Sidebar` (vertical) are two views of the same session list and repeated three clones jscpd flagged: the emit contract (~19 lines), the `unreadCount`/filter computeds, and the All/Unread + refresh row (~11 lines HTML + ~14 lines CSS).

- `sessionList.ts` — `SessionListEmits` (consumed as `defineEmits<SessionListEmits>()`) + `useSessionFilter(props)` → `{ unreadCount, filteredSessions }`
- `SessionFilters.vue` — the All/Unread chips + recency-sort button, with an `alignRefreshEnd` prop for the sidebar's push-to-far-end layout
- `sessionList.css` — the shared `.icon-btn` block via `<style scoped src>`

Pure refactor, no behavior change. Part of #452.

## Items to Confirm / Review

- **`MAX_TABS` cap is preserved.** `SessionTabBar` now does `visibleSessions = filteredSessions.value.slice(0, MAX_TABS)`; `Sidebar` uses `filteredSessions` uncapped. Please confirm the tab bar still caps and the sidebar still doesn't — that asymmetry is intentional and the whole reason they aren't the same component.
- **`unreadCount` counts all sessions, not the capped/filtered view** — `props.sessions.filter(isUnread).length`, matching both originals (the Unread badge reflects the true count even when the tab bar only shows the most-recent N). Preserved in the shared composable.
- **`.icon-btn` scoping verified in the built output:** 5 distinct `data-v-*` scopes (my three consumers + two pre-existing components that independently define `.icon-btn`), **no unscoped copy**. `<style scoped src>` preserves scoping — the sort button's `.sort-btn`/`.push-end` rules stay in `SessionFilters`' own scope.
- **`SessionListEmits` is an imported type used in the `defineEmits` macro** — Vue 3.5 supports this. Worth a glance since imported-type-in-macro is a relatively recent capability.
- **Deliberately left duplicated** (coincidental, not shared concepts): the `.spinner` (different display model + animation name per layout), `.agent-badge` (different padding/text — "cx" vs "codex"), `.new-btn` (26px square vs padded labeled row), and the `.filters` container (each layout owns its wrapper — one is `flex-shrink:0`, the other padded). Merging these would be false abstractions.

## Note on how this was produced

Written by a subagent that ran concurrently with another refactor in the **same working tree**, so its own verification ran against a contaminated tree. I re-split it onto a clean branch with **only** these five files and re-verified from scratch (below).

## Verification (isolated, clean branch)

- `vue-tsc -b --force` → **0 errors**; `vue-tsc -p tsconfig.test.json` → **0**
- `eslint` on the four code files → **0 errors**
- `vite build` → succeeds; `.icon-btn` scoping confirmed as above
- `vitest run test/src/components/` → **396 passed**, including `Sidebar.spec` (9/9), which mounts the real `SessionFilters` and asserts the forwarded `update:filter`/`refresh` emits + `.chip`/`.sort-btn` still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)