### PR TITLE
refactor: move the session lifecycle out of index.ts (#548)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,11 +5,10 @@ import fs from "fs/promises";
 import { randomUUID } from "crypto";
 import { fileURLToPath } from "url";
 import { createPubSub } from "./infra/pubsub.js";
-import { mountAllRoutes, allowedToolNames, toolSummaries } from "./infra/plugins-registry.js";
+import { toolSummaries } from "./infra/plugins-registry.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
-import { mountConfigRoutes, getUserMcpServers, getWorklogConfig } from "./config/config-routes.js";
-import { mountFilesBrowseRoutes } from "./files/files-browse.js";
+import { getUserMcpServers, getWorklogConfig } from "./config/config-routes.js";
 import {
   tmuxAvailable,
   tmuxHasSession,
@@ -18,9 +17,7 @@ import {
   tmuxPaneCommand,
   tmuxAttachedClientCount,
   tmuxCaptureStyledPane,
-  isResumableTmuxSession,
 } from "./infra/tmux.js";
-import { mountTmuxRoutes } from "./infra/tmux-routes.js";
 import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage } from "./infra/sandbox.js";
 import { isAllowedOrigin } from "./infra/allowed-origin.js";
 import { serverErrorExit } from "./infra/server-exit.js";
@@ -35,59 +32,39 @@ import { createTranslationWorker } from "./session/translation-worker.js";
 import { createTitleManager } from "./session/session-title.js";
 import { generateHeaderTitle } from "./config/header-title.js";
 import { mountTerminalWebSockets } from "./routes/ws-routes.js";
-import { mountHookRoute } from "./routes/hook-routes.js";
-import { mountPluginRoutes } from "./routes/plugin-routes.js";
-import { mountMcpRoutes } from "./routes/mcp-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
-import { activity, aiTitles, devTerminalSessions, devTerminalSessionsHydrated, hiddenSessions, knownSessions, ptys } from "./session/registry.js";
-import { resolveWorkspace } from "./config/workspace.js";
-import { mountSessionRoutes } from "./routes/session-routes.js";
+import { activity, aiTitles, hiddenSessions, knownSessions, ptys } from "./session/registry.js";
 import { createToolStores } from "./session/tool-store.js";
-import { mountToolRoutes } from "./routes/tool-routes.js";
-import { mountRepoRoutes } from "./routes/repo-routes.js";
-import { claudeOnDiskSessionIds } from "./session/session-reads.js";
-import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, scheduledSessionInUse, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
-import { codexSessionsRoot } from "./agents/codex-session.js";
-import { codexRolloutExists } from "./agents/codex-sessions.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
-import { mountOpenDirRoute } from "./files/open-dir.js";
-import { mountGitRemoteRoute } from "./git/gitRemote.js";
-import { mountWorktreeRoutes } from "./git/worktree-routes.js";
-import { mountPickFileRoute } from "./files/pick-file.js";
-import { mountCommandSummaryRoute } from "./session/command-summary.js";
-import { mountCostRoute } from "./session/cost.js";
-import { initCollectionsBackend, mountCollectionRoutes } from "./backends/collections.js";
-import { initGoogleBackend, mountGoogleRoutes } from "./backends/google.js";
+import { initCollectionsBackend } from "./backends/collections.js";
+import { initGoogleBackend } from "./backends/google.js";
 import { initPluginRuntime } from "./infra/pluginRuntime.js";
-import { mountWikiRoutes } from "./backends/wiki.js";
-import { initAccountingBackend, mountAccountingRoutes } from "./backends/accounting.js";
-import { initFeedsBackend, mountFeedsRoutes } from "./backends/feeds.js";
-import { HOST_ID as REMOTE_HOST_ID, initRemoteHostBackend, mountRemoteHostRoutes } from "./backends/remoteHost/index.js";
+import { initAccountingBackend } from "./backends/accounting.js";
+import { initFeedsBackend } from "./backends/feeds.js";
+import { HOST_ID as REMOTE_HOST_ID, initRemoteHostBackend } from "./backends/remoteHost/index.js";
 import { createSessionActivityPublisher, firestoreSessionActivityStore } from "./backends/remoteHost/sessionActivity.js";
 import { currentFirestore, currentUid } from "./backends/remoteHost/session.js";
 import { feedRefreshTaskDef, type AgentWorkerRunner } from "@mulmoclaude/core/feeds/server";
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
 import { installConfigSkill } from "./infra/install-config-skill.js";
 import { initFileChangePublisher } from "./backends/fileChange.js";
-import { initNotifier, mountNotificationRoutes } from "./backends/notifier.js";
-import { mountWhisperRoutes, stopWhisperSidecar } from "./backends/whisper.js";
+import { initNotifier } from "./backends/notifier.js";
+import { stopWhisperSidecar } from "./backends/whisper.js";
 import { startCollectionCompletionWatchers } from "./backends/collectionWatchers.js";
-import { initUserTaskScheduler, mountSchedulerRoutes } from "./backends/scheduler.js";
+import { initUserTaskScheduler } from "./backends/scheduler.js";
 import { worklogSystemTask } from "./backends/worklog.js";
 import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
-import { mountFilesRoutes } from "./backends/files.js";
-import { mountShortcutsRoutes } from "./backends/shortcuts.js";
-import { mountTranslationRoutes } from "./backends/translation.js";
-import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
-import { initMulmoScriptBackend, mountMulmoScriptDispatchRoute, mountMulmoScriptMediaRoute } from "./backends/mulmoscript.js";
-import { SPA_FALLBACK_RE } from "./infra/spa-fallback.js";
+import { initMulmoScriptBackend } from "./backends/mulmoscript.js";
 import { createSessionLifecycle, SESSIONS_CHANNEL } from "./session/lifecycle.js";
+import { mountAppRoutes } from "./routes/app-routes.js";
+import { allowedToolNames } from "./infra/plugins-registry.js";
+import { resumableSessionPredicate } from "./session/resumable-sessions.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 
@@ -120,7 +97,6 @@ installConfigSkill();
 
 // Pub/sub channel telling the client a directory's .mulmoterminal.json changed, so it re-reads that
 // dir's config and recolours its cells without a page reload. Fed by the tool hooks, not a watcher.
-const DIR_CONFIG_CHANNEL = "dir-config";
 
 // Per-session pub/sub channel the GUI panel subscribes to. The MCP broker POSTs a
 // toolResult to /api/agent/toolResult, which stores it keyed by session id and
@@ -145,7 +121,6 @@ const GUI_MCP_TOOLS = [...allowedToolNames(), "mcp__mulmoterminal-gui__submitTra
 const toolStores = createToolStores({
   publish: (channel, data) => pubsub?.publish(channel, data),
 });
-const { recordToolCallStart, recordToolCallEnd } = toolStores;
 
 // Bytes of recent output kept per pty and replayed when a client reattaches to
 // a background session, so the user sees context instead of a blank screen.
@@ -233,200 +208,24 @@ const app = express();
 // Generous body limit: PostToolUse hook payloads carry the tool's full output
 // (a big Read/Bash result can blow past Express's 100kb default, which would 413
 // the hook and leave its tool-call entry stuck on "running").
-app.use(express.json({ limit: "25mb" }));
-
-// The GUI-plugin tool routes this server answers itself: spawnBackgroundChat,
-// manageAccounting, manageCollection (routes/plugin-routes.ts). ALL of them must precede
-// mountAllRoutes' /api/plugin/:toolName catch-all below, which would otherwise take them.
-mountPluginRoutes(app, { spawnClaudePty, spawnCodexPty });
-
-// presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
-// /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
-// catch-all (which handles the tool-call); a request without `kind` falls through.
-mountHtmlDispatchRoute(app);
-
-// presentMulmoScript: the View's dispatch (kind router) AND the tool-call both
-// handled by the mulmoscript backend (realpath guard + autoGenerateMovie trigger
-// the generic catch-all lacks). MUST precede mountAllRoutes. The media route
-// (movie/PDF bytes for the View's fetchMediaBlob) has its own path.
-mountMulmoScriptDispatchRoute(app);
-mountMulmoScriptMediaRoute(app);
-
-// Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
-// POST /api/form). The GUI MCP server dispatches tool calls to these.
-mountAllRoutes(app);
-
-// Read-side collection routes (GET /api/collections/list + /:slug/detail) over the
-// shared workspace, backing the @mulmoclaude/collection-plugin presentCollection
-// card and (later) the collections toolbar. The engine itself is configured below
-// once CLAUDE_CWD is the confirmed workspace.
-mountCollectionRoutes(app);
-
-// Read-only wiki routes (GET /api/wiki[?slug=] + /graph + /lint) over the shared
-// workspace, thin consumers of @mulmoclaude/core/wiki/server. Claude authors the wiki
-// via the real CLI in the terminal; MT's overlay only browses. Mounted before the /api
-// SPA fallback.
-mountWikiRoutes(app, { workspace: CLAUDE_CWD });
-
-// Accounting dispatch route (POST /api/accounting) from @mulmoclaude/accounting-plugin.
-// Drives BOTH the AccountingView (configureAccountingHost.apiCall) and the
-// manageAccounting host tool below. The engine is configured (workspace + pub/sub)
-// further down, once CLAUDE_CWD + pubsub exist.
-mountAccountingRoutes(app);
-
-// Collection Refresh route (POST /api/collections/:slug/refresh) from
-// @mulmoclaude/core/feeds — fetches declarative feeds or dispatches an agent-ingest
-// worker. Backs the collection-view Refresh button. The engine is configured below.
-mountFeedsRoutes(app);
-
-// Notification REST surface (list active / history, dismiss one) — backs the toolbar
-// bell. The engine is configured below once pubsub + the workspace exist.
-mountNotificationRoutes(app);
-
-// Scheduler REST surface (read-only list of user cron tasks) — backs a future tasks
-// UI. The tasks themselves are loaded + started below, once the spawn infra exists.
-mountSchedulerRoutes(app, { workspace: CLAUDE_CWD });
-
-// Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
-// fields and custom-view <img> URLs. Rooted at the shared workspace.
-mountFilesRoutes(app, { workspace: CLAUDE_CWD });
-
-// Serve presentHtml pages for the View's iframe (GET /artifacts/html/<rest>) with an
-// HTML preview CSP. The View navigates the iframe to this URL (htmlArtifactPreviewUrl).
-mountHtmlPreviewRoute(app, { workspace: CLAUDE_CWD });
-
-// Shared launcher favorites (GET/PUT /api/shortcuts) over the same
-// <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.
-mountShortcutsRoutes(app, { workspace: CLAUDE_CWD });
-
-// Local voice input (POST /api/transcribe + model status/download) — macOS only,
-// whisper.cpp via @mulmoclaude/core/whisper. Models live in the shared
-// <workspace>/models dir, so a download by either app is reused.
-mountWhisperRoutes(app, { workspace: CLAUDE_CWD });
-
-// Runtime UI-string translation (POST /api/translation), backing the shared
-// @mulmoclaude/core/translation/client. The HTTP contract + on-disk cache schema
-// match MulmoClaude (so the <workspace>/data/translation cache is shared between the
-// apps), but the LLM step is MulmoTerminal's own: translateViaHiddenChat spawns a
-// hidden background claude session (NEVER `claude -p`) and is filtered from the
-// sidebar (see session/translation-worker.ts).
-mountTranslationRoutes(app, { workspace: CLAUDE_CWD, translateBatch: translateViaHiddenChat });
-
-// The agent-facing MCP surface (routes/mcp-routes.ts): the in-process GUI MCP server over
-// Streamable HTTP, and the worker-only landing point the hidden translation worker reports to.
-mountMcpRoutes(app);
-
-// Serve Vite build output
-app.use(express.static(path.join(__dirname, "../dist")));
-
-// SPA fallback for vue-router history mode: a hard reload / deep-link of a client
-// route (e.g. /terminals, /collections/foo) must serve index.html. Mounted AFTER
-// express.static so real asset files win, and after the /artifacts/html preview
-// route (registered above) so it wins too. SPA_FALLBACK_RE reserves the single /api
-// prefix — see server/spa-fallback.ts for why that's sufficient.
-app.get(SPA_FALLBACK_RE, (_req, res) => res.sendFile(path.join(__dirname, "../dist/index.html")));
-
-// The Claude hook endpoint (routes/hook-routes.ts). Session lifecycle, the title
-// bookkeeping and the tool stores stay here; the fan-out that reads them moves out.
-mountHookRoute(app, {
-  setWorking: (id, working, event) => setWorking(id, working, event),
-  setWaiting: (id, waiting, event) => setWaiting(id, waiting, event),
-  publishActivity: (id) => publishActivity(id),
+mountAppRoutes(app, {
+  clientDir: __dirname,
+  isAllowedOrigin,
+  publish: (channel, data) => pubsub?.publish(channel, data),
+  sessionChannel,
+  toolStores,
+  toolSummaries,
+  spawnClaudePty,
+  spawnCodexPty,
+  translateViaHiddenChat,
+  freshenRosterTitle,
   forgetTitle,
   noteTitleTurn,
   maybeGenerateTitle,
-  recordToolCallStart,
-  recordToolCallEnd,
-  publishDirConfig: (cwd) => pubsub?.publish(DIR_CONFIG_CHANNEL, { cwd }),
-  // Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server,
-  // whose port the backend only knows when CLIENT_PORT is set in its environment.
-  uiPort: String(process.env.CLIENT_PORT || PORT),
-});
-
-// The tools pane: the toolResult sink, its replay, the available-tool list and the
-// call history (see routes/tool-routes.ts).
-mountToolRoutes(app, { stores: toolStores, toolSummaries, publish: (c, d) => pubsub?.publish(c, d), sessionChannel });
-
-// The /prs and /issues views (see routes/repo-routes.ts).
-mountRepoRoutes(app);
-
-// GET/POST /api/config (workspace dir + directory presets) — in its own module.
-// GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
-// modal's directory presets. The single view never calls it.
-mountConfigRoutes(app, CLAUDE_CWD);
-
-// Project-scoped file browsing + editing for the full-screen Files view
-// (GET /api/files/browse/{list,text,md}, PUT .../write — all ?cwd=&path=). Each
-// terminal browses its own session's project dir; paths are contained within it.
-mountFilesBrowseRoutes(app, { defaultCwd: CLAUDE_CWD });
-
-// Directory-scoped reads for a terminal cell: scripts, skills, dir config, git status,
-// PR phase, resolved header, custom sound. All keyed by ?cwd= (see routes/dir-routes.ts).
-mountDirRoutes(app);
-
-// GRID-ONLY (dev_tool): POST /api/open-dir reveals a cell's working directory in the
-// OS file manager (a browser tab can't, but this local server can).
-mountOpenDirRoute(app, { isAllowedOrigin });
-
-// GRID-ONLY (dev_tool): POST /api/git-remote reports a cell dir's GitHub repository
-// URL (null if it isn't a GitHub repo), so the header can offer an "open on GitHub" link.
-mountGitRemoteRoute(app, { isAllowedOrigin });
-
-// GRID-ONLY (dev_tool): /api/worktrees — detect a git repo, list/create/remove the
-// per-agent worktrees a cell launches into, so several agents work one repo in
-// isolated working trees.
-mountWorktreeRoutes(app, { isAllowedOrigin });
-
-// POST /api/pick-file opens the OS file dialog and returns the chosen absolute
-// path(s) — how a browser tab inserts a real filesystem path into the terminal
-// (the browser hides paths from drag/drop and <input type=file>).
-mountPickFileRoute(app, { isAllowedOrigin });
-
-// POST /api/command/summarize runs `claude -p` headless over a Run cell's captured
-// terminal output and returns a short Errors/Warnings/cause/fix summary (issue #246).
-// Same-origin guarded like the other local-action routes.
-mountCommandSummaryRoute(app, { isAllowedOrigin });
-
-// GET /api/cost — estimated $ cost (session + today/month roll-up) for a project's
-// sessions, from public per-model pricing. Read-only; shown in the Settings modal (#245).
-mountCostRoute(app, { resolveCwd: resolveWorkspace });
-
-// POST /api/remote-host/connect|disconnect + GET /status — start/stop the
-// Firestore host loop from the toolbar Connect control. Same-origin guarded like
-// the other local-only routes; the connect idToken is never logged.
-mountRemoteHostRoutes(app, { isAllowedOrigin });
-
-// GET /api/google/status + POST /api/google/authorize|unlink — the Settings modal's
-// Google account link. Consent needs a browser on THIS machine (loopback listener),
-// which is exactly the local-browser case; `mulmoterminal google login` is the
-// fallback for remote setups. Same-origin guarded; tokens never reach a response.
-mountGoogleRoutes(app, { isAllowedOrigin });
-
-// Sidebar listing, one session's detail, the grid's attention poll, the tool timeline and
-// codex's own sessions (see routes/session-routes.ts).
-mountSessionRoutes(app, { freshenRosterTitle });
-
-// Explicit close (reliable reap over HTTP) + one-shot orphan cleanup. Extracted to a
-// module so the origin guard / id validation / orphan-selection boundary are testable.
-// Shared by the orphan cleanup (which must never reap a resumable session) and the phone's
-// session picker (which must never OFFER a non-resumable one) — the same rule read from
-// both directions, so they can't drift apart.
-const resumableSessionPredicate = async (): Promise<(id: string) => boolean> => {
-  await devTerminalSessionsHydrated;
-  const live = new Set(ptys.keys());
-  const claudeOnDisk = claudeOnDiskSessionIds();
-  const codexRoot = codexSessionsRoot();
-  return (id) => isResumableTmuxSession(id, live, devTerminalSessions, claudeOnDisk, (i) => codexRolloutExists(codexRoot, i));
-};
-
-mountTmuxRoutes(app, {
-  isAllowedOrigin,
-  isValidSessionId: (id) => SESSION_ID_RE.test(id),
-  reapSession: reap,
-  hasTmux: tmuxHasSession,
-  killTmux: tmuxKillSession,
-  listTmuxIds: tmuxListSessionIds,
-  resumablePredicate: resumableSessionPredicate,
+  reap,
+  setWorking,
+  setWaiting,
+  publishActivity,
 });
 
 const server = http.createServer(app);

--- a/server/index.ts
+++ b/server/index.ts
@@ -21,7 +21,7 @@ import {
   isResumableTmuxSession,
 } from "./infra/tmux.js";
 import { mountTmuxRoutes } from "./infra/tmux-routes.js";
-import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage, cleanupSandbox } from "./infra/sandbox.js";
+import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage } from "./infra/sandbox.js";
 import { isAllowedOrigin } from "./infra/allowed-origin.js";
 import { serverErrorExit } from "./infra/server-exit.js";
 import { PORT, CLAUDE_CWD, MULMOTERMINAL_HOME, SESSION_ID_RE } from "./config/env.js";
@@ -40,30 +40,13 @@ import { mountPluginRoutes } from "./routes/plugin-routes.js";
 import { mountMcpRoutes } from "./routes/mcp-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
-import {
-  activity,
-  aiTitles,
-  devTerminalSessions,
-  devTerminalSessionsHydrated,
-  hiddenSessions,
-  knownSessions,
-  launchChoices,
-  lastPrompts,
-  lastResponses,
-  lastTitleAttemptMs,
-  lastTitledUserTurns,
-  persistActivityState,
-  ptys,
-  titleInFlight,
-} from "./session/registry.js";
-import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./session/reap-policy.js";
-import { nextActivity, sessionRow, shouldRefreshReply } from "./session/activity-transition.js";
+import { activity, aiTitles, devTerminalSessions, devTerminalSessionsHydrated, hiddenSessions, knownSessions, ptys } from "./session/registry.js";
 import { resolveWorkspace } from "./config/workspace.js";
 import { mountSessionRoutes } from "./routes/session-routes.js";
 import { createToolStores } from "./session/tool-store.js";
 import { mountToolRoutes } from "./routes/tool-routes.js";
 import { mountRepoRoutes } from "./routes/repo-routes.js";
-import { claudeOnDiskSessionIds, readLatestResponse } from "./session/session-reads.js";
+import { claudeOnDiskSessionIds } from "./session/session-reads.js";
 import { mountDirRoutes } from "./routes/dir-routes.js";
 import { createScheduledSessionRegistry, scheduledSessionInUse, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
@@ -71,7 +54,6 @@ import { codexAdapter } from "./agents/codex.js";
 import { codexSessionsRoot } from "./agents/codex-session.js";
 import { codexRolloutExists } from "./agents/codex-sessions.js";
 import { renderScreen } from "./session/headlessScreen.js";
-import { cleanupSessionSettings } from "./session/session-settings.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
 import { mountOpenDirRoute } from "./files/open-dir.js";
@@ -105,6 +87,7 @@ import { mountTranslationRoutes } from "./backends/translation.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "./backends/html.js";
 import { initMulmoScriptBackend, mountMulmoScriptDispatchRoute, mountMulmoScriptMediaRoute } from "./backends/mulmoscript.js";
 import { SPA_FALLBACK_RE } from "./infra/spa-fallback.js";
+import { createSessionLifecycle, SESSIONS_CHANNEL } from "./session/lifecycle.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 
@@ -134,7 +117,6 @@ initWorkspaceSetup({ workspace: CLAUDE_CWD });
 installConfigSkill();
 
 // Pub/sub channel the sidebar subscribes to for live session-activity changes.
-const SESSIONS_CHANNEL = "sessions";
 
 // Pub/sub channel telling the client a directory's .mulmoterminal.json changed, so it re-reads that
 // dir's config and recolours its cells without a page reload. Fed by the tool hooks, not a watcher.
@@ -165,11 +147,6 @@ const toolStores = createToolStores({
 });
 const { recordToolCallStart, recordToolCallEnd } = toolStores;
 
-function refreshLastResponse(id: string, cwd: string): void {
-  const text = readLatestResponse(id, cwd);
-  if (text) lastResponses.set(id, text); // a failed read leaves any prior value
-}
-
 // Bytes of recent output kept per pty and replayed when a client reattaches to
 // a background session, so the user sees context instead of a blank screen.
 const OUTPUT_BUFFER_LIMIT = 64 * 1024;
@@ -182,67 +159,6 @@ let pubsub: ReturnType<typeof createPubSub> | null = null;
 // what keeps a finished/needs-attention background session bold (via its
 // on-disk record) until the user opens it. This keeps `activity` from growing
 // unbounded while preserving the bold-until-viewed behavior.
-// On disconnect we don't kill an idle session immediately — a page reload is a
-// brief disconnect, and reaping then would throw away a perfectly good live
-// terminal (and its scrollback). Instead we keep the pty for a grace window; a
-// reattach within it cancels the reap, so a reload just re-attaches to the same
-// running terminal. Only after the window with no reattach do we reap.
-const REAP_GRACE_MS = 30_000;
-// A detached session that still needs the user — mid-turn output the user hasn't
-// seen, or blocked on a permission/question prompt (the `waiting` flag) — is an
-// unfinished task: reaping it loses work. So it gets a much longer grace than an
-// idle one, long enough that you can switch away, do other things, and come back
-// to answer it. Override with WAIT_REAP_GRACE_MS=0 to never auto-close these.
-const WAIT_REAP_GRACE_DEFAULT_MS = 30 * 60_000;
-const WAIT_REAP_GRACE_MS = parseWaitGraceMs(process.env.WAIT_REAP_GRACE_MS, WAIT_REAP_GRACE_DEFAULT_MS, (raw) =>
-  console.warn(`[pty] ignoring non-numeric WAIT_REAP_GRACE_MS=${JSON.stringify(raw)}; using default ${WAIT_REAP_GRACE_DEFAULT_MS}ms`),
-);
-const reapTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
-function cancelReap(id: string) {
-  const t = reapTimers.get(id);
-  if (t) {
-    clearTimeout(t);
-    reapTimers.delete(id);
-  }
-}
-
-function scheduleReap(id: string, delayMs: number = REAP_GRACE_MS) {
-  // null => never auto-reap; the session stays until reattached or explicitly
-  // terminated (see reapTimerDelay for why a bad value must not reach setTimeout).
-  const delay = reapTimerDelay(delayMs);
-  if (delay === null) return;
-  if (reapTimers.has(id)) return;
-  reapTimers.set(
-    id,
-    setTimeout(() => {
-      reapTimers.delete(id);
-      const entry = ptys.get(id);
-      if (entry && !entry.ws) reap(id); // still detached after the grace window
-    }, delay),
-  );
-}
-
-// Decide whether/when to reap a detached session based on its activity. A session
-// that's actively thinking (`working`) is never reaped — that's "clearly working,
-// don't close it". One that needs the user (`waiting`) gets the long grace. A
-// genuinely idle session (finished AND already viewed, so neither flag) gets the
-// short grace — that's the "auto-close inactive ones" behaviour. The ordering rule
-// lives in reapDecisionFor (pure/tested).
-function armReapForDetached(id: string) {
-  const entry = ptys.get(id);
-  if (!entry || entry.ws) return; // still attached: nothing to reap
-  // Recompute from scratch: state may have escalated (idle -> waiting) since the
-  // last arm, and a stale short timer must not survive to reap a session that now
-  // needs the user. cancelReap clears it so scheduleReap re-arms with the right grace.
-  cancelReap(id);
-  const decision = reapDecisionFor(activity.get(id), { idleMs: REAP_GRACE_MS, waitingMs: WAIT_REAP_GRACE_MS });
-  if (decision.kind === "keep") {
-    console.log(`[pty] keeping working session ${id} alive (detached)`);
-    return;
-  }
-  scheduleReap(id, decision.delayMs);
-}
 
 // Per-connection plumbing (session/pty-connection.ts). The reap decisions stay here —
 // they read activity state and schedule timers that outlive any one connection.
@@ -252,43 +168,6 @@ const { reattachPty, handleClientFrame, handleClientClose } = createConnectionHa
   setWaiting: (id, waiting) => setWaiting(id, waiting),
   armReapForDetached: (id) => armReapForDetached(id),
 });
-
-function reap(id: string) {
-  cancelReap(id);
-  const entry = ptys.get(id);
-  if (!entry) return; // already reaped
-  ptys.delete(id);
-  // An unpersisted new session vanishes with its pty; a persisted one stays
-  // visible via its on-disk record.
-  knownSessions.delete(id);
-  launchChoices.delete(id); // the picked backend dies with the session that used it
-  lastPrompts.delete(id); // don't leak prompt text for torn-down sessions
-  lastResponses.delete(id); // ditto, and keep this map from growing across closed sessions
-  forgetTitle(id);
-  sessionActivityPublisher.forget(id); // drop the phone's copy so its picker has no ghosts
-  titleInFlight.delete(id);
-  lastTitledUserTurns.delete(id); // teardown only — kept across /clear as the re-title baseline
-  lastTitleAttemptMs.delete(id);
-  if (shouldForgetActivity(activity.get(id))) {
-    activity.delete(id);
-    hiddenSessions.delete(id); // the hidden flag rides with the record — see shouldForgetActivity
-  }
-  try {
-    entry.term.kill();
-  } catch {
-    // already gone
-  }
-  // Killing the pty only DETACHES a tmux client — end the tmux session too so an
-  // explicit close / idle reap actually stops the program (no orphan within a live
-  // server). A server crash never runs this, so sessions survive that (the point).
-  if (entry.tmux) tmuxKillSession(id);
-  // A sandbox container likewise outlives its killed `docker run` client — force-remove
-  // it (and drop the throwaway per-session config).
-  if (entry.sandbox) cleanupSandbox(id);
-  // A provider session's settings file holds its token — drop it with the session (#579).
-  cleanupSessionSettings(id);
-  pubsub?.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed" });
-}
 
 // Mirrors session activity into Firestore so the phone's terminal viewer can refresh
 // on a real transition instead of polling (#439). Deduped and fire-and-forget inside;
@@ -300,21 +179,14 @@ const sessionActivityPublisher = createSessionActivityPublisher({
   onError: (err) => console.warn("[remote-host] session activity publish failed:", err),
 });
 
-// Publish a session's current activity (working + waiting) to subscribers.
-function publishActivity(id: string) {
-  const a = activity.get(id);
-  // `cwd` rides along so the attention-sound player can pick up that directory's custom
-  // sound (<cwd>/.mulmoterminal.json). Null for a session with no live PTY.
-  const cwd = ptys.get(id)?.cwd ?? null;
-  if (shouldRefreshReply(a, cwd)) refreshLastResponse(id, cwd);
-  const row = sessionRow(id, a, cwd, {
-    lastPrompt: lastPrompts.get(id),
-    aiTitle: aiTitles.get(id),
-    lastResponse: lastResponses.get(id),
-  });
-  sessionActivityPublisher.publish(id, { working: row.working, waiting: row.waiting });
-  pubsub?.publish(SESSIONS_CHANNEL, row);
-}
+// Session teardown + activity publishing (session/lifecycle.ts). `forgetTitle` is bound
+// lazily because the title manager below needs publishActivity — the cycle is real.
+const lifecycle = createSessionLifecycle({
+  publish: (channel, data) => pubsub?.publish(channel, data),
+  forgetTitle: (id) => forgetTitle(id),
+  sessionActivityPublisher,
+});
+const { cancelReap, reap, armReapForDetached, publishActivity, setWorking, setWaiting } = lifecycle;
 
 // AI-title bookkeeping (session/session-title.ts). publishActivity stays here — it
 // publishes the whole session row, of which the title is one field.
@@ -323,40 +195,6 @@ const { forgetTitle, noteTitleTurn, maybeGenerateTitle, freshenRosterTitle } = c
   now: () => Date.now(),
   generateTitle: (raw) => generateHeaderTitle(raw),
 });
