### PR TITLE
refactor: put the Settings cost formatter behind a tested function (#611)

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -10,6 +10,7 @@ import SettingsField from "./SettingsField.vue";
 import type { Launcher } from "./launchers";
 import type { UserMcpServer } from "./userMcp";
 import { canAddLauncher, canAddMcpServer, canAddRepo } from "./settingsValidators";
+import { formatUsd } from "./formatUsd";
 
 const props = defineProps<{
   soundFile?: string | null;
@@ -191,11 +192,6 @@ function onThemeKey(e: KeyboardEvent, index: number) {
 
 // Read-only estimated cost (Session / Today / Month), loaded when the modal opens.
 const { cost, error: costError, load: loadCost } = useCost();
-function formatUsd(value: number | undefined): string {
-  if (value === undefined) return "—";
-  if (value > 0 && value < 0.01) return "<$0.01";
-  return `$${value.toFixed(2)}`;
-}
 
 const modalEl = ref<HTMLElement>();
 

--- a/src/components/formatUsd.ts
+++ b/src/components/formatUsd.ts
@@ -1,0 +1,12 @@
+// The estimated-cost figures in Settings (Session / Today / Month). A money string that
+// looks right is believed, so the two edges that would quietly mislead get their own rule:
+// an absent value reads as "—" rather than "$0.00" (nothing loaded yet is not "free"), and a
+// positive amount under a cent reads as "<$0.01" rather than rounding down to "$0.00" (a real
+// cost must never render as no cost). Everything else is a plain two-decimal dollar amount.
+const CENT_USD = 0.01;
+
+export function formatUsd(value: number | undefined): string {
+  if (value === undefined) return "—";
+  if (value > 0 && value < CENT_USD) return "<$0.01";
+  return `$${value.toFixed(2)}`;
+}

--- a/test/src/components/formatUsd.spec.ts
+++ b/test/src/components/formatUsd.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+
+import { formatUsd } from "../../../src/components/formatUsd";
+
+const CENT_USD = 0.01;
+
+describe("formatUsd", () => {
+  // Nothing loaded yet is not "$0.00" — the dash says "no figure", a zero says "cost is zero".
+  it("shows a dash for an absent value", () => {
+    expect(formatUsd(undefined)).toBe("—");
+  });
+
+  // A genuine zero cost is a real figure and reads as such.
+  it("shows an exact zero as $0.00", () => {
+    expect(formatUsd(0)).toBe("$0.00");
+  });
+
+  // A positive amount under a cent must not round down to "$0.00" — a real cost never renders
+  // as no cost. The boundary is exactly one cent.
+  it.each([
+    [0.0001, "<$0.01"],
+    [0.004, "<$0.01"],
+    [0.009, "<$0.01"],
+  ])("shows a sub-cent %d as <$0.01", (value, expected) => {
+    expect(formatUsd(value)).toBe(expected);
+  });
+
+  it("shows exactly one cent as $0.01, not <$0.01", () => {
+    expect(formatUsd(CENT_USD)).toBe("$0.01");
+  });
+
+  it.each([
+    [1.5, "$1.50"],
+    [12.3, "$12.30"],
+    [1234.5, "$1234.50"],
+  ])("shows %d as %s", (value, expected) => {
+    expect(formatUsd(value)).toBe(expected);
+  });
+
+  // Two decimals, rounding the third.
+  it.each([
+    [1.005, "$1.00"],
+    [1.006, "$1.01"],
+    [1234.567, "$1234.57"],
+  ])("rounds %d to two decimals as %s", (value, expected) => {
+    expect(formatUsd(value)).toBe(expected);
+  });
+
+  // Deliberate asymmetry: the sub-cent rule guards only positive amounts (cost is never
+  // negative in practice), so a negative slips straight to the plain formatter rather than
+  // "<$0.01". Pinned so the guard is not "helpfully" widened to `Math.abs`.
+  it("does not apply the sub-cent rule to negatives", () => {
+    expect(formatUsd(-0.004)).toBe("$-0.00");
+  });
+});


### PR DESCRIPTION
## Summary

Extracts `formatUsd` from `SettingsModal.vue` into `src/components/formatUsd.ts` and covers it with unit tests. Part of the #611 campaign: pull small display/decision rules out of components and pin the ones that fail silently.

## Items to Confirm / Review

- **Behavior is byte-identical** to the inline version — pure move, no logic change. Reviewer should confirm the three branches (`undefined → "—"`, positive sub-cent → `"<$0.01"`, else → `$X.XX`) match the original.
- **Deliberate asymmetry pinned**: the sub-cent guard only applies to positive values, so a negative falls straight through to `toFixed` (`-0.004 → "$-0.00"`). Cost is never negative in practice; the test documents this so the guard isn't later "helpfully" widened to `Math.abs`.

## Why this one

Cost figures (Session / Today / Month) are exactly the "a number that looks like a number is believed" case: an off-by-one at the sub-cent boundary, or showing `$0.00` when the value hasn't loaded, is invisible until someone trusts a wrong figure. Two edges now have named tests, verified via mutation (flipping `<` to `<=` turns the one-cent boundary test red).

## Test plan

- `yarn vitest run test/src/components/formatUsd.spec.ts` — 13 passing.
- `yarn lint` / `yarn typecheck` / `yarn build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)