### PR TITLE
refactor: make the launch directory rules testable (#598 B)

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -7,6 +7,7 @@ import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
 import { unsavedWork } from "./unsavedWork";
+import { preferredLaunchDir, shouldSyncLaunchDir } from "./launchDir";
 import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 import GitBranchChip from "./GitBranchChip.vue";
 import ModelContextBadge from "./ModelContextBadge.vue";
@@ -118,12 +119,12 @@ const filmstrip = computed(() => !!props.zoomed && !props.expanded);
 // recent preset, then the server default. Both `presets` and `defaultCwd` arrive
 // async from /api/config, so the watcher upgrades a still-pristine field once they
 // load (cold-load / open-before-config) — it never clobbers the user's own edit.
-const dirInput = ref(props.initialCwd ?? props.presets[0]?.path ?? props.defaultCwd ?? "");
+const dirInput = ref(preferredLaunchDir(props));
 const dirTouched = ref(false); // true once the user types in / picks a dir
 watch([() => props.presets, () => props.defaultCwd], () => {
   if (cwd.value === null && props.defaultCwd) cwd.value = props.defaultCwd;
-  if (props.initialCwd || dirTouched.value || launched.value) return;
-  const preferred = props.presets[0]?.path ?? props.defaultCwd;
+  if (!shouldSyncLaunchDir({ hasInitialCwd: !!props.initialCwd, touched: dirTouched.value, launched: launched.value })) return;
+  const preferred = preferredLaunchDir({ presets: props.presets, defaultCwd: props.defaultCwd });
   if (preferred && dirInput.value !== preferred) dirInput.value = preferred;
 });
 

--- a/src/components/launchDir.ts
+++ b/src/components/launchDir.ts
@@ -1,0 +1,35 @@
+// Which directory the launch form offers, and when it may be changed for the user.
+//
+// The consequence of getting either wrong is the same: the user presses Enter and starts an
+// agent in the wrong repository. `presets` and `defaultCwd` arrive asynchronously from
+// /api/config, so a cell opened before that lands starts with a blank or stale field and has
+// to be upgraded when it arrives — without ever overwriting the path the user just typed.
+
+export interface LaunchDirSources {
+  // This cell's persisted directory, restored from the grid layout.
+  initialCwd?: string | null;
+  // The user's recent directories, most recent first.
+  presets: readonly { path: string }[];
+  // The server's workspace default.
+  defaultCwd?: string | null;
+}
+
+// Persisted cell dir → most recent preset → server default → empty.
+export function preferredLaunchDir({ initialCwd, presets, defaultCwd }: LaunchDirSources): string {
+  return initialCwd ?? presets[0]?.path ?? defaultCwd ?? "";
+}
+
+export interface LaunchDirSyncFacts {
+  // A cell restored with its own directory already knows better than any default.
+  hasInitialCwd: boolean;
+  // The user typed in or picked a directory — never overwrite that.
+  touched: boolean;
+  // The cell already launched; its field is history.
+  launched: boolean;
+}
+
+// Whether late-arriving config may still upgrade the field. The `touched` guard is the one
+// that matters most: config can land one keystroke before the user hits Go.
+export function shouldSyncLaunchDir({ hasInitialCwd, touched, launched }: LaunchDirSyncFacts): boolean {
+  return !hasInitialCwd && !touched && !launched;
+}

--- a/test/src/components/launchDir.spec.ts
+++ b/test/src/components/launchDir.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import { preferredLaunchDir, shouldSyncLaunchDir } from "../../../src/components/launchDir";
+
+const preset = (path: string) => ({ path });
+
+// Get either of these wrong and the user presses Enter and starts an agent in the wrong
+// repository.
+describe("preferredLaunchDir", () => {
+  it("prefers the cell's own persisted directory", () => {
+    expect(preferredLaunchDir({ initialCwd: "/work/mine", presets: [preset("/work/other")], defaultCwd: "/home" })).toBe("/work/mine");
+  });
+
+  it("falls back to the most recent preset", () => {
+    expect(preferredLaunchDir({ presets: [preset("/work/recent"), preset("/work/older")], defaultCwd: "/home" })).toBe("/work/recent");
+  });
+
+  it("falls back to the server default when there are no presets", () => {
+    expect(preferredLaunchDir({ presets: [], defaultCwd: "/home" })).toBe("/home");
+  });
+
+  it("offers an empty field when nothing is known", () => {
+    expect(preferredLaunchDir({ presets: [] })).toBe("");
+  });
+
+  // Null is what an unset persisted dir looks like — it must fall through, not win.
+  it("treats a null persisted dir as unset", () => {
+    expect(preferredLaunchDir({ initialCwd: null, presets: [preset("/work/recent")] })).toBe("/work/recent");
+  });
+});
+
+describe("shouldSyncLaunchDir", () => {
+  const fresh = { hasInitialCwd: false, touched: false, launched: false };
+
+  // The upgrade this exists for: a cell opened before /api/config landed starts blank.
+  it("upgrades a pristine field when config finally arrives", () => {
+    expect(shouldSyncLaunchDir(fresh)).toBe(true);
+  });
+
+  // The guard that matters most — config can land one keystroke before the user hits Go.
+  it("never overwrites a directory the user typed", () => {
+    expect(shouldSyncLaunchDir({ ...fresh, touched: true })).toBe(false);
+  });
+
+  it("leaves a restored cell's own directory alone", () => {
+    expect(shouldSyncLaunchDir({ ...fresh, hasInitialCwd: true })).toBe(false);
+  });
+
+  it("does not touch a cell that already launched", () => {
+    expect(shouldSyncLaunchDir({ ...fresh, launched: true })).toBe(false);
+  });
+
+  it("stays put when several reasons apply", () => {
+    expect(shouldSyncLaunchDir({ hasInitialCwd: true, touched: true, launched: true })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two expressions of one rule, previously split across a `ref` initializer and a watcher over async props:

- **`preferredLaunchDir`** — persisted cell dir → most recent preset → server default → empty
- **`shouldSyncLaunchDir`** — whether late-arriving `/api/config` may still upgrade the field

Getting either wrong has the same consequence: the user presses Enter and **starts an agent in the wrong repository**.

They were covered only by three full mounts that fake the config arrival ordering; the permutations of the sources were never asserted directly, and neither were the three guards individually.

## Items to Confirm / Review

1. **Behaviour unchanged.** Same precedence, same guards, same "only upgrade a pristine field" semantics.
2. **The `touched` guard is the load-bearing one** — config can land one keystroke before the user hits Go. Removing it turns a test red.
3. The watcher's unrelated first line (`if (cwd.value === null && props.defaultCwd) cwd.value = props.defaultCwd`) is left exactly where it was; it is about the cell's resolved cwd, not the form field.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `188 files / 2415 tests` — all verified by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)