### PR TITLE
refactor: tool store を DI 付きで切り出し＋テスト20件（#548 Step 2c-1）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -55,7 +55,7 @@ import { resolveSession, type SessionResolution } from "./session/session-resolv
 import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "./session/activity-hook.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { hasErrnoCode, messageOf } from "./errors.js";
-import type { PtyEntry, ToolCall, ToolResult } from "./session/types.js";
+import type { PtyEntry } from "./session/types.js";
 import {
   activity,
   aiTitles,
@@ -81,6 +81,7 @@ import {
 import { reapDecisionFor } from "./session/reap-policy.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
+import { createToolStores } from "./session/tool-store.js";
 import { claudeOnDiskSessionIds, latestUserPrompt, projectSessionsDir, sessionExistsOnDisk, LAST_RESPONSE_MAX } from "./session/session-reads.js";
 import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, heldByAnotherProcess, scheduledSessionsDir } from "./session/scheduled-sessions.js";
@@ -207,148 +208,11 @@ const sessionChannel = (id: string) => `session:${id}`;
 // worker can call it without a permission prompt.
 const GUI_MCP_TOOLS = [...allowedToolNames(), "mcp__mulmoterminal-gui__submitTranslation"].join(",");
 
-// A per-session list store mirrored to disk so it survives a server reboot — one
-// JSON file per session under <workspace>/<dirName>/<sessionId>.json
-// (<workspace> = CLAUDE_CWD). The in-memory Map is the working copy; the file is
-// rewritten on each change and lazy-loaded on first access. Session ids are
-// validated UUIDs (SESSION_ID_RE), so they're safe to use as filenames.
-function createSessionStore<T>(dirName: string) {
-  const dir = path.join(MULMOTERMINAL_HOME, dirName);
-  const fileFor = (id: string) => path.join(dir, `${id}.json`);
-  const map = new Map<string, T[]>(); // id -> list (the working copy; mutate in place)
-  const loading = new Map<string, Promise<T[]>>(); // id -> Promise<list>, dedupes concurrent loads
-
-  // Lazily load a session's list from disk, then keep using the in-memory copy.
-  function get(sessionId: string): Promise<T[]> {
-    const cached = map.get(sessionId);
-    if (cached) return Promise.resolve(cached);
-    const inflight = loading.get(sessionId);
-    if (inflight) return inflight;
-    const p = (async () => {
-      let list: T[] = [];
-      if (SESSION_ID_RE.test(sessionId)) {
-        try {
-          const parsed = JSON.parse(await fs.readFile(fileFor(sessionId), "utf8"));
-          if (Array.isArray(parsed)) list = parsed;
-        } catch {
-          // No file yet (or unreadable) => start empty.
-        }
-      }
-      map.set(sessionId, list);
-      loading.delete(sessionId);
-      return list;
-    })();
-    loading.set(sessionId, p);
-    return p;
-  }
-
-  // Persist a session's list (best-effort, fire-and-forget).
-  async function save(sessionId: string) {
-    if (!SESSION_ID_RE.test(sessionId)) return;
-    try {
-      await fs.mkdir(dir, { recursive: true });
-      await fs.writeFile(fileFor(sessionId), JSON.stringify(map.get(sessionId) || []));
-    } catch (e) {
-      console.error(`[${dirName}] failed to persist ${sessionId}: ${messageOf(e)}`);
-    }
-  }
-
-  return { get, save };
-}
-
-// GUI toolResults per session, persisted under ~/.mulmoterminal/toolresults so
-// the panel replays the rendered views even after a server reboot. (Chat +
-// message history live in the terminal and Claude's .jsonl; this is the GUI-side
-// store.) Each entry is an array of toolResults, capped to the most recent N.
-const toolResultsStore = createSessionStore<ToolResult>("toolresults");
-const GUI_HISTORY_LIMIT = 50;
-
-// Upsert a toolResult into a session's list, deduped by uuid — a re-emitted result
-// (e.g. a form whose viewState changed after the user submitted) updates in place.
-// Mirrors MulmoClaude's applyToolResultToSession.
-async function storeToolResult(sessionId: string, result: ToolResult) {
-  const list = await toolResultsStore.get(sessionId);
-  const idx = list.findIndex((r) => r.uuid === result.uuid);
-  if (idx >= 0) {
-    list[idx] = result;
-  } else {
-    list.push(result);
-    if (list.length > GUI_HISTORY_LIMIT) list.splice(0, list.length - GUI_HISTORY_LIMIT);
-  }
-  toolResultsStore.save(sessionId);
-}
-
-// Per-session tool-call history, fed by Claude's PreToolUse/PostToolUse hooks so
-// it captures EVERY tool call — built-ins (Bash, Read, …), the user's MCP tools,
-// AND our GUI plugin tools — not just the GUI ones the broker sees. Published on a
-// per-session channel the tools pane subscribes to. (The broker's toolResults
-// store above is separate; it only drives rendering of GUI views.)
-//
-// Persisted under ~/.mulmoterminal/toolcalls via the same disk-backed store as
-// the toolResults, so the history survives a server reboot.
-const toolCallsStore = createSessionStore<ToolCall>("toolcalls");
-const TOOLCALLS_LIMIT = 200;
-const toolCallsChannel = (id: string) => `toolcalls:${id}`;
-// Stored tool outputs are capped so one verbose tool can't bloat the on-disk
-// history (and the pane). The raw output still reaches the LLM via the terminal;
-// this is only the history copy.
-const TOOL_OUTPUT_CAP = 20_000;
-
-function capToolOutput(output: unknown): unknown {
-  if (typeof output === "string" && output.length > TOOL_OUTPUT_CAP) {
-    return output.slice(0, TOOL_OUTPUT_CAP) + `\n… (truncated ${output.length - TOOL_OUTPUT_CAP} chars)`;
-  }
-  return output;
-}
-
-// PreToolUse: a tool started. Append a "running" entry (deduped by tool_use_id).
-async function recordToolCallStart(sessionId: string, { toolUseId, toolName, toolInput }: { toolUseId?: string; toolName?: string; toolInput?: unknown }) {
-  const list = await toolCallsStore.get(sessionId);
-  if (toolUseId && list.some((c) => c.toolUseId === toolUseId)) return;
-  const call = { toolUseId, toolName, toolInput, status: "running", at: Date.now() };
-  list.push(call);
-  if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
-  pubsub?.publish(toolCallsChannel(sessionId), call);
-  toolCallsStore.save(sessionId);
-}
-
-// PostToolUse (status "completed") or PostToolUseFailure (status "failed"):
-// complete the matching entry by tool_use_id (or add one if we never saw the
-// start). A failed tool fires PostToolUseFailure, NOT PostToolUse, so both route
-// here — otherwise the entry would be stuck on "running".
-async function recordToolCallEnd(
-  sessionId: string,
-  {
-    toolUseId,
-    toolName,
-    toolInput,
-    toolOutput,
-    durationMs,
-    status,
-  }: {
-    toolUseId?: string;
-    toolName?: string;
-    toolInput?: unknown;
-    toolOutput?: unknown;
-    durationMs?: number;
-    status: string;
-  },
-) {
-  const list = await toolCallsStore.get(sessionId);
-  const output = capToolOutput(toolOutput);
-  let call = toolUseId ? list.find((c) => c.toolUseId === toolUseId) : undefined;
-  if (call) {
-    call.status = status;
-    call.toolOutput = output;
-    call.durationMs = durationMs;
-  } else {
-    call = { toolUseId, toolName, toolInput, toolOutput: output, status, at: Date.now(), durationMs };
-    list.push(call);
-    if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
-  }
-  pubsub?.publish(toolCallsChannel(sessionId), call);
-  toolCallsStore.save(sessionId);
-}
+// The panel's per-session stores. `publish` is a closure rather than the pubsub object
+// because pub/sub only exists once the HTTP server does, and these are built before it.
+const { toolResultsStore, toolCallsStore, storeToolResult, recordToolCallStart, recordToolCallEnd } = createToolStores({
+  publish: (channel, data) => pubsub?.publish(channel, data),
+});
 
 const LAST_PROMPT_CAP = 200;
 

--- a/server/session/tool-store.ts
+++ b/server/session/tool-store.ts
@@ -1,0 +1,169 @@
+// The GUI panel's two per-session stores: the tool RESULTS a plugin rendered, and the
+// tool-CALL history every hook records. Both are disk-backed so the panel replays after a
+// reboot. Extracted from index.ts (#548) with two things injected rather than imported:
+//
+// - `publish`, because pub/sub only exists once the HTTP server does. It arrives as a
+//   closure, so it stays correct however late that happens.
+// - `root`, so a test writes to a temp directory instead of the developer's own
+//   ~/.mulmoterminal — the readers' equivalent of that binding is why registry.ts still
+//   has no tests.
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
+import { messageOf } from "../errors.js";
+import type { ToolCall, ToolResult } from "./types.js";
+
+export interface ToolStoreDeps {
+  /** Fan a change out to the panel; a no-op before pub/sub exists. */
+  publish: (channel: string, data: unknown) => void;
+  /** Where the JSON files live. Defaults to ~/.mulmoterminal. */
+  root?: string;
+}
+
+// A per-session list store mirrored to disk so it survives a server reboot — one
+// JSON file per session under <workspace>/<dirName>/<sessionId>.json
+// (<workspace> = CLAUDE_CWD). The in-memory Map is the working copy; the file is
+// rewritten on each change and lazy-loaded on first access. Session ids are
+// validated UUIDs (SESSION_ID_RE), so they're safe to use as filenames.
+export function createSessionStore<T>(dirName: string, root: string = MULMOTERMINAL_HOME) {
+  const dir = path.join(root, dirName);
+  const fileFor = (id: string) => path.join(dir, `${id}.json`);
+  const map = new Map<string, T[]>(); // id -> list (the working copy; mutate in place)
+  const loading = new Map<string, Promise<T[]>>(); // id -> Promise<list>, dedupes concurrent loads
+
+  // Lazily load a session's list from disk, then keep using the in-memory copy.
+  function get(sessionId: string): Promise<T[]> {
+    const cached = map.get(sessionId);
+    if (cached) return Promise.resolve(cached);
+    const inflight = loading.get(sessionId);
+    if (inflight) return inflight;
+    const p = (async () => {
+      let list: T[] = [];
+      if (SESSION_ID_RE.test(sessionId)) {
+        try {
+          const parsed = JSON.parse(await fs.readFile(fileFor(sessionId), "utf8"));
+          if (Array.isArray(parsed)) list = parsed;
+        } catch {
+          // No file yet (or unreadable) => start empty.
+        }
+      }
+      map.set(sessionId, list);
+      loading.delete(sessionId);
+      return list;
+    })();
+    loading.set(sessionId, p);
+    return p;
+  }
+
+  // Persist a session's list (best-effort, fire-and-forget).
+  async function save(sessionId: string) {
+    if (!SESSION_ID_RE.test(sessionId)) return;
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(fileFor(sessionId), JSON.stringify(map.get(sessionId) || []));
+    } catch (e) {
+      console.error(`[${dirName}] failed to persist ${sessionId}: ${messageOf(e)}`);
+    }
+  }
+
+  return { get, save };
+}
+
+export const toolCallsChannel = (id: string) => `toolcalls:${id}`;
+
+// Stored tool outputs are capped so one verbose tool can't bloat the on-disk history (and
+// the pane). The raw output still reaches the LLM via the terminal; this is only the copy.
+const TOOL_OUTPUT_CAP = 20_000;
+
+export function capToolOutput(output: unknown): unknown {
+  if (typeof output === "string" && output.length > TOOL_OUTPUT_CAP) {
+    return output.slice(0, TOOL_OUTPUT_CAP) + `\n… (truncated ${output.length - TOOL_OUTPUT_CAP} chars)`;
+  }
+  return output;
+}
+
+/** The panel's stores, bound to one pub/sub and one directory root. */
+export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolStoreDeps) {
+  // GUI toolResults per session, persisted under ~/.mulmoterminal/toolresults so
+  // the panel replays the rendered views even after a server reboot. (Chat +
+  // message history live in the terminal and Claude's .jsonl; this is the GUI-side
+  // store.) Each entry is an array of toolResults, capped to the most recent N.
+  const toolResultsStore = createSessionStore<ToolResult>("toolresults", root);
+  const GUI_HISTORY_LIMIT = 50;
+
+  // Upsert a toolResult into a session's list, deduped by uuid — a re-emitted result
+  // (e.g. a form whose viewState changed after the user submitted) updates in place.
+  // Mirrors MulmoClaude's applyToolResultToSession.
+  async function storeToolResult(sessionId: string, result: ToolResult) {
+    const list = await toolResultsStore.get(sessionId);
+    const idx = list.findIndex((r) => r.uuid === result.uuid);
+    if (idx >= 0) {
+      list[idx] = result;
+    } else {
+      list.push(result);
+      if (list.length > GUI_HISTORY_LIMIT) list.splice(0, list.length - GUI_HISTORY_LIMIT);
+    }
+    toolResultsStore.save(sessionId);
+  }
+
+  // Per-session tool-call history, fed by Claude's PreToolUse/PostToolUse hooks so
+  // it captures EVERY tool call — built-ins (Bash, Read, …), the user's MCP tools,
+  // AND our GUI plugin tools — not just the GUI ones the broker sees. Published on a
+  // per-session channel the tools pane subscribes to. (The broker's toolResults
+  // store above is separate; it only drives rendering of GUI views.)
+  //
+  // Persisted under ~/.mulmoterminal/toolcalls via the same disk-backed store as
+  // the toolResults, so the history survives a server reboot.
+  const toolCallsStore = createSessionStore<ToolCall>("toolcalls", root);
+  const TOOLCALLS_LIMIT = 200;
+  // PreToolUse: a tool started. Append a "running" entry (deduped by tool_use_id).
+  async function recordToolCallStart(sessionId: string, { toolUseId, toolName, toolInput }: { toolUseId?: string; toolName?: string; toolInput?: unknown }) {
+    const list = await toolCallsStore.get(sessionId);
+    if (toolUseId && list.some((c) => c.toolUseId === toolUseId)) return;
+    const call = { toolUseId, toolName, toolInput, status: "running", at: Date.now() };
+    list.push(call);
+    if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
+    publish(toolCallsChannel(sessionId), call);
+    toolCallsStore.save(sessionId);
+  }
+
+  // PostToolUse (status "completed") or PostToolUseFailure (status "failed"):
+  // complete the matching entry by tool_use_id (or add one if we never saw the
+  // start). A failed tool fires PostToolUseFailure, NOT PostToolUse, so both route
+  // here — otherwise the entry would be stuck on "running".
+  async function recordToolCallEnd(
+    sessionId: string,
+    {
+      toolUseId,
+      toolName,
+      toolInput,
+      toolOutput,
+      durationMs,
+      status,
+    }: {
+      toolUseId?: string;
+      toolName?: string;
+      toolInput?: unknown;
+      toolOutput?: unknown;
+      durationMs?: number;
+      status: string;
+    },
+  ) {
+    const list = await toolCallsStore.get(sessionId);
+    const output = capToolOutput(toolOutput);
+    let call = toolUseId ? list.find((c) => c.toolUseId === toolUseId) : undefined;
+    if (call) {
+      call.status = status;
+      call.toolOutput = output;
+      call.durationMs = durationMs;
+    } else {
+      call = { toolUseId, toolName, toolInput, toolOutput: output, status, at: Date.now(), durationMs };
+      list.push(call);
+      if (list.length > TOOLCALLS_LIMIT) list.splice(0, list.length - TOOLCALLS_LIMIT);
+    }
+    publish(toolCallsChannel(sessionId), call);
+    toolCallsStore.save(sessionId);
+  }
+
+  return { toolResultsStore, toolCallsStore, storeToolResult, recordToolCallStart, recordToolCallEnd };
+}

