### PR TITLE
refactor: layer the shared cell chrome, convert TerminalCell header + dir form

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -889,21 +889,37 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
              model / tokens / custom) don't shrink, so without this they would overflow and
              push the actions past the cell's `overflow: hidden` edge — the buttons must
              stay reachable no matter how much a dir's config crams in here. -->
-        <div class="cell-header-main">
+        <div data-testid="cell-header-main" class="flex min-w-0 flex-auto items-center gap-2 overflow-hidden">
           <span class="cell-dot" :class="statusClass" :title="statusLabel" />
           <!-- Normal grid: the dir is a button that opens it. As a filmstrip thumbnail the
                header's job is to zoom (switch to this terminal), so the dir is inert text
                and a click on it falls through to the header's zoom gesture. -->
-          <button v-if="headerDir && !filmstrip" type="button" class="cell-dir" :title="cwd ? `Open ${cwd}` : ''" @click="openDir">
-            <span class="cell-dir-path">{{ headerDir }}</span>
+          <button
+            v-if="headerDir && !filmstrip"
+            type="button"
+            class="cell-dir flex-initial min-w-[16ch] max-w-[60%] cursor-pointer truncate border-none bg-transparent p-0 text-left font-mono text-[11px] text-[var(--cell-header-fg,var(--text-dim))] [direction:rtl] hover:text-muted hover:underline"
+            :title="cwd ? `Open ${cwd}` : ''"
+            @click="openDir"
+          >
+            <span class="cell-dir-path [unicode-bidi:plaintext]">{{ headerDir }}</span>
           </button>
-          <span v-else-if="headerDir" class="cell-dir" :title="cwd ?? ''">
-            <span class="cell-dir-path">{{ headerDir }}</span>
+          <span
+            v-else-if="headerDir"
+            class="cell-dir flex-initial min-w-[16ch] max-w-[60%] cursor-pointer truncate border-none bg-transparent p-0 text-left font-mono text-[11px] text-[var(--cell-header-fg,var(--text-dim))] [direction:rtl] hover:text-muted hover:underline"
+            :title="cwd ?? ''"
+          >
+            <span class="cell-dir-path [unicode-bidi:plaintext]">{{ headerDir }}</span>
           </span>
           <!-- Info (dir badge / git / diff / model / tokens) is dropped on a filmstrip
                thumbnail, leaving only dir + what it's doing + a zoom button. -->
           <template v-if="!filmstrip">
-            <span v-if="dirConfig.name" class="cell-badge" :style="dirBadgeStyle" :title="dirConfig.name">{{ dirConfig.name }}</span>
+            <span
+              v-if="dirConfig.name"
+              class="max-w-[14ch] flex-none truncate rounded-[10px] px-[7px] py-px font-sans text-[11px] font-semibold"
+              :style="dirBadgeStyle"
+              :title="dirConfig.name"
+              >{{ dirConfig.name }}</span
+            >
             <template v-for="chip in cellChips" :key="chip.key">
               <GitBranchChip v-if="chip.builtin === 'git'" :status="gitStatus" :hide-dirty="isWorktreeCell" />
               <button
@@ -918,11 +934,28 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
                 <span v-if="diff.dirty > 0" data-testid="wt-dirty-count" class="text-[var(--warn-text,#e0a030)]">●{{ diff.dirty }}</span>
               </button>
               <ModelContextBadge v-else-if="chip.builtin === 'ctx' && context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
-              <span v-else-if="chip.builtin === 'usage' && showUsage" class="cell-usage" :title="usageTitle">{{ usageLabel }}</span>
-              <span v-else-if="chip.custom" class="cell-hdr-chip" :title="chip.custom.label || chip.custom.text">{{ chip.custom.text }}</span>
+              <span
+                v-else-if="chip.builtin === 'usage' && showUsage"
+                data-testid="cell-usage"
+                class="flex-none whitespace-nowrap font-mono text-[10px] tracking-[0.02em] text-dim"
+                :title="usageTitle"
+                >{{ usageLabel }}</span
+              >
+              <span
+                v-else-if="chip.custom"
+                data-testid="cell-hdr-chip"
+                class="flex-none whitespace-nowrap rounded-full border border-border px-1.5 py-px text-[10px] text-dim"
+                :title="chip.custom.label || chip.custom.text"
+                >{{ chip.custom.text }}</span
+              >
             </template>
           </template>
