### PR TITLE
test: cover four pure modules that had none (#598 C)

### DIFF
--- a/test/server/backends/remoteHost/applySkillFilter.spec.ts
+++ b/test/server/backends/remoteHost/applySkillFilter.spec.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { applySkillFilter, type DiscoveredSkill } from "../../../../server/backends/remoteHost/skills.js";
+
+const skill = (slug: string): DiscoveredSkill => ({ slug, description: `${slug} desc` });
+
+// The per-dir Skill-menu allowlist. It decides both WHICH skills a directory offers and in
+// WHAT ORDER — the menu follows the filter, not discovery order — so a regression yields a
+// plausible-looking menu that is quietly wrong.
+describe("applySkillFilter", () => {
+  const skills = [skill("alpha"), skill("beta"), skill("gamma")];
+
+  it("returns everything unchanged when there is no filter", () => {
+    expect(applySkillFilter(skills, null)).toBe(skills);
+  });
+
+  it("keeps only the listed slugs", () => {
+    expect(applySkillFilter(skills, ["gamma", "alpha"]).map((s) => s.slug)).toEqual(["gamma", "alpha"]);
+  });
+
+  // The filter's order wins — that is how a directory puts its most-used skill first.
+  it("follows the filter's order, not discovery order", () => {
+    expect(applySkillFilter(skills, ["gamma", "beta", "alpha"]).map((s) => s.slug)).toEqual(["gamma", "beta", "alpha"]);
+  });
+
+  // A slug the user listed but that no longer exists is dropped, not rendered as a dead entry
+  // that types a slash command nothing answers.
+  it("drops a listed slug that was not discovered", () => {
+    expect(applySkillFilter(skills, ["alpha", "ghost"]).map((s) => s.slug)).toEqual(["alpha"]);
+  });
+
+  it("shows nothing for an empty filter", () => {
+    expect(applySkillFilter(skills, [])).toEqual([]);
+  });
+
+  it("does not invent entries when nothing was discovered", () => {
+    expect(applySkillFilter([], ["alpha"])).toEqual([]);
+  });
+
+  it("does not mutate the list it was given", () => {
+    applySkillFilter(skills, ["gamma"]);
+    expect(skills.map((s) => s.slug)).toEqual(["alpha", "beta", "gamma"]);
+  });
+});

--- a/test/src/components/dirBadge.spec.ts
+++ b/test/src/components/dirBadge.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { badgeStyleFor } from "../../../src/components/dirBadge";
+
+// The badge is how a user tells nine parallel agents apart at a glance, so the contrast
+// decision is functional, not decorative: black text on a dark badge is unreadable in both
+// the grid and the single view.
+describe("badgeStyleFor", () => {
+  it("puts dark text on a bright badge", () => {
+    expect(badgeStyleFor("#ffffff")).toEqual({ background: "#ffffff", color: "#000" });
+  });
+
+  it("puts light text on a dark badge", () => {
+    expect(badgeStyleFor("#000000")).toEqual({ background: "#000000", color: "#fff" });
+  });
+
+  // Perceived brightness, not raw magnitude: the same channel value reads very differently
+  // depending on which channel it is in.
+  it("weighs the channels by how bright they look, not by their value", () => {
+    expect(badgeStyleFor("#80ff80").color).toBe("#000"); // 202.6
+    expect(badgeStyleFor("#8080ff").color).toBe("#fff"); // 142.5
+  });
+
+  // Recorded because it is surprising rather than because it is right: pure green scores
+  // 0.587 x 255 = 149.685, a fraction under the 150 threshold, so a vivid green badge gets
+  // WHITE text. Worth a look if a green badge ever reads as hard to see — the fix would be
+  // the threshold, which changes existing badges, so it is not made here.
+  it("gives pure green light text, just under the threshold", () => {
+    expect(badgeStyleFor("#00ff00").color).toBe("#fff");
+  });
+
+  it("keeps a mid grey on the light side of the threshold", () => {
+    // 0.299·155 + 0.587·155 + 0.114·155 = 155 > 150
+    expect(badgeStyleFor("#9b9b9b").color).toBe("#000");
+    // …and 140 < 150.
+    expect(badgeStyleFor("#8c8c8c").color).toBe("#fff");
+  });
+
+  it("accepts upper-case hex", () => {
+    expect(badgeStyleFor("#FFFFFF")).toEqual({ background: "#FFFFFF", color: "#000" });
+  });
+
+  // Anything that is not a full six-digit hex falls back to the neutral chip rather than
+  // being handed to the browser as a background it may or may not understand.
+  it.each([[null], [undefined], [""], ["#fff"], ["red"], ["#gggggg"], ["#ffffff00"], [" #ffffff"]])("falls back to the neutral chip for %j", (color) => {
+    expect(badgeStyleFor(color)).toEqual({ background: "var(--bg-elevated)", color: "var(--text-secondary)" });
+  });
+
+  it("returns a fresh object each call, so one badge cannot restyle another", () => {
+    const first = badgeStyleFor("#123456");
+    first.background = "mutated";
+    expect(badgeStyleFor("#123456").background).toBe("#123456");
+  });
+});

--- a/test/src/types/shortcuts.spec.ts
+++ b/test/src/types/shortcuts.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+import { sameShortcut } from "../../../src/types/shortcuts";
+
+// The dedupe/removal key for the whole favourites store: unpin, the add-if-absent check, and
+// the reconcile all match on this. Too loose and unpinning one favourite removes another;
+// too tight and the same thing can be pinned twice.
+describe("sameShortcut", () => {
+  it("matches the same kind and slug", () => {
+    expect(sameShortcut({ kind: "collection", slug: "tasks" }, { kind: "collection", slug: "tasks" })).toBe(true);
+  });
+
+  // A collection and a feed may legitimately share a slug — they are different targets, and
+  // matching on slug alone would let one unpin the other.
+  it("does not match the same slug under a different kind", () => {
+    expect(sameShortcut({ kind: "collection", slug: "news" }, { kind: "feed", slug: "news" })).toBe(false);
+  });
+
+  it("does not match different slugs of the same kind", () => {
+    expect(sameShortcut({ kind: "feed", slug: "a" }, { kind: "feed", slug: "b" })).toBe(false);
+  });
+
+  it("is exact, not fuzzy", () => {
+    expect(sameShortcut({ kind: "collection", slug: "tasks" }, { kind: "collection", slug: "Tasks" })).toBe(false);
+    expect(sameShortcut({ kind: "collection", slug: "tasks" }, { kind: "collection", slug: "tasks " })).toBe(false);
+  });
+
+  it("ignores the fields that are not part of the identity", () => {
+    const left = { kind: "collection", slug: "tasks", title: "One", icon: "star" } as const;
+    const right = { kind: "collection", slug: "tasks", title: "Two", icon: "bolt" } as const;
+    expect(sameShortcut(left, right)).toBe(true);
+  });
+});

--- a/test/src/utils/fetchJson.spec.ts
+++ b/test/src/utils/fetchJson.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { fetchJson } from "../../../src/utils/fetchJson";
+
+// Callers branch on `status`: the collection UI treats 404 as "not found" and anything else
+// as "skip". A transport failure reports 0 — there was no response to have a status — and
+// conflating the two would make an offline browser look like a missing collection.
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchJson", () => {
+  it("returns the parsed body on success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ a: 1 }) }));
+    expect(await fetchJson<{ a: number }>("/api/x")).toEqual({ ok: true, data: { a: 1 } });
+  });
+
+  it("reports the HTTP status on an HTTP failure", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: "HTTP 404", status: 404 });
+  });
+
+  // The distinction the callers depend on.
+  it("reports status 0 when the request never reached a server", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Failed to fetch")));
+    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: "Failed to fetch", status: 0 });
+  });
+
+  it("survives a rejection that is not an Error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue("boom"));
+    expect(await fetchJson("/api/x")).toEqual({ ok: false, error: "boom", status: 0 });
+  });
+
+  // A 200 whose body is not JSON must not be reported as success with garbage data.
+  it("fails with status 0 when the body will not parse", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new SyntaxError("Unexpected token");
+        },
+      }),
+    );
+    const result = await fetchJson("/api/x");
+    expect(result).toMatchObject({ ok: false, status: 0 });
+  });
+
+  it("passes the request options through", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchJson("/api/x", { method: "POST" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/x", { method: "POST" });
+  });
+});