-
-// Claude is thinking (UserPromptSubmit) until it finishes (Stop). No-op (and no
-// publish) when the state is unchanged.
-function setWorking(id: string, working: boolean, event?: string) {
-  const next = nextActivity(activity.get(id), { working }, event, Date.now());
-  if (!next) return;
-  activity.set(id, next);
-  publishActivity(id);
-  // Persist `working` so an in-progress turn survives a restart (see ACTIVITY_STATE_FILE).
-  persistActivityState((id) => hiddenSessions.has(id));
-
-  // A background session (no attached client) that just finished a turn is no
-  // longer `working`. Don't kill it outright — if it ended its turn to ask the
-  // user something (it'll be flagged `waiting`), reaping now would lose the task
-  // before the user can answer. Arm a reap whose grace matches its state.
-  if (!working) armReapForDetached(id);
-}
-
-// A background session needs the user's attention: it is waiting for input
-// (Notification: permission / question / idle) or has finished a turn with
-// output the user hasn't seen (Stop). Cleared when brought to the foreground
-// (see the WebSocket connection handler).
-function setWaiting(id: string, waiting: boolean, event?: string) {
-  const next = nextActivity(activity.get(id), { waiting }, event, Date.now());
-  if (!next) return;
-  activity.set(id, next);
-  publishActivity(id);
-  // Persist the blocked/done set so it survives a server restart (see ACTIVITY_STATE_FILE).
-  persistActivityState((id) => hiddenSessions.has(id));
-
-  // A detached session that just started needing the user escalates from the short
-  // idle grace to the long one — re-arm so it isn't reaped before they can return.
-  if (waiting) armReapForDetached(id);
-}
 
 // The PTY spawners (session/spawn-*.ts). They take what index.ts still owns — the session
 // lifecycle it drives, and this file's port and live user config bound into the two payload

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -1,0 +1,280 @@
+// Everything this server answers over HTTP, in the order the middleware stack needs.
+//
+// Moved out of index.ts (#548): a table of ~40 mount calls is a list of what exists, not a
+// decision, and reading index.ts should not mean scrolling past it to reach the parts that
+// do decide something. The ORDER still matters and is preserved exactly — the plugin tool
+// routes must precede mountAllRoutes' /api/plugin/:toolName catch-all, and the SPA fallback
+// must come after the static mount.
+//
+// What arrives as deps is what index.ts owns: the spawners, the session lifecycle, the title
+// manager, the tool stores, and `publish` (pub/sub exists only once the HTTP server does).
+import path from "node:path";
+import express, { type Express } from "express";
+import { mountAllRoutes } from "../infra/plugins-registry.js";
+import { mountConfigRoutes } from "../config/config-routes.js";
+import { mountFilesBrowseRoutes } from "../files/files-browse.js";
+import { mountTmuxRoutes } from "../infra/tmux-routes.js";
+import { mountHookRoute } from "../routes/hook-routes.js";
+import { mountPluginRoutes } from "../routes/plugin-routes.js";
+import { mountMcpRoutes } from "../routes/mcp-routes.js";
+import { mountSessionRoutes } from "../routes/session-routes.js";
+import { mountToolRoutes } from "../routes/tool-routes.js";
+import { mountRepoRoutes } from "../routes/repo-routes.js";
+import { mountDirRoutes } from "../routes/dir-routes.js";
+import { mountOpenDirRoute } from "../files/open-dir.js";
+import { mountGitRemoteRoute } from "../git/gitRemote.js";
+import { mountWorktreeRoutes } from "../git/worktree-routes.js";
+import { mountPickFileRoute } from "../files/pick-file.js";
+import { mountCommandSummaryRoute } from "../session/command-summary.js";
+import { mountCostRoute } from "../session/cost.js";
+import { mountCollectionRoutes } from "../backends/collections.js";
+import { mountGoogleRoutes } from "../backends/google.js";
+import { mountWikiRoutes } from "../backends/wiki.js";
+import { mountAccountingRoutes } from "../backends/accounting.js";
+import { mountFeedsRoutes } from "../backends/feeds.js";
+import { mountRemoteHostRoutes } from "../backends/remoteHost/index.js";
+import { mountNotificationRoutes } from "../backends/notifier.js";
+import { mountWhisperRoutes } from "../backends/whisper.js";
+import { mountSchedulerRoutes } from "../backends/scheduler.js";
+import { mountFilesRoutes } from "../backends/files.js";
+import { mountShortcutsRoutes } from "../backends/shortcuts.js";
+import { mountTranslationRoutes } from "../backends/translation.js";
+import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "../backends/html.js";
+import { mountMulmoScriptDispatchRoute, mountMulmoScriptMediaRoute } from "../backends/mulmoscript.js";
+import { CLAUDE_CWD, PORT, SESSION_ID_RE } from "../config/env.js";
+import { resolveWorkspace } from "../config/workspace.js";
+import type { createToolStores } from "../session/tool-store.js";
+import type { createClaudeSpawner } from "../session/spawn-claude.js";
+import type { createCodexSpawner } from "../session/spawn-codex.js";
+import type { createTranslationWorker } from "../session/translation-worker.js";
+import type { createTitleManager } from "../session/session-title.js";
+import { tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "../infra/tmux.js";
+import { resumableSessionPredicate } from "../session/resumable-sessions.js";
+import { SPA_FALLBACK_RE } from "../infra/spa-fallback.js";
+
+export interface AppRouteDeps {
+  clientDir: string;
+  isAllowedOrigin: (origin: string | undefined) => boolean;
+  publish: (channel: string, data: unknown) => void;
+  sessionChannel: (id: string) => string;
+  toolStores: ReturnType<typeof createToolStores>;
+  toolSummaries: Parameters<typeof mountToolRoutes>[1]["toolSummaries"];
+  spawnClaudePty: ReturnType<typeof createClaudeSpawner>["spawnClaudePty"];
+  spawnCodexPty: ReturnType<typeof createCodexSpawner>["spawnCodexPty"];
+  translateViaHiddenChat: ReturnType<typeof createTranslationWorker>["translateViaHiddenChat"];
+  freshenRosterTitle: ReturnType<typeof createTitleManager>["freshenRosterTitle"];
+  forgetTitle: (id: string) => void;
+  noteTitleTurn: (id: string, prompt: string) => void;
+  maybeGenerateTitle: (id: string, cwd: string | undefined) => Promise<void>;
+  reap: (id: string) => void;
+  setWorking: (id: string, working: boolean, event?: string) => void;
+  setWaiting: (id: string, waiting: boolean, event?: string) => void;
+  publishActivity: (id: string) => void;
+}
+
+// The channel a directory-config change is announced on.
+const DIR_CONFIG_CHANNEL = "dir-config";
+
+export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
+  const clientDir = deps.clientDir;
+  app.use(express.json({ limit: "25mb" }));
+
+  // The GUI-plugin tool routes this server answers itself: spawnBackgroundChat,
+  // manageAccounting, manageCollection (routes/plugin-routes.ts). ALL of them must precede
+  // mountAllRoutes' /api/plugin/:toolName catch-all below, which would otherwise take them.
+  mountPluginRoutes(app, { spawnClaudePty: deps.spawnClaudePty, spawnCodexPty: deps.spawnCodexPty });
+
+  // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
+  // /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName
+  // catch-all (which handles the tool-call); a request without `kind` falls through.
+  mountHtmlDispatchRoute(app);
+
+  // presentMulmoScript: the View's dispatch (kind router) AND the tool-call both
+  // handled by the mulmoscript backend (realpath guard + autoGenerateMovie trigger
+  // the generic catch-all lacks). MUST precede mountAllRoutes. The media route
+  // (movie/PDF bytes for the View's fetchMediaBlob) has its own path.
+  mountMulmoScriptDispatchRoute(app);
+  mountMulmoScriptMediaRoute(app);
+
+  // Mount each enabled GUI plugin's REST routes (e.g. POST /api/markdown,
+  // POST /api/form). The GUI MCP server dispatches tool calls to these.
+  mountAllRoutes(app);
+
+  // Read-side collection routes (GET /api/collections/list + /:slug/detail) over the
+  // shared workspace, backing the @mulmoclaude/collection-plugin presentCollection
+  // card and (later) the collections toolbar. The engine itself is configured below
+  // once CLAUDE_CWD is the confirmed workspace.
+  mountCollectionRoutes(app);
+
+  // Read-only wiki routes (GET /api/wiki[?slug=] + /graph + /lint) over the shared
+  // workspace, thin consumers of @mulmoclaude/core/wiki/server. Claude authors the wiki
+  // via the real CLI in the terminal; MT's overlay only browses. Mounted before the /api
+  // SPA fallback.
+  mountWikiRoutes(app, { workspace: CLAUDE_CWD });
+
+  // Accounting dispatch route (POST /api/accounting) from @mulmoclaude/accounting-plugin.
+  // Drives BOTH the AccountingView (configureAccountingHost.apiCall) and the
+  // manageAccounting host tool below. The engine is configured (workspace + pub/sub)
+  // further down, once CLAUDE_CWD + pubsub exist.
+  mountAccountingRoutes(app);
+
+  // Collection Refresh route (POST /api/collections/:slug/refresh) from
+  // @mulmoclaude/core/feeds — fetches declarative feeds or dispatches an agent-ingest
+  // worker. Backs the collection-view Refresh button. The engine is configured below.
+  mountFeedsRoutes(app);
+
+  // Notification REST surface (list active / history, dismiss one) — backs the toolbar
+  // bell. The engine is configured below once pubsub + the workspace exist.
+  mountNotificationRoutes(app);
+
+  // Scheduler REST surface (read-only list of user cron tasks) — backs a future tasks
+  // UI. The tasks themselves are loaded + started below, once the spawn infra exists.
+  mountSchedulerRoutes(app, { workspace: CLAUDE_CWD });
+
+  // Raw workspace-file serving (GET /api/files/raw?path=) — backs collection image/file
+  // fields and custom-view <img> URLs. Rooted at the shared workspace.
+  mountFilesRoutes(app, { workspace: CLAUDE_CWD });
+
+  // Serve presentHtml pages for the View's iframe (GET /artifacts/html/<rest>) with an
+  // HTML preview CSP. The View navigates the iframe to this URL (htmlArtifactPreviewUrl).
+  mountHtmlPreviewRoute(app, { workspace: CLAUDE_CWD });
+
+  // Shared launcher favorites (GET/PUT /api/shortcuts) over the same
+  // <workspace>/config/shortcuts.json MulmoClaude uses — backs the collections toolbar.
+  mountShortcutsRoutes(app, { workspace: CLAUDE_CWD });
+
+  // Local voice input (POST /api/transcribe + model status/download) — macOS only,
+  // whisper.cpp via @mulmoclaude/core/whisper. Models live in the shared
+  // <workspace>/models dir, so a download by either app is reused.
+  mountWhisperRoutes(app, { workspace: CLAUDE_CWD });
+
+  // Runtime UI-string translation (POST /api/translation), backing the shared
+  // @mulmoclaude/core/translation/client. The HTTP contract + on-disk cache schema
+  // match MulmoClaude (so the <workspace>/data/translation cache is shared between the
+  // apps), but the LLM step is MulmoTerminal's own: deps.translateViaHiddenChat spawns a
+  // hidden background claude session (NEVER `claude -p`) and is filtered from the
+  // sidebar (see session/translation-worker.ts).
+  mountTranslationRoutes(app, { workspace: CLAUDE_CWD, translateBatch: deps.translateViaHiddenChat });
+
+  // The agent-facing MCP surface (routes/mcp-routes.ts): the in-process GUI MCP server over
+  // Streamable HTTP, and the worker-only landing point the hidden translation worker reports to.
+  mountMcpRoutes(app);
+
+  // Serve Vite build output
+  app.use(express.static(path.join(clientDir, "../dist")));
+
+  // SPA fallback for vue-router history mode: a hard reload / deep-link of a client
+  // route (e.g. /terminals, /collections/foo) must serve index.html. Mounted AFTER
+  // express.static so real asset files win, and after the /artifacts/html preview
+  // route (registered above) so it wins too. SPA_FALLBACK_RE reserves the single /api
+  // prefix — see server/spa-fallback.ts for why that's sufficient.
+  app.get(SPA_FALLBACK_RE, (_req, res) => res.sendFile(path.join(clientDir, "../dist/index.html")));
+
+  // The Claude hook endpoint (routes/hook-routes.ts). Session lifecycle, the title
+  // bookkeeping and the tool stores stay here; the fan-out that reads them moves out.
+  mountSessionFacingRoutes(app, deps);
+}
+
+// The session-facing half: hooks, tool history, and everything the browser asks about a
+// directory or a repository. Split from the block above only to keep each readable — the
+// order across the two is still the order they are mounted in.
+function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
+  mountHookRoute(app, {
+    setWorking: (id, working, event) => deps.setWorking(id, working, event),
+    setWaiting: (id, waiting, event) => deps.setWaiting(id, waiting, event),
+    publishActivity: (id) => deps.publishActivity(id),
+    forgetTitle: deps.forgetTitle,
+    noteTitleTurn: deps.noteTitleTurn,
+    maybeGenerateTitle: deps.maybeGenerateTitle,
+    recordToolCallStart: deps.toolStores.recordToolCallStart,
+    recordToolCallEnd: deps.toolStores.recordToolCallEnd,
+    publishDirConfig: (cwd) => deps.publish(DIR_CONFIG_CHANNEL, { cwd }),
+    // Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server,
+    // whose port the backend only knows when CLIENT_PORT is set in its environment.
+    uiPort: String(process.env.CLIENT_PORT || PORT),
+  });
+
+  // The tools pane: the toolResult sink, its replay, the available-tool list and the
+  // call history (see routes/tool-routes.ts).
+  mountToolRoutes(app, {
+    stores: deps.toolStores,
+    toolSummaries: deps.toolSummaries,
+    publish: (c, d) => deps.publish(c, d),
+    sessionChannel: deps.sessionChannel,
+  });
+
+  // The /prs and /issues views (see routes/repo-routes.ts).
+  mountRepoRoutes(app);
+
+  // GET/POST /api/config (workspace dir + directory presets) — in its own module.
+  // GRID-ONLY (dev_tool): backs the grid launcher's default dir + the settings
+  // modal's directory presets. The single view never calls it.
+  mountConfigRoutes(app, CLAUDE_CWD);
+
+  // Project-scoped file browsing + editing for the full-screen Files view
+  // (GET /api/files/browse/{list,text,md}, PUT .../write — all ?cwd=&path=). Each
+  // terminal browses its own session's project dir; paths are contained within it.
+  mountFilesBrowseRoutes(app, { defaultCwd: CLAUDE_CWD });
+
+  // Directory-scoped reads for a terminal cell: scripts, skills, dir config, git status,
+  // PR phase, resolved header, custom sound. All keyed by ?cwd= (see routes/dir-routes.ts).
+  mountDirRoutes(app);
+
+  // GRID-ONLY (dev_tool): POST /api/open-dir reveals a cell's working directory in the
+  // OS file manager (a browser tab can't, but this local server can).
+  mountOpenDirRoute(app, { isAllowedOrigin: deps.isAllowedOrigin });
+
+  // GRID-ONLY (dev_tool): POST /api/git-remote reports a cell dir's GitHub repository
+  // URL (null if it isn't a GitHub repo), so the header can offer an "open on GitHub" link.
+  mountGitRemoteRoute(app, { isAllowedOrigin: deps.isAllowedOrigin });
+
+  // GRID-ONLY (dev_tool): /api/worktrees — detect a git repo, list/create/remove the
+  // per-agent worktrees a cell launches into, so several agents work one repo in
+  // isolated working trees.
+  mountWorktreeRoutes(app, { isAllowedOrigin: deps.isAllowedOrigin });
+
+  // POST /api/pick-file opens the OS file dialog and returns the chosen absolute
+  // path(s) — how a browser tab inserts a real filesystem path into the terminal
+  // (the browser hides paths from drag/drop and <input type=file>).
+  mountPickFileRoute(app, { isAllowedOrigin: deps.isAllowedOrigin });
+
+  // POST /api/command/summarize runs `claude -p` headless over a Run cell's captured
+  // terminal output and returns a short Errors/Warnings/cause/fix summary (issue #246).
+  // Same-origin guarded like the other local-action routes.
+  mountCommandSummaryRoute(app, { isAllowedOrigin: deps.isAllowedOrigin });
+
+  // GET /api/cost — estimated $ cost (session + today/month roll-up) for a project's
+  // sessions, from public per-model pricing. Read-only; shown in the Settings modal (#245).
+  mountCostRoute(app, { resolveCwd: resolveWorkspace });
+
+  // POST /api/remote-host/connect|disconnect + GET /status — start/stop the
+  // Firestore host loop from the toolbar Connect control. Same-origin guarded like
+  // the other local-only routes; the connect idToken is never logged.
+  mountRemoteHostRoutes(app, { isAllowedOrigin: deps.isAllowedOrigin });
+
+  // GET /api/google/status + POST /api/google/authorize|unlink — the Settings modal's
+  // Google account link. Consent needs a browser on THIS machine (loopback listener),
+  // which is exactly the local-browser case; `mulmoterminal google login` is the
+  // fallback for remote setups. Same-origin guarded; tokens never reach a response.
+  mountGoogleRoutes(app, { isAllowedOrigin: deps.isAllowedOrigin });
+
+  // Sidebar listing, one session's detail, the grid's attention poll, the tool timeline and
+  // codex's own sessions (see routes/session-routes.ts).
+  mountSessionRoutes(app, { freshenRosterTitle: deps.freshenRosterTitle });
+
+  // Explicit close (reliable deps.reap over HTTP) + one-shot orphan cleanup. Extracted to a
+  // module so the origin guard / id validation / orphan-selection boundary are testable.
+  // Shared by the orphan cleanup (which must never deps.reap a resumable session) and the phone's
+  // session picker (which must never OFFER a non-resumable one) — the same rule read from
+  // both directions, so they can't drift apart.
+
+  mountTmuxRoutes(app, {
+    isAllowedOrigin: deps.isAllowedOrigin,
+    isValidSessionId: (id) => SESSION_ID_RE.test(id),
+    reapSession: deps.reap,
+    hasTmux: tmuxHasSession,
+    killTmux: tmuxKillSession,
+    listTmuxIds: tmuxListSessionIds,
+    resumablePredicate: resumableSessionPredicate,
+  });
+}

