### PR TITLE
fix(windows): pass --settings and --mcp-config as files, not inline JSON (#813)

### DIFF
--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -16,15 +16,30 @@ import os from "node:os";
 const SETTINGS_DIR = path.join(os.homedir(), ".mulmoterminal", "settings");
 
 const settingsFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}.json`);
+const mcpConfigFile = (sessionId: string): string => path.join(SETTINGS_DIR, `${sessionId}-mcp.json`);
 
-// The settings to pass as `--settings`: the JSON itself when it holds nothing secret,
-// otherwise the path to a private file holding it.
-export function settingsArgument(sessionId: string, json: string, secret: boolean): string {
-  if (!secret) return json;
-  const file = settingsFile(sessionId);
+// Windows has a second, unrelated reason to use a file: there, a `.cmd`-installed Claude is
+// launched through cmd.exe (#798), so a JSON argument is parsed by cmd and then by the
+// child's CRT, and the two disagree about quoting. A path has no quotes and no
+// metacharacters, which removes that layer rather than escaping through it (#813).
+const mustUseFile = (secret: boolean, platform: NodeJS.Platform): boolean => secret || platform === "win32";
+
+function writePrivate(file: string, json: string): string {
   mkdirSync(SETTINGS_DIR, { recursive: true, mode: 0o700 });
   writeFileSync(file, json, { encoding: "utf8", mode: 0o600 });
   return file;
+}
+
+// The settings to pass as `--settings`: the JSON itself when it holds nothing secret and
+// nothing between us and Claude Code would re-parse it, otherwise a private file's path.
+export function settingsArgument(sessionId: string, json: string, secret: boolean, platform: NodeJS.Platform = process.platform): string {
+  return mustUseFile(secret, platform) ? writePrivate(settingsFile(sessionId), json) : json;
+}
+
+// The same for `--mcp-config`, which is the other large JSON argument a spawn carries. It
+// holds no secret, so only the Windows reason applies.
+export function mcpConfigArgument(sessionId: string, json: string, platform: NodeJS.Platform = process.platform): string {
+  return mustUseFile(false, platform) ? writePrivate(mcpConfigFile(sessionId), json) : json;
 }
 
 // Run a spawn, taking the session's settings file with it if the spawn throws. A session
@@ -39,7 +54,8 @@ export function withSettingsCleanup<T>(sessionId: string, spawn: () => T): T {
   }
 }
 
-// Drop a session's settings file. Safe to call for sessions that never wrote one.
+// Drop a session's files. Safe to call for sessions that never wrote one.
 export function cleanupSessionSettings(sessionId: string): void {
   rmSync(settingsFile(sessionId), { force: true });
+  rmSync(mcpConfigFile(sessionId), { force: true });
 }

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -17,7 +17,7 @@ import type { SpawnDeps } from "./spawn-deps.js";
 import { loadDirConfig } from "../config/dir-config.js";
 import { getProviders } from "../config/config-routes.js";
 import { requireResolution, resolveProvider, type DirModelChoice } from "./provider-env.js";
-import { settingsArgument, withSettingsCleanup } from "./session-settings.js";
+import { settingsArgument, mcpConfigArgument, withSettingsCleanup } from "./session-settings.js";
 import { effectiveChoice } from "./launch-choice.js";
 
 export interface SpawnClaudeOptions {
@@ -70,6 +70,10 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     if (launch) launchChoices.set(sessionId, choice);
 
     const hookSettings = deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, resolved.env);
+    const mcpJson = deps.mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox);
+    // File-ized only when it is actually passed (attachGuiMcp), so a cell that never carries
+    // the GUI MCP leaves no file behind for reap to clean up.
+    const mcpConfig = attachGuiMcp ? mcpConfigArgument(sessionId, mcpJson) : mcpJson;
     const args = buildClaudeArgs({
       model: resolved.model,
       sessionId,
@@ -81,7 +85,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
       settings: settingsArgument(sessionId, hookSettings, Object.keys(resolved.env).length > 0),
       permissionMode: deps.permissionMode,
       attachGuiMcp,
-      mcpConfig: deps.mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox),
+      mcpConfig,
       // Auto-allow the GUI tools + the user's own configured MCP servers (mcp__<id>), so
       // their tools don't trip a permission prompt on every call.
       guiMcpTools: [deps.guiMcpTools, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(","),

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -170,6 +170,37 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
     expect(() => JSON.parse(received[3])).not.toThrow();
   });
 
+  // #813 again, and the reason the case above was misleading: it reads the child's PARSED
+  // argv, and node is the most forgiving argv parser on Windows — it implements the MSVC
+  // extension where `""` inside a quoted argument means one literal quote. The real target
+  // (`claude.exe`, a native binary) does not, and drops them. So assert what cmd.exe actually
+  // DELIVERS, which is the thing this code is responsible for; how the far end parses it is
+  // the far end's contract, and the reason the JSON now travels as a file at all.
+  //
+  // The shim here is cmd-shim's NON-shebang branch — what npm generates for a package whose
+  // bin is a native .exe, which is what Claude Code ships. It differs from the compound form
+  // above, and the point of having both is that the shim shape does not matter: both hand
+  // `%*` on unchanged.
+  it("delivers our escaping to the shim intact, whatever the shim shape", async () => {
+    const rawShim = `mt-rawshim-${process.pid}`;
+    const rawOut = path.join(dir, "raw.txt");
+    writeFileSync(
+      path.join(dir, `${rawShim}.cmd`),
+      ["@ECHO off", "GOTO start", ":find_dp0", "SET dp0=%~dp0", "EXIT /b", ":start", "SETLOCAL", "CALL :find_dp0", `>"${rawOut}" ECHO %*`, ""].join("\r\n"),
+    );
+
+    rmSync(rawOut, { force: true });
+    const settings = hookSettingsJson({ host: "127.0.0.1", port: 34567, sessionId: "11111111-2222-3333-4444-555555555555" });
+    expect(await exitCodeOf(spawnPty(rawShim, ["--settings", settings], dir))).toBe(0);
+
+    const raw = readFileSync(rawOut, "utf8");
+    // Our own escaping, unaltered: cmd.exe passed the command line through rather than
+    // rewriting it. If this ever fails, cmd IS the corrupting layer and cmd-escape.ts is wrong.
+    expect(raw).toContain('""hooks""');
+    expect(raw).toContain("-d @- >/dev/null 2>&1");
+    expect(raw.trim().startsWith('"--settings"')).toBe(true);
+  });
+
   // cmd.exe is an extra process between us and the shim, so a non-zero exit has one more
   // layer to survive than it did before #798.
   it("propagates a failing shim's exit code through the cmd.exe layer", async () => {

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import pty from "node-pty";
 import { spawnPty } from "../../../server/session/pty-spawn";
 import { resolvePtyLaunchForEnv } from "../../../server/infra/resolve-bin";
+import { hookSettingsJson } from "../../../server/session/hook-settings";
 
 const isWindows = process.platform === "win32";
 
@@ -128,6 +129,45 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
   // correctness wart rather than a privilege boundary.
   it("expands %VAR% inside an argument — the known limitation of the cmd.exe path", async () => {
     expect(await argvThroughShim(["%MT_MARKER%"])).toEqual(["expanded-by-cmd"]);
+  });
+
+  // #813: the real thing. The cases above use a shim of our own shape and payloads we chose;
+  // a user on npm-installed Claude Code reported the `--settings` JSON arriving with almost
+  // every quote gone, through exactly this path. So: npm's OWN generated shim (cmd-shim's
+  // template, whose last line is a compound `endLocal & goto … || title … & "%_prog%" … %*`)
+  // carrying the ACTUAL hookSettingsJson payload — 1.6 kB with embedded single quotes, `@`,
+  // `>` and `&` inside JSON string values.
+  it("round-trips the real --settings payload through npm's own generated shim", async () => {
+    const npmShim = `mt-npmshim-${process.pid}`;
+    const echoJs = path.join(dir, "echo-args.js");
+    writeFileSync(
+      path.join(dir, `${npmShim}.cmd`),
+      [
+        "@ECHO off",
+        "GOTO start",
+        ":find_dp0",
+        "SET dp0=%~dp0",
+        "EXIT /b",
+        ":start",
+        "SETLOCAL",
+        "CALL :find_dp0",
+        "",
+        `SET "_prog=${probeExe}"`,
+        "",
+        `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "${probeExe}"  "${echoJs}" %*`,
+        "",
+      ].join("\r\n"),
+    );
+
+    const settings = hookSettingsJson({ host: "127.0.0.1", port: 34567, sessionId: "11111111-2222-3333-4444-555555555555" });
+    const args = ["--session-id", "11111111-2222-3333-4444-555555555555", "--settings", settings, "--permission-mode", "auto"];
+
+    rmSync(argsOut, { force: true });
+    expect(await exitCodeOf(spawnPty(npmShim, args, dir))).toBe(0);
+    const received: string[] = JSON.parse(readFileSync(argsOut, "utf8"));
+    expect(received).toEqual(args);
+    // Said explicitly, because this is the reported symptom: the JSON must still parse.
+    expect(() => JSON.parse(received[3])).not.toThrow();
   });
 
   // cmd.exe is an extra process between us and the shim, so a non-zero exit has one more

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import os from "node:os";
 
 import { cleanupSessionSettings, settingsArgument, mcpConfigArgument, withSettingsCleanup } from "../../../server/session/session-settings.js";
+import { hookSettingsJson } from "../../../server/session/hook-settings.js";
+import { buildClaudeArgs } from "../../../server/agents/claude-args.js";
 
 const SESSION = "settings-spec-session";
 const fileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}.json`);
