### PR TITLE
feat(cli): read the launch directory's .env when started via npx (#795)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,15 @@ Requires **Node ≥ 22.9** (uses `node --env-file-if-exists`) and the `claude` C
 ## Configuration
 
 The server is configured entirely through environment variables, optionally
-loaded from a `.env` file via `node --env-file-if-exists=.env` (wired into the
-npm scripts). The `.env` is optional — every variable below has a default, so
-the server runs without one.
+loaded from a `.env` file. `npx mulmoterminal` reads the `.env` **in the
+directory you run it from**; the npm scripts read the one in the repo root. The
+`.env` is optional — every variable below has a default, so the server runs
+without one.
+
+A variable already set in your shell wins over the same name in `.env`, so
+adding a file never overrides what you exported. The server's environment is
+inherited by every terminal it starts, so anything in `.env` is also visible to
+the `claude` / `codex` sessions themselves.
 
 | Variable     | Default        | Description |
 | ------------ | -------------- | ----------- |

--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -9,3 +9,4 @@ export declare function saysYes(answer: unknown): boolean;
 export declare const SECOND_INSTANCE_NOTE: string;
 export declare const MIN_NODE_LABEL: string;
 export declare function nodeMeetsMinimum(version: string): boolean;
+export declare function serverNodeArgs(serverEntry: string, launchDir: string): string[];

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -9,6 +9,7 @@
 //
 // These return a decision; the caller prints and exits. Nothing here reads argv, the
 // environment or the filesystem.