--- a/server/session/lifecycle.ts
+++ b/server/session/lifecycle.ts
@@ -1,0 +1,217 @@
+// When a session dies, and who is told about its state.
+//
+// The last stateful thing index.ts owned. The DECISIONS inside were extracted and tested
+// earlier (#548): reapDecisionFor picks the grace window, shouldForgetActivity decides what
+// survives a teardown, nextActivity folds a flag change. What was left is the part that holds
+// timers and calls them in the right order — which is exactly the part that could not be
+// reached without booting the server.
+//
+// Three things arrive as deps rather than imports, for the same reason each did in index.ts:
+//
+//   publish — pub/sub only exists once the HTTP server does, and this is built before it.
+//   forgetTitle — the title manager needs publishActivity, and reap needs forgetTitle. The
+//     cycle is real; binding it late is how index.ts already broke it.
+//   sessionActivityPublisher — the phone mirror, which needs Firestore credentials.
+//
+// Everything else is the shared session registry, which is imported directly.
+import {
+  activity,
+  aiTitles,
+  hiddenSessions,
+  knownSessions,
+  lastPrompts,
+  lastResponses,
+  lastTitleAttemptMs,
+  lastTitledUserTurns,
+  launchChoices,
+  persistActivityState,
+  ptys,
+  titleInFlight,
+} from "./registry.js";
+import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./reap-policy.js";
+import { nextActivity, sessionRow, shouldRefreshReply } from "./activity-transition.js";
+import { readLatestResponse } from "./session-reads.js";
+import { cleanupSessionSettings } from "./session-settings.js";
+import { cleanupSandbox } from "../infra/sandbox.js";
+import { tmuxKillSession } from "../infra/tmux.js";
+
+// The channel every session row is published on.
+export const SESSIONS_CHANNEL = "sessions";
+
+export interface SessionLifecycleDeps {
+  /** Fan a row out to subscribers; a no-op before pub/sub exists. */
+  publish: (channel: string, data: unknown) => void;
+  /** Drop a session's AI title so the next turn regenerates it. */
+  forgetTitle: (id: string) => void;
+  /** Mirror of working/waiting for the phone's viewer. */
+  sessionActivityPublisher: { publish: (id: string, state: { working: boolean; waiting: boolean }) => void; forget: (id: string) => void };
+}
+
+// Timers live per process, not per factory call — there is one server.
+const reapTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function refreshLastResponse(id: string, cwd: string): void {
+  const text = readLatestResponse(id, cwd);
+  if (text) lastResponses.set(id, text); // a failed read leaves any prior value
+}
+
+// On disconnect we don't kill an idle session immediately — a page reload is a
+// brief disconnect, and reaping then would throw away a perfectly good live
+// terminal (and its scrollback). Instead we keep the pty for a grace window; a
+// reattach within it cancels the reap, so a reload just re-attaches to the same
+// running terminal. Only after the window with no reattach do we reap.
+const REAP_GRACE_MS = 30_000;
+// A detached session that still needs the user — mid-turn output the user hasn't
+// seen, or blocked on a permission/question prompt (the `waiting` flag) — is an
+// unfinished task: reaping it loses work. So it gets a much longer grace than an
+// idle one, long enough that you can switch away, do other things, and come back
+// to answer it. Override with WAIT_REAP_GRACE_MS=0 to never auto-close these.
+const WAIT_REAP_GRACE_DEFAULT_MS = 30 * 60_000;
+const WAIT_REAP_GRACE_MS = parseWaitGraceMs(process.env.WAIT_REAP_GRACE_MS, WAIT_REAP_GRACE_DEFAULT_MS, (raw) =>
+  console.warn(`[pty] ignoring non-numeric WAIT_REAP_GRACE_MS=${JSON.stringify(raw)}; using default ${WAIT_REAP_GRACE_DEFAULT_MS}ms`),
+);
+
+function cancelReap(id: string) {
+  const t = reapTimers.get(id);
+  if (t) {
+    clearTimeout(t);
+    reapTimers.delete(id);
+  }
+}
+
+function scheduleReap(deps: SessionLifecycleDeps, id: string, delayMs: number = REAP_GRACE_MS) {
+  // null => never auto-reap; the session stays until reattached or explicitly
+  // terminated (see reapTimerDelay for why a bad value must not reach setTimeout).
+  const delay = reapTimerDelay(delayMs);
+  if (delay === null) return;
+  if (reapTimers.has(id)) return;
+  reapTimers.set(
+    id,
+    setTimeout(() => {
+      reapTimers.delete(id);
+      const entry = ptys.get(id);
+      if (entry && !entry.ws) reap(deps, id); // still detached after the grace window
+    }, delay),
+  );
+}
+
+// Decide whether/when to reap a detached session based on its activity. A session
+// that's actively thinking (`working`) is never reaped — that's "clearly working,
+// don't close it". One that needs the user (`waiting`) gets the long grace. A
+// genuinely idle session (finished AND already viewed, so neither flag) gets the
+// short grace — that's the "auto-close inactive ones" behaviour. The ordering rule
+// lives in reapDecisionFor (pure/tested).
+function armReapForDetached(deps: SessionLifecycleDeps, id: string) {
+  const entry = ptys.get(id);
+  if (!entry || entry.ws) return; // still attached: nothing to reap
+  // Recompute from scratch: state may have escalated (idle -> waiting) since the
+  // last arm, and a stale short timer must not survive to reap a session that now
+  // needs the user. cancelReap clears it so scheduleReap re-arms with the right grace.
+  cancelReap(id);
+  const decision = reapDecisionFor(activity.get(id), { idleMs: REAP_GRACE_MS, waitingMs: WAIT_REAP_GRACE_MS });
+  if (decision.kind === "keep") {
+    console.log(`[pty] keeping working session ${id} alive (detached)`);
+    return;
+  }
+  scheduleReap(deps, id, decision.delayMs);
+}
+
+function reap(deps: SessionLifecycleDeps, id: string) {
+  cancelReap(id);
+  const entry = ptys.get(id);
+  if (!entry) return; // already reaped
+  ptys.delete(id);
+  // An unpersisted new session vanishes with its pty; a persisted one stays
+  // visible via its on-disk record.
+  knownSessions.delete(id);
+  launchChoices.delete(id); // the picked backend dies with the session that used it
+  lastPrompts.delete(id); // don't leak prompt text for torn-down sessions
+  lastResponses.delete(id); // ditto, and keep this map from growing across closed sessions
+  deps.forgetTitle(id);
+  deps.sessionActivityPublisher.forget(id); // drop the phone's copy so its picker has no ghosts
+  titleInFlight.delete(id);
+  lastTitledUserTurns.delete(id); // teardown only — kept across /clear as the re-title baseline
+  lastTitleAttemptMs.delete(id);
+  if (shouldForgetActivity(activity.get(id))) {
+    activity.delete(id);
+    hiddenSessions.delete(id); // the hidden flag rides with the record — see shouldForgetActivity
+  }
+  try {
+    entry.term.kill();
+  } catch {
+    // already gone
+  }
+  // Killing the pty only DETACHES a tmux client — end the tmux session too so an
+  // explicit close / idle reap actually stops the program (no orphan within a live
+  // server). A server crash never runs this, so sessions survive that (the point).
+  if (entry.tmux) tmuxKillSession(id);
+  // A sandbox container likewise outlives its killed `docker run` client — force-remove
+  // it (and drop the throwaway per-session config).
+  if (entry.sandbox) cleanupSandbox(id);
+  // A provider session's settings file holds its token — drop it with the session (#579).
+  cleanupSessionSettings(id);
+  deps.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed" });
+}
+
+// Publish a session's current activity (working + waiting) to subscribers.
+function publishActivity(deps: SessionLifecycleDeps, id: string) {
+  const a = activity.get(id);
+  // `cwd` rides along so the attention-sound player can pick up that directory's custom
+  // sound (<cwd>/.mulmoterminal.json). Null for a session with no live PTY.
+  const cwd = ptys.get(id)?.cwd ?? null;
+  if (shouldRefreshReply(a, cwd)) refreshLastResponse(id, cwd);
+  const row = sessionRow(id, a, cwd, {
+    lastPrompt: lastPrompts.get(id),
+    aiTitle: aiTitles.get(id),
+    lastResponse: lastResponses.get(id),
+  });
+  deps.sessionActivityPublisher.publish(id, { working: row.working, waiting: row.waiting });
+  deps.publish(SESSIONS_CHANNEL, row);
+}
+
+// Claude is thinking (UserPromptSubmit) until it finishes (Stop). No-op (and no
+// publish) when the state is unchanged.
+function setWorking(deps: SessionLifecycleDeps, id: string, working: boolean, event?: string) {
+  const next = nextActivity(activity.get(id), { working }, event, Date.now());
+  if (!next) return;
+  activity.set(id, next);
+  publishActivity(deps, id);
+  // Persist `working` so an in-progress turn survives a restart (see ACTIVITY_STATE_FILE).
+  persistActivityState((id) => hiddenSessions.has(id));
+
+  // A background session (no attached client) that just finished a turn is no
+  // longer `working`. Don't kill it outright — if it ended its turn to ask the
+  // user something (it'll be flagged `waiting`), reaping now would lose the task
+  // before the user can answer. Arm a reap whose grace matches its state.
+  if (!working) armReapForDetached(deps, id);
+}
+
+// A background session needs the user's attention: it is waiting for input
+// (Notification: permission / question / idle) or has finished a turn with
+// output the user hasn't seen (Stop). Cleared when brought to the foreground
+// (see the WebSocket connection handler).
+function setWaiting(deps: SessionLifecycleDeps, id: string, waiting: boolean, event?: string) {
+  const next = nextActivity(activity.get(id), { waiting }, event, Date.now());
+  if (!next) return;
+  activity.set(id, next);
+  publishActivity(deps, id);
+  // Persist the blocked/done set so it survives a server restart (see ACTIVITY_STATE_FILE).
+  persistActivityState((id) => hiddenSessions.has(id));
+
+  // A detached session that just started needing the user escalates from the short
+  // idle grace to the long one — re-arm so it isn't reaped before they can return.
+  if (waiting) armReapForDetached(deps, id);
+}
+
+export function createSessionLifecycle(deps: SessionLifecycleDeps) {
+  return {
+    refreshLastResponse,
+    cancelReap,
+    scheduleReap: (id: string, delayMs?: number) => scheduleReap(deps, id, delayMs),
+    armReapForDetached: (id: string) => armReapForDetached(deps, id),
+    reap: (id: string) => reap(deps, id),
+    publishActivity: (id: string) => publishActivity(deps, id),
+    setWorking: (id: string, working: boolean, event?: string) => setWorking(deps, id, working, event),
+    setWaiting: (id: string, waiting: boolean, event?: string) => setWaiting(deps, id, waiting, event),
+  };
+}

