### PR TITLE
refactor: extract partitionPending pure function (#676 B3)

### DIFF
--- a/plans/refactor-676-b3-partition-pending.md
+++ b/plans/refactor-676-b3-partition-pending.md
@@ -1,0 +1,51 @@
+# refactor: extract partitionPending pure function (#676 B3)
+
+## Context
+
+`server/session/session-reads.ts` の `collectPendingSessions` は、in-memory の pending
+セッション群を「ディスクに載ったものは剪定、それ以外はサイドバー行に積む」判断と、
+その副作用(**iterate 中の `knownSessions.delete`**)を同居させていた:
+
+```ts
+for (const [id, meta] of includePending ? knownSessions : []) {
+  if (onDisk.has(id)) {
+    knownSessions.delete(id); // 純判断の途中で破壊的 side-effect
+    continue;
+  }
+  pending.push({ kind: "pending", id, title: meta.title, mtime: meta.createdAt, ... });
+}
+```
+
+判断は pure 関数として未抽出・未テストだった (#676 優先度 B3、テスト 0)。壊れると
+ディスクに載った session の剪定が狂い、サイドバーに古い pending 行が残る/消える。
+
+## 変更
+
+- 新ファイル `server/session/partitionPending.ts` に pure 関数 `partitionPending` を切り出し。
+  - シグネチャ: `partitionPending(known: Iterable<[string, KnownSession]>, onDisk: Set<string>, activityOf, isHidden): { keep: PendingSession[]; persisted: string[] }`
+  - `keep` = pending に積む `PendingSession`(入力順を保持)、`persisted` = onDisk に載っていて
+    `knownSessions` から消すべき id。
+  - `working/waiting/event` の解決(`activity.get(id)`)と `hidden`(`hiddenSessions.has(id)`)は
+    純度を保つため関数 `activityOf`/`isHidden` として**注入**する。元と同じ `?? false` / `?? null`
+    デフォルトを維持。
+- `collectPendingSessions` は `includePending ? knownSessions : []` を `known` として渡し、
+  `partitionPending` を呼ぶ。返った `persisted` を使って `knownSessions.delete(id)`(= 書き込み I/O)
+  を呼び出し側で行い、`keep` をそのまま返す。**挙動不変**(iterate 中 delete → iterate 後 delete は、
+  訪問集合・削除集合ともに同一)。
+
+## テスト `test/server/session/partitionPending.spec.ts`
+
+- onDisk に載る id → `persisted` に入り `keep` に入らない
+- 載らない id → `keep` に `PendingSession` として積む(全フィールドの形を検証)
+- 注入した activity/hidden から `working/waiting/event/hidden` を導出
+- 空 known / 全部 onDisk / 混在
+- keep・persisted の順序保持
+- 生の `Map` iterable も受ける
+
+## 検証
+
+- 変異テスト: `if (onDisk.has(id))` を `if (!onDisk.has(id))` に反転 → spec の 8 件中 7 件が赤に
+  なることを確認して戻す。
+- `prettier --write` / `eslint` / `typecheck`(`vue-tsc -b`)/ `typecheck:server` /
+  `typecheck:test`(`vue-tsc -p tsconfig.test.json --noEmit` + `tsc -p tsconfig.test-server.json`)/
+  `vitest run test/server/session`(43 files / 770 tests green)。

--- a/server/session/partitionPending.ts
+++ b/server/session/partitionPending.ts
@@ -1,0 +1,39 @@
+// Split in-memory (pending) sessions against what disk already holds: a session disk has
+// persisted is pruned (its on-disk record, with the real title, wins), everything else is a
+// pending sidebar row. Kept pure — the knownSessions delete (a write) and the activity/hidden
+// lookups stay injectable so the decision can be tested without the live registry.
+import type { Activity, KnownSession, PendingSession } from "./types.js";
+
+export interface PartitionPendingResult {
+  keep: PendingSession[]; // pending rows to show, input order preserved
+  persisted: string[]; // ids the caller should delete from knownSessions
+}
+
+function toPendingRow(id: string, meta: KnownSession, activityOf: (id: string) => Activity | undefined, isHidden: (id: string) => boolean): PendingSession {
+  const a = activityOf(id);
+  return {
+    kind: "pending",
+    id,
+    title: meta.title,
+    mtime: meta.createdAt,
+    working: a?.working ?? false,
+    waiting: a?.waiting ?? false,
+    event: a?.event ?? null,
+    hidden: isHidden(id),
+  };
+}
+
+export function partitionPending(
+  known: Iterable<[string, KnownSession]>,
+  onDisk: Set<string>,
+  activityOf: (id: string) => Activity | undefined,
+  isHidden: (id: string) => boolean,
+): PartitionPendingResult {
+  const keep: PendingSession[] = [];
+  const persisted: string[] = [];
+  for (const [id, meta] of known) {
+    if (onDisk.has(id)) persisted.push(id);
+    else keep.push(toPendingRow(id, meta, activityOf, isHidden));
+  }
+  return { keep, persisted };
+}

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -36,6 +36,7 @@ import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRolloutIds, hiddenSessions, knownSessions } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
 import { lastTurnFromClaudeParsed, lastTurnFromCodexRollout, EMPTY_TURN, type LastTurn } from "./last-turn.js";
+import { partitionPending } from "./partitionPending.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import type { DiskStat, PendingSession, SessionMeta } from "./types.js";
@@ -244,22 +245,13 @@ export async function collectOnDiskSessionStats(dir: string, files: string[]): P
 // In-memory sessions not yet written to disk. Prune (delete from knownSessions) any that
 // have since been persisted — the on-disk record (with its real title) wins.
 export function collectPendingSessions(onDisk: Set<string>, includePending: boolean): PendingSession[] {
-  const pending: PendingSession[] = [];
-  for (const [id, meta] of includePending ? knownSessions : []) {
-    if (onDisk.has(id)) {
-      knownSessions.delete(id);
-      continue;
-    }
-    pending.push({
-      kind: "pending",
-      id,
-      title: meta.title,
-      mtime: meta.createdAt,
-      working: activity.get(id)?.working ?? false,
-      waiting: activity.get(id)?.waiting ?? false,
-      event: activity.get(id)?.event ?? null,
-      hidden: hiddenSessions.has(id),
-    });
-  }
-  return pending;
+  const known = includePending ? knownSessions : [];
+  const { keep, persisted } = partitionPending(
+    known,
+    onDisk,
+    (id) => activity.get(id),
+    (id) => hiddenSessions.has(id),
+  );
+  persisted.forEach((id) => knownSessions.delete(id));
+  return keep;
 }

--- a/test/server/session/partitionPending.spec.ts
+++ b/test/server/session/partitionPending.spec.ts
@@ -1,0 +1,87 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { partitionPending } from "../../../server/session/partitionPending.js";
+import type { Activity, KnownSession } from "../../../server/session/types.js";
+
+const meta = (title: string, createdAt: number): KnownSession => ({ title, createdAt });
+
+// Default resolvers: nothing active, nothing hidden — isolates the partition decision.
+const noActivity = (): Activity | undefined => undefined;
+const noneHidden = (): boolean => false;
+
+describe("partitionPending", () => {
+  it("routes an id that disk already holds into persisted and never into keep", () => {
+    const known: [string, KnownSession][] = [["a", meta("A", 1)]];
+    const { keep, persisted } = partitionPending(known, new Set(["a"]), noActivity, noneHidden);
+    expect(persisted).toEqual(["a"]);
+    expect(keep).toEqual([]);
+  });
+
+  it("builds a full pending row for an id that is not on disk", () => {
+    const known: [string, KnownSession][] = [["b", meta("Draft", 42)]];
+    const { keep, persisted } = partitionPending(known, new Set(), noActivity, noneHidden);
+    expect(persisted).toEqual([]);
+    expect(keep).toEqual([{ kind: "pending", id: "b", title: "Draft", mtime: 42, working: false, waiting: false, event: null, hidden: false }]);
+  });
+
+  it("derives working/waiting/event from the injected activity and hidden from isHidden", () => {
+    const activity = new Map<string, Activity>([["b", { working: true, waiting: true, event: "Stop" }]]);
+    const hidden = new Set(["b"]);
+    const { keep } = partitionPending(
+      [["b", meta("Draft", 7)]],
+      new Set(),
+      (id) => activity.get(id),
+      (id) => hidden.has(id),
+    );
+    expect(keep[0]).toMatchObject({ working: true, waiting: true, event: "Stop", hidden: true });
+  });
+
+  it("returns empty keep and persisted for empty known", () => {
+    expect(partitionPending([], new Set(["a"]), noActivity, noneHidden)).toEqual({ keep: [], persisted: [] });
+  });
+
+  it("puts every id in persisted when they are all on disk", () => {
+    const known: [string, KnownSession][] = [
+      ["a", meta("A", 1)],
+      ["b", meta("B", 2)],
+    ];
+    const { keep, persisted } = partitionPending(known, new Set(["a", "b"]), noActivity, noneHidden);
+    expect(keep).toEqual([]);
+    expect(persisted).toEqual(["a", "b"]);
+  });
+
+  it("splits a mixed set into keep and persisted", () => {
+    const known: [string, KnownSession][] = [
+      ["a", meta("A", 1)],
+      ["b", meta("B", 2)],
+      ["c", meta("C", 3)],
+    ];
+    const { keep, persisted } = partitionPending(known, new Set(["b"]), noActivity, noneHidden);
+    expect(persisted).toEqual(["b"]);
+    expect(keep.map((r) => r.id)).toEqual(["a", "c"]);
+  });
+
+  it("preserves input order in both keep and persisted", () => {
+    const known: [string, KnownSession][] = [
+      ["k1", meta("1", 1)],
+      ["p1", meta("2", 2)],
+      ["k2", meta("3", 3)],
+      ["p2", meta("4", 4)],
+      ["k3", meta("5", 5)],
+    ];
+    const { keep, persisted } = partitionPending(known, new Set(["p1", "p2"]), noActivity, noneHidden);
+    expect(keep.map((r) => r.id)).toEqual(["k1", "k2", "k3"]);
+    expect(persisted).toEqual(["p1", "p2"]);
+  });
+
+  it("consumes a live Map iterable, not just an array of tuples", () => {
+    const known = new Map<string, KnownSession>([
+      ["a", meta("A", 1)],
+      ["b", meta("B", 2)],
+    ]);
+    const { keep, persisted } = partitionPending(known, new Set(["a"]), noActivity, noneHidden);
+    expect(persisted).toEqual(["a"]);
+    expect(keep.map((r) => r.id)).toEqual(["b"]);
+  });
+});


### PR DESCRIPTION
## Summary

`server/session/session-reads.ts` の `collectPendingSessions`(#676 B3、テスト 0)から
純判断を `server/session/partitionPending.ts` に切り出した。`partitionPending` は known
セッションを `keep`(積む `PendingSession`)と `persisted`(ディスクに載っていて
`knownSessions` から消すべき id)に**純粋に**分割し、`knownSessions.delete`(書き込み)は
呼び出し側に残す。iterate 中 delete → iterate 後 delete で挙動は不変。8 件の unit test を追加。

## Items to Confirm / Review

- **注入した 2 引数(`activityOf` / `isHidden`)**: タスクの示したシグネチャは
  `partitionPending(known, onDisk)` の 2 引数だが、`keep` を**フル `PendingSession[]`** として
  返す(呼び出し側は `keep` をそのまま return)には `working/waiting/event`(`activity.get(id)`)と
  `hidden`(`hiddenSessions.has(id)`)の解決が必要。これらをモジュール singleton として import
  すると純度・テスト容易性(#676 の主目的)が失われるため、関数引数として**注入**した。
  → 挙動不変・純関数・テスト可能を同時に満たすための判断。この 2 引数追加が妥当かご確認ください。
- **挙動不変性**: 元は Map iterate 中に `delete` していたのを、iterate 後にまとめて `delete` する
  形へ変更。訪問集合・削除集合はともに同一で等価(元は各エントリを訪問直後にのみ削除するため
  全エントリを訪問する)。
- `includePending` のゲートは呼び出し側に残し、`includePending ? knownSessions : []` を `known`
  として渡す(元と同じ式)。

## User Prompt

> #676 の優先度B項目を実装する。

(本 PR はそのうち **B3** = `collectPendingSessions` の `partitionPending` 切り出しを担当。)

## 変更

- `server/session/partitionPending.ts`(新規): `partitionPending(known, onDisk, activityOf, isHidden)`
  → `{ keep: PendingSession[]; persisted: string[] }`。行の組み立ては `toPendingRow` に分離。
- `server/session/session-reads.ts`: `collectPendingSessions` は `partitionPending` を呼び、
  `persisted` を使って `knownSessions.delete(id)` を実行、`keep` を返すだけに。
- `test/server/session/partitionPending.spec.ts`(新規): onDisk 分割 / 行の形 / 注入した
  activity・hidden の導出 / 空 known / 全 onDisk / 混在 / 順序保持 / 生 Map iterable。
- `plans/refactor-676-b3-partition-pending.md`(新規)。

## 検証

- 変異テスト: `if (onDisk.has(id))` → `if (!onDisk.has(id))` に反転 → spec 8 件中 7 件が赤化を確認して戻した。
- typecheck 3 種すべて green: `vue-tsc -b` / `tsc -p tsconfig.server.json` /
  (`vue-tsc -p tsconfig.test.json --noEmit` + `tsc -p tsconfig.test-server.json`)。
- `prettier --write` / `eslint` / `vitest run test/server/session`(43 files / 770 tests green)。

Part of #676
