### PR TITLE
fix: a file dropped anywhere no longer navigates the page away

### DIFF
--- a/plans/fix-file-drop-navigation.md
+++ b/plans/fix-file-drop-navigation.md
@@ -1,0 +1,33 @@
+# fix: ファイル D&D でページごと画像に遷移する (#750)
+
+## 原因
+
+ブラウザはファイルをページに落とすと既定でそのファイルを開く（遷移）。止めるには
+dragover と drop の両方で preventDefault を、ドロップされうる全領域で呼ぶ必要があるが、
+現状は `Terminal.vue` のターミナル本体 div だけに付いており、外側（ヘッダー・隙間・背景）に
+「うっかり」落とすと遷移していた。加えて `onDrop` は preventDefault の前に return する枝が
+あり、Chrome ではパスが取れず無言で何も起きなかった。
+
+## 修正
+
+1. **window レベルのガード**（`src/composables/useFileDropGuard.ts` の `installFileDropGuard`）を
+   `main.ts` で 1 回インストール。ファイルドラッグ（`dragCarriesFiles` = types に "Files"）の
+   dragover / drop を preventDefault し、どこに落としても遷移しない。ターミナル本体のハンドラは
+   バブリングで先に走るのでパス挿入のハッピーパスは維持。in-app のドラッグ（"Files" を含まない）は
+   素通し。
+2. **`onDrop` を修正**: 判定を `dragCarriesFiles` に統一し preventDefault を確実化。パスが取れた
+   ときは挿入、取れなかったとき（Chrome 等）は **📎 ボタン（Insert a file path）を使うよう促す
+   一時ヒント**を表示。
+3. ヒント文言は `translateUiSentence`（`src/utils/translateUi.ts`、AbortController タイムアウト付き）で
+   ランタイム翻訳（このホストは静的 i18n を持たない）。
+
+## テスト
+
+- `dragCarriesFiles` の純関数テスト（dropPaths.spec）。
+- `installFileDropGuard`: fake target で preventDefault の呼び出し/非呼び出し/teardown、
+  さらに**実 window** に cancelable な drop を dispatch して `defaultPrevented` を検証。
+- `translateUiSentence`: en は無 fetch、非 en は翻訳、失敗系は英語フォールバック。
+
+## 非対象
+
+- #729/#737 の選択・ホイール系には触れない。

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -3,7 +3,8 @@ import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watc
 import { type ITheme } from "@xterm/xterm";
 import { FLIP_MS, shouldRefocusOnZoomChange } from "./cellFlip";
 import { terminalManagesAttention, terminalViewActive } from "./terminalViewActive";
-import { dropTextFromUriList } from "./dropPaths";
+import { dragCarriesFiles, dropTextFromUriList } from "./dropPaths";
+import { translateUiSentence } from "../utils/translateUi";
 import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
 import { badgeStyleFor } from "./dirBadge";
 import { terminalHeaderStyleFor } from "./cellHeaderStyle";
