### PR TITLE
refactor: share the modal Tab focus-trap

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { trapTabKey } from "../utils/focusTrap";
 import { useTheme } from "../composables/useTheme";
 import { previewAttention } from "../composables/useAttentionSound";
 import { useCost } from "../composables/useCost";
@@ -215,19 +216,7 @@ function onKeydown(e: KeyboardEvent) {
     return;
   }
   if (e.key !== "Tab" || !modalEl.value) return;
-  const focusable = [...modalEl.value.querySelectorAll<HTMLElement>('button, input, [tabindex]:not([tabindex="-1"])')].filter(
-    (el) => !el.hasAttribute("disabled"),
-  );
-  if (focusable.length === 0) return;
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault();
-    last.focus();
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault();
-    first.focus();
-  }
+  trapTabKey(e, modalEl.value, 'button, input, [tabindex]:not([tabindex="-1"])');
 }
 
 // Load cost unconditionally — the server falls back to the workspace when no cwd is

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -3,6 +3,7 @@
 // first), fetched from GET /api/transcript/timeline. Opened from the cell header's
 // 🕘 button so you can see "what did it do?" without scrolling the raw transcript.
 import { ref, watch, onUnmounted, nextTick } from "vue";
+import { trapTabKey } from "../utils/focusTrap";
 
 interface TimelineEvent {
   ts: string;
@@ -68,17 +69,7 @@ const onKeydown = (e: KeyboardEvent) => {
     return;
   }
   if (e.key !== "Tab" || !modalEl.value) return;
-  const focusable = [...modalEl.value.querySelectorAll<HTMLElement>('button, [tabindex]:not([tabindex="-1"])')].filter((el) => !el.hasAttribute("disabled"));
-  if (focusable.length === 0) return;
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  if (e.shiftKey && document.activeElement === first) {
-    e.preventDefault();
-    last.focus();
-  } else if (!e.shiftKey && document.activeElement === last) {
-    e.preventDefault();
-    first.focus();
-  }
+  trapTabKey(e, modalEl.value);
 };
 
 // One watch over open + identity: (re)load whenever the overlay is open — covering

--- a/src/utils/focusTrap.ts
+++ b/src/utils/focusTrap.ts
@@ -1,0 +1,17 @@
+// Keep Tab focus inside `container`: on Tab from the last focusable element wrap to
+// the first, and on Shift+Tab from the first wrap to the last — so focus can't reach
+// background controls behind a modal. Call from a keydown handler on a "Tab" event.
+// `selector` picks the focusable elements; disabled ones are excluded.
+export function trapTabKey(e: KeyboardEvent, container: HTMLElement, selector = 'button, [tabindex]:not([tabindex="-1"])'): void {
+  const focusable = [...container.querySelectorAll<HTMLElement>(selector)].filter((el) => !el.hasAttribute("disabled"));
+  if (focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}

--- a/test/src/utils/focusTrap.spec.ts
+++ b/test/src/utils/focusTrap.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { trapTabKey } from "../../../src/utils/focusTrap";
+
+// jsdom's element.focus() only sets document.activeElement for elements attached to
+// the document, so the container is mounted into document.body per test.
+function mount(html: string): HTMLElement {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+function el(container: HTMLElement, selector: string): HTMLElement {
+  const found = container.querySelector<HTMLElement>(selector);
+  if (!found) throw new Error(`test fixture missing: ${selector}`);
+  return found;
+}
+
+function tab(shift: boolean): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key: "Tab", shiftKey: shift, cancelable: true });
+}
+
+describe("trapTabKey", () => {
+  let container: HTMLElement;
+  afterEach(() => container?.remove());
+
+  describe("with three focusable buttons", () => {
+    beforeEach(() => {
+      container = mount('<button id="a">a</button><button id="b">b</button><button id="c">c</button>');
+    });
+
+    it("Tab from the last element wraps to the first", () => {
+      el(container, "#c").focus();
+      const e = tab(false);
+      trapTabKey(e, container);
+      expect(document.activeElement).toBe(el(container, "#a"));
+      expect(e.defaultPrevented).toBe(true);
+    });
+
+    it("Shift+Tab from the first element wraps to the last", () => {
+      el(container, "#a").focus();
+      const e = tab(true);
+      trapTabKey(e, container);
+      expect(document.activeElement).toBe(el(container, "#c"));
+      expect(e.defaultPrevented).toBe(true);
+    });
+
+    it("does nothing when focus is on a middle element (native Tab proceeds)", () => {
+      el(container, "#b").focus();
+      const e = tab(false);
+      trapTabKey(e, container);
+      expect(document.activeElement).toBe(el(container, "#b"));
+      expect(e.defaultPrevented).toBe(false);
+    });
+  });
+
+  it("skips disabled elements when picking first/last", () => {
+    container = mount('<button id="a">a</button><button id="b">b</button><button id="c" disabled>c</button>');
+    el(container, "#b").focus(); // #b is the last ENABLED element
+    const e = tab(false);
+    trapTabKey(e, container);
+    expect(document.activeElement).toBe(el(container, "#a"));
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("is a no-op when nothing matches the selector", () => {
+    container = mount("<span>no focusables</span>");
+    const e = tab(false);
+    trapTabKey(e, container);
+    expect(e.defaultPrevented).toBe(false);
+  });
+
+  it("honors a custom selector (e.g. including inputs)", () => {
+    container = mount('<input id="in" /><button id="btn">b</button>');
+    el(container, "#in").focus();
+    const e = tab(true);
+    trapTabKey(e, container, 'button, input, [tabindex]:not([tabindex="-1"])');
+    expect(document.activeElement).toBe(el(container, "#btn"));
+    expect(e.defaultPrevented).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`SettingsModal` and `TimelineOverlay` carried a **byte-identical** Tab focus-trap block (on Tab from the last focusable element wrap to the first; shift-Tab the other way). `trapTabKey(e, container, selector?)` (new `src/utils/focusTrap.ts`) now holds it.

## Items to Confirm / Review

- **The only real difference is the selector**, now the optional third argument: `SettingsModal` includes `input` (`'button, input, [tabindex]...'`), `TimelineOverlay` doesn't (`'button, [tabindex]...'`). Preserved exactly — SettingsModal passes its selector, TimelineOverlay uses the default.
- **Each modal keeps its own Escape handling and listener wiring**, which genuinely differ: SettingsModal does `document.addEventListener` in `onMounted`/`onUnmounted`; TimelineOverlay adds/removes the listener from a `watch` on the open transition. Only the Tab-trap body was shared — I did NOT merge the divergent wiring.
- **Added a unit test** (`test/src/utils/focusTrap.spec.ts`) — `TimelineOverlay.spec.ts` had **no** coverage for its focus-trap, so this is net-new coverage: both wrap directions, the middle-element no-op (native Tab proceeds), disabled-element exclusion, the empty-container no-op, and a custom `input`-inclusive selector. `SettingsModal.spec.ts` already exercised its Tab path and still passes.
- Pure DOM function (no Vue lifecycle), so it lives in `src/utils/` beside `fetchJson.ts` rather than as a composable. No `!` non-null assertions (repo forbids them) — the test uses a throwing `el()` fixture helper.

## Verification

- `vue-tsc -b --force` → 0 errors · `yarn typecheck:test` → 0 · `eslint` → 0
- `vitest`: `focusTrap.spec` **6 passed**, `SettingsModal` + `TimelineOverlay` specs **20 passed**; full baseline 1470 unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)