### PR TITLE
fix: list only grid sessions in the phone's terminal view (#766)

### DIFF
--- a/plans/fix-766-phone-terminal-list-grid-only.md
+++ b/plans/fix-766-phone-terminal-list-grid-only.md
@@ -1,0 +1,45 @@
+# fix: 電話（mulmoserver）の端末一覧を grid セッションのみに絞る (#766)
+
+## 原因
+
+RemoteHost 経由でスマホへ送る端末一覧は `server/index.ts` の
+`remoteHostListTerminalSessions` → `buildSessionList()`
+（`server/backends/remoteHost/terminalScreen.ts`）で作られる。ここは live な pty 全部 +
+tmux 全部を `isResumable` と「title あり or live」だけで絞っており、**grid セッション集合に
+よる絞り込みが無い**。そのため単一ビュー(chat)セッションや、grid セルでない tmux 常駐シェルまで
+電話に出ていた。
+
+「grid view のものだけに絞る」変更を入れたつもりだったが、全 ref・stash・reflog を探しても
+存在せず＝未実装だった（`remoteHostListTerminalSessions` は初出の #435 以降触られていない）。
+
+grid セル（`gui=0`）は生成時に `markDevTerminalSession()`（`server/session/registry.ts`）で
+`devTerminalSessions` 集合に登録され、ディスク永続＋ハイドレートされる（元は chat サイドバーから
+grid を隠す用途）。この集合を intersect すれば grid のみに絞れる。
+
+## 修正
+
+1. **`buildSessionList` に純粋述語 `isGridSession: (id) => boolean` を追加**し、id を
+   `.filter(isResumable).filter(isGridSession)` で絞る（規則は純粋関数側に置き、テスト可能に）。
+2. **呼び出し側（`server/index.ts`）で `isGridSession: (id) => devTerminalSessions.has(id)` を
+   渡す**。`resumableSessionPredicate()` が既に `devTerminalSessionsHydrated` を await 済みなので、
+   `buildSessionList` 実行時点で集合はハイドレート済み（追加 await 不要）。
+
+## 効果
+
+電話の端末一覧は **grid セルのみ**。単一ビュー(chat)セッション・grid でない tmux シェル・
+内部ワーカーは除外される（それらが live/resumable でも出さない）。
+
+## テスト
+
+`test/server/backends/remoteHost/terminalScreen.spec.ts` に 2 ケース追加：
+
+- live だが grid でないセッションを落とす（chat を除外）。
+- tmux のみで生き残った grid セッションは残し、隣の非 grid tmux シェルは落とす（再起動後も
+  永続集合が名前を保つ）。
+
+ミューテーション確認：`.filter(isGridSession)` を外すと上記 2 ケースが赤くなることを検証済み。
+
+## 非対象
+
+- grid の resume picker（#724 で revert 済み）や chat サイドバーの隠蔽（既存動作）には触れない。
+- mulmoserver（別リポの PWA）側は変更しない。送信元で絞るのが確実。

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -48,6 +48,10 @@ export interface SessionListInput {
   // Excludes sessions an orphan cleanup would reap — without it the picker fills with
   // long-dead tmux shells (66 of them on the author's machine when this was written).
   isResumable: (id: string) => boolean;
+  // Keeps only multi-terminal GRID sessions (the dev-terminal set). The phone drives the
+  // grid's cells, so the single-view chat session and any tmux shell that was never a grid
+  // cell are excluded — even while they are live and resumable.
+  isGridSession: (id: string) => boolean;
   detailOf: (id: string) => SessionDetail;
 }
 
@@ -60,9 +64,9 @@ const byLiveThenTitle = (a: TerminalSessionSummary, b: TerminalSessionSummary): 
 // dozens of long-finished ones the host can no longer name. A row showing nothing but
 // a UUID is not a choice the user can make, so a nameless session earns its place only
 // by being live — where the id at least identifies something currently running.
