### PR TITLE
fix: grid resume ピッカーを grid 起動セッションのみに絞る（#724）

### DIFF
--- a/plans/fix-724-grid-resume-picker-dev-terminal-only.md
+++ b/plans/fix-724-grid-resume-picker-dev-terminal-only.md
@@ -1,0 +1,49 @@
+# fix #724 — grid resume ピッカーを grid 起動セッションのみに絞る
+
+## 症状
+
+grid 空セルの resume ピッカー（作業ディレクトリを選ぶと出る一覧）に、その dir の Claude
+セッション transcript が全部並ぶ。grid 起動分だけでなく、素の `claude` や mulmoclaude など
+grid 外で作られたセッションも混ざる。grid で起動した terminal だけにしたい。
+
+## 根本原因
+
+resume ピッカーは `/api/sessions?cwd=<dir>` を呼ぶ（`src/components/TerminalCell.vue:394`）。
+`selectSessionRows`（`server/session/session-list.ts`）は dev-terminal（grid 起動）除外を
+**unscoped（チャット sidebar, `includePending=true`）にだけ**適用し、cwd スコープ付き
+（`includePending=false`）は「全部残す」。よって同 dir の全 Claude セッションが出る。
+
+`includePending` は「unscoped か cwd スコープか」の判別フラグ（型定義のコメントどおり）で、
+cwd スコープ付きの唯一の消費者は grid resume ピッカーのみ（`TerminalCell.vue:394`）。
+
+## 修正
+
+1. `server/session/session-list.ts` — dev-terminal フィルタを左右対称に:
+   - unscoped: `!isDevTerminal`（grid を隠す）… 現状維持
+   - cwd スコープ: `isDevTerminal`（**grid のみ残す**）… 新
+   ```ts
+   .filter((row) => (filter.includePending ? !filter.isDevTerminal(row.id) : filter.isDevTerminal(row.id)))
+   ```
+   関数 doc と `SessionRowFilter.includePending` の doc も更新。
+
+2. `server/routes/session-routes.ts` — `devTerminalSessionsHydrated` の await を **両経路**に
+   （現状は `if (includePending)` のみ）。cwd スコープも set に依存するため、boot と競合した
+   resume ピッカー要求が空の set を見て grid セッションを取りこぼさないように。
+
+## 挙動
+
+- grid 起動セッション: resume ピッカーに出続ける（resume 可能）。
+- grid 外セッション（素の `claude` / 単一ビュー / mulmoclaude 等）: resume ピッカーから消える。
+- unscoped チャット sidebar: 不変（grid を隠す）。
+
+## テスト
+
+- `test/server/session/session-list.spec.ts`:
+  - 既存「keeps grid sessions in a cwd-scoped listing」を「cwd スコープは **grid のみ** 残し外部を落とす（#724）」に更新（期待 `["grid"]`）。
+  - unscoped が grid を隠す既存テストは不変であることを確認。
+
+## 確認事項（レビュー観点）
+
+- 外部（非 grid）セッションを grid の resume ピッカーから resume したいケースがあれば要相談。
+  「grid 起動分だけで良い」が要望なので想定どおり。
+- 単一ビューのチャット sidebar は不変。

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -123,9 +123,11 @@ async function sessionList(req: Request, res: Response) {
     const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
     const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
     const includePending = !cwdParam;
-    // Wait for the persisted grid-session set before filtering (below), so a chat
-    // request racing server boot can't leak previously-hidden grid transcripts.
-    if (includePending) await devTerminalSessionsHydrated;
+    // Wait for the persisted grid-session set before filtering (below). Both queries depend on
+    // it now: the chat sidebar hides grid sessions, and the grid's cwd-scoped resume picker shows
+    // ONLY them (#724) — either way a request racing server boot must see the restored set, not an
+    // empty one (which would leak grid transcripts into chat, or empty the resume picker).
+    await devTerminalSessionsHydrated;
     const dir = projectSessionsDir(cwd);
     let files: string[] = [];
     try {

--- a/server/session/session-list.ts
+++ b/server/session/session-list.ts
@@ -13,20 +13,22 @@ export interface SessionRowFilter {
   isTranslationWorker: (id: string) => boolean;
   /** Multi-terminal GRID sessions. */
   isDevTerminal: (id: string) => boolean;
-  /** True for the unscoped (chat sidebar) query, false for a cwd-scoped one. */
+  /** True for the unscoped (chat sidebar) query, false for a cwd-scoped one. Also picks the
+   *  dev-terminal direction: unscoped hides grid sessions, cwd-scoped shows ONLY them (#724). */
   includePending: boolean;
   limit: number;
 }
 
 /** The rows a listing should render: newest first, capped, with the hidden kinds dropped.
- *  The dev-terminal exclusion applies ONLY to the unscoped chat query — the grid's own
- *  resume picker passes ?cwd= and must keep listing its sessions, or they stop being
- *  resumable. Pure so that rule can be pinned; it is one boolean away from silently
- *  hiding the grid's own sessions from itself. */
+ *  Two mirror-image rules on the same dev-terminal set: the unscoped CHAT sidebar hides grid
+ *  sessions (they're the grid's, not chats), while the grid's OWN cwd-scoped resume picker shows
+ *  ONLY grid sessions — a plain `claude`/mulmoclaude transcript in the dir isn't a grid terminal
+ *  and shouldn't be offered to resume there (#724). The grid's own sessions must stay listed in
+ *  the cwd-scoped view, or they stop being resumable. Pure so both rules can be pinned. */
 export function selectSessionRows(rows: readonly SessionRow[], filter: SessionRowFilter): SessionRow[] {
   return rows
     .filter((row) => !filter.isTranslationWorker(row.id))
-    .filter((row) => !filter.includePending || !filter.isDevTerminal(row.id))
+    .filter((row) => (filter.includePending ? !filter.isDevTerminal(row.id) : filter.isDevTerminal(row.id)))
     .sort((a, b) => b.mtime - a.mtime)
     .slice(0, filter.limit);
 }

--- a/test/server/session/session-list.spec.ts
+++ b/test/server/session/session-list.spec.ts
@@ -36,16 +36,17 @@ describe("selectSessionRows", () => {
     expect(ids(selectSessionRows(rows, filter({ isTranslationWorker: (id) => id === "worker" })))).toEqual(["keep"]);
   });
 
-  // The rule with history: hiding grid sessions from the CHAT sidebar must not hide them
-  // from the grid's OWN cwd-scoped resume picker, or they stop being resumable there.
+  // Two mirror-image rules on the same dev-terminal set: the chat sidebar hides grid sessions,
+  // and the grid's OWN cwd-scoped resume picker shows ONLY them (#724). The grid's sessions must
+  // still appear in the cwd-scoped view, or they stop being resumable there.
   it("hides grid sessions from the unscoped chat listing", () => {
     const rows = [disk("chat", 2), disk("grid", 3)];
     expect(ids(selectSessionRows(rows, filter({ isDevTerminal: (id) => id === "grid", includePending: true })))).toEqual(["chat"]);
   });
 
-  it("keeps grid sessions in a cwd-scoped listing (the grid's own resume picker)", () => {
+  it("shows ONLY grid sessions in the cwd-scoped resume picker, dropping externally-started ones (#724)", () => {
     const rows = [disk("chat", 2), disk("grid", 3)];
-    expect(ids(selectSessionRows(rows, filter({ isDevTerminal: (id) => id === "grid", includePending: false })))).toEqual(["grid", "chat"]);
+    expect(ids(selectSessionRows(rows, filter({ isDevTerminal: (id) => id === "grid", includePending: false })))).toEqual(["grid"]);
   });
 
   it("caps the listing, keeping the newest", () => {


### PR DESCRIPTION
## Summary

grid 空セルの resume ピッカー（作業ディレクトリを選ぶと出る一覧）が、その dir の Claude セッションを**全部**並べていた（grid 起動分だけでなく、素の `claude` / 単一ビュー / mulmoclaude など grid 外のセッションも混ざる）。これを **grid 起動（dev-terminal）セッションのみ**に絞る。

## Items to Confirm / Review

- **外部セッションが grid の resume ピッカーから消える**：素の `claude`・単一ビュー・mulmoclaude 等、grid 外で始めたセッションは grid の resume 候補に出なくなる。「grid 起動分だけで良い」が要望なので想定どおりだが、外部セッションを grid から resume したい運用があれば要相談。
- 単一ビューのチャット sidebar（unscoped）は**不変**（従来どおり grid セッションを隠す）。
- `devTerminalSessionsHydrated` の await を両経路に広げた点（cwd スコープも set 依存になったため。boot 競合で resume ピッカーが空にならないように）。

## User Prompt

> issue でサーバ側で terminal みえるけど、grid view で起動している terminal だけでよい。mulmoclaude 的なのは混ぜないで。

（#724 として起票 → 実装〜マージまで依頼）

## 原因

resume ピッカーは `/api/sessions?cwd=<dir>` を呼ぶ（`src/components/TerminalCell.vue:394`）。`selectSessionRows`（`server/session/session-list.ts`）は dev-terminal（grid 起動）除外を **unscoped（`includePending=true`）にだけ**適用し、cwd スコープ付き（`includePending=false`）は全部残していた。`includePending` は「unscoped か cwd スコープか」の判別フラグで、cwd スコープの唯一の消費者は grid resume ピッカーのみ。

## 修正

- `session-list.ts`：dev-terminal フィルタを左右対称に。unscoped=`!isDevTerminal`（現状維持）／ cwd スコープ=`isDevTerminal`（**grid のみ残す**）。
- `session-routes.ts`：`devTerminalSessionsHydrated` の await を両経路へ。

## テスト

- `test/server/session/session-list.spec.ts`：cwd スコープのテストを「**grid のみ**残し外部を落とす（#724）」に更新（期待 `["grid"]`）。旧ロジックで fail することを確認済み。unscoped が grid を隠す既存テストは不変。
- `yarn format` / `lint`（0 errors）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `knip` / 全テスト（3463 passed）green。

plan: `plans/fix-724-grid-resume-picker-dev-terminal-only.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)