### PR TITLE
fix: tint the expand roster rows with each directory's header color

### DIFF
--- a/plans/fix-roster-header-color.md
+++ b/plans/fix-roster-header-color.md
@@ -11,15 +11,15 @@ grid expand したとき、サイドメニューのロスター（既定の cock
 
 ## 変更
 
-**ロスター行の背景を、そのターミナルの header color に染める。**（見た目はユーザー選択）
+**ロスター行の上部（status バッジ ＋ ディレクトリ名の行）をヘッダー帯にして、そこに header color の背景をつける。**（行まるごとは重すぎたため、実機フィードバックでヘッダー帯方式に変更）
 
 `phaseByCwd` と同じ reactive Map パターンを `chromeByCwd` として追加:
 
 - `GridView.vue`: `chromeByCwd`（cwd → `{headerColor, headerTextColor}`）を `fetchDirConfig`（共有キャッシュ）から seed。`dir-config` pubsub チャネルを購読し、`.mulmoterminal.json` 編集時に該当 cwd を invalidate + 再 seed → 開いたままのロスターがリロードなしで再着色。`forgetClosedCells` で prune
 - `listRows` に `headerColor` / `headerTextColor` を追加
-- `TerminalGrid.vue`: `CockpitRow` に2フィールド追加。ロスター行に `:style="headerStyleFor(row.headerColor, row.headerTextColor)"`（既存の純関数を再利用）を適用し、背景を `bg-[var(--cell-header-bg,var(--bg-panel))]`、文字色を `text-[var(--cell-header-fg,var(--text))]` に。TerminalCell のヘッダーと同じ CSS 変数の使い方
+- `TerminalGrid.vue`: `CockpitRow` に2フィールド追加。**行の上部の status+cwd の span をヘッダー帯**にし、`:style="headerStyleFor(...)"`（既存の純関数を再利用）＋ `bg-[var(--cell-header-bg,transparent)]` を適用。負マージン（`-mx-2.5 -mt-2`）で行の上端・両端まで帯を伸ばす。行本体（summary/prompt/reply）はテーマ既定のまま。cwd テキストは `text-[var(--cell-header-fg,var(--text-dim))]` で、色付き帯では headerTextColor、未設定では従来の dim
 
-未設定のディレクトリは CSS 変数がセットされず、テーマ既定（`--bg-panel` / `--text`）にフォールバック。
+未設定のディレクトリは CSS 変数がセットされず、ヘッダー帯は透明（＝行と一体で従来の見た目）にフォールバック。
 
 ### TDZ 注意
 

