### PR TITLE
refactor: the last of the grid's display rules (#598 Tier 3)

### DIFF
--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -24,6 +24,7 @@ import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import { handoffTargets, pullLastTurn, type HandoffTarget } from "../composables/useHandoff";
 import { runOneExchange, liveCrossTalkDeps } from "../composables/useCrossTalk";
 import { outcomeMessage } from "../composables/exchangeRules";
+import { worktreeFailureMessage } from "./cellChromeRules";
 
 // How long a handoff failure stays on the cell before it clears itself.
 const ASK_MSG_MS = 4000;
@@ -888,15 +889,6 @@ function commitViaClaude() {
   const delivered = termRef.value?.submitText(COMMIT_PROMPT);
   prMsg.value = delivered ? "Asked Claude to commit…" : "Couldn't reach the session";
 }
-const REASON_MSG: Record<string, string> = {
-  "not-worktree": "Not a worktree",
-  "no-branch": "No branch to push",
-  "no-remote": "No git remote (origin) configured",
-  "no-github": "Not a GitHub repo — push succeeded; open the PR manually",
-  "push-failed": "Push failed",
-  failed: "Failed",
-};
-const reasonMsg = (reason?: string) => REASON_MSG[reason ?? ""] ?? "Failed";
 
 async function worktreeAction(endpoint: "push" | "pr"): Promise<Record<string, unknown> | null> {
   if (!cwd.value || prBusy.value) return null;
@@ -923,7 +915,7 @@ async function worktreeAction(endpoint: "push" | "pr"): Promise<Record<string, u
 
 async function pushBranch() {
   const data = await worktreeAction("push");
-  if (data) prMsg.value = data.ok ? `Pushed ${data.branch}` : reasonMsg(data.reason as string);
+  if (data) prMsg.value = data.ok ? `Pushed ${data.branch}` : worktreeFailureMessage(data.reason as string);
 }
 
 async function openPR() {
@@ -933,7 +925,7 @@ async function openPR() {
     window.open(data.url, "_blank", "noopener,noreferrer");
     prMsg.value = data.via === "gh" ? "PR created" : "Opened PR page";
   } else {
-    prMsg.value = reasonMsg(data.reason as string);
+    prMsg.value = worktreeFailureMessage(data.reason as string);
   }
 }
 

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -12,6 +12,7 @@ import type { RunCommand } from "./runCommand";
 import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterPhase";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
+import { flipTargetUid, shouldFlipZoom } from "./cellChromeRules";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -161,12 +162,9 @@ function flipCell(uid: number, first: DOMRect) {
 watch(
   () => props.expandedUid,
   (to, from) => {
-    const uid = to ?? from;
-    if (uid === null || uid === undefined) return;
-    // swapping between two already-zoomed cells (cockpit list click) has no on-screen
-    // source to fly from — the incoming cell sits off-screen in `.grid` — so skip the FLIP.
-    if (to !== null && from !== null) return;
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const uid = flipTargetUid(to, from);
+    if (uid === null) return;
+    if (!shouldFlipZoom(to, from, window.matchMedia("(prefers-reduced-motion: reduce)").matches)) return;
     const el = cellEl(uid);
     if (!el) return;
     const first = el.getBoundingClientRect();

--- a/src/components/cellChromeRules.ts
+++ b/src/components/cellChromeRules.ts
@@ -1,0 +1,35 @@
+// The last of the grid's small display rules: what a failed worktree action says, and when a
+// zoom animates.
+
+const REASON_MESSAGES = new Map<string, string>([
+  ["not-worktree", "Not a worktree"],
+  ["no-branch", "No branch to push"],
+  ["no-remote", "No git remote (origin) configured"],
+  ["no-github", "Not a GitHub repo — push succeeded; open the PR manually"],
+  ["push-failed", "Push failed"],
+  ["failed", "Failed"],
+]);
+
+// A Map, not an object literal: indexed by a string that arrives in a server response, an
+// object would answer `constructor` or `toString` through its prototype chain — and `?? ` does
+// not catch a function, so the UI would render "function Object() { [native code] }" where a
+// sentence belongs.
+export function worktreeFailureMessage(reason?: string | null): string {
+  return REASON_MESSAGES.get(reason ?? "") ?? "Failed";
+}
+
+// Which cell the zoom transition should fly, given the expanded cell before and after.
+export function flipTargetUid(to: number | null | undefined, from: number | null | undefined): number | null {
+  return to ?? from ?? null;
+}
+
+// Whether that transition should run at all.
+//
+// Two reasons not to. Swapping between two already-zoomed cells (a cockpit list click) has no
+// on-screen source to fly from — the incoming cell sits off-screen in the grid — so the
+// animation would start from nowhere. And a user who asked for reduced motion gets none.
+export function shouldFlipZoom(to: number | null | undefined, from: number | null | undefined, reducedMotion: boolean): boolean {
+  if (flipTargetUid(to, from) === null) return false;
+  if (to !== null && to !== undefined && from !== null && from !== undefined) return false;
+  return !reducedMotion;
+}

--- a/test/src/components/cellChromeRules.spec.ts
+++ b/test/src/components/cellChromeRules.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+
+import { flipTargetUid, shouldFlipZoom, worktreeFailureMessage } from "../../../src/components/cellChromeRules";
+
+describe("worktreeFailureMessage", () => {
+  it.each([
+    ["not-worktree", "Not a worktree"],
+    ["no-branch", "No branch to push"],
+    ["push-failed", "Push failed"],
+  ])("explains %s", (reason, expected) => {
+    expect(worktreeFailureMessage(reason)).toBe(expected);
+  });
+
+  // The push half succeeded — the message has to say so, or the user re-pushes.
+  it("tells the user their push landed even though the PR did not", () => {
+    expect(worktreeFailureMessage("no-github")).toContain("push succeeded");
+  });
+
+  it.each([[undefined], [null], [""], ["something-new"]])("falls back to a plain failure for %j", (reason) => {
+    expect(worktreeFailureMessage(reason)).toBe("Failed");
+  });
+
+  // A reason arrives inside a server response, so a plain object literal would answer these
+  // through its prototype chain — and `??` does not catch a function, so the UI would render
+  // "function Object() { [native code] }" where a sentence belongs.
+  it.each([["constructor"], ["toString"], ["__proto__"], ["hasOwnProperty"]])("does not resolve %s through the prototype chain", (reason) => {
+    expect(worktreeFailureMessage(reason)).toBe("Failed");
+  });
+});
+
+describe("flipTargetUid", () => {
+  it("flies the cell being zoomed in", () => {
+    expect(flipTargetUid(3, null)).toBe(3);
+  });
+
+  it("flies the cell being zoomed out", () => {
+    expect(flipTargetUid(null, 3)).toBe(3);
+  });
+
+  it("has nothing to fly when neither end names a cell", () => {
+    expect(flipTargetUid(null, null)).toBeNull();
+    expect(flipTargetUid(undefined, undefined)).toBeNull();
+  });
+
+  // uid 0 is a real cell, and `??` is what keeps it from being read as "none".
+  it("treats cell 0 as a cell", () => {
+    expect(flipTargetUid(0, null)).toBe(0);
+    expect(flipTargetUid(null, 0)).toBe(0);
+  });
+});
+
+describe("shouldFlipZoom", () => {
+  it("animates a zoom in and a zoom out", () => {
+    expect(shouldFlipZoom(3, null, false)).toBe(true);
+    expect(shouldFlipZoom(null, 3, false)).toBe(true);
+  });
+
+  // Swapping between two already-zoomed cells has no on-screen source to fly from — the
+  // incoming cell sits off-screen in the grid — so the animation would start from nowhere.
+  it("skips a swap between two zoomed cells", () => {
+    expect(shouldFlipZoom(4, 3, false)).toBe(false);
+  });
+
+  it("respects a reduced-motion preference", () => {
+    expect(shouldFlipZoom(3, null, true)).toBe(false);
+  });
+
+  it("does nothing when there is no cell at either end", () => {
+    expect(shouldFlipZoom(null, null, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The remaining Tier 3 items from #598, in one PR.

**`reasonMsg` had the prototype-chain hole again.** Its table was an object literal indexed by a string that arrives **in a server response**, so `reason: "constructor"` resolved to a function — and `??` does not catch a function, so the UI would render `function Object() { [native code] }` where a sentence belongs. A `Map` now, the same fix as #621. Our own server only sends known codes, so this was latent rather than live.

**The FLIP skip conditions** move out of a watcher that measures `getBoundingClientRect()`: a swap between two already-zoomed cells has no on-screen source to fly from (the incoming cell sits off-screen in the grid), and a reduced-motion preference is honoured. Removing the swap guard turns a test red.

## Items to Confirm / Review

1. `flipTargetUid` keeps `??` rather than `||` deliberately — **cell 0 is a real cell**, and a test says so.
2. Behaviour otherwise unchanged.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `204 files / 2718 tests` — by exit code.

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)