### PR TITLE
refactor: extract collectionUi pure decisions into collectionUiRules (#676 A6)

### DIFF
--- a/plans/refactor-676-a6-collection-ui-rules.md
+++ b/plans/refactor-676-a6-collection-ui-rules.md
@@ -1,0 +1,59 @@
+# refactor: extract collectionUi.ts pure decisions into collectionUiRules.ts (#676 A6)
+
+Date: 2026-07-23
+
+## Goal
+
+Part of #676 (audit of source for pure functions that can be extracted and tested).
+Priority-A item A6: pull three pure decisions out of `src/composables/collectionUi.ts`
+into a sibling `src/composables/collectionUiRules.ts` so they can be unit-tested without
+the fetch/DOM host around them. Behavior-preserving (1:1 move).
+
+## Extracted functions
+
+- `htmlPreviewUrl(value: string): string | null`
+  - Returns the sandbox preview route URL only when `value` is an `artifacts/html/*.html`
+    path; otherwise `null` (caller falls back to the raw-download URL).
+  - **Deliberate pre-existing asymmetry preserved**: the `.html` suffix is matched
+    case-insensitively (`toLowerCase().endsWith(".html")`) but the `artifacts/html/`
+    directory prefix is matched case-sensitively (`startsWith`). Kept as-is; pinned by a
+    test annotated as intentional existing behavior.
+  - Per-segment `encodeURIComponent` URL assembly reproduced exactly.
+- `remoteViewItemsQuery(req: { offset?: number; limit?: number; fields?: string[] }): string`
+  - Builds the `?offset=…&limit=…&fields=…` suffix (or `""`).
+  - `offset` guarded with `!= null` (NOT truthy) so `offset:0` is kept; empty `fields`
+    array is dropped.
+- `deleteErrorMessage(body: unknown, status: number): string`
+  - Server `{ error: string }` body when present, else `HTTP <status>`. Uses `isObject`
+    from `graphai` as the type guard (no `as` casts).
+
+`collectionUi.ts` keeps all fetch/DOM/`configureCollectionUi` wiring and now calls these.
+
+## Tests
+
+`test/src/composables/collectionUiRules.spec.ts` (vitest):
+
+- htmlPreviewUrl: happy path + per-segment encoding; uppercase `.HTML` extension passes
+  (case-insensitive suffix); uppercase `Artifacts/HTML/` prefix falls back to null
+  (case-sensitive prefix — pinned as intentional); non-html; wrong directory; empty rest;
+  empty string.
+- remoteViewItemsQuery: `offset:0` included; non-zero offset; offset omitted; limit
+  (incl. `limit:0`); empty `fields` dropped; populated `fields`; all three combined;
+  all omitted → `""`.
+- deleteErrorMessage: error string returned; non-string error → `HTTP <status>`; missing
+  error field → `HTTP <status>`; null body → `HTTP <status>`; non-object body →
+  `HTTP <status>`.
+
+## Mutation check
+
+Changed `if (req.offset != null)` → `if (req.offset)` (truthy). The `offset:0` pin tests
+(`includes offset when it is 0`, `combines all three params`) turned red (2 failed);
+reverted and all 21 pass again.
+
+## Verification
+
+- `prettier --write` + `eslint` on changed/new files: clean.
+- `vitest run test/src/composables/collectionUiRules.spec.ts`: 21 passed.
+- `yarn typecheck` (vue-tsc -b): pass.
+- `yarn typecheck:server` (tsc -p tsconfig.server.json): pass.
+- `yarn typecheck:test` (vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json): pass.

--- a/src/composables/collectionUi.ts
+++ b/src/composables/collectionUi.ts
@@ -33,6 +33,7 @@ import type { RegistryListResponse, RegistryImportResponse } from "@mulmoclaude/
 import type { TranslateRequest, TranslateResponse } from "@mulmoclaude/core/translation/client";
 import { buildCustomViewSrcdoc } from "../utils/customViewSrcdoc";
 import { fetchJson } from "../utils/fetchJson";
+import { htmlPreviewUrl, remoteViewItemsQuery, deleteErrorMessage } from "./collectionUiRules";
 import { useShortcuts } from "./useShortcuts";
 import {
   browseGotoIndex,
@@ -81,8 +82,7 @@ async function apiDelete(url: string): Promise<{ ok: true } | { ok: false; error
     const res = await fetch(url, { method: "DELETE" });
     if (res.ok) return { ok: true };
     const body = await res.json().catch(() => null);
-    const error = body && typeof body.error === "string" ? body.error : `HTTP ${res.status}`;
-    return { ok: false, error };
+    return { ok: false, error: deleteErrorMessage(body, res.status) };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
@@ -115,21 +115,9 @@ function rawFileUrl(value: unknown): string {
   return `/api/files/raw?path=${encodeURIComponent(String(value))}`;
 }
 
-// A `file` field holding an `artifacts/html/*.html` path points at an
-// LLM-authored page. The raw-file route serves it as octet-stream (no `.html`
-// in its MIME map) so the browser downloads it; the dedicated preview route
-// (server/backends/html.ts → mountHtmlPreviewRoute) serves it as text/html
-// with the sandboxed preview CSP, so it renders in a new tab. Detect that
-// shape and return the preview URL; everything else falls back to rawFileUrl.
-const HTML_PREVIEW_DIR_PREFIX = "artifacts/html/";
-function htmlPreviewUrl(value: string): string | null {
-  if (!value.toLowerCase().endsWith(".html")) return null;
-  if (!value.startsWith(HTML_PREVIEW_DIR_PREFIX)) return null;
-  const rest = value.slice(HTML_PREVIEW_DIR_PREFIX.length);
-  if (rest.length === 0) return null;
-  return `/artifacts/html/${rest.split("/").map(encodeURIComponent).join("/")}`;
-}
-
+// The preview route (server/backends/html.ts → mountHtmlPreviewRoute) serves
+// artifacts/html/*.html with the sandboxed preview CSP so it renders in a new tab;
+// everything else falls back to the raw-file route. See htmlPreviewUrl.
 configureCollectionUi({
   // ── real (read side) ──
   fetchCollectionDetail: (slug) => apiGet<CollectionDetailResponse>(`/api/collections/${encodeURIComponent(slug)}/detail`),
@@ -194,15 +182,10 @@ configureCollectionUi({
   // so the host projects to `fields` and inlines the view's declared image fields
   // as `data:` thumbnails. Without this the preview would page raw (CSP-blocked)
   // paths and show broken images.
-  fetchRemoteViewItems: (slug, viewId, request) => {
-    const query = new URLSearchParams();
-    if (request.offset != null) query.set("offset", String(request.offset));
-    if (request.limit != null) query.set("limit", String(request.limit));
-    if (request.fields?.length) query.set("fields", request.fields.join(","));
-    const qs = query.toString();
-    const suffix = qs ? `?${qs}` : "";
-    return apiGet<CollectionRemoteViewItemsResult>(`/api/collections/${encodeURIComponent(slug)}/remote-view/${encodeURIComponent(viewId)}/items${suffix}`);
-  },
+  fetchRemoteViewItems: (slug, viewId, request) =>
+    apiGet<CollectionRemoteViewItemsResult>(
+      `/api/collections/${encodeURIComponent(slug)}/remote-view/${encodeURIComponent(viewId)}/items${remoteViewItemsQuery(request)}`,
+    ),
 
   // MulmoTerminal serves no per-view translations — return the documented
   // "no i18n" shape ({ locale: "", dict: {} }) so the iframe's __MC_VIEW.t(key)

--- a/src/composables/collectionUiRules.ts
+++ b/src/composables/collectionUiRules.ts
@@ -1,0 +1,42 @@
+// Pure decisions extracted from collectionUi.ts so they can be tested without the
+// fetch/DOM host around them. The host keeps the network and configureCollectionUi
+// wiring; these functions only shape strings.
+import { isObject } from "graphai";
+
+const HTML_PREVIEW_DIR_PREFIX = "artifacts/html/";
+
+// A `file` field holding an `artifacts/html/*.html` path points at an LLM-authored
+// page. The raw-file route serves it as octet-stream (no `.html` in its MIME map) so
+// the browser downloads it; the dedicated preview route serves it as text/html with
+// the sandboxed preview CSP, so it renders in a new tab. Detect that shape and return
+// the preview URL; everything else returns null so the caller falls back to raw.
+//
+// Note the deliberate asymmetry: the `.html` suffix is matched case-insensitively
+// (via toLowerCase) but the directory prefix is matched case-sensitively. Preserved
+// as the existing behavior — see collectionUiRules.spec.ts.
+export function htmlPreviewUrl(value: string): string | null {
+  if (!value.toLowerCase().endsWith(".html")) return null;
+  if (!value.startsWith(HTML_PREVIEW_DIR_PREFIX)) return null;
+  const rest = value.slice(HTML_PREVIEW_DIR_PREFIX.length);
+  if (rest.length === 0) return null;
+  return `/artifacts/html/${rest.split("/").map(encodeURIComponent).join("/")}`;
+}
+
+// The `?offset=…&limit=…&fields=…` suffix (or "") for a remote-view items page. `offset`
+// is kept when it is 0 (a valid first-page offset), so the test uses `!= null` rather
+// than a truthy check; an empty `fields` array is dropped.
+export function remoteViewItemsQuery(req: { offset?: number; limit?: number; fields?: string[] }): string {
+  const query = new URLSearchParams();
+  if (req.offset != null) query.set("offset", String(req.offset));
+  if (req.limit != null) query.set("limit", String(req.limit));
+  if (req.fields?.length) query.set("fields", req.fields.join(","));
+  const qs = query.toString();
+  return qs ? `?${qs}` : "";
+}
+
+// The message for a failed DELETE: the server's `{ error }` body when present, else a
+// bare `HTTP <status>` (e.g. a delete-refusal reason like "preset collections can't be
+// deleted" instead of "HTTP 403").
+export function deleteErrorMessage(body: unknown, status: number): string {
+  return isObject(body) && typeof body.error === "string" ? body.error : `HTTP ${status}`;
+}

--- a/test/src/composables/collectionUiRules.spec.ts
+++ b/test/src/composables/collectionUiRules.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { htmlPreviewUrl, remoteViewItemsQuery, deleteErrorMessage } from "../../../src/composables/collectionUiRules";
+
+describe("htmlPreviewUrl", () => {
+  it("maps a well-formed artifacts/html/*.html path to the preview route", () => {
+    expect(htmlPreviewUrl("artifacts/html/report.html")).toBe("/artifacts/html/report.html");
+  });
+
+  it("encodes each path segment", () => {
+    expect(htmlPreviewUrl("artifacts/html/sub dir/a b.html")).toBe("/artifacts/html/sub%20dir/a%20b.html");
+  });
+
+  // The `.html` suffix is lowercased before the check, so an uppercase extension still
+  // reaches the preview route.
+  it("accepts an uppercase .HTML extension (suffix is case-insensitive)", () => {
+    expect(htmlPreviewUrl("artifacts/html/X.HTML")).toBe("/artifacts/html/X.HTML");
+  });
+
+  // Deliberate, pre-existing asymmetry: the extension is matched case-insensitively but
+  // the `artifacts/html/` directory prefix is matched case-sensitively. An uppercase
+  // prefix therefore falls through to null (raw fallback). Pinned so it isn't
+  // "corrected" into symmetry without an explicit decision.
+  it("rejects an uppercase directory prefix (prefix is case-sensitive) — intentional existing behavior", () => {
+    expect(htmlPreviewUrl("Artifacts/HTML/x.html")).toBeNull();
+  });
+
+  it("returns null for a non-html file", () => {
+    expect(htmlPreviewUrl("artifacts/html/data.json")).toBeNull();
+  });
+
+  it("returns null when the html path is under a different directory", () => {
+    expect(htmlPreviewUrl("docs/report.html")).toBeNull();
+  });
+
+  it("returns null when nothing follows the prefix", () => {
+    expect(htmlPreviewUrl("artifacts/html/.html")).toBe("/artifacts/html/.html");
+    expect(htmlPreviewUrl("artifacts/html/")).toBeNull();
+  });
+
+  it("returns null for the empty string", () => {
+    expect(htmlPreviewUrl("")).toBeNull();
+  });
+});
+
+describe("remoteViewItemsQuery", () => {
+  // offset:0 is a valid first-page offset and must survive — the guard is `!= null`,
+  // not a truthy check.
+  it("includes offset when it is 0", () => {
+    expect(remoteViewItemsQuery({ offset: 0 })).toBe("?offset=0");
+  });
+
+  it("includes a non-zero offset", () => {
+    expect(remoteViewItemsQuery({ offset: 20 })).toBe("?offset=20");
+  });
+
+  it("omits offset when it is absent", () => {
+    expect(remoteViewItemsQuery({ limit: 10 })).toBe("?limit=10");
+  });
+
+  it("includes limit (including limit:0)", () => {
+    expect(remoteViewItemsQuery({ limit: 0 })).toBe("?limit=0");
+  });
+
+  it("drops an empty fields array", () => {
+    expect(remoteViewItemsQuery({ offset: 5, fields: [] })).toBe("?offset=5");
+  });
+
+  it("includes a populated fields array joined by commas", () => {
+    expect(remoteViewItemsQuery({ fields: ["title", "image"] })).toBe("?fields=title%2Cimage");
+  });
+
+  it("combines all three params", () => {
+    expect(remoteViewItemsQuery({ offset: 0, limit: 10, fields: ["a", "b"] })).toBe("?offset=0&limit=10&fields=a%2Cb");
+  });
+
+  it("returns an empty string when everything is omitted", () => {
+    expect(remoteViewItemsQuery({})).toBe("");
+  });
+});
+
+describe("deleteErrorMessage", () => {
+  it("returns the server error string when present", () => {
+    expect(deleteErrorMessage({ error: "preset collections can't be deleted" }, 403)).toBe("preset collections can't be deleted");
+  });
+
+  it("falls back to HTTP <status> when error is not a string", () => {
+    expect(deleteErrorMessage({ error: 42 }, 500)).toBe("HTTP 500");
+  });
+
+  it("falls back to HTTP <status> when the object has no error field", () => {
+    expect(deleteErrorMessage({ message: "nope" }, 404)).toBe("HTTP 404");
+  });
+
+  it("falls back to HTTP <status> when body is null (parse failure)", () => {
+    expect(deleteErrorMessage(null, 400)).toBe("HTTP 400");
+  });
+
+  it("falls back to HTTP <status> when body is a non-object", () => {
+    expect(deleteErrorMessage("just a string", 502)).toBe("HTTP 502");
+    expect(deleteErrorMessage(123, 418)).toBe("HTTP 418");
+  });
+});


### PR DESCRIPTION
## Summary

Refactor-only, behavior-preserving. Extracts three pure decisions out of
`src/composables/collectionUi.ts` into a sibling `src/composables/collectionUiRules.ts`
so they can be unit-tested without the fetch/DOM host that wraps them, and adds a
vitest spec. Part of #676 (priority A6).

Extracted (1:1 move, no behavior change):

- `htmlPreviewUrl(value: string): string | null` — sandbox preview route URL for an
  `artifacts/html/*.html` path, else `null` (caller falls back to the raw-download URL).
  Per-segment `encodeURIComponent` assembly reproduced exactly.
- `remoteViewItemsQuery(req: { offset?: number; limit?: number; fields?: string[] }): string`
  — the `?offset=…&limit=…&fields=…` suffix (or `""`). `offset` guarded with `!= null`
  (not truthy) so `offset:0` is kept; empty `fields` array dropped.
- `deleteErrorMessage(body: unknown, status: number): string` — server `{ error: string }`
  body when present, else `HTTP <status>`. Uses `isObject` from `graphai` as the type
  guard (no `as` casts).

`collectionUi.ts` keeps all fetch/DOM/`configureCollectionUi` wiring and now calls these.

## Items to Confirm / Review

- **Intentional case-sensitivity asymmetry preserved.** `htmlPreviewUrl` matches the
  `.html` suffix case-insensitively (`toLowerCase().endsWith(".html")`) but the
  `artifacts/html/` directory prefix case-sensitively (`startsWith`). So
  `artifacts/html/X.HTML` → preview route, but `Artifacts/HTML/x.html` → raw fallback.
  This asymmetry is the pre-existing behavior; it is kept as-is and pinned by a test
  annotated as intentional. Flagging in case the asymmetry itself is actually a latent
  bug worth a separate fix — out of scope for this behavior-preserving refactor.
- **`deleteErrorMessage` type guard.** Original was `body && typeof body.error === "string"`
  with `body: any`. New version takes `body: unknown` and narrows via graphai `isObject`
  (returns true for arrays too, same as the original's truthy check → all non-`{error:string}`
  inputs still fall through to `HTTP <status>`). Confirm graphai `isObject` is the right
  shared guard here.

## Mutation check

Changed `if (req.offset != null)` → `if (req.offset)` (truthy) in `remoteViewItemsQuery`;
the `offset:0` pin tests (`includes offset when it is 0`, `combines all three params`)
turned red (2 failed). Reverted; all 21 tests pass.

## Verification

- `prettier --write` + `eslint` on changed/new files: clean.
- `vitest run test/src/composables/collectionUiRules.spec.ts`: 21 passed.
- `yarn typecheck` (vue-tsc -b): pass.
- `yarn typecheck:server` (tsc -p tsconfig.server.json): pass.
- `yarn typecheck:test` (vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json): pass.

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した(#676)。その優先度A項目を実装する。

Part of #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
