### PR TITLE
fix: activity-state を所有者単位で永続化し、2つ目のインスタンスの waiting/working を守る (#672)

### DIFF
--- a/plans/fix-672-activity-state-cross-process.md
+++ b/plans/fix-672-activity-state-cross-process.md
@@ -1,0 +1,35 @@
+# fix #672 — activity-state.json の丸ごと書き出しが別インスタンスの waiting/working を消す
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/672
+関連: #620(別ファミリー欄)、#635(同型の dev-terminal 修正)
+
+## 問題
+
+`persistActivityState`(`server/session/registry.ts`)は、メモリ上の `activity` マップ全体のスナップショットを共有ファイル `MULMOTERMINAL_HOME/activity-state.json` に `fs.writeFile` で**丸ごと上書き**していた。このパスは PORT にもワークスペースにもスコープされておらず、同一マシンの全インスタンスが共有する（直列化はプロセス内のみ）。
+
+`--port` を分けた 2 インスタンスが同じ `MULMOTERMINAL_HOME` を共有すると:
+
+1. A が a1(working)を書く → `{a1}`
+2. B が起動時に a1 を hydrate し、b1(waiting)を書く → `{a1, b1}`
+3. A の a1 が idle 化 → A は自分のマップ `{}` を書き **b1 を消す**
+4. 逆に A は hydrate した b1 を持ち続け、persist の度に **stale な b1 を復活**させる ping-pong
+
+`waiting` は自己修正しない（Claude はプロンプト待ち中に Notification を再発火しない）ため、消えると再起動後にユーザが入力待ちセッションに気付けない。
+
+append ログ化(#635 方式)は working/waiting が可変値なので不可（消えた状態を union で復活させてはいけない）。
+
+## 修正
+
+**「自分が所有しない session id を書かない/消さない」**を徹底する read-merge-write に変更。
+
+- `ownedActivityIds: Set<string>` を追加し、`setFlag`(lifecycle.ts)で `activity.set` するたびに `claimActivityOwnership(id)` で所有を記録。所有は `ptys` からの導出ではなくフラグ時に記録するので、**reap 済み（pty は既に消えた）own セッションも自分のものと認識して削除できる**。
+- `persistActivityState` は書き込み時にディスクを読み直し、pure 関数 `mergeOwnedActivity(onDisk, owned, isOwned)` で「own は自分の snapshot（idle は削除）、foreign はディスクのまま保持」を合成して書く。
+- hydration は変更なし（foreign id は `activity` に入るが `ownedActivityIds` には入らないので、persist で自分のメモリからは書き戻さない）。
+
+## テスト
+
+`test/server/session/activity-state.spec.ts` に `mergeOwnedActivity` の直接テストを追加:
+
+- own を書き foreign を保持 / own が idle でも foreign を落とさない / reap 済み own をディスクの stale ごと削除 / own をディスクから復活させない（自分が権威）/ own が無いとき foreign を丸ごと保持
+
+ディスク保持を外す変異で 3 件が赤・入れると緑を確認済み。合成規則(判断)を pure 関数に出し、read/write の I/O は registry 側に残した（config-routes の read-merge-write と同じ形）。

--- a/server/session/activity-state.ts
+++ b/server/session/activity-state.ts
@@ -33,6 +33,23 @@ export function buildActivitySnapshot(
   return snapshot;
 }
 
+// Merge this instance's snapshot of the sessions IT owns onto whatever is currently on disk,
+// leaving entries owned by another instance untouched. The file is shared by every server
+// rooted at the same MULMOTERMINAL_HOME, so writing a full in-memory snapshot would drop the
+// other instance's sessions (they're not in this map) and revive ones it already cleared.
+// Owned ids present in `owned` are written; owned ids absent from it (gone idle / reaped) are
+// removed; every foreign id on disk is preserved as-is.
+export function mergeOwnedActivity(
+  onDisk: Record<string, PersistedActivity>,
+  owned: Record<string, PersistedActivity>,
+  isOwned: (id: string) => boolean,
+): Record<string, PersistedActivity> {
+  const merged: Record<string, PersistedActivity> = {};
+  for (const [id, a] of Object.entries(onDisk)) if (!isOwned(id)) merged[id] = a;
+  for (const [id, a] of Object.entries(owned)) merged[id] = a;
+  return merged;
+}
+
 // Parse a persisted snapshot back into activity records, dropping anything that isn't a valid
 // session id / well-formed entry (a corrupt/tampered file must not smuggle entries into the map).
 export function parseActivityState(raw: unknown, isValidId: (id: string) => boolean): Array<{ id: string } & PersistedActivity> {

--- a/server/session/lifecycle.ts
+++ b/server/session/lifecycle.ts
@@ -22,6 +22,7 @@ import {
   lastPrompts,
   lastResponses,
   lastTitleAttemptMs,
+  claimActivityOwnership,
   lastTitledUserTurns,
   launchChoices,
   persistActivityState,
@@ -178,6 +179,7 @@ function setFlag(deps: SessionLifecycleDeps, id: string, flag: ActivityFlag, val
   const effect = flagEffect(activity.get(id), flag, value, event, Date.now());
   if (!effect.next) return;
   activity.set(id, effect.next);
+  claimActivityOwnership(id); // this instance drives this session — persist may write/remove it
   publishActivity(deps, id);
   // Persist so an in-progress turn / the blocked-or-done set survives a restart (ACTIVITY_STATE_FILE).
   persistActivityState((id) => hiddenSessions.has(id));

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -12,7 +12,7 @@ import path from "node:path";
 import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
-import { buildActivitySnapshot, parseActivityState } from "./activity-state.js";
+import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { devTerminalSessionLine, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
 
@@ -162,15 +162,43 @@ export const activityStateHydrated: Promise<void> = (async () => {
   }
 })();
 
-// Serialize writes into one chain (like appendDevTerminalSession) and snapshot the
-// CURRENT working/waiting entries at write time, so the last link always writes the complete set.
-// `isHidden` comes from the caller rather than closing over `hiddenSessions`: which sessions
-// are hidden is the session layer's policy, and this module owns storage, not policy.
+// The sessions THIS process drives (every id it has flagged working/waiting). The file is
+// shared with any other server rooted at the same MULMOTERMINAL_HOME, and hydration pulls the
+// other instance's ids into `activity` too — so a snapshot of the whole map is not this
+// instance's to write back. Ownership is claimed on the flag, not derived from `ptys`, so a
+// just-reaped session (pty already gone) is still recognised as ours and removed from the file.
+const ownedActivityIds = new Set<string>();
+export function claimActivityOwnership(id: string): void {
+  ownedActivityIds.add(id);
+}
+
+async function readPersistedActivity(): Promise<Record<string, PersistedActivity>> {
+  try {
+    const parsed = parseActivityState(JSON.parse(await fs.readFile(ACTIVITY_STATE_FILE, "utf8")), (x) => SESSION_ID_RE.test(x));
+    return Object.fromEntries(parsed.map(({ id, working, waiting, event }) => [id, { working, waiting, event }]));
+  } catch {
+    return {}; // no file yet / unreadable => nothing to preserve
+  }
+}
+
+// Serialize writes into one chain (like appendDevTerminalSession). Read the current file and
+// rewrite only the entries THIS instance owns, so a second instance's sessions are neither
+// dropped nor revived. `isHidden` comes from the caller rather than closing over
+// `hiddenSessions`: which sessions are hidden is the session layer's policy, and this module
+// owns storage, not policy.
 let activityPersist: Promise<void> = Promise.resolve();
 export function persistActivityState(isHidden: (id: string) => boolean): void {
   activityPersist = activityPersist
     .then(() => activityStateHydrated)
     .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
-    .then(() => fs.writeFile(ACTIVITY_STATE_FILE, JSON.stringify(buildActivitySnapshot(activity, isHidden))))
+    .then(async () => {
+      const onDisk = await readPersistedActivity();
+      const owned = buildActivitySnapshot(
+        [...activity].filter(([id]) => ownedActivityIds.has(id)),
+        isHidden,
+      );
+      const next = mergeOwnedActivity(onDisk, owned, (id) => ownedActivityIds.has(id));
+      await fs.writeFile(ACTIVITY_STATE_FILE, JSON.stringify(next));
+    })
     .catch((e) => console.error(`[activity-state] failed to persist: ${messageOf(e)}`));
 }

--- a/test/server/session/activity-state.spec.ts
+++ b/test/server/session/activity-state.spec.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { buildActivitySnapshot, parseActivityState, type RestartActivity } from "../../../server/session/activity-state.js";
+import {
+  buildActivitySnapshot,
+  mergeOwnedActivity,
+  parseActivityState,
+  type PersistedActivity,
+  type RestartActivity,
+} from "../../../server/session/activity-state.js";
 
 const never = () => false;
 const anyId = () => true;
+
+const P = (over: Partial<PersistedActivity> = {}): PersistedActivity => ({ working: false, waiting: false, event: null, ...over });
 
 describe("buildActivitySnapshot", () => {
   it("keeps working OR waiting sessions with their full state, dropping idle ones", () => {
@@ -51,5 +59,49 @@ describe("parseActivityState", () => {
   it("returns [] for non-object input", () => {
     expect(parseActivityState(null, anyId)).toEqual([]);
     expect(parseActivityState("x", anyId)).toEqual([]);
+  });
+});
+
+// Two servers rooted at the same MULMOTERMINAL_HOME share this file. A persist must rewrite
+// only the sessions THIS instance owns and leave the other instance's alone — otherwise a
+// full-snapshot overwrite drops or revives the other's sessions (the #672 cross-process bug).
+describe("mergeOwnedActivity", () => {
+  const ownedBy =
+    (...ids: string[]) =>
+    (id: string) =>
+      ids.includes(id);
+
+  it("writes this instance's owned entries and preserves another instance's", () => {
+    const onDisk = { a1: P({ working: true }), b1: P({ waiting: true, event: "Notification" }) };
+    const owned = { a1: P({ waiting: true, event: "Stop" }) };
+    // a1 is ours (updated); b1 belongs to the other instance (left as-is on disk).
+    expect(mergeOwnedActivity(onDisk, owned, ownedBy("a1"))).toEqual({
+      a1: P({ waiting: true, event: "Stop" }),
+      b1: P({ waiting: true, event: "Notification" }),
+    });
+  });
+
+  it("does not drop the other instance's session when ours goes idle", () => {
+    // ours (a1) went idle so it's absent from `owned`; the other instance's b1 must survive.
+    expect(mergeOwnedActivity({ a1: P({ working: true }), b1: P({ waiting: true }) }, {}, ownedBy("a1"))).toEqual({
+      b1: P({ waiting: true }),
+    });
+  });
+
+  it("removes an owned session that is no longer active, even if still stale on disk", () => {
+    // a1 is ours and reaped: gone from `owned`, but a stale entry lingers on disk. Ours wins.
+    expect(mergeOwnedActivity({ a1: P({ working: true }) }, {}, ownedBy("a1"))).toEqual({});
+  });
+
+  it("does not revive an owned session from disk — this instance is authoritative for its ids", () => {
+    // disk says a1 working (a stale write), but we own it and know it's idle now.
+    expect(mergeOwnedActivity({ a1: P({ working: true }) }, { a1: P({ working: false, waiting: false }) }, ownedBy("a1"))).toEqual({
+      a1: P({ working: false }),
+    });
+  });
+
+  it("keeps foreign entries untouched when we own nothing", () => {
+    const onDisk = { b1: P({ working: true }), c1: P({ waiting: true }) };
+    expect(mergeOwnedActivity(onDisk, {}, never)).toEqual(onDisk);
   });
 });


### PR DESCRIPTION
## Summary

`persistActivityState`(`server/session/registry.ts`)は、メモリ上の `activity` マップ全体を共有ファイル `MULMOTERMINAL_HOME/activity-state.json` に**丸ごと上書き**していた。このファイルは同一 `MULMOTERMINAL_HOME` の全サーバが共有するので、`--port` を分けた 2 インスタンスが互いのセッションを潰し合っていた（片方が idle 化すると相手のセッションを消し、hydrate した foreign id を stale なメモリから復活させる）。消えた `waiting` は自己修正しない（Claude はプロンプト待ち中に Notification を再発火しない）ため、再起動後に入力待ちセッションが idle として復帰していた。

自分が所有する id だけを書き換え、相手のエントリは残す **read-merge-write** に変更した。

## 変更

- `ownedActivityIds` を追加し、`setFlag`(lifecycle) で working/waiting を立てるたびに所有を記録。`ptys` からの導出ではなくフラグ時に記録するので、**reap 済み（pty は消えた）own セッションも自分のものとして削除できる**（丸ごと導出だと消せず残る）。
- `persistActivityState` は書き込み時にディスクを読み直し、pure 関数 `mergeOwnedActivity(onDisk, owned, isOwned)` で「own は自分の snapshot、foreign はディスクのまま保持」を合成。
- hydration は不変（foreign id は `activity` に入るが所有はしないので、自分のメモリからは書き戻さない）。

## Items to Confirm / Review

- append ログ化(#635)は working/waiting が可変値なので**不可**（消えた状態を union で復活させてはいけない）。read-merge-write は config-routes と同じ形で、残る競合窓は 2 インスタンスが**同時に**書く同期処理数命令ぶんのみ。
- 合成規則(判断)を pure 関数 `mergeOwnedActivity` に出し、直接テスト。ディスク保持を外す変異で 3 件が赤・入れると緑を確認済み。read/write の I/O は registry 側。
- `yarn typecheck` / `typecheck:server` / `typecheck:test` 通過、session+routes 793 テスト緑。

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所と、並行してバグを洗い出して issue 化した(第3弾, #676)。その中のバグ issue #672 を修正する。

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)