### PR TITLE
refactor: share the file-stat 404 guard and remote-view preamble

### DIFF
--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -15,9 +15,9 @@
 //     navigation or <iframe>; PDFs skip the sandbox CSP (WebKit refuses to render
 //     sandbox-opaque PDFs) but keep nosniff. Matches MulmoClaude's RAW_SECURITY_HEADERS.
 import path from "node:path";
-import fs from "node:fs";
 import { createReadStream } from "node:fs";
 import type { Express, Request, Response } from "express";
+import { statFileOr404 } from "./statFileOr404.js";
 
 const MAX_RAW_BYTES = 25 * 1024 * 1024; // images / text / generic
 const MAX_MEDIA_BYTES = 500 * 1024 * 1024; // audio / video (streamed via Range)
@@ -77,17 +77,8 @@ export function mountFilesRoutes(app: Express, deps: { workspace: string }): voi
       res.status(403).json({ error: "path escapes the workspace root" });
       return;
     }
-    let stat: fs.Stats;
-    try {
-      stat = fs.statSync(abs);
-    } catch {
-      res.status(404).json({ error: "not found" });
-      return;
-    }
-    if (!stat.isFile()) {
-      res.status(404).json({ error: "not a file" });
-      return;
-    }
+    const stat = statFileOr404(res, abs);
+    if (!stat) return;
 
     const ext = path.extname(abs).toLowerCase();
     const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -14,12 +14,12 @@
 //      workspace with an HTML preview CSP (sandboxed-ish: inline scripts + a curated
 //      CDN allowlist, but connect-src 'none' so a page can't phone home).
 import path from "node:path";
-import fs from "node:fs";
 import { createReadStream } from "node:fs";
 import type { Express, Request, Response, NextFunction } from "express";
 import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
 import { artifactsFileOps } from "./artifacts.js";
 import { publishFileChange } from "./fileChange.js";
+import { statFileOr404 } from "./statFileOr404.js";
 
 // Curated CDN allowlist (matches the collection custom-view policy) for an
 // LLM-authored page that may pull a charting/util lib or font from a CDN.
@@ -88,17 +88,8 @@ export function mountHtmlPreviewRoute(app: Express, deps: { workspace: string })
       res.status(400).json({ error: "not an .html file" });
       return;
     }
-    let stat: fs.Stats;
-    try {
-      stat = fs.statSync(abs);
-    } catch {
-      res.status(404).json({ error: "not found" });
-      return;
-    }
-    if (!stat.isFile()) {
-      res.status(404).json({ error: "not a file" });
-      return;
-    }
+    const stat = statFileOr404(res, abs);
+    if (!stat) return;
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("Content-Security-Policy", HTML_PREVIEW_CSP);

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -61,14 +61,24 @@ export interface BuildRemoteViewDeps {
   readCustomViewI18n: typeof readCustomViewI18n;
 }
 
+type ResolvedMobileView = { kind: "ok"; view: CollectionCustomView } | { kind: "view-not-found"; viewId: string } | { kind: "not-mobile"; viewId: string };
+
+/** Find the requested view and require it be a mobile view. A desktop view's
+ *  HTML assumes the token/dataUrl contract and would just break on the phone —
+ *  refuse it instead of serving a broken page. */
+function resolveMobileView(collection: LoadedCollection, viewId: string): ResolvedMobileView {
+  const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
+  if (!view) return { kind: "view-not-found", viewId };
+  if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+  return { kind: "ok", view };
+}
+
 export const createBuildRemoteView =
   (deps: BuildRemoteViewDeps) =>
   async (collection: LoadedCollection, viewId: string, locale: string): Promise<RemoteViewBuildResult> => {
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) return { kind: "view-not-found", viewId };
-    // A desktop view's HTML assumes the token/dataUrl contract and would just
-    // break on the phone — refuse it instead of serving a broken page.
-    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    const resolved = resolveMobileView(collection, viewId);
+    if (resolved.kind !== "ok") return resolved;
+    const { view } = resolved;
     const html = await deps.readCustomViewHtml(collection, view.file);
     if (html === null) return { kind: "file-missing", file: view.file };
     const i18n = view.i18n ? await deps.readCustomViewI18n(collection, view.i18n, locale) : { locale: "", dict: {} };
