### PR TITLE
docs: correct the terminal scrollback/selection FAQ entry (#782)

### DIFF
--- a/server/skills/mulmoterminal-bug-report/faq.md
+++ b/server/skills/mulmoterminal-bug-report/faq.md
@@ -69,14 +69,22 @@ design. The conditions and the exclusions are listed in the notifications guide 
 order (RemoteHost connected, the toggle on, at least one registered device) before treating it as a
 bug.
 
-## No scrollbar, selection doesn't autoscroll, or links in the output aren't clickable
+## Can't select or copy text that scrolled off screen (or no scrollbar) in a Claude/Codex terminal
 
+source: server/infra/tmux.ts
 source: src/composables/useTerminalConnections.ts
+source: docs/terminal-notes.md
 
-Known and unresolved — a renderer generation mismatch is the prime suspect, and the source comment
-at that call site explains why it cannot simply be bumped. Issues already exist, so **do not open a
-new one**: search the repo for "scrollbar", "OSC 8" or "renderer" and add the environment and repro
-steps to the matching one.
+Not a renderer bug — the canvas-mismatch theory was ruled out, and the OSC 8 "links aren't
+clickable" half was tmux stripping hyperlinks (fixed in #785). tmux owns the scrollback, so the
+outer terminal only ever holds the visible screen. A **shell** cell keeps its history in tmux and
+can be drag-selected; a **Claude/Codex** cell runs in the alternate screen, which has no scrollback
+at all (its tmux `history_size` is 0) — the app redraws its own transcript as you scroll. Selecting
+that scrolled-off history is therefore impossible in ANY terminal (VS Code / iTerm included), not
+specific to this app. Workaround: to copy long output from a Claude/Codex cell, redirect it to a
+file and open it in the browser viewer (source/text files render inline, #785), or select
+screen-by-screen. Background and the parked shell-cell fix live in #782 and docs/terminal-notes.md;
+**do not open a new issue** — add repro details to #782.
 
 ## The phone's terminal view shows no directory or branch
 


### PR DESCRIPTION
## Summary

Corrects the bug-report FAQ entry about terminal scrollback / selection. The old entry blamed a
"renderer generation mismatch" — the investigation in #782 **ruled that out**. The real cause is
that **tmux owns the scrollback**, and it splits by cell type:

- **shell** cell → main buffer, tmux keeps real history → can be drag-selected.
- **Claude/Codex** cell → alternate screen, `history_size = 0` → the app redraws its own transcript
  on scroll, so its scrolled-off history can't be drag-selected in **any** terminal (VS Code / iTerm
  included). Not specific to this app.

The OSC 8 "links aren't clickable" half was already fixed in #785, so it's dropped from the entry.
Adds the practical workaround: redirect long output to a file and open it in the browser viewer.

Docs-only change — no code. The shell-cell fix is implemented but **parked** on
`fix/782-tmux-copy-mode` (not in this PR), because it doesn't address the issue's real target
(Claude/Codex cells). Full analysis is in #782.

## Items to Confirm / Review

- The FAQ format requires every `source:`/`guide:` to be a real path (CI-checked). This entry
  points at `server/infra/tmux.ts`, `src/composables/useTerminalConnections.ts`,
  `docs/terminal-notes.md` — all present. `bugReportFaq.spec.ts` / `faqEntries.spec.ts` pass.
- The claim "impossible in any terminal (VS Code/iTerm too)" is a property of the alternate screen
  (no scrollback), reasoned from terminal fundamentals + measured here (`alt=1`, `history_size=0`
  on real Claude/Codex sessions). Please sanity-check the wording.

## User Prompt

> ターミナルのコピペ・スクロール（画面外まで選択できない／スクロールすると範囲選択がずれる／
> スクロールバーが出ない、#782）を直せないか調査してほしい。方針は tmux コピーモードに統合。
> 調査の結果、Claude/Codex セルは構造上むずかしいと判明したので、一旦調査結果を issue に残し、
> FAQ にも既知の問題として追加して区切りにする。長文コピーはファイルに出してブラウザで開くのを
> ワークアラウンドに。

(Investigate #782 terminal copy/scroll; direction was tmux copy-mode integration. The investigation
found Claude/Codex cells are architecturally limited, so wrap up by recording the findings in the
issue and adding a known-issue FAQ entry, with "write output to a file and open it in the browser"
as the workaround.)

## Background

Full investigation, measured data, and the parked shell-cell implementation are documented in #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
