### PR TITLE
refactor: share overlay escape-to-close and backdrop chrome

### DIFF
--- a/src/components/AccountingOverlay.vue
+++ b/src/components/AccountingOverlay.vue
@@ -6,21 +6,15 @@
 // selectedResult: the View self-fetches its books on mount and auto-selects one (or
 // shows the first-run "New book" form on an empty workspace). The host seams
 // (apiCall / subscribe / locale) are wired once in composables/accountingUi.ts.
-import { onBeforeUnmount, onMounted } from "vue";
 import { AccountingView } from "@mulmoclaude/accounting-plugin/vue";
 import accountingCss from "@mulmoclaude/accounting-plugin/style.css?inline";
 import PluginFrame from "./PluginFrame.vue";
 import { useAccountingView } from "../composables/useAccountingView";
+import { useEscapeToClose } from "../composables/useEscapeToClose";
 
 const { isOpen, close } = useAccountingView();
 
-// Close on Escape (window-level so it fires without focusing the overlay), matching
-// CollectionsBrowseOverlay.
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape" && isOpen.value) close();
-}
-onMounted(() => window.addEventListener("keydown", onKeydown));
-onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
+useEscapeToClose(isOpen, close);
 </script>
 
 <template>

--- a/src/components/CollectionsBrowseOverlay.vue
+++ b/src/components/CollectionsBrowseOverlay.vue
@@ -5,11 +5,12 @@
 // inside a PluginFrame shadow root with the collection styles, exactly like the chat
 // card. Opened by the toolbar launcher / index cards / ref hops via the binding's nav
 // capabilities (collectionUi.ts).
-import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { onBeforeUnmount, ref, watch } from "vue";
 import { CollectionsIndexView, CollectionView } from "@mulmoclaude/collection-plugin/vue";
 import PluginFrame from "./PluginFrame.vue";
 import { collectionShadowCss } from "../collectionShadowCss";
 import { useCollectionBrowse } from "../composables/useCollectionBrowse";
+import { useEscapeToClose } from "../composables/useEscapeToClose";
 import { pushCollectionTeleportTarget, popCollectionTeleportTarget } from "../composables/collectionUi";
 import { launchAgent } from "../composables/useChatLauncher";
 
@@ -38,20 +39,13 @@ watch(probe, (el) => {
     pushCollectionTeleportTarget(root);
   }
 });
-onBeforeUnmount(() => {
-  unregister();
-  window.removeEventListener("keydown", onKeydown);
-});
+onBeforeUnmount(unregister);
 
-// Close on Escape (window-level so it fires without focusing the overlay).
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape" && isOpen.value) close();
-}
-onMounted(() => window.addEventListener("keydown", onKeydown));
+useEscapeToClose(isOpen, close);
 </script>
 
 <template>
-  <div v-if="isOpen" class="browse-overlay" role="region" aria-label="Collections">
+  <div v-if="isOpen" class="overlay-root" role="region" aria-label="Collections">
     <div class="browse-bar">
       <span class="browse-bar-label">Launch with</span>
       <div class="agent-toggle" role="radiogroup" aria-label="Launch agent">
@@ -88,20 +82,8 @@ onMounted(() => window.addEventListener("keydown", onKeydown));
   </div>
 </template>
 
+<style scoped src="./overlay.css"></style>
 <style scoped>
