### PR TITLE
feat: render clicked .json and .csv/.tsv instead of serving the source (#808)

### DIFF
--- a/server/files/files-browse.ts
+++ b/server/files/files-browse.ts
@@ -11,34 +11,14 @@ import fs from "node:fs";
 import { marked } from "marked";
 import type { Express, Request, Response } from "express";
 import { resolveBase, containedPath, realContainedWithin } from "./pathContainment.js";
+import { htmlDoc, jsonHtmlDoc, tableHtmlDoc, delimiterForExtension } from "./renderedDoc.js";
 
 // Cap on the bytes served to the editor / accepted on write — a text editor, not a
 // blob store. Large/binary files are refused rather than streamed into a textarea.
 export const MAX_EDIT_BYTES = 2 * 1024 * 1024;
 
-// Wrap marked's HTML output in a minimal, self-contained document (served sandboxed).
-//
-// Colours follow the READER's system theme rather than the app's: this document opens in its
-// own tab under a sandbox CSP, so it cannot ask the app for its theme — and a hardcoded light
-// page is a white flash for anyone reading in the dark. `color-scheme` is what gets the
-// scrollbars and form controls to match; the media query does the rest.
-export function mdToHtmlDoc(bodyHtml: string, title: string): string {
-  const esc = (s: string) => s.replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c] ?? c);
-  const style = [
-    ":root{color-scheme:light dark}",
-    "body{max-width:48rem;margin:2rem auto;padding:0 1rem;font-family:system-ui,sans-serif;line-height:1.6;color:#1a1a2e;background:#fff}",
-    "pre{background:#f4f4f4;padding:1rem;overflow:auto}code{font-family:ui-monospace,monospace}img{max-width:100%}",
-    "a{color:#0b57d0}blockquote{margin:0;padding:0 1rem;border-left:4px solid #d0d0d8;color:#55555f}",
-    "table{border-collapse:collapse}th,td{border:1px solid #d0d0d8;padding:.25rem .5rem}",
-    "@media(prefers-color-scheme:dark){",
-    "body{color:#e6e6ea;background:#16161a}",
-    "pre{background:#232329}",
-    "a{color:#8ab4f8}blockquote{border-left-color:#3a3a44;color:#a0a0aa}",
-    "th,td{border-color:#3a3a44}",
-    "}",
-  ].join("");
-  return `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${esc(title)}</title><style>${style}</style></head><body>${bodyHtml}</body></html>`;
-}
+/** Wrap marked's HTML output in the shared self-contained document (served sandboxed). */
+export const mdToHtmlDoc = (bodyHtml: string, title: string): string => htmlDoc(bodyHtml, title);
 
 export interface BrowseEntry {
   name: string;
@@ -88,6 +68,45 @@ function containedFor(req: Request, res: Response, defaultCwd: string): string |
   return abs;
 }
 
+type RenderDoc = (text: string, title: string) => string | Promise<string>;
+
+// The file's text, or null with the response already answered. Shared by the rendered views
+// so "directory / too large / missing" reads the same from every one of them.
+function readTextOr4xx(res: Response, abs: string): string | null {
+  try {
+    const stat = fs.statSync(abs);
+    if (stat.isDirectory()) {
+      res.status(400).json({ error: "not a file" });
+      return null;
+    }
+    // The same cap as /text and /write: a huge file must not be read and parsed into memory.
+    if (stat.size > MAX_EDIT_BYTES) {
+      res.status(413).json({ error: "file too large" });
+      return null;
+    }
+    return fs.readFileSync(abs, "utf8");
+  } catch {
+    res.status(404).json({ error: "not found" });
+    return null;
+  }
+}
+
+// A rendered view (#808): read the file the same guarded way, answer with a self-contained
+// document under the sandbox CSP. Only the rendering differs between routes, so that is all
+// the caller supplies.
+function mountRenderedRoute(app: Express, routePath: string, defaultCwd: string, render: RenderDoc): void {
+  app.get(routePath, async (req, res) => {
+    const abs = containedFor(req, res, defaultCwd);
+    if (!abs) return;
+    const text = readTextOr4xx(res, abs);
+    if (text === null) return;
+    res.setHeader("Content-Type", "text/html; charset=utf-8");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Content-Security-Policy", "sandbox");
+    res.send(await render(text, path.basename(abs)));
+  });
+}
+
 export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string }): void {
   const { defaultCwd } = deps;
 
@@ -116,24 +135,12 @@ export function mountFilesBrowseRoutes(app: Express, deps: { defaultCwd: string 
     }
   });
 
