### PR TITLE
refactor: クライアント側の重複した前置き 2 件 (#646 A4–A5)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,7 @@ import WikiBrowseOverlay from "./components/WikiBrowseOverlay.vue";
 import PrsOverlay from "./components/PrsOverlay.vue";
 import FilesOverlay from "./components/FilesOverlay.vue";
 import GridView from "./components/GridView.vue";
-import SettingsModal from "./components/SettingsModal.vue";
+import AppSettingsModal from "./components/AppSettingsModal.vue";
 import AppToolbar from "./components/AppToolbar.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
 import { browseClose } from "./composables/useCollectionBrowse";
@@ -150,8 +150,7 @@ onMounted(() => window.addEventListener("resize", onViewportResize));
 
 // Settings (theme + notification sound), shared with the grid view via useAppConfig
 // and opened from the toolbar's gear button.
-const { defaultCwd, loadConfig, saveSound, pushEnabled, savePushEnabled, prRepos, savePrRepos, launchers, saveLaunchers, userMcpServers, saveUserMcpServers } =
-  useAppConfig();
+const { defaultCwd, loadConfig } = useAppConfig();
 // Drive the single view's dir overrides off the dir the terminal ACTUALLY runs in
 // (reported by the server, which may resolve/fall back), not the static default — so
 // the badge/theme/colors always track the active session. Falls back to the default
@@ -379,22 +378,6 @@ function onSession(id: string) {
     <PrsOverlay />
     <!-- Full-screen file explorer + editor; opened by a terminal header's Files button. -->
     <FilesOverlay />
-    <SettingsModal
-      v-if="showSettings"
-      :sound-file="soundFile"
-      :push-enabled="pushEnabled"
-      :pr-repos="prRepos"
-      :launchers="launchers"
-      :user-mcp-servers="userMcpServers"
-      :cwd="effectiveCwd"
-      :session-id="activeId"
-      @update-sound="saveSound"
-      @update-push-enabled="savePushEnabled"
-      @update-repos="savePrRepos"
-      @update-launchers="saveLaunchers"
-      @update-user-mcp="saveUserMcpServers"
-      @configure-appearance="configureAppearance"
-      @close="closeSettings"
-    />
+    <AppSettingsModal v-if="showSettings" :cwd="effectiveCwd" :session-id="activeId" @configure-appearance="configureAppearance" @close="closeSettings" />
   </div>
 </template>

--- a/src/components/AppSettingsModal.vue
+++ b/src/components/AppSettingsModal.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+// The settings modal with its config wiring already attached.
+//
+// Both shells open the same modal — the chat view and the grid — and each wired the same five
+// values and five save handlers to it by hand. Ten identical lines in two places is how one
+// of them ends up missing a setting added later, and the symptom would be a control that
+// silently does nothing in one view (#646 A5).
+//
+// useAppConfig's state is a singleton, so reading it here is the same state the shells read.
+// What genuinely differs stays a prop or an event: the chat view knows a cwd and a session,
+// and each shell configures appearance its own way.
+import { useAppConfig } from "../composables/useAppConfig";
+import SettingsModal from "./SettingsModal.vue";
+
+defineProps<{ cwd?: string | null; sessionId?: string | null }>();
+const emit = defineEmits<{ (e: "configure-appearance" | "close"): void }>();
+
+const { soundFile, saveSound, pushEnabled, savePushEnabled, prRepos, savePrRepos, launchers, saveLaunchers, userMcpServers, saveUserMcpServers } =
+  useAppConfig();
+</script>
+
+<template>
+  <SettingsModal
+    :sound-file="soundFile"
+    :push-enabled="pushEnabled"
+    :pr-repos="prRepos"
+    :launchers="launchers"
+    :user-mcp-servers="userMcpServers"
+    :cwd="cwd"
+    :session-id="sessionId"
+    @update-sound="saveSound"
+    @update-push-enabled="savePushEnabled"
+    @update-repos="savePrRepos"
+    @update-launchers="saveLaunchers"
+    @update-user-mcp="saveUserMcpServers"
+    @configure-appearance="emit('configure-appearance')"
+    @close="emit('close')"
+  />
+</template>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch, onMounted, onBeforeUnmount, onActivated, onDeactivated } from "vue";
 import TerminalGrid from "./TerminalGrid.vue";
-import SettingsModal from "./SettingsModal.vue";
+import AppSettingsModal from "./AppSettingsModal.vue";
 import AppToolbar from "./AppToolbar.vue";
 import { startCollectionChat } from "../composables/useChatLauncher";
 import { router } from "../router";
@@ -306,24 +306,7 @@ onDeactivated(detachNewTerminal);
 onBeforeUnmount(detachNewTerminal);
 
 // Server config: the default workspace dir + the auto-recorded dir presets + sound.
-const {
-  defaultCwd,
-  home,
-  presets,
-  soundFile,
-  pushEnabled,
-  prRepos,
-  launchers,
-  userMcpServers,
-  loadConfig,
-  recordPreset,
-  removePreset,
-  saveSound,
-  savePushEnabled,
-  savePrRepos,
-  saveLaunchers,
-  saveUserMcpServers,
-} = useAppConfig();
+const { defaultCwd, home, presets, launchers, loadConfig, recordPreset, removePreset } = useAppConfig();
 const showSettings = ref(false);
 onMounted(loadConfig);
 
@@ -392,20 +375,6 @@ function configureAppearance() {
       @status="onStatus"
       @list-mode="onListMode"
     />
-    <SettingsModal
-      v-if="showSettings"
-      :sound-file="soundFile"
-      :push-enabled="pushEnabled"
-      :pr-repos="prRepos"
-      :launchers="launchers"
-      :user-mcp-servers="userMcpServers"
-      @update-sound="saveSound"
-      @update-push-enabled="savePushEnabled"
-      @update-repos="savePrRepos"
-      @update-launchers="saveLaunchers"
-      @update-user-mcp="saveUserMcpServers"
-      @configure-appearance="configureAppearance"
-      @close="closeSettings"
-    />
+    <AppSettingsModal v-if="showSettings" @configure-appearance="configureAppearance" @close="closeSettings" />
   </div>
 </template>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -202,28 +202,41 @@ function applyActivity(d: ActivityMsg) {
   aiTitle.value = next.aiTitle;
 }
 
-async function loadInitial(id: string) {
+// This session's detail, or nothing to apply. Nothing covers three cases the callers all
+// treat the same: the read failed (best-effort — pub/sub fills it in on the next event), the
+// server refused, or the cell has since closed or switched session, in which case applying
+// the answer would leak the old session's state into the new one.
+//
+// The cell's dir goes along so the server can read the transcript and report the session's
+// most recent prompt rather than the bare id after a resume.
+type SessionDetail = ActivityMsg & { usage?: unknown; context?: unknown };
+
+async function fetchSessionDetail(id: string): Promise<SessionDetail | null> {
   try {
-    // Pass the cell's dir so the server can read the transcript and report the
-    // session's most recent prompt (not just the bare id) after a resume.
     const q = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
     const res = await fetch(`/api/session/${id}${q}`);
-    if (!res.ok) return;
+    if (!res.ok) return null;
     const data = await res.json();
-    // Guard against a stale response: the cell may have closed / switched session
-    // while the fetch was in flight — don't leak old status into the new state.
-    if (id === sessionId.value) {
-      applyActivity(data);
-      // Cleared rather than kept when the shape is wrong: the server always sends both
-      // (EMPTY_USAGE / EMPTY_CONTEXT when it has nothing to report), so an unrenderable one
-      // means something is actually broken — and a badge showing the previous turn's numbers
-      // as if they were current is the failure this guard exists to stop.
-      usage.value = isCellUsage(data.usage) ? data.usage : null;
-      context.value = isCellContext(data.context) ? data.context : null;
-    }
+    return id === sessionId.value ? data : null;
   } catch {
-    // best-effort — pub/sub will fill it in on the next event
+    return null;
   }
+}
+
+// Cleared rather than kept when the shape is wrong: the server always sends both
+// (EMPTY_USAGE / EMPTY_CONTEXT when it has nothing to report), so an unrenderable one means
+// something is actually broken — and a badge showing the previous turn's numbers as if they
+// were current is the failure the guards exist to stop.
+function applyBadges(data: SessionDetail) {
+  usage.value = isCellUsage(data.usage) ? data.usage : null;
+  context.value = isCellContext(data.context) ? data.context : null;
+}
+
+async function loadInitial(id: string) {
+  const data = await fetchSessionDetail(id);
+  if (!data) return;
+  applyActivity(data);
+  applyBadges(data);
 }
 
 // Refresh ONLY the token usage (not the live activity — that's pub/sub's job). Called
@@ -231,17 +244,8 @@ async function loadInitial(id: string) {
 async function refreshUsage() {
   const id = sessionId.value;
   if (!id) return;
-  try {
-    const q = cwd.value ? `?cwd=${encodeURIComponent(cwd.value)}` : "";
-    const res = await fetch(`/api/session/${id}${q}`);
-    if (!res.ok) return;
-    const data = await res.json();
-    if (id !== sessionId.value) return;
-    usage.value = isCellUsage(data.usage) ? data.usage : null;
-    context.value = isCellContext(data.context) ? data.context : null;
-  } catch {
-    // best-effort
-  }
+  const data = await fetchSessionDetail(id);
+  if (data) applyBadges(data);
 }
 
 onMounted(() => {


### PR DESCRIPTION
Refs #646

## Summary

| | 場所 | 重複していたもの |
|---|---|---|
| **A4** | `TerminalCell.vue` | `/api/session/:id` を叩く 2 箇所の前置き |
| **A5** | `App.vue` ↔ `GridView.vue` | 設定モーダルの配線 10 行 |

### A4 — 「止まる理由」が 3 つあり、呼び出し側はどれも同じ扱い

両方が同じ書き出しを持っていました：`?cwd=` を組み立て、fetch し、拒否されたら抜け、parse し、**待っている間にセルが閉じた／別セッションに切り替わっていないか**を確認する。

`fetchSessionDetail` は「詳細」か「何もなし」を返します。**何もなし**は 3 つの理由（読めなかった／サーバが拒否した／セルが別物になった）をまとめたもので、呼び出し側にとってはどれも同じ「止まる」です。`applyBadges` が続く 2 つのガードを持ちます。

> **申告**: これは一部**私が作りました**。#642 で両方の呼び出し側を同じ 2 行に揃えた結果、元々あった「ほぼ重複」が**完全一致**になりました。

### A5 — 片方だけ設定が抜ける形

チャット側とグリッド側が、**同じ 5 つの値と 5 つの保存ハンドラを手で配線**していました。同一の 10 行が 2 箇所にあると、**後から足した設定が片方に入らない**事故が起きます。症状は「片方のビューでだけコントロールが黙って効かない」で、気づきにくい類です。

`AppSettingsModal` が配線を持ちます。`useAppConfig` の状態は singleton なので、そこで読んでも**両シェルが読むのと同じ状態**です。**本当に違うものだけ**を prop / イベントに残しました（チャット側は cwd とセッションを知っている、外観設定の実装は各シェル固有）。

## Items to Confirm / Review

1. **A5 でラッパーが `useAppConfig()` を自分で呼ぶ設計**（singleton 前提）。両親からは未使用になった分割代入を削っています
2. A4 の `fetchSessionDetail` が返す `null` は 3 つの意味を兼ねます。**呼び出し側が区別する必要がない**と判断しましたが、将来分けたくなる可能性はあります
3. A4 の型は `ActivityMsg & { usage?: unknown; context?: unknown }`（応答が両方を含むため）

## 効果

jscpd: **8 clones → 6**。

## 検証

挙動不変です。既存テストは**無変更で通ります**:

- `GridView.spec.ts` の設定モーダル回帰（#347）— ラッパー越しでもそのまま通る
- `TerminalCell.spec.ts` のバッジ系（#642 で追加したものを含む）— 抽出した fetch に対して通る

`yarn format` / `yarn lint`(0 errors) / `yarn typecheck` / `yarn build` / `yarn test`（209 files, 2818 tests）通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
