### PR TITLE
fix: expand 時の view-toggle をグローバルヘッダー左端へ移設（✕/歯車と非衝突・不要時は非表示）

### DIFF
--- a/plans/fix-grid-expand-toggle-covers-close.md
+++ b/plans/fix-grid-expand-toggle-covers-close.md
@@ -1,0 +1,38 @@
+# fix: expand 時に view-toggle(☰) がセルの ✕ 閉じるボタンを覆って閉じられない
+
+## User Prompt
+
+> あれれ、expand時のボタンを移動したせいで、今度は閉じられなくない？
+
+（#769 で `.stage { position: relative }` を入れた直後の回帰報告）
+
+## 背景 / 症状
+
+#769 で「grid+expand 時に設定歯車が view-toggle に覆われる」問題を、`.stage` に
+`position: relative` を与えて解決した。しかしこれで view-toggle（`☰`/`▤`、`absolute right-3 top-2 z-10`）
+の絶対配置基準が viewport → `.stage` に変わり、今度は **stage 右上 = zoom セル（`.zoom-main`）右上に固定された
+`.cell-actions`（⤢/⤡ 展開＋✕ 閉じる、各 28×26px）の真上**に乗ってしまい、✕ で閉じられなくなった。
+歯車の overlap を ✕ の overlap に付け替えてしまった形。
+
+## 原因
+
+view-toggle は右上固定。zoom セルの閉じる/展開ボタンも（セルは stage 右上を占めるため）stage 右上固定。
+両者が同じ右上コーナーで重なる。`.stage` を static に戻すと #768（歯車 overlap）が再発するので戻せない。
+
+## 修正
+
+view-toggle を stage の **左上**（`right-3` → `left-3`）へ移動。
+- 歯車（ヘッダ右上）とも ✕/⤡（セル右上）とも重ならない。
+- トグルは元々「左サイドパネル（コックピット/ストリップ）の表示切替」なので左上配置は意味的にも自然。
+- `.stage { position: relative }` は維持（無いと左上が viewport 基準になりヘッダのタイトル/ナビに乗る）。
+
+副作用: 左上はコックピット先頭行ヘッダ（listMode）／zoom セルのステータスドット（strip）の左端に
+26px 重なるが、いずれも**操作ボタンではなく情報表示**なので実害なし。
+
+## 検証
+
+- 実レイアウト（toolbar＋歯車／stage relative／cockpit＋zoom-main／セル `.cell-actions` を実寸で再現）で
+  Before/After を描画。Before は ▤ が ✕ を覆う（報告と一致）、After は ✕（赤）と ⤡ が露出・歯車もクリア。
+- CSS レイアウト修正のため jsdom 単体テスト不可（機構は再現＋コメントで固定）。
+
+typecheck(app) / build / grid テスト（TerminalGrid + GridView, 29件）パス。

--- a/plans/fix-grid-expand-toggle-covers-close.md
+++ b/plans/fix-grid-expand-toggle-covers-close.md
@@ -1,38 +1,32 @@
-# fix: expand 時に view-toggle(☰) がセルの ✕ 閉じるボタンを覆って閉じられない
+# fix: expand 時の view-toggle を撤去し、グローバルヘッダー左端へ移設
 
 ## User Prompt
 
 > あれれ、expand時のボタンを移動したせいで、今度は閉じられなくない？
+> expandひだりうえ！！じゃなくて設定とかあるglobalヘッダーの一番左に於けば良い。不要なときは隠して。
 
-（#769 で `.stage { position: relative }` を入れた直後の回帰報告）
+（#769 で `.stage { position: relative }` を入れた直後の回帰 → 位置の作り直し）
 
 ## 背景 / 症状
 
