### PR TITLE
refactor: make the voice-clip admission chain testable (#598 B)

### DIFF
--- a/server/backends/audioAdmission.ts
+++ b/server/backends/audioAdmission.ts
@@ -1,0 +1,62 @@
+// Whether a voice clip may be transcribed, and in what language.
+//
+// Unreachable from a test where it lived: the route bails with 503 unless the host is macOS
+// with whisper-server and ffmpeg on PATH, so CI never got past the first line of the handler
+// — while these are the checks that decide whether holding the mic button for fifty seconds
+// works or returns a bare 413 the UI cannot explain.
+//
+// The ORDER is part of the rule. The raw data-URL cap runs before decoding so a giant
+// payload is refused without first being expanded into memory; the post-decode cap then
+// bounds what actually reaches ffmpeg.
+
+// ~60s of opus. The cap bounds resource use against a client that bypassed the UI.
+export const MAX_AUDIO_BYTES = 10 * 1024 * 1024;
+// base64 is ~+33%, so this is a deliberately loose pre-decode bound.
+export const MAX_DATAURL_CHARS = MAX_AUDIO_BYTES * 3;
+
+const BAD_REQUEST = 400;
+const PAYLOAD_TOO_LARGE = 413;
+
+export interface AudioParts {
+  mimeType: string;
+  base64: string;
+}
+
+export type AudioAdmission = { ok: true; parts: AudioParts } | { ok: false; status: number; error: string };
+
+/** Parse a `data:<mime>;base64,<payload>` URL. Null for anything else. Hand-parsed (no
+ *  regex) to sidestep catastrophic-backtracking concerns on attacker-sized input. */
+export function parseDataUrl(dataUrl: string): AudioParts | null {
+  if (!dataUrl.startsWith("data:")) return null;
+  const comma = dataUrl.indexOf(",");
+  if (comma === -1) return null;
+  const header = dataUrl.slice("data:".length, comma);
+  if (!header.includes(";base64")) return null;
+  const mimeType = header.split(";")[0] || "application/octet-stream";
+  return { mimeType, base64: dataUrl.slice(comma + 1) };
+}
+
+/** Decoded size, without decoding. */
+export function approxBytes(base64: string): number {
+  return Math.floor((base64.length * 3) / 4);
+}
+
+export function admitAudioClip(dataUrl: unknown): AudioAdmission {
+  if (typeof dataUrl !== "string" || !dataUrl) return { ok: false, status: BAD_REQUEST, error: "dataUrl is required" };
+  if (dataUrl.length > MAX_DATAURL_CHARS) return { ok: false, status: PAYLOAD_TOO_LARGE, error: "audio clip exceeds the size limit" };
+  const parts = parseDataUrl(dataUrl);
+  if (!parts) return { ok: false, status: BAD_REQUEST, error: "dataUrl must be a base64 data: URI" };
+  if (approxBytes(parts.base64) > MAX_AUDIO_BYTES) return { ok: false, status: PAYLOAD_TOO_LARGE, error: "audio clip exceeds the size limit" };
+  return { ok: true, parts };
+}
+
+/** A whisper language code, or "auto" to detect from the audio. Anything that is not a short
+ *  code falls back rather than being handed to whisper — but note the length bound also
+ *  downgrades legitimate longer tags like `zh-Hant`, which silently costs transcription
+ *  quality rather than failing visibly. */
+const MAX_LANGUAGE_CODE_LENGTH = 5;
+
+export function normalizeLanguage(language: unknown): string {
+  if (typeof language === "string" && language.length > 0 && language.length <= MAX_LANGUAGE_CODE_LENGTH) return language;
+  return "auto";
+}

--- a/server/backends/whisper.ts
+++ b/server/backends/whisper.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import { existsSync } from "node:fs";
 import type { Express, Request, Response } from "express";
 import { createWhisper, DEFAULT_WHISPER_MODEL, type WhisperLogger, type WhisperModelName } from "@mulmoclaude/core/whisper";
+import { admitAudioClip, normalizeLanguage } from "./audioAdmission.js";
 
 const log: WhisperLogger = {
   info: (message, data) => console.log(`[whisper] ${message}`, data ?? ""),
@@ -30,12 +31,6 @@ function service(): ReturnType<typeof createWhisper> {
   if (!whisper) throw new Error("whisper backend not mounted");
   return whisper;
 }
-
-// 10 MB decoded audio is ~60 s of opus; the cap just bounds resource use against a
-// bypassed client. The raw data-URL cap (base64 ~+33%) is applied before decoding
-// so an oversized payload is rejected without first allocating the decoded buffer.
-const MAX_AUDIO_BYTES = 10 * 1024 * 1024;
-const MAX_DATAURL_CHARS = MAX_AUDIO_BYTES * 3;
 
 // Probe a binary once (memoized) by scanning PATH for an executable of that name —
 // no child process. Binaries don't appear mid-session, so caching is safe and keeps
@@ -102,34 +97,6 @@ export function stopWhisperSidecar(): void {
   whisper?.shutdown();
 }
 
-interface DataUrlParts {
-  mimeType: string;
-  base64: string;
-}
-
-/** Parse a `data:<mime>;base64,<payload>` URL. Returns null for anything else.
- *  Hand-parsed (no regex) to sidestep catastrophic-backtracking concerns. */
-function parseDataUrl(dataUrl: string): DataUrlParts | null {
-  if (!dataUrl.startsWith("data:")) return null;
-  const comma = dataUrl.indexOf(",");
-  if (comma === -1) return null;
-  const header = dataUrl.slice("data:".length, comma);
-  if (!header.includes(";base64")) return null;
-  const mimeType = header.split(";")[0] || "application/octet-stream";
-  return { mimeType, base64: dataUrl.slice(comma + 1) };
-}
-
-/** Whisper language code or "auto". Keep short codes; anything else falls back to
- *  auto-detection from the audio. */
-function normalizeLanguage(language: unknown): string {
-  if (typeof language === "string" && language.length > 0 && language.length <= 5) return language;
-  return "auto";
-}
-
-function approxBytes(base64: string): number {
-  return Math.floor((base64.length * 3) / 4);
-}
-
 interface TranscribeBody {
   dataUrl?: string;
   language?: string;
@@ -141,29 +108,15 @@ async function handleTranscribe(req: Request<object, unknown, TranscribeBody>, r
     return;
   }
   const { dataUrl, language } = req.body ?? {};
-  if (typeof dataUrl !== "string" || !dataUrl) {
-    res.status(400).json({ error: "dataUrl is required" });
-    return;
-  }
-  // Bound the raw payload BEFORE decoding so a giant data URL can't be expanded
-  // into memory ahead of the post-decode cap.
-  if (dataUrl.length > MAX_DATAURL_CHARS) {
-    res.status(413).json({ error: "audio clip exceeds the size limit" });
-    return;
-  }
-  const parsed = parseDataUrl(dataUrl);
-  if (!parsed) {
-    res.status(400).json({ error: "dataUrl must be a base64 data: URI" });
-    return;
-  }
-  if (approxBytes(parsed.base64) > MAX_AUDIO_BYTES) {
-    res.status(413).json({ error: "audio clip exceeds the size limit" });
+  const admitted = admitAudioClip(dataUrl);
+  if (!admitted.ok) {
+    res.status(admitted.status).json({ error: admitted.error });
     return;
   }
   try {
     const { text } = await service().transcribe({
-      base64: parsed.base64,
-      mimeType: parsed.mimeType,
+      base64: admitted.parts.base64,
+      mimeType: admitted.parts.mimeType,
       language: normalizeLanguage(language),
       model: selectedModel(),
     });

--- a/test/server/backends/audioAdmission.spec.ts
+++ b/test/server/backends/audioAdmission.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { admitAudioClip, approxBytes, MAX_AUDIO_BYTES, MAX_DATAURL_CHARS, normalizeLanguage, parseDataUrl } from "../../../server/backends/audioAdmission.js";
+
+const dataUrl = (base64: string, header = "audio/webm;base64") => `data:${header},${base64}`;
+
+describe("admitAudioClip", () => {
+  it("admits a well-formed clip and hands back its parts", () => {
+    expect(admitAudioClip(dataUrl("AAAA"))).toEqual({ ok: true, parts: { mimeType: "audio/webm", base64: "AAAA" } });
+  });
+
+  it.each([[undefined], [null], [""], [42], [{}]])("refuses %j with 400", (value) => {
+    expect(admitAudioClip(value)).toEqual({ ok: false, status: 400, error: "dataUrl is required" });
+  });
+
+  // Order matters: this bound exists so a giant payload is refused WITHOUT first being
+  // expanded into memory, so it has to fire BEFORE the parse. A huge string that is not a
+  // data URL at all is the case only this check can catch — without it the parse would
+  // answer 400 instead, after the whole payload had already been walked.
+  it("refuses an oversized payload on length, before deciding whether it parses", () => {
+    expect(admitAudioClip("x".repeat(MAX_DATAURL_CHARS + 1))).toEqual({ ok: false, status: 413, error: "audio clip exceeds the size limit" });
+  });
+
+  it("refuses an oversized well-formed payload too", () => {
+    expect(admitAudioClip(`data:audio/webm;base64,${"A".repeat(MAX_DATAURL_CHARS)}`)).toMatchObject({ ok: false, status: 413 });
+  });
+
+  // A payload under the raw bound can still decode to more than the real cap.
+  it("refuses a clip whose decoded size is over the cap", () => {
+    const base64Length = Math.ceil(((MAX_AUDIO_BYTES + 1024) * 4) / 3);
+    expect(admitAudioClip(dataUrl("A".repeat(base64Length)))).toMatchObject({ ok: false, status: 413 });
+  });
+
+  it("admits a clip right at the decoded cap", () => {
+    const base64Length = Math.floor((MAX_AUDIO_BYTES * 4) / 3);
+    expect(admitAudioClip(dataUrl("A".repeat(base64Length))).ok).toBe(true);
+  });
+
+  it.each([["notadataurl"], ["data:audio/webm"], ["data:audio/webm,AAAA"], ["http://example.com/a.webm"]])("refuses the malformed URL %j with 400", (value) => {
+    expect(admitAudioClip(value)).toEqual({ ok: false, status: 400, error: "dataUrl must be a base64 data: URI" });
+  });
+});
+
+describe("parseDataUrl", () => {
+  it("keeps the mime type ahead of the parameters", () => {
+    expect(parseDataUrl("data:audio/ogg;codecs=opus;base64,AA")?.mimeType).toBe("audio/ogg");
+  });
+
+  // What ffmpeg is handed when the client sent no mime type at all.
+  it("falls back to octet-stream for a headerless URL", () => {
+    expect(parseDataUrl("data:;base64,AA")?.mimeType).toBe("application/octet-stream");
+  });
+
+  it("returns everything after the comma as the payload", () => {
+    expect(parseDataUrl("data:audio/webm;base64,AA,BB")?.base64).toBe("AA,BB");
+  });
+});
+
+describe("approxBytes", () => {
+  it("estimates the decoded size without decoding", () => {
+    expect(approxBytes("AAAA")).toBe(3);
+    expect(approxBytes("")).toBe(0);
+  });
+});
+
+describe("normalizeLanguage", () => {
+  it.each([["ja"], ["en"], ["zh"]])("keeps the short code %s", (code) => {
+    expect(normalizeLanguage(code)).toBe(code);
+  });
+
+  it.each([[undefined], [null], [""], [42], [{}]])("falls back to auto for %j", (value) => {
+    expect(normalizeLanguage(value)).toBe("auto");
+  });
+
+  // Recorded because it is a real cost, not because it is right: a legitimate tag longer
+  // than five characters is silently downgraded to auto-detection, which shows up as worse
+  // transcription rather than as an error.
+  it("downgrades a longer legitimate tag such as zh-Hant to auto", () => {
+    expect(normalizeLanguage("zh-Hant")).toBe("auto");
+    expect(normalizeLanguage("en-US")).toBe("en-US");
+  });
+});


### PR DESCRIPTION
## Summary

The four checks that decide whether a voice clip is transcribed, plus the language normalizer, move into `server/backends/audioAdmission.ts`.

**They were unreachable from a test.** `handleTranscribe` bails with 503 unless the host is macOS with `whisper-server` and `ffmpeg` on PATH, so CI never got past the handler's first line — while these are the checks standing between "hold the mic button for fifty seconds and it works" and a bare 413 the UI cannot explain.

Same statuses, same wording; the route now just sends what the decision returns.

## Items to Confirm / Review

1. **The order is part of the rule and is now pinned.** The raw data-URL bound fires *before* the parse, so a giant payload is refused without first being walked and expanded into memory.
2. **Two behaviours recorded rather than changed:**
   - `normalizeLanguage`'s five-character bound silently downgrades legitimate tags like `zh-Hant` to auto-detection — that costs transcription quality without failing visibly. Worth deciding on separately.
   - A headerless `data:;base64,…` is handed to ffmpeg as `application/octet-stream`.

## A test that lied, and how it was caught

The mutation check earned its keep here. Removing the pre-decode bound **did not** turn my ordering test red at first: its oversized payload was *also* over the decoded cap, so the later check returned the identical status and message. The test named the ordering but did not observe it.

The ordering is only observable with a payload that is huge **and not a data URL at all** — with the bound it is 413, without it the parse answers 400. Rewritten that way, the mutation turns it red.

## Checks

lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `188 files / 2432 tests` — all by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)