### PR TITLE
refactor: PTY spawn 関数群を deps 注入で切り出し（#548 step 3c）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -50,6 +50,7 @@ import { hasErrnoCode, messageOf } from "./errors.js";
 import type { PtyEntry } from "./session/types.js";
 import { spawnPty, ptySpawn, spawnSandboxEntry, sandboxWouldRun } from "./session/pty-spawn.js";
 import { attachDraftInjection, attachCodexAutoRun } from "./session/draft-injection.js";
+import { sendFrame, sendExitAndClose, closeWithError, isResizeFrame } from "./session/ws-frames.js";
 import {
   activity,
   aiTitles,
@@ -1711,43 +1712,6 @@ async function startRunTerminal(ws: WebSocket, url: URL): Promise<void> {
       // already exited — nothing to kill
     }
   });
-}
-
-// Bounds a resize frame must satisfy before it reaches the PTY: a crafted or buggy
-// client must not be able to ask for a 0-column or absurdly large terminal.
-const MIN_TERM_COLS = 2;
-const MAX_TERM_COLS = 500;
-const MIN_TERM_ROWS = 1;
-const MAX_TERM_ROWS = 200;
-
-/** A well-formed `resize` frame with both dimensions inside the allowed bounds. */
-function isResizeFrame(msg: { type?: unknown; cols?: unknown; rows?: unknown }): msg is { type: "resize"; cols: number; rows: number } {
-  if (msg.type !== "resize" || !Number.isInteger(msg.cols) || !Number.isInteger(msg.rows)) return false;
-  const cols = Number(msg.cols);
-  const rows = Number(msg.rows);
-  return cols >= MIN_TERM_COLS && cols <= MAX_TERM_COLS && rows >= MIN_TERM_ROWS && rows <= MAX_TERM_ROWS;
-}
-
-// Send a JSON frame if the socket is still there and open. Null-tolerant so the PTY
-// handlers don't each repeat the readyState guard; reports whether it went out.
-function sendFrame(socket: WebSocket | null | undefined, payload: unknown): boolean {
-  if (!socket || socket.readyState !== socket.OPEN) return false;
-  socket.send(JSON.stringify(payload));
-  return true;
-}
-
-// Report a PTY exit to the browser, then hang up — shared by every PTY kind. The
-// socket is read at exit time because a reattach can swap it after wiring.
-function sendExitAndClose(socket: WebSocket | null | undefined, exitCode: number, signal: number | undefined): void {
-  if (sendFrame(socket, { type: "exit", exitCode, signal })) socket?.close();
-}
-
-// Send a terminal error to the socket and close it (no reconnect on the client side).
-function closeWithError(ws: WebSocket, message: string): void {
-  if (ws.readyState === ws.OPEN) {
-    ws.send(JSON.stringify({ type: "error", message }));
-    ws.close();
-  }
 }
 
 // The command a launcher runs when spawned fresh. On a tmux reattach it's ignored

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,7 +13,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./infra/plugins
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getLaunchers, getUserMcpServers, getHeaderConfig, getPushEnabled, getWorklogConfig } from "./config/config-routes.js";
+import { mountConfigRoutes, getUserMcpServers, getHeaderConfig, getPushEnabled, getWorklogConfig } from "./config/config-routes.js";
 import { sendWebPush } from "./infra/web-push.js";
 import { buildHeaderContext, loadHeaderConfig } from "./config/header-context.js";
 import { resolveButtonCommand } from "./config/header-resolve.js";
@@ -38,23 +38,23 @@ import {
   refreshHostKeychainIfExpired,
   cleanupSandbox,
   rewriteLoopbackForDocker,
-  SANDBOX_HOST,
 } from "./infra/sandbox.js";
 import { dirConfigWriteTarget } from "./config/dir-config.js";
 import { resolveScript } from "./files/scripts.js";
-import { buildClaudeArgs } from "./agents/claude-args.js";
 import { resolveSession, type SessionResolution } from "./session/session-resolve.js";
 import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "./session/activity-hook.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { hasErrnoCode, messageOf } from "./errors.js";
 import type { PtyEntry } from "./session/types.js";