@@ -113,5 +115,31 @@ describe("the Windows reason for a file", () => {
     cleanupSessionSettings(SESSION);
     expect(existsSync(fileFor(SESSION))).toBe(false);
     expect(existsSync(mcpFileFor(SESSION))).toBe(false);
+  });
+});
+
+// The property that makes #813 impossible, stated once over the arguments a real spawn
+// builds: with the two JSON payloads travelling as files, NOTHING claude is launched with
+// contains a quote — so no parser downstream, however unforgiving, has anything to lose.
+describe("the argv a Windows spawn ends up with", () => {
+  it("contains no quote at all once the JSON payloads are files", () => {
+    const settings = settingsArgument(SESSION, hookSettingsJson({ host: "127.0.0.1", port: 34567, sessionId: SESSION }), false, "win32");
+    const mcpConfig = mcpConfigArgument(
+      SESSION,
+      JSON.stringify({ mcpServers: { "mulmoterminal-gui": { type: "http", url: "http://127.0.0.1:34567/api/mcp/x" } } }),
+      "win32",
+    );
+    const args = buildClaudeArgs({
+      model: null,
+      sessionId: SESSION,
+      resume: null,
+      canResume: false,
+      settings,
+      permissionMode: "auto",
+      attachGuiMcp: true,
+      mcpConfig,
+      guiMcpTools: "mulmoterminal_readXPost,mulmoterminal_searchX",
+    });
+    expect(args.filter((a) => a.includes('"'))).toEqual([]);
   });
 });

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -14,10 +14,12 @@ afterEach(() => cleanupSessionSettings(SESSION));
 
 describe("settingsArgument", () => {
   // A settings payload with no secret in it keeps travelling inline, so every existing
-  // session's spawn is untouched by this feature.
+  // session's spawn is untouched by this feature. The platform is named rather than
+  // inherited: Windows has its own reason to use a file (#813, below), so left implicit
+  // this would assert the opposite of the truth on the Windows runner.
   it("returns the JSON itself when nothing in it is secret", () => {
     const json = JSON.stringify({ hooks: {} });
-    expect(settingsArgument(SESSION, json, false)).toBe(json);
+    expect(settingsArgument(SESSION, json, false, "linux")).toBe(json);
     expect(existsSync(fileFor(SESSION))).toBe(false);
   });
 

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -4,10 +4,11 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 
-import { cleanupSessionSettings, settingsArgument, withSettingsCleanup } from "../../../server/session/session-settings.js";
+import { cleanupSessionSettings, settingsArgument, mcpConfigArgument, withSettingsCleanup } from "../../../server/session/session-settings.js";
 
 const SESSION = "settings-spec-session";
 const fileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}.json`);
+const mcpFileFor = (id: string) => path.join(os.homedir(), ".mulmoterminal", "settings", `${id}-mcp.json`);
 
 afterEach(() => cleanupSessionSettings(SESSION));
 
@@ -69,5 +70,46 @@ describe("withSettingsCleanup", () => {
 describe("cleanupSessionSettings", () => {
   it("is a no-op for a session that never wrote one", () => {
     expect(() => cleanupSessionSettings("never-existed-session")).not.toThrow();
+  });
+});
+
+// #813: on Windows a `.cmd`-installed Claude is launched through cmd.exe, so an inline JSON
+// argument is parsed by cmd and then by the child's CRT — two parsers that disagree about
+// quoting. A path carries no quotes and no metacharacters, so the layer stops mattering.
+describe("the Windows reason for a file", () => {
+  const json = JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command: "curl -d @- >/dev/null 2>&1" }] }] } });
+
+  it("writes a file on win32 even when nothing is secret", () => {
+    expect(settingsArgument(SESSION, json, false, "win32")).toBe(fileFor(SESSION));
+    expect(readFileSync(fileFor(SESSION), "utf8")).toBe(json);
+  });
+
+  it("keeps POSIX inline, so a working platform is untouched", () => {
+    expect(settingsArgument(SESSION, json, false, "darwin")).toBe(json);
+    expect(settingsArgument(SESSION, json, false, "linux")).toBe(json);
+    expect(existsSync(fileFor(SESSION))).toBe(false);
+  });
+
+  it("gives --mcp-config its own file, so the two never overwrite each other", () => {
+    const settings = settingsArgument(SESSION, json, false, "win32");
+    const mcp = mcpConfigArgument(SESSION, '{"mcpServers":{}}', "win32");
+    expect(mcp).toBe(mcpFileFor(SESSION));
+    expect(mcp).not.toBe(settings);
+    expect(readFileSync(settings, "utf8")).toBe(json);
+    expect(readFileSync(mcp, "utf8")).toBe('{"mcpServers":{}}');
+  });
+
+  it("passes --mcp-config inline off Windows", () => {
+    expect(mcpConfigArgument(SESSION, "{}", "darwin")).toBe("{}");
+  });
+
+  // reap() calls this once per session; it has to take BOTH files or the mcp one outlives
+  // every Windows session.
+  it("cleans up both files", () => {
+    settingsArgument(SESSION, json, false, "win32");
+    mcpConfigArgument(SESSION, "{}", "win32");
+    cleanupSessionSettings(SESSION);
+    expect(existsSync(fileFor(SESSION))).toBe(false);
+    expect(existsSync(mcpFileFor(SESSION))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Windows で `--settings` の JSON が claude に**クォートをほぼ失った状態で届く**という報告（#813）への対策。

**Windows では `--settings` と `--mcp-config` を argv の inline JSON ではなく、ファイルのパスとして渡す**ようにしました。Windows では `.cmd` 導入の Claude Code を cmd.exe 経由で起動する（#798）ため、JSON 引数は **cmd と子プロセスの CRT という、クォート規則の異なる2つのパーサ**を通ります。**パスにはクォートもメタ文字も含まれない**ので、その層自体が問題でなくなります。

## Items to Confirm / Review

- **⚠️ これは「診断済みの修正」ではありません。** 同ブランチで追加した再現テスト（**npm が生成する実物のシム** × **実際の 1.6 kB の `hookSettingsJson()` 出力**）は Windows ランナーで **PASS** しました。つまり報告された失敗はこちらで**再現できていません**。この PR は**問題のクラスを経路ごと消す**もので、どの層が実際に壊したのかは #813 で未解決のままです（報告者に `via tmux` の有無などを確認中）。
- **仕組みは新規ではありません。** #579 で「provider のトークンが argv だと `ps` で他ユーザーに見える」という理由で**すでにファイル経由の仕組みがあり**（`session-settings.ts`）、その発動条件を `secret` → `secret || win32` に広げただけです。
- **POSIX は完全に無変更**（テストで固定）。inline のままにした理由は2つ: argv と execvp の間に何も挟まらないので壊れようがないこと、そして **Docker サンドボックスは darwin 限定**なので、ホストのパスを渡すとコンテナ内で解決できないこと。win32 に限定することでこの問題は構造的に起きません。
- **`--mcp-config` にも同じ扱い**を入れました。もう一方の大きな JSON 引数で、inline で残せば同じクラスの問題が残るためです。**専用のファイル名**（`<id>-mcp.json`）にして両者が上書きし合わないようにし、`reap()` は両方を消します。GUI MCP を持たないセルではファイルを作りません。

### 副作用として実際にあるもの（正直に）

| | 内容 |
| --- | --- |
| ファイルの寿命 | claude が起動時に読んだ後 `/clear` 等で**再読み込みするかは未確認**。削除は従来どおり reap 時のみで、リスクの形は #579 から不変。ただし**適用範囲が Windows の全セッションに広がる** |
| 書き込み失敗 | inline なら失敗し得なかった経路が、ディスク/権限エラーで spawn 失敗になり得ます（既存の `withSettingsCleanup` がファイルを片付けて例外を伝播） |
| Windows の 0600 | Windows は POSIX モードを無視します。既存テストにその旨のコメントがあり、`%USERPROFILE%\.mulmoterminal` 自体がユーザー専用であることで担保 |

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/813 調査して
>
> 対策するなら 一時ファイル経由がよさそうだね。
>
> ではファイル化はしておこうか。これって副作用ないよね？

## テスト

- `test/server/session/session-settings.spec.ts` — win32 では secret でなくてもファイル化 / **POSIX は inline のまま**（動いているプラットフォームを触らないことの固定）/ `--mcp-config` は専用ファイル / POSIX では mcp も inline / **reap が両方消す**
- `test/server/session/pty-spawn-win.spec.ts` — **#813 の再現テスト**（npm の実シム × 実ペイロード、argv の往復と `JSON.parse` の成功を検証）。**現状 PASS** なので、これは「再現できなかった」ことの記録として残します
- 条件を壊すとテストが落ちることを確認済み（`win32` の条件を外すと2件赤）
- `yarn format` / `lint` / `typecheck` ×3 / `build` / `test` — **すべて終了コード 0 で確認**

#813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
