### PR TITLE
refactor: convert TerminalCell diff panel to Tailwind

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -999,28 +999,37 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
         </template>
       </TerminalView>
-      <div v-if="diffOpen && diff" class="cell-diff">
-        <div class="cell-diff-head">
-          <span class="cell-diff-title">Changes vs {{ diff?.base ?? "base" }}</span>
-          <span class="cell-diff-sum">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>
+      <div
+        v-if="diffOpen && diff"
+        data-testid="cell-diff"
+        class="absolute inset-x-0 bottom-0 top-[34px] z-[15] flex flex-col overflow-hidden border-t border-t-border bg-base"
+      >
+        <div class="flex flex-none items-center gap-2 border-b border-b-border bg-panel px-2 py-1.5">
+          <span class="font-sans text-[12px] font-semibold text-fg">Changes vs {{ diff?.base ?? "base" }}</span>
+          <span class="flex-auto font-sans text-[11px] text-dim">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>
           <button class="cell-btn" title="Close diff" aria-label="Close diff" @click="diffOpen = false">✕</button>
         </div>
-        <div v-if="diff && diff.files.length" class="cell-diff-files">
-          <div v-for="f in diff.files" :key="f.path" class="cell-diff-file">
-            <span class="df-path">{{ f.path }}</span>
-            <span v-if="f.status === 'untracked'" class="df-new">new</span>
-            <span v-else class="df-nums">
-              <span class="df-add">+{{ f.additions < 0 ? "bin" : f.additions }}</span>
-              <span class="df-del">−{{ f.deletions < 0 ? "bin" : f.deletions }}</span>
+        <div v-if="diff && diff.files.length" class="max-h-[35%] flex-none overflow-y-auto border-b border-b-border px-2 py-1">
+          <div v-for="f in diff.files" :key="f.path" data-testid="cell-diff-file" class="flex items-baseline gap-2 py-px font-mono text-[11px]">
+            <span class="min-w-0 flex-auto truncate text-secondary [direction:rtl]">{{ f.path }}</span>
+            <span v-if="f.status === 'untracked'" data-testid="df-new" class="flex-none text-[#3fae6b]">new</span>
+            <span v-else class="flex-none">
+              <span class="text-[#3fae6b]">+{{ f.additions < 0 ? "bin" : f.additions }}</span>
+              <span class="text-err-text">−{{ f.deletions < 0 ? "bin" : f.deletions }}</span>
             </span>
           </div>
         </div>
-        <pre v-if="diff && diff.patch" class="cell-diff-patch">{{ diff.patch }}</pre>
-        <p v-if="diff && diff.truncated" class="cell-diff-note">Diff truncated — open the worktree to see the rest.</p>
-        <p v-if="diff && !diff.files.length" class="cell-diff-empty">No changes yet.</p>
-        <div class="cell-diff-actions">
+        <pre
+          v-if="diff && diff.patch"
+          data-testid="cell-diff-patch"
+          class="m-0 flex-auto overflow-auto whitespace-pre p-2 font-mono text-[11px] leading-[1.45] text-secondary [tab-size:2]"
+          >{{ diff.patch }}</pre>
+        <p v-if="diff && diff.truncated" class="m-0 p-2 font-sans text-[11px] text-dim">Diff truncated — open the worktree to see the rest.</p>
+        <p v-if="diff && !diff.files.length" class="m-0 p-2 font-sans text-[11px] text-dim">No changes yet.</p>
+        <div class="flex flex-none items-center gap-2 border-t border-t-border bg-panel px-2 py-1.5">
           <button
-            class="cell-diff-btn"
+            data-testid="cell-diff-btn"
+            class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="prBusy || working || (diff?.dirty ?? 0) === 0"
             :title="(diff?.dirty ?? 0) === 0 ? 'No uncommitted changes' : working ? 'Wait for the session to finish' : 'Ask Claude to commit the changes'"
             @click="commitViaClaude"
@@ -1028,7 +1037,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             ✓ Commit
           </button>
           <button
-            class="cell-diff-btn"
+            data-testid="cell-diff-btn"
+            class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="prBusy || (diff?.ahead ?? 0) === 0"
             :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes first' : 'git push -u origin'"
             @click="pushBranch"
