### PR TITLE
refactor: index.ts が全体に注入している3つのビルダーを pure にしてテストを付ける (#548 step 3j)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -23,9 +23,12 @@ import {
   isResumableTmuxSession,
 } from "./infra/tmux.js";
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
-import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage, cleanupSandbox, rewriteLoopbackForDocker } from "./infra/sandbox.js";
+import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage, cleanupSandbox } from "./infra/sandbox.js";
+import { isAllowedOrigin } from "./infra/allowed-origin.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
 import { hasErrnoCode, messageOf } from "./errors.js";
+import { hookSettingsJson } from "./session/hook-settings.js";
+import { mcpConfigJson } from "./session/mcp-config.js";
 import { createClaudeSpawner } from "./session/spawn-claude.js";
 import { createCodexSpawner } from "./session/spawn-codex.js";
 import { createShellSpawners } from "./session/spawn-shell.js";
@@ -133,20 +136,6 @@ initWorkspaceSetup({ workspace: CLAUDE_CWD });
 // launched terminal can run `/mulmoterminal-config` to author a .mulmoterminal.json.
 // Best-effort + never clobbers a user's own same-named skill (see install-config-skill.ts).
 installConfigSkill();
-
-// Only same-machine browser origins may open the terminal / pub-sub sockets, so
-// a malicious website the user visits can't drive the local Claude PTY (a
-// cross-site WebSocket hijack). A missing Origin (non-browser local client) is
-// allowed; any localhost host on any port is allowed (covers the Vite dev proxy).
-function isAllowedOrigin(origin?: string) {
-  if (!origin) return true;
-  try {
-    const host = new URL(origin).hostname;
-    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
-  } catch {
-    return false;
-  }
-}
 
 // Pub/sub channel the sidebar subscribes to for live session-activity changes.
 const SESSIONS_CHANNEL = "sessions";
@@ -373,60 +362,9 @@ function setWaiting(id: string, waiting: boolean, event?: string) {
   if (waiting) armReapForDetached(id);
 }
 
-// Hook config injected via `claude --settings <json>`. Each event POSTs the full
-// hook payload to /api/hook. UserPromptSubmit => working, Stop => idle,
-// Notification => waiting for input. PreToolUse/PostToolUse/PostToolUseFailure
-// (matcher "" => every tool, including built-ins and MCP tools) feed the
-// per-session tool-call history that the GUI's tools pane shows. A failed tool
-// fires PostToolUseFailure (NOT PostToolUse), so we register both to complete the
-// entry either way — otherwise a failed call would stay stuck on "running".
-function hookSettingsJson(host: string, sessionId: string, env: Record<string, string> = {}) {
-  // Tag every hook with mulmoterminal's STABLE session id via a header. Claude reissues its own session_id
-  // on /clear and /compact, but the PTY — and the id the client tracks — stays this one, so attributing
-  // hooks by this header keeps activity / header prompt / tool history correlated across a clear.
-  const cmd = `curl -s -X POST http://${host}:${PORT}/api/hook ` + `-H 'content-type: application/json' -H 'x-mt-session: ${sessionId}' -d @- >/dev/null 2>&1`;
-  const entry = [{ hooks: [{ type: "command", command: cmd }] }];
-  // Tool hooks take a matcher; "" matches all tools.
-  const toolEntry = [{ matcher: "", hooks: [{ type: "command", command: cmd }] }];
-  // `env` aims a provider session at its backend (#579). Claude Code applies this block
-  // itself, so it lands identically on the host, under tmux — where a pane inherits the
-  // tmux SERVER's environment, not ours — and in a container.
-  return JSON.stringify({
-    ...(Object.keys(env).length ? { env } : {}),
-    hooks: {
-      UserPromptSubmit: entry,
-      Stop: entry,
-      Notification: entry,
-      // SessionStart fires with source "clear" on /clear — we use it to reset the header prompt.
-      SessionStart: entry,
-      PreToolUse: toolEntry,
-      PostToolUse: toolEntry,
-      PostToolUseFailure: toolEntry,
-    },
-  });
-}
-
-// MCP config injected via `claude --mcp-config <json>`. Points claude at the
-// in-process GUI MCP server served over Streamable HTTP. The session id rides in
-// the URL path (the MCP server is otherwise stateless), so no env or subprocess is
-// needed — the agent just makes an HTTP call back to this server. Using
-// 127.0.0.1 (not localhost) avoids an IPv6/IPv4 resolution mismatch against the
-// server's listen address.
-function mcpConfigJson(sessionId: string, host: string = "127.0.0.1", sandbox: boolean = false) {
-  const mcpServers: Record<string, { type: string; url: string }> = {};
-  // User-added HTTP MCP servers (Settings). In the sandbox their loopback host is
-  // rewritten so the container can reach a server running on the host. Added FIRST so
-  // the built-in GUI entry below always wins (sanitizeUserMcpServers already reserves
-  // its id, this is defense in depth).
-  for (const s of getUserMcpServers()) {
-    mcpServers[s.id] = { type: "http", url: sandbox ? rewriteLoopbackForDocker(s.url) : s.url };
-  }
-  mcpServers["mulmoterminal-gui"] = { type: "http", url: `http://${host}:${PORT}/api/mcp/${sessionId}` };
-  return JSON.stringify({ mcpServers });
-}
-
 // The PTY spawners (session/spawn-*.ts). They take what index.ts still owns — the session
