### PR TITLE
refactor: 翻訳ワーカーのツール遮断をテスト可能にする (#611 A1)

### DIFF
--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -27,6 +27,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "node:crypto";
 import { toolDefinitions } from "../infra/plugins-registry.js";
+import { offeredTools, routeToolCall, SUBMIT_TRANSLATION_TOOL_NAME } from "./tool-gate.js";
 
 // Shape of the dispatch route's response (POST /api/plugin/<tool>). `data` gates
 // whether a toolResult is published to the GUI; the rest is narration/metadata.
@@ -50,20 +51,13 @@ async function postJson(url: string, body: unknown) {
   return res;
 }
 
-// A ToolDefinition's optional `prompt` is host-injected usage guidance that isn't
-// part of the JSON-schema sent to the model; fold it into the description so claude
-// still sees it (MulmoClaude does the same).
-function describe(def: { description?: string; prompt?: string }) {
-  return [def.description, def.prompt].filter(Boolean).join("\n\n");
-}
-
 // The worker-only result tool used by the hidden translation chat (see
 // translateViaHiddenChat in server/index.ts). It is NOT a plugin: the worker calls it
 // to hand its structured answer straight back, so the broker special-cases it (POST
 // to /api/translation/submit WITH the session id) instead of the /api/plugin path.
 // Advertised only when `submitTranslationTool` is set, so normal chats never see it.
 const SUBMIT_TRANSLATION_TOOL = {
-  name: "submitTranslation",
+  name: SUBMIT_TRANSLATION_TOOL_NAME,
   description:
     "Report the finished translation. Call this EXACTLY ONCE with a `translations` array of the " +
     "translated strings, in the same order and length as the input. This is the only way to return " +
@@ -88,34 +82,27 @@ const SUBMIT_TRANSLATION_TOOL = {
 export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { submitTranslationTool?: boolean } = {}): Server {
   const server = new Server({ name: "mulmoterminal-gui", version: "0.0.0" }, { capabilities: { tools: {} } });
 
-  // A hidden translation worker processes UNTRUSTED sentence content with its tools
-  // auto-allowed, so a prompt-injected string must not be able to reach the regular
-  // GUI/plugin tools. Such sessions are therefore exposed ONLY submitTranslation —
-  // every other tool is hidden AND refused below (defense in depth).
+  // Both layers of the worker gate live in mcp/tool-gate.ts (pure/tested): a worker is
+  // offered submitTranslation alone, and anything else it names is refused below.
+  const isWorker = !!opts.submitTranslationTool;
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: opts.submitTranslationTool
-      ? [SUBMIT_TRANSLATION_TOOL]
-      : toolDefinitions.map((def) => ({
-          name: def.name,
-          description: describe(def),
-          inputSchema: def.parameters ?? { type: "object", properties: {} },
-        })),
+    tools: offeredTools(isWorker, toolDefinitions, SUBMIT_TRANSLATION_TOOL),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
+    const route = routeToolCall(name, isWorker);
+
     // Worker-only result tool: deliver the structured translations back to the
     // waiting request (keyed by session id), bypassing the plugin dispatch path.
-    if (name === SUBMIT_TRANSLATION_TOOL.name) {
+    if (route.kind === "submit-translation") {
       await postJson(`${baseUrl}/api/translation/submit`, { sessionId, translations: isRecord(args) ? args.translations : undefined });
       return { content: [{ type: "text", text: "Translation received. You are done." }] };
     }
 
-    // Translation workers may call NOTHING else — refuse any other tool even if the
-    // model is steered toward it by injected sentence content.
-    if (opts.submitTranslationTool) {
-      return { content: [{ type: "text", text: `Tool "${name}" is not available; call submitTranslation with the translations.` }], isError: true };
+    if (route.kind === "refused") {
+      return { content: [{ type: "text", text: route.message }], isError: true };
     }
 
     // 1. Dispatch to the plugin's server-side handler.

--- a/server/mcp/tool-gate.ts
+++ b/server/mcp/tool-gate.ts
@@ -49,9 +49,15 @@ export type ToolRoute =
   | { kind: "dispatch" };
 
 export function routeToolCall(name: string, isTranslationWorker: boolean): ToolRoute {
-  if (name === SUBMIT_TRANSLATION_TOOL_NAME) return { kind: "submit-translation" };
+  const isWorkerTool = name === SUBMIT_TRANSLATION_TOOL_NAME;
   if (isTranslationWorker) {
+    if (isWorkerTool) return { kind: "submit-translation" };
     return { kind: "refused", message: `Tool "${name}" is not available; call submitTranslation with the translations.` };
   }
+  // The hand-off is the worker's, and an ordinary session is never offered it. Naming it
+  // anyway is refused rather than dispatched: what stops it today is that the session has no
+  // translation pending, which is a 404 from another module rather than a decision made here
+  // — and the layer above already assumes a model can name a tool it was never shown.
+  if (isWorkerTool) return { kind: "refused", message: `Tool "${name}" is not available.` };
   return { kind: "dispatch" };
 }

--- a/server/mcp/tool-gate.ts
+++ b/server/mcp/tool-gate.ts
@@ -1,0 +1,57 @@
+// Which tools a session may see, and what happens when it calls one.
+//
+// The rule that matters here is a security boundary, not a convenience. A hidden
+// translation worker is fed UNTRUSTED sentence content — collection entries, custom-view
+// strings — and its tools are auto-allowed, so it never stops at a permission prompt. A
+// string that talks the model into calling `manageCollection` must therefore find nothing
+// to call: the worker is offered submitTranslation ALONE, and any other name is refused
+// even though it was never advertised. Two layers, because the first one is only a list and
+// a model can name a tool it was not shown.
+//
+// Split out of broker.ts because both rules previously lived inside MCP request handlers,
+// reachable only by standing up a server and speaking JSON-RPC to it — so neither had a
+// test (#611 A1).
+
+// The shape the broker registers, structurally rather than by import, so this file stays
+// free of the plugin registry (and of everything the registry loads).
+export interface PluginToolDefinition {
+  name: string;
+  description?: string;
+  prompt?: string;
+  parameters?: unknown;
+}
+
+export interface OfferedTool {
+  name: string;
+  description: string;
+  inputSchema: unknown;
+}
+
+export const SUBMIT_TRANSLATION_TOOL_NAME = "submitTranslation";
+
+// An empty object schema, for a definition that declares no parameters — MCP requires the
+// field, and omitting it makes some clients drop the tool.
+const NO_PARAMETERS = { type: "object", properties: {} };
+
+// A definition's `prompt` is host-injected usage guidance that is not part of the schema the
+// model receives, so it is folded into the description or the model never sees it.
+export const describeTool = (def: PluginToolDefinition): string => [def.description, def.prompt].filter(Boolean).join("\n\n");
+
+export function offeredTools(isTranslationWorker: boolean, plugins: readonly PluginToolDefinition[], workerTool: OfferedTool): OfferedTool[] {
+  if (isTranslationWorker) return [workerTool];
+  return plugins.map((def) => ({ name: def.name, description: describeTool(def), inputSchema: def.parameters ?? NO_PARAMETERS }));
+}
+
+export type ToolRoute =
+  | { kind: "submit-translation" }
+  | { kind: "refused"; message: string }
+  // Hand off to the plugin dispatch route.
+  | { kind: "dispatch" };
+
+export function routeToolCall(name: string, isTranslationWorker: boolean): ToolRoute {
+  if (name === SUBMIT_TRANSLATION_TOOL_NAME) return { kind: "submit-translation" };
+  if (isTranslationWorker) {
+    return { kind: "refused", message: `Tool "${name}" is not available; call submitTranslation with the translations.` };
+  }
+  return { kind: "dispatch" };
+}

--- a/test/server/mcp/tool-gate.spec.ts
+++ b/test/server/mcp/tool-gate.spec.ts
@@ -80,12 +80,18 @@ describe("the translation worker's tool gate", () => {
       expect(routeToolCall("anything-at-all", false)).toEqual({ kind: "dispatch" });
     });
 
-    // Current behaviour, pinned rather than endorsed: the submit branch is checked before
-    // the worker branch, so an ordinary session that guesses the name reaches it too. It
-    // can only ever submit for its OWN session id (the broker captures it), and with no
-    // translation pending that answers 404 — but "worker-only" is not what the code enforces.
-    it("also reaches the submit path if it names the worker tool", () => {
-      expect(routeToolCall(SUBMIT_TRANSLATION_TOOL_NAME, false)).toEqual({ kind: "submit-translation" });
+    // The tool is not offered to an ordinary session, so naming it is the same move the
+    // refusal above exists for. What used to stop it was the session having no translation
+    // pending — a 404 raised elsewhere, not a decision taken here.
+    it("is refused the worker-only tool rather than reaching the hand-off", () => {
+      expect(routeToolCall(SUBMIT_TRANSLATION_TOOL_NAME, false).kind).toBe("refused");
+    });
+
+    // The worker's refusal tells it to call submitTranslation instead; saying that to a
+    // session that has no such tool would send it back for another try at the same wall.
+    it("is not told to call submitTranslation instead", () => {
+      const route = routeToolCall(SUBMIT_TRANSLATION_TOOL_NAME, false);
+      expect(route.kind === "refused" && route.message).toBe('Tool "submitTranslation" is not available.');
     });
   });
 

--- a/test/server/mcp/tool-gate.spec.ts
+++ b/test/server/mcp/tool-gate.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  offeredTools,
+  routeToolCall,
+  describeTool,
+  SUBMIT_TRANSLATION_TOOL_NAME,
+  type PluginToolDefinition,
+  type OfferedTool,
+} from "../../../server/mcp/tool-gate.js";
+
+const WORKER_TOOL: OfferedTool = {
+  name: SUBMIT_TRANSLATION_TOOL_NAME,
+  description: "Report the finished translation.",
+  inputSchema: { type: "object", properties: { translations: { type: "array" } } },
+};
+
+const PLUGINS: PluginToolDefinition[] = [
+  { name: "manageCollection", description: "Read and write collections.", parameters: { type: "object", properties: { action: { type: "string" } } } },
+  { name: "presentHtml", description: "Show an HTML artifact.", prompt: "Prefer this over printing HTML.", parameters: { type: "object" } },
+  { name: "spawnBackgroundChat", description: "Start another session." },
+];
+
+const names = (tools: OfferedTool[]) => tools.map((tool) => tool.name);
+
+// A hidden translation worker is fed untrusted sentence content with its tools auto-allowed,
+// so nothing stops it at a permission prompt. These two rules are what keeps an injected
+// string from reaching a real tool.
+describe("the translation worker's tool gate", () => {
+  describe("what a worker is offered", () => {
+    it("offers the worker exactly one tool", () => {
+      expect(offeredTools(true, PLUGINS, WORKER_TOOL)).toEqual([WORKER_TOOL]);
+    });
+
+    it("offers a worker no plugin tool, however many there are", () => {
+      expect(names(offeredTools(true, PLUGINS, WORKER_TOOL))).not.toContain("manageCollection");
+      expect(offeredTools(true, PLUGINS, WORKER_TOOL)).toHaveLength(1);
+    });
+  });
+
+  describe("what a worker may call", () => {
+    it("lets it report its translation", () => {
+      expect(routeToolCall(SUBMIT_TRANSLATION_TOOL_NAME, true)).toEqual({ kind: "submit-translation" });
+    });
+
+    // The second layer: the list is only a list, and a model can name a tool it was never
+    // shown — the name is exactly what an injected string would supply.
+    it.each(["manageCollection", "spawnBackgroundChat", "presentHtml", "manageAccounting"])("refuses %s even though it was never offered", (name) => {
+      const route = routeToolCall(name, true);
+      expect(route.kind).toBe("refused");
+    });
+
+    it("names the refused tool, so the model can tell what it did wrong", () => {
+      const route = routeToolCall("manageCollection", true);
+      expect(route.kind === "refused" && route.message).toContain("manageCollection");
+      expect(route.kind === "refused" && route.message).toContain("submitTranslation");
+    });
+
+    // Near-misses matter: the check is an exact match, so anything that merely looks like
+    // the worker tool has to fall through to the refusal rather than the submit path.
+    it.each(["submitTranslations", "SubmitTranslation", "submit_translation", " submitTranslation", "submitTranslation ", ""])(
+      "refuses the look-alike %o",
+      (name) => {
+        expect(routeToolCall(name, true).kind).toBe("refused");
+      },
+    );
+  });
+
+  describe("an ordinary session is unaffected", () => {
+    it("is offered every plugin, in order", () => {
+      expect(names(offeredTools(false, PLUGINS, WORKER_TOOL))).toEqual(["manageCollection", "presentHtml", "spawnBackgroundChat"]);
+    });
+
+    it("is not offered the worker-only tool", () => {
+      expect(names(offeredTools(false, PLUGINS, WORKER_TOOL))).not.toContain(SUBMIT_TRANSLATION_TOOL_NAME);
+    });
+
+    it("dispatches whatever it calls", () => {
+      expect(routeToolCall("manageCollection", false)).toEqual({ kind: "dispatch" });
+      expect(routeToolCall("anything-at-all", false)).toEqual({ kind: "dispatch" });
+    });
+
+    // Current behaviour, pinned rather than endorsed: the submit branch is checked before
+    // the worker branch, so an ordinary session that guesses the name reaches it too. It
+    // can only ever submit for its OWN session id (the broker captures it), and with no
+    // translation pending that answers 404 — but "worker-only" is not what the code enforces.
+    it("also reaches the submit path if it names the worker tool", () => {
+      expect(routeToolCall(SUBMIT_TRANSLATION_TOOL_NAME, false)).toEqual({ kind: "submit-translation" });
+    });
+  });
+
+  describe("edge cases in the offered list", () => {
+    it("offers nothing when no plugin is enabled", () => {
+      expect(offeredTools(false, [], WORKER_TOOL)).toEqual([]);
+    });
+
+    it("still offers the worker its tool when no plugin is enabled", () => {
+      expect(offeredTools(true, [], WORKER_TOOL)).toEqual([WORKER_TOOL]);
+    });
+
+    // MCP requires the field, and a tool without one is dropped by some clients.
+    it("gives a definition with no parameters an empty object schema", () => {
+      const [, , noParams] = offeredTools(false, PLUGINS, WORKER_TOOL);
+      expect(noParams.inputSchema).toEqual({ type: "object", properties: {} });
+    });
+
+    it("passes a declared schema through untouched", () => {
+      const [collection] = offeredTools(false, PLUGINS, WORKER_TOOL);
+      expect(collection.inputSchema).toEqual(PLUGINS[0].parameters);
+    });
+  });
+});
+
+// The host's usage guidance is not part of the schema the model receives, so it only reaches
+// the model by riding in the description.
+describe("describeTool", () => {
+  it("folds the prompt in after the description", () => {
+    expect(describeTool({ name: "x", description: "What it does.", prompt: "When to use it." })).toBe("What it does.\n\nWhen to use it.");
+  });
+
+  it("leaves a description without a prompt alone", () => {
+    expect(describeTool({ name: "x", description: "What it does." })).toBe("What it does.");
+  });
+
+  it("uses the prompt alone when there is no description", () => {
+    expect(describeTool({ name: "x", prompt: "When to use it." })).toBe("When to use it.");
+  });
+
+  it("produces an empty string when there is neither", () => {
+    expect(describeTool({ name: "x" })).toBe("");
+  });
+});


### PR DESCRIPTION
Refs #611

## Summary

`server/mcp/broker.ts` には **spec が 1 件も存在せず**、その中に**セキュリティ境界が 2 層**入っていました。

隠し翻訳ワーカーは、コレクション項目やカスタムビュー由来の**信頼できない文字列**を処理します。しかもツールは auto-allow なので、**権限プロンプトで止まりません**。注入された文字列が `manageCollection` などに到達するのを防いでいるのが、この 2 つです。

| 層 | ルール |
|---|---|
| ① | ワーカーには `submitTranslation` **1 つだけ**を広告する |
| ② | それ以外の名前を呼ばれたら**拒否**する（広告していなくても） |

②が必要なのは、**一覧はあくまで一覧**であり、モデルは見せられていないツール名を口にできるからです。名前こそが注入文字列が供給するものです。

どちらも MCP のリクエストハンドラの中にあり、**サーバを起動して JSON-RPC を話さないと通らない**位置にありました。`server/mcp/tool-gate.ts` に両方を出し、プラグイン定義は構造的に受け取る形（レジストリを import しない）にしてテスト可能にしています。

**テスト 26 件**。`broker.ts` は 24 行削減。

## Items to Confirm / Review

1. **判断してほしい既存挙動が 1 つあります**（下記「現状維持にした点」）
2. `describeTool`（プラグインの `prompt` を description に畳み込む処理）も一緒に移しました。モデルに host 側の使い方ガイダンスが届く唯一の経路なので、消えると気づきにくいためです
3. `tool-gate.ts` がプラグインレジストリを import しない設計にしています（レジストリは plugins.json を読んで実際にプラグインをロードするため、import するとテストがそれに引きずられる）

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| ワーカーにプラグイン一覧も見せる（①を破る） | 2 件 |
| 拒否をやめて通常ディスパッチさせる（②を破る） | **10 件超** |
| 名前の一致を完全一致 → 前方一致に緩める | 2 件（`submitTranslations` と末尾スペース） |

3 つ目は、`submitTranslation` に似た名前が submit 経路に滑り込まないことを守るテストです。

## 現状維持にした点（判断をお願いします）

**submit 分岐が worker 判定より先にあります。**

```ts
if (name === SUBMIT_TRANSLATION_TOOL_NAME) return { kind: "submit-translation" };  // ← ワーカーかどうかを見ていない
if (isTranslationWorker) return { kind: "refused", ... };
```

つまり**通常セッションでも、名前を当てれば submit 経路に到達できます**。ただし:

- ブローカーは session id を URL から取得して閉じ込めているので、**他人のセッションに対しては submit できません**
- 自分のセッションには保留中の翻訳が無いので、`/api/translation/submit` は 404 を返します（実害なし）

**漏れはありませんが、「worker-only」というコメントが言っていることをコードは強制していません。** 現状の挙動をテストで固定したうえで、そのまま残しています。`isTranslationWorker` でゲートする方が意図に合うなら、この PR で直せます（通常セッションには「利用できません」という拒否が返るようになるだけです）。

## User Prompt

> 他にももっとテストできるものがないか全部調べて〜〜。pure関数マニア。codexにも。

調査結果は #611 にまとめました。この PR はその A1 です。#598（`routes/` `backends/` `src/` が対象）とは範囲が重なりません。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:server` / `typecheck:test` / `yarn build` / `yarn test`（188 files, 2424 tests）/ `yarn knip` すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
