### PR TITLE
refactor: WebSocket 接続の配管と判断ロジックを切り出し（#548 step 3d）

### DIFF
--- a/server/config/header-resolve.ts
+++ b/server/config/header-resolve.ts
@@ -128,3 +128,10 @@ export function resolveHeader(config: HeaderConfig, ctx: HeaderContext): Resolve
   const chips = config.chips === null ? null : config.chips.map((c) => resolveChip(c, ctx)).filter((c): c is ResolvedChip => c !== null);
   return { buttons, chips };
 }
+
+// POSIX/PowerShell single-arg quoting, so a substituted ${branch}/${repo}/${task} can't break out of the
+// command string. POSIX closes the quote, escapes the literal quote, reopens; PowerShell doubles quotes.
+export function shellQuoteFor(platform: NodeJS.Platform): (value: string) => string {
+  if (platform === "win32") return (value) => `'${value.replace(/'/g, "''")}'`;
+  return (value) => `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import http from "http";
-import { WebSocketServer, WebSocket, type RawData } from "ws";
+import { WebSocketServer, WebSocket } from "ws";
 import type { IPty } from "node-pty";
 import path from "path";
 import fs from "fs/promises";
@@ -47,10 +47,11 @@ import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/en
 import { hasErrnoCode, messageOf } from "./errors.js";
 import type { PtyEntry } from "./session/types.js";
 import { sandboxWouldRun } from "./session/pty-spawn.js";
-import { closeWithError, isResizeFrame } from "./session/ws-frames.js";
+import { closeWithError } from "./session/ws-frames.js";
 import { createClaudeSpawner } from "./session/spawn-claude.js";
 import { createCodexSpawner } from "./session/spawn-codex.js";
 import { createShellSpawners } from "./session/spawn-shell.js";
+import { createConnectionHandlers, handleCommandFrame } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
 import {
   activity,
@@ -89,7 +90,6 @@ import { codexAdapter } from "./agents/codex.js";
 import { codexSessionsRoot } from "./agents/codex-session.js";
 import { codexRolloutExists } from "./agents/codex-sessions.js";
 import { codexifySkillSeed } from "./agents/codex-skills.js";
-import { stripTerminalQueries } from "./session/terminal-replay.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
 import { isRecord, isTrivialPrompt, countUserTurnsFromJsonl, latestAssistantTextFromJsonl, preferredHeaderPrompt } from "./session/transcript.js";
@@ -319,6 +319,15 @@ function armReapForDetached(id: string) {
   }
   scheduleReap(id, decision.delayMs);
 }
+
+// Per-connection plumbing (session/pty-connection.ts). The reap decisions stay here —
+// they read activity state and schedule timers that outlive any one connection.
+const { reattachPty, handleClientFrame, handleClientClose } = createConnectionHandlers({
+  cancelReap: (id) => cancelReap(id),
+  reap: (id) => reap(id),
+  setWaiting: (id, waiting) => setWaiting(id, waiting),
+  armReapForDetached: (id) => armReapForDetached(id),
+});
 
 function reap(id: string) {
   cancelReap(id);
@@ -1254,32 +1263,6 @@ server.on("upgrade", (req, socket, head) => {
   target.handleUpgrade(req, socket, head, (ws) => target.emit("connection", ws, req));
 });
 
-// Reattach a live background PTY to a new socket: drop any stale socket, swap in
-// the new one, and replay the buffered tail for context.
-function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntry {
-  cancelReap(sessionId); // a reattach within the grace window keeps the session
-  console.log(`[ws] reattach ${sessionId} (pid=${entry.term.pid})`);
-  // Drop any socket still attached (e.g. the same session open in another tab).
-  // Tell it it's been superseded FIRST so it stops instead of auto-reconnecting —
-  // otherwise two clients on one session ping-pong (each reattach kicks the other,
-  // the kicked one reconnects, …) into a storm.
-  if (entry.ws && entry.ws !== ws && entry.ws.readyState === entry.ws.OPEN) {
-    try {
-      entry.ws.send(JSON.stringify({ type: "superseded" }));
-    } catch {
-      // socket already going away — closing below is enough
-    }
-    entry.ws.close();
-  }
-  entry.ws = ws;
-  if (entry.buffer && ws.readyState === ws.OPEN) {
-    // Strip terminal queries from the replay so xterm doesn't re-answer them as stray input
-    // (e.g. a DA reply surfacing as "0;276;0c" in the prompt) — see terminal-replay.ts.
-    ws.send(JSON.stringify({ type: "output", data: stripTerminalQueries(entry.buffer) }));
-  }
-  return entry;
-}
-
 // How long to wait for a hidden translation worker to call submitTranslation before
 // giving up (cold claude startup + one short turn). Generous; the result is cached.
 const TRANSLATION_TIMEOUT_MS = 120_000;
@@ -1354,77 +1337,6 @@ async function translateViaHiddenChat(targetLanguage: string, sentences: readonl
     }
   }
   throw lastErr instanceof Error ? lastErr : new Error("[translation] hidden chat failed");
-}
-
-// browser -> PTY. The protocol is client-controlled, so validate every frame
-// before touching node-pty (bad cols/rows or non-string input can throw).
-function handleClientFrame(entry: PtyEntry, ws: WebSocket, raw: RawData, sessionId: string) {
-  // Ignore frames from a socket that a newer client has already superseded.
-  if (entry.ws !== ws) return;
-  let msg;
-  try {
-    msg = JSON.parse(raw.toString());
-  } catch {
-    return; // not JSON — never write arbitrary payloads to the PTY
-  }
-  try {
-    if (msg.type === "terminate") {
-      // Explicit close (the cell's ✕) — reap now instead of waiting out the
-      // disconnect grace window, so the session slot frees immediately.
-      reap(sessionId);
-    } else if (msg.type === "view" && typeof msg.active === "boolean") {
-      // The user's focus moved onto/off this pane (a grid cell zoomed/opened, or
-      // blurred). An active pane suppresses the attention flag and marks it read;
-      // an inactive grid cell can surface blocked/done among its siblings.
-      entry.active = msg.active;
-      if (msg.active) setWaiting(sessionId, false);
-    } else if (msg.type === "input" && typeof msg.data === "string") {
-      entry.term.write(msg.data);
-    } else if (isResizeFrame(msg)) {
-      entry.term.resize(msg.cols, msg.rows);
-    }
-  } catch (err) {
-    // e.g. a write/resize that races the PTY exiting — drop it, never crash.
-    console.warn(`[ws] dropped message for ${sessionId}: ${messageOf(err)}`);
-  }
-}
-
-// browser -> command PTY. Like handleClientFrame but for the session-less command
-// terminal: only input/resize (no terminate/session machinery).
-function handleCommandFrame(term: IPty, raw: RawData) {
-  let msg;
-  try {
-    msg = JSON.parse(raw.toString());
-  } catch {
-    return; // not JSON — never write arbitrary payloads to the PTY
-  }
-  try {
-    if (msg.type === "input" && typeof msg.data === "string") {
-      term.write(msg.data);
-    } else if (isResizeFrame(msg)) {
-      term.resize(msg.cols, msg.rows);
-    }
-  } catch (err) {
-    console.warn(`[ws/run] dropped message: ${messageOf(err)}`);
-  }
-}
-
-// Socket closed: detach it and decide the PTY's fate by activity — working stays
-// alive, needs-the-user gets a long grace, idle gets the short grace.
-function handleClientClose(entry: PtyEntry, ws: WebSocket, sessionId: string) {
-  // Ignore if a newer client already reattached to this session.
-  if (entry.ws !== ws) return;
-  entry.ws = null;
-  // A session with no live socket is by definition not being viewed. Clear `active`
-  // so an UNCLEAN disconnect (crash / network drop / killed tab, where the client
-  // can't send `view active:false`) can't leave the attention flag suppressed until
-  // reconnect. A reattach re-asserts `active` (attach default + the client's view frame).
-  entry.active = false;
-  // Keep a working session alive indefinitely, give a session that needs the user
-  // the long grace, and reap a genuinely idle one after the short grace. A reload
-  // reconnects in a moment and re-attaches (cancelling the reap) regardless.
-  console.log(`[ws] disconnected ${sessionId}`);
-  armReapForDetached(sessionId);
 }
 
 // Pick the effective session id for a /ws connection: reattach a same-process live pty,

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,7 +16,7 @@ import { initArtifactsBackend } from "./backends/artifacts.js";
 import { mountConfigRoutes, getUserMcpServers, getHeaderConfig, getPushEnabled, getWorklogConfig } from "./config/config-routes.js";
 import { sendWebPush } from "./infra/web-push.js";
 import { buildHeaderContext, loadHeaderConfig } from "./config/header-context.js";
-import { resolveButtonCommand } from "./config/header-resolve.js";
+import { resolveButtonCommand, shellQuoteFor } from "./config/header-resolve.js";
 import { mountFilesBrowseRoutes } from "./files/files-browse.js";
 import {
   tmuxAvailable,
@@ -41,7 +41,7 @@ import {
 } from "./infra/sandbox.js";
 import { dirConfigWriteTarget } from "./config/dir-config.js";
 import { resolveScript } from "./files/scripts.js";
-import { resolveSession, type SessionResolution } from "./session/session-resolve.js";
+import { canStartLauncher, resolveReattachableId, resolveSession, type SessionResolution } from "./session/session-resolve.js";
 import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "./session/activity-hook.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { hasErrnoCode, messageOf } from "./errors.js";
@@ -1449,13 +1449,6 @@ runWss.on("connection", (ws, req) => {
   void startRunTerminal(ws, new URL(req.url ?? "/", "http://localhost"));
 });
 
-// POSIX/PowerShell single-arg quoting, so a substituted ${branch}/${repo}/${task} can't break out of the
-// command string. POSIX closes the quote, escapes the literal quote, reopens; PowerShell doubles quotes.
-function shellQuoteFor(platform: NodeJS.Platform): (value: string) => string {
-  if (platform === "win32") return (value) => `'${value.replace(/'/g, "''")}'`;
-  return (value) => `'${value.replace(/'/g, "'\\''")}'`;
-}
-
 async function resolveButtonRun(url: URL, cwd: string): Promise<{ command: string; cwd: string } | null> {
   const buttonId = url.searchParams.get("buttonId");
   if (!buttonId) return null;
@@ -1519,16 +1512,14 @@ function resolveLaunchSession(
   index: number,
   shell: boolean,
 ): { sessionId: string; live: PtyEntry | undefined; command: string } | null {
-  const reattachId = requested && ptys.has(requested) ? requested : null;
-  const live = reattachId ? ptys.get(reattachId) : undefined;
+  const hasLivePty = !!requested && ptys.has(requested);
+  const live = hasLivePty && requested ? ptys.get(requested) : undefined;
   const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
   // A live PTY / surviving tmux session reattaches regardless of the index; only a fresh
   // spawn needs the launcher resolved (the pty already IS the chosen program on reattach).
   const launcher = live || tmuxAlive ? null : resolveLauncher(index);
-  // `shell` (the header "new terminal" button) runs the OS default shell with no configured
-  // index, so a fresh spawn is allowed without a resolvable launcher.
-  if (!live && !tmuxAlive && !launcher && !shell) return null;
-  const sessionId = reattachId ?? (tmuxAlive && requested ? requested : randomUUID());
+  if (!canStartLauncher({ hasLivePty, tmuxAlive, hasLauncher: !!launcher, isShell: shell })) return null;
+  const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: false }, randomUUID);
   return { sessionId, live, command: launcher?.command ?? DEFAULT_LAUNCH_CMD };
 }
 
