### PR TITLE
fix(windows): resolve a bare command name to its .exe before node-pty sees it (#794)

### DIFF
--- a/.github/workflows/windows-daily.yaml
+++ b/.github/workflows/windows-daily.yaml
@@ -4,9 +4,11 @@
 # on main instead, which is early enough to catch a regression before a release.
 #
 # What it actually guards: server/infra/pty-env.ts branches on PATH casing ("Path"),
-# the ";" delimiter and "\" separators; server/index.ts spawns powershell.exe; and the
-# postinstall (server/fix-pty-perms.js) runs on every install. None of that had ever
-# executed on Windows before this workflow.
+# the ";" delimiter and "\" separators; server/infra/resolve-bin.ts resolves a bare
+# command name to an .exe on PATH before node-pty sees it (#794), and its spec spawns a
+# real PTY here; server/index.ts spawns powershell.exe; and the postinstall
+# (server/fix-pty-perms.js) runs on every install. None of that had ever executed on
+# Windows before this workflow.
 name: Windows (daily)
 
 on:

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ the server runs without one.
 | ------------ | -------------- | ----------- |
 | `PORT`        | `34567`        | Backend HTTP/WebSocket port (prod: the URL you open). |
 | `CLIENT_PORT` | `6856`         | Vite dev-server port (dev only: the URL you open with `yarn dev`). |
-| `CLAUDE_BIN` | `claude`       | The Claude Code binary to spawn. |
+| `CLAUDE_BIN` | `claude`       | The Claude Code binary to spawn. On Windows a bare name is resolved to the `.exe` on `PATH` before it reaches the PTY layer, which matches file names exactly. |
 | `CLAUDE_CWD` | current dir    | Working directory each `claude` PTY runs in; determines which project's sessions the sidebar lists. Via `npx mulmoterminal` it defaults to the directory you ran the command from (override with `--cwd <dir>`, relative allowed); when the server is run directly it falls back to `~/mulmoclaude`. A value read from `.env` must be an absolute path (`~` is not expanded). |
 | `CLAUDE_PERMISSION_MODE` | `auto` | Permission mode passed to each `claude` spawn. |
 | `MT_TITLE_MODEL` | `haiku` | Model used for the cell header's AI title (a cheap/fast model summarizing the recent turns). Accepts a `--model` alias or a full model id. |

--- a/docs/spawn-architecture.md
+++ b/docs/spawn-architecture.md
@@ -37,7 +37,7 @@ pty.spawn(CLAUDE_BIN, [
 
 | # | Setting | Value / source | Purpose | Risk if changed / removed |
 |---|---------|----------------|---------|---------------------------|
-| 1 | program | `CLAUDE_BIN` (env, default `claude`) | The binary run in the PTY | Wrong/missing → spawn fails (now caught: the connection closes with an error instead of crashing the server) |
+| 1 | program | `CLAUDE_BIN` (env, default `claude`) — on Windows resolved to an absolute `.exe` first (`infra/resolve-bin.ts`) | The binary run in the PTY | Wrong/missing → spawn fails (now caught: the connection closes with an error instead of crashing the server) |
 | 2 | `cwd` | `CLAUDE_CWD` (launcher `--cwd` / env, default `~/mulmoclaude`) | Directory claude runs in. **Also scopes** which `.claude/skills` and (if enabled) `.mcp.json` are picked up, and which `~/.claude/projects/<encoded cwd>` session list the sidebar shows | Change → a different project + session list; missing dir is `mkdir -p`'d |
 | 3 | `env` | `process.env` (full passthrough) | claude finds the CLI + tools via `PATH`, and sees `CLAUDE_CWD` / any API keys present | Narrowing risks breaking `PATH` / auth; full passthrough also exposes all server env to the child |
 | 4 | `--session-id <uuid>` | new sessions | Server picks the id up front, so it knows the session before claude writes any file | Must be a fresh UUID; reuse collides with an existing session |

--- a/plans/fix-794-windows-pathext.md
+++ b/plans/fix-794-windows-pathext.md
@@ -1,0 +1,108 @@
+# fix #794 — Windows: `claude` fails to spawn when only `claude.exe` exists
+
+## Symptom
+
+On Windows every `claude` session fails to start:
+
+```
+[ws] failed to start session <id>: File not found:
+```
+
+— the path after `File not found:` is EMPTY. Codex sessions on the same host spawn fine.
+
+## Root cause (confirmed against node-pty 1.1.0 sources)
+
+`pty.spawn("claude", …)` reaches node-pty's Windows entry point, which gates the spawn on
+its own PATH lookup (`src/win/conpty.cc:275-288`, same shape in the legacy `winpty.cc`):
+
+```cpp
+if (::PathIsRelativeW(filename.c_str())) shellpath = path_util::get_shell_path(filename.c_str());
+else                                     shellpath = filename;
+if (shellpath.empty() || !path_util::file_exists(shellpath)) throw "File not found: " + shellpath;
+```
+
+`get_shell_path` (`src/win/path_util.cc`) walks the PATH directories and compares the file
+name **exactly** — it never appends an executable extension. A bare `"claude"` therefore
+misses `…\.local\bin\claude.exe`, `shellpath` stays empty, and the message prints nothing
+after the colon.
+
+Three findings beyond the issue report, all read from the vendored sources:
+
+1. **The gate and the actual launch resolve differently.** `PtyConnect` calls
+   `CreateProcessW(nullptr, cmdline, …)` (`conpty.cc:413`), so Windows itself searches PATH
+   and appends `.exe` when the name has no extension. `get_shell_path` is *only* a
+   pre-flight check. That is why `codex` works on the reporter's host by accident: the
+   extensionless shim `…\.local\bin\codex` satisfies the gate, while the process that
+   actually runs is a `codex.exe` from a different PATH directory.
+2. **`CreateProcessW` cannot execute `.cmd` / `.bat` / extensionless shims.** Resolving a
+   bare name to such a file would turn a working spawn into `Cannot create process` — the
+   codex case above is exactly that regression. So the resolver must only ever hand back a
+   PE image (`.exe` / `.com`). npm-global installs (`claude.cmd` + an extensionless shim)
+   need a `cmd.exe` wrapper and are deliberately out of scope here (follow-up issue).
+3. **Two more node-pty bugs in the same function**, neither on the critical path but worth
+   pinning in tests: the PATH splitter never pushes the segment after the last `;`, so the
+   final PATH directory is never searched; and an early `if (file_exists(filename)) return
+   shellpath;` returns the *empty* string for a name that exists relative to the cwd.
+
+node-pty's latest stable is still 1.1.0 (1.2.0 is beta-only), so waiting for upstream is
+not an option — this is fixed on our side.
+
+## Scope: every bare name we hand to node-pty
+
+All five spawn sites funnel through one function, `spawnPty()` (`server/session/pty-spawn.ts`):
+
+| call site | name passed |
+| --- | --- |
+| `session/spawn-claude.ts` | `deps.claudeBin` — `CLAUDE_BIN` or `"claude"` (`agents/claude.ts`) |
+| `session/spawn-codex.ts` | `deps.codexBin` — `CODEX_BIN` or `"codex"` (`agents/codex.ts`) |
+| `session/pty-spawn.ts` (tmux) | `"tmux"` — hard-coded, no env override |
+| `session/pty-spawn.ts` (sandbox) | `"docker"` — darwin-gated, unaffected in practice |
+| `session/spawn-shell.ts` | `"powershell.exe"` on win32 (already has an extension) |
+
+Fixing `spawnPty()` covers all of them, including the tmux path reported in the issue
+follow-up, which has no `*_BIN` escape hatch of its own.
+
+## The fix
+
+New `server/infra/resolve-bin.ts`:
+
+- `resolveWindowsExecutable(bin, searchPath, isExecutableFile)` — pure. Returns the absolute
+  path of the first `<PATH dir>\<bin>.exe` / `.com` (or `<PATH dir>\<bin>` when `bin`
+  already ends in `.exe`/`.com`), or `null`. Uses `path.win32` and `";"` explicitly so the
+  rule is checkable from any host. `null` for a name that already contains a separator.
+- `resolvePtyBin(bin, platform, searchPath)` — `bin` unchanged on non-Windows and whenever
+  nothing resolves, so a host that works today keeps working.
+
+`spawnPty()` calls `resolvePtyBin` with the PATH of the **sanitized child env** (via a new
+`pathFromEnv` in `infra/pty-env.ts`, which knows Windows spells it `Path`) rather than
+`process.env` — the binary a session needs is the one findable from the environment that
+session will run in.
+
+Deliberately NOT done here:
+
+- No `.cmd`/`.bat` support (needs a `cmd.exe /c` wrapper plus its own escaping story —
+  filed separately).
+- No memoization: PATH lookups are ~2 `existsSync` calls per PATH entry per spawn, and a
+  cache would go stale the moment a user installs the CLI mid-session.
+- `tmuxAvailable()` still detects via `spawnSync` (libuv, which does honour PATHEXT), so a
+  `tmux.cmd`-only host would still detect tmux and then fail to spawn it. psmux ships
+  `tmux.exe`; revisit with the `.cmd` follow-up.
+
+## Tests
+
+`test/server/infra/resolve-bin.spec.ts` — pure, runs on every OS in the PR CI matrix:
+happy path, PATH order, the **last** PATH entry (the node-pty splitter drops it),
+extensionless / `.cmd` / `.bat` candidates ignored, a name that already carries `.exe`,
+names containing a separator, empty and missing PATH, empty PATH entries, case-insensitive
+extension match, and `resolvePtyBin`'s two pass-through arms.
+
+`test/server/session/pty-spawn-win.spec.ts` — `skipIf(process.platform !== "win32")`, so it
+only runs in `.github/workflows/windows-daily.yaml` (which already runs `yarn test`):
+copy `process.execPath` into a temp dir as `mt-probe-<pid>.exe`, prepend the dir to PATH,
+then assert (a) the resolver returns that absolute path, (b) `spawnPty` with the bare name
+actually spawns and exits 0, and (c) a raw `pty.spawn` with the same bare name still throws
+`File not found:` — the regression pin that tells us when node-pty fixes this upstream and
+the workaround can be dropped.
+
+Run the Windows job on the PR branch with
+`gh workflow run windows-daily.yaml --ref fix/794-windows-pathext`.

--- a/server/infra/pty-env.ts
+++ b/server/infra/pty-env.ts
@@ -37,6 +37,14 @@ export function isPathVar(name: string): boolean {
   return name.toLowerCase() === "path";
 }
 
+// The search path out of a PLAIN env object. `env.PATH` is only reliable on the live
+// `process.env`, whose Windows lookups are case-insensitive; a copy (what sanitizePtyEnv
+// returns) keeps the original "Path" key and answers undefined to `.PATH`.
+export function pathFromEnv(env: NodeJS.ProcessEnv): string | undefined {
+  const entry = Object.entries(env).find(([name]) => isPathVar(name));
+  return entry?.[1];
+}
+
 // yarn v1's temp dir is `yarn--` + a timestamp.
 const YARN_SHIM_DIR = /^yarn--\d/;
 

--- a/server/infra/resolve-bin.ts
+++ b/server/infra/resolve-bin.ts
@@ -1,0 +1,67 @@
+// Windows-only PATH resolution for the binaries we hand to node-pty.
+//
+// node-pty gates a spawn on its OWN lookup (src/win/path_util.cc get_shell_path), which
+// compares each PATH directory's file name EXACTLY — it never appends an executable
+// extension. A bare "claude" therefore misses `…\.local\bin\claude.exe` and the spawn dies
+// with `File not found: ` (nothing after the colon, since the path it failed to find is the
+// empty string). Handing it an absolute path skips that lookup entirely.
+//
+// The gate is all this has to satisfy: node-pty then launches via
+// `CreateProcessW(nullptr, cmdline, …)`, which does its own PATH search. Which is also why
+// only a PE image may be returned here — CreateProcess cannot run a `.cmd`, a `.bat`, or an
+// extensionless shell shim, so resolving a bare name to one would turn a spawn that works
+// today (the shim satisfies the gate, CreateProcess finds the real .exe elsewhere on PATH)
+// into `Cannot create process`.
+import { statSync } from "node:fs";
+import path from "node:path";
+import { pathFromEnv } from "./pty-env.js";
+
+// `.exe` first: with both present, a bare name would have reached the `.exe` (CreateProcess
+// appends exactly that), so resolving must not silently switch which file runs.
+const EXECUTABLE_EXTENSIONS = [".exe", ".com"] as const;
+
+const hasExecutableExtension = (bin: string): boolean => EXECUTABLE_EXTENSIONS.some((ext) => bin.toLowerCase().endsWith(ext));
+
+// A name node-pty/CreateProcess already resolves on its own (absolute, or relative to a
+// directory) rather than by searching PATH.
+const namesAPath = (bin: string): boolean => bin.includes("\\") || bin.includes("/");
+
+export function isExecutableFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** The absolute path of the executable a bare Windows command name refers to, or null when
+ *  PATH holds no `.exe`/`.com` for it (the caller then leaves the name as it is). Pure —
+ *  `searchPath` and the existence check are parameters, and `path.win32` + ";" are used
+ *  explicitly, so the rule is checkable from a POSIX host too. */
+export function resolveWindowsExecutable(bin: string, searchPath: string | undefined, fileExists: (candidate: string) => boolean): string | null {
+  if (bin === "" || namesAPath(bin)) return null;
+  const names = hasExecutableExtension(bin) ? [bin] : EXECUTABLE_EXTENSIONS.map((ext) => bin + ext);
+  const candidates = searchDirectories(searchPath).flatMap((dir) => names.map((name) => path.win32.join(dir, name)));
+  return candidates.find(fileExists) ?? null; // `find` is lazy: it stops at the first hit
+}
+
+// A PATH entry may be quoted — `"C:\Program Files\tools"` — which the shells strip and a
+// plain join would not, leaving a path that matches nothing.
+const searchDirectories = (searchPath: string | undefined): string[] =>
+  (searchPath ?? "")
+    .split(";")
+    .map((entry) => entry.replace(/^"(.*)"$/, "$1"))
+    .filter((entry) => entry !== "");
+
+/** The name to hand node-pty for `bin`. Unchanged off Windows, and unchanged when nothing
+ *  resolves — a host that spawns fine today must keep spawning fine. */
+export function resolvePtyBin(bin: string, platform: NodeJS.Platform, searchPath: string | undefined, fileExists = isExecutableFile): string {
+  if (platform !== "win32") return bin;
+  return resolveWindowsExecutable(bin, searchPath, fileExists) ?? bin;
+}
+
+/** `resolvePtyBin` against the environment the session itself will run with: the binary that
+ *  matters is the one reachable from the child's PATH, not the server's. */
+export function resolvePtyBinForEnv(bin: string, env: NodeJS.ProcessEnv): string {
+  return resolvePtyBin(bin, process.platform, pathFromEnv(env));
+}

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -7,6 +7,7 @@ import type { IPty } from "node-pty";
 import path from "node:path";
 import type { WebSocket } from "ws";
 import { sanitizePtyEnv } from "../infra/pty-env.js";
+import { resolvePtyBinForEnv } from "../infra/resolve-bin.js";
 import { withoutUnset } from "./provider-env.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxScrubEnvNames } from "../infra/tmux.js";
 import {
@@ -33,7 +34,9 @@ const PTY_ROWS = 30;
 // the settings `env` block, which can set a variable but not remove one.
 export function spawnPty(bin: string, args: string[], cwd: string, unset: readonly string[] = []): IPty {
   const env = withoutUnset(sanitizePtyEnv(process.env, path.delimiter), unset);
-  return pty.spawn(bin, args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env });
+  // On Windows a bare name never reaches node-pty as-is: its own PATH lookup ignores
+  // executable extensions, so `claude` misses claude.exe (see infra/resolve-bin.ts, #794).
+  return pty.spawn(resolvePtyBinForEnv(bin, env), args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env });
 }
 
 // Would this session run in the Docker sandbox? Single-view interactive only (the caller

--- a/test/server/infra/pty-env.spec.ts
+++ b/test/server/infra/pty-env.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isLauncherEnvVar, isPathVar, sanitizePathEntries, sanitizePtyEnv } from "../../../server/infra/pty-env";
+import { isLauncherEnvVar, isPathVar, pathFromEnv, sanitizePathEntries, sanitizePtyEnv } from "../../../server/infra/pty-env";
 
 describe("isLauncherEnvVar", () => {
   it("flags the vars package-manager launchers inject", () => {
@@ -115,5 +115,22 @@ describe("sanitizePtyEnv", () => {
   it("cleans a windows-cased Path key", () => {
     const out = sanitizePtyEnv({ Path: "C:\\repo\\node_modules\\.bin;C:\\Windows" }, ";");
     expect(out.Path).toBe("C:\\Windows");
+  });
+});
+
+describe("pathFromEnv", () => {
+  it("reads the search path whatever the key's casing is", () => {
+    expect(pathFromEnv({ PATH: "/usr/bin" })).toBe("/usr/bin");
+    expect(pathFromEnv({ Path: "C:\\Windows" })).toBe("C:\\Windows");
+    expect(pathFromEnv({ path: "/usr/bin" })).toBe("/usr/bin");
+  });
+
+  it("is undefined when the env carries no search path", () => {
+    expect(pathFromEnv({ HOME: "/Users/u", PATHEXT: ".COM;.EXE" })).toBeUndefined();
+    expect(pathFromEnv({})).toBeUndefined();
+  });
+
+  it("survives an empty value rather than reporting it as absent", () => {
+    expect(pathFromEnv({ Path: "" })).toBe("");
   });
 });

--- a/test/server/infra/resolve-bin.spec.ts
+++ b/test/server/infra/resolve-bin.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { resolveWindowsExecutable, resolvePtyBin } from "../../../server/infra/resolve-bin";
+
+// A fake Windows filesystem: the exact set of files that exist, matched case-insensitively
+// the way Windows does.
+const filesystem = (...files: string[]) => {
+  const present = new Set(files.map((file) => file.toLowerCase()));
+  return (candidate: string) => present.has(candidate.toLowerCase());
+};
+
+const LOCAL_BIN = "C:\\Users\\u\\.local\\bin";
+const SYSTEM32 = "C:\\Windows\\System32";
+
+describe("resolveWindowsExecutable", () => {
+  it("finds the .exe a bare name refers to (the #794 case: no extensionless shim exists)", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.exe`);
+    expect(resolveWindowsExecutable("claude", `${SYSTEM32};${LOCAL_BIN};C:\\tools`, exists)).toBe(`${LOCAL_BIN}\\claude.exe`);
+  });
+
+  it("searches the LAST PATH entry — node-pty's own splitter never pushes the segment after the final ';'", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.exe`);
+    expect(resolveWindowsExecutable("claude", `${SYSTEM32};${LOCAL_BIN}`, exists)).toBe(`${LOCAL_BIN}\\claude.exe`);
+  });
+
+  it("takes the first PATH directory that has it", () => {
+    const exists = filesystem(`${SYSTEM32}\\tmux.exe`, `${LOCAL_BIN}\\tmux.exe`);
+    expect(resolveWindowsExecutable("tmux", `${SYSTEM32};${LOCAL_BIN}`, exists)).toBe(`${SYSTEM32}\\tmux.exe`);
+  });
+
+  it("prefers .exe over .com in the same directory, since a bare name would have reached the .exe", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.com`, `${LOCAL_BIN}\\claude.exe`);
+    expect(resolveWindowsExecutable("claude", LOCAL_BIN, exists)).toBe(`${LOCAL_BIN}\\claude.exe`);
+  });
+
+  it("finds a .com when that is the only candidate", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.com`);
+    expect(resolveWindowsExecutable("claude", LOCAL_BIN, exists)).toBe(`${LOCAL_BIN}\\claude.com`);
+  });
+
+  // CreateProcessW — which node-pty calls right after the lookup this feeds — runs PE images
+  // only. Naming a shim directly breaks a spawn that works today, where the shim merely
+  // satisfies node-pty's existence gate and CreateProcess finds the real .exe further down PATH.
+  it("ignores an extensionless shim and keeps looking for a real executable (the codex case)", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\codex`, `${SYSTEM32}\\codex.exe`);
+    expect(resolveWindowsExecutable("codex", `${LOCAL_BIN};${SYSTEM32}`, exists)).toBe(`${SYSTEM32}\\codex.exe`);
+  });
+
+  it("ignores .cmd / .bat / .ps1 — CreateProcess cannot execute them", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.cmd`, `${LOCAL_BIN}\\claude.bat`, `${LOCAL_BIN}\\claude.ps1`);
+    expect(resolveWindowsExecutable("claude", LOCAL_BIN, exists)).toBeNull();
+  });
+
+  it("matches a name that already carries .exe exactly, without appending another extension", () => {
+    const exists = filesystem(`${SYSTEM32}\\powershell.exe`);
+    expect(resolveWindowsExecutable("powershell.exe", SYSTEM32, exists)).toBe(`${SYSTEM32}\\powershell.exe`);
+    expect(resolveWindowsExecutable("powershell.exe", SYSTEM32, filesystem(`${SYSTEM32}\\powershell.exe.exe`))).toBeNull();
+  });
+
+  it("matches the given extension case-insensitively", () => {
+    const exists = filesystem(`${SYSTEM32}\\powershell.exe`);
+    expect(resolveWindowsExecutable("PowerShell.EXE", SYSTEM32, exists)).toBe(`${SYSTEM32}\\PowerShell.EXE`);
+  });
+
+  it("leaves a name that already names a path alone — node-pty resolves those itself", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.exe`);
+    expect(resolveWindowsExecutable(`${LOCAL_BIN}\\claude.exe`, LOCAL_BIN, exists)).toBeNull();
+    expect(resolveWindowsExecutable("bin\\claude", LOCAL_BIN, exists)).toBeNull();
+    expect(resolveWindowsExecutable("./claude", LOCAL_BIN, exists)).toBeNull();
+  });
+
+  it("returns null for an empty name, an empty PATH, and a missing PATH", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.exe`);
+    expect(resolveWindowsExecutable("", `${LOCAL_BIN}`, exists)).toBeNull();
+    expect(resolveWindowsExecutable("claude", "", exists)).toBeNull();
+    expect(resolveWindowsExecutable("claude", undefined, exists)).toBeNull();
+  });
+
+  it("skips empty PATH entries rather than resolving against the cwd", () => {
+    const seen: string[] = [];
+    const exists = (candidate: string) => {
+      seen.push(candidate);
+      return candidate === `${LOCAL_BIN}\\claude.exe`;
+    };
+    expect(resolveWindowsExecutable("claude", `;;${LOCAL_BIN};`, exists)).toBe(`${LOCAL_BIN}\\claude.exe`);
+    expect(seen).toEqual([`${LOCAL_BIN}\\claude.exe`]);
+  });
+
+  it("unquotes a PATH entry, the way a shell does", () => {
+    const programFiles = "C:\\Program Files\\tools";
+    const exists = filesystem(`${programFiles}\\tmux.exe`);
+    expect(resolveWindowsExecutable("tmux", `"${programFiles}"`, exists)).toBe(`${programFiles}\\tmux.exe`);
+  });
+
+  it("returns null when nothing on PATH matches", () => {
+    expect(resolveWindowsExecutable("claude", `${SYSTEM32};${LOCAL_BIN}`, filesystem(`${SYSTEM32}\\codex.exe`))).toBeNull();
+  });
+});
+
+describe("resolvePtyBin", () => {
+  it("is a no-op off Windows even when a candidate would match — node-pty resolves bare names there", () => {
+    const everythingExists = () => true;
+    expect(resolvePtyBin("claude", "darwin", "/usr/local/bin", everythingExists)).toBe("claude");
+    expect(resolvePtyBin("claude", "linux", "/usr/local/bin", everythingExists)).toBe("claude");
+    expect(resolvePtyBin("claude", "win32", "C:\\bin", everythingExists)).toBe("C:\\bin\\claude.exe");
+  });
+
+  it("keeps the bare name on Windows when nothing resolves, so a host that works today still works", () => {
+    expect(resolvePtyBin("claude", "win32", "C:\\nowhere")).toBe("claude");
+  });
+});

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -1,0 +1,67 @@
+// Windows-only: the real node-pty spawn that #794 broke. Skipped everywhere else, so it
+// runs in .github/workflows/windows-daily.yaml (which already runs `yarn test`) rather than
+// in the PR matrix — the rule itself is covered by the pure tests in infra/resolve-bin.spec.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import pty from "node-pty";
+import { spawnPty } from "../../../server/session/pty-spawn";
+import { resolvePtyBinForEnv } from "../../../server/infra/resolve-bin";
+
+const isWindows = process.platform === "win32";
+
+// A binary that exists ONLY as an .exe, with no extensionless twin — the shape of a Claude
+// Code install from the official Windows installer. node.exe stands in for it: it is
+// guaranteed present and answers `-e`.
+const PROBE = `mt-probe-${process.pid}`;
+
+describe.skipIf(!isWindows)("spawnPty on Windows", () => {
+  let dir = "";
+  let probeExe = "";
+  let originalPath: string | undefined;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "mt-probe-"));
+    probeExe = path.join(dir, `${PROBE}.exe`);
+    copyFileSync(process.execPath, probeExe);
+    originalPath = process.env.PATH;
+    process.env.PATH = `${dir};${process.env.PATH ?? ""}`;
+  });
+
+  afterAll(() => {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolves a bare name to the .exe on PATH", () => {
+    expect(resolvePtyBinForEnv(PROBE, process.env)).toBe(probeExe);
+  });
+
+  it("spawns a PTY for a bare name whose only match is an .exe", async () => {
+    const term = spawnPty(PROBE, ["-e", "process.stdout.write('mt-probe ok')"], dir);
+    expect(term.pid).toBeGreaterThan(0);
+    let output = "";
+    term.onData((data) => {
+      output += data;
+    });
+    const exitCode = await new Promise<number>((resolve) => term.onExit(({ exitCode }) => resolve(exitCode)));
+    expect(exitCode).toBe(0);
+    expect(output).toContain("mt-probe ok");
+  });
+
+  // The reason resolve-bin.ts exists. When this starts failing, node-pty has learned to
+  // resolve executable extensions itself (its src/win/path_util.cc get_shell_path) and the
+  // workaround can be reconsidered — it is not a sign that anything here regressed.
+  it("pins the node-pty bug it works around: a bare name alone still fails", () => {
+    let term: pty.IPty;
+    try {
+      term = pty.spawn(PROBE, [], { name: "xterm-256color", cols: 80, rows: 24, cwd: dir, env: process.env });
+    } catch (err) {
+      expect(String(err)).toMatch(/File not found/);
+      return;
+    }
+    term.kill();
+    expect.fail("node-pty resolved a bare name on its own — re-check whether infra/resolve-bin.ts is still needed");
+  });
+});


