### PR TITLE
refactor: share the WebSocket connection-param parsing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2539,24 +2539,28 @@ function resolveClaudeSession(requested: string | null, cwd: string): SessionRes
   return resolveSession(requested, { hasLivePty, tmuxAlive, onDisk }, randomUUID);
 }
 
+// The params every terminal WebSocket reads: the request URL, the validated
+// session id, and the resolved cwd. A non-UUID session id is treated as "no
+// session" — it could otherwise smuggle path/flag fragments into
+// sessionExistsOnDisk / --resume — and cwd (?cwd=<abs>) falls back to CLAUDE_CWD.
+function wsConnectionContext(req: { url?: string }): { url: URL; requested: string | null; cwd: string } {
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const raw = url.searchParams.get("session");
+  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
+  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+  return { url, requested, cwd };
+}
+
 wss.on("connection", (ws, req) => {
   // ?session=<id> resumes an existing conversation; absent => fresh session. For
   // new sessions we generate the id ourselves (--session-id) so the server always
   // knows the current session's id, even before any file exists.
-  const url = new URL(req.url ?? "/", "http://localhost");
-  const raw = url.searchParams.get("session");
-  // A non-UUID id is never used (it could smuggle path/flag fragments into
-  // sessionExistsOnDisk / --resume). Treat it as "no session requested" rather
-  // than closing the socket — closing without a replacement id makes the client
-  // auto-reconnect with the same bad id forever. Falling through mints a fresh
-  // session and tells the browser the new id, so the cell self-recovers.
-  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
-  if (raw && !requested) console.warn(`[ws] ignoring non-UUID session id: ${JSON.stringify(raw)} — starting fresh`);
-
-  // The cell may launch a terminal in a chosen directory (?cwd=<abs>). Validated
-  // (absolute, existing dir) and used as the PTY cwd + the project to resume from;
-  // falls back to CLAUDE_CWD.
-  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+  const { url, requested, cwd } = wsConnectionContext(req);
+  // A bad id is never silently reused — closing the socket without a replacement
+  // makes the client auto-reconnect with the same bad id forever, so we warn and
+  // fall through to mint a fresh session, then tell the browser the new id.
+  const rawSession = url.searchParams.get("session");
+  if (rawSession && !requested) console.warn(`[ws] ignoring non-UUID session id: ${JSON.stringify(rawSession)} — starting fresh`);
 
   // ?gui=0 (the grid's dev terminals) spawns claude WITHOUT the GUI plugin MCP /
   // --strict-mcp-config, so the user's + project's MCP servers load normally. Absent
@@ -2746,10 +2750,7 @@ function resolveLaunchSession(
 // lifecycle (reattach + reap grace + handleClientClose) but with no hooks/transcript,
 // and is marked a dev-terminal session so it stays out of the chat sidebar.
 runLaunchWss.on("connection", (ws, req) => {
-  const url = new URL(req.url ?? "/", "http://localhost");
-  const raw = url.searchParams.get("session");
-  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
-  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+  const { url, requested, cwd } = wsConnectionContext(req);
   const indexRaw = url.searchParams.get("launcher");
   const index = indexRaw !== null && /^\d+$/.test(indexRaw) ? Number(indexRaw) : NaN;
   const shell = url.searchParams.get("shell") === "1";
@@ -2870,10 +2871,7 @@ function startCodexEntry(
 // codex without the GUI MCP and keeps it out of the sidebar; absent (single view) attaches the GUI
 // MCP so codex drives the GUI panel like claude.
 runCodexWss.on("connection", (ws, req) => {
-  const url = new URL(req.url ?? "/", "http://localhost");
-  const raw = url.searchParams.get("session");
-  const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
-  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+  const { url, requested, cwd } = wsConnectionContext(req);
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);


### PR DESCRIPTION
## Summary

The three terminal WebSocket handlers (claude `/ws`, launcher `/ws/launch`, codex `/ws/codex`) each opened with the same four lines: parse the request URL, validate the session id against `SESSION_ID_RE`, resolve cwd. `wsConnectionContext(req)` now returns `{ url, requested, cwd }`.

Part of the #452 sweep. Follows #461, which shared the other PTY plumbing in this file.

## Items to Confirm / Review

- **`server/index.ts` has no unit-test file**, so the green suite proves little about this specifically. I smoke-tested `/ws/launch` (one of the three refactored sites) against a running server:
  - valid UUID session id → connects, **cwd resolves to the requested dir**, output frames + clean exit
  - bad session id (`bad-id`) → **fresh id minted, no crash**, cwd still resolves
  Both confirm `wsConnectionContext` threads `requested` and `cwd` correctly.
- **The main `/ws` handler keeps its warn-on-non-UUID log; the launcher/codex sockets deliberately still don't get it.** To preserve that exactly, `/ws` reads the raw session param back from the returned `url` (`url.searchParams.get("session")`) for its warn — so no site gains or loses the warning. If you'd actually prefer all three sockets to warn on a bad id (arguably better), say so and I'll lift the warn into the helper as a separate, intentional change — I kept it out to stay a pure refactor.
- **`resolveButtonRun`'s session parse was left alone.** It uses the same `SESSION_ID_RE.test(...)` shape but in a different context — it operates on an already-parsed `url` and resolves no cwd — so folding it in would be a false match.
- **`req` is typed structurally as `{ url?: string }`** (the only field used) rather than importing `http.IncomingMessage`, matching how the handlers already use it.

## Verification

- `yarn test` → **1470 passed**
- `yarn typecheck:server` → 0 errors; `eslint` → 0 errors (the one `spawnClaudePty` max-params warning is pre-existing and documented)
- live `/ws/launch` smoke test as described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)