### PR TITLE
refactor: make the mic button's state machine testable (#598 Tier 3)

### DIFF
--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -12,6 +12,7 @@
 import { onScopeDispose, ref, type Ref } from "vue";
 import { createVoiceCapture, localeToWhisperLanguage, type VoiceCaptureTransport } from "@mulmoclaude/core/whisper/client";
 import { browserLocale } from "../utils/browserLocale";
+import { modelReadiness, voiceAction } from "./voiceAction";
 
 interface VoiceModelStatusResponse {
   capable: boolean;
@@ -68,8 +69,9 @@ function createVoiceTransport(capable: Ref<boolean>, downloading: Ref<boolean>):
     async getStatus() {
       const status = await fetchModelStatus();
       capable.value = status?.capable ?? false;
-      downloading.value = status?.model?.state === "downloading";
-      return { ready: status?.capable === true && status?.model?.state === "ready", downloading: downloading.value };
+      const readiness = modelReadiness(status);
+      downloading.value = readiness.downloading;
+      return readiness;
     },
   };
 }
@@ -114,16 +116,14 @@ export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
   }
 
   async function toggle(): Promise<void> {
-    if (listening.value) {
-      capture.stop();
-      return;
-    }
-    if (available.value) {
+    const action = voiceAction({ listening: listening.value, available: available.value, downloading: downloading.value });
+    if (action === "stop") return capture.stop();
+    if (action === "start") {
       error.value = null;
       await capture.start();
       return;
     }
-    if (!downloading.value) await requestDownload();
+    if (action === "download") await requestDownload();
   }
 
   onScopeDispose(() => capture.dispose());

--- a/src/composables/voiceAction.ts
+++ b/src/composables/voiceAction.ts
@@ -1,0 +1,34 @@
+// What pressing the mic button should do, given what the voice input is currently doing.
+//
+// One button with four possible meanings, and the guard that matters is the last one: an
+// impatient user pressing a button that already looks like it is doing nothing must not
+// re-POST the model download on every click.
+
+export interface VoiceState {
+  // A capture is running — the press ends it.
+  listening: boolean;
+  // The model is present and the platform supports it.
+  available: boolean;
+  // A download is already running.
+  downloading: boolean;
+}
+
+export type VoiceAction = "stop" | "start" | "download" | "none";
+
+export function voiceAction({ listening, available, downloading }: VoiceState): VoiceAction {
+  if (listening) return "stop";
+  if (available) return "start";
+  return downloading ? "none" : "download";
+}
+
+export interface VoiceModelStatus {
+  capable?: boolean;
+  model?: { state?: string };
+}
+
+// Ready means BOTH halves: a platform that can run it and a model that finished downloading.
+// Optional chaining throughout so a malformed status degrades to "not ready" rather than
+// throwing inside the poll that produced it.
+export function modelReadiness(status: VoiceModelStatus | null | undefined): { ready: boolean; downloading: boolean } {
+  return { ready: status?.capable === true && status?.model?.state === "ready", downloading: status?.model?.state === "downloading" };
+}

--- a/test/src/composables/voiceAction.spec.ts
+++ b/test/src/composables/voiceAction.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { modelReadiness, voiceAction } from "../../../src/composables/voiceAction";
+
+const state = (over: Partial<Parameters<typeof voiceAction>[0]> = {}) => ({ listening: false, available: false, downloading: false, ...over });
+
+describe("voiceAction", () => {
+  it("stops a capture that is running", () => {
+    expect(voiceAction(state({ listening: true }))).toBe("stop");
+  });
+
+  // Stopping outranks everything: a press while listening must never start a download.
+  it("stops even when a download is also in progress", () => {
+    expect(voiceAction(state({ listening: true, downloading: true, available: true }))).toBe("stop");
+  });
+
+  it("starts a capture when the model is ready", () => {
+    expect(voiceAction(state({ available: true }))).toBe("start");
+  });
+
+  it("offers to download when there is no model yet", () => {
+    expect(voiceAction(state())).toBe("download");
+  });
+
+  // The guard that matters: the button looks like it is doing nothing while a download runs,
+  // so an impatient user clicks it repeatedly. Each click must not re-POST the download.
+  it("does nothing while a download is already running", () => {
+    expect(voiceAction(state({ downloading: true }))).toBe("none");
+  });
+
+  it("prefers starting over downloading once the model has landed", () => {
+    expect(voiceAction(state({ available: true, downloading: true }))).toBe("start");
+  });
+});
+
+describe("modelReadiness", () => {
+  it("is ready only when the platform can run it AND the model finished", () => {
+    expect(modelReadiness({ capable: true, model: { state: "ready" } })).toEqual({ ready: true, downloading: false });
+  });
+
+  it("is not ready on a platform that cannot run it, however ready the model", () => {
+    expect(modelReadiness({ capable: false, model: { state: "ready" } }).ready).toBe(false);
+  });
+
+  it("is not ready while the model is still downloading", () => {
+    expect(modelReadiness({ capable: true, model: { state: "downloading" } })).toEqual({ ready: false, downloading: true });
+  });
+
+  // A status blip must degrade to "not ready" rather than throwing inside the poll that
+  // produced it — that is what the optional chaining is for.
+  it.each([[null], [undefined], [{}], [{ capable: true }], [{ model: {} }], [{ capable: "yes" }]])("degrades to not-ready for %j", (status) => {
+    expect(modelReadiness(status as never)).toEqual({ ready: false, downloading: false });
+  });
+});


### PR DESCRIPTION
## Summary

One button with four meanings — stop / start / download / nothing — closed over five refs and a MediaRecorder-backed capture, in a composable with **no spec of any kind**.

**The guard worth testing is the last branch.** While a download runs the button looks like it is doing nothing, so an impatient user clicks it repeatedly; without `!downloading`, each click **re-POSTs the model download**. Removing it turns a test red.

`modelReadiness` is the other half: ready means **both** a platform that can run it and a model that finished, and a malformed status must degrade to "not ready" rather than throwing inside the poll that produced it. That optional chaining now has cases behind it.

## Items to Confirm / Review

- Behaviour unchanged. The precedence is pinned explicitly, including that **stopping outranks everything** (a press while listening must never start a download) and that starting wins over downloading once the model has landed.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `202 files / 2644 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)