### PR TITLE
refactor: make the endpoint and reconnect decisions testable (#598 A1/A4)

### DIFF
--- a/src/components/wsUrl.ts
+++ b/src/components/wsUrl.ts
@@ -1,6 +1,7 @@
 // Pure builder for the terminal WebSocket URL. Kept separate from Terminal.vue so
 // the query it sends — including ?gui=0, which tells the server to run a plain dev
 // terminal (no GUI MCP) — is unit-testable without xterm/WebSocket.
+import type { RunCommand } from "./runCommand";
 
 // What the launch form picked for THIS session (#584), overriding the directory's own
 // default. Either half may be absent: a bare model is a valid pick on the default
@@ -99,4 +100,45 @@ export interface CodexWsUrlInput {
 // to codex's own rollout id. ?gui=0 (grid) runs codex without the GUI MCP.
 export function buildCodexWsUrl(input: CodexWsUrlInput): string {
   return sessionTerminalWsUrl("ws/codex", input);
+}
+
+// What a connection slot is pointed at, as far as choosing an endpoint is concerned. Named
+// separately from the connection manager's own `ConnTarget` so this module stays free of it
+// — TypeScript is structural, so a `ConnTarget` satisfies this.
+export interface ConnTargetUrlInput {
+  cwd: string | null;
+  devTerminal: boolean;
+  // An ephemeral Run cell: the browser sends a REFERENCE (script index / button id), never a command.
+  command: RunCommand | null;
+  // A configured launcher by index, or the OS default shell.
+  launcher: { index: number } | { shell: true } | null;
+  codex?: boolean;
+  launch?: LaunchChoice | null;
+}
+
+// A command cell's endpoint: a script.json entry by index, or a header shell button by id
+// (+ the session context to re-resolve it server-side).
+function runCommandWsUrl(command: RunCommand, host: string, secure: boolean): string {
+  return command.source === "button"
+    ? buildRunWsUrl({ host, secure, cwd: command.cwd, buttonId: command.buttonId, session: command.session, agent: command.agent, model: command.model })
+    : buildRunWsUrl({ host, secure, cwd: command.cwd, index: command.index });
+}
+
+// Which endpoint a slot connects to. The order is the rule: a Run command is ephemeral and
+// outranks everything; then a configured launcher; then codex; then a Claude session, the
+// default. Getting it wrong is silent and destructive-adjacent — a restored codex cell that
+// falls through to `/ws` comes back as Claude, and a command cell that does re-runs its
+// script as an agent session.
+//
+// `host`/`secure` are parameters rather than reads of `location`, which is what lets this be
+// exercised at all.
+export function connWsUrl(target: ConnTargetUrlInput, resumeId: string | null, host: string, secure: boolean): string {
+  if (target.command) return runCommandWsUrl(target.command, host, secure);
+  if (target.launcher) {
+    return "shell" in target.launcher
+      ? buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, shell: true })
+      : buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
+  }
+  if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
+  return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal, launch: target.launch });
 }

--- a/src/composables/reconnectPolicy.ts
+++ b/src/composables/reconnectPolicy.ts
@@ -1,0 +1,32 @@
+// Whether a dropped terminal socket should come back, and how long to wait before trying.
+//
+// Split from the connection manager because both halves are decisions with consequences the
+// manager's own tests can't reach: reconnecting something that should stay down re-runs a
+// command the user watched finish, or has two browser tabs take turns evicting each other
+// forever, while a broken backoff turns one server restart into a reconnect storm.
+
+// 500ms, doubling, capped at 5s. The cap is what keeps a server that is down (rather than
+// restarting) from being hammered.
+const RECONNECT_BASE_MS = 500;
+const RECONNECT_MAX_MS = 5000;
+
+export interface ReconnectFacts {
+  // The slot was torn down deliberately — nothing should bring it back.
+  released: boolean;
+  // The session ended on purpose (an exit frame, or another tab superseded this one).
+  // Reconnecting here is how two tabs end up fighting over one session.
+  sawExit: boolean;
+  // A retry is already armed; a second one would double the rate every drop.
+  reconnectPending: boolean;
+  // A Run cell's process is unique and unresumable — reconnecting would re-run the command.
+  isCommand: boolean;
+}
+
+export function shouldReconnect({ released, sawExit, reconnectPending, isCommand }: ReconnectFacts): boolean {
+  return !released && !sawExit && !reconnectPending && !isCommand;
+}
+
+// Exponential backoff by attempt number (0 = the first retry after a drop).
+export function reconnectDelayMs(attempts: number): number {
+  return Math.min(RECONNECT_BASE_MS * 2 ** attempts, RECONNECT_MAX_MS);
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -21,7 +21,8 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import "@xterm/xterm/css/xterm.css";
-import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl, type LaunchChoice } from "../components/wsUrl";
+import { connWsUrl, type LaunchChoice } from "../components/wsUrl";
+import { reconnectDelayMs, shouldReconnect } from "./reconnectPolicy";
 import type { RunCommand } from "../components/runCommand";
 import { readableSlot, type SlotCandidate, type SlotInfo } from "./readableSlot";
 
