### PR TITLE
fix: a response no longer speaks for what the live channel changed since (#620 F2/F3)

### DIFF
--- a/src/composables/liveMerge.ts
+++ b/src/composables/liveMerge.ts
@@ -22,3 +22,36 @@ export function mergeLiveIntoSnapshot<T>(snapshot: readonly T[], arrivedSince: r
   }
   return merged;
 }
+
+// The same race, for a list the live channel can also REMOVE from.
+//
+// A dismissed notification is the case that matters: the fetch went out while it still
+// existed, so the response still lists it, and applying that wholesale brings it BACK — the
+// bell re-lights for something the user already dealt with. The reverse happens too: one
+// published mid-flight is absent from the response and would disappear.
+export type LiveTouch<T> = { kind: "upsert"; item: T } | { kind: "remove" };
+
+export function applyLiveTouches<T>(snapshot: readonly T[], touched: ReadonlyMap<string, LiveTouch<T>>, identify: (item: T) => string): T[] {
+  if (touched.size === 0) return [...snapshot];
+  const merged = snapshot
+    .filter((item) => touched.get(identify(item))?.kind !== "remove")
+    .map((item) => {
+      const touch = touched.get(identify(item));
+      return touch?.kind === "upsert" ? touch.item : item;
+    });
+  const known = new Set(merged.map(identify));
+  // Anything the live channel added that the snapshot predates.
+  for (const [id, touch] of touched) {
+    if (touch.kind === "upsert" && !known.has(id)) merged.push(touch.item);
+  }
+  return merged;
+}
+
+// The map shape of the same race: which ids a snapshot may still speak for.
+//
+// A response about a set of sessions is authoritative as of when it was SENT. An id the live
+// channel has touched since then is newer, so applying the snapshot to it walks the cell
+// backwards — a working cell blinks to idle until the next event happens to arrive.
+export function snapshotAppliesTo(id: string, touchedSince: ReadonlySet<string>): boolean {
+  return !touchedSince.has(id);
+}