--- a/test/server/session/tool-store.spec.ts
+++ b/test/server/session/tool-store.spec.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { capToolOutput, createSessionStore, createToolStores, toolCallsChannel } from "../../../server/session/tool-store.js";
+
+const SESSION = "11111111-2222-4333-8444-555555555555";
+const OTHER = "99999999-2222-4333-8444-555555555555";
+
+describe("capToolOutput", () => {
+  it("passes a short string through untouched", () => {
+    expect(capToolOutput("hello")).toBe("hello");
+  });
+
+  it("truncates a long string and says how much it dropped", () => {
+    const out = capToolOutput("x".repeat(20_050));
+    expect(typeof out).toBe("string");
+    expect(String(out)).toContain("truncated 50 chars");
+    expect(String(out).length).toBeLessThan(20_100);
+  });
+
+  it("keeps a string exactly at the cap whole", () => {
+    expect(capToolOutput("x".repeat(20_000))).toBe("x".repeat(20_000));
+  });
+
+  // Only strings are capped — a structured output would be destroyed by slicing.
+  it("leaves non-strings alone", () => {
+    const obj = { a: 1 };
+    expect(capToolOutput(obj)).toBe(obj);
+    expect(capToolOutput(undefined)).toBeUndefined();
+    expect(capToolOutput(null)).toBeNull();
+    expect(capToolOutput(42)).toBe(42);
+  });
+});
+
+describe("toolCallsChannel", () => {
+  it("namespaces per session", () => {
+    expect(toolCallsChannel("abc")).toBe("toolcalls:abc");
+    expect(toolCallsChannel("abc")).not.toBe(toolCallsChannel("abd"));
+  });
+});
+
+describe("createSessionStore", () => {
+  let root = "";
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "mt-store-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("starts empty and persists what it is given", async () => {
+    const store = createSessionStore<{ n: number }>("things", root);
+    const list = await store.get(SESSION);
+    expect(list).toEqual([]);
+    list.push({ n: 1 });
+    await store.save(SESSION);
+    expect(JSON.parse(await fs.readFile(path.join(root, "things", `${SESSION}.json`), "utf8"))).toEqual([{ n: 1 }]);
+  });
+
+  it("reloads a session's list from disk in a fresh store", async () => {
+    await fs.mkdir(path.join(root, "things"), { recursive: true });
+    await fs.writeFile(path.join(root, "things", `${SESSION}.json`), JSON.stringify([{ n: 7 }]));
+    expect(await createSessionStore<{ n: number }>("things", root).get(SESSION)).toEqual([{ n: 7 }]);
+  });
+
+  it("hands back the SAME array each time, since callers mutate in place", async () => {
+    const store = createSessionStore<{ n: number }>("things", root);
+    const first = await store.get(SESSION);
+    first.push({ n: 1 });
+    expect(await store.get(SESSION)).toBe(first);
+  });
+
+  it("dedupes concurrent first loads into one list", async () => {
+    const store = createSessionStore<{ n: number }>("things", root);
+    const [a, b] = await Promise.all([store.get(SESSION), store.get(SESSION)]);
+    expect(a).toBe(b);
+  });
+
+  it("keeps sessions apart", async () => {
+    const store = createSessionStore<{ n: number }>("things", root);
+    (await store.get(SESSION)).push({ n: 1 });
+    expect(await store.get(OTHER)).toEqual([]);
+  });
+
+  it("starts empty when the file is corrupt or not an array", async () => {
+    await fs.mkdir(path.join(root, "things"), { recursive: true });
+    await fs.writeFile(path.join(root, "things", `${SESSION}.json`), "{not json");
+    expect(await createSessionStore("things", root).get(SESSION)).toEqual([]);
+    await fs.writeFile(path.join(root, "things", `${OTHER}.json`), '{"a":1}');
+    expect(await createSessionStore("things", root).get(OTHER)).toEqual([]);
+  });
+
+  // The id becomes a filename, so a bad one must never reach the disk.
+  it("refuses to read or write an id that is not a session uuid", async () => {
+    const store = createSessionStore<{ n: number }>("things", root);
+    const list = await store.get("../escape");
+    expect(list).toEqual([]);
+    list.push({ n: 1 });
+    await store.save("../escape");
+    await expect(fs.stat(path.join(root, "escape.json"))).rejects.toThrow();
+    await expect(fs.stat(path.join(root, "things"))).rejects.toThrow();
+  });
+});
+
+describe("createToolStores", () => {
+  let root = "";
+  const publish = vi.fn();
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "mt-tools-"));
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const stores = () => createToolStores({ publish, root });
+
+  it("appends a tool result", async () => {
+    const s = stores();
+    await s.storeToolResult(SESSION, { uuid: "a", value: 1 });
+    expect(await s.toolResultsStore.get(SESSION)).toEqual([{ uuid: "a", value: 1 }]);
+  });
+
+  // A form that re-emits after its state changes must update, not stack up.
+  it("replaces a result with the same uuid in place", async () => {
+    const s = stores();
+    await s.storeToolResult(SESSION, { uuid: "a", value: 1 });
+    await s.storeToolResult(SESSION, { uuid: "a", value: 2 });
+    expect(await s.toolResultsStore.get(SESSION)).toEqual([{ uuid: "a", value: 2 }]);
+  });
+
+  it("caps the result history at 50, keeping the newest", async () => {
+    const s = stores();
+    for (let i = 0; i < 55; i++) await s.storeToolResult(SESSION, { uuid: `u${i}` });
+    const list = await s.toolResultsStore.get(SESSION);
+    expect(list).toHaveLength(50);
+    expect(list[0].uuid).toBe("u5");
+    expect(list.at(-1)?.uuid).toBe("u54");
+  });
+
+  it("records a call as running, then completes the SAME entry", async () => {
+    const s = stores();
+    await s.recordToolCallStart(SESSION, { toolUseId: "t1", toolName: "Bash", toolInput: { command: "ls" } });
+    await s.recordToolCallEnd(SESSION, { toolUseId: "t1", toolOutput: "done", durationMs: 12, status: "ok" });
+    const list = await s.toolCallsStore.get(SESSION);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({ toolUseId: "t1", toolName: "Bash", status: "ok", toolOutput: "done", durationMs: 12 });
+  });
+
+  // PostToolUseFailure can arrive without a matching start (e.g. after a restart).
+  it("creates an entry when an end arrives with no start", async () => {
+    const s = stores();
+    await s.recordToolCallEnd(SESSION, { toolUseId: "orphan", toolName: "Read", status: "error" });
+    expect(await s.toolCallsStore.get(SESSION)).toHaveLength(1);
+  });
+
+  it("caps a long tool output when storing it", async () => {
+    const s = stores();
+    await s.recordToolCallEnd(SESSION, { toolUseId: "t1", toolOutput: "x".repeat(20_050), status: "ok" });
+    expect(String((await s.toolCallsStore.get(SESSION))[0].toolOutput)).toContain("truncated");
+  });
+
+  it("publishes each call on the session's channel so the pane can follow it", async () => {
+    const s = stores();
+    await s.recordToolCallStart(SESSION, { toolUseId: "t1", toolName: "Bash" });
+    await s.recordToolCallEnd(SESSION, { toolUseId: "t1", status: "ok" });
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(publish.mock.calls.every(([channel]) => channel === `toolcalls:${SESSION}`)).toBe(true);
+  });
+
+  it("writes under the injected root, never the real home", async () => {
+    const s = stores();
+    await s.storeToolResult(SESSION, { uuid: "a" });
+    await s.recordToolCallStart(SESSION, { toolUseId: "t1" });
+    expect((await fs.readdir(root)).sort()).toEqual(["toolcalls", "toolresults"]);
+  });
+});


