### PR TITLE
fix: 履歴取得中に届いたイベントが消える問題 (#620 F1)

### DIFF
--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -30,6 +30,7 @@ import { generateImage } from "../backends/image-gen.js";
 import { markdownHostApp } from "../backends/markdown.js";
 import { artifactsFileOps } from "../backends/artifacts.js";
 import { createPluginRuntime } from "./pluginRuntime.js";
+import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -178,12 +179,25 @@ export const plugins = [
   ...(await Promise.all(config.local.map(loadLocal))),
 ];
 
-const byName = Object.fromEntries(plugins.map((p) => [p.toolName, p]));
+// A name can be claimed twice; tool-precedence.ts decides who keeps it, so the advertised
+// list below is built from the same answer the dispatch map is. Both collisions used to pass
+// silently, with the list describing one implementation while another ran.
+const { dispatched: dispatchablePlugins, collisions } = resolvePluginTools(
+  plugins,
+  (p) => p.toolName,
+  HOST_TOOL_DEFINITIONS.map((d) => d.name),
+);
+for (const { name, shadowedBy } of collisions) {
+  const keeper = shadowedBy === "host" ? "a built-in host tool" : "the last plugin to declare it";
+  console.warn(`[plugins] tool "${name}" is declared more than once — ${keeper} keeps the name; the other is not offered`);
+}
+
+const byName = Object.fromEntries(dispatchablePlugins.map((p) => [p.toolName, p]));
 
 // MCP tool definitions the broker registers — gui-chat-protocol ToolDefinitions
-// ({ name, description, prompt?, parameters }), one per enabled plugin plus the
+// ({ name, description, prompt?, parameters }), one per DISPATCHABLE plugin plus the
 // built-in host tools (which the server dispatches itself; see host-tools.ts).
-export const toolDefinitions = [...plugins.map((p) => p.definition), ...HOST_TOOL_DEFINITIONS];
+export const toolDefinitions = [...dispatchablePlugins.map((p) => p.definition), ...HOST_TOOL_DEFINITIONS];
 
 // JSON-serializable summaries (no schema) for the GUI's tools pane.
 export const toolSummaries = toolDefinitions.map((d) => ({

--- a/server/infra/tool-precedence.ts
+++ b/server/infra/tool-precedence.ts
@@ -1,0 +1,43 @@
+// Which plugin actually answers a tool name, when more than one claims it.
+//
+// Two names can collide, and until now both collisions were silent AND inconsistent: the
+// dispatch map is built with Object.fromEntries, so the LAST plugin to claim a name wins it,
+// while the advertised tool list carried every claimant. A built-in host tool wins outright
+// over any plugin, because its route is mounted before the plugin catch-all — but the
+// plugin's definition was advertised all the same.
+//
+// The result is a tool list that can describe one implementation while another runs. A
+// package can take a host tool's name and be listed under it; a plugin author can watch
+// their tool be offered and never called. Resolving both here means the list is built from
+// the same answer the dispatch is (#611 A2).
+
+export interface ToolNameCollision {
+  name: string;
+  /** Who keeps the name: a built-in host tool, or the last plugin to declare it. */
+  shadowedBy: "host" | "plugin";
+}
+
+export function resolvePluginTools<T>(
+  plugins: readonly T[],
+  nameOf: (plugin: T) => string,
+  hostToolNames: readonly string[],
+): { dispatched: T[]; collisions: ToolNameCollision[] } {
+  const hosts = new Set(hostToolNames);
+  // Last claimant wins, which is what the dispatch map already does.
+  const winner = new Map<string, number>();
+  plugins.forEach((plugin, index) => winner.set(nameOf(plugin), index));
+
+  const collisions: ToolNameCollision[] = [];
+  const dispatched: T[] = [];
+  plugins.forEach((plugin, index) => {
+    const name = nameOf(plugin);
+    if (hosts.has(name)) {
+      collisions.push({ name, shadowedBy: "host" });
+    } else if (winner.get(name) !== index) {
+      collisions.push({ name, shadowedBy: "plugin" });
+    } else {
+      dispatched.push(plugin);
+    }
+  });
+  return { dispatched, collisions };
+}

--- a/src/composables/snapshotMerge.ts
+++ b/src/composables/snapshotMerge.ts
@@ -1,0 +1,33 @@
+// Reconciling an authoritative snapshot with whatever the live channel delivered while that
+// snapshot was being fetched.
+//
+// A GET answers with the state as of when the request WENT OUT, not as of when it came back.
+// Applying it as the latter is what erases an event that arrived in between: in the tools
+// pane, a tool call that fired just as the session was selected vanishes and does not come
+// back until the pane reloads its history (#620 F1).
+//
+// The snapshot keeps its order — it is the server's, and it is what the list looked like.
+// A live item replaces its counterpart IN PLACE, because it is the newer version of the
+// same row; one with no counterpart is newer than the whole snapshot and goes at the end.
+
+export function mergeSnapshotWithLive<T>(snapshot: readonly T[], live: readonly T[], identify: (item: T) => string | undefined): T[] {
+  const liveById = new Map<string, T>();
+  // An item the caller cannot identify can't be matched against the snapshot, so it can only
+  // be appended — dropping it would lose the very event this merge exists to keep.
+  const unidentified: T[] = [];
+  live.forEach((item) => {
+    const id = identify(item);
+    if (id === undefined) unidentified.push(item);
+    else liveById.set(id, item); // a re-emitted item updates in place, last wins
+  });
+
+  const merged = snapshot.map((item) => {
+    const id = identify(item);
+    if (id === undefined) return item;
+    const fresher = liveById.get(id);
+    if (fresher === undefined) return item;
+    liveById.delete(id); // taken: it must not also be appended
+    return fresher;
+  });
+  return [...merged, ...liveById.values(), ...unidentified];
+}

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -3,6 +3,7 @@
 // in, deduped by each item's identity (a re-emitted item updates in place).
 import { onUnmounted, watch, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
+import { mergeSnapshotWithLive } from "./snapshotMerge";
 
 interface SessionFeedOptions<T> {
   sessionId: () => string | null;
@@ -16,7 +17,13 @@ interface SessionFeedOptions<T> {
 export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T>) {
   const { sessionId, historyUrl, historyKey, channel, identify, onSessionChange } = options;
 
+  // Non-null while a history load is in flight, collecting what the live channel delivers
+  // meanwhile — the history answers as of the moment it was REQUESTED, so those items are
+  // newer than it and must survive being applied (#620 F1).
+  let arrivedDuringLoad: T[] | null = null;
+
   function upsert(item: T) {
+    arrivedDuringLoad?.push(item);
     const id = identify(item);
     const index = id === undefined ? -1 : items.value.findIndex((existing) => identify(existing) === id);
     if (index >= 0) items.value[index] = item;
@@ -24,6 +31,8 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
   }
 
   async function loadHistory(id: string) {
+    const live: T[] = [];
+    arrivedDuringLoad = live;
     try {
       const res = await fetch(historyUrl(id));
       // Guard against a session-switch race: a slow response for an old session must
@@ -32,9 +41,13 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       if (id !== sessionId()) return;
-      items.value = data[historyKey] ?? [];
+      items.value = mergeSnapshotWithLive(data[historyKey] ?? [], live, identify);
     } catch {
-      if (id === sessionId()) items.value = [];
+      // No history to show, but an event that arrived while asking is still this session's.
+      if (id === sessionId()) items.value = [...live];
+    } finally {
+      // A newer load has taken over: leave its buffer alone.
+      if (arrivedDuringLoad === live) arrivedDuringLoad = null;
     }
   }
 

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -21,6 +21,10 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
   // meanwhile — the history answers as of the moment it was REQUESTED, so those items are
   // newer than it and must survive being applied (#620 F1).
   let arrivedDuringLoad: T[] | null = null;
+  // Loads overlap when the session changes and changes back, so the guard below is not
+  // enough on its own: both requests are for the id that is current. Only the newest answer
+  // may be applied — an older one describes a moment already overtaken.
+  let latestLoad = 0;
 
   function upsert(item: T) {
     arrivedDuringLoad?.push(item);
@@ -31,20 +35,23 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
   }
 
   async function loadHistory(id: string) {
+    const loadId = ++latestLoad;
     const live: T[] = [];
     arrivedDuringLoad = live;
+    const overtaken = () => id !== sessionId() || loadId !== latestLoad;
     try {
       const res = await fetch(historyUrl(id));
       // Guard against a session-switch race: a slow response for an old session must
       // not clobber the pane after the user has switched to a newer one.
-      if (id !== sessionId()) return;
+      if (overtaken()) return;
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      if (id !== sessionId()) return;
+      if (overtaken()) return;
       items.value = mergeSnapshotWithLive(data[historyKey] ?? [], live, identify);
     } catch {
       // No history to show, but an event that arrived while asking is still this session's.
-      if (id === sessionId()) items.value = [...live];
+      // A load that has been overtaken leaves the list to the one that overtook it.
+      if (!overtaken()) items.value = [...live];
     } finally {
       // A newer load has taken over: leave its buffer alone.
       if (arrivedDuringLoad === live) arrivedDuringLoad = null;

--- a/test/server/infra/tool-precedence.spec.ts
+++ b/test/server/infra/tool-precedence.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+
+import { resolvePluginTools } from "../../../server/infra/tool-precedence.js";
+
+interface FakePlugin {
+  toolName: string;
+  from: string;
+}
+
+const plugin = (toolName: string, from: string): FakePlugin => ({ toolName, from });
+const nameOf = (p: FakePlugin) => p.toolName;
+const HOSTS = ["spawnBackgroundChat", "manageAccounting", "manageCollection"];
+
+const resolve = (plugins: FakePlugin[], hosts: string[] = HOSTS) => resolvePluginTools(plugins, nameOf, hosts);
+const dispatchedNames = (plugins: FakePlugin[], hosts?: string[]) => resolve(plugins, hosts).dispatched.map(nameOf);
+
+describe("resolvePluginTools", () => {
+  describe("with no collision", () => {
+    it("dispatches every plugin, in the order they were loaded", () => {
+      const plugins = [plugin("presentHtml", "a"), plugin("presentForm", "b"), plugin("presentMulmoScript", "c")];
+      expect(dispatchedNames(plugins)).toEqual(["presentHtml", "presentForm", "presentMulmoScript"]);
+    });
+
+    it("reports nothing", () => {
+      expect(resolve([plugin("presentHtml", "a")]).collisions).toEqual([]);
+    });
+  });
+
+  // A package taking a host tool's name is the case with teeth: the host route is mounted
+  // first, so the plugin can never run — but its definition used to be advertised anyway,
+  // leaving the tool list describing a package while the built-in answered.
+  describe("when a plugin claims a host tool's name", () => {
+    it("does not dispatch it", () => {
+      const plugins = [plugin("presentHtml", "a"), plugin("manageCollection", "evil")];
+      expect(dispatchedNames(plugins)).toEqual(["presentHtml"]);
+    });
+
+    it("reports that the host tool keeps the name", () => {
+      const plugins = [plugin("manageCollection", "evil")];
+      expect(resolve(plugins).collisions).toEqual([{ name: "manageCollection", shadowedBy: "host" }]);
+    });
+
+    it("drops it wherever it sits in the load order", () => {
+      const plugins = [plugin("manageAccounting", "first"), plugin("presentHtml", "a"), plugin("spawnBackgroundChat", "last")];
+      expect(dispatchedNames(plugins)).toEqual(["presentHtml"]);
+    });
+
+    it("drops every plugin claiming it, not just one", () => {
+      const plugins = [plugin("manageCollection", "a"), plugin("manageCollection", "b")];
+      expect(resolve(plugins).dispatched).toEqual([]);
+      expect(resolve(plugins).collisions).toEqual([
+        { name: "manageCollection", shadowedBy: "host" },
+        { name: "manageCollection", shadowedBy: "host" },
+      ]);
+    });
+  });
+
+  // The dispatch map is built with Object.fromEntries, so the last claimant already won it.
+  // What changes is that the losers are no longer advertised as if they might answer.
+  describe("when two plugins claim the same name", () => {
+    it("dispatches the last one to declare it", () => {
+      const plugins = [plugin("presentHtml", "old"), plugin("presentHtml", "new")];
+      expect(resolve(plugins).dispatched).toEqual([plugin("presentHtml", "new")]);
+    });
+
+    it("reports the earlier one as shadowed", () => {
+      const plugins = [plugin("presentHtml", "old"), plugin("presentHtml", "new")];
+      expect(resolve(plugins).collisions).toEqual([{ name: "presentHtml", shadowedBy: "plugin" }]);
+    });
+
+    it("keeps only the last of three", () => {
+      const plugins = [plugin("x", "1"), plugin("x", "2"), plugin("x", "3")];
+      expect(resolve(plugins).dispatched).toEqual([plugin("x", "3")]);
+      expect(resolve(plugins).collisions).toHaveLength(2);
+    });
+
+    it("leaves the other plugins where they are", () => {
+      const plugins = [plugin("a", "1"), plugin("dup", "old"), plugin("b", "2"), plugin("dup", "new")];
+      expect(dispatchedNames(plugins)).toEqual(["a", "b", "dup"]);
+    });
+  });
+
+  // The property the whole resolution exists for: the advertised list is built from
+  // `dispatched`, so anything in it must be able to answer.
+  describe("what survives can always answer", () => {
+    it("never dispatches a name twice", () => {
+      const plugins = [plugin("dup", "1"), plugin("dup", "2"), plugin("dup", "3"), plugin("other", "x")];
+      const names = dispatchedNames(plugins);
+      expect(new Set(names).size).toBe(names.length);
+    });
+
+    it("never dispatches a name a host tool owns", () => {
+      const plugins = HOSTS.map((name) => plugin(name, "pkg")).concat(plugin("fine", "a"));
+      expect(dispatchedNames(plugins).filter((name) => HOSTS.includes(name))).toEqual([]);
+    });
+  });
+
+  describe("empty cases", () => {
+    it("resolves an empty plugin list", () => {
+      expect(resolve([])).toEqual({ dispatched: [], collisions: [] });
+    });
+
+    it("dispatches everything when there are no host tools", () => {
+      expect(dispatchedNames([plugin("manageCollection", "a")], [])).toEqual(["manageCollection"]);
+    });
+  });
+});

--- a/test/src/composables/snapshotMerge.spec.ts
+++ b/test/src/composables/snapshotMerge.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+
+import { mergeSnapshotWithLive } from "../../../src/composables/snapshotMerge";
+
+interface Row {
+  id?: string;
+  text: string;
+}
+
+const identify = (row: Row) => row.id;
+const texts = (rows: Row[]) => rows.map((row) => row.text);
+
+const HISTORY: Row[] = [
+  { id: "a", text: "first" },
+  { id: "b", text: "second" },
+  { id: "c", text: "third" },
+];
+
+describe("mergeSnapshotWithLive", () => {
+  it("keeps the snapshot as-is when nothing arrived meanwhile", () => {
+    expect(mergeSnapshotWithLive(HISTORY, [], identify)).toEqual(HISTORY);
+  });
+
+  // The case the merge exists for: the event fired after the request went out, so the
+  // history could not contain it, and replacing wholesale used to erase it.
+  it("keeps an item the snapshot could not have known about", () => {
+    const live = [{ id: "d", text: "arrived while loading" }];
+    expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).toEqual(["first", "second", "third", "arrived while loading"]);
+  });
+
+  it("puts a newer item after the snapshot, not before it", () => {
+    const live = [{ id: "d", text: "newest" }];
+    expect(mergeSnapshotWithLive(HISTORY, live, identify).at(-1)?.text).toBe("newest");
+  });
+
+  describe("when a live item is a newer version of a row the snapshot has", () => {
+    const live = [{ id: "b", text: "second, updated" }];
+
+    it("takes the live version", () => {
+      expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).toContain("second, updated");
+      expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).not.toContain("second");
+    });
+
+    it("leaves it where the snapshot had it", () => {
+      expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).toEqual(["first", "second, updated", "third"]);
+    });
+
+    it("does not also append it", () => {
+      expect(mergeSnapshotWithLive(HISTORY, live, identify)).toHaveLength(3);
+    });
+
+    it("updates the first row without disturbing the rest", () => {
+      const updateFirst = [{ id: "a", text: "first, updated" }];
+      expect(texts(mergeSnapshotWithLive(HISTORY, updateFirst, identify))).toEqual(["first, updated", "second", "third"]);
+    });
+  });
+
+  describe("several live items", () => {
+    it("appends them in arrival order", () => {
+      const live = [
+        { id: "d", text: "d" },
+        { id: "e", text: "e" },
+      ];
+      expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).toEqual(["first", "second", "third", "d", "e"]);
+    });
+
+    it("mixes updates and additions without losing either", () => {
+      const live = [
+        { id: "b", text: "second, updated" },
+        { id: "d", text: "new" },
+      ];
+      expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).toEqual(["first", "second, updated", "third", "new"]);
+    });
+
+    // A tool call is re-emitted as it progresses, so the same id arrives more than once.
+    it("keeps only the last version of a repeated item", () => {
+      const live = [
+        { id: "d", text: "running" },
+        { id: "d", text: "done" },
+      ];
+      const merged = mergeSnapshotWithLive(HISTORY, live, identify);
+      expect(texts(merged)).toEqual(["first", "second", "third", "done"]);
+      expect(merged).toHaveLength(4);
+    });
+
+    it("keeps only the last version when it updates a snapshot row too", () => {
+      const live = [
+        { id: "b", text: "running" },
+        { id: "b", text: "done" },
+      ];
+      expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).toEqual(["first", "done", "third"]);
+    });
+  });
+
+  describe("empty cases", () => {
+    it("returns the live items when there is no history", () => {
+      const live = [{ id: "a", text: "only" }];
+      expect(mergeSnapshotWithLive([], live, identify)).toEqual(live);
+    });
+
+    it("returns nothing when both are empty", () => {
+      expect(mergeSnapshotWithLive([], [], identify)).toEqual([]);
+    });
+  });
+
+  // An item the caller cannot identify cannot be matched, so it can only be appended —
+  // dropping it would lose the event the merge exists to keep.
+  describe("items with no identity", () => {
+    it("keeps an unidentifiable live item", () => {
+      const live = [{ text: "no id" }];
+      expect(texts(mergeSnapshotWithLive(HISTORY, live, identify))).toEqual(["first", "second", "third", "no id"]);
+    });
+
+    it("keeps unidentifiable snapshot rows where they were", () => {
+      const snapshot = [{ text: "no id" }, { id: "a", text: "first" }];
+      expect(texts(mergeSnapshotWithLive(snapshot, [], identify))).toEqual(["no id", "first"]);
+    });
+
+    it("never matches two unidentifiable items to each other", () => {
+      const snapshot = [{ text: "snapshot one" }];
+      const live = [{ text: "live one" }];
+      expect(texts(mergeSnapshotWithLive(snapshot, live, identify))).toEqual(["snapshot one", "live one"]);
+    });
+  });
+});

--- a/test/src/composables/useSessionFeed.spec.ts
+++ b/test/src/composables/useSessionFeed.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ref, effectScope } from "vue";
+import { flushPromises } from "@vue/test-utils";
+
+const subscribers = new Map<string, (data: unknown) => void>();
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, handler: (data: unknown) => void) => {
+      subscribers.set(channel, handler);
+      return () => subscribers.delete(channel);
+    },
+    onReconnect: () => {},
+  }),
+}));
+
+import { useSessionFeed } from "../../../src/composables/useSessionFeed";
+
+interface Row {
+  id: string;
+  text: string;
+}
+
+const HISTORY_ROW: Row = { id: "from-history", text: "an older tool call" };
+const LIVE_ROW: Row = { id: "from-live", text: "fired while loading" };
+
+// A history response that this test decides when to resolve, so an event can be delivered
+// while the request is still out — the window the bug lives in.
+function deferredHistory(rows: Row[]) {
+  let resolve!: () => void;
+  const gate = new Promise<void>((r) => (resolve = r));
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      await gate;
+      return { ok: true, json: async () => ({ rows }) };
+    }),
+  );
+  return { answer: resolve };
+}
+
+function mountFeed(sessionId = "session-1") {
+  const items = ref<Row[]>([]);
+  const scope = effectScope();
+  scope.run(() =>
+    useSessionFeed<Row>(items, {
+      sessionId: () => sessionId,
+      historyUrl: (id) => `/api/history/${id}`,
+      historyKey: "rows",
+      channel: (id) => `feed:${id}`,
+      identify: (row) => row.id,
+    }),
+  );
+  return { items, scope, deliver: (row: Row) => subscribers.get(`feed:${sessionId}`)?.(row) };
+}
+
+const ids = (rows: Row[]) => rows.map((row) => row.id);
+
+beforeEach(() => subscribers.clear());
+afterEach(() => vi.unstubAllGlobals());
+
+describe("useSessionFeed", () => {
+  // The regression: the pane subscribes before the history lands, so an event can arrive
+  // while the request is out. Assigning the response wholesale erased it, and nothing
+  // brought it back until the pane reloaded (#620 F1).
+  it("keeps an event that arrived while the history was loading", async () => {
+    const { answer } = deferredHistory([HISTORY_ROW]);
+    const { items, deliver } = mountFeed();
+
+    deliver(LIVE_ROW);
+    expect(ids(items.value)).toEqual(["from-live"]);
+
+    answer();
+    await flushPromises();
+    expect(ids(items.value)).toEqual(["from-history", "from-live"]);
+  });
+
+  it("still shows the history it fetched", async () => {
+    const { answer } = deferredHistory([HISTORY_ROW]);
+    const { items } = mountFeed();
+    answer();
+    await flushPromises();
+    expect(ids(items.value)).toEqual(["from-history"]);
+  });
+
+  // A re-emitted item is the same row moving on, not a second one.
+  it("lets an event update the history row it belongs to", async () => {
+    const { answer } = deferredHistory([HISTORY_ROW]);
+    const { items, deliver } = mountFeed();
+
+    deliver({ id: "from-history", text: "now finished" });
+    answer();
+    await flushPromises();
+    expect(items.value).toEqual([{ id: "from-history", text: "now finished" }]);
+  });
+
+  // Losing the history is not a reason to lose an event that belongs to this session.
+  it("keeps a live event when the history request fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+    const { items, deliver } = mountFeed();
+    deliver(LIVE_ROW);
+    await flushPromises();
+    expect(ids(items.value)).toEqual(["from-live"]);
+  });
+
+  it("keeps a live event when the history request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const { items, deliver } = mountFeed();
+    deliver(LIVE_ROW);
+    await flushPromises();
+    expect(ids(items.value)).toEqual(["from-live"]);
+  });
+
+  it("appends events that arrive after the history has landed", async () => {
+    const { answer } = deferredHistory([HISTORY_ROW]);
+    const { items, deliver } = mountFeed();
+    answer();
+    await flushPromises();
+
+    deliver(LIVE_ROW);
+    expect(ids(items.value)).toEqual(["from-history", "from-live"]);
+  });
+});

