### PR TITLE
refactor: extract sessionListTitle pure function (#676 A4)

### DIFF
--- a/plans/refactor-676-a4-session-list-title.md
+++ b/plans/refactor-676-a4-session-list-title.md
@@ -1,0 +1,35 @@
+# refactor: extract sessionListTitle pure function (#676 A4)
+
+## Context
+
+`server/session/session-reads.ts` の `readSessionMeta` はサイドバー行のタイトルを
+5 段の優先順位で決めていた:
+
+```ts
+const title = aiTitles.get(id) || aiTitle || lastPrompt || firstUserMsg || "(untitled session)";
+```
+
+「ライブ AI タイトル > ディスク ai-title > ディスク last-prompt > 最初のユーザ発言 >
+フォールバック」。空文字を飛ばす `||` セマンティクスが load-bearing で、`session-detail-view.ts`
+の `??`(空文字を勝たせる `/clear` の契約)とは**別物**。この判断は pure 関数として
+未抽出・未テストだった (#676 優先度 A4)。
+
+## 変更
+
+- 新ファイル `server/session/sessionListTitle.ts` に pure 関数 `sessionListTitle` を切り出し。
+  - シグネチャ: `sessionListTitle(input: { liveAiTitle: string | undefined; diskAiTitle: string | null; diskLastPrompt: string | null; firstUserMsg: string | null }): string`
+  - 型は元の値に忠実: `aiTitles.get(id)` は `string | undefined`、他 3 つは `string | null`。
+  - `UNTITLED_SESSION = "(untitled session)"` を named const として公開。
+  - `||`(空文字スキップ)を厳密に維持 — **挙動不変**。
+- `readSessionMeta` は入力収集 (I/O) だけ残し、この関数を呼ぶ。
+- テスト `test/server/session/sessionListTitle.spec.ts`:
+  - live があればそれが勝つ / live 不在で disk-ai → last-prompt → first の順に落ちる
+  - 各段の空文字 `""` をスキップ(`||` の pin)
+  - live="" かつ disk-ai="実タイトル" → "実タイトル"(`??` との差を固定)
+  - 全 null/undefined、および全 "" → sentinel
+
+## 検証
+
+- 変異テスト: `||` → `??` に変えると空文字スキップの pin が赤になることを確認して戻す。
+- `prettier --write` / `eslint` / `typecheck` / `typecheck:server` / `typecheck:test` /
+  `vitest run test/server/session`。

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -32,6 +32,7 @@ import {
 } from "./transcript.js";
 import { createFileCache, type FileStamp } from "./file-cache.js";
 import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
+import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRolloutIds, hiddenSessions, knownSessions } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
 import { lastTurnFromClaudeParsed, lastTurnFromCodexRollout, EMPTY_TURN, type LastTurn } from "./last-turn.js";
@@ -211,8 +212,7 @@ export async function readSessionMeta(dir: string, file: string): Promise<Sessio
   }
 
   const id = path.basename(file, ".jsonl");