### PR DESCRIPTION
## Summary

Windows で `claude` セッションが必ず `File not found:`（コロンの後ろが空文字）で失敗する #794 の修正。

node-pty は Windows で spawn の前に**自前の PATH 検索**（`src/win/path_util.cc` の `get_shell_path`）
でファイルの存在を確認するが、この検索は**ファイル名の完全一致しか見ない**（実行可能拡張子を一切
補わない）。そのため bare な `"claude"` は公式インストーラが作る `…\.local\bin\claude.exe` にヒット
せず、`shellpath` が空のまま `File not found: `（空文字付き）で throw する。

修正は、すべての PTY spawn が通る唯一の関数 `spawnPty()`（`server/session/pty-spawn.ts`）で、Windows
のときだけコマンド名を `PATH` 上の `.exe` / `.com` の**絶対パス**に解決してから node-pty に渡す、というもの。
`claude` / `codex` / `tmux`（`*_BIN` の逃げ道が無い、issue の追加報告のケース）/ `powershell.exe` が
まとめて直る。解決できなければ bare 名のまま渡す＝**今日動いているホストの挙動は変わらない**。

## Items to Confirm / Review

- **`.exe` / `.com` しか返さない**という判断（`server/infra/resolve-bin.ts`）。node-pty は最終的に
  `CreateProcessW(nullptr, cmdline, …)` でプロセスを作るため、`.cmd` / `.bat` / 拡張子なしの sh シムは
  実行できない。ここに解決してしまうと、「拡張子なしシムが存在チェックを通し、実体は別ディレクトリの
  `codex.exe` が CreateProcess 側で解決される」という**今動いている codex が壊れる**。→ npm グローバル
  導入（`.cmd` のみ）の対応は #798 に分離した。
