### PR TITLE
refactor: make the roster metadata merge testable (#598 B)

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -37,7 +37,7 @@ import {
   MAX_TERMINALS,
 } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
-import { isPrPhase, isWorkPhase, type PrPhase, type WorkPhase } from "./rosterPhase";
+import { EMPTY_SESSION_META, isPrPhase, mergeSessionMeta, type PrPhase, type WorkPhase } from "./rosterPhase";
 import { useGridActivity } from "../composables/useGridActivity";
 import { registerNewTerminalHandler, type NewTerminalRequest } from "../composables/useNewTerminal";
 import { usePendingScript } from "../composables/usePendingScript";
@@ -115,15 +115,7 @@ async function seedMeta(id: string, cwd: string | null) {
     const res = await fetch(`/api/session/${id}${query}`);
     if (!res.ok) return;
     const d = (await res.json()) as Partial<SessionMeta>;
-    const prev = sessionMeta.get(id) ?? { lastPrompt: null, aiTitle: null, lastResponse: null, workPhase: null };
-    sessionMeta.set(id, {
-      lastPrompt: d.lastPrompt ?? prev.lastPrompt,
-      aiTitle: d.aiTitle ?? prev.aiTitle,
-      lastResponse: d.lastResponse ?? prev.lastResponse,
-      // A successful fetch is authoritative for workPhase (unlike the text fields, which the
-      // summary can transiently miss), so take it as-is — including null (no tools / not working).
-      workPhase: isWorkPhase(d.workPhase) ? d.workPhase : null,
-    });
+    sessionMeta.set(id, mergeSessionMeta(sessionMeta.get(id) ?? EMPTY_SESSION_META, d));
   } catch {
     // best-effort — the next poll retries
   }

--- a/src/components/rosterPhase.ts
+++ b/src/components/rosterPhase.ts
@@ -31,3 +31,35 @@ export const isWorkPhase = (v: unknown): v is WorkPhase => v === "planning" || v
 
 // "editing" reads clearer than "implementing" in the tiny roster badge.
 export const WORK_WORD: Record<WorkPhase, string> = { planning: "planning", implementing: "editing" };
+
+// What the roster shows for a session after a metadata fetch, given what it already showed.
+//
+// Two opposite policies in one merge, and both are deliberate:
+//
+// The TEXT fields merge — an absent value keeps whatever is on screen. The summary can
+// transiently miss a transcript, and blanking every row on the first poll that comes up
+// empty would strip the cockpit exactly when the user is scanning it to decide which of nine
+// agents to look at.
+//
+// `workPhase` is taken AS-IS, including null, because a successful fetch is authoritative for
+// it: null means "no tools yet / not working", which is a real state. Merge it like the text
+// and a finished agent keeps a "planning" badge forever.
+export interface SessionMetaView {
+  lastPrompt: string | null;
+  aiTitle: string | null;
+  lastResponse: string | null;
+  workPhase: WorkPhase | null;
+}
+
+export const EMPTY_SESSION_META: SessionMetaView = { lastPrompt: null, aiTitle: null, lastResponse: null, workPhase: null };
+
+// `workPhase` is typed unknown because it arrives as untrusted JSON — isWorkPhase is the
+// only thing that may decide it is a phase.
+export function mergeSessionMeta(previous: SessionMetaView, fetched: Omit<Partial<SessionMetaView>, "workPhase"> & { workPhase?: unknown }): SessionMetaView {
+  return {
+    lastPrompt: fetched.lastPrompt ?? previous.lastPrompt,
+    aiTitle: fetched.aiTitle ?? previous.aiTitle,
+    lastResponse: fetched.lastResponse ?? previous.lastResponse,
+    workPhase: isWorkPhase(fetched.workPhase) ? fetched.workPhase : null,
+  };
+}

--- a/test/src/components/rosterPhase.spec.ts
+++ b/test/src/components/rosterPhase.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isPrPhase, phaseDisplay, type PrPhase } from "../../../src/components/rosterPhase";
+import { isPrPhase, phaseDisplay, type PrPhase, mergeSessionMeta, EMPTY_SESSION_META } from "../../../src/components/rosterPhase";
 
 describe("isPrPhase", () => {
   it.each(["none", "draft", "ci-failing", "changes-requested", "ci-running", "ready", "merged", "closed"])("accepts %s", (v) => {
@@ -28,5 +28,51 @@ describe("phaseDisplay", () => {
     const d = phaseDisplay(phase);
     expect(d?.label).toBe(label);
     expect(d?.title).toMatch(/PR|Draft/);
+  });
+});
+
+describe("mergeSessionMeta", () => {
+  const shown = { lastPrompt: "fix the login bug", aiTitle: "Login fix", lastResponse: "done", workPhase: "implementing" as const };
+
+  it("takes what the fetch returned", () => {
+    const merged = mergeSessionMeta(shown, { lastPrompt: "new task", aiTitle: "New", lastResponse: "ok", workPhase: "planning" });
+    expect(merged).toEqual({ lastPrompt: "new task", aiTitle: "New", lastResponse: "ok", workPhase: "planning" });
+  });
+
+  // The text fields MERGE: the summary can transiently miss a transcript, and blanking every
+  // row on the first poll that comes up empty strips the cockpit exactly when the user is
+  // scanning it to decide which of nine agents to look at.
+  it("keeps the text already on screen when the fetch has none", () => {
+    const merged = mergeSessionMeta(shown, {});
+    expect([merged.lastPrompt, merged.aiTitle, merged.lastResponse]).toEqual(["fix the login bug", "Login fix", "done"]);
+  });
+
+  // workPhase is the opposite: a successful fetch is authoritative, and null is a real state
+  // ("no tools yet / not working"). Merge it like the text and a finished agent keeps a
+  // "planning" badge forever.
+  it("clears the phase when the fetch says there is none", () => {
+    expect(mergeSessionMeta(shown, {}).workPhase).toBeNull();
+    expect(mergeSessionMeta(shown, { workPhase: null }).workPhase).toBeNull();
+  });
+
+  it("refuses a phase value it does not recognise", () => {
+    for (const workPhase of ["done", "", 1, {}, "PLANNING"]) {
+      expect(mergeSessionMeta(shown, { workPhase }).workPhase).toBeNull();
+    }
+  });
+
+  it("updates one text field without disturbing the others", () => {
+    const merged = mergeSessionMeta(shown, { aiTitle: "Renamed" });
+    expect([merged.lastPrompt, merged.aiTitle, merged.lastResponse]).toEqual(["fix the login bug", "Renamed", "done"]);
+  });
+
+  it("starts from nothing for a session it has not seen", () => {
+    expect(mergeSessionMeta(EMPTY_SESSION_META, { lastPrompt: "first" })).toEqual({ lastPrompt: "first", aiTitle: null, lastResponse: null, workPhase: null });
+  });
+
+  it("does not mutate what it was given", () => {
+    const previous = { ...shown };
+    mergeSessionMeta(previous, { lastPrompt: "new" });
+    expect(previous).toEqual(shown);
   });
 });


### PR DESCRIPTION
## Summary

`seedMeta`'s merge held **two opposite policies in one object literal**, both deliberate and neither asserted anywhere.

| Field | Policy | If it were the other way |
|---|---|---|
| `lastPrompt` / `aiTitle` / `lastResponse` | **merge** — absent keeps what is on screen | The first poll that misses a transcript **blanks every row**, exactly when the user is scanning the cockpit to pick which of nine agents to look at |
| `workPhase` | **authoritative, including null** — a successful fetch decides | A finished agent keeps a **"planning" badge forever** |

It lands in `rosterPhase.ts`, which already owns `WorkPhase` and `isWorkPhase`. Merging `workPhase` like the text turns **2 tests red**.

## Items to Confirm / Review

1. **Behaviour unchanged** — same two policies, same validation of the phase value.
2. **`workPhase` is typed `unknown` on the way in**, since it arrives as untrusted JSON and `isWorkPhase` should be the only thing that decides it is a phase. My first attempt wrote `Partial<T> & { workPhase?: unknown }`, which does nothing (`unknown & X` is `X`) — `typecheck:test` caught it, not the tests.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `192 files / 2490 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)