### PR TITLE
fix: メディアのシークを壊す Range ヘッダのバグ 3 件 (#611 A4)

### DIFF
--- a/server/backends/byte-range.ts
+++ b/server/backends/byte-range.ts
@@ -1,0 +1,40 @@
+// Which bytes a `Range: bytes=…` header actually asks for.
+//
+// Out of files.ts because the answer decides between 206-with-data and a 416, and a 416 to a
+// media player is a failed seek — the one place where being stricter than the spec is worse
+// than being wrong (#611 A4). It was reachable only through an HTTP request, and only the
+// one satisfiable case was ever exercised.
+//
+// RFC 7233 §2.1 is deliberately forgiving about the far end of a range, because a player
+// asking past the end of a file is normal: it is seeking and does not yet know the length.
+
+export interface ByteRange {
+  start: number;
+  end: number;
+}
+
+// `bytes=<first>-<last>` with either side optional; anything else is not a range we serve.
+const BYTE_RANGE = /^bytes=(\d*)-(\d*)$/;
+
+export function parseByteRange(header: string, size: number): ByteRange | null {
+  const match = BYTE_RANGE.exec(header.trim());
+  if (!match) return null;
+  const [, firstText, lastText] = match;
+  // "bytes=-" names neither end.
+  if (firstText === "" && lastText === "") return null;
+
+  // A suffix range asks for the LAST n bytes, so the number after the dash is a LENGTH and
+  // not a position — it says where the range starts, and the range always runs to the end.
+  // Asking for more than the file holds is the whole file, not a refusal: the client cannot
+  // know the length before it asks.
+  const suffix = firstText === "";
+  const start = suffix ? Math.max(0, size - Number(lastText)) : Number(firstText);
+  // An absent or past-the-end far side means "to the end", again because a seek is a guess.
+  const requestedEnd = suffix || lastText === "" ? size - 1 : Number(lastText);
+  const end = Math.min(requestedEnd, size - 1);
+
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  // Nothing to serve: an empty file, a start past the end, or a zero-length suffix.
+  if (size === 0 || start >= size || end < start) return null;
+  return { start, end };
+}

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -18,6 +18,7 @@ import path from "node:path";
 import { createReadStream } from "node:fs";
 import type { Express, Request, Response } from "express";
 import { statFileOr404 } from "./statFileOr404.js";
+import { parseByteRange } from "./byte-range.js";
 
 const MAX_RAW_BYTES = 25 * 1024 * 1024; // images / text / generic
 const MAX_MEDIA_BYTES = 500 * 1024 * 1024; // audio / video (streamed via Range)
@@ -47,18 +48,6 @@ const MIME_BY_EXT: Record<string, string> = {
 
 function isMedia(mime: string): boolean {
   return mime.startsWith("audio/") || mime.startsWith("video/");
-}
-
-function parseRange(header: string, size: number): { start: number; end: number } | null {
-  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
-  if (!match) return null;
-  const [, startStr, endStr] = match;
-  if (startStr === "" && endStr === "") return null;
-  const start = startStr === "" ? size - Number(endStr) : Number(startStr);
-  const end = endStr === "" ? size - 1 : Number(endStr);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
-  if (start < 0 || end < start || end >= size) return null;
-  return { start, end };
 }
 
 export function mountFilesRoutes(app: Express, deps: { workspace: string }): void {
@@ -98,7 +87,7 @@ export function mountFilesRoutes(app: Express, deps: { workspace: string }): voi
     // Range support (required for <video>/<audio> seeking in Safari).
     const rangeHeader = req.headers.range;
     if (rangeHeader) {
-      const range = parseRange(rangeHeader, stat.size);
+      const range = parseByteRange(rangeHeader, stat.size);
       if (!range) {
         res.status(416).setHeader("Content-Range", `bytes */${stat.size}`);
         res.json({ error: "invalid range" });

--- a/test/server/backends/byte-range.spec.ts
+++ b/test/server/backends/byte-range.spec.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+
+import { parseByteRange } from "../../../server/backends/byte-range.js";
+
+const SIZE = 1000;
+const of = (header: string, size = SIZE) => parseByteRange(header, size);
+
+describe("parseByteRange", () => {
+  describe("an ordinary range", () => {
+    it("takes both ends as given", () => {
+      expect(of("bytes=0-499")).toEqual({ start: 0, end: 499 });
+    });
+
+    it("serves a single byte", () => {
+      expect(of("bytes=0-0")).toEqual({ start: 0, end: 0 });
+    });
+
+    it("serves the last byte", () => {
+      expect(of("bytes=999-999")).toEqual({ start: 999, end: 999 });
+    });
+
+    it("serves the whole file when asked for exactly that", () => {
+      expect(of("bytes=0-999")).toEqual({ start: 0, end: 999 });
+    });
+
+    it("ignores surrounding whitespace", () => {
+      expect(of("  bytes=0-499  ")).toEqual({ start: 0, end: 499 });
+    });
+  });
+
+  describe("an open-ended range", () => {
+    it("runs to the end of the file", () => {
+      expect(of("bytes=500-")).toEqual({ start: 500, end: 999 });
+    });
+
+    it("from zero is the whole file", () => {
+      expect(of("bytes=0-")).toEqual({ start: 0, end: 999 });
+    });
+
+    it("from the last byte is that byte", () => {
+      expect(of("bytes=999-")).toEqual({ start: 999, end: 999 });
+    });
+  });
+
+  describe("a suffix range asks for the last n bytes", () => {
+    it("counts back from the end", () => {
+      expect(of("bytes=-500")).toEqual({ start: 500, end: 999 });
+    });
+
+    it("asking for exactly the file gives the whole file", () => {
+      expect(of("bytes=-1000")).toEqual({ start: 0, end: 999 });
+    });
+
+    // A player seeking to the end does not know the length yet, so it guesses high. The
+    // answer is the whole file, not a refusal — this used to be a 416, and a 416 to a media
+    // element is a failed seek.
+    it("asking for more than the file holds gives the whole file", () => {
+      expect(of("bytes=-5000")).toEqual({ start: 0, end: 999 });
+    });
+
+    it("asking for nothing is unsatisfiable", () => {
+      expect(of("bytes=-0")).toBeNull();
+    });
+  });
+
+  // RFC 7233 §2.1: a last-byte-pos at or past the end means "the rest of it". Same reason —
+  // the client is guessing, and refusing the guess breaks seeking.
+  describe("a far end past the end of the file", () => {
+    it("is truncated to the last byte", () => {
+      expect(of("bytes=0-99999")).toEqual({ start: 0, end: 999 });
+    });
+
+    it("is truncated when the start is partway in", () => {
+      expect(of("bytes=900-99999")).toEqual({ start: 900, end: 999 });
+    });
+
+    it("is truncated for an absurdly large value", () => {
+      expect(of("bytes=0-99999999999999999999")).toEqual({ start: 0, end: 999 });
+    });
+  });
+
+  describe("nothing to serve", () => {
+    it("refuses a start past the end", () => {
+      expect(of("bytes=1000-")).toBeNull();
+      expect(of("bytes=1000-1001")).toBeNull();
+    });
+
+    it("refuses a backwards range", () => {
+      expect(of("bytes=500-499")).toBeNull();
+    });
+
+    it("refuses any range on an empty file", () => {
+      expect(of("bytes=0-0", 0)).toBeNull();
+      expect(of("bytes=0-", 0)).toBeNull();
+      expect(of("bytes=-1", 0)).toBeNull();
+    });
+  });
+
+  describe("headers that are not a byte range we serve", () => {
+    it.each([
+      ["a missing unit", "0-499"],
+      ["another unit", "items=0-499"],
+      ["no numbers at all", "bytes=-"],
+      ["a non-numeric end", "bytes=0-abc"],
+      ["a non-numeric start", "bytes=abc-499"],
+      ["a negative number", "bytes=--5"],
+      ["a multi-range request", "bytes=0-99,200-299"],
+      ["a decimal", "bytes=0.5-9"],
+      ["an empty header", ""],
+      ["whitespace only", "   "],
+      ["a plus sign", "bytes=+0-499"],
+      ["internal whitespace", "bytes=0 - 499"],
+    ])("refuses %s", (_label, header) => {
+      expect(of(header)).toBeNull();
+    });
+  });
+
+  // The one-byte file is where "size - 1" and "start >= size" meet.
+  describe("a one-byte file", () => {
+    it("serves its only byte", () => {
+      expect(of("bytes=0-0", 1)).toEqual({ start: 0, end: 0 });
+      expect(of("bytes=0-", 1)).toEqual({ start: 0, end: 0 });
+      expect(of("bytes=-1", 1)).toEqual({ start: 0, end: 0 });
+    });
+
+    it("refuses anything beyond it", () => {
+      expect(of("bytes=1-", 1)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Refs #611

## Summary

`parseRange` は `files.ts` の中に private で置かれ、**成立する 1 ケースの HTTP テストからしか通っていませんでした**。境界を洗い出したところ、**プレイヤーがデータを期待する場面で 416 を返す（あるいは誤ったバイトを返す）経路が 3 つ**見つかりました。

**メディア要素にとって 416 は「シーク失敗」です。**

| # | 症状 | 例（1000 バイトのファイル） |
|---|---|---|
| 1 | **suffix range が 1 バイトしか返さない** | `bytes=-500`（末尾 500 バイト）→ `bytes 500-500/1000` |
| 2 | ファイルより長い suffix を拒否 | `bytes=-5000` → **416**（正しくは全体） |
| 3 | 終端がファイル末尾を超えると拒否 | `bytes=0-99999` → **416**（正しくは末尾まで） |

### 1 は「端のケース」ではなく機能自体の破損です

`bytes=-500` の「500」は**長さ**であって last-byte-pos ではありません。それを終端位置として使っていたため、**suffix range は丸ごと壊れていました**。

2・3 はいずれも RFC 7233 §2.1 が明示的に許容を求めている挙動です。理由は同じで、**プレイヤーは長さを知る前にシークするので、必ず高めに推測する**からです。推測を拒否すると再生が止まります。

## Items to Confirm / Review

1. **バグ 1 は読んで見つけたのではなく、テストが見つけました。** 抽出時は元の実装を忠実に移しており、境界の行列を書いて初めて「答えが 1 バイト幅」だと分かりました
2. **変えていないもの**：不正な Range に対しては今も 416 を返します（RFC は無視して 200 を返すことを推奨）。これはより広い挙動変更で、そもそも送ってくるクライアントも知られていないため、**別途判断すべき**と考えて手を付けていません
3. 呼び出し側（416 / 206 の分岐）は変更していません

## テスト

`server/backends/byte-range.ts` に切り出し、**32 ケース**：通常・開放端・suffix の各 range、2 種類のクランプ、空ファイルと 1 バイトファイル、そして「byte range ではないヘッダ」12 種。

**修正前の挙動に戻すと 7 件が赤くなります。**

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:server` / `yarn test`（199 files, 2597 tests）通過。既存の `files.spec.ts` も無変更で通ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
