### PR TITLE
feat(session): ディレクトリ単位でモデル／Anthropic 互換バックエンドを選ぶ (#579)

### DIFF
--- a/plans/feat-579-model-and-provider.md
+++ b/plans/feat-579-model-and-provider.md
@@ -1,0 +1,96 @@
+# feat #579 — モデル指定と Anthropic 互換プロバイダでのセッション起動
+
+## スコープ（この PR）
+
+セッションを **ディレクトリ単位で** 別モデル・別プロバイダに向けられるようにする。設定は既存の
+`.mulmoterminal.json`（per-dir）＋グローバル config で完結し、**新しい UI は作らない**。
+
+UI（起動フォームでのプロバイダ/モデル選択）は後続 PR。
+
+## なぜ per-dir 設定か
+
+`spawnClaudePty` は既に引数 7 個で lint の上限（6）を超えている。引数を増やすのではなく、
+**すでに渡っている `cwd` から `loadDirConfig(cwd)` で引く**。per-dir の色・テーマ・スキルと
+同じ仕組みに乗るだけで済み、新しい配線が要らない。
+
+## 設定の形
+
+```jsonc
+// ~/.mulmoterminal/config.json — 鍵の実体は書かない
+{
+  "providers": [{
+    "id": "openrouter",
+    "label": "OpenRouter",
+    "baseUrl": "https://openrouter.ai/api",   // CC が /v1/messages を付けるので付けない
+    "tokenEnv": "OPENROUTER_API_KEY",          // 名前だけ。実体はサーバの env / .env
+    "maxOutputTokens": 16000                   // 省略時 16000（thinking モデル対策）
+  }]
+}
+```
+
+```jsonc
+// <dir>/.mulmoterminal.json
+{ "provider": "openrouter", "model": "z-ai/glm-5.2" }
+```
+
+`provider` を省いて `model` だけなら、Anthropic 本家のまま `--model` を渡す。
+
+## 実装
+
+### 1. `server/session/provider-env.ts`（新規・純粋関数）
+
+この機能の判断を全部ここに集める。起動しないとテストできない場所にロジックを置かない。
+
+```ts
+export interface ProviderResolution {
+  model: string | null;          // --model に渡す値
+  env: Record<string, string>;   // settings の env ブロックに載せる
+  unset: string[];               // 子プロセスの env から取り除く名前
+}
+export type ProviderResult =
+  | { ok: true; value: ProviderResolution }
+  | { ok: false; reason: string };
+```
+
+規則（すべて #579 の実測に基づく）:
+
+- **`baseUrl` とトークンは常にペア**。`tokenEnv` が解決できなければ `ok: false` で**起動を拒否**する。
+  黙って fallback すると、認証優先順位の最下位まで落ちて**サブスク認証情報が第三者に送信される**
+- `ANTHROPIC_SMALL_FAST_MODEL` を必ず同じモデルで埋める（未設定だと背景の haiku 呼び出しが 400）
+- `CLAUDE_CODE_MAX_OUTPUT_TOKENS` を既定 16000（小さいと thinking モデルが本文を返さない）
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`（リダイレクト中に本家 API を叩かせない）
+- `unset` に `ANTHROPIC_API_KEY`（`env` ブロックでは消せないため、経路ごとに実際に取り除く）
+
+### 2. `server/config/config-schema.ts`
+
+`providerSchema` と、per-dir の `provider` / `model` フィールド（lenient parser、既存の
+`dirThemeField` 等と同じ書き方）。
+
+### 3. `server/agents/claude-args.ts`
+
+`model?: string` を受けて `--model` を足す。既存のテスト済み純粋関数。
+
+### 4. `--settings` をインライン JSON → 一時ファイル（0600）
+
+鍵を argv に載せないため。`--settings` はファイルパスも受ける。ファイルには hooks に加えて
+`env` ブロックを載せる。**`env` は Claude Code 自身が適用するので、tmux の環境変数伝播にも
+docker の `-e` にも依存しない**（#579 の実測参照）。セッション終了時に削除。
+
+### 5. tmux: `ANTHROPIC_API_KEY` をサーバのグローバル環境から除外
+
+実測で「pane は tmux サーバのグローバル環境を継ぐ」ことが分かっているため、既存の
+`scrubGlobalEnvironment()`（launcher 変数に対して `set-environment -r` を使う）に 1 つ足す。
+
+### 6. sandbox は当面プロバイダ非対応 → **明示的に拒否**
+
+BASE_URL のループバック書き換えと settings ファイルの bind-mount が要るため、この PR では
+sandbox × プロバイダの組み合わせを `ok: false` で弾く。黙って本家に流れる方が危険。
+
+## テスト
+
+- `provider-env.ts`: トークン欠落で拒否、`SMALL_FAST_MODEL` の補完、`maxOutputTokens` 既定値、
+  `unset` に `ANTHROPIC_API_KEY` が入ること、provider なし + model だけ、設定なし（何もしない）
+- `claude-args.ts`: `--model` の有無
+- 設定スキーマ: 不正な provider 参照、baseUrl 末尾の `/v1` を弾く（CC が付けるため）
+
+各テストは「壊したら赤くなる」ことをミューテーションで確認する。

--- a/server/agents/claude-args.ts
+++ b/server/agents/claude-args.ts
@@ -17,10 +17,15 @@ export interface ClaudeArgsInput {
   attachGuiMcp: boolean;
   mcpConfig: string; // GUI MCP config JSON (--mcp-config), used only when attachGuiMcp
   guiMcpTools: string; // comma-joined GUI tool names (--allowedTools), used only when attachGuiMcp
+  // What this session runs (#579): an alias (sonnet/opus/haiku) or a backend's own model
+  // name. Null leaves the choice to Claude Code. `--model` outranks both the settings
+  // `model` key and ANTHROPIC_MODEL, so it is the one place the decision has to be made.
+  model?: string | null;
 }
 
 export function buildClaudeArgs(input: ClaudeArgsInput): string[] {
   const guiArgs = ["--permission-mode", input.permissionMode];
+  if (input.model) guiArgs.push("--model", input.model);
   if (input.attachGuiMcp) {
     guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config", "--allowedTools", input.guiMcpTools);
   }

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -6,7 +6,17 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets } from "./cwd-presets.js";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
-import { launcherSchema, userMcpServerSchema, type CwdPreset, type Launcher, type UserMcpServer, type HeaderButton, type HeaderChip } from "./config-schema.js";
+import {
+  launcherSchema,
+  userMcpServerSchema,
+  providerSchema,
+  type CwdPreset,
+  type Provider,
+  type Launcher,
+  type UserMcpServer,
+  type HeaderButton,
+  type HeaderChip,
+} from "./config-schema.js";
 
 export interface AppConfig {
   cwdPresets: CwdPreset[];
@@ -32,6 +42,9 @@ export interface AppConfig {
   // session on each run, so it costs tokens). `worklogIntervalHours` is the cadence.
   worklogEnabled: boolean;
   worklogIntervalHours: number;
+  // Anthropic-compatible backends a directory can point its sessions at (#579). Safe to
+  // serve: an entry names the env var holding its key (`tokenEnv`), never the key.
+  providers: Provider[];
 }
 
 // `id` becomes an MCP server name + `mcp__<id>` tool prefix, so restrict to a plain
@@ -137,7 +150,19 @@ const emptyConfig = (): AppConfig => ({
   pushEnabled: false,
   worklogEnabled: false,
   worklogIntervalHours: DEFAULT_WORKLOG_INTERVAL_HOURS,
+  providers: [],
 });
+
+// Drop malformed entries rather than rejecting the whole config: one bad provider must
+// not cost the user their launchers and presets. A bad entry surfaces at spawn time,
+// where resolveProvider names the actual problem.
+export function sanitizeProviders(input: unknown): Provider[] {
+  if (!Array.isArray(input)) return [];
+  return input.flatMap((entry) => {
+    const parsed = providerSchema.safeParse(entry);
+    return parsed.success ? [parsed.data] : [];
+  });
+}
 
 export function loadAppConfig(file: string): AppConfig {
   try {
@@ -154,6 +179,7 @@ export function loadAppConfig(file: string): AppConfig {
       pushEnabled: sanitizePushEnabled(raw?.pushEnabled),
       worklogEnabled: sanitizeWorklogEnabled(raw?.worklogEnabled),
       worklogIntervalHours: sanitizeWorklogIntervalHours(raw?.worklogIntervalHours),
+      providers: sanitizeProviders(raw?.providers),
     };
   } catch {
     return emptyConfig();
@@ -177,6 +203,7 @@ export function mergeConfigUpdate(base: AppConfig, body: Record<string, unknown>
     pushEnabled: body.pushEnabled !== undefined ? sanitizePushEnabled(body.pushEnabled) : base.pushEnabled,
     worklogEnabled: body.worklogEnabled !== undefined ? sanitizeWorklogEnabled(body.worklogEnabled) : base.worklogEnabled,
     worklogIntervalHours: body.worklogIntervalHours !== undefined ? sanitizeWorklogIntervalHours(body.worklogIntervalHours) : base.worklogIntervalHours,
+    providers: body.providers !== undefined ? sanitizeProviders(body.providers) : base.providers,
   };
 }
 
@@ -186,6 +213,7 @@ export function mergeConfigUpdate(base: AppConfig, body: Record<string, unknown>
 export function toPublicAppConfig(config: AppConfig): AppConfig {
   return {
     cwdPresets: config.cwdPresets,
+    providers: config.providers,
     soundFile: config.soundFile,
     prRepos: config.prRepos,
     launchers: config.launchers,

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -9,7 +9,7 @@ import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
 import { loadAppConfig, saveAppConfig, mergeConfigUpdate, toPublicAppConfig, type AppConfig } from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
-import { type Launcher, type UserMcpServer } from "./config-schema.js";
+import { type Launcher, type Provider, type UserMcpServer } from "./config-schema.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -30,6 +30,12 @@ export function getLaunchers(): Launcher[] {
 // Claude spawn without a restart.
 export function getUserMcpServers(): UserMcpServer[] {
   return config.userMcpServers;
+}
+
+// The configured Anthropic-compatible backends, read live so a config edit applies to the
+// next session without a restart (#579).
+export function getProviders(): Provider[] {
+  return config.providers;
 }
 
 // The global terminal-header buttons/chips — read live so /api/header reflects a config

--- a/server/config/config-schema.ts
+++ b/server/config/config-schema.ts
@@ -134,6 +134,25 @@ export const dirColorsField = z
   .nullable()
   .catch(null);
 
+// An Anthropic-compatible backend a directory can point its sessions at (#579). The key
+// itself is never stored here — `tokenEnv` names the env var the SERVER reads it from,
+// because this config is served over HTTP to the browser and the phone.
+export const providerSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  // No trailing /v1: Claude Code appends /v1/messages itself.
+  baseUrl: z.string().min(1),
+  tokenEnv: z.string().min(1),
+  maxOutputTokens: z.number().int().positive().optional(),
+});
+export type Provider = z.infer<typeof providerSchema>;
+
+// Which provider/model a directory's sessions run on. Both lenient: a typo must not stop
+// the directory's other settings from loading — resolveProvider reports the real problem
+// at spawn time, where the user sees it.
+export const dirProviderField = z.string().trim().min(1).nullable().catch(null);
+export const dirModelField = z.string().trim().min(1).nullable().catch(null);
+
 // A per-dir allowlist for the header Skill menu: which skill slugs to show, in this
 // order. Trimmed, deduped, capped. null when unset/garbage/empty — which means
 // "no filter, show every discovered skill" (absent config == show all).

--- a/server/config/dir-config.ts
+++ b/server/config/dir-config.ts
@@ -14,6 +14,8 @@ import {
   dirThemeField,
   dirColorsField,
   dirSkillsField,
+  dirProviderField,
+  dirModelField,
   type ThemeId,
   type HeaderButton,
   type HeaderChip,
@@ -36,6 +38,9 @@ export interface DirConfig extends DirChrome {
   // Header Skill-menu allowlist: show only these skill slugs, in this order. null =
   // this dir doesn't filter, so the menu shows every discovered skill.
   skills: string[] | null;
+  // Which backend/model this directory's sessions run on (#579). Never a secret.
+  provider: string | null;
+  model: string | null;
 }
 
 // What the browser receives: the raw sound path stays server-side (streamed via
@@ -107,6 +112,8 @@ const EMPTY: DirConfig = {
   buttons: null,
   chips: null,
   skills: null,
+  provider: null,
+  model: null,
 };
 
 export function loadDirConfig(cwd: string): DirConfig {
@@ -131,6 +138,8 @@ export function loadDirConfig(cwd: string): DirConfig {
       buttons: sanitizeButtons(raw.buttons),
       chips: sanitizeChips(raw.chips),
       skills: dirSkillsField.parse(raw.skills),
+      provider: dirProviderField.parse(raw.provider),
+      model: dirModelField.parse(raw.model),
     };
   } catch {
     return EMPTY;

--- a/server/index.ts
+++ b/server/index.ts
@@ -71,6 +71,7 @@ import { codexSessionsRoot } from "./agents/codex-session.js";
 import { codexRolloutExists } from "./agents/codex-sessions.js";
 import { codexifySkillSeed } from "./agents/codex-skills.js";
 import { renderScreen } from "./session/headlessScreen.js";
+import { cleanupSessionSettings } from "./session/session-settings.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
 import { isRecord, latestAssistantTextFromJsonl, preferredHeaderPrompt } from "./session/transcript.js";
@@ -329,6 +330,8 @@ function reap(id: string) {
   // A sandbox container likewise outlives its killed `docker run` client — force-remove
   // it (and drop the throwaway per-session config).
   if (entry.sandbox) cleanupSandbox(id);
+  // A provider session's settings file holds its token — drop it with the session (#579).
+  cleanupSessionSettings(id);
   pubsub?.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed" });
 }
 
@@ -413,7 +416,7 @@ function setWaiting(id: string, waiting: boolean, event?: string) {
 // per-session tool-call history that the GUI's tools pane shows. A failed tool
 // fires PostToolUseFailure (NOT PostToolUse), so we register both to complete the
 // entry either way — otherwise a failed call would stay stuck on "running".
-function hookSettingsJson(host: string, sessionId: string) {
+function hookSettingsJson(host: string, sessionId: string, env: Record<string, string> = {}) {
   // Tag every hook with mulmoterminal's STABLE session id via a header. Claude reissues its own session_id
   // on /clear and /compact, but the PTY — and the id the client tracks — stays this one, so attributing
   // hooks by this header keeps activity / header prompt / tool history correlated across a clear.
@@ -421,7 +424,11 @@ function hookSettingsJson(host: string, sessionId: string) {
   const entry = [{ hooks: [{ type: "command", command: cmd }] }];
   // Tool hooks take a matcher; "" matches all tools.
   const toolEntry = [{ matcher: "", hooks: [{ type: "command", command: cmd }] }];
+  // `env` aims a provider session at its backend (#579). Claude Code applies this block
+  // itself, so it lands identically on the host, under tmux — where a pane inherits the
+  // tmux SERVER's environment, not ours — and in a container.
   return JSON.stringify({
+    ...(Object.keys(env).length ? { env } : {}),
     hooks: {
       UserPromptSubmit: entry,
       Stop: entry,

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -114,11 +114,17 @@ export function parseTmuxEnvironment(stdout: string): Map<string, string> {
 //
 // Session environments need no scrub either: tmux copies only `update-environment`
 // vars (DISPLAY, SSH_*, …) into them, never launcher vars.
+// Beyond the launcher vars: a session pointed at an Anthropic-compatible backend must not
+// see ANTHROPIC_API_KEY, which silently outranks the auth token that aims it there. The
+// settings `env` block cannot express a REMOVAL, and a pane inherits the tmux server's
+// environment rather than ours, so this is where it has to be taken out (#579).
+const SCRUBBED_NAMES = new Set(["ANTHROPIC_API_KEY"]);
+
 function scrubGlobalEnvironment(): void {
   const r = tmux(["show-environment", "-g"]);
   if (r.status !== 0) return;
   for (const name of parseTmuxEnvironment(r.stdout).keys()) {
-    if (isLauncherEnvVar(name)) tmux(["set-environment", "-g", "-r", name]);
+    if (isLauncherEnvVar(name) || SCRUBBED_NAMES.has(name)) tmux(["set-environment", "-g", "-r", name]);
   }
 }
 

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -128,6 +128,20 @@ function scrubGlobalEnvironment(): void {
   }
 }
 
+// Flag names for removal from the RUNNING tmux server's global environment, so panes
+// created from here on don't inherit them.
+//
+// ensureConf's scrub is not enough on its own: it only runs when a server already existed
+// when this process started. A server that a LATER spawn creates inherits that spawn's
+// environment instead — measured — so a first non-provider session can seed the server
+// with ANTHROPIC_API_KEY and every provider pane after it would inherit the key that
+// silently outranks its auth token (#579). Called before a provider spawn; a no-op (and
+// harmless failure) when no server is running yet, where the fresh server inherits the
+// already-stripped environment.
+export function tmuxScrubEnvNames(names: readonly string[]): void {
+  for (const name of names) tmux(["set-environment", "-g", "-r", name]);
+}
+
 function ensureConf(): void {
   try {
     mkdirSync(path.dirname(CONF_FILE), { recursive: true });

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -24,6 +24,7 @@ import { codexRolloutIds, markDevTerminalSession, ptys } from "../session/regist
 import { sandboxWouldRun } from "../session/pty-spawn.js";
 import { handleCommandFrame } from "../session/pty-connection.js";
 import { closeWithError } from "../session/ws-frames.js";
+import { ProviderRefusedError } from "../session/provider-env.js";
 import { sessionExistsOnDisk } from "../session/session-reads.js";
 import { canStartLauncher, resolveReattachableId, resolveSession, type SessionResolution } from "../session/session-resolve.js";
 import type { PtyEntry } from "../session/types.js";
@@ -257,6 +258,9 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: { u
     // A failed spawn (claude missing, or node-pty's spawn-helper not executable)
     // must close just this connection — never crash the whole server.
     console.error(`[ws] failed to start session ${sessionId}: ${messageOf(err)}`);
+    // A provider refusal already says exactly what is wrong with the directory's config
+    // (#579); the generic hint below would bury it.
+    if (err instanceof ProviderRefusedError) return closeWithError(ws, err.message);
     closeWithError(ws, "Failed to start Claude. Is the `claude` CLI installed and on your PATH?");
     return;
   }

--- a/server/session/provider-env.ts
+++ b/server/session/provider-env.ts
@@ -1,0 +1,104 @@
+// Which model a session runs, and — when a directory points at an Anthropic-compatible
+// third party (OpenRouter, Moonshot, a LiteLLM gateway) — the environment that aims
+// Claude Code there (#579).
+//
+// Every rule here was measured against a working setup, not inferred from the docs:
+//
+//   - The token is NOT optional. Claude Code's auth precedence puts ANTHROPIC_AUTH_TOKEN
+//     above the subscription OAuth credential, but a base URL with NO token falls all the
+//     way through to that credential — and sends it to the third party. So a provider
+//     whose token cannot be resolved must REFUSE to launch, never quietly fall back.
+//   - ANTHROPIC_SMALL_FAST_MODEL has to be set too. Claude Code makes background "haiku"
+//     calls (title generation and friends); against a backend with no haiku they 400.
+//   - Thinking models need output headroom. Starved of it they spend the whole budget
+//     thinking and return empty visible text, which reads as a hung session.
+//   - ANTHROPIC_API_KEY must be UNSET, not empty — a leftover value silently outranks the
+//     auth token. It cannot be expressed here as a value, hence `unset`.
+
+export interface ProviderConfig {
+  id: string;
+  label: string;
+  // What Claude Code hits. WITHOUT a trailing /v1: the CLI appends /v1/messages itself.
+  baseUrl: string;
+  // The NAME of the env var holding the key, never the key. The value is read from the
+  // server's own environment, so no secret is stored in a config file the app serves.
+  tokenEnv: string;
+  maxOutputTokens?: number;
+}
+
+export interface DirModelChoice {
+  provider: string | null;
+  model: string | null;
+}
+
+export interface ProviderResolution {
+  // Passed as `claude --model`, which outranks both the settings `model` and
+  // ANTHROPIC_MODEL. Null when the directory names no model.
+  model: string | null;
+  // Goes in the settings file's `env` block, which Claude Code applies itself — so it
+  // reaches the session identically on the host, under tmux, and in a container.
+  env: Record<string, string>;
+  // Names to remove from the spawned process's environment (see ANTHROPIC_API_KEY above).
+  unset: string[];
+}
+
+export type ProviderResult = { ok: true; value: ProviderResolution } | { ok: false; reason: string };
+
+// Enough room for a thinking model to think AND answer. Below this the visible text
+// comes back empty.
+export const DEFAULT_MAX_OUTPUT_TOKENS = 16000;
+
+// Claude Code appends /v1/messages, so a base URL that already ends in /v1 produces
+// /v1/v1/messages and 404s. Caught here rather than at request time, where it surfaces
+// as an unexplained failure inside the session.
+export const isUsableBaseUrl = (baseUrl: string): boolean => /^https?:\/\/\S+$/.test(baseUrl) && !/\/v1\/?$/.test(baseUrl);
+
+const NOTHING: ProviderResolution = { model: null, env: {}, unset: [] };
+
+const providerEnv = (provider: ProviderConfig, model: string, token: string): Record<string, string> => ({
+  ANTHROPIC_BASE_URL: provider.baseUrl,
+  ANTHROPIC_AUTH_TOKEN: token,
+  ANTHROPIC_MODEL: model,
+  // The background "haiku" calls go to the same model — the backend has no haiku.
+  ANTHROPIC_SMALL_FAST_MODEL: model,
+  CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(provider.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS),
+  // A redirected session must not keep calling the real Anthropic API in the background.
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+});
+
+// What a session in this directory should run, or why it must not start.
+//
+// `sandbox` refuses the combination outright: the container inherits no environment and
+// cannot reach a loopback gateway, so a sandboxed provider session would silently run
+// against Anthropic instead of where the directory asked for.
+export function resolveProvider(
+  choice: DirModelChoice,
+  providers: readonly ProviderConfig[],
+  env: NodeJS.ProcessEnv,
+  sandbox: boolean = false,
+): ProviderResult {
+  if (!choice.provider) {
+    // No provider named: stay on Anthropic, honour a bare model choice.
+    return { ok: true, value: { ...NOTHING, model: choice.model } };
+  }
+  const provider = providers.find((candidate) => candidate.id === choice.provider);
+  if (!provider) return { ok: false, reason: `unknown provider '${choice.provider}' — add it to config.json under "providers"` };
+  if (sandbox) return { ok: false, reason: `provider '${provider.id}' cannot run in the Docker sandbox yet` };
+  if (!isUsableBaseUrl(provider.baseUrl)) {
+    return { ok: false, reason: `provider '${provider.id}' has an unusable baseUrl '${provider.baseUrl}' — an http(s) URL without a trailing /v1` };
+  }
+  if (!choice.model) return { ok: false, reason: `provider '${provider.id}' needs a model — set "model" in .mulmoterminal.json` };
+  const token = env[provider.tokenEnv];
+  if (!token) {
+    return { ok: false, reason: `provider '${provider.id}' needs ${provider.tokenEnv} in the server's environment — refusing to start` };
+  }
+  return { ok: true, value: { model: choice.model, env: providerEnv(provider, choice.model, token), unset: ["ANTHROPIC_API_KEY"] } };
+}
+
+// Apply a resolution's `unset` to an environment copy. The settings `env` block can set
+// a variable but not remove one, so removal has to happen on the process environment.
+export function withoutUnset(env: NodeJS.ProcessEnv, unset: readonly string[]): NodeJS.ProcessEnv {
+  if (unset.length === 0) return env;
+  const removed = new Set(unset);
+  return Object.fromEntries(Object.entries(env).filter(([name]) => !removed.has(name)));
+}

