### PR TITLE
fix: Windows-portable worktree/slug/temp handling — #478 (B)

### DIFF
--- a/plans/fix-478b-worktree-windows-portability.md
+++ b/plans/fix-478b-worktree-windows-portability.md
@@ -1,0 +1,60 @@
+# fix: #478 系統 B — worktree/slug/temp の Windows 移植性
+
+Issue: #478（`windows-daily` で露見した 9 件のうち、系統 A の 3 件は #480 で完了。本 PR は残り 6 件）
+
+## 対象の失敗（windows-daily run 29777648627）
+
+| テスト | 原因系統 | 種別 |
+|---|---|---|
+| `worktrees: creates, lists, detects dirty, and removes` | B1 8.3/セパレータ | テスト |
+| `worktrees: creates, lists (with dirty)`（routes 側含む） | B1 | テスト+実コード |
+| `worktrees: rejects a symlink … escapes it` | B2 symlink 権限 | テスト(skip) |
+| `skills: rejects dir names that aren't safe slugs` | B3 不正ファイル名 | テスト |
+| `shortcuts: handles concurrent PUTs …` | B4b rename 競合 | 実コード |
+| `worktree-pr: createOrOpenPR pushes …` / `worktree-routes: 500s an internal git failure` | B4a/B5 | テスト |
+
+## 根本原因と修正
+
+### 実コード
+
+1. **`server/git/worktrees.ts`: `realpathSync` → `realpathSync.native`**（`worktreesBase` と `canonicalPath`）。
+   Windows では native 呼び出しだけが 8.3 短縮名（`C:\Users\RUNNER~1`）を長名（`…\runneradmin`）へ展開する。
+   `git worktree list` は長名を返すため、`isManagedWorktree` の包含判定で両辺を一致させるのに必要。
+   本番の `MULMOTERMINAL_HOME` は `os.homedir()`（長名）なので実害は出ていなかったが、canonicalPath が
+   真に正規（8.3 展開済み）を返すことは containment guard の前提として正しい。
+
+2. **`server/backends/shortcuts.ts`: `fs.rename` に sharing-violation リトライ**。
+   POSIX の rename は atomic replace だが、Windows の MoveFileEx は並行 writer が対象を掴んでいる間、
+   2 つ目の rename を EPERM/EACCES/EBUSY で一時的に拒否する。並行 PUT（複数タブ）が全部成功するよう
+   短いバックオフでリトライ。他のエラーは即 throw。
+
+### テスト
+
+3. **worktree 3 spec の `repo` を git 正規形に揃える**。`worktreesRoot` は repo 文字列をハッシュする。
+   テストが `realpathSync(mkdtemp)` 形（Windows で 8.3/`\`）を渡す一方、本番 `repoRoot` は git 形（長名/`/`）を
+   返すため、ハッシュが食い違って managed-root 判定が外れていた（B1/B5）。`beforeEach` を async 化し
+   `repo = (await gitTopLevel(repo)) ?? repo` で本番と同じ形に。
+
+4. **teardown の `rmSync` にリトライ**（`test/server/git/wtTestUtil.ts` の `rmDirRetrying`）。
+   Windows は git 子プロセス終了後も worktree dir のハンドルを一瞬保持し、`rmSync` が EBUSY を投げる（B4a）。
+   `maxRetries`/`retryDelay` で待つ。
+
+5. **git 統合テストの timeout 拡張**（`GIT_TEST_TIMEOUT_MS = 30s`）。Windows では git 子プロセスが遅く、
+   vitest 既定 5s を超えて timeout していた。
+
+6. **symlink escape テストを skip 可能に**（`canSymlink` probe）。Windows は symlink 作成に権限/開発者モードが
+   要り、フィクスチャの `symlinkSync` が落ちる。判定ロジック（`isManagedWorktree`）自体は `canonicalPath`+`path.sep`
+   で Windows でも健全（= 本 PR で確認済みの安全事実）。symlink が存在しない環境では検証対象が無いので skip。
+
+7. **skills の不正名フィクスチャを許容**（`tryWriteUnsafeSkill`）。`q"uote` は Windows で不正ファイル名なので
+   `mkdirSync` が落ちる。作成失敗は「discovery に現れない」という検証の期待と同じ終状態なので握りつぶす。
+
+## 検証
+
+- macOS: 全 1470 tests green、lint error 0、typecheck/build OK
+- Windows: マージ前に windows-daily をこのブランチへ `workflow_dispatch` して確認（実機なし、CI 検証）
+
+## 補足（安全）
+
+`isManagedWorktree` は `canonicalPath`（realpath ベース）+ `path.sep` を使うため、Windows でも symlink escape の
+string-prefix bypass は成立しない。B2 の失敗は判定ロジックではなくフィクスチャ作成の失敗だった。

--- a/server/backends/remoteHost/skills.spec.ts
+++ b/server/backends/remoteHost/skills.spec.ts
@@ -13,6 +13,17 @@ const writeSkill = (root: string, name: string, contents: string): void => {
   writeFileSync(path.join(dir, "SKILL.md"), contents);
 };
 
