### PR TITLE
feat: grid view の右アイコン群に worklog（#worklog）ショートカットを追加 (#764)

### DIFF
--- a/plans/feat-764-worklog-header-shortcut.md
+++ b/plans/feat-764-worklog-header-shortcut.md
@@ -1,0 +1,34 @@
+# feat: grid view の右アイコン群に worklog ショートカットを追加（#764）
+
+## User Prompt
+
+> worklogをwikiにかきだしているけど、そのショートカットってどこにあったっけ？
+> grid viewにしたときに、右上の方のアイコン群からリンクがあれば良い
+
+（クリア済みの仕様）
+- リンク先: **#worklog タグで絞り込んだ Wiki** を開く
+- 配置: **grid view のときだけ、右のアイコン群に**
+
+## 背景
+
+worklog はスケジュールタスクで Wiki（ハブ `data/wiki/pages/worklog.md` ＋ 週次 `dev-log-YYYY-www`、`#worklog` タグ）に書き出される。素早く辿る導線が無く、既存の Wiki ボタンは Wiki インデックスを開くだけ。
+
+## 実装
+
+- `src/components/wikiTagFilter.ts`: `parseTagQuery(raw)` を追加（router クエリ値 `string | string[] | null` → タグ Set、trim・空・非文字列を除去、重複除去）。pure でテスト可能。
+- `src/components/WikiIndexView.vue`: `selected` を `?tag=` クエリで初期化し、クエリ変化を `watch`（既に index を開いた状態で別タグへ来ても再適用）。手動チップトグルはローカル state を更新。
+- `src/composables/useWikiBrowse.ts`: `wikiGotoTag(tag)` を追加（`/wiki?tag=<tag>` へ push）。
+- `src/components/AppToolbar.vue`: `v-if="inGrid"` の Worklog ボタン（icon `history_edu`）を右グループ（Sound の前）に追加。クリックで `wikiGotoTag("worklog")`。`worklogActive` computed で #worklog Wiki を開いている間ハイライト。
+
+## テスト
+
+- `test/src/components/wikiTagFilter.spec.ts`: `parseTagQuery` の単一/配列/trim/空/重複除去。
+- 実アプリで検証（ヘッドレス Chrome）: grid に Worklog ボタン表示・chat には非表示（grid限定）・クリックで Wiki が #worklog で絞り込まれ「作業ログ 一覧」表示・設定ボタン(⚙)は健在。
+
+AppToolbar はルーター/多数 composable に依存する薄いビューで既存 spec 無し（pure ロジックを切り出してテストする方針）のため、判定は `parseTagQuery` の単体テスト＋実アプリ検証でカバー。
+
+全 3656 テスト + typecheck(app/test) + lint + build パス。
+
+## 補足（別件の調査）
+
+同時に相談のあった「grid view で設定ボタンが消える」件は、現行コード・稼働ビルドとも 480〜1400px の全幅で ⚙ が表示され再現せず（古いブラウザキャッシュの疑い → ハード再読み込みを案内済み）。本 PR とは独立。

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -8,11 +8,12 @@ import LauncherButton from "./LauncherButton.vue";
 import { useShortcuts } from "../composables/useShortcuts";
 import { useCollectionBrowse, browseGotoIndex, browseGotoDetail } from "../composables/useCollectionBrowse";
 import { useAccountingView, accountingViewOpen } from "../composables/useAccountingView";
-import { useWikiBrowse, wikiGotoIndex } from "../composables/useWikiBrowse";
+import { useWikiBrowse, wikiGotoIndex, wikiGotoTag } from "../composables/useWikiBrowse";
 import { usePrsView, prsGotoIndex } from "../composables/usePrsView";
 import { useSoundEnabled } from "../composables/useSoundEnabled";
 import { useUpdateStatus } from "../composables/useUpdateStatus";
 import { useDropdownMenu } from "../composables/useDropdownMenu";
+import { parseTagQuery } from "./wikiTagFilter";
 import type { Shortcut } from "../types/shortcuts";
 import type { StatusCounts } from "./gridTabs";
 import { gridStatusSummary } from "./gridTabs";