- **解決に使う PATH を「sanitize 済みの子プロセス env」から取っている**点（node-pty 自身は親プロセスの
  `Path` を読む）。セッションが実際に走る環境から見つかるバイナリを選ぶ、という意図。
- **Windows 実機テストは daily ワークフロー側**に置いた（`windows-daily.yaml` の方針コメントに従い、
  PR CI の Windows 追加はしていない）。このブランチでは
  `gh workflow run windows-daily.yaml --ref fix/794-windows-pathext` で手動実行して確認する想定。
- `tmuxAvailable()` は今も `spawnSync`（libuv = 拡張子解決あり）で検出しているため、`tmux.cmd` しか
  無いホストでは「検出は成功 → spawn は失敗」の非対称が残る（psmux は `tmux.exe` を配るので実害なし、
  #798 で扱う）。
- メモ化していない（PATH 探索は 1 spawn あたり数十回の `statSync`）。セッション中に CLI を入れた
  ユーザーが即座に救われる方を優先した。

## User Prompt

> これって直せる？？そもそもの原因ってあっている？CIでテストも追加できる？
> https://github.com/receptron/mulmoterminal/issues/794
>
> （スコープの確認に対して）v1のみ：spawnPty() に win32 の PATHEXT 解決（.exe/.com のみ採用、
> 見つからなければ現状維持）を集約。claude.exe / tmux.exe が直り、退行リスクゼロ。
> 純粋関数テスト＋Windows実機テストを追加。
>
> cmd/batも、必要だったら別途issueかしておいてね。

