### PR TITLE
refactor: share the fetch-normalizer and auto-refresh composables

### DIFF
--- a/src/composables/accountingUi.ts
+++ b/src/composables/accountingUi.ts
@@ -9,6 +9,7 @@
 //     package's self-contained i18n falls back to English for anything else.
 import { configureAccountingHost } from "@mulmoclaude/accounting-plugin/vue";
 import type { ApiResult } from "@mulmoclaude/accounting-plugin/vue";
+import { fetchJson } from "../utils/fetchJson";
 import { usePubSub } from "./usePubSub";
 
 const { subscribe } = usePubSub();
@@ -16,18 +17,13 @@ const { subscribe } = usePubSub();
 // Network seam — normalise fetch into the package's ApiResult union (the View
 // pattern-matches on `.ok`). Mirrors MulmoClaude's apiCall shape so the View's
 // `apiCall("/api/accounting", { method, body })` calls just work.
-async function apiCall<T = unknown>(path: string, opts: { method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"; body?: unknown }): Promise<ApiResult<T>> {
-  try {
-    const res = await fetch(path, {
-      method: opts.method,
-      headers: opts.body !== undefined ? { "content-type": "application/json" } : undefined,
-      body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    });
-    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
-    return { ok: true, data: (await res.json()) as T };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
-  }
+function apiCall<T = unknown>(path: string, opts: { method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE"; body?: unknown }): Promise<ApiResult<T>> {
+  const hasBody = opts.body !== undefined;
+  return fetchJson<T>(path, {
+    method: opts.method,
+    headers: hasBody ? { "content-type": "application/json" } : undefined,
+    body: hasBody ? JSON.stringify(opts.body) : undefined,
+  });
 }
 
 configureAccountingHost({

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -32,6 +32,7 @@ import type {
 import type { RegistryListResponse, RegistryImportResponse } from "@mulmoclaude/core/collection/registry";
 import type { TranslateRequest, TranslateResponse } from "@mulmoclaude/core/translation/client";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
+import { fetchJson } from "../utils/fetchJson";
 import { useShortcuts } from "./useShortcuts";
 import {
   browseGotoIndex,
@@ -64,25 +65,10 @@ export function popCollectionTeleportTarget(target: HTMLElement | ShadowRoot): v
 
 // Read helper: normalise fetch into the package's CollectionApiResult (the view
 // treats `ok:false` with `status` 404 as not-found, any other failure as a skip).
-async function apiGet<T>(url: string): Promise<CollectionApiResult<T>> {
-  try {
-    const res = await fetch(url);
-    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
-    return { ok: true, data: (await res.json()) as T };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
-  }
-}
+const apiGet = <T>(url: string): Promise<CollectionApiResult<T>> => fetchJson<T>(url);
 
-async function apiSend<T>(method: "POST" | "PUT", url: string, body: unknown): Promise<CollectionApiResult<T>> {
-  try {
-    const res = await fetch(url, { method, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
-    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
-    return { ok: true, data: (await res.json()) as T };
-  } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
-  }
-}
+const apiSend = <T>(method: "POST" | "PUT", url: string, body: unknown): Promise<CollectionApiResult<T>> =>
+  fetchJson<T>(url, { method, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
 const apiPost = <T>(url: string, body: unknown) => apiSend<T>("POST", url, body);
 const apiPut = <T>(url: string, body: unknown) => apiSend<T>("PUT", url, body);
 

--- a/src/composables/useAutoRefresh.ts
+++ b/src/composables/useAutoRefresh.ts
@@ -1,0 +1,12 @@
+import { onMounted, onBeforeUnmount, watch, type WatchSource } from "vue";
+
+// Also refreshes on mount and whenever the window regains focus (focus listener cleaned up on unmount).
+export function useAutoRefresh(refresh: () => void | Promise<void>, sources: WatchSource<unknown>[]): void {
+  const onFocus = () => void refresh();
+  onMounted(() => {
+    void refresh();
+    window.addEventListener("focus", onFocus);
+  });
+  onBeforeUnmount(() => window.removeEventListener("focus", onFocus));
+  watch(sources, () => void refresh());
+}

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -3,7 +3,8 @@
 // dirty, model, …). Re-fetches when the dir/session/agent change or the window regains focus, so
 // ${branch}/${dirty} etc. stay current. `chips: null` means unconfigured (the client keeps its
 // default header); an empty `buttons` array means nothing extra is shown.
-import { ref, watch, onMounted, onBeforeUnmount, type Ref } from "vue";
+import { ref, type Ref } from "vue";
+import { useAutoRefresh } from "./useAutoRefresh";
 
 export interface OpenTarget {
   url?: string;
@@ -63,13 +64,7 @@ export function useHeaderButtons(params: Params) {
     }
   }
 
-  const onFocus = () => void refresh();
-  onMounted(() => {
-    void refresh();
-    window.addEventListener("focus", onFocus);
-  });
-  onBeforeUnmount(() => window.removeEventListener("focus", onFocus));
-  watch([params.cwd, params.session, params.agent, () => params.model?.value], () => void refresh());
+  useAutoRefresh(refresh, [params.cwd, params.session, params.agent, () => params.model?.value]);
 
   return { buttons, chips, refresh };
 }

--- a/src/composables/useSessionContext.ts
+++ b/src/composables/useSessionContext.ts
@@ -1,7 +1,8 @@
 // Fetches a session's running model + current-turn context size from /api/session/:id.
 // Used where only the model/context is needed (e.g. header `${model}` substitution). Components that
 // also need live activity/usage (TerminalCell) fetch the same endpoint alongside those concerns.
-import { ref, watch, onMounted, onBeforeUnmount, type Ref } from "vue";
+import { ref, type Ref } from "vue";
+import { useAutoRefresh } from "./useAutoRefresh";
 
 export interface SessionContext {
   model: string | null;
@@ -44,13 +45,7 @@ export function useSessionContext(sessionId: Ref<string | null>, cwd: Ref<string
     }
   }
 
-  const onFocus = () => void refresh();
-  onMounted(() => {
-    void refresh();
-    window.addEventListener("focus", onFocus);
-  });
-  onBeforeUnmount(() => window.removeEventListener("focus", onFocus));
-  watch([sessionId, cwd], () => void refresh());
+  useAutoRefresh(refresh, [sessionId, cwd]);
 
   return { context, refresh };
 }

--- a/src/utils/fetchJson.ts
+++ b/src/utils/fetchJson.ts
@@ -5,7 +5,7 @@ export async function fetchJson<T>(input: RequestInfo | URL, init?: RequestInit)
     const res = await fetch(input, init);
     // `status` is the HTTP status on an HTTP failure, or 0 on a transport failure (no response).
     if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
-    return { ok: true, data: (await res.json()) as T };
+    return { ok: true, data: await res.json() };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
   }

--- a/src/utils/fetchJson.ts
+++ b/src/utils/fetchJson.ts
@@ -1,0 +1,12 @@
+export type FetchResult<T> = { ok: true; data: T } | { ok: false; error: string; status: number };
+
+export async function fetchJson<T>(input: RequestInfo | URL, init?: RequestInit): Promise<FetchResult<T>> {
+  try {
+    const res = await fetch(input, init);
+    // `status` is the HTTP status on an HTTP failure, or 0 on a transport failure (no response).
+    if (!res.ok) return { ok: false, error: `HTTP ${res.status}`, status: res.status };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), status: 0 };
+  }
+}


### PR DESCRIPTION
## Summary

Two composable clones jscpd flagged, both genuine shared concepts:

- **`fetchJson<T>()`** (new `src/utils/fetchJson.ts`) — `accountingUi.apiCall`, `collectionUi.apiGet`, and `apiSend` all normalized a `fetch` into the same `{ ok: true, data } | { ok: false, error, status }` union. The accounting package's `.d.ts` even documents its `ApiResult<T>` as "Mirrors the host's `ApiResult<T>`" — a real host concept. Each call site keeps building its own `RequestInit`; only the try/fetch/normalize tail was shared. `apiDelete` (parses the error body) and `postTranslation` (returns `T | null`) are a different shape and were left alone.
- **`useAutoRefresh(refresh, sources)`** (new `src/composables/useAutoRefresh.ts`) — `useHeaderButtons` and `useSessionContext` had byte-identical mount / window-focus / unmount / watch wiring around a `refresh` fn. Only the watched sources and the `refresh` bodies differ; those stay in place.

Written by a worktree-isolated subagent; **I re-verified independently and made one improvement** (below).

## Items to Confirm / Review

- **I removed a pre-existing `as T` cast.** The originals (and the subagent's faithful copy) had `data: (await res.json()) as T`. `res.json()` already resolves to `any`, so the assignment reaches the generic `T` without a cast — I dropped it now that it lives in one place. Verified `vue-tsc` stays at 0 errors. (Note: the same `as T` still appears in the untouched `postTranslation` — out of scope here, but a candidate for the same cleanup.)
- **The two package return types are structurally identical** (`{ok:true;data:T} | {ok:false;error:string;status:number}`), which is why `FetchResult<T>` is assignable at each binding with no cast — confirmed against the package `.d.ts` files.
- `useAutoRefresh` refreshes on mount, on window focus, and on any watched-source change; the focus listener is cleaned up on unmount. `useSessionContext`'s `loadedFor` staleness tracking stays in its own `refresh` body.
- No `any`, no disable comments; the only `as` was the pre-existing one I removed.

## Verification (independent, clean)

- `vue-tsc -b --force` → **0 errors**
- `eslint` on all changed files → **0 errors**
- `vitest run` → **1470 passed / 133 files** (baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)