### PR TITLE
fix: 古い GET 応答が新しい状態を上書きする残り 2 箇所（#620 同族） (#673)

### DIFF
--- a/plans/fix-673-stale-response-overwrite.md
+++ b/plans/fix-673-stale-response-overwrite.md
@@ -1,0 +1,25 @@
+# fix #673 — 古い GET 応答が新しい状態を上書きする残り 2 箇所（#620 同族）
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/673
+
+#620 の行列（F1〜F5）は「GET 中に届いた **live 更新**を応答が上書きする」形だった。今回は同族だが「**同じ対象への 2 つの GET 応答が逆順で適用される**」型を 2 箇所直す。どちらも同じファイル／兄弟に確立済みのガードがあるのに、その箇所だけ漏れていた。
+
+## G1. `src/components/TerminalCell.vue` — usage/context バッジ
+
+`loadInitial`（seed）と `refreshUsage`（ターン終了時）の両方が `applyBadges` を呼ぶ。`loadInitial` は `latestSeed` で守られているが、**`refreshUsage` は無トークン**。連続してターンが終わると `/api/session` 読み取りが 2 つ同時に in-flight になり、古い方が後着すると前ターンの数値でバッジを巻き戻す（次の refresh まで固定）。
+
+同ファイルの他の 5 fetch（resumable/scripts/…）は単調トークンで保護済み、GridView の `seedMeta` も per-id トークンを持つ。バッジ経路だけ取り残されていた。
+
+**修正**: バッジ適用専用の `latestBadgeReq` を追加し、`loadInitial` と `refreshUsage` の**両方**が fetch 前に `++latestBadgeReq` して、適用前に `=== latestBadgeReq` を確認。最新のバッジ fetch が勝つ。`latestSeed`／`activityGen` の既存ロジックは不変。
+
+## G2. `src/composables/useGitStatus.ts` — cwd→null 遷移
+
+`refresh()` は `my === req` トークンを持つが、`cwd` が無いときの early return（`status.value = null; return;`）が `++req` の**前**にあった。dir→null 遷移（ランチャー／command セルへ切替）で `req` が増えないため、前 dir の in-flight 応答が `my === req` を通過して `status = null` を上書きし、**前のディレクトリのブランチチップが復活**する。dir→dir 遷移は両方 `++req` を通るので元から正しく、穴は dir→null の 1 遷移だけ。
+
+**修正**: `++req` を early return の**前**へ移動。null 分岐でもトークンを進め、in-flight 応答を無効化する。
+
+## テスト
+
+- `test/src/components/TerminalCell.spec.ts`: 2 つの refreshUsage を逆順で解決させ、新しい方の数値が残ることを確認。
+- `test/src/composables/useGitStatus.spec.ts`（新規）: `useGridActivity.spec` と同じ mount + gated-fetch ハーネスで、dir→null 後に古い応答が来ても `status` が null のままであることを確認。
+- 両方とも修正を戻すと赤・入れると緑を変異テストで確認済み。

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -193,6 +193,11 @@ let activityGen = 0;
 // Seeds also overlap each other — mount racing a reconnect, or reconnect flaps. Only the
 // newest may apply; an older one, even resolving last, describes a moment already overtaken.
 let latestSeed = 0;