### PR DESCRIPTION
## Summary

Four already-pure, already-exported functions with a real decision inside and **no spec anywhere**. Nothing needed extracting — only the tests.

| Module | The decision |
|---|---|
| `src/components/dirBadge.ts` | Black or white text on a project badge — the contrast call that makes nine parallel agents distinguishable |
| `src/utils/fetchJson.ts` | `status: 0` on a transport failure vs the HTTP status on an HTTP failure |
| `src/types/shortcuts.ts` | The dedupe/removal key for the favourites store |
| `server/backends/remoteHost/skills.ts` | The Skill-menu allowlist — a filter **and** an ordering |

Why each matters if it regresses: an unreadable badge; an offline browser that looks like a missing collection; unpinning one favourite removing another (a collection and a feed may share a slug); a Skill menu in the wrong order or with a dead entry that types a slash command nothing answers.

## Items to Confirm / Review — two findings, both recorded rather than changed

1. **Pure green gets white text.** `#00ff00` scores `0.587 x 255 = 149.685` against a threshold of `150`, so a vivid green badge is rendered with **white** text. It is a contrast call worth a look, but the fix would be the threshold, which moves every existing badge — not something to smuggle into a test-only PR. Pinned with a comment saying exactly that.
2. **`fetchJson` reports an unparseable body as `status: 0`**, the same as a transport failure. Defensible — there was no usable response either way — and left as is, now stated by a test.

## Note on my own verification

`yarn typecheck:test` failed on the first pass here (a lazy `as never` in a fixture) and I nearly missed it, because I had been reading the *output* rather than the exit code. Everything in this PR was re-verified by exit code: lint 0, `typecheck` 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `187 files / 2398 tests`.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)