### PR TITLE
refactor: make the codex resume precedence testable (#598 B)

### DIFF
--- a/server/agents/codex-resume.ts
+++ b/server/agents/codex-resume.ts
@@ -1,0 +1,26 @@
+// Which codex conversation a requested session key resumes, if any.
+//
+// The browser-facing id is a key MulmoTerminal minted; codex's own rollout id is discovered
+// after the spawn. So a key can mean two different things, and the order matters: a rollout
+// id we recorded FOR that key wins over treating the key as a rollout id itself. Reverse
+// them and a key that happens to also name a rollout resumes the wrong conversation.
+//
+// The other half is the guard: a cold resume is only attempted when there is nothing live to
+// reattach. Without it a reattach also carries a resume id into the spawner, starting a
+// second codex on a conversation already running in tmux.
+
+export interface CodexResumeFacts {
+  // The rollout id this server recorded for the key, if it started that session.
+  mappedRolloutId?: string | null;
+  // Whether the key is itself the id of a rollout on disk (the sidebar hands these over).
+  // A thunk, not a value: it reads the filesystem, and a reattach must not pay for a probe
+  // whose answer it is about to discard.
+  rolloutExists: () => boolean;
+  hasLivePty: boolean;
+  tmuxAlive: boolean;
+}
+
+export function codexResumeId(requested: string | null, facts: CodexResumeFacts): string | null {
+  if (!requested || facts.hasLivePty || facts.tmuxAlive) return null;
+  return facts.mappedRolloutId || (facts.rolloutExists() ? requested : null);
+}

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -30,6 +30,7 @@ import { sessionExistsOnDisk } from "../session/session-reads.js";
 import { canStartLauncher, resolveReattachableId, resolveSession, type SessionResolution } from "../session/session-resolve.js";
 import type { PtyEntry } from "../session/types.js";
 import type { SpawnClaudePty, SpawnCodexPty, SpawnCommandPty, SpawnLauncherPty, ResolveLauncher } from "../session/spawners.js";
+import { codexResumeId } from "../agents/codex-resume.js";
 
 export interface WsRouteDeps {
   /** The http server these endpoints hang their `upgrade` handler off. */
@@ -151,19 +152,16 @@ function resolveLaunchSession(
 // after spawn and resume it with `codex resume <id>` once the live PTY is gone. Reattach a live
 // pty / surviving tmux session (running codex picked up, no resume); else cold-resume a known
 // rollout id; else a fresh session (a new minted key).
-// A rollout id to cold-resume for a requested session key: one we started here (key -> rollout id),
-// or a rollout id straight from the sidebar (its own id), or null (start fresh).
-function codexResumeIdFor(requested: string): string | null {
-  const mapped = codexRolloutIds.get(requested);
-  if (mapped) return mapped;
-  return codexRolloutExists(codexSessionsRoot(), requested) ? requested : null;
-}
-
 function resolveCodexSession(requested: string | null): { sessionId: string; live: PtyEntry | undefined; resumeRolloutId: string | null } {
   const hasLivePty = !!requested && ptys.has(requested);
   const live = hasLivePty && requested ? ptys.get(requested) : undefined;
   const tmuxAlive = !live && !!requested && tmuxHasSession(requested);
-  const resumeRolloutId = !live && !tmuxAlive && requested ? codexResumeIdFor(requested) : null;
+  const resumeRolloutId = codexResumeId(requested, {
+    mappedRolloutId: requested ? codexRolloutIds.get(requested) : null,
+    rolloutExists: () => !!requested && codexRolloutExists(codexSessionsRoot(), requested),
+    hasLivePty: !!live,
+    tmuxAlive,
+  });
   const { sessionId } = resolveReattachableId(requested, { hasLivePty, tmuxAlive, canResume: !!resumeRolloutId }, randomUUID);
   return { sessionId, live, resumeRolloutId };
 }

--- a/test/server/agents/codex-resume.spec.ts
+++ b/test/server/agents/codex-resume.spec.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+
+import { codexResumeId } from "../../../server/agents/codex-resume.js";
+
+const KEY = "11111111-2222-4333-8444-555555555555";
+const facts = (over: Partial<Parameters<typeof codexResumeId>[1]> = {}) => ({
+  mappedRolloutId: null,
+  rolloutExists: () => false,
+  hasLivePty: false,
+  tmuxAlive: false,
+  ...over,
+});
+
+describe("codexResumeId", () => {
+  // The browser-facing key and codex's rollout id are different namespaces, and a key can
+  // look like either. A rollout we recorded FOR this key is the authoritative answer.
+  it("prefers the rollout id recorded for the key", () => {
+    expect(codexResumeId(KEY, facts({ mappedRolloutId: "rollout-9", rolloutExists: () => true }))).toBe("rollout-9");
+  });
+
+  it("falls back to treating the key as a rollout id", () => {
+    expect(codexResumeId(KEY, facts({ rolloutExists: () => true }))).toBe(KEY);
+  });
+
+  it("resumes nothing when the key names no rollout", () => {
+    expect(codexResumeId(KEY, facts())).toBeNull();
+  });
+
+  // Carrying a resume id into a reattach starts a SECOND codex on a conversation that is
+  // already running.
+  it("never resumes when a live pty can be reattached", () => {
+    expect(codexResumeId(KEY, facts({ hasLivePty: true, mappedRolloutId: "rollout-9" }))).toBeNull();
+  });
+
+  it("never resumes when a tmux session survived", () => {
+    expect(codexResumeId(KEY, facts({ tmuxAlive: true, mappedRolloutId: "rollout-9" }))).toBeNull();
+  });
+
+  it("resumes nothing for a fresh session with no key", () => {
+    expect(codexResumeId(null, facts({ rolloutExists: () => true }))).toBeNull();
+  });
+
+  // The probe reads the filesystem; a reattach must not pay for an answer it discards.
+  it("does not probe the disk when there is nothing to resume anyway", () => {
+    const rolloutExists = vi.fn().mockReturnValue(true);
+    codexResumeId(KEY, facts({ hasLivePty: true, rolloutExists }));
+    codexResumeId(null, facts({ rolloutExists }));
+    expect(rolloutExists).not.toHaveBeenCalled();
+  });
+
+  it("does not probe the disk when a mapped rollout already answers", () => {
+    const rolloutExists = vi.fn().mockReturnValue(true);
+    expect(codexResumeId(KEY, facts({ mappedRolloutId: "rollout-9", rolloutExists }))).toBe("rollout-9");
+    expect(rolloutExists).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

A codex session's browser-facing id is a key **MulmoTerminal** minted; codex's own rollout id is discovered after the spawn. So a key can mean two different things, and two rules govern it:

1. **A rollout id recorded *for* that key wins** over treating the key as a rollout id itself. Reverse them and a key that also happens to name a rollout **resumes the wrong conversation**.
2. **A cold resume is only attempted when there is nothing live to reattach.** Without the guard, a reattach carries a resume id into the spawner and starts a **second codex** on a conversation already running in tmux.

Neither was reachable from a test: the module-level `codexRolloutIds` map, a `~/.codex` read, the `ptys` table, and a shell-out to `tmux` stood in front. `codexRolloutExists` is itself tested — the precedence around it was not.

## Items to Confirm / Review

1. **The disk probe is now a thunk, not a value.** My first version computed `rolloutExists` eagerly, which would have made every *reattach* pay for a filesystem probe whose answer it immediately discards. Passing `() => boolean` preserves the inline version's laziness, and a test asserts the probe is not called when a live pty or a mapped rollout already answers.
2. Behaviour otherwise unchanged.
3. Inverting the precedence and dropping the live guard turns **5 tests red**.

## Checks

lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `190 files / 2450 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)