### PR TITLE
refactor: make the git output parsers testable (#611)

### DIFF
--- a/server/git/git-parse.ts
+++ b/server/git/git-parse.ts
@@ -1,0 +1,34 @@
+// Pure parsing rules that were trapped behind `gh` / `git` spawns, so no test reached them.
+
+// The PR URL from `gh pr create` output: the LAST http(s) line. gh prints the PR URL last,
+// after any tips or notices — so a tip that happens to contain an http line must not win, and
+// the last one is taken rather than the first. Empty output → null (the caller falls back to
+// the compare URL).
+export function lastGhUrl(stdout: string): string | null {
+  const urls = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("http"));
+  return urls.length ? urls[urls.length - 1] : null;
+}
+
+export interface NumstatEntry {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
+// A `git diff --numstat` line: <adds>\t<dels>\t<path>. A binary file reports "-" for its
+// counts, which becomes -1 (the badge shows "binary" rather than a bogus +/-). The path is
+// rejoined with tabs so a path that itself contains a tab survives.
+export function parseNumstatLine(line: string, toCount: (s: string) => number): NumstatEntry {
+  const [add, del, ...rest] = line.split("\t");
+  const num = (s: string) => (s === "-" ? -1 : toCount(s));
+  return { path: rest.join("\t"), additions: num(add), deletions: num(del) };
+}
+
+// Cap a diff patch so a huge one does not bloat the payload over the socket; `truncated` tells
+// the client it is showing a prefix.
+export function capPatch(full: string, limit: number): { patch: string; truncated: boolean } {
+  return full.length > limit ? { patch: full.slice(0, limit), truncated: true } : { patch: full, truncated: false };
+}

--- a/server/git/worktree-diff.ts
+++ b/server/git/worktree-diff.ts
@@ -4,6 +4,7 @@
 // the shared runner and never throw — a non-worktree dir is just `isWorktree:false`.
 import { git, repoRoot, defaultBaseBranch, isManagedWorktree } from "./worktrees.js";
 import { dirtyCount } from "./dirty-count.js";
+import { capPatch, parseNumstatLine } from "./git-parse.js";
 
 export interface WorktreeFile {
   path: string;
@@ -46,16 +47,14 @@ async function changedFiles(cwd: string, base: string): Promise<WorktreeFile[]> 
 }
 
 function parseNumstat(line: string): WorktreeFile {
-  const [add, del, ...rest] = line.split("\t");
-  const toNum = (s: string) => (s === "-" ? -1 : toCount(s));
-  return { path: rest.join("\t"), additions: toNum(add), deletions: toNum(del), status: "changed" };
+  return { ...parseNumstatLine(line, toCount), status: "changed" };
 }
 
 async function diffPatch(cwd: string, base: string): Promise<{ patch: string; truncated: boolean }> {
   const res = await git(["diff", base], cwd);
   if (!res.ok) return { patch: "", truncated: false };
   const full = res.stdout;
-  return full.length > PATCH_LIMIT_CHARS ? { patch: full.slice(0, PATCH_LIMIT_CHARS), truncated: true } : { patch: full, truncated: false };
+  return capPatch(full, PATCH_LIMIT_CHARS);
 }
 
 export async function worktreeDiff(cwd: string): Promise<WorktreeDiff> {

--- a/server/git/worktree-pr.ts
+++ b/server/git/worktree-pr.ts
@@ -5,6 +5,7 @@
 import { repoRoot, defaultBaseBranch, isManagedWorktree, git } from "./worktrees.js";
 import { resolveGithubUrl } from "./gitRemote.js";
 import { spawnCollect, type SpawnResult } from "./spawn-collect.js";
+import { lastGhUrl } from "./git-parse.js";
 
 type Reason = "not-worktree" | "no-branch" | "no-remote" | "no-github" | "push-failed" | "failed";
 
@@ -64,15 +65,6 @@ export async function pushWorktree(cwd: string): Promise<PushResult> {
   return pushed.ok ? { ok: true, branch } : { ok: false, reason: "push-failed", detail: pushed.stderr.trim().slice(0, DETAIL_LIMIT) };
 }
 
-// The last http(s) line of gh's output — `gh pr create` prints the PR URL last.
-function lastUrl(stdout: string): string | null {
-  const urls = stdout
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l.startsWith("http"));
-  return urls.length ? urls[urls.length - 1] : null;
-}
-
 // Push, then create a PR via gh — falling back to the GitHub compare URL when gh is
 // absent/unauthed/errors. Returns the URL to open and which path produced it.
 export async function createOrOpenPR(cwd: string): Promise<PrResult> {
@@ -84,7 +76,7 @@ export async function createOrOpenPR(cwd: string): Promise<PrResult> {
   const base = await defaultBaseBranch(repo);
 
   const gh = await run("gh", ["pr", "create", "--base", base, "--head", branch, "--fill"], cwd);
-  const ghUrl = gh.ok ? lastUrl(gh.stdout) : null;
+  const ghUrl = gh.ok ? lastGhUrl(gh.stdout) : null;
   if (ghUrl) return { ok: true, url: ghUrl, via: "gh" };
 
   const githubUrl = await resolveGithubUrl(cwd);

--- a/test/server/git/git-parse.spec.ts
+++ b/test/server/git/git-parse.spec.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { capPatch, lastGhUrl, parseNumstatLine } from "../../../server/git/git-parse.js";
+
+const toCount = (s: string) => Number(s) || 0;
+
+describe("lastGhUrl", () => {
+  it("takes the last http line", () => {
+    expect(lastGhUrl("Warning: something\nhttps://github.com/o/r/pull/1")).toBe("https://github.com/o/r/pull/1");
+  });
+
+  // gh prints the PR URL last — an earlier http line (a tip, an Actions URL) must not win.
+  // Both lines here start with http, so this genuinely tests LAST, not just "the only one".
+  it("prefers the last URL when several http lines are present", () => {
+    expect(lastGhUrl("https://github.com/o/r/actions/runs/9\nhttps://github.com/o/r/pull/2\n")).toBe("https://github.com/o/r/pull/2");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(lastGhUrl("   https://github.com/o/r/pull/3   ")).toBe("https://github.com/o/r/pull/3");
+  });
+
+  it("is null when there is no http line", () => {
+    expect(lastGhUrl("Creating pull request...\ndone")).toBeNull();
+    expect(lastGhUrl("")).toBeNull();
+  });
+});
+
+describe("parseNumstatLine", () => {
+  it("parses adds, dels and path", () => {
+    expect(parseNumstatLine("3\t1\tsrc/a.ts", toCount)).toEqual({ path: "src/a.ts", additions: 3, deletions: 1 });
+  });
+
+  // A binary file reports "-" — the badge must show "binary", not a bogus count.
+  it("maps a binary '-' count to -1", () => {
+    expect(parseNumstatLine("-\t-\timage.png", toCount)).toEqual({ path: "image.png", additions: -1, deletions: -1 });
+  });
+
+  // A path containing a tab must survive — split then rejoin with tabs.
+  it("keeps a tab inside the path", () => {
+    expect(parseNumstatLine("1\t0\tweird\tname.ts", toCount).path).toBe("weird\tname.ts");
+  });
+
+  it("handles one side binary and the other numeric", () => {
+    expect(parseNumstatLine("5\t-\tmixed", toCount)).toEqual({ path: "mixed", additions: 5, deletions: -1 });
+  });
+});
+
+describe("capPatch", () => {
+  it("passes a short patch through untouched", () => {
+    expect(capPatch("diff", 100)).toEqual({ patch: "diff", truncated: false });
+  });
+
+  it("truncates and flags a patch over the limit", () => {
+    expect(capPatch("abcdef", 4)).toEqual({ patch: "abcd", truncated: true });
+  });
+
+  // Exactly at the limit is not truncated (> not >=).
+  it("does not truncate a patch exactly at the limit", () => {
+    expect(capPatch("abcd", 4)).toEqual({ patch: "abcd", truncated: false });
+  });
+});


### PR DESCRIPTION
## Summary

Three pure rules were trapped behind `gh` / `git` spawns, so their specs (real-repo integration tests) documented that these exact branches never ran:

- **`lastGhUrl`** — the PR URL is the **last** http line of `gh pr create` output; a tip or Actions URL printed earlier must not win. `worktree-pr.spec` explicitly notes the gh-success path can't be exercised locally.
- **`parseNumstatLine`** — a binary file's `"-"` count becomes `-1` (the badge shows *binary*, not a bogus +/-), and a tab inside a path survives the split/rejoin. `worktree-diff.spec` asserts only `additions > 0` for a text file.
- **`capPatch`** — the 200k patch cap and its `truncated` flag; never exercised over the limit.

Behaviour unchanged. Taking the first gh URL instead of the last turns a test red.

## A note on my own process (worth reading)

The "prefers the last URL" test first **passed against that mutation** — because its earlier line began with `"see "` and was filtered out (doesn't start with `http`), leaving one URL. It wasn't testing "last" at all. I caught it because the mutation check didn't go red, made both lines start with `http`, and then it does. Recording it because it's the same class of "test that passes for the wrong reason" that has come up before in this series.

## Checks
lint 0, `typecheck:server` 0, `typecheck:test` 0, build 0, `219 files / 2974 tests`.

Refs #611
🤖 Generated with [Claude Code](https://claude.com/claude-code)