### PR TITLE
refactor: convert SessionFilters sort button to Tailwind

### DIFF
--- a/src/components/SessionFilters.vue
+++ b/src/components/SessionFilters.vue
@@ -20,8 +20,8 @@ const emit = defineEmits<{
   <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
   <FilterChip label="Unread" :count="unreadCount" :active="filter === 'unread'" @click="emit('update:filter', 'unread')" />
   <button
-    class="sort-btn bg-transparent border-0 text-muted text-base leading-none cursor-pointer hover:text-fg"
-    :class="{ 'push-end': alignRefreshEnd }"
+    class="cursor-pointer border-0 bg-transparent text-[14px] leading-none text-muted hover:text-fg"
+    :class="{ 'ml-auto': alignRefreshEnd }"
     title="Sort by most recent"
     aria-label="Sort by most recent"
     @click="emit('refresh')"
@@ -29,12 +29,3 @@ const emit = defineEmits<{
     <span class="material-symbols-outlined">refresh</span>
   </button>
 </template>
-
-<style scoped>
-.sort-btn {
-  font-size: 14px;
-}
-.sort-btn.push-end {
-  margin-left: auto;
-}
-</style>

--- a/test/src/components/Sidebar.spec.ts
+++ b/test/src/components/Sidebar.spec.ts
@@ -85,7 +85,7 @@ describe("Sidebar", () => {
 
   it("emits refresh when the sort button is clicked", async () => {
     const wrapper = mountSidebar({ sessions: [row({ id: "a" })] });
-    await wrapper.find(".sort-btn").trigger("click");
+    await wrapper.find('[aria-label="Sort by most recent"]').trigger("click");
     expect(wrapper.emitted("refresh")).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary

Removes the last `<style scoped>` block from `SessionFilters.vue` — the sort button is now fully utility-driven.

- `.sort-btn { font-size: 14px }` → `text-[14px]`. Note this *fixes a latent dead style*: the button's inline class had `text-base` (16px) but the unlayered scoped `font-size: 14px` won, so it rendered at 14px. The conversion keeps 14px and drops the stale `text-base`.
- `.sort-btn.push-end { margin-left: auto }` → `:class="{ 'ml-auto': alignRefreshEnd }"`, driven directly by the existing prop.
- `Sidebar.spec.ts` selected the button by `.sort-btn`; re-pointed to `[aria-label="Sort by most recent"]` (styling classes aren't stable selectors).

## Items to Confirm / Review

- The `text-base`→`text-[14px]` change: confirm 14px is the intended size (it's what rendered before, since scoped CSS won over the utility).

## User Prompt

Part of the standing Tailwind migration (prefer utilities, reduce scoped CSS, keep the style traveling with the markup), prioritizing doable components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)