### PR TITLE
fix: 起動時のポーリング多重化と孤児 tmux セッションの誤 kill / mutate too-large の誤報 (#747)

### DIFF
--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -7,13 +7,13 @@
 
 import { execSync, spawn } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
-import { get as httpGet } from "node:http";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { computeUpdateNotice, isUpdateCheckDisabled } from "./update-check.js";
+import { waitUntilReady } from "./wait-ready.js";
 import {
   chooseCwd,
   parsePortArg,
@@ -30,7 +30,6 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = join(__dirname, "..");
 const SERVER_ENTRY = join(PKG_DIR, "server", "index.ts");
 const DEFAULT_PORT = 34567;
-const READY_TIMEOUT_MS = 15_000;
 // Server exit code meaning "port taken at bind time" — keep in sync with
 // server/index.ts (PORT_IN_USE_EXIT_CODE).
 const PORT_IN_USE_EXIT_CODE = 75;
@@ -168,36 +167,6 @@ function isPortFree(port) {
     probe.once("listening", () => probe.close(() => resolve(true)));
     probe.listen(port);
   });
-}
-
-// Poll the server until it answers, then call onReady; give up after the timeout
-// so the launcher never hangs on a crash loop. Returns a cancel function — a
-// raced/abandoned attempt stops polling so it can't fire a stale banner.
-function waitUntilReady(port, onReady) {
-  const startedAt = Date.now();
-  let timer = null;
-  let cancelled = false;
-  const attempt = () => {
-    if (cancelled) return;
-    const req = httpGet({ host: "127.0.0.1", port, path: "/", timeout: 1000 }, (res) => {
-      res.resume();
-      if (!cancelled) onReady();
-    });
-    req.on("error", retry);
-    req.on("timeout", () => {
-      req.destroy();
-      retry();
-    });
-  };
-  const retry = () => {
-    if (cancelled || Date.now() - startedAt > READY_TIMEOUT_MS) return;
-    timer = setTimeout(attempt, 300);
-  };
-  attempt();
-  return () => {
-    cancelled = true;
-    if (timer) clearTimeout(timer);
-  };
 }
 
 function printReadyBanner(url) {

--- a/bin/wait-ready.d.ts
+++ b/bin/wait-ready.d.ts
@@ -1,0 +1,26 @@
+// Only the surface probeOnce actually touches — narrower than http.ClientRequest /
+// IncomingMessage on purpose, so a test fake and the real node:http both satisfy it.
+export interface ProbeRequest {
+  on(event: "error" | "timeout", listener: (...args: unknown[]) => void): unknown;
+  destroy(): void;
+}
+
+export interface ProbeResponse {
+  resume(): void;
+}
+
+export type ProbeGet = (opts: { host: string; port: number; path: string; timeout: number }, cb: (res: ProbeResponse) => void) => ProbeRequest;
+
+export declare function probeOnce(get: ProbeGet, port: number, timeoutMs?: number): Promise<"ready" | "retry">;
+
+export declare function waitUntilReady(
+  port: number,
+  onReady: () => void,
+  deps?: {
+    get?: ProbeGet;
+    now?: () => number;
+    timeoutMs?: number;
+    intervalMs?: number;
+    readyTimeoutMs?: number;
+  },
+): () => void;

--- a/bin/wait-ready.js
+++ b/bin/wait-ready.js
@@ -1,0 +1,61 @@
+// Polling the launched server until it answers `/`, then firing onReady exactly once.
+// Split out of mulmoterminal.js so the retry state machine is testable without a socket.
+
+import { get as httpGet } from "node:http";
+
+const PROBE_TIMEOUT_MS = 1000;
+const RETRY_INTERVAL_MS = 300;
+const DEFAULT_READY_TIMEOUT_MS = 15_000;
+
+// One probe of the server: resolves "ready" if it answers, else "retry". It NEVER
+// rejects, and yields exactly ONE outcome per call — the crucial guarantee. Destroying a
+// timed-out request itself emits an 'error', so a single timeout would otherwise trigger
+// both the timeout handler AND the error handler; each schedules a retry, the poll loop
+// forks in two, and every fork fires onReady when the server finally answers — printing
+// the banner and opening the browser several times. The `settled` latch collapses each
+// request to one outcome.
+export function probeOnce(get, port, timeoutMs = PROBE_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (outcome) => {
+      if (settled) return;
+      settled = true;
+      resolve(outcome);
+    };
+    const req = get({ host: "127.0.0.1", port, path: "/", timeout: timeoutMs }, (res) => {
+      res.resume();
+      done("ready");
+    });
+    req.on("error", () => done("retry"));
+    req.on("timeout", () => {
+      req.destroy();
+      done("retry");
+    });
+  });
+}
+
+// Poll until the server answers, then call onReady once; give up after readyTimeoutMs so
+// the launcher never hangs on a crash loop. Returns a cancel function — a raced/abandoned
+// attempt stops polling so it can't fire a stale banner. `deps` is injectable for tests.
+export function waitUntilReady(port, onReady, deps = {}) {
+  const { get = httpGet, now = Date.now, timeoutMs = PROBE_TIMEOUT_MS, intervalMs = RETRY_INTERVAL_MS, readyTimeoutMs = DEFAULT_READY_TIMEOUT_MS } = deps;
+  const startedAt = now();
+  let cancelled = false;
+  let timer = null;
+  const loop = async () => {
+    if (cancelled) return;
+    const outcome = await probeOnce(get, port, timeoutMs);
+    if (cancelled) return;
+    if (outcome === "ready") {
+      onReady();
+      return;
+    }
+    if (now() - startedAt > readyTimeoutMs) return;
+    timer = setTimeout(loop, intervalMs);
+  };
+  loop();
+  return () => {
+    cancelled = true;
+    if (timer) clearTimeout(timer);
+  };
+}