### PR DESCRIPTION
## Summary

#548 Step 2c の 1/2。GUI パネルの per-session ストア 2 つを `server/session/tool-store.ts` へ。`server/index.ts` を **2359 → 2223 行**（-136）。

**ルートを動かす前段です**（2b-1 と同じ構造）。加えて、追加した CLAUDE.md の「できる限り純粋関数にし、越えられない境界は DI」というルールの最初の実践でもあります。

## Items to Confirm / Review

1. **束縛していた 2 つを引数化しました**
   - `publish` — pubsub オブジェクトではなく**クロージャ**で受けます。pub/sub は HTTP サーバ生成後にしか存在せず、ストアはそれより前に作られるためです
   - `root` — テストが**開発者の実際の `~/.mulmoterminal` に書き込まない**ため。これは前 PR で「registry.ts がテスト不能」として記載した負債と同じ原因で、こちらは先に返済しました
2. **`capToolOutput` / `toolCallsChannel` はモジュールスコープに残しました**（状態を持たず、単体でテストする価値があるため）
3. **`registry.ts` の同じ負債は未返済**です。`MULMOTERMINAL_HOME` を import 時に束縛しており、テストすると実ホームに書き込みます。別 PR で `root` 注入に揃えるべきです

## テスト（20 件・ゼロからの追加）

