### PR TITLE
feat: ask before starting a second instance instead of refusing (#653)

### DIFF
--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -3,3 +3,7 @@ export type CwdChoice = { path: string; mustExist: boolean } | { error: string }
 export declare function parsePortArg(args: string[], defaultPort: number): PortChoice;
 export declare function chooseCwd(args: string[], env: Record<string, string | undefined>): CwdChoice;
 export declare function portInUseMessage(port: number, explicit: boolean): string;
+export declare function portInUseAction(explicit: boolean, isTTY: boolean | undefined): "ask" | "stop";
+export declare function secondInstancePrompt(port: number): string;
+export declare function saysYes(answer: unknown): boolean;
+export declare const SECOND_INSTANCE_NOTE: string;

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -1,4 +1,5 @@
-// What the launcher's two flags resolve to, decided without touching the process.
+// What the launcher decides before it starts anything, kept out of the executable so each
+// decision can be checked without a process to exit or a terminal to type into.
 //
 // `--cwd` picks the workspace claude runs in and whose sessions the sidebar lists, so it is
 // a data-scope boundary: getting it wrong points the whole app at someone else's project.
@@ -61,3 +62,52 @@ export function portInUseMessage(port, explicit) {
   lines.push(explicit ? "  Pick a different --port, or stop the other process." : "  To start a second one anyway: --port <number>");
   return lines.join("\n");
 }
+
+/**
+ * What to do when the wanted port is taken: "ask" whether to start a second instance,
+ * or "stop".
+ *
+ * Two conditions rule the question out. An explicit --port already named the port that
+ * was wanted, so offering a different one answers a question nobody asked; and with no
+ * terminal to type into (a script, a service, CI) a prompt has nobody to answer it and
+ * would hang the start instead of failing it.
+ */
+export function portInUseAction(explicit, isTTY) {
+  return explicit || !isTTY ? "stop" : "ask";
+}
+
+/**
+ * The question asked when the default port is taken and there is somebody to answer.
+ *
+ * Two servers is not a supported setup (#611), but it is a legitimate thing to want on
+ * purpose — so the answer is a question rather than a refusal, and the default is no.
+ */
+export function secondInstancePrompt(port) {
+  return [`Port ${port} is already in use — MulmoTerminal may already be running at http://localhost:${port}`, "Start a second instance anyway? [y/N] "].join(
+    "\n",
+  );
+}
+
+/**
+ * Whether an answer to that question is a yes.
+ *
+ * Only an explicit yes counts. The prompt says [y/N], so Enter — and anything unrecognised —
+ * means no: starting a second server by misreading a stray keystroke is the outcome worth
+ * avoiding, and saying no costs one retyped command.
+ */
+export function saysYes(answer) {
+  return /^y(es)?$/i.test(String(answer ?? "").trim());
+}
+
+/**
+ * What someone who said yes should know before the second one comes up.
+ *
+ * One line, and only the part that is still true: config and the hidden-session list are
+ * safe across instances, but a session's tool history is cached per process and its live
+ * updates never cross — so the instance that did not start a session shows a frozen history
+ * for it (#611).
+ */
+export const SECOND_INSTANCE_NOTE = [
+  "  Note: both share ~/.mulmoterminal. A session's tool history does not live-update",
+  "  in the instance that did not start it.",
+].join("\n");

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -14,7 +14,7 @@ import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { fetchLatestVersion, isNewerVersion } from "./update-check.js";
-import { chooseCwd, parsePortArg, portInUseMessage } from "./cli-args.js";
+import { chooseCwd, parsePortArg, portInUseAction, portInUseMessage, saysYes, secondInstancePrompt, SECOND_INSTANCE_NOTE } from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = join(__dirname, "..");
@@ -69,7 +69,7 @@ function promptYesNo(question) {
     const rl = createInterface({ input: process.stdin, output: process.stdout });
     rl.question(question, (answer) => {
       rl.close();
-      res(/^y(es)?$/i.test(answer.trim()));
+      res(saysYes(answer));
     });
   });
 }
@@ -226,18 +226,42 @@ function resolveCwd(args) {
   return abs;
 }
 
