### PR TITLE
refactor: index/agent クエリパラメータのパーサを1箇所に集約 (#676 ついで)

### DIFF
--- a/plans/refactor-676-route-param-parsers.md
+++ b/plans/refactor-676-route-param-parsers.md
@@ -1,0 +1,23 @@
+# refactor: shared route-param parsers (#676 ついで)
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/676（「ついで」節）
+
+## 問題
+
+2 つの query-param 判断がルートにコピペで散在していた:
+
+- `/^\d+$/` の index パース: `ws-routes.ts` の `?index=`（run）と `?launcher=`（launch）で完全重複。
+- `agent === "codex" ? "codex" : "claude"` の正規化: `ws-routes.ts` / `session-routes.ts` / `dir-routes.ts` の 3 箇所に重複（大文字 `CODEX` は黙って claude に倒れる）。
+
+判断が複数箇所に散ると片方だけ変わってドリフトする。
+
+## 変更
+
+- 新規 `server/routes/routeParams.ts`:
+  - `parseIndexParam(raw: string | null): number` — 非負整数のみ、それ以外は NaN（下流 `resolveScript`/`canStartLauncher` が NaN を拒否）。
+  - `normalizeAgent(raw: unknown): "codex" | "claude"` — 厳密に `"codex"` のときだけ codex、それ以外（`"CODEX"`・空・null・配列など）は claude。
+- 5 箇所の呼び出しを置換（ws-routes ×3、session-routes ×1、dir-routes ×1）。挙動不変。
+
+## テスト
+
+`test/server/routes/routeParams.spec.ts`: parseIndexParam の正常/NaN 群（空・負・小数・指数・前後空白）、normalizeAgent の codex 一致・各種フォールバック・大小文字非対称の pin。両パーサを壊すと 3 件赤・戻すと緑を変異テストで確認済み。

--- a/server/routes/dir-routes.ts
+++ b/server/routes/dir-routes.ts
@@ -6,6 +6,7 @@
 import type { Express } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
 import { workspaceFromQuery } from "../config/workspace.js";
+import { normalizeAgent } from "./routeParams.js";
 import { getHeaderConfig } from "../config/config-routes.js";
 import { publicDirConfig, dirSoundFile, loadDirConfig } from "../config/dir-config.js";
 import { buildHeaderContext, loadHeaderConfig, repoFromWebUrl } from "../config/header-context.js";
@@ -74,7 +75,7 @@ export function mountDirRoutes(app: Express): void {
   app.get("/api/header", async (req, res) => {
     const cwd = workspaceFromQuery(req.query.cwd);
     const session = typeof req.query.session === "string" && SESSION_ID_RE.test(req.query.session) ? req.query.session : null;
-    const agent = req.query.agent === "codex" ? "codex" : "claude";
+    const agent = normalizeAgent(req.query.agent);
     const model = typeof req.query.model === "string" ? req.query.model : null;
     const config = loadHeaderConfig(cwd, getHeaderConfig());
     const context = await buildHeaderContext(cwd, { session, agent, model });

--- a/server/routes/routeParams.ts
+++ b/server/routes/routeParams.ts
@@ -1,0 +1,19 @@
+// Two tiny query-param decisions shared by the terminal ws/session/dir routes, pulled out of
+// the handlers so the parse rules live in one place (they were copied verbatim across three
+// files, which is how they drift).
+
+// A non-negative integer index from a query param, or NaN for anything else — empty string,
+// "-1", "1.5", "1e2", or a missing param. The anchored /^\d+$/ is deliberate: downstream
+// resolveScript / canStartLauncher treat NaN as "no such index" and refuse, so a sloppy value
+// must not slip through as some other number.
+export function parseIndexParam(raw: string | null): number {
+  return raw !== null && /^\d+$/.test(raw) ? Number(raw) : NaN;
+}
+
+// The agent a request selects, normalized. Only an exact "codex" chooses codex; everything
+// else — including "CODEX", "", null, an array, or a missing param — falls back to claude, the
+// default backend. Case-sensitive on purpose: the query value comes straight from a URL, and a
+// mis-cased "CODEX" starting Claude is safer than guessing the user meant codex.
+export function normalizeAgent(raw: unknown): "codex" | "claude" {
+  return raw === "codex" ? "codex" : "claude";
+}

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -7,6 +7,7 @@
 import type { Express, Request, Response } from "express";
 import { promises as fs } from "node:fs";
 import { CLAUDE_CWD, SESSION_ID_RE } from "../config/env.js";
+import { normalizeAgent } from "./routeParams.js";
 import { resolveWorkspace } from "../config/workspace.js";
 import { hasErrnoCode } from "../errors.js";
 import {
@@ -102,7 +103,7 @@ async function toolTimeline(req: Request, res: Response) {
 async function lastTurn(req: Request, res: Response) {
   const { session } = req.query;
   if (typeof session !== "string" || !SESSION_ID_RE.test(session)) return res.status(400).json({ error: "invalid session id" });
-  const agent = req.query.agent === "codex" ? "codex" : "claude";
+  const agent = normalizeAgent(req.query.agent);
   const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
   const turn = await sessionLastTurn(cwd, session, agent);
   // ?as=reply drops the prompt block: the caller is relaying an ANSWER back to whoever

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -31,6 +31,7 @@ import { canStartLauncher, resolveReattachableId, resolveSession, type SessionRe
 import type { PtyEntry } from "../session/types.js";
 import type { SpawnClaudePty, SpawnCodexPty, SpawnCommandPty, SpawnLauncherPty, ResolveLauncher } from "../session/spawners.js";
 import { terminalWsKind, type TerminalWsKind } from "./terminal-ws-path.js";
+import { normalizeAgent, parseIndexParam } from "./routeParams.js";
 import { codexResumeId } from "../agents/codex-resume.js";
 
 export interface WsRouteDeps {
@@ -83,7 +84,7 @@ async function resolveButtonRun(url: URL, cwd: string): Promise<{ command: strin
   if (!buttonId) return null;
   const sessionRaw = url.searchParams.get("session");
   const session = sessionRaw && SESSION_ID_RE.test(sessionRaw) ? sessionRaw : null;
-  const agent = url.searchParams.get("agent") === "codex" ? "codex" : "claude";
+  const agent = normalizeAgent(url.searchParams.get("agent"));
   const config = loadHeaderConfig(cwd, getHeaderConfig());
   const context = await buildHeaderContext(cwd, { session, agent, model: url.searchParams.get("model") });
   const command = resolveButtonCommand(config, context, buttonId, shellQuoteFor(process.platform));
@@ -94,9 +95,7 @@ async function resolveRunTarget(url: URL): Promise<{ command: string; cwd: strin
   const cwd = resolveWorkspace(url.searchParams.get("cwd"));
   const byButton = await resolveButtonRun(url, cwd);
   if (byButton) return byButton;
-  const indexRaw = url.searchParams.get("index");
-  const index = indexRaw !== null && /^\d+$/.test(indexRaw) ? Number(indexRaw) : NaN;
-  return resolveScript(cwd, index);
+  return resolveScript(cwd, parseIndexParam(url.searchParams.get("index")));
 }
 
 async function startRunTerminal(deps: WsRouteDeps, ws: WebSocket, url: URL): Promise<void> {
@@ -292,8 +291,7 @@ function handleRunConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: stri
 // and is marked a dev-terminal session so it stays out of the chat sidebar.
 function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: string; headers?: unknown }) {
   const { url, requested, cwd } = wsConnectionContext(req);
-  const indexRaw = url.searchParams.get("launcher");
-  const index = indexRaw !== null && /^\d+$/.test(indexRaw) ? Number(indexRaw) : NaN;
+  const index = parseIndexParam(url.searchParams.get("launcher"));
   const shell = url.searchParams.get("shell") === "1";
 
   const resolved = resolveLaunchSession(deps, requested, index, shell);

--- a/test/server/routes/routeParams.spec.ts
+++ b/test/server/routes/routeParams.spec.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { parseIndexParam, normalizeAgent } from "../../../server/routes/routeParams.js";
+
+describe("parseIndexParam", () => {
+  it("parses a non-negative integer", () => {
+    expect(parseIndexParam("0")).toBe(0);
+    expect(parseIndexParam("5")).toBe(5);
+    expect(parseIndexParam("12")).toBe(12);
+  });
+
+  it("is NaN for a missing param", () => {
+    expect(parseIndexParam(null)).toBeNaN();
+  });
+
+  it("is NaN for anything that isn't a bare non-negative integer", () => {
+    for (const raw of ["", "-1", "1.5", "1e2", "abc", " 3", "3 ", "+3", "0x1"]) {
+      expect(parseIndexParam(raw)).toBeNaN();
+    }
+  });
+});
+
+describe("normalizeAgent", () => {
+  it("selects codex only for an exact 'codex'", () => {
+    expect(normalizeAgent("codex")).toBe("codex");
+  });
+
+  it("falls back to claude for everything else", () => {
+    for (const raw of ["claude", "", "gpt", null, undefined, 5, ["codex"], { agent: "codex" }]) {
+      expect(normalizeAgent(raw)).toBe("claude");
+    }
+  });
+
+  // Case-sensitive on purpose: the value comes from a raw URL, and a mis-cased "CODEX"
+  // starting Claude is safer than guessing.
+  it("does not match a mis-cased CODEX", () => {
+    expect(normalizeAgent("CODEX")).toBe("claude");
+    expect(normalizeAgent("Codex")).toBe("claude");
+  });
+});


### PR DESCRIPTION
## Summary

2 つの query-param 判断がターミナルルートにコピペで散在していたのを 1 箇所に集約した。
- `/^\d+$/` の index パース — `ws-routes.ts` の `?index=`（run）と `?launcher=`（launch）で完全重複。
- `agent === "codex" ? "codex" : "claude"` の正規化 — `ws-routes.ts` / `session-routes.ts` / `dir-routes.ts` の 3 箇所に重複。

新規 `server/routes/routeParams.ts` に `parseIndexParam` / `normalizeAgent` を出し、5 箇所の呼び出しを置換。**挙動不変**。

## Items to Confirm / Review

- `normalizeAgent` は大文字 `"CODEX"` を意図的に claude へフォールバックさせる（URL 由来の値なので、誤 casing で codex を推測するより安全）。テストで pin。
- `parseIndexParam` は非負整数のみ（空・負・小数・指数・前後空白は NaN）。下流 `resolveScript`/`canStartLauncher` が NaN を拒否。
- 両パーサを壊すと 3 件赤・戻すと緑を変異テストで確認済み。`typecheck` / `:server` / `:test` 通過、route 系 75 テスト緑。

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した(#676)。その「ついで」項目（重複した判断の集約）を実装する。

Part of #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)