### PR TITLE
refactor: convert TerminalCell launcher panels to Tailwind

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -909,12 +909,13 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               <button
                 v-else-if="chip.builtin === 'diff' && showDiffBadge && diff"
                 type="button"
-                class="cell-wt-badge"
+                data-testid="cell-wt-badge"
+                class="inline-flex flex-none cursor-pointer items-center gap-1.5 rounded-[10px] border border-border bg-elevated px-[7px] py-px font-mono text-[11px] hover:bg-hover"
                 :title="`View changes vs ${diff.base ?? 'base'}`"
                 @click="openDiff"
               >
-                <span v-if="diff.ahead > 0" class="wt-ahead">+{{ diff.ahead }}</span>
-                <span v-if="diff.dirty > 0" class="wt-dirty-count">●{{ diff.dirty }}</span>
+                <span v-if="diff.ahead > 0" data-testid="wt-ahead" class="text-accent">+{{ diff.ahead }}</span>
+                <span v-if="diff.dirty > 0" data-testid="wt-dirty-count" class="text-[var(--warn-text,#e0a030)]">●{{ diff.dirty }}</span>
               </button>
               <ModelContextBadge v-else-if="chip.builtin === 'ctx' && context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
               <span v-else-if="chip.builtin === 'usage' && showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
@@ -1145,11 +1146,19 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         </div>
       </div>
     </template>
-    <div v-else class="cell-launch">
-      <button v-if="cancellable" type="button" class="cell-launch-cancel" title="Cancel new terminal" aria-label="Cancel new terminal" @click="emit('close')">
+    <div v-else data-testid="cell-launch" class="flex min-h-0 flex-1 flex-col items-center justify-start gap-2 overflow-y-auto p-4">
+      <button
+        v-if="cancellable"
+        type="button"
+        data-testid="cell-launch-cancel"
+        class="absolute right-1.5 top-1.5 inline-flex h-[26px] w-7 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-[16px] leading-none text-secondary hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+        title="Cancel new terminal"
+        aria-label="Cancel new terminal"
+        @click="emit('close')"
+      >
         ✕
       </button>
-      <div v-if="presets.length" class="cell-presets">
+      <div v-if="presets.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
         <span
           v-for="p in presets"
           :key="p.label + p.path"
@@ -1202,11 +1211,11 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           </button>
         </span>
       </div>
-      <div class="cell-agent" role="radiogroup" aria-label="Agent">
+      <div class="inline-flex gap-0.5 self-start rounded-[7px] border border-border bg-deep p-0.5" role="radiogroup" aria-label="Agent">
         <button
           type="button"
-          class="cell-agent-btn"
-          :class="{ active: agent === 'claude' }"
+          class="cursor-pointer rounded-[5px] border-none px-3.5 py-1 font-sans text-[12px] font-medium"
+          :class="agent === 'claude' ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
           role="radio"
           :aria-checked="agent === 'claude'"
           @click="agent = 'claude'"
@@ -1215,8 +1224,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         </button>
         <button
           type="button"
-          class="cell-agent-btn"
-          :class="{ active: agent === 'codex' }"
+          class="cursor-pointer rounded-[5px] border-none px-3.5 py-1 font-sans text-[12px] font-medium"
+          :class="agent === 'codex' ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
           role="radio"
           :aria-checked="agent === 'codex'"
           @click="agent = 'codex'"
@@ -1224,8 +1233,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           Codex
         </button>
       </div>
-      <label class="cell-launch-label">
-        <span class="cell-launch-caption">Working directory</span>
+      <label class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Working directory</span>
         <span class="cell-dir-row">
           <input
             v-model="dirInput"
@@ -1257,57 +1266,94 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           </button>
         </span>
       </label>
-      <div v-if="isGitRepo" class="cell-worktrees">
-        <span class="cell-launch-caption">or isolate in a worktree (git repo)</span>
-        <div class="wt-new">
+      <div v-if="isGitRepo" data-testid="cell-worktrees" class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
+        <div class="flex gap-1.5">
           <input
             v-model="worktreeTask"
