### PR TITLE
refactor: dedup setWorking/setWaiting behind one tested decision (#548)

### DIFF
--- a/server/session/activity-flag.ts
+++ b/server/session/activity-flag.ts
@@ -1,0 +1,31 @@
+// What setting a session's working/waiting flag should DO, separated from doing it.
+//
+// setWorking and setWaiting were the same twelve lines with one word changed — jscpd flagged
+// the duplication, and the duplication hid the one real difference: which edge re-arms the
+// reap. A session that stops WORKING might have stopped to ask the user something, so it must
+// not be killed before they answer; a session that starts WAITING has just escalated from the
+// short idle grace to the long one. Both re-arm, but on opposite edges, and writing them
+// twice is how those two conditions drift.
+//
+// This decides; the caller applies. `changed` is null when the flag's value did not actually
+// move — every hook calls these, and publishing an unchanged row would flood the socket.
+import type { Activity } from "./types.js";
+import { nextActivity } from "./activity-transition.js";
+
+export type ActivityFlag = "working" | "waiting";
+
+export interface FlagEffect {
+  // The activity record to store and publish. Null means nothing changed — do nothing.
+  next: Activity | null;
+  // Whether the detached-reap should be re-armed for this session after publishing.
+  rearmReap: boolean;
+}
+
+// working: re-arm when it goes FALSE (a finished turn might be waiting on the user).
+// waiting: re-arm when it goes TRUE (needing the user escalates to the long grace).
+export function flagEffect(prev: Activity | undefined, flag: ActivityFlag, value: boolean, event: string | undefined, now: number): FlagEffect {
+  const next = nextActivity(prev, flag === "working" ? { working: value } : { waiting: value }, event, now);
+  if (!next) return { next: null, rearmReap: false };
+  const rearmReap = flag === "working" ? !value : value;
+  return { next, rearmReap };
+}

--- a/server/session/lifecycle.ts
+++ b/server/session/lifecycle.ts
@@ -29,7 +29,8 @@ import {
   titleInFlight,
 } from "./registry.js";
 import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./reap-policy.js";
-import { nextActivity, sessionRow, shouldRefreshReply } from "./activity-transition.js";
+import { sessionRow, shouldRefreshReply } from "./activity-transition.js";
+import { flagEffect, type ActivityFlag } from "./activity-flag.js";
 import { readLatestResponse } from "./session-reads.js";
 import { cleanupSessionSettings } from "./session-settings.js";
 import { cleanupSandbox } from "../infra/sandbox.js";
@@ -169,38 +170,18 @@ function publishActivity(deps: SessionLifecycleDeps, id: string) {
   deps.publish(SESSIONS_CHANNEL, row);
 }
 
-// Claude is thinking (UserPromptSubmit) until it finishes (Stop). No-op (and no
-// publish) when the state is unchanged.
-function setWorking(deps: SessionLifecycleDeps, id: string, working: boolean, event?: string) {
-  const next = nextActivity(activity.get(id), { working }, event, Date.now());
-  if (!next) return;
-  activity.set(id, next);
+// Set a session's working (thinking, UserPromptSubmit→Stop) or waiting (needs the user)
+// flag, publish the change, persist it, and re-arm the reap on the edge that calls for it.
+// A no-op when the flag's value did not actually move — flagEffect returns null and every
+// hook calls through here, so an unchanged publish would flood the socket.
+function setFlag(deps: SessionLifecycleDeps, id: string, flag: ActivityFlag, value: boolean, event?: string) {
+  const effect = flagEffect(activity.get(id), flag, value, event, Date.now());
+  if (!effect.next) return;
+  activity.set(id, effect.next);
   publishActivity(deps, id);
-  // Persist `working` so an in-progress turn survives a restart (see ACTIVITY_STATE_FILE).
+  // Persist so an in-progress turn / the blocked-or-done set survives a restart (ACTIVITY_STATE_FILE).
   persistActivityState((id) => hiddenSessions.has(id));
-
-  // A background session (no attached client) that just finished a turn is no
-  // longer `working`. Don't kill it outright — if it ended its turn to ask the
-  // user something (it'll be flagged `waiting`), reaping now would lose the task
-  // before the user can answer. Arm a reap whose grace matches its state.
-  if (!working) armReapForDetached(deps, id);
-}
-
-// A background session needs the user's attention: it is waiting for input
-// (Notification: permission / question / idle) or has finished a turn with
-// output the user hasn't seen (Stop). Cleared when brought to the foreground
-// (see the WebSocket connection handler).
-function setWaiting(deps: SessionLifecycleDeps, id: string, waiting: boolean, event?: string) {
-  const next = nextActivity(activity.get(id), { waiting }, event, Date.now());
-  if (!next) return;
-  activity.set(id, next);
-  publishActivity(deps, id);
-  // Persist the blocked/done set so it survives a server restart (see ACTIVITY_STATE_FILE).
-  persistActivityState((id) => hiddenSessions.has(id));
-
-  // A detached session that just started needing the user escalates from the short
-  // idle grace to the long one — re-arm so it isn't reaped before they can return.
-  if (waiting) armReapForDetached(deps, id);
+  if (effect.rearmReap) armReapForDetached(deps, id);
 }
 
 export function createSessionLifecycle(deps: SessionLifecycleDeps) {
@@ -211,7 +192,7 @@ export function createSessionLifecycle(deps: SessionLifecycleDeps) {
     armReapForDetached: (id: string) => armReapForDetached(deps, id),
     reap: (id: string) => reap(deps, id),
     publishActivity: (id: string) => publishActivity(deps, id),
-    setWorking: (id: string, working: boolean, event?: string) => setWorking(deps, id, working, event),
-    setWaiting: (id: string, waiting: boolean, event?: string) => setWaiting(deps, id, waiting, event),
+    setWorking: (id: string, working: boolean, event?: string) => setFlag(deps, id, "working", working, event),
+    setWaiting: (id: string, waiting: boolean, event?: string) => setFlag(deps, id, "waiting", waiting, event),
   };
 }

--- a/test/server/session/activity-flag.spec.ts
+++ b/test/server/session/activity-flag.spec.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { flagEffect } from "../../../server/session/activity-flag.js";
+import type { Activity } from "../../../server/session/types.js";
+
+const NOW = 1_000;
+const at = (over: Partial<Activity> = {}): Activity => ({ working: false, waiting: false, event: null, at: 0, ...over });
+
+describe("flagEffect", () => {
+  it("carries the new working flag through", () => {
+    const e = flagEffect(undefined, "working", true, "UserPromptSubmit", NOW);
+    expect(e.next?.working).toBe(true);
+  });
+
+  // Every hook calls the setters, so an unchanged value must produce no effect — otherwise
+  // the socket floods with identical rows.
+  it("is a no-op when the flag did not actually move", () => {
+    expect(flagEffect(at({ working: true }), "working", true, "UserPromptSubmit", NOW)).toEqual({ next: null, rearmReap: false });
+    expect(flagEffect(at({ waiting: true }), "waiting", true, "Notification", NOW)).toEqual({ next: null, rearmReap: false });
+  });
+
+  // The difference the duplication was hiding: working re-arms the reap when it goes FALSE
+  // (a finished turn may be waiting on the user), waiting re-arms when it goes TRUE.
+  it("re-arms the reap when working goes false, not when it goes true", () => {
+    expect(flagEffect(at(), "working", true, "UserPromptSubmit", NOW).rearmReap).toBe(false);
+    expect(flagEffect(at({ working: true }), "working", false, "Stop", NOW).rearmReap).toBe(true);
+  });
+
+  it("re-arms the reap when waiting goes true, not when it goes false", () => {
+    expect(flagEffect(at(), "waiting", true, "Notification", NOW).rearmReap).toBe(true);
+    expect(flagEffect(at({ waiting: true }), "waiting", false, undefined, NOW).rearmReap).toBe(false);
+  });
+
+  // A no-op never re-arms — the two must not disagree.
+  it("does not re-arm on a no-op even on the re-arming edge", () => {
+    // waiting already true, set true again → no change → must not re-arm
+    expect(flagEffect(at({ waiting: true }), "waiting", true, "Notification", NOW).rearmReap).toBe(false);
+  });
+
+  it("touches only the flag it is given", () => {
+    const e = flagEffect(at({ waiting: true, event: "Notification" }), "working", true, "UserPromptSubmit", NOW);
+    expect(e.next?.waiting).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

**Code-scanning alert #105** (jscpd) flagged `lifecycle.ts:175-186` as a duplicated block: `setWorking` and `setWaiting` were the same twelve lines with one word changed.

The duplication hid the one real difference — **which edge re-arms the detached reap**:
- a session that stops **working** may have stopped to ask the user something → re-arm as working goes *false*
- a session that starts **waiting** has escalated from the short idle grace to the long one → re-arm as waiting goes *true*

Opposite edges, written twice, which is exactly how those two conditions drift apart.

The edge rule is now a pure function (`flagEffect`), the two setters are one `setFlag`, and the decision has a test. Flipping the working re-arm edge turns a test red. `jscpd` now reports 0 clones in the file.

## Checks
lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `212 files / 2853 tests`. Behaviour unchanged.

Refs #548
🤖 Generated with [Claude Code](https://claude.com/claude-code)