### PR TITLE
refactor: extract stagedStorageIds into a pure, tested module (#676 A2)

### DIFF
--- a/plans/refactor-676-a2-staged-storage-ids.md
+++ b/plans/refactor-676-a2-staged-storage-ids.md
@@ -1,0 +1,45 @@
+# refactor: extract `stagedStorageIds` (#676 A2)
+
+Part of #676 — pull the decision rule out of I/O so it can be pinned with tests.
+
+## What
+
+`server/backends/remoteHost/onExpire.ts` holds a non-exported `stagedStorageIds(params)` plus the
+traversal guard `STORAGE_ID_RE = /^[A-Za-z0-9-]+$/`. When the shared runner drops an expired
+command, `onExpire` reads each `params.attachments[].storage_id` and hands it straight to
+`deleteObject(users/{uid}/uploads/{storageId})`. The regex is the only thing standing between a
+malformed id and a reshaped Storage path (no `/`, no `..`).
+
+This is the **lenient** copy of a rule that exists in three places: the strict version
+(`handlers.spec`) and the ingest version (`ingestAttachments.spec`, which pins `../evil` / `a/b`
+rejection) are both tested. This copy — cleanup, so malformed entries are skipped rather than
+thrown — was the only one non-exported and untested.
+
+## Change
+
+- New pure file `server/backends/remoteHost/stagedStorageIds.ts` exporting `stagedStorageIds` and
+  `STORAGE_ID_RE`. Kept separate from `onExpire.ts` so the pure rule never pulls in `firebase`.
+- `onExpire.ts` imports from it. **Behavior unchanged** — the function body is moved verbatim.
+- Colocated `stagedStorageIds.spec.ts` (sibling to `ingestAttachments.spec.ts`).
+
+`JsonObject` comes from `@mulmoclaude/core/remote-host`.
+
+## Tests
+
+Order-preserving extraction of valid ids; `../evil` and `a/b` rejected; non-array `attachments`
+⇒ `[]`; null / array / `storage_id`-less entries skipped without throwing; non-string
+`storage_id` excluded; empty attachments ⇒ `[]`.
+
+## Mutation check
+
+- Loosen `STORAGE_ID_RE` to `/^.+$/` → the traversal-guard test goes red (returns `../evil`,
+  `a/b`).
+- Drop the `typeof rawId === "string" && STORAGE_ID_RE.test(rawId)` filter → both the
+  traversal-guard and non-string-exclusion tests go red.
+
+Reverted both; suite green.
+
+## Verification
+
+`prettier` + `eslint` on the touched files; `yarn typecheck`, `yarn typecheck:server`,
+`yarn typecheck:test` all clean; `vitest run server/backends/remoteHost` green.

--- a/server/backends/remoteHost/onExpire.ts
+++ b/server/backends/remoteHost/onExpire.ts
@@ -17,28 +17,14 @@
 // regardless). Unlike startChat's strict attachment parsing, extraction here is
 // lenient — this is cleanup, so a malformed entry is skipped, not surfaced.
 import { deleteObject, ref } from "firebase/storage";
-import type { Command, JsonObject } from "@mulmoclaude/core/remote-host";
+import type { Command } from "@mulmoclaude/core/remote-host";
 
 import { currentStorage } from "./session.js";
+import { stagedStorageIds } from "./stagedStorageIds.js";
 
 const PREFIX = "[remote-host]";
 
-// Same safe-token guard ingestAttachments applies before interpolating a
-// storage_id into the Storage path (no `/`, no `..`).
-const STORAGE_ID_RE = /^[A-Za-z0-9-]+$/;
-
 const errorText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
-
-// Pull the staged storage_ids out of a command's `{ attachments: [{ storage_id }] }`
-// params, skipping anything malformed. Absent / wrong-shaped ⇒ [].
-const stagedStorageIds = (params: JsonObject): string[] => {
-  const { attachments } = params;
-  if (!Array.isArray(attachments)) return [];
-  return attachments.flatMap((entry) => {
-    const rawId = entry && typeof entry === "object" && !Array.isArray(entry) ? entry.storage_id : undefined;
-    return typeof rawId === "string" && STORAGE_ID_RE.test(rawId) ? [rawId] : [];
-  });
-};
 
 export const onExpire = async (command: Command, uid: string): Promise<void> => {
   for (const storageId of stagedStorageIds(command.params)) {

--- a/server/backends/remoteHost/stagedStorageIds.spec.ts
+++ b/server/backends/remoteHost/stagedStorageIds.spec.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import type { JsonObject } from "@mulmoclaude/core/remote-host";
+
+import { stagedStorageIds } from "./stagedStorageIds.js";
+
+describe("stagedStorageIds", () => {
+  it("extracts well-formed ids in order", () => {
+    const params: JsonObject = { attachments: [{ storage_id: "a1" }, { storage_id: "b2" }, { storage_id: "c3" }] };
+    expect(stagedStorageIds(params)).toEqual(["a1", "b2", "c3"]);
+  });
+
+  it("rejects ids that would reshape the Storage path (slash, dot-dot)", () => {
+    const params: JsonObject = { attachments: [{ storage_id: "../evil" }, { storage_id: "a/b" }, { storage_id: "ok" }] };
+    expect(stagedStorageIds(params)).toEqual(["ok"]);
+  });
+
+  it("returns [] when attachments is not an array", () => {
+    expect(stagedStorageIds({ attachments: "nope" })).toEqual([]);
+    expect(stagedStorageIds({ attachments: 42 })).toEqual([]);
+    expect(stagedStorageIds({ attachments: { storage_id: "a1" } })).toEqual([]);
+    expect(stagedStorageIds({})).toEqual([]);
+  });
+
+  it("skips null, array, and storage_id-less entries without throwing", () => {
+    const params: JsonObject = { attachments: [null, ["a1"], {}, { other: "x" }, { storage_id: "keep" }] };
+    expect(stagedStorageIds(params)).toEqual(["keep"]);
+  });
+
+  it("excludes entries whose storage_id is not a string", () => {
+    const params: JsonObject = { attachments: [{ storage_id: 123 }, { storage_id: true }, { storage_id: null }, { storage_id: "keep" }] };
+    expect(stagedStorageIds(params)).toEqual(["keep"]);
+  });
+
+  it("returns [] for empty attachments", () => {
+    expect(stagedStorageIds({ attachments: [] })).toEqual([]);
+  });
+});

--- a/server/backends/remoteHost/stagedStorageIds.ts
+++ b/server/backends/remoteHost/stagedStorageIds.ts
@@ -1,0 +1,16 @@
+import type { JsonObject } from "@mulmoclaude/core/remote-host";
+
+// Same safe-token guard ingestAttachments applies before interpolating a
+// storage_id into the Storage path (no `/`, no `..`).
+export const STORAGE_ID_RE = /^[A-Za-z0-9-]+$/;
+
+// Pull the staged storage_ids out of a command's `{ attachments: [{ storage_id }] }`
+// params, skipping anything malformed. Absent / wrong-shaped ⇒ [].
+export const stagedStorageIds = (params: JsonObject): string[] => {
+  const { attachments } = params;
+  if (!Array.isArray(attachments)) return [];
+  return attachments.flatMap((entry) => {
+    const rawId = entry && typeof entry === "object" && !Array.isArray(entry) ? entry.storage_id : undefined;
+    return typeof rawId === "string" && STORAGE_ID_RE.test(rawId) ? [rawId] : [];
+  });
+};


### PR DESCRIPTION
## Summary

`onExpire.ts` held a non-exported `stagedStorageIds(params)` and its traversal guard `STORAGE_ID_RE = /^[A-Za-z0-9-]+$/`. On an expired command, `onExpire` reads each `params.attachments[].storage_id` and hands it straight to `deleteObject(users/{uid}/uploads/{storageId})` — the regex is the only thing keeping a malformed id from reshaping the Storage path (no `/`, no `..`).

This is the **lenient** copy of a rule that lives in three places. The strict version (`handlers.spec`) and the ingest version (`ingestAttachments.spec`, which pins `../evil` / `a/b` rejection) are both tested; this copy — cleanup, so malformed entries are skipped rather than thrown — was the only one non-exported and untested.

- New pure file `server/backends/remoteHost/stagedStorageIds.ts` exports `stagedStorageIds` and `STORAGE_ID_RE`. Kept separate from `onExpire.ts` so the pure rule never imports `firebase`.
- `onExpire.ts` now imports from it. **Behavior unchanged** — the function body is moved verbatim.
- Colocated `stagedStorageIds.spec.ts` (sibling to `ingestAttachments.spec.ts`).

## Items to Confirm / Review

- **Behavior-preserving move**: the extracted function is byte-for-byte the original body; `onExpire.ts` only swaps the local definition for an import (and drops the now-unused `JsonObject` import).
- **Mutation check** (proves the tests bite):
  - Loosen `STORAGE_ID_RE` to `/^.+$/` → traversal-guard test goes red (returns `../evil`, `a/b`).
  - Drop the `typeof rawId === "string" && STORAGE_ID_RE.test(rawId)` filter → both the traversal-guard and non-string-exclusion tests go red.
  - Both reverted; suite green.
- **Verification**: `prettier` + `eslint` on touched files; `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test` all clean; `vitest run server/backends/remoteHost` green (13 files / 147 tests, 6 new).

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した（#676）。その優先度A項目を実装する。

---

Part of #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