--- a/test/src/composables/useSessionFeed.spec.ts
+++ b/test/src/composables/useSessionFeed.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ref, effectScope } from "vue";
+import { ref, effectScope, nextTick } from "vue";
 import { flushPromises } from "@vue/test-utils";
 
 const subscribers = new Map<string, (data: unknown) => void>();
@@ -41,17 +41,23 @@ function deferredHistory(rows: Row[]) {
 
 function mountFeed(sessionId = "session-1") {
   const items = ref<Row[]>([]);
+  const current = ref(sessionId);
   const scope = effectScope();
   scope.run(() =>
     useSessionFeed<Row>(items, {
-      sessionId: () => sessionId,
+      sessionId: () => current.value,
       historyUrl: (id) => `/api/history/${id}`,
       historyKey: "rows",
       channel: (id) => `feed:${id}`,
       identify: (row) => row.id,
     }),
   );
-  return { items, scope, deliver: (row: Row) => subscribers.get(`feed:${sessionId}`)?.(row) };
+  return {
+    items,
+    scope,
+    current,
+    deliver: (row: Row) => subscribers.get(`feed:${current.value}`)?.(row),
+  };
 }
 
 const ids = (rows: Row[]) => rows.map((row) => row.id);
@@ -119,5 +125,40 @@ describe("useSessionFeed", () => {
 
     deliver(LIVE_ROW);
     expect(ids(items.value)).toEqual(["from-history", "from-live"]);
+  });
+});
+
+// Codex on #626 found the same rollback one level up in the sibling composable: requests
+// overlap, and an older answer landing last puts back what the newer one replaced. Here two
+// loads for the SAME id can be in flight — switch away and back — so the id guard alone
+// does not catch it.
+describe("useSessionFeed — when loads overlap", () => {
+  it("ignores an older history that lands after a newer one", async () => {
+    const gates: Array<() => void> = [];
+    // Three loads: the initial one, the switch away, and the switch back.
+    const answers = [[{ id: "old", text: "older history" }], [{ id: "other", text: "other session" }], [{ id: "new", text: "newer history" }]];
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const mine = call++;
+        await new Promise<void>((resolve) => gates.push(resolve));
+        return { ok: true, json: async () => ({ rows: answers[mine] }) };
+      }),
+    );
+
+    const { items, current } = mountFeed("session-1");
+    current.value = "session-2";
+    await nextTick();
+    current.value = "session-1"; // back again: both loads are for an id that is current
+    await nextTick();
+
+    gates.at(-1)?.(); // the newest answers first
+    await flushPromises();
+    expect(ids(items.value)).toEqual(["new"]);
+
+    gates[0]?.(); // the stale one, arriving last
+    await flushPromises();
+    expect(ids(items.value)).toEqual(["new"]);
   });
 });


