### PR TITLE
test: make dir-config write-target tests platform-agnostic (Windows) — #478 (A)

### DIFF
--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -198,17 +198,21 @@ describe("loadDirConfig", () => {
 });
 
 describe("dirConfigWriteTarget", () => {
-  const file = "/Users/me/proj/.mulmoterminal.json";
+  // Built through `path` so inputs and expectations carry the running platform's drive
+  // and separators — the function returns path.resolve()'d dirs, which on Windows are
+  // `D:\...` with backslashes, not POSIX literals.
+  const projDir = path.resolve("/Users/me/proj");
+  const file = path.join(projDir, ".mulmoterminal.json");
 
   it("returns the directory for each file-writing tool", () => {
     for (const tool of ["Write", "Edit", "MultiEdit"]) {
-      expect(dirConfigWriteTarget(tool, { file_path: file })).toBe("/Users/me/proj");
+      expect(dirConfigWriteTarget(tool, { file_path: file })).toBe(projDir);
     }
   });
 
   it("resolves a relative path against the SESSION cwd, not the server's", () => {
-    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" }, "/Users/me/proj")).toBe("/Users/me/proj");
-    expect(dirConfigWriteTarget("Write", { file_path: "sub/.mulmoterminal.json" }, "/Users/me/proj")).toBe("/Users/me/proj/sub");
+    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" }, projDir)).toBe(projDir);
+    expect(dirConfigWriteTarget("Write", { file_path: path.join("sub", ".mulmoterminal.json") }, projDir)).toBe(path.join(projDir, "sub"));
   });
 
   it("publishes nothing for a relative path when the session cwd is unknown", () => {
@@ -218,7 +222,7 @@ describe("dirConfigWriteTarget", () => {
   });
 
   it("ignores the session cwd for an absolute path", () => {
-    expect(dirConfigWriteTarget("Write", { file_path: file }, "/somewhere/else")).toBe("/Users/me/proj");
+    expect(dirConfigWriteTarget("Write", { file_path: file }, path.resolve("/somewhere/else"))).toBe(projDir);
   });
 
   it("ignores tools that don't write the file", () => {


### PR DESCRIPTION
## Summary

#478（`windows-daily` で露見した既存テストの Windows 失敗 9 件）の**第 1 スライス**。原因系統 A（path セパレータ / ドライブレター）の `test/server/config/dir-config.spec.ts` 3 件を修正します。

## Items to Confirm / Review

- **実コードは無変更・無バグ**という判断への同意。`dirConfigWriteTarget` は `path.isAbsolute` / `path.resolve` / `path.dirname` を通すので、実行時には本物の Windows パスが入り一貫した Windows ディレクトリが返ります。**テスト側だけ**が POSIX リテラル（`/Users/me/proj`）を入出力にハードコードしていたため、`expected 'D:\Users\me\proj' to be '/Users/me/proj'` で 3 件落ちていました。
- 修正方針: 入力と期待値を `path.resolve` / `path.join` で構築し、両辺を同じ正規化に通す。`path.resolve` が付けるドライブが何であれ、両辺が同じ変換を受けるのでアサーションは成立します。

## 検証

- macOS スイート green（1470/1470、lint error 0 / typecheck:server OK）
- `path.win32` セマンティクスで全 4 アサーションを手元シミュレーション → 全 true（ドライブ有無に関わらず両辺一致を確認）
- `windows-daily` 上での確認はマージ後に手動 dispatch（新規ワークフロー同様、この PR では自動実行されないため）

## 系統 B は別 PR

残り 6 件（`worktrees` / `worktree-routes` / `worktree-pr` / `shortcuts` / `skills`）は別の根本原因（8.3 短縮パス、Windows での symlink 作成権限、temp ファイル、slug 検証）で、テストインフラの移植性が中心。#478 の方針どおり系統ごとに分けます。

**先行して確認できた安全上の結論**: `isManagedWorktree` は `canonicalPath`（realpath ベース）+ `path.sep` を使っており **Windows でも正しく動作**します。symlink escape テストの失敗はフィクスチャの `symlinkSync` が Windows で権限不足で落ちているだけで、プロダクションのセキュリティバグではありません。

Refs #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
