### PR TITLE
fix: wait for the stream outcome instead of a 20ms sleep (#816)

### DIFF
--- a/test/server/backends/streamFile.spec.ts
+++ b/test/server/backends/streamFile.spec.ts
@@ -29,7 +29,10 @@ function fakeRes(headersSent: boolean) {
   return { res, stream, status, json, destroy };
 }
 
-const settle = () => new Promise((r) => setTimeout(r, 20));
+// Real file I/O has no settle time we can name: on a loaded Windows runner the open hadn't
+// even delivered a byte after the 20ms sleep this used to use, so the test read an empty
+// buffer and failed. Wait for the outcome itself instead of guessing how long it takes.
+const SETTLE_TIMEOUT_MS = 3000;
 
 describe("streamFileToResponse", () => {
   it("serves an existing file", async () => {
@@ -40,7 +43,8 @@ describe("streamFileToResponse", () => {
     const chunks: Buffer[] = [];
     stream.on("data", (c: Buffer) => chunks.push(c));
     streamFileToResponse(file, res);
-    await settle();
+    // The pipe ends the response once the file is drained, so by then `chunks` holds it all.
+    await vi.waitFor(() => expect(stream.readableEnded).toBe(true), { timeout: SETTLE_TIMEOUT_MS });
     expect(Buffer.concat(chunks).toString()).toBe("hello");
     expect(status).not.toHaveBeenCalled();
   });
@@ -50,8 +54,7 @@ describe("streamFileToResponse", () => {
   it("responds 500 when the file can't be read and nothing was sent yet", async () => {
     const { res, status, json, destroy } = fakeRes(false);
     streamFileToResponse(path.join(tmpdir(), "does-not-exist-xyz.bin"), res);
-    await settle();
-    expect(status).toHaveBeenCalledWith(500);
+    await vi.waitFor(() => expect(status).toHaveBeenCalledWith(500), { timeout: SETTLE_TIMEOUT_MS });
     expect(json).toHaveBeenCalledWith({ error: "failed to read file" });
     expect(destroy).not.toHaveBeenCalled();
   });
@@ -59,8 +62,7 @@ describe("streamFileToResponse", () => {
   it("destroys the connection when the stream errors after headers were sent", async () => {
     const { res, status, destroy } = fakeRes(true);
     streamFileToResponse(path.join(tmpdir(), "does-not-exist-xyz.bin"), res);
-    await settle();
-    expect(destroy).toHaveBeenCalled();
+    await vi.waitFor(() => expect(destroy).toHaveBeenCalled(), { timeout: SETTLE_TIMEOUT_MS });
     expect(status).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Windows CI の flaky テスト 1 件を修正します。`test/server/backends/streamFile.spec.ts` が実ファイル I/O の完了を **20ms の固定スリープ**で待っていたため、負荷のかかった Windows ランナーで空バッファを assert して失敗していました。固定スリープをやめ、結果そのものを待つ形にします。

**テストのみの変更で、製品コードは変更していません。**

Closes #816

## Items to Confirm / Review

- **`readableEnded` を待つ判断** — 「serves an existing file」では `chunks` の中身ではなく `stream.readableEnded` を待っています。pipe がレスポンスを終了させた時点で全バイトが `chunks` に入っているためで、元のテストより強い検証（バイトは届くがレスポンスが終わらない = ハングするリクエスト、も検出できる）になっています。ここは意図的な変更なのでご確認ください。
- **`SETTLE_TIMEOUT_MS = 3000`** — vitest のテストタイムアウト (15s) より十分短く、かつ元の 20ms の 150 倍。失敗時にどのテストが何を待っていたかが 3 秒で分かります。値の妥当性をご確認ください。
- **横断調査の判定** — 固定スリープを使う他 4 箇所は「対応不要」と判断しました（下表）。この判定に異論があればご指摘ください。
- **本 PR のスコープ外の既知事項** — 下記「別途確認いただきたい点」に 2 件記載しています。

## User Prompt

> ci エラー https://github.com/receptron/mulmoterminal/actions/runs/30157655628

（以降、日本語での回答と、修正を main から切った新ブランチで PR にすることを指示いただきました。）

## 症状

失敗した run: https://github.com/receptron/mulmoterminal/actions/runs/30157655628
`lint_test_windows (22.x)` のみ失敗、24.x は成功。

```
FAIL test/server/backends/streamFile.spec.ts > streamFileToResponse > serves an existing file
AssertionError: expected '' to be 'hello' // Object.is equality
 ❯ test/server/backends/streamFile.spec.ts:44:46
```

実行元のブランチ `fix/813-settings-json-escaping` は `test/server/session/pty-spawn-win.spec.ts` にテストを追加しただけで、このテストにも対象コードにも触れていません。main にも存在する既存の flake です。

## 原因

```ts
const settle = () => new Promise((r) => setTimeout(r, 20));
...
streamFileToResponse(file, res);
await settle();                                     // 20ms 固定で待つだけ
expect(Buffer.concat(chunks).toString()).toBe("hello");
```

`createReadStream` の完了を 20ms の固定スリープで待っていました。負荷のかかった Windows ランナーでは 20ms 以内に 1 バイトも届かず、`chunks` が空のまま assert に到達します。実 I/O に「必ずこの時間で終わる」値は存在しないため、スリープを伸ばすのは対症療法にしかなりません。

## 実装

固定スリープを削除し、結果そのものを待ちます。`vi.waitFor` は `test/bin/wait-ready.spec.ts` で既に使われている書き方です。

```ts
const SETTLE_TIMEOUT_MS = 3000;

// serves an existing file
await vi.waitFor(() => expect(stream.readableEnded).toBe(true), { timeout: SETTLE_TIMEOUT_MS });
expect(Buffer.concat(chunks).toString()).toBe("hello");

// responds 500 ...
await vi.waitFor(() => expect(status).toHaveBeenCalledWith(500), { timeout: SETTLE_TIMEOUT_MS });

// destroys the connection ...
await vi.waitFor(() => expect(destroy).toHaveBeenCalled(), { timeout: SETTLE_TIMEOUT_MS });
```

## 検証

**ミューテーションテスト** — 実装を 3 通り壊し、各テストが確実に落ちること（＝壊れたコードに対しても通ってしまうテストになっていないこと）を確認しました。

| 壊した箇所 | 落ちたテスト | 所要 |
|---|---|---|
| `stream.pipe(res)` を削除 | serves an existing file | 3.0s |
| エラー時に常に `destroy` | responds 500 when the file can't be read | 3.0s |
| エラー時に常に `500` | destroys the connection ... after headers sent | 3.0s |

修正前は pipe を消した場合 15 秒（vitest のテストタイムアウト）かかって落ちていました。

**全テスト** — 3976 件パス。

## 横断調査

固定スリープで同期しているテストを全て洗い出しました。**5 箇所中、実際に壊れているのは本件のみ**です。

| 箇所 | 判定 |
|---|---|
| `test/server/backends/streamFile.spec.ts` | 実 I/O を固定スリープで同期 → **本 PR で修正** |
| `test/scripts/dev-server.spec.ts` | 既にポーリング済み + Windows は `skipIf` 済み (#802) → 対応不要 |
| `test/bin/wait-ready.spec.ts` | 「余計に発火しないこと」を確認する意図的な待ち時間。長引いても壊れない → 対応不要 |
| `test/src/composables/useAppConfig.spec.ts` | スリープはモック内の遅延生成で、テストは実 promise を await → 対応不要 |
| `test/src/composables/useDirConfig.spec.ts` | モック遅延 60ms に対し 120ms 待ち。タイマー順序は負荷で逆転しない → 対応不要 |

## 別途確認いただきたい点（本 PR のスコープ外）

1. **`yarn build` / `yarn typecheck` がローカルで失敗** — 作業ツリーの未コミットな `package.json` (`@codemirror/state` ^6.7.0 → ^6.7.1) により、`codemirror` 配下にネストした 6.7.0 と型が衝突します (`src/components/cmEditor.ts:46`)。CI 側は Typecheck ✓ なので本 PR とは無関係ですが、依存更新作業を進める際は重複解消が必要です。
2. **`TerminalCell.spec.ts` も 1 回だけ失敗** — 全体実行 3 回中 1 回 (`cancels a pending debounced load`)。単体では 6/6 パスで再現せず、並列負荷時のみの別 flake と思われます。本 PR では手を付けていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)