### PR TITLE
feat: grid の cockpit roster 各行に ⋮ メニューで並べ替え（manual ソート時） (#707)

### DIFF
--- a/plans/feat-707-cockpit-roster-reorder-menu.md
+++ b/plans/feat-707-cockpit-roster-reorder-menu.md
@@ -1,0 +1,30 @@
+# feat #707 — cockpit roster の各行に ⋮ メニューで並べ替え
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/707
+
+## 決定事項（モックで確認済み）
+
+- ⋮ は grid ズーム時の cockpit roster（`data-testid="cockpit"`）各行ヘッダーの**右端**。
+- メニューは **上へ移動 / 下へ移動**。端の行は該当方向を無効化。
+- **manual ソートのときだけ** ⋮ を出す（`reorderable` prop）。
+- 実処理は既存の `moveCell(uid, ±1)`（縦なので −1=上 / +1=下）。
+
+## 実装
+
+### `src/components/gridTabs.ts`
+- 隣接ガードを pure 関数 `canMoveCell(cells, uid, dir): boolean` に切り出す（端 / 末尾 launch セル手前で false）。`moveCell` を `if (!canMoveCell(...)) return state` で書き換え（挙動不変）。端の無効化判定に使う。
+
+### `src/components/CockpitRowMenu.vue`（新規）
+- ⋮ ボタン + ドロップダウン（上へ移動 / 下へ移動）。`useDropdownMenu` を流用（外側クリック / Esc で閉じる）。props `canUp` / `canDown` で各項目を無効化。`move(dir)` を emit。root は `@click.stop` で行のクリック（拡大切替）に伝播させない。
+
+### `src/components/TerminalGrid.vue`
+- roster 行を `<button>` → `<div role="button" tabindex="0">` に（ボタン入れ子回避）。`@click` は据え置き、`@keydown.enter/space.self` で activate（`.self` で ⋮ ボタンのキー操作と衝突しない）。
+- ヘッダーの dir の後ろに `<CockpitRowMenu v-if="reorderable" :can-up="canMoveCell(cells, row.uid, -1)" :can-down="canMoveCell(cells, row.uid, 1)" @move="(dir) => emit('move', row.uid, dir)" />` を追加。`@move` は既存の `move` emit（GridView の `onMove` → `moveCell`）に流す。
+
+## テスト
+
+- `test/src/components/gridTabs.spec.ts`: `canMoveCell`（中間 true、先頭 up false、末尾 down false、末尾 launch セル手前 false、不正 uid false）。既存 `moveCell` テストは不変で緑。
+- `test/src/components/CockpitRowMenu.spec.ts`（新規）: 初期は閉、⋮ で開閉、上/下クリックで `move(∓1)` emit + 閉、無効項目は emit しない。
+- `test/src/components/TerminalGrid.spec.ts`: `mountCockpit` に `reorderable` 引数を足し、reorderable=true で ⋮ が出て up/down が `move(uid, dir)` を emit、false で ⋮ が出ないことを確認。
+
+各テストは変異テストで「壊すと落ちる」ことを確認してからマージ。

--- a/src/components/CockpitRowMenu.vue
+++ b/src/components/CockpitRowMenu.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+// The ⋮ reorder menu on a cockpit roster row (grid manual sort). Sits at the right of the row
+// header and offers up/down moves, disabled at the ends. Only the move is here — the actual
+// reorder is the parent's existing moveCell, driven off the emitted direction. `@click.stop` on
+// the root keeps a click on the menu from also toggling which terminal the row expands.
+import { useTemplateRef } from "vue";
+import { useDropdownMenu } from "../composables/useDropdownMenu";
+
+defineProps<{ canUp: boolean; canDown: boolean }>();
+const emit = defineEmits<{ move: [dir: -1 | 1] }>();
+
+const root = useTemplateRef<HTMLElement>("root");
+const { open, close, toggle } = useDropdownMenu(root);
+
+function pick(dir: -1 | 1) {
+  emit("move", dir);
+  close();
+}
+</script>
+
+<template>
+  <div ref="root" class="relative flex-none" @click.stop>
+    <button
+      type="button"
+      data-testid="cockpit-reorder"
+      class="grid h-[22px] w-[22px] place-items-center rounded-md border border-transparent text-[16px] leading-none text-dim hover:border-border hover:bg-panel hover:text-fg"
+      :class="{ 'border-border bg-panel text-fg': open }"
+      :aria-expanded="open"
+      aria-haspopup="menu"
+      aria-label="このセルを並べ替え"
+      title="並べ替え"
+      @click="toggle"
+    >
+      ⋮
+    </button>
+    <div
+      v-if="open"
+      data-testid="cockpit-reorder-menu"
+      role="menu"
+      class="absolute right-0 top-[26px] z-20 min-w-[150px] rounded-lg border border-border bg-panel p-1.5 text-fg shadow-xl"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        data-testid="reorder-up"
+        class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] enabled:hover:bg-[#29344a] disabled:cursor-default disabled:text-dim disabled:opacity-50"
+        :disabled="!canUp"
+        @click="pick(-1)"
+      >
+        <span class="w-3.5 text-center font-mono text-[#4a9eff]">↑</span> 上へ移動
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        data-testid="reorder-down"
+        class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] enabled:hover:bg-[#29344a] disabled:cursor-default disabled:text-dim disabled:opacity-50"
+        :disabled="!canDown"
+        @click="pick(1)"
+      >
+        <span class="w-3.5 text-center font-mono text-[#4a9eff]">↓</span> 下へ移動
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/components/CockpitRowMenu.vue
+++ b/src/components/CockpitRowMenu.vue
@@ -1,26 +1,63 @@
 <script setup lang="ts">
 // The ⋮ reorder menu on a cockpit roster row (grid manual sort). Sits at the right of the row
 // header and offers up/down moves, disabled at the ends. Only the move is here — the actual
-// reorder is the parent's existing moveCell, driven off the emitted direction. `@click.stop` on
-// the root keeps a click on the menu from also toggling which terminal the row expands.
-import { useTemplateRef } from "vue";
-import { useDropdownMenu } from "../composables/useDropdownMenu";
+// reorder is the parent's existing moveCell, driven off the emitted direction.
+//
+// The dropdown is teleported to <body> and fixed-positioned under the ⋮: the roster row is
+// overflow-hidden inside an overflow-y-auto aside, so a menu left in place would be clipped.
+// `@click.stop` on the trigger + menu keeps a click from also toggling which terminal the row
+// expands, and a roster scroll closes it (the fixed panel would otherwise detach from the ⋮).
+import { ref, onBeforeUnmount, useTemplateRef } from "vue";
 
 defineProps<{ canUp: boolean; canDown: boolean }>();
 const emit = defineEmits<{ move: [dir: -1 | 1] }>();
 
-const root = useTemplateRef<HTMLElement>("root");
-const { open, close, toggle } = useDropdownMenu(root);
+const trigger = useTemplateRef<HTMLElement>("trigger");
+const menu = useTemplateRef<HTMLElement>("menu");
+const open = ref(false);
+const pos = ref({ top: 0, left: 0 });
+const MENU_WIDTH_PX = 152;
 
+function place() {
+  const rect = trigger.value?.getBoundingClientRect();
+  if (rect) pos.value = { top: Math.round(rect.bottom + 4), left: Math.round(Math.max(8, rect.right - MENU_WIDTH_PX)) };
+}
+function onOutside(event: PointerEvent) {
+  const target = event.target instanceof Node ? event.target : null;
+  if (!trigger.value?.contains(target) && !menu.value?.contains(target)) close();
+}
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") close();
+}
+function openMenu() {
+  place();
+  open.value = true;
+  window.addEventListener("pointerdown", onOutside);
+  window.addEventListener("keydown", onKeydown);
+  window.addEventListener("scroll", close, true); // a roster scroll slides the ⋮ out from under the menu
+}
+function close() {
+  if (!open.value) return;
+  open.value = false;
+  window.removeEventListener("pointerdown", onOutside);
+  window.removeEventListener("keydown", onKeydown);
+  window.removeEventListener("scroll", close, true);
+}
+function toggle() {
+  if (open.value) close();
+  else openMenu();
+}
 function pick(dir: -1 | 1) {
   emit("move", dir);
   close();
 }
