### PR TITLE
refactor: convert GitBranchChip to Tailwind with arbitrary-value colors

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -40,10 +40,16 @@ Spacing/radius use Tailwind's scale on a 4px base: `px-2` = 8px, `px-2.5` = 10px
 
 1. **Default to Tailwind utilities.** New or changed markup gets utility classes,
    not a fresh `<style scoped>` block.
-2. **Never hardcode a color.** Use a token utility (`bg-elevated`, `text-muted`),
-   never `bg-[#20203a]` or a raw hex — the token is what theme-switches. Reach for an
-   arbitrary value only for a one-off *dimension* Tailwind's scale lacks (e.g.
-   `py-[5px]`, `text-[18px]`), never for color.
+2. **Prefer a token over a raw hex.** Where a token exists, `bg-elevated` beats
+   `bg-[#20203a]` — the token is what theme-switches, so the arbitrary hex would be a
+   regression. **But** when a color is *already* hardcoded in the scoped CSS and has no
+   token — a deliberate fixed color like a status green or a terminal palette —
+   `bg-[#hex]` / `text-[#hex]` is a faithful move: it deletes the scoped rule without
+   changing behavior (the color didn't theme-switch before and still won't). If such a
+   color *should* theme-switch, promote it to a token in `style.css` instead — but
+   that's a visual change on the other themes, a separate decision from the refactor.
+   Arbitrary values for *dimensions* Tailwind's scale lacks (`py-[5px]`, `max-w-[16ch]`,
+   `bg-[color-mix(...)]`) are always fine.
 3. **Shared custom CSS goes global, once.** If a pattern genuinely can't be utilities
    and repeats across components, add it to `style.css` (a token or a shared class) —
    as one shared design primitive, not a copy per component.

