### PR TITLE
fix: codex セッション状態追跡の取りこぼし（中断ターンで working が残る / 削除スキルのミラーが残る）(#742)

### DIFF
--- a/plans/fix-742-codex-activity-tracking.md
+++ b/plans/fix-742-codex-activity-tracking.md
@@ -1,0 +1,46 @@
+# fix: codex セッションの状態追跡の取りこぼし（#742）
+
+## User Prompt
+
+> mulmoclaude で全ファイルをレビューして…（略）バグを issue 化し、順に対応・CI・レビュー対応・マージまで進める
+
+## 1. 中断ターンで working フラグが残り続ける
+
+`turnBoundaries`（`server/agents/codex-activity.ts`）は `event_msg` の payload type のうち
+`task_started` と `task_complete` しか境界として扱っていなかった。
+
+実データ（`~/.codex/sessions`）で確認:
+- 400ファイル中の payload type 集計で `task_started` 540 / `task_complete` 512（差 28）/ `turn_aborted` 25。
+- 実際のロールアウトで、Esc 中断したターンは `task_started`(207) → `turn_aborted`(242) で
+  `task_complete` を書かないことを確認（`task_complete` の後に何も無い）。
+- 「エラー」で終わったターンは `task_complete` を出すので、影響は中断のみ。
+
+`codex-activity-track.ts` は `started` で working=true、`completed` でのみ解除するため、
+中断ターンは working のまま → スピナー回りっぱなし、完了 push 無し、`reapDecisionFor` が
+keep を返して切断済みセッションが回収されない。
+
+**修正**: `TURN_END_TYPES = { task_complete, turn_aborted }` を追加し、どちらも `completed` 境界にする。
+
+## 2. ワークスペースからスキルを削除しても codex 側のミラーが残る
+
+`syncCodexSkills`（`server/agents/codex-skills.ts`）は source に現存するディレクトリ名しか
+走査しないため、`.claude/skills` から消えたスキルの `$CODEX_HOME/skills/<name>`
+（`.mt-mirror` マーカー付き）が永久に残り、codex が削除済みスキルを読み続ける。
+
+**修正**: `removeOrphanedMirrors(destDir, keep)` を追加。
+dest 側を走査し、マーカーを持つ（＝ours）のに source に無いものを削除する。
+codex 自身のスキル（マーカー無し）は決して触らない。source ディレクトリごと消えた場合も
+全ミラーを orphan として削除。返り値に `removed: string[]` を追加。
+
+## テスト
+
+`test/server/agents/codex-activity.spec.ts`:
+- `turn_aborted` が completed 境界になること（回帰）。TURN_END_TYPES から外すと赤になることを確認。
+- 正常ターン→中断ターンの並び。
+
+`test/server/agents/codex-skills.spec.ts`:
+- source から消えた ours ミラーが削除される（回帰）。rmSync をスキップすると赤になることを確認。
+- codex 自身のスキル（マーカー無し）は削除しない。
+- source ディレクトリごと消えた場合に全 orphan を削除。
+
+全 typecheck / lint / 該当テストパス。

--- a/server/agents/codex-activity.ts
+++ b/server/agents/codex-activity.ts
@@ -46,13 +46,21 @@ function eventType(line: string): string | null {
   }
 }
 
+// The event_msg payload types that END a turn. `task_complete` is the normal finish;
+// `turn_aborted` is what an INTERRUPTED turn writes (Esc / steer) — verified against real
+// rollouts, where an aborted turn logs task_started … turn_aborted with NO task_complete.
+// An "error" turn still gets task_complete, so only interrupts rely on turn_aborted. Miss
+// it and the working flag set at task_started never clears: the spinner spins forever, no
+// "finished" push fires, and reapDecisionFor keeps the detached session alive.
+const TURN_END_TYPES = new Set(["task_complete", "turn_aborted"]);
+
 // The turn boundaries in these lines, oldest first. A turn that both starts and finishes
 // within one poll yields both, in order, so no transition is collapsed away.
 export function turnBoundaries(lines: string[]): CodexTurnBoundary[] {
   return lines.flatMap((line) => {
     const type = eventType(line);
     if (type === "task_started") return ["started" as const];
-    return type === "task_complete" ? ["completed" as const] : [];
+    return type !== null && TURN_END_TYPES.has(type) ? ["completed" as const] : [];
   });
 }
 

--- a/server/agents/codex-skills.ts
+++ b/server/agents/codex-skills.ts
@@ -17,18 +17,43 @@ export function codexSkillsRoot(): string {
 
 const isOurs = (dir: string): boolean => existsSync(path.join(dir, MIRROR_MARKER));
 
-// Mirror each skill dir from the workspace's .claude/skills into codex's skills dir (same SKILL.md
-// format), so codex loads them by description like claude does. Skips any name codex already owns
-// (no marker) to avoid clobbering codex's own skills; re-copies ours fresh so edits/removals in the
-// workspace propagate.
-export function syncCodexSkills(sourceDir: string, destDir: string): { mirrored: string[]; skipped: string[] } {
-  const mirrored: string[] = [];
-  const skipped: string[] = [];
-  if (!existsSync(sourceDir)) return { mirrored, skipped };
-  mkdirSync(destDir, { recursive: true });
-  const names = readdirSync(sourceDir, { withFileTypes: true })
+const directoryNames = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true })
     .filter((e) => e.isDirectory())
     .map((e) => e.name);
