### PR TITLE
fix: 読み込み中に消した通知が復活する問題 (#620 F2)

### DIFF
--- a/src/composables/liveMerge.ts
+++ b/src/composables/liveMerge.ts
@@ -22,3 +22,26 @@ export function mergeLiveIntoSnapshot<T>(snapshot: readonly T[], arrivedSince: r
   }
   return merged;
 }
+
+// Some lists lose entries while a snapshot is in flight, not just gain them: the bell's list
+// is fetched whole while the channel is clearing entries out of it. A merge that only knows
+// about arrivals hands a dismissed notification straight back (#620 F2).
+export type LiveChange<T> = { kind: "upsert"; item: T } | { kind: "remove"; id: string };
+
+// Replayed IN ORDER, because the order is the answer: publish-then-clear leaves nothing,
+// clear-then-publish leaves the item, and a set of touched ids could not tell them apart.
+export function applyLiveChanges<T>(snapshot: readonly T[], changes: readonly LiveChange<T>[], identify: (item: T) => string | undefined): T[] {
+  const merged = [...snapshot];
+  for (const change of changes) {
+    if (change.kind === "remove") {
+      const at = merged.findIndex((existing) => identify(existing) === change.id);
+      if (at >= 0) merged.splice(at, 1);
+      continue;
+    }
+    const id = identify(change.item);
+    const at = id === undefined ? -1 : merged.findIndex((existing) => identify(existing) === id);
+    if (at >= 0) merged[at] = change.item;
+    else merged.push(change.item);
+  }
+  return merged;
+}

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -8,6 +8,7 @@
 // matching the wire shape the server's /api/notifications + NotifierEvent emit.
 import { ref, computed } from "vue";
 import { usePubSub } from "./usePubSub";
+import { applyLiveChanges, type LiveChange } from "./liveMerge";
 import { browseNavigateToRecord } from "./useCollectionBrowse";
 
 // Must match server/backends/notifier.ts NOTIFIER_CHANNEL.
