### PR TITLE
docs: add npx cache corruption troubleshooting to README and landing …

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ The published package ships the server (run via `tsx`) plus the pre-built web UI
 server, and opens the browser. For local development from a clone, see
 [Running](#running).
 
+**Won't start with `ERR_MODULE_NOT_FOUND`?** If a first `npx` run was interrupted, a half-unpacked `~/.npm/_npx/<hash>` cache can remain and a later run fails at startup — a corrupted npx cache, not a bug in the published package.
+The launcher detects it and prints the exact, OS-appropriate removal command; run that, then `npx mulmoterminal@latest` again.
+
 ---
 
 ## Contents

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,12 @@ runs, you're ready. **Recommended:** `tmux` (session persistence) · `gh` (PRs/I
 npx mulmoterminal@latest                        # opens http://localhost:34567
 ```
 
+**うまく起動しないとき（npx キャッシュ破損）:** 最初の `npx` インストールが途中で中断されると、`~/.npm/_npx/<hash>` が壊れたまま残り、次回起動が `ERR_MODULE_NOT_FOUND` で落ちることがあります（公開パッケージの不具合ではありません）。
+ランチャが破損キャッシュを検知して**削除コマンドを表示**するので、それを実行してから再度 `npx mulmoterminal@latest` してください。
+
+**If it won't start (`ERR_MODULE_NOT_FOUND`):** If a first `npx` install was interrupted, a half-unpacked `~/.npm/_npx/<hash>` can remain and a later run fails at startup — a corrupted npx cache, not a bug in the published package.
+The launcher detects it and prints the exact removal command; run that, then `npx mulmoterminal@latest` again.
+
 ---
 
 ## 日本語


### PR DESCRIPTION
## Summary
README と docs のランディング（docs/index.md）に、npx キャッシュ破損による起動失敗（ERR_MODULE_NOT_FOUND）の troubleshooting を追記した。
- 症状と、それが公開パッケージのバグではなく破損した `~/.npm/_npx/<hash>` キャッシュであることを明記
- 復旧は、ランチャが起動時に表示する削除コマンドに従えばよい旨を案内
- #735（アプリ内の検知・案内。実装/クローズ済み）のフォローアップ。従来この情報は ChangeLog のみだったため、README/ランディングから検索でたどり着ける導線を追加

## Items to Confirm / Review
- 追記位置（README: Install & run の末尾 / docs/index.md: Quick start 直後・バイリンガル）が適切か
- 文言が現行実装（`bin/npx-cache-hint.js` が削除コマンドを表示する挙動）と一致しているか

## User Prompt
- npx キャッシュ破損の件（#735 で共有された、初回 npx インストール中断による `ERR_MODULE_NOT_FOUND`）を「どこかに書いておいたほうがよいのでは」という相談が発端
- 調査の結果、#735 は既にクローズ済みでアプリ内案内も実装済みだったため、残る任意作業として「README/docs の troubleshooting への追記」を提案・承認のうえ実施

## 変更内容
- README.md: Install & run セクション末尾に英語で1段落
- docs/index.md: Quick start 直後に日英2段落（ページのバイリンガル方針に合わせる）
- コードは変更なし（docs のみ。prettier は .prettierignore の `*.md` で対象外）
