### PR TITLE
fix: 共有の ⤢/✕ ボタンに scope id を与えて cell-btn スタイルを効かせる (#787)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,7 @@ export default [
       "src/components/CommandCell.vue", //        overrides of the shared .cell-btn + the shared chrome imports
       "src/components/TerminalCell.vue", //       shared chrome import
       "src/components/LauncherCell.vue", //       shared chrome imports
+      "src/components/CellChromeButtons.vue", //  shared chrome import — also what gives its fragment root a scope id (#787)
       "src/components/ToolbarPopover.vue", //     shared popover chrome import
     ],
     rules: { "vue/no-restricted-block": "off" },

--- a/plans/fix-787-cell-chrome-buttons-scope.md
+++ b/plans/fix-787-cell-chrome-buttons-scope.md
@@ -1,0 +1,58 @@
+# fix: 共有 ⤢ / ✕ ボタンに scoped CSS が当たらない (#787)
+
+## 症状
+
+セルヘッダ右上の拡大 ⤢ / 閉じる ✕ が、Claude Code セル（TerminalCell）ではフラットな
+アイコンボタンなのに、ランチャー / コマンドセル（LauncherCell / CommandCell）では
+**ブラウザ既定の `<button>`**（グレー背景＋枠、縦に間延び）になる。同じヘッダの ◀ ▶ は
+正しいので、この 2 つだけが浮く。
+
+## 原因
+
+#646 B3 で ⤢ / ✕ を `CellChromeButtons.vue` に切り出した。このコンポーネントは
+
+- ルートが **2 つの `<button>`（フラグメント）** → Vue は親の scope id を継承させない
+  （継承されるのは単一ルートのときだけ）
+- **自前の `<style scoped>` が無い** → 自身の scope id も付かない
+
+一方 `.cell-btn` / `.cell-close` の実体は、各セルが `<style scoped src="./cellChromeBase.css">`
+で読む scoped CSS（＝ `.cell-btn[data-v-xxxx]`）。よってこの 2 つのボタンには `data-v-*` が
+1 つも付かず、ルールが当たらない。
+
+LauncherCell を実際にマウントして確認したヘッダ:
+
+```html
+<button data-v-cbeb535d class="cell-btn">◀</button>   <!-- 親 scope id あり → 効く -->
+<button class="cell-btn">⤢</button>                    <!-- scope id なし → 効かない -->
+<button class="cell-btn cell-close">✕</button>         <!-- scope id なし → 効かない -->
+```
+
+TerminalCell の ⤢ / ✕ は自分のテンプレート内に直接あるので影響を受けない＝
+「Claude Code のときと、ターミナルのときで閉じるボタンが違う」という見え方になる。
+
+## 対応
+
+`CellChromeButtons.vue` に他 3 セルと同じ 1 行を足し、自身の scope id が付くようにする:
+
+```html
+<style scoped src="./cellChromeBase.css"></style>
+```
+
+これで `.cell-btn[data-v-<CellChromeButtons>]` が自分のボタンに当たる。共有 CSS の
+出どころは 1 箇所のまま（DRY）で、他セルの見た目は変わらない。
+
+### 代替案（不採用）
+
+- 共有チャームをグローバル CSS 化: 3 セルすべての特異度・レイヤ関係が変わり、影響範囲が
+  この不具合より広い。
+- ルートを 1 要素で包む: 親の scope id は包んだ要素にしか付かず、中のボタンには依然
+  当たらないので直らない。
+
+## テスト
+
+`test/src/components/CellChromeButtons.spec.ts`（新規）
+
+- ⤢ / ✕ の両方に `data-v-*` 属性が付く（＝ scoped CSS が当たる）ことを固定する回帰テスト。
+  `<style scoped>` を外すと落ちる（外して赤くなることを確認済み）。
+- expanded で ⤡ / title が Restore に変わる、クリックで `toggle-expand` / `close` が
+  emit される、という既存の振る舞いも併せて固定する。

--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -22,3 +22,9 @@ const emit = defineEmits<{ (e: "toggle-expand" | "close"): void }>();
   </button>
   <button class="cell-btn cell-close" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
 </template>
+
+<!-- The shared chrome is SCOPED CSS in every cell that uses it, so a `.cell-btn` here only
+     matches while this component carries a scope id of its own — and a fragment root (two
+     buttons) never inherits the parent cell's. Without this import both buttons fall back to
+     the browser's default button chrome (#787). -->
+<style scoped src="./cellChromeBase.css"></style>

