### PR TITLE
refactor: convert PrsOverlay to Tailwind

### DIFF
--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -91,235 +91,122 @@ function relativeTime(iso: string): string {
 const CI_TITLE: Record<CiState, string> = { passing: "Checks passing", failing: "Checks failing", pending: "Checks running", none: "No checks" };
 const REVIEW_LABEL: Record<string, string> = { APPROVED: "approved", CHANGES_REQUESTED: "changes requested", REVIEW_REQUIRED: "review required" };
 
+// CI dot colour: passing green (hardcoded, token-less), failing/pending on the
+// theme err/amber tokens, no-checks the dim default.
+function ciDotClass(ci: CiState): string {
+  if (ci === "passing") return "bg-[#3fae6b]";
+  if (ci === "failing") return "bg-err-text";
+  if (ci === "pending") return "bg-amber";
+  return "bg-dim";
+}
+// Review-tag colour: approved green, changes-requested red; anything else keeps
+// the neutral tag colours. Returns text + border together so there's no cascade race.
+function reviewTagClass(review: string): string {
+  if (review === "APPROVED") return "border-[#3fae6b] text-[#3fae6b]";
+  if (review === "CHANGES_REQUESTED") return "border-err-text text-err-text";
+  return "border-border text-muted";
+}
+
 useEscapeToClose(isOpen, close);
 </script>
 
 <template>
   <div v-if="isOpen" class="fixed inset-x-0 top-10 bottom-0 z-50 bg-deep flex flex-col" role="region" aria-label="Pull requests and issues">
-    <header class="prs-head">
-      <span class="prs-title">PRs &amp; Issues</span>
-      <button type="button" class="prs-reload" :disabled="loading" title="Reload" aria-label="Reload PR and issue list" @click="load">↻</button>
-      <span v-if="loading" class="prs-status">Loading…</span>
+    <header class="flex flex-none items-center gap-2.5 border-b border-border bg-panel px-4 py-2">
+      <span class="text-[14px] font-[650] text-fg">PRs &amp; Issues</span>
+      <button
+        type="button"
+        class="h-6 w-[26px] cursor-pointer rounded-md border border-border bg-base text-[14px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
+        :disabled="loading"
+        title="Reload"
+        aria-label="Reload PR and issue list"
+        @click="load"
+      >
+        ↻
+      </button>
+      <span v-if="loading" class="text-[12px] text-muted">Loading…</span>
     </header>
-    <div class="prs-content">
-      <p v-if="!loading && !prsError && !issuesError && repos.length === 0 && issueRepos.length === 0" class="prs-msg">
+    <div class="flex-auto overflow-y-auto px-4 pb-16 pt-3">
+      <p v-if="!loading && !prsError && !issuesError && repos.length === 0 && issueRepos.length === 0" class="px-1 py-6 text-[13px] text-muted">
         No repositories configured. Add <code>owner/repo</code> entries under Settings (⚙) → Pull request repos.
       </p>
       <template v-else>
-        <h2 class="prs-section">Pull requests</h2>
-        <p v-if="prsError" class="prs-msg prs-error">{{ prsError }}</p>
-        <section v-for="r in repos" :key="`pr-${r.repo}`" class="prs-repo">
-          <h3 class="prs-repo-name">
+        <h2
+          class="mb-3 mt-1 text-[11px] font-bold uppercase tracking-[0.06em] text-muted [&:not(:first-child)]:mt-7 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border [&:not(:first-child)]:pt-4"
+        >
+          Pull requests
+        </h2>
+        <p v-if="prsError" class="px-1 py-6 text-[13px] text-err">{{ prsError }}</p>
+        <section v-for="r in repos" :key="`pr-${r.repo}`" class="mb-5">
+          <h3 class="my-1.5 flex items-center gap-2 border-b border-border pb-1 font-mono text-[13px] font-semibold text-fg">
             {{ r.repo }}
-            <span v-if="r.prs" class="prs-count">{{ r.prs.length }}</span>
+            <span v-if="r.prs" class="text-[11px] font-normal text-muted">{{ r.prs.length }}</span>
           </h3>
-          <p v-if="r.error" class="prs-msg prs-error">{{ r.error }}</p>
-          <p v-else-if="r.prs && r.prs.length === 0" class="prs-msg prs-empty">No open PRs</p>
-          <ul v-else-if="r.prs" class="prs-list">
+          <p v-if="r.error" class="px-1 py-6 text-[13px] text-err">{{ r.error }}</p>
+          <p v-else-if="r.prs && r.prs.length === 0" class="px-1 py-2 text-[13px] text-muted">No open PRs</p>
+          <ul v-else-if="r.prs" class="m-0 list-none p-0">
             <li v-for="pr in r.prs" :key="pr.number">
-              <a class="prs-row" :href="pr.url" target="_blank" rel="noopener noreferrer">
-                <span class="prs-ci" :class="`ci-${pr.ci}`" role="img" :aria-label="CI_TITLE[pr.ci]" :title="CI_TITLE[pr.ci]" />
-                <span class="prs-num">#{{ pr.number }}</span>
-                <span class="prs-name">{{ pr.title }}</span>
-                <span v-if="pr.isDraft" class="prs-tag prs-draft">draft</span>
-                <span v-if="pr.review" class="prs-tag" :class="`rev-${pr.review}`">{{ REVIEW_LABEL[pr.review] ?? pr.review.toLowerCase() }}</span>
-                <span class="prs-meta">{{ pr.author }} · {{ relativeTime(pr.updatedAt) }}</span>
+              <a
+                data-testid="prs-row"
+                class="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-[7px] text-left text-[13px] text-secondary no-underline hover:bg-hover hover:text-fg"
+                :href="pr.url"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span
+                  class="h-[9px] w-[9px] flex-none rounded-full"
+                  :class="ciDotClass(pr.ci)"
+                  role="img"
+                  :aria-label="CI_TITLE[pr.ci]"
+                  :title="CI_TITLE[pr.ci]"
+                />
+                <span class="flex-none font-[ui-monospace,monospace] text-dim">#{{ pr.number }}</span>
+                <span class="min-w-0 flex-auto truncate">{{ pr.title }}</span>
+                <span v-if="pr.isDraft" class="flex-none rounded-[10px] border border-border px-1.5 py-px text-[11px] text-dim">draft</span>
+                <span v-if="pr.review" class="flex-none rounded-[10px] border px-1.5 py-px text-[11px]" :class="reviewTagClass(pr.review)">{{
+                  REVIEW_LABEL[pr.review] ?? pr.review.toLowerCase()
+                }}</span>
+                <span class="flex-none text-[11px] text-dim">{{ pr.author }} · {{ relativeTime(pr.updatedAt) }}</span>
               </a>
             </li>
           </ul>
-          <p v-if="r.truncated" class="prs-msg prs-empty">Showing the first {{ r.prs?.length ?? 0 }} — this repo has more open PRs.</p>
+          <p v-if="r.truncated" class="px-1 py-2 text-[13px] text-muted">Showing the first {{ r.prs?.length ?? 0 }} — this repo has more open PRs.</p>
         </section>
 
-        <h2 class="prs-section">Issues</h2>
-        <p v-if="issuesError" class="prs-msg prs-error">{{ issuesError }}</p>
-        <section v-for="r in issueRepos" :key="`iss-${r.repo}`" class="prs-repo">
-          <h3 class="prs-repo-name">
+        <h2
+          class="mb-3 mt-1 text-[11px] font-bold uppercase tracking-[0.06em] text-muted [&:not(:first-child)]:mt-7 [&:not(:first-child)]:border-t [&:not(:first-child)]:border-border [&:not(:first-child)]:pt-4"
+        >
+          Issues
+        </h2>
+        <p v-if="issuesError" class="px-1 py-6 text-[13px] text-err">{{ issuesError }}</p>
+        <section v-for="r in issueRepos" :key="`iss-${r.repo}`" class="mb-5">
+          <h3 class="my-1.5 flex items-center gap-2 border-b border-border pb-1 font-mono text-[13px] font-semibold text-fg">
             {{ r.repo }}
-            <span v-if="r.issues" class="prs-count">{{ r.issues.length }}</span>
+            <span v-if="r.issues" class="text-[11px] font-normal text-muted">{{ r.issues.length }}</span>
           </h3>
-          <p v-if="r.error" class="prs-msg prs-error">{{ r.error }}</p>
-          <p v-else-if="r.issues && r.issues.length === 0" class="prs-msg prs-empty">No open issues</p>
-          <ul v-else-if="r.issues" class="prs-list">
+          <p v-if="r.error" class="px-1 py-6 text-[13px] text-err">{{ r.error }}</p>
+          <p v-else-if="r.issues && r.issues.length === 0" class="px-1 py-2 text-[13px] text-muted">No open issues</p>
+          <ul v-else-if="r.issues" class="m-0 list-none p-0">
             <li v-for="iss in r.issues" :key="iss.number">
-              <a class="prs-row" :href="iss.url" target="_blank" rel="noopener noreferrer">
-                <span class="prs-num">#{{ iss.number }}</span>
-                <span class="prs-name">{{ iss.title }}</span>
-                <span class="prs-meta">{{ iss.author }} · {{ relativeTime(iss.updatedAt) }}</span>
+              <a
+                data-testid="prs-row"
+                class="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2 py-[7px] text-left text-[13px] text-secondary no-underline hover:bg-hover hover:text-fg"
+                :href="iss.url"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span class="flex-none font-[ui-monospace,monospace] text-dim">#{{ iss.number }}</span>
+                <span class="min-w-0 flex-auto truncate">{{ iss.title }}</span>
+                <span class="flex-none text-[11px] text-dim">{{ iss.author }} · {{ relativeTime(iss.updatedAt) }}</span>
               </a>
             </li>
           </ul>
-          <p v-if="r.truncated" class="prs-msg prs-empty">
+          <p v-if="r.truncated" class="px-1 py-2 text-[13px] text-muted">
             Showing the latest {{ r.issues?.length ?? 0 }} —
-            <a :href="r.url" target="_blank" rel="noopener noreferrer" class="prs-link">see all open issues on GitHub</a>.
+            <a :href="r.url" target="_blank" rel="noopener noreferrer" data-testid="prs-link" class="text-accent underline">see all open issues on GitHub</a>.
           </p>
         </section>
       </template>
     </div>
   </div>
 </template>
-
-<style scoped>
-.prs-head {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-panel);
-}
-.prs-title {
-  font-weight: 650;
-  font-size: 14px;
-  color: var(--text);
-}
-.prs-reload {
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: 6px;
-  width: 26px;
-  height: 24px;
-  font-size: 14px;
-}
-.prs-reload:hover:not(:disabled) {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.prs-reload:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-.prs-status {
-  font-size: 12px;
-  color: var(--text-muted);
-}
-.prs-content {
-  flex: 1 1 auto;
-  overflow-y: auto;
-  padding: 12px 16px 64px;
-}
-.prs-msg {
-  padding: 24px 4px;
-  color: var(--text-muted);
-  font-size: 13px;
-}
-.prs-error {
-  color: var(--err);
-}
-.prs-empty {
-  padding: 8px 4px;
-}
-.prs-section {
-  margin: 4px 0 12px;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text-muted);
-}
-.prs-section:not(:first-child) {
-  margin-top: 28px;
-  padding-top: 16px;
-  border-top: 1px solid var(--border);
-}
-.prs-link {
-  color: var(--accent, #3b82f6);
-  text-decoration: underline;
-}
-.prs-repo {
-  margin-bottom: 20px;
-}
-.prs-repo-name {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-  margin: 6px 0;
-  padding-bottom: 4px;
-  border-bottom: 1px solid var(--border);
-}
-.prs-count {
-  font-size: 11px;
-  color: var(--text-muted);
-  font-weight: 400;
-}
-.prs-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.prs-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  text-align: left;
-  color: var(--text-secondary);
-  text-decoration: none;
-  cursor: pointer;
-  padding: 7px 8px;
-  border-radius: 6px;
-  font-size: 13px;
-}
-.prs-row:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.prs-ci {
-  flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--text-dim);
-}
-.ci-passing {
-  background: #3fae6b;
-}
-.ci-failing {
-  background: var(--err-text, #e0556b);
-}
-.ci-pending {
-  background: var(--amber, #e0a030);
-}
-.prs-num {
-  flex: 0 0 auto;
-  font-family: ui-monospace, monospace;
-  color: var(--text-dim);
-}
-.prs-name {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.prs-tag {
-  flex: 0 0 auto;
-  font-size: 11px;
-  padding: 1px 6px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  color: var(--text-muted);
-}
-.prs-draft {
-  color: var(--text-dim);
-}
-.rev-APPROVED {
-  color: #3fae6b;
-  border-color: #3fae6b;
-}
-.rev-CHANGES_REQUESTED {
-  color: var(--err-text, #e0556b);
-  border-color: var(--err-text, #e0556b);
-}
-.prs-meta {
-  flex: 0 0 auto;
-  font-size: 11px;
-  color: var(--text-dim);
-}
-</style>

--- a/test/src/components/PrsOverlay.spec.ts
+++ b/test/src/components/PrsOverlay.spec.ts
@@ -57,7 +57,7 @@ describe("PrsOverlay", () => {
     expect(w.text()).toContain("more open PRs"); // truncation note
     expect(w.text()).toContain("No open PRs"); // octo/empty
     // Rows are real links (right-click / new-tab / ⌘-click work), not JS buttons.
-    const row = w.get("a.prs-row");
+    const row = w.get('[data-testid="prs-row"]');
     expect(row.attributes("href")).toBe("u3");
     expect(row.attributes("target")).toBe("_blank");
     expect(row.attributes("rel")).toContain("noopener");
@@ -82,8 +82,8 @@ describe("PrsOverlay", () => {
     expect(w.text()).toContain("#42");
     expect(w.text()).toContain("flaky test");
     expect(w.text()).toContain("No open issues"); // octo/quiet
-    expect(w.get("a.prs-row").attributes("href")).toBe("https://github.com/octo/hello/issues/42"); // issue row is a real link
-    const seeAll = w.get("a.prs-link");
+    expect(w.get('[data-testid="prs-row"]').attributes("href")).toBe("https://github.com/octo/hello/issues/42"); // issue row is a real link
+    const seeAll = w.get('[data-testid="prs-link"]');
     expect(seeAll.attributes("href")).toBe("https://github.com/octo/hello/issues");
     expect(seeAll.text()).toContain("see all open issues");
   });


### PR DESCRIPTION
## Summary

Full conversion of `PrsOverlay.vue` (the cross-repo PR + issue dashboard) to Tailwind. `<style scoped>` is deleted.

- Header / reload button / sections / repo groups / rows / count / tags → utilities.
- **CI dot & review-tag colours** move from `.ci-*` / `.rev-*` classes + scoped CSS to `ciDotClass()` / `reviewTagClass()` helpers returning utilities: passing-green and approved-green as arbitrary hex (`bg-[#3fae6b]`, `text-[#3fae6b]`); failing/changes on the theme `err-text` token, pending on `amber`. `reviewTagClass` returns text+border together so the two never race in the cascade.
- `.prs-section:not(:first-child)` (the Issues header's top rule/border) → `[&:not(:first-child)]:mt-7 …:border-t …:pt-4`.
- `.prs-num`'s exact `ui-monospace, monospace` stack preserved via `font-[ui-monospace,monospace]` (not `font-mono`, which prepends JetBrains Mono); repo names DO use the full stack so they're `font-mono`.
- Verified byte-identical in the built CSS (`font-[650]`, `h-6`/`w-[26px]`, `rounded-[10px]`, `no-underline`, the sibling-header rule).

## Items to Confirm / Review

- **Test selectors**: the spec used `a.prs-row` / `a.prs-link`; re-pointed to `data-testid="prs-row"` / `"prs-link"`. All other assertions are `w.text()`, untouched.

## User Prompt

You asked which remaining components are realistically doable; PrsOverlay ranked most doable (low class-coupling, no `:deep`/keyframes), so I did it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)