### PR TITLE
refactor: index.ts に埋もれた最後の 2 つの判断をテスト可能に（#548 step 3i）

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -52,8 +52,9 @@ import {
   ptys,
   titleInFlight,
 } from "./session/registry.js";
-import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay } from "./session/reap-policy.js";
+import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./session/reap-policy.js";
 import { nextActivity, sessionRow, shouldRefreshReply } from "./session/activity-transition.js";
+import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "./session/background-chat.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
@@ -281,12 +282,9 @@ function reap(id: string) {
   titleInFlight.delete(id);
   lastTitledUserTurns.delete(id); // teardown only — kept across /clear as the re-title baseline
   lastTitleAttemptMs.delete(id);
-  const a = activity.get(id);
-  if (!a || (!a.working && !a.waiting)) {
+  if (shouldForgetActivity(activity.get(id))) {
     activity.delete(id);
-    // Drop the hidden flag only when activity is dropped too — while `waiting`
-    // persists (the bold-until-viewed window), keep it so the row stays un-bold.
-    hiddenSessions.delete(id);
+    hiddenSessions.delete(id); // the hidden flag rides with the record — see shouldForgetActivity
   }
   try {
     entry.term.kill();
@@ -472,22 +470,19 @@ app.use(express.json({ limit: "25mb" }));
 // so the user reviews and presses Enter. Registered BEFORE mountAllRoutes so this
 // specific route wins over /api/plugin/:toolName.
 app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
-  const body = isRecord(req.body) ? req.body : {};
-  const message = typeof body.message === "string" ? body.message.trim() : "";
-  if (!message) {
-    return res.json({ message: "spawnBackgroundChat: `message` is required (non-empty string)." });
-  }
-  const draft = body.draft === true;
-  const agent = body.agent === "codex" ? "codex" : "claude";
+  const parsed = parseBackgroundChat(req.body);
+  if (!parsed.ok) return res.json({ message: parsed.message });
+  const { agent, draft, hidden, message } = parsed.request;
   const sessionId = randomUUID();
-  if (body.hidden === true) hiddenSessions.add(sessionId);
+  if (hidden) hiddenSessions.add(sessionId);
   // ws is null: the session runs headless until the user opens it (reattach replays the buffered
   // output). A claude draft spawns with NO initial prompt (so it doesn't auto-run) and gets the text
   // typed into its input box. codex has no editable-draft path (no stable TUI ready-marker), so its
   // seed always auto-runs as codex's positional first-turn prompt, with the GUI MCP attached.
   try {
-    if (agent === "codex") spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, codexifySkillSeed(message));
-    else if (draft) spawnClaudePty(sessionId, null, null, undefined, CLAUDE_CWD, true, message);
+    const mode = spawnModeFor(agent, draft);
+    if (mode === "codex-run") spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, codexifySkillSeed(message));
+    else if (mode === "claude-draft") spawnClaudePty(sessionId, null, null, undefined, CLAUDE_CWD, true, message);
     else spawnClaudePty(sessionId, null, null, message);
   } catch (err) {
     console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);
@@ -495,12 +490,6 @@ app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
   }
   return res.json({ message: backgroundChatMessage(agent, draft, sessionId), jsonData: { chatId: sessionId, agent } });
 });
-
-function backgroundChatMessage(agent: "claude" | "codex", draft: boolean, sessionId: string): string {
-  if (agent === "codex") return `Spawned a new codex session (chatId ${sessionId}) auto-running the prompt.`;
-  if (draft) return `Opened a new terminal session (chatId ${sessionId}) with the text prefilled in the input for the user to review and send.`;
-  return `Spawned a new terminal session (chatId ${sessionId}). It runs in parallel; the user can open it from the sidebar.`;
-}
 
 // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
 // /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName

--- a/server/session/background-chat.ts
+++ b/server/session/background-chat.ts
@@ -1,0 +1,47 @@
+// What a spawnBackgroundChat request asks for. Split from the route (#548) because the
+// two rules below are policy, not plumbing, and the route is otherwise just a uuid, a
+// spawn and a response.
+//
+// The agent tool calls this, so the body is whatever a model produced — every field is
+// treated as absent unless it is exactly what we accept.
+
+export interface BackgroundChatRequest {
+  agent: "claude" | "codex";
+  /** Type the text into the input box for the user to review, instead of running it. */
+  draft: boolean;
+  /** Keep the session out of the sidebar. */
+  hidden: boolean;
+  message: string;
+}
+
+/** The request, or the message to answer with when it cannot be served. */
+export function parseBackgroundChat(body: unknown): { ok: true; request: BackgroundChatRequest } | { ok: false; message: string } {
+  const record = typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
+  const message = typeof record.message === "string" ? record.message.trim() : "";
+  if (!message) return { ok: false, message: "spawnBackgroundChat: `message` is required (non-empty string)." };
+  return {
+    ok: true,
+    request: {
+      agent: record.agent === "codex" ? "codex" : "claude",
+      draft: record.draft === true,
+      hidden: record.hidden === true,
+      message,
+    },
+  };
+}
+
+/** How the seed reaches the agent. codex has no editable-draft path — no stable TUI
+ *  ready-marker to type against — so its seed always auto-runs, and asking for a codex
+ *  draft gets a run rather than nothing. */
+export function spawnModeFor(agent: "claude" | "codex", draft: boolean): "codex-run" | "claude-draft" | "claude-run" {
+  if (agent === "codex") return "codex-run";
+  return draft ? "claude-draft" : "claude-run";
+}
+
+/** What the agent tool is told it did. The wording differs because the outcomes differ:
+ *  a draft waits for the user, a run is already working. */
+export function backgroundChatMessage(agent: "claude" | "codex", draft: boolean, sessionId: string): string {
+  if (agent === "codex") return `Spawned a new codex session (chatId ${sessionId}) auto-running the prompt.`;
+  if (draft) return `Opened a new terminal session (chatId ${sessionId}) with the text prefilled in the input for the user to review and send.`;
+  return `Spawned a new terminal session (chatId ${sessionId}). It runs in parallel; the user can open it from the sidebar.`;
+}

--- a/server/session/reap-policy.ts
+++ b/server/session/reap-policy.ts
@@ -53,3 +53,11 @@ export function parseWaitGraceMs(raw: string | undefined, defaultMs: number, onI
   }
   return n;
 }
+
+/** Whether teardown may also drop the session's activity record. A session that is still
+ *  working or still waiting keeps it: `waiting` is the bold-until-viewed window, and the
+ *  row has to stay bold after its pty is gone until the user actually looks. Only once
+ *  neither holds is the record — and the hidden flag that rides with it — safe to drop. */
+export function shouldForgetActivity(activity: ReapActivity | undefined): boolean {
+  return !activity || (!activity.working && !activity.waiting);
+}