-          <span class="cell-prompt" :title="lastPrompt || aiTitle || ''">{{ headerText }}</span>
+          <span
+            data-testid="cell-prompt"
+            class="min-w-0 flex-auto truncate font-sans text-[12px] text-[var(--cell-header-fg,var(--text-secondary))]"
+            :title="lastPrompt || aiTitle || ''"
+            >{{ headerText }}</span
+          >
         </div>
         <!-- Expand/restore + close stay on row 1 (the info row) and OUTSIDE the info
              track, so they're always pinned top-right. `.stop` so they don't trigger the
@@ -1235,10 +1268,11 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
       </div>
       <label class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
         <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Working directory</span>
-        <span class="cell-dir-row">
+        <span class="flex w-full items-stretch gap-1.5">
           <input
             v-model="dirInput"
-            class="cell-dir-input"
+            data-testid="cell-dir-input"
+            class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] font-mono text-[12px] text-fg focus:border-accent focus:outline-none min-w-0 flex-auto"
             type="text"
             placeholder="/path/to/project"
             spellcheck="false"
@@ -1256,13 +1290,17 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           </button>
           <button
             type="button"
-            class="cell-dir-go"
+            data-testid="cell-dir-go"
+            class="cursor-default opacity-40"
             :disabled="!dirInput.trim()"
             title="Start a new terminal here (or press Enter)"
             aria-label="Start a new terminal here"
             @click="launch"
           >
-            <span class="material-symbols-outlined text-[14px]">play_arrow</span>
+            <span
+              class="material-symbols-outlined cursor-pointer rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary"
+              >play_arrow</span
+            >
           </button>
         </span>
       </label>
@@ -1272,14 +1310,19 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <input
             v-model="worktreeTask"
             data-testid="wt-task"
-            class="cell-dir-input w-auto min-w-0 flex-auto"
+            class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] font-mono text-[12px] text-fg focus:border-accent focus:outline-none w-auto min-w-0 flex-auto"
             type="text"
             placeholder="task name (e.g. fix-login)"
             aria-label="Worktree task name"
             spellcheck="false"
             @keydown.enter="createWorktreeAndLaunch"
           />
-          <button data-testid="wt-start" class="cell-start flex-none whitespace-nowrap" :disabled="!worktreeTask.trim()" @click="createWorktreeAndLaunch">
+          <button
+            data-testid="wt-start"
+            class="cursor-pointer rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary flex-none whitespace-nowrap hover:bg-hover hover:text-fg"
+            :disabled="!worktreeTask.trim()"
+            @click="createWorktreeAndLaunch"
+          >
             ＋ New worktree
           </button>
         </div>
@@ -1423,80 +1466,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   background: var(--amber);
 }
 
