### PR TITLE
fix: a history response no longer discards what arrived while it was in flight (#620 F1)

### DIFF
--- a/src/composables/liveMerge.ts
+++ b/src/composables/liveMerge.ts
@@ -1,0 +1,24 @@
+// Applying a fetched snapshot without discarding what arrived while it was in flight.
+//
+// A response carries the authoritative state as of when the REQUEST was sent, not as of when
+// it came back. Applied as the latter, it silently undoes everything pub/sub delivered in
+// between — a tool call that fired during a session switch vanishes from the pane and does
+// not come back until a reload.
+//
+// The rule: the snapshot supplies the baseline, and anything the live channel touched since
+// the request went out wins over it. An item the snapshot has never heard of is kept, not
+// dropped — it is newer than the snapshot, not older.
+
+// Items whose identity cannot be determined can't be matched against the snapshot, so they
+// are appended — the same thing the live path does when it cannot find them.
+export function mergeLiveIntoSnapshot<T>(snapshot: readonly T[], arrivedSince: readonly T[], identify: (item: T) => string | undefined): T[] {
+  if (arrivedSince.length === 0) return [...snapshot];
+  const merged = [...snapshot];
+  for (const item of arrivedSince) {
+    const id = identify(item);
+    const at = id === undefined ? -1 : merged.findIndex((existing) => identify(existing) === id);
+    if (at >= 0) merged[at] = item;
+    else merged.push(item);
+  }
+  return merged;
+}

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -3,6 +3,7 @@
 // in, deduped by each item's identity (a re-emitted item updates in place).
 import { onUnmounted, watch, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
+import { mergeLiveIntoSnapshot } from "./liveMerge";
 
 interface SessionFeedOptions<T> {
   sessionId: () => string | null;
@@ -16,7 +17,13 @@ interface SessionFeedOptions<T> {
 export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T>) {
   const { sessionId, historyUrl, historyKey, channel, identify, onSessionChange } = options;
 
+  // What the live channel delivered while a history request was in flight. The response is
+  // authoritative as of when it was SENT, so these have to survive it (#620 F1).
+  let loadingSession: string | null = null;
+  let arrivedDuringLoad: T[] = [];
+
   function upsert(item: T) {
+    if (loadingSession !== null) arrivedDuringLoad.push(item);
     const id = identify(item);
     const index = id === undefined ? -1 : items.value.findIndex((existing) => identify(existing) === id);
     if (index >= 0) items.value[index] = item;
@@ -24,6 +31,8 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
   }
 
   async function loadHistory(id: string) {
+    loadingSession = id;
+    arrivedDuringLoad = [];
     try {
       const res = await fetch(historyUrl(id));
       // Guard against a session-switch race: a slow response for an old session must
@@ -32,9 +41,16 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       if (id !== sessionId()) return;
-      items.value = data[historyKey] ?? [];
+      items.value = mergeLiveIntoSnapshot(data[historyKey] ?? [], arrivedDuringLoad, identify);
     } catch {
-      if (id === sessionId()) items.value = [];
+      // A failed history read must not take the live events with it.
+      if (id === sessionId()) items.value = mergeLiveIntoSnapshot([], arrivedDuringLoad, identify);
+    } finally {
+      // Only if a newer load has not already taken over the tracking.
+      if (loadingSession === id) {
+        loadingSession = null;
+        arrivedDuringLoad = [];
+      }
     }
   }
 

--- a/test/src/composables/liveMerge.spec.ts
+++ b/test/src/composables/liveMerge.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+
+import { mergeLiveIntoSnapshot } from "../../../src/composables/liveMerge";
+
+interface Item {
+  id?: string;
+  text: string;
+}
+const identify = (item: Item) => item.id;
+
+describe("mergeLiveIntoSnapshot", () => {
+  it("is the snapshot when nothing arrived meanwhile", () => {
+    const snapshot = [{ id: "a", text: "A" }];
+    expect(mergeLiveIntoSnapshot(snapshot, [], identify)).toEqual(snapshot);
+  });
+
+  // The bug this exists for (#620 F1): a tool call that fires during a session switch used
+  // to vanish when the history response landed, and not come back until a reload.
+  it("keeps an item the snapshot has never heard of", () => {
+    const merged = mergeLiveIntoSnapshot([{ id: "a", text: "A" }], [{ id: "b", text: "B" }], identify);
+    expect(merged).toEqual([
+      { id: "a", text: "A" },
+      { id: "b", text: "B" },
+    ]);
+  });
+
+  // The live value is newer than the snapshot by definition — the request was sent first.
+  it("lets a live update win over the snapshot's copy", () => {
+    const merged = mergeLiveIntoSnapshot([{ id: "a", text: "old" }], [{ id: "a", text: "new" }], identify);
+    expect(merged).toEqual([{ id: "a", text: "new" }]);
+  });
+
+  it("updates in place rather than appending a duplicate", () => {
+    const merged = mergeLiveIntoSnapshot(
+      [
+        { id: "a", text: "A" },
+        { id: "b", text: "B" },
+      ],
+      [{ id: "a", text: "A2" }],
+      identify,
+    );
+    expect(merged.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+
+  it("keeps the snapshot's order and appends new arrivals after it", () => {
+    const merged = mergeLiveIntoSnapshot(
+      [
+        { id: "a", text: "A" },
+        { id: "b", text: "B" },
+      ],
+      [
+        { id: "c", text: "C" },
+        { id: "d", text: "D" },
+      ],
+      identify,
+    );
+    expect(merged.map((i) => i.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("applies several updates to the same item in arrival order", () => {
+    const merged = mergeLiveIntoSnapshot(
+      [{ id: "a", text: "old" }],
+      [
+        { id: "a", text: "mid" },
+        { id: "a", text: "new" },
+      ],
+      identify,
+    );
+    expect(merged).toEqual([{ id: "a", text: "new" }]);
+  });
+
+  // An empty snapshot is what a FAILED history read supplies — the live events must still
+  // survive it, rather than the pane going blank.
+  it("keeps live arrivals when the snapshot is empty", () => {
+    expect(mergeLiveIntoSnapshot([], [{ id: "a", text: "A" }], identify)).toEqual([{ id: "a", text: "A" }]);
+  });
+
+  // Unidentifiable items cannot be matched, so they are appended — the same thing the live
+  // path does when it cannot find them.
+  it("appends items with no identity rather than dropping them", () => {
+    const merged = mergeLiveIntoSnapshot([{ text: "S" }], [{ text: "L1" }, { text: "L2" }], identify);
+    expect(merged.map((i) => i.text)).toEqual(["S", "L1", "L2"]);
+  });
+
+  it("does not mutate either input", () => {
+    const snapshot = [{ id: "a", text: "A" }];
+    const arrived = [{ id: "a", text: "A2" }];
+    mergeLiveIntoSnapshot(snapshot, arrived, identify);
+    expect(snapshot).toEqual([{ id: "a", text: "A" }]);
+    expect(arrived).toEqual([{ id: "a", text: "A2" }]);
+  });
+});

--- a/test/src/composables/useSessionFeed.spec.ts
+++ b/test/src/composables/useSessionFeed.spec.ts
@@ -1,0 +1,101 @@
+// The race this file exists for (#620 F1): the history response is authoritative as of when
+// the REQUEST went out, so anything pub/sub delivered while it was in flight has to survive
+// it. Driven through the real composable — a pure-function test alone would not prove the
+// composable actually remembers what arrived.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { defineComponent, h, ref, nextTick } from "vue";
+import { flushPromises, mount } from "@vue/test-utils";
+
+const handlers = new Map<string, (data: unknown) => void>();
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, handler: (data: unknown) => void) => {
+      handlers.set(channel, handler);
+      return () => handlers.delete(channel);
+    },
+  }),
+}));
+
+const { useSessionFeed } = await import("../../../src/composables/useSessionFeed");
+
+interface Item {
+  id: string;
+  text: string;
+}
+
+// Mount the composable with a history fetch we control the timing of.
+function mountFeed(respond: () => Promise<{ ok: boolean; json?: () => Promise<unknown> }>) {
+  const items = ref<Item[]>([]);
+  const sessionId = ref<string | null>("s1");
+  vi.stubGlobal("fetch", vi.fn().mockImplementation(respond));
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        useSessionFeed<Item>(items, {
+          sessionId: () => sessionId.value,
+          historyUrl: (id) => `/api/history/${id}`,
+          historyKey: "items",
+          channel: (id) => `feed:${id}`,
+          identify: (item) => item.id,
+        });
+        return () => h("div");
+      },
+    }),
+  );
+  return { items, sessionId, wrapper };
+}
+
+const deliver = (channel: string, item: Item) => handlers.get(channel)?.(item);
+
+beforeEach(() => {
+  handlers.clear();
+  vi.unstubAllGlobals();
+});
+
+describe("useSessionFeed", () => {
+  it("shows the history it fetched", async () => {
+    const { items } = mountFeed(async () => ({ ok: true, json: async () => ({ items: [{ id: "a", text: "A" }] }) }));
+    await vi.waitFor(() => expect(items.value).toEqual([{ id: "a", text: "A" }]));
+  });
+
+  // THE bug: a tool call that fires while the pane is loading used to disappear the moment
+  // the response landed, and stay gone until a reload.
+  it("keeps an item that arrived while the history was in flight", async () => {
+    let release!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const { items } = mountFeed(() => new Promise((resolve) => (release = resolve)));
+    await nextTick();
+
+    deliver("feed:s1", { id: "live", text: "arrived mid-flight" });
+    expect(items.value.map((i) => i.id)).toEqual(["live"]);
+
+    release({ ok: true, json: async () => ({ items: [{ id: "a", text: "A" }] }) });
+    await vi.waitFor(() => expect(items.value.map((i) => i.id)).toEqual(["a", "live"]));
+  });
+
+  // The same hole in the failure path: losing the history must not take the live events too.
+  it("keeps live arrivals when the history request fails", async () => {
+    let reject!: (reason: Error) => void;
+    const { items } = mountFeed(() => new Promise((_, r) => (reject = r)));
+    await nextTick();
+
+    deliver("feed:s1", { id: "live", text: "arrived mid-flight" });
+    reject(new Error("offline"));
+    // Flush rather than poll: waitFor would pass on the state BEFORE the catch ran, so the
+    // wipe this guards against would never be observed.
+    await flushPromises();
+    await flushPromises();
+
+    expect(items.value.map((i) => i.id)).toEqual(["live"]);
+  });
+
+  it("lets the live copy win when the history also has that item", async () => {
+    let release!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const { items } = mountFeed(() => new Promise((resolve) => (release = resolve)));
+    await nextTick();
+
+    deliver("feed:s1", { id: "a", text: "newer" });
+    release({ ok: true, json: async () => ({ items: [{ id: "a", text: "older" }] }) });
+
+    await vi.waitFor(() => expect(items.value).toEqual([{ id: "a", text: "newer" }]));
+  });
+});


### PR DESCRIPTION
## Summary

First of the #620 family. A response carries the authoritative state as of when the **request was sent**, not as of when it came back — `useSessionFeed` applied it as the latter:

```
① fetch starts        ← the server state that ends up in the response
② a pub/sub item arrives, upsert() shows it
③ response lands: items.value = data[historyKey] ?? []   ← ② is gone
```

A tool call delivered during the load vanished from the tools pane / GUI panel and did not come back until a reload. Most easily hit **at a session switch**, which is exactly when the history is loading.

The failure path had the same hole and was worse: `catch { items.value = [] }` threw away the live events along with the history it could not read.

## The fix

The decision — what the snapshot may overwrite — is a pure function (`mergeLiveIntoSnapshot`): the snapshot is the baseline, anything the live channel touched since the request went out wins, and an item the snapshot has never heard of is **kept** (it is newer, not older). The composable keeps the I/O: remembering what arrived after the request went out, and dropping that record when a newer load takes over.

## Items to Confirm / Review

1. **Tested through the real composable**, not only the pure function — the pure function alone cannot show that the composable *remembers* anything. Both holes fail against the old code (the success path and the `catch`).
2. **One test nearly passed for the wrong reason.** `vi.waitFor` succeeded on the state *before* the `catch` ran, so the wipe it guards against was never observed — it passed against the unfixed code too. It flushes and asserts once now. Worth knowing for the F2/F3 tests in this family.
3. Ordering: history first, then live-only arrivals in arrival order. Items with no identity are appended, matching what the live path already does.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `194 files / 2503 tests` — by exit code.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)