### PR TITLE
fix: an older session-list answer no longer overwrites a newer one (#620 F4)

### DIFF
--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -72,11 +72,19 @@ export function useSessions() {
     }
   }
 
+  // load() runs on every "sessions" push, so bursts of activity put several in flight at
+  // once and they can answer out of order. An older answer applied last reverts titles and
+  // ordering to a state the user already saw replaced (#620 F4). Only the newest request may
+  // write.
+  let latestRequest = 0;
+
   async function load(resort = false) {
+    const request = ++latestRequest;
     try {
       const [res, codex] = await Promise.all([fetch("/api/sessions"), fetchCodexSessions()]);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
+      if (request !== latestRequest) return; // a newer load has already answered
       const incoming = [...(data.sessions ?? []), ...codex].sort((a: Session, b: Session) => b.mtime - a.mtime);
       sessions.value = mergeStable(sessions.value, incoming, resort);
       error.value = null;

--- a/test/src/composables/useSessions.spec.ts
+++ b/test/src/composables/useSessions.spec.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { mergeStable, isUnread, type Session } from "../../../src/composables/useSessions";
+import { describe, it, expect, vi } from "vitest";
+import { nextTick } from "vue";
+import { flushPromises } from "@vue/test-utils";
+import { mergeStable, isUnread, useSessions, type Session } from "../../../src/composables/useSessions";
 
 function row(id: string): Session {
   return { id, title: id, mtime: 1, working: false, waiting: false };
@@ -50,5 +52,51 @@ describe("mergeStable", () => {
     const prev = [row("a"), row("b")];
     const incoming = [row("b"), row("a")];
     expect(mergeStable(prev, incoming, true).map((s) => s.id)).toEqual(["b", "a"]);
+  });
+});
+
+// #620 F4: load() runs on every "sessions" push, so bursts put several requests in flight and
+// they can answer out of order. Driven through the composable — the guard is about WHICH
+// answer writes, which no pure function can show on its own.
+describe("useSessions — out-of-order responses", () => {
+  const listOf = (ids: string[]) => ({ ok: true, json: async () => ({ sessions: ids.map(row) }) });
+
+  it("ignores an older answer that lands after a newer one", async () => {
+    const releases: ((value: unknown) => void)[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).includes("codex")) return Promise.resolve({ ok: true, json: async () => ({ sessions: [] }) });
+        return new Promise((resolve) => releases.push(resolve));
+      }),
+    );
+    const { sessions, load } = useSessions();
+    const first = load();
+    const second = load();
+    await nextTick();
+
+    // The newer request answers first, then the older one arrives late.
+    releases[1]?.(listOf(["new"]));
+    await second;
+    releases[0]?.(listOf(["old"]));
+    await first;
+    await flushPromises();
+
+    expect(sessions.value.map((s) => s.id)).toEqual(["new"]);
+  });
+
+  it("applies the answer when nothing newer was asked for", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementation((url: string) =>
+          Promise.resolve(String(url).includes("codex") ? { ok: true, json: async () => ({ sessions: [] }) } : listOf(["a"])),
+        ),
+    );
+    const { sessions, load } = useSessions();
+    await load();
+    await flushPromises();
+    expect(sessions.value.map((s) => s.id)).toEqual(["a"]);
   });
 });


### PR DESCRIPTION
## Summary

**F4 turned out not to be the same bug as F1–F3**, and the difference decides the fix.

`sessions.value` is written **only** by `load()` — the pub/sub handler calls `load()` rather than mutating state. So there is no live update for a snapshot to overwrite, and the live-merge rule the other three share does not apply here.

What there *is*: `load()` runs on **every** push, so a burst of activity puts several requests in flight at once and they can answer **out of order**. An older answer applied last reverts titles and ordering to a state the user already watched get replaced.

The fix is a request-ordering guard: only the newest request may write.

## Items to Confirm / Review

1. **The issue rated this "軽微 (depends on `mergeStable`'s semantics)".** Having read it: `mergeStable` keeps the *previous order* but takes the *incoming values*, so a stale answer does overwrite fresher rows. It is real, just narrower than F1–F3 — no data disappears, the list rewinds.
2. Removing the guard turns the out-of-order test red. The test drives the composable with two overlapping loads and releases them in reverse.

## F5 (`seedMeta`) — assessed, not changed

Same shape as F4 (parallel polls for one session), same narrow symptom: transiently older text, self-healing on the next poll. It is worth the same guard, but it belongs with the roster-polling code rather than bolted on here; happy to do it as its own PR if you want it closed out.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `195 files / 2529 tests` — by exit code.

Refs #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)