### PR TITLE
docs: モデルとバックエンド — Anthropic の認証・必要な許可・実際に渡る環境変数

### DIFF
--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -59,6 +59,9 @@ Claude Code can talk to any Anthropic-compatible backend. MulmoTerminal reads th
 `config.json`, and their keys from the environment the **server** was started with — a key never
 lives in a config file.
 
+> Anthropic's own authentication, what reaches the session, the full list of credentials and
+> permissions, and how a resume behaves are covered in [Models and backends](models.html).
+
 ### 1. Add the backend to `~/.mulmoterminal/config.json`
 
 ```json

--- a/docs/guide/en/index.md
+++ b/docs/guide/en/index.md
@@ -58,5 +58,6 @@ npx mulmoterminal@latest    # opens http://localhost:34567
 2. [Scenarios — workflows by example](scenarios.html)
 3. [Feature reference](features.html) (grouped by the four pillars)
 4. [Configuration](config.html) (settings modal · `config.json` · `.mulmoterminal.json` · the **DSL**)
+5. [Models and backends](models.html) (Anthropic auth · other backends · **the credentials and permissions each needs**)
 
 > The Japanese guide is here: [日本語ガイド](../ja/).

--- a/docs/guide/en/models.md
+++ b/docs/guide/en/models.md
@@ -1,0 +1,200 @@
+---
+title: Models and backends
+layout: default
+parent: English
+nav_order: 6
+---
+
+# Models and backends
+{: .no_toc }
+
+- TOC
+{:toc}
+
+Which model a session runs on, and what credentials or permissions each route needs.
+For how to write the settings, see [Configuration](config.html#providers) — this page is the
+other half: what actually happens when a session starts.
+
+Configure nothing and sessions stay on Anthropic, on Claude Code's own default model.
+
+---
+
+## What decides, and in what order
+
+| What decides | Where you write it | How far it reaches |
+|---|---|---|
+| **The directory's default** | `provider` / `model` in `<project>/.mulmoterminal.json` | every session opened in that directory |
+| **The launch pick** | the **MODEL** field in an empty cell's launch form | **that one session only** — the file is not rewritten |
+| Nothing at all | — | Anthropic, on Claude Code's default model |
+
+- **A new session** takes the launch pick when there is one, otherwise the directory's default.
+- **A resume** IGNORES the launch pick and continues on **the backend that session started on**.
+  That memory is process-lifetime only, so after a server restart a resumed session falls back
+  to the directory's default.
+
+> **Why a resume ignores the pick**
+> The browser re-sends whatever its cell still holds on every reconnect, and that value belongs to
+> the session that cell launched — not necessarily to the one being resumed. A backend swapping
+> mid-conversation is the worse outcome, so what the session actually started on wins.
+
+`provider` and `model` always travel as a **pair**. Neither is ever taken from one source and
+combined with the other from somewhere else: a dropped provider whose model survived would send
+another vendor's model id to Anthropic.
+
+---
+
+## Staying on Anthropic (the default)
+
+### Authentication
+
+MulmoTerminal holds no Anthropic credential of its own — it uses **whatever the `claude` command
+is already authenticated with**. If `claude` runs in your terminal, nothing else is needed.
+
+Claude Code's own precedence, strongest first:
+
+1. `ANTHROPIC_API_KEY`
+2. `ANTHROPIC_AUTH_TOKEN`
+3. the subscription OAuth credential (on macOS, the `Claude Code-credentials` Keychain entry)
+
+**A leftover `ANTHROPIC_API_KEY` silently outranks the other two.** That is usually the answer to
+"I'm logged in, so why am I being billed per token?" and "why did my provider session go to
+Anthropic anyway?". For provider sessions MulmoTerminal removes it explicitly — see below.
+
+### Running a different Anthropic model
+
+Put `model` in `.mulmoterminal.json` and leave `provider` out.
+
+```json
+{ "model": "sonnet" }
+```
+
+The value is passed to `claude --model` verbatim, so an alias (`sonnet` / `opus` / `haiku`) and a
+full model id are equally fine.
+
+> **The launch form's MODEL field does not list Anthropic models.**
+> It offers the models of the backends registered in `config.json` under `providers`, and with no
+> provider registered **the field does not appear at all** (a link to the setup help takes its
+> place). Today, `model` in `.mulmoterminal.json` is the only way to change the Anthropic model.
+
+---
+
+## Running on another backend (providers)
+
+For the registration steps see [Configuration → Running on another model](config.html#providers).
+What follows is how such a session is actually started.
+
+### What reaches the session
+
+A provider session receives these through the `env` block of Claude Code's settings (`--settings`):
+
+| Variable | Value | Why |
+|---|---|---|
+| `ANTHROPIC_BASE_URL` | `baseUrl` | where to connect |
+| `ANTHROPIC_AUTH_TOKEN` | the **value** of the env var named by `tokenEnv` | authentication |
+| `ANTHROPIC_MODEL` | the chosen model id | |
+| `ANTHROPIC_SMALL_FAST_MODEL` | the same model id | Claude Code makes background "haiku" calls (title generation and friends); against a backend with no haiku they 400, so they are aimed at the same model |
+| `CLAUDE_CODE_MAX_OUTPUT_TOKENS` | `maxOutputTokens` (**16000** when omitted) | a thinking model starved of output room spends the budget thinking and returns **empty** visible text |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `1` | a redirected session must not keep calling the real Anthropic API in the background |
+| `ANTHROPIC_API_KEY` | **removed from the environment** | left in place it silently outranks the auth token, sending the session somewhere nobody chose |
+
+The settings `env` block is the transport rather than the process environment because **Claude Code
+applies it itself**, so it reaches the session identically on the host, in a tmux pane, and inside a
+container.
+
+Settings carrying a token are written to `~/.mulmoterminal/settings/<session-id>.json` with mode
+`0600` and only the PATH reaches the command line, so the token is not visible to other users
+through `ps`. The file is removed when the session ends.
+
+### No key, no launch
+
+If the env var named by `tokenEnv` is empty or unset, the session **refuses to start**.
+
+```
+provider 'openrouter' needs OPENROUTER_API_KEY in the server's environment — refusing to start
+```
+
+It does not quietly fall back to Anthropic, because **a base URL with no token does not disable
+Claude Code's authentication — it sends your subscription credential to that third party**.
+Stopping is the safe answer.
+
+### If you use tmux
+
+A tmux pane inherits the environment of the **tmux server**, not of the client that spawned it. So
+before a provider session starts, MulmoTerminal strips `ANTHROPIC_API_KEY` from the tmux server's
+global environment — otherwise an earlier non-provider session could seed the server with the key
+and every provider pane after it would inherit the thing that outranks its auth token.
+
+---
+
+## Credentials and permissions you need
+
+| To do this | You need | Where it goes |
+|---|---|---|
+| **Stay on Anthropic** | `claude` to be authenticated | managed by Claude Code itself; MulmoTerminal does not touch it |
+| **Use a provider** | that service's API key | an **environment variable of the shell that starts the server**, or a `.env` beside it — never the config file |
+| **Use OpenRouter** | your account's data policy to allow the serving providers | [openrouter.ai/settings/privacy](https://openrouter.ai/settings/privacy) |
+| **Change the tool-permission level** | `CLAUDE_PERMISSION_MODE` | the server's environment at startup |
+| **Run in the Docker sandbox** | macOS + a running Docker | `MULMOTERMINAL_SANDBOX=1`. **Cannot be combined with a provider** |
+
+Keys are always referenced **by name**: what goes in `config.json` is `tokenEnv`, the NAME of an
+environment variable, never its value. This config is served over HTTP to the browser and the phone,
+so there is deliberately nowhere to put a secret in it.
+
+Adding an environment variable requires **restarting the server**.
+
+### Tool permissions (`CLAUDE_PERMISSION_MODE`)
+
+Claude sessions are spawned with `--permission-mode`. The default is **`auto`**, so a backend
+session runs hands-off. Override it in the server's environment:
+
+```bash
+CLAUDE_PERMISSION_MODE=default npx mulmoterminal@latest
+```
+
+`default` / `acceptEdits` / `bypassPermissions` / `plan` and friends can be passed through.
+
+### The macOS Keychain (sandbox only)
+
+With `MULMOTERMINAL_SANDBOX=1`, MulmoTerminal reads the `Claude Code-credentials` Keychain entry to
+hand the container the current credential — a container cannot read the Keychain, and
+`~/.claude/.credentials.json` is often absent or stale. macOS may ask you to allow that access. If
+the token has expired it drives the host `claude` to refresh it first.
+
+Ordinary sessions running on the host never take this route.
+
+---
+
+## Choosing at launch
+
+When at least one provider is usable, an empty cell's launch form grows a **MODEL** field.
+
+```
+Kimi K2.7 Code · 3/3 · 14s · 262k
+```
+
+Those numbers are measured (`3/3` = tool-using task completed / attempts, `14s` = median,
+`262k` = context length). How to read them, and how they were produced, is in
+[Configuration → Choosing at launch](config.html#providers).
+
+A provider that **cannot** be used — a missing key, for instance — is not offered. The help beside
+the field carries the very sentence a session would have refused with, naming the single thing to
+fix. Fix it and restart the server.
+
+---
+
+## When it doesn't work
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `... needs XXX_API_KEY in the server's environment` | the key is not in the server's environment | put it in the shell or `.env`, restart the server |
+| `unknown provider 'xxx'` | `provider` in `.mulmoterminal.json` matches no `providers` entry in `config.json` | make the ids agree |
+| `provider 'xxx' needs a model` | a provider was named with no model | add `model` to `.mulmoterminal.json` |
+| `has an unusable baseUrl` | not `http(s)://`, or it ends in `/v1` | drop the `/v1` — Claude Code appends `/v1/messages` itself |
+| 404s from the backend | same as above (`/v1/v1/messages`) | drop the `/v1` from `baseUrl` |
+| the reply comes back **empty** | a thinking model with too little output room | raise `maxOutputTokens` (default 16000) |
+| a resumed session isn't on the model you picked | by design: a resume continues on the backend it started on | start a new session instead |
+| after a server restart, resumed sessions fall back to the default | that memory is process-lifetime only | expected; put the default in `.mulmoterminal.json` |
+| `cannot run in the Docker sandbox yet` | a provider combined with the sandbox | drop one of the two |
+| the picker says `not reachable from this account` | the OpenRouter account used for the measurement had every serving provider excluded by its privacy settings | **not a defect in the model** — it may well run on your account |
+
+The model list is `common/modelPresets.ts`; the measurement script is `scripts/model-trials.ts`.

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -59,6 +59,9 @@ nav_order: 4
 Claude Code は Anthropic 互換のバックエンドなら何にでも接続できます。MulmoTerminal はその接続先を
 `config.json` から、**鍵はサーバを起動したときの環境変数から**読みます。鍵が設定ファイルに入ることはありません。
 
