### PR TITLE
refactor: extract nodeMeetsMinimum pure function (#676 B8)

### DIFF
--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -7,3 +7,5 @@ export declare function portInUseAction(explicit: boolean, isTTY: boolean | unde
 export declare function secondInstancePrompt(port: number): string;
 export declare function saysYes(answer: unknown): boolean;
 export declare const SECOND_INSTANCE_NOTE: string;
+export declare const MIN_NODE_LABEL: string;
+export declare function nodeMeetsMinimum(version: string): boolean;

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -111,3 +111,25 @@ export const SECOND_INSTANCE_NOTE = [
   "  Note: both share ~/.mulmoterminal. A session's tool history does not live-update",
   "  in the instance that did not start it.",
 ].join("\n");
+
+const MIN_NODE_MAJOR = 22;
+const MIN_NODE_MINOR = 9;
+
+/**
+ * The lowest Node the `init` check reports as good, for the "needs ≥ x.y" line.
+ */
+export const MIN_NODE_LABEL = `${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}`;
+
+/**
+ * Whether the running Node is new enough for the `init` pre-flight tick.
+ *
+ * `process.versions.node` is "major.minor.patch", with a "-prerelease" tag on the patch for
+ * nightlies ("22.9.0-nightly…"). Only major.minor gate, and Number.parseInt stops at the
+ * first non-digit, so that tag never reaches the comparison. A string that is not a version
+ * parses to NaN, and every comparison against NaN is false, so an unreadable version reads as
+ * "below minimum" — the safe direction for a display-only check.
+ */
+export function nodeMeetsMinimum(version) {
+  const [major, minor] = version.split(".").map((part) => Number.parseInt(part, 10));
+  return major > MIN_NODE_MAJOR || (major === MIN_NODE_MAJOR && minor >= MIN_NODE_MINOR);
+}

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -14,7 +14,17 @@ import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { computeUpdateNotice, isUpdateCheckDisabled } from "./update-check.js";
-import { chooseCwd, parsePortArg, portInUseAction, portInUseMessage, saysYes, secondInstancePrompt, SECOND_INSTANCE_NOTE } from "./cli-args.js";
+import {
+  chooseCwd,
+  parsePortArg,
+  portInUseAction,
+  portInUseMessage,
+  saysYes,
+  secondInstancePrompt,
+  SECOND_INSTANCE_NOTE,
+  nodeMeetsMinimum,
+  MIN_NODE_LABEL,
+} from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = join(__dirname, "..");
@@ -78,9 +88,8 @@ function promptYesNo(question) {
 async function runInit(initArgs) {
   log("Setting up MulmoTerminal…\n");
 
-  const [maj, min] = process.versions.node.split(".").map((n) => Number.parseInt(n, 10));
-  const nodeOk = maj > 22 || (maj === 22 && min >= 9);
-  console.log(nodeOk ? `  ✓ Node ${process.versions.node}` : `  ✗ Node ${process.versions.node} — MulmoTerminal needs ≥ 22.9`);
+  const nodeOk = nodeMeetsMinimum(process.versions.node);
+  console.log(nodeOk ? `  ✓ Node ${process.versions.node}` : `  ✗ Node ${process.versions.node} — MulmoTerminal needs ≥ ${MIN_NODE_LABEL}`);
 
   const hasClaude = claudeInstalled();
   if (hasClaude) {

--- a/plans/refactor-676-b8-node-min-version.md
+++ b/plans/refactor-676-b8-node-min-version.md
@@ -1,0 +1,49 @@
+# refactor: extract nodeMeetsMinimum pure function (#676 B8)
+
+## Context
+
+`bin/mulmoterminal.js` の `runInit` は `init` プレフライトの Node バージョン判定を
+実行ファイルに埋め込んでいた:
+
+```js
+const [maj, min] = process.versions.node.split(".").map((n) => Number.parseInt(n, 10));
+const nodeOk = maj > 22 || (maj === 22 && min >= 9);
+console.log(nodeOk ? `  ✓ Node ${process.versions.node}` : `  ✗ Node ${process.versions.node} — MulmoTerminal needs ≥ 22.9`);
+```
+
+表示専用(✓/✗ を出すだけで起動はブロックしない)だが、実行ファイル埋め込みのため
+プロセスを起動せずには検証できず未テストだった (#676 優先度 B8)。
+
+`≥ 22.9` の文言と `22 / 9` の閾値が別の場所に散っており、片方だけ動かすと
+チェックとメッセージがずれるドリフトの種でもあった。
+
+## 変更
+
+- `bin/cli-args.js`(既存の launcher 決定関数の集約先)に pure 関数を切り出し:
+  - `nodeMeetsMinimum(version: string): boolean` — 元のインライン式をそのまま
+    パラメータ化。**挙動不変**。
+  - `MIN_NODE_MAJOR = 22` / `MIN_NODE_MINOR = 9` を named const 化(マジックナンバー排除)。
+  - `MIN_NODE_LABEL = "22.9"` を export し、メッセージの単一ソースにする。
+- `bin/cli-args.d.ts` に `nodeMeetsMinimum` と `MIN_NODE_LABEL` の型を追加。
+- `bin/mulmoterminal.js` は `nodeMeetsMinimum(process.versions.node)` を呼び、
+  メッセージは `MIN_NODE_LABEL` から組み立てる。出力文字列は従来と同一。
+
+### パース仕様(現行に忠実)
+
+- `process.versions.node` は "major.minor.patch"、nightly は patch に
+  "-prerelease" タグ("22.9.0-nightly…")。`Number.parseInt` が最初の非数字で
+  止まるため、タグは major.minor の比較に届かない。
+- 版として読めない文字列は `NaN` にパースされ、`NaN` との比較はすべて false に
+  なるので「最低版未満」と判定される — ✓/✗ を描くだけの表示専用チェックとしては
+  安全側。
+
+## 検証
+
+- 変異テスト: `MIN_NODE_MINOR` を 9 → 10 に変えると `"22.9.0"→true` 系のテストが
+  赤化することを確認して戻した(3 テスト赤化)。
+- `prettier --write` / `eslint` はクリーン。
+- typecheck 3 種すべて通過:
+  - `vue-tsc -b`
+  - `tsc -p tsconfig.server.json`
+  - `vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json`
+- `vitest run test/bin/cli-args.spec.ts`(66 tests green、うち B8 分 10 件追加)。

--- a/test/bin/cli-args.spec.ts
+++ b/test/bin/cli-args.spec.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect } from "vitest";
 
-import { parsePortArg, chooseCwd, portInUseAction, portInUseMessage, secondInstancePrompt, saysYes, SECOND_INSTANCE_NOTE } from "../../bin/cli-args.js";
+import {
+  parsePortArg,
+  chooseCwd,
+  portInUseAction,
+  portInUseMessage,
+  secondInstancePrompt,
+  saysYes,
+  SECOND_INSTANCE_NOTE,
+  nodeMeetsMinimum,
+  MIN_NODE_LABEL,
+} from "../../bin/cli-args.js";
 
 const DEFAULT_PORT = 34567;
 const port = (args: string[]) => parsePortArg(args, DEFAULT_PORT);
@@ -241,5 +251,45 @@ describe("SECOND_INSTANCE_NOTE", () => {
   // long enough to read at a glance, not a paragraph to scroll past.
   it("stays short", () => {
     expect(SECOND_INSTANCE_NOTE.split("\n")).toHaveLength(2);
+  });
+});
+
+// The `init` pre-flight tick, fed process.versions.node ("22.9.0", "22.9.0-nightly…").
+// Display-only: a wrong answer changes a ✓/✗, it never blocks the launch.
+describe("nodeMeetsMinimum", () => {
+  it("passes the minimum and anything above it", () => {
+    expect(nodeMeetsMinimum("22.9.0")).toBe(true);
+    expect(nodeMeetsMinimum("22.10.0")).toBe(true);
+    expect(nodeMeetsMinimum("23.0.0")).toBe(true);
+  });
+
+  it("fails a lower minor on the boundary major", () => {
+    expect(nodeMeetsMinimum("22.8.0")).toBe(false);
+  });
+
+  it("fails a lower major even with a high minor", () => {
+    expect(nodeMeetsMinimum("21.9.0")).toBe(false);
+  });
+
+  // Number.parseInt stops at the first non-digit, so the nightly tag on the patch never
+  // reaches the comparison — major.minor is all that gates.
+  it("judges a nightly by its major.minor", () => {
+    expect(nodeMeetsMinimum("22.9.0-nightly20240101abcd")).toBe(true);
+    expect(nodeMeetsMinimum("22.8.0-nightly20240101abcd")).toBe(false);
+  });
+
+  // An unreadable version parses to NaN, and every comparison against NaN is false, so it
+  // reads as "below minimum" — the safe direction for a check that only draws a tick.
+  describe("an unreadable version reads as below minimum", () => {
+    it.each(["", "not-a-version", "vvv", "22", "22.x"])("fails %o", (value) => {
+      expect(nodeMeetsMinimum(value)).toBe(false);
+    });
+  });
+
+  // The message's "needs ≥ x.y" and the comparison have to name the same minimum, or the
+  // tick and the advice disagree.
+  it("labels the minimum it enforces", () => {
+    expect(MIN_NODE_LABEL).toBe("22.9");
+    expect(nodeMeetsMinimum(`${MIN_NODE_LABEL}.0`)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`bin/mulmoterminal.js` の `runInit` に埋め込まれていた Node 最低バージョン判定
(`maj > 22 || (maj === 22 && min >= 9)`、≥22.9)を、pure 関数 `nodeMeetsMinimum(version)`
として `bin/cli-args.js` に切り出しました。**挙動不変**。表示専用チェック
(`init` の ✓/✗ を描くだけで起動はブロックしない)を、プロセスを起動せずに
テストできるようにするのが目的です (#676 優先度 B8)。

- `bin/cli-args.js`: `nodeMeetsMinimum(version: string): boolean` を追加。
  閾値を `MIN_NODE_MAJOR = 22` / `MIN_NODE_MINOR = 9` の named const 化し、
  `MIN_NODE_LABEL = "22.9"` を export してメッセージの単一ソースにした。
- `bin/cli-args.d.ts`: 型を追加。
- `bin/mulmoterminal.js`: `nodeMeetsMinimum(process.versions.node)` を呼ぶだけに。
  出力文字列は従来と同一。
- `test/bin/cli-args.spec.ts`: `nodeMeetsMinimum` の describe を追加(10 件)。

## Items to Confirm / Review

- **挙動不変の確認**: 抽出前後で判定式もメッセージ文字列も変えていません。
  `MIN_NODE_LABEL` は `"22.9"` を生成し、既存の `≥ 22.9` と一致します。
- **不正入力の扱いは「現行に忠実」**: `process.versions.node` 以外の版として
  読めない文字列(`""`, `"not-a-version"`, `"22"`, `"22.x"` 等)は `NaN` に
  パースされ、`NaN` との比較がすべて false になるため「最低版未満」と判定します。
  これは元のインラインコードと同じ挙動で、✓/✗ を描くだけの表示専用チェックとして
  安全側です。テストでこの挙動を pin しています。
- **nightly**: `Number.parseInt` が最初の非数字で止まるため、patch の
  `-nightly…` タグは major.minor の比較に届かず、`"22.9.0-nightly…"` → true。

## 変異テスト

`MIN_NODE_MINOR` を `9 → 10` に変えると、`nodeMeetsMinimum("22.9.0") === true` を
期待するテスト(および nightly・label のテスト)が赤化(3 件 fail)することを確認し、
戻しました。壊すと落ちることを確認済みです。

## User Prompt

> #676 の優先度B項目を実装する。

(本 PR はそのうち B8: `bin/mulmoterminal.js` runInit の Node ≥22.9 判定の切り出し。)

## 検証

- `prettier --write` / `eslint`: クリーン
- typecheck 3 種すべて通過:
  - `vue-tsc -b`
  - `tsc -p tsconfig.server.json`
  - `vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json`
- `vitest run test/bin/cli-args.spec.ts`: 66 passed(B8 分 10 件追加)

Part of #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