@@ -1036,14 +1046,15 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             ⬆ Push
           </button>
           <button
-            class="cell-diff-btn"
+            data-testid="cell-diff-btn"
+            class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="prBusy || (diff?.ahead ?? 0) === 0"
             :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'Push and open a pull request'"
             @click="openPR"
           >
             ⧉ Open PR
           </button>
-          <span v-if="prMsg" class="cell-diff-msg">{{ prMsg }}</span>
+          <span v-if="prMsg" data-testid="cell-diff-msg" class="min-w-0 flex-auto truncate font-sans text-[11px] text-dim">{{ prMsg }}</span>
         </div>
       </div>
       <div v-if="closeConfirm" class="cell-close-confirm" role="dialog" aria-modal="true" :aria-label="`Close worktree ${headerDir}`">
@@ -1776,133 +1787,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 }
 .wt-dirty-count {
   color: var(--warn-text, #e0a030);
-}
-
-/* Read-only diff panel: overlays the terminal area of the cell. */
-.cell-diff {
-  position: absolute;
-  inset: 34px 0 0 0; /* below the 34px header */
-  z-index: 15;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg-base);
-  border-top: 1px solid var(--border);
-  overflow: hidden;
-}
-.cell-diff-head {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-panel);
-}
-.cell-diff-title {
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
-}
-.cell-diff-sum {
-  flex: 1 1 auto;
-  font-family: system-ui, sans-serif;
-  font-size: 11px;
-  color: var(--text-dim);
-}
-.cell-diff-files {
-  flex: 0 0 auto;
-  max-height: 35%;
-  overflow-y: auto;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--border);
-}
-.cell-diff-file {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 11px;
-  padding: 1px 0;
-}
-.df-path {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  direction: rtl;
-  color: var(--text-secondary);
-}
-.df-nums {
-  flex: 0 0 auto;
-}
-.df-add {
-  color: #3fae6b;
-}
-.df-del {
-  color: var(--err-text, #e0556b);
-}
-.df-new {
-  flex: 0 0 auto;
-  color: #3fae6b;
-}
-.cell-diff-patch {
-  flex: 1 1 auto;
-  margin: 0;
-  overflow: auto;
-  padding: 8px;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 11px;
-  line-height: 1.45;
-  color: var(--text-secondary);
-  white-space: pre;
-  tab-size: 2;
-}
-.cell-diff-note,
-.cell-diff-empty {
-  margin: 0;
-  padding: 8px;
-  font-family: system-ui, sans-serif;
-  font-size: 11px;
-  color: var(--text-dim);
-}
-.cell-diff-actions {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-top: 1px solid var(--border);
-  background: var(--bg-panel);
-}
-.cell-diff-btn {
-  border: 1px solid var(--border);
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  padding: 4px 12px;
-  border-radius: 6px;
-}
-.cell-diff-btn:hover:not(:disabled) {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.cell-diff-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-.cell-diff-msg {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  font-family: system-ui, sans-serif;
-  font-size: 11px;
-  color: var(--text-dim);
 }
 
 /* Close confirmation: keep or remove the worktree before tearing the cell down. */

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -920,16 +920,16 @@ describe("TerminalCell", () => {
     expect(badge.find(".wt-ahead").text()).toBe("+3");
     expect(badge.find(".wt-dirty-count").text()).toBe("●2");
 
-    expect(w.find(".cell-diff").exists()).toBe(false); // panel closed initially
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false); // panel closed initially
     await badge.trigger("click");
     await flushPromises();
-    expect(w.find(".cell-diff").exists()).toBe(true);
-    expect(w.findAll(".cell-diff-file")).toHaveLength(2);
-    expect(w.find(".df-new").exists()).toBe(true); // the untracked file
-    expect(w.find(".cell-diff-patch").text()).toContain("hello");
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(true);
+    expect(w.findAll('[data-testid="cell-diff-file"]')).toHaveLength(2);
+    expect(w.find('[data-testid="df-new"]').exists()).toBe(true); // the untracked file
+    expect(w.find('[data-testid="cell-diff-patch"]').text()).toContain("hello");
 
-    await w.find(".cell-diff .cell-btn").trigger("click"); // ✕ closes it
-    expect(w.find(".cell-diff").exists()).toBe(false);
+    await w.find('[data-testid="cell-diff"] .cell-btn').trigger("click"); // ✕ closes it
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false);
   });
 
   it("shows no diff badge for a clean worktree (0 ahead / 0 dirty)", async () => {
@@ -987,11 +987,11 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-wt-badge").trigger("click");
     await flushPromises();
-    expect(w.find(".cell-diff").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(true);
     // leaving the worktree clears `diff`; the panel must not linger as an empty overlay
     w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/plain-proj");
     await flushPromises();
-    expect(w.find(".cell-diff").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false);
   });
 
   it("does not auto-reopen the diff panel after leaving and re-entering a worktree", async () => {
@@ -1000,17 +1000,17 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-wt-badge").trigger("click"); // user opens the panel
     await flushPromises();
-    expect(w.find(".cell-diff").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(true);
 
     const term = w.findComponent({ name: "TerminalView" });
     term.vm.$emit("cwd", "/home/me/plain-proj"); // leave the worktree → panel closes
     await flushPromises();
-    expect(w.find(".cell-diff").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false);
 
     term.vm.$emit("cwd", WT_CWD); // re-enter a worktree
     await flushPromises();
     expect(w.find(".cell-wt-badge").exists()).toBe(true); // badge returns…
-    expect(w.find(".cell-diff").exists()).toBe(false); // …but the panel stays closed until clicked
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false); // …but the panel stays closed until clicked
   });
 
   it("closes the diff panel on Escape (document-level handler)", async () => {
@@ -1019,10 +1019,10 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-wt-badge").trigger("click");
     await flushPromises();
-    expect(w.find(".cell-diff").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(true);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })); // focus may be on the badge/terminal
     await flushPromises();
-    expect(w.find(".cell-diff").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false);
   });
 
   it("ignores an in-flight diff fetch that resolves after the cwd left the worktree", async () => {
@@ -1090,7 +1090,7 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await openPanel(w);
-    const btns = w.findAll(".cell-diff-btn");
+    const btns = w.findAll('[data-testid="cell-diff-btn"]');
     const labelled = (text: string) => btns.find((b) => b.text().includes(text));
     expect(labelled("Push")?.attributes("disabled")).toBeDefined(); // no commits ahead
     expect(labelled("Open PR")?.attributes("disabled")).toBeDefined();
@@ -1102,14 +1102,14 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await openPanel(w);
-    const push = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Push"));
+    const push = w.findAll('[data-testid="cell-diff-btn"]').find((b) => b.text().includes("Push"));
     if (!push) throw new Error("Push button not found");
     await push.trigger("click");
     await flushPromises();
     const req = posts.find((p) => p.url.includes("/api/worktrees/push"));
     if (!req) throw new Error("push not called");
     expect(JSON.parse(req.body)).toEqual({ cwd: WT_CWD });
-    expect(w.find(".cell-diff-msg").text()).toBe("Pushed agent/fix-login");
+    expect(w.find('[data-testid="cell-diff-msg"]').text()).toBe("Pushed agent/fix-login");
   });
 
   it("Open PR opens the returned url in a new tab", async () => {
@@ -1118,12 +1118,12 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await openPanel(w);
-    const pr = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Open PR"));
+    const pr = w.findAll('[data-testid="cell-diff-btn"]').find((b) => b.text().includes("Open PR"));
     if (!pr) throw new Error("Open PR button not found");
     await pr.trigger("click");
     await flushPromises();
     expect(openSpy).toHaveBeenCalledWith("https://github.com/owner/repo/pull/9", "_blank", "noopener,noreferrer");
-    expect(w.find(".cell-diff-msg").text()).toBe("PR created");
+    expect(w.find('[data-testid="cell-diff-msg"]').text()).toBe("PR created");
     openSpy.mockRestore();
   });
 
