### PR TITLE
refactor: make the terminal message→effect table testable (#611)

### DIFF
--- a/src/composables/serverMessage.ts
+++ b/src/composables/serverMessage.ts
@@ -1,0 +1,50 @@
+// What a terminal WebSocket message means, separated from carrying it out.
+//
+// handleMessage does the I/O — writing to xterm, flipping status, firing handlers — but the
+// decisions underneath are the fragile part: which messages are terminal (so reconnect must
+// NOT retry them), which fire onExit (so a cell offers a re-run), and the wording. The one
+// that bites is `superseded`: it is terminal like `exit`, but it must NOT fire onExit, or a
+// cell offers to re-run a session that is alive in another tab — and if it were treated as
+// retryable, the two tabs would evict each other forever. This is exactly why it wants a test.
+
+export interface ParsedServerMessage {
+  type?: string;
+  data?: unknown;
+  id?: unknown;
+  cwd?: unknown;
+  message?: unknown;
+}
+
+// The non-output effects of a message. `output` is handled directly (a hot path, just a
+// write) and is not modelled here.
+export interface MessageEffect {
+  // A terminal message stops the connection — reconnect must not retry it.
+  terminal: boolean;
+  // Fire the onExit handler (a CommandCell uses it to offer a re-run). Deliberately false for
+  // `superseded`: the session is still alive elsewhere.
+  callsOnExit: boolean;
+  // The line written to the terminal, or null (session/output write nothing here).
+  banner: string | null;
+}
+
+const GREEN = "\x1b[33m";
+const RED = "\x1b[31m";
+const RESET = "\x1b[0m";
+const line = (colour: string, text: string) => `\r\n${colour}${text}${RESET}\r\n`;
+
+// `isCommand` is whether this slot runs a one-off Run command rather than an agent session —
+// it only changes the wording of the exit banner.
+export function messageEffect(type: string | undefined, isCommand: boolean, errorMessage?: unknown): MessageEffect {
+  switch (type) {
+    case "exit":
+      return { terminal: true, callsOnExit: true, banner: line(GREEN, isCommand ? "[finished]" : "[session ended]") };
+    case "superseded":
+      return { terminal: true, callsOnExit: false, banner: line(GREEN, "[detached — this session is open in another window]") };
+    case "error": {
+      const detail = typeof errorMessage === "string" ? errorMessage : "failed to start";
+      return { terminal: true, callsOnExit: true, banner: line(RED, `[${detail}]`) };
+    }
+    default:
+      return { terminal: false, callsOnExit: false, banner: null };
+  }
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -25,6 +25,7 @@ import { connWsUrl, type LaunchChoice } from "../components/wsUrl";
 import { reconnectDelayMs, shouldReconnect } from "./reconnectPolicy";
 import type { RunCommand } from "../components/runCommand";
 import { readableSlot, type SlotCandidate, type SlotInfo } from "./readableSlot";
+import { messageEffect } from "./serverMessage";
 
 export type ConnStatus = "connecting" | "connected" | "disconnected";
 
@@ -287,28 +288,16 @@ function handleMessage(c: Conn, event: MessageEvent) {
       if (v) v.serverCwd = msg.cwd;
       c.handlers.onCwd?.(msg.cwd);
     }
-  } else if (msg.type === "exit") {
-    // The process exited (claude, or a Run command) — an intentional end; don't
-    // auto-reconnect. The cell uses `exit` to offer a re-run.
+  } else {
+    // exit / superseded / error — a terminal message. messageEffect decides which retries,
+    // which fires onExit (NOT superseded — the session is alive in another tab), and the
+    // wording; this applies it.
+    const effect = messageEffect(msg.type, !!c.target.command, msg.message);
+    if (!effect.terminal) return;
     c.sawExit = true;
-    c.term.write(c.target.command ? "\r\n\x1b[33m[finished]\x1b[0m\r\n" : "\r\n\x1b[33m[session ended]\x1b[0m\r\n");
+    if (effect.banner) c.term.write(effect.banner);
     setStatus(c, "disconnected");
-    c.handlers.onExit?.();
-  } else if (msg.type === "superseded") {
-    // Another client (this session open in another tab/cell) took over. Stop —
-    // reconnecting would kick the other one off and ping-pong forever.
-    c.sawExit = true;
-    c.term.write("\r\n\x1b[33m[detached — this session is open in another window]\x1b[0m\r\n");
-    setStatus(c, "disconnected");
-  } else if (msg.type === "error") {
-    // Server-declared terminal failure (CLI missing, command unresolvable). Not
-    // transient — reconnecting would re-trigger the failed spawn, so stop and
-    // surface a stable error. Emit `exit` so a CommandCell can offer a re-run.
-    c.sawExit = true;
-    const detail = typeof msg.message === "string" ? msg.message : "failed to start";
-    c.term.write(`\r\n\x1b[31m[${detail}]\x1b[0m\r\n`);
-    setStatus(c, "disconnected");
-    c.handlers.onExit?.();
+    if (effect.callsOnExit) c.handlers.onExit?.();
   }
 }
 