-import { spawnPty, ptySpawn, spawnSandboxEntry, sandboxWouldRun } from "./session/pty-spawn.js";
-import { attachDraftInjection, attachCodexAutoRun } from "./session/draft-injection.js";
-import { sendFrame, sendExitAndClose, closeWithError, isResizeFrame } from "./session/ws-frames.js";
+import { sandboxWouldRun } from "./session/pty-spawn.js";
+import { closeWithError, isResizeFrame } from "./session/ws-frames.js";
+import { createClaudeSpawner } from "./session/spawn-claude.js";
+import { createCodexSpawner } from "./session/spawn-codex.js";
+import { createShellSpawners } from "./session/spawn-shell.js";
+import type { SpawnDeps } from "./session/spawn-deps.js";
 import {
   activity,
   aiTitles,
-  claimedCodexRollouts,
   codexRolloutIds,
   devTerminalSessions,
   devTerminalSessionsHydrated,
@@ -86,11 +86,10 @@ import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, heldByAnotherProcess, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
-import { buildCodexArgs } from "./agents/codex-args.js";
-import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "./agents/codex-session.js";
+import { codexSessionsRoot } from "./agents/codex-session.js";
 import { codexRolloutExists } from "./agents/codex-sessions.js";
 import { codexifySkillSeed } from "./agents/codex-skills.js";
-import { appendBoundedOutput, stripTerminalQueries } from "./session/terminal-replay.js";
+import { stripTerminalQueries } from "./session/terminal-replay.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
 import { isRecord, isTrivialPrompt, countUserTurnsFromJsonl, latestAssistantTextFromJsonl, preferredHeaderPrompt } from "./session/transcript.js";
@@ -471,6 +470,25 @@ function mcpConfigJson(sessionId: string, host: string = "127.0.0.1", sandbox: b
   mcpServers["mulmoterminal-gui"] = { type: "http", url: `http://${host}:${PORT}/api/mcp/${sessionId}` };
   return JSON.stringify({ mcpServers });
 }
+
+// The PTY spawners (session/spawn-*.ts). They take what index.ts still owns — the session
+// lifecycle it drives and the config it builds the hook/MCP json from — as deps.
+const spawnDeps: SpawnDeps = {
+  claudeBin: CLAUDE_BIN,
+  codexBin: CODEX_BIN,
+  codexModel: CODEX_MODEL,
+  permissionMode: CLAUDE_PERMISSION_MODE,
+  guiMcpTools: GUI_MCP_TOOLS,
+  outputBufferLimit: OUTPUT_BUFFER_LIMIT,
+  hookSettingsJson,
+  mcpConfigJson,
+  reap: (id) => reap(id),
+  setWorking: (id, working) => setWorking(id, working),
+  publishSessionCreated: (sessionId) => pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" }),
+};
+const { spawnClaudePty } = createClaudeSpawner(spawnDeps);
+const { spawnCodexPty } = createCodexSpawner(spawnDeps);
+const { spawnCommandPty, spawnLauncherPty, resolveLauncher } = createShellSpawners(spawnDeps);
 
 const app = express();
 // Generous body limit: PostToolUse hook payloads carry the tool's full output
@@ -1338,97 +1356,6 @@ async function translateViaHiddenChat(targetLanguage: string, sentences: readonl
   throw lastErr instanceof Error ? lastErr : new Error("[translation] hidden chat failed");
 }
 
-// Spawn a fresh claude PTY for this session, register it, and wire its output /
-// exit back to the browser socket. `ws` may be null for a session spawned without
-// a viewer yet (e.g. spawnBackgroundChat) — output just buffers until a client
-// reattaches. `initialPrompt`, when given, is passed to claude as the first turn
-// so the session starts working immediately, before anyone opens it. `draft` is the
-// opposite: it is NOT auto-submitted — once claude's UI is ready the text is typed
-// into the input box (no Enter) so the user can review / edit / send it. Pass one or
-// the other, never both.
-function spawnClaudePty(
-  sessionId: string,
-  resume: string | null,
-  ws: WebSocket | null,
-  initialPrompt?: string,
-  cwd: string = CLAUDE_CWD,
-  attachGuiMcp: boolean = true,
-  draft?: string,
-): PtyEntry {
-  // attachGuiMcp picks the MCP mode (see buildClaudeArgs): the single view (default)
-  // attaches the GUI MCP + --strict-mcp-config (main's classic behavior); the grid's
-  // dev terminals attach neither, so the user's + project's MCP servers load normally.
-  // Only --resume when the session has an on-disk transcript — claude doesn't write
-  // a session's .jsonl until its first prompt, so a started-but-unused session can't
-  // be resumed; we restart fresh (reusing the id via --session-id) instead.
-  // Sandbox only the SINGLE-VIEW interactive session: attachGuiMcp=true excludes grid
-  // dev terminals (?gui=0), and ws!==null excludes hidden background/translation workers.
-  // Falls back to the host spawn if the Docker daemon isn't reachable.
-  const sandbox = sandboxWouldRun(attachGuiMcp) && ws !== null;
-  const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
-  const args = buildClaudeArgs({
-    sessionId,
-    resume,
-    canResume,
-    // In the sandbox the hooks + GUI MCP are reached over host.docker.internal.
-    settings: hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId),
-    permissionMode: CLAUDE_PERMISSION_MODE,
-    attachGuiMcp,
-    mcpConfig: mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox),
-    // Auto-allow the GUI tools + the user's own configured MCP servers (mcp__<id>), so
-    // their tools don't trip a permission prompt on every call.
-    guiMcpTools: [GUI_MCP_TOOLS, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(","),
-  });
-
-  console.log(`[ws] client connected (${canResume ? "resume" : "new"} ${sessionId})`);
-
-  // Sandbox → run claude inside a fresh container (no tmux). Otherwise the host path:
-  // a live tmux session for this id (survived a restart) reattaches; else create it.
-  let entry: PtyEntry;
-  if (sandbox) {
-    entry = spawnSandboxEntry(sessionId, args, cwd, ws);
-  } else {
-    const { term, tmux } = ptySpawn(sessionId, CLAUDE_BIN, args, cwd, true);
-    console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);
-    entry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "claude" };
-  }
-  ptys.set(sessionId, entry);
-
-  if (!canResume) {
-    // Brand-new (or restarted-idle) session: surface it in the sidebar before
-    // it's persisted. A spawned session (initialPrompt or a draft) gets a title from
-    // that text so it's recognizable in the sidebar before anyone opens it.
-    const seed = initialPrompt ?? draft;
-    const title = seed ? seed.replace(/\s+/g, " ").trim().slice(0, 60) || "New session" : "New session";
-    knownSessions.set(sessionId, { createdAt: Date.now(), title });
-    pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" });
-  }
-
-  // The auto-run prompt / editable draft is typed into the input box once ready (see
-  // attachDraftInjection) — its scanner is fed the pty output below.
-  const scanForDraftReady = attachDraftInjection(entry, initialPrompt, draft);
-
-  // PTY -> browser (buffering a bounded tail for reattach).
-  entry.term.onData((data) => {
-    entry.buffer = appendBoundedOutput(entry.buffer, data, OUTPUT_BUFFER_LIMIT);
-    sendFrame(entry.ws, { type: "output", data });
-    scanForDraftReady(data);
-  });
-
-  entry.term.onExit(({ exitCode, signal }) => {
-    console.log(`[pty] exited code=${exitCode} signal=${signal}`);
-    sendExitAndClose(entry.ws, exitCode, signal);
-    // Clear the dot if it died mid-turn, then tear down everything (deletes
-    // ptys/knownSessions/activity and publishes "closed") so a process that
-    // exits on its own — e.g. a brand-new session that never persisted —
-    // doesn't linger in the sidebar.
-    setWorking(sessionId, false);
-    reap(sessionId);
-  });
-
-  return entry;
-}
-
 // browser -> PTY. The protocol is client-controlled, so validate every frame
 // before touching node-pty (bad cols/rows or non-string input can throw).
 function handleClientFrame(entry: PtyEntry, ws: WebSocket, raw: RawData, sessionId: string) {
@@ -1460,62 +1387,6 @@ function handleClientFrame(entry: PtyEntry, ws: WebSocket, raw: RawData, session
     // e.g. a write/resize that races the PTY exiting — drop it, never crash.
     console.warn(`[ws] dropped message for ${sessionId}: ${messageOf(err)}`);
   }
-}
-
-// Run an arbitrary shell command in a PTY and relay its I/O to the browser. Unlike
-// spawnClaudePty this is NOT a Claude session — no id, no hooks, no transcript, no
-// reap/grace. It's an ephemeral grid terminal (the Run menu); the caller kills it
-// when the viewer's socket closes.
-function spawnCommandPty(command: string, cwd: string, ws: WebSocket): IPty {
-  const isWindows = process.platform === "win32";
-  const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
-  const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", command];
-  const term = spawnPty(shell, args, cwd);
-  console.log(`[pty] spawned command (pid=${term.pid}) in ${cwd}: ${command}`);
-
-  term.onData((data) => {
-    sendFrame(ws, { type: "output", data });
-  });
-  term.onExit(({ exitCode, signal }) => {
-    console.log(`[pty] command exited code=${exitCode} signal=${signal}`);
-    sendExitAndClose(ws, exitCode, signal);
-  });
-  return term;
-}
-
-// Resolve a launcher by its position in the user's configured list — the browser
-// sends only an INDEX (the config is the allowlist), never a raw command.
-function resolveLauncher(index: number): { label: string; command: string } | null {
-  const list = getLaunchers();
-  return Number.isInteger(index) && index >= 0 && index < list.length ? list[index] : null;
-}
-
-// Spawn a configured launcher command as a PERSISTENT, reattachable PTY that shares
-// the Claude session lifecycle (ptys map, reattach, reap grace) but has NO hooks,
-// transcript, or resume. The command is run via the login shell with `exec` so it
-// becomes the single foreground process ($SHELL, codex, etc.) — env vars in the
-// command (e.g. $SHELL) expand, and the process stays interactive in the PTY.
-function spawnLauncherPty(sessionId: string, ws: WebSocket, command: string, cwd: string): PtyEntry {
-  const isWindows = process.platform === "win32";
-  const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
-  const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", `exec ${command}`];
-  // Persistent: reattaches a surviving tmux session (command ignored) or creates one.
-  const { term, tmux } = ptySpawn(sessionId, shell, args, cwd, true);
-  console.log(`[pty] spawned launcher (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}: ${command}`);
-
-  const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "shell" };
-  ptys.set(sessionId, entry);
-
-  term.onData((data) => {
-    entry.buffer = appendBoundedOutput(entry.buffer, data, OUTPUT_BUFFER_LIMIT);
-    sendFrame(entry.ws, { type: "output", data });
-  });
-  term.onExit(({ exitCode, signal }) => {
-    console.log(`[pty] launcher exited code=${exitCode} signal=${signal}`);
-    sendExitAndClose(entry.ws, exitCode, signal);
-    reap(sessionId);
-  });
-  return entry;
 }
 
 // browser -> command PTY. Like handleClientFrame but for the session-less command