@@ -1574,11 +1565,11 @@ function codexResumeIdFor(requested: string): string | null {
 }
 
 function resolveCodexSession(requested: string | null): { sessionId: string; live: PtyEntry | undefined; resumeRolloutId: string | null } {
-  const reattachId = requested && ptys.has(requested) ? requested : null;
-  const live = reattachId ? ptys.get(reattachId) : undefined;
+  const hasLivePty = !!requested && ptys.has(requested);
+  const live = hasLivePty && requested ? ptys.get(requested) : undefined;
   const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
   const resumeRolloutId = !live && !tmuxAlive && requested ? codexResumeIdFor(requested) : null;
-  const sessionId = reattachId ?? ((tmuxAlive || resumeRolloutId) && requested ? requested : randomUUID());
+  const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: !!resumeRolloutId }, randomUUID);
   return { sessionId, live, resumeRolloutId };
 }
 

--- a/server/session/pty-connection.ts
+++ b/server/session/pty-connection.ts
@@ -1,0 +1,127 @@
+// What happens on a terminal connection once it exists: handing a live PTY to a new
+// socket, dispatching the frames a browser sends, and deciding the PTY's fate when the
+// socket goes away. Split from index.ts (#548 step 3d) — shared by every terminal
+// endpoint (/ws, /ws/launch, /ws/codex), so it comes out ahead of the handlers.
+//
+// The reap decisions stay in index.ts and arrive as deps: they read activity state and
+// schedule timers that outlive any one connection.
+import type { IPty } from "node-pty";
+import type { WebSocket } from "ws";
+import { messageOf } from "../errors.js";
+import { isResizeFrame } from "./ws-frames.js";
+import { stripTerminalQueries } from "./terminal-replay.js";
+import type { PtyEntry } from "./types.js";
+
+/** A frame as it arrives off the socket. Only `toString()` is used — ws hands us a
+ *  Buffer, and narrowing to this lets a test pass one without a live connection. */
+export type WireFrame = { toString(): string };
+
+export interface ConnectionDeps {
+  /** A reattach inside the grace window keeps the session alive. */
+  cancelReap: (id: string) => void;
+  /** Explicit close from the client — tear down now, don't wait out the grace. */
+  reap: (id: string) => void;
+  setWaiting: (id: string, waiting: boolean) => void;
+  /** Socket gone: keep, grace, or reap according to what the session was doing. */
+  armReapForDetached: (id: string) => void;
+}
+
+// browser -> command PTY. Like handleClientFrame but for the session-less command
+// terminal: only input/resize (no terminate/session machinery).
+export function handleCommandFrame(term: IPty, raw: WireFrame) {
+  let msg;
+  try {
+    msg = JSON.parse(raw.toString());
+  } catch {
+    return; // not JSON — never write arbitrary payloads to the PTY
+  }
+  try {
+    if (msg.type === "input" && typeof msg.data === "string") {
+      term.write(msg.data);
+    } else if (isResizeFrame(msg)) {
+      term.resize(msg.cols, msg.rows);
+    }
+  } catch (err) {
+    console.warn(`[ws/run] dropped message: ${messageOf(err)}`);
+  }
+}
+
+export function createConnectionHandlers(deps: ConnectionDeps) {
+  // Reattach a live background PTY to a new socket: drop any stale socket, swap in
+  // the new one, and replay the buffered tail for context.
+  function reattachPty(entry: PtyEntry, ws: WebSocket, sessionId: string): PtyEntry {
+    deps.cancelReap(sessionId); // a reattach within the grace window keeps the session
+    console.log(`[ws] reattach ${sessionId} (pid=${entry.term.pid})`);
+    // Drop any socket still attached (e.g. the same session open in another tab).
+    // Tell it it's been superseded FIRST so it stops instead of auto-reconnecting —
+    // otherwise two clients on one session ping-pong (each reattach kicks the other,
+    // the kicked one reconnects, …) into a storm.
+    if (entry.ws && entry.ws !== ws && entry.ws.readyState === entry.ws.OPEN) {
+      try {
+        entry.ws.send(JSON.stringify({ type: "superseded" }));
+      } catch {
+        // socket already going away — closing below is enough
+      }
+      entry.ws.close();
+    }
+    entry.ws = ws;
+    if (entry.buffer && ws.readyState === ws.OPEN) {
+      // Strip terminal queries from the replay so xterm doesn't re-answer them as stray input
+      // (e.g. a DA reply surfacing as "0;276;0c" in the prompt) — see terminal-replay.ts.
+      ws.send(JSON.stringify({ type: "output", data: stripTerminalQueries(entry.buffer) }));
+    }
+    return entry;
+  }
+
+  // browser -> PTY. The protocol is client-controlled, so validate every frame
+  // before touching node-pty (bad cols/rows or non-string input can throw).
+  function handleClientFrame(entry: PtyEntry, ws: WebSocket, raw: WireFrame, sessionId: string) {
+    // Ignore frames from a socket that a newer client has already superseded.
+    if (entry.ws !== ws) return;
+    let msg;
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return; // not JSON — never write arbitrary payloads to the PTY
+    }
+    try {
+      if (msg.type === "terminate") {
+        // Explicit close (the cell's ✕) — reap now instead of waiting out the
+        // disconnect grace window, so the session slot frees immediately.
+        deps.reap(sessionId);
+      } else if (msg.type === "view" && typeof msg.active === "boolean") {
+        // The user's focus moved onto/off this pane (a grid cell zoomed/opened, or
+        // blurred). An active pane suppresses the attention flag and marks it read;
+        // an inactive grid cell can surface blocked/done among its siblings.
+        entry.active = msg.active;
+        if (msg.active) deps.setWaiting(sessionId, false);
+      } else if (msg.type === "input" && typeof msg.data === "string") {
+        entry.term.write(msg.data);
+      } else if (isResizeFrame(msg)) {
+        entry.term.resize(msg.cols, msg.rows);
+      }
+    } catch (err) {
+      // e.g. a write/resize that races the PTY exiting — drop it, never crash.
+      console.warn(`[ws] dropped message for ${sessionId}: ${messageOf(err)}`);
+    }
+  }
+
+  // Socket closed: detach it and decide the PTY's fate by activity — working stays
+  // alive, needs-the-user gets a long grace, idle gets the short grace.
+  function handleClientClose(entry: PtyEntry, ws: WebSocket, sessionId: string) {
+    // Ignore if a newer client already reattached to this session.
+    if (entry.ws !== ws) return;
+    entry.ws = null;
+    // A session with no live socket is by definition not being viewed. Clear `active`
+    // so an UNCLEAN disconnect (crash / network drop / killed tab, where the client
+    // can't send `view active:false`) can't leave the attention flag suppressed until
+    // reconnect. A reattach re-asserts `active` (attach default + the client's view frame).
+    entry.active = false;
+    // Keep a working session alive indefinitely, give a session that needs the user
+    // the long grace, and reap a genuinely idle one after the short grace. A reload
+    // reconnects in a moment and re-attaches (cancelling the reap) regardless.
+    console.log(`[ws] disconnected ${sessionId}`);
+    deps.armReapForDetached(sessionId);
+  }
+  return { reattachPty, handleClientFrame, handleClientClose };
+}