--- a/plans/fix-747-startup-orphan-mutatestatus.md
+++ b/plans/fix-747-startup-orphan-mutatestatus.md
@@ -1,0 +1,47 @@
+# fix: 起動ポーリング多重化 + 孤児 tmux 誤 kill + mutate too-large 誤報（#747）
+
+## User Prompt
+
+> mulmoclaude で全ファイルをレビューして…（略）バグを issue 化し、順に対応・CI・レビュー対応・マージまで進める
+
+## 1. `waitUntilReady` がタイムアウトのたびにポーリングを分裂させる（`bin/mulmoterminal.js`）
+
+timeout ハンドラで `req.destroy()` を呼ぶと 'error' イベントが発火し、`req.on("error", retry)` が
+**もう一度** retry を呼ぶ。1リクエストのタイムアウトで retry が 2 回 → ポーリング連鎖が指数的に分裂し、
+サーバ応答時に各連鎖が onReady を呼んでバナー多重表示・ブラウザ多重起動になる。
+
+**修正**: ポーリングロジックを `bin/wait-ready.js`（+ `.d.ts`）に切り出し、注入可能に。
+`probeOnce(get, port, timeoutMs)` が1プローブにつき **必ず1つの結果**（"ready"/"retry"）を返す
+（Promise + settled ラッチ）。`waitUntilReady` は直列ループ（await）で fork 不可能。`mulmoterminal.js` はこれを import。
+
+## 2. cleanup-orphans が他プロセスの生きた tmux セッションを kill（`server/infra/tmux-routes.ts`）
+
+`resumablePredicate` は自プロセスの live/grid/on-disk しか見ないため、別の mulmoterminal が
+新規作成してまだトランスクリプトの無いセッションを「resumable でない」と判定して kill する。
+
+**修正**: `orphanReapable(resumable, attachedCount)` を pure 関数として追加。
+cleanup 到達時点で id は自プロセスの live に無い（あれば resumable で除外済み）ので、
+`attachedCount >= 1` は他プロセスが保持を意味する。resumable でない **かつ** attachedCount === 0 のみ kill。
+null（tmux が答えられない）は「保持」として安全側に倒す。dep `attachedClientCount: tmuxAttachedClientCount` を配線。
+
+（メモリの follow-up「別プロセスが同じ dir/セッションを共有したら警告」と同根の問題）
+
+## 3. mutate の too-large で書き込み済みなのに 400（`server/backends/mutateStatus.ts` 他）
+
+`too-large` は「更新は成功したが応答が大きすぎる」ケース（メッセージが明言）。
+`mutateStatus` が 400 に落とすため、UI が編集失敗と表示し古いデータを保持する。
+
+**修正**: 型ガード `mutateWriteApplied(result)` を追加（`too-large` を narrow）。
+デスクトップ preview（`collections.ts`）とスマホ channel（`remoteHost/handlers.ts`）の両ハンドラで、
+`too-large` を成功扱い（`{ op, id, applied: true, warning }`）にし、クライアントに refetch を促す。
+
+## テスト
+
+- `test/bin/wait-ready.spec.ts`（新規）: probeOnce の ready/retry、timeout+destroy 二重発火でも単一結果、
+  onReady が retry を挟んでも1回、readyTimeout で諦め、cancel で停止。ready 時 return 削除のミューテーションで赤。
+- `test/server/infra/tmux-routes.spec.ts`: 他プロセスがアタッチした非 resumable を spare、`orphanReapable` の真理値表。
+  attachedCount を無視するミューテーションで赤。
+- `test/server/backends/mutateStatus.spec.ts`: `mutateWriteApplied` の真偽、too-large を 400 リストから除外。
+  常に false のミューテーションで赤。
+
+全 3551 テスト + typecheck（server/test/app）+ lint + build パス。