@@ -1797,66 +1668,6 @@ function resolveCodexSession(requested: string | null): { sessionId: string; liv
   const resumeRolloutId = !live && !tmuxAlive && requested ? codexResumeIdFor(requested) : null;
   const sessionId = reattachId ?? ((tmuxAlive || resumeRolloutId) && requested ? requested : randomUUID());
   return { sessionId, live, resumeRolloutId };
-}
-
-function wireCodexRelay(entry: PtyEntry, sessionId: string, onOutput?: (data: string) => void): void {
-  entry.term.onData((data) => {
-    entry.buffer = appendBoundedOutput(entry.buffer, data, OUTPUT_BUFFER_LIMIT);
-    sendFrame(entry.ws, { type: "output", data });
-    onOutput?.(data);
-  });
-  entry.term.onExit(({ exitCode, signal }) => {
-    console.log(`[pty] codex exited code=${exitCode} signal=${signal}`);
-    sendExitAndClose(entry.ws, exitCode, signal);
-    reap(sessionId);
-  });
-}
-
-// codex persists its rollout only after the first user turn, so watch a FRESH session's lifetime
-// (stop once its pty is gone) and capture the minted id so a later cold reconnect can
-// `codex resume <id>`. Attribution is unambiguous-only (see pickFreshSession).
-function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
-  watchForCodexSession(root, before, { cwd, claimed: claimedCodexRollouts, isCancelled: () => !ptys.has(sessionId) })
-    .then((meta) => {
-      if (!meta) return;
-      claimedCodexRollouts.add(meta.file);
-      codexRolloutIds.set(sessionId, meta.id);
-    })
-    .catch(() => {});
-}
-
-function spawnCodexPty(
-  sessionId: string,
-  ws: WebSocket | null,
-  resumeRolloutId: string | null,
-  cwd: string,
-  attachGuiMcp: boolean,
-  initialPrompt: string | null,
-): PtyEntry {
-  const root = codexSessionsRoot();
-  const before = snapshotSessions(root);
-  // Single view: point codex at the in-process GUI MCP (same per-session URL as claude's) so it
-  // can drive the GUI panel. Grid dev terminals pass gui=0 → no MCP.
-  const guiMcpUrl = attachGuiMcp ? `http://127.0.0.1:${PORT}/api/mcp/${sessionId}` : null;
-  const args = buildCodexArgs({ resume: resumeRolloutId, model: CODEX_MODEL, guiMcpUrl });
-  const { term, tmux } = ptySpawn(sessionId, CODEX_BIN, args, cwd, true);
-  const via = tmux ? " via tmux" : "";
-  const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";
-  console.log(`[pty] spawned codex (pid=${term.pid}${via}) in ${cwd}${resumeNote}`);
-  const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "codex" };
-  ptys.set(sessionId, entry);
-  if (resumeRolloutId) {
-    codexRolloutIds.set(sessionId, resumeRolloutId);
-  } else {
-    // Discover the id only for a FRESH session. On resume we already know it; running the watcher
-    // could overwrite the known id with a mis-attributed concurrent rollout.
-    rememberCodexRollout(sessionId, root, before, cwd);
-  }
-  // A seed prompt is typed into codex's input box after it settles (not a CLI arg — see
-  // attachCodexAutoRun), so a long collection-action prompt can't overflow tmux's command limit.
-  const autoRun = initialPrompt ? attachCodexAutoRun(entry, initialPrompt) : undefined;
-  wireCodexRelay(entry, sessionId, autoRun);
-  return entry;
 }
 
 function startCodexEntry(

--- a/server/session/shell-command.ts
+++ b/server/session/shell-command.ts
@@ -1,0 +1,28 @@
+// The two decisions spawn-shell.ts makes before it touches a PTY: which shell invocation
+// runs a command, and which configured launcher an index refers to. Both are pure and both
+// are load-bearing — the invocation differs per platform (and only Windows CI would catch
+// a mistake), and the index guard is what stops a browser-supplied number from reaching
+// outside the configured allowlist.
+
+export interface ShellInvocation {
+  shell: string;
+  args: string[];
+}
+
+/** How to run `command` through the platform's shell. `replaceShell` runs it under `exec`
+ *  so the program becomes the PTY's foreground process rather than a child of the shell —
+ *  POSIX only, since `powershell -Command` already runs exactly the one command. The
+ *  command stays a single argv element, so nothing in it is re-split into arguments.
+ *  `platform` and `shellPath` are passed in rather than read here, so the choice is a
+ *  function of its arguments and both arms can be checked from any host. */
+export function shellInvocation(command: string, replaceShell: boolean, platform: string, shellPath: string | undefined): ShellInvocation {
+  if (platform === "win32") return { shell: "powershell.exe", args: ["-NoLogo", "-Command", command] };
+  return { shell: shellPath || "/bin/bash", args: ["-lc", replaceShell ? `exec ${command}` : command] };
+}
+
+/** The entry at `index`, or null when the index is not a real position in the list. The
+ *  browser sends only an index — the configured list is the allowlist — so a fractional,
+ *  negative, or past-the-end index has to resolve to nothing rather than to undefined. */
+export function launcherAt<T>(list: readonly T[], index: number): T | null {
+  return Number.isInteger(index) && index >= 0 && index < list.length ? list[index] : null;
+}

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -1,0 +1,111 @@
+// Starting a claude session in a PTY and wiring it to the browser. The most entangled
+// piece of index.ts (#548 step 3c): it spans the sandbox decision, the CLI args, the
+// sidebar's optimistic row, the draft typed into the input box, and teardown on exit.
+import type { WebSocket } from "ws";
+import { CLAUDE_CWD } from "../config/env.js";
+import { getUserMcpServers } from "../config/config-routes.js";
+import { SANDBOX_HOST } from "../infra/sandbox.js";
+import { buildClaudeArgs } from "../agents/claude-args.js";
+import { knownSessions, ptys } from "./registry.js";
+import { ptySpawn, sandboxWouldRun, spawnSandboxEntry } from "./pty-spawn.js";
+import { attachDraftInjection } from "./draft-injection.js";
+import { sendExitAndClose, sendFrame } from "./ws-frames.js";
+import { appendBoundedOutput } from "./terminal-replay.js";
+import { sessionExistsOnDisk } from "./session-reads.js";
+import type { PtyEntry } from "./types.js";
+import type { SpawnDeps } from "./spawn-deps.js";
+
+export function createClaudeSpawner(deps: SpawnDeps) {
+  // Spawn a fresh claude PTY for this session, register it, and wire its output /
+  // exit back to the browser socket. `ws` may be null for a session spawned without
+  // a viewer yet (e.g. spawnBackgroundChat) — output just buffers until a client
+  // reattaches. `initialPrompt`, when given, is passed to claude as the first turn
+  // so the session starts working immediately, before anyone opens it. `draft` is the
+  // opposite: it is NOT auto-submitted — once claude's UI is ready the text is typed
+  // into the input box (no Enter) so the user can review / edit / send it. Pass one or
+  // the other, never both.
+  function spawnClaudePty(
+    sessionId: string,
+    resume: string | null,
+    ws: WebSocket | null,
+    initialPrompt?: string,
+    cwd: string = CLAUDE_CWD,
+    attachGuiMcp: boolean = true,
+    draft?: string,
+  ): PtyEntry {
+    // attachGuiMcp picks the MCP mode (see buildClaudeArgs): the single view (default)
+    // attaches the GUI MCP + --strict-mcp-config (main's classic behavior); the grid's
+    // dev terminals attach neither, so the user's + project's MCP servers load normally.
+    // Only --resume when the session has an on-disk transcript — claude doesn't write
+    // a session's .jsonl until its first prompt, so a started-but-unused session can't
+    // be resumed; we restart fresh (reusing the id via --session-id) instead.
+    // Sandbox only the SINGLE-VIEW interactive session: attachGuiMcp=true excludes grid
+    // dev terminals (?gui=0), and ws!==null excludes hidden background/translation workers.
+    // Falls back to the host spawn if the Docker daemon isn't reachable.
+    const sandbox = sandboxWouldRun(attachGuiMcp) && ws !== null;
+    const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
+    const args = buildClaudeArgs({
+      sessionId,
+      resume,
+      canResume,
+      // In the sandbox the hooks + GUI MCP are reached over host.docker.internal.
+      settings: deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId),
+      permissionMode: deps.permissionMode,
+      attachGuiMcp,
+      mcpConfig: deps.mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox),
+      // Auto-allow the GUI tools + the user's own configured MCP servers (mcp__<id>), so
+      // their tools don't trip a permission prompt on every call.
+      guiMcpTools: [deps.guiMcpTools, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(","),
+    });
+
+    console.log(`[ws] client connected (${canResume ? "resume" : "new"} ${sessionId})`);
+
+    // Sandbox → run claude inside a fresh container (no tmux). Otherwise the host path:
+    // a live tmux session for this id (survived a restart) reattaches; else create it.
+    let entry: PtyEntry;
+    if (sandbox) {
+      entry = spawnSandboxEntry(sessionId, args, cwd, ws);
+    } else {
+      const { term, tmux } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true);
+      console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);
+      entry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "claude" };
+    }
+    ptys.set(sessionId, entry);
+
+    if (!canResume) {
+      // Brand-new (or restarted-idle) session: surface it in the sidebar before
+      // it's persisted. A spawned session (initialPrompt or a draft) gets a title from
+      // that text so it's recognizable in the sidebar before anyone opens it.
+      const seed = initialPrompt ?? draft;
+      const title = seed ? seed.replace(/\s+/g, " ").trim().slice(0, 60) || "New session" : "New session";
+      knownSessions.set(sessionId, { createdAt: Date.now(), title });
+      deps.publishSessionCreated(sessionId);
+    }
+
+    // The auto-run prompt / editable draft is typed into the input box once ready (see
+    // attachDraftInjection) — its scanner is fed the pty output below.
+    const scanForDraftReady = attachDraftInjection(entry, initialPrompt, draft);
+
+    // PTY -> browser (buffering a bounded tail for reattach).
+    entry.term.onData((data) => {
+      entry.buffer = appendBoundedOutput(entry.buffer, data, deps.outputBufferLimit);
+      sendFrame(entry.ws, { type: "output", data });
+      scanForDraftReady(data);
+    });
+
+    entry.term.onExit(({ exitCode, signal }) => {
+      console.log(`[pty] exited code=${exitCode} signal=${signal}`);
+      sendExitAndClose(entry.ws, exitCode, signal);
+      // Clear the dot if it died mid-turn, then tear down everything (deletes
+      // ptys/knownSessions/activity and publishes "closed") so a process that
+      // exits on its own — e.g. a brand-new session that never persisted —
+      // doesn't linger in the sidebar.
+      deps.setWorking(sessionId, false);
+      deps.reap(sessionId);
+    });
+
+    return entry;
+  }
+
+  return { spawnClaudePty };
+}

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -1,0 +1,78 @@
+// Starting a codex session in a PTY. Unlike claude, codex mints its rollout id only after
+// the first turn, so a fresh session is watched until that id appears — that is what lets
+// a later cold reconnect resume it. Split from index.ts (#548 step 3c).
+import type { WebSocket } from "ws";
+import { PORT } from "../config/env.js";
+import { buildCodexArgs } from "../agents/codex-args.js";
+import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../agents/codex-session.js";
+import { claimedCodexRollouts, codexRolloutIds, ptys } from "./registry.js";
+import { ptySpawn } from "./pty-spawn.js";
+import { attachCodexAutoRun } from "./draft-injection.js";
+import { sendExitAndClose, sendFrame } from "./ws-frames.js";
+import { appendBoundedOutput } from "./terminal-replay.js";
+import type { PtyEntry } from "./types.js";
+import type { SpawnDeps } from "./spawn-deps.js";
+
+export function createCodexSpawner(deps: SpawnDeps) {
+  function wireCodexRelay(entry: PtyEntry, sessionId: string, onOutput?: (data: string) => void): void {
+    entry.term.onData((data) => {
+      entry.buffer = appendBoundedOutput(entry.buffer, data, deps.outputBufferLimit);
+      sendFrame(entry.ws, { type: "output", data });
+      onOutput?.(data);
+    });
+    entry.term.onExit(({ exitCode, signal }) => {
+      console.log(`[pty] codex exited code=${exitCode} signal=${signal}`);
+      sendExitAndClose(entry.ws, exitCode, signal);
+      deps.reap(sessionId);
+    });
+  }
+
+  // codex persists its rollout only after the first user turn, so watch a FRESH session's lifetime
+  // (stop once its pty is gone) and capture the minted id so a later cold reconnect can
+  // `codex resume <id>`. Attribution is unambiguous-only (see pickFreshSession).
+  function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
+    watchForCodexSession(root, before, { cwd, claimed: claimedCodexRollouts, isCancelled: () => !ptys.has(sessionId) })
+      .then((meta) => {
+        if (!meta) return;
+        claimedCodexRollouts.add(meta.file);
+        codexRolloutIds.set(sessionId, meta.id);
+      })
+      .catch(() => {});
+  }
+
+  function spawnCodexPty(
+    sessionId: string,
+    ws: WebSocket | null,
+    resumeRolloutId: string | null,
+    cwd: string,
+    attachGuiMcp: boolean,
+    initialPrompt: string | null,
+  ): PtyEntry {
+    const root = codexSessionsRoot();
+    const before = snapshotSessions(root);
+    // Single view: point codex at the in-process GUI MCP (same per-session URL as claude's) so it
+    // can drive the GUI panel. Grid dev terminals pass gui=0 → no MCP.
+    const guiMcpUrl = attachGuiMcp ? `http://127.0.0.1:${PORT}/api/mcp/${sessionId}` : null;
+    const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpUrl });
+    const { term, tmux } = ptySpawn(sessionId, deps.codexBin, args, cwd, true);
+    const via = tmux ? " via tmux" : "";
+    const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";
+    console.log(`[pty] spawned codex (pid=${term.pid}${via}) in ${cwd}${resumeNote}`);
+    const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "codex" };
+    ptys.set(sessionId, entry);
+    if (resumeRolloutId) {
+      codexRolloutIds.set(sessionId, resumeRolloutId);
+    } else {
+      // Discover the id only for a FRESH session. On resume we already know it; running the watcher
+      // could overwrite the known id with a mis-attributed concurrent rollout.
+      rememberCodexRollout(sessionId, root, before, cwd);
+    }
+    // A seed prompt is typed into codex's input box after it settles (not a CLI arg — see
+    // attachCodexAutoRun), so a long collection-action prompt can't overflow tmux's command limit.
+    const autoRun = initialPrompt ? attachCodexAutoRun(entry, initialPrompt) : undefined;
+    wireCodexRelay(entry, sessionId, autoRun);
+    return entry;
+  }
+
+  return { spawnCodexPty };
+}

