### PR TITLE
refactor: セッション寿命中核の純粋な判断を抽出してテスト（#548 step 3h）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -53,7 +53,7 @@ import {
   titleInFlight,
 } from "./session/registry.js";
 import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay } from "./session/reap-policy.js";
-import { nextActivity } from "./session/activity-transition.js";
+import { nextActivity, sessionRow, shouldRefreshReply } from "./session/activity-transition.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
@@ -314,24 +314,18 @@ const sessionActivityPublisher = createSessionActivityPublisher({
 
 // Publish a session's current activity (working + waiting) to subscribers.
 function publishActivity(id: string) {
-  const a = activity.get(id) || {};
+  const a = activity.get(id);
+  // `cwd` rides along so the attention-sound player can pick up that directory's custom
+  // sound (<cwd>/.mulmoterminal.json). Null for a session with no live PTY.
   const cwd = ptys.get(id)?.cwd ?? null;
-  // A turn just ended (waiting) → capture the reply's tail for the roster.
-  if (a.waiting && cwd) refreshLastResponse(id, cwd);
-  sessionActivityPublisher.publish(id, { working: a.working ?? false, waiting: a.waiting ?? false });
-  pubsub?.publish(SESSIONS_CHANNEL, {
-    id,
-    // The session's working dir, so the attention-sound player can pick up that
-    // directory's custom sound (<cwd>/.mulmoterminal.json). Null for a session with
-    // no live PTY (a reaped background worker).
-    cwd,
-    working: a.working ?? false,
-    waiting: a.waiting ?? false,
-    event: a.event ?? null,
-    lastPrompt: lastPrompts.get(id) ?? null,
-    aiTitle: aiTitles.get(id) ?? null,
-    lastResponse: lastResponses.get(id) ?? null,
+  if (shouldRefreshReply(a, cwd)) refreshLastResponse(id, cwd);
+  const row = sessionRow(id, a, cwd, {
+    lastPrompt: lastPrompts.get(id),
+    aiTitle: aiTitles.get(id),
+    lastResponse: lastResponses.get(id),
   });
+  sessionActivityPublisher.publish(id, { working: row.working, waiting: row.waiting });
+  pubsub?.publish(SESSIONS_CHANNEL, row);
 }
 
 // AI-title bookkeeping (session/session-title.ts). publishActivity stays here — it

--- a/server/index.ts
+++ b/server/index.ts
@@ -53,6 +53,7 @@ import {
   titleInFlight,
 } from "./session/registry.js";
 import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay } from "./session/reap-policy.js";
+import { nextActivity } from "./session/activity-transition.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
@@ -344,9 +345,9 @@ const { forgetTitle, noteTitleTurn, maybeGenerateTitle, freshenRosterTitle } = c
 // Claude is thinking (UserPromptSubmit) until it finishes (Stop). No-op (and no
 // publish) when the state is unchanged.
 function setWorking(id: string, working: boolean, event?: string) {
-  const prev = activity.get(id) || {};
-  if ((prev.working ?? false) === working) return;
-  activity.set(id, { ...prev, working, event: event ?? prev.event ?? null, at: Date.now() });
+  const next = nextActivity(activity.get(id), { working }, event, Date.now());
+  if (!next) return;
+  activity.set(id, next);
   publishActivity(id);
   // Persist `working` so an in-progress turn survives a restart (see ACTIVITY_STATE_FILE).
   persistActivityState((id) => hiddenSessions.has(id));
@@ -363,9 +364,9 @@ function setWorking(id: string, working: boolean, event?: string) {
 // output the user hasn't seen (Stop). Cleared when brought to the foreground
 // (see the WebSocket connection handler).
 function setWaiting(id: string, waiting: boolean, event?: string) {
-  const prev = activity.get(id) || {};
-  if ((prev.waiting ?? false) === waiting) return;
-  activity.set(id, { ...prev, waiting, event: event ?? prev.event ?? null, at: Date.now() });
+  const next = nextActivity(activity.get(id), { waiting }, event, Date.now());
+  if (!next) return;
+  activity.set(id, next);
   publishActivity(id);
   // Persist the blocked/done set so it survives a server restart (see ACTIVITY_STATE_FILE).
   persistActivityState((id) => hiddenSessions.has(id));

--- a/server/index.ts
+++ b/server/index.ts
@@ -52,7 +52,7 @@ import {
   ptys,
   titleInFlight,
 } from "./session/registry.js";
-import { reapDecisionFor } from "./session/reap-policy.js";
+import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay } from "./session/reap-policy.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
@@ -204,17 +204,10 @@ const REAP_GRACE_MS = 30_000;
 // unfinished task: reaping it loses work. So it gets a much longer grace than an
 // idle one, long enough that you can switch away, do other things, and come back
 // to answer it. Override with WAIT_REAP_GRACE_MS=0 to never auto-close these.
-const WAIT_REAP_GRACE_MS = (() => {
-  const def = 30 * 60_000;
-  const raw = process.env.WAIT_REAP_GRACE_MS;
-  if (raw === undefined) return def;
-  const n = Number(raw);
-  if (!Number.isFinite(n)) {
-    console.warn(`[pty] ignoring non-numeric WAIT_REAP_GRACE_MS=${JSON.stringify(raw)}; using default ${def}ms`);
-    return def;
-  }
-  return n; // a non-positive value means "never auto-reap waiting sessions" (see scheduleReap)
-})();
+const WAIT_REAP_GRACE_DEFAULT_MS = 30 * 60_000;
+const WAIT_REAP_GRACE_MS = parseWaitGraceMs(process.env.WAIT_REAP_GRACE_MS, WAIT_REAP_GRACE_DEFAULT_MS, (raw) =>
+  console.warn(`[pty] ignoring non-numeric WAIT_REAP_GRACE_MS=${JSON.stringify(raw)}; using default ${WAIT_REAP_GRACE_DEFAULT_MS}ms`),
+);
 const reapTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 function cancelReap(id: string) {
@@ -225,17 +218,12 @@ function cancelReap(id: string) {
   }
 }
 
-// Node's setTimeout delay is a signed 32-bit int; a larger value overflows and
-// fires at ~1ms. Clamp to the max so a big grace doesn't become an instant reap.
-const MAX_TIMER_MS = 2_147_483_647;
-
 function scheduleReap(id: string, delayMs: number = REAP_GRACE_MS) {
-  // Non-positive or non-finite (e.g. a bad env value yielding NaN) => never
-  // auto-reap; the session stays until reattached or explicitly terminated.
-  // Guarding here matters because setTimeout(..., NaN) would fire ~immediately.
-  if (!Number.isFinite(delayMs) || delayMs <= 0) return;
+  // null => never auto-reap; the session stays until reattached or explicitly
+  // terminated (see reapTimerDelay for why a bad value must not reach setTimeout).
+  const delay = reapTimerDelay(delayMs);
+  if (delay === null) return;
   if (reapTimers.has(id)) return;
-  const delay = Math.min(delayMs, MAX_TIMER_MS);
   reapTimers.set(
     id,
     setTimeout(() => {

--- a/server/session/activity-transition.ts
+++ b/server/session/activity-transition.ts
@@ -1,0 +1,23 @@
+// What a working/waiting flag change does to a session's activity record — the decision
+// only, with no publish, no persistence and no reap. Split from index.ts (#548 step 3h):
+// setWorking and setWaiting differed by one field but each re-derived the same rules, and
+// both are load-bearing. The "unchanged" answer is what keeps an idle session from
+// republishing on every hook, and the event fallback is what keeps a row labelled with the
+// event that last meant something rather than blanking it.
+import type { Activity } from "./types.js";
+
+/** The record to store, or null when nothing changed and the caller should do nothing.
+ *  `event` falls back to the previous one so a change that carries no event keeps the
+ *  label the row already had; only an explicit null clears it (via a first-ever write). */
+export function nextActivity(
+  prev: Activity | undefined,
+  patch: { working: boolean } | { waiting: boolean },
+  event: string | undefined,
+  now: number,
+): Activity | null {
+  const current = prev ?? {};
+  const key = "working" in patch ? "working" : "waiting";
+  const value = "working" in patch ? patch.working : patch.waiting;
+  if ((current[key] ?? false) === value) return null;
+  return { ...current, [key]: value, event: event ?? current.event ?? null, at: now };
+}

--- a/server/session/activity-transition.ts
+++ b/server/session/activity-transition.ts
@@ -1,5 +1,6 @@
-// What a working/waiting flag change does to a session's activity record — the decision
-// only, with no publish, no persistence and no reap. Split from index.ts (#548 step 3h):
+// Pure derivations from a session's activity record: what a flag change makes it, and what
+// the row published to subscribers looks like. The decisions only — no publish, no
+// persistence, no reap. Split from index.ts (#548 step 3h):
 // setWorking and setWaiting differed by one field but each re-derived the same rules, and
 // both are load-bearing. The "unchanged" answer is what keeps an idle session from
 // republishing on every hook, and the event fallback is what keeps a row labelled with the
@@ -20,4 +21,44 @@ export function nextActivity(
   const value = "working" in patch ? patch.working : patch.waiting;
   if ((current[key] ?? false) === value) return null;
   return { ...current, [key]: value, event: event ?? current.event ?? null, at: now };
+}
+
+/** The session row published to subscribers. Every field is defaulted here rather than at
+ *  the receiving end, so a session with no activity yet still reads as idle instead of
+ *  arriving with holes. */
+export interface SessionRow {
+  id: string;
+  cwd: string | null;
+  working: boolean;
+  waiting: boolean;
+  event: string | null;
+  lastPrompt: string | null;
+  aiTitle: string | null;
+  lastResponse: string | null;
+}
+
+export function sessionRow(
+  id: string,
+  activity: Activity | undefined,
+  cwd: string | null,
+  texts: { lastPrompt?: string; aiTitle?: string; lastResponse?: string },
+): SessionRow {
+  const a = activity ?? {};
+  return {
+    id,
+    cwd,
+    working: a.working ?? false,
+    waiting: a.waiting ?? false,
+    event: a.event ?? null,
+    lastPrompt: texts.lastPrompt ?? null,
+    aiTitle: texts.aiTitle ?? null,
+    lastResponse: texts.lastResponse ?? null,
+  };
+}
+
+/** Whether to re-read the transcript's tail before publishing. `waiting` means a turn just
+ *  ended, which is the moment the roster's copy of the reply goes stale; without a cwd
+ *  there is no transcript to read. */
+export function shouldRefreshReply(activity: Activity | undefined, cwd: string | null): cwd is string {
+  return !!(activity?.waiting && cwd);
 }

--- a/server/session/reap-policy.ts
+++ b/server/session/reap-policy.ts
@@ -25,3 +25,31 @@ export function reapDecisionFor(activity: ReapActivity | undefined, graces: Reap
   if (activity?.working) return { kind: "keep" }; // clearly working, don't close it
   return { kind: "arm", delayMs: graces.idleMs };
 }
+
+// ── the two numbers that decision produces, before they reach a timer ──────────
+
+/** Node's setTimeout delay is a signed 32-bit int; a larger value overflows and fires at
+ *  ~1ms, turning a long grace into an instant reap. */
+export const MAX_TIMER_MS = 2_147_483_647;
+
+/** How long to actually wait, or null for "never auto-reap". A non-positive grace is the
+ *  documented way to switch auto-reaping off, and a non-finite one can only come from a
+ *  bad config — both must mean "no timer" rather than setTimeout's ~immediate fire. */
+export function reapTimerDelay(delayMs: number): number | null {
+  if (!Number.isFinite(delayMs) || delayMs <= 0) return null;
+  return Math.min(delayMs, MAX_TIMER_MS);
+}
+
+/** The grace a detached-but-needed session gets, read from WAIT_REAP_GRACE_MS. Anything
+ *  that isn't a number falls back to the default rather than disabling reaping by
+ *  accident; a non-positive value is an explicit "never auto-close these". `onInvalid`
+ *  reports the fallback so the caller can warn. */
+export function parseWaitGraceMs(raw: string | undefined, defaultMs: number, onInvalid?: (raw: string) => void): number {
+  if (raw === undefined) return defaultMs;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    onInvalid?.(raw);
+    return defaultMs;
+  }
+  return n;
+}

--- a/test/server/session/activity-transition.spec.ts
+++ b/test/server/session/activity-transition.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { nextActivity } from "../../../server/session/activity-transition.js";
+
+const NOW = 1_700_000_000_000;
+
+describe("nextActivity", () => {
+  describe("no-op detection", () => {
+    it("reports no change when the flag already holds that value", () => {
+      // Every hook calls a setter; without this an idle session would republish its row
+      // on each one, waking every subscribed client for nothing.
+      expect(nextActivity({ working: true }, { working: true }, undefined, NOW)).toBeNull();
+      expect(nextActivity({ waiting: false }, { waiting: false }, undefined, NOW)).toBeNull();
+    });
+
+    it("treats an absent flag as false, so clearing an unset one is a no-op", () => {
+      expect(nextActivity({}, { working: false }, undefined, NOW)).toBeNull();
+      expect(nextActivity(undefined, { waiting: false }, undefined, NOW)).toBeNull();
+      expect(nextActivity({ waiting: true }, { working: false }, undefined, NOW)).toBeNull();
+    });
+
+    it("reports a change even when only the event would differ", () => {
+      // The flag is what decides; an event alone must not trigger a write.
+      expect(nextActivity({ working: true, event: "A" }, { working: true }, "B", NOW)).toBeNull();
+    });
+  });
+
+  describe("setting a flag", () => {
+    it("records the new value and the time", () => {
+      expect(nextActivity(undefined, { working: true }, "UserPromptSubmit", NOW)).toEqual({
+        working: true,
+        event: "UserPromptSubmit",
+        at: NOW,
+      });
+    });
+
+    it("keeps the other flag untouched", () => {
+      expect(nextActivity({ working: true, waiting: true, event: "Stop", at: 1 }, { working: false }, undefined, NOW)).toEqual({
+        working: false,
+        waiting: true,
+        event: "Stop",
+        at: NOW,
+      });
+    });
+
+    it("clears a set flag", () => {
+      expect(nextActivity({ waiting: true, event: "Notification", at: 1 }, { waiting: false }, undefined, NOW)).toEqual({
+        waiting: false,
+        event: "Notification",
+        at: NOW,
+      });
+    });
+
+    it("always advances `at`, so the record reflects this change", () => {
+      expect(nextActivity({ working: false, at: 1 }, { working: true }, undefined, NOW)?.at).toBe(NOW);
+    });
+  });
+
+  describe("event label", () => {
+    it("takes the event it was given", () => {
+      expect(nextActivity({ event: "Stop" }, { working: true }, "UserPromptSubmit", NOW)?.event).toBe("UserPromptSubmit");
+    });
+
+    it("keeps the previous event when none is given", () => {
+      // A change carrying no event must not blank a row that was labelled "Notification" —
+      // the label is what the UI shows for why the session wants attention.
+      expect(nextActivity({ waiting: true, event: "Notification" }, { working: true }, undefined, NOW)?.event).toBe("Notification");
+    });
+
+    it("is null when neither the change nor the previous record has one", () => {
+      expect(nextActivity(undefined, { working: true }, undefined, NOW)?.event).toBeNull();
+      expect(nextActivity({ event: null }, { working: true }, undefined, NOW)?.event).toBeNull();
+    });
+
+    it("prefers an explicit empty event over the previous one", () => {
+      // "" is a given value, not an absent one — `??` only falls through on null/undefined.
+      expect(nextActivity({ event: "Stop" }, { working: true }, "", NOW)?.event).toBe("");
+    });
+  });
+
+  it("does not mutate the record it was given", () => {
+    const prev = { working: false, event: "Stop", at: 1 };
+    nextActivity(prev, { working: true }, "UserPromptSubmit", NOW);
+    expect(prev).toEqual({ working: false, event: "Stop", at: 1 });
+  });
+
+  it("drives both setters identically apart from which flag moves", () => {
+    const prev = { event: "Stop", at: 1 };
+    expect(nextActivity(prev, { working: true }, undefined, NOW)).toEqual({ working: true, event: "Stop", at: NOW });
+    expect(nextActivity(prev, { waiting: true }, undefined, NOW)).toEqual({ waiting: true, event: "Stop", at: NOW });
+  });
+});

--- a/test/server/session/activity-transition.spec.ts
+++ b/test/server/session/activity-transition.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { nextActivity } from "../../../server/session/activity-transition.js";
+import { nextActivity, sessionRow, shouldRefreshReply } from "../../../server/session/activity-transition.js";
 
 const NOW = 1_700_000_000_000;
 
@@ -87,5 +87,71 @@ describe("nextActivity", () => {
     const prev = { event: "Stop", at: 1 };
     expect(nextActivity(prev, { working: true }, undefined, NOW)).toEqual({ working: true, event: "Stop", at: NOW });
     expect(nextActivity(prev, { waiting: true }, undefined, NOW)).toEqual({ waiting: true, event: "Stop", at: NOW });
+  });
+});
+
+// The row every subscribed client renders from. Defaults are applied here so a session
+// with no activity yet reads as idle rather than arriving with holes the UI must guess at.
+describe("sessionRow", () => {
+  it("fills every field for a session with no activity yet", () => {
+    expect(sessionRow("S", undefined, null, {})).toEqual({
+      id: "S",
+      cwd: null,
+      working: false,
+      waiting: false,
+      event: null,
+      lastPrompt: null,
+      aiTitle: null,
+      lastResponse: null,
+    });
+  });
+
+  it("carries the activity flags and label through", () => {
+    const row = sessionRow("S", { working: true, waiting: true, event: "Stop", at: 1 }, "/ws", {});
+    expect(row).toMatchObject({ working: true, waiting: true, event: "Stop", cwd: "/ws" });
+  });
+
+  it("does not leak `at` — it is bookkeeping, not part of the row", () => {
+    expect(Object.keys(sessionRow("S", { working: true, at: 999 }, null, {}))).not.toContain("at");
+  });
+
+  it("carries the roster texts, defaulting each missing one to null", () => {
+    expect(sessionRow("S", undefined, null, { lastPrompt: "p", lastResponse: "r" })).toMatchObject({
+      lastPrompt: "p",
+      aiTitle: null,
+      lastResponse: "r",
+    });
+  });
+
+  it("keeps an empty text as empty rather than turning it into null", () => {
+    // `/clear` blanks the prompt deliberately: "" beats the transcript fallback the
+    // reader applies, while null would let the pre-clear prompt resurface.
+    expect(sessionRow("S", undefined, null, { lastPrompt: "", lastResponse: "" })).toMatchObject({
+      lastPrompt: "",
+      lastResponse: "",
+    });
+  });
+
+  it("keeps a null cwd, which is what a reaped session has", () => {
+    expect(sessionRow("S", { working: true }, null, {}).cwd).toBeNull();
+  });
+});
+
+describe("shouldRefreshReply", () => {
+  it("refreshes when a turn just ended and there is a transcript to read", () => {
+    expect(shouldRefreshReply({ waiting: true }, "/ws")).toBe(true);
+  });
+
+  it("does not refresh a session that is not waiting", () => {
+    // Re-reading on every publish would put a file read in the path of each hook.
+    expect(shouldRefreshReply({ working: true }, "/ws")).toBe(false);
+    expect(shouldRefreshReply({ waiting: false }, "/ws")).toBe(false);
+    expect(shouldRefreshReply({}, "/ws")).toBe(false);
+    expect(shouldRefreshReply(undefined, "/ws")).toBe(false);
+  });
+
+  it("does not refresh without a cwd — there is no transcript to read", () => {
+    expect(shouldRefreshReply({ waiting: true }, null)).toBe(false);
+    expect(shouldRefreshReply({ waiting: true }, "")).toBe(false);
   });
 });

--- a/test/server/session/reap-policy.spec.ts
+++ b/test/server/session/reap-policy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { reapDecisionFor } from "../../../server/session/reap-policy.js";
+import { reapDecisionFor, reapTimerDelay, parseWaitGraceMs, MAX_TIMER_MS } from "../../../server/session/reap-policy.js";
 
 const graces = { idleMs: 30_000, waitingMs: 1_800_000 };
 
@@ -34,5 +34,99 @@ describe("reapDecisionFor", () => {
   // decision just passes the value through rather than second-guessing it.
   it("passes a disabled (zero) waiting grace straight through", () => {
     expect(reapDecisionFor({ waiting: true }, { idleMs: 30_000, waitingMs: 0 })).toEqual({ kind: "arm", delayMs: 0 });
+  });
+});
+
+// The grace a decision produces still has to survive setTimeout. Node's delay is a signed
+// 32-bit int: a larger value overflows and fires at ~1ms, so an unclamped 30-minute grace
+// would reap the session almost immediately — the opposite of what it asks for.
+describe("reapTimerDelay", () => {
+  it("passes an ordinary grace through unchanged", () => {
+    expect(reapTimerDelay(30_000)).toBe(30_000);
+    expect(reapTimerDelay(30 * 60_000)).toBe(1_800_000);
+  });
+
+  it("clamps a grace past the 32-bit timer limit instead of letting it overflow", () => {
+    expect(reapTimerDelay(2_147_483_648)).toBe(2_147_483_647);
+    expect(reapTimerDelay(1e12)).toBe(2_147_483_647);
+  });
+
+  it("pins the limit to the actual 32-bit maximum", () => {
+    // Spelled out rather than compared against the constant, so shifting the constant
+    // is a failure instead of something the test quietly follows.
+    expect(MAX_TIMER_MS).toBe(2_147_483_647);
+    expect(reapTimerDelay(2_147_483_647)).toBe(2_147_483_647);
+    expect(reapTimerDelay(2_147_483_646)).toBe(2_147_483_646);
+    expect(reapTimerDelay(2_147_483_648)).toBe(2_147_483_647);
+  });
+
+  it("means never for a non-positive grace, which is how auto-reaping is switched off", () => {
+    expect(reapTimerDelay(0)).toBeNull();
+    expect(reapTimerDelay(-1)).toBeNull();
+    expect(reapTimerDelay(-Infinity)).toBeNull();
+  });
+
+  it("means never for a non-finite grace rather than firing immediately", () => {
+    // setTimeout(..., NaN) fires on the next tick — a bad config must not reap instantly.
+    expect(reapTimerDelay(NaN)).toBeNull();
+    expect(reapTimerDelay(Infinity)).toBeNull();
+  });
+
+  it("keeps a sub-millisecond grace rather than rounding it away", () => {
+    expect(reapTimerDelay(0.5)).toBe(0.5);
+  });
+});
+
+// WAIT_REAP_GRACE_MS decides how long a session that needs the user survives once
+// detached. Misreading it either closes an unfinished task early or never closes it.
+describe("parseWaitGraceMs", () => {
+  const DEFAULT_MS = 30 * 60_000;
+
+  it("uses the default when the variable is unset", () => {
+    expect(parseWaitGraceMs(undefined, DEFAULT_MS)).toBe(DEFAULT_MS);
+  });
+
+  it("reads a numeric value", () => {
+    expect(parseWaitGraceMs("60000", DEFAULT_MS)).toBe(60_000);
+    expect(parseWaitGraceMs(" 60000 ", DEFAULT_MS)).toBe(60_000); // Number() trims
+  });
+
+  it("keeps a non-positive value, which switches auto-reaping off", () => {
+    expect(parseWaitGraceMs("0", DEFAULT_MS)).toBe(0);
+    expect(parseWaitGraceMs("-1", DEFAULT_MS)).toBe(-1);
+  });
+
+  it("treats an empty or blank value as 0 — never auto-reap — not as unset", () => {
+    // Number("") is 0, so this is a real behavioural distinction from `undefined`.
+    expect(parseWaitGraceMs("", DEFAULT_MS)).toBe(0);
+    expect(parseWaitGraceMs("   ", DEFAULT_MS)).toBe(0);
+  });
+
+  it("falls back to the default for a value that is not a number", () => {
+    // Falling back matters: a typo must not silently disable reaping.
+    expect(parseWaitGraceMs("abc", DEFAULT_MS)).toBe(DEFAULT_MS);
+    expect(parseWaitGraceMs("NaN", DEFAULT_MS)).toBe(DEFAULT_MS);
+    expect(parseWaitGraceMs("30m", DEFAULT_MS)).toBe(DEFAULT_MS);
+  });
+
+  it("falls back for an infinite value, which no timer could honour", () => {
+    expect(parseWaitGraceMs("Infinity", DEFAULT_MS)).toBe(DEFAULT_MS);
+    expect(parseWaitGraceMs("1e400", DEFAULT_MS)).toBe(DEFAULT_MS); // overflows to Infinity
+  });
+
+  it("reports the raw value it rejected, and only then", () => {
+    const rejected: string[] = [];
+    const onInvalid = (raw: string) => rejected.push(raw);
+    parseWaitGraceMs("abc", DEFAULT_MS, onInvalid);
+    parseWaitGraceMs("60000", DEFAULT_MS, onInvalid);
+    parseWaitGraceMs(undefined, DEFAULT_MS, onInvalid);
+    parseWaitGraceMs("0", DEFAULT_MS, onInvalid);
+    expect(rejected).toEqual(["abc"]);
+  });
+
+  it("feeds reapTimerDelay: a rejected value still yields a real timer", () => {
+    // The two compose — a bad env var must land on the default grace, not on "never".
+    expect(reapTimerDelay(parseWaitGraceMs("abc", DEFAULT_MS))).toBe(DEFAULT_MS);
+    expect(reapTimerDelay(parseWaitGraceMs("0", DEFAULT_MS))).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

これはモジュール移動ではなく、**index.ts のセッション寿命の中核から純粋な判断だけを取り出してテストする**変更です（#548 step 3h）。タイマー・マップ・publish は index.ts に残したままなので、影響範囲を絞っています。

index.ts: **1053 → 1036 行**／テスト: 1839 → **1875 件**（+36）

| コミット | 取り出したもの | 元の在り処 |
|---|---|---|
| `bcec20a` | `reapTimerDelay` / `parseWaitGraceMs` | `scheduleReap` 内のインラインガードと、module load 時に `process.env` を読む IIFE |
| `b11bef6` | `nextActivity` | `setWorking` と `setWaiting` が各々インラインで同じ規則を再導出 |
| `4202a6a` | `sessionRow` / `shouldRefreshReply` | `publishActivity` 内のインライン組み立て |

## なぜこれらか

いずれも**今の場所では単体テストが書けず**、かつ**壊れても静かに劣化する**ものです。

| 関数 | 壊れると |
|---|---|
| `reapTimerDelay` | 32bit 上限超えの猶予が ~1ms で発火し、30 分の猶予が実質「即 reap」になる。`NaN` も同様 |
| `parseWaitGraceMs` | `WAIT_REAP_GRACE_MS=""` は `Number("")===0` で「自動 reap しない」、`=abc` は既定値へフォールバック。取り違えると未完了タスクが勝手に閉じる／永久に閉じない |
| `nextActivity` | 「変化なし」判定が消えると全フックで行が再 publish される。`event` フォールバックが消えると UI が表示中の `Notification` ラベルが消える |
| `sessionRow` | 空文字の `lastPrompt` を null に潰すと、`/clear` したはずの旧プロンプトが transcript フォールバック経由で復活する |

## Items to Confirm / Review

- **`scheduleReap` の順序**: main は「有効性判定 → `reapTimers.has` → クランプ」、本 PR は「判定＋クランプ → `reapTimers.has`」。`reapTimerDelay` は純粋で副作用が無いため観測可能な差はありません。
- **`publishActivity` の順序**: `refreshLastResponse` は `sessionRow` の**前**に走り、更新した `lastResponses` が行に反映されます（main と同順）。
- **`nextActivity` の computed key**: `{ ...current, [key]: value, ... }` が元のリテラルと同じ形になることを総当たりで確認済みです。

## 検証

**1. 等価性の総当たり** — 置き換え前に元の式と結果を突き合わせ:

| 対象 | ケース数 | 結果 |
|---|---|---|
| `reapTimerDelay` / `parseWaitGraceMs` | 29 | 全一致 |
| `nextActivity` | 144 | 全一致 |
| `sessionRow` / `shouldRefreshReply` | 252 | 全一致 |

**2. 実行時比較（main と並行起動）** — 実際のフック列で状態遷移を比較:

`UserPromptSubmit` → 同じ `UserPromptSubmit`（変化なし）→ `Notification` → `Stop` → 同じ `Stop`（変化なし）→ `SessionStart/clear` の 6 ステップすべてで `working`/`waiting`/`event` が一致。`/api/sessions` の行も一致。

**3. teeth 確認**（変異の適用を毎回検証）— 19 パターンすべて赤:

- reap: 32bit クランプ除去／非有限を通す／非正を通す／上限 off-by-one／未設定でも `Number()`／非数値を既定値に戻さない／`onInvalid` を呼ばない
- transition: 変化なし判定除去／未設定を false 扱いしない／`event` フォールバック除去／前の `event` を優先／spread 除去／`at` を更新しない
- row: `working` 既定値除去／`event` 既定値除去／空文字を null に潰す／`at` を行に漏らす／`waiting` を無視して常に refresh／cwd 無しでも refresh

なお「上限 off-by-one」は当初緑でした（テストが定数を参照していて相対的に整合してしまう）。実数値 `2_147_483_647` を直接書くよう直して赤になることを確認しています。

**4. ゲート** — lint 0 error / build / **typecheck 3 種すべて** / 全テスト 155 files・**1875 passed**。

## 残り

`server/index.ts` は 1036 行。これで寿命中核の「判断」は出し切ったので、残るのは**状態そのもの**（`reapTimers` マップ、タイマー起動、`activity` への書き込み、publish）と**起動・配線**です。前者を動かすかはこの PR とは別の判断になります。
