### PR TITLE
refactor: extract the draft-vs-autorun decision and test it (#611)

### DIFF
--- a/server/session/draft-injection.ts
+++ b/server/session/draft-injection.ts
@@ -5,6 +5,7 @@
 import { claudeAdapter } from "../agents/claude.js";
 import type { PtyEntry } from "./types.js";
 import { sanitizeDraftText } from "./pty-text.js";
+import { planDraftInjection } from "./draft-plan.js";
 
 // Claude must have its input box + bracketed-paste mode up before it will capture a
 // typed `draft`; too early and the bytes are echoed into the scrollback instead. We
@@ -30,10 +31,9 @@ const DRAFT_SUBMIT_MS = 150;
 // the pty output to: it types once the input-box readiness marker paints (after a settle),
 // or after DRAFT_FALLBACK_MS if the marker never appears (UI drift). No-op when neither.
 export function attachDraftInjection(entry: PtyEntry, initialPrompt: string | undefined, draft: string | undefined): (data: string) => void {
-  const pendingText = draft ?? initialPrompt;
-  const autoSubmit = draft === undefined && initialPrompt !== undefined;
-  const draftText = pendingText ? sanitizeDraftText(pendingText) : "";
-  if (!draftText) return () => {};
+  const plan = planDraftInjection(initialPrompt, draft, sanitizeDraftText);
+  if (!plan) return () => {};
+  const { text: draftText, autoSubmit } = plan;
   let done = false;
   let scan = "";
   const typeDraft = () => {

--- a/server/session/draft-plan.ts
+++ b/server/session/draft-plan.ts
@@ -1,0 +1,21 @@
+// The draft-vs-auto-run decision behind attachDraftInjection, pulled out so the precedence and
+// the never-auto-submit-a-draft rule can be decided without a PTY or timers.
+
+export interface DraftPlan {
+  text: string;
+  // An initialPrompt is typed AND submitted (Enter); a draft is only typed, so the user reviews
+  // and sends it themselves. Auto-submitting a draft would fire unreviewed text.
+  autoSubmit: boolean;
+}
+
+// A draft takes precedence over an initialPrompt when both are present (`??`, so an empty-string
+// draft still shadows the initialPrompt). Returns null — a no-op — when there is nothing to type,
+// or the text sanitizes to empty. `sanitize` is injected so the rule can be tested without the
+// real control-byte stripper.
+export function planDraftInjection(initialPrompt: string | undefined, draft: string | undefined, sanitize: (text: string) => string): DraftPlan | null {
+  const pendingText = draft ?? initialPrompt;
+  if (pendingText === undefined) return null;
+  const text = sanitize(pendingText);
+  if (!text) return null;
+  return { text, autoSubmit: draft === undefined && initialPrompt !== undefined };
+}

--- a/test/server/session/draft-plan.spec.ts
+++ b/test/server/session/draft-plan.spec.ts
@@ -1,0 +1,49 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { planDraftInjection } from "../../../server/session/draft-plan.js";
+
+const identity = (s: string) => s;
+
+describe("planDraftInjection", () => {
+  it("is a no-op when neither prompt nor draft is given", () => {
+    expect(planDraftInjection(undefined, undefined, identity)).toBeNull();
+  });
+
+  // An initialPrompt is typed AND submitted — it is meant to run on its own.
+  it("auto-submits an initialPrompt", () => {
+    expect(planDraftInjection("run me", undefined, identity)).toEqual({ text: "run me", autoSubmit: true });
+  });
+
+  // A draft is typed but NOT submitted, so the user reviews and sends it. This asymmetry is the
+  // whole point: an auto-submitted draft would fire unreviewed text.
+  it("never auto-submits a draft", () => {
+    expect(planDraftInjection(undefined, "edit me", identity)).toEqual({ text: "edit me", autoSubmit: false });
+  });
+
+  // A draft takes precedence over an initialPrompt when both are present — and it still does not
+  // auto-submit, even though an initialPrompt was also supplied.
+  it("prefers the draft over the initialPrompt and does not submit", () => {
+    expect(planDraftInjection("run me", "edit me", identity)).toEqual({ text: "edit me", autoSubmit: false });
+  });
+
+  // `??` keeps an empty-string draft, so it still shadows the initialPrompt and yields a no-op —
+  // the initialPrompt does not "show through" a blank draft.
+  it("treats an empty-string draft as a no-op that shadows the initialPrompt", () => {
+    expect(planDraftInjection("run me", "", identity)).toBeNull();
+  });
+
+  it("is a no-op for an empty-string initialPrompt", () => {
+    expect(planDraftInjection("", undefined, identity)).toBeNull();
+  });
+
+  // Sanitizing to empty (e.g. text that was all control bytes) collapses to a no-op.
+  it("is a no-op when the text sanitizes to empty", () => {
+    expect(planDraftInjection("\x1b\x03", undefined, () => "")).toBeNull();
+  });
+
+  // The sanitized text is what lands in the plan, not the raw input.
+  it("carries the sanitized text, not the raw input", () => {
+    expect(planDraftInjection("  keep  ", undefined, (s) => s.trim())).toEqual({ text: "keep", autoSubmit: true });
+  });
+});


### PR DESCRIPTION
## Summary

`attachDraftInjection` (`server/session/draft-injection.ts`) decided inline whether a prompt should be **typed-and-submitted** (an `initialPrompt`) or **typed-only** (an editable `draft`). That decision — a precedence and a safety asymmetry — was buried behind PTY writes and timers, untestable. This PR pulls it into a pure `planDraftInjection` (`draft-plan.ts`) with `sanitize` injected, and adds unit tests. Behavior-preserving.

## Items to Confirm / Review

- **Behavior-preserving**: `attachDraftInjection` now calls `planDraftInjection(initialPrompt, draft, sanitizeDraftText)` and no-ops on `null`; the `text`/`autoSubmit` it destructures are exactly what it computed inline before. Full `session` test suite (801 tests) still green. The `??` / truthiness edge cases are preserved (empty-string draft still shadows an initialPrompt; empty text ⇒ no-op).
- **The safety asymmetry, pinned**: a `draft` is **never** auto-submitted (the user reviews and sends it) — an auto-submitted draft would fire unreviewed text. An `initialPrompt` **is** auto-submitted. Tested for draft-only, initialPrompt-only, and both-present.
- **Precedence, pinned**: a `draft` wins over an `initialPrompt` when both are given — and still does not auto-submit.
- **Mutation-verified**: dropping the `draft === undefined` guard on `autoSubmit`, flipping `draft ?? initialPrompt` to `initialPrompt ?? draft`, and removing the empty-text guard each turn tests red.

## User Prompt

Continuation of the #611 campaign. Per CLAUDE.md, separate the decision from the I/O so the rule can be tested — this precedence/asymmetry was reachable only by booting a PTY. Extracted and covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)