--- a/server/session/session-resolve.ts
+++ b/server/session/session-resolve.ts
@@ -35,3 +35,27 @@ export function resolveSession(requested: string | null, facts: SessionFacts, mi
   const sessionId = reattachId ?? (requested && (facts.tmuxAlive || resume) ? requested : mintId());
   return { reattachId, resume, sessionId };
 }
+
+// ── the same decision for the two non-claude terminals ─────────────────────────
+
+/** Which id a launcher or codex connection runs as. A live pty in this process always
+ *  wins; otherwise the requested id is reused only when something can actually serve it
+ *  (a surviving tmux session, or — for codex — a rollout to resume). Anything else mints
+ *  a fresh id, because reusing an id nothing can serve strands the client on a dead one. */
+export function resolveReattachableId(
+  requested: string | null,
+  facts: { hasLivePty: boolean; tmuxAlive: boolean; canResume: boolean },
+  mintId: () => string,
+): { reattachId: string | null; sessionId: string } {
+  const reattachId = requested && facts.hasLivePty ? requested : null;
+  const sessionId = reattachId ?? (requested && (facts.tmuxAlive || facts.canResume) ? requested : mintId());
+  return { reattachId, sessionId };
+}
+
+/** Whether a launcher connection may start at all. A reattach needs no launcher index —
+ *  the pty already IS the chosen program — and the header's "new terminal" button runs the
+ *  default shell with no configured index. Otherwise the index must name a real launcher,
+ *  or there is nothing to run. */
+export function canStartLauncher(facts: { hasLivePty: boolean; tmuxAlive: boolean; hasLauncher: boolean; isShell: boolean }): boolean {
+  return facts.hasLivePty || facts.tmuxAlive || facts.hasLauncher || facts.isShell;
+}

