### PR TITLE
fix: tmux の OSC52 クリップボード転送が壊れている（conf のダブルクォートで \E が消える）(#740)

### DIFF
--- a/plans/fix-740-tmux-osc52-conf-quoting.md
+++ b/plans/fix-740-tmux-osc52-conf-quoting.md
@@ -1,0 +1,48 @@
+# fix: tmux の OSC52 クリップボード転送が壊れている（#740）
+
+## User Prompt
+
+> mulmoclaude で全ファイルをレビューして pure 関数化できる部分は関数化しつつバグを探したら結構なバグがあったんだけど、こっちでもできる？
+> （全ファイルレビューで検出したバグを issue 化し、順に対応・CI・レビュー対応・マージまで進める）
+
+## 症状
+
+tmux 経由のセッションで Claude Code の自動コピー（OSC 52）がブラウザのクリップボードに届かず、
+代わりに `E]52;c;<base64>` という文字列がターミナルに表示される。
+
+## 原因
+
+`server/infra/tmux.ts` の conf 行がダブルクォートを使っていた。
+
+```ts
+`set -ag terminal-overrides "${OSC52_MS_OVERRIDE}"`   // OSC52_MS_OVERRIDE = ",*:Ms=\\E]52;%p1%s;%p2%s\\007"
+```
+
+tmux はダブルクォート内でエスケープ処理を行うため `\E` が食われて素の `E` になり、`\007` は生の BEL になる。
+tmux 3.6a で実測して確認：
+
+| 書き方 | tmux が保存する値 |
+|---|---|
+| ダブルクォート（旧） | `*:Ms=E]52;%p1%s;%p2%s<BEL>`（壊れ） |
+| シングルクォート | `*:Ms=\E]52;%p1%s;%p2%s\007`（正） |
+| argv 直渡し（live パス） | `*:Ms=\E]52;%p1%s;%p2%s\007`（正） |
+
+初回起動（tmux サーバ未起動）は必ず conf 経由なので標準的な使い方でこの経路に入る。
+さらに `applyLiveTmuxOptions` のガード `includes("Ms=")` は壊れた値にもマッチするため自動修復されなかった。
+
+## 修正
+
+1. conf 行をシングルクォートにして tmux に `\E` をそのまま渡す。
+2. `OSC52_MS_OVERRIDE` の本体を `MS_OVERRIDE_ENTRY` として切り出し export。
+3. `planMsOverride(showStdout)` を純粋関数として追加。
+   実行中サーバの `show -g terminal-overrides` 出力から `append` / `ok` / `replace(index)` を判定する。
+   壊れた値を保存済みの既存サーバ（このfix以前に起動）はインデックス指定 set で修正する。
+4. `applyLiveTmuxOptions` を「Ms= を含むか」ではなく `planMsOverride` の結果で分岐するよう変更。
+
+## テスト
+
+`test/server/infra/tmux.spec.ts`:
+- conf 行がシングルクォートで、ダブルクォートを含まないこと（回帰）。ダブルクォートに戻すと落ちることを確認済み。
+- `planMsOverride`: append（未設定）/ ok（正しい値）/ replace（壊れた値を保存済み）/ 他人の override は無視、を実 tmux 出力フィクスチャで固定。
+
+実 tmux 3.6a に修正後 conf を読ませ、`Ms=\E]52;...` が正しく保存されることをエンドツーエンドで確認。

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -33,8 +33,10 @@ export function tmuxAvailable(): boolean {
 // OSC 52 to the OUTER terminal when it knows the outer terminal supports it — our web
 // xterm does (via the ClipboardAddon, #206), but its terminfo doesn't advertise `Ms`, so
 // we declare it. Without this, tmux swallows Claude Code's auto-copy and it never reaches
-// the browser clipboard. Appended (not set) so tmux's built-in overrides survive.
-const OSC52_MS_OVERRIDE = ",*:Ms=\\E]52;%p1%s;%p2%s\\007";
+// the browser clipboard.
+export const MS_OVERRIDE_ENTRY = "*:Ms=\\E]52;%p1%s;%p2%s\\007";
+// Appended (not set) so tmux's built-in overrides survive.
+const OSC52_MS_OVERRIDE = `,${MS_OVERRIDE_ENTRY}`;
 
 // Minimal config for our server: no status bar (this is a terminal INSIDE a terminal),
 // instant escape, generous scrollback, follow the latest client's size, never destroy a
@@ -53,19 +55,44 @@ export const TMUX_CONF_LINES: readonly string[] = [
   "set -g destroy-unattached off",
   "set -g mouse on",
   "set -g set-clipboard on",
-  `set -ag terminal-overrides "${OSC52_MS_OVERRIDE}"`,
+  // SINGLE quotes: inside double quotes tmux runs its own escape processing over the
+  // value, which eats the `\E` (leaving a bare `E` that is not an escape at all) and turns
+  // `\007` into a raw BEL — so the capability tmux stores emits `E]52;…` as literal text
+  // instead of an OSC 52 sequence. Measured on tmux 3.6a.
+  `set -ag terminal-overrides '${OSC52_MS_OVERRIDE}'`,
 ];
+
+export type MsOverridePlan = { kind: "ok" } | { kind: "append" } | { kind: "replace"; index: number };
+
+// What a RUNNING server's `show -g terminal-overrides` says we must do to get a working
+// `Ms`. Its own function because the repair case only exists for servers that stored the
+// double-quoted (broken) value before this was fixed, and that is not reachable from a
+// test without standing up a tmux server.
+//
+// tmux prints one `terminal-overrides[N] value` line per entry and doubles each stored
+// backslash, so a correct entry shows as `Ms=\\E]52;` and the broken one as `Ms=E]52;`.
+export function planMsOverride(showStdout: string): MsOverridePlan {
+  for (const line of showStdout.split("\n")) {
+    const entry = /^terminal-overrides\[(\d+)\] (.*)$/.exec(line);
+    if (!entry) continue;
+    const [, index, value] = entry;
+    if (!value.includes("Ms=") || !value.includes("]52;")) continue; // someone else's override
+    return value.includes("Ms=\\\\E]52;") ? { kind: "ok" } : { kind: "replace", index: Number(index) };
+  }
+  return { kind: "append" };
+}
 
 // A fresh server sources CONF_FILE via `-f` on its first `new-session`, but a server
 // already running from persisted sessions ignores it — so apply the options that must be
 // live. Idempotent across node restarts: mouse/set-clipboard are plain global sets; the
-// Ms override is appended only when it isn't already present.
+// Ms override is appended when absent and rewritten in place when a previous version
+// stored the broken value (a server can outlive the upgrade that fixed it).
 function applyLiveTmuxOptions(): void {
   tmux(["set", "-g", "mouse", "on"]);
   tmux(["set", "-g", "set-clipboard", "on"]);
-  if (!tmux(["show", "-g", "terminal-overrides"]).stdout.includes("Ms=")) {
-    tmux(["set", "-ag", "terminal-overrides", OSC52_MS_OVERRIDE]);
-  }
+  const plan = planMsOverride(tmux(["show", "-g", "terminal-overrides"]).stdout);
+  if (plan.kind === "append") tmux(["set", "-ag", "terminal-overrides", OSC52_MS_OVERRIDE]);
+  if (plan.kind === "replace") tmux(["set", "-g", `terminal-overrides[${plan.index}]`, MS_OVERRIDE_ENTRY]);
 }
 
 // The two line shapes `show-environment` emits. Anything else continues the

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -6,6 +6,8 @@ import {
   isResumableTmuxSession,
   parseTmuxEnvironment,
   parseAttachedClientCount,
+  planMsOverride,
+  MS_OVERRIDE_ENTRY,
 } from "../../../server/infra/tmux";
 
 describe("tmuxSessionName", () => {
@@ -46,6 +48,43 @@ describe("TMUX_CONF_LINES", () => {
   it("forwards OSC 52 to the outer terminal (Claude's auto-copy → browser clipboard)", () => {
     expect(TMUX_CONF_LINES).toContain("set -g set-clipboard on");
     expect(TMUX_CONF_LINES.some((l) => l.includes("terminal-overrides") && l.includes("Ms="))).toBe(true);
+  });
+
+  // Regression (#740): with DOUBLE quotes tmux escape-processes the value while parsing the
+  // conf — `\E` becomes a bare `E` and `\007` a raw BEL — so the stored capability emits
+  // `E]52;…` as literal text and the clipboard write never happens. Measured on tmux 3.6a.
+  it("single-quotes the Ms override so tmux stores `\\E` rather than eating it", () => {
+    const line = TMUX_CONF_LINES.find((l) => l.includes("Ms="));
+    expect(line).toBe(`set -ag terminal-overrides ',${MS_OVERRIDE_ENTRY}'`);
+    expect(line).not.toContain('"');
+    expect(MS_OVERRIDE_ENTRY).toContain("Ms=\\E]52;");
+  });
+});
+
+describe("planMsOverride", () => {
+  // Captured from a real `tmux -L … show -g terminal-overrides` on tmux 3.6a. tmux doubles
+  // each stored backslash on the way out, so a working entry reads `Ms=\\E]52;`.
+  const DEFAULT_ONLY = "terminal-overrides[0] linux*:AX@\n";
+  const WORKING = `${DEFAULT_ONLY}terminal-overrides[1] "*:Ms=\\\\E]52;%p1%s;%p2%s\\\\007"\n`;
+  const BROKEN = `${DEFAULT_ONLY}terminal-overrides[1] "*:Ms=E]52;%p1%s;%p2%s\\a"\n`;
+
+  it("appends when the server has no OSC 52 override yet", () => {
+    expect(planMsOverride(DEFAULT_ONLY)).toEqual({ kind: "append" });
+    expect(planMsOverride("")).toEqual({ kind: "append" });
+  });
+
+  it("leaves a correctly-stored override alone", () => {
+    expect(planMsOverride(WORKING)).toEqual({ kind: "ok" });
+  });
+
+  // A server started before #740 keeps the broken value for its whole life — rewriting that
+  // one index is the only way an upgrade reaches it.
+  it("rewrites the entry a pre-fix server stored with the escape eaten", () => {
+    expect(planMsOverride(BROKEN)).toEqual({ kind: "replace", index: 1 });
+  });
+
+  it("ignores overrides that are not ours", () => {
+    expect(planMsOverride("terminal-overrides[0] xterm*:XT\nterminal-overrides[1] screen*:Ms@\n")).toEqual({ kind: "append" });
   });
 });
 


### PR DESCRIPTION
## Summary

tmux 経由のセッションで Claude Code の自動コピー（OSC 52）がブラウザのクリップボードに届かず、代わりに `E]52;c;<base64>` という文字列がターミナルに表示される問題を修正。原因は `server/infra/tmux.ts` の conf 行がダブルクォートを使っていたこと。tmux がダブルクォート内でエスケープ処理を行い `\E` を素の `E` に、`\007` を生の BEL に変換していた。

## Items to Confirm / Review

- **実 tmux で検証済み**: tmux 3.6a に修正後 conf を読ませ、`terminal-overrides[1] "*:Ms=\\E]52;..."` が正しく保存されることをエンドツーエンドで確認。ダブルクォート／シングルクォート／argv 直渡しの3経路で保存値を比較した結果に基づく。
- **既存サーバの自動修復**: `planMsOverride` は、このfix以前に起動して壊れた値を保存済みの tmux サーバに対し、インデックス指定 set (`terminal-overrides[N]`) で該当エントリのみ書き換える。tmux がこの部分更新をサポートすることも実機確認済み。ここは実サーバ相手のパスでユニットテストから到達できないため、判定ロジック `planMsOverride` を純粋関数に切り出してテストしている。
- 旧ガード `includes("Ms=")` は壊れた値 `Ms=E]...` にもマッチして再適用をスキップしていたため自動修復されなかった。`planMsOverride` の判定に置き換えている。

## User Prompt

> mulmoclaude で全ファイルをレビューして pure 関数化できる部分は関数化しつつバグを探したら結構なバグがあったんだけど、こっちでもできる？

全ファイルレビュー（マルチエージェント）で検出したバグを issue 化し（#740〜#748）、順に対応・CI・レビュー対応・マージまで進める依頼のうちの1件。

## 原因の詳細

| 書き方 | tmux が保存する値 | 判定 |
|---|---|---|
| ダブルクォート（旧） | `*:Ms=E]52;%p1%s;%p2%s<BEL>` | 壊れ |
| シングルクォート（新） | `*:Ms=\E]52;%p1%s;%p2%s\007` | 正 |
| argv 直渡し（live パス） | `*:Ms=\E]52;%p1%s;%p2%s\007` | 正 |

初回起動（tmux サーバ未起動）は必ず conf を経由するため、標準的な使い方でこの経路に入る。

## テスト

- conf 行がシングルクォートでダブルクォートを含まないこと（回帰。ダブルクォートに戻すと落ちることを確認）
- `planMsOverride`: append / ok / replace / 他人の override 無視 を実 tmux 出力フィクスチャで固定

関連: #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)