+> Anthropic 自体の認証、セッションに渡る環境変数、必要な許可の一覧、再開時の挙動は
+> [モデルとバックエンド](models.html) にまとめてあります。
+
 ### 1. 接続先を `~/.mulmoterminal/config.json` に足す
 
 ```json

--- a/docs/guide/ja/index.md
+++ b/docs/guide/ja/index.md
@@ -58,5 +58,6 @@ npx mulmoterminal@latest    # → http://localhost:34567 が開く
 2. [応用編 — シナリオ別の使い方](scenarios.html)
 3. [機能一覧](features.html)（4 本柱で整理）
 4. [設定方法](config.html)（設定モーダル・`config.json`・`.mulmoterminal.json`・**DSL 拡張**）
+5. [モデルとバックエンド](models.html)（Anthropic の認証・別バックエンド・**必要な許可と鍵**）
 
 > 英語版は [English guide](../en/) にあります。

--- a/docs/guide/ja/models.md
+++ b/docs/guide/ja/models.md
@@ -1,0 +1,191 @@
+---
+title: モデルとバックエンド
+layout: default
+parent: 日本語
+nav_order: 6
+---
+
+# モデルとバックエンド
+{: .no_toc }
+
+- TOC
+{:toc}
+
+セッションを**どのモデルで動かすか**と、そのために**何の許可・鍵が要るか**をまとめたページです。
+設定の書き方そのものは [設定方法](config.html#providers) にあります。ここは「実際に何が起きるか」側です。
+
+何も設定しなければ、Anthropic のまま Claude Code 自身の既定モデルで動きます。
+
+---
+
+## 決まり方と優先順位
+
+| 決めるもの | 書く場所 | 効く範囲 |
+|---|---|---|
+| **ディレクトリの既定** | `<project>/.mulmoterminal.json` の `provider` / `model` | そのディレクトリで開くセッション全部 |
+| **起動時の選択** | 空セルの起動フォームの **MODEL** 欄 | **その 1 セッションだけ**（ファイルは書き換わりません） |
+| 何も指定しない | — | Anthropic + Claude Code の既定モデル |
+
+- **新規セッション** … 起動時に選んだものがあればそれ、なければディレクトリの既定。
+- **再開（resume）** … 起動時の選択は**無視**され、**そのセッションが開始したときのバックエンド**を引き継ぎます。
+  サーバを再起動すると開始時の記録（プロセス内のみ）が消えるため、その後の再開はディレクトリの既定に戻ります。
+
+> **なぜ再開時は無視するのか**
+> ブラウザは再接続のたびにセルが保持している選択を送りますが、その値は**そのセルが起動したセッション**のもので、
+> いま再開しようとしているセッションのものとは限りません。会話の途中でバックエンドが入れ替わる方が危険なので、
+> 開始時のものを優先します。
+
+`provider` と `model` は常に**ペアで**扱われます。片方を別の場所から持ってきて混ぜることはしません
+（provider だけ落ちて model が残ると、他社のモデル id を Anthropic に投げることになるため）。
+
+---
+
+## Anthropic のまま使う（既定）
+
+### 認証
+
+MulmoTerminal は Anthropic 用の鍵を自分では持たず、**`claude` コマンド自身の認証をそのまま使います**。
+ターミナルで `claude` が動く状態なら、追加の設定は要りません。
+
+Claude Code 側の認証の優先順位は次のとおりです（上ほど強い）。
+
+1. `ANTHROPIC_API_KEY`
+2. `ANTHROPIC_AUTH_TOKEN`
+3. サブスクリプションの OAuth 資格情報（macOS では Keychain の `Claude Code-credentials`）
+
+**`ANTHROPIC_API_KEY` が環境に残っていると、下の 2 つを黙って上回ります。** 「ログインしているはずなのに
+API 課金される」「プロバイダに向けたはずが本家に行く」はたいていこれが原因です。プロバイダを使うセッションでは
+MulmoTerminal が明示的に取り除きます（後述）。
+
+### 別の Anthropic モデルを使う
+
+`.mulmoterminal.json` に `model` **だけ**書きます（`provider` は書きません）。
+
+```json
+{ "model": "sonnet" }
+```
+
+値は `claude --model` にそのまま渡るので、`sonnet` / `opus` / `haiku` のエイリアスでも、正式なモデル id でも構いません。
+
+> **起動フォームの MODEL 欄に Anthropic のモデルは並びません。**
+> 選択肢に出るのは `config.json` の `providers` に登録したバックエンドのモデルだけで、プロバイダを 1 つも
+> 登録していなければ**選択欄そのものが出ません**（代わりに設定方法へのリンクが出ます）。
+> Anthropic 側のモデルを変える手段は、いまのところ `.mulmoterminal.json` の `model` だけです。
+
+---
+
+## 別のバックエンドで動かす（プロバイダ）
+
+登録手順は [設定方法 → 別のモデルで動かす](config.html#providers) を見てください。ここでは、
+そのセッションが**実際にどう起動されるか**を書きます。
+
+### セッションに渡るもの
+
+プロバイダを使うセッションには、Claude Code の設定ファイル（`--settings`）の `env` ブロック経由で次が渡ります。
+
+| 変数 | 値 | なぜ必要か |
+|---|---|---|
+| `ANTHROPIC_BASE_URL` | `baseUrl` | 接続先 |
+| `ANTHROPIC_AUTH_TOKEN` | `tokenEnv` が指す環境変数の**値** | 認証 |
+| `ANTHROPIC_MODEL` | 選んだモデル id | |
+| `ANTHROPIC_SMALL_FAST_MODEL` | 同じモデル id | Claude Code はタイトル生成などで裏に haiku を呼びます。haiku を持たないバックエンドではそれが 400 になるため、同じモデルに向けます |
+| `CLAUDE_CODE_MAX_OUTPUT_TOKENS` | `maxOutputTokens`（省略時 **16000**） | 思考型モデルは出力枠が足りないと考えるだけで終わり、**返答が空**になります |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | `1` | 転送したセッションが裏で本家 Anthropic を叩き続けないように |
+| `ANTHROPIC_API_KEY` | **環境から削除** | 残っていると認証トークンを黙って上回り、意図しない接続先になります |
+
+環境変数を直接渡すのではなく設定ファイルの `env` ブロックを使うのは、**Claude Code 自身がそれを適用する**ため、
+ホスト・tmux のペイン・コンテナのどれでも同じように効くからです。
+
+トークンを含む設定は `ps` から他ユーザーに見えないよう、`~/.mulmoterminal/settings/<session-id>.json`
+（パーミッション `0600`）に書き出され、コマンドラインにはそのパスだけが載ります。ファイルはセッション終了時に消えます。
+
+### 鍵が無ければ起動しません
+
+`tokenEnv` が指す環境変数が空／未設定なら、そのセッションは**起動を拒否します**。
+
+```
+provider 'openrouter' needs OPENROUTER_API_KEY in the server's environment — refusing to start
+```
+
+黙って Anthropic に落とさないのは、**base URL だけがあってトークンが無い状態は、あなたのサブスクリプション
+資格情報をその第三者に送ってしまう**からです（Claude Code の認証は base URL の変更だけでは止まりません）。
+落とす代わりに止めます。
+
+### tmux を使っている場合
+
+tmux のペインは、起動したクライアントではなく **tmux サーバの環境**を継承します。そのため MulmoTerminal は
+プロバイダのセッションを起動する前に、tmux サーバのグローバル環境から `ANTHROPIC_API_KEY` を取り除きます。
+先に起動した非プロバイダのセッションが tmux サーバに鍵を持ち込み、後続のプロバイダのペインがそれを継承して
+しまうのを防ぐためです。
+
+---
+
+## 必要な許可・認証情報
+
+| やりたいこと | 必要なもの | どこに置くか |
+|---|---|---|
+| **Anthropic のまま使う** | `claude` が認証済みであること | Claude Code 自身が管理（MulmoTerminal は触りません） |
+| **プロバイダを使う** | そのサービスの API キー | **サーバを起動するシェルの環境変数**、または隣に置いた `.env`。設定ファイルには入れません |
+| **OpenRouter を使う** | アカウントのデータポリシー設定で配信元を許可 | [openrouter.ai/settings/privacy](https://openrouter.ai/settings/privacy) |
+| **ツール実行の許可レベルを変える** | `CLAUDE_PERMISSION_MODE` | サーバ起動時の環境変数 |
+| **Docker サンドボックスで動かす** | macOS + 起動中の Docker | `MULMOTERMINAL_SANDBOX=1`。**プロバイダとは併用できません** |
+
+鍵は必ず**名前**で参照します。`config.json` に書くのは `tokenEnv`（環境変数の名前）であって、値ではありません。
+この設定はブラウザやスマホにも HTTP で配られるため、値を書ける場所を用意していません。
+
+環境変数を足したら**サーバの再起動**が必要です。
+
+### ツール実行の許可（`CLAUDE_PERMISSION_MODE`）
+
+MulmoTerminal が起動する Claude セッションは `--permission-mode` 付きで起動します。既定は **`auto`**
+（バックエンドが手離しで進める状態）。変えたいときはサーバ側の環境変数で指定します。
+
+```bash
+CLAUDE_PERMISSION_MODE=default npx mulmoterminal@latest
+```
+
+`default` / `acceptEdits` / `bypassPermissions` / `plan` などが渡せます。
+
+### macOS の Keychain（サンドボックス使用時のみ）
+
+`MULMOTERMINAL_SANDBOX=1` でコンテナ実行するときだけ、MulmoTerminal は Keychain の
+`Claude Code-credentials` を読み、コンテナに現在の資格情報を渡します（コンテナは Keychain を読めず、
+`~/.claude/.credentials.json` は無い／古いことが多いため）。macOS がアクセスの許可を求めることがあります。
+トークンが期限切れなら、先にホストの `claude` を動かして更新してから渡します。
+
+ホストでそのまま動かす通常のセッションでは、この経路は使いません。
+
+---
+
+## 起動時に選ぶ
+
+プロバイダが 1 つでも使える状態なら、空セルの起動フォームに **MODEL** の選択欄が出ます。
+
+```
+Kimi K2.7 Code · 3/3 · 14s · 262k
+```
+
+脇の数字は実測値です（`3/3` = ツールを使う課題を完走した回数 / 試行回数、`14s` = 中央値、`262k` = コンテキスト長）。
+読み方と計測方法は [設定方法 → 起動時に選ぶ](config.html#providers) にあります。
+
+鍵が無いなど**使えない状態のプロバイダは選択肢に出ません**。代わりにヘルプ側に、そのセッションが拒否されるときと
+**同じ一文**が出ます。直すべき 1 か所がそのまま書いてあるので、それを直してサーバを再起動してください。
+
+---
+
+## うまくいかないとき
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `... needs XXX_API_KEY in the server's environment` | 鍵がサーバの環境に無い | シェルか `.env` に入れてサーバを再起動 |
+| `unknown provider 'xxx'` | `.mulmoterminal.json` の `provider` が `config.json` の `providers` に無い | id の綴りを合わせる |
+| `provider 'xxx' needs a model` | provider だけ指定して model が無い | `.mulmoterminal.json` に `model` も書く |
+| `has an unusable baseUrl` | `http(s)://` でない、または末尾が `/v1` | `/v1` を外す（Claude Code が `/v1/messages` を自分で足します） |
+| 404 が返る | 上と同じ（`/v1/v1/messages` になっている） | `baseUrl` から `/v1` を外す |
+| **返答が空**のまま終わる | 思考型モデルで出力枠が足りない | `maxOutputTokens` を上げる（既定 16000） |
+| 選んだはずのモデルで動かない（再開時） | 再開は**開始時**のバックエンドを引き継ぐ仕様 | 新しいセッションとして起動し直す |
+| サーバ再起動後、再開セッションが既定に戻る | 開始時の記録はプロセス内のみ | 仕様。ディレクトリ既定を `.mulmoterminal.json` に書いておく |
+| `cannot run in the Docker sandbox yet` | プロバイダとサンドボックスの併用 | どちらかを外す |
+| ピッカーに `not reachable from this account` と出る | 計測に使った OpenRouter アカウントのプライバシー設定で配信元が全部除外されていた | **モデルの欠陥ではありません**。自分のアカウント設定次第では動きます |
+
+モデル一覧は `common/modelPresets.ts`、計測スクリプトは `scripts/model-trials.ts` です。