@@ -36,6 +37,13 @@ const SEVERITY_RANK: Record<NotifierSeverity, number> = { info: 0, nudge: 1, urg
 
 const active = ref<NotifierEntry[]>([]);
 let initialized = false;
+// Non-null while the authoritative list is being fetched, recording what the channel did
+// meanwhile. The response answers as of the moment it was REQUESTED, so applying it as-is
+// hands back a notification the user has since dismissed (#620 F2).
+let changesDuringFetch: LiveChange<NotifierEntry>[] | null = null;
+// Fetches overlap: the bell asks on init and again on every pub/sub reconnect. Only the
+// newest answer may be applied — an older one describes a moment already overtaken.
+let latestFetch = 0;
 
 /** Parse a collection deep-link (`/collections/<slug>?selected=<itemId>`) into its
  *  parts. String ops + URLSearchParams only — no regex (lint bans backtracking-prone
@@ -81,26 +89,38 @@ function applyEvent(event: NotifierEvent): void {
   switch (event.type) {
     case "published":
     case "updated":
+      changesDuringFetch?.push({ kind: "upsert", item: event.entry });
       upsert(event.entry);
       break;
     case "cleared":
     case "cancelled":
+      changesDuringFetch?.push({ kind: "remove", id: event.id });
       remove(event.id);
       break;
   }
 }
 
 async function fetchActive(): Promise<void> {
+  const fetchId = ++latestFetch;
+  const changes: LiveChange<NotifierEntry>[] = [];
+  changesDuringFetch = changes;
   try {
     const res = await fetch("/api/notifications");
+    // Overtaken while we waited: leave the list to the fetch that overtook us.
+    if (fetchId !== latestFetch) return;
     if (!res.ok) {
       console.error(`[notifications] list failed: HTTP ${res.status}`);
       return;
     }
     const data = (await res.json()) as { active?: NotifierEntry[] };
-    active.value = Array.isArray(data.active) ? data.active : [];
+    if (fetchId !== latestFetch) return;
+    const snapshot = Array.isArray(data.active) ? data.active : [];
+    active.value = applyLiveChanges(snapshot, changes, (entry) => entry.id);
   } catch (err) {
     console.error("[notifications] list failed", err);
+  } finally {
+    // A newer fetch has taken over: leave its record alone.
+    if (changesDuringFetch === changes) changesDuringFetch = null;
   }
 }
 

--- a/test/src/composables/liveMerge.spec.ts
+++ b/test/src/composables/liveMerge.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { mergeLiveIntoSnapshot } from "../../../src/composables/liveMerge";
+import { mergeLiveIntoSnapshot, applyLiveChanges } from "../../../src/composables/liveMerge";
 
 interface Item {
   id?: string;
@@ -88,5 +88,57 @@ describe("mergeLiveIntoSnapshot", () => {
     mergeLiveIntoSnapshot(snapshot, arrived, identify);
     expect(snapshot).toEqual([{ id: "a", text: "A" }]);
     expect(arrived).toEqual([{ id: "a", text: "A2" }]);
+  });
+});
+
+// The bell's list loses entries while it is being fetched, not just gains them, so what is
+// recorded is what the channel DID — in order (#620 F2).
+describe("applyLiveChanges", () => {
+  interface Row {
+    id: string;
+    text: string;
+  }
+  const identify = (row: Row) => row.id;
+  const SNAPSHOT: Row[] = [
+    { id: "a", text: "first" },
+    { id: "b", text: "second" },
+  ];
+  const texts = (rows: Row[]) => rows.map((row) => row.text);
+
+  it("keeps the snapshot when nothing happened", () => {
+    expect(applyLiveChanges(SNAPSHOT, [], identify)).toEqual(SNAPSHOT);
+  });
+
+  it("drops an entry removed while the snapshot was in flight", () => {
+    expect(texts(applyLiveChanges(SNAPSHOT, [{ kind: "remove", id: "a" }], identify))).toEqual(["second"]);
+  });
+
+  it("ignores a removal for something the snapshot never had", () => {
+    expect(applyLiveChanges(SNAPSHOT, [{ kind: "remove", id: "zzz" }], identify)).toEqual(SNAPSHOT);
+  });
+
+  it("adds an entry that arrived while the snapshot was in flight", () => {
+    expect(texts(applyLiveChanges(SNAPSHOT, [{ kind: "upsert", item: { id: "c", text: "third" } }], identify))).toEqual(["first", "second", "third"]);
+  });
+
+  it("updates in place", () => {
+    expect(texts(applyLiveChanges(SNAPSHOT, [{ kind: "upsert", item: { id: "a", text: "first, updated" } }], identify))).toEqual(["first, updated", "second"]);
+  });
+
+  // Order is the whole point: a set of touched ids could not tell these two apart.
+  it("leaves nothing when an entry was added and then removed", () => {
+    const changes = [
+      { kind: "upsert" as const, item: { id: "c", text: "third" } },
+      { kind: "remove" as const, id: "c" },
+    ];
+    expect(applyLiveChanges(SNAPSHOT, changes, identify)).toEqual(SNAPSHOT);
+  });
+
+  it("keeps the entry when it was removed and then added again", () => {
+    const changes = [
+      { kind: "remove" as const, id: "a" },
+      { kind: "upsert" as const, item: { id: "a", text: "first, again" } },
+    ];
+    expect(texts(applyLiveChanges(SNAPSHOT, changes, identify))).toEqual(["second", "first, again"]);
   });
 });

--- a/test/src/composables/useNotifications.spec.ts
+++ b/test/src/composables/useNotifications.spec.ts
@@ -1,5 +1,24 @@
-import { describe, it, expect } from "vitest";
-import { parseCollectionTarget } from "../../../src/composables/useNotifications";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { flushPromises } from "@vue/test-utils";
+import { parseCollectionTarget, type NotifierEntry } from "../../../src/composables/useNotifications";
+
+const subscribers = new Map<string, (data: unknown) => void>();
+// The bell re-fetches its list on every pub/sub reconnect, which is how a second request
+// starts while the first is still out.
+let fireReconnect: (() => void) | undefined;
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, handler: (data: unknown) => void) => {
+      subscribers.set(channel, handler);
+      return () => subscribers.delete(channel);
+    },
+    onReconnect: (handler: () => void) => {
+      fireReconnect = handler;
+      return () => {};
+    },
+  }),
+}));
 
 describe("parseCollectionTarget", () => {
   it("parses slug + selected itemId", () => {
@@ -43,5 +62,139 @@ describe("parseCollectionTarget", () => {
 
   it("returns null for undefined", () => {
     expect(parseCollectionTarget(undefined)).toBeNull();
+  });
+});
+
+// The bell's list is fetched whole, and the channel keeps changing it while that request is
+// out — including clearing an entry the response still lists. Applying the response as-is
+// brought a dismissed notification back (#620 F2).
+describe("useNotifications — the list fetched while the channel is live", () => {
+  const entry = (id: string, title: string): NotifierEntry => ({
+    id,
+    pluginPkg: "test",
+    severity: "info",
+    title,
+    createdAt: "2026-07-22T00:00:00Z",
+  });
+
+  const BELL = entry("n1", "Build finished");
+  const OTHER = entry("n2", "Review requested");
+
+  // The module keeps `active` and its initialised flag in module scope, so each case needs
+  // its own copy to say anything about what a fresh page does.
+  const freshModule = async () => {
+    vi.resetModules();
+    return import("../../../src/composables/useNotifications");
+  };
+
+  // A list request this test decides when to answer, so an event can be delivered while it
+  // is still out — the window the bug lives in.
+  function deferredList(active: NotifierEntry[]) {
+    let answer!: () => void;
+    const gate = new Promise<void>((resolve) => (answer = resolve));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        await gate;
+        return { ok: true, json: async () => ({ active }) };
+      }),
+    );
+    return { answer };
+  }
+
+  const deliver = (event: unknown) => subscribers.get("notifications")?.(event);
+
+  beforeEach(() => subscribers.clear());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not bring back a notification cleared while the list was loading", async () => {
+    const { answer } = deferredList([BELL, OTHER]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "cleared", id: "n1" });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.id)).toEqual(["n2"]);
+  });
+
+  it("keeps a notification published while the list was loading", async () => {
+    const { answer } = deferredList([BELL]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "published", entry: OTHER });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.id)).toEqual(["n1", "n2"]);
+  });
+
+  it("takes an update that landed while the list was loading", async () => {
+    const { answer } = deferredList([BELL]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "updated", entry: entry("n1", "Build failed") });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.title)).toEqual(["Build failed"]);
+  });
+
+  // Order is the answer: cleared-then-published leaves the entry, and the reverse does not.
+  it("replays what happened in the order it happened", async () => {
+    const { answer } = deferredList([BELL]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    deliver({ type: "cleared", id: "n1" });
+    deliver({ type: "published", entry: entry("n1", "Build finished again") });
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.title)).toEqual(["Build finished again"]);
+  });
+
+  // Codex on #626, applied here too: the bell fetches on init AND on every reconnect, so an
+  // older list can land after a newer one and put back what it replaced.
+  it("ignores an older list that lands after a newer one", async () => {
+    const gates: Array<() => void> = [];
+    const answers = [[BELL], [OTHER]];
+    let call = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        const mine = call++;
+        await new Promise<void>((resolve) => gates.push(resolve));
+        return { ok: true, json: async () => ({ active: answers[mine] }) };
+      }),
+    );
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+    fireReconnect?.(); // a reconnect asks again while the first request is still out
+
+    gates[1]?.(); // the newer answer arrives first
+    await flushPromises();
+    expect(active.value.map((e) => e.id)).toEqual(["n2"]);
+
+    gates[0]?.(); // the stale one, arriving last
+    await flushPromises();
+    expect(active.value.map((e) => e.id)).toEqual(["n2"]);
+  });
+
+  it("shows the fetched list when nothing happened meanwhile", async () => {
+    const { answer } = deferredList([BELL, OTHER]);
+    const { useNotifications } = await freshModule();
+    const { active } = useNotifications();
+
+    answer();
+    await flushPromises();
+
+    expect(active.value.map((e) => e.id)).toEqual(["n1", "n2"]);
   });
 });


### PR DESCRIPTION
Refs #620

> #624 の作り直しです。元 PR は自前のヘルパの上に立っていましたが、**同等のものが先に main へ入った**（`liveMerge.ts`、#622 は重複としてクローズ）ため、そちらを拡張する形にしました。

## Summary

**消したはずの通知が復活する**バグの修正です。

ベルは権威あるリストを丸ごと取得しますが、その間もチャネルはリストを変更し続けます。**取得中に消した通知が、応答にはまだ載っています。** `fetchActive` は **pub/sub の再接続時にも発火**するので、イベントが飛び交うタイミングと重なりやすい経路です。

## `liveMerge` に足したもの

main の `mergeLiveIntoSnapshot` は「**到着したもの**をスナップショットに重ねる」形です。通知のリストは取得中に**項目が消えもする**ので、到着だけでは表現できません。

`applyLiveChanges` は「**チャネルが何をしたか**」を順序付きで記録して再生します。

| 起きた順 | 正しい結果 |
|---|---|
| publish → clear | 残らない |
| clear → publish | 残る |

**触られた id の集合では、この 2 つを区別できません。**

## 二次の層（Codex が #626 で指摘）

`fetchActive` は初期化時と**再接続のたび**に走るので、**自分自身と重なります**。古い応答が新しい応答の結果を上書きするため、世代を取って追い越された応答を捨てます。

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| 応答で無条件置換（元のバグ） | 4 件 |
| 到着だけ記録し、削除を記録しない | **「消した通知が復活しない」1 件だけ** |
| 世代ガードを外す | **「古いリストが後着しても無視する」1 件だけ** |

2 つ目と 3 つ目が、それぞれ別の層を守っていることを示しています。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `yarn test`（197 files, 2556 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
