### PR TITLE
fix: git ワーカーのデッドロックと文字化け（stderr 未 drain / マルチバイト分断 / 非ASCIIパス）(#743)

### DIFF
--- a/plans/fix-743-git-worker-deadlock-encoding.md
+++ b/plans/fix-743-git-worker-deadlock-encoding.md
@@ -1,0 +1,45 @@
+# fix: git ワーカーのデッドロックと文字化け（#743）
+
+## User Prompt
+
+> mulmoclaude で全ファイルをレビューして…（略）バグを issue 化し、順に対応・CI・レビュー対応・マージまで進める
+
+## 1. `git()` が stderr を読まずデッドロック（`server/git/worktrees.ts`）
+
+`git()` は `stdio: ["ignore", "pipe", "pipe"]` で stderr パイプを開くのに stdout しか購読しておらず、
+git が stderr に 64KB 以上出力するとパイプバッファが埋まって git 側が write でブロック → デッドロック。
+git-lfs 未インストール等で `git worktree add` が大量の smudge エラーを出す場合に発生し、
+`/api/worktrees/create` が永久ハング、以降の作成要求も全て詰まる。
+
+**修正**: stderr を drain（破棄）して読み続ける。あわせて stdout をバイト蓄積 + 末尾で1回デコードに変更
+（マルチバイト文字のチャンク分断対策）。ハング保険として `timeout: 120000ms` を追加。
+
+## 2. spawn-collect のチャンク境界 UTF-8 破損 + タイムアウト無し（`server/git/spawn-collect.ts`）
+
+チャンクごとに `Buffer.toString()` していたため、UTF-8 の 1 文字がパイプのチャンク境界で分断されると
+置換文字に化ける（日本語の PR タイトル・ブランチ名・コミットメッセージ）。
+
+**修正**: stdout/stderr を `Buffer[]` に蓄積し、close 時に `Buffer.concat(...).toString("utf8")` で1回デコード。
+`gh` のストール対策として `timeout: 30000ms`（`timeoutMs` で上書き可）を追加。
+
+## 3. worktree diff の非ASCIIパスが C クォート/8進エスケープのまま（`server/git/worktree-diff.ts`）
+
+git はデフォルト（`core.quotePath` on）で非ASCIIパスを `"\346\227\245..."` の形で出力する。
+`changedFiles`（numstat / ls-files）と `diffPatch`（patch ヘッダ）がこれをそのまま返していた。
+
+**修正**: 該当 git 呼び出しに `-c core.quotePath=false` を付与し、生の UTF-8 で出させる。
+
+## テスト
+
+`test/server/git/spawn-collect.spec.ts`（新規）:
+- 成功/非ゼロ終了+stderr/spawn 失敗。
+- マルチバイト UTF-8 のチャンク分断（子プロセスが `日` の 3 バイトを 1+2 に分けて出力）で `日本語` が保たれること。
+  per-chunk toString に戻すと赤になることを確認。
+- タイムアウトで kill され ok:false。
+
+`test/server/git/worktree-diff.spec.ts`（実 git 統合テストに追加）:
+- 日本語ファイル名（tracked/untracked/patch）が生のまま返り、`\` を含まないこと。
+  `core.quotePath=false` を外すと赤になることを確認。
+
+実 git 3.x（tmux 検証と同様に実機）で `-c core.quotePath=false` が octal を解くことを事前確認。
+全 git テスト 126 件 + typecheck / lint パス。

--- a/server/git/spawn-collect.ts
+++ b/server/git/spawn-collect.ts
@@ -6,18 +6,27 @@ export interface SpawnResult {
   stderr: string;
 }
 
+// A network-backed `gh` call that stalls (no route, an auth prompt, a hung proxy) would
+// otherwise pin an HTTP request open and stack subprocesses across retries. Kill it.
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 // Run a local dev tool (git / gh) with argv only — no shell — and collect its output.
 // The tool name is a caller-supplied argument, not a string literal, so this isn't a
-// spawn-of-a-string-literal from PATH. Never rejects: a spawn failure resolves ok:false
-// with `errorStderr`, so callers branch on the result instead of catching.
-export function spawnCollect(bin: string, args: string[], opts: { cwd?: string; errorStderr: string }): Promise<SpawnResult> {
+// spawn-of-a-string-literal from PATH. Never rejects: a spawn failure (or timeout) resolves
+// ok:false with `errorStderr`, so callers branch on the result instead of catching.
+export function spawnCollect(bin: string, args: string[], opts: { cwd?: string; errorStderr: string; timeoutMs?: number }): Promise<SpawnResult> {
   return new Promise((resolve) => {
-    const child = spawn(bin, args, { cwd: opts.cwd, stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (c) => (stdout += c.toString()));
-    child.stderr.on("data", (c) => (stderr += c.toString()));
+    const child = spawn(bin, args, { cwd: opts.cwd, stdio: ["ignore", "pipe", "pipe"], timeout: opts.timeoutMs ?? DEFAULT_TIMEOUT_MS });
+    // Collect bytes and decode ONCE at the end: a chunk boundary can fall inside a
+    // multibyte UTF-8 character (a Japanese PR title, branch, or commit message), and
+    // per-chunk toString() would corrupt it into replacement characters.
+    const outChunks: Buffer[] = [];
+    const errChunks: Buffer[] = [];
+    child.stdout.on("data", (c: Buffer) => outChunks.push(c));
+    child.stderr.on("data", (c: Buffer) => errChunks.push(c));
     child.on("error", () => resolve({ ok: false, stdout: "", stderr: opts.errorStderr }));
-    child.on("close", (code) => resolve({ ok: code === 0, stdout, stderr }));
+    child.on("close", (code) =>
+      resolve({ ok: code === 0, stdout: Buffer.concat(outChunks).toString("utf8"), stderr: Buffer.concat(errChunks).toString("utf8") }),
+    );
   });
 }

--- a/server/git/worktree-diff.ts
+++ b/server/git/worktree-diff.ts
@@ -36,12 +36,17 @@ async function aheadOf(cwd: string, base: string): Promise<number> {
   return res.ok ? toCount(res.stdout) : 0;
 }
 
+// git escapes non-ASCII paths as C-quoted octal ("\346\227\245…") by default, which the
+// UI would show as garbage. `-c core.quotePath=false` makes it emit raw UTF-8 instead, so
+// a 日本語.txt reads as itself. Applied to every call whose output is a file PATH.
+const QUOTE_PATH_OFF = ["-c", "core.quotePath=false"];
+
 // Tracked changes vs base, with +/- counts (numstat: "<add>\t<del>\t<path>", "-"
 // for binary). Untracked files aren't in `git diff`, so add them from status.
 async function changedFiles(cwd: string, base: string): Promise<WorktreeFile[]> {
-  const tracked = await git(["diff", "--numstat", base], cwd);
+  const tracked = await git([...QUOTE_PATH_OFF, "diff", "--numstat", base], cwd);
   const files: WorktreeFile[] = tracked.ok ? tracked.stdout.split("\n").filter(Boolean).map(parseNumstat) : [];
-  const untracked = await git(["ls-files", "--others", "--exclude-standard"], cwd);
+  const untracked = await git([...QUOTE_PATH_OFF, "ls-files", "--others", "--exclude-standard"], cwd);
   const news = untracked.ok ? untracked.stdout.split("\n").filter(Boolean) : [];
   return [...files, ...news.map((path): WorktreeFile => ({ path, additions: 0, deletions: 0, status: "untracked" }))];
 }
@@ -51,7 +56,9 @@ function parseNumstat(line: string): WorktreeFile {
 }
 
 async function diffPatch(cwd: string, base: string): Promise<{ patch: string; truncated: boolean }> {
-  const res = await git(["diff", base], cwd);
+  // Same quoting fix as changedFiles: the patch's own `diff --git a/… b/…` headers carry
+  // the paths, so a non-ASCII filename would otherwise render as octal escapes here too.
+  const res = await git([...QUOTE_PATH_OFF, "diff", base], cwd);
   if (!res.ok) return { patch: "", truncated: false };
   const full = res.stdout;
   return capPatch(full, PATCH_LIMIT_CHARS);

--- a/server/git/worktree-pr.ts
+++ b/server/git/worktree-pr.ts
@@ -25,10 +25,16 @@ export interface PrResult {
 
 const DETAIL_LIMIT = 500;
 
+// `git push` and `gh pr create` are outward network mutations that can legitimately take
+// minutes on a large branch or a slow remote — far longer than spawnCollect's default,
+// which is tuned for quick `gh` reads. Give them a generous ceiling so a real push isn't
+// killed at 30s and mis-reported as push-failed, while still bounding a truly-stuck process.
+export const NETWORK_MUTATION_TIMEOUT_MS = 300_000;
+
 // worktrees.ts' git() drops stderr and only runs git; push/gh failures report via
 // stderr, so use the stderr-capturing runner, constrained to those two tools.
 function run(cmd: "git" | "gh", args: string[], cwd: string): Promise<SpawnResult> {
-  return spawnCollect(cmd, args, { cwd, errorStderr: "spawn failed" });
+  return spawnCollect(cmd, args, { cwd, errorStderr: "spawn failed", timeoutMs: NETWORK_MUTATION_TIMEOUT_MS });
 }
 
 async function currentBranch(cwd: string): Promise<string | null> {

--- a/server/git/worktrees.ts
+++ b/server/git/worktrees.ts
@@ -104,16 +104,27 @@ export function parseWorktreeList(porcelain: string): { path: string; head: stri
   return out;
 }
 
+// Kill a git call that never finishes (a broken hook waiting on input, a stuck lfs
+// smudge) so it can't pin a request forever. Generous: a real `worktree add` that
+// checks out a large repo is slow but not infinite.
+const GIT_TIMEOUT_MS = 120_000;
+
 // Run git with argv (no shell) in `cwd`; resolve { ok, stdout } — never reject, so
 // a missing git / non-repo dir is just `ok:false` and the caller falls back.
 export function git(args: string[], cwd?: string): Promise<{ ok: boolean; stdout: string }> {
   return new Promise((resolve) => {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' is a standard tool from PATH in this local dev server; all inputs go through argv (no shell)
-    const child = spawn("git", cwd ? ["-C", cwd, ...args] : args, { stdio: ["ignore", "pipe", "pipe"] });
-    let stdout = "";
-    child.stdout.on("data", (c) => (stdout += c.toString()));
+    const child = spawn("git", cwd ? ["-C", cwd, ...args] : args, { stdio: ["ignore", "pipe", "pipe"], timeout: GIT_TIMEOUT_MS });
+    // Collect bytes and decode ONCE: a chunk can split a multibyte UTF-8 character, and
+    // per-chunk toString() would turn a non-ASCII path/message into replacement chars.
+    const chunks: Buffer[] = [];
+    child.stdout.on("data", (c: Buffer) => chunks.push(c));
+    // stderr is not returned, but it MUST still be drained: git blocks on a full stderr
+    // pipe (a repo that prints thousands of lfs/hook warnings easily exceeds the 64KB
+    // buffer), so an unread pipe deadlocks the whole call. Discard the bytes, keep reading.
+    child.stderr.on("data", () => {});
     child.on("error", () => resolve({ ok: false, stdout: "" }));
-    child.on("close", (code) => resolve({ ok: code === 0, stdout }));
+    child.on("close", (code) => resolve({ ok: code === 0, stdout: Buffer.concat(chunks).toString("utf8") }));
   });
 }
 

--- a/test/server/git/spawn-collect.spec.ts
+++ b/test/server/git/spawn-collect.spec.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { spawnCollect } from "../../../server/git/spawn-collect.js";
+
+describe("spawnCollect", () => {
+  it("resolves ok:true with stdout for a successful command", async () => {
+    const r = await spawnCollect(process.execPath, ["-e", "process.stdout.write('hello')"], { errorStderr: "spawn failed" });
+    expect(r).toEqual({ ok: true, stdout: "hello", stderr: "" });
+  });
+
+  it("resolves ok:false with captured stderr for a non-zero exit", async () => {
+    const r = await spawnCollect(process.execPath, ["-e", "process.stderr.write('boom'); process.exit(3)"], { errorStderr: "spawn failed" });
+    expect(r.ok).toBe(false);
+    expect(r.stderr).toBe("boom");
+  });
+
+  it("resolves ok:false with errorStderr when the binary can't be spawned", async () => {
+    const r = await spawnCollect("definitely-not-a-real-binary-xyz", ["--version"], { errorStderr: "gh not found" });
+    expect(r).toEqual({ ok: false, stdout: "", stderr: "gh not found" });
+  });
+
+  // Regression (#743): the child writes a multibyte UTF-8 string as two byte-halves across a
+  // delay, forcing a chunk boundary INSIDE the character. Per-chunk toString() corrupted it
+  // into replacement chars; decoding the concatenated buffer once keeps it intact.
+  it("decodes multibyte UTF-8 split across stdout chunk boundaries", async () => {
+    // '日' is E6 97 A5. Emit E6 then (after a tick) 97 A5, so the first chunk ends mid-char.
+    const script = "const b=Buffer.from('日本語','utf8'); process.stdout.write(b.subarray(0,1)); setTimeout(()=>process.stdout.write(b.subarray(1)), 30);";
+    const r = await spawnCollect(process.execPath, ["-e", script], { errorStderr: "spawn failed" });
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toBe("日本語");
+    expect(r.stdout).not.toContain("�"); // no replacement character
+  });
+
+  it("kills a command that exceeds the timeout and resolves ok:false", async () => {
+    const r = await spawnCollect(process.execPath, ["-e", "setTimeout(()=>{}, 60000)"], { errorStderr: "spawn failed", timeoutMs: 150 });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/test/server/git/worktree-diff.spec.ts
+++ b/test/server/git/worktree-diff.spec.ts
@@ -80,4 +80,28 @@ describe("worktreeDiff", () => {
     const d = await worktreeDiff(wt.path);
     expect(d).toMatchObject({ isWorktree: true, base: "main", ahead: 0, dirty: 0, files: [], patch: "" });
   });
+
+  // Regression (#743): git C-quotes non-ASCII paths ("\346\227\245…") by default, so the
+  // changed-file list and the patch showed octal garbage for a Japanese filename. The fix
+  // passes -c core.quotePath=false; here the real git output must carry the raw name.
+  it.skipIf(!hasGit)("returns non-ASCII filenames raw, not C-quoted/octal-escaped", async () => {
+    const wt = await createWorktree(repo, "unicode");
+    if (!wt) throw new Error("expected a worktree");
+    // a committed tracked change with a Japanese name (numstat + patch paths)
+    writeFileSync(path.join(wt.path, "日本語.txt"), "本文\n");
+    g(wt.path, "add", "-A");
+    g(wt.path, "commit", "-m", "add japanese tracked file");
+    // and an untracked one (ls-files path)
+    writeFileSync(path.join(wt.path, "メモ.txt"), "memo\n");
+
+    const d = await worktreeDiff(wt.path);
+    const tracked = d.files.find((f) => f.status === "changed");
+    const untracked = d.files.find((f) => f.status === "untracked");
+    expect(tracked?.path).toBe("日本語.txt");
+    expect(untracked?.path).toBe("メモ.txt");
+    // no octal escapes / surrounding quotes leaked through
+    expect(d.files.some((f) => f.path.includes("\\"))).toBe(false);
+    expect(d.patch).toContain("日本語.txt");
+    expect(d.patch).not.toContain("\\346");
+  });
 });

--- a/test/server/git/worktree-pr-timeout.spec.ts
+++ b/test/server/git/worktree-pr-timeout.spec.ts
@@ -1,0 +1,36 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Regression for #754 codex review: the shared spawnCollect default (30s, tuned for quick
+// gh reads) also governed `git push`, so a slow push on a large repo/remote was killed and
+// mis-reported as push-failed. The push path must opt into a generous timeout. Mock both
+// dependencies so pushWorktree's argv choices are observable without a real remote.
+vi.mock("../../../server/git/spawn-collect.js", () => ({
+  spawnCollect: vi.fn(async () => ({ ok: true, stdout: "", stderr: "" })),
+}));
+vi.mock("../../../server/git/worktrees.js", () => ({
+  git: vi.fn(async (args: string[]) => {
+    if (args[0] === "rev-parse") return { ok: true, stdout: "feature\n" }; // currentBranch
+    if (args[0] === "remote") return { ok: true, stdout: "origin\n" }; // hasOrigin
+    return { ok: true, stdout: "" };
+  }),
+  repoRoot: vi.fn(async () => "/repo"),
+  isManagedWorktree: vi.fn(() => true),
+  defaultBaseBranch: vi.fn(async () => "main"),
+}));
+
+import { spawnCollect } from "../../../server/git/spawn-collect.js";
+import { pushWorktree, NETWORK_MUTATION_TIMEOUT_MS } from "../../../server/git/worktree-pr.js";
+
+describe("pushWorktree timeout (#754)", () => {
+  beforeEach(() => vi.mocked(spawnCollect).mockClear());
+
+  it("gives git push a generous timeout, not the 30s default that kills slow pushes", async () => {
+    const res = await pushWorktree("/repo/wt");
+    expect(res.ok).toBe(true);
+    const pushCall = vi.mocked(spawnCollect).mock.calls.find((c) => c[0] === "git" && c[1][0] === "push");
+    expect(pushCall).toBeDefined();
+    expect(pushCall?.[2].timeoutMs).toBe(NETWORK_MUTATION_TIMEOUT_MS);
+    expect(NETWORK_MUTATION_TIMEOUT_MS).toBeGreaterThanOrEqual(60_000);
+  });
+});


### PR DESCRIPTION
## Summary

git ワーカー周りの 3 件を修正。

1. **`git()` の stderr デッドロック**: `stdio: ["ignore","pipe","pipe"]` で stderr パイプを開くのに stdout しか読んでおらず、git が stderr に 64KB 超出力するとパイプバッファが埋まり write でブロック → デッドロック。git-lfs 未インストール等で `git worktree add` が大量の smudge エラーを出すと `/api/worktrees/create` が永久ハングし、以降の作成要求も全部詰まる。
2. **チャンク境界の UTF-8 破損**: `git()` と `spawnCollect` がチャンクごとに `Buffer.toString()` していたため、マルチバイト文字がチャンク境界で分断されると化ける（日本語の PR タイトル・ブランチ名・コミットメッセージ）。
3. **非ASCIIパスの C クォート**: worktree diff が `core.quotePath` デフォルト on のせいで `"\346\227\245..."` を返していた。

## Items to Confirm / Review

- **stderr は drain（破棄）**: `git()` は元々 stderr を返さないので、読み捨てる形でデッドロックのみ解消（挙動不変）。stdout はバイト蓄積 + 末尾で1回デコードに変更。
- **タイムアウト追加**: `git()` に 120s（大きめ。実 `worktree add` は遅いが無限ではない）、`spawnCollect` に 30s（`gh` のネットワーク stall 対策、`timeoutMs` で上書き可）。過度に短くして正当な長時間処理を kill しないよう配慮。
- **非ASCIIパス**: `-c core.quotePath=false` を numstat / ls-files / patch の各呼び出しに付与。実 git で octal が解けることを事前確認。
- 両エンコード修正ともミューテーション（per-chunk toString に戻す / quotePath を外す）で該当テストが赤になることを確認済み。

## User Prompt

> mulmoclaude で全ファイルをレビューして pure 関数化できる部分は関数化しつつバグを探したら結構なバグがあったんだけど、こっちでもできる？

全ファイルレビュー（マルチエージェント）で検出したバグの issue 化（#740〜#748）と順次対応の一環。

## テスト

- `spawn-collect.spec.ts`（新規）: 成功/失敗/spawn 失敗、マルチバイト UTF-8 のチャンク分断（`日` を 1+2 バイトに分けて出力）で文字が保たれること、タイムアウト kill。
- `worktree-diff.spec.ts`（実 git 統合）: 日本語ファイル名（tracked/untracked/patch）が生のまま返り `\` を含まないこと。

全 git テスト 126 件 + typecheck / lint パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)