### PR TITLE
refactor: convert AccountingOverlay to Tailwind utilities

### DIFF
--- a/src/components/AccountingOverlay.vue
+++ b/src/components/AccountingOverlay.vue
@@ -18,23 +18,9 @@ useEscapeToClose(isOpen, close);
 </script>
 
 <template>
-  <div v-if="isOpen" class="accounting-overlay" role="region" aria-label="Accounting">
+  <div v-if="isOpen" class="fixed inset-x-0 top-10 bottom-0 z-50 bg-deep" role="region" aria-label="Accounting">
     <PluginFrame :css="accountingCss" height="100%">
       <AccountingView />
     </PluginFrame>
   </div>
 </template>
-
-<style scoped>
-/* Fills the page BELOW the toolbar (40px) — the toolbar stays visible + clickable,
-   so the user can switch back to Chat / Collections. Matches CollectionsBrowseOverlay. */
-.accounting-overlay {
-  position: fixed;
-  top: 40px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 50;
-  background: var(--bg-deep);
-}
-</style>


### PR DESCRIPTION
## Summary

Fourth Tailwind migration. `AccountingOverlay`'s fixed-below-the-40px-toolbar root → utilities, `<style scoped>` deleted.

`fixed inset-x-0 top-10 bottom-0 z-50 bg-deep` — verified in the built CSS: `position:fixed`, `inset-inline:0`, `top:calc(--spacing*10)`=40px, `bottom:0`, `z-index:50`, `background-color:var(--bg-deep)`.

## Items to Confirm / Review

- Single-element, token-based, **no test coupling** (nothing selects `.accounting-overlay`). Clean full conversion.
- `top-10` = 40px (Tailwind's 0.25rem spacing base × 10). This is the toolbar height the overlay sits below.
- Note: the other four overlays (`Collections`/`Files`/`Prs`/`Wiki`) share `overlay.css`'s `.overlay-root` (same positioning + `flex flex-col`). That shared stylesheet is a natural next Tailwind target — deliberately left for its own PR.

## Verification

- `vue-tsc -b --force` → 0 · `vitest run` → **1483 passed** · `eslint`/`prettier` clean

Follows `docs/styling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)