-  app.get("/api/files/browse/md", async (req, res) => {
-    const abs = containedFor(req, res, defaultCwd);
-    if (!abs) return;
-    let text: string;
-    try {
-      const stat = fs.statSync(abs);
-      if (stat.isDirectory()) return res.status(400).json({ error: "not a file" });
-      // Same cap as /text and /write, so a huge file can't be read+parsed by marked.
-      if (stat.size > MAX_EDIT_BYTES) return res.status(413).json({ error: "file too large" });
-      text = fs.readFileSync(abs, "utf8");
-    } catch {
-      return res.status(404).json({ error: "not found" });
-    }
-    res.setHeader("Content-Type", "text/html; charset=utf-8");
-    res.setHeader("X-Content-Type-Options", "nosniff");
-    res.setHeader("Content-Security-Policy", "sandbox");
-    res.send(mdToHtmlDoc(await marked.parse(text), path.basename(abs)));
-  });
+  const serveRendered = (routePath: string, render: RenderDoc) => mountRenderedRoute(app, routePath, defaultCwd, render);
+
+  serveRendered("/api/files/browse/md", async (text, title) => htmlDoc(await marked.parse(text), title));
+  serveRendered("/api/files/browse/json", (text, title) => jsonHtmlDoc(text, title));
+  // The delimiter comes from the file's own extension, so one route serves .csv and .tsv.
+  serveRendered("/api/files/browse/table", (text, title) => tableHtmlDoc(text, title, delimiterForExtension(path.extname(title))));
 
   app.put("/api/files/browse/write", (req, res) => {
     const abs = containedFor(req, res, defaultCwd);

--- a/server/files/renderedDoc.ts
+++ b/server/files/renderedDoc.ts
@@ -1,0 +1,151 @@
+// The self-contained HTML documents the browse routes serve for files worth showing as
+// something other than their source (#808). Every one of them opens in its own tab under
+// `Content-Security-Policy: sandbox`, which is what shapes the rules here:
+//
+//   - no script, no external stylesheet, no webfont — a sandboxed document cannot run the
+//     first and should not need a request for the others,
+//   - colours follow the READER's system theme, since the page cannot ask the app which
+//     theme is on,
+//   - and every value taken from the file is escaped, because "the sandbox will catch it"
+//     is not a reason to emit broken markup.
+//
+// Pure: text in, HTML string out. The routes own the reading, the caps and the headers.
+
+/** HTML-escape a value that lands in text content or an attribute. */
+export const escapeHtml = (s: string): string =>
+  s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c);
+
+const STYLE = [
+  ":root{color-scheme:light dark}",
+  "body{max-width:48rem;margin:2rem auto;padding:0 1rem;font-family:system-ui,sans-serif;line-height:1.6;color:#1a1a2e;background:#fff}",
+  "pre{background:#f4f4f4;padding:1rem;overflow:auto}code{font-family:ui-monospace,monospace}img{max-width:100%}",
+  "a{color:#0b57d0}blockquote{margin:0;padding:0 1rem;border-left:4px solid #d0d0d8;color:#55555f}",
+  "table{border-collapse:collapse}th,td{border:1px solid #d0d0d8;padding:.25rem .5rem}",
+  "@media(prefers-color-scheme:dark){",
+  "body{color:#e6e6ea;background:#16161a}",
+  "pre{background:#232329}",
+  "a{color:#8ab4f8}blockquote{border-left-color:#3a3a44;color:#a0a0aa}",
+  "th,td{border-color:#3a3a44}",
+  "}",
+].join("");
+
+// A wide table has to scroll inside its own box rather than push the page sideways, and the
+// header row has to stay put while the body scrolls — both only matter for the table view,
+// so they ride with it instead of widening the shared sheet.
+const TABLE_STYLE = [
+  "body{max-width:none}",
+  ".wrap{overflow:auto;max-height:85vh}",
+  "table{font-size:13px;font-family:ui-monospace,monospace}",
+  "thead th{position:sticky;top:0;background:#fff;text-align:left}",
+  "tbody tr:nth-child(even){background:#f7f7fa}",
+  "@media(prefers-color-scheme:dark){thead th{background:#16161a}tbody tr:nth-child(even){background:#1d1d23}}",
+].join("");
+
+/** Wrap rendered body HTML in the shared document shell. */
+export function htmlDoc(bodyHtml: string, title: string, extraStyle = ""): string {
+  const head = `<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${escapeHtml(title)}</title><style>${STYLE}${extraStyle}</style>`;
+  return `<!doctype html><html><head>${head}</head><body>${bodyHtml}</body></html>`;
+}
+
+/** A JSON file, indented. Unparseable text is shown AS IT IS rather than replaced by an
+ *  error: a file that fails to parse is exactly when someone needs to look at it. */
+export function jsonHtmlDoc(text: string, title: string): string {
+  return htmlDoc(`<pre><code>${escapeHtml(prettyJson(text))}</code></pre>`, title);
+}
+
+function prettyJson(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+/** The delimiter a separated-values file uses, from its extension. */
+export const delimiterForExtension = (ext: string): string => (ext.toLowerCase() === ".tsv" ? "\t" : ",");
+
+/**
+ * Rows of a delimited file, by RFC 4180: a field may be quoted, a quoted field may contain
+ * the delimiter, a newline, or a doubled `""` standing for one quote.
+ *
+ * Hand-written rather than pulled in: the rule is small enough to state exactly, and the
+ * failure mode of a loose one is a table that silently splits a field in half — which is
+ * worse than not rendering at all, and invisible without the cases below.
+ */
+export function parseDelimited(text: string, delimiter: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let i = 0;
+  const endField = () => {
+    row.push(field);
+    field = "";
+  };
+  const endRow = () => {
+    endField();
+    rows.push(row);
+    row = [];
+  };
+  while (i < text.length) {
+    const ch = text[i];
+    // Only at the START of a field — `5" pipe` is text, not an opening quote.
+    if (ch === '"' && field === "") {
+      const quoted = readQuotedField(text, i + 1);
+      field = quoted.value;
+      i = quoted.next;
+      continue;
+    }
+    if (ch === delimiter) {
+      endField();
+      i++;
+      continue;
+    }
+    const rowBreak = rowBreakLength(text, i);
+    if (rowBreak > 0) {
+      endRow();
+      i += rowBreak;
+      continue;
+    }
+    field += ch;
+    i++;
+  }
+  // A trailing newline ends the last row rather than starting an empty one.
+  if (field !== "" || row.length > 0) endRow();
+  return rows;
+}
+
+// How many characters the row break at `i` occupies: CRLF is one break, not two.
+const rowBreakLength = (text: string, i: number): number => {
+  if (text[i] === "\r") return text[i + 1] === "\n" ? 2 : 1;
+  return text[i] === "\n" ? 1 : 0;
+};
+
+// A quoted field, scanned from just after its opening quote. `""` is one literal quote; an
+// unterminated quote takes the rest of the file rather than dropping it.
+function readQuotedField(text: string, start: number): { value: string; next: number } {
+  let value = "";
+  let i = start;
+  while (i < text.length) {
+    if (text[i] === '"') {
+      if (text[i + 1] !== '"') return { value, next: i + 1 };
+      value += '"';
+      i += 2;
+      continue;
+    }
+    value += text[i];
+    i++;
+  }
+  return { value, next: i };
+}
+
+/** A delimited file as a table, first row as the header. An empty file renders as a note,
+ *  not an empty table — "nothing here" reads better than a bare frame. */
+export function tableHtmlDoc(text: string, title: string, delimiter: string): string {
+  const rows = parseDelimited(text, delimiter);
+  if (rows.length === 0) return htmlDoc(`<p>${escapeHtml(title)} is empty.</p>`, title, TABLE_STYLE);
+  const [header, ...body] = rows;
+  const cells = (values: string[], tag: "th" | "td") => values.map((v) => `<${tag}>${escapeHtml(v)}</${tag}>`).join("");
+  const bodyRows = body.map((r) => `<tr>${cells(r, "td")}</tr>`).join("");
+  const table = `<table><thead><tr>${cells(header, "th")}</tr></thead><tbody>${bodyRows}</tbody></table>`;
+  return htmlDoc(`<div class="wrap">${table}</div>`, title, TABLE_STYLE);
+}

--- a/src/composables/terminalFilePathLinkProvider.ts
+++ b/src/composables/terminalFilePathLinkProvider.ts
@@ -54,6 +54,9 @@ export function computeFilePathLinks(cells: TerminalCell[]): ColumnLink[] {
 const ROUTE_BY_EXTENSION: Record<string, string> = {
   ".md": "/api/files/browse/md",
   ".markdown": "/api/files/browse/md",
+  ".json": "/api/files/browse/json",
+  ".csv": "/api/files/browse/table",
+  ".tsv": "/api/files/browse/table",
 };
 
 const RAW_ROUTE = "/api/files/raw";

--- a/test/server/files/renderedDoc.spec.ts
+++ b/test/server/files/renderedDoc.spec.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import { escapeHtml, htmlDoc, jsonHtmlDoc, tableHtmlDoc, parseDelimited, delimiterForExtension } from "../../../server/files/renderedDoc";
+
+describe("escapeHtml", () => {
+  it("escapes everything that can break out of text or an attribute", () => {
+    expect(escapeHtml(`<script>alert("x") & 'y'</script>`)).toBe("&lt;script&gt;alert(&quot;x&quot;) &amp; &#39;y&#39;&lt;/script&gt;");
+  });
+
+  it("leaves ordinary text alone", () => {
+    expect(escapeHtml("日本語 a-b_c 100%")).toBe("日本語 a-b_c 100%");
+  });
+});
+
+describe("htmlDoc", () => {
+  it("escapes the title and keeps the body", () => {
+    const doc = htmlDoc("<p>x</p>", "a<b>.md");
+    expect(doc).toContain("<p>x</p>");
+    expect(doc).toContain("<title>a&lt;b&gt;.md</title>");
+    expect(doc.startsWith("<!doctype html>")).toBe(true);
+  });
+
+  // The page opens in its own tab under a sandbox CSP, so it cannot ask the app which theme
+  // is on — it follows the reader's system setting instead of flashing white (#808).
+  it("follows the reader's colour scheme", () => {
+    expect(htmlDoc("", "a")).toContain("color-scheme:light dark");
+    expect(htmlDoc("", "a")).toContain("@media(prefers-color-scheme:dark)");
+  });
+
+  // A sandboxed document cannot run a script, and should not need a request for anything
+  // else either — styling has to work with no network at all.
+  it("stays self-contained — no external stylesheet, script or font", () => {
+    const doc = htmlDoc("<p>x</p>", "a");
+    expect(doc).not.toContain("<link");
+    expect(doc).not.toContain("<script");
+    expect(doc).not.toMatch(/https?:\/\//);
+  });
+});
+
+describe("jsonHtmlDoc", () => {
+  it("indents the document", () => {
+    expect(jsonHtmlDoc('{"a":1,"b":[2,3]}', "x.json")).toContain(`{\n  &quot;a&quot;: 1,\n  &quot;b&quot;: [\n    2,\n    3\n  ]\n}`);
+  });
+
+  // A file that does not parse is exactly when someone opens it to look, so it must still be
+  // shown — not replaced by an error page.
+  it("shows unparseable text as it is", () => {
+    expect(jsonHtmlDoc('{"a": oops,,}', "x.json")).toContain("{&quot;a&quot;: oops,,}");
+  });
+
+  it("escapes values rather than emitting them as markup", () => {
+    const doc = jsonHtmlDoc('{"a":"<img onerror=1>"}', "x.json");
+    expect(doc).not.toContain("<img");
+    expect(doc).toContain("&lt;img");
+  });
+
+  it("renders an empty file without throwing", () => {
+    expect(() => jsonHtmlDoc("", "x.json")).not.toThrow();
+  });
+});
+
+describe("delimiterForExtension", () => {
+  it("is a tab for .tsv and a comma otherwise", () => {
+    expect(delimiterForExtension(".tsv")).toBe("\t");
+    expect(delimiterForExtension(".TSV")).toBe("\t");
+    expect(delimiterForExtension(".csv")).toBe(",");
+    expect(delimiterForExtension("")).toBe(",");
+  });
+});
+
+describe("parseDelimited", () => {
+  it("splits plain rows and fields", () => {
+    expect(parseDelimited("a,b\n1,2", ",")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("handles CRLF as one row break", () => {
+    expect(parseDelimited("a,b\r\n1,2\r\n", ",")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("does not start an empty row on a trailing newline", () => {
+    expect(parseDelimited("a\n", ",")).toEqual([["a"]]);
+  });
+
+  // The whole reason this is not a `split(",")`: a loose parser cuts a quoted field in half
+  // and the table silently shows the wrong thing.
+  it("keeps a delimiter inside a quoted field", () => {
+    expect(parseDelimited('"a,b",c', ",")).toEqual([["a,b", "c"]]);
+  });
+
+  it("keeps a newline inside a quoted field", () => {
+    expect(parseDelimited('"line1\nline2",c', ",")).toEqual([["line1\nline2", "c"]]);
+  });
+
+  it("reads a doubled quote as one literal quote", () => {
+    expect(parseDelimited('"say ""hi""",c', ",")).toEqual([['say "hi"', "c"]]);
+  });
+
+  it("treats a quote in the middle of an unquoted field as text", () => {
+    expect(parseDelimited(`5" pipe,c`, ",")).toEqual([[`5" pipe`, "c"]]);
+  });
+
+  // Deliberate, and surprising enough to record: a quote that follows whitespace does NOT
+  // open a quoted field, so this row splits at the inner comma. That is RFC 4180, and it is
+  // what Python's `csv.reader` produces for the same input (checked against it) — matching
+  // the reference implementation matters more here than guessing at the author's intent.
+  it("does not treat a quote after leading spaces as opening a field", () => {
+    expect(parseDelimited('a,  "b,c"', ",")).toEqual([["a", '  "b', 'c"']]);
+  });
+
+  it("keeps empty fields, including a trailing one", () => {
+    expect(parseDelimited("a,,c,", ",")).toEqual([["a", "", "c", ""]]);
+  });
+
+  it("splits on tabs when that is the delimiter", () => {
+    expect(parseDelimited("a\tb\n1\t2", "\t")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("returns no rows for an empty file", () => {
+    expect(parseDelimited("", ",")).toEqual([]);
+  });
+
+  // A truncated file is exactly when someone opens the viewer, so the rest is kept rather
+  // than dropped on the floor.
+  it("takes the rest of the file when a quote is never closed", () => {
+    expect(parseDelimited('a,"unterminated', ",")).toEqual([["a", "unterminated"]]);
+  });
+
+  it("keeps rows of differing length as they are, rather than padding", () => {
+    expect(parseDelimited("a,b,c\n1,2", ",")).toEqual([
+      ["a", "b", "c"],
+      ["1", "2"],
+    ]);
+  });
+});
+
+describe("tableHtmlDoc", () => {
+  it("uses the first row as the header", () => {
+    const doc = tableHtmlDoc("name,size\na.txt,10", "x.csv", ",");
+    expect(doc).toContain("<thead><tr><th>name</th><th>size</th></tr></thead>");
+    expect(doc).toContain("<tbody><tr><td>a.txt</td><td>10</td></tr></tbody>");
+  });
+
+  it("escapes cell values", () => {
+    const doc = tableHtmlDoc('h\n"<b>x</b>"', "x.csv", ",");
+    expect(doc).not.toContain("<b>x</b>");
+    expect(doc).toContain("&lt;b&gt;x&lt;/b&gt;");
+  });
+
+  it("says so for an empty file instead of drawing an empty frame", () => {
+    const doc = tableHtmlDoc("", "x.csv", ",");
+    expect(doc).toContain("is empty");
+    expect(doc).not.toContain("<table>");
+  });
+
+  it("renders a header-only file as a table with no body rows", () => {
+    const doc = tableHtmlDoc("a,b", "x.csv", ",");
+    expect(doc).toContain("<th>a</th>");
+    expect(doc).toContain("<tbody></tbody>");
+  });
+
+  // A wide table has to scroll inside its own box; the page must not scroll sideways.
+  it("wraps the table in its own scroll container", () => {
+    expect(tableHtmlDoc("a\n1", "x.csv", ",")).toContain('<div class="wrap">');
+  });
+});

--- a/test/src/terminalFilePathLinkProvider.spec.ts
+++ b/test/src/terminalFilePathLinkProvider.spec.ts
@@ -61,9 +61,18 @@ describe("fileViewerRoute", () => {
     expect(fileViewerRoute("Notes.Markdown")).toBe("/api/files/browse/md");
   });
 
+  it("indents JSON instead of serving it as one line", () => {
+    expect(fileViewerRoute("package.json")).toBe("/api/files/browse/json");
+  });
+
+  // One route, because the delimiter comes from the file's own extension.
+  it.each([".csv", ".tsv"])("renders %s as a table", (ext) => {
+    expect(fileViewerRoute(`data/rows${ext}`)).toBe("/api/files/browse/table");
+  });
+
   // Everything the raw route already serves well — images, PDFs, source files as text — must
   // keep going there. Only a file we can present BETTER gets a different route.
-  it.each(["a.png", "a.pdf", "a.ts", "a.txt", "a.json", "a.svg", "a.html"])("leaves %s on the raw route", (file) => {
+  it.each(["a.png", "a.pdf", "a.ts", "a.txt", "a.svg", "a.html", "a.yaml"])("leaves %s on the raw route", (file) => {
     expect(fileViewerRoute(file)).toBe("/api/files/raw");
   });
 


### PR DESCRIPTION
## Summary

#808 の拡張子ロードマップのうち、**小（`.json`）と 小〜中（`.csv` / `.tsv`）** を実装しました。#809 で入れた markdown ルートの続きです。

| 拡張子 | 表示 |
| --- | --- |
| `.json` | インデント整形（Chrome / Safari は生 JSON を1行で表示するので実益あり） |
| `.csv` / `.tsv` | **表**。ヘッダ行は sticky、横に広い表は自分のボックス内でスクロール（ページは横スクロールしない） |

依存追加はありません。

## Items to Confirm / Review

- **CSV パーサを手書きした判断**。RFC 4180 の規則（クォート、`""`、フィールド内の区切り文字と改行、CRLF）は正確に書き切れる程度に小さく、一方で**緩いパーサはフィールドを黙って半分に割る**（誰も気づかない誤った表になる）ので、外部依存を足すより自前で書いてテストで固めました。
  **出力を Python の `csv.reader` と突き合わせて一致を確認しています。** 特に「**空白に続くクォートは引用フィールドを開かない**」という驚きのある挙動（RFC どおり）が両者で一致することをテストにピン留めしました。参照実装と一致していることの方が、作者の意図を推測するより確かだという判断です。
- **壊れた入力を隠さない**方針。パースできない JSON と閉じられていないクォートは、**エラーページに差し替えず中身をそのまま出します**（そういうファイルこそビューアを開くので）。
- **共有シェルの抽出**。ドキュメントの外枠（自己完結・ダーク対応・エスケープ）を `server/files/renderedDoc.ts` に集約し、`mdToHtmlDoc` もそこを通します。3つのビューが styling でズレないようにするためです。
- ルートは `mountRenderedRoute` 1本に集約（読み込み・サイズ上限・sandbox ヘッダは全部同じで、違うのはレンダリングだけ）。lint の関数長・認知的複雑度に引っかかったので `readTextOr4xx` と `readQuotedField` / `rowBreakLength` に分割してあります。
- `.csv` と `.tsv` は**1つのルート**（`/browse/table`）。区切り文字はファイル自身の拡張子から決まるため。

## User Prompt

> md以外でも表示できそうな拡張子あれば随時対応したいね
>
> 808の小、中までは対応しよう

**中（ソースのシンタックスハイライト）は別途相談させてください** — 依存追加なしでやるなら「アプリ内 Files ビューで開く」（CodeMirror のハイライトは既に動いている）になり、新タブを維持するなら**ハイライタの依存追加**が必要で、UX の判断が要るためです。`.rst` / `.adoc` も同様に新規依存が要るので保留しています。

## テスト

- `test/server/files/renderedDoc.spec.ts`（新規28ケース）— エスケープ、共有シェル（配色追従・**外部リソースを読まない自己完結**）、JSON（整形 / 壊れた入力 / 値のエスケープ / 空ファイル）、区切り文字の決定、**パーサ13ケース**（引用内の区切り文字・改行、`""`、非引用フィールド中のクォート、空フィールド、CRLF、末尾改行、タブ、空ファイル、行長の不揃い、閉じられていないクォート、空白後のクォート）、表（ヘッダ、エスケープ、空ファイル、ヘッダのみ、スクロール容器）
- `test/src/terminalFilePathLinkProvider.spec.ts` — `.json` / `.csv` / `.tsv` の行き先、他は従来どおり raw
- 実装を壊すとテストが落ちることを2パターンで確認（引用モードを無効化 / 末尾行の条件を外す）
- `yarn format` / `lint` / `build` / `typecheck` ×3 / `test`（3935 passed）/ `knip` 実行済み

#808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