--- a/server/session/provider-env.ts
+++ b/server/session/provider-env.ts
@@ -95,6 +95,23 @@ export function resolveProvider(
   return { ok: true, value: { model: choice.model, env: providerEnv(provider, choice.model, token), unset: ["ANTHROPIC_API_KEY"] } };
 }
 
+// A directory asked for a backend that cannot be honoured. Thrown rather than downgraded:
+// staying on Anthropic would send the session's prompts to a backend the directory did
+// NOT select, which is the failure this whole module exists to prevent.
+export class ProviderRefusedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "ProviderRefusedError";
+  }
+}
+
+// The resolution, or a throw. Callers get no third option — a `{ ok: false }` that a
+// caller can quietly ignore is how the contract above gets lost.
+export function requireResolution(result: ProviderResult): ProviderResolution {
+  if (!result.ok) throw new ProviderRefusedError(result.reason);
+  return result.value;
+}
+
 // Apply a resolution's `unset` to an environment copy. The settings `env` block can set
 // a variable but not remove one, so removal has to happen on the process environment.
 export function withoutUnset(env: NodeJS.ProcessEnv, unset: readonly string[]): NodeJS.ProcessEnv {

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -7,6 +7,7 @@ import type { IPty } from "node-pty";
 import path from "node:path";
 import type { WebSocket } from "ws";
 import { sanitizePtyEnv } from "../infra/pty-env.js";
+import { withoutUnset } from "./provider-env.js";
 import { tmuxAvailable, tmuxNewSessionArgs } from "../infra/tmux.js";
 import {
   sandboxEnabled,
@@ -27,8 +28,12 @@ const PTY_ROWS = 30;
 // so the tmux/shell/claude spawns aren't flagged as spawn-of-a-string-literal.
 // The env is sanitized: package-manager launcher vars (yarn's PREFIX kills nvm
 // in spawned shells — see infra/pty-env.ts) must not leak into PTYs.
-export function spawnPty(bin: string, args: string[], cwd: string): IPty {
-  return pty.spawn(bin, args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env: sanitizePtyEnv(process.env, path.delimiter) });
+// `unset` drops variables the session must NOT inherit — ANTHROPIC_API_KEY for a provider
+// session, which would silently outrank its auth token (#579). It cannot be expressed in
+// the settings `env` block, which can set a variable but not remove one.
+export function spawnPty(bin: string, args: string[], cwd: string, unset: readonly string[] = []): IPty {
+  const env = withoutUnset(sanitizePtyEnv(process.env, path.delimiter), unset);
+  return pty.spawn(bin, args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env });
 }
 
 // Would this session run in the Docker sandbox? Single-view interactive only (the caller
@@ -41,11 +46,18 @@ export function sandboxWouldRun(attachGuiMcp: boolean): boolean {
 // Spawn a terminal, wrapping it in a persistent tmux session when tmux is available and
 // `persistent` is set, so it survives the server dying. `tmux new-session -A` creates it
 // (running file+args) or reattaches the surviving one. Returns whether tmux backs it.
-export function ptySpawn(sessionId: string, file: string, args: string[], cwd: string, persistent: boolean): { term: IPty; tmux: boolean } {
+export function ptySpawn(
+  sessionId: string,
+  file: string,
+  args: string[],
+  cwd: string,
+  persistent: boolean,
+  unset: readonly string[] = [],
+): { term: IPty; tmux: boolean } {
   if (persistent && tmuxAvailable()) {
-    return { term: spawnPty("tmux", tmuxNewSessionArgs(sessionId, file, args, cwd), cwd), tmux: true };
+    return { term: spawnPty("tmux", tmuxNewSessionArgs(sessionId, file, args, cwd), cwd, unset), tmux: true };
   }
-  return { term: spawnPty(file, args, cwd), tmux: false };
+  return { term: spawnPty(file, args, cwd, unset), tmux: false };
 }
 
 // Spawn the single-view session inside a Docker container (the sandbox path). Exports the

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 import type { WebSocket } from "ws";
 import { sanitizePtyEnv } from "../infra/pty-env.js";
 import { withoutUnset } from "./provider-env.js";
-import { tmuxAvailable, tmuxNewSessionArgs } from "../infra/tmux.js";
+import { tmuxAvailable, tmuxNewSessionArgs, tmuxScrubEnvNames } from "../infra/tmux.js";
 import {
   sandboxEnabled,
   sandboxPlatformSupported,
@@ -55,6 +55,9 @@ export function ptySpawn(
   unset: readonly string[] = [],
 ): { term: IPty; tmux: boolean } {
   if (persistent && tmuxAvailable()) {
+    // A pane inherits the tmux SERVER's environment, so stripping our own copy is not
+    // enough — the server may already carry the name from an earlier session.
+    if (unset.length > 0) tmuxScrubEnvNames(unset);
     return { term: spawnPty("tmux", tmuxNewSessionArgs(sessionId, file, args, cwd), cwd, unset), tmux: true };
   }
   return { term: spawnPty(file, args, cwd, unset), tmux: false };

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -1,0 +1,33 @@
+// Claude Code's per-session `--settings`, written to a file when it carries secrets.
+//
+// `--settings` accepts a path OR an inline JSON string, and every session until now
+// passed it inline. That is fine for hooks, but a provider session's settings carry an
+// API token in their `env` block — and an inline argument is visible to every user on
+// the host through `ps`. So a settings payload with an env block goes to a 0600 file and
+// only its PATH reaches argv (#579).
+//
+// The env block is the transport for a reason: Claude Code applies it itself, so it
+// reaches the session identically on the host, under tmux — where a pane inherits the
+// tmux SERVER's environment, not the spawning client's — and inside a container.
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+const SETTINGS_DIR = path.join(os.homedir(), ".mulmoterminal", "settings");
+
+const settingsFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}.json`);
+
+// The settings to pass as `--settings`: the JSON itself when it holds nothing secret,
+// otherwise the path to a private file holding it.
+export function settingsArgument(sessionId: string, json: string, secret: boolean): string {
+  if (!secret) return json;
+  const file = settingsFile(sessionId);
+  mkdirSync(SETTINGS_DIR, { recursive: true, mode: 0o700 });
+  writeFileSync(file, json, { encoding: "utf8", mode: 0o600 });
+  return file;
+}
+
+// Drop a session's settings file. Safe to call for sessions that never wrote one.
+export function cleanupSessionSettings(sessionId: string): void {
+  rmSync(settingsFile(sessionId), { force: true });
+}

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -27,6 +27,18 @@ export function settingsArgument(sessionId: string, json: string, secret: boolea
   return file;
 }
 
+// Run a spawn, taking the session's settings file with it if the spawn throws. A session
+// that never starts never reaches reap(), where the cleanup normally happens — so without
+// this a failed spawn leaves a token-bearing file behind (#579).
+export function withSettingsCleanup<T>(sessionId: string, spawn: () => T): T {
+  try {
+    return spawn();
+  } catch (err) {
+    cleanupSessionSettings(sessionId);
+    throw err;
+  }
+}
+
 // Drop a session's settings file. Safe to call for sessions that never wrote one.
 export function cleanupSessionSettings(sessionId: string): void {
   rmSync(settingsFile(sessionId), { force: true });

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -14,6 +14,10 @@ import { appendBoundedOutput } from "./terminal-replay.js";
 import { sessionExistsOnDisk } from "./session-reads.js";
 import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
+import { loadDirConfig } from "../config/dir-config.js";
+import { getProviders } from "../config/config-routes.js";
+import { resolveProvider } from "./provider-env.js";
+import { settingsArgument } from "./session-settings.js";
 
 export function createClaudeSpawner(deps: SpawnDeps) {
   // Spawn a fresh claude PTY for this session, register it, and wire its output /
@@ -44,12 +48,25 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     // Falls back to the host spawn if the Docker daemon isn't reachable.
     const sandbox = sandboxWouldRun(attachGuiMcp) && ws !== null;
     const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
+
+    // What this directory asked its sessions to run (#579). A refusal is NOT applied —
+    // the session stays on Anthropic, which is the safe outcome — but it is logged loudly,
+    // because silently ignoring the directory's choice is its own kind of surprise.
+    const dir = loadDirConfig(cwd);
+    const choice = resolveProvider({ provider: dir.provider, model: dir.model }, getProviders(), process.env, sandbox);
+    if (!choice.ok) console.warn(`[provider] ${cwd}: ${choice.reason} — staying on Anthropic`);
+    const resolved = choice.ok ? choice.value : { model: null, env: {}, unset: [] };
+
+    const hookSettings = deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, resolved.env);
     const args = buildClaudeArgs({
+      model: resolved.model,
       sessionId,
       resume,
       canResume,
-      // In the sandbox the hooks + GUI MCP are reached over host.docker.internal.
-      settings: deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId),
+      // In the sandbox the hooks + GUI MCP are reached over host.docker.internal. A
+      // provider session's settings carry its token, so they go to a 0600 file instead of
+      // argv — see session-settings.ts.
+      settings: settingsArgument(sessionId, hookSettings, Object.keys(resolved.env).length > 0),
       permissionMode: deps.permissionMode,
       attachGuiMcp,
       mcpConfig: deps.mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox),

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -16,7 +16,7 @@ import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 import { loadDirConfig } from "../config/dir-config.js";
 import { getProviders } from "../config/config-routes.js";
-import { resolveProvider } from "./provider-env.js";
+import { requireResolution, resolveProvider } from "./provider-env.js";
 import { settingsArgument } from "./session-settings.js";
 
 export function createClaudeSpawner(deps: SpawnDeps) {
@@ -49,13 +49,12 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     const sandbox = sandboxWouldRun(attachGuiMcp) && ws !== null;
     const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
 
-    // What this directory asked its sessions to run (#579). A refusal is NOT applied —
-    // the session stays on Anthropic, which is the safe outcome — but it is logged loudly,
-    // because silently ignoring the directory's choice is its own kind of surprise.
+    // What this directory asked its sessions to run (#579). A refusal THROWS: falling back
+    // to Anthropic would send this session's prompts to a backend the directory did not
+    // select, which is exactly what the provider contract exists to prevent. The ws route
+    // turns it into a message in the terminal.
     const dir = loadDirConfig(cwd);
-    const choice = resolveProvider({ provider: dir.provider, model: dir.model }, getProviders(), process.env, sandbox);
-    if (!choice.ok) console.warn(`[provider] ${cwd}: ${choice.reason} — staying on Anthropic`);
-    const resolved = choice.ok ? choice.value : { model: null, env: {}, unset: [] };
+    const resolved = requireResolution(resolveProvider({ provider: dir.provider, model: dir.model }, getProviders(), process.env, sandbox));
 
     const hookSettings = deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, resolved.env);
     const args = buildClaudeArgs({
@@ -83,7 +82,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     if (sandbox) {
       entry = spawnSandboxEntry(sessionId, args, cwd, ws);
     } else {
-      const { term, tmux } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true);
+      const { term, tmux } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true, resolved.unset);
       console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);
       entry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "claude" };
     }

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -17,7 +17,7 @@ import type { SpawnDeps } from "./spawn-deps.js";
 import { loadDirConfig } from "../config/dir-config.js";
 import { getProviders } from "../config/config-routes.js";
 import { requireResolution, resolveProvider } from "./provider-env.js";
-import { settingsArgument } from "./session-settings.js";
+import { settingsArgument, withSettingsCleanup } from "./session-settings.js";
 
 export function createClaudeSpawner(deps: SpawnDeps) {
   // Spawn a fresh claude PTY for this session, register it, and wire its output /
@@ -78,13 +78,16 @@ export function createClaudeSpawner(deps: SpawnDeps) {
 
     // Sandbox → run claude inside a fresh container (no tmux). Otherwise the host path:
     // a live tmux session for this id (survived a restart) reattaches; else create it.
-    let entry: PtyEntry;
-    if (sandbox) {
-      entry = spawnSandboxEntry(sessionId, args, cwd, ws);
-    } else {
+    // The settings file is already on disk and may hold a provider token, so a failed
+    // spawn has to take it with it — a session that never starts never reaches reap(),
+    // where the cleanup normally happens (#579).
+    const entry = withSettingsCleanup(sessionId, spawnEntry);
+
+    function spawnEntry(): PtyEntry {
+      if (sandbox) return spawnSandboxEntry(sessionId, args, cwd, ws);
       const { term, tmux } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true, resolved.unset);
       console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);
-      entry = { term, ws, buffer: "", cwd, tmux, active: false, agent: "claude" };
+      return { term, ws, buffer: "", cwd, tmux, active: false, agent: "claude" };
     }
     ptys.set(sessionId, entry);
 

--- a/server/session/spawn-deps.ts
+++ b/server/session/spawn-deps.ts
@@ -10,7 +10,7 @@ export interface SpawnDeps {
   guiMcpTools: string;
   /** Bytes of pty output kept for a client that reattaches later. */
   outputBufferLimit: number;
-  hookSettingsJson: (host: string, sessionId: string) => string;
+  hookSettingsJson: (host: string, sessionId: string, env?: Record<string, string>) => string;
   mcpConfigJson: (sessionId: string, host?: string, sandbox?: boolean) => string;
   reap: (id: string) => void;
   setWorking: (id: string, working: boolean) => void;

--- a/test/server/agents/claude-args.spec.ts
+++ b/test/server/agents/claude-args.spec.ts
@@ -12,6 +12,8 @@ const base: ClaudeArgsInput = {
   guiMcpTools: "mcp__gui__a,mcp__gui__b",
 };
 
+const cfg = (over: Partial<ClaudeArgsInput> = {}): ClaudeArgsInput => ({ ...base, ...over });
+
 describe("buildClaudeArgs", () => {
   it("single view (attachGuiMcp): attaches GUI MCP + --strict-mcp-config + --allowedTools", () => {
     const args = buildClaudeArgs(base);
@@ -59,5 +61,26 @@ describe("buildClaudeArgs", () => {
   it("never emits a `--` positional (auto-run text is typed in, not passed as an arg)", () => {
     expect(buildClaudeArgs(base)).not.toContain("--");
     expect(buildClaudeArgs({ ...base, canResume: true, resume: "44444444-4444-4444-4444-444444444444" })).not.toContain("--");
+  });
+});
+
+// #579: a directory can pin its sessions to a model — an alias or a third-party backend's
+// own name. `--model` is the one lever that outranks both the settings `model` key and
+// ANTHROPIC_MODEL, so the choice has to land here.
+describe("model selection", () => {
+  it("passes the chosen model through", () => {
+    expect(buildClaudeArgs(cfg({ model: "z-ai/glm-5.2" }))).toContain("--model");
+    expect(buildClaudeArgs(cfg({ model: "z-ai/glm-5.2" }))).toContain("z-ai/glm-5.2");
+  });
+
+  it("omits the flag entirely when no model is chosen", () => {
+    expect(buildClaudeArgs(base)).not.toContain("--model");
+    expect(buildClaudeArgs(cfg({ model: null }))).not.toContain("--model");
+  });
+
+  it("still passes it on a resumed session", () => {
+    const args = buildClaudeArgs(cfg({ model: "opus", resume: "abc", canResume: true }));
+    expect(args).toContain("--resume");
+    expect(args).toContain("--model");
   });
 });

--- a/test/server/config/app-config.spec.ts
+++ b/test/server/config/app-config.spec.ts
@@ -123,6 +123,7 @@ describe("loadAppConfig / saveAppConfig", () => {
     pushEnabled: false,
     worklogEnabled: false,
     worklogIntervalHours: 6,
+    providers: [],
   };
   it("round-trips presets + soundFile + prRepos + launchers + userMcpServers through a file", () => {
     const dir = tmp();
@@ -138,6 +139,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       pushEnabled: true,
       worklogEnabled: true,
       worklogIntervalHours: 12,
+      providers: [],
     };
     expect(saveAppConfig(file, cfg)).toBe(true);
     expect(JSON.parse(readFileSync(file, "utf8"))).toEqual(cfg);
@@ -178,6 +180,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       pushEnabled: false,
       worklogEnabled: false,
       worklogIntervalHours: 6,
+      providers: [],
     });
     rmSync(dir, { recursive: true, force: true });
   });
@@ -211,6 +214,7 @@ describe("mergeConfigUpdate", () => {
     pushEnabled: false,
     worklogEnabled: false,
     worklogIntervalHours: 6,
+    providers: [],
     ...over,
   });
 

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -20,6 +20,8 @@ const EMPTY = {
   buttons: null,
   chips: null,
   skills: null,
+  provider: null,
+  model: null,
 };
 
 function withConfig(body: unknown): { dir: string; cleanup: () => void } {
@@ -131,6 +133,8 @@ describe("loadDirConfig", () => {
       buttons: null,
       chips: null,
       skills: ["review", "commit"], // trimmed, deduped, empties dropped
+      provider: null,
+      model: null,
     });
     cleanup();
   });

--- a/test/server/session/provider-env.spec.ts
+++ b/test/server/session/provider-env.spec.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { DEFAULT_MAX_OUTPUT_TOKENS, isUsableBaseUrl, resolveProvider, withoutUnset, type ProviderConfig } from "../../../server/session/provider-env.js";
+
+const OPENROUTER: ProviderConfig = {
+  id: "openrouter",
+  label: "OpenRouter",
+  baseUrl: "https://openrouter.ai/api",
+  tokenEnv: "OPENROUTER_API_KEY",
+};
+
+const PROVIDERS = [OPENROUTER];
+const WITH_TOKEN = { OPENROUTER_API_KEY: "sk-or-test" };
+const CHOICE = { provider: "openrouter", model: "z-ai/glm-5.2" };
+
+const resolved = (over: Partial<Parameters<typeof resolveProvider>[0]> = {}, env: NodeJS.ProcessEnv = WITH_TOKEN) => {
+  const result = resolveProvider({ ...CHOICE, ...over }, PROVIDERS, env);
+  if (!result.ok) throw new Error(`expected a resolution, got: ${result.reason}`);
+  return result.value;
+};
+
+describe("resolveProvider — no provider named", () => {
+  it("does nothing at all when the directory configures neither", () => {
+    const result = resolveProvider({ provider: null, model: null }, PROVIDERS, {});
+    expect(result).toEqual({ ok: true, value: { model: null, env: {}, unset: [] } });
+  });
+
+  // A bare model choice stays on Anthropic — it is just `claude --model`.
+  it("passes a bare model through without touching the environment", () => {
+    const result = resolveProvider({ provider: null, model: "opus" }, PROVIDERS, {});
+    expect(result).toEqual({ ok: true, value: { model: "opus", env: {}, unset: [] } });
+  });
+});
+
+describe("resolveProvider — refusals", () => {
+  // THE safety rule. Claude Code's auth precedence puts the subscription OAuth credential
+  // last, so a base URL with no token would send that credential to the third party.
+  it("refuses when the token env var is missing, rather than falling back", () => {
+    const result = resolveProvider(CHOICE, PROVIDERS, {});
+    expect(result).toEqual({ ok: false, reason: expect.stringContaining("OPENROUTER_API_KEY") });
+  });
+
+  it("refuses when the token env var is present but empty", () => {
+    const result = resolveProvider(CHOICE, PROVIDERS, { OPENROUTER_API_KEY: "" });
+    expect(result.ok).toBe(false);
+  });
+
+  it("refuses a provider id that is not configured", () => {
+    const result = resolveProvider({ provider: "typo", model: "x" }, PROVIDERS, WITH_TOKEN);
+    expect(result).toEqual({ ok: false, reason: expect.stringContaining("unknown provider") });
+  });
+
+  it("refuses a provider with no model chosen", () => {
+    const result = resolveProvider({ provider: "openrouter", model: null }, PROVIDERS, WITH_TOKEN);
+    expect(result).toEqual({ ok: false, reason: expect.stringContaining("needs a model") });
+  });
+
+  // The container inherits no environment and cannot reach a loopback gateway, so a
+  // sandboxed provider session would silently run against Anthropic instead.
+  it("refuses the Docker sandbox rather than silently running against Anthropic", () => {
+    const result = resolveProvider(CHOICE, PROVIDERS, WITH_TOKEN, true);
+    expect(result).toEqual({ ok: false, reason: expect.stringContaining("sandbox") });
+  });
+
+  // Claude Code appends /v1/messages itself, so a baseUrl ending in /v1 404s at request
+  // time — a failure that surfaces inside the session with no explanation.
+  it("refuses a baseUrl that already ends in /v1", () => {
+    const providers = [{ ...OPENROUTER, baseUrl: "https://openrouter.ai/api/v1" }];
+    const result = resolveProvider(CHOICE, providers, WITH_TOKEN);
+    expect(result).toEqual({ ok: false, reason: expect.stringContaining("baseUrl") });
+  });
+});
+
+describe("isUsableBaseUrl", () => {
+  it("accepts the endpoint Claude Code expects", () => {
+    expect(isUsableBaseUrl("https://openrouter.ai/api")).toBe(true);
+    expect(isUsableBaseUrl("http://localhost:4000")).toBe(true);
+    expect(isUsableBaseUrl("https://api.moonshot.ai/anthropic")).toBe(true);
+  });
+
+  it("rejects a trailing /v1, with or without the slash", () => {
+    expect(isUsableBaseUrl("https://openrouter.ai/api/v1")).toBe(false);
+    expect(isUsableBaseUrl("https://openrouter.ai/api/v1/")).toBe(false);
+  });
+
+  it("rejects anything that is not an http(s) URL", () => {
+    expect(isUsableBaseUrl("openrouter.ai/api")).toBe(false);
+    expect(isUsableBaseUrl("")).toBe(false);
+  });
+});
+
+describe("resolveProvider — the environment it builds", () => {
+  it("aims Claude Code at the provider with its token", () => {
+    expect(resolved().env).toMatchObject({
+      ANTHROPIC_BASE_URL: "https://openrouter.ai/api",
+      ANTHROPIC_AUTH_TOKEN: "sk-or-test",
+      ANTHROPIC_MODEL: "z-ai/glm-5.2",
+    });
+  });
+
+  // Background "haiku" calls go to a backend that has no haiku, and 400 without this.
+  it("points the background model at the same model", () => {
+    expect(resolved().env.ANTHROPIC_SMALL_FAST_MODEL).toBe("z-ai/glm-5.2");
+  });
+
+  // Starved of output budget a thinking model spends it all thinking and returns empty
+  // visible text, which reads as a hung session.
+  it("gives thinking models output headroom by default", () => {
+    expect(resolved().env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe(String(DEFAULT_MAX_OUTPUT_TOKENS));
+    expect(DEFAULT_MAX_OUTPUT_TOKENS).toBeGreaterThanOrEqual(16000);
+  });
+
+  it("lets a provider raise the output cap", () => {
+    const providers = [{ ...OPENROUTER, maxOutputTokens: 32000 }];
+    const result = resolveProvider(CHOICE, providers, WITH_TOKEN);
+    expect(result.ok && result.value.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe("32000");
+  });
+
+  // A redirected session must not keep calling the real Anthropic API in the background.
+  it("cuts background traffic to Anthropic", () => {
+    expect(resolved().env.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).toBe("1");
+  });
+
+  // The settings `env` block can set a variable but not remove one, and a leftover
+  // ANTHROPIC_API_KEY silently outranks the auth token.
+  it("asks for ANTHROPIC_API_KEY to be removed, not blanked", () => {
+    expect(resolved().unset).toEqual(["ANTHROPIC_API_KEY"]);
+    expect(resolved().env).not.toHaveProperty("ANTHROPIC_API_KEY");
+  });
+
+  it("passes the model to --model as well as the environment", () => {
+    expect(resolved().model).toBe("z-ai/glm-5.2");
+  });
+});
+
+describe("withoutUnset", () => {
+  it("removes the named variables and keeps the rest", () => {
+    expect(withoutUnset({ ANTHROPIC_API_KEY: "sk-ant", PATH: "/usr/bin" }, ["ANTHROPIC_API_KEY"])).toEqual({ PATH: "/usr/bin" });
+  });
+
+  it("returns the same object when there is nothing to remove", () => {
+    const env = { PATH: "/usr/bin" };
+    expect(withoutUnset(env, [])).toBe(env);
+  });
+});

--- a/test/server/session/provider-env.spec.ts
+++ b/test/server/session/provider-env.spec.ts
@@ -1,7 +1,15 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { DEFAULT_MAX_OUTPUT_TOKENS, isUsableBaseUrl, resolveProvider, withoutUnset, type ProviderConfig } from "../../../server/session/provider-env.js";
+import {
+  DEFAULT_MAX_OUTPUT_TOKENS,
+  ProviderRefusedError,
+  isUsableBaseUrl,
+  requireResolution,
+  resolveProvider,
+  withoutUnset,
+  type ProviderConfig,
+} from "../../../server/session/provider-env.js";
 
 const OPENROUTER: ProviderConfig = {
   id: "openrouter",
@@ -142,5 +150,31 @@ describe("withoutUnset", () => {
   it("returns the same object when there is nothing to remove", () => {
     const env = { PATH: "/usr/bin" };
     expect(withoutUnset(env, [])).toBe(env);
+  });
+});
+
+// A `{ ok: false }` a caller can quietly ignore is how the refusal contract gets lost —
+// it already happened once, with the spawn path downgrading refusals to a warning and
+// running the session on Anthropic instead.
+describe("requireResolution", () => {
+  it("throws the reason rather than returning something ignorable", () => {
+    const refused = resolveProvider({ provider: "openrouter", model: "m" }, PROVIDERS, {});
+    expect(() => requireResolution(refused)).toThrow(ProviderRefusedError);
+    expect(() => requireResolution(refused)).toThrow(/OPENROUTER_API_KEY/);
+  });
+
+  it("passes a good resolution straight through", () => {
+    const ok = resolveProvider(CHOICE, PROVIDERS, WITH_TOKEN);
+    expect(requireResolution(ok).model).toBe("z-ai/glm-5.2");
+  });
+
+  it("throws for every refusal reason, not just the missing token", () => {
+    for (const refused of [
+      resolveProvider({ provider: "typo", model: "m" }, PROVIDERS, WITH_TOKEN),
+      resolveProvider({ provider: "openrouter", model: null }, PROVIDERS, WITH_TOKEN),
+      resolveProvider(CHOICE, PROVIDERS, WITH_TOKEN, true),
+    ]) {
+      expect(() => requireResolution(refused)).toThrow(ProviderRefusedError);
+    }
   });
 });

--- a/test/server/session/pty-spawn-env.spec.ts
+++ b/test/server/session/pty-spawn-env.spec.ts
@@ -5,9 +5,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // the pty itself is mocked: what matters here is the ENVIRONMENT handed to it.
 const spawn = vi.fn(() => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn() }));
 vi.mock("node-pty", () => ({ default: { spawn: (...args: unknown[]) => spawn(...(args as [])) } }));
+const scrub = vi.fn();
 vi.mock("../../../server/infra/tmux.js", () => ({
   tmuxAvailable: () => tmuxOn,
   tmuxNewSessionArgs: (id: string, file: string, args: string[]) => ["new-session", id, file, ...args],
+  tmuxScrubEnvNames: (names: readonly string[]) => scrub(names),
 }));
 
 let tmuxOn = false;
@@ -18,6 +20,7 @@ const envOf = (call: number = 0): NodeJS.ProcessEnv => (spawn.mock.calls[call] a
 
 beforeEach(() => {
   spawn.mockClear();
+  scrub.mockClear();
   tmuxOn = false;
   process.env.ANTHROPIC_API_KEY = "sk-ant-leftover";
   process.env.MT_KEEP_ME = "kept";
@@ -57,5 +60,22 @@ describe("ptySpawn — carries the removal down both paths", () => {
     const result = ptySpawn("s1", "claude", [], "/tmp", true, ["ANTHROPIC_API_KEY"]);
     expect(result.tmux).toBe(true);
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
+  });
+});
+
+// Stripping our own copy is not enough: a pane inherits the tmux SERVER's environment,
+// and a server created by an earlier non-provider session already carries the key. The
+// scrub in ensureConf only covers a server that predates this process.
+describe("ptySpawn — the tmux server's own environment", () => {
+  it("scrubs the names from the running server before a provider spawn", () => {
+    tmuxOn = true;
+    ptySpawn("s1", "claude", [], "/tmp", true, ["ANTHROPIC_API_KEY"]);
+    expect(scrub).toHaveBeenCalledWith(["ANTHROPIC_API_KEY"]);
+  });
+
+  it("leaves the server alone for an ordinary session", () => {
+    tmuxOn = true;
+    ptySpawn("s1", "claude", [], "/tmp", true);
+    expect(scrub).not.toHaveBeenCalled();
   });
 });

--- a/test/server/session/pty-spawn-env.spec.ts
+++ b/test/server/session/pty-spawn-env.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// node-pty is a native module and spawning is the whole point of the file under test, so
+// the pty itself is mocked: what matters here is the ENVIRONMENT handed to it.
+const spawn = vi.fn(() => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn() }));
+vi.mock("node-pty", () => ({ default: { spawn: (...args: unknown[]) => spawn(...(args as [])) } }));
+vi.mock("../../../server/infra/tmux.js", () => ({
+  tmuxAvailable: () => tmuxOn,
+  tmuxNewSessionArgs: (id: string, file: string, args: string[]) => ["new-session", id, file, ...args],
+}));
+
+let tmuxOn = false;
+
+const { spawnPty, ptySpawn } = await import("../../../server/session/pty-spawn.js");
+
+const envOf = (call: number = 0): NodeJS.ProcessEnv => (spawn.mock.calls[call] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
+
+beforeEach(() => {
+  spawn.mockClear();
+  tmuxOn = false;
+  process.env.ANTHROPIC_API_KEY = "sk-ant-leftover";
+  process.env.MT_KEEP_ME = "kept";
+});
+
+// A leftover ANTHROPIC_API_KEY silently outranks the auth token that aims a provider
+// session at its backend, and the settings `env` block can set a variable but not remove
+// one. So the removal has to happen HERE — computing it and not applying it (which is
+// exactly what shipped first) leaves the routing broken with no symptom until a request.
+describe("spawnPty — the environment it hands the pty", () => {
+  it("removes the named variables", () => {
+    spawnPty("claude", [], "/tmp", ["ANTHROPIC_API_KEY"]);
+    expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
+  });
+
+  it("keeps everything else", () => {
+    spawnPty("claude", [], "/tmp", ["ANTHROPIC_API_KEY"]);
+    expect(envOf().MT_KEEP_ME).toBe("kept");
+  });
+
+  it("leaves the environment alone when nothing is named", () => {
+    spawnPty("claude", [], "/tmp");
+    expect(envOf().ANTHROPIC_API_KEY).toBe("sk-ant-leftover");
+  });
+});
+
+// The tmux pane inherits the tmux SERVER's environment rather than this one, so the scrub
+// there is what actually protects it — but the non-tmux path has only this.
+describe("ptySpawn — carries the removal down both paths", () => {
+  it("applies it on the direct spawn", () => {
+    ptySpawn("s1", "claude", [], "/tmp", false, ["ANTHROPIC_API_KEY"]);
+    expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
+  });
+
+  it("applies it on the tmux spawn too", () => {
+    tmuxOn = true;
+    const result = ptySpawn("s1", "claude", [], "/tmp", true, ["ANTHROPIC_API_KEY"]);
+    expect(result.tmux).toBe(true);
+    expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
+  });
+});

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, it, expect, afterEach } from "vitest";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import { cleanupSessionSettings, settingsArgument, withSettingsCleanup } from "../../../server/session/session-settings.js";
+
+const SESSION = "settings-spec-session";
+const fileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}.json`);
+
+afterEach(() => cleanupSessionSettings(SESSION));
+
+describe("settingsArgument", () => {
+  // A settings payload with no secret in it keeps travelling inline, so every existing
+  // session's spawn is untouched by this feature.
+  it("returns the JSON itself when nothing in it is secret", () => {
+    const json = JSON.stringify({ hooks: {} });
+    expect(settingsArgument(SESSION, json, false)).toBe(json);
+    expect(existsSync(fileFor(SESSION))).toBe(false);
+  });
+
+  // An inline `--settings` is visible to every user on the host through `ps`, and a
+  // provider session's settings carry its API token.
+  it("writes a private file and returns its path when it is", () => {
+    const json = JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "sk-secret" }, hooks: {} });
+    const arg = settingsArgument(SESSION, json, true);
+    expect(arg).toBe(fileFor(SESSION));
+    expect(arg).not.toContain("sk-secret");
+    expect(readFileSync(arg, "utf8")).toBe(json);
+  });
+
+  it("keeps the file readable only by its owner", () => {
+    const arg = settingsArgument(SESSION, "{}", true);
+    expect(statSync(arg).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("withSettingsCleanup", () => {
+  // A session that never starts never reaches reap(), where the cleanup normally happens
+  // — so without this a failed spawn leaves a token-bearing file on disk.
+  it("removes the file when the spawn throws, and re-throws", () => {
+    settingsArgument(SESSION, '{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-secret"}}', true);
+    expect(existsSync(fileFor(SESSION))).toBe(true);
+    expect(() =>
+      withSettingsCleanup(SESSION, () => {
+        throw new Error("spawn failed");
+      }),
+    ).toThrow(/spawn failed/);
+    expect(existsSync(fileFor(SESSION))).toBe(false);
+  });
+
+  it("keeps the file — the session needs it — when the spawn succeeds", () => {
+    settingsArgument(SESSION, "{}", true);
+    expect(withSettingsCleanup(SESSION, () => "entry")).toBe("entry");
+    expect(existsSync(fileFor(SESSION))).toBe(true);
+  });
+});
+
+describe("cleanupSessionSettings", () => {
+  it("is a no-op for a session that never wrote one", () => {
+    expect(() => cleanupSessionSettings("never-existed-session")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

ディレクトリ単位でセッションのモデルを固定でき、Anthropic の代わりに **Anthropic 互換バックエンド**（OpenRouter / Moonshot / LiteLLM ゲートウェイ）に向けられるようにします。

Claude Code のサブエージェントは 1 プロセス 1 エンドポイントでモデル名しか変えられませんが、**mulmoterminal はセッションごとに別プロセス**なので、セッション単位で実際にバックエンドを変えられます。これがこの機能の本質です。

Closes #579（UI と sandbox 対応は後続）。

```jsonc
// ~/.mulmoterminal/config.json — 鍵の実体は書かない
{ "providers": [{ "id": "openrouter", "label": "OpenRouter",
                  "baseUrl": "https://openrouter.ai/api", "tokenEnv": "OPENROUTER_API_KEY" }] }

// <dir>/.mulmoterminal.json
{ "provider": "openrouter", "model": "moonshotai/kimi-k2.6" }
```

## Items to Confirm / Review

1. **`provider-env.ts` の規則はすべて実機で確認したもので、ドキュメントから起こしたものではありません。** 最重要は「**BASE_URL があるのにトークンが解決できないなら起動を拒否**」です。Claude Code の認証優先順位はサブスクの OAuth 認証情報が**最下位**なので、中途半端に適用すると**その認証情報が第三者に送信されます**。fallback ではなく拒否が唯一の安全な答えです
2. **`ANTHROPIC_SMALL_FAST_MODEL` を必ず同時に設定**します。未設定だと背景の「haiku」呼び出しが haiku を持たないバックエンドに飛んで 400 になります
3. **出力上限の既定 16000** — 検証中に Kimi K2.6 で実際に踏みました。枠が足りないと thinking で使い切って本文が空になり、ハングしたように見えます
4. **`ANTHROPIC_API_KEY` は空文字ではなく削除**。残っていると認証トークンを静かに上書きします。settings の `env` ブロックは**削除を表現できない**ため、プロセス env 側で落としています
5. **伝送経路も実測で決めました。** tmux の pane は **tmux サーバ**の環境を継ぎ、spawn した client の env は継ぎません。つまり client env に置く方式は「tmux サーバが新しいときだけ動く」＝クイックテストでは通り本番で静かに壊れます。そのため env は **settings ファイルの `env` ブロック**で運びます（Claude Code 自身が適用するので host / tmux / container で同じ挙動）
6. **トークンを argv に出さない。** env ブロックを持つ settings は **0600 のファイル**に書き、argv にはパスだけが載ります。**env ブロックを持たない既存セッションは従来どおりインライン JSON のまま**なので、既存経路への影響はありません
7. **sandbox はプロバイダを明示的に拒否**します。環境を継承せずループバックにも届かないため、黙って Anthropic に流れる方が危険だからです

## User Prompt

> claude code起動時に、modelを指定できるようにしたい
> claude codeでopen routerやmoonshotのapi(anthropic互換）を利用して、それらのモデルを使ったセッションを起動できるようにしたい。環境変数の指定、保存方法含めてどうすれば安全化、docker利用時も考慮して考えてね。

（続けて「実装して」の指示。エンドポイントの注意点と実機の鍵の提供を受けています。）

## Implementation

- `server/session/provider-env.ts`（新規・純粋関数）— 判断を全部ここに集約。ペア検証・`SMALL_FAST_MODEL` 補完・出力枠の既定・`unset` の算出
- `server/session/session-settings.ts`（新規）— 秘密を含むときだけ 0600 ファイルに書く
- `claude-args.ts` に `--model`（settings の `model` と `ANTHROPIC_MODEL` の両方に優先する唯一のレバー）
- `tmux.ts` — 既存の launcher 変数スクラブに `ANTHROPIC_API_KEY` を追加
- 設定: グローバルに `providers`、per-dir に `provider` / `model`

## Tests

`yarn test` **1862 pass** · `yarn lint` 0 errors · `yarn build` · `yarn typecheck:server` · `yarn typecheck:test`

新規 20 ケース。ミューテーションで全部レッド確認済み（トークン欠落を許す / `SMALL_FAST_MODEL` を落とす / 出力枠を 4096 に下げる / `unset` を空にする）。

**エンドツーエンド検証**（実際の OpenRouter アカウントで実施）:

- settings は mode 600 のパスで渡り、**トークンは argv に出ない**
- `ANTHROPIC_API_KEY` は子 env から除去される
- 直接実行 → `"routed"`
- **tmux pane 経由 → `"routed"`**（プロセス env では届かないと実測した経路）

🤖 Generated with [Claude Code](https://claude.com/claude-code)