### PR TITLE
refactor: make the splitter's geometry and keys testable (#598 Tier 3)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,6 +26,7 @@ import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
 import { useUnloadGuard, reportActiveTerminals } from "./composables/useUnloadGuard";
 import { browserLocale } from "./utils/browserLocale";
+import { clampTerminalWidth, maxTerminalWidth, MIN_TERMINAL, splitterKeyWidth } from "./components/splitterWidth";
 
 // View mode is now the URL: the multi-terminal grid is /terminals, everything else
 // (chat + the collection/accounting overlays) lives under the single-view shell.
@@ -87,17 +88,16 @@ useFaviconState(sessions);
 // and the GUI panel; the GUI panel absorbs whatever is left. Persisted across
 // reloads. The terminal's own ResizeObserver refits xterm's cols/rows as this
 // changes, so a drag live-resizes the PTY.
-const MIN_TERMINAL = 320;
-const MIN_GUI = 360;
+
 const terminalWidth = ref<number>(Number(localStorage.getItem("terminal_width")) || 560);
 
 // Track the viewport so the splitter's max (and aria-valuemax) stays correct and
 // the saved width re-clamps when the window shrinks.
 const viewportWidth = ref(window.innerWidth);
-const maxTerminal = computed(() => Math.max(MIN_TERMINAL, viewportWidth.value - MIN_GUI));
+const maxTerminal = computed(() => maxTerminalWidth(viewportWidth.value));
 
 function clampWidth(w: number): number {
-  return Math.max(MIN_TERMINAL, Math.min(w, maxTerminal.value));
+  return clampTerminalWidth(w, viewportWidth.value);
 }
 
 function persistWidth() {
@@ -133,12 +133,11 @@ function startDrag(e: MouseEvent) {
 // Keyboard resize for the separator (arrows nudge, Home/End jump to the limits)
 // so the splitter is operable without a mouse.
 function onSplitterKey(e: KeyboardEvent) {
-  const STEP = 16;
-  if (e.key === "ArrowLeft") terminalWidth.value = clampWidth(terminalWidth.value - STEP);
-  else if (e.key === "ArrowRight") terminalWidth.value = clampWidth(terminalWidth.value + STEP);
-  else if (e.key === "Home") terminalWidth.value = MIN_TERMINAL;
-  else if (e.key === "End") terminalWidth.value = maxTerminal.value;
-  else return;
+  const next = splitterKeyWidth(e.key, terminalWidth.value, viewportWidth.value);
+  // Null means the key is not ours — returning BEFORE preventDefault is what keeps the
+  // separator from swallowing Tab and Escape while it has focus.
+  if (next === null) return;
+  terminalWidth.value = next;
   e.preventDefault();
   persistWidth();
 }

--- a/src/components/splitterWidth.ts
+++ b/src/components/splitterWidth.ts
@@ -1,0 +1,31 @@
+// The terminal/GUI splitter's geometry rules.
+//
+// Both sides have a floor, and the window can be narrower than the two floors together —
+// that is the case worth being careful about. When it is, the terminal's floor wins and the
+// GUI gives up its own, because a terminal below its minimum reflows xterm into garbage
+// while a squeezed GUI panel is merely cramped.
+
+// Below this xterm's reflow stops being usable.
+export const MIN_TERMINAL = 320;
+// Enough of the GUI panel to still be worth showing.
+export const MIN_GUI = 360;
+// One arrow-key nudge.
+export const SPLITTER_STEP = 16;
+
+export function maxTerminalWidth(viewport: number): number {
+  return Math.max(MIN_TERMINAL, viewport - MIN_GUI);
+}
+
+export function clampTerminalWidth(width: number, viewport: number): number {
+  return Math.max(MIN_TERMINAL, Math.min(width, maxTerminalWidth(viewport)));
+}
+
+// The width a key produces, or null when the key is not ours — the caller must NOT
+// preventDefault on null, or the separator would swallow Tab and Escape while focused.
+export function splitterKeyWidth(key: string, current: number, viewport: number): number | null {
+  if (key === "ArrowLeft") return clampTerminalWidth(current - SPLITTER_STEP, viewport);
+  if (key === "ArrowRight") return clampTerminalWidth(current + SPLITTER_STEP, viewport);
+  if (key === "Home") return MIN_TERMINAL;
+  if (key === "End") return maxTerminalWidth(viewport);
+  return null;
+}

--- a/test/src/components/splitterWidth.spec.ts
+++ b/test/src/components/splitterWidth.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+
+import { clampTerminalWidth, maxTerminalWidth, MIN_GUI, MIN_TERMINAL, splitterKeyWidth, SPLITTER_STEP } from "../../../src/components/splitterWidth";
+
+const WIDE = 1600;
+
+describe("maxTerminalWidth", () => {
+  it("leaves room for the GUI panel", () => {
+    expect(maxTerminalWidth(WIDE)).toBe(WIDE - MIN_GUI);
+  });
+
+  // The case worth being careful about: a window narrower than both floors together. The
+  // terminal's floor wins, because a terminal below its minimum reflows xterm into garbage
+  // while a squeezed GUI panel is merely cramped.
+  it("never returns less than the terminal's floor, however narrow the window", () => {
+    expect(maxTerminalWidth(400)).toBe(MIN_TERMINAL);
+    expect(maxTerminalWidth(0)).toBe(MIN_TERMINAL);
+  });
+});
+
+describe("clampTerminalWidth", () => {
+  it("leaves a width that already fits alone", () => {
+    expect(clampTerminalWidth(560, WIDE)).toBe(560);
+  });
+
+  it("pulls a too-small width up to the floor", () => {
+    expect(clampTerminalWidth(100, WIDE)).toBe(MIN_TERMINAL);
+  });
+
+  it("pulls a too-large width down to the maximum", () => {
+    expect(clampTerminalWidth(WIDE, WIDE)).toBe(WIDE - MIN_GUI);
+  });
+
+  // A saved width from a bigger screen, re-opened on a small one.
+  it("re-clamps a stored width when the window is smaller than it was", () => {
+    expect(clampTerminalWidth(1200, 700)).toBe(700 - MIN_GUI);
+  });
+
+  it("does not invert on a window narrower than both floors", () => {
+    expect(clampTerminalWidth(500, 400)).toBe(MIN_TERMINAL);
+  });
+});
+
+describe("splitterKeyWidth", () => {
+  it("nudges left and right by one step", () => {
+    expect(splitterKeyWidth("ArrowLeft", 560, WIDE)).toBe(560 - SPLITTER_STEP);
+    expect(splitterKeyWidth("ArrowRight", 560, WIDE)).toBe(560 + SPLITTER_STEP);
+  });
+
+  it("jumps to the limits", () => {
+    expect(splitterKeyWidth("Home", 560, WIDE)).toBe(MIN_TERMINAL);
+    expect(splitterKeyWidth("End", 560, WIDE)).toBe(WIDE - MIN_GUI);
+  });
+
+  it("clamps a nudge at the edges rather than walking past them", () => {
+    expect(splitterKeyWidth("ArrowLeft", MIN_TERMINAL, WIDE)).toBe(MIN_TERMINAL);
+    expect(splitterKeyWidth("ArrowRight", WIDE - MIN_GUI, WIDE)).toBe(WIDE - MIN_GUI);
+  });
+
+  // Null is what tells the caller NOT to preventDefault. Answer a width here and the
+  // separator swallows Tab and Escape whenever it has focus.
+  it.each([["Tab"], ["Escape"], ["Enter"], [" "], ["ArrowUp"], ["ArrowDown"], ["a"], ["arrowleft"]])("does not claim %j", (key) => {
+    expect(splitterKeyWidth(key, 560, WIDE)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

The terminal/GUI splitter's clamp and keyboard map move into `src/components/splitterWidth.ts`. They were bound to `window.innerWidth`, `localStorage`, a mousemove drag and a keydown handler inside a 400-line root component with no spec — neither had ever been exercised.

**The clamp's interesting case** is a window narrower than both floors together. The terminal's floor wins there, because a terminal below its minimum reflows xterm into garbage while a squeezed GUI panel is merely cramped. Nothing said so, and nothing checked that the expression does not invert.

**The key map's load-bearing part is what it does *not* claim.** Returning null is what keeps the caller from calling `preventDefault`, and a separator that swallows Tab and Escape while focused is a keyboard trap. Making unknown keys return a width turns **8 tests red**.

## Items to Confirm / Review

1. **Behaviour unchanged**, including the constants — `MIN_TERMINAL` 320, `MIN_GUI` 360. I wrote 280 for `MIN_GUI` from memory first and checked the source before committing; worth a glance that they read correctly now that they live elsewhere.
2. The early return for a foreign key is now explicit in `App.vue` with the reason on it, rather than being the `else return` at the bottom of an if-chain.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `201 files / 2629 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)