### PR TITLE
refactor: make the toolbar's grid-status summary testable (#611)

### DIFF
--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -13,6 +13,7 @@ import { usePrsView, prsGotoIndex } from "../composables/usePrsView";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
 import type { Shortcut } from "../types/shortcuts";
 import type { StatusCounts } from "./gridTabs";
+import { gridStatusSummary } from "./gridTabs";
 
 // The standard header, shared by the single (App.vue) and grid (GridView.vue) views so
 // both show one identical toolbar. Every launcher button now just pushes a route — the
@@ -27,17 +28,9 @@ const emit = defineEmits<{ (e: "add-terminal" | "toggle-sort" | "settings"): voi
 const route = useRoute();
 // Grid-wide, at-a-glance tally: how many cells are blocked (need input) / done
 // (review) / working, across every page. Shown only when something is running.
-const summaryTitle = computed(() => {
-  const c = props.statusCounts;
-  if (!c) return "";
-  const parts: string[] = [];
-  if (c.blocked) parts.push(`${c.blocked} need input`);
-  if (c.done) parts.push(`${c.done} done (review)`);
-  if (c.working) parts.push(`${c.working} working`);
-  if (c.idle) parts.push(`${c.idle} idle`);
-  return parts.join(" · ");
-});
-const hasSummary = computed(() => !!props.statusCounts && props.statusCounts.blocked + props.statusCounts.done + props.statusCounts.working > 0);
+const summary = computed(() => gridStatusSummary(props.statusCounts));
+const summaryTitle = computed(() => summary.value.title);
+const hasSummary = computed(() => summary.value.show);
 const { shortcuts } = useShortcuts();
 const { view: browseView } = useCollectionBrowse();
 const { isOpen: accountingOpen } = useAccountingView();

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -353,3 +353,27 @@ export function resolveCellStatus(
   }
   return out;
 }
+
+// The toolbar's grid-wide, at-a-glance tally. Two decisions, and the asymmetry is deliberate:
+//
+// The badge shows only when something is actually RUNNING — blocked + done + working > 0.
+// Idle is NOT counted there: a grid of nothing but idle cells has nothing to triage, and
+// surfacing the strip on every quiet session is noise. But idle IS in the tooltip text, as
+// the trailing part, because once the strip is up "how many are idle" is useful context.
+//
+// Order is fixed: blocked (needs you) first, then done, working, idle — the reading order for
+// deciding which cell to look at.
+export interface GridStatusSummary {
+  show: boolean;
+  title: string;
+}
+
+export function gridStatusSummary(counts: StatusCounts | null | undefined): GridStatusSummary {
+  if (!counts) return { show: false, title: "" };
+  const parts: string[] = [];
+  if (counts.blocked) parts.push(`${counts.blocked} need input`);
+  if (counts.done) parts.push(`${counts.done} done (review)`);
+  if (counts.working) parts.push(`${counts.working} working`);
+  if (counts.idle) parts.push(`${counts.idle} idle`);
+  return { show: counts.blocked + counts.done + counts.working > 0, title: parts.join(" · ") };
+}

--- a/test/src/components/gridTabs.spec.ts
+++ b/test/src/components/gridTabs.spec.ts
@@ -31,6 +31,7 @@ import {
   type CellStatus,
   type GridState,
   type Cell,
+  gridStatusSummary,
 } from "../../../src/components/gridTabs.js";
 
 const U = (n: number) => `${String(n % 10).repeat(8)}-aaaa-aaaa-aaaa-aaaaaaaaaaaa`;
@@ -518,5 +519,40 @@ describe("resolveCellStatus", () => {
 
   it("returns an empty map for no cells", () => {
     expect(resolveCellStatus([], new Map<string, CellStatus>(), {})).toEqual({});
+  });
+});
+
+describe("gridStatusSummary", () => {
+  const counts = (over: Partial<Record<"blocked" | "done" | "working" | "idle", number>> = {}) => ({ blocked: 0, done: 0, working: 0, idle: 0, ...over });
+
+  it("shows nothing when there are no counts", () => {
+    expect(gridStatusSummary(null)).toEqual({ show: false, title: "" });
+    expect(gridStatusSummary(undefined)).toEqual({ show: false, title: "" });
+  });
+
+  // The asymmetry this exists for: idle alone does not raise the badge — a wholly-idle grid
+  // has nothing to triage, and the strip would be noise on every quiet session.
+  it("does not show for a grid that is only idle", () => {
+    expect(gridStatusSummary(counts({ idle: 9 })).show).toBe(false);
+  });
+
+  it.each(["blocked", "done", "working"] as const)("shows as soon as one cell is %s", (key) => {
+    expect(gridStatusSummary(counts({ [key]: 1 })).show).toBe(true);
+  });
+
+  // …but idle IS in the tooltip text once the strip is up.
+  it("includes idle in the title even though it does not raise the badge", () => {
+    const s = gridStatusSummary(counts({ working: 1, idle: 3 }));
+    expect(s.show).toBe(true);
+    expect(s.title).toBe("1 working · 3 idle");
+  });
+
+  // Reading order: blocked (needs you) first.
+  it("orders the parts blocked, done, working, idle", () => {
+    expect(gridStatusSummary(counts({ blocked: 1, done: 2, working: 3, idle: 4 })).title).toBe("1 need input · 2 done (review) · 3 working · 4 idle");
+  });
+
+  it("omits a zero count from the title", () => {
+    expect(gridStatusSummary(counts({ blocked: 2, working: 1 })).title).toBe("2 need input · 1 working");
   });
 });


### PR DESCRIPTION
## Summary

`summaryTitle` and `hasSummary` were two closures over `statusCounts` in `AppToolbar`, which has no spec. The decision worth pinning is the **idle asymmetry**:

- idle is **excluded** from the visibility test (`blocked + done + working > 0`) — a wholly-idle grid has nothing to triage, so the strip would be noise on every quiet session
- idle **is** in the tooltip text (the trailing part) — once the strip is up, "how many idle" is useful context

Written inline, that asymmetry reads like a bug and invites a "fix". `gridStatusSummary(counts) → { show, title }` lands in `gridTabs.ts`, which already owns `StatusCounts`.

## Items to Confirm / Review
- Counting idle in `show` turns a test red — that is the specific regression this guards.
- The reading order (blocked → done → working → idle) is fixed and pinned.
- Behaviour unchanged.

## Checks
lint 0, `typecheck` 0, `typecheck:test` 0, build 0, `216 files / 2925 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)