--- a/server/session/spawn-deps.ts
+++ b/server/session/spawn-deps.ts
@@ -1,0 +1,19 @@
+// What index.ts still owns after the PTY machinery moved out (#548 step 3c). The json
+// builders read config it holds; `reap` and `setWorking` drive a session lifecycle that
+// reaches well beyond spawning, so they arrive as deps rather than as imports.
+export interface SpawnDeps {
+  claudeBin: string;
+  codexBin: string;
+  codexModel: string | null;
+  permissionMode: string;
+  /** Tool names auto-allowed for every session, already comma-joined. */
+  guiMcpTools: string;
+  /** Bytes of pty output kept for a client that reattaches later. */
+  outputBufferLimit: number;
+  hookSettingsJson: (host: string, sessionId: string) => string;
+  mcpConfigJson: (sessionId: string, host?: string, sandbox?: boolean) => string;
+  reap: (id: string) => void;
+  setWorking: (id: string, working: boolean) => void;
+  /** Surface a brand-new session in the sidebar before it is persisted. */
+  publishSessionCreated: (sessionId: string) => void;
+}

--- a/server/session/spawn-shell.ts
+++ b/server/session/spawn-shell.ts
@@ -1,0 +1,73 @@
+// The two PTYs that run a shell rather than an agent: the Run menu's one-off command
+// (ephemeral, no session identity) and a configured launcher (persistent and reattachable,
+// sharing the session lifecycle but with no hooks, transcript, or resume).
+// Split from index.ts (#548 step 3c).
+import type { IPty } from "node-pty";
+import type { WebSocket } from "ws";
+import { getLaunchers } from "../config/config-routes.js";
+import { ptys } from "./registry.js";
+import { ptySpawn, spawnPty } from "./pty-spawn.js";
+import { sendExitAndClose, sendFrame } from "./ws-frames.js";
+import { appendBoundedOutput } from "./terminal-replay.js";
+import type { PtyEntry } from "./types.js";
+import type { SpawnDeps } from "./spawn-deps.js";
+
+export function createShellSpawners(deps: SpawnDeps) {
+  // Run an arbitrary shell command in a PTY and relay its I/O to the browser. Unlike
+  // spawnClaudePty this is NOT a Claude session — no id, no hooks, no transcript, no
+  // reap/grace. It's an ephemeral grid terminal (the Run menu); the caller kills it
+  // when the viewer's socket closes.
+  function spawnCommandPty(command: string, cwd: string, ws: WebSocket): IPty {
+    const isWindows = process.platform === "win32";
+    const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
+    const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", command];
+    const term = spawnPty(shell, args, cwd);
+    console.log(`[pty] spawned command (pid=${term.pid}) in ${cwd}: ${command}`);
+
+    term.onData((data) => {
+      sendFrame(ws, { type: "output", data });
+    });
+    term.onExit(({ exitCode, signal }) => {
+      console.log(`[pty] command exited code=${exitCode} signal=${signal}`);
+      sendExitAndClose(ws, exitCode, signal);
+    });
+    return term;
+  }
+
+  // Resolve a launcher by its position in the user's configured list — the browser
+  // sends only an INDEX (the config is the allowlist), never a raw command.
+  function resolveLauncher(index: number): { label: string; command: string } | null {
+    const list = getLaunchers();
+    return Number.isInteger(index) && index >= 0 && index < list.length ? list[index] : null;
+  }
+
+  // Spawn a configured launcher command as a PERSISTENT, reattachable PTY that shares
+  // the Claude session lifecycle (ptys map, reattach, reap grace) but has NO hooks,
+  // transcript, or resume. The command is run via the login shell with `exec` so it
+  // becomes the single foreground process ($SHELL, codex, etc.) — env vars in the
+  // command (e.g. $SHELL) expand, and the process stays interactive in the PTY.
+  function spawnLauncherPty(sessionId: string, ws: WebSocket, command: string, cwd: string): PtyEntry {
+    const isWindows = process.platform === "win32";
+    const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
+    const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", `exec ${command}`];
+    // Persistent: reattaches a surviving tmux session (command ignored) or creates one.
+    const { term, tmux } = ptySpawn(sessionId, shell, args, cwd, true);
+    console.log(`[pty] spawned launcher (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}: ${command}`);
+
+    const entry: PtyEntry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "shell" };
+    ptys.set(sessionId, entry);
+
+    term.onData((data) => {
+      entry.buffer = appendBoundedOutput(entry.buffer, data, deps.outputBufferLimit);
+      sendFrame(entry.ws, { type: "output", data });
+    });
+    term.onExit(({ exitCode, signal }) => {
+      console.log(`[pty] launcher exited code=${exitCode} signal=${signal}`);
+      sendExitAndClose(entry.ws, exitCode, signal);
+      deps.reap(sessionId);
+    });
+    return entry;
+  }
+
+  return { spawnCommandPty, spawnLauncherPty, resolveLauncher };
+}

