### PR TITLE
refactor: extract WikiIndexView tag-filter rules into a pure module (#676 A5)

### DIFF
--- a/plans/refactor-676-a5-wiki-tag-filter.md
+++ b/plans/refactor-676-a5-wiki-tag-filter.md
@@ -1,0 +1,58 @@
+# refactor(#676 A5): extract WikiIndexView tag-filter rules into a pure, testable module
+
+Part of #676. Priority-A item A5.
+
+## Problem
+
+`src/components/WikiIndexView.vue` held the whole tag-filter / chip decision set inline in
+its `computed` group (`tagCounts` → `meaningfulTags` → `cutoffTags` → `visibleTags` →
+`filtered`). Those rules — count aggregation, singleton drop, count-desc/name-asc ordering,
+an adaptive cutoff that keeps equally-popular tags together (not a fixed `slice`), restoring
+a cutoff-hidden selected tag at the tail, and the AND filter — could only be reached by
+mounting the component, so none of them were tested.
+
+## Change
+
+Extract the rules into a new same-directory pure module `src/components/wikiTagFilter.ts`
+and reduce the `.vue` to `computed` calls into it. Behavior is unchanged (1:1 move).
+
+Public API:
+
+- `tagCounts(entries: WikiPageEntry[]): Map<string, number>` — per-tag page counts.
+- `filterChips(entries, selected: ReadonlySet<string>, target = TARGET_FILTER_CHIPS): [string, number][]`
+  — meaningful ranking → adaptive cutoff → restore cutoff-hidden selected tags at the tail.
+- `filterEntriesByTags(entries, selected: ReadonlySet<string>): WikiPageEntry[]` — AND filter;
+  empty selection matches everything.
+
+`TARGET_FILTER_CHIPS = 20` is kept as a named constant and used as `filterChips`'s default
+`target`. `WikiPageEntry` comes from `@mulmoclaude/core/wiki`. The ranking helpers copy the
+count entries before sorting, so the caller's `props.entries` are never mutated.
+
+Internally `filterChips` is split into small named helpers (`rankMeaningfulTags`,
+`adaptiveCutoff`, `appendHiddenSelected`) so each rule reads on its own.
+
+## Tests
+
+`test/src/components/wikiTagFilter.spec.ts`:
+
+- `tagCounts`: aggregation, empty entries, no mutation of tag arrays.
+- singleton (count == 1) tags dropped from chips.
+- count desc, then name asc on ties.
+- **adaptive cutoff pin**: the 20th and 21st tags tie → both kept (bar length exceeds the
+  target); a second case pins the same with an explicit small `target`. Both fail if the
+  cutoff is replaced by `slice(0, target)`.
+- cutoff-hidden **selected** tag restored at the tail with count fallback 1 (both a page
+  singleton and a tag absent from every page); multiple restored tags sorted by name.
+- AND filter across multiple selected tags; empty selection returns all; single tag; and a
+  selection no entry satisfies returns `[]`.
+
+## Mutation check
+
+Replacing `adaptiveCutoff` with `return ranked.slice(0, target)` turned both boundary-tie
+pin tests red (default-target length-22 test and the small-target test) while the other 11
+stayed green; reverted after confirming.
+
+## Verification
+
+`prettier --write` + `eslint` on the touched files; `yarn typecheck`, `yarn typecheck:server`,
+`yarn typecheck:test`; `vitest run` on the new spec.

--- a/src/components/WikiIndexView.vue
+++ b/src/components/WikiIndexView.vue
@@ -6,49 +6,14 @@ import { computed, ref } from "vue";
 import type { WikiPageEntry } from "@mulmoclaude/core/wiki";
 import FilterChip from "./FilterChip.vue";
 import { wikiGotoPage } from "../composables/useWikiBrowse";
+import { filterChips, filterEntriesByTags } from "./wikiTagFilter";
 
 const props = defineProps<{ entries: WikiPageEntry[] }>();
 
 const selected = ref<Set<string>>(new Set());
 
-// Full per-tag page counts.
-const tagCounts = computed(() => {
-  const counts = new Map<string, number>();
-  for (const e of props.entries) for (const t of e.tags) counts.set(t, (counts.get(t) ?? 0) + 1);
-  return counts;
-});
-
-// Filter-bar chips, mirroring MulmoClaude's wiki View: drop singletons (a tag on one
-// page adds no filtering value, just visual noise — it stays clickable from the card),
-// sort by count desc then name asc, and raise the cutoff adaptively so the row stays
-// around TARGET_FILTER_CHIPS even on big wikis. The cutoff is the count at the target
-// position, so equally-popular tags are kept together rather than sliced arbitrarily.
-const TARGET_FILTER_CHIPS = 20;
-const meaningfulTags = computed(() => [...tagCounts.value.entries()].filter(([, c]) => c > 1).sort(([ta, ca], [tb, cb]) => cb - ca || ta.localeCompare(tb)));
-const cutoffTags = computed<[string, number][]>(() => {
-  const m = meaningfulTags.value;
-  if (m.length <= TARGET_FILTER_CHIPS) return m;
-  const cutoff = m[TARGET_FILTER_CHIPS - 1][1];
-  return m.filter(([, c]) => c >= cutoff);
-});
-// Keep any selected tag the cutoff hides (e.g. a singleton picked from a card) visible
-// in the bar so it stays removable.
-const visibleTags = computed<[string, number][]>(() => {
-  const shown = new Set(cutoffTags.value.map(([t]) => t));
-  const extra = [...selected.value]
-    .filter((t) => !shown.has(t))
-    .sort((a, b) => a.localeCompare(b))
-    .map((t): [string, number] => [t, tagCounts.value.get(t) ?? 1]);
-  return [...cutoffTags.value, ...extra];
-});
-
-const filtered = computed(() => {
-  if (selected.value.size === 0) return props.entries;
-  return props.entries.filter((e) => {
-    const tags = new Set(e.tags);
-    return [...selected.value].every((t) => tags.has(t));
-  });
-});
+const visibleTags = computed(() => filterChips(props.entries, selected.value));
+const filtered = computed(() => filterEntriesByTags(props.entries, selected.value));
 
 function toggleTag(tag: string): void {
   const next = new Set(selected.value);

--- a/src/components/wikiTagFilter.ts
+++ b/src/components/wikiTagFilter.ts
@@ -1,0 +1,52 @@
+import type { WikiPageEntry } from "@mulmoclaude/core/wiki";
+
+// Aim the filter bar at roughly this many chips; the cutoff floats around it (see below).
+export const TARGET_FILTER_CHIPS = 20;
+
+type TagCount = [string, number];
+
+export const tagCounts = (entries: WikiPageEntry[]): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const entry of entries) for (const tag of entry.tags) counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  return counts;
+};
+
+// A tag on a single page filters nothing, so drop singletons; rank the rest by frequency
+// then name so the bar order is stable.
+const rankMeaningfulTags = (counts: Map<string, number>): TagCount[] =>
+  [...counts.entries()].filter(([, count]) => count > 1).sort(([nameA, countA], [nameB, countB]) => countB - countA || nameA.localeCompare(nameB));
+
+// Cut at the count of the target-th tag, keeping equally-popular tags together instead of
+// slicing the row at an arbitrary boundary — so the bar can exceed the target on ties.
+const adaptiveCutoff = (ranked: TagCount[], target: number): TagCount[] => {
+  if (ranked.length <= target) return ranked;
+  const cutoffCount = ranked[target - 1][1];
+  return ranked.filter(([, count]) => count >= cutoffCount);
+};
+
+// Re-append any selected tag the cutoff dropped (e.g. a singleton picked from a card) so
+// it stays visible and removable; its count falls back to 1 when absent from the map.
+const appendHiddenSelected = (shown: TagCount[], selected: ReadonlySet<string>, counts: Map<string, number>): TagCount[] => {
+  const shownTags = new Set(shown.map(([tag]) => tag));
+  const hidden = [...selected]
+    .filter((tag) => !shownTags.has(tag))
+    .sort((a, b) => a.localeCompare(b))
+    .map((tag): TagCount => [tag, counts.get(tag) ?? 1]);
+  return [...shown, ...hidden];
+};
+
+export const filterChips = (entries: WikiPageEntry[], selected: ReadonlySet<string>, target: number = TARGET_FILTER_CHIPS): TagCount[] => {
+  const counts = tagCounts(entries);
+  const shown = adaptiveCutoff(rankMeaningfulTags(counts), target);
+  return appendHiddenSelected(shown, selected, counts);
+};
+
+// AND across selected tags: keep entries carrying every selected tag; an empty selection
+// matches everything.
+export const filterEntriesByTags = (entries: WikiPageEntry[], selected: ReadonlySet<string>): WikiPageEntry[] => {
+  if (selected.size === 0) return entries;
+  return entries.filter((entry) => {
+    const tags = new Set(entry.tags);
+    return [...selected].every((tag) => tags.has(tag));
+  });
+};

