### PR TITLE
fix: hidden セッションのマーカーが spawn 失敗時にリークするのを直す (#676 ついで)

### DIFF
--- a/plans/fix-676-hidden-session-spawn-leak.md
+++ b/plans/fix-676-hidden-session-spawn-leak.md
@@ -1,0 +1,28 @@
+# fix: don't leak a hidden-session marker when the spawn throws (#676 ついで)
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/676（「ついで」節）
+
+## 問題
+
+`spawnBackgroundChat`（`plugin-routes.ts`）と `feedsSpawnWorker`（`index.ts`）は
+`if (hidden) hiddenSessions.add(sessionId)` を spawn の**前**に実行し、spawn が throw しても
+その id を集合から取り除かない。id はランダム UUID で他に reap する経路が無いため、失敗した
+hidden spawn ごとにマーカーがプロセス終了まで滞留する（軽微だが恒久的なリーク）。
+
+## 修正
+
+判断を pure な higher-order 関数に切り出す:
+
+```ts
+runWithHiddenMarker(hidden, sessionId, markers, spawn)
+```
+
+spawn 前にマーカーを付け（mid-spawn の hook が hidden を見られるよう add は前）、spawn が
+throw したら delete して再 throw する。`plugin-routes.ts` と `index.ts` の 2 箇所を置換。
+`hiddenSessions`（Set）を `markers` として渡す。挙動は成功時不変・失敗時にリークが消える。
+
+## テスト
+
+`test/server/session/hiddenMarker.spec.ts`: 成功でマーカー維持 / throw で add→delete され再 throw /
+hidden=false では add/delete を一切呼ばない（成功・throw 双方）。catch の delete を外すと
+「throw でマーカーが残らない」テストが赤・戻すと緑を変異テストで確認済み。

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import { mountTerminalWebSockets } from "./routes/ws-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
 import { activity, aiTitles, hiddenSessions, knownSessions, ptys } from "./session/registry.js";
+import { runWithHiddenMarker } from "./session/hiddenMarker.js";
 import { createToolStores } from "./session/tool-store.js";
 import { createScheduledSessionRegistry, scheduledSessionInUse, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
@@ -282,10 +283,9 @@ initAccountingBackend({ workspace: CLAUDE_CWD, pubsub });
 // watch; `onComplete` is honoured only for hidden (scheduled) workers, which MulmoTerminal
 // doesn't register yet, so it's unused for now. `roleId` is ignored (no role system).
 const feedsSpawnWorker: AgentWorkerRunner = async ({ message, hidden }) => {
+  const sessionId = randomUUID();
   try {
-    const sessionId = randomUUID();
-    if (hidden) hiddenSessions.add(sessionId);
-    spawnClaudePty(sessionId, null, null, { initialPrompt: message });
+    runWithHiddenMarker(hidden, sessionId, hiddenSessions, () => spawnClaudePty(sessionId, null, null, { initialPrompt: message }));
     return { ok: true, chatId: sessionId };
   } catch (err) {
     return { ok: false, error: messageOf(err) };

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -11,6 +11,7 @@ import { CLAUDE_CWD, PORT } from "../config/env.js";
 import { messageOf } from "../errors.js";
 import { isRecord } from "../session/transcript.js";
 import { hiddenSessions } from "../session/registry.js";
+import { runWithHiddenMarker } from "../session/hiddenMarker.js";
 import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../session/background-chat.js";
 import { codexifySkillSeed } from "../agents/codex-skills.js";
 import { manageCollectionHandler } from "../infra/collection-tool.js";
@@ -36,16 +37,17 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
     if (!parsed.ok) return res.json({ message: parsed.message });
     const { agent, draft, hidden, message } = parsed.request;
     const sessionId = randomUUID();
-    if (hidden) hiddenSessions.add(sessionId);
     // ws is null: the session runs headless until the user opens it (reattach replays the buffered
     // output). A claude draft spawns with NO initial prompt (so it doesn't auto-run) and gets the text
     // typed into its input box. codex has no editable-draft path (no stable TUI ready-marker), so its
     // seed always auto-runs as codex's positional first-turn prompt, with the GUI MCP attached.
     try {
-      const mode = spawnModeFor(agent, draft);
-      if (mode === "codex-run") deps.spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, codexifySkillSeed(message));
-      else if (mode === "claude-draft") deps.spawnClaudePty(sessionId, null, null, { draft: message });
-      else deps.spawnClaudePty(sessionId, null, null, { initialPrompt: message });
+      runWithHiddenMarker(hidden, sessionId, hiddenSessions, () => {
+        const mode = spawnModeFor(agent, draft);
+        if (mode === "codex-run") deps.spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, codexifySkillSeed(message));
+        else if (mode === "claude-draft") deps.spawnClaudePty(sessionId, null, null, { draft: message });
+        else deps.spawnClaudePty(sessionId, null, null, { initialPrompt: message });
+      });
     } catch (err) {
       console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);
       return res.json({ message: `Failed to spawn a new session: ${messageOf(err)}` });

--- a/server/session/hiddenMarker.ts
+++ b/server/session/hiddenMarker.ts
@@ -1,0 +1,15 @@
+// Run a session spawn while it is marked hidden, and un-mark it if the spawn throws.
+//
+// A hidden session id is a random UUID that only this process knows; nothing else ever reaps
+// it. So if we add the marker, then the spawn fails, the id would linger in the hidden set for
+// the life of the process — a slow leak on every failed background/feed spawn. Add before the
+// spawn (a hook that fires mid-spawn must already see it hidden), remove again on failure.
+export function runWithHiddenMarker<T>(hidden: boolean, sessionId: string, markers: { add(id: string): void; delete(id: string): void }, spawn: () => T): T {
+  if (hidden) markers.add(sessionId);
+  try {
+    return spawn();
+  } catch (err) {
+    if (hidden) markers.delete(sessionId);
+    throw err;
+  }
+}

--- a/test/server/session/hiddenMarker.spec.ts
+++ b/test/server/session/hiddenMarker.spec.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+
+import { runWithHiddenMarker } from "../../../server/session/hiddenMarker.js";
+
+describe("runWithHiddenMarker", () => {
+  it("marks the session hidden and keeps the marker when the spawn succeeds", () => {
+    const set = new Set<string>();
+    const result = runWithHiddenMarker(true, "s1", set, () => "spawned");
+    expect(result).toBe("spawned");
+    expect(set.has("s1")).toBe(true);
+  });
+
+  it("removes the marker again when the spawn throws, and re-throws", () => {
+    const set = new Set<string>();
+    const boom = new Error("spawn failed");
+    expect(() =>
+      runWithHiddenMarker(true, "s2", set, () => {
+        expect(set.has("s2")).toBe(true); // added before the spawn runs (a mid-spawn hook must see it)
+        throw boom;
+      }),
+    ).toThrow(boom);
+    expect(set.has("s2")).toBe(false); // no phantom hidden id left behind
+  });
+
+  it("never touches the set when the session isn't hidden (success)", () => {
+    const set = { add: vi.fn(), delete: vi.fn() };
+    expect(runWithHiddenMarker(false, "s3", set, () => 42)).toBe(42);
+    expect(set.add).not.toHaveBeenCalled();
+    expect(set.delete).not.toHaveBeenCalled();
+  });
+
+  it("never touches the set when the session isn't hidden (throw)", () => {
+    const set = { add: vi.fn(), delete: vi.fn() };
+    expect(() =>
+      runWithHiddenMarker(false, "s4", set, () => {
+        throw new Error("x");
+      }),
+    ).toThrow("x");
+    expect(set.add).not.toHaveBeenCalled();
+    expect(set.delete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`spawnBackgroundChat`（`plugin-routes.ts`）と `feedsSpawnWorker`（`index.ts`）は `if (hidden) hiddenSessions.add(sessionId)` を spawn の**前**に行い、spawn が throw してもその id を集合から取り除かなかった。id はランダム UUID で他に reap 経路が無いため、失敗した hidden spawn ごとにマーカーがプロセス終了まで滞留していた（軽微だが恒久的なリーク）。

判断を pure な higher-order 関数 `runWithHiddenMarker(hidden, sessionId, markers, spawn)` に切り出し、spawn 前に付与・throw 時に除去して再 throw するようにした。2 箇所を置換。

## Items to Confirm / Review

- add は spawn の**前**のまま（mid-spawn の hook が hidden を見られる必要があるため）。除去は catch でのみ。成功時の挙動は不変、失敗時にリークが消える。
- `hiddenSessions`(Set) を `markers` として注入。テストは fake Set / vi.fn で成功・throw・hidden=false を網羅。catch の delete を外すと該当テストが赤・戻すと緑を変異テストで確認済み。
- `typecheck` / `:server` / `:test` 通過、server session+routes 860 テスト緑。

## User Prompt

全ソースを調査して pure 関数として切り出し・テスト化できる箇所を洗い出し issue 化した(#676)。その「ついで」項目（潜在リークの修正）を実装する。

Part of #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)