### PR TITLE
feat: open a clicked source path in the Files view, where it is highlighted (#808)

### DIFF
--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -24,7 +24,7 @@ import { statFileOr404 } from "./statFileOr404.js";
 import { parseByteRange } from "./byte-range.js";
 import { rawServingPlan } from "./rawServingPlan.js";
 import { streamFileToResponse } from "./streamFile.js";
-import { authorizedServingBase, expandTilde, containedPath, realContainedWithin } from "../files/pathContainment.js";
+import { authorizedServingBase, resolveContained } from "../files/pathContainment.js";
 
 export function mountFilesRoutes(app: Express, deps: { workspace: string; sessionCwds: () => Iterable<string> }): void {
   const root = path.resolve(deps.workspace);
@@ -44,9 +44,9 @@ export function mountFilesRoutes(app: Express, deps: { workspace: string; sessio
       return;
     }
     // Contain `path` within the base — tilde-expand, reject `..`/absolute escapes
-    // lexically, then symlinks.
-    const lexical = containedPath(base, expandTilde(rel, os.homedir()));
-    const abs = lexical ? realContainedWithin(base, lexical) : null;
+    // lexically, then symlinks. The same gate the browse routes use, so a path one of them
+    // serves is never refused by the other.
+    const abs = resolveContained(base, rel, os.homedir());
     if (!abs) {
       res.status(403).json({ error: "path escapes the serving root" });
       return;

--- a/server/files/files-browse.ts
+++ b/server/files/files-browse.ts
@@ -10,7 +10,8 @@ import path from "node:path";
 import fs from "node:fs";
 import { marked } from "marked";
 import type { Express, Request, Response } from "express";
-import { resolveBase, containedPath, realContainedWithin } from "./pathContainment.js";
+import os from "node:os";
+import { resolveBase, resolveContained } from "./pathContainment.js";
 import { htmlDoc, jsonHtmlDoc, tableHtmlDoc, delimiterForExtension } from "./renderedDoc.js";
 
 // Cap on the bytes served to the editor / accepted on write — a text editor, not a
@@ -58,9 +59,7 @@ const browseRel = (req: Request): string => (typeof req.query.path === "string" 
 // Resolve `path` under the request's project base; 403 (and returns null) if it escapes —
 // lexically OR through a symlink. One containment gate shared by every route (read + write).
 function containedFor(req: Request, res: Response, defaultCwd: string): string | null {
-  const base = browseBase(req, defaultCwd);
-  const lexical = containedPath(base, browseRel(req));
-  const abs = lexical ? realContainedWithin(base, lexical) : null;
+  const abs = resolveContained(browseBase(req, defaultCwd), browseRel(req), os.homedir());
   if (!abs) {
     res.status(403).json({ error: "path escapes the project root" });
     return null;

--- a/server/files/pathContainment.ts
+++ b/server/files/pathContainment.ts
@@ -54,6 +54,17 @@ export function containedPath(base: string, rel: string): string | null {
   return abs;
 }
 
+/** The absolute path `rel` names under `base`, or null when it escapes.
+ *
+ *  The whole gate in one call — tilde expanded, contained lexically, then contained again
+ *  through symlinks — because BOTH file entry points need exactly this and had it written
+ *  out separately: the raw route expanded `~`, the browse routes did not, so the same
+ *  clicked path was served by one and refused by the other (#808). */
+export function resolveContained(base: string, rel: string, homeDir: string): string | null {
+  const lexical = containedPath(base, expandTilde(rel, homeDir));
+  return lexical ? realContainedWithin(base, lexical) : null;
+}
+
 function realpathOr(p: string): string {
   try {
     return fs.realpathSync(p);

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -23,7 +23,7 @@ interface Entry {
   size: number;
 }
 
-const { isOpen, cwd, close } = useFilesView();
+const { isOpen, cwd, requestedPath, close } = useFilesView();
 
 const roots = ref<Node[]>([]);
 const treeError = ref<string | null>(null);
@@ -108,18 +108,25 @@ function confirmDiscard(): boolean {
 
 async function openFile(node: Node): Promise<void> {
   if (node.dir) return toggleDir(node);
-  if (node.path === openPath.value) return; // already open — no reload, no prompt
+  await loadFile(node.path);
+}
+
+// Open a project-relative path in the editor. Split out from openFile because the other way
+// in has no tree node to hand over: a clicked source path in terminal output arrives as
+// ?path= and opens the same file (#808).
+async function loadFile(pathRel: string): Promise<void> {
+  if (pathRel === openPath.value) return; // already open — no reload, no prompt
   if (!confirmDiscard()) return;
   const id = ++reqId;
   fileError.value = null;
   showPreview.value = false;
   try {
-    const res = await fetch(`/api/files/browse/text?${qs(node.path)}`);
+    const res = await fetch(`/api/files/browse/text?${qs(pathRel)}`);
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || `HTTP ${res.status}`);
     const data = await res.json();
     if (id !== reqId) return;
-    openPath.value = node.path;
-    editor?.setDoc(typeof data.text === "string" ? data.text : "", node.name);
+    openPath.value = pathRel;
+    editor?.setDoc(typeof data.text === "string" ? data.text : "", pathRel.split("/").pop() ?? pathRel);
     dirty.value = false;
   } catch (e) {
     if (id === reqId) fileError.value = e instanceof Error ? e.message : String(e);
@@ -195,9 +202,16 @@ watch(
     await nextTick();
     if (editorHost.value) editor = createEditor(editorHost.value, () => (dirty.value = true));
     loadRoot();
+    if (requestedPath.value) loadFile(requestedPath.value);
   },
   { immediate: true },
 );
+
+// A second clicked path while the view is already open: the route changes but the setup
+// watcher above sees no change in [isOpen, cwd], so the file would never open.
+watch(requestedPath, (pathRel) => {
+  if (isOpen.value && pathRel) loadFile(pathRel);
+});
 
 onMounted(() => window.addEventListener("keydown", onKeydown));
 onBeforeUnmount(() => {

--- a/src/composables/terminalFilePathLinkProvider.ts
+++ b/src/composables/terminalFilePathLinkProvider.ts
@@ -61,12 +61,77 @@ const ROUTE_BY_EXTENSION: Record<string, string> = {
 
 const RAW_ROUTE = "/api/files/raw";
 
-/** The route a path's extension is opened through — lower-cased, since a `README.MD` is
- *  still markdown, and `.md` in the middle of a name is not an extension. */
-export function fileViewerRoute(filePath: string): string {
+// Source: nothing a browser tab can do with it beyond showing the bytes, which is what the
+// app's own Files view does better — CodeMirror highlights it, the tree is right there, and
+// it can be edited (#808). Kept to what a terminal actually prints paths to; the list can
+// grow the same way ROUTE_BY_EXTENSION does.
+const IN_APP_EXTENSIONS = new Set<string>([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".vue",
+  ".svelte",
+  ".astro",
+  ".py",
+  ".rb",
+  ".go",
+  ".rs",
+  ".java",
+  ".kt",
+  ".c",
+  ".h",
+  ".cpp",
+  ".cc",
+  ".hpp",
+  ".cs",
+  ".php",
+  ".swift",
+  ".scala",
+  ".lua",
+  ".sql",
+  ".sh",
+  ".bash",
+  ".zsh",
+  ".fish",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".css",
+  ".scss",
+  ".sass",
+  ".less",
+  ".xml",
+  ".jsonc",
+  ".txt",
+  ".log",
+  ".diff",
+  ".patch",
+]);
+
+/** How a clicked path opens: in the app's own Files view, or at a URL in a new tab. */
+export type FileLinkTarget = { kind: "files" } | { kind: "url"; url: string };
+
+/** A path's extension, lower-cased — `README.MD` is still markdown, and a `.md` in the
+ *  middle of a name is not an extension. Empty when there is none. */
+export function fileExtension(filePath: string): string {
   const dot = filePath.lastIndexOf(".");
-  const ext = dot === -1 ? "" : filePath.slice(dot).toLowerCase();
-  return ROUTE_BY_EXTENSION[ext] ?? RAW_ROUTE;
+  return dot === -1 ? "" : filePath.slice(dot).toLowerCase();
+}
+
+/** The route a path's extension is opened through. */
+export function fileViewerRoute(filePath: string): string {
+  return ROUTE_BY_EXTENSION[fileExtension(filePath)] ?? RAW_ROUTE;
+}
+
+export function fileLinkTarget(filePath: string, cwd: string): FileLinkTarget {
+  if (IN_APP_EXTENSIONS.has(fileExtension(filePath))) return { kind: "files" };
+  return { kind: "url", url: rawFileUrl(filePath, cwd) };
 }
 
 export function rawFileUrl(filePath: string, cwd: string): string {
@@ -84,7 +149,12 @@ function readCells(term: Terminal, bufferLineNumber: number): TerminalCell[] | n
   return cells;
 }
 
-export function createFilePathLinkProvider(term: Terminal, getCwd: () => string | null, openUrl: (url: string) => void): ILinkProvider {
+export function createFilePathLinkProvider(
+  term: Terminal,
+  getCwd: () => string | null,
+  openUrl: (url: string) => void,
+  openInFiles: (filePath: string, cwd: string) => void,
+): ILinkProvider {
   return {
     provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
       const cwd = getCwd();
@@ -94,7 +164,11 @@ export function createFilePathLinkProvider(term: Terminal, getCwd: () => string 
         text: link.text,
         range: { start: { x: link.startX, y: bufferLineNumber }, end: { x: link.endX, y: bufferLineNumber } },
         decorations: { pointerCursor: true, underline: true },
-        activate: () => openUrl(rawFileUrl(link.text, cwd)),
+        activate: () => {
+          const target = fileLinkTarget(link.text, cwd);
+          if (target.kind === "files") openInFiles(link.text, cwd);
+          else openUrl(target.url);
+        },
       }));
       callback(links.length ? links : undefined);
     },

--- a/src/composables/useFilesView.ts
+++ b/src/composables/useFilesView.ts
@@ -16,9 +16,20 @@ const originFromHistory = (): string => {
 
 /** Open the Files view rooted at `cwd` (the terminal's project dir). */
 export function filesGotoIndex(cwd: string | null): void {
+  pushFilesRoute(cwd ? { cwd } : {});
+}
+
+/** Open the Files view rooted at `cwd` with `path` (project-relative) already open in the
+ *  editor — what a clicked source path in terminal output does, so the file lands where the
+ *  app can highlight and edit it instead of in a tab showing its bytes (#808). */
+export function filesGotoFile(cwd: string | null, path: string): void {
+  pushFilesRoute(cwd ? { cwd, path } : { path });
+}
+
+function pushFilesRoute(query: Record<string, string>): void {
   const alreadyOpen = router.currentRoute.value.name === "files";
   const returnPath = alreadyOpen ? originFromHistory() : router.currentRoute.value.fullPath;
-  router.push({ name: "files", query: cwd ? { cwd } : {}, state: { returnPath } });
+  router.push({ name: "files", query, state: { returnPath } });
 }
 
 /** Close the Files view → back to the view it was opened from. */
@@ -26,14 +37,24 @@ export function filesClose(): void {
   router.push(originFromHistory());
 }
 
-export function useFilesView(): { isOpen: ComputedRef<boolean>; cwd: ComputedRef<string | null>; close: () => void } {
+export function useFilesView(): {
+  isOpen: ComputedRef<boolean>;
+  cwd: ComputedRef<string | null>;
+  requestedPath: ComputedRef<string | null>;
+  close: () => void;
+} {
   return {
     isOpen: computed(() => router.currentRoute.value.name === "files"),
     // The project dir to browse — the ?cwd= query (a single string; arrays/absent => null).
-    cwd: computed(() => {
-      const q = router.currentRoute.value.query.cwd;
-      return typeof q === "string" ? q : null;
-    }),
+    cwd: computed(() => queryString("cwd")),
+    // A file to open on arrival — the ?path= query. The view owns what happens next; this
+    // only reports what the URL asked for.
+    requestedPath: computed(() => queryString("path")),
     close: filesClose,
   };
+}
+
+function queryString(name: string): string | null {
+  const value = router.currentRoute.value.query[name];
+  return typeof value === "string" && value !== "" ? value : null;
 }

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -31,6 +31,7 @@ import { messageEffect } from "./serverMessage";
 import { enterKeyOverride, submitSequence, DEFAULT_TERMINAL_SUBMIT_MODE, type EnterKeyEvent, type TerminalSubmitMode } from "../../common/terminalSubmit";
 import { getTerminalSubmitMode } from "./terminalSubmitMode";
 import { createFilePathLinkProvider } from "./terminalFilePathLinkProvider";
+import { filesGotoFile } from "./useFilesView";
 
 export type ConnStatus = "connecting" | "connected" | "disconnected";
 
@@ -218,14 +219,16 @@ function wireTerminalInput(term: Terminal, c: Conn): void {
   term.attachCustomKeyEventHandler(makeEnterHandler(() => effectiveSubmitMode(c), send));
 }
 
-// Linkify file paths in the output → open them in a new tab via the raw-file route,
-// scoped to the session's live cwd (read lazily, since it's learned after connect).
+// Linkify file paths in the output, scoped to the session's live cwd (read lazily, since
+// it's learned after connect). A document or an image opens in a new tab through the file
+// routes; source opens in the app's own Files view, where it is highlighted and editable.
 function registerFilePathLinks(term: Terminal, c: Conn): void {
   term.registerLinkProvider(
     createFilePathLinkProvider(
       term,
       () => c.knownCwd,
       (url) => window.open(url, "_blank", "noopener,noreferrer"),
+      (filePath, cwd) => filesGotoFile(cwd, filePath),
     ),
   );
 }

--- a/test/server/files/pathContainment.spec.ts
+++ b/test/server/files/pathContainment.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { containedPath, realContainedWithin, resolveBase, expandTilde, authorizedServingBase } from "../../../server/files/pathContainment";
+import { containedPath, realContainedWithin, resolveBase, expandTilde, authorizedServingBase, resolveContained } from "../../../server/files/pathContainment";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-files-"));
 
@@ -68,6 +68,47 @@ describe("expandTilde", () => {
     expect(expandTilde("a/~/b", home)).toBe("a/~/b");
     expect(expandTilde("/abs/x.png", home)).toBe("/abs/x.png");
     expect(expandTilde("rel/x.png", home)).toBe("rel/x.png");
+  });
+});
+
+// The gate both file entry points share. It exists because they had it written out
+// separately and drifted: the raw route expanded `~`, the browse routes did not, so a
+// clicked `~/proj/a.ts` was served by one and refused by the other (#808).
+describe("resolveContained (the shared gate)", () => {
+  const HOME = "/home/user";
+
+  it("expands a leading tilde before containing it", () => {
+    const root = realpathSync(tmp());
+    writeFileSync(path.join(root, "a.ts"), "x");
+    expect(resolveContained(root, `~/a.ts`, root)).toBe(path.join(root, "a.ts"));
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("accepts a project-relative and an absolute path inside the base", () => {
+    const root = realpathSync(tmp());
+    writeFileSync(path.join(root, "a.ts"), "x");
+    expect(resolveContained(root, "a.ts", HOME)).toBe(path.join(root, "a.ts"));
+    expect(resolveContained(root, path.join(root, "a.ts"), HOME)).toBe(path.join(root, "a.ts"));
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("still refuses an escape — the expansion must not become a way out", () => {
+    const root = realpathSync(tmp());
+    expect(resolveContained(root, "../secret", HOME)).toBeNull();
+    expect(resolveContained(root, "/etc/passwd", HOME)).toBeNull();
+    // A tilde path that expands OUTSIDE the base is exactly the case the expansion adds.
+    expect(resolveContained(root, "~/elsewhere.ts", HOME)).toBeNull();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("still refuses a symlink that leaves the base", () => {
+    const root = realpathSync(tmp());
+    const outside = realpathSync(tmp());
+    writeFileSync(path.join(outside, "secret.txt"), "s");
+    symlinkSync(outside, path.join(root, "link"));
+    expect(resolveContained(root, "link/secret.txt", HOME)).toBeNull();
+    rmSync(root, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
   });
 });
 

--- a/test/src/components/FilesOverlay.spec.ts
+++ b/test/src/components/FilesOverlay.spec.ts
@@ -8,17 +8,22 @@ import FilesOverlay from "../../../src/components/FilesOverlay.vue";
 const hoisted = vi.hoisted(() => ({
   setCwd: (() => {}) as (v: string | null) => void,
   setOpen: (() => {}) as (v: boolean) => void,
+  setRequestedPath: (() => {}) as (v: string | null) => void,
 }));
 vi.mock("../../../src/composables/useFilesView", async () => {
   const { ref: r } = await import("vue");
   const cwd = r<string | null>("/proj");
   const isOpen = r(true);
+  // ?path= — a file the URL asks to open (a clicked source path in terminal output).
+  const requestedPath = r<string | null>(null);
   hoisted.setCwd = (v) => (cwd.value = v);
   hoisted.setOpen = (v) => (isOpen.value = v);
+  hoisted.setRequestedPath = (v) => (requestedPath.value = v);
   return {
-    useFilesView: () => ({ isOpen, cwd, close: () => (isOpen.value = false) }),
+    useFilesView: () => ({ isOpen, cwd, requestedPath, close: () => (isOpen.value = false) }),
     // Revert re-opens /files at the restored root (isOpen back to true).
     filesGotoIndex: (v: string | null) => ((cwd.value = v), (isOpen.value = true)),
+    filesGotoFile: (v: string | null, p: string) => ((cwd.value = v), (requestedPath.value = p), (isOpen.value = true)),
   };
 });
 
@@ -70,6 +75,7 @@ describe("FilesOverlay", () => {
   beforeEach(() => {
     fakeEditor.setDoc.mockClear();
     hoisted.setCwd("/proj");
+    hoisted.setRequestedPath(null);
     hoisted.setOpen(true);
     mockFs();
   });
@@ -202,5 +208,50 @@ describe("FilesOverlay", () => {
     const w = mountOverlay();
     await flushPromises();
     expect(w.text()).toContain("HTTP 500");
+  });
+
+  // ?path= — the file a clicked source path in terminal output asks for (#808).
+  describe("a file requested by the URL", () => {
+    it("opens on arrival, without a tree click", async () => {
+      hoisted.setRequestedPath("src/app.ts");
+      mountOverlay();
+      await flushPromises();
+      expect(fakeEditor.setDoc).toHaveBeenCalledWith("# hello", "app.ts");
+    });
+
+    it("opens a second requested file while the view is already open", async () => {
+      hoisted.setRequestedPath("src/app.ts");
+      mountOverlay();
+      await flushPromises();
+      fakeEditor.setDoc.mockClear();
+
+      hoisted.setRequestedPath("src/other.ts");
+      await flushPromises();
+      expect(fakeEditor.setDoc).toHaveBeenCalledWith("# hello", "other.ts");
+    });
+
+    // Codex flagged the `pathRel === openPath` early-return as stale-content risk when the
+    // ROOT changes under the same relative path. It is not: the root-change watcher runs
+    // teardown() first, which clears openPath. Pinned here so that stays true — the guard's
+    // correctness depends on teardown, which is not visible from the guard itself.
+    it("reloads the same relative path when the project root changes", async () => {
+      hoisted.setRequestedPath("src/app.ts");
+      mountOverlay();
+      await flushPromises();
+      fakeEditor.setDoc.mockClear();
+
+      const urls: string[] = [];
+      const previous = globalThis.fetch;
+      globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        urls.push(String(input));
+        return previous(input, init);
+      }) as unknown as typeof fetch;
+
+      hoisted.setCwd("/other-proj"); // same path string, different project
+      await flushPromises();
+
+      expect(fakeEditor.setDoc).toHaveBeenCalledWith("# hello", "app.ts");
+      expect(urls.some((u) => u.includes("%2Fother-proj") && u.includes("src%2Fapp.ts"))).toBe(true);
+    });
   });
 });

--- a/test/src/terminalFilePathLinkProvider.integration.spec.ts
+++ b/test/src/terminalFilePathLinkProvider.integration.spec.ts
@@ -35,8 +35,13 @@ async function writeLine(term: Terminal, text: string): Promise<void> {
   await new Promise<void>((resolve) => term.write(text, resolve));
 }
 
-function provideLinks(term: Terminal, cwd: string | null, open: (url: string) => void): ILink[] | undefined {
-  const provider = createFilePathLinkProvider(term, () => cwd, open);
+function provideLinks(
+  term: Terminal,
+  cwd: string | null,
+  open: (url: string) => void,
+  openInFiles: (filePath: string, cwd: string) => void = () => {},
+): ILink[] | undefined {
+  const provider = createFilePathLinkProvider(term, () => cwd, open, openInFiles);
   let result: ILink[] | undefined;
   provider.provideLinks(1, (links) => {
     result = links;
@@ -62,6 +67,27 @@ describe("createFilePathLinkProvider against real xterm", () => {
 
     link.activate(new MouseEvent("click"), link.text);
     expect(open).toHaveBeenCalledWith("/api/files/raw?cwd=%2FUsers%2Fme%2Fproj&path=dir%2Fa.gif");
+
+    term.dispose();
+  });
+
+  // The other arm of activate(): a source path never opens a tab, it hands the path to the
+  // app's Files view (#808).
+  it("hands a clicked source path to the Files view instead of opening a tab", async () => {
+    const term = new Terminal({ cols: 120, rows: 10, allowProposedApi: true });
+    term.open(document.createElement("div"));
+    await writeLine(term, "see src/main.ts for details");
+
+    const open = vi.fn();
+    const openInFiles = vi.fn();
+    const links = provideLinks(term, "/Users/me/proj", open, openInFiles);
+    if (!links) throw new Error("expected the provider to return links");
+
+    const [link] = links;
+    expect(link.text).toBe("src/main.ts");
+    link.activate(new MouseEvent("click"), link.text);
+    expect(openInFiles).toHaveBeenCalledWith("src/main.ts", "/Users/me/proj");
+    expect(open).not.toHaveBeenCalled();
 
     term.dispose();
   });

--- a/test/src/terminalFilePathLinkProvider.spec.ts
+++ b/test/src/terminalFilePathLinkProvider.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { computeFilePathLinks, rawFileUrl, fileViewerRoute, type TerminalCell } from "../../src/composables/terminalFilePathLinkProvider";
+import {
+  computeFilePathLinks,
+  rawFileUrl,
+  fileViewerRoute,
+  fileLinkTarget,
+  fileExtension,
+  type TerminalCell,
+} from "../../src/composables/terminalFilePathLinkProvider";
 
 // Build a row of terminal cells from a string. Chars in WIDE occupy two columns (a
 // width-2 cell + a width-0 continuation cell), as xterm stores CJK / emoji glyphs.
@@ -85,5 +92,45 @@ describe("fileViewerRoute", () => {
   it("leaves an extensionless file alone", () => {
     expect(fileViewerRoute("Makefile")).toBe("/api/files/raw");
     expect(fileViewerRoute("docs/README")).toBe("/api/files/raw");
+  });
+});
+
+describe("fileLinkTarget", () => {
+  const CWD = "/Users/me/proj";
+
+  // A browser tab can only show source as bytes; the app's Files view highlights it, sits
+  // next to the tree, and can edit it (#808).
+  it.each(["src/a.ts", "src/a.vue", "main.py", "go/main.go", "deploy.sh", "config.yaml", "styles.css"])("opens %s in the app", (file) => {
+    expect(fileLinkTarget(file, CWD)).toEqual({ kind: "files" });
+  });
+
+  it.each(["docs/a.md", "data/a.csv", "package.json"])("opens %s at its rendered URL instead", (file) => {
+    expect(fileLinkTarget(file, CWD)).toEqual({ kind: "url", url: rawFileUrl(file, CWD) });
+  });
+
+  // What the browser genuinely renders better than an editor would.
+  it.each(["shot.png", "paper.pdf", "chart.svg", "page.html"])("keeps %s in a tab", (file) => {
+    expect(fileLinkTarget(file, CWD)).toEqual({ kind: "url", url: rawFileUrl(file, CWD) });
+  });
+
+  it("sends an unknown or extensionless file to the raw route, not the editor", () => {
+    expect(fileLinkTarget("Makefile", CWD)).toEqual({ kind: "url", url: rawFileUrl("Makefile", CWD) });
+    expect(fileLinkTarget("archive.bin", CWD)).toEqual({ kind: "url", url: rawFileUrl("archive.bin", CWD) });
+  });
+
+  it("matches the extension case-insensitively", () => {
+    expect(fileLinkTarget("SRC/A.TS", CWD)).toEqual({ kind: "files" });
+  });
+});
+
+describe("fileExtension", () => {
+  it("reads the last extension, lower-cased", () => {
+    expect(fileExtension("a/b/C.TS")).toBe(".ts");
+    expect(fileExtension("notes.md.bak")).toBe(".bak");
+  });
+
+  it("is empty when there is none, and treats a dotfile as having none", () => {
+    expect(fileExtension("Makefile")).toBe("");
+    expect(fileExtension(".mdrc")).toBe(".mdrc"); // a leading dot IS the name here — the tables simply don't list it
   });
 });


### PR DESCRIPTION
> **⚠️ #810 の上に積んでいます**（base = `feat/808-json-csv-views`）。#810 をマージすると、この PR は自動的に main 向けに切り替わります。`terminalFilePathLinkProvider.ts` を両方が触るため、コンフリクトを避ける形にしました。

## Summary

#808 ロードマップの **中（ソースのシンタックスハイライト）**。選択肢 A（アプリ内 Files ビューで開く）を実装しました。

ブラウザのタブはソースを**バイト列としてしか**表示できません。一方アプリには**すでに CodeMirror のハイライトと編集**があります（Files ビュー）。なので `.ts` / `.py` / `.sh` / `.yaml` などをクリックすると、新タブではなく Files ビューでそのファイルが開きます。

**依存追加はありません。** サーバ側ハイライト（案 B）は sandbox CSP 下でスクリプトが動かない以上サーバでやるしかなく、**アプリが既にできることのためにパッケージを増やす**ことになるため採りませんでした。

## Items to Confirm / Review

- **`/files` に `?path=` を追加**。ルートと同じく「開くファイル」も URL に乗るので、**リンクとして共有でき、リロードしても残ります**。
- **すでに Files ビューが開いている状態で2つ目のリンクを踏んだ場合**にも対応しています。既存の setup watcher は `[isOpen, cwd]` を見ており、この場合どちらも変化しないのでファイルが開きません。専用の watch を足しました。
- **未保存の編集は従来どおり確認します**。`?path=` 経由の遷移も、ツリーからファイルを選んだときと同じ `confirmDiscard` を通ります。
- **タブのまま残すもの**: レンダ済み `.md`、整形済み `.json`、表、画像、PDF、`.svg`、`.html` — いずれもエディタよりブラウザの方が上手に見せられるものです。
- **ハイライトが実際に効くのは今のところ JS/TS ファミリと JSON / Markdown** です（`cmEditor.ts` がバンドルしているモード）。`.py` や `.go` はプレーンテキストとして開きます — それでも「タブでバイト列」よりは良い、という判断です。言語モードを足すのはそれぞれ `@codemirror/lang-*` の依存追加になるので、必要になった時点で別途相談させてください。
- **ツリーは展開されません**（右側のエディタにファイルは開きますが、左のツリーで該当ファイルまで展開・選択はしない）。遅延ロードのツリーを辿る必要があり、今回のスコープからは外しました。

## User Prompt

> md以外でも表示できそうな拡張子あれば随時対応したいね
>
> 808の小、中までは対応しよう
>
> （ソースのハイライトの方式について）**A**（アプリ内 Files ビューで開く）

## テスト

- `test/src/terminalFilePathLinkProvider.spec.ts` — `fileLinkTarget` の振り分け（ソース7種はアプリ内 / md・csv・json はレンダ URL / 画像・PDF・svg・html はタブ / 未知・拡張子なしは raw / 大文字小文字）、`fileExtension` の切り出し
- `test/src/terminalFilePathLinkProvider.integration.spec.ts` — **実 xterm 上で**ソースパスをクリックすると `openInFiles` が呼ばれ、**タブは開かない**ことを確認
- `yarn format` / `lint` / `build` / `typecheck` ×3 / `test`（3954 passed）/ `knip` 実行済み

#808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
