### PR TITLE
ci: run lint-and-build on macOS as well as ubuntu (#459)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,15 @@ on:
     branches: [main, dev_tool, feat/multi-agent]
 
 jobs:
+  # ubuntu + macOS on every PR. macOS matters here beyond redundancy: the Docker sandbox
+  # is darwin-gated (sandboxPlatformSupported), so its code paths — Keychain credential
+  # export/refresh, mount building — only run for real on a macOS runner.
   lint-and-build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

`ci.yml` の `lint-and-build` を **`[ubuntu-latest, macos-latest]` の matrix** にします。#459（CI カバレッジ）の最後の一歩。

macOS は単なる冗長化ではありません: **Docker sandbox は darwin 専用**（`sandboxPlatformSupported`）なので、Keychain credential の export/refresh・マウント構築といった経路が実際に走るのは macOS runner だけです（#494 で追加した `refreshHostKeychainIfExpired` などは ubuntu CI では実行されない）。

`fail-fast: false` で片方の OS の失敗がもう片方をキャンセルしないようにしています。

## Items to Confirm / Review

- **この PR 自体で macOS ジョブが走ります**（PR トリガ）。実際に macOS で lint/typecheck/build/test が緑になることをこの PR で確認できます。
- node バージョンは現行どおり 22 のみ（OS 次元だけ追加）。node 24 追加は別スコープ。
- `package-smoke` は ubuntu のみのまま（node-pty spawn-helper の回帰ガード #33 は `linux-x64` 固有）。macOS 版パッケージスモークは必要なら別途。

## User Prompt

- macOS matrix 追加して（#459 の残タスク）

## 検証

- YAML 妥当性確認済み（matrix.os = [ubuntu-latest, macos-latest], fail-fast: false, steps 9）
- macOS 実行結果はこの PR の CI で確認

Refs #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)
