### PR TITLE
refactor: ランチャの CLI 引数の判断をテスト可能にする (#611 A3)

### DIFF
--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -1,0 +1,4 @@
+export type PortChoice = { port: number; explicit: boolean } | { error: string };
+export type CwdChoice = { path: string; mustExist: boolean } | { error: string };
+export declare function parsePortArg(args: string[], defaultPort: number): PortChoice;
+export declare function chooseCwd(args: string[], env: Record<string, string | undefined>): CwdChoice;

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -1,0 +1,44 @@
+// What the launcher's two flags resolve to, decided without touching the process.
+//
+// `--cwd` picks the workspace claude runs in and whose sessions the sidebar lists, so it is
+// a data-scope boundary: getting it wrong points the whole app at someone else's project.
+// `--port` decides whether a clash is a hard error or a silent retry. Both used to be
+// decided inside the executable, where they exit the process on a bad value and so could not
+// be checked at all (#611 A3).
+//
+// These return a decision; the caller prints and exits. Nothing here reads argv, the
+// environment or the filesystem.
+
+/**
+ * Which port the launcher should ask for.
+ * `--port` must be a plain integer in range: a value that merely starts with digits ("80x")
+ * or carries a sign or padding ("+80", "080") is a typo, and silently launching on 80 is
+ * worse than saying so.
+ */
+export function parsePortArg(args, defaultPort) {
+  const at = args.indexOf("--port");
+  if (at === -1) return { port: defaultPort, explicit: false };
+  const raw = args[at + 1];
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isInteger(parsed) || String(parsed) !== raw || parsed < 1 || parsed > 65535) {
+    return { error: `Invalid --port value: "${raw ?? ""}" (expected integer 1..65535)` };
+  }
+  return { port: parsed, explicit: true };
+}
+
+/**
+ * Which directory to run in, before it is made absolute.
+ * Precedence: `--cwd` (relative allowed) > CLAUDE_CWD > the directory the launcher was run
+ * from. `mustExist` is set only for `--cwd`: a typo there should stop the launch, while a
+ * CLAUDE_CWD naming a directory that isn't there yet is the managed-workspace case the
+ * server creates on boot.
+ */
+export function chooseCwd(args, env) {
+  const at = args.indexOf("--cwd");
+  if (at === -1) return { path: env.CLAUDE_CWD ?? ".", mustExist: false };
+  const value = args[at + 1];
+  // A missing value swallows the next flag ("--cwd --port 3000" would run in a directory
+  // called "--port"), so anything flag-shaped is treated as absent.
+  if (value === undefined || value.startsWith("-")) return { error: "--cwd requires a directory path" };
+  return { path: value, mustExist: true };
+}

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -14,6 +14,7 @@ import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { fetchLatestVersion, isNewerVersion } from "./update-check.js";
+import { chooseCwd, parsePortArg } from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = join(__dirname, "..");
@@ -220,35 +221,23 @@ function printReadyBanner(url) {
   console.log(`${bar}\n`);
 }
 
