### PR TITLE
refactor: extract the mutate HTTP status, and describe it correctly (#598 B)

### DIFF
--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -65,6 +65,7 @@ import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability
 // action so a view can never do more than the agent's own data plane.
 import { manageCollectionHandler } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
+import { mutateStatus } from "./mutateStatus.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
 // (prefix, message, optional structured data) — shared with the other engines'
@@ -261,16 +262,6 @@ function csvParam(value: unknown): string[] | undefined {
   if (Array.isArray(value)) return value.map((entry) => String(entry));
   if (typeof value === "string" && value.length > 0) return value.split(",");
   return undefined;
-}
-
-/** HTTP status for a non-ok remote-view mutate (message via
- *  mutateRemoteViewFailureMessage): 404 for a missing view/record, 403 for a
- *  policy refusal, 400 otherwise. */
-function mutateStatus(kind: string): number {
-  if (kind === "view-not-found" || kind === "item-not-found") return 404;
-  if (kind === "read-only-collection") return 405;
-  if (kind === "not-writable" || kind === "delete-not-allowed" || kind === "field-not-editable" || kind === "path-escape") return 403;
-  return 400;
 }
 
 // ── Route handlers ──────────────────────────────────────────────────────────

--- a/server/backends/mutateStatus.ts
+++ b/server/backends/mutateStatus.ts
@@ -1,0 +1,28 @@
+// HTTP status for a failed remote-view mutate. The phone and the desktop preview branch on
+// it, so it is the machine-readable half of the answer (the sentence being the other half —
+// mutateRemoteViewFailureMessage).
+//
+// The distinctions are the point, and they were previously described wrongly: the doc comment
+// said "404 for a missing view/record, 403 for a policy refusal, 400 otherwise" and never
+// mentioned 405 at all. A `read-only-collection` demoted to 400 tells the client the request
+// was malformed, when in fact no request of that shape can ever succeed against this
+// collection — the caller should stop retrying, not fix its payload.
+
+const NOT_FOUND = 404;
+const METHOD_NOT_ALLOWED = 405;
+const FORBIDDEN = 403;
+const BAD_REQUEST = 400;
+
+// Whatever the collection cannot do at all, regardless of the request.
+const METHOD_NOT_ALLOWED_KINDS = new Set(["read-only-collection"]);
+// The target does not exist.
+const NOT_FOUND_KINDS = new Set(["view-not-found", "item-not-found"]);
+// The target exists and the request is well-formed; policy refuses it.
+const FORBIDDEN_KINDS = new Set(["not-writable", "delete-not-allowed", "field-not-editable", "path-escape"]);
+
+export function mutateStatus(kind: string): number {
+  if (NOT_FOUND_KINDS.has(kind)) return NOT_FOUND;
+  if (METHOD_NOT_ALLOWED_KINDS.has(kind)) return METHOD_NOT_ALLOWED;
+  if (FORBIDDEN_KINDS.has(kind)) return FORBIDDEN;
+  return BAD_REQUEST;
+}

--- a/test/server/backends/mutateStatus.spec.ts
+++ b/test/server/backends/mutateStatus.spec.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { mutateStatus } from "../../../server/backends/mutateStatus.js";
+
+describe("mutateStatus", () => {
+  it.each([["view-not-found"], ["item-not-found"]])("answers 404 for the missing target %s", (kind) => {
+    expect(mutateStatus(kind)).toBe(404);
+  });
+
+  // The branch the old doc comment forgot to mention. It is not a client mistake: no request
+  // of any shape succeeds against a dataSource-backed collection, so the caller should stop
+  // rather than fix its payload.
+  it("answers 405 for a collection that cannot be written at all", () => {
+    expect(mutateStatus("read-only-collection")).toBe(405);
+  });
+
+  it.each([["not-writable"], ["delete-not-allowed"], ["field-not-editable"], ["path-escape"]])("answers 403 for the policy refusal %s", (kind) => {
+    expect(mutateStatus(kind)).toBe(403);
+  });
+
+  it.each([["invalid-patch"], ["invalid-id"], ["too-large"], ["not-mobile"]])("answers 400 for the malformed request %s", (kind) => {
+    expect(mutateStatus(kind)).toBe(400);
+  });
+
+  // 405 is the one an unknown kind must not fall into: it tells the client this collection
+  // can never be written, which is a much stronger claim than "something went wrong".
+  it("answers 400, not 405, for a kind it does not know", () => {
+    expect(mutateStatus("brand-new-failure")).toBe(400);
+  });
+
+  it("keeps the read-only case distinct from every policy refusal", () => {
+    expect(mutateStatus("read-only-collection")).not.toBe(mutateStatus("not-writable"));
+  });
+});


### PR DESCRIPTION
## Summary

`mutateStatus` moves out of `collections.ts` into its own module with tests — and its description is corrected.

The doc comment said:

> 404 for a missing view/record, 403 for a policy refusal, 400 otherwise

…while the code two lines below also returned **405** for `read-only-collection`. A comment that has drifted from its code is how the next reader "simplifies" the branch away.

**405 is worth keeping distinct.** A read-only (dataSource-backed) collection is not a client mistake: no request of any shape will ever succeed against it, so the caller should stop rather than fix its payload. 400 tells them the opposite.

## Items to Confirm / Review

1. **Behaviour is unchanged** — same kind → same status. Only the description and the location changed.
2. **Coverage went from 2 kinds to 11.** The mapping was unexported and reachable only through a route needing a fixture workspace, a discovered collection, a mobile view and a real record; `collections.spec.ts` reaches 200 and one 403.
3. **The unknown-kind case is pinned**: a kind nobody has written yet answers **400, never 405** — the fall-through must not claim "this collection can never be written".

## Checks

`181 files / 2322 tests`, lint 0 errors, `typecheck:server` exit 0, build clean. Removing the 405 branch turns its test red.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)