### PR TITLE
fix: presetsForProvider の重複排除を case-insensitive にして presetFor と揃える (#674)

### DIFF
--- a/common/modelPresets.ts
+++ b/common/modelPresets.ts
@@ -303,9 +303,11 @@ export const MODEL_PRESETS: readonly ModelPreset[] = [
 // than appearing twice.
 export function presetsForProvider(providerId: string, userModels: readonly string[] = []): ModelPreset[] {
   const presets = MODEL_PRESETS.filter((preset) => preset.provider === providerId);
-  const known = new Set(presets.map((preset) => preset.id));
+  // Match `presetFor` (modelOption.ts), which compares ids case-insensitively: a user
+  // entry that only differs from a preset in case is the same model, not a new one.
+  const known = new Set(presets.map((preset) => preset.id.toLowerCase()));
   const added: ModelPreset[] = userModels
-    .filter((id) => !known.has(id))
+    .filter((id) => !known.has(id.toLowerCase()))
     .map((id) => ({ provider: providerId, id, label: id, contextLength: 0, pricePerMTok: { input: 0, output: 0 }, trials: { status: "unmeasured" } }));
   return [...presets, ...added];
 }

--- a/plans/fix-674-preset-dedup-case-insensitive.md
+++ b/plans/fix-674-preset-dedup-case-insensitive.md
@@ -1,0 +1,20 @@
+# fix #674 — presetsForProvider の重複排除だけ大文字小文字を区別していた
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/674
+
+## 問題
+
+モデル id の照合基準が 2 箇所で食い違っていた。
+
+- `common/modelPresets.ts` `presetsForProvider` の重複排除 — **raw 一致**(`known.has(id)`)
+- `src/components/modelOption.ts` `presetFor` — **case-insensitive**(`preset.id.toLowerCase() === model.toLowerCase()`)
+
+ユーザが config の `providers[].models` にプリセットと同じモデルを大小混在で書く(例 `"MoonshotAI/Kimi-K2.7-Code"`)と、dedup をすり抜けて「unmeasured (not tested)」エントリが追加され、ランチャーのモデルピッカーに**同一モデルが 2 行**並ぶ。dedup のコメント(“keeps the preset's measured numbers rather than appearing twice”)が防ぐと明言している事態そのもの。
+
+## 修正
+
+`known` を小文字化した集合にし、`id.toLowerCase()` で判定する。`presetFor` と同じ照合基準に揃える。
+
+## テスト
+
+`test/server/config/launch-options.spec.ts` に大小混在ケースを 1 本追加。修正を戻すと赤・入れると緑を確認済み(変異テスト)。

--- a/test/server/config/launch-options.spec.ts
+++ b/test/server/config/launch-options.spec.ts
@@ -49,6 +49,16 @@ describe("launchOptions", () => {
     expect(matches[0].trials.status).toBe("measured");
   });
 
+  // The dedup has to agree with `presetFor`, which matches ids case-insensitively. A user
+  // who lists the preset in different case must still get the measured preset once, not a
+  // second "unmeasured" row for the same model.
+  it("dedups a user model that matches a preset only by case", () => {
+    const [option] = launchOptions([{ ...OPENROUTER, models: ["MoonshotAI/Kimi-K2.7-Code"] }], WITH_KEY).providers;
+    const matches = option.models.filter((model) => model.id.toLowerCase() === "moonshotai/kimi-k2.7-code");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].trials.status).toBe("measured");
+  });
+
   it("still lists a provider whose token is missing, and says so", () => {
     const { providers, anyReady } = launchOptions([OPENROUTER], {} as NodeJS.ProcessEnv);
     expect(anyReady).toBe(false);


### PR DESCRIPTION
## Summary

モデル id の照合基準が食い違っていた。`presetsForProvider`(`common/modelPresets.ts`)の重複排除は **raw 一致**、照合側の `presetFor`(`src/components/modelOption.ts`)は **case-insensitive**。ユーザが config の `providers[].models` にプリセットと同じモデルを大小混在で書くと dedup をすり抜け、ランチャーのモデルピッカーに**同一モデルが 2 行**(片方は計測値あり、片方は "not tested")並んでいた。`known` を小文字集合にし `id.toLowerCase()` で判定するよう直した。

## Items to Confirm / Review

- 回帰テストは `test/server/config/launch-options.spec.ts` の既存 dedup テストの隣に大小混在ケースを追加。**修正を戻すと赤・入れると緑**を変異テストで確認済み。
- `presetFor` と `dir-model-choice` の id 照合はもともと意図的に case-insensitive。ここだけ case-sensitive だったのを揃えた形で、他の照合には影響なし。

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所と、並行してバグを洗い出して issue 化した(第3弾, #676)。その中のバグ issue #674 を修正する。

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)