--- a/server/session/spawn-shell.ts
+++ b/server/session/spawn-shell.ts
@@ -5,6 +5,7 @@
 import type { IPty } from "node-pty";
 import type { WebSocket } from "ws";
 import { getLaunchers } from "../config/config-routes.js";
+import { launcherAt, shellInvocation } from "./shell-command.js";
 import { ptys } from "./registry.js";
 import { ptySpawn, spawnPty } from "./pty-spawn.js";
 import { sendExitAndClose, sendFrame } from "./ws-frames.js";
@@ -18,9 +19,7 @@ export function createShellSpawners(deps: SpawnDeps) {
   // reap/grace. It's an ephemeral grid terminal (the Run menu); the caller kills it
   // when the viewer's socket closes.
   function spawnCommandPty(command: string, cwd: string, ws: WebSocket): IPty {
-    const isWindows = process.platform === "win32";
-    const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
-    const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", command];
+    const { shell, args } = shellInvocation(command, false, process.platform, process.env.SHELL);
     const term = spawnPty(shell, args, cwd);
     console.log(`[pty] spawned command (pid=${term.pid}) in ${cwd}: ${command}`);
 
@@ -37,8 +36,7 @@ export function createShellSpawners(deps: SpawnDeps) {
   // Resolve a launcher by its position in the user's configured list — the browser
   // sends only an INDEX (the config is the allowlist), never a raw command.
   function resolveLauncher(index: number): { label: string; command: string } | null {
-    const list = getLaunchers();
-    return Number.isInteger(index) && index >= 0 && index < list.length ? list[index] : null;
+    return launcherAt(getLaunchers(), index);
   }
 
   // Spawn a configured launcher command as a PERSISTENT, reattachable PTY that shares
@@ -47,10 +45,8 @@ export function createShellSpawners(deps: SpawnDeps) {
   // becomes the single foreground process ($SHELL, codex, etc.) — env vars in the
   // command (e.g. $SHELL) expand, and the process stays interactive in the PTY.
   function spawnLauncherPty(sessionId: string, ws: WebSocket, command: string, cwd: string): PtyEntry {
-    const isWindows = process.platform === "win32";
-    const shell = isWindows ? "powershell.exe" : process.env.SHELL || "/bin/bash";
-    const args = isWindows ? ["-NoLogo", "-Command", command] : ["-lc", `exec ${command}`];
     // Persistent: reattaches a surviving tmux session (command ignored) or creates one.
+    const { shell, args } = shellInvocation(command, true, process.platform, process.env.SHELL);
     const { term, tmux } = ptySpawn(sessionId, shell, args, cwd, true);
     console.log(`[pty] spawned launcher (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}: ${command}`);
 

--- a/server/session/ws-frames.ts
+++ b/server/session/ws-frames.ts
@@ -1,0 +1,51 @@
+// The wire protocol between a PTY and the browser: what we send down a socket, and what
+// we accept coming back up. Split from index.ts (#548) ahead of the spawn functions that
+// use it — none of it touches session state, and all of it is worth pinning, because a
+// frame that goes out on a closing socket throws and a resize frame that isn't bounded
+// reaches node-pty unchecked.
+
+// The socket surface these helpers actually use. Narrower than ws's WebSocket (which
+// satisfies it structurally) so a test can hand in a fake instead of a live connection.
+export interface FrameSocket {
+  readyState: number;
+  readonly OPEN: number;
+  send(data: string): void;
+  close(): void;
+}
+
+// Bounds a resize frame must satisfy before it reaches the PTY: a crafted or buggy
+// client must not be able to ask for a 0-column or absurdly large terminal.
+const MIN_TERM_COLS = 2;
+const MAX_TERM_COLS = 500;
+const MIN_TERM_ROWS = 1;
+const MAX_TERM_ROWS = 200;
+
+/** A well-formed `resize` frame with both dimensions inside the allowed bounds. */
+export function isResizeFrame(msg: { type?: unknown; cols?: unknown; rows?: unknown }): msg is { type: "resize"; cols: number; rows: number } {
+  if (msg.type !== "resize" || !Number.isInteger(msg.cols) || !Number.isInteger(msg.rows)) return false;
+  const cols = Number(msg.cols);
+  const rows = Number(msg.rows);
+  return cols >= MIN_TERM_COLS && cols <= MAX_TERM_COLS && rows >= MIN_TERM_ROWS && rows <= MAX_TERM_ROWS;
+}
+
+// Send a JSON frame if the socket is still there and open. Null-tolerant so the PTY
+// handlers don't each repeat the readyState guard; reports whether it went out.
+export function sendFrame(socket: FrameSocket | null | undefined, payload: unknown): boolean {
+  if (!socket || socket.readyState !== socket.OPEN) return false;
+  socket.send(JSON.stringify(payload));
+  return true;
+}
+
+// Report a PTY exit to the browser, then hang up — shared by every PTY kind. The
+// socket is read at exit time because a reattach can swap it after wiring.
+export function sendExitAndClose(socket: FrameSocket | null | undefined, exitCode: number, signal: number | undefined): void {
+  if (sendFrame(socket, { type: "exit", exitCode, signal })) socket?.close();
+}
+
+// Send a terminal error to the socket and close it (no reconnect on the client side).
+export function closeWithError(ws: FrameSocket, message: string): void {
+  if (ws.readyState === ws.OPEN) {
+    ws.send(JSON.stringify({ type: "error", message }));
+    ws.close();
+  }
+}

--- a/test/server/session/shell-command.spec.ts
+++ b/test/server/session/shell-command.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { shellInvocation, launcherAt } from "../../../server/session/shell-command.js";
+
+// platform and SHELL are parameters, so both branches are exercised on every runner —
+// otherwise the Windows arm would only ever be checked by the Windows CI job.
+describe("shellInvocation", () => {
+  describe("posix", () => {
+    it("runs the command through the login shell", () => {
+      expect(shellInvocation("ls -la", false, "darwin", "/bin/zsh")).toEqual({ shell: "/bin/zsh", args: ["-lc", "ls -la"] });
+    });
+
+    it("execs the command when it must become the foreground process", () => {
+      // Without exec the launcher's program is a CHILD of the shell, so the pty's
+      // foreground process is the shell and the program never owns the terminal.
+      expect(shellInvocation("codex", true, "linux", "/bin/zsh")).toEqual({ shell: "/bin/zsh", args: ["-lc", "exec codex"] });
+    });
+
+    it("falls back to /bin/bash when SHELL is unset or empty", () => {
+      expect(shellInvocation("ls", false, "darwin", undefined).shell).toBe("/bin/bash");
+      expect(shellInvocation("ls", false, "darwin", "").shell).toBe("/bin/bash");
+    });
+
+    it("keeps the whole command as one argv element", () => {
+      // The shell parses it, not execve — so quotes, spaces and operators survive
+      // intact rather than being split into separate arguments.
+      const { args } = shellInvocation("echo 'a b' && ls | wc -l", false, "linux", "/bin/zsh");
+      expect(args).toEqual(["-lc", "echo 'a b' && ls | wc -l"]);
+    });
+  });
+
+  describe("windows", () => {
+    it("runs the command through powershell", () => {
+      expect(shellInvocation("dir", false, "win32", undefined)).toEqual({ shell: "powershell.exe", args: ["-NoLogo", "-Command", "dir"] });
+    });
+
+    it("ignores SHELL, which is a posix concept", () => {
+      expect(shellInvocation("dir", false, "win32", "/bin/zsh").shell).toBe("powershell.exe");
+    });
+
+    it("has no exec form — powershell -Command already runs the one command", () => {
+      expect(shellInvocation("codex", true, "win32", undefined)).toEqual(shellInvocation("codex", false, "win32", undefined));
+    });
+  });
+});
+
+// The browser sends only an index; the configured list IS the allowlist. Anything that is
+// not a real position must resolve to null rather than to undefined, which would spawn a
+// launcher with no command.
+describe("launcherAt", () => {
+  const list = [
+    { label: "shell", command: "$SHELL" },
+    { label: "codex", command: "codex" },
+    { label: "top", command: "top" },
+  ];
+
+  it("returns the entry at a valid index", () => {
+    expect(launcherAt(list, 1)).toEqual({ label: "codex", command: "codex" });
+  });
+
+  it("accepts the first and last positions", () => {
+    expect(launcherAt(list, 0)).toBe(list[0]);
+    expect(launcherAt(list, 2)).toBe(list[2]);
+  });
+
+  it("rejects one past either end", () => {
+    expect(launcherAt(list, -1)).toBeNull();
+    expect(launcherAt(list, 3)).toBeNull();
+  });
+
+  it("rejects a wildly out-of-range index", () => {
+    expect(launcherAt(list, 9999)).toBeNull();
+    expect(launcherAt(list, -9999)).toBeNull();
+  });
+
+  it("rejects a non-integer index", () => {
+    expect(launcherAt(list, 1.5)).toBeNull();
+    expect(launcherAt(list, NaN)).toBeNull();
+    expect(launcherAt(list, Infinity)).toBeNull();
+    expect(launcherAt(list, -Infinity)).toBeNull();
+  });
+
+  it("resolves nothing when no launcher is configured", () => {
+    expect(launcherAt([], 0)).toBeNull();
+  });
+});

--- a/test/server/session/ws-frames.spec.ts
+++ b/test/server/session/ws-frames.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { sendFrame, sendExitAndClose, closeWithError, isResizeFrame, type FrameSocket } from "../../../server/session/ws-frames.js";
+
+const OPEN = 1;
+const CLOSED = 3;
+
+// A stand-in for the browser's socket that records what reached the wire, so the
+// send/close decisions can be asserted without a live connection.
+function fakeSocket(readyState = OPEN) {
+  const sent: string[] = [];
+  let closed = 0;
+  const socket: FrameSocket = {
+    readyState,
+    OPEN,
+    send: (data) => {
+      sent.push(data);
+    },
+    close: () => {
+      closed++;
+    },
+  };
+  return {
+    socket,
+    sent,
+    closeCount: () => closed,
+    parsed: () => sent.map((s) => JSON.parse(s)),
+  };
+}
+
+describe("sendFrame", () => {
+  it("serializes the payload to an open socket and reports it went out", () => {
+    const f = fakeSocket();
+    expect(sendFrame(f.socket, { type: "output", data: "hi" })).toBe(true);
+    expect(f.parsed()).toEqual([{ type: "output", data: "hi" }]);
+  });
+
+  it("sends nothing on a socket that is no longer open", () => {
+    // The PTY keeps producing output after the viewer navigates away; writing to a
+    // closing socket throws, so this guard is what keeps an exit from crashing us.
+    const f = fakeSocket(CLOSED);
+    expect(sendFrame(f.socket, { type: "output", data: "hi" })).toBe(false);
+    expect(f.sent).toEqual([]);
+  });
+
+  it("tolerates a missing socket, so callers need no null check of their own", () => {
+    expect(sendFrame(null, { type: "output" })).toBe(false);
+    expect(sendFrame(undefined, { type: "output" })).toBe(false);
+  });
+});
+
+describe("sendExitAndClose", () => {
+  it("reports the exit, then hangs up", () => {
+    const f = fakeSocket();
+    sendExitAndClose(f.socket, 0, undefined);
+    expect(f.parsed()).toEqual([{ type: "exit", exitCode: 0, signal: undefined }]);
+    expect(f.closeCount()).toBe(1);
+  });
+
+  it("carries a non-zero code and a signal through", () => {
+    const f = fakeSocket();
+    sendExitAndClose(f.socket, 137, 9);
+    expect(f.parsed()).toEqual([{ type: "exit", exitCode: 137, signal: 9 }]);
+  });
+
+  it("does not close a socket the exit frame never reached", () => {
+    // Closing a socket we could not write to would double-close one a reattach
+    // has already swapped in.
+    const f = fakeSocket(CLOSED);
+    sendExitAndClose(f.socket, 0, undefined);
+    expect(f.closeCount()).toBe(0);
+  });
+
+  it("tolerates a missing socket", () => {
+    expect(() => sendExitAndClose(null, 0, undefined)).not.toThrow();
+    expect(() => sendExitAndClose(undefined, 1, 15)).not.toThrow();
+  });
+});
+
+describe("closeWithError", () => {
+  it("sends the message and closes", () => {
+    const f = fakeSocket();
+    closeWithError(f.socket, "no such workspace");
+    expect(f.parsed()).toEqual([{ type: "error", message: "no such workspace" }]);
+    expect(f.closeCount()).toBe(1);
+  });
+
+  it("does nothing to an already-closed socket", () => {
+    const f = fakeSocket(CLOSED);
+    closeWithError(f.socket, "boom");
+    expect(f.sent).toEqual([]);
+    expect(f.closeCount()).toBe(0);
+  });
+});
+
+// The frame arrives from a client we do not control, so anything that is not a
+// well-formed, in-bounds resize must be rejected before it reaches node-pty.
+describe("isResizeFrame", () => {
+  it("accepts a well-formed frame", () => {
+    expect(isResizeFrame({ type: "resize", cols: 120, rows: 30 })).toBe(true);
+  });
+
+  it("rejects a frame of another type", () => {
+    expect(isResizeFrame({ type: "input", cols: 120, rows: 30 })).toBe(false);
+    expect(isResizeFrame({ cols: 120, rows: 30 })).toBe(false);
+  });
+
+  it("accepts the exact bounds", () => {
+    expect(isResizeFrame({ type: "resize", cols: 2, rows: 1 })).toBe(true);
+    expect(isResizeFrame({ type: "resize", cols: 500, rows: 200 })).toBe(true);
+  });
+
+  it("rejects just outside the bounds", () => {
+    expect(isResizeFrame({ type: "resize", cols: 1, rows: 30 })).toBe(false);
+    expect(isResizeFrame({ type: "resize", cols: 501, rows: 30 })).toBe(false);
+    expect(isResizeFrame({ type: "resize", cols: 120, rows: 0 })).toBe(false);
+    expect(isResizeFrame({ type: "resize", cols: 120, rows: 201 })).toBe(false);
+  });
+
+  it("rejects a zero or negative terminal", () => {
+    expect(isResizeFrame({ type: "resize", cols: 0, rows: 0 })).toBe(false);
+    expect(isResizeFrame({ type: "resize", cols: -80, rows: -24 })).toBe(false);
+  });
+
+  it("rejects non-integer dimensions", () => {
+    expect(isResizeFrame({ type: "resize", cols: 120.5, rows: 30 })).toBe(false);
+    expect(isResizeFrame({ type: "resize", cols: NaN, rows: 30 })).toBe(false);
+    expect(isResizeFrame({ type: "resize", cols: Infinity, rows: 30 })).toBe(false);
+  });
+
+  it("rejects dimensions that are not numbers at all", () => {
+    expect(isResizeFrame({ type: "resize", cols: "120", rows: "30" })).toBe(false);
+    expect(isResizeFrame({ type: "resize", cols: null, rows: 30 })).toBe(false);
+    expect(isResizeFrame({ type: "resize" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`server/index.ts` から **PTY まわりの最後の塊**を切り出しました（#548 step 3c）。ここが最も index.ts と絡んでいた部分です。

index.ts: **1981 → 1756 行**（-225）／テスト: 1646 → **1675 件**

コミットは 3 本で、それぞれ独立してレビューできます。

| コミット | 内容 |
|---|---|
| `1340a2e` (3c-1) | `sendFrame` / `sendExitAndClose` / `closeWithError` / `isResizeFrame` を `session/ws-frames.ts` へ。spawn 群が全て `sendFrame` を経由するので、先に出さないと無意味に注入する羽目になるため |
| `94013f8` (3c-2) | `spawnClaudePty` / `spawnCodexPty` / `spawnCommandPty` / `spawnLauncherPty` / `wireCodexRelay` / `rememberCodexRollout` / `resolveLauncher` を `spawn-claude.ts` / `spawn-codex.ts` / `spawn-shell.ts` へ。deps 注入 |
| `e934504` | `spawn-shell` の 2 つの判断（シェル起動・launcher の境界チェック）を純粋関数化してテスト |

## Items to Confirm / Review

- **注入した依存が忠実か（最重要）**。index.ts が持ち続けるもの（`reap` / `setWorking` / `hookSettingsJson` / `mcpConfigJson` / `publishSessionCreated` と設定値）を `SpawnDeps` として渡しています。既に切り出し済みのもの（registry・pty-spawn・draft-injection・ws-frames）は直接 import です。
- **`FrameSocket` への型の絞り込み**。ws の `WebSocket` ではなく、実際に使う 4 メンバ（`readyState` / `OPEN` / `send` / `close`）だけの構造的インターフェースにしました。実 `WebSocket` は構造的に適合します。これによりテストが fake で書けます。
- **モジュール分割の理由**。当初 1 ファイルにまとめたところ `max-lines-per-function`（60行）に触れました。lint を黙らせず、起動対象ごとに 3 分割して各 factory を制限内（51 / 48 / 38 行）に収めています。claude の経路（サンドボックス判定・CLI 引数・サイドバーの楽観行・draft 注入）とシェル実行は共通点が無いので、分割は素直な形です。
- **`shellInvocation` が platform と SHELL を引数で受ける点**。テストを書いた際に、デフォルト引数で `process.env.SHELL` を読むと「SHELL 未設定」ケースが開発者自身のシェルを読んでしまい検証にならないことが判明したため、呼び出し側に出しました。これで Windows 側の分岐も全ホストで検証できます（従来は Windows CI ジョブでしか通らなかった）。

## 検証

**1. 移動の忠実性（機械照合）** — 全 11 関数について `git show main:server/index.ts` と行単位で突き合わせ、注入のための置換以外の差分が無いことを確認:

```
spawnClaudePty 一致(82行) / wireCodexRelay 一致(12) / rememberCodexRollout 一致(9)
spawnCodexPty 一致(33) / spawnCommandPty 一致(16) / resolveLauncher 一致(4)
spawnLauncherPty 一致(22) / isResizeFrame・sendFrame・sendExitAndClose・closeWithError 一致
```

**2. 実行時比較（main と並行起動）** — main のワークツリーと本ブランチを別ポートで同時起動:

- API 8 エンドポイント: ステータス・ボディとも**全一致**
- **実 PTY を起動**（`/ws/run` → `spawnCommandPty` → `shellInvocation`）: 出力・終了コードとも完全一致
- **`spawnClaudePty` の CLI 引数**: `CLAUDE_BIN` を argv 出力用のスタブに差し替えて実際に spawn し、**11 個の引数が完全一致**（UUID とポートのみ正規化）。注入した `hookSettingsJson` / `mcpConfigJson` / `permissionMode` / `guiMcpTools` がそのまま渡っていることの実証です。
- 検証中は tmux スタブで永続化を無効化したため、tmux セッションは残していません（確認済み）。

**3. teeth 確認** — 新規テストが実装を壊すと赤くなることを確認:

- ws-frames: ①readyState ガード除去 ②送信失敗時にも close ③整数チェック除去 ④上限チェック除去 ⑤下限 off-by-one → いずれも赤
- shell-command: ①exec 付与をやめる ②Windows 分岐除去 ③`/bin/bash` フォールバック除去 ④整数チェック除去 ⑤上端 off-by-one → いずれも赤

**4. ローカル Codex レビュー** — 全差分を範囲指定なしでレビュー（**LGTM / findings なし**）。移動の同一性、注入の忠実性、モジュールスコープでの初期化順序（TDZ）、import 循環、`FrameSocket` の絞り込みの安全性、テストの非空振り性を検証させています。

**5. ゲート** — lint 0 error / build / typecheck 通過 / 全テスト 146 files・**1675 passed**。

## 次段階

index.ts に残る WebSocket 接続ハンドラ群（`/ws`・`/ws/run`・`/ws/launch`・`/ws/codex`）。spawn がモジュール化されたので、次はこれらが対象になります。
