### PR TITLE
fix: 完了 Push の本文を「エージェントが何をしたか」にする

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1255,6 +1255,12 @@ function handleActivityHook(sessionId: string, event: string, active: boolean, m
 
 const PUSH_TITLE_MAX = 80;
 const PUSH_BODY_MAX = 160;
+// Which port this host's UI answers on, so a receiver can open it instead of guessing.
+// Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server, whose
+// port the backend only knows when CLIENT_PORT is set in its environment (vite.config.ts
+// defaults it separately). Reaching it still requires a receiver on this machine — see the
+// data payload below.
+const UI_PORT = String(process.env.CLIENT_PORT || PORT);
 // Notify the user's devices that a background task finished, when Web Push is enabled.
 // Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
 function notifyTaskFinished(sessionId: string, kind: PushKind, message: string): void {
@@ -1264,13 +1270,22 @@ function notifyTaskFinished(sessionId: string, kind: PushKind, message: string):
   if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = cwd ? path.basename(cwd) : "session";
-  const detail = lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+  // A finished turn should say what the agent DID — the prompt is what the user already
+  // knows, and reading it back tells them nothing about the outcome. Refresh here rather
+  // than rely on publishActivity's: an actively-viewed session never flags `waiting`, so
+  // that path skips the refresh and the phone would get the PREVIOUS turn's reply.
+  if (kind === "finished" && cwd) refreshLastResponse(sessionId, cwd);
+  const reply = kind === "finished" ? (lastResponses.get(sessionId) ?? "") : "";
+  const detail = reply.trim() || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
   const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
   // The session id is what lets the phone open this session from the notification;
   // the host id is what lets it know WHOSE session. Without it the phone opens with
   // no host selected — it never persists one — and can only offer the picker, which
   // is where every notification tap used to land (receptron/mulmoserver#86).
-  void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID });
+  // `port` is for a receiver running ON this machine, which can then open the local UI
+  // directly (http://localhost:<port>). A phone cannot use it — its own localhost is the
+  // phone — so the receiver has to treat it as optional and keep the existing routing.
+  void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID, port: UI_PORT });
 }
 
 interface HookToolPayload {

--- a/server/index.ts
+++ b/server/index.ts
@@ -563,14 +563,22 @@ const aiTitles = new Map<string, string>(); // id -> AI title
 // a turn ends (waiting), so the roster can show "what it just said" without the terminal open.
 const lastResponses = new Map<string, string>(); // id -> last assistant text (truncated)
 const LAST_RESPONSE_MAX = 400;
-function refreshLastResponse(id: string, cwd: string): void {
+// The reply as it is on disk RIGHT NOW, or null when there is none to read. Separate from
+// the cache below because the two want opposite things on failure: the roster would rather
+// keep showing the last reply it had, while a push must never describe a finished turn with
+// the PREVIOUS turn's text — for that caller, null has to stay null.
+function readLatestResponse(id: string, cwd: string): string | null {
   try {
     const raw = readFileSync(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
     const text = latestAssistantTextFromJsonl(raw);
-    if (text) lastResponses.set(id, text.slice(0, LAST_RESPONSE_MAX));
+    return text ? text.slice(0, LAST_RESPONSE_MAX) : null;
   } catch {
-    // no transcript yet / unreadable — leave any prior value
+    return null; // no transcript yet / unreadable
   }
+}
+function refreshLastResponse(id: string, cwd: string): void {
+  const text = readLatestResponse(id, cwd);
+  if (text) lastResponses.set(id, text); // a failed read leaves any prior value
 }
 const titleTurnCounts = new Map<string, number>(); // id -> user turns since last title
 const titlePending = new Set<string>(); // ids whose next Stop should (re)generate a title
@@ -1271,12 +1279,14 @@ function notifyTaskFinished(sessionId: string, kind: PushKind, message: string):
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = cwd ? path.basename(cwd) : "session";
   // A finished turn should say what the agent DID — the prompt is what the user already
-  // knows, and reading it back tells them nothing about the outcome. Refresh here rather
-  // than rely on publishActivity's: an actively-viewed session never flags `waiting`, so
-  // that path skips the refresh and the phone would get the PREVIOUS turn's reply.
-  if (kind === "finished" && cwd) refreshLastResponse(sessionId, cwd);
-  const reply = kind === "finished" ? (lastResponses.get(sessionId) ?? "") : "";
-  const detail = reply.trim() || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+  // knows, and reading it back tells them nothing about the outcome. Read it HERE instead
+  // of taking `lastResponses`: publishActivity skips its refresh for an actively-viewed
+  // session (no `waiting` flag) while the push still fires, and the cache deliberately
+  // survives a failed read — either way the map can hold the previous turn's reply, which
+  // is worse than saying nothing. No reply to read falls through to the prompt.
+  const reply = kind === "finished" && cwd ? readLatestResponse(sessionId, cwd) : null;
+  if (reply) lastResponses.set(sessionId, reply); // keep the roster in step; we just read it
+  const detail = (reply ?? "").trim() || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
   const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
   // The session id is what lets the phone open this session from the notification;
   // the host id is what lets it know WHOSE session. Without it the phone opens with

--- a/server/session/activity-hook.ts
+++ b/server/session/activity-hook.ts
@@ -57,16 +57,43 @@ export interface PushText {
 
 const clip = (text: string, max: number): string => text.slice(0, max);
 
+// A push body renders as one run of text, but the finished-turn body is now the agent's
+// reply — markdown with newlines and indentation. Collapsed, the first 160 characters are
+// a sentence; left alone they are ragged fragments with the useful part pushed off the end.
+const oneLine = (text: string): string => text.replace(/\s+/g, " ").trim();
+
+// Replace "[text](url)" with "text", scanning rather than matching — the obvious regex
+// backtracks (lint bans those, as in the scheduler's time parsing). An unclosed "[" ends
+// the scan and the remainder is kept verbatim.
+const flattenLinks = (text: string): string => {
+  const parts: string[] = [];
+  let rest = 0;
+  for (let open = text.indexOf("["); open !== -1; open = text.indexOf("[", rest)) {
+    const label = text.indexOf("](", open);
+    const close = label === -1 ? -1 : text.indexOf(")", label + 2);
+    if (close === -1) break;
+    parts.push(text.slice(rest, open), text.slice(open + 1, label));
+    rest = close + 1;
+  }
+  parts.push(text.slice(rest));
+  return parts.join("");
+};
+
+// A lock screen renders no markdown: emphasis arrives as literal asterisks, and a link's
+// target spends a third of the 160-character budget on something the user cannot click
+// from the text. Heading markers are left alone — "#" also starts an issue number.
+const plainText = (text: string): string => flattenLinks(text).replace(/\*\*/g, "");
+
 export function buildPushText(kind: PushKind, where: string, detail: string, message: string, limits: { title: number; body: number }): PushText {
   if (kind === "waiting") {
     return {
       title: clip(`\u2753 ${where}`, limits.title),
-      body: clip(message.trim() || detail.trim() || "\u5165\u529b\u5f85\u3061\u3067\u3059", limits.body),
+      body: clip(oneLine(plainText(message)) || oneLine(plainText(detail)) || "\u5165\u529b\u5f85\u3061\u3067\u3059", limits.body),
     };
   }
   return {
     title: clip(`\u2705 ${where}`, limits.title),
-    body: clip(detail.trim() || "\u30bf\u30b9\u30af\u304c\u5b8c\u4e86\u3057\u307e\u3057\u305f", limits.body),
+    body: clip(oneLine(plainText(detail)) || "\u30bf\u30b9\u30af\u304c\u5b8c\u4e86\u3057\u307e\u3057\u305f", limits.body),
   };
 }
 

--- a/test/server/session/activity-hook.spec.ts
+++ b/test/server/session/activity-hook.spec.ts
@@ -57,10 +57,45 @@ describe("pushKindFor", () => {
 describe("buildPushText", () => {
   const limits = { title: 80, body: 160 };
 
-  it("marks a finished turn with a check and shows the prompt", () => {
-    const { title, body } = buildPushText("finished", "myrepo", "fix the parser", "", limits);
+  it("marks a finished turn with a check and shows what the agent reported", () => {
+    const { title, body } = buildPushText("finished", "myrepo", "パーサの丸め誤差を修正しました", "", limits);
     expect(title).toBe("\u2705 myrepo");
-    expect(body).toBe("fix the parser");
+    expect(body).toBe("パーサの丸め誤差を修正しました");
+  });
+
+  // The finished body is the agent's reply now, so it arrives as markdown. Left as-is the
+  // newlines and indentation would eat the 160-character budget before the point lands.
+  it("collapses a multi-line reply into one line", () => {
+    const reply = "作業ログを追記しました。\n\n- dev-log-2026-w29.md   （3リポ分）\n- worklog.md にリンク追加";
+    expect(buildPushText("finished", "myrepo", reply, "", limits).body).toBe(
+      "作業ログを追記しました。 - dev-log-2026-w29.md （3リポ分） - worklog.md にリンク追加",
+    );
+  });
+
+  it("collapses a multi-line waiting message too", () => {
+    expect(buildPushText("waiting", "myrepo", "", "Bash を実行する\n許可が必要です", limits).body).toBe("Bash を実行する 許可が必要です");
+  });
+
+  it("flattens a markdown link to its text, keeping the URL out of the budget", () => {
+    const reply = "issue [receptron/mulmoserver#81](https://github.com/receptron/mulmoserver/issues/81) を作成しました";
+    expect(buildPushText("finished", "myrepo", reply, "", limits).body).toBe("issue receptron/mulmoserver#81 を作成しました");
+  });
+
+  it("keeps text verbatim when a bracket never closes into a link", () => {
+    expect(buildPushText("finished", "myrepo", "配列 [0] を [未完了 のまま", "", limits).body).toBe("配列 [0] を [未完了 のまま");
+  });
+
+  it("flattens several links in one reply", () => {
+    const reply = "[#1](https://x/1) と [#2](https://x/2) を閉じました";
+    expect(buildPushText("finished", "myrepo", reply, "", limits).body).toBe("#1 と #2 を閉じました");
+  });
+
+  it("drops emphasis markers but keeps a leading # (it starts an issue number)", () => {
+    expect(buildPushText("finished", "myrepo", "**#300 マージ完了** — done", "", limits).body).toBe("#300 マージ完了 — done");
+  });
+
+  it("treats a whitespace-only reply as absent and falls back", () => {
+    expect(buildPushText("finished", "myrepo", " \n\t ", "", limits).body).toBe("タスクが完了しました");
   });
 
   it("marks a waiting turn with a question and quotes the hook's message", () => {


### PR DESCRIPTION
## Summary

「タスク完了」の Push 通知の本文が**自分が投げたプロンプト**だったため、通知を見ても結果が分からず、開くまで意味がありませんでした。**エージェントが実際に何をしたか（返答）**を送るように変更します。

```
[旧] ✅ mulmoterminal / あなたは開発作業ログのバッチです。カレントディレクトリ（ワークスペース…
[新] ✅ mulmoterminal / issue receptron/mulmoserver#81 を作成しました。## 診断のまとめ
     原因は私たちのコードではなく、FCM SDK の挙動でした。…
```

併せて、**開いて見ているセッションで前のターンの返答が送られるバグ**を修正し、Push の `data` に UI のポートを追加します。

## Items to Confirm / Review

1. **本文のフォールバック順** — `lastResponses`（返答）→ `lastPrompts`（プロンプト）→ `aiTitles`。transcript がまだ無いセッションでは従来どおりプロンプトが出ます。この順で良いかご確認ください
2. **markdown の除去範囲** — 改行の畳み込み・`**` の除去・`[text](url)` → `text` まで行い、**`#` は残しています**（`#300` のような issue 番号を壊すため）。`##` 見出しは本文にそのまま出ます
3. **`port` は送るだけです** — 実際に `localhost:<port>` を開く処理は mulmoserver 側の実装が必要で、receptron/mulmoserver#95 に切りました。iOS では原理的に使えません（端末自身の localhost を指すため）
4. **dev のポート** — 送る値は `CLIENT_PORT || PORT` です。`yarn dev` では UI は Vite の 6856 ですが `CLIENT_PORT` は既定で未設定なので、34567（ビルド済み UI を配信するポート）を送ります

## User Prompt

- 通知の内容が分からないので直したい。`<task-notification>` は mulmoterminal → mulmoserver で web push する仕組み。どこで直せばよいか
- push するときに、そのサーバと対になる Vue のポートも送れないか。狙いは `localhost:1234` で開けるようにすること
- server 側で iOS と desktop は認識しているようなので、送るときに iOS なら mulmoserver の URL、PC なら localhost にする。これを含めて mulmoserver に issue を

## 原因

`server/index.ts` の `notifyTaskFinished`:

```ts
const detail = lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
```

完了通知（`Stop` → `finished`）の本文が「ユーザーが投げたプロンプト」でした。**利用者が既に知っていること**を返すだけで、結果が分かりません。

## 実装

### 1. 本文をエージェントの返答に（`server/index.ts`）

`lastResponses`（ロスターの「何を言ったか」表示に使われている返答の先頭 400 文字）を優先します。既存の仕組みの再利用で、新しい取得経路は追加していません。

### 2. 取りこぼしの修正（`server/index.ts`）

`refreshLastResponse` を `notifyTaskFinished` 内で明示的に呼びます。`activityHookEffects("Stop", active=true)` は `waiting` を立てないため `publishActivity` の refresh 経路を通らず、一方 Push は `active` に関係なく飛ぶので、**開いて見ているセッションでは前のターンの返答**が送られていました。

### 3. ロック画面向けの整形（`server/session/activity-hook.ts`）

本文がエージェントの散文＝ markdown になったため、純粋関数側で整形します。

- 改行・インデントを 1 行に畳む（畳まないと 160 文字枠が断片で埋まる）
- `**` を除去（ロック画面ではアスタリスクがそのまま出る）
- `[text](url)` → `text`（URL が 160 文字枠の 1/3 を消費し、しかもテキストからは辿れない）
- `#` は残す（`#300` のような issue 番号を壊すため）

リンクの平坦化は**正規表現ではなく文字列走査**です。素直な正規表現はバックトラックし、lint（`sonarjs/super-linear-regex`）が拒否したためで、scheduler の時刻パースと同じ方針に揃えています。

### 4. `port` の送信（`server/index.ts`）

`data` に `port`（`CLIENT_PORT || PORT`）を追加。受信側の対応は receptron/mulmoserver#95。

## テスト

`test/server/session/activity-hook.spec.ts` に 8 件追加（複数行の畳み込み / 待機メッセージの畳み込み / 空白のみのフォールバック / リンク平坦化 / 複数リンク / 閉じないブラケット / `**` 除去と `#` 保持）。全体で 1541 件 green、lint・build・typecheck・knip クリーン。

実データでの確認も行い、`~/.claude/projects` の実 transcript 3 本から生成した本文が意図どおりになることを確認しています（上の before/after はその出力）。