## 原因の裏取り（node-pty 1.1.0 のソースを直接確認）

```cpp
// src/win/conpty.cc:275-288
if (::PathIsRelativeW(filename.c_str())) shellpath = path_util::get_shell_path(filename.c_str());
else                                     shellpath = filename;
if (shellpath.empty() || !path_util::file_exists(shellpath)) throw "File not found: " + shellpath;
```

`get_shell_path`（`src/win/path_util.cc`）は PATH の各ディレクトリで `PathCombineW(dir, filename)` の
存在を見るだけで、`%PATHEXT%` も `.exe` も試さない。→ 報告された原因は**正しい**。

報告に無かった追加の知見:

1. **存在チェックと実際の起動は別解決**。`PtyConnect` は `CreateProcessW(nullptr, cmdline, …)`
   （`conpty.cc:413`）で、Windows 自身が PATH を検索し拡張子なしなら `.exe` を補う。つまり
   `get_shell_path` は**ゲートでしかない**。codex が動くのは「拡張子なしシムがゲートを通し、実体は
   別の `codex.exe`」という二重の偶然。
2. **だから `.cmd` に解決してはいけない**（上記 Items to Confirm）。
3. **同じ関数にさらに 2 つのバグ**: PATH 分割ループが最後の `;` 以降の要素を push しないので**PATH 末尾の
   ディレクトリが検索されない**。また `if (file_exists(filename)) return shellpath;` が cwd 相対に存在
   するとき**空文字**を返す。前者は回帰テストとしてピン留めした。