+import { join } from "node:path";
 
 /**
  * Which port the launcher should ask for.
@@ -132,4 +133,20 @@ export const MIN_NODE_LABEL = `${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}`;
 export function nodeMeetsMinimum(version) {
   const [major, minor] = version.split(".").map((part) => Number.parseInt(part, 10));
   return major > MIN_NODE_MAJOR || (major === MIN_NODE_MAJOR && minor >= MIN_NODE_MINOR);
+}
+
+/**
+ * The node arguments the launcher spawns the server with.
+ *
+ * `--env-file-if-exists` is what makes a `.env` in the LAUNCH directory reach the server
+ * (#795): the dev scripts have always passed it, the launcher never did, so a key written
+ * there was silently absent and the provider stayed unusable. The path is absolute because
+ * the spawn runs with `cwd` set to the package directory — a relative `.env` would be looked
+ * for inside node_modules and quietly not found.
+ *
+ * Node options must precede the script path; anything after it is an argument to the script.
+ * The launch directory is passed rather than read here so the choice stays checkable.
+ */
+export function serverNodeArgs(serverEntry, launchDir) {
+  return ["--import", "tsx", `--env-file-if-exists=${join(launchDir, ".env")}`, serverEntry];
 }

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -25,6 +25,7 @@ import {
   SECOND_INSTANCE_NOTE,
   nodeMeetsMinimum,
   MIN_NODE_LABEL,
+  serverNodeArgs,
 } from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -248,7 +249,9 @@ function runServer(port, noOpen, cwd, onChild) {
     // stderr is piped (and passed through) so a fatal boot error can be inspected once the
     // child closes — a half-unpacked npx cache entry crashes here with ERR_MODULE_NOT_FOUND,
     // and without reading stderr the launcher cannot tell that from a real bug.
-    const server = spawn(process.execPath, ["--import", "tsx", SERVER_ENTRY], {
+    // The .env comes from where the user ran the command — the spawn's own cwd is the
+    // package directory, so serverNodeArgs makes that path absolute (#795).
+    const server = spawn(process.execPath, serverNodeArgs(SERVER_ENTRY, process.cwd()), {
       cwd: PKG_DIR,
       env: { ...process.env, NODE_ENV: "production", PORT: String(port), CLAUDE_CWD: cwd },
       stdio: ["inherit", "inherit", "pipe"],

--- a/plans/feat-795-env-file.md
+++ b/plans/feat-795-env-file.md
@@ -1,0 +1,62 @@
+# feat #795 — load `.env` from the launch directory when started via npx
+
+## The gap
+
+The "Running a session on another model" modal tells the user their key belongs "in the
+shell that starts MulmoTerminal, or a `.env` beside it". That is true for a dev launch and
+false for every real one:
+
+| launch | server spawn | `.env` |
+| --- | --- | --- |
+| `yarn dev` / `yarn server` | `node --import tsx --env-file-if-exists=.env server/index.ts` | read |
+| `npx mulmoterminal` | `spawn(node, ["--import","tsx", SERVER_ENTRY], { cwd: PKG_DIR, env: {...process.env} })` | **never read** |
+
+So a key written into `.env` never reaches the server, the provider stays `ready:false`, and
+the launch form shows no MODEL selector. The only workaround is exporting in the shell first.
+
+## Measured behaviour (Node v24.12, this host)
+
+Both settled by experiment rather than by reading docs, because both decide what a user's
+key does:
+
+- **The shell wins.** A variable set in the environment is NOT overwritten by the same name
+  in `.env` — so adding this cannot silently replace a key someone exported.
+- **With several `--env-file` flags, the last one wins**, and every file's unique keys load.
+
+Pinned as a test (`test/bin/env-file-precedence.spec.ts`) rather than trusted: the whole
+point of the feature is which value a key ends up with, and CI runs Node 22 and 24.
+
+## Decision: the launch directory, not the workspace
+
+`.env` is read from `process.cwd()` — where the user typed the command — and nowhere else.
+
+The two coincide for a bare `npx mulmoterminal`: `chooseCwd` (bin/cli-args.js) returns `"."`
+with no `--cwd`, so the workspace already IS the launch directory. (`~/mulmoclaude` is
+`server/config/env.ts`'s fallback for a server started WITHOUT the launcher; the launcher
+always passes a resolved `CLAUDE_CWD`.) They differ only when `--cwd <dir>` is given, and
+there the shell's directory is what the modal's wording promises, and what the user can see.
+
+Not done: a `.env` in the workspace, a global one, or several files at once.
+
+## Change
+
+- `bin/cli-args.js` gains `serverNodeArgs(serverEntry, launchDir)` — the launcher's decisions
+  live there precisely so they can be checked without spawning anything.
+- `bin/mulmoterminal.js` uses it for the server spawn. The spawn `cwd` stays `PKG_DIR`, so
+  the flag carries an absolute path; a relative `.env` would resolve against the package
+  directory and find nothing.
+- Docs say the launch directory, in all three places that describe this: the modal
+  (`src/components/ModelSetupHelp.vue`), the config skill
+  (`server/skills/mulmoterminal-config/SKILL.md`), and the README.
+
+`.env` values reach the PTY sessions too, since a session inherits the server's environment.
+That is already true of a dev launch and is what the modal describes, so it stays — stated in
+the docs rather than left to be discovered.
+
+## Tests
+
+- `test/bin/cli-args.spec.ts` — the flag is present, carries the absolute `.env` path, sits
+  before the entry script (a Node option after the script path is an argument to the script),
+  and a launch directory containing spaces stays one argv element (no shell is involved).
+- `test/bin/env-file-precedence.spec.ts` — spawns the real `node` to pin both measured rules
+  above, so a Node upgrade that flips either one fails here instead of in someone's session.

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -252,7 +252,8 @@ the session in a way that is hard to diagnose from inside it.
   the picker on its own. `models` exists only to ADD ids we have not measured — an empty array in the
   example teaches the user they must fill it in.
 - **Never write the API key into this file, or into any file.** `tokenEnv` is the *name* of an
-  environment variable; the key belongs in the shell that starts the server, or a `.env` beside it.
+  environment variable; the key belongs in the shell that starts the server, or a `.env` in the
+  directory it is started from.
   If the user pastes a key at you, tell them where it goes — do not store it.
 - `baseUrl` must **not** end in `/v1`. Claude Code appends `/v1/messages` itself, so a trailing
   `/v1` produces `/v1/v1/messages` and every request 404s.

--- a/src/components/ModelSetupHelp.vue
+++ b/src/components/ModelSetupHelp.vue
@@ -98,7 +98,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
         <pre class="m-0 overflow-x-auto rounded-md border border-border bg-input p-3 font-mono text-[11px] leading-relaxed text-fg">
 OPENROUTER_API_KEY=sk-or-…</pre>
         <p class="m-0 font-sans text-[11px] leading-relaxed text-secondary">
-          In the shell that starts MulmoTerminal, or a <code class="font-mono">.env</code> beside it. Keys never go in
+          In the shell that starts MulmoTerminal, or a <code class="font-mono">.env</code> in the directory you start it from. Keys never go in
           <code class="font-mono">config.json</code>. Restart the server after adding one.
         </p>
       </section>

--- a/test/bin/cli-args.spec.ts
+++ b/test/bin/cli-args.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import path from "node:path";
 
 import {
   parsePortArg,
@@ -10,6 +11,7 @@ import {
   SECOND_INSTANCE_NOTE,
   nodeMeetsMinimum,
   MIN_NODE_LABEL,
+  serverNodeArgs,
 } from "../../bin/cli-args.js";
 
 const DEFAULT_PORT = 34567;
@@ -291,5 +293,40 @@ describe("nodeMeetsMinimum", () => {
   it("labels the minimum it enforces", () => {
     expect(MIN_NODE_LABEL).toBe("22.9");
     expect(nodeMeetsMinimum(`${MIN_NODE_LABEL}.0`)).toBe(true);
+  });
+});
+
+describe("serverNodeArgs", () => {
+  const ENTRY = "/pkg/server/index.ts";
+
+  // The gap #795 closes: the dev scripts always passed this flag and the launcher never did,
+  // so a key written into .env was silently absent from the server.
+  it("reads .env from the launch directory, by absolute path", () => {
+    expect(serverNodeArgs(ENTRY, "/home/u/project")).toContain(`--env-file-if-exists=${path.join("/home/u/project", ".env")}`);
+  });
+
+  // The spawn runs with cwd set to the package directory, so a relative path would be looked
+  // for inside node_modules.
+  it("does not pass a bare relative .env", () => {
+    expect(serverNodeArgs(ENTRY, "/home/u/project")).not.toContain("--env-file-if-exists=.env");
+  });
+
+  // A node option after the script path is an argument to the script, not to node.
+  it("keeps every node option ahead of the entry script", () => {
+    const args = serverNodeArgs(ENTRY, "/home/u/project");
+    expect(args[args.length - 1]).toBe(ENTRY);
+    expect(args.filter((a) => a.startsWith("--")).every((a) => args.indexOf(a) < args.indexOf(ENTRY))).toBe(true);
+  });
+
+  it("still loads tsx, which is what lets the server entry be TypeScript", () => {
+    expect(serverNodeArgs(ENTRY, "/home/u/p").slice(0, 2)).toEqual(["--import", "tsx"]);
+  });
+
+  // No shell is involved in the spawn, so a directory with spaces needs no quoting — and
+  // must not get any, or the path would carry literal quote characters.
+  it("leaves a launch directory containing spaces as one unquoted argument", () => {
+    const flag = serverNodeArgs(ENTRY, "/home/u/My Projects/app").find((a) => a.startsWith("--env-file"));
+    expect(flag).toBe(`--env-file-if-exists=${path.join("/home/u/My Projects/app", ".env")}`);
+    expect(flag).not.toContain('"');
   });
 });

--- a/test/bin/env-file-precedence.spec.ts
+++ b/test/bin/env-file-precedence.spec.ts
@@ -1,0 +1,77 @@
+// What `--env-file-if-exists` actually does to a key — pinned against the real node this
+// repo runs on, not against the docs. The launcher passes this flag so a `.env` beside the
+// user's shell reaches the server (#795), and the whole feature is "which value does the key
+// end up with", so a Node release that changed either rule below would change what a user's
+// API key is without anything else failing. CI runs Node 22 and 24; this catches both.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { serverNodeArgs } from "../../bin/cli-args.js";
+
+// Read the names back out of a child node, which is the only place the rules apply.
+function envFromChild(envFileArgs: string[], env: NodeJS.ProcessEnv): Record<string, string | undefined> {
+  const script = "console.log(JSON.stringify({ shared: process.env.MT_SHARED, onlyA: process.env.MT_ONLY_A, onlyB: process.env.MT_ONLY_B }))";
+  const out = execFileSync(process.execPath, [...envFileArgs, "-e", script], { env, encoding: "utf8" });
+  return JSON.parse(out);
+}
+
+describe("node --env-file-if-exists", () => {
+  let dir = "";
+  let fileA = "";
+  let fileB = "";
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "mt-envfile-"));
+    fileA = path.join(dir, "a.env");
+    fileB = path.join(dir, "b.env");
+    writeFileSync(fileA, "MT_SHARED=from-a\nMT_ONLY_A=a\n");
+    writeFileSync(fileB, "MT_SHARED=from-b\nMT_ONLY_B=b\n");
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("loads a key the environment does not already have", () => {
+    expect(envFromChild([`--env-file-if-exists=${fileA}`], { ...process.env }).onlyA).toBe("a");
+  });
+
+  // The safety property this feature leans on: adding the flag cannot silently replace a key
+  // the user exported in their shell.
+  it("does NOT override a name already set in the environment", () => {
+    const child = envFromChild([`--env-file-if-exists=${fileA}`], { ...process.env, MT_SHARED: "from-shell" });
+    expect(child.shared).toBe("from-shell");
+  });
+
+  it("is a no-op for a file that does not exist, rather than an error", () => {
+    const missing = path.join(dir, "nope.env");
+    expect(() => envFromChild([`--env-file-if-exists=${missing}`], { ...process.env })).not.toThrow();
+  });
+
+  // Not used today (the launcher passes exactly one file), but it is the rule any later
+  // "also read the workspace .env" would inherit, so record which side would win.
+  it("takes the LAST file when several are given, keeping every file's unique keys", () => {
+    const child = envFromChild([`--env-file-if-exists=${fileA}`, `--env-file-if-exists=${fileB}`], { ...process.env });
+    expect(child).toEqual({ shared: "from-b", onlyA: "a", onlyB: "b" });
+  });
+
+  // The arguments the launcher actually builds, run by the actual node, from a DIFFERENT
+  // working directory — which is the shape that made the bug invisible to a unit test: the
+  // spawn's cwd is the package dir, so only an absolute path finds the user's file. The
+  // server itself is never started; this is about the argv, not the app.
+  it("loads the launch directory's .env through the launcher's own arguments, spawned from elsewhere", () => {
+    const launchDir = mkdtempSync(path.join(tmpdir(), "mt-launch-"));
+    writeFileSync(path.join(launchDir, ".env"), "MT_ONLY_A=from-launch-dir\n");
+    const stub = path.join(dir, "stub.mjs");
+    writeFileSync(stub, "console.log(process.env.MT_ONLY_A ?? '<unset>');\n");
+    // --import tsx is dropped: this exercises the .env flag, and loading tsx here would only
+    // add a dependency on the transform.
+    const args = serverNodeArgs(stub, launchDir).filter((arg) => arg !== "--import" && arg !== "tsx");
+    try {
+      const out = execFileSync(process.execPath, args, { cwd: process.cwd(), env: { ...process.env }, encoding: "utf8" });
+      expect(out.trim()).toBe("from-launch-dir");
+    } finally {
+      rmSync(launchDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

npx 起動で起動ディレクトリの `.env` が読まれず、モーダルの案内（"In the shell that starts MulmoTerminal, or a `.env` beside it"）が嘘になっていた問題（#795）。

| 起動方法 | サーバの spawn | `.env` |
| --- | --- | --- |
| `yarn dev` / `yarn server` | `node --import tsx --env-file-if-exists=.env server/index.ts` | 読まれる |
| `npx mulmoterminal` | `spawn(node, ["--import","tsx", SERVER_ENTRY], { cwd: PKG_DIR })` | **読まれない** |

ランチャの spawn に `--env-file-if-exists=<起動ディレクトリ>/.env` を追加しました。

## Items to Confirm / Review

- **`.env` は `process.cwd()`（コマンドを打った場所）から読みます。** ワークスペースではありません。
  素の `npx mulmoterminal` では両者は同じです（`chooseCwd` は `--cwd` 無しなら `"."` を返すので**ワークスペース＝起動ディレクトリ**。`~/mulmoclaude` は `server/config/env.ts` の fallback で、ランチャを通さずサーバを直接起動したときにだけ使われます）。差が出るのは `--cwd` を明示したときだけで、そこはモーダルの文言どおり「シェルのいる場所」を採りました。
- **パスは絶対パス**。spawn の `cwd` はパッケージ導入先なので、相対 `.env` は node_modules の中を探して静かに見つからない。
- **優先順位は実測して決めました**（docs を読むのではなく）。この機能の本質が「鍵がどの値になるか」なので:
  - **シェルの env が勝つ** — `.env` を足しても、export 済みの鍵を黙って上書きしない
  - `--env-file` を複数指定すると**後勝ち**（今は1つしか渡さないが、将来「ワークスペースの .env も読む」を足すときに効く規則なので記録）
  どちらも `test/bin/env-file-precedence.spec.ts` で**実際の node を spawn して**ピン留めしてあります。Node 22 / 24 の両方が CI で回るので、上流が挙動を変えたらここで落ちます。
- **PTY セッションへの流入は据え置き**（dev と同じ）。サーバの env はすべての PTY に継承されるので `.env` の値は claude / codex セッションにも入ります。issue の「一貫する」という判断に従い、READMEに明記する形にしました。
- 実サーバを別ポートで起動する E2E は**やっていません**。起動時の tmux セッション掃除がユーザーの稼働中セッションに触れうるためです。代わりに「ランチャが組み立てた引数を、**別の作業ディレクトリから実際の node で実行**して `.env` が読まれること」を統合テストにしました（サーバは起こさない）。ユニットテストでは見えなかった「絶対パスでないと見つからない」という形そのものを踏みます。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/795 これの対応ってできる？
>
> （`.env` の場所について）どういうこと？ワークスペースって~/mulmo~~だよね？そこには.envはおかないので、pwdじゃないのかな？ → **pwd のみ**
> （PTY への流入について）**そのまま（dev と同じ）**

## テスト

- `test/bin/cli-args.spec.ts` — `serverNodeArgs` 5ケース: フラグが絶対パスを持つ / 相対 `.env` を渡さない / **node オプションがエントリスクリプトより前にある**（後ろに置くとスクリプトへの引数になる）/ `--import tsx` が残っている / **空白を含む起動ディレクトリが1つの argv 要素のまま**（シェルを介さないのでクォート不要、かつ付けてはいけない）
- `test/bin/env-file-precedence.spec.ts`（新規5ケース）— 上記の実測ピン留め＋統合テスト
- 実装を壊すとテストが落ちることを2パターンで確認（フラグを削る / エントリの後ろに置く）
- `yarn format` / `lint` / `build` / `typecheck` ×3 / `test`（3889 passed）/ `knip` 実行済み

## ドキュメント

実挙動に合わせて3箇所とも直しました: モーダル（`ModelSetupHelp.vue`）、設定スキル（`mulmoterminal-config/SKILL.md`）、README（読まれる場所・シェルが勝つこと・セッションにも入ることを追記）。

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)
