### PR TITLE
fix: restore the launcher Go button's styling (regressed in 1970f28)

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1291,16 +1291,13 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <button
             type="button"
             data-testid="cell-dir-go"
-            class="cursor-default opacity-40"
+            class="inline-flex flex-none cursor-pointer items-center justify-center rounded-md border border-border bg-elevated px-2 text-secondary enabled:hover:border-accent enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40"
             :disabled="!dirInput.trim()"
             title="Start a new terminal here (or press Enter)"
             aria-label="Start a new terminal here"
             @click="launch"
           >
-            <span
-              class="material-symbols-outlined cursor-pointer rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary"
-              >play_arrow</span
-            >
+            <span class="material-symbols-outlined text-[18px]">play_arrow</span>
           </button>
         </span>
       </label>


### PR DESCRIPTION
## What I found

You asked whether the two oddities I flagged were intentional. They weren't — and the regression is **mine**, from this migration.

| commit | what happened |
|---|---|
| **#155** | Introduced `.cell-dir-go`: a normal button box, a hover state, and `opacity: .4` **only** when `:disabled`. Correct. |
| **#334** | Added the folder-picker and shared those rules correctly — each selector became a comma list (`.cell-dir-go, .cell-dir-pick { … }`). Still correct. |
| **`1970f28`** (the first Tailwind PR of this migration) | Converted `.cell-dir-pick` to utilities and deleted its lines **including the shared rules' `{ … }` bodies**. The `.cell-dir-go` selectors were left dangling and ran into the following rule. |

Net effect since then:

- the button **lost its box and hover entirely**,
- `:disabled`'s `opacity: .4; cursor: default` became **unconditional** — the ▶ button has been permanently dimmed and unresponsive-looking,
- the **icon** picked up `.cell-start`'s button chrome, so the box moved onto the glyph.

## Fix

Restores #334's design as utilities — matching the sibling folder-pick button, with `enabled:hover:` / `disabled:` variants — and puts the icon back to `text-[18px]`.

## Verification

Rendered against the **pre-regression** rules (`1970f28^`) and compared every computed property:

| state | result |
|---|---|
| enabled | ✅ identical |
| disabled | ✅ identical |
| icon | ✅ identical |

Full suite 1483 passed.

## Takeaway

This is the same class of failure as #535: a mechanical edit to CSS that no test and no built-CSS grep could catch. It's an argument for the render-comparison check on **every** CSS change, and for treating a multi-line comma selector list as a unit when deleting from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)