### PR TITLE
feat: tell git-clone users about updates, not just npm users (#654)

### DIFF
--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -13,7 +13,15 @@ import { createServer } from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
-import { fetchLatestVersion, isNewerVersion } from "./update-check.js";
+import {
+  classifyInstall,
+  fetchLatestVersion,
+  gitUpdateNotice,
+  hasNodeModulesSegment,
+  isUpdateCheckDisabled,
+  npmUpdateNotice,
+  parseLsRemoteHead,
+} from "./update-check.js";
 import { chooseCwd, parsePortArg, portInUseMessage } from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -32,19 +40,71 @@ const { version: VERSION } = createRequire(import.meta.url)("../package.json");
 const log = (msg) => console.log(`\x1b[36m[mulmoterminal]\x1b[0m ${msg}`);
 const error = (msg) => console.error(`\x1b[31m[mulmoterminal]\x1b[0m ${msg}`);
 
-// Non-blocking notice when a newer version is published — `npm i -g` never
-// auto-updates. Opt out via MULMOTERMINAL_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
-function checkForUpdate() {
-  if (process.env.MULMOTERMINAL_NO_UPDATE_CHECK || process.env.NO_UPDATE_NOTIFIER) return;
-  fetchLatestVersion()
-    .then((latest) => {
-      if (latest && isNewerVersion(latest, VERSION)) {
-        log(`\x1b[33mUpdate available: ${VERSION} → ${latest}  ·  run: npm i -g mulmoterminal\x1b[0m`);
-      }
-    })
-    .catch(() => {
-      // best-effort; never disrupt startup
+// Upper bound on every git probe, including the network ls-remote — matches the
+// npm fetch timeout so a slow remote can't delay the notice past startup.
+const GIT_PROBE_TIMEOUT_MS = 1500;
+
+// Run git inside the package directory, best-effort. Resolves the trimmed stdout
+// on a clean exit, or null on anything else (git absent, non-zero exit, timeout).
+// GIT_TERMINAL_PROMPT=0 turns an auth prompt into a fast failure instead of a
+// hang, so ls-remote against a private remote can't block startup waiting on a
+// password nobody is there to type.
+function runGit(gitArgs, timeout_ms = GIT_PROBE_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn("git", ["-C", PKG_DIR, ...gitArgs], {
+        stdio: ["ignore", "pipe", "ignore"],
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      });
+    } catch {
+      return resolve(null);
+    }
+    let out = "";
+    const timer = setTimeout(() => child.kill("SIGKILL"), timeout_ms);
+    child.stdout.on("data", (chunk) => (out += chunk));
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve(null);
     });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve(code === 0 ? out.trim() : null);
+    });
+  });
+}
+
+// npm install → registry latest vs the bundled version; git checkout → local
+// HEAD vs the remote's, read without fetching. Only ask git which one this is
+// when the path doesn't already answer it.
+async function installKind() {
+  if (hasNodeModulesSegment(PKG_DIR)) return "npm";
+  return classifyInstall(PKG_DIR, (await runGit(["rev-parse", "--is-inside-work-tree"])) === "true");
+}
+
+// The git-side notice, or null. A dirty tree stops here without touching the
+// network — it can't fast-forward, so there is nothing worth asking the remote.
+async function gitUpdateMessage() {
+  const status = await runGit(["status", "--porcelain"]);
+  if (status === null || status !== "") return null;
+  const [localSha, localShort, lsRemote] = await Promise.all([
+    runGit(["rev-parse", "HEAD"]),
+    runGit(["rev-parse", "--short", "HEAD"]),
+    runGit(["ls-remote", "origin", "HEAD"]),
+  ]);
+  return gitUpdateNotice({ localSha, localShort, remoteSha: parseLsRemoteHead(lsRemote), dirty: false });
+}
+
+// Non-blocking notice that a newer version exists — neither `npm i -g` nor a git
+// checkout auto-updates. Opt out via MULMOTERMINAL_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
+async function checkForUpdate() {
+  if (isUpdateCheckDisabled(process.env)) return;
+  try {
+    const notice = (await installKind()) === "git" ? await gitUpdateMessage() : npmUpdateNotice(VERSION, await fetchLatestVersion());
+    if (notice) log(`\x1b[33m${notice}\x1b[0m`);
+  } catch {
+    // best-effort; never disrupt startup
+  }
 }
 
 // Detect a CLI on the user's PATH by asking for its version. Intentionally resolves from
