### PR TITLE
refactor: グリッドがセルに要求する契約に名前を付ける (#646 B1)

### DIFF
--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -4,30 +4,21 @@ import TerminalView from "./Terminal.vue";
 import type { RunCommand } from "./runCommand";
 import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
-import type { CellStatus } from "./gridTabs";
+import type { GridCellEmits, GridCellProps } from "./gridCell";
 import { browserLocale } from "../utils/browserLocale";
 
 // A grid cell that runs a `script.json` command (a cell launcher's Run) instead of
 // a Claude session. Ephemeral: it has no session id and isn't persisted — a reload
 // drops it. `command.index` is the script's position in `<command.cwd>/script.json`
 // (the server resolves it); the command runs in `command.cwd`.
-const props = defineProps<{
-  expanded: boolean;
-  // True while SOME cell in the grid is zoomed → this cell is a filmstrip thumbnail
-  // (unless it's the zoomed one). Only then does a header-background click zoom it.
-  zoomed?: boolean;
-  command: RunCommand;
-  home: string | null;
-  // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
-  reorderable?: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "toggle-expand" | "close"): void;
-  // Swap this cell left (-1) or right (+1) in manual sort mode.
-  (e: "move", dir: -1 | 1): void;
-  // Report activity up so the grid can attention-sort in auto mode.
-  (e: "status", value: CellStatus): void;
-}>();
+const props = defineProps<
+  GridCellProps & {
+    command: RunCommand;
+    // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+    reorderable?: boolean;
+  }
+>();
+const emit = defineEmits<GridCellEmits>();
 
 // connectKey forces Terminal.vue to (re)connect — bumped to re-run after exit.
 const connectKey = ref(0);

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -3,7 +3,8 @@ import { computed, ref, watch } from "vue";
 import TerminalView from "./Terminal.vue";
 import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
-import { isShellLauncher, type CellStatus, type CellLauncher } from "./gridTabs";
+import { isShellLauncher, type CellLauncher } from "./gridTabs";
+import type { GridCellEmits, GridCellProps } from "./gridCell";
 
 // A grid cell running a configured launch command (a plain shell, codex, any
 // interactive program) instead of Claude. Unlike CommandCell this is PERSISTENT: it
@@ -11,27 +12,22 @@ import { isShellLauncher, type CellStatus, type CellLauncher } from "./gridTabs"
 // switches and reconnects — but it has no Claude hooks, so its status is only
 // running (working) / exited (idle). `launcher.index` is the command's position in the
 // configured launcher list (the server's allowlist); it runs in `cwd`.
-const props = defineProps<{
-  uid: number;
-  expanded: boolean;
-  // True while SOME cell in the grid is zoomed → this cell is a filmstrip thumbnail
-  // (unless it's the zoomed one). Only then does a header-background click zoom it.
-  zoomed?: boolean;
-  launcher: CellLauncher;
-  session: string | null;
-  cwd: string | null;
-  home: string | null;
-  // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
-  reorderable?: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "toggle-expand" | "close"): void;
-  (e: "move", dir: -1 | 1): void;
-  // Report activity up so the grid can attention-sort in auto mode.
-  (e: "status", value: CellStatus): void;
-  // The server-assigned session id, so the parent persists it for reconnect.
-  (e: "session", id: string): void;
-}>();
+const props = defineProps<
+  GridCellProps & {
+    uid: number;
+    launcher: CellLauncher;
+    session: string | null;
+    cwd: string | null;
+    // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+    reorderable?: boolean;
+  }
+>();
+const emit = defineEmits<
+  GridCellEmits & {
+    // The server-assigned session id, so the parent persists it for reconnect.
+    (e: "session", id: string): void;
+  }
+>();
 
 // Clicking the header background zooms (switches to) this cell, except the already-
 // expanded one. Buttons keep their action.

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -22,6 +22,7 @@ import TimelineOverlay from "./TimelineOverlay.vue";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { activityStatus, type CellStatus } from "./gridTabs";
+import type { GridCellEmits, GridCellProps } from "./gridCell";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import { handoffTargets, pullLastTurn, type HandoffTarget } from "../composables/useHandoff";
 import { runOneExchange, liveCrossTalkDeps } from "../composables/useCrossTalk";
