### PR TITLE
refactor: make the pinned-shortcuts reconcile testable (#598 A5)

### DIFF
--- a/src/composables/reconcileShortcuts.ts
+++ b/src/composables/reconcileShortcuts.ts
@@ -1,0 +1,43 @@
+// Bringing the pinned-shortcuts file back in line with what actually exists.
+//
+// Worth being a tested function rather than a loop inside a queued async: the caller writes
+// the result with a REPLACE-ALL persist, to a file shared with MulmoClaude. An over-eager
+// prune here does not degrade a view — it deletes the user's pinned favourites in both apps,
+// with no undo. So the rule that decides what to drop is the dangerous part, and the
+// `drifted` flag matters just as much: it is what keeps a routine index fetch from rewriting
+// that file on every visit.
+import { type Shortcut, type ShortcutKind } from "../types/shortcuts";
+
+// What the index that just fetched knows about the things of this kind that exist.
+export interface LiveEntry {
+  slug: string;
+  title: string;
+  icon: string;
+}
+
+export interface Reconciled {
+  next: Shortcut[];
+  // False when nothing changed — the caller must then not write.
+  drifted: boolean;
+}
+
+// Only entries of `kind` are judged; the authoritative list says nothing about the others,
+// so a collection fetch must never prune a feed shortcut (or vice versa).
+export function reconcileShortcuts(current: readonly Shortcut[], kind: ShortcutKind, live: readonly LiveEntry[]): Reconciled {
+  const liveBySlug = new Map(live.map((entry) => [entry.slug, entry]));
+  let drifted = false;
+  const next = current.flatMap((entry) => {
+    if (entry.kind !== kind) return [entry];
+    const fresh = liveBySlug.get(entry.slug);
+    if (!fresh) {
+      drifted = true;
+      return [];
+    }
+    if (fresh.title !== entry.title || fresh.icon !== entry.icon) {
+      drifted = true;
+      return [{ ...entry, title: fresh.title, icon: fresh.icon }];
+    }
+    return [entry];
+  });
+  return { next, drifted };
+}

--- a/src/composables/useShortcuts.ts
+++ b/src/composables/useShortcuts.ts
@@ -9,6 +9,7 @@
 // with rollback, and serialized so overlapping replace-all PUTs can't reorder.
 import { computed, ref, type ComputedRef } from "vue";
 import { sameShortcut, type Shortcut, type ShortcutKind } from "../types/shortcuts";
+import { reconcileShortcuts } from "./reconcileShortcuts";
 import { fetchJson } from "../utils/fetchJson";
 
 const shortcuts = ref<Shortcut[]>([]);
@@ -107,21 +108,7 @@ function reconcile(kind: ShortcutKind, live: { slug: string; title: string; icon
   return enqueue(async () => {
     await load();
     if (!loaded.value) return;
-    const liveBySlug = new Map(live.map((entry) => [entry.slug, entry]));
-    let drifted = false;
-    const next = shortcuts.value.flatMap((entry) => {
-      if (entry.kind !== kind) return [entry];
-      const fresh = liveBySlug.get(entry.slug);
-      if (!fresh) {
-        drifted = true;
-        return [];
-      }
-      if (fresh.title !== entry.title || fresh.icon !== entry.icon) {
-        drifted = true;
-        return [{ ...entry, title: fresh.title, icon: fresh.icon }];
-      }
-      return [entry];
-    });
+    const { next, drifted } = reconcileShortcuts(shortcuts.value, kind, live);
     if (drifted) await persist(next, shortcuts.value);
   });
 }

--- a/test/src/composables/reconcileShortcuts.spec.ts
+++ b/test/src/composables/reconcileShortcuts.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+
+import { reconcileShortcuts } from "../../../src/composables/reconcileShortcuts";
+import type { Shortcut } from "../../../src/types/shortcuts";
+
+const pin = (kind: Shortcut["kind"], slug: string, title = slug, icon = "star"): Shortcut => ({ kind, slug, title, icon });
+
+describe("reconcileShortcuts", () => {
+  // The flag the caller writes on. A routine index fetch that changed nothing must not
+  // rewrite a file shared with another app.
+  it("reports no drift when everything already matches", () => {
+    const current = [pin("collection", "tasks"), pin("feed", "news")];
+    const result = reconcileShortcuts(current, "collection", [{ slug: "tasks", title: "tasks", icon: "star" }]);
+    expect(result.drifted).toBe(false);
+    expect(result.next).toEqual(current);
+  });
+
+  it("drops a shortcut whose target no longer exists", () => {
+    const result = reconcileShortcuts([pin("collection", "gone"), pin("collection", "tasks")], "collection", [{ slug: "tasks", title: "tasks", icon: "star" }]);
+    expect(result.drifted).toBe(true);
+    expect(result.next.map((s) => s.slug)).toEqual(["tasks"]);
+  });
+
+  it("refreshes a renamed title and a changed icon", () => {
+    const result = reconcileShortcuts([pin("collection", "tasks", "Old", "star")], "collection", [{ slug: "tasks", title: "New", icon: "bolt" }]);
+    expect(result.drifted).toBe(true);
+    expect(result.next).toEqual([{ kind: "collection", slug: "tasks", title: "New", icon: "bolt" }]);
+  });
+
+  // The persist is REPLACE-ALL against a file shared with MulmoClaude, so a fetch about one
+  // kind must never take the other kind's pins with it. This is the deletion that has no undo.
+  it("never touches another kind, even when that kind's slugs are absent from the live list", () => {
+    const current = [pin("feed", "news"), pin("feed", "blog"), pin("collection", "tasks")];
+    const result = reconcileShortcuts(current, "collection", [{ slug: "tasks", title: "tasks", icon: "star" }]);
+    expect(result.next.filter((s) => s.kind === "feed")).toHaveLength(2);
+  });
+
+  // A failed/empty fetch reaching this would wipe every pin of that kind. Pinned as the
+  // documented consequence, so a future caller knows an empty list must never be passed
+  // speculatively.
+  it("prunes everything of that kind when the live list is empty", () => {
+    const result = reconcileShortcuts([pin("collection", "a"), pin("feed", "b")], "collection", []);
+    expect(result.drifted).toBe(true);
+    expect(result.next.map((s) => s.slug)).toEqual(["b"]);
+  });
+
+  it("keeps the user's order rather than the live list's", () => {
+    const current = [pin("collection", "c"), pin("collection", "a"), pin("collection", "b")];
+    const live = [
+      { slug: "a", title: "a", icon: "star" },
+      { slug: "b", title: "b", icon: "star" },
+      { slug: "c", title: "c", icon: "star" },
+    ];
+    expect(reconcileShortcuts(current, "collection", live).next.map((s) => s.slug)).toEqual(["c", "a", "b"]);
+  });
+
+  it("does not add a live entry the user never pinned", () => {
+    const result = reconcileShortcuts([pin("collection", "tasks")], "collection", [
+      { slug: "tasks", title: "tasks", icon: "star" },
+      { slug: "unpinned", title: "unpinned", icon: "star" },
+    ]);
+    expect(result.next.map((s) => s.slug)).toEqual(["tasks"]);
+  });
+
+  it("does not mutate the list it was given", () => {
+    const current = [pin("collection", "tasks", "Old")];
+    reconcileShortcuts(current, "collection", [{ slug: "tasks", title: "New", icon: "bolt" }]);
+    expect(current[0].title).toBe("Old");
+  });
+
+  it("handles an empty store without drift", () => {
+    expect(reconcileShortcuts([], "collection", [{ slug: "tasks", title: "tasks", icon: "star" }])).toEqual({ next: [], drifted: false });
+  });
+
+  // Same slug under both kinds is legal — they are different targets.
+  it("matches on kind and slug together", () => {
+    const current = [pin("collection", "news", "Collection news"), pin("feed", "news", "Feed news")];
+    const result = reconcileShortcuts(current, "feed", [{ slug: "news", title: "Feed news renamed", icon: "star" }]);
+    expect(result.next).toEqual([pin("collection", "news", "Collection news"), { kind: "feed", slug: "news", title: "Feed news renamed", icon: "star" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Fourth from #598, and the one with the worst blast radius. `reconcile`'s drift computation moves out of `useShortcuts.ts` into `src/composables/reconcileShortcuts.ts`.

The caller writes the result with a **replace-all** persist to `config/shortcuts.json` — a file **shared with MulmoClaude**. An over-eager prune here does not degrade a view; it deletes the user's pinned favourites **in both apps, with no undo**. There was no spec for `useShortcuts.ts` of any kind, so none of this had a single assertion.

## Items to Confirm / Review

1. **The kind guard is the load-bearing line.** A collection fetch must never prune a feed pin — the authoritative list it was handed says nothing about feeds. Removing that guard turns **4 tests red**.
2. **`drifted` is tested as a first-class outcome**, not an implementation detail: it is what stops a routine index fetch from rewriting the shared file on every visit.
3. **One consequence is now pinned rather than implicit**: an empty `live` list prunes every pin of that kind. That is correct for "this index legitimately has nothing", and dangerous for "the fetch failed" — the test states it so a future caller does not pass one speculatively. If you'd rather it refused an empty list outright, that's a behaviour change I'd do separately.
4. Behaviour is otherwise identical, including keeping the **user's** ordering rather than the live list's.

## Verification

- `175 files / 2225 tests`, lint 0 errors, typecheck + build clean.
- Mutation-checked as described above.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)