--- a/src/composables/useGridActivity.ts
+++ b/src/composables/useGridActivity.ts
@@ -1,6 +1,7 @@
 import { reactive, watch, onMounted, onUnmounted, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
 import { parseSessionActivityPayload, type CellActivity } from "./sessionActivity";
+import { snapshotAppliesTo } from "./liveMerge";
 
 // Live attention state (working / waiting / event) for a set of grid cell sessions,
 // keyed by session id. Unlike the sidebar's /api/sessions list this includes
@@ -11,9 +12,15 @@ import { parseSessionActivityPayload, type CellActivity } from "./sessionActivit
 export function useGridActivity(sessionIds: Ref<string[]>) {
   const activity = reactive(new Map<string, CellActivity>());
 
+  // Sessions the live channel spoke for while a seed was in flight (#620 F3). The response is
+  // authoritative as of when it was SENT, so it must not speak for these.
+  let seeding = false;
+  const touchedDuringSeed = new Set<string>();
+
   function apply(data: unknown): void {
     const update = parseSessionActivityPayload(data);
     if (!update) return;
+    if (seeding) touchedDuringSeed.add(update.id);
     if ("closed" in update) activity.delete(update.id);
     else activity.set(update.id, update.activity);
   }
@@ -21,15 +28,21 @@ export function useGridActivity(sessionIds: Ref<string[]>) {
   async function seed(): Promise<void> {
     const ids = [...new Set(sessionIds.value.filter(Boolean))];
     if (ids.length === 0) return;
+    seeding = true;
+    touchedDuringSeed.clear();
     try {
       const res = await fetch(`/api/activity?ids=${encodeURIComponent(ids.join(","))}`);
       if (!res.ok) return;
       const data: Record<string, CellActivity> = await res.json();
       for (const [id, a] of Object.entries(data)) {
+        if (!snapshotAppliesTo(id, touchedDuringSeed)) continue;
         activity.set(id, { working: !!a.working, waiting: !!a.waiting, event: a.event ?? null });
       }
     } catch {
       // Transient — the pub/sub stream catches up on the next activity change.
+    } finally {
+      seeding = false;
+      touchedDuringSeed.clear();
     }
   }
 

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -9,6 +9,7 @@
 import { ref, computed } from "vue";
 import { usePubSub } from "./usePubSub";
 import { browseNavigateToRecord } from "./useCollectionBrowse";
+import { applyLiveTouches, type LiveTouch } from "./liveMerge";
 
 // Must match server/backends/notifier.ts NOTIFIER_CHANNEL.
 const NOTIFIER_CHANNEL = "notifications";
@@ -66,13 +67,20 @@ export function parseCollectionTarget(target: string | undefined): { slug: strin
   }
 }
 
+// What the live channel did to the list while a fetch was in flight (#620 F2). The response
+// is authoritative as of when it was SENT, so these have to survive it.
+let fetchInFlight = false;
+let touchedDuringFetch = new Map<string, LiveTouch<NotifierEntry>>();
+
 function upsert(entry: NotifierEntry): void {
+  if (fetchInFlight) touchedDuringFetch.set(entry.id, { kind: "upsert", item: entry });
   const idx = active.value.findIndex((existing) => existing.id === entry.id);
   if (idx === -1) active.value.push(entry);
   else active.value.splice(idx, 1, entry);
 }
 
 function remove(id: string): void {
+  if (fetchInFlight) touchedDuringFetch.set(id, { kind: "remove" });
   const idx = active.value.findIndex((existing) => existing.id === id);
   if (idx !== -1) active.value.splice(idx, 1);
 }
@@ -91,6 +99,8 @@ function applyEvent(event: NotifierEvent): void {
 }
 
 async function fetchActive(): Promise<void> {
+  fetchInFlight = true;
+  touchedDuringFetch = new Map();
   try {
     const res = await fetch("/api/notifications");
     if (!res.ok) {
@@ -98,9 +108,13 @@ async function fetchActive(): Promise<void> {
       return;
     }
     const data = (await res.json()) as { active?: NotifierEntry[] };
-    active.value = Array.isArray(data.active) ? data.active : [];
+    const snapshot = Array.isArray(data.active) ? data.active : [];
+    active.value = applyLiveTouches(snapshot, touchedDuringFetch, (entry) => entry.id);
   } catch (err) {
     console.error("[notifications] list failed", err);
+  } finally {
+    fetchInFlight = false;
+    touchedDuringFetch = new Map();
   }
 }
 

--- a/test/src/composables/liveMerge.spec.ts
+++ b/test/src/composables/liveMerge.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { mergeLiveIntoSnapshot } from "../../../src/composables/liveMerge";
+import { applyLiveTouches, mergeLiveIntoSnapshot, snapshotAppliesTo } from "../../../src/composables/liveMerge";
 
 interface Item {
   id?: string;
@@ -88,5 +88,76 @@ describe("mergeLiveIntoSnapshot", () => {
     mergeLiveIntoSnapshot(snapshot, arrived, identify);
     expect(snapshot).toEqual([{ id: "a", text: "A" }]);
     expect(arrived).toEqual([{ id: "a", text: "A2" }]);
+  });
+});
+
+describe("applyLiveTouches", () => {
+  const entry = (id: string, text = id) => ({ id, text });
+  const byId = (item: { id: string }) => item.id;
+
+  it("is the snapshot when nothing happened meanwhile", () => {
+    const snapshot = [entry("a")];
+    expect(applyLiveTouches(snapshot, new Map(), byId)).toEqual(snapshot);
+  });
+
+  // The bug this exists for (#620 F2): the fetch went out while the notification still
+  // existed, so the response still lists it — applied wholesale, the bell re-lights for
+  // something the user already dismissed.
+  it("keeps a dismissed item dismissed", () => {
+    const touched = new Map([["a", { kind: "remove" as const }]]);
+    expect(applyLiveTouches([entry("a"), entry("b")], touched, byId).map(byId)).toEqual(["b"]);
+  });
+
+  // The other direction: one published mid-flight is absent from the response.
+  it("keeps an item published while the fetch was in flight", () => {
+    const touched = new Map([["new", { kind: "upsert" as const, item: entry("new") }]]);
+    expect(applyLiveTouches([entry("a")], touched, byId).map(byId)).toEqual(["a", "new"]);
+  });
+
+  it("lets a live update win over the snapshot's copy", () => {
+    const touched = new Map([["a", { kind: "upsert" as const, item: entry("a", "newer") }]]);
+    expect(applyLiveTouches([entry("a", "older")], touched, byId)).toEqual([{ id: "a", text: "newer" }]);
+  });
+
+  it("updates in place rather than moving the item to the end", () => {
+    const touched = new Map([["a", { kind: "upsert" as const, item: entry("a", "newer") }]]);
+    expect(applyLiveTouches([entry("a"), entry("b")], touched, byId).map(byId)).toEqual(["a", "b"]);
+  });
+
+  it("handles a removal and an addition in the same flight", () => {
+    const touched = new Map<string, { kind: "remove" } | { kind: "upsert"; item: { id: string; text: string } }>([
+      ["a", { kind: "remove" }],
+      ["c", { kind: "upsert", item: entry("c") }],
+    ]);
+    expect(applyLiveTouches([entry("a"), entry("b")], touched, byId).map(byId)).toEqual(["b", "c"]);
+  });
+
+  // Dismissing something the snapshot never had must not resurrect it as an addition.
+  it("does not re-add an item that was removed and is absent from the snapshot", () => {
+    const touched = new Map([["gone", { kind: "remove" as const }]]);
+    expect(applyLiveTouches([entry("a")], touched, byId).map(byId)).toEqual(["a"]);
+  });
+
+  it("does not mutate the snapshot", () => {
+    const snapshot = [entry("a")];
+    applyLiveTouches(snapshot, new Map([["a", { kind: "remove" as const }]]), byId);
+    expect(snapshot.map(byId)).toEqual(["a"]);
+  });
+});
+
+describe("snapshotAppliesTo", () => {
+  it("lets a snapshot speak for an id nothing has touched since", () => {
+    expect(snapshotAppliesTo("s1", new Set())).toBe(true);
+  });
+
+  // The bug this exists for (#620 F3): a working cell blinks to idle when a seed response
+  // lands after a live event, and stays wrong until the next event happens to arrive.
+  it("refuses a snapshot for an id the live channel already spoke for", () => {
+    expect(snapshotAppliesTo("s1", new Set(["s1"]))).toBe(false);
+  });
+
+  it("judges each id on its own", () => {
+    const touched = new Set(["s1"]);
+    expect([snapshotAppliesTo("s1", touched), snapshotAppliesTo("s2", touched)]).toEqual([false, true]);
   });
 });


### PR DESCRIPTION
## Summary

The remaining two confirmed cases from #620, in the two shapes the issue identified.

**F2 — notifications.** `active.value = data.active` replaced the list wholesale, so a notification **dismissed while the fetch was in flight came back**: the request went out while it still existed, so the response still listed it. The bell re-lights for something the user already dealt with — and `onReconnect` re-fetches, which is exactly when this is easiest to hit. The reverse happened too: one published mid-flight was absent from the response and disappeared.

**F3 — grid activity.** The seed response wrote every id it carried, unconditionally, so a cell the live channel had already moved to `working` **blinked back to idle** until the next event happened to arrive.

## Two functions, not one

- `applyLiveTouches` — a list the channel can also **remove** from (F2)
- `snapshotAppliesTo` — a map keyed by id: an id touched since the request is not overwritten (F3)

Deliberately separate, per the issue: forcing them together would obscure that **a removal is not an absence**. Both sit beside F1's `mergeLiveIntoSnapshot`.

The composables keep the I/O — remembering what the channel touched after the request went out, and forgetting it once the response is applied.

## Items to Confirm / Review

1. **Stacked on #625 (F1)**, which introduces `liveMerge.ts`. The base retargets to `main` when that merges; review this diff on its own.
2. F4 / F5 from the issue are **not** touched — they already merge and their symptoms are transient. Whether to move them onto the same rule is a call worth making after these land.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `194 files / 2507 tests` — by exit code.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)