### PR TITLE
refactor: extract the phone-push body rules (#676 B2)

### DIFF
--- a/plans/refactor-676-b2-task-push.md
+++ b/plans/refactor-676-b2-task-push.md
@@ -1,0 +1,48 @@
+# refactor: extract the phone-push body rules (#676 B2)
+
+## Context
+
+`server/session/task-push.ts` の `notifyTaskFinished` は、電話プッシュ本文を組み立てる際に
+3 つの判断を I/O に混ぜて持っていた:
+
+```ts
+if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
+const cwd = ptys.get(sessionId)?.cwd ?? null;
+const where = cwd ? path.basename(cwd) : "session";
+...
+const detail = reply || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+```
+
+1. **detail の優先順位** `reply || lastPrompt || aiTitle || ""` — 「エージェントが何をしたか
+   = 返信」を最優先し、無ければ last prompt → AI title の順にフォールバック。空文字を飛ばす
+   `||` セマンティクスが load-bearing。
+2. **抑制ゲート** `hidden || translationWorker` — 隠しバックグラウンドワーカーと翻訳ワーカーは
+   実ユーザタスクではないのでプッシュしない。
+3. **where 表示** `cwd ? basename(cwd) : "session"` — 作業ディレクトリの basename、無ければ
+   sentinel。
+
+いずれも pure な判断だが未抽出・未テストだった (#676 優先度 B2)。
+
+## 変更
+
+- 新ファイル `server/session/taskPushRules.ts` に pure 関数 3 つを切り出し:
+  - `buildPushDetail(input: { reply: string | null; lastPrompt: string | undefined; aiTitle: string | undefined }): string`
+    — 型は元の値に忠実(`latestReply` は `string | null`、Map の `.get` は `string | undefined`)。
+  - `shouldSuppressPush(hidden: boolean, translationWorker: boolean): boolean`
+  - `pushWhere(cwd: string | null): string`(`NO_CWD_LABEL = "session"` を named const として公開、`node:path` の basename を使用)
+  - すべて **挙動不変**。
+- `notifyTaskFinished` は I/O(config 読み・PTY 参照・transcript 読み・sendWebPush)だけ残し、
+  この 3 関数を呼ぶ。task-push.ts から `node:path` import を削除(唯一の利用箇所が移動したため)。
+- テスト `test/server/session/taskPushRules.spec.ts`:
+  - buildPushDetail: 各段優先 / 空文字・undefined スキップ / 全無し → ""
+  - shouldSuppressPush: hidden / translationWorker / 両方 / どちらでもない
+  - pushWhere: パスあり → basename、null → sentinel
+
+## 検証
+
+- 変異テスト:
+  - `shouldSuppressPush` の `||` → `&&` に変えると「hidden のみ / worker のみ」が赤になることを確認して戻す。
+  - `buildPushDetail` の優先順を入れ替えると対応テストが赤になることを確認して戻す。
+- `prettier --write` / `eslint` / `typecheck`(vue-tsc -b)/ `typecheck:server`(tsc -p tsconfig.server.json)/
+  `typecheck:test`(vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json)/
+  `vitest run test/server/session`。

--- a/server/session/task-push.ts
+++ b/server/session/task-push.ts
@@ -3,13 +3,13 @@
 // boundaries off its rollout (no hooks exist to POST for it), and a codex turn has to
 // reach the same notification, or the phone stays silent for half the grid.
 
-import path from "node:path";
 import { getPushEnabled } from "../config/config-routes.js";
 import { sendWebPush } from "../infra/web-push.js";
 import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
 import { buildPushText, type PushKind } from "./activity-hook.js";
 import { aiTitles, hiddenSessions, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
 import { sessionLastTurn, LAST_RESPONSE_MAX } from "./session-reads.js";
+import { buildPushDetail, pushWhere, shouldSuppressPush } from "./taskPushRules.js";
 
 const PUSH_TITLE_MAX = 80;
 const PUSH_BODY_MAX = 160;
@@ -34,14 +34,14 @@ async function latestReply(sessionId: string, cwd: string): Promise<string | nul
 // Fire-and-forget; sendWebPush no-ops when RemoteHost (its Firebase auth) isn't connected.
 export async function notifyTaskFinished(sessionId: string, kind: PushKind, message: string, uiPort: string): Promise<void> {
   if (!getPushEnabled()) return;
-  // Internal helper turns flow through /api/hook with active=false too — hidden background
-  // workers and translation workers aren't real user tasks, so never push for them.
-  if (hiddenSessions.has(sessionId) || translationWorkerIds.has(sessionId)) return;
+  // Internal helper turns flow through /api/hook with active=false too — the suppression gate
+  // keeps those (hidden background workers, translation workers) from ever reaching the phone.
+  if (shouldSuppressPush(hiddenSessions.has(sessionId), translationWorkerIds.has(sessionId))) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
-  const where = cwd ? path.basename(cwd) : "session";
+  const where = pushWhere(cwd);
   const reply = kind === "finished" && cwd ? await latestReply(sessionId, cwd) : null;
   if (reply) lastResponses.set(sessionId, reply); // keep the roster in step; we just read it
-  const detail = reply || lastPrompts.get(sessionId) || aiTitles.get(sessionId) || "";
+  const detail = buildPushDetail({ reply, lastPrompt: lastPrompts.get(sessionId), aiTitle: aiTitles.get(sessionId) });
   const { title, body } = buildPushText(kind, where, detail, message, { title: PUSH_TITLE_MAX, body: PUSH_BODY_MAX });
   // The session id is what lets the phone open this session from the notification;
   // the host id is what lets it know WHOSE session. Without it the phone opens with

--- a/server/session/taskPushRules.ts
+++ b/server/session/taskPushRules.ts
@@ -1,0 +1,33 @@
+// The three decisions the phone-push body rests on, pulled out of notifyTaskFinished so the
+// precedence, the suppression gate, and the location label can each be tested without a PTY,
+// a config read, or a transcript on disk. All pure — the caller keeps the I/O.
+
+import path from "node:path";
+
+export interface PushDetailInput {
+  reply: string | null;
+  lastPrompt: string | undefined;
+  aiTitle: string | undefined;
+}
+
+export const NO_CWD_LABEL = "session";
+
+// A finished turn should say what the agent DID, so the reply wins; the last prompt and the AI
+// title are fallbacks for when there is no reply (a blocked turn, or a read that came back
+// empty). `||`, not `??`: every tier is a string that must be SKIPPED when empty — an empty
+// reply means "nothing to report about the outcome", not a value to pin as the body.
+export function buildPushDetail(input: PushDetailInput): string {
+  return input.reply || input.lastPrompt || input.aiTitle || "";
+}
+
+// Hidden background workers and translation workers aren't real user tasks, so a turn ending
+// on one must never reach the phone.
+export function shouldSuppressPush(hidden: boolean, translationWorker: boolean): boolean {
+  return hidden || translationWorker;
+}
+
+// Where the turn happened, for the notification: the working directory's basename, or a
+// sentinel when the session was spawned without one.
+export function pushWhere(cwd: string | null): string {
+  return cwd ? path.basename(cwd) : NO_CWD_LABEL;
+}

--- a/test/server/session/taskPushRules.spec.ts
+++ b/test/server/session/taskPushRules.spec.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { buildPushDetail, pushWhere, shouldSuppressPush, NO_CWD_LABEL } from "../../../server/session/taskPushRules.js";
+
+describe("buildPushDetail", () => {
+  it("prefers the reply over the last prompt and the AI title", () => {
+    expect(buildPushDetail({ reply: "did the thing", lastPrompt: "do the thing", aiTitle: "the thing" })).toBe("did the thing");
+  });
+
+  it("falls back to the last prompt when there is no reply", () => {
+    expect(buildPushDetail({ reply: null, lastPrompt: "do the thing", aiTitle: "the thing" })).toBe("do the thing");
+  });
+
+  it("falls back to the AI title when there is neither reply nor last prompt", () => {
+    expect(buildPushDetail({ reply: null, lastPrompt: undefined, aiTitle: "the thing" })).toBe("the thing");
+  });
+
+  // `||`, not `??`: an empty string at any tier means "nothing usable here", so it is skipped
+  // rather than pinned as the body.
+  it("skips an empty-string reply and takes the last prompt", () => {
+    expect(buildPushDetail({ reply: "", lastPrompt: "do the thing", aiTitle: "the thing" })).toBe("do the thing");
+  });
+
+  it("skips an empty-string last prompt and takes the AI title", () => {
+    expect(buildPushDetail({ reply: null, lastPrompt: "", aiTitle: "the thing" })).toBe("the thing");
+  });
+
+  it("returns the empty string when nothing is present", () => {
+    expect(buildPushDetail({ reply: null, lastPrompt: undefined, aiTitle: undefined })).toBe("");
+  });
+
+  it("returns the empty string when every tier is empty", () => {
+    expect(buildPushDetail({ reply: "", lastPrompt: "", aiTitle: "" })).toBe("");
+  });
+});
+
+describe("shouldSuppressPush", () => {
+  it("suppresses when the session is hidden", () => {
+    expect(shouldSuppressPush(true, false)).toBe(true);
+  });
+
+  it("suppresses when the session is a translation worker", () => {
+    expect(shouldSuppressPush(false, true)).toBe(true);
+  });
+
+  it("suppresses when both flags are set", () => {
+    expect(shouldSuppressPush(true, true)).toBe(true);
+  });
+
+  it("does not suppress a real user task", () => {
+    expect(shouldSuppressPush(false, false)).toBe(false);
+  });
+});
+
+describe("pushWhere", () => {
+  it("uses the working directory's basename when a cwd is present", () => {
+    expect(pushWhere("/Users/isamu/ss/llm/mulmoterminal2")).toBe("mulmoterminal2");
+  });
+
+  it("falls back to the sentinel label when there is no cwd", () => {
+    expect(pushWhere(null)).toBe(NO_CWD_LABEL);
+    expect(pushWhere(null)).toBe("session");
+  });
+});


### PR DESCRIPTION
## Summary

`server/session/task-push.ts` の `notifyTaskFinished` が I/O に混ぜて持っていた電話プッシュ本文の 3 つの純粋な判断を、新ファイル `server/session/taskPushRules.ts` に切り出しました。挙動不変(behaviour-preserving)で、呼び出し側は I/O(config 読み・PTY 参照・transcript 読み・`sendWebPush`)を保持したまま判断だけを委譲します。

- `buildPushDetail({ reply, lastPrompt, aiTitle }): string` — `reply || lastPrompt || aiTitle || ""`。「エージェントが何をしたか=返信」を最優先。空文字を飛ばす `||` セマンティクスを維持。
- `shouldSuppressPush(hidden, translationWorker): boolean` — `hidden || translationWorker`。隠しバックグラウンドワーカー/翻訳ワーカーはプッシュしない。
- `pushWhere(cwd): string` — `cwd ? basename(cwd) : "session"`(`NO_CWD_LABEL` を named const で公開)。

型は元の値に忠実:`latestReply` は `string | null`、Map の `.get` は `string | undefined`、`cwd` は `string | null`。`task-push.ts` からは唯一の利用箇所が移ったため `node:path` import を削除。

## Items to Confirm / Review

- **挙動不変の確認**: 3 関数はいずれも元の式をそのまま移設しただけ。特に `detail` の `||`(空文字スキップ)を `??` に変えていないこと。
- **抑制ゲートのコメント**: `/api/hook` 経由で `active=false` の内部ヘルパーターンが流れてくるという WHY を呼び出し側コメントに残しています。
- **変異テスト結果**(下記)で各テストが対応する破壊を捕捉することを確認済み。

## User Prompt

> #676 の優先度B項目を実装する。

(本 PR は #676 の B2: `task-push.ts` の電話プッシュ本文 3 判断の pure 関数抽出。)

## テスト

`test/server/session/taskPushRules.spec.ts`(13 ケース):
- `buildPushDetail`: 各段優先 / 空文字・undefined スキップ / 全無し → `""`
- `shouldSuppressPush`: hidden のみ / worker のみ / 両方 / どちらでもない
- `pushWhere`: パスあり → basename、null → sentinel

### 変異テスト(赤化確認済み)
- `shouldSuppressPush` の `||` → `&&`: 「hidden のみ」「worker のみ」の 2 ケースが赤 → 戻して緑。
- `buildPushDetail` の優先順入替(`lastPrompt || reply || ...`):「prefers the reply over the last prompt」が赤 → 戻して緑。

### 検証コマンド(全て green)
- `prettier --write` / `eslint`
- `typecheck`(vue-tsc -b)/ `typecheck:server`(tsc -p tsconfig.server.json)/ `typecheck:test`(vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json)
- `vitest run test/server/session` — 43 files / 775 tests passed

Part of #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
