### PR TITLE
fix: stop one uncaught error from disconnecting every terminal

### DIFF
--- a/plans/fix-backend-crash-disconnects-all-terminals.md
+++ b/plans/fix-backend-crash-disconnects-all-terminals.md
@@ -1,0 +1,111 @@
+# fix — バックエンドの未捕捉例外でプロセスが死に、全ターミナルが切断される
+
+対象: 実行中に突然すべてのターミナルがサーバから切断され、サーバコンソールに
+`[vite] ws proxy error` / `[vite] http proxy error` + `AggregateError [ECONNREFUSED]`
+が数秒おきに出続ける現象。
+
+## 症状（ユーザ報告のログ）
+
+```
+[vite] ws proxy error:
+[vite] AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1134:18)
+    at afterConnectMultiple (node:net:1715:7)
+[vite] http proxy error: /api/git-status?cwd=%2FUsers%2Fsatoshi%2Fmulmoclaude
+[vite] AggregateError [ECONNREFUSED]: ...
+```
+
+## 分析（何が起きているか）
+
+構成: `yarn dev` は `concurrently` で 2 プロセスを起動する（`package.json`）。
+
+- **vite**（`CLIENT_PORT` = 6856）: 単なるプロキシ。`/ws`・`/ws/pubsub`・`/api`・`/artifacts`
+  をすべて **バックエンド（`BACKEND_PORT` = 34567）** へ転送する（`vite.config.ts` の `server.proxy`）。
+- **server**（Express, 34567, `server/index.ts:453` の `server.listen(PORT)`）: 実体。
+  ターミナルの WebSocket も `/api` ポーリングもここに集約される。
+
+`ECONNREFUSED` は「34567 で誰も listen していない」＝**バックエンドプロセスが落ちた**ことを意味する。
+per-terminal の問題ではない証拠に、素の `/api/git-status` すら ECONNREFUSED になっている。
+バックエンドが死ぬと、全ターミナルの WebSocket が同時に切れ、クライアントが再接続を試みるたびに
+vite が上記エラーを吐き続ける → ユーザ視点では「全ターミナルが一斉に切断」。
+
+**なぜ復帰しないか**: dev スクリプトは `node --watch` でバックエンドを動かしている。
+`node --watch` は**ファイル変更**では再起動するが、**クラッシュ（未捕捉例外での exit）では再起動しない**
+（"Completed running" を表示して待機するだけ）。だからファイルを保存するまで死んだまま = 切断が継続する。
+
+**根本原因**: `server/` に `process.on("uncaughtException")` / `process.on("unhandledRejection")`
+のトップレベルガードが**一切ない**（grep 済み）。したがって、バックエンドのどこかで発生した
+1 個の未捕捉エラー（下記いずれか）だけで Express プロセス全体が落ち、全ターミナルを道連れにする。
+
+- `server.on("error")` は既に存在するが、これは**bind 失敗（ポート使用中）専用**のガード
+  （`server/index.ts:447`, `serverErrorExit`）。ランタイムの未捕捉例外はカバーしていない。
+
+**最も疑わしい発生源（PTY/ソケット系）**: node-pty で多数の子プロセスを spawn している
+（`server/session/pty-spawn.ts` の `spawnPty` / `spawnSandboxEntry`、
+`spawn-claude.ts` / `spawn-codex.ts` / `spawn-shell.ts`）。
+リスナ不在の `'error'` イベント（子プロセス・ソケットの EPIPE/ECONNRESET 等）や、
+WebSocket ハンドラ内の reject された Promise は、いずれもプロセスを即死させる。
+`[[shell-npm-prefix-bug]]`（spawnPty が環境によって失敗しうる件）も候補。
+
+## 修正方針
+
+2 段階。まず「1 個の不良イベントで全ターミナルが落ちる崖」を止め、同時に**真の原因のスタックを捕捉**する。
+
+### Step A（先行・最小）— トップレベルガードで即死を止め、原因を可視化
+
+`server/index.ts` に以下を追加:
+
+```ts
+process.on("unhandledRejection", (reason) => {
+  console.error("[fatal] unhandledRejection:", reason);
+});
+process.on("uncaughtException", (err) => {
+  console.error("[fatal] uncaughtException:", err);
+});
+```
+
+- 目的: (1) 未捕捉エラーでプロセスを殺さず、全ターミナル切断の崖を防ぐ。
+  (2) **本当のスタックトレース**をサーバペインにフルで残し、根本原因（Step B）を特定する。
+- 注意: `bind failure`（`server.on("error")` → `process.exit`）は従来どおり即終了させる。
+  こちらは正しく落ちるべきケースなので `uncaughtException` ハンドラでは握り潰さない
+  （`server.on("error")` が先に exit するため衝突しない）。
+- 方針判断: uncaughtException 後にプロセスを継続させるのは Node 的にはグレー（状態が壊れている
+  可能性）。ただし本アプリは「全ターミナルの巻き添え死」より「1 セッションの不整合」の方が遥かにマシ
+  なので、まずは**ログして継続**を採用。将来 supervisor（クラッシュ時に再起動する `node --watch`
+  ラッパ / nodemon）導入時に fail-fast へ切り替える余地は残す。
+
+### Step B（根本原因の第一候補）— WebSocket ソケットの `'error'` 未リスナを塞ぐ ✅ 本 PR で実施
+
+grep の結果、`server/routes/ws-routes.ts` の**どの ws 接続にも `ws.on("error")` が無い**ことが判明。
+`ws` ライブラリでは、リスナ不在の socket が `'error'` を emit すると Node がそれを再送出し
+→ 未捕捉 → **プロセス全体がクラッシュ**する。クライアントのネットワークがセッション途中で切れると
+socket は `ECONNRESET`/`EPIPE` を `'error'` として emit するため、これが症状に極めて良く一致する。
+
+修正: `handleUpgrade` のコールバック（claude/run/launch/codex の**全 4 サーバが通る唯一の choke
+point**）で、connection ハンドラ実行前に `attachSocketErrorLogger(ws, kind)` を配線。単体テスト可能な
+よう小関数として export（`beginRunTerminal` と同じ流儀）。これで 1 クライアントの切断が 1 クライアントの
+切断で収まり、全ターミナルを道連れにしない。
+
+将来 Step A のログで別の発生源（PTY 系等）が判明したら、そこも同様に塞ぐ。
+
+## 切り分け手順（次回発生時 / 再現時）
+
+1. **今は原因スタックが見えていない**: ユーザが貼ったのは `concurrently` の **vite ペイン（緑）**。
+   バックエンドの本当のスタックは **server ペイン（青）** の ECONNREFUSED ストーム直前に 1 回だけ出る。
+   まずそこをスクロールして確認。
+2. Step A を入れれば、以後はプロセスが生き残り、そのスタックが確実にログに残る。
+
+## テスト（実装済み）
+
+- `test/server/infra/process-guards.spec.ts`: (1) install で各イベントにハンドラが 1 個ずつ登録される
+  (2) 冪等（2 回呼んでも増えない）(3) ハンドラ実行が throw せず `console.error` にスタックを出す
+  ＝プロセスが生存する、を検証。
+- `test/server/routes/ws-socket-error.spec.ts`: bare `EventEmitter` に `'error'` を emit すると
+  （リスナ無しでは）throw することをまず確認し、`attachSocketErrorLogger` 適用後は同じ emit が
+  吸収されて警告ログのみになることを検証（変異テスト的に「無ければ死ぬ／有れば生きる」を担保）。
+
+## 未確定事項 / フォローアップ
+
+- 実際の原因スタック: Step B（ws socket error）が本命だが、Step A のガードで今後別の発生源
+  （PTY 系等）が判明したら都度塞ぐ。
+- fail-fast（log→exit→supervisor 再起動）にすべきか、log→継続のままにするか。まずは継続で運用し判断。

