### PR TITLE
feat: セッション活動 doc に event と workPhase を載せる（#727）

### DIFF
--- a/plans/feat-727-activity-doc-event-workphase.md
+++ b/plans/feat-727-activity-doc-event-workphase.md
@@ -1,0 +1,77 @@
+# feat #727 — セッション活動 doc に event と workPhase を載せる
+
+## やりたいこと
+
+Firestore のセッション活動 doc（#439）に `event` と `workPhase` を載せ、mulmoserver（スマホ側,
+receptron/mulmoserver#99）が cockpit/grid と同じ状態語彙（`blocked` / `done` / `editing` /
+`planning` / `working` / `idle`）を出せるようにする。
+
+## 調査で分かった前提（issue の想定との差分）
+
+- **`event`**: publish 時点で既に手元にある。`Activity` / `sessionRow` が持ち、`publishActivity`
+  （`server/session/lifecycle.ts`）が `row.event` として参照できる。→ そのまま渡すだけ。
+- **`workPhase`**: **publish 時点ではメモリに無い**。`classifyWorkPhase(現ターンのツール名)` は
+  transcript を読む `readSessionSummary`（`session-reads.ts:155`）でのみ算出され、roster の
+  `/api/session/:id` だけが使う。publish は同期 hook 経路上の fire-and-forget なので、そこで
+  transcript を読むのは既存設計に反する（読んではいけない）。
+  → **hook 経路で live に追跡する仕組みを新設**する。
+
+## 設計
+
+### 1. live work-phase トラッカー（新規・純粋）
+
+`server/session/work-phase-tracker.ts`（純関数 + 小さな状態）:
+
+transcript 版 `currentTurnToolNamesFromParsed` のターン境界ルールを hook イベントに写す:
+
+- `UserPromptSubmit` → 新しいターン開始（ツール名リセット）
+- `PreToolUse` の `tool_name` → 現ターンのツール名として蓄積
+- 判定は既存の `classifyWorkPhase`（`workPhase.ts`）をそのまま再利用（roster と同じ意味論）
+
+純粋な遷移関数として書き、セッションごとの Map は薄いラッパに閉じる:
+
+```ts
+export function nextTurnTools(prev: string[], event: string, toolName?: string): string[]
+export function createWorkPhaseTracker() // note(id, event, toolName) / phaseOf(id) / forget(id)
+```
+
+### 2. doc に 2 フィールド追加（後方互換, optional）
+
+`server/backends/remoteHost/sessionActivity.ts`:
+
+```ts
+export interface SessionActivity {
+  working: boolean;
+  waiting: boolean;
+  event?: string | null;        // waiting を立てた hook（Notification / Stop など）
+  workPhase?: WorkPhase | null; // planning | implementing
+}
+```
+
+`stateKey` にも 2 つを含める（working/waiting が同じでも event / workPhase が変われば書く。
+逆に無関係な再 publish は従来どおり抑制）。
+
+### 3. 配線
+
+- `lifecycle.ts` の `publishActivity`: `sessionActivityPublisher.publish(id, { working, waiting,
+  event: row.event, workPhase })` へ。`workPhase` は deps 経由の getter（`workPhaseOf(id)`）で
+  取得し、lifecycle は tracker を知らない。
+- `hook-routes.ts`: activity hook で `deps.noteWorkPhase(sessionId, event, tool_name)` を呼ぶ。
+- `index.ts`: tracker を生成して両者に配線。`reap` 時に `forget`。
+
+## テスト
+
+- `work-phase-tracker`: ターンリセット / mutation → implementing / 読みのみ → planning /
+  ツール無し → null / 別セッション独立 / forget。
+- `sessionActivity` publisher: event だけ変わった場合に書く / workPhase だけ変わった場合に書く /
+  3 つとも同じなら書かない（dedup 維持）/ payload に両フィールドが載る。
+- `lifecycle`: publish に event と workPhase が渡る。
+
+## 確認事項（レビュー観点）
+
+- workPhase の live 算出は hook 由来（PreToolUse）で、roster の transcript 由来と**独立**。
+  同じ `classifyWorkPhase` を共有するので語彙は一致するが、境界条件（サーバ再起動直後、hook を
+  取りこぼした場合）では roster と一時的にズレうる。null に degrade する設計。
+- `stateKey` に 2 フィールドを足すことで、従来より write 回数が増えるケースがある
+  （working/waiting 据え置きで workPhase だけ planning→implementing に動く等）。意図どおり
+  （スマホがその遷移を表示するため）だが Firestore の write 量に影響する。

