### PR TITLE
feat: detect codex turn boundaries and flag the cell working / done (#582)

### DIFF
--- a/plans/feat-582-codex-activity.md
+++ b/plans/feat-582-codex-activity.md
@@ -1,0 +1,60 @@
+# feat #582 — codex のターン境界を検知して活動フラグを立てる
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/582
+関連: #550 / #574（ターミナル間の会話受け渡し）、#254（Codex と Claude の差分）
+
+## なぜ必要か
+
+グリッドのセル状態は claude の hook（`/api/hook` → `activityHookEffects`）が立てている。`hookSettingsJson` は `spawn-claude.ts` からしか呼ばれず、**codex には hook 機構が無い**。結果 codex セルは永久に idle で、状態表示も注意喚起も鳴らず、#550 Phase 3 が必要とする「ターンが終わった」信号も存在しない。
+
+## rollout が使えることは実測済み
+
+| | |
+|---|---|
+| `task_complete` レコードの timestamp | `2026-07-22T02:23:54.907Z` |
+| rollout ファイルの mtime | `2026-07-22T02:23:54.907461Z` |
+| **フラッシュ遅延** | **0.5 ms** |
+
+#254 が記録していたのは「rollout **ファイル**が最初のユーザーターンまで作られない」ことで、レコード単位の遅延ではなかった。
+
+## 設計
+
+### ポーリング（`fs.watch` は使わない）
+
+`~/.codex/sessions` はユーザープロファイル配下。Windows で 8.3 短縮パスに `fs.watch` を張ると **libuv が `abort()` してプロセスごと落ちる**（catch 不能）。flush が 0.5ms なので 1秒ポーリング＋バイトオフセット追跡で十分。
+
+### リプレイ防止（最重要）
+
+`--resume` した rollout には過去のターンが全部入っている。オフセット 0 から読むと過去の `task_started` / `task_complete` を再生して嘘のフラグを立てる。
+
+- **新規**セッション（`pickFreshSession` が新しく見つけた rollout）→ オフセット **0**
+- **resume** → 監視開始時点の**ファイルサイズ**から
+
+### ファイル構成
+
+| ファイル | 役割 |
+| --- | --- |
+| `server/agents/codex-activity.ts` | **純関数** — 行分割（部分行の持ち越し）、読み取り範囲の決定（切り詰め検知）、ターン境界の抽出、hook イベント名への対応付け |
+| `server/session/codex-activity-watch.ts` | ポーラー。I/O は全て DI |
+| `server/session/spawn-codex.ts` | rollout id が判明した時点で監視を開始、pty が消えたら停止 |
+
+境界は claude と**同じ `activityHookEffects` を通す**。「ターン境界がフラグに何をするか」の定義を1箇所に保つため。
+
+- `task_started` → `UserPromptSubmit` 相当（working）
+- `task_complete` → `Stop` 相当（done・未読）
+
+## 非スコープ
+
+- **`blocked`（承認待ち）の検知** — codex の承認プロンプトは rollout に現れない。working と done のみ
+- Phase 3 の自動ループ本体
+
+## テスト
+
+純関数（`node:test` ではなく既存の vitest に合わせる）:
+
+- 行分割: 部分行の持ち越し / 複数行 / 空 / 末尾改行あり・なし
+- 読み取り範囲: 増加 / 変化なし / **縮小（切り詰め・ローテーション）**
+- 境界抽出: `task_started` / `task_complete` / 両方 / 壊れた行混在 / `turn_context`（`payload.type` を持たない）を誤検知しない
+- リプレイ防止: resume 開始時に過去のターンを再生しないこと
+
+ポーラーは DI したフェイクで、境界が `onBoundary` に届くこと・停止後に呼ばれないことを確認する。

--- a/server/agents/codex-activity.ts
+++ b/server/agents/codex-activity.ts
@@ -6,6 +6,7 @@
 // Everything here is pure: the tailing itself lives in session/codex-activity-watch.ts.
 
 import { isRecord } from "../session/transcript.js";
+import { activityHookEffects, pushKindFor, type ActivityEffect, type PushKind } from "../session/activity-hook.js";
 
 export type CodexTurnBoundary = "started" | "completed";
 
@@ -53,4 +54,17 @@ export function turnBoundaries(lines: string[]): CodexTurnBoundary[] {
     if (type === "task_started") return ["started" as const];
     return type === "task_complete" ? ["completed" as const] : [];
   });
+}
+
+// What a boundary does: the flag changes, and whether the phone should hear about it.
+// Both come from claude's tables so the two agents cannot drift apart — a codex turn that
+// finishes has to notify exactly as a claude Stop does, or half the grid stays silent.
+export interface BoundaryOutcome {
+  effects: ActivityEffect[];
+  push: PushKind | null;
+}
+
+export function boundaryOutcome(boundary: CodexTurnBoundary, active: boolean): BoundaryOutcome {
+  const event = HOOK_EVENT_FOR[boundary];
+  return { effects: activityHookEffects(event, active), push: pushKindFor(event) };
 }

