### PR TITLE
refactor: convert TerminalCell preset chips to Tailwind

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1150,30 +1150,50 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         ✕
       </button>
       <div v-if="presets.length" class="cell-presets">
-        <span v-for="p in presets" :key="p.label + p.path" :class="['cell-chip', { 'is-running': isCwdRunning(p.path) }]">
+        <span
+          v-for="p in presets"
+          :key="p.label + p.path"
+          data-testid="cell-chip"
+          class="inline-flex items-stretch overflow-hidden rounded-[14px] border"
+          :class="[
+            { 'is-running': isCwdRunning(p.path) },
+            isCwdRunning(p.path)
+              ? 'border-[color-mix(in_srgb,#3b82f6_55%,var(--border))] bg-[color-mix(in_srgb,#3b82f6_14%,var(--bg-elevated))]'
+              : 'border-border bg-elevated',
+          ]"
+        >
           <button
             type="button"
-            class="cell-chip-main"
+            data-testid="cell-chip-main"
+            class="cursor-pointer border-none bg-transparent px-2.5 py-1 font-sans text-[12px] hover:bg-hover hover:text-fg"
+            :class="isCwdRunning(p.path) ? 'text-fg' : 'text-secondary'"
             :title="p.path"
             :aria-label="`Use ${p.label} — fill the field to browse / resume here (without launching)`"
             @click="fillDir(p.path)"
           >
-            <span v-if="isCwdRunning(p.path)" class="cell-chip-dot" aria-hidden="true" />{{ p.label }}
+            <span
+              v-if="isCwdRunning(p.path)"
+              data-testid="cell-chip-dot"
+              class="mr-[5px] inline-block h-1.5 w-1.5 rounded-full bg-[#3b82f6] align-middle"
+              aria-hidden="true"
+            />{{ p.label }}
           </button>
           <button
             type="button"
