### PR TITLE
fix: grid expand 時に設定ボタンが view-toggle(☰) に覆われて消える (#768)

### DIFF
--- a/plans/fix-768-grid-expand-settings-overlap.md
+++ b/plans/fix-768-grid-expand-settings-overlap.md
@@ -1,0 +1,33 @@
+# fix: grid expand 時に設定ボタンが view-toggle に覆われる（#768）
+
+## User Prompt
+
+> 右上のアイコン群、grid viewにすると設定ボタンが消えるからなおして
+> grid + expand時にでないのだ。
+
+## 症状
+
+grid view で**セルを expand した時だけ**、global header の設定ボタン（⚙）が消え、白い ☰ ボックスに置き換わって見える。
+
+## 原因
+
+`TerminalGrid.vue` の zoom 時に出る view-toggle ボタン（`☰`/`▤`、list⇔strip 切替）は
+`position: absolute; right: 12px; top: 8px; z-index: 10`。しかし親 `.stage` に `position` が無く（static）、
+祖先チェーン（`.stage` → GridView の flex 列 → App）にも positioned 要素が無いため、
+絶対配置の基準が **viewport（初期包含ブロック）** になる。結果、ボタンはウィンドウ右上＝ツールバーの
+設定ボタン位置に来て、z-10 で ⚙ を覆う。`overflow: hidden` は包含ブロックを作らない（position/transform 等が必要）。
+
+## 修正
+
+`src/components/TerminalGrid.vue` の `.stage` に `position: relative` を追加（+ 理由コメント）。
+view-toggle は `.stage`（ツールバーの下）の右上に収まり、⚙ が復活。off-screen `.grid`（`left:-99999px`）等
+他の絶対配置子は基準が viewport→.stage に変わるが位置は不変（-99999px は依然オフスクリーン）。
+
+## 検証
+
+- 最小 HTML でツールバー＋非 positioned `.stage`＋絶対 top-right ボタンを再現。
+  position 無し → ☰ が⚙を覆う（ユーザー報告スクショと一致）。`position: relative` → ⚙復活・☰は stage 内へ。
+- 通常（非expand）グリッドは回帰なし（実アプリでスクショ確認）。
+- CSS レイアウト修正のため jsdom 単体テスト不可（機構は最小再現＋コメントで固定）。
+
+typecheck(app) / build / 関連 grid テスト（29件）パス。

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -318,6 +318,10 @@ watch(
   min-height: 0;
   min-width: 0;
   background: var(--bg-deep);
+  /* Containing block for the absolutely-positioned view-toggle (☰) button. Without it the
+     toggle resolves against the viewport and lands over the global header's Settings gear,
+     covering it while a cell is expanded. */
+  position: relative;
 }
 
 .grid {


### PR DESCRIPTION
## Summary

grid view で**セルを expand した時だけ**、global header の設定ボタン（⚙）が消える不具合を修正。原因は、zoom 時に出る view-toggle ボタン（☰/▤）が `position: absolute` なのに親 `.stage` に `position` が無く、絶対配置の基準が **viewport** になってウィンドウ右上＝設定ボタンの位置に来て z-10 で覆っていたこと。`.stage` に `position: relative` を追加して包含ブロックを与え、トグルを stage 内（ツールバーの下）に収めた。

## Items to Confirm / Review

- **根本原因**: `.stage`（TerminalGrid ルート）に `position` が無く、祖先にも positioned 要素が無い（`overflow:hidden` は包含ブロックを作らない）ため、`absolute` の view-toggle が viewport 基準になっていた。
- **修正の副作用**: off-screen `.grid`（`left:-99999px`）など他の絶対配置子は基準が viewport→.stage に変わるが、位置は不変（オフスクリーンのまま）。通常グリッドの回帰なし。
- **検証**: 最小 HTML でツールバー＋非 positioned `.stage`＋絶対 top-right ボタンを再現 → position 無しで ☰ が⚙を覆う（**ユーザー報告スクショと一致**）、`position: relative` で⚙復活。実アプリで通常グリッドの回帰なしをスクショ確認。CSS レイアウト修正のため jsdom 単体テスト不可（機構は最小再現＋コード内コメントで固定）。

## User Prompt

> 右上のアイコン群、grid viewにすると設定ボタンが消えるからなおして
> grid + expand時にでないのだ。

## テスト

typecheck(app) / build / grid テスト（TerminalGrid + GridView, 29件）パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)