### PR TITLE
fix: ストリーム/外部呼び出しのエラー・タイムアウト漏れでハング / uncaughtException が起きる (#744)

### DIFF
--- a/plans/fix-744-stream-error-handlers.md
+++ b/plans/fix-744-stream-error-handlers.md
@@ -1,0 +1,38 @@
+# fix: ストリーム/外部呼び出しのエラー・タイムアウト漏れ（#744）
+
+## User Prompt
+
+> mulmoclaude で全ファイルをレビューして…（略）バグを issue 化し、順に対応・CI・レビュー対応・マージまで進める
+
+## 1. 生ファイル配信のストリームに error ハンドラが無い（`server/backends/files.ts`）
+
+`GET /api/files/raw` は `createReadStream(abs).pipe(res)` を error ハンドラ無しで実行。
+`statFileOr404` の statSync 後〜ストリーム open の間にファイルが消える／読めない（`chmod 000`）と、
+未処理の 'error' → uncaughtException になり、レスポンスが返らないままハングする。
+Range 分岐と全体配信の 2 箇所が該当。
+
+## 2. HTML プレビューも同型（`server/backends/html.ts`）
+
+`GET /artifacts/html/<rest>` の `createReadStream(abs).pipe(res)` も error ハンドラ無し。
+
+## 3. Gemini 画像生成にタイムアウト／abort が無い（`server/backends/image-gen.ts`）
+
+`generateContent` がストールすると呼び出し側が無期限に待ち、ツール呼び出しが "running" のまま残る。
+
+## 修正
+
+- `server/backends/streamFile.ts`（新規）に共有ヘルパを作成:
+  - `streamErrorAction(headersSent)`（pure）: ヘッダ送信済みなら `"destroy"`、未送信なら `"500"`。
+  - `streamFileToResponse(abs, res, range?)`: read stream に error ハンドラを付け、
+    ヘッダ未送信なら 500、送信済みなら `res.destroy()`。files.ts（2箇所）と html.ts が使用。
+- `image-gen.ts`: `AbortController` + `setTimeout`（120s）で abort。`GenerateContentConfig.abortSignal`
+  に渡す（@google/genai 2.12.0 でサポート確認済み）。timeout 時はメッセージに「timed out」を明示。
+
+## テスト
+
+`test/server/backends/streamFile.spec.ts`（新規）:
+- `streamErrorAction`: headersSent true→destroy / false→500。
+- `streamFileToResponse`: 正常配信、存在しないファイルで 500（ENOENT 発火）、ヘッダ送信済みで destroy。
+  分岐反転のミューテーションで 4 テストが赤になることを確認。
+
+全 backend テスト 506 件 + typecheck / lint パス。

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -15,11 +15,11 @@
 //     navigation or <iframe>; PDFs skip the sandbox CSP (WebKit refuses to render
 //     sandbox-opaque PDFs) but keep nosniff. Matches MulmoClaude's RAW_SECURITY_HEADERS.
 import path from "node:path";
-import { createReadStream } from "node:fs";
 import type { Express, Request, Response } from "express";
 import { statFileOr404 } from "./statFileOr404.js";
 import { parseByteRange } from "./byte-range.js";
 import { rawServingPlan } from "./rawServingPlan.js";
+import { streamFileToResponse } from "./streamFile.js";
 
 export function mountFilesRoutes(app: Express, deps: { workspace: string }): void {
   const root = path.resolve(deps.workspace);
@@ -65,11 +65,11 @@ export function mountFilesRoutes(app: Express, deps: { workspace: string }): voi
       res.status(206);
       res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${stat.size}`);
       res.setHeader("Content-Length", String(range.end - range.start + 1));
-      createReadStream(abs, { start: range.start, end: range.end }).pipe(res);
+      streamFileToResponse(abs, res, { start: range.start, end: range.end });
       return;
     }
 
     res.setHeader("Content-Length", String(stat.size));
-    createReadStream(abs).pipe(res);
+    streamFileToResponse(abs, res);
   });
 }

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -14,12 +14,12 @@
 //      workspace with an HTML preview CSP (sandboxed-ish: inline scripts + a curated
 //      CDN allowlist, but connect-src 'none' so a page can't phone home).
 import path from "node:path";
-import { createReadStream } from "node:fs";
 import type { Express, Request, Response, NextFunction } from "express";
 import { executeHtmlDispatch } from "@mulmoclaude/html-plugin";
 import { artifactsFileOps } from "./artifacts.js";
 import { publishFileChange } from "./fileChange.js";
 import { statFileOr404 } from "./statFileOr404.js";
+import { streamFileToResponse } from "./streamFile.js";
 
 // Curated CDN allowlist (matches the collection custom-view policy) for an
 // LLM-authored page that may pull a charting/util lib or font from a CDN.
@@ -93,6 +93,6 @@ export function mountHtmlPreviewRoute(app: Express, deps: { workspace: string })
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("Content-Security-Policy", HTML_PREVIEW_CSP);
-    createReadStream(abs).pipe(res);
+    streamFileToResponse(abs, res);
   });
 }

--- a/server/backends/image-gen.ts
+++ b/server/backends/image-gen.ts
@@ -20,6 +20,11 @@ const DEFAULT_IMAGE_CONFIG = {
   imageConfig: { aspectRatio: "16:9" },
 };
 
+// A stalled generateContent (network hiccup, model queue) would otherwise leave the tool
+// call hanging forever. Cap it; the SDK's abortSignal frees our caller (it won't cancel
+// server-side billing, but nothing here is waiting on that).
+const IMAGE_TIMEOUT_MS = 120_000;
+
 let client: GoogleGenAI | null = null;
 function getClient() {
   const apiKey = process.env.GEMINI_API_KEY;
@@ -35,14 +40,20 @@ export async function generateImage(prompt: string) {
     return { message: "Image generation is unavailable on this server (set GEMINI_API_KEY)." };
   }
   let response;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), IMAGE_TIMEOUT_MS);
   try {
     response = await ai.models.generateContent({
       model: DEFAULT_IMAGE_MODEL,
       contents: [{ text: prompt }],
-      config: DEFAULT_IMAGE_CONFIG,
+      config: { ...DEFAULT_IMAGE_CONFIG, abortSignal: controller.signal },
     });
   } catch (e) {
-    return { message: `Image generation failed: ${e instanceof Error ? e.message : String(e)}` };
+    const cause = e instanceof Error ? e.message : String(e);
+    const reason = controller.signal.aborted ? `timed out after ${IMAGE_TIMEOUT_MS / 1000}s` : cause;
+    return { message: `Image generation failed: ${reason}` };
+  } finally {
+    clearTimeout(timer);
   }
 
   const parts = response?.candidates?.[0]?.content?.parts ?? [];

--- a/server/backends/streamFile.ts
+++ b/server/backends/streamFile.ts
@@ -1,0 +1,26 @@
+// Serving a file by streaming it to an HTTP response, with the one thing every raw-file
+// route here kept forgetting: an `error` handler on the read stream. Without it, a file
+// that vanishes or turns unreadable between stat and open (EACCES / ENOENT) emits an
+// unhandled 'error' → uncaughtException, and the request hangs with no response.
+import { createReadStream } from "node:fs";
+import type { Response } from "express";
+
+// What to do when the read stream errors, decided purely on whether the response has
+// already begun. Once headers/body bytes are on the wire we can't change the status, so
+// the only correct move is to abort the connection; before that, a clean 500 is possible.
+export type StreamErrorAction = "500" | "destroy";
+
+export function streamErrorAction(headersSent: boolean): StreamErrorAction {
+  return headersSent ? "destroy" : "500";
+}
+
+// Pipe a file to the response with the error handling above. `range` streams a byte slice
+// (the caller has already set 206 + Content-Range); omit it for the whole file.
+export function streamFileToResponse(abs: string, res: Response, range?: { start: number; end: number }): void {
+  const stream = range ? createReadStream(abs, range) : createReadStream(abs);
+  stream.on("error", () => {
+    if (streamErrorAction(res.headersSent) === "500") res.status(500).json({ error: "failed to read file" });
+    else res.destroy();
+  });
+  stream.pipe(res);
+}

--- a/test/server/backends/streamFile.spec.ts
+++ b/test/server/backends/streamFile.spec.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+import { describe, it, expect, vi } from "vitest";
+import { PassThrough } from "node:stream";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Response } from "express";
+import { streamErrorAction, streamFileToResponse } from "../../../server/backends/streamFile.js";
+
+describe("streamErrorAction", () => {
+  it("sends a 500 while the response is still open", () => {
+    expect(streamErrorAction(false)).toBe("500");
+  });
+  // Once bytes are on the wire the status is fixed, so the only honest move is to abort.
+  it("destroys the connection once headers have been sent", () => {
+    expect(streamErrorAction(true)).toBe("destroy");
+  });
+});
+
+// A fake express Response backed by a real Writable so `.pipe(res)` works. `destroy`
+// already exists on Writable (so it's spied, not reassigned); `status`/`json` are added.
+function fakeRes(headersSent: boolean) {
+  const stream = new PassThrough();
+  const status = vi.fn().mockReturnThis();
+  const json = vi.fn().mockReturnThis();
+  const destroy = vi.spyOn(stream, "destroy");
+  Object.assign(stream, { headersSent, status, json });
+  const res = stream as unknown as Response;
+  return { res, stream, status, json, destroy };
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 20));
+
+describe("streamFileToResponse", () => {
+  it("serves an existing file", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-stream-"));
+    const file = path.join(dir, "a.txt");
+    writeFileSync(file, "hello");
+    const { res, stream, status } = fakeRes(false);
+    const chunks: Buffer[] = [];
+    stream.on("data", (c: Buffer) => chunks.push(c));
+    streamFileToResponse(file, res);
+    await settle();
+    expect(Buffer.concat(chunks).toString()).toBe("hello");
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  // Regression (#744): the read stream errored with no handler → uncaughtException and a
+  // hung request. A file that can't be opened must now yield a clean 500.
+  it("responds 500 when the file can't be read and nothing was sent yet", async () => {
+    const { res, status, json, destroy } = fakeRes(false);
+    streamFileToResponse(path.join(tmpdir(), "does-not-exist-xyz.bin"), res);
+    await settle();
+    expect(status).toHaveBeenCalledWith(500);
+    expect(json).toHaveBeenCalledWith({ error: "failed to read file" });
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  it("destroys the connection when the stream errors after headers were sent", async () => {
+    const { res, status, destroy } = fakeRes(true);
+    streamFileToResponse(path.join(tmpdir(), "does-not-exist-xyz.bin"), res);
+    await settle();
+    expect(destroy).toHaveBeenCalled();
+    expect(status).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

ストリームと外部呼び出しのエラー／タイムアウト処理漏れで、リクエストがハングしたりサーバが uncaughtException で落ちたりする 3 件を修正。

1. **生ファイル配信の error ハンドラ欠落**: `GET /api/files/raw` が `createReadStream(abs).pipe(res)` を error ハンドラ無しで実行。stat 後〜open の間にファイルが消える／読めない（`chmod 000`）と未処理 'error' → uncaughtException でハング。Range 分岐と全体配信の 2 箇所。
2. **HTML プレビューも同型**: `/artifacts/html/<rest>` も同じ。
3. **Gemini 画像生成のタイムアウト欠落**: `generateContent` がストールすると無期限に待ち、ツール呼び出しが "running" のまま。

## Items to Confirm / Review

- **共有ヘルパに集約**: `server/backends/streamFile.ts` を新設。決定 `streamErrorAction(headersSent)` を pure 関数に切り出し（ヘッダ送信済み→`destroy` / 未送信→`500`）、`streamFileToResponse` が read stream に error ハンドラを配線。files.ts（2箇所）と html.ts の計 3 箇所が使用。
- **abortSignal**: `image-gen.ts` に `AbortController` + 120s タイムアウト。`GenerateContentConfig.abortSignal` に渡す（@google/genai 2.12.0 で型サポート確認済み）。SDK 注記どおり abort はサーバ側課金を止めないが、こちらの caller は解放される。
- 分岐反転のミューテーションで streamFile のテスト 4 件が赤になることを確認済み。

## User Prompt

> mulmoclaude で全ファイルをレビューして pure 関数化できる部分は関数化しつつバグを探したら結構なバグがあったんだけど、こっちでもできる？

全ファイルレビュー（マルチエージェント）で検出したバグの issue 化（#740〜#748）と順次対応の一環。

## テスト

- `streamFile.spec.ts`（新規）: `streamErrorAction` の両分岐、正常配信、存在しないファイルで 500、ヘッダ送信済みで destroy。

全 backend テスト 506 件 + typecheck / lint パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)