### PR TITLE
feat: pick a provider/model when launching a session (#584)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ today — **Claude Code** (the default) and **Codex**.
 cell's launch form and the Collections browser carry a **Claude / Codex** toggle (your
 choice is remembered).
 
+**Other models.**
+Claude Code can run against any **Anthropic-compatible** backend (OpenRouter, Moonshot, a
+LiteLLM gateway). Backends are listed in `~/.mulmoterminal/config.json` under `providers`,
+and their **keys are read from the server's environment** — never from a file the app
+serves. A directory sets its default in `.mulmoterminal.json` (`provider` / `model`), and
+each grid cell's launch form has a **MODEL** select that overrides it for one session,
+listing ~27 curated models with the measured pass rate of a real tool-using task beside
+each. A provider whose token can't be resolved **refuses to start** rather than falling
+back to Anthropic, and providers can't be combined with the Docker sandbox. See
+[Configuration → providers](https://receptron.github.io/mulmoterminal/guide/en/config.html#providers).
+
 **Skills for Codex.** Codex has no `/<slug>` slash commands, so on session setup
 MulmoTerminal **mirrors the workspace's `.claude/skills` into `~/.codex/skills`** (each
 mirrored directory carries a `.mt-mirror` marker so a re-sync overwrites what MulmoTerminal
@@ -668,8 +679,10 @@ Each grid cell's header shows two badges for its session, refreshed when a turn 
 
 - **Context badge** — e.g. `Opus · ctx 35%`: the model family plus how full its context
   window is (the *last* turn's input + cache tokens ÷ the model's window — **1M** for
-  current-gen Opus / Sonnet / Fable, **200k** otherwise; an unknown model shows the label
-  with no %).
+  current-gen Opus / Sonnet / Fable, **200k** otherwise). A session running on a
+  [provider model](#agents-claude--codex) shows that model's name and its published window
+  (`Kimi K2.7 Code · ctx 12%`); a model in neither list keeps the label and hides the %,
+  since the window is never guessed.
 - **Token badge** — `⇡<in> ⇣<out>`: cumulative input (fresh + cache-read + cache-creation)
   and output tokens for the session, k/M-formatted, with a full breakdown in the tooltip.
 
@@ -938,8 +951,9 @@ same-origin-guarded.
 
 | Endpoint | Purpose |
 | -------- | ------- |
-| `GET\|POST /api/config` | User UI config (`cwdPresets`, `soundFile`, `prRepos`, `launchers`, `userMcpServers`). |
+| `GET\|POST /api/config` | User UI config (`cwdPresets`, `soundFile`, `prRepos`, `launchers`, `userMcpServers`, `providers`). |
 | `GET /api/sound` · `/api/dir-sound?cwd=` · `/api/dir-config?cwd=` | Custom / per-directory attention sound + per-dir config. |
+| `GET /api/launch-options` | The Anthropic-compatible backends this server can reach, each with its models and — when it can't — the reason. Reports the **name** of the env var a key is read from, never the key. |
 | `GET /api/notifications`(`/history`) · `POST /api/notifications/:id/clear` | Notification feed. |
 | `POST /api/transcribe`(`/model`…) | Voice-input transcription (Whisper, macOS). |
 | `POST /api/translation` | Runtime UI-string translation. |

--- a/common/modelIds.ts
+++ b/common/modelIds.ts
@@ -1,0 +1,17 @@
+// The shape a provider id or model id is allowed to take.
+//
+// Shared because the same string is checked in three places that must agree: the config
+// schema that accepts it, the launch picker that offers it, and the ws query that carries
+// it to `claude --model` and ANTHROPIC_MODEL. When those disagree, a config-accepted id is
+// dropped at launch — and a dropped *provider* with its model kept would start the session
+// on Anthropic instead, which is exactly the silent-wrong-backend this feature exists to
+// prevent.
+//
+// Vendor ids in the wild: `moonshotai/kimi-k2.7-code`, `gpt-5.6-luna-pro`, `z-ai/glm-5.2`.
+export const MODEL_ID_MAX_LENGTH = 120;
+
+// No leading dash (argv would read it as another flag), no whitespace, no control
+// characters, and no `|` — the picker joins provider and model with it.
+const MODEL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+export const isUsableModelId = (value: string): boolean => value.length <= MODEL_ID_MAX_LENGTH && MODEL_ID_RE.test(value);

--- a/common/modelPresets.ts
+++ b/common/modelPresets.ts
@@ -1,0 +1,311 @@
+// The models MulmoTerminal offers when launching a session on an Anthropic-compatible
+// backend, and how well each one actually drove Claude Code when it was measured.
+//
+// Shared across the build boundary (like themeIds / dirChrome): the launch picker reads
+// it in the browser, and the mulmoterminal-config skill reads it to know what it may
+// suggest. One list, one source of truth.
+//
+// WHY THE NUMBERS: a model that answers a plain prompt can still be unusable, because the
+// reply arrives while the tool loop never fires. Measuring that needs a task no model can
+// complete by talking — so `scripts/model-trials.ts` makes each one read a file and write
+// another, through the real spawn path, and records how many attempts actually produced
+// the file. Two models flipped between pass and fail across runs, so this is a ratio, not
+// a boolean, and the picker shows it. Re-measure with that script when adding entries.
+
+export interface ModelTrialsMeasured {
+  status: "measured";
+  // Attempts that completed a tool-using task, out of attempts made.
+  passed: number;
+  of: number;
+  // Typical wall-clock for that task, over the attempts that passed. The spread is wide
+  // and worth showing: the same probe ran in 11s on one model and 69s on another. Null
+  // when nothing passed — a model can be reachable, answer in prose, and never once call
+  // a tool, and that is a different thing from being slow.
+  medianSeconds: number | null;
+  measuredAt: string;
+}
+
+// Could not be reached from the account that ran the measurement — NOT a defect in the
+// model. OpenRouter answers 404 "No endpoints available matching your guardrail
+// restrictions and data policy" when the account's privacy settings exclude every
+// provider serving it. Kept in the list, clearly marked, because another account (or a
+// settings change) may run it fine.
+export interface ModelTrialsUnreachable {
+  status: "unreachable";
+  reason: string;
+  measuredAt: string;
+}
+
+// A model the USER added in their own config. We have no numbers for it — saying so is
+// better than implying it was checked.
+export interface ModelTrialsUnmeasured {
+  status: "unmeasured";
+}
+
+export type ModelTrials = ModelTrialsMeasured | ModelTrialsUnreachable | ModelTrialsUnmeasured;
+
+export interface ModelPreset {
+  // The `id` of a provider in config.json's `providers`.
+  provider: string;
+  // Passed to `claude --model`, verbatim.
+  id: string;
+  label: string;
+  contextLength: number;
+  // US dollars per million tokens, as published by the provider's catalog. Shown because
+  // the range across this list is two orders of magnitude.
+  pricePerMTok: { input: number; output: number };
+  trials: ModelTrials;
+}
+
+const MEASURED_AT = "2026-07-22";
+
+const measured = (passed: number, of: number, medianSeconds: number | null): ModelTrialsMeasured => ({
+  status: "measured",
+  passed,
+  of,
+  medianSeconds,
+  measuredAt: MEASURED_AT,
+});
+
+const unreachable = (reason: string): ModelTrialsUnreachable => ({ status: "unreachable", reason, measuredAt: MEASURED_AT });
+
+const ACCOUNT_PRIVACY = "OpenRouter returned no endpoints for this account's privacy settings — see openrouter.ai/settings/privacy";
+
+export const MODEL_PRESETS: readonly ModelPreset[] = [
+  // ── Open models: cheapest first ──────────────────────────────────────────────
+  {
+    provider: "openrouter",
+    id: "nvidia/nemotron-3-super-120b-a12b",
+    label: "Nemotron 3 Super 120B",
+    contextLength: 1_000_000,
+    pricePerMTok: { input: 0.08, output: 0.45 },
+    trials: measured(3, 3, 18),
+  },
+  {
+    provider: "openrouter",
+    id: "qwen/qwen3-235b-a22b-2507",
+    label: "Qwen3 235B A22B",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.09, output: 0.55 },
+    trials: measured(3, 3, 16),
+  },
+  {
+    provider: "openrouter",
+    id: "minimax/minimax-m2.7",
+    label: "MiniMax M2.7",
+    contextLength: 204_800,
+    pricePerMTok: { input: 0.25, output: 1.0 },
+    trials: measured(3, 3, 16),
+  },
+  {
+    provider: "openrouter",
+    id: "deepseek/deepseek-v3.2",
+    label: "DeepSeek V3.2",
+    contextLength: 163_840,
+    pricePerMTok: { input: 0.269, output: 0.4 },
+    trials: measured(3, 3, 42),
+  },
+  {
+    provider: "openrouter",
+    id: "minimax/minimax-m3",
+    label: "MiniMax M3",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.3, output: 1.2 },
+    trials: measured(3, 3, 14),
+  },
+  {
+    provider: "openrouter",
+    id: "deepseek/deepseek-v4-pro",
+    label: "DeepSeek V4 Pro",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.435, output: 0.87 },
+    trials: measured(3, 3, 20),
+  },
+  {
+    provider: "openrouter",
+    id: "deepseek/deepseek-v4-flash",
+    label: "DeepSeek V4 Flash",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.094, output: 0.188 },
+    trials: measured(3, 4, 26),
+  },
+  {
+    provider: "openrouter",
+    id: "openai/gpt-oss-120b",
+    label: "GPT-OSS 120B",
+    contextLength: 131_072,
+    pricePerMTok: { input: 0.037, output: 0.17 },
+    trials: measured(3, 4, 18),
+  },
+  {
+    provider: "openrouter",
+    id: "moonshotai/kimi-k2-0905",
+    label: "Kimi K2 0905",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.6, output: 2.5 },
+    trials: measured(3, 3, 18),
+  },
+  {
+    provider: "openrouter",
+    id: "moonshotai/kimi-k2-thinking",
+    label: "Kimi K2 Thinking",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.6, output: 2.5 },
+    trials: measured(3, 3, 20),
+  },
+  {
+    provider: "openrouter",
+    id: "moonshotai/kimi-k2.6",
+    label: "Kimi K2.6",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.684, output: 3.42 },
+    trials: measured(3, 3, 46),
+  },
+  {
+    provider: "openrouter",
+    id: "z-ai/glm-5.2",
+    label: "GLM 5.2",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.819, output: 2.574 },
+    trials: measured(3, 3, 21),
+  },
+  {
+    provider: "openrouter",
+    id: "moonshotai/kimi-k2.7-code",
+    label: "Kimi K2.7 Code",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.82, output: 3.75 },
+    trials: measured(3, 3, 14),
+  },
+  {
+    provider: "openrouter",
+    id: "moonshotai/kimi-k3",
+    label: "Kimi K3",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 3.0, output: 15.0 },
+    trials: measured(3, 3, 29),
+  },
+  {
+    provider: "openrouter",
+    id: "tencent/hy3",
+    label: "Tencent Hy3",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.14, output: 0.58 },
+    trials: measured(3, 3, 17),
+  },
+  {
+    provider: "openrouter",
+    id: "nvidia/nemotron-3-ultra-550b-a55b",
+    label: "Nemotron 3 Ultra 550B",
+    contextLength: 512_288,
+    pricePerMTok: { input: 0.6, output: 3.6 },
+    trials: measured(3, 3, 13),
+  },
+
+  // ── Frontier vendors: cheapest first ─────────────────────────────────────────
+  {
+    provider: "openrouter",
+    id: "google/gemini-3.5-flash-lite",
+    label: "Gemini 3.5 Flash-Lite",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.3, output: 2.5 },
+    trials: measured(3, 3, 11),
+  },
+  {
+    provider: "openrouter",
+    id: "amazon/nova-2-lite-v1",
+    label: "Nova 2 Lite",
+    contextLength: 1_000_000,
+    pricePerMTok: { input: 0.3, output: 2.5 },
+    trials: measured(2, 3, 20),
+  },
+  {
+    provider: "openrouter",
+    id: "openai/gpt-5.6-luna",
+    label: "GPT-5.6 Luna",
+    contextLength: 1_050_000,
+    pricePerMTok: { input: 1.0, output: 6.0 },
+    trials: measured(3, 3, 27),
+  },
+  {
+    provider: "openrouter",
+    id: "openai/gpt-5.6-luna-pro",
+    label: "GPT-5.6 Luna Pro",
+    contextLength: 1_050_000,
+    pricePerMTok: { input: 1.0, output: 6.0 },
+    trials: measured(3, 3, 69),
+  },
+  {
+    provider: "openrouter",
+    id: "google/gemini-3.6-flash",
+    label: "Gemini 3.6 Flash",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 1.5, output: 7.5 },
+    trials: measured(3, 3, 16),
+  },
+  {
+    provider: "openrouter",
+    id: "x-ai/grok-4.5",
+    label: "Grok 4.5",
+    contextLength: 500_000,
+    pricePerMTok: { input: 2.0, output: 6.0 },
+    trials: measured(3, 3, 13),
+  },
+  {
+    provider: "openrouter",
+    id: "openai/gpt-5.6-terra-pro",
+    label: "GPT-5.6 Terra Pro",
+    contextLength: 1_050_000,
+    pricePerMTok: { input: 2.5, output: 15.0 },
+    trials: measured(3, 3, 38),
+  },
+
+  // ── Reached fine, never drove the tool loop ──────────────────────────────────
+  // Kept so the list answers "what about X?" with a measurement instead of silence.
+  {
+    provider: "openrouter",
+    id: "meta-llama/llama-4-maverick",
+    label: "Llama 4 Maverick",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.2, output: 0.8 },
+    trials: measured(0, 4, null),
+  },
+
+  // ── Not measurable from the machine that built this list ─────────────────────
+  {
+    provider: "openrouter",
+    id: "qwen/qwen3.7-plus",
+    label: "Qwen3.7 Plus",
+    contextLength: 1_000_000,
+    pricePerMTok: { input: 0.32, output: 1.28 },
+    trials: unreachable(ACCOUNT_PRIVACY),
+  },
+  {
+    provider: "openrouter",
+    id: "mistralai/mistral-medium-3-5",
+    label: "Mistral Medium 3.5",
+    contextLength: 262_144,
+    pricePerMTok: { input: 1.5, output: 7.5 },
+    trials: unreachable(ACCOUNT_PRIVACY),
+  },
+  {
+    provider: "openrouter",
+    id: "mistralai/devstral-2512",
+    label: "Devstral 2512",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.4, output: 2.0 },
+    trials: unreachable(ACCOUNT_PRIVACY),
+  },
+];
+
+// Presets for one provider, plus whatever the user added to that provider's `models`.
+// A user entry with the same id as a preset keeps the preset's measured numbers rather
+// than appearing twice.
+export function presetsForProvider(providerId: string, userModels: readonly string[] = []): ModelPreset[] {
+  const presets = MODEL_PRESETS.filter((preset) => preset.provider === providerId);
+  const known = new Set(presets.map((preset) => preset.id));
+  const added: ModelPreset[] = userModels
+    .filter((id) => !known.has(id))
+    .map((id) => ({ provider: providerId, id, label: id, contextLength: 0, pricePerMTok: { input: 0, output: 0 }, trials: { status: "unmeasured" } }));
+  return [...presets, ...added];
+}

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -51,10 +51,111 @@ Open it from the ⚙ in the toolbar.
 | `launchers` | The launch commands that appear under "OR LAUNCH" in a grid cell |
 | `prRepos` | The repos targeted by the cross-repo PR/Issue view |
 | `buttons` / `chips` | Header buttons / chips (merged with project settings → [Customizing the header](#header)) |
+| `providers` | Anthropic-compatible backends (→ [Running on another model](#providers)) |
+
+## Running on another model (providers) {#providers}
+
+Claude Code can talk to any Anthropic-compatible backend. MulmoTerminal reads those backends from
+`config.json`, and their keys from the environment the **server** was started with — a key never
+lives in a config file.
+
+### 1. Add the backend to `~/.mulmoterminal/config.json`
+
+```json
+{
+  "providers": [
+    {
+      "id": "openrouter",
+      "label": "OpenRouter",
+      "baseUrl": "https://openrouter.ai/api",
+      "tokenEnv": "OPENROUTER_API_KEY",
+      "maxOutputTokens": 16000,
+      "models": []
+    }
+  ]
+}
+```
+
+| Key | Role |
+|---|---|
+| `id` | The name `.mulmoterminal.json` and the launch picker refer to |
+| `baseUrl` | **No trailing `/v1`** — Claude Code appends `/v1/messages` itself, so a trailing `/v1` produces `/v1/v1/messages` and 404s |
+| `tokenEnv` | The **name** of the environment variable holding the key, never the key |
+| `maxOutputTokens` | Defaults to 16000. Starved of output headroom, a thinking model spends its whole budget thinking and returns **empty** visible text |
+| `models` | Extra model ids to offer alongside the built-in presets |
+
+### 2. Put the key in the server's environment
+
+In the shell that starts MulmoTerminal, or a `.env` beside it:
+
+```bash
+OPENROUTER_API_KEY=sk-or-…
+```
+
+Restart the server after adding one. A provider whose token cannot be resolved **refuses to
+launch** — quietly falling back to Anthropic would send the session's prompts to a backend the
+directory did not select.
+
+### 3. A default for one project (optional)
+
+```json
+{
+  "provider": "openrouter",
+  "model": "moonshotai/kimi-k2.7-code"
+}
+```
+
+Every session opened in that directory starts on it.
+
+### Choosing at launch
+
+When at least one provider is usable, the empty cell's launch form grows a **MODEL** select. The
+choice applies to **that session only** — it does not rewrite `.mulmoterminal.json`. Leaving it
+alone uses the directory's default.
+
+The numbers beside each option are measured:
+
+```
+Kimi K2.7 Code · 3/3 · 14s · 262k
+```
+
+`3/3` is how many attempts of a real read-a-file-write-a-file task the model **completed**, out of
+attempts made. Models that answer fluently but never call a tool are exactly why that number is
+there. `14s` is the median run, `262k` the context window.
+
+- `0/4 — never used a tool` — answers arrive, the tool loop never fires
+- `not reachable from this account` — the OpenRouter account used for the measurement had every
+  serving provider excluded by its [privacy settings](https://openrouter.ai/settings/privacy).
+  **Not a defect in the model**; another account may run it fine
+- `not tested` — a model you added yourself under `models`
+
+The list lives in `common/modelPresets.ts`; re-measure with `scripts/model-trials.ts`:
+
+```bash
+yarn tsx scripts/model-trials.ts --provider openrouter --trials 3 <model-id>
+```
+
+### Limitation
+
+Providers cannot be combined with the Docker sandbox (`MULMOTERMINAL_SANDBOX`). The container
+inherits no environment, so such a session would silently run against **Anthropic instead of the
+backend you picked** — it is refused outright rather than downgraded.
 
 ## Per-project `.mulmoterminal.json` {#per-dir}
 
 Place this at the project root to change the appearance, sound, and header of **terminals (grid cells) opened in that directory**.
+
+### Which model to use
+
+```json
+{
+  "provider": "openrouter",
+  "model": "moonshotai/kimi-k2.7-code"
+}
+```
+
+The backend and model this directory's sessions start on. Omit `provider` and give only `model` to
+pick a different model on Anthropic itself. → [Running on another model](#providers)
 
 ### Name badge and colors
 

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -52,10 +52,107 @@ nav_order: 4
 | `launchers` | グリッドセルの「OR LAUNCH」に並ぶ起動コマンド |
 | `prRepos` | 横断 PR/Issue ビューの対象リポ |
 | `buttons` / `chips` | ヘッダーのボタン/チップ（プロジェクト設定とマージ。→ [ヘッダーのカスタマイズ](#header)） |
+| `providers` | Anthropic 互換の接続先（→ [別のモデルで動かす](#providers)） |
+
+## 別のモデルで動かす（プロバイダ） {#providers}
+
+Claude Code は Anthropic 互換のバックエンドなら何にでも接続できます。MulmoTerminal はその接続先を
+`config.json` から、**鍵はサーバを起動したときの環境変数から**読みます。鍵が設定ファイルに入ることはありません。
+
+### 1. 接続先を `~/.mulmoterminal/config.json` に足す
+
+```json
+{
+  "providers": [
+    {
+      "id": "openrouter",
+      "label": "OpenRouter",
+      "baseUrl": "https://openrouter.ai/api",
+      "tokenEnv": "OPENROUTER_API_KEY",
+      "maxOutputTokens": 16000,
+      "models": []
+    }
+  ]
+}
+```
+
+| キー | 役割 |
+|---|---|
+| `id` | `.mulmoterminal.json` や起動時の選択から参照する名前 |
+| `baseUrl` | **末尾に `/v1` を付けない** — Claude Code が `/v1/messages` を自分で足すため、付けると `/v1/v1/messages` になって 404 |
+| `tokenEnv` | 鍵が入っている環境変数の**名前**（値ではありません） |
+| `maxOutputTokens` | 省略時 16000。思考型モデルは出力枠が足りないと考えるだけで終わり、**返答が空**になります |
+| `models` | プリセットに加えて選択肢に出したいモデル id |
+
+### 2. 鍵はサーバの環境変数に置く
+
+MulmoTerminal を起動するシェル、または隣に置いた `.env` に書きます。
+
+```bash
+OPENROUTER_API_KEY=sk-or-…
+```
+
+追加したらサーバを再起動してください。鍵が解決できないプロバイダは**起動を拒否します** — Anthropic に
+黙って落とすと、そのディレクトリが選んでいないバックエンドにプロンプトが流れてしまうためです。
+
+### 3. プロジェクトの既定（任意）
+
+```json
+{
+  "provider": "openrouter",
+  "model": "moonshotai/kimi-k2.7-code"
+}
+```
+
+そのディレクトリで開いた端末はすべてこれで起動します。
+
+### 起動時に選ぶ
+
+プロバイダが 1 つでも使える状態なら、空セルの起動フォームに **MODEL** の選択欄が出ます。選んだ内容は
+**そのセッションだけ**に効き、`.mulmoterminal.json` の既定は書き換えません。選ばなければ既定のままです。
+
+選択肢の脇の数字は実測値です。
+
+```
+Kimi K2.7 Code · 3/3 · 14s · 262k
+```
+
+`3/3` は「ファイルを読んで別のファイルに書く」課題を**実際に完走した回数 / 試行回数**。プロンプトに
+流暢に答えても一度もツールを呼ばないモデルが実在するため、この数字が載っています。`14s` は中央値、
+`262k` はコンテキスト長です。
+
+- `0/4 — never used a tool` … 応答は返るがツールを使えない
+- `not reachable from this account` … 計測した OpenRouter アカウントの
+  [プライバシー設定](https://openrouter.ai/settings/privacy)で配信元が全部除外されていたもの。
+  **モデルの欠陥ではなく**、別のアカウントなら動く可能性があります
+- `not tested` … `models` に自分で足したもの
+
+一覧は `common/modelPresets.ts`、計測スクリプトは `scripts/model-trials.ts` です。
+
+```bash
+yarn tsx scripts/model-trials.ts --provider openrouter --trials 3 <model-id>
+```
+
+### 制限
+
+Docker サンドボックス（`MULMOTERMINAL_SANDBOX`）とは併用できません。コンテナは環境変数を引き継がず、
+そのまま動かすと**選んだはずのプロバイダではなく Anthropic に**接続してしまうため、明示的に拒否します。
 
 ## プロジェクトごとの `.mulmoterminal.json` {#per-dir}
 
 プロジェクト直下に置くと、**そのディレクトリで開いた端末（グリッドセル）**の見た目・音・ヘッダーを変えられます。
+
+### 使うモデル
+
+```json
+{
+  "provider": "openrouter",
+  "model": "moonshotai/kimi-k2.7-code"
+}
+```
+
+そのディレクトリのセッションが既定で使うバックエンドとモデル。`provider` を省いて `model` だけ書くと
+Anthropic のまま別のモデルを指定できます。→ [別のモデルで動かす](#providers)
 
 ### 名前バッジと色
 

--- a/plans/feat-584-model-picker.md
+++ b/plans/feat-584-model-picker.md
@@ -1,0 +1,66 @@
+# feat #584 — 起動時のモデル選択 + ヘッダー表示 + ヘルプ + ドキュメント
+
+#579 / #580 でディレクトリ単位のプロバイダ指定が入った。その上に、選ぶ・見える・分かる導線を載せる。
+
+## 1. モデル preset（`common/modelPresets.ts`）
+
+**動的取得はしない。** OpenRouter は `${baseUrl}/v1/models` で当たるが、Moonshot の Anthropic 互換
+`/anthropic` の下にカタログは無く（実測 404）、**カタログ URL は `ANTHROPIC_BASE_URL` から導出できない**。
+プロバイダごとの `modelsUrl` ＋ キャッシュ ＋ 失効表示を抱えるより、組み込み preset ＋ ユーザー追加が軽い。
+
+各エントリは**実測値**を持つ。`-p "say routed"` が通ってもツールループが壊れているモデルがあり、
+単発では判定できない（2 モデルが試行間で PASS/FAIL を往復した）ため、比率で持つ:
+
+- `measured` — 通過数 / 試行数 / 中央値秒 / 計測日
+- `unreachable` — アカウントのプライバシー設定で到達不能。**モデルの欠陥ではない**
+- `unmeasured` — ユーザーが自分で足したもの
+
+計測は `scripts/model-trials.ts`（本番と同じ spawn 経路で、ファイルを読んで書かせる）。preset を
+更新するときはこれを回す。
+
+## 2. ヘッダー Row 1 のモデル表示
+
+既に `ModelContextBadge` が Row 1 にあり `/api/session/:id` の `model` を出している。preset を参照して:
+
+- **ラベル** — `moonshotai/kimi-k2.7-code` → `Kimi K2.7 Code`（現状は id の末尾）
+- **コンテキスト長** — preset の `contextLength` を使う。現状は Claude 系の substring リストに
+  無いモデルで % を出さない（「決して推測しない」という既存方針は正しいので、**推測ではなく実データで埋める**）
+
+## 3. 起動時のピッカー
+
+新規ターミナルの起動フォームに provider / model のセレクトを出す。**使えるプロバイダがあるときだけ**。
+
+選択の寿命は**そのセッションだけ**。`.mulmoterminal.json` の `provider` / `model` は既定値で、
+選ばなければそれが使われる。あのファイルはユーザーが手で管理していて色・テーマ・スキルが同居するため、
+mulmoterminal が書き戻すのは別の判断として後回しにする。
+
+起動時の選択は ws の検索パラメータで渡す（`cwd` / `gui` と同じ経路）。`spawnClaudePty` は既に引数 7 個で
+lint 上限のため、引数は増やさず**セッション id をキーにした受け渡し**にする。
+
+## 4. ヘルプ
+
+プロバイダ未設定、または鍵が解決できないときに起動フォームから開ける。**そのとき足りていないものだけ**を出す:
+
+- `~/.mulmoterminal/config.json` の `providers` の例（コピー可）
+- 鍵はサーバの環境変数（`.env`）に置く。**設定ファイルには書かない**
+- `.mulmoterminal.json` に既定を書く例
+- 「LLM に設定してもらう」導線
+
+`resolveProvider` は既に理由つきで拒否する（「`OPENROUTER_API_KEY` が要る」等）ので、その文言をそのまま使う。
+
+## 5. ドキュメント
+
+`docs/guide/{ja,en}` に追記（このリポジトリの docs は Jekyll + markdown）。設定の書き方、鍵の置き場所、
+preset の意味（通過率・中央値）、到達不能の説明。
+
+## 6. 設定支援スキル
+
+`server/skills/mulmoterminal-config/SKILL.md` に provider / model の節を足す。既存スキルが
+`palettes.json` を出典にするのと同じ関係で、**`common/modelPresets.ts` を唯一の出典**として読ませる。
+
+## テスト
+
+- preset: 重複 id、ユーザー追加のマージ、`unmeasured` が付くこと
+- バッジ: preset にあるモデルのラベルと ctx%、無いモデルで % を出さないこと（既存方針の回帰）
+- ピッカー: プロバイダが無いときに出ないこと、選択が ws パラメータに乗ること
+- 起動時の選択が dir 設定の既定を上書きすること

--- a/scripts/model-trials.ts
+++ b/scripts/model-trials.ts
@@ -1,0 +1,134 @@
+// Measure whether a model can actually DRIVE Claude Code, and record how reliably.
+//
+// A model that answers `-p "say routed"` correctly can still be unusable: the reply comes
+// back fine while the tool loop never fires. Measured here, three models did exactly that
+// — one printed `Read(file_path=...)` as prose instead of calling the tool. So the probe
+// is a task that CANNOT be completed without tools: read a file, write another, and the
+// verdict is whether the output file exists with the right contents.
+//
+// It is also not a single-shot judgement. Two models flipped between PASS and FAIL across
+// runs, so each model is tried N times and the preset records the ratio rather than a
+// boolean. `common/modelPresets.ts` carries those numbers so the picker can show them.
+//
+//   yarn tsx scripts/model-trials.ts --provider openrouter --trials 3 <model> [<model>...]
+//
+// Needs the provider configured in ~/.mulmoterminal/config.json and its token in the
+// environment (the same rules resolveProvider enforces at spawn time).
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { claudeAdapter } from "../server/agents/claude.js";
+import { loadAppConfig } from "../server/config/app-config.js";
+import { cleanupSessionSettings, settingsArgument } from "../server/session/session-settings.js";
+import { requireResolution, resolveProvider, withoutUnset } from "../server/session/provider-env.js";
+
+const TRIAL_TIMEOUT_MS = 240_000;
+const ANSI = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*m`, "g");
+
+// Read one file, write another. Neither half is possible without a working tool loop.
+const PROBE_WORD = "banana";
+const PROBE_TASK =
+  "Read the file input.txt in the current directory. It contains one word. " +
+  "Write that word, uppercased, into output.txt. Then reply with just the word you wrote.";
+
+// Not reaching a model is not the same as a model failing. OpenRouter answers 404 "No
+// endpoints available matching your guardrail restrictions and data policy" when the
+// ACCOUNT excludes every provider serving that model — nothing to do with the model, and
+// a different account may run it fine. Three models in the first sweep looked broken
+// until the real response was read; the preset marks them unverified rather than dropping
+// them.
+export type TrialStatus = "measured" | "unreachable";
+
+export interface TrialResult {
+  model: string;
+  status: TrialStatus;
+  passed: number;
+  of: number;
+  medianSeconds: number | null;
+  failures: string[];
+}
+
+const UNREACHABLE = /No endpoints available|No endpoints found/i;
+
+const median = (values: number[]): number | null => {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+};
+
+// One attempt, through the SAME path a real session uses: the provider environment in a
+// settings file, the token stripped from the child's own environment.
+function attempt(provider: string, model: string): { ok: boolean; seconds: number; detail: string } {
+  const config = loadAppConfig(path.join(os.homedir(), ".mulmoterminal", "config.json"));
+  const resolved = requireResolution(resolveProvider({ provider, model }, config.providers, process.env));
+  const sessionId = `model-trial-${model.replace(/[^a-z0-9]/gi, "-")}`;
+  const settings = settingsArgument(sessionId, JSON.stringify({ env: resolved.env, hooks: {} }), true);
+  const cwd = mkdtempSync(path.join(os.tmpdir(), "mt-model-trial-"));
+  writeFileSync(path.join(cwd, "input.txt"), `${PROBE_WORD}\n`);
+  const started = Date.now();
+  try {
+    execFileSync(claudeAdapter.bin(), ["-p", PROBE_TASK, "--settings", settings, "--model", model, "--dangerously-skip-permissions"], {
+      cwd,
+      env: withoutUnset(process.env, resolved.unset) as NodeJS.ProcessEnv,
+      encoding: "utf8",
+      timeout: TRIAL_TIMEOUT_MS,
+    });
+    const out = path.join(cwd, "output.txt");
+    const wrote = existsSync(out) ? readFileSync(out, "utf8").trim() : "";
+    const ok = wrote.toUpperCase().includes(PROBE_WORD.toUpperCase());
+    return { ok, seconds: Math.round((Date.now() - started) / 1000), detail: ok ? "" : `no tool write (wrote ${JSON.stringify(wrote)})` };
+  } catch (err) {
+    const e = err as { stderr?: string; stdout?: string; message?: string; signal?: string };
+    // Keep the WHOLE message: the interesting part is rarely at the end — the tail is
+    // usually Claude Code's benign "connectors are disabled" warning, which hid the real
+    // 404 through the first sweep of this script.
+    const detail = ((e.stderr ?? "") + (e.stdout ?? "") + (e.message ?? "")).replace(ANSI, "").replace(/\s+/g, " ");
+    return { ok: false, seconds: Math.round((Date.now() - started) / 1000), detail: e.signal === "SIGTERM" ? "timeout" : detail };
+  } finally {
+    cleanupSessionSettings(sessionId);
+  }
+}
+
+export function runTrials(provider: string, model: string, trials: number): TrialResult {
+  const seconds: number[] = [];
+  const failures: string[] = [];
+  for (let i = 0; i < trials; i += 1) {
+    const result = attempt(provider, model);
+    if (result.ok) seconds.push(result.seconds);
+    else if (UNREACHABLE.test(result.detail)) return { model, status: "unreachable", passed: 0, of: 0, medianSeconds: null, failures: [result.detail] };
+    else failures.push(result.detail);
+  }
+  return { model, status: "measured", passed: seconds.length, of: trials, medianSeconds: median(seconds), failures };
+}
+
+const FAILURE_EXCERPT = 120;
+
+// What to add after the numbers: why there are none, or the first thing that went wrong.
+function trialNote(result: TrialResult): string {
+  if (result.status === "unreachable") return "  unreachable from this account (openrouter.ai/settings/privacy)";
+  if (result.failures.length === 0) return "";
+  return `  ${result.failures[0].slice(0, FAILURE_EXCERPT)}`;
+}
+
+const flag = (name: string, fallback: string): string => {
+  const at = process.argv.indexOf(`--${name}`);
+  return at === -1 ? fallback : (process.argv[at + 1] ?? fallback);
+};
+
+if (process.argv[1]?.endsWith("model-trials.ts")) {
+  const provider = flag("provider", "openrouter");
+  const trials = Number(flag("trials", "3"));
+  const models = process.argv.slice(2).filter((arg, i, all) => !arg.startsWith("--") && !all[i - 1]?.startsWith("--"));
+  if (models.length === 0) {
+    console.error("usage: yarn tsx scripts/model-trials.ts [--provider <id>] [--trials <n>] <model>...");
+    process.exit(1);
+  }
+  for (const model of models) {
+    const result = runTrials(provider, model, trials);
+    const rate = result.status === "unreachable" ? "n/a" : `${result.passed}/${result.of}`;
+    const speed = result.medianSeconds === null ? "-" : `${result.medianSeconds}s`;
+    console.log(`${rate.padEnd(6)} ${speed.padEnd(6)} ${model}${trialNote(result)}`);
+  }
+}

--- a/server/config/config-body.ts
+++ b/server/config/config-body.ts
@@ -1,0 +1,27 @@
+// Which fields of a POST /api/config body are the wrong SHAPE — the check that decides
+// between a 400 and a merge.
+//
+// Kept pure and separate from the route because the route module reads the user's real
+// config file at import time, so the rule could not otherwise be tested without touching
+// the developer's home directory.
+//
+// Why shape is checked before merging at all: the merge treats "present" as "replace", and
+// every sanitizer answers a non-array with an empty array. So a body like
+// `{"providers": {}}` would not fail — it would silently WIPE the saved providers. The
+// guard exists so a malformed field is rejected instead of applied as a deletion.
+
+// Must be an array when present. A partial POST may omit any of them.
+export const ARRAY_FIELDS = ["cwdPresets", "prRepos", "launchers", "userMcpServers", "providers"] as const;
+
+// `buttons`/`chips` are nullable (null = unconfigured), so they can't join ARRAY_FIELDS:
+// reject any present value that is neither an array nor null instead of letting the
+// sanitizer silently coerce it to null.
+export const NULLABLE_ARRAY_FIELDS = ["buttons", "chips"] as const;
+
+export function badArrayField(body: Record<string, unknown>): string | null {
+  return ARRAY_FIELDS.find((field) => body[field] !== undefined && !Array.isArray(body[field])) ?? null;
+}
+
+export function badNullableArrayField(body: Record<string, unknown>): string | null {
+  return NULLABLE_ARRAY_FIELDS.find((field) => body[field] !== undefined && body[field] !== null && !Array.isArray(body[field])) ?? null;
+}

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -10,6 +10,7 @@ import type { Express } from "express";
 import { loadAppConfig, saveAppConfig, mergeConfigUpdate, toPublicAppConfig, type AppConfig } from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type Provider, type UserMcpServer } from "./config-schema.js";
+import { launchOptions } from "./launch-options.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -102,6 +103,13 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });
     config = next;
     res.json(configResponse());
+  });
+
+  // What the launch form may offer (#584): the configured backends, whether each can be
+  // reached right now, and the models it can run. Never the tokens themselves — only the
+  // NAME of the variable each is read from, which is what the setup help has to say.
+  app.get("/api/launch-options", (_req, res) => {
+    res.json(launchOptions(config.providers, process.env));
   });
 
   // Stream the user's custom attention sound (their own file, set in config). The

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -11,6 +11,7 @@ import { loadAppConfig, saveAppConfig, mergeConfigUpdate, toPublicAppConfig, typ
 import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type Provider, type UserMcpServer } from "./config-schema.js";
 import { launchOptions } from "./launch-options.js";
+import { badArrayField, badNullableArrayField } from "./config-body.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -55,25 +56,6 @@ export function getPushEnabled(): boolean {
 // scheduler wiring (a restart, currently). Off by default.
 export function getWorklogConfig(): { enabled: boolean; intervalHours: number } {
   return { enabled: config.worklogEnabled, intervalHours: config.worklogIntervalHours };
-}
-
-// Body fields that must be an array when present (a partial POST /api/config may omit any).
-const ARRAY_FIELDS = ["cwdPresets", "prRepos", "launchers", "userMcpServers"] as const;
-function badArrayField(body: Record<string, unknown>): string | null {
-  for (const field of ARRAY_FIELDS) {
-    if (body[field] !== undefined && !Array.isArray(body[field])) return field;
-  }
-  return null;
-}
-
-// `buttons`/`chips` are nullable (null = unconfigured), so they can't join ARRAY_FIELDS: reject any present
-// value that is neither an array nor null instead of letting the sanitizer silently coerce it to null.
-const NULLABLE_ARRAY_FIELDS = ["buttons", "chips"] as const;
-function badNullableArrayField(body: Record<string, unknown>): string | null {
-  for (const field of NULLABLE_ARRAY_FIELDS) {
-    if (body[field] !== undefined && body[field] !== null && !Array.isArray(body[field])) return field;
-  }
-  return null;
 }
 
 export function mountConfigRoutes(app: Express, claudeCwd: string): void {

--- a/server/config/config-schema.ts
+++ b/server/config/config-schema.ts
@@ -144,6 +144,10 @@ export const providerSchema = z.object({
   baseUrl: z.string().min(1),
   tokenEnv: z.string().min(1),
   maxOutputTokens: z.number().int().positive().optional(),
+  // Extra model ids to offer in the launch picker, on top of the built-in presets
+  // (common/modelPresets.ts). Listed here rather than measured, so the picker shows them
+  // without the pass-rate the presets carry.
+  models: z.array(z.string().trim().min(1)).catch([]).default([]),
 });
 export type Provider = z.infer<typeof providerSchema>;
 
@@ -239,6 +243,10 @@ const writableDirConfigSchema = z.object({
   chips: z.array(writableHeaderChipSchema).max(MAX_CHIPS).optional(),
   // Header Skill-menu allowlist: show only these skill slugs, in this order. Omit to show all.
   skills: z.array(nonEmptyText).max(MAX_SKILL_FILTER).optional(),
+  // Which backend this directory's sessions run on (#579). `provider` names an entry in the
+  // global config's `providers`; `model` alone picks a different model on Anthropic itself.
+  provider: nonEmptyText.optional(),
+  model: nonEmptyText.optional(),
 });
 
 export function dirConfigJsonSchema(): Record<string, unknown> {

--- a/server/config/config-schema.ts
+++ b/server/config/config-schema.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 // Shared with the client dir-config parser so the two can't drift — see common/themeColors.ts.
 import { THEME_COLOR_KEYS } from "../../common/themeColors.js";
 import { THEME_IDS } from "../../common/themeIds.js";
+import { isUsableModelId } from "../../common/modelIds.js";
 
 // ---- shared constants ---------------------------------------------------------------------
 
@@ -134,11 +135,16 @@ export const dirColorsField = z
   .nullable()
   .catch(null);
 
+// A provider/model id the launch path will actually accept. Enforced here too, so the
+// picker can never offer an id that the ws query drops on the way to the spawn — a
+// dropped provider whose model survives would start the session on Anthropic instead.
+const modelIdSchema = z.string().trim().refine(isUsableModelId);
+
 // An Anthropic-compatible backend a directory can point its sessions at (#579). The key
 // itself is never stored here — `tokenEnv` names the env var the SERVER reads it from,
 // because this config is served over HTTP to the browser and the phone.
 export const providerSchema = z.object({
-  id: z.string().min(1),
+  id: modelIdSchema,
   label: z.string().min(1),
   // No trailing /v1: Claude Code appends /v1/messages itself.
   baseUrl: z.string().min(1),
@@ -146,8 +152,13 @@ export const providerSchema = z.object({
   maxOutputTokens: z.number().int().positive().optional(),
   // Extra model ids to offer in the launch picker, on top of the built-in presets
   // (common/modelPresets.ts). Listed here rather than measured, so the picker shows them
-  // without the pass-rate the presets carry.
-  models: z.array(z.string().trim().min(1)).catch([]).default([]),
+  // without the pass-rate the presets carry. A malformed entry is dropped on its own —
+  // one typo must not take the provider's other models with it.
+  models: z
+    .array(z.unknown())
+    .transform((entries) => entries.filter((entry): entry is string => typeof entry === "string" && isUsableModelId(entry.trim())).map((entry) => entry.trim()))
+    .catch([])
+    .default([]),
 });
 export type Provider = z.infer<typeof providerSchema>;
 

--- a/server/config/launch-options.ts
+++ b/server/config/launch-options.ts
@@ -1,0 +1,45 @@
+// What the launch form may offer: the backends this server can actually reach right now,
+// each with the models it can run (#584).
+//
+// Kept pure — providers and the environment come in as arguments — because the interesting
+// part is the decision, not the reading: which backend is offerable, and what to tell the
+// user about one that isn't. A provider that is configured but missing its token still
+// appears, carrying the same sentence a session would have refused with, so the help can
+// name the one thing to fix instead of describing the whole setup.
+import { presetsForProvider, type ModelPreset } from "../../common/modelPresets.js";
+import { usableProvider, type ProviderConfig } from "../session/provider-env.js";
+
+export interface LaunchProviderOption {
+  id: string;
+  label: string;
+  // False when this server cannot start a session on it as configured.
+  ready: boolean;
+  // Why not, in resolveProvider's own words. Absent when ready.
+  reason?: string;
+  // The env var this provider's key is read from — the help needs to name it, and it is
+  // the NAME, never the value.
+  tokenEnv: string;
+  models: ModelPreset[];
+}
+
+export interface LaunchOptions {
+  providers: LaunchProviderOption[];
+  // True when at least one provider can be launched on. The picker hides itself otherwise:
+  // with no reachable backend there is nothing to choose between, only setup to explain.
+  anyReady: boolean;
+}
+
+export function launchOptions(providers: readonly ProviderConfig[], env: NodeJS.ProcessEnv): LaunchOptions {
+  const options = providers.map((provider): LaunchProviderOption => {
+    const usable = usableProvider(provider, env);
+    return {
+      id: provider.id,
+      label: provider.label,
+      ready: usable.ok,
+      ...(usable.ok ? {} : { reason: usable.reason }),
+      tokenEnv: provider.tokenEnv,
+      models: presetsForProvider(provider.id, provider.models ?? []),
+    };
+  });
+  return { providers: options, anyReady: options.some((option) => option.ready) };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -43,6 +43,7 @@ import {
   devTerminalSessionsHydrated,
   hiddenSessions,
   knownSessions,
+  launchChoices,
   lastPrompts,
   lastResponses,
   lastTitleAttemptMs,
@@ -274,6 +275,7 @@ function reap(id: string) {
   // An unpersisted new session vanishes with its pty; a persisted one stays
   // visible via its on-disk record.
   knownSessions.delete(id);
+  launchChoices.delete(id); // the picked backend dies with the session that used it
   lastPrompts.delete(id); // don't leak prompt text for torn-down sessions
   lastResponses.delete(id); // ditto, and keep this map from growing across closed sessions
   forgetTitle(id);

--- a/server/index.ts
+++ b/server/index.ts
@@ -467,7 +467,7 @@ const { translateViaHiddenChat } = createTranslationWorker({
   reap: (id) => reap(id),
   spawnHiddenChat: (sessionId, prompt) => {
     // ws=null → headless; the worker buffers output nobody reads. Default cwd = CLAUDE_CWD (trusted).
-    spawnClaudePty(sessionId, null, null, prompt);
+    spawnClaudePty(sessionId, null, null, { initialPrompt: prompt });
   },
 });
 
@@ -502,8 +502,8 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   // seed always auto-runs as codex's positional first-turn prompt, with the GUI MCP attached.
   try {
     if (agent === "codex") spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, codexifySkillSeed(message));
-    else if (draft) spawnClaudePty(sessionId, null, null, undefined, CLAUDE_CWD, true, message);
-    else spawnClaudePty(sessionId, null, null, message);
+    else if (draft) spawnClaudePty(sessionId, null, null, { draft: message });
+    else spawnClaudePty(sessionId, null, null, { initialPrompt: message });
   } catch (err) {
     console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);
     return res.json({ message: `Failed to spawn a new session: ${messageOf(err)}` });
@@ -850,7 +850,7 @@ const feedsSpawnWorker: AgentWorkerRunner = async ({ message, hidden }) => {
   try {
     const sessionId = randomUUID();
     if (hidden) hiddenSessions.add(sessionId);
-    spawnClaudePty(sessionId, null, null, message);
+    spawnClaudePty(sessionId, null, null, { initialPrompt: message });
     return { ok: true, chatId: sessionId };
   } catch (err) {
     return { ok: false, error: messageOf(err) };
@@ -864,7 +864,7 @@ initFeedsBackend({ workspace: CLAUDE_CWD, spawnWorker: feedsSpawnWorker });
 // signs in as the user) starts the actual Firestore runner + presence heartbeat.
 const remoteHostSpawnChat = (message: string) => {
   const sessionId = randomUUID();
-  spawnClaudePty(sessionId, null, null, message);
+  spawnClaudePty(sessionId, null, null, { initialPrompt: message });
   return { chatId: sessionId };
 };
 // The phone's remote terminal view (#435). Both accessors live here because the PTY table
@@ -966,7 +966,7 @@ setInterval(() => void scheduledSessions.sweep(), SCHEDULED_SWEEP_INTERVAL_MS).u
 function spawnScheduledChat(message: string): void {
   const sessionId = randomUUID();
   try {
-    spawnClaudePty(sessionId, null, null, message);
+    spawnClaudePty(sessionId, null, null, { initialPrompt: message });
     scheduledSessions.register(sessionId);
   } catch (err) {
     console.error(`[scheduler] failed to spawn chat for a scheduled task: ${messageOf(err)}`);

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -18,6 +18,8 @@ import { resolveButtonCommand, shellQuoteFor } from "../config/header-resolve.js
 import { resolveScript } from "../files/scripts.js";
 import { refreshHostKeychainIfExpired, writeSandboxCredentials } from "../infra/sandbox.js";
 import { tmuxHasSession } from "../infra/tmux.js";
+import type { SpawnClaudeOptions } from "../session/spawn-claude.js";
+import { launchChoiceFromParams } from "../session/launch-choice.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
 import { codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
@@ -39,15 +41,7 @@ export interface WsRouteDeps {
   reattachPty: (entry: PtyEntry, ws: WebSocket, sessionId: string) => PtyEntry;
   handleClientFrame: (entry: PtyEntry, ws: WebSocket, raw: { toString(): string }, sessionId: string) => void;
   handleClientClose: (entry: PtyEntry, ws: WebSocket, sessionId: string) => void;
-  spawnClaudePty: (
-    sessionId: string,
-    resume: string | null,
-    ws: WebSocket | null,
-    initialPrompt?: string,
-    cwd?: string,
-    attachGuiMcp?: boolean,
-    draft?: string,
-  ) => PtyEntry;
+  spawnClaudePty: (sessionId: string, resume: string | null, ws: WebSocket | null, options?: SpawnClaudeOptions) => PtyEntry;
   spawnCodexPty: (
     sessionId: string,
     ws: WebSocket | null,
@@ -210,6 +204,11 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: { u
   // (the single view) keeps main's behavior: GUI MCP attached + strict.
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
+  // ?provider=/?model= — what the launch form picked for THIS session (#584). It replaces
+  // the directory's default; absent (the usual case) leaves that default alone. Ignored on
+  // a reattach, where no spawn happens and the running session keeps what it started with.
+  const launch = launchChoiceFromParams(url.searchParams);
+
   // Decide the effective session id BEFORE telling the browser. A requested id
   // is honored only if it can actually be served: a live pty (reattach) or an
   // on-disk transcript (`--resume`). A requested id that's neither — e.g. a cell
@@ -253,7 +252,7 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: { u
     // file. On reconnect, re-sync it from the (now-refreshed) Keychain so a token that
     // rotated since spawn doesn't leave the reattached session stuck at "Not logged in".
     if (live?.sandbox) writeSandboxCredentials(sessionId);
-    entry = live ? deps.reattachPty(live, ws, sessionId) : deps.spawnClaudePty(sessionId, resume, ws, undefined, cwd, attachGuiMcp);
+    entry = live ? deps.reattachPty(live, ws, sessionId) : deps.spawnClaudePty(sessionId, resume, ws, { cwd, attachGuiMcp, launch });
   } catch (err) {
     // A failed spawn (claude missing, or node-pty's spawn-helper not executable)
     // must close just this connection — never crash the whole server.

--- a/server/session/launch-choice.ts
+++ b/server/session/launch-choice.ts
@@ -58,6 +58,13 @@ export interface ChoiceInputs {
 // necessarily to the one being resumed. What the session was actually started on is the
 // only defensible answer; the directory's default is the fallback when this server never
 // saw it start.
+//
+// Only the PICKER'S choice is remembered, and the asymmetry is deliberate. That choice has
+// nowhere else to live, so losing it drops the session onto a backend its user never chose
+// for it. The directory's default IS that backend — and like every other field in
+// .mulmoterminal.json (theme, colours, the skill list) it is read fresh on each spawn, so
+// editing the file takes effect. Making these two keys uniquely sticky would also read
+// differently either side of a server restart, since this memory is in-process.
 export function effectiveChoice({ launch, remembered, dir, resuming }: ChoiceInputs): DirModelChoice {
   if (resuming) return remembered ?? dir;
   return launch ?? dir;

--- a/server/session/launch-choice.ts
+++ b/server/session/launch-choice.ts
@@ -1,0 +1,44 @@
+// What the browser picked in the launch form (#584), turned into a provider/model choice.
+//
+// These two values reach `claude --model` as argv and ANTHROPIC_MODEL in the child's
+// environment, so they are validated here rather than trusted: a model id is an opaque
+// vendor string, but it is never blank, never long, and never carries whitespace, control
+// characters, or a leading dash that argv would read as another flag.
+import type { DirModelChoice } from "./provider-env.js";
+
+const MAX_ID_LENGTH = 120;
+
+// Vendor ids in the wild: `moonshotai/kimi-k2.7-code`, `gpt-5.6-luna-pro`, `z-ai/glm-5.2`.
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const isUsableId = (value: string): boolean => value.length <= MAX_ID_LENGTH && ID_RE.test(value);
+
+const cleanParam = (params: URLSearchParams, name: string): string | null => {
+  const value = params.get(name);
+  if (value === null) return null;
+  const trimmed = value.trim();
+  if (!isUsableId(trimmed)) {
+    console.warn(`[ws] ignoring unusable ${name} in launch params: ${JSON.stringify(value)}`);
+    return null;
+  }
+  return trimmed;
+};
+
+// Undefined — the usual case — means "whatever this directory's .mulmoterminal.json says".
+// Returning a partial choice is intentional: a bare `model` is a valid pick on the default
+// Anthropic backend, and a `provider` with no model is refused later by resolveProvider
+// with a message that names what is missing.
+export function launchChoiceFromParams(params: URLSearchParams): DirModelChoice | undefined {
+  const provider = cleanParam(params, "provider");
+  const model = cleanParam(params, "model");
+  if (!provider && !model) return undefined;
+  return { provider, model };
+}
+
+// What a session actually runs on: the launch form's pick when there was one, otherwise
+// the directory's default. Whole-pair, never field-by-field — mixing a provider from the
+// picker with a model from .mulmoterminal.json produces a combination neither of them
+// asked for, and the pairing is the part that has to be right.
+export function effectiveChoice(launch: DirModelChoice | undefined, dir: DirModelChoice): DirModelChoice {
+  return launch ?? dir;
+}

--- a/server/session/launch-choice.ts
+++ b/server/session/launch-choice.ts
@@ -1,44 +1,64 @@
 // What the browser picked in the launch form (#584), turned into a provider/model choice.
 //
 // These two values reach `claude --model` as argv and ANTHROPIC_MODEL in the child's
-// environment, so they are validated here rather than trusted: a model id is an opaque
-// vendor string, but it is never blank, never long, and never carries whitespace, control
-// characters, or a leading dash that argv would read as another flag.
+// environment, so they are validated here rather than trusted — against the same id shape
+// the config schema accepts, so the picker can never offer something this drops.
+//
+// The parsing is ALL-OR-NOTHING on purpose. Keeping the usable half of a bad pair is the
+// one outcome that must not happen: a rejected `provider` whose `model` survives resolves
+// to Anthropic running another vendor's model id, which is the silent wrong-backend this
+// whole feature exists to prevent. A wholly-dropped choice falls back to the directory's
+// own default — at least a pair its owner chose.
+import { isUsableModelId } from "../../common/modelIds.js";
 import type { DirModelChoice } from "./provider-env.js";
 
-const MAX_ID_LENGTH = 120;
+type CleanParam = { ok: true; value: string | null } | { ok: false };
 
-// Vendor ids in the wild: `moonshotai/kimi-k2.7-code`, `gpt-5.6-luna-pro`, `z-ai/glm-5.2`.
-const ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
-
-const isUsableId = (value: string): boolean => value.length <= MAX_ID_LENGTH && ID_RE.test(value);
-
-const cleanParam = (params: URLSearchParams, name: string): string | null => {
-  const value = params.get(name);
-  if (value === null) return null;
-  const trimmed = value.trim();
-  if (!isUsableId(trimmed)) {
-    console.warn(`[ws] ignoring unusable ${name} in launch params: ${JSON.stringify(value)}`);
-    return null;
+const cleanParam = (params: URLSearchParams, name: string): CleanParam => {
+  const raw = params.get(name);
+  if (raw === null) return { ok: true, value: null };
+  const value = raw.trim();
+  if (!isUsableModelId(value)) {
+    console.warn(`[ws] ignoring launch params: unusable ${name} ${JSON.stringify(raw)}`);
+    return { ok: false };
   }
-  return trimmed;
+  return { ok: true, value };
 };
 
 // Undefined — the usual case — means "whatever this directory's .mulmoterminal.json says".
-// Returning a partial choice is intentional: a bare `model` is a valid pick on the default
-// Anthropic backend, and a `provider` with no model is refused later by resolveProvider
-// with a message that names what is missing.
+// A provider with no model still travels: resolveProvider refuses it with a message naming
+// what is missing, which is more use to the reader than quietly ignoring their pick.
 export function launchChoiceFromParams(params: URLSearchParams): DirModelChoice | undefined {
   const provider = cleanParam(params, "provider");
   const model = cleanParam(params, "model");
-  if (!provider && !model) return undefined;
-  return { provider, model };
+  if (!provider.ok || !model.ok) return undefined;
+  if (!provider.value && !model.value) return undefined;
+  return { provider: provider.value, model: model.value };
 }
 
-// What a session actually runs on: the launch form's pick when there was one, otherwise
-// the directory's default. Whole-pair, never field-by-field — mixing a provider from the
-// picker with a model from .mulmoterminal.json produces a combination neither of them
-// asked for, and the pairing is the part that has to be right.
-export function effectiveChoice(launch: DirModelChoice | undefined, dir: DirModelChoice): DirModelChoice {
+export interface ChoiceInputs {
+  // What the browser picked for the session it is starting now.
+  launch?: DirModelChoice;
+  // What THIS session id was started on, when this server is the one that started it.
+  remembered?: DirModelChoice;
+  // The directory's own default.
+  dir: DirModelChoice;
+  // Continuing an existing conversation rather than beginning one.
+  resuming: boolean;
+}
+
+// What a session actually runs on.
+//
+// Whole-pair, never field-by-field: mixing a provider from one source with a model from
+// another produces a combination neither asked for, and the pairing is the part that has
+// to be right.
+//
+// A resume ignores the picker entirely. The browser re-sends whatever its cell still holds
+// on every reconnect, and that value belongs to the session that cell launched — not
+// necessarily to the one being resumed. What the session was actually started on is the
+// only defensible answer; the directory's default is the fallback when this server never
+// saw it start.
+export function effectiveChoice({ launch, remembered, dir, resuming }: ChoiceInputs): DirModelChoice {
+  if (resuming) return remembered ?? dir;
   return launch ?? dir;
 }

--- a/server/session/provider-env.ts
+++ b/server/session/provider-env.ts
@@ -24,6 +24,8 @@ export interface ProviderConfig {
   // server's own environment, so no secret is stored in a config file the app serves.
   tokenEnv: string;
   maxOutputTokens?: number;
+  // Extra model ids the user listed for this provider; offered alongside the presets.
+  models?: readonly string[];
 }
 
 export interface DirModelChoice {
@@ -55,6 +57,19 @@ export const isUsableBaseUrl = (baseUrl: string): boolean => /^https?:\/\/\S+$/.
 
 const NOTHING: ProviderResolution = { model: null, env: {}, unset: [] };
 
+// Whether a provider can be used at all, independent of which model is picked — and its
+// token when it can. The launch picker asks this to decide what to offer and what to say
+// when it can't, so the wording a session refuses with and the wording the UI explains
+// with are the same sentence.
+export function usableProvider(provider: ProviderConfig, env: NodeJS.ProcessEnv): { ok: true; token: string } | { ok: false; reason: string } {
+  if (!isUsableBaseUrl(provider.baseUrl)) {
+    return { ok: false, reason: `provider '${provider.id}' has an unusable baseUrl '${provider.baseUrl}' — an http(s) URL without a trailing /v1` };
+  }
+  const token = env[provider.tokenEnv];
+  if (!token) return { ok: false, reason: `provider '${provider.id}' needs ${provider.tokenEnv} in the server's environment — refusing to start` };
+  return { ok: true, token };
+}
+
 const providerEnv = (provider: ProviderConfig, model: string, token: string): Record<string, string> => ({
   ANTHROPIC_BASE_URL: provider.baseUrl,
   ANTHROPIC_AUTH_TOKEN: token,
@@ -84,15 +99,10 @@ export function resolveProvider(
   const provider = providers.find((candidate) => candidate.id === choice.provider);
   if (!provider) return { ok: false, reason: `unknown provider '${choice.provider}' — add it to config.json under "providers"` };
   if (sandbox) return { ok: false, reason: `provider '${provider.id}' cannot run in the Docker sandbox yet` };
-  if (!isUsableBaseUrl(provider.baseUrl)) {
-    return { ok: false, reason: `provider '${provider.id}' has an unusable baseUrl '${provider.baseUrl}' — an http(s) URL without a trailing /v1` };
-  }
+  const usable = usableProvider(provider, env);
+  if (!usable.ok) return usable;
   if (!choice.model) return { ok: false, reason: `provider '${provider.id}' needs a model — set "model" in .mulmoterminal.json` };
-  const token = env[provider.tokenEnv];
-  if (!token) {
-    return { ok: false, reason: `provider '${provider.id}' needs ${provider.tokenEnv} in the server's environment — refusing to start` };
-  }
-  return { ok: true, value: { model: choice.model, env: providerEnv(provider, choice.model, token), unset: ["ANTHROPIC_API_KEY"] } };
+  return { ok: true, value: { model: choice.model, env: providerEnv(provider, choice.model, usable.token), unset: ["ANTHROPIC_API_KEY"] } };
 }
 
 // A directory asked for a backend that cannot be honoured. Thrown rather than downgraded:

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -10,6 +10,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
+import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, parseActivityState } from "./activity-state.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
@@ -29,6 +30,13 @@ export const ptys = new Map<string, PtyEntry>(); // id -> { term, ws, buffer }
 // freshly created session shows in the sidebar immediately. An entry is dropped
 // once the file exists (the on-disk record takes over) or the pty is reaped.
 export const knownSessions = new Map<string, KnownSession>(); // id -> { createdAt, title }
+
+// What each session was STARTED on, when the launch form picked it rather than the
+// directory (#584). Read back on resume: the browser re-sends its cell's pick on every
+// reconnect, and that value belongs to the session the cell launched, not necessarily to
+// the one being resumed. Process-lifetime only — after a restart a resumed session falls
+// back to the directory's default, same as one this server never started.
+export const launchChoices = new Map<string, DirModelChoice>(); // id -> { provider, model }
 
 // Sessions spawned as hidden background workers (spawnBackgroundChat hidden:true).
 // They list normally but never render bold/unread. Process-lifetime only (not

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -16,27 +16,31 @@ import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 import { loadDirConfig } from "../config/dir-config.js";
 import { getProviders } from "../config/config-routes.js";
-import { requireResolution, resolveProvider } from "./provider-env.js";
+import { requireResolution, resolveProvider, type DirModelChoice } from "./provider-env.js";
 import { settingsArgument, withSettingsCleanup } from "./session-settings.js";
+import { effectiveChoice } from "./launch-choice.js";
+
+export interface SpawnClaudeOptions {
+  // Passed to claude as the first turn, so the session starts working before anyone
+  // opens it. Mutually exclusive with `draft`.
+  initialPrompt?: string;
+  cwd?: string;
+  attachGuiMcp?: boolean;
+  // Typed into the input box once claude is ready, NOT submitted — the user reviews it.
+  draft?: string;
+  // What the browser picked in the launch form (#584). Replaces the directory's default
+  // as a PAIR: a provider from one source with a model from the other is a combination
+  // neither of them asked for. Absent — the usual case — means "use the directory's".
+  launch?: DirModelChoice;
+}
 
 export function createClaudeSpawner(deps: SpawnDeps) {
   // Spawn a fresh claude PTY for this session, register it, and wire its output /
   // exit back to the browser socket. `ws` may be null for a session spawned without
   // a viewer yet (e.g. spawnBackgroundChat) — output just buffers until a client
-  // reattaches. `initialPrompt`, when given, is passed to claude as the first turn
-  // so the session starts working immediately, before anyone opens it. `draft` is the
-  // opposite: it is NOT auto-submitted — once claude's UI is ready the text is typed
-  // into the input box (no Enter) so the user can review / edit / send it. Pass one or
-  // the other, never both.
-  function spawnClaudePty(
-    sessionId: string,
-    resume: string | null,
-    ws: WebSocket | null,
-    initialPrompt?: string,
-    cwd: string = CLAUDE_CWD,
-    attachGuiMcp: boolean = true,
-    draft?: string,
-  ): PtyEntry {
+  // reattaches.
+  function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, options: SpawnClaudeOptions = {}): PtyEntry {
+    const { initialPrompt, cwd = CLAUDE_CWD, attachGuiMcp = true, draft, launch } = options;
     // attachGuiMcp picks the MCP mode (see buildClaudeArgs): the single view (default)
     // attaches the GUI MCP + --strict-mcp-config (main's classic behavior); the grid's
     // dev terminals attach neither, so the user's + project's MCP servers load normally.
@@ -54,7 +58,8 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     // select, which is exactly what the provider contract exists to prevent. The ws route
     // turns it into a message in the terminal.
     const dir = loadDirConfig(cwd);
-    const resolved = requireResolution(resolveProvider({ provider: dir.provider, model: dir.model }, getProviders(), process.env, sandbox));
+    const choice = effectiveChoice(launch, { provider: dir.provider, model: dir.model });
+    const resolved = requireResolution(resolveProvider(choice, getProviders(), process.env, sandbox));
 
     const hookSettings = deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, resolved.env);
     const args = buildClaudeArgs({

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -6,7 +6,7 @@ import { CLAUDE_CWD } from "../config/env.js";
 import { getUserMcpServers } from "../config/config-routes.js";
 import { SANDBOX_HOST } from "../infra/sandbox.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
-import { knownSessions, ptys } from "./registry.js";
+import { knownSessions, launchChoices, ptys } from "./registry.js";
 import { ptySpawn, sandboxWouldRun, spawnSandboxEntry } from "./pty-spawn.js";
 import { attachDraftInjection } from "./draft-injection.js";
 import { sendExitAndClose, sendFrame } from "./ws-frames.js";
@@ -58,8 +58,16 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     // select, which is exactly what the provider contract exists to prevent. The ws route
     // turns it into a message in the terminal.
     const dir = loadDirConfig(cwd);
-    const choice = effectiveChoice(launch, { provider: dir.provider, model: dir.model });
+    const choice = effectiveChoice({
+      launch,
+      remembered: launchChoices.get(sessionId),
+      dir: { provider: dir.provider, model: dir.model },
+      resuming: canResume,
+    });
     const resolved = requireResolution(resolveProvider(choice, getProviders(), process.env, sandbox));
+    // Remembered so a later resume continues on the backend this session began on, instead
+    // of silently moving to the directory's default mid-conversation.
+    if (launch) launchChoices.set(sessionId, choice);
 
     const hookSettings = deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, resolved.env);
     const args = buildClaudeArgs({

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mulmoterminal-config
-description: Create or edit a .mulmoterminal.json to customize how a directory looks and behaves in MulmoTerminal — its name badge, chrome colors, xterm palette, attention sound, and header buttons/chips. Walks a beginner through it: pick directories with checkboxes, start from a colour preset (warm / tropical / cool / bold), apply it and look at the real cell, then refine. Configures the current directory OR several of your recent MulmoTerminal directories at once. Use when the user wants to configure, theme, color-code, rename, or add header buttons/chips to a project's terminal — for one project or across many.
+description: Create or edit a .mulmoterminal.json to customize how a directory looks and behaves in MulmoTerminal — its name badge, chrome colors, xterm palette, attention sound, header buttons/chips, and which model/provider its sessions run on. Also sets up an Anthropic-compatible backend (OpenRouter, Moonshot, a gateway) in the global config. Walks a beginner through it: pick directories with checkboxes, start from a colour preset (warm / tropical / cool / bold), apply it and look at the real cell, then refine. Configures the current directory OR several of your recent MulmoTerminal directories at once. Use when the user wants to configure, theme, color-code, rename, or add header buttons/chips to a project's terminal — for one project or across many.
 ---
 
 # Configure a MulmoTerminal directory
@@ -40,7 +40,7 @@ no `cwdPresets`, say there's no history yet and ask for the paths.
 ### 2. Pick what to configure — checkboxes again
 
 One `multiSelect` question: **Name badge + chrome colors** / **Terminal palette** / **Header buttons** /
-**Header chips** / **Attention sound**. Configure only what they ticked.
+**Header chips** / **Attention sound** / **Which model it runs on**. Configure only what they ticked.
 
 ### 3. Choose a colour direction — preset first, never a blank hex
 
@@ -129,6 +129,26 @@ malformed, so an invalid field just won't take effect — get it right so the us
 > Working/attention state colors override these (they show while a session is busy or waiting);
 > your colors show when the cell is idle.
 
+### Model — `provider` and `model`
+
+| Key | Meaning |
+|---|---|
+| `provider` | `id` of a backend in `~/.mulmoterminal/config.json` under `providers`. Omit to stay on Anthropic. |
+| `model` | Passed to `claude --model`. With no `provider`, this picks a different Anthropic model. |
+
+Both are defaults for the directory — the launch form can override them for a single session.
+
+**Never invent a model id.** Read `common/modelPresets.ts` in the MulmoTerminal repo and offer what
+is listed there, with its measured pass rate. Each entry records how many attempts of a real
+tool-using task the model completed: a model can answer fluently and still never call a tool, so
+`3/3` and `0/4` are the difference between a usable session and a broken one. Prefer entries whose
+`trials` are `measured` with `passed === of`. If the user names a model that is not listed, add it
+to that provider's `models` array in the global config rather than silently trusting it, and say it
+is untested.
+
+A directory naming a `provider` that is missing its key does not fall back — its sessions refuse to
+start. Check the provider exists in the global config before writing `provider` here.
+
 ### Terminal palette — `colors` and `theme`
 
 `headerColor` etc. tint the **chrome** around the terminal. `colors` (and `theme`) paint the
@@ -206,6 +226,39 @@ that don't resolve to a real skill are simply ignored.
 Atoms: `isGitRepo`, `!isGitRepo`, `key == value`, `key != value` (keys = the `${var}` names).
 Combine with `&&` (binds tighter) and `||`. No parentheses. Empty/absent → always shown.
 Example: `agent == claude && isGitRepo`.
+
+## Setting up a backend — `~/.mulmoterminal/config.json`
+
+Only when the user wants a model that is not Anthropic's. This is a **different file** from the
+per-directory one, and the rules below were measured against a working setup — each of them breaks
+the session in a way that is hard to diagnose from inside it.
+
+```json
+{
+  "providers": [
+    {
+      "id": "openrouter",
+      "label": "OpenRouter",
+      "baseUrl": "https://openrouter.ai/api",
+      "tokenEnv": "OPENROUTER_API_KEY",
+      "maxOutputTokens": 16000,
+      "models": []
+    }
+  ]
+}
+```
+
+- **Never write the API key into this file, or into any file.** `tokenEnv` is the *name* of an
+  environment variable; the key belongs in the shell that starts the server, or a `.env` beside it.
+  If the user pastes a key at you, tell them where it goes — do not store it.
+- `baseUrl` must **not** end in `/v1`. Claude Code appends `/v1/messages` itself, so a trailing
+  `/v1` produces `/v1/v1/messages` and every request 404s.
+- Keep `maxOutputTokens` at 16000 or above. A thinking model given less spends the whole budget
+  thinking and returns empty visible text, which reads as a hung session.
+- This is a partial `POST /api/config` merge — write only `providers`, so the user's other settings
+  survive.
+- The server reads the environment at startup: after adding a key, it has to be restarted.
+- Providers do not work in the Docker sandbox; say so rather than letting the user find out.
 
 ## Example result
 

--- a/src/components/ModelContextBadge.vue
+++ b/src/components/ModelContextBadge.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { presetFor } from "./modelOption";
 
 // Which model is running + how full its context is, e.g. `Opus · ctx 35%`. Model
 // and contextTokens come from the transcript (server /api/session/:id); the agent
@@ -45,12 +46,18 @@ const PERCENT = 100;
 const AGENT_NAME: Record<"claude" | "codex", string> = { claude: "Claude", codex: "Codex" };
 
 function shortModelLabel(model: string): string {
+  const preset = presetFor(model);
+  if (preset) return preset.label;
   const lower = model.toLowerCase();
   const family = CLAUDE_FAMILIES.find((f) => lower.includes(f.match));
   return family ? family.label : (model.split("/").pop() ?? model);
 }
 
 function contextWindowTokens(model: string): number | null {
+  // A preset carries the window its provider publishes, so a session on one shows a real
+  // % instead of nothing — the substring lists below only know Claude's own families.
+  const preset = presetFor(model);
+  if (preset?.contextLength) return preset.contextLength;
   const lower = model.toLowerCase();
   const entry = CONTEXT_WINDOWS.find((w) => lower.includes(w.match));
   return entry ? entry.tokens : null;

--- a/src/components/ModelPicker.vue
+++ b/src/components/ModelPicker.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+// Which backend + model a session starts on, chosen at launch (#584). Sits in the empty
+// cell's launch form, under the working directory.
+//
+// The choice lasts for this session only — the directory's .mulmoterminal.json still holds
+// the default, and leaving this alone is what uses it. The picker only appears when there
+// is something to choose between: with no reachable provider there is no decision to make,
+// only setup to explain, so it collapses to a link into the help.
+import { computed, ref } from "vue";
+import { useLaunchOptions } from "../composables/useLaunchOptions";
+import { modelOptionLabel, sortedModels } from "./modelOption";
+import ModelSetupHelp from "./ModelSetupHelp.vue";
+import type { LaunchChoice } from "./wsUrl";
+
+const props = defineProps<{ modelValue: LaunchChoice | null }>();
+const emit = defineEmits<{ (e: "update:modelValue", choice: LaunchChoice | null): void }>();
+
+const { launchOptions } = useLaunchOptions();
+const helpOpen = ref(false);
+
+// A provider is only offerable when this server can actually reach it; an unready one is
+// left to the help, which names the single thing that is missing.
+const readyProviders = computed(() => launchOptions.value.providers.filter((provider) => provider.ready));
+
+// One flat <select>: "<provider>|<model>", empty string for the directory's own default.
+const SEPARATOR = "|";
+const selected = computed({
+  get: () => (props.modelValue?.model ? `${props.modelValue.provider ?? ""}${SEPARATOR}${props.modelValue.model}` : ""),
+  set: (value: string) => {
+    if (!value) return emit("update:modelValue", null);
+    const [provider, model] = value.split(SEPARATOR);
+    emit("update:modelValue", { provider: provider || null, model });
+  },
+});
+</script>
+
+<template>
+  <div class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+    <span class="flex w-full items-center justify-between">
+      <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Model</span>
+      <button
+        type="button"
+        data-testid="cell-model-help"
+        class="cursor-pointer border-none bg-transparent p-0 font-sans text-[11px] text-dim underline hover:text-fg"
+        @click="helpOpen = true"
+      >
+        {{ launchOptions.anyReady ? "How this works" : "Use another model…" }}
+      </button>
+    </span>
+
+    <select
+      v-if="launchOptions.anyReady"
+      v-model="selected"
+      data-testid="cell-model-select"
+      aria-label="Model for this session"
+      class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] font-mono text-[12px] text-fg focus:border-accent focus:outline-none"
+    >
+      <option value="">This directory's default</option>
+      <optgroup v-for="provider in readyProviders" :key="provider.id" :label="provider.label">
+        <option v-for="model in sortedModels(provider.models)" :key="model.id" :value="`${provider.id}${SEPARATOR}${model.id}`">
+          {{ modelOptionLabel(model) }}
+        </option>
+      </optgroup>
+    </select>
+
+    <ModelSetupHelp v-if="helpOpen" :providers="launchOptions.providers" @close="helpOpen = false" />
+  </div>
+</template>

--- a/src/components/ModelSetupHelp.vue
+++ b/src/components/ModelSetupHelp.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+// What to configure, and where, to run a session on something other than the Anthropic
+// subscription (#584).
+//
+// Deliberately narrow: when a provider is already configured but unusable, the server
+// already knows exactly what is missing — that sentence goes at the top, and the full
+// walkthrough moves below it. Setup instructions that bury the one broken line are how a
+// user ends up re-doing the parts that already worked.
+import { computed, onMounted, onUnmounted, nextTick, ref } from "vue";
+import { trapTabKey } from "../utils/focusTrap";
+import type { LaunchProviderOption } from "../composables/useLaunchOptions";
+
+const props = defineProps<{ providers: LaunchProviderOption[] }>();
+const emit = defineEmits<{ (e: "close"): void }>();
+
+const blocked = computed(() => props.providers.filter((provider) => !provider.ready));
+
+const CONFIG_EXAMPLE = `{
+  "providers": [
+    {
+      "id": "openrouter",
+      "label": "OpenRouter",
+      "baseUrl": "https://openrouter.ai/api",
+      "tokenEnv": "OPENROUTER_API_KEY",
+      "maxOutputTokens": 16000
+    }
+  ]
+}`;
+
+const DIR_EXAMPLE = `{
+  "provider": "openrouter",
+  "model": "moonshotai/kimi-k2.7-code"
+}`;
+
+const copy = (text: string) => navigator.clipboard?.writeText(text);
+
+const modalEl = ref<HTMLElement>();
+
+// Same modal keyboard contract as the settings dialog: Escape closes, Tab stays inside.
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape") return emit("close");
+  if (e.key !== "Tab" || !modalEl.value) return;
+  trapTabKey(e, modalEl.value, 'button, input, [tabindex]:not([tabindex="-1"])');
+}
+
+onMounted(() => {
+  document.addEventListener("keydown", onKeydown);
+  nextTick(() => modalEl.value?.querySelector<HTMLElement>("button")?.focus());
+});
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
+</script>
+
+<template>
+  <div class="fixed inset-0 z-[100] flex items-center justify-center bg-[rgba(0,0,0,0.55)] p-4" @click.self="emit('close')">
+    <div
+      ref="modalEl"
+      class="flex max-h-full w-full max-w-[560px] flex-col gap-4 overflow-y-auto rounded-lg border border-border bg-panel p-5 text-left"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Running a session on another model"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <h2 class="m-0 font-sans text-[15px] font-semibold text-fg">Running a session on another model</h2>
+        <button type="button" class="cursor-pointer border-none bg-transparent p-0 text-dim hover:text-fg" aria-label="Close" @click="emit('close')">
+          <span class="material-symbols-outlined text-[20px]">close</span>
+        </button>
+      </div>
+
+      <p class="m-0 font-sans text-[12px] leading-relaxed text-secondary">
+        Claude Code can talk to any Anthropic-compatible backend. MulmoTerminal reads the backends from its own config, and their keys from the environment the
+        <em>server</em> was started with — never from a file it serves.
+      </p>
+
+      <!-- The one sentence that matters when something is already configured but unusable. -->
+      <section v-if="blocked.length" class="flex flex-col gap-1.5 rounded-md border border-border bg-elevated p-3">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Needs attention</span>
+        <p v-for="provider in blocked" :key="provider.id" class="m-0 font-mono text-[11px] leading-relaxed text-fg">{{ provider.reason }}</p>
+      </section>
+
+      <section class="flex flex-col gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">1 — Add the backend to ~/.mulmoterminal/config.json</span>
+        <pre class="m-0 overflow-x-auto rounded-md border border-border bg-input p-3 font-mono text-[11px] leading-relaxed text-fg">{{ CONFIG_EXAMPLE }}</pre>
+        <button
+          type="button"
+          class="self-start cursor-pointer border-none bg-transparent p-0 font-sans text-[11px] text-dim underline hover:text-fg"
+          @click="copy(CONFIG_EXAMPLE)"
+        >
+          Copy
+        </button>
+        <p class="m-0 font-sans text-[11px] leading-relaxed text-secondary">
+          <code class="font-mono">baseUrl</code> must not end in <code class="font-mono">/v1</code> — Claude Code appends
+          <code class="font-mono">/v1/messages</code> itself. <code class="font-mono">tokenEnv</code> is the <em>name</em> of the variable holding the key.
+        </p>
+      </section>
+
+      <section class="flex flex-col gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">2 — Put the key in the server's environment</span>
+        <pre class="m-0 overflow-x-auto rounded-md border border-border bg-input p-3 font-mono text-[11px] leading-relaxed text-fg">
+OPENROUTER_API_KEY=sk-or-…</pre>
+        <p class="m-0 font-sans text-[11px] leading-relaxed text-secondary">
+          In the shell that starts MulmoTerminal, or a <code class="font-mono">.env</code> beside it. Keys never go in
+          <code class="font-mono">config.json</code>. Restart the server after adding one.
+        </p>
+      </section>
+
+      <section class="flex flex-col gap-1.5">
+        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">3 — Optional: a default for one project</span>
+        <pre class="m-0 overflow-x-auto rounded-md border border-border bg-input p-3 font-mono text-[11px] leading-relaxed text-fg">{{ DIR_EXAMPLE }}</pre>
+        <button
+          type="button"
+          class="self-start cursor-pointer border-none bg-transparent p-0 font-sans text-[11px] text-dim underline hover:text-fg"
+          @click="copy(DIR_EXAMPLE)"
+        >
+          Copy
+        </button>
+        <p class="m-0 font-sans text-[11px] leading-relaxed text-secondary">
+          In that project's <code class="font-mono">.mulmoterminal.json</code>. Every session there starts on it, and the picker above overrides it for one
+          session.
+        </p>
+      </section>
+
+      <p class="m-0 font-sans text-[11px] leading-relaxed text-secondary">
+        Rather not edit JSON? Ask a Claude session in any directory: <em>“set up OpenRouter in my mulmoterminal config”</em> — the bundled
+        <code class="font-mono">mulmoterminal-config</code> skill knows this file and the tested model list.
+      </p>
+
+      <p class="m-0 font-sans text-[11px] leading-relaxed text-dim">
+        The pass rate beside each model — <code class="font-mono">3/3</code>, <code class="font-mono">2/3</code> — is how many attempts of a real
+        read-a-file-write-a-file task it completed when it was measured. Models that answer fluently but never call a tool are the reason it is there.
+      </p>
+    </div>
+  </div>
+</template>

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -18,6 +18,7 @@ import { useHeaderButtons, type HeaderButton } from "../composables/useHeaderBut
 import { useSessionContext } from "../composables/useSessionContext";
 import { runHeaderButton } from "../composables/useHeaderAction";
 import type { RunCommand } from "./runCommand";
+import type { LaunchChoice } from "./wsUrl";
 
 // `null` => start a fresh session; otherwise resume the given session id.
 // `connectKey` increments on every user action so re-selecting the same
@@ -49,6 +50,8 @@ const props = defineProps<{
   launcher?: { index: number } | { shell: true } | null;
   // A first-class codex session — connects to /ws/codex instead of /ws (Claude).
   codex?: boolean;
+  // Provider/model picked in the launch form, for this session only (#584).
+  launch?: LaunchChoice | null;
   runMenu?: boolean;
   // Hide this terminal's own header row (used when a grid cell is zoomed: the cell's
   // header already shows dir + activity, so the embedded header would just be clutter).
@@ -90,6 +93,7 @@ function currentTarget(): conn.ConnTarget {
     command: props.command ?? null,
     launcher: props.launcher ?? null,
     codex: !!props.codex,
+    launch: props.launch ?? null,
   };
 }
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -9,6 +9,8 @@ import { badgeStyleFor } from "./dirBadge";
 import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 import GitBranchChip from "./GitBranchChip.vue";
 import ModelContextBadge from "./ModelContextBadge.vue";
+import ModelPicker from "./ModelPicker.vue";
+import type { LaunchChoice } from "./wsUrl";
 import type { RunCommand } from "./runCommand";
 import { useHeaderButtons } from "../composables/useHeaderButtons";
 import TimelineOverlay from "./TimelineOverlay.vue";
@@ -275,6 +277,11 @@ function launchIn(dir: string | null) {
   recordNextCwd = true;
   loadDiff(); // no-op for a non-worktree dir
 }
+// The provider/model picked in the launch form, for the session this cell is about to
+// start. Null — the usual case — means the directory's own default decides. Kept for the
+// life of the cell so a relaunch in the same cell repeats the choice.
+const launchChoice = ref<LaunchChoice | null>(null);
+
 function launch() {
   launchIn(dirInput.value.trim() || props.defaultCwd);
 }
@@ -1057,6 +1064,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :connect-key="connectKey"
         :cwd="cwd"
         :codex="agent === 'codex'"
+        :launch="launchChoice"
         :dir-theme="dirConfig.theme"
         :dir-colors="dirConfig.colors"
         :dir-header-color="dirConfig.headerColor"
@@ -1417,6 +1425,8 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           </button>
         </span>
       </label>
+      <!-- Codex has its own model configuration and doesn't read this one. -->
+      <ModelPicker v-if="agent === 'claude'" v-model="launchChoice" />
       <div v-if="isGitRepo" data-testid="cell-worktrees" class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5">
         <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
         <div class="flex gap-1.5">

--- a/src/components/modelOption.ts
+++ b/src/components/modelOption.ts
@@ -1,0 +1,54 @@
+// How a model preset reads in the launch picker (#584), and in what order.
+//
+// The measurement is the point: every model in the list answers prompts, but only some of
+// them drive a tool loop, so an option that showed only a name would be hiding the one
+// thing that decides whether the session is usable. The numbers ride in the option text
+// because a <select> has nowhere else to put them.
+import { MODEL_PRESETS, type ModelPreset } from "../../common/modelPresets";
+
+// Ordering buckets. Within a bucket the built-in order is kept — it runs cheapest-first,
+// which is the next thing worth comparing once reliability is equal.
+const RELIABLE = 0;
+const UNTESTED = 1;
+const TROUBLED = 2;
+
+export function modelRank(preset: ModelPreset): number {
+  const { trials } = preset;
+  if (trials.status === "unmeasured") return UNTESTED;
+  if (trials.status === "unreachable") return TROUBLED;
+  if (trials.passed === 0) return TROUBLED;
+  return trials.passed === trials.of ? RELIABLE : UNTESTED;
+}
+
+// A model nobody could reach, or that never once used a tool, stays in the list — the
+// question "what about X?" deserves a measurement rather than silence — but it sorts
+// below everything that works.
+export function sortedModels(models: readonly ModelPreset[]): ModelPreset[] {
+  return [...models].sort((a, b) => modelRank(a) - modelRank(b));
+}
+
+const CONTEXT_PER_K = 1000;
+
+const contextLabel = (tokens: number): string =>
+  tokens >= CONTEXT_PER_K * CONTEXT_PER_K ? `${Math.round(tokens / CONTEXT_PER_K / CONTEXT_PER_K)}M` : `${Math.round(tokens / CONTEXT_PER_K)}k`;
+
+// The part after the name: how it did, then how big a conversation it can hold.
+function trialsLabel(preset: ModelPreset): string[] {
+  const { trials } = preset;
+  if (trials.status === "unreachable") return ["not reachable from this account"];
+  if (trials.status === "unmeasured") return ["not tested"];
+  if (trials.passed === 0) return [`0/${trials.of} — never used a tool`];
+  const rate = `${trials.passed}/${trials.of}`;
+  return trials.medianSeconds === null ? [rate] : [rate, `${trials.medianSeconds}s`];
+}
+
+export function modelOptionLabel(preset: ModelPreset): string {
+  const parts = [...trialsLabel(preset)];
+  if (preset.contextLength > 0) parts.push(contextLabel(preset.contextLength));
+  return `${preset.label} · ${parts.join(" · ")}`;
+}
+
+// The preset a running session's model id belongs to, if we know it. Exact match: these
+// ids are what we passed to `claude --model`, and a substring match would let
+// `kimi-k2` claim `kimi-k2.7-code`'s context window.
+export const presetFor = (model: string): ModelPreset | undefined => MODEL_PRESETS.find((preset) => preset.id.toLowerCase() === model.toLowerCase());

--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -2,21 +2,34 @@
 // the query it sends — including ?gui=0, which tells the server to run a plain dev
 // terminal (no GUI MCP) — is unit-testable without xterm/WebSocket.
 
+// What the launch form picked for THIS session (#584), overriding the directory's own
+// default. Either half may be absent: a bare model is a valid pick on the default
+// Anthropic backend.
+export interface LaunchChoice {
+  provider?: string | null;
+  model?: string | null;
+}
+
 export interface TerminalWsUrlInput {
   host: string; // location.host
   secure: boolean; // location.protocol === "https:"
   sessionId: string | null; // resume this session; null => fresh session
   cwd?: string | null; // launch in this directory
   devTerminal?: boolean; // grid dev terminal: no GUI MCP (?gui=0)
+  launch?: LaunchChoice | null; // picked at launch; absent => the directory's default
 }
 
 // The two session-terminal endpoints (/ws for claude, /ws/codex for codex) send the
 // identical session/cwd/gui query, so they share this assembly — only the path differs.
-function sessionTerminalWsUrl(path: string, { host, secure, sessionId, cwd, devTerminal }: TerminalWsUrlInput): string {
+function sessionTerminalWsUrl(path: string, { host, secure, sessionId, cwd, devTerminal, launch }: TerminalWsUrlInput): string {
   const params = new URLSearchParams();
   if (sessionId) params.set("session", sessionId);
   if (cwd) params.set("cwd", cwd);
   if (devTerminal) params.set("gui", "0");
+  // Only sent when the user picked one — an absent param is what tells the server to use
+  // the directory's own provider/model.
+  if (launch?.provider) params.set("provider", launch.provider);
+  if (launch?.model) params.set("model", launch.model);
   const qs = params.toString();
   const suffix = qs ? `?${qs}` : "";
   const proto = secure ? "wss:" : "ws:";

--- a/src/composables/useLaunchOptions.ts
+++ b/src/composables/useLaunchOptions.ts
@@ -25,7 +25,13 @@ const EMPTY: LaunchOptions = { providers: [], anyReady: false };
 const FETCH_TIMEOUT_MS = 8000;
 
 const options = ref<LaunchOptions>(EMPTY);
+// The request currently in the air, so a grid mounting a dozen empty cells at once asks
+// the server once. Cleared when it settles.
 let inFlight: Promise<void> | null = null;
+// Whether a fetch has actually SUCCEEDED. A failed one must not count: the first attempt
+// can lose a race with a server that is still starting, and without this the picker would
+// stay hidden for the rest of the page session even after the server came back.
+let loaded = false;
 
 async function fetchOptions(): Promise<void> {
   const abort = new AbortController();
@@ -34,22 +40,33 @@ async function fetchOptions(): Promise<void> {
     const res = await fetch("/api/launch-options", { signal: abort.signal });
     if (!res.ok) throw new Error(`GET /api/launch-options → ${res.status}`);
     options.value = await res.json();
+    loaded = true;
   } catch (err) {
     // A picker that cannot load its list is not an error the user can act on — the launch
-    // form still works and starts the session on the directory's own default.
+    // form still works and starts the session on the directory's own default. The next cell
+    // to mount tries again.
     console.warn("[launch-options] falling back to the directory default:", err);
     options.value = EMPTY;
   } finally {
     clearTimeout(timer);
+    // Cleared here rather than in a .finally() on the returned promise, so it is already
+    // null by the time anything awaiting this call resumes.
+    inFlight = null;
   }
 }
 
-export function reloadLaunchOptions(): Promise<void> {
+const startFetch = (): Promise<void> => {
   inFlight = fetchOptions();
   return inFlight;
+};
+
+// Re-ask the server — for a settings screen that just changed what there is to offer.
+export function reloadLaunchOptions(): Promise<void> {
+  loaded = false;
+  return startFetch();
 }
 
 export function useLaunchOptions() {
-  inFlight ??= fetchOptions();
+  if (!loaded && !inFlight) void startFetch();
   return { launchOptions: options };
 }

--- a/src/composables/useLaunchOptions.ts
+++ b/src/composables/useLaunchOptions.ts
@@ -1,0 +1,55 @@
+// The backends this server can launch a session on, for the launch picker (#584).
+//
+// Fetched once and shared: a full grid mounts a dozen empty cells at the same moment, and
+// each one wants the same list. The answer only changes when the user edits config.json or
+// restarts the server with a different environment, so `reloadLaunchOptions` is there for
+// the settings screen rather than a poll.
+import { ref } from "vue";
+import type { ModelPreset } from "../../common/modelPresets";
+
+export interface LaunchProviderOption {
+  id: string;
+  label: string;
+  ready: boolean;
+  reason?: string;
+  tokenEnv: string;
+  models: ModelPreset[];
+}
+
+export interface LaunchOptions {
+  providers: LaunchProviderOption[];
+  anyReady: boolean;
+}
+
+const EMPTY: LaunchOptions = { providers: [], anyReady: false };
+const FETCH_TIMEOUT_MS = 8000;
+
+const options = ref<LaunchOptions>(EMPTY);
+let inFlight: Promise<void> | null = null;
+
+async function fetchOptions(): Promise<void> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch("/api/launch-options", { signal: abort.signal });
+    if (!res.ok) throw new Error(`GET /api/launch-options → ${res.status}`);
+    options.value = await res.json();
+  } catch (err) {
+    // A picker that cannot load its list is not an error the user can act on — the launch
+    // form still works and starts the session on the directory's own default.
+    console.warn("[launch-options] falling back to the directory default:", err);
+    options.value = EMPTY;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function reloadLaunchOptions(): Promise<void> {
+  inFlight = fetchOptions();
+  return inFlight;
+}
+
+export function useLaunchOptions() {
+  inFlight ??= fetchOptions();
+  return { launchOptions: options };
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -21,7 +21,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import "@xterm/xterm/css/xterm.css";
-import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } from "../components/wsUrl";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl, type LaunchChoice } from "../components/wsUrl";
 import type { RunCommand } from "../components/runCommand";
 import { readableSlot, type SlotCandidate, type SlotInfo } from "./readableSlot";
 
@@ -67,6 +67,9 @@ export interface ConnTarget {
   // A first-class codex session (/ws/codex) instead of a Claude one. Persistent &
   // reattachable like a Claude cell; the server discovers + resumes codex's own id.
   codex?: boolean;
+  // The provider/model the launch form picked for this session (#584). Claude only —
+  // it rides the /ws query and overrides the directory's default.
+  launch?: LaunchChoice | null;
 }
 
 // Forwarded to whatever component is currently attached, so the parent's existing
@@ -246,7 +249,7 @@ function connUrl(target: ConnTarget, resumeId: string | null, secure: boolean): 
       ? buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, shell: true })
       : buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
   if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
-  return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
+  return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal, launch: target.launch });
 }
 
 function connect(c: Conn) {

--- a/test/server/config/config-body.spec.ts
+++ b/test/server/config/config-body.spec.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { ARRAY_FIELDS, badArrayField, badNullableArrayField } from "../../../server/config/config-body.js";
+import { loadAppConfig, mergeConfigUpdate, sanitizeProviders } from "../../../server/config/app-config.js";
+
+describe("badArrayField", () => {
+  it("passes a body that omits every array field — a partial POST is the normal case", () => {
+    expect(badArrayField({ soundFile: "/home/user/ding.wav" })).toBeNull();
+  });
+
+  it("passes arrays, including empty ones (clearing a list is a real edit)", () => {
+    expect(badArrayField({ cwdPresets: [], prRepos: ["acme/web"], providers: [] })).toBeNull();
+  });
+
+  it.each(ARRAY_FIELDS)("rejects %s when it is present but not an array", (field) => {
+    expect(badArrayField({ [field]: {} })).toBe(field);
+  });
+
+  it.each([{}, "openrouter", 42, true])("rejects the malformed providers value %j", (value) => {
+    expect(badArrayField({ providers: value })).toBe("providers");
+  });
+
+  // Codex on PR #587: `providers` was the one array field missing from this guard.
+  it("guards providers alongside the array fields that predate it", () => {
+    expect(ARRAY_FIELDS).toContain("providers");
+  });
+
+  it("names only the first offender — the response reports one field", () => {
+    expect(badArrayField({ prRepos: {}, providers: {} })).toBe("prRepos");
+  });
+
+  it("treats null as malformed for a non-nullable list", () => {
+    expect(badArrayField({ providers: null })).toBe("providers");
+  });
+});
+
+describe("badNullableArrayField", () => {
+  it("allows null — that is how buttons/chips are unconfigured", () => {
+    expect(badNullableArrayField({ buttons: null, chips: null })).toBeNull();
+  });
+
+  it("allows arrays", () => {
+    expect(badNullableArrayField({ chips: ["git"] })).toBeNull();
+  });
+
+  it.each(["buttons", "chips"])("rejects %s when it is neither", (field) => {
+    expect(badNullableArrayField({ [field]: "git" })).toBe(field);
+  });
+});
+
+// Why the guard has to run BEFORE the merge, kept as an executable statement of the hazard
+// rather than a comment: the merge reads "present" as "replace", and every sanitizer answers
+// a non-array with an empty array. Without the guard, `{"providers": {}}` is not an error —
+// it is a silent deletion of the user's backends.
+describe("the deletion the guard prevents", () => {
+  const PROVIDER = { id: "openrouter", label: "OpenRouter", baseUrl: "https://openrouter.ai/api", tokenEnv: "OPENROUTER_API_KEY", models: [] };
+
+  it("would wipe saved providers if a malformed body reached the merge", () => {
+    const base = { ...loadAppConfig("/nonexistent/config.json"), providers: sanitizeProviders([PROVIDER]) };
+    expect(base.providers).toHaveLength(1);
+    expect(mergeConfigUpdate(base, { providers: {} }).providers).toEqual([]);
+    expect(badArrayField({ providers: {} })).toBe("providers");
+  });
+
+  it("keeps saved providers when the body simply omits them", () => {
+    const base = { ...loadAppConfig("/nonexistent/config.json"), providers: sanitizeProviders([PROVIDER]) };
+    expect(mergeConfigUpdate(base, { soundFile: null }).providers).toHaveLength(1);
+  });
+});

--- a/test/server/config/config-schema.spec.ts
+++ b/test/server/config/config-schema.spec.ts
@@ -90,6 +90,14 @@ describe("dirConfigJsonSchema", () => {
     expect(props).toEqual(expect.arrayContaining(["name", "badgeColor", "headerColor", "theme", "colors", "sound", "buttons", "chips", "skills"]));
   });
 
+  // The skill writes a directory's config from this schema, so a key the runtime honours but the
+  // schema omits is a key the skill will refuse to write — which is what happened to provider /
+  // model between the backend landing (#579) and the picker (#584).
+  it("includes the keys that choose a backend, so the config skill can write them", () => {
+    const props = isRecord(dirConfigJsonSchema().properties) ? dirConfigJsonSchema().properties : {};
+    expect(Object.keys(isRecord(props) ? props : {})).toEqual(expect.arrayContaining(["provider", "model"]));
+  });
+
   it("caps the skills allowlist at MAX_SKILL_FILTER", () => {
     const schema = dirConfigJsonSchema();
     const props = isRecord(schema.properties) ? schema.properties : {};

--- a/test/server/config/launch-options.spec.ts
+++ b/test/server/config/launch-options.spec.ts
@@ -3,6 +3,8 @@ import { describe, it, expect } from "vitest";
 
 import { launchOptions } from "../../../server/config/launch-options.js";
 import { resolveProvider, type ProviderConfig } from "../../../server/session/provider-env.js";
+import { sanitizeProviders } from "../../../server/config/app-config.js";
+import { launchChoiceFromParams } from "../../../server/session/launch-choice.js";
 
 const OPENROUTER: ProviderConfig = {
   id: "openrouter",
@@ -79,5 +81,32 @@ describe("launchOptions", () => {
   it("is ready when any one of several providers is", () => {
     const broken = { ...OPENROUTER, id: "moonshot", label: "Moonshot", tokenEnv: "MOONSHOT_API_KEY" };
     expect(launchOptions([broken, OPENROUTER], WITH_KEY).anyReady).toBe(true);
+  });
+});
+
+// Codex on PR #587: the config schema accepted ids the launch parser then dropped, and a
+// dropped provider whose model survived would have started the session on Anthropic. The
+// two now share one id shape — this pins them together rather than trusting they agree.
+describe("what config accepts and what the launch path accepts", () => {
+  const provider = (id: string) => ({ id, label: "X", baseUrl: "https://x.example/api", tokenEnv: "X_KEY" });
+
+  it("keeps a provider whose id the launch parser would also accept", () => {
+    expect(sanitizeProviders([provider("open-router.v2")]).map((p) => p.id)).toEqual(["open-router.v2"]);
+  });
+
+  it.each(["has space", "-leading-dash", "pipe|char", ""])("refuses the id %j that the launch parser would drop", (id) => {
+    expect(sanitizeProviders([provider(id)])).toEqual([]);
+  });
+
+  it("drops only the malformed model, not the provider's whole list", () => {
+    const [saved] = sanitizeProviders([{ ...provider("openrouter"), models: ["z-ai/glm-5.2", "bad id", 42] }]);
+    expect(saved.models).toEqual(["z-ai/glm-5.2"]);
+  });
+
+  // The round trip that matters: anything config keeps must survive the ws query.
+  it("round-trips every id config keeps through the launch parser", () => {
+    for (const { id } of sanitizeProviders([provider("openrouter"), provider("moonshot"), provider("gw.internal:8080")])) {
+      expect(launchChoiceFromParams(new URLSearchParams({ provider: id, model: "m" }))).toEqual({ provider: id, model: "m" });
+    }
   });
 });

--- a/test/server/config/launch-options.spec.ts
+++ b/test/server/config/launch-options.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { launchOptions } from "../../../server/config/launch-options.js";
+import { resolveProvider, type ProviderConfig } from "../../../server/session/provider-env.js";
+
+const OPENROUTER: ProviderConfig = {
+  id: "openrouter",
+  label: "OpenRouter",
+  baseUrl: "https://openrouter.ai/api",
+  tokenEnv: "OPENROUTER_API_KEY",
+};
+
+const WITH_KEY = { OPENROUTER_API_KEY: "sk-test" } as NodeJS.ProcessEnv;
+
+describe("launchOptions", () => {
+  it("offers nothing when no provider is configured", () => {
+    expect(launchOptions([], WITH_KEY)).toEqual({ providers: [], anyReady: false });
+  });
+
+  it("marks a provider ready when its token is in the environment", () => {
+    const { providers, anyReady } = launchOptions([OPENROUTER], WITH_KEY);
+    expect(anyReady).toBe(true);
+    expect(providers[0]).toMatchObject({ id: "openrouter", label: "OpenRouter", ready: true });
+    expect(providers[0].reason).toBeUndefined();
+  });
+
+  it("lists the built-in presets for that provider", () => {
+    const [option] = launchOptions([OPENROUTER], WITH_KEY).providers;
+    expect(option.models.length).toBeGreaterThan(10);
+    expect(option.models.map((model) => model.id)).toContain("moonshotai/kimi-k2.7-code");
+    expect(option.models.every((model) => model.provider === "openrouter")).toBe(true);
+  });
+
+  it("appends the user's own models, marked as never measured", () => {
+    const [option] = launchOptions([{ ...OPENROUTER, models: ["acme/experimental-1"] }], WITH_KEY).providers;
+    const added = option.models.find((model) => model.id === "acme/experimental-1");
+    expect(added?.trials.status).toBe("unmeasured");
+  });
+
+  // A model the user lists that we already measured must not appear twice — and must keep
+  // the measurement rather than being downgraded to "unmeasured" by the duplicate.
+  it("does not duplicate a user model that is already a preset", () => {
+    const [option] = launchOptions([{ ...OPENROUTER, models: ["moonshotai/kimi-k2.7-code"] }], WITH_KEY).providers;
+    const matches = option.models.filter((model) => model.id === "moonshotai/kimi-k2.7-code");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].trials.status).toBe("measured");
+  });
+
+  it("still lists a provider whose token is missing, and says so", () => {
+    const { providers, anyReady } = launchOptions([OPENROUTER], {} as NodeJS.ProcessEnv);
+    expect(anyReady).toBe(false);
+    expect(providers[0].ready).toBe(false);
+    expect(providers[0].reason).toContain("OPENROUTER_API_KEY");
+  });
+
+  it("reports an unusable baseUrl instead of offering a backend that would 404", () => {
+    const [option] = launchOptions([{ ...OPENROUTER, baseUrl: "https://openrouter.ai/api/v1" }], WITH_KEY).providers;
+    expect(option.ready).toBe(false);
+    expect(option.reason).toContain("/v1");
+  });
+
+  // The picker's explanation and the session's refusal have to be the same sentence — a UI
+  // that says one thing while the spawn says another is how a user ends up debugging the
+  // wrong half of their setup.
+  it("explains a refusal in the same words the spawn would refuse with", () => {
+    const [option] = launchOptions([OPENROUTER], {} as NodeJS.ProcessEnv).providers;
+    const spawn = resolveProvider({ provider: "openrouter", model: "moonshotai/kimi-k2.7-code" }, [OPENROUTER], {} as NodeJS.ProcessEnv);
+    expect(spawn.ok).toBe(false);
+    expect(option.reason).toBe(spawn.ok ? undefined : spawn.reason);
+  });
+
+  it("never exposes the token itself, only the variable's name", () => {
+    const serialized = JSON.stringify(launchOptions([OPENROUTER], WITH_KEY));
+    expect(serialized).toContain("OPENROUTER_API_KEY");
+    expect(serialized).not.toContain("sk-test");
+  });
+
+  it("is ready when any one of several providers is", () => {
+    const broken = { ...OPENROUTER, id: "moonshot", label: "Moonshot", tokenEnv: "MOONSHOT_API_KEY" };
+    expect(launchOptions([broken, OPENROUTER], WITH_KEY).anyReady).toBe(true);
+  });
+});

--- a/test/server/session/launch-choice.spec.ts
+++ b/test/server/session/launch-choice.spec.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { effectiveChoice, launchChoiceFromParams } from "../../../server/session/launch-choice.js";
+
+const params = (query: string) => new URLSearchParams(query);
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("launchChoiceFromParams", () => {
+  // The overwhelmingly common case: no picker involvement, so the directory's own
+  // .mulmoterminal.json must be left to decide.
+  it("is undefined when neither param is present", () => {
+    expect(launchChoiceFromParams(params("cwd=/tmp&gui=0"))).toBeUndefined();
+  });
+
+  it("carries a provider/model pair through", () => {
+    expect(launchChoiceFromParams(params("provider=openrouter&model=moonshotai%2Fkimi-k2.7-code"))).toEqual({
+      provider: "openrouter",
+      model: "moonshotai/kimi-k2.7-code",
+    });
+  });
+
+  // A bare model is a real pick on the default Anthropic backend ("run this one on Opus"),
+  // so it must not require a provider to travel.
+  it("allows a model with no provider", () => {
+    expect(launchChoiceFromParams(params("model=claude-opus-4-8"))).toEqual({ provider: null, model: "claude-opus-4-8" });
+  });
+
+  // resolveProvider is the one that explains what's missing, so this half-choice has to
+  // reach it rather than being dropped here.
+  it("allows a provider with no model", () => {
+    expect(launchChoiceFromParams(params("provider=openrouter"))).toEqual({ provider: "openrouter", model: null });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(launchChoiceFromParams(params("model=%20glm-5.2%20"))?.model).toBe("glm-5.2");
+  });
+
+  // These two values become `claude --model <value>` in argv and ANTHROPIC_MODEL in the
+  // child's environment. Anything that isn't shaped like a model id is dropped, not passed.
+  it.each([
+    ["a leading dash argv would read as a flag", "model=--dangerously-skip-permissions"],
+    ["an embedded space", "model=kimi%20k2"],
+    ["a newline", "model=kimi%0Aecho"],
+    ["a shell metacharacter", "model=kimi%3Brm%20-rf%20%2F"],
+    ["a NUL byte", "model=kimi%00"],
+    ["an empty value", "model="],
+    ["only whitespace", "model=%20%20"],
+  ])("drops a model with %s", (_why, query) => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(launchChoiceFromParams(params(query))).toBeUndefined();
+  });
+
+  it("drops an absurdly long id rather than putting it in argv", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(launchChoiceFromParams(params(`model=${"m".repeat(121)}`))).toBeUndefined();
+    expect(launchChoiceFromParams(params(`model=${"m".repeat(120)}`))?.model).toHaveLength(120);
+  });
+
+  // One bad half must not silently promote the other half into a pair the user never
+  // chose — but the good half is still a choice, so it travels and resolveProvider judges it.
+  it("keeps the usable half when the other is rejected", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(launchChoiceFromParams(params("provider=openrouter&model=%20"))).toEqual({ provider: "openrouter", model: null });
+  });
+
+  it("says which param it ignored", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    launchChoiceFromParams(params("provider=%3Bwhoami"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("provider"));
+  });
+});
+
+describe("effectiveChoice", () => {
+  const DIR = { provider: "openrouter", model: "moonshotai/kimi-k2.6" };
+
+  it("uses the directory's default when the form picked nothing", () => {
+    expect(effectiveChoice(undefined, DIR)).toEqual(DIR);
+  });
+
+  it("lets the launch pick win over the directory's default", () => {
+    const picked = { provider: "openrouter", model: "z-ai/glm-5.2" };
+    expect(effectiveChoice(picked, DIR)).toEqual(picked);
+  });
+
+  // The pairing is the part that has to be right: keeping the directory's provider while
+  // taking the form's model would aim one vendor's id at another vendor's endpoint.
+  it("does not blend the two — a picked model drops the directory's provider", () => {
+    expect(effectiveChoice({ provider: null, model: "claude-opus-4-8" }, DIR)).toEqual({ provider: null, model: "claude-opus-4-8" });
+  });
+
+  it("passes a picked provider with no model through, for resolveProvider to refuse", () => {
+    expect(effectiveChoice({ provider: "openrouter", model: null }, DIR)).toEqual({ provider: "openrouter", model: null });
+  });
+
+  it("works from a directory with no provider or model at all", () => {
+    expect(effectiveChoice(undefined, { provider: null, model: null })).toEqual({ provider: null, model: null });
+  });
+});

--- a/test/server/session/launch-choice.spec.ts
+++ b/test/server/session/launch-choice.spec.ts
@@ -60,9 +60,18 @@ describe("launchChoiceFromParams", () => {
 
   // One bad half must not silently promote the other half into a pair the user never
   // chose — but the good half is still a choice, so it travels and resolveProvider judges it.
-  it("keeps the usable half when the other is rejected", () => {
+  // The finding that made this all-or-nothing (Codex, PR #587): dropping the provider while
+  // keeping the model resolves to ANTHROPIC running another vendor's model id — the exact
+  // silent wrong-backend this feature exists to prevent. The whole pick goes instead, and
+  // the directory's own default decides.
+  it("drops the whole pair when the model half is unusable", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    expect(launchChoiceFromParams(params("provider=openrouter&model=%20"))).toEqual({ provider: "openrouter", model: null });
+    expect(launchChoiceFromParams(params("provider=openrouter&model=%20"))).toBeUndefined();
+  });
+
+  it("drops the whole pair when the provider half is unusable", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(launchChoiceFromParams(params("provider=not%20an%20id&model=z-ai%2Fglm-5.2"))).toBeUndefined();
   });
 
   it("says which param it ignored", () => {
@@ -74,27 +83,57 @@ describe("launchChoiceFromParams", () => {
 
 describe("effectiveChoice", () => {
   const DIR = { provider: "openrouter", model: "moonshotai/kimi-k2.6" };
+  const fresh = (over: Partial<Parameters<typeof effectiveChoice>[0]> = {}) => effectiveChoice({ dir: DIR, resuming: false, ...over });
 
   it("uses the directory's default when the form picked nothing", () => {
-    expect(effectiveChoice(undefined, DIR)).toEqual(DIR);
+    expect(fresh()).toEqual(DIR);
   });
 
   it("lets the launch pick win over the directory's default", () => {
     const picked = { provider: "openrouter", model: "z-ai/glm-5.2" };
-    expect(effectiveChoice(picked, DIR)).toEqual(picked);
+    expect(fresh({ launch: picked })).toEqual(picked);
   });
 
   // The pairing is the part that has to be right: keeping the directory's provider while
   // taking the form's model would aim one vendor's id at another vendor's endpoint.
   it("does not blend the two — a picked model drops the directory's provider", () => {
-    expect(effectiveChoice({ provider: null, model: "claude-opus-4-8" }, DIR)).toEqual({ provider: null, model: "claude-opus-4-8" });
+    expect(fresh({ launch: { provider: null, model: "claude-opus-4-8" } })).toEqual({ provider: null, model: "claude-opus-4-8" });
   });
 
   it("passes a picked provider with no model through, for resolveProvider to refuse", () => {
-    expect(effectiveChoice({ provider: "openrouter", model: null }, DIR)).toEqual({ provider: "openrouter", model: null });
+    expect(fresh({ launch: { provider: "openrouter", model: null } })).toEqual({ provider: "openrouter", model: null });
   });
 
   it("works from a directory with no provider or model at all", () => {
-    expect(effectiveChoice(undefined, { provider: null, model: null })).toEqual({ provider: null, model: null });
+    expect(effectiveChoice({ dir: { provider: null, model: null }, resuming: false })).toEqual({ provider: null, model: null });
+  });
+});
+
+// Codex's other finding on PR #587: the cell re-sends its pick on every reconnect, so a
+// resume could apply a choice belonging to a different session.
+describe("effectiveChoice while resuming", () => {
+  const DIR = { provider: null, model: null };
+  const STALE = { provider: "openrouter", model: "z-ai/glm-5.2" };
+  const STARTED_ON = { provider: "openrouter", model: "moonshotai/kimi-k2.7-code" };
+
+  it("ignores the browser's pick and continues on what the session started on", () => {
+    expect(effectiveChoice({ launch: STALE, remembered: STARTED_ON, dir: DIR, resuming: true })).toEqual(STARTED_ON);
+  });
+
+  // The dangerous shape: a cell holding a stale pick reattaches a session that was never
+  // started on a provider at all. Resuming it must not move the conversation elsewhere.
+  it("does not apply a stale pick to a session this server never started on one", () => {
+    expect(effectiveChoice({ launch: STALE, remembered: undefined, dir: DIR, resuming: true })).toEqual(DIR);
+  });
+
+  it("falls back to the directory's default, not to nothing, when the memory is gone", () => {
+    const dir = { provider: "openrouter", model: "moonshotai/kimi-k2.6" };
+    expect(effectiveChoice({ dir, resuming: true })).toEqual(dir);
+  });
+
+  // A resume keeps the provider it began on rather than silently sliding to the directory
+  // default halfway through a conversation.
+  it("keeps a remembered provider even when the directory names none", () => {
+    expect(effectiveChoice({ remembered: STARTED_ON, dir: DIR, resuming: true })).toEqual(STARTED_ON);
   });
 });

--- a/test/server/session/launch-choice.spec.ts
+++ b/test/server/session/launch-choice.spec.ts
@@ -136,4 +136,13 @@ describe("effectiveChoice while resuming", () => {
   it("keeps a remembered provider even when the directory names none", () => {
     expect(effectiveChoice({ remembered: STARTED_ON, dir: DIR, resuming: true })).toEqual(STARTED_ON);
   });
+
+  // Pinned as a decision rather than left to fall out of the code (Codex asked for the
+  // opposite on PR #587): a directory's own default stays LIVE across a resume, exactly as
+  // it was before the picker existed and as every other .mulmoterminal.json field behaves.
+  // Only the picker's choice is sticky, because only it has nowhere else to live.
+  it("lets a directory's edited default apply on resume", () => {
+    const edited = { provider: "openrouter", model: "z-ai/glm-5.2" };
+    expect(effectiveChoice({ dir: edited, resuming: true })).toEqual(edited);
+  });
 });

--- a/test/src/components/ModelPicker.spec.ts
+++ b/test/src/components/ModelPicker.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+import ModelPicker from "../../../src/components/ModelPicker.vue";
+import { reloadLaunchOptions } from "../../../src/composables/useLaunchOptions";
+
+const MODELS = [
+  {
+    provider: "openrouter",
+    id: "moonshotai/kimi-k2.7-code",
+    label: "Kimi K2.7 Code",
+    contextLength: 262_144,
+    pricePerMTok: { input: 0.82, output: 3.75 },
+    trials: { status: "measured" as const, passed: 3, of: 3, medianSeconds: 14, measuredAt: "2026-07-22" },
+  },
+  {
+    provider: "openrouter",
+    id: "meta-llama/llama-4-maverick",
+    label: "Llama 4 Maverick",
+    contextLength: 1_048_576,
+    pricePerMTok: { input: 0.2, output: 0.8 },
+    trials: { status: "measured" as const, passed: 0, of: 4, medianSeconds: null, measuredAt: "2026-07-22" },
+  },
+];
+
+const READY = { providers: [{ id: "openrouter", label: "OpenRouter", ready: true, tokenEnv: "OPENROUTER_API_KEY", models: MODELS }], anyReady: true };
+const UNCONFIGURED = { providers: [], anyReady: false };
+const BLOCKED = {
+  providers: [
+    {
+      id: "openrouter",
+      label: "OpenRouter",
+      ready: false,
+      reason: "provider 'openrouter' needs OPENROUTER_API_KEY",
+      tokenEnv: "OPENROUTER_API_KEY",
+      models: MODELS,
+    },
+  ],
+  anyReady: false,
+};
+
+const serve = async (payload: unknown) => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => payload }));
+  await reloadLaunchOptions();
+};
+
+const picker = () => mount(ModelPicker, { props: { modelValue: null } });
+
+beforeEach(() => vi.unstubAllGlobals());
+
+describe("ModelPicker", () => {
+  it("offers each reachable provider's models, defaulting to the directory's own choice", async () => {
+    await serve(READY);
+    const wrapper = picker();
+    await flushPromises();
+    const select = wrapper.get('[data-testid="cell-model-select"]');
+    expect(select.findAll("optgroup").map((group) => group.attributes("label"))).toEqual(["OpenRouter"]);
+    expect(select.findAll("option")[0].text()).toBe("This directory's default");
+    expect(select.findAll("option")[0].attributes("value")).toBe("");
+  });
+
+  // The measurement has to survive the trip into the option text — a bare name would hide
+  // the only thing that says whether the session will work.
+  it("shows the pass rate next to each model", async () => {
+    await serve(READY);
+    const wrapper = picker();
+    await flushPromises();
+    expect(wrapper.text()).toContain("Kimi K2.7 Code · 3/3 · 14s · 262k");
+    expect(wrapper.text()).toContain("never used a tool");
+  });
+
+  it("sorts a model that never used a tool below one that always did", async () => {
+    await serve(READY);
+    const wrapper = picker();
+    await flushPromises();
+    const values = wrapper.findAll("option").map((option) => option.attributes("value"));
+    expect(values.indexOf("openrouter|moonshotai/kimi-k2.7-code")).toBeLessThan(values.indexOf("openrouter|meta-llama/llama-4-maverick"));
+  });
+
+  it("emits the provider and model as a pair when one is picked", async () => {
+    await serve(READY);
+    const wrapper = picker();
+    await flushPromises();
+    await wrapper.get('[data-testid="cell-model-select"]').setValue("openrouter|moonshotai/kimi-k2.7-code");
+    expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([{ provider: "openrouter", model: "moonshotai/kimi-k2.7-code" }]);
+  });
+
+  // Null is what makes the server fall back to .mulmoterminal.json, so going back to the
+  // default must clear the choice rather than emit an empty pair.
+  it("emits null when the user returns to the directory's default", async () => {
+    await serve(READY);
+    const wrapper = picker();
+    await flushPromises();
+    const select = wrapper.get('[data-testid="cell-model-select"]');
+    await select.setValue("openrouter|moonshotai/kimi-k2.7-code");
+    await select.setValue("");
+    expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([null]);
+  });
+
+  it("hides the select when nothing is configured, and offers the help instead", async () => {
+    await serve(UNCONFIGURED);
+    const wrapper = picker();
+    await flushPromises();
+    expect(wrapper.find('[data-testid="cell-model-select"]').exists()).toBe(false);
+    expect(wrapper.get('[data-testid="cell-model-help"]').text()).toBe("Use another model…");
+  });
+
+  // A configured-but-unusable provider is the case where the user most needs the one
+  // sentence naming what is missing — so it must not be offered as if it worked.
+  it("does not offer a provider whose key is missing", async () => {
+    await serve(BLOCKED);
+    const wrapper = picker();
+    await flushPromises();
+    expect(wrapper.find('[data-testid="cell-model-select"]').exists()).toBe(false);
+  });
+
+  it("puts that provider's own refusal at the top of the help", async () => {
+    await serve(BLOCKED);
+    const wrapper = picker();
+    await flushPromises();
+    await wrapper.get('[data-testid="cell-model-help"]').trigger("click");
+    expect(wrapper.text()).toContain("provider 'openrouter' needs OPENROUTER_API_KEY");
+  });
+
+  // A picker that cannot load its list must not block launching: the form still starts a
+  // session on whatever the directory already says.
+  it("falls back to the directory default when the list cannot be fetched", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    await reloadLaunchOptions();
+    const wrapper = picker();
+    await flushPromises();
+    expect(wrapper.find('[data-testid="cell-model-select"]').exists()).toBe(false);
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+});

--- a/test/src/components/modelOption.spec.ts
+++ b/test/src/components/modelOption.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+
+import { modelOptionLabel, modelRank, presetFor, sortedModels } from "../../../src/components/modelOption";
+import { MODEL_PRESETS, type ModelPreset } from "../../../common/modelPresets";
+
+const preset = (over: Partial<ModelPreset>): ModelPreset => ({
+  provider: "openrouter",
+  id: "acme/model",
+  label: "Acme",
+  contextLength: 262_144,
+  pricePerMTok: { input: 1, output: 2 },
+  trials: { status: "measured", passed: 3, of: 3, medianSeconds: 14, measuredAt: "2026-07-22" },
+  ...over,
+});
+
+describe("modelOptionLabel", () => {
+  it("leads with the name, then how it did and how much it holds", () => {
+    expect(modelOptionLabel(preset({}))).toBe("Acme · 3/3 · 14s · 262k");
+  });
+
+  it("rounds a million-token window to M", () => {
+    expect(modelOptionLabel(preset({ contextLength: 1_048_576 }))).toContain("1M");
+  });
+
+  // The whole reason the numbers are shown: a model that answers but never calls a tool
+  // must not read like one that works.
+  it("says so when nothing ever used a tool", () => {
+    expect(modelOptionLabel(preset({ trials: { status: "measured", passed: 0, of: 4, medianSeconds: null, measuredAt: "x" } }))).toContain(
+      "0/4 — never used a tool",
+    );
+  });
+
+  it("distinguishes unreachable from failing", () => {
+    const label = modelOptionLabel(preset({ trials: { status: "unreachable", reason: "privacy settings", measuredAt: "x" } }));
+    expect(label).toContain("not reachable from this account");
+    expect(label).not.toContain("0/");
+  });
+
+  it("admits when a user's own model was never tested", () => {
+    expect(modelOptionLabel(preset({ trials: { status: "unmeasured" }, contextLength: 0 }))).toBe("Acme · not tested");
+  });
+
+  it("omits an unknown context window rather than printing 0k", () => {
+    expect(modelOptionLabel(preset({ contextLength: 0 }))).not.toContain("0k");
+  });
+});
+
+describe("sortedModels", () => {
+  it("sinks what cannot be used below what can, keeping the built-in order within a tier", () => {
+    const models = [
+      preset({ id: "dead", trials: { status: "measured", passed: 0, of: 3, medianSeconds: null, measuredAt: "x" } }),
+      preset({ id: "flaky", trials: { status: "measured", passed: 2, of: 3, medianSeconds: 20, measuredAt: "x" } }),
+      preset({ id: "cheap-solid" }),
+      preset({ id: "unreachable", trials: { status: "unreachable", reason: "r", measuredAt: "x" } }),
+      preset({ id: "dear-solid" }),
+    ];
+    expect(sortedModels(models).map((model) => model.id)).toEqual(["cheap-solid", "dear-solid", "flaky", "dead", "unreachable"]);
+  });
+
+  it("does not mutate the list it was given", () => {
+    const models = [preset({ id: "b", trials: { status: "unmeasured" } }), preset({ id: "a" })];
+    sortedModels(models);
+    expect(models.map((model) => model.id)).toEqual(["b", "a"]);
+  });
+
+  it("ranks a flaky model with the untested ones — neither is trustworthy, both are usable", () => {
+    expect(modelRank(preset({ trials: { status: "measured", passed: 2, of: 3, medianSeconds: 9, measuredAt: "x" } }))).toBe(
+      modelRank(preset({ trials: { status: "unmeasured" } })),
+    );
+  });
+});
+
+describe("presetFor", () => {
+  it("finds a model by its exact id", () => {
+    expect(presetFor("moonshotai/kimi-k2.7-code")?.label).toBe("Kimi K2.7 Code");
+  });
+
+  it("ignores case, since the id travels through argv and a transcript", () => {
+    expect(presetFor("MoonshotAI/Kimi-K2.7-Code")?.label).toBe("Kimi K2.7 Code");
+  });
+
+  // A substring match would let the shorter id claim the longer one's context window, and
+  // the badge would then report a full session's usage against the wrong denominator.
+  it("does not let a prefix claim a longer id", () => {
+    expect(presetFor("moonshotai/kimi-k2")).toBeUndefined();
+  });
+
+  it("is undefined for a model nobody listed", () => {
+    expect(presetFor("claude-opus-4-8")).toBeUndefined();
+  });
+});
+
+describe("the built-in preset list", () => {
+  it("has no duplicate ids", () => {
+    const ids = MODEL_PRESETS.map((model) => `${model.provider}/${model.id}`);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  // Every entry claims to have been measured on a real date; a placeholder would quietly
+  // present a guess as a measurement.
+  it("dates every measurement it claims", () => {
+    for (const model of MODEL_PRESETS) {
+      if (model.trials.status !== "unmeasured") expect(model.trials.measuredAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("gives every model a context window and a price", () => {
+    for (const model of MODEL_PRESETS) {
+      expect(model.contextLength, model.id).toBeGreaterThan(0);
+      expect(model.pricePerMTok.output, model.id).toBeGreaterThan(0);
+    }
+  });
+
+  it("records a median only for models that actually passed", () => {
+    for (const model of MODEL_PRESETS) {
+      if (model.trials.status !== "measured") continue;
+      expect(model.trials.medianSeconds === null, model.id).toBe(model.trials.passed === 0);
+    }
+  });
+});

--- a/test/src/components/wsUrl.spec.ts
+++ b/test/src/components/wsUrl.spec.ts
@@ -128,3 +128,37 @@ describe("buildCodexWsUrl", () => {
     expect(u.searchParams.has("gui")).toBe(false);
   });
 });
+
+describe("buildTerminalWsUrl — the launch picker's choice (#584)", () => {
+  const base = { host: "h", secure: false, sessionId: null };
+
+  // Absent params are what tell the server to use the directory's own .mulmoterminal.json,
+  // so the default launch must send neither.
+  it("sends neither param when nothing was picked", () => {
+    const q = new URL(buildTerminalWsUrl({ ...base, launch: null })).searchParams;
+    expect(q.has("provider")).toBe(false);
+    expect(q.has("model")).toBe(false);
+  });
+
+  it("sends the picked provider and model", () => {
+    const q = new URL(buildTerminalWsUrl({ ...base, launch: { provider: "openrouter", model: "moonshotai/kimi-k2.7-code" } })).searchParams;
+    expect(q.get("provider")).toBe("openrouter");
+    expect(q.get("model")).toBe("moonshotai/kimi-k2.7-code");
+  });
+
+  // Picking an Anthropic model ("run this one on Opus") names no provider.
+  it("sends a bare model with no provider", () => {
+    const q = new URL(buildTerminalWsUrl({ ...base, launch: { provider: null, model: "claude-opus-4-8" } })).searchParams;
+    expect(q.get("model")).toBe("claude-opus-4-8");
+    expect(q.has("provider")).toBe(false);
+  });
+
+  it("escapes a model id containing a slash", () => {
+    expect(buildTerminalWsUrl({ ...base, launch: { model: "z-ai/glm-5.2" } })).toContain("model=z-ai%2Fglm-5.2");
+  });
+
+  it("keeps carrying session, cwd and gui alongside it", () => {
+    const q = new URL(buildTerminalWsUrl({ host: "h", secure: false, sessionId: "abc", cwd: "/w", devTerminal: true, launch: { model: "m" } })).searchParams;
+    expect([q.get("session"), q.get("cwd"), q.get("gui"), q.get("model")]).toEqual(["abc", "/w", "0", "m"]);
+  });
+});

--- a/test/src/composables/useLaunchOptions.spec.ts
+++ b/test/src/composables/useLaunchOptions.spec.ts
@@ -2,6 +2,7 @@
 // asks the server once. That state has to be reset between tests, hence the fresh import
 // per case rather than a shared top-level one.
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { flushPromises } from "@vue/test-utils";
 
 const READY = { providers: [{ id: "openrouter", label: "OpenRouter", ready: true, tokenEnv: "OPENROUTER_API_KEY", models: [] }], anyReady: true };
 
@@ -42,6 +43,21 @@ describe("useLaunchOptions", () => {
     const { useLaunchOptions } = await freshModule();
     const { launchOptions } = useLaunchOptions();
     await vi.waitFor(() => expect(launchOptions.value.anyReady).toBe(true));
+    useLaunchOptions();
+    useLaunchOptions();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // "Nothing is configured" is an answer, and it is the one a fresh install gets. Since it
+  // looks exactly like the failure fallback, only the success flag separates them — take it
+  // for a failure and a grid would ask once per cell forever.
+  it("treats an empty list as an answer, not a failure", async () => {
+    const fetchMock = ok({ providers: [], anyReady: false });
+    vi.stubGlobal("fetch", fetchMock);
+    const { useLaunchOptions } = await freshModule();
+    const { launchOptions } = useLaunchOptions();
+    await flushPromises();
+    expect(launchOptions.value).toEqual({ providers: [], anyReady: false });
     useLaunchOptions();
     useLaunchOptions();
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/test/src/composables/useLaunchOptions.spec.ts
+++ b/test/src/composables/useLaunchOptions.spec.ts
@@ -1,0 +1,107 @@
+// The module keeps its fetched list in module scope so a grid mounting a dozen empty cells
+// asks the server once. That state has to be reset between tests, hence the fresh import
+// per case rather than a shared top-level one.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const READY = { providers: [{ id: "openrouter", label: "OpenRouter", ready: true, tokenEnv: "OPENROUTER_API_KEY", models: [] }], anyReady: true };
+
+const freshModule = async () => {
+  vi.resetModules();
+  return import("../../../src/composables/useLaunchOptions");
+};
+
+const ok = (payload: unknown) => vi.fn().mockResolvedValue({ ok: true, json: async () => payload });
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useLaunchOptions", () => {
+  it("fetches the list and exposes it", async () => {
+    const fetchMock = ok(READY);
+    vi.stubGlobal("fetch", fetchMock);
+    const { useLaunchOptions } = await freshModule();
+    const { launchOptions } = useLaunchOptions();
+    await vi.waitFor(() => expect(launchOptions.value.anyReady).toBe(true));
+    expect(fetchMock).toHaveBeenCalledWith("/api/launch-options", expect.anything());
+  });
+
+  // A full grid mounts many empty cells at the same moment; they must not each ask.
+  it("asks the server once for many simultaneous callers", async () => {
+    const fetchMock = ok(READY);
+    vi.stubGlobal("fetch", fetchMock);
+    const { useLaunchOptions } = await freshModule();
+    for (let i = 0; i < 12; i += 1) useLaunchOptions();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not re-ask once it has an answer", async () => {
+    const fetchMock = ok(READY);
+    vi.stubGlobal("fetch", fetchMock);
+    const { useLaunchOptions } = await freshModule();
+    const { launchOptions } = useLaunchOptions();
+    await vi.waitFor(() => expect(launchOptions.value.anyReady).toBe(true));
+    useLaunchOptions();
+    useLaunchOptions();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Codex on PR #587: a failed first attempt used to be remembered as "asked", so the
+  // picker stayed hidden for the rest of the page session — even after the server was
+  // healthy again. The first mount can easily lose a race with a server still starting up.
+  it("tries again on the next mount after a failure", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue({ ok: true, json: async () => READY });
+    vi.stubGlobal("fetch", fetchMock);
+    const { useLaunchOptions } = await freshModule();
+
+    const { launchOptions } = useLaunchOptions();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(launchOptions.value.anyReady).toBe(false);
+
+    // Each poll is another cell mounting — the retry happens on one of them.
+    await vi.waitFor(() => {
+      useLaunchOptions();
+      expect(launchOptions.value.anyReady).toBe(true);
+    });
+  });
+
+  it("treats a non-2xx response as a failure worth retrying", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
+      .mockResolvedValue({ ok: true, json: async () => READY });
+    vi.stubGlobal("fetch", fetchMock);
+    const { useLaunchOptions } = await freshModule();
+
+    const { launchOptions } = useLaunchOptions();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => {
+      useLaunchOptions();
+      expect(launchOptions.value.anyReady).toBe(true);
+    });
+  });
+
+  it("keeps the launch form usable while the list is unavailable", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const { useLaunchOptions } = await freshModule();
+    const { launchOptions } = useLaunchOptions();
+    await vi.waitFor(() => expect(launchOptions.value).toEqual({ providers: [], anyReady: false }));
+  });
+
+  it("re-asks on an explicit reload, even after a success", async () => {
+    const fetchMock = ok(READY);
+    vi.stubGlobal("fetch", fetchMock);
+    const { useLaunchOptions, reloadLaunchOptions } = await freshModule();
+    useLaunchOptions();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await reloadLaunchOptions();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

#579/#580 landed the ability to run a session on an Anthropic-compatible backend, but the
only way to reach it was hand-editing a directory's `.mulmoterminal.json`. This adds the
way in: **choose at launch, see what is running, and find out what to configure when
nothing is.**

- **A curated, measured model list** — `common/modelPresets.ts`, 27 models. Each one was
  actually launched and made to complete a real task, and the entry records how many
  attempts succeeded.
- **A MODEL select in the launch form**, shown only when a provider is genuinely reachable.
  The pick lasts for that session; the directory's default is never rewritten.
- **The header's model badge now knows provider models** — name and a real `ctx %` instead
  of an id tail with no percentage.
- **Help** that leads with the exact sentence the spawn would have refused with.
- **Docs** (ja + en + README) and the `mulmoterminal-config` skill.

Closes #584.

## Items to Confirm / Review

1. **No visual pass was done.** Browser tooling wasn't available in the session that wrote
   this, so the picker and the help dialog are covered by component tests only
   (`test/src/components/ModelPicker.spec.ts`) — not by looking at them. Please eyeball the
   launch form and the modal, especially on a narrow cell and on mobile.
2. **`spawnClaudePty`'s tail arguments became an options object.** It was already at the
   7-parameter lint cap, so the launch choice had nowhere to go; a side-channel keyed by
   session id read worse than the refactor. Six call sites changed — all mechanical, but
   it is the riskiest diff here.
3. **A 0/4 model is kept in the list.** `meta-llama/llama-4-maverick` reaches fine and never
   once called a tool. It is listed, sorted to the bottom, and labelled
   `0/4 — never used a tool`, on the same reasoning as the unreachable entries: answering
   "what about X?" with a measurement beats answering it with silence. Say the word and it
   goes.
4. **The measurements are from one account, one day (2026-07-22).** Three models are marked
   `not reachable from this account` — that is an OpenRouter **privacy setting**, not a
   defect, and another account may run them fine. The wording tries to make that clear;
   worth a second read.
5. **`provider` / `model` were missing from the writable dir-config schema** — a gap from
   #579, not something this PR introduced. The config skill generates its JSON Schema from
   it, so it could not write the two keys the runtime already honoured. Fixed here with a
   regression test.

## User Prompt

> Claude Code 起動時に model を指定できるようにしたい。Claude Code で OpenRouter や
> Moonshot の API（Anthropic 互換）を利用して、それらのモデルを使ったセッションを起動でき
> るようにしたい。環境変数の指定・保存方法を含めて、どうすれば安全か、Docker 利用時も考慮
> して考えてほしい。

> `.mulmoterminal.json` で default を指定できるとして、terminal を起動するときに指定でき
> るようにしてほしい。これは OpenRouter が有効な場合ね。で、モデルも preset で多くのモデル
> から選べるようにしてほしい。

> それらが設定されないときは、設定方法がわかるようにヘルプを用意して、クリックすれば何を
> どこに設定すればよいかわかるようにしてほしい。

> ヘルプも必要だけど document も必要。

> やっぱり動的にすると問題がありそうなので、こっちで preset を組み込んでメンテする。その
> うえでユーザが明示的に設定で追加できるようにしよう。その設定も LLM でサポートすれば良い。

> header の 1 行目の方に、モデル名を出せるようにしてほしい。でも、全部テストしてね。動くか
> どうか。skill で動かさないときちんと動くかわからないよ。

## Why the numbers, and why they are ratios

A model that answers `-p "say routed"` correctly can still be unusable: the reply comes
back while the tool loop never fires — one model printed `Read(file_path=…)` as prose
instead of calling the tool. So the probe is a task that **cannot** be completed by
talking: read `input.txt`, write the word uppercased into `output.txt`, and the verdict is
whether that file exists with the right contents.

It is also not a single-shot judgement. Two models flipped between pass and fail across
runs, so each was tried 3–4 times and the preset records the ratio. The picker shows it:

```
Kimi K2.7 Code · 3/3 · 14s · 262k
Llama 4 Maverick · 0/4 — never used a tool · 1M
Qwen3.7 Plus · not reachable from this account · 1M
```

`scripts/model-trials.ts` is the harness, committed so the list can be re-measured:

```bash
yarn tsx scripts/model-trials.ts --provider openrouter --trials 3 <model-id>
```

Prices and context lengths are read from the provider's catalog, not estimated.

## Why not fetch the catalog dynamically

It was tried first. `${baseUrl}/v1/models` works for OpenRouter but **the catalog URL is
not derivable from `ANTHROPIC_BASE_URL`** — Moonshot's Anthropic-compatible `/anthropic`
has nothing under it (measured: 404). Supporting it properly means a per-provider
`modelsUrl`, a cache, and a staleness story, all to fetch a list whose useful content is
the part a catalog does not carry: whether the model can actually drive Claude Code.

## How the choice travels

`?provider=` / `?model=` on the existing `/ws` query, beside `cwd` and `gui`. Both values
end up in `claude --model` argv and `ANTHROPIC_MODEL`, so they are validated rather than
trusted (`launchChoiceFromParams`): shaped like a model id, length-capped, no leading dash
argv would read as a flag, no whitespace or control characters.

The launch choice replaces the directory's default **as a pair** (`effectiveChoice`) —
taking the picker's model while keeping the directory's provider would aim one vendor's id
at another vendor's endpoint.

## Verification

- 2006 tests / 164 files pass; lint 0 errors; `typecheck`, `typecheck:server`,
  `typecheck:test`, and `build` all clean (after merging `origin/main`).
- **End-to-end against a running server**, not just unit tests: opening `/ws` with
  `?provider=openrouter&model=z-ai/glm-5.2` produced a session whose settings carry
  `ANTHROPIC_BASE_URL=https://openrouter.ai/api` and `ANTHROPIC_MODEL=z-ai/glm-5.2`, with
  `--model z-ai/glm-5.2` in argv and **the token in a 0600 file rather than argv**. The
  same socket with no params produced a plain Anthropic session with no provider
  environment at all.
- `GET /api/launch-options` was checked for token leakage: the payload names
  `OPENROUTER_API_KEY` and never contains its value.
- New tests were mutation-checked — removing the param validation turns 7 red, and breaking
  the picker's "only when reachable" guard turns 3 red.

## Not in scope

- **Writing the pick back to `.mulmoterminal.json`.** That file is hand-maintained and
  holds colours, themes and skills; having the app rewrite it is a separate decision.
- **The Docker sandbox.** Still refused outright: a container inherits no environment, so
  such a session would silently run against Anthropic instead of the chosen backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
