### PR TITLE
refactor: make the header/title hook decision testable (#598 A3)

### DIFF
--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -6,6 +6,7 @@ import type { Express, Request, Response } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
 import { dirConfigWriteTarget } from "../config/dir-config.js";
 import { activityHookEffects, pushKindFor, resolveHookSessionId } from "../session/activity-hook.js";
+import { headerHookEffect } from "../session/header-hook.js";
 import { lastPrompts, lastResponses, ptys } from "../session/registry.js";
 import { latestUserPrompt } from "../session/session-reads.js";
 import { notifyTaskFinished } from "../session/task-push.js";
@@ -13,7 +14,6 @@ import { preferredHeaderPrompt } from "../session/transcript.js";
 import { failPendingTranslation } from "../session/translation-worker.js";
 
 // The header shows one line, so a longer prompt is stored truncated rather than in full.
-const LAST_PROMPT_CAP = 200;
 
 export interface HookDeps {
   setWorking: (id: string, working: boolean, event?: string) => void;
@@ -115,15 +115,15 @@ function clearHeaderPrompt(deps: HookDeps, sessionId: string): void {
 // doesn't inflate the handler. Runs before handleActivityHook so the activity publish it
 // triggers already carries the new lastPrompt.
 async function applyHeaderHooks(deps: HookDeps, sessionId: string, event: string, body: Record<string, unknown>, cwd: string | undefined): Promise<void> {
-  if (event === "UserPromptSubmit" && typeof body.prompt === "string" && body.prompt.trim()) {
-    const prompt = body.prompt.trim().slice(0, LAST_PROMPT_CAP);
-    await trackPromptForHeader(sessionId, prompt, cwd);
-    deps.noteTitleTurn(sessionId, prompt);
-  } else if (event === "SessionStart" && body.source === "clear") {
-    clearHeaderPrompt(deps, sessionId);
-  } else if (event === "Stop") {
-    void deps.maybeGenerateTitle(sessionId, cwd);
+  const effect = headerHookEffect(event, body);
+  if (!effect) return;
+  if (effect.kind === "prompt") {
+    await trackPromptForHeader(sessionId, effect.text, cwd);
+    deps.noteTitleTurn(sessionId, effect.text);
+    return;
   }
+  if (effect.kind === "clear") return clearHeaderPrompt(deps, sessionId);
+  void deps.maybeGenerateTitle(sessionId, cwd);
 }
 
 // Claude hooks (Stop / Notification / Pre|PostToolUse / SessionStart) POST their payload here so

--- a/server/session/header-hook.ts
+++ b/server/session/header-hook.ts
@@ -1,0 +1,38 @@
+// Pure decision for what a Claude hook does to the cell header and its AI title.
+//
+// The sibling of activityHookEffects, and the reason this exists: that one — which sets the
+// working/waiting flags — is extracted and tested, while this one was left inside the route.
+// So the flags could stay right while the header lied, which is the harder failure to
+// notice: the dot says "working" and the header still shows the task the user abandoned two
+// prompts ago.
+//
+// The caller does the work each effect names (read the transcript, blank the maps, publish,
+// queue a title); this only decides which one, if any.
+
+export type HeaderHookEffect =
+  // Record this as the session's current query. Already trimmed and capped.
+  | { kind: "prompt"; text: string }
+  // `/clear` restarted the conversation — the header must stop showing the pre-clear prompt.
+  | { kind: "clear" }
+  // A turn's reply is on disk; (re)generate the AI title from it.
+  | { kind: "title" };
+
+// A prompt longer than this is a paste, not a headline — the header shows one line.
+export const LAST_PROMPT_CAP = 200;
+
+// Null means "this hook changes nothing about the header", which is the common case: every
+// tool hook, every SessionStart that is not a `/clear`, and — deliberately — a
+// UserPromptSubmit carrying a blank or non-string prompt. Blanking the header on an empty
+// submit would erase the query the user is still waiting on.
+export function headerHookEffect(event: string, body: Record<string, unknown>, cap: number = LAST_PROMPT_CAP): HeaderHookEffect | null {
+  if (event === "UserPromptSubmit") {
+    if (typeof body.prompt !== "string" || !body.prompt.trim()) return null;
+    return { kind: "prompt", text: body.prompt.trim().slice(0, cap) };
+  }
+  // Only `source: "clear"`. A `/compact` also arrives as SessionStart, and clearing on it
+  // would wipe the user's task line and their title in the middle of a conversation that is
+  // still going.
+  if (event === "SessionStart") return body.source === "clear" ? { kind: "clear" } : null;
+  if (event === "Stop") return { kind: "title" };
+  return null;
+}

--- a/test/server/session/header-hook.spec.ts
+++ b/test/server/session/header-hook.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { headerHookEffect, LAST_PROMPT_CAP } from "../../../server/session/header-hook.js";
+
+describe("headerHookEffect", () => {
+  it("records a submitted prompt as the session's query", () => {
+    expect(headerHookEffect("UserPromptSubmit", { prompt: "  fix the login bug  " })).toEqual({ kind: "prompt", text: "fix the login bug" });
+  });
+
+  it("caps a pasted wall of text to one header line", () => {
+    const effect = headerHookEffect("UserPromptSubmit", { prompt: "x".repeat(LAST_PROMPT_CAP + 50) });
+    expect(effect).toEqual({ kind: "prompt", text: "x".repeat(LAST_PROMPT_CAP) });
+  });
+
+  // Blanking the header on an empty submit would erase the query the user is still waiting
+  // on — so a blank or non-string prompt changes nothing rather than falling through.
+  it.each([[""], ["   "], ["\n\t "], [null], [undefined], [42], [{ text: "hi" }], [["hi"]]])("ignores the unusable prompt %j", (prompt) => {
+    expect(headerHookEffect("UserPromptSubmit", { prompt })).toBeNull();
+  });
+
+  it("clears the header when /clear restarts the conversation", () => {
+    expect(headerHookEffect("SessionStart", { source: "clear" })).toEqual({ kind: "clear" });
+  });
+
+  // The distinction this rule exists for: /compact also arrives as SessionStart. Clearing on
+  // it would wipe the user's task line and AI title mid-conversation.
+  it.each([["compact"], ["startup"], ["resume"], [undefined], [null], ["CLEAR"]])("does not clear on SessionStart source %j", (source) => {
+    expect(headerHookEffect("SessionStart", { source })).toBeNull();
+  });
+
+  it("regenerates the title once a turn's reply is on disk", () => {
+    expect(headerHookEffect("Stop", {})).toEqual({ kind: "title" });
+  });
+
+  // Every other hook — the tool ones fire constantly — must leave the header alone.
+  it.each([["PreToolUse"], ["PostToolUse"], ["PostToolUseFailure"], ["Notification"], ["SessionEnd"], [""], ["userpromptsubmit"]])(
+    "changes nothing on %j",
+    (event) => {
+      expect(headerHookEffect(event, { prompt: "ignored", source: "clear" })).toBeNull();
+    },
+  );
+
+  // Order matters, not just the mapping: a payload carrying both a prompt and a clear source
+  // must be judged by its EVENT, never by whichever field is present.
+  it("decides on the event, not on stray payload fields", () => {
+    expect(headerHookEffect("Stop", { prompt: "still here", source: "clear" })).toEqual({ kind: "title" });
+    expect(headerHookEffect("SessionStart", { prompt: "still here", source: "clear" })).toEqual({ kind: "clear" });
+  });
+
+  it("honours an explicit cap over the default", () => {
+    expect(headerHookEffect("UserPromptSubmit", { prompt: "abcdef" }, 3)).toEqual({ kind: "prompt", text: "abc" });
+  });
+});


### PR DESCRIPTION
## Summary

Third of the small PRs from #598. The event → header/title dispatch moves out of `hook-routes.ts` into `server/session/header-hook.ts`, following its sibling `activity-hook.ts` exactly (an effect, returned; the caller applies it).

**Why this one and not another:** `activityHookEffects` — which sets the working/waiting flags — is already extracted and tested. This function, which decides what the *header* shows, was not. So the flags could stay right while the header lied, and that is the harder failure to notice: the status dot says "working" while the header still shows the task the user abandoned two prompts ago.

## Items to Confirm / Review

1. **Behaviour is unchanged**, including two deliberate no-ops that now have tests:
   - a blank / non-string `UserPromptSubmit` changes nothing (blanking the header there would erase the query the user is still waiting on)
   - `SessionStart` clears **only** on `source: "clear"` — `/compact` arrives as `SessionStart` too, and clearing on it would wipe the task line and the AI title mid-conversation
2. **`LAST_PROMPT_CAP` moved** into the new module (it is part of the rule) and is now exported so the test asserts against the same constant rather than a copy of `200`.
3. The route's `if/else` chain became early returns over a discriminated union — worth a glance that the three branches still map exactly as before.

## Verification

- **Mutation-checked**: widening the `SessionStart` branch to accept every source turns **6 tests red**.
- `172 files / 2183 tests`, lint 0 errors, `typecheck:server` + build clean.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)