### PR TITLE
refactor: convert TerminalCell close-confirm to Tailwind

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1057,25 +1057,62 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <span v-if="prMsg" data-testid="cell-diff-msg" class="min-w-0 flex-auto truncate font-sans text-[11px] text-dim">{{ prMsg }}</span>
         </div>
       </div>
-      <div v-if="closeConfirm" class="cell-close-confirm" role="dialog" aria-modal="true" :aria-label="`Close worktree ${headerDir}`">
-        <div class="ccx-box">
-          <p class="ccx-title">Close {{ headerDir }}</p>
+      <div
+        v-if="closeConfirm"
+        data-testid="cell-close-confirm"
+        class="absolute inset-0 z-[25] flex items-center justify-center bg-[color-mix(in_srgb,var(--bg-base)_82%,transparent)] p-4"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="`Close worktree ${headerDir}`"
+      >
+        <div class="flex max-w-[320px] flex-col gap-2.5 rounded-lg border border-border bg-panel p-4 shadow-[0_8px_24px_rgba(0,0,0,0.4)]">
+          <p class="m-0 font-sans text-[13px] font-semibold text-fg">Close {{ headerDir }}</p>
           <template v-if="!closeError">
-            <p v-if="hasUnsaved" class="ccx-warn">{{ unsavedSummary }} will be discarded if you remove the worktree.</p>
-            <p v-else class="ccx-sub">Keep the worktree to reuse it later, or remove it.</p>
-            <div class="ccx-actions">
-              <button class="ccx-btn ccx-keep" @click="teardown">Keep worktree</button>
-              <button class="ccx-btn ccx-remove" :disabled="closeChecking" @click="removeAndClose">
+            <p v-if="hasUnsaved" data-testid="ccx-warn" class="m-0 font-sans text-[12px] text-[var(--warn-text,#e0a030)]">
+              {{ unsavedSummary }} will be discarded if you remove the worktree.
+            </p>
+            <p v-else class="m-0 font-sans text-[12px] text-dim">Keep the worktree to reuse it later, or remove it.</p>
+            <div class="flex flex-wrap gap-1.5">
+              <button
+                data-testid="ccx-keep"
+                class="cursor-pointer rounded-md border border-accent bg-elevated px-3 py-1.5 font-sans text-[12px] text-fg hover:bg-hover hover:text-fg"
+                @click="teardown"
+              >
+                Keep worktree
+              </button>
+              <button
+                data-testid="ccx-remove"
+                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+                :disabled="closeChecking"
+                @click="removeAndClose"
+              >
                 {{ closeChecking ? "Checking…" : hasUnsaved ? "Discard &amp; remove" : "Remove worktree" }}
               </button>
-              <button class="ccx-btn ccx-cancel" @click="cancelClose">Cancel</button>
+              <button
+                data-testid="ccx-cancel"
+                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                @click="cancelClose"
+              >
+                Cancel
+              </button>
             </div>
           </template>
           <template v-else>
-            <p class="ccx-warn">{{ closeError }}</p>
-            <div class="ccx-actions">
-              <button class="ccx-btn ccx-remove" @click="removeAndClose">Retry</button>
-              <button class="ccx-btn" @click="teardown">Close cell</button>
+            <p data-testid="ccx-warn" class="m-0 font-sans text-[12px] text-[var(--warn-text,#e0a030)]">{{ closeError }}</p>
+            <div class="flex flex-wrap gap-1.5">
+              <button
+                data-testid="ccx-remove"
+                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+                @click="removeAndClose"
+              >
+                Retry
+              </button>
+              <button
+                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                @click="teardown"
+              >
+                Close cell
+              </button>
             </div>
           </template>
         </div>
@@ -1787,75 +1824,5 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 }
 .wt-dirty-count {
   color: var(--warn-text, #e0a030);
-}
-
-/* Close confirmation: keep or remove the worktree before tearing the cell down. */
-.cell-close-confirm {
-  position: absolute;
-  inset: 0;
-  z-index: 25;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 16px;
-  background: color-mix(in srgb, var(--bg-base) 82%, transparent);
-}
-.ccx-box {
-  max-width: 320px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 16px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-}
-.ccx-title {
-  margin: 0;
-  font-family: system-ui, sans-serif;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-}
-.ccx-sub {
-  margin: 0;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  color: var(--text-dim);
-}
-.ccx-warn {
-  margin: 0;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  color: var(--warn-text, #e0a030);
-}
-.ccx-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-.ccx-btn {
-  border: 1px solid var(--border);
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  padding: 6px 12px;
-  border-radius: 6px;
-}
-.ccx-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.ccx-keep {
-  border-color: var(--accent);
-  color: var(--text);
-}
-.ccx-remove:hover {
-  background: var(--err-hover-bg);
-  color: var(--err-text);
-  border-color: var(--err-text, #e0556b);
 }
 </style>

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1268,7 +1268,7 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await w.find(".cell-close").trigger("click");
-    expect(w.find(".cell-close-confirm").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(true);
     expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true); // session not torn down yet
   });
 
@@ -1277,7 +1277,7 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-close").trigger("click");
     await nextTick();
-    expect(w.find(".cell-close-confirm").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(false);
     expect(w.find(".cell-launch").exists()).toBe(true); // torn down to the launcher
   });
 
