### PR TITLE
refactor: 起動まわりの2つのポリシーを index.ts から出す (#548 step 3l)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -23,8 +23,9 @@ import {
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
 import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage, cleanupSandbox } from "./infra/sandbox.js";
 import { isAllowedOrigin } from "./infra/allowed-origin.js";
+import { serverErrorExit } from "./infra/server-exit.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
-import { hasErrnoCode, messageOf } from "./errors.js";
+import { messageOf } from "./errors.js";
 import { hookSettingsJson } from "./session/hook-settings.js";
 import { mcpConfigJson } from "./session/mcp-config.js";
 import { createClaudeSpawner } from "./session/spawn-claude.js";
@@ -64,7 +65,7 @@ import { mountToolRoutes } from "./routes/tool-routes.js";
 import { mountRepoRoutes } from "./routes/repo-routes.js";
 import { claudeOnDiskSessionIds, readLatestResponse } from "./session/session-reads.js";
 import { mountDirRoutes } from "./routes/dir-routes.js";
-import { createScheduledSessionRegistry, heldByAnotherProcess, scheduledSessionsDir } from "./session/scheduled-sessions.js";
+import { createScheduledSessionRegistry, scheduledSessionInUse, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { codexSessionsRoot } from "./agents/codex-session.js";
@@ -736,19 +737,16 @@ startCollectionCompletionWatchers().catch((err) => {
 // never finishes a turn, so the hook-driven reap can miss it entirely — hence the
 // registry, which bounds them by count and age whatever their hooks did (#541).
 
-// Would killing this session take it away from someone? Two answers are needed: our own
-// viewer (a local fact) and any OTHER server process holding it, which only tmux can tell
-// us — see heldByAnotherProcess for the arithmetic.
-function scheduledSessionInUse(id: string): boolean {
+// The rule lives with heldByAnotherProcess (pure/tested); this only reads the live facts.
+const sessionInUse = (id: string): boolean => {
   const entry = ptys.get(id);
-  if (entry?.ws) return true; // our own user is looking at it
-  return heldByAnotherProcess(tmuxAttachedClientCount(id), !!entry);
-}
+  return scheduledSessionInUse({ hasViewer: !!entry?.ws, weHoldAPty: !!entry }, () => tmuxAttachedClientCount(id));
+};
 
 const scheduledSessions = createScheduledSessionRegistry({
   dir: scheduledSessionsDir(CLAUDE_CWD, MULMOTERMINAL_HOME),
   isValidId: (id) => SESSION_ID_RE.test(id),
-  isInUse: scheduledSessionInUse,
+  isInUse: sessionInUse,
   reapSession: reap,
   hasTmux: tmuxHasSession,
   killTmux: tmuxKillSession,
@@ -805,19 +803,13 @@ mountTerminalWebSockets({
   resolveLauncher,
 });
 
-// Exit code the launcher (bin/mulmoterminal.js) treats as "port was taken at
-// bind time" so it can retry on a fresh port. Keep in sync with the launcher.
-const PORT_IN_USE_EXIT_CODE = 75;
-
-// A bind failure (most often the port already in use) must not surface as an
-// unhandled 'error' event / stack trace — exit with a clear message instead.
+// A bind failure (most often the port already in use) must not surface as an unhandled
+// 'error' event / stack trace — exit with a clear message and the code the launcher reads
+// (infra/server-exit.ts).
 server.on("error", (err) => {
-  if (hasErrnoCode(err) && err.code === "EADDRINUSE") {
-    console.error(`[mulmoterminal] Port ${PORT} is already in use — set PORT=<n> or pass --port <n>.`);
-    process.exit(PORT_IN_USE_EXIT_CODE);
-  }
-  console.error(`[mulmoterminal] server error: ${messageOf(err)}`);
-  process.exit(1);
+  const { message, code } = serverErrorExit(err, PORT);
+  console.error(message);
+  process.exit(code);
 });
 
 server.listen(PORT, () => {

--- a/server/infra/server-exit.ts
+++ b/server/infra/server-exit.ts
@@ -1,0 +1,30 @@
+// What a failure of the HTTP server itself becomes: the line the operator reads, and the
+// code the process leaves with.
+//
+// The code is a CONTRACT with bin/mulmoterminal.js. 75 tells the launcher the port was taken
+// at bind time, so it retries on a fresh one; anything else tells it to stop. Get that wrong
+// and the retry either never fires (the app just fails to start on a busy port) or fires for
+// errors retrying cannot fix.
+//
+// Out of the listener because a policy reachable only by failing to bind a port is a policy
+// nothing can check — the listener now only prints and exits (#548).
+import { hasErrnoCode, messageOf } from "../errors.js";
+
+// Keep in sync with bin/mulmoterminal.js — a test asserts the two agree.
+export const PORT_IN_USE_EXIT_CODE = 75;
+export const SERVER_ERROR_EXIT_CODE = 1;
+
+export interface ServerExit {
+  message: string;
+  code: number;
+}
+
+export function serverErrorExit(err: unknown, port: string | number): ServerExit {
+  if (hasErrnoCode(err) && err.code === "EADDRINUSE") {
+    return {
+      message: `[mulmoterminal] Port ${port} is already in use — set PORT=<n> or pass --port <n>.`,
+      code: PORT_IN_USE_EXIT_CODE,
+    };
+  }
+  return { message: `[mulmoterminal] server error: ${messageOf(err)}`, code: SERVER_ERROR_EXIT_CODE };
+}

--- a/server/session/scheduled-sessions.ts
+++ b/server/session/scheduled-sessions.ts
@@ -74,6 +74,15 @@ export function heldByAnotherProcess(attachedClients: number | null, weHoldAPty:
   return attachedClients > (weHoldAPty ? 1 : 0);
 }
 
+/** Would killing this session take it away from someone? Two answers are needed: our own
+ *  viewer (a local fact) and any OTHER server process holding it, which only tmux can tell
+ *  us. The count is a thunk because asking tmux spawns a process: a session someone is
+ *  watching is in use whatever tmux would say, and the sweep runs over every session. */
+export function scheduledSessionInUse(local: { hasViewer: boolean; weHoldAPty: boolean }, attachedClients: () => number | null): boolean {
+  if (local.hasViewer) return true;
+  return heldByAnotherProcess(attachedClients(), local.weHoldAPty);
+}
+
 // A path can't be used as a filename raw: on Windows it carries `\` and `:`, which are a
 // separator and a stream marker, so the write would fail (or land somewhere unintended)
 // and Windows would silently lose restart-time cleanup. Fold everything unsafe to "-" and

--- a/test/server/infra/server-exit.spec.ts
+++ b/test/server/infra/server-exit.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { serverErrorExit, PORT_IN_USE_EXIT_CODE, SERVER_ERROR_EXIT_CODE } from "../../../server/infra/server-exit.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+describe("serverErrorExit", () => {
+  describe("a port taken at bind time", () => {
+    it("asks for the launcher's retry code", () => {
+      expect(serverErrorExit({ code: "EADDRINUSE" }, 34567).code).toBe(PORT_IN_USE_EXIT_CODE);
+    });
+
+    it("names the port and how to change it", () => {
+      expect(serverErrorExit({ code: "EADDRINUSE" }, 34567).message).toBe("[mulmoterminal] Port 34567 is already in use — set PORT=<n> or pass --port <n>.");
+    });
+
+    it("takes the port as given, whether a number or a string", () => {
+      expect(serverErrorExit({ code: "EADDRINUSE" }, "8080").message).toContain("Port 8080 ");
+    });
+  });
+
+  describe("any other failure", () => {
+    // Retrying on a different port cannot fix these, so the launcher must be told to stop.
+    it.each([
+      ["a different errno", { code: "EACCES" }],
+      ["an Error", new Error("socket hang up")],
+      ["an errno-less object", { message: "nope" }],
+      ["a string", "nope"],
+      ["a number", 7],
+      ["null", null],
+      ["undefined", undefined],
+    ])("exits %s with the generic code", (_label, err) => {
+      expect(serverErrorExit(err, 34567).code).toBe(SERVER_ERROR_EXIT_CODE);
+    });
+
+    it("carries an Error's own message", () => {
+      expect(serverErrorExit(new Error("socket hang up"), 34567).message).toBe("[mulmoterminal] server error: socket hang up");
+    });
+
+    it("renders a thrown non-Error rather than dropping it", () => {
+      expect(serverErrorExit("nope", 34567).message).toBe("[mulmoterminal] server error: nope");
+    });
+
+    // EACCES on a privileged port is the near miss: it looks port-related, but a retry on
+    // another port is the launcher's job to decide, not this one's — and today it stops.
+    it("does not treat a permission error as a port clash", () => {
+      expect(serverErrorExit({ code: "EACCES" }, 80).code).not.toBe(PORT_IN_USE_EXIT_CODE);
+    });
+  });
+
+  // Both files carry the number as a literal and a comment asking the other to keep in step.
+  // Nothing enforced it: changing one side silently breaks the retry — the app just fails to
+  // start on a busy port, with no sign of why.
+  describe("the contract with bin/mulmoterminal.js", () => {
+    const launcher = readFileSync(path.join(REPO_ROOT, "bin", "mulmoterminal.js"), "utf8");
+
+    it("uses the exit code the launcher retries on", () => {
+      const declared = launcher.match(/PORT_IN_USE_EXIT_CODE\s*=\s*(\d+)/);
+      expect(declared, "bin/mulmoterminal.js no longer declares PORT_IN_USE_EXIT_CODE — the retry contract moved or was renamed").not.toBeNull();
+      expect(Number(declared?.[1])).toBe(PORT_IN_USE_EXIT_CODE);
+    });
+
+    it("is still what the launcher branches on", () => {
+      expect(launcher).toMatch(/code === PORT_IN_USE_EXIT_CODE/);
+    });
+  });
+});

--- a/test/server/session/scheduled-sessions.spec.ts
+++ b/test/server/session/scheduled-sessions.spec.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   createScheduledSessionRegistry,
   heldByAnotherProcess,
+  scheduledSessionInUse,
   parseScheduledSessionRecord,
   scheduledSessionsDir,
   selectExpiredScheduledSessions,
@@ -95,6 +96,47 @@ describe("parseScheduledSessionRecord", () => {
     expect(parseScheduledSessionRecord("a", "nope", anyId)).toBeNull();
     expect(parseScheduledSessionRecord("a", null, anyId)).toBeNull();
     expect(parseScheduledSessionRecord("a", [1], anyId)).toBeNull();
+  });
+});
+
+describe("scheduledSessionInUse", () => {
+  const tmuxSays = (count: number | null) => vi.fn().mockReturnValue(count);
+
+  // Someone is looking at it right now — nothing tmux could say changes the answer.
+  it("is in use when our own viewer is attached", () => {
+    expect(scheduledSessionInUse({ hasViewer: true, weHoldAPty: true }, tmuxSays(0))).toBe(true);
+  });
+
+  // Asking costs a tmux subprocess, and the sweep runs over every session.
+  it("does not ask tmux when a viewer is attached", () => {
+    const attachedClients = tmuxSays(0);
+    scheduledSessionInUse({ hasViewer: true, weHoldAPty: true }, attachedClients);
+    expect(attachedClients).not.toHaveBeenCalled();
+  });
+
+  // The whole point of the registry: our own DETACHED pty is reapable, even though it still
+  // holds a tmux client of its own.
+  it("is free when only our own detached pty holds it", () => {
+    expect(scheduledSessionInUse({ hasViewer: false, weHoldAPty: true }, tmuxSays(1))).toBe(false);
+  });
+
+  it("is in use when a second client holds it alongside our pty", () => {
+    expect(scheduledSessionInUse({ hasViewer: false, weHoldAPty: true }, tmuxSays(2))).toBe(true);
+  });
+
+  // A session that outlived our process: we hold nothing, so any client is someone else's.
+  it("is in use when a client holds it and we hold no pty", () => {
+    expect(scheduledSessionInUse({ hasViewer: false, weHoldAPty: false }, tmuxSays(1))).toBe(true);
+  });
+
+  it("is free when nothing holds it", () => {
+    expect(scheduledSessionInUse({ hasViewer: false, weHoldAPty: false }, tmuxSays(0))).toBe(false);
+  });
+
+  // No tmux session to take from anyone.
+  it("is free when tmux cannot answer", () => {
+    expect(scheduledSessionInUse({ hasViewer: false, weHoldAPty: false }, tmuxSays(null))).toBe(false);
+    expect(scheduledSessionInUse({ hasViewer: false, weHoldAPty: true }, tmuxSays(null))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`index.ts` に残っていた判断のうち、**テスト不可能な位置にあり、かつ間違えると実害が大きい 2 つ**を抽出しました。856 → 848 行、**テスト 22 件追加**。

| 抽出先 | 判断 | 間違えると |
|---|---|---|
| `infra/server-exit.ts` | どのエラーが「ポートが埋まっていた＝別ポートで再試行」か | ランチャの自動リトライが黙って死ぬ |
| `session/scheduled-sessions.ts` | このセッションを殺すと誰かから奪うことになるか | **人が見ているセッションを殺す** |

どちらも「ポートのバインドに失敗する」「tmux が生きている状態で毎時のスイープが走る」という状況でしか通らないコードで、テストが 1 件もありませんでした。

## Items to Confirm / Review

1. **ランチャとの契約をテストで縛りました** — `bin/mulmoterminal.js` を読んで `PORT_IN_USE_EXIT_CODE` の値が一致することを assert しています。ソースを正規表現で読む形なので多少 brittle ですが、**リネーム時に人間が見るべきタイミングで落ちる**ので許容と判断しました。異論があれば外します
2. **クライアント数を thunk（遅延）で渡した判断** — 下記のとおり短絡が load-bearing なためですが、シグネチャが少し変わった形になっています
3. Codex に独立した調査を依頼し、**3 つ目の候補（起動時 sandbox バナー）は取り下げました**（下記）

## なぜ thunk なのか

```ts
export function scheduledSessionInUse(local: { hasViewer: boolean; weHoldAPty: boolean }, attachedClients: () => number | null): boolean {
  if (local.hasViewer) return true;
  return heldByAnotherProcess(attachedClients(), local.weHoldAPty);
}
```

`tmuxAttachedClientCount` は **tmux のサブプロセスを起動します**。ビューアが付いているセッションは tmux が何と答えようが使用中なので、素朴に「引数を先に全部評価する純粋関数」にすると、**毎時のスイープでビューア付きセッション全部について無駄にプロセスを起動する**ようになります。thunk なら「ビューアがいるときは tmux に聞かない」ことまでテストで固定できます。

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| 終了コードを 75 → 76 | ランチャとの契約テスト |
| errno があれば全部ポート衝突扱い | `EACCES` 系 2 件 |
| tmux を先に評価（短絡をやめる） | 「ビューアがいるとき tmux に聞かない」 |
| 自分の pty を勘定に入れ忘れる | 「自分の detached pty だけなら回収可能」 |

4 つ目は、このレジストリが存在する理由そのもの（自分の detached なバックグラウンド pty は tmux クライアントを 1 つ持つので、それを他人扱いすると**永久に回収されないリークになる**）を守るテストです。

## Codex に聞いた結果（取り下げた候補）

ユーザーの許可を得て `codex exec` で独立した調査を依頼しました。結果は 3 点:

- **`scheduledSessionInUse` を「唯一明確に価値がある抽出」と評価** — 私は当初「薄い委譲」として見送るつもりでした。Codex が正しかったので採用しています
- **`serverErrorExit` は一致** — 外部契約なので小さくても価値あり
- **起動時 sandbox バナー（4 分岐）は「過剰設計」と判定** — 私はこれを最有力候補と考えていましたが、能力判定自体は既に `sandbox.ts` にあり、残りはログ文言の選択にすぎない、という指摘です。私は「`ensureSandboxImage()` の副作用があるので順序が load-bearing」と反論しようとしましたが、**現状のコードは既に正しい順序であり、抽出して初めてその危険が生まれる**（自作のリスクを自分で塞ぐ話）と気づいたので取り下げました

Codex が「抽出しない方がよい」と判定したその他: `reap` の後片付け、`setWorking`/`setWaiting`、`scheduleReap` のタイマー重複排除、hidden セッションのマーキング。いずれも判断ではなく lifecycle の配線というのが理由で、私の見立てとも一致します。

## User Prompt

> 他、index.tsでpure関数できるものはすすめて。codexにきいてもよいよ

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:server` / `typecheck:test` / `yarn build` / `yarn test`（179 files, 2309 tests）/ `yarn knip` すべて通過。

## #548 の残り

これで index.ts に残る「テストされていない判断」は、私と Codex の双方の見立てでは**なくなりました**。残りは配線・ライフサイクル・起動処理です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
