### PR TITLE
refactor: PTY spawn プリミティブと draft 注入を切り出し（#548 step 3b）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,6 @@
 import express from "express";
 import http from "http";
 import { WebSocketServer, WebSocket, type RawData } from "ws";
-import pty from "node-pty";
 import type { IPty } from "node-pty";
 import path from "path";
 import fs from "fs/promises";
@@ -30,7 +29,6 @@ import {
   isResumableTmuxSession,
 } from "./infra/tmux.js";
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
-import { sanitizePtyEnv } from "./infra/pty-env.js";
 import {
   sandboxEnabled,
   sandboxPlatformSupported,
@@ -50,7 +48,7 @@ import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, 
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { hasErrnoCode, messageOf } from "./errors.js";
 import type { PtyEntry } from "./session/types.js";
-import { ptySpawn, spawnSandboxEntry, sandboxWouldRun } from "./session/pty-spawn.js";
+import { spawnPty, ptySpawn, spawnSandboxEntry, sandboxWouldRun } from "./session/pty-spawn.js";
 import { attachDraftInjection, attachCodexAutoRun } from "./session/draft-injection.js";
 import {
   activity,
@@ -1471,7 +1469,7 @@ function spawnCommandPty(command: string, cwd: string, ws: WebSocket): IPty {
   const isWindows = process.platform === "win32";
   const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
   const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", command];
-  const term = pty.spawn(shell, args, { name: "xterm-256color", cols: 120, rows: 30, cwd, env: sanitizePtyEnv(process.env, path.delimiter) });
+  const term = spawnPty(shell, args, cwd);
   console.log(`[pty] spawned command (pid=${term.pid}) in ${cwd}: ${command}`);
 
   term.onData((data) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,7 +21,6 @@ import { resolveButtonCommand } from "./config/header-resolve.js";
 import { mountFilesBrowseRoutes } from "./files/files-browse.js";
 import {
   tmuxAvailable,
-  tmuxNewSessionArgs,
   tmuxHasSession,
   tmuxKillSession,
   tmuxListSessionIds,
@@ -36,10 +35,7 @@ import {
   sandboxEnabled,
   sandboxPlatformSupported,
   dockerAvailable,
-  sandboxImageExists,
   ensureSandboxImage,
-  buildDockerRunArgs,
-  writeSandboxClaudeConfig,
   writeSandboxCredentials,
   refreshHostKeychainIfExpired,
   cleanupSandbox,
@@ -54,6 +50,8 @@ import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, 
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { hasErrnoCode, messageOf } from "./errors.js";
 import type { PtyEntry } from "./session/types.js";
+import { ptySpawn, spawnSandboxEntry, sandboxWouldRun } from "./session/pty-spawn.js";
+import { attachDraftInjection, attachCodexAutoRun } from "./session/draft-injection.js";
 import {
   activity,
   aiTitles,
@@ -1341,29 +1339,6 @@ async function translateViaHiddenChat(targetLanguage: string, sentences: readonl
   throw lastErr instanceof Error ? lastErr : new Error("[translation] hidden chat failed");
 }
 
-// Claude must have its input box + bracketed-paste mode up before it will capture a
-// typed `draft`; too early and the bytes are echoed into the scrollback instead. We
-// wait for its status line to paint (the "shift+tab to cycle" mode hint), settle
-// briefly, then type. A fallback fires if that marker never shows (UI string drift).
-const DRAFT_READY_MARKER = claudeAdapter.draftReadyMarker;
-const DRAFT_SETTLE_MS = 250;
-const DRAFT_FALLBACK_MS = 6000;
-// Claude's TUI commits a bracketed paste to its input box asynchronously; a CR glued
-// onto the same write can arrive before the paste lands and be dropped — leaving an
-// auto-run prompt typed-but-unsent. Send the submitting Enter as a SEPARATE chunk a
-// beat after the paste so it actually registers.
-const DRAFT_SUBMIT_MS = 150;
-
-// Sanitize a draft before typing it into a PTY: strip ALL control bytes (C0/C1 —
-// ESC, Ctrl-C, CR/LF, and an embedded bracketed-paste terminator) so untrusted draft
-// content can't inject terminal control sequences that break out of the paste and
-// submit/interrupt. Only printable text survives, with whitespace collapsed.
-// eslint-disable-next-line no-control-regex -- intentional: match terminal control bytes (C0/C1) to strip them
-const DRAFT_CONTROL_BYTES_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
-function sanitizeDraftText(text: string): string {
-  return text.replace(DRAFT_CONTROL_BYTES_RE, " ").replace(/\s+/g, " ").trim();
-}
-
 // Spawn a fresh claude PTY for this session, register it, and wire its output /
 // exit back to the browser socket. `ws` may be null for a session spawned without
 // a viewer yet (e.g. spawnBackgroundChat) — output just buffers until a client
@@ -1372,141 +1347,6 @@ function sanitizeDraftText(text: string): string {
 // opposite: it is NOT auto-submitted — once claude's UI is ready the text is typed
 // into the input box (no Enter) so the user can review / edit / send it. Pass one or
 // the other, never both.
-const PTY_COLS = 120;
-const PTY_ROWS = 30;
-
-// pty.spawn with the binary as a PARAMETER (never a string literal at the call site),
-// so the tmux/shell/claude spawns aren't flagged as spawn-of-a-string-literal.
-// The env is sanitized: package-manager launcher vars (yarn's PREFIX kills nvm
-// in spawned shells — see infra/pty-env.ts) must not leak into PTYs.
-function spawnPty(bin: string, args: string[], cwd: string): IPty {
-  return pty.spawn(bin, args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env: sanitizePtyEnv(process.env, path.delimiter) });
-}
-
-// Would this session run in the Docker sandbox? Single-view interactive only (the caller
-// adds `ws !== null`). Shared by the spawn gate and the connection handler so the
-// pre-spawn credential refresh fires exactly when a sandbox spawn will.
-function sandboxWouldRun(attachGuiMcp: boolean): boolean {
-  return sandboxEnabled() && sandboxPlatformSupported() && attachGuiMcp && dockerAvailable() && sandboxImageExists();
-}
-
-// Spawn a terminal, wrapping it in a persistent tmux session when tmux is available and
-// `persistent` is set, so it survives the server dying. `tmux new-session -A` creates it
-// (running file+args) or reattaches the surviving one. Returns whether tmux backs it.
-function ptySpawn(sessionId: string, file: string, args: string[], cwd: string, persistent: boolean): { term: IPty; tmux: boolean } {
-  if (persistent && tmuxAvailable()) {
-    return { term: spawnPty("tmux", tmuxNewSessionArgs(sessionId, file, args, cwd), cwd), tmux: true };
-  }
-  return { term: spawnPty(file, args, cwd), tmux: false };
-}
-
-// Spawn the single-view session inside a Docker container (the sandbox path). Exports the
-// host's live Keychain credential so the containerized claude is authenticated — without
-// it the container reads a stale/absent ~/.claude/.credentials.json and shows "Not logged in".
-function spawnSandboxEntry(sessionId: string, claudeArgs: string[], cwd: string, ws: WebSocket | null): PtyEntry {
-  cleanupSandbox(sessionId); // clear any stale container/config/credential with this name
-  const claudeConfig = writeSandboxClaudeConfig(sessionId, cwd);
-  const credentials = writeSandboxCredentials(sessionId);
-  if (credentials === null)
-    console.warn("[sandbox] no Claude credential found in the macOS Keychain — the container may be unauthenticated. Run `claude` on the host to log in.");
-  const term = spawnPty("docker", buildDockerRunArgs(sessionId, claudeArgs, cwd, claudeConfig, credentials), cwd);
-  console.log(`[pty] spawned claude (pid=${term.pid} via docker sandbox) in ${cwd}`);
-  return { term, ws, buffer: "", cwd, sandbox: true, active: false, agent: "claude" };
-}
-
-// Deliver an auto-run prompt (initialPrompt) or an editable draft by TYPING it into
-// claude's input box once it's ready — NOT as a `claude` CLI arg, which a large prompt
-// would overflow tmux's `new-session` command-length limit with ("command too long",
-// killing the session). ALL control bytes are stripped first — C0/C1, including ESC,
-// Ctrl-C, CR/LF and an embedded bracketed-paste terminator (\e[201~) — so untrusted text
-// (collection / custom-view) can't inject sequences that break out of the paste. It's
-// wrapped in bracketed paste (\e[200~…\e[201~); initialPrompt then presses Enter to run
-// it, while a draft gets NO Enter so the user reviews + sends. Returns a scanner to feed
-// the pty output to: it types once the input-box readiness marker paints (after a settle),
-// or after DRAFT_FALLBACK_MS if the marker never appears (UI drift). No-op when neither.
-function attachDraftInjection(entry: PtyEntry, initialPrompt: string | undefined, draft: string | undefined): (data: string) => void {
-  const pendingText = draft ?? initialPrompt;
-  const autoSubmit = draft === undefined && initialPrompt !== undefined;
-  const draftText = pendingText ? sanitizeDraftText(pendingText) : "";
-  if (!draftText) return () => {};
-  let done = false;
-  let scan = "";
-  const typeDraft = () => {
-    if (done) return;
-    done = true;
-    try {
-      // Type the paste first; for an auto-run, submit with a CR in a SEPARATE write a beat
-      // later (DRAFT_SUBMIT_MS) so the Enter isn't dropped while Claude's TUI is still
-      // committing the paste. A draft gets no CR — the user reviews + sends.
-      entry.term.write(`\x1b[200~${draftText}\x1b[201~`);
-      if (autoSubmit) {
-        setTimeout(() => {
-          try {
-            entry.term.write("\r");
-          } catch {
-            // pty already gone — nothing to submit
-          }
-        }, DRAFT_SUBMIT_MS);
-      }
-    } catch {
-      // pty already gone — nothing to draft into
-    }
-  };
-  // Fallback: type even if the readiness marker never appears (UI string drift).
-  setTimeout(typeDraft, DRAFT_FALLBACK_MS);
-  return (data: string) => {
-    if (done) return;
-    // Type the draft once claude's input box has painted (its mode-hint status line),
-    // then settle briefly so the paste lands in the input rather than the scrollback.
-    scan = (scan + data).slice(-4096);
-    if (DRAFT_READY_MARKER.test(scan)) {
-      scan = "";
-      setTimeout(typeDraft, DRAFT_SETTLE_MS);
-    }
-  };
-}
-
-// codex's TUI has no stable "input ready" marker (its placeholder rotates), so instead of matching
-// a string we wait for its startup output to SETTLE — the boot banner + MCP-boot spinner keep
-// emitting until the input prompt is ready, so a quiet gap means codex is waiting for input. Then
-// paste the seed + Enter to auto-run it. Same reason as attachDraftInjection: a long prompt can't go
-// through tmux's new-session command-length limit ("command too long"). Returns a scanner fed the
-// pty output.
-const CODEX_READY_QUIET_MS = 1000;
-const CODEX_AUTORUN_MAX_WAIT_MS = 15_000;
-function attachCodexAutoRun(entry: PtyEntry, prompt: string): (data: string) => void {
-  const text = sanitizeDraftText(prompt);
-  if (!text) return () => {};
-  let done = false;
-  let quiet: ReturnType<typeof setTimeout> | null = null;
-  const type = () => {
-    if (done) return;
-    done = true;
-    if (quiet) clearTimeout(quiet);
-    try {
-      entry.term.write(`\x1b[200~${text}\x1b[201~`);
-      setTimeout(() => {
-        try {
-          entry.term.write("\r");
-        } catch {
-          // pty already gone — nothing to submit
-        }
-      }, DRAFT_SUBMIT_MS);
-    } catch {
-      // pty already gone — nothing to type into
-    }
-  };
-  const cap = setTimeout(type, CODEX_AUTORUN_MAX_WAIT_MS);
-  return () => {
-    if (done) return;
-    if (quiet) clearTimeout(quiet);
-    quiet = setTimeout(() => {
-      clearTimeout(cap);
-      type();
-    }, CODEX_READY_QUIET_MS);
-  };
-}
-
 function spawnClaudePty(
   sessionId: string,
   resume: string | null,

--- a/server/session/draft-injection.ts
+++ b/server/session/draft-injection.ts
@@ -1,0 +1,122 @@
+// Getting a prompt INTO an agent's TUI by typing it, rather than passing it as a CLI
+// argument — a long prompt overflows tmux's `new-session` command-length limit and kills
+// the session. Split from index.ts (#548): the two agents differ only in how they decide
+// the input box is ready, and neither decision needs any of index.ts's session state.
+import { claudeAdapter } from "../agents/claude.js";
+import type { PtyEntry } from "./types.js";
+
+// Claude must have its input box + bracketed-paste mode up before it will capture a
+// typed `draft`; too early and the bytes are echoed into the scrollback instead. We
+// wait for its status line to paint (the "shift+tab to cycle" mode hint), settle
+// briefly, then type. A fallback fires if that marker never shows (UI string drift).
+const DRAFT_READY_MARKER = claudeAdapter.draftReadyMarker;
+const DRAFT_SETTLE_MS = 250;
+const DRAFT_FALLBACK_MS = 6000;
+// Claude's TUI commits a bracketed paste to its input box asynchronously; a CR glued
+// onto the same write can arrive before the paste lands and be dropped — leaving an
+// auto-run prompt typed-but-unsent. Send the submitting Enter as a SEPARATE chunk a
+// beat after the paste so it actually registers.
+const DRAFT_SUBMIT_MS = 150;
+
+// Sanitize a draft before typing it into a PTY: strip ALL control bytes (C0/C1 —
+// ESC, Ctrl-C, CR/LF, and an embedded bracketed-paste terminator) so untrusted draft
+// content can't inject terminal control sequences that break out of the paste and
+// submit/interrupt. Only printable text survives, with whitespace collapsed.
+// eslint-disable-next-line no-control-regex -- intentional: match terminal control bytes (C0/C1) to strip them
+const DRAFT_CONTROL_BYTES_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
+export function sanitizeDraftText(text: string): string {
+  return text.replace(DRAFT_CONTROL_BYTES_RE, " ").replace(/\s+/g, " ").trim();
+}
+
+// Deliver an auto-run prompt (initialPrompt) or an editable draft by TYPING it into
+// claude's input box once it's ready — NOT as a `claude` CLI arg, which a large prompt
+// would overflow tmux's `new-session` command-length limit with ("command too long",
+// killing the session). ALL control bytes are stripped first — C0/C1, including ESC,
+// Ctrl-C, CR/LF and an embedded bracketed-paste terminator (\e[201~) — so untrusted text
+// (collection / custom-view) can't inject sequences that break out of the paste. It's
+// wrapped in bracketed paste (\e[200~…\e[201~); initialPrompt then presses Enter to run
+// it, while a draft gets NO Enter so the user reviews + sends. Returns a scanner to feed
+// the pty output to: it types once the input-box readiness marker paints (after a settle),
+// or after DRAFT_FALLBACK_MS if the marker never appears (UI drift). No-op when neither.
+export function attachDraftInjection(entry: PtyEntry, initialPrompt: string | undefined, draft: string | undefined): (data: string) => void {
+  const pendingText = draft ?? initialPrompt;
+  const autoSubmit = draft === undefined && initialPrompt !== undefined;
+  const draftText = pendingText ? sanitizeDraftText(pendingText) : "";
+  if (!draftText) return () => {};
+  let done = false;
+  let scan = "";
+  const typeDraft = () => {
+    if (done) return;
+    done = true;
+    try {
+      // Type the paste first; for an auto-run, submit with a CR in a SEPARATE write a beat
+      // later (DRAFT_SUBMIT_MS) so the Enter isn't dropped while Claude's TUI is still
+      // committing the paste. A draft gets no CR — the user reviews + sends.
+      entry.term.write(`\x1b[200~${draftText}\x1b[201~`);
+      if (autoSubmit) {
+        setTimeout(() => {
+          try {
+            entry.term.write("\r");
+          } catch {
+            // pty already gone — nothing to submit
+          }
+        }, DRAFT_SUBMIT_MS);
+      }
+    } catch {
+      // pty already gone — nothing to draft into
+    }
+  };
+  // Fallback: type even if the readiness marker never appears (UI string drift).
+  setTimeout(typeDraft, DRAFT_FALLBACK_MS);
+  return (data: string) => {
+    if (done) return;
+    // Type the draft once claude's input box has painted (its mode-hint status line),
+    // then settle briefly so the paste lands in the input rather than the scrollback.
+    scan = (scan + data).slice(-4096);
+    if (DRAFT_READY_MARKER.test(scan)) {
+      scan = "";
+      setTimeout(typeDraft, DRAFT_SETTLE_MS);
+    }
+  };
+}
+
+// codex's TUI has no stable "input ready" marker (its placeholder rotates), so instead of matching
+// a string we wait for its startup output to SETTLE — the boot banner + MCP-boot spinner keep
+// emitting until the input prompt is ready, so a quiet gap means codex is waiting for input. Then
+// paste the seed + Enter to auto-run it. Same reason as attachDraftInjection: a long prompt can't go
+// through tmux's new-session command-length limit ("command too long"). Returns a scanner fed the
+// pty output.
+const CODEX_READY_QUIET_MS = 1000;
+const CODEX_AUTORUN_MAX_WAIT_MS = 15_000;
+export function attachCodexAutoRun(entry: PtyEntry, prompt: string): (data: string) => void {
+  const text = sanitizeDraftText(prompt);
+  if (!text) return () => {};
+  let done = false;
+  let quiet: ReturnType<typeof setTimeout> | null = null;
+  const type = () => {
+    if (done) return;
+    done = true;
+    if (quiet) clearTimeout(quiet);
+    try {
+      entry.term.write(`\x1b[200~${text}\x1b[201~`);
+      setTimeout(() => {
+        try {
+          entry.term.write("\r");
+        } catch {
+          // pty already gone — nothing to submit
+        }
+      }, DRAFT_SUBMIT_MS);
+    } catch {
+      // pty already gone — nothing to type into
+    }
+  };
+  const cap = setTimeout(type, CODEX_AUTORUN_MAX_WAIT_MS);
+  return () => {
+    if (done) return;
+    if (quiet) clearTimeout(quiet);
+    quiet = setTimeout(() => {
+      clearTimeout(cap);
+      type();
+    }, CODEX_READY_QUIET_MS);
+  };
+}

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -1,0 +1,63 @@
+// The low-level ways this server starts a terminal: a bare pty, a tmux-backed one that
+// survives the server dying, and the Docker sandbox. Split from index.ts (#548) ahead of
+// the spawn functions that build on them — these four depend only on infra, so they move
+// without carrying any of index.ts's session state along.
+import pty from "node-pty";
+import type { IPty } from "node-pty";
+import path from "node:path";
+import type { WebSocket } from "ws";
+import { sanitizePtyEnv } from "../infra/pty-env.js";
+import { tmuxAvailable, tmuxNewSessionArgs } from "../infra/tmux.js";
+import {
+  sandboxEnabled,
+  sandboxPlatformSupported,
+  dockerAvailable,
+  sandboxImageExists,
+  buildDockerRunArgs,
+  writeSandboxClaudeConfig,
+  writeSandboxCredentials,
+  cleanupSandbox,
+} from "../infra/sandbox.js";
+import type { PtyEntry } from "./types.js";
+
+const PTY_COLS = 120;
+const PTY_ROWS = 30;
+
+// pty.spawn with the binary as a PARAMETER (never a string literal at the call site),
+// so the tmux/shell/claude spawns aren't flagged as spawn-of-a-string-literal.
+// The env is sanitized: package-manager launcher vars (yarn's PREFIX kills nvm
+// in spawned shells — see infra/pty-env.ts) must not leak into PTYs.
+export function spawnPty(bin: string, args: string[], cwd: string): IPty {
+  return pty.spawn(bin, args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env: sanitizePtyEnv(process.env, path.delimiter) });
+}
+
+// Would this session run in the Docker sandbox? Single-view interactive only (the caller
+// adds `ws !== null`). Shared by the spawn gate and the connection handler so the
+// pre-spawn credential refresh fires exactly when a sandbox spawn will.
+export function sandboxWouldRun(attachGuiMcp: boolean): boolean {
+  return sandboxEnabled() && sandboxPlatformSupported() && attachGuiMcp && dockerAvailable() && sandboxImageExists();
+}
+
+// Spawn a terminal, wrapping it in a persistent tmux session when tmux is available and
+// `persistent` is set, so it survives the server dying. `tmux new-session -A` creates it
+// (running file+args) or reattaches the surviving one. Returns whether tmux backs it.
+export function ptySpawn(sessionId: string, file: string, args: string[], cwd: string, persistent: boolean): { term: IPty; tmux: boolean } {
+  if (persistent && tmuxAvailable()) {
+    return { term: spawnPty("tmux", tmuxNewSessionArgs(sessionId, file, args, cwd), cwd), tmux: true };
+  }
+  return { term: spawnPty(file, args, cwd), tmux: false };
+}
+
+// Spawn the single-view session inside a Docker container (the sandbox path). Exports the
+// host's live Keychain credential so the containerized claude is authenticated — without
+// it the container reads a stale/absent ~/.claude/.credentials.json and shows "Not logged in".
+export function spawnSandboxEntry(sessionId: string, claudeArgs: string[], cwd: string, ws: WebSocket | null): PtyEntry {
+  cleanupSandbox(sessionId); // clear any stale container/config/credential with this name
+  const claudeConfig = writeSandboxClaudeConfig(sessionId, cwd);
+  const credentials = writeSandboxCredentials(sessionId);
+  if (credentials === null)
+    console.warn("[sandbox] no Claude credential found in the macOS Keychain — the container may be unauthenticated. Run `claude` on the host to log in.");
+  const term = spawnPty("docker", buildDockerRunArgs(sessionId, claudeArgs, cwd, claudeConfig, credentials), cwd);
+  console.log(`[pty] spawned claude (pid=${term.pid} via docker sandbox) in ${cwd}`);
+  return { term, ws, buffer: "", cwd, sandbox: true, active: false, agent: "claude" };
+}

--- a/test/server/session/draft-injection.spec.ts
+++ b/test/server/session/draft-injection.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeDraftText } from "../../../server/session/draft-injection.js";
+
+// This is the guard between untrusted text (a collection action, a custom view) and a
+// live terminal. The draft is delivered wrapped in a bracketed paste, so any control
+// byte that survives can close the paste early and run whatever follows as keystrokes.
+describe("sanitizeDraftText", () => {
+  it("keeps ordinary text intact", () => {
+    expect(sanitizeDraftText("summarize the diff")).toBe("summarize the diff");
+  });
+
+  it("strips the bracketed-paste terminator so text cannot escape the paste", () => {
+    // The ESC of an embedded "\e[201~" is what would end the paste early; without it
+    // the rest is just characters typed into the input box.
+    expect(sanitizeDraftText("safe\x1b[201~rm -rf /")).toBe("safe [201~rm -rf /");
+  });
+
+  it("strips a carriage return, which would submit the prompt early", () => {
+    expect(sanitizeDraftText("first\rsecond")).toBe("first second");
+  });
+
+  it("strips ESC and Ctrl-C", () => {
+    expect(sanitizeDraftText("a\x1bb\x03c")).toBe("a b c");
+  });
+
+  it("strips C1 control bytes, not just C0", () => {
+    expect(sanitizeDraftText("a\x80b\x9fc")).toBe("a b c");
+  });
+
+  it("strips DEL", () => {
+    expect(sanitizeDraftText("a\x7fb")).toBe("a b");
+  });
+
+  it("collapses the whitespace a stripped run leaves behind", () => {
+    expect(sanitizeDraftText("a\x00\x01\x02b")).toBe("a b");
+    expect(sanitizeDraftText("a \n\t b")).toBe("a b");
+  });
+
+  it("trims the edges", () => {
+    expect(sanitizeDraftText("   padded  ")).toBe("padded");
+  });
+
+  it("reduces text that is only control bytes to an empty string", () => {
+    // The callers treat "" as "nothing to type", so this is what makes a
+    // control-bytes-only prompt a no-op rather than a stray paste.
+    expect(sanitizeDraftText("\r\n")).toBe("");
+    expect(sanitizeDraftText("\x1b\x03\x9b")).toBe("");
+    expect(sanitizeDraftText("   ")).toBe("");
+  });
+
+  it("keeps non-ascii text, which is printable and not a control byte", () => {
+    expect(sanitizeDraftText("日本語の指示 — ok")).toBe("日本語の指示 — ok");
+  });
+
+  it("keeps the characters bracketing a paste when they are ordinary text", () => {
+    expect(sanitizeDraftText("use [200~ as a literal")).toBe("use [200~ as a literal");
+  });
+});


### PR DESCRIPTION
## Summary

`server/index.ts` から PTY spawn 系のうち、**index.ts のセッション状態に一切触れない 2 群**を先に切り出しました（#548 step 3b）。高レベルの `spawnClaudePty` / `spawnCodexPty` / `spawnCommandPty` / `spawnLauncherPty` は `reap` / `setWorking` / `sendFrame` 等への注入が必要なため次段階に回しています。

- **`server/session/pty-spawn.ts`** — `spawnPty` / `ptySpawn` / `spawnSandboxEntry` / `sandboxWouldRun`。ターミナルの起動方法そのもの（素の pty、tmux 常駐、Docker サンドボックス）。依存は infra のみ。
- **`server/session/draft-injection.ts`** — `sanitizeDraftText` と、エージェントの TUI にプロンプトを打ち込む 2 つの ready 判定（claude はマーカー一致、codex は出力の沈黙待ち）。

index.ts: **2143 → 1983 行**（-160）

## Items to Confirm / Review

- **純粋な移動であることの機械的検証**: 移動した 7 関数すべてについて、本体が main の index.ts と 1 文字も違わないことを差分照合で確認済みです（`spawnPty` / `sandboxWouldRun` / `ptySpawn` / `spawnSandboxEntry` / `sanitizeDraftText` / `attachDraftInjection` / `attachCodexAutoRun`）。挙動変更はありません。
- **コメント位置の修正**: `spawnClaudePty` を説明するコメントが `PTY_COLS` の上に取り残されていたため、本来の `spawnClaudePty` 直前に戻しました。これが唯一の非機械的な変更です。
- **`sanitizeDraftText` のテスト追加（11 ケース）**: 純粋関数であり、**信頼できないテキスト（collection / custom view）と生きたターミナルの間に立つ唯一のガード**なので、この機会にテストを入れました。bracketed paste を早期に閉じうる制御バイト（ESC、Ctrl-C、CR、DEL、C1、`\e[201~` 埋め込み）が残らないことを検証しています。テスト内の制御バイトはリテラルではなくエスケープ表記で書いています。

## 実装

1. 2 モジュールを新規作成し、index.ts から該当ブロックを削除。
2. index.ts は新モジュールを import。不要になった `tmuxNewSessionArgs` / `sandboxImageExists` / `buildDockerRunArgs` / `writeSandboxClaudeConfig` の import を整理。
3. `test/server/session/draft-injection.spec.ts` を追加。

## 検証

- 移動関数の本体が main と完全一致することを照合（上記）。
- teeth 確認: ①制御バイト除去をやめる ②C0 のみ除去して C1 を見逃す ③trim をやめる、の 3 パターンでテストが赤 → 復元で緑。
- format / lint（0 error）/ build / typecheck 通過。
- 全テスト: 144 files / **1646 passed**。

## 次段階（step 3c）

`spawnClaudePty` / `spawnCodexPty` / `spawnCommandPty` / `spawnLauncherPty`。これらは index.ts ローカルの `reap` / `setWorking` / `sendFrame` / `sendExitAndClose` / `hookSettingsJson` / `mcpConfigJson` / `wireCodexRelay` / `reattachPty` に依存するため、確立済み手順どおり registry から state を import しつつ残りは注入する形になります。



---

## 追加コミット: `spawnCommandPty` を `spawnPty` 経由に (`b3a595c`)

ローカルレビュー中に見つけた重複の解消です。`spawnCommandPty` は `spawnPty` と同じ `pty.spawn` オプションを自前で組み立てており、しかも `PTY_COLS`/`PTY_ROWS` ではなく `cols: 120, rows: 30` をベタ書きしていました。定数を新モジュールへ移したことでこの重複が顕在化したため、`spawnPty(shell, args, cwd)` の呼び出しに置き換えています。

- 引数以外は元と同一なので**挙動は不変**（name / cols / rows / cwd / env すべて一致）
- 重複とマジックナンバーが解消され、それまで呼び出し元が無かった `spawnPty` の export にも意味が出た
- 結果として **index.ts が node-pty を直接参照しなくなり**、`pty` と `sanitizePtyEnv` の import も不要に

`server/infra/sandbox.ts:201` にもう 1 つ `pty.spawn` がありますが、こちらは意図的に別オプション（`xterm-color` / 80x30 / 素の `process.env`）なので統合対象外です。

index.ts: 2143 → **1981 行**（-162）

## ローカルレビュー

`codex exec --sandbox read-only` で最終状態の全差分をレビュー済み（**CODEX VERDICT: LGTM / findings なし**）。

検証させた項目: 移動した全関数の本体が `main` と一致すること、`DRAFT_CONTROL_BYTES_RE` が C0(0x00-0x1F)・DEL(0x7F)・C1(0x80-0x9F) の全域を覆うこと、7 つの定数の値が不変であること、`spawnPty` 置換の等価性、import の過不足と循環の不在、`eslint-disable-next-line no-control-regex` の位置、テストが空振りしていないこと。

正規表現リテラルは authoring 中にツール往復で壊れて手修正した経緯があるため、「見た目が妥当そうでも信用せず第一原理から検証せよ」と明示して確認させています。