--- a/test/server/config/header-resolve.spec.ts
+++ b/test/server/config/header-resolve.spec.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { substitute, substituteShell, evalWhen, resolveHeader, resolveButtonCommand, headerHasPrButton } from "../../../server/config/header-resolve.js";
+import {
+  substitute,
+  substituteShell,
+  evalWhen,
+  resolveHeader,
+  resolveButtonCommand,
+  headerHasPrButton,
+  shellQuoteFor,
+} from "../../../server/config/header-resolve.js";
 import type { HeaderConfig, HeaderContext } from "../../../server/config/header-config.js";
 
 // POSIX single-quote escaping, matching the server's shellQuoteFor(non-win32).
@@ -175,5 +183,46 @@ describe("headerHasPrButton", () => {
   });
   it("checks DEFAULT_BUTTONS when unconfigured (they have no pr button)", () => {
     expect(headerHasPrButton({ buttons: null, chips: null })).toBe(false);
+  });
+});
+
+// A header button's command is a string the shell parses, and ${branch}/${repo}/${task}
+// come from the repo and the user's config. Quoting is the only thing standing between a
+// branch named `; rm -rf ~` and that command running.
+describe("shellQuoteFor", () => {
+  const posix = shellQuoteFor("darwin");
+  const win = shellQuoteFor("win32");
+
+  it("wraps a plain value in single quotes on posix", () => {
+    expect(posix("main")).toBe("'main'");
+  });
+
+  it("neutralizes shell metacharacters by quoting them", () => {
+    for (const evil of ["; rm -rf ~", "$(id)", "`id`", "a && b", "a | b", "a > f", "$HOME", "a\nb"]) {
+      const quoted = posix(evil);
+      expect(quoted.startsWith("'")).toBe(true);
+      expect(quoted.endsWith("'")).toBe(true);
+      // Nothing between the quotes may be a bare quote that ends the string early.
+      expect(quoted.slice(1, -1)).not.toContain("'");
+    }
+  });
+
+  it("escapes an embedded single quote by closing, escaping, reopening", () => {
+    // The classic break-out: a value containing ' would otherwise end the quoted string.
+    expect(posix("it's")).toBe("'it'\\''s'");
+  });
+
+  it("keeps a break-out attempt inside the quotes on posix", () => {
+    expect(posix("'; rm -rf ~; echo '")).toBe("''\\''; rm -rf ~; echo '\\'''");
+  });
+
+  it("doubles single quotes on powershell", () => {
+    expect(win("it's")).toBe("'it''s'");
+    expect(win("'; rm -rf ~")).toBe("'''; rm -rf ~'");
+  });
+
+  it("quotes an empty value rather than producing a bare gap", () => {
+    expect(posix("")).toBe("''");
+    expect(win("")).toBe("''");
   });
 });

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createConnectionHandlers, handleCommandFrame } from "../../../server/session/pty-connection.js";
 import type { PtyEntry } from "../../../server/session/types.js";
 
