### PR TITLE
fix: 履歴取得が重なったとき、古い応答が新しい結果を巻き戻す (#620 F1 二次層)

### DIFF
--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -21,6 +21,10 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
   // authoritative as of when it was SENT, so these have to survive it (#620 F1).
   let loadingSession: string | null = null;
   let arrivedDuringLoad: T[] = [];
+  // The session id is not enough to tell two loads apart: switching away and back leaves two
+  // in flight for the id that is current, so both pass the guard below. Only the newest may
+  // apply — an older answer describes a moment already overtaken (#620).
+  let latestLoad = 0;
 
   function upsert(item: T) {
     if (loadingSession !== null) arrivedDuringLoad.push(item);
@@ -31,23 +35,26 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
   }
 
   async function loadHistory(id: string) {
+    const loadId = ++latestLoad;
     loadingSession = id;
     arrivedDuringLoad = [];
+    // A slow response for an old session must not clobber the pane after the user has
+    // switched away — nor an older response for the session they switched back to.
+    const overtaken = () => id !== sessionId() || loadId !== latestLoad;
     try {
       const res = await fetch(historyUrl(id));
-      // Guard against a session-switch race: a slow response for an old session must
-      // not clobber the pane after the user has switched to a newer one.
-      if (id !== sessionId()) return;
+      if (overtaken()) return;
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      if (id !== sessionId()) return;
+      if (overtaken()) return;
       items.value = mergeLiveIntoSnapshot(data[historyKey] ?? [], arrivedDuringLoad, identify);
     } catch {
       // A failed history read must not take the live events with it.
-      if (id === sessionId()) items.value = mergeLiveIntoSnapshot([], arrivedDuringLoad, identify);
+      if (!overtaken()) items.value = mergeLiveIntoSnapshot([], arrivedDuringLoad, identify);
     } finally {
-      // Only if a newer load has not already taken over the tracking.
-      if (loadingSession === id) {
+      // Only if a newer load has not already taken over the tracking. Comparing the load,
+      // not the session id: switching back gives the newer load the same id as this one.
+      if (loadId === latestLoad) {
         loadingSession = null;
         arrivedDuringLoad = [];
       }

--- a/test/src/composables/useSessionFeed.spec.ts
+++ b/test/src/composables/useSessionFeed.spec.ts
@@ -99,3 +99,34 @@ describe("useSessionFeed", () => {
     await vi.waitFor(() => expect(items.value).toEqual([{ id: "a", text: "newer" }]));
   });
 });
+
+// The second layer of the same race, raised by Codex on the sibling PR (#626): the id guard
+// above cannot tell two loads apart when the user switches AWAY and BACK, because both are
+// for the session that is current. An older answer landing last then puts back what the
+// newer one replaced — and the `finally` clears the newer load's tracking along with it.
+describe("useSessionFeed — overlapping loads for the same session", () => {
+  it("ignores an older history that lands after a newer one", async () => {
+    const gates: Array<() => void> = [];
+    // Three loads: the initial one, the switch away, and the switch back.
+    const answers = [[{ id: "old", text: "older" }], [{ id: "other", text: "other session" }], [{ id: "new", text: "newer" }]];
+    let call = 0;
+    const { items, sessionId } = mountFeed(async () => {
+      const mine = call++;
+      await new Promise<void>((resolve) => gates.push(resolve));
+      return { ok: true, json: async () => ({ items: answers[mine] }) };
+    });
+
+    sessionId.value = "s2";
+    await nextTick();
+    sessionId.value = "s1"; // back again: two loads are in flight for "s1"
+    await nextTick();
+
+    gates.at(-1)?.(); // the newest answers first
+    await flushPromises();
+    expect(items.value.map((item) => item.id)).toEqual(["new"]);
+
+    gates[0]?.(); // the stale one, arriving last
+    await flushPromises();
+    expect(items.value.map((item) => item.id)).toEqual(["new"]);
+  });
+});


### PR DESCRIPTION
Refs #620

## Summary

main の F1 修正（`liveMerge` / #622 は重複クローズ）には、**同じ競合の二次の層**が残っています。Codex が兄弟 PR #626 で指摘したものです。

```ts
if (id !== sessionId()) return;   // ← セッション切替は捕まえるが…
```

**セッションを A→B→A と切り替えると、A への load が 2 本同時に飛びます。** どちらも「現在の id」なのでこのガードを両方通り、**古い応答が後着して新しい結果を巻き戻します**。

`finally` 側にも逆向きの死角がありました。

```ts
if (loadingSession === id) { loadingSession = null; arrivedDuringLoad = []; }
```

**古い load でもこの条件が真になる**ため、新しい load の追跡を古い load が消してしまいます。消された側は、待っている間に届いたイベントを保持できなくなります。

## 直し方

どちらも**セッション id ではなく load そのもの**を比較します（世代カウンタ）。

## Items to Confirm / Review

1. **これは main に既にある修正への追補です**（#622 は重複としてクローズ済み）。中身の重複はありません
2. 同じ形が `useNotifications`(#630) と `useGridActivity`(#626) にもあり、そちらはそれぞれの PR で対応済みです
3. `finally` の死角は Codex の指摘には含まれておらず、同じ観点でコードを読み直して見つけたものです

## テストが効くことの確認

世代ガードを外す（＝現在の main の状態に戻す）と、**新規 1 件だけ**が落ちます。既存 4 件は通ったままです。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `yarn test`（197 files, 2544 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
