### PR TITLE
fix(windows): run a .cmd shim through cmd.exe so npm-global installs spawn (#798)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ the server runs without one.
 | ------------ | -------------- | ----------- |
 | `PORT`        | `34567`        | Backend HTTP/WebSocket port (prod: the URL you open). |
 | `CLIENT_PORT` | `6856`         | Vite dev-server port (dev only: the URL you open with `yarn dev`). |
-| `CLAUDE_BIN` | `claude`       | The Claude Code binary to spawn. On Windows a bare name is resolved to the `.exe` on `PATH` before it reaches the PTY layer, which matches file names exactly. |
+| `CLAUDE_BIN` | `claude`       | The Claude Code binary to spawn. On Windows a bare name is resolved on `PATH` before it reaches the PTY layer (which matches file names exactly): to the `.exe` when there is one, otherwise to the `.cmd` shim an npm-global install leaves, run through `cmd.exe`. |
 | `CLAUDE_CWD` | current dir    | Working directory each `claude` PTY runs in; determines which project's sessions the sidebar lists. Via `npx mulmoterminal` it defaults to the directory you ran the command from (override with `--cwd <dir>`, relative allowed); when the server is run directly it falls back to `~/mulmoclaude`. A value read from `.env` must be an absolute path (`~` is not expanded). |
 | `CLAUDE_PERMISSION_MODE` | `auto` | Permission mode passed to each `claude` spawn. |
 | `MT_TITLE_MODEL` | `haiku` | Model used for the cell header's AI title (a cheap/fast model summarizing the recent turns). Accepts a `--model` alias or a full model id. |

--- a/docs/spawn-architecture.md
+++ b/docs/spawn-architecture.md
@@ -37,7 +37,7 @@ pty.spawn(CLAUDE_BIN, [
 
 | # | Setting | Value / source | Purpose | Risk if changed / removed |
 |---|---------|----------------|---------|---------------------------|
-| 1 | program | `CLAUDE_BIN` (env, default `claude`) — on Windows resolved to an absolute `.exe` first (`infra/resolve-bin.ts`) | The binary run in the PTY | Wrong/missing → spawn fails (now caught: the connection closes with an error instead of crashing the server) |
+| 1 | program | `CLAUDE_BIN` (env, default `claude`) — on Windows resolved to an absolute `.exe`, else to a `.cmd`/`.bat` shim run under `cmd.exe` (`infra/resolve-bin.ts`, `infra/cmd-escape.ts`) | The binary run in the PTY | Wrong/missing → spawn fails (now caught: the connection closes with an error instead of crashing the server) |
 | 2 | `cwd` | `CLAUDE_CWD` (launcher `--cwd` / env, default `~/mulmoclaude`) | Directory claude runs in. **Also scopes** which `.claude/skills` and (if enabled) `.mcp.json` are picked up, and which `~/.claude/projects/<encoded cwd>` session list the sidebar shows | Change → a different project + session list; missing dir is `mkdir -p`'d |
 | 3 | `env` | `process.env` (full passthrough) | claude finds the CLI + tools via `PATH`, and sees `CLAUDE_CWD` / any API keys present | Narrowing risks breaking `PATH` / auth; full passthrough also exposes all server env to the child |
 | 4 | `--session-id <uuid>` | new sessions | Server picks the id up front, so it knows the session before claude writes any file | Must be a fresh UUID; reuse collides with an existing session |

--- a/plans/fix-798-windows-cmd-wrapper.md
+++ b/plans/fix-798-windows-cmd-wrapper.md
@@ -1,0 +1,85 @@
+# fix #798 — Windows: launch a `.cmd`-only CLI through `cmd.exe`
+
+Follow-up to #794 / #799, which resolved a bare command name to an absolute `.exe`/`.com`
+before node-pty's own PATH lookup could fail on it. This one covers the case that fix
+deliberately left out: an npm-global install, where the only thing on PATH is a batch shim.
+
+```
+npm i -g @anthropic-ai/claude-code   →  <npm prefix>\claude       (extensionless sh shim)
+                                        <npm prefix>\claude.cmd
+                                        <npm prefix>\claude.ps1
+                                        (no claude.exe)
+```
+
+## Why it fails today
+
+node-pty launches through `CreateProcessW`, which runs PE images only — it cannot execute a
+`.cmd`, a `.bat`, or an extensionless shell shim. Both shapes of the failure look identical
+to the user (the generic "Failed to start Claude" close frame):
+
+| on PATH | node-pty's gate (`get_shell_path`) | `CreateProcessW` | logged |
+| --- | --- | --- | --- |
+| `claude.cmd` only | fails (exact-name match) | never reached | `File not found: ` |
+| `claude` shim + `claude.cmd` | passes on the shim | looks for `claude.exe`, misses | `Cannot create process` |
+
+## The fix
+
+`cmd.exe /d /s /c "…"` wrapping, decided in the same place as #799 so every spawn site
+inherits it:
+
+- **`server/infra/cmd-escape.ts`** (new, pure) — builds the command line for a batch target.
+  `/d` skips AutoRun (a registry-injected command would otherwise run first), `/s` makes cmd
+  strip exactly the outer quote pair and take the rest verbatim, which is what keeps the
+  quoting rules below predictable.
+- **`server/infra/resolve-bin.ts`** — resolution now returns a launch descriptor
+  (`{ file, args }`) rather than a path, so a batch target can name `cmd.exe` as the file.
+- **`server/session/pty-spawn.ts`** — hands the descriptor to `pty.spawn`. node-pty accepts a
+  raw command-line **string** in place of an argv array (`argsToCommandLine` passes a string
+  through verbatim), which is what lets us own the quoting of everything after `cmd.exe`.
+
+### Resolution order: `.exe`/`.com` everywhere, only then `.cmd`/`.bat`
+
+Not cmd.exe's own per-directory order. A host that works today must keep running the exact
+same file: the reporter's codex install has an extensionless shim (and a `.cmd`) in an
+*earlier* PATH directory than the `codex.exe` that actually runs, so a per-directory order
+would silently move it onto the batch path — more layers, and the escaping caveats below —
+where it currently launches directly. The batch path is a fallback for "nothing executable
+exists at all", never a preference.
+
+### Argument escaping — the actual work
+
+Wrapping in `cmd.exe` means the command line is parsed twice: by cmd, then by the child's
+CRT. cmd treats `& | < > ^ ( )` as metacharacters, and `\"` — the CRT's escape, which
+node-pty's own `argsToCommandLine` emits — does **not** escape a quote to cmd; it just ends
+the quoted section, which is precisely the injection this has to prevent. So for the cmd
+layer each argument is:
+
+- rejected outright when it contains NUL, CR or LF (not representable on a command line),
+- always wrapped in `"` (inside quotes, cmd's metacharacters are literal),
+- with every internal `"` doubled (`""`, cmd's own escape — not `\"`),
+- and a trailing run of backslashes doubled, so it cannot escape the closing quote at the
+  CRT layer.
+
+Known limitation, pinned as a test rather than fixed: `%VAR%` is still expanded by cmd inside
+double quotes, and `^` cannot prevent it. Rust hit the same wall (CVE-2024-24576) and Node
+answered it by refusing to spawn `.cmd` without `shell: true` at all (CVE-2024-27980).
+Rejecting every argument containing `%` was considered and dropped — a Claude prompt with a
+percent sign in it is ordinary, and env-var substitution into our own child's argument is a
+correctness wart, not a privilege boundary.
+
+The escaping is empirical, not theoretical: the Windows CI job round-trips real arguments
+through a shim built like npm's (`node "…cli.js" %*`) and asserts the child's `process.argv`
+matches what was passed. Anything that does not round-trip gets rejected by the escaper
+rather than guessed at.
+
+## Tests
+
+- `test/server/infra/cmd-escape.spec.ts` — pure, every OS: plain, spaces, tabs, embedded
+  quotes, JSON (our real `--settings` / `--mcp-config` payloads), `& | < > ^ ( )`, trailing
+  backslashes, empty string, CJK, and the NUL/CR/LF rejections.
+- `test/server/infra/resolve-bin.spec.ts` — the `.exe`-before-`.cmd` ordering, the descriptor
+  shape for each target kind, and the existing #794 cases unchanged.
+- `test/server/session/pty-spawn-win.spec.ts` — Windows only: spawn through a generated
+  npm-style `.cmd` shim and assert the argument round-trip, plus exit code propagation.
+
+Verify with `gh workflow run windows-daily.yaml --ref fix/798-windows-cmd-wrapper`.

--- a/server/infra/cmd-escape.ts
+++ b/server/infra/cmd-escape.ts
@@ -1,0 +1,48 @@
+// Building the command line that runs a Windows batch shim (`claude.cmd` from an npm-global
+// install) under `cmd.exe`. CreateProcessW — what node-pty ultimately calls — executes PE
+// images only, so a batch target has no other way in (#798).
+//
+// The command line is then parsed TWICE: by cmd.exe, and by the child's CRT. The two
+// disagree about escaping, and cmd's rules are the ones that decide whether an argument
+// stays an argument: `\"` (the CRT's escape, and what node-pty's own argsToCommandLine
+// emits) does not escape a quote for cmd — it ends the quoted run, after which a `&` in the
+// same argument is a command separator. Hence the rules below, which are cmd's.
+
+/** An argument that cannot be represented on a Windows command line. Thrown rather than
+ *  silently mangled: a truncated argument reaches the agent as a DIFFERENT instruction. */
+export class UnsafeArgumentError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "UnsafeArgumentError";
+  }
+}
+
+// A command line has no encoding for these: CR/LF end it, NUL terminates it.
+const UNREPRESENTABLE = /[\0\r\n]/;
+
+// Counted rather than matched: an anchored `\\+$` backtracks over a long run.
+const trailingBackslashCount = (text: string): number => {
+  const fromEnd = [...text].reverse().findIndex((ch) => ch !== "\\");
+  return fromEnd === -1 ? text.length : fromEnd;
+};
+
+/** One argument, quoted for cmd.exe. Always quoted — inside quotes cmd's metacharacters
+ *  (`& | < > ^ ( )`) are literal, which is the whole defence. Internal quotes are doubled
+ *  (cmd's escape), and a trailing backslash run is doubled so it escapes itself instead of
+ *  the closing quote when the CRT parses the same text afterwards. */
+export function escapeBatchArgument(arg: string): string {
+  if (UNREPRESENTABLE.test(arg)) throw new UnsafeArgumentError(`argument contains a NUL, CR or LF: ${JSON.stringify(arg)}`);
+  const quotesDoubled = arg.replace(/"/g, '""');
+  return `"${quotesDoubled}${"\\".repeat(trailingBackslashCount(quotesDoubled))}"`;
+}
+
+/** Everything after `cmd.exe` for running `batchPath args…`.
+ *
+ *  `/d` skips AutoRun, so a `HKCU\…\Command Processor\AutoRun` command cannot run inside our
+ *  session first. `/s` makes cmd strip exactly the outer quote pair and take the rest
+ *  verbatim, instead of applying its "is the first token a quoted path?" heuristics to a line
+ *  that already contains quoted arguments. */
+export function batchCommandLine(batchPath: string, args: readonly string[]): string {
+  const command = [escapeBatchArgument(batchPath), ...args.map(escapeBatchArgument)].join(" ");
+  return `/d /s /c "${command}"`;
+}

--- a/server/infra/pty-env.ts
+++ b/server/infra/pty-env.ts
@@ -37,13 +37,16 @@ export function isPathVar(name: string): boolean {
   return name.toLowerCase() === "path";
 }
 
-// The search path out of a PLAIN env object. `env.PATH` is only reliable on the live
-// `process.env`, whose Windows lookups are case-insensitive; a copy (what sanitizePtyEnv
-// returns) keeps the original "Path" key and answers undefined to `.PATH`.
-export function pathFromEnv(env: NodeJS.ProcessEnv): string | undefined {
-  const entry = Object.entries(env).find(([name]) => isPathVar(name));
-  return entry?.[1];
+// A variable out of a PLAIN env object, matched the way Windows matches: case-insensitively.
+// `env.PATH` / `env.ComSpec` are only reliable on the live `process.env`, whose Windows
+// lookups are case-insensitive; a copy (what sanitizePtyEnv returns) keeps whatever casing
+// the system used and answers undefined to any other spelling.
+export function envValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const wanted = name.toLowerCase();
+  return Object.entries(env).find(([key]) => key.toLowerCase() === wanted)?.[1];
 }
+
+export const pathFromEnv = (env: NodeJS.ProcessEnv): string | undefined => envValue(env, "PATH");
 
 // yarn v1's temp dir is `yarn--` + a timestamp.
 const YARN_SHIM_DIR = /^yarn--\d/;

--- a/server/infra/resolve-bin.ts
+++ b/server/infra/resolve-bin.ts
@@ -4,27 +4,32 @@
 // compares each PATH directory's file name EXACTLY — it never appends an executable
 // extension. A bare "claude" therefore misses `…\.local\bin\claude.exe` and the spawn dies
 // with `File not found: ` (nothing after the colon, since the path it failed to find is the
-// empty string). Handing it an absolute path skips that lookup entirely.
+// empty string). Handing it an absolute path skips that lookup entirely (#794).
 //
-// The gate is all this has to satisfy: node-pty then launches via
-// `CreateProcessW(nullptr, cmdline, …)`, which does its own PATH search. Which is also why
-// only a PE image may be returned here — CreateProcess cannot run a `.cmd`, a `.bat`, or an
-// extensionless shell shim, so resolving a bare name to one would turn a spawn that works
-// today (the shim satisfies the gate, CreateProcess finds the real .exe elsewhere on PATH)
-// into `Cannot create process`.
+// node-pty then launches via `CreateProcessW(nullptr, cmdline, …)`, which runs PE images
+// only. A batch shim — all an npm-global install leaves on PATH — therefore has to go
+// through `cmd.exe` instead of being named directly (#798), which is why this resolves to a
+// launch descriptor rather than to a path.
 import { statSync } from "node:fs";
 import path from "node:path";
-import { pathFromEnv } from "./pty-env.js";
+import { envValue, pathFromEnv } from "./pty-env.js";
+import { batchCommandLine } from "./cmd-escape.js";
 
 // `.exe` first: with both present, a bare name would have reached the `.exe` (CreateProcess
 // appends exactly that), so resolving must not silently switch which file runs.
 const EXECUTABLE_EXTENSIONS = [".exe", ".com"] as const;
+const BATCH_EXTENSIONS = [".cmd", ".bat"] as const;
 
-const hasExecutableExtension = (bin: string): boolean => EXECUTABLE_EXTENSIONS.some((ext) => bin.toLowerCase().endsWith(ext));
+const endsWithOneOf = (bin: string, extensions: readonly string[]): boolean => extensions.some((ext) => bin.toLowerCase().endsWith(ext));
 
 // A name node-pty/CreateProcess already resolves on its own (absolute, or relative to a
 // directory) rather than by searching PATH.
 const namesAPath = (bin: string): boolean => bin.includes("\\") || bin.includes("/");
+
+// What node-pty is handed. `args` as a STRING is a raw command line that node-pty passes
+// through verbatim (its argsToCommandLine only quotes an argv ARRAY) — which is what lets
+// the cmd.exe wrapping below own its own quoting.
+export type PtyLaunch = { file: string; args: string[] | string };
 
 export function isExecutableFile(candidate: string): boolean {
   try {
@@ -32,17 +37,6 @@ export function isExecutableFile(candidate: string): boolean {
   } catch {
     return false;
   }
-}
-
-/** The absolute path of the executable a bare Windows command name refers to, or null when
- *  PATH holds no `.exe`/`.com` for it (the caller then leaves the name as it is). Pure —
- *  `searchPath` and the existence check are parameters, and `path.win32` + ";" are used
- *  explicitly, so the rule is checkable from a POSIX host too. */
-export function resolveWindowsExecutable(bin: string, searchPath: string | undefined, fileExists: (candidate: string) => boolean): string | null {
-  if (bin === "" || namesAPath(bin)) return null;
-  const names = hasExecutableExtension(bin) ? [bin] : EXECUTABLE_EXTENSIONS.map((ext) => bin + ext);
-  const candidates = searchDirectories(searchPath).flatMap((dir) => names.map((name) => path.win32.join(dir, name)));
-  return candidates.find(fileExists) ?? null; // `find` is lazy: it stops at the first hit
 }
 
 // A PATH entry may be quoted — `"C:\Program Files\tools"` — which the shells strip and a
@@ -53,15 +47,63 @@ const searchDirectories = (searchPath: string | undefined): string[] =>
     .map((entry) => entry.replace(/^"(.*)"$/, "$1"))
     .filter((entry) => entry !== "");
 
-/** The name to hand node-pty for `bin`. Unchanged off Windows, and unchanged when nothing
- *  resolves — a host that spawns fine today must keep spawning fine. */
-export function resolvePtyBin(bin: string, platform: NodeJS.Platform, searchPath: string | undefined, fileExists = isExecutableFile): string {
-  if (platform !== "win32") return bin;
-  return resolveWindowsExecutable(bin, searchPath, fileExists) ?? bin;
+// The first `<dir>\<bin><ext>` that exists, over every PATH directory for one set of
+// extensions. `find` is lazy, so it stops at the first hit.
+function searchPathFor(bin: string, extensions: readonly string[], searchPath: string | undefined, fileExists: (candidate: string) => boolean): string | null {
+  const names = endsWithOneOf(bin, extensions) ? [bin] : extensions.map((ext) => bin + ext);
+  return (
+    searchDirectories(searchPath)
+      .flatMap((dir) => names.map((name) => path.win32.join(dir, name)))
+      .find(fileExists) ?? null
+  );
 }
 
-/** `resolvePtyBin` against the environment the session itself will run with: the binary that
- *  matters is the one reachable from the child's PATH, not the server's. */
-export function resolvePtyBinForEnv(bin: string, env: NodeJS.ProcessEnv): string {
-  return resolvePtyBin(bin, process.platform, pathFromEnv(env));
+/** The absolute path of the executable a bare Windows command name refers to, or null when
+ *  PATH holds no `.exe`/`.com` for it. Pure — `searchPath` and the existence check are
+ *  parameters, and `path.win32` + ";" are used explicitly, so the rule is checkable from a
+ *  POSIX host too. */
+export function resolveWindowsExecutable(bin: string, searchPath: string | undefined, fileExists: (candidate: string) => boolean): string | null {
+  if (bin === "" || namesAPath(bin)) return null;
+  return searchPathFor(bin, EXECUTABLE_EXTENSIONS, searchPath, fileExists);
+}
+
+/** The absolute path of the batch shim a bare command name refers to, or null. Only ever
+ *  consulted after `resolveWindowsExecutable` has come up empty ACROSS THE WHOLE PATH —
+ *  deliberately not cmd.exe's per-directory order. An install whose shim sits in an earlier
+ *  PATH directory than its real `.exe` runs the `.exe` today; moving it onto the cmd.exe
+ *  path would add a parsing layer to a spawn that already works. */
+export function resolveWindowsBatch(bin: string, searchPath: string | undefined, fileExists: (candidate: string) => boolean): string | null {
+  if (bin === "" || namesAPath(bin)) return null;
+  return searchPathFor(bin, BATCH_EXTENSIONS, searchPath, fileExists);
+}
+
+/** How to launch `bin args…`. Off Windows, and whenever nothing resolves, this is the
+ *  arguments unchanged — a host that spawns fine today must keep spawning fine. */
+export function resolvePtyLaunch(
+  bin: string,
+  args: string[],
+  platform: NodeJS.Platform,
+  searchPath: string | undefined,
+  comspec: string | undefined,
+  fileExists = isExecutableFile,
+): PtyLaunch {
+  if (platform !== "win32") return { file: bin, args };
+  const executable = resolveWindowsExecutable(bin, searchPath, fileExists);
+  if (executable) return { file: executable, args };
+  const batch = resolveWindowsBatch(bin, searchPath, fileExists);
+  if (batch) return { file: commandProcessor(comspec, searchPath, fileExists), args: batchCommandLine(batch, args) };
+  return { file: bin, args };
+}
+
+// ComSpec is where Windows itself records the command processor; falling back to a PATH
+// lookup (and then to the bare name) keeps a stripped environment working.
+function commandProcessor(comspec: string | undefined, searchPath: string | undefined, fileExists: (candidate: string) => boolean): string {
+  if (comspec && namesAPath(comspec) && fileExists(comspec)) return comspec;
+  return resolveWindowsExecutable("cmd.exe", searchPath, fileExists) ?? "cmd.exe";
+}
+
+/** `resolvePtyLaunch` against the environment the session itself will run with: the binary
+ *  that matters is the one reachable from the child's PATH, not the server's. */
+export function resolvePtyLaunchForEnv(bin: string, args: string[], env: NodeJS.ProcessEnv): PtyLaunch {
+  return resolvePtyLaunch(bin, args, process.platform, pathFromEnv(env), envValue(env, "ComSpec"));
 }

--- a/server/infra/resolve-bin.ts
+++ b/server/infra/resolve-bin.ts
@@ -88,6 +88,15 @@ export function resolvePtyLaunch(
   fileExists = isExecutableFile,
 ): PtyLaunch {
   if (platform !== "win32") return { file: bin, args };
+  // A name that already names a path needs no PATH search — but CreateProcess still cannot
+  // RUN a batch file, and `CLAUDE_BIN=C:\…\claude.cmd` is exactly what someone reaches for
+  // when working around a broken spawn. Wrapped without an existence check: a relative path
+  // is relative to the PTY's cwd, not this process's, so checking here would ask the wrong
+  // directory — and cmd.exe naming the path it cannot find beats node-pty's empty message.
+  if (namesAPath(bin)) {
+    if (!endsWithOneOf(bin, BATCH_EXTENSIONS)) return { file: bin, args };
+    return { file: commandProcessor(comspec, searchPath, fileExists), args: batchCommandLine(bin, args) };
+  }
   const executable = resolveWindowsExecutable(bin, searchPath, fileExists);
   if (executable) return { file: executable, args };
   const batch = resolveWindowsBatch(bin, searchPath, fileExists);

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -7,7 +7,7 @@ import type { IPty } from "node-pty";
 import path from "node:path";
 import type { WebSocket } from "ws";
 import { sanitizePtyEnv } from "../infra/pty-env.js";
-import { resolvePtyBinForEnv } from "../infra/resolve-bin.js";
+import { resolvePtyLaunchForEnv } from "../infra/resolve-bin.js";
 import { withoutUnset } from "./provider-env.js";
 import { tmuxAvailable, tmuxNewSessionArgs, tmuxScrubEnvNames } from "../infra/tmux.js";
 import {
@@ -34,9 +34,11 @@ const PTY_ROWS = 30;
 // the settings `env` block, which can set a variable but not remove one.
 export function spawnPty(bin: string, args: string[], cwd: string, unset: readonly string[] = []): IPty {
   const env = withoutUnset(sanitizePtyEnv(process.env, path.delimiter), unset);
-  // On Windows a bare name never reaches node-pty as-is: its own PATH lookup ignores
-  // executable extensions, so `claude` misses claude.exe (see infra/resolve-bin.ts, #794).
-  return pty.spawn(resolvePtyBinForEnv(bin, env), args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env });
+  // On Windows neither the name nor the arguments reach node-pty as they are: its PATH
+  // lookup ignores executable extensions (so `claude` misses claude.exe, #794), and a batch
+  // shim has to be run through cmd.exe (#798). See infra/resolve-bin.ts.
+  const launch = resolvePtyLaunchForEnv(bin, args, env);
+  return pty.spawn(launch.file, launch.args, { name: "xterm-256color", cols: PTY_COLS, rows: PTY_ROWS, cwd, env });
 }
 
 // Would this session run in the Docker sandbox? Single-view interactive only (the caller

--- a/test/server/infra/cmd-escape.spec.ts
+++ b/test/server/infra/cmd-escape.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { batchCommandLine, escapeBatchArgument, UnsafeArgumentError } from "../../../server/infra/cmd-escape";
+
+const CLAUDE_CMD = "C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd";
+
+describe("escapeBatchArgument", () => {
+  it("quotes even an argument that needs nothing, so cmd cannot re-split it", () => {
+    expect(escapeBatchArgument("--resume")).toBe('"--resume"');
+  });
+
+  it("keeps whitespace inside one argument", () => {
+    expect(escapeBatchArgument("fix the login bug")).toBe('"fix the login bug"');
+    expect(escapeBatchArgument("a\tb")).toBe('"a\tb"');
+  });
+
+  // The injection this whole module exists to stop: unquoted, cmd would read `&` as a
+  // command separator and run the rest as its own command.
+  it.each(["&", "|", "<", ">", "^", "(", ")", "&&", "||", "&calc"])("neutralises the cmd metacharacter %s by quoting", (meta) => {
+    expect(escapeBatchArgument(`prompt${meta}`)).toBe(`"prompt${meta}"`);
+  });
+
+  // cmd's escape is a doubled quote. The CRT's `\"` — what node-pty's argsToCommandLine
+  // emits — would END the quoted run here, leaving the rest of the argument as cmd input.
+  it("doubles an internal quote rather than backslash-escaping it", () => {
+    expect(escapeBatchArgument('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeBatchArgument('"')).toBe('""""');
+  });
+
+  it("escapes the JSON payloads we actually pass (--settings, --mcp-config)", () => {
+    const json = '{"hooks":{"Stop":[{"command":"curl -s http://127.0.0.1:34567/api/hook"}]}}';
+    expect(escapeBatchArgument(json)).toBe(`"${json.replace(/"/g, '""')}"`);
+  });
+
+  // Without this, the CRT reading the same text sees `\"` — an escaped quote — and swallows
+  // the argument boundary: `C:\dir\` would run on into the next argument.
+  it("doubles a trailing backslash run so it cannot escape the closing quote", () => {
+    expect(escapeBatchArgument("C:\\dir\\")).toBe('"C:\\dir\\\\"');
+    expect(escapeBatchArgument("C:\\dir\\\\")).toBe('"C:\\dir\\\\\\\\"');
+  });
+
+  it("leaves backslashes that are not at the end alone", () => {
+    expect(escapeBatchArgument("C:\\dir\\file.txt")).toBe('"C:\\dir\\file.txt"');
+  });
+
+  it("keeps an empty argument as an argument", () => {
+    expect(escapeBatchArgument("")).toBe('""');
+  });
+
+  it("passes non-ASCII through unchanged", () => {
+    expect(escapeBatchArgument("ログインの不具合")).toBe('"ログインの不具合"');
+  });
+
+  // Known limitation, deliberately not "fixed": cmd expands %VAR% inside double quotes and
+  // `^` cannot prevent it. Rejecting every argument with a percent sign would break ordinary
+  // prompts ("50% done"), and substituting our own child's env into its own argument is a
+  // correctness wart, not a privilege boundary. Recorded so the next reader knows it was a
+  // decision.
+  it("does NOT prevent %VAR% expansion — cmd has no escape for it inside quotes", () => {
+    expect(escapeBatchArgument("%PATH%")).toBe('"%PATH%"');
+  });
+
+  it.each([
+    ["NUL", "a\0b"],
+    ["CR", "a\rb"],
+    ["LF", "a\nb"],
+  ])("rejects an argument containing %s rather than mangling it", (_name, arg) => {
+    expect(() => escapeBatchArgument(arg)).toThrow(UnsafeArgumentError);
+  });
+});
+
+describe("batchCommandLine", () => {
+  it("builds `/d /s /c` with the shim and its arguments inside one outer quote pair", () => {
+    expect(batchCommandLine(CLAUDE_CMD, ["--resume", "abc"])).toBe(`/d /s /c ""${CLAUDE_CMD}" "--resume" "abc""`);
+  });
+
+  it("runs the shim with no arguments at all", () => {
+    expect(batchCommandLine(CLAUDE_CMD, [])).toBe(`/d /s /c ""${CLAUDE_CMD}""`);
+  });
+
+  it("starts with /d, so a registry AutoRun command cannot run inside the session first", () => {
+    expect(batchCommandLine(CLAUDE_CMD, [])).toMatch(/^\/d /);
+  });
+
+  it("propagates the rejection instead of emitting a truncated command line", () => {
+    expect(() => batchCommandLine(CLAUDE_CMD, ["ok", "bad\nline"])).toThrow(UnsafeArgumentError);
+  });
+});

--- a/test/server/infra/resolve-bin.spec.ts
+++ b/test/server/infra/resolve-bin.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveWindowsExecutable, resolvePtyBin } from "../../../server/infra/resolve-bin";
+import { resolveWindowsExecutable, resolveWindowsBatch, resolvePtyLaunch } from "../../../server/infra/resolve-bin";
 
 // A fake Windows filesystem: the exact set of files that exist, matched case-insensitively
 // the way Windows does.
@@ -10,6 +10,8 @@ const filesystem = (...files: string[]) => {
 
 const LOCAL_BIN = "C:\\Users\\u\\.local\\bin";
 const SYSTEM32 = "C:\\Windows\\System32";
+const NPM_BIN = "C:\\Users\\u\\AppData\\Roaming\\npm";
+const COMSPEC = `${SYSTEM32}\\cmd.exe`;
 
 describe("resolveWindowsExecutable", () => {
   it("finds the .exe a bare name refers to (the #794 case: no extensionless shim exists)", () => {
@@ -96,15 +98,64 @@ describe("resolveWindowsExecutable", () => {
   });
 });
 
-describe("resolvePtyBin", () => {
+describe("resolveWindowsBatch", () => {
+  it("finds the .cmd an npm-global install leaves on PATH", () => {
+    const exists = filesystem(`${NPM_BIN}\\claude`, `${NPM_BIN}\\claude.cmd`, `${NPM_BIN}\\claude.ps1`);
+    expect(resolveWindowsBatch("claude", NPM_BIN, exists)).toBe(`${NPM_BIN}\\claude.cmd`);
+  });
+
+  it("finds a .bat too, and prefers .cmd when both are there", () => {
+    expect(resolveWindowsBatch("tool", NPM_BIN, filesystem(`${NPM_BIN}\\tool.bat`))).toBe(`${NPM_BIN}\\tool.bat`);
+    expect(resolveWindowsBatch("tool", NPM_BIN, filesystem(`${NPM_BIN}\\tool.bat`, `${NPM_BIN}\\tool.cmd`))).toBe(`${NPM_BIN}\\tool.cmd`);
+  });
+
+  it("ignores an extensionless shim — cmd.exe cannot run one either", () => {
+    expect(resolveWindowsBatch("claude", NPM_BIN, filesystem(`${NPM_BIN}\\claude`))).toBeNull();
+  });
+});
+
+describe("resolvePtyLaunch", () => {
+  const ARGS = ["--resume", "abc"];
+
   it("is a no-op off Windows even when a candidate would match — node-pty resolves bare names there", () => {
     const everythingExists = () => true;
-    expect(resolvePtyBin("claude", "darwin", "/usr/local/bin", everythingExists)).toBe("claude");
-    expect(resolvePtyBin("claude", "linux", "/usr/local/bin", everythingExists)).toBe("claude");
-    expect(resolvePtyBin("claude", "win32", "C:\\bin", everythingExists)).toBe("C:\\bin\\claude.exe");
+    expect(resolvePtyLaunch("claude", ARGS, "darwin", "/usr/local/bin", undefined, everythingExists)).toEqual({ file: "claude", args: ARGS });
+    expect(resolvePtyLaunch("claude", ARGS, "linux", "/usr/local/bin", undefined, everythingExists)).toEqual({ file: "claude", args: ARGS });
+  });
+
+  it("names the .exe and leaves the arguments as an argv array (#794, unchanged)", () => {
+    const exists = filesystem(`${LOCAL_BIN}\\claude.exe`);
+    expect(resolvePtyLaunch("claude", ARGS, "win32", LOCAL_BIN, COMSPEC, exists)).toEqual({ file: `${LOCAL_BIN}\\claude.exe`, args: ARGS });
+  });
+
+  it("runs a .cmd through cmd.exe as one raw command line", () => {
+    const exists = filesystem(`${NPM_BIN}\\claude.cmd`, COMSPEC);
+    expect(resolvePtyLaunch("claude", ARGS, "win32", NPM_BIN, COMSPEC, exists)).toEqual({
+      file: COMSPEC,
+      args: `/d /s /c ""${NPM_BIN}\\claude.cmd" "--resume" "abc""`,
+    });
+  });
+
+  // The reporter's codex install in #794: an extensionless shim (and a .cmd) in an EARLIER
+  // PATH directory than the codex.exe that actually runs today. cmd.exe's own per-directory
+  // order would move it onto the batch path; a spawn that works must not gain a layer.
+  it("prefers an .exe anywhere on PATH over a .cmd in an earlier directory", () => {
+    const exists = filesystem(`${NPM_BIN}\\codex`, `${NPM_BIN}\\codex.cmd`, `${LOCAL_BIN}\\codex.exe`);
+    expect(resolvePtyLaunch("codex", [], "win32", `${NPM_BIN};${LOCAL_BIN}`, COMSPEC, exists)).toEqual({ file: `${LOCAL_BIN}\\codex.exe`, args: [] });
   });
 
   it("keeps the bare name on Windows when nothing resolves, so a host that works today still works", () => {
-    expect(resolvePtyBin("claude", "win32", "C:\\nowhere")).toBe("claude");
+    expect(resolvePtyLaunch("claude", ARGS, "win32", "C:\\nowhere", COMSPEC, filesystem())).toEqual({ file: "claude", args: ARGS });
+  });
+
+  it("falls back to a PATH lookup for the command processor when ComSpec is unusable", () => {
+    const exists = filesystem(`${NPM_BIN}\\claude.cmd`, `${SYSTEM32}\\cmd.exe`);
+    const launch = resolvePtyLaunch("claude", [], "win32", `${NPM_BIN};${SYSTEM32}`, "C:\\gone\\cmd.exe", exists);
+    expect(launch.file).toBe(`${SYSTEM32}\\cmd.exe`);
+  });
+
+  it("still names cmd.exe when neither ComSpec nor PATH can place it", () => {
+    const launch = resolvePtyLaunch("claude", [], "win32", NPM_BIN, undefined, filesystem(`${NPM_BIN}\\claude.cmd`));
+    expect(launch.file).toBe("cmd.exe");
   });
 });

--- a/test/server/infra/resolve-bin.spec.ts
+++ b/test/server/infra/resolve-bin.spec.ts
@@ -117,10 +117,19 @@ describe("resolveWindowsBatch", () => {
 describe("resolvePtyLaunch", () => {
   const ARGS = ["--resume", "abc"];
 
-  it("is a no-op off Windows even when a candidate would match — node-pty resolves bare names there", () => {
-    const everythingExists = () => true;
-    expect(resolvePtyLaunch("claude", ARGS, "darwin", "/usr/local/bin", undefined, everythingExists)).toEqual({ file: "claude", args: ARGS });
-    expect(resolvePtyLaunch("claude", ARGS, "linux", "/usr/local/bin", undefined, everythingExists)).toEqual({ file: "claude", args: ARGS });
+  // Off Windows this must be inert, not merely equivalent: node-pty resolves bare names
+  // correctly there, so the name goes through untouched, the SAME argv array is handed on,
+  // and the filesystem is never consulted (no probe runs at all).
+  it.each(["darwin", "linux"] as const)("touches nothing on %s — same name, same argv array, no filesystem probe", (platform) => {
+    let probes = 0;
+    const countingProbe = () => {
+      probes++;
+      return true;
+    };
+    const launch = resolvePtyLaunch("claude", ARGS, platform, "/usr/local/bin", "/bin/sh", countingProbe);
+    expect(launch.file).toBe("claude");
+    expect(launch.args).toBe(ARGS);
+    expect(probes).toBe(0);
   });
 
   it("names the .exe and leaves the arguments as an argv array (#794, unchanged)", () => {

--- a/test/server/infra/resolve-bin.spec.ts
+++ b/test/server/infra/resolve-bin.spec.ts
@@ -153,6 +153,27 @@ describe("resolvePtyLaunch", () => {
     expect(resolvePtyLaunch("codex", [], "win32", `${NPM_BIN};${LOCAL_BIN}`, COMSPEC, exists)).toEqual({ file: `${LOCAL_BIN}\\codex.exe`, args: [] });
   });
 
+  // `CLAUDE_BIN=C:\…\claude.cmd` is what someone sets to work around a broken spawn, and it
+  // skips the PATH search entirely — but CreateProcess still cannot run a batch file.
+  it("wraps an explicit .cmd/.bat path, absolute or relative", () => {
+    const explicit = `${NPM_BIN}\\claude.cmd`;
+    expect(resolvePtyLaunch(explicit, ARGS, "win32", NPM_BIN, COMSPEC, filesystem(COMSPEC))).toEqual({
+      file: COMSPEC,
+      args: `/d /s /c ""${explicit}" "--resume" "abc""`,
+    });
+    const relative = ".\\claude.bat";
+    expect(resolvePtyLaunch(relative, [], "win32", NPM_BIN, COMSPEC, filesystem(COMSPEC))).toEqual({
+      file: COMSPEC,
+      args: `/d /s /c ""${relative}""`,
+    });
+  });
+
+  it("leaves an explicit .exe path alone — node-pty and CreateProcess both handle it", () => {
+    const explicit = `${LOCAL_BIN}\\claude.exe`;
+    expect(resolvePtyLaunch(explicit, ARGS, "win32", LOCAL_BIN, COMSPEC, filesystem(explicit))).toEqual({ file: explicit, args: ARGS });
+    expect(resolvePtyLaunch("/bin/bash", ARGS, "win32", LOCAL_BIN, COMSPEC, filesystem())).toEqual({ file: "/bin/bash", args: ARGS });
+  });
+
   it("keeps the bare name on Windows when nothing resolves, so a host that works today still works", () => {
     expect(resolvePtyLaunch("claude", ARGS, "win32", "C:\\nowhere", COMSPEC, filesystem())).toEqual({ file: "claude", args: ARGS });
   });

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -114,6 +114,14 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
     expect(await argvThroughShim(args)).toEqual(args);
   });
 
+  // The CLAUDE_BIN workaround from #794, applied to an npm-global install: an absolute path
+  // skips the PATH search, and a batch file still cannot be handed to CreateProcess.
+  it("runs an explicit absolute .cmd path", async () => {
+    rmSync(argsOut, { force: true });
+    expect(await exitCodeOf(spawnPty(shimCmd, ["--explicit"], dir))).toBe(0);
+    expect(JSON.parse(readFileSync(argsOut, "utf8"))).toEqual(["--explicit"]);
+  });
+
   // Pinned, not fixed: cmd expands %VAR% inside double quotes and has no escape for it. See
   // cmd-escape.ts — rejecting every argument containing a percent sign would break ordinary
   // prompts, and substituting our own child's environment into its own argument is a

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -1,13 +1,14 @@
-// Windows-only: the real node-pty spawn that #794 broke. Skipped everywhere else, so it
-// runs in .github/workflows/windows-daily.yaml (which already runs `yarn test`) rather than
-// in the PR matrix — the rule itself is covered by the pure tests in infra/resolve-bin.spec.
+// Windows-only: the real node-pty spawns that #794 and #798 are about. Skipped everywhere
+// else, so this runs in .github/workflows/windows-daily.yaml (which already runs `yarn test`)
+// rather than in the PR matrix — the rules themselves are covered by the pure tests in
+// infra/resolve-bin.spec and infra/cmd-escape.spec.
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import pty from "node-pty";
 import { spawnPty } from "../../../server/session/pty-spawn";
-import { resolvePtyBinForEnv } from "../../../server/infra/resolve-bin";
+import { resolvePtyLaunchForEnv } from "../../../server/infra/resolve-bin";
 
 const isWindows = process.platform === "win32";
 
@@ -15,27 +16,55 @@ const isWindows = process.platform === "win32";
 // Code install from the official Windows installer. node.exe stands in for it: it is
 // guaranteed present and answers `-e`.
 const PROBE = `mt-probe-${process.pid}`;
+// A command that exists ONLY as a .cmd — what an npm-global install leaves on PATH.
+const SHIM = `mt-shim-${process.pid}`;
+
+const exitCodeOf = (term: pty.IPty): Promise<number> => new Promise((resolve) => term.onExit(({ exitCode }) => resolve(exitCode)));
 
 describe.skipIf(!isWindows)("spawnPty on Windows", () => {
   let dir = "";
   let probeExe = "";
+  let shimCmd = "";
+  let argsOut = "";
   let originalPath: string | undefined;
 
   beforeAll(() => {
     dir = mkdtempSync(path.join(tmpdir(), "mt-probe-"));
     probeExe = path.join(dir, `${PROBE}.exe`);
     copyFileSync(process.execPath, probeExe);
+
+    // The argv the shim's child actually received, recorded to a file rather than stdout: a
+    // conpty wraps and escapes what it prints, which would corrupt the comparison.
+    argsOut = path.join(dir, "args.json");
+    const echoJs = path.join(dir, "echo-args.js");
+    writeFileSync(echoJs, `require("node:fs").writeFileSync(process.env.MT_ARGS_OUT, JSON.stringify(process.argv.slice(2)));\n`);
+    // Shaped like npm's generated shim: forward %* to a node script. CRLF, as batch files are.
+    shimCmd = path.join(dir, `${SHIM}.cmd`);
+    writeFileSync(shimCmd, ["@ECHO off", `"${probeExe}" "${echoJs}" %*`, ""].join("\r\n"));
+
     originalPath = process.env.PATH;
     process.env.PATH = `${dir};${process.env.PATH ?? ""}`;
+    process.env.MT_ARGS_OUT = argsOut;
+    process.env.MT_MARKER = "expanded-by-cmd";
   });
 
   afterAll(() => {
     process.env.PATH = originalPath;
+    delete process.env.MT_ARGS_OUT;
+    delete process.env.MT_MARKER;
     rmSync(dir, { recursive: true, force: true });
   });
 
+  // Run the .cmd shim through spawnPty and return the argv its child received.
+  async function argvThroughShim(args: string[]): Promise<string[]> {
+    rmSync(argsOut, { force: true });
+    const term = spawnPty(SHIM, args, dir);
+    expect(await exitCodeOf(term)).toBe(0);
+    return JSON.parse(readFileSync(argsOut, "utf8"));
+  }
+
   it("resolves a bare name to the .exe on PATH", () => {
-    expect(resolvePtyBinForEnv(PROBE, process.env)).toBe(probeExe);
+    expect(resolvePtyLaunchForEnv(PROBE, [], process.env)).toEqual({ file: probeExe, args: [] });
   });
 
   it("spawns a PTY for a bare name whose only match is an .exe", async () => {
@@ -45,8 +74,7 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
     term.onData((data) => {
       output += data;
     });
-    const exitCode = await new Promise<number>((resolve) => term.onExit(({ exitCode }) => resolve(exitCode)));
-    expect(exitCode).toBe(0);
+    expect(await exitCodeOf(term)).toBe(0);
     expect(output).toContain("mt-probe ok");
   });
 
@@ -63,5 +91,42 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
     }
     term.kill();
     expect.fail("node-pty resolved a bare name on its own — re-check whether infra/resolve-bin.ts is still needed");
+  });
+
+  it("resolves a .cmd-only command to cmd.exe with a raw command line", () => {
+    const launch = resolvePtyLaunchForEnv(SHIM, ["--resume"], process.env);
+    expect(launch.file.toLowerCase()).toContain("cmd.exe");
+    expect(launch.args).toBe(`/d /s /c ""${shimCmd}" "--resume""`);
+  });
+
+  // Everything below is the empirical half of #798: the escaping is only correct if the
+  // argv on the far side of cmd.exe AND the shim's own `%*` forwarding is what we passed.
+  it.each([
+    ["plain arguments", ["--resume", "abc123"]],
+    ["whitespace inside one argument", ["fix the login bug"]],
+    ["cmd metacharacters that would otherwise split the command", ["a&b", "c|d", "e>f", "g^h", "(i)"]],
+    ["embedded quotes", ['say "hi"']],
+    ["a JSON payload, the shape of --settings / --mcp-config", ['{"hooks":{"Stop":[{"command":"curl -s http://127.0.0.1:34567/api/hook"}]}}']],
+    ["a path ending in a backslash", ["C:\\Users\\u\\projects\\"]],
+    ["non-ASCII", ["ログインの不具合", "修正して"]],
+    ["a percent sign with no variable behind it", ["50% done"]],
+  ])("round-trips %s through the .cmd shim", async (_case, args) => {
+    expect(await argvThroughShim(args)).toEqual(args);
+  });
+
+  // Pinned, not fixed: cmd expands %VAR% inside double quotes and has no escape for it. See
+  // cmd-escape.ts — rejecting every argument containing a percent sign would break ordinary
+  // prompts, and substituting our own child's environment into its own argument is a
+  // correctness wart rather than a privilege boundary.
+  it("expands %VAR% inside an argument — the known limitation of the cmd.exe path", async () => {
+    expect(await argvThroughShim(["%MT_MARKER%"])).toEqual(["expanded-by-cmd"]);
+  });
+
+  // cmd.exe is an extra process between us and the shim, so a non-zero exit has one more
+  // layer to survive than it did before #798.
+  it("propagates a failing shim's exit code through the cmd.exe layer", async () => {
+    const failing = `mt-fail-${process.pid}`;
+    writeFileSync(path.join(dir, `${failing}.cmd`), ["@ECHO off", "exit /b 3", ""].join("\r\n"));
+    expect(await exitCodeOf(spawnPty(failing, [], dir))).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

#794 / #799 で bare 名を `.exe` の絶対パスに解決するようにしたが、**npm グローバル導入（`claude.cmd` のみで `.exe` が無い形）はまだ起動できなかった**。その残件（#798）の対応。

`CreateProcessW`（node-pty が最終的に呼ぶ）は **PE イメージしか実行できない**ため、npm 版は2通りに壊れる:

| PATH の中身 | node-pty のゲート | `CreateProcessW` | ログ |
| --- | --- | --- | --- |
| `claude.cmd` のみ | 通らない（完全一致検索） | 到達しない | `File not found: `（空文字） |
| `claude`（sh シム）+ `claude.cmd` | シムで通る | `claude.exe` を探して失敗 | `Cannot create process` |

解決結果を「パス」から**起動記述子 `{ file, args }`** に変え、バッチが対象のときは `cmd.exe` を `file` に、`/d /s /c "…"` を**生のコマンドライン文字列**として `args` に渡す（node-pty は args が文字列なら `argsToCommandLine` を通さず**そのまま**使うので、クォートをこちら側で完全に握れる）。#799 で解決処理を `spawnPty()` 1 箇所に集約済みのため、claude / codex / tmux / launcher が同時に対応される。

## Items to Confirm / Review

- **`.exe` は PATH 全体で優先し、`.cmd` はその後**（cmd.exe 本来のディレクトリ単位の順序では**ない**）。#794 の報告者の codex 環境は「先頭ディレクトリに拡張子なしシム＋`.cmd`、後ろのディレクトリに `codex.exe`」で、per-dir 順にすると**今 `.exe` で直接動いているものが cmd.exe 経由に移ってしまう**。動いている spawn に層を足さないことを優先した（`resolve-bin.ts` の docstring とテストに理由を記載）。
- **エスケープは cmd の規則であって CRT の規則ではない**（`server/infra/cmd-escape.ts`）。`\"` は cmd にとってクォートのエスケープではなく**クォート区間の終了**で、そこから先の `&` はコマンド区切りになる。よって「常にダブルクォートで囲む／内部の `"` は `""` に倍化／末尾のバックスラッシュ連続を倍化／NUL・CR・LF は例外で拒否」。
- **`%VAR%` は展開されたまま**。cmd はダブルクォート内の `%` をエスケープする手段を持たない。`%` を含む引数を全部拒否する案は捨てた（"50% done" のような**普通のプロンプトが通らなくなる**うえ、自分の子プロセスの引数に自分の環境変数が入るのは権限境界の問題ではなく正しさの傷）。テストとして**ピン留め**してある。Rust は CVE-2024-24576 で同じ壁に当たり、Node は CVE-2024-27980 で「`shell: true` 無しの `.cmd` spawn を拒否する」方に倒した経緯も docstring に記録。
- **エスケープは机上ではなく実測で確認している**: Windows ジョブが npm と同じ形のシム（`node "…cli.js" %*`）を生成し、**子プロセスの `process.argv` が渡した引数と一致するか**を往復で検証する。JSON ペイロード（実際の `--settings` / `--mcp-config` の形）、`& | > ^ ( )`、埋め込みクォート、末尾バックスラッシュ、CJK、`50% done` を含む。
- `exit /b 3` のシムで**終了コードが cmd.exe の層を越えて伝播する**ことも確認している。

## User Prompt

> 798を！
>
> （#794 対応時の議論より）cmd/batも、必要だったら別途issueかしておいてね。／Mをやるけど、いったんissueで。

## テスト

- `test/server/infra/cmd-escape.spec.ts`（新規・全 OS、26 ケース）— メタ文字、埋め込みクォート、JSON、末尾バックスラッシュ、空文字、CJK、`%VAR%` の既知の限界、NUL/CR/LF の拒否。
- `test/server/infra/resolve-bin.spec.ts` — `.cmd`/`.bat` 解決、`.exe` 優先、起動記述子の形、ComSpec のフォールバック。#794 の既存ケースは無変更で通っている。
- `test/server/session/pty-spawn-win.spec.ts`（Windows のみ）— 上記の往復検証＋終了コード伝播。
- 実装を壊すとテストが落ちることを 3 パターンで確認（クォート倍化を外す / 末尾バックスラッシュ倍化を外す / `.exe` と `.cmd` の優先順を入れ替える）。
- `yarn format` / `lint` / `build` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（3848 passed）/ `knip` 実行済み。
- Windows 実機ジョブをこのブランチで実行中: `gh workflow run windows-daily.yaml --ref fix/798-windows-cmd-wrapper`
  ※ `windows-daily` には **main 由来の既存の赤**（`header-context.spec.ts > worktreeTask` ×2、`dev-server.spec.ts` ×1）があるため、ジョブ全体は赤になる。見るべきは `pty-spawn-win.spec.ts` / `cmd-escape.spec.ts` / `resolve-bin.spec.ts` の結果。

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)
