### PR TITLE
test: raise global vitest timeout to absorb load spikes (#463)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,13 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     include: ["src/**/*.spec.ts", "test/**/*.spec.ts", "server/**/*.spec.ts", "bin/**/*.spec.ts"],
+    // The suite runs files in parallel across all cores. On a machine also running a build
+    // (a dev's `yarn build` alongside `yarn test`) the cores are oversubscribed, so an
+    // I/O- or mount-heavy test that finishes in milliseconds when idle can cross vitest's
+    // 5s default and flake — the victim is whichever test is running at peak load, not any
+    // one test. CI never hits this (it doesn't build and test at once). A roomier baseline
+    // absorbs the load spike without slowing the normal case (passing tests still finish in
+    // ms) or masking a real hang (that still trips this ceiling).
+    testTimeout: 15_000,
   },
 });


### PR DESCRIPTION
## Summary

#463（media route テストの断続的失敗）を調査した結果、**mulmoscript 固有のバグではなく、負荷時の vitest timeout** が真の原因と判明しました。global `testTimeout` を 5s（既定）→ 15s に引き上げます。

## 調査で分かったこと

失敗時の実出力を捕まえるため「3並走ビルド + 全スイート」で再現したところ、犠牲になったのは media route テストではなく **`GridView.spec.ts` の別テストで `Test timed out in 5000ms`**（#492 作業中にもフレークした同じテスト）。

- media route テストは非最大負荷時は 7ms で pass
- vitest はファイルを全コア並列実行するため、`yarn build` と `yarn test` を同時に走らせるとコアが oversubscribe され、通常 ms のテストが 5s 既定を超える
- 犠牲は「ピーク負荷で走っていたテスト」でランダム。media route は #463 を立てた日にたまたま犠牲になっただけ
- **CI は一貫して緑**（build と test を同時に走らせないため）

当初の 2 仮説のうち仮説 B（timeout）が正解、仮説 A（describe 順序依存で 404）は誤りでした。

## Items to Confirm / Review

- **global timeout 引き上げの是非**。CI では無影響（pass するテストは ms で終わる）、ローカル負荷時の誤 timeout を解消、真のハングは 15s で検出されるので隠蔽になりません。git 統合テスト（30s）や sandbox（30s）で既に明示 timeout を使っているので baseline 15s は一貫します。
- これはプロダクション欠陥ではなく**開発体験の改善**です（CI は元々緑）。

## 検証

- 修正前: 「3並走ビルド + 全スイート」で ~2回に1回失敗
- 修正後: 同条件で 4/4 pass
- 通常の lint / build / typecheck も緑

## User Prompt

- #463 を調べて（media route テストの断続的失敗）

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
