### PR TITLE
refactor: 同じ意味を持つセルの展開／閉じるボタンを 1 つにする (#646 B3)

### DIFF
--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+// The expand/restore and close buttons every grid cell's header ends with.
+//
+// Identical in the command and launcher cells, down to the labels and the glyphs, because
+// they mean the same thing to the grid: one zooms this cell, the other retires it (#646 B3).
+//
+// TerminalCell keeps its own pair. Its close is not the same action — it may hold a live
+// session, so it goes through a confirmation — and sharing a button whose click means two
+// different things is how the confirmation would eventually get lost.
+defineProps<{ expanded: boolean }>();
+const emit = defineEmits<{ (e: "toggle-expand" | "close"): void }>();
+</script>
+
+<template>
+  <button
+    class="cell-btn"
+    :title="expanded ? 'Restore' : 'Expand'"
+    :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
+    @click="emit('toggle-expand')"
+  >
+    {{ expanded ? "⤡" : "⤢" }}
+  </button>
+  <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
+</template>

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import TerminalView from "./Terminal.vue";
+import CellChromeButtons from "./CellChromeButtons.vue";
 import type { RunCommand } from "./runCommand";
 import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
@@ -161,15 +162,7 @@ function onHeaderClick(event: MouseEvent) {
         >
           {{ summaryState === "loading" ? "⋯" : "✦" }}
         </button>
-        <button
-          class="cell-btn"
-          :title="expanded ? 'Restore' : 'Expand'"
-          :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
-          @click="emit('toggle-expand')"
-        >
-          {{ expanded ? "⤡" : "⤢" }}
-        </button>
-        <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
+        <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
       </span>
     </div>
     <TerminalView

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import TerminalView from "./Terminal.vue";
+import CellChromeButtons from "./CellChromeButtons.vue";
 import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import { isShellLauncher, type CellStatus, type CellLauncher } from "./gridTabs";
@@ -73,15 +74,7 @@ function relaunch() {
         <button v-if="reorderable" class="cell-btn" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">◀</button>
         <button v-if="reorderable" class="cell-btn" title="Move right" aria-label="Move launcher right" @click="emit('move', 1)">▶</button>
         <button v-if="finished" class="cell-btn" title="Relaunch" aria-label="Relaunch" @click="relaunch">↻</button>
-        <button
-          class="cell-btn"
-          :title="expanded ? 'Restore' : 'Expand'"
-          :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
-          @click="emit('toggle-expand')"
-        >
-          {{ expanded ? "⤡" : "⤢" }}
-        </button>
-        <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
+        <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
       </span>
     </div>
     <TerminalView


### PR DESCRIPTION
Refs #646

## Summary

command セルと launcher セルは、ヘッダーの末尾に**同じ 2 つのボタン**を持っていました — ラベルもグリフもイベントも同一で、**グリッドにとって同じ意味**（一方はこのセルを拡大し、他方は畳む）だからです。

`CellChromeButtons.vue` に切り出しました。

## Items to Confirm / Review

1. **TerminalCell は意図的に共有していません。** そちらの「閉じる」は**同じ動作ではありません** — 生きたセッションを抱えている可能性があるため確認ダイアログを挟みます。**クリックの意味が 2 通りあるボタンを共有すると、その確認がいずれ落ちます**
2. **`.stop` は付けていません**（元の記述どおり）。`shouldZoomOnHeaderClick` が `target.closest("button")` で**ボタン内クリックを既に除外**しているため、ヘッダークリックの拡大は裏で発火しません。引き写しではなく確認しました
3. 移動ボタン（◀▶）は共有していません。aria-label が "Move command left" / "Move launcher left" と**対象名で異なり**、閾値にも掛かっていないため

## 効果

jscpd: **8 clones → 7**。CommandCell/LauncherCell の組は 2 件あり、**この PR が markup 側、#647 が props/emits 側**を消します。両方入れば **B1・B3 の 2 件が解消**します。

## テスト

`CommandCell.spec.ts` が既に「ヘッダーのボタンから両イベントが出る」ことを検証しており、**切り出し後も無変更で通ります**。それが狙いどおりであることの確認になっています。

## 検証

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `yarn build` / `yarn test`（209 files, 2818 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
