### PR TITLE
refactor: make the WebSocket upgrade routing testable (#598 B)

### DIFF
--- a/server/routes/terminal-ws-path.ts
+++ b/server/routes/terminal-ws-path.ts
@@ -1,0 +1,25 @@
+// Which terminal WebSocket, if any, owns an upgrade request's path.
+//
+// Returning null is not a failure — it is how /ws/pubsub reaches socket.io, which installs
+// its OWN upgrade handler on the same server. Swallow that path here (a prefix match, a
+// trailing-slash tolerance, a case-insensitive compare) and socket.io never sees the
+// upgrade: live activity, status and roster updates die silently across the whole app while
+// the terminals keep working perfectly, which is a miserable thing to debug.
+//
+// Exact matches only, for that reason.
+
+export type TerminalWsKind = "claude" | "run" | "launch" | "codex";
+
+// A Map, not an object literal: a plain object would answer `constructor` or `toString`
+// through its prototype chain with a truthy value. Unreachable through a URL pathname, which
+// always begins with "/", but this table should not depend on that being true forever.
+const BY_PATH = new Map<string, TerminalWsKind>([
+  ["/ws", "claude"],
+  ["/ws/run", "run"],
+  ["/ws/launch", "launch"],
+  ["/ws/codex", "codex"],
+]);
+
+export function terminalWsKind(pathname: string): TerminalWsKind | null {
+  return BY_PATH.get(pathname) ?? null;
+}

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -30,6 +30,7 @@ import { sessionExistsOnDisk } from "../session/session-reads.js";
 import { canStartLauncher, resolveReattachableId, resolveSession, type SessionResolution } from "../session/session-resolve.js";
 import type { PtyEntry } from "../session/types.js";
 import type { SpawnClaudePty, SpawnCodexPty, SpawnCommandPty, SpawnLauncherPty, ResolveLauncher } from "../session/spawners.js";
+import { terminalWsKind, type TerminalWsKind } from "./terminal-ws-path.js";
 
 export interface WsRouteDeps {
   /** The http server these endpoints hang their `upgrade` handler off. */
@@ -342,17 +343,15 @@ export function mountTerminalWebSockets(deps: WsRouteDeps) {
   // First-class codex sessions — persistent + reattachable like /ws/launch, but running codex
   // with session discovery + resume. Its own endpoint so /ws stays claude-only.
   const runCodexWss = new WebSocketServer({ noServer: true });
-  function wssForPath(pathname: string): WebSocketServer | null {
-    if (pathname === "/ws") return wss;
-    if (pathname === "/ws/run") return runWss;
-    if (pathname === "/ws/launch") return runLaunchWss;
-    if (pathname === "/ws/codex") return runCodexWss;
-    return null; // e.g. /ws/pubsub — left to socket.io's own upgrade handler
-  }
+  const serverFor: Record<TerminalWsKind, WebSocketServer> = { claude: wss, run: runWss, launch: runLaunchWss, codex: runCodexWss };
   deps.server.on("upgrade", (req, socket, head) => {
     const { pathname } = new URL(req.url ?? "/", "http://localhost");
-    const target = wssForPath(pathname);
-    if (!target) return;
+    const kind = terminalWsKind(pathname);
+    // Not ours (e.g. /ws/pubsub) — leave it for socket.io's own upgrade handler. This
+    // returns BEFORE the origin check on purpose: rejecting here would destroy a socket
+    // socket.io is entitled to.
+    if (!kind) return;
+    const target = serverFor[kind];
     if (!deps.isAllowedOrigin(req.headers.origin)) {
       console.warn(`[ws] rejected cross-origin upgrade from ${req.headers.origin}`);
       socket.destroy();

--- a/test/server/routes/terminal-ws-path.spec.ts
+++ b/test/server/routes/terminal-ws-path.spec.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { terminalWsKind } from "../../../server/routes/terminal-ws-path.js";
+
+describe("terminalWsKind", () => {
+  it.each([
+    ["/ws", "claude"],
+    ["/ws/run", "run"],
+    ["/ws/launch", "launch"],
+    ["/ws/codex", "codex"],
+  ])("routes %s to the %s socket", (pathname, kind) => {
+    expect(terminalWsKind(pathname)).toBe(kind);
+  });
+
+  // The one that matters: socket.io installs its own upgrade handler on the same server, and
+  // /ws/pubsub is its path. Claiming it here means socket.io never sees the upgrade — live
+  // activity, status and roster updates die across the whole app while the terminals keep
+  // working, which is a miserable thing to debug.
+  it("leaves the pubsub path to socket.io", () => {
+    expect(terminalWsKind("/ws/pubsub")).toBeNull();
+  });
+
+  // Exact matches only, for the same reason: any tolerance here can swallow a path that is
+  // not ours.
+  it.each([["/ws/"], ["/WS"], ["/ws/run/"], ["/ws/runner"], ["/wsx"], ["/ws/run?x=1"], [""], ["/"], ["/api/ws"]])("does not claim %j", (pathname) => {
+    expect(terminalWsKind(pathname)).toBeNull();
+  });
+
+  // A path that names an Object.prototype member must not resolve through the prototype
+  // chain into something truthy.
+  it.each([["constructor"], ["toString"], ["__proto__"], ["hasOwnProperty"]])("does not resolve %s through the prototype chain", (pathname) => {
+    expect(terminalWsKind(pathname)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`wssForPath` was a closure over four `WebSocketServer` instances created inside `mountTerminalWebSockets` — not importable, and reachable only through a real HTTP server and a real upgrade request.

What it decides is worth pinning: **returning null is not a failure.** It is how `/ws/pubsub` reaches socket.io, which installs its **own** upgrade handler on the same server. Claim that path here — a prefix match, a trailing-slash tolerance, a case-insensitive compare — and socket.io never sees the upgrade. Live activity, status and roster updates die **silently across the whole app** while the terminals keep working perfectly.

The unknown-path return also stays deliberately **before** the origin check: rejecting there would destroy a socket socket.io is entitled to. That ordering is now stated in the code rather than implied by line order.

## Items to Confirm / Review

1. **My first version had a bug and its own test caught it.** I used an object literal, so `terminalWsKind("constructor")` resolved through the prototype chain and returned a truthy function instead of null. Unreachable through a URL pathname (which always begins with `/`), but the table should not depend on that staying true — it is a `Map` now.
2. Behaviour otherwise identical: the same four exact paths, the same servers, the same ordering.

## A note on an intermittent local failure

A single test has failed once in each of three separate full-suite runs during this session, and has never reproduced — including 4 consecutive runs just now, and every CI run on the ~14 PRs in this series has been green. I cannot name the test and am not claiming it is unrelated; recording it here so a red CI on this branch is investigated rather than assumed to be the same thing.

## Checks

lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `190 files / 2460 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)