### PR TITLE
refactor: convert GridView to Tailwind utilities

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -314,7 +314,7 @@ function configureAppearance() {
 </script>
 
 <template>
-  <div class="shell">
+  <div class="flex flex-col h-screen w-screen overflow-hidden">
     <AppToolbar
       :add-terminal-active="launchOpen"
       :auto-sort="state.sortMode === 'auto'"
@@ -323,13 +323,23 @@ function configureAppearance() {
       @toggle-sort="toggleSortMode"
       @settings="showSettings = true"
     />
-    <nav v-if="pages > 1 && expandedUid === null" class="tabbar" aria-label="Grid tabs">
-      <button v-for="p in pages" :key="p" :class="['tab', { active: p - 1 === state.page }]" :aria-pressed="p - 1 === state.page" @click="switchTo(p - 1)">
+    <nav
+      v-if="pages > 1 && expandedUid === null"
+      class="flex-none flex items-center gap-1 h-[30px] px-4 bg-panel border-b border-border"
+      aria-label="Grid tabs"
+    >
+      <button
+        v-for="p in pages"
+        :key="p"
+        class="border border-border bg-base text-muted font-mono text-xs min-w-[28px] py-[3px] px-2 rounded-md cursor-pointer hover:bg-hover hover:text-fg aria-pressed:bg-hover aria-pressed:text-fg aria-pressed:border-accent"
+        :aria-pressed="p - 1 === state.page"
+        @click="switchTo(p - 1)"
+      >
         {{ p }}
       </button>
     </nav>
     <TerminalGrid
-      class="main"
+      class="flex-1 min-h-0 min-w-0"
       :cells="displayCells"
       :expanded-uid="expandedUid"
       :list-rows="listRows"
@@ -372,50 +382,3 @@ function configureAppearance() {
     />
   </div>
 </template>
-
-<style scoped>
-.shell {
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-  width: 100vw;
-  overflow: hidden;
-}
-
-.tabbar {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  height: 30px;
-  padding: 0 16px;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--border);
-}
-.tab {
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-  color: var(--text-muted);
-  font-family: ui-monospace, monospace;
-  font-size: 12px;
-  min-width: 28px;
-  padding: 3px 8px;
-  border-radius: 6px;
-  cursor: pointer;
-}
-.tab:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.tab.active {
-  background: var(--bg-hover);
-  color: var(--text);
-  border-color: var(--accent);
-}
-
-.main {
-  flex: 1;
-  min-height: 0;
-  min-width: 0;
-}
-</style>


### PR DESCRIPTION
## Summary

Ninth Tailwind migration. `GridView` (the grid shell + tab bar) → utilities, its whole `<style scoped>` deleted. Fully token-based, no hardcoded colors, no combinators.

## Items to Confirm / Review

- **The active tab is the `aria-pressed:` variant**, driven by the `:aria-pressed` the tab already sets — `aria-pressed:bg-hover aria-pressed:text-fg aria-pressed:border-accent`. The `{ active: … }` class binding is gone. Same pattern as the menu triggers' `aria-expanded:`. Verified: `[aria-pressed=true]{border-color:var(--accent)}`.
- **No test coupling** — `GridView.spec` selects a toolbar stub's `.open-settings`, not GridView's own classes (repo-wide grep per #504).
- `h-screen`=100vh, `w-screen`=100vw, `border-b`, `min-w-[28px]`, `py-[3px]` verified against the originals. `text-xs` for the tab (12px, matches; the tab had no explicit line-height so the bundled one is fine here).

## Verification

- `vue-tsc -b --force` → 0 · `eslint`/`prettier` clean
- `vitest` GridView spec → 1 passed; full suite → **1483 passed**

Follows `docs/styling.md`. (Skipping the harder targets — toolbarPopover's hardcoded/ordering, CommandCell's non-token summary panel, etc. — per direction.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)