+// Like writeSkill, but for names that are INTENTIONALLY unsafe: some (a `"`) are
+// illegal on Windows, where the OS rejects the mkdir. That failure is the same end
+// state the test asserts — the name never becomes a discoverable skill — so swallow it.
+const tryWriteUnsafeSkill = (root: string, name: string, contents: string): void => {
+  try {
+    writeSkill(root, name, contents);
+  } catch {
+    /* OS refused the unsafe name; discovery would have dropped it anyway */
+  }
+};
+
 const SKILL_MD = "---\ndescription: does a thing\n---\n\nbody";
 
 describe("discoverSkillNames", () => {
@@ -128,9 +139,9 @@ describe("discoverSkills", () => {
   // whitespace/quotes (e.g. from an untrusted repo's .claude/skills) must never be
   // discovered — even with valid frontmatter.
   it("rejects dir names that aren't safe slugs (whitespace/quotes/leading dash)", async () => {
-    writeSkill(ws, "bad name", SKILL_MD); // space
-    writeSkill(ws, 'q"uote', SKILL_MD); // quote
-    writeSkill(ws, "-lead", SKILL_MD); // non-alnum start
+    tryWriteUnsafeSkill(ws, "bad name", SKILL_MD); // space
+    tryWriteUnsafeSkill(ws, 'q"uote', SKILL_MD); // quote — illegal on Windows
+    tryWriteUnsafeSkill(ws, "-lead", SKILL_MD); // non-alnum start
     writeSkill(ws, "safe-slug_1", SKILL_MD); // the only valid one
     expect((await discoverSkills({ workspaceRoot: ws, userDir: userDir() })).map((s) => s.slug)).toEqual(["safe-slug_1"]);
   });

--- a/server/backends/shortcuts.ts
+++ b/server/backends/shortcuts.ts
@@ -86,6 +86,25 @@ export async function readShortcuts(workspace: string): Promise<Shortcut[]> {
   }
 }
 
+// POSIX rename atomically replaces the destination; Windows MoveFileEx does too, but
+// while a concurrent writer's rename holds the target it briefly denies a second one
+// with EPERM/EACCES/EBUSY. Retry those a few times so concurrent replace-all PUTs
+// (two tabs) all succeed instead of one 500ing. Other errors propagate at once.
+const RENAME_RETRIES = 10;
+const RENAME_RETRY_DELAY_MS = 20;
+const RENAME_LOCK_CODES = new Set(["EPERM", "EACCES", "EBUSY"]);
+async function renameReplacing(from: string, to: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fs.rename(from, to);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code ?? "";
+      if (attempt >= RENAME_RETRIES || !RENAME_LOCK_CODES.has(code)) throw err;
+      await new Promise((resolve) => setTimeout(resolve, RENAME_RETRY_DELAY_MS));
+    }
+  }
+}
+
 /** Replace the full list. Normalises (validate + dedupe) before an atomic write
  *  (temp file + rename) so the on-disk file is always clean and never half-written.
  *  Returns the canonical list. */
@@ -101,7 +120,7 @@ async function writeShortcuts(workspace: string, input: unknown): Promise<Shortc
   const tmp = `${file}.${randomUUID()}.tmp`;
   try {
     await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-    await fs.rename(tmp, file);
+    await renameReplacing(tmp, file);
   } catch (err) {
     await fs.rm(tmp, { force: true }); // don't leave a stray temp on failure
     throw err;

--- a/server/git/worktrees.ts
+++ b/server/git/worktrees.ts
@@ -151,9 +151,13 @@ export async function listWorktrees(repoDir: string): Promise<WorktreeInfo[]> {
   if (!repo) return [];
   const res = await git(["worktree", "list", "--porcelain"], repo);
   if (!res.ok) return [];
-  return parseWorktreeList(res.stdout)
-    .filter((w) => isManagedWorktree(repo, w.path))
-    .map((w) => ({ path: w.path, branch: w.branch, head: w.head, task: path.basename(w.path) }));
+  return (
+    parseWorktreeList(res.stdout)
+      .filter((w) => isManagedWorktree(repo, w.path))
+      // git reports forward-slash paths even on Windows; normalize to the OS separator so
+      // a listed worktree's path matches what createWorktree (path.join) returned for it.
+      .map((w) => ({ path: path.normalize(w.path), branch: w.branch, head: w.head, task: path.basename(w.path) }))
+  );
 }
 
 // Whether a worktree has uncommitted changes (so we don't delete it silently).

--- a/server/git/worktrees.ts
+++ b/server/git/worktrees.ts
@@ -10,6 +10,11 @@ import { realpathSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+// realpathSync.native, not the JS one: on Windows only the native call expands an
+// 8.3 short component (C:\Users\RUNNER~1 → …\runneradmin) to the long form that
+// `git worktree list` reports, so the two agree in the containment check below.
+const realpath = realpathSync.native;
+
 // Read lazily so MULMOTERMINAL_HOME can redirect the managed root (used by tests to
 // avoid touching the real home dir; defaults to ~/.mulmoterminal). Resolved to its
 // realpath so it matches the realpaths `git worktree list` reports (e.g. macOS
@@ -17,7 +22,7 @@ import path from "node:path";
 function worktreesBase(): string {
   const base = process.env.MULMOTERMINAL_HOME || path.join(os.homedir(), ".mulmoterminal");
   try {
-    return path.join(realpathSync(base), "worktrees");
+    return path.join(realpath(base), "worktrees");
   } catch {
     return path.join(base, "worktrees"); // doesn't exist yet — first run
   }
@@ -58,7 +63,7 @@ function canonicalPath(p: string): string {
   let cur = resolved;
   for (;;) {
     try {
-      const real = realpathSync(cur);
+      const real = realpath(cur);
       return missing.length ? path.join(real, ...missing) : real;
     } catch {
       const parent = path.dirname(cur);

--- a/test/server/git/worktree-pr.spec.ts
+++ b/test/server/git/worktree-pr.spec.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { mkdtempSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { createWorktree } from "../../../server/git/worktrees.js";
+import { createWorktree, gitTopLevel } from "../../../server/git/worktrees.js";
 import { compareUrl, pushWorktree, createOrOpenPR } from "../../../server/git/worktree-pr.js";
+import { rmDirRetrying, GIT_TEST_TIMEOUT_MS } from "./wtTestUtil.js";
 
 describe("compareUrl", () => {
   it("builds the GitHub compare/open-PR url, keeping the branch slash raw", () => {
@@ -32,7 +33,7 @@ describe("push / PR actions", () => {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
     execFileSync("git", ["-C", dir, ...a], { stdio: "ignore" });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-home-")));
     process.env.MULMOTERMINAL_HOME = home;
     repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-repo-")));
@@ -46,56 +47,74 @@ describe("push / PR actions", () => {
     writeFileSync(path.join(repo, "README.md"), "hi\n");
     g(repo, "add", "-A");
     g(repo, "commit", "-m", "init");
+    // Adopt git's toplevel string so worktreesRoot() hashes the same form the engine does.
+    repo = (await gitTopLevel(repo)) ?? repo;
   });
   afterEach(() => {
     delete process.env.MULMOTERMINAL_HOME;
-    rmSync(home, { recursive: true, force: true });
-    rmSync(repo, { recursive: true, force: true });
-    rmSync(remote, { recursive: true, force: true });
+    rmDirRetrying(home);
+    rmDirRetrying(repo);
+    rmDirRetrying(remote);
   });
 
-  it.skipIf(!hasGit)("pushes the worktree branch to origin", async () => {
-    g(repo, "remote", "add", "origin", remote);
-    const wt = await createWorktree(repo, "fix login");
-    if (!wt) throw new Error("expected a worktree");
-    writeFileSync(path.join(wt.path, "a.txt"), "x");
-    g(wt.path, "add", "-A");
-    g(wt.path, "commit", "-m", "work");
+  it.skipIf(!hasGit)(
+    "pushes the worktree branch to origin",
+    async () => {
+      g(repo, "remote", "add", "origin", remote);
+      const wt = await createWorktree(repo, "fix login");
+      if (!wt) throw new Error("expected a worktree");
+      writeFileSync(path.join(wt.path, "a.txt"), "x");
+      g(wt.path, "add", "-A");
+      g(wt.path, "commit", "-m", "work");
 
-    const res = await pushWorktree(wt.path);
-    expect(res).toEqual({ ok: true, branch: "agent/fix-login" });
-    // the branch now exists on the bare remote
-    const refs = execFileSync("git", ["-C", remote, "branch", "--list", "agent/fix-login"], { encoding: "utf8" }); // eslint-disable-line sonarjs/no-os-command-from-path
-    expect(refs).toContain("agent/fix-login");
-  });
+      const res = await pushWorktree(wt.path);
+      expect(res).toEqual({ ok: true, branch: "agent/fix-login" });
+      // the branch now exists on the bare remote
+      const refs = execFileSync("git", ["-C", remote, "branch", "--list", "agent/fix-login"], { encoding: "utf8" }); // eslint-disable-line sonarjs/no-os-command-from-path
+      expect(refs).toContain("agent/fix-login");
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("refuses to push when there is no origin remote", async () => {
-    const wt = await createWorktree(repo, "no-remote");
-    if (!wt) throw new Error("expected a worktree");
-    expect(await pushWorktree(wt.path)).toEqual({ ok: false, reason: "no-remote" });
-  });
+  it.skipIf(!hasGit)(
+    "refuses to push when there is no origin remote",
+    async () => {
+      const wt = await createWorktree(repo, "no-remote");
+      if (!wt) throw new Error("expected a worktree");
+      expect(await pushWorktree(wt.path)).toEqual({ ok: false, reason: "no-remote" });
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("refuses a path that isn't a managed worktree", async () => {
-    expect(await pushWorktree(repo)).toEqual({ ok: false, reason: "not-worktree" });
-  });
+  it.skipIf(!hasGit)(
+    "refuses a path that isn't a managed worktree",
+    async () => {
+      expect(await pushWorktree(repo)).toEqual({ ok: false, reason: "not-worktree" });
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("createOrOpenPR pushes, then reports no-github for a non-GitHub remote", async () => {
-    g(repo, "remote", "add", "origin", remote); // a local bare remote, not github.com
-    const wt = await createWorktree(repo, "feature");
-    if (!wt) throw new Error("expected a worktree");
-    writeFileSync(path.join(wt.path, "a.txt"), "x");
-    g(wt.path, "add", "-A");
-    g(wt.path, "commit", "-m", "work");
+  it.skipIf(!hasGit)(
+    "createOrOpenPR pushes, then reports no-github for a non-GitHub remote",
+    async () => {
+      g(repo, "remote", "add", "origin", remote); // a local bare remote, not github.com
+      const wt = await createWorktree(repo, "feature");
+      if (!wt) throw new Error("expected a worktree");
+      writeFileSync(path.join(wt.path, "a.txt"), "x");
+      g(wt.path, "add", "-A");
+      g(wt.path, "commit", "-m", "work");
 
-    const res = await createOrOpenPR(wt.path);
-    // gh can't make a PR (no GitHub) and the remote isn't github.com → no compare url
-    expect(res.ok).toBe(false);
-    expect(res.reason).toBe("no-github");
-    // but the push half still landed the branch on the remote
-    const refs = execFileSync("git", ["-C", remote, "branch", "--list", "agent/feature"], { encoding: "utf8" }); // eslint-disable-line sonarjs/no-os-command-from-path
-    expect(refs).toContain("agent/feature");
-    // (the compare-url SUCCESS path can't be exercised locally — origin can't be
-    // both a pushable bare repo and github.com — so compareUrl() is unit-tested
-    // above and the gh→fallback wiring is covered by this no-github case.)
-  });
+      const res = await createOrOpenPR(wt.path);
+      // gh can't make a PR (no GitHub) and the remote isn't github.com → no compare url
+      expect(res.ok).toBe(false);
+      expect(res.reason).toBe("no-github");
+      // but the push half still landed the branch on the remote
+      const refs = execFileSync("git", ["-C", remote, "branch", "--list", "agent/feature"], { encoding: "utf8" }); // eslint-disable-line sonarjs/no-os-command-from-path
+      expect(refs).toContain("agent/feature");
+      // (the compare-url SUCCESS path can't be exercised locally — origin can't be
+      // both a pushable bare repo and github.com — so compareUrl() is unit-tested
+      // above and the gh→fallback wiring is covered by this no-github case.)
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 });

--- a/test/server/git/worktree-routes.spec.ts
+++ b/test/server/git/worktree-routes.spec.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { Express } from "express";
-import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { mkdtempSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { mountWorktreeRoutes } from "../../../server/git/worktree-routes.js";
-import { createWorktree, worktreesRoot } from "../../../server/git/worktrees.js";
+import { createWorktree, worktreesRoot, gitTopLevel } from "../../../server/git/worktrees.js";
+import { rmDirRetrying, GIT_TEST_TIMEOUT_MS } from "./wtTestUtil.js";
 
 interface FakeRes {
   statusCode: number;
@@ -103,7 +104,7 @@ describe("worktree routes: origin guard + validation", () => {
       await routes(allow)["GET /api/worktrees"]({ headers: {}, query: { cwd: dir } }, res);
       expect(res.payload).toEqual({ isGit: false, base: null, worktrees: [] });
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      rmDirRetrying(dir);
     }
   });
 
@@ -133,7 +134,7 @@ describe("worktree routes: create → list → remove lifecycle", () => {
     }
   })();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     home = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-home-")));
     process.env.MULMOTERMINAL_HOME = home;
     repo = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-repo-")));
@@ -146,107 +147,129 @@ describe("worktree routes: create → list → remove lifecycle", () => {
     writeFileSync(path.join(repo, "README.md"), "hi");
     g("add", "-A");
     g("commit", "-m", "init");
+    // Adopt git's toplevel string so worktreesRoot() hashes the same form the routes do.
+    repo = (await gitTopLevel(repo)) ?? repo;
   });
   afterEach(() => {
     delete process.env.MULMOTERMINAL_HOME;
-    rmSync(home, { recursive: true, force: true });
-    rmSync(repo, { recursive: true, force: true });
+    rmDirRetrying(home);
+    rmDirRetrying(repo);
   });
 
-  it.skipIf(!hasGit)("creates, lists (with dirty), refuses a dirty remove, then force-removes", async () => {
-    const r = routes(allow);
+  it.skipIf(!hasGit)(
+    "creates, lists (with dirty), refuses a dirty remove, then force-removes",
+    async () => {
+      const r = routes(allow);
 
-    const created = makeRes();
-    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "Fix Login" } }, created);
-    expect(created.statusCode).toBe(200);
-    const wt = created.payload as { path: string; branch: string };
-    expect(wt.branch).toBe("agent/fix-login");
+      const created = makeRes();
+      await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "Fix Login" } }, created);
+      expect(created.statusCode).toBe(200);
+      const wt = created.payload as { path: string; branch: string };
+      expect(wt.branch).toBe("agent/fix-login");
 
-    const listed = makeRes();
-    await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, listed);
-    const body = listed.payload as { isGit: boolean; base: string; worktrees: { task: string; dirty: boolean }[] };
-    expect(body.isGit).toBe(true);
-    expect(body.worktrees).toEqual([{ path: wt.path, branch: "agent/fix-login", head: expect.any(String), task: "fix-login", dirty: false }]);
+      const listed = makeRes();
+      await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, listed);
+      const body = listed.payload as { isGit: boolean; base: string; worktrees: { task: string; dirty: boolean }[] };
+      expect(body.isGit).toBe(true);
+      expect(body.worktrees).toEqual([{ path: wt.path, branch: "agent/fix-login", head: expect.any(String), task: "fix-login", dirty: false }]);
 
-    writeFileSync(path.join(wt.path, "new.txt"), "x");
-    const listed2 = makeRes();
-    await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, listed2);
-    expect((listed2.payload as { worktrees: { dirty: boolean }[] }).worktrees[0].dirty).toBe(true);
+      writeFileSync(path.join(wt.path, "new.txt"), "x");
+      const listed2 = makeRes();
+      await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, listed2);
+      expect((listed2.payload as { worktrees: { dirty: boolean }[] }).worktrees[0].dirty).toBe(true);
 
-    const refused = makeRes();
-    await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path } }, refused);
-    expect(refused.statusCode).toBe(409);
-    expect(refused.payload).toEqual({ ok: false, reason: "dirty" });
+      const refused = makeRes();
+      await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path } }, refused);
+      expect(refused.statusCode).toBe(409);
+      expect(refused.payload).toEqual({ ok: false, reason: "dirty" });
 
-    const removed = makeRes();
-    await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path, force: true, deleteBranch: true } }, removed);
-    expect(removed.statusCode).toBe(200);
-    expect(removed.payload).toEqual({ ok: true });
+      const removed = makeRes();
+      await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path, force: true, deleteBranch: true } }, removed);
+      expect(removed.statusCode).toBe(200);
+      expect(removed.payload).toEqual({ ok: true });
 
-    const empty = makeRes();
-    await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, empty);
-    expect((empty.payload as { worktrees: unknown[] }).worktrees).toEqual([]);
-  });
+      const empty = makeRes();
+      await r["GET /api/worktrees"]({ headers: {}, query: { cwd: repo } }, empty);
+      expect((empty.payload as { worktrees: unknown[] }).worktrees).toEqual([]);
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("409s a remove of the main checkout (not under the managed root)", async () => {
-    const res = makeRes();
-    await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: repo } }, res);
-    expect(res.statusCode).toBe(409);
-    expect(res.payload).toEqual({ ok: false, reason: "not-managed" });
-  });
+  it.skipIf(!hasGit)(
+    "409s a remove of the main checkout (not under the managed root)",
+    async () => {
+      const res = makeRes();
+      await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: repo } }, res);
+      expect(res.statusCode).toBe(409);
+      expect(res.payload).toEqual({ ok: false, reason: "not-managed" });
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("treats a non-boolean force as false (no accidental force-delete of a dirty worktree)", async () => {
-    const r = routes(allow);
-    const created = makeRes();
-    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "wip" } }, created);
-    const wt = created.payload as { path: string };
-    writeFileSync(path.join(wt.path, "dirty.txt"), "x"); // make it dirty
+  it.skipIf(!hasGit)(
+    "treats a non-boolean force as false (no accidental force-delete of a dirty worktree)",
+    async () => {
+      const r = routes(allow);
+      const created = makeRes();
+      await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "wip" } }, created);
+      const wt = created.payload as { path: string };
+      writeFileSync(path.join(wt.path, "dirty.txt"), "x"); // make it dirty
 