--- a/test/src/composables/serverMessage.spec.ts
+++ b/test/src/composables/serverMessage.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+import { messageEffect } from "../../../src/composables/serverMessage";
+
+describe("messageEffect", () => {
+  // An unknown or non-terminal type must not stop the connection — output/session are handled
+  // elsewhere, and a stray type must not be mistaken for a terminal one.
+  it.each([["output"], ["session"], [undefined], ["heartbeat"], [""]])("is non-terminal for %j", (type) => {
+    expect(messageEffect(type, false)).toEqual({ terminal: false, callsOnExit: false, banner: null });
+  });
+
+  it("treats exit as terminal and fires onExit", () => {
+    const e = messageEffect("exit", false);
+    expect([e.terminal, e.callsOnExit]).toEqual([true, true]);
+  });
+
+  // A Run command finished vs an agent session ended — only the wording differs.
+  it("words the exit banner by whether the slot is a command", () => {
+    expect(messageEffect("exit", true).banner).toContain("[finished]");
+    expect(messageEffect("exit", false).banner).toContain("[session ended]");
+  });
+
+  // THE decision this file exists for: superseded is terminal (don't reconnect — the two tabs
+  // would evict each other forever) but must NOT fire onExit — the session is alive elsewhere,
+  // so offering a re-run is wrong.
+  it("stops on superseded WITHOUT firing onExit", () => {
+    const e = messageEffect("superseded", false);
+    expect([e.terminal, e.callsOnExit]).toEqual([true, false]);
+    expect(e.banner).toContain("another window");
+  });
+
+  it("treats error as terminal and fires onExit", () => {
+    const e = messageEffect("error", false, "claude not found");
+    expect([e.terminal, e.callsOnExit]).toEqual([true, true]);
+    expect(e.banner).toContain("claude not found");
+  });
+
+  // A non-string message (or none) must not paste "undefined" into the terminal.
+  it.each([[undefined], [null], [42], [{}]])("falls back to a stable error banner for message %j", (message) => {
+    expect(messageEffect("error", false, message).banner).toContain("failed to start");
+  });
+
+  it("uses the command wording only for exit, not for error", () => {
+    // error is the same regardless of isCommand — the branch is exit-only.
+    expect(messageEffect("error", true, "x").banner).toBe(messageEffect("error", false, "x").banner);
+  });
+});


### PR DESCRIPTION
## Summary

`handleMessage`'s `exit` / `superseded` / `error` branches each decided three things — is this terminal (so reconnect must not retry), does it fire `onExit` (so a cell offers a re-run), and the wording — and all of it surfaced only through xterm writes, status flips, and reconnect suppression. Nothing asserted any of it.

The one that bites is **`superseded`**: it is terminal like `exit`, but it must **not** fire `onExit` — the session is alive in another tab, so offering a re-run is wrong — and it must **not** be retried, or the two tabs evict each other forever. Written inline, that distinction is one word from wrong and invisible in review.

`messageEffect(type, isCommand, errorMessage) → { terminal, callsOnExit, banner }`. The handler keeps the writes, the status, and the `onExit` call. `output`/`session` paths unchanged.

## Items to Confirm / Review
- Making `superseded` fire `onExit` turns a test red — that is the specific regression this guards.
- `error` with a non-string `message` falls back to `"failed to start"` rather than pasting `undefined`; pinned.
- The `[finished]` vs `[session ended]` wording is exit-only (a Run command vs an agent session).

## Checks
lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `213 files / 2876 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)