--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -65,7 +65,7 @@ import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability
 // action so a view can never do more than the agent's own data plane.
 import { manageCollectionHandler } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
-import { mutateStatus } from "./mutateStatus.js";
+import { mutateStatus, mutateWriteApplied } from "./mutateStatus.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
 // (prefix, message, optional structured data) — shared with the other engines'
@@ -607,6 +607,12 @@ const remoteViewMutateHandler: RequestHandler<{ slug: string; viewId: string }> 
   const collection = await resolveCollection(res, slug);
   if (!collection) return;
   const result = await mutateRemoteView(collection, viewId, request);
+  if (mutateWriteApplied(result)) {
+    // The write applied; only its response blew the byte budget. Report success (not a 4xx
+    // that reads as a failed edit and strands stale data) and tell the client to re-fetch.
+    res.json({ op: request.op, id: request.id, applied: true, warning: mutateRemoteViewFailureMessage(result, slug) });
+    return;
+  }
   if (result.kind !== "ok") {
     res.status(mutateStatus(result.kind)).json({ error: mutateRemoteViewFailureMessage(result, slug) });
     return;

--- a/server/backends/mutateStatus.ts
+++ b/server/backends/mutateStatus.ts
@@ -26,3 +26,12 @@ export function mutateStatus(kind: string): number {
   if (FORBIDDEN_KINDS.has(kind)) return FORBIDDEN;
   return BAD_REQUEST;
 }
+
+// "too-large" on a mutate is NOT a failure: the record WAS written, only its response
+// (the enriched, thumbnail-inlined item) exceeded the command-channel byte budget. Callers
+// must report it as an applied write so the client re-fetches — a 4xx here reads as "edit
+// failed" and strands stale data in the UI (#747). A type guard so both the desktop preview
+// HTTP handler and the phone channel narrow the result and branch on it in one place.
+export function mutateWriteApplied<T extends { kind: string }>(result: T): result is Extract<T, { kind: "too-large" }> {
+  return result.kind === "too-large";
+}

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -25,6 +25,7 @@ import {
   remoteViewItems,
   remoteViewItemsFailureMessage,
 } from "../remoteView.js";
+import { mutateWriteApplied } from "../mutateStatus.js";
 import type { Attachment } from "./ingestAttachments.js";
 import { createTerminalInputSender } from "./terminalInput.js";
 import type { SessionScreen, TerminalSessionSummary } from "./terminalScreen.js";
@@ -134,6 +135,11 @@ const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (par
   const collection = await loadCollection(slug);
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await mutateRemoteView(collection, viewId, request);
+  // The write applied but its response blew the byte budget — report success (+refetch),
+  // not a thrown error the phone shows as a failed edit while keeping stale data (#747).
+  if (mutateWriteApplied(result)) {
+    return { op: request.op, id: request.id, applied: true, warning: mutateRemoteViewFailureMessage(result, slug) } as unknown as JsonObject;
+  }
   if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
   return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
 };

--- a/server/infra/tmux-routes.ts
+++ b/server/infra/tmux-routes.ts
@@ -11,9 +11,23 @@ export interface TmuxRouteDeps {
   hasTmux: (id: string) => boolean;
   killTmux: (id: string) => void;
   listTmuxIds: () => string[];
+  // Clients attached to a tmux session, or null when tmux can't say. Each mulmoterminal
+  // holds ONE client per session it is live on; the cleanup only reaches ids this process
+  // is NOT live on, so any count >= 1 means ANOTHER process is holding it.
+  attachedClientCount: (id: string) => number | null;
   // Build the resumability predicate for a cleanup pass (awaits any hydration, snapshots
   // the live / grid / on-disk sets). A tmux id is reaped only when it returns false.
   resumablePredicate: () => Promise<(id: string) => boolean>;
+}
+
+// Whether an orphan tmux session is safe to reap. Not resumable is necessary but not
+// sufficient: a second mulmoterminal process may have just created it (no transcript yet)
+// and be attached to it. We only reach here for ids THIS process isn't live on, so any
+// attached client is someone else — and a null count (tmux couldn't say) is treated as
+// "held", never killing what we can't confirm is free. Pure, hence unit-testable.
+export function orphanReapable(resumable: boolean, attachedCount: number | null): boolean {
+  if (resumable) return false;
+  return attachedCount === 0;
 }
 
 export function mountTmuxRoutes(app: Express, deps: TmuxRouteDeps): void {
@@ -37,7 +51,9 @@ export function mountTmuxRoutes(app: Express, deps: TmuxRouteDeps): void {
     const isResumable = await deps.resumablePredicate();
     const killed: string[] = [];
     for (const id of deps.listTmuxIds()) {
-      if (isResumable(id)) continue;
+      // Skip a session another running mulmoterminal is attached to — killing it would
+      // yank a live session out from under that process (#747).
+      if (!orphanReapable(isResumable(id), deps.attachedClientCount(id))) continue;
       deps.killTmux(id);
       killed.push(id);
     }

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -48,7 +48,7 @@ import type { createClaudeSpawner } from "../session/spawn-claude.js";
 import type { createCodexSpawner } from "../session/spawn-codex.js";
 import type { createTranslationWorker } from "../session/translation-worker.js";
 import type { createTitleManager } from "../session/session-title.js";
-import { tmuxHasSession, tmuxKillSession, tmuxListSessionIds } from "../infra/tmux.js";
+import { tmuxHasSession, tmuxKillSession, tmuxListSessionIds, tmuxAttachedClientCount } from "../infra/tmux.js";
 import { resumableSessionPredicate } from "../session/resumable-sessions.js";
 import { SPA_FALLBACK_RE } from "../infra/spa-fallback.js";
 
@@ -278,6 +278,7 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
     hasTmux: tmuxHasSession,
     killTmux: tmuxKillSession,
     listTmuxIds: tmuxListSessionIds,
+    attachedClientCount: tmuxAttachedClientCount,
     resumablePredicate: resumableSessionPredicate,
   });
 }

