### PR TITLE
refactor: make the cell status precedence testable, and use the one cap (#598 B)

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -33,6 +33,8 @@ import {
   type GridState,
   type CellStatus,
   type Cell,
+  resolveCellStatus,
+  MAX_TERMINALS,
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import { isPrPhase, isWorkPhase, type PrPhase, type WorkPhase } from "./rosterPhase";
@@ -86,14 +88,7 @@ const sessionStatus = computed(() => {
   for (const [id, a] of gridActivity) m.set(id, activityStatus(a.working, a.waiting, a.event));
   return m;
 });
-const statusForSort = computed<Record<number, CellStatus>>(() => {
-  const out: Record<number, CellStatus> = {};
-  for (const c of state.value.cells) {
-    const fromSession = c.session ? sessionStatus.value.get(c.session) : undefined;
-    out[c.uid] = fromSession ?? statusByUid[c.uid] ?? "idle";
-  }
-  return out;
-});
+const statusForSort = computed<Record<number, CellStatus>>(() => resolveCellStatus(state.value.cells, sessionStatus.value, statusByUid));
 // At-a-glance tally across ALL pages, for the toolbar summary.
 const statusCounts = computed(() => countByStatus(state.value.cells, statusForSort.value));
 const reorderable = computed(() => state.value.sortMode === "manual");
@@ -224,7 +219,7 @@ const openCwds = computed(() =>
 );
 
 function onAddTerminal() {
-  if (runningCount(state.value.cells) >= 81 && !launchOpen.value) return; // surfaced by the disabled button
+  if (runningCount(state.value.cells) >= MAX_TERMINALS && !launchOpen.value) return; // surfaced by the disabled button
   state.value = addCell(state.value);
 }
 const onSession = (uid: number, id: string) => (state.value = setSession(state.value, uid, id));

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -322,3 +322,26 @@ export function initialState(curRaw: string | null, legacyRaw: string | null): {
   if (migrated) return { state: migrated, migrated: true };
   return { state: ensureEntry({ cells: [], expanded: null, page: 0, nextUid: 0, sortMode: "manual" }), migrated: false };
 }
+
+// Which status a cell sorts and tallies by.
+//
+// The precedence is the rule: the server's activity for the cell's SESSION wins, because it
+// is the only source that knows a turn is blocked. A cell's own reported status is the
+// fallback — command cells have no session id, and a just-launched cell has none yet — and
+// idle is the floor.
+//
+// This feeds orderCells and countByStatus, so getting it backwards is not cosmetic: in auto
+// mode a blocked cell on page 3 stops floating to page 1, which is the entire point of that
+// mode, and the toolbar's "needs you" tally goes with it.
+export function resolveCellStatus(
+  cells: readonly { uid: number; session: string | null }[],
+  bySession: ReadonlyMap<string, CellStatus>,
+  byUid: Readonly<Record<number, CellStatus>>,
+): Record<number, CellStatus> {
+  const out: Record<number, CellStatus> = {};
+  for (const cell of cells) {
+    const fromSession = cell.session ? bySession.get(cell.session) : undefined;
+    out[cell.uid] = fromSession ?? byUid[cell.uid] ?? "idle";
+  }
+  return out;
+}

--- a/test/src/components/gridTabs.spec.ts
+++ b/test/src/components/gridTabs.spec.ts
@@ -3,6 +3,7 @@ import type { RunCommand } from "../../../src/components/runCommand.js";
 import {
   pageCount,
   pageSlice,
+  resolveCellStatus,
   runningCount,
   addCell,
   setSession,
@@ -454,5 +455,44 @@ describe("parseGridState / migrateLegacy / initialState", () => {
     const fresh = initialState(null, null);
     expect(fresh.state.cells).toHaveLength(1);
     expect(fresh.state.cells[0].session).toBeNull();
+  });
+});
+
+describe("resolveCellStatus", () => {
+  const cell = (uid: number, session: string | null) => ({ uid, session });
+
+  // The server's activity for the cell's session wins: it is the only source that knows a
+  // turn is blocked, which is what auto mode sorts on.
+  it("prefers the session's live status over the cell's own", () => {
+    const out = resolveCellStatus([cell(1, "s1")], new Map<string, CellStatus>([["s1", "blocked"]]), { 1: "working" });
+    expect(out[1]).toBe("blocked");
+  });
+
+  // Command cells have no session id, and a just-launched cell has none yet — without the
+  // fallback they would read idle and sort past cells that need nothing.
+  it("falls back to the cell's own status when it has no session", () => {
+    expect(resolveCellStatus([cell(2, null)], new Map<string, CellStatus>(), { 2: "working" })[2]).toBe("working");
+  });
+
+  it("falls back when the session has no activity yet", () => {
+    expect(resolveCellStatus([cell(3, "unknown")], new Map<string, CellStatus>(), { 3: "working" })[3]).toBe("working");
+  });
+
+  it("lands on idle when nothing knows anything", () => {
+    expect(resolveCellStatus([cell(4, null)], new Map<string, CellStatus>(), {})[4]).toBe("idle");
+  });
+
+  it("answers for every cell, not just the ones with activity", () => {
+    const out = resolveCellStatus([cell(1, "s1"), cell(2, null), cell(3, "s3")], new Map<string, CellStatus>([["s1", "blocked"]]), {});
+    expect(Object.keys(out).sort()).toEqual(["1", "2", "3"]);
+  });
+
+  it("keys by uid, so two cells on the same session can still differ elsewhere", () => {
+    const out = resolveCellStatus([cell(1, "s1"), cell(2, "s1")], new Map<string, CellStatus>([["s1", "working"]]), {});
+    expect([out[1], out[2]]).toEqual(["working", "working"]);
+  });
+
+  it("returns an empty map for no cells", () => {
+    expect(resolveCellStatus([], new Map<string, CellStatus>(), {})).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

Two things in `GridView.vue`.

**1. `statusForSort` → `resolveCellStatus` in `gridTabs.ts`.** It is the sole input to `orderCells` and `countByStatus` and had **no coverage** — `GridView.spec.ts` is 71 lines and tests only the settings wiring. Getting the precedence backwards is not cosmetic: in auto mode a blocked cell on page 3 stops floating to page 1, which is the entire point of that mode, and the toolbar's "needs you" tally goes with it.

The rule lands in the module that already owns `CellStatus` and the ordering that consumes it. Session activity wins (it is the only source that knows a turn is blocked); the cell's own status is the fallback for command cells and for a cell that has not been given a session id yet.

**2. The terminal cap had two sources of truth.** `GridView.vue` hardcoded `>= 81` while importing from `gridTabs`, which exports `MAX_TERMINALS = 81` and uses it in the two functions that actually add cells — so the guard and the thing it guards could drift.

## Items to Confirm / Review

- Behaviour unchanged in both cases; inverting the precedence turns a test red.
- The cap change is a no-op today (both are 81) — it is about the next time one of them moves.

## Note

Two mistakes of mine were caught by `typecheck:test`, not by the test run: a `Map` narrowed to a literal type, and — more usefully — **`"waiting"` is not a `CellStatus`** (the values are `blocked | done | working | idle`). I had written tests against a status that does not exist and they passed, because the map was only read back through the same wrong assumption. Verified here by exit code: lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `187 files / 2405 tests`.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)