+// Ask the OS for a free port (listen on 0) and return the one it assigned, or null. Only
+// reached once someone has said yes to a second instance.
+function findEphemeralPort() {
+  return new Promise((resolve) => {
+    const probe = createServer();
+    probe.once("error", () => resolve(null));
+    probe.once("listening", () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+    probe.listen(0);
+  });
+}
+
 async function choosePort(requested, explicit) {
   if (await isPortFree(requested)) return requested;
-  // No silent fallback to another port: that is what quietly puts a second server on the
-  // same home directory, where the two disagree about state neither sees the other change.
-  error(portInUseMessage(requested, explicit));
-  process.exit(1);
+  // No SILENT fallback: starting a second server on another port without saying so is how
+  // someone ends up with two sharing one home directory without knowing (#611).
+  if (portInUseAction(explicit, process.stdin.isTTY) === "stop") {
+    error(portInUseMessage(requested, explicit));
+    process.exit(1);
+  }
+  if (!(await promptYesNo(secondInstancePrompt(requested)))) process.exit(1);
+  const fallback = await findEphemeralPort();
+  if (fallback === null) {
+    error("No free port could be found for a second instance.");
+    process.exit(1);
+  }
+  log(SECOND_INSTANCE_NOTE);
+  return fallback;
 }
 
 // Spawn the server on `port` and report the child via `onChild` (so signal
 // handlers target the live process). Resolves only when the server exits because
 // the port was taken at bind time before it became ready — the caller then
-// retries on a fresh port. In every other case (clean shutdown, fatal error,
+// reports that and stops. In every other case (clean shutdown, fatal error,
 // or the server simply running) the process exits with the server's code.
 function runServer(port, noOpen, cwd, onChild) {
   return new Promise((resolveExit) => {
@@ -290,7 +314,9 @@ Commands:
 
 Options:
   --cwd <dir>       Working directory claude runs in (default: current directory; relative paths allowed)
-  --port <number>   Server port (default: ${DEFAULT_PORT}; startup stops if it is in use)
+  --port <number>   Server port (default: ${DEFAULT_PORT}). If it is in use, you are asked
+                    whether to start a second instance on a free port; with --port, or
+                    with no terminal to ask, startup stops instead.
   --no-open         Don't open the browser automatically
   --version         Show version
   --help            Show this help

--- a/test/bin/cli-args.spec.ts
+++ b/test/bin/cli-args.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { parsePortArg, chooseCwd, portInUseMessage } from "../../bin/cli-args.js";
+import { parsePortArg, chooseCwd, portInUseAction, portInUseMessage, secondInstancePrompt, saysYes, SECOND_INSTANCE_NOTE } from "../../bin/cli-args.js";
 
 const DEFAULT_PORT = 34567;
 const port = (args: string[]) => parsePortArg(args, DEFAULT_PORT);
@@ -159,5 +159,87 @@ describe("portInUseMessage", () => {
 
   it("puts each part on its own line", () => {
     expect(portInUseMessage(34567, false).split("\n")).toHaveLength(3);
+  });
+});
+
+describe("portInUseAction", () => {
+  it("asks when the port was the default and someone is there to answer", () => {
+    expect(portInUseAction(false, true)).toBe("ask");
+  });
+
+  // A prompt written to a pipe is never answered, so the start would hang rather than fail.
+  it("stops rather than prompt with no terminal", () => {
+    expect(portInUseAction(false, false)).toBe("stop");
+    expect(portInUseAction(false, undefined)).toBe("stop");
+  });
+
+  // --port named the port that was wanted; a different one is not what was asked for.
+  it("stops when the port was given explicitly", () => {
+    expect(portInUseAction(true, true)).toBe("stop");
+    expect(portInUseAction(true, false)).toBe("stop");
+  });
+});
+
+describe("secondInstancePrompt", () => {
+  it("names the port that is taken and where that server would be", () => {
+    const asked = secondInstancePrompt(34567);
+    expect(asked).toContain("34567");
+    expect(asked).toContain("http://localhost:34567");
+  });
+
+  // "[y/N]" is the whole contract with saysYes: the capital N is what tells the reader
+  // that Enter declines. A prompt claiming [Y/n] would be lying about the default.
+  it("shows no as the default", () => {
+    expect(secondInstancePrompt(34567)).toContain("[y/N]");
+    expect(secondInstancePrompt(34567)).not.toContain("[Y/n]");
+  });
+
+  // readline writes the prompt as-is, so the trailing space is what keeps the typed
+  // answer off the question mark.
+  it("leaves room for the answer on the same line", () => {
+    expect(secondInstancePrompt(34567).endsWith("] ")).toBe(true);
+  });
+});
+
+describe("saysYes", () => {
+  it("accepts the ways someone says yes", () => {
+    ["y", "Y", "yes", "YES", "Yes", " y ", "\ty\n"].forEach((answer) => {
+      expect(saysYes(answer), answer).toBe(true);
+    });
+  });
+
+  // Enter is the common one: the prompt offered N as the default, so an empty line takes it.
+  it("treats an empty answer as no", () => {
+    expect(saysYes("")).toBe(false);
+    expect(saysYes("   ")).toBe(false);
+  });
+
+  it("treats a no as no", () => {
+    ["n", "N", "no", "NO"].forEach((answer) => expect(saysYes(answer), answer).toBe(false));
+  });
+
+  // Anything unrecognised declines rather than guessing. Starting a second server off a
+  // mistyped word is the expensive direction to be wrong in; declining costs one retry.
+  it("declines anything it does not recognise", () => {
+    ["yolo", "yep", "ya", "sure", "yes please", "y/n", "1", "true"].forEach((answer) => expect(saysYes(answer), answer).toBe(false));
+  });
+
+  it("declines a missing answer", () => {
+    expect(saysYes(undefined)).toBe(false);
+    expect(saysYes(null)).toBe(false);
+  });
+});
+
+describe("SECOND_INSTANCE_NOTE", () => {
+  // The point of the note is the one thing that actually breaks with two instances.
+  it("names the shared directory and what goes stale", () => {
+    expect(SECOND_INSTANCE_NOTE).toContain("~/.mulmoterminal");
+    expect(SECOND_INSTANCE_NOTE).toContain("live-update");
+  });
+
+  // It is printed just before the URL, in the middle of a start that is going ahead —
+  // long enough to read at a glance, not a paragraph to scroll past.
+  it("stays short", () => {
+    expect(SECOND_INSTANCE_NOTE.split("\n")).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

A taken port used to just stop the launcher (#643). Now it **asks**, defaulting to no:

```
Port 34567 is already in use — MulmoTerminal may already be running at http://localhost:34567
Start a second instance anyway? [y/N] y

  Note: both share ~/.mulmoterminal. A session's tool history does not live-update
  in the instance that did not start it.
Starting MulmoTerminal on port 51234...
```

Two cases keep erroring unchanged: an explicit `--port` (it already named the port that was wanted, so offering a different one answers a question nobody asked), and no TTY (a prompt with nobody at the keyboard hangs the start instead of failing it).

## Items to Confirm / Review

1. **The note's wording.** It claims config and the hidden-session list are safe across instances and only tool history goes stale. That matches the audit behind #611 (config.json is read-merge-write; the dev-terminal-sessions list is an append log; the tool store is a per-process cache whose hook URLs bake in the owning server's port) — but it is the one user-facing claim here that could age badly.
2. **The yes path was never run live**, on purpose: doing so starts a real second server on your machine. `findEphemeralPort` (restored from #643) and the note text are covered by unit tests only. If you want it exercised end-to-end, that is a deliberate manual step.
3. **`promptYesNo` now calls `saysYes`** instead of repeating `/^y(es)?$/i` inline. Same behaviour, but it now also governs the existing `init` prompts — worth a glance that widening that shared function is wanted.

## User Prompt

> issue追加したい
> ２重起動に警告を出してy/nで起動をきく

Then, working the three new issues one at a time (「１こ１こつめていこう」), three decisions:

- Port when the answer is yes → 「OS に空きを貰う（推奨）」
- How a script opts out of the prompt → 「`--port` だけで十分（推奨）」 (no new flag)
- Whether to warn about shared state → 「1 行だけ添える（推奨）」

Standing context: 「基本２つ動かさない」 — two instances is not a supported setup, which is why the default is no and why the note is printed at all.

## Implementation

Every decision is a pure function in `bin/cli-args.js`, so none of them need a process to exit or a terminal to type into in order to be tested:

| function | decides |
|---|---|
| `portInUseAction(explicit, isTTY)` | `"ask"` vs `"stop"` |
| `secondInstancePrompt(port)` | the question text, `[y/N]`, trailing space for the answer |
| `saysYes(answer)` | only an explicit yes counts; empty/unrecognised declines |
| `SECOND_INSTANCE_NOTE` | the one-line caveat |

`bin/mulmoterminal.js` keeps the I/O: `choosePort` branches on `portInUseAction`, prompts via the existing `promptYesNo`, and on yes calls `findEphemeralPort` (restored — #643 had deleted it) and logs the note. `--help` documents all three outcomes.

## Testing

13 new tests (2835 → 2848), all 210 files green.

**Mutation testing** — each new assertion was checked to go red against a broken implementation:

| mutation | caught by |
|---|---|
| `saysYes` prefix-matches (`"yolo"` → yes) | "declines anything it does not recognise" |
| `saysYes` treats empty as yes | 3 tests |
| prompt shows `[Y/n]` | "shows no as the default" |
| prompt drops its trailing space | "leaves room for the answer" |
| note collapsed to one vague line | 2 tests |
| `portInUseAction` prompts with no TTY | "stops rather than prompt with no terminal" |
| `portInUseAction` prompts despite `--port` | "stops when the port was given explicitly" |

**Live checks**, against your `yarn dev` server actually holding 34567 (not touched):

- `--port <taken>` → exits 1 with the existing message, nothing spawned
- piped stdin → `isTTY` is `undefined` → `"stop"`, no prompt
- pty + `n` → prompt renders, exits, port 34567 still held by that one PID only

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)