### PR TITLE
fix: 2 つ目のインスタンスが、相手の隠しグリッドセッションを取りこぼす (#611 B1)

### DIFF
--- a/server/session/dev-terminal-sessions.ts
+++ b/server/session/dev-terminal-sessions.ts
@@ -1,0 +1,25 @@
+// The set of grid/dev-terminal session ids, as it is read from and written back to disk.
+//
+// The set exists to keep a grid cell's transcript out of the chat sidebar — the "chat
+// hijacked my multi-terminal session" bug — so an id going missing brings that back.
+//
+// It is shared between INSTANCES, not just between requests. MULMOTERMINAL_HOME is
+// ~/.mulmoterminal for every server on the machine, and launching twice is the ordinary way
+// to get two: the launcher falls back to another port when the default is busy. Writing the
+// in-memory set alone therefore drops whatever a peer added since we booted, so a write
+// unions with what is on disk first — the same thing POST /api/config does, for the same
+// reason (#611 B1).
+//
+// A union is the whole answer only because the set is append-only: nothing removes an id, so
+// there is no removal for a peer's copy to resurrect.
+
+/** Ids from a parsed file, keeping only what is usable as a session id (and a filename). */
+export function parseDevTerminalSessionIds(raw: unknown, isValidId: (id: string) => boolean): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((id): id is string => typeof id === "string" && isValidId(id));
+}
+
+/** What to write: everything on disk plus everything we know, in a stable order. */
+export function mergeDevTerminalSessionIds(onDisk: readonly string[], inMemory: Iterable<string>): string[] {
+  return [...new Set([...onDisk, ...inMemory])].sort();
+}

--- a/server/session/dev-terminal-sessions.ts
+++ b/server/session/dev-terminal-sessions.ts
@@ -5,21 +5,42 @@
 //
 // It is shared between INSTANCES, not just between requests. MULMOTERMINAL_HOME is
 // ~/.mulmoterminal for every server on the machine, and launching twice is the ordinary way
-// to get two: the launcher falls back to another port when the default is busy. Writing the
-// in-memory set alone therefore drops whatever a peer added since we booted, so a write
-// unions with what is on disk first — the same thing POST /api/config does, for the same
-// reason (#611 B1).
+// to get two: the launcher falls back to another port when the default is busy.
 //
-// A union is the whole answer only because the set is append-only: nothing removes an id, so
-// there is no removal for a peer's copy to resurrect.
+// So the file is an APPEND LOG, one id per line, rather than a rewritten snapshot. That is
+// what makes it safe without a lock: a snapshot has to be read, merged and written back, and
+// two instances doing that at once lose whichever finishes first — narrowing the window does
+// not close it. Appending needs no read at all, and an id is the only thing ever added
+// (nothing removes one), so there is no ordering to get wrong (#611 B1).
+//
+// The old format was a single JSON array. It is still read, so an existing file keeps
+// working and simply stops being rewritten.
 
-/** Ids from a parsed file, keeping only what is usable as a session id (and a filename). */
-export function parseDevTerminalSessionIds(raw: unknown, isValidId: (id: string) => boolean): string[] {
-  if (!Array.isArray(raw)) return [];
-  return raw.filter((id): id is string => typeof id === "string" && isValidId(id));
+/** One line of the log: a bare id, or the whole legacy JSON array. */
+function idsFromLine(line: string, isValidId: (id: string) => boolean): string[] {
+  const text = line.trim();
+  if (!text) return [];
+  if (text.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(text);
+      return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string" && isValidId(id)) : [];
+    } catch {
+      return []; // a truncated legacy line is not worth guessing at
+    }
+  }
+  return isValidId(text) ? [text] : [];
 }
 
