### PR TITLE
refactor: make the tool-hook decisions testable (#598 B)

### DIFF
--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -12,6 +12,7 @@ import { latestUserPrompt } from "../session/session-reads.js";
 import { notifyTaskFinished } from "../session/task-push.js";
 import { preferredHeaderPrompt } from "../session/transcript.js";
 import { failPendingTranslation } from "../session/translation-worker.js";
+import { publishesDirConfig, toolHookRecord } from "../session/tool-hook.js";
 
 // The header shows one line, so a longer prompt is stored truncated rather than in full.
 
@@ -58,24 +59,15 @@ interface HookToolPayload {
   duration_ms?: number;
 }
 
-// Pre/PostToolUse hooks feed the per-session tool-call history. A failed tool
-// fires PostToolUseFailure (NOT PostToolUse), so both complete the entry.
+// Pre/PostToolUse hooks feed the per-session tool-call history; toolHookRecord decides what
+// each event means and this applies it.
 async function handleToolHook(deps: HookDeps, sessionId: string, event: string, p: HookToolPayload) {
-  if (event === "PreToolUse") {
-    await deps.recordToolCallStart(sessionId, { toolUseId: p.tool_use_id, toolName: p.tool_name, toolInput: p.tool_input });
-  } else if (event === "PostToolUse" || event === "PostToolUseFailure") {
-    await deps.recordToolCallEnd(sessionId, {
-      toolUseId: p.tool_use_id,
-      toolName: p.tool_name,
-      toolInput: p.tool_input,
-      toolOutput: p.tool_output ?? p.tool_response,
-      durationMs: p.duration_ms,
-      status: event === "PostToolUseFailure" ? "failed" : "completed",
-    });
-  }
+  const record = toolHookRecord(event, p);
+  if (record?.phase === "start") await deps.recordToolCallStart(sessionId, record.call);
+  if (record?.phase === "end") await deps.recordToolCallEnd(sessionId, record.call);
   // A SUCCESSFUL write to <dir>/.mulmoterminal.json is the live-reload signal: the hook that already
   // reports every tool call tells the client to re-read that directory's config, so no fs watchers.
-  if (event === "PostToolUse") {
+  if (publishesDirConfig(event)) {
     const cwd = dirConfigWriteTarget(p.tool_name, p.tool_input, ptys.get(sessionId)?.cwd ?? null);
     if (cwd) deps.publishDirConfig(cwd);
   }

--- a/server/session/tool-hook.ts
+++ b/server/session/tool-hook.ts
@@ -1,0 +1,59 @@
+// What a tool hook means, separated from the recorders and the pty table it currently
+// reaches for.
+//
+// Three decisions live here, and each has its own way of going quietly wrong:
+//   - which events OPEN a history entry and which CLOSE one
+//   - which payload field carries the output, since the CLI has used two names
+//   - whether this event should trigger the directory-config live reload
+//
+// The last one is deliberately narrower than it looks: only a SUCCESSFUL write signals a
+// reload. Letting the failure event through makes every rejected write to
+// .mulmoterminal.json tell every watching client to re-read a file that did not change.
+
+export interface ToolHookPayload {
+  tool_use_id?: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  tool_output?: unknown;
+  tool_response?: unknown;
+  duration_ms?: number;
+}
+
+export interface ToolCallStart {
+  toolUseId?: string;
+  toolName?: string;
+  toolInput: unknown;
+}
+
+export interface ToolCallEnd extends ToolCallStart {
+  toolOutput: unknown;
+  durationMs?: number;
+  status: "completed" | "failed";
+}
+
+export type ToolHookRecord = { phase: "start"; call: ToolCallStart } | { phase: "end"; call: ToolCallEnd } | null;
+
+// A failed tool fires PostToolUseFailure, NOT PostToolUse — both close the entry, and the
+// difference between them is the whole reason the tools pane can show a failure at all.
+// Collapse them and a user debugging a stuck agent reads a history in which nothing failed.
+export function toolHookRecord(event: string, payload: ToolHookPayload): ToolHookRecord {
+  const call = { toolUseId: payload.tool_use_id, toolName: payload.tool_name, toolInput: payload.tool_input };
+  if (event === "PreToolUse") return { phase: "start", call };
+  if (event !== "PostToolUse" && event !== "PostToolUseFailure") return null;
+  return {
+    phase: "end",
+    call: {
+      ...call,
+      // The CLI has used both names; whichever is present is the output. Lose this and tool
+      // outputs render blank for whichever version uses the other one.
+      toolOutput: payload.tool_output ?? payload.tool_response,
+      durationMs: payload.duration_ms,
+      status: event === "PostToolUseFailure" ? "failed" : "completed",
+    },
+  };
+}
+
+// Only a successful write is a live-reload signal.
+export function publishesDirConfig(event: string): boolean {
+  return event === "PostToolUse";
+}

--- a/test/server/session/tool-hook.spec.ts
+++ b/test/server/session/tool-hook.spec.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { publishesDirConfig, toolHookRecord } from "../../../server/session/tool-hook.js";
+
+const payload = { tool_use_id: "t1", tool_name: "Edit", tool_input: { file: "a.ts" }, duration_ms: 42 };
+
+describe("toolHookRecord", () => {
+  it("opens an entry on PreToolUse", () => {
+    expect(toolHookRecord("PreToolUse", payload)).toEqual({ phase: "start", call: { toolUseId: "t1", toolName: "Edit", toolInput: { file: "a.ts" } } });
+  });
+
+  it("closes it as completed on PostToolUse", () => {
+    const record = toolHookRecord("PostToolUse", { ...payload, tool_output: "done" });
+    expect(record).toMatchObject({ phase: "end", call: { status: "completed", toolOutput: "done", durationMs: 42 } });
+  });
+
+  // The distinction the tools pane exists to show. Collapse the two Post events and a user
+  // debugging a stuck agent reads a history in which nothing failed.
+  it("closes it as failed on PostToolUseFailure", () => {
+    expect(toolHookRecord("PostToolUseFailure", payload)).toMatchObject({ phase: "end", call: { status: "failed" } });
+  });
+
+  // The CLI has used both field names; whichever is present is the output.
+  it("takes the output from tool_output", () => {
+    expect(toolHookRecord("PostToolUse", { ...payload, tool_output: "A", tool_response: "B" })).toMatchObject({ call: { toolOutput: "A" } });
+  });
+
+  it("falls back to tool_response", () => {
+    expect(toolHookRecord("PostToolUse", { ...payload, tool_response: "B" })).toMatchObject({ call: { toolOutput: "B" } });
+  });
+
+  // An empty string is a real output — `??` must let it through where `||` would not.
+  it("keeps an empty output rather than reaching for the other field", () => {
+    expect(toolHookRecord("PostToolUse", { ...payload, tool_output: "", tool_response: "B" })).toMatchObject({ call: { toolOutput: "" } });
+  });
+
+  it.each([["Stop"], ["UserPromptSubmit"], ["Notification"], ["SessionStart"], [""], ["posttooluse"]])("ignores %j", (event) => {
+    expect(toolHookRecord(event, payload)).toBeNull();
+  });
+
+  it("carries a partial payload through rather than dropping the entry", () => {
+    expect(toolHookRecord("PreToolUse", {})).toEqual({ phase: "start", call: { toolUseId: undefined, toolName: undefined, toolInput: undefined } });
+  });
+});
+
+describe("publishesDirConfig", () => {
+  it("reloads the directory config after a successful write", () => {
+    expect(publishesDirConfig("PostToolUse")).toBe(true);
+  });
+
+  // Deliberately NOT the failure event: a rejected write to .mulmoterminal.json would make
+  // every watching client re-read a file that did not change.
+  it("does not reload after a failed one", () => {
+    expect(publishesDirConfig("PostToolUseFailure")).toBe(false);
+  });
+
+  it.each([["PreToolUse"], ["Stop"], ["SessionStart"]])("does not reload on %s", (event) => {
+    expect(publishesDirConfig(event)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three decisions come out of `handleToolHook` into `server/session/tool-hook.ts`. Each has its own quiet failure mode:

| Decision | If it's wrong |
|---|---|
| Which events **open** an entry vs **close** one | A failed tool fires `PostToolUseFailure`, not `PostToolUse`. Collapse them and a user debugging a stuck agent reads a history in which **nothing failed** |
| Which field carries the **output** | The CLI has used both `tool_output` and `tool_response`; lose the fallback and outputs render **blank** against whichever version uses the other name |
| Whether the dir-config **live reload** fires | Deliberately `PostToolUse` only — letting the failure through makes every **rejected** write to `.mulmoterminal.json` tell every client to re-read a file that did not change |

All three were reachable only through two injected async recorders plus the module-level `ptys` table. `dirConfigWriteTarget` — which decides *which* directory — is already pure and tested; the event gate in front of it was not.

## Items to Confirm / Review

1. **Behaviour unchanged.** Same recorder calls with the same fields, same publish condition.
2. **One case worth a look**: an **empty-string** tool output is kept rather than falling through to `tool_response` (`??`, not `||`). That is what the old code did too; it is now stated by a test.
3. Marking failures as completed, and widening the reload to the failure event, turn **2 tests red**.

## Checks

lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `191 files / 2464 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)