@@ -52,7 +112,6 @@ function checkForUpdate() {
 // `init` checks.
 function hasCommand(cmd, versionArg = "--version") {
   try {
-    // eslint-disable-next-line sonarjs/no-os-command-from-path
     execSync(`${cmd} ${versionArg}`, { stdio: "pipe" });
     return true;
   } catch {
@@ -120,7 +179,6 @@ async function runInit(initArgs) {
   // must never block waiting on stdin.
   if (hasClaude && process.stdin.isTTY && (await promptYesNo("\nConfigure interactively now with the /mulmoterminal-config skill? [y/N] "))) {
     log("Launching Claude — use  /mulmoterminal-config  (or just ask it to configure MulmoTerminal).");
-    // eslint-disable-next-line sonarjs/no-os-command-from-path
     spawn("claude", ["Use the mulmoterminal-config skill to configure MulmoTerminal."], { stdio: "inherit" });
     return;
   }

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -18,6 +18,7 @@ import {
   fetchLatestVersion,
   gitUpdateNotice,
   hasNodeModulesSegment,
+  isTreeDirtyForUpdate,
   isUpdateCheckDisabled,
   npmUpdateNotice,
   parseLsRemoteHead,
@@ -86,7 +87,7 @@ async function installKind() {
 // network — it can't fast-forward, so there is nothing worth asking the remote.
 async function gitUpdateMessage() {
   const status = await runGit(["status", "--porcelain"]);
-  if (status === null || status !== "") return null;
+  if (status === null || isTreeDirtyForUpdate(status)) return null;
   const [localSha, localShort, lsRemote] = await Promise.all([
     runGit(["rev-parse", "HEAD"]),
     runGit(["rev-parse", "--short", "HEAD"]),

--- a/bin/update-check.d.ts
+++ b/bin/update-check.d.ts
@@ -5,4 +5,5 @@ export declare function hasNodeModulesSegment(pkgDir: string): boolean;
 export declare function classifyInstall(pkgDir: string, isGitWorkTree: boolean): "npm" | "git";
 export declare function parseLsRemoteHead(stdout: string | null | undefined): string | null;
 export declare function npmUpdateNotice(current: string, latest: string | null): string | null;
+export declare function isTreeDirtyForUpdate(porcelain: string | null | undefined): boolean;
 export declare function gitUpdateNotice(args: { localSha: string | null; localShort: string | null; remoteSha: string | null; dirty: boolean }): string | null;

--- a/bin/update-check.d.ts
+++ b/bin/update-check.d.ts
@@ -1,2 +1,8 @@
 export declare function fetchLatestVersion(pkg?: string): Promise<string | null>;
 export declare function isNewerVersion(latest: string, current: string): boolean;
+export declare function isUpdateCheckDisabled(env: Record<string, string | undefined>): boolean;
+export declare function hasNodeModulesSegment(pkgDir: string): boolean;
+export declare function classifyInstall(pkgDir: string, isGitWorkTree: boolean): "npm" | "git";
+export declare function parseLsRemoteHead(stdout: string | null | undefined): string | null;
+export declare function npmUpdateNotice(current: string, latest: string | null): string | null;
+export declare function gitUpdateNotice(args: { localSha: string | null; localShort: string | null; remoteSha: string | null; dirty: boolean }): string | null;

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -69,7 +69,9 @@ export function classifyInstall(pkgDir, isGitWorkTree) {
 export function parseLsRemoteHead(stdout) {
   for (const line of String(stdout ?? "").split("\n")) {
     const [sha, ref] = line.split("\t");
-    if (ref === "HEAD" && /^[0-9a-f]{7,40}$/i.test(sha ?? "")) return sha;
+    // 40 hex for SHA-1, 64 for a SHA-256 repository — accept both (and anything between,
+    // since ls-remote emits the full object id, never an abbreviation).
+    if (ref === "HEAD" && /^[0-9a-f]{7,64}$/i.test(sha ?? "")) return sha;
   }
   return null;
 }

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -35,3 +35,59 @@ export function isNewerVersion(latest, current) {
   }
   return false;
 }
+
+// The bundled package.json version only tells you anything for an npm install;
+// a git checkout has to be measured against its own remote instead. These two
+// installs need different current-versions, different "is there something newer"
+// checks, and different upgrade commands — so which one this is decides everything.
+
+// Whether both opt-out switches are respected. NO_UPDATE_NOTIFIER is the
+// ecosystem-wide convention; the namespaced one lets you silence only this tool.
+export function isUpdateCheckDisabled(env) {
+  return Boolean(env.MULMOTERMINAL_NO_UPDATE_CHECK || env.NO_UPDATE_NOTIFIER);
+}
+
+// A package living under a node_modules directory was installed by a package
+// manager — that covers a global install (…/lib/node_modules/mulmoterminal) and
+// one vendored into another project. Only a bare checkout counts as a git
+// install, so the tool merely sitting inside some unrelated repo is not mistaken
+// for one.
+export function hasNodeModulesSegment(pkgDir) {
+  return String(pkgDir)
+    .split(/[\\/]+/)
+    .includes("node_modules");
+}
+
+export function classifyInstall(pkgDir, isGitWorkTree) {
+  if (hasNodeModulesSegment(pkgDir)) return "npm";
+  return isGitWorkTree ? "git" : "npm";
+}
+
+// `git ls-remote origin HEAD` prints "<sha>\tHEAD". Return the object id HEAD
+// resolves to on the remote, or null if the output carries none — reading it
+// from the remote is what avoids a `git fetch` and its lock/auth/network cost.
+export function parseLsRemoteHead(stdout) {
+  for (const line of String(stdout ?? "").split("\n")) {
+    const [sha, ref] = line.split("\t");
+    if (ref === "HEAD" && /^[0-9a-f]{7,40}$/i.test(sha ?? "")) return sha;
+  }
+  return null;
+}
+
+// The one thing an npm install is told, or null when it is already current.
+export function npmUpdateNotice(current, latest) {
+  if (!latest || !isNewerVersion(latest, current)) return null;
+  return `Update available: ${current} → ${latest}  ·  run: npm i -g mulmoterminal`;
+}
+
+// Whether a git checkout should hear that an update exists, and what to say.
+// Silent whenever the notice could not be acted on or trusted: a dirty tree
+// cannot fast-forward, a missing sha means local or remote could not be read,
+// and equal shas mean it is already current. Only a clean checkout whose HEAD
+// differs from the remote's is behind — count is deliberately absent, since
+// counting commits needs the objects a `git fetch` would bring and we skip it.
+export function gitUpdateNotice({ localSha, localShort, remoteSha, dirty }) {
+  if (dirty) return null;
+  if (!localSha || !remoteSha || localSha === remoteSha) return null;
+  return `Update available: ${localShort || localSha.slice(0, 7)} → origin  ·  run: git pull`;
+}

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -80,6 +80,17 @@ export function npmUpdateNotice(current, latest) {
   return `Update available: ${current} → ${latest}  ·  run: npm i -g mulmoterminal`;
 }
 
+// Whether `git status --porcelain` output means a tree too dirty to fast-forward. Untracked
+// files (`??`) don't count: build output, .env, logs and other scratch are normal in any
+// working clone and `git pull` proceeds past them, so an untracked-only tree is treated as
+// clean here — otherwise a checkout that is genuinely behind never hears about it just
+// because it has a stray file. Tracked modifications (anything not `??`) are the real block.
+export function isTreeDirtyForUpdate(porcelain) {
+  return String(porcelain ?? "")
+    .split("\n")
+    .some((line) => line.trim() !== "" && !line.startsWith("??"));
+}
+
 // Whether a git checkout should hear that an update exists, and what to say.
 // Silent whenever the notice could not be acted on or trusted: a dirty tree
 // cannot fast-forward, a missing sha means local or remote could not be read,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,6 +67,16 @@ export default [
     },
   },
   {
+    // The launcher's job is to run the user's installed CLIs — claude, gh, tmux,
+    // codex, git — which have no portable absolute path and are found on PATH by
+    // design. no-os-command-from-path fights that premise on every spawn, so it
+    // is off here rather than suppressed inline at each call.
+    files: ["bin/**/*.js"],
+    rules: {
+      "sonarjs/no-os-command-from-path": "off",
+    },
+  },
+  {
     // Complexity / size guards. Cognitive complexity is already covered by sonarjs
     // (error@15). All ERRORS (enforced going forward) except max-params, which stays WARN
     // for its one intentional offender: spawnClaudePty's 7 params (hot path, not worth

--- a/test/bin/update-check.spec.ts
+++ b/test/bin/update-check.spec.ts
@@ -117,6 +117,13 @@ describe("parseLsRemoteHead", () => {
     expect(parseLsRemoteHead("88a82bc1f5abb50328b27aea3ae50a196ba3fc12\tHEAD")).toBe("88a82bc1f5abb50328b27aea3ae50a196ba3fc12");
   });
 
+  // A SHA-256 repository emits a 64-char object id; a SHA-1-length cap would drop it and
+  // silence update notices for that repo even when behind.
+  it("reads a 64-char SHA-256 HEAD id", () => {
+    const sha256 = "a".repeat(64);
+    expect(parseLsRemoteHead(`${sha256}\tHEAD`)).toBe(sha256);
+  });
+
   // It must key off the HEAD ref, not the first line — a stray line without HEAD
   // should never be mistaken for the answer.
   it("finds HEAD among other refs", () => {

--- a/test/bin/update-check.spec.ts
+++ b/test/bin/update-check.spec.ts
@@ -7,6 +7,7 @@ import {
   classifyInstall,
   parseLsRemoteHead,
   npmUpdateNotice,
+  isTreeDirtyForUpdate,
   gitUpdateNotice,
 } from "../../bin/update-check.js";
 
@@ -185,5 +186,32 @@ describe("gitUpdateNotice", () => {
   // Falls back to a trimmed full sha if the short one was not captured.
   it("uses a trimmed sha when the short one is missing", () => {
     expect(gitUpdateNotice({ ...behind, localShort: null })).toContain("0123456 →");
+  });
+});
+
+describe("isTreeDirtyForUpdate", () => {
+  it("treats an empty tree as clean", () => {
+    expect(isTreeDirtyForUpdate("")).toBe(false);
+    expect(isTreeDirtyForUpdate(null)).toBe(false);
+    expect(isTreeDirtyForUpdate(undefined)).toBe(false);
+  });
+
+  // The whole point of the review fix: scratch files a working clone accumulates (build
+  // output, .env, logs) must not suppress the update notice — git pull proceeds past them.
+  it("treats an untracked-only tree as clean", () => {
+    expect(isTreeDirtyForUpdate("?? build/out.js")).toBe(false);
+    expect(isTreeDirtyForUpdate("?? a.log\n?? .env\n?? node_modules/")).toBe(false);
+  });
+
+  it("is dirty on a tracked modification", () => {
+    expect(isTreeDirtyForUpdate(" M src/app.ts")).toBe(true);
+    expect(isTreeDirtyForUpdate("M  staged.ts")).toBe(true);
+    expect(isTreeDirtyForUpdate("A  added.ts")).toBe(true);
+    expect(isTreeDirtyForUpdate("UU conflict.ts")).toBe(true);
+  });
+
+  // A tracked change hiding among untracked files still counts.
+  it("is dirty when a tracked change sits among untracked ones", () => {
+    expect(isTreeDirtyForUpdate("?? a.log\n M src/app.ts\n?? b.log")).toBe(true);
   });
 });

--- a/test/bin/update-check.spec.ts
+++ b/test/bin/update-check.spec.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { isNewerVersion, fetchLatestVersion } from "../../bin/update-check.js";
+import {
+  isNewerVersion,
+  fetchLatestVersion,
+  isUpdateCheckDisabled,
+  hasNodeModulesSegment,
+  classifyInstall,
+  parseLsRemoteHead,
+  npmUpdateNotice,
+  gitUpdateNotice,
+} from "../../bin/update-check.js";
 
 describe("isNewerVersion", () => {
   const cases: [string, string, boolean][] = [
@@ -42,5 +51,139 @@ describe("fetchLatestVersion", () => {
   it("returns null when the payload has no version string", async () => {
     stubFetch(async () => ({ ok: true, json: async () => ({ name: "mulmoterminal" }) }));
     expect(await fetchLatestVersion()).toBeNull();
+  });
+});
+
+describe("isUpdateCheckDisabled", () => {
+  it("is silent for neither switch set", () => {
+    expect(isUpdateCheckDisabled({})).toBe(false);
+  });
+
+  // The namespaced switch silences only this tool.
+  it("respects the namespaced opt-out", () => {
+    expect(isUpdateCheckDisabled({ MULMOTERMINAL_NO_UPDATE_CHECK: "1" })).toBe(true);
+  });
+
+  // NO_UPDATE_NOTIFIER is the ecosystem-wide convention; honouring it means a
+  // user who silenced every tool's notice does not have to name this one too.
+  it("respects the ecosystem-wide opt-out", () => {
+    expect(isUpdateCheckDisabled({ NO_UPDATE_NOTIFIER: "1" })).toBe(true);
+  });
+});
+
+describe("hasNodeModulesSegment", () => {
+  it("spots a global install", () => {
+    expect(hasNodeModulesSegment("/usr/local/lib/node_modules/mulmoterminal")).toBe(true);
+  });
+
+  // Windows separators count too, or every Windows global install misreads as git.
+  it("spots a global install with Windows separators", () => {
+    expect(hasNodeModulesSegment("C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\mulmoterminal")).toBe(true);
+  });
+
+  it("does not see one in a plain checkout", () => {
+    expect(hasNodeModulesSegment("/home/dev/src/mulmoterminal")).toBe(false);
+  });
+
+  // A directory that merely contains the substring is not the segment — only a
+  // real path component named exactly node_modules makes it an npm install.
+  it("matches the segment, not the substring", () => {
+    expect(hasNodeModulesSegment("/home/dev/node_modules_backup/mulmoterminal")).toBe(false);
+  });
+});
+
+describe("classifyInstall", () => {
+  // node_modules wins even inside a git work tree: a dependency vendored into
+  // another project sits under the parent repo, and must not be read as a git
+  // install of this tool.
+  it("calls a node_modules path npm even when git says work tree", () => {
+    expect(classifyInstall("/proj/node_modules/mulmoterminal", true)).toBe("npm");
+  });
+
+  it("calls a bare checkout git", () => {
+    expect(classifyInstall("/home/dev/mulmoterminal", true)).toBe("git");
+  });
+
+  // Not a work tree and not under node_modules (e.g. an unpacked tarball) falls
+  // back to the npm path — the git checks would find nothing to compare against.
+  it("falls back to npm when it is neither", () => {
+    expect(classifyInstall("/opt/mulmoterminal", false)).toBe("npm");
+  });
+});
+
+describe("parseLsRemoteHead", () => {
+  it("reads the sha HEAD points to", () => {
+    expect(parseLsRemoteHead("88a82bc1f5abb50328b27aea3ae50a196ba3fc12\tHEAD")).toBe("88a82bc1f5abb50328b27aea3ae50a196ba3fc12");
+  });
+
+  // It must key off the HEAD ref, not the first line — a stray line without HEAD
+  // should never be mistaken for the answer.
+  it("finds HEAD among other refs", () => {
+    const out = "aaaa1111aaaa1111aaaa1111aaaa1111aaaa1111\trefs/heads/x\nbbbb2222bbbb2222bbbb2222bbbb2222bbbb2222\tHEAD";
+    expect(parseLsRemoteHead(out)).toBe("bbbb2222bbbb2222bbbb2222bbbb2222bbbb2222");
+  });
+
+  it("returns null for empty or missing output", () => {
+    expect(parseLsRemoteHead("")).toBeNull();
+    expect(parseLsRemoteHead(null)).toBeNull();
+    expect(parseLsRemoteHead(undefined)).toBeNull();
+  });
+
+  // A HEAD line whose first field is not a sha is not a usable answer.
+  it("rejects a non-sha in the HEAD line", () => {
+    expect(parseLsRemoteHead("not-a-sha\tHEAD")).toBeNull();
+  });
+});
+
+describe("npmUpdateNotice", () => {
+  it("names both versions and the npm command when newer", () => {
+    expect(npmUpdateNotice("0.7.0", "0.8.0")).toBe("Update available: 0.7.0 → 0.8.0  ·  run: npm i -g mulmoterminal");
+  });
+
+  it("stays silent when current is already latest", () => {
+    expect(npmUpdateNotice("0.8.0", "0.8.0")).toBeNull();
+    expect(npmUpdateNotice("0.9.0", "0.8.0")).toBeNull();
+  });
+
+  // A null latest is what fetchLatestVersion returns offline — no notice, no throw.
+  it("stays silent when latest is unknown", () => {
+    expect(npmUpdateNotice("0.8.0", null)).toBeNull();
+  });
+});
+
+describe("gitUpdateNotice", () => {
+  // localShort deliberately differs from the first 7 of localSha, so a test can
+  // tell whether the notice used the captured short sha or re-sliced the full one.
+  const behind = { localSha: "0123456789abcdef", localShort: "short12", remoteSha: "fedcba9876543210", dirty: false };
+
+  it("names the local short sha and git pull when behind and clean", () => {
+    expect(gitUpdateNotice(behind)).toBe("Update available: short12 → origin  ·  run: git pull");
+  });
+
+  // Dirty stops it even when the shas differ — a checkout with local edits can't
+  // fast-forward, so telling it to pull is noise.
+  it("stays silent on a dirty tree", () => {
+    expect(gitUpdateNotice({ ...behind, dirty: true })).toBeNull();
+  });
+
+  it("stays silent when HEAD already matches the remote", () => {
+    expect(gitUpdateNotice({ ...behind, remoteSha: behind.localSha })).toBeNull();
+  });
+
+  // A null on either side means a git probe failed; guessing would be wrong.
+  it("stays silent when local or remote could not be read", () => {
+    expect(gitUpdateNotice({ ...behind, localSha: null })).toBeNull();
+    expect(gitUpdateNotice({ ...behind, remoteSha: null })).toBeNull();
+  });
+
+  // No commit count is shown: counting needs the objects a fetch would bring,
+  // and this check deliberately never fetches.
+  it("shows no commit count", () => {
+    expect(gitUpdateNotice(behind)).not.toContain("commit");
+  });
+
+  // Falls back to a trimmed full sha if the short one was not captured.
+  it("uses a trimmed sha when the short one is missing", () => {
+    expect(gitUpdateNotice({ ...behind, localShort: null })).toContain("0123456 →");
   });
 });


### PR DESCRIPTION
## Summary

The startup update check only worked for npm installs. For a **git clone** it compared the registry's latest against the *bundled package.json version* — meaningless, since that version has nothing to do with the commit actually running. So a clone on an old `main` heard nothing, and right after a release it wrongly said "update available".

Now the launcher tells the two installs apart:

| install | current | compared to | says |
|---|---|---|---|
| npm (path under `node_modules`) | bundled version | registry latest | `npm i -g mulmoterminal` (unchanged) |
| git checkout | local `HEAD` | `git ls-remote origin HEAD` | `<shortsha> → origin  ·  run: git pull` |

```
[mulmoterminal] Update available: 6b20339 → origin  ·  run: git pull
```

## Items to Confirm / Review

1. **Comparison target is `origin`'s default branch** (`ls-remote origin HEAD`), which is exactly right for the common case — a user running from a clone of `main`. A developer sitting on a **clean feature branch** whose HEAD differs from `origin`'s default would also see the notice; in practice a feature-branch checkout is almost always dirty (→ silent), so this is a narrow edge, but flagging it since it's a deliberate scope choice (matching what the issue asked for).
2. **`ls-remote` needs the network** (like the existing npm fetch). It's best-effort, bounded at 1.5s, and `GIT_TERMINAL_PROMPT=0` makes a private remote fail fast rather than hang startup on a password prompt. No `git fetch` is ever run.
3. **No "N commits behind" count**, even though the issue floated it — counting reliably needs the objects a `git fetch` would bring, and this check deliberately never fetches. Showing a number we can't stand behind would be worse than showing none.
4. **eslint change**: `sonarjs/no-os-command-from-path` is turned off for `bin/**/*.js` in one place with a rationale (the launcher's whole job is spawning the user's PATH CLIs — claude, gh, tmux, codex, git — which have no portable absolute path). This **replaces two scattered inline `eslint-disable` comments** (one of which was already dead), so net suppressions go down. If you'd rather keep it surgical/inline, easy to flip back.

## User Prompt

> issue追加したい
> git版、npm版、それぞれバージョンを(gitはcommit)を把握して更新がある場合はユーザに伝えたい

Two settled decisions while working it (「つめよう」):
- git "update available" detection → **`git ls-remote origin HEAD`** (asks the remote every time, no fetch) over relying on the last local fetch (which reports "up to date" when the user simply hasn't fetched).
- dirty working tree → **stay silent** (a checkout with local edits is a dev tree, not "out of date").

## Implementation

Every decision is a pure function in `bin/update-check.js`:

| function | decides |
|---|---|
| `isUpdateCheckDisabled(env)` | both opt-out switches |
| `hasNodeModulesSegment(pkgDir)` / `classifyInstall(pkgDir, isGitWorkTree)` | npm vs git |
| `parseLsRemoteHead(stdout)` | the remote HEAD sha |
| `npmUpdateNotice(current, latest)` | the npm line, or null |
| `gitUpdateNotice({ localSha, localShort, remoteSha, dirty })` | the git line, or null |

`bin/mulmoterminal.js` keeps only I/O: a best-effort `runGit` (pipe stdout, 1.5s kill timer, `GIT_TERMINAL_PROMPT=0`) and the dispatch. It short-circuits — a `node_modules` path never spawns git, a dirty tree never hits the network.

## Testing

23 new tests (2847 → 2870), all 210 files green.

**Mutation testing** — each new assertion verified to go red against a broken implementation (14 mutations): opt-out honouring only one switch, `node_modules` substring-vs-segment, Windows separators, classify ignoring git / losing to node_modules, `ls-remote` taking the first line instead of the HEAD ref / skipping sha validation, git notice ignoring the dirty guard / firing when equal / firing on a null sha / re-slicing instead of using the captured short sha, npm notice firing when not newer.

**Integration**, against a real local clone (no server started):

- behind + clean → `Update available: 6b20339 → origin  ·  run: git pull`
- dirty tree → silent
- up-to-date + clean → silent
- pure functions cross-checked against this repo's real `git ls-remote` / `rev-parse` output

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)