### PR TITLE
refactor: share the session-terminal WebSocket URL assembly

### DIFF
--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -10,7 +10,9 @@ export interface TerminalWsUrlInput {
   devTerminal?: boolean; // grid dev terminal: no GUI MCP (?gui=0)
 }
 
-export function buildTerminalWsUrl({ host, secure, sessionId, cwd, devTerminal }: TerminalWsUrlInput): string {
+// The two session-terminal endpoints (/ws for claude, /ws/codex for codex) send the
+// identical session/cwd/gui query, so they share this assembly — only the path differs.
+function sessionTerminalWsUrl(path: string, { host, secure, sessionId, cwd, devTerminal }: TerminalWsUrlInput): string {
   const params = new URLSearchParams();
   if (sessionId) params.set("session", sessionId);
   if (cwd) params.set("cwd", cwd);
@@ -18,7 +20,11 @@ export function buildTerminalWsUrl({ host, secure, sessionId, cwd, devTerminal }
   const qs = params.toString();
   const suffix = qs ? `?${qs}` : "";
   const proto = secure ? "wss:" : "ws:";
-  return `${proto}//${host}/ws${suffix}`;
+  return `${proto}//${host}/${path}${suffix}`;
+}
+
+export function buildTerminalWsUrl(input: TerminalWsUrlInput): string {
+  return sessionTerminalWsUrl("ws", input);
 }
 
 export type RunWsUrlInput = { host: string; secure: boolean; cwd?: string | null } & (
@@ -78,13 +84,6 @@ export interface CodexWsUrlInput {
 // The codex-terminal endpoint (a first-class codex session). Persistent & reattachable like
 // /ws; the browser sends the mulmoterminal session id to reattach/resume — the server maps it
 // to codex's own rollout id. ?gui=0 (grid) runs codex without the GUI MCP.
-export function buildCodexWsUrl({ host, secure, sessionId, cwd, devTerminal }: CodexWsUrlInput): string {
-  const params = new URLSearchParams();
-  if (sessionId) params.set("session", sessionId);
-  if (cwd) params.set("cwd", cwd);
-  if (devTerminal) params.set("gui", "0");
-  const qs = params.toString();
-  const suffix = qs ? `?${qs}` : "";
-  const proto = secure ? "wss:" : "ws:";
-  return `${proto}//${host}/ws/codex${suffix}`;
+export function buildCodexWsUrl(input: CodexWsUrlInput): string {
+  return sessionTerminalWsUrl("ws/codex", input);
 }


### PR DESCRIPTION
## Summary

`buildTerminalWsUrl` (`/ws`) and `buildCodexWsUrl` (`/ws/codex`) built the **identical** session/cwd/gui query, proto, and suffix — only the path differed (jscpd's `wsUrl.ts` self-clone). `sessionTerminalWsUrl(path, input)` now holds that assembly; both public builders are one-liners over it.

## Items to Confirm / Review

- **`CodexWsUrlInput` and `TerminalWsUrlInput` are structurally identical** (`{ host, secure, sessionId, cwd?, devTerminal? }`), so `buildCodexWsUrl` passes its input straight through to the helper (typed as `TerminalWsUrlInput`) with no cast — `vue-tsc` accepts it. Both public input types stay exported (they carry different doc comments describing each endpoint).
- `buildRunWsUrl` / `buildLaunchWsUrl` were **not** folded in — their query params (index/buttonId, launcher/shell) differ and they append `?${params}` unconditionally rather than the empty-guarded suffix. Only the two truly-identical session endpoints share the helper.

## Verification

- `vue-tsc -b --force` → 0 errors · `eslint` → 0
- `vitest` `wsUrl.spec.ts` → **19 passed** (covers both `/ws` and `/ws/codex`, including the `?gui=0` dev-terminal query); baseline 1470 unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)