-  // The live in-memory title (this process run) wins over the on-disk record.
-  const title = aiTitles.get(id) || aiTitle || lastPrompt || firstUserMsg || "(untitled session)";
+  const title = sessionListTitle({ liveAiTitle: aiTitles.get(id), diskAiTitle: aiTitle, diskLastPrompt: lastPrompt, firstUserMsg });
   const a = activity.get(id);
   return {
     id,

--- a/server/session/sessionListTitle.ts
+++ b/server/session/sessionListTitle.ts
@@ -1,0 +1,22 @@
+// The title a sidebar row shows, in five-tier precedence: this process's live AI title
+// wins, then the on-disk ai-title, then the on-disk last-prompt, then the session's first
+// user message, and a sentinel when there is nothing at all.
+//
+// `||` is load-bearing here, and DIFFERENT from the `??` in session-detail-view.ts: every
+// tier is a string that must be SKIPPED when empty. A live title of "" is not "the user
+// cleared it, show blank" (that is the detail view's contract) — here it means "this
+// process has no usable live title, fall through to disk". Tidying `||` into `??` would
+// pin an empty string as the row's title and hide the real one sitting on disk right below.
+
+export interface SessionListTitleInput {
+  liveAiTitle: string | undefined;
+  diskAiTitle: string | null;
+  diskLastPrompt: string | null;
+  firstUserMsg: string | null;
+}
+
+export const UNTITLED_SESSION = "(untitled session)";
+
+export function sessionListTitle(input: SessionListTitleInput): string {
+  return input.liveAiTitle || input.diskAiTitle || input.diskLastPrompt || input.firstUserMsg || UNTITLED_SESSION;
+}

--- a/test/server/session/sessionListTitle.spec.ts
+++ b/test/server/session/sessionListTitle.spec.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { sessionListTitle, UNTITLED_SESSION } from "../../../server/session/sessionListTitle.js";
+
+const NONE = { liveAiTitle: undefined, diskAiTitle: null, diskLastPrompt: null, firstUserMsg: null };
+
+describe("sessionListTitle", () => {
+  it("prefers the live AI title over every disk source", () => {
+    const title = sessionListTitle({ liveAiTitle: "live", diskAiTitle: "disk-ai", diskLastPrompt: "prompt", firstUserMsg: "first" });
+    expect(title).toBe("live");
+  });
+
+  it("falls through disk-ai, then last-prompt, then first user message when the live title is absent", () => {
+    expect(sessionListTitle({ ...NONE, diskAiTitle: "disk-ai", diskLastPrompt: "prompt", firstUserMsg: "first" })).toBe("disk-ai");
+    expect(sessionListTitle({ ...NONE, diskLastPrompt: "prompt", firstUserMsg: "first" })).toBe("prompt");
+    expect(sessionListTitle({ ...NONE, firstUserMsg: "first" })).toBe("first");
+  });
+
+  // `||`, not `??`: an empty string at any tier means "nothing usable here", so it is skipped
+  // rather than pinned as the title.
+  it("skips an empty string at each tier and takes the next non-empty source", () => {
+    expect(sessionListTitle({ liveAiTitle: "", diskAiTitle: "disk-ai", diskLastPrompt: "prompt", firstUserMsg: "first" })).toBe("disk-ai");
+    expect(sessionListTitle({ liveAiTitle: "", diskAiTitle: "", diskLastPrompt: "prompt", firstUserMsg: "first" })).toBe("prompt");
+    expect(sessionListTitle({ liveAiTitle: "", diskAiTitle: "", diskLastPrompt: "", firstUserMsg: "first" })).toBe("first");
+  });
+
+  // THE contract that makes this a `||` and not a `??`: a live title of "" must NOT win — it
+  // is not the detail view's "the user cleared it", it means "fall through to disk".
+  it("lets a real disk title win over an empty live title", () => {
+    expect(sessionListTitle({ ...NONE, liveAiTitle: "", diskAiTitle: "実タイトル" })).toBe("実タイトル");
+  });
+
+  it("returns the sentinel when nothing is present", () => {
+    expect(sessionListTitle(NONE)).toBe(UNTITLED_SESSION);
+  });
+
+  it("returns the sentinel when every tier is an empty string", () => {
+    expect(sessionListTitle({ liveAiTitle: "", diskAiTitle: "", diskLastPrompt: "", firstUserMsg: "" })).toBe(UNTITLED_SESSION);
+  });
+});


### PR DESCRIPTION
## Summary

`readSessionMeta`(`server/session/session-reads.ts`)のサイドバー行タイトルを決める5段優先順位を、pure 関数 `sessionListTitle` として新ファイル `server/session/sessionListTitle.ts` に切り出しました。**挙動不変**のリファクタで、`readSessionMeta` は入力収集(I/O)だけを残してこの関数に判断を委譲します。

優先順位: **ライブ AI タイトル > ディスク ai-title > ディスク last-prompt > 最初のユーザ発言 > `(untitled session)`**

ここでの `||`(空文字を飛ばすセマンティクス)は load-bearing で、`session-detail-view.ts` の `??`(`/clear` が書き込む空文字を勝たせる契約)とは**別物**です。この行では各段の空文字は「次のソースへフォールバック」を意味するため、ライブタイトルが `""` のときにディスク上の実タイトルを覆い隠してはいけません。

## Items to Confirm / Review

- **型の忠実さ**: `aiTitles.get(id)` は `string | undefined`、他3つ(`diskAiTitle` / `diskLastPrompt` / `firstUserMsg`)は `string | null`。元の変数の型をそのまま関数シグネチャに反映しています。
- **`||` vs `??`**: 空文字スキップが契約の核。変異テスト(`||` → `??`)で pin テストが赤くなることを確認済み(下記)。ここを `??` に「整理」しないよう、テストとコメントで固定しています。
- **境界ケース**: `liveAiTitle=""` かつ `diskAiTitle="実タイトル"` → `"実タイトル"` を明示的にテスト。

## User Prompt

> 全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した(#676)。その優先度A項目を実装する。

## テスト

`test/server/session/sessionListTitle.spec.ts`:
- live があればそれが勝つ
- live 不在で disk-ai → last-prompt → first-user の順に落ちる
- 各段の空文字 `""` をスキップ(`||`)
- live="" かつ disk-ai="実タイトル" → "実タイトル"
- 全 null/undefined、および全 "" → `"(untitled session)"`

**変異テスト**: `||` を `??` に変えると、空文字スキップ系の3テスト(各段スキップ / disk 実タイトル勝ち / 全空文字→sentinel)が赤くなることを確認し、元に戻しました。

**検証**: `prettier --check` / `eslint` クリーン、`typecheck`(vue-tsc -b)/ `typecheck:server` / `typecheck:test` すべて緑、`vitest run test/server/session` 全 762 件パス。

Part of #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