-/** What to write: everything on disk plus everything we know, in a stable order. */
-export function mergeDevTerminalSessionIds(onDisk: readonly string[], inMemory: Iterable<string>): string[] {
-  return [...new Set([...onDisk, ...inMemory])].sort();
+/**
+ * The ids a file holds, in either format. Anything unusable as a session id is dropped
+ * rather than carried along — these end up as filenames elsewhere.
+ */
+export function parseDevTerminalSessionIds(contents: string, isValidId: (id: string) => boolean): string[] {
+  const ids = contents.split("\n").flatMap((line) => idsFromLine(line, isValidId));
+  return [...new Set(ids)];
+}
+
+/** What to append for a newly marked id. */
+export function devTerminalSessionLine(id: string): string {
+  return `${id}\n`;
 }

--- a/server/session/dev-terminal-sessions.ts
+++ b/server/session/dev-terminal-sessions.ts
@@ -40,7 +40,15 @@ export function parseDevTerminalSessionIds(contents: string, isValidId: (id: str
   return [...new Set(ids)];
 }
 
-/** What to append for a newly marked id. */
+/**
+ * What to append for a newly marked id.
+ *
+ * The newline goes BEFORE the id, not after. An existing file holds the legacy JSON array
+ * with no trailing newline, so appending `<id>\n` would weld the first id onto the end of
+ * that array — the line then parses as neither, and every previously hidden session is lost
+ * on the next hydrate. Leading it instead means an appended id always starts its own line,
+ * whatever the file ended with.
+ */
 export function devTerminalSessionLine(id: string): string {
-  return `${id}\n`;
+  return `\n${id}`;
 }

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -13,7 +13,7 @@ import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, parseActivityState } from "./activity-state.js";
-import { mergeDevTerminalSessionIds, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
+import { devTerminalSessionLine, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
 
 // Per-session "working" state, driven by Claude hooks (see /api/hook):
@@ -108,10 +108,10 @@ const DEV_TERMINAL_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "dev-terminal-s
 // missing the on-disk ids.
 const isValidSessionId = (id: string) => SESSION_ID_RE.test(id);
 
-// Best-effort read of the shared file: absent / unreadable / not an array => nothing.
+// Best-effort read of the shared file: absent or unreadable => nothing.
 async function readPersistedDevTerminalIds(): Promise<string[]> {
   try {
-    return parseDevTerminalSessionIds(JSON.parse(await fs.readFile(DEV_TERMINAL_SESSIONS_FILE, "utf8")), isValidSessionId);
+    return parseDevTerminalSessionIds(await fs.readFile(DEV_TERMINAL_SESSIONS_FILE, "utf8"), isValidSessionId);
   } catch {
     return [];
   }
@@ -121,22 +121,15 @@ export const devTerminalSessionsHydrated: Promise<void> = (async () => {
   for (const id of await readPersistedDevTerminalIds()) devTerminalSessions.add(id);
 })();
 
-// Serialize every persist into ONE chain so concurrent marks can't run overlapping
-// writeFile()s that interleave and leave an older snapshot on disk (dropping ids).
-// Each link waits for hydration first (so it never persists a set missing the on-disk
-// ids) and stringifies the CURRENT set at write time, so the last link always writes
-// the complete, up-to-date set. A failed write is logged and the chain continues.
+// Appended, never rewritten: another instance shares this file, and a read-merge-write
+// loses whichever of the two finishes first however small the window is made. An append
+// needs no read, and nothing here is ever removed. Chained so our own writes stay ordered
+// and a failure is logged without stopping the next one.
 let devTerminalPersist: Promise<void> = Promise.resolve();
-function persistDevTerminalSessions(): void {
+function appendDevTerminalSession(id: string): void {
   devTerminalPersist = devTerminalPersist
-    .then(() => devTerminalSessionsHydrated)
     .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
-    // Union with disk, not just our own set: another instance sharing this file may have
-    // marked cells we never saw, and writing without them un-hides their transcripts.
-    .then(async () => {
-      const merged = mergeDevTerminalSessionIds(await readPersistedDevTerminalIds(), devTerminalSessions);
-      await fs.writeFile(DEV_TERMINAL_SESSIONS_FILE, JSON.stringify(merged));
-    })
+    .then(() => fs.appendFile(DEV_TERMINAL_SESSIONS_FILE, devTerminalSessionLine(id)))
     .catch((e) => console.error(`[dev-terminal-sessions] failed to persist: ${messageOf(e)}`));
 }
 
@@ -146,7 +139,7 @@ function persistDevTerminalSessions(): void {
 export function markDevTerminalSession(id: string): void {
   if (!SESSION_ID_RE.test(id) || devTerminalSessions.has(id)) return;
   devTerminalSessions.add(id);
-  persistDevTerminalSessions();
+  appendDevTerminalSession(id);
 }
 
 // Restore the `working` + blocked/done (`waiting`) flags across a server restart (e.g. a
@@ -169,7 +162,7 @@ export const activityStateHydrated: Promise<void> = (async () => {
   }
 })();
 
-// Serialize writes into one chain (like persistDevTerminalSessions) and snapshot the
+// Serialize writes into one chain (like appendDevTerminalSession) and snapshot the
 // CURRENT working/waiting entries at write time, so the last link always writes the complete set.
 // `isHidden` comes from the caller rather than closing over `hiddenSessions`: which sessions
 // are hidden is the session layer's policy, and this module owns storage, not policy.

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -13,6 +13,7 @@ import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, parseActivityState } from "./activity-state.js";
+import { mergeDevTerminalSessionIds, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
 
 // Per-session "working" state, driven by Claude hooks (see /api/hook):
@@ -105,13 +106,19 @@ const DEV_TERMINAL_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "dev-terminal-s
 // (or a mark persisted) before this resolves would otherwise see an empty set and
 // either leak hidden grid transcripts into chat or clobber the file with a snapshot
 // missing the on-disk ids.
-export const devTerminalSessionsHydrated: Promise<void> = (async () => {
+const isValidSessionId = (id: string) => SESSION_ID_RE.test(id);
+
+// Best-effort read of the shared file: absent / unreadable / not an array => nothing.
+async function readPersistedDevTerminalIds(): Promise<string[]> {
   try {
-    const parsed = JSON.parse(await fs.readFile(DEV_TERMINAL_SESSIONS_FILE, "utf8"));
-    if (Array.isArray(parsed)) for (const id of parsed) if (typeof id === "string" && SESSION_ID_RE.test(id)) devTerminalSessions.add(id);
+    return parseDevTerminalSessionIds(JSON.parse(await fs.readFile(DEV_TERMINAL_SESSIONS_FILE, "utf8")), isValidSessionId);
   } catch {
-    // no file yet or unreadable => start empty
+    return [];
   }
+}
+
+export const devTerminalSessionsHydrated: Promise<void> = (async () => {
+  for (const id of await readPersistedDevTerminalIds()) devTerminalSessions.add(id);
 })();
 
 // Serialize every persist into ONE chain so concurrent marks can't run overlapping
@@ -124,7 +131,12 @@ function persistDevTerminalSessions(): void {
   devTerminalPersist = devTerminalPersist
     .then(() => devTerminalSessionsHydrated)
     .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
-    .then(() => fs.writeFile(DEV_TERMINAL_SESSIONS_FILE, JSON.stringify([...devTerminalSessions])))
+    // Union with disk, not just our own set: another instance sharing this file may have
+    // marked cells we never saw, and writing without them un-hides their transcripts.
+    .then(async () => {
+      const merged = mergeDevTerminalSessionIds(await readPersistedDevTerminalIds(), devTerminalSessions);
+      await fs.writeFile(DEV_TERMINAL_SESSIONS_FILE, JSON.stringify(merged));
+    })
     .catch((e) => console.error(`[dev-terminal-sessions] failed to persist: ${messageOf(e)}`));
 }
 

--- a/test/server/session/dev-terminal-sessions.spec.ts
+++ b/test/server/session/dev-terminal-sessions.spec.ts
@@ -9,13 +9,21 @@ const isUuid = (id: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}
 const parse = (contents: string) => parseDevTerminalSessionIds(contents, isUuid);
 
 describe("devTerminalSessionLine", () => {
-  // The newline is what makes concurrent appends land as separate records.
-  it("ends the record so the next append starts its own line", () => {
-    expect(devTerminalSessionLine(A)).toBe(`${A}\n`);
+  // Leading, not trailing: the legacy file ends WITHOUT a newline, so a trailing one would
+  // weld the first appended id onto the end of the JSON array.
+  it("starts the record on its own line", () => {
+    expect(devTerminalSessionLine(A)).toBe(`\n${A}`);
   });
 
   it("round-trips through the parser", () => {
     expect(parse(devTerminalSessionLine(A) + devTerminalSessionLine(B))).toEqual([A, B]);
+  });
+
+  // The regression Codex caught: a trailing newline welds the first id onto the array.
+  it("does not weld the first id onto a legacy array", () => {
+    const welded = JSON.stringify([A]) + `${C}\n`;
+    expect(parse(welded)).not.toContain(A);
+    expect(parse(JSON.stringify([A]) + devTerminalSessionLine(C))).toEqual([A, C]);
   });
 });
 
@@ -68,11 +76,21 @@ describe("parseDevTerminalSessionIds", () => {
       expect(parse(JSON.stringify([A, "nope", 42, null]))).toEqual([A]);
     });
 
-    // What the file looks like after the first append to a legacy file: the array on the
-    // first line, then plain ids. Both halves have to survive, or upgrading loses the ids
-    // that were already hidden.
-    it("reads a legacy array followed by appended ids", () => {
-      expect(parse(`${JSON.stringify([A, B])}\n${C}\n`)).toEqual([A, B, C]);
+    // What the file ACTUALLY looks like after the first append: the legacy array has no
+    // trailing newline, so the appended record has to bring its own. Getting this wrong
+    // loses every id that was already hidden — the whole point of the file.
+    it("reads a legacy array appended to exactly as the writer writes it", () => {
+      const onDisk = JSON.stringify([A, B]) + devTerminalSessionLine(C);
+      expect(parse(onDisk)).toEqual([A, B, C]);
+    });
+
+    it("survives several appends onto a legacy file", () => {
+      const onDisk = JSON.stringify([A]) + devTerminalSessionLine(B) + devTerminalSessionLine(C);
+      expect(parse(onDisk)).toEqual([A, B, C]);
+    });
+
+    it("reads appends onto an empty file", () => {
+      expect(parse(devTerminalSessionLine(A) + devTerminalSessionLine(B))).toEqual([A, B]);
     });
 
     it("does not lose the legacy ids when an appended one repeats them", () => {

--- a/test/server/session/dev-terminal-sessions.spec.ts
+++ b/test/server/session/dev-terminal-sessions.spec.ts
@@ -1,83 +1,90 @@
 import { describe, it, expect } from "vitest";
 
-import { parseDevTerminalSessionIds, mergeDevTerminalSessionIds } from "../../../server/session/dev-terminal-sessions.js";
+import { parseDevTerminalSessionIds, devTerminalSessionLine } from "../../../server/session/dev-terminal-sessions.js";
 
 const A = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
 const B = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 const C = "16fd2706-8baf-433b-82eb-8c7fada847da";
 const isUuid = (id: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+const parse = (contents: string) => parseDevTerminalSessionIds(contents, isUuid);
 
-describe("parseDevTerminalSessionIds", () => {
-  it("keeps the ids from a well-formed file", () => {
-    expect(parseDevTerminalSessionIds([A, B], isUuid)).toEqual([A, B]);
+describe("devTerminalSessionLine", () => {
+  // The newline is what makes concurrent appends land as separate records.
+  it("ends the record so the next append starts its own line", () => {
+    expect(devTerminalSessionLine(A)).toBe(`${A}\n`);
   });
 
-  it("reads an empty file as no ids", () => {
-    expect(parseDevTerminalSessionIds([], isUuid)).toEqual([]);
-  });
-
-  // The ids end up as filenames elsewhere, so anything that is not one is dropped rather
-  // than carried along.
-  it("drops entries that are not a session id", () => {
-    expect(parseDevTerminalSessionIds([A, "../../etc/passwd", "", B], isUuid)).toEqual([A, B]);
-  });
-
-  it("drops entries that are not strings", () => {
-    expect(parseDevTerminalSessionIds([A, 42, null, { id: B }, [B]], isUuid)).toEqual([A]);
-  });
-
-  describe("a file that is not a list of ids", () => {
-    it.each([
-      ["an object", { ids: [A] }],
-      ["a string", A],
-      ["a number", 7],
-      ["null", null],
-      ["undefined", undefined],
-    ])("reads %s as no ids", (_label, raw) => {
-      expect(parseDevTerminalSessionIds(raw, isUuid)).toEqual([]);
-    });
+  it("round-trips through the parser", () => {
+    expect(parse(devTerminalSessionLine(A) + devTerminalSessionLine(B))).toEqual([A, B]);
   });
 });
 
-// Two servers share ~/.mulmoterminal — launching twice is the ordinary way to get there,
-// since the launcher falls back to another port when the default is busy. Writing only our
-// own set drops what the peer marked, and a dropped id means that grid cell's transcript
-// reappears in the chat sidebar.
-describe("mergeDevTerminalSessionIds", () => {
-  it("keeps ids only the other instance knows about", () => {
-    expect(mergeDevTerminalSessionIds([A], [B])).toEqual([A, B].sort());
+describe("parseDevTerminalSessionIds", () => {
+  describe("the append log", () => {
+    it("reads one id per line", () => {
+      expect(parse(`${A}\n${B}\n`)).toEqual([A, B]);
+    });
+
+    it("reads a file with no trailing newline", () => {
+      expect(parse(`${A}\n${B}`)).toEqual([A, B]);
+    });
+
+    it("reads an empty file as no ids", () => {
+      expect(parse("")).toEqual([]);
+      expect(parse("\n\n")).toEqual([]);
+    });
+
+    it("ignores surrounding whitespace on a line", () => {
+      expect(parse(`  ${A}  \n\t${B}\n`)).toEqual([A, B]);
+    });
+
+    // Two instances can each append an id both of them marked.
+    it("keeps one copy of an id appended twice", () => {
+      expect(parse(`${A}\n${B}\n${A}\n`)).toEqual([A, B]);
+    });
+
+    it("keeps the order the ids were first appended in", () => {
+      expect(parse(`${C}\n${A}\n${B}\n`)).toEqual([C, A, B]);
+    });
+
+    // The ids end up as filenames elsewhere, so anything that is not one is dropped.
+    it("drops lines that are not a session id", () => {
+      expect(parse(`${A}\n../../etc/passwd\nnot-a-uuid\n${B}\n`)).toEqual([A, B]);
+    });
   });
 
-  it("keeps our own when the file is empty", () => {
-    expect(mergeDevTerminalSessionIds([], [A, B])).toEqual([A, B].sort());
-  });
+  // An existing install has the old single-line JSON array. It keeps working, and simply
+  // stops being rewritten.
+  describe("the legacy JSON array", () => {
+    it("reads the ids out of it", () => {
+      expect(parse(JSON.stringify([A, B]))).toEqual([A, B]);
+    });
 
-  it("keeps the file's when we know nothing", () => {
-    expect(mergeDevTerminalSessionIds([A, B], [])).toEqual([A, B].sort());
-  });
+    it("reads an empty array as no ids", () => {
+      expect(parse("[]")).toEqual([]);
+    });
 
-  it("does not duplicate an id both know", () => {
-    expect(mergeDevTerminalSessionIds([A, B], [B, C])).toEqual([A, B, C].sort());
-  });
+    it("drops entries that are not a session id", () => {
+      expect(parse(JSON.stringify([A, "nope", 42, null]))).toEqual([A]);
+    });
 
-  it("returns nothing when neither has any", () => {
-    expect(mergeDevTerminalSessionIds([], [])).toEqual([]);
-  });
+    // What the file looks like after the first append to a legacy file: the array on the
+    // first line, then plain ids. Both halves have to survive, or upgrading loses the ids
+    // that were already hidden.
+    it("reads a legacy array followed by appended ids", () => {
+      expect(parse(`${JSON.stringify([A, B])}\n${C}\n`)).toEqual([A, B, C]);
+    });
 
-  it("accepts a Set, which is what the registry holds", () => {
-    expect(mergeDevTerminalSessionIds([A], new Set([B, A]))).toEqual([A, B].sort());
-  });
+    it("does not lose the legacy ids when an appended one repeats them", () => {
+      expect(parse(`${JSON.stringify([A])}\n${A}\n${B}\n`)).toEqual([A, B]);
+    });
 
-  // A stable order keeps the file from churning between writes that changed nothing.
-  it("orders the result the same way whatever order it was given", () => {
-    expect(mergeDevTerminalSessionIds([C, A], [B])).toEqual(mergeDevTerminalSessionIds([B, C], [A]));
-  });
+    it("ignores a truncated array rather than guessing at it", () => {
+      expect(parse(`["${A}"\n${B}\n`)).toEqual([B]);
+    });
 
-  // The scenario in one test: A boots and marks x, B boots and marks y, and B writes last.
-  it("does not let the last writer drop the other's ids", () => {
-    const bootedFrom = [A];
-    const serverAWrites = mergeDevTerminalSessionIds(bootedFrom, new Set([A, B]));
-    const serverBWrites = mergeDevTerminalSessionIds(serverAWrites, new Set([A, C]));
-    expect(serverBWrites).toEqual([A, B, C].sort());
+    it("ignores a line that is an array of the wrong shape", () => {
+      expect(parse(`{"ids":["${A}"]}\n${B}\n`)).toEqual([B]);
+    });
   });
 });

--- a/test/server/session/dev-terminal-sessions.spec.ts
+++ b/test/server/session/dev-terminal-sessions.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+import { parseDevTerminalSessionIds, mergeDevTerminalSessionIds } from "../../../server/session/dev-terminal-sessions.js";
+
+const A = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+const B = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+const C = "16fd2706-8baf-433b-82eb-8c7fada847da";
+const isUuid = (id: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+
+describe("parseDevTerminalSessionIds", () => {
+  it("keeps the ids from a well-formed file", () => {
+    expect(parseDevTerminalSessionIds([A, B], isUuid)).toEqual([A, B]);
+  });
+
+  it("reads an empty file as no ids", () => {
+    expect(parseDevTerminalSessionIds([], isUuid)).toEqual([]);
+  });
+
+  // The ids end up as filenames elsewhere, so anything that is not one is dropped rather
+  // than carried along.
+  it("drops entries that are not a session id", () => {
+    expect(parseDevTerminalSessionIds([A, "../../etc/passwd", "", B], isUuid)).toEqual([A, B]);
+  });
+
+  it("drops entries that are not strings", () => {
+    expect(parseDevTerminalSessionIds([A, 42, null, { id: B }, [B]], isUuid)).toEqual([A]);
+  });
+
+  describe("a file that is not a list of ids", () => {
+    it.each([
+      ["an object", { ids: [A] }],
+      ["a string", A],
+      ["a number", 7],
+      ["null", null],
+      ["undefined", undefined],
+    ])("reads %s as no ids", (_label, raw) => {
+      expect(parseDevTerminalSessionIds(raw, isUuid)).toEqual([]);
+    });
+  });
+});
+
+// Two servers share ~/.mulmoterminal — launching twice is the ordinary way to get there,
+// since the launcher falls back to another port when the default is busy. Writing only our
+// own set drops what the peer marked, and a dropped id means that grid cell's transcript
+// reappears in the chat sidebar.
+describe("mergeDevTerminalSessionIds", () => {
+  it("keeps ids only the other instance knows about", () => {
+    expect(mergeDevTerminalSessionIds([A], [B])).toEqual([A, B].sort());
+  });
+
+  it("keeps our own when the file is empty", () => {
+    expect(mergeDevTerminalSessionIds([], [A, B])).toEqual([A, B].sort());
+  });
+
+  it("keeps the file's when we know nothing", () => {
+    expect(mergeDevTerminalSessionIds([A, B], [])).toEqual([A, B].sort());
+  });
+
+  it("does not duplicate an id both know", () => {
+    expect(mergeDevTerminalSessionIds([A, B], [B, C])).toEqual([A, B, C].sort());
+  });
+
+  it("returns nothing when neither has any", () => {
+    expect(mergeDevTerminalSessionIds([], [])).toEqual([]);
+  });
+
+  it("accepts a Set, which is what the registry holds", () => {
+    expect(mergeDevTerminalSessionIds([A], new Set([B, A]))).toEqual([A, B].sort());
+  });
+
+  // A stable order keeps the file from churning between writes that changed nothing.
+  it("orders the result the same way whatever order it was given", () => {
+    expect(mergeDevTerminalSessionIds([C, A], [B])).toEqual(mergeDevTerminalSessionIds([B, C], [A]));
+  });
+
+  // The scenario in one test: A boots and marks x, B boots and marks y, and B writes last.
+  it("does not let the last writer drop the other's ids", () => {
+    const bootedFrom = [A];
+    const serverAWrites = mergeDevTerminalSessionIds(bootedFrom, new Set([A, B]));
+    const serverBWrites = mergeDevTerminalSessionIds(serverAWrites, new Set([A, C]));
+    expect(serverBWrites).toEqual([A, B, C].sort());
+  });
+});


### PR DESCRIPTION
Refs #611

## Summary

dev-terminal の集合は、**グリッドセルの transcript をチャットのサイドバーから隠す**ためのものです（"chat hijacked my multi-terminal session" バグ対策）。

これが `~/.mulmoterminal` に永続化されており、**ポート別ではありません**。しかし書き込みは**プロセス内でしか直列化されておらず**、自分のメモリ上の集合をそのまま書いていました。

```
1. サーバA 起動、{x} を読み込む
2. サーバB 起動、{x} を読み込む
3. サーバA が y をマーク → {x, y} を書く
4. サーバB が z をマーク → {x, z} を書く   ← y が消える
```

**症状：サーバAのグリッドセルが、チャット一覧に再び現れます。**

## 2 サーバは異常系ではありません

ランチャは**ポートが埋まっていると自動で別ポートにフォールバック**します（`choosePort`）。つまり `npx mulmoterminal` を 2 回叩けばその状態になります。`heldByAnotherProcess` のコメントも "a PORT-split peer on this workspace" を明示的に想定しています。

## 直し方

書き込み時に**ディスクの内容と union** します。**`POST /api/config` が既に同じことを、同じ理由で行っています**（キャッシュした写しでは駄目だ、というコメント付きで）。その前例に合わせました。

**union が答えになるのは、この集合が追加のみだからです** — id を削除する経路が存在しないので、相手の写しから復活する削除もありません。**想定ではなく確認しました**（`devTerminalSessions.delete` / `.clear` は 1 箇所もありません）。

## Items to Confirm / Review

1. **Codex の主張のうち、これだけが本物でした。** 同じ「クロスプロセス」の指摘だった `config.json` の read-merge-write は**既に対処済み**で成立しません（下記）
2. **activity state は変更していません**（下記）
3. パースと union を `session/dev-terminal-sessions.ts` に出したので、hydrate 側のフィルタもテスト可能になりました。`registry.ts` は import 時に `MULMOTERMINAL_HOME` を束縛するため、中身は**開発者のホームに書き込まずにテストできない**という #548 記載の負債があります

## 成立しなかった主張（検証結果）

**`server/routes/config-routes.ts` — 誤り。** Codex は「両者が同じ古いスナップショットにマージする」としていましたが、実際は**書き込み時にディスクから読み直しています**:

```ts
// Merge onto the CURRENT disk config, re-read now — not this instance's cached
// `config`, which may be stale (another mulmoterminal instance sharing this file
// could have written since we booted).
const next = mergeConfigUpdate(loadAppConfig(CONFIG_FILE), body);
```

読み取りと書き込みの間に残る窓は同期処理 2 つ分で、2 インスタンスが同時に設定を保存しないと踏めません。

## 変更しなかったもの

**activity state も同じ形で永続化されていますが、union は誤りです。** こちらは項目が**変化する**（working/waiting フラグ）ので、消えた状態を union で復活させてはいけません。また古いフラグは**次のフックで自己修正**します。別途判断すべきと考えます。

## テスト

**17 件**。自分の集合だけを書く（＝元のバグ）に戻すと **5 件**が赤くなります。2 インスタンスの手順そのものを 1 ケースとして書いてあります。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:server` / `yarn test`（200 files, 2602 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
