### PR TITLE
refactor: share the identical cell-chrome rules across all three cell kinds

### DIFF
--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -205,6 +205,7 @@ function onHeaderClick(event: MouseEvent) {
   </div>
 </template>
 
+<style scoped src="./cellChromeBase.css"></style>
 <style scoped src="./cellChrome.css"></style>
 
 <style scoped>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -99,4 +99,5 @@ function relaunch() {
   </div>
 </template>
 
+<style scoped src="./cellChromeBase.css"></style>
 <style scoped src="./cellChrome.css"></style>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1209,6 +1209,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   </div>
 </template>
 
+<style scoped src="./cellChromeBase.css"></style>
+
 <style scoped>
 .cell {
   position: relative; /* anchors the diff overlay */
@@ -1261,44 +1263,12 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   color: var(--warn);
   border-bottom-color: var(--amber);
 }
-/* A filmstrip thumbnail's header is a click target: zoom (switch to) this terminal.
-   Signalled with a pointer cursor + a hover tint so it's discoverable. (Normal grid
-   cells are not zoomable by header click — only the ⤢ button.) */
-.cell-header.is-zoomable {
-  cursor: pointer;
-}
-.cell-header.is-zoomable:hover {
-  background: var(--bg-hover);
-}
-
-/* Status dot: idle / working (pulsing blue) / done (static blue) / blocked (amber). */
-.cell-dot {
-  flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  /* Custom color tints the idle dot; the status classes below override it while
-     working/waiting so the activity signal stays intact. */
-  background: var(--cell-dot, var(--text-dim));
-}
-.cell-dot.is-working {
-  background: var(--accent);
-  animation: pulse 1.2s ease-in-out infinite;
-}
+/* The done/blocked dot states (idle + working + pulse live in cellChromeBase.css). */
 .cell-dot.is-done {
   background: var(--accent);
 }
 .cell-dot.is-blocked {
   background: var(--amber);
-}
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
 }
 
 .cell-dir {
@@ -1443,40 +1413,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   align-items: center;
   gap: 8px;
 }
-/* Never shrinks, never scrolls away: expand + close stay pinned at the top-right. */
-.cell-actions {
-  flex: 0 0 auto;
-  display: flex;
-  gap: 4px;
-}
-.cell-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 26px;
-  border: none;
-  background: transparent;
-  color: var(--cell-btn, var(--text-secondary));
-  cursor: pointer;
-  font-size: 16px;
-  line-height: 1;
-  border-radius: 6px;
-}
-.cell-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.cell-close:hover {
-  background: var(--err-hover-bg);
-  color: var(--err-text);
-}
-
-.cell-term {
-  flex: 1;
-  min-height: 0;
-}
-
 /* Empty cell: pick a directory, then launch. */
 .cell-launch {
   flex: 1;

--- a/src/components/cellChrome.css
+++ b/src/components/cellChrome.css
@@ -1,7 +1,9 @@
-/* Chrome shared by the non-Claude grid cells (CommandCell, LauncherCell): the
-   frame, the header strip, and its status dot / path / label / buttons. Colors are
-   the same theme tokens TerminalCell uses, so all three cell kinds recolor together
-   when the app theme changes — and pick up a directory's .mulmoterminal.json tint
+/* Frame + header/path/label chrome specific to the non-Claude grid cells
+   (CommandCell, LauncherCell). The rules identical to every cell kind — the
+   zoomable-header affordance, the status dot, the action buttons — live in
+   cellChromeBase.css, which these two import alongside this file. Colors are the
+   same theme tokens TerminalCell uses, so all three cell kinds recolor together
+   when the app theme changes, and pick up a directory's .mulmoterminal.json tint
    through the same override vars the moment one is set. */
 .cell {
   display: flex;
@@ -23,34 +25,6 @@
   padding: 0 8px;
   background: var(--cell-header-bg, var(--bg-panel));
   border-bottom: 1px solid var(--border);
-}
-/* Header background is a click target: zoom (switch to) this cell. */
-.cell-header.is-zoomable {
-  cursor: pointer;
-}
-.cell-header.is-zoomable:hover {
-  background: var(--bg-hover);
-}
-
-.cell-dot {
-  flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--cell-dot, var(--text-dim));
-}
-.cell-dot.is-working {
-  background: var(--accent);
-  animation: pulse 1.2s ease-in-out infinite;
-}
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.35;
-  }
 }
 
 .cell-dir {
@@ -82,37 +56,4 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.cell-actions {
-  flex: 0 0 auto;
-  display: flex;
-  gap: 4px;
-}
-.cell-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 26px;
-  border: none;
-  background: transparent;
-  color: var(--cell-btn, var(--text-secondary));
-  cursor: pointer;
-  font-size: 16px;
-  line-height: 1;
-  border-radius: 6px;
-}
-.cell-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.cell-close:hover {
-  background: var(--err-hover-bg);
-  color: var(--err-text);
-}
-
-.cell-term {
-  flex: 1;
-  min-height: 0;
 }