+
+// Delete mirrors we own (marker present) whose source skill is gone from the workspace, so
+// removing a skill from .claude/skills actually un-mirrors it from codex. Without this a
+// deleted skill's mirror survives every sync and codex keeps auto-loading it forever; the
+// claude side prunes retired skills for exactly this reason, and the two must not diverge.
+// Only marked dirs are touched — codex's own skills (no marker) are never removed.
+function removeOrphanedMirrors(destDir: string, keep: ReadonlySet<string>): string[] {
+  const removed: string[] = [];
+  for (const name of directoryNames(destDir)) {
+    if (keep.has(name)) continue;
+    const dst = path.join(destDir, name);
+    if (!isOurs(dst)) continue;
+    rmSync(dst, { recursive: true, force: true });
+    removed.push(name);
+  }
+  return removed;
+}
+
+// Mirror each skill dir from the workspace's .claude/skills into codex's skills dir (same SKILL.md
+// format), so codex loads them by description like claude does. Skips any name codex already owns
+// (no marker) to avoid clobbering codex's own skills; re-copies ours fresh so edits in the workspace
+// propagate; and deletes our mirrors whose source skill was removed, so a whole-skill deletion
+// propagates too (not just file removals inside a still-present skill).
+export function syncCodexSkills(sourceDir: string, destDir: string): { mirrored: string[]; skipped: string[]; removed: string[] } {
+  const mirrored: string[] = [];
+  const skipped: string[] = [];
+  if (!existsSync(sourceDir)) {
+    // Source gone entirely — every mirror we own is now orphaned.
+    const removed = existsSync(destDir) ? removeOrphanedMirrors(destDir, new Set()) : [];
+    return { mirrored, skipped, removed };
+  }
+  mkdirSync(destDir, { recursive: true });
+  const names = directoryNames(sourceDir);
   for (const name of names) {
     const dst = path.join(destDir, name);
     if (existsSync(dst) && !isOurs(dst)) {
@@ -40,7 +65,8 @@ export function syncCodexSkills(sourceDir: string, destDir: string): { mirrored:
     writeFileSync(path.join(dst, MIRROR_MARKER), "managed by mulmoterminal\n");
     mirrored.push(name);
   }
-  return { mirrored, skipped };
+  const removed = removeOrphanedMirrors(destDir, new Set(names));
+  return { mirrored, skipped, removed };
 }
 
 // codex has no /<slug> command (skills auto-load by description), so a collection chat seed

--- a/server/backends/workspaceSetup.ts
+++ b/server/backends/workspaceSetup.ts
@@ -91,6 +91,6 @@ export function initWorkspaceSetup(deps: { workspace: string }): void {
   // by description — codex has no /<slug> command, so a codex chat seed names the skill instead.
   safeStep("mirrorCodexSkills", () => {
     const result = syncCodexSkills(path.join(workspace, ".claude", "skills"), codexSkillsRoot());
-    log.info("mirrored skills to codex", { mirrored: result.mirrored.length, skipped: result.skipped.length });
+    log.info("mirrored skills to codex", { mirrored: result.mirrored.length, skipped: result.skipped.length, removed: result.removed.length });
   });
 }

--- a/test/server/agents/codex-activity.spec.ts
+++ b/test/server/agents/codex-activity.spec.ts
@@ -4,6 +4,7 @@ import { nextReadRange, takeCompleteLines, turnBoundaries, boundaryOutcome, HOOK
 const line = (o: unknown) => JSON.stringify(o);
 const started = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_started", turn_id: turnId } });
 const complete = (turnId = "t1") => line({ type: "event_msg", payload: { type: "task_complete", turn_id: turnId, last_agent_message: "done" } });
+const aborted = (turnId = "t1") => line({ type: "event_msg", payload: { type: "turn_aborted", turn_id: turnId, reason: "interrupted" } });
 const agentMessage = () => line({ type: "event_msg", payload: { type: "agent_message", message: "thinking" } });
 // A turn_context row carries a turn_id but no payload.type — the shape most likely to be
 // misread as a boundary.
@@ -62,6 +63,18 @@ describe("turnBoundaries", () => {
 
   it("reports several turns from one poll without collapsing any", () => {
     expect(turnBoundaries([started("t1"), complete("t1"), started("t2"), complete("t2")])).toEqual(["started", "completed", "started", "completed"]);
+  });
+
+  // Regression (#742): an interrupted turn (Esc / steer) writes task_started … turn_aborted
+  // with NO task_complete — verified against real ~/.codex/sessions rollouts. Without this,
+  // the working flag set at task_started never clears: spinner stuck, no finished-push, and
+  // the detached session is never reaped.
+  it("treats turn_aborted as a completed boundary (interrupted turns clear the working flag)", () => {
+    expect(turnBoundaries([started(), agentMessage(), aborted()])).toEqual(["started", "completed"]);
+  });
+
+  it("handles a normal turn followed by an interrupted one", () => {
+    expect(turnBoundaries([started("t1"), complete("t1"), started("t2"), aborted("t2")])).toEqual(["started", "completed", "started", "completed"]);
   });
 
   it("ignores rows that are not turn boundaries", () => {

--- a/test/server/agents/codex-skills.spec.ts
+++ b/test/server/agents/codex-skills.spec.ts
@@ -65,6 +65,38 @@ describe("syncCodexSkills", () => {
   });
 
   it("no-ops when the source doesn't exist", () => {
-    expect(syncCodexSkills(path.join(src, "nope"), dst)).toEqual({ mirrored: [], skipped: [] });
+    expect(syncCodexSkills(path.join(src, "nope"), dst)).toEqual({ mirrored: [], skipped: [], removed: [] });
+  });
+
+  // Regression (#742): a skill removed from the workspace must be un-mirrored from codex,
+  // or codex keeps auto-loading a deleted skill's SKILL.md forever.
+  it("removes a mirror we own once its source skill is gone", () => {
+    writeSkill(src, "keep-me", "# still here");
+    // A prior mirror whose source has since been deleted (marked = ours).
+    mkdirSync(path.join(dst, "gone"), { recursive: true });
+    writeFileSync(path.join(dst, "gone", ".mt-mirror"), "x");
+    writeFileSync(path.join(dst, "gone", "SKILL.md"), "# deleted upstream");
+    const res = syncCodexSkills(src, dst);
+    expect(res.mirrored).toEqual(["keep-me"]);
+    expect(res.removed).toEqual(["gone"]);
+    expect(existsSync(path.join(dst, "gone"))).toBe(false);
+    expect(existsSync(path.join(dst, "keep-me", "SKILL.md"))).toBe(true);
+  });
+
+  it("never removes a codex-owned skill (no marker), only our orphaned mirrors", () => {
+    writeSkill(dst, "codex-native", "# codex's own"); // unmarked
+    const res = syncCodexSkills(src, dst); // empty source, but dst exists
+    expect(res.removed).toEqual([]);
+    expect(readFileSync(path.join(dst, "codex-native", "SKILL.md"), "utf8")).toBe("# codex's own");
+  });
+
+  it("removes every orphaned mirror when the source dir is gone entirely", () => {
+    mkdirSync(path.join(dst, "orphan"), { recursive: true });
+    writeFileSync(path.join(dst, "orphan", ".mt-mirror"), "x");
+    writeSkill(dst, "codex-native", "# keep"); // unmarked — codex's own
+    const res = syncCodexSkills(path.join(src, "nope"), dst);
+    expect(res.removed).toEqual(["orphan"]);
+    expect(existsSync(path.join(dst, "orphan"))).toBe(false);
+    expect(existsSync(path.join(dst, "codex-native"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

codex 連携のセッション状態追跡にある 2 件の取りこぼしを修正。

1. **中断ターンで working フラグが残る**: `turnBoundaries` が `task_started`/`task_complete` しか境界として扱っておらず、Esc 等で中断したターンが書く `turn_aborted`（`task_complete` を伴わない）を無視していた。working フラグが解除されず、スピナー回りっぱなし・完了 push 無し・`reapDecisionFor` が keep を返して切断済みセッションが回収されない。
2. **削除スキルのミラーが残る**: `syncCodexSkills` が source に現存する名前しか走査せず、ワークスペースから消したスキルの `$CODEX_HOME/skills` ミラーが永久に残り、codex が削除済みスキルを読み続ける。

## Items to Confirm / Review

- **実データで検証済み**: `~/.codex/sessions` の 400 ファイル中、payload type は `task_started` 540 / `task_complete` 512（差 28）/ `turn_aborted` 25。実ロールアウトで中断ターンが `task_started` → `turn_aborted` で終わり `task_complete` を書かないことを確認。「エラー」ターンは `task_complete` を出すので、影響を受けるのは中断のみ。
- **ミラー削除の安全性**: `removeOrphanedMirrors` は `.mt-mirror` マーカーを持つ（＝mulmoterminal 所有）ディレクトリのみ削除し、codex 自身のスキル（マーカー無し）には決して触れない。source ディレクトリごと消えた場合も全ミラーを orphan として削除。返り値に `removed: string[]` を追加（呼び出し側 `workspaceSetup.ts` のログにも反映）。
- 両方ともミューテーション（`turn_aborted` を境界から外す / `rmSync` をスキップ）で該当テストが赤になることを確認済み。

## User Prompt

> mulmoclaude で全ファイルをレビューして pure 関数化できる部分は関数化しつつバグを探したら結構なバグがあったんだけど、こっちでもできる？

全ファイルレビュー（マルチエージェント）で検出したバグの issue 化（#740〜#748）と順次対応の一環。

## テスト

- `codex-activity.spec.ts`: `turn_aborted` が completed 境界になること、正常→中断の並び。
- `codex-skills.spec.ts`: 消えた ours ミラーの削除、codex 自身のスキルは不削除、source ごと消えた場合の全削除。

全 typecheck / lint / 該当テストパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)