@@ -98,9 +99,6 @@ interface Conn {
   reconnectTimer: ReturnType<typeof setTimeout> | null;
   attachedEl: HTMLElement | null;
 }
-
-const RECONNECT_BASE_MS = 500;
-const RECONNECT_MAX_MS = 5000;
 
 // The heavy per-slot runtime (non-reactive — Vue never needs to track these).
 const conns = new Map<string, Conn>();
@@ -220,36 +218,13 @@ function ensure(key: string, target: ConnTarget): Conn {
 }
 
 function scheduleReconnect(c: Conn) {
-  // A command/Run process is unique and unresumable — never reconnect it. A
-  // released or intentionally-ended slot stays down too.
-  if (c.released || c.sawExit || c.reconnectTimer || c.target.command) return;
-  const delay = Math.min(RECONNECT_BASE_MS * 2 ** c.reconnectAttempts, RECONNECT_MAX_MS);
+  if (!shouldReconnect({ released: c.released, sawExit: c.sawExit, reconnectPending: c.reconnectTimer !== null, isCommand: !!c.target.command })) return;
+  const delay = reconnectDelayMs(c.reconnectAttempts);
   c.reconnectAttempts++;
   c.reconnectTimer = setTimeout(() => {
     c.reconnectTimer = null;
     if (!c.released) connect(c);
   }, delay);
-}
-
-// A command cell's endpoint: a script.json entry by index, or a header shell button by id (+ the session
-// context to re-resolve it server-side). Either way the browser sends a reference, never a raw command.
-function runCommandUrl(command: RunCommand, host: string, secure: boolean): string {
-  return command.source === "button"
-    ? buildRunWsUrl({ host, secure, cwd: command.cwd, buttonId: command.buttonId, session: command.session, agent: command.agent, model: command.model })
-    : buildRunWsUrl({ host, secure, cwd: command.cwd, index: command.index });
-}
-
-// Pick the endpoint for a target: a Run command (ephemeral), a launcher (persistent
-// shell/codex), or a Claude session (default). Kept flat to avoid a nested ternary.
-function connUrl(target: ConnTarget, resumeId: string | null, secure: boolean): string {
-  const host = location.host;
-  if (target.command) return runCommandUrl(target.command, host, secure);
-  if (target.launcher)
-    return "shell" in target.launcher
-      ? buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, shell: true })
-      : buildLaunchWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, launcher: target.launcher.index });
-  if (target.codex) return buildCodexWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal });
-  return buildTerminalWsUrl({ host, secure, sessionId: resumeId, cwd: target.cwd, devTerminal: target.devTerminal, launch: target.launch });
 }
 
 function connect(c: Conn) {
@@ -272,7 +247,7 @@ function connect(c: Conn) {
   // same session instead of spawning a fresh one each retry.
   const resumeId = c.knownSessionId ?? c.target.sessionId;
   const secure = location.protocol === "https:";
-  const url = connUrl(c.target, resumeId, secure);
+  const url = connWsUrl(c.target, resumeId, location.host, secure);
   const sock = new WebSocket(url);
   c.ws = sock;
 

--- a/test/src/components/wsUrl.spec.ts
+++ b/test/src/components/wsUrl.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl } from "../../../src/components/wsUrl.js";
+import { buildTerminalWsUrl, buildRunWsUrl, buildLaunchWsUrl, buildCodexWsUrl, connWsUrl, type ConnTargetUrlInput } from "../../../src/components/wsUrl.js";
 
 describe("buildTerminalWsUrl", () => {
   it("single view: session only, no gui=0", () => {
@@ -160,5 +160,71 @@ describe("buildTerminalWsUrl — the launch picker's choice (#584)", () => {
   it("keeps carrying session, cwd and gui alongside it", () => {
     const q = new URL(buildTerminalWsUrl({ host: "h", secure: false, sessionId: "abc", cwd: "/w", devTerminal: true, launch: { model: "m" } })).searchParams;
     expect([q.get("session"), q.get("cwd"), q.get("gui"), q.get("model")]).toEqual(["abc", "/w", "0", "m"]);
+  });
+});
+
+// Which endpoint a slot connects to. The precedence is the rule, and every way of getting it
+// wrong is silent: the cell reconnects, looks alive, and is the wrong thing.
+describe("connWsUrl — endpoint precedence", () => {
+  const HOST = "localhost:3456";
+  const target = (over: Partial<ConnTargetUrlInput> = {}): ConnTargetUrlInput => ({
+    cwd: "/work/proj",
+    devTerminal: false,
+    command: null,
+    launcher: null,
+    ...over,
+  });
+  const pathOf = (url: string) => new URL(url).pathname;
+
+  it("defaults to the Claude session endpoint", () => {
+    expect(pathOf(connWsUrl(target(), "abc", HOST, false))).toBe("/ws");
+  });
+
+  it("sends a codex slot to the codex endpoint, not the Claude one", () => {
+    expect(pathOf(connWsUrl(target({ codex: true }), "abc", HOST, false))).toBe("/ws/codex");
+  });
+
+  it("sends a launcher slot to the launch endpoint", () => {
+    expect(pathOf(connWsUrl(target({ launcher: { index: 2 } }), "abc", HOST, false))).toBe("/ws/launch");
+  });
+
+  it("sends a command slot to the run endpoint", () => {
+    const url = connWsUrl(target({ command: { source: "script", index: 3, label: "build", cwd: "/work/proj" } }), null, HOST, false);
+    expect(pathOf(url)).toBe("/ws/run");
+    expect(new URL(url).searchParams.get("index")).toBe("3");
+  });
+
+  // The order matters, not just the mapping: a command slot that also carries a launcher or
+  // codex flag is still a one-off Run, and reconnecting it as a session would re-run it.
+  it("lets a command outrank a launcher and codex", () => {
+    const command = { source: "script", index: 0, label: "x", cwd: null } as const;
+    expect(pathOf(connWsUrl(target({ command, launcher: { shell: true }, codex: true }), "abc", HOST, false))).toBe("/ws/run");
+  });
+
+  it("lets a launcher outrank codex", () => {
+    expect(pathOf(connWsUrl(target({ launcher: { shell: true }, codex: true }), "abc", HOST, false))).toBe("/ws/launch");
+  });
+
+  it("distinguishes the OS shell launcher from a configured one", () => {
+    const shell = new URL(connWsUrl(target({ launcher: { shell: true } }), "abc", HOST, false)).searchParams;
+    const indexed = new URL(connWsUrl(target({ launcher: { index: 4 } }), "abc", HOST, false)).searchParams;
+    expect([shell.get("shell"), shell.get("launcher")]).toEqual(["1", null]);
+    expect([indexed.get("shell"), indexed.get("launcher")]).toEqual([null, "4"]);
+  });
+
+  it("re-resolves a header button server-side, sending its context rather than a command", () => {
+    const command = { source: "button", buttonId: "diff", label: "Diff", cwd: "/w", session: "s1", agent: "codex", model: "opus" } as const;
+    const q = new URL(connWsUrl(target({ command }), null, HOST, false)).searchParams;
+    expect([q.get("buttonId"), q.get("session"), q.get("agent"), q.get("model")]).toEqual(["diff", "s1", "codex", "opus"]);
+  });
+
+  it("carries the resume id, cwd, dev-terminal flag and launch pick to the session endpoint", () => {
+    const url = connWsUrl(target({ devTerminal: true, launch: { provider: "openrouter", model: "z-ai/glm-5.2" } }), "sess-1", HOST, false);
+    const q = new URL(url).searchParams;
+    expect([q.get("session"), q.get("cwd"), q.get("gui"), q.get("provider")]).toEqual(["sess-1", "/work/proj", "0", "openrouter"]);
+  });
+
+  it("uses wss over https", () => {
+    expect(connWsUrl(target(), null, HOST, true).startsWith("wss://")).toBe(true);
   });
 });

--- a/test/src/composables/reconnectPolicy.spec.ts
+++ b/test/src/composables/reconnectPolicy.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import { reconnectDelayMs, shouldReconnect, type ReconnectFacts } from "../../../src/composables/reconnectPolicy";
+
+// A live Claude/codex session whose socket just dropped for no good reason — the one case
+// that SHOULD come back.
+const DROPPED: ReconnectFacts = { released: false, sawExit: false, reconnectPending: false, isCommand: false };
+
+describe("shouldReconnect", () => {
+  it("reconnects a session socket that simply dropped", () => {
+    expect(shouldReconnect(DROPPED)).toBe(true);
+  });
+
+  // A Run cell's process is unique and unresumable: reconnecting re-runs the command the
+  // user just watched finish, in their repository.
+  it("never reconnects a command cell", () => {
+    expect(shouldReconnect({ ...DROPPED, isCommand: true })).toBe(false);
+  });
+
+  // `sawExit` is also set when another tab supersedes this one. Reconnect here and the two
+  // tabs take turns evicting each other for as long as both stay open.
+  it("does not reconnect after an intentional end", () => {
+    expect(shouldReconnect({ ...DROPPED, sawExit: true })).toBe(false);
+  });
+
+  it("does not reconnect a slot that was released", () => {
+    expect(shouldReconnect({ ...DROPPED, released: true })).toBe(false);
+  });
+
+  // Without this the retry rate doubles on every drop that lands while one is already armed.
+  it("does not arm a second retry while one is pending", () => {
+    expect(shouldReconnect({ ...DROPPED, reconnectPending: true })).toBe(false);
+  });
+
+  it("stays down when several reasons apply at once", () => {
+    expect(shouldReconnect({ released: true, sawExit: true, reconnectPending: true, isCommand: true })).toBe(false);
+  });
+});
+
+describe("reconnectDelayMs", () => {
+  it("starts at half a second and doubles", () => {
+    expect([0, 1, 2, 3].map(reconnectDelayMs)).toEqual([500, 1000, 2000, 4000]);
+  });
+
+  // The cap is what separates "a server restarting" from "a server that is down": without it
+  // the 20th attempt would be measured in days, and without doubling the client would hammer
+  // a dead server twice a second forever.
+  it("caps the wait at five seconds", () => {
+    expect(reconnectDelayMs(4)).toBe(5000);
+    expect(reconnectDelayMs(40)).toBe(5000);
+  });
+
+  it("never returns a negative or zero delay", () => {
+    for (const attempts of [0, 1, 10]) expect(reconnectDelayMs(attempts)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

First of the small PRs from the #598 survey. Two rules out of `useTerminalConnections.ts`, both previously reachable only by constructing a real `WebSocket` and a real xterm `Terminal` — so neither had a single assertion.

| Moved | To | Why it matters if it's wrong |
|---|---|---|
| `connUrl` + `runCommandUrl` → `connWsUrl` | `src/components/wsUrl.ts` (already fully tested, already the delegate) | A codex cell that falls through to `/ws` **reconnects as Claude**; a command cell that does **re-runs its script** as an agent session in the user's repo |
| `scheduleReconnect`'s two decisions → `shouldReconnect` / `reconnectDelayMs` | `src/composables/reconnectPolicy.ts` | Re-running a command the user watched finish; two tabs evicting each other forever; a reconnect storm on server restart |

Behaviour is unchanged — the same builders are called with the same arguments in the same order.

## Items to Confirm / Review

1. **`ConnTargetUrlInput` is a new type in `wsUrl.ts`, not a moved one.** `ConnTarget` stays in the connection manager because `Terminal.vue` refers to it as `conn.ConnTarget`; moving it would have needed a re-export, which this repo's CLAUDE.md rules out. TypeScript is structural, so a `ConnTarget` satisfies the new input type — no cycle, no re-export, no change to `Terminal.vue`.
2. **`host` became a parameter.** `connUrl` read `location.host` directly; that read now happens at the one call site in `connect()`. This is the change that makes the rule reachable from a test.
3. **The precedence tests assert order, not just mapping** — e.g. a slot carrying a command *and* a launcher *and* `codex: true` still goes to `/ws/run`. Those combinations don't occur today, but the ordering is the rule and the tests should fail if someone reorders the branches.

## Verification

- **Mutation-checked**: deleting the codex branch, and dropping the `isCommand` guard, each turn exactly the matching test red. Restored, all pass.
- `172 files / 2175 tests`, lint 0 errors, `typecheck` / `typecheck:server` / `typecheck:test` / `build` clean.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)