--- a/server/session/resumable-sessions.ts
+++ b/server/session/resumable-sessions.ts
@@ -1,0 +1,18 @@
+// Whether a surviving tmux session can be resumed as a real session.
+//
+// Shared by the tmux routes (which offer them) and the remote-host bridge (which lists them),
+// so it lives here rather than in either. Reads live state — the pty table, the persisted
+// dev-terminal set, and both agents' on-disk transcripts — and returns a predicate over ids.
+
+import { claudeOnDiskSessionIds } from "./session-reads.js";
+import { codexSessionsRoot } from "../agents/codex-session.js";
+import { codexRolloutExists } from "../agents/codex-sessions.js";
+import { devTerminalSessions, devTerminalSessionsHydrated, ptys } from "./registry.js";
+import { isResumableTmuxSession } from "../infra/tmux.js";
+export const resumableSessionPredicate = async (): Promise<(id: string) => boolean> => {
+  await devTerminalSessionsHydrated;
+  const live = new Set(ptys.keys());
+  const claudeOnDisk = claudeOnDiskSessionIds();
+  const codexRoot = codexSessionsRoot();
+  return (id) => isResumableTmuxSession(id, live, devTerminalSessions, claudeOnDisk, (i) => codexRolloutExists(codexRoot, i));
+};