@@ -1132,13 +1132,13 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await openPanel(w);
-    const push = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Push"));
+    const push = w.findAll('[data-testid="cell-diff-btn"]').find((b) => b.text().includes("Push"));
     await push?.trigger("click");
     await flushPromises();
-    expect(w.find(".cell-diff-msg").text()).toContain("No git remote");
+    expect(w.find('[data-testid="cell-diff-msg"]').text()).toContain("No git remote");
   });
 
-  const commitBtn = (w: ReturnType<typeof mountCell>) => w.findAll(".cell-diff-btn").find((b) => b.text().includes("Commit"));
+  const commitBtn = (w: ReturnType<typeof mountCell>) => w.findAll('[data-testid="cell-diff-btn"]').find((b) => b.text().includes("Commit"));
 
   it("Commit asks the Claude session to commit when there are uncommitted changes", async () => {
     // ahead 0, dirty 2 → the badge shows (dirty) and the Commit button is enabled
@@ -1167,7 +1167,7 @@ describe("TerminalCell", () => {
     await flushPromises();
     expect(submit).toHaveBeenCalledTimes(1);
     expect(submit.mock.calls[0][0]).toContain("Commit all current changes");
-    expect(w.find(".cell-diff-msg").text()).toContain("Asked Claude to commit");
+    expect(w.find('[data-testid="cell-diff-msg"]').text()).toContain("Asked Claude to commit");
   });
 
   it("disables Commit when there are no uncommitted changes (dirty=0)", async () => {
@@ -1219,7 +1219,7 @@ describe("TerminalCell", () => {
     vi.spyOn(term.vm as unknown as { submitText: (t: string) => boolean }, "submitText").mockReturnValue(false);
     await commitBtn(w)?.trigger("click");
     await flushPromises();
-    expect(w.find(".cell-diff-msg").text()).toContain("Couldn't reach the session");
+    expect(w.find('[data-testid="cell-diff-msg"]').text()).toContain("Couldn't reach the session");
   });
 
   it("does not get stuck on 'Pushing…' when the response has no JSON body (403)", async () => {
@@ -1240,10 +1240,10 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await openPanel(w);
-    const push = w.findAll(".cell-diff-btn").find((b) => b.text().includes("Push"));
+    const push = w.findAll('[data-testid="cell-diff-btn"]').find((b) => b.text().includes("Push"));
     await push?.trigger("click");
     await flushPromises();
-    const msg = w.find(".cell-diff-msg").text();
+    const msg = w.find('[data-testid="cell-diff-msg"]').text();
     expect(msg).not.toBe("Pushing…");
     expect(msg).toContain("Not allowed");
   });


### PR DESCRIPTION
## Summary

First slice of `TerminalCell.vue` — the read-only **diff overlay** (panel, header, file list, patch, notes, action bar + buttons). Scoped CSS **751 → 624 lines**.

- Self-contained: no shared `cellChrome` class is involved, so the layering constraint doesn't bite here (the ✕ keeps its `.cell-btn` untouched).
- Directional border colours (`border-t-border` / `border-b-border`) instead of `border-border`, so only the side that actually has a width gets a colour.
- `direction: rtl` and `tab-size: 2` preserved via `[direction:rtl]` / `[tab-size:2]`; `.df-add`/`.df-new` keep their hardcoded green as `text-[#3fae6b]`; `.df-del` uses the defined `err-text` token.

## Verification — rendered, not grepped

Rendered the **original markup + original rules** and the **new utility markup** side by side and compared **every** computed property of all 16 elements:

> ✅ ALL 16 ELEMENTS: every computed property identical

This is the check that was missing from the earlier migration PRs — grepping the built CSS only proves a rule was *generated*, which is exactly how the cascade-layer regression (#535) slipped through. Adopting it from here on.

Full suite 1483 passed, typecheck clean, 0 new lint warnings.

## Items to Confirm / Review

- **Test selectors**: `.cell-diff` / `-file` / `-patch` / `-btn` / `-msg` / `.df-new` → `data-testid`. The `.cell-diff .cell-btn` descendant assertion became `[data-testid="cell-diff"] .cell-btn` (that ✕ still uses shared chrome).

## Next slices

`.cell-chip` (~65), `.cell-dir` (~62), `.ccx-` close-confirm (~59), `.cell-gh` (~57), `.cell-launch` (~52), `.wt-` worktrees (~43), `.cell-resume` (~37)… the header row (`.cell-header` / `.cell-btn` / `.cell-dot`) comes last since it needs the shared-chrome layering decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)