### PR TITLE
test: cover the staged-attachment storage-id guard (#611)

### DIFF
--- a/test/server/backends/remoteHost/stagedStorageIds.spec.ts
+++ b/test/server/backends/remoteHost/stagedStorageIds.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import type { JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
+
+import { stagedStorageIds, STORAGE_ID_RE } from "../../../../server/backends/remoteHost/stagedStorageIds.js";
+
+// The guard that decides which attachment ids get interpolated into a Storage path. Its whole
+// job is to keep `/` and `..` out of that path, so a regression fails silently in the worst
+// direction: loosen it and a crafted id escapes the storage prefix; tighten it and a legitimate
+// attachment just vanishes with no error. Neither shows up until someone inspects the bytes.
+const withAttachments = (attachments: JsonValue): JsonObject => ({ attachments });
+const staged = (storage_id: JsonValue): JsonObject => withAttachments([{ storage_id }]);
+
+describe("STORAGE_ID_RE", () => {
+  it.each(["abc", "ABC123", "a-b-c", "0", "A", "9-9"])("accepts the safe token %j", (id) => {
+    expect(STORAGE_ID_RE.test(id)).toBe(true);
+  });
+
+  // The two the guard exists for, plus the neighbours a reader might assume are allowed.
+  it.each(["..", "a/b", "../etc", "a.b", "a_b", "a b", "a\tb", "café", "", "a\nb"])("rejects the unsafe token %j", (id) => {
+    expect(STORAGE_ID_RE.test(id)).toBe(false);
+  });
+
+  // Anchored at both ends: a valid core with a traversal prefix/suffix must not match.
+  it.each(["../abc", "abc/..", "abc/../def"])("is anchored so %j cannot match on a substring", (id) => {
+    expect(STORAGE_ID_RE.test(id)).toBe(false);
+  });
+});
+
+// Rows wrapped as 1-tuples so a value that is itself an array (a nested-array entry) reaches the
+// callback whole, instead of being spread into positional args by it.each.
+const nonStringIds: [JsonValue][] = [[42], [true], [null]];
+const nonObjectEntries: [JsonValue][] = [[null], ["just-a-string"], [123], [["nested"]]];
+const nonArrayAttachments: [JsonValue][] = [["a-string"], [42], [{ nested: "obj" }], [null]];
+
+describe("stagedStorageIds", () => {
+  it("keeps every safe id, in order", () => {
+    expect(stagedStorageIds(withAttachments([{ storage_id: "aaa" }, { storage_id: "bbb" }, { storage_id: "c-c" }]))).toEqual(["aaa", "bbb", "c-c"]);
+  });
+
+  it("returns a single safe id", () => {
+    expect(stagedStorageIds(staged("photo-1"))).toEqual(["photo-1"]);
+  });
+
+  // The security cases: a path-traversal or slashed id must be dropped, never returned.
+  it.each(["..", "../secret", "a/b", "/etc/passwd", "a/../b"])("drops the unsafe id %j", (id) => {
+    expect(stagedStorageIds(staged(id))).toEqual([]);
+  });
+
+  it("keeps the safe ids and drops the unsafe ones from a mixed list", () => {
+    expect(stagedStorageIds(withAttachments([{ storage_id: "ok-1" }, { storage_id: "../bad" }, { storage_id: "ok-2" }, { storage_id: "a/b" }]))).toEqual([
+      "ok-1",
+      "ok-2",
+    ]);
+  });
+
+  it("drops an empty-string id (the regex requires at least one char)", () => {
+    expect(stagedStorageIds(staged(""))).toEqual([]);
+  });
+
+  it.each(nonStringIds)("drops an entry whose storage_id is not a string (%j)", (id) => {
+    expect(stagedStorageIds(staged(id))).toEqual([]);
+  });
+
+  it("drops an entry with no storage_id field", () => {
+    expect(stagedStorageIds(withAttachments([{ other: "x" }]))).toEqual([]);
+  });
+
+  it.each(nonObjectEntries)("drops a non-object entry (%j)", (entry) => {
+    expect(stagedStorageIds(withAttachments([entry]))).toEqual([]);
+  });
+
+  it("is empty when attachments is absent", () => {
+    expect(stagedStorageIds({})).toEqual([]);
+  });
+
+  it.each(nonArrayAttachments)("is empty when attachments is not an array (%j)", (attachments) => {
+    expect(stagedStorageIds(withAttachments(attachments))).toEqual([]);
+  });
+
+  it("is empty for an empty attachments array", () => {
+    expect(stagedStorageIds(withAttachments([]))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`stagedStorageIds` / `STORAGE_ID_RE` (`server/backends/remoteHost/stagedStorageIds.ts`) is the guard that decides which attachment `storage_id`s get interpolated into a Firebase Storage path. Its whole job is to keep `/` and `..` out of that path — but it had zero tests. This PR adds unit coverage for the security boundary and the extractor's shape handling. No source change: test-only.

## Items to Confirm / Review

- **Silent-failure framing**: a regression here fails invisibly in both directions — loosen the regex and a crafted id escapes the storage prefix (path traversal); tighten it and a legitimate attachment just vanishes with no error. Neither surfaces until someone inspects the stored bytes.
- **Mutation-verified**: unanchoring the regex (`/^[A-Za-z0-9-]+$/` → `/[A-Za-z0-9-]+/`, i.e. allowing traversal ids to slip through) turns **16** of the 42 tests red. Restored after checking.
- **`it.each` array-spread trap**: rows for the "non-object entry" / "non-array attachments" cases are wrapped as `[JsonValue]` 1-tuples so a value that is itself an array reaches the callback whole instead of being spread into positional args.
- No `as` casts; all fixtures are plain `JsonValue` literals.

## User Prompt

Continuation of the #611 campaign: survey the codebase for pure decision rules (validation, precedence, ordering, caps, formatting) buried in I/O-bound code, and cover them with unit tests — ranking targets by how silently they fail. This one is a path-traversal validator with no coverage, which is the highest-severity silent-failure shape.

## Test cases

- `STORAGE_ID_RE`: accepts safe tokens (`abc`, `A`, `9-9`, …); rejects `..`, `a/b`, `../etc`, `a.b`, `a_b`, whitespace, non-ASCII, empty; anchored so `../abc` / `abc/..` can't match on a substring.
- `stagedStorageIds`: keeps safe ids in order; drops path-traversal / slashed ids; mixed lists keep only the safe ones; drops empty-string / non-string / missing `storage_id`; drops non-object entries; `[]` for absent / non-array / empty `attachments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)