### PR TITLE
fix: dev-server watch テストの Windows fs.watch flake を解消（再起動まで再タッチ）

### DIFF
--- a/plans/fix-dev-server-watch-flake.md
+++ b/plans/fix-dev-server-watch-flake.md
@@ -1,0 +1,36 @@
+# fix: dev-server supervisor テストの Windows fs.watch flake
+
+## User Prompt
+
+> https://github.com/receptron/mulmoterminal/actions/runs/30087539279 fix
+
+（main の #773 マージ run で Windows CI が失敗）
+
+## 症状
+
+`test/scripts/dev-server.spec.ts > restarts the backend when a watched source file changes` が
+**Windows 24.x で失敗・22.x で pass**（同一 run 内）＝典型的な flake。他 OS では常に pass。
+
+## 原因
+
+このテストは watchDir にソースファイルを**1回だけ書き込み**、supervisor の `fs.watch` が
+それを検知して再起動することを期待していた。しかし:
+- `fs.watch` は**イベント配信を保証しない**（Node ドキュメント）。とくに Windows では recursive watch の
+  arm が遅れたり最初のイベントを取りこぼすことがある。
+- `os.tmpdir()` は Windows CI で 8.3 短縮パス（`C:\Users\RUNNER~1\…`）になり、fs.watch が不安定
+  （`docs/windows-gotchas.md`）。
+
+1回の書き込みが取りこぼされると再起動が起きず、`bootCount < 2` でテストが落ちる。
+
+## 修正（テストのみ）
+
+- watchDir を `realpathSync` で実パス化（8.3 短縮パスを展開）。
+- ポーリングループで、再起動（2回目の boot）が観測されるまで**毎回ソースを再タッチ**。
+  取りこぼし/arm 遅延があっても後続の書き込みが確実にトリガーする。余分な再起動は `>=2` 判定を通すだけ。
+- デバウンス（120ms）より長い 200ms 間隔、タイムアウトは 20s に。
+
+production コード（supervisor）は変更なし。fs.watch の非保証性に対するテストの堅牢化。
+
+## 検証
+
+macOS で3回連続パス。typecheck / build / lint パス。

--- a/test/scripts/dev-server.spec.ts
+++ b/test/scripts/dev-server.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, afterEach } from "vitest";
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, realpathSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
@@ -62,27 +62,32 @@ describe("dev-server supervisor", () => {
       stub,
       `import { appendFileSync } from "node:fs";\nappendFileSync(${JSON.stringify(boots)}, process.pid + "\\n");\nsetInterval(() => {}, 1000);\n`,
     );
-    const watchDir = mkdtempSync(path.join(os.tmpdir(), "dev-server-watch-"));
+    // realpathSync expands a Windows 8.3 short path (os.tmpdir() → C:\Users\RUNNER~1\…), which
+    // fs.watch is unreliable on (see docs/windows-gotchas.md).
+    const watchDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "dev-server-watch-")));
 
     child = spawn(process.execPath, [SUPERVISOR], {
       env: { ...process.env, DEV_SERVER_ENTRY: stub, DEV_SERVER_WATCH: watchDir },
       stdio: "ignore",
     });
 
-    // Wait for the first (persistent) boot, then edit a source file in the watched dir.
+    // Wait for the first (persistent) boot before touching the watched dir.
     for (let i = 0; i < 40 && !existsSync(boots); i++) await wait(100);
-    await wait(300); // let fs.watch attach before the edit
-    writeFileSync(path.join(watchDir, "touched.ts"), "export const x = 1;\n");
 
-    // Poll for the second boot: proof the change killed the live backend and restarted it.
+    // Poll for the second boot, RE-TOUCHING the source each round. fs.watch gives no delivery
+    // guarantee and on Windows can arm late or drop the first event, so a single write is flaky;
+    // re-touching until the restart lands makes it deterministic. Extra restarts only push the
+    // count past the >=2 we assert.
+    const touched = path.join(watchDir, "touched.ts");
     let bootCount = 0;
-    for (let i = 0; i < 40; i++) {
+    for (let i = 0; i < 50; i++) {
+      writeFileSync(touched, `export const x = ${i};\n`);
+      await wait(200); // > the supervisor's 120ms change debounce, so each write can trigger
       bootCount = existsSync(boots) ? readFileSync(boots, "utf8").trim().split("\n").filter(Boolean).length : 0;
       if (bootCount >= 2) break;
-      await wait(200);
     }
     rmSync(watchDir, { recursive: true, force: true });
 
     expect(bootCount).toBeGreaterThanOrEqual(2);
-  }, 15000);
+  }, 20000);
 });


### PR DESCRIPTION
## Summary

main の CI（[run 30087539279](https://github.com/receptron/mulmoterminal/actions/runs/30087539279)）で `test/scripts/dev-server.spec.ts > restarts the backend when a watched source file changes` が **Windows 24.x で失敗・22.x で pass**（同一 run 内）＝ flake。テストを堅牢化して解消。

## 原因

このテストは watchDir にソースを**1回だけ書き込み**、supervisor の `fs.watch` の検知→再起動を待っていた。だが `fs.watch` は**配信保証が無く**、Windows では recursive watch の arm 遅延や最初のイベント取りこぼしが起きる（さらに `os.tmpdir()` は Windows CI で 8.3 短縮パス `RUNNER~1`）。1回の書き込みが取りこぼされると再起動せず `bootCount < 2` で落ちる。

## Items to Confirm / Review

- **テストのみの変更**（`scripts/dev-server.mjs` は不変）。fs.watch の非保証性に対する堅牢化。
- watchDir を `realpathSync` で実パス化（8.3 短縮パス対策・`docs/windows-gotchas.md` 準拠）。
- ポーリング各回で**再起動が観測されるまでソースを再タッチ**（取りこぼしを retry）。余分な再起動は `>=2` 判定を通すだけ。デバウンス 120ms より長い 200ms 間隔、timeout 20s。
- macOS で3回連続パス。typecheck / build / lint パス。

## User Prompt

> https://github.com/receptron/mulmoterminal/actions/runs/30087539279 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)