### PR TITLE
feat: 更新があるとき Web ヘッダにバッジを出す (#677)

### DIFF
--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -7,24 +7,13 @@
 
 import { execSync, spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
 import { get as httpGet } from "node:http";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
-import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
-import {
-  classifyInstall,
-  fetchLatestVersion,
-  gitUpdateNotice,
-  hasNodeModulesSegment,
-  isTreeDirtyForUpdate,
-  isUpdateCheckDisabled,
-  npmUpdateNotice,
-  parseLsRemoteHead,
-} from "./update-check.js";
+import { computeUpdateNotice, isUpdateCheckDisabled } from "./update-check.js";
 import { chooseCwd, parsePortArg, portInUseAction, portInUseMessage, saysYes, secondInstancePrompt, SECOND_INSTANCE_NOTE } from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -43,95 +32,17 @@ const { version: VERSION } = createRequire(import.meta.url)("../package.json");
 const log = (msg) => console.log(`\x1b[36m[mulmoterminal]\x1b[0m ${msg}`);
 const error = (msg) => console.error(`\x1b[31m[mulmoterminal]\x1b[0m ${msg}`);
 
-// Upper bound on every git probe, including the network ls-remote — matches the
-// npm fetch timeout so a slow remote can't delay the notice past startup.
-const GIT_PROBE_TIMEOUT_MS = 1500;
-
-// Run git inside the package directory, best-effort. Resolves the trimmed stdout
-// on a clean exit, or null on anything else (git absent, non-zero exit, timeout).
-// GIT_TERMINAL_PROMPT=0 turns an auth prompt into a fast failure instead of a
-// hang, so ls-remote against a private remote can't block startup waiting on a
-// password nobody is there to type.
-function runGit(gitArgs, timeout_ms = GIT_PROBE_TIMEOUT_MS) {
-  return new Promise((resolve) => {
-    let child;
-    try {
-      child = spawn("git", ["-C", PKG_DIR, ...gitArgs], {
-        stdio: ["ignore", "pipe", "ignore"],
-        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
-      });
-    } catch {
-      return resolve(null);
-    }
-    let out = "";
-    const timer = setTimeout(() => child.kill("SIGKILL"), timeout_ms);
-    child.stdout.on("data", (chunk) => (out += chunk));
-    child.on("error", () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve(code === 0 ? out.trim() : null);
-    });
-  });
-}
-
-// npm install → registry latest vs the bundled version; git checkout → local
-// HEAD vs the remote's, read without fetching. Only ask git which one this is
-// when the path doesn't already answer it.
-async function installKind() {
-  if (hasNodeModulesSegment(PKG_DIR)) return "npm";
-  return classifyInstall(PKG_DIR, (await runGit(["rev-parse", "--is-inside-work-tree"])) === "true");
-}
-
-// The git-side notice, or null. A dirty tree stops here without touching the
-// network — it can't fast-forward, so there is nothing worth asking the remote.
-async function gitUpdateMessage() {
-  const status = await runGit(["status", "--porcelain"]);
-  if (status === null || isTreeDirtyForUpdate(status)) return null;
-  const [localSha, localShort, lsRemote] = await Promise.all([
-    runGit(["rev-parse", "HEAD"]),
-    runGit(["rev-parse", "--short", "HEAD"]),
-    runGit(["ls-remote", "origin", "HEAD"]),
-  ]);
-  return gitUpdateNotice({ localSha, localShort, remoteSha: parseLsRemoteHead(lsRemote), dirty: false });
-}
-
-// Where the notice is left for the running server to read and surface in the web header —
-// the console line is easy to miss when you only watch the browser. Sits next to the other
-// shared ~/.mulmoterminal state (activity-state.json, etc.).
-const UPDATE_STATUS_FILE = join(homedir(), ".mulmoterminal", "update-status.json");
-
-// Persist the current notice (null when clean, opted out, or the check failed). Written on
-// every start so a stale "update available" from a prior run can't linger after the user
-// updated. Best-effort — a failed write never disrupts startup.
-async function writeUpdateStatus(notice) {
-  try {
-    await mkdir(dirname(UPDATE_STATUS_FILE), { recursive: true });
-    await writeFile(UPDATE_STATUS_FILE, JSON.stringify({ notice: notice ?? null }));
-  } catch {
-    // best-effort
-  }
-}
-
-// Non-blocking notice that a newer version exists — neither `npm i -g` nor a git
-// checkout auto-updates. Opt out via MULMOTERMINAL_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
+// Non-blocking console notice that a newer version exists — neither `npm i -g` nor a git
+// checkout auto-updates. Opt out via MULMOTERMINAL_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER. The
+// same check runs in the server for the web-header badge (the launcher isn't involved under
+// `yarn dev`), sharing computeUpdateNotice so the two never drift.
 async function checkForUpdate() {
-  // Clear a prior run's notice first, so the header can't keep showing a stale "update
-  // available" before this run's (async) check overwrites the file — or if it never does
-  // (opt-out, clean, or a failed check).
-  await writeUpdateStatus(null);
   if (isUpdateCheckDisabled(process.env)) return;
-  let notice = null;
   try {
-    notice = (await installKind()) === "git" ? await gitUpdateMessage() : npmUpdateNotice(VERSION, await fetchLatestVersion());
+    const notice = await computeUpdateNotice(PKG_DIR, VERSION);
+    if (notice) log(`\x1b[33m${notice}\x1b[0m`);
   } catch {
     // best-effort; never disrupt startup
-  }
-  if (notice) {
-    await writeUpdateStatus(notice);
-    log(`\x1b[33m${notice}\x1b[0m`);
   }
 }
 

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -7,9 +7,11 @@
 
 import { execSync, spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import { get as httpGet } from "node:http";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
+import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
@@ -96,16 +98,36 @@ async function gitUpdateMessage() {
   return gitUpdateNotice({ localSha, localShort, remoteSha: parseLsRemoteHead(lsRemote), dirty: false });
 }
 
+// Where the notice is left for the running server to read and surface in the web header —
+// the console line is easy to miss when you only watch the browser. Sits next to the other
+// shared ~/.mulmoterminal state (activity-state.json, etc.).
+const UPDATE_STATUS_FILE = join(homedir(), ".mulmoterminal", "update-status.json");
+
+// Persist the current notice (null when clean, opted out, or the check failed). Written on
+// every start so a stale "update available" from a prior run can't linger after the user
+// updated. Best-effort — a failed write never disrupts startup.
+async function writeUpdateStatus(notice) {
+  try {
+    await mkdir(dirname(UPDATE_STATUS_FILE), { recursive: true });
+    await writeFile(UPDATE_STATUS_FILE, JSON.stringify({ notice: notice ?? null }));
+  } catch {
+    // best-effort
+  }
+}
+
 // Non-blocking notice that a newer version exists — neither `npm i -g` nor a git
 // checkout auto-updates. Opt out via MULMOTERMINAL_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
 async function checkForUpdate() {
-  if (isUpdateCheckDisabled(process.env)) return;
-  try {
-    const notice = (await installKind()) === "git" ? await gitUpdateMessage() : npmUpdateNotice(VERSION, await fetchLatestVersion());
-    if (notice) log(`\x1b[33m${notice}\x1b[0m`);
-  } catch {
-    // best-effort; never disrupt startup
+  let notice = null;
+  if (!isUpdateCheckDisabled(process.env)) {
+    try {
+      notice = (await installKind()) === "git" ? await gitUpdateMessage() : npmUpdateNotice(VERSION, await fetchLatestVersion());
+    } catch {
+      // best-effort; never disrupt startup
+    }
   }
+  await writeUpdateStatus(notice);
+  if (notice) log(`\x1b[33m${notice}\x1b[0m`);
 }
 
 // Detect a CLI on the user's PATH by asking for its version. Intentionally resolves from

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -118,16 +118,21 @@ async function writeUpdateStatus(notice) {
 // Non-blocking notice that a newer version exists — neither `npm i -g` nor a git
 // checkout auto-updates. Opt out via MULMOTERMINAL_NO_UPDATE_CHECK / NO_UPDATE_NOTIFIER.
 async function checkForUpdate() {
+  // Clear a prior run's notice first, so the header can't keep showing a stale "update
+  // available" before this run's (async) check overwrites the file — or if it never does
+  // (opt-out, clean, or a failed check).
+  await writeUpdateStatus(null);
+  if (isUpdateCheckDisabled(process.env)) return;
   let notice = null;
-  if (!isUpdateCheckDisabled(process.env)) {
-    try {
-      notice = (await installKind()) === "git" ? await gitUpdateMessage() : npmUpdateNotice(VERSION, await fetchLatestVersion());
-    } catch {
-      // best-effort; never disrupt startup
-    }
+  try {
+    notice = (await installKind()) === "git" ? await gitUpdateMessage() : npmUpdateNotice(VERSION, await fetchLatestVersion());
+  } catch {
+    // best-effort; never disrupt startup
   }
-  await writeUpdateStatus(notice);
-  if (notice) log(`\x1b[33m${notice}\x1b[0m`);
+  if (notice) {
+    await writeUpdateStatus(notice);
+    log(`\x1b[33m${notice}\x1b[0m`);
+  }
 }
 
 // Detect a CLI on the user's PATH by asking for its version. Intentionally resolves from

--- a/bin/update-check.d.ts
+++ b/bin/update-check.d.ts
@@ -10,6 +10,13 @@ export declare function isUpdateCheckDisabled(env: Record<string, string | undef
 export declare function hasNodeModulesSegment(pkgDir: string): boolean;
 export declare function classifyInstall(pkgDir: string, isGitWorkTree: boolean): "npm" | "git";
 export declare function parseLsRemoteHead(stdout: string | null | undefined): string | null;
+export declare function parseLsRemoteDefaultBranch(stdout: string | null | undefined): string | null;
 export declare function npmUpdateNotice(current: string, latest: string | null): string | null;
 export declare function isTreeDirtyForUpdate(porcelain: string | null | undefined): boolean;
-export declare function gitUpdateNotice(args: { localSha: string | null; localShort: string | null; remoteSha: string | null; dirty: boolean }): string | null;
+export declare function gitUpdateNotice(args: {
+  localSha: string | null;
+  localShort: string | null;
+  remoteSha: string | null;
+  defaultBranch?: string | null;
+  dirty: boolean;
+}): string | null;

--- a/bin/update-check.d.ts
+++ b/bin/update-check.d.ts
@@ -1,5 +1,11 @@
 export declare function fetchLatestVersion(pkg?: string): Promise<string | null>;
 export declare function isNewerVersion(latest: string, current: string): boolean;
+export declare function runGit(pkgDir: string, gitArgs: string[], timeout_ms?: number): Promise<string | null>;
+export interface UpdateNoticeDeps {
+  runGit?: (args: string[]) => Promise<string | null>;
+  fetchLatest?: () => Promise<string | null>;
+}
+export declare function computeUpdateNotice(pkgDir: string, currentVersion: string, deps?: UpdateNoticeDeps): Promise<string | null>;
 export declare function isUpdateCheckDisabled(env: Record<string, string | undefined>): boolean;
 export declare function hasNodeModulesSegment(pkgDir: string): boolean;
 export declare function classifyInstall(pkgDir: string, isGitWorkTree: boolean): "npm" | "git";

--- a/bin/update-check.d.ts
+++ b/bin/update-check.d.ts
@@ -11,6 +11,7 @@ export declare function hasNodeModulesSegment(pkgDir: string): boolean;
 export declare function classifyInstall(pkgDir: string, isGitWorkTree: boolean): "npm" | "git";
 export declare function parseLsRemoteHead(stdout: string | null | undefined): string | null;
 export declare function parseLsRemoteDefaultBranch(stdout: string | null | undefined): string | null;
+export declare function isSafeBranchName(name: unknown): boolean;
 export declare function npmUpdateNotice(current: string, latest: string | null): string | null;
 export declare function isTreeDirtyForUpdate(porcelain: string | null | undefined): boolean;
 export declare function gitUpdateNotice(args: {

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -1,7 +1,42 @@
-// Update-check helpers for the launcher, split out so the version comparison is
-// unit-testable. Network calls are best-effort and never throw.
+// Update-check helpers, split out so the check is unit-testable and can be run from both the
+// launcher (console notice) and the server (the header badge — the launcher isn't in the loop
+// under `yarn dev`, so the server has to be able to check on its own). Network/git calls are
+// best-effort and never throw.
+import { spawn } from "node:child_process";
 
 const REGISTRY = (process.env.npm_config_registry || "https://registry.npmjs.org").replace(/\/$/, "");
+
+// Upper bound on every git probe, including the network ls-remote — matches the npm fetch
+// timeout so a slow remote can't delay the caller.
+const GIT_PROBE_TIMEOUT_MS = 1500;
+
+// Run git inside pkgDir, best-effort. Resolves the trimmed stdout on a clean exit, or null on
+// anything else (git absent, non-zero exit, timeout). GIT_TERMINAL_PROMPT=0 turns an auth
+// prompt into a fast failure instead of a hang against a private remote.
+export function runGit(pkgDir, gitArgs, timeout_ms = GIT_PROBE_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn("git", ["-C", pkgDir, ...gitArgs], {
+        stdio: ["ignore", "pipe", "ignore"],
+        env: { ...process.env, GIT_TERMINAL_PROMPT: "0" },
+      });
+    } catch {
+      return resolve(null);
+    }
+    let out = "";
+    const timer = setTimeout(() => child.kill("SIGKILL"), timeout_ms);
+    child.stdout.on("data", (chunk) => (out += chunk));
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve(code === 0 ? out.trim() : null);
+    });
+  });
+}
 
 // Best-effort latest-version lookup. Resolves null on any failure (offline,
 // timeout, non-OK, bad payload) so callers never block or break startup.
@@ -103,4 +138,29 @@ export function gitUpdateNotice({ localSha, localShort, remoteSha, dirty }) {
   if (dirty) return null;
   if (!localSha || !remoteSha || localSha === remoteSha) return null;
   return `Update available: ${localShort || localSha.slice(0, 7)} → origin  ·  run: git pull`;
+}
+
+// The git branch of the check: local HEAD vs the remote's, read with ls-remote so no fetch is
+// forced. Silent on a dirty tree (can't fast-forward) or any unreadable probe.
+async function gitUpdateNotice_(git) {
+  const status = await git(["status", "--porcelain"]);
+  if (status === null || isTreeDirtyForUpdate(status)) return null;
+  const [localSha, localShort, lsRemote] = await Promise.all([
+    git(["rev-parse", "HEAD"]),
+    git(["rev-parse", "--short", "HEAD"]),
+    git(["ls-remote", "origin", "HEAD"]),
+  ]);
+  return gitUpdateNotice({ localSha, localShort, remoteSha: parseLsRemoteHead(lsRemote), dirty: false });
+}
+
+// The whole check, front to back: which install this is, then its notice (or null when
+// current). `pkgDir` is where the tool lives — a node_modules dir (→ npm) or a bare checkout
+// (→ git). `deps` lets tests drive it without spawning git or hitting the network; production
+// callers pass nothing and get the real git/registry probes bound to pkgDir.
+export async function computeUpdateNotice(pkgDir, currentVersion, deps = {}) {
+  const git = deps.runGit ?? ((args) => runGit(pkgDir, args));
+  const fetchLatest = deps.fetchLatest ?? fetchLatestVersion;
+  const inWorkTree = hasNodeModulesSegment(pkgDir) ? false : (await git(["rev-parse", "--is-inside-work-tree"])) === "true";
+  if (classifyInstall(pkgDir, inWorkTree) === "git") return gitUpdateNotice_(git);
+  return npmUpdateNotice(currentVersion, await fetchLatest());
 }

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -128,16 +128,27 @@ export function isTreeDirtyForUpdate(porcelain) {
     .some((line) => line.trim() !== "" && !line.startsWith("??"));
 }
 
+// The remote's default branch, from the "ref: refs/heads/<branch>\tHEAD" line that
+// `git ls-remote --symref origin HEAD` prints, or null. `git pull` with no args pulls the
+// CURRENT branch's upstream — which isn't the release a clone is behind if you're on some
+// other branch. Naming origin + the default branch is what actually updates it, and reading
+// the name (rather than hardcoding "main") keeps it right for a "master" remote too.
+export function parseLsRemoteDefaultBranch(stdout) {
+  const match = String(stdout ?? "").match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD$/m);
+  return match ? match[1] : null;
+}
+
 // Whether a git checkout should hear that an update exists, and what to say.
 // Silent whenever the notice could not be acted on or trusted: a dirty tree
 // cannot fast-forward, a missing sha means local or remote could not be read,
 // and equal shas mean it is already current. Only a clean checkout whose HEAD
 // differs from the remote's is behind — count is deliberately absent, since
 // counting commits needs the objects a `git fetch` would bring and we skip it.
-export function gitUpdateNotice({ localSha, localShort, remoteSha, dirty }) {
+export function gitUpdateNotice({ localSha, localShort, remoteSha, defaultBranch, dirty }) {
   if (dirty) return null;
   if (!localSha || !remoteSha || localSha === remoteSha) return null;
-  return `Update available: ${localShort || localSha.slice(0, 7)} → origin  ·  run: git pull`;
+  const pull = defaultBranch ? `git pull origin ${defaultBranch}` : "git pull";
+  return `Update available: ${localShort || localSha.slice(0, 7)} → origin  ·  run: ${pull}`;
 }
 
 // ls-remote reaches the network (an SSH/HTTPS handshake to the origin host), so it routinely
@@ -154,9 +165,15 @@ async function gitUpdateNotice_(git) {
   const [localSha, localShort, lsRemote] = await Promise.all([
     git(["rev-parse", "HEAD"]),
     git(["rev-parse", "--short", "HEAD"]),
-    git(["ls-remote", "origin", "HEAD"], LS_REMOTE_TIMEOUT_MS),
+    git(["ls-remote", "--symref", "origin", "HEAD"], LS_REMOTE_TIMEOUT_MS),
   ]);
-  return gitUpdateNotice({ localSha, localShort, remoteSha: parseLsRemoteHead(lsRemote), dirty: false });
+  return gitUpdateNotice({
+    localSha,
+    localShort,
+    remoteSha: parseLsRemoteHead(lsRemote),
+    defaultBranch: parseLsRemoteDefaultBranch(lsRemote),
+    dirty: false,
+  });
 }
 
 // The whole check, front to back: which install this is, then its notice (or null when

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -138,6 +138,16 @@ export function parseLsRemoteDefaultBranch(stdout) {
   return match ? match[1] : null;
 }
 
+// Whether a branch name is safe to drop into a copy/paste shell command. The name comes from
+// the remote (`ls-remote --symref`), which is untrusted — git allows `;`, `$`, backticks and
+// other shell metacharacters in ref names, so a hostile default branch like `main;rm -rf ~`
+// would inject when pasted. Ordinary branch names (main, master, release/2.x) are all letters,
+// digits, and `._/-`; anything outside that is refused rather than escaped, so the notice
+// falls back to a bare `git pull` instead of showing a weird quoted command.
+export function isSafeBranchName(name) {
+  return typeof name === "string" && /^[A-Za-z0-9._/-]+$/.test(name);
+}
+
 // Whether a git checkout should hear that an update exists, and what to say.
 // Silent whenever the notice could not be acted on or trusted: a dirty tree
 // cannot fast-forward, a missing sha means local or remote could not be read,
@@ -147,7 +157,7 @@ export function parseLsRemoteDefaultBranch(stdout) {
 export function gitUpdateNotice({ localSha, localShort, remoteSha, defaultBranch, dirty }) {
   if (dirty) return null;
   if (!localSha || !remoteSha || localSha === remoteSha) return null;
-  const pull = defaultBranch ? `git pull origin ${defaultBranch}` : "git pull";
+  const pull = isSafeBranchName(defaultBranch) ? `git pull origin ${defaultBranch}` : "git pull";
   return `Update available: ${localShort || localSha.slice(0, 7)} → origin  ·  run: ${pull}`;
 }
 

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -140,6 +140,12 @@ export function gitUpdateNotice({ localSha, localShort, remoteSha, dirty }) {
   return `Update available: ${localShort || localSha.slice(0, 7)} → origin  ·  run: git pull`;
 }
 
+// ls-remote reaches the network (an SSH/HTTPS handshake to the origin host), so it routinely
+// takes several seconds — far longer than a local rev-parse. The default git timeout would
+// kill it first and read the checkout as "no remote HEAD" → no notice. Give just that probe
+// room; the check is background and best-effort, so waiting a few seconds costs nothing.
+const LS_REMOTE_TIMEOUT_MS = 6000;
+
 // The git branch of the check: local HEAD vs the remote's, read with ls-remote so no fetch is
 // forced. Silent on a dirty tree (can't fast-forward) or any unreadable probe.
 async function gitUpdateNotice_(git) {
@@ -148,7 +154,7 @@ async function gitUpdateNotice_(git) {
   const [localSha, localShort, lsRemote] = await Promise.all([
     git(["rev-parse", "HEAD"]),
     git(["rev-parse", "--short", "HEAD"]),
-    git(["ls-remote", "origin", "HEAD"]),
+    git(["ls-remote", "origin", "HEAD"], LS_REMOTE_TIMEOUT_MS),
   ]);
   return gitUpdateNotice({ localSha, localShort, remoteSha: parseLsRemoteHead(lsRemote), dirty: false });
 }
@@ -158,7 +164,7 @@ async function gitUpdateNotice_(git) {
 // (→ git). `deps` lets tests drive it without spawning git or hitting the network; production
 // callers pass nothing and get the real git/registry probes bound to pkgDir.
 export async function computeUpdateNotice(pkgDir, currentVersion, deps = {}) {
-  const git = deps.runGit ?? ((args) => runGit(pkgDir, args));
+  const git = deps.runGit ?? ((args, timeout_ms) => runGit(pkgDir, args, timeout_ms));
   const fetchLatest = deps.fetchLatest ?? fetchLatestVersion;
   const inWorkTree = hasNodeModulesSegment(pkgDir) ? false : (await git(["rev-parse", "--is-inside-work-tree"])) === "true";
   if (classifyInstall(pkgDir, inWorkTree) === "git") return gitUpdateNotice_(git);

--- a/plans/feat-677-update-header-badge.md
+++ b/plans/feat-677-update-header-badge.md
@@ -1,0 +1,22 @@
+# feat(#677): 更新バッジを Web ヘッダに出す
+
+## 目的
+起動時の更新チェック(#654)はコンソール1行のみ。ブラウザだけ見る使い方でも気づけるよう、AppToolbar に控えめなバッジを出す。
+
+## 方式: ファイル経由の共有状態
+更新チェックは非同期(〜1.5s)で spawn 時 env に間に合わないため、`~/.mulmoterminal/update-status.json`(既存の共有状態パターン)を介す。チェックは launcher 1回のまま(非ブロッキング・追加NW無し)。
+
+## 変更
+1. `bin/mulmoterminal.js`: `checkForUpdate` が算出した notice を `update-status.json`(`{notice, version, at}`)に best-effort 書き込み。opt-out/clean/error では `notice:null`。
+2. `server/config/update-status.ts`(新): `parseUpdateStatus(raw)`(純) + `readUpdateStatus()`(ファイル読取)。
+3. `server/config/config-routes.ts`: `GET /api/update-status` → `{notice}`。
+4. `src/composables/useUpdateStatus.ts`(新): mount で1回 fetch。
+5. `src/components/AppToolbar.vue`: notice がある時だけバッジ。title=全文、click=コマンドコピー。
+
+## テスト
+- `parseUpdateStatus`: valid/null/壊れ/欠損
+- `useUpdateStatus` or バッジ: notice有→表示, null→非表示, コマンド抽出
+- launcher 書き込み: 統合確認
+
+## 非対象
+- 定期再チェック(起動時1回)。更新後は次回起動で上書きされ消える。

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -12,7 +12,7 @@ import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type Provider, type UserMcpServer } from "./config-schema.js";
 import { launchOptions } from "./launch-options.js";
 import { badArrayField, badNullableArrayField } from "./config-body.js";
-import { readUpdateStatus } from "./update-status.js";
+import { getUpdateStatus } from "./update-status.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -68,11 +68,11 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     res.json({ ...configResponse(), home: os.homedir() });
   });
 
-  // The update notice the launcher left on disk, for the header's "update available" badge.
-  // Its own route (not folded into /api/config) so it can be re-fetched cheaply once the
-  // launcher's async check has written the file, without re-reading the whole config.
-  app.get("/api/update-status", async (_req, res) => {
-    res.json(await readUpdateStatus());
+  // The update notice for the header's "update available" badge, from the check the server
+  // ran at startup (refreshUpdateStatus). Served from memory; the client re-fetches once so a
+  // request that beat the async check still picks the notice up.
+  app.get("/api/update-status", (_req, res) => {
+    res.json(getUpdateStatus());
   });
 
   app.post("/api/config", (req, res) => {

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -12,6 +12,7 @@ import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type Provider, type UserMcpServer } from "./config-schema.js";
 import { launchOptions } from "./launch-options.js";
 import { badArrayField, badNullableArrayField } from "./config-body.js";
+import { readUpdateStatus } from "./update-status.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
 let config: AppConfig = loadAppConfig(CONFIG_FILE);
@@ -65,6 +66,13 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
 
   app.get("/api/config", (_req, res) => {
     res.json({ ...configResponse(), home: os.homedir() });
+  });
+
+  // The update notice the launcher left on disk, for the header's "update available" badge.
+  // Its own route (not folded into /api/config) so it can be re-fetched cheaply once the
+  // launcher's async check has written the file, without re-reading the whole config.
+  app.get("/api/update-status", async (_req, res) => {
+    res.json(await readUpdateStatus());
   });
 
   app.post("/api/config", (req, res) => {

--- a/server/config/update-status.ts
+++ b/server/config/update-status.ts
@@ -1,46 +1,20 @@
 // The "update available" state for the web-header badge. The server runs the check itself
 // (shared computeUpdateNotice) rather than reading a launcher-written file, because under
-// `yarn dev` the launcher isn't in the loop — only the server is. The result is cached in
-// ~/.mulmoterminal/update-status.json with a timestamp so a dev `--watch` restart storm reuses
-// a recent answer instead of firing a git ls-remote (or a registry fetch) every reload.
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+// `yarn dev` the launcher isn't in the loop — only the server is. Recomputed on each start so
+// the badge reflects the current checkout (a `git pull` clears it on the next restart); the
+// probe is background and best-effort, and the opt-out env vars skip it entirely.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { computeUpdateNotice, isUpdateCheckDisabled } from "../../bin/update-check.js";
-import { MULMOTERMINAL_HOME } from "./env.js";
 
 // This file is server/config/update-status.ts, so two dirs up is the install root — the git
 // checkout (dev / a clone) or the package dir under node_modules (npm) the check runs against.
 const PKG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const { version: VERSION } = createRequire(import.meta.url)("../../package.json") as { version: string };
 
-export const UPDATE_STATUS_FILE = path.join(MULMOTERMINAL_HOME, "update-status.json");
-const CACHE_TTL_MS = 60 * 60 * 1000;
-
 export interface UpdateStatus {
   notice: string | null;
-}
-
-interface CacheEntry {
-  notice: string | null;
-  at: number;
-}
-
-// A cached result is worth reusing only if it carries a real timestamp and hasn't aged out.
-// A missing/garbage `at` forces a fresh check rather than trusting an unknown vintage.
-export function isCacheFresh(at: unknown, now: number, ttlMs: number = CACHE_TTL_MS): boolean {
-  return typeof at === "number" && at > 0 && at <= now && now - at < ttlMs;
-}
-
-// The cache entry out of whatever was on disk, or null when it can't be trusted (not an
-// object, no timestamp, non-string notice). Never throws — a hand-edited or half-written file
-// just means "no usable cache", so the check re-runs.
-export function parseCacheEntry(raw: unknown): CacheEntry | null {
-  if (typeof raw !== "object" || raw === null) return null;
-  const { notice, at } = raw as { notice?: unknown; at?: unknown };
-  if (typeof at !== "number") return null;
-  return { notice: typeof notice === "string" && notice.length > 0 ? notice : null, at };
 }
 
 let cached: UpdateStatus = { notice: null };
@@ -48,39 +22,16 @@ export function getUpdateStatus(): UpdateStatus {
   return cached;
 }
 
-async function readCache(): Promise<CacheEntry | null> {
-  try {
-    return parseCacheEntry(JSON.parse(await readFile(UPDATE_STATUS_FILE, "utf8")));
-  } catch {
-    return null;
-  }
-}
-
-async function writeCache(notice: string | null, now: number): Promise<void> {
-  try {
-    await mkdir(MULMOTERMINAL_HOME, { recursive: true });
-    await writeFile(UPDATE_STATUS_FILE, JSON.stringify({ notice, at: now }));
-  } catch {
-    // best-effort — the badge simply won't have a cache next restart
-  }
-}
-
-// Populate the in-memory status the route serves: honour the opt-out, else reuse a fresh
-// cache, else run the check and cache it. Best-effort — any failure leaves the badge hidden.
-export async function refreshUpdateStatus(now: number = Date.now()): Promise<void> {
+// Populate the in-memory status the route serves. Call fire-and-forget at startup: honours the
+// opt-out, else runs the check and caches its result. Best-effort — a failure leaves the badge
+// hidden rather than disrupting the server.
+export async function refreshUpdateStatus(): Promise<void> {
   if (isUpdateCheckDisabled(process.env)) {
     cached = { notice: null };
     return;
   }
-  const disk = await readCache();
-  if (disk && isCacheFresh(disk.at, now)) {
-    cached = { notice: disk.notice };
-    return;
-  }
   try {
-    const notice = await computeUpdateNotice(PKG_DIR, VERSION);
-    cached = { notice };
-    await writeCache(notice, now);
+    cached = { notice: await computeUpdateNotice(PKG_DIR, VERSION) };
   } catch {
     // best-effort — keep the last good value
   }

--- a/server/config/update-status.ts
+++ b/server/config/update-status.ts
@@ -1,32 +1,87 @@
-// The update notice the launcher leaves in ~/.mulmoterminal/update-status.json for the web
-// header to show. The launcher runs the actual check (npm registry / git ls-remote) once at
-// startup — this side only reads what it wrote, so the browser can surface an "update
-// available" badge the terminal-only console line would otherwise hide.
-import { readFile } from "node:fs/promises";
+// The "update available" state for the web-header badge. The server runs the check itself
+// (shared computeUpdateNotice) rather than reading a launcher-written file, because under
+// `yarn dev` the launcher isn't in the loop — only the server is. The result is cached in
+// ~/.mulmoterminal/update-status.json with a timestamp so a dev `--watch` restart storm reuses
+// a recent answer instead of firing a git ls-remote (or a registry fetch) every reload.
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { computeUpdateNotice, isUpdateCheckDisabled } from "../../bin/update-check.js";
 import { MULMOTERMINAL_HOME } from "./env.js";
 
+// This file is server/config/update-status.ts, so two dirs up is the install root — the git
+// checkout (dev / a clone) or the package dir under node_modules (npm) the check runs against.
+const PKG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const { version: VERSION } = createRequire(import.meta.url)("../../package.json") as { version: string };
+
 export const UPDATE_STATUS_FILE = path.join(MULMOTERMINAL_HOME, "update-status.json");
+const CACHE_TTL_MS = 60 * 60 * 1000;
 
 export interface UpdateStatus {
   notice: string | null;
 }
 
-// The notice out of whatever was parsed from disk, or null. A missing/empty notice, a
-// non-string notice, or a non-object file all mean "nothing to show" — never a throw, so a
-// hand-edited or partially-written file can't take the header route down.
-export function parseUpdateStatus(raw: unknown): UpdateStatus {
-  if (typeof raw !== "object" || raw === null) return { notice: null };
-  const notice = (raw as { notice?: unknown }).notice;
-  return { notice: typeof notice === "string" && notice.length > 0 ? notice : null };
+interface CacheEntry {
+  notice: string | null;
+  at: number;
 }
 
-// Best-effort read: no file yet (the launcher's async check hasn't written it), an unreadable
-// or malformed file, all resolve to no notice rather than an error.
-export async function readUpdateStatus(file: string = UPDATE_STATUS_FILE): Promise<UpdateStatus> {
+// A cached result is worth reusing only if it carries a real timestamp and hasn't aged out.
+// A missing/garbage `at` forces a fresh check rather than trusting an unknown vintage.
+export function isCacheFresh(at: unknown, now: number, ttlMs: number = CACHE_TTL_MS): boolean {
+  return typeof at === "number" && at > 0 && at <= now && now - at < ttlMs;
+}
+
+// The cache entry out of whatever was on disk, or null when it can't be trusted (not an
+// object, no timestamp, non-string notice). Never throws — a hand-edited or half-written file
+// just means "no usable cache", so the check re-runs.
+export function parseCacheEntry(raw: unknown): CacheEntry | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const { notice, at } = raw as { notice?: unknown; at?: unknown };
+  if (typeof at !== "number") return null;
+  return { notice: typeof notice === "string" && notice.length > 0 ? notice : null, at };
+}
+
+let cached: UpdateStatus = { notice: null };
+export function getUpdateStatus(): UpdateStatus {
+  return cached;
+}
+
+async function readCache(): Promise<CacheEntry | null> {
   try {
-    return parseUpdateStatus(JSON.parse(await readFile(file, "utf8")));
+    return parseCacheEntry(JSON.parse(await readFile(UPDATE_STATUS_FILE, "utf8")));
   } catch {
-    return { notice: null };
+    return null;
+  }
+}
+
+async function writeCache(notice: string | null, now: number): Promise<void> {
+  try {
+    await mkdir(MULMOTERMINAL_HOME, { recursive: true });
+    await writeFile(UPDATE_STATUS_FILE, JSON.stringify({ notice, at: now }));
+  } catch {
+    // best-effort — the badge simply won't have a cache next restart
+  }
+}
+
+// Populate the in-memory status the route serves: honour the opt-out, else reuse a fresh
+// cache, else run the check and cache it. Best-effort — any failure leaves the badge hidden.
+export async function refreshUpdateStatus(now: number = Date.now()): Promise<void> {
+  if (isUpdateCheckDisabled(process.env)) {
+    cached = { notice: null };
+    return;
+  }
+  const disk = await readCache();
+  if (disk && isCacheFresh(disk.at, now)) {
+    cached = { notice: disk.notice };
+    return;
+  }
+  try {
+    const notice = await computeUpdateNotice(PKG_DIR, VERSION);
+    cached = { notice };
+    await writeCache(notice, now);
+  } catch {
+    // best-effort — keep the last good value
   }
 }

--- a/server/config/update-status.ts
+++ b/server/config/update-status.ts
@@ -1,0 +1,32 @@
+// The update notice the launcher leaves in ~/.mulmoterminal/update-status.json for the web
+// header to show. The launcher runs the actual check (npm registry / git ls-remote) once at
+// startup — this side only reads what it wrote, so the browser can surface an "update
+// available" badge the terminal-only console line would otherwise hide.
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { MULMOTERMINAL_HOME } from "./env.js";
+
+export const UPDATE_STATUS_FILE = path.join(MULMOTERMINAL_HOME, "update-status.json");
+
+export interface UpdateStatus {
+  notice: string | null;
+}
+
+// The notice out of whatever was parsed from disk, or null. A missing/empty notice, a
+// non-string notice, or a non-object file all mean "nothing to show" — never a throw, so a
+// hand-edited or partially-written file can't take the header route down.
+export function parseUpdateStatus(raw: unknown): UpdateStatus {
+  if (typeof raw !== "object" || raw === null) return { notice: null };
+  const notice = (raw as { notice?: unknown }).notice;
+  return { notice: typeof notice === "string" && notice.length > 0 ? notice : null };
+}
+
+// Best-effort read: no file yet (the launcher's async check hasn't written it), an unreadable
+// or malformed file, all resolve to no notice rather than an error.
+export async function readUpdateStatus(file: string = UPDATE_STATUS_FILE): Promise<UpdateStatus> {
+  try {
+    return parseUpdateStatus(JSON.parse(await readFile(file, "utf8")));
+  } catch {
+    return { notice: null };
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import { toolSummaries } from "./infra/plugins-registry.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
 import { getUserMcpServers, getWorklogConfig } from "./config/config-routes.js";
+import { refreshUpdateStatus } from "./config/update-status.js";
 import {
   tmuxAvailable,
   tmuxHasSession,
@@ -471,6 +472,9 @@ server.listen(PORT, () => {
       );
     }
   }
+  // Run the update check for the header badge (best-effort, non-blocking). Works under
+  // `yarn dev` too, where the launcher — which used to be the only checker — isn't involved.
+  void refreshUpdateStatus();
 });
 
 // The whisper sidecar is a spawned child that won't die with the parent on a

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -11,6 +11,7 @@ import { useAccountingView, accountingViewOpen } from "../composables/useAccount
 import { useWikiBrowse, wikiGotoIndex } from "../composables/useWikiBrowse";
 import { usePrsView, prsGotoIndex } from "../composables/usePrsView";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
+import { useUpdateStatus } from "../composables/useUpdateStatus";
 import type { Shortcut } from "../types/shortcuts";
 import type { StatusCounts } from "./gridTabs";
 import { gridStatusSummary } from "./gridTabs";
@@ -37,6 +38,20 @@ const { isOpen: accountingOpen } = useAccountingView();
 const { isOpen: wikiOpen } = useWikiBrowse();
 const { isOpen: prsOpen } = usePrsView();
 const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
+const { badge: updateBadge } = useUpdateStatus();
+
+// The badge offers the upgrade command; copying beats making the user retype it. Clipboard
+// can be unavailable (older browser, insecure context) — a failed copy is a no-op, the full
+// command is still in the tooltip.
+async function copyUpdateCommand(): Promise<void> {
+  const command = updateBadge.value?.command;
+  if (!command) return;
+  try {
+    await navigator.clipboard.writeText(command);
+  } catch {
+    // best-effort — the tooltip still shows the command to copy by hand
+  }
+}
 
 const inGrid = computed(() => route.name === "terminals");
 const inSingle = computed(() => !inGrid.value);
@@ -132,6 +147,17 @@ function showPrs(): void {
     </nav>
     <NotificationBell class="ml-auto" />
     <RemoteHostControl />
+    <button
+      v-if="updateBadge"
+      type="button"
+      class="mr-1 inline-flex flex-none items-center gap-1 rounded-full border border-accent px-2 py-0.5 text-[12px] leading-none text-accent hover:bg-selected"
+      :title="updateBadge.command ? `${updateBadge.text} (click to copy)` : updateBadge.text"
+      :aria-label="updateBadge.text"
+      @click="copyUpdateCommand"
+    >
+      <span class="material-symbols-outlined text-[15px] leading-none" aria-hidden="true">upgrade</span>
+      Update
+    </button>
     <LauncherButton
       :icon="soundEnabled ? 'notifications_active' : 'notifications_off'"
       :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, useTemplateRef } from "vue";
 import { useRoute } from "vue-router";
 import { router } from "../router";
 import NotificationBell from "./NotificationBell.vue";
@@ -12,6 +12,7 @@ import { useWikiBrowse, wikiGotoIndex } from "../composables/useWikiBrowse";
 import { usePrsView, prsGotoIndex } from "../composables/usePrsView";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
 import { useUpdateStatus } from "../composables/useUpdateStatus";
+import { useDropdownMenu } from "../composables/useDropdownMenu";
 import type { Shortcut } from "../types/shortcuts";
 import type { StatusCounts } from "./gridTabs";
 import { gridStatusSummary } from "./gridTabs";
@@ -40,16 +41,26 @@ const { isOpen: prsOpen } = usePrsView();
 const { enabled: soundEnabled, toggle: toggleSound } = useSoundEnabled();
 const { badge: updateBadge } = useUpdateStatus();
 
-// The badge offers the upgrade command; copying beats making the user retype it. Clipboard
-// can be unavailable (older browser, insecure context) — a failed copy is a no-op, the full
-// command is still in the tooltip.
+// Clicking the badge opens a popover that spells out what to run — a silent clipboard copy
+// gave no hint of what happened or which command it even was.
+const updateRoot = useTemplateRef<HTMLElement>("updateRoot");
+const { open: updateOpen, toggle: toggleUpdate } = useDropdownMenu(updateRoot);
+const copied = ref(false);
+let copiedTimer: ReturnType<typeof setTimeout> | undefined;
+
+// Copy the command shown in the popover; a brief "Copied" confirms it. Clipboard can be
+// unavailable (older browser, insecure context) — then it's a no-op and the command stays on
+// screen to copy by hand.
 async function copyUpdateCommand(): Promise<void> {
   const command = updateBadge.value?.command;
   if (!command) return;
   try {
     await navigator.clipboard.writeText(command);
+    copied.value = true;
+    if (copiedTimer) clearTimeout(copiedTimer);
+    copiedTimer = setTimeout(() => (copied.value = false), 1500);
   } catch {
-    // best-effort — the tooltip still shows the command to copy by hand
+    // best-effort — the command is on screen to copy by hand
   }
 }
 
@@ -147,17 +158,39 @@ function showPrs(): void {
     </nav>
     <NotificationBell class="ml-auto" />
     <RemoteHostControl />
-    <button
-      v-if="updateBadge"
-      type="button"
-      class="mr-1 inline-flex flex-none items-center gap-1 rounded-full border border-accent px-2 py-0.5 text-[12px] leading-none text-accent hover:bg-selected"
-      :title="updateBadge.command ? `${updateBadge.text} (click to copy)` : updateBadge.text"
-      :aria-label="updateBadge.text"
-      @click="copyUpdateCommand"
-    >
-      <span class="material-symbols-outlined text-[15px] leading-none" aria-hidden="true">upgrade</span>
-      Update
-    </button>
+    <div v-if="updateBadge" ref="updateRoot" class="relative mr-1 flex-none">
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-full border border-accent px-2 py-0.5 text-[12px] leading-none text-accent hover:bg-selected"
+        :class="{ 'bg-selected': updateOpen }"
+        :title="updateBadge.text"
+        :aria-label="updateBadge.text"
+        :aria-expanded="updateOpen"
+        aria-haspopup="true"
+        @click="toggleUpdate"
+      >
+        <span class="material-symbols-outlined text-[15px] leading-none" aria-hidden="true">upgrade</span>
+        Update
+      </button>
+      <div
+        v-if="updateOpen"
+        class="absolute right-0 top-full z-50 mt-1 w-64 rounded-md border border-border bg-panel p-3 text-[13px] text-fg shadow-lg"
+        role="group"
+        aria-label="Update available"
+      >
+        <p class="mb-2 font-semibold">A newer version is available</p>
+        <template v-if="updateBadge.command">
+          <p class="mb-1 text-muted">Run this to update:</p>
+          <div class="flex items-center gap-2">
+            <code class="min-w-0 flex-1 overflow-x-auto rounded bg-selected px-2 py-1 font-mono text-[12px] whitespace-nowrap">{{ updateBadge.command }}</code>
+            <button type="button" class="flex-none rounded border border-border px-2 py-1 text-[12px] hover:bg-selected" @click="copyUpdateCommand">
+              {{ copied ? "Copied" : "Copy" }}
+            </button>
+          </div>
+        </template>
+        <p v-else class="text-muted">{{ updateBadge.text }}</p>
+      </div>
+    </div>
     <LauncherButton
       :icon="soundEnabled ? 'notifications_active' : 'notifications_off'"
       :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"

--- a/src/composables/updateNotice.ts
+++ b/src/composables/updateNotice.ts
@@ -1,0 +1,17 @@
+// The launcher's one-line update notice, split for the header badge: the whole line is the
+// tooltip, and the command after "run: " is pulled out so the badge can offer to copy just
+// that (`git pull` / `npm i -g mulmoterminal`). Null when there is nothing to show, so the
+// badge renders nothing.
+export interface UpdateBadge {
+  text: string;
+  command: string | null;
+}
+
+const RUN_MARKER = "run: ";
+
+export function parseUpdateNotice(notice: string | null | undefined): UpdateBadge | null {
+  if (!notice) return null;
+  const at = notice.indexOf(RUN_MARKER);
+  const command = at === -1 ? "" : notice.slice(at + RUN_MARKER.length).trim();
+  return { text: notice, command: command || null };
+}

--- a/src/composables/useUpdateStatus.ts
+++ b/src/composables/useUpdateStatus.ts
@@ -1,0 +1,32 @@
+import { ref, computed, onMounted } from "vue";
+import { parseUpdateNotice } from "./updateNotice";
+
+// The launcher writes update-status.json asynchronously after startup, so the file may not
+// exist yet on the first load. One delayed re-fetch catches a notice that wasn't ready.
+const RETRY_MS = 4000;
+
+// The header's "update available" badge state, read from GET /api/update-status (which the
+// launcher fills in via ~/.mulmoterminal/update-status.json). Best-effort — any failure just
+// leaves the badge hidden.
+export function useUpdateStatus() {
+  const notice = ref<string | null>(null);
+  const badge = computed(() => parseUpdateNotice(notice.value));
+
+  async function fetchOnce(): Promise<void> {
+    try {
+      const res = await fetch("/api/update-status");
+      if (!res.ok) return;
+      const data = await res.json();
+      if (typeof data?.notice === "string") notice.value = data.notice;
+    } catch {
+      // best-effort — no badge is fine
+    }
+  }
+
+  onMounted(async () => {
+    await fetchOnce();
+    if (!notice.value) setTimeout(() => void fetchOnce(), RETRY_MS);
+  });
+
+  return { badge };
+}

--- a/src/composables/useUpdateStatus.ts
+++ b/src/composables/useUpdateStatus.ts
@@ -1,13 +1,15 @@
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import { parseUpdateNotice } from "./updateNotice";
 
-// The launcher writes update-status.json asynchronously after startup, so the file may not
-// exist yet on the first load. One delayed re-fetch catches a notice that wasn't ready.
-const RETRY_MS = 4000;
+// The server runs the check at startup and it reaches the network (git ls-remote can take
+// several seconds), so an early read returns null before it lands. Poll a few times to catch a
+// notice that shows up late, then stop — a genuinely up-to-date server just answers null each
+// time.
+const POLL_MS = 3000;
+const MAX_POLLS = 5;
 
-// The header's "update available" badge state, read from GET /api/update-status (which the
-// launcher fills in via ~/.mulmoterminal/update-status.json). Best-effort — any failure just
-// leaves the badge hidden.
+// The header's "update available" badge state, read from GET /api/update-status (the server's
+// startup check). Best-effort — any failure just leaves the badge hidden.
 export function useUpdateStatus() {
   const notice = ref<string | null>(null);
   const badge = computed(() => parseUpdateNotice(notice.value));
@@ -17,21 +19,26 @@ export function useUpdateStatus() {
       const res = await fetch("/api/update-status");
       if (!res.ok) return;
       const data = await res.json();
-      // Assign both ways: a null answer must CLEAR a notice a first read picked up, else a
-      // stale badge from the previous run's file would never go away once the launcher's
-      // check overwrites it clean.
+      // Assign both ways: a null answer must CLEAR a notice an earlier read picked up (e.g.
+      // after a `git pull` + restart), not just be ignored.
       notice.value = typeof data?.notice === "string" ? data.notice : null;
     } catch {
       // best-effort — no badge is fine
     }
   }
 
-  onMounted(async () => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let polls = 0;
+  async function poll(): Promise<void> {
     await fetchOnce();
-    // Always re-read once: the first read can land before the launcher's async check has
-    // (over)written the file, so its answer may be stale — not merely empty.
-    setTimeout(() => void fetchOnce(), RETRY_MS);
-  });
+    polls += 1;
+    // Keep polling only while there's nothing to show and we haven't given up: once a notice
+    // arrives it won't change without a restart, and a null is either "current" or "not ready".
+    if (notice.value === null && polls < MAX_POLLS) timer = setTimeout(() => void poll(), POLL_MS);
+  }
+
+  onMounted(() => void poll());
+  onUnmounted(() => timer && clearTimeout(timer));
 
   return { badge };
 }

--- a/src/composables/useUpdateStatus.ts
+++ b/src/composables/useUpdateStatus.ts
@@ -17,7 +17,10 @@ export function useUpdateStatus() {
       const res = await fetch("/api/update-status");
       if (!res.ok) return;
       const data = await res.json();
-      if (typeof data?.notice === "string") notice.value = data.notice;
+      // Assign both ways: a null answer must CLEAR a notice a first read picked up, else a
+      // stale badge from the previous run's file would never go away once the launcher's
+      // check overwrites it clean.
+      notice.value = typeof data?.notice === "string" ? data.notice : null;
     } catch {
       // best-effort — no badge is fine
     }
@@ -25,7 +28,9 @@ export function useUpdateStatus() {
 
   onMounted(async () => {
     await fetchOnce();
-    if (!notice.value) setTimeout(() => void fetchOnce(), RETRY_MS);
+    // Always re-read once: the first read can land before the launcher's async check has
+    // (over)written the file, so its answer may be stale — not merely empty.
+    setTimeout(() => void fetchOnce(), RETRY_MS);
   });
 
   return { badge };

--- a/test/bin/update-check.spec.ts
+++ b/test/bin/update-check.spec.ts
@@ -6,6 +6,7 @@ import {
   hasNodeModulesSegment,
   classifyInstall,
   parseLsRemoteHead,
+  parseLsRemoteDefaultBranch,
   npmUpdateNotice,
   isTreeDirtyForUpdate,
   gitUpdateNotice,
@@ -142,6 +143,25 @@ describe("parseLsRemoteHead", () => {
   it("rejects a non-sha in the HEAD line", () => {
     expect(parseLsRemoteHead("not-a-sha\tHEAD")).toBeNull();
   });
+
+  // The sha is still readable from --symref output (the ref: line's first field isn't a sha).
+  it("reads the sha out of --symref output too", () => {
+    expect(parseLsRemoteHead("ref: refs/heads/main\tHEAD\nd451b53dfcda7ef7395bed8a04cf5e1060d6e55f\tHEAD")).toBe("d451b53dfcda7ef7395bed8a04cf5e1060d6e55f");
+  });
+});
+
+describe("parseLsRemoteDefaultBranch", () => {
+  it("reads the default branch from a --symref line", () => {
+    expect(parseLsRemoteDefaultBranch("ref: refs/heads/main\tHEAD\nd451b53\tHEAD")).toBe("main");
+    expect(parseLsRemoteDefaultBranch("ref: refs/heads/master\tHEAD\nabc\tHEAD")).toBe("master");
+  });
+
+  // Without --symref (or on odd output) there's no ref line — fall back to null → bare git pull.
+  it("is null when there is no ref line", () => {
+    expect(parseLsRemoteDefaultBranch("d451b53\tHEAD")).toBeNull();
+    expect(parseLsRemoteDefaultBranch("")).toBeNull();
+    expect(parseLsRemoteDefaultBranch(null)).toBeNull();
+  });
 });
 
 describe("npmUpdateNotice", () => {
@@ -165,8 +185,15 @@ describe("gitUpdateNotice", () => {
   // tell whether the notice used the captured short sha or re-sliced the full one.
   const behind = { localSha: "0123456789abcdef", localShort: "short12", remoteSha: "fedcba9876543210", dirty: false };
 
-  it("names the local short sha and git pull when behind and clean", () => {
+  it("names the local short sha and a bare git pull when the default branch is unknown", () => {
     expect(gitUpdateNotice(behind)).toBe("Update available: short12 → origin  ·  run: git pull");
+  });
+
+  // `git pull` alone pulls the current branch's upstream, not the release. Naming the remote's
+  // default branch is what actually updates a clone that's on it (or behind it).
+  it("names origin + the default branch when it is known", () => {
+    expect(gitUpdateNotice({ ...behind, defaultBranch: "main" })).toBe("Update available: short12 → origin  ·  run: git pull origin main");
+    expect(gitUpdateNotice({ ...behind, defaultBranch: "master" })).toContain("git pull origin master");
   });
 
   // Dirty stops it even when the shas differ — a checkout with local edits can't
@@ -255,11 +282,11 @@ describe("computeUpdateNotice", () => {
       if (args[0] === "status") return ""; // clean
       if (args[0] === "rev-parse" && args[1] === "HEAD") return "0123456789abcdef";
       if (args[0] === "rev-parse" && args[1] === "--short") return "0123456";
-      if (args[0] === "ls-remote") return "fedcba9876543210\tHEAD";
+      if (args[0] === "ls-remote") return "ref: refs/heads/main\tHEAD\nfedcba9876543210\tHEAD";
       return null;
     };
     const notice = await computeUpdateNotice("/home/dev/mulmoterminal", "0.7.0", { runGit: git, fetchLatest: async () => null });
-    expect(notice).toBe("Update available: 0123456 → origin  ·  run: git pull");
+    expect(notice).toBe("Update available: 0123456 → origin  ·  run: git pull origin main");
   });
 
   it("is silent on the git path when the checkout is dirty", async () => {

--- a/test/bin/update-check.spec.ts
+++ b/test/bin/update-check.spec.ts
@@ -9,6 +9,7 @@ import {
   npmUpdateNotice,
   isTreeDirtyForUpdate,
   gitUpdateNotice,
+  computeUpdateNotice,
 } from "../../bin/update-check.js";
 
 describe("isNewerVersion", () => {
@@ -220,5 +221,53 @@ describe("isTreeDirtyForUpdate", () => {
   // A tracked change hiding among untracked files still counts.
   it("is dirty when a tracked change sits among untracked ones", () => {
     expect(isTreeDirtyForUpdate("?? a.log\n M src/app.ts\n?? b.log")).toBe(true);
+  });
+});
+
+describe("computeUpdateNotice", () => {
+  // A checkout under node_modules is an npm install: it must NOT run git, and the answer
+  // comes from the registry vs the bundled version.
+  it("takes the npm path for a node_modules dir, without touching git", async () => {
+    let gitCalls = 0;
+    const notice = await computeUpdateNotice("/proj/node_modules/mulmoterminal", "0.7.0", {
+      runGit: async () => {
+        gitCalls++;
+        return null;
+      },
+      fetchLatest: async () => "0.8.0",
+    });
+    expect(notice).toBe("Update available: 0.7.0 → 0.8.0  ·  run: npm i -g mulmoterminal");
+    expect(gitCalls).toBe(0);
+  });
+
+  it("is silent on the npm path when already latest", async () => {
+    const notice = await computeUpdateNotice("/proj/node_modules/mulmoterminal", "0.8.0", {
+      runGit: async () => null,
+      fetchLatest: async () => "0.8.0",
+    });
+    expect(notice).toBeNull();
+  });
+
+  // A bare checkout is a git install: local HEAD vs the remote's, read via ls-remote.
+  it("takes the git path for a checkout and reports behind", async () => {
+    const git = async (args: string[]): Promise<string | null> => {
+      if (args[0] === "rev-parse" && args[1] === "--is-inside-work-tree") return "true";
+      if (args[0] === "status") return ""; // clean
+      if (args[0] === "rev-parse" && args[1] === "HEAD") return "0123456789abcdef";
+      if (args[0] === "rev-parse" && args[1] === "--short") return "0123456";
+      if (args[0] === "ls-remote") return "fedcba9876543210\tHEAD";
+      return null;
+    };
+    const notice = await computeUpdateNotice("/home/dev/mulmoterminal", "0.7.0", { runGit: git, fetchLatest: async () => null });
+    expect(notice).toBe("Update available: 0123456 → origin  ·  run: git pull");
+  });
+
+  it("is silent on the git path when the checkout is dirty", async () => {
+    const git = async (args: string[]): Promise<string | null> => {
+      if (args[0] === "rev-parse" && args[1] === "--is-inside-work-tree") return "true";
+      if (args[0] === "status") return " M src/app.ts"; // tracked change => dirty
+      return "whatever";
+    };
+    expect(await computeUpdateNotice("/home/dev/mulmoterminal", "0.7.0", { runGit: git, fetchLatest: async () => null })).toBeNull();
   });
 });

--- a/test/bin/update-check.spec.ts
+++ b/test/bin/update-check.spec.ts
@@ -7,6 +7,7 @@ import {
   classifyInstall,
   parseLsRemoteHead,
   parseLsRemoteDefaultBranch,
+  isSafeBranchName,
   npmUpdateNotice,
   isTreeDirtyForUpdate,
   gitUpdateNotice,
@@ -164,6 +165,28 @@ describe("parseLsRemoteDefaultBranch", () => {
   });
 });
 
+describe("isSafeBranchName", () => {
+  it("accepts ordinary branch names", () => {
+    for (const name of ["main", "master", "develop", "release/2.x", "feat/update-badge", "v1.2.3", "a_b-c"]) {
+      expect(isSafeBranchName(name), name).toBe(true);
+    }
+  });
+
+  // The name comes from an untrusted remote and lands in a copy/paste shell command; anything
+  // that could break out of `git pull origin <name>` must be refused.
+  it("rejects names with shell metacharacters", () => {
+    for (const name of ["main;rm -rf ~", "main$(whoami)", "a`id`", "a|b", "a&b", "a b", "a>b", "'x'", '"x"', ""]) {
+      expect(isSafeBranchName(name), name).toBe(false);
+    }
+  });
+
+  it("rejects non-strings", () => {
+    expect(isSafeBranchName(null)).toBe(false);
+    expect(isSafeBranchName(undefined)).toBe(false);
+    expect(isSafeBranchName(42)).toBe(false);
+  });
+});
+
 describe("npmUpdateNotice", () => {
   it("names both versions and the npm command when newer", () => {
     expect(npmUpdateNotice("0.7.0", "0.8.0")).toBe("Update available: 0.7.0 → 0.8.0  ·  run: npm i -g mulmoterminal");
@@ -194,6 +217,13 @@ describe("gitUpdateNotice", () => {
   it("names origin + the default branch when it is known", () => {
     expect(gitUpdateNotice({ ...behind, defaultBranch: "main" })).toBe("Update available: short12 → origin  ·  run: git pull origin main");
     expect(gitUpdateNotice({ ...behind, defaultBranch: "master" })).toContain("git pull origin master");
+  });
+
+  // The branch is untrusted remote metadata pasted into a shell — a metachar name must fall
+  // back to a bare `git pull`, never inject.
+  it("falls back to a bare git pull for an unsafe branch name", () => {
+    expect(gitUpdateNotice({ ...behind, defaultBranch: "main;rm -rf ~" })).toBe("Update available: short12 → origin  ·  run: git pull");
+    expect(gitUpdateNotice({ ...behind, defaultBranch: "$(whoami)" })).not.toContain("whoami");
   });
 
   // Dirty stops it even when the shas differ — a checkout with local edits can't
@@ -287,6 +317,21 @@ describe("computeUpdateNotice", () => {
     };
     const notice = await computeUpdateNotice("/home/dev/mulmoterminal", "0.7.0", { runGit: git, fetchLatest: async () => null });
     expect(notice).toBe("Update available: 0123456 → origin  ·  run: git pull origin main");
+  });
+
+  // End to end: a hostile remote whose default branch carries a shell metachar must not reach
+  // the pasteable command — the notice falls back to a bare git pull.
+  it("does not inject an unsafe remote default branch into the command", async () => {
+    const git = async (args: string[]): Promise<string | null> => {
+      if (args[0] === "rev-parse" && args[1] === "--is-inside-work-tree") return "true";
+      if (args[0] === "status") return "";
+      if (args[0] === "rev-parse" && args[1] === "HEAD") return "0123456789abcdef";
+      if (args[0] === "rev-parse" && args[1] === "--short") return "0123456";
+      if (args[0] === "ls-remote") return "ref: refs/heads/main;rm$IFS-rf\tHEAD\nfedcba9876543210\tHEAD";
+      return null;
+    };
+    const notice = await computeUpdateNotice("/home/dev/mulmoterminal", "0.7.0", { runGit: git, fetchLatest: async () => null });
+    expect(notice).toBe("Update available: 0123456 → origin  ·  run: git pull");
   });
 
   it("is silent on the git path when the checkout is dirty", async () => {

--- a/test/server/config/update-status.spec.ts
+++ b/test/server/config/update-status.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { parseUpdateStatus, readUpdateStatus } from "../../../server/config/update-status.js";
+
+describe("parseUpdateStatus", () => {
+  it("reads a string notice", () => {
+    expect(parseUpdateStatus({ notice: "Update available: git pull" })).toEqual({ notice: "Update available: git pull" });
+  });
+
+  it("is null when the launcher wrote no notice (clean / opted out)", () => {
+    expect(parseUpdateStatus({ notice: null })).toEqual({ notice: null });
+  });
+
+  // An empty string is nothing to show — treat it as no notice so the badge stays hidden.
+  it("treats an empty notice as none", () => {
+    expect(parseUpdateStatus({ notice: "" })).toEqual({ notice: null });
+  });
+
+  // A hand-edited or partially-written file must never take the route down.
+  it("is null for junk rather than throwing", () => {
+    expect(parseUpdateStatus(null)).toEqual({ notice: null });
+    expect(parseUpdateStatus("nope")).toEqual({ notice: null });
+    expect(parseUpdateStatus(42)).toEqual({ notice: null });
+    expect(parseUpdateStatus({})).toEqual({ notice: null });
+    expect(parseUpdateStatus({ notice: 123 })).toEqual({ notice: null });
+  });
+});
+
+describe("readUpdateStatus", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-update-"));
+  const file = path.join(dir, "update-status.json");
+  const cleanup = () => rmSync(dir, { recursive: true, force: true });
+
+  it("returns the notice from a well-formed file", async () => {
+    writeFileSync(file, JSON.stringify({ notice: "Update available: 0.7.1 → 0.8.0  ·  run: npm i -g mulmoterminal" }));
+    expect((await readUpdateStatus(file)).notice).toContain("npm i -g mulmoterminal");
+  });
+
+  // The launcher's async check may not have written the file yet on first load — that is the
+  // common case, not an error, and it must read as "no badge".
+  it("is null when the file does not exist", async () => {
+    expect(await readUpdateStatus(path.join(dir, "missing.json"))).toEqual({ notice: null });
+  });
+
+  it("is null for malformed JSON", async () => {
+    writeFileSync(file, "{ not json");
+    expect(await readUpdateStatus(file)).toEqual({ notice: null });
+    cleanup();
+  });
+});

--- a/test/server/config/update-status.spec.ts
+++ b/test/server/config/update-status.spec.ts
@@ -1,52 +1,54 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { parseUpdateStatus, readUpdateStatus } from "../../../server/config/update-status.js";
+import { parseCacheEntry, isCacheFresh } from "../../../server/config/update-status.js";
 
-describe("parseUpdateStatus", () => {
-  it("reads a string notice", () => {
-    expect(parseUpdateStatus({ notice: "Update available: git pull" })).toEqual({ notice: "Update available: git pull" });
+describe("parseCacheEntry", () => {
+  it("reads a cached notice with its timestamp", () => {
+    expect(parseCacheEntry({ notice: "Update available: git pull", at: 1000 })).toEqual({
+      notice: "Update available: git pull",
+      at: 1000,
+    });
   });
 
-  it("is null when the launcher wrote no notice (clean / opted out)", () => {
-    expect(parseUpdateStatus({ notice: null })).toEqual({ notice: null });
+  it("keeps the timestamp but nulls a clean notice", () => {
+    expect(parseCacheEntry({ notice: null, at: 1000 })).toEqual({ notice: null, at: 1000 });
+    expect(parseCacheEntry({ notice: "", at: 1000 })).toEqual({ notice: null, at: 1000 });
   });
 
-  // An empty string is nothing to show — treat it as no notice so the badge stays hidden.
-  it("treats an empty notice as none", () => {
-    expect(parseUpdateStatus({ notice: "" })).toEqual({ notice: null });
+  // No usable timestamp => no usable cache => the check must re-run rather than trust it.
+  it("is null without a numeric timestamp", () => {
+    expect(parseCacheEntry({ notice: "x" })).toBeNull();
+    expect(parseCacheEntry({ notice: "x", at: "soon" })).toBeNull();
   });
 
-  // A hand-edited or partially-written file must never take the route down.
-  it("is null for junk rather than throwing", () => {
-    expect(parseUpdateStatus(null)).toEqual({ notice: null });
-    expect(parseUpdateStatus("nope")).toEqual({ notice: null });
-    expect(parseUpdateStatus(42)).toEqual({ notice: null });
-    expect(parseUpdateStatus({})).toEqual({ notice: null });
-    expect(parseUpdateStatus({ notice: 123 })).toEqual({ notice: null });
+  // A hand-edited or half-written file must never throw the route.
+  it("is null for junk", () => {
+    expect(parseCacheEntry(null)).toBeNull();
+    expect(parseCacheEntry("nope")).toBeNull();
+    expect(parseCacheEntry(42)).toBeNull();
   });
 });
 
-describe("readUpdateStatus", () => {
-  const dir = mkdtempSync(path.join(tmpdir(), "mt-update-"));
-  const file = path.join(dir, "update-status.json");
-  const cleanup = () => rmSync(dir, { recursive: true, force: true });
+describe("isCacheFresh", () => {
+  const TTL = 60 * 60 * 1000;
 
-  it("returns the notice from a well-formed file", async () => {
-    writeFileSync(file, JSON.stringify({ notice: "Update available: 0.7.1 → 0.8.0  ·  run: npm i -g mulmoterminal" }));
-    expect((await readUpdateStatus(file)).notice).toContain("npm i -g mulmoterminal");
+  it("is fresh within the ttl", () => {
+    expect(isCacheFresh(1000, 1000 + TTL - 1, TTL)).toBe(true);
+    expect(isCacheFresh(1000, 1000, TTL)).toBe(true);
   });
 
-  // The launcher's async check may not have written the file yet on first load — that is the
-  // common case, not an error, and it must read as "no badge".
-  it("is null when the file does not exist", async () => {
-    expect(await readUpdateStatus(path.join(dir, "missing.json"))).toEqual({ notice: null });
+  it("is stale at or past the ttl", () => {
+    expect(isCacheFresh(1000, 1000 + TTL, TTL)).toBe(false);
+    expect(isCacheFresh(1000, 1000 + TTL + 1, TTL)).toBe(false);
   });
 
-  it("is null for malformed JSON", async () => {
-    writeFileSync(file, "{ not json");
-    expect(await readUpdateStatus(file)).toEqual({ notice: null });
-    cleanup();
+  // A timestamp from the future (clock skew, a copied file) isn't trustworthy — re-check.
+  it("rejects a future timestamp", () => {
+    expect(isCacheFresh(2000, 1000, TTL)).toBe(false);
+  });
+
+  it("rejects a missing / non-numeric timestamp", () => {
+    expect(isCacheFresh(undefined, 1000, TTL)).toBe(false);
+    expect(isCacheFresh(0, 1000, TTL)).toBe(false);
+    expect(isCacheFresh("1000", 1000, TTL)).toBe(false);
   });
 });

--- a/test/server/config/update-status.spec.ts
+++ b/test/server/config/update-status.spec.ts
@@ -1,54 +1,47 @@
-import { describe, it, expect } from "vitest";
-import { parseCacheEntry, isCacheFresh } from "../../../server/config/update-status.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-describe("parseCacheEntry", () => {
-  it("reads a cached notice with its timestamp", () => {
-    expect(parseCacheEntry({ notice: "Update available: git pull", at: 1000 })).toEqual({
-      notice: "Update available: git pull",
-      at: 1000,
-    });
-  });
+// vi.mock is hoisted above imports, so the doubles it returns must be created inside a
+// vi.hoisted block rather than referencing top-level consts (which aren't initialized yet).
+const { computeUpdateNotice, isUpdateCheckDisabled } = vi.hoisted(() => ({
+  computeUpdateNotice: vi.fn<(pkgDir: string, version: string) => Promise<string | null>>(),
+  isUpdateCheckDisabled: vi.fn<(env: Record<string, string | undefined>) => boolean>(),
+}));
+vi.mock("../../../bin/update-check.js", () => ({ computeUpdateNotice, isUpdateCheckDisabled }));
 
-  it("keeps the timestamp but nulls a clean notice", () => {
-    expect(parseCacheEntry({ notice: null, at: 1000 })).toEqual({ notice: null, at: 1000 });
-    expect(parseCacheEntry({ notice: "", at: 1000 })).toEqual({ notice: null, at: 1000 });
-  });
+import { refreshUpdateStatus, getUpdateStatus } from "../../../server/config/update-status.js";
 
-  // No usable timestamp => no usable cache => the check must re-run rather than trust it.
-  it("is null without a numeric timestamp", () => {
-    expect(parseCacheEntry({ notice: "x" })).toBeNull();
-    expect(parseCacheEntry({ notice: "x", at: "soon" })).toBeNull();
-  });
-
-  // A hand-edited or half-written file must never throw the route.
-  it("is null for junk", () => {
-    expect(parseCacheEntry(null)).toBeNull();
-    expect(parseCacheEntry("nope")).toBeNull();
-    expect(parseCacheEntry(42)).toBeNull();
-  });
+beforeEach(() => {
+  computeUpdateNotice.mockReset();
+  isUpdateCheckDisabled.mockReset();
 });
 
-describe("isCacheFresh", () => {
-  const TTL = 60 * 60 * 1000;
-
-  it("is fresh within the ttl", () => {
-    expect(isCacheFresh(1000, 1000 + TTL - 1, TTL)).toBe(true);
-    expect(isCacheFresh(1000, 1000, TTL)).toBe(true);
+describe("refreshUpdateStatus", () => {
+  it("caches the computed notice for the route to serve", async () => {
+    isUpdateCheckDisabled.mockReturnValue(false);
+    computeUpdateNotice.mockResolvedValue("Update available: a1b2c3d → origin  ·  run: git pull");
+    await refreshUpdateStatus();
+    expect(getUpdateStatus()).toEqual({ notice: "Update available: a1b2c3d → origin  ·  run: git pull" });
   });
 
-  it("is stale at or past the ttl", () => {
-    expect(isCacheFresh(1000, 1000 + TTL, TTL)).toBe(false);
-    expect(isCacheFresh(1000, 1000 + TTL + 1, TTL)).toBe(false);
+  it("caches null when the checkout is current", async () => {
+    isUpdateCheckDisabled.mockReturnValue(false);
+    computeUpdateNotice.mockResolvedValue(null);
+    await refreshUpdateStatus();
+    expect(getUpdateStatus()).toEqual({ notice: null });
   });
 
-  // A timestamp from the future (clock skew, a copied file) isn't trustworthy — re-check.
-  it("rejects a future timestamp", () => {
-    expect(isCacheFresh(2000, 1000, TTL)).toBe(false);
+  // Opt-out must skip the probe entirely, not just hide the result.
+  it("stays hidden and skips the check when opted out", async () => {
+    isUpdateCheckDisabled.mockReturnValue(true);
+    await refreshUpdateStatus();
+    expect(getUpdateStatus()).toEqual({ notice: null });
+    expect(computeUpdateNotice).not.toHaveBeenCalled();
   });
 
-  it("rejects a missing / non-numeric timestamp", () => {
-    expect(isCacheFresh(undefined, 1000, TTL)).toBe(false);
-    expect(isCacheFresh(0, 1000, TTL)).toBe(false);
-    expect(isCacheFresh("1000", 1000, TTL)).toBe(false);
+  // A thrown check must not surface — the badge just keeps its last value.
+  it("does not throw when the check rejects", async () => {
+    isUpdateCheckDisabled.mockReturnValue(false);
+    computeUpdateNotice.mockRejectedValue(new Error("offline"));
+    await expect(refreshUpdateStatus()).resolves.toBeUndefined();
   });
 });

--- a/test/src/composables/updateNotice.spec.ts
+++ b/test/src/composables/updateNotice.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { parseUpdateNotice } from "../../../src/composables/updateNotice";
+
+describe("parseUpdateNotice", () => {
+  it("is null when there is no notice", () => {
+    expect(parseUpdateNotice(null)).toBeNull();
+    expect(parseUpdateNotice(undefined)).toBeNull();
+    expect(parseUpdateNotice("")).toBeNull();
+  });
+
+  // The command after "run: " is pulled out so the badge can copy just that.
+  it("pulls the npm command out of the notice", () => {
+    const badge = parseUpdateNotice("Update available: 0.7.1 → 0.8.0  ·  run: npm i -g mulmoterminal");
+    expect(badge).toEqual({
+      text: "Update available: 0.7.1 → 0.8.0  ·  run: npm i -g mulmoterminal",
+      command: "npm i -g mulmoterminal",
+    });
+  });
+
+  it("pulls the git command out of the notice", () => {
+    expect(parseUpdateNotice("Update available: a1b2c3d → origin  ·  run: git pull")?.command).toBe("git pull");
+  });
+
+  // A notice without the marker still shows (as the tooltip); there is just nothing to copy.
+  it("keeps the text but has no command when there is no run marker", () => {
+    expect(parseUpdateNotice("A new version is out")).toEqual({ text: "A new version is out", command: null });
+  });
+});

--- a/test/src/composables/useUpdateStatus.spec.ts
+++ b/test/src/composables/useUpdateStatus.spec.ts
@@ -19,11 +19,13 @@ function mountStatus() {
   return { w, badge: () => badge.value };
 }
 
+const GIT_NOTICE = "Update available: a1b2c3d → origin  ·  run: git pull";
+
 describe("useUpdateStatus", () => {
   it("exposes a badge when the server reports a notice", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({ ok: true, json: async () => ({ notice: "Update available: a1b2c3d → origin  ·  run: git pull" }) })),
+      vi.fn(async () => ({ ok: true, json: async () => ({ notice: GIT_NOTICE }) })),
     );
     const { badge } = mountStatus();
     await flushPromises();
@@ -40,28 +42,6 @@ describe("useUpdateStatus", () => {
     expect(badge()).toBeNull();
   });
 
-  // The codex-flagged race: the first read returns a previous run's notice, but this run is
-  // clean once the launcher overwrites the file. The delayed re-read must clear the stale
-  // badge rather than skip because a (stale) value was already present.
-  it("clears a stale badge on the delayed re-read", async () => {
-    vi.useFakeTimers();
-    try {
-      let current = "Update available: a1b2c3d → origin  ·  run: git pull";
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => ({ ok: true, json: async () => ({ notice: current }) })),
-      );
-      const { badge } = mountStatus();
-      await vi.waitFor(() => expect(badge()?.command).toBe("git pull"));
-
-      current = null as unknown as string; // launcher overwrote the file: this run is clean
-      await vi.advanceTimersByTimeAsync(5000);
-      expect(badge()).toBeNull();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
   // The file may not be readable / the request may fail — the badge just stays hidden.
   it("stays hidden when the fetch fails", async () => {
     vi.stubGlobal(
@@ -73,5 +53,42 @@ describe("useUpdateStatus", () => {
     const { badge } = mountStatus();
     await flushPromises();
     expect(badge()).toBeNull();
+  });
+
+  // The server's check reaches the network (ls-remote can take seconds), so the first read is
+  // null; a later poll must pick the notice up rather than give up on the first empty answer.
+  it("shows the badge when the notice arrives on a later poll", async () => {
+    vi.useFakeTimers();
+    try {
+      let served: string | null = null; // the server check hasn't finished yet
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({ ok: true, json: async () => ({ notice: served }) })),
+      );
+      const { badge } = mountStatus();
+      await vi.waitFor(() => expect(badge).not.toBeUndefined());
+      expect(badge()).toBeNull();
+
+      served = GIT_NOTICE; // the check finished behind
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(badge()?.command).toBe("git pull");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A server that is genuinely up to date answers null every time — polling must give up, not
+  // hammer the endpoint forever.
+  it("stops polling after a bounded number of empty reads", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ notice: null }) }));
+      vi.stubGlobal("fetch", fetchMock);
+      mountStatus();
+      await vi.advanceTimersByTimeAsync(3000 * 10);
+      expect(fetchMock.mock.calls).toHaveLength(5);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/src/composables/useUpdateStatus.spec.ts
+++ b/test/src/composables/useUpdateStatus.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { defineComponent, h, type ComputedRef } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { useUpdateStatus } from "../../../src/composables/useUpdateStatus";
+import type { UpdateBadge } from "../../../src/composables/updateNotice";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function mountStatus() {
+  let badge!: ComputedRef<UpdateBadge | null>;
+  const w = mount(
+    defineComponent({
+      setup() {
+        badge = useUpdateStatus().badge;
+        return () => h("div");
+      },
+    }),
+  );
+  return { w, badge: () => badge.value };
+}
+
+describe("useUpdateStatus", () => {
+  it("exposes a badge when the server reports a notice", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ notice: "Update available: a1b2c3d → origin  ·  run: git pull" }) })),
+    );
+    const { badge } = mountStatus();
+    await flushPromises();
+    expect(badge()?.command).toBe("git pull");
+  });
+
+  it("has no badge when the server reports none", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ notice: null }) })),
+    );
+    const { badge } = mountStatus();
+    await flushPromises();
+    expect(badge()).toBeNull();
+  });
+
+  // The file may not be readable / the request may fail — the badge just stays hidden.
+  it("stays hidden when the fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    const { badge } = mountStatus();
+    await flushPromises();
+    expect(badge()).toBeNull();
+  });
+});

--- a/test/src/composables/useUpdateStatus.spec.ts
+++ b/test/src/composables/useUpdateStatus.spec.ts
@@ -40,6 +40,28 @@ describe("useUpdateStatus", () => {
     expect(badge()).toBeNull();
   });
 
+  // The codex-flagged race: the first read returns a previous run's notice, but this run is
+  // clean once the launcher overwrites the file. The delayed re-read must clear the stale
+  // badge rather than skip because a (stale) value was already present.
+  it("clears a stale badge on the delayed re-read", async () => {
+    vi.useFakeTimers();
+    try {
+      let current = "Update available: a1b2c3d → origin  ·  run: git pull";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({ ok: true, json: async () => ({ notice: current }) })),
+      );
+      const { badge } = mountStatus();
+      await vi.waitFor(() => expect(badge()?.command).toBe("git pull"));
+
+      current = null as unknown as string; // launcher overwrote the file: this run is clean
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(badge()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   // The file may not be readable / the request may fail — the badge just stays hidden.
   it("stays hidden when the fetch fails", async () => {
     vi.stubGlobal(


### PR DESCRIPTION
## Summary

`#654` の更新チェックはコンソール1行だけで、ブラウザしか見ない使い方だと気づけなかった。AppToolbar に控えめな **⬆ Update** バッジを出す。

```
┌ MulmoTerminal  Chat  Grid  … ────────── 🔔  [⬆ Update]  🔈  ⚙ ┐
                                            ↑ 更新がある時だけ表示
```
- ホバー: 全文（`Update available: 0.7.1 → 0.8.0  ·  run: npm i -g mulmoterminal` / git版は `… → origin · run: git pull origin main`（default branch を symref から検出））
- クリック: ポップオーバーで実行コマンドを表示（`git pull origin <default>` / `npm i -g mulmoterminal`）＋ Copy ボタン

## 設計（レビュー/実機テストを経て確定）

**チェックはサーバ側で実行**する。当初は launcher が結果をファイルに書く方式にしたが、`yarn dev`（= `node server/index.ts` を直接）では launcher が動かず、ファイルが書かれずバッジが出なかった。そこで orchestration を `bin/update-check.js` の `computeUpdateNotice`（DI 対応・共有）に集約し、

- **launcher**: 従来通りコンソール通知（`computeUpdateNotice` を使用）
- **server**: 起動時に `computeUpdateNotice` を実行（背景・非ブロッキング）し、`GET /api/update-status` でメモリから返す

これで `yarn dev` でも本番でも動く。バッジは**クリーンかつ behind の checkout** で表示（dirty は #654 の「dirty→黙る」通り抑制）。

## Items to Confirm / Review

1. **ls-remote のタイムアウト**: `git ls-remote origin HEAD` は SSH/HTTPS ハンドシェイクで数秒かかる（実測 4.7s）。共有 1.5s では毎回タイムアウトして notice が null になっていた（**#654 のコンソール通知も同じ潜在バグ**）。ls-remote だけ 6s に延長（背景チェックなので影響なし。local git 操作は 1.5s のまま）。
2. **起動直後の取りこぼし**: サーバのチェックは ~5s かかるため、`useUpdateStatus` は `/api/update-status` を数回ポーリング（5×3s）して遅れて来た notice を拾う。notice が来る or 予算切れで停止。
3. **キャッシュ無し**: サーバ起動ごとに毎回判定（背景・best-effort）。`git pull` 後は次の再起動でバッジが消える。TTLキャッシュは「更新後もバッジが残る」staleness があり不採用。
4. **opt-out**（`MULMOTERMINAL_NO_UPDATE_CHECK` / `NO_UPDATE_NOTIFIER`）はサーバ側でも尊重。
5. 実機確認: 動作中の dev サーバ（clean・behind）で `/api/update-status` が `Update available: … → origin · run: git pull` を返すことを確認済み。

## User Prompt

> バージョン情報ってコンソールに出るだけ？headerにupdateありとかだす？（→ A: header に出す）
> たぶん設定でheader変えているから表示されない / global でかな
> 今ここで動かしているんだけどでないね

## Implementation

| レイヤ | 変更 |
|---|---|
| `bin/update-check.js` | `runGit` + `computeUpdateNotice`（install判別→git/npm、DI対応）を追加。ls-remote は 6s |
| `bin/mulmoterminal.js` | `checkForUpdate` を `computeUpdateNotice` 呼び出しに簡素化（コンソール通知は不変） |
| `server/config/update-status.ts` | 起動時 `refreshUpdateStatus`（computeUpdateNotice）→ `getUpdateStatus` をメモリ保持 |
| `server/config/config-routes.ts` | `GET /api/update-status` → `getUpdateStatus()` |
| `server/index.ts` | listen 時に `refreshUpdateStatus()` を fire-and-forget |
| `src/composables/updateNotice.ts` | `parseUpdateNotice`(純): notice を `{text, command}` に分解 |
| `src/composables/useUpdateStatus.ts` | `/api/update-status` を数回ポーリング → badge |
| `src/components/AppToolbar.vue` | notice がある時だけピル表示 |

## Testing

全 **3057 pass**（223ファイル）。`computeUpdateNotice` は DI で単体テスト（npm-path は git を呼ばない / git-path は behind・dirty で黙る）、ポーリングは fake timer で「遅れて来た notice を拾う」「予算切れで停止」を検証、純関数（parse系）も変異検証済み。実機の dev サーバで notice 応答を確認。

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)