### PR DESCRIPTION
## Summary

`docs/guide/{ja,en}/models.md` を新設。既存の `config.md` は「プロバイダの登録手順」は説明しているが、**Anthropic 自体の認証**・**セッションに実際に渡るもの**・**どの経路にどの許可/鍵が要るか**を書いていなかった。セッションが誰も選んでいないバックエンドに行ったときに知りたいのはそちら側なので、そこを実装から起こして 1 ページにまとめた。

日英とも新規、`config.md` のプロバイダ節と両言語のガイド index からリンク。既存ページの変更はリンク 1 行ずつのみ。

## Items to Confirm / Review

記述はすべてコードを読んで裏取りしたが、**特に見てほしい判断**は以下:

1. **「起動フォームに Anthropic のモデルは並ばない」と明記した** — `MODEL_PRESETS` に `provider: "anthropic"` のエントリが 0 件で、`launchOptions()` は `config.json` の `providers` だけを写すため、プロバイダ未登録だとピッカー自体が出ない（`ModelPicker.vue` の `v-if="launchOptions.anyReady"`）。仕様として意図どおりか、それとも今後 Anthropic も並べる予定か。後者なら書き方を変える
2. **`CLAUDE_PERMISSION_MODE` の既定値を `auto` と書いた** — `server/index.ts` の `process.env.CLAUDE_PERMISSION_MODE || "auto"` に従った。`auto` が Claude Code 側で有効な値かどうかまでは検証していない（コード上の既定値をそのまま記載）
3. **macOS Keychain の節をサンドボックス限定と書いた** — `refreshHostKeychainIfExpired` の呼び出しが `if (live?.sandbox || sandboxWouldRun(attachGuiMcp))` に閉じているため。ホスト実行の通常セッションでこの経路が走らない、という理解で合っているか
4. **`ANTHROPIC_API_KEY` が残っているときの症状**を「ログインしているのに課金される」「プロバイダに向けたはずが本家に行く」と書いた — `provider-env.ts` の「a leftover value silently outranks the auth token」からの敷衍で、前者は実測ではなく認証優先順位からの帰結として書いている
5. 用語（「バックエンド」「プロバイダ」「起動時の選択」）が既存ページと揃っているか