--- a/test/server/session/background-chat.spec.ts
+++ b/test/server/session/background-chat.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../../../server/session/background-chat.js";
+
+const SESSION = "11111111-2222-3333-4444-555555555555";
+const ok = (body: unknown) => {
+  const parsed = parseBackgroundChat(body);
+  if (!parsed.ok) throw new Error(`expected a request, got: ${parsed.message}`);
+  return parsed.request;
+};
+
+// The body comes from an agent tool call, so it is whatever a model produced. Every field
+// has to read as absent unless it is exactly what we accept.
+describe("parseBackgroundChat", () => {
+  it("accepts a plain message and defaults the rest", () => {
+    expect(ok({ message: "look at the failing test" })).toEqual({
+      agent: "claude",
+      draft: false,
+      hidden: false,
+      message: "look at the failing test",
+    });
+  });
+
+  it("trims the message", () => {
+    expect(ok({ message: "  spaced  " }).message).toBe("spaced");
+  });
+
+  describe("rejection", () => {
+    const rejected = (body: unknown) => {
+      const parsed = parseBackgroundChat(body);
+      expect(parsed.ok).toBe(false);
+      return parsed.ok ? "" : parsed.message;
+    };
+
+    it("refuses a missing, empty or whitespace-only message", () => {
+      // Spawning on an empty message would leave the user an idle session with no task.
+      expect(rejected({})).toMatch(/`message` is required/);
+      expect(rejected({ message: "" })).toMatch(/`message` is required/);
+      expect(rejected({ message: "   " })).toMatch(/`message` is required/);
+    });
+
+    it("refuses a message that is not a string", () => {
+      for (const message of [42, ["hi"], null, { text: "hi" }]) {
+        expect(rejected({ message })).toMatch(/`message` is required/);
+      }
+    });
+
+    it("refuses a body that is not an object", () => {
+      for (const body of [null, undefined, "just a string", 42, []]) {
+        expect(rejected(body)).toMatch(/`message` is required/);
+      }
+    });
+  });
+
+  describe("flags", () => {
+    it("takes draft only when it is exactly true", () => {
+      // A model may pass "true" or 1; anything but the boolean must run the prompt
+      // rather than silently leaving it unsent in the input box.
+      expect(ok({ message: "m", draft: true }).draft).toBe(true);
+      expect(ok({ message: "m", draft: "true" }).draft).toBe(false);
+      expect(ok({ message: "m", draft: 1 }).draft).toBe(false);
+      expect(ok({ message: "m" }).draft).toBe(false);
+    });
+
+    it("takes hidden only when it is exactly true", () => {
+      expect(ok({ message: "m", hidden: true }).hidden).toBe(true);
+      expect(ok({ message: "m", hidden: "yes" }).hidden).toBe(false);
+    });
+
+    it("takes codex only for that exact string, and defaults to claude", () => {
+      expect(ok({ message: "m", agent: "codex" }).agent).toBe("codex");
+      expect(ok({ message: "m", agent: "Codex" }).agent).toBe("claude");
+      expect(ok({ message: "m", agent: "gpt" }).agent).toBe("claude");
+      expect(ok({ message: "m" }).agent).toBe("claude");
+    });
+  });
+});
+
+describe("spawnModeFor", () => {
+  it("runs a claude prompt by default", () => {
+    expect(spawnModeFor("claude", false)).toBe("claude-run");
+  });
+
+  it("drafts a claude prompt when asked", () => {
+    expect(spawnModeFor("claude", true)).toBe("claude-draft");
+  });
+
+  it("runs a codex prompt whether or not a draft was asked for", () => {
+    // codex has no editable-draft path — no stable TUI ready-marker to type against —
+    // so a codex draft has to become a run rather than nothing at all.
+    expect(spawnModeFor("codex", false)).toBe("codex-run");
+    expect(spawnModeFor("codex", true)).toBe("codex-run");
+  });
+});
+
+describe("backgroundChatMessage", () => {
+  it("says the codex session is already running", () => {
+    const text = backgroundChatMessage("codex", false, SESSION);
+    expect(text).toContain(SESSION);
+    expect(text).toMatch(/auto-running/);
+  });
+
+  it("says a draft is waiting for the user rather than running", () => {
+    // The caller decides what to tell the user next, so a draft must not read as started.
+    const text = backgroundChatMessage("claude", true, SESSION);
+    expect(text).toMatch(/prefilled/);
+    expect(text).not.toMatch(/runs in parallel/);
+  });
+
+  it("says a claude run is working in parallel", () => {
+    const text = backgroundChatMessage("claude", false, SESSION);
+    expect(text).toMatch(/runs in parallel/);
+    expect(text).not.toMatch(/prefilled/);
+  });
+
+  it("always carries the session id, which is how the caller reopens it", () => {
+    for (const [agent, draft] of [
+      ["claude", false],
+      ["claude", true],
+      ["codex", false],
+    ] as const) {
+      expect(backgroundChatMessage(agent, draft, SESSION)).toContain(SESSION);
+    }
+  });
+});

--- a/test/server/session/reap-policy.spec.ts
+++ b/test/server/session/reap-policy.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { reapDecisionFor, reapTimerDelay, parseWaitGraceMs, MAX_TIMER_MS } from "../../../server/session/reap-policy.js";
+import { reapDecisionFor, reapTimerDelay, parseWaitGraceMs, MAX_TIMER_MS, shouldForgetActivity } from "../../../server/session/reap-policy.js";
 
 const graces = { idleMs: 30_000, waitingMs: 1_800_000 };
 
