### PR TITLE
fix: put the plugin openUrl allowlist behind a tested function (#611)

### DIFF
--- a/src/composables/pluginRuntime.ts
+++ b/src/composables/pluginRuntime.ts
@@ -15,23 +15,17 @@
 import { computed, defineComponent, h, markRaw, provide, ref, type Component, type Ref } from "vue";
 import { PLUGIN_RUNTIME_KEY, type BrowserPluginRuntime } from "gui-chat-protocol/vue";
 import { usePubSub } from "./usePubSub";
+import { isOpenablePluginUrl } from "./pluginUrlPolicy";
 
 function pluginChannelName(scope: string, eventName: string): string {
   return `plugin:${scope}:${eventName}`;
 }
 
-const OPEN_URL_ALLOWED_SCHEMES: ReadonlySet<string> = new Set(["http:", "https:"]);
 function makeOpenUrl(scope: string): BrowserPluginRuntime["openUrl"] {
   return (url: string) => {
-    let parsed: URL;
-    try {
-      parsed = new URL(url);
-    } catch {
-      console.warn(`[plugin/${scope}] openUrl rejected unparseable URL`, { url });
-      return;
-    }
-    if (!OPEN_URL_ALLOWED_SCHEMES.has(parsed.protocol)) {
-      console.warn(`[plugin/${scope}] openUrl rejected non-http(s) scheme`, { scheme: parsed.protocol });
+    // The scheme allowlist is the security boundary — see pluginUrlPolicy.ts.
+    if (!isOpenablePluginUrl(url)) {
+      console.warn(`[plugin/${scope}] openUrl rejected non-http(s) or unparseable URL`, { url });
       return;
     }
     window.open(url, "_blank", "noopener,noreferrer");

--- a/src/composables/pluginUrlPolicy.ts
+++ b/src/composables/pluginUrlPolicy.ts
@@ -1,0 +1,20 @@
+// Whether a plugin view may open a URL in a new tab.
+//
+// A plugin view runs LLM-authored markup, and openUrl hands its argument to window.open. The
+// only thing between that and a `javascript:` / `data:` / `file:` URL executing in the app
+// origin is this check — so it is a security boundary, and it should be a tested function
+// rather than a branch buried in a closure that no test reaches.
+//
+// http(s) only, and only when the URL parses at all. An unparseable string is refused rather
+// than passed to window.open to interpret however it likes.
+const ALLOWED_SCHEMES: ReadonlySet<string> = new Set(["http:", "https:"]);
+
+export function isOpenablePluginUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  return ALLOWED_SCHEMES.has(parsed.protocol);
+}

--- a/test/src/composables/pluginUrlPolicy.spec.ts
+++ b/test/src/composables/pluginUrlPolicy.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+import { isOpenablePluginUrl } from "../../../src/composables/pluginUrlPolicy";
+
+describe("isOpenablePluginUrl", () => {
+  it.each([["https://example.com"], ["http://example.com/path?q=1"], ["https://sub.example.com:8443/x#y"]])("allows the http(s) URL %s", (url) => {
+    expect(isOpenablePluginUrl(url)).toBe(true);
+  });
+
+  // The whole reason this exists: a plugin view runs LLM-authored markup, and its openUrl
+  // hands the argument to window.open. Each of these executes or exfiltrates in the app
+  // origin if it gets through.
+  it.each([
+    ["javascript:alert(1)"],
+    ["JavaScript:alert(1)"],
+    ["  javascript:alert(1)"],
+    ["data:text/html,<script>alert(1)</script>"],
+    ["file:///etc/passwd"],
+    ["vbscript:msgbox(1)"],
+    ["blob:https://example.com/uuid"],
+  ])("refuses the dangerous scheme %j", (url) => {
+    expect(isOpenablePluginUrl(url)).toBe(false);
+  });
+
+  // An unparseable string must be refused, not handed to window.open to interpret.
+  it.each([[""], ["not a url"], ["///"], ["http:"], ["example.com"], ["//example.com"]])("refuses the unparseable or scheme-relative %j", (url) => {
+    expect(isOpenablePluginUrl(url)).toBe(false);
+  });
+
+  // mailto/tel are not opened in a tab here — only http(s). Recorded so widening the set is a
+  // deliberate choice.
+  it.each([["mailto:a@b.com"], ["tel:+123"], ["ssh://host"]])("does not open the non-web scheme %j", (url) => {
+    expect(isOpenablePluginUrl(url)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A plugin view runs LLM-authored markup, and its `openUrl` hands the argument to `window.open`. The scheme allowlist is **the only thing between that and a `javascript:` / `data:` / `file:` URL executing in the app origin** — a security boundary, and it had zero coverage: the check was a branch inside `makeOpenUrl`'s closure, unexported, reached by no test.

Moved to `isOpenablePluginUrl`. Behaviour unchanged (http/https only, unparseable refused); `makeOpenUrl` keeps the `window.open` and the warn.

## Items to Confirm / Review
- The dangerous schemes are pinned: `javascript` / `data` / `file` / `vbscript` / `blob`, in case- and whitespace-variant forms, plus unparseable and scheme-relative (`//host`). Adding `javascript:` to the set turns 3 red.
- `mailto:` / `tel:` are **not** opened here (http(s) only) — pinned so widening that is a deliberate choice.

## Checks
lint 0, typecheck (app/test) 0, build 0, `212 files / 2866 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)