### PR TITLE
refactor: make the document-name sanitizer testable (#611)

### DIFF
--- a/server/backends/docPath.ts
+++ b/server/backends/docPath.ts
@@ -22,3 +22,32 @@ export function isDocPath(rel: string): boolean {
   const normalized = path.posix.normalize(rel);
   return normalized === rel && !normalized.includes("..");
 }
+
+const PREFIX_MAX_LENGTH = 60;
+
+// Turn an LLM-supplied document title into exactly ONE path-safe filename segment: lowercase,
+// every run of non-[a-z0-9] collapsed to a single "-", no leading/trailing "-", capped, and a
+// "document" fallback when nothing survives.
+//
+// This is the only thing standing between a model-authored title like `../../etc/x` or
+// `foo/bar` and a path separator injected into a workspace write. The single-segment property
+// is the whole point — a value that keeps a `/` reaches buildDocPath and escapes DOCS_DIR, or
+// produces a name isDocPath later rejects so the saved doc never loads.
+export function sanitizeDocPrefix(prefix: string): string {
+  const cleaned = String(prefix || "document")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    // Runs are already collapsed to a single "-" above, so trim one at each end (no
+    // quantifier — keeps the regex trivially linear).
+    .replace(/^-|-$/g, "")
+    .slice(0, PREFIX_MAX_LENGTH);
+  return cleaned || "document";
+}
+
+// The workspace-relative path a new document is written to: artifacts/documents/YYYY/MM/<prefix>-<rand>.md.
+// `now` and `rand` are parameters so the path is assertable; the caller passes the real clock and id.
+export function buildDocPath(prefix: string, now: Date, rand: string): string {
+  const yyyy = String(now.getFullYear());
+  const mm = String(now.getMonth() + 1).padStart(2, "0");
+  return `${DOCS_DIR}/${yyyy}/${mm}/${sanitizeDocPrefix(prefix)}-${rand}.md`;
+}

--- a/server/backends/markdown.ts
+++ b/server/backends/markdown.ts
@@ -20,7 +20,7 @@ import { renderMarpDeck, fillImagePlaceholders } from "@mulmoclaude/markdown-plu
 import type { MarkdownHostApp, ExportPdfOptions } from "@mulmoclaude/markdown-plugin";
 import { publishFileChange } from "./fileChange.js";
 import { generateImage } from "./image-gen.js";
-import { DOCS_DIR, isDocPath } from "./docPath.js";
+import { buildDocPath, isDocPath } from "./docPath.js";
 
 // Set once at boot (server/index.ts) — workspace = CLAUDE_CWD. File-change
 // live-refresh is forwarded by the shared publisher (see fileChange.ts).
@@ -33,25 +33,6 @@ export function initMarkdownBackend(deps: { workspace: string }): void {
 function absFor(rel: string): string {
   if (!workspace) throw new Error("markdown backend not initialised (missing workspace)");
   return path.join(workspace, rel);
-}
-
-function sanitizePrefix(prefix: string): string {
-  const cleaned = String(prefix || "document")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    // Runs are already collapsed to a single "-" above, so trim one at each end
-    // (no quantifier — keeps the regex trivially linear).
-    .replace(/^-|-$/g, "")
-    .slice(0, 60);
-  return cleaned || "document";
-}
-
-function buildNewDocPath(prefix: string): string {
-  const now = new Date();
-  const yyyy = String(now.getFullYear());
-  const mm = String(now.getMonth() + 1).padStart(2, "0");
-  const rand = randomUUID().slice(0, 8);
-  return `${DOCS_DIR}/${yyyy}/${mm}/${sanitizePrefix(prefix)}-${rand}.md`;
 }
 
 const MARKDOWN_PDF_CSS = `
@@ -76,7 +57,7 @@ export const markdownHostApp: MarkdownHostApp = {
   },
 
   async saveNewDoc(prefix, markdown) {
-    const rel = buildNewDocPath(prefix);
+    const rel = buildDocPath(prefix, new Date(), randomUUID().slice(0, 8));
     const abs = absFor(rel);
     await fs.promises.mkdir(path.dirname(abs), { recursive: true });
     await fs.promises.writeFile(abs, markdown);

--- a/test/server/backends/docPath.spec.ts
+++ b/test/server/backends/docPath.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { DOCS_DIR, isDocPath } from "../../../server/backends/docPath.js";
+import { buildDocPath, DOCS_DIR, isDocPath, sanitizeDocPrefix } from "../../../server/backends/docPath.js";
 
 describe("isDocPath", () => {
   it("accepts a document under the documents directory", () => {
@@ -52,5 +52,69 @@ describe("isDocPath", () => {
 
   it("refuses an empty string", () => {
     expect(isDocPath("")).toBe(false);
+  });
+});
+
+describe("sanitizeDocPrefix", () => {
+  it("keeps a plain title as one lowercase segment", () => {
+    expect(sanitizeDocPrefix("Design Review")).toBe("design-review");
+  });
+
+  // The security property: a model-authored title must never contribute a path separator.
+  it.each([
+    ["../../etc/passwd", "etc-passwd"],
+    ["foo/bar", "foo-bar"],
+    ["a\\b", "a-b"],
+    ["x/../../y", "x-y"],
+  ])("collapses %j to a single segment with no separators", (input, expected) => {
+    const out = sanitizeDocPrefix(input);
+    expect(out).not.toMatch(/[/\\]/);
+    expect(out).not.toContain("..");
+    expect(out).toBe(expected);
+  });
+
+  it("collapses a run of unsafe characters to one dash", () => {
+    expect(sanitizeDocPrefix("a   !!!   b")).toBe("a-b");
+  });
+
+  it("trims a leading and trailing dash", () => {
+    expect(sanitizeDocPrefix("!hello!")).toBe("hello");
+    expect(sanitizeDocPrefix("///only-slashes///")).toBe("only-slashes");
+  });
+
+  // Without the fallback, a title of only unsafe characters would leave a filename starting
+  // with the random suffix's dash.
+  it.each([[""], ["   "], ["!!!"], ["/"], ["....."]])("falls back to 'document' for %j", (input) => {
+    expect(sanitizeDocPrefix(input)).toBe("document");
+  });
+
+  it("caps the length at 60 characters", () => {
+    expect(sanitizeDocPrefix("a".repeat(200))).toHaveLength(60);
+  });
+
+  // The cap slices AFTER the trim, so a boundary landing at position 60 can leave a trailing
+  // dash. Harmless — it is one segment either way, and buildDocPath appends `-<rand>` so the
+  // filename is still valid — but pinned so a future "tidy the trailing dash" change is a
+  // deliberate one, not an accident.
+  it("may keep a trailing dash when the cap lands on a boundary", () => {
+    expect(sanitizeDocPrefix("a".repeat(59) + " tail")).toBe("a".repeat(59) + "-");
+  });
+});
+
+describe("buildDocPath", () => {
+  const rand = "ab12cd34";
+
+  it("composes a dated path under the documents directory", () => {
+    expect(buildDocPath("notes", new Date("2026-07-23T00:00:00Z"), rand)).toBe(`${DOCS_DIR}/2026/07/notes-${rand}.md`);
+  });
+
+  it("zero-pads the month", () => {
+    expect(buildDocPath("x", new Date("2026-03-01T00:00:00Z"), rand)).toContain("/2026/03/");
+  });
+
+  // The whole chain: whatever the title, the result is a path isDocPath will accept — which
+  // is what keeps the write inside the workspace and lets the saved doc load afterwards.
+  it.each([["../../escape"], ["foo/bar"], [""], ["!!!"], ["a".repeat(200)]])("always produces a path isDocPath accepts, for %j", (title) => {
+    expect(isDocPath(buildDocPath(title, new Date("2026-07-23T00:00:00Z"), rand))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`sanitizePrefix` turns an LLM-supplied document title into one filename segment, and it is **the only thing between a model-authored title like `../../etc/x` or `foo/bar` and a path separator injected into a workspace write**. It was private in `markdown.ts`, which has no spec and cannot be imported in isolation (the module pulls in `marked`, a plugin, and `image-gen`, which imports `@google/genai` at load). So the one security-relevant rule in the file had zero coverage.

Moved to `docPath.ts`, beside `isDocPath` — the containment check it feeds — and joined by `buildDocPath`, which takes `now`/`rand` as parameters so the whole path is assertable.

## Items to Confirm / Review
1. **Traversal cases pinned**: `../../etc/passwd`, `foo/bar`, backslashes → one segment, no separators, no `..`. Plus the property tying it together: whatever the title, `buildDocPath` produces a path `isDocPath` accepts.
2. **One real behaviour recorded, not changed**: the cap slices *after* the trim, so a boundary at position 60 can leave a trailing dash. Harmless (`buildDocPath` appends `-<rand>`), pinned so tidying it later is deliberate.
3. Dropping the run-collapse turns 7 red.

## Checks
lint 0, typecheck (server/test) 0, build 0, `211 files / 2868 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)