### PR TITLE
test: cover the per-key TTL cache (#611)

### DIFF
--- a/test/server/git/ttl-cache.spec.ts
+++ b/test/server/git/ttl-cache.spec.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { createTtlCache } from "../../../server/git/ttl-cache.js";
+
+// A fixed clock, so every expiry test is deterministic — the whole point of the injected `now`.
+const at = (ms: number) => (): number => ms;
+
+describe("createTtlCache", () => {
+  it("returns undefined for a key that was never set", () => {
+    const cache = createTtlCache<string>();
+    expect(cache.get("missing", at(0), 100)).toBeUndefined();
+  });
+
+  // The freshness window is [0, ttlMs): a value survives while its age is strictly less than
+  // ttlMs, and an age of EXACTLY ttlMs is already stale. Widening the `<` to `<=` would serve an
+  // entry one tick too long — invisible until stale data leaks out. A ttlMs of 0 is never fresh,
+  // since `now() - at < 0` can't hold even for an immediate read.
+  it.each<[number, number, string | undefined]>([
+    [50, 100, "v"], // comfortably inside
+    [99, 100, "v"], // last fresh tick
+    [100, 100, undefined], // exactly ttlMs — stale
+    [101, 100, undefined], // past expiry
+    [0, 0, undefined], // ttl 0 — never fresh
+  ])("an age of %d against ttl %d yields %j", (readAt, ttlMs, expected) => {
+    const cache = createTtlCache<string>();
+    cache.set("k", "v", at(0));
+    expect(cache.get("k", at(readAt), ttlMs)).toBe(expected);
+  });
+
+  // The invariant the comment pins: get reads the clock ONLY on a hit, so probing a missing key
+  // must not even call `now`. Proven by a clock that throws if read.
+  it("does not read the clock when the key is absent", () => {
+    const cache = createTtlCache<string>();
+    const throwingNow = (): number => {
+      throw new Error("clock must not be read on a miss");
+    };
+    expect(() => cache.get("missing", throwingNow, 100)).not.toThrow();
+    expect(cache.get("missing", throwingNow, 100)).toBeUndefined();
+  });
+
+  it("reads the clock on a hit", () => {
+    const cache = createTtlCache<string>();
+    let reads = 0;
+    const countingNow = (): number => {
+      reads += 1;
+      return 10;
+    };
+    cache.set("k", "v", at(0));
+    cache.get("k", countingNow, 100);
+    expect(reads).toBe(1);
+  });
+
+  it("re-stamps the write time when a key is overwritten", () => {
+    const cache = createTtlCache<string>();
+    cache.set("k", "old", at(0));
+    cache.set("k", "new", at(200));
+    // 250 - 200 = 50 < 100 → fresh, and the value is the newer one.
+    expect(cache.get("k", at(250), 100)).toBe("new");
+  });
+
+  it("expires each key against its own write time", () => {
+    const cache = createTtlCache<string>();
+    cache.set("a", "va", at(0));
+    cache.set("b", "vb", at(100));
+    expect(cache.get("a", at(150), 100)).toBeUndefined(); // 150 - 0  = 150 ≥ 100
+    expect(cache.get("b", at(150), 100)).toBe("vb"); //        150 - 100 = 50  < 100
+  });
+
+  it("drops everything on clear", () => {
+    const cache = createTtlCache<string>();
+    cache.set("k", "v", at(0));
+    cache.clear();
+    expect(cache.get("k", at(0), 100)).toBeUndefined();
+  });
+
+  it("keeps each instance's store separate", () => {
+    const one = createTtlCache<string>();
+    const two = createTtlCache<string>();
+    one.set("k", "v", at(0));
+    expect(two.get("k", at(0), 100)).toBeUndefined();
+  });
+
+  it("returns the stored reference for object values", () => {
+    const cache = createTtlCache<{ n: number }>();
+    const value = { n: 1 };
+    cache.set("k", value, at(0));
+    expect(cache.get("k", at(0), 100)).toBe(value);
+  });
+});


### PR DESCRIPTION
## Summary

`createTtlCache` (`server/git/ttl-cache.ts`) is the per-key TTL cache behind the PR-phase and pr-for-branch lookups. It had no tests. This PR adds unit coverage. Test-only, no source change.

## Items to Confirm / Review

- **Silent-failure framing**: a cache-freshness bug never throws. Loosen the expiry and stale PR state is served as current; tighten it and every read misses. Both surface only when someone notices wrong data.
- **Strict-`<` boundary, pinned**: the freshness window is `[0, ttlMs)` — an age of *exactly* `ttlMs` is already stale. A parameterized test covers 50/99 (fresh), 100/101 (stale), and a `ttlMs: 0` row (never fresh). Mutation: `<` → `<=` turns the `100/100` and `0/0` rows red.
- **Clock-read invariant, pinned**: `get` reads the injected `now` **only on a hit**, so probing a missing key must not even call the clock. Proven by a `now` that throws — `get` on an absent key must not throw. Mutation: reading the clock unconditionally turns that test red.
- Injected clock throughout (`at = (ms) => () => ms`), so every expiry assertion is deterministic — no real time, no fakes.

## User Prompt

Continuation of the #611 campaign: find pure decision rules buried in I/O-bound code and cover them with unit tests, ranking by how silently they fail. A TTL cache's expiry boundary is a textbook silent off-by-one, and its clock-only-on-hit invariant is a deliberate design choice worth pinning.

## Test cases

- Freshness window (parameterized): inside TTL, last-fresh-tick, exactly-ttl (stale), past-expiry, ttl-0.
- Miss on an unset key; clock not read on a miss; clock read once on a hit.
- Overwrite re-stamps the write time; each key expires against its own write time.
- `clear()` drops everything; separate instances don't share a store; object values return by reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)