### PR TITLE
refactor: convert CommandCell summary panel to Tailwind

### DIFF
--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -183,19 +183,35 @@ function onHeaderClick(event: MouseEvent) {
       :zoomed="zoomed"
       @exit="onExit"
     />
-    <div v-if="showSummary" class="cell-summary">
-      <div class="cell-summary-head">
-        <span class="cell-summary-title">✦ Summary</span>
+    <div v-if="showSummary" data-testid="cell-summary" class="flex max-h-[40%] min-h-0 flex-none flex-col border-t border-t-[#2a2a4e] bg-[#141b33]">
+      <div class="flex flex-none items-center justify-between border-b border-b-[#232a48] py-0.5 pl-2.5 pr-1.5">
+        <span class="font-sans text-[11px] font-semibold text-[#9db4ff]">✦ Summary</span>
         <button class="cell-btn cell-summary-close" title="Dismiss summary" aria-label="Dismiss summary" @click="closeSummary">✕</button>
       </div>
-      <div class="cell-summary-body">
-        <span v-if="summaryState === 'loading'" class="cell-summary-loading">Summarizing…</span>
-        <p v-else-if="summaryState === 'error'" class="cell-summary-error">{{ summaryError }}</p>
+      <div class="min-h-0 flex-auto overflow-auto px-2.5 pb-2 pt-1.5">
+        <span v-if="summaryState === 'loading'" class="font-sans text-[12px] text-[#7f88ad]">Summarizing…</span>
+        <p
+          v-else-if="summaryState === 'error'"
+          data-testid="cell-summary-error"
+          class="m-0 font-mono text-[12px] text-[#ff8a8a] whitespace-pre-wrap [word-break:break-word]"
+        >
+          {{ summaryError }}
+        </p>
         <template v-else>
-          <pre class="cell-summary-text">{{ summaryText }}</pre>
-          <p v-if="summaryTruncated" class="cell-summary-note">(long output — summarized the tail only)</p>
-          <div class="cell-summary-actions">
-            <button type="button" class="cell-summary-continue" title="Copy this as a prompt to paste into a Claude session" @click="copyPrompt">
+          <pre data-testid="cell-summary-text" class="m-0 font-mono text-[12px] leading-[1.5] text-[#d6dcf5] whitespace-pre-wrap [word-break:break-word]">{{
+            summaryText
+          }}</pre>
+          <p v-if="summaryTruncated" data-testid="cell-summary-note" class="mt-1.5 font-sans text-[11px] text-[#7f88ad]">
+            (long output — summarized the tail only)
+          </p>
+          <div class="mt-2 flex justify-end">
+            <button
+              type="button"
+              data-testid="cell-summary-continue"
+              class="cursor-pointer rounded-md border border-[#3b4a7a] bg-[#232a45] px-2.5 py-1 font-sans text-[12px] text-[#cdd6ff] hover:bg-[#2c355a]"
+              title="Copy this as a prompt to paste into a Claude session"
+              @click="copyPrompt"
+            >
               {{ copied ? "✓ Copied" : "⧉ Copy as prompt" }}
             </button>
           </div>
@@ -208,6 +224,10 @@ function onHeaderClick(event: MouseEvent) {
 <style scoped src="./cellChromeBase.css"></style>
 <style scoped src="./cellChrome.css"></style>
 
+<!-- These two buttons carry the shared .cell-btn class (cellChromeBase.css). That
+     rule is unlayered scoped CSS, which beats Tailwind's layered utilities, so their
+     per-instance overrides (colour, size) can't move to utilities until the shared
+     chrome itself is converted — kept scoped for now. -->
 <style scoped>
 .cell-summarize {
   color: #9db4ff;
@@ -220,87 +240,9 @@ function onHeaderClick(event: MouseEvent) {
   color: #7f88ad;
   cursor: default;
 }
-
-/* Result panel: a short, scrollable strip below the terminal (never steals more than
-   ~40% of the cell). */
-.cell-summary {
-  flex: 0 0 auto;
-  max-height: 40%;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  background: #141b33;
-  border-top: 1px solid #2a2a4e;
-}
-.cell-summary-head {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 2px 6px 2px 10px;
-  border-bottom: 1px solid #232a48;
-}
-.cell-summary-title {
-  font-family: system-ui, sans-serif;
-  font-size: 11px;
-  font-weight: 600;
-  color: #9db4ff;
-}
 .cell-summary-close {
   width: 22px;
   height: 22px;
   font-size: 13px;
-}
-.cell-summary-body {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow: auto;
-  padding: 6px 10px 8px;
-}
-.cell-summary-loading {
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  color: #7f88ad;
-}
-.cell-summary-error {
-  margin: 0;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 12px;
-  color: #ff8a8a;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.cell-summary-text {
-  margin: 0;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 12px;
-  line-height: 1.5;
-  color: #d6dcf5;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.cell-summary-note {
-  margin: 6px 0 0;
-  font-family: system-ui, sans-serif;
-  font-size: 11px;
-  color: #7f88ad;
-}
-.cell-summary-actions {
-  margin-top: 8px;
-  display: flex;
-  justify-content: flex-end;
-}
-.cell-summary-continue {
-  border: 1px solid #3b4a7a;
-  background: #232a45;
-  color: #cdd6ff;
-  border-radius: 6px;
-  padding: 4px 10px;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  cursor: pointer;
-}
-.cell-summary-continue:hover {
-  background: #2c355a;
 }
 </style>

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -198,9 +198,13 @@ function onHeaderClick(event: MouseEvent) {
           {{ summaryError }}
         </p>
         <template v-else>
-          <pre data-testid="cell-summary-text" class="m-0 font-mono text-[12px] leading-[1.5] text-[#d6dcf5] whitespace-pre-wrap [word-break:break-word]">{{
-            summaryText
-          }}</pre>
+          <!-- v-text (not {{ }}): keeps the summary's exact bytes and is immune to a
+               formatter wrapping the interpolation onto its own indented line inside <pre>. -->
+          <pre
+            data-testid="cell-summary-text"
+            class="m-0 font-mono text-[12px] leading-[1.5] text-[#d6dcf5] whitespace-pre-wrap [word-break:break-word]"
+            v-text="summaryText"
+          ></pre>
           <p v-if="summaryTruncated" data-testid="cell-summary-note" class="mt-1.5 font-sans text-[11px] text-[#7f88ad]">
             (long output — summarized the tail only)
           </p>

--- a/test/src/components/CommandCell.spec.ts
+++ b/test/src/components/CommandCell.spec.ts
@@ -90,7 +90,7 @@ describe("CommandCell summarize", () => {
   it("has no summary panel until the button is clicked", () => {
     const w = mountCell();
     expect(w.find('[aria-label="Summarize command output"]').exists()).toBe(true);
-    expect(w.find(".cell-summary").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-summary"]').exists()).toBe(false);
   });
 
   it("posts the captured output and renders the returned summary", async () => {
@@ -109,7 +109,7 @@ describe("CommandCell summarize", () => {
     const sent = JSON.parse(String(init?.body));
     expect(sent.log).toContain("npm ERR!");
     expect(typeof sent.locale).toBe("string"); // browser locale forwarded for the reply language
-    expect(w.find(".cell-summary-text").text()).toContain("missing module foo");
+    expect(w.find('[data-testid="cell-summary-text"]').text()).toContain("missing module foo");
   });
 
   it("copies the command + summary as a prompt to the clipboard", async () => {
@@ -123,14 +123,14 @@ describe("CommandCell summarize", () => {
     await w.find('[aria-label="Summarize command output"]').trigger("click");
     await flushPromises();
 
-    await w.find(".cell-summary-continue").trigger("click");
+    await w.find('[data-testid="cell-summary-continue"]').trigger("click");
     expect(writeText).toHaveBeenCalledOnce();
     const copied = String(writeText.mock.calls[0][0]);
     expect(copied).toContain("Dev server"); // the command label
     expect(copied).toContain("/work/proj"); // the command's dir
     expect(copied).toContain("missing module foo"); // the summary
     await flushPromises();
-    expect(w.find(".cell-summary-continue").text()).toContain("Copied");
+    expect(w.find('[data-testid="cell-summary-continue"]').text()).toContain("Copied");
   });
 
   it("does not throw when the clipboard API is unavailable (insecure origin / webview)", async () => {
@@ -142,8 +142,8 @@ describe("CommandCell summarize", () => {
     const w = mountCell();
     await w.find('[aria-label="Summarize command output"]').trigger("click");
     await flushPromises();
-    await w.find(".cell-summary-continue").trigger("click"); // must not throw
-    expect(w.find(".cell-summary-continue").text()).toContain("Copy"); // stays "Copy as prompt"
+    await w.find('[data-testid="cell-summary-continue"]').trigger("click"); // must not throw
+    expect(w.find('[data-testid="cell-summary-continue"]').text()).toContain("Copy"); // stays "Copy as prompt"
   });
 
   it("shows the truncation note when the server truncated the log", async () => {
@@ -154,7 +154,7 @@ describe("CommandCell summarize", () => {
     const w = mountCell();
     await w.find('[aria-label="Summarize command output"]').trigger("click");
     await flushPromises();
-    expect(w.find(".cell-summary-note").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-summary-note"]').exists()).toBe(true);
   });
 
   it("surfaces the server error message on failure", async () => {
@@ -165,8 +165,8 @@ describe("CommandCell summarize", () => {
     const w = mountCell();
     await w.find('[aria-label="Summarize command output"]').trigger("click");
     await flushPromises();
-    expect(w.find(".cell-summary-error").text()).toContain("not logged in");
-    expect(w.find(".cell-summary-text").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-summary-error"]').text()).toContain("not logged in");
+    expect(w.find('[data-testid="cell-summary-text"]').exists()).toBe(false);
   });
 
   it("dismisses the summary panel", async () => {
@@ -177,8 +177,8 @@ describe("CommandCell summarize", () => {
     const w = mountCell();
     await w.find('[aria-label="Summarize command output"]').trigger("click");
     await flushPromises();
-    expect(w.find(".cell-summary").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-summary"]').exists()).toBe(true);
     await w.find('[aria-label="Dismiss summary"]').trigger("click");
-    expect(w.find(".cell-summary").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-summary"]').exists()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Converts `CommandCell.vue`'s inline `<style scoped>` (the AI-summary strip) to utilities. The two shared `<style scoped src="./cellChrome*.css">` imports are untouched.

- Summary panel / head / title / body / loading / error / text / note / actions / continue button → utilities. Its hardcoded, **token-less** blue palette (`#141b33`, `#9db4ff`, `#d6dcf5`, …) uses arbitrary hex — faithful, and now travels with the markup.
- **Kept scoped — `.cell-summarize` and `.cell-summary-close`**: both carry the shared `.cell-btn` class from `cellChromeBase.css`. That's **unlayered scoped CSS, which beats Tailwind's layered utilities**, so their per-instance colour/size overrides can't move to utilities until the shared chrome itself is converted. Flagging this because it's the core reason the `TerminalCell` / `TerminalGrid` / `Terminal` family is genuinely hard: they're built on that shared `.cell-*` chrome, and a clean conversion needs the shared stylesheet done first (a coordinated change), not per-component work.

## Items to Confirm / Review

- **Partial by design** — the two `.cell-btn` buttons stay scoped (documented in the file).
- **Test selectors**: `.cell-summary` / `-text` / `-continue` / `-note` / `-error` → `data-testid`. The `.cell-cmd` / `.cell-dir` / `.cell-header` (`is-zoomable`) assertions hit **shared-chrome** classes that this PR doesn't touch, so they're unchanged.

## User Prompt

Continuing the "realistically doable" list — CommandCell's summary panel was self-contained and convertible; the surfaced shared-chrome constraint explains the remaining Terminal* tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)