-/* Fills the page BELOW the toolbar (40px) — the toolbar stays visible + clickable. */
-.browse-overlay {
-  position: fixed;
-  top: 40px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 50;
-  background: var(--bg-deep);
-  display: flex;
-  flex-direction: column;
-}
-
 /* A thin bar picking which agent a collection action / chat launches. */
 .browse-bar {
   flex: 0 0 auto;

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -207,7 +207,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div v-if="isOpen" class="files-overlay" role="region" aria-label="Files">
+  <div v-if="isOpen" class="overlay-root" role="region" aria-label="Files">
     <header class="files-head">
       <span class="files-title">Files</span>
       <span class="files-root" :title="cwd ?? ''">{{ cwd ?? "(default workspace)" }}</span>
@@ -250,18 +250,8 @@ onBeforeUnmount(() => {
   </div>
 </template>
 
+<style scoped src="./overlay.css"></style>
 <style scoped>
-.files-overlay {
-  position: fixed;
-  top: 40px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 50;
-  background: var(--bg-deep);
-  display: flex;
-  flex-direction: column;
-}
 .files-head {
   flex: 0 0 auto;
   display: flex;

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -3,8 +3,9 @@
 // AccountingOverlay. Driven by usePrsView (the /prs route). Fetches /api/prs and
 // /api/issues (the repos set in Settings, aggregated server-side via `gh`) on open and
 // on the reload button, grouped by repo. Read-only: a row click opens it on GitHub.
-import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import { usePrsView } from "../composables/usePrsView";
+import { useEscapeToClose } from "../composables/useEscapeToClose";
 
 type CiState = "passing" | "failing" | "pending" | "none";
 interface PrItem {
@@ -90,15 +91,11 @@ function relativeTime(iso: string): string {
 const CI_TITLE: Record<CiState, string> = { passing: "Checks passing", failing: "Checks failing", pending: "Checks running", none: "No checks" };
 const REVIEW_LABEL: Record<string, string> = { APPROVED: "approved", CHANGES_REQUESTED: "changes requested", REVIEW_REQUIRED: "review required" };
 
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape" && isOpen.value) close();
-}
-onMounted(() => window.addEventListener("keydown", onKeydown));
-onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
+useEscapeToClose(isOpen, close);
 </script>
 
 <template>
-  <div v-if="isOpen" class="prs-overlay" role="region" aria-label="Pull requests and issues">
+  <div v-if="isOpen" class="overlay-root" role="region" aria-label="Pull requests and issues">
     <header class="prs-head">
       <span class="prs-title">PRs &amp; Issues</span>
       <button type="button" class="prs-reload" :disabled="loading" title="Reload" aria-label="Reload PR and issue list" @click="load">↻</button>
@@ -161,18 +158,8 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
   </div>
 </template>
 
+<style scoped src="./overlay.css"></style>
 <style scoped>
-.prs-overlay {
-  position: fixed;
-  top: 40px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 50;
-  background: var(--bg-deep);
-  display: flex;
-  flex-direction: column;
-}
 .prs-head {
   flex: 0 0 auto;
   display: flex;

--- a/src/components/WikiBrowseOverlay.vue
+++ b/src/components/WikiBrowseOverlay.vue
@@ -7,9 +7,10 @@
 //
 // Data is re-fetched on every view entry (the shared workspace changes underfoot as
 // the terminal Claude edits pages), so the browser never shows a stale page/graph.
-import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import type { WikiGraph } from "@mulmoclaude/core/wiki";
 import { useWikiBrowse, wikiGotoIndex, wikiGotoGraph, wikiGotoLint, type WikiView } from "../composables/useWikiBrowse";
+import { useEscapeToClose } from "../composables/useEscapeToClose";
 import { fetchWikiIndex, fetchWikiGraph, fetchWikiPage, fetchWikiLint, type WikiIndex, type WikiPage, type WikiLint } from "../wikiApi";
 import { renderWikiHtml } from "../wikiMarkdown";
 import WikiIndexView from "./WikiIndexView.vue";
@@ -92,15 +93,11 @@ watch(
   { immediate: true },
 );
 
-function onKeydown(e: KeyboardEvent): void {
-  if (e.key === "Escape" && isOpen.value) close();
-}
-onMounted(() => window.addEventListener("keydown", onKeydown));
-onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
+useEscapeToClose(isOpen, close);
 </script>
 
 <template>
-  <div v-if="isOpen" class="wiki-overlay" role="region" aria-label="Wiki">
+  <div v-if="isOpen" class="overlay-root" role="region" aria-label="Wiki">
     <nav class="wiki-tabs" aria-label="Wiki sections">
       <button type="button" :class="{ active: view.mode === 'index' }" @click="wikiGotoIndex">Index</button>
       <button v-if="view.mode === 'page'" type="button" class="active" aria-current="page" disabled>
@@ -123,20 +120,8 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
   </div>
 </template>
 
+<style scoped src="./overlay.css"></style>
 <style scoped>
-/* Fills the page BELOW the toolbar (40px) — the toolbar stays visible + clickable so
-   the user can switch back to Chat. Matches the other overlays. */
-.wiki-overlay {
-  position: fixed;
-  top: 40px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 50;
-  background: var(--bg-deep);
-  display: flex;
-  flex-direction: column;
-}
 .wiki-tabs {
   flex: 0 0 auto;
   display: flex;

--- a/src/components/overlay.css
+++ b/src/components/overlay.css
@@ -1,0 +1,15 @@
+/* The root frame shared by the full-screen overlays (Collections, Files, PRs, Wiki):
+   a fixed pane filling the page BELOW the 40px toolbar — the toolbar stays visible +
+   clickable so the user can switch back to Chat — laid out as a column so each overlay
+   can stack its own header/body on top. Each overlay layers its own rules separately. */
+.overlay-root {
+  position: fixed;
+  top: 40px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 50;
+  background: var(--bg-deep);
+  display: flex;
+  flex-direction: column;
+}

--- a/src/composables/useEscapeToClose.ts
+++ b/src/composables/useEscapeToClose.ts
@@ -1,0 +1,11 @@
+import { onBeforeUnmount, onMounted, type Ref } from "vue";
+
+// Close a full-screen overlay on Escape. The listener sits on window (not the overlay
+// element) so it fires without the overlay holding focus.
+export function useEscapeToClose(isOpen: Ref<boolean>, close: () => void): void {
+  const onKeydown = (e: KeyboardEvent): void => {
+    if (e.key === "Escape" && isOpen.value) close();
+  };
+  onMounted(() => window.addEventListener("keydown", onKeydown));
+  onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
+}


### PR DESCRIPTION
## Summary

Deduplicated across the five full-screen overlay components:

- **`useEscapeToClose(isOpen, close)`** (new composable) — `AccountingOverlay`, `PrsOverlay`, `WikiBrowseOverlay` had a byte-identical window-level `onKeydown`/`onMounted`/`onBeforeUnmount` trio; `CollectionsBrowseOverlay` shared the keydown but keeps its own extra `onBeforeUnmount(unregister)` (Vue runs both hooks). Fully replaced by one call each.
- **`overlay.css`** (new shared stylesheet) — the `.overlay-root` fixed-pane-below-the-40px-toolbar backdrop, byte-identical across `Collections`/`Files`/`Prs`/`Wiki`, consumed via `<style scoped src>`. Each root `div`'s class renamed to `overlay-root` (the only markup change).

Net **−36 lines**. Written by a worktree-isolated subagent; **I re-verified independently** (below).

## Items to Confirm / Review

- **`FilesOverlay` was deliberately left out of the composable** — its window keydown handles **Cmd/Ctrl+S to save**, not Escape-to-close, and never closes on Escape. Folding it in would change behavior. Please confirm that's the right call (it is the one overlay whose keyboard handler is genuinely different).
- **`AccountingOverlay` keeps its own `.accounting-overlay`** rather than `overlay.css` — it's identical *except* it lacks `display:flex; flex-direction:column` (it wraps a single `height:100%` PluginFrame, so adding flex could change sizing). Left local on purpose.
- **Headers/bars left duplicated on purpose**: `.files-head`/`.prs-head` happen to be byte-identical, but `.browse-bar` and `.wiki-tabs` differ (padding/gap/font). Sharing only 2 of 4 conceptually-distinct toolbars would be a coincidental abstraction — all headers stay local.
- **Markup change**: each overlay root `div` class → `overlay-root`. `role`/`aria`/structure unchanged. The `PrsOverlay`/`FilesOverlay` specs assert on child classes (`prs-row`/`files-row`), so they're unaffected — confirmed green.

## Verification (independent, clean worktree)

- `vue-tsc -b --force` → **0 errors** · `eslint` → **0** · `vite build` → succeeds
- **`.overlay-root` scoping**: emitted under **4 distinct `data-v-*` scopes** (one per consuming component), **no unscoped** copy — `<style scoped src>` preserves scoping (same mechanism as `cellChromeBase.css`)
- `vitest` overlay specs pass; full suite baseline 1470 unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)