-            class="cell-dir-input wt-task"
+            data-testid="wt-task"
+            class="cell-dir-input w-auto min-w-0 flex-auto"
             type="text"
             placeholder="task name (e.g. fix-login)"
             aria-label="Worktree task name"
             spellcheck="false"
             @keydown.enter="createWorktreeAndLaunch"
           />
-          <button class="cell-start wt-start" :disabled="!worktreeTask.trim()" @click="createWorktreeAndLaunch">＋ New worktree</button>
+          <button data-testid="wt-start" class="cell-start flex-none whitespace-nowrap" :disabled="!worktreeTask.trim()" @click="createWorktreeAndLaunch">
+            ＋ New worktree
+          </button>
         </div>
-        <div v-for="w in worktrees" :key="w.path" class="wt-row">
+        <div v-for="w in worktrees" :key="w.path" class="flex items-center gap-1.5">
           <button
             class="flex-auto min-w-0 text-left rounded-md border border-border bg-elevated text-secondary cursor-pointer font-mono text-[12px] py-[5px] px-2.5 truncate hover:bg-hover hover:text-fg"
             data-testid="worktree-reuse"
             :title="w.branch ?? w.path"
             @click="reuseWorktree(w)"
           >
-            ⎇ {{ w.task }}<span v-if="w.dirty" class="wt-dirty" title="uncommitted changes">●</span>
+            ⎇ {{ w.task }}<span v-if="w.dirty" data-testid="wt-dirty" class="ml-1.5 text-[var(--warn-text,#e0a030)]" title="uncommitted changes">●</span>
           </button>
-          <button class="wt-del" title="Remove worktree" aria-label="Remove worktree" @click="removeWorktree(w)">🗑</button>
+          <button
+            data-testid="wt-del"
+            class="flex-none cursor-pointer rounded-md border-none bg-transparent px-1.5 py-1 text-[13px] hover:bg-[var(--err-hover-bg)]"
+            title="Remove worktree"
+            aria-label="Remove worktree"
+            @click="removeWorktree(w)"
+          >
+            🗑
+          </button>
         </div>
       </div>
-      <div v-if="scripts.length" class="cell-scripts">
-        <span class="cell-launch-caption">or run a script</span>
-        <div class="cell-script-list">
-          <button v-for="s in scripts" :key="s.index" class="cell-script-item" :title="s.command" @click="runScript(s)">▶ {{ s.label }}</button>
+      <div v-if="scripts.length" class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or run a script</span>
+        <div class="flex w-full flex-wrap justify-center gap-1.5">
+          <button
+            v-for="s in scripts"
+            :key="s.index"
+            data-testid="cell-script-item"
+            class="cursor-pointer rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
+            :title="s.command"
+            @click="runScript(s)"
+          >
+            ▶ {{ s.label }}
+          </button>
         </div>
       </div>
-      <div v-if="launchers && launchers.length" class="cell-scripts">
-        <span class="cell-launch-caption">or launch</span>
-        <div class="cell-script-list">
-          <button v-for="(l, i) in launchers" :key="l.label" class="cell-script-item" :title="l.command" @click="launchProgram(i, l)">⌘ {{ l.label }}</button>
+      <div v-if="launchers && launchers.length" class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or launch</span>
+        <div class="flex w-full flex-wrap justify-center gap-1.5">
+          <button
+            v-for="(l, i) in launchers"
+            :key="l.label"
+            data-testid="cell-script-item"
+            class="cursor-pointer rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
+            :title="l.command"
+            @click="launchProgram(i, l)"
+          >
+            ⌘ {{ l.label }}
+          </button>
         </div>
       </div>
-      <div v-if="resumable.length" class="cell-resume">
-        <span class="cell-launch-caption">or resume here</span>
-        <div class="cell-resume-list">
+      <div v-if="resumable.length" data-testid="cell-resume" class="flex min-h-0 w-full max-w-[360px] flex-col items-center gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or resume here</span>
+        <div class="flex w-full flex-col gap-1">
           <button
             v-for="s in resumable"
             :key="s.id"