@@ -137,13 +137,21 @@ describe("handleClientFrame", () => {
     expect(calls).toEqual([]);
   });
 
-  it("never writes a non-JSON payload to the pty", () => {
+  it("never writes a non-JSON payload to the pty, and drops it silently", () => {
+    // Silently matters: a client can send anything, so a malformed frame must not
+    // reach the pty AND must not let that client flood the server log.
     const { handleClientFrame } = setup();
     const t = fakeTerm();
     const s = fakeSocket();
-    const entry = entryWith({ term: t.term as never, ws: s.ws as never });
-    handleClientFrame(entry, s.ws as never, "not json at all", SESSION);
-    expect(t.writes).toEqual([]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const entry = entryWith({ term: t.term as never, ws: s.ws as never });
+      handleClientFrame(entry, s.ws as never, "not json at all", SESSION);
+      expect(t.writes).toEqual([]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("ignores an unknown frame type and a non-string input payload", () => {
@@ -193,12 +201,18 @@ describe("handleCommandFrame", () => {
     expect(t.resizes).toEqual([]);
   });
 
-  it("ignores malformed JSON and out-of-bounds resizes", () => {
+  it("drops malformed JSON silently, and ignores out-of-bounds resizes", () => {
     const t = fakeTerm();
-    handleCommandFrame(t.term as never, "{{{");
-    handleCommandFrame(t.term as never, frame({ type: "resize", cols: 9999, rows: 24 }));
-    expect(t.writes).toEqual([]);
-    expect(t.resizes).toEqual([]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      handleCommandFrame(t.term as never, "{{{");
+      expect(warn).not.toHaveBeenCalled();
+      handleCommandFrame(t.term as never, frame({ type: "resize", cols: 9999, rows: 24 }));
+      expect(t.writes).toEqual([]);
+      expect(t.resizes).toEqual([]);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("survives a pty that throws", () => {

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from "vitest";
+import { createConnectionHandlers, handleCommandFrame } from "../../../server/session/pty-connection.js";
+import type { PtyEntry } from "../../../server/session/types.js";
+
+const OPEN = 1;
+const CLOSED = 3;
+const SESSION = "11111111-2222-3333-4444-555555555555";
+
+// Records what the PTY and the socket were asked to do, so a frame's effect can be
+// asserted without a real terminal or connection.
+function fakeTerm() {
+  const writes: string[] = [];
+  const resizes: Array<[number, number]> = [];
+  return {
+    writes,
+    resizes,
+    term: {
+      pid: 4242,
+      write: (d: string) => {
+        writes.push(d);
+      },
+      resize: (cols: number, rows: number) => {
+        resizes.push([cols, rows]);
+      },
+    },
+  };
+}
+
+function fakeSocket(readyState = OPEN) {
+  const sent: string[] = [];
+  let closed = 0;
+  return {
+    sent,
+    closeCount: () => closed,
+    parsed: () => sent.map((s) => JSON.parse(s)),
+    ws: {
+      readyState,
+      OPEN,
+      send: (d: string) => {
+        sent.push(d);
+      },
+      close: () => {
+        closed++;
+      },
+    },
+  };
+}
+
+function setup() {
+  const calls: string[] = [];
+  const handlers = createConnectionHandlers({
+    cancelReap: (id) => calls.push(`cancelReap:${id}`),
+    reap: (id) => calls.push(`reap:${id}`),
+    setWaiting: (id, waiting) => calls.push(`setWaiting:${id}:${waiting}`),
+    armReapForDetached: (id) => calls.push(`armReap:${id}`),
+  });
+  return { ...handlers, calls };
+}
+
+// PtyEntry carries fields these handlers never touch; the fakes model the ones they do.
+function entryWith(over: Partial<PtyEntry> = {}) {
+  const { term } = fakeTerm();
+  return { term, ws: null, buffer: "", cwd: "/ws", active: false, agent: "claude", ...over } as unknown as PtyEntry;
+}
+
+describe("handleClientFrame", () => {
+  const frame = (o: unknown) => JSON.stringify(o);
+
+  it("writes an input frame to the pty", () => {
+    const { handleClientFrame } = setup();
+    const t = fakeTerm();
+    const s = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: s.ws as never });
+    handleClientFrame(entry, s.ws as never, frame({ type: "input", data: "ls\r" }), SESSION);
+    expect(t.writes).toEqual(["ls\r"]);
+  });
+
+  it("resizes on a valid resize frame", () => {
+    const { handleClientFrame } = setup();
+    const t = fakeTerm();
+    const s = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: s.ws as never });
+    handleClientFrame(entry, s.ws as never, frame({ type: "resize", cols: 100, rows: 40 }), SESSION);
+    expect(t.resizes).toEqual([[100, 40]]);
+  });
+
+  it("ignores a resize outside the allowed bounds", () => {
+    const { handleClientFrame } = setup();
+    const t = fakeTerm();
+    const s = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: s.ws as never });
+    handleClientFrame(entry, s.ws as never, frame({ type: "resize", cols: 0, rows: 99999 }), SESSION);
+    expect(t.resizes).toEqual([]);
+  });
+
+  it("reaps immediately on terminate rather than waiting out the grace window", () => {
+    const { handleClientFrame, calls } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: s.ws as never });
+    handleClientFrame(entry, s.ws as never, frame({ type: "terminate" }), SESSION);
+    expect(calls).toEqual([`reap:${SESSION}`]);
+  });
+
+  it("marks an activated pane read, and only tracks the flag when deactivated", () => {
+    const { handleClientFrame, calls } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: s.ws as never });
+
+    handleClientFrame(entry, s.ws as never, frame({ type: "view", active: true }), SESSION);
+    expect(entry.active).toBe(true);
+    expect(calls).toEqual([`setWaiting:${SESSION}:false`]);
+
+    handleClientFrame(entry, s.ws as never, frame({ type: "view", active: false }), SESSION);
+    expect(entry.active).toBe(false);
+    expect(calls).toHaveLength(1); // deactivating must not clear the attention flag
+  });
+
+  it("ignores a view frame whose active flag is not a boolean", () => {
+    const { handleClientFrame, calls } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: s.ws as never, active: true });
+    handleClientFrame(entry, s.ws as never, frame({ type: "view", active: "yes" }), SESSION);
+    expect(entry.active).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it("ignores frames from a socket a newer client has superseded", () => {
+    // Two tabs on one session: the older socket must not drive the pty the newer one owns.
+    const { handleClientFrame, calls } = setup();
+    const t = fakeTerm();
+    const current = fakeSocket();
+    const stale = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: current.ws as never });
+    handleClientFrame(entry, stale.ws as never, frame({ type: "input", data: "rm -rf /" }), SESSION);
+    handleClientFrame(entry, stale.ws as never, frame({ type: "terminate" }), SESSION);
+    expect(t.writes).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  it("never writes a non-JSON payload to the pty", () => {
+    const { handleClientFrame } = setup();
+    const t = fakeTerm();
+    const s = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: s.ws as never });
+    handleClientFrame(entry, s.ws as never, "not json at all", SESSION);
+    expect(t.writes).toEqual([]);
+  });
+
+  it("ignores an unknown frame type and a non-string input payload", () => {
+    const { handleClientFrame } = setup();
+    const t = fakeTerm();
+    const s = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: s.ws as never });
+    handleClientFrame(entry, s.ws as never, frame({ type: "whatever" }), SESSION);
+    handleClientFrame(entry, s.ws as never, frame({ type: "input", data: { evil: true } }), SESSION);
+    expect(t.writes).toEqual([]);
+  });
+
+  it("survives a pty that throws mid-write instead of crashing the server", () => {
+    // A write racing the pty's exit throws; dropping the frame is the whole point.
+    const { handleClientFrame } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({
+      ws: s.ws as never,
+      term: {
+        write: () => {
+          throw new Error("EIO");
+        },
+      } as never,
+    });
+    expect(() => handleClientFrame(entry, s.ws as never, frame({ type: "input", data: "x" }), SESSION)).not.toThrow();
+  });
+});
+
+// The Run menu's terminal has no session identity, so it accepts only input/resize —
+// never terminate, which would reach for session machinery that isn't there.
+describe("handleCommandFrame", () => {
+  const frame = (o: unknown) => JSON.stringify(o);
+
+  it("writes input and applies a valid resize", () => {
+    const t = fakeTerm();
+    handleCommandFrame(t.term as never, frame({ type: "input", data: "echo hi\r" }));
+    handleCommandFrame(t.term as never, frame({ type: "resize", cols: 80, rows: 24 }));
+    expect(t.writes).toEqual(["echo hi\r"]);
+    expect(t.resizes).toEqual([[80, 24]]);
+  });
+
+  it("ignores terminate and view — this terminal has no session to act on", () => {
+    const t = fakeTerm();
+    handleCommandFrame(t.term as never, frame({ type: "terminate" }));
+    handleCommandFrame(t.term as never, frame({ type: "view", active: true }));
+    expect(t.writes).toEqual([]);
+    expect(t.resizes).toEqual([]);
+  });
+
+  it("ignores malformed JSON and out-of-bounds resizes", () => {
+    const t = fakeTerm();
+    handleCommandFrame(t.term as never, "{{{");
+    handleCommandFrame(t.term as never, frame({ type: "resize", cols: 9999, rows: 24 }));
+    expect(t.writes).toEqual([]);
+    expect(t.resizes).toEqual([]);
+  });
+
+  it("survives a pty that throws", () => {
+    const term = {
+      write: () => {
+        throw new Error("EIO");
+      },
+    };
+    expect(() => handleCommandFrame(term as never, frame({ type: "input", data: "x" }))).not.toThrow();
+  });
+});
+
+describe("reattachPty", () => {
+  it("cancels the pending reap and swaps in the new socket", () => {
+    const { reattachPty, calls } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: null });
+    reattachPty(entry, s.ws as never, SESSION);
+    expect(calls).toEqual([`cancelReap:${SESSION}`]);
+    expect(entry.ws).toBe(s.ws);
+  });
+
+  it("replays the buffered tail so the reattached view has context", () => {
+    const { reattachPty } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: null, buffer: "previous output" });
+    reattachPty(entry, s.ws as never, SESSION);
+    expect(s.parsed()).toEqual([{ type: "output", data: "previous output" }]);
+  });
+
+  it("strips terminal queries from the replay so xterm does not answer them as input", () => {
+    const { reattachPty } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: null, buffer: "before\x1b[c after" });
+    reattachPty(entry, s.ws as never, SESSION);
+    expect(s.parsed()[0].data).not.toContain("\x1b[c");
+  });
+
+  it("sends nothing when there is no buffered output", () => {
+    const { reattachPty } = setup();
+    const s = fakeSocket();
+    reattachPty(entryWith({ ws: null, buffer: "" }), s.ws as never, SESSION);
+    expect(s.sent).toEqual([]);
+  });
+
+  it("tells a superseded socket it lost the session before closing it", () => {
+    // Without the notice the kicked client auto-reconnects and the two tabs
+    // ping-pong, each reattach kicking the other.
+    const { reattachPty } = setup();
+    const old = fakeSocket();
+    const fresh = fakeSocket();
+    const entry = entryWith({ ws: old.ws as never, buffer: "" });
+    reattachPty(entry, fresh.ws as never, SESSION);
+    expect(old.parsed()).toEqual([{ type: "superseded" }]);
+    expect(old.closeCount()).toBe(1);
+    expect(entry.ws).toBe(fresh.ws);
+  });
+
+  it("does not supersede the same socket reattaching to itself", () => {
+    const { reattachPty } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: s.ws as never, buffer: "" });
+    reattachPty(entry, s.ws as never, SESSION);
+    expect(s.parsed()).toEqual([]);
+    expect(s.closeCount()).toBe(0);
+  });
+
+  it("leaves an already-closed previous socket alone", () => {
+    const { reattachPty } = setup();
+    const old = fakeSocket(CLOSED);
+    const fresh = fakeSocket();
+    reattachPty(entryWith({ ws: old.ws as never, buffer: "" }), fresh.ws as never, SESSION);
+    expect(old.sent).toEqual([]);
+    expect(old.closeCount()).toBe(0);
+  });
+});
+
+describe("handleClientClose", () => {
+  it("detaches the socket and arms the reap", () => {
+    const { handleClientClose, calls } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: s.ws as never, active: true });
+    handleClientClose(entry, s.ws as never, SESSION);
+    expect(entry.ws).toBeNull();
+    expect(calls).toEqual([`armReap:${SESSION}`]);
+  });
+
+  it("clears active, so an unclean disconnect cannot suppress the attention flag", () => {
+    // A crashed tab never sends `view active:false`; without this the session would
+    // stay "being viewed" until someone reconnects.
+    const { handleClientClose } = setup();
+    const s = fakeSocket();
+    const entry = entryWith({ ws: s.ws as never, active: true });
+    handleClientClose(entry, s.ws as never, SESSION);
+    expect(entry.active).toBe(false);
+  });
+
+  it("ignores the close of a socket a newer client already replaced", () => {
+    const { handleClientClose, calls } = setup();
+    const current = fakeSocket();
+    const stale = fakeSocket();
+    const entry = entryWith({ ws: current.ws as never, active: true });
+    handleClientClose(entry, stale.ws as never, SESSION);
+    expect(entry.ws).toBe(current.ws); // the live socket must survive the old one's close
+    expect(entry.active).toBe(true);
+    expect(calls).toEqual([]);
+  });
+});