--- a/server/backends/remoteHost/sessionActivity.ts
+++ b/server/backends/remoteHost/sessionActivity.ts
@@ -10,10 +10,17 @@
 // Deliberately fire-and-forget: the caller sits on the synchronous hook path that
 // serves Claude Code's own requests, and a Firestore hiccup must never disturb it.
 import { deleteDoc, doc, serverTimestamp, setDoc, type DocumentReference, type Firestore } from "firebase/firestore";
+import type { WorkPhase } from "../../session/workPhase.js";
 
 export interface SessionActivity {
   working: boolean;
   waiting: boolean;
+  // The two fields the phone needs to speak the same status vocabulary as the cockpit roster
+  // (#727): `event` splits a `waiting` session into blocked (Notification) vs done (Stop), and
+  // `workPhase` splits a `working` one into planning vs editing. Optional so a host that hasn't
+  // observed them yet simply omits them and the reader degrades to working/waiting.
+  event?: string | null;
+  workPhase?: WorkPhase | null;
 }
 
 // `rev` is monotonic per session so a watcher can distinguish "changed again" from a
@@ -52,7 +59,10 @@ export interface SessionActivityPublisherDeps {
 export function createSessionActivityPublisher(deps: SessionActivityPublisherDeps) {
   const revisions = new Map<string, number>();
   const published = new Map<string, string>();
-  const stateKey = ({ working, waiting }: SessionActivity): string => `${working}:${waiting}`;
+  // Every field the phone renders belongs in the key: a turn that moves planning → implementing,
+  // or a waiting one that changes from blocked to done, keeps the same working/waiting pair and
+  // would otherwise be deduped away — leaving the phone showing the superseded status (#727).
+  const stateKey = ({ working, waiting, event, workPhase }: SessionActivity): string => `${working}:${waiting}:${event ?? ""}:${workPhase ?? ""}`;
 
   // Not every caller of the host's publishActivity is a state transition — generating
   // an AI title or clearing the header republishes an unchanged working/waiting pair.

--- a/server/index.ts
+++ b/server/index.ts
@@ -51,6 +51,7 @@ import { initAccountingBackend } from "./backends/accounting.js";
 import { initFeedsBackend } from "./backends/feeds.js";
 import { HOST_ID as REMOTE_HOST_ID, initRemoteHostBackend } from "./backends/remoteHost/index.js";
 import { createSessionActivityPublisher, firestoreSessionActivityStore } from "./backends/remoteHost/sessionActivity.js";
+import { createWorkPhaseTracker } from "./session/work-phase-tracker.js";
 import { currentFirestore, currentUid } from "./backends/remoteHost/session.js";
 import { feedRefreshTaskDef, type AgentWorkerRunner } from "@mulmoclaude/core/feeds/server";
 import { initWorkspaceSetup } from "./backends/workspaceSetup.js";
@@ -158,10 +159,17 @@ const sessionActivityPublisher = createSessionActivityPublisher({
 
 // Session teardown + activity publishing (session/lifecycle.ts). `forgetTitle` is bound
 // lazily because the title manager below needs publishActivity — the cycle is real.
+// The live turn's planning-vs-editing phase, fed by the hook route and read by the activity
+// publisher — the phone's status vocabulary needs it, and the publish path can't read the
+// transcript the roster parses for the same answer (#727).
+const workPhaseTracker = createWorkPhaseTracker();
+
 const lifecycle = createSessionLifecycle({
   publish: (channel, data) => pubsub?.publish(channel, data),
   forgetTitle: (id) => forgetTitle(id),
   sessionActivityPublisher,
+  workPhaseOf: (id) => workPhaseTracker.phaseOf(id),
+  forgetWorkPhase: (id) => workPhaseTracker.forget(id),
 });
 const { cancelReap, reap, armReapForDetached, publishActivity, setWorking, setWaiting } = lifecycle;
 
@@ -223,6 +231,7 @@ mountAppRoutes(app, {
   freshenRosterTitle,
   forgetTitle,
   noteTitleTurn,
+  noteWorkPhase: (id, event, toolName) => workPhaseTracker.note(id, event, toolName),
   maybeGenerateTitle,
   reap,
   setWorking,

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -65,6 +65,8 @@ export interface AppRouteDeps {
   freshenRosterTitle: ReturnType<typeof createTitleManager>["freshenRosterTitle"];
   forgetTitle: (id: string) => void;
   noteTitleTurn: (id: string, prompt: string) => void;
+  /** Feed the live turn's tool names for the phone's planning-vs-editing status (#727). */
+  noteWorkPhase: (id: string, event: string, toolName?: string) => void;
   maybeGenerateTitle: (id: string, cwd: string | undefined) => Promise<void>;
   reap: (id: string) => void;
   setWorking: (id: string, working: boolean, event?: string) => void;
@@ -185,6 +187,7 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
     publishActivity: (id) => deps.publishActivity(id),
     forgetTitle: deps.forgetTitle,
     noteTitleTurn: deps.noteTitleTurn,
+    noteWorkPhase: deps.noteWorkPhase,
     maybeGenerateTitle: deps.maybeGenerateTitle,
     recordToolCallStart: deps.toolStores.recordToolCallStart,
     recordToolCallEnd: deps.toolStores.recordToolCallEnd,

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -140,7 +140,10 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
     await applyHeaderHooks(deps, sessionId, event, body, cwd);
     // Before the activity publish below, so the row it mirrors to the phone already carries this
     // hook's phase (a turn's first Edit must read as "editing" in the same push, not the next one).
-    deps.noteWorkPhase(sessionId, event, typeof body.tool_name === "string" ? body.tool_name : undefined);
+    // Live sessions only: a tracked turn is reclaimed by reap, which itself does nothing without a
+    // pty — so tracking an id with no pty (any well-formed uuid may be posted here) would never be
+    // reclaimed. A session whose pty is gone simply reports no phase, as it does before its first tool.
+    if (entry) deps.noteWorkPhase(sessionId, event, typeof body.tool_name === "string" ? body.tool_name : undefined);
     handleActivityHook(deps, sessionId, event, active, typeof body.message === "string" ? body.message : "");
     await handleToolHook(deps, sessionId, event, body, cwd);
     // A hidden translation worker that ends its turn while still pending never called

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -22,6 +22,8 @@ export interface HookDeps {
   publishActivity: (id: string) => void;
   forgetTitle: (id: string) => void;
   noteTitleTurn: (id: string, prompt: string) => void;
+  /** Feed the live turn's tool names, so the published status can say planning vs editing (#727). */
+  noteWorkPhase: (id: string, event: string, toolName?: string) => void;
   maybeGenerateTitle: (id: string, cwd: string | undefined) => Promise<void>;
   recordToolCallStart: (sessionId: string, call: { toolUseId?: string; toolName?: string; toolInput?: unknown }) => Promise<void>;
   recordToolCallEnd: (
@@ -136,6 +138,9 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
     const active = !!(entry && entry.active);
     const cwd = resolveHookCwd(body.cwd, entry?.cwd);
     await applyHeaderHooks(deps, sessionId, event, body, cwd);
+    // Before the activity publish below, so the row it mirrors to the phone already carries this
+    // hook's phase (a turn's first Edit must read as "editing" in the same push, not the next one).
+    deps.noteWorkPhase(sessionId, event, typeof body.tool_name === "string" ? body.tool_name : undefined);
     handleActivityHook(deps, sessionId, event, active, typeof body.message === "string" ? body.message : "");
     await handleToolHook(deps, sessionId, event, body, cwd);
     // A hidden translation worker that ends its turn while still pending never called

--- a/server/session/lifecycle.ts
+++ b/server/session/lifecycle.ts
@@ -32,6 +32,7 @@ import {
 import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./reap-policy.js";
 import { sessionRow, shouldRefreshReply } from "./activity-transition.js";
 import { flagEffect, type ActivityFlag } from "./activity-flag.js";
+import type { WorkPhase } from "./workPhase.js";
 import { readLatestResponse } from "./session-reads.js";
 import { cleanupSessionSettings } from "./session-settings.js";
 import { cleanupSandbox } from "../infra/sandbox.js";
@@ -45,8 +46,15 @@ export interface SessionLifecycleDeps {
   publish: (channel: string, data: unknown) => void;
   /** Drop a session's AI title so the next turn regenerates it. */
   forgetTitle: (id: string) => void;
-  /** Mirror of working/waiting for the phone's viewer. */
-  sessionActivityPublisher: { publish: (id: string, state: { working: boolean; waiting: boolean }) => void; forget: (id: string) => void };
+  /** Mirror of the session's status for the phone's viewer. */
+  sessionActivityPublisher: {
+    publish: (id: string, state: { working: boolean; waiting: boolean; event: string | null; workPhase: WorkPhase | null }) => void;
+    forget: (id: string) => void;
+  };
+  /** The live turn's planning-vs-implementing phase, or null when nothing has been observed (#727). */
+  workPhaseOf: (id: string) => WorkPhase | null;
+  /** Drop that tracking when the session is torn down. */
+  forgetWorkPhase: (id: string) => void;
 }
 
 // Timers live per process, not per factory call — there is one server.
@@ -131,6 +139,7 @@ function reap(deps: SessionLifecycleDeps, id: string) {
   lastResponses.delete(id); // ditto, and keep this map from growing across closed sessions
   deps.forgetTitle(id);
   deps.sessionActivityPublisher.forget(id); // drop the phone's copy so its picker has no ghosts
+  deps.forgetWorkPhase(id); // the live turn dies with the session
   titleInFlight.delete(id);
   lastTitledUserTurns.delete(id); // teardown only — kept across /clear as the re-title baseline
   lastTitleAttemptMs.delete(id);
@@ -167,7 +176,7 @@ function publishActivity(deps: SessionLifecycleDeps, id: string) {
     aiTitle: aiTitles.get(id),
     lastResponse: lastResponses.get(id),
   });
-  deps.sessionActivityPublisher.publish(id, { working: row.working, waiting: row.waiting });
+  deps.sessionActivityPublisher.publish(id, { working: row.working, waiting: row.waiting, event: row.event, workPhase: deps.workPhaseOf(id) });
   deps.publish(SESSIONS_CHANNEL, row);
 }
 

--- a/server/session/work-phase-tracker.ts
+++ b/server/session/work-phase-tracker.ts
@@ -30,8 +30,15 @@ export function nextTurnTools(prev: readonly string[], event: string, toolName?:
 export function createWorkPhaseTracker() {
   const turnTools = new Map<string, string[]>();
 
+  // Only allocate when there is something to remember. /api/hook accepts any well-formed uuid
+  // (the id is shape-checked, not looked up), and an entry is only reclaimed by reap — which
+  // never runs for a session that has no pty. Storing an empty turn for an unrelated event would
+  // therefore leave a permanent entry per uuid ever posted, so those are dropped here instead.
   const note = (sessionId: string, event: string, toolName?: string): void => {
-    turnTools.set(sessionId, nextTurnTools(turnTools.get(sessionId) ?? [], event, toolName));
+    const prev = turnTools.get(sessionId);
+    const next = nextTurnTools(prev ?? [], event, toolName);
+    if (!prev && next.length === 0) return;
+    turnTools.set(sessionId, next);
   };
 
   // null while nothing has been observed yet (a just-started or restored session) — the phone
@@ -42,5 +49,8 @@ export function createWorkPhaseTracker() {
     turnTools.delete(sessionId);
   };
 
-  return { note, phaseOf, forget };
+  /** How many sessions hold a turn — the observable for "ignored hooks allocate nothing". */
+  const trackedCount = (): number => turnTools.size;
+
+  return { note, phaseOf, forget, trackedCount };
 }

--- a/server/session/work-phase-tracker.ts
+++ b/server/session/work-phase-tracker.ts
@@ -1,0 +1,46 @@
+// The work phase (planning vs implementing) of a LIVE turn, tracked from Claude's hooks.
+//
+// The roster derives the same thing by parsing the transcript (readSessionSummary →
+// currentTurnToolNamesFromParsed → classifyWorkPhase), which is fine for a request handler but
+// not for the publish path: that sits on the synchronous hook Claude waits on, and must not read
+// files. So the turn's tool names are accumulated as the hooks arrive instead, and handed to the
+// SAME classifier — the two agree on vocabulary even though they observe different sources.
+//
+// The turn boundary mirrors the transcript rule: a fresh user prompt starts a new turn, and every
+// tool the agent then runs belongs to it. A tool-result round trip does NOT reset (only
+// UserPromptSubmit does), so an Edit early in a turn keeps reading as "implementing" through the
+// verification reads that follow it.
+import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
+
+const TURN_START_EVENT = "UserPromptSubmit";
+const TOOL_START_EVENT = "PreToolUse";
+// One turn's tools; a long turn is capped so a runaway session can't grow this without bound.
+// The classifier only asks "was there a mutation", which the oldest entries already answer.
+const TURN_TOOLS_LIMIT = 200;
+
+/** The turn's tool names after one hook. Pure, so the boundary rule can be pinned. */
+export function nextTurnTools(prev: readonly string[], event: string, toolName?: string): string[] {
+  if (event === TURN_START_EVENT) return [];
+  if (event !== TOOL_START_EVENT || !toolName) return [...prev];
+  const next = [...prev, toolName];
+  return next.length > TURN_TOOLS_LIMIT ? next.slice(next.length - TURN_TOOLS_LIMIT) : next;
+}
+
+/** Per-session live work phase, fed by the hook route and read by the activity publisher. */
+export function createWorkPhaseTracker() {
+  const turnTools = new Map<string, string[]>();
+
+  const note = (sessionId: string, event: string, toolName?: string): void => {
+    turnTools.set(sessionId, nextTurnTools(turnTools.get(sessionId) ?? [], event, toolName));
+  };
+
+  // null while nothing has been observed yet (a just-started or restored session) — the phone
+  // then shows the plain "working", exactly as it does today.
+  const phaseOf = (sessionId: string): WorkPhase | null => classifyWorkPhase(turnTools.get(sessionId) ?? []);
+
+  const forget = (sessionId: string): void => {
+    turnTools.delete(sessionId);
+  };
+
+  return { note, phaseOf, forget };
+}

--- a/test/server/backends/remoteHost/sessionActivity.spec.ts
+++ b/test/server/backends/remoteHost/sessionActivity.spec.ts
@@ -2,16 +2,24 @@
 import { describe, it, expect, vi } from "vitest";
 
 import { createSessionActivityPublisher, type SessionActivityStore } from "../../../../server/backends/remoteHost/sessionActivity.js";
+import type { WorkPhase } from "../../../../server/session/workPhase.js";
 
 const UID = "user-1";
 const HOST = "mulmoterminal";
 
 const recorder = () => {
-  const writes: Array<{ sessionId: string; rev: number; working: boolean; waiting: boolean }> = [];
+  const writes: Array<{ sessionId: string; rev: number; working: boolean; waiting: boolean; event?: string | null; workPhase?: WorkPhase | null }> = [];
   const removes: string[] = [];
   const store: SessionActivityStore = {
     write: async (_uid, _hostId, sessionId, payload) => {
-      writes.push({ sessionId, rev: payload.rev, working: payload.working, waiting: payload.waiting });
+      writes.push({
+        sessionId,
+        rev: payload.rev,
+        working: payload.working,
+        waiting: payload.waiting,
+        event: payload.event,
+        workPhase: payload.workPhase,
+      });
     },
     remove: async (_uid, _hostId, sessionId) => {
       removes.push(sessionId);
@@ -92,6 +100,43 @@ describe("createSessionActivityPublisher", () => {
     activity.publish("s1", { working: true, waiting: false });
     expect(writes).toHaveLength(2);
     expect(writes.at(-1)?.rev).toBe(1);
+  });
+
+  // #727: the phone speaks the roster's status vocabulary, which needs these two alongside the
+  // flags — and the dedup key has to carry them, or a change the user can see is swallowed.
+  it("carries the event and the work phase into the written doc", () => {
+    const { writes, store } = recorder();
+    publisher(store).publish("s1", { working: true, waiting: false, event: "UserPromptSubmit", workPhase: "planning" });
+    expect(writes.at(-1)).toMatchObject({ event: "UserPromptSubmit", workPhase: "planning" });
+  });
+
+  it("writes when only the work phase moves (planning -> implementing)", () => {
+    const { writes, store } = recorder();
+    const activity = publisher(store);
+    activity.publish("s1", { working: true, waiting: false, event: "PreToolUse", workPhase: "planning" });
+    activity.publish("s1", { working: true, waiting: false, event: "PreToolUse", workPhase: "implementing" });
+    expect(writes).toHaveLength(2);
+    expect(writes.at(-1)).toMatchObject({ workPhase: "implementing" });
+  });
+
+  // blocked (Notification) vs done (Stop) share `waiting: true` — without the event in the key the
+  // phone would keep showing the superseded one.
+  it("writes when only the event moves (blocked -> done)", () => {
+    const { writes, store } = recorder();
+    const activity = publisher(store);
+    activity.publish("s1", { working: false, waiting: true, event: "Notification", workPhase: null });
+    activity.publish("s1", { working: false, waiting: true, event: "Stop", workPhase: null });
+    expect(writes).toHaveLength(2);
+    expect(writes.at(-1)).toMatchObject({ event: "Stop" });
+  });
+
+  it("still dedups when every published field is unchanged", () => {
+    const { writes, store } = recorder();
+    const activity = publisher(store);
+    const state = { working: true, waiting: false, event: "PreToolUse", workPhase: "implementing" } as const;
+    activity.publish("s1", { ...state });
+    activity.publish("s1", { ...state });
+    expect(writes).toHaveLength(1);
   });
 
   // The caller sits on the synchronous hook path serving Claude Code's own requests.

--- a/test/server/session/lifecycle.spec.ts
+++ b/test/server/session/lifecycle.spec.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { createSessionLifecycle } from "../../../server/session/lifecycle.js";
+import type { WorkPhase } from "../../../server/session/workPhase.js";
 import { activity, aiTitles, hiddenSessions, knownSessions, lastPrompts, lastResponses, launchChoices, ptys } from "../../../server/session/registry.js";
 
 vi.mock("../../../server/infra/tmux.js", () => ({ tmuxKillSession: vi.fn() }));
@@ -15,10 +16,12 @@ vi.mock("../../../server/session/session-settings.js", () => ({ cleanupSessionSe
 
 const ID = "11111111-2222-4333-8444-555555555555";
 
-const makeDeps = () => ({
+const makeDeps = (workPhase: WorkPhase | null = null) => ({
   publish: vi.fn(),
   forgetTitle: vi.fn(),
   sessionActivityPublisher: { publish: vi.fn(), forget: vi.fn() },
+  workPhaseOf: vi.fn(() => workPhase),
+  forgetWorkPhase: vi.fn(),
 });
 
 // A pty entry with just the fields the lifecycle reads.
@@ -112,11 +115,18 @@ describe("setWorking / setWaiting", () => {
     expect(deps.publish).not.toHaveBeenCalled();
   });
 
-  it("mirrors the flags to the phone", () => {
-    const deps = makeDeps();
+  // The phone renders the same status vocabulary as the cockpit roster, which needs the event
+  // (blocked vs done) and the live work phase (planning vs editing) alongside the flags (#727).
+  it("mirrors the flags, the event and the work phase to the phone", () => {
+    const deps = makeDeps("implementing");
     ptys.set(ID, fakeEntry({ ws: {} }));
     createSessionLifecycle(deps).setWaiting(ID, true, "Notification");
-    expect(deps.sessionActivityPublisher.publish).toHaveBeenCalledWith(ID, { working: false, waiting: true });
+    expect(deps.sessionActivityPublisher.publish).toHaveBeenCalledWith(ID, {
+      working: false,
+      waiting: true,
+      event: "Notification",
+      workPhase: "implementing",
+    });
   });
 });
 

--- a/test/server/session/work-phase-tracker.spec.ts
+++ b/test/server/session/work-phase-tracker.spec.ts
@@ -101,4 +101,34 @@ describe("createWorkPhaseTracker", () => {
     t.forget(S);
     expect(t.phaseOf(S)).toBeNull();
   });
+
+  // The leak this guards: /api/hook shape-checks the uuid rather than looking it up, and an entry
+  // is only reclaimed by reap — which does nothing for a session with no pty. An ignored hook must
+  // therefore allocate nothing, or every uuid ever posted would occupy the map for good.
+  it("allocates nothing for hooks that carry no turn information", () => {
+    const t = createWorkPhaseTracker();
+    t.note("unseen-1", "Stop");
+    t.note("unseen-2", "Notification");
+    t.note("unseen-3", "PostToolUse", "Edit");
+    t.note("unseen-4", "UserPromptSubmit"); // a turn reset with nothing to reset
+    t.note("unseen-5", "PreToolUse"); // no tool name
+    expect(t.trackedCount()).toBe(0);
+  });
+
+  it("allocates once a turn actually runs a tool, and releases it on forget", () => {
+    const t = createWorkPhaseTracker();
+    t.note(S, "PreToolUse", "Read");
+    expect(t.trackedCount()).toBe(1);
+    t.forget(S);
+    expect(t.trackedCount()).toBe(0);
+  });
+
+  // A tracked session must still be able to RESET — the reset only allocates when there is a turn.
+  it("keeps resetting a tracked session's turn on a new prompt", () => {
+    const t = createWorkPhaseTracker();
+    t.note(S, "PreToolUse", "Edit");
+    t.note(S, "UserPromptSubmit");
+    expect(t.phaseOf(S)).toBeNull();
+    expect(t.trackedCount()).toBe(1); // still tracked, just empty
+  });
 });

--- a/test/server/session/work-phase-tracker.spec.ts
+++ b/test/server/session/work-phase-tracker.spec.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+//
+// The live counterpart of the transcript's work-phase read. The rule it has to match is the turn
+// boundary: a fresh user prompt resets, tool results do not — so an Edit early in a turn keeps the
+// turn reading as "implementing" through every verification read that follows it.
+import { describe, it, expect } from "vitest";
+
+import { createWorkPhaseTracker, nextTurnTools } from "../../../server/session/work-phase-tracker.js";
+
+const S = "session-1";
+
+describe("nextTurnTools", () => {
+  it("starts a new turn on a user prompt, dropping the previous turn's tools", () => {
+    expect(nextTurnTools(["Edit", "Read"], "UserPromptSubmit")).toEqual([]);
+  });
+
+  it("appends the tool a PreToolUse names", () => {
+    expect(nextTurnTools(["Read"], "PreToolUse", "Edit")).toEqual(["Read", "Edit"]);
+  });
+
+  it("ignores hooks that are not a turn start or a tool start", () => {
+    expect(nextTurnTools(["Read"], "PostToolUse", "Edit")).toEqual(["Read"]);
+    expect(nextTurnTools(["Read"], "Stop")).toEqual(["Read"]);
+    expect(nextTurnTools(["Read"], "Notification")).toEqual(["Read"]);
+  });
+
+  it("ignores a PreToolUse with no tool name", () => {
+    expect(nextTurnTools(["Read"], "PreToolUse")).toEqual(["Read"]);
+  });
+
+  it("does not mutate the array it is given", () => {
+    const prev = ["Read"];
+    nextTurnTools(prev, "PreToolUse", "Edit");
+    expect(prev).toEqual(["Read"]);
+  });
+
+  // A single turn can run a very long tool chain; the classifier only asks "was there a mutation",
+  // so the window is capped rather than grown without bound.
+  it("caps one turn's tools, keeping the most recent", () => {
+    const many = Array.from({ length: 200 }, (_, i) => `T${i}`);
+    const next = nextTurnTools(many, "PreToolUse", "Edit");
+    expect(next).toHaveLength(200);
+    expect(next[199]).toBe("Edit");
+    expect(next[0]).toBe("T1"); // the oldest fell off
+  });
+});
+
+describe("createWorkPhaseTracker", () => {
+  it("reports null before anything has been observed", () => {
+    expect(createWorkPhaseTracker().phaseOf(S)).toBeNull();
+  });
+
+  it("reads a turn that has only searched/read as planning", () => {
+    const t = createWorkPhaseTracker();
+    t.note(S, "UserPromptSubmit");
+    t.note(S, "PreToolUse", "Read");
+    t.note(S, "PreToolUse", "Grep");
+    expect(t.phaseOf(S)).toBe("planning");
+  });
+
+  it("reads a turn that has changed the workspace as implementing", () => {
+    const t = createWorkPhaseTracker();
+    t.note(S, "UserPromptSubmit");
+    t.note(S, "PreToolUse", "Read");
+    t.note(S, "PreToolUse", "Edit");
+    expect(t.phaseOf(S)).toBe("implementing");
+  });
+
+  // The stability rule: verification reads AFTER an edit must not demote the turn to planning.
+  it("stays implementing through the reads that follow an edit", () => {
+    const t = createWorkPhaseTracker();
+    t.note(S, "UserPromptSubmit");
+    t.note(S, "PreToolUse", "Edit");
+    t.note(S, "PreToolUse", "Read");
+    t.note(S, "PreToolUse", "Bash");
+    expect(t.phaseOf(S)).toBe("implementing");
+  });
+
+  // The leak the turn boundary exists to prevent: last turn's Edit must not colour a new turn
+  // that is only reading.
+  it("forgets the previous turn's edit when a new prompt arrives", () => {
+    const t = createWorkPhaseTracker();
+    t.note(S, "UserPromptSubmit");
+    t.note(S, "PreToolUse", "Edit");
+    t.note(S, "UserPromptSubmit");
+    expect(t.phaseOf(S)).toBeNull(); // no tools yet in the new turn
+    t.note(S, "PreToolUse", "Read");
+    expect(t.phaseOf(S)).toBe("planning");
+  });
+
+  it("tracks each session independently", () => {
+    const t = createWorkPhaseTracker();
+    t.note("a", "PreToolUse", "Edit");
+    t.note("b", "PreToolUse", "Read");
+    expect([t.phaseOf("a"), t.phaseOf("b")]).toEqual(["implementing", "planning"]);
+  });
+
+  it("drops a session's turn on forget, so a reused id starts clean", () => {
+    const t = createWorkPhaseTracker();
+    t.note(S, "PreToolUse", "Edit");
+    t.forget(S);
+    expect(t.phaseOf(S)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Firestore のセッション活動 doc（#439）に `event` と `workPhase` を追加し、mulmoserver（スマホ側, receptron/mulmoserver#99）が cockpit/grid と同じ状態語彙（`blocked` / `done` / `editing` / `planning` / `working` / `idle`）を出せるようにする。どちらも optional なので、フィールドを知らない読み手は従来どおり working/waiting に degrade。

## Items to Confirm / Review

- **`workPhase` は issue の想定と実装が違う**：issue は「既に持っている workPhase を渡すだけ」だったが、調査したところ **publish 時点ではメモリに無い**。roster は transcript を読んで算出（`session-reads.ts:155`）しており、publish は Claude が待つ同期 hook 経路上の fire-and-forget なので、そこで transcript を読むのは既存設計に反する。→ **hook からライブに追跡する仕組みを新設**した（`server/session/work-phase-tracker.ts`）。ここが一番のレビューポイント。
- **live 追跡と roster 由来のズレ**：判定は同じ `classifyWorkPhase` を共有するので語彙は一致するが、ソースが独立（hook vs transcript）。サーバ再起動直後や hook 取りこぼし時は roster と一時的にズレうる（その場合 `null` に degrade＝スマホは素の "working" 表示）。許容範囲かの確認をお願いします。
- **Firestore の write 量**：`stateKey`（dedup キー）に 2 フィールドを追加したため、working/waiting 据え置きで workPhase だけ planning→implementing に動くケースなどで write が増える。スマホにその遷移を出すためには必要だが、コスト影響として認識しておきたい点。
- ターン境界の定義：`UserPromptSubmit` でリセット、`PreToolUse` で蓄積（tool-result の往復ではリセットしない）。transcript 版 `currentTurnToolNamesFromParsed` のルールに合わせている。

## User Prompt

> #727（を進めて、両方を 1PR で今実装）

issue #727 本文：セッション活動 doc（Firestore, #439）に `event` と `workPhase` も載せて、mulmoserver（スマホ側）の一覧が cockpit/grid と同じ状態語彙を出せるようにする。

## 実装

1. **`server/session/work-phase-tracker.ts`（新規）** — hook 由来のライブ work phase。純関数 `nextTurnTools(prev, event, toolName)` ＋ セッションごとの薄いラッパ（`note` / `phaseOf` / `forget`）。判定は既存の `classifyWorkPhase` を再利用。1ターンのツール数は 200 で cap。
2. **`sessionActivity.ts`** — `SessionActivity` に `event?` / `workPhase?` を追加（optional）。`stateKey` にも両方を含める。
3. **配線** — `lifecycle.ts` の publish が `event`（既存の `row.event`）と `workPhase`（deps 経由の getter）を渡す。`hook-routes.ts` が activity publish の**前に** `noteWorkPhase` を呼ぶ（同じ push にそのターンの phase が乗るように）。`reap` 時に `forgetWorkPhase`。

## テスト

- `work-phase-tracker.spec.ts`（新規, 13件）：ターンリセット / mutation→implementing / 読みのみ→planning / edit 後の read で implementing を維持 / 前ターンの edit が漏れない / セッション独立 / forget / cap / 非破壊。
- `sessionActivity.spec.ts`（+4件）：doc に両フィールドが載る / workPhase だけ動いたら書く / event だけ動いたら（blocked→done）書く / 全部同じなら dedup 維持。
- `lifecycle.spec.ts`：publish に event と workPhase が渡ることを検証。
- **破壊テスト実施済み**：`stateKey` から新フィールドを外す → 該当2件が fail、lifecycle の workPhase 受け渡しを潰す → 該当1件が fail。復元後 green。
- `yarn format` / `lint`（0 errors）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `knip` / 全テスト（**3480 passed**）green。

plan: `plans/feat-727-activity-doc-event-workphase.md`

## 関連

- #439（activity doc の初出）
- receptron/mulmoserver#99（受け側。フィールドが来なくても graceful に degrade するので、任意のタイミングでマージ可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)