### PR TITLE
feat: roster と strip サムネイルでヘッダーを共有（CockpitHeader）— dir 色を常時適用 (#710)

### DIFF
--- a/plans/feat-710-shared-cockpit-header.md
+++ b/plans/feat-710-shared-cockpit-header.md
@@ -1,0 +1,27 @@
+# feat #710 — 共有 CockpitHeader（roster と strip サムネイルで同じヘッダー表示）
+
+対象 issue: https://github.com/receptron/mulmoterminal/issues/710
+
+## 背景
+
+strip サムネイルの header は `TerminalCell` の cell-header で、dir 色は **idle のときだけ**適用され、working/done/blocked ではステータス色が上書きする。roster はステータスに関係なく**常に dir 色**をバーに出す。ユーザーは strip サムネイルも roster と同じ（色＋ラベル）にしたい。共有コンポーネント化も希望。
+
+## 実装
+
+### `src/components/CockpitHeader.vue`（新規）
+roster 行ヘッダーを部品化：色付きバー（`--cell-header-bg` を常時＝dir 色、`headerStyleFor`）＋ ステータスドット ＋ バッジ（`statusWord`：running/waiting/done/idle、working+workPhase は WORK_WORD）＋ 任意 phase バッジ ＋ 任意 codex タグ ＋ dir（`formatCwd`）＋ 末尾 `<slot />`。
+- props: `status, agent, cwd, home, headerColor, headerTextColor, workPhase?, phase?, dirLength=44`。
+- DOT_CLASS / BADGE_CLASS / PHASE_CLASS / statusWord / phaseClass を TerminalGrid から移設（一元化）。負のマージン等の位置調整は呼び出し側の passthrough class。
+
+### `TerminalGrid.vue`（roster）
+インラインの cockpit-header を `<CockpitHeader class="-mx-2.5 -mt-2 ...">` に置換。末尾スロットに `CockpitRowMenu`(⋮)。`data-testid="cockpit-header"` / `cockpit-badge` は CockpitHeader 側に付けて維持。移設した定数・helper を削除。
+
+### `TerminalCell.vue`（strip サムネイル）
+`filmstrip`(zoomed && !expanded) のとき、cell-header を `<CockpitHeader class="cell-header is-zoomable ..." :status :agent :cwd :home :header-color=dirConfig.headerColor :header-text-color=dirConfig.headerTextColor @click="onHeaderClick">` に置換し、末尾スロットに expand/close(`cell-actions`)。dir 色は常時適用・ラベルは roster と同じ。通常グリッド（非 filmstrip）は現状の cell-header のまま。
+
+## テスト
+- `CockpitHeader.spec`：色（headerStyleFor で `--cell-header-bg`）・ラベル（各 status / workPhase）・phase/codex 有無・dir 整形・slot。
+- `TerminalGrid.spec`：roster が CockpitHeader を使い cockpit-header/badge を維持、⋮ が slot で出る。
+- `TerminalCell.spec`：filmstrip の header が CockpitHeader（dir 色常時＋バッジ）になり、click で zoom、expand/close が残ることを更新。
+
+変異テストで「壊すと落ちる」ことを確認してからマージ。

--- a/src/components/CockpitHeader.vue
+++ b/src/components/CockpitHeader.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+// The status/dir header bar shared by the cockpit roster rows and the strip thumbnails, so both
+// read as the same directory: the bar is always tinted with the dir's configured header colour
+// (status is carried by the dot + badge, not the bar background), with the roster's status
+// wording. Trailing controls — the roster's ⋮ reorder menu, or a thumbnail's expand/close —
+// go in the default slot.
+import { computed } from "vue";
+import { formatCwd } from "./cwdDisplay";
+import { headerStyleFor } from "./cellHeaderStyle";
+import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterPhase";
+import type { CellStatus } from "./gridTabs";
+
+const props = withDefaults(
+  defineProps<{
+    status: CellStatus;
+    agent: string;
+    cwd: string | null;
+    home: string | null;
+    headerColor: string | null;
+    headerTextColor: string | null;
+    workPhase?: WorkPhase | null;
+    phase?: PrPhase;
+    dirLength?: number;
+  }>(),
+  { workPhase: null, phase: "none", dirLength: 44 },
+);
+
+const STATUS_WORD: Record<CellStatus, string> = { working: "running", blocked: "waiting", done: "done", idle: "idle" };
+// Hardcoded, token-less roster hues — come through as arbitrary utilities; fill + text paired.
+const DOT_CLASS: Record<CellStatus, string> = { working: "bg-[#4a9eff]", done: "bg-[#22c55e]", blocked: "bg-[#f59e0b]", idle: "bg-[#666]" };
+const BADGE_CLASS: Record<CellStatus, string> = {
+  working: "bg-[#4a9eff] text-[#04121f]",
+  done: "bg-[#22c55e] text-[#04120a]",
+  blocked: "bg-[#f59e0b] text-[#1f1300]",
+  idle: "bg-[#333] text-[#ddd]",
+};
+// Outlined pill, coloured by PR lifecycle; anything unlisted keeps the neutral grey.
+const PHASE_CLASS: Record<string, string> = {
+  "ci-running": "text-[#4a9eff]",
+  "ci-failing": "text-[#f87171]",
+  "changes-requested": "text-[#f59e0b]",
+  ready: "text-[#22c55e]",
+  merged: "text-[#a78bfa]",
+};
+
+// A working cell shows what it's doing (planning / editing) when known, else the plain word.
+const badgeWord = computed(() => (props.status === "working" && props.workPhase ? WORK_WORD[props.workPhase] : STATUS_WORD[props.status]));
+const phaseInfo = computed(() => phaseDisplay(props.phase ?? "none"));
+const phaseColor = computed(() => PHASE_CLASS[props.phase ?? "none"] ?? "text-[#9aa4b2]");
+const dirText = computed(() => formatCwd(props.cwd, props.home, props.dirLength ?? 44) || "—");
+const barStyle = computed(() => headerStyleFor(props.headerColor, props.headerTextColor));
+</script>
+
+<template>
+  <div
+    data-testid="cockpit-header"
+    class="flex min-w-0 items-center gap-1.5 bg-[var(--cell-header-bg,transparent)] px-2.5 py-1.5 text-[var(--cell-header-fg,inherit)]"
+    :style="barStyle"
+  >
+    <span class="h-2 w-2 flex-none rounded-full" :class="DOT_CLASS[status]" aria-hidden="true" />
+    <span data-testid="cockpit-badge" class="flex-none rounded-full px-1.5 py-px text-[10px] font-bold" :class="BADGE_CLASS[status]">{{ badgeWord }}</span>
+    <span
+      v-if="phaseInfo"
+      data-testid="cockpit-phase"
+      class="flex-none whitespace-nowrap rounded-full border border-current px-1.5 text-[10px] font-bold"
+      :class="[`ph-${phase}`, phaseColor]"
+      :title="phaseInfo.title"
+      >{{ phaseInfo.label }}</span
+    >
+    <span v-if="agent === 'codex'" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">codex</span>
+    <span class="min-w-0 flex-auto truncate text-[11px] text-[var(--cell-header-fg,var(--text-dim))]">{{ dirText }}</span>
+    <slot />
+  </div>
+</template>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -19,6 +19,7 @@ import type { LaunchChoice } from "./wsUrl";
 import type { RunCommand } from "./runCommand";
 import { useHeaderButtons } from "../composables/useHeaderButtons";
 import TimelineOverlay from "./TimelineOverlay.vue";
+import CockpitHeader from "./CockpitHeader.vue";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { activityStatus, type CellStatus } from "./gridTabs";
@@ -991,9 +992,37 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
     :style="cellStyle"
   >
     <template v-if="launched">
-      <!-- Row 1 — INFO only: dir + git + model/token + what it's doing. Every icon
-           BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
+      <!-- Filmstrip thumbnail: the same roster header (CockpitHeader) — the dir colour is applied
+           regardless of status (status is the dot + badge), so a thumbnail reads as its directory
+           the way the roster row does. Expand/close go in its trailing slot. -->
+      <CockpitHeader
+        v-if="filmstrip"
+        class="cell-header flex-none border-b"
+        :class="[statusClass, { 'is-zoomable': !expanded }]"
+        :status="status"
+        :agent="agent"
+        :cwd="cwd"
+        :home="home"
+        :header-color="dirConfig.headerColor"
+        :header-text-color="dirConfig.headerTextColor"
+        @click="onHeaderClick"
+      >
+        <span class="cell-actions">
+          <button
+            class="cell-btn"
+            :title="expanded ? 'Restore' : 'Expand'"
+            :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
+            @click.stop="emit('toggle-expand')"
+          >
+            {{ expanded ? "⤡" : "⤢" }}
+          </button>
+          <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click.stop="close">✕</button>
+        </span>
+      </CockpitHeader>
+      <!-- Row 1 — INFO only (normal grid / expanded): dir + git + model/token + what it's doing.
+           Every icon BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
       <div
+        v-else
         class="cell-header flex h-[34px] flex-none items-center gap-2 border-b px-2"
         :class="[statusClass, headerStatusClass, { 'is-zoomable': !expanded }]"
         :style="headerStyle"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -4,17 +4,16 @@ import TerminalCell from "./TerminalCell.vue";
 import CommandCell from "./CommandCell.vue";
 import LauncherCell from "./LauncherCell.vue";
 import CockpitRowMenu from "./CockpitRowMenu.vue";
+import CockpitHeader from "./CockpitHeader.vue";
 import * as conn from "../composables/useTerminalConnections";
 import { trackStyle, layoutForCount } from "./gridLayout";
 import { flipKeyframes, flipPairs, onScreen, FLIP_MS, FLIP_EASING } from "./cellFlip";
-import { formatCwd } from "./cwdDisplay";
 import { canMoveCell, type Cell, type CellStatus } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
-import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterPhase";
+import type { PrPhase, WorkPhase } from "./rosterPhase";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { shouldFlipZoom } from "./cellChromeRules";
-import { headerStyleFor } from "./cellHeaderStyle";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -38,32 +37,6 @@ export interface CockpitRow {
   headerColor: string | null; // the directory's configured header background, tinting the row
   headerTextColor: string | null; // and its text colour, so the row stays legible on that tint
 }
-const STATUS_WORD: Record<CellStatus, string> = { working: "running", blocked: "waiting", done: "done", idle: "idle" };
-// A working cell shows what it's doing (planning / editing) when known, else the plain word.
-const statusWord = (row: CockpitRow): string => (row.status === "working" && row.workPhase ? WORK_WORD[row.workPhase] : STATUS_WORD[row.status]);
-// Roster colours. These hues are hardcoded and token-less, so they come through as
-// arbitrary utilities; returning fill+text together keeps the pair in one place.
-const DOT_CLASS: Record<CellStatus, string> = {
-  working: "bg-[#4a9eff]",
-  done: "bg-[#22c55e]",
-  blocked: "bg-[#f59e0b]",
-  idle: "bg-[#666]",
-};
-const BADGE_CLASS: Record<CellStatus, string> = {
-  working: "bg-[#4a9eff] text-[#04121f]",
-  done: "bg-[#22c55e] text-[#04120a]",
-  blocked: "bg-[#f59e0b] text-[#1f1300]",
-  idle: "bg-[#333] text-[#ddd]",
-};
-// Outlined pill, coloured by PR lifecycle; anything unlisted keeps the neutral grey.
-const PHASE_CLASS: Record<string, string> = {
-  "ci-running": "text-[#4a9eff]",
-  "ci-failing": "text-[#f87171]",
-  "changes-requested": "text-[#f59e0b]",
-  ready: "text-[#22c55e]",
-  merged: "text-[#a78bfa]",
-};
-const phaseClass = (phase: PrPhase): string => PHASE_CLASS[phase] ?? "text-[#9aa4b2]";
 const props = defineProps<{
   cells: Cell[];
   expandedUid: number | null;
@@ -233,36 +206,27 @@ watch(
         @keydown.enter.self.prevent="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
         @keydown.space.self.prevent="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
       >
-        <!-- The status + directory line is the row's header: it carries the directory's
-             configured header colour as a bar, pulled to the row's top and side edges. A
-             directory with no colour set leaves the bar transparent. -->
-        <span
-          data-testid="cockpit-header"
-          class="-mx-2.5 -mt-2 flex min-w-0 items-center gap-1.5 bg-[var(--cell-header-bg,transparent)] px-2.5 py-1.5 text-[var(--cell-header-fg,inherit)]"
-          :style="headerStyleFor(row.headerColor, row.headerTextColor)"
+        <!-- The status + directory line is the row's header: a bar tinted with the directory's
+             configured header colour, pulled to the row's top and side edges. Shared with the
+             strip thumbnails (CockpitHeader) so both read as the same directory. -->
+        <CockpitHeader
+          class="-mx-2.5 -mt-2"
+          :status="row.status"
+          :agent="row.agent"
+          :cwd="row.cwd"
+          :home="home"
+          :header-color="row.headerColor"
+          :header-text-color="row.headerTextColor"
+          :work-phase="row.workPhase"
+          :phase="row.phase"
         >
-          <span class="h-2 w-2 flex-none rounded-full" :class="DOT_CLASS[row.status]" aria-hidden="true" />
-          <span data-testid="cockpit-badge" class="flex-none rounded-full px-1.5 py-px text-[10px] font-bold" :class="BADGE_CLASS[row.status]">{{
-            statusWord(row)
-          }}</span>
-          <span
-            v-if="phaseDisplay(row.phase)"
-            data-testid="cockpit-phase"
-            class="flex-none whitespace-nowrap rounded-full border border-current px-1.5 text-[10px] font-bold"
-            :class="[`ph-${row.phase}`, phaseClass(row.phase)]"
-            :title="phaseDisplay(row.phase)?.title"
-          >
-            {{ phaseDisplay(row.phase)?.label }}
-          </span>
-          <span v-if="row.agent === 'codex'" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">codex</span>
-          <span class="min-w-0 flex-auto truncate text-[11px] text-[var(--cell-header-fg,var(--text-dim))]">{{ formatCwd(row.cwd, home, 44) || "—" }}</span>
           <CockpitRowMenu
             v-if="reorderable"
             :can-up="canMoveCell(cells, row.uid, -1)"
             :can-down="canMoveCell(cells, row.uid, 1)"
             @move="(dir) => emit('move', row.uid, dir)"
           />
-        </span>
+        </CockpitHeader>
         <span v-if="row.summary" data-testid="cockpit-line" class="line-clamp-2 overflow-hidden text-[12px] leading-[1.35]"
           ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">summary</b> {{ row.summary }}</span
         >

--- a/test/src/components/CockpitHeader.spec.ts
+++ b/test/src/components/CockpitHeader.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CockpitHeader from "../../../src/components/CockpitHeader.vue";
+import type { CellStatus } from "../../../src/components/gridTabs";
+import type { PrPhase, WorkPhase } from "../../../src/components/rosterPhase";
+
+type Props = {
+  status: CellStatus;
+  agent: string;
+  cwd: string | null;
+  home: string | null;
+  headerColor: string | null;
+  headerTextColor: string | null;
+  workPhase?: WorkPhase | null;
+  phase?: PrPhase;
+  dirLength?: number;
+};
+const base: Props = { status: "idle", agent: "claude", cwd: "/home/me/proj", home: "/home/me", headerColor: null, headerTextColor: null };
+const mountH = (over: Partial<Props> = {}, slot?: string) => mount(CockpitHeader, { props: { ...base, ...over }, slots: slot ? { default: slot } : {} });
+const bar = (w: ReturnType<typeof mountH>) => w.get('[data-testid="cockpit-header"]');
+const badge = (w: ReturnType<typeof mountH>) => w.get('[data-testid="cockpit-badge"]').text();
+
+describe("CockpitHeader", () => {
+  it("tints the bar with the configured header colour, and leaves it untinted when there is none", () => {
+    expect(bar(mountH({ headerColor: "#123456" })).attributes("style")).toContain("--cell-header-bg: #123456");
+    expect(bar(mountH({ headerColor: null })).attributes("style") ?? "").not.toContain("--cell-header-bg");
+  });
+
+  it("shows the roster status word for each status", () => {
+    expect(badge(mountH({ status: "idle" }))).toBe("idle");
+    expect(badge(mountH({ status: "working" }))).toBe("running");
+    expect(badge(mountH({ status: "blocked" }))).toBe("waiting");
+    expect(badge(mountH({ status: "done" }))).toBe("done");
+  });
+
+  it("shows the work phase word while working when it is known", () => {
+    expect(badge(mountH({ status: "working", workPhase: "implementing" }))).toBe("editing");
+    expect(badge(mountH({ status: "working", workPhase: "planning" }))).toBe("planning");
+  });
+
+  it("shows the PR phase pill only when there is a phase", () => {
+    expect(mountH({ phase: "none" }).find('[data-testid="cockpit-phase"]').exists()).toBe(false);
+    expect(mountH({ phase: "ready" }).find('[data-testid="cockpit-phase"]').exists()).toBe(true);
+  });
+
+  it("tags codex cells and not claude ones", () => {
+    expect(mountH({ agent: "codex" }).text()).toContain("codex");
+    expect(mountH({ agent: "claude" }).text()).not.toContain("codex");
+  });
+
+  it("renders the directory and the trailing slot", () => {
+    const w = mountH({ cwd: "/home/me/proj", home: "/home/me" }, '<button data-testid="slotted">x</button>');
+    expect(w.text()).toContain("proj");
+    expect(w.find('[data-testid="slotted"]').exists()).toBe(true);
+  });
+});

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1609,21 +1609,24 @@ describe("TerminalCell", () => {
     expect(w.find("button.cell-dir").exists()).toBe(true); // dir stays clickable
   });
 
-  it("a filmstrip thumbnail (another cell zoomed) drops to dir + activity + zoom only", async () => {
+  it("a filmstrip thumbnail (another cell zoomed) uses the shared roster header, chips stripped", async () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", zoomed: true, expanded: false });
     await flushPromises();
-    // Info stripped: no git chip / usage; the second (terminal) header row is hidden.
+    // The roster-style header (dir colour applied regardless of status, plus its status badge),
+    // NOT the full info header.
+    expect(w.find('[data-testid="cockpit-header"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cockpit-badge"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-header-main"]').exists()).toBe(false);
+    // Info stripped: no git chip / usage / open-dir button; the terminal's own header row is hidden.
     expect(w.find('[data-testid="git-chip"]').exists()).toBe(false);
     expect(w.find('[data-testid="cell-usage"]').exists()).toBe(false);
-    expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
-    // Row 1 keeps dir + prompt + the expand/close actions (row 2 is hidden).
-    expect(w.find('[aria-label="Expand terminal"]').exists()).toBe(true);
-    // The dir stays visible but as inert text (not an "open dir" button).
-    expect(w.find("span.cell-dir").exists()).toBe(true);
     expect(w.find("button.cell-dir").exists()).toBe(false);
+    expect(w.findComponent({ name: "TerminalView" }).props("hideHeader")).toBe(true);
+    // Expand/close stay available.
+    expect(w.find('[aria-label="Expand terminal"]').exists()).toBe(true);
   });
 
-  it("a filmstrip thumbnail's dir click zooms (switch to it) instead of opening the dir", async () => {
+  it("a filmstrip thumbnail's header click zooms (switch to it) instead of opening the dir", async () => {
     const urls: string[] = [];
     globalThis.fetch = vi.fn((url: string) => {
       urls.push(String(url));
@@ -1633,7 +1636,7 @@ describe("TerminalCell", () => {
 
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/proj", zoomed: true, expanded: false });
     await flushPromises();
-    await w.find(".cell-dir").trigger("click");
+    await w.find('[data-testid="cockpit-header"]').trigger("click");
 
     expect(w.emitted("toggle-expand")).toHaveLength(1); // zoomed instead
     expect(urls).not.toContain("/api/open-dir"); // dir was NOT opened


### PR DESCRIPTION
## Summary

grid ズーム時の strip サムネイルは、ユーザー設定の dir ヘッダー色が **idle のときだけ**適用され、working/done/blocked では**ステータス色が上書き**していた。roster（サイドメニュー）は**常に dir 色**をバーに出すため、strip と見た目が食い違っていた。

roster 行ヘッダーを**共有コンポーネント `CockpitHeader.vue`** に切り出し、roster 行と strip サムネイルの**両方**で使うようにした。dir 色は**常時適用**（ステータスはドット＋バッジで表現）、ラベルも roster と同じ（running / waiting / done / idle、working 中は work phase）。

- **roster（TerminalGrid）**: インライン header を `<CockpitHeader>` に置換、末尾スロットに ⋮（`CockpitRowMenu`）。
- **strip サムネイル（TerminalCell の filmstrip 時）**: 縮小 cell-header を `<CockpitHeader>` に置換、末尾スロットに expand/close。通常グリッド／拡大時は従来の情報ヘッダーのまま。

## Items to Confirm / Review

- **見た目の実機確認**を推奨（strip サムネイルのヘッダーが roster と同じ色・ラベルになるか）。`git pull` 後、grid をズーム → ▤/☰ でサムネイル帯に切替。
- DOT/BADGE/PHASE クラス・`statusWord` を `CockpitHeader` に一元化（TerminalGrid から重複削除）。scoped CSS（`.cell-header.is-zoomable` / `.cell-actions` / `.cell-btn`）は Vue の「子ルートに親スコープが乗る」「スロットは親スコープ」規則で従来どおり効く。
- filmstrip サムネイルは情報チップ（git/usage/dir ボタン/プロンプト）を出さず、dir＋ステータス＋expand/close のみ（roster に寄せた）。クリックでズーム・close は維持。
- テスト3層：`CockpitHeader.spec`（色・ラベル・phase/codex・dir・slot）／`TerminalGrid.spec`（roster が cockpit-header/badge を維持）／`TerminalCell.spec`（filmstrip が CockpitHeader を使う・クリックでズーム）。各々を変異テストで確認済み。`typecheck`/`:test`/`build` 通過、コンポーネント 225 テスト緑。

## User Prompt

grid ズーム時の strip サムネイルの header 色が、ユーザー設定の dir 色になっていない。header は roster（サイドメニュー）表示時と同じ（色もラベルも）にしたい。できれば共有コンポーネントにして roster と strip で同じものを使う。

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)