### PR TITLE
fix(#676 B1): adopt the first inline image in image-gen (data + MIME atomically)

### DIFF
--- a/plans/fix-676-b1-image-gen-first.md
+++ b/plans/fix-676-b1-image-gen-first.md
@@ -1,0 +1,57 @@
+# fix(#676 B1): adopt the FIRST inline image (data + MIME atomically) in image-gen
+
+Part of #676. Priority-B item B1.
+
+## Problem
+
+`server/backends/image-gen.ts` reduced the Gemini response `parts` inline. Its comment
+claimed it took "the first inline image", but the `for` loop had no `break`, so each
+image part overwrote the previous one and the **last** image actually won. Worse, `imageData`
+and `mimeType` were tracked independently: an allowed-MIME image followed by a
+disallowed-MIME image left `imageData` pointing at the last part while `mimeType` kept an
+earlier value (or vice versa), so the emitted `data:` URL could pair one part's bytes with
+another part's MIME — a desync. The whole thing was reachable only through a live Gemini
+call, so it was untested.
+
+## Change
+
+Extract the decision into a new pure module `server/backends/imageResult.ts` and have
+`image-gen.ts` call it right after the `ai.models.generateContent` I/O.
+
+Public API:
+
+- `extractImageResult(parts: Part[]): { imageData?: string; mimeType: string; text?: string }`
+  — adopts the FIRST inline image and reads its `data` and `mimeType` from that **same**
+  part (via `Array.find`), so the two can never desync. `text` is the FIRST text part, for
+  the same first-wins consistency.
+- `ALLOWED_IMAGE_MIME` — the safe image MIME allowlist (png/jpeg/webp/gif), moved here from
+  `image-gen.ts` (it had no other consumer).
+
+The MIME comes from the untrusted model response and is embedded into a `data:` URL, so when
+the first image's MIME is outside the allowlist we fall back to `"image/png"` — but the bytes
+stay that same part's, preserving atomicity. Behavior decision (first-wins) was confirmed
+with the user; it matches the file's own comment and the MulmoClaude `gemini.ts#extractImageResult`
+mirror the file claims to follow.
+
+## Tests
+
+`test/server/backends/imageResult.spec.ts`:
+
+- single image + text → correct `{ imageData, mimeType, text }` data-URL material.
+- multiple images → the FIRST is adopted (pinned distinct from the second's bytes and MIME).
+- first image's MIME outside the allowlist → `mimeType` is `"image/png"` while `imageData`
+  is **that same disallowed part's** bytes (the desync regression guard).
+- no image → `imageData` undefined, text returned.
+- an `inlineData` part with no `data` is not treated as an image.
+- empty-string text part is skipped in favor of a later real one (truthiness parity).
+- no text / empty parts.
+
+## Mutation check
+
+Changing `parts.find(...)` to `parts.findLast(...)` for the image part (i.e. last-wins,
+the pre-fix behavior) turned the "adopts the FIRST image" test red; reverted after confirming.
+
+## Verification
+
+`prettier --write` + `eslint` on the touched/new files; `typecheck`, `typecheck:server`,
+`typecheck:test`; `vitest run test/server/backends`.

--- a/server/backends/image-gen.ts
+++ b/server/backends/image-gen.ts
@@ -9,6 +9,7 @@
 // binds that straight into `<img src>`, so MulmoTerminal needs no image storage or
 // serving route. Mirrors MulmoClaude's server/utils/gemini.ts (same model + config).
 import { GoogleGenAI } from "@google/genai";
+import { extractImageResult } from "./imageResult.js";
 
 // Mirrors MulmoClaude's default. This is a PREVIEW model Google schedules for
 // retirement (~mid-2026); override with GEMINI_IMAGE_MODEL to pin a stable model
@@ -18,10 +19,6 @@ const DEFAULT_IMAGE_CONFIG = {
   responseModalities: ["TEXT", "IMAGE"],
   imageConfig: { aspectRatio: "16:9" },
 };
-
-// The MIME type comes from the (untrusted) model response and is embedded into a
-// `data:` URL, so constrain it to a safe image allowlist and default to PNG.
-const ALLOWED_IMAGE_MIME = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
 
 let client: GoogleGenAI | null = null;
 function getClient() {
@@ -48,21 +45,8 @@ export async function generateImage(prompt: string) {
     return { message: `Image generation failed: ${e instanceof Error ? e.message : String(e)}` };
   }
 
-  // Reduce the response parts to the first inline image + any text (mirrors
-  // gemini.ts#extractImageResult).
   const parts = response?.candidates?.[0]?.content?.parts ?? [];
-  let imageData;
-  let mimeType = "image/png";
-  let text;
-  for (const part of parts) {
-    if (part.inlineData?.data) {
-      imageData = part.inlineData.data;
-      const mt = part.inlineData.mimeType;
-      if (mt && ALLOWED_IMAGE_MIME.has(mt)) mimeType = mt;
-    } else if (part.text) {
-      text = part.text;
-    }
-  }
+  const { imageData, mimeType, text } = extractImageResult(parts);
 
   if (!imageData) {
     return { message: text || "Gemini returned no image (the prompt may have been filtered)." };

--- a/server/backends/imageResult.ts
+++ b/server/backends/imageResult.ts
@@ -1,0 +1,28 @@
+import type { Part } from "@google/genai";
+
+// The MIME type comes from the (untrusted) model response and is embedded into a
+// `data:` URL, so constrain it to a safe image allowlist and default to PNG.
+export const ALLOWED_IMAGE_MIME = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+
+const DEFAULT_IMAGE_MIME = "image/png";
+
+export type ImageResult = {
+  imageData?: string;
+  mimeType: string;
+  text?: string;
+};
+
+const safeMimeType = (mimeType: string | undefined): string => (mimeType && ALLOWED_IMAGE_MIME.has(mimeType) ? mimeType : DEFAULT_IMAGE_MIME);
+
+// Take the FIRST inline image together with its OWN mimeType, so a `data:` URL can
+// never pair one part's bytes with another part's MIME. When that image's MIME is
+// outside the allowlist we fall back to PNG, but the bytes stay that same part's.
+export const extractImageResult = (parts: Part[]): ImageResult => {
+  const imagePart = parts.find((part) => part.inlineData?.data);
+  const textPart = parts.find((part) => part.text);
+  return {
+    imageData: imagePart?.inlineData?.data,
+    mimeType: safeMimeType(imagePart?.inlineData?.mimeType),
+    text: textPart?.text,
+  };
+};

--- a/test/server/backends/imageResult.spec.ts
+++ b/test/server/backends/imageResult.spec.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import type { Part } from "@google/genai";
+
+import { extractImageResult, ALLOWED_IMAGE_MIME } from "../../../server/backends/imageResult.js";
+
+const imagePart = (data: string, mimeType?: string): Part => ({ inlineData: { data, mimeType } });
+const textPart = (text: string): Part => ({ text });
+
+describe("extractImageResult", () => {
+  it("returns the data + mime of a single image alongside its text", () => {
+    const result = extractImageResult([imagePart("AAA", "image/jpeg"), textPart("a caption")]);
+    expect(result).toEqual({ imageData: "AAA", mimeType: "image/jpeg", text: "a caption" });
+  });
+
+  // The desync bug embedded one part's bytes under another part's MIME; the fix must
+  // keep the FIRST image's data and MIME together.
+  it("adopts the FIRST image when several are present, not the last", () => {
+    const result = extractImageResult([imagePart("FIRST", "image/png"), imagePart("SECOND", "image/webp")]);
+    expect(result.imageData).toBe("FIRST");
+    expect(result.mimeType).toBe("image/png");
+    expect(result.imageData).not.toBe("SECOND");
+  });
+
+  it("falls back to image/png when the first image's MIME is outside the allowlist, keeping that same part's bytes", () => {
+    expect(ALLOWED_IMAGE_MIME.has("image/svg+xml")).toBe(false);
+    const result = extractImageResult([imagePart("DODGY", "image/svg+xml"), imagePart("SAFE", "image/png")]);
+    expect(result.mimeType).toBe("image/png");
+    expect(result.imageData).toBe("DODGY");
+  });
+
+  it("adopts the FIRST text when several are present", () => {
+    const result = extractImageResult([textPart("first"), textPart("second")]);
+    expect(result.text).toBe("first");
+  });
+
+  it("returns imageData undefined and the text when there is no image", () => {
+    const result = extractImageResult([textPart("only words")]);
+    expect(result.imageData).toBeUndefined();
+    expect(result.mimeType).toBe("image/png");
+    expect(result.text).toBe("only words");
+  });
+
+  it("leaves text undefined when no part carries text", () => {
+    const result = extractImageResult([imagePart("AAA", "image/png")]);
+    expect(result.text).toBeUndefined();
+  });
+
+  // An image part missing its data is not a usable image.
+  it("ignores an inlineData part with no data", () => {
+    const result = extractImageResult([{ inlineData: { mimeType: "image/png" } }, textPart("hi")]);
+    expect(result.imageData).toBeUndefined();
+    expect(result.text).toBe("hi");
+  });
+
+  // Empty string is falsy, matching the original truthiness check — an empty text part
+  // must not shadow a later real one.
+  it("skips an empty-string text part and takes the next real one", () => {
+    const result = extractImageResult([textPart(""), textPart("real")]);
+    expect(result.text).toBe("real");
+  });
+
+  it("returns imageData/text undefined and the PNG default for empty parts", () => {
+    const result = extractImageResult([]);
+    expect(result).toEqual({ imageData: undefined, mimeType: "image/png", text: undefined });
+  });
+});


### PR DESCRIPTION
## Summary

`server/backends/image-gen.ts` reduced the Gemini response `parts` inline. Its comment claimed it took the *first* inline image, but the `for` loop had no `break`, so the **last** image actually won; and `imageData` / `mimeType` were tracked independently, so an allowed-MIME image followed by a disallowed-MIME one could emit a `data:` URL that pairs **one part's bytes with another part's MIME** (a desync). The logic was only reachable through a live Gemini call, so it was untested.

This PR extracts the decision into a pure, tested module `server/backends/imageResult.ts`:

- `extractImageResult(parts): { imageData?: string; mimeType: string; text?: string }` — takes the **first** inline image and reads its `data` and `mimeType` from that **same** part (via `Array.find`), so the two can never desync. `text` is the first text part, for the same first-wins consistency. When the first image's MIME is outside the allowlist it falls back to `"image/png"`, but the bytes stay that same part's.
- `ALLOWED_IMAGE_MIME` — moved here from `image-gen.ts` (it had no other consumer).

`image-gen.ts` now calls `extractImageResult(parts)` right after the `ai.models.generateContent` I/O; the I/O stays in the caller.

## Items to Confirm / Review

- **Behavior decision (first-wins) was confirmed with the user.** It matches the file's own comment and the MulmoClaude `gemini.ts#extractImageResult` mirror the file claims to follow.
- **Image and text are found independently** (first image part, first text part). The original used `if/else if`, so a single part carrying *both* inline image and text would have contributed only its image; now such a part's text can also be picked up as the first text. Gemini returns image and text in separate parts, and no test exercises the both-in-one-part case, but flagging the semantic nuance.
- **Functional style over a `for`+`break`:** per the repo's coding rules the pure function uses `Array.find` rather than a loop with `break`. The equivalent "first→last" mutation is `find` → `findLast`.

## Mutation check

Changing the image-part `find` to `findLast` (last-wins, the pre-fix behavior) turned the "adopts the FIRST image" and the desync-fallback tests red; reverted after confirming. All other tests stayed green.

## Verification

`prettier --write` + `eslint` on the touched/new files. All three typechecks pass: `typecheck` (`vue-tsc -b`), `typecheck:server` (`tsc -p tsconfig.server.json`), `typecheck:test` (`vue-tsc -p tsconfig.test.json --noEmit` && `tsc -p tsconfig.test-server.json`). `vitest run test/server/backends` — 28 files / 377 tests pass, including the 9 new `imageResult.spec.ts` cases.

## User Prompt

#676 の優先度B項目を実装する（挙動判断はユーザ確認済み: 最初の画像を採用）。

Part of #676