-.cell-dir {
-  flex: 0 1 auto;
-  /* Floor the width at ~15 chars of the path so the current dir stays readable
-     even on a narrow cell (1ch ≈ one monospace char; the leading … takes one). */
-  min-width: 16ch;
-  max-width: 60%;
-  border: none;
-  background: none;
-  padding: 0;
-  text-align: left;
-  cursor: pointer;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 11px;
-  color: var(--cell-header-fg, var(--text-dim));
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  /* Truncate from the FRONT so the tail (the project dir) stays visible: in an
-     rtl box the ellipsis falls on the left. The inner span keeps the path itself
-     in natural left-to-right order (plaintext base direction). */
-  direction: rtl;
-}
-.cell-dir-path {
-  unicode-bidi: plaintext;
-}
-/* Project badge from <cwd>/.mulmoterminal.json — a per-directory identity chip. */
-.cell-badge {
-  flex: 0 0 auto;
-  max-width: 14ch;
-  padding: 1px 7px;
-  border-radius: 10px;
-  font-family: system-ui, sans-serif;
-  font-size: 11px;
-  font-weight: 600;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.cell-dir:hover {
-  color: var(--text-muted);
-  text-decoration: underline;
-}
-.cell-prompt {
-  flex: 1 1 auto;
-  min-width: 0;
-  font-family: system-ui, sans-serif;
-  font-size: 12px;
-  color: var(--cell-header-fg, var(--text-secondary));
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* Per-cell token usage: ⇡ input · ⇣ output. Dim + monospace so it reads as metadata. */
-.cell-usage {
-  flex: 0 0 auto;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 10px;
-  color: var(--text-dim);
-  white-space: nowrap;
-  letter-spacing: 0.02em;
-}
-
-/* A user-defined display-only chip (from the `chips` config). */
-.cell-hdr-chip {
-  flex: 0 0 auto;
-  font-size: 10px;
-  color: var(--text-dim);
-  white-space: nowrap;
-  padding: 1px 6px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-}
-
 /* The info track absorbs all the width pressure: it grows into the free space and,
    crucially, is allowed to shrink below its content (min-width: 0) and clip. That keeps
    the non-shrinking chips from pushing .cell-actions out of the cell. */
@@ -1507,52 +1476,5 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
   display: flex;
   align-items: center;
   gap: 8px;
-}
-.cell-dir-input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 7px 10px;
-  background: var(--bg-input);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--text);
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 12px;
-}
-.cell-dir-input:focus {
-  outline: none;
-  border-color: var(--accent);
-}
-.cell-dir-row {
-  display: flex;
-  align-items: stretch;
-  gap: 6px;
-  width: 100%;
-}
-.cell-dir-row .cell-dir-input {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-.cell-dir-go,
-.cell-dir-go:hover:not(:disabled),
-.cell-dir-go:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-.cell-dir-go .material-symbols-outlined,
-.cell-start {
-  border: 1px solid var(--border);
-  background: var(--bg-elevated);
-  color: var(--text-secondary);
-  cursor: pointer;
-  font-family: system-ui, sans-serif;
-  font-size: 14px;
-  font-weight: 500;
-  padding: 7px 16px;
-  border-radius: 6px;
-}
-.cell-start:hover {
-  background: var(--bg-hover);
-  color: var(--text);
 }
 </style>

--- a/src/components/cellChrome.css
+++ b/src/components/cellChrome.css
@@ -1,59 +1,65 @@
-/* Frame + header/path/label chrome specific to the non-Claude grid cells
-   (CommandCell, LauncherCell). The rules identical to every cell kind — the
-   zoomable-header affordance, the status dot, the action buttons — live in
-   cellChromeBase.css, which these two import alongside this file. Colors are the
-   same theme tokens TerminalCell uses, so all three cell kinds recolor together
-   when the app theme changes, and pick up a directory's .mulmoterminal.json tint
-   through the same override vars the moment one is set. */
-.cell {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
-  background: var(--cell-bg, var(--bg-base));
-  border: 1px solid var(--cell-border, var(--border));
-  border-radius: 6px;
-  overflow: hidden;
-}
+/* Wrapped in @layer components so Tailwind utilities (@layer utilities, declared
+   last) can override this shared chrome on a per-cell basis. Unlayered it beats
+   every utility regardless of specificity. Each component's own <style scoped>
+   stays unlayered and therefore still wins over these, exactly as before. */
+@layer components {
+  /* Frame + header/path/label chrome specific to the non-Claude grid cells
+     (CommandCell, LauncherCell). The rules identical to every cell kind — the
+     zoomable-header affordance, the status dot, the action buttons — live in
+     cellChromeBase.css, which these two import alongside this file. Colors are the
+     same theme tokens TerminalCell uses, so all three cell kinds recolor together
+     when the app theme changes, and pick up a directory's .mulmoterminal.json tint
+     through the same override vars the moment one is set. */
+  .cell {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    background: var(--cell-bg, var(--bg-base));
+    border: 1px solid var(--cell-border, var(--border));
+    border-radius: 6px;
+    overflow: hidden;
+  }
 
-.cell-header {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  height: 34px;
-  padding: 0 8px;
-  background: var(--cell-header-bg, var(--bg-panel));
-  border-bottom: 1px solid var(--border);
-}
+  .cell-header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 34px;
+    padding: 0 8px;
+    background: var(--cell-header-bg, var(--bg-panel));
+    border-bottom: 1px solid var(--border);
+  }
 
-.cell-dir {
-  flex: 0 1 auto;
-  /* Floor the width at ~15 chars of the path so the current dir stays readable
-     even on a narrow cell (1ch ≈ one monospace char; the leading … takes one). */
-  min-width: 16ch;
-  max-width: 45%;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 11px;
-  color: var(--cell-header-fg, var(--text-dim));
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  /* Truncate from the FRONT so the tail (the project dir) stays visible. */
-  direction: rtl;
-  /* Left-align so a short path hugs the dot instead of floating right (rtl). */
-  text-align: left;
-}
-.cell-dir-path {
-  unicode-bidi: plaintext;
-}
-.cell-cmd {
-  flex: 1 1 auto;
-  min-width: 0;
-  font-family: ui-monospace, "JetBrains Mono", monospace;
-  font-size: 12px;
-  color: var(--text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  .cell-dir {
+    flex: 0 1 auto;
+    /* Floor the width at ~15 chars of the path so the current dir stays readable
+       even on a narrow cell (1ch ≈ one monospace char; the leading … takes one). */
+    min-width: 16ch;
+    max-width: 45%;
+    font-family: ui-monospace, "JetBrains Mono", monospace;
+    font-size: 11px;
+    color: var(--cell-header-fg, var(--text-dim));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    /* Truncate from the FRONT so the tail (the project dir) stays visible. */
+    direction: rtl;
+    /* Left-align so a short path hugs the dot instead of floating right (rtl). */
+    text-align: left;
+  }
+  .cell-dir-path {
+    unicode-bidi: plaintext;
+  }
+  .cell-cmd {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-family: ui-monospace, "JetBrains Mono", monospace;
+    font-size: 12px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }

--- a/src/components/cellChromeBase.css
+++ b/src/components/cellChromeBase.css
@@ -1,66 +1,72 @@
-/* The grid-cell chrome rules that are identical across every cell kind — the Claude
-   cell (TerminalCell), the command cell, and the launcher cell: the zoomable-header
-   affordance, the status dot's working/pulse animation, and the action buttons. Each
-   cell's own stylesheet layers its cell-specific rules (frame, header tint, dir, and
-   any status states) on top. */
-.cell-header.is-zoomable {
-  cursor: pointer;
-}
-.cell-header.is-zoomable:hover {
-  background: var(--bg-hover);
-}
-
-.cell-dot {
-  flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  /* Custom color tints the idle dot; the status classes override it while active. */
-  background: var(--cell-dot, var(--text-dim));
-}
-.cell-dot.is-working {
-  background: var(--accent);
-  animation: pulse 1.2s ease-in-out infinite;
-}
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
+/* Wrapped in @layer components so Tailwind utilities (@layer utilities, declared
+   last) can override this shared chrome on a per-cell basis. Unlayered it beats
+   every utility regardless of specificity. Each component's own <style scoped>
+   stays unlayered and therefore still wins over these, exactly as before. */
+@layer components {
+  /* The grid-cell chrome rules that are identical across every cell kind — the Claude
+     cell (TerminalCell), the command cell, and the launcher cell: the zoomable-header
+     affordance, the status dot's working/pulse animation, and the action buttons. Each
+     cell's own stylesheet layers its cell-specific rules (frame, header tint, dir, and
+     any status states) on top. */
+  .cell-header.is-zoomable {
+    cursor: pointer;
   }
-  50% {
-    opacity: 0.35;
+  .cell-header.is-zoomable:hover {
+    background: var(--bg-hover);
   }
-}
 
-.cell-actions {
-  flex: 0 0 auto;
-  display: flex;
-  gap: 4px;
-}
-.cell-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 26px;
-  border: none;
-  background: transparent;
-  color: var(--cell-btn, var(--text-secondary));
-  cursor: pointer;
-  font-size: 16px;
-  line-height: 1;
-  border-radius: 6px;
-}
-.cell-btn:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-.cell-close:hover {
-  background: var(--err-hover-bg);
-  color: var(--err-text);
-}
+  .cell-dot {
+    flex: 0 0 auto;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    /* Custom color tints the idle dot; the status classes override it while active. */
+    background: var(--cell-dot, var(--text-dim));
+  }
+  .cell-dot.is-working {
+    background: var(--accent);
+    animation: pulse 1.2s ease-in-out infinite;
+  }
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.35;
+    }
+  }
 
-.cell-term {
-  flex: 1;
-  min-height: 0;
+  .cell-actions {
+    flex: 0 0 auto;
+    display: flex;
+    gap: 4px;
+  }
+  .cell-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 26px;
+    border: none;
+    background: transparent;
+    color: var(--cell-btn, var(--text-secondary));
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    border-radius: 6px;
+  }
+  .cell-btn:hover {
+    background: var(--bg-hover);
+    color: var(--text);
+  }
+  .cell-close:hover {
+    background: var(--err-hover-bg);
+    color: var(--err-text);
+  }
+
+  .cell-term {
+    flex: 1;
+    min-height: 0;
+  }
 }

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -34,7 +34,7 @@ vi.mock("../../../src/components/Terminal.vue", () => ({
   },
 }));
 
