### PR TITLE
fix: 稼働中セッションが idle 表示のまま復帰しない (#669)

### DIFF
--- a/server/session/activity-hook.ts
+++ b/server/session/activity-hook.ts
@@ -11,8 +11,16 @@
 
 export type ActivityEffect = { kind: "working" | "waiting"; value: boolean };
 
+// A prompt starts a turn and a tool call is the middle of one — both mean the session is
+// working right now. Tool events matter beyond the obvious: `working` is set once at
+// UserPromptSubmit and cleared at Stop, so across a long turn nothing re-asserts it. If it
+// is ever lost mid-turn (a --watch restart between the prompt and the Stop), the session
+// reads idle until it finally stops — unless each tool call puts `working` back. nextActivity
+// no-ops when the flag is already true, so this re-asserts only after a loss, never spams.
+const WORKING_EVENTS = new Set(["UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure"]);
+
 export function activityHookEffects(event: string, active: boolean): ActivityEffect[] {
-  if (event === "UserPromptSubmit") return [{ kind: "working", value: true }];
+  if (WORKING_EVENTS.has(event)) return [{ kind: "working", value: true }];
   // A finished turn (Stop) has unseen output; a paused turn (Notification) waits on the
   // user. Either flags the session for attention UNLESS it's the actively-viewed pane.
   if (event === "Stop") {

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -172,8 +172,9 @@ const cellChips = computed<CellChipView[]>(() => {
   return views;
 });
 
-const { subscribe } = usePubSub();
+const { subscribe, onReconnect } = usePubSub();
 let unsubscribe: (() => void) | null = null;
+let offReconnect: (() => void) | null = null;
 
 interface ActivityMsg {
   id: string;
@@ -185,7 +186,12 @@ interface ActivityMsg {
 }
 const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" && d !== null && "id" in d;
 
+// Bumped on every applied activity change. A seed (loadInitial) reads the state as of the
+// moment it ASKED; a live push that lands while it is in flight is newer, so the seed must
+// not overwrite it — the #620 race, scoped to one cell.
+let activityGen = 0;
 function applyActivity(d: ActivityMsg) {
+  activityGen++;
   const next = applyActivityPush(
     { working: working.value, waiting: waiting.value, event: activityEvent.value, lastPrompt: lastPrompt.value, aiTitle: aiTitle.value },
     d,
@@ -228,9 +234,13 @@ function applyBadges(data: SessionDetail) {
 }
 
 async function loadInitial(id: string) {
+  const genBeforeFetch = activityGen;
   const data = await fetchSessionDetail(id);
   if (!data) return;
-  applyActivity(data);
+  // A live push landed while we were fetching: it is newer than this snapshot, so keep it
+  // and don't let a stale seed put the cell back to idle. Badges have no such push, so they
+  // always refresh.
+  if (activityGen === genBeforeFetch) applyActivity(data);
   applyBadges(data);
 }
 
@@ -247,6 +257,13 @@ onMounted(() => {
   unsubscribe = subscribe("sessions", (d) => {
     if (isActivityMsg(d) && d.id === sessionId.value) applyActivity(d);
   });
+  // A dropped socket misses the pushes sent while it was down, and this cell's status is
+  // derived state that pub/sub only replays room membership for — not the missed events. So
+  // on reconnect re-seed from the authoritative snapshot (guarded by activityGen), or a turn
+  // that started during the outage stays showing idle until it ends.
+  offReconnect = onReconnect(() => {
+    if (sessionId.value) loadInitial(sessionId.value);
+  });
   if (sessionId.value) {
     loadInitial(sessionId.value);
     loadDiff(); // a resumed worktree cell shows its diff on restore
@@ -258,6 +275,7 @@ onMounted(() => {
 });
 onUnmounted(() => {
   unsubscribe?.();
+  offReconnect?.();
   if (resumableTimer) clearTimeout(resumableTimer);
 });
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -190,6 +190,9 @@ const isActivityMsg = (d: unknown): d is ActivityMsg => typeof d === "object" &&
 // moment it ASKED; a live push that lands while it is in flight is newer, so the seed must
 // not overwrite it — the #620 race, scoped to one cell.
 let activityGen = 0;
+// Seeds also overlap each other — mount racing a reconnect, or reconnect flaps. Only the
+// newest may apply; an older one, even resolving last, describes a moment already overtaken.
+let latestSeed = 0;
 function applyActivity(d: ActivityMsg) {
   activityGen++;
   const next = applyActivityPush(
@@ -234,9 +237,12 @@ function applyBadges(data: SessionDetail) {
 }
 
 async function loadInitial(id: string) {
+  const seedId = ++latestSeed;
   const genBeforeFetch = activityGen;
   const data = await fetchSessionDetail(id);
-  if (!data) return;
+  // A newer seed superseded this one while it was in flight: its answer is the current one,
+  // so this stale snapshot applies neither activity nor badges.
+  if (!data || seedId !== latestSeed) return;
   // A live push landed while we were fetching: it is newer than this snapshot, so keep it
   // and don't let a stale seed put the cell back to idle. Badges have no such push, so they
   // always refresh.

--- a/test/server/session/activity-hook.spec.ts
+++ b/test/server/session/activity-hook.spec.ts
@@ -7,6 +7,15 @@ describe("activityHookEffects", () => {
     expect(activityHookEffects("UserPromptSubmit", false)).toEqual([{ kind: "working", value: true }]);
   });
 
+  // A tool call is the middle of a live turn, so it re-asserts working. This is what lets a
+  // long turn recover its status after a --watch restart lost it: `working` is otherwise only
+  // set at the prompt and cleared at Stop, and a stop can be an hour away. Independent of
+  // `active` — the same rule as the prompt.
+  it.each(["PreToolUse", "PostToolUse", "PostToolUseFailure"])("%s re-asserts working regardless of active", (event) => {
+    expect(activityHookEffects(event, true)).toEqual([{ kind: "working", value: true }]);
+    expect(activityHookEffects(event, false)).toEqual([{ kind: "working", value: true }]);
+  });
+
   it("Stop on the actively-viewed pane clears working only (no attention flag)", () => {
     expect(activityHookEffects("Stop", true)).toEqual([{ kind: "working", value: false }]);
   });
@@ -30,9 +39,11 @@ describe("activityHookEffects", () => {
     expect(activityHookEffects("Notification", false)).toEqual([{ kind: "waiting", value: true }]);
   });
 
-  it("ignores unrelated events", () => {
-    expect(activityHookEffects("PreToolUse", false)).toEqual([]);
+  it("ignores events that are neither a turn boundary nor tool activity", () => {
+    // SessionStart fires before any prompt — the session exists but isn't working yet.
     expect(activityHookEffects("SessionStart", true)).toEqual([]);
+    expect(activityHookEffects("PreCompact", false)).toEqual([]);
+    expect(activityHookEffects("", false)).toEqual([]);
   });
 });
 

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -601,6 +601,39 @@ describe("TerminalCell", () => {
     expect(dotClass(w)).toContain("is-done");
   });
 
+  it("does not let an older seed clobber a newer one when two reconnect re-seeds overlap", async () => {
+    // seed-vs-seed (reconnect flaps): the OLDER seed resolves FIRST with a now-stale snapshot,
+    // the NEWER one resolves LAST with the current one. Without a per-request token the older
+    // applies first and the newer is then dropped by the push-guard — leaving the stale value.
+    const id = "55555555-5555-5555-5555-555555555555";
+    const gates = [deferred<boolean>(), deferred<boolean>()];
+    let call = 0;
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      if (u.includes(`/api/session/${id}`)) {
+        const n = call++;
+        if (n === 0) return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) }; // mount
+        await gates[n - 1].promise;
+        // seed #1 => working (stale), seed #2 => idle (current, the turn has since ended).
+        return { ok: true, json: async () => ({ working: n === 1, waiting: false, lastPrompt: null }) };
+      }
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(id);
+    await flushPromises();
+
+    reconnect?.(); // seed #1 (older) — reports working
+    reconnect?.(); // seed #2 (newer) — reports idle
+    gates[0].resolve(true); // OLDER resolves first
+    await flushPromises();
+    gates[1].resolve(true); // NEWER resolves last
+    await flushPromises();
+    await nextTick();
+    expect(dotClass(w)).toContain("is-idle"); // the newest seed wins, not the first to resolve
+  });
+
   it("shows a token-usage badge from /api/session/:id", async () => {
     const id = "55555555-5555-5555-5555-555555555555";
     globalThis.fetch = vi.fn(async (url: string) => {

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -3,12 +3,18 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalCell from "../../../src/components/TerminalCell.vue";
 
-// Capture the "sessions" pub/sub callback so tests can push activity directly.
+// Capture the "sessions" pub/sub callback and the reconnect handler so tests can push
+// activity and simulate a dropped-then-restored socket directly.
 let captured: ((data: unknown) => void) | null = null;
+let reconnect: (() => void) | null = null;
 vi.mock("../../../src/composables/usePubSub", () => ({
   usePubSub: () => ({
     subscribe: (_channel: string, cb: (data: unknown) => void) => {
       captured = cb;
+      return () => {};
+    },
+    onReconnect: (cb: () => void) => {
+      reconnect = cb;
       return () => {};
     },
   }),
@@ -56,6 +62,7 @@ function deferred<T>() {
 
 beforeEach(() => {
   captured = null;
+  reconnect = null;
   mockFetch();
 });
 
@@ -524,6 +531,72 @@ describe("TerminalCell", () => {
     expect(dotClass(w)).toContain("is-blocked");
 
     captured?.({ id, working: false, waiting: true, event: "Stop", lastPrompt: "refactor the parser" });
+    await nextTick();
+    expect(dotClass(w)).toContain("is-done");
+  });
+
+  it("re-seeds its status from the server on a pub/sub reconnect", async () => {
+    // The dropped socket missed the push that would have said "working", so the cell is idle.
+    // On reconnect it must re-ask /api/session — not sit idle until the session's next event,
+    // which for a long turn is its far-off Stop.
+    const id = "33333333-3333-3333-3333-333333333333";
+    let working = false;
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      if (u.includes(`/api/session/${id}`)) return { ok: true, json: async () => ({ working, waiting: false, lastPrompt: null }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(id);
+    await flushPromises();
+    expect(dotClass(w)).toContain("is-idle");
+
+    // The server now knows the turn is running; the reconnect re-fetch should pick that up.
+    working = true;
+    reconnect?.();
+    await flushPromises();
+    await nextTick();
+    expect(dotClass(w)).toContain("is-working");
+  });
+
+  it("does not let a reconnect re-seed clobber a push that lands mid-fetch", async () => {
+    // The #620 race in one cell: the reconnect fetch reads a stale "working" snapshot, but a
+    // "Stop" push arrives before it resolves. The fresher push must win.
+    const id = "44444444-4444-4444-4444-444444444444";
+    const gate = deferred<boolean>();
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      if (u.includes(`/api/session/${id}`)) {
+        await gate.promise; // hold the reconnect seed in flight
+        return { ok: true, json: async () => ({ working: true, waiting: false, lastPrompt: null }) };
+      }
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(id);
+    gate.resolve(true); // let the mount seed settle
+    await flushPromises();
+
+    // A second gate for the reconnect seed, so a push can land while it is in flight.
+    const gate2 = deferred<boolean>();
+    (globalThis.fetch as unknown as { mockImplementation: (f: unknown) => void }).mockImplementation(async (url: string) => {
+      const u = String(url);
+      if (u.includes(`/api/session/${id}`)) {
+        await gate2.promise;
+        return { ok: true, json: async () => ({ working: true, waiting: false, lastPrompt: null }) };
+      }
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    });
+
+    reconnect?.(); // starts the seed fetch, now blocked on gate2
+    captured?.({ id, working: false, waiting: true, event: "Stop" }); // fresher: the turn ended
+    await nextTick();
+    expect(dotClass(w)).toContain("is-done");
+
+    gate2.resolve(true); // the stale "working" snapshot resolves last — and must be ignored
+    await flushPromises();
     await nextTick();
     expect(dotClass(w)).toContain("is-done");
   });


### PR DESCRIPTION
## Summary

グリッドのセルが、実際には稼働中のセッションなのに `idle` 表示のまま復帰しない不具合。実機（`~/ss/llm/mulmoclaude4`、claude が auto mode で 1h26m のターン中）で再現・原因特定しました。バックエンドは hook でしか「working」を知れず、そのセッションの working が失われていました。**2つの独立したギャップ**（bug family）を潰します。

| # | レイヤ | ギャップ | 修正 |
|---|---|---|---|
| A | backend `activityHookEffects` | `working:true` は `UserPromptSubmit` のみ、解除は `Stop`。長ターン中に再起動で working が失われると Stop まで復帰不能。ツール hook は毎回飛ぶのに何も再主張しない | `PreToolUse`/`PostToolUse`/`PostToolUseFailure` でも `working:true` を返す |
| B | frontend `TerminalCell.vue` | 派生状態を持つのに `onReconnect` 再seedが無い（`useGridActivity` にはある）。切断中に飛んだ変化を取りこぼし idle 固定 | `onReconnect(loadInitial)` を追加（世代ガード付き） |

## Items to Confirm / Review

1. **A の副作用（再publish頻度）**: `nextActivity` は値が変わらなければ null を返し再publishしないので、working が既に true の間はツール hook はノーオペ。working を失った時だけ次の1回で復帰。スパムしません。
2. **A と `waiting`（blocked/done）**: 本修正は `working` のみ触り `waiting` は不変。ブロック中セッションがツール再開しても blocked 表示のまま、という既存挙動は変えていません（別件・スコープ外）。
3. **B の #620 レース**: `onReconnect → loadInitial` は「fetch 中に来た新 push を古い snapshot が上書き」する #620 の系統を持ち込みうるため、per-cell の `activityGen` で「seed 前後で push が来ていたら seed の activity 適用をスキップ（badges は常に更新）」とガード。テストで固定。
4. B は backend にデータがある前提の一般復旧策。A が無いと、長ターンでそもそも backend が idle を返すため B だけでは直りません。両輪です。

## User Prompt

> なんかstatusがidleのままのがおおいんだけど、でグレッタ？
> ~/ss/llm/mulmoclaude4のところがidleのままでなおらないのだよね / リロードしてもだめ
> （①スタックしたセッション確認 ②onReconnect修正 ③永続の窓調査 に対して）全部！！

## 調査で分かったこと（記録）

- 動いているコードは実質 main（動作枝は追加テスト1ファイルのみ）＝ **コードの回帰ではない**。既存の抜け。
- hook 設定は正常（`POST localhost:34567/api/hook`, `x-mt-session` 付き）＝ ポート違い/2重起動ではない。
- `activity-state.json` への restart 永続化・hydrate は正常。ただし A のため「hook をほとんど出さない長ターン」には効かない。
- ① のセッション自体は健全（暴走ではない・kill 不要）。570MB まで肥大した transcript は claude 側の hygiene 問題で本 PR のスコープ外（claude 自身が `/clear` を提案）。
- ③ の「一瞬 0 件になる `activity-state.json`」は正常な all-clear の瞬間で、永続バグではなかった。長ターンの working 消失の本質は A。

## Testing

- 新規テスト、全 210 ファイル緑（2963 → 2987）。
- **変異検証**（各 assertion が壊れた実装で赤になることを確認）:
  - A: `WORKING_EVENTS` を `UserPromptSubmit` のみに戻す → ツール3イベントのテストが赤（3件）
  - B: `onReconnect` 再seedを削除 → reconnect テストが赤 / 世代ガードを外す → レーステストが赤
- backend の A は `activityHookEffects`（claude/codex 共通の純関数）1点で完結。

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)