### PR TITLE
refactor: make the "would this destroy work?" rule testable (#598 A2)

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -6,6 +6,7 @@ import { useDirConfig } from "../composables/useDirConfig";
 import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
+import { unsavedWork } from "./unsavedWork";
 import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 import GitBranchChip from "./GitBranchChip.vue";
 import ModelContextBadge from "./ModelContextBadge.vue";
@@ -692,15 +693,9 @@ function teardown() {
 const closeConfirm = ref(false);
 const closeChecking = ref(false); // refreshing dirty/ahead — the destructive action is held until it's accurate
 const closeError = ref<string | null>(null);
-const hasUnsaved = computed(() => (diff.value?.dirty ?? 0) > 0 || (diff.value?.ahead ?? 0) > 0);
-const unsavedSummary = computed(() => {
-  const ahead = diff.value?.ahead ?? 0;
-  const dirty = diff.value?.dirty ?? 0;
-  const parts: string[] = [];
-  if (ahead) parts.push(`${ahead} unpushed commit${ahead > 1 ? "s" : ""}`);
-  if (dirty) parts.push(`${dirty} uncommitted change${dirty > 1 ? "s" : ""}`);
-  return parts.join(" + ");
-});
+const unsaved = computed(() => unsavedWork(diff.value));
+const hasUnsaved = computed(() => unsaved.value.has);
+const unsavedSummary = computed(() => unsaved.value.summary);
 
 async function close() {
   if (!isWorktreeCell.value) {

--- a/src/components/unsavedWork.ts
+++ b/src/components/unsavedWork.ts
@@ -1,0 +1,31 @@
+// Whether removing a worktree would throw away work, and how to say so.
+//
+// This is the rule standing between the user and lost work: it decides whether the close
+// dialog shows the amber warning and whether its button reads "Discard & remove" or the
+// reassuring "Remove worktree". Answer `false` when it should be `true` and someone deletes
+// uncommitted changes believing the room was empty — so it is worth being a function with
+// tests rather than two independent `computed`s that could drift apart.
+//
+// Both counts are optional because the diff is null until its fetch lands; absent means
+// "nothing known yet", which reads as nothing to lose — the dialog shows "Checking…" over
+// this until then.
+
+export interface UnsavedWork {
+  // True when the worktree holds work that removing it would destroy.
+  has: boolean;
+  // The warning's subject, e.g. "2 unpushed commits + 5 uncommitted changes". Empty when
+  // there is nothing to lose.
+  summary: string;
+}
+
+const countPhrase = (count: number, noun: string): string => `${count} ${noun}${count > 1 ? "s" : ""}`;
+
+// Unpushed commits first: they are the harder loss to recover from.
+export function unsavedWork(diff: { ahead?: number; dirty?: number } | null | undefined): UnsavedWork {
+  const ahead = diff?.ahead ?? 0;
+  const dirty = diff?.dirty ?? 0;
+  const parts: string[] = [];
+  if (ahead > 0) parts.push(countPhrase(ahead, "unpushed commit"));
+  if (dirty > 0) parts.push(countPhrase(dirty, "uncommitted change"));
+  return { has: parts.length > 0, summary: parts.join(" + ") };
+}

--- a/test/src/components/unsavedWork.spec.ts
+++ b/test/src/components/unsavedWork.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+
+import { unsavedWork } from "../../../src/components/unsavedWork";
+
+describe("unsavedWork", () => {
+  // The reassuring case: nothing to lose, so the dialog's button reads "Remove worktree".
+  it("reports nothing to lose on a clean, pushed worktree", () => {
+    expect(unsavedWork({ ahead: 0, dirty: 0 })).toEqual({ has: false, summary: "" });
+  });
+
+  it("counts uncommitted changes", () => {
+    expect(unsavedWork({ ahead: 0, dirty: 5 })).toEqual({ has: true, summary: "5 uncommitted changes" });
+  });
+
+  it("counts unpushed commits", () => {
+    expect(unsavedWork({ ahead: 3, dirty: 0 })).toEqual({ has: true, summary: "3 unpushed commits" });
+  });
+
+  // Unpushed commits lead: they are the harder loss to recover from.
+  it("names both, commits first", () => {
+    expect(unsavedWork({ ahead: 2, dirty: 4 }).summary).toBe("2 unpushed commits + 4 uncommitted changes");
+  });
+
+  it("says it in the singular for exactly one", () => {
+    expect(unsavedWork({ ahead: 1, dirty: 1 }).summary).toBe("1 unpushed commit + 1 uncommitted change");
+  });
+
+  // A single change is still work. An off-by-one here is the difference between a warning
+  // and a button that says the room is clean.
+  it("warns for a single uncommitted change", () => {
+    expect(unsavedWork({ ahead: 0, dirty: 1 }).has).toBe(true);
+  });
+
+  // The diff is null until its fetch lands, and either count can be absent.
+  it.each([[null], [undefined], [{}], [{ ahead: 0 }], [{ dirty: 0 }]])("treats %j as nothing known yet", (diff) => {
+    expect(unsavedWork(diff)).toEqual({ has: false, summary: "" });
+  });
+
+  // `has` and `summary` used to be two independent computeds; a single source is what keeps
+  // "there is unsaved work" from ever pairing with an empty sentence.
+  it.each([
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [7, 9],
+  ])("keeps the flag and the sentence agreeing (ahead=%i dirty=%i)", (ahead, dirty) => {
+    const { has, summary } = unsavedWork({ ahead, dirty });
+    expect(has).toBe(summary.length > 0);
+  });
+
+  // Guard against a negative count from a miscomputed diff reading as work to lose.
+  it("does not treat a negative count as work", () => {
+    expect(unsavedWork({ ahead: -1, dirty: -2 })).toEqual({ has: false, summary: "" });
+  });
+});


### PR DESCRIPTION
## Summary

Second of the small PRs from #598. `hasUnsaved` / `unsavedSummary` move out of `TerminalCell.vue` into `src/components/unsavedWork.ts`.

This is the rule standing between the user and lost work: it decides whether the worktree close dialog shows the amber warning, and whether its button reads **"Discard & remove"** or the reassuring **"Remove worktree"**. Answer `false` when it should be `true` and someone deletes uncommitted changes believing the room was empty.

It lived as two independent `computed`s over a ref that only `loadDiff()`'s fetch populates, so only the happy path was ever asserted — the zero / one / both-zero permutations were unreachable without more fetch choreography.

## Items to Confirm / Review

1. **One deliberate behaviour change.** A negative count no longer reads as work to lose. The old `if (ahead)` was truthy for `-1` and would have rendered *"-1 unpushed commits"*, while `hasUnsaved` tested `> 0` — the two disagreed. The guard is now `> 0` in both, matching what `hasUnsaved` always meant. If a negative count is genuinely possible and should warn, say so and I'll invert it.
2. **`has` and `summary` now come from one call**, so "there is unsaved work" can no longer pair with an empty sentence. A test pins that agreement across four count combinations.
3. Everything else is byte-for-byte the same wording: commits first, `" + "` join, singular/plural, either half omitted when zero.

## Verification

- **Mutation-checked**: deleting the unpushed-commits half turns 3 tests red.
- `172 files / 2172 tests`, lint 0 errors, typecheck + build clean. The existing `TerminalCell.spec.ts` mount test for this dialog still passes untouched.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)