### PR TITLE
refactor: share the public-config projection and spawn-capture helper

### DIFF
--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -180,24 +180,30 @@ export function mergeConfigUpdate(base: AppConfig, body: Record<string, unknown>
   };
 }
 
+// The config's serializable shape, shared by the persisted file and the GET/POST
+// /api/config response so the two can't drift. Fresh object each call; the key order
+// here is the on-disk key order.
+export function toPublicAppConfig(config: AppConfig): AppConfig {
+  return {
+    cwdPresets: config.cwdPresets,
+    soundFile: config.soundFile,
+    prRepos: config.prRepos,
+    launchers: config.launchers,
+    userMcpServers: config.userMcpServers,
+    buttons: config.buttons,
+    chips: config.chips,
+    pushEnabled: config.pushEnabled,
+    worklogEnabled: config.worklogEnabled,
+    worklogIntervalHours: config.worklogIntervalHours,
+  };
+}
+
 // Persist the whole config; returns false on any write failure so the caller can
 // surface it instead of reporting a false success.
 export function saveAppConfig(file: string, config: AppConfig): boolean {
   try {
     mkdirSync(path.dirname(file), { recursive: true });
-    const payload = {
-      cwdPresets: config.cwdPresets,
-      soundFile: config.soundFile,
-      prRepos: config.prRepos,
-      launchers: config.launchers,
-      userMcpServers: config.userMcpServers,
-      buttons: config.buttons,
-      chips: config.chips,
-      pushEnabled: config.pushEnabled,
-      worklogEnabled: config.worklogEnabled,
-      worklogIntervalHours: config.worklogIntervalHours,
-    };
-    writeFileSync(file, JSON.stringify(payload, null, 2));
+    writeFileSync(file, JSON.stringify(toPublicAppConfig(config), null, 2));
     return true;
   } catch {
     return false;

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
-import { loadAppConfig, saveAppConfig, mergeConfigUpdate, type AppConfig } from "./app-config.js";
+import { loadAppConfig, saveAppConfig, mergeConfigUpdate, toPublicAppConfig, type AppConfig } from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type UserMcpServer } from "./config-schema.js";
 
@@ -72,19 +72,7 @@ function badNullableArrayField(body: Record<string, unknown>): string | null {
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {
   // The live config as the API exposes it, so a client (e.g. a settings UI) can read back
   // everything it can write — buttons/chips included — and round-trip it.
-  const configResponse = () => ({
-    cwd: claudeCwd,
-    cwdPresets: config.cwdPresets,
-    soundFile: config.soundFile,
-    prRepos: config.prRepos,
-    launchers: config.launchers,
-    userMcpServers: config.userMcpServers,
-    buttons: config.buttons,
-    chips: config.chips,
-    pushEnabled: config.pushEnabled,
-    worklogEnabled: config.worklogEnabled,
-    worklogIntervalHours: config.worklogIntervalHours,
-  });
+  const configResponse = () => ({ cwd: claudeCwd, ...toPublicAppConfig(config) });
 
   app.get("/api/config", (_req, res) => {
     res.json({ ...configResponse(), home: os.homedir() });

--- a/server/infra/sandbox.ts
+++ b/server/infra/sandbox.ts
@@ -15,6 +15,7 @@ import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import os from "node:os";
+import { spawnCapture } from "./spawnCapture.js";
 
 const IMAGE = process.env.MULMOTERMINAL_SANDBOX_IMAGE || "mulmoterminal-sandbox";
 const CONTAINER_HOME = "/home/node";
@@ -81,7 +82,7 @@ export function sandboxImageExists(): boolean {
 }
 
 function builtImageSha(): string {
-  const r = runCapture("docker", ["image", "inspect", IMAGE, "--format", `{{index .Config.Labels "${IMAGE_SHA_LABEL}"}}`]);
+  const r = spawnCapture("docker", ["image", "inspect", IMAGE, "--format", `{{index .Config.Labels "${IMAGE_SHA_LABEL}"}}`]);
   return r.status === 0 ? r.stdout.trim() : "";
 }
 
@@ -150,7 +151,7 @@ export function sandboxCredentialsPath(sessionId: string): string {
 // overlay, falling back to whatever ~/.claude/.credentials.json holds.
 export function writeSandboxCredentials(sessionId: string): string | null {
   if (process.platform !== "darwin") return null;
-  const r = runCapture("security", ["find-generic-password", "-s", KEYCHAIN_CREDENTIAL_SERVICE, "-w"]);
+  const r = spawnCapture("security", ["find-generic-password", "-s", KEYCHAIN_CREDENTIAL_SERVICE, "-w"]);
   const credential = r.status === 0 ? r.stdout.trim() : "";
   if (!credential) return null;
   mkdirSync(SANDBOX_DIR, { recursive: true });
@@ -189,16 +190,11 @@ export function parseMountConfigNames(csv: string | undefined): string[] {
   return [...new Set(names)];
 }
 
-function runCapture(bin: string, args: string[]): { status: number | null; stdout: string } {
-  const r = spawnSync(bin, args, { encoding: "utf8" });
-  return { status: r.status, stdout: r.stdout ?? "" };
-}
-
 // gh on macOS keeps its token in the Keychain (not ~/.config/gh/hosts.yml), so mounting
 // the config dir alone won't authenticate gh / git-over-https. Best-effort: pass the
 // token as GH_TOKEN so it works inside the container.
 function ghTokenArgs(): string[] {
-  const r = runCapture("gh", ["auth", "token"]);
+  const r = spawnCapture("gh", ["auth", "token"]);
   const token = r.status === 0 ? r.stdout.trim() : "";
   return token ? ["-e", `GH_TOKEN=${token}`] : [];
 }

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -1,7 +1,5 @@
 import { spawnSync } from "node:child_process";
 
-// Bin passed as a parameter (never a string literal at the call site) so callers aren't
-// flagged as a spawn-of-a-string-literal.
 export function spawnCapture(bin: string, args: string[]): { status: number | null; stdout: string } {
   const r = spawnSync(bin, args, { encoding: "utf8" });
   return { status: r.status, stdout: r.stdout ?? "" };

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -1,0 +1,8 @@
+import { spawnSync } from "node:child_process";
+
+// Bin passed as a parameter (never a string literal at the call site) so callers aren't
+// flagged as a spawn-of-a-string-literal.
+export function spawnCapture(bin: string, args: string[]): { status: number | null; stdout: string } {
+  const r = spawnSync(bin, args, { encoding: "utf8" });
+  return { status: r.status, stdout: r.stdout ?? "" };
+}

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -5,23 +5,17 @@
 //
 // Isolation: we use our OWN tmux server (`-L mulmoterminal`) and config file, so none
 // of this touches the user's own tmux sessions, keybindings, or status bar.
-import { spawnSync } from "node:child_process";
 import { writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { isLauncherEnvVar } from "./pty-env.js";
+import { spawnCapture } from "./spawnCapture.js";
 
 const SERVER_SOCKET = "mulmoterminal";
 const SESSION_PREFIX = "mt-";
 const CONF_FILE = path.join(os.homedir(), ".mulmoterminal", "tmux.conf");
 
-// Spawn a command with the binary as a PARAMETER (not a string literal at the call
-// site) — mirrors server/gh.ts so it isn't flagged as a spawn-of-a-string-literal.
-function run(bin: string, args: string[]): { status: number | null; stdout: string } {
-  const r = spawnSync(bin, args, { encoding: "utf8" });
-  return { status: r.status, stdout: r.stdout ?? "" };
-}
-const tmux = (args: string[]) => run("tmux", ["-L", SERVER_SOCKET, ...args]);
+const tmux = (args: string[]) => spawnCapture("tmux", ["-L", SERVER_SOCKET, ...args]);
 
 let cachedAvailable: boolean | null = null;
 
@@ -29,7 +23,7 @@ let cachedAvailable: boolean | null = null;
 // detection the isolated config is written so `new-session` picks it up via `-f`.
 export function tmuxAvailable(): boolean {
   if (cachedAvailable === null) {
-    cachedAvailable = run("tmux", ["-V"]).status === 0;
+    cachedAvailable = spawnCapture("tmux", ["-V"]).status === 0;
     if (cachedAvailable) ensureConf();
   }
   return cachedAvailable;


### PR DESCRIPTION
## Summary

Two small server clones jscpd flagged:

- **`toPublicAppConfig(config)`** — `saveAppConfig` (app-config.ts) and `configResponse` (config-routes.ts) built the same 10-field projection of `AppConfig`. `saveAppConfig` now does `JSON.stringify(toPublicAppConfig(config), null, 2)` (field order preserved → byte-identical on-disk file); `configResponse` is `{ cwd: claudeCwd, ...toPublicAppConfig(config) }` (cwd still first → identical JSON response).
- **`spawnCapture(bin, args)`** (new `server/infra/spawnCapture.ts`) — `sandbox.ts`'s `runCapture` and `tmux.ts`'s `run` were byte-identical `spawnSync → {status, stdout}` wrappers. `sandbox.ts` keeps its distinct stdio-`ignore`/`inherit` helpers (not merged); `tmux.ts`'s `tmux()` wrapper is preserved.

Written by a worktree-isolated subagent; **I re-verified independently and made one correction** (below).

## ⚠️ Security-scanner note — please read

The subagent's run raised an automated security warning, because its comment on `spawnCapture` said the bin-as-parameter shape existed "so callers aren't flagged as a spawn-of-a-string-literal" — wording that reads as deliberately evading a scanner. **I reviewed the actual code and removed that comment.** My assessment, from the primary source:

- **The code is benign.** `spawnCapture(bin, args)` is an ordinary generic spawn helper — the same shape the git-helpers PR (#486) used. Every call site passes a **hardcoded** tool name: `"docker"`, `"security"` (macOS Keychain CLI, pre-existing), `"gh"`, `"tmux"`. **No bin is user-derived**, so there's no command-injection surface, and the refactor adds none.
- **The comment was also factually wrong**: the original `runCapture(bin, args)` *already* took a variable `bin`, so the helper changes no scanner behavior versus the code it replaces.
- So the warning was a false positive triggered purely by the comment's framing. Removing the comment (a generic helper needs none) resolves it without weakening anything.

Please still give the spawn call sites a look to confirm you agree all bins are fixed tool names.

## Items to Confirm / Review

- **`toPublicAppConfig` returns `AppConfig`** (the projected set equals the whole interface). Field order is preserved exactly so `saveAppConfig`'s on-disk JSON is byte-identical — worth confirming, since it's a persisted file.
- `sandbox.ts` keeps its `spawnSync` import (still used by its `run`/`runInherit` stdio variants, deliberately not merged); `tmux.ts` drops its now-unused `spawnSync` import.
- No `any`/`as`/suppressions.

## Verification (independent, clean worktree)

- `tsc -p tsconfig.server.json` → **0 errors** · `eslint` on all changed files → **0**
- `vitest` config + sandbox + tmux specs → **53 passed** (full suite baseline 1470 unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)