### PR TITLE
docs: canvas レンダラの導入理由と xterm5/6 不一致の注意書きをソースに追記

### DIFF
--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -261,8 +261,17 @@ function ensure(key: string, target: ConnTarget): Conn {
   host.style.height = "100%";
   term.open(host);
   // Render each glyph in its own cell (canvas) instead of the default DOM renderer, which flows text
-  // as inline runs. A full-width CJK glyph that isn't exactly 2× the Latin cell would otherwise let a
-  // long Japanese line drift right and spill its tail past the terminal's edge into the hidden area.
+  // as inline runs: a full-width CJK glyph that isn't exactly 2× the Latin cell lets a long Japanese
+  // line drift right and spill its tail past the terminal's edge (the reason this was added, b12cc48).
+  // A fixed-grid renderer makes that structurally impossible.
+  //
+  // CAVEAT — version mismatch: @xterm/addon-canvas is xterm-5 era (its peerDependency is
+  // `@xterm/xterm@^5`, and there is no stable xterm-6 build — even 0.8.0-beta still peers ^5), but the
+  // app runs @xterm/xterm@6. It renders, but this xterm-5 renderer on xterm-6 internals is the
+  // suspected cause of broken selection auto-scroll + scrollbar (#782) and OSC 8 link click (#783),
+  // all of which regressed when this was introduced. Don't just bump the addon; the real fix is a
+  // renderer decision — WebGL keeps the fixed grid (so the CJK drift above stays fixed), the DOM
+  // renderer drops the dependency but risks that drift. Read #782 before touching this.
   // Best-effort: if the canvas renderer can't initialise, xterm keeps the DOM renderer.
   try {
     term.loadAddon(new CanvasAddon());


### PR DESCRIPTION
## Summary

`useTerminalConnections.ts` の canvas レンダラ load 箇所に、**なぜ入れたか**と**落とし穴**をコメントで明記（コメントのみ、挙動変更なし）。

- **なぜ**: 既定 DOM レンダラだと全角 CJK グリフのメトリクス差で長い日本語行が右へドリフトしてはみ出す（`b12cc48`）。固定グリッドの canvas で構造的に回避。
- **落とし穴**: `@xterm/addon-canvas` は **xterm5 系（peer `@xterm/xterm@^5`、xterm6 stable 無し・0.8.0-beta も peer ^5）** なのに、アプリは **`@xterm/xterm@6`**。描画はできるが、この不一致が **選択オートスクロール/スクロールバー（#782）と OSC 8 リンククリック（#783）の退行**の疑い元。**単純な addon bump ではなく renderer 移行（WebGL or DOM）の判断が要る**旨と、#782 参照を明記。

次に触る人が「なぜ canvas があるのか」「なぜ迂闊に外せない/bump できないのか」を1か所で分かるようにするのが狙いです。

## Items to Confirm / Review
- コメントのみ（`term.loadAddon(new CanvasAddon())` の直前）。lint/typecheck green。
- 文面の妥当性（CJK 対策の説明＋ xterm5/6 不一致＋ #782 誘導）。

## User Prompt
> canvas addon をそもそもなんで入れたか等の情報を、該当部分のソースにコメントとして入れておいてほしい。

## 関連
- #782（スクロール/スクロールバー/選択 — renderer 移行判断）
- #783（OSC 8 リンク）
- `b12cc48`（canvas 導入コミット）

🤖 Generated with [Claude Code](https://claude.com/claude-code)