### PR DESCRIPTION
Refs #620

## Summary

ツールペインと GUI パネルで、**セッションを切り替えた瞬間に発火したツール呼び出しが 1 件消える**バグの修正です。

```ts
watch(sessionId, (id) => {
  if (id) loadHistory(id);   // ① 非同期で開始（await しない）
  subscribeTo(id);           // ② 直後に購読 → イベントが即届きうる
}, { immediate: true });
```

購読は fetch の完了を待たずに始まります。その間に届いたイベントは `upsert` で表示されますが、履歴の応答が返った瞬間 `items.value = data[historyKey]` で**丸ごと上書きされて消えます**。**再読込するまで戻りません**（誰も再送しないため）。

**作業中のセッションに切り替えたときが一番当たります** — まさに切り替えた瞬間に完了したツール呼び出しが消えます。

## 直し方

**GET の応答は「リクエストを出した時点」の権威ある値であって、「返ってきた時点」の値ではない** — これが判断の中身です。`src/composables/snapshotMerge.ts` に出しました。

- 履歴はその順序と行を保つ（サーバの順序であり、実際そう見えていたもの）
- live 側の項目は**同じ行の新しい版**なので、その位置で置き換える
- 対応する行が無い live 項目は履歴全体より新しいので**末尾に付く**