--- a/test/src/components/wikiTagFilter.spec.ts
+++ b/test/src/components/wikiTagFilter.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import type { WikiPageEntry } from "@mulmoclaude/core/wiki";
+import { tagCounts, filterChips, filterEntriesByTags, TARGET_FILTER_CHIPS } from "../../../src/components/wikiTagFilter";
+
+const entry = (slug: string, tags: string[]): WikiPageEntry => ({ title: slug, slug, description: "", tags });
+
+// One page per repetition, each carrying a single tag, so every tag lands at exactly its
+// configured count with no overlap — handy for exercising the ranking/cutoff rules.
+const entriesFromCounts = (counts: Record<string, number>): WikiPageEntry[] =>
+  Object.entries(counts).flatMap(([tag, n]) => Array.from({ length: n }, (_, i) => entry(`${tag}-p${i}`, [tag])));
+
+const names = (chips: [string, number][]): string[] => chips.map(([tag]) => tag);
+
+describe("tagCounts", () => {
+  it("aggregates per-tag page counts across entries", () => {
+    const counts = tagCounts([entry("a", ["x", "y"]), entry("b", ["x"]), entry("c", ["y"]), entry("d", ["x", "y", "z"])]);
+    expect(counts.get("x")).toBe(3);
+    expect(counts.get("y")).toBe(3);
+    expect(counts.get("z")).toBe(1);
+    expect(counts.size).toBe(3);
+  });
+
+  it("returns an empty map for no entries", () => {
+    expect(tagCounts([]).size).toBe(0);
+  });
+
+  it("does not mutate the entries' tag arrays", () => {
+    const entries = [entry("a", ["x", "y"])];
+    tagCounts(entries);
+    expect(entries[0].tags).toEqual(["x", "y"]);
+  });
+});
+
+describe("filterChips", () => {
+  it("drops singleton tags (a tag on one page) from the bar", () => {
+    const chips = filterChips([entry("a", ["shared", "solo"]), entry("b", ["shared"])], new Set());
+    expect(names(chips)).toEqual(["shared"]);
+  });
+
+  it("sorts by count desc, then name asc on ties", () => {
+    const chips = filterChips(entriesFromCounts({ zed: 3, beta: 2, alpha: 2 }), new Set());
+    expect(names(chips)).toEqual(["zed", "alpha", "beta"]);
+  });
+
+  it("keeps tags tied at the cutoff position together (adaptive, not a fixed slice)", () => {
+    // Ranks 1-19 get distinct descending counts; ranks 20, 21, 22 all tie at 5. A plain
+    // slice(0, 20) would keep only the first of the tied group; the adaptive cutoff keeps
+    // all three because the cutoff is the *count* at the target position.
+    const counts: Record<string, number> = {};
+    Array.from({ length: 19 }, (_, i) => (counts[`t${String(i).padStart(2, "0")}`] = 30 - i));
+    counts["t19"] = 5;
+    counts["t20"] = 5;
+    counts["t21"] = 5;
+    const chips = filterChips(entriesFromCounts(counts), new Set());
+    expect(chips).toHaveLength(22);
+    expect(names(chips)).toContain("t20");
+    expect(names(chips)).toContain("t21");
+    expect(TARGET_FILTER_CHIPS).toBe(20);
+  });
+
+  it("keeps the tied boundary group with an explicit small target too", () => {
+    const chips = filterChips(entriesFromCounts({ a: 5, b: 3, c: 3, d: 2 }), new Set(), 2);
+    // target 2 → cutoff is b's count (3); both b and c survive, d (count 2) does not.
+    expect(names(chips)).toEqual(["a", "b", "c"]);
+  });
+
+  it("restores a cutoff-hidden selected tag at the tail with count fallback 1", () => {
+    const entries = [entry("a", ["shared", "solo"]), entry("b", ["shared"])];
+    const chips = filterChips(entries, new Set(["solo"]));
+    expect(chips).toEqual([
+      ["shared", 2],
+      ["solo", 1],
+    ]);
+  });
+
+  it("appends selected tags absent from any page with count 1, sorted by name", () => {
+    const entries = [entry("a", ["shared"]), entry("b", ["shared"])];
+    const chips = filterChips(entries, new Set(["zeta", "alpha"]));
+    expect(chips).toEqual([
+      ["shared", 2],
+      ["alpha", 1],
+      ["zeta", 1],
+    ]);
+  });
+});
+
+describe("filterEntriesByTags", () => {
+  const entries = [entry("a", ["x", "y"]), entry("b", ["x"]), entry("c", ["y"]), entry("d", ["x", "y", "z"])];
+
+  it("returns all entries when nothing is selected", () => {
+    expect(filterEntriesByTags(entries, new Set())).toBe(entries);
+  });
+
+  it("keeps only entries carrying every selected tag (AND)", () => {
+    const kept = filterEntriesByTags(entries, new Set(["x", "y"]));
+    expect(kept.map((e) => e.slug)).toEqual(["a", "d"]);
+  });
+
+  it("keeps every entry with a single selected tag", () => {
+    const kept = filterEntriesByTags(entries, new Set(["x"]));
+    expect(kept.map((e) => e.slug)).toEqual(["a", "b", "d"]);
+  });
+
+  it("returns nothing when no entry carries all selected tags", () => {
+    expect(filterEntriesByTags(entries, new Set(["x", "y", "z", "missing"]))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the tag-filter / chip decision set out of `src/components/WikiIndexView.vue`'s `computed` group into a new same-directory pure module `src/components/wikiTagFilter.ts`, and reduces the `.vue` to `computed` calls into it. The rules were previously only reachable by mounting the component, so none were tested; they now have direct unit tests. **Behavior is unchanged** (1:1 move).

Public API of the new module:
- `tagCounts(entries: WikiPageEntry[]): Map<string, number>`
- `filterChips(entries, selected: ReadonlySet<string>, target = TARGET_FILTER_CHIPS): [string, number][]` — meaningful ranking (drop singletons, count desc / name asc) → adaptive cutoff (keeps equally-popular tags together, **not** a fixed `slice`) → restore any cutoff-hidden selected tag at the tail (count fallback 1).
- `filterEntriesByTags(entries, selected: ReadonlySet<string>): WikiPageEntry[]` — AND filter; empty selection matches everything.

`TARGET_FILTER_CHIPS = 20` is kept as a named constant and is `filterChips`'s default `target`. `WikiPageEntry` comes from `@mulmoclaude/core/wiki`. The ranking copies the count entries before sorting, so the caller's `props.entries` are never mutated.

## Items to Confirm / Review

- **Behavior parity**: confirm the extracted functions reproduce the original `tagCounts` / `meaningfulTags` / `cutoffTags` / `visibleTags` / `filtered` chain exactly (including the count-`?? 1` fallback for a restored selected tag and the name-asc ordering of restored tags).
- **Adaptive cutoff pin**: the key non-obvious rule is that ties at the target boundary are all kept (the bar can exceed the target), rather than `slice(0, target)`. This is pinned by two tests. Mutation check: replacing `adaptiveCutoff` with `return ranked.slice(0, target)` turned both boundary-tie tests red (default-target length-22 test and the small-target test) while the other 11 stayed green; reverted after confirming.
- **Internal split**: `filterChips` is split into `rankMeaningfulTags` / `adaptiveCutoff` / `appendHiddenSelected` (module-private). Tests exercise them through the three public functions.

## User Prompt

> 全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した(#676)。その優先度A項目を実装する。

## Verification

- `prettier --write` + `eslint` clean on the touched files.
- `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test` all pass.
- `vitest run test/src/components/wikiTagFilter.spec.ts` → 13 passed.

Part of #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)