### PR TITLE
fix(windows): three silent Windows-only failures — BOM'd configs, DOS device names, locked-file cleanup

### DIFF
--- a/server/agents/codex-skills.ts
+++ b/server/agents/codex-skills.ts
@@ -34,8 +34,9 @@ function removeOrphanedMirrors(destDir: string, keep: ReadonlySet<string>): stri
     if (keep.has(name)) continue;
     const dst = path.join(destDir, name);
     if (!isOurs(dst)) continue;
-    removeQuietly(dst);
-    removed.push(name);
+    // Only report what actually went: a mirror we could not delete is still there, and
+    // saying otherwise would hide a retired skill codex is still loading.
+    if (removeQuietly(dst)) removed.push(name);
   }
   return removed;
 }
@@ -61,7 +62,15 @@ export function syncCodexSkills(sourceDir: string, destDir: string): { mirrored:
       skipped.push(name);
       continue;
     }
-    removeQuietly(dst);
+    // Copying ON TOP of a mirror we failed to remove would leave whatever the source has
+    // since deleted in place — a stale skill codex keeps auto-loading — while the sync
+    // reported success. Skip it instead, and say so. (Windows: a mirror another process
+    // holds open cannot be removed; see infra/fs-cleanup.ts.)
+    if (!removeQuietly(dst)) {
+      console.warn(`[codex-skills] could not replace the mirror for ${name} — leaving the existing one alone`);
+      skipped.push(name);
+      continue;
+    }
     cpSync(path.join(sourceDir, name), dst, { recursive: true });
     writeFileSync(path.join(dst, MIRROR_MARKER), "managed by mulmoterminal\n");
     mirrored.push(name);

--- a/server/agents/codex-skills.ts
+++ b/server/agents/codex-skills.ts
@@ -1,6 +1,7 @@
-import { existsSync, readdirSync, mkdirSync, cpSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, mkdirSync, cpSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { removeQuietly } from "../infra/fs-cleanup.js";
 
 // Marks a codex skill dir mulmoterminal owns, so a re-sync overwrites OURS but never clobbers
 // codex's own curated/system skills.
@@ -33,7 +34,7 @@ function removeOrphanedMirrors(destDir: string, keep: ReadonlySet<string>): stri
     if (keep.has(name)) continue;
     const dst = path.join(destDir, name);
     if (!isOurs(dst)) continue;
-    rmSync(dst, { recursive: true, force: true });
+    removeQuietly(dst);
     removed.push(name);
   }
   return removed;
@@ -60,7 +61,7 @@ export function syncCodexSkills(sourceDir: string, destDir: string): { mirrored:
       skipped.push(name);
       continue;
     }
-    rmSync(dst, { recursive: true, force: true });
+    removeQuietly(dst);
     cpSync(path.join(sourceDir, name), dst, { recursive: true });
     writeFileSync(path.join(dst, MIRROR_MARKER), "managed by mulmoterminal\n");
     mirrored.push(name);

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -16,11 +16,11 @@
 // supplied by server/index.ts. journal / chat-index stay MulmoClaude-only (their run
 // logic isn't in the shared package).
 import path from "node:path";
-import { readFileSync } from "node:fs";
 import type { Express, Request, Response } from "express";
 import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import { createTaskManager } from "@mulmoclaude/core/scheduler";
 import type { TaskDefinition, TaskSchedule } from "@mulmoclaude/core/scheduler";