--- a/server/agents/codex-activity.ts
+++ b/server/agents/codex-activity.ts
@@ -1,0 +1,56 @@
+// Reading turn boundaries out of a codex rollout as it is appended to. codex has no
+// hook mechanism — claude reports its own turns via `--settings` hooks, and there is no
+// equivalent flag to pass codex (see docs/codex-vs-claude.md) — so the rollout is the
+// only place a codex turn announces that it started or finished.
+//
+// Everything here is pure: the tailing itself lives in session/codex-activity-watch.ts.
+
+import { isRecord } from "../session/transcript.js";
+
+export type CodexTurnBoundary = "started" | "completed";
+
+// codex boundaries are routed through the SAME effect table as claude's hooks, so what a
+// turn boundary does to the working / attention flags is defined once rather than per
+// agent. codex never reports being blocked on input — its approval prompt is drawn in the
+// TUI and never reaches the rollout — so there is deliberately no Notification here.
+export const HOOK_EVENT_FOR: Record<CodexTurnBoundary, string> = {
+  started: "UserPromptSubmit",
+  completed: "Stop",
+};
+
+// Where to read next, or null when there is nothing new. A file SMALLER than the offset
+// restarted underneath us (truncated, or the id was reused): reading from the stale
+// offset would slice mid-record, so the read starts over from the beginning.
+export function nextReadRange(offset: number, size: number): { from: number; to: number } | null {
+  if (size < offset) return { from: 0, to: size };
+  return size > offset ? { from: offset, to: size } : null;
+}
+
+// A poll can land mid-record, so the trailing fragment is carried to the next tick rather
+// than parsed as a line. Text ending in a newline leaves nothing pending.
+export function takeCompleteLines(pending: string, chunk: string): { lines: string[]; pending: string } {
+  const parts = (pending + chunk).split("\n");
+  return { lines: parts.slice(0, -1).filter((line) => line.trim()), pending: parts[parts.length - 1] };
+}
+
+// The `event_msg` payload type of a line, or null for anything else. A `turn_context` row
+// carries a turn_id but no payload.type, so matching on the payload alone would misread it.
+function eventType(line: string): string | null {
+  try {
+    const doc: unknown = JSON.parse(line);
+    if (!isRecord(doc) || doc.type !== "event_msg" || !isRecord(doc.payload)) return null;
+    return typeof doc.payload.type === "string" ? doc.payload.type : null;
+  } catch {
+    return null; // a row that isn't JSON — codex writes none, but a torn file could
+  }
+}
+
+// The turn boundaries in these lines, oldest first. A turn that both starts and finishes
+// within one poll yields both, in order, so no transition is collapsed away.
+export function turnBoundaries(lines: string[]): CodexTurnBoundary[] {
+  return lines.flatMap((line) => {
+    const type = eventType(line);
+    if (type === "task_started") return ["started" as const];
+    return type === "task_complete" ? ["completed" as const] : [];
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -447,7 +447,8 @@ const spawnDeps: SpawnDeps = {
   hookSettingsJson,
   mcpConfigJson,
   reap: (id) => reap(id),
-  setWorking: (id, working) => setWorking(id, working),
+  setWorking: (id, working, event) => setWorking(id, working, event),
+  setWaiting: (id, waiting, event) => setWaiting(id, waiting, event),
   publishSessionCreated: (sessionId) => pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" }),
 };
 const { spawnClaudePty } = createClaudeSpawner(spawnDeps);

--- a/server/index.ts
+++ b/server/index.ts
@@ -456,6 +456,7 @@ const spawnDeps: SpawnDeps = {
   reap: (id) => reap(id),
   setWorking: (id, working, event) => setWorking(id, working, event),
   setWaiting: (id, waiting, event) => setWaiting(id, waiting, event),
+  uiPort: String(process.env.CLIENT_PORT || PORT),
   publishSessionCreated: (sessionId) => pubsub?.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "created" }),
 };
 const { spawnClaudePty } = createClaudeSpawner(spawnDeps);

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -6,7 +6,7 @@ import type { Express, Request, Response } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
 import { dirConfigWriteTarget } from "../config/dir-config.js";
 import { activityHookEffects, pushKindFor, resolveHookSessionId } from "../session/activity-hook.js";
-import { lastPrompts, ptys } from "../session/registry.js";
+import { lastPrompts, lastResponses, ptys } from "../session/registry.js";
 import { latestUserPrompt } from "../session/session-reads.js";
 import { notifyTaskFinished } from "../session/task-push.js";
 import { preferredHeaderPrompt } from "../session/transcript.js";

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -3,15 +3,12 @@
 // phone, the tool-call history, the header prompt and the AI title. Split from index.ts
 // (#548 step 3g) — the fan-out is what made the route long, not the route itself.
 import type { Express, Request, Response } from "express";
-import path from "node:path";
 import { SESSION_ID_RE } from "../config/env.js";
-import { getPushEnabled } from "../config/config-routes.js";
 import { dirConfigWriteTarget } from "../config/dir-config.js";
-import { sendWebPush } from "../infra/web-push.js";
-import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
-import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId, type PushKind } from "../session/activity-hook.js";
-import { aiTitles, hiddenSessions, lastPrompts, lastResponses, ptys, translationWorkerIds } from "../session/registry.js";
-import { latestUserPrompt, readLatestResponse } from "../session/session-reads.js";
+import { activityHookEffects, pushKindFor, resolveHookSessionId } from "../session/activity-hook.js";
+import { lastPrompts, ptys } from "../session/registry.js";
+import { latestUserPrompt } from "../session/session-reads.js";
+import { notifyTaskFinished } from "../session/task-push.js";
 import { preferredHeaderPrompt } from "../session/transcript.js";
 import { failPendingTranslation } from "../session/translation-worker.js";
 