| 対象 | 内容 |
|---|---|
| uuid ガード | 不正 id がファイル名にならない（`../escape` でディレクトリ外に書かない） |
| uuid 重複排除 | 再送するフォームが積み上がらず置換される |
| 上限 2 種 | 結果 50 件・出力 20,000 文字 |
| start/end の対応 | 同一エントリの更新、**start 無しの end**（`PostToolUseFailure` で起きる） |
| 注入した root | 書き込みが temp 配下に閉じる |
| `capToolOutput` | 境界ちょうど・非文字列は素通し |

**すべて teeth を確認済み**です。ガード削除・上限削除・重複排除の無効化・出力 cap の削除、それぞれで該当テストが赤になることを実際に見ています。

## 挙動不変の検証

main と本ブランチを並行起動し、**POST で結果を保存 → 読み戻し**まで含めて突き合わせ、完全一致:

```
POST /api/agent/toolResult              200
/api/tools                              200
/api/agent/toolResults/<uuid>           200  ← POST した内容が読める
/api/agent/toolResults/bad-id           400
/api/tool-calls/<uuid>                  200
/api/tool-calls/bad-id                  400
diff → 差分なし
```

検証で実ホームに作られたテスト用ファイルは削除済みです。

`lint` / `build` / `typecheck` ×2 / `knip` / `test`（**1603 件**）すべて green。

## 残り

**2c-2**: ルート本体（`/api/agent/*` `/api/tools` `/api/tool-calls` `/api/prs` `/api/issues` `/api/plugin/*` `/api/mcp/*` `/api/hook` `/api/translation/submit`）

Refs #548
