### PR TITLE
refactor: convert FilterChip to Tailwind utilities

### DIFF
--- a/src/components/FilterChip.vue
+++ b/src/components/FilterChip.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-// Ported from mulmoclaude's FilterChip — a small pill toggle used to filter
-// the session list. Adapted to mulmoterminal's dark scoped-CSS theme.
+// A small pill toggle used to filter the session list. Active chips ignore hover
+// (the accent fill wins), so the hover styles apply only in the inactive state.
 defineProps<{
   active: boolean;
   label: string;
@@ -10,35 +10,13 @@ defineEmits<{ (e: "click"): void }>();
 </script>
 
 <template>
-  <button type="button" :aria-pressed="active" :class="['chip', { active }]" @click="$emit('click')">
+  <button
+    type="button"
+    :aria-pressed="active"
+    class="inline-flex items-center py-0.5 px-2.5 text-[11px] leading-4 rounded-full border cursor-pointer transition-colors duration-[120ms]"
+    :class="active ? 'bg-accent-bg border-accent-bg text-on-accent' : 'bg-subtle border-border text-muted hover:bg-selected-hover hover:text-secondary'"
+    @click="$emit('click')"
+  >
     {{ label }}<template v-if="count !== undefined"> ({{ count }}) </template>
   </button>
 </template>
-
-<style scoped>
-.chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 10px;
-  font-size: 11px;
-  line-height: 16px;
-  border-radius: 9999px;
-  border: 1px solid var(--border);
-  background: var(--bg-subtle);
-  color: var(--text-muted);
-  cursor: pointer;
-  transition:
-    background 0.12s,
-    color 0.12s,
-    border-color 0.12s;
-}
-.chip:hover {
-  background: var(--bg-selected-hover);
-  color: var(--text-secondary);
-}
-.chip.active {
-  background: var(--accent-bg);
-  border-color: var(--accent-bg);
-  color: var(--on-accent);
-}
-</style>

--- a/test/src/components/Sidebar.spec.ts
+++ b/test/src/components/Sidebar.spec.ts
@@ -77,7 +77,7 @@ describe("Sidebar", () => {
     const wrapper = mountSidebar({
       sessions: [row({ id: "a", waiting: true }), row({ id: "b" })],
     });
-    const unreadChip = wrapper.findAll(".chip")[1];
+    const unreadChip = wrapper.findAll("[aria-pressed]")[1];
     expect(unreadChip.text()).toContain("(1)");
     await unreadChip.trigger("click");
     expect(wrapper.emitted("update:filter")?.[0]).toEqual(["unread"]);


### PR DESCRIPTION
## Summary

Second Tailwind migration (after #495 enabled it). `FilterChip` is now **fully Tailwind — its entire `<style scoped>` block is deleted**. This is the "end state" a migrated component looks like: styling lives on the element, nothing to move if the markup is copy-pasted or extracted.

## Items to Confirm / Review

- **Base is static; the variant is a conditional `:class`.** The active and inactive states set the same three properties (background, border-color, color), so putting both as always-on utilities would collide. Instead `:class` picks one set or the other:
  - inactive → `bg-subtle border-border text-muted hover:bg-selected-hover hover:text-secondary`
  - active → `bg-accent-bg border-accent-bg text-on-accent`
- **Hover applies only when inactive — on purpose.** In the original CSS, `.chip.active` and `.chip:hover` have equal specificity, and `.chip.active` came later, so an active+hovered chip showed the accent fill, not the hover. The conditional class reproduces that (hover utilities are only in the inactive branch). Please confirm that matches the intent.
- **Each utility = the byte-identical original declaration**, verified in the built CSS: `py-0.5`=2px, `px-2.5`=10px, `text-[11px]` (font-size only, no bundled line-height), `leading-4`=16px, `rounded-full`, `transition-colors` + `duration-[120ms]`=.12s, and the color tokens.
- **`Sidebar.spec` selector changed** from `.chip` (removed) to `[aria-pressed]` — the accessible attribute every FilterChip carries — per the doc's "don't couple tests to styling classes" rule.

## Verification

- `vue-tsc -b --force` → 0 · `yarn typecheck:test` → 0
- `vitest run` → **1483 passed** (incl. Sidebar spec that renders FilterChip through SessionFilters)
- `eslint` clean · `prettier` clean

Follows `docs/styling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)