@@ -49,44 +46,7 @@ function handleActivityHook(deps: HookDeps, sessionId: string, event: string, ac
   // decides the wording. Stop is one event per finished turn, so this fires once even
   // though a background Stop publishes twice.
   const kind = pushKindFor(event);
-  if (kind) notifyTaskFinished(deps, sessionId, kind, message);
-}
-
-const PUSH_TITLE_MAX = 80;
-const PUSH_BODY_MAX = 160;
-// Which port this host's UI answers on, so a receiver can open it instead of guessing.
-// Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server, whose
-// port the backend only knows when CLIENT_PORT is set in its environment (vite.config.ts
-// defaults it separately). Reaching it still requires a receiver on this machine — see the
-// data payload below.
-
-// Notify the user's devices that a background task finished, when Web Push is enabled.
-// Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
-function notifyTaskFinished(deps: HookDeps, sessionId: string, kind: PushKind, message: string): void {
-  if (!getPushEnabled()) return;
-  // Internal helper turns flow through /api/hook with active=false too — hidden background
-  // workers and translation workers aren't real user tasks, so never push for them.
-  if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
-  const cwd = ptys.get(sessionId)?.cwd ?? null;
-  const where = cwd ? path.basename(cwd) : "session";
-  // A finished turn should say what the agent DID — the prompt is what the user already
-  // knows, and reading it back tells them nothing about the outcome. Read it HERE instead
-  // of taking `lastResponses`: publishActivity skips its refresh for an actively-viewed
-  // session (no `waiting` flag) while the push still fires, and the cache deliberately
-  // survives a failed read — either way the map can hold the previous turn's reply, which
-  // is worse than saying nothing. No reply to read falls through to the prompt.
-  const reply = kind === "finished" && cwd ? readLatestResponse(sessionId, cwd) : null;
-  if (reply) lastResponses.set(sessionId, reply); // keep the roster in step; we just read it
-  const detail = (reply ?? "").trim() || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
-  const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
-  // The session id is what lets the phone open this session from the notification;
-  // the host id is what lets it know WHOSE session. Without it the phone opens with
-  // no host selected — it never persists one — and can only offer the picker, which
-  // is where every notification tap used to land (receptron/mulmoserver#86).
-  // `port` is for a receiver running ON this machine, which can then open the local UI
-  // directly (http://localhost:<port>). A phone cannot use it — its own localhost is the
-  // phone — so the receiver has to treat it as optional and keep the existing routing.
-  void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID, port: deps.uiPort });
+  if (kind) void notifyTaskFinished(sessionId, kind, message, deps.uiPort);
 }
 
 interface HookToolPayload {

--- a/server/session/codex-activity-track.ts
+++ b/server/session/codex-activity-track.ts
@@ -12,9 +12,11 @@ export interface CodexActivityTrackDeps {
   setWorking: (id: string, working: boolean, event?: string) => void;
   setWaiting: (id: string, waiting: boolean, event?: string) => void;
   /** Is this session the user's actively-viewed pane? Suppresses the attention flag. */
-  isActive: (id: string) => boolean;
-  /** False once the pty is gone, which is what stops the tail. */
-  isAlive: (id: string) => boolean;
+  isActive: () => boolean;
+  /** False once THIS pty is gone. Must identify the pty, not just its session id: a
+   *  session reaped and respawned under the same id within one poll would otherwise
+   *  leave this tail running beside the new one, reporting every boundary twice. */
+  isAlive: () => boolean;
 }
 
 const readSliceOf =
@@ -40,7 +42,7 @@ const sizeOf = (file: string) => async (): Promise<number | null> => {
 
 function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: CodexActivityTrackDeps): void {
   const event = HOOK_EVENT_FOR[boundary];
-  for (const eff of activityHookEffects(event, deps.isActive(sessionId))) {
+  for (const eff of activityHookEffects(event, deps.isActive())) {
     if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
     else deps.setWaiting(sessionId, eff.value, event);
   }
@@ -54,7 +56,7 @@ export function trackCodexActivity(sessionId: string, file: string, startAtEnd: 
     fileSize: sizeOf(file),
     readSlice: readSliceOf(file),
     onBoundary: (boundary) => applyBoundary(sessionId, boundary, deps),
-    isAlive: () => deps.isAlive(sessionId),
+    isAlive: deps.isAlive,
     startAtEnd,
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   }).catch(() => {}); // a rollout that vanishes mid-session just stops reporting

--- a/server/session/codex-activity-track.ts
+++ b/server/session/codex-activity-track.ts
@@ -1,0 +1,61 @@
+// Wiring a codex session's rollout tail to its activity flags: the filesystem side of
+// codex-activity-watch, plus the translation from a turn boundary to the same effects
+// claude's hooks produce. Kept out of the spawner so starting a PTY stays about starting
+// a PTY.
+
+import { promises as fs } from "node:fs";
+import { HOOK_EVENT_FOR, type CodexTurnBoundary } from "../agents/codex-activity.js";
+import { activityHookEffects } from "./activity-hook.js";
+import { watchCodexActivity } from "./codex-activity-watch.js";
+
+export interface CodexActivityTrackDeps {
+  setWorking: (id: string, working: boolean, event?: string) => void;
+  setWaiting: (id: string, waiting: boolean, event?: string) => void;
+  /** Is this session the user's actively-viewed pane? Suppresses the attention flag. */
+  isActive: (id: string) => boolean;
+  /** False once the pty is gone, which is what stops the tail. */
+  isAlive: (id: string) => boolean;
+}
+
+const readSliceOf =
+  (file: string) =>
+  async (from: number, to: number): Promise<string> => {
+    const handle = await fs.open(file, "r");
+    try {
+      const buf = Buffer.alloc(to - from);
+      const { bytesRead } = await handle.read(buf, 0, buf.length, from);
+      return buf.subarray(0, bytesRead).toString("utf8");
+    } finally {
+      await handle.close();
+    }
+  };
+
+const sizeOf = (file: string) => async (): Promise<number | null> => {
+  try {
+    return (await fs.stat(file)).size;
+  } catch {
+    return null; // not written yet, or removed under us
+  }
+};
+
+function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: CodexActivityTrackDeps): void {
+  const event = HOOK_EVENT_FOR[boundary];
+  for (const eff of activityHookEffects(event, deps.isActive(sessionId))) {
+    if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
+    else deps.setWaiting(sessionId, eff.value, event);
+  }
+}
+
+// Start tailing; it stops on its own once the session is gone. `startAtEnd` skips a
+// resumed rollout's history — replaying it would flag the cell from turns that finished
+// days ago.
+export function trackCodexActivity(sessionId: string, file: string, startAtEnd: boolean, deps: CodexActivityTrackDeps): void {
+  watchCodexActivity({
+    fileSize: sizeOf(file),
+    readSlice: readSliceOf(file),
+    onBoundary: (boundary) => applyBoundary(sessionId, boundary, deps),
+    isAlive: () => deps.isAlive(sessionId),
+    startAtEnd,
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  }).catch(() => {}); // a rollout that vanishes mid-session just stops reporting
+}

--- a/server/session/codex-activity-track.ts
+++ b/server/session/codex-activity-track.ts
@@ -4,8 +4,8 @@
 // a PTY.
 
 import { promises as fs } from "node:fs";
-import { HOOK_EVENT_FOR, type CodexTurnBoundary } from "../agents/codex-activity.js";
-import { activityHookEffects } from "./activity-hook.js";
+import { HOOK_EVENT_FOR, boundaryOutcome, type CodexTurnBoundary } from "../agents/codex-activity.js";
+import { notifyTaskFinished } from "./task-push.js";
 import { watchCodexActivity } from "./codex-activity-watch.js";
 
 export interface CodexActivityTrackDeps {
@@ -13,6 +13,8 @@ export interface CodexActivityTrackDeps {
   setWaiting: (id: string, waiting: boolean, event?: string) => void;
   /** Is this session the user's actively-viewed pane? Suppresses the attention flag. */
   isActive: () => boolean;
+  /** Which port this host's UI answers on, so a notification can open it. */
+  uiPort: string;
   /** False once THIS pty is gone. Must identify the pty, not just its session id: a
    *  session reaped and respawned under the same id within one poll would otherwise
    *  leave this tail running beside the new one, reporting every boundary twice. */
@@ -42,10 +44,14 @@ const sizeOf = (file: string) => async (): Promise<number | null> => {
 
 function applyBoundary(sessionId: string, boundary: CodexTurnBoundary, deps: CodexActivityTrackDeps): void {
   const event = HOOK_EVENT_FOR[boundary];
-  for (const eff of activityHookEffects(event, deps.isActive())) {
+  const { effects, push } = boundaryOutcome(boundary, deps.isActive());
+  for (const eff of effects) {
     if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
     else deps.setWaiting(sessionId, eff.value, event);
   }
+  // `message` is empty: codex has no Notification equivalent, and a finished turn's body
+  // comes from its reply, not from a hook payload.
+  if (push) void notifyTaskFinished(sessionId, push, "", deps.uiPort);
 }
 
 // Start tailing; it stops on its own once the session is gone. `startAtEnd` skips a

--- a/server/session/codex-activity-watch.ts
+++ b/server/session/codex-activity-watch.ts
@@ -1,0 +1,51 @@
+// Tail a live codex session's rollout and report each turn boundary it appends.
+//
+// Polling, not fs.watch: the rollout lives under the user's profile, and on Windows a
+// watch opened on an 8.3 short path makes libuv abort() the whole process — uncatchable
+// by try/catch, on("error"), or uncaughtException. codex flushes each record immediately
+// (measured at 0.5 ms), so a one-second poll costs a negligible amount of detection lag
+// and none of that risk.
+//
+// Every dependency is injected so the loop can be driven with fakes: the real one reads
+// the filesystem and mutates session flags, neither of which a test should need.
+
+import { nextReadRange, takeCompleteLines, turnBoundaries, type CodexTurnBoundary } from "../agents/codex-activity.js";
+
+export const CODEX_ACTIVITY_POLL_MS = 1000;
+
+export interface CodexActivityDeps {
+  /** Byte length of the rollout, or null while it doesn't exist yet. */
+  fileSize: () => Promise<number | null>;
+  /** The rollout's bytes in [from, to). */
+  readSlice: (from: number, to: number) => Promise<string>;
+  onBoundary: (boundary: CodexTurnBoundary) => void;
+  /** False once the session's pty is gone — the loop stops on the next tick. */
+  isAlive: () => boolean;
+  /** Resume only: skip what the rollout already holds. A fresh session starts at 0 so its
+   *  first turn isn't missed; a resumed one would otherwise REPLAY every past turn and
+   *  leave the cell flagged from history rather than from what is happening now. */
+  startAtEnd: boolean;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export async function watchCodexActivity(deps: CodexActivityDeps): Promise<void> {
+  let offset = deps.startAtEnd ? await startingOffset(deps) : 0;
+  let pending = "";
+  while (deps.isAlive()) {
+    await deps.sleep(CODEX_ACTIVITY_POLL_MS);
+    if (!deps.isAlive()) return;
+    const size = await deps.fileSize();
+    if (size === null) continue; // rollout not written yet (codex creates it on the first turn)
+    const range = nextReadRange(offset, size);
+    if (!range) continue;
+    if (range.from === 0 && offset > 0) pending = ""; // the file restarted — the fragment is stale
+    const taken = takeCompleteLines(pending, await deps.readSlice(range.from, range.to));
+    pending = taken.pending;
+    offset = range.to;
+    turnBoundaries(taken.lines).forEach(deps.onBoundary);
+  }
+}
+
+// A rollout that doesn't exist yet has no history to skip, so a resume that beat codex to
+// the file still starts from 0 and sees its first turn.
+const startingOffset = async (deps: CodexActivityDeps): Promise<number> => (await deps.fileSize()) ?? 0;

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -15,16 +15,17 @@ import { appendBoundedOutput } from "./terminal-replay.js";
 import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
-export function createCodexSpawner(deps: SpawnDeps) {
-  // Bound to ONE pty: `ptys.has(id)` would keep a stale tail alive after a reap-then-
-  // respawn under the same id, and both tails would report the same boundaries.
-  const activityDepsFor = (sessionId: string, entry: PtyEntry) => ({
-    setWorking: deps.setWorking,
-    setWaiting: deps.setWaiting,
-    isActive: () => ptys.get(sessionId)?.active ?? false,
-    isAlive: () => ptys.get(sessionId) === entry,
-  });
+// Bound to ONE pty: `ptys.has(id)` would keep a stale tail alive after a reap-then-
+// respawn under the same id, and both tails would report the same boundaries.
+const activityDepsFor = (sessionId: string, entry: PtyEntry, deps: SpawnDeps) => ({
+  setWorking: deps.setWorking,
+  setWaiting: deps.setWaiting,
+  isActive: () => ptys.get(sessionId)?.active ?? false,
+  uiPort: deps.uiPort,
+  isAlive: () => ptys.get(sessionId) === entry,
+});
 
+export function createCodexSpawner(deps: SpawnDeps) {
   function wireCodexRelay(entry: PtyEntry, sessionId: string, onOutput?: (data: string) => void): void {
     entry.term.onData((data) => {
       entry.buffer = appendBoundedOutput(entry.buffer, data, deps.outputBufferLimit);
@@ -49,7 +50,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
         codexRolloutIds.set(sessionId, meta.id);
         // A rollout only discovered now is one this session just created, so it is read
         // whole: its first turn is in there and hasn't been reported yet.
-        trackCodexActivity(sessionId, meta.file, false, activityDepsFor(sessionId, entry));
+        trackCodexActivity(sessionId, meta.file, false, activityDepsFor(sessionId, entry, deps));
       })
       .catch(() => {});
   }
@@ -77,7 +78,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
     if (resumeRolloutId) {
       codexRolloutIds.set(sessionId, resumeRolloutId);
       const file = codexRolloutPath(root, resumeRolloutId);
-      if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry));
+      if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry, deps));
     } else {
       // Discover the id only for a FRESH session. On resume we already know it; running the watcher
       // could overwrite the known id with a mis-attributed concurrent rollout.

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -16,12 +16,14 @@ import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
 export function createCodexSpawner(deps: SpawnDeps) {
-  const activityDeps = {
+  // Bound to ONE pty: `ptys.has(id)` would keep a stale tail alive after a reap-then-
+  // respawn under the same id, and both tails would report the same boundaries.
+  const activityDepsFor = (sessionId: string, entry: PtyEntry) => ({
     setWorking: deps.setWorking,
     setWaiting: deps.setWaiting,
-    isActive: (id: string) => ptys.get(id)?.active ?? false,
-    isAlive: (id: string) => ptys.has(id),
-  };
+    isActive: () => ptys.get(sessionId)?.active ?? false,
+    isAlive: () => ptys.get(sessionId) === entry,
+  });
 
   function wireCodexRelay(entry: PtyEntry, sessionId: string, onOutput?: (data: string) => void): void {
     entry.term.onData((data) => {
@@ -39,7 +41,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
   // codex persists its rollout only after the first user turn, so watch a FRESH session's lifetime
   // (stop once its pty is gone) and capture the minted id so a later cold reconnect can
   // `codex resume <id>`. Attribution is unambiguous-only (see pickFreshSession).
-  function rememberCodexRollout(sessionId: string, root: string, before: Set<string>, cwd: string): void {
+  function rememberCodexRollout(sessionId: string, entry: PtyEntry, root: string, before: Set<string>, cwd: string): void {
     watchForCodexSession(root, before, { cwd, claimed: claimedCodexRollouts, isCancelled: () => !ptys.has(sessionId) })
       .then((meta) => {
         if (!meta) return;
@@ -47,7 +49,7 @@ export function createCodexSpawner(deps: SpawnDeps) {
         codexRolloutIds.set(sessionId, meta.id);
         // A rollout only discovered now is one this session just created, so it is read
         // whole: its first turn is in there and hasn't been reported yet.
-        trackCodexActivity(sessionId, meta.file, false, activityDeps);
+        trackCodexActivity(sessionId, meta.file, false, activityDepsFor(sessionId, entry));
       })
       .catch(() => {});
   }
@@ -75,11 +77,11 @@ export function createCodexSpawner(deps: SpawnDeps) {
     if (resumeRolloutId) {
       codexRolloutIds.set(sessionId, resumeRolloutId);
       const file = codexRolloutPath(root, resumeRolloutId);
-      if (file) trackCodexActivity(sessionId, file, true, activityDeps);
+      if (file) trackCodexActivity(sessionId, file, true, activityDepsFor(sessionId, entry));
     } else {
       // Discover the id only for a FRESH session. On resume we already know it; running the watcher
       // could overwrite the known id with a mis-attributed concurrent rollout.
-      rememberCodexRollout(sessionId, root, before, cwd);
+      rememberCodexRollout(sessionId, entry, root, before, cwd);
     }
     // A seed prompt is typed into codex's input box after it settles (not a CLI arg — see
     // attachCodexAutoRun), so a long collection-action prompt can't overflow tmux's command limit.

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -5,6 +5,8 @@ import type { WebSocket } from "ws";
 import { PORT } from "../config/env.js";
 import { buildCodexArgs } from "../agents/codex-args.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../agents/codex-session.js";
+import { codexRolloutPath } from "../agents/codex-sessions.js";
+import { trackCodexActivity } from "./codex-activity-track.js";
 import { claimedCodexRollouts, codexRolloutIds, ptys } from "./registry.js";
 import { ptySpawn } from "./pty-spawn.js";
 import { attachCodexAutoRun } from "./draft-injection.js";
@@ -14,6 +16,13 @@ import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
 export function createCodexSpawner(deps: SpawnDeps) {
+  const activityDeps = {
+    setWorking: deps.setWorking,
+    setWaiting: deps.setWaiting,
+    isActive: (id: string) => ptys.get(id)?.active ?? false,
+    isAlive: (id: string) => ptys.has(id),
+  };
+
   function wireCodexRelay(entry: PtyEntry, sessionId: string, onOutput?: (data: string) => void): void {
     entry.term.onData((data) => {
       entry.buffer = appendBoundedOutput(entry.buffer, data, deps.outputBufferLimit);
@@ -36,6 +45,9 @@ export function createCodexSpawner(deps: SpawnDeps) {
         if (!meta) return;
         claimedCodexRollouts.add(meta.file);
         codexRolloutIds.set(sessionId, meta.id);
+        // A rollout only discovered now is one this session just created, so it is read
+        // whole: its first turn is in there and hasn't been reported yet.
+        trackCodexActivity(sessionId, meta.file, false, activityDeps);
       })
       .catch(() => {});
   }
@@ -62,6 +74,8 @@ export function createCodexSpawner(deps: SpawnDeps) {
     ptys.set(sessionId, entry);
     if (resumeRolloutId) {
       codexRolloutIds.set(sessionId, resumeRolloutId);
+      const file = codexRolloutPath(root, resumeRolloutId);
+      if (file) trackCodexActivity(sessionId, file, true, activityDeps);
     } else {
       // Discover the id only for a FRESH session. On resume we already know it; running the watcher
       // could overwrite the known id with a mis-attributed concurrent rollout.

--- a/server/session/spawn-deps.ts
+++ b/server/session/spawn-deps.ts
@@ -13,7 +13,10 @@ export interface SpawnDeps {
   hookSettingsJson: (host: string, sessionId: string) => string;
   mcpConfigJson: (sessionId: string, host?: string, sandbox?: boolean) => string;
   reap: (id: string) => void;
-  setWorking: (id: string, working: boolean) => void;
+  setWorking: (id: string, working: boolean, event?: string) => void;
+  /** Needed alongside setWorking because a finished codex turn flags the cell for attention,
+   *  exactly as claude's Stop hook does — see codex-activity-watch. */
+  setWaiting: (id: string, waiting: boolean, event?: string) => void;
   /** Surface a brand-new session in the sidebar before it is persisted. */
   publishSessionCreated: (sessionId: string) => void;
 }

--- a/server/session/spawn-deps.ts
+++ b/server/session/spawn-deps.ts
@@ -17,6 +17,8 @@ export interface SpawnDeps {
   /** Needed alongside setWorking because a finished codex turn flags the cell for attention,
    *  exactly as claude's Stop hook does — see codex-activity-watch. */
   setWaiting: (id: string, waiting: boolean, event?: string) => void;
+  /** Which port this host's UI answers on, so a codex completion notification can open it. */
+  uiPort: string;
   /** Surface a brand-new session in the sidebar before it is persisted. */
   publishSessionCreated: (sessionId: string) => void;
 }

--- a/server/session/task-push.ts
+++ b/server/session/task-push.ts
@@ -1,0 +1,51 @@
+// Telling the user's phone that a turn ended or is blocked. Split out of hook-routes
+// because claude is no longer the only thing that finishes a turn: codex reports its
+// boundaries off its rollout (no hooks exist to POST for it), and a codex turn has to
+// reach the same notification, or the phone stays silent for half the grid.
+
+import path from "node:path";
+import { getPushEnabled } from "../config/config-routes.js";
+import { sendWebPush } from "../infra/web-push.js";
+import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
+import { buildPushText, type PushKind } from "./activity-hook.js";
+import { aiTitles, hiddenSessions, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
+import { sessionLastTurn } from "./session-reads.js";
+
+const PUSH_TITLE_MAX = 80;
+const PUSH_BODY_MAX = 160;
+
+// A finished turn should say what the agent DID — the prompt is what the user already
+// knows, and reading it back tells them nothing about the outcome. Read it HERE instead
+// of taking `lastResponses`: publishActivity skips its refresh for an actively-viewed
+// session (no `waiting` flag) while the push still fires, and the cache deliberately
+// survives a failed read — either way the map can hold the previous turn's reply, which
+// is worse than saying nothing. Which log to read depends on the agent, so it goes
+// through sessionLastTurn rather than assuming a claude transcript.
+async function latestReply(sessionId: string, cwd: string): Promise<string | null> {
+  const agent = ptys.get(sessionId)?.agent === "codex" ? "codex" : "claude";
+  const turn = await sessionLastTurn(cwd, sessionId, agent);
+  return turn.reply?.trim() || null;
+}
+
+// Notify the user's devices that a turn finished or is blocked, when Web Push is enabled.
+// Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
+export async function notifyTaskFinished(sessionId: string, kind: PushKind, message: string, uiPort: string): Promise<void> {
+  if (!getPushEnabled()) return;
+  // Internal helper turns flow through /api/hook with active=false too — hidden background
+  // workers and translation workers aren't real user tasks, so never push for them.
+  if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
+  const cwd = ptys.get(sessionId)?.cwd ?? null;
+  const where = cwd ? path.basename(cwd) : "session";
+  const reply = kind === "finished" && cwd ? await latestReply(sessionId, cwd) : null;
+  if (reply) lastResponses.set(sessionId, reply); // keep the roster in step; we just read it
+  const detail = reply || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+  const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
+  // The session id is what lets the phone open this session from the notification;
+  // the host id is what lets it know WHOSE session. Without it the phone opens with
+  // no host selected — it never persists one — and can only offer the picker, which
+  // is where every notification tap used to land (receptron/mulmoserver#86).
+  // `port` is for a receiver running ON this machine, which can then open the local UI
+  // directly (http://localhost:<port>). A phone cannot use it — its own localhost is the
+  // phone — so the receiver has to treat it as optional and keep the existing routing.
+  void sendWebPush(title, body, { sessionId, hostId: REMOTE_HOST_ID, port: uiPort });
+}

--- a/server/session/task-push.ts
+++ b/server/session/task-push.ts
@@ -9,7 +9,7 @@ import { sendWebPush } from "../infra/web-push.js";
 import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
 import { buildPushText, type PushKind } from "./activity-hook.js";
 import { aiTitles, hiddenSessions, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
-import { sessionLastTurn } from "./session-reads.js";
+import { sessionLastTurn, LAST_RESPONSE_MAX } from "./session-reads.js";
 
 const PUSH_TITLE_MAX = 80;
 const PUSH_BODY_MAX = 160;
@@ -24,7 +24,10 @@ const PUSH_BODY_MAX = 160;
 async function latestReply(sessionId: string, cwd: string): Promise<string | null> {
   const agent = ptys.get(sessionId)?.agent === "codex" ? "codex" : "claude";
   const turn = await sessionLastTurn(cwd, sessionId, agent);
-  return turn.reply?.trim() || null;
+  const reply = turn.reply?.trim();
+  // Capped like every other writer of lastResponses — the map is declared as holding
+  // truncated text, and it is served in the roster payload for every listed session.
+  return reply ? reply.slice(0, LAST_RESPONSE_MAX) : null;
 }
 
 // Notify the user's devices that a turn finished or is blocked, when Web Push is enabled.

--- a/test/server/agents/codex-activity.spec.ts
+++ b/test/server/agents/codex-activity.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { nextReadRange, takeCompleteLines, turnBoundaries, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
+import { nextReadRange, takeCompleteLines, turnBoundaries, boundaryOutcome, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
 
 const line = (o: unknown) => JSON.stringify(o);
 const started = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } });
@@ -92,5 +92,31 @@ describe("HOOK_EVENT_FOR", () => {
   it("routes codex boundaries through claude's effect table, so the rules live in one place", () => {
     expect(HOOK_EVENT_FOR.started).toBe("UserPromptSubmit");
     expect(HOOK_EVENT_FOR.completed).toBe("Stop");
+  });
+});
+
+describe("boundaryOutcome", () => {
+  it("notifies the phone when a turn finishes, exactly as claude's Stop does", () => {
+    // The regression this guards: setting the flags but never reaching the push path, so
+    // a finished codex turn left the phone silent while a claude one notified.
+    const { effects, push } = boundaryOutcome("completed", false);
+    expect(push).toBe("finished");
+    expect(effects).toEqual([
+      { kind: "waiting", value: true },
+      { kind: "working", value: false },
+    ]);
+  });
+
+  it("does not notify when a turn merely starts", () => {
+    const { effects, push } = boundaryOutcome("started", false);
+    expect(push).toBeNull();
+    expect(effects).toEqual([{ kind: "working", value: true }]);
+  });
+
+  it("suppresses the attention flag for the pane the user is looking at", () => {
+    const { effects, push } = boundaryOutcome("completed", true);
+    expect(effects).toEqual([{ kind: "working", value: false }]);
+    // The phone is elsewhere, so it is told regardless of what is on screen here.
+    expect(push).toBe("finished");
   });
 });

--- a/test/server/agents/codex-activity.spec.ts
+++ b/test/server/agents/codex-activity.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { nextReadRange, takeCompleteLines, turnBoundaries, HOOK_EVENT_FOR } from "../../../server/agents/codex-activity.js";
+
+const line = (o: unknown) => JSON.stringify(o);
+const started = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } });
+const complete = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_complete", turn_id: turnId, last_agent_message: "done" } });
+const agentMessage = () => line({ type: "event_msg", payload: { type: "agent_message", message: "thinking" } });
+// A turn_context row carries a turn_id but no payload.type — the shape most likely to be
+// misread as a boundary.
+const turnContext = (turnId = "t1") => line({ type: "turn_context", payload: { turn_id: turnId, cwd: "/w" } });
+
+describe("nextReadRange", () => {
+  it("reads the appended bytes when the file grew", () => {
+    expect(nextReadRange(100, 250)).toEqual({ from: 100, to: 250 });
+  });
+
+  it("reads nothing when the file is unchanged", () => {
+    expect(nextReadRange(100, 100)).toBeNull();
+  });
+
+  it("starts over when the file shrank, rather than slicing from a stale offset", () => {
+    expect(nextReadRange(100, 40)).toEqual({ from: 0, to: 40 });
+  });
+
+  it("handles the first read of a file that already has content", () => {
+    expect(nextReadRange(0, 80)).toEqual({ from: 0, to: 80 });
+  });
+
+  it("reads nothing from an empty file", () => {
+    expect(nextReadRange(0, 0)).toBeNull();
+  });
+});
+
+describe("takeCompleteLines", () => {
+  it("returns whole lines and keeps the trailing fragment", () => {
+    expect(takeCompleteLines("", "a\nb\nhalf")).toEqual({ lines: ["a", "b"], pending: "half" });
+  });
+
+  it("joins a fragment carried from the previous poll", () => {
+    const first = takeCompleteLines("", '{"ty');
+    expect(first.lines).toEqual([]);
+    expect(takeCompleteLines(first.pending, 'pe":"x"}\n').lines).toEqual(['{"type":"x"}']);
+  });
+
+  it("leaves nothing pending when the chunk ends on a newline", () => {
+    expect(takeCompleteLines("", "a\nb\n")).toEqual({ lines: ["a", "b"], pending: "" });
+  });
+
+  it("drops blank lines rather than passing them on as records", () => {
+    expect(takeCompleteLines("", "a\n\n\nb\n").lines).toEqual(["a", "b"]);
+  });
+
+  it("is empty for an empty chunk", () => {
+    expect(takeCompleteLines("", "")).toEqual({ lines: [], pending: "" });
+  });
+});
+
+describe("turnBoundaries", () => {
+  it("reports a turn starting and finishing, in order", () => {
+    expect(turnBoundaries([started(), agentMessage(), complete()])).toEqual(["started", "completed"]);
+  });
+
+  it("reports several turns from one poll without collapsing any", () => {
+    expect(turnBoundaries([started("t1"), complete("t1"), started("t2"), complete("t2")])).toEqual(["started", "completed", "started", "completed"]);
+  });
+
+  it("ignores rows that are not turn boundaries", () => {
+    expect(turnBoundaries([agentMessage(), line({ type: "response_item", payload: { type: "message" } })])).toEqual([]);
+  });
+
+  it("does not mistake a turn_context row for a boundary", () => {
+    expect(turnBoundaries([turnContext()])).toEqual([]);
+  });
+
+  it("only treats event_msg rows as boundaries, whatever their payload says", () => {
+    // Guards the `doc.type === "event_msg"` check specifically: the turn_context case
+    // above passes with or without it, since that row has no payload.type at all.
+    const impostor = line({ type: "response_item", payload: { type: "task_complete", last_agent_message: "no" } });
+    expect(turnBoundaries([impostor])).toEqual([]);
+  });
+
+  it("skips a torn line instead of throwing", () => {
+    expect(turnBoundaries(['{"type":"event_msg", "payl', complete()])).toEqual(["completed"]);
+  });
+
+  it("is empty for no lines", () => {
+    expect(turnBoundaries([])).toEqual([]);
+  });
+});
+
+describe("HOOK_EVENT_FOR", () => {
+  it("routes codex boundaries through claude's effect table, so the rules live in one place", () => {
+    expect(HOOK_EVENT_FOR.started).toBe("UserPromptSubmit");
+    expect(HOOK_EVENT_FOR.completed).toBe("Stop");
+  });
+});

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -111,3 +111,29 @@ describe("watchCodexActivity", () => {
     expect(boundaries).toEqual([]);
   });
 });
+
+describe("watcher lifetime", () => {
+  it("reports nothing more once its pty has been replaced", async () => {
+    // The regression this guards: binding the tail to `ptys.has(id)` rather than to the
+    // pty itself. A session reaped and respawned under the SAME id within one poll would
+    // leave the old tail alive next to the new one, reporting every boundary twice.
+    const ownPty = { id: 1 };
+    let current: { id: number } | undefined = ownPty;
+    const boundaries: CodexTurnBoundary[] = [];
+    let content = "";
+    let ticks = 0;
+    await watchCodexActivity({
+      fileSize: async () => Buffer.byteLength(content),
+      readSlice: async (from, to) => Buffer.from(content).subarray(from, to).toString(),
+      onBoundary: (b) => boundaries.push(b),
+      isAlive: () => current === ownPty,
+      startAtEnd: false,
+      sleep: async () => {
+        ticks += 1;
+        if (ticks === 1) current = { id: 2 }; // reaped and respawned under the same id
+        content += started();
+      },
+    });
+    expect(boundaries).toEqual([]);
+  });
+});

--- a/test/server/session/codex-activity-watch.spec.ts
+++ b/test/server/session/codex-activity-watch.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { watchCodexActivity, type CodexActivityDeps } from "../../../server/session/codex-activity-watch.js";
+import type { CodexTurnBoundary } from "../../../server/agents/codex-activity.js";
+
+const line = (o: unknown) => JSON.stringify(o);
+const started = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } }) + "\n";
+const complete = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_complete", turn_id: turnId, last_agent_message: "done" } }) + "\n";
+
+// A fake rollout the test appends to, driving the loop one tick at a time. `sleep`
+// resolves immediately, and the loop is stopped by a tick budget rather than a timer.
+function harness(initial: string, startAtEnd: boolean) {
+  let content = initial;
+  let ticks = 0;
+  const maxTicks = 12;
+  const boundaries: CodexTurnBoundary[] = [];
+  const appendAtTick: Map<number, string> = new Map();
+  let missing = false;
+
+  const deps: CodexActivityDeps = {
+    fileSize: async () => (missing ? null : Buffer.byteLength(content)),
+    readSlice: async (from, to) => Buffer.from(content).subarray(from, to).toString(),
+    onBoundary: (b) => boundaries.push(b),
+    isAlive: () => ticks < maxTicks,
+    startAtEnd,
+    sleep: async () => {
+      ticks += 1;
+      const add = appendAtTick.get(ticks);
+      if (add !== undefined) content += add;
+    },
+  };
+  return {
+    deps,
+    boundaries,
+    appendAt: (tick: number, text: string) => appendAtTick.set(tick, text),
+    setMissing: (v: boolean) => (missing = v),
+    run: () => watchCodexActivity(deps),
+  };
+}
+
+describe("watchCodexActivity", () => {
+  it("reports the boundaries appended while it runs", async () => {
+    const h = harness("", false);
+    h.appendAt(1, started());
+    h.appendAt(3, complete());
+    await h.run();
+    expect(h.boundaries).toEqual(["started", "completed"]);
+  });
+
+  it("reads a fresh session's existing content, so its first turn isn't missed", async () => {
+    const h = harness(started(), false);
+    await h.run();
+    expect(h.boundaries).toEqual(["started"]);
+  });
+
+  it("does NOT replay a resumed rollout's history", async () => {
+    // The regression this guards: starting a resumed session at offset 0 would re-report
+    // every past turn and leave the cell flagged from history rather than from now.
+    const h = harness(started("old") + complete("old"), true);
+    await h.run();
+    expect(h.boundaries).toEqual([]);
+  });
+
+  it("still reports a resumed session's NEW turns", async () => {
+    const h = harness(started("old") + complete("old"), true);
+    h.appendAt(2, started("new"));
+    h.appendAt(4, complete("new"));
+    await h.run();
+    expect(h.boundaries).toEqual(["started", "completed"]);
+  });
+
+  it("joins a record split across two polls", async () => {
+    const whole = complete();
+    const h = harness("", false);
+    h.appendAt(1, whole.slice(0, 20));
+    h.appendAt(2, whole.slice(20));
+    await h.run();
+    expect(h.boundaries).toEqual(["completed"]);
+  });
+
+  it("waits without failing while the rollout does not exist yet", async () => {
+    const h = harness("", false);
+    h.setMissing(true);
+    h.appendAt(2, started());
+    await h.run();
+    expect(h.boundaries).toEqual([]); // never readable, so nothing reported — and no throw
+  });
+
+  it("starts a resumed session at 0 when the rollout isn't on disk yet", async () => {
+    const h = harness("", true);
+    h.appendAt(1, started());
+    await h.run();
+    expect(h.boundaries).toEqual(["started"]);
+  });
+
+  it("stops once the session is gone", async () => {
+    let alive = true;
+    const boundaries: CodexTurnBoundary[] = [];
+    let content = "";
+    const deps: CodexActivityDeps = {
+      fileSize: async () => Buffer.byteLength(content),
+      readSlice: async (from, to) => Buffer.from(content).subarray(from, to).toString(),
+      onBoundary: (b) => boundaries.push(b),
+      isAlive: () => alive,
+      startAtEnd: false,
+      sleep: async () => {
+        alive = false; // the pty went away during the wait
+        content += started();
+      },
+    };
+    await watchCodexActivity(deps);
+    expect(boundaries).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #582. Groundwork for #550 Phase 3.

## Summary

**codex セルがグリッド上で永久に idle だった問題を直す。** 活動フラグは claude の hook が立てているが、`hookSettingsJson` は `spawn-claude.ts` からしか呼ばれない — **codex には hook 機構が無い**。

codex の rollout にはターン境界が記録されている（`task_started` / `task_complete`）ので、それを追ってフラグを立てる。

実機で確認した遷移:

| 時刻 | 活動フラグ |
|---|---|
| 0.5s | `working:false, waiting:false` （idle） |
| 5.5s | `working:true, event:"UserPromptSubmit"` （ターン開始） |
| 7.0s | `working:false, waiting:true, event:"Stop"` （ターン終了 = done） |

これで codex でも状態表示・注意喚起・Web Push が機能し、#550 Phase 3 が必要とする「ターンが終わった」信号が得られる。

## Items to Confirm / Review

1. **`fs.watch` ではなくポーリングにした理由** — `~/.codex/sessions` はユーザープロファイル配下。Windows で 8.3 短縮パスに `fs.watch` を張ると **libuv が `abort()` してプロセスごと落ちる**（`try`/`catch`・`on("error")`・`uncaughtException` すべて素通り）。実測で codex の flush は **0.5ms** なので、1秒ポーリングで検知遅延はほぼ無く、この危険を完全に避けられる。この判断を見てほしい

2. **リプレイ防止**（いちばん危ない箇所）— `--resume` した rollout には過去のターンが全部入っている。オフセット 0 から読むと**何日も前に終わったターンでセルにフラグを立てる**。新規は 0 から、resume は開始時のファイルサイズから読む。テストで「壊すと赤くなる」ことを確認済み

3. **`blocked` は検知しない（意図的）** — codex の承認プロンプトは TUI に描かれるだけで rollout に現れない。working と done のみ扱う。claude と挙動が揃わない点を許容してよいか

4. **`activityHookEffects` を共有した** — codex の境界を claude の hook イベント名（`UserPromptSubmit` / `Stop`）に対応付けて同じ効果テーブルに通している。「ターン境界がフラグに何をするか」を1箇所に保つため。エージェント名を借りるのが妥当か、別テーブルにすべきか

5. **`SpawnDeps` に `setWaiting` を追加した** — 終了したターンがセルを注意喚起状態にするのに必要（claude の Stop と同じ）

## User Prompt

> Phase 3進めて

#550 Phase 3（自動収束ループ）に着手するにあたり実現可能性を調査したところ、**要となるターン終了検知が codex 側に存在しない**ことが判明した。ユーザーと相談し、「まず codex の検知だけ作る」方針で合意（ループ本体は後続）。単体でも価値がある（グリッドで codex の状態が見える、注意喚起が鳴る）ため。

## 調査で判明した、計画の誤り

`plans/done/feat-550-terminal-handoff.md` に「#254 の遅延書き込みがあるのでポーリング前提」と書いていたが、実測すると:

| | |
|---|---|
| `task_complete` レコードの timestamp | `2026-07-22T02:23:54.907Z` |
| rollout ファイルの mtime | `2026-07-22T02:23:54.907461Z` |
| **フラッシュ遅延** | **0.5 ms** |

#254 が記録していたのは「rollout **ファイル自体**が最初のユーザーターンまで作られない」という別の話で、レコード単位の遅延ではなかった。2つを混同していた。

## 実装

計画ファイル: `plans/feat-582-codex-activity.md`

| ファイル | 役割 |
| --- | --- |
| `server/agents/codex-activity.ts` | **純関数** — 行分割（部分行の持ち越し）、読み取り範囲の決定（切り詰め検知）、ターン境界抽出、hook イベント名への対応付け |
| `server/session/codex-activity-watch.ts` | ポーリングループ。I/O は全て DI |
| `server/session/codex-activity-track.ts` | ファイル I/O ＋ フラグ適用の配線 |
| `server/session/spawn-codex.ts` | rollout 判明時に監視開始、pty 消失で停止 |

## 検証

- **単体テスト 26 件**追加
- **重要ルールをコードを壊して検証**: リプレイ防止 / 切り詰め検知 / `event_msg` 以外を境界と誤認しないこと
  - うち1件は**最初赤くならなかった** — `turn_context` のテストが `doc.type === "event_msg"` ガードを実際には検証していなかった（そのレコードには `payload.type` が無いので、ガードの有無に関わらず通る）。ガードを実際に踏むフィクスチャを追加して直した
- **実機で1ターン走らせて遷移を確認**（上の表）
- `yarn format` / `lint`（新規 error 0）/ `build` / `typecheck` / `typecheck:test` / `knip` / `test`（156 files, 1865 tests）すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)