### PR TITLE
feat: open a clicked .md rendered instead of as source (#808)

### DIFF
--- a/server/files/files-browse.ts
+++ b/server/files/files-browse.ts
@@ -17,12 +17,27 @@ import { resolveBase, containedPath, realContainedWithin } from "./pathContainme
 export const MAX_EDIT_BYTES = 2 * 1024 * 1024;
 
 // Wrap marked's HTML output in a minimal, self-contained document (served sandboxed).
+//
+// Colours follow the READER's system theme rather than the app's: this document opens in its
+// own tab under a sandbox CSP, so it cannot ask the app for its theme — and a hardcoded light
+// page is a white flash for anyone reading in the dark. `color-scheme` is what gets the
+// scrollbars and form controls to match; the media query does the rest.
 export function mdToHtmlDoc(bodyHtml: string, title: string): string {
   const esc = (s: string) => s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c] ?? c);
-  const style =
-    "body{max-width:48rem;margin:2rem auto;padding:0 1rem;font-family:system-ui,sans-serif;line-height:1.6;color:#1a1a2e}" +
-    "pre{background:#f4f4f4;padding:1rem;overflow:auto}code{font-family:ui-monospace,monospace}img{max-width:100%}";
-  return `<!doctype html><html><head><meta charset="utf-8"><title>${esc(title)}</title><style>${style}</style></head><body>${bodyHtml}</body></html>`;
+  const style = [
+    ":root{color-scheme:light dark}",
+    "body{max-width:48rem;margin:2rem auto;padding:0 1rem;font-family:system-ui,sans-serif;line-height:1.6;color:#1a1a2e;background:#fff}",
+    "pre{background:#f4f4f4;padding:1rem;overflow:auto}code{font-family:ui-monospace,monospace}img{max-width:100%}",
+    "a{color:#0b57d0}blockquote{margin:0;padding:0 1rem;border-left:4px solid #d0d0d8;color:#55555f}",
+    "table{border-collapse:collapse}th,td{border:1px solid #d0d0d8;padding:.25rem .5rem}",
+    "@media(prefers-color-scheme:dark){",
+    "body{color:#e6e6ea;background:#16161a}",
+    "pre{background:#232329}",
+    "a{color:#8ab4f8}blockquote{border-left-color:#3a3a44;color:#a0a0aa}",
+    "th,td{border-color:#3a3a44}",
+    "}",
+  ].join("");
+  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${esc(title)}</title><style>${style}</style></head><body>${bodyHtml}</body></html>`;
 }
 
 export interface BrowseEntry {

--- a/src/composables/terminalFilePathLinkProvider.ts
+++ b/src/composables/terminalFilePathLinkProvider.ts
@@ -42,8 +42,32 @@ export function computeFilePathLinks(cells: TerminalCell[]): ColumnLink[] {
   }));
 }
 
+// Which route opens a clicked path, by extension. A file the browser can only show as
+// SOURCE goes to the raw route; one we can present better gets its own. Kept as a table so
+// the next extension is a row rather than a branch (#808).
+//
+// The markdown route is what the Files overlay already previews with — same `cwd`/`path`
+// query, marked-rendered, served under a sandbox CSP. It resolves its base slightly more
+// loosely than the raw route (any existing absolute dir, vs. the raw route's "root or a live
+// session cwd"), which is the browse routes' documented posture; the cwd handed over here is
+// the session's own either way.
+const ROUTE_BY_EXTENSION: Record<string, string> = {
+  ".md": "/api/files/browse/md",
+  ".markdown": "/api/files/browse/md",
+};
+
+const RAW_ROUTE = "/api/files/raw";
+
+/** The route a path's extension is opened through — lower-cased, since a `README.MD` is
+ *  still markdown, and `.md` in the middle of a name is not an extension. */
+export function fileViewerRoute(filePath: string): string {
+  const dot = filePath.lastIndexOf(".");
+  const ext = dot === -1 ? "" : filePath.slice(dot).toLowerCase();
+  return ROUTE_BY_EXTENSION[ext] ?? RAW_ROUTE;
+}
+
 export function rawFileUrl(filePath: string, cwd: string): string {
-  return `/api/files/raw?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent(filePath)}`;
+  return `${fileViewerRoute(filePath)}?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent(filePath)}`;
 }
 
 function readCells(term: Terminal, bufferLineNumber: number): TerminalCell[] | null {

--- a/test/server/files/files-browse.spec.ts
+++ b/test/server/files/files-browse.spec.ts
@@ -28,4 +28,21 @@ describe("mdToHtmlDoc", () => {
     expect(doc).toContain("<title>a&lt;b&gt;.md</title>");
     expect(doc.startsWith("<!doctype html>")).toBe(true);
   });
+
+  // The page opens in its own tab under a sandbox CSP, so it cannot ask the app which theme
+  // is on — it has to follow the reader's system setting instead of flashing white (#808).
+  it("follows the reader's colour scheme", () => {
+    const doc = mdToHtmlDoc("<p>x</p>", "a.md");
+    expect(doc).toContain("color-scheme:light dark");
+    expect(doc).toContain("@media(prefers-color-scheme:dark)");
+  });
+
+  // Everything is inlined on purpose: a sandboxed document fetching a stylesheet or a font
+  // would be a request the CSP has to allow, for styling that has to work offline anyway.
+  it("stays self-contained — no external stylesheet, script or font", () => {
+    const doc = mdToHtmlDoc("<p>x</p>", "a.md");
+    expect(doc).not.toContain("<link");
+    expect(doc).not.toContain("<script");
+    expect(doc).not.toMatch(/https?:\/\//);
+  });
 });

--- a/test/src/terminalFilePathLinkProvider.spec.ts
+++ b/test/src/terminalFilePathLinkProvider.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeFilePathLinks, rawFileUrl, type TerminalCell } from "../../src/composables/terminalFilePathLinkProvider";
+import { computeFilePathLinks, rawFileUrl, fileViewerRoute, type TerminalCell } from "../../src/composables/terminalFilePathLinkProvider";
 
 // Build a row of terminal cells from a string. Chars in WIDE occupy two columns (a
 // width-2 cell + a width-0 continuation cell), as xterm stores CJK / emoji glyphs.
@@ -42,5 +42,39 @@ describe("computeFilePathLinks", () => {
 describe("rawFileUrl", () => {
   it("builds a cwd-scoped raw-file URL with both params encoded", () => {
     expect(rawFileUrl("assets/a b.gif", "/Users/me/proj")).toBe("/api/files/raw?cwd=%2FUsers%2Fme%2Fproj&path=assets%2Fa%20b.gif");
+  });
+
+  // A doc is for reading: the raw route serves .md as text/plain, so clicking one used to
+  // open the source (#808). Same query shape, so only the route changes.
+  it("sends markdown to the rendering route, keeping the same params", () => {
+    expect(rawFileUrl("docs/terminal notes.md", "/Users/me/proj")).toBe("/api/files/browse/md?cwd=%2FUsers%2Fme%2Fproj&path=docs%2Fterminal%20notes.md");
+  });
+});
+
+describe("fileViewerRoute", () => {
+  it.each([".md", ".markdown"])("renders %s", (ext) => {
+    expect(fileViewerRoute(`docs/notes${ext}`)).toBe("/api/files/browse/md");
+  });
+
+  it("matches the extension case-insensitively — README.MD is still markdown", () => {
+    expect(fileViewerRoute("README.MD")).toBe("/api/files/browse/md");
+    expect(fileViewerRoute("Notes.Markdown")).toBe("/api/files/browse/md");
+  });
+
+  // Everything the raw route already serves well — images, PDFs, source files as text — must
+  // keep going there. Only a file we can present BETTER gets a different route.
+  it.each(["a.png", "a.pdf", "a.ts", "a.txt", "a.json", "a.svg", "a.html"])("leaves %s on the raw route", (file) => {
+    expect(fileViewerRoute(file)).toBe("/api/files/raw");
+  });
+
+  it("does not treat a mid-name .md or a dotfile as an extension", () => {
+    expect(fileViewerRoute("notes.md.bak")).toBe("/api/files/raw");
+    expect(fileViewerRoute("archive.md.gz")).toBe("/api/files/raw");
+    expect(fileViewerRoute(".mdrc")).toBe("/api/files/raw");
+  });
+
+  it("leaves an extensionless file alone", () => {
+    expect(fileViewerRoute("Makefile")).toBe("/api/files/raw");
+    expect(fileViewerRoute("docs/README")).toBe("/api/files/raw");
   });
 });


### PR DESCRIPTION
## Summary

ターミナル出力のファイルパスをクリックしたとき、`.md` が**生の markdown**で開いていた問題（#808）。

調べたところ**レンダリング機能はすでにアプリ内にあり、リンクの向き先だけが違っていました**:

| エンドポイント | `.md` の扱い | 使っている場所 |
| --- | --- | --- |
| `/api/files/raw` | `text/plain` = 生 md | ターミナルのファイルリンク |
| `/api/files/browse/md` | **marked でレンダ済み HTML**（sandbox CSP 付き） | Files オーバーレイのプレビュー |

クエリの形（`cwd` / `path`）も同じなので、**リンク先を切り替えるだけ**です。

## Items to Confirm / Review

- **拡張子テーブル1本で決める形にしました**（`ROUTE_BY_EXTENSION`）。「md 以外も随時足したい」という要望があるので、次の拡張子は**分岐ではなく1行**で足せます。今回入れたのは `.md` / `.markdown` のみ。
- **`@mulmoclaude/markdown-plugin` は使っていません。** 当初の発想はそれでしたが、あれは `presentDocument` の **GUI パネル用プラグイン**で、`GuiPanel.vue` が ToolResult ごとに `viewComponent` を描画する仕組みに乗っており、扱えるドキュメントは `docPath.ts` の `isDocPath` で **`artifacts/documents/*.md` に限定**されています。これは LLM が書いたパスをワークスペース外に出さないための**書き込みガード**なので、閲覧のために緩めるのは方向が逆です。売りの Marp / PDF / AI 画像補完もリポジトリのドキュメントを読む用途には重い。詳細は #808 に書きました。
- **`mdToHtmlDoc` のダーク対応**。配色がライト固定（`color:#1a1a2e`）だったので、ダークテーマのユーザーには真っ白なページが開いていました。この文書は**別タブで sandbox CSP 下**に開くためアプリのテーマを問い合わせられません。取れる唯一の信号である**読み手のシステム設定**（`color-scheme` + `prefers-color-scheme`）に従わせています。リンク・引用・表の配色も同時に入れました。
- **ベースの解決方法が2つの口で違う**点はコードにコメントを残しました。`/api/files/raw` は `authorizedServingBase`（root か稼働中セッションの cwd のみ）、`/api/files/browse/*` は `resolveBase`（絶対パスで存在するディレクトリなら可、browse 系の既存の姿勢）。ターミナルから渡す `cwd` はセッション自身の値なので、この用途では実質同じです。

## User Prompt

> http://localhost:6856/api/files/raw?cwd=…&path=docs%2Fterminal-notes.md な機能あるけど、mdなら生mdじゃなくてtextと加工済みを見たいね。@mulmoclaude/markdown-pluginを使えると良いけど。
>
> md以外でも表示できそうな拡張子あれば随時対応したいね
>
> （スコープの確認に対して）最小：リンク先を切り替え＋ダーク対応

## テスト

- `test/src/terminalFilePathLinkProvider.spec.ts` — `.md` / `.markdown` はレンダ側、**大文字小文字を区別しない**（`README.MD`）、画像 / PDF / ソース / `.txt` / `.json` / `.svg` / `.html` は**従来どおり raw**、`notes.md.bak` や `.mdrc` を拡張子と誤認しない、拡張子なしファイル。
- `test/server/files/files-browse.spec.ts` — 読み手の配色に追従すること、**外部リンク・スクリプト・フォントを読まない自己完結**であること（sandbox 下で追加のリクエストを CSP に許させないため）。
- 実装を壊すとテストが落ちることを2パターンで確認（常に raw を返す / 小文字化をやめる）。
- 稼働中の dev サーバで `/api/files/browse/md` に実際に curl し、`200 text/html` でレンダ済み HTML が返ることを確認済み（新しい CSS はそのプロセスにはまだ反映されていない＝ユニットテストで担保）。
- `yarn format` / `lint` / `build` / `typecheck` ×3 / `test`（3904 passed）実行済み。

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
