### PR TITLE
fix: クロスプロセスで tool-store の read キャッシュが古くなるのを直す (#705)

### DIFF
--- a/plans/fix-705-tool-store-cache-invalidation.md
+++ b/plans/fix-705-tool-store-cache-invalidation.md
@@ -1,0 +1,29 @@
+# fix #705 — クロスプロセスで tool-store の read キャッシュが古くなる
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/705（#620 から分離）
+
+## 問題
+
+`server/session/tool-store.ts` の `createSessionStore` は in-memory `Map` を一度ロードしたら再起動まで読み直さなかった。同一 `MULMOTERMINAL_HOME` を 2 サーバが共有する構成で、非所有サーバのUIで所有サーバのセッションのツール履歴を開くと、所有サーバの追記が反映されない（read の陳腐化・自己修復なし）。
+
+## 設計判断
+
+キャッシュを「所有」で分ける:
+- **このインスタンスが save したセッションは所有**（`owned: Set`）。そのマップが真実で、**決して再読込しない**。save は fire-and-forget なので、再読込すると未フラッシュの in-place 変更を上書きしてしまう（実際、最初に試した mtime 単独ガードでは 55 回 push が 1 件に化ける lost-update レースが出た）。
+- **read しかしていないセッション（他サーバ所有）**は、ファイルの mtime がキャッシュ時より新しければ `get` で再読込。
+
+所有判定はプロセス内の store インスタンス単位で正しい: フック/ブローカーの URL に所有サーバのポートが焼き込まれているため、あるセッションの `save`（storeToolResult / recordToolCall*）は所有サーバでしか走らない。非所有サーバの store は同セッションを save しない。
+
+`statMtimeMs` を引数注入にし、テストで mtime を決定的に駆動できるようにした。
+
+## テスト
+
+`test/server/session/tool-store.spec.ts` に 2 本追加:
+- 非所有: 別インスタンスがファイルに追記 → mtime が進む → 次の `get` で再読込して新内容を返す。変化なしなら再読込しない。
+- 所有: `save` 後の `get` は同じ working array を返す（自分の書き込みを再読込しない）。
+
+変異テスト2件で確認済み:
+1. 再読込を消すと非所有テストが赤（陳腐化解消のコア）。
+2. 所有の短絡を消すと「cap 50」テストが赤（lost-update レースが再発）。
+
+既存 22 テスト（同一 array 契約・concurrent load dedup・corrupt→[]・traversal 拒否）は不変で緑。

--- a/server/session/tool-store.ts
+++ b/server/session/tool-store.ts
@@ -20,34 +20,60 @@ export interface ToolStoreDeps {
   root?: string;
 }
 
+// The file's mtime, or 0 when there is no readable file.
+async function fileMtimeMs(file: string): Promise<number> {
+  try {
+    return (await fs.stat(file)).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
 // A per-session list store mirrored to disk so it survives a server reboot — one
 // JSON file per session under <workspace>/<dirName>/<sessionId>.json
 // (<workspace> = CLAUDE_CWD). The in-memory Map is the working copy; the file is
 // rewritten on each change and lazy-loaded on first access. Session ids are
 // validated UUIDs (SESSION_ID_RE), so they're safe to use as filenames.
-export function createSessionStore<T>(dirName: string, root: string = MULMOTERMINAL_HOME) {
+//
+// The file is shared with any other server rooted at the same MULMOTERMINAL_HOME. Only the
+// server that spawned a session ever WRITES its file (the hook/broker URLs bake in the owning
+// server's port), but a NON-owning server can READ it (a phone/browser attached to it opens
+// that session's tool history). This instance OWNS any session it has ever saved: that map is
+// the source of truth and is never re-read (its writes are fire-and-forget, so re-reading could
+// clobber an in-place mutation not yet flushed). A session this instance has only READ is
+// re-read when the file's mtime is newer than the copy it cached, so the non-owner picks up the
+// owner's appends instead of holding a stale copy until it restarts. `statMtimeMs` is a
+// parameter so a test can drive the mtime deterministically. (#705)
+export function createSessionStore<T>(dirName: string, root: string = MULMOTERMINAL_HOME, statMtimeMs: (file: string) => Promise<number> = fileMtimeMs) {
   const dir = path.join(root, dirName);
   const fileFor = (id: string) => path.join(dir, `${id}.json`);
   const map = new Map<string, T[]>(); // id -> list (the working copy; mutate in place)
+  const owned = new Set<string>(); // sessions this instance has written => authoritative, never re-read
+  const loadedMtime = new Map<string, number>(); // id -> file mtime as of the last read (non-owned only)
   const loading = new Map<string, Promise<T[]>>(); // id -> Promise<list>, dedupes concurrent loads
 
-  // Lazily load a session's list from disk, then keep using the in-memory copy.
-  function get(sessionId: string): Promise<T[]> {
-    const cached = map.get(sessionId);
-    if (cached) return Promise.resolve(cached);
+  // Read a session's list off disk. Stat BEFORE reading so a write that races the read is
+  // caught on the next get (a stale-newer mtime only costs one extra re-read; a stale-older one
+  // could miss the update). Missing / corrupt / non-array file => empty.
+  async function readFromDisk(sessionId: string): Promise<{ list: T[]; mtimeMs: number }> {
+    if (!SESSION_ID_RE.test(sessionId)) return { list: [], mtimeMs: 0 };
+    const file = fileFor(sessionId);
+    const mtimeMs = await statMtimeMs(file);
+    try {
+      const parsed = JSON.parse(await fs.readFile(file, "utf8"));
+      return { list: Array.isArray(parsed) ? parsed : [], mtimeMs };
+    } catch {
+      return { list: [], mtimeMs: 0 };
+    }
+  }
+
+  function firstLoad(sessionId: string): Promise<T[]> {
     const inflight = loading.get(sessionId);
     if (inflight) return inflight;
     const p = (async () => {
-      let list: T[] = [];
-      if (SESSION_ID_RE.test(sessionId)) {
-        try {
-          const parsed = JSON.parse(await fs.readFile(fileFor(sessionId), "utf8"));
-          if (Array.isArray(parsed)) list = parsed;
-        } catch {
-          // No file yet (or unreadable) => start empty.
-        }
-      }
+      const { list, mtimeMs } = await readFromDisk(sessionId);
       map.set(sessionId, list);
+      loadedMtime.set(sessionId, mtimeMs);
       loading.delete(sessionId);
       return list;
     })();
@@ -55,9 +81,31 @@ export function createSessionStore<T>(dirName: string, root: string = MULMOTERMI
     return p;
   }
 
-  // Persist a session's list (best-effort, fire-and-forget).
+  // Return the cached list, or re-read it if another instance wrote the file since we cached it.
+  async function maybeReload(sessionId: string, cached: T[]): Promise<T[]> {
+    if (!SESSION_ID_RE.test(sessionId)) return cached; // an invalid id never had a file
+    if ((await statMtimeMs(fileFor(sessionId))) <= (loadedMtime.get(sessionId) ?? 0)) return cached;
+    const { list, mtimeMs } = await readFromDisk(sessionId);
+    map.set(sessionId, list);
+    loadedMtime.set(sessionId, mtimeMs);
+    return list;
+  }
+
+  // Lazily load a session's list from disk; on later calls keep the in-memory copy. A session
+  // this instance owns (has written) is always its cached working array; one it has only read is
+  // re-read when a second instance that owns it has since appended to the file.
+  function get(sessionId: string): Promise<T[]> {
+    const cached = map.get(sessionId);
+    if (!cached) return firstLoad(sessionId);
+    if (owned.has(sessionId)) return Promise.resolve(cached);
+    return maybeReload(sessionId, cached);
+  }
+
+  // Persist a session's list (best-effort, fire-and-forget). Writing marks the session owned by
+  // this instance, so subsequent reads trust the in-memory working copy over the disk.
   async function save(sessionId: string) {
     if (!SESSION_ID_RE.test(sessionId)) return;
+    owned.add(sessionId);
     try {
       await fs.mkdir(dir, { recursive: true });
       await fs.writeFile(fileFor(sessionId), JSON.stringify(map.get(sessionId) || []));

--- a/test/server/session/tool-store.spec.ts
+++ b/test/server/session/tool-store.spec.ts
@@ -103,6 +103,36 @@ describe("createSessionStore", () => {
     await expect(fs.stat(path.join(root, "escape.json"))).rejects.toThrow();
     await expect(fs.stat(path.join(root, "things"))).rejects.toThrow();
   });
+
+  // A second server rooted at the same MULMOTERMINAL_HOME owns this session and appends to its
+  // file; a non-owning server that already cached the list must pick up the change on the next
+  // read instead of holding the stale copy until it restarts. (#705)
+  it("re-reads when the file changed since it was cached (another instance appended)", async () => {
+    await fs.mkdir(path.join(root, "things"), { recursive: true });
+    const file = path.join(root, "things", `${SESSION}.json`);
+    await fs.writeFile(file, JSON.stringify([{ n: 1 }]));
+    let mtime = 100;
+    const store = createSessionStore<{ n: number }>("things", root, async () => mtime);
+    expect(await store.get(SESSION)).toEqual([{ n: 1 }]); // cached at mtime 100
+
+    await fs.writeFile(file, JSON.stringify([{ n: 1 }, { n: 2 }])); // the owning instance appended
+    mtime = 200;
+    expect(await store.get(SESSION)).toEqual([{ n: 1 }, { n: 2 }]); // newer mtime => re-read
+
+    expect(await store.get(SESSION)).toEqual([{ n: 1 }, { n: 2 }]); // unchanged now => cached, no re-read
+  });
+
+  // The owning server writes via save(), which records the post-write mtime — so its next get()
+  // returns the same working array it mutates in place, never re-reading its own write.
+  it("does not re-read the store's own write (keeps the working array)", async () => {
+    let mtime = 0;
+    const store = createSessionStore<{ n: number }>("things", root, async () => mtime);
+    const list = await store.get(SESSION);
+    list.push({ n: 1 });
+    mtime = 500; // the write below lands at this mtime
+    await store.save(SESSION);
+    expect(await store.get(SESSION)).toBe(list); // same array, no re-read
+  });
 });
 
 describe("createToolStores", () => {


### PR DESCRIPTION
## Summary

`server/session/tool-store.ts` の `createSessionStore` は in-memory `Map` を一度ロードしたら再起動まで読み直さなかった。同一 `MULMOTERMINAL_HOME` を 2 サーバが共有する構成で、**非所有サーバのUIで所有サーバのセッションのツール履歴を開くと、追記が反映されない**（read 陳腐化・自己修復なし）。

**所有で分ける**設計にした:
- このインスタンスが `save` したセッションは**所有** → マップが真実で**再読込しない**（save は fire-and-forget なので、再読込すると未フラッシュの in-place 変更を上書きする）。
- **read しかしていない**セッション（他サーバ所有）は、ファイルの mtime がキャッシュ時より新しければ `get` で再読込。

所有判定は store インスタンス単位で正しい（フック/ブローカーの URL に所有サーバのポートが焼き込まれ、`save` は所有サーバでしか走らない）。

## Items to Confirm / Review

- **最初 mtime 単独ガードで試したところ、fire-and-forget save と再読込が競合して 55 回 push が 1 件に化ける lost-update レースが出た**（テストが検出）。所有の短絡でこれを封じている。変異テスト2件で「再読込を消すと非所有テストが赤」「所有の短絡を消すと cap50 テストが赤」を確認。
- mtime 粒度: 現代 fs は sub-ms なので実運用の追記検知には十分。理論上、同一 mtime tick 内の連続書き込みは検知漏れしうるが、非所有サーバのポーリング表示という用途では実害なし（次のポーリングで自己修復）。
- 既存 22 テスト（同一 array 契約等）は不変で緑。`typecheck` / `:server` / `:test` 通過、session 793 テスト緑。

## User Prompt

#620 から分離した #705（tool-store のクロスプロセス read 陳腐化）を、キャッシュ無効化の設計判断込みで実装する。

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)