### PR TITLE
refactor: spawner のシグネチャ宣言を1か所に（ファクトリから導出）

### DIFF
--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -6,7 +6,6 @@
 // plugin-narration.ts for why a failed tool call must still be a 200.
 import { randomUUID } from "node:crypto";
 import type { Express } from "express";
-import type { WebSocket } from "ws";
 
 import { CLAUDE_CWD, PORT } from "../config/env.js";
 import { messageOf } from "../errors.js";
@@ -16,19 +15,11 @@ import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../ses
 import { codexifySkillSeed } from "../agents/codex-skills.js";
 import { manageCollectionHandler } from "../infra/collection-tool.js";
 import { upstreamFailureMessage } from "./plugin-narration.js";
-import type { PtyEntry } from "../session/types.js";
-import type { SpawnClaudeOptions } from "../session/spawn-claude.js";
+import type { SpawnClaudePty, SpawnCodexPty } from "../session/spawners.js";
 
 export interface PluginRouteDeps {
-  spawnClaudePty: (sessionId: string, resume: string | null, ws: WebSocket | null, options?: SpawnClaudeOptions) => PtyEntry;
-  spawnCodexPty: (
-    sessionId: string,
-    ws: WebSocket | null,
-    resumeRolloutId: string | null,
-    cwd: string,
-    attachGuiMcp: boolean,
-    initialPrompt: string | null,
-  ) => PtyEntry;
+  spawnClaudePty: SpawnClaudePty;
+  spawnCodexPty: SpawnCodexPty;
 }
 
 export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -18,7 +18,6 @@ import { resolveButtonCommand, shellQuoteFor } from "../config/header-resolve.js
 import { resolveScript } from "../files/scripts.js";
 import { refreshHostKeychainIfExpired, writeSandboxCredentials } from "../infra/sandbox.js";
 import { tmuxHasSession } from "../infra/tmux.js";
-import type { SpawnClaudeOptions } from "../session/spawn-claude.js";
 import { launchChoiceFromParams } from "../session/launch-choice.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
@@ -30,6 +29,7 @@ import { ProviderRefusedError } from "../session/provider-env.js";
 import { sessionExistsOnDisk } from "../session/session-reads.js";
 import { canStartLauncher, resolveReattachableId, resolveSession, type SessionResolution } from "../session/session-resolve.js";
 import type { PtyEntry } from "../session/types.js";
