### PR TITLE
refactor: make the plugin tool-envelope interpretation testable (#611)

### DIFF
--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -28,17 +28,10 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprot
 import { randomUUID } from "node:crypto";
 import { toolDefinitions } from "../infra/plugins-registry.js";
 import { offeredTools, routeToolCall, SUBMIT_TRANSLATION_TOOL_NAME } from "./tool-gate.js";
+import { interpretToolEnvelope } from "./tool-envelope.js";
 
 // Shape of the dispatch route's response (POST /api/plugin/<tool>). `data` gates
 // whether a toolResult is published to the GUI; the rest is narration/metadata.
-interface ToolEnvelope {
-  data?: unknown;
-  title?: unknown;
-  jsonData?: unknown;
-  message?: unknown;
-  instructions?: unknown;
-}
-
 const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 async function postJson(url: string, body: unknown) {
@@ -105,26 +98,15 @@ export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { su
       return { content: [{ type: "text", text: route.message }], isError: true };
     }
 
-    // 1. Dispatch to the plugin's server-side handler.
+    // Dispatch to the plugin's server-side handler, then interpret its envelope (tool-envelope.ts).
     const parsed = await (await postJson(`${baseUrl}/api/plugin/${name}`, args ?? {})).json();
-    const envelope: ToolEnvelope = isRecord(parsed) ? parsed : {};
+    const { publish, narration } = interpretToolEnvelope(isRecord(parsed) ? parsed : {});
 
-    // 2. Publish a toolResult to the GUI — only when there is data to render.
-    if (envelope.data !== undefined) {
-      await postJson(`${baseUrl}/api/agent/toolResult`, {
-        sessionId,
-        toolName: name,
-        uuid: randomUUID(),
-        title: envelope.title,
-        data: envelope.data,
-        jsonData: envelope.jsonData ?? envelope.data,
-        message: envelope.message,
-      });
+    // A GUI toolResult, only when there is data to render.
+    if (publish) {
+      await postJson(`${baseUrl}/api/agent/toolResult`, { sessionId, toolName: name, uuid: randomUUID(), ...publish });
     }
-
-    // 3. Return the narration to claude.
-    const parts = [envelope.message, envelope.instructions].filter(Boolean);
-    return { content: [{ type: "text", text: parts.length ? parts.join("\n") : "Done" }] };
+    return { content: [{ type: "text", text: narration }] };
   });
 
   return server;

--- a/server/mcp/tool-envelope.ts
+++ b/server/mcp/tool-envelope.ts
@@ -1,0 +1,38 @@
+// How a plugin's response envelope becomes two things: what the GUI panel renders, and what
+// claude is told.
+//
+// Three decisions sat inline in the CallTool handler, between two postJson calls, so no test
+// reached them — yet they run for EVERY plugin call:
+//
+//   - publish a GUI toolResult ONLY when the plugin returned `data`. Flip this and either
+//     every panel (forms, charts, collection views) silently stops rendering, or the GUI is
+//     flooded with empty results.
+//   - the structured-view payload is `jsonData ?? data` — a view falls back to the plain data
+//     when the plugin sent no separate structured form.
+//   - the narration handed back to claude is message+instructions joined, or the literal
+//     "Done". Lose the join and claude gets "Done" instead of a form's instructions and stops
+//     following up — a broad, silent regression across all plugins.
+
+export interface ToolEnvelope {
+  data?: unknown;
+  title?: unknown;
+  jsonData?: unknown;
+  message?: unknown;
+  instructions?: unknown;
+}
+
+export interface ToolEnvelopeResult {
+  // The GUI toolResult to publish, or null when there is no data to render.
+  publish: { title: unknown; data: unknown; jsonData: unknown; message: unknown } | null;
+  // The text returned to claude — never empty.
+  narration: string;
+}
+
+export function interpretToolEnvelope(envelope: ToolEnvelope): ToolEnvelopeResult {
+  const publish =
+    envelope.data !== undefined
+      ? { title: envelope.title, data: envelope.data, jsonData: envelope.jsonData ?? envelope.data, message: envelope.message }
+      : null;
+  const parts = [envelope.message, envelope.instructions].filter(Boolean);
+  return { publish, narration: parts.length ? parts.join("\n") : "Done" };
+}

--- a/test/server/mcp/tool-envelope.spec.ts
+++ b/test/server/mcp/tool-envelope.spec.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { interpretToolEnvelope } from "../../../server/mcp/tool-envelope.js";
+
+describe("interpretToolEnvelope — the GUI publish", () => {
+  // Publish only when there is data. Flip this and every plugin panel either stops rendering
+  // or the GUI floods with empty results.
+  it("publishes when the plugin returned data", () => {
+    expect(interpretToolEnvelope({ data: { rows: [] } }).publish).not.toBeNull();
+  });
+
+  it("does not publish when there is no data", () => {
+    expect(interpretToolEnvelope({ message: "noted" }).publish).toBeNull();
+  });
+
+  // null / false / 0 / "" are real data a view may render — only `undefined` means "nothing".
+  it.each([[null], [false], [0], [""]])("treats %j as data worth publishing", (data) => {
+    expect(interpretToolEnvelope({ data }).publish).not.toBeNull();
+  });
+
+  it("carries title, data and message through", () => {
+    const r = interpretToolEnvelope({ data: 1, title: "T", message: "M" });
+    expect(r.publish).toMatchObject({ title: "T", data: 1, message: "M" });
+  });
+
+  // The structured view falls back to the plain data when the plugin sent no separate form.
+  it("uses jsonData when present, else data", () => {
+    expect(interpretToolEnvelope({ data: 1, jsonData: 2 }).publish?.jsonData).toBe(2);
+    expect(interpretToolEnvelope({ data: 1 }).publish?.jsonData).toBe(1);
+  });
+});
+
+describe("interpretToolEnvelope — the narration to claude", () => {
+  it("joins message and instructions", () => {
+    expect(interpretToolEnvelope({ message: "saved", instructions: "now ask X" }).narration).toBe("saved\nnow ask X");
+  });
+
+  it("uses whichever of the two is present", () => {
+    expect(interpretToolEnvelope({ message: "only message" }).narration).toBe("only message");
+    expect(interpretToolEnvelope({ instructions: "only instructions" }).narration).toBe("only instructions");
+  });
+
+  // Lose this and claude gets "Done" instead of the plugin's instructions and stops following
+  // up — a silent regression across all plugins.
+  it("never returns an empty string", () => {
+    expect(interpretToolEnvelope({}).narration).toBe("Done");
+    expect(interpretToolEnvelope({ data: 1 }).narration).toBe("Done");
+  });
+
+  // filter(Boolean) drops empty strings, so a blank message must not produce a leading newline.
+  it("does not join a blank part into the narration", () => {
+    expect(interpretToolEnvelope({ message: "", instructions: "go" }).narration).toBe("go");
+  });
+});


### PR DESCRIPTION
## Summary

Three decisions ran for **every** plugin call, inline between two `postJson` calls in the CallTool handler, so no test reached any of them:

- **publish a GUI toolResult only when the plugin returned `data`** — and `data !== undefined`, not truthiness, because `null` / `false` / `0` / `""` are real values a view renders. Flip it and every panel (forms, charts, collection views) stops rendering, or the GUI floods with empty results.
- the structured-view payload is `jsonData ?? data`.
- the **narration to claude** is `message`+`instructions` joined, else `"Done"`. Lose the join and claude gets `"Done"` instead of a form's instructions and stops following up — a silent regression across all plugins.

`interpretToolEnvelope(envelope) → { publish, narration }`. The handler keeps the two `postJson` calls. Behaviour unchanged.

## Items to Confirm / Review
- The `undefined`-not-truthy distinction is pinned: `null`/`false`/`0`/`""` all publish. Degrading the check to truthiness turns 4 red.
- `narration` is never empty; a blank `message` does not produce a leading newline (`filter(Boolean)`).

## Checks
lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `214 files / 2888 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)