### PR TITLE
fix: restore the second empty-state assertion in the menu specs

### DIFF
--- a/test/src/components/RunMenu.spec.ts
+++ b/test/src/components/RunMenu.spec.ts
@@ -34,7 +34,7 @@ describe("RunMenu", () => {
     mockFetch([]);
     const w = await mountMenu();
     expect(w.find('[aria-haspopup="menu"]').exists()).toBe(false);
-    expect(w.find('[aria-haspopup="menu"]').exists()).toBe(false);
+    expect(w.find('[role="menu"]').exists()).toBe(false);
   });
 
   it("does not fetch (no button) while cwd is unresolved, avoiding default-workspace scripts", async () => {

--- a/test/src/components/SkillMenu.spec.ts
+++ b/test/src/components/SkillMenu.spec.ts
@@ -32,7 +32,7 @@ describe("SkillMenu", () => {
     mockFetch([]);
     const w = await mountMenu();
     expect(w.find('[aria-haspopup="menu"]').exists()).toBe(false);
-    expect(w.find('[aria-haspopup="menu"]').exists()).toBe(false);
+    expect(w.find('[role="menu"]').exists()).toBe(false);
   });
 
   it("does not fetch (no button) while cwd is unresolved, avoiding default-workspace skills", async () => {


### PR DESCRIPTION
## Summary

Addresses codex's review on #505. Converting the menu selectors mapped **both** `.menu-trigger` and `.menu-root` to `[aria-haspopup="menu"]`, so each empty-state test (`renders nothing when the project has no scripts/skills`) asserted the same condition twice — the second, independent check was lost.

The second assertion now verifies the popup (`[role="menu"]`) is absent, so both specs check two distinct conditions again (no trigger **and** no popup when there's no data).

This is exactly the risk in a mechanical sed-based selector rename: two different original selectors collapsing to one. Noting it as a lesson for the migration.

## Verification

- `vitest` RunMenu + SkillMenu specs → 12 passed · `yarn typecheck:test` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)