### PR TITLE
refactor: extract attachment path/naming rules and test them (#611)

### DIFF
--- a/server/backends/remoteHost/attachment-path.ts
+++ b/server/backends/remoteHost/attachment-path.ts
@@ -1,0 +1,31 @@
+// Pure path/naming rules for the workspace attachment store: the extension a MIME maps to, and
+// the UTC YYYY/MM partition an upload lands in. Split out of attachmentStore's file I/O so both
+// can be tested without touching disk — a mis-cased extension or an off-by-one month partition is
+// invisible once the bytes are already written.
+
+export const ATTACHMENTS_DIR = "data/attachments";
+
+// MIME → extension. Narrow on purpose (covers phone photos + PDFs + a few text types); anything
+// unmapped falls back to `.bin` so we never guess. Case-insensitive so "IMAGE/PNG" maps the same
+// as "image/png".
+const MIME_EXT: Readonly<Record<string, string>> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/heic": ".heic", // iOS default capture format
+  "image/heif": ".heif",
+  "image/tiff": ".tif",
+  "application/pdf": ".pdf",
+  "text/plain": ".txt",
+  "text/markdown": ".md",
+  "text/csv": ".csv",
+};
+
+export const extensionForMime = (mimeType: string): string => MIME_EXT[mimeType.toLowerCase()] ?? ".bin";
+
+// UTC YYYY/MM partition so a workspace with many uploads stays browsable. getUTCMonth is
+// 0-indexed, hence +1; zero-padded to two digits. UTC (not local) so the partition a file lands
+// in doesn't drift with the server's timezone.
+export const yearMonthUtc = (when: Date): string => `${when.getUTCFullYear()}/${String(when.getUTCMonth() + 1).padStart(2, "0")}`;

--- a/server/backends/remoteHost/attachmentStore.ts
+++ b/server/backends/remoteHost/attachmentStore.ts
@@ -9,30 +9,7 @@
 import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
