### PR TITLE
fix: 名前が衝突したとき、答えられないプラグインを広告しないようにする (#611 A2)

### DIFF
--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -30,6 +30,7 @@ import { generateImage } from "../backends/image-gen.js";
 import { markdownHostApp } from "../backends/markdown.js";
 import { artifactsFileOps } from "../backends/artifacts.js";
 import { createPluginRuntime } from "./pluginRuntime.js";
+import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -178,12 +179,25 @@ export const plugins = [
   ...(await Promise.all(config.local.map(loadLocal))),
 ];
 
-const byName = Object.fromEntries(plugins.map((p) => [p.toolName, p]));
+// A name can be claimed twice; tool-precedence.ts decides who keeps it, so the advertised
+// list below is built from the same answer the dispatch map is. Both collisions used to pass
+// silently, with the list describing one implementation while another ran.
+const { dispatched: dispatchablePlugins, collisions } = resolvePluginTools(
+  plugins,
+  (p) => p.toolName,
+  HOST_TOOL_DEFINITIONS.map((d) => d.name),
+);
+for (const { name, shadowedBy } of collisions) {
+  const keeper = shadowedBy === "host" ? "a built-in host tool" : "the last plugin to declare it";
+  console.warn(`[plugins] tool "${name}" is declared more than once — ${keeper} keeps the name; the other is not offered`);
+}
+
+const byName = Object.fromEntries(dispatchablePlugins.map((p) => [p.toolName, p]));
 
 // MCP tool definitions the broker registers — gui-chat-protocol ToolDefinitions
-// ({ name, description, prompt?, parameters }), one per enabled plugin plus the
+// ({ name, description, prompt?, parameters }), one per DISPATCHABLE plugin plus the
 // built-in host tools (which the server dispatches itself; see host-tools.ts).
-export const toolDefinitions = [...plugins.map((p) => p.definition), ...HOST_TOOL_DEFINITIONS];
+export const toolDefinitions = [...dispatchablePlugins.map((p) => p.definition), ...HOST_TOOL_DEFINITIONS];
 
 // JSON-serializable summaries (no schema) for the GUI's tools pane.
 export const toolSummaries = toolDefinitions.map((d) => ({

--- a/server/infra/tool-precedence.ts
+++ b/server/infra/tool-precedence.ts
@@ -1,0 +1,43 @@
+// Which plugin actually answers a tool name, when more than one claims it.
+//
+// Two names can collide, and until now both collisions were silent AND inconsistent: the
+// dispatch map is built with Object.fromEntries, so the LAST plugin to claim a name wins it,
+// while the advertised tool list carried every claimant. A built-in host tool wins outright
+// over any plugin, because its route is mounted before the plugin catch-all — but the
+// plugin's definition was advertised all the same.
+//
+// The result is a tool list that can describe one implementation while another runs. A
+// package can take a host tool's name and be listed under it; a plugin author can watch
+// their tool be offered and never called. Resolving both here means the list is built from
+// the same answer the dispatch is (#611 A2).
+
+export interface ToolNameCollision {
+  name: string;
+  /** Who keeps the name: a built-in host tool, or the last plugin to declare it. */
+  shadowedBy: "host" | "plugin";
+}
+
+export function resolvePluginTools<T>(
+  plugins: readonly T[],
+  nameOf: (plugin: T) => string,
+  hostToolNames: readonly string[],
+): { dispatched: T[]; collisions: ToolNameCollision[] } {
+  const hosts = new Set(hostToolNames);
+  // Last claimant wins, which is what the dispatch map already does.
+  const winner = new Map<string, number>();
+  plugins.forEach((plugin, index) => winner.set(nameOf(plugin), index));
+
+  const collisions: ToolNameCollision[] = [];
+  const dispatched: T[] = [];
+  plugins.forEach((plugin, index) => {
+    const name = nameOf(plugin);
+    if (hosts.has(name)) {
+      collisions.push({ name, shadowedBy: "host" });
+    } else if (winner.get(name) !== index) {
+      collisions.push({ name, shadowedBy: "plugin" });
+    } else {
+      dispatched.push(plugin);
+    }
+  });
+  return { dispatched, collisions };
+}

--- a/test/server/infra/tool-precedence.spec.ts
+++ b/test/server/infra/tool-precedence.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+
+import { resolvePluginTools } from "../../../server/infra/tool-precedence.js";
+
+interface FakePlugin {
+  toolName: string;
+  from: string;
+}
+
+const plugin = (toolName: string, from: string): FakePlugin => ({ toolName, from });
+const nameOf = (p: FakePlugin) => p.toolName;
+const HOSTS = ["spawnBackgroundChat", "manageAccounting", "manageCollection"];
+
+const resolve = (plugins: FakePlugin[], hosts: string[] = HOSTS) => resolvePluginTools(plugins, nameOf, hosts);
+const dispatchedNames = (plugins: FakePlugin[], hosts?: string[]) => resolve(plugins, hosts).dispatched.map(nameOf);
+
+describe("resolvePluginTools", () => {
+  describe("with no collision", () => {
+    it("dispatches every plugin, in the order they were loaded", () => {
+      const plugins = [plugin("presentHtml", "a"), plugin("presentForm", "b"), plugin("presentMulmoScript", "c")];
+      expect(dispatchedNames(plugins)).toEqual(["presentHtml", "presentForm", "presentMulmoScript"]);
+    });
+
+    it("reports nothing", () => {
+      expect(resolve([plugin("presentHtml", "a")]).collisions).toEqual([]);
+    });
+  });
+
+  // A package taking a host tool's name is the case with teeth: the host route is mounted
+  // first, so the plugin can never run — but its definition used to be advertised anyway,
+  // leaving the tool list describing a package while the built-in answered.
+  describe("when a plugin claims a host tool's name", () => {
+    it("does not dispatch it", () => {
+      const plugins = [plugin("presentHtml", "a"), plugin("manageCollection", "evil")];
+      expect(dispatchedNames(plugins)).toEqual(["presentHtml"]);
+    });
+
+    it("reports that the host tool keeps the name", () => {
+      const plugins = [plugin("manageCollection", "evil")];
+      expect(resolve(plugins).collisions).toEqual([{ name: "manageCollection", shadowedBy: "host" }]);
+    });
+
+    it("drops it wherever it sits in the load order", () => {
+      const plugins = [plugin("manageAccounting", "first"), plugin("presentHtml", "a"), plugin("spawnBackgroundChat", "last")];
+      expect(dispatchedNames(plugins)).toEqual(["presentHtml"]);
+    });
+
+    it("drops every plugin claiming it, not just one", () => {
+      const plugins = [plugin("manageCollection", "a"), plugin("manageCollection", "b")];
+      expect(resolve(plugins).dispatched).toEqual([]);
+      expect(resolve(plugins).collisions).toEqual([
+        { name: "manageCollection", shadowedBy: "host" },
+        { name: "manageCollection", shadowedBy: "host" },
+      ]);
+    });
+  });
+
+  // The dispatch map is built with Object.fromEntries, so the last claimant already won it.
+  // What changes is that the losers are no longer advertised as if they might answer.
+  describe("when two plugins claim the same name", () => {
+    it("dispatches the last one to declare it", () => {
+      const plugins = [plugin("presentHtml", "old"), plugin("presentHtml", "new")];
+      expect(resolve(plugins).dispatched).toEqual([plugin("presentHtml", "new")]);
+    });
+
+    it("reports the earlier one as shadowed", () => {
+      const plugins = [plugin("presentHtml", "old"), plugin("presentHtml", "new")];
+      expect(resolve(plugins).collisions).toEqual([{ name: "presentHtml", shadowedBy: "plugin" }]);
+    });
+
+    it("keeps only the last of three", () => {
+      const plugins = [plugin("x", "1"), plugin("x", "2"), plugin("x", "3")];
+      expect(resolve(plugins).dispatched).toEqual([plugin("x", "3")]);
+      expect(resolve(plugins).collisions).toHaveLength(2);
+    });
+
+    it("leaves the other plugins where they are", () => {
+      const plugins = [plugin("a", "1"), plugin("dup", "old"), plugin("b", "2"), plugin("dup", "new")];
+      expect(dispatchedNames(plugins)).toEqual(["a", "b", "dup"]);
+    });
+  });
+
+  // The property the whole resolution exists for: the advertised list is built from
+  // `dispatched`, so anything in it must be able to answer.
+  describe("what survives can always answer", () => {
+    it("never dispatches a name twice", () => {
+      const plugins = [plugin("dup", "1"), plugin("dup", "2"), plugin("dup", "3"), plugin("other", "x")];
+      const names = dispatchedNames(plugins);
+      expect(new Set(names).size).toBe(names.length);
+    });
+
+    it("never dispatches a name a host tool owns", () => {
+      const plugins = HOSTS.map((name) => plugin(name, "pkg")).concat(plugin("fine", "a"));
+      expect(dispatchedNames(plugins).filter((name) => HOSTS.includes(name))).toEqual([]);
+    });
+  });
+
+  describe("empty cases", () => {
+    it("resolves an empty plugin list", () => {
+      expect(resolve([])).toEqual({ dispatched: [], collisions: [] });
+    });
+
+    it("dispatches everything when there are no host tools", () => {
+      expect(dispatchedNames([plugin("manageCollection", "a")], [])).toEqual(["manageCollection"]);
+    });
+  });
+});


### PR DESCRIPTION
Refs #611

## Summary

ツール名の衝突が **2 種類とも黙って通り**、しかも**レジストリの前半と後半で結論が食い違っていました**。

| | 実際にディスパッチされるもの | 広告されるもの |
|---|---|---|
| プラグイン同士の重複 | `Object.fromEntries` により**最後**が勝つ | **全部**（同じ名前が一覧に複数並ぶ） |
| ホストツールとの衝突 | ホストが勝つ（ルートが catch-all より先にマウントされるため） | **プラグイン側も広告される** |

つまり**「一覧に書いてある説明と、実際に動く実装が違う」**状態が起こりえました。

サードパーティのパッケージが `manageCollection` を名乗ると、その名前で一覧に載りながら**一度も呼ばれず**、実際にはビルトインが答えます。逆向きの読み方の方が厄介で、**運用者は自分のプラグインが提供されているのを見て、エージェントがそれに到達すると思い込みます**。

`server/infra/tool-precedence.ts` に「誰が名前を保持するか」を出し、**広告リストをその答えから組み立てる**ようにしました。これで**提供されているものは必ず応答できます**。

**テスト 14 件**追加。

## Items to Confirm / Review

1. **衝突は throw ではなく警告ログにしました** — サードパーティのパッケージが名前を取っただけでアプリが起動しなくなるのは過剰と判断。異論があれば throw に変えられます
2. **プラグイン同士の重複は「最後が勝つ」を維持** — `Object.fromEntries` の既存挙動に合わせています。「最初が勝つ」の方が直感的という考え方もありますが、それは挙動変更になるので踏み込んでいません
3. **広告されなくなるものがある**（＝挙動変更）— ホストツール名を名乗ったプラグイン、および重複した先着プラグインの definition が一覧から消えます。**どれも元々ディスパッチされないもの**なので、実行される内容は変わりません

## なぜ既存 spec で気づけなかったか

```ts
it("loads every package in plugins.json without a duplicate tool name", () => {
  const names = plugins.map((plugin) => plugin.toolName);
  expect(new Set(names).size).toBe(names.length);
});
```

**「今の構成に重複が無い」ことしか見ていません。** 重複が起きたときにどうなるかは未検証で、そこが壊れていました。ホストツールとの衝突に至っては観点自体がありませんでした。

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| ホストツールとの衝突を無視する | **5 件** |
| 重複時に最後ではなく最初を残す | 3 件 |

「提供されたものは必ず応答できる」という性質そのものを検査するテスト（`never dispatches a name twice` / `never dispatches a name a host tool owns`）も入れています。

## 出所

#611 の A2。`codex exec` によるリポジトリ全体調査で指摘された箇所を、実コードに当てて裏を取ったものです。ホストツールとの衝突は Codex の指摘には無く、`HOST_TOOL_DEFINITIONS` を追ったときに見つけました。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:server` / `yarn build` / `yarn test`（190 files, 2456 tests）/ `yarn knip` すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
