### PR TITLE
refactor: make a cell's activity push and header text testable (#598 Tier 3)

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -8,6 +8,7 @@ import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import { badgeStyleFor } from "./dirBadge";
 import { unsavedWork } from "./unsavedWork";
 import { relativeTime as relativeTimeFrom, usageBadge } from "./cellDisplay";
+import { applyActivityPush, cellHeaderText } from "./cellActivity";
 import { preferredLaunchDir, shouldSyncLaunchDir } from "./launchDir";
 import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 import GitBranchChip from "./GitBranchChip.vue";
@@ -200,13 +201,15 @@ interface ActivityMsg {
 const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" && d !== null && "id" in d;
 
 function applyActivity(d: ActivityMsg) {
-  working.value = d.working ?? false;
-  waiting.value = d.waiting ?? false;
-  if (d.event !== undefined) activityEvent.value = d.event;
-  // Apply lastPrompt/aiTitle whenever the field is present — including an explicit null,
-  // so a cleared/new session doesn't keep showing the previous prompt or title.
-  if (d.lastPrompt !== undefined) lastPrompt.value = d.lastPrompt;
-  if (d.aiTitle !== undefined) aiTitle.value = d.aiTitle;
+  const next = applyActivityPush(
+    { working: working.value, waiting: waiting.value, event: activityEvent.value, lastPrompt: lastPrompt.value, aiTitle: aiTitle.value },
+    d,
+  );
+  working.value = next.working;
+  waiting.value = next.waiting;
+  activityEvent.value = next.event;
+  lastPrompt.value = next.lastPrompt;
+  aiTitle.value = next.aiTitle;
 }
 
 async function loadInitial(id: string) {
@@ -820,7 +823,7 @@ const dotStatusClass = computed(() => DOT_STATUS[status.value]);
 const statusLabel = computed(() => STATUS_LABEL[status.value]);
 watch(status, (s) => emit("status", s), { immediate: true });
 
-const headerText = computed(() => aiTitle.value || lastPrompt.value || (sessionId.value ? sessionId.value.slice(0, 8) : "starting…"));
+const headerText = computed(() => cellHeaderText(aiTitle.value, lastPrompt.value, sessionId.value));
 
 // Per-cell token usage badge: ⇡ total input (fresh + cache) · ⇣ output generated.
 const usageView = computed(() => usageBadge(usage.value));

--- a/src/components/cellActivity.ts
+++ b/src/components/cellActivity.ts
@@ -1,0 +1,43 @@
+// How a live activity push updates what a grid cell shows, and what the header says.
+//
+// Two different treatments of "absent", and the difference is the whole rule:
+//
+//   working / waiting — absent means FALSE. A push that omits them is saying the session is
+//   not doing that; defaulting to the previous value would leave a finished session pulsing.
+//
+//   lastPrompt / aiTitle — absent means "no news, keep what is shown", but an explicit NULL
+//   means "there is none now". Collapse the two and a cleared or restarted session keeps
+//   displaying the prompt and title from the conversation the user just ended.
+
+export interface ActivityPush {
+  working?: boolean;
+  waiting?: boolean;
+  event?: string | null;
+  lastPrompt?: string | null;
+  aiTitle?: string | null;
+}
+
+export interface CellActivityState {
+  working: boolean;
+  waiting: boolean;
+  event: string | null;
+  lastPrompt: string | null;
+  aiTitle: string | null;
+}
+
+export function applyActivityPush(previous: CellActivityState, push: ActivityPush): CellActivityState {
+  return {
+    working: push.working ?? false,
+    waiting: push.waiting ?? false,
+    event: push.event !== undefined ? push.event : previous.event,
+    lastPrompt: push.lastPrompt !== undefined ? push.lastPrompt : previous.lastPrompt,
+    aiTitle: push.aiTitle !== undefined ? push.aiTitle : previous.aiTitle,
+  };
+}
+
+// What the cell header shows for a session: our summary, else the last prompt, else enough
+// of the id to tell two cells apart, else a session that has not reported anything yet.
+// `||` rather than `??` on purpose — an empty title or prompt is nothing to show, not a value.
+export function cellHeaderText(aiTitle: string | null, lastPrompt: string | null, sessionId: string | null): string {
+  return aiTitle || lastPrompt || (sessionId ? sessionId.slice(0, 8) : "starting…");
+}

--- a/test/src/components/cellActivity.spec.ts
+++ b/test/src/components/cellActivity.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+
+import { applyActivityPush, cellHeaderText, type CellActivityState } from "../../../src/components/cellActivity";
+
+const shown: CellActivityState = { working: true, waiting: false, event: "Stop", lastPrompt: "fix the login bug", aiTitle: "Login fix" };
+
+describe("applyActivityPush", () => {
+  it("takes the flags the push carries", () => {
+    expect(applyActivityPush(shown, { working: false, waiting: true })).toMatchObject({ working: false, waiting: true });
+  });
+
+  // Absent means FALSE for the flags: a push that omits them is saying the session is not
+  // doing that. Keep the previous value and a finished session goes on pulsing.
+  it("treats an omitted flag as not-doing-that, not as no-news", () => {
+    expect(applyActivityPush(shown, {})).toMatchObject({ working: false, waiting: false });
+  });
+
+  // The opposite for the text: absent means no news…
+  it("keeps the prompt and title a push says nothing about", () => {
+    expect(applyActivityPush(shown, {})).toMatchObject({ lastPrompt: "fix the login bug", aiTitle: "Login fix" });
+  });
+
+  // …and an explicit null means there is none now. Collapse the two and a cleared or
+  // restarted session keeps displaying the conversation the user just ended.
+  it("clears the prompt and title on an explicit null", () => {
+    expect(applyActivityPush(shown, { lastPrompt: null, aiTitle: null })).toMatchObject({ lastPrompt: null, aiTitle: null });
+  });
+
+  it("clears one without disturbing the other", () => {
+    expect(applyActivityPush(shown, { aiTitle: null })).toMatchObject({ lastPrompt: "fix the login bug", aiTitle: null });
+  });
+
+  it("keeps the event when the push omits it, and clears it on an explicit null", () => {
+    expect(applyActivityPush(shown, {}).event).toBe("Stop");
+    expect(applyActivityPush(shown, { event: null }).event).toBeNull();
+  });
+
+  it("does not mutate the state it was given", () => {
+    applyActivityPush(shown, { working: false, lastPrompt: null });
+    expect(shown).toEqual({ working: true, waiting: false, event: "Stop", lastPrompt: "fix the login bug", aiTitle: "Login fix" });
+  });
+});
+
+describe("cellHeaderText", () => {
+  it("prefers our summary", () => {
+    expect(cellHeaderText("Login fix", "fix the login bug", "abcdef12-3456")).toBe("Login fix");
+  });
+
+  it("falls back to the last prompt", () => {
+    expect(cellHeaderText(null, "fix the login bug", "abcdef12-3456")).toBe("fix the login bug");
+  });
+
+  // Enough of the id to tell two untitled cells apart.
+  it("falls back to a short session id", () => {
+    expect(cellHeaderText(null, null, "abcdef12-3456")).toBe("abcdef12");
+  });
+
+  it("says a session has not reported anything yet", () => {
+    expect(cellHeaderText(null, null, null)).toBe("starting…");
+  });
+
+  // An empty title is nothing to show, not a value — `||`, not `??`.
+  it("skips an empty title and an empty prompt", () => {
+    expect(cellHeaderText("", "fix the login bug", "abcdef12")).toBe("fix the login bug");
+    expect(cellHeaderText("", "", "abcdef12")).toBe("abcdef12");
+  });
+});


### PR DESCRIPTION
## Summary

`applyActivity` held **two different treatments of "absent"** in one handler, and the difference *is* the rule:

| Fields | Absent means | If collapsed |
|---|---|---|
| `working` / `waiting` | **false** — the push is saying the session is not doing that | A finished session goes on **pulsing** |
| `lastPrompt` / `aiTitle` | **no news, keep what is shown** — while an explicit `null` means "there is none now" | A cleared or restarted session keeps displaying **the conversation the user just ended** |

`?? previous` is the obvious tidy-up and is wrong for the second row. This is the client half of the same sentinel contract the server side pins in `session-detail-view.ts`.

Both were reachable only by mounting the cell and pushing through pub/sub. Confusing null with absent, and defaulting a flag to its previous value, turn **2 tests red**.

`cellHeaderText` rides along: title → prompt → enough of the id to tell two untitled cells apart → "starting…". `||` not `??`, because an empty title is nothing to show.

## Items to Confirm / Review

- Behaviour unchanged; the handler now assembles one object and assigns the refs from it, so the two policies are visible side by side instead of spread over five statements.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `203 files / 2656 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)