### PR TITLE
chore: update @codemirror/state to 6.7.1, lang-markdown to 6.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",
-    "@codemirror/lang-markdown": "^6.5.0",
-    "@codemirror/state": "^6.7.0",
+    "@codemirror/lang-markdown": "^6.5.1",
+    "@codemirror/state": "^6.7.1",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@google/genai": "^2.13.0",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,10 +200,10 @@
     "@codemirror/language" "^6.0.0"
     "@lezer/json" "^1.0.0"
 
-"@codemirror/lang-markdown@^6.5.0":
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz#29df87310a555b007beba8e12893363956a26e8e"
-  integrity sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==
+"@codemirror/lang-markdown@^6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-markdown/-/lang-markdown-6.5.1.tgz#eb53c488e368b8fa581409a06531dfedd573d88c"
+  integrity sha512-6re5avCNfyRMIoi3XNjbEfQM1vTeVD3JS3g/Fyegyso/eoANFM71Cyvbb66LDyYtQLMEcRFlzioywCqDo9SlLA==
   dependencies:
     "@codemirror/autocomplete" "^6.7.1"
     "@codemirror/lang-html" "^6.0.0"
@@ -243,10 +243,10 @@
     "@codemirror/view" "^6.37.0"
     crelt "^1.0.5"
 
-"@codemirror/state@^6.0.0", "@codemirror/state@^6.7.0":
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.7.0.tgz#624c3504dc3d04e727dd49711fb75244e675e8e7"
-  integrity sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.7.0", "@codemirror/state@^6.7.1":
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.7.1.tgz#9e88a17448c1dbc7b50acbeeec979ed7ccf1d6fc"
+  integrity sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==
   dependencies:
     "@marijn/find-cluster-break" "^1.0.0"
 


### PR DESCRIPTION
## Summary

CodeMirror の patch 更新 2 件と、それに伴って発生した **yarn.lock の重複解消**です。

bump 時に `@codemirror/state` の lockfile エントリが 2 つに分裂し、`codemirror` が古い 6.7.0 に解決されてネストコピーが生まれていました。`EditorState` 型が 2 つ存在する状態になり、**`yarn build` / `yarn typecheck` が `cmEditor.ts:46` で失敗**していたのを直します。

変更は `package.json` / `yarn.lock` の 2 ファイルのみ、production コードの変更はありません。

## Items to Confirm / Review

- **`@codemirror/lang-markdown` 6.5.1 はユーザー可視の挙動変更を含みます** — blockquote 配下の継続段落で `deleteMarkupBackward`（backspace）が過剰削除する不具合の上流修正です。markdown エディタの backspace 挙動が変わるので、意図した方向か確認してください。
- **`safe-buffer` の重複は意図的に残しています** — `~5.1.0` / `~5.1.1` と `~5.2.0` に共通バージョンが存在せず、**解消不可能**な重複です（`yarn-deduplicate --strategy=fewer` も何も変更しません）。`--list` が「could get 5.2.1」と報告するのは個々の range を単体で見た結果で、統合はできません。
- **dedupe の対象を `@codemirror/state` に限定しました** — `npx yarn-deduplicate --packages @codemirror/state` として、無関係な依存が巻き込まれないようにしています。

## User Prompt

> （前タスクの残作業リストから）2

`@codemirror/state` の依存更新（未コミットのまま作業ツリーに残存し、ネストした 6.7.0 との型衝突で `yarn build` / `yarn typecheck` が失敗する状態）の対応を選択。

> 作って CI からマージまで一気に

なお `package.json` の bump 自体は作業ツリーに元々あったもので、本 PR はそれをそのまま採用しています。

## 原因

`yarn.lock` に `@codemirror/state` のエントリが 2 つ存在していました。

```
"@codemirror/state@^6.0.0", "@codemirror/state@^6.7.0":   → 6.7.0   ← codemirror が ^6.0.0 で要求
"@codemirror/state@^6.7.1":                                → 6.7.1   ← bump で新規追加
```

`^6.0.0` も `^6.7.0` も 6.7.1 で満たせるにもかかわらず、bump が既存エントリを更新せず新規エントリを追加したため、`codemirror` が古い方に解決され `node_modules/codemirror/node_modules/@codemirror/state` (6.7.0) が生成されていました。

結果として `EditorState` 型が 2 種類存在し、vue-tsc が `src/components/cmEditor.ts:46` で TS2322 を報告していました。

```
Type 'import(".../node_modules/@codemirror/state").EditorState' is not assignable to
type 'import(".../node_modules/codemirror/node_modules/@codemirror/state").EditorState'.
  Types have separate declarations of a private property 'flags'.
```

## 実装

```
npx yarn-deduplicate --packages @codemirror/state yarn.lock
yarn install
```

3 つの range が 1 エントリに統合されます。

```diff
-"@codemirror/state@^6.0.0", "@codemirror/state@^6.7.0":
-  version "6.7.0"
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.7.0", "@codemirror/state@^6.7.1":
+  version "6.7.1"
```

`node_modules/codemirror/node_modules/` は消え、`@codemirror/state` は 6.7.1 単一解決になります。

## 検証

| ゲート | 結果 |
|---|---|
| `yarn typecheck` | pass（TS2322 解消） |
| `yarn typecheck:server` | pass |
| `yarn lint` | エラー 0（警告 4 件は既存） |
| `yarn build` | pass |
| `yarn test` | 3961 件 pass |
| `yarn install --frozen-lockfile` | pass（CI と同条件で lockfile 整合を確認） |

## 更新内容

- **`@codemirror/state` 6.7.0 → 6.7.1** — facet provider / precedence extension / compartment instance に、`Extension` 型が主張する `extension` フィールドを実際に持たせる修正
- **`@codemirror/lang-markdown` 6.5.0 → 6.5.1** — blockquote 配下の継続段落で `deleteMarkupBackward` が過剰に削除する不具合の修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)