### PR TITLE
refactor: make the server-tool load gate testable (#611)

### DIFF
--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -32,6 +32,7 @@ import { artifactsFileOps } from "../backends/artifacts.js";
 import { createPluginRuntime } from "./pluginRuntime.js";
 import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
+import { missingRequiredEnv, soleExecutor } from "./server-tool-load.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // ../.. climbs server/infra/ → server/ → package root, where plugins/ lives.
@@ -96,11 +97,7 @@ async function loadPackage(name: string) {
   // and ship no `pluginCore` on the core entry (their origin host registers the tool
   // as a built-in). Fall back to a sole `execute*` function export so such packages
   // still load without hardcoding their name.
-  const soleExecuteStar = (() => {
-    const fns = Object.entries(mod).filter(([key, val]) => key.startsWith("execute") && typeof val === "function");
-    return fns.length === 1 ? (fns[0][1] as (...args: unknown[]) => unknown) : undefined;
-  })();
-  const execute = mod.pluginCore?.execute ?? mod.execute ?? soleExecuteStar;
+  const execute = mod.pluginCore?.execute ?? mod.execute ?? soleExecutor(mod);
   if (!definition || typeof execute !== "function") {
     throw new Error(`Package "${name}" is not a gui-chat-protocol plugin (missing TOOL_DEFINITION/execute).`);
   }
@@ -136,7 +133,7 @@ async function loadServerToolPackage(name: string) {
   }
   return tools
     .filter((tool) => {
-      const missing = (tool.requiredEnv ?? []).filter((key) => !process.env[key]);
+      const missing = missingRequiredEnv(tool.requiredEnv, process.env);
       if (missing.length > 0) {
         console.warn(`[plugins] skipping server tool "${tool.definition.name}" — missing env: ${missing.join(", ")}`);
         return false;

--- a/server/infra/server-tool-load.ts
+++ b/server/infra/server-tool-load.ts
@@ -1,0 +1,29 @@
+// The two load-time decisions for a server-tool package, out of the async importer that reads
+// process.env and the module namespace directly.
+//
+// requiredEnv: a server-only tool (e.g. an X/Twitter plugin) whose required env vars are not
+// all set is DROPPED, so claude never sees a tool it cannot run. Invert or mis-key this and
+// either a credential-less tool reaches the broker — claude calls it mid-task, gets a
+// missing-token error, wastes a turn — or a perfectly runnable tool silently disappears.
+//
+// soleExecutor: a package that ships no `execute`/`pluginCore.execute` but a single
+// descriptively-named `execute*` function is loaded by picking that one. Two such exports →
+// give up (ambiguous), rather than choosing arbitrarily.
+
+// Which of a tool's required env vars are absent from the given environment.
+export function missingRequiredEnv(requiredEnv: readonly string[] | undefined, env: NodeJS.ProcessEnv): string[] {
+  return (requiredEnv ?? []).filter((key) => !env[key]);
+}
+
+// A tool loads only when none of its required env vars is missing.
+export function serverToolEnabled(requiredEnv: readonly string[] | undefined, env: NodeJS.ProcessEnv): boolean {
+  return missingRequiredEnv(requiredEnv, env).length === 0;
+}
+
+// The sole `execute*` function export, or undefined when there is not exactly one — the
+// fallback executor for packages that name their entry point descriptively and ship no
+// `execute`. Undefined for zero (nothing to pick) and for two or more (ambiguous).
+export function soleExecutor(mod: Record<string, unknown>): ((...args: unknown[]) => unknown) | undefined {
+  const fns = Object.entries(mod).filter(([key, val]) => key.startsWith("execute") && typeof val === "function");
+  return fns.length === 1 ? (fns[0][1] as (...args: unknown[]) => unknown) : undefined;
+}

--- a/test/server/infra/server-tool-load.spec.ts
+++ b/test/server/infra/server-tool-load.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { missingRequiredEnv, serverToolEnabled, soleExecutor } from "../../../server/infra/server-tool-load.js";
+
+const env = (obj: Record<string, string>) => obj as NodeJS.ProcessEnv;
+
+describe("missingRequiredEnv", () => {
+  it("is empty when a tool needs nothing", () => {
+    expect(missingRequiredEnv(undefined, env({}))).toEqual([]);
+    expect(missingRequiredEnv([], env({}))).toEqual([]);
+  });
+
+  it("names every var that is absent", () => {
+    expect(missingRequiredEnv(["A", "B", "C"], env({ B: "set" }))).toEqual(["A", "C"]);
+  });
+
+  // An env var present but empty is still "not set" — a blank token cannot run the tool.
+  it("treats an empty value as missing", () => {
+    expect(missingRequiredEnv(["A"], env({ A: "" }))).toEqual(["A"]);
+  });
+});
+
+describe("serverToolEnabled", () => {
+  // The gate: a credential-less tool must be dropped so claude never calls one it can't run.
+  it("enables a tool only when all its env vars are set", () => {
+    expect(serverToolEnabled(["X_TOKEN"], env({ X_TOKEN: "t" }))).toBe(true);
+    expect(serverToolEnabled(["X_TOKEN"], env({}))).toBe(false);
+  });
+
+  it("enables a tool that needs no env at all", () => {
+    expect(serverToolEnabled(undefined, env({}))).toBe(true);
+  });
+
+  it("is disabled when even one of several is missing", () => {
+    expect(serverToolEnabled(["A", "B"], env({ A: "set" }))).toBe(false);
+  });
+});
+
+describe("soleExecutor", () => {
+  const fn = () => 1;
+
+  it("picks the one execute* export", () => {
+    expect(soleExecutor({ executePresentForm: fn, TOOL_DEFINITION: {} })).toBe(fn);
+  });
+
+  // Two execute* exports is ambiguous — pick neither rather than guess.
+  it("returns undefined when two execute* functions exist", () => {
+    expect(soleExecutor({ executeA: fn, executeB: () => 2 })).toBeUndefined();
+  });
+
+  it("returns undefined when there is none", () => {
+    expect(soleExecutor({ TOOL_DEFINITION: {}, helper: fn })).toBeUndefined();
+  });
+
+  // Only a function counts — an `executeConfig` object export must not be chosen.
+  it("ignores an execute* export that is not a function", () => {
+    expect(soleExecutor({ executeConfig: { a: 1 } })).toBeUndefined();
+  });
+
+  it("matches on the execute prefix, not a bare name", () => {
+    expect(soleExecutor({ runExecute: fn })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two load-time decisions were buried in async importers reading `process.env` and the module namespace directly, so the only spec (a "does `plugins.json` still import" smoke test) never touched them:

- **requiredEnv gate** — a server-only tool whose required env vars aren't all set is dropped, so claude never sees a tool it can't run. Invert or mis-key it and either a credential-less tool reaches the broker (claude calls it, gets a missing-token error, wastes a turn) or a runnable tool silently disappears.
- **sole `execute*` fallback** — a package that ships one descriptively-named `execute*` function and no bare `execute` is loaded by picking it; two such exports is ambiguous → pick neither.

`missingRequiredEnv` / `serverToolEnabled` / `soleExecutor` are pure now; the loaders keep the `await import` and `process.env` read.

## Items to Confirm / Review
- **An empty env value counts as missing** (`!env[key]`) — a blank token can't run the tool. Pinned.
- Making `soleExecutor` pick the first of several turns a test red; a non-function `execute*` export is ignored.

## Checks
lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `215 files / 2899 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)