### PR TITLE
fix: 設定ファイルの保護をプラットフォーム別に検証（Windows CI 赤）

### DIFF
--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -30,7 +30,16 @@ describe("settingsArgument", () => {
     expect(readFileSync(arg, "utf8")).toBe(json);
   });
 
-  it("keeps the file readable only by its owner", () => {
+  // The file holds an API token, so who can read it is the point of writing it at all.
+  // How that is enforced differs by platform, so the assertion does too: POSIX has mode
+  // bits, Windows has none — node maps `mode` to the read-only attribute there and
+  // stat reports 0o666 — and the containment below is what protects it instead.
+  it("keeps the file inside the user's own profile directory", () => {
+    const arg = settingsArgument(SESSION, "{}", true);
+    expect(arg.startsWith(path.join(os.homedir(), ".mulmoterminal", "settings") + path.sep)).toBe(true);
+  });
+
+  it.skipIf(process.platform === "win32")("keeps the file readable only by its owner", () => {
     const arg = settingsArgument(SESSION, "{}", true);
     expect(statSync(arg).mode & 0o777).toBe(0o600);
   });


### PR DESCRIPTION
## Summary

`Windows (daily)` が main で赤のままだったので修正しました（`5a0f67c8` 成功 → `b45b75f2` 以降 失敗）。

```
FAIL test/server/session/session-settings.spec.ts > settingsArgument > keeps the file readable only by its owner
AssertionError: expected 438 to be 384
```

`438` = `0o666`、`384` = `0o600`。

## 根本原因

`session-settings.ts` はプロバイダセッションの設定（`ANTHROPIC_AUTH_TOKEN` を含む）を `0600` のファイルに書きます。インラインの `--settings` はホスト上の全ユーザーから `ps` で見えるため、これは実質のあるセキュリティ対策です（#579）。

ただし **Windows には POSIX のパーミッションビットがありません**。node は `mode` を read-only 属性にしか対応させず、`statSync().mode & 0o777` は書き込み可能なファイルに対して `0o666` を返します。つまりこのアサーションは、**実装側では直しようのない理由で** Windows で必ず失敗します。

## 修正

保証が platform で分かれるので、アサーションも分けました。

| アサーション | 対象 |
|---|---|
| ファイルがユーザープロファイル配下（`~/.mulmoterminal/settings/`）にあること | 全 OS。**Windows で実際に保護しているのはこれ** |
| 所有者のみ読める（`0600`） | POSIX のみ（`it.skipIf(process.platform === "win32")`） |

実装は変更していません。`0600` は POSIX で正しく、Windows では無害です。

## 検証

- **Windows daily をこのブランチの ref で dispatch し、success を確認**（run 29893750563）。ローカル macOS だけでは検証にならないため。
- 同種の POSIX mode アサーションが他に無いことを確認（`grep` で該当はこの 1 箇所のみ）。
- lint 0 error / build / typecheck 3 種 / 全テスト 160 files・1945 passed。

## 補足

このテストは #579 で追加されたもので、私の #548 分割作業とは別系統です。main が赤だったため先に対処しました。