@@ -1286,7 +1286,7 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await w.find(".cell-close").trigger("click");
-    await w.find(".ccx-keep").trigger("click");
+    await w.find('[data-testid="ccx-keep"]').trigger("click");
     await flushPromises();
     expect(posts.some((p) => p.url.includes("/api/worktrees/remove"))).toBe(false);
     expect(w.find(".cell-launch").exists()).toBe(true);
@@ -1298,7 +1298,7 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-close").trigger("click");
     await flushPromises(); // the close() diff refresh enables the Remove button
-    await w.find(".ccx-remove").trigger("click");
+    await w.find('[data-testid="ccx-remove"]').trigger("click");
     await flushPromises();
     const rm = posts.find((p) => p.url.includes("/api/worktrees/remove"));
     if (!rm) throw new Error("remove not called");
@@ -1323,10 +1323,10 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-close").trigger("click"); // close() refresh is pending on `gate`
     await nextTick();
-    expect(w.find(".ccx-remove").attributes("disabled")).toBeDefined(); // held while checking
+    expect(w.find('[data-testid="ccx-remove"]').attributes("disabled")).toBeDefined(); // held while checking
     gate.resolve({ ok: true, json: async () => cleanWtDiff });
     await flushPromises();
-    expect(w.find(".ccx-remove").attributes("disabled")).toBeUndefined(); // released
+    expect(w.find('[data-testid="ccx-remove"]').attributes("disabled")).toBeUndefined(); // released
   });
 
   it("keeps the confirm open with an error when the remove fails (no false success)", async () => {
@@ -1341,11 +1341,11 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-close").trigger("click");
     await flushPromises();
-    await w.find(".ccx-remove").trigger("click");
+    await w.find('[data-testid="ccx-remove"]').trigger("click");
     await flushPromises();
-    expect(w.find(".cell-close-confirm").exists()).toBe(true); // NOT torn down
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(true); // NOT torn down
     expect(w.find(".cell-launch").exists()).toBe(false);
-    expect(w.find(".ccx-warn").text()).toContain("Couldn't remove");
+    expect(w.find('[data-testid="ccx-warn"]').text()).toContain("Couldn't remove");
   });
 
   it("Escape dismisses the close confirmation", async () => {
@@ -1353,10 +1353,10 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await w.find(".cell-close").trigger("click");
-    expect(w.find(".cell-close-confirm").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(true);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     await nextTick();
-    expect(w.find(".cell-close-confirm").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(false);
     expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true);
   });
 
@@ -1365,8 +1365,8 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
     await w.find(".cell-close").trigger("click");
-    await w.find(".ccx-cancel").trigger("click");
-    expect(w.find(".cell-close-confirm").exists()).toBe(false);
+    await w.find('[data-testid="ccx-cancel"]').trigger("click");
+    expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(false);
     expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(true);
   });
 
@@ -1384,11 +1384,11 @@ describe("TerminalCell", () => {
     await flushPromises();
     await w.find(".cell-close").trigger("click");
     await flushPromises(); // the close() diff refresh
-    const warn = w.find(".ccx-warn");
+    const warn = w.find('[data-testid="ccx-warn"]');
     expect(warn.exists()).toBe(true);
     expect(warn.text()).toContain("2 unpushed");
     expect(warn.text()).toContain("1 uncommitted");
-    expect(w.find(".ccx-remove").text()).toContain("Discard");
+    expect(w.find('[data-testid="ccx-remove"]').text()).toContain("Discard");
   });
 
   it("keeps expand + close on row 1 (cell-header); the other icons live on row 2", async () => {


### PR DESCRIPTION
## Summary

Second slice of `TerminalCell.vue` — the **keep-or-remove-worktree confirm dialog** (overlay, box, title/warning/sub copy, three action buttons). Scoped CSS **624 → 554 lines**.

- Self-contained; no shared `cellChrome` class involved.
- **`--warn-text` is undefined app-wide**, so `.ccx-warn`'s `var(--warn-text, #e0a030)` fallback is preserved verbatim as `text-[var(--warn-text,#e0a030)]` — dropping it would have changed the colour.
- The per-button hover overrides (`.ccx-keep` accent border, `.ccx-remove` danger hover) are written out per button so the base and override hovers can't race.

## Verification — rendered, not grepped

Every computed property of all 9 elements compared against the original markup + original rules:

- **8/9 elements: every property identical.**
- The box differs only in `box-shadow` *serialization* — Tailwind emits its composition chain (four fully-transparent, zero-size shadows) before the real `rgba(0,0,0,0.4) 0 8px 24px`. Confirmed **visually identical** by a same-position full-viewport pixel comparison: `identical: true`.

Full suite 1483 passed, typecheck clean.

## Items to Confirm / Review

- **Test selectors**: `.cell-close-confirm` / `.ccx-keep` / `-remove` / `-cancel` / `-warn` → `data-testid`.

## Progress

TerminalCell 751 → 554. Remaining slices: `.cell-chip` (~65), `.cell-dir` (~62), `.cell-gh` (~57), `.cell-launch` (~52), `.wt-` (~49), `.cell-resume` (~37), … header row last (shared-chrome layering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)