-    // the string "false" is truthy in JS — strict validation must NOT force-remove
-    const res = makeRes();
-    await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path, force: "false", deleteBranch: "false" } }, res);
-    expect(res.statusCode).toBe(409);
-    expect(res.payload).toEqual({ ok: false, reason: "dirty" });
-  });
+      // the string "false" is truthy in JS — strict validation must NOT force-remove
+      const res = makeRes();
+      await r["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: wt.path, force: "false", deleteBranch: "false" } }, res);
+      expect(res.statusCode).toBe(409);
+      expect(res.payload).toEqual({ ok: false, reason: "dirty" });
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("500s an internal git failure (managed path, but not a registered worktree)", async () => {
-    await createWorktree(repo, "real"); // makes the managed root dir exist
-    const ghost = path.join(worktreesRoot(repo), "ghost"); // under the root, but no worktree there
-    const res = makeRes();
-    await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: ghost } }, res);
-    expect(res.statusCode).toBe(500);
-    expect(res.payload).toEqual({ ok: false, reason: "failed" });
-  });
+  it.skipIf(!hasGit)(
+    "500s an internal git failure (managed path, but not a registered worktree)",
+    async () => {
+      await createWorktree(repo, "real"); // makes the managed root dir exist
+      const ghost = path.join(worktreesRoot(repo), "ghost"); // under the root, but no worktree there
+      const res = makeRes();
+      await routes(allow)["POST /api/worktrees/remove"]({ headers: {}, body: { repoDir: repo, path: ghost } }, res);
+      expect(res.statusCode).toBe(500);
+      expect(res.payload).toEqual({ ok: false, reason: "failed" });
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("POST /api/worktrees/push 200s with the branch (and 409s with no remote)", async () => {
-    const r = routes(allow);
-    const created = makeRes();
-    await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "ship it" } }, created);
-    const wt = created.payload as { path: string };
-    writeFileSync(path.join(wt.path, "a.txt"), "x");
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
-    execFileSync("git", ["-C", wt.path, "add", "-A"], { stdio: "ignore" });
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
-    execFileSync("git", ["-C", wt.path, "commit", "-m", "work"], { stdio: "ignore" });
-
-    const noRemote = makeRes();
-    await r["POST /api/worktrees/push"]({ headers: {}, body: { cwd: wt.path } }, noRemote);
-    expect(noRemote.statusCode).toBe(409);
-    expect(noRemote.payload).toMatchObject({ ok: false, reason: "no-remote" });
-
-    const remote = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-remote-")));
-    try {
+  it.skipIf(!hasGit)(
+    "POST /api/worktrees/push 200s with the branch (and 409s with no remote)",
+    async () => {
+      const r = routes(allow);
+      const created = makeRes();
+      await r["POST /api/worktrees/create"]({ headers: {}, body: { repoDir: repo, task: "ship it" } }, created);
+      const wt = created.payload as { path: string };
+      writeFileSync(path.join(wt.path, "a.txt"), "x");
       // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
-      execFileSync("git", ["init", "--bare", "-b", "main", remote], { stdio: "ignore" });
+      execFileSync("git", ["-C", wt.path, "add", "-A"], { stdio: "ignore" });
       // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
-      execFileSync("git", ["-C", repo, "remote", "add", "origin", remote], { stdio: "ignore" });
+      execFileSync("git", ["-C", wt.path, "commit", "-m", "work"], { stdio: "ignore" });
 
-      const pushed = makeRes();
-      await r["POST /api/worktrees/push"]({ headers: {}, body: { cwd: wt.path } }, pushed);
-      expect(pushed.statusCode).toBe(200);
-      expect(pushed.payload).toEqual({ ok: true, branch: "agent/ship-it" });
-    } finally {
-      rmSync(remote, { recursive: true, force: true });
-    }
-  });
+      const noRemote = makeRes();
+      await r["POST /api/worktrees/push"]({ headers: {}, body: { cwd: wt.path } }, noRemote);
+      expect(noRemote.statusCode).toBe(409);
+      expect(noRemote.payload).toMatchObject({ ok: false, reason: "no-remote" });
+
+      const remote = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-remote-")));
+      try {
+        // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+        execFileSync("git", ["init", "--bare", "-b", "main", remote], { stdio: "ignore" });
+        // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+        execFileSync("git", ["-C", repo, "remote", "add", "origin", remote], { stdio: "ignore" });
+
+        const pushed = makeRes();
+        await r["POST /api/worktrees/push"]({ headers: {}, body: { cwd: wt.path } }, pushed);
+        expect(pushed.statusCode).toBe(200);
+        expect(pushed.payload).toEqual({ ok: true, branch: "agent/ship-it" });
+      } finally {
+        rmDirRetrying(remote);
+      }
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 });

