### PR TITLE
feat(terminal): hand the agent's dim suggestion to the phone (#563)

### DIFF
--- a/plans/feat-563-terminal-suggestion.md
+++ b/plans/feat-563-terminal-suggestion.md
@@ -1,0 +1,80 @@
+# feat #563 — Claude の候補（dim ゴーストテキスト）を画面と一緒にスマホへ渡す
+
+## 問題
+
+Claude Code は次の一手を入力欄に **dim（`ESC[2m`）のゴーストテキスト**として提示し、キーボードなら Tab で確定できる。実機の `tmux capture-pane -p -e`:
+
+```
+ESC[39m❯ ESC[2mmilestones に目標を書くESC[0m
+```
+
+`tmuxCapturePane` は `-e` なしで取っている（`server/infra/tmux.ts`）ため、mulmoserver（スマホ）に届く画面テキストでは
+
+```
+❯ milestones に目標を書く
+```
+
+としか見えない。**Claude の候補**と**ユーザーが打った文字**を区別する情報が消えており、スマホからは「文字が入っているのに送れない」状態になる。区別が要るのは、送信の意味が違うから:
+
+- 候補（dim）: ホストの入力欄は実質空。ペーストすればそのまま正しく入る
+- 実際に打った文字: ペーストは**追記**になるので、同じ文字列を送ると二重になる
+
+つまり色を捨てている限り、スマホ側だけでは正しく実装できない。ホストが dim を読んで渡す。
+
+## 変更
+
+### 1. `server/session/screen-rows.ts`（新規・純粋関数）
+
+画面を「1 行 = プレーンテキスト + その行の dim 部分」に正規化する。
+
+```ts
+export interface ScreenRow {
+  text: string; // 行のプレーンテキスト
+  dim: string; // その行の dim 属性が付いた部分（無ければ ""）
+}
+
+export const parseStyledRows = (styled: string): ScreenRow[];
+export const rowsToScreen = (rows: readonly ScreenRow[]): string;
+export const suggestionFromRows = (rows: readonly ScreenRow[]): string;
+```
+
+- `parseStyledRows` — `capture-pane -e` の出力を SGR / OSC で分割して走査する。tmux は `-e` で
+  **SGR（`ESC[…m`）と OSC 8 ハイパーリンク**の両方を出す（実機の pane で確認済み）ので、どちらも
+  テキストから外す。SGR のパラメータ走査は `38;5;N` / `38;2;R;G;B` の引数を読み飛ばす —
+  さもないと色 `38;5;2` の末尾の `2` が dim 属性に化ける
+- `suggestionFromRows` — プロンプト記号（`❯` / `>`）で始まり、**キャレット以降が丸ごと dim** の行を
+  探し、最後の 1 つを採る。打った文字は dim にならないのでこの条件で落ちる。折り返しは、後続の
+  「行全体が dim」の行を連結する（両端が ASCII の語なら空白を 1 つ入れる — 英語は折り返しで空白が
+  消え、日本語は入れてはいけない）
+
+### 2. `server/infra/tmux.ts`
+
+`tmuxCapturePane` → `tmuxCaptureStyledPane`（`capture-pane -p -e`）。プレーン画面は
+`rowsToScreen(parseStyledRows(...))` で再構成する。
+
+### 3. `server/session/headlessScreen.ts`
+
+`renderScreen` の戻り値を `string` → `ScreenRow[]` に。dim は `@xterm/headless` のセル属性
+（`IBufferCell.isDim()`、`allowProposedApi` は既に有効）から読む。tmux 経路と headless 経路で
+同じ `ScreenRow[]` を作るので、候補の判定ルールは 1 つで済む。
+
+### 4. `server/backends/remoteHost/terminalScreen.ts` → 配線
+
+`captureSessionScreen` の戻り値を `string` → `{ screen, suggestion }` に。
+`getTerminalScreen` のレスポンスがそのまま `{ screen, suggestion }` になる（`handlers.ts`,
+`remoteHost/index.ts`, `server/index.ts` の配線を追随）。候補が無ければ `suggestion: ""`。
+
+## テスト
+
+- `parseStyledRows` — SGR on/off、`ESC[0m` / `ESC[22m` によるリセット、`38;5;2` の誤検出、
+  OSC 8 ハイパーリンク、エスケープ無しの行、空行
+- `suggestionFromRows` — 実機のキャプチャ（候補あり / 空の入力欄 / 打ち込み済み / 権限プロンプト）、
+  折り返し（日本語・英語）、キャレット以外の dim 行（差分の行番号など）を拾わないこと
+- **golden**: 実 pane の `capture-pane -p` と `rowsToScreen(parseStyledRows(capture-pane -p -e))` が
+  一致すること — 画面表示の互換が壊れていないことの担保
+- `renderScreen` — 既存のテストを `ScreenRow[]` に追随。dim セルが `dim` に入ること
+
+## スコープ外
+
+- 画面そのものの色付け（receptron/mulmoserver#92）。`-e` 取得という土台はここで入るが、色の配信はしない
+- スマホ側の UI（チップ表示、定型チップの常時表示、`ok` 追加）は receptron/mulmoserver#97

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -58,7 +58,7 @@ describe("createRemoteHostHandlers · getFeed", () => {
       spawnChat: () => ({ chatId: "x" }),
       ingest: async () => [],
       listTerminalSessions: async () => [],
-      captureTerminalScreen: async () => "",
+      captureTerminalScreen: async () => ({ screen: "", suggestion: "" }),
       writeToSession: () => false,
     });
   });

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -9,7 +9,7 @@ import { initCollectionsBackend } from "../collections.js";
 
 const unusedTerminalDeps = {
   listTerminalSessions: async () => [],
-  captureTerminalScreen: async () => "",
+  captureTerminalScreen: async () => ({ screen: "", suggestion: "" }),
   writeToSession: () => false,
 };
 

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -27,7 +27,7 @@ import {
 } from "../remoteView.js";
 import type { Attachment } from "./ingestAttachments.js";
 import { createTerminalInputSender } from "./terminalInput.js";
