### PR TITLE
refactor: 翻訳ワーカーのプロンプトと結果検証を純粋関数に（#548 Step 3a）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -80,6 +80,7 @@ import { reapDecisionFor } from "./session/reap-policy.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
+import { buildTranslationPrompt, isValidTranslationResult } from "./session/translation-prompt.js";
 import { mountToolRoutes } from "./routes/tool-routes.js";
 import { mountRepoRoutes } from "./routes/repo-routes.js";
 import { claudeOnDiskSessionIds, latestUserPrompt, projectSessionsDir, sessionExistsOnDisk, LAST_RESPONSE_MAX } from "./session/session-reads.js";
@@ -1306,9 +1307,10 @@ async function runTranslationWorkerOnce(prompt: string, expected: number): Promi
     // pending entry now so this internal worker never surfaces as a sidebar row (the
     // /api/sessions filter on translationWorkerIds covers its on-disk transcript).
     knownSessions.delete(sessionId);
-    const translations = await submitted;
-    if (translations.length !== expected || !translations.every((s) => typeof s === "string")) {
-      throw new Error(`[translation] submitTranslation returned ${translations.length} strings for ${expected} inputs`);
+    const translations: unknown = await submitted;
+    if (!isValidTranslationResult(translations, expected)) {
+      const got = Array.isArray(translations) ? `${translations.length} strings` : "a non-array";
+      throw new Error(`[translation] submitTranslation returned ${got} for ${expected} inputs`);
     }
     return translations;
   } finally {
@@ -1324,13 +1326,7 @@ async function runTranslationWorkerOnce(prompt: string, expected: number): Promi
 // /api/translation/submit). Retries a fresh worker if one answers without submitting.
 async function translateViaHiddenChat(targetLanguage: string, sentences: readonly string[]): Promise<string[]> {
   const expected = sentences.length;
-  const prompt =
-    `You are an automated translation service. Translate each of the ${expected} English strings in ` +
-    `the JSON array below into the target language (BCP-47 code: ${targetLanguage}), preserving ` +
-    `placeholders like {name}, {count}, %s and any HTML tags verbatim. You MUST deliver the result by ` +
-    `calling the submitTranslation tool with a "translations" array of exactly ${expected} strings in ` +
-    `the same order — that tool call is the ONLY way to return the result; a text reply is discarded. ` +
-    `Do not call any other tool.\n\nInput: ${JSON.stringify(sentences)}`;
+  const prompt = buildTranslationPrompt(targetLanguage, sentences);
 
   let lastErr: unknown;
   for (let attempt = 1; attempt <= TRANSLATION_MAX_ATTEMPTS; attempt++) {

--- a/server/session/translation-prompt.ts
+++ b/server/session/translation-prompt.ts
@@ -22,5 +22,7 @@ export function buildTranslationPrompt(targetLanguage: string, sentences: readon
  *  A wrong count means the order no longer lines up with the inputs, so a partial answer
  *  is worse than none — the caller retries a fresh worker instead. */
 export function isValidTranslationResult(translations: unknown, expected: number): translations is string[] {
-  return Array.isArray(translations) && translations.length === expected && translations.every((s) => typeof s === "string");
+  // Array.from materializes holes as undefined so a sparse array (e.g. new Array(n))
+  // is rejected — `.every` skips holes and would wave one through as all-strings.
+  return Array.isArray(translations) && translations.length === expected && Array.from(translations).every((s) => typeof s === "string");
 }

--- a/server/session/translation-prompt.ts
+++ b/server/session/translation-prompt.ts
@@ -1,0 +1,26 @@
+// What the hidden translation worker is asked for, and what counts as an answer. Split
+// from the worker that spawns it (#548) because both are pure and both are load-bearing:
+// the prompt is the only thing making the model call submitTranslation instead of replying
+// in text, and the check is the only thing standing between a short or non-string answer
+// and the caller's UI.
+
+/** The worker's instructions. The tool call is named as the ONLY delivery mechanism —
+ *  a text reply is discarded by the caller, so the prompt has to close that door. */
+export function buildTranslationPrompt(targetLanguage: string, sentences: readonly string[]): string {
+  const expected = sentences.length;
+  return (
+    `You are an automated translation service. Translate each of the ${expected} English strings in ` +
+    `the JSON array below into the target language (BCP-47 code: ${targetLanguage}), preserving ` +
+    `placeholders like {name}, {count}, %s and any HTML tags verbatim. You MUST deliver the result by ` +
+    `calling the submitTranslation tool with a "translations" array of exactly ${expected} strings in ` +
+    `the same order — that tool call is the ONLY way to return the result; a text reply is discarded. ` +
+    `Do not call any other tool.\n\nInput: ${JSON.stringify(sentences)}`
+  );
+}
+
+/** Whether a worker's answer can be handed back: one string per input, in the same shape.
+ *  A wrong count means the order no longer lines up with the inputs, so a partial answer
+ *  is worse than none — the caller retries a fresh worker instead. */
+export function isValidTranslationResult(translations: unknown, expected: number): translations is string[] {
+  return Array.isArray(translations) && translations.length === expected && translations.every((s) => typeof s === "string");
+}

--- a/test/server/session/translation-prompt.spec.ts
+++ b/test/server/session/translation-prompt.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { buildTranslationPrompt, isValidTranslationResult } from "../../../server/session/translation-prompt.js";
+
+describe("buildTranslationPrompt", () => {
+  it("states the count in both places the model must match", () => {
+    const p = buildTranslationPrompt("ja", ["a", "b", "c"]);
+    expect(p).toContain("each of the 3 English strings");
+    expect(p).toContain("exactly 3 strings");
+  });
+
+  it("names the target language", () => {
+    expect(buildTranslationPrompt("fr-CA", ["a"])).toContain("BCP-47 code: fr-CA");
+  });
+
+  // A text reply is discarded by the caller, so the prompt has to shut that door.
+  it("names the tool call as the only delivery mechanism", () => {
+    const p = buildTranslationPrompt("ja", ["a"]);
+    expect(p).toContain("submitTranslation");
+    expect(p).toContain("ONLY way to return the result");
+  });
+
+  it("embeds the inputs as JSON so quotes and newlines survive", () => {
+    expect(buildTranslationPrompt("ja", ['He said "hi"', "line\nbreak"])).toContain(JSON.stringify(['He said "hi"', "line\nbreak"]));
+  });
+
+  it("tells the model to keep placeholders verbatim", () => {
+    expect(buildTranslationPrompt("ja", ["Hi {name}"])).toContain("{name}");
+  });
+
+  it("handles an empty input list without breaking the count", () => {
+    expect(buildTranslationPrompt("ja", [])).toContain("each of the 0 English strings");
+  });
+});
+
+describe("isValidTranslationResult", () => {
+  it("accepts one string per input", () => {
+    expect(isValidTranslationResult(["a", "b"], 2)).toBe(true);
+  });
+
+  // A short answer no longer lines up with the inputs, so it is worse than none.
+  it("rejects a count that does not match", () => {
+    expect(isValidTranslationResult(["a"], 2)).toBe(false);
+    expect(isValidTranslationResult(["a", "b", "c"], 2)).toBe(false);
+  });
+
+  it("rejects non-string entries", () => {
+    expect(isValidTranslationResult(["a", 2], 2)).toBe(false);
+    expect(isValidTranslationResult(["a", null], 2)).toBe(false);
+  });
+
+  it("rejects anything that is not an array", () => {
+    expect(isValidTranslationResult("a", 1)).toBe(false);
+    expect(isValidTranslationResult(undefined, 1)).toBe(false);
+    expect(isValidTranslationResult({ 0: "a", length: 1 }, 1)).toBe(false);
+  });
+
+  it("accepts an empty answer only for an empty request", () => {
+    expect(isValidTranslationResult([], 0)).toBe(true);
+    expect(isValidTranslationResult([], 1)).toBe(false);
+  });
+});

--- a/test/server/session/translation-prompt.spec.ts
+++ b/test/server/session/translation-prompt.spec.ts
@@ -48,6 +48,15 @@ describe("isValidTranslationResult", () => {
     expect(isValidTranslationResult(["a", null], 2)).toBe(false);
   });
 
+  it("rejects a sparse array whose holes are not real strings", () => {
+    // `.every` skips holes, so a right-length sparse array would slip through as
+    // all-strings and hand the caller a row of undefineds.
+    expect(isValidTranslationResult(new Array(2), 2)).toBe(false);
+    const withHole = ["a"];
+    withHole[2] = "c"; // index 1 is a hole
+    expect(isValidTranslationResult(withHole, 3)).toBe(false);
+  });
+
   it("rejects anything that is not an array", () => {
     expect(isValidTranslationResult("a", 1)).toBe(false);
     expect(isValidTranslationResult(undefined, 1)).toBe(false);


### PR DESCRIPTION
## Summary

#548 Step 3 の入口。翻訳ワーカーの**純粋な部分**を `server/session/translation-prompt.ts` へ切り出し、テスト 11 件を追加しました。

- `buildTranslationPrompt(targetLanguage, sentences)`
- `isValidTranslationResult(translations, expected)`

## なぜこの 2 つか

どちらも**壊れると静かに壊れる**ロジックです。

- **プロンプト** — モデルにテキスト返信ではなく `submitTranslation` を呼ばせる唯一の仕掛けです。テキスト返信は呼び出し側が破棄するため、この指示文が契約そのものです
- **結果検証** — 件数が合わない答えは入力との対応が崩れているので、部分的な答えは無いより悪い（呼び出し側は新しいワーカーで再試行します）

どちらも spawn と await を含む関数の内側にあり、**テストから到達できませんでした**。

## Items to Confirm / Review

1. **型の絞り込みが変わりました。** ガードが `unknown` を取るため、エラー分岐で `.length` を読めなくなり（`never` に絞られる）、非配列の場合は `"a non-array"` と表示するようにしています
2. テストは「件数がプロンプトの 2 箇所に現れる」「ツール名が唯一の返却手段として明示される」「入力が JSON 埋め込みで引用符や改行を保つ」「答えが間違っている各パターン」をカバー

**teeth 確認済み**: 件数比較を削除 → 2 件赤 / ツール指示文を削除 → 1 件赤。

`lint` / `build` / `typecheck` ×2 / `test`（**1614 件**）green。

## Step 3 の残り

`index.ts` に残る約 900 行の塊のうち、今回は独立性の高い純粋部分のみです。残りは **PTY spawn 群**（~400行）と **WebSocket 接続処理**（~350行）で、後者は前者に依存するため spawn を先に切り出す必要があります。

Refs #548