### PR TITLE
fix: resolve dir-config live-reload against body.cwd, not the spawn cwd (#676 B6)

### DIFF
--- a/plans/fix-676-b6-hook-dir-config-cwd.md
+++ b/plans/fix-676-b6-hook-dir-config-cwd.md
@@ -1,0 +1,50 @@
+# fix #676 B6 — dir-config live-reload resolves relative paths against the wrong cwd
+
+Part of #676 (棚卸し 第3弾, priority B, item B6). Behavior change approved by the user:
+`body.cwd` takes precedence over the spawn-time PTY cwd.
+
+## Problem
+
+`server/routes/hook-routes.ts` resolves the dir-config live-reload target two different ways
+depending on the hook path:
+
+- `handleHookRequest` (the header/title path) uses
+  `typeof body.cwd === "string" ? body.cwd : entry?.cwd` — the CLI-reported live cwd wins.
+- `handleToolHook` (the `.mulmoterminal.json` live-reload path, line ~71) uses only
+  `ptys.get(sessionId)?.cwd ?? null` — the directory the PTY was **spawned** in.
+
+The PTY entry's `cwd` is the spawn dir; it goes stale the moment the session `cd`s. So a
+session that has changed directory and writes `.mulmoterminal.json` with a **relative**
+`file_path` publishes a reload notification for the *wrong* directory (the spawn dir), while
+missing the directory that actually changed. Low probability, but the two hook paths disagree
+on a decision that should be identical.
+
+## Fix
+
+Resolve the hook cwd **once** and share it across both hook paths.
+
+1. Extract the resolution into a pure, testable function
+   `resolveHookCwd(bodyCwd, spawnCwd)` in `server/session/activity-hook.ts` (next to the
+   sibling `resolveHookSessionId`). It returns `typeof bodyCwd === "string" ? bodyCwd : spawnCwd`
+   — exactly what `handleHookRequest` already computed inline.
+2. `handleHookRequest` calls `resolveHookCwd(body.cwd, entry?.cwd)` and passes the result to
+   `handleToolHook`, which stops reaching into `ptys` for its own cwd and uses the shared value
+   when calling `dirConfigWriteTarget`.
+
+This eliminates the divergence entirely: there is one cwd, resolved one way, for the whole
+request.
+
+## Tests (test/server/session/activity-hook.spec.ts)
+
+Pin the decision the route delegates:
+
+- `resolveHookCwd` prefers `body.cwd` over the spawn cwd (the regression this fixes).
+- Falls back to the spawn cwd when `body.cwd` is absent / not a string.
+- Returns `undefined` when neither is present.
+- End-to-end with `dirConfigWriteTarget`: a relative `.mulmoterminal.json` write resolves under
+  `body.cwd`, not the spawn cwd.
+
+## Mutation check
+
+Revert `resolveHookCwd` to ignore `body.cwd` (return the spawn cwd) and confirm the new
+"prefers body.cwd" tests go red, then restore.

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -5,7 +5,7 @@
 import type { Express, Request, Response } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
 import { dirConfigWriteTarget } from "../config/dir-config.js";
-import { activityHookEffects, pushKindFor, resolveHookSessionId } from "../session/activity-hook.js";
+import { activityHookEffects, pushKindFor, resolveHookCwd, resolveHookSessionId } from "../session/activity-hook.js";
 import { headerHookEffect } from "../session/header-hook.js";
 import { lastPrompts, lastResponses, ptys } from "../session/registry.js";
 import { latestUserPrompt } from "../session/session-reads.js";
@@ -61,15 +61,17 @@ interface HookToolPayload {
 
 // Pre/PostToolUse hooks feed the per-session tool-call history; toolHookRecord decides what
 // each event means and this applies it.
-async function handleToolHook(deps: HookDeps, sessionId: string, event: string, p: HookToolPayload) {
+async function handleToolHook(deps: HookDeps, sessionId: string, event: string, p: HookToolPayload, cwd: string | undefined) {
   const record = toolHookRecord(event, p);
   if (record?.phase === "start") await deps.recordToolCallStart(sessionId, record.call);
   if (record?.phase === "end") await deps.recordToolCallEnd(sessionId, record.call);
   // A SUCCESSFUL write to <dir>/.mulmoterminal.json is the live-reload signal: the hook that already
   // reports every tool call tells the client to re-read that directory's config, so no fs watchers.
+  // `cwd` is the request-wide resolved cwd (body.cwd over the spawn dir) — a relative file_path
+  // must resolve against the same directory the header path uses, not the stale spawn cwd.
   if (publishesDirConfig(event)) {
-    const cwd = dirConfigWriteTarget(p.tool_name, p.tool_input, ptys.get(sessionId)?.cwd ?? null);
-    if (cwd) deps.publishDirConfig(cwd);
+    const target = dirConfigWriteTarget(p.tool_name, p.tool_input, cwd ?? null);
+    if (target) deps.publishDirConfig(target);
   }
 }
 
@@ -132,10 +134,10 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
   if (sessionId) {
     const entry = ptys.get(sessionId);
     const active = !!(entry && entry.active);
-    const cwd = typeof body.cwd === "string" ? body.cwd : entry?.cwd;
+    const cwd = resolveHookCwd(body.cwd, entry?.cwd);
     await applyHeaderHooks(deps, sessionId, event, body, cwd);
     handleActivityHook(deps, sessionId, event, active, typeof body.message === "string" ? body.message : "");
-    await handleToolHook(deps, sessionId, event, body);
+    await handleToolHook(deps, sessionId, event, body, cwd);
     // A hidden translation worker that ends its turn while still pending never called
     // submitTranslation — fail it now rather than hang until the timeout. (When it DID
     // submit, the entry is already resolved and this reject is a no-op.)

--- a/server/session/activity-hook.ts
+++ b/server/session/activity-hook.ts
@@ -120,3 +120,12 @@ export function resolveHookSessionId(header: unknown, bodyValue: unknown, isVali
   const usable = (value: unknown): string | null => (typeof value === "string" && isValidId(value) ? value : null);
   return usable(header) ?? usable(bodyValue);
 }
+
+// Which directory a hook's relative paths resolve against. The CLI reports its live cwd in
+// the payload, but the PTY table only holds the dir the session was SPAWNED in — that value
+// goes stale the moment the session `cd`s. So the payload cwd wins, falling back to the spawn
+// dir only when the hook carries none. Shared by every hook path so they can't disagree on
+// which directory a relative write (e.g. a `.mulmoterminal.json` live-reload) belongs to.
+export function resolveHookCwd(bodyCwd: unknown, spawnCwd: string | undefined): string | undefined {
+  return typeof bodyCwd === "string" ? bodyCwd : spawnCwd;
+}

--- a/test/server/session/activity-hook.spec.ts
+++ b/test/server/session/activity-hook.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { activityHookEffects, buildPushText, pushKindFor, resolveHookSessionId } from "../../../server/session/activity-hook.js";
+import path from "node:path";
+import { activityHookEffects, buildPushText, pushKindFor, resolveHookCwd, resolveHookSessionId } from "../../../server/session/activity-hook.js";
+import { dirConfigWriteTarget } from "../../../server/config/dir-config.js";
 
 describe("activityHookEffects", () => {
   it("UserPromptSubmit sets working regardless of active", () => {
@@ -169,5 +171,35 @@ describe("resolveHookSessionId", () => {
 
   it("accepts either case, since the shape check is case-insensitive", () => {
     expect(resolve(undefined, UUID.toUpperCase())).toBe(UUID.toUpperCase());
+  });
+});
+
+describe("resolveHookCwd", () => {
+  const spawnCwd = path.resolve("/spawn/dir");
+  const liveCwd = path.resolve("/live/dir");
+
+  // The regression this fixes: the CLI-reported cwd is the session's live directory, while the
+  // PTY entry only holds the SPAWN dir. When both are present the live one must win — otherwise
+  // a session that `cd`ed writes a relative file that resolves against the stale spawn dir.
+  it("prefers the payload cwd over the spawn cwd", () => {
+    expect(resolveHookCwd(liveCwd, spawnCwd)).toBe(liveCwd);
+  });
+
+  it("falls back to the spawn cwd when the payload carries no usable cwd", () => {
+    expect(resolveHookCwd(undefined, spawnCwd)).toBe(spawnCwd);
+    expect(resolveHookCwd(42, spawnCwd)).toBe(spawnCwd);
+    expect(resolveHookCwd({ cwd: liveCwd }, spawnCwd)).toBe(spawnCwd);
+  });
+
+  it("is undefined when neither source names a directory", () => {
+    expect(resolveHookCwd(undefined, undefined)).toBeUndefined();
+    expect(resolveHookCwd(null, undefined)).toBeUndefined();
+  });
+
+  // End to end with the live-reload target: a relative `.mulmoterminal.json` write must publish
+  // the directory under the payload cwd, not the spawn cwd — the two used to disagree.
+  it("resolves a relative dir-config write under the payload cwd, not the spawn cwd", () => {
+    const cwd = resolveHookCwd(liveCwd, spawnCwd);
+    expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" }, cwd ?? null)).toBe(liveCwd);
   });
 });


### PR DESCRIPTION
## Summary

The Claude tool-hook path (`Pre`/`PostToolUse`) resolved a **relative** `.mulmoterminal.json`
write against the PTY's **spawn** cwd (`ptys.get(sessionId)?.cwd`), while the header/title hook
path in the same request already resolved cwd as `body.cwd` over `entry?.cwd`. The two paths
disagreed. A session that had `cd`ed and wrote `.mulmoterminal.json` with a relative `file_path`
therefore published the live-reload signal for the **stale spawn directory** — telling clients to
re-read a directory that didn't change while missing the one that did.

Fix: extract the resolution into a pure `resolveHookCwd(bodyCwd, spawnCwd)` shared by both hook
paths, so the whole request resolves cwd exactly once, the same way. The tool-hook handler now
receives that resolved cwd instead of reaching into the `ptys` table itself. `body.cwd` (the CLI's
live cwd) wins over the spawn dir; the spawn dir is the fallback only when the hook carries no cwd.

## Items to Confirm / Review

- **Behavior change (user-approved):** `body.cwd` now takes precedence over the spawn-time PTY cwd
  for the dir-config live-reload target. This aligns it with the header/title path, which already
  behaved this way.
- The resolution rule is the exact form the header path used (`typeof bodyCwd === "string" ? bodyCwd
  : spawnCwd`), not a looser `??` — a non-string `body.cwd` (e.g. a number) still falls back to the
  spawn dir, keeping `dirConfigWriteTarget`'s `string | null` contract intact.
- `resolveHookCwd` lives in `server/session/activity-hook.ts` next to the sibling
  `resolveHookSessionId`.

## Mutation test

Reverting `resolveHookCwd` to ignore `body.cwd` (return the spawn cwd) turns the two new
"prefers the payload cwd" tests **red** (`prefers the payload cwd over the spawn cwd` and the
end-to-end `resolveHookCwd` + `dirConfigWriteTarget` case), while the fallback/undefined tests stay
green. Restored → all green.

## Verification

- `npx prettier --write` / `npx eslint` — clean
- Typecheck (all 3): `npx vue-tsc -b` / `npx tsc -p tsconfig.server.json` /
  `npx vue-tsc -p tsconfig.test.json --noEmit` + `npx tsc -p tsconfig.test-server.json` — all pass
- `npx vitest run test/server/session test/server/routes` — 835 passed

## User Prompt

> #676 の優先度B項目を実装する(挙動修正はユーザ承認済み: body.cwd を優先)。

Part of #676.
