### PR TITLE
refactor: extract wiki [[link]] click resolution into a pure module (#676 B5)

### DIFF
--- a/plans/refactor-676-b5-wiki-click-target.md
+++ b/plans/refactor-676-b5-wiki-click-target.md
@@ -1,0 +1,67 @@
+# refactor(#676 B5): extract the `[[wiki link]]` click resolution into a pure, testable module
+
+Part of #676. Priority-B item B5.
+
+## Problem
+
+`src/components/WikiPageView.vue`'s `activateLink` resolved a clicked `[[wiki link]]`'s raw
+target to a slug inline: graph resolution (`resolveLinkTarget`) first, then a `wikiSlugify`
+fallback gated by `isSafeWikiSlug`, returning null (skip navigation) when nothing safe
+resolves. The individual functions come from `@mulmoclaude/core/wiki` and are already tested,
+but this **composition** — the fallback order, the `props.graph ?` guard, and the safety gate
+on the fallback — could only be reached by mounting the component and clicking, so it was
+untested. A "simplification" that dropped the safety gate or reordered the fallback would
+silently change which page a click opens.
+
+## Change
+
+Extract the composition into a new same-directory pure module
+`src/components/wikiClickTarget.ts` and reduce `activateLink` to the DOM read + navigate. The
+DOM operations (`el.getAttribute("data-page")`, `wikiGotoPage`) stay in the `.vue`. Behavior
+is unchanged (1:1 move).
+
+Signature, faithful to what the `.vue` currently passes:
+
+```ts
+resolveWikiClickTarget(rawTarget: string, deps: {
+  graph: WikiGraph | null;
+  fileSlugs: ReadonlySet<string>;
+  slugByTitle: ReadonlyMap<string, string>;
+}): string | null
+```
+
+`deps.graph` reproduces the original `props.graph ? resolveLinkTarget(...) : null` guard
+exactly (the resolver is skipped when the graph is null); `fileSlugs` / `slugByTitle` are the
+same derived maps the `.vue` already computed. The three core functions are imported directly
+(they are the already-tested primitives; the composition is what this module pins).
+
+## Tests
+
+`test/src/components/wikiClickTarget.spec.ts` (fixtures built from real graph nodes so
+`fileSlugs` / `slugByTitle` stay internally consistent, exercised against the real core
+functions):
+
+- graph resolution succeeds → returns that slug (direct slug match).
+- graph title-match returns a slug that differs from the plain slugify form
+  ("Meeting Notes" → "meeting-notes-2026") → pins graph-first ordering.
+- graph misses → safe `wikiSlugify` fallback returned ("Unknown Page" → "unknown-page").
+- graph misses and fallback is unsafe (non-ASCII "日本語" slugifies to "") → null.
+- graph is null but `fileSlugs` / `slugByTitle` are populated → resolver is skipped, safe
+  fallback returned (pins the `deps.graph ?` guard).
+- graph is null and fallback unsafe → null.
+
+## Mutation check
+
+- Dropping the safety gate (`return isSafeWikiSlug(fallback) ? fallback : null` →
+  `return fallback`) turned the two unsafe-fallback tests red (`""` instead of `null`); the
+  other four stayed green.
+- Reversing the fallback order (try `wikiSlugify` before the graph resolver) turned the
+  title-match ordering test red (`"meeting-notes"` instead of `"meeting-notes-2026"`).
+
+Reverted after confirming each.
+
+## Verification
+
+`prettier --write` + `eslint` on the touched files; `vue-tsc -b`, `tsc -p tsconfig.server.json`,
+`vue-tsc -p tsconfig.test.json --noEmit` + `tsc -p tsconfig.test-server.json`; `vitest run` on
+the new spec (6 passing).

--- a/src/components/WikiPageView.vue
+++ b/src/components/WikiPageView.vue
@@ -4,9 +4,10 @@
 // section derived from the shared graph. Navigation is delegated up via the
 // useWikiBrowse helpers — clicking a link/backlink pushes /wiki/pages/<slug>.
 import { computed } from "vue";
-import { resolveLinkTarget, wikiSlugify, isSafeWikiSlug, incomingLinks, type WikiGraph } from "@mulmoclaude/core/wiki";
+import { incomingLinks, type WikiGraph } from "@mulmoclaude/core/wiki";
 import { renderWikiHtml } from "../wikiMarkdown";
 import { wikiGotoPage } from "../composables/useWikiBrowse";
+import { resolveWikiClickTarget } from "./wikiClickTarget";
 import type { WikiPage } from "../wikiApi";
 
 const props = defineProps<{ slug: string; page: WikiPage; graph: WikiGraph | null }>();
@@ -22,16 +23,11 @@ const fileSlugs = computed(() => new Set((props.graph?.nodes ?? []).map((n) => n
 const slugByTitle = computed(() => new Map((props.graph?.nodes ?? []).map((n) => [n.title, n.slug])));
 const backlinks = computed(() => (props.graph ? incomingLinks(props.graph, props.slug) : []));
 
-// Resolve a `[[link]]` span's raw target to a file slug (graph first, then a plain
-// slugify fallback) and navigate.
+// Read the clicked span's raw target from the DOM, resolve it to a slug, and navigate.
 function activateLink(el: HTMLElement | null): void {
   const target = el?.getAttribute("data-page");
   if (!target) return;
-  let slug = props.graph ? resolveLinkTarget(target, fileSlugs.value, slugByTitle.value) : null;
-  if (!slug) {
-    const fallback = wikiSlugify(target);
-    slug = isSafeWikiSlug(fallback) ? fallback : null;
-  }
+  const slug = resolveWikiClickTarget(target, { graph: props.graph, fileSlugs: fileSlugs.value, slugByTitle: slugByTitle.value });
   if (slug) wikiGotoPage(slug);
 }
 

--- a/src/components/wikiClickTarget.ts
+++ b/src/components/wikiClickTarget.ts
@@ -1,0 +1,19 @@
+import { resolveLinkTarget, wikiSlugify, isSafeWikiSlug, type WikiGraph } from "@mulmoclaude/core/wiki";
+
+type WikiClickTargetDeps = {
+  graph: WikiGraph | null;
+  fileSlugs: ReadonlySet<string>;
+  slugByTitle: ReadonlyMap<string, string>;
+};
+
+// Resolve a clicked `[[wiki link]]`'s raw target to a navigable slug. The graph resolver
+// wins first (it can map a title to a slug that differs from the plain slugify form); only
+// when it finds nothing do we fall back to slugifying the target ourselves. The fallback is
+// gated by the router's own safety check so a non-ASCII target that slugifies to "" — or any
+// unsafe value — yields null instead of a bogus route, leaving the caller to skip navigation.
+export const resolveWikiClickTarget = (rawTarget: string, deps: WikiClickTargetDeps): string | null => {
+  const graphSlug = deps.graph ? resolveLinkTarget(rawTarget, deps.fileSlugs, deps.slugByTitle) : null;
+  if (graphSlug) return graphSlug;
+  const fallback = wikiSlugify(rawTarget);
+  return isSafeWikiSlug(fallback) ? fallback : null;
+};

--- a/test/src/components/wikiClickTarget.spec.ts
+++ b/test/src/components/wikiClickTarget.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import type { WikiGraph } from "@mulmoclaude/core/wiki";
+import { resolveWikiClickTarget } from "../../../src/components/wikiClickTarget";
+
+// Build deps the way WikiPageView does: fileSlugs / slugByTitle are derived from the same
+// nodes, so the fixtures stay internally consistent with a real graph.
+const depsFrom = (nodes: { slug: string; title: string }[], graphNull = false) => {
+  const graph: WikiGraph | null = graphNull ? null : { nodes, edges: [] };
+  return {
+    graph,
+    fileSlugs: new Set(nodes.map((n) => n.slug)),
+    slugByTitle: new Map(nodes.map((n) => [n.title, n.slug] as const)),
+  };
+};
+
+describe("resolveWikiClickTarget — graph resolution wins first", () => {
+  it("returns the graph slug on a direct slug match", () => {
+    const deps = depsFrom([{ slug: "alpha", title: "Alpha" }]);
+    expect(resolveWikiClickTarget("Alpha", deps)).toBe("alpha");
+  });
+
+  // Title match: the graph maps the title to a slug that the plain slugify would NOT produce
+  // ("Meeting Notes" → "meeting-notes"). Pins graph-first ordering — trying slugify first
+  // would return "meeting-notes" instead of the real "meeting-notes-2026".
+  it("returns a title-matched slug that differs from the slugified target", () => {
+    const deps = depsFrom([{ slug: "meeting-notes-2026", title: "Meeting Notes" }]);
+    expect(resolveWikiClickTarget("Meeting Notes", deps)).toBe("meeting-notes-2026");
+  });
+});
+
+describe("resolveWikiClickTarget — slugify fallback when the graph misses", () => {
+  it("falls back to the slugified target and returns it when safe", () => {
+    const deps = depsFrom([{ slug: "other", title: "Other" }]);
+    expect(resolveWikiClickTarget("Unknown Page", deps)).toBe("unknown-page");
+  });
+});
+
+describe("resolveWikiClickTarget — safety gate on the fallback", () => {
+  // A non-ASCII target slugifies to "" (empty is unsafe), so neither the graph nor the
+  // fallback yields a slug. Returns null instead of a bogus route.
+  it("returns null when the graph misses and the fallback is unsafe", () => {
+    const deps = depsFrom([{ slug: "other", title: "Other" }]);
+    expect(resolveWikiClickTarget("日本語", deps)).toBeNull();
+  });
+});
+
+describe("resolveWikiClickTarget — graph guard (null graph skips the resolver)", () => {
+  it("uses the fallback, not the resolver, when graph is null", () => {
+    // fileSlugs / slugByTitle are populated, but graph === null must short-circuit the
+    // resolver — so the title match ("meeting-notes-2026") is NOT taken; the safe slugify
+    // fallback ("meeting-notes") is returned instead.
+    const deps = depsFrom([{ slug: "meeting-notes-2026", title: "Meeting Notes" }], true);
+    expect(resolveWikiClickTarget("Meeting Notes", deps)).toBe("meeting-notes");
+  });
+
+  it("returns null when graph is null and the fallback is unsafe", () => {
+    const deps = depsFrom([], true);
+    expect(resolveWikiClickTarget("***", deps)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the `[[wiki link]]` click-resolution **composition** from
`src/components/WikiPageView.vue`'s `activateLink` into a pure, testable module
`src/components/wikiClickTarget.ts`, and pins it with unit + mutation tests. The
individual primitives (`resolveLinkTarget` / `wikiSlugify` / `isSafeWikiSlug`) already
come tested from `@mulmoclaude/core/wiki`; what was untested was their composition — the
fallback order, the `props.graph ?` guard, and the safety gate on the fallback. A
"simplification" that dropped the gate or reordered the fallback would silently change
which page a click opens.

Behavior is unchanged (1:1 move). The DOM read (`el.getAttribute("data-page")`) and
`wikiGotoPage` navigation stay in the `.vue`.

New signature, faithful to what the `.vue` currently passes:

```ts
resolveWikiClickTarget(rawTarget: string, deps: {
  graph: WikiGraph | null;
  fileSlugs: ReadonlySet<string>;
  slugByTitle: ReadonlyMap<string, string>;
}): string | null
```

`deps.graph` reproduces the original `props.graph ? resolveLinkTarget(...) : null` guard
exactly (resolver skipped when the graph is null).

## Items to Confirm / Review

- **Behavior-preserving guard translation**: original `let slug = graph ? resolve() : null; if (!slug) { fallback }` → `if (graphSlug) return graphSlug; ...`. `resolveLinkTarget` only ever returns a non-empty slug or `null`, so the `!slug` (falsy) vs `if (graphSlug)` (truthy) branch is equivalent — please sanity-check that reasoning.
- **`deps` shape vs the issue's sketch**: #676 sketched `resolveWikiClickTarget(target, fileSlugs, slugByTitle)`. I added `graph` to the `deps` object so the `props.graph ?` null-guard is reproduced verbatim rather than dropped (when `graph` is null the derived maps are empty anyway, but keeping the guard makes the extraction exactly behavior-preserving and the guard itself testable).
- **Comment style** on the new module (a short WHY block explaining graph-first ordering + the safety gate) matches the sibling `wikiTagFilter.ts` convention.

## User Prompt

> #676 の優先度B項目を実装する。

(This PR implements item **B5** of #676.)

## Tests

`test/src/components/wikiClickTarget.spec.ts` (6 cases), fixtures built from real graph
nodes and run against the real core functions:

- graph resolution succeeds → returns that slug (direct slug match).
- graph title-match returns a slug differing from the plain slugify form
  ("Meeting Notes" → "meeting-notes-2026") → pins **graph-first ordering**.
- graph misses → safe `wikiSlugify` fallback returned.
- graph misses and fallback unsafe (non-ASCII "日本語" → "") → `null`.
- graph null but maps populated → resolver skipped, safe fallback returned (pins the guard).
- graph null and fallback unsafe → `null`.

### Mutation check

- Dropping the safety gate (`isSafeWikiSlug(fallback) ? fallback : null` → `fallback`) →
  the two unsafe-fallback tests go red (`""` vs `null`).
- Reversing the fallback order (slugify before the graph resolver) → the title-match
  ordering test goes red (`"meeting-notes"` vs `"meeting-notes-2026"`).

Both reverted after confirming.

## Verification

`prettier --write` + `eslint` on the touched files; typecheck (all three):
`vue-tsc -b`, `tsc -p tsconfig.server.json`,
`vue-tsc -p tsconfig.test.json --noEmit` + `tsc -p tsconfig.test-server.json`;
`vitest run test/src/components/wikiClickTarget.spec.ts` (6 passing).

Part of #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
