### PR TITLE
refactor: ツールペイン系4本と repo 系2本を server/routes/ へ（#548 Step 2c-2）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -14,7 +14,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./infra/plugins
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getPrRepos, getLaunchers, getUserMcpServers, getHeaderConfig, getPushEnabled, getWorklogConfig } from "./config/config-routes.js";
+import { mountConfigRoutes, getLaunchers, getUserMcpServers, getHeaderConfig, getPushEnabled, getWorklogConfig } from "./config/config-routes.js";
 import { sendWebPush } from "./infra/web-push.js";
 import { buildHeaderContext, loadHeaderConfig } from "./config/header-context.js";
 import { resolveButtonCommand } from "./config/header-resolve.js";
@@ -46,8 +46,6 @@ import {
   rewriteLoopbackForDocker,
   SANDBOX_HOST,
 } from "./infra/sandbox.js";
-import { listPrsAcrossRepos } from "./git/prs.js";
-import { listIssuesAcrossRepos } from "./git/issues.js";
 import { dirConfigWriteTarget } from "./config/dir-config.js";
 import { resolveScript } from "./files/scripts.js";
 import { buildClaudeArgs } from "./agents/claude-args.js";
@@ -82,6 +80,8 @@ import { reapDecisionFor } from "./session/reap-policy.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
+import { mountToolRoutes } from "./routes/tool-routes.js";
+import { mountRepoRoutes } from "./routes/repo-routes.js";
 import { claudeOnDiskSessionIds, latestUserPrompt, projectSessionsDir, sessionExistsOnDisk, LAST_RESPONSE_MAX } from "./session/session-reads.js";
 import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, heldByAnotherProcess, scheduledSessionsDir } from "./session/scheduled-sessions.js";
