### PR TITLE
refactor: /api/hook とその fan-out を切り出し（#548 step 3g）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -10,8 +10,7 @@ import { mountAllRoutes, allowedToolNames, toolSummaries } from "./infra/plugins
 import { buildGuiMcpServer } from "./mcp/broker.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getUserMcpServers, getPushEnabled, getWorklogConfig } from "./config/config-routes.js";
-import { sendWebPush } from "./infra/web-push.js";
+import { mountConfigRoutes, getUserMcpServers, getWorklogConfig } from "./config/config-routes.js";
 import { mountFilesBrowseRoutes } from "./files/files-browse.js";
 import {
   tmuxAvailable,
@@ -25,17 +24,16 @@ import {
 } from "./infra/tmux.js";
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
 import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage, cleanupSandbox, rewriteLoopbackForDocker } from "./infra/sandbox.js";
-import { dirConfigWriteTarget } from "./config/dir-config.js";
-import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "./session/activity-hook.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { hasErrnoCode, messageOf } from "./errors.js";
 import { createClaudeSpawner } from "./session/spawn-claude.js";
 import { createCodexSpawner } from "./session/spawn-codex.js";
 import { createShellSpawners } from "./session/spawn-shell.js";
-import { createTranslationWorker, failPendingTranslation, submitTranslation } from "./session/translation-worker.js";
+import { createTranslationWorker, submitTranslation } from "./session/translation-worker.js";
 import { createTitleManager } from "./session/session-title.js";
 import { generateHeaderTitle } from "./config/header-title.js";
 import { mountTerminalWebSockets } from "./routes/ws-routes.js";