@@ -92,6 +93,13 @@ function showAccounting(): void {
 }
 function showWiki(): void {
   wikiGotoIndex();
+}
+// Grid-only shortcut to the dev worklog: the wiki filtered to the #worklog tag (the weekly
+// dev-log pages the scheduled worklog task writes).
+const WORKLOG_TAG = "worklog";
+const worklogActive = computed(() => wikiOpen.value && parseTagQuery(route.query.tag).has(WORKLOG_TAG));
+function showWorklog(): void {
+  wikiGotoTag(WORKLOG_TAG);
 }
 function showPrs(): void {
   prsGotoIndex();
@@ -191,6 +199,14 @@ function showPrs(): void {
         <p v-else class="text-muted">{{ updateBadge.text }}</p>
       </div>
     </div>
+    <LauncherButton
+      v-if="inGrid"
+      icon="history_edu"
+      title="Worklog — the dev work log in the wiki (#worklog)"
+      label="Worklog"
+      :active="worklogActive"
+      @click="showWorklog"
+    />
     <LauncherButton
       :icon="soundEnabled ? 'notifications_active' : 'notifications_off'"
       :title="soundEnabled ? 'Attention sound on' : 'Attention sound off'"

--- a/src/components/WikiIndexView.vue
+++ b/src/components/WikiIndexView.vue
@@ -2,15 +2,26 @@
 // The wiki page catalog: a tag filter + one card per page, parsed from index.md by the
 // shared core engine (entries come straight from GET /api/wiki). Clicking a card opens
 // the page; clicking a tag chip filters the list (AND across selected tags). Read-only.
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
+import { useRoute } from "vue-router";
 import type { WikiPageEntry } from "@mulmoclaude/core/wiki";
 import FilterChip from "./FilterChip.vue";
 import { wikiGotoPage } from "../composables/useWikiBrowse";
-import { filterChips, filterEntriesByTags } from "./wikiTagFilter";
+import { filterChips, filterEntriesByTags, parseTagQuery } from "./wikiTagFilter";
 
 const props = defineProps<{ entries: WikiPageEntry[] }>();
 
-const selected = ref<Set<string>>(new Set());
+const route = useRoute();
+// Pre-select tags named by `?tag=` (the Worklog header shortcut opens `/wiki?tag=worklog`).
+// Watched so arriving at an already-open index via a new tag re-applies the filter; manual
+// chip toggles below then take over local state without touching the URL.
+const selected = ref<Set<string>>(parseTagQuery(route.query.tag));
+watch(
+  () => route.query.tag,
+  (tag) => {
+    selected.value = parseTagQuery(tag);
+  },
+);
 
 const visibleTags = computed(() => filterChips(props.entries, selected.value));
 const filtered = computed(() => filterEntriesByTags(props.entries, selected.value));

--- a/src/components/wikiTagFilter.ts
+++ b/src/components/wikiTagFilter.ts
@@ -50,3 +50,11 @@ export const filterEntriesByTags = (entries: WikiPageEntry[], selected: Readonly
     return [...selected].every((tag) => tags.has(tag));
   });
 };
+
+// The tags a `?tag=` wiki-index query names, as a set to pre-select. A router query value is
+// `string | string[] | null` (repeated `?tag=a&tag=b` → array); non-strings and blanks are
+// dropped. Pure so the "open the wiki filtered by #worklog" deep-link is unit-testable.
+export const parseTagQuery = (raw: unknown): Set<string> => {
+  const values = Array.isArray(raw) ? raw : [raw];
+  return new Set(values.filter((v): v is string => typeof v === "string" && v.trim().length > 0).map((v) => v.trim()));
+};

--- a/src/composables/useWikiBrowse.ts
+++ b/src/composables/useWikiBrowse.ts
@@ -17,6 +17,12 @@ export function wikiGotoIndex(): void {
   router.push("/wiki");
 }
 