-            class="cell-chip-launch"
+            data-testid="cell-chip-launch"
+            class="inline-flex cursor-pointer items-center border-0 border-l border-l-border bg-transparent px-[5px] text-secondary hover:bg-hover hover:text-fg"
             :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here in another terminal` : `Launch a new terminal in ${p.path} now`"
             :aria-label="
               isCwdRunning(p.path) ? `${p.label} — a session is already running here in another terminal` : `Launch a new terminal in ${p.label} now`
             "
             @click="selectPreset(p)"
           >
-            <span class="material-symbols-outlined">play_arrow</span>
+            <span class="material-symbols-outlined text-[14px]">play_arrow</span>
           </button>
           <button
             type="button"
-            class="cell-chip-del"
+            data-testid="cell-chip-del"
+            class="cursor-pointer border-0 border-l border-l-border bg-transparent px-[7px] text-[11px] text-secondary hover:bg-hover hover:text-[var(--danger,#e5484d)]"
             :title="`Remove ${p.path} from the list`"
             :aria-label="`Remove ${p.path} from the list`"
             @click="emit('remove-preset', p.path)"
@@ -1233,7 +1253,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             aria-label="Start a new terminal here"
             @click="launch"
           >
-            <span class="material-symbols-outlined">play_arrow</span>
+            <span class="material-symbols-outlined text-[14px]">play_arrow</span>
           </button>
         </span>
       </label>
@@ -1485,73 +1505,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   justify-content: center;
   gap: 6px;
   max-width: 360px;
-}
-/* A chip is a segmented pill: the main button launches; the tiny end button just
-   fills the working-directory field (so the user can resume a session there). */
-.cell-chip {
-  display: inline-flex;
-  align-items: stretch;
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  overflow: hidden;
-  background: var(--bg-elevated);
-}
-/* A dir already running a session in another cell: tint the chip + show a dot. */
-.cell-chip.is-running {
-  border-color: color-mix(in srgb, #3b82f6 55%, var(--border));
-  background: color-mix(in srgb, #3b82f6 14%, var(--bg-elevated));
-}
-.cell-chip-dot {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  margin-right: 5px;
-  border-radius: 50%;
-  background: #3b82f6;
-  vertical-align: middle;
-}
-.cell-chip-main {
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  padding: 4px 10px;
-}
-.cell-chip.is-running .cell-chip-main {
-  color: var(--text);
-}
-.cell-chip-launch {
-  display: inline-flex;
-  align-items: center;
-  border: none;
-  border-left: 1px solid var(--border);
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  padding: 0 5px;
-}
-.cell-chip-launch .material-symbols-outlined {
-  font-size: 14px;
-}
-.cell-chip-del {
-  border: none;
-  border-left: 1px solid var(--border);
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: 11px;
-  padding: 0 7px;
-}
-.cell-chip-main:hover,
-.cell-chip-launch:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.cell-chip-del:hover {
-  background: var(--bg-hover);
-  color: var(--danger, #e5484d);
 }
 .cell-launch-label {
   display: flex;

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -301,9 +301,9 @@ describe("TerminalCell", () => {
 
     const w = mountCell(null, { defaultCwd: "/A", presets: [{ label: "B", path: "/B" }] });
     await nextTick(); // mount → fetch #1 (dir A) in flight
-    const chipB = w.findAll(".cell-chip").find((c) => c.find(".cell-chip-main").text() === "B");
+    const chipB = w.findAll('[data-testid="cell-chip"]').find((c) => c.find('[data-testid="cell-chip-main"]').text() === "B");
     if (!chipB) throw new Error("preset B not found");
-    await chipB.find(".cell-chip-main").trigger("click"); // main click = fillDir → fetch #2 (dir B)
+    await chipB.find('[data-testid="cell-chip-main"]').trigger("click"); // main click = fillDir → fetch #2 (dir B)
 
     second.resolve({ ok: true, json: async () => ({ cwd: "/B", sessions: [{ id: "b-id", title: "B-sess", mtime: 1 }] }) });
     await flushPromises();
@@ -329,7 +329,7 @@ describe("TerminalCell", () => {
   it("clicking a preset chip's main button fills the dir WITHOUT launching (so the user can resume or start)", async () => {
     const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
     await flushPromises();
-    const main = w.findAll(".cell-chip-main").find((b) => b.text() === "proj");
+    const main = w.findAll('[data-testid="cell-chip-main"]').find((b) => b.text() === "proj");
     if (!main) throw new Error("preset chip not found");
     await main.trigger("click");
     // No terminal — the main click only selects the directory (fill, not launch).
@@ -340,9 +340,9 @@ describe("TerminalCell", () => {
   it("the chip's ▶ launch button quick-starts a fresh session in its dir", async () => {
     const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
     await flushPromises();
-    const chip = w.findAll(".cell-chip").find((c) => c.find(".cell-chip-main").text() === "proj");
+    const chip = w.findAll('[data-testid="cell-chip"]').find((c) => c.find('[data-testid="cell-chip-main"]').text() === "proj");
     if (!chip) throw new Error("preset chip not found");
-    await chip.find(".cell-chip-launch").trigger("click");
+    await chip.find('[data-testid="cell-chip-launch"]').trigger("click");
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/work/proj");
@@ -357,7 +357,7 @@ describe("TerminalCell", () => {
         (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter((c) => String(c[0]).includes("/api/sessions")).length;
       const before = sessionCalls();
 
-      const main = w.findAll(".cell-chip-main").find((b) => b.text() === "x");
+      const main = w.findAll('[data-testid="cell-chip-main"]').find((b) => b.text() === "x");
       if (!main) throw new Error("preset chip not found");
       await main.trigger("click"); // fillDir → one immediate /api/sessions load
       await flushPromises();
@@ -385,7 +385,7 @@ describe("TerminalCell", () => {
       await w.find(".cell-dir-input").setValue("/typed"); // schedules a 300ms debounced load
       const before = sessionCalls();
 
-      const main = w.findAll(".cell-chip-main").find((b) => b.text() === "x");
+      const main = w.findAll('[data-testid="cell-chip-main"]').find((b) => b.text() === "x");
       if (!main) throw new Error("preset chip not found");
       await main.trigger("click"); // fillDir → immediate load + must cancel the pending /typed debounce
       await flushPromises();
@@ -417,9 +417,9 @@ describe("TerminalCell", () => {
   it("emits remove-preset (and does NOT launch) when a chip's ✕ is clicked", async () => {
     const w = mountCell(null, { presets: [{ label: "proj", path: "/work/proj" }] });
     await flushPromises();
-    const chip = w.findAll(".cell-chip").find((c) => c.find(".cell-chip-main").text() === "proj");
+    const chip = w.findAll('[data-testid="cell-chip"]').find((c) => c.find('[data-testid="cell-chip-main"]').text() === "proj");
     if (!chip) throw new Error("preset chip not found");
-    await chip.find(".cell-chip-del").trigger("click");
+    await chip.find('[data-testid="cell-chip-del"]').trigger("click");
     expect(w.emitted("remove-preset")?.at(-1)).toEqual(["/work/proj"]);
     expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
   });
@@ -1522,16 +1522,16 @@ describe("TerminalCell", () => {
       ],
       openCwds: ["/home/me/a"],
     });
-    const chips = w.findAll(".cell-chip");
+    const chips = w.findAll('[data-testid="cell-chip"]');
     const running = chips.find((c) => c.text().includes("proj-a"));
     const idle = chips.find((c) => c.text().includes("proj-b"));
     expect(running?.classes()).toContain("is-running");
-    expect(running?.find(".cell-chip-dot").exists()).toBe(true);
+    expect(running?.find('[data-testid="cell-chip-dot"]').exists()).toBe(true);
     // a11y: the running state is exposed in text (on the ▶ launch button — the action that
     // would actually double-launch there), not just color/hover.
-    expect(running?.find(".cell-chip-launch").attributes("aria-label")).toContain("already running");
+    expect(running?.find('[data-testid="cell-chip-launch"]').attributes("aria-label")).toContain("already running");
     expect(idle?.classes()).not.toContain("is-running");
-    expect(idle?.find(".cell-chip-dot").exists()).toBe(false);
-    expect(idle?.find(".cell-chip-launch").attributes("aria-label")).not.toContain("already running");
+    expect(idle?.find('[data-testid="cell-chip-dot"]').exists()).toBe(false);
+    expect(idle?.find('[data-testid="cell-chip-launch"]').attributes("aria-label")).not.toContain("already running");
   });
 });


### PR DESCRIPTION
## Summary

Fourth slice of `TerminalCell.vue` — the **cwd preset chips** (pill, main button, running dot, launch + delete segments). Scoped CSS **497 → 430 lines**.

- `is-running` stays as a **state marker** (the spec asserts `classes()`), with the tint moving to a mutually-exclusive `:class` so the two border/background pairs can't race.
- The parent-state rule `.cell-chip.is-running .cell-chip-main` becomes a conditional colour on the button itself.
- **`--danger` is undefined app-wide**, so the delete hover keeps its fallback verbatim: `hover:text-[var(--danger,#e5484d)]`.
- **`border-0 + border-l`, not `border-none + border-l`**, for the segment dividers — `border-none` sets `--tw-border-style: none`, which `border-l` then inherits, erasing the divider. (Worth knowing: `border-none` is the exact map for a plain `border: none`, but it can't be combined with a directional border.)

## Verification — rendered, not grepped

The only computed-style differences are:
- border colours/styles on **zero-width** sides (the visible left dividers match exactly), and
- `rounded-full` vs `50%` on the 6px dot.

Proven **visually identical** by a same-position pixel comparison of both chip states (idle and running-with-dot) at 3× DPR: `identical: true`.

Full suite 1483 passed, typecheck clean.

## Note on a pre-existing oddity found while scoping

`.cell-dir-go` shares a rule with `.cell-start`, and that rule applies **button** padding/border to `.cell-dir-go .material-symbols-outlined` (an icon span) rather than to the button. It looks like an authoring slip. I deliberately left `.cell-dir*` out of this PR so it can be converted faithfully — and that oddity flagged — on its own.

## Progress

TerminalCell 751 → 430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)