+import { mountHookRoute } from "./routes/hook-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
 import {
@@ -60,7 +58,7 @@ import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
 import { mountToolRoutes } from "./routes/tool-routes.js";
 import { mountRepoRoutes } from "./routes/repo-routes.js";
-import { claudeOnDiskSessionIds, latestUserPrompt, readLatestResponse } from "./session/session-reads.js";
+import { claudeOnDiskSessionIds, readLatestResponse } from "./session/session-reads.js";
 import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, heldByAnotherProcess, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
@@ -71,7 +69,7 @@ import { codexifySkillSeed } from "./agents/codex-skills.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
-import { isRecord, preferredHeaderPrompt } from "./session/transcript.js";
+import { isRecord } from "./session/transcript.js";
 import { mountOpenDirRoute } from "./files/open-dir.js";
 import { mountGitRemoteRoute } from "./git/gitRemote.js";
 import { mountWorktreeRoutes } from "./git/worktree-routes.js";
@@ -177,8 +175,6 @@ const toolStores = createToolStores({
   publish: (channel, data) => pubsub?.publish(channel, data),
 });
 const { recordToolCallStart, recordToolCallEnd } = toolStores;
-
-const LAST_PROMPT_CAP = 200;
 
 function refreshLastResponse(id: string, cwd: string): void {
   const text = readLatestResponse(id, cwd);
@@ -688,161 +684,21 @@ app.use(express.static(path.join(__dirname, "../dist")));
 // prefix — see server/spa-fallback.ts for why that's sufficient.
 app.get(SPA_FALLBACK_RE, (_req, res) => res.sendFile(path.join(__dirname, "../dist/index.html")));
 
-// Activity hooks update a session's working / needs-attention flags. `active` (this
-// session is the user's actively-viewed pane) suppresses the attention flag — see
-// activityHookEffects for why a mere attached socket doesn't count in the grid.
-function handleActivityHook(sessionId: string, event: string, active: boolean, message: string) {
-  for (const eff of activityHookEffects(event, active)) {
-    if (eff.kind === "working") setWorking(sessionId, eff.value, event);
-    else setWaiting(sessionId, eff.value, event);
-  }
-  // Push regardless of `active` — the phone is elsewhere, unlike the attention beep.
-  // A finished turn (Stop) and a blocked one (Notification) both reach here; the kind
-  // decides the wording. Stop is one event per finished turn, so this fires once even
-  // though a background Stop publishes twice.
-  const kind = pushKindFor(event);
-  if (kind) notifyTaskFinished(sessionId, kind, message);
-}
-
-const PUSH_TITLE_MAX = 80;
-const PUSH_BODY_MAX = 160;
-// Which port this host's UI answers on, so a receiver can open it instead of guessing.
-// Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server, whose
-// port the backend only knows when CLIENT_PORT is set in its environment (vite.config.ts
-// defaults it separately). Reaching it still requires a receiver on this machine — see the
-// data payload below.
-const UI_PORT = String(process.env.CLIENT_PORT || PORT);
-// Notify the user's devices that a background task finished, when Web Push is enabled.
-// Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
-function notifyTaskFinished(sessionId: string, kind: PushKind, message: string): void {
-  if (!getPushEnabled()) return;
-  // Internal helper turns flow through /api/hook with active=false too — hidden background
-  // workers and translation workers aren't real user tasks, so never push for them.
-  if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
-  const cwd = ptys.get(sessionId)?.cwd ?? null;
-  const where = cwd ? path.basename(cwd) : "session";
-  // A finished turn should say what the agent DID — the prompt is what the user already
-  // knows, and reading it back tells them nothing about the outcome. Read it HERE instead
-  // of taking `lastResponses`: publishActivity skips its refresh for an actively-viewed
-  // session (no `waiting` flag) while the push still fires, and the cache deliberately
-  // survives a failed read — either way the map can hold the previous turn's reply, which
-  // is worse than saying nothing. No reply to read falls through to the prompt.
-  const reply = kind === "finished" && cwd ? readLatestResponse(sessionId, cwd) : null;
-  if (reply) lastResponses.set(sessionId, reply); // keep the roster in step; we just read it
-  const detail = (reply ?? "").trim() || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
-  const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
-  // The session id is what lets the phone open this session from the notification;
-  // the host id is what lets it know WHOSE session. Without it the phone opens with
-  // no host selected — it never persists one — and can only offer the picker, which
-  // is where every notification tap used to land (receptron/mulmoserver#86).
-  // `port` is for a receiver running ON this machine, which can then open the local UI
-  // directly (http://localhost:<port>). A phone cannot use it — its own localhost is the
-  // phone — so the receiver has to treat it as optional and keep the existing routing.
-  void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID, port: UI_PORT });
-}
-
-interface HookToolPayload {
-  tool_use_id?: string;
-  tool_name?: string;
-  tool_input?: unknown;
-  tool_output?: unknown;
-  tool_response?: unknown;
-  duration_ms?: number;
-}
-
-// Pre/PostToolUse hooks feed the per-session tool-call history. A failed tool
-// fires PostToolUseFailure (NOT PostToolUse), so both complete the entry.
-async function handleToolHook(sessionId: string, event: string, p: HookToolPayload) {
-  if (event === "PreToolUse") {
-    await recordToolCallStart(sessionId, { toolUseId: p.tool_use_id, toolName: p.tool_name, toolInput: p.tool_input });
-  } else if (event === "PostToolUse" || event === "PostToolUseFailure") {
-    await recordToolCallEnd(sessionId, {
-      toolUseId: p.tool_use_id,
-      toolName: p.tool_name,
-      toolInput: p.tool_input,
-      toolOutput: p.tool_output ?? p.tool_response,
-      durationMs: p.duration_ms,
-      status: event === "PostToolUseFailure" ? "failed" : "completed",
-    });
-  }
-  // A SUCCESSFUL write to <dir>/.mulmoterminal.json is the live-reload signal: the hook that already
-  // reports every tool call tells the client to re-read that directory's config, so no fs watchers.
-  if (event === "PostToolUse") {
-    const cwd = dirConfigWriteTarget(p.tool_name, p.tool_input, ptys.get(sessionId)?.cwd ?? null);
-    if (cwd) pubsub?.publish(DIR_CONFIG_CHANNEL, { cwd });
-  }
-}
-
-// Track the prompt the cell header shows for a session, from a UserPromptSubmit
-// hook. On the FIRST live prompt after a (re)start/resume the in-memory baseline is
-// empty, so seed it from the transcript's meaningful prompt — otherwise a trivial
-// ack ("ok") would overwrite the restored task. (Brand-new sessions have no
-// transcript yet => null => the new prompt becomes the first shown.) Then keep the
-// last MEANINGFUL prompt (preferredHeaderPrompt) while still tracking the latest for
-// an all-trivial session.
-async function trackPromptForHeader(sessionId: string, prompt: string, cwd: string | undefined) {
-  if (!lastPrompts.has(sessionId)) {
-    const seeded = cwd ? await latestUserPrompt(cwd, sessionId) : null;
-    if (seeded) lastPrompts.set(sessionId, seeded);
-  }
-  lastPrompts.set(sessionId, preferredHeaderPrompt(lastPrompts.get(sessionId) ?? null, prompt));
-}
-
-// `/clear` restarts the conversation, so the header must stop showing the pre-clear prompt. Blank it
-// (empty string beats the `?? transcriptPrompt` fallback in /api/session, so the old transcript can't
-// resurface) and publish; the next UserPromptSubmit sets the new query. `forgetTitle` drops the AI title
-// so it's regenerated fresh on the next turn (leaving it in `aiTitles` — even as "" — would read as
-// "already titled" and suppress that regeneration). The cockpit's last reply is blanked the same way as
-// the prompt (empty beats `?? transcriptResponse`) so it can't show the pre-clear answer.
-function clearHeaderPrompt(sessionId: string): void {
-  lastPrompts.set(sessionId, "");
-  lastResponses.set(sessionId, "");
-  forgetTitle(sessionId);
-  publishActivity(sessionId);
-}
-
-// Header-prompt / AI-title side effects of a hook, per event: track the submitted prompt
-// (UserPromptSubmit), drop it on `/clear` (SessionStart source=clear), or (re)generate the
-// AI title once a turn's reply is on disk (Stop). Kept out of the route so its branching
-// doesn't inflate the handler. Runs before handleActivityHook so the activity publish it
-// triggers already carries the new lastPrompt.
-async function applyHeaderHooks(sessionId: string, event: string, body: Record<string, unknown>, cwd: string | undefined): Promise<void> {
-  if (event === "UserPromptSubmit" && typeof body.prompt === "string" && body.prompt.trim()) {
-    const prompt = body.prompt.trim().slice(0, LAST_PROMPT_CAP);
-    await trackPromptForHeader(sessionId, prompt, cwd);
-    noteTitleTurn(sessionId, prompt);
-  } else if (event === "SessionStart" && body.source === "clear") {
-    clearHeaderPrompt(sessionId);
-  } else if (event === "Stop") {
-    void maybeGenerateTitle(sessionId, cwd);
-  }
-}
-
-// Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so
-// we can flag which background sessions have new activity / build tool history.
-app.post("/api/hook", async (req, res) => {
-  const body = req.body || {};
-  const sessionId = resolveHookSessionId(req.headers["x-mt-session"], body.session_id, (id) => SESSION_ID_RE.test(id));
-  const event = body.hook_event_name;
-  if (!sessionId && body.session_id) {
-    // Rejecting silently would make hooks look simply broken; the id shape is the
-    // precondition for using it as a Firestore doc id and as push routing.
-    console.warn(`[hook] ignoring ${event} — session id is not a canonical uuid`);
-  }
-  if (sessionId) {
-    const entry = ptys.get(sessionId);
-    const active = !!(entry && entry.active);
-    const cwd = typeof body.cwd === "string" ? body.cwd : entry?.cwd;
-    await applyHeaderHooks(sessionId, event, body, cwd);
-    handleActivityHook(sessionId, event, active, typeof body.message === "string" ? body.message : "");
-    await handleToolHook(sessionId, event, body);
-    // A hidden translation worker that ends its turn while still pending never called
-    // submitTranslation — fail it now rather than hang until the timeout. (When it DID
-    // submit, the entry is already resolved and this reject is a no-op.)
-    if (event === "Stop") failPendingTranslation(sessionId, "[translation] worker ended its turn without calling submitTranslation");
-    console.log(`[hook] ${event} for ${sessionId}`);
-  }
-  res.json({ ok: true });
+// The Claude hook endpoint (routes/hook-routes.ts). Session lifecycle, the title
+// bookkeeping and the tool stores stay here; the fan-out that reads them moves out.
+mountHookRoute(app, {
+  setWorking: (id, working, event) => setWorking(id, working, event),
+  setWaiting: (id, waiting, event) => setWaiting(id, waiting, event),
+  publishActivity: (id) => publishActivity(id),
+  forgetTitle,
+  noteTitleTurn,
+  maybeGenerateTitle,
+  recordToolCallStart,
+  recordToolCallEnd,
+  publishDirConfig: (cwd) => pubsub?.publish(DIR_CONFIG_CHANNEL, { cwd }),
+  // Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server,
+  // whose port the backend only knows when CLIENT_PORT is set in its environment.
+  uiPort: String(process.env.CLIENT_PORT || PORT),
 });
 
 // The tools pane: the toolResult sink, its replay, the available-tool list and the

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,6 @@ import http from "http";
 import path from "path";
 import fs from "fs/promises";
 import { randomUUID } from "crypto";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "url";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createPubSub } from "./infra/pubsub.js";
@@ -61,8 +60,7 @@ import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
 import { mountToolRoutes } from "./routes/tool-routes.js";
 import { mountRepoRoutes } from "./routes/repo-routes.js";
-import { claudeOnDiskSessionIds, latestUserPrompt, LAST_RESPONSE_MAX } from "./session/session-reads.js";
-import { projectSessionsDir } from "./session/project-dir.js";
+import { claudeOnDiskSessionIds, latestUserPrompt, readLatestResponse } from "./session/session-reads.js";
 import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, heldByAnotherProcess, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
@@ -73,7 +71,7 @@ import { codexifySkillSeed } from "./agents/codex-skills.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
-import { isRecord, latestAssistantTextFromJsonl, preferredHeaderPrompt } from "./session/transcript.js";
+import { isRecord, preferredHeaderPrompt } from "./session/transcript.js";
 import { mountOpenDirRoute } from "./files/open-dir.js";
 import { mountGitRemoteRoute } from "./git/gitRemote.js";
 import { mountWorktreeRoutes } from "./git/worktree-routes.js";
@@ -182,19 +180,6 @@ const { recordToolCallStart, recordToolCallEnd } = toolStores;
 
 const LAST_PROMPT_CAP = 200;
 
-// The reply as it is on disk RIGHT NOW, or null when there is none to read. Separate from
-// the cache below because the two want opposite things on failure: the roster would rather
-// keep showing the last reply it had, while a push must never describe a finished turn with
-// the PREVIOUS turn's text — for that caller, null has to stay null.
-function readLatestResponse(id: string, cwd: string): string | null {
-  try {
-    const raw = readFileSync(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
-    const text = latestAssistantTextFromJsonl(raw);
-    return text ? text.slice(0, LAST_RESPONSE_MAX) : null;
-  } catch {
-    return null; // no transcript yet / unreadable
-  }
-}
 function refreshLastResponse(id: string, cwd: string): void {
   const text = readLatestResponse(id, cwd);
   if (text) lastResponses.set(id, text); // a failed read leaves any prior value

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -196,5 +196,8 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
 export function mountHookRoute(app: Express, deps: HookDeps) {
   // Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so
   // we can flag which background sessions have new activity / build tool history.
-  app.post("/api/hook", (req, res) => void handleHookRequest(deps, req, res));
+  // Return the promise rather than dropping it: express 5 forwards a rejected handler
+  // to its error middleware, and swallowing it here would turn a failed hook into an
+  // unhandled rejection instead of a 500.
+  app.post("/api/hook", (req, res) => handleHookRequest(deps, req, res));
 }

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -1,0 +1,200 @@
+// The Claude hook endpoint: every Stop / Notification / Pre|PostToolUse / SessionStart
+// POSTs here. One request fans out to the session's attention flags, a push to the user's
+// phone, the tool-call history, the header prompt and the AI title. Split from index.ts
+// (#548 step 3g) — the fan-out is what made the route long, not the route itself.
+import type { Express, Request, Response } from "express";
+import path from "node:path";
+import { SESSION_ID_RE } from "../config/env.js";
+import { getPushEnabled } from "../config/config-routes.js";
+import { dirConfigWriteTarget } from "../config/dir-config.js";
+import { sendWebPush } from "../infra/web-push.js";
+import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
+import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "../session/activity-hook.js";
+import { aiTitles, hiddenSessions, lastPrompts, lastResponses, ptys, translationWorkerIds } from "../session/registry.js";
+import { latestUserPrompt, readLatestResponse } from "../session/session-reads.js";
+import { preferredHeaderPrompt } from "../session/transcript.js";
+import { failPendingTranslation } from "../session/translation-worker.js";
+
+// The header shows one line, so a longer prompt is stored truncated rather than in full.
+const LAST_PROMPT_CAP = 200;
+
+export interface HookDeps {
+  setWorking: (id: string, working: boolean, event?: string) => void;
+  setWaiting: (id: string, waiting: boolean, event?: string) => void;
+  publishActivity: (id: string) => void;
+  forgetTitle: (id: string) => void;
+  noteTitleTurn: (id: string, prompt: string) => void;
+  maybeGenerateTitle: (id: string, cwd: string | undefined) => Promise<void>;
+  recordToolCallStart: (sessionId: string, call: { toolUseId?: string; toolName?: string; toolInput?: unknown }) => Promise<void>;
+  recordToolCallEnd: (
+    sessionId: string,
+    call: { toolUseId?: string; toolName?: string; toolInput?: unknown; toolOutput?: unknown; durationMs?: number; status: "completed" | "failed" },
+  ) => Promise<void>;
+  /** Tell clients watching that directory to re-read its .mulmoterminal.json. */
+  publishDirConfig: (cwd: string) => void;
+  /** Which port this host's UI answers on, so a receiver can open it instead of guessing. */
+  uiPort: string;
+}
+
+// Activity hooks update a session's working / needs-attention flags. `active` (this
+// session is the user's actively-viewed pane) suppresses the attention flag — see
+// activityHookEffects for why a mere attached socket doesn't count in the grid.
+function handleActivityHook(deps: HookDeps, sessionId: string, event: string, active: boolean, message: string) {
+  for (const eff of activityHookEffects(event, active)) {
+    if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
+    else deps.setWaiting(sessionId, eff.value, event);
+  }
+  // Push regardless of `active` — the phone is elsewhere, unlike the attention beep.
+  // A finished turn (Stop) and a blocked one (Notification) both reach here; the kind
+  // decides the wording. Stop is one event per finished turn, so this fires once even
+  // though a background Stop publishes twice.
+  const kind = pushKindFor(event);
+  if (kind) notifyTaskFinished(deps, sessionId, kind, message);
+}
+
+const PUSH_TITLE_MAX = 80;
+const PUSH_BODY_MAX = 160;
+// Which port this host's UI answers on, so a receiver can open it instead of guessing.
+// Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server, whose
+// port the backend only knows when CLIENT_PORT is set in its environment (vite.config.ts
+// defaults it separately). Reaching it still requires a receiver on this machine — see the
+// data payload below.
+
+// Notify the user's devices that a background task finished, when Web Push is enabled.
+// Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
+function notifyTaskFinished(deps: HookDeps, sessionId: string, kind: PushKind, message: string): void {
+  if (!getPushEnabled()) return;
+  // Internal helper turns flow through /api/hook with active=false too — hidden background
+  // workers and translation workers aren't real user tasks, so never push for them.
+  if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
+  const cwd = ptys.get(sessionId)?.cwd ?? null;
+  const where = cwd ? path.basename(cwd) : "session";
+  // A finished turn should say what the agent DID — the prompt is what the user already
+  // knows, and reading it back tells them nothing about the outcome. Read it HERE instead
+  // of taking `lastResponses`: publishActivity skips its refresh for an actively-viewed
+  // session (no `waiting` flag) while the push still fires, and the cache deliberately
+  // survives a failed read — either way the map can hold the previous turn's reply, which
+  // is worse than saying nothing. No reply to read falls through to the prompt.
+  const reply = kind === "finished" && cwd ? readLatestResponse(sessionId, cwd) : null;
+  if (reply) lastResponses.set(sessionId, reply); // keep the roster in step; we just read it
+  const detail = (reply ?? "").trim() || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+  const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
+  // The session id is what lets the phone open this session from the notification;
+  // the host id is what lets it know WHOSE session. Without it the phone opens with
+  // no host selected — it never persists one — and can only offer the picker, which
+  // is where every notification tap used to land (receptron/mulmoserver#86).
+  // `port` is for a receiver running ON this machine, which can then open the local UI
+  // directly (http://localhost:<port>). A phone cannot use it — its own localhost is the
+  // phone — so the receiver has to treat it as optional and keep the existing routing.
+  void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID, port: deps.uiPort });
+}
+
+interface HookToolPayload {
+  tool_use_id?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  tool_output?: unknown;
+  tool_response?: unknown;
+  duration_ms?: number;
+}
+
+// Pre/PostToolUse hooks feed the per-session tool-call history. A failed tool
+// fires PostToolUseFailure (NOT PostToolUse), so both complete the entry.
+async function handleToolHook(deps: HookDeps, sessionId: string, event: string, p: HookToolPayload) {
+  if (event === "PreToolUse") {
+    await deps.recordToolCallStart(sessionId, { toolUseId: p.tool_use_id, toolName: p.tool_name, toolInput: p.tool_input });
+  } else if (event === "PostToolUse" || event === "PostToolUseFailure") {
+    await deps.recordToolCallEnd(sessionId, {
+      toolUseId: p.tool_use_id,
+      toolName: p.tool_name,
+      toolInput: p.tool_input,
+      toolOutput: p.tool_output ?? p.tool_response,
+      durationMs: p.duration_ms,
+      status: event === "PostToolUseFailure" ? "failed" : "completed",
+    });
+  }
+  // A SUCCESSFUL write to <dir>/.mulmoterminal.json is the live-reload signal: the hook that already
+  // reports every tool call tells the client to re-read that directory's config, so no fs watchers.
+  if (event === "PostToolUse") {
+    const cwd = dirConfigWriteTarget(p.tool_name, p.tool_input, ptys.get(sessionId)?.cwd ?? null);
+    if (cwd) deps.publishDirConfig(cwd);
+  }
+}
+
+// Track the prompt the cell header shows for a session, from a UserPromptSubmit
+// hook. On the FIRST live prompt after a (re)start/resume the in-memory baseline is
+// empty, so seed it from the transcript's meaningful prompt — otherwise a trivial
+// ack ("ok") would overwrite the restored task. (Brand-new sessions have no
+// transcript yet => null => the new prompt becomes the first shown.) Then keep the
+// last MEANINGFUL prompt (preferredHeaderPrompt) while still tracking the latest for
+// an all-trivial session.
+async function trackPromptForHeader(sessionId: string, prompt: string, cwd: string | undefined) {
+  if (!lastPrompts.has(sessionId)) {
+    const seeded = cwd ? await latestUserPrompt(cwd, sessionId) : null;
+    if (seeded) lastPrompts.set(sessionId, seeded);
+  }
+  lastPrompts.set(sessionId, preferredHeaderPrompt(lastPrompts.get(sessionId) ?? null, prompt));
+}
+
+// `/clear` restarts the conversation, so the header must stop showing the pre-clear prompt. Blank it
+// (empty string beats the `?? transcriptPrompt` fallback in /api/session, so the old transcript can't
+// resurface) and publish; the next UserPromptSubmit sets the new query. `forgetTitle` drops the AI title
+// so it's regenerated fresh on the next turn (leaving it in `aiTitles` — even as "" — would read as
+// "already titled" and suppress that regeneration). The cockpit's last reply is blanked the same way as
+// the prompt (empty beats `?? transcriptResponse`) so it can't show the pre-clear answer.
+function clearHeaderPrompt(deps: HookDeps, sessionId: string): void {
+  lastPrompts.set(sessionId, "");
+  lastResponses.set(sessionId, "");
+  deps.forgetTitle(sessionId);
+  deps.publishActivity(sessionId);
+}
+
+// Header-prompt / AI-title side effects of a hook, per event: track the submitted prompt
+// (UserPromptSubmit), drop it on `/clear` (SessionStart source=clear), or (re)generate the
+// AI title once a turn's reply is on disk (Stop). Kept out of the route so its branching
+// doesn't inflate the handler. Runs before handleActivityHook so the activity publish it
+// triggers already carries the new lastPrompt.
+async function applyHeaderHooks(deps: HookDeps, sessionId: string, event: string, body: Record<string, unknown>, cwd: string | undefined): Promise<void> {
+  if (event === "UserPromptSubmit" && typeof body.prompt === "string" && body.prompt.trim()) {
+    const prompt = body.prompt.trim().slice(0, LAST_PROMPT_CAP);
+    await trackPromptForHeader(sessionId, prompt, cwd);
+    deps.noteTitleTurn(sessionId, prompt);
+  } else if (event === "SessionStart" && body.source === "clear") {
+    clearHeaderPrompt(deps, sessionId);
+  } else if (event === "Stop") {
+    void deps.maybeGenerateTitle(sessionId, cwd);
+  }
+}
+
+// Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so
+// we can flag which background sessions have new activity / build tool history.
+async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
+  const body = req.body || {};
+  const sessionId = resolveHookSessionId(req.headers["x-mt-session"], body.session_id, (id) => SESSION_ID_RE.test(id));
+  const event = body.hook_event_name;
+  if (!sessionId && body.session_id) {
+    // Rejecting silently would make hooks look simply broken; the id shape is the
+    // precondition for using it as a Firestore doc id and as push routing.
+    console.warn(`[hook] ignoring ${event} — session id is not a canonical uuid`);
+  }
+  if (sessionId) {
+    const entry = ptys.get(sessionId);
+    const active = !!(entry && entry.active);
+    const cwd = typeof body.cwd === "string" ? body.cwd : entry?.cwd;
+    await applyHeaderHooks(deps, sessionId, event, body, cwd);
+    handleActivityHook(deps, sessionId, event, active, typeof body.message === "string" ? body.message : "");
+    await handleToolHook(deps, sessionId, event, body);
+    // A hidden translation worker that ends its turn while still pending never called
+    // submitTranslation — fail it now rather than hang until the timeout. (When it DID
+    // submit, the entry is already resolved and this reject is a no-op.)
+    if (event === "Stop") failPendingTranslation(sessionId, "[translation] worker ended its turn without calling submitTranslation");
+    console.log(`[hook] ${event} for ${sessionId}`);
+  }
+  res.json({ ok: true });
+}
+
+export function mountHookRoute(app: Express, deps: HookDeps) {
+  // Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so
+  // we can flag which background sessions have new activity / build tool history.
+  app.post("/api/hook", (req, res) => void handleHookRequest(deps, req, res));
+}

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -8,7 +8,7 @@
 // own module: the dependency runs one way. One of them also WRITES — collectPendingSessions
 // drops a session from knownSessions once disk has it — so "reads" describes the direction
 // of the data, not a guarantee of purity.
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -20,6 +20,7 @@ import {
   countUserTurnsFromParsed,
   latestMeaningfulUserPromptFromJsonl,
   latestMeaningfulUserPromptFromParsed,
+  latestAssistantTextFromJsonl,
   latestAssistantTextFromParsed,
   sessionUsageFromParsed,
   latestTurnContextFromParsed,
@@ -40,6 +41,20 @@ import type { DiskStat, PendingSession, SessionMeta } from "./types.js";
 
 // Bytes of an assistant reply kept for the roster; the same cap the push body uses.
 export const LAST_RESPONSE_MAX = 400;
+
+// The reply as it is on disk RIGHT NOW, or null when there is none to read. Separate from
+// the cache below because the two want opposite things on failure: the roster would rather
+// keep showing the last reply it had, while a push must never describe a finished turn with
+// the PREVIOUS turn's text — for that caller, null has to stay null.
+export function readLatestResponse(id: string, cwd: string): string | null {
+  try {
+    const raw = readFileSync(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
+    const text = latestAssistantTextFromJsonl(raw);
+    return text ? text.slice(0, LAST_RESPONSE_MAX) : null;
+  } catch {
+    return null; // no transcript yet / unreadable
+  }
+}
 
 // Whether a session has an on-disk transcript (claude only writes it after the
 // first prompt) in the given workspace. Determines whether `--resume` will work.


### PR DESCRIPTION
## Summary

`/api/hook` エンドポイントとその fan-out を `server/routes/hook-routes.ts` へ切り出しました（#548 step 3g）。

index.ts: **1212 → 1053 行**（-159）

Claude の全フック（Stop / Notification / Pre|PostToolUse / SessionStart）がここに POST され、1 リクエストが「注目フラグ・スマホへの push・ツール履歴・ヘッダーのプロンプト・AI タイトル」へ波及します。長かったのはルートではなくこの fan-out なので、まとめて出しました。

| コミット | 内容 |
|---|---|
| `00428b6` | `readLatestResponse` を `session/session-reads.ts` へ（push 経路と index.ts の双方が使うため先に共有化） |
| `9ad4605` | `/api/hook` と fan-out 一式を `routes/hook-routes.ts` へ |
| `4a6bff3` | Codex 指摘対応（express の promise 伝播） |

## Items to Confirm / Review

- **注入した依存**: `setWorking` / `setWaiting` / `publishActivity` / `forgetTitle` / `noteTitleTurn` / `maybeGenerateTitle` / `recordToolCallStart` / `recordToolCallEnd` / `publishDirConfig` / `uiPort`。`setWorking`・`setWaiting` は第 3 引数 `event` を持つので、そのまま透過することを確認済みです。
- **`publishDirConfig`** は元の `pubsub?.publish(DIR_CONFIG_CHANNEL, { cwd })` と等価（optional chaining 込み）。

## Codex レビューで見つかった実バグ（重要）

ルートを `(req, res) => void handleHookRequest(deps, req, res)` と包んだところ、**promise を捨てていた**という High 指摘を受けました。妥当だったので修正しています。

express 5.2.1 に対して実際に再現したところ、影響は指摘より深刻でした:

| 実装 | フック処理が reject したとき |
|---|---|
| main（inline async） | **500 を返す** |
| 私の `void` 版 | **応答を一切返さず、呼び出し側がタイムアウトまでハングする** |

Claude 側のフックは `curl` で POST するため、失敗時にそのプロセスが待たされることになります。`void` を外して promise を返すよう修正しました。

## 検証

**1. 移動の忠実性** — 6 関数＋ルート本体を `git show main:server/index.ts` と照合。差分は「`deps` を第 1 引数に足す」「`deps.*` への書き換え」のみで、他の引数の順序・内容は不変。

**2. 実行時比較（main と並行起動）** — 7 種のフックイベントを実際に POST:

| 検証 | 結果 |
|---|---|
| UserPromptSubmit / Notification / PreToolUse / PostToolUse / Stop / SessionStart(clear) / 未知イベント | 応答すべて一致 |
| `/api/activity` の副作用（working/waiting/event） | 一致 |
| `/api/tool-calls/<id>` のツール履歴（Pre→Post の完了処理込み） | 内容まで完全一致 |
| 非 UUID の session id | 一致 |
| 修正後の正常系 / 不正 JSON | 200 / 400 |

**3. ローカル Codex レビュー** — 初回 CHANGES REQUESTED（上記）、修正後に再レビューで **LGTM**。

**4. ゲート** — lint 0 error / build / **typecheck・typecheck:server・typecheck:test の 3 種すべて** / 全テスト 154 files・**1839 passed**。

## 次段階

`server/index.ts` は 1053 行。残るのは主に起動・配線（各 mount 呼び出し、pubsub、スケジューラ）と、セッション寿命の中核（`reap` / `setWorking` / `setWaiting` / `publishActivity`）です。後者は多くのモジュールが依存しているので、動かすなら次の候補になります。
