### PR TITLE
fix: /ws/run が接続解決の await 中にソケットが閉じると孤児 PTY をリークする (#671)

### DIFF
--- a/plans/fix-671-ws-run-pty-leak.md
+++ b/plans/fix-671-ws-run-pty-leak.md
@@ -1,0 +1,22 @@
+# fix #671 — /ws/run が接続解決の await 中にソケットが閉じると孤児 PTY をリーク
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/671
+
+## 問題
+
+`startRunTerminal`(`server/routes/ws-routes.ts`)は `await resolveRunTarget(url)` が解決した**後**にしか `ws.on("close", () => term.kill())` を配線しない。button 経路は `resolveButtonRun` → `buildHeaderContext(cwd)` が `git status` サブプロセスを await するため数十〜数百 ms の窓がある。この間にクライアントが離脱すると `close` イベントはリスナ不在のまま発火して消え、await 解決後に spawn した PTY は close 済みで二度と kill されない。`/ws/run` は ephemeral(reap/grace 対象外)なので、長命なボタンコマンド(`npm run dev` 等)だとサーバ終了まで孤児プロセスが残る。
+
+claude ハンドラ(`handleClaudeConnection`)は同型の窓(Keychain refresh の await 後)を `ws.readyState !== ws.OPEN` で既にガードしている。run ハンドラにだけこのガードが無かった。
+
+## 修正
+
+`startRunTerminal` を「非同期 resolve」と、同期の `beginRunTerminal(deps, ws, resolved)`(**readyState ガード → spawn → message/close 配線**)に分割し、後者を export。resolve 後に `ws.readyState !== ws.OPEN` なら spawn せず return。claude 側と同じ判断。
+
+## テスト
+
+`test/server/routes/ws-run-terminal.spec.ts`(新規)で `beginRunTerminal` を注入 deps + fake ws で直接検証:
+
+- ソケットが OPEN のとき spawn し、`close` で `term.kill()` される
+- resolve 中に閉じた(readyState=CLOSED)ソケットでは **spawn しない**(リーク防止)
+
+ガードを外すと後者が赤・入れると緑を変異テストで確認済み。

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -102,6 +102,17 @@ async function resolveRunTarget(url: URL): Promise<{ command: string; cwd: strin
 async function startRunTerminal(deps: WsRouteDeps, ws: WebSocket, url: URL): Promise<void> {
   const resolved = await resolveRunTarget(url);
   if (!resolved) return closeWithError(ws, "Command not found — check your config / script.json.");
+  beginRunTerminal(deps, ws, resolved);
+}
+
+// Spawn the ephemeral Run PTY and wire its lifecycle. resolveRunTarget above can await a git
+// subprocess (buildHeaderContext for a button command), and the viewer can leave during that
+// window — before any close handler is wired. Spawning then leaks a PTY nobody reaps (/ws/run
+// is ephemeral: no reattach, no reap/grace, so its only kill is the close handler below). Bail
+// if the socket has since closed — the same guard handleClaudeConnection applies after its
+// keychain refresh.
+export function beginRunTerminal(deps: WsRouteDeps, ws: WebSocket, resolved: { command: string; cwd: string }): void {
+  if (ws.readyState !== ws.OPEN) return;
   let term: IPty;
   try {
     term = deps.spawnCommandPty(resolved.command, resolved.cwd, ws);

--- a/test/server/routes/ws-run-terminal.spec.ts
+++ b/test/server/routes/ws-run-terminal.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import type { WebSocket } from "ws";
+import type { IPty } from "node-pty";
+
+import { beginRunTerminal, type WsRouteDeps } from "../../../server/routes/ws-routes.js";
+
+// A minimal ws stand-in: just the readyState + OPEN the guard reads and an on/emit pair so a
+// test can fire the "close" event the handler wires.
+function fakeWs(readyState: number) {
+  const listeners = new Map<string, ((...args: unknown[]) => void)[]>();
+  return {
+    readyState,
+    OPEN: 1,
+    on(event: string, cb: (...args: unknown[]) => void) {
+      const list = listeners.get(event) ?? [];
+      list.push(cb);
+      listeners.set(event, list);
+    },
+    emit(event: string) {
+      (listeners.get(event) ?? []).forEach((cb) => cb());
+    },
+  };
+}
+
+const OPEN = 1;
+const CLOSED = 3;
+const RESOLVED = { command: "npm run dev", cwd: "/repo" };
+
+describe("beginRunTerminal", () => {
+  it("spawns and kills the ephemeral PTY when the viewer's socket is still open", () => {
+    const term = { kill: vi.fn() } as unknown as IPty;
+    const spawnCommandPty = vi.fn(() => term);
+    const ws = fakeWs(OPEN);
+
+    beginRunTerminal({ spawnCommandPty } as unknown as WsRouteDeps, ws as unknown as WebSocket, RESOLVED);
+
+    expect(spawnCommandPty).toHaveBeenCalledWith(RESOLVED.command, RESOLVED.cwd, ws);
+    ws.emit("close"); // the viewer leaves — the ephemeral PTY must be killed
+    expect(term.kill).toHaveBeenCalledTimes(1);
+  });
+
+  // The leak: the viewer left during the (git-backed) resolve, so the socket is already
+  // closed by the time we get here. Spawning now would leak a PTY whose only kill is a close
+  // handler for an event that already fired.
+  it("does not spawn a PTY when the socket closed during the async resolve", () => {
+    const spawnCommandPty = vi.fn();
+    const ws = fakeWs(CLOSED);
+
+    beginRunTerminal({ spawnCommandPty } as unknown as WsRouteDeps, ws as unknown as WebSocket, RESOLVED);
+
+    expect(spawnCommandPty).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`startRunTerminal`(`server/routes/ws-routes.ts`)は `await resolveRunTarget(url)` が解決した**後**にしか `ws.on("close", () => term.kill())` を配線していなかった。button 経路は `resolveButtonRun` → `buildHeaderContext(cwd)` が `git status` サブプロセスを await するため窓があり、その間にクライアントが離脱すると `close` はリスナ不在で発火して消え、後から spawn した PTY が二度と kill されない。`/ws/run` は ephemeral(reap/grace 対象外)なので、長命なボタンコマンド(`npm run dev` 等)だとサーバ終了まで孤児プロセスが残る。

claude ハンドラは同型の窓(Keychain refresh 後)を `ws.readyState !== ws.OPEN` で既にガードしていた。run ハンドラにだけ無かったので揃えた。

## 変更

- `startRunTerminal` を「非同期 resolve」と、同期の `beginRunTerminal(deps, ws, resolved)`(readyState ガード → spawn → message/close 配線)に分割。resolve 後にソケットが閉じていれば spawn せず return。

## Items to Confirm / Review

- launcher 経路(`handleLaunchConnection`)は resolve が同期なので同じ窓は無い(このPRの対象外)。
- テスト `test/server/routes/ws-run-terminal.spec.ts`(新規)で `beginRunTerminal` を注入 deps + fake ws で検証: OPEN なら spawn+close で kill、CLOSED なら **spawn しない**。ガードを外すと後者が赤・入れると緑を変異テストで確認済み。
- `yarn typecheck` / `typecheck:server` / `typecheck:test` すべて通過。

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所と、並行してバグを洗い出して issue 化した(第3弾, #676)。その中のバグ issue #671 を修正する。

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)