### PR TITLE
refactor: pin the cleared-session contract that spans two files (#598 B)

### DIFF
--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -33,6 +33,7 @@ import { codexSessionsRoot } from "../agents/codex-session.js";
 import { listCodexSessions } from "../agents/codex-sessions.js";
 import type { SessionMeta } from "../session/types.js";
 import { parseActivityIds, selectSessionRows } from "../session/session-list.js";
+import { sessionDetailView } from "../session/session-detail-view.js";
 
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
@@ -56,27 +57,15 @@ async function sessionDetail(req: Request<{ id: string }>, res: Response, freshe
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   await activityStateHydrated; // a reconnect re-fetch must see the restored working/waiting, not idle
-  const a = activity.get(id) || {};
   const { lastPrompt: transcriptPrompt, lastResponse: transcriptResponse, userTurns, usage, context, workPhase } = await readSessionSummary(cwd, id);
-  const lastPrompt = lastPrompts.get(id) ?? transcriptPrompt;
-  // The roster always shows OUR summary, never the external on-disk `ai-title` (MulmoClaude's).
-  // If we haven't titled it yet, kick off a summary and fall back to the prompt meanwhile.
+  // If we haven't titled it yet, kick off a summary; sessionDetailView falls back meanwhile.
   freshenRosterTitle(id, cwd, userTurns);
-  const aiTitle = aiTitles.get(id) ?? null;
-  const lastResponse = lastResponses.get(id) ?? transcriptResponse;
-  res.json({
-    id,
-    cwd,
-    working: a.working ?? false,
-    waiting: a.waiting ?? false,
-    event: a.event ?? null,
-    lastPrompt,
-    aiTitle,
-    lastResponse,
-    usage,
-    context,
-    workPhase,
-  });
+  const view = sessionDetailView(
+    { lastPrompt: lastPrompts.get(id), lastResponse: lastResponses.get(id), aiTitle: aiTitles.get(id) },
+    { lastPrompt: transcriptPrompt, lastResponse: transcriptResponse },
+    activity.get(id) ?? {},
+  );
+  res.json({ id, cwd, ...view, usage, context, workPhase });
 }
 
 // Attention state (working / waiting / event) for an explicit set of session ids.

--- a/server/session/session-detail-view.ts
+++ b/server/session/session-detail-view.ts
@@ -1,0 +1,54 @@
+// What GET /api/session/:id answers, given what this process remembers and what the
+// transcript says.
+//
+// The rule is a precedence with a sentinel, and the two halves of it live in different files:
+// `/clear` writes an EMPTY STRING into the live maps (hook-routes.ts), and this is the reader
+// that must let that empty string win over the transcript. `??` does; `||` does not.
+//
+// That is the whole reason this is a tested function. Someone tidying `?? transcriptPrompt`
+// into `|| transcriptPrompt` — or changing the writer's `set(id, "")` into `delete(id)` —
+// brings the pre-clear prompt and the pre-clear reply back into the cockpit. It reads as
+// plausible output, so it survives review, and the user sees a session that appears to still
+// be working on the task they just abandoned.
+
+export interface LiveSessionState {
+  // Present, including as "", once this process has seen the session. Absent means "this
+  // process knows nothing" — only then does the transcript speak.
+  lastPrompt?: string;
+  lastResponse?: string;
+  aiTitle?: string;
+}
+
+export interface TranscriptSessionState {
+  lastPrompt: string | null;
+  lastResponse: string | null;
+}
+
+export interface SessionActivity {
+  working?: boolean;
+  waiting?: boolean;
+  event?: string | null;
+}
+
+export interface SessionDetailView {
+  working: boolean;
+  waiting: boolean;
+  event: string | null;
+  lastPrompt: string | null;
+  lastResponse: string | null;
+  aiTitle: string | null;
+}
+
+export function sessionDetailView(live: LiveSessionState, transcript: TranscriptSessionState, activity: SessionActivity): SessionDetailView {
+  return {
+    // An absent activity record is an idle session, not an unknown one — the cockpit renders
+    // a dot either way and "unknown" has no dot to render.
+    working: activity.working ?? false,
+    waiting: activity.waiting ?? false,
+    event: activity.event ?? null,
+    lastPrompt: live.lastPrompt ?? transcript.lastPrompt,
+    lastResponse: live.lastResponse ?? transcript.lastResponse,
+    // Ours only — never the external on-disk ai-title.
+    aiTitle: live.aiTitle ?? null,
+  };
+}

--- a/test/server/session/session-detail-view.spec.ts
+++ b/test/server/session/session-detail-view.spec.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { sessionDetailView } from "../../../server/session/session-detail-view.js";
+
+const TRANSCRIPT = { lastPrompt: "the old task", lastResponse: "the old reply" };
+const NO_ACTIVITY = {};
+
+describe("sessionDetailView", () => {
+  it("prefers what this process saw over the transcript", () => {
+    const view = sessionDetailView({ lastPrompt: "live task", lastResponse: "live reply" }, TRANSCRIPT, NO_ACTIVITY);
+    expect([view.lastPrompt, view.lastResponse]).toEqual(["live task", "live reply"]);
+  });
+
+  it("falls back to the transcript for a session this process never saw", () => {
+    const view = sessionDetailView({}, TRANSCRIPT, NO_ACTIVITY);
+    expect([view.lastPrompt, view.lastResponse]).toEqual(["the old task", "the old reply"]);
+  });
+
+  // THE contract. `/clear` writes "" into the live maps precisely so it outranks the
+  // transcript; `||` would let the abandoned task and its reply come straight back, and it
+  // would read as plausible output rather than as a bug.
+  it("lets a cleared session stay cleared, rather than resurrecting the transcript", () => {
+    const view = sessionDetailView({ lastPrompt: "", lastResponse: "" }, TRANSCRIPT, NO_ACTIVITY);
+    expect([view.lastPrompt, view.lastResponse]).toEqual(["", ""]);
+  });
+
+  it("clears the prompt and the reply independently", () => {
+    const view = sessionDetailView({ lastPrompt: "" }, TRANSCRIPT, NO_ACTIVITY);
+    expect([view.lastPrompt, view.lastResponse]).toEqual(["", "the old reply"]);
+  });
+
+  it("reports nothing when neither side has anything", () => {
+    const view = sessionDetailView({}, { lastPrompt: null, lastResponse: null }, NO_ACTIVITY);
+    expect([view.lastPrompt, view.lastResponse]).toEqual([null, null]);
+  });
+
+  // Ours only — never the external on-disk ai-title, which is MulmoClaude's.
+  it("reports our own title, or none", () => {
+    expect(sessionDetailView({ aiTitle: "Fix the login bug" }, TRANSCRIPT, NO_ACTIVITY).aiTitle).toBe("Fix the login bug");
+    expect(sessionDetailView({}, TRANSCRIPT, NO_ACTIVITY).aiTitle).toBeNull();
+  });
+
+  // A cleared title is "" in the map only briefly; either way it must not become the
+  // transcript's.
+  it("does not substitute anything for an empty title", () => {
+    expect(sessionDetailView({ aiTitle: "" }, TRANSCRIPT, NO_ACTIVITY).aiTitle).toBe("");
+  });
+
+  describe("activity", () => {
+    it("passes the flags through", () => {
+      const view = sessionDetailView({}, TRANSCRIPT, { working: true, waiting: false, event: "Stop" });
+      expect([view.working, view.waiting, view.event]).toEqual([true, false, "Stop"]);
+    });
+
+    // An absent record is an idle session, not an unknown one: the cockpit renders a dot
+    // either way, and "unknown" has no dot to render.
+    it("treats an absent record as idle", () => {
+      const view = sessionDetailView({}, TRANSCRIPT, {});
+      expect([view.working, view.waiting, view.event]).toEqual([false, false, null]);
+    });
+
+    it("keeps a session that is waiting distinct from one that is merely not working", () => {
+      expect(sessionDetailView({}, TRANSCRIPT, { waiting: true }).waiting).toBe(true);
+      expect(sessionDetailView({}, TRANSCRIPT, { working: false }).waiting).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`/clear` writes an **empty string** into `lastPrompts` / `lastResponses` (`hook-routes.ts`) precisely so it outranks the transcript, and `GET /api/session/:id` reads it back with `??` — a hundred lines away, in another module. **Nothing tied the two halves together.**

The reader now lives in `server/session/session-detail-view.ts`, with the contract as its first test.

## Why this one is worth a module

The failure mode is a tidy-up, not a typo:

```ts
const lastPrompt = lastPrompts.get(id) ?? transcriptPrompt;   // correct
const lastPrompt = lastPrompts.get(id) || transcriptPrompt;   // "simplified"
```

…or the writer's `set(id, "")` becoming `delete(id)`. Either brings the pre-clear prompt and the pre-clear reply back into the cockpit. It reads as **plausible output** rather than as a bug, so it survives review — and the user sees a session that appears to still be working on the task they just abandoned.

Swapping `??` for `||` turns **2 tests red**.

## Items to Confirm / Review

- Behaviour unchanged, including the absent-activity defaults: an absent record is an **idle** session, not an unknown one (the cockpit renders a dot either way, and "unknown" has no dot).
- The route keeps the disk read, the hydration await and `freshenRosterTitle`; only the assembly moved.
- `aiTitle` stays ours-only — never the external on-disk `ai-title`.

## Checks

lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `189 files / 2442 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)