+/** Open the wiki index pre-filtered to a tag (e.g. the Worklog shortcut → `#worklog`).
+ *  WikiIndexView reads `?tag=` into its initial selection. */
+export function wikiGotoTag(tag: string): void {
+  router.push({ path: "/wiki", query: { tag } });
+}
+
 /** Open one page by slug. Unsafe slugs are coerced to the index rather than pushing a
  *  route the API would reject — the guard mirrors the server's isSafeWikiSlug. */
 export function wikiGotoPage(slug: string): void {

--- a/test/src/components/wikiTagFilter.spec.ts
+++ b/test/src/components/wikiTagFilter.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { WikiPageEntry } from "@mulmoclaude/core/wiki";
-import { tagCounts, filterChips, filterEntriesByTags, TARGET_FILTER_CHIPS } from "../../../src/components/wikiTagFilter";
+import { tagCounts, filterChips, filterEntriesByTags, parseTagQuery, TARGET_FILTER_CHIPS } from "../../../src/components/wikiTagFilter";
 
 const entry = (slug: string, tags: string[]): WikiPageEntry => ({ title: slug, slug, description: "", tags });
 
@@ -103,5 +103,29 @@ describe("filterEntriesByTags", () => {
 
   it("returns nothing when no entry carries all selected tags", () => {
     expect(filterEntriesByTags(entries, new Set(["x", "y", "z", "missing"]))).toEqual([]);
+  });
+});
+
+describe("parseTagQuery", () => {
+  it("reads a single tag from a string query", () => {
+    expect([...parseTagQuery("worklog")]).toEqual(["worklog"]);
+  });
+
+  it("reads repeated tags from an array query", () => {
+    expect([...parseTagQuery(["worklog", "notes"])]).toEqual(["worklog", "notes"]);
+  });
+
+  it("trims whitespace and drops blank / non-string values", () => {
+    expect([...parseTagQuery(["  worklog  ", "", "   ", 5, null])]).toEqual(["worklog"]);
+  });
+
+  it("is empty for null / undefined / a blank string (no filter)", () => {
+    expect(parseTagQuery(null).size).toBe(0);
+    expect(parseTagQuery(undefined).size).toBe(0);
+    expect(parseTagQuery("").size).toBe(0);
+  });
+
+  it("de-duplicates repeated tags", () => {
+    expect([...parseTagQuery(["worklog", "worklog"])]).toEqual(["worklog"]);
   });
 });


### PR DESCRIPTION
## Summary

grid view のとき、global header の**右アイコン群**に「Worklog」ボタンを追加。クリックで **Wiki を `#worklog` タグで絞り込んだ状態**（週次 dev-log を書き出しているハブ「作業ログ 一覧」）で開きます。

## Items to Confirm / Review

- **配置**: `AppToolbar.vue` の右グループ（Sound の前）に `v-if="inGrid"` で追加。chat view には出ません（要望どおり grid 限定）。アイコンは `history_edu`。
- **リンク先**: `wikiGotoTag("worklog")` → `/wiki?tag=worklog`。`WikiIndexView` が `?tag=` クエリを初期タグ選択に反映し、変化を watch（既に index を開いていても再適用）。
- **pure 関数化 + テスト**: クエリ→タグ Set の変換を `parseTagQuery`（`wikiTagFilter.ts`）に切り出し単体テスト（単一/配列/trim/空/重複除去）。
- **実アプリ検証（ヘッドレス Chrome）**: grid にボタン表示・chat には非表示・クリックで #worklog 絞り込み表示・**設定ボタン(⚙)は健在**、をスクショで確認済み。

## User Prompt

> worklogをwikiにかきだしているけど、そのショートカットってどこにあったっけ？
> grid viewにしたときに、右上の方のアイコン群からリンクがあれば良い

（クリア: リンク先=#worklog タグの Wiki / 配置=grid view のときだけ右のアイコン群に）

## 補足

同時相談の「grid で設定ボタンが消える」件は、現行コード・稼働ビルドとも全幅で ⚙ 表示され再現せず（古いブラウザキャッシュの疑い → ハード再読み込みを案内）。本 PR とは独立です。

## テスト

`wikiTagFilter.spec.ts` に `parseTagQuery` の5ケース追加。全 3656 テスト + typecheck(app/test) + lint + build パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)