### PR TITLE
fix: cockpit roster（サイドメニュー）が行数過多で縦スクロールせず崩れる (#722)

### DIFF
--- a/plans/fix-722-cockpit-roster-scroll.md
+++ b/plans/fix-722-cockpit-roster-scroll.md
@@ -1,0 +1,32 @@
+# fix #722 — cockpit roster が行数過多で縦スクロールせず崩れる
+
+## 症状
+
+ズーム時に出る cockpit roster（サイドメニュー、`data-testid="cockpit"`）に行を入れすぎると、
+縦スクロールせず枠内へ詰め込まれ、各行が潰れてレイアウトが崩れる。期待は縦スクロール。
+
+## 根本原因
+
+`TerminalGrid.vue`:
+
+- roster `<aside>` は `flex flex-col ... overflow-y-auto`、高さは `.stage`（`height:100%`、list mode で
+  `flex-direction:row`）に拘束されている（＝ aside 自体の高さは bounded）。
+- 各行 `<div data-testid="cockpit-row">` は aside（flex-col）の flex 子要素だが `flex-shrink` が既定の `1`。
+
+行の合計高さが aside を超えると、行が縮んで枠に収まってしまい、オーバーフローが起きない
+→ `overflow-y-auto` のスクロールバーが出ない。行内は `overflow-hidden` なので潰れた中身がクリップ
+されて崩れて見える。典型的な flexbox の shrink バグ。
+
+（左の `Sidebar.vue` はセッション一覧の `<ul>` が block（flex ではない）＋ `flex-1 overflow-y-auto` で
+正常。今回の対象は cockpit roster のみ。）
+
+## 修正
+
+roster 行に `shrink-0`（`flex-shrink: 0`）を付与するだけ。行が自然な高さを保つことで aside が
+オーバーフローし、`overflow-y-auto` により縦スクロールする。行の折り畳み（line-clamp）や中身は不変。
+
+## テスト
+
+`TerminalGrid.spec.ts` の cockpit テストに、roster 行が `shrink-0` を持つことの回帰アサーションを追加。
+jsdom は実レイアウト（scrollHeight 等）を計算しないため、崩れ自体は再現できない。縮み防止の要である
+`shrink-0` クラスの付与を pin することで、将来 class から落ちる回帰を検出する。

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -200,7 +200,7 @@ watch(
         role="button"
         :tabindex="0"
         data-testid="cockpit-row"
-        class="flex cursor-pointer flex-col gap-1 overflow-hidden rounded-lg border border-l-[3px] bg-panel px-2.5 py-2 text-left text-fg hover:brightness-[1.15] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4a9eff]"
+        class="flex shrink-0 cursor-pointer flex-col gap-1 overflow-hidden rounded-lg border border-l-[3px] bg-panel px-2.5 py-2 text-left text-fg hover:brightness-[1.15] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#4a9eff]"
         :class="row.uid === expandedUid ? 'border-[#4a9eff] border-l-[#4a9eff]' : 'border-border border-l-transparent'"
         @click="row.uid !== expandedUid && emit('toggle-expand', row.uid)"
         @keydown.enter.self.prevent="row.uid !== expandedUid && emit('toggle-expand', row.uid)"

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -235,6 +235,20 @@ describe("grid cockpit (list view)", () => {
     expect(w.find(".stage").classes()).not.toContain("listmode"); // filmstrip mode
   });
 
+  it("keeps roster rows full-height (shrink-0) so a long list scrolls instead of squishing (#722)", async () => {
+    const many = Array.from({ length: 6 }, (_, i) => cell(i, `s${i}`));
+    const w = mountCockpit(
+      many,
+      0,
+      many.map((_, i) => rosterRow(i)),
+    );
+    await nextTick();
+    // The roster is a bounded flex-col scroll container...
+    expect(w.get('[data-testid="cockpit"]').classes()).toContain("overflow-y-auto");
+    // ...and each row refuses to shrink, so the list overflows (scrolls) rather than cramming.
+    for (const row of w.findAll('[data-testid="cockpit-row"]')) expect(row.classes()).toContain("shrink-0");
+  });
+
   it("emits list-mode as the roster is toggled off then on, so the parent can pause its poll", async () => {
     const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0)]);
     await nextTick();


### PR DESCRIPTION
## Summary

cockpit roster（ズーム時に横に出るサイドメニュー）に**ターミナル（行）を入れすぎると、縦スクロールせず枠内へ詰め込まれ、各行が潰れてレイアウトが崩れる**バグの修正。roster 行に `shrink-0`（`flex-shrink: 0`）を付けるだけ。

## Items to Confirm / Review

- **視覚確認**：jsdom は実レイアウト（scrollHeight 等）を計算しないため、崩れそのものは単体テストで再現できません。実機（ズーム→list mode→行を多数）で縦スクロールすること・行が潰れないことの目視確認をお願いします。
- クラス1個の追加のみ。他モード（filmstrip / 非ズーム）や manual の ⋮ には影響なし。

## User Prompt

> 今見つけたバグだけど、サイドメニューにターミナル入れすぎるとスクロールしないで枠に入れてしまってレイアウトが壊れる。縦スクロールしてほしい。

## 原因

`TerminalGrid.vue` の roster `<aside>` は `flex flex-col overflow-y-auto` で高さは `.stage`（`height:100%`、list mode で `flex-direction:row`）に拘束済み。しかし各行 `<div data-testid="cockpit-row">` は aside（flex-col）の flex 子要素なのに `flex-shrink` が既定の `1`。

→ 行の合計高さが aside を超えると行が**縮んで**枠に収まり、オーバーフローが起きない＝ `overflow-y-auto` のスクロールバーが出ない。行内は `overflow-hidden` なので潰れた中身がクリップされ崩れて見える。典型的な flexbox の shrink バグ。

（左の `Sidebar.vue` はセッション一覧の `<ul>` が block ＋ `flex-1 overflow-y-auto` で正常。今回の対象は cockpit roster のみ。）

## 修正

roster 行に `shrink-0` を付与。行が自然な高さを保つことで aside がオーバーフローし、`overflow-y-auto` により縦スクロールする。line-clamp などの中身は不変。

## テスト

- `TerminalGrid.spec.ts` の cockpit テストに回帰アサーションを追加：roster が `overflow-y-auto` を持ち、各行が `shrink-0` を持つこと（`shrink-0` を外すと fail することを確認済み）。
- `yarn format` / `lint`（0 errors）/ `typecheck` / `typecheck:test` / `build` / `knip` / 全テスト（3462 passed）green。

plan: `plans/fix-722-cockpit-roster-scroll.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)