--- a/server/index.ts
+++ b/server/index.ts
@@ -68,8 +68,14 @@ import { createSessionLifecycle, SESSIONS_CHANNEL } from "./session/lifecycle.js
 import { mountAppRoutes } from "./routes/app-routes.js";
 import { allowedToolNames } from "./infra/plugins-registry.js";
 import { resumableSessionPredicate } from "./session/resumable-sessions.js";
+import { installProcessGuards } from "./infra/process-guards.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
+
+// Register the top-level uncaughtException/unhandledRejection guards before any async boot
+// work runs, so a single unhandled error can't silently kill the backend and disconnect
+// every terminal at once (see infra/process-guards.ts).
+installProcessGuards();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/server/infra/process-guards.ts
+++ b/server/infra/process-guards.ts
@@ -1,0 +1,32 @@
+// Top-level safety net for the backend process. Without these, a single uncaught error
+// anywhere in the server — most often an unhandled 'error' event on a node-pty child or a
+// rejected promise inside a WebSocket handler — exits the whole Express process. When that
+// happens under `node --watch`, nothing restarts it (watch only restarts on file changes,
+// not on a crash), so every terminal's WebSocket and every /api poll starts hitting a dead
+// port: the Vite dev proxy then floods the console with `ws proxy error` / `http proxy
+// error` + `ECONNREFUSED` and, to the user, "all terminals disconnected at once".
+//
+// The trade-off: continuing after an uncaughtException is officially discouraged (process
+// state may be corrupt). We accept it deliberately — for this app, one session left in an
+// inconsistent state is far better than taking down every other terminal with it. The
+// logged stack is also what lets us find and fix the real emitter (Step B). A genuinely
+// fatal bind failure still exits, because server.on("error") in index.ts runs its own
+// process.exit before anything reaches here.
+import { messageOf } from "../errors.js";
+
+const onUnhandledRejection: NodeJS.UnhandledRejectionListener = (reason) => {
+  console.error("[fatal] unhandledRejection — process kept alive:", reason instanceof Error ? (reason.stack ?? reason) : reason);
+};
+
+const onUncaughtException: NodeJS.UncaughtExceptionListener = (err) => {
+  console.error(`[fatal] uncaughtException — process kept alive: ${messageOf(err)}`);
+  if (err instanceof Error && err.stack) console.error(err.stack);
+};
+
+// Idempotent: registers exactly one of each handler, so repeated calls don't stack listeners
+// or trip Node's MaxListenersExceededWarning. Keyed on the handler references actually being
+// attached (not a module-level flag) so it stays correct if a caller detaches them.
+export function installProcessGuards(): void {
+  if (!process.listeners("unhandledRejection").includes(onUnhandledRejection)) process.on("unhandledRejection", onUnhandledRejection);
+  if (!process.listeners("uncaughtException").includes(onUncaughtException)) process.on("uncaughtException", onUncaughtException);
+}

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -98,6 +98,16 @@ async function resolveRunTarget(url: URL): Promise<{ command: string; cwd: strin
   return resolveScript(cwd, parseIndexParam(url.searchParams.get("index")));
 }
 