--- a/plans/fix-roster-header-color.md
+++ b/plans/fix-roster-header-color.md
@@ -1,0 +1,36 @@
+# fix — grid expand 時のロスター行にディレクトリの header color を反映
+
+## 要望
+
+grid expand したとき、サイドメニューのロスター（既定の cockpit リスト表示）のターミナル行に、ユーザーがディレクトリごとに設定した header color が反映されない。反映してほしい。
+
+## 現状
+
+- **フィルムストリップ**（`listMode=false`）は完全な `TerminalCell` を描画するので header color は出る
+- **ロスター**（`listMode=true`、既定）は `CockpitRow`（テキスト行）で描画され、`headerColor` を持たず、status 色と固定枠だけ。ディレクトリ設定（`.mulmoterminal.json` の `headerColor`）が反映されない
+
+## 変更
+
+**ロスター行の背景を、そのターミナルの header color に染める。**（見た目はユーザー選択）
+
+`phaseByCwd` と同じ reactive Map パターンを `chromeByCwd` として追加:
+
+- `GridView.vue`: `chromeByCwd`（cwd → `{headerColor, headerTextColor}`）を `fetchDirConfig`（共有キャッシュ）から seed。`dir-config` pubsub チャネルを購読し、`.mulmoterminal.json` 編集時に該当 cwd を invalidate + 再 seed → 開いたままのロスターがリロードなしで再着色。`forgetClosedCells` で prune
+- `listRows` に `headerColor` / `headerTextColor` を追加
+- `TerminalGrid.vue`: `CockpitRow` に2フィールド追加。ロスター行に `:style="headerStyleFor(row.headerColor, row.headerTextColor)"`（既存の純関数を再利用）を適用し、背景を `bg-[var(--cell-header-bg,var(--bg-panel))]`、文字色を `text-[var(--cell-header-fg,var(--text))]` に。TerminalCell のヘッダーと同じ CSS 変数の使い方
+
+未設定のディレクトリは CSS 変数がセットされず、テーマ既定（`--bg-panel` / `--text`）にフォールバック。
+
+### TDZ 注意
+
+`chromeByCwd` は `forgetClosedCells` より前に宣言する必要がある（cells-key watch が `immediate: true` で setup 中に `forgetClosedCells` を呼ぶため）。
+
+## テスト
+
+- ロスター行が `headerColor`/`headerTextColor` から `--cell-header-bg`/`--cell-header-fg` を適用すること（TerminalGrid をマウントして検証）
+- 未設定時は変数を出さないこと
+- `:style` 束縛を外すと赤くなることを確認済み
+
+## 未検証
+
+実際の色の見た目は実機で要確認（染まること・可読性）。配線とレンダリングはコンポーネントテストで担保。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -156,8 +156,15 @@ async function seedPhase(cwd: string) {
 // the directory's, like the phase), fetched through the shared dir-config cache.
 type RowChrome = { headerColor: string | null; headerTextColor: string | null };
 const chromeByCwd = reactive(new Map<string, RowChrome>());
+// A freshness token per cwd, exactly like latestPhaseSeed: two rapid dir-config edits can
+// leave fetches resolving out of order, and without this a stale one would overwrite the
+// newer colour.
+const latestChromeSeed = new Map<string, number>();
 async function seedChrome(cwd: string) {
+  const seed = (latestChromeSeed.get(cwd) ?? 0) + 1;
+  latestChromeSeed.set(cwd, seed);
   const config = await fetchDirConfig(cwd);
+  if (latestChromeSeed.get(cwd) !== seed) return; // a newer seed for this cwd already won
   chromeByCwd.set(cwd, { headerColor: config.headerColor, headerTextColor: config.headerTextColor });
 }
 const refreshAllChrome = () => {
@@ -165,16 +172,18 @@ const refreshAllChrome = () => {
   cwds.forEach((cwd) => void seedChrome(cwd));
 };
 // A user editing .mulmoterminal.json is announced on the dir-config channel; re-fetch that
-// directory's chrome so an open roster recolours without a reload.
+// directory's chrome so an open roster recolours without a reload. The unsubscribe is kept
+// and called on unmount so a remounted grid doesn't stack duplicate handlers.
 const cwdOf = (data: unknown): string | null =>
   typeof data === "object" && data !== null && typeof (data as { cwd?: unknown }).cwd === "string" ? (data as { cwd: string }).cwd : null;
-usePubSub().subscribe("dir-config", (data) => {
+const unsubscribeDirConfig = usePubSub().subscribe("dir-config", (data) => {
   const cwd = cwdOf(data);
   if (cwd) {
     invalidateDirConfig(cwd);
     void seedChrome(cwd);
   }
 });
+onBeforeUnmount(unsubscribeDirConfig);
 
 const forgetClosedCells = () => {
   const sessions = new Set(state.value.cells.map((c) => c.session).filter((s): s is string => !!s));
@@ -187,7 +196,10 @@ const forgetClosedCells = () => {
     phaseByCwd.delete(cwd);
     latestPhaseSeed.delete(cwd);
   });
-  staleCacheKeys(chromeByCwd.keys(), cwds).forEach((cwd) => chromeByCwd.delete(cwd));
+  staleCacheKeys(chromeByCwd.keys(), cwds).forEach((cwd) => {
+    chromeByCwd.delete(cwd);
+    latestChromeSeed.delete(cwd);
+  });
 };
 
 // This watch runs whether or not the roster is on screen, and it is what fills sessionMeta,

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -44,6 +44,8 @@ import { registerNewTerminalHandler, type NewTerminalRequest } from "../composab
 import { usePendingScript } from "../composables/usePendingScript";
 import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
+import { fetchDirConfig, invalidateDirConfig } from "../composables/useDirConfig";
+import { usePubSub } from "../composables/usePubSub";
 
 // The multi-terminal grid view, shown at /terminals. Leaving the grid is just a
 // route push from the shared toolbar (Chat / Collections / a favorite), so there's
@@ -149,6 +151,31 @@ async function seedPhase(cwd: string) {
 }
 // Drop what no cell asks for any more, so a day of relaunching cells doesn't leave an entry
 // behind for every session the grid ever showed.
+// The directory chrome each roster row is tinted with — its configured header colour, so
+// a row reads as the same directory as its terminal's header. Keyed by cwd (the config is
+// the directory's, like the phase), fetched through the shared dir-config cache.
+type RowChrome = { headerColor: string | null; headerTextColor: string | null };
+const chromeByCwd = reactive(new Map<string, RowChrome>());
+async function seedChrome(cwd: string) {
+  const config = await fetchDirConfig(cwd);
+  chromeByCwd.set(cwd, { headerColor: config.headerColor, headerTextColor: config.headerTextColor });
+}
+const refreshAllChrome = () => {
+  const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
+  cwds.forEach((cwd) => void seedChrome(cwd));
+};
+// A user editing .mulmoterminal.json is announced on the dir-config channel; re-fetch that
+// directory's chrome so an open roster recolours without a reload.
+const cwdOf = (data: unknown): string | null =>
+  typeof data === "object" && data !== null && typeof (data as { cwd?: unknown }).cwd === "string" ? (data as { cwd: string }).cwd : null;
+usePubSub().subscribe("dir-config", (data) => {
+  const cwd = cwdOf(data);
+  if (cwd) {
+    invalidateDirConfig(cwd);
+    void seedChrome(cwd);
+  }
+});
+
 const forgetClosedCells = () => {
   const sessions = new Set(state.value.cells.map((c) => c.session).filter((s): s is string => !!s));
   const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
@@ -160,6 +187,7 @@ const forgetClosedCells = () => {
     phaseByCwd.delete(cwd);
     latestPhaseSeed.delete(cwd);
   });
+  staleCacheKeys(chromeByCwd.keys(), cwds).forEach((cwd) => chromeByCwd.delete(cwd));
 };
 
 // This watch runs whether or not the roster is on screen, and it is what fills sessionMeta,
@@ -180,10 +208,12 @@ const refreshAllPhases = () => {
   const cwds = new Set(state.value.cells.map((c) => c.cwd).filter((c): c is string => c !== null));
   cwds.forEach((cwd) => void seedPhase(cwd));
 };
+
 const refreshRoster = () => {
   forgetClosedCells();
   refreshAllMeta();
   refreshAllPhases();
+  refreshAllChrome();
 };
 const ROSTER_POLL_MS = 4000;
 let rosterTimer: ReturnType<typeof setInterval> | null = null;
@@ -230,6 +260,8 @@ const listRows = computed(() =>
       fallback: fallbackLabel(c),
       phase: (c.cwd ? phaseByCwd.get(c.cwd) : undefined) ?? ("none" as PrPhase),
       workPhase: meta?.workPhase ?? null,
+      headerColor: (c.cwd ? chromeByCwd.get(c.cwd)?.headerColor : null) ?? null,
+      headerTextColor: (c.cwd ? chromeByCwd.get(c.cwd)?.headerTextColor : null) ?? null,
     };
   }),
 );

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -225,12 +225,18 @@ watch(
         :key="row.uid"
         type="button"
         data-testid="cockpit-row"
-        class="flex cursor-pointer flex-col gap-1 rounded-lg border border-l-[3px] bg-[var(--cell-header-bg,var(--bg-panel))] px-2.5 py-2 text-left text-[var(--cell-header-fg,var(--text))] [font:inherit] hover:brightness-[1.15]"
+        class="flex cursor-pointer flex-col gap-1 overflow-hidden rounded-lg border border-l-[3px] bg-panel px-2.5 py-2 text-left text-fg [font:inherit] hover:brightness-[1.15]"
         :class="row.uid === expandedUid ? 'border-[#4a9eff] border-l-[#4a9eff]' : 'border-border border-l-transparent'"
-        :style="headerStyleFor(row.headerColor, row.headerTextColor)"
         @click="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
       >
-        <span class="flex min-w-0 items-center gap-1.5">
+        <!-- The status + directory line is the row's header: it carries the directory's
+             configured header colour as a bar, pulled to the row's top and side edges. A
+             directory with no colour set leaves the bar transparent. -->
+        <span
+          data-testid="cockpit-header"
+          class="-mx-2.5 -mt-2 flex min-w-0 items-center gap-1.5 bg-[var(--cell-header-bg,transparent)] px-2.5 py-1.5 text-[var(--cell-header-fg,inherit)]"
+          :style="headerStyleFor(row.headerColor, row.headerTextColor)"
+        >
           <span class="h-2 w-2 flex-none rounded-full" :class="DOT_CLASS[row.status]" aria-hidden="true" />
           <span data-testid="cockpit-badge" class="flex-none rounded-full px-1.5 py-px text-[10px] font-bold" :class="BADGE_CLASS[row.status]">{{
             statusWord(row)
@@ -245,7 +251,7 @@ watch(
             {{ phaseDisplay(row.phase)?.label }}
           </span>
           <span v-if="row.agent === 'codex'" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">codex</span>
-          <span class="min-w-0 flex-auto truncate text-[11px] text-dim">{{ formatCwd(row.cwd, home, 44) || "—" }}</span>
+          <span class="min-w-0 flex-auto truncate text-[11px] text-[var(--cell-header-fg,var(--text-dim))]">{{ formatCwd(row.cwd, home, 44) || "—" }}</span>
         </span>
         <span v-if="row.summary" data-testid="cockpit-line" class="line-clamp-2 overflow-hidden text-[12px] leading-[1.35]"
           ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">summary</b> {{ row.summary }}</span

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -13,6 +13,7 @@ import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterP
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { shouldFlipZoom } from "./cellChromeRules";
+import { headerStyleFor } from "./cellHeaderStyle";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -33,6 +34,8 @@ export interface CockpitRow {
   fallback: string | null; // label when there's no prompt/summary yet (launcher/command name)
   phase: PrPhase; // the branch's PR workflow phase (`none` until a PR exists)
   workPhase: WorkPhase | null; // planning vs editing while working; null when unknown / not working
+  headerColor: string | null; // the directory's configured header background, tinting the row
+  headerTextColor: string | null; // and its text colour, so the row stays legible on that tint
 }
 const STATUS_WORD: Record<CellStatus, string> = { working: "running", blocked: "waiting", done: "done", idle: "idle" };
 // A working cell shows what it's doing (planning / editing) when known, else the plain word.
@@ -222,8 +225,9 @@ watch(
         :key="row.uid"
         type="button"
         data-testid="cockpit-row"
-        class="flex cursor-pointer flex-col gap-1 rounded-lg border border-l-[3px] bg-panel px-2.5 py-2 text-left text-fg [font:inherit] hover:brightness-[1.15]"
+        class="flex cursor-pointer flex-col gap-1 rounded-lg border border-l-[3px] bg-[var(--cell-header-bg,var(--bg-panel))] px-2.5 py-2 text-left text-[var(--cell-header-fg,var(--text))] [font:inherit] hover:brightness-[1.15]"
         :class="row.uid === expandedUid ? 'border-[#4a9eff] border-l-[#4a9eff]' : 'border-border border-l-transparent'"
+        :style="headerStyleFor(row.headerColor, row.headerTextColor)"
         @click="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
       >
         <span class="flex min-w-0 items-center gap-1.5">

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -257,19 +257,22 @@ describe("grid cockpit (list view)", () => {
     expect(w.find('[data-testid="cockpit-phase"]').exists()).toBe(false);
   });
 
-  it("tints a row with its directory's configured header colour", async () => {
+  it("colours a row's header bar with its directory's configured header colour", async () => {
     const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { headerColor: "#123456", headerTextColor: "#abcdef" })]);
     await nextTick();
-    const style = w.find('[data-testid="cockpit-row"]').attributes("style") ?? "";
-    expect(style).toContain("--cell-header-bg: #123456");
-    expect(style).toContain("--cell-header-fg: #abcdef");
+    const header = w.find('[data-testid="cockpit-header"]').attributes("style") ?? "";
+    expect(header).toContain("--cell-header-bg: #123456");
+    expect(header).toContain("--cell-header-fg: #abcdef");
+    // Only the header bar is tinted — the row body stays on the theme default.
+    const row = w.find('[data-testid="cockpit-row"]').attributes("style") ?? "";
+    expect(row).not.toContain("--cell-header-bg");
   });
 
-  it("leaves a row on the theme default when its directory sets no header colour", async () => {
+  it("leaves the header bar transparent when its directory sets no header colour", async () => {
     const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { headerColor: null, headerTextColor: null })]);
     await nextTick();
-    const style = w.find('[data-testid="cockpit-row"]').attributes("style") ?? "";
-    expect(style).not.toContain("--cell-header-bg");
+    const header = w.find('[data-testid="cockpit-header"]').attributes("style") ?? "";
+    expect(header).not.toContain("--cell-header-bg");
   });
 
   it.each([

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -63,6 +63,8 @@ const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => (
   fallback: null,
   phase: "none",
   workPhase: null,
+  headerColor: null,
+  headerTextColor: null,
   ...over,
 });
 const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[]) =>
@@ -253,6 +255,21 @@ describe("grid cockpit (list view)", () => {
     const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { phase: "none" })]);
     await nextTick();
     expect(w.find('[data-testid="cockpit-phase"]').exists()).toBe(false);
+  });
+
+  it("tints a row with its directory's configured header colour", async () => {
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { headerColor: "#123456", headerTextColor: "#abcdef" })]);
+    await nextTick();
+    const style = w.find('[data-testid="cockpit-row"]').attributes("style") ?? "";
+    expect(style).toContain("--cell-header-bg: #123456");
+    expect(style).toContain("--cell-header-fg: #abcdef");
+  });
+
+  it("leaves a row on the theme default when its directory sets no header colour", async () => {
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { headerColor: null, headerTextColor: null })]);
+    await nextTick();
+    const style = w.find('[data-testid="cockpit-row"]').attributes("style") ?? "";
+    expect(style).not.toContain("--cell-header-bg");
   });
 
   it.each([


### PR DESCRIPTION
## Summary

grid expand 時のサイドメニュー（既定の cockpit ロスター）の行に、ユーザーがディレクトリごとに設定した **header color が反映されていなかった**。行の背景をその header color に染めるようにした。

- **フィルムストリップ**（サムネイル表示）は完全な TerminalCell を描くので元から色が出ていた
- **ロスター**（既定のテキスト行表示）は `CockpitRow` が色を持たず、status 色だけだった ← ここを修正

## Items to Confirm / Review

1. **見た目の確認は実機で** — 実際に染まること・可読性は目視してほしい。配線とレンダリングはコンポーネントテスト（TerminalGrid をマウントして `--cell-header-bg` 適用を検証）で担保
2. **背景を header color に**（ユーザー選択）— TerminalCell のヘッダーと同じ `headerStyleFor` / CSS 変数の使い方。`headerTextColor` 未設定で `headerColor` だけ設定した場合はテーマ既定の文字色に乗るが、これはターミナルヘッダーと同じ挙動
3. **ライブ更新** — `dir-config` pubsub を購読し、`.mulmoterminal.json` 編集時に該当 cwd を invalidate + 再 seed。開いたままのロスターがリロードなしで再着色する
4. **TDZ** — `chromeByCwd` を `forgetClosedCells` より前に宣言（cells-key watch が `immediate: true` で setup 中に呼ぶため）

## User Prompt

> grid expandでsidemenuのterminalのheader colorがユーザ設定反映されない。なおして
>
> （確認）行背景を header color に

## 実装

計画ファイル: `plans/fix-roster-header-color.md`

`phaseByCwd` と同じ reactive Map パターンを `chromeByCwd`（cwd → `{headerColor, headerTextColor}`）として追加。`fetchDirConfig`（共有キャッシュ）から seed、`forgetClosedCells` で prune、`refreshRoster` に組み込み。`listRows` に2フィールドを足し、`TerminalGrid` のロスター行が `headerStyleFor` で適用。

## 検証

- コンポーネントテスト2件（色を適用する / 未設定時は変数を出さない）。`:style` 束縛を外すと赤くなることを確認済み
- `typecheck` / `typecheck:server` / `typecheck:test` / `lint` / `build` / `test`（233 files, 3202 tests）green
- **実際の色の見た目のみ実機確認が必要**

🤖 Generated with [Claude Code](https://claude.com/claude-code)