### PR TITLE
fix: ロスターのキャッシュがセルより長生きする (#620 F5)

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -36,7 +36,7 @@ import {
   resolveCellStatus,
   MAX_TERMINALS,
 } from "./gridTabs";
-import { staleCacheKeys } from "./rosterCache";
+import { rosterCellsKey, staleCacheKeys } from "./rosterCache";
 import type { RunCommand } from "./runCommand";
 import { EMPTY_SESSION_META, isPrPhase, mergeSessionMeta, type PrPhase, type WorkPhase } from "./rosterPhase";
 import { useGridActivity } from "../composables/useGridActivity";
@@ -165,8 +165,10 @@ const forgetClosedCells = () => {
 // This watch runs whether or not the roster is on screen, and it is what fills sessionMeta,
 // so the cleanup has to hang off it too — pruning only on the roster poll leaves the cache
 // growing for anyone who never opens the roster.
+// Keyed on the cwd as well as the session: a cell that keeps its session and only moves
+// directory still retires a phaseByCwd entry, and the roster may be hidden for hours.
 watch(
-  () => state.value.cells.map((c) => c.session ?? "").join(","),
+  () => rosterCellsKey(state.value.cells),
   () => {
     forgetClosedCells();
     refreshAllMeta();

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -129,8 +129,6 @@ async function seedMeta(id: string, cwd: string | null) {
   }
 }
 const refreshAllMeta = () => state.value.cells.forEach((c) => c.session && void seedMeta(c.session, c.cwd));
-watch(() => state.value.cells.map((c) => c.session ?? "").join(","), refreshAllMeta, { immediate: true });
-
 // The PR workflow phase per directory (GET /api/pr-phase), shown in the roster beside the
 // agent status. Keyed by cwd, not session — the phase is the branch's, so cells sharing a dir
 // share one fetch. Best-effort and cached server-side, so the roster poll can re-fetch cheaply.
@@ -149,10 +147,6 @@ async function seedPhase(cwd: string) {
     // best-effort — the next poll retries
   }
 }
-const refreshAllPhases = () => {
-  const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
-  cwds.forEach((cwd) => void seedPhase(cwd));
-};
 // Drop what no cell asks for any more, so a day of relaunching cells doesn't leave an entry
 // behind for every session the grid ever showed.
 const forgetClosedCells = () => {
@@ -168,6 +162,22 @@ const forgetClosedCells = () => {
   });
 };
 
+// This watch runs whether or not the roster is on screen, and it is what fills sessionMeta,
+// so the cleanup has to hang off it too — pruning only on the roster poll leaves the cache
+// growing for anyone who never opens the roster.
+watch(
+  () => state.value.cells.map((c) => c.session ?? "").join(","),
+  () => {
+    forgetClosedCells();
+    refreshAllMeta();
+  },
+  { immediate: true },
+);
+
+const refreshAllPhases = () => {
+  const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
+  cwds.forEach((cwd) => void seedPhase(cwd));
+};
 const refreshRoster = () => {
   forgetClosedCells();
   refreshAllMeta();

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -36,6 +36,7 @@ import {
   resolveCellStatus,
   MAX_TERMINALS,
 } from "./gridTabs";
+import { staleCacheKeys } from "./rosterCache";
 import type { RunCommand } from "./runCommand";
 import { EMPTY_SESSION_META, isPrPhase, mergeSessionMeta, type PrPhase, type WorkPhase } from "./rosterPhase";
 import { useGridActivity } from "../composables/useGridActivity";
@@ -109,12 +110,19 @@ const sessionMeta = reactive(new Map<string, SessionMeta>());
 // Seed on appearance, then poll while the roster is on screen. Merge, never overwrite: a
 // fetch that can't find the transcript (absent/mismatched cwd) returns nulls that must not
 // wipe a value already shown. (The status badge is separate — it rides `statusForSort`.)
+// The roster polls every few seconds, so a slow answer can still be in flight when the next
+// one goes out. Only the newest may be applied: an older one describes a moment already
+// overtaken, and its fields would put back what the newer answer replaced (#620).
+const latestMetaSeed = new Map<string, number>();
 async function seedMeta(id: string, cwd: string | null) {
+  const seed = (latestMetaSeed.get(id) ?? 0) + 1;
+  latestMetaSeed.set(id, seed);
   try {
     const query = cwd ? `?cwd=${encodeURIComponent(cwd)}` : "";
     const res = await fetch(`/api/session/${id}${query}`);
-    if (!res.ok) return;
+    if (!res.ok || latestMetaSeed.get(id) !== seed) return;
     const d = (await res.json()) as Partial<SessionMeta>;
+    if (latestMetaSeed.get(id) !== seed) return;
     sessionMeta.set(id, mergeSessionMeta(sessionMeta.get(id) ?? EMPTY_SESSION_META, d));
   } catch {
     // best-effort — the next poll retries
@@ -127,11 +135,15 @@ watch(() => state.value.cells.map((c) => c.session ?? "").join(","), refreshAllM
 // agent status. Keyed by cwd, not session — the phase is the branch's, so cells sharing a dir
 // share one fetch. Best-effort and cached server-side, so the roster poll can re-fetch cheaply.
 const phaseByCwd = reactive(new Map<string, PrPhase>());
+const latestPhaseSeed = new Map<string, number>();
 async function seedPhase(cwd: string) {
+  const seed = (latestPhaseSeed.get(cwd) ?? 0) + 1;
+  latestPhaseSeed.set(cwd, seed);
   try {
     const res = await fetch(`/api/pr-phase?cwd=${encodeURIComponent(cwd)}`);
-    if (!res.ok) return;
+    if (!res.ok || latestPhaseSeed.get(cwd) !== seed) return;
     const d = (await res.json()) as { phase?: unknown };
+    if (latestPhaseSeed.get(cwd) !== seed) return;
     if (isPrPhase(d.phase)) phaseByCwd.set(cwd, d.phase);
   } catch {
     // best-effort — the next poll retries
@@ -141,7 +153,23 @@ const refreshAllPhases = () => {
   const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
   cwds.forEach((cwd) => void seedPhase(cwd));
 };
+// Drop what no cell asks for any more, so a day of relaunching cells doesn't leave an entry
+// behind for every session the grid ever showed.
+const forgetClosedCells = () => {
+  const sessions = new Set(state.value.cells.map((c) => c.session).filter((s): s is string => !!s));
+  const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
+  staleCacheKeys(sessionMeta.keys(), sessions).forEach((id) => {
+    sessionMeta.delete(id);
+    latestMetaSeed.delete(id);
+  });
+  staleCacheKeys(phaseByCwd.keys(), cwds).forEach((cwd) => {
+    phaseByCwd.delete(cwd);
+    latestPhaseSeed.delete(cwd);
+  });
+};
+
 const refreshRoster = () => {
+  forgetClosedCells();
   refreshAllMeta();
   refreshAllPhases();
 };

--- a/src/components/rosterCache.ts
+++ b/src/components/rosterCache.ts
@@ -1,0 +1,15 @@
+// Keeping the roster's two per-cell caches from outliving the cells they describe.
+//
+// `sessionMeta` (per session) and `phaseByCwd` (per directory) are filled by a poll that
+// runs while the roster is on screen, and nothing ever removed from them: a cell that was
+// closed, relaunched under a new session id, or pointed at another directory left its entry
+// behind for as long as the page stayed open. A grid that gets used all day accumulates one
+// per session it ever showed (#620 F5).
+//
+// Dropping is keyed on what the cells currently ARE, not on what changed, so a key that
+// comes back is simply refetched by the next poll.
+
+/** Cached keys that no cell asks for any more. */
+export function staleCacheKeys(cached: Iterable<string>, inUse: ReadonlySet<string>): string[] {
+  return [...cached].filter((key) => !inUse.has(key));
+}

--- a/src/components/rosterCache.ts
+++ b/src/components/rosterCache.ts
@@ -13,3 +13,18 @@
 export function staleCacheKeys(cached: Iterable<string>, inUse: ReadonlySet<string>): string[] {
   return [...cached].filter((key) => !inUse.has(key));
 }
+
+/**
+ * What the cleanup watch keys on.
+ *
+ * Both caches have to retire together, and they are keyed differently: sessionMeta by
+ * session, phaseByCwd by directory. Keying the watch on the session ids alone means a cell
+ * that keeps its session and only moves directory never fires it, so the old directory's
+ * entry stays for as long as the page does.
+ *
+ * The parts are joined with a NUL, which cannot appear in a session id or a path, so a cwd
+ * containing the separator cannot forge a boundary and make two different rosters look alike.
+ */
+export function rosterCellsKey(cells: readonly { session: string | null; cwd: string | null }[]): string {
+  return cells.map((cell) => `${cell.session ?? ""}\u0000${cell.cwd ?? ""}`).join("\u0000\u0000");
+}

--- a/test/src/components/rosterCache.spec.ts
+++ b/test/src/components/rosterCache.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { staleCacheKeys } from "../../../src/components/rosterCache";
+import { staleCacheKeys, rosterCellsKey } from "../../../src/components/rosterCache";
 
 const inUse = (...keys: string[]) => new Set(keys);
 
@@ -37,5 +37,45 @@ describe("staleCacheKeys", () => {
   // Relaunching a cell gives it a new session id; the old one is what has to go.
   it("drops the id a relaunched cell replaced", () => {
     expect(staleCacheKeys(["old-session", "other"], inUse("new-session", "other"))).toEqual(["old-session"]);
+  });
+});
+
+// Codex on #640: the cleanup watch keyed on session ids alone, so a cell that kept its
+// session and only moved directory never fired it — and phaseByCwd is keyed by directory.
+describe("rosterCellsKey", () => {
+  const cell = (session: string | null, cwd: string | null) => ({ session, cwd });
+
+  it("changes when a cell's session changes", () => {
+    expect(rosterCellsKey([cell("a", "/w")])).not.toBe(rosterCellsKey([cell("b", "/w")]));
+  });
+
+  it("changes when only a cell's cwd changes", () => {
+    expect(rosterCellsKey([cell("a", "/w")])).not.toBe(rosterCellsKey([cell("a", "/other")]));
+  });
+
+  it("does not change when nothing changed", () => {
+    expect(rosterCellsKey([cell("a", "/w"), cell("b", null)])).toBe(rosterCellsKey([cell("a", "/w"), cell("b", null)]));
+  });
+
+  it("changes when a cell is added or removed", () => {
+    expect(rosterCellsKey([cell("a", "/w")])).not.toBe(rosterCellsKey([cell("a", "/w"), cell("b", "/w")]));
+  });
+
+  it("changes when cells are reordered", () => {
+    expect(rosterCellsKey([cell("a", "/w"), cell("b", "/x")])).not.toBe(rosterCellsKey([cell("b", "/x"), cell("a", "/w")]));
+  });
+
+  it("treats an empty roster as its own key", () => {
+    expect(rosterCellsKey([])).toBe("");
+  });
+
+  // A path is user data. With a separator that can appear in one, two different rosters
+  // could serialise the same and the cleanup would not fire.
+  it("cannot be forged by a cwd containing the separator", () => {
+    expect(rosterCellsKey([cell("a", "/w,b"), cell(null, null)])).not.toBe(rosterCellsKey([cell("a", "/w"), cell("b", null)]));
+  });
+
+  it("distinguishes an empty session from an empty cwd", () => {
+    expect(rosterCellsKey([cell(null, "x")])).not.toBe(rosterCellsKey([cell("x", null)]));
   });
 });

--- a/test/src/components/rosterCache.spec.ts
+++ b/test/src/components/rosterCache.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import { staleCacheKeys } from "../../../src/components/rosterCache";
+
+const inUse = (...keys: string[]) => new Set(keys);
+
+describe("staleCacheKeys", () => {
+  it("drops a key no cell asks for any more", () => {
+    expect(staleCacheKeys(["closed", "open"], inUse("open"))).toEqual(["closed"]);
+  });
+
+  it("keeps everything still in use", () => {
+    expect(staleCacheKeys(["a", "b"], inUse("a", "b"))).toEqual([]);
+  });
+
+  it("drops everything when no cell is left", () => {
+    expect(staleCacheKeys(["a", "b"], inUse())).toEqual(["a", "b"]);
+  });
+
+  it("has nothing to drop from an empty cache", () => {
+    expect(staleCacheKeys([], inUse("a"))).toEqual([]);
+  });
+
+  // A key that is in use but not cached is simply not our business — the poll fills it.
+  it("says nothing about a key that is in use but uncached", () => {
+    expect(staleCacheKeys(["a"], inUse("a", "b"))).toEqual([]);
+  });
+
+  it("accepts the Map key iterator the caches hand it", () => {
+    const cache = new Map([
+      ["a", 1],
+      ["gone", 2],
+    ]);
+    expect(staleCacheKeys(cache.keys(), inUse("a"))).toEqual(["gone"]);
+  });
+
+  // Relaunching a cell gives it a new session id; the old one is what has to go.
+  it("drops the id a relaunched cell replaced", () => {
+    expect(staleCacheKeys(["old-session", "other"], inUse("new-session", "other"))).toEqual(["old-session"]);
+  });
+});


### PR DESCRIPTION
Refs #620

## Summary

ロスターの**セル単位キャッシュ 2 つが、一度も掃除されていませんでした**。

| キャッシュ | キー |
|---|---|
| `sessionMeta` | セッション id |
| `phaseByCwd` | ディレクトリ |

セルを閉じても、別セッション id で起動し直しても、別ディレクトリに向け直しても、**エントリはページを開いている限り残り続けます**。一日使ったグリッドには、それまでに表示した**全セッション分**が溜まります。

掃除は「何が変わったか」ではなく「**いま何があるか**」を基準にしています。戻ってきたキーは次のポーリングが取り直すだけです。

## ファミリーの最後の 1 件

このポーリングは、**#620 のファミリーで唯一まだ応答を無条件に適用していた箇所**でもあります。数秒ごとに走るので、遅い応答が次の要求と重なり、古い方が新しい結果を巻き戻します。両方の seed に**キーごとの世代**を入れました（この形の 4 例目、これで最後）。

## Items to Confirm / Review

1. **これはファミリーの軽い側です**（行列にもそう書いてあります）。古い応答は数秒後の次のポーリングで自己修復します。**キャッシュの増加は自己修復しません**
2. **テストは「落とす」側のルールに付けました。** ここは逆方向の間違いの方が高くつくためです — **使用中のキーを落とすと、生きているセルのプロンプト表示が消えます**
3. `main` 側で `mergeSessionMeta` の抽出が既に入っていたので、マージ部分には手を付けていません（#628 と衝突しないよう `GridView.vue` のみ触っています）

## テストが効くことの確認

| 壊し方 | 落ちるテスト |
|---|---|
| 何も落とさない（＝元の挙動） | 4 件 |
| 使用中のキーまで落とす | 5 件 |

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `yarn build` / `yarn test`（204 files, 2705 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
