### PR TITLE
fix(terminal): スマホからは「スマホの文字だけ」を送る (#572)

### DIFF
--- a/plans/fix-572-clear-host-box.md
+++ b/plans/fix-572-clear-host-box.md
@@ -1,0 +1,72 @@
+# fix #572 — スマホから送るとき、ホスト側の入力欄に残った下書きと連結される
+
+## 問題
+
+`terminalInput.ts` は bracketed paste → 150ms 後に CR を書くだけで、入力欄に既にあるものを消しません。ホストで打ちかけた下書きが残っていると、スマホの文字がその後ろに連結されて送信されます（区切りの空白すら入らない）。
+
+再現（使い捨ての tmux セッション）:
+
+```
+ホストの入力欄: yes I already typed this
+スマホの送信:   ok
+実際の送信:     yes I already typed thisok
+```
+
+#445 の時点からある挙動ですが、#563 / mulmoserver#98 のチップで「タップして送る」が主要操作になったぶん踏みやすくなりました。
+
+## 実測に基づく解決策
+
+実際の Claude / Codex の TUI に各キーを送って確認した結果:
+
+| キー | 結果 |
+|---|---|
+| Ctrl-U | 表示 1 行分のみ。折り返した下書きは残る |
+| Ctrl-U 繰り返し | 行頭で止まり、行をまたげない |
+| Ctrl-A → Ctrl-K | 同じく行単位 |
+| Esc | 消えない |
+| **Ctrl-C** | **入力欄全体が 1 打で消える** |
+
+さらに **Ctrl-C とペーストは 1 回の書き込みにまとめられる**（3 行にまたがる下書きでも `❯ ok` だけになる）。遅延の追加は不要で、既存の「CR は別書き込みで 150ms 後」はそのまま。空の入力欄に送っても no-op。Codex（キャレット `›`）も同挙動。
+
+## 適用範囲
+
+Ctrl-C は**ターン実行中に送ると中断させる**ため、「ホストがアイドルだと確実に分かっている場合」のみに限定する:
+
+- **Claude セッションのみ** — `setWorking` を呼ぶのは Claude の activity hook だけで、codex の working 状態はホストが追跡していない。追跡していない以上アイドル判定ができない
+- **shell は対象外** — プロンプトに居るのか長時間コマンド実行中なのか分からず、後者では実行中のプロセスを殺す
+- **ターン実行中の Claude も対象外** — 従来どおり連結になるが、実行中に入力欄にあるのは「キューされたプロンプト」であり、黙って捨てる方が危険
+
+codex の working 追跡が入れば、そのまま対象を広げられる。
+
+## 変更
+
+### `server/backends/remoteHost/terminalInput.ts`
+
+```ts
+export const CLEAR_BOX = "\x03";
+
+export interface TerminalInputDeps {
+  writeToSession: (sessionId: string, chunk: string) => boolean;
+  // 入力欄を安全に空にできるか。省略時は false（＝従来どおり上に重ねてペースト）。
+  canClearBox?: (sessionId: string) => boolean;
+  scheduleSubmit?: (submit: () => void) => void;
+}
+```
+
+ペーストのチャンクを `${clear}${PASTE_START}${safe}${PASTE_END}` にするだけ。省略可能なので既存の呼び出し・テストの挙動は変わらない。
+
+### `server/index.ts` の配線
+
+```ts
+const remoteHostCanClearBox = (sessionId: string): boolean =>
+  ptys.get(sessionId)?.agent === "claude" && activity.get(sessionId)?.working !== true;
+```
+
+`handlers.ts` / `remoteHost/index.ts` の deps 型も追随。
+
+## テスト
+
+- `canClearBox` が true のとき、ペーストと**同じ 1 回の書き込み**で Ctrl-C が先行すること
+- false のとき（ターン実行中 / codex / shell / dep 省略）先行しないこと
+- スマホの文字自体に Ctrl-C を混ぜても `sanitizeTerminalInput` が落とすので、我々が付けた 1 個だけであること
+- 既存の直列化・失敗時のチェーン維持の回帰テストが通ること

--- a/plans/fix-572-clear-host-box.md
+++ b/plans/fix-572-clear-host-box.md
@@ -33,6 +33,7 @@
 Ctrl-C は**ターン実行中に送ると中断させる**ため、「ホストがアイドルだと確実に分かっている場合」のみに限定する:
 
 - **Claude セッションのみ** — `setWorking` を呼ぶのは Claude の activity hook だけで、codex の working 状態はホストが追跡していない。追跡していない以上アイドル判定ができない
+- **「ターンの完了をホストが見た」場合のみ**（`working === false`、`!== true` ではない）— activity レコードが無いのは「まだ誰も報告していない」であってアイドルではない。`initialPrompt` 付きで spawn されたセッションは hook が飛ぶ前に最初のターンを走らせており（`spawn-claude.ts`）、`setWorking(id, false)` はレコードを作りすらしない。未知をアイドルと読むとそのターンを中断してしまう
 - **shell は対象外** — プロンプトに居るのか長時間コマンド実行中なのか分からず、後者では実行中のプロセスを殺す
 - **ターン実行中の Claude も対象外** — 従来どおり連結になるが、実行中に入力欄にあるのは「キューされたプロンプト」であり、黙って捨てる方が危険
 
@@ -59,14 +60,16 @@ export interface TerminalInputDeps {
 
 ```ts
 const remoteHostCanClearBox = (sessionId: string): boolean =>
-  ptys.get(sessionId)?.agent === "claude" && activity.get(sessionId)?.working !== true;
+  canClearInputBox(ptys.get(sessionId)?.agent, activity.get(sessionId)?.working);
 ```
+
+判定そのものは純粋関数 `canClearInputBox(agent, working)` として `terminalInput.ts` に置く（`index.ts` に埋めると起動しないとテストできないため）。
 
 `handlers.ts` / `remoteHost/index.ts` の deps 型も追随。
 
 ## テスト
 
 - `canClearBox` が true のとき、ペーストと**同じ 1 回の書き込み**で Ctrl-C が先行すること
-- false のとき（ターン実行中 / codex / shell / dep 省略）先行しないこと
+- false のとき（ターン実行中 / activity レコード無し / codex / shell / dep 省略）先行しないこと
 - スマホの文字自体に Ctrl-C を混ぜても `sanitizeTerminalInput` が落とすので、我々が付けた 1 個だけであること
 - 既存の直列化・失敗時のチェーン維持の回帰テストが通ること

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -60,6 +60,7 @@ describe("createRemoteHostHandlers · getFeed", () => {
       listTerminalSessions: async () => [],
       captureTerminalScreen: async () => ({ screen: "", suggestion: "" }),
       writeToSession: () => false,
+      canClearBox: () => false,
     });
   });
   afterEach(() => vi.mocked(listFeeds).mockReset());

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -11,6 +11,7 @@ const unusedTerminalDeps = {
   listTerminalSessions: async () => [],
   captureTerminalScreen: async () => ({ screen: "", suggestion: "" }),
   writeToSession: () => false,
+  canClearBox: () => false,
 };
 
 describe("createRemoteHostHandlers", () => {

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -44,6 +44,10 @@ export interface RemoteHostHandlerDeps {
   // in this process — a tmux session that outlived a restart stays viewable but not
   // writable from here.
   writeToSession: (sessionId: string, chunk: string) => boolean;
+  // Whether typing may empty the session's input box first, so only the phone's text
+  // is submitted (#572). Answered in server/index.ts, where the agent kind and the
+  // turn state live.
+  canClearBox: (sessionId: string) => boolean;
 }
 
 // Parse the optional `attachments` param ([{ storage_id }]) into storage ids. A
@@ -137,11 +141,11 @@ const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (par
 // since #445 — type into it. Screens are bounded by the terminal's own geometry
 // (rows x cols), so unlike collections they need no paging to stay under the 1 MiB
 // command-doc ceiling.
-type TerminalScreenDeps = Pick<RemoteHostHandlerDeps, "listTerminalSessions" | "captureTerminalScreen" | "writeToSession">;
+type TerminalScreenDeps = Pick<RemoteHostHandlerDeps, "listTerminalSessions" | "captureTerminalScreen" | "writeToSession" | "canClearBox">;
 
-const terminalScreenHandlers = ({ listTerminalSessions, captureTerminalScreen, writeToSession }: TerminalScreenDeps): CommandHandlers => {
+const terminalScreenHandlers = ({ listTerminalSessions, captureTerminalScreen, writeToSession, canClearBox }: TerminalScreenDeps): CommandHandlers => {
   // One sender per host, so its per-session ordering actually spans every command.
-  const sendInput = createTerminalInputSender({ writeToSession });
+  const sendInput = createTerminalInputSender({ writeToSession, canClearBox });
   return {
     listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
 

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -39,6 +39,8 @@ export interface RemoteHostBackendDeps {
   captureTerminalScreen: (sessionId: string) => Promise<SessionScreen>;
   // Type into a session's live PTY (#445); false when none is attached here.
   writeToSession: (sessionId: string, chunk: string) => boolean;
+  // Whether typing may empty that session's input box first (#572).
+  canClearBox: (sessionId: string) => boolean;
 }
 
 export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
@@ -63,6 +65,7 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
       listTerminalSessions: deps.listTerminalSessions,
       captureTerminalScreen: deps.captureTerminalScreen,
       writeToSession: deps.writeToSession,
+      canClearBox: deps.canClearBox,
     }),
     log: {
       info: (msg) => console.log(PREFIX, msg),

--- a/server/backends/remoteHost/terminalInput.spec.ts
+++ b/server/backends/remoteHost/terminalInput.spec.ts
@@ -172,10 +172,16 @@ describe("sendTerminalInput", () => {
 // rule that decides is deliberately narrow — and narrow in a way that is easy to widen
 // by accident, which is what these lock down.
 describe("canClearInputBox", () => {
-  it("allows it for a Claude session that is not mid-turn", () => {
+  it("allows it for a Claude the host has seen finish a turn", () => {
     expect(canClearInputBox("claude", false)).toBe(true);
-    // No activity record yet (nothing has happened in this session) reads as idle.
-    expect(canClearInputBox("claude", undefined)).toBe(true);
+  });
+
+  // A missing activity record is "nobody has reported yet", NOT "idle". A session
+  // spawned with an initialPrompt runs its first turn before any hook fires, and
+  // setWorking(id, false) does not even create a record — so reading unknown as idle
+  // would interrupt that turn.
+  it("refuses when no activity has been reported for the session", () => {
+    expect(canClearInputBox("claude", undefined)).toBe(false);
   });
 
   // Ctrl-C mid-turn interrupts the turn. Whatever is in the box then is a QUEUED
@@ -191,9 +197,7 @@ describe("canClearInputBox", () => {
     expect(canClearInputBox("codex", undefined)).toBe(false);
   });
 
-  // At a prompt Ctrl-C is harmless; during a long build it kills the build, and the
-  // host cannot tell the two apart.
-  it("refuses for a shell", () => {
+  it("refuses for a shell even once it has reported idle", () => {
     expect(canClearInputBox("shell", false)).toBe(false);
   });
 

--- a/server/backends/remoteHost/terminalInput.spec.ts
+++ b/server/backends/remoteHost/terminalInput.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { PASTE_END, PASTE_START, createTerminalInputSender, sanitizeTerminalInput } from "./terminalInput.js";
+import { CLEAR_BOX, PASTE_END, PASTE_START, canClearInputBox, createTerminalInputSender, sanitizeTerminalInput } from "./terminalInput.js";
 
 // Collects what would have reached the PTY, and runs the delayed Enter on demand
 // so the tests never wait on real time.
@@ -13,7 +13,7 @@ const hasSequenceIntroducer = (text: string): boolean => text.includes("\u001B")
 // run before asserting on what reached the PTY.
 const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
-const recorder = (writable = true) => {
+const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean) => {
   const chunks: string[] = [];
   const submits: Array<() => void> = [];
   const deps = {
@@ -22,6 +22,7 @@ const recorder = (writable = true) => {
       chunks.push(chunk);
       return true;
     },
+    canClearBox,
     // Queue the Enters instead of timing them, so a test decides when each lands.
     scheduleSubmit: (fn: () => void) => {
       submits.push(fn);
@@ -164,5 +165,96 @@ describe("sendTerminalInput", () => {
     flushSubmit();
     await expect(after).resolves.toEqual({ sent: true });
     expect(chunks).toEqual([`${PASTE_START}ls${PASTE_END}`, "\r"]);
+  });
+});
+
+// Ctrl-C is destructive wherever the host cannot vouch for the session's state, so the
+// rule that decides is deliberately narrow — and narrow in a way that is easy to widen
+// by accident, which is what these lock down.
+describe("canClearInputBox", () => {
+  it("allows it for a Claude session that is not mid-turn", () => {
+    expect(canClearInputBox("claude", false)).toBe(true);
+    // No activity record yet (nothing has happened in this session) reads as idle.
+    expect(canClearInputBox("claude", undefined)).toBe(true);
+  });
+
+  // Ctrl-C mid-turn interrupts the turn. Whatever is in the box then is a QUEUED
+  // prompt, so the old merge behaviour is the lesser evil against discarding it.
+  it("refuses while Claude is mid-turn", () => {
+    expect(canClearInputBox("claude", true)).toBe(false);
+  });
+
+  // Nothing calls setWorking for codex, so `working` is false even mid-turn and the
+  // idle answer would be a guess — not a fact.
+  it("refuses for codex, whose turn state the host does not track", () => {
+    expect(canClearInputBox("codex", false)).toBe(false);
+    expect(canClearInputBox("codex", undefined)).toBe(false);
+  });
+
+  // At a prompt Ctrl-C is harmless; during a long build it kills the build, and the
+  // host cannot tell the two apart.
+  it("refuses for a shell", () => {
+    expect(canClearInputBox("shell", false)).toBe(false);
+  });
+
+  it("refuses when the host cannot say what is running", () => {
+    expect(canClearInputBox(null, false)).toBe(false);
+    expect(canClearInputBox(undefined, false)).toBe(false);
+  });
+});
+
+// #572: a draft left in the box on the host used to be submitted merged with the
+// phone's text ("yes I already typed this" + "ok" → "yes I already typedthisok").
+describe("clearing the host's input box", () => {
+  it("empties the box in the same write as the paste, so only the phone's text is left", async () => {
+    const { chunks, flushSubmit, send } = recorder(true, () => true);
+    const sent = send("s1", "ok");
+    await tick();
+    // ONE write: measured against a live TUI, the clear needs no delay of its own —
+    // unlike the Enter, which still follows separately.
+    expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}ok${PASTE_END}`]);
+    flushSubmit();
+    await expect(sent).resolves.toEqual({ sent: true });
+    expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}ok${PASTE_END}`, "\r"]);
+  });
+
+  // Ctrl-C mid-turn interrupts the turn, and in a shell it kills whatever is running,
+  // so the host withholds permission for everything it cannot vouch for.
+  it("leaves the box alone when the host says it is not safe", async () => {
+    const { chunks, send } = recorder(true, () => false);
+    void send("s1", "ok");
+    await tick();
+    expect(chunks).toEqual([`${PASTE_START}ok${PASTE_END}`]);
+  });
+
+  // The old callers pass no such dep at all; they must keep the old behaviour.
+  it("leaves the box alone when no host answer is wired at all", async () => {
+    const { chunks, send } = recorder();
+    void send("s1", "ok");
+    await tick();
+    expect(chunks[0]).not.toContain(CLEAR_BOX);
+  });
+
+  it("asks per session, not once for the host", async () => {
+    const asked: string[] = [];
+    const { chunks, send } = recorder(true, (sessionId) => {
+      asked.push(sessionId);
+      return sessionId === "idle-claude";
+    });
+    void send("idle-claude", "ok");
+    void send("busy-one", "ok");
+    await tick();
+    expect(asked).toEqual(["idle-claude", "busy-one"]);
+    expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}ok${PASTE_END}`, `${PASTE_START}ok${PASTE_END}`]);
+  });
+
+  // The clear is ours to send; the phone must never be able to smuggle its own in and
+  // wipe a draft on a session the host declined to clear.
+  it("sends exactly the one clear it decided on, whatever the phone typed", async () => {
+    const { chunks, send } = recorder(true, () => true);
+    void send("s1", `ok${CLEAR_BOX}and more`);
+    await tick();
+    expect(chunks[0].split(CLEAR_BOX)).toHaveLength(2);
+    expect(chunks[0].startsWith(CLEAR_BOX)).toBe(true);
   });
 });

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -13,6 +13,8 @@
 //   3. Send the submitting Enter as a SEPARATE write a beat later — Claude's TUI
 //      drops a CR that arrives while it is still committing the paste.
 
+import type { SessionAgent } from "./terminalScreen.js";
+
 // Strip ALL control bytes (C0/C1 — ESC, Ctrl-C, CR/LF, and an embedded
 // bracketed-paste terminator). Only printable text survives, whitespace collapsed.
 // eslint-disable-next-line no-control-regex -- intentional: match terminal control bytes (C0/C1) to strip them
@@ -23,6 +25,24 @@ export const sanitizeTerminalInput = (text: string): string => text.replace(CONT
 export const PASTE_START = "\x1b[200~";
 export const PASTE_END = "\x1b[201~";
 
+// An agent's input box keeps whatever the user typed on the host until they submit it,
+// so a paste lands AFTER that draft and the two are submitted merged — "yes I already
+// typed this" + "ok" arrives as "yes I already typedthisok" (#572). Ctrl-C empties the
+// box in one keystroke; Ctrl-U and Ctrl-A/Ctrl-K only clear the current VISUAL row and
+// leave a wrapped draft behind, and Esc does nothing to it. Measured against a live
+// Claude TUI, which also showed the clear can ride in the SAME write as the paste (no
+// extra delay) and is a no-op on an already-empty box.
+export const CLEAR_BOX = "\x03";
+
+// Who may have their box cleared. Ctrl-C is destructive everywhere the host cannot
+// vouch for the session's state — mid-turn it interrupts the turn, and in a shell it
+// kills whatever is running — so this says yes only for an IDLE CLAUDE.
+//
+// Codex is excluded despite its TUI clearing identically: nothing calls setWorking for
+// a codex session (only Claude's activity hooks do), so `working` never turns true there
+// and "idle" would be a guess. Include it once its turn state is tracked.
+export const canClearInputBox = (agent: SessionAgent | null | undefined, working: boolean | undefined): boolean => agent === "claude" && working !== true;
+
 // Matches DRAFT_SUBMIT_MS in server/index.ts: the same TUI, the same reason.
 export const SUBMIT_DELAY_MS = 150;
 
@@ -31,6 +51,11 @@ export interface TerminalInputDeps {
   // process — a tmux session that outlived a restart is viewable (capture-pane) but
   // not writable from here.
   writeToSession: (sessionId: string, chunk: string) => boolean;
+  // Whether the box can be emptied before pasting (see CLEAR_BOX). True only where the
+  // host KNOWS the session is idle, because Ctrl-C mid-turn interrupts the turn and in
+  // a shell it kills whatever is running. Omitted means no — the old behaviour of
+  // pasting on top of whatever is there.
+  canClearBox?: (sessionId: string) => boolean;
   // Injected so tests don't wait on real time.
   scheduleSubmit?: (submit: () => void) => void;
 }
@@ -41,7 +66,8 @@ const defaultSchedule = (submit: () => void): void => {
 
 // Paste, then press Enter a beat later, resolving once the Enter has gone out.
 const typeAndSubmit = (deps: TerminalInputDeps, sessionId: string, safe: string): Promise<void> => {
-  if (!deps.writeToSession(sessionId, `${PASTE_START}${safe}${PASTE_END}`)) {
+  const clear = deps.canClearBox?.(sessionId) ? CLEAR_BOX : "";
+  if (!deps.writeToSession(sessionId, `${clear}${PASTE_START}${safe}${PASTE_END}`)) {
     return Promise.reject(new Error(`session ${sessionId} has no live terminal on this host`));
   }
   return new Promise((resolve) => {

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -36,12 +36,19 @@ export const CLEAR_BOX = "\x03";
 
 // Who may have their box cleared. Ctrl-C is destructive everywhere the host cannot
 // vouch for the session's state — mid-turn it interrupts the turn, and in a shell it
-// kills whatever is running — so this says yes only for an IDLE CLAUDE.
+// kills whatever is running — so this says yes only for a Claude the host has SEEN
+// finish a turn.
+//
+// `working === false`, not `!== true`: a missing activity record means nobody has
+// reported on this session yet, which is emphatically not the same as idle. A session
+// spawned with an initialPrompt runs its first turn before any hook has fired
+// (spawn-claude.ts), and setWorking(id, false) doesn't even create a record — so
+// "unknown" covers a live turn, and reading it as idle would interrupt one.
 //
 // Codex is excluded despite its TUI clearing identically: nothing calls setWorking for
 // a codex session (only Claude's activity hooks do), so `working` never turns true there
 // and "idle" would be a guess. Include it once its turn state is tracked.
-export const canClearInputBox = (agent: SessionAgent | null | undefined, working: boolean | undefined): boolean => agent === "claude" && working !== true;
+export const canClearInputBox = (agent: SessionAgent | null | undefined, working: boolean | undefined): boolean => agent === "claude" && working === false;
 
 // Matches DRAFT_SUBMIT_MS in server/index.ts: the same TUI, the same reason.
 export const SUBMIT_DELAY_MS = 150;

--- a/server/index.ts
+++ b/server/index.ts
@@ -92,6 +92,7 @@ import { codexRolloutExists } from "./agents/codex-sessions.js";
 import { codexifySkillSeed } from "./agents/codex-skills.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
+import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
 import { isRecord, isTrivialPrompt, countUserTurnsFromJsonl, latestAssistantTextFromJsonl, preferredHeaderPrompt } from "./session/transcript.js";
 import { mountOpenDirRoute } from "./files/open-dir.js";
 import { mountGitRemoteRoute } from "./git/gitRemote.js";
@@ -1143,6 +1144,10 @@ const remoteHostWriteToSession = (sessionId: string, chunk: string): boolean => 
   }
 };
 
+// Whether the phone's typing may empty the input box before pasting, so only the
+// phone's text is submitted (#572). The rule itself lives with the sender.
+const remoteHostCanClearBox = (sessionId: string): boolean => canClearInputBox(ptys.get(sessionId)?.agent, activity.get(sessionId)?.working);
+
 const remoteHostCaptureTerminalScreen = (sessionId: string) =>
   captureSessionScreen(sessionId, {
     captureStyledPane: tmuxCaptureStyledPane,
@@ -1159,6 +1164,7 @@ initRemoteHostBackend({
   listTerminalSessions: remoteHostListTerminalSessions,
   captureTerminalScreen: remoteHostCaptureTerminalScreen,
   writeToSession: remoteHostWriteToSession,
+  canClearBox: remoteHostCanClearBox,
 });
 
 // Mount per-collection fs.watchers → completion bells via the notifier. After the


### PR DESCRIPTION
## Summary

ホストの入力欄に打ちかけの下書きが残っていると、スマホから送った文字が**その後ろに連結されて**送信されていました（区切りの空白すら入らない）。

| | 中身 |
|---|---|
| ホストの入力欄 | `yes I already typed this` |
| スマホの送信 | `ok` |
| 実際の送信（修正前） | `yes I already typedthisok` |

ペーストの前に **Ctrl-C** を送って入力欄を空にします。Closes #572。

## Items to Confirm / Review

1. **キー選定は推測ではなく実測です。** 本物の Claude TUI に各キーを送って確認しました:

   | キー | 結果 |
   |---|---|
   | Ctrl-U | 表示 1 行分のみ。折り返した下書きは残る |
   | Ctrl-U 繰り返し | 行頭で止まり、行をまたげない |
   | Ctrl-A → Ctrl-K | 同じく行単位 |
   | Esc | 消えない |
   | **Ctrl-C** | **1 打で全体が消える** |

   同じ実測で「**クリアはペーストと同じ 1 回の書き込みに載せられる**」「**空の入力欄では no-op**」も確認済みなので、遅延の追加はありません（別書き込みで 150ms 後の Enter は従来どおり）。

2. **適用範囲がこの PR の肝です。** Ctrl-C は安全な操作ではありません — 実行中のターンは中断され、shell なら実行中のコマンドを殺します。そのため「ホストがアイドルだと**事実として**分かっている場合」に限定しました:
   - **アイドルの Claude のみ**
   - **ターン実行中の Claude は対象外** → 従来どおり連結になりますが、実行中に入力欄にあるのは「キューされたプロンプト」で、黙って捨てる方が危険だと判断しました
   - **codex は対象外** — TUI での挙動は同一だと実測済みですが、`setWorking` を呼ぶのは Claude の activity hook だけで codex の working 状態は追跡されていません。追跡がない以上「アイドル」は事実ではなく推測になります。追跡が入れば `canClearInputBox` を 1 行広げるだけで対応できます
   - **shell は対象外** — プロンプトに居るのか長時間コマンド実行中なのか判別できません

3. **判定ルールは純粋関数 `canClearInputBox(agent, working)` に切り出してあります**（`server/index.ts` に埋めると起動しないとテストできないため）。「うっかり広げてしまう」形の変更に対するテストを付けています

4. **エンドツーエンド確認済み** — 実際の `createTerminalInputSender` を本物の Claude セッションに向けて動かし、折り返した古い下書きが送った文字だけに置き換わることを確認しました（Enter は発火させていないので送信はしていません）

## User Prompt

> 1 ってなに？

> 1 はスマホから送るなら、スマホの文字だけでサーバに送ってほしい。できる？

> 1 ok

## Implementation

- `terminalInput.ts`: `CLEAR_BOX = "\x03"` と純粋関数 `canClearInputBox`、および任意 dep `canClearBox`。省略時は false ＝従来の挙動なので、既存の呼び出しは影響を受けません
- `server/index.ts`: `canClearInputBox(ptys.get(id)?.agent, activity.get(id)?.working)` を配線
- `handlers.ts` / `remoteHost/index.ts`: dep の受け渡し

Plan: `plans/fix-572-clear-host-box.md`

## Tests

`yarn lint` 0 errors · `yarn build` · `yarn typecheck:server` · `yarn typecheck:test` · `yarn test` **1794 pass**

新規 11 ケース。ミューテーションテストで全部レッドになることを確認済み: クリアを常に外す / 許可を無視して常にクリア / codex も許可 / working チェックを落とす。

🤖 Generated with [Claude Code](https://claude.com/claude-code)