@@ -309,21 +310,39 @@ function insertText(text: string) {
 // Drop a file onto the terminal to insert its absolute path, like a native
 // terminal. Browsers expose the real path only via the drag's file:// URIs
 // (text/uri-list); the File object hides it. Browsers that withhold the path
-// (e.g. Chrome) yield no URIs, so we insert nothing rather than a wrong string —
-// the file-picker button is the path-in-Chrome route.
+// (e.g. Chrome) yield no URIs — instead of silently inserting nothing, point the
+// user at the 📎 file-picker button, which is the path-in-Chrome route.
 function onDrop(e: DragEvent) {
   dragOver.value = false;
   const dt = e.dataTransfer;
-  if (!dt || dt.files.length === 0) return; // not a file drop — leave text drags alone
+  if (!dt || !dragCarriesFiles(dt.types)) return; // not a file drop — leave text drags alone
   e.preventDefault();
-  insertText(dropTextFromUriList(dt.getData("text/uri-list") || dt.getData("text/plain")));
+  const text = dropTextFromUriList(dt.getData("text/uri-list") || dt.getData("text/plain"));
+  if (text) insertText(text);
+  else showDropHint();
 }
 
 function onDragOver(e: DragEvent) {
-  if (!e.dataTransfer?.types.includes("Files")) return;
+  if (!e.dataTransfer || !dragCarriesFiles(e.dataTransfer.types)) return;
   e.preventDefault(); // required for the drop event to fire
   dragOver.value = true;
 }
+
+// Shown when a file was dropped but the browser withheld its path — the drop can't
+// do anything, so tell the user to use the 📎 button (whose tooltip explains it)
+// rather than leaving the failed drop looking like nothing happened.
+const DROP_HINT_EN = "This browser doesn't share a dropped file's path. Use the 📎 button in the header (Insert a file path) instead.";
+const dropHint = ref(false);
+const dropHintText = ref(DROP_HINT_EN);
+const DROP_HINT_MS = 6000;
+let dropHintTimer: ReturnType<typeof setTimeout> | undefined;
+async function showDropHint() {
+  dropHint.value = true;
+  clearTimeout(dropHintTimer);
+  dropHintTimer = setTimeout(() => (dropHint.value = false), DROP_HINT_MS);
+  if (dropHintText.value === DROP_HINT_EN) dropHintText.value = await translateUiSentence(DROP_HINT_EN, "mulmoterminal-ui");
+}
+onUnmounted(() => clearTimeout(dropHintTimer));
 
 onUnmounted(() => {
   resizeObserver?.disconnect();
@@ -336,7 +355,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-base">
+  <div class="relative flex h-full min-h-0 min-w-0 flex-1 flex-col bg-base">
     <div
       v-if="!hideHeader"
       class="flex items-center gap-3 bg-[var(--cell-header-bg,var(--bg-panel))] px-4 py-2 font-sans text-[14px] text-[var(--cell-header-fg,var(--text))]"
@@ -393,6 +412,21 @@ onUnmounted(() => {
       @dragleave="dragOver = false"
       @drop="onDrop"
     />
+    <Transition
+      enter-active-class="transition-opacity duration-200 ease-[ease]"
+      leave-active-class="transition-opacity duration-200 ease-[ease]"
+      enter-from-class="opacity-0"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="dropHint"
+        class="pointer-events-none absolute bottom-3 left-1/2 z-20 flex max-w-[min(90%,560px)] -translate-x-1/2 items-center gap-2 rounded-lg border-2 border-[#c98a00] bg-[#ffd54a] px-4 py-2.5 font-sans text-[13px] font-semibold leading-[1.4] text-[#1a1a2e] shadow-[0_4px_16px_rgba(0,0,0,0.45)]"
+        role="status"
+      >
+        <span class="material-symbols-outlined shrink-0 text-[18px]" aria-hidden="true">attach_file</span>
+        <span>{{ dropHintText }}</span>
+      </div>
+    </Transition>
   </div>
 </template>
 

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -15,7 +15,7 @@ import RunMenu from "./RunMenu.vue";
 import SkillMenu from "./SkillMenu.vue";
 import { skillSeed } from "./skillSeed";
 import GitBranchChip from "./GitBranchChip.vue";
-import { useHeaderButtons, type HeaderButton } from "../composables/useHeaderButtons";
+import { useHeaderButtons, hasPickFileButton, type HeaderButton } from "../composables/useHeaderButtons";
 import { useSessionContext } from "../composables/useSessionContext";
 import { runHeaderButton } from "../composables/useHeaderAction";
 import type { RunCommand } from "./runCommand";
@@ -328,19 +328,25 @@ function onDragOver(e: DragEvent) {
   dragOver.value = true;
 }
 
-// Shown when a file was dropped but the browser withheld its path — the drop can't
-// do anything, so tell the user to use the 📎 button (whose tooltip explains it)
-// rather than leaving the failed drop looking like nothing happened.
-const DROP_HINT_EN = "This browser doesn't share a dropped file's path. Use the 📎 button in the header (Insert a file path) instead.";
+// Shown when a file was dropped but the browser withheld its path — the drop can't do
+// anything, so tell the user how to insert the path rather than leaving the failed drop
+// looking like nothing happened. The guidance depends on the header: point at the 📎 picker
+// only when it's actually present (buttons are configurable and it can be removed), otherwise
+// fall back to advice that always holds.
+const DROP_HINT_PICKER_EN = "This browser doesn't share a dropped file's path. Use the 📎 button in the header (Insert a file path) instead.";
+const DROP_HINT_TYPE_EN = "This browser doesn't share a dropped file's path — type or paste the path instead.";
 const dropHint = ref(false);
-const dropHintText = ref(DROP_HINT_EN);
+const dropHintText = ref("");
 const DROP_HINT_MS = 6000;
 let dropHintTimer: ReturnType<typeof setTimeout> | undefined;
 async function showDropHint() {
+  const english = hasPickFileButton(headerButtons.value) ? DROP_HINT_PICKER_EN : DROP_HINT_TYPE_EN;
+  dropHintText.value = english; // show immediately; the translation (server-cached) swaps in
   dropHint.value = true;
   clearTimeout(dropHintTimer);
   dropHintTimer = setTimeout(() => (dropHint.value = false), DROP_HINT_MS);
-  if (dropHintText.value === DROP_HINT_EN) dropHintText.value = await translateUiSentence(DROP_HINT_EN, "mulmoterminal-ui");
+  const translated = await translateUiSentence(english, "mulmoterminal-ui");
+  if (dropHint.value) dropHintText.value = translated; // ignore if it resolved after the hint hid
 }
 onUnmounted(() => clearTimeout(dropHintTimer));
 

--- a/src/components/dropPaths.ts
+++ b/src/components/dropPaths.ts
@@ -43,3 +43,12 @@ export function toInsertText(paths: string[]): string {
 export function dropTextFromUriList(uriList: string): string {
   return toInsertText(parseFileUris(uriList));
 }
+
+// A drag carries external files when its type list includes the "Files" sentinel.
+// Internal element drags (custom types / plain text) don't, so anything keyed on this
+// intercepts only file drops — the window-level navigation guard never swallows an
+// in-app drag. `types` is a DataTransfer.types (available during dragover, when
+// `.files` is still empty).
+export function dragCarriesFiles(types: readonly string[]): boolean {
+  return types.includes("Files");
+}

--- a/src/composables/useFileDropGuard.ts
+++ b/src/composables/useFileDropGuard.ts
@@ -1,0 +1,24 @@
+import { dragCarriesFiles } from "../components/dropPaths";
+
+// A file dropped onto the page navigates the whole tab to that file by default —
+// losing every live session. The terminal body turns a file drop into an inserted
+// path, but an imprecise ("うっかり") drop lands outside it — the header, a gutter,
+// the background — where nothing stops the browser. This window-level net
+// preventDefaults every file drag anywhere, so no drop can navigate; the terminal's
+// own handler runs first (events bubble child→window) and still inserts the path on
+// the happy path. Gated on dragCarriesFiles so it only touches external file drags,
+// never an in-app element drag.
+type DragTarget = Pick<Window, "addEventListener" | "removeEventListener">;
+
+export function installFileDropGuard(target: DragTarget = window): () => void {
+  const guard = (event: Event) => {
+    const dt = (event as DragEvent).dataTransfer;
+    if (dt && dragCarriesFiles(dt.types)) event.preventDefault();
+  };
+  target.addEventListener("dragover", guard);
+  target.addEventListener("drop", guard);
+  return () => {
+    target.removeEventListener("dragover", guard);
+    target.removeEventListener("drop", guard);
+  };
+}

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -26,6 +26,13 @@ export interface HeaderButton {
 }
 export type ResolvedChip = { kind: "builtin"; id: string } | { kind: "custom"; label: string; text: string };
 
+// Whether the resolved header offers a file-path picker (an `open` button with `pickFile`).
+// Header buttons are user-configurable and the default picker can be removed, so anything that
+// points the user at "the 📎 button" must first confirm it is actually present.
+export function hasPickFileButton(buttons: readonly HeaderButton[]): boolean {
+  return buttons.some((b) => b.run === "open" && b.open?.pickFile === true);
+}
+
 interface Params {
   cwd: Ref<string | null>;
   session: Ref<string | null>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,12 +8,18 @@ import "./composables/collectionUi";
 // locale) once, before any manageAccounting card mounts.
 import "./composables/accountingUi";
 import { initTheme } from "./composables/useTheme";
+import { installFileDropGuard } from "./composables/useFileDropGuard";
 import { router } from "./router";
 import App from "./App.vue";
 
 // Apply the persisted theme to <html> before mount so there's no flash of the
 // default palette.
 initTheme();
+
+// Catch a file dropped anywhere in the tab so an imprecise drop can't navigate the
+// page to the file and lose every session. Installed on window, before mount, so it
+// covers both views and any area between them.
+installFileDropGuard();
 
 // Mount only AFTER the router's initial (async) navigation resolves. On a hard
 // reload / deep-link to /terminals, mounting eagerly would first render the single

--- a/src/utils/translateUi.ts
+++ b/src/utils/translateUi.ts
@@ -1,0 +1,30 @@
+import { browserLocale } from "./browserLocale";
+
+const REQUEST_TIMEOUT_MS = 8000;
+
+// Localize one English host string via the same runtime-translation route the
+// collection UX uses (the mulmoterminal host ships no static i18n). Returns the
+// English input unchanged for an English locale, and on any failure — so a caller
+// can assign the result unconditionally. Translated strings are server-cached, so
+// the first call per sentence is the only slow one.
+export async function translateUiSentence(english: string, namespace: string): Promise<string> {
+  const locale = browserLocale();
+  if (locale === "en") return english;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch("/api/translation", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ namespace, targetLanguage: locale, sentences: [english] }),
+      signal: controller.signal,
+    });
+    if (!res.ok) return english;
+    const data = (await res.json()) as { translations?: string[] };
+    return typeof data.translations?.[0] === "string" ? data.translations[0] : english;
+  } catch {
+    return english;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/test/src/components/dropPaths.spec.ts
+++ b/test/src/components/dropPaths.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseFileUris, toShellArg, toInsertText, dropTextFromUriList } from "../../../src/components/dropPaths.js";
+import { parseFileUris, toShellArg, toInsertText, dropTextFromUriList, dragCarriesFiles } from "../../../src/components/dropPaths.js";
 
 describe("parseFileUris", () => {
   it("parses a single file:// URI into an absolute path", () => {
@@ -73,5 +73,18 @@ describe("dropTextFromUriList", () => {
   it("returns empty string when no file path is present", () => {
     expect(dropTextFromUriList("")).toBe("");
     expect(dropTextFromUriList("https://example.com")).toBe("");
+  });
+});
+
+describe("dragCarriesFiles", () => {
+  it("is true when the type list includes the Files sentinel", () => {
+    expect(dragCarriesFiles(["Files"])).toBe(true);
+    expect(dragCarriesFiles(["text/plain", "text/uri-list", "Files"])).toBe(true);
+  });
+
+  it("is false for an in-app / text-only drag and an empty list", () => {
+    expect(dragCarriesFiles(["text/plain"])).toBe(false);
+    expect(dragCarriesFiles(["application/x-cell-reorder"])).toBe(false);
+    expect(dragCarriesFiles([])).toBe(false);
   });
 });

--- a/test/src/composables/useFileDropGuard.spec.ts
+++ b/test/src/composables/useFileDropGuard.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { installFileDropGuard } from "../../../src/composables/useFileDropGuard";
+
+// A minimal window double: records listeners so a test can fire them, and drops them
+// on removeEventListener so teardown is observable.
+function fakeTarget() {
+  const listeners = new Map<string, EventListener>();
+  return {
+    addEventListener: (type: string, fn: EventListener) => listeners.set(type, fn),
+    removeEventListener: (type: string, fn: EventListener) => {
+      if (listeners.get(type) === fn) listeners.delete(type);
+    },
+    fire: (type: string, dataTransfer: { types: string[] } | null) => {
+      const preventDefault = vi.fn();
+      listeners.get(type)?.({ dataTransfer, preventDefault } as unknown as Event);
+      return preventDefault;
+    },
+    has: (type: string) => listeners.has(type),
+  };
+}
+
+describe("installFileDropGuard", () => {
+  it("prevents the default on a file dragover and drop, so nothing navigates", () => {
+    const target = fakeTarget();
+    installFileDropGuard(target);
+    expect(target.fire("dragover", { types: ["Files"] })).toHaveBeenCalled();
+    expect(target.fire("drop", { types: ["text/uri-list", "Files"] })).toHaveBeenCalled();
+  });
+
+  it("leaves an in-app / text drag alone", () => {
+    const target = fakeTarget();
+    installFileDropGuard(target);
+    expect(target.fire("dragover", { types: ["text/plain"] })).not.toHaveBeenCalled();
+    expect(target.fire("drop", { types: ["application/x-cell-reorder"] })).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the event carries no dataTransfer", () => {
+    const target = fakeTarget();
+    installFileDropGuard(target);
+    expect(target.fire("drop", null)).not.toHaveBeenCalled();
+  });
+
+  it("removes both listeners on teardown", () => {
+    const target = fakeTarget();
+    const uninstall = installFileDropGuard(target);
+    uninstall();
+    expect(target.has("dragover")).toBe(false);
+    expect(target.has("drop")).toBe(false);
+  });
+
+  // The unit tests above assert preventDefault is CALLED; this drives the real window so the
+  // browser-observable effect — a cancelled event, i.e. no navigation — is what's verified.
+  it("cancels a real file drop dispatched on window (so the browser won't navigate)", () => {
+    const uninstall = installFileDropGuard(window);
+    const drop = new Event("drop", { cancelable: true, bubbles: true });
+    Object.defineProperty(drop, "dataTransfer", { value: { types: ["Files"] } });
+    window.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(true);
+
+    const textDrop = new Event("drop", { cancelable: true, bubbles: true });
+    Object.defineProperty(textDrop, "dataTransfer", { value: { types: ["text/plain"] } });
+    window.dispatchEvent(textDrop);
+    expect(textDrop.defaultPrevented).toBe(false);
+    uninstall();
+  });
+});

--- a/test/src/composables/useHeaderButtons.spec.ts
+++ b/test/src/composables/useHeaderButtons.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createApp, defineComponent, ref } from "vue";
 import { flushPromises } from "@vue/test-utils";
-import { useHeaderButtons } from "../../../src/composables/useHeaderButtons";
+import { useHeaderButtons, hasPickFileButton, type HeaderButton } from "../../../src/composables/useHeaderButtons";
 
 function withSetup<T>(composable: () => T): { result: T; unmount: () => void } {
   let result!: T;
@@ -34,5 +34,23 @@ describe("useHeaderButtons", () => {
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/api/header?"));
     expect(result.buttons.value.map((b) => b.id)).toEqual(["pr"]);
     unmount();
+  });
+});
+
+describe("hasPickFileButton", () => {
+  const btn = (over: Partial<HeaderButton>): HeaderButton => ({ id: "x", label: "x", run: "open", ...over });
+
+  it("is true when an open button carries pickFile", () => {
+    expect(hasPickFileButton([btn({ id: "pick", open: { pickFile: true } })])).toBe(true);
+    expect(hasPickFileButton([btn({ id: "url", open: { url: "https://x" } }), btn({ id: "pick", open: { pickFile: true } })])).toBe(true);
+  });
+
+  it("is false when the picker was configured away", () => {
+    expect(hasPickFileButton([btn({ id: "url", open: { url: "https://x" } }), btn({ id: "rev", open: { reveal: "${dir}" } })])).toBe(false);
+    expect(hasPickFileButton([])).toBe(false);
+  });
+
+  it("does not count a non-open button or pickFile:false", () => {
+    expect(hasPickFileButton([btn({ id: "sh", run: "shell" }), btn({ id: "p", open: { pickFile: false } })])).toBe(false);
   });
 });

--- a/test/src/utils/translateUi.spec.ts
+++ b/test/src/utils/translateUi.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { translateUiSentence } from "../../../src/utils/translateUi";
+
+const EN = "Use the button instead.";
+
+function setLocale(tag: string) {
+  vi.stubGlobal("navigator", { language: tag });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("translateUiSentence", () => {
+  it("returns the English input unchanged for an English locale, without fetching", () => {
+    setLocale("en-US");
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    return translateUiSentence(EN, "ns").then((out) => {
+      expect(out).toBe(EN);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("returns the server's translation for a non-English locale", async () => {
+    setLocale("ja");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ translations: ["ボタンを使ってください。"] }) }));
+    expect(await translateUiSentence(EN, "ns")).toBe("ボタンを使ってください。");
+  });
+
+  it("falls back to English when the request fails, is not ok, or returns no translation", async () => {
+    setLocale("ja");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+    expect(await translateUiSentence(EN, "ns")).toBe(EN);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    expect(await translateUiSentence(EN, "ns")).toBe(EN);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+    expect(await translateUiSentence(EN, "ns")).toBe(EN);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #750. Accidentally dropping a file onto the terminal navigated the whole tab to that file (an image), losing every live session.

**Root cause** (three gaps): the drop guard lived only on the terminal-body `div`, so an imprecise drop onto the header / a gutter / the background hit the browser default and navigated; `onDrop` also `return`ed before `preventDefault()` on the no-files branch; and when the browser withheld the path (Chrome) the drop silently inserted nothing.

**Fix:**
- **Window-level guard** (`installFileDropGuard`, wired once in `main.ts`): `preventDefault` on `dragover` + `drop` for file drags (types include `"Files"`), so a drop **anywhere** can't navigate. The terminal's own handler still runs first (events bubble child→window) and inserts the path on the happy path. In-app element drags (no `"Files"`) pass through untouched.
- **`onDrop`** now keys on `dragCarriesFiles`, always `preventDefault`s a file drop, inserts the path when available, and otherwise shows a **transient hint pointing at the 📎 "Insert a file path" button** — instead of failing silently on Chrome.
- Hint copy is localized via a new `translateUiSentence` helper (AbortController timeout; English fallback), since this host ships no static i18n.

## Items to Confirm / Review

- **Please try it in the app**: drop a file on the terminal body (path inserts on Firefox/Safari), on the header / empty gutter / page background (nothing navigates), and in Chrome (hint appears pointing to 📎). I verified the guard against a real jsdom `window` (`defaultPrevented`), not a live browser — the browser MCP wasn't loaded this session.
- The guard gates strictly on the `"Files"` type so it never swallows an in-app drag. Flag if any current in-app interaction uses native HTML5 file-type drags (I found only mouse-based splitter/reorder, not native DnD).
- The hint uses the same amber toast style as the existing draft hint, bottom-center over the terminal. Placement/wording open to taste.

## User Prompt

> うっかりターミナルにファイルをD&Dするとその画像に遷移するよね。一応D&Dはハンドルして、ブラウザでうけとれないから、tool tipのをつかうようにUIでおしえてあげて。issue化 → 着手！

## Implementation notes

- Plan: `plans/fix-file-drop-navigation.md`.
- New pure/tested units: `dragCarriesFiles` (dropPaths), `installFileDropGuard` (fake-target + real-window integration test), `translateUiSentence` (en no-fetch / translate / fallbacks). Full suite 3541 passed; format/lint/typecheck×2/build green by exit code.
- Out of scope: the #729/#737 selection & wheel handling (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