@@ -45,52 +46,46 @@ function onHeaderClick(event: MouseEvent) {
 // `initialCwd` is this cell's persisted working dir; `defaultCwd` is the server
 // default used to prefill the launch form; `presets` are quick-pick dirs; `home`
 // is the server home dir (to anchor the header path on ~).
-const props = defineProps<{
-  // The grid cell's stable uid — the durable-connection slot key for this cell's
-  // terminal, so flipping to an off-page tab detaches the view without reaping the PTY.
-  uid: number;
-  expanded: boolean;
-  // True while SOME cell in the grid is zoomed. A non-expanded cell then renders as a
-  // small filmstrip thumbnail, so it drops to a minimal header (dir + activity + zoom).
-  zoomed?: boolean;
-  initialSessionId: string | null;
-  initialCwd: string | null;
-  // The persisted agent for this cell: "codex" reconnects via /ws/codex on reload; absent
-  // (or "claude") resumes as a normal Claude session.
-  initialAgent?: "codex" | null;
-  defaultCwd: string | null;
-  presets: CwdPreset[];
-  // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
-  launchers?: Launcher[];
-  home: string | null;
-  // Session ids open in other grid cells. Resuming one of them would detach that
-  // cell, so the launcher flags such rows and confirms before opening.
-  openSessionIds?: string[];
-  // Dirs with a running session in another cell, so the launcher can tint preset
-  // chips whose dir is already in use.
-  openCwds?: string[];
-  // An added (not the sole entry) launcher: show a ✕ to dismiss it before launching.
-  cancellable?: boolean;
-  // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
-  reorderable?: boolean;
-}>();
-const emit = defineEmits<{
-  (e: "toggle-expand" | "close"): void;
-  // `record-cwd`: auto-record a fresh launch's server-confirmed cwd as a preset.
-  // `remove-preset`: drop a preset (its ✕) from the shared list — value is the path.
-  (e: "session" | "cwd" | "record-cwd" | "remove-preset", value: string): void;
-  // `run` launches in THIS (empty) cell from the launcher; `runSpare` is the running
-  // terminal's header menu, which must NOT replace the session — it runs in a new cell.
-  (e: "run" | "runSpare", value: RunCommand): void;
-  // The user picked a configured launcher (shell/codex/…) to run in this empty cell.
-  (e: "launch", value: LaunchPick): void;
-  // Swap this cell left (-1) or right (+1) in manual sort mode.
-  (e: "move", dir: -1 | 1): void;
-  // Report live activity up so the grid can attention-sort in auto mode.
-  (e: "status", value: CellStatus): void;
-  // The agent chosen (Claude/Codex) for this fresh launch, so the grid persists it.
-  (e: "agent", value: "claude" | "codex"): void;
-}>();
+const props = defineProps<
+  GridCellProps & {
+    // The grid cell's stable uid — the durable-connection slot key for this cell's
+    // terminal, so flipping to an off-page tab detaches the view without reaping the PTY.
+    uid: number;
+    initialSessionId: string | null;
+    initialCwd: string | null;
+    // The persisted agent for this cell: "codex" reconnects via /ws/codex on reload; absent
+    // (or "claude") resumes as a normal Claude session.
+    initialAgent?: "codex" | null;
+    defaultCwd: string | null;
+    presets: CwdPreset[];
+    // Configured launch commands (shell/codex/…) offered next to Claude in this launcher.
+    launchers?: Launcher[];
+    // Session ids open in other grid cells. Resuming one of them would detach that
+    // cell, so the launcher flags such rows and confirms before opening.
+    openSessionIds?: string[];
+    // Dirs with a running session in another cell, so the launcher can tint preset
+    // chips whose dir is already in use.
+    openCwds?: string[];
+    // An added (not the sole entry) launcher: show a ✕ to dismiss it before launching.
+    cancellable?: boolean;
+    // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+    reorderable?: boolean;
+  }
+>();
+const emit = defineEmits<
+  GridCellEmits & {
+    // `record-cwd`: auto-record a fresh launch's server-confirmed cwd as a preset.
+    // `remove-preset`: drop a preset (its ✕) from the shared list — value is the path.
+    (e: "session" | "cwd" | "record-cwd" | "remove-preset", value: string): void;
+    // `run` launches in THIS (empty) cell from the launcher; `runSpare` is the running
+    // terminal's header menu, which must NOT replace the session — it runs in a new cell.
+    (e: "run" | "runSpare", value: RunCommand): void;
+    // The user picked a configured launcher (shell/codex/…) to run in this empty cell.
+    (e: "launch", value: LaunchPick): void;
+    // The agent chosen (Claude/Codex) for this fresh launch, so the grid persists it.
+    (e: "agent", value: "claude" | "codex"): void;
+  }
+>();
 
 // A cell with a persisted session relaunches (resumes) on mount; otherwise it
 // starts empty and lazy-launches when the user picks a dir and clicks Start.

--- a/src/components/gridCell.ts
+++ b/src/components/gridCell.ts
@@ -1,0 +1,26 @@
+// What the grid requires of any cell, whichever kind it is.
+//
+// Three cell types render in the same grid — a Claude session, a script run, a configured
+// launcher — and GridView drives all three identically: it expands one, reorders them, and
+// sorts by the attention each reports. That contract belongs to the GRID, not to any cell,
+// and it was written out three times with the same comments attached (#646 B1).
+//
+// Named once so a fourth cell type gets it by construction rather than by copying, and so a
+// change to what the grid needs cannot land in two of the three.
+import type { CellStatus } from "./gridTabs";
+
+export interface GridCellProps {
+  expanded: boolean;
+  // True while SOME cell in the grid is zoomed → this cell is a filmstrip thumbnail
+  // (unless it's the zoomed one). Only then does a header-background click zoom it.
+  zoomed?: boolean;
+  home: string | null;
+}
+
+export interface GridCellEmits {
+  (e: "toggle-expand" | "close"): void;
+  // Swap this cell left (-1) or right (+1) in manual sort mode.
+  (e: "move", dir: -1 | 1): void;
+  // Report activity up so the grid can attention-sort in auto mode.
+  (e: "status", value: CellStatus): void;
+}


### PR DESCRIPTION
Refs #646

## Summary

**同じ契約が 3 回書かれていました。** グリッドには 3 種類のセル（Claude セッション / スクリプト実行 / 設定済みランチャ）が並び、`GridView` は 3 つとも**同じように**扱います — 1 つを展開し、並べ替え、各セルが報告する状態で attention-sort する。

| | TerminalCell | CommandCell | LauncherCell |
|---|---|---|---|
| `expanded` / `zoomed?` / `home` | ✓ | ✓ | ✓ |
| `toggle-expand` / `close` / `move` / `status` | ✓ | ✓ | ✓ |

**コメントまで一字一句同じ**でした。jscpd が拾ったのは 3 つのうち 2 つで、3 つ目は長い宣言に埋もれて閾値に届かなかっただけです。

## 重複は症状の方です

**この契約はグリッド側の要求**で、各セルの都合ではありません。それが名前を持たなかったため:

- **4 つ目のセル型がこれを守るべきだと誰も言っていない**
- グリッドの要求が変わったとき、**3 つのうち 2 つにだけ入る**事故が起こりうる

`components/gridCell.ts` に名前を付け、各セルは `GridCellProps & { …固有 }` / `GridCellEmits & { …固有 }` と書く形にしました。

## Items to Confirm / Review

1. **親側の型が維持されることを確認しています。** Vue が交差した emits 型を解決できないと、`TerminalGrid` の `@move="(dir) => …"` が**暗黙の any に落ちます**。実際、import 漏れのときにその形でエラーが出ました（`vue-tsc` は現在 implicit any ゼロ）
2. 3 コンポーネントが 1 つの型に結合します。分岐したくなったらそのとき型を分ける、という前提です
3. `reorderable?` は 3 つとも持っていますが、**グリッドの要求ではなく表示オプション**なので共有型には入れていません（各セルの固有側に残しています）

## 効果

jscpd: **8 clones → 7**。残る CommandCell/LauncherCell の 1 件はボタン markup で、#646 B3 として別に扱います。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck`(implicit any 0) / `yarn build` / `yarn test`（209 files, 2818 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
