### PR TITLE
feat: getTerminalScreen に cwd / branch / summary / prompt を載せる (#786)

### DIFF
--- a/plans/feat-786-terminal-screen-meta.md
+++ b/plans/feat-786-terminal-screen-meta.md
@@ -1,0 +1,64 @@
+# feat: getTerminalScreen に cwd / branch / summary / prompt を足す (#786)
+
+受け側は mulmoserver#107（スマホの個別セッション画面）。画面の上に「どのディレクトリの・どの
+ブランチで・何をやっている・直前のプロンプト」を出したいが、`getTerminalScreen` の応答が
+`{ screen, suggestion }` だけなので出せない。
+
+## 変更
+
+### 1. ワイヤ型（`server/backends/remoteHost/terminalScreen.ts`）
+
+```ts
+export interface SessionScreenMeta {
+  cwd?: string;
+  branch?: string;
+  summary?: string; // aiTitle
+  prompt?: string;  // lastPrompt
+}
+export interface SessionScreen extends SessionScreenMeta {
+  screen: string;
+  suggestion: string;
+}
+```
+
+すべて optional ＝ 後方互換。**値が無いキーは `undefined` を入れず落とす**（`definedScreenMeta`）:
+
+- 応答は Firestore の command ドキュメントに書かれる。`undefined` を含むオブジェクトは
+  Firestore が拒否するので、「無い」は「キーごと無い」で表す。
+- 受け側もラベル付きの行をフィールド単位で出すので、空文字だと「ブランチが無い」ではなく
+  「ラベルだけの空行」に見えてしまう。
+
+### 2. 依存の注入
+
+`CaptureScreenDeps` に optional な `metaOf(id)` を追加。terminalScreen.ts は PTY もタイトル表も
+知らないままで、実際の読み出しは server/index.ts（テーブルがある場所）が渡す。
+
+- **画面取得と並行**に実行（`Promise.all`）。branch は git を叩くので直列だと素で遅くなる。
+- **metaOf が失敗しても画面は返す**。メタは画面の装飾で、git の失敗や消えた dir で
+  ターミナル表示ごと落とすのは割に合わない。
+
+### 3. 値の出どころ（`server/index.ts`）
+
+`listTerminalSessions` の `detailOf` と同じテーブルを読む:
+
+| フィールド | 出どころ |
+| --- | --- |
+| cwd | `ptys.get(id)?.cwd` |
+| branch | `currentBranch(cwd)`（`server/git/git-status.ts` から export） |
+| summary | `aiTitles.get(id)` |
+| prompt | `lastPrompts.get(id)` |
+
+branch は `gitStatus()` 全部（git 4 プロセス）ではなく `currentBranch()` だけを使う
+（symbolic-ref 1 回、detached でも失敗しない）。dirty / ahead / behind はスマホ個別画面では
+使わないので取らない。再起動をまたいだ tmux-only セッションは `ptys` に無く cwd が空 →
+git も呼ばず、4 フィールドとも落ちる。
+
+## テスト
+
+`test/server/backends/remoteHost/terminalScreen.spec.ts` に追加:
+
+- `definedScreenMeta`: 空文字 / 空白のみ / undefined を落とす、前後の空白は値としては保つ、
+  空オブジェクト。
+- `captureSessionScreen`: metaOf の 4 値が応答に載る／空の値はキーごと落ちる／
+  `metaOf` 未指定なら `{ screen, suggestion }` のまま（後方互換）／`metaOf` が throw しても
+  画面は返る。

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createRemoteHostHandlers } from "./handlers.js";
+import type { SessionScreen } from "./terminalScreen.js";
 import { initCollectionsBackend } from "../collections.js";
 
 const unusedTerminalDeps = {
@@ -206,5 +207,40 @@ describe("createRemoteHostHandlers · listSkills", () => {
     const { skills } = (await handlers.listSkills({})) as unknown as { skills: string[] };
     expect(skills).toContain("mt-plain-skill");
     expect(skills).not.toContain("mt-collection");
+  });
+});
+
+// The phone's per-session view (#786, mulmoserver#107) reads the session's dir, branch,
+// summary and prompt off this response, so the handler has to forward whatever the host
+// could answer instead of trimming the payload back to screen + suggestion.
+describe("getTerminalScreen", () => {
+  const handlersFor = (screen: SessionScreen) =>
+    createRemoteHostHandlers({
+      workspace: "/nowhere",
+      spawnChat: () => ({ chatId: "x" }),
+      ingest: async () => ({ attachments: [], cleanupStaging: async () => {} }),
+      ...unusedTerminalDeps,
+      captureTerminalScreen: async () => screen,
+    });
+
+  it("forwards the session's cwd, branch, summary and prompt beside the screen", async () => {
+    const handlers = handlersFor({ screen: "$ ", suggestion: "", cwd: "/repo", branch: "main", summary: "Fix the parser", prompt: "fix it" });
+    expect(await handlers.getTerminalScreen({ sessionId: "a" })).toEqual({
+      screen: "$ ",
+      suggestion: "",
+      cwd: "/repo",
+      branch: "main",
+      summary: "Fix the parser",
+      prompt: "fix it",
+    });
+  });
+
+  it("forwards a screen the host had no metadata for unchanged", async () => {
+    const handlers = handlersFor({ screen: "$ ", suggestion: "ls" });
+    expect(await handlers.getTerminalScreen({ sessionId: "a" })).toEqual({ screen: "$ ", suggestion: "ls" });
+  });
+
+  it("rejects a request with no session id", async () => {
+    await expect(handlersFor({ screen: "", suggestion: "" }).getTerminalScreen({})).rejects.toThrow(/sessionId is required/);
   });
 });

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -167,12 +167,14 @@ const terminalScreenHandlers = ({
     listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
 
     // `suggestion` is the agent's own dim ghost text — the phone offers it as a chip,
-    // since it has no Tab key to accept it with (#563).
+    // since it has no Tab key to accept it with (#563). The screen also carries the
+    // session's cwd / branch / summary / prompt when the host knows them, so the phone can
+    // head the terminal with what the grid cell shows (#786); the whole SessionScreen is
+    // the wire shape, so a field added there reaches the phone without another edit here.
     getTerminalScreen: async (params: JsonObject) => {
       const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
       if (!sessionId) throw new Error("sessionId is required");
-      const { screen, suggestion } = await captureTerminalScreen(sessionId);
-      return { screen, suggestion };
+      return (await captureTerminalScreen(sessionId)) as unknown as JsonObject;
     },
 
     // Type a line into the session and press Enter, as if the user were at the

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -84,14 +84,36 @@ export interface CaptureScreenDeps {
   captureStyledPane: (id: string) => string | null;
   sourceOf: (id: string) => ScreenSource | undefined;
   render: (input: ScreenSource) => Promise<ScreenRow[]>;
+  // What the grid cell's header shows for this session, for the phone to head the screen
+  // with (#786). Optional: a host that can't answer any of it just sends the screen.
+  metaOf?: (id: string) => Promise<SessionScreenMeta>;
 }
 
-export interface SessionScreen {
+// The session's identity around the screen — the dir it runs in, that dir's git branch, the
+// AI summary of the session, and the prompt that started the latest turn (mulmoserver#107).
+// Every field is optional: a session that outlived a restart has no PTY left, so the host
+// knows none of them.
+export interface SessionScreenMeta {
+  cwd?: string;
+  branch?: string;
+  summary?: string;
+  prompt?: string;
+}
+
+export interface SessionScreen extends SessionScreenMeta {
   screen: string;
   // The follow-up prompt the agent is offering as dim ghost text, "" when it offers none.
   // The phone cannot press Tab to accept it, so it is handed over as its own value for
   // the phone to offer as a chip (#563).
   suggestion: string;
+}
+
+// A field the host can't answer is dropped entirely rather than sent as "": the response is
+// written to a Firestore command doc, which rejects an `undefined` value outright, and the
+// phone renders each field it receives as its own labelled row — an empty one would read as
+// "this session has no branch" instead of "not known".
+export function definedScreenMeta(meta: SessionScreenMeta): SessionScreenMeta {
+  return Object.fromEntries(Object.entries(meta).filter(([, value]) => value !== undefined && value.trim() !== ""));
 }
 
 // tmux first: it renders the real screen, works while detached, and survives a restart.
@@ -105,7 +127,20 @@ const screenRowsOf = async (id: string, { captureStyledPane, sourceOf, render }:
   return render(source);
 };
 
+// The metadata decorates the screen, so a failure reading it (a git call that blew up, a dir
+// that has since been deleted) costs those fields — never the terminal output itself.
+const screenMetaOf = async (id: string, metaOf: CaptureScreenDeps["metaOf"]): Promise<SessionScreenMeta> => {
+  if (!metaOf) return {};
+  try {
+    return definedScreenMeta(await metaOf(id));
+  } catch {
+    return {};
+  }
+};
+
 export async function captureSessionScreen(id: string, deps: CaptureScreenDeps): Promise<SessionScreen> {
-  const rows = await screenRowsOf(id, deps);
-  return { screen: rowsToScreen(rows).trimEnd(), suggestion: suggestionFromRows(rows) };
+  // Concurrently: the meta read shells out to git, which is otherwise pure latency added to
+  // every screen the phone pulls.
+  const [rows, meta] = await Promise.all([screenRowsOf(id, deps), screenMetaOf(id, deps.metaOf)]);
+  return { screen: rowsToScreen(rows).trimEnd(), suggestion: suggestionFromRows(rows), ...meta };
 }

--- a/server/git/git-status.ts
+++ b/server/git/git-status.ts
@@ -21,11 +21,12 @@ const toCount = (s: string): number => {
   return Number.isFinite(n) ? n : 0;
 };
 
-// The current branch, or detached when HEAD isn't on a branch. `symbolic-ref`
+// The current branch, or detached when HEAD isn't on a branch. Exported for the callers
+// that want only the branch — one git call instead of gitStatus's four. `symbolic-ref`
 // resolves the branch even on an UNBORN branch (fresh `git init` before the first
 // commit), where `rev-parse --abbrev-ref HEAD` fails; it also fails cleanly on a
 // detached HEAD, which we then confirm by whether HEAD resolves to a commit.
-async function currentBranch(cwd: string): Promise<{ branch: string | null; detached: boolean }> {
+export async function currentBranch(cwd: string): Promise<{ branch: string | null; detached: boolean }> {
   const sym = await git(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd);
   const name = sym.ok ? sym.stdout.trim() : "";
   if (name) return { branch: name, detached: false };

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,14 +36,15 @@ import { generateHeaderTitle } from "./config/header-title.js";
 import { mountTerminalWebSockets } from "./routes/ws-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
-import { activity, aiTitles, devTerminalSessions, hiddenSessions, knownSessions, ptys } from "./session/registry.js";
+import { activity, aiTitles, devTerminalSessions, hiddenSessions, knownSessions, lastPrompts, ptys } from "./session/registry.js";
 import { runWithHiddenMarker } from "./session/hiddenMarker.js";
 import { createToolStores } from "./session/tool-store.js";
 import { createScheduledSessionRegistry, scheduledSessionInUse, scheduledSessionsDir } from "./session/scheduled-sessions.js";
 import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { renderScreen } from "./session/headlessScreen.js";
-import { agentFromPaneCommand, buildSessionList, captureSessionScreen } from "./backends/remoteHost/terminalScreen.js";
+import { agentFromPaneCommand, buildSessionList, captureSessionScreen, type SessionScreenMeta } from "./backends/remoteHost/terminalScreen.js";
+import { currentBranch } from "./git/git-status.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
 import { initCollectionsBackend } from "./backends/collections.js";
 import { initGoogleBackend } from "./backends/google.js";
@@ -365,6 +366,21 @@ const remoteHostWriteToSession = (sessionId: string, chunk: string): boolean => 
 // phone's text is submitted (#572). The rule itself lives with the sender.
 const remoteHostCanClearBox = (sessionId: string): boolean => canClearInputBox(ptys.get(sessionId)?.agent, activity.get(sessionId)?.working);
 
+// What the phone's per-session view heads the screen with (#786, mulmoserver#107): the same
+// dir / branch / summary / prompt the grid cell shows, read from the tables /api/sessions
+// answers from. A session that outlived a restart has no PtyEntry, so it has no cwd here and
+// no branch to look up — those fields are simply absent, and the phone shows the screen alone.
+const remoteHostSessionScreenMeta = async (sessionId: string): Promise<SessionScreenMeta> => {
+  const cwd = ptys.get(sessionId)?.cwd ?? "";
+  const head = cwd ? await currentBranch(cwd) : null;
+  return {
+    cwd,
+    branch: head?.branch ?? "",
+    summary: aiTitles.get(sessionId) ?? "",
+    prompt: lastPrompts.get(sessionId) ?? "",
+  };
+};
+
 const remoteHostCaptureTerminalScreen = (sessionId: string) =>
   captureSessionScreen(sessionId, {
     captureStyledPane: tmuxCaptureStyledPane,
@@ -373,6 +389,7 @@ const remoteHostCaptureTerminalScreen = (sessionId: string) =>
       return entry ? { buffer: entry.buffer, cols: entry.term.cols, rows: entry.term.rows } : undefined;
     },
     render: renderScreen,
+    metaOf: remoteHostSessionScreenMeta,
   });
 
 initRemoteHostBackend({

--- a/test/server/backends/remoteHost/terminalScreen.spec.ts
+++ b/test/server/backends/remoteHost/terminalScreen.spec.ts
@@ -5,6 +5,7 @@ import {
   agentFromPaneCommand,
   buildSessionList,
   captureSessionScreen,
+  definedScreenMeta,
   type CaptureScreenDeps,
   type SessionListInput,
 } from "../../../../server/backends/remoteHost/terminalScreen.js";
@@ -183,5 +184,87 @@ describe("captureSessionScreen", () => {
 
   it("reports no suggestion when the fallback renderer is the source", async () => {
     expect((await captureSessionScreen("a", captureDeps())).suggestion).toBe("");
+  });
+
+  // The phone's per-session view heads the screen with the same four things the grid cell
+  // shows (#786) — read for the session being captured, and only for that one.
+  it("carries the session's cwd, branch, summary and prompt beside the screen", async () => {
+    const metaOf = vi.fn(async () => ({ cwd: "/repo", branch: "feat/786", summary: "Adding meta", prompt: "add branch to the phone view" }));
+    const captured = await captureSessionScreen("a", captureDeps({ metaOf }));
+    expect(captured).toEqual({
+      screen: "rendered:buffered",
+      suggestion: "",
+      cwd: "/repo",
+      branch: "feat/786",
+      summary: "Adding meta",
+      prompt: "add branch to the phone view",
+    });
+    expect(metaOf).toHaveBeenCalledWith("a");
+  });
+
+  // A host that answers nothing looks exactly like one built before #786 — the phone
+  // renders the screen alone.
+  it("sends only the screen when the host has no metadata to add", async () => {
+    const captured = await captureSessionScreen("a", captureDeps({ metaOf: async () => ({ cwd: "", branch: "", summary: "", prompt: "" }) }));
+    expect(captured).toEqual({ screen: "rendered:buffered", suggestion: "" });
+  });
+
+  it("sends only the screen when no metadata reader is wired at all", async () => {
+    expect(await captureSessionScreen("a", captureDeps())).toEqual({ screen: "rendered:buffered", suggestion: "" });
+  });
+
+  // Metadata decorates the screen: a git call that blew up or a dir that has since been
+  // deleted must not cost the phone the terminal output it asked for.
+  it("still returns the screen when reading the metadata throws", async () => {
+    const metaOf = vi.fn(async () => {
+      throw new Error("git exploded");
+    });
+    expect(await captureSessionScreen("a", captureDeps({ metaOf }))).toEqual({ screen: "rendered:buffered", suggestion: "" });
+  });
+
+  // Reading the metadata shells out to git, so it must not queue behind the capture.
+  it("reads the metadata concurrently with the screen", async () => {
+    const order: string[] = [];
+    const captured = await captureSessionScreen(
+      "a",
+      captureDeps({
+        render: async () => {
+          order.push("render:start");
+          await Promise.resolve();
+          order.push("render:end");
+          return [{ text: "screen", dim: "" }];
+        },
+        metaOf: async () => {
+          order.push("meta:start");
+          return { branch: "main" };
+        },
+      }),
+    );
+    expect(order).toEqual(["render:start", "meta:start", "render:end"]);
+    expect(captured.branch).toBe("main");
+  });
+});
+
+// The response is written into a Firestore command doc, which rejects `undefined` outright,
+// and the phone renders one labelled row per field it receives.
+describe("definedScreenMeta", () => {
+  it("keeps the fields the host could answer", () => {
+    const meta = { cwd: "/repo", branch: "main", summary: "Fix the parser", prompt: "fix it" };
+    expect(definedScreenMeta(meta)).toEqual(meta);
+  });
+
+  it("drops a field the host has no value for, key and all", () => {
+    expect(definedScreenMeta({ cwd: "/repo", branch: undefined, summary: "", prompt: "   " })).toEqual({ cwd: "/repo" });
+    expect(Object.keys(definedScreenMeta({ cwd: "/repo", branch: undefined }))).toEqual(["cwd"]);
+  });
+
+  it("returns nothing for an empty read", () => {
+    expect(definedScreenMeta({})).toEqual({});
+  });
+
+  // Emptiness is judged on the trimmed value, but the value itself is passed through as-is:
+  // a prompt's own leading spaces are the user's text, not ours to edit.
+  it("passes a value with surrounding whitespace through unchanged", () => {
+    expect(definedScreenMeta({ prompt: "  fix it  " })).toEqual({ prompt: "  fix it  " });
   });
 });


### PR DESCRIPTION
## Summary

`getTerminalScreen` の応答に **cwd / branch / summary / prompt** を追加した（#786）。
受け側はスマホの個別セッション画面（mulmoserver#107）で、画面の上に「どのディレクトリの・
どのブランチで・何をやっていて・直前のプロンプトは何か」を出すために使う。

- `SessionScreen` が新しい `SessionScreenMeta`（4 つとも optional）を継承する形にした＝**後方互換**。
- 値の出どころは `listTerminalSessions` の `detailOf` と同じテーブル:
  `ptys[id].cwd` / `currentBranch(cwd)` / `aiTitles` / `lastPrompts`。
- 値が無いフィールドは **キーごと落とす**（`definedScreenMeta`）。応答は Firestore の command
  ドキュメントに書かれるため `undefined` を入れられず、また受け側はフィールド単位でラベル付き行を
  出すので空文字だと「ラベルだけの空行」になる。
- メタ取得は画面キャプチャと **並行**（git を叩くので直列だと素で遅い）。**メタが失敗しても画面は返す**
  （メタは画面の装飾で、git の失敗でターミナル表示ごと落とすのは割に合わない）。
- branch は `gitStatus()`（git 4 プロセス）ではなく `currentBranch()` だけを使う。dirty / ahead / behind は
  この画面では使わないため。そのために `server/git/git-status.ts` から `currentBranch` を export した。

## Items to Confirm / Review

- **prompt / summary の出どころ**: in-memory の `lastPrompts` / `aiTitles` のみを見ている
  （issue の「既に持っている per-session メタを詰めるだけ」に沿った）。再起動をまたいだセッションで
  transcript から読み直す（`readSessionSummary`）ところまでは踏み込んでいない。必要なら別途。
- **tmux-only セッション**: `ptys` に無いので cwd が空 → git も呼ばず、4 フィールドとも落ちる
  （画面だけ返る）。この割り切りで良いか。
- **git の呼び出し頻度**: 画面取得のたびに `symbolic-ref` を 1 回叩く。スマホはアクティビティ遷移ごとに
  更新する想定なので TTL キャッシュは入れていない。ポーリング頻度が上がるようならキャッシュを検討。
- **ハンドラの戻り値**: `{ screen, suggestion }` の詰め直しをやめ、`SessionScreen` をそのまま返している
  （今後フィールドが増えてもハンドラを触らずに済む）。ワイヤ型をそのまま流す方針で良いか。
- **ドキュメント**: 受け側 UI が mulmoserver#107 で出るまでユーザーから見える変化は無いので、
  `docs/guide/*/notifications.md`（スマホからの閲覧の説明）は今回触っていない。

## User Prompt

> 786 も並行してやって！

（#786「feat: getTerminalScreen に cwd/branch/summary/prompt を追加（スマホ個別画面・mulmoserver#107）」を指す）

## 実装

- `server/backends/remoteHost/terminalScreen.ts`: `SessionScreenMeta` / `SessionScreen extends` /
  `definedScreenMeta`（純関数）/ `CaptureScreenDeps.metaOf`（optional）/ 並行実行＋失敗時フォールバック。
- `server/backends/remoteHost/handlers.ts`: `getTerminalScreen` が `SessionScreen` をそのまま返す。
- `server/git/git-status.ts`: `currentBranch` を export（コメントで理由を明記）。
- `server/index.ts`: `remoteHostSessionScreenMeta` を `captureSessionScreen` に注入。
- テスト: `test/server/backends/remoteHost/terminalScreen.spec.ts`（4 値が載る / 空はキーごと落ちる /
  metaOf 未指定でも従来通り / metaOf が throw しても画面は返る / 並行実行 / `definedScreenMeta` の
  境界ケース）と `server/backends/remoteHost/handlers.spec.ts`（ハンドラ越しに 4 値が通る / メタ無し /
  sessionId 必須）。**それぞれ実装を壊すと赤くなることを確認済み**（Promise.all → 直列、try/catch 削除、
  空文字フィルタ削除の 3 パターンで 4 テストが fail）。
- `plans/feat-786-terminal-screen-meta.md`: 設計と判断の記録。

## 確認済み

`yarn format` / `yarn lint` / `yarn build` / `yarn typecheck` / `typecheck:server` / `typecheck:test` 全て green。
サーバー系テスト 2333 passed。

Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)
