### PR TITLE
fix: expand 時の view-toggle をヘッダー右端（Settings 隣）へ移動

### DIFF
--- a/plans/fix-view-toggle-right-end.md
+++ b/plans/fix-view-toggle-right-end.md
@@ -1,0 +1,21 @@
+# fix: expand 時の view-toggle をヘッダー左端 → 右端（Settings 隣）へ
+
+## User Prompt
+
+> で、expand 時の view-toggleのぼたん、左じゃなくて右端にして。
+
+## 背景
+
+#771 で view-toggle（roster ⇄ strip）をグローバルヘッダーの**左端**（タイトル前）に置いたが、
+右端が良いとの要望。
+
+## 修正
+
+`src/components/AppToolbar.vue` の view-toggle LauncherButton を、ヘッダー左端から
+**右クラスタの Sound と Settings の間**へ移動（`v-if="showViewToggle"` は維持＝expand 時のみ表示）。
+左端に付けていた `mr-1` は不要になり削除（右クラスタは gap 無しで隣接）。
+
+## 検証
+
+typecheck / build / lint(0 error) / GridView テスト（トグル結線）パス。
+配置のみの変更で挙動・結線は不変。

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -115,16 +115,6 @@ function showPrs(): void {
 
 <template>
   <header class="flex h-10 flex-none items-center border-b border-border bg-panel px-4">
-    <!-- Zoomed-grid only: switch the expanded terminal's side panel between the cockpit roster and
-         the thumbnail strip. Lives at the far left and hides when nothing is expanded. -->
-    <LauncherButton
-      v-if="showViewToggle"
-      class="mr-1"
-      :icon="listMode ? 'view_carousel' : 'view_agenda'"
-      :title="listMode ? 'Show thumbnail strip' : 'Show list roster'"
-      :label="listMode ? 'Show thumbnail strip' : 'Show list roster'"
-      @click="emit('toggle-view')"
-    />
     <span class="font-sans text-[14px] font-semibold tracking-[0.02em] text-fg">MulmoTerminal</span>
     <nav class="ml-4 flex min-w-0 items-center gap-[3px] overflow-x-auto" aria-label="Views">
       <LauncherButton icon="chat" title="Chat" label="Chat" :active="chatActive" @click="showChat" />
@@ -231,6 +221,15 @@ function showPrs(): void {
       :active="soundEnabled"
       :aria-pressed="soundEnabled"
       @click="toggleSound"
+    />
+    <!-- Zoomed-grid only: switch the expanded terminal's side panel between the cockpit roster and
+         the thumbnail strip. Sits at the right end (next to Settings) and hides when nothing is expanded. -->
+    <LauncherButton
+      v-if="showViewToggle"
+      :icon="listMode ? 'view_carousel' : 'view_agenda'"
+      :title="listMode ? 'Show thumbnail strip' : 'Show list roster'"
+      :label="listMode ? 'Show thumbnail strip' : 'Show list roster'"
+      @click="emit('toggle-view')"
     />
     <LauncherButton icon="settings" title="Settings" label="Settings" @click="emit('settings')" />
   </header>


### PR DESCRIPTION
## Summary

#771 でグローバルヘッダー**左端**に置いた view-toggle（roster ⇄ strip、expand 時のみ表示）を、要望により**右端の Sound と Settings の間**へ移動。

## User Prompt

> で、expand 時の view-toggleのぼたん、左じゃなくて右端にして。

## テスト

typecheck / build / lint(0 error) / GridView 結線テストパス。配置のみの変更で挙動・結線は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)