### PR TITLE
refactor: extract collection notifier adapter pure helpers (#676 A1)

### DIFF
--- a/plans/refactor-676-a1-collection-notifier-adapter.md
+++ b/plans/refactor-676-a1-collection-notifier-adapter.md
@@ -1,0 +1,63 @@
+# refactor: extract collection notifier adapter pure helpers (#676 A1)
+
+## Background
+
+`server/backends/collectionWatchers.ts` carries the cross-app-parity requirement that
+its notification adapter stay **byte-identical** to MulmoClaude's counterpart
+(`server/workspace/collections/notifications.ts`): both apps share one notifier file
+(`<ws>/data/notifier/active.json`), so a record's bell must round-trip through either
+app's `readEntry` with the same `legacyId` or a duplicate bell appears. The wrap/unwrap
+logic that enforces this was buried in the module as un-exported, un-tested functions —
+exactly the code where a silent divergence produces double bells.
+
+Issue #676 priority A1 asks to extract these pure functions into their own file and pin
+them with tests, without changing behavior.
+
+## Scope
+
+Extract, verbatim (behavior unchanged), into a new sibling file
+`server/backends/collectionNotifierAdapter.ts`:
+
+- `LegacyNotifierPluginData` interface (the bell marker shape)
+- `isLegacyNotifierPluginData(value): value is LegacyNotifierPluginData`
+- `buildNavigateTarget(slug, itemId): string`
+- `priorityToSeverity(priority): NotifierSeverity`
+- `buildPluginData({ legacyId, slug, itemId, priority }): LegacyNotifierPluginData`
+- `readEntry(pluginData): { legacyId, priority } | null`
+
+`collectionWatchers.ts` keeps the I/O boundary: it imports the helpers and assembles
+`adapter: CollectionNotificationAdapter` (still owning `pluginPkg: "todo"`, the `log`
+object, and `startCollectionCompletionWatchers`).
+
+Types `CollectionNotificationAdapter` / `CompletionPriority` come from
+`@mulmoclaude/core/collection-watchers`; `NotifierSeverity` from
+`@mulmoclaude/core/notifier` (used only to annotate `priorityToSeverity`'s return —
+previously supplied by contextual typing on the inline adapter).
+
+## Tests
+
+`test/server/backends/collectionNotifierAdapter.spec.ts` (vitest, node env):
+
+- `buildPluginData` -> `readEntry` priority round-trip (high stays high; anything else
+  stored as normal)
+- `readEntry` returns null for non-marker input (null / non-object, legacy marker
+  missing, non-string `legacyId`, non-string `kind`)
+- `isLegacyNotifierPluginData` truth table (true only for `legacy:true` + string
+  `legacyId` + string `kind`)
+- `buildNavigateTarget`: normal slug -> `/collections/<enc>?selected=<enc>`; empty
+  itemId drops the query; `.` / `..` -> `/collections`; reserved chars percent-encoded
+- `priorityToSeverity`: high -> urgent, normal -> nudge
+
+### Mutation checks (confirmed the tests fail against broken code, then restored)
+
+- Removed the `.` / `..` fallback in `buildNavigateTarget` -> "falls back to the index
+  for dot-segment slugs" went red.
+- Inverted the priority decision in `readEntry` (`=== "high"` -> `!== "high"`) -> both
+  round-trip tests went red.
+- Swapped the `priorityToSeverity` branches -> both mapping tests went red.
+
+## Verification
+
+- `prettier --write` + `eslint` on the changed/new files: clean
+- `yarn typecheck` (vue-tsc -b), `yarn typecheck:server`, `yarn typecheck:test`: all pass
+- `vitest run test/server/backends`: 27 files / 368 tests green

--- a/server/backends/collectionNotifierAdapter.ts
+++ b/server/backends/collectionNotifierAdapter.ts
@@ -1,0 +1,57 @@
+// The pure wrap/unwrap helpers behind MulmoTerminal's collection-completion bells.
+// CROSS-APP PARITY: these MUST stay byte-identical to MulmoClaude's
+// (server/workspace/collections/notifications.ts) so a bell either app published
+// carries the same shape and the same `legacyId` — otherwise a record recognised by
+// only one app's `readEntry` gets a second bell. The legacy types live in
+// MulmoClaude's app source (not the published package), so the shape is mirrored
+// here rather than imported.
+import type { CompletionPriority } from "@mulmoclaude/core/collection-watchers";
+import type { NotifierSeverity } from "@mulmoclaude/core/notifier";
+
+// `legacy: true` + a string `legacyId` + a string `kind` is the marker both apps'
+// readEntry recognise; the navigate `action` preserves the bell's icon/routing.
+export interface LegacyNotifierPluginData {
+  legacy: true;
+  legacyId: string;
+  kind: "todo";
+  priority: "normal" | "high";
+  action: { type: "navigate"; target: { view: "collections"; slug: string; itemId: string } };
+}
+
+export function isLegacyNotifierPluginData(value: unknown): value is LegacyNotifierPluginData {
+  if (value === null || typeof value !== "object") return false;
+  const rec = value as Record<string, unknown>;
+  return rec.legacy === true && typeof rec.legacyId === "string" && typeof rec.kind === "string";
+}
+
+/** Deep-link the bell row navigates to: `/collections/<slug>?selected=<itemId>` (the
+ *  documented record permalink). Dot-segment slugs would normalise out of the route,
+ *  so fall back to the index — matches MulmoClaude's builder. */
+export function buildNavigateTarget(slug: string, itemId: string): string {
+  if (slug === "." || slug === "..") return "/collections";
+  const base = `/collections/${encodeURIComponent(slug)}`;
+  return itemId ? `${base}?selected=${encodeURIComponent(itemId)}` : base;
+}
+
+// high → urgent (red), normal → nudge (amber). Never "info" — the engine forbids
+// info-severity action entries.
+export function priorityToSeverity(priority: CompletionPriority): NotifierSeverity {
+  return priority === "high" ? "urgent" : "nudge";
+}
+
+export function buildPluginData(input: { legacyId: string; slug: string; itemId: string; priority: CompletionPriority }): LegacyNotifierPluginData {
+  const { legacyId, slug, itemId, priority } = input;
+  return {
+    legacy: true,
+    legacyId,
+    kind: "todo",
+    priority: priority === "high" ? "high" : "normal",
+    action: { type: "navigate", target: { view: "collections", slug, itemId } },
+  };
+}
+
+export function readEntry(pluginData: unknown): { legacyId: string; priority: CompletionPriority } | null {
+  if (!isLegacyNotifierPluginData(pluginData)) return null;
+  const priority: CompletionPriority = pluginData.priority === "high" ? "high" : "normal";
+  return { legacyId: pluginData.legacyId, priority };
+}

--- a/server/backends/collectionWatchers.ts
+++ b/server/backends/collectionWatchers.ts
@@ -7,67 +7,27 @@
 // (<ws>/data/notifier/active.json) and never run simultaneously. For a record to
 // carry exactly ONE bell regardless of which app published it, this adapter MUST be
 // byte-identical to MulmoClaude's (server/workspace/collections/notifications.ts):
-// the same pluginPkg, the same `LegacyNotifierPluginData` shape, and a `readEntry`
-// that recognises ANY legacy entry by its marker. Then MulmoTerminal's reconciler
-// recognises a bell MulmoClaude already published (same legacyId) and won't add a
-// duplicate — and vice-versa. Diverging here is what produced double bells.
-//
-// The legacy types live in MulmoClaude's app source (not the published package), so
-// the small shape is mirrored locally rather than imported.
+// the same pluginPkg and the same wrap/unwrap helpers (in ./collectionNotifierAdapter),
+// whose `readEntry` recognises ANY legacy entry by its marker. Then MulmoTerminal's
+// reconciler recognises a bell MulmoClaude already published (same legacyId) and won't
+// add a duplicate — and vice-versa. Diverging here is what produced double bells.
 import { configureCollectionWatchers, startCollectionWatchers } from "@mulmoclaude/core/collection-watchers";
-import type { CollectionNotificationAdapter, CompletionPriority } from "@mulmoclaude/core/collection-watchers";
+import type { CollectionNotificationAdapter } from "@mulmoclaude/core/collection-watchers";
+import { buildNavigateTarget, buildPluginData, priorityToSeverity, readEntry } from "./collectionNotifierAdapter.js";
 
 const log = {
   info: (message: string, data?: Record<string, unknown>) => console.log(`[collection-watchers] ${message}`, data ?? ""),
   warn: (message: string, data?: Record<string, unknown>) => console.warn(`[collection-watchers] ${message}`, data ?? ""),
 };
 
-// Mirror of MulmoClaude's LegacyNotifierPluginData (the subset collection bells use).
-// `legacy: true` + a string `legacyId` + a string `kind` is the marker both apps'
-// readEntry recognise; the navigate `action` preserves the bell's icon/routing.
-interface LegacyNotifierPluginData {
-  legacy: true;
-  legacyId: string;
-  kind: "todo";
-  priority: "normal" | "high";
-  action: { type: "navigate"; target: { view: "collections"; slug: string; itemId: string } };
-}
-
-function isLegacyNotifierPluginData(value: unknown): value is LegacyNotifierPluginData {
-  if (value === null || typeof value !== "object") return false;
-  const rec = value as Record<string, unknown>;
-  return rec.legacy === true && typeof rec.legacyId === "string" && typeof rec.kind === "string";
-}
-
-/** Deep-link the bell row navigates to: `/collections/<slug>?selected=<itemId>` (the
- *  documented record permalink). Dot-segment slugs would normalise out of the route,
- *  so fall back to the index — matches MulmoClaude's builder. */
-function buildNavigateTarget(slug: string, itemId: string): string {
-  if (slug === "." || slug === "..") return "/collections";
-  const base = `/collections/${encodeURIComponent(slug)}`;
-  return itemId ? `${base}?selected=${encodeURIComponent(itemId)}` : base;
-}
-
 const adapter: CollectionNotificationAdapter = {
   // MulmoClaude's collection bells publish under its legacy namespace; match it so
   // the shared notifier treats both apps' bells as the same entry.
   pluginPkg: "todo",
-  // high → urgent (red), normal → nudge (amber). Never "info" — the engine forbids
-  // info-severity action entries.
-  priorityToSeverity: (priority) => (priority === "high" ? "urgent" : "nudge"),
+  priorityToSeverity,
   buildNavigateTarget,
-  buildPluginData: ({ legacyId, slug, itemId, priority }): LegacyNotifierPluginData => ({
-    legacy: true,
-    legacyId,
-    kind: "todo",
-    priority: priority === "high" ? "high" : "normal",
-    action: { type: "navigate", target: { view: "collections", slug, itemId } },
-  }),
-  readEntry: (pluginData) => {
-    if (!isLegacyNotifierPluginData(pluginData)) return null;
-    const priority: CompletionPriority = pluginData.priority === "high" ? "high" : "normal";
-    return { legacyId: pluginData.legacyId, priority };
-  },
+  buildPluginData,
+  readEntry,
 };
 
 /** Configure the adapter + mount the watchers. Fire-and-forget at boot AFTER

--- a/test/server/backends/collectionNotifierAdapter.spec.ts
+++ b/test/server/backends/collectionNotifierAdapter.spec.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import {
+  buildNavigateTarget,
+  buildPluginData,
+  isLegacyNotifierPluginData,
+  priorityToSeverity,
+  readEntry,
+} from "../../../server/backends/collectionNotifierAdapter.js";
+
+// These helpers must stay byte-identical to MulmoClaude's so a bell either app
+// published round-trips through the other app's readEntry with the same legacyId.
+// The tests below pin the marker recognition, the priority round-trip, and the
+// deep-link builder — the three places a divergence would silently double a bell or
+// misroute a click.
+
+describe("buildPluginData -> readEntry round-trip", () => {
+  it("preserves a high priority", () => {
+    const data = buildPluginData({ legacyId: "todo:a/b", slug: "a", itemId: "b", priority: "high" });
+    expect(readEntry(data)).toEqual({ legacyId: "todo:a/b", priority: "high" });
+  });
+
+  it("preserves a normal priority", () => {
+    const data = buildPluginData({ legacyId: "todo:a/b", slug: "a", itemId: "b", priority: "normal" });
+    expect(readEntry(data)).toEqual({ legacyId: "todo:a/b", priority: "normal" });
+  });
+
+  it("stores high verbatim and anything else as normal", () => {
+    expect(buildPluginData({ legacyId: "x", slug: "s", itemId: "i", priority: "high" }).priority).toBe("high");
+    expect(buildPluginData({ legacyId: "x", slug: "s", itemId: "i", priority: "normal" }).priority).toBe("normal");
+  });
+});
+
+describe("readEntry rejects non-marker entries", () => {
+  it("returns null for null / non-object", () => {
+    expect(readEntry(null)).toBeNull();
+    expect(readEntry(undefined)).toBeNull();
+    expect(readEntry("todo")).toBeNull();
+    expect(readEntry(42)).toBeNull();
+  });
+
+  it("returns null when the legacy marker is missing", () => {
+    expect(readEntry({ legacyId: "x", kind: "todo" })).toBeNull();
+    expect(readEntry({ legacy: false, legacyId: "x", kind: "todo" })).toBeNull();
+  });
+
+  it("returns null when legacyId is not a string", () => {
+    expect(readEntry({ legacy: true, legacyId: 7, kind: "todo" })).toBeNull();
+    expect(readEntry({ legacy: true, kind: "todo" })).toBeNull();
+  });
+
+  it("returns null when kind is not a string", () => {
+    expect(readEntry({ legacy: true, legacyId: "x", kind: 1 })).toBeNull();
+    expect(readEntry({ legacy: true, legacyId: "x" })).toBeNull();
+  });
+});
+
+describe("isLegacyNotifierPluginData", () => {
+  it("is true only for legacy:true + string legacyId + string kind", () => {
+    expect(isLegacyNotifierPluginData({ legacy: true, legacyId: "x", kind: "todo" })).toBe(true);
+  });
+
+  it("is false when any part of the marker is absent or wrong-typed", () => {
+    expect(isLegacyNotifierPluginData(null)).toBe(false);
+    expect(isLegacyNotifierPluginData("nope")).toBe(false);
+    expect(isLegacyNotifierPluginData({ legacy: false, legacyId: "x", kind: "todo" })).toBe(false);
+    expect(isLegacyNotifierPluginData({ legacy: true, legacyId: 1, kind: "todo" })).toBe(false);
+    expect(isLegacyNotifierPluginData({ legacy: true, legacyId: "x", kind: 2 })).toBe(false);
+    expect(isLegacyNotifierPluginData({ legacyId: "x", kind: "todo" })).toBe(false);
+  });
+});
+
+describe("buildNavigateTarget", () => {
+  it("links to /collections/<slug>?selected=<itemId> for a normal record", () => {
+    expect(buildNavigateTarget("tasks", "abc")).toBe("/collections/tasks?selected=abc");
+  });
+
+  it("omits the selected query when itemId is empty", () => {
+    expect(buildNavigateTarget("tasks", "")).toBe("/collections/tasks");
+  });
+
+  it("falls back to the index for dot-segment slugs", () => {
+    expect(buildNavigateTarget(".", "abc")).toBe("/collections");
+    expect(buildNavigateTarget("..", "abc")).toBe("/collections");
+  });
+
+  it("percent-encodes reserved characters in slug and itemId", () => {
+    expect(buildNavigateTarget("a b/c", "x?y&z")).toBe("/collections/a%20b%2Fc?selected=x%3Fy%26z");
+  });
+});
+
+describe("priorityToSeverity", () => {
+  it("maps high to urgent", () => {
+    expect(priorityToSeverity("high")).toBe("urgent");
+  });
+
+  it("maps normal to nudge", () => {
+    expect(priorityToSeverity("normal")).toBe("nudge");
+  });
+});


### PR DESCRIPTION
## Summary

Extract the collection-completion-bell adapter's pure wrap/unwrap helpers out of
`server/backends/collectionWatchers.ts` into a new, testable sibling module
`server/backends/collectionNotifierAdapter.ts`, and pin them with unit tests.

`collectionWatchers.ts` keeps the I/O boundary — it now imports the helpers and only
assembles `adapter: CollectionNotificationAdapter` (still owning `pluginPkg: "todo"`,
the `log` object, and `startCollectionCompletionWatchers`). **Behavior is unchanged** —
this matters because the comment on that adapter requires it to stay **byte-identical**
to MulmoClaude's counterpart (`server/workspace/collections/notifications.ts`): both
apps share one notifier file, so a record's bell must round-trip through either app's
`readEntry` with the same `legacyId` or a duplicate bell appears.

Extracted (verbatim logic):

- `LegacyNotifierPluginData` interface
- `isLegacyNotifierPluginData(value): value is LegacyNotifierPluginData`
- `buildNavigateTarget(slug, itemId): string`
- `priorityToSeverity(priority): NotifierSeverity`
- `buildPluginData({ legacyId, slug, itemId, priority }): LegacyNotifierPluginData`
- `readEntry(pluginData): { legacyId, priority } | null`

New tests: `test/server/backends/collectionNotifierAdapter.spec.ts` (15 tests).

## Items to Confirm / Review

- **Behavior preservation is the whole point.** Please sanity-check the diff of
  `collectionWatchers.ts` — it should be a pure move (imports + adapter assembly), no
  logic edits. The `value as Record<string, unknown>` cast inside
  `isLegacyNotifierPluginData` was moved verbatim to keep parity with MulmoClaude's
  version rather than rewritten.
- **One new import:** `priorityToSeverity`'s return type is now annotated as
  `NotifierSeverity` (from `@mulmoclaude/core/notifier`). Previously the inline arrow
  got this type from contextual typing on the adapter; the annotation makes the
  extracted function explicit. No runtime effect.
- `buildPluginData` intentionally destructures only `{ legacyId, slug, itemId, priority }`
  and ignores the adapter contract's extra `navigateTarget` input field — same as the
  original inline implementation.

## User Prompt

> 全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した(#676)。その優先度A項目を実装する。

## Mutation checks

Confirmed each new test fails when the covered logic is broken, then restored:

| Mutation | Test that went red |
| --- | --- |
| Removed the `.` / `..` fallback in `buildNavigateTarget` | `buildNavigateTarget > falls back to the index for dot-segment slugs` |
| Inverted `readEntry` priority (`=== "high"` → `!== "high"`) | both `buildPluginData -> readEntry round-trip` priority tests |
| Swapped `priorityToSeverity` branches | both `priorityToSeverity` mapping tests |

## Verification

- `prettier --write` + `eslint` on changed/new files: clean
- `yarn typecheck` (vue-tsc -b), `yarn typecheck:server`, `yarn typecheck:test`: all pass
- `vitest run test/server/backends`: 27 files / 368 tests green (15 new)

Part of #676