-const promptText = (w: ReturnType<typeof mount>) => w.find(".cell-prompt").text();
+const promptText = (w: ReturnType<typeof mount>) => w.find('[data-testid="cell-prompt"]').text();
 const dotClass = (w: ReturnType<typeof mount>) => w.find(".cell-dot").classes();
 
 // Route by URL: /api/scripts (run list), /api/sessions (resume list), or
@@ -131,8 +131,8 @@ describe("TerminalCell", () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
     expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
-    await w.find(".cell-dir-input").setValue("/home/me/picked");
-    await w.find(".cell-dir-input").trigger("keydown.enter");
+    await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/picked");
+    await w.find('[data-testid="cell-dir-input"]').trigger("keydown.enter");
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/home/me/picked");
@@ -141,8 +141,8 @@ describe("TerminalCell", () => {
   it("launches via the go button next to the field (alternative to Enter)", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
-    await w.find(".cell-dir-input").setValue("/home/me/picked");
-    await w.find(".cell-dir-go").trigger("click");
+    await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/picked");
+    await w.find('[data-testid="cell-dir-go"]').trigger("click");
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/home/me/picked");
@@ -151,10 +151,10 @@ describe("TerminalCell", () => {
   it("disables the go button when the field is empty", async () => {
     const w = mountCell(null, { defaultCwd: null });
     await flushPromises();
-    await w.find(".cell-dir-input").setValue("   ");
-    expect((w.find(".cell-dir-go").element as HTMLButtonElement).disabled).toBe(true);
-    await w.find(".cell-dir-input").setValue("/home/me/picked");
-    expect((w.find(".cell-dir-go").element as HTMLButtonElement).disabled).toBe(false);
+    await w.find('[data-testid="cell-dir-input"]').setValue("   ");
+    expect((w.find('[data-testid="cell-dir-go"]').element as HTMLButtonElement).disabled).toBe(true);
+    await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/picked");
+    expect((w.find('[data-testid="cell-dir-go"]').element as HTMLButtonElement).disabled).toBe(false);
   });
 
   it("the folder button opens the OS folder picker and fills the working directory", async () => {
@@ -172,7 +172,7 @@ describe("TerminalCell", () => {
     await w.find('[aria-label="Choose the working directory"]').trigger("click");
     await flushPromises();
     expect(body).toContain('"directory":true');
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/picked/dir");
+    expect((w.find('[data-testid="cell-dir-input"]').element as HTMLInputElement).value).toBe("/picked/dir");
   });
 
   it("shows a cancel ✕ on a cancellable launcher that emits close, but not otherwise", async () => {
@@ -280,7 +280,7 @@ describe("TerminalCell", () => {
     const w = mountCell(id, { initialCwd: "/home/me/proj" });
     await flushPromises();
 
-    expect(w.find(".cell-prompt").text()).toBe("refactor the parser");
+    expect(w.find('[data-testid="cell-prompt"]').text()).toBe("refactor the parser");
     expect(urls.some((u) => u.includes(`/api/session/${id}`) && u.includes("cwd=%2Fhome%2Fme%2Fproj"))).toBe(true);
   });
 
@@ -334,7 +334,7 @@ describe("TerminalCell", () => {
     await main.trigger("click");
     // No terminal — the main click only selects the directory (fill, not launch).
     expect(w.findComponent({ name: "TerminalView" }).exists()).toBe(false);
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/work/proj");
+    expect((w.find('[data-testid="cell-dir-input"]').element as HTMLInputElement).value).toBe("/work/proj");
   });
 
   it("the chip's ▶ launch button quick-starts a fresh session in its dir", async () => {
@@ -382,7 +382,7 @@ describe("TerminalCell", () => {
       const sessionCalls = () =>
         (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter((c) => String(c[0]).includes("/api/sessions")).length;
 
-      await w.find(".cell-dir-input").setValue("/typed"); // schedules a 300ms debounced load
+      await w.find('[data-testid="cell-dir-input"]').setValue("/typed"); // schedules a 300ms debounced load
       const before = sessionCalls();
 
       const main = w.findAll('[data-testid="cell-chip-main"]').find((b) => b.text() === "x");
@@ -407,8 +407,8 @@ describe("TerminalCell", () => {
     // auto-record that dir as a preset (the parent persists it to config).
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
-    await w.find(".cell-dir-input").setValue("/home/me/alpha");
-    await w.find(".cell-dir-input").trigger("keydown.enter");
+    await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/alpha");
+    await w.find('[data-testid="cell-dir-input"]').trigger("keydown.enter");
     w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/alpha");
     await flushPromises();
     expect(w.emitted("record-cwd")?.at(-1)).toEqual(["/home/me/alpha"]);
@@ -450,8 +450,8 @@ describe("TerminalCell", () => {
     mockFetch([{ id: "77777777-7777-7777-7777-777777777777", title: "t", mtime: Date.now() }]);
     const w = mountCell(null, { defaultCwd: "/home/me/proj" });
     await flushPromises();
-    await w.find(".cell-dir-input").setValue("/home/me/fresh");
-    await w.find(".cell-dir-input").trigger("keydown.enter"); // flag = true, no cwd yet
+    await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/fresh");
+    await w.find('[data-testid="cell-dir-input"]').trigger("keydown.enter"); // flag = true, no cwd yet
     await w.find(".cell-close").trigger("click"); // teardown must clear the flag
     await flushPromises();
     await w.find('[data-testid="cell-resume-item"]').trigger("click"); // resume an existing session
@@ -463,7 +463,7 @@ describe("TerminalCell", () => {
   it("prefills the launch field with the most recent preset (not the server default)", async () => {
     const w = mountCell(null, { presets: [{ label: "last", path: "/home/me/last-used" }], defaultCwd: "/home/me/default" });
     await flushPromises();
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/last-used");
+    expect((w.find('[data-testid="cell-dir-input"]').element as HTMLInputElement).value).toBe("/home/me/last-used");
   });
 
   it("syncs a late-arriving preset into the pristine launch field (open-before-config-load)", async () => {
@@ -471,36 +471,36 @@ describe("TerminalCell", () => {
     // and the field falls back to the server default.
     const w = mountCell(null, { presets: [], defaultCwd: "/home/me/default" });
     await flushPromises();
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/default");
+    expect((w.find('[data-testid="cell-dir-input"]').element as HTMLInputElement).value).toBe("/home/me/default");
     // /api/config resolves, delivering the most-recent preset — the pristine field upgrades.
     await w.setProps({ presets: [{ label: "alpha", path: "/home/me/alpha" }] });
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/alpha");
+    expect((w.find('[data-testid="cell-dir-input"]').element as HTMLInputElement).value).toBe("/home/me/alpha");
   });
 
   it("does NOT override a user-edited launch field when presets arrive late", async () => {
     const w = mountCell(null, { presets: [], defaultCwd: "/home/me/default" });
     await flushPromises();
-    await w.find(".cell-dir-input").setValue("/home/me/typed");
+    await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/typed");
     await w.setProps({ presets: [{ label: "alpha", path: "/home/me/alpha" }] });
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/typed");
+    expect((w.find('[data-testid="cell-dir-input"]').element as HTMLInputElement).value).toBe("/home/me/typed");
   });
 
   it("resets the launch form to the default dir after close", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
-    await w.find(".cell-dir-input").setValue("/home/me/picked");
-    await w.find(".cell-dir-input").trigger("keydown.enter");
+    await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/picked");
+    await w.find('[data-testid="cell-dir-input"]').trigger("keydown.enter");
     await w.find(".cell-close").trigger("click");
     await nextTick();
     expect(w.find('[data-testid="cell-launch"]').exists()).toBe(true);
-    expect((w.find(".cell-dir-input").element as HTMLInputElement).value).toBe("/home/me/default");
+    expect((w.find('[data-testid="cell-dir-input"]').element as HTMLInputElement).value).toBe("/home/me/default");
   });
 
   it("adopts the EFFECTIVE cwd the server reports (persists/shows that, not the typed one)", async () => {
     const w = mountCell(null, { defaultCwd: "/home/me/default" });
     await flushPromises();
-    await w.find(".cell-dir-input").setValue("relative/bad/path");
-    await w.find(".cell-dir-input").trigger("keydown.enter");
+    await w.find('[data-testid="cell-dir-input"]').setValue("relative/bad/path");
+    await w.find('[data-testid="cell-dir-input"]').trigger("keydown.enter");
     // Server rejected the bad path and fell back; it reports the real cwd.
     w.findComponent({ name: "TerminalView" }).vm.$emit("cwd", "/home/me/default");
     await nextTick();
@@ -546,7 +546,7 @@ describe("TerminalCell", () => {
     }) as unknown as typeof fetch;
     const w = mountCell(id);
     await flushPromises();
-    const badge = w.find(".cell-usage");
+    const badge = w.find('[data-testid="cell-usage"]');
     expect(badge.exists()).toBe(true);
     expect(badge.text()).toContain("2.0k"); // input 1200 + cacheRead 800 = 2000
     expect(badge.text()).toContain("3.4k"); // output 3400
@@ -601,8 +601,8 @@ describe("TerminalCell", () => {
     }) as unknown as typeof fetch;
     const w = mountCell(id, { initialCwd: "/home/me/proj" });
     await flushPromises();
-    expect(w.find(".cell-hdr-chip").text()).toBe("prod"); // custom chip renders its substituted text
-    expect(w.find(".cell-usage").exists()).toBe(true); // usage is listed
+    expect(w.find('[data-testid="cell-hdr-chip"]').text()).toBe("prod"); // custom chip renders its substituted text
+    expect(w.find('[data-testid="cell-usage"]').exists()).toBe(true); // usage is listed
     expect(w.find('[data-testid="model-badge"]').exists()).toBe(false); // ctx omitted from the list → hidden despite context set
   });
 
@@ -636,7 +636,7 @@ describe("TerminalCell", () => {
     }) as unknown as typeof fetch;
     const w = mountCell(id, { initialCwd: "/home/me/proj" });
     await flushPromises();
-    expect(w.findAll(".cell-usage")).toHaveLength(2); // both duplicates render, unique keys → no collision
+    expect(w.findAll('[data-testid="cell-usage"]')).toHaveLength(2); // both duplicates render, unique keys → no collision
   });
 
   it("shows no model badge when the session has no model yet", async () => {
@@ -1408,12 +1408,12 @@ describe("TerminalCell", () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj" });
     await flushPromises();
     // The info (dot / dir / chips / prompt) lives in the shrinkable, clipping track…
-    expect(w.find(".cell-header > .cell-header-main").exists()).toBe(true);
-    expect(w.find(".cell-header-main .cell-dir").exists()).toBe(true);
-    expect(w.find(".cell-header-main .cell-prompt").exists()).toBe(true);
+    expect(w.find('.cell-header > [data-testid="cell-header-main"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-header-main"] .cell-dir').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-header-main"] [data-testid="cell-prompt"]').exists()).toBe(true);
     // …while the actions are a SIBLING of it, so they can never be pushed out of the cell.
     expect(w.find(".cell-header > .cell-actions").exists()).toBe(true);
-    expect(w.find(".cell-header-main .cell-actions").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-header-main"] .cell-actions').exists()).toBe(false);
     expect(w.find('.cell-actions [aria-label="Expand terminal"]').exists()).toBe(true);
     expect(w.find(".cell-actions .cell-close").exists()).toBe(true);
   });
@@ -1430,7 +1430,7 @@ describe("TerminalCell", () => {
     await flushPromises();
     // Info stripped: no git chip / usage; the second (terminal) header row is hidden.
     expect(w.find('[data-testid="git-chip"]').exists()).toBe(false);
-    expect(w.find(".cell-usage").exists()).toBe(false);
+    expect(w.find('[data-testid="cell-usage"]').exists()).toBe(false);
     expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
     // Row 1 keeps dir + prompt + the expand/close actions (row 2 is hidden).
     expect(w.find('[aria-label="Expand terminal"]').exists()).toBe(true);


### PR DESCRIPTION
## Summary

**Two parts, one CI cycle.**

### 1. Shared cell chrome → `@layer components`

`cellChromeBase.css` / `cellChrome.css` are loaded as unlayered scoped CSS, so they beat **every** Tailwind utility regardless of specificity — that's what blocked per-cell overrides (surfaced back in #529). Wrapping them in `@layer components` lets utilities win, while each component's own `<style scoped>` stays unlayered and still wins over them, exactly as before.

**Nothing changes visually today** — verified by rendering the same cell-chrome markup against the before/after stylesheets: **pixel-identical**.

### 2. TerminalCell header track + dir form

With that unlocked: `header-main`, dir button + path, badge, usage chip, custom chip, prompt, dir row/input/go, and `cell-start`. **191 → 70 scoped lines.**

## Render-verification caught a bug I introduced

A blanket string replace put the dir-go button chrome on **both** `play_arrow` icons, boxing the preset chip's launch icon in a bordered, padded box. Caught by inspecting the converted output, restored to `text-[14px]`, and re-verified against the chip's original rules — the icon now shows zero computed-style differences.

(Earlier in this same change the harness also caught the active agent button losing its background to a `bg-transparent`/`bg-elevated` race.)

## Verification

- Every computed property compared for 12 header/form elements + the chip: remaining differences are only `border-*-color`/`style` on **zero-width** sides and `999px` vs `rounded-full` — all unpaintable/equivalent.
- **Pixel-identical** header row + dir form at 3× DPR.
- Full suite 1483 passed, typecheck clean.

## Items to Confirm / Review

- **Two pre-existing oddities carried over verbatim** rather than "fixed" in a refactor: `.cell-dir-go` is always `opacity: .4; cursor: default` (even when enabled), and its button chrome lands on the **icon** rather than the button. Worth a separate look if that's not intended.
- Test selectors → `data-testid` for `cell-dir-input` / `-go` / `cell-prompt` / `cell-usage` / `cell-hdr-chip` / `cell-header-main`.

## Progress

**TerminalCell 751 → 70.** What's left is only the cell frame + status states (`.cell`, `.cell.is-*`, `.cell-header` tints, `.cell-dot.is-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)