### PR TITLE
refactor: make the raw-file serving plan testable — including the SVG sandbox (#611)

### DIFF
--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -19,36 +19,7 @@ import { createReadStream } from "node:fs";
 import type { Express, Request, Response } from "express";
 import { statFileOr404 } from "./statFileOr404.js";
 import { parseByteRange } from "./byte-range.js";
-
-const MAX_RAW_BYTES = 25 * 1024 * 1024; // images / text / generic
-const MAX_MEDIA_BYTES = 500 * 1024 * 1024; // audio / video (streamed via Range)
-
-const MIME_BY_EXT: Record<string, string> = {
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".gif": "image/gif",
-  ".webp": "image/webp",
-  ".avif": "image/avif",
-  ".svg": "image/svg+xml",
-  ".bmp": "image/bmp",
-  ".ico": "image/x-icon",
-  ".pdf": "application/pdf",
-  ".mp3": "audio/mpeg",
-  ".m4a": "audio/mp4",
-  ".wav": "audio/wav",
-  ".ogg": "audio/ogg",
-  ".mp4": "video/mp4",
-  ".webm": "video/webm",
-  ".mov": "video/quicktime",
-  ".txt": "text/plain; charset=utf-8",
-  ".json": "application/json; charset=utf-8",
-  ".csv": "text/csv; charset=utf-8",
-};
-
-function isMedia(mime: string): boolean {
-  return mime.startsWith("audio/") || mime.startsWith("video/");
-}
+import { rawServingPlan } from "./rawServingPlan.js";
 
 export function mountFilesRoutes(app: Express, deps: { workspace: string }): void {
   const root = path.resolve(deps.workspace);
@@ -69,19 +40,17 @@ export function mountFilesRoutes(app: Express, deps: { workspace: string }): voi
     const stat = statFileOr404(res, abs);
     if (!stat) return;
 
-    const ext = path.extname(abs).toLowerCase();
-    const mime = MIME_BY_EXT[ext] ?? "application/octet-stream";
-    const cap = isMedia(mime) ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
-    if (stat.size > cap) {
-      res.status(413).json({ error: `file too large (${stat.size} bytes, limit ${cap})` });
+    const plan = rawServingPlan(abs, stat.size);
+    if (plan.tooLarge) {
+      res.status(413).json({ error: `file too large (${stat.size} bytes)` });
       return;
     }
 
-    res.setHeader("Content-Type", mime);
+    res.setHeader("Content-Type", plan.contentType);
     res.setHeader("X-Content-Type-Options", "nosniff");
-    // Sandbox the response so an SVG/HTML with embedded JS can't escape into the app
-    // origin. PDFs skip it (WebKit won't render sandbox-opaque PDFs).
-    if (mime !== "application/pdf") res.setHeader("Content-Security-Policy", "sandbox");
+    // An SVG/HTML with embedded JS must not escape into the app origin; PDFs are the sole
+    // exception (WebKit won't render a sandbox-opaque PDF). See rawServingPlan.
+    if (plan.sandbox) res.setHeader("Content-Security-Policy", "sandbox");
     res.setHeader("Accept-Ranges", "bytes");
 
     // Range support (required for <video>/<audio> seeking in Safari).

--- a/server/backends/rawServingPlan.ts
+++ b/server/backends/rawServingPlan.ts
@@ -1,0 +1,56 @@
+// How /api/files/raw should serve a workspace file: its content type, whether the response
+// must be sandboxed, and whether it is over the size cap.
+//
+// Three decisions that were inline in the route and reached, between them, by one .png test.
+// The one that matters is the sandbox: an .svg can carry inline <script>, so the response
+// gets `Content-Security-Policy: sandbox` to keep it out of the app origin. PDFs are the sole
+// exception — WebKit will not render a sandbox-opaque PDF — and that exception is exactly the
+// kind of thing that widens by accident. Serving an SVG WITHOUT the sandbox is stored XSS
+// against /api/* and the session cookie.
+import path from "node:path";
+
+const MAX_RAW_BYTES = 25 * 1024 * 1024; // images / text / generic
+const MAX_MEDIA_BYTES = 500 * 1024 * 1024; // audio / video (streamed via Range)
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".ico": "image/x-icon",
+  ".pdf": "application/pdf",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".txt": "text/plain; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".csv": "text/csv; charset=utf-8",
+};
+
+// Audio and video are the large, Range-streamed kinds that get the bigger cap.
+function isMedia(mime: string): boolean {
+  return mime.startsWith("audio/") || mime.startsWith("video/");
+}
+
+export interface RawServingPlan {
+  contentType: string;
+  // False only for application/pdf; everything else is sandboxed.
+  sandbox: boolean;
+  // True when the file is over the cap for its kind — the route answers 413.
+  tooLarge: boolean;
+}
+
+export function rawServingPlan(absPath: string, size: number): RawServingPlan {
+  const ext = path.extname(absPath).toLowerCase();
+  const contentType = MIME_BY_EXT[ext] ?? "application/octet-stream";
+  const cap = isMedia(contentType) ? MAX_MEDIA_BYTES : MAX_RAW_BYTES;
+  return { contentType, sandbox: contentType !== "application/pdf", tooLarge: size > cap };
+}

--- a/test/server/backends/rawServingPlan.spec.ts
+++ b/test/server/backends/rawServingPlan.spec.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { rawServingPlan } from "../../../server/backends/rawServingPlan.js";
+
+const KB = 1024,
+  MB = 1024 * KB;
+
+describe("rawServingPlan — content type", () => {
+  it.each([
+    ["/w/a.png", "image/png"],
+    ["/w/a.JPG", "image/jpeg"],
+    ["/w/a.svg", "image/svg+xml"],
+    ["/w/a.pdf", "application/pdf"],
+    ["/w/a.mp4", "video/mp4"],
+    ["/w/a.json", "application/json; charset=utf-8"],
+  ])("maps %s to %s", (p, ct) => {
+    expect(rawServingPlan(p, 1).contentType).toBe(ct);
+  });
+
+  it("falls back to octet-stream for an unknown extension", () => {
+    expect(rawServingPlan("/w/a.xyz", 1).contentType).toBe("application/octet-stream");
+    expect(rawServingPlan("/w/noext", 1).contentType).toBe("application/octet-stream");
+  });
+});
+
+describe("rawServingPlan — the sandbox boundary", () => {
+  // The security-relevant branch, and the one the route's single .png test never exercised.
+  // An SVG can carry inline <script>; served without the sandbox it runs in the app origin.
+  it("sandboxes an SVG", () => {
+    expect(rawServingPlan("/w/x.svg", 1).sandbox).toBe(true);
+  });
+
+  it("sandboxes an image, a text file, and an unknown type", () => {
+    for (const p of ["/w/x.png", "/w/x.txt", "/w/x.xyz"]) expect(rawServingPlan(p, 1).sandbox).toBe(true);
+  });
+
+  // The deliberate exception — and the only one. WebKit won't render a sandbox-opaque PDF.
+  it("does NOT sandbox a PDF", () => {
+    expect(rawServingPlan("/w/x.pdf", 1).sandbox).toBe(false);
+  });
+
+  it("still sandboxes everything that is not a PDF", () => {
+    for (const p of ["/w/x.mp4", "/w/x.json", "/w/x.gif"]) expect(rawServingPlan(p, 1).sandbox).toBe(true);
+  });
+});
+
+describe("rawServingPlan — the size cap", () => {
+  // Audio/video get 500 MiB (Range-streamed); everything else 25 MiB.
+  it("lets a 400 MiB video through but 413s a 30 MiB image", () => {
+    expect(rawServingPlan("/w/x.mp4", 400 * MB).tooLarge).toBe(false);
+    expect(rawServingPlan("/w/x.png", 30 * MB).tooLarge).toBe(true);
+  });
+
+  it("holds an image right at the 25 MiB cap", () => {
+    expect(rawServingPlan("/w/x.png", 25 * MB).tooLarge).toBe(false);
+    expect(rawServingPlan("/w/x.png", 25 * MB + 1).tooLarge).toBe(true);
+  });
+
+  it("413s a video only past 500 MiB", () => {
+    expect(rawServingPlan("/w/x.webm", 500 * MB).tooLarge).toBe(false);
+    expect(rawServingPlan("/w/x.webm", 500 * MB + 1).tooLarge).toBe(true);
+  });
+
+  // An audio file is media too, not a generic file on the small cap.
+  it("gives audio the media cap", () => {
+    expect(rawServingPlan("/w/x.mp3", 100 * MB).tooLarge).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`/api/files/raw` made three decisions inline — content type, size cap, and whether to sandbox the response — reached, between them, by **one `.png` test**.

The sandbox is the one that matters. An `.svg` can carry inline `<script>`, so the response gets `Content-Security-Policy: sandbox` to keep it out of the app origin. PDF is the **sole** exception (WebKit won't render a sandbox-opaque PDF). Served without the sandbox, an SVG is **stored XSS against `/api/*` and the session cookie** — and that branch had never run in a test.

`rawServingPlan(absPath, size) → { contentType, sandbox, tooLarge }`. The route keeps the containment check, the `stat`, the headers and the streaming. Behaviour unchanged.

## Items to Confirm / Review
1. **The sandbox boundary is the point**: SVG / image / text / unknown → sandboxed; PDF → not. Widening the PDF exception to images (so an SVG would skip the sandbox) turns **3 red**.
2. **The cap boundary**: audio/video 500 MiB, everything else 25 MiB, asserted at the exact edge. Inverting it turns **4 red**.
3. The 413 message no longer prints the cap value (it was derived inside the route); it still says the size. Trivial, mention if you want it back.

## Checks
lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `212 files / 2881 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)