+import type { SpawnClaudePty, SpawnCodexPty, SpawnCommandPty, SpawnLauncherPty, ResolveLauncher } from "../session/spawners.js";
 
 export interface WsRouteDeps {
   /** The http server these endpoints hang their `upgrade` handler off. */
@@ -41,18 +41,11 @@ export interface WsRouteDeps {
   reattachPty: (entry: PtyEntry, ws: WebSocket, sessionId: string) => PtyEntry;
   handleClientFrame: (entry: PtyEntry, ws: WebSocket, raw: { toString(): string }, sessionId: string) => void;
   handleClientClose: (entry: PtyEntry, ws: WebSocket, sessionId: string) => void;
-  spawnClaudePty: (sessionId: string, resume: string | null, ws: WebSocket | null, options?: SpawnClaudeOptions) => PtyEntry;
-  spawnCodexPty: (
-    sessionId: string,
-    ws: WebSocket | null,
-    resumeRolloutId: string | null,
-    cwd: string,
-    attachGuiMcp: boolean,
-    initialPrompt: string | null,
-  ) => PtyEntry;
-  spawnCommandPty: (command: string, cwd: string, ws: WebSocket) => IPty;
-  spawnLauncherPty: (sessionId: string, ws: WebSocket, command: string, cwd: string) => PtyEntry;
-  resolveLauncher: (index: number) => { label: string; command: string } | null;
+  spawnClaudePty: SpawnClaudePty;
+  spawnCodexPty: SpawnCodexPty;
+  spawnCommandPty: SpawnCommandPty;
+  spawnLauncherPty: SpawnLauncherPty;
+  resolveLauncher: ResolveLauncher;
 }
 
 // Pick the effective session id for a /ws connection: reattach a same-process live pty,

--- a/server/session/spawners.ts
+++ b/server/session/spawners.ts
@@ -1,0 +1,15 @@
+// What each spawner looks like to the modules that are handed one.
+//
+// Derived from the factory that produces it rather than written out again, because a route
+// module can only declare what it needs by describing a function it does not own — and two
+// modules describing the same six-argument positional signature by hand is a copy that can
+// drift from the implementation without anything noticing (#548).
+import type { createClaudeSpawner } from "./spawn-claude.js";
+import type { createCodexSpawner } from "./spawn-codex.js";
+import type { createShellSpawners } from "./spawn-shell.js";
+
+export type SpawnClaudePty = ReturnType<typeof createClaudeSpawner>["spawnClaudePty"];
+export type SpawnCodexPty = ReturnType<typeof createCodexSpawner>["spawnCodexPty"];
+export type SpawnCommandPty = ReturnType<typeof createShellSpawners>["spawnCommandPty"];
+export type SpawnLauncherPty = ReturnType<typeof createShellSpawners>["spawnLauncherPty"];
+export type ResolveLauncher = ReturnType<typeof createShellSpawners>["resolveLauncher"];


### PR DESCRIPTION
## Summary

PR #599 で `github-advanced-security[bot]` (jscpd) が指摘した **64 トークンの重複コード**への対応です。

`ws-routes.ts` と `plugin-routes.ts` が、同じ spawner 関数のシグネチャを**それぞれ手書き**していました。とくに `spawnCodexPty` は**位置引数 6 個**で、うち複数が同じ型です。

```ts
spawnCodexPty: (
  sessionId: string, ws: WebSocket | null, resumeRolloutId: string | null,
  cwd: string, attachGuiMcp: boolean, initialPrompt: string | null,
) => PtyEntry;
```

`server/session/spawners.ts` を新設し、**各型を実装（ファクトリ）から導出**するようにしました。

```ts
export type SpawnCodexPty = ReturnType<typeof createCodexSpawner>["spawnCodexPty"];
```

これで「宣言＝実装」になり、手書きのコピーが実装から乖離する余地がなくなります。

**型のみの変更**です。ランタイムには何も残りません（`import type` は消える）。

## なぜ「重複を消す」以上の意味があるか

`spawnCodexPty` は位置引数 6 個で、`sessionId: string` / `resumeRolloutId: string | null` / `cwd: string` のように**同じ型が並んでいます**。もし実装側で引数の順序を入れ替えても、手書きの宣言が 2 か所に残っていれば**両方の呼び出し側は古い記述に対して型チェックを通過し続けます**。コンパイラは何も言わず、壊れるのは実行時です。

導出型ならこの経路自体が存在しません。

## Items to Confirm / Review

1. **これは予防であって、バグ修正ではありません。** 手書き版は実装と一致していました（導出型に差し替えて型エラーが 0 件だったことが根拠）
2. **導出型が `any` に潰れていないことを確認済み**：`spawnCodexPty` を引数 3 個で呼ぶと 3 エラー、`spawnClaudePty` に存在しないオプションキーを渡すと 1 エラーになることを実測。潰れていれば全部通ってしまうので、この確認をしています
3. 置き場所を `server/session/spawners.ts` にした判断 — `spawn-deps.ts`（ファクトリが**必要とするもの**）と対になる「ファクトリが**produce するもの**」として分けました。同居させると `spawn-deps.ts` ↔ spawner 各モジュールが型循環するため、別ファイルにしています
4. `ws-routes.ts` の `spawnCommandPty` / `spawnLauncherPty` / `resolveLauncher` も同時に導出型へ寄せました（重複はしていませんでしたが、同じ理由で乖離しうるため）

## User Prompt

> 型は１つにしよう。PRで。

（PR #599 マージ後、jscpd が指摘していた spawner シグネチャの重複について）

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` / `yarn test`（174 files, 2215 tests）/ `yarn knip` すべて通過。

テストは追加していません。型宣言の一本化であり、実行されるコードが 1 行も変わらないためです（上記 2 の型レベルの確認をもって代えています）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