+// The usage/context badges are filled from two async sources — a seed (loadInitial) and
+// refreshUsage on turn end — so back-to-back turns can leave two /api/session reads in
+// flight at once. Neither path bumps latestSeed for badges, so a stale read resolving last
+// would clobber the newer numbers. This token makes the newest badge fetch win. (#620.)
+let latestBadgeReq = 0;
 function applyActivity(d: ActivityMsg) {
   activityGen++;
   const next = applyActivityPush(
@@ -238,6 +243,7 @@ function applyBadges(data: SessionDetail) {
 
 async function loadInitial(id: string) {
   const seedId = ++latestSeed;
+  const badgeReq = ++latestBadgeReq;
   const genBeforeFetch = activityGen;
   const data = await fetchSessionDetail(id);
   // A newer seed superseded this one while it was in flight: its answer is the current one,
@@ -245,9 +251,9 @@ async function loadInitial(id: string) {
   if (!data || seedId !== latestSeed) return;
   // A live push landed while we were fetching: it is newer than this snapshot, so keep it
   // and don't let a stale seed put the cell back to idle. Badges have no such push, so they
-  // always refresh.
+  // always refresh — unless a newer badge fetch has since superseded this one.
   if (activityGen === genBeforeFetch) applyActivity(data);
-  applyBadges(data);
+  if (badgeReq === latestBadgeReq) applyBadges(data);
 }
 
 // Refresh ONLY the token usage (not the live activity — that's pub/sub's job). Called
@@ -255,8 +261,9 @@ async function loadInitial(id: string) {
 async function refreshUsage() {
   const id = sessionId.value;
   if (!id) return;
+  const badgeReq = ++latestBadgeReq;
   const data = await fetchSessionDetail(id);
-  if (data) applyBadges(data);
+  if (data && badgeReq === latestBadgeReq) applyBadges(data);
 }
 
 onMounted(() => {

--- a/src/composables/useGitStatus.ts
+++ b/src/composables/useGitStatus.ts
@@ -24,12 +24,15 @@ export function useGitStatus(cwd: Ref<string | null>) {
   let req = 0;
 
   async function refresh(): Promise<void> {
+    // Bump the token BEFORE the early return: switching a cell to a dir-less state (e.g. a
+    // launcher cell) must invalidate an in-flight fetch for the previous dir, or its late
+    // response would apply `my === req` and put the old branch chip back. (#620.)
+    const my = ++req;
     const dir = cwd.value;
     if (!dir) {
       status.value = null;
       return;
     }
-    const my = ++req;
     try {
       const res = await fetch(`/api/git-status?cwd=${encodeURIComponent(dir)}`);
       if (!res.ok) return;

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -685,6 +685,57 @@ describe("TerminalCell", () => {
     expect(w.find('[data-testid="cell-usage"]').exists()).toBe(false);
   });
 
+  // #620, on the badge path: two turns end back-to-back, so two /api/session reads for the
+  // same session are in flight at once. The older one resolving last must not put the
+  // previous turn's token numbers back on the badge.
+  it("does not let a stale usage refresh clobber a newer one (out-of-order)", async () => {
+    const id = "66666666-6666-6666-6666-666666666666";
+    const gates = [deferred<boolean>(), deferred<boolean>()];
+    let sessionCall = 0;
+    const INITIAL = { inputTokens: 100, outputTokens: 100, cacheReadTokens: 0, cacheCreationTokens: 0 };
+    const OLD = { inputTokens: 1000, outputTokens: 2000, cacheReadTokens: 0, cacheCreationTokens: 0 };
+    const NEW = { inputTokens: 5000, outputTokens: 9000, cacheReadTokens: 0, cacheCreationTokens: 0 };
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/p", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      if (u.includes(`/api/session/${id}`)) {
+        const n = sessionCall++;
+        if (n === 0) return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, usage: INITIAL }) }; // mount seed
+        const usage = n === 1 ? OLD : NEW; // refresh #1 = older turn, refresh #2 = newer turn
+        await gates[n - 1].promise;
+        return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null, usage }) };
+      }
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(id);
+    await flushPromises();
+    expect(w.find('[data-testid="cell-usage"]').text()).toContain("100"); // initial seed
+
+    // First turn ends → refresh #1 (older), held on gates[0].
+    captured?.({ id, working: true, waiting: false });
+    await flushPromises();
+    captured?.({ id, working: false, waiting: false, event: "Stop" });
+    await flushPromises();
+    // Second turn ends → refresh #2 (newer), held on gates[1].
+    captured?.({ id, working: true, waiting: false });
+    await flushPromises();
+    captured?.({ id, working: false, waiting: false, event: "Stop" });
+    await flushPromises();
+
+    gates[1].resolve(true); // newer resolves first → applies the current turn's numbers
+    await flushPromises();
+    gates[0].resolve(true); // older resolves last → must be ignored, not revive the prior turn
+    await flushPromises();
+    await nextTick();
+
+    const badge = w.find('[data-testid="cell-usage"]').text();
+    expect(badge).toContain("5.0k"); // NEW input
+    expect(badge).toContain("9.0k"); // NEW output
+    expect(badge).not.toContain("1.0k"); // not OLD input
+  });
+
   it("shows the model/context badge from /api/session/:id context", async () => {
     const id = "55555555-5555-5555-5555-555555555555";
     globalThis.fetch = vi.fn(async (url: string) => {

--- a/test/src/composables/useGitStatus.spec.ts
+++ b/test/src/composables/useGitStatus.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { defineComponent, ref, h, nextTick } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+
+import { useGitStatus, type GitStatus } from "../../../src/composables/useGitStatus";
+
+const REPO: GitStatus = { repo: true, branch: "main", detached: false, dirty: 2, ahead: 0, behind: 0, upstream: true };
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+function mountGit(initialCwd: string | null) {
+  const cwd = ref<string | null>(initialCwd);
+  let status!: ReturnType<typeof useGitStatus>["status"];
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        status = useGitStatus(cwd).status;
+        return () => h("div");
+      },
+    }),
+  );
+  return { wrapper, cwd, get: () => status.value };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("useGitStatus", () => {
+  it("applies the fetched status for the current dir", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => REPO })),
+    );
+    const { get } = mountGit("/repo");
+    await flushPromises();
+    expect(get()).toEqual(REPO);
+  });
+
+  // The #620 shape, on the dir→null edge: a launcher/command cell has no dir, and switching
+  // to it while a status fetch for the previous dir is still out must not let that late
+  // response repaint the old branch chip. The token has to advance on the null branch too.
+  it("drops an in-flight response for a dir the cell has since left", async () => {
+    const gate = deferred<boolean>();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        await gate.promise;
+        return { ok: true, json: async () => REPO };
+      }),
+    );
+    const { cwd, get } = mountGit("/repo"); // mount starts the /repo fetch, held on the gate
+
+    cwd.value = null; // switch to a dir-less cell: status clears synchronously
+    await nextTick();
+    await flushPromises();
+    expect(get()).toBeNull();
+
+    gate.resolve(true); // the stale /repo response finally lands
+    await flushPromises();
+    expect(get()).toBeNull(); // and must be ignored, not revive the old branch
+  });
+});


