### PR TITLE
refactor: サーバ側の重複した前置き 3 件 (#646 A1–A3)

### DIFF
--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -357,14 +357,28 @@ const detailHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   res.json({ collection: toDetail(collection), items, ...(issues.length > 0 ? { issues } : {}) });
 };
 
+// Both write handlers open the same way: find the collection, then find something to write
+// with. Either step answers the request itself when it cannot — a 404 for an unknown slug, a
+// 405 for a read-only store — so the caller's only job is to stop.
+async function resolveWriteRequest(
+  res: Response,
+  slug: string,
+  body: unknown,
+): Promise<{ collection: ResolvedCollection; target: { write: CollectionWriteFn; record: CollectionItem } } | null> {
+  const collection = await resolveCollection(res, slug);
+  if (!collection) return null;
+  const target = resolveWriteTarget(res, collection, body);
+  if (!target) return null;
+  return { collection, target };
+}
+
 // ── Record CRUD (Tier 1: interactive editing — e.g. checking a to-do item) ──
 // Create a record. The id is the schema's primaryKey value from the body, or a
 // generated one; a singleton collection pins every create to its fixed id.
 const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
-  if (!collection) return;
-  const target = resolveWriteTarget(res, collection, req.body);
-  if (!target) return;
+  const resolved = await resolveWriteRequest(res, req.params.slug, req.body);
+  if (!resolved) return;
+  const { collection, target } = resolved;
   const itemId = resolveCreateItemId(collection.schema, target.record) ?? generateItemId();
   const recordWithId: CollectionItem = { ...target.record, [collection.schema.primaryKey]: itemId };
   const result = await target.write(itemId, recordWithId, { refuseOverwrite: true });