-import type { TerminalSessionSummary } from "./terminalScreen.js";
+import type { SessionScreen, TerminalSessionSummary } from "./terminalScreen.js";
 
 export interface RemoteHostHandlerDeps {
   workspace: string;
@@ -39,7 +39,7 @@ export interface RemoteHostHandlerDeps {
   // The phone's remote terminal view (#435) — the picker's list and one session's
   // current screen. Wired in server/index.ts, where the PTY table lives.
   listTerminalSessions: () => Promise<TerminalSessionSummary[]>;
-  captureTerminalScreen: (sessionId: string) => Promise<string>;
+  captureTerminalScreen: (sessionId: string) => Promise<SessionScreen>;
   // Type into one session's live PTY (#445). Returns false when no PTY is attached
   // in this process — a tmux session that outlived a restart stays viewable but not
   // writable from here.
@@ -145,10 +145,13 @@ const terminalScreenHandlers = ({ listTerminalSessions, captureTerminalScreen, w
   return {
     listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
 
+    // `suggestion` is the agent's own dim ghost text — the phone offers it as a chip,
+    // since it has no Tab key to accept it with (#563).
     getTerminalScreen: async (params: JsonObject) => {
       const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
       if (!sessionId) throw new Error("sessionId is required");
-      return { screen: await captureTerminalScreen(sessionId) };
+      const { screen, suggestion } = await captureTerminalScreen(sessionId);
+      return { screen, suggestion };
     },
 
     // Type a line into the session and press Enter, as if the user were at the

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -17,7 +17,7 @@ import type { Express } from "express";
 import { createRemoteHost, startHostRunner, type RemoteHostLifecycle } from "@mulmoclaude/core/remote-host/server";
 
 import { createRemoteHostHandlers } from "./handlers.js";
-import type { TerminalSessionSummary } from "./terminalScreen.js";
+import type { SessionScreen, TerminalSessionSummary } from "./terminalScreen.js";
 import { createSaveAttachment } from "./attachmentStore.js";
 import { buildIngestAttachments } from "./ingestAttachments.js";
 import { onExpire } from "./onExpire.js";
@@ -36,7 +36,7 @@ export interface RemoteHostBackendDeps {
   workspace: string;
   spawnChat: (message: string) => { chatId: string };
   listTerminalSessions: () => Promise<TerminalSessionSummary[]>;
-  captureTerminalScreen: (sessionId: string) => Promise<string>;
+  captureTerminalScreen: (sessionId: string) => Promise<SessionScreen>;
   // Type into a session's live PTY (#445); false when none is attached here.
   writeToSession: (sessionId: string, chunk: string) => boolean;
 }

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -2,6 +2,8 @@
 //
 // Both entry points are dependency-injected and free of server/index.ts internals, so the
 // join rules and the capture fallback are unit-testable without a live PTY or tmux.
+import { parseStyledRows, rowsToScreen, suggestionFromRows, type ScreenRow } from "../../session/screen-rows.js";
+
 // What is running in a session, so the phone can offer input that suits it: shell
 // command suggestions are useful in zsh and meaningless to an agent that reads prose
 // (mulmoserver#84). Null when the host cannot tell — a session that outlived a restart
@@ -75,18 +77,31 @@ export interface ScreenSource {
 }
 
 export interface CaptureScreenDeps {
-  capturePane: (id: string) => string | null;
+  captureStyledPane: (id: string) => string | null;
   sourceOf: (id: string) => ScreenSource | undefined;
-  render: (input: ScreenSource) => Promise<string>;
+  render: (input: ScreenSource) => Promise<ScreenRow[]>;
+}
+
+export interface SessionScreen {
+  screen: string;
+  // The follow-up prompt the agent is offering as dim ghost text, "" when it offers none.
+  // The phone cannot press Tab to accept it, so it is handed over as its own value for
+  // the phone to offer as a chip (#563).
+  suggestion: string;
 }
 
 // tmux first: it renders the real screen, works while detached, and survives a restart.
 // Falling back to the in-process buffer covers the tmux-less host, the non-persistent
 // spawn, AND the race where the session ends between listing and reading.
-export async function captureSessionScreen(id: string, { capturePane, sourceOf, render }: CaptureScreenDeps): Promise<string> {
-  const captured = capturePane(id);
-  if (captured !== null) return captured.trimEnd();
+const screenRowsOf = async (id: string, { captureStyledPane, sourceOf, render }: CaptureScreenDeps): Promise<ScreenRow[]> => {
+  const captured = captureStyledPane(id);
+  if (captured !== null) return parseStyledRows(captured);
   const source = sourceOf(id);
   if (!source) throw new Error(`terminal session '${id}' not found`);
   return render(source);
+};
+
+export async function captureSessionScreen(id: string, deps: CaptureScreenDeps): Promise<SessionScreen> {
+  const rows = await screenRowsOf(id, deps);
+  return { screen: rowsToScreen(rows).trimEnd(), suggestion: suggestionFromRows(rows) };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,7 +25,7 @@ import {
   tmuxListSessionIds,
   tmuxPaneCommand,
   tmuxAttachedClientCount,
-  tmuxCapturePane,
+  tmuxCaptureStyledPane,
   isResumableTmuxSession,
 } from "./infra/tmux.js";
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
@@ -1117,7 +1117,7 @@ const remoteHostWriteToSession = (sessionId: string, chunk: string): boolean => 
 
 const remoteHostCaptureTerminalScreen = (sessionId: string) =>
   captureSessionScreen(sessionId, {
-    capturePane: tmuxCapturePane,
+    captureStyledPane: tmuxCaptureStyledPane,
     sourceOf: (id) => {
       const entry = ptys.get(id);
       return entry ? { buffer: entry.buffer, cols: entry.term.cols, rows: entry.term.rows } : undefined;

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -159,10 +159,13 @@ export function tmuxKillSession(id: string): void {
 // The rendered contents of a session's visible pane — what the user would see right now,
 // available even while the session is DETACHED and across a server restart (tmux outlives
 // the node process). Null when tmux has no such session, which is also how a tmux-less
-// host reports "ask someone else". Colour sequences are dropped (no `-e`): the headless
-// fallback can only produce plain text, and one contract beats two.
-export function tmuxCapturePane(id: string): string | null {
-  const r = tmux(["capture-pane", "-p", "-t", tmuxSessionName(id)]);
+// host reports "ask someone else".
+//
+// `-e` keeps the escape sequences, which the caller strips back out (session/screen-rows).
+// Only one attribute is actually wanted — dim, the thing that marks an agent's ghost
+// suggestion apart from text the user typed — but tmux has no way to emit that alone.
+export function tmuxCaptureStyledPane(id: string): string | null {
+  const r = tmux(["capture-pane", "-p", "-e", "-t", tmuxSessionName(id)]);
   return r.status === 0 ? r.stdout : null;
 }
 

--- a/server/session/headlessScreen.ts
+++ b/server/session/headlessScreen.ts
@@ -10,6 +10,8 @@
 // back to CJS and can't statically see the named export — a bare named import throws at
 // startup under `node --import tsx`, even though bundlers (and vitest) resolve it fine.
 import headless from "@xterm/headless";
+import type { IBufferLine } from "@xterm/headless";
+import type { ScreenRow } from "./screen-rows.js";
 
 const { Terminal } = headless;
 
@@ -19,18 +21,29 @@ export interface HeadlessScreenInput {
   rows: number;
 }
 
+// Dim is read off the cells rather than re-parsed out of the buffer, so this path yields
+// the same ScreenRow shape as a tmux capture and the suggestion rule stays single.
+const rowOf = (line: IBufferLine | undefined, cols: number): ScreenRow => {
+  if (!line) return { text: "", dim: "" };
+  const cells = Array.from({ length: cols }, (_, column) => line.getCell(column));
+  return {
+    text: line.translateToString(true),
+    dim: cells.flatMap((cell) => (cell?.isDim() ? [cell.getChars()] : [])).join(""),
+  };
+};
+
 // `term.write` is ASYNC — the callback fires once the parser has consumed the chunk, and
 // reading `buffer.active` before that yields an EMPTY screen. The await is load-bearing.
-export async function renderScreen({ buffer, cols, rows }: HeadlessScreenInput): Promise<string> {
-  // `buffer` is still proposed API in xterm 6; reading it throws without this opt-in.
+export async function renderScreen({ buffer, cols, rows }: HeadlessScreenInput): Promise<ScreenRow[]> {
+  // `buffer` is still proposed API in xterm 6; reading it (and the cells below) throws
+  // without this opt-in.
   const term = new Terminal({ cols, rows, allowProposedApi: true });
   try {
     await new Promise<void>((resolve) => term.write(buffer, resolve));
     const active = term.buffer.active;
     // baseY is the top of the viewport, so this reads the CURRENT screen rather than the
-    // emulator's whole scrollback — matching what `tmux capture-pane -p` returns.
-    const lines = Array.from({ length: rows }, (_, row) => active.getLine(active.baseY + row)?.translateToString(true) ?? "");
-    return lines.join("\n").trimEnd();
+    // emulator's whole scrollback — matching what `tmux capture-pane` returns.
+    return Array.from({ length: rows }, (_, row) => rowOf(active.getLine(active.baseY + row), cols));
   } finally {
     term.dispose();
   }

--- a/server/session/screen-rows.ts
+++ b/server/session/screen-rows.ts
@@ -1,0 +1,123 @@
+// A captured screen, row by row, with each row's DIM run kept beside its plain text.
+//
+// Dim is the one attribute that has to survive capture. Claude Code offers a follow-up
+// prompt as dim ghost text in its input box — accepted with Tab at the keyboard:
+//
+//   ESC[39m❯ ESC[2mmilestones に目標を書くESC[0m
+//
+// Stripped of colour that is indistinguishable from a line the user typed, and the two
+// need opposite handling on the phone: the ghost text can be sent as it stands, while
+// typed text is already in the box and sending it again would double it.
+
+export interface ScreenRow {
+  text: string;
+  // The dim-attributed part of the row, "" when it has none.
+  dim: string;
+}
+
+const ESC = "\u001b";
+const BEL = "\u0007";
+
+// tmux's `capture-pane -e` re-emits two kinds of escape, both verified against a live
+// pane: SGR (the attributes) and OSC 8 hyperlinks. Neither belongs in the text. The
+// trailing alternative catches any other two-byte escape rather than printing it:
+//
+//   ESC ] <text> (BEL | ESC \)  |  ESC [ <params> <letter>  |  ESC <byte>
+//
+// Composed from the control bytes rather than written as one literal: a regex literal
+// carrying them is exactly what the control-character lint rules exist to stop.
+const ESCAPE_SPLIT = new RegExp(`(${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)?|${ESC}\\[[\\d;:]*[a-zA-Z]|${ESC}[@-_])`, "u");
+const SGR = new RegExp(`^${ESC}\\[([\\d;:]*)m$`, "u");
+
+// Walk SGR parameters left to right. 38/48/58 introduce an extended colour whose own
+// arguments must be skipped — otherwise the trailing 2 of "38;5;2" (green) reads as the
+// dim attribute and swallows the rest of the line.
+const dimAfter = (dim: boolean, params: readonly string[]): boolean => {
+  const [code, ...rest] = params;
+  if (code === undefined) return dim;
+  if (code === "38" || code === "48" || code === "58") return dimAfter(dim, rest.slice(rest[0] === "5" ? 2 : 4));
+  if (code === "2") return dimAfter(true, rest);
+  if (code === "" || code === "0" || code === "22") return dimAfter(false, rest);
+  return dimAfter(dim, rest);
+};
+
+const dimAfterEscape = (sequence: string, dim: boolean): boolean => {
+  const sgr = SGR.exec(sequence);
+  return sgr === null ? dim : dimAfter(dim, sgr[1].split(";"));
+};
+
+interface RowScan {
+  text: string;
+  dim: string;
+  on: boolean;
+}
+
+// Splitting on a capturing escape pattern yields text and escapes alternately, so the
+// odd positions are the sequences and the even ones the printable runs between them.
+const foldPart = (scan: RowScan, part: string, index: number): RowScan => {
+  if (index % 2 === 1) return { ...scan, on: dimAfterEscape(part, scan.on) };
+  return { ...scan, text: scan.text + part, dim: scan.on ? scan.dim + part : scan.dim };
+};
+
+// `capture-pane` drops the blanks that pad a row WITHOUT `-e` and keeps them WITH it,
+// so they are dropped here — the phone is shown the plain screen. Only the ASCII space
+// is padding: Claude Code draws its empty input box as "❯" + U+00A0, which tmux keeps
+// and a plain trimEnd would eat.
+// Scanned rather than matched with " +$", which backtracks quadratically on a row that
+// is mostly blanks — and a screen row is as wide as the terminal.
+const withoutTrailingPad = (text: string): string => text.slice(0, text.split("").findLastIndex((char) => char !== " ") + 1);
+
+const parseRow = (line: string): ScreenRow => {
+  const { text, dim } = line.split(ESCAPE_SPLIT).reduce(foldPart, { text: "", dim: "", on: false });
+  return { text: withoutTrailingPad(text), dim: withoutTrailingPad(dim) };
+};
+
+export const parseStyledRows = (styled: string): ScreenRow[] => styled.split("\n").map(parseRow);
+
+export const rowsToScreen = (rows: readonly ScreenRow[]): string => rows.map((row) => row.text).join("\n");
+
+// The caret an agent draws in front of its input box. Deliberately NOT the ASCII ">":
+// agent output is full of quoted lines and diffs, and one of those rendered dim would
+// read as a suggestion the user never saw.
+const CARET = /^\s*[❯›]\s/u;
+
+const afterCaret = (text: string): string | undefined => {
+  const caret = CARET.exec(text);
+  return caret === null ? undefined : text.slice(caret[0].length);
+};
+
+// The row that OFFERS a suggestion: everything past the caret is dim. Text the user
+// typed is not dim, which is what keeps a real draft out of this.
+const offersSuggestion = (row: ScreenRow): boolean => {
+  const rest = afterCaret(row.text)?.trim();
+  return rest !== undefined && rest !== "" && rest === row.dim.trim();
+};
+
+// A wrapped continuation of the row above: no caret of its own, all of it dim.
+const continuesSuggestion = (row: ScreenRow): boolean => {
+  const text = row.text.trim();
+  return text !== "" && text === row.dim.trim() && !CARET.test(row.text);
+};
+
+const ASCII_TAIL = /[!-~]$/u;
+const ASCII_HEAD = /^[!-~]/u;
+
+// The box wraps the ghost text itself, so the break carries no character: an English
+// line break ate the space between two words, a Japanese one had none to eat.
+const joinWrapped = (head: string, tail: string): string => {
+  if (ASCII_TAIL.test(head) && ASCII_HEAD.test(tail)) return `${head} ${tail}`;
+  return `${head}${tail}`;
+};
+
+const wrappedRows = (rows: readonly ScreenRow[]): readonly ScreenRow[] => {
+  const broken = rows.findIndex((row) => !continuesSuggestion(row));
+  return broken === -1 ? rows : rows.slice(0, broken);
+};
+
+// The suggestion the screen is currently offering, or "" when it is offering none.
+// Scans for the LAST caret row: scrollback can hold an old prompt above the live one.
+export const suggestionFromRows = (rows: readonly ScreenRow[]): string => {
+  const start = rows.findLastIndex(offersSuggestion);
+  if (start === -1) return "";
+  return [rows[start], ...wrappedRows(rows.slice(start + 1))].map((row) => row.dim.trim()).reduce(joinWrapped);
+};

--- a/test/server/backends/remoteHost/terminalScreen.spec.ts
+++ b/test/server/backends/remoteHost/terminalScreen.spec.ts
@@ -9,6 +9,8 @@ import {
   type SessionListInput,
 } from "../../../../server/backends/remoteHost/terminalScreen.js";
 
+const ESC = String.fromCharCode(0x1b);
+
 const listInput = (over: Partial<SessionListInput> = {}): SessionListInput => ({
   liveIds: [],
   tmuxIds: [],
@@ -121,22 +123,22 @@ describe("buildSessionList", () => {
 });
 
 const captureDeps = (over: Partial<CaptureScreenDeps> = {}): CaptureScreenDeps => ({
-  capturePane: () => null,
+  captureStyledPane: () => null,
   sourceOf: () => ({ buffer: "buffered", cols: 80, rows: 24 }),
-  render: async ({ buffer }) => `rendered:${buffer}`,
+  render: async ({ buffer }) => [{ text: `rendered:${buffer}`, dim: "" }],
   ...over,
 });
 
 describe("captureSessionScreen", () => {
   it("prefers tmux, which renders the real screen even while detached", async () => {
     const render = vi.fn();
-    const screen = await captureSessionScreen("a", captureDeps({ capturePane: () => "from tmux\n\n", render }));
-    expect(screen).toBe("from tmux");
+    const captured = await captureSessionScreen("a", captureDeps({ captureStyledPane: () => "from tmux\n\n", render }));
+    expect(captured.screen).toBe("from tmux");
     expect(render).not.toHaveBeenCalled();
   });
 
   it("renders the in-process buffer when tmux has no such session", async () => {
-    expect(await captureSessionScreen("a", captureDeps())).toBe("rendered:buffered");
+    expect((await captureSessionScreen("a", captureDeps())).screen).toBe("rendered:buffered");
   });
 
   // The session can end between the phone listing it and reading it.
@@ -145,7 +147,7 @@ describe("captureSessionScreen", () => {
   });
 
   it("passes the terminal's own geometry to the renderer", async () => {
-    const render = vi.fn(async () => "ok");
+    const render = vi.fn(async () => []);
     await captureSessionScreen("a", captureDeps({ sourceOf: () => ({ buffer: "b", cols: 120, rows: 30 }), render }));
     expect(render).toHaveBeenCalledWith({ buffer: "b", cols: 120, rows: 30 });
   });
@@ -153,7 +155,18 @@ describe("captureSessionScreen", () => {
   // An empty pane is a real answer, not a miss — it must not fall through to the buffer.
   it("treats an empty tmux capture as authoritative", async () => {
     const render = vi.fn();
-    expect(await captureSessionScreen("a", captureDeps({ capturePane: () => "", render }))).toBe("");
+    expect((await captureSessionScreen("a", captureDeps({ captureStyledPane: () => "", render }))).screen).toBe("");
     expect(render).not.toHaveBeenCalled();
+  });
+
+  // The phone has no Tab key, so the agent's ghost text has to arrive as its own value.
+  it("hands the agent's dim suggestion over beside the screen", async () => {
+    const styled = `${ESC}[38;5;246m────${ESC}[39m\n${ESC}[39m❯ ${ESC}[2mwrite the tests${ESC}[0m\n${ESC}[38;5;246m────${ESC}[39m`;
+    const captured = await captureSessionScreen("a", captureDeps({ captureStyledPane: () => styled }));
+    expect(captured).toEqual({ screen: "────\n❯ write the tests\n────", suggestion: "write the tests" });
+  });
+
+  it("reports no suggestion when the fallback renderer is the source", async () => {
+    expect((await captureSessionScreen("a", captureDeps())).suggestion).toBe("");
   });
 });

--- a/test/server/session/headlessScreen.spec.ts
+++ b/test/server/session/headlessScreen.spec.ts
@@ -5,8 +5,13 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 
 import { renderScreen } from "../../../server/session/headlessScreen.js";
+import { rowsToScreen } from "../../../server/session/screen-rows.js";
 
 const ESC = String.fromCharCode(0x1b);
+
+// renderScreen returns rows carrying each line's dim run alongside its text (#563);
+// everything below this helper is about the text.
+const screenOf = async (input: Parameters<typeof renderScreen>[0]): Promise<string> => rowsToScreen(await renderScreen(input)).trimEnd();
 
 // @xterm/headless ships a UMD/CJS bundle whose `module` field points at a path that does
 // not exist, so Node's ESM loader falls back to CJS and cannot see the named export. A
@@ -25,43 +30,55 @@ describe("renderScreen", () => {
   // The whole point: a byte stream is not a screen until an emulator has run it.
   it("renders the screen a stream would produce, not the stream", async () => {
     const buffer = `${ESC}[31mRED${ESC}[0m plain\r\nsecond`;
-    expect(await renderScreen({ buffer, cols: 40, rows: 5 })).toBe("RED plain\nsecond");
+    expect(await screenOf({ buffer, cols: 40, rows: 5 })).toBe("RED plain\nsecond");
   });
 
   // Reading buffer.active before term.write's callback yields an empty screen — the
   // regression this asserts against is a silent one (blank screens, no error).
   it("waits for the parser instead of returning a blank screen", async () => {
-    expect(await renderScreen({ buffer: "content", cols: 20, rows: 3 })).toBe("content");
+    expect(await screenOf({ buffer: "content", cols: 20, rows: 3 })).toBe("content");
   });
 
   it("honours cursor addressing rather than replaying in write order", async () => {
     // Write "second" on row 2, then jump back to row 1 and write "first".
     const buffer = `${ESC}[2;1Hsecond${ESC}[1;1Hfirst`;
-    expect(await renderScreen({ buffer, cols: 20, rows: 4 })).toBe("first\nsecond");
+    expect(await screenOf({ buffer, cols: 20, rows: 4 })).toBe("first\nsecond");
   });
 
   it("applies an erase-screen so stale content does not survive", async () => {
     const buffer = `garbage${ESC}[2J${ESC}[1;1Hclean`;
-    expect(await renderScreen({ buffer, cols: 20, rows: 3 })).toBe("clean");
+    expect(await screenOf({ buffer, cols: 20, rows: 3 })).toBe("clean");
   });
 
   it("returns the CURRENT screen once output has scrolled past the viewport", async () => {
     const buffer = Array.from({ length: 12 }, (_, i) => `line${i}`).join("\r\n");
     // rows: 4 → only the last four lines are on screen.
-    expect(await renderScreen({ buffer, cols: 20, rows: 4 })).toBe("line8\nline9\nline10\nline11");
+    expect(await screenOf({ buffer, cols: 20, rows: 4 })).toBe("line8\nline9\nline10\nline11");
   });
 
   it("wraps at the configured width", async () => {
-    expect(await renderScreen({ buffer: "abcdef", cols: 3, rows: 4 })).toBe("abc\ndef");
+    expect(await screenOf({ buffer: "abcdef", cols: 3, rows: 4 })).toBe("abc\ndef");
   });
 
   it("handles an empty buffer", async () => {
-    expect(await renderScreen({ buffer: "", cols: 20, rows: 3 })).toBe("");
+    expect(await screenOf({ buffer: "", cols: 20, rows: 3 })).toBe("");
   });
 
   // A truncated tail can begin mid-sequence (#434 trims that, but a lone ESC at the very
   // end is still possible) — an unterminated sequence must not hang or throw.
   it("survives a buffer ending mid-sequence", async () => {
-    expect(await renderScreen({ buffer: `visible${ESC}[3`, cols: 20, rows: 3 })).toBe("visible");
+    expect(await screenOf({ buffer: `visible${ESC}[3`, cols: 20, rows: 3 })).toBe("visible");
+  });
+
+  // Dim is what tells an agent's ghost suggestion apart from text the user typed, so a
+  // tmux-less host has to carry it out of the emulator too.
+  it("reads the dim run off the cells", async () => {
+    const rows = await renderScreen({ buffer: `❯ ${ESC}[2mwrite the tests${ESC}[0m`, cols: 40, rows: 2 });
+    expect(rows[0]).toEqual({ text: "❯ write the tests", dim: "write the tests" });
+  });
+
+  it("leaves dim empty on a plain row", async () => {
+    const rows = await renderScreen({ buffer: "❯ write the tests", cols: 40, rows: 2 });
+    expect(rows[0]).toEqual({ text: "❯ write the tests", dim: "" });
   });
 });

--- a/test/server/session/screen-rows.spec.ts
+++ b/test/server/session/screen-rows.spec.ts
@@ -1,0 +1,154 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { parseStyledRows, rowsToScreen, suggestionFromRows } from "../../../server/session/screen-rows.js";
+
+const ESC = String.fromCharCode(0x1b);
+const NBSP = String.fromCharCode(0xa0);
+
+// Captured verbatim from `tmux capture-pane -p -e` against a pane painted to mimic
+// Claude Code's TUI: 256-colour hints, an OSC 8 hyperlink, a dim ghost suggestion in the
+// input box, and the 38;5;2 trap (green, whose trailing 2 is NOT the dim attribute).
+const STYLED = [
+  `${ESC}[38;5;241m⏺${ESC}[39m ${ESC}[38;5;2mgreen 38;5;2 must not read as dim${ESC}[39m`,
+  `  ${ESC}]8;id=1;https://github.com/receptron/mulmoterminal/pull/563${ESC}\\PR #563${ESC}]8;;${ESC}\\`,
+  `${ESC}[2mdimmed prose that is not the input box${ESC}[0m`,
+  `${ESC}[38;5;246m────────────────────────────${ESC}[39m`,
+  `❯ ${ESC}[2mmilestones に目標を書く${ESC}[0m`,
+  `${ESC}[38;5;246m────────────────────────────${ESC}[39m`,
+  `  ${ESC}[38;5;137m⏵⏵ auto mode on${ESC}[38;5;241m (shift+tab to cycle)${ESC}[39m`,
+].join("\n");
+
+// The same pane read with `tmux capture-pane -p` — what the phone used to receive, and
+// must keep receiving now that the host captures with `-e` and strips it back out.
+const PLAIN = [
+  "⏺ green 38;5;2 must not read as dim",
+  "  PR #563",
+  "dimmed prose that is not the input box",
+  "────────────────────────────",
+  "❯ milestones に目標を書く",
+  "────────────────────────────",
+  "  ⏵⏵ auto mode on (shift+tab to cycle)",
+].join("\n");
+
+const rowsOf = (...lines: string[]) => parseStyledRows(lines.join("\n"));
+
+describe("rowsToScreen", () => {
+  it("reproduces the plain capture of the same pane, byte for byte", () => {
+    expect(rowsToScreen(parseStyledRows(STYLED))).toBe(PLAIN);
+  });
+
+  it("keeps a screen with no styling at all untouched", () => {
+    expect(rowsToScreen(parseStyledRows("plain\n  indented\n"))).toBe("plain\n  indented\n");
+  });
+
+  // `-e` keeps the blanks a coloured background painted to the end of the row; plain
+  // capture drops them. The phone is shown the plain screen, so these must not leak in.
+  it("drops the trailing blanks that -e keeps and -p does not", () => {
+    expect(rowsToScreen(parseStyledRows(`${ESC}[48;5;236mRan 2 shell commands   ${ESC}[49m`))).toBe("Ran 2 shell commands");
+  });
+
+  // Claude Code draws its empty input box as "❯" + U+00A0. tmux keeps that character in
+  // both captures, so a trim wide enough to eat it would rewrite the screen the phone
+  // has always been shown.
+  it("keeps the no-break space an empty input box is drawn with", () => {
+    expect(rowsToScreen(parseStyledRows(`${ESC}[38;5;241m❯${NBSP}${ESC}[39m`))).toBe(`❯${NBSP}`);
+  });
+});
+
+describe("parseStyledRows", () => {
+  it("collects the dim run beside the row's text", () => {
+    expect(rowsOf(`❯ ${ESC}[2mghost${ESC}[0m`)).toEqual([{ text: "❯ ghost", dim: "ghost" }]);
+  });
+
+  it("leaves dim empty on an unstyled row", () => {
+    expect(rowsOf("nothing dim here")).toEqual([{ text: "nothing dim here", dim: "" }]);
+  });
+
+  // 22 turns off bold/dim without resetting colour; 0 resets everything. Both end the run.
+  it("ends the run on either reset", () => {
+    expect(rowsOf(`${ESC}[2mdim${ESC}[22m after`)[0].dim).toBe("dim");
+    expect(rowsOf(`${ESC}[2mdim${ESC}[0m after`)[0].dim).toBe("dim");
+    expect(rowsOf(`${ESC}[2mdim${ESC}[m after`)[0].dim).toBe("dim");
+  });
+
+  // The trailing 2 of an extended colour is an argument, not the dim attribute — reading
+  // it as dim would mark the whole rest of the line as ghost text.
+  it("does not read an extended colour's arguments as attributes", () => {
+    expect(rowsOf(`${ESC}[38;5;2mgreen`)[0].dim).toBe("");
+    expect(rowsOf(`${ESC}[38;2;1;2;3mtruecolor`)[0].dim).toBe("");
+    expect(rowsOf(`${ESC}[48;5;2mon green`)[0].dim).toBe("");
+  });
+
+  it("still sees dim when it rides along with a colour", () => {
+    expect(rowsOf(`${ESC}[2;38;5;241mboth`)[0].dim).toBe("both");
+  });
+
+  // tmux re-emits hyperlinks with -e; they carry no attribute and no text.
+  it("drops OSC hyperlinks without dropping their label", () => {
+    expect(rowsOf(`${ESC}]8;;https://example.com${ESC}\\label${ESC}]8;;${ESC}\\`)).toEqual([{ text: "label", dim: "" }]);
+  });
+
+  it("handles an empty screen", () => {
+    expect(parseStyledRows("")).toEqual([{ text: "", dim: "" }]);
+  });
+
+  // Attributes do not survive a line break in a capture — tmux re-states them per row.
+  it("starts each row with the attributes reset", () => {
+    expect(rowsOf(`${ESC}[2mdim`, "next row").map((row) => row.dim)).toEqual(["dim", ""]);
+  });
+});
+
+describe("suggestionFromRows", () => {
+  it("reads the ghost text out of a real screen", () => {
+    expect(suggestionFromRows(parseStyledRows(STYLED))).toBe("milestones に目標を書く");
+  });
+
+  // The whole point of carrying dim: text the user typed looks identical once colour is
+  // gone, and offering it back would double it when the phone pastes.
+  it("ignores a draft the user typed", () => {
+    expect(suggestionFromRows(rowsOf("❯ half a sentence I typed"))).toBe("");
+  });
+
+  it("says nothing about an empty input box", () => {
+    expect(suggestionFromRows(rowsOf("❯ "))).toBe("");
+  });
+
+  // Dim is used for hints and diff gutters all over an agent's output; only the input
+  // box's caret marks a suggestion.
+  it("ignores dim text that is not in the input box", () => {
+    expect(suggestionFromRows(rowsOf(`${ESC}[2m 19   const x = 1;${ESC}[0m`))).toBe("");
+  });
+
+  // Half-dim means the user is typing over the ghost, so there is nothing whole to offer.
+  it("ignores a row that is only partly dim", () => {
+    expect(suggestionFromRows(rowsOf(`❯ typed ${ESC}[2mghost${ESC}[0m`))).toBe("");
+  });
+
+  // Scrollback keeps old prompts above the live one.
+  it("takes the last box on the screen", () => {
+    const rows = rowsOf(`❯ ${ESC}[2mold idea${ESC}[0m`, "some output", `❯ ${ESC}[2mnew idea${ESC}[0m`);
+    expect(suggestionFromRows(rows)).toBe("new idea");
+  });
+
+  // The box wraps the ghost text itself, so the break ate the space between two words.
+  it("rejoins a suggestion wrapped across rows", () => {
+    const rows = rowsOf(`❯ ${ESC}[2madd tests for the${ESC}[0m`, `  ${ESC}[2mnew parser${ESC}[0m`);
+    expect(suggestionFromRows(rows)).toBe("add tests for the new parser");
+  });
+
+  // Japanese wraps mid-phrase with no space to restore — inserting one would corrupt it.
+  it("rejoins a wrapped Japanese suggestion without inventing a space", () => {
+    const rows = rowsOf(`❯ ${ESC}[2mmilestones に目標${ESC}[0m`, `  ${ESC}[2mを書く${ESC}[0m`);
+    expect(suggestionFromRows(rows)).toBe("milestones に目標を書く");
+  });
+
+  it("stops rejoining at the box's bottom rule", () => {
+    const rows = rowsOf(`❯ ${ESC}[2mwrite the tests${ESC}[0m`, `${ESC}[38;5;246m────${ESC}[39m`, `${ESC}[2munrelated dim line${ESC}[0m`);
+    expect(suggestionFromRows(rows)).toBe("write the tests");
+  });
+
+  it("says nothing about a screen with no input box", () => {
+    expect(suggestionFromRows(rowsOf("just output", "more output"))).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Claude Code offers a follow-up prompt as **dim ghost text** in its input box, accepted with Tab at the keyboard. `tmuxCapturePane` read the pane *without* `-e`, so the phone (mulmoserver) received it as plain text — indistinguishable from a draft the user typed. On the phone it looked like text already in the box that nothing would send.

The pane is now captured with `-e` and normalised into `ScreenRow` (a row's plain text + its dim run). The screen is rebuilt from those rows, and the suggestion is read off them. `getTerminalScreen` gains `suggestion` beside `screen` (`""` when the agent offers none).

Closes #563. Companion UI: receptron/mulmoserver#97.

## Items to Confirm / Review

1. **The screen the phone sees must not change.** Verified against **all 10 tmux panes on the author's machine**: `rowsToScreen(parseStyledRows(capture-pane -p -e))` matches `capture-pane -p` byte for byte. That check found two real differences, both now covered by tests:
   - `-e` keeps the blank cells that pad a styled run; `-p` drops them.
   - Claude Code draws its **empty** input box as `❯` + **U+00A0**, which tmux keeps in both captures — a plain `trimEnd()` ate it. Only the ASCII space is stripped.
2. **The dim/typed distinction is the whole point.** A row qualifies only when *everything past the caret* is dim. Typed text is never dim, so a real draft is never offered back — which matters because the phone's send pastes, and pasting a draft back would double it.
3. **False positives.** The caret set is `❯` / `›` only — deliberately *not* ASCII `>`, since agent output is full of quoted lines and diffs that could be dim.
4. **SGR parsing.** `38;5;2` (green) must not read as the dim attribute `2`; extended-colour arguments are skipped. Test covers `38;5;2`, `38;2;r;g;b`, `48;5;2`.
5. **Wrapped suggestions** are rejoined with a space only when both sides are ASCII — English wrapping ate a space, Japanese had none to eat. This is the one rule I could not exercise against a live wrapped suggestion; it is unit-tested both ways.
6. **`renderScreen` now returns rows, not a string.** The headless fallback reads dim off `IBufferCell.isDim()`, so the suggestion rule stays single across both capture paths.

## User Prompt

> mulmoserverに通知してユーザが選択する機能あるけど、terminalだと、suggest分が入っていてtabで入力できる場合がある。あれってmulmoserverだとすでに文字が入って見えるんだけど、それを入力できない。選択肢に加えたい
>
> あと、選択肢がある場合も、yes/noとかdefaultのだしてほしいし、okってないから追加してほしい

（後半の「選択肢がある場合も定型チップを出す / `ok` を追加」は mulmoserver 側のみの変更なので receptron/mulmoserver#97 で対応。）

## Implementation

- `server/session/screen-rows.ts` (new, pure) — `parseStyledRows` / `rowsToScreen` / `suggestionFromRows`. Strips SGR **and** OSC 8 hyperlinks (tmux re-emits both with `-e`; verified on a live pane). The escape patterns are composed from named control bytes rather than written as literals, so no `eslint-disable` is needed.
- `server/infra/tmux.ts` — `tmuxCapturePane` → `tmuxCaptureStyledPane` (`capture-pane -p -e`).
- `server/session/headlessScreen.ts` — `renderScreen` returns `ScreenRow[]`, reading dim from the emulator's cells.
- `server/backends/remoteHost/terminalScreen.ts` — `captureSessionScreen` returns `{ screen, suggestion }`; wiring follows in `handlers.ts`, `remoteHost/index.ts`, `server/index.ts`.

Plan: `plans/feat-563-terminal-suggestion.md`.

## Tests

`yarn test` 1672 pass · `yarn lint` 0 errors · `yarn build` · `yarn typecheck:server` · `yarn typecheck:test`.

New: `test/server/session/screen-rows.spec.ts` (23 cases, incl. a golden fixture captured verbatim from `tmux capture-pane -p -e`). Each new rule was mutation-checked — dropping the dim guard, the extended-colour skip, or the OSC alternative each turns the suite red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)