### PR TITLE
fix(theme): pick badge text by real contrast, not a brightness approximation (#308)

### DIFF
--- a/src/components/contrast.ts
+++ b/src/components/contrast.ts
@@ -1,0 +1,41 @@
+// Picking readable text for an arbitrary background colour.
+//
+// The previous rule claimed to be "sRGB relative luminance (WCAG)" but was the YIQ
+// perceived-brightness approximation (0.299/0.587/0.114 on raw channel values, threshold
+// 150). Those are different things: WCAG gamma-decodes each channel first and weights green
+// far more heavily. Measured across a 32 768-point sample of the colour space, the
+// approximation picks the WORSE of black/white for 29.7% of colours, and 28.7% of its picks
+// fall below the WCAG AA 4.5:1 minimum for normal text.
+//
+// A vivid green badge was the visible case: #00ff00 scored 149.685 against the threshold of
+// 150, so it got WHITE text at a contrast ratio of 1.37:1 — effectively unreadable — where
+// black would have given 15.3:1.
+
+const CHANNEL_MAX = 255;
+const SRGB_LINEAR_CUTOFF = 0.03928;
+const SRGB_LINEAR_DIVISOR = 12.92;
+
+// sRGB → linear light, which is what luminance has to be computed on.
+function toLinear(channel: number): number {
+  const value = channel / CHANNEL_MAX;
+  return value <= SRGB_LINEAR_CUTOFF ? value / SRGB_LINEAR_DIVISOR : Math.pow((value + 0.055) / 1.055, 2.4);
+}
+
+export function relativeLuminance(r: number, g: number, b: number): number {
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+// WCAG contrast ratio between two relative luminances, 1:1 (identical) to 21:1 (black/white).
+export function contrastRatio(luminanceA: number, luminanceB: number): number {
+  return (Math.max(luminanceA, luminanceB) + 0.05) / (Math.min(luminanceA, luminanceB) + 0.05);
+}
+
+const BLACK_LUMINANCE = 0;
+const WHITE_LUMINANCE = 1;
+
+// Whichever of black or white is more readable on this background. Ties go to black, which
+// only happens at the exact midpoint.
+export function readableTextColor(r: number, g: number, b: number): "#000" | "#fff" {
+  const background = relativeLuminance(r, g, b);
+  return contrastRatio(background, BLACK_LUMINANCE) >= contrastRatio(background, WHITE_LUMINANCE) ? "#000" : "#fff";
+}

--- a/src/components/dirBadge.ts
+++ b/src/components/dirBadge.ts
@@ -1,13 +1,15 @@
+import { readableTextColor } from "./contrast";
+
 // Inline style for a directory's name badge: the configured color as the
 // background, with black or white text picked for contrast. Shared by the single
 // view (Terminal header) and the grid (cell header) so the badge looks the same in
 // both. A null/missing color falls back to a neutral panel chip.
 
-// sRGB relative luminance (WCAG): bright backgrounds get dark text, dark ones light.
-function isLight(hex: string): boolean {
+// Text colour is whichever of black/white WCAG says is more readable on the badge — see
+// contrast.ts for why the old brightness approximation was not good enough.
+function textColorFor(hex: string): "#000" | "#fff" {
   const n = parseInt(hex.slice(1), 16);
-  const [r, g, b] = [(n >> 16) & 255, (n >> 8) & 255, n & 255];
-  return 0.299 * r + 0.587 * g + 0.114 * b > 150;
+  return readableTextColor((n >> 16) & 255, (n >> 8) & 255, n & 255);
 }
 
 const HEX_COLOR_RE = /^#[0-9a-fA-F]{6}$/;
@@ -16,5 +18,5 @@ export function badgeStyleFor(color: string | null | undefined): Record<string, 
   if (!color || !HEX_COLOR_RE.test(color)) {
     return { background: "var(--bg-elevated)", color: "var(--text-secondary)" };
   }
-  return { background: color, color: isLight(color) ? "#000" : "#fff" };
+  return { background: color, color: textColorFor(color) };
 }

--- a/test/src/components/contrast.spec.ts
+++ b/test/src/components/contrast.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import { contrastRatio, readableTextColor, relativeLuminance } from "../../../src/components/contrast";
+
+const hex = (value: string): [number, number, number] => {
+  const n = parseInt(value.slice(1), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+};
+const ratioOn = (background: string, text: "#000" | "#fff") => contrastRatio(relativeLuminance(...hex(background)), text === "#000" ? 0 : 1);
+
+describe("relativeLuminance", () => {
+  it("is 0 for black and 1 for white", () => {
+    expect(relativeLuminance(0, 0, 0)).toBe(0);
+    expect(relativeLuminance(255, 255, 255)).toBeCloseTo(1, 10);
+  });
+
+  // Gamma-decoded, not raw: mid grey is far darker than half of white.
+  it("gamma-decodes rather than averaging raw channels", () => {
+    expect(relativeLuminance(128, 128, 128)).toBeCloseTo(0.2159, 3);
+  });
+
+  it("weights green far above blue", () => {
+    expect(relativeLuminance(0, 255, 0)).toBeGreaterThan(relativeLuminance(0, 0, 255) * 5);
+  });
+});
+
+describe("contrastRatio", () => {
+  it("is 21 for black on white and 1 for a colour on itself", () => {
+    expect(contrastRatio(0, 1)).toBeCloseTo(21, 10);
+    expect(contrastRatio(0.5, 0.5)).toBe(1);
+  });
+
+  it("does not care which way round the two are given", () => {
+    expect(contrastRatio(0.2, 0.8)).toBeCloseTo(contrastRatio(0.8, 0.2), 10);
+  });
+});
+
+describe("readableTextColor", () => {
+  it("puts dark text on white and light text on black", () => {
+    expect(readableTextColor(255, 255, 255)).toBe("#000");
+    expect(readableTextColor(0, 0, 0)).toBe("#fff");
+  });
+
+  // The case that motivated this (#308, and the boundary noted in #634): the old brightness
+  // approximation scored pure green at 149.685 against a threshold of 150 and chose WHITE —
+  // a contrast ratio of 1.37:1, effectively unreadable, where black gives 15.3:1.
+  it("chooses black on vivid green, which the old rule got backwards", () => {
+    expect(readableTextColor(...hex("#00ff00"))).toBe("#000");
+    expect(ratioOn("#00ff00", "#000")).toBeGreaterThan(14);
+    expect(ratioOn("#00ff00", "#fff")).toBeLessThan(1.5);
+  });
+
+  // A sample of real palette colours whose text colour the old rule chose badly.
+  it.each([["#22c55e"], ["#ff0000"], ["#8c8c8c"], ["#00ff00"]])("meets WCAG AA on %s, which the old rule failed", (color) => {
+    expect(ratioOn(color, readableTextColor(...hex(color)))).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("keeps the colours the old rule already handled well", () => {
+    expect(readableTextColor(...hex("#2563eb"))).toBe("#fff");
+    expect(readableTextColor(...hex("#e0a52d"))).toBe("#000");
+  });
+
+  // The guarantee worth stating: black and white are 21:1 apart, so the better of the two is
+  // never below 4.5:1 for any background whatsoever.
+  it("never leaves a background below WCAG AA, across the colour space", () => {
+    let worst = Infinity;
+    for (let r = 0; r < 256; r += 17) {
+      for (let g = 0; g < 256; g += 17) {
+        for (let b = 0; b < 256; b += 17) {
+          const background = relativeLuminance(r, g, b);
+          const chosen = readableTextColor(r, g, b) === "#000" ? 0 : 1;
+          worst = Math.min(worst, contrastRatio(background, chosen));
+        }
+      }
+    }
+    expect(worst).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/test/src/components/dirBadge.spec.ts
+++ b/test/src/components/dirBadge.spec.ts
@@ -14,26 +14,25 @@ describe("badgeStyleFor", () => {
     expect(badgeStyleFor("#000000")).toEqual({ background: "#000000", color: "#fff" });
   });
 
-  // Perceived brightness, not raw magnitude: the same channel value reads very differently
-  // depending on which channel it is in.
+  // Green carries far more perceived light than blue, so the same channel value reads very
+  // differently depending on which channel it is in.
   it("weighs the channels by how bright they look, not by their value", () => {
-    expect(badgeStyleFor("#80ff80").color).toBe("#000"); // 202.6
-    expect(badgeStyleFor("#8080ff").color).toBe("#fff"); // 142.5
+    // The same channel value: green carries most of the perceived light, blue almost none.
+    expect(badgeStyleFor("#00ff00").color).toBe("#000");
+    expect(badgeStyleFor("#0000ff").color).toBe("#fff");
   });
 
-  // Recorded because it is surprising rather than because it is right: pure green scores
-  // 0.587 x 255 = 149.685, a fraction under the 150 threshold, so a vivid green badge gets
-  // WHITE text. Worth a look if a green badge ever reads as hard to see — the fix would be
-  // the threshold, which changes existing badges, so it is not made here.
-  it("gives pure green light text, just under the threshold", () => {
-    expect(badgeStyleFor("#00ff00").color).toBe("#fff");
+  // Was the other way round until #308: the old brightness approximation scored pure green a
+  // fraction under its threshold and chose white, at a contrast ratio of 1.37:1.
+  it("gives a mid green dark text", () => {
+    expect(badgeStyleFor("#22c55e").color).toBe("#000");
   });
 
-  it("keeps a mid grey on the light side of the threshold", () => {
-    // 0.299·155 + 0.587·155 + 0.114·155 = 155 > 150
+  // A mid grey is darker than it looks once gamma is accounted for, but black still wins on
+  // both of these — the old rule flipped one of them to white.
+  it("gives mid greys dark text", () => {
     expect(badgeStyleFor("#9b9b9b").color).toBe("#000");
-    // …and 140 < 150.
-    expect(badgeStyleFor("#8c8c8c").color).toBe("#fff");
+    expect(badgeStyleFor("#8c8c8c").color).toBe("#000");
   });
 
   it("accepts upper-case hex", () => {


### PR DESCRIPTION
## The bug

`dirBadge.ts` said it used *"sRGB relative luminance (WCAG)"*. It used the **YIQ perceived-brightness approximation** — raw channels weighted `0.299/0.587/0.114` against a threshold of 150. Those are different things: WCAG gamma-decodes each channel first, and weights green far more heavily.

Measured over a 32,768-point sample of the colour space:

- the approximation picks the **worse** of black/white for **29.7%** of colours
- **28.7%** of its picks fall **below the WCAG AA 4.5:1 minimum** for normal text

```
#00ff00  chose white at 1.37:1   (black would give 15.30:1)
#22c55e  chose white at 2.28:1   (black:  9.22:1)
#ff0000  chose white at 4.00:1   (black:  5.25:1)
#8c8c8c  chose white at 3.36:1   (black:  6.25:1)
```

The first is the vivid-green case I noted while writing `dirBadge`'s tests — the threshold comparison landed **0.315 short**. I recorded it then instead of fixing it, on the grounds that changing the rule moves existing badges. It does: **it moves them to the readable choice.**

## The fix

Text colour is whichever of black/white has the higher WCAG contrast ratio. Because those two are 21:1 apart, the better of them is **never** below AA for any background whatsoever — asserted across the colour space rather than argued.

## Items to Confirm / Review

1. **Existing badges will change colour** — that is the change, and it is why this was not folded into an earlier refactor PR. Roughly 3 in 10 configured colours are affected, all in the direction of readability.
2. **Three `dirBadge` tests pinned the old answers** and are updated. The point of the change, not a casualty of it.
3. **This covers the badge half of #308 only.** The GitHub-icon half — an image carrying its own white background — is a different problem and is untouched. Worth keeping the issue open if you want that half tracked, in which case say so and I will drop the `Closes`.

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `208 files / 2778 tests` — by exit code. Removing the gamma decode turns 2 tests red.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)