@@ -126,9 +136,9 @@ export interface MutateRemoteViewDeps {
 export const createMutateRemoteView =
   (deps: MutateRemoteViewDeps) =>
   async (collection: LoadedCollection, viewId: string, request: RemoteViewMutateRequest): Promise<MutateRemoteViewResult> => {
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) return { kind: "view-not-found", viewId };
-    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    const resolved = resolveMobileView(collection, viewId);
+    if (resolved.kind !== "ok") return resolved;
+    const { view } = resolved;
     // A dataSource collection is read-only regardless of what write surface
     // the view declares — the collection-level rule outranks the view's. The
     // store encodes it as absent write/delete methods (core 0.25 storage seam).
@@ -258,9 +268,9 @@ async function inlineImages(
 export const createRemoteViewItems =
   (deps: RemoteViewItemsDeps) =>
   async (collection: LoadedCollection, viewId: string, request: RemoteViewPageRequest): Promise<RemoteViewItemsResult> => {
-    const view = (collection.schema.views ?? []).find((entry) => entry.id === viewId);
-    if (!view) return { kind: "view-not-found", viewId };
-    if (view.target !== "mobile") return { kind: "not-mobile", viewId };
+    const resolved = resolveMobileView(collection, viewId);
+    if (resolved.kind !== "ok") return resolved;
+    const { view } = resolved;
     // Hydrate through the same server resolver getItems uses (enrichItems): refs
     // loaded, derived formulas evaluated, toggles/embeds resolved — the phone
     // gets plain resolved scalars so mobile numbers match desktop exactly.

--- a/server/backends/statFileOr404.ts
+++ b/server/backends/statFileOr404.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import type { Response } from "express";
+
+// Stat `abs` for the raw file-serving routes, sending a 404 for a missing entry
+// or a non-file. Returns the stat, or null after the response is sent — so the
+// caller does `if (!stat) return;`.
+export function statFileOr404(res: Response, abs: string): fs.Stats | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(abs);
+  } catch {
+    res.status(404).json({ error: "not found" });
+    return null;
+  }
+  if (!stat.isFile()) {
+    res.status(404).json({ error: "not a file" });
+    return null;
+  }
+  return stat;
+}


### PR DESCRIPTION
## Summary

Two server-side clones jscpd flagged:

- **`statFileOr404()`** (new `server/backends/statFileOr404.ts`) — `files.ts` and `html.ts` both did the same `statSync` → 404 "not found" on throw, then `!isFile()` → 404 "not a file". Both now call `const stat = statFileOr404(res, abs); if (!stat) return;`. Dropping the inline block made `import fs` unused in both (they keep their own `createReadStream` import).
- **`resolveMobileView()`** — inside `remoteView.ts`, the "find view by id → `view-not-found` → require `target: mobile` → `not-mobile`" preamble was repeated across all three factories (`buildRemoteView`, `mutateRemoteView`, `remoteViewItems`). Factored into one local helper returning a discriminated union whose failure members are structurally identical to what each caller already returned, so callers do `if (resolved.kind !== "ok") return resolved;` — no widening, no `as`.

Written by a worktree-isolated subagent; **I re-verified independently** in a clean worktree (below).

## Items to Confirm / Review

- **`remoteView.ts` has no dedicated spec** — its behavior is guarded by `tsc`'s exhaustive union typing and the unchanged failure-message functions, but there's no runtime test exercising `resolveMobileView`'s branches directly. The `view-not-found` / `not-mobile` paths are reached through the collections routes (covered), but flagging that this helper isn't unit-tested in isolation.
- The discriminated-union approach means each caller returns the helper's failure value verbatim — please confirm the failure `kind`s and their downstream HTTP mappings (in `collections.ts`'s `remoteView*Handler`) are unchanged.
- No `as`, no `any`, no disable comments (verified by grep over the added lines).

## Verification (independent, clean worktree off origin/main)

- `tsc -p tsconfig.server.json` → **0 errors**
- `eslint` on all four files → **0 errors**
- `vitest` files + html specs → **13 passed**; full suite baseline 1470 unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)