-
-const ATTACHMENTS_DIR = "data/attachments";
-
-// MIME → extension. Narrow on purpose (covers phone photos + PDFs + a few text
-// types); anything unmapped falls back to `.bin` so we never guess.
-const MIME_EXT: Readonly<Record<string, string>> = {
-  "image/png": ".png",
-  "image/jpeg": ".jpg",
-  "image/jpg": ".jpg",
-  "image/webp": ".webp",
-  "image/gif": ".gif",
-  "image/heic": ".heic", // iOS default capture format
-  "image/heif": ".heif",
-  "image/tiff": ".tif",
-  "application/pdf": ".pdf",
-  "text/plain": ".txt",
-  "text/markdown": ".md",
-  "text/csv": ".csv",
-};
-
-const extensionForMime = (mimeType: string): string => MIME_EXT[mimeType.toLowerCase()] ?? ".bin";
-
-// UTC YYYY/MM partition so a workspace with many uploads stays browsable.
-const yearMonthUtc = (when: Date): string => `${when.getUTCFullYear()}/${String(when.getUTCMonth() + 1).padStart(2, "0")}`;
+import { ATTACHMENTS_DIR, extensionForMime, yearMonthUtc } from "./attachment-path.js";
 
 export interface SavedAttachment {
   relativePath: string;

--- a/test/server/backends/remoteHost/attachment-path.spec.ts
+++ b/test/server/backends/remoteHost/attachment-path.spec.ts
@@ -1,0 +1,63 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { ATTACHMENTS_DIR, extensionForMime, yearMonthUtc } from "../../../../server/backends/remoteHost/attachment-path.js";
+
+describe("extensionForMime", () => {
+  it.each([
+    ["image/png", ".png"],
+    ["image/jpeg", ".jpg"],
+    ["image/jpg", ".jpg"], // deliberately the same as image/jpeg
+    ["image/webp", ".webp"],
+    ["image/gif", ".gif"],
+    ["image/heic", ".heic"],
+    ["image/heif", ".heif"],
+    ["image/tiff", ".tif"], // .tif, not .tiff — pinned so it isn't "corrected"
+    ["application/pdf", ".pdf"],
+    ["text/plain", ".txt"],
+    ["text/markdown", ".md"],
+    ["text/csv", ".csv"],
+  ])("maps %s to %s", (mime, ext) => {
+    expect(extensionForMime(mime)).toBe(ext);
+  });
+
+  // Case-insensitive: a phone that sends an upper-cased MIME must map the same.
+  it.each([
+    ["IMAGE/PNG", ".png"],
+    ["Application/PDF", ".pdf"],
+    ["Image/Jpeg", ".jpg"],
+  ])("is case-insensitive for %s", (mime, ext) => {
+    expect(extensionForMime(mime)).toBe(ext);
+  });
+
+  // Anything unmapped falls back to .bin — never a guessed extension.
+  it.each(["application/octet-stream", "image/bmp", "video/mp4", "", "not-a-mime"])("falls back to .bin for %j", (mime) => {
+    expect(extensionForMime(mime)).toBe(".bin");
+  });
+});
+
+describe("yearMonthUtc", () => {
+  // getUTCMonth is 0-indexed, so the +1 and the zero-pad both have to be right — January must
+  // read "01", not "00" or "0".
+  it.each<[number, number, string]>([
+    [2026, 0, "2026/01"], // January — the +1 boundary
+    [2026, 8, "2026/09"], // September — single digit, zero-padded
+    [2026, 9, "2026/10"], // October — two digits, not over-padded
+    [2026, 11, "2026/12"], // December — the top of the range
+    [1999, 0, "1999/01"], // year passes through verbatim
+  ])("formats %d-%d as %s", (year, monthIndex, expected) => {
+    expect(yearMonthUtc(new Date(Date.UTC(year, monthIndex, 15, 12, 0, 0)))).toBe(expected);
+  });
+
+  // Reads UTC fields, not local ones: an instant that is still January 1st in UTC partitions as
+  // 2026/01 regardless of the runner's timezone.
+  it("uses UTC calendar fields", () => {
+    expect(yearMonthUtc(new Date(Date.UTC(2026, 0, 1, 0, 0, 0)))).toBe("2026/01");
+  });
+});
+
+describe("ATTACHMENTS_DIR", () => {
+  it("is the workspace-relative attachments root", () => {
+    expect(ATTACHMENTS_DIR).toBe("data/attachments");
+  });
+});


### PR DESCRIPTION
## Summary

`extensionForMime` (MIME → file extension) and `yearMonthUtc` (the UTC `YYYY/MM` upload partition) were module-private inside `attachmentStore.ts`, reachable only by writing a real file to disk. This PR moves them into a new pure module `attachment-path.ts` (behavior-preserving — the store imports them back) and adds direct unit tests.

## Items to Confirm / Review

- **Behavior-preserving move**: `attachmentStore.ts` loses the two local `const`s and the `MIME_EXT` map and imports them from `./attachment-path.js`. No logic changed. Full `remoteHost` test suite (157 tests) still green.
- **Both rules are textbook silent failures** — the reason they're worth isolating and pinning:
  - `extensionForMime`: a wrong extension is invisible once bytes are on disk. Tests pin the whole map, the **case-insensitivity** (`IMAGE/PNG` → `.png`), the `.bin` **fallback for anything unmapped** (never a guessed ext), and two deliberate choices: `image/jpg` maps identically to `image/jpeg`, and `image/tiff` → `.tif` (not `.tiff`).
  - `yearMonthUtc`: `getUTCMonth()` is 0-indexed, so the `+1` and the `padStart(2,"0")` both have to be right — January must read `01`, not `00`/`0`. Tests cover Jan/Sep/Oct/Dec boundaries and assert UTC calendar fields are used.
- **Mutation-verified**: dropping `.toLowerCase()`, changing the `.bin` fallback, dropping the month `+1`, and dropping the zero-pad each turn multiple tests red.

## User Prompt

Continuation of the #611 campaign. Per CLAUDE.md, pure data-transformation rules belong in their own file for testability; these two were buried behind file I/O. Extracted and covered, ranked in by how silently they fail (mis-cased extension, off-by-one month — both named in the coding guidelines as classic invisible-until-a-user-notices bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)