### PR TITLE
fix: median averages the two middle values for even counts (#676 B7)

### DIFF
--- a/common/median.ts
+++ b/common/median.ts
@@ -1,0 +1,13 @@
+// The middle value of a set of numbers, or null when there is nothing to measure.
+//
+// For an even count there are two middle values; the median is their AVERAGE. Returning
+// the upper one instead skews every even-length measurement toward the slower half — which
+// is what happened to the model-trial timings that get transcribed into the preset table
+// (a 2/3-passing model records two numbers, an even count, on every run).
+export const median = (values: number[]): number | null => {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+};

--- a/plans/refactor-676-b7-median-average.md
+++ b/plans/refactor-676-b7-median-average.md
@@ -1,0 +1,54 @@
+# refactor: extract median as a correct pure function (#676 B7)
+
+## Context
+
+`scripts/model-trials.ts` の `median()` (55-59 行) は偶数長で **上側中央値**
+(2 つの中央値のうち遅い方) を返していた:
+
+```ts
+const median = (values: number[]): number | null => {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)]; // 偶数長で上側を返す = バグ
+};
+```
+
+`runTrials` は成功した試行の秒数だけを集めるので、`--trials 3` で 2/3 合格のような
+**偶数長**が普通に起きる。そのとき記録値が悲観側 (遅い方) に振れ、その数値が
+`common/modelPresets.ts` のプリセット表へ**手動転記**され、最終的にランチャの
+ピッカーに出る。挙動修正はユーザ承認済み。
+
+`scripts/` はどの tsconfig の include にも入っておらず、その場に置いた spec は
+typecheck・テストから解決できない。よって median を **`common/`** に切り出す。
+`common/**/*.ts` は `tsconfig.app.json` (typecheck) と `tsconfig.server.json`
+(typecheck:server) の両方で型検査され、`test/server` / `test/src` の双方から import できる。
+
+## 変更
+
+- 新ファイル `common/median.ts` に pure 関数 `median` を切り出し、**偶数長は 2 つの
+  中央値の平均**を返す正しい定義に修正 (奇数長は不変)。
+  - シグネチャ: `median(values: number[]): number | null`
+  - 空配列 → `null`。それ以外は非破壊コピーを数値昇順ソートしてから中央を取る
+    (元の `[...values].sort((a, b) => a - b)` の挙動を維持 — 未ソート・負値も正しく扱う)。
+  - 偶数長: `(sorted[mid - 1] + sorted[mid]) / 2`、奇数長: `sorted[mid]`
+    (`mid = Math.floor(length / 2)`)。
+- `scripts/model-trials.ts` はローカル定義を削除し `../common/median.js` から import。
+  既存の modelPresets の数値 (過去の測定値) は転記済みのため変更しない。
+- テスト `test/server/median.spec.ts` (test-server tsconfig, strict):
+  - 空 → `null` / 1 件 → その値
+  - 偶数長 = 平均: `[2, 20]` → `11`
+  - 奇数長 = 中央: `[1, 2, 20]` → `2`
+  - 未ソート入力を内部でソートする (`[20, 1, 2]` → `2`, `[20, 2]` → `11`)
+  - 負値・重複・境界 (2 要素平均が非整数になる `[11, 12]` → `11.5`)
+
+## 変異テスト
+
+平均を上側中央値 (`sorted[Math.floor(length / 2)]`) に戻すと偶数長テスト
+(`[2, 20]` → `11` 等) が赤になることを確認してから戻す。
+
+## 検証
+
+- `prettier --write` / `eslint` / typecheck 3 種
+  (`vue-tsc -b` / `tsc -p tsconfig.server.json` /
+  `vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json`) /
+  `vitest run test/server/median.spec.ts`。

--- a/scripts/model-trials.ts
+++ b/scripts/model-trials.ts
@@ -19,6 +19,7 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { median } from "../common/median.js";
 import { claudeAdapter } from "../server/agents/claude.js";
 import { loadAppConfig } from "../server/config/app-config.js";
 import { cleanupSessionSettings, settingsArgument } from "../server/session/session-settings.js";
@@ -51,12 +52,6 @@ export interface TrialResult {
 }
 
 const UNREACHABLE = /No endpoints available|No endpoints found/i;
-
-const median = (values: number[]): number | null => {
-  if (values.length === 0) return null;
-  const sorted = [...values].sort((a, b) => a - b);
-  return sorted[Math.floor(sorted.length / 2)];
-};
 
 // One attempt, through the SAME path a real session uses: the provider environment in a
 // settings file, the token stripped from the child's own environment.

--- a/test/server/median.spec.ts
+++ b/test/server/median.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { median } from "../../common/median.js";
+
+describe("median", () => {
+  it("returns null for an empty array", () => {
+    expect(median([])).toBeNull();
+  });
+
+  it("returns the sole value for a single element", () => {
+    expect(median([7])).toBe(7);
+  });
+
+  // The bug this file guards: an even count has two middle values, and the median is their
+  // average — not the upper one (20, which the old floor(n/2) index returned).
+  it("averages the two middle values for an even count", () => {
+    expect(median([2, 20])).toBe(11);
+  });
+
+  it("takes the middle value for an odd count", () => {
+    expect(median([1, 2, 20])).toBe(2);
+  });
+
+  it("sorts unsorted input before measuring", () => {
+    expect(median([20, 1, 2])).toBe(2);
+    expect(median([20, 2])).toBe(11);
+  });
+
+  it("handles negative values", () => {
+    expect(median([-5, -1, -3])).toBe(-3);
+    expect(median([-4, -2])).toBe(-3);
+  });
+
+  it("keeps duplicates in the count", () => {
+    expect(median([5, 5, 5, 5])).toBe(5);
+  });
+
+  it("returns a fractional median when the two middle values do not average to an integer", () => {
+    expect(median([11, 12])).toBe(11.5);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const input = [20, 1, 2];
+    median(input);
+    expect(input).toEqual([20, 1, 2]);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/model-trials.ts` の `median()` は偶数長のとき **上側中央値** (2 つの中央値のうち遅い方) を返すバグがあった。`runTrials` は成功した試行の秒数だけを集めるため、`--trials 3` で 2/3 合格のような偶数長が普通に起き、記録値が悲観側 (遅い方) に振れる。その数値は `common/modelPresets.ts` のプリセット表へ**手動転記**され、ランチャのモデルピッカーに表示される。

この PR は `median` を pure 関数として `common/median.ts` に切り出し、**偶数長は 2 つの中央値の平均**を返す正しい定義に修正する (奇数長は不変)。挙動修正はユーザ承認済み。

- `common/median.ts` — 新規 pure 関数。`common/**/*.ts` は `tsconfig.app.json` (typecheck) と `tsconfig.server.json` (typecheck:server) の両方で型検査され、`test/server` からも import できる。`scripts/` はどの tsconfig にも含まれないため、テスト可能な場所として `common/` を選定。
- `scripts/model-trials.ts` — ローカル定義を削除し `../common/median.js` を import。既存の `modelPresets` の数値 (過去の測定値) は転記済みのため変更しない。
- `test/server/median.spec.ts` — 空/1件/偶数=平均/奇数/未ソート/負値/重複/非整数平均/非破壊を固定 (9 ケース)。

## Items to Confirm / Review

- **median の配置**: `common/median.ts`。`scripts/` はどの tsconfig の include にも入っておらず spec が解決できないため共有可能な `common/` を選んだ。app・server 両 tsconfig で型検査され、`test/server` から import 可能。この配置で問題ないか。
- **戻り値が非整数になり得る**: 偶数長で 2 つの中央値の平均が非整数のとき `medianSeconds` が小数になる (例: `[11, 12]` → `11.5`)。表示は `${medianSeconds}s` なので `11.5s` と出る。丸めは意図的に**入れていない** — pure な median としては数学的に正しい値を返すべきで、丸め (転記時の判断) は別関心。この方針で良いか。
- **既存の modelPresets 値は未変更**: 過去の測定は旧 median で算出済み。手動転記された数値は今回触っていない (再測定は `scripts/model-trials.ts` を回したときに反映)。

## User Prompt

> #676 の優先度B項目を実装する（median を正しい平均中央値に、はユーザ承認済み）。

## 変異テスト (mutation test)

平均を上側中央値 (`sorted[Math.floor(sorted.length / 2)]`) に戻すと、偶数長のテスト 4 件 (`[2, 20]` → `11` 等) が赤化し、奇数長のテストは緑のまま — を確認してから正しい実装に戻した。

Part of #676