-// lifecycle it drives and the config it builds the hook/MCP json from — as deps.
+// lifecycle it drives, and this file's port and live user config bound into the two payload
+// builders (session/hook-settings.ts, session/mcp-config.ts) — as deps.
 const spawnDeps: SpawnDeps = {
   claudeBin: CLAUDE_BIN,
   codexBin: CODEX_BIN,
@@ -434,8 +372,9 @@ const spawnDeps: SpawnDeps = {
   permissionMode: CLAUDE_PERMISSION_MODE,
   guiMcpTools: GUI_MCP_TOOLS,
   outputBufferLimit: OUTPUT_BUFFER_LIMIT,
-  hookSettingsJson,
-  mcpConfigJson,
+  hookSettingsJson: (host, sessionId, env) => hookSettingsJson({ host, port: PORT, sessionId, env }),
+  // The user's MCP servers are read per spawn, so a settings edit applies to the next session.
+  mcpConfigJson: (sessionId, host, sandbox) => mcpConfigJson({ sessionId, host, port: PORT, userMcpServers: getUserMcpServers(), sandbox }),
   reap: (id) => reap(id),
   setWorking: (id, working, event) => setWorking(id, working, event),
   setWaiting: (id, waiting, event) => setWaiting(id, waiting, event),

--- a/server/infra/allowed-origin.ts
+++ b/server/infra/allowed-origin.ts
@@ -1,0 +1,24 @@
+// Which browser origins may open this server's sockets and reach its privileged routes.
+//
+// Only same-machine browser origins, so a malicious website the user happens to visit can't
+// drive the local Claude PTY (a cross-site WebSocket hijack). A MISSING Origin is allowed —
+// that is a non-browser local client, which cannot be a cross-site request. Any localhost
+// host on any port is allowed, which is what covers the Vite dev proxy.
+//
+// Out of index.ts because every route module and the pub/sub socket take this as a
+// dependency and every one of their tests passes a stub, so the real predicate — the single
+// thing standing between a visited page and the user's terminal — was the one piece nothing
+// exercised (#548).
+//
+// `hostname` is what `new URL()` normalises to, so an IPv6 literal arrives bracketed
+// (`[::1]`) however it was written, and a host is already lower-cased and punycoded.
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+export function isAllowedOrigin(origin?: string): boolean {
+  if (!origin) return true;
+  try {
+    return LOOPBACK_HOSTNAMES.has(new URL(origin).hostname);
+  } catch {
+    return false;
+  }
+}

--- a/server/session/hook-settings.ts
+++ b/server/session/hook-settings.ts
@@ -1,0 +1,57 @@
+// The `claude --settings` payload every spawned session carries.
+//
+// Each hook event POSTs the full payload to /api/hook: UserPromptSubmit => working,
+// Stop => idle, Notification => waiting for input. PreToolUse / PostToolUse /
+// PostToolUseFailure (matcher "" => every tool, including built-ins and MCP tools) feed the
+// per-session tool-call history the GUI's tools pane shows. A failed tool fires
+// PostToolUseFailure and NOT PostToolUse, so both are registered — otherwise a failed call
+// would stay stuck on "running".
+//
+// Pure, with the port passed in: index.ts built this against a module-level PORT, which left
+// the shape of the settings — including the env block that carries a provider's token —
+// reachable only by booting the server (#548).
+
+export interface HookSettingsInput {
+  // Where the session should reach this server. Differs per spawn: a container cannot use
+  // loopback, so the sandbox passes its own gateway host.
+  host: string;
+  port: string | number;
+  sessionId: string;
+  // Aims a provider session at its backend (#579). Claude Code applies this block itself, so
+  // it lands identically on the host, under tmux — where a pane inherits the tmux SERVER's
+  // environment, not ours — and inside a container. Omitted entirely when empty, so a
+  // non-provider session's settings stay free of anything secret.
+  env?: Record<string, string>;
+}
+
+// Tag every hook with mulmoterminal's STABLE session id via a header. Claude reissues its own
+// session_id on /clear and /compact, but the PTY — and the id the client tracks — stays this
+// one, so attributing hooks by this header keeps activity / header prompt / tool history
+// correlated across a clear.
+//
+// The id is interpolated into a shell command inside single quotes. Every caller takes its id
+// from randomUUID() or a SESSION_ID_RE match, so a quote cannot reach here; the assertion is
+// in the tests rather than a runtime check, because a session id that got this far malformed
+// is a bug upstream and not something to paper over.
+const hookCommand = (host: string, port: string | number, sessionId: string): string =>
+  `curl -s -X POST http://${host}:${port}/api/hook ` + `-H 'content-type: application/json' -H 'x-mt-session: ${sessionId}' -d @- >/dev/null 2>&1`;
+
+export function hookSettingsJson({ host, port, sessionId, env = {} }: HookSettingsInput): string {
+  const cmd = hookCommand(host, port, sessionId);
+  const entry = [{ hooks: [{ type: "command", command: cmd }] }];
+  // Tool hooks take a matcher; "" matches all tools.
+  const toolEntry = [{ matcher: "", hooks: [{ type: "command", command: cmd }] }];
+  return JSON.stringify({
+    ...(Object.keys(env).length ? { env } : {}),
+    hooks: {
+      UserPromptSubmit: entry,
+      Stop: entry,
+      Notification: entry,
+      // SessionStart fires with source "clear" on /clear — used to reset the header prompt.
+      SessionStart: entry,
+      PreToolUse: toolEntry,
+      PostToolUse: toolEntry,
+      PostToolUseFailure: toolEntry,
+    },
+  });
+}

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -1,0 +1,36 @@
+// The `claude --mcp-config` payload every spawned session carries.
+//
+// Points claude at the in-process GUI MCP server served over Streamable HTTP. The session id
+// rides in the URL path (the MCP server is otherwise stateless), so no env var and no
+// subprocess are needed — the agent just calls back into this server.
+//
+// Pure, with the port and the user's servers passed in: index.ts read both from module state,
+// so the precedence rule below could not be tested without booting the server (#548).
+import { rewriteLoopbackForDocker } from "../infra/sandbox.js";
+import type { UserMcpServer } from "../config/config-schema.js";
+
+export interface McpConfigInput {
+  sessionId: string;
+  // 127.0.0.1 rather than localhost avoids an IPv6/IPv4 resolution mismatch against the
+  // server's listen address.
+  host?: string;
+  port: string | number;
+  // The user's own HTTP MCP servers (Settings).
+  userMcpServers: readonly UserMcpServer[];
+  // Inside a container the user's loopback URLs have to be rewritten to reach the host.
+  sandbox?: boolean;
+}
+
+const DEFAULT_HOST = "127.0.0.1";
+const GUI_SERVER_ID = "mulmoterminal-gui";
+
+export function mcpConfigJson({ sessionId, host = DEFAULT_HOST, port, userMcpServers, sandbox = false }: McpConfigInput): string {
+  const mcpServers: Record<string, { type: string; url: string }> = {};
+  // The user's servers go in FIRST so the built-in GUI entry below always wins on a clashing
+  // id. sanitizeUserMcpServers already reserves that id; this is defense in depth.
+  for (const server of userMcpServers) {
+    mcpServers[server.id] = { type: "http", url: sandbox ? rewriteLoopbackForDocker(server.url) : server.url };
+  }
+  mcpServers[GUI_SERVER_ID] = { type: "http", url: `http://${host}:${port}/api/mcp/${sessionId}` };
+  return JSON.stringify({ mcpServers });
+}

--- a/test/server/infra/allowed-origin.spec.ts
+++ b/test/server/infra/allowed-origin.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+
+import { isAllowedOrigin } from "../../../server/infra/allowed-origin.js";
+
+// The predicate every route module and the pub/sub socket is handed, and which all of their
+// tests stub out — so until now the real one was never run. It is the only thing standing
+// between a page the user happens to visit and their local Claude PTY, so the cases that
+// matter are the ones where a hostile origin tries to look local.
+describe("isAllowedOrigin", () => {
+  describe("same-machine origins are allowed", () => {
+    it.each(["http://localhost:34567", "http://localhost", "https://localhost:5173", "http://127.0.0.1:34567", "http://127.0.0.1"])("allows %s", (origin) => {
+      expect(isAllowedOrigin(origin)).toBe(true);
+    });
+
+    // Any port: the Vite dev server proxies from its own.
+    it("allows localhost on a port nobody configured", () => {
+      expect(isAllowedOrigin("http://localhost:61234")).toBe(true);
+    });
+
+    it("allows the bracketed IPv6 loopback", () => {
+      expect(isAllowedOrigin("http://[::1]:34567")).toBe(true);
+    });
+
+    // `new URL` normalises the long form, so the check never sees the expanded spelling.
+    it("allows the expanded IPv6 loopback, which normalises to [::1]", () => {
+      expect(isAllowedOrigin("http://[0:0:0:0:0:0:0:1]:34567")).toBe(true);
+    });
+
+    it("allows an upper-cased origin, which normalises to lower case", () => {
+      expect(isAllowedOrigin("HTTP://LOCALHOST:34567")).toBe(true);
+    });
+
+    // The accepted set reaches further than its four literals suggest: `new URL` expands
+    // every shorthand and alternate base for an IPv4 address before the check sees it. Each
+    // of these IS 127.0.0.1, so allowing them is right — worth pinning so the normalisation
+    // is a decision on the record rather than a surprise found later.
+    it.each(["http://127.1", "http://127.0.1", "http://2130706433", "http://0x7f.0.0.1"])("allows %s, which normalises to 127.0.0.1", (origin) => {
+      expect(isAllowedOrigin(origin)).toBe(true);
+      expect(new URL(origin).hostname).toBe("127.0.0.1");
+    });
+  });
+
+  // A non-browser local client (curl, the CLI, a native app) sends no Origin at all, and it
+  // cannot be a cross-site request. Anything a BROWSER sends has one.
+  describe("a missing origin is allowed", () => {
+    it("allows undefined", () => {
+      expect(isAllowedOrigin(undefined)).toBe(true);
+    });
+
+    it("allows a call with no argument", () => {
+      expect(isAllowedOrigin()).toBe(true);
+    });
+
+    it("allows the empty string, which is what an absent header reads as", () => {
+      expect(isAllowedOrigin("")).toBe(true);
+    });
+  });
+
+  // The scheme is never consulted, so these carry the https a real page would be served
+  // over — the hostname is the whole decision.
+  describe("a remote origin is refused", () => {
+    it.each(["https://evil.com", "https://evil.com:34567", "https://claude.ai", "https://192.168.1.10:34567", "https://10.0.0.5"])("refuses %s", (origin) => {
+      expect(isAllowedOrigin(origin)).toBe(false);
+    });
+  });
+
+  // The whole point of parsing rather than string-matching. Each of these contains the text
+  // "localhost" or "127.0.0.1" somewhere a substring check would accept.
+  describe("hosts that merely look local are refused", () => {
+    it("refuses a subdomain of an attacker's domain", () => {
+      expect(isAllowedOrigin("https://localhost.evil.com")).toBe(false);
+    });
+
+    it("refuses an attacker's domain prefixed with the loopback address", () => {
+      expect(isAllowedOrigin("https://127.0.0.1.evil.com")).toBe(false);
+    });
+
+    it("refuses a host that merely ends in localhost", () => {
+      expect(isAllowedOrigin("https://notlocalhost")).toBe(false);
+    });
+
+    // The userinfo trick: everything before @ is credentials, and the real host is evil.com.
+    it("refuses an origin where localhost is only the userinfo", () => {
+      expect(isAllowedOrigin("https://localhost@evil.com")).toBe(false);
+    });
+
+    it("refuses an origin where the loopback address is only the userinfo", () => {
+      expect(isAllowedOrigin("https://127.0.0.1@evil.com")).toBe(false);
+    });
+  });
+
+  describe("anything unparseable is refused", () => {
+    // What a file:// page and a sandboxed iframe send. It must not be read as "no origin".
+    it("refuses the literal string null", () => {
+      expect(isAllowedOrigin("null")).toBe(false);
+    });
+
+    it.each(["not a url", "//localhost", "localhost:34567", "http://", " "])("refuses %o", (origin) => {
+      expect(isAllowedOrigin(origin)).toBe(false);
+    });
+
+    // A scheme with no host at all parses, but its hostname is empty.
+    it("refuses a file URL", () => {
+      expect(isAllowedOrigin("file:///Users/me/page.html")).toBe(false);
+    });
+  });
+
+  // Deliberately narrower than 127.0.0.0/8 and than the IPv6-mapped forms: only the one
+  // address, however it is spelled. Nothing a browser sends for a page this server served
+  // uses the rest, and widening the set should have to be argued for rather than inherited.
+  describe("loopback addresses other than 127.0.0.1 are refused", () => {
+    it.each(["https://127.0.0.2", "https://127.0.0.53", "https://[::ffff:127.0.0.1]", "https://0.0.0.0"])("refuses %s", (origin) => {
+      expect(isAllowedOrigin(origin)).toBe(false);
+    });
+  });
+});

--- a/test/server/session/hook-settings.spec.ts
+++ b/test/server/session/hook-settings.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+
+import { hookSettingsJson } from "../../../server/session/hook-settings.js";
+import { SESSION_ID_RE } from "../../../server/config/env.js";
+
+const SESSION = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+const settings = (over: Partial<Parameters<typeof hookSettingsJson>[0]> = {}) =>
+  JSON.parse(hookSettingsJson({ host: "localhost", port: 34567, sessionId: SESSION, ...over }));
+
+const HOOK_EVENTS = ["UserPromptSubmit", "Stop", "Notification", "SessionStart"] as const;
+const TOOL_EVENTS = ["PreToolUse", "PostToolUse", "PostToolUseFailure"] as const;
+
+const commandOf = (entry: { hooks: { command: string }[] }): string => entry.hooks[0].command;
+
+describe("hookSettingsJson", () => {
+  it("registers every event the session's bookkeeping depends on", () => {
+    expect(Object.keys(settings().hooks)).toEqual([...HOOK_EVENTS, ...TOOL_EVENTS]);
+  });
+
+  it("points every hook at this server's /api/hook", () => {
+    const { hooks } = settings({ host: "127.0.0.1", port: 5555 });
+    const commands = [...HOOK_EVENTS, ...TOOL_EVENTS].map((event) => commandOf(hooks[event][0]));
+    commands.forEach((command) => expect(command).toContain("http://127.0.0.1:5555/api/hook"));
+  });
+
+  it("takes the port as given, whether a number or a string", () => {
+    expect(commandOf(settings({ port: "8080" }).hooks.Stop[0])).toContain(":8080/api/hook");
+    expect(commandOf(settings({ port: 8080 }).hooks.Stop[0])).toContain(":8080/api/hook");
+  });
+
+  // The PTY's id, not claude's — claude reissues its own on /clear and /compact, and the
+  // header is what keeps activity, header prompt and tool history correlated across one.
+  it("tags every hook with the stable session id", () => {
+    const { hooks } = settings();
+    [...HOOK_EVENTS, ...TOOL_EVENTS].forEach((event) => expect(commandOf(hooks[event][0])).toContain(`x-mt-session: ${SESSION}`));
+  });
+
+  it("gives tool hooks the matcher that matches every tool", () => {
+    TOOL_EVENTS.forEach((event) => expect(settings().hooks[event][0].matcher).toBe(""));
+  });
+
+  it("gives lifecycle hooks no matcher", () => {
+    HOOK_EVENTS.forEach((event) => expect(settings().hooks[event][0]).not.toHaveProperty("matcher"));
+  });
+
+  // A failed tool fires PostToolUseFailure and NOT PostToolUse. Registering only the latter
+  // leaves the failed call stuck on "running" in the tools pane forever.
+  it("registers the failure event alongside the success one, so a failed call still completes", () => {
+    const { hooks } = settings();
+    expect(commandOf(hooks.PostToolUseFailure[0])).toBe(commandOf(hooks.PostToolUse[0]));
+  });
+
+  describe("the env block", () => {
+    // It is the one part of these settings that can hold a provider's API token, and its
+    // presence is what makes the caller write the settings to a 0600 file instead of argv.
+    it("is absent entirely when there is nothing to set", () => {
+      expect(settings()).not.toHaveProperty("env");
+      expect(settings({ env: {} })).not.toHaveProperty("env");
+    });
+
+    it("carries the provider environment when there is one", () => {
+      const env = { ANTHROPIC_BASE_URL: "https://openrouter.ai/api", ANTHROPIC_AUTH_TOKEN: "sk-or-secret" };
+      expect(settings({ env }).env).toEqual(env);
+    });
+
+    it("keeps the hooks intact when an env block is present", () => {
+      const withEnv = settings({ env: { ANTHROPIC_MODEL: "moonshotai/kimi-k2.7-code" } });
+      expect(Object.keys(withEnv.hooks)).toEqual([...HOOK_EVENTS, ...TOOL_EVENTS]);
+    });
+  });
+
+  it("produces parseable JSON", () => {
+    expect(() => JSON.parse(hookSettingsJson({ host: "localhost", port: 34567, sessionId: SESSION }))).not.toThrow();
+  });
+
+  // The id is interpolated into a shell command inside single quotes, so the safety of that
+  // interpolation rests entirely on the id's shape being guaranteed upstream. Every caller
+  // takes its id from randomUUID() or a SESSION_ID_RE match — pinned here so a later
+  // loosening of that pattern fails a test instead of opening a hook-command injection.
+  describe("the id shape the single-quoted interpolation relies on", () => {
+    it("lands the id inside the quoted header", () => {
+      expect(commandOf(settings().hooks.Stop[0])).toContain(`-H 'x-mt-session: ${SESSION}' `);
+    });
+
+    it.each(["'; touch /tmp/pwned; '", "a'b", `"; id; "`, "../../etc/passwd", ""])("rejects %o upstream, so it can never be interpolated", (id) => {
+      expect(SESSION_ID_RE.test(id)).toBe(false);
+    });
+
+    it("accepts the uuid shape the spawners generate", () => {
+      expect(SESSION_ID_RE.test(SESSION)).toBe(true);
+    });
+  });
+});

--- a/test/server/session/mcp-config.spec.ts
+++ b/test/server/session/mcp-config.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+
+import { mcpConfigJson } from "../../../server/session/mcp-config.js";
+import { SANDBOX_HOST } from "../../../server/infra/sandbox.js";
+
+const SESSION = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+const GUI = "mulmoterminal-gui";
+
+const config = (over: Partial<Parameters<typeof mcpConfigJson>[0]> = {}) =>
+  JSON.parse(mcpConfigJson({ sessionId: SESSION, port: 34567, userMcpServers: [], ...over })).mcpServers as Record<string, { type: string; url: string }>;
+
+describe("mcpConfigJson", () => {
+  it("points the session at this server's own GUI MCP endpoint", () => {
+    expect(config()[GUI]).toEqual({ type: "http", url: `http://127.0.0.1:34567/api/mcp/${SESSION}` });
+  });
+
+  // Not "localhost": that can resolve to ::1 while the server listens on 127.0.0.1.
+  it("defaults to the numeric loopback host", () => {
+    expect(config()[GUI].url).toContain("http://127.0.0.1:");
+  });
+
+  it("uses the host it is given, which is how a container reaches the host machine", () => {
+    expect(config({ host: SANDBOX_HOST })[GUI].url).toBe(`http://${SANDBOX_HOST}:34567/api/mcp/${SESSION}`);
+  });
+
+  it("takes the port as given, whether a number or a string", () => {
+    expect(config({ port: "8080" })[GUI].url).toContain(":8080/");
+  });
+
+  describe("with no user servers", () => {
+    it("offers the GUI server alone", () => {
+      expect(Object.keys(config())).toEqual([GUI]);
+    });
+  });
+
+  describe("with user servers", () => {
+    const userMcpServers = [
+      { id: "notes", url: "https://notes.example.com/mcp" },
+      { id: "local-tool", url: "http://localhost:7000/mcp" },
+    ];
+
+    it("offers each one over http alongside the GUI server", () => {
+      const servers = config({ userMcpServers });
+      expect(servers.notes).toEqual({ type: "http", url: "https://notes.example.com/mcp" });
+      expect(servers["local-tool"]).toEqual({ type: "http", url: "http://localhost:7000/mcp" });
+      expect(servers[GUI]).toBeDefined();
+    });
+
+    // sanitizeUserMcpServers already reserves the id; this is the defense in depth behind it,
+    // and the reason the user's entries are written first.
+    it("lets the built-in GUI entry win when a user server claims its id", () => {
+      const servers = config({ userMcpServers: [{ id: GUI, url: "http://evil.example.com/mcp" }] });
+      expect(servers[GUI].url).toBe(`http://127.0.0.1:34567/api/mcp/${SESSION}`);
+      expect(Object.keys(servers)).toEqual([GUI]);
+    });
+  });
+
+  describe("in the sandbox", () => {
+    it("rewrites a user server's loopback host so the container can reach it", () => {
+      const servers = config({ sandbox: true, userMcpServers: [{ id: "local-tool", url: "http://localhost:7000/mcp" }] });
+      expect(servers["local-tool"].url).toBe(`http://${SANDBOX_HOST}:7000/mcp`);
+    });
+
+    it("rewrites the numeric loopback too", () => {
+      const servers = config({ sandbox: true, userMcpServers: [{ id: "local-tool", url: "http://127.0.0.1:7000/mcp" }] });
+      expect(servers["local-tool"].url).toBe(`http://${SANDBOX_HOST}:7000/mcp`);
+    });
+
+    it("leaves a remote user server alone", () => {
+      const servers = config({ sandbox: true, userMcpServers: [{ id: "notes", url: "https://notes.example.com/mcp" }] });
+      expect(servers.notes.url).toBe("https://notes.example.com/mcp");
+    });
+
+    // The GUI entry is built from the host parameter, never rewritten — the caller is the one
+    // that knows to pass the gateway host for a sandboxed spawn.
+    it("does not rewrite the GUI entry, which is built from the host it was given", () => {
+      expect(config({ sandbox: true })[GUI].url).toBe(`http://127.0.0.1:34567/api/mcp/${SESSION}`);
+    });
+
+    it("leaves user servers alone when not sandboxed", () => {
+      const servers = config({ sandbox: false, userMcpServers: [{ id: "local-tool", url: "http://localhost:7000/mcp" }] });
+      expect(servers["local-tool"].url).toBe("http://localhost:7000/mcp");
+    });
+  });
+
+  it("produces parseable JSON", () => {
+    expect(() => JSON.parse(mcpConfigJson({ sessionId: SESSION, port: 34567, userMcpServers: [] }))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

`server/index.ts` に残っていた**「あちこちに注入されるのに、どのテストでも実行されていない」3 つ**を pure モジュールへ切り出し、テストを付けました。挙動は不変です。

| 切り出し先 | 中身 | 注入先 |
|---|---|---|
| `server/infra/allowed-origin.ts` | `isAllowedOrigin` — 依存なしの純粋関数 | ルートモジュール 9 本 + pub/sub WebSocket の計 10 か所 |
| `server/session/hook-settings.ts` | `hookSettingsJson` — PORT を引数化 | 全 Claude spawn |
| `server/session/mcp-config.ts` | `mcpConfigJson` — PORT と MCP サーバ一覧を引数化 | 全 Claude spawn |

`index.ts` は **1036 → 975 行**。`SpawnDeps` のシグネチャは変えず、呼び出し側で `PORT` を束ねています。MCP サーバ一覧は従来どおり spawn ごとに読むので、設定変更が次のセッションに効く挙動も維持。

**テスト 68 件追加**（170 files / 2137 tests）。

## Items to Confirm / Review

1. **`isAllowedOrigin` は 10 か所に注入される唯一の CSWSH 防御なのに、既存のルート spec が全て `isAllowedOrigin: () => true/false` のスタブを渡しており、本物の実装を実行するテストが 1 件も存在しませんでした。** これが今回の主目的です
2. **許可範囲がリテラル 4 つより広い**ことが判明（下記）。挙動は正しいと判断して**変更せずテストで固定**しましたが、意図どおりか確認してください
3. hook コマンドのセッション id 補間について、上流の `SESSION_ID_RE` を前提とする形をテストで固定しました。ランタイムチェックを足していない判断の妥当性
4. `mcpConfigJson` が `infra/sandbox.js` の `rewriteLoopbackForDocker` を import します（sandbox.ts に import 時副作用がないことは確認済み・既存の sandbox.spec.ts が import できている）

## テストが実際に効くことの確認

3 つとも壊して該当テストだけが赤くなることを確認しました。

| 壊し方 | 落ちるテスト |
|---|---|
| origin 判定を substring 一致（この種の関数で最も典型的な誤実装）に | **8 件**。`localhost@evil.com`（userinfo トリック）、`localhost.evil.com`（サブドメイン）、`127.0.0.1.evil.com`、正規化系 |
| env ブロックを常に出力するように | 「空なら env キー自体を出さない」1 件 |
| GUI の MCP エントリをユーザーサーバより**先**に書くように | 「id 衝突時に組み込みが勝つ」1 件 |

## 記録した既存挙動（変更していません）

**1. 許可される origin はリテラル 4 つより広い**

`new URL()` が IPv4 の短縮形・別基数を正規化するため、`http://127.1` `http://127.0.1` `http://2130706433` `http://0x7f.0.0.1` はすべて `127.0.0.1` になり許可されます。**いずれも本物のループバックなので挙動としては正しい**と判断しました。ただし「4 つのリテラルだけ許可」という見た目と実際の範囲が違うので、テストで明示しています。

逆に `127.0.0.2` や `[::ffff:127.0.0.1]`、`0.0.0.0` は拒否されます（RFC 上はループバックでも受け付けない、より厳しい側）。ここも固定しました。

**2. hook コマンドのシングルクォート補間**

`-H 'x-mt-session: ${sessionId}'` はシェルコマンド文字列に id をシングルクォート内で埋め込みます。安全なのは**全呼び出し元が `randomUUID()` か `SESSION_ID_RE` 一致の id しか渡さないから**であって、この関数自身は防御していません。呼び出し元は全て確認済み（`index.ts` の 4 か所は `randomUUID()`、外部入力経路は `ws-routes.ts` / `session-routes.ts` などで `SESSION_ID_RE` 検証）。

ランタイムチェックを足すのではなく、`SESSION_ID_RE` がクォートを含む id を弾くことをテストで固定しました。パターンが緩められたら CI が落ちます。ここまで壊れた id が到達している時点で上流のバグであり、この層で握り潰すべきではないという判断です。

## User Prompt

> 548ってまだできる？できるだけpure関数にしてテストは増やしてほしい。バグがあるかもしれないので。

## 検証

`yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` / `yarn test`（170 files, 2137 tests）/ `yarn knip` すべて通過。

## #548 の残り

このあと index.ts に残るのは、直書きルート 5 本（`/api/plugin/*` 3 本・`/api/translation/submit`・`/api/mcp/:sessionId` = issue の **Step 2c**）、remoteHost 配線、scheduled chat、reap/publish の I/O 部分、起動処理です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
