### PR TITLE
fix: put global CSS in @layer base so Tailwind utilities apply

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -75,6 +75,16 @@ Spacing/radius use Tailwind's scale on a 4px base: `px-2` = 8px, `px-2.5` = 10px
 - **Unlayered scoped CSS beats layered utilities.** An existing `<style scoped>` rule
   wins over a Tailwind utility at equal specificity, so when migrating an element you
   must *remove* its scoped declarations, not just add the utility.
+- **Global CSS must live in `@layer base`, or it silently kills utilities.** Unlayered
+  author CSS beats *every* layered utility regardless of specificity — a bare
+  `* { margin: 0; padding: 0 }` disables **every** `p-*` / `m-*` class app-wide, and an
+  unlayered `.material-symbols-outlined { font-size: … }` disables every icon `text-*`.
+  `style.css` therefore wraps its resets in `@layer base` and pulls the Material Symbols
+  package in with `@import … layer(base)`. Third-party CSS imported from JS is unlayered:
+  import it from CSS with `layer(base)` instead.
+- **Verify that a utility *wins*, not just that it exists.** Grepping the built CSS for
+  `.px-2\.5{…}` only proves it was generated. Confirm the rendered `getComputedStyle`
+  matches the original declaration — that is what catches a cascade-layer loss.
 
 ## Migrating an existing component
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { createApp } from "vue";
-import "material-symbols/outlined.css";
 import "./style.css";
 import "./tailwind.css";
 // Configure the @mulmoclaude/collection-plugin UI binding (data fetch, asset URLs,

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,12 @@
+/* Layer order, declared here too (this file loads first) so it never depends on
+   import order: utilities must come last to win over the base defaults below. */
+@layer theme, base, components, utilities;
+
+/* Material Symbols ships an unlayered `.material-symbols-outlined { font-size: 24px }`.
+   Pulling it into `base` lets our own icon rule below (same layer, declared later)
+   keep winning as it always did, while `text-*` utilities can now size an icon. */
+@import "material-symbols/outlined.css" layer(base);
+
 /* Theme tokens. The default (:root) palette is "Midnight"; [data-theme] blocks
    below override it. Components reference these via var(--token), so switching
    the data-theme attribute on <html> recolors the whole app. The four themes
@@ -139,28 +148,36 @@
   --err-hover-bg: #f6d4d7;
 }
 
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
+/* These global defaults live in @layer base so Tailwind utilities (@layer
+   utilities, declared last in tailwind.css) can override them. Unlayered they
+   would WIN over every utility: the universal reset silently killed every
+   padding and margin utility, and the icon rule killed every icon font-size
+   utility. Component `<style scoped>` is unlayered and still beats these,
+   exactly as before. */
+@layer base {
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
 
-body {
-  background: var(--bg-base);
-  overflow: hidden;
-}
+  body {
+    background: var(--bg-base);
+    overflow: hidden;
+  }
 
-/* Project-wide icon convention: Material Symbols (outlined). Icons inherit the
-   surrounding text size by default; set font-size on the element to scale, and
-   the optical-size axis (opsz) follows so weight stays balanced. */
-.material-symbols-outlined {
-  font-size: inherit;
-  line-height: 1;
-  vertical-align: middle;
-  user-select: none;
-  font-variation-settings:
-    "FILL" 0,
-    "wght" 400,
-    "GRAD" 0,
-    "opsz" 20;
+  /* Project-wide icon convention: Material Symbols (outlined). Icons inherit the
+     surrounding text size by default; set font-size on the element to scale, and
+     the optical-size axis (opsz) follows so weight stays balanced. */
+  .material-symbols-outlined {
+    font-size: inherit;
+    line-height: 1;
+    vertical-align: middle;
+    user-select: none;
+    font-variation-settings:
+      "FILL" 0,
+      "wght" 400,
+      "GRAD" 0,
+      "opsz" 20;
+  }
 }


### PR DESCRIPTION
## Summary

**Bug:** the app's global CSS was **unlayered**, and unlayered author CSS beats *every* `@layer utilities` rule regardless of specificity. So:

- `* { margin: 0; padding: 0 }` silently disabled **every `p-*` / `m-*` / `ml-auto` utility app-wide**
- `.material-symbols-outlined { font-size: inherit }` disabled **every icon `text-*` utility**

Measured before the fix — utilities generated but losing the cascade:

| utility | computed |
|---|---|
| `px-4 py-2` | `0px` / `0px` |
| `p-2.5` | `0px` |
| `mb-2 mt-4` | `0px` / `0px` |

This is what broke the grid roster's frame/spacing.

## Fix

- Wrap the reset, `body`, and the icon rule in **`@layer base`**.
- Declare the layer order in `style.css` as well, so it never depends on import order.
- Import `material-symbols/outlined.css` **from CSS with `layer(base)`** instead of from `main.ts` — the package ships an unlayered `font-size: 24px` that would otherwise beat our icon rule once ours moved into a layer (I hit exactly that regression mid-fix).

Component `<style scoped>` stays unlayered and still wins over these, exactly as before.

## Verification (rendered, not grepped)

| check | result |
|---|---|
| `px-4 py-2`, `p-2.5`, `mb-2 mt-4` | apply ✓ |
| `ml-auto` in a flex row | `auto` ✓ |
| icon + `text-[18px]` | `18px` ✓ |
| icon with **no** utility inside a 13px parent | inherits `13px` ✓ (unchanged) |
| plain element | still zeroed by the reset ✓ |
| **grid roster row vs pre-migration original** | padding `8px 10px`, border-left `3px`, radius `8px`, bg, gap, **height 55.5px** — identical ✓ |

Full suite 1483 passed, typecheck clean.

## Items to Confirm / Review

- **My mistake, and the process fix:** every migration PR verified that the utility *rule existed* in the built CSS — not that it *won the cascade*. That is exactly what this class of bug slips through. `docs/styling.md` now documents both the layering rule and "verify computed style, not rule presence."
- Worth a quick visual pass over the grid roster and toolbars once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)