### PR TITLE
test: cover remote-host collection pagination (#611)

### DIFF
--- a/test/server/backends/remoteHost/collectionPage.spec.ts
+++ b/test/server/backends/remoteHost/collectionPage.spec.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { pageResult, deriveItems } from "../../../../server/backends/remoteHost/collectionPage.js";
+
+const rows = (n: number) => Array.from({ length: n }, (_, i) => ({ id: i }));
+
+describe("pageResult", () => {
+  it("slices the first page and echoes offset/limit", () => {
+    const result = pageResult({ slug: "c" }, rows(10), 0, 5);
+    expect(result.items).toEqual(rows(5));
+    expect(result.offset).toBe(0);
+    expect(result.limit).toBe(5);
+    expect(result.collection).toEqual({ slug: "c" });
+  });
+
+  it("slices a middle page by offset", () => {
+    const result = pageResult(null, rows(10), 5, 5);
+    expect(result.items).toEqual([{ id: 5 }, { id: 6 }, { id: 7 }, { id: 8 }, { id: 9 }]);
+  });
+
+  // `total` is the FULL record count, never the page's length. The mobile client renders
+  // "showing N of TOTAL" from it, so a regression to the sliced length silently breaks paging —
+  // the last short page would claim it is the whole collection.
+  it("reports the full total even when the page is short", () => {
+    const result = pageResult(null, rows(10), 8, 5);
+    expect(result.items).toEqual([{ id: 8 }, { id: 9 }]); // only 2 remain
+    expect(result.total).toBe(10); // ...but total stays 10
+  });
+
+  it("returns an empty page past the end while keeping total and the echoed offset", () => {
+    const result = pageResult(null, rows(10), 20, 5);
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(10);
+    expect(result.offset).toBe(20);
+    expect(result.limit).toBe(5);
+  });
+
+  it("returns nothing for a zero limit", () => {
+    const result = pageResult(null, rows(10), 0, 0);
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(10);
+  });
+
+  it("handles an empty collection", () => {
+    const result = pageResult(null, [], 0, 50);
+    expect(result.items).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe("deriveItems", () => {
+  // With no derivable fields the derive pass is a no-op, so each record passes through with its
+  // stored fields intact — same records, same order.
+  it("passes records through unchanged when the schema declares no fields", () => {
+    expect(deriveItems({ fields: {} }, [{ a: 1 }, { b: 2 }])).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  // The `schema.fields ?? {}` default: a schema with no `fields` key must not throw.
+  it("tolerates a schema with no fields key", () => {
+    expect(deriveItems({}, [{ a: 1 }])).toEqual([{ a: 1 }]);
+  });
+
+  it("returns an empty array for no items", () => {
+    expect(deriveItems({ fields: {} }, [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`pageResult` / `deriveItems` (`server/backends/remoteHost/collectionPage.ts`) paginate a collection for the remote-host command channel. Neither had tests. This PR adds coverage. Test-only, no source change.

## Items to Confirm / Review

- **`total` is the full count, not the page length** — the headline silent failure. The mobile client renders "showing N of TOTAL" from `total`, so a regression to the sliced length would make the last short page claim it is the whole collection. Test: offset 8 / limit 5 over 10 rows ⇒ 2 items but `total === 10`.
- **Slice window**: first page, middle page (by offset), past-the-end (empty page, `total`/`offset` preserved), zero limit, empty collection. `offset`/`limit` are echoed verbatim (the client pages off them).
- **`deriveItems`** is only lightly covered on purpose: the derive engine (`deriveAll`) is the package's, tested there. These tests pin just what this wrapper owns — the `schema.fields ?? {}` default (a schema with no `fields` key must not throw) and no-op passthrough / order preservation.
- **Mutation-verified**: `total: items.length` → page length, and collapsing the slice window, each turn 3 tests red.

## User Prompt

Continuation of the #611 campaign: cover untested pure decision rules, ranked by how silently they fail. A paging helper whose `total` can silently drop to the page length is a textbook silent-failure shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)