### PR TITLE
fix: make SettingsModal Google warnings actually red

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -331,7 +331,7 @@ onUnmounted(() => {
         and finishes on <strong>this machine</strong>, so use a browser here — over a remote connection, run
         <code>npx mulmoterminal google login</code> instead. The link is shared with MulmoClaude.
       </p>
-      <p v-if="googleSecretHint" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-[var(--danger)]">{{ googleSecretHint }}</p>
+      <p v-if="googleSecretHint" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-err-text">{{ googleSecretHint }}</p>
       <div class="mb-3 flex items-center gap-2.5">
         <span class="text-[12px]" :class="googleStatus?.linked ? 'text-ok' : 'text-muted'">{{ googleStatusText }}</span>
         <SettingsButton
@@ -343,7 +343,7 @@ onUnmounted(() => {
         </SettingsButton>
         <SettingsButton v-else :disabled="googleBusy" @click="onUnlinkGoogle">Unlink</SettingsButton>
       </div>
-      <p v-if="googleError" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-[var(--danger)]" role="alert">{{ googleError }}</p>
+      <p v-if="googleError" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-err-text" role="alert">{{ googleError }}</p>
 
       <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Pull request repos</h3>
       <p class="mb-3 mt-1.5 text-[12px] text-dim">


### PR DESCRIPTION
## Summary

The Google-account warnings (missing client secret / sign-in error) were styled with `color: var(--danger)`, but **`--danger` is undefined app-wide** — so the winning declaration was invalid and the text inherited the base color instead of a red. This fixes them to use the app's existing theme-aware error token.

- `text-[var(--danger)]` → `text-err-text` on both `.google-warn` paragraphs.
- `--err-text` is theme-aware: `#ff7b7b` on dark themes, `#c0392b` on light — so the warning reads as red across all four themes.

Follow-up to #522, which flagged this pre-existing issue during the Tailwind conversion.

## Items to Confirm / Review

- Chose `--err-text` (the app's error-text token, already used for the modal's ✕-button hover) over inventing a `--danger` token. If you'd prefer a stronger red (`--err-strong` = `#ef4444`), say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)