--- a/src/components/GitBranchChip.vue
+++ b/src/components/GitBranchChip.vue
@@ -20,42 +20,16 @@ const title = computed(() => {
 </script>
 
 <template>
-  <span v-if="status?.repo && (status.branch || status.detached)" class="git-chip" :class="{ detached: status.detached }" :title="title">
-    <span class="git-branch">⎇ {{ label }}</span>
-    <span v-if="!hideDirty && status.dirty > 0" class="git-dirty">●{{ status.dirty }}</span>
-    <span v-if="status.upstream && status.ahead > 0" class="git-ab">↑{{ status.ahead }}</span>
-    <span v-if="status.upstream && status.behind > 0" class="git-ab">↓{{ status.behind }}</span>
+  <span
+    v-if="status?.repo && (status.branch || status.detached)"
+    data-testid="git-chip"
+    class="inline-flex items-center gap-[0.25em] px-[0.4em] h-[1.5em] rounded-[0.75em] text-[0.72rem] leading-[1.5em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] opacity-85 whitespace-nowrap max-w-[16ch] overflow-hidden"
+    :class="status.detached ? 'text-[#d19a66]' : 'text-inherit'"
+    :title="title"
+  >
+    <span data-testid="git-branch" class="overflow-hidden text-ellipsis">⎇ {{ label }}</span>
+    <span v-if="!hideDirty && status.dirty > 0" data-testid="git-dirty" class="text-[#e5c07b]">●{{ status.dirty }}</span>
+    <span v-if="status.upstream && status.ahead > 0" data-testid="git-ab" class="opacity-80">↑{{ status.ahead }}</span>
+    <span v-if="status.upstream && status.behind > 0" data-testid="git-ab" class="opacity-80">↓{{ status.behind }}</span>
   </span>
 </template>
-
-<style scoped>
-.git-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25em;
-  padding: 0 0.4em;
-  height: 1.5em;
-  border-radius: 0.75em;
-  font-size: 0.72rem;
-  line-height: 1.5em;
-  background: color-mix(in srgb, currentColor 12%, transparent);
-  color: inherit;
-  opacity: 0.85;
-  white-space: nowrap;
-  max-width: 16ch;
-  overflow: hidden;
-}
-.git-branch {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.git-chip.detached {
-  color: #d19a66;
-}
-.git-dirty {
-  color: #e5c07b;
-}
-.git-ab {
-  opacity: 0.8;
-}
-</style>

--- a/test/src/components/GitBranchChip.spec.ts
+++ b/test/src/components/GitBranchChip.spec.ts
@@ -9,45 +9,45 @@ const render = (status: GitStatus | null, hideDirty = false) => mount(GitBranchC
 
 describe("GitBranchChip", () => {
   it("renders nothing when status is null", () => {
-    expect(render(null).find(".git-chip").exists()).toBe(false);
+    expect(render(null).find('[data-testid="git-chip"]').exists()).toBe(false);
   });
 
   it("renders nothing for a non-git dir (repo:false)", () => {
     expect(
       render({ ...base, repo: false, branch: null })
-        .find(".git-chip")
+        .find('[data-testid="git-chip"]')
         .exists(),
     ).toBe(false);
   });
 
   it("shows the branch name on a clean repo", () => {
     const w = render(base);
-    expect(w.find(".git-chip").exists()).toBe(true);
-    expect(w.find(".git-branch").text()).toContain("main");
-    expect(w.find(".git-dirty").exists()).toBe(false);
+    expect(w.find('[data-testid="git-chip"]').exists()).toBe(true);
+    expect(w.find('[data-testid="git-branch"]').text()).toContain("main");
+    expect(w.find('[data-testid="git-dirty"]').exists()).toBe(false);
   });
 
   it("shows the dirty count when there are uncommitted changes", () => {
     const w = render({ ...base, dirty: 3 });
-    expect(w.find(".git-dirty").text()).toBe("●3");
+    expect(w.find('[data-testid="git-dirty"]').text()).toBe("●3");
   });
 
   it("hides the dirty count when hideDirty is set (worktree cell)", () => {
     const w = render({ ...base, dirty: 3 }, true);
-    expect(w.find(".git-dirty").exists()).toBe(false);
-    expect(w.find(".git-branch").text()).toContain("main");
+    expect(w.find('[data-testid="git-dirty"]').exists()).toBe(false);
+    expect(w.find('[data-testid="git-branch"]').text()).toContain("main");
   });
 
   it("shows ahead/behind only when an upstream exists", () => {
     const noUpstream = render({ ...base, ahead: 2, behind: 1, upstream: false });
-    expect(noUpstream.findAll(".git-ab")).toHaveLength(0);
+    expect(noUpstream.findAll('[data-testid="git-ab"]')).toHaveLength(0);
     const withUpstream = render({ ...base, ahead: 2, behind: 1, upstream: true });
-    const abs = withUpstream.findAll(".git-ab").map((n) => n.text());
+    const abs = withUpstream.findAll('[data-testid="git-ab"]').map((n) => n.text());
     expect(abs).toEqual(["↑2", "↓1"]);
   });
 
   it("labels a detached HEAD", () => {
     const w = render({ ...base, branch: null, detached: true });
-    expect(w.find(".git-branch").text()).toContain("detached");
+    expect(w.find('[data-testid="git-branch"]').text()).toContain("detached");
   });
 });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1429,7 +1429,7 @@ describe("TerminalCell", () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", zoomed: true, expanded: false });
     await flushPromises();
     // Info stripped: no git chip / usage; the second (terminal) header row is hidden.
-    expect(w.find(".git-chip").exists()).toBe(false);
+    expect(w.find('[data-testid="git-chip"]').exists()).toBe(false);
     expect(w.find(".cell-usage").exists()).toBe(false);
     expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
     // Row 1 keeps dir + prompt + the expand/close actions (row 2 is hidden).


### PR DESCRIPTION
## Summary

Answers "can't the hex colors be arbitrary values?" — **yes**, and it unblocks the components I'd skipped for hardcoded colors. `GitBranchChip` is the demo: fully converted, `<style scoped>` deleted.

The chip's fixed status colors (`detached` #d19a66, `dirty` #e5c07b) have **no token and never theme-switched**, so `text-[#d19a66]` / `text-[#e5c07b]` is a *faithful* move — it deletes the scoped rule without changing behavior. Same for the `currentColor` translucent background (`bg-[color-mix(in_srgb,currentColor_12%,transparent)]`) and the em-based sizing (`h-[1.5em]`, `rounded-[0.75em]`, `text-[0.72rem]`, `max-w-[16ch]`).

## Items to Confirm / Review

- **`docs/styling.md`'s color rule is refined** (also in this PR): prefer a token where one exists (arbitrary hex over a token would be a theme-switch regression), **but** an arbitrary hex is fine for an *already-hardcoded, token-less* color — promote it to a token only if it *should* theme-switch, which is a separate visual change. Please confirm you're happy with that nuance before I apply it to the other skipped components (CommandCell summary panel, TimelineOverlay, toolbarPopover's connected green).
- **Cross-component test coupling, caught by the #504 grep rule:** `.git-chip` was asserted on in **both** `GitBranchChip.spec` *and* `TerminalCell.spec` (TerminalCell renders the chip). All four sub-elements now carry `data-testid` (`git-chip`/`git-branch`/`git-dirty`/`git-ab`) and both specs select by it.
- The `detached` color is a conditional `:class` (`text-[#d19a66]` vs `text-inherit`) rather than two competing color utilities.
- Every arbitrary value verified in the built CSS: `color:#d19a66`, `color:#e5c07b`, `color-mix(in srgb,currentColor 12%,transparent)`, `opacity:.85`, `max-width:16ch`, `border-radius:.75em`.

## Verification

- `vue-tsc -b --force` → 0 · `eslint`/`prettier` clean
- `vitest` GitBranchChip + TerminalCell specs → 99 passed; full suite → **1483 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)