### PR TITLE
fix: activity の seed が、読み込み中に届いた push を巻き戻す問題 (#620 F3)

### DIFF
--- a/src/composables/useGridActivity.ts
+++ b/src/composables/useGridActivity.ts
@@ -16,6 +16,10 @@ export function useGridActivity(sessionIds: Ref<string[]>) {
   // and has to go back on top of it — otherwise a cell that just started working is seeded
   // back to idle, and one that just closed reappears (#620 F3).
   let pushedDuringSeed: unknown[] | null = null;
+  // Seeds overlap — mount, the cell-list watch and a reconnect all ask. Only the newest
+  // answer may be applied: an older one describes a moment that has already been overtaken,
+  // and applying it puts back what the newer state replaced.
+  let latestSeed = 0;
 
   function apply(data: unknown): void {
     pushedDuringSeed?.push(data);
@@ -28,12 +32,16 @@ export function useGridActivity(sessionIds: Ref<string[]>) {
   async function seed(): Promise<void> {
     const ids = [...new Set(sessionIds.value.filter(Boolean))];
     if (ids.length === 0) return;
+    const seedId = ++latestSeed;
     const pushed: unknown[] = [];
     pushedDuringSeed = pushed;
     try {
       const res = await fetch(`/api/activity?ids=${encodeURIComponent(ids.join(","))}`);
-      if (!res.ok) return;
+      // Overtaken while we waited: this answer is older than what is on screen. Returning
+      // also leaves the newer seed's record alone — it is the one that will replay.
+      if (seedId !== latestSeed || !res.ok) return;
       const data: Record<string, CellActivity> = await res.json();
+      if (seedId !== latestSeed) return;
       for (const [id, a] of Object.entries(data)) {
         activity.set(id, { working: !!a.working, waiting: !!a.waiting, event: a.event ?? null });
       }

--- a/src/composables/useGridActivity.ts
+++ b/src/composables/useGridActivity.ts
@@ -11,7 +11,14 @@ import { parseSessionActivityPayload, type CellActivity } from "./sessionActivit
 export function useGridActivity(sessionIds: Ref<string[]>) {
   const activity = reactive(new Map<string, CellActivity>());
 
+  // Non-null while a seed is in flight, keeping what the channel pushed meanwhile. /api/activity
+  // answers as of the moment it was ASKED, so anything after that is newer than the answer
+  // and has to go back on top of it — otherwise a cell that just started working is seeded
+  // back to idle, and one that just closed reappears (#620 F3).
+  let pushedDuringSeed: unknown[] | null = null;
+
   function apply(data: unknown): void {
+    pushedDuringSeed?.push(data);
     const update = parseSessionActivityPayload(data);
     if (!update) return;
     if ("closed" in update) activity.delete(update.id);
@@ -21,6 +28,8 @@ export function useGridActivity(sessionIds: Ref<string[]>) {
   async function seed(): Promise<void> {
     const ids = [...new Set(sessionIds.value.filter(Boolean))];
     if (ids.length === 0) return;
+    const pushed: unknown[] = [];
+    pushedDuringSeed = pushed;
     try {
       const res = await fetch(`/api/activity?ids=${encodeURIComponent(ids.join(","))}`);
       if (!res.ok) return;
@@ -28,8 +37,15 @@ export function useGridActivity(sessionIds: Ref<string[]>) {
       for (const [id, a] of Object.entries(data)) {
         activity.set(id, { working: !!a.working, waiting: !!a.waiting, event: a.event ?? null });
       }
+      // Stop recording before replaying, or each replayed update records itself again.
+      if (pushedDuringSeed === pushed) pushedDuringSeed = null;
+      // In arrival order: a session that went working then closed must end up closed.
+      pushed.forEach((update) => apply(update));
     } catch {
       // Transient — the pub/sub stream catches up on the next activity change.
+    } finally {
+      // A newer seed has taken over: leave its record alone.
+      if (pushedDuringSeed === pushed) pushedDuringSeed = null;
     }
   }
 

--- a/test/src/composables/useGridActivity.spec.ts
+++ b/test/src/composables/useGridActivity.spec.ts
@@ -37,17 +37,26 @@ function deferredSeed(payload: Record<string, CellActivity>) {
 
 function mountGrid(ids: string[] = [SESSION]) {
   let activity!: Map<string, CellActivity>;
+  const sessionIds = ref(ids);
   const component = defineComponent({
     setup() {
-      activity = useGridActivity(ref(ids)).activity;
+      activity = useGridActivity(sessionIds).activity;
       return () => h("div");
     },
   });
   const wrapper = mount(component);
-  return { wrapper, get: () => activity };
+  // Re-run the seed the way the cell-list watch does, so a second request overlaps the first.
+  const seedAgain = async () => {
+    sessionIds.value = [...sessionIds.value, `extra-${sessionIds.value.length}`];
+    await wrapper.vm.$nextTick();
+  };
+  return { wrapper, get: () => activity, seedAgain };
 }
 
 const push = (data: unknown) => subscribers.get("sessions")?.(data);
+
+// Sentinel for twoSeeds: the second request answers !ok.
+const FAILS: Record<string, CellActivity> = {};
 
 beforeEach(() => subscribers.clear());
 afterEach(() => vi.unstubAllGlobals());
@@ -110,6 +119,58 @@ describe("useGridActivity", () => {
 
     expect(get().get("other")?.working).toBe(true);
     expect(get().get(SESSION)?.working).toBe(true);
+  });
+
+  // Codex on #626: seeds overlap (mount + the cell-list watch + reconnect), and an older
+  // answer landing last put back what the newer state had replaced — the same rollback this
+  // PR is about, one level up.
+  describe("when seeds overlap", () => {
+    // Two gates, so the test can land the OLDER answer last.
+    function twoSeeds(first: Record<string, CellActivity>, second: Record<string, CellActivity>) {
+      let answerFirst!: () => void;
+      let answerSecond!: () => void;
+      const firstGate = new Promise<void>((r) => (answerFirst = r));
+      const secondGate = new Promise<void>((r) => (answerSecond = r));
+      let call = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          const mine = ++call;
+          await (mine === 1 ? firstGate : secondGate);
+          if (mine === 2 && second === FAILS) return { ok: false, status: 500 };
+          return { ok: true, json: async () => (mine === 1 ? first : second) };
+        }),
+      );
+      return { answerFirst, answerSecond };
+    }
+
+    it("ignores an older answer that lands after a newer one", async () => {
+      const { answerFirst, answerSecond } = twoSeeds({ [SESSION]: IDLE }, { [SESSION]: { working: true, waiting: false, event: "newer" } });
+      const { get, seedAgain } = mountGrid();
+      await seedAgain();
+
+      answerSecond();
+      await flushPromises();
+      expect(get().get(SESSION)?.working).toBe(true);
+
+      answerFirst(); // the stale one, arriving last
+      await flushPromises();
+      expect(get().get(SESSION)?.working).toBe(true);
+    });
+
+    it("does not lose a push when the newer seed fails", async () => {
+      const { answerFirst, answerSecond } = twoSeeds({ [SESSION]: IDLE }, FAILS);
+      const { get, seedAgain } = mountGrid();
+      await seedAgain();
+
+      push({ id: SESSION, working: true, waiting: false, event: "started" });
+      answerSecond(); // fails, so nothing is applied and nothing needs undoing
+      await flushPromises();
+      answerFirst(); // stale: must not put the idle snapshot back
+      await flushPromises();
+
+      expect(get().get(SESSION)?.working).toBe(true);
+    });
   });
 
   it("applies a push that arrives after the seed has landed", async () => {

--- a/test/src/composables/useGridActivity.spec.ts
+++ b/test/src/composables/useGridActivity.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { defineComponent, ref, h } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+
+const subscribers = new Map<string, (data: unknown) => void>();
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, handler: (data: unknown) => void) => {
+      subscribers.set(channel, handler);
+      return () => subscribers.delete(channel);
+    },
+    onReconnect: () => () => {},
+  }),
+}));
+
+import { useGridActivity } from "../../../src/composables/useGridActivity";
+import type { CellActivity } from "../../../src/composables/sessionActivity";
+
+const IDLE = { working: false, waiting: false, event: null };
+const SESSION = "session-1";
+
+// A seed response this test decides when to answer, so a push can be delivered while the
+// request is still out — the window the bug lives in.
+function deferredSeed(payload: Record<string, CellActivity>) {
+  let answer!: () => void;
+  const gate = new Promise<void>((resolve) => (answer = resolve));
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      await gate;
+      return { ok: true, json: async () => payload };
+    }),
+  );
+  return { answer };
+}
+
+function mountGrid(ids: string[] = [SESSION]) {
+  let activity!: Map<string, CellActivity>;
+  const component = defineComponent({
+    setup() {
+      activity = useGridActivity(ref(ids)).activity;
+      return () => h("div");
+    },
+  });
+  const wrapper = mount(component);
+  return { wrapper, get: () => activity };
+}
+
+const push = (data: unknown) => subscribers.get("sessions")?.(data);
+
+beforeEach(() => subscribers.clear());
+afterEach(() => vi.unstubAllGlobals());
+
+describe("useGridActivity", () => {
+  // The regression: /api/activity answers as of when it was ASKED, so a cell that started
+  // working in the meantime was seeded straight back to idle (#620 F3).
+  it("keeps a status that arrived while the seed was in flight", async () => {
+    const { answer } = deferredSeed({ [SESSION]: IDLE });
+    const { get } = mountGrid();
+
+    push({ id: SESSION, working: true, waiting: false, event: "started" });
+    answer();
+    await flushPromises();
+
+    expect(get().get(SESSION)?.working).toBe(true);
+  });
+
+  // The same hole in the other direction: the seed still lists a session that has closed.
+  it("does not bring back a session that closed while the seed was in flight", async () => {
+    const { answer } = deferredSeed({ [SESSION]: IDLE });
+    const { get } = mountGrid();
+
+    push({ id: SESSION, event: "closed" });
+    answer();
+    await flushPromises();
+
+    expect(get().has(SESSION)).toBe(false);
+  });
+
+  it("replays what happened in the order it happened", async () => {
+    const { answer } = deferredSeed({ [SESSION]: IDLE });
+    const { get } = mountGrid();
+
+    push({ id: SESSION, working: true, waiting: false, event: "started" });
+    push({ id: SESSION, event: "closed" });
+    answer();
+    await flushPromises();
+
+    expect(get().has(SESSION)).toBe(false);
+  });
+
+  it("still seeds the state it fetched when nothing arrived meanwhile", async () => {
+    const { answer } = deferredSeed({ [SESSION]: { working: true, waiting: false, event: "seeded" } });
+    const { get } = mountGrid();
+
+    answer();
+    await flushPromises();
+
+    expect(get().get(SESSION)?.working).toBe(true);
+  });
+
+  it("leaves other sessions the seed reported alone", async () => {
+    const { answer } = deferredSeed({ [SESSION]: IDLE, other: { working: true, waiting: false, event: null } });
+    const { get } = mountGrid([SESSION, "other"]);
+
+    push({ id: SESSION, working: true, waiting: false, event: "started" });
+    answer();
+    await flushPromises();
+
+    expect(get().get("other")?.working).toBe(true);
+    expect(get().get(SESSION)?.working).toBe(true);
+  });
+
+  it("applies a push that arrives after the seed has landed", async () => {
+    const { answer } = deferredSeed({ [SESSION]: IDLE });
+    const { get } = mountGrid();
+    answer();
+    await flushPromises();
+
+    push({ id: SESSION, working: true, waiting: false, event: "started" });
+    expect(get().get(SESSION)?.working).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #620

## Summary

グリッドのセルが **working → idle に巻き戻る**、閉じたセルが**復活する**バグの修正です。ファミリー #620 の F3。

`/api/activity` は**リクエストを出した時点**の状態を返しますが、グリッドはこれをマウント時・再接続時・セル一覧の変更時に seed します。**取得中に届いた push は一度適用されたあと、古い応答で上書きされていました。**

## 直し方

取得中に届いた push を記録し、応答を適用したあとに**到着順で再適用**します。

順序が必要な理由：working → closed と届いたセッションは **closed で終わらなければなりません**。「触られた id の集合」では、この逆順と区別できません。

再適用の前に記録を止めています（止めないと、再適用した update 自身がまた記録されます）。

## Items to Confirm / Review

1. **この修正には新しい純粋関数を作っていません。** composable には既に `apply` があり、修正の中身は「取りこぼした分をもう一度 `apply` に通す」ことです。無理に抽象を足すより素直だと判断しました。ルールはテスト側に書いてあります
2. F1(#622) / F2(#624) は `snapshotMerge` を共有しますが、**これは独立**しています（main から直接分岐、依存なし）
3. `useGridActivity` は `onMounted` を使うため、テストは `effectScope` ではなく実際にコンポーネントを mount しています

## テストが効くことの確認

再適用を外すと **6 件中 4 件**が落ちます。

## テストを書いていて見つけた自分の誤り

`closed` の push は `{ id, closed: true }` ではなく **`{ id, event: "closed" }`** でした（`parseSessionActivityPayload` の形）。最初のテストがこれを間違えており、**修正が効いていないように見えました**。コードではなくテストの誤りでした。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:test` / `yarn test`（194 files, 2497 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
