### PR TITLE
feat: add user-guide help links to empty grid and settings

### DIFF
--- a/plans/feat-guide-help-links.md
+++ b/plans/feat-guide-help-links.md
@@ -1,0 +1,43 @@
+# feat: 空グリッドと設定画面にユーザーガイドへのヘルプリンクを追加
+
+## 背景
+
+初めて使うユーザーが「使い方がわからない」ときに、アプリ内から
+ユーザーガイド（`receptron.github.io/mulmoterminal`）へたどり着く導線がなかった。
+グリッドビューでターミナルが1つも起動していない状態と、設定画面に
+ヘルプリンクを置く。
+
+## 方針
+
+日本語 / 英語のガイド着地ページへのリンクを共通コンポーネント化し、
+2箇所（空グリッドのフッター・設定モーダル）で再利用する。ロケール自動判定で
+片方だけ出すのではなく、両言語をそれぞれの言語名（日本語 / English）で
+自己ラベル表示する — 読める方をユーザー自身が選べる（README と同じ方式）。
+
+リンク先:
+- 日本語 → `https://receptron.github.io/mulmoterminal/guide/ja/`
+- English → `https://receptron.github.io/mulmoterminal/guide/en/`
+
+## 実装
+
+1. `src/components/GuideLinks.vue`（新規・共通コンポーネント）
+   - 「📖 Not sure how to use MulmoTerminal? Read the guide — 日本語 · English」の
+     1行ヒント。リンクは別タブ（`target="_blank" rel="noopener noreferrer"`）。
+2. `src/components/GridView.vue`
+   - `noRunningTerminals = runningCount(cells) === 0`（起動中ターミナルが無い＝
+     entry launch cell だけの状態）を computed で判定。
+   - `TerminalGrid` の下に、`noRunningTerminals` のときだけ `<GuideLinks>` のフッターを表示。
+     ターミナルが起動した瞬間に消える。
+3. `src/components/SettingsModal.vue`
+   - 末尾（Cost セクションの後、Close の前）に「Help & user guide」セクションを追加し
+     `<GuideLinks>` を配置。両シェル（グリッド／チャット）が同じモーダルを開くため両方に効く。
+4. テスト `test/src/components/GridView.spec.ts`
+   - ターミナル未起動時にフッター（ja/en リンク）が出て、起動中セルがあると消えることを検証。
+     ガード反転で red になることも確認済み。
+
+## 検証
+
+- `yarn format` / `yarn lint`（0 errors）/ `yarn build`（vue-tsc 含む）/ `yarn typecheck` — すべてグリーン。
+- `yarn test` — 全パス（GridView に回帰テスト1件追加）。
+- 新 SFC が実 Vite dev パイプラインでコンパイルされることを確認（HTTP 200）。
+- README は既に同ガイド URL を記載済みのため変更不要（アプリ内導線を足しただけ）。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -3,6 +3,7 @@ import { ref, reactive, computed, watch, onMounted, onBeforeUnmount, onActivated
 import TerminalGrid from "./TerminalGrid.vue";
 import AppSettingsModal from "./AppSettingsModal.vue";
 import AppToolbar from "./AppToolbar.vue";
+import GuideLinks from "./GuideLinks.vue";
 import { startCollectionChat } from "../composables/useChatLauncher";
 import { router } from "../router";
 import {
@@ -76,6 +77,10 @@ watch(
 );
 
 const pages = computed(() => pageCount(state.value.cells.length));
+
+// Nothing has been launched yet (only the entry launch cell) — show the newcomer a
+// pointer to the guide, cleared the moment any terminal starts.
+const noRunningTerminals = computed(() => runningCount(state.value.cells) === 0);
 
 // The "auto" order needs every cell's status, including cells on pages that aren't
 // mounted. useGridActivity tracks each cell session's live attention state by id —
@@ -422,6 +427,9 @@ function configureAppearance() {
       @status="onStatus"
       @list-mode="onListMode"
     />
+    <footer v-if="noRunningTerminals" class="flex-none border-t border-border bg-panel px-4 py-2 text-center">
+      <GuideLinks />
+    </footer>
     <AppSettingsModal v-if="showSettings" @configure-appearance="configureAppearance" @close="closeSettings" />
   </div>
 </template>

--- a/src/components/GuideLinks.vue
+++ b/src/components/GuideLinks.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+// The user guide's per-language landing pages, surfaced where a first-time user is most
+// likely stuck: the empty grid and the settings modal. Both languages are offered as
+// self-labelled links (日本語 / English) rather than a locale-detected single one — each
+// label is written in its own language, so a reader reaches the version they can read
+// without the app guessing from navigator.language.
+const GUIDE_JA = "https://receptron.github.io/mulmoterminal/guide/ja/";
+const GUIDE_EN = "https://receptron.github.io/mulmoterminal/guide/en/";
+const LINK_CLASS = "font-medium text-accent hover:underline";
+</script>
+
+<template>
+  <p class="m-0 font-sans text-[12px] text-dim">
+    📖 Not sure how to use MulmoTerminal? Read the guide —
+    <a :class="LINK_CLASS" :href="GUIDE_JA" target="_blank" rel="noopener noreferrer">日本語</a>
+    <span aria-hidden="true"> · </span>
+    <a :class="LINK_CLASS" :href="GUIDE_EN" target="_blank" rel="noopener noreferrer">English</a>
+  </p>
+</template>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -7,6 +7,7 @@ import { useCost } from "../composables/useCost";
 import { useGoogleLink } from "../composables/useGoogleLink";
 import SettingsButton from "./SettingsButton.vue";
 import SettingsField from "./SettingsField.vue";
+import GuideLinks from "./GuideLinks.vue";
 import type { Launcher } from "./launchers";
 import type { UserMcpServer } from "./userMcp";
 import { canAddLauncher, canAddMcpServer, canAddRepo } from "./settingsValidators";
@@ -463,6 +464,9 @@ onUnmounted(() => {
       <p v-else-if="cost && (cost.unpricedTurns > 0 || cost.sessionUnpricedTurns > 0)" class="mt-2 text-[12px] text-dim">
         Some turns used a model with no known price and are excluded from these estimates.
       </p>
+
+      <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Help &amp; user guide</h3>
+      <GuideLinks />
 
       <div class="mt-4 flex items-center gap-2">
         <span class="flex-1" />

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -101,6 +101,31 @@ describe("GridView roster ordering (#720)", () => {
   });
 });
 
+describe("GridView guide help (empty state)", () => {
+  it("shows the guide footer (ja/en links) when no terminal is running, and hides it once one is", async () => {
+    // Empty grid: ensureEntry leaves only the entry launch cell, so runningCount === 0.
+    const empty = await mountGrid();
+    const footer = empty.find("footer");
+    expect(footer.exists()).toBe(true);
+    const hrefs = footer.findAll("a").map((a) => a.attributes("href"));
+    expect(hrefs).toContain("https://receptron.github.io/mulmoterminal/guide/ja/");
+    expect(hrefs).toContain("https://receptron.github.io/mulmoterminal/guide/en/");
+    empty.unmount();
+
+    // A running session cell (occupied) — the newcomer hint must step out of the way.
+    localStorage.setItem(
+      "grid_v2",
+      JSON.stringify({ cells: [{ uid: 1, session: IDS.idleA, cwd: "/w" }], expanded: null, page: 0, sortMode: "manual" }),
+    );
+    const running = mount((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: true, AppToolbar: ToolbarStub, SettingsModal: SettingsStub } },
+    });
+    await flushPromises();
+    expect(running.find("footer").exists()).toBe(false);
+    running.unmount();
+  });
+});
+
 describe("GridView settings wiring", () => {
   it("passes pushEnabled to SettingsModal and saves it on update-push-enabled (regression #347)", async () => {
     const w = await mountGrid();


### PR DESCRIPTION
## Summary
First-time users had no in-app path to the user guide. This adds a link to the guide (日本語 / English) in the two places a stuck newcomer looks:
- **Empty grid** — a footer hint shows while no terminal is running (`runningCount === 0`), and disappears the moment any terminal starts.
- **Settings** — a new "Help & user guide" section (covers both the grid and chat shells, which share the modal).

Links point at the existing landing pages: `guide/ja/` and `guide/en/`. Both languages are shown as self-labelled links rather than locale-detected, so the reader picks the one they can read (same approach as the README).

## Items to Confirm / Review
- **Wording**: "📖 Not sure how to use MulmoTerminal? Read the guide — 日本語 · English". OK, or prefer different copy?
- **Grid placement**: a slim footer under the grid vs. somewhere more prominent.
- **English-only label**: the app has no static i18n (only a runtime-translation route for one string), so the intro text is English and consistent with the rest of the UI; the links themselves are language-named.
- **Visual check**: no browser was available in the dev environment, so appearance wasn't screenshotted — behavior is covered by a DOM test, and styling reuses existing Tailwind tokens (`border-border` / `bg-panel` / `text-dim` / `text-accent`, same `<h3>` as other settings sections).

## User Prompt
> グリッドビューでターミナルが何もないときと、設定画面にヘルプを作ってほしい。
> https://receptron.github.io/mulmoterminal/ の日本語・英語のページにリンクを張って、使い方がわからない場合のリンクにしたい。

## Implementation
- **`src/components/GuideLinks.vue`** (new) — shared one-line hint with the two guide links (`target="_blank" rel="noopener noreferrer"`), single source of truth for the URLs.
- **`src/components/GridView.vue`** — `noRunningTerminals` computed + a `<GuideLinks>` footer rendered only when it's true.
- **`src/components/SettingsModal.vue`** — "Help & user guide" section before the Close footer.
- **`test/src/components/GridView.spec.ts`** — regression test: footer + ja/en hrefs present with no terminals, gone once a session cell exists (verified to fail when the guard is inverted).
- **`plans/feat-guide-help-links.md`** — plan doc.

## Verification
`yarn format` / `yarn lint` (0 errors) / `yarn build` (incl. vue-tsc) / `yarn typecheck` — all green. `yarn test` — 3652 tests pass. README already documents these guide URLs, so no doc change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)