-#769 で「grid+expand 時に設定歯車が view-toggle に覆われる」問題を、`.stage` に
-`position: relative` を与えて解決した。しかしこれで view-toggle（`☰`/`▤`、`absolute right-3 top-2 z-10`）
-の絶対配置基準が viewport → `.stage` に変わり、今度は **stage 右上 = zoom セル（`.zoom-main`）右上に固定された
-`.cell-actions`（⤢/⤡ 展開＋✕ 閉じる、各 28×26px）の真上**に乗ってしまい、✕ で閉じられなくなった。
-歯車の overlap を ✕ の overlap に付け替えてしまった形。
+- #768/#769: grid+expand 時に view-toggle（`☰`/`▤`）が設定歯車を覆う → `.stage { position: relative }` で解決。
+- その副作用で toggle の絶対配置基準が viewport→`.stage` になり、今度は **zoom セル右上の ✕ 閉じる/⤡ 展開ボタン**を覆って閉じられなくなった（回帰）。
+- stage 左上へ逃がす案（PR #771 初版）も、コックピット先頭行に重なりユーザー却下。
 
-## 原因
+## 方針（確定）
 
-view-toggle は右上固定。zoom セルの閉じる/展開ボタンも（セルは stage 右上を占めるため）stage 右上固定。
-両者が同じ右上コーナーで重なる。`.stage` を static に戻すと #768（歯車 overlap）が再発するので戻せない。
+toggle を stage から撤去し、**グローバルヘッダー（AppToolbar）の一番左**へ移設。expand 時のみ表示、非 expand 時は隠す。
+toggle は元々「左サイドパネル（コックピット⇄ストリップ）の表示切替」なので、他のビュー系ボタンと同じヘッダーに置くのが自然。
 
-## 修正
+## 実装
 
-view-toggle を stage の **左上**（`right-3` → `left-3`）へ移動。
-- 歯車（ヘッダ右上）とも ✕/⤡（セル右上）とも重ならない。
-- トグルは元々「左サイドパネル（コックピット/ストリップ）の表示切替」なので左上配置は意味的にも自然。
-- `.stage { position: relative }` は維持（無いと左上が viewport 基準になりヘッダのタイトル/ナビに乗る）。
+- **TerminalGrid.vue**: stage 内の absolute トグルを削除。`listMode` をローカル ref → **prop 化**（source of truth は親）。`list-mode` emit と `.stage { position: relative }` を撤去（元の stage に復元）。
+- **GridView.vue**: `listModeOn` を source of truth 化。`toggleListMode()`（反転＋poll 同期）を追加。AppToolbar へ `:show-view-toggle="expandedUid !== null"` `:list-mode` を渡し `@toggle-view`。TerminalGrid へ `:list-mode="listModeOn"`。
+- **AppToolbar.vue**: props `showViewToggle` / `listMode`、emit `toggle-view`。ヘッダー左端（タイトル前）に `v-if="showViewToggle"` の LauncherButton（roster=`view_agenda` / strip=`view_carousel`）。
 
-副作用: 左上はコックピット先頭行ヘッダ（listMode）／zoom セルのステータスドット（strip）の左端に
-26px 重なるが、いずれも**操作ボタンではなく情報表示**なので実害なし。
+## テスト
 
-## 検証
+- TerminalGrid.spec: トグルクリック依存のテストを **`listMode` prop 駆動**へ。削除した `list-mode` emit のテストを除去。mount ヘルパーに `listMode` 追加。
+- GridView.spec: **結線テスト**を追加（expand 時のみ toggle 表示 / `toggle-view` で grid の `listMode` が反転）。ミューテーション（grid の `:list-mode` を定数化）で赤くなることを確認済み。
 
-- 実レイアウト（toolbar＋歯車／stage relative／cockpit＋zoom-main／セル `.cell-actions` を実寸で再現）で
-  Before/After を描画。Before は ▤ が ✕ を覆う（報告と一致）、After は ✕（赤）と ⤡ が露出・歯車もクリア。
-- CSS レイアウト修正のため jsdom 単体テスト不可（機構は再現＋コメントで固定）。
-
-typecheck(app) / build / grid テスト（TerminalGrid + GridView, 29件）パス。
+typecheck(app) / build / lint（0 error）/ grid・gridview テスト（30件）パス。実レイアウト再現で閉じる/歯車の露出も確認済み。

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -25,8 +25,15 @@ import { gridStatusSummary } from "./gridTabs";
 // active states re-derive from route.name (via the route-backed browse/accounting
 // stores). Grid-only state (`addTerminalActive`, `autoSort`) is still passed in, and
 // the grid-only actions (add-terminal / toggle-sort) and settings stay emits.