-            :class="['cell-resume-item', { 'is-open': sessionOpenElsewhere(s.id) }]"
+            data-testid="cell-resume-item"
+            class="flex cursor-pointer items-baseline justify-between gap-2 rounded-md border bg-deep px-2.5 py-[5px] text-left font-sans text-[12px] text-secondary hover:border-accent hover:bg-elevated"
+            :class="[{ 'is-open': sessionOpenElsewhere(s.id) }, sessionOpenElsewhere(s.id) ? 'border-amber' : 'border-border']"
             :title="sessionOpenElsewhere(s.id) ? `${s.title} — already open in another terminal` : s.title"
             @click="resume(s)"
           >
-            <span class="ri-title">{{ s.title }}</span>
-            <span v-if="sessionOpenElsewhere(s.id)" class="ri-open" title="Already open in another terminal">● open</span>
-            <span class="ri-time">{{ relativeTime(s.mtime) }}</span>
+            <span data-testid="ri-title" class="truncate">{{ s.title }}</span>
+            <span
+              v-if="sessionOpenElsewhere(s.id)"
+              data-testid="ri-open"
+              class="flex-none whitespace-nowrap text-[11px] text-amber"
+              title="Already open in another terminal"
+              >● open</span
+            >
+            <span class="flex-none text-[11px] text-dim">{{ relativeTime(s.mtime) }}</span>
           </button>
         </div>
       </div>
@@ -1462,93 +1508,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   align-items: center;
   gap: 8px;
 }