--- a/test/server/session/lifecycle.spec.ts
+++ b/test/server/session/lifecycle.spec.ts
@@ -1,0 +1,184 @@
+// @vitest-environment node
+//
+// The stateful half of session teardown: it holds timers and calls things in an order that
+// matters. The DECISIONS it consults (reapDecisionFor, shouldForgetActivity, nextActivity)
+// have their own specs; what is exercised here is the orchestration that used to be
+// unreachable without booting the server.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createSessionLifecycle } from "../../../server/session/lifecycle.js";
+import { activity, aiTitles, hiddenSessions, knownSessions, lastPrompts, lastResponses, launchChoices, ptys } from "../../../server/session/registry.js";
+
+vi.mock("../../../server/infra/tmux.js", () => ({ tmuxKillSession: vi.fn() }));
+vi.mock("../../../server/infra/sandbox.js", () => ({ cleanupSandbox: vi.fn() }));
+vi.mock("../../../server/session/session-settings.js", () => ({ cleanupSessionSettings: vi.fn() }));
+
+const ID = "11111111-2222-4333-8444-555555555555";
+
+const makeDeps = () => ({
+  publish: vi.fn(),
+  forgetTitle: vi.fn(),
+  sessionActivityPublisher: { publish: vi.fn(), forget: vi.fn() },
+});
+
+// A pty entry with just the fields the lifecycle reads.
+const fakeEntry = (over: Record<string, unknown> = {}) => ({ term: { kill: vi.fn() }, ws: null, cwd: "/work", tmux: false, ...over }) as never;
+
+const clearRegistry = () => {
+  for (const map of [ptys, activity, knownSessions, lastPrompts, lastResponses, aiTitles, launchChoices]) map.clear();
+  hiddenSessions.clear();
+};
+
+beforeEach(clearRegistry);
+afterEach(() => {
+  vi.useRealTimers();
+  clearRegistry();
+});
+
+describe("reap", () => {
+  it("removes every trace of the session", () => {
+    const deps = makeDeps();
+    ptys.set(ID, fakeEntry());
+    knownSessions.set(ID, { createdAt: 1, title: "t" });
+    lastPrompts.set(ID, "p");
+    lastResponses.set(ID, "r");
+    launchChoices.set(ID, { provider: "openrouter", model: "m" });
+
+    createSessionLifecycle(deps).reap(ID);
+
+    // A leak here is a session that lingers in the sidebar, or a provider token's settings
+    // file left on disk.
+    expect([ptys.has(ID), knownSessions.has(ID), lastPrompts.has(ID), lastResponses.has(ID), launchChoices.has(ID)]).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+    expect(deps.forgetTitle).toHaveBeenCalledWith(ID);
+    expect(deps.sessionActivityPublisher.forget).toHaveBeenCalledWith(ID);
+  });
+
+  it("kills the pty and tells subscribers the session closed", () => {
+    const deps = makeDeps();
+    const entry = fakeEntry();
+    ptys.set(ID, entry);
+    createSessionLifecycle(deps).reap(ID);
+    expect((entry as { term: { kill: ReturnType<typeof vi.fn> } }).term.kill).toHaveBeenCalled();
+    expect(deps.publish).toHaveBeenCalledWith("sessions", expect.objectContaining({ id: ID, working: false, event: "closed" }));
+  });
+
+  it("does nothing for a session that was already reaped", () => {
+    const deps = makeDeps();
+    createSessionLifecycle(deps).reap(ID);
+    expect(deps.publish).not.toHaveBeenCalled();
+  });
+
+  // The bold-until-viewed behaviour: a finished background session keeps its activity record
+  // so it stays flagged for the user, while an idle one is dropped to bound the map.
+  it("keeps a waiting session's activity record but drops an idle one's", () => {
+    const deps = makeDeps();
+    const lifecycle = createSessionLifecycle(deps);
+
+    ptys.set(ID, fakeEntry());
+    activity.set(ID, { working: false, waiting: true, event: "Notification", at: 1 });
+    lifecycle.reap(ID);
+    expect(activity.has(ID)).toBe(true);
+
+    activity.set(ID, { working: false, waiting: false, event: "Stop", at: 1 });
+    ptys.set(ID, fakeEntry());
+    lifecycle.reap(ID);
+    expect(activity.has(ID)).toBe(false);
+  });
+});
+
+describe("setWorking / setWaiting", () => {
+  it("publishes a row when the flag actually changes", () => {
+    const deps = makeDeps();
+    ptys.set(ID, fakeEntry({ ws: {} }));
+    createSessionLifecycle(deps).setWorking(ID, true, "UserPromptSubmit");
+    expect(activity.get(ID)?.working).toBe(true);
+    expect(deps.publish).toHaveBeenCalled();
+  });
+
+  // Every hook fires these; publishing an unchanged row would flood the socket.
+  it("stays silent when the flag is unchanged", () => {
+    const deps = makeDeps();
+    const lifecycle = createSessionLifecycle(deps);
+    ptys.set(ID, fakeEntry({ ws: {} }));
+    lifecycle.setWorking(ID, true, "UserPromptSubmit");
+    deps.publish.mockClear();
+    lifecycle.setWorking(ID, true, "UserPromptSubmit");
+    expect(deps.publish).not.toHaveBeenCalled();
+  });
+
+  it("mirrors the flags to the phone", () => {
+    const deps = makeDeps();
+    ptys.set(ID, fakeEntry({ ws: {} }));
+    createSessionLifecycle(deps).setWaiting(ID, true, "Notification");
+    expect(deps.sessionActivityPublisher.publish).toHaveBeenCalledWith(ID, { working: false, waiting: true });
+  });
+});
+
+describe("the reap timer", () => {
+  // A session the user is looking at must never be reaped out from under them.
+  // Two independent guards protect an attached session: arming skips it, and the timer
+  // re-checks when it fires. Asserting only "the session survived" cannot tell them apart —
+  // removing either one alone still leaves it alive. So this asserts the arming guard
+  // directly, by observing that no timer was created at all.
+  it("does not arm anything while a client is attached", () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    ptys.set(ID, fakeEntry({ ws: {} }));
+    activity.set(ID, { working: false, waiting: false, event: "Stop", at: 1 });
+    createSessionLifecycle(deps).armReapForDetached(ID);
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(60 * 60_000);
+    expect(ptys.has(ID)).toBe(true);
+  });
+
+  // "Clearly working — don't close it."
+  it("keeps a detached session that is still working", () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    ptys.set(ID, fakeEntry());
+    activity.set(ID, { working: true, waiting: false, event: "UserPromptSubmit", at: 1 });
+    createSessionLifecycle(deps).armReapForDetached(ID);
+    vi.advanceTimersByTime(60 * 60_000);
+    expect(ptys.has(ID)).toBe(true);
+  });
+
+  it("reaps a detached idle session after the short grace", () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    ptys.set(ID, fakeEntry());
+    createSessionLifecycle(deps).armReapForDetached(ID);
+    vi.advanceTimersByTime(29_000);
+    expect(ptys.has(ID)).toBe(true);
+    vi.advanceTimersByTime(2_000);
+    expect(ptys.has(ID)).toBe(false);
+  });
+
+  // A reattach within the window is the whole point: a page reload must not cost the session.
+  it("cancels a pending reap", () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    const lifecycle = createSessionLifecycle(deps);
+    ptys.set(ID, fakeEntry());
+    lifecycle.armReapForDetached(ID);
+    lifecycle.cancelReap(ID);
+    vi.advanceTimersByTime(60 * 60_000);
+    expect(ptys.has(ID)).toBe(true);
+  });
+
+  // The timer fires on a session that has since reattached — it must check again, not reap.
+  it("does not reap a session that reattached during the grace", () => {
+    vi.useFakeTimers();
+    const deps = makeDeps();
+    ptys.set(ID, fakeEntry());
+    createSessionLifecycle(deps).armReapForDetached(ID);
+    ptys.set(ID, fakeEntry({ ws: {} })); // the user came back
+    vi.advanceTimersByTime(60_000);
+    expect(ptys.has(ID)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The last stateful thing `index.ts` owned — **when a session dies, and who is told about its state** — moves to `server/session/lifecycle.ts`. **848 → 686 lines.**

`cancelReap` / `scheduleReap` / `armReapForDetached` / `reap` / `publishActivity` / `setWorking` / `setWaiting` / `refreshLastResponse`, plus the grace-window constants, the reap timer table, and `SESSIONS_CHANNEL`.

The **decisions** inside were extracted and tested earlier in this series — `reapDecisionFor` picks the grace window, `shouldForgetActivity` decides what survives a teardown, `nextActivity` folds a flag change. What was left is the part that **holds timers and calls them in the right order**: the part that could not be reached without booting the server, and that is now importable.

## Items to Confirm / Review

1. **Three things stay as deps rather than imports**, each for the reason it already was one in `index.ts`:
   - `publish` — pub/sub only exists once the HTTP server does
   - `forgetTitle` — the title manager needs `publishActivity`, and `reap` needs `forgetTitle`. **That cycle is real**; binding it late is how `index.ts` already broke it
   - `sessionActivityPublisher` — needs Firestore credentials

   Everything else is the shared registry, imported directly.
2. **The functions take `deps` as a first parameter** rather than closing over it in a factory. The factory version tripped `max-lines-per-function` at 99 lines; this reads the same and keeps each function separately callable.
3. **Behaviour unchanged** — same functions, same order, only their home and how deps reach them.

## Verification

Beyond the suite: **the server was booted** and answered `GET /api/config` (200) and `GET /api/sessions`, with no errors on startup. A pure typecheck would not have caught a broken late binding.

lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `210 files / 2835 tests` — by exit code.

Refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)