@@ -382,10 +396,9 @@ const itemCreateHandler: RequestHandler<{ slug: string }> = async (req, res) => 
 // Update a record. The primaryKey is pinned to the URL itemId (the body can't
 // smuggle a different id). Singletons only accept their one fixed id.
 const itemUpdateHandler: RequestHandler<{ slug: string; itemId: string }> = async (req, res) => {
-  const collection = await resolveCollection(res, req.params.slug);
-  if (!collection) return;
-  const target = resolveWriteTarget(res, collection, req.body);
-  if (!target) return;
+  const resolved = await resolveWriteRequest(res, req.params.slug, req.body);
+  if (!resolved) return;
+  const { collection, target } = resolved;
   const { singleton, primaryKey } = collection.schema;
   if (singleton && req.params.itemId !== singleton) {
     res.status(400).json({ error: `collection '${collection.slug}' is a singleton; the only valid item id is '${singleton}'` });

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -16,8 +16,7 @@
 import type { Express } from "express";
 import { createRemoteHost, startHostRunner, type RemoteHostLifecycle } from "@mulmoclaude/core/remote-host/server";
 
-import { createRemoteHostHandlers } from "./handlers.js";
-import type { SessionScreen, TerminalSessionSummary } from "./terminalScreen.js";
+import { createRemoteHostHandlers, type RemoteHostHandlerDeps } from "./handlers.js";
 import { createSaveAttachment } from "./attachmentStore.js";
 import { buildIngestAttachments } from "./ingestAttachments.js";
 import { onExpire } from "./onExpire.js";
@@ -32,16 +31,10 @@ const PREFIX = "[remote-host]";
 // Module-level singleton — one host runner per process. Null until initialized.
 let lifecycle: RemoteHostLifecycle | null = null;
 
-export interface RemoteHostBackendDeps {
-  workspace: string;
-  spawnChat: (message: string) => { chatId: string };
-  listTerminalSessions: () => Promise<TerminalSessionSummary[]>;
-  captureTerminalScreen: (sessionId: string) => Promise<SessionScreen>;
-  // Type into a session's live PTY (#445); false when none is attached here.
-  writeToSession: (sessionId: string, chunk: string) => boolean;
-  // Whether typing may empty that session's input box first (#572).
-  canClearBox: (sessionId: string) => boolean;
-}
+// Everything the handlers need except `ingest`, which this module builds itself — it has to
+// read the LIVE session's storage/uid, which only exist once a connection is up. Derived
+// rather than restated so a new handler dependency cannot be added in one place only.
+export type RemoteHostBackendDeps = Omit<RemoteHostHandlerDeps, "ingest">;
 
 export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
   // Ingest pulls the phone's staged uploads (Firebase Storage, signed in as the

--- a/server/git/branch-query.ts
+++ b/server/git/branch-query.ts
@@ -1,0 +1,29 @@
+// What a per-branch `gh` query opens with, in one place.
+//
+// Both branch-scoped queries — the open PR's URL and the branch's PR phase — take the same
+// injectable dependencies, cache under the same key shape, and expire on the same 30s window.
+// Each wrote that out itself, so a change to the caching (a different TTL, a different key)
+// could land in one and not the other while both still compiled (#646 A3).
+//
+// The cache itself stays with each caller: they store different things in it.
+import { runGh } from "./gh.js";
+
+// A roster poll re-asks every few seconds; gh is a subprocess and a network call, so the
+// answer is held briefly. Short enough that opening a PR shows up on the next poll or two.
+export const BRANCH_QUERY_TTL_MS = 30_000;
+
+export interface BranchQueryDeps {
+  runGh?: typeof runGh;
+  now?: () => number;
+  ttlMs?: number;
+}
+
+/** The resolved dependencies and the cache key for one repo/branch lookup. */
+export function branchQuery(deps: BranchQueryDeps, repo: string, branch: string) {
+  return {
+    run: deps.runGh ?? runGh,
+    now: deps.now ?? Date.now,
+    ttlMs: deps.ttlMs ?? BRANCH_QUERY_TTL_MS,
+    key: `${repo}:${branch}`,
+  };
+}

--- a/server/git/pr-for-branch.ts
+++ b/server/git/pr-for-branch.ts
@@ -1,10 +1,9 @@
 // The open PR URL for a branch (the header "open this branch's PR" button). One `gh pr list --head`,
 // cached briefly per (repo, branch) so /api/header — which fires on every focus / dir / session change —
 // doesn't shell out to gh each time. Pure parse + injectable deps keep it unit-testable without gh.
-import { runGh } from "./gh.js";
 import { createTtlCache } from "./ttl-cache.js";
+import { branchQuery, type BranchQueryDeps } from "./branch-query.js";
 
-const CACHE_TTL_MS = 30_000;
 const cache = createTtlCache<string | null>();
 
 // The first url in `gh pr list --json url` output, or null (no open PR / malformed).
@@ -23,19 +22,12 @@ export function parsePrUrl(stdout: string): string | null {
   return null;
 }
 
-export interface PrForBranchDeps {
-  runGh?: typeof runGh;
-  now?: () => number;
-  ttlMs?: number;
-}
+export type PrForBranchDeps = BranchQueryDeps;
 
 // The open PR URL for `branch` in `repo`, or null when there's none (the button is then hidden).
 // Never throws — a gh failure resolves to null (the button just doesn't show).
 export async function prUrlForBranch(repo: string, branch: string, deps: PrForBranchDeps = {}): Promise<string | null> {
-  const run = deps.runGh ?? runGh;
-  const now = deps.now ?? Date.now;
-  const ttlMs = deps.ttlMs ?? CACHE_TTL_MS;
-  const key = `${repo}:${branch}`;
+  const { run, now, ttlMs, key } = branchQuery(deps, repo, branch);
   const hit = cache.get(key, now, ttlMs);
   if (hit !== undefined) return hit;
   let url: string | null = null;

--- a/server/git/prPhase.ts
+++ b/server/git/prPhase.ts
@@ -10,6 +10,7 @@
 import { runGh } from "./gh.js";
 import { rollupCiState, type CiState } from "./prs.js";
 import { createTtlCache } from "./ttl-cache.js";
+import { branchQuery, type BranchQueryDeps } from "./branch-query.js";
 
 // Ordered roughly along the lifecycle so the client can pick a colour/label per phase.
 // `none` = no PR for this branch yet (still local work); `ready` = open, CI green, no
@@ -65,15 +66,10 @@ export interface PrPhaseResult {
   url: string | null;
 }
 
-const CACHE_TTL_MS = 30_000;
 const GH_FIELDS = "state,isDraft,reviewDecision,statusCheckRollup,url";
 const cache = createTtlCache<PrPhaseResult>();
 
-export interface PrPhaseDeps {
-  runGh?: typeof runGh;
-  now?: () => number;
-  ttlMs?: number;
-}
+export type PrPhaseDeps = BranchQueryDeps;
 
 const NONE: PrPhaseResult = { phase: "none", url: null };
 
@@ -95,10 +91,7 @@ async function listPr(run: typeof runGh, repo: string, branch: string, state: "o
 // resolves to `none` and is NOT cached, so the next roster poll retries instead of showing a
 // stale phase.
 export async function phaseForRepoBranch(repo: string, branch: string, deps: PrPhaseDeps = {}): Promise<PrPhaseResult> {
-  const run = deps.runGh ?? runGh;
-  const now = deps.now ?? Date.now;
-  const ttlMs = deps.ttlMs ?? CACHE_TTL_MS;
-  const key = `${repo}:${branch}`;
+  const { run, now, ttlMs, key } = branchQuery(deps, repo, branch);
   const hit = cache.get(key, now, ttlMs);
   if (hit !== undefined) return hit;
 


### PR DESCRIPTION
Refs #646

## Summary

**複数の入口が同じ準備処理を書いている**箇所 3 件。個々は小さいですが、共通しているのは「**コピーが黙ってズレる**」ことです — どちらに変更が入っても型は通り、片方だけが修正を持つ状態になります。

| | 場所 | 重複していたもの |
|---|---|---|
| **A1** | `collections.ts` | 2 つの書き込みハンドラの前置き |
| **A2** | `remoteHost` | Deps 定義の二重宣言 |
| **A3** | `pr-for-branch` / `prPhase` | deps 解決 + キャッシュキー |

### A1 — 「解決できなければ応答して終わる」

両ハンドラとも、コレクションを解決し、次に書き込み先を解決します。**各段が失敗時に自分で応答を返す**（不明な slug なら 404、読み取り専用なら 405）ので、呼び出し側の仕事は**止まることだけ**です。`resolveWriteRequest` がその対を担います。

### A2 — 片方が他方の全フィールドを書き写していた

`RemoteHostBackendDeps` は `RemoteHostHandlerDeps` から `ingest` を除いた**全フィールドを再宣言**していました（`ingest` は index.ts 側が生きたセッションの storage/uid を要するため自前で組み立てる）。`Omit` で導出したので、**ハンドラの依存が片方にだけ追加される事故**が起きなくなります。

### A3 — 同じキャッシュ規約が 2 回書かれていた

branch 単位の `gh` クエリ 2 つが、**同じ注入可能な依存・同じキー形・同じ 30 秒**を各自で書いていました。`git/branch-query.ts` に形と解決を置きます。**キャッシュ本体は各呼び出し側に残しました** — 保持するものが違うためです。

## Items to Confirm / Review

1. **A3 でキャッシュ本体を共有しなかった判断**（`string | null` と `PrPhaseResult` で型が違う）
2. **A2 は型の導出だけ**で、実行されるコードは変わりません
3. A1 の `resolveWriteRequest` は `{ collection, target } | null` を返します。null は「応答済み、呼び出し側は return するだけ」という意味です

## 効果

jscpd: **8 clones → 5**。

## 検証

挙動不変です。**テストは 1 件も変更していません** — これらの経路を覆う既存テストがそのまま通ることが、移動としての正しさの確認になります。

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `typecheck:server` / `yarn test`（209 files, 2818 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