-export function buildSessionList({ liveIds, tmuxIds, isResumable, detailOf }: SessionListInput): TerminalSessionSummary[] {
+export function buildSessionList({ liveIds, tmuxIds, isResumable, isGridSession, detailOf }: SessionListInput): TerminalSessionSummary[] {
   const live = new Set(liveIds);
-  const ids = [...new Set([...liveIds, ...tmuxIds])].filter(isResumable);
+  const ids = [...new Set([...liveIds, ...tmuxIds])].filter(isResumable).filter(isGridSession);
   return ids
     .map((id) => ({ id, ...detailOf(id), live: live.has(id) }))
     .filter((session) => session.title !== "" || session.live)

--- a/server/index.ts
+++ b/server/index.ts
@@ -35,7 +35,7 @@ import { generateHeaderTitle } from "./config/header-title.js";
 import { mountTerminalWebSockets } from "./routes/ws-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
-import { activity, aiTitles, hiddenSessions, knownSessions, ptys } from "./session/registry.js";
+import { activity, aiTitles, devTerminalSessions, hiddenSessions, knownSessions, ptys } from "./session/registry.js";
 import { runWithHiddenMarker } from "./session/hiddenMarker.js";
 import { createToolStores } from "./session/tool-store.js";
 import { createScheduledSessionRegistry, scheduledSessionInUse, scheduledSessionsDir } from "./session/scheduled-sessions.js";
@@ -324,6 +324,10 @@ const remoteHostListTerminalSessions = async () =>
     liveIds: [...ptys.keys()],
     tmuxIds: tmuxListSessionIds(),
     isResumable: await resumableSessionPredicate(),
+    // The phone lists the multi-terminal grid's cells only — not the single-view chat
+    // session or a tmux shell that was never a grid cell. resumableSessionPredicate()
+    // above already awaited devTerminalSessionsHydrated, so this set is fully seeded.
+    isGridSession: (id) => devTerminalSessions.has(id),
     // Empty title rather than the id as a fallback — buildSessionList uses "nameless"
     // to drop the long tail of finished sessions the phone can't meaningfully offer.
     detailOf: (id) => ({

--- a/test/server/backends/remoteHost/terminalScreen.spec.ts
+++ b/test/server/backends/remoteHost/terminalScreen.spec.ts
@@ -15,6 +15,7 @@ const listInput = (over: Partial<SessionListInput> = {}): SessionListInput => ({
   liveIds: [],
   tmuxIds: [],
   isResumable: () => true,
+  isGridSession: () => true,
   detailOf: (id) => ({ title: id, cwd: "/w", agent: "shell" as const }),
   ...over,
 });
@@ -86,6 +87,20 @@ describe("buildSessionList", () => {
   it("drops sessions an orphan cleanup would reap", () => {
     const sessions = buildSessionList(listInput({ tmuxIds: ["keep", "dead"], isResumable: (id) => id === "keep" }));
     expect(sessions.map((s) => s.id)).toEqual(["keep"]);
+  });
+
+  // The phone drives the grid's cells: a live single-view chat session is not one of them
+  // and must not show up, even though it is live and resumable.
+  it("drops a live session that is not a grid cell", () => {
+    const sessions = buildSessionList(listInput({ liveIds: ["grid", "chat"], isGridSession: (id) => id === "grid" }));
+    expect(sessions.map((s) => s.id)).toEqual(["grid"]);
+  });
+
+  // A grid cell that outlived a restart lives only in tmux; the persisted dev-terminal set
+  // still names it, so it stays offerable while a non-grid tmux shell alongside it is dropped.
+  it("keeps a tmux-only grid session and drops a non-grid tmux shell", () => {
+    const sessions = buildSessionList(listInput({ tmuxIds: ["grid", "shell"], isGridSession: (id) => id === "grid" }));
+    expect(sessions.map((s) => s.id)).toEqual(["grid"]);
   });
 
   // Resumable keeps anything with a transcript on disk, which on a working machine is


### PR DESCRIPTION
Closes #766

## Summary

The remote-host terminal list sent to the phone (mulmoserver) was built from **every** live pty + tmux session, filtered only by `isResumable` and "has a title / is live". It never restricted to the multi-terminal **grid** — so the single-view chat session and non-grid tmux shells showed up on the phone too.

The "grid view only" filter the author believed had been added **was never actually in the code** (not on `main`, not on any branch, not in stash/reflog — `remoteHostListTerminalSessions` hadn't been touched since #435). This adds it.

**Fix** (one rule, in a pure function, + wiring):
- `server/backends/remoteHost/terminalScreen.ts` — `buildSessionList` gains a pure `isGridSession` predicate; ids are filtered `.filter(isResumable).filter(isGridSession)`.
- `server/index.ts` — passes `isGridSession: (id) => devTerminalSessions.has(id)`. That set (grid/dev-terminal cells, `gui=0`) is already persisted and hydrated — `resumableSessionPredicate()` above awaits `devTerminalSessionsHydrated`, so no extra await is needed, and grid cells that outlived a restart stay listed.

**Effect:** the phone lists **grid cells only**. The single-view chat session, non-grid tmux shells, and internal workers are excluded (even while live/resumable).

## Items to Confirm / Review

- **Behavior is intentional and confirmed with the requester:** the single-view (chat) session is now **excluded** from the phone list — the phone drives the grid's cells only. Flag if any non-grid session should still be reachable from the phone.
- **Hydration timing:** the filter reads `devTerminalSessions` synchronously inside `buildSessionList`, relying on `resumableSessionPredicate()` (called on the line above) having already awaited `devTerminalSessionsHydrated`. If that ordering ever changes, a fresh-boot phone poll could momentarily drop tmux-only grid survivors. Please sanity-check that coupling.
- **Set membership:** `devTerminalSessions` is append-only (ids are never removed). A grid cell that is closed stays in the set, so its tmux/on-disk survivor remains offerable — consistent with the resume-picker behavior. Confirm that's desired.

## User Prompt

> I'm pretty sure I made a change so that when we send the terminal list to mulmoserver, it filters to grid view only — but it doesn't seem to be working. Can you check and fix it?
>
> (Confirmed: exclude everything that isn't a grid cell, including the single-view chat session.)

## Test

`test/server/backends/remoteHost/terminalScreen.spec.ts` — two cases added:
- drops a live session that is not a grid cell (chat excluded);
- keeps a tmux-only grid survivor and drops a non-grid tmux shell beside it.

Mutation-checked: removing `.filter(isGridSession)` turns both red. Full suite green (267 files / 3653 tests), plus build / lint / typecheck / format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)