--- a/test/bin/wait-ready.spec.ts
+++ b/test/bin/wait-ready.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { probeOnce, waitUntilReady } from "../../bin/wait-ready.js";
+
+type FakeReq = EventEmitter & { destroy: () => void; destroyed: boolean };
+
+// A fake ClientRequest that lets a test drive error / timeout / response, and records
+// whether destroy() was called. Mirrors the http.ClientRequest surface probeOnce uses.
+function fakeReq(): FakeReq {
+  const req = new EventEmitter() as FakeReq;
+  req.destroyed = false;
+  req.destroy = () => {
+    req.destroyed = true;
+    // Node emits 'error' ("socket hang up") when you destroy an in-flight request — the
+    // exact behavior that used to double-fire the retry.
+    req.emit("error", new Error("socket hang up"));
+  };
+  return req;
+}
+
+describe("probeOnce", () => {
+  it("resolves 'ready' when the server answers", async () => {
+    const req = fakeReq();
+    const get = vi.fn((_opts: unknown, cb: (res: { resume(): void }) => void) => {
+      queueMicrotask(() => cb({ resume() {} }));
+      return req;
+    });
+    expect(await probeOnce(get, 3000)).toBe("ready");
+  });
+
+  it("resolves 'retry' on a connection error", async () => {
+    const req = fakeReq();
+    const get = vi.fn(() => {
+      queueMicrotask(() => req.emit("error", new Error("ECONNREFUSED")));
+      return req;
+    });
+    expect(await probeOnce(get, 3000)).toBe("retry");
+  });
+
+  // Regression (#747): a timeout calls req.destroy(), which itself emits 'error'. Without
+  // the settled latch that produced TWO outcomes (two retries) from one probe, forking the
+  // poll loop. probeOnce must resolve exactly once.
+  it("yields a single 'retry' on timeout even though destroy() also emits 'error'", async () => {
+    const req = fakeReq();
+    const get = vi.fn(() => {
+      queueMicrotask(() => req.emit("timeout"));
+      return req;
+    });
+    const resolved = vi.fn();
+    const p = probeOnce(get, 3000).then(resolved);
+    await p;
+    // Give any stray error-driven resolution a chance to (wrongly) fire.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(req.destroyed).toBe(true);
+    expect(resolved).toHaveBeenCalledTimes(1);
+    expect(resolved).toHaveBeenCalledWith("retry");
+  });
+});
+
+describe("waitUntilReady", () => {
+  it("calls onReady exactly once after retries, never forking on a timeout", async () => {
+    let calls = 0;
+    // First probe times out (fires timeout + destroy's error), then the server answers.
+    const get = vi.fn((_opts: unknown, cb: (res: { resume(): void }) => void) => {
+      const req = fakeReq();
+      calls += 1;
+      if (calls === 1) queueMicrotask(() => req.emit("timeout"));
+      else queueMicrotask(() => cb({ resume() {} }));
+      return req;
+    });
+    const onReady = vi.fn();
+    waitUntilReady(3000, onReady, { get, intervalMs: 1, readyTimeoutMs: 5000 });
+    await vi.waitFor(() => expect(onReady).toHaveBeenCalled(), { timeout: 1000 });
+    await new Promise((r) => setTimeout(r, 20)); // let any fork try to fire again
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after readyTimeoutMs without calling onReady", async () => {
+    const get = vi.fn(() => {
+      const req = fakeReq();
+      queueMicrotask(() => req.emit("error", new Error("ECONNREFUSED")));
+      return req;
+    });
+    const onReady = vi.fn();
+    const now = vi.fn().mockReturnValueOnce(0).mockReturnValue(10_000); // immediately past the deadline
+    waitUntilReady(3000, onReady, { get, intervalMs: 1, readyTimeoutMs: 5000, now });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it("stops polling once cancelled", async () => {
+    const get = vi.fn(() => {
+      const req = fakeReq();
+      queueMicrotask(() => req.emit("error", new Error("ECONNREFUSED")));
+      return req;
+    });
+    const onReady = vi.fn();
+    const cancel = waitUntilReady(3000, onReady, { get, intervalMs: 1, readyTimeoutMs: 5000 });
+    cancel();
+    const before = get.mock.calls.length;
+    await new Promise((r) => setTimeout(r, 20));
+    expect(get.mock.calls.length).toBeLessThanOrEqual(before + 1);
+    expect(onReady).not.toHaveBeenCalled();
+  });
+});

--- a/test/server/backends/mutateStatus.spec.ts
+++ b/test/server/backends/mutateStatus.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { mutateStatus } from "../../../server/backends/mutateStatus.js";
+import { mutateStatus, mutateWriteApplied } from "../../../server/backends/mutateStatus.js";
 
 describe("mutateStatus", () => {
   it.each([["view-not-found"], ["item-not-found"]])("answers 404 for the missing target %s", (kind) => {
@@ -19,7 +19,7 @@ describe("mutateStatus", () => {
     expect(mutateStatus(kind)).toBe(403);
   });
 
-  it.each([["invalid-patch"], ["invalid-id"], ["too-large"], ["not-mobile"]])("answers 400 for the malformed request %s", (kind) => {
+  it.each([["invalid-patch"], ["invalid-id"], ["not-mobile"]])("answers 400 for the malformed request %s", (kind) => {
     expect(mutateStatus(kind)).toBe(400);
   });
 
@@ -31,5 +31,19 @@ describe("mutateStatus", () => {
 
   it("keeps the read-only case distinct from every policy refusal", () => {
     expect(mutateStatus("read-only-collection")).not.toBe(mutateStatus("not-writable"));
+  });
+});
+
+describe("mutateWriteApplied", () => {
+  // Regression (#747): "too-large" means the write APPLIED but its response was oversized —
+  // callers must treat it as success (refetch), never a 4xx that shows the edit as failed.
+  it("is true only for too-large (an applied write with an oversized response)", () => {
+    expect(mutateWriteApplied({ kind: "too-large", bytes: 1 })).toBe(true);
+  });
+
+  it("is false for genuine failures and for a plain ok", () => {
+    for (const kind of ["ok", "not-writable", "item-not-found", "read-only-collection", "invalid-patch", "path-escape"]) {
+      expect(mutateWriteApplied({ kind })).toBe(false);
+    }
   });
 });

--- a/test/server/infra/tmux-routes.spec.ts
+++ b/test/server/infra/tmux-routes.spec.ts
@@ -47,6 +47,7 @@ function baseDeps(over: Partial<TmuxRouteDeps> = {}): TmuxRouteDeps {
     hasTmux: () => false,
     killTmux: vi.fn(),
     listTmuxIds: () => [],
+    attachedClientCount: () => 0, // nobody else attached, by default
     resumablePredicate: async () => () => false,
     ...over,
   };
@@ -116,5 +117,39 @@ describe("mountTmuxRoutes — POST /api/tmux/cleanup-orphans", () => {
     await cleanup({ headers: {}, params: {} }, res);
     expect(killTmux.mock.calls.map((c) => c[0])).toEqual(["orphan-1", "orphan-2"]);
     expect(res.payload).toEqual({ killed: ["orphan-1", "orphan-2"], killedCount: 2 });
+  });
+
+  // Regression (#747): a second mulmoterminal process may have just created a session (no
+  // transcript yet, so not resumable here) and be attached to it. Killing it would yank a
+  // live session out from under that process, so an orphan another process holds is spared.
+  it("spares a non-resumable session that another process is attached to", async () => {
+    const killTmux = vi.fn();
+    const attached = new Map<string, number | null>([
+      ["mine-orphan", 0], // no one attached → really an orphan
+      ["theirs", 1], // another process holds it
+      ["unknown", null], // tmux couldn't say → treat as held
+    ]);
+    const { cleanup } = mountAndCapture(
+      baseDeps({
+        killTmux,
+        listTmuxIds: () => ["mine-orphan", "theirs", "unknown"],
+        attachedClientCount: (id) => (attached.has(id) ? (attached.get(id) ?? null) : 0),
+        resumablePredicate: async () => () => false, // none resumable
+      }),
+    );
+    const res = makeRes();
+    await cleanup({ headers: {}, params: {} }, res);
+    expect(killTmux.mock.calls.map((c) => c[0])).toEqual(["mine-orphan"]);
+    expect(res.payload).toEqual({ killed: ["mine-orphan"], killedCount: 1 });
+  });
+});
+
+describe("orphanReapable", () => {
+  it("reaps only a non-resumable session with zero attached clients", async () => {
+    const { orphanReapable } = await import("../../../server/infra/tmux-routes.js");
+    expect(orphanReapable(false, 0)).toBe(true);
+    expect(orphanReapable(true, 0)).toBe(false); // resumable → never
+    expect(orphanReapable(false, 1)).toBe(false); // another process holds it
+    expect(orphanReapable(false, null)).toBe(false); // unknown → treat as held
   });
 });


### PR DESCRIPTION
## Summary

3 件を修正。

1. **`waitUntilReady` のポーリング分裂**: timeout ハンドラの `req.destroy()` が 'error' を発火し、`req.on("error", retry)` が二重に retry を呼ぶため、ポーリング連鎖が指数的に分裂 → サーバ応答時にバナー多重表示・ブラウザ多重起動。
2. **cleanup-orphans が他プロセスのセッションを kill**: 自プロセスの状態しか見ず、別 mulmoterminal が新規作成した（トランスクリプト無し）セッションを孤児と誤判定して kill。
3. **mutate too-large で書き込み済みなのに 400**: UI が編集失敗と表示し古いデータを保持。

## Items to Confirm / Review

- **ポーリング**: `bin/wait-ready.js`（+`.d.ts`）に切り出し。`probeOnce` が1プローブ＝1結果を保証（Promise）、`waitUntilReady` は直列 await ループで fork 不可能。注入可能にして単体テスト。`mulmoterminal.js` は import に置換。
- **孤児判定**: pure `orphanReapable(resumable, attachedCount)`。cleanup 到達時 id は自プロセスの live に無い → `attachedCount>=1` は他プロセス保持。`resumable でない かつ attachedCount===0` のみ kill、null は安全側（保持）。dep に `tmuxAttachedClientCount` を配線。メモリの follow-up（別プロセス共有警告）と同根。
- **too-large**: 型ガード `mutateWriteApplied(result)` で narrow。両ハンドラ（desktop preview / phone channel）で成功扱い `{op,id,applied:true,warning}` にし refetch を促す。**注**: 応答 shape が `{item}` から `{applied,warning}` に変わるので、クライアント（mulmoserver/app）側の対応が別途必要な場合あり — レビューで確認希望。
- 3 件ともミューテーション（ready 時 return 削除 / attachedCount 無視 / 常に false）で該当テストが赤になることを確認済み。

## User Prompt

> mulmoclaude で全ファイルをレビューして pure 関数化できる部分は関数化しつつバグを探したら結構なバグがあったんだけど、こっちでもできる？

全ファイルレビュー（マルチエージェント）で検出したバグの issue 化（#740〜#748）と順次対応の一環。

## テスト

- `wait-ready.spec.ts`（新規）、`tmux-routes.spec.ts`、`mutateStatus.spec.ts` に回帰テスト追加。全 3551 テスト + typecheck(server/test/app) + lint + build パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)