@@ -128,5 +128,38 @@ describe("parseWaitGraceMs", () => {
     // The two compose — a bad env var must land on the default grace, not on "never".
     expect(reapTimerDelay(parseWaitGraceMs("abc", DEFAULT_MS))).toBe(DEFAULT_MS);
     expect(reapTimerDelay(parseWaitGraceMs("0", DEFAULT_MS))).toBeNull();
+  });
+});
+
+// Teardown removes the pty, but the row the user sees outlives it. Dropping the activity
+// record too early un-bolds a session that finished with output nobody has looked at yet.
+describe("shouldForgetActivity", () => {
+  it("forgets a session with no activity record at all", () => {
+    expect(shouldForgetActivity(undefined)).toBe(true);
+    expect(shouldForgetActivity({})).toBe(true);
+  });
+
+  it("forgets a session that is neither working nor waiting", () => {
+    expect(shouldForgetActivity({ working: false, waiting: false })).toBe(true);
+  });
+
+  it("keeps a session that still needs the user", () => {
+    // `waiting` is the bold-until-viewed window: the pty is gone, but the row must stay
+    // bold until someone actually looks at it.
+    expect(shouldForgetActivity({ waiting: true })).toBe(false);
+    expect(shouldForgetActivity({ working: false, waiting: true })).toBe(false);
+  });
+
+  it("keeps a session still marked working", () => {
+    expect(shouldForgetActivity({ working: true })).toBe(false);
+    expect(shouldForgetActivity({ working: true, waiting: false })).toBe(false);
+  });
+
+  it("keeps a session with both flags set", () => {
+    expect(shouldForgetActivity({ working: true, waiting: true })).toBe(false);
+  });
+
+  it("ignores fields that are not the two flags", () => {
+    expect(shouldForgetActivity({ event: "Stop", at: 1 } as never)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Codex に「これ以上切り出す価値のあるものはあるか」を相談し、**推奨された 2 件だけ**を実施しました（#548 step 3i）。

index.ts: 1045 → **1034 行**／テスト: 1945 → **1966 件**（+21）

行数の削減はわずかです。狙いは行数ではなく、**周りを動かさないと到達できなかった 2 つの判断をテスト可能にすること**です。

| 取り出したもの | 元の在り処 |
|---|---|
| `shouldForgetActivity` | `reap()` 内、十数個の delete に挟まれたインライン条件 |
| `parseBackgroundChat` / `spawnModeFor` / `backgroundChatMessage` | `spawnBackgroundChat` ルート内 |

## なぜこの 2 つか

**`shouldForgetActivity`**: `waiting` は「見られるまで太字」の窓です。pty が消えた後も、ユーザーが実際に見るまで行は太字のままである必要があります。早く落とすと**終わった仕事が静かに未読解除される**。

**`parseBackgroundChat`**: body はエージェントのツール呼び出し由来＝モデルが作った任意の値です。厳密一致でないものはすべて「無し」として扱う必要があります。モデルが `draft: "true"` を渡したとき、**プロンプトを実行せず入力欄に置いたまま**になると、ユーザーは何も起きていないセッションを見ることになります。

**`spawnModeFor`**: codex には編集可能な draft 経路がありません（TUI の ready マーカーが安定しないため）。したがって codex への draft 要求は**実行に落とす**必要があり、これは業務ルールです。

## Codex の評価（相談結果）

「**一巡だけやって止めるべき、既に逓減している**」という結論でした。本 PR はその推奨 1〜2 を実施したものです。

Codex が**移すべきでない**とした箇所も尊重しています:

- `mount*()` の連なり・pubsub 初期化・スケジューラ・`server.listen` — composition root として順序と依存が見えることに価値があり、`createServerDeps()` の裏に隠すと監査性が下がる
- `reap()` 本体・remote-host アダプタ — 共有可変状態を巨大な deps 越しに動かすだけで、テスト可能になるものが増えない

3 番目の推奨（`hookSettingsJson` / `mcpConfigJson`）は「optional」だったため見送りました。

## 検証

- **等価性**: `shouldForgetActivity` 10 ケース、background-chat 24 ケースで元の式と全一致（置き換え前に確認）
- **teeth 確認**: 12 パターンすべて赤（waiting/working を無視・常に忘れる・記録なしを保持／trim しない・空 message を通す・draft/hidden/agent の判定を緩める・codex で draft を許す・draft と run を取り違える・文言の取り違え）
- **ゲート**: lint 0 error / build / typecheck 3 種 / 全テスト 161 files・**1966 passed**

## 一区切り

これで #548 の分割は **2143 → 1034 行（-52%）**、テストは 1541 → 1966 件（+425）です。残る index.ts は composition root（起動・配線）とセッション寿命の状態そのもので、Codex・私とも「これ以上は逓減」という見立てです。
