### PR TITLE
refactor: セッション系ルート 5 本を server/routes/ へ（#548 Step 2b-2）

### DIFF
--- a/server/errors.ts
+++ b/server/errors.ts
@@ -1,3 +1,6 @@
 // Error message extracted defensively from an unknown thrown value. Shared rather than
 // re-declared because the boot module and the session registry log failures identically.
 export const messageOf = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+// Node fs errors carry a `code` (e.g. "ENOENT"); narrow before reading it.
+export const hasErrnoCode = (e: unknown): e is { code?: string } => typeof e === "object" && e !== null;

--- a/server/index.ts
+++ b/server/index.ts
@@ -54,11 +54,10 @@ import { buildClaudeArgs } from "./agents/claude-args.js";
 import { resolveSession, type SessionResolution } from "./session/session-resolve.js";
 import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "./session/activity-hook.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
-import { messageOf } from "./errors.js";
-import type { PtyEntry, SessionMeta, ToolCall, ToolResult } from "./session/types.js";
+import { hasErrnoCode, messageOf } from "./errors.js";
+import type { PtyEntry, ToolCall, ToolResult } from "./session/types.js";
 import {
   activity,
-  activityStateHydrated,
   aiTitles,
   claimedCodexRollouts,
   codexRolloutIds,
@@ -71,6 +70,7 @@ import {
   lastTitleAttemptMs,
   lastTitledUserTurns,
   markDevTerminalSession,
+  translationWorkerIds,
   persistActivityState,
   ptys,
   titleEpoch,
@@ -80,25 +80,15 @@ import {
 } from "./session/registry.js";
 import { reapDecisionFor } from "./session/reap-policy.js";
 import { resolveWorkspace } from "./config/workspace.js";
-import {
-  claudeOnDiskSessionIds,
-  collectOnDiskSessionStats,
-  collectPendingSessions,
-  latestUserPrompt,
-  projectSessionsDir,
-  readSessionMeta,
-  readSessionSummary,
-  sessionExistsOnDisk,
-  sessionTimeline,
-  LAST_RESPONSE_MAX,
-} from "./session/session-reads.js";
+import { mountSessionRoutes } from "./routes/session-routes.js";
+import { claudeOnDiskSessionIds, latestUserPrompt, projectSessionsDir, sessionExistsOnDisk, LAST_RESPONSE_MAX } from "./session/session-reads.js";
 import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, heldByAnotherProcess, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { buildCodexArgs } from "./agents/codex-args.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./agents/codex-session.js";
-import { listCodexSessions, codexRolloutExists } from "./agents/codex-sessions.js";
+import { codexRolloutExists } from "./agents/codex-sessions.js";
 import { codexifySkillSeed } from "./agents/codex-skills.js";
 import { appendBoundedOutput, stripTerminalQueries } from "./session/terminal-replay.js";
 import { renderScreen } from "./session/headlessScreen.js";
@@ -146,9 +136,6 @@ import { SPA_FALLBACK_RE } from "./infra/spa-fallback.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 
-// Node fs errors carry a `code` (e.g. "ENOENT"); narrow before reading it.
-const hasErrnoCode = (e: unknown): e is { code?: string } => typeof e === "object" && e !== null;
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const CLAUDE_BIN = claudeAdapter.bin();
@@ -173,13 +160,6 @@ initWorkspaceSetup({ workspace: CLAUDE_CWD });
 // launched terminal can run `/mulmoterminal-config` to author a .mulmoterminal.json.
 // Best-effort + never clobbers a user's own same-named skill (see install-config-skill.ts).
 installConfigSkill();
-
-// Hidden translation-worker sessions run in CLAUDE_CWD — the workspace the user has
-// already trusted — because claude blocks on its workspace-trust dialog in any
-// untrusted dir (no input ever comes, so the worker would hang). Their session ids
-// are tracked here so they're FILTERED OUT of /api/sessions: a translation worker is
-// a transient internal helper, not a chat the user should see in the sidebar.
-const translationWorkerIds = new Set<string>();
 
 // sessionId → settlers for a hidden translation worker's in-flight request.
 // `resolve` is called from POST /api/translation/submit when the worker reports its
@@ -369,13 +349,6 @@ async function recordToolCallEnd(
   pubsub?.publish(toolCallsChannel(sessionId), call);
   toolCallsStore.save(sessionId);
 }
-
-// Only the most-recent N sessions are listed in the sidebar; older ones aren't
-// read or parsed, keeping /api/sessions cheap for projects with many sessions.
-const SESSION_LIST_LIMIT = 50;
-// Cap on ids per /api/activity request — a grid can't show more cells than this, and
-// it bounds the query string a client can make us parse.
-const ACTIVITY_IDS_LIMIT = 200;
 
 const LAST_PROMPT_CAP = 200;
 
@@ -1223,123 +1196,9 @@ mountRemoteHostRoutes(app, { isAllowedOrigin });
 // fallback for remote setups. Same-origin guarded; tokens never reach a response.
 mountGoogleRoutes(app, { isAllowedOrigin });
 
-// GRID-ONLY (dev_tool): initial per-session status + last prompt, so a grid cell
-// can render its header immediately (live updates then arrive via the "sessions"
-// pub/sub channel). The single view reads activity straight from that channel.
-// ?cwd= locates the transcript so a freshly-resumed session shows its most recent
-// prompt; the live in-memory prompt (this process run) takes precedence.
-app.get("/api/session/:id", async (req, res) => {
-  const { id } = req.params;
-  if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
-  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
-  await activityStateHydrated; // a reconnect re-fetch must see the restored working/waiting, not idle
-  const a = activity.get(id) || {};
-  const { lastPrompt: transcriptPrompt, lastResponse: transcriptResponse, userTurns, usage, context, workPhase } = await readSessionSummary(cwd, id);
-  const lastPrompt = lastPrompts.get(id) ?? transcriptPrompt;
-  // The roster always shows OUR summary, never the external on-disk `ai-title` (MulmoClaude's).
-  // If we haven't titled it yet, kick off a summary and fall back to the prompt meanwhile.
-  freshenRosterTitle(id, cwd, userTurns);
-  const aiTitle = aiTitles.get(id) ?? null;
-  const lastResponse = lastResponses.get(id) ?? transcriptResponse;
-  res.json({
-    id,
-    cwd,
-    working: a.working ?? false,
-    waiting: a.waiting ?? false,
-    event: a.event ?? null,
-    lastPrompt,
-    aiTitle,
-    lastResponse,
-    usage,
-    context,
-    workPhase,
-  });
-});
-
-// Attention state (working / waiting / event) for an explicit set of session ids.
-// The grid uses this to seed the status of its OFF-PAGE cells, which /api/sessions
-// can't serve: it hides dev-terminal sessions and is capped by the list limit. Reads
-// only the in-memory activity map (no disk), so it's cheap to call per grid render.
-app.get("/api/activity", async (req, res) => {
-  await activityStateHydrated; // the grid re-seeds this on reconnect — must not race hydration back to idle
-  const raw = typeof req.query.ids === "string" ? req.query.ids : "";
-  const ids = raw
-    .split(",")
-    .filter((id) => SESSION_ID_RE.test(id))
-    .slice(0, ACTIVITY_IDS_LIMIT);
-  const out: Record<string, { working: boolean; waiting: boolean; event: string | null }> = {};
-  for (const id of ids) {
-    const a = activity.get(id) || {};
-    out[id] = { working: a.working ?? false, waiting: a.waiting ?? false, event: a.event ?? null };
-  }
-  res.json(out);
-});
-
-// The tool-activity timeline for a session (what the agent ran, newest last), so a
-// cell can show "what did it do?" without scrolling the raw transcript.
-app.get("/api/transcript/timeline", async (req, res) => {
-  const { session } = req.query;
-  if (typeof session !== "string" || !SESSION_ID_RE.test(session)) return res.status(400).json({ error: "invalid session id" });
-  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
-  res.json(await sessionTimeline(cwd, session));
-});
-
-// List the chat sessions for the current project (CLAUDE_CWD), including
-// newly-created sessions that aren't persisted to disk yet.
-app.get("/api/sessions", async (req, res) => {
-  try {
-    await activityStateHydrated; // list working/waiting from the restored state, not a racing idle
-    // Optional ?cwd= scopes the list to that project's on-disk sessions (the grid
-    // cell's resume picker). Without it, the classic single view's behavior is
-    // unchanged: CLAUDE_CWD + in-memory pending sessions.
-    const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
-    const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
-    const includePending = !cwdParam;
-    // Wait for the persisted grid-session set before filtering (below), so a chat
-    // request racing server boot can't leak previously-hidden grid transcripts.
-    if (includePending) await devTerminalSessionsHydrated;
-    const dir = projectSessionsDir(cwd);
-    let files: string[] = [];
-    try {
-      files = (await fs.readdir(dir)).filter((f) => f.endsWith(".jsonl"));
-    } catch (err) {
-      if (!hasErrnoCode(err) || err.code !== "ENOENT") throw err;
-    }
-
-    const onDiskStats = await collectOnDiskSessionStats(dir, files);
-    const onDisk = new Set(onDiskStats.map((s) => s.id));
-    // Pending is skipped for a cwd-scoped query (pending sessions aren't tracked per dir).
-    const pending = collectPendingSessions(onDisk, includePending);
-
-    // Keep only the most-recent N, then read & parse contents for just those
-    // on-disk files (a deleted/corrupt file is dropped, not fatal). Hidden translation
-    // workers are dropped first — they're transient internal helpers, not user chats.
-    const top = [...onDiskStats, ...pending]
-      .filter((s) => !translationWorkerIds.has(s.id))
-      // Hide multi-terminal GRID sessions from the CHAT sidebar (the unscoped query
-      // only). The grid's own resume picker passes ?cwd= (includePending=false) and
-      // must keep listing them, so gate the exclusion on includePending.
-      .filter((s) => !includePending || !devTerminalSessions.has(s.id))
-      .sort((a, b) => b.mtime - a.mtime)
-      .slice(0, SESSION_LIST_LIMIT);
-    const sessions = (
-      await Promise.all(
-        top.map((s) =>
-          s.kind === "pending"
-            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, event: s.event, hidden: s.hidden }
-            : readSessionMeta(dir, s.file).catch(() => null),
-        ),
-      )
-    )
-      .filter((s): s is SessionMeta => s !== null)
-      .sort((a, b) => b.mtime - a.mtime);
-
-    res.json({ cwd, sessions });
-  } catch (err) {
-    console.error("[api] /api/sessions failed:", err);
-    res.status(500).json({ error: String(err) });
-  }
-});
+// Sidebar listing, one session's detail, the grid's attention poll, the tool timeline and
+// codex's own sessions (see routes/session-routes.ts).
+mountSessionRoutes(app, { freshenRosterTitle });
 
 // Explicit close (reliable reap over HTTP) + one-shot orphan cleanup. Extracted to a
 // module so the origin guard / id validation / orphan-selection boundary are testable.
@@ -1362,20 +1221,6 @@ mountTmuxRoutes(app, {
   killTmux: tmuxKillSession,
   listTmuxIds: tmuxListSessionIds,
   resumablePredicate: resumableSessionPredicate,
-});
-
-// codex's own sessions for a workspace (?cwd=, default CLAUDE_CWD), read from ~/.codex rollouts —
-// the single view's sidebar lists these so past codex conversations are switchable + resumable.
-app.get("/api/codex/sessions", async (req, res) => {
-  try {
-    const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
-    const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
-    const sessions = await listCodexSessions(codexSessionsRoot(), cwd, SESSION_LIST_LIMIT);
-    res.json({ cwd, sessions });
-  } catch (err) {
-    console.error("[api] /api/codex/sessions failed:", err);
-    res.status(500).json({ error: String(err) });
-  }
 });
 
 const server = http.createServer(app);

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -30,6 +30,7 @@ import {
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { listCodexSessions } from "../agents/codex-sessions.js";
 import type { SessionMeta } from "../session/types.js";
+import { parseActivityIds, selectSessionRows } from "../session/session-list.js";
 
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
@@ -82,11 +83,7 @@ async function sessionDetail(req: Request<{ id: string }>, res: Response, freshe
 // only the in-memory activity map (no disk), so it's cheap to call per grid render.
 async function activitySnapshot(req: Request, res: Response) {
   await activityStateHydrated; // the grid re-seeds this on reconnect — must not race hydration back to idle
-  const raw = typeof req.query.ids === "string" ? req.query.ids : "";
-  const ids = raw
-    .split(",")
-    .filter((id) => SESSION_ID_RE.test(id))
-    .slice(0, ACTIVITY_IDS_LIMIT);
+  const ids = parseActivityIds(req.query.ids, (id) => SESSION_ID_RE.test(id), ACTIVITY_IDS_LIMIT);
   const out: Record<string, { working: boolean; waiting: boolean; event: string | null }> = {};
   for (const id of ids) {
     const a = activity.get(id) || {};
@@ -134,14 +131,12 @@ async function sessionList(req: Request, res: Response) {
     // Keep only the most-recent N, then read & parse contents for just those
     // on-disk files (a deleted/corrupt file is dropped, not fatal). Hidden translation
     // workers are dropped first — they're transient internal helpers, not user chats.
-    const top = [...onDiskStats, ...pending]
-      .filter((s) => !translationWorkerIds.has(s.id))
-      // Hide multi-terminal GRID sessions from the CHAT sidebar (the unscoped query
-      // only). The grid's own resume picker passes ?cwd= (includePending=false) and
-      // must keep listing them, so gate the exclusion on includePending.
-      .filter((s) => !includePending || !devTerminalSessions.has(s.id))
-      .sort((a, b) => b.mtime - a.mtime)
-      .slice(0, SESSION_LIST_LIMIT);
+    const top = selectSessionRows([...onDiskStats, ...pending], {
+      isTranslationWorker: (id) => translationWorkerIds.has(id),
+      isDevTerminal: (id) => devTerminalSessions.has(id),
+      includePending,
+      limit: SESSION_LIST_LIMIT,
+    });
     const sessions = (
       await Promise.all(
         top.map((s) =>

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -1,0 +1,184 @@
+// The session routes: what the sidebar lists, what one session looks like, and the
+// attention flags the grid polls. They come out of index.ts last of step 2 (#548) because
+// they were the most entangled — every reader they call had to become a module first.
+//
+// `freshenRosterTitle` is the one thing still injected: re-titling a viewed session spawns
+// a summarizer, which belongs to the title machinery index.ts still owns.
+import type { Express, Request, Response } from "express";
+import { promises as fs } from "node:fs";
+import { CLAUDE_CWD, SESSION_ID_RE } from "../config/env.js";
+import { resolveWorkspace } from "../config/workspace.js";
+import { hasErrnoCode } from "../errors.js";
+import {
+  activity,
+  activityStateHydrated,
+  aiTitles,
+  devTerminalSessions,
+  devTerminalSessionsHydrated,
+  lastPrompts,
+  lastResponses,
+  translationWorkerIds,
+} from "../session/registry.js";
+import {
+  collectOnDiskSessionStats,
+  collectPendingSessions,
+  projectSessionsDir,
+  readSessionMeta,
+  readSessionSummary,
+  sessionTimeline,
+} from "../session/session-reads.js";
+import { codexSessionsRoot } from "../agents/codex-session.js";
+import { listCodexSessions } from "../agents/codex-sessions.js";
+import type { SessionMeta } from "../session/types.js";
+
+// Only the most-recent N sessions are listed in the sidebar; older ones aren't
+// read or parsed, keeping /api/sessions cheap for projects with many sessions.
+const SESSION_LIST_LIMIT = 50;
+// Cap on ids per /api/activity request — a grid can't show more cells than this, and
+// it bounds the query string a client can make us parse.
+const ACTIVITY_IDS_LIMIT = 200;
+
+export interface SessionRouteDeps {
+  /** Kick off a re-title for a session the roster just showed, when it has moved on enough. */
+  freshenRosterTitle: (sessionId: string, cwd: string, currentUserTurns: number) => void;
+}
+
+// GRID-ONLY (dev_tool): initial per-session status + last prompt, so a grid cell
+// can render its header immediately (live updates then arrive via the "sessions"
+// pub/sub channel). The single view reads activity straight from that channel.
+// ?cwd= locates the transcript so a freshly-resumed session shows its most recent
+// prompt; the live in-memory prompt (this process run) takes precedence.
+async function sessionDetail(req: Request<{ id: string }>, res: Response, freshenRosterTitle: SessionRouteDeps["freshenRosterTitle"]) {
+  const { id } = req.params;
+  if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  await activityStateHydrated; // a reconnect re-fetch must see the restored working/waiting, not idle
+  const a = activity.get(id) || {};
+  const { lastPrompt: transcriptPrompt, lastResponse: transcriptResponse, userTurns, usage, context, workPhase } = await readSessionSummary(cwd, id);
+  const lastPrompt = lastPrompts.get(id) ?? transcriptPrompt;
+  // The roster always shows OUR summary, never the external on-disk `ai-title` (MulmoClaude's).
+  // If we haven't titled it yet, kick off a summary and fall back to the prompt meanwhile.
+  freshenRosterTitle(id, cwd, userTurns);
+  const aiTitle = aiTitles.get(id) ?? null;
+  const lastResponse = lastResponses.get(id) ?? transcriptResponse;
+  res.json({
+    id,
+    cwd,
+    working: a.working ?? false,
+    waiting: a.waiting ?? false,
+    event: a.event ?? null,
+    lastPrompt,
+    aiTitle,
+    lastResponse,
+    usage,
+    context,
+    workPhase,
+  });
+}
+
+// Attention state (working / waiting / event) for an explicit set of session ids.
+// The grid uses this to seed the status of its OFF-PAGE cells, which /api/sessions
+// can't serve: it hides dev-terminal sessions and is capped by the list limit. Reads
+// only the in-memory activity map (no disk), so it's cheap to call per grid render.
+async function activitySnapshot(req: Request, res: Response) {
+  await activityStateHydrated; // the grid re-seeds this on reconnect — must not race hydration back to idle
+  const raw = typeof req.query.ids === "string" ? req.query.ids : "";
+  const ids = raw
+    .split(",")
+    .filter((id) => SESSION_ID_RE.test(id))
+    .slice(0, ACTIVITY_IDS_LIMIT);
+  const out: Record<string, { working: boolean; waiting: boolean; event: string | null }> = {};
+  for (const id of ids) {
+    const a = activity.get(id) || {};
+    out[id] = { working: a.working ?? false, waiting: a.waiting ?? false, event: a.event ?? null };
+  }
+  res.json(out);
+}
+
+// The tool-activity timeline for a session (what the agent ran, newest last), so a
+// cell can show "what did it do?" without scrolling the raw transcript.
+async function toolTimeline(req: Request, res: Response) {
+  const { session } = req.query;
+  if (typeof session !== "string" || !SESSION_ID_RE.test(session)) return res.status(400).json({ error: "invalid session id" });
+  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  res.json(await sessionTimeline(cwd, session));
+}
+
+// List the chat sessions for the current project (CLAUDE_CWD), including
+// newly-created sessions that aren't persisted to disk yet.
+async function sessionList(req: Request, res: Response) {
+  try {
+    await activityStateHydrated; // list working/waiting from the restored state, not a racing idle
+    // Optional ?cwd= scopes the list to that project's on-disk sessions (the grid
+    // cell's resume picker). Without it, the classic single view's behavior is
+    // unchanged: CLAUDE_CWD + in-memory pending sessions.
+    const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
+    const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
+    const includePending = !cwdParam;
+    // Wait for the persisted grid-session set before filtering (below), so a chat
+    // request racing server boot can't leak previously-hidden grid transcripts.
+    if (includePending) await devTerminalSessionsHydrated;
+    const dir = projectSessionsDir(cwd);
+    let files: string[] = [];
+    try {
+      files = (await fs.readdir(dir)).filter((f) => f.endsWith(".jsonl"));
+    } catch (err) {
+      if (!hasErrnoCode(err) || err.code !== "ENOENT") throw err;
+    }
+
+    const onDiskStats = await collectOnDiskSessionStats(dir, files);
+    const onDisk = new Set(onDiskStats.map((s) => s.id));
+    // Pending is skipped for a cwd-scoped query (pending sessions aren't tracked per dir).
+    const pending = collectPendingSessions(onDisk, includePending);
+
+    // Keep only the most-recent N, then read & parse contents for just those
+    // on-disk files (a deleted/corrupt file is dropped, not fatal). Hidden translation
+    // workers are dropped first — they're transient internal helpers, not user chats.
+    const top = [...onDiskStats, ...pending]
+      .filter((s) => !translationWorkerIds.has(s.id))
+      // Hide multi-terminal GRID sessions from the CHAT sidebar (the unscoped query
+      // only). The grid's own resume picker passes ?cwd= (includePending=false) and
+      // must keep listing them, so gate the exclusion on includePending.
+      .filter((s) => !includePending || !devTerminalSessions.has(s.id))
+      .sort((a, b) => b.mtime - a.mtime)
+      .slice(0, SESSION_LIST_LIMIT);
+    const sessions = (
+      await Promise.all(
+        top.map((s) =>
+          s.kind === "pending"
+            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, event: s.event, hidden: s.hidden }
+            : readSessionMeta(dir, s.file).catch(() => null),
+        ),
+      )
+    )
+      .filter((s): s is SessionMeta => s !== null)
+      .sort((a, b) => b.mtime - a.mtime);
+
+    res.json({ cwd, sessions });
+  } catch (err) {
+    console.error("[api] /api/sessions failed:", err);
+    res.status(500).json({ error: String(err) });
+  }
+}
+
+// codex's own sessions for a workspace (?cwd=, default CLAUDE_CWD), read from ~/.codex rollouts —
+// the single view's sidebar lists these so past codex conversations are switchable + resumable.
+async function codexSessionList(req: Request, res: Response) {
+  try {
+    const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
+    const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
+    const sessions = await listCodexSessions(codexSessionsRoot(), cwd, SESSION_LIST_LIMIT);
+    res.json({ cwd, sessions });
+  } catch (err) {
+    console.error("[api] /api/codex/sessions failed:", err);
+    res.status(500).json({ error: String(err) });
+  }
+}
+
+export function mountSessionRoutes(app: Express, deps: SessionRouteDeps): void {
+  app.get("/api/session/:id", (req, res) => sessionDetail(req, res, deps.freshenRosterTitle));
+  app.get("/api/activity", activitySnapshot);
+  app.get("/api/transcript/timeline", toolTimeline);
+  app.get("/api/sessions", sessionList);
+  app.get("/api/codex/sessions", codexSessionList);
+}

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -73,6 +73,13 @@ export const codexRolloutIds = new Map<string, string>();
 // (which would let both cold-resume the same conversation). Serialized by the single event loop.
 export const claimedCodexRollouts = new Set<string>();
 
+// Hidden translation-worker sessions run in CLAUDE_CWD — the workspace the user has
+// already trusted — because claude blocks on its workspace-trust dialog in any
+// untrusted dir (no input ever comes, so the worker would hang). Their session ids
+// are tracked here so they're FILTERED OUT of /api/sessions: a translation worker is
+// a transient internal helper, not a chat the user should see in the sidebar.
+export const translationWorkerIds = new Set<string>();
+
 // Session ids that belong to the multi-terminal GRID — dev terminals, spawned with
 // gui=0 (no GUI MCP; see the ?gui handling in the WS connection handler). They're
 // FILTERED OUT of the chat sidebar's /api/sessions so a grid terminal never surfaces

--- a/server/session/session-list.ts
+++ b/server/session/session-list.ts
@@ -1,0 +1,42 @@
+// The rules behind the two list endpoints, separated from the routes that serve them so
+// they can be tested without an app: which sessions the sidebar shows, in what order, and
+// which ids an activity poll is allowed to ask about.
+//
+// Worth isolating because the rules are quiet — a row that should have been hidden still
+// looks like a plausible response, so a regression here reads as correct output.
+import type { DiskStat, PendingSession } from "./types.js";
+
+export type SessionRow = DiskStat | PendingSession;
+
+export interface SessionRowFilter {
+  /** Transient internal helpers, never user-visible chats. */
+  isTranslationWorker: (id: string) => boolean;
+  /** Multi-terminal GRID sessions. */
+  isDevTerminal: (id: string) => boolean;
+  /** True for the unscoped (chat sidebar) query, false for a cwd-scoped one. */
+  includePending: boolean;
+  limit: number;
+}
+
+/** The rows a listing should render: newest first, capped, with the hidden kinds dropped.
+ *  The dev-terminal exclusion applies ONLY to the unscoped chat query — the grid's own
+ *  resume picker passes ?cwd= and must keep listing its sessions, or they stop being
+ *  resumable. Pure so that rule can be pinned; it is one boolean away from silently
+ *  hiding the grid's own sessions from itself. */
+export function selectSessionRows(rows: readonly SessionRow[], filter: SessionRowFilter): SessionRow[] {
+  return rows
+    .filter((row) => !filter.isTranslationWorker(row.id))
+    .filter((row) => !filter.includePending || !filter.isDevTerminal(row.id))
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, filter.limit);
+}
+
+/** The session ids an /api/activity poll may ask about: well-formed ones only, capped so a
+ *  client can't make us parse an unbounded query string. A non-string query yields none. */
+export function parseActivityIds(raw: unknown, isValidId: (id: string) => boolean, limit: number): string[] {
+  if (typeof raw !== "string") return [];
+  return raw
+    .split(",")
+    .filter((id) => isValidId(id))
+    .slice(0, limit);
+}

--- a/test/server/config/workspace.spec.ts
+++ b/test/server/config/workspace.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveWorkspace, workspaceFromQuery } from "../../../server/config/workspace.js";
+import { CLAUDE_CWD } from "../../../server/config/env.js";
+
+// resolveWorkspace guards what becomes a PTY's cwd, so every rejection matters: anything
+// it lets through unchecked is a path the client chose.
+describe("resolveWorkspace", () => {
+  let dir = "";
+  let file = "";
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "mt-ws-"));
+    file = path.join(dir, "a-file");
+    await fs.writeFile(file, "");
+  });
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("accepts an absolute path to an existing directory", () => {
+    expect(resolveWorkspace(dir)).toBe(dir);
+  });
+
+  it("falls back for a relative path, however real it is", () => {
+    expect(resolveWorkspace("server")).toBe(CLAUDE_CWD);
+    expect(resolveWorkspace("./server")).toBe(CLAUDE_CWD);
+    expect(resolveWorkspace("../mulmoterminal")).toBe(CLAUDE_CWD);
+  });
+
+  it("falls back for a path that does not exist", () => {
+    expect(resolveWorkspace(path.join(dir, "no-such-dir"))).toBe(CLAUDE_CWD);
+  });
+
+  it("falls back for a file — a cwd has to be a directory", () => {
+    expect(resolveWorkspace(file)).toBe(CLAUDE_CWD);
+  });
+
+  it("falls back for null and for empty", () => {
+    expect(resolveWorkspace(null)).toBe(CLAUDE_CWD);
+    expect(resolveWorkspace("")).toBe(CLAUDE_CWD);
+  });
+});
+
+describe("workspaceFromQuery", () => {
+  it("resolves a string query", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mt-wsq-"));
+    expect(workspaceFromQuery(dir)).toBe(dir);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  // Express hands over an array when a param repeats (?cwd=a&cwd=b) and undefined when it
+  // is absent; neither may reach the validation as a path.
+  it("falls back for anything that is not a string", () => {
+    expect(workspaceFromQuery(undefined)).toBe(CLAUDE_CWD);
+    expect(workspaceFromQuery(["/tmp", "/etc"])).toBe(CLAUDE_CWD);
+    expect(workspaceFromQuery(42)).toBe(CLAUDE_CWD);
+    expect(workspaceFromQuery(null)).toBe(CLAUDE_CWD);
+  });
+});

--- a/test/server/errors.spec.ts
+++ b/test/server/errors.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { hasErrnoCode, messageOf } from "../../server/errors.js";
+
+describe("messageOf", () => {
+  it("takes the message off an Error", () => {
+    expect(messageOf(new Error("boom"))).toBe("boom");
+  });
+
+  it("keeps a subclass's message", () => {
+    expect(messageOf(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  // Anything can be thrown, and the result goes straight into a log line.
+  it("stringifies a non-Error throw", () => {
+    expect(messageOf("just a string")).toBe("just a string");
+    expect(messageOf(42)).toBe("42");
+    expect(messageOf(null)).toBe("null");
+    expect(messageOf(undefined)).toBe("undefined");
+  });
+
+  it("does not throw on an object with no message", () => {
+    expect(messageOf({ code: "ENOENT" })).toBe("[object Object]");
+  });
+});
+
+describe("hasErrnoCode", () => {
+  it("accepts an fs error carrying a code", () => {
+    const err = Object.assign(new Error("missing"), { code: "ENOENT" });
+    expect(hasErrnoCode(err)).toBe(true);
+    if (hasErrnoCode(err)) expect(err.code).toBe("ENOENT");
+  });
+
+  // The guard only narrows to "could have a code" — callers still compare the value.
+  it("accepts any object, since a code may simply be absent", () => {
+    expect(hasErrnoCode(new Error("no code"))).toBe(true);
+    expect(hasErrnoCode({})).toBe(true);
+  });
+
+  it("rejects null and primitives, which would throw on property access", () => {
+    expect(hasErrnoCode(null)).toBe(false);
+    expect(hasErrnoCode(undefined)).toBe(false);
+    expect(hasErrnoCode("ENOENT")).toBe(false);
+    expect(hasErrnoCode(42)).toBe(false);
+  });
+});

--- a/test/server/files/atomic-write.spec.ts
+++ b/test/server/files/atomic-write.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { writeFileAtomic } from "../../../server/files/atomic-write.js";
+
+describe("writeFileAtomic", () => {
+  let dir = "";
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "mt-atomic-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes the file", async () => {
+    const file = path.join(dir, "state.json");
+    await writeFileAtomic(file, '{"a":1}');
+    expect(await fs.readFile(file, "utf8")).toBe('{"a":1}');
+  });
+
+  it("creates missing parent directories", async () => {
+    const file = path.join(dir, "deep", "nested", "state.json");
+    await writeFileAtomic(file, "hi");
+    expect(await fs.readFile(file, "utf8")).toBe("hi");
+  });
+
+  // The point of the rename: readers see the old file or the new one, never a temp.
+  it("leaves no temp file behind", async () => {
+    await writeFileAtomic(path.join(dir, "state.json"), "hi");
+    expect(await fs.readdir(dir)).toEqual(["state.json"]);
+  });
+
+  it("replaces existing content rather than appending", async () => {
+    const file = path.join(dir, "state.json");
+    await writeFileAtomic(file, "first");
+    await writeFileAtomic(file, "second");
+    expect(await fs.readFile(file, "utf8")).toBe("second");
+  });
+
+  // Each call picks a unique temp name, so two writers cannot trample one another's.
+  it("survives concurrent writes to the same path", async () => {
+    const file = path.join(dir, "state.json");
+    await Promise.all([writeFileAtomic(file, "a"), writeFileAtomic(file, "b"), writeFileAtomic(file, "c")]);
+    expect(["a", "b", "c"]).toContain(await fs.readFile(file, "utf8"));
+    expect(await fs.readdir(dir)).toEqual(["state.json"]);
+  });
+
+  it("writes an empty string as an empty file", async () => {
+    const file = path.join(dir, "empty.json");
+    await writeFileAtomic(file, "");
+    expect(await fs.readFile(file, "utf8")).toBe("");
+  });
+});

--- a/test/server/session/session-list.spec.ts
+++ b/test/server/session/session-list.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { parseActivityIds, selectSessionRows, type SessionRow } from "../../../server/session/session-list.js";
+
+const never = () => false;
+const disk = (id: string, mtime: number): SessionRow => ({ kind: "disk", id, file: `${id}.jsonl`, mtime });
+const pending = (id: string, mtime: number): SessionRow => ({
+  kind: "pending",
+  id,
+  title: id,
+  mtime,
+  working: false,
+  waiting: false,
+  event: null,
+  hidden: false,
+});
+const ids = (rows: SessionRow[]) => rows.map((r) => r.id);
+const filter = (over: Partial<Parameters<typeof selectSessionRows>[1]> = {}) => ({
+  isTranslationWorker: never,
+  isDevTerminal: never,
+  includePending: true,
+  limit: 50,
+  ...over,
+});
+
+describe("selectSessionRows", () => {
+  it("orders newest first, whatever order they arrive in", () => {
+    expect(ids(selectSessionRows([disk("old", 1), disk("new", 3), disk("mid", 2)], filter()))).toEqual(["new", "mid", "old"]);
+  });
+
+  it("interleaves pending rows with on-disk ones by recency", () => {
+    expect(ids(selectSessionRows([disk("a", 1), pending("b", 3), disk("c", 2)], filter()))).toEqual(["b", "c", "a"]);
+  });
+
+  it("drops translation workers — they are internal helpers, not chats", () => {
+    const rows = [disk("keep", 2), disk("worker", 3)];
+    expect(ids(selectSessionRows(rows, filter({ isTranslationWorker: (id) => id === "worker" })))).toEqual(["keep"]);
+  });
+
+  // The rule with history: hiding grid sessions from the CHAT sidebar must not hide them
+  // from the grid's OWN cwd-scoped resume picker, or they stop being resumable there.
+  it("hides grid sessions from the unscoped chat listing", () => {
+    const rows = [disk("chat", 2), disk("grid", 3)];
+    expect(ids(selectSessionRows(rows, filter({ isDevTerminal: (id) => id === "grid", includePending: true })))).toEqual(["chat"]);
+  });
+
+  it("keeps grid sessions in a cwd-scoped listing (the grid's own resume picker)", () => {
+    const rows = [disk("chat", 2), disk("grid", 3)];
+    expect(ids(selectSessionRows(rows, filter({ isDevTerminal: (id) => id === "grid", includePending: false })))).toEqual(["grid", "chat"]);
+  });
+
+  it("caps the listing, keeping the newest", () => {
+    const rows = [disk("a", 1), disk("b", 2), disk("c", 3)];
+    expect(ids(selectSessionRows(rows, filter({ limit: 2 })))).toEqual(["c", "b"]);
+  });
+
+  it("keeps exactly `limit` rows at the boundary", () => {
+    const rows = [disk("a", 1), disk("b", 2)];
+    expect(selectSessionRows(rows, filter({ limit: 2 }))).toHaveLength(2);
+  });
+
+  it("returns nothing for a zero limit", () => {
+    expect(selectSessionRows([disk("a", 1)], filter({ limit: 0 }))).toEqual([]);
+  });
+
+  it("returns nothing for no rows", () => {
+    expect(selectSessionRows([], filter())).toEqual([]);
+  });
+
+  it("filters before capping, so a hidden row cannot consume a slot", () => {
+    const rows = [disk("worker", 9), disk("a", 2), disk("b", 1)];
+    expect(ids(selectSessionRows(rows, filter({ isTranslationWorker: (id) => id === "worker", limit: 2 })))).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const rows = [disk("a", 1), disk("b", 3)];
+    selectSessionRows(rows, filter());
+    expect(ids(rows)).toEqual(["a", "b"]);
+  });
+});
+
+describe("parseActivityIds", () => {
+  const uuidish = (id: string) => id.startsWith("id-");
+
+  it("keeps the well-formed ids", () => {
+    expect(parseActivityIds("id-1,id-2", uuidish, 10)).toEqual(["id-1", "id-2"]);
+  });
+
+  it("drops ids that fail validation", () => {
+    expect(parseActivityIds("id-1,../evil,id-2", uuidish, 10)).toEqual(["id-1", "id-2"]);
+  });
+
+  it("caps the count so the query string stays bounded", () => {
+    expect(parseActivityIds("id-1,id-2,id-3", uuidish, 2)).toEqual(["id-1", "id-2"]);
+  });
+
+  it("returns none for an empty query", () => {
+    expect(parseActivityIds("", uuidish, 10)).toEqual([]);
+  });
+
+  // Express gives an array when a param repeats (?ids=a&ids=b), and undefined when absent.
+  it("returns none for a non-string query", () => {
+    expect(parseActivityIds(["id-1", "id-2"], uuidish, 10)).toEqual([]);
+    expect(parseActivityIds(undefined, uuidish, 10)).toEqual([]);
+    expect(parseActivityIds(null, uuidish, 10)).toEqual([]);
+  });
+
+  it("returns none when nothing validates", () => {
+    expect(parseActivityIds("nope,also-nope", uuidish, 10)).toEqual([]);
+  });
+});

--- a/test/server/session/session-reads.spec.ts
+++ b/test/server/session/session-reads.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { projectSessionsDir } from "../../../server/session/session-reads.js";
+
+// Claude owns this encoding — we only mirror it to find the directory it already wrote.
+// Pinned because a mismatch is silent: the wrong path just reads as "no sessions yet".
+describe("projectSessionsDir", () => {
+  const projects = path.join(os.homedir(), ".claude", "projects");
+
+  it("encodes an absolute posix path with / and . folded to -", () => {
+    expect(projectSessionsDir("/Users/me/ss/my.app")).toBe(path.join(projects, "-Users-me-ss-my-app"));
+  });
+
+  it("resolves a relative path first, so the same dir maps to one directory", () => {
+    expect(projectSessionsDir("/ws/sub/../app")).toBe(projectSessionsDir("/ws/app"));
+  });
+
+  it("keeps different workspaces apart", () => {
+    expect(projectSessionsDir("/ws/app")).not.toBe(projectSessionsDir("/ws/app2"));
+  });
+
+  it("lands under ~/.claude/projects", () => {
+    expect(projectSessionsDir("/ws/app").startsWith(projects)).toBe(true);
+  });
+
+  // Two paths that differ only in "/" vs "." collapse to the same name. That is Claude's
+  // scheme, not ours; the test records the collision so a future reader knows it is known
+  // rather than assuming the encoding is injective.
+  it("collides where Claude's own encoding collides", () => {
+    expect(projectSessionsDir("/ws/a.b")).toBe(projectSessionsDir("/ws/a/b"));
+  });
+});


### PR DESCRIPTION
## Summary

#548 Step 2 の 3/4。セッション系ルート 5 本を `server/routes/session-routes.ts` へ。`server/index.ts` を **2514 → 2359 行**（-155）。

`/api/sessions` `/api/session/:id` `/api/activity` `/api/transcript/timeline` `/api/codex/sessions`

**Step 2 で最も絡まっていた塊です。** Step 1 で状態が、2b-1 で読み手がモジュールになったおかげで、**注入すべき依存は 8 個から 1 個に減りました**。

## Items to Confirm / Review

1. **注入は `freshenRosterTitle` だけ**です。閲覧中セッションの再タイトル付けは要約セッションを spawn するため、index.ts が持つタイトル生成機構側の責務として残しました
2. **`translationWorkerIds` を registry へ、`hasErrnoCode` を errors.ts へ移しました**（注入ではなく、既に必要とされていた場所へ）。前者はルート・hook・翻訳ワーカーが共に読む per-session 状態で、Step 1 の基準に合致します
3. **lint が mount を 97 行（上限 60）と検出**したため、上限を緩めるのではなく**各ルートを名前付きハンドラに分割**しました（`sessionDetail` / `activitySnapshot` / `toolTimeline` / `sessionList` / `codexSessionList`）。mount は 5 行の登録だけです
4. **`sessionDetail` は `Request<{ id: string }>` を取ります。** ハンドラを独立関数にすると Express のパスリテラルからの型推論が効かず `req.params.id` が `string | string[]` になるためで、`backends/feeds.ts` と同じ書き方に揃えました

## 挙動不変であることの検証

移動したコードに **400 を返す入力検証が含まれる**ため、今回は異常系も比較対象に加えました。main と本ブランチを並行起動し、**9 リクエストすべて完全一致**:

```
/api/sessions?cwd=…                        200
/api/sessions                              200   ← cwd 無指定（pending 合流あり）
/api/session/<uuid>?cwd=…                  200
/api/session/not-a-uuid                    400   ← 不正 id
/api/activity?ids=<uuid>                   200
/api/activity?ids=not-a-uuid               200   ← 不正 id は除外され空を返す
/api/transcript/timeline?session=<uuid>    200
/api/transcript/timeline?session=not-a-uuid 400  ← 不正 id
/api/codex/sessions?cwd=…                  200
diff → 差分なし
```

`index.ts` への追加行は mount 呼び出しと import のみ。`lint` / `build` / `typecheck` ×2 / `knip` / `test`（1541 件）すべて green。

## Step 2 の残り

**2c**: エージェント/GUI 系 8 本（`/api/hook` `/api/agent/*` `/api/tools` `/api/tool-calls` `/api/mcp/*` `/api/plugin/*` `/api/translation/submit`）。直書きルートは 27 → 9 本になりました。

Refs #548