--- a/test/src/components/CellChromeButtons.spec.ts
+++ b/test/src/components/CellChromeButtons.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CellChromeButtons from "../../../src/components/CellChromeButtons.vue";
+
+const mountButtons = (expanded = false) => mount(CellChromeButtons, { props: { expanded } });
+
+const scopeIds = (html: string): string[] => [...html.matchAll(/data-v-[0-9a-f]+/g)].map((m) => m[0]);
+
+describe("CellChromeButtons", () => {
+  // The shared .cell-btn / .cell-close rules are SCOPED CSS (cellChromeBase.css), so they
+  // only reach these buttons while the component has a scope id of its own — a fragment root
+  // never inherits the parent cell's. Without one both buttons rendered with the browser's
+  // default button chrome while the neighbouring ◀ ▶ (in the cell's own template) did not (#787).
+  it("stamps a scope id on both buttons, so the shared cell-btn styles apply", () => {
+    const w = mountButtons();
+    expect(scopeIds(w.find('[aria-label="Expand terminal"]').html())).not.toHaveLength(0);
+    expect(scopeIds(w.find('[aria-label="Close terminal"]').html())).not.toHaveLength(0);
+  });
+
+  it("carries the shared chrome classes the styles key off", () => {
+    const w = mountButtons();
+    expect(w.find('[aria-label="Expand terminal"]').classes()).toContain("cell-btn");
+    expect(w.find('[aria-label="Close terminal"]').classes()).toEqual(expect.arrayContaining(["cell-btn", "cell-close"]));
+  });
+
+  it("offers expand while tiled and restore while expanded", () => {
+    expect(mountButtons(false).find(".cell-btn").text()).toBe("⤢");
+    const expanded = mountButtons(true);
+    expect(expanded.find(".cell-btn").text()).toBe("⤡");
+    expect(expanded.find(".cell-btn").attributes("title")).toBe("Restore");
+    expect(expanded.find('[aria-label="Restore terminal"]').exists()).toBe(true);
+  });
+
+  it("emits toggle-expand and close from their own buttons", async () => {
+    const w = mountButtons();
+    await w.find('[aria-label="Expand terminal"]').trigger("click");
+    await w.find('[aria-label="Close terminal"]').trigger("click");
+    expect(w.emitted("toggle-expand")).toHaveLength(1);
+    expect(w.emitted("close")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

セルヘッダ右上の **拡大 ⤢ / 閉じる ✕** が、ランチャー / コマンドセルでだけ
**ブラウザ既定の `<button>`**（グレー背景＋角丸枠、縦に間延び）になっていたのを、
Claude Code セルと同じフラットなアイコンボタンに揃えた。

原因は CSS ではなく **Vue の scope id**:
`CellChromeButtons.vue`（#646 B3 で切り出した共有ボタン）は

- ルートが 2 つの `<button>` = **フラグメント** → 親の scope id は継承されない（単一ルートのときだけ）
- 自前の `<style scoped>` が無い → 自身の scope id も付かない

一方 `.cell-btn` / `.cell-close` の実体は各セルが `<style scoped src="./cellChromeBase.css">`
で読む **scoped CSS**（`.cell-btn[data-v-xxxx]`）。よってこの 2 つのボタンにはどの `data-v-*`
も付かず、共有チャームのルールが 1 つも当たらなかった。

LauncherCell を実際にマウントして確認したヘッダ（修正前）:

```html
<button data-v-cbeb535d class="cell-btn">◀</button>   <!-- 親 scope id あり → 効く -->
<button class="cell-btn">⤢</button>                    <!-- scope id なし → 効かない -->
<button class="cell-btn cell-close">✕</button>         <!-- scope id なし → 効かない -->
```

修正は `CellChromeButtons.vue` に他 3 セルと同じ共有チャーム import を 1 行足すだけ
（これで自身の scope id が付く）。

## Items to Confirm / Review

- **見た目の確認**: ランチャーセル / コマンドセルの ⤢ ✕ が Claude Code セル（TerminalCell）と
  同じフラットなアイコンになっているか。ホバー時の色（✕ は赤系）も含めて。
- **共有 CSS の重複**: `cellChromeBase.css` を読むコンポーネントが 3 → 4 になり、scoped コピーが
  1 つ増える（この方式は既存 3 セルと同じ）。`.cell-header` / `.cell-dot` など、このコンポーネントでは
  使わないルールも一緒に入る点は許容と判断した。グローバル CSS 化は 3 セル全体の特異度・レイヤ
  関係が変わるため、この不具合の範囲を超えると考えて見送っている。
- **eslint 許可リスト**: `vue/no-restricted-block`（`<style>` 禁止）の allowlist に
  `CellChromeButtons.vue` を理由付きで追加した。追加が妥当か。

## User Prompt

> claude code のときと、ターミナルの時で閉じる部分のボタンが違う。これはターミナル。claude code にあわせて
>（スクリーンショット: ヘッダ右上の ⤢ / ✕ だけがグレーの枠付きボタンになっている）

## 実装

- `src/components/CellChromeButtons.vue`: `<style scoped src="./cellChromeBase.css"></style>` を追加。
  なぜ必要か（フラグメント・ルートは親の scope id を継承しない）をコメントで残した。
- `eslint.config.js`: scoped-CSS allowlist に理由付きで追加。
- `test/src/components/CellChromeButtons.spec.ts`（新規）: 両ボタンに `data-v-*` が付くことを
  固定する回帰テスト＋既存の振る舞い（⤢/⤡ の切替、emit）。**import を外すと赤くなることを確認済み**。
- `plans/fix-787-cell-chrome-buttons-scope.md`: 調査と判断の記録。

## 確認済み

`yarn format` / `yarn lint` / `yarn build` / `yarn typecheck` / `typecheck:server` / `typecheck:test` 全て green。
`test/src/components` 767 tests passed。

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