+// A terminal socket is a raw EventEmitter: an unhandled 'error' (a client whose network
+// drops mid-session emits ECONNRESET/EPIPE) is re-thrown by the ws library and would crash
+// the whole backend — disconnecting EVERY terminal, not just this one, and leaving the Vite
+// dev proxy to flood the console with ECONNREFUSED. Attach a no-op-but-logging listener
+// before the connection handler runs so one dropped client stays one dropped client. Wired
+// at the single handleUpgrade choke point, so it covers claude/run/launch/codex alike.
+export function attachSocketErrorLogger(ws: Pick<WebSocket, "on">, kind: TerminalWsKind): void {
+  ws.on("error", (err) => console.warn(`[ws] socket error (${kind}): ${messageOf(err)}`));
+}
+
 async function startRunTerminal(deps: WsRouteDeps, ws: WebSocket, url: URL): Promise<void> {
   const resolved = await resolveRunTarget(url);
   if (!resolved) return closeWithError(ws, "Command not found — check your config / script.json.");
@@ -364,7 +374,10 @@ export function mountTerminalWebSockets(deps: WsRouteDeps) {
       socket.destroy();
       return;
     }
-    target.handleUpgrade(req, socket, head, (ws) => target.emit("connection", ws, req));
+    target.handleUpgrade(req, socket, head, (ws) => {
+      attachSocketErrorLogger(ws, kind);
+      target.emit("connection", ws, req);
+    });
   });
 
   wss.on("connection", (ws, req) => void handleClaudeConnection(deps, ws, req));

