### PR TITLE
chore: make scoped CSS a lint error, with a reasoned allowlist

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -39,7 +39,14 @@ Spacing/radius use Tailwind's scale on a 4px base: `px-2` = 8px, `px-2.5` = 10px
 ## Rules
 
 1. **Default to Tailwind utilities.** New or changed markup gets utility classes,
-   not a fresh `<style scoped>` block.
+   not a fresh `<style scoped>` block. **This is enforced:** `vue/no-restricted-block`
+   makes a `<style>` block in `src/**/*.vue` a lint error. If a rule genuinely can't be
+   a utility, add the file to the **scoped-CSS allowlist in `eslint.config.js` with a
+   one-line reason** — don't reach for an inline `eslint-disable`. Keeping the list in
+   one place means every exception is visible in review, and the reasons can be audited
+   (and entries deleted) as the constraints go away. Today's entries are all `@keyframes`,
+   `:deep` into `v-html`/CodeMirror, a sibling combinator, a parent-state layout machine,
+   and the shared cell-chrome imports.
 2. **Prefer a token over a raw hex.** Where a token exists, `bg-elevated` beats
    `bg-[#20203a]` — the token is what theme-switches, so the arbitrary hex would be a
    regression. **But** when a color is *already* hardcoded in the scoped CSS and has no

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,37 @@ export default [
     rules: {
       "vue/multi-word-component-names": "off",
       "vue/max-attributes-per-line": "off",
+      // Components are styled with Tailwind utilities (docs/styling.md) so the styling
+      // travels with the markup. A <style> block is the exception, not the default —
+      // add the file to the allowlist below WITH a reason rather than disabling inline.
+      "vue/no-restricted-block": [
+        "error",
+        {
+          element: "style",
+          message:
+            "Use Tailwind utilities (see docs/styling.md). If this genuinely can't be a utility, add the file to the scoped-CSS allowlist in eslint.config.js with a reason.",
+        },
+      ],
     },
+  },
+  {
+    // Scoped-CSS allowlist. Each entry is something Tailwind utilities cannot express;
+    // keep the reason current, and delete the entry when the reason goes away.
+    files: [
+      "src/components/Sidebar.vue", //            @keyframes — the "thinking" spinner ring
+      "src/components/SessionTabBar.vue", //      @keyframes — the same spinner
+      "src/components/Terminal.vue", //           @keyframes — the voice button's pulse / spin
+      "src/components/TerminalGrid.vue", //       parent-state x descendant layout machine + FLIP @keyframes
+      "src/components/GuiPanel.vue", //           `.frame + .frame` sibling-combinator spacing
+      "src/components/WikiPageView.vue", //       :deep into v-html markdown
+      "src/components/WikiBrowseOverlay.vue", //  :deep into v-html lint output
+      "src/components/FilesOverlay.vue", //       :deep into CodeMirror's injected root
+      "src/components/CommandCell.vue", //        overrides of the shared .cell-btn + the shared chrome imports
+      "src/components/TerminalCell.vue", //       shared chrome import
+      "src/components/LauncherCell.vue", //       shared chrome imports
+      "src/components/ToolbarPopover.vue", //     shared popover chrome import
+    ],
+    rules: { "vue/no-restricted-block": "off" },
   },
   {
     files: ["server/**/*.js", "bin/**/*.js", "scripts/**/*.{js,mjs}"],


### PR DESCRIPTION
## Summary

Now that the app is Tailwind-first, this keeps it that way: **`vue/no-restricted-block` makes a `<style>` block in `src/**/*.vue` a lint error.**

A blanket ban would be wrong — twelve files legitimately need CSS no utility can express — so the exceptions live in **one allowlist in `eslint.config.js`, each with its reason**:

| reason | files |
|---|---|
| `@keyframes` | Sidebar, SessionTabBar (spinner), Terminal (voice pulse/spin), TerminalGrid (FLIP) |
| `:deep` into `v-html` / CodeMirror | WikiPageView, WikiBrowseOverlay, FilesOverlay |
| parent-state × descendant layout machine | TerminalGrid |
| sibling combinator | GuiPanel |
| shared cell-chrome imports / overrides | TerminalCell, CommandCell, LauncherCell, ToolbarPopover |

**Allowlist, not inline `eslint-disable`** — deliberately. One place means every exception is visible in review, the reasons stay auditable, and entries get deleted as constraints go away (rather than `eslint-disable` comments quietly accumulating).

## Verification

- The tree lints clean (0 errors; the 5 pre-existing warnings are unrelated).
- **Guard tested**: temporarily adding a `<style scoped>` block to a non-allowlisted component (`FilterChip.vue`) fails with the guidance message:
  > Use Tailwind utilities (see docs/styling.md). If this genuinely can't be a utility, add the file to the scoped-CSS allowlist in eslint.config.js with a reason.
  Removing it returns to clean.
- Build + full suite (1483) pass.

`docs/styling.md` rule 1 now states the enforcement and how to request an exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)