### PR TITLE
test: confirm send-correlation survives truncation (#595 follow-up)

### DIFF
--- a/test/src/composables/exchangeRules.spec.ts
+++ b/test/src/composables/exchangeRules.spec.ts
@@ -48,6 +48,16 @@ describe("answersOurSend", () => {
   it("matches a short message in full", () => {
     expect(answersOurSend("please review this", "please review this")).toBe(true);
   });
+
+  it("still distinguishes two long messages that were both truncated", () => {
+    // The 160-char window reaches back into the excerpt, past the shared "… (truncated)"
+    // and "--- end ---" tail, so distinct content before the mark still separates them.
+    const truncated = (body: string) => sentText(body + "\n… (truncated)");
+    const a = truncated("A".repeat(2900) + "distinct-alpha");
+    const b = truncated("B".repeat(2900) + "distinct-bravo");
+    expect(answersOurSend(a, a)).toBe(true);
+    expect(answersOurSend(a, b)).toBe(false);
+  });
 });
 
 describe("waitVerdict", () => {


### PR DESCRIPTION
## Summary

PR #597（#595 PR 1）で最後に push したテスト1件が、GitHub の PR ヘッド同期の取りこぼしにより**マージに含まれなかった**ため、単独で載せ直す。テストのみ・+10行。

## 背景

#597 は `f8da1f2` でマージされたが、その直後に push した `e86140b`（このテスト）を GitHub の PR オブジェクトがヘッドに反映せず、`f8da1f2` のままマージされた。実装（相関ロジック）は既に main にある。このテストはそれを裏づけるもの。

## 何を確認するテストか

送信テキストと相手 prompt の相関（`answersOurSend`）が、**返答が上限で truncate されたケースでも**壊れないこと。160文字の相関窓が共通の `… (truncated)` / `--- end ---` 末尾より奥まで届き、内容の違う2つの長い truncate 済みメッセージを区別できることを直接確認する（推論ではなく実測で確かめた挙動をテスト化）。

## User Prompt

（#597 のレビューループ中に自己レビューで見つけたエッジケース。#597 マージ時に取りこぼされたぶんの復旧）

🤖 Generated with [Claude Code](https://claude.com/claude-code)