-const props = defineProps<{ addTerminalActive?: boolean; autoSort?: boolean; statusCounts?: StatusCounts }>();
-const emit = defineEmits<{ (e: "add-terminal" | "toggle-sort" | "settings"): void }>();
+const props = defineProps<{
+  addTerminalActive?: boolean;
+  autoSort?: boolean;
+  statusCounts?: StatusCounts;
+  // Grid zoom state, so the header can host the roster ⇄ strip toggle (shown only while zoomed).
+  showViewToggle?: boolean;
+  listMode?: boolean;
+}>();
+const emit = defineEmits<{ (e: "add-terminal" | "toggle-sort" | "toggle-view" | "settings"): void }>();
 
 const route = useRoute();
 // Grid-wide, at-a-glance tally: how many cells are blocked (need input) / done
@@ -108,6 +115,16 @@ function showPrs(): void {
 
 <template>
   <header class="flex h-10 flex-none items-center border-b border-border bg-panel px-4">
+    <!-- Zoomed-grid only: switch the expanded terminal's side panel between the cockpit roster and
+         the thumbnail strip. Lives at the far left and hides when nothing is expanded. -->
+    <LauncherButton
+      v-if="showViewToggle"
+      class="mr-1"
+      :icon="listMode ? 'view_carousel' : 'view_agenda'"
+      :title="listMode ? 'Show thumbnail strip' : 'Show list roster'"
+      :label="listMode ? 'Show thumbnail strip' : 'Show list roster'"
+      @click="emit('toggle-view')"
+    />
     <span class="font-sans text-[14px] font-semibold tracking-[0.02em] text-fg">MulmoTerminal</span>
     <nav class="ml-4 flex min-w-0 items-center gap-[3px] overflow-x-auto" aria-label="Views">
       <LauncherButton icon="chat" title="Chat" label="Chat" :active="chatActive" @click="showChat" />

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -249,8 +249,10 @@ const syncPoll = () => (rosterVisible() ? startPoll() : stopPoll());
 // immediate: a reload that restores a zoomed grid sets expandedUid up front (no "change"
 // to react to), so start here too, or the roster would freeze at its first snapshot.
 watch(expandedUid, syncPoll, { immediate: true });
-const onListMode = (on: boolean) => {
-  listModeOn.value = on;
+// The header's view toggle (shown only while zoomed) flips roster ⇄ thumbnail strip; the poll
+// follows since the roster is its sole consumer.
+const toggleListMode = () => {
+  listModeOn.value = !listModeOn.value;
   syncPoll();
 };
 // Under <KeepAlive>, leaving /terminals deactivates (doesn't unmount) this view — pause the
@@ -376,8 +378,11 @@ function configureAppearance() {
       :add-terminal-active="launchOpen"
       :auto-sort="state.sortMode === 'auto'"
       :status-counts="statusCounts"
+      :show-view-toggle="expandedUid !== null"
+      :list-mode="listModeOn"
       @add-terminal="onAddTerminal"
       @toggle-sort="toggleSortMode"
+      @toggle-view="toggleListMode"
       @settings="showSettings = true"
     />
     <nav
@@ -408,6 +413,7 @@ function configureAppearance() {
       :reorderable="reorderable"
       :open-session-ids="openSessionIds"
       :open-cwds="openCwds"
+      :list-mode="listModeOn"
       @session="onSession"
       @agent="onAgent"
       @cwd="onCwd"
@@ -420,7 +426,6 @@ function configureAppearance() {
       @launch="onLaunch"
       @move="onMove"
       @status="onStatus"
-      @list-mode="onListMode"
     />
     <AppSettingsModal v-if="showSettings" @configure-appearance="configureAppearance" @close="closeSettings" />
   </div>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -184,7 +184,7 @@ watch(
       v-if="zoomed"
       type="button"
       data-testid="view-toggle"
-      class="absolute right-3 top-2 z-10 h-[26px] w-[26px] cursor-pointer rounded-md border border-border bg-panel text-[13px] leading-none text-fg"
+      class="absolute left-3 top-2 z-10 h-[26px] w-[26px] cursor-pointer rounded-md border border-border bg-panel text-[13px] leading-none text-fg"
       :title="listMode ? 'Show thumbnails' : 'Show list'"
       :aria-label="listMode ? 'Switch to thumbnail strip' : 'Switch to list'"
       @click="listMode = !listMode"
@@ -318,9 +318,10 @@ watch(
   min-height: 0;
   min-width: 0;
   background: var(--bg-deep);
-  /* Containing block for the absolutely-positioned view-toggle (☰) button. Without it the
-     toggle resolves against the viewport and lands over the global header's Settings gear,
-     covering it while a cell is expanded. */
+  /* Containing block for the absolutely-positioned view-toggle (☰) button, which sits at the
+     stage's TOP-LEFT. Without a containing block it resolves against the viewport and lands over
+     the global header's Settings gear; and the top-left corner (over the side panel) keeps it clear
+     of the zoomed cell's expand/close buttons, which are pinned to the cell's top-right. */
   position: relative;
 }
 

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -51,6 +51,9 @@ const props = defineProps<{
   reorderable?: boolean;
   openSessionIds: string[];
   openCwds: string[];
+  // While a cell is zoomed: cockpit roster (true) vs thumbnail strip (false). Owned by GridView
+  // so the toggle can live in the global toolbar rather than float over the stage.
+  listMode: boolean;
 }>();
 const emit = defineEmits<{
   (e: "session" | "cwd", uid: number, value: string): void;
@@ -60,8 +63,6 @@ const emit = defineEmits<{
   (e: "move", uid: number, dir: -1 | 1): void;
   (e: "status", uid: number, value: CellStatus): void;
   (e: "agent", uid: number, value: "claude" | "codex"): void;
-  // Roster shown (true) / thumbnail strip (false), so the parent can pause the roster-only poll.
-  (e: "list-mode", on: boolean): void;
   // Shared preset list events — uid-less since they mutate the one config list.
   (e: "record-cwd" | "remove-preset", value: string): void;
 }>();
@@ -104,10 +105,6 @@ const zoomMain = ref<HTMLElement | null>(null);
 const mounted = ref(false);
 onMounted(() => (mounted.value = true));
 const zoomed = computed(() => props.expandedUid !== null && mounted.value);
-// While zoomed, show the cockpit roster (true) or the old thumbnail filmstrip (false).
-const listMode = ref(true);
-// The roster is the only consumer of the parent's /api/session poll — tell it when we hide it.
-watch(listMode, (on) => emit("list-mode", on));
 
 const stage = ref<HTMLElement | null>(null);
 // The cells currently flying between slots. Also gates the stylesheet: the cells not in
@@ -179,18 +176,6 @@ watch(
 
 <template>
   <div ref="stage" class="stage" :class="{ zoomed, listmode: listMode, flipping: flippingUids.size > 0 }" :style="flipVars" @focusin="onFocusIn">
-    <!-- toggle the zoomed side panel between the text roster and the old thumbnail strip. -->
-    <button
-      v-if="zoomed"
-      type="button"
-      data-testid="view-toggle"
-      class="absolute left-3 top-2 z-10 h-[26px] w-[26px] cursor-pointer rounded-md border border-border bg-panel text-[13px] leading-none text-fg"
-      :title="listMode ? 'Show thumbnails' : 'Show list'"
-      :aria-label="listMode ? 'Switch to thumbnail strip' : 'Switch to list'"
-      @click="listMode = !listMode"
-    >
-      {{ listMode ? "▤" : "☰" }}
-    </button>
     <!-- Cockpit roster: a tall text row per cell (status / dir / summary / prompt / latest
          reply). Click a row to swap which terminal is enlarged. -->
     <aside v-if="zoomed && listMode" data-testid="cockpit" class="flex min-w-0 shrink-0 grow-0 basis-[360px] flex-col gap-[5px] overflow-y-auto bg-deep p-1.5">
@@ -318,11 +303,6 @@ watch(
   min-height: 0;
   min-width: 0;
   background: var(--bg-deep);
-  /* Containing block for the absolutely-positioned view-toggle (☰) button, which sits at the
-     stage's TOP-LEFT. Without a containing block it resolves against the viewport and lands over
-     the global header's Settings gear; and the top-left corner (over the side panel) keeps it clear
-     of the zoomed cell's expand/close buttons, which are pinned to the cell's top-right. */
-  position: relative;
 }
 
 .grid {

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -101,6 +101,48 @@ describe("GridView roster ordering (#720)", () => {
   });
 });
 
+// A toolbar stub that surfaces the view-toggle props and can fire the toggle-view event, plus a
+// TerminalGrid stub exposing the listMode prop — together they trace the header → GridView → grid
+// wiring for the roster ⇄ strip toggle.
+const ViewToggleToolbarStub = {
+  name: "AppToolbar",
+  props: ["showViewToggle", "listMode"],
+  emits: ["toggle-view"],
+  template: '<button class="toggle-view" @click="$emit(\'toggle-view\')" />',
+};
+const ListModeGridStub = { name: "TerminalGrid", props: ["listMode", "expandedUid"], template: '<div class="lm-stub" />' };
+
+describe("GridView view toggle wiring", () => {
+  it("shows the toggle only while zoomed and flips the grid's listMode when the header fires toggle-view", async () => {
+    localStorage.setItem("grid_v2", JSON.stringify({ cells: [{ uid: 10, session: IDS.idleA, cwd: "/w" }], expanded: 10, page: 0, sortMode: "manual" }));
+    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: ListModeGridStub, AppToolbar: ViewToggleToolbarStub, SettingsModal: SettingsStub } },
+    });
+    await flushPromises();
+    const toolbar = w.findComponent(ViewToggleToolbarStub);
+    const grid = w.findComponent(ListModeGridStub);
+    // A cell is expanded → the toggle is offered, and both surfaces start in roster (list) mode.
+    expect(toolbar.props("showViewToggle")).toBe(true);
+    expect(toolbar.props("listMode")).toBe(true);
+    expect(grid.props("listMode")).toBe(true);
+    // The header toggle flips roster → strip for the grid too.
+    await toolbar.trigger("click");
+    expect(grid.props("listMode")).toBe(false);
+    expect(toolbar.props("listMode")).toBe(false);
+    w.unmount();
+  });
+
+  it("hides the toggle when nothing is expanded", async () => {
+    localStorage.setItem("grid_v2", JSON.stringify({ cells: [{ uid: 10, session: IDS.idleA, cwd: "/w" }], expanded: null, page: 0, sortMode: "manual" }));
+    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: ListModeGridStub, AppToolbar: ViewToggleToolbarStub, SettingsModal: SettingsStub } },
+    });
+    await flushPromises();
+    expect(w.findComponent(ViewToggleToolbarStub).props("showViewToggle")).toBe(false);
+    w.unmount();
+  });
+});
+
 describe("GridView settings wiring", () => {
   it("passes pushEnabled to SettingsModal and saves it on update-push-enabled (regression #347)", async () => {
     const w = await mountGrid();

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -47,6 +47,7 @@ const mountGrid = (cells: Cell[], expandedUid: number | null = null, cancelUid: 
       openSessionIds: [],
       openCwds: [],
       reorderable,
+      listMode: true,
     },
   });
 const cellsOf = (w: ReturnType<typeof mount>) => w.findAllComponents({ name: "TerminalCell" });
@@ -67,7 +68,7 @@ const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => (
   headerTextColor: null,
   ...over,
 });
-const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[], reorderable = false) =>
+const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[], reorderable = false, listMode = true) =>
   mount(TerminalGrid, {
     props: {
       cells,
@@ -81,6 +82,7 @@ const mountCockpit = (cells: Cell[], expandedUid: number, listRows: CockpitRow[]
       openSessionIds: [],
       openCwds: [],
       reorderable,
+      listMode,
     },
   });
 
@@ -223,14 +225,14 @@ describe("active-cell focus zoom", () => {
 });
 
 describe("grid cockpit (list view)", () => {
-  it("toggles between the text roster and the thumbnail strip", async () => {
+  it("shows the roster in list mode and the thumbnail strip otherwise (driven by the listMode prop)", async () => {
     const w = mountCockpit([cell(0, "s0"), cell(1, "s1")], 0, [rosterRow(0), rosterRow(1)]);
     await nextTick();
     expect(w.find('[data-testid="cockpit"]').exists()).toBe(true);
     expect(w.find(".stage").classes()).toContain("listmode");
     expect(w.findAll('[data-testid="cockpit-row"]')).toHaveLength(2);
 
-    await w.get('[data-testid="view-toggle"]').trigger("click");
+    await w.setProps({ listMode: false });
     expect(w.find('[data-testid="cockpit"]').exists()).toBe(false); // roster gone
     expect(w.find(".stage").classes()).not.toContain("listmode"); // filmstrip mode
   });
@@ -247,15 +249,6 @@ describe("grid cockpit (list view)", () => {
     expect(w.get('[data-testid="cockpit"]').classes()).toContain("overflow-y-auto");
     // ...and each row refuses to shrink, so the list overflows (scrolls) rather than cramming.
     for (const row of w.findAll('[data-testid="cockpit-row"]')) expect(row.classes()).toContain("shrink-0");
-  });
-
-  it("emits list-mode as the roster is toggled off then on, so the parent can pause its poll", async () => {
-    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0)]);
-    await nextTick();
-    await w.get('[data-testid="view-toggle"]').trigger("click"); // roster -> strip
-    expect(w.emitted("list-mode")?.[0]).toEqual([false]);
-    await w.get('[data-testid="view-toggle"]').trigger("click"); // strip -> roster
-    expect(w.emitted("list-mode")?.[1]).toEqual([true]);
   });
 
   it("emits toggle-expand when a NON-active row is clicked, and not for the active one", async () => {


### PR DESCRIPTION
## Summary

grid+expand 時の view-toggle（☰/▤）の配置を作り直し。floating な stage 内ボタンを撤去し、**グローバルヘッダーの一番左**に移設。**expand 時のみ表示**（非 expand 時は隠す）。これで zoom セルの ✕ 閉じる/⤡ 展開ボタンとも設定歯車とも衝突しなくなり、#768/#769 の overlap 系を根本解消。

（経緯: #768 歯車 overlap → `.stage{position:relative}` で解決 → 副作用で ✕ を覆う回帰 → stage 左上案はコックピットに重なり却下 → **ヘッダー左端へ移設**で確定。）

## Items to Confirm / Review

- **設計**: toggle は「左サイドパネル（コックピット⇄ストリップ）の表示切替」なので、他ビュー系ボタンと同じヘッダーに置くのが自然。`listMode` を GridView に持ち上げ（source of truth）、TerminalGrid は prop 化。ヘッダーは `toggle-view` を emit して反転。
- **stage 復元**: `.stage { position: relative }` を撤去し元の（position 無し）状態へ。stage 内 absolute トグルが無くなったため不要。off-screen `.grid`（`left:-99999px`）は基準が変わっても位置不変。
- **表示条件**: `show-view-toggle = (expandedUid !== null)`。非 expand では非表示。
- **アイコン**: roster 時 `view_agenda` / strip 時 `view_carousel`（LauncherButton、他ヘッダーボタンと同スタイル）。

## User Prompt

> あれれ、expand時のボタンを移動したせいで、今度は閉じられなくない？
> expandひだりうえ！！じゃなくて設定とかあるglobalヘッダーの一番左に於けば良い。不要なときは隠して。

## テスト

- TerminalGrid.spec: トグルクリック依存 → `listMode` prop 駆動へ。削除した `list-mode` emit のテストを除去。
- GridView.spec: 結線テスト追加（expand 時のみ表示 / `toggle-view` で grid の `listMode` 反転）。ミューテーション（grid の `:list-mode` 定数化）で赤くなることを確認。
- typecheck(app) / build / lint(0 error) / grid・gridview テスト（30件）パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)