### PR TITLE
fix: cockpit roster（サイドメニュー）にも auto ソートを効かせる (#720)

### DIFF
--- a/plans/fix-720-cockpit-roster-auto-sort.md
+++ b/plans/fix-720-cockpit-roster-auto-sort.md
@@ -1,0 +1,52 @@
+# fix #720 — cockpit roster が auto ソートを反映しない
+
+## 背景 / 症状
+
+グリッドをズームしたときに出る cockpit roster（サイドメニュー、`data-testid="cockpit"`）の行順が
+auto（注目度順）ソートを反映しない。auto にしても blocked / waiting のセルがロースター上部に
+浮いてこず、追加した順（生順）のまま並ぶ。グリッド／フィルムストリップ（`displayCells`）は auto
+が効いているので、両者で並び順が食い違う。
+
+## 根本原因
+
+`GridView.vue` でグリッドとロースターが別々の順序ソースを使っている:
+
+- グリッド `displayCells = visibleOrdered(state, statusForSort)` … `orderCells` 適用済み（auto 反映）
+- ロースター `listRows = state.value.cells.map(...)` … 生順のまま、`orderCells` を通していない
+
+`orderCells`（純関数・テスト済み）をロースター側に通し忘れた取りこぼし。意図的に生順にした形跡
+（コメント等）はなし。
+
+## 修正
+
+`GridView.vue`:
+
+1. `orderCells` を import に追加。
+2. 注目度順の全セルを 1 本の computed に切り出す:
+   ```ts
+   const orderedCells = computed(() => orderCells(state.value.cells, statusForSort.value, state.value.sortMode));
+   ```
+   これを **グリッドとロースターの単一の順序ソース**にして、二度と食い違わないようにする。
+   - `displayCells` … ズーム時は `orderedCells`、非ズーム時はページスライス（現 `visibleOrdered` と等価）。
+   - `listRows` … `orderedCells.value.map(...)`（メタ組み立ては現状のまま）。
+
+挙動:
+- auto: ロースターもグリッドと同じ注目度順（blocked→done→idle→working、末尾 launcher）で浮上。
+- manual: `orderCells` は生順を返すため現状維持。⋮ の上下入れ替え（manual 限定）にも影響なし。
+
+## テスト
+
+- `orderCells` / `visibleOrdered` の既存純関数テストはそのまま（順序ロジックは変えない）。
+- `GridView.spec.ts` に統合テストを追加:
+  - `useGridActivity` をモックして特定セッションを blocked にする。
+  - `grid_v2` を seed（auto ＋ 1 セルを expanded＝ズーム、status 差のあるセッション群）。
+  - `TerminalGrid` スタブに渡る `listRows` の uid 順が **注目度順（blocked 先頭）** で、生順ではない
+    ことを検証。
+  - 旧コード（`state.value.cells.map`）では生順になり fail することを確認してから修正。
+
+## 確認事項（レビュー観点）
+
+- ロースターが status 変化のたびに行を入れ替える点（`orderCells` は stable sort なので、順位が
+  変わったセルだけ動く。グリッドと同じ挙動）。これが望ましい（監視用途）前提。
+- `visibleOrdered` を GridView から外す場合、テストのみ利用になるが knip 上問題ないか（→ 本 PR では
+  `visibleOrdered` の内部ロジックを `orderedCells` + ページスライスへインライン化し、export は残す）。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -21,7 +21,8 @@ import {
   launchInCell,
   setSortMode,
   moveCell,
-  visibleOrdered,
+  orderCells,
+  pageSlice,
   activityStatus,
   countByStatus,
   cancelableLaunchUid,
@@ -95,10 +96,12 @@ const statusForSort = computed<Record<number, CellStatus>>(() => resolveCellStat
 // At-a-glance tally across ALL pages, for the toolbar summary.
 const statusCounts = computed(() => countByStatus(state.value.cells, statusForSort.value));
 const reorderable = computed(() => state.value.sortMode === "manual");
-// In "auto" mode the whole list is attention-sorted then paged (a waiting cell from
-// any page floats to the front); "manual" keeps the hand-arranged order. While a cell
-// is zoomed, render EVERY cell so the filmstrip lines up all tabs' terminals (live).
-const displayCells = computed(() => visibleOrdered(state.value, statusForSort.value));
+// In "auto" mode the whole list is attention-sorted; "manual" keeps the hand-arranged order.
+// The ONE ordering both the grid and the cockpit roster read, so the two can't drift (#720).
+const orderedCells = computed(() => orderCells(state.value.cells, statusForSort.value, state.value.sortMode));
+// The grid: while a cell is zoomed, render EVERY cell (the filmstrip lines up all tabs' terminals,
+// live); otherwise just the active page's slice. A waiting cell from any page floats to the front.
+const displayCells = computed(() => (zoomedUid(state.value) !== null ? orderedCells.value : pageSlice(orderedCells.value, state.value.page)));
 const expandedUid = computed(() => zoomedUid(state.value));
 
 // The zoomed grid's cockpit roster: a text row per cell — status + dir + AI summary +
@@ -259,7 +262,7 @@ onBeforeUnmount(stopPoll);
 // A cell with no session/prompt yet still gets a human label from what it IS running.
 const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "starting…" : "empty");
 const listRows = computed(() =>
-  state.value.cells.map((c) => {
+  orderedCells.value.map((c) => {
     const meta = c.session ? sessionMeta.get(c.session) : undefined;
     return {
       uid: c.uid,

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -6,10 +6,22 @@ vi.mock("../../../src/composables/usePubSub", () => ({
   usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
 }));
 
+// Session ids for the roster-ordering test (must be valid UUIDs or parseGridState drops them).
+const IDS = vi.hoisted(() => ({
+  blocked: "11111111-1111-1111-1111-111111111111",
+  idleA: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  idleB: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+}));
+// Feed one blocked session so the auto sort has something to float to the front.
+vi.mock("../../../src/composables/useGridActivity", () => ({
+  useGridActivity: () => ({ activity: new Map([[IDS.blocked, { working: false, waiting: true, event: "Notification" }]]) }),
+}));
+
 // Config GET hydrates pushEnabled=true; capture POSTs so we can assert the toggle saves.
 const posts: Array<{ url: string; body: unknown }> = [];
 beforeEach(() => {
   posts.length = 0;
+  localStorage.clear();
   globalThis.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
     const u = String(url);
     if (u.includes("/api/config")) {
@@ -51,6 +63,43 @@ const mountGrid = async () => {
   await flushPromises(); // onMounted loadConfig
   return w;
 };
+
+// A TerminalGrid stub that exposes the ordering props the roster/grid receive.
+const OrderStub = {
+  name: "TerminalGrid",
+  props: ["cells", "listRows", "expandedUid", "reorderable"],
+  template: '<div class="order-stub" />',
+};
+
+describe("GridView roster ordering (#720)", () => {
+  it("orders the cockpit roster (listRows) attention-first in auto mode, matching the grid", async () => {
+    // Auto sort, one cell zoomed (roster visible); the middle cell (uid→1) is the blocked one.
+    localStorage.setItem(
+      "grid_v2",
+      JSON.stringify({
+        cells: [
+          { uid: 10, session: IDS.idleA, cwd: "/w" },
+          { uid: 11, session: IDS.blocked, cwd: "/w" },
+          { uid: 12, session: IDS.idleB, cwd: "/w" },
+        ],
+        expanded: 10,
+        page: 0,
+        sortMode: "auto",
+      }),
+    );
+    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: OrderStub, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
+    });
+    await flushPromises();
+    const grid = w.findComponent(OrderStub);
+    // The blocked cell (renumbered uid 1) floats to the top; the two idle cells keep manual order.
+    const rosterOrder = grid.props("listRows").map((r: { uid: number }) => r.uid);
+    expect(rosterOrder).toEqual([1, 0, 2]);
+    // The grid reads the SAME ordering — roster and grid can't drift.
+    expect(grid.props("cells").map((c: { uid: number }) => c.uid)).toEqual([1, 0, 2]);
+    w.unmount();
+  });
+});
 
 describe("GridView settings wiring", () => {
   it("passes pushEnabled to SettingsModal and saves it on update-push-enabled (regression #347)", async () => {


### PR DESCRIPTION
## Summary

cockpit roster（ズーム時に横に出るサイドメニュー）の行順が **auto（注目度順）ソートを反映していなかった**バグの修正。グリッド／フィルムストリップは auto が効いていたのに、ロースターだけ生順（追加順）のままで、両者の並びが食い違っていた。

グリッドとロースターが **単一の順序ソース `orderedCells`** を読むようにして解消。auto では両方とも注目度順（blocked→done→idle→working、末尾 launcher）、manual では従来どおり手動並び。⋮ の上下入れ替え（manual 限定）は影響なし。

## Items to Confirm / Review

- **ロースターが status 変化で行を入れ替える挙動**：`orderCells` は stable sort なので、順位が変わったセルだけ動く（グリッドと同じ挙動）。監視用途として望ましい前提で入れています。読書中に行が動くのが気になる場合は要相談。
- **`visibleOrdered`（gridTabs）が本 PR で src から未使用に**：`orderedCells` + ページスライスへインライン化したため、現状は `gridTabs.spec.ts` のテストからのみ参照。テスト付きの純関数として残置しています（knip は問題視せず）。将来的に整理してよいかはお任せ。
- テストの seed／status 注入方法（`useGridActivity` をモックして 1 セッションを blocked に、`grid_v2` を localStorage に seed）。

## User Prompt

> あれ、結局、サイドメニューの三点ボタンで上下入れ替え、動いてないな。

最初は「⋮（三点）ボタンの上下入れ替えが効かない」という報告でしたが、調査の結果それは仕様（⋮ は manual ソート時のみ表示）で、切り分ける中でユーザーが次を指摘：

> そうなると auto がきいてないのかもね。サイドメニューのときにきかない？

→ 確認したところ、**auto ソートが cockpit roster（サイドメニュー）に反映されていない**のが真因。「auto で roster も注目度順にする」方針で修正を依頼された。

## 原因

`GridView.vue` でグリッドとロースターが別々の順序ソースを使っていた：

- グリッド `displayCells = visibleOrdered(...)` … `orderCells` 適用済み（auto 反映）
- ロースター `listRows = state.value.cells.map(...)` … 生順のまま（`orderCells` 未適用）

`orderCells`（純関数・テスト済み）をロースター側に通し忘れた取りこぼし。意図的な形跡（コメント等）なし。

## 修正

`GridView.vue`：

- `orderedCells = computed(() => orderCells(cells, statusForSort, sortMode))` を新設し、**グリッドとロースターの単一の順序ソース**に。
- `displayCells` … ズーム時は `orderedCells`、非ズーム時はページスライス（旧 `visibleOrdered` と等価）。
- `listRows` … `orderedCells.value.map(...)`（メタ組み立ては従来どおり）。

## テスト

- `test/src/components/GridView.spec.ts` に統合テストを追加：auto ＋ズーム状態で status 差のあるセッション群を seed し、`TerminalGrid` へ渡る `listRows`／`cells` の uid 順が **注目度順（blocked 先頭 `[1,0,2]`）** になることを検証。旧コード（生順 `[0,1,2]`）では fail することを確認済み。
- 既存の `orderCells` / `visibleOrdered` の純関数テストは変更なし。
- `yarn format` / `lint`（0 errors）/ `typecheck` / `typecheck:test` / `build` / `knip` / 全テスト（3462 passed）green。

plan: `plans/fix-720-cockpit-roster-auto-sort.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)