### PR TITLE
fix: config.json が壊れていると次の設定保存で全設定が消える (#741)

### DIFF
--- a/plans/fix-741-config-corrupt-wipe.md
+++ b/plans/fix-741-config-corrupt-wipe.md
@@ -1,0 +1,45 @@
+# fix: config.json が壊れていると次の設定保存で全設定が消える（#741）
+
+## User Prompt
+
+> mulmoclaude で全ファイルをレビューして…（略）バグを issue 化し、順に対応・CI・レビュー対応・マージまで進める
+
+## 症状
+
+`~/.mulmoterminal/config.json` が壊れている（手編集で余計なカンマが入った等）と、
+設定 UI で何か 1 項目を保存した瞬間に presets / launchers / providers / buttons / chips / userMcpServers が全部消える。
+バックアップも取られず、エラー表示も出ない。
+
+## 原因
+
+`loadAppConfig` が JSON パース失敗を catch して `emptyConfig()` を返す（＝「ファイル不在」と区別できない）。
+`config-routes.ts` の POST ハンドラと `cli-init.ts` はこれを `mergeConfigUpdate` のベースに使うため、
+破損時は空のベースに body をマージして書き戻し、省略フィールドが全て空で確定する。
+
+## 修正（決定を pure 関数に、I/O は呼び出し側）
+
+`server/config/app-config.ts`:
+- `sanitizeAppConfig(raw)` を pure 関数として切り出し（旧 `loadAppConfig` の中身）。
+- `loadAppConfigResult(file): { status: "ok" | "missing" | "corrupt" }` を追加。
+  「不在」と「破損」を区別する。書き込み経路はこれを使う。
+- `loadAppConfig` は `loadAppConfigResult` の薄いラッパに（不在・破損とも空を返す寛容ロード。
+  boot の読み取り専用用途はクラッシュさせない）。既存シグネチャ・挙動は維持。
+- `backupCorruptConfig(file)` を追加。破損ファイルを `config.json.corrupt.bak` に退避（best-effort）。
+
+`server/config/config-routes.ts`（POST /api/config）:
+- `loadAppConfigResult` で読み、`corrupt` なら退避して 409 を返し**上書きしない**。
+- `ok`/`missing` の場合のみ従来どおり merge → save。
+
+`server/cli-init.ts`（プリセット seeding）:
+- 同じハザードがあるため、`corrupt` なら書き込まず exit 1。
+
+## テスト
+
+`test/server/config/app-config.spec.ts`:
+- `loadAppConfigResult`: missing / corrupt / ok を区別すること。
+- `backupCorruptConfig`: 退避コピーができること、失敗時 null。
+- #741 シナリオ: 正常ベースは pushEnabled のみ更新で全フィールド保持。
+  破損ベースは merge の**前に**検出される（旧寛容ロードだと空ベースで全消しになることも同テストで証明）。
+
+破損を missing 扱いに変えるミューテーションでシナリオテストが赤になることを確認済み。
+全 3539 テストパス。

--- a/server/cli-init.ts
+++ b/server/cli-init.ts
@@ -6,7 +6,7 @@
 import { statSync, readdirSync, openSync, readSync, closeSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { loadAppConfig, loadAppConfigResult, mergeConfigUpdate, saveAppConfig } from "./config/app-config.js";
+import { loadAppConfigResult, emptyConfig, mergeConfigUpdate, saveAppConfig } from "./config/app-config.js";
 import { deriveCwdPresets, extractCwdFromTranscript, type CwdRecord } from "./config/cwd-presets.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
@@ -90,11 +90,15 @@ function main(): void {
   }
   // Refuse to overwrite a config we couldn't parse: seeding presets onto an empty base
   // would wipe the user's existing launchers/providers/etc. (same hazard as POST /api/config).
-  if (loadAppConfigResult(CONFIG_FILE).status === "corrupt") {
+  // Read ONCE and reuse — a second load could race a concurrent write turning the file
+  // corrupt between the check and the merge.
+  const loaded = loadAppConfigResult(CONFIG_FILE);
+  if (loaded.status === "corrupt") {
     console.error(`\x1b[31m[init]\x1b[0m ${CONFIG_FILE} is unreadable — fix or remove it before seeding presets. No changes written.`);
     process.exit(1);
   }
-  const next = mergeConfigUpdate(loadAppConfig(CONFIG_FILE), { cwdPresets: presets });
+  const base = loaded.status === "ok" ? loaded.config : emptyConfig();
+  const next = mergeConfigUpdate(base, { cwdPresets: presets });
   if (!saveAppConfig(CONFIG_FILE, next)) {
     console.error(`\x1b[31m[init]\x1b[0m Failed to write ${CONFIG_FILE}`);
     process.exit(1);

--- a/server/cli-init.ts
+++ b/server/cli-init.ts
@@ -6,7 +6,7 @@
 import { statSync, readdirSync, openSync, readSync, closeSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { loadAppConfig, mergeConfigUpdate, saveAppConfig } from "./config/app-config.js";
+import { loadAppConfig, loadAppConfigResult, mergeConfigUpdate, saveAppConfig } from "./config/app-config.js";
 import { deriveCwdPresets, extractCwdFromTranscript, type CwdRecord } from "./config/cwd-presets.js";
 
 const CONFIG_FILE = path.join(os.homedir(), ".mulmoterminal", "config.json");
@@ -87,6 +87,12 @@ function main(): void {
     log(`[dry-run] Would set ${presets.length} working-directory preset(s) (no changes written):`);
     for (const p of presets) console.log(`    • ${p.path}`);
     return;
+  }
+  // Refuse to overwrite a config we couldn't parse: seeding presets onto an empty base
+  // would wipe the user's existing launchers/providers/etc. (same hazard as POST /api/config).
+  if (loadAppConfigResult(CONFIG_FILE).status === "corrupt") {
+    console.error(`\x1b[31m[init]\x1b[0m ${CONFIG_FILE} is unreadable — fix or remove it before seeding presets. No changes written.`);
+    process.exit(1);
   }
   const next = mergeConfigUpdate(loadAppConfig(CONFIG_FILE), { cwdPresets: presets });
   if (!saveAppConfig(CONFIG_FILE, next)) {

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -138,8 +138,10 @@ export function sanitizeWorklogIntervalHours(input: unknown): number {
 }
 
 // Fresh object each call — callers hold and mutate the returned config in place, so a
-// shared default constant would be corrupted across loads.
-const emptyConfig = (): AppConfig => ({
+// shared default constant would be corrupted across loads. Exported so a write path can
+// use it as the base for a MISSING file WITHOUT a second disk read (that re-read could
+// race a concurrent write turning the file corrupt between the two reads).
+export const emptyConfig = (): AppConfig => ({
   cwdPresets: [],
   soundFile: null,
   prRepos: [],

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -2,7 +2,7 @@
 // presets plus an optional custom attention-sound file. Unified read/write so a
 // partial update (e.g. just the sound) never clobbers the other field. Extracted
 // from config-routes.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets } from "./cwd-presets.js";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
@@ -164,25 +164,65 @@ export function sanitizeProviders(input: unknown): Provider[] {
   });
 }
 
-export function loadAppConfig(file: string): AppConfig {
+// Sanitize a parsed config object into an AppConfig. Pure; `raw` is whatever JSON.parse
+// produced (any shape), so every field is defended by its own sanitizer.
+function sanitizeAppConfig(raw: unknown): AppConfig {
+  const o = (raw ?? {}) as Record<string, unknown>;
+  return {
+    cwdPresets: sanitizePresets(o.cwdPresets),
+    soundFile: sanitizeSoundFile(o.soundFile),
+    prRepos: sanitizeRepos(o.prRepos),
+    launchers: sanitizeLaunchers(o.launchers),
+    userMcpServers: sanitizeUserMcpServers(o.userMcpServers),
+    buttons: sanitizeButtons(o.buttons),
+    chips: sanitizeChips(o.chips),
+    pushEnabled: sanitizePushEnabled(o.pushEnabled),
+    worklogEnabled: sanitizeWorklogEnabled(o.worklogEnabled),
+    worklogIntervalHours: sanitizeWorklogIntervalHours(o.worklogIntervalHours),
+    providers: sanitizeProviders(o.providers),
+  };
+}
+
+// "missing" and "corrupt" are DIFFERENT and a caller about to overwrite must tell them
+// apart: an absent file means "first run, start from empty"; an unparseable file means
+// "the user has real config here that we simply failed to read", where writing an empty
+// base back would silently erase presets/launchers/providers. loadAppConfig collapses
+// both to empty (safe for read-only boot); a WRITE path must use this instead.
+export type AppConfigLoad = { status: "ok"; config: AppConfig } | { status: "missing" } | { status: "corrupt"; error: string };
+
+export function loadAppConfigResult(file: string): AppConfigLoad {
+  if (!existsSync(file)) return { status: "missing" };
+  let text: string;
   try {
-    if (!existsSync(file)) return emptyConfig();
-    const raw = JSON.parse(readFileSync(file, "utf8"));
-    return {
-      cwdPresets: sanitizePresets(raw?.cwdPresets),
-      soundFile: sanitizeSoundFile(raw?.soundFile),
-      prRepos: sanitizeRepos(raw?.prRepos),
-      launchers: sanitizeLaunchers(raw?.launchers),
-      userMcpServers: sanitizeUserMcpServers(raw?.userMcpServers),
-      buttons: sanitizeButtons(raw?.buttons),
-      chips: sanitizeChips(raw?.chips),
-      pushEnabled: sanitizePushEnabled(raw?.pushEnabled),
-      worklogEnabled: sanitizeWorklogEnabled(raw?.worklogEnabled),
-      worklogIntervalHours: sanitizeWorklogIntervalHours(raw?.worklogIntervalHours),
-      providers: sanitizeProviders(raw?.providers),
-    };
+    text = readFileSync(file, "utf8");
+  } catch (err) {
+    return { status: "corrupt", error: `cannot read ${file}: ${String(err)}` };
+  }
+  try {
+    return { status: "ok", config: sanitizeAppConfig(JSON.parse(text)) };
+  } catch (err) {
+    return { status: "corrupt", error: `invalid JSON in ${file}: ${String(err)}` };
+  }
+}
+
+// Lenient load for read-only / boot callers: a missing OR unreadable file yields an empty
+// config so startup never crashes. Callers that then WRITE must NOT use this — see
+// loadAppConfigResult, or a corrupt file gets overwritten with the empty base.
+export function loadAppConfig(file: string): AppConfig {
+  const loaded = loadAppConfigResult(file);
+  return loaded.status === "ok" ? loaded.config : emptyConfig();
+}
+
+// Copy a corrupt config aside before refusing to overwrite it, so the user's unreadable-
+// but-real config isn't lost. Returns the backup path, or null if even the copy failed
+// (best-effort — the caller still refuses the write regardless).
+export function backupCorruptConfig(file: string): string | null {
+  const bak = `${file}.corrupt.bak`;
+  try {
+    copyFileSync(file, bak);
+    return bak;
   } catch {
-    return emptyConfig();
+    return null;
   }
 }
 

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -7,7 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
-import { loadAppConfig, saveAppConfig, mergeConfigUpdate, toPublicAppConfig, type AppConfig } from "./app-config.js";
+import { loadAppConfig, loadAppConfigResult, backupCorruptConfig, saveAppConfig, mergeConfigUpdate, toPublicAppConfig, type AppConfig } from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type Provider, type UserMcpServer } from "./config-schema.js";
 import { launchOptions } from "./launch-options.js";
@@ -87,7 +87,19 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
     // `config`, which may be stale (another mulmoterminal instance sharing this file
     // could have written since we booted). Using the stale copy for omitted fields
     // would clobber those edits (e.g. a chips-only POST wiping another's buttons).
-    const next = mergeConfigUpdate(loadAppConfig(CONFIG_FILE), body);
+    const loaded = loadAppConfigResult(CONFIG_FILE);
+    // A corrupt file is real config we merely failed to parse; merging the partial body
+    // onto an empty base would erase every omitted field. Back it up and refuse rather
+    // than overwrite (a single stray comma must not cost the user their whole config).
+    if (loaded.status === "corrupt") {
+      const bak = backupCorruptConfig(CONFIG_FILE);
+      const backupNote = bak ? ` (backed up to ${path.basename(bak)})` : "";
+      return res.status(409).json({
+        error: `config.json is unreadable and was NOT overwritten${backupNote}. Fix or remove it, then retry.`,
+      });
+    }
+    const base = loaded.status === "ok" ? loaded.config : loadAppConfig(CONFIG_FILE);
+    const next = mergeConfigUpdate(base, body);
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.
     if (!saveAppConfig(CONFIG_FILE, next)) return res.status(500).json({ error: "failed to persist config" });

--- a/server/config/config-routes.ts
+++ b/server/config/config-routes.ts
@@ -7,7 +7,16 @@ import os from "node:os";
 import path from "node:path";
 import { existsSync, statSync } from "node:fs";
 import type { Express } from "express";
-import { loadAppConfig, loadAppConfigResult, backupCorruptConfig, saveAppConfig, mergeConfigUpdate, toPublicAppConfig, type AppConfig } from "./app-config.js";
+import {
+  loadAppConfig,
+  loadAppConfigResult,
+  backupCorruptConfig,
+  emptyConfig,
+  saveAppConfig,
+  mergeConfigUpdate,
+  toPublicAppConfig,
+  type AppConfig,
+} from "./app-config.js";
 import { type HeaderConfig } from "./header-config.js";
 import { type Launcher, type Provider, type UserMcpServer } from "./config-schema.js";
 import { launchOptions } from "./launch-options.js";
@@ -98,7 +107,11 @@ export function mountConfigRoutes(app: Express, claudeCwd: string): void {
         error: `config.json is unreadable and was NOT overwritten${backupNote}. Fix or remove it, then retry.`,
       });
     }
-    const base = loaded.status === "ok" ? loaded.config : loadAppConfig(CONFIG_FILE);
+    // status is "ok" or "missing" here (corrupt returned above). Use the config we already
+    // read, or a fresh empty base for a missing file — NOT a second loadAppConfig() read,
+    // which could race a concurrent write turning the file corrupt between the two reads and
+    // silently merge onto empty.
+    const base = loaded.status === "ok" ? loaded.config : emptyConfig();
     const next = mergeConfigUpdate(base, body);
     // Stage, persist, commit in-memory only on success — a failed write must not
     // leave GET exposing values that won't survive a restart.

--- a/test/server/config/app-config.spec.ts
+++ b/test/server/config/app-config.spec.ts
@@ -12,6 +12,7 @@ import {
   loadAppConfig,
   loadAppConfigResult,
   backupCorruptConfig,
+  emptyConfig,
   saveAppConfig,
   mergeConfigUpdate,
   type AppConfig,
@@ -227,6 +228,19 @@ describe("loadAppConfigResult (missing vs corrupt vs ok)", () => {
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }], pushEnabled: true }));
     const loaded = loadAppConfigResult(file);
     expect(loaded).toMatchObject({ status: "ok", config: { cwdPresets: [{ label: "a", path: "/a" }], pushEnabled: true } });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // The write path uses emptyConfig() as the base for a MISSING file instead of a second
+  // loadAppConfig() read (which could race a concurrent write turning it corrupt in between).
+  // A missing-file merge must therefore behave exactly like merging onto empty.
+  it("emptyConfig is a fresh default base equal to loading a missing file", () => {
+    const dir = tmp();
+    expect(emptyConfig()).toEqual(loadAppConfig(path.join(dir, "none.json")));
+    // fresh object each call (callers mutate in place)
+    expect(emptyConfig()).not.toBe(emptyConfig());
+    const merged = mergeConfigUpdate(emptyConfig(), { pushEnabled: true });
+    expect(merged).toEqual({ ...emptyConfig(), pushEnabled: true });
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/test/server/config/app-config.spec.ts
+++ b/test/server/config/app-config.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -10,6 +10,8 @@ import {
   sanitizePushEnabled,
   sanitizeWorklogIntervalHours,
   loadAppConfig,
+  loadAppConfigResult,
+  backupCorruptConfig,
   saveAppConfig,
   mergeConfigUpdate,
   type AppConfig,
@@ -185,7 +187,7 @@ describe("loadAppConfig / saveAppConfig", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("returns defaults for invalid JSON", () => {
+  it("returns defaults for invalid JSON (lenient boot load)", () => {
     const dir = tmp();
     const file = path.join(dir, "bad.json");
     writeFileSync(file, "{ not json");
@@ -198,6 +200,103 @@ describe("loadAppConfig / saveAppConfig", () => {
     const file = path.join(dir, "config.json");
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }] }));
     expect(loadAppConfig(file)).toEqual({ ...base, cwdPresets: [{ label: "a", path: "/a" }] });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("loadAppConfigResult (missing vs corrupt vs ok)", () => {
+  it("reports a missing file as missing, not corrupt", () => {
+    const dir = tmp();
+    expect(loadAppConfigResult(path.join(dir, "none.json"))).toEqual({ status: "missing" });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reports unparseable JSON as corrupt (distinct from missing)", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    // A single trailing comma — the realistic hand-edit that triggered #741.
+    writeFileSync(file, '{ "pushEnabled": true, }');
+    const loaded = loadAppConfigResult(file);
+    expect(loaded.status).toBe("corrupt");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns the sanitized config for a good file", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }], pushEnabled: true }));
+    const loaded = loadAppConfigResult(file);
+    expect(loaded).toMatchObject({ status: "ok", config: { cwdPresets: [{ label: "a", path: "/a" }], pushEnabled: true } });
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("backupCorruptConfig", () => {
+  it("copies the unreadable file aside so it isn't lost when the caller refuses the write", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, "{ not json");
+    const bak = backupCorruptConfig(file);
+    expect(bak).toBe(`${file}.corrupt.bak`);
+    expect(bak && readFileSync(bak, "utf8")).toBe("{ not json");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns null (best-effort) when the source can't be copied", () => {
+    const dir = tmp();
+    expect(backupCorruptConfig(path.join(dir, "does-not-exist.json"))).toBeNull();
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// The core #741 hazard as a scenario test: a corrupt file must not become the empty base
+// that a merge writes back. This is what a POST /api/config write path must do.
+describe("#741 corrupt config is not silently wiped by a partial update", () => {
+  const richConfig = {
+    cwdPresets: [{ label: "proj", path: "/proj" }],
+    soundFile: null,
+    prRepos: ["o/r"],
+    launchers: [{ label: "Shell", command: "$SHELL" }],
+    userMcpServers: [{ id: "weather", url: "http://localhost:9000/mcp" }],
+    buttons: null,
+    chips: null,
+    pushEnabled: false,
+    worklogEnabled: false,
+    worklogIntervalHours: 6,
+    providers: [],
+  };
+
+  it("a valid base keeps every omitted field through a pushEnabled-only update", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    saveAppConfig(file, richConfig);
+    const loaded = loadAppConfigResult(file);
+    expect(loaded.status).toBe("ok");
+    const base = loaded.status === "ok" ? loaded.config : loadAppConfig(file);
+    const next = mergeConfigUpdate(base, { pushEnabled: true });
+    expect(next).toEqual({ ...richConfig, pushEnabled: true });
+    expect(next.cwdPresets).toEqual(richConfig.cwdPresets);
+    expect(next.launchers).toEqual(richConfig.launchers);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("a corrupt base is caught BEFORE merge, so the write path can refuse instead of wiping", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    saveAppConfig(file, richConfig);
+    // Corrupt it the way a hand-edit would (append a stray token).
+    writeFileSync(file, readFileSync(file, "utf8") + "  oops");
+    const loaded = loadAppConfigResult(file);
+    expect(loaded.status).toBe("corrupt");
+    // The write path refuses here — but if it had fallen through to the OLD lenient load,
+    // the merge base would have been empty and every rich field erased. Prove that gap:
+    const wipedBase = loadAppConfig(file); // lenient path returns empty on corrupt
+    const wouldWipe = mergeConfigUpdate(wipedBase, { pushEnabled: true });
+    expect(wouldWipe.cwdPresets).toEqual([]); // <- the regression the fix prevents
+    expect(wouldWipe.launchers).toEqual([]);
+    // And the corrupt file can be preserved rather than lost.
+    const bak = backupCorruptConfig(file);
+    expect(bak && existsSync(bak)).toBe(true);
     rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

`~/.mulmoterminal/config.json` にパースエラー（手編集で余計なカンマが入った等）があると、設定 UI で 1 項目保存しただけで presets / launchers / providers / buttons / chips / userMcpServers が全て消える問題を修正。原因は `loadAppConfig` が JSON パース失敗を「ファイル不在」と同じ空 config として返し、POST ハンドラと CLI seeder がそれを `mergeConfigUpdate` のベースにして書き戻していたこと。

## Items to Confirm / Review

- **「不在」と「破損」を区別**: 新設 `loadAppConfigResult` が `ok` / `missing` / `corrupt` を返す。書き込み経路（`POST /api/config`、`cli-init`）はこれを使い、`corrupt` の場合は **上書きせず** `config.json.corrupt.bak` に退避して 409（CLI は exit 1）を返す。
- **既存挙動の維持**: `loadAppConfig` は寛容ロードのまま（不在・破損とも空を返す）で boot の読み取り専用用途をクラッシュさせない。シグネチャ変更なし。既存テスト「returns defaults for invalid JSON」も維持（意図を明示するためテスト名だけ更新）。
- **テスト観点**: #741 のハザードをシナリオテストで固定。破損ベースが merge の前に検出されること、そして「もし旧寛容ロードのまま merge に渡していたら空ベースで全消しになる」ギャップも同テスト内で証明。破損を missing 扱いにするミューテーションで赤になることを確認済み。
- `.corrupt.bak` というバックアップ命名で問題ないか（既存の good なバックアップは上書きしない別名）。

## User Prompt

> mulmoclaude で全ファイルをレビューして pure 関数化できる部分は関数化しつつバグを探したら結構なバグがあったんだけど、こっちでもできる？

全ファイルレビュー（マルチエージェント）で検出したバグの issue 化（#740〜#748）と、順次の対応・マージ依頼のうちの1件。

## 変更

- `server/config/app-config.ts`: `sanitizeAppConfig`（pure 切り出し）/ `loadAppConfigResult` / `backupCorruptConfig` を追加、`loadAppConfig` を薄いラッパ化。
- `server/config/config-routes.ts`: POST で破損検出 → 退避 → 409。
- `server/cli-init.ts`: 破損時は書き込まず exit 1。
- `test/server/config/app-config.spec.ts`: 上記のテストを追加（全 3539 テストパス）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)