-function parsePortArg(args) {
-  const idx = args.indexOf("--port");
-  if (idx === -1) return { requestedPort: DEFAULT_PORT, portExplicit: false };
-  const raw = args[idx + 1];
-  const parsed = Number.parseInt(raw ?? "", 10);
-  if (!Number.isInteger(parsed) || String(parsed) !== raw || parsed < 1 || parsed > 65535) {
-    error(`Invalid --port value: "${raw ?? ""}" (expected integer 1..65535)`);
+// The two flag decisions live in cli-args.js so they can be checked without a process to
+// exit; this turns a decision into the message and the exit.
+function decideOrExit(choice) {
+  if ("error" in choice) {
+    error(choice.error);
     process.exit(1);
   }
-  return { requestedPort: parsed, portExplicit: true };
+  return choice;
 }
 
 // Resolve the workspace directory claude runs in (and whose sessions the sidebar
-// lists). Precedence: --cwd (relative paths allowed) > CLAUDE_CWD env > the
-// directory npx was run from. Always returned absolute. An explicit --cwd that
-// isn't an existing directory is a hard error (catches typos before launch).
+// lists), always absolute. An explicit --cwd that isn't an existing directory is a hard
+// error (catches typos before launch); an inherited one is the workspace the server creates.
 function resolveCwd(args) {
-  const idx = args.indexOf("--cwd");
-  let flagValue;
-  if (idx !== -1) {
-    flagValue = args[idx + 1];
-    if (flagValue === undefined || flagValue.startsWith("-")) {
-      error("--cwd requires a directory path");
-      process.exit(1);
-    }
-  }
-  const chosen = flagValue ?? process.env.CLAUDE_CWD ?? ".";
+  const { path: chosen, mustExist } = decideOrExit(chooseCwd(args, process.env));
   const abs = resolve(process.cwd(), chosen);
-  if (idx !== -1 && (!existsSync(abs) || !statSync(abs).isDirectory())) {
+  if (mustExist && (!existsSync(abs) || !statSync(abs).isDirectory())) {
     error(`--cwd is not a directory: ${abs}`);
     process.exit(1);
   }
@@ -369,7 +358,7 @@ async function main() {
     process.exit(1);
   }
 
-  const { requestedPort, portExplicit } = parsePortArg(args);
+  const { port: requestedPort, explicit: portExplicit } = decideOrExit(parsePortArg(args, DEFAULT_PORT));
   const noOpen = args.includes("--no-open");
   const cwd = resolveCwd(args);
   log(`Workspace: ${cwd}`);

--- a/test/bin/cli-args.spec.ts
+++ b/test/bin/cli-args.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+
+import { parsePortArg, chooseCwd } from "../../bin/cli-args.js";
+
+const DEFAULT_PORT = 34567;
+const port = (args: string[]) => parsePortArg(args, DEFAULT_PORT);
+const cwd = (args: string[], env: Record<string, string | undefined> = {}) => chooseCwd(args, env);
+
+describe("parsePortArg", () => {
+  it("falls back to the default when the flag is absent", () => {
+    expect(port([])).toEqual({ port: DEFAULT_PORT, explicit: false });
+    expect(port(["--cwd", "/tmp"])).toEqual({ port: DEFAULT_PORT, explicit: false });
+  });
+
+  // `explicit` is what decides whether a busy port is a hard error or a silent retry on
+  // another one, so it has to distinguish "asked for" from "happens to be the default".
+  it("marks a port the user asked for as explicit, even when it is the default", () => {
+    expect(port(["--port", String(DEFAULT_PORT)])).toEqual({ port: DEFAULT_PORT, explicit: true });
+  });
+
+  it("takes a valid port", () => {
+    expect(port(["--port", "3000"])).toEqual({ port: 3000, explicit: true });
+  });
+
+  it("reads the flag wherever it sits", () => {
+    expect(port(["--cwd", "/tmp", "--port", "3000", "--foo"])).toEqual({ port: 3000, explicit: true });
+  });
+
+  describe("boundaries", () => {
+    it.each([1, 80, 1024, 65535])("accepts %i", (value) => {
+      expect(port(["--port", String(value)])).toEqual({ port: value, explicit: true });
+    });
+
+    it.each(["0", "65536", "-1", "99999"])("refuses %s", (value) => {
+      expect(port(["--port", value])).toHaveProperty("error");
+    });
+  });
+
+  // parseInt stops at the first non-digit, so a typo would otherwise launch on a port the
+  // user never named — "80x" silently becoming 80 is worse than being told.
+  describe("values that are not plainly an integer", () => {
+    it.each([
+      ["trailing letters", "80x"],
+      ["a decimal", "3000.5"],
+      ["padding", "0300"],
+      ["a plus sign", "+3000"],
+      ["surrounding space", " 3000"],
+      ["a thousands separator", "3,000"],
+      ["hex", "0x1f90"],
+      ["words", "three thousand"],
+      ["empty", ""],
+    ])("refuses %s", (_label, value) => {
+      expect(port(["--port", value])).toHaveProperty("error");
+    });
+
+    it("refuses a flag at the end of the arguments", () => {
+      expect(port(["--port"])).toHaveProperty("error");
+    });
+
+    // Otherwise "--port --cwd /tmp" would swallow the next flag.
+    it("refuses the next flag as a value", () => {
+      expect(port(["--port", "--cwd", "/tmp"])).toHaveProperty("error");
+    });
+
+    it("names the offending value in the message", () => {
+      const result = port(["--port", "80x"]);
+      expect("error" in result && result.error).toContain('"80x"');
+    });
+  });
+});
+
+// The workspace claude runs in, and whose sessions the sidebar lists — so this is a
+// data-scope boundary, not a convenience.
+describe("chooseCwd", () => {
+  describe("precedence", () => {
+    it("prefers the flag over the environment", () => {
+      expect(cwd(["--cwd", "/from/flag"], { CLAUDE_CWD: "/from/env" })).toEqual({ path: "/from/flag", mustExist: true });
+    });
+
+    it("falls back to the environment", () => {
+      expect(cwd([], { CLAUDE_CWD: "/from/env" })).toEqual({ path: "/from/env", mustExist: false });
+    });
+
+    it("falls back to where the launcher was run", () => {
+      expect(cwd([], {})).toEqual({ path: ".", mustExist: false });
+    });
+
+    it("treats an unset environment variable as absent", () => {
+      expect(cwd([], { CLAUDE_CWD: undefined })).toEqual({ path: ".", mustExist: false });
+    });
+  });
+
+  // A typo in an explicit --cwd should stop the launch; an inherited CLAUDE_CWD naming a
+  // directory that is not there yet is the managed workspace the server creates on boot.
+  describe("which source has to exist already", () => {
+    it("requires the flag's directory to exist", () => {
+      expect(cwd(["--cwd", "/tmp"])).toHaveProperty("mustExist", true);
+    });
+
+    it("does not require the environment's to", () => {
+      expect(cwd([], { CLAUDE_CWD: "/not/yet" })).toHaveProperty("mustExist", false);
+    });
+  });
+
+  describe("relative and unusual paths are passed through", () => {
+    it.each(["..", "./sub dir", "~/projects", "sub/dir/"])("keeps %o as written", (value) => {
+      expect(cwd(["--cwd", value])).toEqual({ path: value, mustExist: true });
+    });
+  });
+
+  describe("a missing value", () => {
+    it("refuses the flag at the end of the arguments", () => {
+      expect(cwd(["--cwd"])).toHaveProperty("error");
+    });
+
+    // Otherwise the launch would run in a directory called "--port".
+    it("refuses the next flag as a value", () => {
+      expect(cwd(["--cwd", "--port", "3000"])).toHaveProperty("error");
+    });
+
+    it("refuses a lone dash-prefixed value", () => {
+      expect(cwd(["--cwd", "-"])).toHaveProperty("error");
+    });
+  });
+});


### PR DESCRIPTION
Refs #611

## Summary

`bin/mulmoterminal.js` の 2 つのフラグ判断を `bin/cli-args.js` に切り出しました。**判断を返すだけ**にして、メッセージ出力と `process.exit` はランチャ側に残しています（既に同じ形で分かれている `bin/update-check.js` に倣いました）。

**`--cwd` は利便性ではなくデータ範囲の境界です** — claude が動くワークスペースであり、サイドバーが一覧するセッションの出所でもあります。間違えるとアプリ全体が別プロジェクトを向きます。`--port` は衝突時に起動を止めるか黙って別ポートで再試行するかを決めます。

どちらも**実行ファイルの中で `process.exit` する形**だったため、**検査する手段がありませんでした**。

**テスト 37 件**追加。

## 暗黙だったルールを明文化しました

| ルール | なぜ重要か |
|---|---|
| `explicit` は「明示的に指定された」と「たまたま既定値と同じ」を区別する | ポート衝突時に**ハードエラーにするか黙って別ポートにするか**を分ける |
| ポートは**素直な整数**でなければならない | `parseInt` は最初の非数字で止まるので、`80x` は**黙って 80 番で起動**してしまう |
| フラグ形の値は「値なし」として扱う | でないと `--cwd --port 3000` が **`--port` という名前のディレクトリ**で起動する |
| **存在必須なのは `--cwd` だけ** | 環境変数 `CLAUDE_CWD` がまだ無いディレクトリを指すのは、サーバが起動時に作る管理ワークスペースの正常系。この非対称は意図的で、今回テストで固定 |

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| 厳密な整数チェック（`String(parsed) !== raw`）を外す | **5 件** |
| `--cwd` のフラグ形チェックを外す | 2 件 |
| 環境変数側も存在必須にする | 4 件 |

## 挙動不変の確認

**ランチャを実際に動かして確認しました。**

- `--help` — 従来どおり
- `--port 80x` — `Invalid --port value: "80x" (expected integer 1..65535)`
- `--cwd /definitely/not/here` — `--cwd is not a directory: /definitely/not/here`

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:test` / `yarn test`（199 files, 2602 tests）/ `yarn knip` すべて通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