+import { readTextFile } from "../infra/read-text-file.js";
 
 const log = {
   info: (message: string, data?: Record<string, unknown>) => console.log(`[scheduler] ${message}`, data ?? ""),
@@ -77,7 +77,7 @@ function tasksFilePath(workspace: string): string {
 export function loadUserTasks(workspace: string): PersistedUserTask[] {
   let raw: string;
   try {
-    raw = readFileSync(tasksFilePath(workspace), "utf8");
+    raw = readTextFile(tasksFilePath(workspace));
   } catch {
     return [];
   }

--- a/server/backends/translation.ts
+++ b/server/backends/translation.ts
@@ -21,6 +21,7 @@ import path from "node:path";
 import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
 import type { Express, Request, Response } from "express";
+import { stripBom } from "../infra/read-text-file.js";
 
 // ── On-disk cache schema (SHARED with MulmoClaude — do not diverge) ───────────
 
@@ -57,7 +58,7 @@ function dictionaryPath(workspace: string, namespace: string): string {
 async function loadDictionary(workspace: string, namespace: string): Promise<DictionaryFile> {
   let raw: unknown;
   try {
-    raw = JSON.parse(await fs.readFile(dictionaryPath(workspace, namespace), "utf8"));
+    raw = JSON.parse(stripBom(await fs.readFile(dictionaryPath(workspace, namespace), "utf8")));
   } catch {
     return emptyDictionary(); // missing / unreadable / malformed → start empty
   }

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -2,7 +2,7 @@
 // presets plus an optional custom attention-sound file. Unified read/write so a
 // partial update (e.g. just the sound) never clobbers the other field. Extracted
 // from config-routes.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
+import { existsSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets } from "./cwd-presets.js";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
@@ -18,6 +18,7 @@ import {
   type HeaderChip,
 } from "./config-schema.js";
 import { DEFAULT_TERMINAL_SUBMIT_MODE, isTerminalSubmitMode, type TerminalSubmitMode } from "../../common/terminalSubmit.js";
+import { readTextFile } from "../infra/read-text-file.js";
 
 export interface AppConfig {
   cwdPresets: CwdPreset[];
@@ -209,7 +210,7 @@ export function loadAppConfigResult(file: string): AppConfigLoad {
   if (!existsSync(file)) return { status: "missing" };
   let text: string;
   try {
-    text = readFileSync(file, "utf8");
+    text = readTextFile(file);
   } catch (err) {
     return { status: "corrupt", error: `cannot read ${file}: ${String(err)}` };
   }

--- a/server/config/cwd-presets.ts
+++ b/server/config/cwd-presets.ts
@@ -1,8 +1,9 @@
 // Directory presets the launch form offers, persisted at config.json. Extracted
 // from index.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { type CwdPreset } from "./config-schema.js";
+import { readJsonFile } from "../infra/read-text-file.js";
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const isPreset = (v: unknown): v is CwdPreset => isRecord(v) && typeof v.label === "string" && typeof v.path === "string";
@@ -21,7 +22,7 @@ export function sanitizePresets(input: unknown, max = 50): CwdPreset[] {
 export function loadPresets(file: string): CwdPreset[] {
   try {
     if (!existsSync(file)) return [];
-    return sanitizePresets(JSON.parse(readFileSync(file, "utf8"))?.cwdPresets);
+    return sanitizePresets((readJsonFile(file) as { cwdPresets?: unknown } | null)?.cwdPresets);
   } catch {
     return [];
   }

--- a/server/config/dir-config.ts
+++ b/server/config/dir-config.ts
@@ -4,11 +4,12 @@
 // terminal falls back to the global theme/sound. Field validation lives in the zod
 // schemas of config-schema.ts; the path-confinement check for `sound` (the security
 // surface) stays here because it touches the filesystem.
-import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
+import { existsSync, statSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
 import type { DirChrome } from "../../common/dirChrome.js";
 import { isWithin } from "../infra/path-within.js";
+import { readJsonFile } from "../infra/read-text-file.js";
 import {
   dirNameField,
   dirColorField,
@@ -120,7 +121,7 @@ export function loadDirConfig(cwd: string): DirConfig {
     const base = path.resolve(cwd);
     const file = path.join(base, DIR_CONFIG_FILE);
     if (!existsSync(file)) return EMPTY;
-    const raw: unknown = JSON.parse(readFileSync(file, "utf8"));
+    const raw: unknown = readJsonFile(file);
     if (!isRecord(raw)) return EMPTY;
     return {
       name: dirNameField.parse(raw.name),

--- a/server/files/pathContainment.ts
+++ b/server/files/pathContainment.ts
@@ -95,7 +95,10 @@ function trimTrailingDotsAndSpaces(text: string): string {
 export function namesAWindowsDevice(rel: string, platform: NodeJS.Platform = process.platform): boolean {
   if (platform !== "win32") return false;
   return rel.split(/[\\/]/).some((segment) => {
-    const stem = trimTrailingDotsAndSpaces(segment.split(".")[0]);
+    // `.` and `:` both end the stem: `CON.txt` is CON, and so is `NUL:$DATA` — a colon opens
+    // an NTFS alternate data stream (and `NUL:` is the legacy device spelling), neither of
+    // which stops the name in front of it being a device.
+    const stem = trimTrailingDotsAndSpaces(segment.split(/[.:]/)[0]);
     return WINDOWS_DEVICE_NAMES.has(stem.toUpperCase());
   });
 }

--- a/server/files/pathContainment.ts
+++ b/server/files/pathContainment.ts
@@ -60,9 +60,44 @@ export function containedPath(base: string, rel: string): string | null {
  *  through symlinks — because BOTH file entry points need exactly this and had it written
  *  out separately: the raw route expanded `~`, the browse routes did not, so the same
  *  clicked path was served by one and refused by the other (#808). */
-export function resolveContained(base: string, rel: string, homeDir: string): string | null {
+export function resolveContained(base: string, rel: string, homeDir: string, platform: NodeJS.Platform = process.platform): string | null {
+  if (namesAWindowsDevice(rel, platform)) return null;
   const lexical = containedPath(base, expandTilde(rel, homeDir));
   return lexical ? realContainedWithin(base, lexical) : null;
+}
+
+// The DOS device names. Windows resolves them in EVERY directory — `C:\anything\NUL` is the
+// null device, not a missing file — so containment says yes and the open lands on a device
+// instead of on the project. NUL reads as empty, which is merely wrong; CON blocks until the
+// console has input, which hangs the request that asked for it. An extension does not help
+// (`CON.txt` is still CON), so the check is on the segment's stem.
+//
+// Windows only: `con` is a perfectly ordinary filename on POSIX, and refusing it there would
+// break a real file for no reason.
+const WINDOWS_DEVICE_NAMES = new Set([
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  ...Array.from({ length: 9 }, (_, i) => `COM${i + 1}`),
+  ...Array.from({ length: 9 }, (_, i) => `LPT${i + 1}`),
+]);
+
+// Counted rather than matched: an anchored `[. ]+$` backtracks over a long run.
+function trimTrailingDotsAndSpaces(text: string): string {
+  let end = text.length;
+  while (end > 0 && (text[end - 1] === "." || text[end - 1] === " ")) end--;
+  return text.slice(0, end);
+}
+
+/** Does any segment of `rel` name a DOS device? Trailing dots and spaces are stripped first,
+ *  because Windows strips them too — `NUL. ` opens NUL. */
+export function namesAWindowsDevice(rel: string, platform: NodeJS.Platform = process.platform): boolean {
+  if (platform !== "win32") return false;
+  return rel.split(/[\\/]/).some((segment) => {
+    const stem = trimTrailingDotsAndSpaces(segment.split(".")[0]);
+    return WINDOWS_DEVICE_NAMES.has(stem.toUpperCase());
+  });
 }
 
 function realpathOr(p: string): string {

--- a/server/files/scripts.ts
+++ b/server/files/scripts.ts
@@ -3,8 +3,9 @@
 // is unit-testable without spawning a PTY. The browser sends only an INDEX into
 // this list (never a raw command), and the server re-reads the file to resolve it
 // — so the file is the allowlist of what can run.
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
+import { readJsonFile } from "../infra/read-text-file.js";
 
 export interface ScriptDef {
   label: string;
@@ -40,7 +41,7 @@ export function loadScripts(workspaceDir: string): ScriptDef[] {
   try {
     const file = path.join(workspaceDir, SCRIPTS_FILE);
     if (!existsSync(file)) return [];
-    return sanitizeScripts(JSON.parse(readFileSync(file, "utf8"))?.scripts);
+    return sanitizeScripts((readJsonFile(file) as { scripts?: unknown } | null)?.scripts);
   } catch {
     return [];
   }

--- a/server/infra/fs-cleanup.ts
+++ b/server/infra/fs-cleanup.ts
@@ -1,0 +1,29 @@
+// Removing something we are done with — a session's settings file, a stale skill tree, a
+// sandbox's credential.
+//
+// `rmSync(..., { force: true })` swallows "it was not there" and nothing else, which is fine
+// until Windows: a file another process still holds open, or a directory something is
+// walking, fails with EPERM/EBUSY/ENOTEMPTY instead. Every caller here is CLEANUP — the work
+// it belongs to has already finished or already failed — so a throw from it can only turn a
+// transient lock into a broken teardown: a reap that stops halfway, a boot that gives up
+// seeding. POSIX never showed this because it lets you unlink an open file.
+//
+// Failing to delete is not silent by accident: `removeQuietly` reports whether it managed it,
+// so a caller that cares can say so.
+import { rmSync } from "node:fs";
+
+/** Remove a file or tree; never throws. Returns false when it could not (a Windows lock),
+ *  which is a fact a caller may want to log — not one that should end its own work. */
+export function removeQuietly(target: string, remove: (t: string) => void = removeRecursively): boolean {
+  try {
+    remove(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// `remove` is injected because the failure this exists for cannot be produced on POSIX: it
+// needs another process holding the file, which is a Windows-only state. Driving the catch
+// with a thrower is the only way to check it from here.
+const removeRecursively = (target: string): void => rmSync(target, { recursive: true, force: true });

--- a/server/infra/install-bundled-skills.ts
+++ b/server/infra/install-bundled-skills.ts
@@ -27,15 +27,23 @@ function bundledSkillDir(name: string): string {
 
 const isOurs = (dir: string): boolean => existsSync(path.join(dir, OWNER_MARKER));
 
+/** What installing one bundled skill did. `unreplaceable` is ours but could not be removed,
+ *  so it was left as it was rather than overlaid — see the copy site. */
+export type InstallOutcome = "installed" | "skipped" | "absent-source" | "unreplaceable";
+
 // Copy `sourceDir` into `<destParent>/<name>`, refreshing our own copy so shipped edits/removals
 // propagate, but SKIPPING a same-named directory we don't own (no marker) so a user's hand-written
 // skill is never clobbered. `extras` are additional files written into the destination after the
 // copy (e.g. a generated schema.json). Returns what happened, for logging/tests.
-export function installOwnedSkill(sourceDir: string, destParent: string, extras: Record<string, string> = {}): "installed" | "skipped" | "absent-source" {
+export function installOwnedSkill(sourceDir: string, destParent: string, extras: Record<string, string> = {}): InstallOutcome {
   if (!existsSync(sourceDir)) return "absent-source";
   const dest = path.join(destParent, path.basename(sourceDir));
   if (existsSync(dest) && !isOurs(dest)) return "skipped";
-  removeQuietly(dest);
+  // Copying ON TOP of a copy we failed to remove leaves whatever the bundle has since
+  // dropped in place, while we report it as freshly installed. That is a distinct outcome
+  // from "skipped": nobody else owns this directory, we simply could not replace it (on
+  // Windows, something still holds it open — see infra/fs-cleanup.ts).
+  if (!removeQuietly(dest)) return "unreplaceable";
   cpSync(sourceDir, dest, { recursive: true });
   writeFileSync(path.join(dest, OWNER_MARKER), OWNER_MARKER_BODY);
   for (const [file, content] of Object.entries(extras)) writeFileSync(path.join(dest, file), content);
@@ -60,7 +68,10 @@ export function installBundledSkills(): void {
     for (const name of BUNDLED_SKILL_NAMES) {
       try {
         mkdirSync(root, { recursive: true });
-        installOwnedSkill(bundledSkillDir(name), root, extrasFor(name));
+        const outcome = installOwnedSkill(bundledSkillDir(name), root, extrasFor(name));
+        // Worth a line: the copy on disk is now older than the bundle, and silence would
+        // read as "up to date".
+        if (outcome === "unreplaceable") console.warn(`[skills] could not replace ${name} in ${root} — leaving the existing copy in place`);
       } catch (err) {
         console.error(`[skills] installing ${name} into ${root} failed — continuing`, err instanceof Error ? err.message : String(err));
       }

--- a/server/infra/install-bundled-skills.ts
+++ b/server/infra/install-bundled-skills.ts
@@ -3,12 +3,13 @@
 // including under `npx`, since they ship in the package. Modeled on server/codex-skills.ts: an
 // ownership marker means we only ever refresh OUR copy and never clobber a user's own same-named
 // skill. Best-effort: a filesystem failure logs and continues, never aborting server startup.
-import { existsSync, mkdirSync, cpSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, cpSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { codexSkillsRoot } from "../agents/codex-skills.js";
 import { dirConfigJsonSchema } from "../config/config-schema.js";
+import { removeQuietly } from "./fs-cleanup.js";
 
 const OWNER_MARKER = ".mt-owned";
 const OWNER_MARKER_BODY = "managed by mulmoterminal\n";
@@ -34,7 +35,7 @@ export function installOwnedSkill(sourceDir: string, destParent: string, extras:
   if (!existsSync(sourceDir)) return "absent-source";
   const dest = path.join(destParent, path.basename(sourceDir));
   if (existsSync(dest) && !isOurs(dest)) return "skipped";
-  rmSync(dest, { recursive: true, force: true });
+  removeQuietly(dest);
   cpSync(sourceDir, dest, { recursive: true });
   writeFileSync(path.join(dest, OWNER_MARKER), OWNER_MARKER_BODY);
   for (const [file, content] of Object.entries(extras)) writeFileSync(path.join(dest, file), content);

--- a/server/infra/read-text-file.ts
+++ b/server/infra/read-text-file.ts
@@ -1,0 +1,23 @@
+// Reading a file a HUMAN may have edited, which on Windows means one that may start with a
+// byte-order mark.
+//
+// Notepad, `Set-Content` and PowerShell 5.1's `Out-File -Encoding utf8` all write UTF-8 WITH a
+// BOM, and node's "utf8" decoding keeps it as a leading U+FEFF. `JSON.parse` then throws on
+// the very first character, and every config reader here answers a throw the same way — with
+// an empty config — so the whole file goes silently missing: a directory's colours, a
+// provider's registration, the Run menu's scripts. Nothing says why.
+//
+// The rule already existed for SKILL.md frontmatter (backends/remoteHost/skills.ts) and for
+// wiki pages (src/wikiMarkdown.ts); this is the same rule where the JSON readers can reach it.
+import { readFileSync } from "node:fs";
+
+/** Drop a leading byte-order mark. Only the leading one: a U+FEFF anywhere else is content. */
+export const stripBom = (text: string): string => (text.charCodeAt(0) === 0xfeff ? text.slice(1) : text);
+
+/** A text file's contents, BOM-free. */
+export const readTextFile = (file: string): string => stripBom(readFileSync(file, "utf8"));
+
+/** Parse a JSON file a human may have edited. Throws like JSON.parse — the callers here
+ *  already decide what a corrupt file means, and that decision differs (an empty config vs.
+ *  refusing to overwrite it), so it stays theirs. */
+export const readJsonFile = (file: string): unknown => JSON.parse(readTextFile(file));

--- a/server/infra/sandbox.ts
+++ b/server/infra/sandbox.ts
@@ -10,13 +10,14 @@
 // Verified in Phase 0 (#202): a sandboxed claude authenticates via the mounted ~/.claude
 // and connects to the host GUI MCP over host.docker.internal.
 import { spawnSync } from "node:child_process";
-import { writeFileSync, readFileSync, copyFileSync, chmodSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, readFileSync, copyFileSync, chmodSync, mkdirSync, existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import os from "node:os";
 import pty from "node-pty";
 import { spawnCapture } from "./spawnCapture.js";
+import { removeQuietly } from "./fs-cleanup.js";
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
@@ -272,8 +273,8 @@ export function writeSandboxCredentials(sessionId: string): string | null {
 // Used before a spawn (clear stale) and on reap.
 export function cleanupSandbox(sessionId: string): void {
   run("docker", ["rm", "-f", sandboxContainerName(sessionId)]);
-  rmSync(sandboxClaudeConfigPath(sessionId), { force: true });
-  rmSync(sandboxCredentialsPath(sessionId), { force: true });
+  removeQuietly(sandboxClaudeConfigPath(sessionId));
+  removeQuietly(sandboxCredentialsPath(sessionId));
 }
 
 // --- Opt-in host credentials for the sandbox ---

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -9,9 +9,10 @@
 // The env block is the transport for a reason: Claude Code applies it itself, so it
 // reaches the session identically on the host, under tmux — where a pane inherits the
 // tmux SERVER's environment, not the spawning client's — and inside a container.
-import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { removeQuietly } from "../infra/fs-cleanup.js";
 
 const SETTINGS_DIR = path.join(os.homedir(), ".mulmoterminal", "settings");
 
@@ -56,6 +57,6 @@ export function withSettingsCleanup<T>(sessionId: string, spawn: () => T): T {
 
 // Drop a session's files. Safe to call for sessions that never wrote one.
 export function cleanupSessionSettings(sessionId: string): void {
-  rmSync(settingsFile(sessionId), { force: true });
-  rmSync(mcpConfigFile(sessionId), { force: true });
+  removeQuietly(settingsFile(sessionId));
+  removeQuietly(mcpConfigFile(sessionId));
 }

--- a/test/server/agents/codex-skills.spec.ts
+++ b/test/server/agents/codex-skills.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { syncCodexSkills, codexifySkillSeed } from "../../../server/agents/codex-skills.js";
@@ -62,6 +62,32 @@ describe("syncCodexSkills", () => {
     expect(res.mirrored).toEqual(["books"]);
     expect(readFileSync(path.join(dst, "books", "SKILL.md"), "utf8")).toBe("# v2");
     expect(existsSync(path.join(dst, "books", "stale.txt"))).toBe(false);
+  });
+
+  // Flagged by Codex on #821: when the mirror cannot be removed, copying ON TOP of it leaves
+  // whatever the source has since deleted in place — a stale skill codex keeps loading —
+  // while the sync reports success. It must skip and say so instead.
+  //
+  // Windows is where an unremovable directory actually happens (another process holding it),
+  // and is also where chmod cannot produce one, so the case is driven the POSIX way.
+  it.skipIf(process.platform === "win32")("skips a mirror it could not replace, rather than overlaying it", () => {
+    writeSkill(src, "books", "# v2");
+    mkdirSync(path.join(dst, "books"), { recursive: true });
+    writeFileSync(path.join(dst, "books", ".mt-mirror"), "x");
+    writeFileSync(path.join(dst, "books", "stale.txt"), "old");
+    chmodSync(dst, 0o500); // read+execute: the child cannot be unlinked
+    try {
+      const res = syncCodexSkills(src, dst);
+      expect(res.mirrored).toEqual([]);
+      expect(res.skipped).toEqual(["books"]);
+      // The new source was NOT laid on top: what makes the overlay dangerous is a mirror that
+      // looks synced while holding whatever the source deleted. (The directory itself may be
+      // partially emptied — rmSync removes contents before it fails on the directory — so the
+      // assertion is on what did NOT arrive, which is the part that matters.)
+      expect(existsSync(path.join(dst, "books", "SKILL.md"))).toBe(false);
+    } finally {
+      chmodSync(dst, 0o700);
+    }
   });
 
   it("no-ops when the source doesn't exist", () => {

--- a/test/server/agents/codex-skills.spec.ts
+++ b/test/server/agents/codex-skills.spec.ts
@@ -72,6 +72,7 @@ describe("syncCodexSkills", () => {
   // and is also where chmod cannot produce one, so the case is driven the POSIX way.
   it.skipIf(process.platform === "win32")("skips a mirror it could not replace, rather than overlaying it", () => {
     writeSkill(src, "books", "# v2");
+    writeFileSync(path.join(src, "books", "only-in-source.md"), "new");
     mkdirSync(path.join(dst, "books"), { recursive: true });
     writeFileSync(path.join(dst, "books", ".mt-mirror"), "x");
     writeFileSync(path.join(dst, "books", "stale.txt"), "old");
@@ -84,7 +85,9 @@ describe("syncCodexSkills", () => {
       // looks synced while holding whatever the source deleted. (The directory itself may be
       // partially emptied — rmSync removes contents before it fails on the directory — so the
       // assertion is on what did NOT arrive, which is the part that matters.)
-      expect(existsSync(path.join(dst, "books", "SKILL.md"))).toBe(false);
+      // A file only the new copy could bring — asserting on one that exists in both would
+      // depend on how far rmSync got before failing, which differs between machines.
+      expect(existsSync(path.join(dst, "books", "only-in-source.md"))).toBe(false);
     } finally {
       chmodSync(dst, 0o700);
     }

--- a/test/server/files/pathContainment.spec.ts
+++ b/test/server/files/pathContainment.spec.ts
@@ -163,6 +163,14 @@ describe("namesAWindowsDevice", () => {
     expect(namesAWindowsDevice(name, "win32")).toBe(true);
   });
 
+  // A colon opens an NTFS alternate data stream, and `NUL:` is the legacy device spelling —
+  // neither stops the name in front of it being a device. Flagged by Codex on #821.
+  it("refuses one behind a colon (alternate data stream / legacy device spelling)", () => {
+    for (const name of ["NUL:$DATA", "CON:foo", "docs/NUL:x", "AUX:"]) {
+      expect(namesAWindowsDevice(name, "win32"), name).toBe(true);
+    }
+  });
+
   it("refuses one whatever its case, extension, or trailing dots and spaces", () => {
     for (const name of ["nul", "Nul", "NUL.txt", "con.log", "NUL.", "NUL. ", "aux .txt"]) {
       expect(namesAWindowsDevice(name, "win32"), name).toBe(true);

--- a/test/server/files/pathContainment.spec.ts
+++ b/test/server/files/pathContainment.spec.ts
@@ -2,7 +2,15 @@ import { describe, it, expect } from "vitest";
 import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { containedPath, realContainedWithin, resolveBase, expandTilde, authorizedServingBase, resolveContained } from "../../../server/files/pathContainment";
+import {
+  containedPath,
+  realContainedWithin,
+  resolveBase,
+  expandTilde,
+  authorizedServingBase,
+  resolveContained,
+  namesAWindowsDevice,
+} from "../../../server/files/pathContainment";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-files-"));
 
@@ -143,5 +151,46 @@ describe("resolveBase", () => {
     expect(resolveBase(null, "/default")).toBe("/default");
     expect(resolveBase(path.join(dir, "missing"), "/default")).toBe("/default");
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// Windows resolves the DOS device names in EVERY directory: `C:\\anything\\NUL` is the null
+// device, not a missing file. Containment says yes — the path is inside the base — and the
+// open lands on a device. NUL reads as empty (merely wrong); CON blocks until the console has
+// input, which hangs the request that asked for it.
+describe("namesAWindowsDevice", () => {
+  it.each(["NUL", "CON", "PRN", "AUX", "COM1", "COM9", "LPT1", "LPT9"])("refuses %s on Windows", (name) => {
+    expect(namesAWindowsDevice(name, "win32")).toBe(true);
+  });
+
+  it("refuses one whatever its case, extension, or trailing dots and spaces", () => {
+    for (const name of ["nul", "Nul", "NUL.txt", "con.log", "NUL.", "NUL. ", "aux .txt"]) {
+      expect(namesAWindowsDevice(name, "win32"), name).toBe(true);
+    }
+  });
+
+  it("refuses one in ANY segment, with either separator", () => {
+    expect(namesAWindowsDevice("docs/NUL/readme.md", "win32")).toBe(true);
+    expect(namesAWindowsDevice("docs\\CON\\readme.md", "win32")).toBe(true);
+  });
+
+  it("allows ordinary names that merely start the same way", () => {
+    for (const name of ["console.ts", "contact.md", "nullable.ts", "com10.txt", "auxiliary/notes.md", "printer.log"]) {
+      expect(namesAWindowsDevice(name, "win32"), name).toBe(false);
+    }
+  });
+
+  // `con` is an ordinary filename on POSIX; refusing it there would break a real file.
+  it("allows every one of them off Windows", () => {
+    for (const name of ["NUL", "con/readme.md", "aux.txt"]) {
+      expect(namesAWindowsDevice(name, "linux"), name).toBe(false);
+    }
+  });
+
+  it("is refused by the shared gate, not just recognised", () => {
+    const root = realpathSync(tmp());
+    expect(resolveContained(root, "NUL", "/home/user", "win32")).toBeNull();
+    expect(resolveContained(root, "docs/CON.txt", "/home/user", "win32")).toBeNull();
+    rmSync(root, { recursive: true, force: true });
   });
 });

--- a/test/server/infra/fs-cleanup.spec.ts
+++ b/test/server/infra/fs-cleanup.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { removeQuietly } from "../../../server/infra/fs-cleanup";
+
+const dirs: string[] = [];
+const tmp = () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-cleanup-"));
+  dirs.push(dir);
+  return dir;
+};
+afterEach(() => dirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+describe("removeQuietly", () => {
+  it("removes a file and says it did", () => {
+    const dir = tmp();
+    const file = path.join(dir, "a.json");
+    writeFileSync(file, "{}");
+    expect(removeQuietly(file)).toBe(true);
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it("removes a whole tree", () => {
+    const dir = tmp();
+    mkdirSync(path.join(dir, "skills", "nested"), { recursive: true });
+    writeFileSync(path.join(dir, "skills", "nested", "SKILL.md"), "x");
+    expect(removeQuietly(path.join(dir, "skills"))).toBe(true);
+    expect(existsSync(path.join(dir, "skills"))).toBe(false);
+  });
+
+  // Every caller is cleanup after the work it belongs to has finished or failed, so "it was
+  // not there" is the normal case, not an error.
+  it("is a no-op for something that was never there", () => {
+    expect(removeQuietly(path.join(tmp(), "never-existed"))).toBe(true);
+  });
+
+  // The reason this exists: on Windows a file another process still holds fails with
+  // EPERM/EBUSY rather than being unlinked, and a throw out of a cleanup turns a transient
+  // lock into a broken teardown — a reap that stops halfway, a boot that gives up seeding.
+  // POSIX cannot produce that lock, so the failure path is driven directly.
+  it("reports a failure instead of throwing it", () => {
+    const locked = () => {
+      const err = new Error("EBUSY: resource busy or locked") as NodeJS.ErrnoException;
+      err.code = "EBUSY";
+      throw err;
+    };
+    expect(() => removeQuietly("C:\\held\\by\\claude.json", locked)).not.toThrow();
+    expect(removeQuietly("C:\\held\\by\\claude.json", locked)).toBe(false);
+  });
+
+  it("says it succeeded when the removal went through", () => {
+    expect(removeQuietly("anything", () => {})).toBe(true);
+  });
+});

--- a/test/server/infra/install-bundled-skills.spec.ts
+++ b/test/server/infra/install-bundled-skills.spec.ts
@@ -66,17 +66,18 @@ describe("installOwnedSkill", () => {
   // cannot produce it there, so the case is driven the POSIX way.
   it.skipIf(process.platform === "win32")("reports unreplaceable rather than overlaying a copy it could not remove", () => {
     installOwnedSkill(source, destParent);
-    writeFileSync(path.join(destParent, path.basename(source), "dropped-from-bundle.md"), "old");
+    // A file only the SECOND copy could bring. Asserting on one that exists in BOTH would
+    // depend on how far rmSync got before failing — it may or may not empty the directory
+    // first, and that differs between machines (this test passed locally and failed in CI on
+    // exactly that).
+    writeFileSync(path.join(source, "new-in-bundle.md"), "shipped later");
     chmodSync(destParent, 0o500);
     try {
       expect(installOwnedSkill(source, destParent)).toBe("unreplaceable");
     } finally {
       chmodSync(destParent, 0o700);
     }
-    // The bundle's copy did not land. (The directory itself may be partially emptied — rmSync
-    // removes contents before it fails on the directory — so the assertion is on what did NOT
-    // arrive, which is the part that would have been reported as a fresh install.)
-    expect(existsSync(path.join(destParent, path.basename(source), "SKILL.md"))).toBe(false);
+    expect(existsSync(path.join(destParent, path.basename(source), "new-in-bundle.md"))).toBe(false);
   });
 
   // Regression: a skill dir holding a file named exactly `schema.json` is loaded by the

--- a/test/server/infra/install-bundled-skills.spec.ts
+++ b/test/server/infra/install-bundled-skills.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { BUNDLED_SKILL_NAMES, installOwnedSkill, SCHEMA_ASSET_FILE } from "../../../server/infra/install-bundled-skills";
@@ -55,6 +55,28 @@ describe("installOwnedSkill", () => {
   it("returns absent-source when the bundled skill is missing", () => {
     expect(installOwnedSkill(path.join(root, "nope"), destParent)).toBe("absent-source");
     expect(existsSync(path.join(destParent, NAME))).toBe(false);
+  });
+
+  // Flagged by Codex on #821, the same stale-overlay class as syncCodexSkills: copying on top
+  // of a copy we could not remove leaves whatever the bundle has since dropped in place while
+  // reporting it as installed. `unreplaceable` is its own outcome — nobody else owns the
+  // directory, we simply could not replace it.
+  //
+  // The state it models (something still holding the directory) is Windows-only, and chmod
+  // cannot produce it there, so the case is driven the POSIX way.
+  it.skipIf(process.platform === "win32")("reports unreplaceable rather than overlaying a copy it could not remove", () => {
+    installOwnedSkill(source, destParent);
+    writeFileSync(path.join(destParent, path.basename(source), "dropped-from-bundle.md"), "old");
+    chmodSync(destParent, 0o500);
+    try {
+      expect(installOwnedSkill(source, destParent)).toBe("unreplaceable");
+    } finally {
+      chmodSync(destParent, 0o700);
+    }
+    // The bundle's copy did not land. (The directory itself may be partially emptied — rmSync
+    // removes contents before it fails on the directory — so the assertion is on what did NOT
+    // arrive, which is the part that would have been reported as a fresh install.)
+    expect(existsSync(path.join(destParent, path.basename(source), "SKILL.md"))).toBe(false);
   });
 
   // Regression: a skill dir holding a file named exactly `schema.json` is loaded by the

--- a/test/server/infra/read-text-file.spec.ts
+++ b/test/server/infra/read-text-file.spec.ts
@@ -1,0 +1,105 @@
+// A config file a human edited on Windows may start with a byte-order mark: Notepad,
+// `Set-Content` and PowerShell 5.1's `Out-File -Encoding utf8` all write one, and node keeps
+// it as a leading U+FEFF. `JSON.parse` then throws on the first character — and every config
+// reader here answers a throw with an empty config, so the file goes silently missing.
+//
+// The BOM is file CONTENT, so these run everywhere: the bug is reachable from any host that
+// opens a file written on Windows (a repo checkout, a synced directory, a pasted config).
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { stripBom, readTextFile, readJsonFile } from "../../../server/infra/read-text-file";
+import { loadDirConfig } from "../../../server/config/dir-config";
+import { loadPresets } from "../../../server/config/cwd-presets";
+import { loadScripts } from "../../../server/files/scripts";
+import { loadAppConfigResult } from "../../../server/config/app-config";
+
+const BOM = "﻿";
+const dirs: string[] = [];
+const tmp = () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-bom-"));
+  dirs.push(dir);
+  return dir;
+};
+afterEach(() => dirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+describe("stripBom", () => {
+  it("removes a LEADING byte-order mark", () => {
+    expect(stripBom(`${BOM}{"a":1}`)).toBe('{"a":1}');
+  });
+
+  // A U+FEFF anywhere else is content — a zero-width no-break space inside a string value —
+  // and removing it would corrupt the file rather than repair it.
+  it("leaves one that is not at the start alone", () => {
+    expect(stripBom(`{"a":"x${BOM}y"}`)).toBe(`{"a":"x${BOM}y"}`);
+  });
+
+  it("leaves text without one untouched, including empty text", () => {
+    expect(stripBom("plain")).toBe("plain");
+    expect(stripBom("")).toBe("");
+  });
+});
+
+describe("readTextFile / readJsonFile", () => {
+  it("reads a BOM-prefixed file as if it had none", () => {
+    const dir = tmp();
+    const file = path.join(dir, "x.json");
+    writeFileSync(file, `${BOM}{"a":1}`, "utf8");
+    expect(readTextFile(file)).toBe('{"a":1}');
+    expect(readJsonFile(file)).toEqual({ a: 1 });
+  });
+
+  // The callers each decide what a corrupt file means — one answers with an empty config,
+  // another refuses to overwrite it — so the parse error has to reach them.
+  it("still throws on JSON that is genuinely malformed", () => {
+    const dir = tmp();
+    const file = path.join(dir, "x.json");
+    writeFileSync(file, `${BOM}{"a":`, "utf8");
+    expect(() => readJsonFile(file)).toThrow();
+  });
+});
+
+// What the bug actually cost, per reader. Each of these silently produced "no config at all"
+// for a file whose only sin was being saved by a Windows editor.
+describe("the config readers, given a BOM", () => {
+  it("keeps a directory's own chrome (.mulmoterminal.json)", () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, ".mulmoterminal.json"), `${BOM}${JSON.stringify({ name: "my project", theme: "nord" })}`, "utf8");
+    const config = loadDirConfig(dir);
+    expect(config.name).toBe("my project");
+    expect(config.theme).toBe("nord");
+  });
+
+  it("keeps the Run menu's scripts (script.json)", () => {
+    const dir = tmp();
+    writeFileSync(path.join(dir, "script.json"), `${BOM}${JSON.stringify({ scripts: [{ label: "build", command: "yarn build" }] })}`, "utf8");
+    expect(loadScripts(dir)).toEqual([{ label: "build", command: "yarn build" }]);
+  });
+
+  it("keeps the cwd presets", () => {
+    const dir = tmp();
+    const file = path.join(dir, "presets.json");
+    writeFileSync(file, `${BOM}${JSON.stringify({ cwdPresets: [{ label: "repo", path: "/Users/me/repo" }] })}`, "utf8");
+    expect(loadPresets(file)).toEqual([{ label: "repo", path: "/Users/me/repo" }]);
+  });
+
+  // This one had the worst failure mode: the whole app config — providers, launchers, header
+  // buttons — read as "corrupt", which the lenient loader turns into an empty config.
+  it("keeps the app config, rather than reading it as corrupt", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, `${BOM}${JSON.stringify({ launchers: [{ label: "shell", command: "bash" }] })}`, "utf8");
+    const result = loadAppConfigResult(file);
+    expect(result.status).toBe("ok");
+  });
+
+  // A genuinely corrupt file must still be reported as corrupt: that verdict is what stops a
+  // write path from overwriting a file the user is still editing.
+  it("still calls a malformed app config corrupt", () => {
+    const dir = tmp();
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, `${BOM}{"launchers":`, "utf8");
+    expect(loadAppConfigResult(file).status).toBe("corrupt");
+  });
+});

--- a/test/server/infra/read-text-file.spec.ts
+++ b/test/server/infra/read-text-file.spec.ts
@@ -6,7 +6,7 @@
 // The BOM is file CONTENT, so these run everywhere: the bug is reachable from any host that
 // opens a file written on Windows (a repo checkout, a synced directory, a pasted config).
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { stripBom, readTextFile, readJsonFile } from "../../../server/infra/read-text-file";
@@ -14,6 +14,7 @@ import { loadDirConfig } from "../../../server/config/dir-config";
 import { loadPresets } from "../../../server/config/cwd-presets";
 import { loadScripts } from "../../../server/files/scripts";
 import { loadAppConfigResult } from "../../../server/config/app-config";
+import { loadUserTasks } from "../../../server/backends/scheduler";
 
 const BOM = "﻿";
 const dirs: string[] = [];
@@ -92,6 +93,19 @@ describe("the config readers, given a BOM", () => {
     writeFileSync(file, `${BOM}${JSON.stringify({ launchers: [{ label: "shell", command: "bash" }] })}`, "utf8");
     const result = loadAppConfigResult(file);
     expect(result.status).toBe("ok");
+  });
+
+  // The user's scheduled tasks — a file they edit by hand, so the same trap, and losing it
+  // means every scheduled run silently stops happening.
+  it("keeps the scheduled tasks (tasks.json)", () => {
+    const workspace = tmp();
+    mkdirSync(path.join(workspace, "config", "scheduler"), { recursive: true });
+    writeFileSync(
+      path.join(workspace, "config", "scheduler", "tasks.json"),
+      `${BOM}${JSON.stringify([{ id: "daily", prompt: "summarise", schedule: { kind: "daily", hour: 9, minute: 0 } }])}`,
+      "utf8",
+    );
+    expect(loadUserTasks(workspace)).toHaveLength(1);
   });
 
   // A genuinely corrupt file must still be reported as corrupt: that verdict is what stops a


### PR DESCRIPTION
## Summary

Windows 固有の問題をコードベース側から掃き出し、**本物のバグ3件**を見つけて直しました。**対策はすべて共通関数**に置いています（同じルールが再び散らないように）。

すべて **Windows でだけ起きて、POSIX からは見えない**類です。

## 1. Windows で保存した設定ファイルが「設定なし」として読まれる

Notepad / `Set-Content` / PowerShell 5.1 の `Out-File -Encoding utf8` は**いずれも UTF-8 BOM 付き**で書きます。Node の utf8 デコードは先頭の U+FEFF を残すので `JSON.parse` が1文字目で例外を投げ、**このリポジトリの設定リーダーは例外を「空の設定」で答える**ため、設定が丸ごと黙って消えます。

| ファイル | 失うもの |
| --- | --- |
| `.mulmoterminal.json` | ディレクトリの色・バッジ・ボタン・provider・model |
| `script.json` | Run メニュー |
| cwd presets | プリセット |
| `config.json` | **"corrupt" 判定 → 寛容ローダーが空設定に** = provider / launcher / ヘッダボタン **全部** |

どれも理由を何も表示しません。

**同じ罠の対策が既にリポジトリ内に2つありました**（`SKILL.md` frontmatter と wiki ページ）。ルールは知られていたのに JSON リーダーに適用されていなかったので、`server/infra/read-text-file.ts` に集約しました。剥がすのは**先頭だけ**です（途中の U+FEFF はゼロ幅ノーブレークスペース＝コンテンツ）。

**壊れた JSON は今までどおり corrupt と判定されます** — app-config の書き込み経路がユーザーの編集中ファイルを上書きしないための歯止めなので、例外は呼び出し側に届けたままです。

## 2. DOS デバイス名がファイルルートに届く

Windows は `CON` / `PRN` / `AUX` / `NUL` / `COM1-9` / `LPT1-9` を**すべてのディレクトリで**解決します。`C:\anything\NUL` は「存在しないファイル」ではなく**ヌルデバイス**です。したがって含有判定は「base の中だ」と答え、open がプロジェクトではなくデバイスに当たります。

- `NUL` → 空を読む（単に誤り）
- **`CON` → コンソール入力が来るまでブロック = そのリクエストがハングする**

拡張子は効きません（`CON.txt` も CON）。末尾のドットと空白も効きません（Windows が落とすので）。

ガードは **`resolveContained`（両方のファイル入口が既に共有しているゲート）**に置きました — 片方だけ直る事故が起きないようにするためです。**Windows のみ**（`con` は POSIX では普通のファイル名で、拒否すると実在のファイルが壊れます）。

## 3. クリーンアップの削除がロック中のファイルで例外を投げる

`rmSync(..., { force: true })` が飲むのは「無かった」だけです。Windows では**他プロセスが開いているファイル**は EPERM/EBUSY で失敗します。

ここでの呼び出しは**すべてクリーンアップ**（属する作業は既に完了か失敗済み）なので、例外は「一時的なロック」を「壊れた後始末」に変えるだけです — **reap が途中で止まる**（まだ終了中の claude が settings ファイルを掴んでいる）、**boot が skill の配置を諦める**。6箇所すべてを `server/infra/fs-cleanup.ts` 経由にし、**失敗は例外ではなく戻り値**で報告するようにしました。

## Items to Confirm / Review

- **3件とも共通関数**です（`read-text-file.ts` / `pathContainment.resolveContained` / `fs-cleanup.ts`）。ご指示どおり、同じルールが再び散らない形にしています。
- **`removeQuietly` の remover を注入可能**にしました。この失敗は **POSIX では作れない**（他プロセスがファイルを掴んでいる状態が必要）ので、catch を未検証のままにせず thrower で直接駆動しています。
- **BOM のテストは全 OS で走ります** — BOM はファイルの内容なので、Windows で書かれたファイルを開けばどのホストでも踏むためです。
- 予約デバイス名の判定は**セグメントごと**・**両方のセパレータ**・**大文字小文字を無視**して行い、`console.ts` / `nullable.ts` / `com10.txt` のような「先頭が同じだけ」の名前は通します。

## User Prompt

> エッジケース コーナーケースなどもね それ以外も検索してWindowsの固有問題のテストふやして／ファイル系も／もう一巡してpr 対策は共通関数作ってね

## テスト

- `test/server/infra/read-text-file.spec.ts`（新規10ケース・全 OS）— BOM の除去、**先頭以外は残す**、4つのリーダーそれぞれで設定が生き残ること、**壊れた app-config は今も corrupt**
- `test/server/files/pathContainment.spec.ts` — デバイス名 6 ケース（全種別 / 大文字小文字・拡張子・末尾ドット / 全セグメント・両セパレータ / 紛らわしい正常名 / POSIX では通す / **共有ゲートが実際に拒否する**）
- `test/server/infra/fs-cleanup.spec.ts`（新規5ケース）— ファイル / ツリー / 無かった場合 / **ロック時に投げずに false を返す**
- 実装を壊すとテストが落ちることを確認済み（BOM 除去を無効化すると 6 件赤）
- `yarn format` / `lint` / `typecheck` ×3 / `build` / `test` / `knip` — **すべて終了コード 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