--- a/src/components/cellChromeBase.css
+++ b/src/components/cellChromeBase.css
@@ -1,0 +1,66 @@
+/* The grid-cell chrome rules that are identical across every cell kind — the Claude
+   cell (TerminalCell), the command cell, and the launcher cell: the zoomable-header
+   affordance, the status dot's working/pulse animation, and the action buttons. Each
+   cell's own stylesheet layers its cell-specific rules (frame, header tint, dir, and
+   any status states) on top. */
+.cell-header.is-zoomable {
+  cursor: pointer;
+}
+.cell-header.is-zoomable:hover {
+  background: var(--bg-hover);
+}
+
+.cell-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  /* Custom color tints the idle dot; the status classes override it while active. */
+  background: var(--cell-dot, var(--text-dim));
+}
+.cell-dot.is-working {
+  background: var(--accent);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.cell-actions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+}
+.cell-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 26px;
+  border: none;
+  background: transparent;
+  color: var(--cell-btn, var(--text-secondary));
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  border-radius: 6px;
+}
+.cell-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.cell-close:hover {
+  background: var(--err-hover-bg);
+  color: var(--err-text);
+}
+
+.cell-term {
+  flex: 1;
+  min-height: 0;
+}


### PR DESCRIPTION
## Summary

After the theme-var change (#468), `TerminalCell` and `cellChrome.css` carried the **same rules** for the zoomable-header affordance, the status dot + pulse, and the action buttons — jscpd's single largest remaining clone (~70L, and my own #468 is what made them converge). `cellChromeBase.css` now holds exactly the rules that are **byte-identical** across all three cell kinds; the Claude, command, and launcher cells all import it.

`TerminalCell.vue` **2070 → 2006** lines. This is the "integrate TerminalCell" follow-up from #452 — the one I'd been deferring because TerminalCell is central and this touches pixels.

**Review aid (4 themes × 4 states):** https://claude.ai/code/artifact/97b08ae2-10ff-47e4-bf84-b0c89ce21a38

## Items to Confirm / Review

- **This touches a central 2000-line component and moves CSS, so verify carefully.** It is a *pure move* — no CSS value changed — so before == after by construction. I confirmed it three ways:
  1. **Built CSS**: each of the three importers gets `.cell-btn[data-v-<hash>]` under its own scopeId, and — the subtle part — its own `@keyframes pulse-<hash>` paired to its `.cell-dot.is-working { animation: … pulse-<hash> }`. So the working-dot animation still resolves *per component* (Vue rewrites both the keyframe name and the reference together). No unscoped `.cell-btn` leaked.
  2. **Visual**: rendered the Claude cell's dot across all four themes × idle/working/done/blocked from the real base + status rules — all render as before (see artifact).
  3. `vitest` full suite → 1470 passed.
- **What I deliberately did NOT merge** (these look similar to jscpd but legitimately differ — folding them would be a false abstraction):
  - `.cell` — TerminalCell adds `position: relative` (anchors the diff overlay)
  - `.cell-header` — TerminalCell adds `--cell-header-fg` + working/done/blocked tints
  - `.cell-dot.is-done` / `.is-blocked` — TerminalCell-only states
  - **`.cell-dir` — a `<button>` in TerminalCell (max-width 60%, border/padding reset, cursor) vs a `<span>` in the other two.** This is the one that made a naive "TerminalCell imports cellChrome.css wholesale" unsafe, and why I extracted only the truly-identical base instead.
  - `.cell-cmd` — the command/launcher label; TerminalCell has no such element
- **Each cell now has an extra `<style scoped src="./cellChromeBase.css">` block.** CommandCell/LauncherCell import base + `cellChrome.css` (trimmed to their specifics); TerminalCell imports base + keeps its own big block. Three components, one new file.
- **The `.cell-dir` in the artifact renders as a plain box** — a harness limitation (I didn't feed it `.cell-dir`, which stays in TerminalCell untouched), not a regression.

## User Prompt

> TerminalCell も統合 … 4テーマ×4状態(idle/working/done/blocked)を実レンダリングで比較

## Verification

- `vue-tsc -b --force` → 0 errors · `eslint` → 0 · `vite build` → succeeds
- `vitest run` → **1470 passed / 133 files**
- built-CSS scoping + per-component keyframe pairing confirmed; 4×4 visual in the artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)