### PR TITLE
refactor: one definition of "is a document path" (#598 B)

### DIFF
--- a/server/backends/docPath.ts
+++ b/server/backends/docPath.ts
@@ -1,0 +1,24 @@
+// What counts as a presentDocument document, for the one place that decides it.
+//
+// Two sites need this answer and had their own copy: the write guard in markdown.ts
+// (loadDoc/saveDoc, where it is the only thing keeping an LLM-authored path inside the
+// workspace) and the live-refresh scope matcher in fileChange.ts, whose comment claimed to
+// "mirror the host write sites exactly" while omitting the normalization check. A predicate
+// that two files define differently while documenting them as identical is a drift waiting
+// to matter — a write site that accepts what the refresh site rejects means a saved document
+// that never updates on screen.
+
+import path from "node:path";
+
+export const DOCS_DIR = "artifacts/documents";
+
+// Strict: under artifacts/documents, ending in .md, and already in normalized POSIX form.
+// The normalization equality is the containment check — `artifacts/documents/../../x.md`
+// normalizes to something else and is refused, so a path can never climb out of the
+// workspace. It also refuses harmless-but-odd spellings like `artifacts/documents/./x.md`,
+// which is intended: there is exactly one way to name a document.
+export function isDocPath(rel: string): boolean {
+  if (!rel.startsWith(`${DOCS_DIR}/`) || !rel.endsWith(".md")) return false;
+  const normalized = path.posix.normalize(rel);
+  return normalized === rel && !normalized.includes("..");
+}

--- a/server/backends/fileChange.ts
+++ b/server/backends/fileChange.ts
@@ -10,6 +10,7 @@
 import path from "node:path";
 import { configureFileChangePublisher, publishFileChange } from "@mulmoclaude/core/file-change";
 import type { createPubSub } from "../infra/pubsub.js";
+import { isDocPath } from "./docPath.js";
 
 type PubSub = ReturnType<typeof createPubSub>;
 
@@ -17,13 +18,9 @@ const log = {
   warn: (message: string, data?: Record<string, unknown>) => console.warn(`[file-change] ${message}`, data ?? ""),
 };
 
-// Scope matchers mirror the host write sites exactly:
-//   markdown — artifacts/documents/**.md (the presentDocument View's isFilePath gate)
-//   html     — **.html                   (the presentHtml View)
-function isMarkdownDoc(posixPath: string): boolean {
-  return posixPath.startsWith("artifacts/documents/") && posixPath.endsWith(".md");
-}
-
+// Scope matchers mirror the host write sites exactly — the markdown one IS the write site's
+// predicate (docPath.ts), so the two cannot drift into a document that saves but never
+// refreshes.
 function isHtmlDoc(posixPath: string): boolean {
   return posixPath.endsWith(".html");
 }
@@ -39,7 +36,7 @@ export function initFileChangePublisher(deps: { workspace: string; pubsub: PubSu
     // separators (our rels are already "/"-joined, so this is a no-op on POSIX).
     toPosix: (relativePath) => relativePath.split(path.sep).join("/"),
     pluginScopes: [
-      { scope: "markdown", matches: isMarkdownDoc },
+      { scope: "markdown", matches: isDocPath },
       { scope: "html", matches: isHtmlDoc },
     ],
     warn: (message, data) => log.warn(message, data),

--- a/server/backends/markdown.ts
+++ b/server/backends/markdown.ts
@@ -20,8 +20,7 @@ import { renderMarpDeck, fillImagePlaceholders } from "@mulmoclaude/markdown-plu
 import type { MarkdownHostApp, ExportPdfOptions } from "@mulmoclaude/markdown-plugin";
 import { publishFileChange } from "./fileChange.js";
 import { generateImage } from "./image-gen.js";
-
-const DOCS_DIR = "artifacts/documents";
+import { DOCS_DIR, isDocPath } from "./docPath.js";
 
 // Set once at boot (server/index.ts) — workspace = CLAUDE_CWD. File-change
 // live-refresh is forwarded by the shared publisher (see fileChange.ts).
@@ -29,14 +28,6 @@ let workspace: string | null = null;
 
 export function initMarkdownBackend(deps: { workspace: string }): void {
   workspace = deps.workspace;
-}
-
-// Strict gate (matches the package's isFilePath + MulmoClaude's isMarkdownPath):
-// only `artifacts/documents/**.md`, normalized, no traversal.
-function isDocPath(rel: string): boolean {
-  if (!rel.startsWith(`${DOCS_DIR}/`) || !rel.endsWith(".md")) return false;
-  const normalized = path.posix.normalize(rel);
-  return normalized === rel && !normalized.includes("..");
 }
 
 function absFor(rel: string): string {

--- a/test/server/backends/docPath.spec.ts
+++ b/test/server/backends/docPath.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { DOCS_DIR, isDocPath } from "../../../server/backends/docPath.js";
+
+describe("isDocPath", () => {
+  it("accepts a document under the documents directory", () => {
+    expect(isDocPath(`${DOCS_DIR}/notes.md`)).toBe(true);
+  });
+
+  it("accepts the dated path saveNewDoc composes", () => {
+    expect(isDocPath(`${DOCS_DIR}/2026/07/design-review-ab12cd34.md`)).toBe(true);
+  });
+
+  // This is the only thing keeping an LLM-authored path inside the workspace: the write
+  // sites call it and throw on false. The normalization equality is the containment check —
+  // a climbing path normalizes to something else and stops here.
+  it.each([[`${DOCS_DIR}/../../evil.md`], [`${DOCS_DIR}/a/../../../evil.md`], [`${DOCS_DIR}/x.md/../../../y.md`], [`${DOCS_DIR}/..%2F..%2Fevil.md`]])(
+    "refuses the climbing path %s",
+    (rel) => {
+      expect(isDocPath(rel)).toBe(false);
+    },
+  );
+
+  it("refuses a path outside the documents directory", () => {
+    expect(isDocPath("artifacts/html/page.md")).toBe(false);
+    expect(isDocPath("notes.md")).toBe(false);
+  });
+
+  // The directory name must be followed by a separator — a sibling directory whose name
+  // merely starts the same way is not inside it.
+  it("refuses a sibling directory with a matching prefix", () => {
+    expect(isDocPath(`${DOCS_DIR}-backup/notes.md`)).toBe(false);
+  });
+
+  it("refuses a non-markdown file", () => {
+    expect(isDocPath(`${DOCS_DIR}/settings.json`)).toBe(false);
+    expect(isDocPath(`${DOCS_DIR}/notes.md.txt`)).toBe(false);
+  });
+
+  it("refuses the directory itself", () => {
+    expect(isDocPath(DOCS_DIR)).toBe(false);
+    expect(isDocPath(`${DOCS_DIR}/`)).toBe(false);
+  });
+
+  // Deliberate: there is exactly one way to name a document, so the write guard and the
+  // live-refresh matcher can never disagree about whether a given string is that document.
+  it("refuses an un-normalized but harmless spelling", () => {
+    expect(isDocPath(`${DOCS_DIR}/./notes.md`)).toBe(false);
+    expect(isDocPath(`${DOCS_DIR}//notes.md`)).toBe(false);
+  });
+
+  it("refuses an empty string", () => {
+    expect(isDocPath("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two files answered the same question differently, while documenting them as identical.

| | Decides | Normalization check |
|---|---|---|
| `markdown.ts` `isDocPath` | whether an LLM-authored path may be **written** | yes |
| `fileChange.ts` `isMarkdownDoc` | which View **live-refreshes** | **no** — despite its comment saying the matchers "mirror the host write sites exactly" |

Both now call one predicate in `server/backends/docPath.ts`, with tests.

## Is anything exploitable today? No — I checked before writing the fix

The write guard is correct. Run against climbing paths it refuses all of them:

```
拒否  artifacts/documents/../../evil.md
拒否  artifacts/documents/a/../../../evil.md
拒否  artifacts/documents/../../.claude/settings.json
拒否  artifacts/documents/x.md/../../../y.md
許可  artifacts/documents/2026/07/x-ab12.md
```

And the loose one is *looser*, not stricter, so every writable path still matches it. **The hazard is the direction of a future edit**: tighten the matcher or loosen the guard and the two disagree, with no test anywhere to notice. A saved document that never refreshes on screen is the mild outcome.

## Items to Confirm / Review

1. **One deliberate behaviour change.** The live-refresh matcher is now strict too, so an un-normalized spelling like `artifacts/documents/./x.md` no longer matches. Such a path cannot be written through the guard in the first place, so nothing that exists can produce one — but if file-change events can arrive from a source other than our own write sites, that assumption is worth a second look.
2. **The traversal cases had never been asserted anywhere.** They are now, along with the prefix-sibling case (`artifacts/documents-backup/notes.md` must not count as inside).
3. Removing the normalization check turns **5 tests red**.

## Checks

`180 files / 2309 tests`, lint 0 errors, `typecheck:server` exit 0, build clean.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)