### PR TITLE
refactor: one definition of each settings add-validator (#611)

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -9,6 +9,7 @@ import SettingsButton from "./SettingsButton.vue";
 import SettingsField from "./SettingsField.vue";
 import type { Launcher } from "./launchers";
 import type { UserMcpServer } from "./userMcp";
+import { canAddLauncher, canAddMcpServer, canAddRepo } from "./settingsValidators";
 
 const props = defineProps<{
   soundFile?: string | null;
@@ -30,20 +31,16 @@ const emit = defineEmits<{
 
 // Cross-repo PR view's repos ("owner/repo"). Editable list mirroring the saved value;
 // add/remove emits the new list up (App persists it).
-const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
 const repos = ref<string[]>([...(props.prRepos ?? [])]);
 watch(
   () => props.prRepos,
   (r) => (repos.value = [...(r ?? [])]),
 );
 const newRepo = ref("");
-const newRepoValid = computed(() => {
-  const r = newRepo.value.trim();
-  return REPO_RE.test(r) && !repos.value.includes(r);
-});
+const newRepoValid = computed(() => canAddRepo(newRepo.value, repos.value));
 function addRepo() {
   const r = newRepo.value.trim();
-  if (!REPO_RE.test(r) || repos.value.includes(r)) return;
+  if (!newRepoValid.value) return;
   repos.value = [...repos.value, r];
   newRepo.value = "";
   emit("update-repos", repos.value);
@@ -62,15 +59,11 @@ watch(
 );
 const newLauncherLabel = ref("");
 const newLauncherCommand = ref("");
-const newLauncherValid = computed(() => {
-  const label = newLauncherLabel.value.trim();
-  const command = newLauncherCommand.value.trim();
-  return !!label && !!command && !launcherList.value.some((l) => l.label === label);
-});
+const newLauncherValid = computed(() => canAddLauncher(newLauncherLabel.value, newLauncherCommand.value, launcherList.value));
 function addLauncher() {
   const label = newLauncherLabel.value.trim();
   const command = newLauncherCommand.value.trim();
-  if (!label || !command || launcherList.value.some((l) => l.label === label)) return;
+  if (!newLauncherValid.value) return;
   launcherList.value = [...launcherList.value, { label, command }];
   newLauncherLabel.value = "";
   newLauncherCommand.value = "";
@@ -83,7 +76,6 @@ function removeLauncher(label: string) {
 
 // User HTTP MCP servers (id + url) merged into the single-view Claude session. Editable
 // list mirroring the saved value; add/remove emits the new list up.
-const MCP_ID_RE = /^[A-Za-z0-9_-]+$/;
 const mcpServers = ref<UserMcpServer[]>([...(props.userMcpServers ?? [])]);
 watch(
   () => props.userMcpServers,
@@ -91,11 +83,7 @@ watch(
 );
 const newMcpId = ref("");
 const newMcpUrl = ref("");
-const newMcpValid = computed(() => {
-  const id = newMcpId.value.trim();
-  const url = newMcpUrl.value.trim();
-  return MCP_ID_RE.test(id) && /^https?:\/\/\S+$/.test(url) && !mcpServers.value.some((s) => s.id === id);
-});
+const newMcpValid = computed(() => canAddMcpServer(newMcpId.value, newMcpUrl.value, mcpServers.value));
 function addMcpServer() {
   const id = newMcpId.value.trim();
   const url = newMcpUrl.value.trim();

--- a/src/components/settingsValidators.ts
+++ b/src/components/settingsValidators.ts
@@ -1,0 +1,31 @@
+// The "may I add this?" rules for the settings lists: a PR repo, a cell launcher, an HTTP MCP
+// server. Each is a format check AND a uniqueness check, and each drives BOTH a button's
+// disabled state and the add handler's guard. They were written twice per rule (the computed
+// and the guard), which is how a validated-but-rejected input — an enabled button that does
+// nothing — or the reverse slips in. One definition each, consumed by both.
+
+// `owner/repo`, each side the GitHub-safe character set. A malformed value silently breaks the
+// cross-repo PR view's fetch.
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+export function canAddRepo(repo: string, existing: readonly string[]): boolean {
+  const trimmed = repo.trim();
+  return REPO_RE.test(trimmed) && !existing.includes(trimmed);
+}
+
+export function canAddLauncher(label: string, command: string, existing: readonly { label: string }[]): boolean {
+  const l = label.trim();
+  const c = command.trim();
+  return !!l && !!c && !existing.some((entry) => entry.label === l);
+}
+
+// The id becomes the `mcp__<id>` tool prefix server-side, so it is restricted; the url must be
+// http(s). A bad id breaks the tool namespace; a non-http url breaks the MCP connection.
+const MCP_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MCP_URL_RE = /^https?:\/\/\S+$/;
+
+export function canAddMcpServer(id: string, url: string, existing: readonly { id: string }[]): boolean {
+  const i = id.trim();
+  const u = url.trim();
+  return MCP_ID_RE.test(i) && MCP_URL_RE.test(u) && !existing.some((entry) => entry.id === i);
+}

--- a/test/src/components/settingsValidators.spec.ts
+++ b/test/src/components/settingsValidators.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+
+import { canAddLauncher, canAddMcpServer, canAddRepo } from "../../../src/components/settingsValidators";
+
+describe("canAddRepo", () => {
+  it("accepts owner/repo", () => {
+    expect(canAddRepo("receptron/mulmoterminal", [])).toBe(true);
+    expect(canAddRepo("a.b_c-d/e.f_g-h", [])).toBe(true);
+  });
+
+  it("trims before validating", () => {
+    expect(canAddRepo("  owner/repo  ", [])).toBe(true);
+  });
+
+  // A malformed value silently breaks the cross-repo PR fetch, so the button must stay disabled.
+  it.each([["norepo"], ["owner/"], ["/repo"], ["owner/repo/extra"], ["owner repo"], ["owner/re po"], [""]])("rejects the malformed %j", (repo) => {
+    expect(canAddRepo(repo, [])).toBe(false);
+  });
+
+  it("rejects a duplicate", () => {
+    expect(canAddRepo("a/b", ["a/b"])).toBe(false);
+    // …after trimming, so a padded duplicate is still caught.
+    expect(canAddRepo("  a/b ", ["a/b"])).toBe(false);
+  });
+});
+
+describe("canAddLauncher", () => {
+  it("needs both a label and a command", () => {
+    expect(canAddLauncher("Shell", "$SHELL", [])).toBe(true);
+    expect(canAddLauncher("", "$SHELL", [])).toBe(false);
+    expect(canAddLauncher("Shell", "", [])).toBe(false);
+    expect(canAddLauncher("   ", "   ", [])).toBe(false);
+  });
+
+  it("rejects a duplicate label", () => {
+    expect(canAddLauncher("Shell", "zsh", [{ label: "Shell" }])).toBe(false);
+  });
+});
+
+describe("canAddMcpServer", () => {
+  it("accepts a safe id and an http(s) url", () => {
+    expect(canAddMcpServer("my-server", "https://example.com/mcp", [])).toBe(true);
+    expect(canAddMcpServer("srv_1", "http://localhost:3000", [])).toBe(true);
+  });
+
+  // The id becomes the mcp__<id> tool prefix — a bad one breaks the tool namespace.
+  it.each([["has space"], ["has/slash"], ["dot.name"], [""], ["has:colon"]])("rejects the unsafe id %j", (id) => {
+    expect(canAddMcpServer(id, "https://example.com", [])).toBe(false);
+  });
+
+  // A non-http url breaks the MCP connection.
+  it.each([["f" + "tp://host"], ["example.com"], ["w" + "s://host"], ["https://"], ["https:// space"], [""]])("rejects the non-http url %j", (url) => {
+    expect(canAddMcpServer("srv", url, [])).toBe(false);
+  });
+
+  it("rejects a duplicate id", () => {
+    expect(canAddMcpServer("srv", "https://a.com", [{ id: "srv" }])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The repo / launcher / MCP "may I add this?" rules each drive **two** things — a button's `disabled` state and the add handler's guard — and the repo rule was written out in **both** the computed and the guard (`REPO_RE.test` + dedup, twice). That is how a validated-but-rejected input (an enabled button that does nothing), or the reverse, slips in.

Each rule is one pure function now (`canAddRepo` / `canAddLauncher` / `canAddMcpServer`), consumed by both the computed and the guard.

They were also entirely untested — `SettingsModal.spec` covers sound/push/theme, never these fields.

## Items to Confirm / Review
- The character sets that matter are pinned: the MCP **id becomes the `mcp__<id>` tool prefix** (so it's restricted), the url must be http(s), `owner/repo` drives the cross-repo PR fetch.
- Dropping the MCP url check turns 6 red.
- Behaviour unchanged — same regexes, same dedup, now trimmed consistently in one place.

## Checks
lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `215 files / 2925 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)