-/* Empty cell: pick a directory, then launch. */
-.cell-launch {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  /* Top-aligned: the form anchors to the top of the cell rather than floating in
-     the vertical middle (which looks adrift when there are few/no resume rows). */
-  justify-content: flex-start;
-  gap: 8px;
-  padding: 16px;
-  overflow-y: auto;
-}
-/* Dismiss an added launcher (anchored to the cell, so it stays put while the form
-   scrolls). */
-.cell-launch-cancel {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 26px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-size: 16px;
-  line-height: 1;
-  border-radius: 6px;
-}
-.cell-launch-cancel:hover {
-  background: var(--err-hover-bg);
-  color: var(--err-text);
-}
-.cell-presets {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 6px;
-  max-width: 360px;
-}
-.cell-launch-label {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  max-width: 360px;
-}
-.cell-launch-caption {
-  font-family: system-ui, sans-serif;
-  font-size: 11px;
-  color: var(--text-dim);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.cell-agent {
-  display: inline-flex;
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--bg-deep);
-  align-self: flex-start;
-}
-.cell-agent-btn {
-  border: none;
-  background: transparent;
-  color: var(--text-dim);
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  font-weight: 500;
-  padding: 4px 14px;
-  border-radius: 5px;
-}
-.cell-agent-btn:hover {
-  color: var(--text);
-}
-.cell-agent-btn.active {
-  background: var(--bg-elevated);
-  color: var(--text);
-}
 .cell-dir-input {
   width: 100%;
   box-sizing: border-box;
@@ -1595,157 +1554,5 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 .cell-start:hover {
   background: var(--bg-hover);
   color: var(--text);
-}
-
-.cell-worktrees {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 6px;
-  width: 100%;
-  max-width: 360px;
-}
-.wt-new {
-  display: flex;
-  gap: 6px;
-}
-.wt-task {
-  flex: 1 1 auto;
-  min-width: 0; /* let the input shrink so the button keeps its width */
-  width: auto;
-}
-.wt-start {
-  flex: 0 0 auto;
-  white-space: nowrap;
-}
-.wt-row {
-  display: flex;
-  gap: 6px;
-  align-items: center;
-}
-.wt-dirty {
-  margin-left: 6px;
-  color: var(--warn-text, #e0a030);
-}
-.wt-del {
-  flex: 0 0 auto;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 13px;
-  padding: 4px 6px;
-  border-radius: 6px;
-}
-.wt-del:hover {
-  background: var(--err-hover-bg);
-}
-
-.cell-scripts {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  max-width: 360px;
-}
-.cell-script-list {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 6px;
-  width: 100%;
-}
-.cell-script-item {
-  border: 1px solid #2a4e3a;
-  background: #16271d;
-  color: #b6e3c7;
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  padding: 4px 10px;
-  border-radius: 14px;
-}
-.cell-script-item:hover {
-  background: #1f3a2a;
-  border-color: #3fae6b;
-  color: #fff;
-}
-
-.cell-resume {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  max-width: 360px;
-  min-height: 0;
-}
-.cell-resume-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  width: 100%;
-}
-.cell-resume-item {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-  border: 1px solid var(--border);
-  background: var(--bg-deep);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  text-align: left;
-  padding: 5px 10px;
-  border-radius: 6px;
-}
-.cell-resume-item:hover {
-  background: var(--bg-elevated);
-  border-color: var(--accent);
-}
-.ri-title {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-.ri-time {
-  flex: 0 0 auto;
-  color: var(--text-dim);
-  font-size: 11px;
-}
-.cell-resume-item.is-open {
-  border-color: var(--amber);
-}
-.ri-open {
-  flex: 0 0 auto;
-  color: var(--amber);
-  font-size: 11px;
-  white-space: nowrap;
-}
-
-/* Worktree diff badge in the header (ahead / uncommitted), opens the diff panel. */
-.cell-wt-badge {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 1px 7px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--bg-elevated);
-  cursor: pointer;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 11px;
-}
-.cell-wt-badge:hover {
-  background: var(--bg-hover);
-}
-.wt-ahead {
-  color: var(--accent);
-}
-.wt-dirty-count {
-  color: var(--warn-text, #e0a030);
 }
 </style>

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -130,7 +130,7 @@ describe("TerminalCell", () => {
   it("launches in the dir typed in the form and sends it to the terminal", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
-    expect(w.find(".cell-launch").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
     await w.find(".cell-dir-input").setValue("/home/me/picked");
     await w.find(".cell-dir-input").trigger("keydown.enter");
     const term = w.findComponent({ name: "TerminalView" });
@@ -178,11 +178,11 @@ describe("TerminalCell", () => {
   it("shows a cancel ✕ on a cancellable launcher that emits close, but not otherwise", async () => {
     const plain = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
-    expect(plain.find(".cell-launch-cancel").exists()).toBe(false);
+    expect(plain.find('[data-testid="cell-launch-cancel"]').exists()).toBe(false);
 
     const w = mountCell(null, { defaultCwd: "/home/me/default", cancellable: true });
     await flushPromises();
-    await w.find(".cell-launch-cancel").trigger("click");
+    await w.find('[data-testid="cell-launch-cancel"]').trigger("click");
     expect(w.emitted("close")).toHaveLength(1);
   });
 
@@ -190,9 +190,9 @@ describe("TerminalCell", () => {
     mockFetch([{ id: "77777777-7777-7777-7777-777777777777", title: "fix the parser", mtime: Date.now() }]);
     const w = mountCell(null, { defaultCwd: "/home/me/proj" });
     await flushPromises();
-    const item = w.find(".cell-resume-item");
+    const item = w.find('[data-testid="cell-resume-item"]');
     expect(item.exists()).toBe(true);
-    expect(item.find(".ri-title").text()).toBe("fix the parser");
+    expect(item.find('[data-testid="ri-title"]').text()).toBe("fix the parser");
     await item.trigger("click");
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
@@ -208,11 +208,11 @@ describe("TerminalCell", () => {
     ]);
     const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: [openId] });
     await flushPromises();
-    const items = w.findAll(".cell-resume-item");
+    const items = w.findAll('[data-testid="cell-resume-item"]');
     expect(items[0].classes()).toContain("is-open");
-    expect(items[0].find(".ri-open").exists()).toBe(true);
+    expect(items[0].find('[data-testid="ri-open"]').exists()).toBe(true);
     expect(items[1].classes()).not.toContain("is-open");
-    expect(items[1].find(".ri-open").exists()).toBe(false);
+    expect(items[1].find('[data-testid="ri-open"]').exists()).toBe(false);
   });
 
   it("confirms before resuming a session open elsewhere, and bails on cancel", async () => {
@@ -221,7 +221,7 @@ describe("TerminalCell", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: [openId] });
     await flushPromises();
-    await w.find(".cell-resume-item").trigger("click");
+    await w.find('[data-testid="cell-resume-item"]').trigger("click");
     expect(confirmSpy).toHaveBeenCalledOnce();
     expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
     confirmSpy.mockRestore();
@@ -233,7 +233,7 @@ describe("TerminalCell", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: [openId] });
     await flushPromises();
-    await w.find(".cell-resume-item").trigger("click");
+    await w.find('[data-testid="cell-resume-item"]').trigger("click");
     expect(confirmSpy).toHaveBeenCalledOnce();
     expect(w.findComponent({ name: "TerminalView" }).props("sessionId")).toBe(openId);
     confirmSpy.mockRestore();
@@ -245,7 +245,7 @@ describe("TerminalCell", () => {
     const confirmSpy = vi.spyOn(window, "confirm");
     const w = mountCell(null, { defaultCwd: "/home/me/proj", openSessionIds: ["other-id"] });
     await flushPromises();
-    await w.find(".cell-resume-item").trigger("click");
+    await w.find('[data-testid="cell-resume-item"]').trigger("click");
     expect(confirmSpy).not.toHaveBeenCalled();
     expect(w.findComponent({ name: "TerminalView" }).props("sessionId")).toBe(id);
     confirmSpy.mockRestore();
@@ -261,7 +261,7 @@ describe("TerminalCell", () => {
     );
     const w = mountCell(null, { defaultCwd: "/home/me/proj" });
     await flushPromises();
-    const items = w.findAll(".cell-script-item");
+    const items = w.findAll('[data-testid="cell-script-item"]');
     expect(items).toHaveLength(2);
     expect(items[0].text()).toContain("Build");
     await items[0].trigger("click");
@@ -287,7 +287,7 @@ describe("TerminalCell", () => {
   it("shows no resume list when the dir has no sessions", async () => {
     const w = mountCell(null);
     await flushPromises();
-    expect(w.find(".cell-resume").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-resume"]').exists()).toBe(false);
   });
 
   it("ignores an out-of-order session-list response (keeps the latest dir's rows)", async () => {
@@ -310,7 +310,7 @@ describe("TerminalCell", () => {
     first.resolve({ ok: true, json: async () => ({ cwd: "/A", sessions: [{ id: "a-id", title: "A-sess", mtime: 1 }] }) });
     await flushPromises();
 
-    expect(w.findAll(".ri-title").map((x) => x.text())).toEqual(["B-sess"]);
+    expect(w.findAll('[data-testid="ri-title"]').map((x) => x.text())).toEqual(["B-sess"]);
   });
 
   it("resumes with the resolved cwd from the API, not the typed input", async () => {
@@ -322,7 +322,7 @@ describe("TerminalCell", () => {
 
     const w = mountCell(null, { defaultCwd: "/typed" });
     await flushPromises();
-    await w.find(".cell-resume-item").trigger("click");
+    await w.find('[data-testid="cell-resume-item"]').trigger("click");
     expect(w.findComponent({ name: "TerminalView" }).props("cwd")).toBe("/resolved");
   });
 
@@ -438,7 +438,7 @@ describe("TerminalCell", () => {
     mockFetch([{ id: "77777777-7777-7777-7777-777777777777", title: "fix the parser", mtime: Date.now() }]);
     const w = mountCell(null, { defaultCwd: "/home/me/proj" });
     await flushPromises();
-    await w.find(".cell-resume-item").trigger("click");
+    await w.find('[data-testid="cell-resume-item"]').trigger("click");
     w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/proj");
     await flushPromises();
     expect(w.emitted("record-cwd")).toBeUndefined();
@@ -454,7 +454,7 @@ describe("TerminalCell", () => {
     await w.find(".cell-dir-input").trigger("keydown.enter"); // flag = true, no cwd yet
     await w.find(".cell-close").trigger("click"); // teardown must clear the flag
     await flushPromises();
-    await w.find(".cell-resume-item").trigger("click"); // resume an existing session
+    await w.find('[data-testid="cell-resume-item"]').trigger("click"); // resume an existing session
     w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/proj");
     await flushPromises();
     expect(w.emitted("record-cwd")).toBeUndefined();
@@ -492,7 +492,7 @@ describe("TerminalCell", () => {
     await w.find(".cell-dir-input").trigger("keydown.enter");
     await w.find(".cell-close").trigger("click");
     await nextTick();
-    expect(w.find(".cell-launch").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
     expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/default");
   });
 
@@ -812,7 +812,7 @@ describe("TerminalCell", () => {
     mockFetchWithWorktrees([{ path: "/wt/fix-login", branch: "agent/fix-login", task: "fix-login", dirty: false }]);
     const w = mountCell(null, { defaultCwd: "/home/me/repo" });
     await flushPromises();
-    expect(w.find(".cell-worktrees").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(true);
     const rows = w.findAll('[data-testid="worktree-reuse"]');
     expect(rows).toHaveLength(1);
     expect(rows[0].text()).toContain("fix-login");
@@ -822,15 +822,15 @@ describe("TerminalCell", () => {
     mockFetch(); // default mock reports no isGit
     const w = mountCell(null, { defaultCwd: "/home/me/proj" });
     await flushPromises();
-    expect(w.find(".cell-worktrees").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-worktrees"]').exists()).toBe(false);
   });
 
   it("creates a worktree for the typed task and launches claude in it", async () => {
     const posts = mockFetchWithWorktrees([], { path: "/wt/fix-login", branch: "agent/fix-login" });
     const w = mountCell(null, { defaultCwd: "/home/me/repo" });
     await flushPromises();
-    await w.find(".wt-task").setValue("fix login");
-    await w.find(".wt-start").trigger("click");
+    await w.find('[data-testid="wt-task"]').setValue("fix login");
+    await w.find('[data-testid="wt-start"]').trigger("click");
     await flushPromises();
     const create = posts.find((p) => p.url.includes("/api/worktrees/create"));
     if (!create) throw new Error("create not called");
@@ -854,7 +854,7 @@ describe("TerminalCell", () => {
     const posts = mockFetchWithWorktrees([{ path: "/wt/done", branch: "agent/done", task: "done", dirty: false }]);
     const w = mountCell(null, { defaultCwd: "/home/me/repo" });
     await flushPromises();
-    await w.find(".wt-del").trigger("click");
+    await w.find('[data-testid="wt-del"]').trigger("click");
     await flushPromises();
     const remove = posts.find((p) => p.url.includes("/api/worktrees/remove"));
     if (!remove) throw new Error("remove not called");
@@ -866,8 +866,8 @@ describe("TerminalCell", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const w = mountCell(null, { defaultCwd: "/home/me/repo" });
     await flushPromises();
-    expect(w.find(".wt-dirty").exists()).toBe(true); // the ● uncommitted-changes marker
-    await w.find(".wt-del").trigger("click");
+    expect(w.find('[data-testid="wt-dirty"]').exists()).toBe(true); // the ● uncommitted-changes marker
+    await w.find('[data-testid="wt-del"]').trigger("click");
     await flushPromises();
     expect(confirmSpy).toHaveBeenCalled();
     const remove = posts.find((p) => p.url.includes("/api/worktrees/remove"));
@@ -881,7 +881,7 @@ describe("TerminalCell", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     const w = mountCell(null, { defaultCwd: "/home/me/repo" });
     await flushPromises();
-    await w.find(".wt-del").trigger("click");
+    await w.find('[data-testid="wt-del"]').trigger("click");
     await flushPromises();
     expect(posts.some((p) => p.url.includes("/api/worktrees/remove"))).toBe(false);
     confirmSpy.mockRestore();
@@ -915,10 +915,10 @@ describe("TerminalCell", () => {
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
 
-    const badge = w.find(".cell-wt-badge");
+    const badge = w.find('[data-testid="cell-wt-badge"]');
     expect(badge.exists()).toBe(true);
-    expect(badge.find(".wt-ahead").text()).toBe("+3");
-    expect(badge.find(".wt-dirty-count").text()).toBe("●2");
+    expect(badge.find('[data-testid="wt-ahead"]').text()).toBe("+3");
+    expect(badge.find('[data-testid="wt-dirty-count"]').text()).toBe("●2");
 
     expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false); // panel closed initially
     await badge.trigger("click");
@@ -936,14 +936,14 @@ describe("TerminalCell", () => {
     mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 0, dirty: 0, files: [], patch: "", truncated: false });
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
-    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-wt-badge"]').exists()).toBe(false);
   });
 
   it("never shows the diff badge for a non-worktree cell", async () => {
     mockFetchWithDiff({ isWorktree: false, base: null, ahead: 9, dirty: 9, files: [], patch: "", truncated: false });
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: "/home/me/regular-proj" });
     await flushPromises();
-    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-wt-badge"]').exists()).toBe(false);
   });
 
   it("bootstraps the diff badge when RESUMING an idle worktree session", async () => {
@@ -956,21 +956,21 @@ describe("TerminalCell", () => {
     }) as unknown as typeof fetch;
     const w = mountCell(null, { defaultCwd: WT_CWD });
     await flushPromises();
-    await w.find(".cell-resume-item").trigger("click"); // resume the idle worktree session
+    await w.find('[data-testid="cell-resume-item"]').trigger("click"); // resume the idle worktree session
     await flushPromises();
-    expect(w.find(".cell-wt-badge").exists()).toBe(true);
-    expect(w.find(".wt-ahead").text()).toBe("+2");
+    expect(w.find('[data-testid="cell-wt-badge"]').exists()).toBe(true);
+    expect(w.find('[data-testid="wt-ahead"]').text()).toBe("+2");
   });
 
   it("clears the diff badge when the cwd falls back to a non-worktree dir", async () => {
     mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 3, dirty: 1, files: [], patch: "", truncated: false });
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
-    expect(w.find(".cell-wt-badge").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-wt-badge"]').exists()).toBe(true);
     // server confirms a different, non-worktree dir → badge must not linger
     w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/plain-proj");
     await flushPromises();
-    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-wt-badge"]').exists()).toBe(false);
   });
 
   it("auto-closes the open diff panel when the cwd leaves the worktree (no empty overlay)", async () => {
@@ -985,7 +985,7 @@ describe("TerminalCell", () => {
     });
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
-    await w.find(".cell-wt-badge").trigger("click");
+    await w.find('[data-testid="cell-wt-badge"]').trigger("click");
     await flushPromises();
     expect(w.find('[data-testid="cell-diff"]').exists()).toBe(true);
     // leaving the worktree clears `diff`; the panel must not linger as an empty overlay
@@ -998,7 +998,7 @@ describe("TerminalCell", () => {
     mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 2, dirty: 0, files: [], patch: "x", truncated: false });
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
-    await w.find(".cell-wt-badge").trigger("click"); // user opens the panel
+    await w.find('[data-testid="cell-wt-badge"]').trigger("click"); // user opens the panel
     await flushPromises();
     expect(w.find('[data-testid="cell-diff"]').exists()).toBe(true);
 
@@ -1009,7 +1009,7 @@ describe("TerminalCell", () => {
 
     term.vm.$emit("cwd", WT_CWD); // re-enter a worktree
     await flushPromises();
-    expect(w.find(".cell-wt-badge").exists()).toBe(true); // badge returns…
+    expect(w.find('[data-testid="cell-wt-badge"]').exists()).toBe(true); // badge returns…
     expect(w.find('[data-testid="cell-diff"]').exists()).toBe(false); // …but the panel stays closed until clicked
   });
 
@@ -1017,7 +1017,7 @@ describe("TerminalCell", () => {
     mockFetchWithDiff({ isWorktree: true, base: "main", ahead: 1, dirty: 0, files: [], patch: "x", truncated: false });
     const w = mountCell("66666666-6666-6666-6666-666666666666", { initialCwd: WT_CWD });
     await flushPromises();
-    await w.find(".cell-wt-badge").trigger("click");
+    await w.find('[data-testid="cell-wt-badge"]').trigger("click");
     await flushPromises();
     expect(w.find('[data-testid="cell-diff"]').exists()).toBe(true);
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" })); // focus may be on the badge/terminal
@@ -1042,7 +1042,7 @@ describe("TerminalCell", () => {
     // the stale worktree diff now resolves — it must not repopulate the badge
     diffFetch.resolve({ ok: true, json: async () => ({ isWorktree: true, base: "main", ahead: 5, dirty: 5, files: [], patch: "", truncated: false }) });
     await flushPromises();
-    expect(w.find(".cell-wt-badge").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-wt-badge"]').exists()).toBe(false);
   });
 
   // Slice 2 — push / open-PR actions in the diff panel footer.
@@ -1069,7 +1069,7 @@ describe("TerminalCell", () => {
     truncated: false,
   });
   const openPanel = async (w: ReturnType<typeof mountCell>) => {
-    await w.find(".cell-wt-badge").trigger("click");
+    await w.find('[data-testid="cell-wt-badge"]').trigger("click");
     await flushPromises();
   };
 
@@ -1278,7 +1278,7 @@ describe("TerminalCell", () => {
     await w.find(".cell-close").trigger("click");
     await nextTick();
     expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(false);
-    expect(w.find(".cell-launch").exists()).toBe(true); // torn down to the launcher
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true); // torn down to the launcher
   });
 
   it("Keep worktree tears the cell down WITHOUT removing the room", async () => {
@@ -1289,7 +1289,7 @@ describe("TerminalCell", () => {
     await w.find('[data-testid="ccx-keep"]').trigger("click");
     await flushPromises();
     expect(posts.some((p) => p.url.includes("/api/worktrees/remove"))).toBe(false);
-    expect(w.find(".cell-launch").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
   });
 
   it("Remove worktree posts a forced remove (path+repoDir = the worktree) then closes", async () => {
@@ -1303,7 +1303,7 @@ describe("TerminalCell", () => {
     const rm = posts.find((p) => p.url.includes("/api/worktrees/remove"));
     if (!rm) throw new Error("remove not called");
     expect(JSON.parse(rm.body)).toMatchObject({ repoDir: WT_CWD, path: WT_CWD, deleteBranch: true, force: true });
-    expect(w.find(".cell-launch").exists()).toBe(true);
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
   });
 
   it("holds Remove (Checking…) until the fresh diff load completes", async () => {
@@ -1344,7 +1344,7 @@ describe("TerminalCell", () => {
     await w.find('[data-testid="ccx-remove"]').trigger("click");
     await flushPromises();
     expect(w.find('[data-testid="cell-close-confirm"]').exists()).toBe(true); // NOT torn down
-    expect(w.find(".cell-launch").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-launch"]').exists()).toBe(false);
     expect(w.find('[data-testid="ccx-warn"]').text()).toContain("Couldn't remove");
   });
 


### PR DESCRIPTION
## Summary

Batched slice of `TerminalCell.vue` — the whole **empty-cell launcher screen**: launch container + cancel button, preset row, captions, agent radiogroup, worktree list, script/launcher chips, resume list, and the header worktree-diff badge. **34 rules removed; scoped CSS 430 → 191 lines.**

Batched deliberately: these panels are all self-contained (zero overlap with the shared `cellChrome` classes), so one build/verify/CI cycle instead of six.

## Render-verification caught a real bug

The active agent button had `bg-transparent` in the shared base **and** `bg-elevated` in the conditional — the two background utilities raced and **the active tint was lost** (`rgb(32,32,58)` → `rgba(0,0,0,0)`). `bg-transparent` now lives only on the inactive branch.

This is precisely the failure mode a built-CSS grep cannot see, and why every slice is now verified by rendering.

## Verification

- Every computed property of 26 elements compared against the original markup + original rules. After the fix, the only differences are `border-*-color` on elements whose `border-style` is `none` — unpaintable either way.
- **Pixel-identical** to the original at 3× DPR across the whole panel set: `identical: true`.
- Full suite 1483 passed, typecheck clean.

## Items to Confirm / Review

- **`--warn-text` is undefined app-wide**, so `wt-dirty` / `wt-dirty-count` keep `var(--warn-text,#e0a030)` verbatim.
- Test selectors for all panel classes → `data-testid`; `is-open` stays as a state marker on the resume row.

## Progress

TerminalCell **751 → 191**. What's left is the cell chrome itself (`.cell`, `.cell.is-*`, `.cell-header*`, `.cell-dot.is-*`) plus `.cell-dir*` / `.cell-start` — the parts entangled with the shared `cellChromeBase.css`, which need the layering decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)