+onBeforeUnmount(close);
 </script>
 
 <template>
-  <div ref="root" class="relative flex-none" @click.stop>
+  <div class="relative flex-none" @click.stop>
     <button
+      ref="trigger"
       type="button"
       data-testid="cockpit-reorder"
       class="grid h-[22px] w-[22px] place-items-center rounded-md border border-transparent text-[16px] leading-none text-dim hover:border-border hover:bg-panel hover:text-fg"
@@ -33,32 +70,37 @@ function pick(dir: -1 | 1) {
     >
       ⋮
     </button>
-    <div
-      v-if="open"
-      data-testid="cockpit-reorder-menu"
-      role="menu"
-      class="absolute right-0 top-[26px] z-20 min-w-[150px] rounded-lg border border-border bg-panel p-1.5 text-fg shadow-xl"
-    >
-      <button
-        type="button"
-        role="menuitem"
-        data-testid="reorder-up"
-        class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] enabled:hover:bg-[#29344a] disabled:cursor-default disabled:text-dim disabled:opacity-50"
-        :disabled="!canUp"
-        @click="pick(-1)"
+    <Teleport to="body">
+      <div
+        v-if="open"
+        ref="menu"
+        data-testid="cockpit-reorder-menu"
+        role="menu"
+        class="fixed z-[60] min-w-[150px] rounded-lg border border-border bg-panel p-1.5 text-fg shadow-xl"
+        :style="{ top: `${pos.top}px`, left: `${pos.left}px` }"
+        @click.stop
       >
-        <span class="w-3.5 text-center font-mono text-[#4a9eff]">↑</span> 上へ移動
-      </button>
-      <button
-        type="button"
-        role="menuitem"
-        data-testid="reorder-down"
-        class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] enabled:hover:bg-[#29344a] disabled:cursor-default disabled:text-dim disabled:opacity-50"
-        :disabled="!canDown"
-        @click="pick(1)"
-      >
-        <span class="w-3.5 text-center font-mono text-[#4a9eff]">↓</span> 下へ移動
-      </button>
-    </div>
+        <button
+          type="button"
+          role="menuitem"
+          data-testid="reorder-up"
+          class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] enabled:hover:bg-[#29344a] disabled:cursor-default disabled:text-dim disabled:opacity-50"
+          :disabled="!canUp"
+          @click="pick(-1)"
+        >
+          <span class="w-3.5 text-center font-mono text-[#4a9eff]">↑</span> 上へ移動
+        </button>
+        <button
+          type="button"
+          role="menuitem"
+          data-testid="reorder-down"
+          class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] enabled:hover:bg-[#29344a] disabled:cursor-default disabled:text-dim disabled:opacity-50"
+          :disabled="!canDown"
+          @click="pick(1)"
+        >
+          <span class="w-3.5 text-center font-mono text-[#4a9eff]">↓</span> 下へ移動
+        </button>
+      </div>
+    </Teleport>
   </div>
 </template>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -3,11 +3,12 @@ import { ref, computed, onMounted, onActivated, watch, nextTick } from "vue";
 import TerminalCell from "./TerminalCell.vue";
 import CommandCell from "./CommandCell.vue";
 import LauncherCell from "./LauncherCell.vue";
+import CockpitRowMenu from "./CockpitRowMenu.vue";
 import * as conn from "../composables/useTerminalConnections";
 import { trackStyle, layoutForCount } from "./gridLayout";
 import { flipKeyframes, flipPairs, onScreen, FLIP_MS, FLIP_EASING } from "./cellFlip";
 import { formatCwd } from "./cwdDisplay";
-import type { Cell, CellStatus } from "./gridTabs";
+import { canMoveCell, type Cell, type CellStatus } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
 import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterPhase";
 import type { CwdPreset } from "./presets";
@@ -220,14 +221,17 @@ watch(
     <!-- Cockpit roster: a tall text row per cell (status / dir / summary / prompt / latest
          reply). Click a row to swap which terminal is enlarged. -->
     <aside v-if="zoomed && listMode" data-testid="cockpit" class="flex min-w-0 shrink-0 grow-0 basis-[360px] flex-col gap-[5px] overflow-y-auto bg-deep p-1.5">
-      <button
+      <div
         v-for="row in listRows"
         :key="row.uid"
-        type="button"
+        role="button"
+        :tabindex="0"
         data-testid="cockpit-row"
-        class="flex cursor-pointer flex-col gap-1 overflow-hidden rounded-lg border border-l-[3px] bg-panel px-2.5 py-2 text-left text-fg [font:inherit] hover:brightness-[1.15]"
+        class="flex cursor-pointer flex-col gap-1 overflow-hidden rounded-lg border border-l-[3px] bg-panel px-2.5 py-2 text-left text-fg hover:brightness-[1.15] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4a9eff]"
         :class="row.uid === expandedUid ? 'border-[#4a9eff] border-l-[#4a9eff]' : 'border-border border-l-transparent'"
         @click="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
+        @keydown.enter.self.prevent="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
+        @keydown.space.self.prevent="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
       >
         <!-- The status + directory line is the row's header: it carries the directory's
              configured header colour as a bar, pulled to the row's top and side edges. A
@@ -252,6 +256,12 @@ watch(
           </span>
           <span v-if="row.agent === 'codex'" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">codex</span>
           <span class="min-w-0 flex-auto truncate text-[11px] text-[var(--cell-header-fg,var(--text-dim))]">{{ formatCwd(row.cwd, home, 44) || "—" }}</span>
+          <CockpitRowMenu
+            v-if="reorderable"
+            :can-up="canMoveCell(cells, row.uid, -1)"
+            :can-down="canMoveCell(cells, row.uid, 1)"
+            @move="(dir) => emit('move', row.uid, dir)"
+          />
         </span>
         <span v-if="row.summary" data-testid="cockpit-line" class="line-clamp-2 overflow-hidden text-[12px] leading-[1.35]"
           ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">summary</b> {{ row.summary }}</span
@@ -262,7 +272,7 @@ watch(
         <span v-if="row.response" data-testid="cockpit-line" class="line-clamp-3 overflow-hidden text-[12px] leading-[1.35] text-dim"
           ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">reply</b> {{ row.response }}</span
         >
-      </button>
+      </div>
     </aside>
     <div ref="zoomMain" class="zoom-main" />
     <div class="grid" :style="gridStyle">

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -187,16 +187,23 @@ export function setSortMode(state: GridState, sortMode: SortMode): GridState {
   return { ...state, sortMode };
 }
 
-// Manual reorder: swap a cell with its neighbour (dir -1 = left, +1 = right) in the
-// flat list. No-op at the ends, and never swaps a cell past the trailing launch
-// cell (it stays last so "+ Terminal"/cancel keep working on it).
-export function moveCell(state: GridState, uid: number, dir: -1 | 1): GridState {
-  const i = state.cells.findIndex((c) => c.uid === uid);
+// Whether moveCell would actually reorder: not off either end, and never swapping a cell past
+// the trailing launch cell (it stays last so "+ Terminal"/cancel keep working on it). Drives the
+// enabled/disabled state of the roster's up/down menu items.
+export function canMoveCell(cells: Cell[], uid: number, dir: -1 | 1): boolean {
+  const i = cells.findIndex((c) => c.uid === uid);
   const j = i + dir;
-  if (i < 0 || j < 0 || j >= state.cells.length) return state;
-  if (isLaunchCell(state.cells[j]) && j === state.cells.length - 1) return state;
+  if (i < 0 || j < 0 || j >= cells.length) return false;
+  return !(isLaunchCell(cells[j]) && j === cells.length - 1);
+}
+
+// Manual reorder: swap a cell with its neighbour (dir -1 = left/up, +1 = right/down) in the
+// flat list. A no-op wherever canMoveCell says the swap isn't allowed.
+export function moveCell(state: GridState, uid: number, dir: -1 | 1): GridState {
+  if (!canMoveCell(state.cells, uid, dir)) return state;
+  const i = state.cells.findIndex((c) => c.uid === uid);
   const cells = state.cells.slice();
-  [cells[i], cells[j]] = [cells[j], cells[i]];
+  [cells[i], cells[i + dir]] = [cells[i + dir], cells[i]];
   return { ...state, cells };
 }
 

--- a/test/src/components/CockpitRowMenu.spec.ts
+++ b/test/src/components/CockpitRowMenu.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CockpitRowMenu from "../../../src/components/CockpitRowMenu.vue";
+
+const mountMenu = (canUp = true, canDown = true) => mount(CockpitRowMenu, { props: { canUp, canDown }, attachTo: document.body });
+
+const kebab = (w: ReturnType<typeof mount>) => w.get('[data-testid="cockpit-reorder"]');
+const menu = (w: ReturnType<typeof mount>) => w.find('[data-testid="cockpit-reorder-menu"]');
+
+describe("CockpitRowMenu", () => {
+  it("starts closed and toggles the menu on the ⋮ button", async () => {
+    const w = mountMenu();
+    expect(menu(w).exists()).toBe(false);
+    await kebab(w).trigger("click");
+    expect(menu(w).exists()).toBe(true);
+    await kebab(w).trigger("click");
+    expect(menu(w).exists()).toBe(false);
+  });
+
+  it("emits move(-1) for up and move(1) for down, then closes", async () => {
+    const w = mountMenu();
+    await kebab(w).trigger("click");
+    await w.get('[data-testid="reorder-up"]').trigger("click");
+    expect(w.emitted("move")?.[0]).toEqual([-1]);
+    expect(menu(w).exists()).toBe(false); // picking a direction closes the menu
+
+    await kebab(w).trigger("click");
+    await w.get('[data-testid="reorder-down"]').trigger("click");
+    expect(w.emitted("move")?.[1]).toEqual([1]);
+  });
+
+  it("disables the direction that can't move and does not emit for it", async () => {
+    const w = mountMenu(false, true); // at the top: up disabled
+    await kebab(w).trigger("click");
+    expect(w.get('[data-testid="reorder-up"]').attributes("disabled")).toBeDefined();
+    await w.get('[data-testid="reorder-up"]').trigger("click");
+    expect(w.emitted("move")).toBeUndefined();
+  });
+
+  it("closes on an outside pointerdown", async () => {
+    const w = mountMenu();
+    await kebab(w).trigger("click");
+    expect(menu(w).exists()).toBe(true);
+    document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    await w.vm.$nextTick();
+    expect(menu(w).exists()).toBe(false);
+    w.unmount();
+  });
+});

--- a/test/src/components/CockpitRowMenu.spec.ts
+++ b/test/src/components/CockpitRowMenu.spec.ts
@@ -1,49 +1,53 @@
 import { describe, it, expect } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, DOMWrapper } from "@vue/test-utils";
 import CockpitRowMenu from "../../../src/components/CockpitRowMenu.vue";
 
+// The dropdown is teleported to <body>, so it lives outside the wrapper — query the document.
+const menuOpen = () => !!document.querySelector('[data-testid="cockpit-reorder-menu"]');
+const item = (id: string) => new DOMWrapper(document.querySelector(`[data-testid="${id}"]`) as Element);
 const mountMenu = (canUp = true, canDown = true) => mount(CockpitRowMenu, { props: { canUp, canDown }, attachTo: document.body });
-
 const kebab = (w: ReturnType<typeof mount>) => w.get('[data-testid="cockpit-reorder"]');
-const menu = (w: ReturnType<typeof mount>) => w.find('[data-testid="cockpit-reorder-menu"]');
 
 describe("CockpitRowMenu", () => {
   it("starts closed and toggles the menu on the ⋮ button", async () => {
     const w = mountMenu();
-    expect(menu(w).exists()).toBe(false);
+    expect(menuOpen()).toBe(false);
     await kebab(w).trigger("click");
-    expect(menu(w).exists()).toBe(true);
+    expect(menuOpen()).toBe(true);
     await kebab(w).trigger("click");
-    expect(menu(w).exists()).toBe(false);
+    expect(menuOpen()).toBe(false);
+    w.unmount();
   });
 
   it("emits move(-1) for up and move(1) for down, then closes", async () => {
     const w = mountMenu();
     await kebab(w).trigger("click");
-    await w.get('[data-testid="reorder-up"]').trigger("click");
+    await item("reorder-up").trigger("click");
     expect(w.emitted("move")?.[0]).toEqual([-1]);
-    expect(menu(w).exists()).toBe(false); // picking a direction closes the menu
+    expect(menuOpen()).toBe(false); // picking a direction closes the menu
 
     await kebab(w).trigger("click");
-    await w.get('[data-testid="reorder-down"]').trigger("click");
+    await item("reorder-down").trigger("click");
     expect(w.emitted("move")?.[1]).toEqual([1]);
+    w.unmount();
   });
 
   it("disables the direction that can't move and does not emit for it", async () => {
     const w = mountMenu(false, true); // at the top: up disabled
     await kebab(w).trigger("click");
-    expect(w.get('[data-testid="reorder-up"]').attributes("disabled")).toBeDefined();
-    await w.get('[data-testid="reorder-up"]').trigger("click");
+    expect(item("reorder-up").attributes("disabled")).toBeDefined();
+    await item("reorder-up").trigger("click");
     expect(w.emitted("move")).toBeUndefined();
+    w.unmount();
   });
 
   it("closes on an outside pointerdown", async () => {
     const w = mountMenu();
     await kebab(w).trigger("click");
-    expect(menu(w).exists()).toBe(true);
+    expect(menuOpen()).toBe(true);
     document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
     await w.vm.$nextTick();
-    expect(menu(w).exists()).toBe(false);
+    expect(menuOpen()).toBe(false);
     w.unmount();
   });
 });

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, DOMWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalGrid, { type CockpitRow } from "../../../src/components/TerminalGrid.vue";
 import type { Cell } from "../../../src/components/gridTabs.js";
@@ -137,8 +137,10 @@ describe("TerminalGrid (page renderer)", () => {
     const kebabs = w.findAll('[data-testid="cockpit-reorder"]');
     expect(kebabs).toHaveLength(2);
     await kebabs[1].trigger("click");
-    await w.get('[data-testid="reorder-up"]').trigger("click"); // the one open menu (row 1)
+    // the dropdown is teleported to <body>, so reach it through the document
+    await new DOMWrapper(document.querySelector('[data-testid="reorder-up"]') as Element).trigger("click");
     expect(w.emitted("move")?.[0]).toEqual([1, -1]);
+    w.unmount();
   });
 
   it("adds the zoomed class only when a cell is expanded", async () => {

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -67,7 +67,7 @@ const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => (
   headerTextColor: null,
   ...over,
 });
-const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[]) =>
+const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[], reorderable = false) =>
   mount(TerminalGrid, {
     props: {
       cells,
@@ -80,7 +80,7 @@ const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[]
       home: "/work",
       openSessionIds: [],
       openCwds: [],
-      reorderable: false,
+      reorderable,
     },
   });
 
@@ -121,6 +121,24 @@ describe("TerminalGrid (page renderer)", () => {
     cellsOf(w)[0].vm.$emit("status", "waiting");
     expect(w.emitted("move")?.[0]).toEqual([7, 1]);
     expect(w.emitted("status")?.[0]).toEqual([7, "waiting"]);
+  });
+
+  it("puts a ⋮ reorder menu on cockpit rows only in manual mode, emitting move tagged with uid", async () => {
+    const cells = [cell(0, "s0"), cell(1, "s1"), cell(2)]; // two running + a trailing launch cell
+    const rows = [rosterRow(0), rosterRow(1)];
+    // auto mode (reorderable = false): the roster renders but carries no ⋮
+    const auto = mountCockpit(cells, 0, rows);
+    await nextTick();
+    expect(auto.findAll('[data-testid="cockpit-row"]')).toHaveLength(2); // roster is shown
+    expect(auto.find('[data-testid="cockpit-reorder"]').exists()).toBe(false);
+    // manual mode: a ⋮ per row, and moving the 2nd row up emits move tagged with its uid
+    const w = mountCockpit(cells, 0, rows, true);
+    await nextTick();
+    const kebabs = w.findAll('[data-testid="cockpit-reorder"]');
+    expect(kebabs).toHaveLength(2);
+    await kebabs[1].trigger("click");
+    await w.get('[data-testid="reorder-up"]').trigger("click"); // the one open menu (row 1)
+    expect(w.emitted("move")?.[0]).toEqual([1, -1]);
   });
 
   it("adds the zoomed class only when a cell is expanded", async () => {

--- a/test/src/components/gridTabs.spec.ts
+++ b/test/src/components/gridTabs.spec.ts
@@ -16,6 +16,7 @@ import {
   insertCellAfter,
   shellCell,
   launchInCell,
+  canMoveCell,
   setSortMode,
   moveCell,
   orderCells,
@@ -320,6 +321,25 @@ describe("setSortMode / moveCell (manual reorder)", () => {
   it("moveCell won't push a cell past the trailing launch cell (it stays last)", () => {
     const s = make([...running(2), cell(2)]); // cell 2 is the trailing launcher
     expect(moveCell(s, 1, 1)).toBe(s);
+  });
+
+  // canMoveCell drives the enabled/disabled state of the roster's up/down menu items, so it must
+  // report exactly the moves moveCell would perform (used to gate them in TerminalGrid).
+  it("canMoveCell allows a swap in the middle", () => {
+    const cells = running(3);
+    expect(canMoveCell(cells, 1, -1)).toBe(true);
+    expect(canMoveCell(cells, 1, 1)).toBe(true);
+  });
+  it("canMoveCell forbids moving off either end or an unknown uid", () => {
+    const cells = running(3);
+    expect(canMoveCell(cells, 0, -1)).toBe(false); // already first
+    expect(canMoveCell(cells, 2, 1)).toBe(false); // already last
+    expect(canMoveCell(cells, 99, 1)).toBe(false); // unknown uid
+  });
+  it("canMoveCell forbids swapping past the trailing launch cell", () => {
+    const cells = [...running(2), cell(2)]; // cell 2 is the trailing launcher
+    expect(canMoveCell(cells, 1, 1)).toBe(false); // would push cell 1 into the launcher's last slot
+    expect(canMoveCell(cells, 0, 1)).toBe(true); // cell 0 down into cell 1 is fine
   });
 });
 


### PR DESCRIPTION
## Summary

グリッドをズームしたときの左サイドバー（cockpit roster）の各行ヘッダー**右端**に **⋮ ボタン**を追加し、**上へ移動 / 下へ移動**のメニューでその場でセルを並べ替えられるようにした。これまで手動並べ替え（`moveCell`）はグリッドの各セルの ◀▶ からしかできず、ズームして roster を見ている状態からは並べ替えられなかった、その穴を埋める。

- **⋮ はヘッダー右端**。行本体クリック（＝拡大するセルの切替）は据え置き。
- メニューは **上へ移動 / 下へ移動**。端の行は該当方向を無効化。
- **manual ソートのときだけ** ⋮ を表示（`reorderable`）。auto は注目度順で自動ソートされ手動並びが上書きされるため。
- 実処理は既存の `moveCell(uid, ±1)` を `@move` 経由で流用。

## Items to Confirm / Review

- **見た目の実機確認**を推奨: ⋮ が色付きヘッダーバーの右端に乗る位置・メニューの体裁。デザインは事前共有したモックに合わせて実装（同じ配色・構造）。
- roster 行を `<button>` → `<div role="button" tabindex="0">` に変更（ボタン入れ子回避）。`@keydown.enter/space.self` で activate、`.self` で ⋮ ボタンのキー操作と衝突しない。⋮ メニュー root は `@click.stop` で行の toggle-expand に伝播させない。
- 端の無効化は pure な `canMoveCell` に一元化（`moveCell` も同じ判定を使う＝ドリフトしない）。
- テストは3層: `canMoveCell`（gridTabs.spec）/ `CockpitRowMenu`（新規 component spec: 開閉・上下 emit・無効項目・外側クリックで閉）/ `TerminalGrid`（manual 時のみ ⋮ が出て `move(uid, dir)` を emit）。各々を変異テストで「壊すと落ちる」ことを確認済み。`typecheck` / `:server` / `:test` / `build` 通過。

## User Prompt

グリッドのズーム時サイドバー（cockpit roster）で各行の順番を入れ替えたい。三点（⋮）ボタン→メニューで並べ替え、⋮ はヘッダーの右端。並べ替えメニューは manual ソートのときだけ出す。

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)