### PR TITLE
refactor: セッション一覧の契約の props 側にも名前を付け、Sidebar のヘッダーを揃える (#646 B2)

### DIFF
--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { isUnread, type Session, type Filter } from "../composables/useSessions";
-import { useSessionFilter, type SessionListEmits } from "../composables/sessionList";
+import { isUnread } from "../composables/useSessions";
+import { useSessionFilter, type SessionListEmits, type SessionListProps } from "../composables/sessionList";
 import SessionFilters from "./SessionFilters.vue";
 
 // Presentational: list + filter are owned by App.vue and shared with the
 // vertical Sidebar, so switching layouts preserves them (no refetch/reset).
-const props = defineProps<{
-  sessions: Session[];
-  activeId: string | null;
-  filter: Filter;
-}>();
+const props = defineProps<SessionListProps>();
 const emit = defineEmits<SessionListEmits>();
 
 const { unreadCount, filteredSessions } = useSessionFilter(props);

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import { isUnread, type Session, type Filter } from "../composables/useSessions";
-import { useSessionFilter, type SessionListEmits } from "../composables/sessionList";
+import { isUnread } from "../composables/useSessions";
+import { useSessionFilter, type SessionListEmits, type SessionListProps } from "../composables/sessionList";
 import SessionFilters from "./SessionFilters.vue";
 
 // Presentational: the session list + filter are owned by App.vue (a single
 // useSessions instance shared across layouts) so toggling vertical/horizontal
 // doesn't reset or refetch them.
-const props = defineProps<{
-  sessions: Session[];
-  loading: boolean;
-  error: string | null;
-  activeId: string | null;
-  filter: Filter;
-}>();
+const props = defineProps<
+  SessionListProps & {
+    // Only the vertical layout has room to report these; the tab bar just shows what it has.
+    loading: boolean;
+    error: string | null;
+  }
+>();
 const emit = defineEmits<SessionListEmits>();
 
 const { unreadCount, filteredSessions } = useSessionFilter(props);
@@ -30,7 +30,7 @@ function relativeTime(ms: number): string {
 
 <template>
   <aside class="flex w-[260px] shrink-0 flex-col overflow-hidden border-r border-border bg-panel font-sans text-fg">
-    <div class="flex items-center justify-between px-3.5 py-2.5">
+    <div class="flex h-10 flex-none items-center justify-between border-b border-border px-3.5">
       <span class="text-[13px] font-semibold tracking-[0.05em] text-muted">Sessions</span>
       <button
         class="bg-transparent border-0 text-muted text-base leading-none cursor-pointer hover:text-fg"

--- a/src/composables/sessionList.ts
+++ b/src/composables/sessionList.ts
@@ -9,9 +9,18 @@ export type SessionListEmits = {
   (e: "update:filter", f: Filter): void;
 };
 
+// What App.vue hands a session-list layout. The event half of this contract has been named
+// since both layouts were written; the props half was left inline in each of them, which is
+// how the same three lines ended up in both components (#646 B2).
+export interface SessionListProps {
+  sessions: Session[];
+  activeId: string | null;
+  filter: Filter;
+}
+
 // The Unread chip's count and the filter-applied list, shared by both layouts.
 // The horizontal bar caps `filteredSessions` to its most-recent tabs itself.
-export function useSessionFilter(props: { sessions: Session[]; filter: Filter }) {
+export function useSessionFilter(props: Pick<SessionListProps, "sessions" | "filter">) {
   const unreadCount = computed(() => props.sessions.filter(isUnread).length);
   const filteredSessions = computed(() => (props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions));
   return { unreadCount, filteredSessions };


### PR DESCRIPTION
Refs #646

## Summary

2 つの変更を含みます。

1. **契約の props 側に名前を付ける**（#646 B2）
2. **Sidebar の 1 行目が他のヘッダーと揃っていない不具合を直す**

## 1. 片方だけ既に共有されていました

`composables/sessionList.ts` には**イベント契約**（`SessionListEmits`）と**フィルタ導出**（`useSessionFilter`）が既に置かれ、コメントにも「App.vue が両レイアウトに配線するもの」と書かれています。

**props 側だけが各コンポーネントに直書きのまま**残っていました。同じ受け渡しを表す 2 つの半分のうち片方だけ名前があるのは、設計の意思ではなく**やり残し**に見えます。

`SessionListProps` を追加し、Sidebar は `SessionListProps & { loading; error }` としました（この 2 つは**縦レイアウトだけが表示する余地を持つ**もの）。

## 2. Sidebar の 1 行目だけ扱いが違っていた

| | 高さ | 下境界 |
|---|---|---|
| `AppToolbar` | `h-10` | `border-b border-border` |
| `SessionTabBar`（横レイアウトの 1 行目） | `h-10` | `border-b border-border` |
| **`Sidebar` の 1 行目** | **なし** | **なし** |

セッション行は自前の背景を持たないため、**ヘッダー行は下のリストと地続きの `bg-panel` のまま**で、どこで切れているのか分かりません。他と同じ扱いにしたので、**横レイアウトが既に揃えているツールバーの高さにも並びます**。

## Items to Confirm / Review — jscpd は消えません（消せません）

**この PR は該当アラートを解消しません。**

残るのは **import 群と、共有契約を*使う* 3 行**です。

```ts
const props = defineProps<SessionListProps>();
const emit = defineEmits<SessionListEmits>();
const { unreadCount, filteredSessions } = useSessionFilter(props);
```

契約を共有する以上、両方が同じ呼び出しを書くのは必然で、**抽出したことで両者は「似ている」から「完全一致」になりました**。

**jscpd の ignore マーカーも効きません。** 検出は `.vue:html` ストリームで起きており、`<script>` 内の `/* */` は HTML トークナイザにとってコメントではないためです（実際に入れて試し、効かないことを確認しました）。

**この 1 件を 0 にするには、コードを歪めるのではなく理由付きでアラートを dismiss するのが正しい**と考えます。#646 に記録します。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck`(implicit any 0) / `yarn build` / `yarn test`（209 files, 2818 tests）通過。既存の `Sidebar.spec.ts` も無変更で通ります。

**見た目の確認は未実施**です。`h-10` 化でヘッダー行の高さが変わる（`py-2.5` → 固定 40px）ので、一度目視いただけると安全です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