--- a/test/server/git/worktrees.spec.ts
+++ b/test/server/git/worktrees.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, existsSync, realpathSync, symlinkSync } from "node:fs";
+import { mkdtempSync, writeFileSync, existsSync, realpathSync, symlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { rmDirRetrying, GIT_TEST_TIMEOUT_MS } from "./wtTestUtil.js";
 import {
   slugify,
   parseWorktreeList,
@@ -59,8 +60,22 @@ describe("git worktree lifecycle", () => {
       return false;
     }
   })();
+  // Creating a symlink needs privilege / Developer Mode on Windows; where it's denied
+  // we can't build the escape fixture. The behaviour under test (containment survives a
+  // symlink escape) only matters where symlinks exist, so skipping there loses nothing.
+  const canSymlink = (() => {
+    const probeDir = mkdtempSync(path.join(tmpdir(), "mt-wt-symprobe-"));
+    try {
+      symlinkSync(probeDir, path.join(probeDir, "l"));
+      return true;
+    } catch {
+      return false;
+    } finally {
+      rmDirRetrying(probeDir);
+    }
+  })();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // realpath: git resolves symlinks (macOS /tmp -> /private/var), and the engine
     // keys the managed root off git's toplevel, so the test dirs must match that.
     home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-home-")));
@@ -75,78 +90,101 @@ describe("git worktree lifecycle", () => {
     writeFileSync(path.join(repo, "README.md"), "hi");
     g("add", "-A");
     g("commit", "-m", "init");
+    // The engine keys the managed root off git's toplevel string; adopt git's exact
+    // form (forward slashes, 8.3 expanded on Windows) so hashes line up on any OS.
+    repo = (await gitTopLevel(repo)) ?? repo;
   });
   afterEach(() => {
     delete process.env.MULMOTERMINAL_HOME;
-    rmSync(home, { recursive: true, force: true });
-    rmSync(repo, { recursive: true, force: true });
+    rmDirRetrying(home);
+    rmDirRetrying(repo);
   });
 
-  it.skipIf(!hasGit)("creates, lists, detects dirty, and removes a worktree", async () => {
-    expect(await gitTopLevel(repo)).toBe(repo);
+  it.skipIf(!hasGit)(
+    "creates, lists, detects dirty, and removes a worktree",
+    async () => {
+      expect(await gitTopLevel(repo)).toBe(repo);
 
-    const wt = await createWorktree(repo, "Fix Login");
-    if (!wt) throw new Error("expected a worktree");
-    expect(wt.branch).toBe("agent/fix-login");
-    expect(existsSync(wt.path)).toBe(true);
-    expect(isManagedWorktree(repo, wt.path)).toBe(true);
+      const wt = await createWorktree(repo, "Fix Login");
+      if (!wt) throw new Error("expected a worktree");
+      expect(wt.branch).toBe("agent/fix-login");
+      expect(existsSync(wt.path)).toBe(true);
+      expect(isManagedWorktree(repo, wt.path)).toBe(true);
 
-    const list = await listWorktrees(repo);
-    expect(list.map((w) => w.branch)).toEqual(["agent/fix-login"]); // excludes the main checkout
+      const list = await listWorktrees(repo);
+      expect(list.map((w) => w.branch)).toEqual(["agent/fix-login"]); // excludes the main checkout
 
-    expect(await isDirty(wt.path)).toBe(false);
-    writeFileSync(path.join(wt.path, "new.txt"), "x");
-    expect(await isDirty(wt.path)).toBe(true);
+      expect(await isDirty(wt.path)).toBe(false);
+      writeFileSync(path.join(wt.path, "new.txt"), "x");
+      expect(await isDirty(wt.path)).toBe(true);
 
-    // a dirty worktree is refused without force, then removed with force + branch
-    expect(await removeWorktree(repo, wt.path)).toEqual({ ok: false, reason: "dirty" });
-    expect(await removeWorktree(repo, wt.path, { force: true, deleteBranch: true })).toEqual({ ok: true });
-    expect(existsSync(wt.path)).toBe(false);
-    expect(await listWorktrees(repo)).toEqual([]);
-  });
+      // a dirty worktree is refused without force, then removed with force + branch
+      expect(await removeWorktree(repo, wt.path)).toEqual({ ok: false, reason: "dirty" });
+      expect(await removeWorktree(repo, wt.path, { force: true, deleteBranch: true })).toEqual({ ok: true });
+      expect(existsSync(wt.path)).toBe(false);
+      expect(await listWorktrees(repo)).toEqual([]);
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("forks a unique branch on a name clash", async () => {
-    const a = await createWorktree(repo, "task");
-    const b = await createWorktree(repo, "task");
-    if (!a || !b) throw new Error("expected two worktrees");
-    expect(a.branch).toBe("agent/task");
-    expect(b.branch).toBe("agent/task-2");
-  });
+  it.skipIf(!hasGit)(
+    "forks a unique branch on a name clash",
+    async () => {
+      const a = await createWorktree(repo, "task");
+      const b = await createWorktree(repo, "task");
+      if (!a || !b) throw new Error("expected two worktrees");
+      expect(a.branch).toBe("agent/task");
+      expect(b.branch).toBe("agent/task-2");
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("allocates distinct branches for CONCURRENT creates of the same task (no TOCTOU collision)", async () => {
-    const isWt = (r: { path: string; branch: string } | null): r is { path: string; branch: string } => r !== null;
-    const results = (
-      await Promise.all([createWorktree(repo, "race"), createWorktree(repo, "race"), createWorktree(repo, "race"), createWorktree(repo, "race")])
-    ).filter(isWt);
-    expect(results).toHaveLength(4); // none failed with a branch-already-exists 500
-    expect(new Set(results.map((r) => r.branch)).size).toBe(4); // all distinct
-    expect(new Set(results.map((r) => r.path)).size).toBe(4);
-  });
+  it.skipIf(!hasGit)(
+    "allocates distinct branches for CONCURRENT creates of the same task (no TOCTOU collision)",
+    async () => {
+      const isWt = (r: { path: string; branch: string } | null): r is { path: string; branch: string } => r !== null;
+      const results = (
+        await Promise.all([createWorktree(repo, "race"), createWorktree(repo, "race"), createWorktree(repo, "race"), createWorktree(repo, "race")])
+      ).filter(isWt);
+      expect(results).toHaveLength(4); // none failed with a branch-already-exists 500
+      expect(new Set(results.map((r) => r.branch)).size).toBe(4); // all distinct
+      expect(new Set(results.map((r) => r.path)).size).toBe(4);
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("refuses to remove a path outside the managed root", async () => {
-    expect(await removeWorktree(repo, repo)).toEqual({ ok: false, reason: "not-managed" });
-    expect(await removeWorktree(repo, path.join(home, "outside-managed"))).toEqual({ ok: false, reason: "not-managed" });
-  });
+  it.skipIf(!hasGit)(
+    "refuses to remove a path outside the managed root",
+    async () => {
+      expect(await removeWorktree(repo, repo)).toEqual({ ok: false, reason: "not-managed" });
+      expect(await removeWorktree(repo, path.join(home, "outside-managed"))).toEqual({ ok: false, reason: "not-managed" });
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
-  it.skipIf(!hasGit)("rejects a symlink under the managed root that escapes it (no string-prefix bypass)", async () => {
-    const wt = await createWorktree(repo, "real"); // creates the managed root dir
-    if (!wt) throw new Error("expected a worktree");
-    const root = worktreesRoot(repo);
-    const outside = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-outside-")));
-    const link = path.join(root, "escape");
-    symlinkSync(outside, link); // <root>/escape -> /outside (canonicalizes out of the root)
-    try {
-      expect(isManagedWorktree(repo, link)).toBe(false);
-      expect(isManagedWorktree(repo, path.join(link, "wt"))).toBe(false); // symlinked ancestor, absent leaf
-      expect(await removeWorktree(repo, link)).toEqual({ ok: false, reason: "not-managed" });
-    } finally {
-      rmSync(outside, { recursive: true, force: true });
-    }
-  });
+  it.skipIf(!hasGit || !canSymlink)(
+    "rejects a symlink under the managed root that escapes it (no string-prefix bypass)",
+    async () => {
+      const wt = await createWorktree(repo, "real"); // creates the managed root dir
+      if (!wt) throw new Error("expected a worktree");
+      const root = worktreesRoot(repo);
+      const outside = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-outside-")));
+      const link = path.join(root, "escape");
+      symlinkSync(outside, link); // <root>/escape -> /outside (canonicalizes out of the root)
+      try {
+        expect(isManagedWorktree(repo, link)).toBe(false);
+        expect(isManagedWorktree(repo, path.join(link, "wt"))).toBe(false); // symlinked ancestor, absent leaf
+        expect(await removeWorktree(repo, link)).toEqual({ ok: false, reason: "not-managed" });
+      } finally {
+        rmDirRetrying(outside);
+      }
+    },
+    GIT_TEST_TIMEOUT_MS,
+  );
 
   it("gitTopLevel returns null for a non-repo dir", async () => {
     const plain = mkdtempSync(path.join(tmpdir(), "mt-wt-plain-"));
     expect(await gitTopLevel(plain)).toBeNull();
-    rmSync(plain, { recursive: true, force: true });
+    rmDirRetrying(plain);
   });
 });

--- a/test/server/git/wtTestUtil.ts
+++ b/test/server/git/wtTestUtil.ts
@@ -1,0 +1,13 @@
+import { rmSync } from "node:fs";
+
+// Windows keeps a brief handle on a worktree dir after the git child that touched it
+// exits, so a plain rmSync in teardown throws EBUSY/ENOTEMPTY. rmSync's own retry loop
+// waits that out; force so a missing dir is a no-op. A no-op everywhere else.
+export function rmDirRetrying(dir: string): void {
+  rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+}
+
+// A local git chain (init → worktree add → commit → push) runs several child processes
+// per test; on the Windows CI runner that overruns vitest's 5s default. Give the
+// integration tests room — a no-op cost on the fast platforms.
+export const GIT_TEST_TIMEOUT_MS = 30_000;

--- a/test/server/infra/sandbox.spec.ts
+++ b/test/server/infra/sandbox.spec.ts
@@ -124,15 +124,22 @@ describe("buildDockerRunArgs credential overlay", () => {
 });
 
 describe("cleanupSandbox", () => {
-  it("unlinks the per-session credential file (no leaked token after reap)", () => {
-    const sid = "cleanup-creds-1";
-    const file = sandboxCredentialsPath(sid);
-    mkdirSync(path.dirname(file), { recursive: true });
-    writeFileSync(file, "dummy");
-    expect(existsSync(file)).toBe(true);
-    cleanupSandbox(sid);
-    expect(existsSync(file)).toBe(false);
-  });
+  // cleanupSandbox runs `docker rm -f` first; on the Windows CI runner the docker CLI
+  // is present but its daemon is slow to answer, pushing this past vitest's 5s default.
+  const DOCKER_CALL_TIMEOUT_MS = 30_000;
+  it(
+    "unlinks the per-session credential file (no leaked token after reap)",
+    () => {
+      const sid = "cleanup-creds-1";
+      const file = sandboxCredentialsPath(sid);
+      mkdirSync(path.dirname(file), { recursive: true });
+      writeFileSync(file, "dummy");
+      expect(existsSync(file)).toBe(true);
+      cleanupSandbox(sid);
+      expect(existsSync(file)).toBe(false);
+    },
+    DOCKER_CALL_TIMEOUT_MS,
+  );
 });
 
 describe("writeSandboxClaudeConfig", () => {


### PR DESCRIPTION
## Summary

#478（`windows-daily` で露見した Windows 失敗）の**第 2 スライス**。系統 B の 6 件を、4 つの根本原因に分けて修正します。実機なしのため、Windows 検証は windows-daily をこのブランチへ `workflow_dispatch` して行います（結果は下にコメントで貼ります）。

## Items to Confirm / Review

1. **プロダクション変更 `realpathSync` → `realpathSync.native`**（`server/git/worktrees.ts`）。Windows で 8.3 短縮名（`C:\Users\RUNNER~1`）を長名に展開するのは native 呼び出しだけで、`git worktree list` の長名出力と `isManagedWorktree` の包含判定を一致させるのに必要です。本番の `MULMOTERMINAL_HOME` は `os.homedir()`（長名）なので実害は出ていませんでしたが、canonicalPath が真に正規なパスを返すのは containment guard の前提として正しい方向です。POSIX では挙動不変。**この方針への同意**を確認してください。

2. **プロダクション変更: `fs.rename` のリトライ**（`server/backends/shortcuts.ts`）。POSIX の rename は atomic replace ですが、Windows の MoveFileEx は並行 writer が対象を掴んでいる間、2 つ目の rename を EPERM/EACCES/EBUSY で一時拒否します。並行 replace-all PUT（複数タブ）が全部成功するよう短いバックオフでリトライ。他エラーは即 throw。

3. **テストの `repo` を git 正規形に揃えた**判断。`worktreesRoot` は repo 文字列をハッシュするので、テストが `realpathSync(mkdtemp)` 形（Windows で 8.3/`\`）を渡すと本番 `repoRoot`（git 形: 長名/`/`）とハッシュが食い違い、managed-root 判定が外れていました（空リスト / 409-instead-of-500）。`beforeEach` を async 化し `repo = (await gitTopLevel(repo)) ?? repo`。

## 変更の内訳（原因 → 対処）

| 原因 | 対処 | 種別 |
|---|---|---|
| B1: 8.3 短縮パス / セパレータで managed-root 判定が外れる | 本番 realpathSync.native + テスト repo を git 形に | 実コード+テスト |
| B4b: 並行 rename が Windows で EPERM | 本番 rename リトライ | 実コード |
| B4a: teardown の rmSync が EBUSY | `rmDirRetrying`（maxRetries） | テスト |
| B4a: git 統合テストが 5s timeout | `GIT_TEST_TIMEOUT_MS = 30s` | テスト |
| B2: symlink 作成が Windows で権限不足 | `canSymlink` probe で skip | テスト |
| B3: `q"uote` が Windows で不正名 | `tryWriteUnsafeSkill` で作成失敗を許容 | テスト |

## 安全上の確認

`isManagedWorktree` は `canonicalPath`（realpath ベース）+ `path.sep` を使うため、Windows でも symlink escape の string-prefix bypass は成立しません。B2 の失敗は判定ロジックではなくフィクスチャ作成（`symlinkSync`）の失敗でした。

## 検証

- macOS: 全 1470 tests green / lint error 0 / typecheck / build OK
- Windows: windows-daily をブランチへ dispatch（結果を本 PR にコメント）

Refs #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