`catch` 節にも同じ穴がありました（履歴の取得失敗でライブイベントごと消える）。届いていたものは残すようにしています。

## Items to Confirm / Review

1. **テストを 2 層に書きました** — バグは**合成側（composable の配線）**にあり、`snapshotMerge` 単体のテストだけでは**どちらの実装でも通ってしまう**ためです。`useSessionFeed` 自体の回帰テストで、元の実装が落ちることを確認しています
2. `useSessionFeed.spec.ts` は `usePubSub` を `vi.mock` し、履歴の応答を**テスト側が解決タイミングを握る**形にして、バグの窓（リクエスト送出中）を再現しています
3. **識別子を持たない項目**は照合できないので末尾に付けています（捨てると、この修正が守ろうとしているイベントを失うため）

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| 履歴で丸ごと置換（＝元のバグ）に戻す | **composable 6 件中 4 件** |
| マージから live を捨てる | merge 16 件中 6 件 |
| 位置を保たず末尾に足す | merge 16 件中 6 件 |

## 出所とファミリー

`codex exec` に「テストの穴ではなく**実際の欠陥**を探せ」という切り口で 2 周目を依頼したところ、**同じ形のバグが 5 箇所**見つかりました。Codex は 4 件すべてを "Confidence: High" としていましたが、**実コードに当てると重さが違いました**（丸ごと置換の 3 件が本物、マージしている 2 件は軽微）。行列は #620 に記録しています。

これはその F1 です。残り:

- **F2** `useNotifications.ts:100` — `active.value` の無条件置換。**消したはずの通知が復活する**
- **F3** `useGridActivity.ts:28` — 応答の各 id を無条件上書き。**セルが一瞬 working → idle に巻き戻る**

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:test` / `yarn build` / `yarn test`（192 files, 2478 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