node-pty の stable は 1.1.0 のまま（1.2.0 は beta のみ）なので、上流待ちにはしない。

## 変更点

| ファイル | 内容 |
| --- | --- |
| `server/infra/resolve-bin.ts` (新規) | `resolveWindowsExecutable()`（純粋。PATH・存在判定を引数で受け、`path.win32` と `";"` を明示するので POSIX ホストからも検証できる）と `resolvePtyBin()` / `resolvePtyBinForEnv()` |
| `server/infra/pty-env.ts` | `pathFromEnv()` を追加。env のコピーは `Path` キーの綴りを保つので `env.PATH` では読めない |
| `server/session/pty-spawn.ts` | `spawnPty()` が node-pty に渡す直前で解決 |
| `README.md` / `docs/spawn-architecture.md` | `CLAUDE_BIN` の Windows 解決について 1 行追記 |
| `.github/workflows/windows-daily.yaml` | 「このワークフローが何を守っているか」のコメントを更新 |
| `plans/fix-794-windows-pathext.md` | 調査と設計の記録 |

## テスト

- `test/server/infra/resolve-bin.spec.ts`（純粋・全 OS で走る、15 ケース）
  正常系 / PATH の順序 / **PATH 末尾の要素**（node-pty の splitter が落とす箇所）/ 拡張子なしシムを
  無視して先の `.exe` を選ぶ（codex 退行防止）/ `.cmd` `.bat` `.ps1` を無視 / 既に `.exe` が付いた名前 /
  大文字小文字 / セパレータを含む名前は素通し / 空 PATH・PATH 無し / 空エントリ / クォートされた
  PATH エントリ / 非 Windows は無変更。
- `test/server/infra/pty-env.spec.ts` に `pathFromEnv` の 3 ケース追加。
- `test/server/session/pty-spawn-win.spec.ts`（`skipIf(platform !== "win32")`）
  `process.execPath` を temp に `mt-probe-<pid>.exe` としてコピー → PATH 先頭に追加 →
  ①resolver が絶対パスを返す ②`spawnPty` が実際に PTY を起こして exit 0 ③**bare 名のままだと node-pty が
  今も `File not found:` で落ちる**ことをピン留め（上流が直ったら失敗して気づける、というコメント付き）。
- 各テストは実装を壊すと落ちることを確認済み（拡張子リストに `""` を足す / PATH 末尾を落とす /
  クォート除去を消す / `pathFromEnv` を大文字固定にする、の 4 パターンで mutation 確認）。
- `yarn format` / `lint` / `build` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（3813 passed）/ `knip` 実行済み。

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