### PR DESCRIPTION
## Summary

#620 の行列（F1〜F5）は「GET 中に届いた **live 更新**を応答が上書きする」形だった。今回はその同族だが「**同じ対象への 2 つの GET 応答が逆順で適用される**」型を 2 箇所直す。どちらも同じファイル／兄弟に確立済みのトークンガードがあるのに、その箇所だけ漏れていた。

- **`TerminalCell.vue` の usage/context バッジ** — `loadInitial`(seed) は `latestSeed` で守られているが、`refreshUsage`(ターン終了時) は**無トークン**。連続ターンで `/api/session` 読み取りが 2 つ同時に in-flight になり、古い方が後着すると前ターンの数値でバッジを巻き戻す。バッジ適用専用の `latestBadgeReq` を両経路に入れ、最新の fetch が勝つようにした。他の 5 fetch と GridView の `seedMeta` は同種のトークンで保護済みで、バッジ経路だけ取り残されていた。
- **`useGitStatus.ts` の cwd→null 遷移** — `my === req` トークンはあるが、dir が無いときの early return が `++req` の**前**にあり、dir→null 遷移(ランチャー/command セルへ切替)で前 dir の in-flight 応答が `status=null` を上書きし、前ディレクトリのブランチチップが復活していた。`++req` を early return の前へ移動。

## Items to Confirm / Review

- `latestSeed` / `activityGen` の既存ロジックは不変（バッジのゲートを追加しただけ）。非レース時の挙動は保存。
- テスト2本とも**修正を戻すと赤・入れると緑**を変異テストで確認済み。`useGitStatus.spec.ts` は新規で、`useGridActivity.spec` と同じ mount + gated-fetch ハーネスに揃えた。

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所と、並行してバグを洗い出して issue 化した(第3弾, #676)。その中のバグ issue #673 を修正する。

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)