--- a/test/server/infra/process-guards.spec.ts
+++ b/test/server/infra/process-guards.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { installProcessGuards } from "../../../server/infra/process-guards.js";
+
+// These attach to the real `process`; snapshot and restore so the suite leaves no listeners
+// behind (and so the module-level idempotency flag doesn't hide a regression across tests).
+describe("installProcessGuards", () => {
+  let uncaughtBefore: NodeJS.UncaughtExceptionListener[];
+  let rejectionBefore: NodeJS.UnhandledRejectionListener[];
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    uncaughtBefore = process.listeners("uncaughtException");
+    rejectionBefore = process.listeners("unhandledRejection");
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Drop only the listeners this suite's install() added, restoring the original set.
+    for (const l of process.listeners("uncaughtException")) if (!uncaughtBefore.includes(l)) process.off("uncaughtException", l);
+    for (const l of process.listeners("unhandledRejection")) if (!rejectionBefore.includes(l)) process.off("unhandledRejection", l);
+    errSpy.mockRestore();
+  });
+
+  it("registers one handler for each fatal event", () => {
+    installProcessGuards();
+    expect(process.listenerCount("uncaughtException")).toBe(uncaughtBefore.length + 1);
+    expect(process.listenerCount("unhandledRejection")).toBe(rejectionBefore.length + 1);
+  });
+
+  it("is idempotent — a second call adds no further listeners", () => {
+    installProcessGuards();
+    installProcessGuards();
+    expect(process.listenerCount("uncaughtException")).toBe(uncaughtBefore.length + 1);
+    expect(process.listenerCount("unhandledRejection")).toBe(rejectionBefore.length + 1);
+  });
+
+  it("logs the offending error instead of rethrowing (process stays alive)", () => {
+    installProcessGuards();
+    const handler = process.listeners("uncaughtException").find((l) => !uncaughtBefore.includes(l));
+    if (!handler) throw new Error("guard did not register an uncaughtException handler");
+    const boom = new Error("kaboom");
+    // The whole point: invoking the handler must NOT throw — that is what keeps the backend
+    // (and every terminal on it) alive after an otherwise-fatal error.
+    expect(() => handler(boom, "uncaughtException")).not.toThrow();
+    expect(errSpy).toHaveBeenCalled();
+    expect(errSpy.mock.calls.flat().join(" ")).toContain("kaboom");
+  });
+});

--- a/test/server/routes/ws-socket-error.spec.ts
+++ b/test/server/routes/ws-socket-error.spec.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import type { WebSocket } from "ws";
+
+import { attachSocketErrorLogger } from "../../../server/routes/ws-routes.js";
+
+describe("attachSocketErrorLogger", () => {
+  it("keeps an 'error' emitted on the socket from crashing the process", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // A bare EventEmitter reproduces the crash: emitting 'error' with NO listener throws
+    // (Node re-raises it), which is exactly what would take down the backend.
+    const ws = new EventEmitter();
+    expect(() => ws.emit("error", new Error("ECONNRESET"))).toThrow(/ECONNRESET/);
+
+    attachSocketErrorLogger(ws as unknown as WebSocket, "claude");
+    // With the listener attached the same emit is absorbed and merely logged.
+    expect(() => ws.emit("error", new Error("ECONNRESET"))).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("socket error (claude)"));
+    expect(warn.mock.calls.flat().join(" ")).toContain("ECONNRESET");
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
## Problem

While running MulmoTerminal, **all terminals sometimes disconnect at once** and the server console floods with:

```
[vite] ws proxy error:
[vite] AggregateError [ECONNREFUSED]: ...
[vite] http proxy error: /api/git-status?cwd=...
[vite] AggregateError [ECONNREFUSED]: ...
```

## Root cause

Vite (dev port 6856) is **only a proxy** in front of the Express backend (34567). `ECONNREFUSED` — even for the plain `/api/git-status` — means the **backend process died**, so every terminal's WebSocket and every `/api` poll now hits a dead port.

Two gaps let a single error do this:

1. **No process-level guard.** `server/` had no `uncaughtException` / `unhandledRejection` handler, so one uncaught error killed the entire backend. Under `node --watch` (which restarts on *file change*, not on *crash*) it then stayed dead — matching the "everything disconnected and never came back" symptom.
2. **No `ws.on("error")` anywhere.** In the `ws` library an unhandled socket `'error'` — a client whose network drops mid-session emits `ECONNRESET`/`EPIPE` — is re-thrown and crashes the process. This is the most likely trigger.

## Fix (two layers)

- **`server/infra/process-guards.ts`** — top-level `uncaughtException`/`unhandledRejection` handlers that log the full stack and keep the process alive, installed first thing in `index.ts`. A genuine bind failure still exits via the existing `server.on("error")`. This stops the cliff *and* captures the real stack for any remaining root cause.
- **`ws-routes.ts`** — `attachSocketErrorLogger` wired at the single `handleUpgrade` choke point, covering claude/run/launch/codex. One dropped client stays one dropped client.

## Tests

- `test/server/infra/process-guards.spec.ts` — registers one handler each, idempotent, and invoking the handler does **not** rethrow (process survives).
- `test/server/routes/ws-socket-error.spec.ts` — a bare emitter throws on `'error'` **without** the listener and is absorbed **with** it.

Full analysis in `plans/fix-backend-crash-disconnects-all-terminals.md`.

Note: the pre-existing `docPath.spec.ts` failure is unrelated (a local-timezone bug that also fails on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)