@@ -210,9 +210,10 @@ const GUI_MCP_TOOLS = [...allowedToolNames(), "mcp__mulmoterminal-gui__submitTra
 
 // The panel's per-session stores. `publish` is a closure rather than the pubsub object
 // because pub/sub only exists once the HTTP server does, and these are built before it.
-const { toolResultsStore, toolCallsStore, storeToolResult, recordToolCallStart, recordToolCallEnd } = createToolStores({
+const toolStores = createToolStores({
   publish: (channel, data) => pubsub?.publish(channel, data),
 });
+const { recordToolCallStart, recordToolCallEnd } = toolStores;
 
 const LAST_PROMPT_CAP = 200;
 
@@ -923,71 +924,12 @@ app.post("/api/hook", async (req, res) => {
   res.json({ ok: true });
 });
 
-// The GUI toolResult sink. Two callers POST here:
-//   - the MCP broker, after a plugin produces a result (data gates rendering);
-//   - the GUI panel, to persist a plugin view's state change (e.g. a submitted
-//     form's viewState) under the same uuid.
-// We store the result keyed by session id and publish it on that session's channel
-// so the active panel renders/updates it live. Mirrors MulmoClaude's internal
-// toolResult route + applyToolResultToSession.
-app.post("/api/agent/toolResult", async (req, res) => {
-  const { sessionId, toolName, uuid } = req.body || {};
-  // The session id flows from env (broker) / the client and ends up in a pub/sub
-  // channel name — keep it to the known UUID shape.
-  if (!sessionId || !SESSION_ID_RE.test(sessionId)) {
-    return res.status(400).json({ error: "invalid sessionId" });
-  }
-  if (typeof toolName !== "string" || !toolName) {
-    return res.status(400).json({ error: "invalid toolName" });
-  }
-  if (typeof uuid !== "string" || !uuid) {
-    return res.status(400).json({ error: "invalid uuid" });
-  }
+// The tools pane: the toolResult sink, its replay, the available-tool list and the
+// call history (see routes/tool-routes.ts).
+mountToolRoutes(app, { stores: toolStores, toolSummaries, publish: (c, d) => pubsub?.publish(c, d), sessionChannel });
 
-  // Store everything except the routing fields; the result itself is the payload
-  // the panel renders.
-  // `persistOnly` (set by the GUI panel when a view persists its own state change)
-  // means: store, but do NOT re-publish on the session channel. Re-publishing would
-  // echo the update back to the originating panel as a fresh result, which re-seeds
-  // the view and re-emits — an infinite flicker loop. The broker (new tool calls)
-  // omits the flag, so its results still publish and render live.
-  const result = { ...req.body };
-  delete result.sessionId;
-  const persistOnly = result.persistOnly === true;
-  delete result.persistOnly;
-  await storeToolResult(sessionId, result);
-
-  if (!persistOnly) {
-    pubsub?.publish(sessionChannel(sessionId), result);
-    console.log(`[gui] toolResult ${toolName} for ${sessionId}`);
-  }
-  res.json({ ok: true });
-});
-
-// Replay a session's stored toolResults so the panel can render them when the
-// user (re)selects that session. Loads from disk (~/.mulmoterminal/toolresults) on
-// first access so the views survive a reboot.
-app.get("/api/agent/toolResults/:sessionId", async (req, res) => {
-  const { sessionId } = req.params;
-  if (!SESSION_ID_RE.test(sessionId)) return res.status(400).json({ error: "invalid sessionId" });
-  res.json({ sessionId, toolResults: await toolResultsStore.get(sessionId) });
-});
-
-// The GUI plugin tools available this session (for the tools pane's "Available
-// Tools" list). The full set claude can call — built-ins, other MCP — is not
-// enumerable server-side; those still show up in the tool-call history below.
-app.get("/api/tools", (_req, res) => {
-  res.json({ tools: toolSummaries });
-});
-
-// Replay a session's tool-call history (every tool, via the Pre/PostToolUse hooks)
-// so the tools pane can render it when the user (re)selects that session. Loads
-// from disk (~/.mulmoterminal/toolcalls) on first access so it survives a reboot.
-app.get("/api/tool-calls/:sessionId", async (req, res) => {
-  const { sessionId } = req.params;
-  if (!SESSION_ID_RE.test(sessionId)) return res.status(400).json({ error: "invalid sessionId" });
-  res.json({ sessionId, toolCalls: await toolCallsStore.get(sessionId) });
-});
+// The /prs and /issues views (see routes/repo-routes.ts).
+mountRepoRoutes(app);
 
 // GET/POST /api/config (workspace dir + directory presets) — in its own module.
 // GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
@@ -998,25 +940,6 @@ mountConfigRoutes(app, CLAUDE_CWD);
 // (GET /api/files/browse/{list,text,md}, PUT .../write — all ?cwd=&path=). Each
 // terminal browses its own session's project dir; paths are contained within it.
 mountFilesBrowseRoutes(app, { defaultCwd: CLAUDE_CWD });
-
-// Cross-repo PR list (the /prs view): aggregate open PRs for the configured repos via
-// the server's `gh` login. Repos come from config (never the request).
-app.get("/api/prs", async (_req, res) => {
-  try {
-    res.json({ repos: await listPrsAcrossRepos(getPrRepos()) });
-  } catch (err) {
-    res.status(500).json({ error: String(err) });
-  }
-});
-
-// Sibling of /api/prs: the same configured repos' open issues (capped per repo).
-app.get("/api/issues", async (_req, res) => {
-  try {
-    res.json({ repos: await listIssuesAcrossRepos(getPrRepos()) });
-  } catch (err) {
-    res.status(500).json({ error: String(err) });
-  }
-});
 
 // Directory-scoped reads for a terminal cell: scripts, skills, dir config, git status,
 // PR phase, resolved header, custom sound. All keyed by ?cwd= (see routes/dir-routes.ts).

--- a/server/routes/repo-routes.ts
+++ b/server/routes/repo-routes.ts
@@ -1,0 +1,27 @@
+// The /prs and /issues views: open pull requests and issues across the repos the user
+// configured, via the server's own `gh` login. Repos come from config, never the request.
+import type { Express } from "express";
+import { getPrRepos } from "../config/config-routes.js";
+import { listPrsAcrossRepos } from "../git/prs.js";
+import { listIssuesAcrossRepos } from "../git/issues.js";
+
+export function mountRepoRoutes(app: Express): void {
+  // Cross-repo PR list (the /prs view): aggregate open PRs for the configured repos via
+  // the server's `gh` login. Repos come from config (never the request).
+  app.get("/api/prs", async (_req, res) => {
+    try {
+      res.json({ repos: await listPrsAcrossRepos(getPrRepos()) });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // Sibling of /api/prs: the same configured repos' open issues (capped per repo).
+  app.get("/api/issues", async (_req, res) => {
+    try {
+      res.json({ repos: await listIssuesAcrossRepos(getPrRepos()) });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+}

--- a/server/routes/tool-routes.ts
+++ b/server/routes/tool-routes.ts
@@ -1,0 +1,83 @@
+// The tools pane's server side: where a plugin's rendered result is stored, and how the
+// pane replays results and call history for a session. The stores arrive as a parameter —
+// they are one instance owned by index.ts, and two would each keep their own in-memory
+// copy of the same sessions.
+import type { Express } from "express";
+import { SESSION_ID_RE } from "../config/env.js";
+import type { createToolStores } from "../session/tool-store.js";
+
+export interface ToolRouteDeps {
+  stores: ReturnType<typeof createToolStores>;
+  /** The GUI plugin tools this server exposes, for the pane's "Available Tools" list. */
+  toolSummaries: unknown;
+  publish: (channel: string, data: unknown) => void;
+  sessionChannel: (id: string) => string;
+}
+
+export function mountToolRoutes(app: Express, deps: ToolRouteDeps): void {
+  // The GUI toolResult sink. Two callers POST here:
+  //   - the MCP broker, after a plugin produces a result (data gates rendering);
+  //   - the GUI panel, to persist a plugin view's state change (e.g. a submitted
+  //     form's viewState) under the same uuid.
+  // We store the result keyed by session id and publish it on that session's channel
+  // so the active panel renders/updates it live. Mirrors MulmoClaude's internal
+  // toolResult route + applyToolResultToSession.
+  app.post("/api/agent/toolResult", async (req, res) => {
+    const { sessionId, toolName, uuid } = req.body || {};
+    // The session id flows from env (broker) / the client and ends up in a pub/sub
+    // channel name — keep it to the known UUID shape.
+    if (!sessionId || !SESSION_ID_RE.test(sessionId)) {
+      return res.status(400).json({ error: "invalid sessionId" });
+    }
+    if (typeof toolName !== "string" || !toolName) {
+      return res.status(400).json({ error: "invalid toolName" });
+    }
+    if (typeof uuid !== "string" || !uuid) {
+      return res.status(400).json({ error: "invalid uuid" });
+    }
+
+    // Store everything except the routing fields; the result itself is the payload
+    // the panel renders.
+    // `persistOnly` (set by the GUI panel when a view persists its own state change)
+    // means: store, but do NOT re-publish on the session channel. Re-publishing would
+    // echo the update back to the originating panel as a fresh result, which re-seeds
+    // the view and re-emits — an infinite flicker loop. The broker (new tool calls)
+    // omits the flag, so its results still publish and render live.
+    const result = { ...req.body };
+    delete result.sessionId;
+    const persistOnly = result.persistOnly === true;
+    delete result.persistOnly;
+    await deps.stores.storeToolResult(sessionId, result);
+
+    if (!persistOnly) {
+      deps.publish(deps.sessionChannel(sessionId), result);
+      console.log(`[gui] toolResult ${toolName} for ${sessionId}`);
+    }
+    res.json({ ok: true });
+  });
+
+  // Replay a session's stored toolResults so the panel can render them when the
+  // user (re)selects that session. Loads from disk (~/.mulmoterminal/toolresults) on
+  // first access so the views survive a reboot.
+  app.get("/api/agent/toolResults/:sessionId", async (req, res) => {
+    const { sessionId } = req.params;
+    if (!SESSION_ID_RE.test(sessionId)) return res.status(400).json({ error: "invalid sessionId" });
+    res.json({ sessionId, toolResults: await deps.stores.toolResultsStore.get(sessionId) });
+  });
+
+  // The GUI plugin tools available this session (for the tools pane's "Available
+  // Tools" list). The full set claude can call — built-ins, other MCP — is not
+  // enumerable server-side; those still show up in the tool-call history below.
+  app.get("/api/tools", (_req, res) => {
+    res.json({ tools: deps.toolSummaries });
+  });
+
+  // Replay a session's tool-call history (every tool, via the Pre/PostToolUse hooks)
+  // so the tools pane can render it when the user (re)selects that session. Loads
+  // from disk (~/.mulmoterminal/toolcalls) on first access so it survives a reboot.
+  app.get("/api/tool-calls/:sessionId", async (req, res) => {
+    const { sessionId } = req.params;
+    if (!SESSION_ID_RE.test(sessionId)) return res.status(400).json({ error: "invalid sessionId" });
+    res.json({ sessionId, toolCalls: await deps.stores.toolCallsStore.get(sessionId) });
+  });
+}


### PR DESCRIPTION
## Summary

#548 Step 2c の 2/3。ツールペイン系 4 本と repo 系 2 本を `server/routes/` へ。`server/index.ts` を **2223 → 2146 行**（-77）、直書きルート **14 → 8 本**。

- `routes/tool-routes.ts` — `/api/agent/toolResult` `/api/agent/toolResults/:sessionId` `/api/tools` `/api/tool-calls/:sessionId`
- `routes/repo-routes.ts` — `/api/prs` `/api/issues`

## Items to Confirm / Review

1. **ストアは 4 つの関数ではなく 1 つのオブジェクトとして渡しています。** index.ts が所有する**単一インスタンス**であり、ルート側に別インスタンスを作らせると同じセッションの in-memory コピーを二重に持つことになるためです（2c-1 でファクトリ化した際の注意点そのもの）
2. `publish` は 2c-1 と同じ理由でクロージャ渡しです
3. `repo-routes.ts` は注入なし（`getPrRepos` / `listPrsAcrossRepos` / `listIssuesAcrossRepos` はいずれも既存モジュール）

## 挙動不変の検証

検証ロジックも一緒に移動したため、異常系を含めて main と並行起動で突き合わせ、**11 リクエスト完全一致**:

```
POST /api/agent/toolResult             200  {"ok":true}     ← 保存
POST（sessionId 不正）                  400  invalid sessionId
POST（toolName 欠落）                   400  invalid toolName
POST（uuid 欠落）                       400  invalid uuid
POST（persistOnly:true）                200  ← 再 publish しない分岐
/api/tools                             200
/api/agent/toolResults/<uuid>          200  ← 保存内容が読める
/api/agent/toolResults/bad             400
/api/tool-calls/<uuid>                 200
/api/prs                               200
/api/issues                            200
diff → 差分なし
```

検証で実ホームに作られたテスト用ファイルは削除済みです。`lint` / `build` / `typecheck` ×2 / `knip` / `test`（1603 件）すべて green。

## 残り（Step 2c-3 で Step 2 完了）

`/api/hook` `/api/plugin/*`（3本）`/api/mcp/*`（3本）`/api/translation/submit`。`/api/hook` はタイトル生成・活動フラグ・ツール履歴・Push に絡むため、最も注入面が広くなります。

Refs #548
