### PR TITLE
docs: add CLAUDE.md with agent-facing conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — mulmoterminal
+
+Working notes for AI coding agents in this repo. Human-facing docs (what it is,
+install, features, full API/architecture) live in **README.md** — read it for
+anything not covered here.
+
+## Stack & package manager
+- TypeScript. Web UI: **Vue 3 (Composition API)** + Vite (`src/`). Backend:
+  **Express** + **node-pty**, run via **tsx** (`server/`). Shared code in `common/`.
+- Package manager: **yarn** (yarn.lock). Use `yarn add`; don't hand-edit package.json.
+
+## Run after changes
+- `yarn format` — Prettier. `.prettierignore` excludes `*.md`, so Markdown is not reformatted.
+- `yarn lint` — ESLint.
+- `yarn typecheck` — `vue-tsc -b`.
+- `yarn build` — `vue-tsc -b && vite build`.
+- `yarn test` — **Vitest** (`test/**/*.spec.ts`). Mock external APIs; tests must run without API keys.
+- `yarn dev` — server + Vite together (local development).
+
+## Layout
+- `server/` — backend (PTY sessions, config, agents, backends). Ships user-facing skills in `server/skills/`.
+- `src/` — Vue web UI (App.vue, components, composables, router).
+- `common/` — code shared by server and UI.
+- `bin/` — CLI entry (`npx mulmoterminal`, `claude-ollama`, …).
+- `docs/` — Jekyll site; bilingual guide under `docs/guide/{en,ja}` (keep both in sync).
+- `plans/` — design notes per change. `test/` — Vitest specs.
+
+## Bundled skills
+`server/skills/` ships skills to end users (mulmoterminal-config, mulmoterminal-bug-report);
+they are mirrored to `~/.claude/skills/`.
+
+## Filing issues
+- Before filing a **bug / "broken" / "weird behaviour"** issue about MulmoTerminal, run the
+  **`mulmoterminal-bug-report`** skill first: it checks whether the behaviour is actually
+  config or by-design (reading the real config/schema/version), searches existing issues, and
+  only files what survives — with env/repro masked.
+- This gate is for bug reports. Pure feature requests / enhancements don't need it.


### PR DESCRIPTION
## Summary
AI コーディングエージェント（Claude Code / Codex 等）向けの短い CLAUDE.md をルートに追加する。
人間向けの網羅ドキュメント（概要・インストール・機能・API/アーキテクチャ）は README にあるので、CLAUDE.md はそれと重複させず「補完」に徹し、エージェントが auto-load して従うべき運用事項だけに絞った。
- 技術スタック / パッケージマネージャ（yarn）
- 変更後に回すコマンド（format=prettier / lint=eslint / typecheck / build / test=Vitest）
- ディレクトリ構成、同梱スキル（server/skills/）
- バグ系 issue を立てる前に mulmoterminal-bug-report skill を通す運用ルール

## 背景
- これまでルートに CLAUDE.md / AGENTS.md が無く、エージェントで作業するたびに技術スタック・開発コマンド・構成をコードから推測する必要があった。
- README は網羅的だが人間向けで長いため、エージェントが最初に読む短い運用メモを別に用意する価値がある。

## Items to Confirm / Review
- ファイル名は CLAUDE.md でよいか（Codex も使うので AGENTS.md 併設 / リネームの選択肢もある）
- 記載が現状と一致しているか（特に test = Vitest、prettier が .prettierignore で *.md を除外する点）
- README と重複しすぎていないか（詳細は README にポインタで委ねている）

## 変更内容
- ルートに CLAUDE.md を新規追加（コード変更なし）
- repo の技術事実 + エージェント workflow のみを記載

## 追加した CLAUDE.md（日本語訳）
レビュー用に、追加した CLAUDE.md（英語）の日本語訳を以下に添える（実ファイルは英語）。

```
# CLAUDE.md — mulmoterminal（日本語訳）

このリポジトリで作業する AI コーディングエージェント向けのメモ。
人間向けの網羅ドキュメント（概要・インストール・機能・API/アーキテクチャ）は README.md にあるので、ここに無いことはそちらを参照。

## スタックとパッケージマネージャ
- TypeScript。Web UI: Vue 3（Composition API）+ Vite（src/）。バックエンド: Express + node-pty、tsx で実行（server/）。共有コードは common/。
- パッケージマネージャ: yarn（yarn.lock）。yarn add を使い、package.json は手編集しない。

## 変更後に回すコマンド
- yarn format — Prettier。.prettierignore が *.md を除外するため Markdown は整形されない。
- yarn lint — ESLint。
- yarn typecheck — vue-tsc -b。
- yarn build — vue-tsc -b && vite build。
- yarn test — Vitest（test/**/*.spec.ts）。外部 API はモックし、API キー無しで実行できること。
- yarn dev — server と Vite を同時起動（ローカル開発）。

## 構成
- server/ — バックエンド（PTY セッション・設定・エージェント・バックエンド）。ユーザー向けスキルを server/skills/ に同梱。
- src/ — Vue Web UI（App.vue・components・composables・router）。
- common/ — server と UI の共有コード。
- bin/ — CLI エントリ（npx mulmoterminal、claude-ollama 等）。
- docs/ — Jekyll サイト。docs/guide/{en,ja} のバイリンガルガイド（両方を同期）。
- plans/ — 変更ごとの設計メモ。test/ — Vitest のテスト。

## 同梱スキル
server/skills/ がユーザーにスキルを配布（mulmoterminal-config、mulmoterminal-bug-report）。~/.claude/skills/ にミラーされる。

## issue を立てる前に
- MulmoTerminal の「バグ / 壊れている / 挙動がおかしい」系 issue を立てる前に、まず mulmoterminal-bug-report skill を通す。
  設定か仕様かを（実際の config/schema/version を読んで）切り分け、既存 issue を検索し、残ったものだけを env/repro をマスクして起票する。
- このゲートはバグ報告用。純粋な機能要望 / 改善は不要。
```