--- a/test/server/session/session-resolve.spec.ts
+++ b/test/server/session/session-resolve.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSession, type SessionFacts } from "../../../server/session/session-resolve.js";
+import { resolveSession, type SessionFacts, resolveReattachableId, canStartLauncher } from "../../../server/session/session-resolve.js";
 
 const FIXED = "fresh-minted-id";
 const mint = () => FIXED;
@@ -37,5 +37,64 @@ describe("resolveSession", () => {
 
   it("prefers a live pty over tmux/disk", () => {
     expect(resolveSession("s1", facts({ hasLivePty: true, tmuxAlive: true, onDisk: true }), mint)).toEqual({ reattachId: "s1", resume: null, sessionId: "s1" });
+  });
+});
+
+// /ws/launch and /ws/codex reuse a requested id only when something can actually serve it.
+// Handing back an id nothing can serve strands the client on a dead session.
+describe("resolveReattachableId", () => {
+  const mint = () => "FRESH";
+  const facts = (over = {}) => ({ hasLivePty: false, tmuxAlive: false, canResume: false, ...over });
+
+  it("mints a fresh id when nothing was requested", () => {
+    expect(resolveReattachableId(null, facts(), mint)).toEqual({ reattachId: null, sessionId: "FRESH" });
+  });
+
+  it("reattaches a live pty in this process", () => {
+    expect(resolveReattachableId("REQ", facts({ hasLivePty: true }), mint)).toEqual({ reattachId: "REQ", sessionId: "REQ" });
+  });
+
+  it("keeps the id for a surviving tmux session, without reattaching a pty", () => {
+    expect(resolveReattachableId("REQ", facts({ tmuxAlive: true }), mint)).toEqual({ reattachId: null, sessionId: "REQ" });
+  });
+
+  it("keeps the id when there is something to resume", () => {
+    expect(resolveReattachableId("REQ", facts({ canResume: true }), mint)).toEqual({ reattachId: null, sessionId: "REQ" });
+  });
+
+  it("mints a fresh id when the requested one cannot be served", () => {
+    expect(resolveReattachableId("REQ", facts(), mint)).toEqual({ reattachId: null, sessionId: "FRESH" });
+  });
+
+  it("prefers the live pty when several facts hold at once", () => {
+    expect(resolveReattachableId("REQ", facts({ hasLivePty: true, tmuxAlive: true, canResume: true }), mint)).toEqual({ reattachId: "REQ", sessionId: "REQ" });
+  });
+
+  it("never reattaches without a requested id, whatever the facts say", () => {
+    expect(resolveReattachableId(null, facts({ hasLivePty: true, tmuxAlive: true, canResume: true }), mint)).toEqual({ reattachId: null, sessionId: "FRESH" });
+  });
+});
+
+// A launcher connection needs SOMETHING to run: an existing process to reattach to, a
+// configured launcher at the requested index, or the "new terminal" shell button.
+describe("canStartLauncher", () => {
+  const facts = (over = {}) => ({ hasLivePty: false, tmuxAlive: false, hasLauncher: false, isShell: false, ...over });
+
+  it("refuses when there is nothing to reattach and no launcher at that index", () => {
+    expect(canStartLauncher(facts())).toBe(false);
+  });
+
+  it("allows a reattach even when the index names no launcher", () => {
+    // The pty already IS the chosen program, so the index is irrelevant.
+    expect(canStartLauncher(facts({ hasLivePty: true }))).toBe(true);
+    expect(canStartLauncher(facts({ tmuxAlive: true }))).toBe(true);
+  });
+
+  it("allows a fresh spawn of a configured launcher", () => {
+    expect(canStartLauncher(facts({ hasLauncher: true }))).toBe(true);
+  });
+
+  it("allows the shell button, which has no configured index", () => {
+    expect(canStartLauncher(facts({ isShell: true }))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

#548 の続き。WebSocket 接続まわりのうち、**全エンドポイントで共有される配管**と**純粋な判断ロジック**を切り出しました。

index.ts: **1756 → 1659 行**（-97）／テスト: 1675 → **1716 件**（+41）

| コミット | 内容 |
|---|---|
| `addb3f8` (3d-1) | `reattachPty` / `handleClientFrame` / `handleCommandFrame` / `handleClientClose` を `session/pty-connection.ts` へ。deps 注入 |
| `43f7e0f` (3d-2) | `shellQuoteFor` を `config/header-resolve.ts` へ。launcher/codex のセッション解決を純粋関数化 |
| `4eab5cd` | Codex 指摘対応（不正フレームを「黙って」捨てる契約をテストで押さえる） |

## Items to Confirm / Review

- **3d-2 は「移動」ではなく「書き換え」です**（最もリスクが高い箇所）。`resolveLaunchSession` / `resolveCodexSession` が各自で導出していた「どの id で動かすか」を、既存の `resolveSession` の隣に置いた `resolveReattachableId` と `canStartLauncher` に集約しました。置き換え前に**ファクトの全 80 通りの組み合わせ**で元の式と結果が一致することを確認しています。Codex も全マトリクスで behaviorally identical と確認済みです。
- **`shellQuoteFor` にテストが無かった点**。ヘッダーボタンが `${branch}` を展開する際、`; rm -rf ~` のようなブランチ名がコマンドを破らないようにする唯一の防御です。`resolveButtonCommand` が引数で受け取る設計なので、その実装が同居する `header-resolve.ts` に移しました。実装は main とバイト一致です。
- **`WireFrame` への型の絞り込み**。`RawData` ではなく `{ toString(): string }` にしたので、テストが文字列を渡せます。Codex 補足: `toString()` の意味は `RawData` の union メンバ間で完全に同一ではありませんが、これは本リファクタ以前からの挙動で回帰ではありません。
- **`handleCommandFrame` は deps を使わない**ため factory の外に置いています。

## 検証

**1. 移動の忠実性** — 3d-1 の 4 関数すべてを `git show main:server/index.ts` と行単位で照合し、注入置換と型名以外の差分ゼロを確認。

**2. 書き換えの等価性** — 全 80 通りの総当たりで元の式と一致。

**3. teeth 確認**（変異が実際に適用されたことを毎回検証）

- pty-connection: superseded ガード除去／superseded 通知の抑止／close 時に active を消さない／terminate で reap しない／setWaiting しない／replay の制御列除去をやめる／JSON パース失敗時の return 除去（2 箇所）→ **すべて赤**
- shellQuoteFor: 引用そのものをやめる／埋め込み引用符のエスケープをやめる／PowerShell の二重化をやめる → すべて赤
- session-resolve: canResume を無視／tmuxAlive を無視／isShell を許可しない／hasLauncher を許可しない → すべて赤

なお `resolveReattachableId` の `requested &&` ガード除去は緑のままでしたが、差が出るのは `requested === ""` のみで `wsConnectionContext` が UUID 以外を `null` にするため到達不能な**等価変異**です（Codex も同意見）。

**4. ローカル Codex レビュー** — 初回は **CHANGES REQUESTED**（不正フレームの silent-drop 契約がテストで押さえられていない）。指摘は妥当だったため修正し、再レビューで **LGTM**。

**5. ゲート** — lint 0 error / build / typecheck 通過 / 全テスト 147 files・**1716 passed**。

## 次段階（step 3e）

残る WebSocket 接続ハンドラ本体（`/ws`・`/ws/run`・`/ws/launch`・`/ws/codex` の `on("connection")` と upgrade ルーティング、約 370 行）。調査の結果、注入が必要な index.ts ローカル参照は **12 個**（`CLAUDE_BIN` / `isAllowedOrigin` / `server` / `setWaiting` + 分割済みモジュール由来の 8 束縛）と分かっています。

ただしこの領域には**翻訳ワーカーのコードが挟まっており連続していません**。先に翻訳ワーカーを切り出すか、非連続な抽出にするかの判断が必要です。
