### PR TITLE
WIP: feat(remote-host): スマホから生キーを送れるようにする（選択メニュー操作） (#781)

### DIFF
--- a/plans/feat-781-remote-host-keys.md
+++ b/plans/feat-781-remote-host-keys.md
@@ -1,0 +1,85 @@
+# feat(remote-host): スマホから生キーを送れるようにする (#781)
+
+Claude は質問を**選択メニュー**で出すことが多い（`/model`、自前の選択肢、権限プロンプト）。
+メニューは**キー押下**に答えるが、スマホからのライブ入力 `sendTerminalInput` は
+
+1. `sanitizeTerminalInput` で制御バイトを全除去（＝矢印のエスケープ列は通らない）
+2. bracketed paste で包む（＝貼り付けた数字はキー押下として届かない）
+
+ので、出先でメニューが出ると作業が止まる。
+
+サニタイズは**緩めない**。スマホから来る文字列は untrusted で、あれは `\e[201~` や Ctrl-C の
+混入を防いでいる。代わりに**キー名の allow-list を取る別コマンド**を足す。バイト列を持つのは
+ホスト側なので、信頼境界は今のまま（任意の制御バイトは PTY に届かない）。
+
+バイト列そのものは実証済み: ブラウザのターミナルは `pty-connection.ts` で同じ
+`term.write` に生キーを流していて、矢印も Esc もそこで動いている。
+
+## 変更
+
+### 1. `server/backends/remoteHost/terminalKeys.ts`（新規・純粋関数）
+
+キー名 → バイト列のテーブルと、ワイヤ param の検証。PTY なしでテストできる。
+
+| キー名 | バイト列 |
+| --- | --- |
+| `up` / `down` / `right` / `left` | `\e[A` / `\e[B` / `\e[C` / `\e[D` |
+| `enter` | `\r` |
+| `escape` | `\e` |
+| `tab` / `shift-tab` | `\t` / `\e[Z` |
+| `backspace` / `space` | `\x7f` / `` ` ` `` |
+| `0`〜`9` | その文字 |
+
+- **破壊的なキーは入れない**。Ctrl-C は turn 中なら turn を中断し、shell なら実行中プロセスを
+  殺す。スマホの誤タップのコストが高すぎるので、必要になったら別途 issue で。
+- **`enter` は `\r` 固定**で、`terminalSubmit`（#772）の submit binding を**通さない**。あれは
+  Claude の**プロンプト入力欄**の binding で、メニューの確定は CR。打った行を確定するのは
+  `sendTerminalInput` の仕事で、そちらは今も binding をセッション単位で解決する。
+- 名前の照合は `hasOwnProperty`。`in` だとプロトタイプ鎖の `constructor` / `toString` が
+  「既知のキー名」として通ってしまう。
+
+### 2. `server/backends/remoteHost/sessionChain.ts`（`terminalInput.ts` から抽出）
+
+「セッションごとに直列、セッション間は独立」という並行制御だけを持つ。抽出の理由は
+**2 つの sender が同じチェーンを共有しないといけない**から: キー送信が
+`[paste]` と 150ms 後の `[CR]` の**間に**割り込むと、矢印が下書き中のカーソル移動として
+効いてしまう。
+
+### 3. `server/backends/remoteHost/terminalInput.ts`
+
+`createTerminalInputSender` → `createTerminalSender` に改名し、`{ sendText, sendKeys }` を返す。
+チェーンは 1 つ。テキスト経路（sanitize → clear+paste → 遅延 Enter）は**変更なし**。
+
+`sendKeys` は sanitize / paste / Ctrl-C クリア / 末尾 submit を**一切通さない**:
+
+- **1 キー 1 write**、キーの間だけ間隔を空ける。理由は paste の Enter を遅らせるのと同じで、
+  ハイライト移動で再描画中の TUI は同じ tick に来たキーを落とし得る。
+  （tmux 側は `escape-time 0`（`server/infra/tmux.ts`）なので、単独の `escape` は
+  シーケンス待ちで溜められず即転送される。）
+- 途中の write が失敗したら**そこで throw**。テキスト経路の Enter は「paste はもう見えている」
+  ので best-effort だが、キー列は何個目まで届いたかがスマホから見えないので黙って諦めない。
+- 1 コマンドあたり最大 16 キー。セッションのチェーンを 1 コマンドが長時間占有しないため。
+
+### 4. `server/backends/remoteHost/handlers.ts`
+
+`sendTerminalKeys({ sessionId, keys: string[] })` を追加。deps は増えない（`writeToSession` は
+既にある）ので `server/index.ts` と `remoteHost/index.ts` は無変更。capability は
+`buildHostPresence` が handler のキーから導出するので**プロトコル変更なし**。
+
+## テスト
+
+- `terminalKeys.spec.ts`: 各キーのバイト列、未知の名前 / 非配列 / 空配列 / 上限超え、
+  プロトタイプ鎖（`constructor` / `__proto__` / `toString`）、`enter` が `\r` であること
+  （#772 の binding を通さない意図の固定）。
+- `sessionChain.spec.ts`: 同一セッションは直列、別セッションは並行、reject 後もチェーンが
+  生きている、最後の 1 つが消える（溜まらない）。
+- `terminalInput.spec.ts`: 既存はそのまま（改名のみ）＋ `sendKeys` の write 内容 / 間隔 /
+  paste 経路と混ざらない / clear も submit も付かない / PTY 無しの報告。
+- `handlers.spec.ts`: handler 一覧に追加、キー列が `writeToSession` まで届く、
+  `sessionId` 欠落と不正なキーの拒否。
+
+## スマホ側（別 PR: receptron/mulmoserver）
+
+キー行（↑↓←→ / Enter / Esc / Tab）と、既にある番号チップ（`useTerminalChips.ts` — 今は
+入力欄に数字を入れるだけ）を「数字キーを押す」に変える。capability に `sendTerminalKeys` が
+無いホスト（旧版）では従来どおり入力欄に入れる。

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -67,6 +67,10 @@ describe("createRemoteHostHandlers", () => {
       "google.calendar.listEvents",
       "google.calendar.listCalendars",
       "google.calendar.colors",
+      "listTerminalSessions",
+      "getTerminalScreen",
+      "sendTerminalInput",
+      "sendTerminalKeys",
     ]) {
       expect(typeof handlers[name]).toBe("function");
     }
@@ -242,5 +246,47 @@ describe("getTerminalScreen", () => {
 
   it("rejects a request with no session id", async () => {
     await expect(handlersFor({ screen: "", suggestion: "" }).getTerminalScreen({})).rejects.toThrow(/sessionId is required/);
+  });
+});
+
+// #781: the phone answers a select menu by naming KEYS. The mapping and the allow-list are
+// terminalKeys.ts's; what this covers is that the wire params reach it and that the bytes
+// reach the PTY.
+describe("sendTerminalKeys", () => {
+  const handlersFor = (writeToSession: (sessionId: string, chunk: string) => boolean) =>
+    createRemoteHostHandlers({
+      workspace: "/nowhere",
+      spawnChat: () => ({ chatId: "x" }),
+      ingest: async () => ({ attachments: [], cleanupStaging: async () => {} }),
+      ...unusedTerminalDeps,
+      writeToSession,
+    });
+
+  it("writes the named keys' bytes to the session", async () => {
+    const writes: Array<[string, string]> = [];
+    const handlers = handlersFor((sessionId, chunk) => {
+      writes.push([sessionId, chunk]);
+      return true;
+    });
+    expect(await handlers.sendTerminalKeys({ sessionId: "a", keys: ["2"] })).toEqual({ sent: true });
+    expect(writes).toEqual([["a", "2"]]);
+  });
+
+  it("rejects a request with no session id", async () => {
+    await expect(handlersFor(() => true).sendTerminalKeys({ keys: ["down"] })).rejects.toThrow(/sessionId is required/);
+  });
+
+  it("rejects a key it does not know, without writing anything", async () => {
+    const writes: string[] = [];
+    const handlers = handlersFor((_sessionId, chunk) => {
+      writes.push(chunk);
+      return true;
+    });
+    await expect(handlers.sendTerminalKeys({ sessionId: "a", keys: ["ctrl-c"] })).rejects.toThrow(/unknown key/);
+    expect(writes).toEqual([]);
+  });
+
+  it("rejects a missing keys param", async () => {
+    await expect(handlersFor(() => true).sendTerminalKeys({ sessionId: "a" })).rejects.toThrow(/keys must be an array/);
   });
 });

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -27,7 +27,8 @@ import {
 } from "../remoteView.js";
 import { mutateWriteApplied } from "../mutateStatus.js";
 import type { Attachment, IngestResult } from "./ingestAttachments.js";
-import { createTerminalInputSender } from "./terminalInput.js";
+import { createTerminalSender } from "./terminalInput.js";
+import { parseTerminalKeys } from "./terminalKeys.js";
 import type { SessionScreen, TerminalSessionSummary } from "./terminalScreen.js";
 import { feedSummary } from "../feed-summary.js";
 
@@ -162,7 +163,12 @@ const terminalScreenHandlers = ({
   submitSequence,
 }: TerminalScreenDeps): CommandHandlers => {
   // One sender per host, so its per-session ordering actually spans every command.
-  const sendInput = createTerminalInputSender({ writeToSession, canClearBox, submitSequence });
+  const { sendText, sendKeys } = createTerminalSender({ writeToSession, canClearBox, submitSequence });
+  const requireSessionId = (params: JsonObject): string => {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
+    if (!sessionId) throw new Error("sessionId is required");
+    return sessionId;
+  };
   return {
     listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
 
@@ -171,20 +177,24 @@ const terminalScreenHandlers = ({
     // session's cwd / branch / summary / prompt when the host knows them, so the phone can
     // head the terminal with what the grid cell shows (#786); the whole SessionScreen is
     // the wire shape, so a field added there reaches the phone without another edit here.
-    getTerminalScreen: async (params: JsonObject) => {
-      const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
-      if (!sessionId) throw new Error("sessionId is required");
-      return (await captureTerminalScreen(sessionId)) as unknown as JsonObject;
-    },
+    getTerminalScreen: async (params: JsonObject) => (await captureTerminalScreen(requireSessionId(params))) as unknown as JsonObject,
 
     // Type a line into the session and press Enter, as if the user were at the
     // keyboard. The phone sends only text; the framing, sanitizing and Enter timing
     // are terminalInput.ts's job.
     sendTerminalInput: async (params: JsonObject) => {
-      const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
-      if (!sessionId) throw new Error("sessionId is required");
+      const sessionId = requireSessionId(params);
       const text = typeof params.text === "string" ? params.text : "";
-      return (await sendInput(sessionId, text)) as unknown as JsonObject;
+      return (await sendText(sessionId, text)) as unknown as JsonObject;
+    },
+
+    // Press keys in the session (#781), which is how its select menus are answered —
+    // /model, a multiple-choice question, a permission prompt. The phone sends NAMES
+    // (["down", "enter"]); the bytes are the host's, from terminalKeys.ts's allow-list, so
+    // this cannot become a way to write arbitrary control input to the terminal.
+    sendTerminalKeys: async (params: JsonObject) => {
+      const sessionId = requireSessionId(params);
+      return (await sendKeys(sessionId, parseTerminalKeys(params.keys))) as unknown as JsonObject;
     },
   };
 };

--- a/server/backends/remoteHost/sessionChain.spec.ts
+++ b/server/backends/remoteHost/sessionChain.spec.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { createSessionChain } from "./sessionChain.js";
+
+const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+// A task that only finishes when the test says so, recording when it started.
+const gate = (log: string[], name: string) => {
+  let release: () => void = () => undefined;
+  const task = () => {
+    log.push(`start ${name}`);
+    return new Promise<string>((resolve) => {
+      release = () => {
+        log.push(`end ${name}`);
+        resolve(name);
+      };
+    });
+  };
+  return { task, release: () => release() };
+};
+
+describe("createSessionChain", () => {
+  it("runs one task at a time per session", async () => {
+    const inOrder = createSessionChain();
+    const log: string[] = [];
+    const first = gate(log, "first");
+    const second = gate(log, "second");
+    const a = inOrder("s1", first.task);
+    const b = inOrder("s1", second.task);
+    await tick();
+    // The second must not have started while the first is unfinished.
+    expect(log).toEqual(["start first"]);
+    first.release();
+    await a;
+    await tick();
+    expect(log).toEqual(["start first", "end first", "start second"]);
+    second.release();
+    await expect(b).resolves.toBe("second");
+  });
+
+  it("does not make one session wait on another", async () => {
+    const inOrder = createSessionChain();
+    const log: string[] = [];
+    const one = gate(log, "one");
+    const two = gate(log, "two");
+    const a = inOrder("s1", one.task);
+    const b = inOrder("s2", two.task);
+    await tick();
+    expect(log).toEqual(["start one", "start two"]);
+    one.release();
+    two.release();
+    await expect(Promise.all([a, b])).resolves.toEqual(["one", "two"]);
+  });
+
+  it("hands the task's result and error to the caller", async () => {
+    const inOrder = createSessionChain();
+    await expect(inOrder("s1", async () => 42)).resolves.toBe(42);
+    await expect(inOrder("s1", async () => Promise.reject(new Error("nope")))).rejects.toThrow(/nope/);
+  });
+
+  // A rejected task must not wedge the session for every later one.
+  it("keeps the chain alive after a failure", async () => {
+    const inOrder = createSessionChain();
+    await expect(inOrder("s1", async () => Promise.reject(new Error("boom")))).rejects.toThrow(/boom/);
+    await expect(inOrder("s1", async () => "after")).resolves.toBe("after");
+  });
+
+  // The rejection is delivered to the caller and swallowed inside the chain; nothing must
+  // reach process-level unhandledRejection.
+  it("does not leave an unhandled rejection behind", async () => {
+    const inOrder = createSessionChain();
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await expect(inOrder("s1", async () => Promise.reject(new Error("boom")))).rejects.toThrow(/boom/);
+      await tick();
+      await tick();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+    expect(unhandled).toEqual([]);
+  });
+
+  // Sessions come and go by the hundred over a host's uptime, so the map must not keep an
+  // entry per session id it has ever seen.
+  it("forgets a session once its last task is done", async () => {
+    const chains = new Map<string, Promise<void>>();
+    const inOrder = createSessionChain(chains);
+    await inOrder("s1", async () => "done");
+    await tick();
+    expect(chains.size).toBe(0);
+  });
+
+  it("keeps the entry while a task is still queued behind another", async () => {
+    const chains = new Map<string, Promise<void>>();
+    const inOrder = createSessionChain(chains);
+    const log: string[] = [];
+    const first = gate(log, "first");
+    const a = inOrder("s1", first.task);
+    const b = inOrder("s1", async () => "second");
+    await tick();
+    expect(chains.size).toBe(1);
+    first.release();
+    await Promise.all([a, b]);
+    await tick();
+    expect(chains.size).toBe(0);
+  });
+
+  it("forgets a failed session too", async () => {
+    const chains = new Map<string, Promise<void>>();
+    const inOrder = createSessionChain(chains);
+    await expect(inOrder("s1", async () => Promise.reject(new Error("boom")))).rejects.toThrow(/boom/);
+    await tick();
+    expect(chains.size).toBe(0);
+  });
+});

--- a/server/backends/remoteHost/sessionChain.ts
+++ b/server/backends/remoteHost/sessionChain.ts
@@ -1,0 +1,32 @@
+// "One at a time per session, never across sessions" — the only thing the phone's two
+// write paths (typing a line, pressing a key) need from each other.
+//
+// Both paths are multi-write: typing is a paste plus a separate Enter a beat later, and a
+// key send is one write per key. Interleaved, the writes of one land INSIDE the other — a
+// second paste before the first Enter submits the two merged, and an arrow between a paste
+// and its Enter moves the cursor through the draft instead of a menu. So the two share ONE
+// chain, and a send waits for the previous send on that session to finish.
+
+// `chains` is a parameter only so a test can see that entries do not accumulate: a host
+// runs for weeks and sees hundreds of session ids, and a leak here is invisible from the
+// outside — a stale resolved link behaves exactly like no link at all.
+export const createSessionChain = (chains: Map<string, Promise<void>> = new Map()) => {
+  return <T>(sessionId: string, task: () => Promise<T>): Promise<T> => {
+    // A failed task must not poison the chain for the next one, so the stored link
+    // swallows the error; the caller still sees it through `run`.
+    const previous = chains.get(sessionId) ?? Promise.resolve();
+    const run = previous.then(task);
+    const link = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    chains.set(sessionId, link);
+    // Drop the entry once it is the last one, so sessions don't accumulate forever.
+    link.then(() => {
+      if (chains.get(sessionId) === link) {
+        chains.delete(sessionId);
+      }
+    });
+    return run;
+  };
+};

--- a/server/backends/remoteHost/terminalInput.spec.ts
+++ b/server/backends/remoteHost/terminalInput.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
-import { CLEAR_BOX, PASTE_END, PASTE_START, canClearInputBox, createTerminalInputSender, sanitizeTerminalInput } from "./terminalInput.js";
+import { CLEAR_BOX, PASTE_END, PASTE_START, canClearInputBox, createTerminalSender, sanitizeTerminalInput } from "./terminalInput.js";
 
 // Collects what would have reached the PTY, and runs the delayed Enter on demand
 // so the tests never wait on real time.
@@ -16,6 +16,7 @@ const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve)
 const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean) => {
   const chunks: string[] = [];
   const submits: Array<() => void> = [];
+  const presses: Array<() => void> = [];
   const deps = {
     writeToSession: (_sessionId: string, chunk: string) => {
       if (!writable) return false;
@@ -27,8 +28,21 @@ const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean)
     scheduleSubmit: (fn: () => void) => {
       submits.push(fn);
     },
+    // Same for the gap between two keys of one send.
+    scheduleKey: (fn: () => void) => {
+      presses.push(fn);
+    },
   };
-  return { chunks, submits, flushSubmit: () => submits.shift()?.(), send: createTerminalInputSender(deps) };
+  const { sendText, sendKeys } = createTerminalSender(deps);
+  return {
+    chunks,
+    submits,
+    presses,
+    flushSubmit: () => submits.shift()?.(),
+    flushKey: () => presses.shift()?.(),
+    send: sendText,
+    sendKeys,
+  };
 };
 
 describe("sanitizeTerminalInput", () => {
@@ -83,7 +97,7 @@ describe("sendTerminalInput", () => {
     const chunks: string[] = [];
     const submits: Array<() => void> = [];
     const seen: string[] = [];
-    const send = createTerminalInputSender({
+    const { sendText: send } = createTerminalSender({
       writeToSession: (_id: string, chunk: string) => {
         chunks.push(chunk);
         return true;
@@ -147,7 +161,7 @@ describe("sendTerminalInput", () => {
     let submit: (() => void) | null = null;
     let alive = true;
     let writes = 0;
-    const send = createTerminalInputSender({
+    const { sendText: send } = createTerminalSender({
       writeToSession: () => {
         writes += 1;
         return alive;
@@ -206,6 +220,105 @@ describe("sendTerminalInput", () => {
     flushSubmit();
     await expect(after).resolves.toEqual({ sent: true });
     expect(chunks).toEqual([`${PASTE_START}ls${PASTE_END}`, "\r"]);
+  });
+});
+
+// #781: answering a select menu means pressing keys, so this path shares nothing with the
+// typing path above — what it must NOT do is as much the point as what it does.
+describe("sendTerminalKeys", () => {
+  it("writes one key immediately", async () => {
+    const { chunks, sendKeys } = recorder();
+    await expect(sendKeys("s1", ["3"])).resolves.toEqual({ sent: true });
+    expect(chunks).toEqual(["3"]);
+  });
+
+  // No bracketed paste (a menu ignores pasted text), no Ctrl-C clear (the box is not being
+  // typed into), no trailing submit (the caller says `enter` if it wants one).
+  it("adds no paste framing, no box clear and no submit of its own", async () => {
+    const { chunks, submits, sendKeys } = recorder(true, () => true);
+    await sendKeys("s1", ["down"]);
+    expect(chunks).toEqual(["\x1b[B"]);
+    expect(submits).toEqual([]);
+  });
+
+  it("writes each key as its own write, spaced apart", async () => {
+    const { chunks, sendKeys, flushKey } = recorder();
+    const sent = sendKeys("s1", ["down", "down", "enter"]);
+    await tick();
+    // The first key goes out at once; the rest wait on the gap, so a TUI re-rendering after
+    // a highlight move is not handed the next key in the same tick.
+    expect(chunks).toEqual(["\x1b[B"]);
+    flushKey();
+    await tick();
+    expect(chunks).toEqual(["\x1b[B", "\x1b[B"]);
+    flushKey();
+    await expect(sent).resolves.toEqual({ sent: true });
+    expect(chunks).toEqual(["\x1b[B", "\x1b[B", "\r"]);
+  });
+
+  it("reports a session with no live terminal", async () => {
+    const { sendKeys } = recorder(false);
+    await expect(sendKeys("ghost", ["down"])).rejects.toThrow(/no live terminal/);
+  });
+
+  // Unlike the paste's Enter, a key list is invisible to the phone as it goes, so a session
+  // that dies mid-list is reported rather than passed off as sent.
+  it("stops and reports when the session dies mid-list", async () => {
+    let alive = true;
+    const chunks: string[] = [];
+    const presses: Array<() => void> = [];
+    const { sendKeys } = createTerminalSender({
+      writeToSession: (_id: string, chunk: string) => {
+        if (!alive) return false;
+        chunks.push(chunk);
+        return true;
+      },
+      scheduleKey: (fn: () => void) => {
+        presses.push(fn);
+      },
+    });
+    const sent = sendKeys("s1", ["down", "down", "enter"]);
+    await tick();
+    alive = false;
+    presses.shift()?.();
+    await expect(sent).rejects.toThrow(/no live terminal/);
+    // The third key was never attempted.
+    expect(chunks).toEqual(["\x1b[B"]);
+    expect(presses).toEqual([]);
+  });
+
+  // The two paths write to one terminal. A key landing between a paste and its Enter would
+  // move the cursor through the draft instead of a menu, so they share the session's chain.
+  it("waits for a typed line's Enter before pressing a key", async () => {
+    const { chunks, flushSubmit, send, sendKeys } = recorder();
+    const typed = send("s1", "hello");
+    const pressed = sendKeys("s1", ["down"]);
+    await tick();
+    expect(chunks).toEqual([`${PASTE_START}hello${PASTE_END}`]);
+    flushSubmit();
+    await typed;
+    await expect(pressed).resolves.toEqual({ sent: true });
+    expect(chunks).toEqual([`${PASTE_START}hello${PASTE_END}`, "\r", "\x1b[B"]);
+  });
+
+  it("makes a typed line wait for a key send in flight", async () => {
+    const { chunks, flushSubmit, flushKey, send, sendKeys } = recorder();
+    const pressed = sendKeys("s1", ["down", "enter"]);
+    const typed = send("s1", "hello");
+    await tick();
+    expect(chunks).toEqual(["\x1b[B"]);
+    flushKey();
+    await pressed;
+    await tick();
+    expect(chunks).toEqual(["\x1b[B", "\r", `${PASTE_START}hello${PASTE_END}`]);
+    flushSubmit();
+    await expect(typed).resolves.toEqual({ sent: true });
+  });
+
+  it("does not make one session wait on another", async () => {
+    const { chunks, sendKeys } = recorder();
+    await Promise.all([sendKeys("s1", ["up"]), sendKeys("s2", ["down"])]);
+    expect(chunks).toEqual(["\x1b[A", "\x1b[B"]);
   });
 });
 

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -1,9 +1,9 @@
-// Typing into a live session from the phone (#445). The wire side is one string;
-// everything that makes it land correctly in a TUI lives here so it can be tested
-// without a PTY.
+// Writing into a live session from the phone: typing a line (#445) and pressing a key
+// (#781). The wire side is one string or one list of key names; everything that makes it
+// land correctly in a TUI lives here so it can be tested without a PTY.
 //
-// Three things matter, and all three are learned behaviour from the spawn paths in
-// server/index.ts:
+// For TYPING, three things matter, and all three are learned behaviour from the spawn
+// paths in server/index.ts:
 //
 //   1. Sanitize first. The text arrives from a phone, so it is untrusted: an
 //      embedded bracketed-paste terminator (\e[201~) or a bare ESC/Ctrl-C would
@@ -12,7 +12,14 @@
 //      keystrokes it might interpret one by one.
 //   3. Send the submitting Enter as a SEPARATE write a beat later — Claude's TUI
 //      drops a CR that arrives while it is still committing the paste.
+//
+// A KEY PRESS is the exact opposite and shares none of it: the bytes are the host's own
+// (terminalKeys.ts), so there is nothing to sanitize, and a menu wants keystrokes rather
+// than a paste. What the two paths DO share is the per-session write chain — see
+// sessionChain.ts.
 
+import { createSessionChain } from "./sessionChain.js";
+import { keyBytes, type TerminalKeyName } from "./terminalKeys.js";
 import type { SessionAgent } from "./terminalScreen.js";
 
 // Strip ALL control bytes (C0/C1 — ESC, Ctrl-C, CR/LF, and an embedded
@@ -53,6 +60,13 @@ export const canClearInputBox = (agent: SessionAgent | null | undefined, working
 // Matches DRAFT_SUBMIT_MS in server/index.ts: the same TUI, the same reason.
 export const SUBMIT_DELAY_MS = 150;
 
+// Between two keys of one send. Same reason as SUBMIT_DELAY_MS: a TUI re-rendering after a
+// highlight move can drop a key that arrives in that same tick, and "the arrow did nothing
+// but the Enter took effect" is exactly what #781 measured. Our tmux runs escape-time 0
+// (server/infra/tmux.ts), so a lone `escape` is forwarded at once rather than held back
+// waiting to see whether a longer sequence follows.
+export const KEY_INTERVAL_MS = 60;
+
 export interface TerminalInputDeps {
   // Write a chunk to the session's live PTY. False when no PTY is attached in this
   // process — a tmux session that outlived a restart is viewable (capture-pane) but
@@ -70,17 +84,26 @@ export interface TerminalInputDeps {
   submitSequence?: (sessionId: string) => string;
   // Injected so tests don't wait on real time.
   scheduleSubmit?: (submit: () => void) => void;
+  // The gap between two keys of one send (KEY_INTERVAL_MS). Separate from scheduleSubmit
+  // because they answer different questions, and a test drives each independently.
+  scheduleKey?: (press: () => void) => void;
 }
 
 const defaultSchedule = (submit: () => void): void => {
   setTimeout(submit, SUBMIT_DELAY_MS);
 };
 
+const defaultKeySchedule = (press: () => void): void => {
+  setTimeout(press, KEY_INTERVAL_MS);
+};
+
+const noLiveTerminal = (sessionId: string): Error => new Error(`session ${sessionId} has no live terminal on this host`);
+
 // Paste, then press Enter a beat later, resolving once the Enter has gone out.
 const typeAndSubmit = (deps: TerminalInputDeps, sessionId: string, safe: string): Promise<void> => {
   const clear = deps.canClearBox?.(sessionId) ? CLEAR_BOX : "";
   if (!deps.writeToSession(sessionId, `${clear}${PASTE_START}${safe}${PASTE_END}`)) {
-    return Promise.reject(new Error(`session ${sessionId} has no live terminal on this host`));
+    return Promise.reject(noLiveTerminal(sessionId));
   }
   const submit = deps.submitSequence?.(sessionId) ?? "\r";
   return new Promise((resolve) => {
@@ -93,34 +116,48 @@ const typeAndSubmit = (deps: TerminalInputDeps, sessionId: string, safe: string)
   });
 };
 
-// Types lines into sessions, one at a time per session.
+// Press keys, one write each, spaced by KEY_INTERVAL_MS.
 //
-// The Enter is deliberately a separate, delayed write, which means two sends that
-// overlap would interleave as paste-A, paste-B, CR, CR — the terminal would run the
-// two commands merged into one line, then submit an empty one. So each session gets
-// a chain: a send waits for the previous send's Enter before its own paste.
-// Different sessions never wait on each other.
-export const createTerminalInputSender = (deps: TerminalInputDeps) => {
-  const chains = new Map<string, Promise<void>>();
+// A write that fails throws and the rest are abandoned: unlike the paste's Enter — which is
+// best-effort because the paste is already on screen — a half-pressed key list is invisible
+// to the phone, so a dead session is reported rather than passed off as sent.
+const pressKeys = (deps: TerminalInputDeps, sessionId: string, keys: TerminalKeyName[]): Promise<void> =>
+  keys.reduce(
+    (previous, key, index) =>
+      previous.then(async () => {
+        if (index > 0) {
+          await new Promise<void>((resolve) => (deps.scheduleKey ?? defaultKeySchedule)(resolve));
+        }
+        if (!deps.writeToSession(sessionId, keyBytes(key))) {
+          throw noLiveTerminal(sessionId);
+        }
+      }),
+    Promise.resolve(),
+  );
 
-  return async (sessionId: string, text: string): Promise<{ sent: boolean }> => {
-    const safe = sanitizeTerminalInput(text);
-    if (!safe) {
-      throw new Error("text is required");
-    }
-    // A failed send must not poison the chain for the next one, so the stored link
-    // swallows the error; the caller still sees it through `run`.
-    const previous = chains.get(sessionId) ?? Promise.resolve();
-    const run = previous.then(() => typeAndSubmit(deps, sessionId, safe));
-    const link = run.catch(() => undefined);
-    chains.set(sessionId, link);
-    // Drop the entry once it is the last one, so sessions don't accumulate forever.
-    link.then(() => {
-      if (chains.get(sessionId) === link) {
-        chains.delete(sessionId);
+// Writes into sessions, one send at a time per session (sessionChain.ts) — a phone tapping a
+// key row while a typed line is still waiting for its Enter must not land the key inside
+// that line.
+//
+//   sendText — a line, sanitized and pasted, then submitted (#445).
+//   sendKeys — key presses, as if at the keyboard: no sanitizing (the bytes are ours), no
+//              paste, no box clear, no trailing submit. `enter` is just another key.
+export const createTerminalSender = (deps: TerminalInputDeps) => {
+  const inOrder = createSessionChain();
+
+  return {
+    sendText: async (sessionId: string, text: string): Promise<{ sent: boolean }> => {
+      const safe = sanitizeTerminalInput(text);
+      if (!safe) {
+        throw new Error("text is required");
       }
-    });
-    await run;
-    return { sent: true };
+      await inOrder(sessionId, () => typeAndSubmit(deps, sessionId, safe));
+      return { sent: true };
+    },
+
+    sendKeys: async (sessionId: string, keys: TerminalKeyName[]): Promise<{ sent: boolean }> => {
+      await inOrder(sessionId, () => pressKeys(deps, sessionId, keys));
+      return { sent: true };
+    },
   };
 };

--- a/server/backends/remoteHost/terminalKeys.spec.ts
+++ b/server/backends/remoteHost/terminalKeys.spec.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+
+import { MAX_KEYS_PER_SEND, TERMINAL_KEY_NAMES, isTerminalKeyName, keyBytes, parseTerminalKeys } from "./terminalKeys.js";
+
+const CONTROL_BYTE_MAX = 0x1f;
+const DEL = 0x7f;
+const C1_MAX = 0x9f;
+const isControlByte = (char: string): boolean => {
+  const code = char.charCodeAt(0);
+  return code <= CONTROL_BYTE_MAX || (code >= DEL && code <= C1_MAX);
+};
+
+describe("keyBytes", () => {
+  // The bytes a terminal emits for each key. Wrong bytes are silent — the menu simply
+  // ignores them — so every one is pinned.
+  it.each([
+    ["up", "\x1b[A"],
+    ["down", "\x1b[B"],
+    ["right", "\x1b[C"],
+    ["left", "\x1b[D"],
+    ["escape", "\x1b"],
+    ["tab", "\t"],
+    ["shift-tab", "\x1b[Z"],
+    ["backspace", "\x7f"],
+    ["space", " "],
+  ] as const)("presses %s as %j", (name, bytes) => {
+    expect(keyBytes(name)).toBe(bytes);
+  });
+
+  it("presses a digit as itself", () => {
+    expect(keyBytes("3")).toBe("3");
+    expect(keyBytes("0")).toBe("0");
+  });
+
+  // Deliberate, and the kind of thing a later reader would "fix": `enter` is the KEY, plain
+  // CR, and does NOT resolve the host's submit binding (#772). That binding describes
+  // Claude's prompt box; a menu confirms on CR. sendTerminalInput still resolves it.
+  it("presses enter as a plain CR, not the host's submit sequence", () => {
+    expect(keyBytes("enter")).toBe("\r");
+  });
+});
+
+describe("isTerminalKeyName", () => {
+  it("accepts every advertised name", () => {
+    expect(TERMINAL_KEY_NAMES.every(isTerminalKeyName)).toBe(true);
+  });
+
+  it("rejects a name that is not a key", () => {
+    expect(isTerminalKeyName("f1")).toBe(false);
+    expect(isTerminalKeyName("ctrl-c")).toBe(false);
+    expect(isTerminalKeyName("Down")).toBe(false); // names are lower-case
+  });
+
+  // The phone chooses this string, and `in` would answer true for anything on
+  // Object.prototype — the name would then be "known" but look up to a function.
+  it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])("rejects the prototype-chain name %j", (name) => {
+    expect(isTerminalKeyName(name)).toBe(false);
+  });
+
+  it("rejects non-strings", () => {
+    expect(isTerminalKeyName(3)).toBe(false);
+    expect(isTerminalKeyName(null)).toBe(false);
+    expect(isTerminalKeyName(undefined)).toBe(false);
+    expect(isTerminalKeyName(["down"])).toBe(false);
+    expect(isTerminalKeyName({ down: true })).toBe(false);
+  });
+
+  // Nothing destructive is in the vocabulary: Ctrl-C interrupts the turn / kills a shell's
+  // running process, and Ctrl-D / Ctrl-Z end or suspend the session. The phone can only ever
+  // name a key, so no control byte may BE a name either.
+  it("has no control byte reachable as a key name", () => {
+    expect(TERMINAL_KEY_NAMES.some((name) => [...name].some(isControlByte))).toBe(false);
+    expect(isTerminalKeyName("\x03")).toBe(false);
+  });
+});
+
+describe("parseTerminalKeys", () => {
+  it("returns the key names in order", () => {
+    expect(parseTerminalKeys(["down", "down", "enter"])).toEqual(["down", "down", "enter"]);
+  });
+
+  it("takes a single key", () => {
+    expect(parseTerminalKeys(["2"])).toEqual(["2"]);
+  });
+
+  it("takes the maximum allowed", () => {
+    const keys = Array.from({ length: MAX_KEYS_PER_SEND }, () => "down");
+    expect(parseTerminalKeys(keys)).toHaveLength(MAX_KEYS_PER_SEND);
+  });
+
+  it("refuses one key past the maximum", () => {
+    const keys = Array.from({ length: MAX_KEYS_PER_SEND + 1 }, () => "down");
+    expect(() => parseTerminalKeys(keys)).toThrow(/at most 16 keys/);
+  });
+
+  it("refuses an empty list", () => {
+    expect(() => parseTerminalKeys([])).toThrow(/keys is required/);
+  });
+
+  it.each([[undefined], [null], ["down"], [3], [{ 0: "down" }]])("refuses %j, which is not an array", (value) => {
+    expect(() => parseTerminalKeys(value)).toThrow(/keys must be an array/);
+  });
+
+  // The prefix it understood must NOT be pressed: a rejected send can be retried, but a key
+  // that landed in a menu cannot be un-pressed.
+  it("rejects the whole list when one name is unknown", () => {
+    expect(() => parseTerminalKeys(["down", "f1", "enter"])).toThrow(/unknown key "f1"/);
+  });
+
+  it("names what is allowed when it rejects", () => {
+    expect(() => parseTerminalKeys(["ctrl-c"])).toThrow(/allowed: .*\bdown\b/);
+  });
+
+  it("rejects a non-string entry", () => {
+    expect(() => parseTerminalKeys([2])).toThrow(/unknown key 2/);
+  });
+});

--- a/server/backends/remoteHost/terminalKeys.ts
+++ b/server/backends/remoteHost/terminalKeys.ts
@@ -1,0 +1,80 @@
+// The phone PRESSING A KEY in a live session (#781), as opposed to typing a line
+// (terminalInput.ts). Claude asks much of what it asks as a select menu — /model, its own
+// multiple-choice questions, permission prompts — and a menu answers to key presses, not
+// to pasted text: the typing path strips every control byte (so no arrow survives it) and
+// wraps the rest in bracketed paste (so a digit arrives as text the menu ignores).
+//
+// This is a SEPARATE vocabulary rather than a loosened sanitizer. The phone names a key
+// and the host owns the bytes, so the trust boundary stays where it was — untrusted input
+// still cannot reach the PTY as control bytes of its own choosing.
+
+// Every key the phone may press, and the bytes a terminal emits for it.
+//
+// Deliberately small: menu navigation and the answers to one. Nothing destructive — Ctrl-C
+// interrupts the turn mid-turn and kills whatever is running in a shell, which is too
+// expensive for a mis-tap on a phone; Ctrl-D / Ctrl-Z likewise end or suspend the session.
+//
+// `enter` is the KEY, plain CR, and deliberately does NOT go through the host's submit
+// binding (#772): that binding describes Claude's PROMPT BOX, while a menu confirms on CR.
+// Committing a typed line is sendTerminalInput's job, and that path still resolves the
+// binding per session.
+const KEY_BYTES = {
+  up: "\x1b[A",
+  down: "\x1b[B",
+  right: "\x1b[C",
+  left: "\x1b[D",
+  enter: "\r",
+  escape: "\x1b",
+  tab: "\t",
+  "shift-tab": "\x1b[Z",
+  backspace: "\x7f",
+  space: " ",
+  "0": "0",
+  "1": "1",
+  "2": "2",
+  "3": "3",
+  "4": "4",
+  "5": "5",
+  "6": "6",
+  "7": "7",
+  "8": "8",
+  "9": "9",
+} as const;
+
+export type TerminalKeyName = keyof typeof KEY_BYTES;
+
+export const TERMINAL_KEY_NAMES: readonly string[] = Object.keys(KEY_BYTES);
+
+// hasOwnProperty, not `in`: `"constructor" in KEY_BYTES` is true through the prototype
+// chain, and the phone chooses this string — a name that passed would then be looked up to
+// a function rather than bytes.
+export const isTerminalKeyName = (value: unknown): value is TerminalKeyName =>
+  typeof value === "string" && Object.prototype.hasOwnProperty.call(KEY_BYTES, value);
+
+export const keyBytes = (name: TerminalKeyName): string => KEY_BYTES[name];
+
+// One send holds the session's write chain for (n - 1) inter-key gaps, so a bound keeps a
+// single command from occupying the terminal — and keeps a mis-built request from being a
+// way to hold it indefinitely. Sixteen is far past any real tap burst.
+export const MAX_KEYS_PER_SEND = 16;
+
+// The `keys` param off the wire → the key names to press. Rejects the whole request rather
+// than pressing the prefix it understood: the phone can retry a rejected send, but it
+// cannot un-press a key that landed in a menu.
+export const parseTerminalKeys = (value: unknown): TerminalKeyName[] => {
+  if (!Array.isArray(value)) {
+    throw new Error("keys must be an array of key names");
+  }
+  if (value.length === 0) {
+    throw new Error("keys is required");
+  }
+  if (value.length > MAX_KEYS_PER_SEND) {
+    throw new Error(`at most ${MAX_KEYS_PER_SEND} keys per send`);
+  }
+  return value.map((name) => {
+    if (!isTerminalKeyName(name)) {
+      throw new Error(`unknown key ${JSON.stringify(name)} — allowed: ${TERMINAL_KEY_NAMES.join(", ")}`);
+    }
+    return name;
+  });
+};


### PR DESCRIPTION
## Summary

**WIP（ホスト側のみ）。** スマホから Claude の**選択メニュー**（`/model`・自前の選択肢・権限プロンプト）を
操作できるようにするための、ホスト側の生キー送信コマンド `sendTerminalKeys` を追加した。
スマホ側（キー行の UI）は `receptron/mulmoserver` の別 PR で、**それが出るまでユーザーの体感は変わらない**。

今のライブ入力 `sendTerminalInput` は ① `sanitizeTerminalInput` で制御バイトを全除去 →
② bracketed paste で包む → ③ 150ms 後に Enter、という経路なので、矢印のエスケープ列は①で消え、
貼り付けた数字はメニューに「キー押下」として届かない（#781）。

**サニタイズは緩めない。** スマホから来る文字列は untrusted で、あれは `\e[201~` や Ctrl-C の混入を
防いでいる。代わりに**スマホはキー名を送り、バイト列はホストが持つ**。信頼境界は今のままで、
untrusted な入力が任意の制御バイトとして PTY に届くことはない。

| ファイル | 内容 |
| --- | --- |
| `terminalKeys.ts`（新規・純粋関数） | キー名 → バイト列の allow-list と、ワイヤ param の検証 |
| `sessionChain.ts`（`terminalInput.ts` から抽出） | 「セッションごと直列・セッション間独立」だけを持つ |
| `terminalInput.ts` | `createTerminalSender` が `{ sendText, sendKeys }` を返す。チェーンは 1 つ |
| `handlers.ts` | `sendTerminalKeys({ sessionId, keys })` |

deps は増えないので `server/index.ts` と `remoteHost/index.ts` は無変更。capability は
`buildHostPresence` が handler テーブルから導出するので**プロトコル変更なし**（旧スマホは単に見えない）。

対応キーは `up` `down` `left` `right` `enter` `escape` `tab` `shift-tab` `backspace` `space` `0`〜`9`。

### 実セッションで検証した（issue で「矢印は不安定」と報告された部分）

捨て socket の tmux + 実 `claude` を、サーバと同じ `term.write` 経路で叩いた:

```
menu up — pointer on row 13: ❯ 1. Yes, I trust this folder
after \x1b[B  → row 14: ❯ 2. No, exit          PASS
after \x1b[A  → row 13: ❯ 1. Yes, I trust ...  PASS
after "2"      → <session ended>                PASS
```

矢印も数字もメニューに届く。**#781 の「矢印が不安定」はバイト列ではなく送信経路側**で、
末尾 Enter の同送か `canClearBox` の Ctrl-C（`/model` 表示中は `working === false` なので条件を満たし、
Ctrl-C はメニューを閉じる）が原因だったと見ている。ブラウザのターミナルも同じ `term.write` に
生キーを流していて（`server/session/pty-connection.ts`）、そこでは前から動いていた。

### テストが壊れたときに落ちることを確認した

7 種の mutation を入れて、狙ったテストが赤くなることを確認済み:
`hasOwnProperty` → `in`／`enter` を ESC+CR に／未知のキーを黙って捨てる／キー間の間隔を削る／
チェーンを共有しない／途中の write 失敗を握り潰す／チェーンの entry を消さない。

## Items to Confirm / Review

- **`enter` を素の CR 固定にした判断**。`terminalSubmit`（#772）の submit binding を通していない。
  あれは Claude の**プロンプト入力欄**の binding で、メニューの確定は CR という理解。
  `esc-cr` に変えている人が**プロンプト入力欄で**このキーを押すと改行になる（打った行の確定は
  `sendTerminalInput` の仕事なので、実害は薄いと判断）。
- **Ctrl-C を allow-list に入れなかった判断**。「出先で暴走 turn を止めたい」は正当な要求だが、
  turn 中なら turn を中断し shell なら実行中プロセスを殺すので、スマホの誤タップのコストが高い。
  欲しければ別 issue にしたい。
- **キー間の間隔 60ms（`KEY_INTERVAL_MS`）** と **1 送信あたり 16 キー上限**。どちらも根拠は
  「paste の Enter を 150ms 遅らせるのと同じ理由」＋チェーン占有時間の上限で、実測ではない。
- **`createSessionChain(chains = new Map())` の引数**。テストから entry が溜まらないことを見るためだけの
  seam。リークは外から観測できない（解決済みの古い link は link 無しと同じ挙動）ので入れたが、
  内部を露出させている。
- **改名 `createTerminalInputSender` → `createTerminalSender`**。呼び出し元はここと spec だけ。

## User Prompt

> これってなんとかなる？？
> https://github.com/receptron/mulmoterminal/issues/781

方針の確認に対する回答:

- スコープ: **ホスト PR → スマホ PR** の順（このリポジトリを先に）
- キー集合: **最小（↑↓←→ / Enter / Esc / Tab / 数字）**
- その後: **wip で PR を出し、issue を更新する**

## 実装の詳細と決めたこと

### 1 キー 1 write、キーの間だけ間隔を空ける

理由は paste の Enter を遅らせるのと同じで、ハイライト移動で再描画中の TUI は同じ tick に来た
キーを落とし得る（#781 の「矢印は効かず末尾の Enter だけが効く」がまさにその症状）。
tmux 側は `escape-time 0`（`server/infra/tmux.ts`）なので、単独の `escape` はシーケンス待ちで
溜められず即転送される。

### 途中の write が失敗したらそこで throw

テキスト経路の Enter は「paste はもう画面に出ている」ので best-effort だが、キー列は何個目まで
届いたかがスマホから見えないので、死んだセッションを「送れた」と報告しない。

### 未知のキー名は列ごと拒否

理解できた接頭辞だけ押すことはしない。拒否された送信はスマホから再送できるが、メニューに
入ってしまったキーは押し戻せない。

### プロトタイプ鎖

キー名の照合は `hasOwnProperty`。`in` だと `constructor` / `toString` が「既知のキー名」として
通り、バイト列ではなく関数を引いてしまう。

## ドキュメント

- `docs/guide/*/notifications.md` の「通知だけじゃない: スマホから見て答える」節は**まだ触っていない**。
  キー行はスマホ側 PR で出るので、今書くと存在しない機能の説明になる。スマホ側 PR と同時に更新する。
- `docs/ChangeLog.md` はこのリポジトリではリリース時に一括で書く運用（`docs: changelog for mulmoterminal@x.y.z`）
  なので触っていない。
- README には remote-host のコマンド一覧が無いため、直すべき記述なし。

## 残り（このあと）

- [ ] `receptron/mulmoserver`: キー行（↑↓←→ / Enter / Esc / Tab）の追加と、既にある番号チップ
      （`useTerminalChips.ts` — 今は入力欄に数字を入れるだけ）を「数字キーを押す」に変更。
      capability に `sendTerminalKeys` が無いホストでは従来動作にフォールバック
- [ ] スマホ実機での通し確認（`/model` を含む）
- [ ] ガイド（notifications.md）の更新

Closes #781 はスマホ側がマージされてからにしたいので、この PR には付けていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