## User Prompt

> document　anthropicの設定をふくめ詳しく書いて。許可必要なのも含め。独立したdocumentでもよいよ

（直前の作業は #587 のレビュー対応とマージ。そこで扱ったモデルピッカーまわりの設定が対象）

## 内容

| 節 | 中身 |
|---|---|
| 決まり方と優先順位 | ディレクトリ既定 / 起動時の選択 / 未指定 の 3 経路と適用順。**再開時は起動時の選択を無視し開始時のバックエンドを引き継ぐ**こと、サーバ再起動でその記録が消えること、`provider`/`model` がペア単位であること |
| Anthropic のまま使う | `claude` 自身の認証をそのまま使う旨、優先順位（`ANTHROPIC_API_KEY` > `ANTHROPIC_AUTH_TOKEN` > サブスク OAuth）、`model` だけ書いて Anthropic の別モデルを使う方法、ピッカーには出ないこと |
| 別のバックエンド | セッションに渡る 6 変数 + `ANTHROPIC_API_KEY` の削除を理由付きの表に。設定ファイル `env` ブロックを使う理由、0600 の settings ファイル、鍵が無いときに**起動を拒否する理由**（base URL だけではサブスク資格情報が第三者に飛ぶ）、tmux サーバ環境の scrub |
| 必要な許可・認証情報 | 経路ごとの表（`claude` のログイン / API キー / OpenRouter のデータポリシー / `CLAUDE_PERMISSION_MODE` / サンドボックス）。`CLAUDE_PERMISSION_MODE` と Keychain の節 |
| 起動時に選ぶ | 実測値の読み方は `config.md` に委ね、**使えないプロバイダは選択肢に出ず、拒否時と同じ一文がヘルプに出る**ことを記載 |
| うまくいかないとき | 症状 → 原因 → 対処。エラー文言は `resolveProvider` / `usableProvider` が実際に出す文字列をそのまま使用 |

## 確認したこと

- 全リンクの解決先（`config.html#providers` は既存アンカー、外部は openrouter の privacy 設定のみ）
- `.prettierignore` に `*.md` があるため format 対象外
- 事実の出典: `server/session/provider-env.ts` / `server/config/launch-options.ts` / `server/config/config-schema.ts` / `server/session/session-settings.ts` / `server/session/launch-choice.ts` / `server/infra/tmux.ts` / `server/infra/sandbox.ts` / `server/agents/claude-args.ts` / `server/index.ts` / `common/modelPresets.ts`
- `cleanupSessionSettings` がセッション終了パス（`server/index.ts:304`）で呼ばれることを確認した上で「セッション終了時に消える」と記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)
