### PR TITLE
fix: zooming a lone cell is a no-op (#374 problem 1)

### DIFF
--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -171,8 +171,16 @@ function expandNeighbour(order: number[] | undefined, uid: number, remaining: Ce
   return neighbour !== undefined && remaining.some((c) => c.uid === neighbour) ? neighbour : null;
 }
 
+// Zooming shows one cell big with the others as a filmstrip beside it, so it only means
+// anything when there IS another cell to switch to. With a single occupied cell the ⤢ button
+// used to swap a working layout for a filmstrip containing nothing, and squeeze the
+// terminal's status bar and input off the bottom of the viewport for no gain (#374).
+//
+// Collapsing is never refused: whatever a state got into, ⤡ has to get out of it.
 export function toggleExpand(state: GridState, uid: number): GridState {
-  return { ...state, expanded: state.expanded === uid ? null : uid };
+  if (state.expanded === uid) return { ...state, expanded: null };
+  if (runningCount(state.cells) < 2) return state;
+  return { ...state, expanded: uid };
 }
 
 export function setSortMode(state: GridState, sortMode: SortMode): GridState {

--- a/test/src/components/gridTabs.spec.ts
+++ b/test/src/components/gridTabs.spec.ts
@@ -163,6 +163,30 @@ describe("setSession / setCwd / toggleExpand", () => {
     expect(toggleExpand(make(running(2)), 1).expanded).toBe(1);
     expect(toggleExpand(make(running(2), { expanded: 1 }), 1).expanded).toBeNull();
   });
+
+  // #374: zooming shows one cell big with the others as a filmstrip, so with nothing to
+  // switch to it swaps a working layout for an empty filmstrip and squeezes the terminal's
+  // status bar and input off the bottom of the viewport, for no gain.
+  it("refuses to zoom when there is only one occupied cell", () => {
+    const single = make([cell(0, U(0)), cell(1)]);
+    expect(toggleExpand(single, 0)).toBe(single);
+  });
+
+  it("refuses to zoom a grid of nothing but launch cells", () => {
+    const empty = make([cell(0), cell(1)]);
+    expect(toggleExpand(empty, 0)).toBe(empty);
+  });
+
+  it("zooms as soon as a second cell is occupied", () => {
+    expect(toggleExpand(make([cell(0, U(0)), cell(1, U(1)), cell(2)]), 0).expanded).toBe(0);
+  });
+
+  // Whatever a state got into, the collapse button has to get out of it — including a state
+  // that was zoomed when its sibling closed.
+  it("always allows collapsing, even down to one cell", () => {
+    const stranded = make([cell(0, U(0)), cell(1)], { expanded: 0 });
+    expect(toggleExpand(stranded, 0).expanded).toBeNull();
+  });
 });
 
 describe("switchPage", () => {


### PR DESCRIPTION
## Summary

Zoom shows one cell big with the others as a filmstrip beside it, so it only means anything when there **is** another cell to switch to. With a single occupied cell, ⤢ swapped a working layout for a filmstrip containing nothing — and squeezed the terminal's status bar and input off the bottom of the viewport, for no gain.

`toggleExpand` now refuses to expand below two occupied cells. **Collapsing is never refused**: whatever a state got into, ⤡ has to get out of it — a cell left zoomed when its sibling closed still collapses, and a test says so.

## Items to Confirm / Review

1. **Problem 2 is not addressed.** The filmstrip's fixed `flex: 0 0 150px` pushing content past the viewport with *several* cells is a CSS layout question, and diagnosing it honestly needs a browser — which this session does not have. Guessing at `.stage.zoomed:not(.listmode) .grid` without seeing it render is how a layout fix becomes a layout bug. The issue itself notes problem 1 resolves the single-cell case of it, so this PR narrows the remaining scope rather than closing it.
2. **The threshold is occupied cells, not total cells** — a grid of one session plus empty launch cells is still "one cell" for this purpose, and a test covers it.

Refs #374 (deliberately not `Closes` — problem 2 remains)

## Checks

lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `208 files / 2782 tests` — by exit code. Removing the guard turns 2 tests red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)