### PR TITLE
fix(ci): ci-sandbox-image の「編集で sha が変わった」チェックが恒真だったのを直す (#675)

### DIFF
--- a/plans/fix-675-ci-sandbox-sha-check.md
+++ b/plans/fix-675-ci-sandbox-sha-check.md
@@ -1,0 +1,30 @@
+# fix #675 — ci-sandbox-image の「編集で sha が変わった」チェックが恒真
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/675
+
+## 問題
+
+`scripts/ci-sandbox-image.ts` のシナリオ3で、「Dockerfile を編集すれば sha が変わる」ことを守る自己チェックが、
+
+```ts
+check("the edit changed the Dockerfile sha",
+      editedSha === original.toString() ? "unchanged" : "changed", "changed");
+```
+
+と **sha256 の hex 文字列(`editedSha`)** と **Dockerfile 本文(`original.toString()`)** を比較していた。種類の違う文字列なので永久に不一致 → 三項は必ず `"changed"` → 恒真で何も検証していない。直後の「変更された Dockerfile がリビルドする」保証が痩せる。
+
+## 修正
+
+編集**前**の sha を取り、sha 同士を比較する。
+
+```ts
+const shaBeforeEdit = dockerfileSha();
+...
+check("the edit changed the Dockerfile sha", editedSha === shaBeforeEdit ? "unchanged" : "changed", "changed");
+```
+
+## 「壊すと落ちる」確認
+
+修正後、`dockerfileSha()` が壊れて編集で sha が変化しなくなると `editedSha === shaBeforeEdit` が真 → `"unchanged"` → check が期待値 `"changed"` と不一致で `process.exit(1)`。修正前は比較対象が常に不一致で必ず通過していた。これで本来の番人として機能する。
+
+CI スクリプト(Docker 実機依存)なので vitest 単体テストは追加しない。

--- a/scripts/ci-sandbox-image.ts
+++ b/scripts/ci-sandbox-image.ts
@@ -51,10 +51,11 @@ check("an unchanged Dockerfile does not rebuild (same image id)", imageId(), idA
 //    A trailing comment changes the file (so the sha) without adding a layer, so the
 //    rebuild is cache-fast. Restored afterwards so the checkout is left as found.
 const original = readFileSync(DOCKERFILE);
+const shaBeforeEdit = dockerfileSha();
 try {
   appendFileSync(DOCKERFILE, "\n# ci-sandbox-image.ts: temporary edit to force a rebuild\n");
   const editedSha = dockerfileSha();
-  check("the edit changed the Dockerfile sha", editedSha === original.toString() ? "unchanged" : "changed", "changed");
+  check("the edit changed the Dockerfile sha", editedSha === shaBeforeEdit ? "unchanged" : "changed", "changed");
   check("a changed Dockerfile rebuilds", ensureSandboxImage(), true);
   check("the label follows the changed Dockerfile", imageLabel(), editedSha);
 } finally {


### PR DESCRIPTION
## Summary

`scripts/ci-sandbox-image.ts` のシナリオ3で、「Dockerfile を編集すれば sha が変わる」ことを守る自己チェックが、**sha256 の hex 文字列** と **Dockerfile 本文** を比較していた。種類の違う文字列なので永久に不一致 → 三項は必ず `"changed"` に倒れ、**恒真で何も検証していなかった**。編集前の sha を取って sha 同士を比較するよう直した。

## Items to Confirm / Review

- CI スクリプト(Docker 実機依存)のため vitest 単体テストは追加していない。「壊すと落ちる」ことは論理で確認: 修正後は `dockerfileSha()` が壊れて編集で sha が変化しなくなると `editedSha === shaBeforeEdit` が真 → `"unchanged"` → 期待値 `"changed"` と不一致で `process.exit(1)`。修正前は比較対象が常に不一致で必ず通過していた。
- 製品コードへの影響なし(CI 自己チェック内の欠陥)。

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所と、並行してバグを洗い出して issue 化した(第3弾, #676)。その中のバグ issue #675 を修正する。

## 変更

- `scripts/ci-sandbox-image.ts`: 編集前の sha を `shaBeforeEdit` として取得し、`editedSha === shaBeforeEdit` を比較。
- `plans/fix-675-ci-sandbox-sha-check.md`: 計画メモ。

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)