### PR TITLE
feat: claude-ollama — run Claude Code locally against an Ollama model (#692)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ listener and needs a browser **on the host**. Either way it needs a Desktop OAut
 as `~/.secrets/client_secret_*.json`; the refresh token lands in `~/.config/mulmo/google-token.json`
 and is **shared with MulmoClaude**, so one link per machine covers both apps.
 
+**Local models (optional).** The package also ships `claude-ollama` — a one-command launcher that
+runs Claude Code **fully locally against an [Ollama](https://ollama.com) model** (no cloud, no API
+key). It starts a large-context Ollama server and launches `claude` with a minimal system prompt so
+small models aren't drowned:
+
+```bash
+ollama pull qwen3:4b
+npx -p mulmoterminal claude-ollama qwen3:4b   # or, if installed globally: claude-ollama qwen3:4b
+```
+
+See [Local models with claude-ollama](https://receptron.github.io/mulmoterminal/guide/en/claude-ollama.html)
+for the details and model notes.
+
 > **Already linked before the calendar-list / colour features?** They need a read scope your existing
 > link doesn't have, so `listCalendars` (and, in practice, `colors`) fail with an insufficient-scope
 > 403 until you re-authorize: **Settings → Google account → Unlink**, then sign in again (or re-run

--- a/bin/claude-ollama.js
+++ b/bin/claude-ollama.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+// `claude-ollama <model> [claude args…]` — run Claude Code fully locally against an
+// Ollama-served model. Ollama 0.31+ serves a native Anthropic-compatible `/v1/messages`, so
+// Claude Code connects directly; this launcher just sets up the three things that make it
+// actually work with a small local model:
+//   1. a dedicated large-context `ollama serve` (the 4096 default overflows Claude's prompt),
+//   2. `--bare --disable-slash-commands` so the system prompt is small enough for the model,
+//   3. the env recipe (unset ANTHROPIC_API_KEY, point ANTHROPIC_BASE_URL at the local server).
+
+import { execSync, spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { get as httpGet } from "node:http";
+import { parseClaudeOllamaArgs, buildClaudeEnv, buildOllamaServeEnv, buildClaudeArgs, modelIsInstalled, OLLAMA_CONTEXT_LENGTH } from "./ollama-launch.js";
+
+const log = (msg) => console.log(`\x1b[36m[claude-ollama]\x1b[0m ${msg}`);
+const error = (msg) => console.error(`\x1b[31m[claude-ollama]\x1b[0m ${msg}`);
+
+const READY_TIMEOUT_MS = 20_000;
+const READY_POLL_MS = 400;
+
+function printHelp() {
+  console.log(
+    [
+      "Usage: claude-ollama <model> [claude args…]",
+      "",
+      "Run Claude Code against a local Ollama model — no cloud, no API key.",
+      "Starts a dedicated large-context Ollama server on a private port and launches",
+      "Claude Code with a minimal system prompt (--bare) so small models aren't drowned.",
+      "",
+      "Examples:",
+      "  claude-ollama qwen3:4b",
+      '  claude-ollama qwen3:30b-a3b "refactor this module"',
+      "",
+      "Notes:",
+      "  - The model must be pulled first:  ollama pull <model>",
+      "  - Validate a model through a real multi-turn tool run; small ones vary.",
+    ].join("\n"),
+  );
+}
+
+function hasCommand(cmd) {
+  try {
+    execSync(`${cmd} --version`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// A free TCP port for the private ollama server, so an Ollama the user already runs (11434)
+// is left alone.
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const { port } = probe.address();
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
+// GET a small JSON endpoint on the local server, best-effort (null on any failure).
+function getJson(port, path, timeout_ms = 2000) {
+  return new Promise((resolve) => {
+    const req = httpGet({ host: "127.0.0.1", port, path, timeout: timeout_ms }, (res) => {
+      let body = "";
+      res.on("data", (chunk) => (body += chunk));
+      res.on("end", () => {
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(null);
+    });
+  });
+}
+
+async function waitUntilReady(port) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < READY_TIMEOUT_MS) {
+    if (await getJson(port, "/api/version")) return true;
+    await new Promise((r) => setTimeout(r, READY_POLL_MS));
+  }
+  return false;
+}
+
+function requireCommands() {
+  if (!hasCommand("ollama")) {
+    error("`ollama` not found on PATH. Install it: https://ollama.com/download");
+    process.exit(1);
+  }
+  if (!hasCommand("claude")) {
+    error("`claude` (Claude Code) not found. Install it: npm install -g @anthropic-ai/claude-code");
+    process.exit(1);
+  }
+}
+
+// Start the private ollama server and return a `stop` that kills it. The stop is wired to
+// this process's own exit and signals so the server never outlives the launcher.
+function startPrivateOllama(host) {
+  const serve = spawn("ollama", ["serve"], {
+    stdio: "ignore",
+    env: buildOllamaServeEnv(process.env, host, OLLAMA_CONTEXT_LENGTH),
+  });
+  let stopped = false;
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    try {
+      serve.kill("SIGTERM");
+    } catch {
+      // already gone
+    }
+  };
+  process.on("exit", stop);
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => {
+      stop();
+      process.exit(signal === "SIGINT" ? 130 : 143);
+    });
+  }
+  serve.on("error", (e) => {
+    error(`failed to start ollama serve: ${e.message}`);
+    process.exit(1);
+  });
+  return stop;
+}
+
+// Hand off to interactive Claude Code; exit with its code and stop our server behind it.
+function runClaude(model, baseUrl, claudeArgs, stopServe) {
+  log(`launching Claude Code on ${model} (minimal prompt: --bare --disable-slash-commands)`);
+  const claude = spawn("claude", buildClaudeArgs(claudeArgs), {
+    stdio: "inherit",
+    env: buildClaudeEnv(process.env, model, baseUrl),
+  });
+  claude.on("error", (e) => {
+    error(`failed to launch claude: ${e.message}`);
+    stopServe();
+    process.exit(1);
+  });
+  claude.on("exit", (code) => {
+    stopServe();
+    process.exit(code ?? 0);
+  });
+}
+
+async function main() {
+  const { help, model, claudeArgs } = parseClaudeOllamaArgs(process.argv.slice(2));
+  if (help || !model) {
+    printHelp();
+    process.exit(help ? 0 : 1);
+  }
+  requireCommands();
+  const port = await findFreePort();
+  const host = `127.0.0.1:${port}`;
+  log(`starting a private Ollama server on ${host} (context ${OLLAMA_CONTEXT_LENGTH})…`);
+  const stopServe = startPrivateOllama(host);
+  if (!(await waitUntilReady(port))) {
+    error("the Ollama server did not become ready in time");
+    stopServe();
+    process.exit(1);
+  }
+  const tags = await getJson(port, "/api/tags");
+  if (tags && !modelIsInstalled(tags, model)) {
+    error(`model '${model}' is not installed. Pull it first:  ollama pull ${model}`);
+    stopServe();
+    process.exit(1);
+  }
+  runClaude(model, `http://${host}`, claudeArgs, stopServe);
+}
+
+main().catch((e) => {
+  error(e?.message || String(e));
+  process.exit(1);
+});

--- a/bin/ollama-launch.d.ts
+++ b/bin/ollama-launch.d.ts
@@ -1,0 +1,13 @@
+export declare const OLLAMA_CONTEXT_LENGTH: number;
+export declare const CLAUDE_MAX_OUTPUT_TOKENS: number;
+export declare const OLLAMA_AUTH_TOKEN: string;
+export declare const MINIMAL_PROMPT_FLAGS: string[];
+export declare function parseClaudeOllamaArgs(argv: string[]): { help: boolean; model: string | null; claudeArgs: string[] };
+export declare function buildClaudeEnv(baseEnv: Record<string, string | undefined>, model: string, baseUrl: string): Record<string, string | undefined>;
+export declare function buildOllamaServeEnv(
+  baseEnv: Record<string, string | undefined>,
+  host: string,
+  contextLength?: number,
+): Record<string, string | undefined>;
+export declare function buildClaudeArgs(claudeArgs: string[]): string[];
+export declare function modelIsInstalled(tags: unknown, model: string): boolean;

--- a/bin/ollama-launch.js
+++ b/bin/ollama-launch.js
@@ -1,0 +1,60 @@
+// Pure helpers for the `claude-ollama` launcher, split out so the decisions can be tested
+// without spawning ollama or claude. The launcher (bin/claude-ollama.js) keeps the I/O.
+
+export const OLLAMA_CONTEXT_LENGTH = 32768;
+export const CLAUDE_MAX_OUTPUT_TOKENS = 8000;
+export const OLLAMA_AUTH_TOKEN = "ollama";
+
+// The flags that shrink Claude Code's system prompt so a small local model isn't drowned by
+// skills / plugins / MCP / hooks. Measured: ~16386 tokens without them, ~400 with — the
+// difference between qwen3:4b answering generically and actually completing a tool loop.
+export const MINIMAL_PROMPT_FLAGS = ["--bare", "--disable-slash-commands"];
+
+// Parse `claude-ollama <model> [claude args…]`: the first argument is the model, the rest pass
+// through to claude untouched. No model (or -h/--help) asks for help.
+export function parseClaudeOllamaArgs(argv) {
+  const args = Array.isArray(argv) ? argv : [];
+  if (args.length === 0 || args[0] === "-h" || args[0] === "--help") {
+    return { help: true, model: null, claudeArgs: [] };
+  }
+  const [model, ...claudeArgs] = args;
+  return { help: false, model, claudeArgs };
+}
+
+// The environment Claude Code needs to talk to the local Ollama server instead of Anthropic's
+// cloud. ANTHROPIC_API_KEY is REMOVED, not overwritten: if it survives, Claude prefers it and
+// ignores the base URL (and warns). Base env is copied so the child keeps PATH etc.
+export function buildClaudeEnv(baseEnv, model, baseUrl) {
+  const env = { ...baseEnv };
+  delete env.ANTHROPIC_API_KEY;
+  env.ANTHROPIC_BASE_URL = baseUrl;
+  env.ANTHROPIC_AUTH_TOKEN = OLLAMA_AUTH_TOKEN;
+  env.ANTHROPIC_MODEL = model;
+  // The background "small/fast" slot must resolve too, or it errors; point it at the same
+  // local model (there is no local haiku).
+  env.ANTHROPIC_SMALL_FAST_MODEL = model;
+  // A reasoning model spends its first budget on a thinking block; a small ceiling makes the
+  // first turn come back empty, so keep it generous.
+  env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = String(CLAUDE_MAX_OUTPUT_TOKENS);
+  return env;
+}
+
+// The environment for the dedicated `ollama serve`: a big context window (Claude's system
+// prompt overflows the 4096 default and the session dies on the second turn) on a private host
+// so any Ollama the user already runs is left untouched.
+export function buildOllamaServeEnv(baseEnv, host, contextLength = OLLAMA_CONTEXT_LENGTH) {
+  return { ...baseEnv, OLLAMA_HOST: host, OLLAMA_CONTEXT_LENGTH: String(contextLength) };
+}
+
+// The full claude argv: the prompt-shrinking flags first, then the user's pass-through args
+// (last, so they can add to or override the defaults).
+export function buildClaudeArgs(claudeArgs) {
+  return [...MINIMAL_PROMPT_FLAGS, ...(Array.isArray(claudeArgs) ? claudeArgs : [])];
+}
+
+// Whether `model` is present in a GET /api/tags payload. Accepts the bare name too
+// (`qwen3` → `qwen3:latest`), the way `ollama run` resolves an untagged name.
+export function modelIsInstalled(tags, model) {
+  const names = Array.isArray(tags?.models) ? tags.models.map((m) => m?.name).filter((n) => typeof n === "string") : [];
+  return names.includes(model) || names.includes(`${model}:latest`);
+}

--- a/docs/guide/en/claude-ollama.md
+++ b/docs/guide/en/claude-ollama.md
@@ -1,0 +1,74 @@
+---
+title: Local models with claude-ollama
+layout: default
+parent: English
+nav_order: 6
+---
+
+# Local models with claude-ollama
+{: .no_toc }
+
+`claude-ollama` is a one-command launcher that runs Claude Code **fully locally against a
+[Ollama](https://ollama.com) model** — no cloud, no API key, works offline.
+
+> This is not the MulmoTerminal web UI — it's a standalone wrapper (bundled with the
+> mulmoterminal package) that launches plain `claude` (the Claude Code CLI) pointed at Ollama.
+
+## Prerequisites
+
+- [Ollama](https://ollama.com/download) installed — **server 0.31 or newer** (it needs the
+  native Anthropic-compatible `/v1/messages`). The **running server** version is what matters:
+  `curl http://localhost:11434/api/version` — the packaged CLI can lag.
+- Claude Code (`claude`) installed (`npm install -g @anthropic-ai/claude-code`).
+- The model pulled (`ollama pull qwen3:4b`).
+
+## Usage
+
+```bash
+# via npx (no install)
+npx -p mulmoterminal claude-ollama qwen3:4b
+
+# or install mulmoterminal globally
+npm install -g mulmoterminal
+claude-ollama qwen3:4b
+
+# extra args pass straight through to claude
+claude-ollama qwen3:30b-a3b "refactor this module"
+```
+
+## What it sets up (three things)
+
+Ollama 0.31+ serves a native Anthropic-compatible `/v1/messages`, so pointing
+`ANTHROPIC_BASE_URL` at it connects with no translation layer. But **making a small local model
+actually work needs three things, which `claude-ollama` wires up for you**:
+
+1. **A big context** — a dedicated `ollama serve` on a private free port with
+   `OLLAMA_CONTEXT_LENGTH=32768`. The 4096 default overflows Claude's system prompt and the
+   session dies on the second turn. **Any Ollama you already run (11434) is left untouched**, and
+   the private server is stopped when you exit.
+2. **A minimal system prompt** — `claude --bare --disable-slash-commands`, dropping
+   skills / plugins / MCP / hooks. This shrinks the prompt from **~16000 to ~400 tokens**.
+   **Without it, a small model drowns and answers generically instead of using tools** — the
+   number-one reason it "doesn't work".
+3. **The env recipe** — remove `ANTHROPIC_API_KEY` (if present it outranks the base URL) and set
+   `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN=ollama` / `ANTHROPIC_MODEL` /
+   `ANTHROPIC_SMALL_FAST_MODEL` (the same model) / `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000`.
+
+## Choosing a model
+
+- **`qwen3:4b` (light) / `qwen3:30b-a3b`** complete a multi-turn tool loop (create a file, read
+  it back, report) cleanly.
+- **`llama3.1:8b` does not** — it returns a valid one-shot tool call but breaks inside the
+  multi-turn loop (its Ollama chat template leaks an `assistant\n\n` prefix on the tool-result
+  turn).
+- **Validate through a real multi-turn run** — a single endpoint probe isn't enough.
+
+## Caveats
+
+- **Speed depends on the model and machine.** Even qwen3:4b can take tens of seconds to a few
+  minutes per tool-using turn under load (it does complete).
+- A fresh dedicated server reloads the model (slower first turn) but guarantees the big context.
+
+---
+
+← [Using another model via OpenRouter](providers.html) / [English guide index](index.html)

--- a/docs/guide/en/index.md
+++ b/docs/guide/en/index.md
@@ -59,5 +59,6 @@ npx mulmoterminal@latest    # opens http://localhost:34567
 3. [Feature reference](features.html) (grouped by the four pillars)
 4. [Configuration](config.html) (settings modal · `config.json` · `.mulmoterminal.json` · the **DSL**)
 5. [Using another model via OpenRouter](providers.html) (run Kimi / DeepSeek / Gemini, with measured data)
+6. [Local models with claude-ollama](claude-ollama.html) (fully local, offline, via Ollama)
 
 > The Japanese guide is here: [日本語ガイド](../ja/).

--- a/docs/guide/en/providers.md
+++ b/docs/guide/en/providers.md
@@ -341,47 +341,11 @@ If you are unsure where to start, try **Kimi K2.7 Code** (fast, coding-oriented)
 - An unresolvable key **refuses the launch**, so prompts never reach an unintended backend
 - `ANTHROPIC_API_KEY` is **removed** from a provider session's environment — left in place it would outrank the auth token
 
-## Running a local LLM from the CLI (claude-ollama)
+## Running a local LLM (claude-ollama)
 
-Everything above is about providers (Anthropic-compatible backends like OpenRouter). You can
-also run Claude Code **fully locally against an Ollama model — no cloud at all**. The bundled
-`claude-ollama` command does exactly that.
-
-> This is not the MulmoTerminal web UI — it's a standalone wrapper that launches plain
-> `claude` (the Claude Code CLI) pointed at Ollama.
-
-### Usage
-
-```bash
-ollama pull qwen3:4b            # pull the model first
-claude-ollama qwen3:4b          # launch Claude Code on the local model
-claude-ollama qwen3:30b-a3b "refactor this module"
-```
-
-### What it sets up (three things)
-
-Ollama 0.31+ serves a native Anthropic-compatible `/v1/messages`, so pointing
-`ANTHROPIC_BASE_URL` at it connects with no translation layer. But making a *small* local model
-actually work needs three things, which `claude-ollama` wires up for you:
-
-1. **A big context** — a dedicated `ollama serve` on a private port with
-   `OLLAMA_CONTEXT_LENGTH=32768` (the 4096 default overflows Claude's system prompt and the
-   session dies on the second turn). Any Ollama you already run (11434) is left untouched.
-2. **A minimal system prompt** — `claude --bare --disable-slash-commands`, which drops
-   skills / plugins / MCP / hooks and shrinks the prompt from **~16000 to ~400 tokens**.
-   Without it, a small model drowns and answers generically instead of using tools.
-3. **The env recipe** — remove `ANTHROPIC_API_KEY` (if present it outranks the base URL) and
-   set `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN=ollama` / `ANTHROPIC_MODEL` /
-   `ANTHROPIC_SMALL_FAST_MODEL` (the same model) / `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000`.
-
-### Caveats
-
-- **Speed depends on the model and machine.** Even qwen3:4b can take tens of seconds to a few
-  minutes per tool-using turn.
-- **Whether a model completes a tool loop varies.** `qwen3:4b` and `qwen3:30b-a3b` complete it;
-  `llama3.1:8b` breaks on the tool-result turn. **Validate through a real multi-turn run** — a
-  single endpoint probe isn't enough.
-- A fresh dedicated server reloads the model (slower first turn) but guarantees the big context.
+To run Claude Code **fully locally against an Ollama model** — no cloud — use the bundled
+`claude-ollama` command (`npx -p mulmoterminal claude-ollama qwen3:4b`). See
+**[Local models with claude-ollama](claude-ollama.html)** for the details.
 
 ---
 

--- a/docs/guide/en/providers.md
+++ b/docs/guide/en/providers.md
@@ -341,6 +341,48 @@ If you are unsure where to start, try **Kimi K2.7 Code** (fast, coding-oriented)
 - An unresolvable key **refuses the launch**, so prompts never reach an unintended backend
 - `ANTHROPIC_API_KEY` is **removed** from a provider session's environment — left in place it would outrank the auth token
 
+## Running a local LLM from the CLI (claude-ollama)
+
+Everything above is about providers (Anthropic-compatible backends like OpenRouter). You can
+also run Claude Code **fully locally against an Ollama model — no cloud at all**. The bundled
+`claude-ollama` command does exactly that.
+
+> This is not the MulmoTerminal web UI — it's a standalone wrapper that launches plain
+> `claude` (the Claude Code CLI) pointed at Ollama.
+
+### Usage
+
+```bash
+ollama pull qwen3:4b            # pull the model first
+claude-ollama qwen3:4b          # launch Claude Code on the local model
+claude-ollama qwen3:30b-a3b "refactor this module"
+```
+
+### What it sets up (three things)
+
+Ollama 0.31+ serves a native Anthropic-compatible `/v1/messages`, so pointing
+`ANTHROPIC_BASE_URL` at it connects with no translation layer. But making a *small* local model
+actually work needs three things, which `claude-ollama` wires up for you:
+
+1. **A big context** — a dedicated `ollama serve` on a private port with
+   `OLLAMA_CONTEXT_LENGTH=32768` (the 4096 default overflows Claude's system prompt and the
+   session dies on the second turn). Any Ollama you already run (11434) is left untouched.
+2. **A minimal system prompt** — `claude --bare --disable-slash-commands`, which drops
+   skills / plugins / MCP / hooks and shrinks the prompt from **~16000 to ~400 tokens**.
+   Without it, a small model drowns and answers generically instead of using tools.
+3. **The env recipe** — remove `ANTHROPIC_API_KEY` (if present it outranks the base URL) and
+   set `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN=ollama` / `ANTHROPIC_MODEL` /
+   `ANTHROPIC_SMALL_FAST_MODEL` (the same model) / `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000`.
+
+### Caveats
+
+- **Speed depends on the model and machine.** Even qwen3:4b can take tens of seconds to a few
+  minutes per tool-using turn.
+- **Whether a model completes a tool loop varies.** `qwen3:4b` and `qwen3:30b-a3b` complete it;
+  `llama3.1:8b` breaks on the tool-result turn. **Validate through a real multi-turn run** — a
+  single endpoint probe isn't enough.
+- A fresh dedicated server reloads the model (slower first turn) but guarantees the big context.
+
 ---
 
 ← [back to Configuration](config.html) / [English guide index](index.html)

--- a/docs/guide/ja/claude-ollama.md
+++ b/docs/guide/ja/claude-ollama.md
@@ -1,0 +1,56 @@
+---
+title: claude-ollama でローカルモデルを動かす
+layout: default
+parent: 日本語
+nav_order: 6
+---
+
+# claude-ollama でローカルモデルを動かす
+{: .no_toc }
+
+`claude-ollama` は、**クラウドを一切使わず、手元の [Ollama](https://ollama.com) モデルで Claude Code を動かす**ための一発起動コマンドです。API キー不要・オフライン可。
+
+> これは MulmoTerminal の Web UI ではなく、**素の `claude`（Claude Code CLI）を Ollama に向けて起動する**スタンドアロンのラッパーです（mulmoterminal パッケージに同梱）。
+
+## 前提
+
+- [Ollama](https://ollama.com/download) が入っていること（**サーバ 0.31 以上**。Anthropic 互換の `/v1/messages` が必要。`ollama --version` ではなく、動いているサーバの版が `curl http://localhost:11434/api/version` で 0.31+ か）
+- Claude Code（`claude`）が入っていること（`npm install -g @anthropic-ai/claude-code`）
+- 使うモデルを pull 済みであること（`ollama pull qwen3:4b`）
+
+## 使い方
+
+```bash
+# npx（インストール不要）
+npx -p mulmoterminal claude-ollama qwen3:4b
+
+# または mulmoterminal をグローバル導入して
+npm install -g mulmoterminal
+claude-ollama qwen3:4b
+
+# claude への引数はそのまま後ろに渡せる
+claude-ollama qwen3:30b-a3b "このモジュールをリファクタして"
+```
+
+## 何をしているか（3点セット）
+
+Ollama 0.31+ は Anthropic 互換の `/v1/messages` を持つので、`ANTHROPIC_BASE_URL` を向けるだけで変換層なしに繋がります。ただし**小型ローカルモデルをまともに動かすには次の3点が要り、`claude-ollama` がこれを自動で仕込みます**:
+
+1. **大きい context** — 専用ポートで `OLLAMA_CONTEXT_LENGTH=32768` の `ollama serve` を起動します。既定の 4096 では Claude のシステムプロンプトが溢れ、2ターン目でセッションが落ちます。**すでに動いている Ollama（11434）は触りません**。終了時に自動で止めます。
+2. **システムプロンプトの最小化** — `claude --bare --disable-slash-commands` を付与し、skills / plugins / MCP / hooks を落とします。これでプロンプトが **約 16000 → 約 400 トークン**に激減します。**これが無いと小型モデルはツールを使わず一般応答してしまいます**（動かない一番の原因）。
+3. **環境変数** — `ANTHROPIC_API_KEY` を外し（残っていると base URL より優先される）、`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN=ollama` / `ANTHROPIC_MODEL` / `ANTHROPIC_SMALL_FAST_MODEL`（＝同じモデル）/ `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000` を設定します。
+
+## モデルの選び方
+
+- **`qwen3:4b`（軽量）/ `qwen3:30b-a3b`** はツールを使うマルチターン（ファイル作成→読み戻し等）の完走を確認済み。
+- **`llama3.1:8b` は不可** — 単発のツール呼び出しは返すが、マルチターンの tool-result ターンで壊れる（Ollama のチャットテンプレートが `assistant\n\n` を漏らす）。
+- **必ず実際のマルチターン実行で確かめること**。単発の疎通確認だけでは判断できません。
+
+## 注意点
+
+- **速度はモデル / マシン依存**。qwen3:4b でも、ツールを使うターンは負荷次第で数十秒〜数分かかることがあります（完走はします）。
+- 毎回専用サーバを立てるため、モデルの**初回ロード**が入ります（初回ターンが遅い）。その代わり context が確実に大きい。
+
+---
+
+← [OpenRouter で別のモデルを使う](providers.html) ／ [日本語ガイドの目次](index.html)

--- a/docs/guide/ja/index.md
+++ b/docs/guide/ja/index.md
@@ -59,5 +59,6 @@ npx mulmoterminal@latest    # → http://localhost:34567 が開く
 3. [機能一覧](features.html)（4 本柱で整理）
 4. [設定方法](config.html)（設定モーダル・`config.json`・`.mulmoterminal.json`・**DSL 拡張**）
 5. [OpenRouter で別のモデルを使う](providers.html)（Kimi / DeepSeek / Gemini などを実測データつきで選ぶ）
+6. [claude-ollama でローカルモデルを動かす](claude-ollama.html)（Ollama で完全ローカル・オフライン）
 
 > 英語版は [English guide](../en/) にあります。

--- a/docs/guide/ja/providers.md
+++ b/docs/guide/ja/providers.md
@@ -334,33 +334,9 @@ yarn tsx scripts/model-trials.ts --provider openrouter --trials 3 qwen/qwen3-cod
 - 鍵が解決できないときは**起動を拒否**します。意図しないバックエンドにプロンプトが流れないためです
 - プロバイダを使うセッションでは `ANTHROPIC_API_KEY` を子プロセスから**取り除きます**（残っていると認証トークンより優先されてしまうため）
 
-## ローカル LLM を CLI で動かす（claude-ollama）
+## ローカル LLM をローカルで動かす（claude-ollama）
 
-ここまではプロバイダ（OpenRouter 等の Anthropic 互換バックエンド）の話でしたが、**クラウドを一切使わず手元の Ollama モデルで Claude Code を動かす**こともできます。付属の `claude-ollama` コマンドがそれです。
-
-> これは MulmoTerminal の Web UI ではなく、**素の `claude`（Claude Code CLI）を Ollama に向けて起動する**スタンドアロンのラッパーです。
-
-### 使い方
-
-```bash
-ollama pull qwen3:4b            # モデルは先に pull しておく
-claude-ollama qwen3:4b          # ローカルモデルで Claude Code を起動
-claude-ollama qwen3:30b-a3b "このモジュールをリファクタして"
-```
-
-### 何をしているか（3点セット）
-
-Ollama 0.31+ は Anthropic 互換の `/v1/messages` を持つので、`ANTHROPIC_BASE_URL` を向けるだけで変換層なしに繋がります。ただし小型モデルをまともに動かすには次の3点が要り、`claude-ollama` がこれを自動で仕込みます:
-
-1. **大きい context** — 専用ポートで `OLLAMA_CONTEXT_LENGTH=32768` の `ollama serve` を起動（既定の 4096 では Claude のシステムプロンプトが溢れ、2ターン目でセッションが落ちる）。既存の Ollama（11434）は触りません。
-2. **システムプロンプトの最小化** — `claude --bare --disable-slash-commands`。skills / plugins / MCP / hooks を落とし、プロンプトを **約 16000 → 約 400 トークン**に縮める。これが無いと小型モデルはツールを使わず一般応答してしまう。
-3. **環境変数** — `ANTHROPIC_API_KEY` を外し（残っていると base URL より優先される）、`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN=ollama` / `ANTHROPIC_MODEL` / `ANTHROPIC_SMALL_FAST_MODEL`（＝同じモデル）/ `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000` を設定。
-
-### 注意点
-
-- **速度はモデル / マシン依存**。qwen3:4b でもツールを使うマルチターンは 1 ターン数十秒〜数分かかることがある。
-- **モデルによって tool ループの完走可否が違う**。`qwen3:4b` / `qwen3:30b-a3b` は完走を確認。`llama3.1:8b` は tool-result のターンで壊れる。**必ず実際のマルチターン実行で確かめる**こと（単発の疎通確認だけでは不十分）。
-- 専用サーバを毎回立てるためモデルの初回ロードが入る（初回ターンが遅い）。その代わり context が確実に大きい。
+クラウドを一切使わず**手元の Ollama モデルで Claude Code を動かす**なら、同梱の `claude-ollama` コマンドが使えます（`npx -p mulmoterminal claude-ollama qwen3:4b`）。詳しくは **[claude-ollama でローカルモデルを動かす](claude-ollama.html)** を参照。
 
 ---
 

--- a/docs/guide/ja/providers.md
+++ b/docs/guide/ja/providers.md
@@ -334,6 +334,34 @@ yarn tsx scripts/model-trials.ts --provider openrouter --trials 3 qwen/qwen3-cod
 - 鍵が解決できないときは**起動を拒否**します。意図しないバックエンドにプロンプトが流れないためです
 - プロバイダを使うセッションでは `ANTHROPIC_API_KEY` を子プロセスから**取り除きます**（残っていると認証トークンより優先されてしまうため）
 
+## ローカル LLM を CLI で動かす（claude-ollama）
+
+ここまではプロバイダ（OpenRouter 等の Anthropic 互換バックエンド）の話でしたが、**クラウドを一切使わず手元の Ollama モデルで Claude Code を動かす**こともできます。付属の `claude-ollama` コマンドがそれです。
+
+> これは MulmoTerminal の Web UI ではなく、**素の `claude`（Claude Code CLI）を Ollama に向けて起動する**スタンドアロンのラッパーです。
+
+### 使い方
+
+```bash
+ollama pull qwen3:4b            # モデルは先に pull しておく
+claude-ollama qwen3:4b          # ローカルモデルで Claude Code を起動
+claude-ollama qwen3:30b-a3b "このモジュールをリファクタして"
+```
+
+### 何をしているか（3点セット）
+
+Ollama 0.31+ は Anthropic 互換の `/v1/messages` を持つので、`ANTHROPIC_BASE_URL` を向けるだけで変換層なしに繋がります。ただし小型モデルをまともに動かすには次の3点が要り、`claude-ollama` がこれを自動で仕込みます:
+
+1. **大きい context** — 専用ポートで `OLLAMA_CONTEXT_LENGTH=32768` の `ollama serve` を起動（既定の 4096 では Claude のシステムプロンプトが溢れ、2ターン目でセッションが落ちる）。既存の Ollama（11434）は触りません。
+2. **システムプロンプトの最小化** — `claude --bare --disable-slash-commands`。skills / plugins / MCP / hooks を落とし、プロンプトを **約 16000 → 約 400 トークン**に縮める。これが無いと小型モデルはツールを使わず一般応答してしまう。
+3. **環境変数** — `ANTHROPIC_API_KEY` を外し（残っていると base URL より優先される）、`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN=ollama` / `ANTHROPIC_MODEL` / `ANTHROPIC_SMALL_FAST_MODEL`（＝同じモデル）/ `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000` を設定。
+
+### 注意点
+
+- **速度はモデル / マシン依存**。qwen3:4b でもツールを使うマルチターンは 1 ターン数十秒〜数分かかることがある。
+- **モデルによって tool ループの完走可否が違う**。`qwen3:4b` / `qwen3:30b-a3b` は完走を確認。`llama3.1:8b` は tool-result のターンで壊れる。**必ず実際のマルチターン実行で確かめる**こと（単発の疎通確認だけでは不十分）。
+- 専用サーバを毎回立てるためモデルの初回ロードが入る（初回ターンが遅い）。その代わり context が確実に大きい。
+
 ---
 
 ← [設定方法に戻る](config.html) ／ [日本語ガイドの目次](index.html)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "mulmoterminal"
   ],
   "bin": {
-    "mulmoterminal": "bin/mulmoterminal.js"
+    "mulmoterminal": "bin/mulmoterminal.js",
+    "claude-ollama": "bin/claude-ollama.js"
   },
   "files": [
     "bin/",

--- a/plans/feat-655-claude-ollama.md
+++ b/plans/feat-655-claude-ollama.md
@@ -1,0 +1,41 @@
+# feat(#655/#692): `claude-ollama` — run Claude Code against a local Ollama model
+
+## What
+A one-command launcher `claude-ollama <model> [claude args…]` that runs Claude Code fully
+locally against an Ollama-served model. No cloud, no API key, no translation proxy — Ollama
+0.31+ serves a native Anthropic-compatible `/v1/messages`.
+
+## Why the naive recipe (#692) isn't enough — verified on-machine
+- Ollama's `/v1/messages` works and big context is honoured, BUT
+- Claude Code's full system prompt is ~16386 tokens (skills/plugins/MCP/hooks). Small local
+  models (qwen3:4b, qwen3:30b-a3b) drown in it and answer generically instead of using tools.
+- `claude --bare --disable-slash-commands` cuts the prompt to ~400 tokens → qwen3:4b then
+  completes a multi-turn tool loop (create file → read back → report). This piece was missing
+  from #692.
+
+## The launcher absorbs three things
+1. **Big context**: a dedicated `ollama serve` on a private free port with
+   `OLLAMA_CONTEXT_LENGTH=32768` (4096 default dies on turn 2).
+2. **Minimal prompt**: `--bare --disable-slash-commands` on the claude invocation.
+3. **Env recipe**: unset `ANTHROPIC_API_KEY`; set `ANTHROPIC_BASE_URL`,
+   `ANTHROPIC_AUTH_TOKEN=ollama`, `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`,
+   `CLAUDE_CODE_MAX_OUTPUT_TOKENS=8000`.
+
+## Files
+- `bin/ollama-launch.js` (+ `.d.ts`): pure, testable — arg parsing, env building, flag list,
+  model-installed check.
+- `bin/claude-ollama.js`: I/O — check ollama/claude on PATH, pick a free port, start the
+  big-context server, wait ready, verify the model is pulled, spawn claude, clean up on exit.
+- `package.json`: add the `claude-ollama` bin.
+- `test/bin/ollama-launch.spec.ts`: pure-function tests + mutation checks.
+- `docs/guide/{ja,en}/providers.md`: a section (usage, the 3-point recipe, caveats).
+
+## Caveats to document
+- Speed is model/hardware dependent (qwen3:4b ~1–2 min/turn under load here; it completes).
+- Model choice matters — validate through a real multi-turn run (llama3.1:8b breaks its
+  tool-result turn per #692). qwen3 works.
+- A fresh dedicated server reloads the model (first turn slower) but guarantees the big context.
+
+## Not in scope
+- Integrating Ollama as a first-class provider inside the mulmoterminal web UI (that's the
+  broader #655; this launcher is the focused, verified first step).

--- a/test/bin/ollama-launch.spec.ts
+++ b/test/bin/ollama-launch.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseClaudeOllamaArgs,
+  buildClaudeEnv,
+  buildOllamaServeEnv,
+  buildClaudeArgs,
+  modelIsInstalled,
+  MINIMAL_PROMPT_FLAGS,
+  OLLAMA_CONTEXT_LENGTH,
+} from "../../bin/ollama-launch.js";
+
+describe("parseClaudeOllamaArgs", () => {
+  it("takes the first arg as the model and passes the rest to claude", () => {
+    expect(parseClaudeOllamaArgs(["qwen3:4b", "-p", "hi"])).toEqual({ help: false, model: "qwen3:4b", claudeArgs: ["-p", "hi"] });
+  });
+
+  it("has no claude args when only a model is given", () => {
+    expect(parseClaudeOllamaArgs(["qwen3:4b"])).toEqual({ help: false, model: "qwen3:4b", claudeArgs: [] });
+  });
+
+  it("asks for help with no args or -h/--help", () => {
+    for (const argv of [[], ["-h"], ["--help"]]) {
+      expect(parseClaudeOllamaArgs(argv)).toEqual({ help: true, model: null, claudeArgs: [] });
+    }
+  });
+});
+
+describe("buildClaudeEnv", () => {
+  const base = { PATH: "/usr/bin", ANTHROPIC_API_KEY: "sk-should-be-removed", HOME: "/home/me" };
+  const env = buildClaudeEnv(base, "qwen3:4b", "http://127.0.0.1:12345");
+
+  // The whole point: a lingering ANTHROPIC_API_KEY makes Claude ignore the base URL, so it
+  // must be gone, not just overwritten.
+  it("removes ANTHROPIC_API_KEY", () => {
+    expect("ANTHROPIC_API_KEY" in env).toBe(false);
+  });
+
+  it("points Claude at the local server with a dummy token", () => {
+    expect(env.ANTHROPIC_BASE_URL).toBe("http://127.0.0.1:12345");
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("ollama");
+  });
+
+  // The main and background slots both resolve to the local model (there is no local haiku).
+  it("sets both the model and the small/fast model", () => {
+    expect(env.ANTHROPIC_MODEL).toBe("qwen3:4b");
+    expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBe("qwen3:4b");
+  });
+
+  // A reasoning model burns the first budget on thinking; too small a ceiling → empty first turn.
+  it("keeps a generous output ceiling", () => {
+    expect(Number(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS)).toBeGreaterThanOrEqual(8000);
+  });
+
+  it("preserves the rest of the environment and does not mutate the input", () => {
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/me");
+    expect(base.ANTHROPIC_API_KEY).toBe("sk-should-be-removed"); // input untouched
+  });
+});
+
+describe("buildOllamaServeEnv", () => {
+  it("sets the host and a big context, keeping the base env", () => {
+    const env = buildOllamaServeEnv({ PATH: "/usr/bin" }, "127.0.0.1:11500");
+    expect(env.OLLAMA_HOST).toBe("127.0.0.1:11500");
+    expect(env.OLLAMA_CONTEXT_LENGTH).toBe(String(OLLAMA_CONTEXT_LENGTH));
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("takes an explicit context length as a string", () => {
+    expect(buildOllamaServeEnv({}, "h", 8192).OLLAMA_CONTEXT_LENGTH).toBe("8192");
+  });
+});
+
+describe("buildClaudeArgs", () => {
+  // The prompt-shrinking flags are what let a small model use tools at all — they must always
+  // be present, ahead of the user's args.
+  it("prepends the minimal-prompt flags", () => {
+    expect(buildClaudeArgs(["-p", "hi"])).toEqual([...MINIMAL_PROMPT_FLAGS, "-p", "hi"]);
+  });
+
+  it("includes --bare and --disable-slash-commands", () => {
+    expect(buildClaudeArgs([])).toContain("--bare");
+    expect(buildClaudeArgs([])).toContain("--disable-slash-commands");
+  });
+});
+
+describe("modelIsInstalled", () => {
+  const tags = { models: [{ name: "qwen3:4b" }, { name: "llama3.1:8b" }, { name: "mistral:latest" }] };
+
+  it("finds an exact tag", () => {
+    expect(modelIsInstalled(tags, "qwen3:4b")).toBe(true);
+  });
+
+  // `ollama run mistral` resolves to mistral:latest — accept the bare name too.
+  it("accepts a bare name that resolves to :latest", () => {
+    expect(modelIsInstalled(tags, "mistral")).toBe(true);
+  });
+
+  it("is false for a model that is not pulled", () => {
+    expect(modelIsInstalled(tags, "qwen3:32b")).toBe(false);
+  });
+
+  it("is false (no throw) for junk tag payloads", () => {
+    expect(modelIsInstalled(null, "qwen3:4b")).toBe(false);
+    expect(modelIsInstalled({}, "qwen3:4b")).toBe(false);
+    expect(modelIsInstalled({ models: "nope" }, "qwen3:4b")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`claude-ollama <model> [claude args…]` runs Claude Code **fully locally** against an Ollama model — no cloud, no API key, no translation proxy.

```bash
ollama pull qwen3:4b
claude-ollama qwen3:4b
claude-ollama qwen3:30b-a3b "refactor this module"
```

Ollama 0.31+ serves a native Anthropic-compatible `/v1/messages`, so Claude Code connects directly.

## Items to Confirm / Review

1. **The key finding (missing from #692), verified on-machine**: Claude Code's full system prompt is ~16386 tokens; small models (qwen3:4b, qwen3:30b-a3b) drown in it and answer generically instead of using tools. `--bare --disable-slash-commands` shrinks it to ~400 tokens → qwen3:4b **completes a multi-turn tool loop** (create file → read back → report). So the launcher forces `--bare --disable-slash-commands` by default. (Posted the measurements to #692.)
2. **A dedicated `ollama serve`** is started on a *private free port* with `OLLAMA_CONTEXT_LENGTH=32768`, so any Ollama the user already runs (11434) is left untouched. It's stopped on exit/SIGINT/SIGTERM. Tradeoff: a fresh server reloads the model (slower first turn) but guarantees the big context.
3. **Scope**: this is a standalone CLI that runs *plain* `claude` against Ollama — it does **not** integrate Ollama into the MulmoTerminal web UI (that's the broader #655; this is the focused, verified first step).
4. **Speed / model choice** are documented caveats: qwen3:4b is slow under load but completes; `llama3.1:8b` breaks on the tool-result turn (per #692); validate a model through a real multi-turn run.

## User Prompt

> #655 と #692 を見て。これできそう？ … A→B 両方で一気に進めて（A: issue に記録、B: 実装）
> small model だと skill や plugin をきって system prompt を小さくし、context の設定を最大にして渡すのがよいらしい。そういうのをそこで吸収できるとよいね

## Implementation

| file | role |
|---|---|
| `bin/ollama-launch.js` (+ `.d.ts`) | **pure** — `parseClaudeOllamaArgs`, `buildClaudeEnv` (removes `ANTHROPIC_API_KEY`), `buildOllamaServeEnv`, `buildClaudeArgs` (prepends the minimal-prompt flags), `modelIsInstalled` |
| `bin/claude-ollama.js` | I/O — PATH checks, free port, start/await/stop the private server, model check, spawn claude (stdio inherit) |
| `package.json` | adds the `claude-ollama` bin |
| `docs/guide/{ja,en}/providers.md` | a section: usage, the 3-point recipe, caveats |
| `plans/feat-655-claude-ollama.md` | plan |

## Testing

- 16 new pure-function tests (3275 → 3291 total, 240 files green).
- **Mutation testing** — each rule verified to go red: not removing `ANTHROPIC_API_KEY`, small/fast model not pinned, minimal flags not prepended, `modelIsInstalled` ignoring `:latest`.
- **Live**, on this machine:
  - end-to-end: `claude-ollama` recipe (big-context server + `--bare` + env) → **qwen3:4b completed the create-file/read-back tool loop** (`proof.txt` = `OLLAMA_WORKS`).
  - the launcher's I/O path: model-not-installed → starts a private server on a free port, detects the missing model, errors with a `ollama pull` hint, and cleans the server up.

Closes #692 · relates to #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)