### PR TITLE
refactor: one browser-locale helper instead of five copies (#598)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@ import { usePendingScript, type PendingCommand } from "./composables/usePendingS
 import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
 import { useUnloadGuard, reportActiveTerminals } from "./composables/useUnloadGuard";
+import { browserLocale } from "./utils/browserLocale";
 
 // View mode is now the URL: the multi-terminal grid is /terminals, everything else
 // (chat + the collection/accounting overlays) lives under the single-view shell.
@@ -222,7 +223,7 @@ let draftHintTimer: ReturnType<typeof setTimeout> | undefined;
 // this keeps the one new user-facing string from being English-only. Translated once
 // per session; the server cache makes it instant thereafter.
 async function localizeDraftHint() {
-  const locale = (navigator.language || "en").split("-")[0];
+  const locale = browserLocale();
   if (locale === "en" || draftHintText.value !== DRAFT_HINT_EN) return;
   try {
     const res = await fetch("/api/translation", {

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -5,6 +5,7 @@ import type { RunCommand } from "./runCommand";
 import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import type { CellStatus } from "./gridTabs";
+import { browserLocale } from "../utils/browserLocale";
 
 // A grid cell that runs a `script.json` command (a cell launcher's Run) instead of
 // a Claude session. Ephemeral: it has no session id and isn't persisted — a reload
@@ -67,7 +68,6 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 // The summary language follows the browser's base language — MulmoTerminal has no
 // locale picker (same signal as useVoiceInput / accountingUi / App.vue).
-const browserLocale = (): string => (navigator.language || "en").split("-")[0];
 
 async function postSummary(log: string): Promise<{ summary: string; truncated: boolean }> {
   const controller = new AbortController();

--- a/src/composables/accountingUi.ts
+++ b/src/composables/accountingUi.ts
@@ -11,6 +11,7 @@ import { configureAccountingHost } from "@mulmoclaude/accounting-plugin/vue";
 import type { ApiResult } from "@mulmoclaude/accounting-plugin/vue";
 import { fetchJson } from "../utils/fetchJson";
 import { usePubSub } from "./usePubSub";
+import { browserLocale } from "../utils/browserLocale";
 
 const { subscribe } = usePubSub();
 
@@ -31,5 +32,5 @@ configureAccountingHost({
   // Raw `accounting:<bookId>` / `accounting:books` channels: the engine publishes
   // book changes (server/backends/accounting.ts) and the View live-refreshes.
   subscribe,
-  localeTag: () => (navigator.language || "en").split("-")[0],
+  localeTag: () => browserLocale(),
 });

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -45,6 +45,7 @@ import {
 } from "./useCollectionBrowse";
 import PinToggle from "../components/PinToggle.vue";
 import { startCollectionChat } from "./useChatLauncher";
+import { browserLocale } from "../utils/browserLocale";
 
 // ── Modal teleport target (Shadow DOM) ──
 // PluginFrame mounts each card inside a per-instance shadow root, but
@@ -140,7 +141,7 @@ configureCollectionUi({
   confirm: (options) => Promise.resolve(window.confirm(options.message)),
   // MulmoTerminal has no host i18n; the plugin runs its own. Pick the browser's
   // base language, defaulting to English.
-  localeTag: () => (navigator.language || "en").split("-")[0],
+  localeTag: () => browserLocale(),
   generalRoleId: "general",
   personalRoleId: "personal",
   pinToggle: PinToggle,

--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -11,6 +11,7 @@
 
 import { onScopeDispose, ref, type Ref } from "vue";
 import { createVoiceCapture, localeToWhisperLanguage, type VoiceCaptureTransport } from "@mulmoclaude/core/whisper/client";
+import { browserLocale } from "../utils/browserLocale";
 
 interface VoiceModelStatusResponse {
   capable: boolean;
@@ -36,12 +37,6 @@ export interface UseVoiceInput {
 export interface UseVoiceInputOptions {
   /** Called with each segment's transcript once recognized (never empty). */
   onTranscript: (text: string) => void;
-}
-
-// Browser UI language is a strong prior for the spoken language. No vue-i18n here,
-// so derive it from the browser like the collection composables do.
-function browserLocale(): string {
-  return (navigator.language || "en").split("-")[0];
 }
 
 async function fetchModelStatus(): Promise<VoiceModelStatusResponse | null> {

--- a/src/utils/browserLocale.ts
+++ b/src/utils/browserLocale.ts
@@ -1,0 +1,13 @@
+// The browser's language as a bare language subtag — `ja`, `en`, `zh`.
+//
+// The same expression had been written out in five places (App, the collection and
+// accounting UIs, voice input, the command cell). They agreed, but each was one edit away
+// from not agreeing, and "which locale does this part of the app think it is in" is not a
+// question worth having five answers to.
+//
+// The region is dropped on purpose: callers use this to pick a translation bundle, and
+// `en-GB` and `en-US` want the same one. A caller that needs the full tag should read
+// `navigator.language` itself and say why.
+export function browserLocale(): string {
+  return (navigator.language || "en").split("-")[0];
+}

--- a/test/src/utils/browserLocale.spec.ts
+++ b/test/src/utils/browserLocale.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { browserLocale } from "../../../src/utils/browserLocale";
+
+const withLanguage = (language: string) => vi.spyOn(navigator, "language", "get").mockReturnValue(language);
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("browserLocale", () => {
+  it("returns a bare language tag as-is", () => {
+    withLanguage("ja");
+    expect(browserLocale()).toBe("ja");
+  });
+
+  // The region is dropped on purpose: callers pick a translation bundle with this, and
+  // en-GB and en-US want the same one.
+  it("drops the region", () => {
+    withLanguage("en-GB");
+    expect(browserLocale()).toBe("en");
+  });
+
+  it("drops a script and region too", () => {
+    withLanguage("zh-Hant-TW");
+    expect(browserLocale()).toBe("zh");
+  });
+
+  // A browser that reports nothing must not produce an empty locale key, which would miss
+  // every bundle rather than falling back to English.
+  it("falls back to English when the browser reports nothing", () => {
+    withLanguage("");
+    expect(browserLocale()).toBe("en");
+  });
+});


### PR DESCRIPTION
## Summary

`(navigator.language || "en").split("-")[0]` was written out in **five** places (the survey said four — `CommandCell.vue` had one too):

- `src/App.vue`
- `src/composables/collectionUi.ts`
- `src/composables/accountingUi.ts`
- `src/composables/useVoiceInput.ts`
- `src/components/CommandCell.vue`

They agreed, but each was one edit away from not agreeing, and "which locale does this part of the app think it is in" is not a question worth five answers. Now one helper with tests, including the fallback (a browser reporting nothing must not produce an empty locale key, which would miss every bundle rather than falling back to English).

## Items to Confirm / Review

1. **Dropping the region is deliberate** and now stated: callers use this to pick a translation bundle, and `en-GB` / `en-US` want the same one. A caller needing the full tag should read `navigator.language` itself and say why.
2. Behaviour is identical at all five sites.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `190 files / 2446 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)