### PR TITLE
fix: 読み込み中に消した通知が復活する問題 (#620 F2)

### DIFF
--- a/src/composables/snapshotMerge.ts
+++ b/src/composables/snapshotMerge.ts
@@ -10,24 +10,35 @@
 // A live item replaces its counterpart IN PLACE, because it is the newer version of the
 // same row; one with no counterpart is newer than the whole snapshot and goes at the end.
 
-export function mergeSnapshotWithLive<T>(snapshot: readonly T[], live: readonly T[], identify: (item: T) => string | undefined): T[] {
-  const liveById = new Map<string, T>();
-  // An item the caller cannot identify can't be matched against the snapshot, so it can only
-  // be appended — dropping it would lose the very event this merge exists to keep.
-  const unidentified: T[] = [];
-  live.forEach((item) => {
-    const id = identify(item);
-    if (id === undefined) unidentified.push(item);
-    else liveById.set(id, item); // a re-emitted item updates in place, last wins
-  });
+// What the live channel did while the snapshot was in flight. Removals have to travel too:
+// a list that only knows about additions would hand back something the user has already
+// dismissed (#620 F2).
+export type LiveChange<T> = { kind: "upsert"; item: T } | { kind: "remove"; id: string };
 
-  const merged = snapshot.map((item) => {
-    const id = identify(item);
-    if (id === undefined) return item;
-    const fresher = liveById.get(id);
-    if (fresher === undefined) return item;
-    liveById.delete(id); // taken: it must not also be appended
-    return fresher;
-  });
-  return [...merged, ...liveById.values(), ...unidentified];
+// Replayed IN ORDER, because the order is the answer: publish-then-clear leaves nothing,
+// clear-then-publish leaves the item, and a set of ids could not tell the two apart.
+export function applyLiveChanges<T>(snapshot: readonly T[], changes: readonly LiveChange<T>[], identify: (item: T) => string | undefined): T[] {
+  const rows = [...snapshot];
+  for (const change of changes) {
+    if (change.kind === "remove") {
+      const index = rows.findIndex((row) => identify(row) === change.id);
+      if (index >= 0) rows.splice(index, 1);
+      continue;
+    }
+    const id = identify(change.item);
+    // An item the caller cannot identify can't be matched, so it can only be appended —
+    // dropping it would lose the very event this exists to keep.
+    const index = id === undefined ? -1 : rows.findIndex((row) => identify(row) === id);
+    if (index >= 0) rows[index] = change.item;
+    else rows.push(change.item);
+  }
+  return rows;
+}
+
+export function mergeSnapshotWithLive<T>(snapshot: readonly T[], live: readonly T[], identify: (item: T) => string | undefined): T[] {
+  return applyLiveChanges(
+    snapshot,
+    live.map((item) => ({ kind: "upsert" as const, item })),
+    identify,
+  );
 }

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -41,6 +41,9 @@ let initialized = false;
 // meanwhile. The response answers as of the moment it was REQUESTED, so applying it as-is
 // hands back a notification the user has since dismissed (#620 F2).
 let changesDuringFetch: LiveChange<NotifierEntry>[] | null = null;
+// Fetches overlap: the bell asks on init and again on every pub/sub reconnect. Only the
+// newest answer may be applied — an older one describes a moment already overtaken.
+let latestFetch = 0;
 
 /** Parse a collection deep-link (`/collections/<slug>?selected=<itemId>`) into its
  *  parts. String ops + URLSearchParams only — no regex (lint bans backtracking-prone
@@ -98,15 +101,19 @@ function applyEvent(event: NotifierEvent): void {
 }
 
 async function fetchActive(): Promise<void> {
+  const fetchId = ++latestFetch;
   const changes: LiveChange<NotifierEntry>[] = [];
   changesDuringFetch = changes;
   try {
     const res = await fetch("/api/notifications");
+    // Overtaken while we waited: leave the list to the fetch that overtook us.
+    if (fetchId !== latestFetch) return;
     if (!res.ok) {
       console.error(`[notifications] list failed: HTTP ${res.status}`);
       return;
     }
     const data = (await res.json()) as { active?: NotifierEntry[] };
+    if (fetchId !== latestFetch) return;
     const snapshot = Array.isArray(data.active) ? data.active : [];
     active.value = applyLiveChanges(snapshot, changes, (entry) => entry.id);
   } catch (err) {

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -8,6 +8,7 @@
 // matching the wire shape the server's /api/notifications + NotifierEvent emit.
 import { ref, computed } from "vue";
 import { usePubSub } from "./usePubSub";
+import { applyLiveChanges, type LiveChange } from "./snapshotMerge";
 import { browseNavigateToRecord } from "./useCollectionBrowse";
 
 // Must match server/backends/notifier.ts NOTIFIER_CHANNEL.
@@ -36,6 +37,10 @@ const SEVERITY_RANK: Record<NotifierSeverity, number> = { info: 0, nudge: 1, urg
 
 const active = ref<NotifierEntry[]>([]);
 let initialized = false;
+// Non-null while the authoritative list is being fetched, recording what the channel did
+// meanwhile. The response answers as of the moment it was REQUESTED, so applying it as-is
+// hands back a notification the user has since dismissed (#620 F2).
+let changesDuringFetch: LiveChange<NotifierEntry>[] | null = null;
 
 /** Parse a collection deep-link (`/collections/<slug>?selected=<itemId>`) into its
  *  parts. String ops + URLSearchParams only — no regex (lint bans backtracking-prone
@@ -81,16 +86,20 @@ function applyEvent(event: NotifierEvent): void {
   switch (event.type) {
     case "published":
     case "updated":
+      changesDuringFetch?.push({ kind: "upsert", item: event.entry });
       upsert(event.entry);
       break;
     case "cleared":
     case "cancelled":
+      changesDuringFetch?.push({ kind: "remove", id: event.id });
       remove(event.id);
       break;
   }
 }
 
 async function fetchActive(): Promise<void> {
+  const changes: LiveChange<NotifierEntry>[] = [];
+  changesDuringFetch = changes;
   try {
     const res = await fetch("/api/notifications");
     if (!res.ok) {
@@ -98,9 +107,13 @@ async function fetchActive(): Promise<void> {
       return;
     }
     const data = (await res.json()) as { active?: NotifierEntry[] };
-    active.value = Array.isArray(data.active) ? data.active : [];
+    const snapshot = Array.isArray(data.active) ? data.active : [];
+    active.value = applyLiveChanges(snapshot, changes, (entry) => entry.id);
   } catch (err) {
     console.error("[notifications] list failed", err);
+  } finally {
+    // A newer fetch has taken over: leave its record alone.
+    if (changesDuringFetch === changes) changesDuringFetch = null;
   }
 }
 

--- a/test/src/composables/useNotifications.spec.ts
+++ b/test/src/composables/useNotifications.spec.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from "vitest";
-import { parseCollectionTarget } from "../../../src/composables/useNotifications";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { flushPromises } from "@vue/test-utils";
+import { parseCollectionTarget, type NotifierEntry } from "../../../src/composables/useNotifications";
+
+const subscribers = new Map<string, (data: unknown) => void>();
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, handler: (data: unknown) => void) => {
+      subscribers.set(channel, handler);
+      return () => subscribers.delete(channel);
+    },
+    onReconnect: () => {},
+  }),
+}));
 
 describe("parseCollectionTarget", () => {
   it("parses slug + selected itemId", () => {
@@ -43,5 +56,112 @@ describe("parseCollectionTarget", () => {
 
   it("returns null for undefined", () => {
     expect(parseCollectionTarget(undefined)).toBeNull();
+  });
+});
+
+// The bell's list is fetched whole, and the channel keeps changing it while that request is
+// out — including clearing an entry the response still lists. Applying the response as-is
+// brought a dismissed notification back (#620 F2).
+describe("useNotifications — the list fetched while the channel is live", () => {
+  const entry = (id: string, title: string): NotifierEntry => ({
+    id,
+    pluginPkg: "test",
+    severity: "info",
+    title,
+    createdAt: "2026-07-22T00:00:00Z",
+  });
+
+  const BELL = entry("n1", "Build finished");
+  const OTHER = entry("n2", "Review requested");
+
+  // The module keeps `active` and its initialised flag in module scope, so each case needs
+  // its own copy to say anything about what a fresh page does.
+  const freshModule = async () => {
+    vi.resetModules();
+    return import("../../../src/composables/useNotifications");
+  };
+
+  // A list request this test decides when to answer, so an event can be delivered while it
+  // is still out — the window the bug lives in.
+  function deferredList(active: NotifierEntry[]) {
+    let answer!: () => void;
+    const gate = new Promise<void>((resolve) => (answer = resolve));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        await gate;
+        return { ok: true, json: async () => ({ active }) };
+      }),
+    );
+    return { answer };
+  }
+
+  const deliver = (event: unknown) => subscribers.get("notifications")?.(event);
+
+  beforeEach(() => subscribers.clear());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not bring back a notification cleared while the list was loading", async () => {
+    const { answer } = deferredList([BELL, OTHER]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "cleared", id: "n1" });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.id)).toEqual(["n2"]);
+  });
+
+  it("keeps a notification published while the list was loading", async () => {
+    const { answer } = deferredList([BELL]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "published", entry: OTHER });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.id)).toEqual(["n1", "n2"]);
+  });
+
+  it("takes an update that landed while the list was loading", async () => {
+    const { answer } = deferredList([BELL]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "updated", entry: entry("n1", "Build failed") });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.title)).toEqual(["Build failed"]);
+  });
+
+  // Order is the answer: cleared-then-published leaves the entry, and the reverse does not.
+  it("replays what happened in the order it happened", async () => {
+    const { answer } = deferredList([BELL]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "cleared", id: "n1" });
+    deliver({ type: "published", entry: entry("n1", "Build finished again") });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.title)).toEqual(["Build finished again"]);
+  });
+
+  it("shows the fetched list when nothing happened meanwhile", async () => {
+    const { answer } = deferredList([BELL, OTHER]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.id)).toEqual(["n1", "n2"]);
   });
 });

--- a/test/src/composables/useNotifications.spec.ts
+++ b/test/src/composables/useNotifications.spec.ts
@@ -3,6 +3,9 @@ import { flushPromises } from "@vue/test-utils";
 import { parseCollectionTarget, type NotifierEntry } from "../../../src/composables/useNotifications";
 
 const subscribers = new Map<string, (data: unknown) => void>();
+// The bell re-fetches its list on every pub/sub reconnect, which is how a second request
+// starts while the first is still out.
+let fireReconnect: (() => void) | undefined;
 
 vi.mock("../../../src/composables/usePubSub", () => ({
   usePubSub: () => ({
@@ -10,7 +13,10 @@ vi.mock("../../../src/composables/usePubSub", () => ({
       subscribers.set(channel, handler);
       return () => subscribers.delete(channel);
     },
-    onReconnect: () => {},
+    onReconnect: (handler: () => void) => {
+      fireReconnect = handler;
+      return () => {};
+    },
   }),
 }));
 
@@ -152,6 +158,33 @@ describe("useNotifications — the list fetched while the channel is live", () =
     await flushPromises();
 
     expect(active.value.map((e) => e.title)).toEqual(["Build finished again"]);
+  });
+
+  // Codex on #626, applied here too: the bell fetches on init AND on every reconnect, so an
+  // older list can land after a newer one and put back what it replaced.
+  it("ignores an older list that lands after a newer one", async () => {
+    const gates: Array<() => void> = [];
+    const answers = [[BELL], [OTHER]];
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const mine = call++;
+        await new Promise<void>((resolve) => gates.push(resolve));
+        return { ok: true, json: async () => ({ active: answers[mine] }) };
+      }),
+    );
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+    fireReconnect?.(); // a reconnect asks again while the first request is still out
+
+    gates[1]?.(); // the newer answer arrives first
+    await flushPromises();
+    expect(active.value.map((e) => e.id)).toEqual(["n2"]);
+
+    gates[0]?.(); // the stale one, arriving last
+    await flushPromises();
+    expect(active.value.map((e) => e.id)).toEqual(["n2"]);
   });
 
   it("shows the fetched list when nothing happened meanwhile", async () => {


### PR DESCRIPTION
Refs #620

> **#622（F1）の上に積んでいます。** ベースは `fix/620-f1-session-feed-live-merge` です。`snapshotMerge.ts` が #622 由来のため。#622 がマージされたらベースを main に切り替えます。

## Summary

**消したはずの通知が復活する**バグの修正です。

ベルは権威あるリストを丸ごと取得しますが、その間もチャネルはリストを変更し続けます。**取得中に消した通知が、応答にはまだ載っています。** 応答をそのまま適用していたので、消したものが戻ってきていました。

`fetchActive` は **pub/sub の再接続時にも発火**します。再接続直後はイベントが飛び交うタイミングそのもので、一番当たりやすい状況です。

## F1 との違い：削除も運ぶ必要がある

追加しか知らないマージだと、**消した項目をそのまま返してしまいます**。そこで取得中に記録するのは「チャネルが何をしたか」の**順序付きリスト**にしました。

| 起きた順 | 正しい結果 |
|---|---|
| publish → clear | 残らない |
| clear → publish | 残る |

**id の集合では、この 2 つを区別できません。** 順序こそが答えです。

`snapshotMerge.ts` に `applyLiveChanges` を基本操作として追加し、F1 の `mergeSnapshotWithLive` はそれに委譲する形にしました。**F1 の 16 件のテストが無変更で通ること**が、一般化で意味論が壊れていない根拠です。

## Items to Confirm / Review

1. **F1 の関数を一般化しました** — #622 のレビュー中に手を入れる形になっています。委譲後も F1 のテストは 1 件も変更していません
2. 既存の `useNotifications.spec.ts` に追記しました（`parseCollectionTarget` のテストのみだったファイル）。`usePubSub` を `vi.mock` し、モジュール状態は `vi.resetModules()` で毎回作り直しています
3. `active` はモジュールスコープの singleton なので、テストごとに再 import しないと初期化フラグが残ります

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| 応答で無条件置換（＝元のバグ）に戻す | 4 件 |
| 削除を記録せず追加だけ拾う | **「消した通知が復活しない」1 件だけ**が的確に落ちる |

2 つ目は、F1 の実装をそのまま流用しただけでは不十分だったことを示すテストです。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:test` / `yarn build` / `yarn test`（192 files, 2483 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
