### PR TITLE
refactor: one definition of a feed summary, for desktop and phone (#611)

### DIFF
--- a/server/backends/feed-summary.ts
+++ b/server/backends/feed-summary.ts
@@ -1,0 +1,27 @@
+// One feeds-index row, from a registered feed's schema and its last-fetch state.
+//
+// The desktop route (feeds.ts) and the phone command channel (remoteHost/handlers.ts) both
+// build this, and both had their own copy of the same defaulting: a feed that declares no
+// `ingest` block still shows a kind and a schedule, `"rss"` and `"on-demand"`. Two copies
+// documented as mirrors is how they drift — the two surfaces would then disagree on a feed's
+// badge, or one would show `undefined` where the other shows a default.
+import type { FeedSummary } from "@mulmoclaude/core/collection";
+
+const DEFAULT_KIND = "rss";
+const DEFAULT_SCHEDULE = "on-demand";
+
+export interface FeedLike {
+  slug: string;
+  schema: { title: string; icon: string; ingest?: { kind?: string; schedule?: string } };
+}
+
+export function feedSummary(feed: FeedLike, lastFetchedAt: string | null): FeedSummary {
+  return {
+    slug: feed.slug,
+    title: feed.schema.title,
+    icon: feed.schema.icon,
+    kind: feed.schema.ingest?.kind ?? DEFAULT_KIND,
+    schedule: feed.schema.ingest?.schedule ?? DEFAULT_SCHEDULE,
+    lastFetchedAt,
+  };
+}

--- a/server/backends/feeds.ts
+++ b/server/backends/feeds.ts
@@ -16,6 +16,7 @@ import { configureFeedsHost, refreshOne, listFeeds, readFeedState, removeFeed, t
 import { loadCollection } from "@mulmoclaude/core/collection/server";
 import type { FeedSummary } from "@mulmoclaude/core/collection";
 import { writeFileAtomic } from "../files/atomic-write.js";
+import { feedSummary } from "./feed-summary.js";
 
 const log: FeedsLogger = {
   error: (prefix, msg, data) => console.error(`[${prefix}] ${msg}`, data ?? ""),
@@ -40,15 +41,7 @@ function errorMessage(err: unknown): string {
 // One feeds-index row: the registered feed's schema + its last-fetch state.
 async function toFeedSummary(feed: Awaited<ReturnType<typeof listFeeds>>[number]): Promise<FeedSummary> {
   const state = await readFeedState(workspaceRoot, feed);
-  const ingest = feed.schema.ingest;
-  return {
-    slug: feed.slug,
-    title: feed.schema.title,
-    icon: feed.schema.icon,
-    kind: ingest?.kind ?? "rss",
-    schedule: ingest?.schedule ?? "on-demand",
-    lastFetchedAt: state.lastFetchedAt,
-  };
+  return feedSummary(feed, state.lastFetchedAt);
 }
 
 /** Mount POST /api/collections/:slug/refresh — generic over ingest.kind (the engine

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -28,6 +28,7 @@ import {
 import type { Attachment } from "./ingestAttachments.js";
 import { createTerminalInputSender } from "./terminalInput.js";
 import type { SessionScreen, TerminalSessionSummary } from "./terminalScreen.js";
+import { feedSummary } from "../feed-summary.js";
 
 export interface RemoteHostHandlerDeps {
   workspace: string;
@@ -197,15 +198,7 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
       const summaries = [];
       for (const feed of feeds) {
         const state = await readFeedState(workspace, feed);
-        const { ingest } = feed.schema;
-        summaries.push({
-          slug: feed.slug,
-          title: feed.schema.title,
-          icon: feed.schema.icon,
-          kind: ingest?.kind ?? "rss",
-          schedule: ingest?.schedule ?? "on-demand",
-          lastFetchedAt: state.lastFetchedAt,
-        });
+        summaries.push(feedSummary(feed, state.lastFetchedAt));
       }
       return { feeds: summaries } as unknown as JsonObject;
     },

--- a/test/server/backends/feed-summary.spec.ts
+++ b/test/server/backends/feed-summary.spec.ts
@@ -1,0 +1,32 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { feedSummary, type FeedLike } from "../../../server/backends/feed-summary.js";
+
+const feed = (over: Partial<FeedLike["schema"]> = {}): FeedLike => ({
+  slug: "news",
+  schema: { title: "News", icon: "rss_feed", ...over },
+});
+
+describe("feedSummary", () => {
+  it("carries the feed's own kind and schedule when it declares an ingest block", () => {
+    const s = feedSummary(feed({ ingest: { kind: "agent", schedule: "daily" } }), "2026-07-23T00:00:00Z");
+    expect(s).toEqual({ slug: "news", title: "News", icon: "rss_feed", kind: "agent", schedule: "daily", lastFetchedAt: "2026-07-23T00:00:00Z" });
+  });
+
+  // The defaulting the two copies had to agree on: a feed with no ingest block still shows a
+  // kind and a schedule on BOTH the desktop route and the phone channel.
+  it("defaults a feed with no ingest to rss / on-demand", () => {
+    const s = feedSummary(feed(), null);
+    expect([s.kind, s.schedule]).toEqual(["rss", "on-demand"]);
+  });
+
+  it("defaults each field independently", () => {
+    expect(feedSummary(feed({ ingest: { schedule: "hourly" } }), null).kind).toBe("rss");
+    expect(feedSummary(feed({ ingest: { kind: "agent" } }), null).schedule).toBe("on-demand");
+  });
+
+  it("passes a null last-fetch time through", () => {
+    expect(feedSummary(feed(), null).lastFetchedAt).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`toFeedSummary` (feeds.ts, desktop) and `listFeeds` (remoteHost/handlers.ts, phone) each built a feed-index row with **their own copy** of the same defaulting: a feed with no `ingest` block still shows kind `"rss"` and schedule `"on-demand"`. Two copies documented as mirrors is how they drift — the two surfaces would then disagree on a feed's badge, or one would show `undefined` where the other shows a default. The desktop copy had a test (`feeds.spec`); the phone copy (`listFeeds`) did not.

`feedSummary(feed, lastFetchedAt)` is the one definition now, with its own test. Both callers keep their `readFeedState` I/O.

## Items to Confirm / Review
- Behaviour unchanged — same fields, same defaults. Each defaults independently (a feed with only `kind` still defaults `schedule`, and vice-versa). Mis-defaulting the schedule turns 2 red.

## Checks
lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `216 files / 2917 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)