### PR TITLE
refactor: extract toolResult store/publish decision into planToolResultUpdate (#676 A3)

### DIFF
--- a/plans/refactor-676-a3-tool-result-plan.md
+++ b/plans/refactor-676-a3-tool-result-plan.md
@@ -1,0 +1,45 @@
+# refactor #676 A3 — toolResult 保存フィールド選別と `persistOnly` publish ゲートの pure 関数化
+
+Part of #676（棚卸し第3弾・優先度A の A3）。
+
+## 背景
+
+`POST /api/agent/toolResult`（`server/routes/tool-routes.ts`）は 2 つの呼び出し元を持つ:
+
+- MCP broker: プラグインが結果を出したとき。`persistOnly` を付けない → publish してライブ描画。
+- GUI パネル: あるビューが自分の viewState 変更を同じ uuid で永続化するとき。`persistOnly: true` を付ける。
+
+判断ルールは 2 つ:
+
+1. `sessionId` と `persistOnly` を除いた残りを保存対象にする。
+2. `persistOnly === true` のときだけ session channel への再 publish を抑止する。再 publish は発生元パネルを再 seed → 再 emit させる**エコー無限フリッカーループ**になる。
+
+`tool-store.spec` はストア挙動のみを見ており、**この判断は未テスト**だった。緩い truthy 判定への「単純化」や strip 対象のズレが、そのままフリッカー再発 or ライブ描画停止になる。
+
+## 変更
+
+- 新ファイル `server/routes/toolResultPlan.ts` に pure 関数 `planToolResultUpdate(body: unknown)` を切り出し。
+  - 戻り値: `{ ok: false; error: string } | { ok: true; stored: ToolResult; publish: boolean; sessionId: string; toolName: string }`。
+  - 検証順序は現行ハンドラと 1:1（sessionId → toolName → uuid）、エラーメッセージも同一（`invalid sessionId` / `invalid toolName` / `invalid uuid`）。
+  - `stored` は body から `sessionId` と `persistOnly` を除いたもの（`uuid`・`toolName`・その他ペイロードは保持）。
+  - `publish` は `persistOnly !== true`。strict boolean `true` のみ抑止。
+- `server/routes/tool-routes.ts` の POST ハンドラは plan を呼び、`storeToolResult` と `publish`（+ ログ）の I/O だけを行う。GET ルート群は不変。
+
+### 検証の型付けに関する意図的な差分（1点）
+
+現行は `req.body` が `any` のため `!sessionId || !SESSION_ID_RE.test(sessionId)` で検証しており、`sessionId` が「UUID 文字列 1 要素だけの配列」の場合、`test()` の文字列強制で **通過**してしまう（到達不能に近い異常入力）。pure 関数は戻り値 `sessionId: string` を型安全に満たす必要があり（`as` キャスト禁止）、`typeof sessionId !== "string"` で narrow する。結果、この配列ケースは `ok:false`（invalid sessionId）になる。実運用の呼び出し元（broker / GUI）はいずれも文字列 id を送るため到達せず、issue の観点「非文字列 → ok:false」とも一致。この非対称は spec にピン留めしコメントで理由を明記した。
+
+## テスト
+
+`test/server/routes/toolResultPlan.spec.ts`:
+
+- 有効 body → `ok:true`、`stored` に `sessionId`/`persistOnly` を含まない、`publish=true`。
+- `persistOnly:true` → `publish=false`、`stored` に `persistOnly` 無し。
+- truthy だが厳密に `true` でない `persistOnly`（`"true"`/`1`/`{}`/`[]`）→ `publish=true`（`=== true` を pin）。
+- 無効 sessionId（欠落・空文字・非 UUID 文字列・数値・真偽値・オブジェクト・非配列 body・UUID 1 要素配列）→ `ok:false` + `invalid sessionId`。
+- 無効 toolName / uuid（現行どおり）→ 各 `invalid toolName` / `invalid uuid`。
+- 検証順序（sessionId → toolName → uuid）のピン。
+
+### 変異テスト
+
+`publish = stored.persistOnly !== true` を `!stored.persistOnly`（truthy 判定）に変えると、truthy-but-not-true の 4 ケースが赤くなることを確認 → 戻した。

--- a/server/routes/tool-routes.ts
+++ b/server/routes/tool-routes.ts
@@ -5,6 +5,7 @@
 import type { Express } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
 import type { createToolStores } from "../session/tool-store.js";
+import { planToolResultUpdate } from "./toolResultPlan.js";
 
 export interface ToolRouteDeps {
   stores: ReturnType<typeof createToolStores>;
@@ -23,35 +24,15 @@ export function mountToolRoutes(app: Express, deps: ToolRouteDeps): void {
   // so the active panel renders/updates it live. Mirrors MulmoClaude's internal
   // toolResult route + applyToolResultToSession.
   app.post("/api/agent/toolResult", async (req, res) => {
-    const { sessionId, toolName, uuid } = req.body || {};
-    // The session id flows from env (broker) / the client and ends up in a pub/sub
-    // channel name — keep it to the known UUID shape.
-    if (!sessionId || !SESSION_ID_RE.test(sessionId)) {
-      return res.status(400).json({ error: "invalid sessionId" });
+    const plan = planToolResultUpdate(req.body);
+    if (!plan.ok) {
+      return res.status(400).json({ error: plan.error });
     }
-    if (typeof toolName !== "string" || !toolName) {
-      return res.status(400).json({ error: "invalid toolName" });
-    }
-    if (typeof uuid !== "string" || !uuid) {
-      return res.status(400).json({ error: "invalid uuid" });
-    }
+    await deps.stores.storeToolResult(plan.sessionId, plan.stored);
 
-    // Store everything except the routing fields; the result itself is the payload
-    // the panel renders.
-    // `persistOnly` (set by the GUI panel when a view persists its own state change)
-    // means: store, but do NOT re-publish on the session channel. Re-publishing would
-    // echo the update back to the originating panel as a fresh result, which re-seeds
-    // the view and re-emits — an infinite flicker loop. The broker (new tool calls)
-    // omits the flag, so its results still publish and render live.
-    const result = { ...req.body };
-    delete result.sessionId;
-    const persistOnly = result.persistOnly === true;
-    delete result.persistOnly;
-    await deps.stores.storeToolResult(sessionId, result);
-
-    if (!persistOnly) {
-      deps.publish(deps.sessionChannel(sessionId), result);
-      console.log(`[gui] toolResult ${toolName} for ${sessionId}`);
+    if (plan.publish) {
+      deps.publish(deps.sessionChannel(plan.sessionId), plan.stored);
+      console.log(`[gui] toolResult ${plan.toolName} for ${plan.sessionId}`);
     }
     res.json({ ok: true });
   });

--- a/server/routes/toolResultPlan.ts
+++ b/server/routes/toolResultPlan.ts
@@ -1,0 +1,39 @@
+// The decision behind POST /api/agent/toolResult, split from its I/O so it can be tested
+// without booting the server (#676). The route keeps the store write and the publish; this
+// only validates the body and decides what to store and whether to publish.
+import { SESSION_ID_RE } from "../config/env.js";
+import { isRecord } from "../session/transcript.js";
+import type { ToolResult } from "../session/types.js";
+
+export type ToolResultPlan = { ok: false; error: string } | { ok: true; stored: ToolResult; publish: boolean; sessionId: string; toolName: string };
+
+export function planToolResultUpdate(body: unknown): ToolResultPlan {
+  const source: Record<string, unknown> = isRecord(body) ? body : {};
+
+  const sessionId = source.sessionId;
+  // The id flows into a pub/sub channel name and a filename — keep it to the UUID shape.
+  if (typeof sessionId !== "string" || !SESSION_ID_RE.test(sessionId)) {
+    return { ok: false, error: "invalid sessionId" };
+  }
+  const toolName = source.toolName;
+  if (typeof toolName !== "string" || !toolName) {
+    return { ok: false, error: "invalid toolName" };
+  }
+  const uuid = source.uuid;
+  if (typeof uuid !== "string" || !uuid) {
+    return { ok: false, error: "invalid uuid" };
+  }
+
+  // Store everything except the routing fields; the rest is the payload the panel renders.
+  const stored: ToolResult = { ...source, uuid };
+  delete stored.sessionId;
+
+  // `persistOnly === true` means the GUI panel is persisting a view's own state change:
+  // store it, but do NOT re-publish. Re-publishing echoes the update back to the originating
+  // panel as a fresh result, which re-seeds the view and re-emits — an infinite flicker loop.
+  // The broker (new tool calls) omits the flag, so its results still publish and render live.
+  const publish = stored.persistOnly !== true;
+  delete stored.persistOnly;
+
+  return { ok: true, stored, publish, sessionId, toolName };
+}

--- a/test/server/routes/toolResultPlan.spec.ts
+++ b/test/server/routes/toolResultPlan.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+
+import { planToolResultUpdate } from "../../../server/routes/toolResultPlan.js";
+
+// A well-formed session id; the plan keeps it to the UUID shape because it becomes a
+// channel name and a filename.
+const SESSION_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const validBody = (extra: Record<string, unknown> = {}) => ({
+  sessionId: SESSION_ID,
+  toolName: "accounting",
+  uuid: "call-1",
+  ...extra,
+});
+
+// The plan is the decision the route used to inline: what to store, and whether to publish.
+// The route now only performs the store write and the publish it hands back.
+describe("planToolResultUpdate", () => {
+  it("accepts a well-formed body and publishes by default", () => {
+    const plan = planToolResultUpdate(validBody({ result: { rows: [] } }));
+    expect(plan).toEqual({
+      ok: true,
+      stored: { toolName: "accounting", uuid: "call-1", result: { rows: [] } },
+      publish: true,
+      sessionId: SESSION_ID,
+      toolName: "accounting",
+    });
+  });
+
+  it("strips the routing fields from what it stores", () => {
+    const plan = planToolResultUpdate(validBody({ persistOnly: false }));
+    if (!plan.ok) throw new Error("expected ok");
+    expect(plan.stored).not.toHaveProperty("sessionId");
+    expect(plan.stored).not.toHaveProperty("persistOnly");
+    // Everything else the panel renders is kept.
+    expect(plan.stored).toMatchObject({ toolName: "accounting", uuid: "call-1" });
+  });
+
+  it("suppresses the publish when the panel persists its own state (persistOnly === true)", () => {
+    const plan = planToolResultUpdate(validBody({ persistOnly: true }));
+    if (!plan.ok) throw new Error("expected ok");
+    expect(plan.publish).toBe(false);
+    expect(plan.stored).not.toHaveProperty("persistOnly");
+  });
+
+  // Only the strict boolean `true` suppresses the echo; anything else is a broker result
+  // that must render live. Pinned so a "truthy" rewrite (`!persistOnly`) is caught.
+  describe("a truthy-but-not-true persistOnly still publishes", () => {
+    it.each([
+      ['the string "true"', "true"],
+      ["the number 1", 1],
+      ["an object", {}],
+      ["an array", []],
+    ])("keeps publish=true for %s", (_label, persistOnly) => {
+      const plan = planToolResultUpdate(validBody({ persistOnly }));
+      if (!plan.ok) throw new Error("expected ok");
+      expect(plan.publish).toBe(true);
+    });
+  });
+
+  describe("rejects a bad sessionId before anything else", () => {
+    it.each([
+      ["missing", undefined],
+      ["empty string", ""],
+      ["a non-UUID string", "not-a-uuid"],
+      ["a uuid with trailing junk", `${SESSION_ID}x`],
+      ["a number", 123],
+      ["a boolean", true],
+      ["an object", {}],
+      // Coerces to the UUID string, but a non-string id is still rejected.
+      ["a single-element array of the uuid", [SESSION_ID]],
+    ])("returns invalid sessionId for %s", (_label, sessionId) => {
+      expect(planToolResultUpdate({ sessionId, toolName: "accounting", uuid: "call-1" })).toEqual({
+        ok: false,
+        error: "invalid sessionId",
+      });
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["a string", "nope"],
+      ["a number", 5],
+      ["an array", []],
+    ])("returns invalid sessionId for a non-record body: %s", (_label, body) => {
+      expect(planToolResultUpdate(body)).toEqual({ ok: false, error: "invalid sessionId" });
+    });
+  });
+
+  describe("rejects a bad toolName once the sessionId is valid", () => {
+    it.each([
+      ["missing", undefined],
+      ["empty string", ""],
+      ["a number", 7],
+      ["null", null],
+    ])("returns invalid toolName for %s", (_label, toolName) => {
+      expect(planToolResultUpdate({ sessionId: SESSION_ID, toolName, uuid: "call-1" })).toEqual({
+        ok: false,
+        error: "invalid toolName",
+      });
+    });
+  });
+
+  describe("rejects a bad uuid last", () => {
+    it.each([
+      ["missing", undefined],
+      ["empty string", ""],
+      ["a number", 7],
+      ["an object", {}],
+    ])("returns invalid uuid for %s", (_label, uuid) => {
+      expect(planToolResultUpdate({ sessionId: SESSION_ID, toolName: "accounting", uuid })).toEqual({
+        ok: false,
+        error: "invalid uuid",
+      });
+    });
+  });
+
+  // Validation order: a body wrong in two ways reports the first failure the route would
+  // have hit, so the messages match the original handler exactly.
+  it("reports sessionId before toolName", () => {
+    expect(planToolResultUpdate({ toolName: 1, uuid: 2 })).toEqual({ ok: false, error: "invalid sessionId" });
+  });
+
+  it("reports toolName before uuid", () => {
+    expect(planToolResultUpdate({ sessionId: SESSION_ID, uuid: 2 })).toEqual({ ok: false, error: "invalid toolName" });
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/agent/toolResult` inlined two decisions the tests never covered: which fields to store, and whether to re-publish on the session channel. This splits them into a pure `planToolResultUpdate(body)` in a new file so they can be tested without booting the server. The route now only performs the store write and the publish. **Behaviour, error messages, and validation order are unchanged** (1:1 with the original handler for every reachable input).

- New `server/routes/toolResultPlan.ts` → `planToolResultUpdate(body: unknown)`.
- `server/routes/tool-routes.ts` POST handler calls the plan, then does the I/O only. GET routes untouched.
- New `test/server/routes/toolResultPlan.spec.ts` pins the store-field selection, the `persistOnly === true` publish gate, and the validation order/messages.

Part of #676 (棚卸し第3弾・優先度A の A3).

## Items to Confirm / Review

1. **Deliberate, documented divergence (one unreachable input).** The original validated `sessionId` as `!sessionId || !SESSION_ID_RE.test(sessionId)` against an `any` body. `RegExp.test` string-coerces, so a **single-element array holding the UUID string** (`[uuid]`) coerced to a valid UUID and *passed*. The pure function returns `sessionId: string`, which (with the no-`as`-cast rule) requires a `typeof sessionId === "string"` narrow — so that array input now correctly returns `ok:false` (invalid sessionId). Real callers (broker / GUI) always send a string id, so this is unreachable in practice, and it matches the issue's stated intent (「非文字列 → ok:false」). Pinned as a test with the reason in a comment. Please confirm this is acceptable.
2. `planToolResultUpdate` returns `stored: ToolResult` (not `Record<string, unknown>`) so the route can pass it to `storeToolResult(sessionId, ToolResult)` without a cast — `uuid` is validated to be a non-empty string first. Adjusted from the issue's return-shape sketch, which noted the shape was tweakable to fit the current code.

## Signature

```ts
export type ToolResultPlan =
  | { ok: false; error: string }
  | { ok: true; stored: ToolResult; publish: boolean; sessionId: string; toolName: string };

export function planToolResultUpdate(body: unknown): ToolResultPlan;
```

`publish` is `stored.persistOnly !== true` — only the strict boolean `true` (the GUI panel persisting its own viewState) suppresses the re-publish, which would otherwise re-seed the originating panel and re-emit in an infinite flicker loop.

## Verification

- Mutation test: flipping `stored.persistOnly !== true` to a truthy `!stored.persistOnly` turns the four "truthy-but-not-true persistOnly still publishes" pins red (`"true"`, `1`, `{}`, `[]`); reverted to green.
- `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test` — all pass.
- `npx vitest run test/server/routes test/server/session/tool-store.spec.ts` — 89 passed.
- Prettier + ESLint clean on all changed files.

## User Prompt

> 全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した（#676）。その優先度A項目を実装する。
