### PR TITLE
fix: the config write can destroy the config, and a crash leaves API tokens behind

### DIFF
--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -2,7 +2,7 @@
 // presets plus an optional custom attention-sound file. Unified read/write so a
 // partial update (e.g. just the sound) never clobbers the other field. Extracted
 // from config-routes.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
+import { existsSync, copyFileSync } from "node:fs";
 import path from "node:path";
 import { sanitizePresets } from "./cwd-presets.js";
 import { sanitizeButtons, sanitizeChips } from "./header-config.js";
@@ -19,6 +19,7 @@ import {
 } from "./config-schema.js";
 import { DEFAULT_TERMINAL_SUBMIT_MODE, isTerminalSubmitMode, type TerminalSubmitMode } from "../../common/terminalSubmit.js";
 import { readTextFile } from "../infra/read-text-file.js";
+import { writeFileAtomicSync } from "../files/atomic-write.js";
 
 export interface AppConfig {
   cwdPresets: CwdPreset[];
@@ -288,8 +289,9 @@ export function toPublicAppConfig(config: AppConfig): AppConfig {
 // surface it instead of reporting a false success.
 export function saveAppConfig(file: string, config: AppConfig): boolean {
   try {
-    mkdirSync(path.dirname(file), { recursive: true });
-    writeFileSync(file, JSON.stringify(toPublicAppConfig(config), null, 2));
+    // Atomic: this is the file holding every provider, launcher and header button, and a
+    // truncated one reads as corrupt on the next boot — i.e. as no configuration at all.
+    writeFileAtomicSync(file, JSON.stringify(toPublicAppConfig(config), null, 2));
     return true;
   } catch {
     return false;

--- a/server/config/cwd-presets.ts
+++ b/server/config/cwd-presets.ts
@@ -1,9 +1,10 @@
 // Directory presets the launch form offers, persisted at config.json. Extracted
 // from index.ts so the sanitize/load/save logic is unit-testable.
-import { existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { type CwdPreset } from "./config-schema.js";
 import { readJsonFile } from "../infra/read-text-file.js";
+import { writeFileAtomicSync } from "../files/atomic-write.js";
 
 const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const isPreset = (v: unknown): v is CwdPreset => isRecord(v) && typeof v.label === "string" && typeof v.path === "string";
@@ -32,8 +33,7 @@ export function loadPresets(file: string): CwdPreset[] {
 // instead of reporting a false success.
 export function savePresets(file: string, presets: CwdPreset[]): boolean {
   try {
-    mkdirSync(path.dirname(file), { recursive: true });
-    writeFileSync(file, JSON.stringify({ cwdPresets: presets }, null, 2));
+    writeFileAtomicSync(file, JSON.stringify({ cwdPresets: presets }, null, 2));
     return true;
   } catch {
     return false;

--- a/server/files/atomic-write.ts
+++ b/server/files/atomic-write.ts
@@ -1,4 +1,5 @@
 import { mkdir, rename, writeFile } from "node:fs/promises";
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { hasErrnoCode } from "../errors.js";
@@ -47,4 +48,32 @@ export async function writeFileAtomic(filePath: string, content: string): Promis
   const tmp = `${filePath}.${randomUUID()}.tmp`;
   await writeFile(tmp, content);
   await renameWithRetry(tmp, filePath);
+}
+
+/** The same guarantee for a caller that cannot await: write a unique temp, then rename over
+ *  the destination. A crash mid-write leaves the temp behind and the PREVIOUS file intact,
+ *  which is the whole point — `writeFileSync` truncates first, so the same crash leaves a
+ *  half-written config that the next boot reads as corrupt.
+ *
+ *  No retry loop here: the async path can wait out a Windows lock, and a synchronous caller
+ *  cannot block the event loop to do the same. A contended rename therefore throws, which the
+ *  callers already turn into "the save failed" — with the old file still on disk. */
+export function writeFileAtomicSync(
+  filePath: string,
+  content: string,
+  // Injected so the property that matters — the destination is never opened for writing —
+  // can be asserted. It cannot be observed from outside: the difference between this and a
+  // plain writeFileSync only shows if the process dies between the two calls.
+  write: (file: string, data: string) => void = writeFileSync,
+  renameOver: (from: string, to: string) => void = renameSync,
+): void {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${randomUUID()}.tmp`;
+  write(tmp, content);
+  try {
+    renameOver(tmp, filePath);
+  } catch (err) {
+    rmSync(tmp, { force: true }); // do not leave our temp behind when the rename is the thing that failed
+    throw err;
+  }
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -71,6 +71,7 @@ import { mountAppRoutes } from "./routes/app-routes.js";
 import { allowedToolNames } from "./infra/plugins-registry.js";
 import { resumableSessionPredicate } from "./session/resumable-sessions.js";
 import { installProcessGuards } from "./infra/process-guards.js";
+import { pruneOrphanSettings } from "./session/session-settings.js";
 
 // Per-session activity flags, driven by Claude hooks (see /api/hook).
 
@@ -499,13 +500,18 @@ server.on("error", (err) => {
 
 server.listen(PORT, () => {
   console.log(`mulmoterminal running at http://localhost:${PORT}`);
+  const surviving = tmuxAvailable() ? tmuxListSessionIds() : [];
   if (tmuxAvailable()) {
-    const surviving = tmuxListSessionIds();
     const detail = surviving.length ? ` — ${surviving.length} session(s) survived; reattach on connect` : "";
     console.log(`[tmux] persistence on${detail}`);
   } else {
     console.log("[tmux] not found — terminals are not persistent across a server restart");
   }
+  // A crash never reaches reap(), so settings files — one of which may hold a provider's API
+  // token — outlive the sessions that used them. Anything not backed by a surviving tmux
+  // session is an orphan: a PTY without tmux died with the server that owned it.
+  const droppedSettings = pruneOrphanSettings(new Set(surviving));
+  if (droppedSettings.length) console.log(`[settings] removed ${droppedSettings.length} orphaned session settings file(s)`);
   if (sandboxEnabled()) {
     if (!sandboxPlatformSupported()) {
       console.log("[sandbox] MULMOTERMINAL_SANDBOX set but only supported on macOS for now — using host spawn");

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -13,6 +13,7 @@ import { writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { removeQuietly } from "../infra/fs-cleanup.js";
+import { SESSION_ID_RE } from "../config/env.js";
 
 const SETTINGS_DIR = path.join(os.homedir(), ".mulmoterminal", "settings");
 
@@ -87,10 +88,13 @@ export function pruneOrphanSettings(liveIds: ReadonlySet<string>, dir: string = 
   return dropped;
 }
 
-// `<id>.json` and `<id>-mcp.json` are the two we write; anything else in the directory is
-// not ours to delete.
+// `<id>.json` and `<id>-mcp.json` are the two we write, and `<id>` is always a session id —
+// every caller takes one from randomUUID() or a SESSION_ID_RE match. Requiring that shape is
+// what keeps this from deleting a file that merely happens to end in `.json`: the directory
+// is ours, but "ours" is not a good enough reason to remove something we did not write.
 function sessionIdFromFileName(name: string): string | null {
   if (!name.endsWith(".json")) return null;
   const stem = name.slice(0, -".json".length);
-  return stem.endsWith("-mcp") ? stem.slice(0, -"-mcp".length) : stem;
+  const id = stem.endsWith("-mcp") ? stem.slice(0, -"-mcp".length) : stem;
+  return SESSION_ID_RE.test(id) ? id : null;
 }

--- a/server/session/session-settings.ts
+++ b/server/session/session-settings.ts
@@ -9,7 +9,7 @@
 // The env block is the transport for a reason: Claude Code applies it itself, so it
 // reaches the session identically on the host, under tmux — where a pane inherits the
 // tmux SERVER's environment, not the spawning client's — and inside a container.
-import { writeFileSync, mkdirSync } from "node:fs";
+import { writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { removeQuietly } from "../infra/fs-cleanup.js";
@@ -59,4 +59,38 @@ export function withSettingsCleanup<T>(sessionId: string, spawn: () => T): T {
 export function cleanupSessionSettings(sessionId: string): void {
   removeQuietly(settingsFile(sessionId));
   removeQuietly(mcpConfigFile(sessionId));
+}
+
+/** Drop settings files left behind by a server that never got to reap.
+ *
+ *  `cleanupSessionSettings` runs from reap(), which a crash — or a machine losing power —
+ *  never reaches. What stays behind is not inert: a provider session's file holds its API
+ *  token, so without this a token outlives the session that used it, survives being rotated
+ *  or revoked, and survives the provider being removed from the config entirely.
+ *
+ *  `liveIds` is what actually survived the restart — the tmux sessions still running. Nothing
+ *  else can still be reading its settings: a PTY without tmux died with the server that owned
+ *  it. Returns the ids it dropped, for the boot log. */
+export function pruneOrphanSettings(liveIds: ReadonlySet<string>, dir: string = SETTINGS_DIR): string[] {
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return []; // no settings dir yet — nothing has been written
+  }
+  const dropped: string[] = [];
+  for (const name of names) {
+    const id = sessionIdFromFileName(name);
+    if (id === null || liveIds.has(id)) continue;
+    if (removeQuietly(path.join(dir, name))) dropped.push(name);
+  }
+  return dropped;
+}
+
+// `<id>.json` and `<id>-mcp.json` are the two we write; anything else in the directory is
+// not ours to delete.
+function sessionIdFromFileName(name: string): string | null {
+  if (!name.endsWith(".json")) return null;
+  const stem = name.slice(0, -".json".length);
+  return stem.endsWith("-mcp") ? stem.slice(0, -"-mcp".length) : stem;
 }

--- a/test/server/files/atomic-write-sync.spec.ts
+++ b/test/server/files/atomic-write-sync.spec.ts
@@ -1,0 +1,92 @@
+// `writeFileSync` truncates the destination and then writes into it, so a crash — or a full
+// disk — in between leaves a half-written file. For the app config that means every provider,
+// launcher and header button read as corrupt on the next boot, i.e. as no configuration at
+// all. The repo already had the async answer to this; this is the same guarantee for a caller
+// that cannot await.
+import { describe, it, expect, afterEach } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { writeFileAtomicSync } from "../../../server/files/atomic-write";
+import { saveAppConfig, loadAppConfigResult } from "../../../server/config/app-config";
+
+const dirs: string[] = [];
+const tmp = () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-atomic-"));
+  dirs.push(dir);
+  return dir;
+};
+afterEach(() => dirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+describe("writeFileAtomicSync", () => {
+  it("writes the content, creating the parent directory", () => {
+    const file = path.join(tmp(), "nested", "deeper", "config.json");
+    writeFileAtomicSync(file, '{"a":1}');
+    expect(readFileSync(file, "utf8")).toBe('{"a":1}');
+  });
+
+  it("replaces an existing file", () => {
+    const file = path.join(tmp(), "config.json");
+    writeFileAtomicSync(file, "first");
+    writeFileAtomicSync(file, "second");
+    expect(readFileSync(file, "utf8")).toBe("second");
+  });
+
+  // The temp is what makes the write atomic; leaving one behind on every save would litter
+  // the config directory with them.
+  it("leaves no temp file behind", () => {
+    const dir = tmp();
+    writeFileAtomicSync(path.join(dir, "config.json"), "x");
+    expect(readdirSync(dir)).toEqual(["config.json"]);
+  });
+
+  // The property itself, which cannot be seen from outside: the destination is never opened
+  // for writing. A plain writeFileSync truncates it first, and the difference only shows if
+  // the process dies in between — so the calls are asserted directly.
+  it("writes somewhere else first and renames onto the destination", () => {
+    const file = path.join(tmp(), "config.json");
+    const calls: string[] = [];
+    writeFileAtomicSync(
+      file,
+      "x",
+      (target) => calls.push(`write ${target}`),
+      (from, to) => calls.push(`rename ${from} -> ${to}`),
+    );
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).not.toBe(`write ${file}`); // never the destination
+    expect(calls[0].startsWith(`write ${file}.`)).toBe(true); // a temp beside it
+    expect(calls[1].endsWith(`-> ${file}`)).toBe(true); // and only then, one rename
+  });
+
+  it("does not leave its temp behind when the rename is what failed", () => {
+    const dir = tmp();
+    // Renaming onto a DIRECTORY fails on every platform — the error class a Windows lock
+    // produces, reachable from here.
+    const blocked = path.join(dir, "occupied");
+    writeFileAtomicSync(path.join(blocked, "keep.txt"), "x"); // makes `occupied` a directory
+    expect(() => writeFileAtomicSync(blocked, "y")).toThrow();
+    expect(readdirSync(dir)).toEqual(["occupied"]);
+  });
+});
+
+describe("saveAppConfig", () => {
+  // What the atomicity is for: the previous config has to still be there when a save fails,
+  // rather than a truncated file that the next boot reads as corrupt.
+  it("round-trips through the real loader", () => {
+    const file = path.join(tmp(), "config.json");
+    expect(saveAppConfig(file, { launchers: [{ label: "shell", command: "bash" }] } as never)).toBe(true);
+    const loaded = loadAppConfigResult(file);
+    expect(loaded.status).toBe("ok");
+  });
+
+  it("reports failure instead of destroying what is there", () => {
+    const dir = tmp();
+    // A path whose parent is a file: the write cannot succeed, and must not be reported as if
+    // it had.
+    const file = path.join(dir, "config.json");
+    saveAppConfig(file, {} as never);
+    const impossible = path.join(file, "child.json");
+    expect(saveAppConfig(impossible, {} as never)).toBe(false);
+    expect(existsSync(file)).toBe(true); // the real config is untouched
+  });
+});

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -165,32 +165,39 @@ describe("pruneOrphanSettings", () => {
 
   const write = (dir: string, name: string) => writeFileSync(path.join(dir, name), "{}");
 
+  const DEAD = "11111111-2222-3333-4444-555555555555";
+  const ALIVE = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
   it("drops both files of a session that did not survive", () => {
     const dir = tmpDir();
-    write(dir, "dead-session.json");
-    write(dir, "dead-session-mcp.json");
-    expect(pruneOrphanSettings(new Set(), dir).sort()).toEqual(["dead-session-mcp.json", "dead-session.json"]);
-    expect(existsSync(path.join(dir, "dead-session.json"))).toBe(false);
-    expect(existsSync(path.join(dir, "dead-session-mcp.json"))).toBe(false);
+    write(dir, `${DEAD}.json`);
+    write(dir, `${DEAD}-mcp.json`);
+    expect(pruneOrphanSettings(new Set(), dir).sort()).toEqual([`${DEAD}-mcp.json`, `${DEAD}.json`]);
+    expect(existsSync(path.join(dir, `${DEAD}.json`))).toBe(false);
+    expect(existsSync(path.join(dir, `${DEAD}-mcp.json`))).toBe(false);
   });
 
   // The whole point of the liveIds argument: a tmux-backed session is still running with the
   // settings it was started with, so taking its file away is the one thing this must not do.
   it("keeps the files of a session that survived", () => {
     const dir = tmpDir();
-    write(dir, "alive.json");
-    write(dir, "alive-mcp.json");
-    expect(pruneOrphanSettings(new Set(["alive"]), dir)).toEqual([]);
-    expect(existsSync(path.join(dir, "alive.json"))).toBe(true);
-    expect(existsSync(path.join(dir, "alive-mcp.json"))).toBe(true);
+    write(dir, `${ALIVE}.json`);
+    write(dir, `${ALIVE}-mcp.json`);
+    expect(pruneOrphanSettings(new Set([ALIVE]), dir)).toEqual([]);
+    expect(existsSync(path.join(dir, `${ALIVE}.json`))).toBe(true);
+    expect(existsSync(path.join(dir, `${ALIVE}-mcp.json`))).toBe(true);
   });
 
-  it("leaves anything that is not one of ours alone", () => {
+  // Flagged by Codex on #822: the first version matched ANY `*.json`, so a file that merely
+  // shares the extension — the exact case its own comment promised to leave alone — was
+  // deleted. The directory being ours is not a reason to remove something we did not write.
+  it("leaves anything that is not one of ours alone, including other .json files", () => {
     const dir = tmpDir();
-    write(dir, "notes.txt");
-    write(dir, "README.md");
+    for (const name of ["notes.txt", "README.md", "notes.json", "backup.json", "not-a-uuid-mcp.json"]) write(dir, name);
     expect(pruneOrphanSettings(new Set(), dir)).toEqual([]);
-    expect(existsSync(path.join(dir, "notes.txt"))).toBe(true);
+    for (const name of ["notes.txt", "README.md", "notes.json", "backup.json", "not-a-uuid-mcp.json"]) {
+      expect(existsSync(path.join(dir, name)), name).toBe(true);
+    }
   });
 
   it("is a no-op when nothing has ever been written", () => {

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -1,10 +1,17 @@
 // @vitest-environment node
 import { describe, it, expect, afterEach } from "vitest";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { tmpdir } from "node:os";
 
-import { cleanupSessionSettings, settingsArgument, mcpConfigArgument, withSettingsCleanup } from "../../../server/session/session-settings.js";
+import {
+  cleanupSessionSettings,
+  settingsArgument,
+  mcpConfigArgument,
+  withSettingsCleanup,
+  pruneOrphanSettings,
+} from "../../../server/session/session-settings.js";
 import { hookSettingsJson } from "../../../server/session/hook-settings.js";
 import { buildClaudeArgs } from "../../../server/agents/claude-args.js";
 
@@ -141,5 +148,52 @@ describe("the argv a Windows spawn ends up with", () => {
       guiMcpTools: "mulmoterminal_readXPost,mulmoterminal_searchX",
     });
     expect(args.filter((a) => a.includes('"'))).toEqual([]);
+  });
+});
+
+// A crash never reaches reap(), so its sessions' settings files stay behind — and a provider
+// session's file holds its API token, which then outlives the session, survives being rotated
+// or revoked, and survives the provider being removed from the config.
+describe("pruneOrphanSettings", () => {
+  const dirs: string[] = [];
+  const tmpDir = () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mt-prune-"));
+    dirs.push(dir);
+    return dir;
+  };
+  afterEach(() => dirs.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true })));
+
+  const write = (dir: string, name: string) => writeFileSync(path.join(dir, name), "{}");
+
+  it("drops both files of a session that did not survive", () => {
+    const dir = tmpDir();
+    write(dir, "dead-session.json");
+    write(dir, "dead-session-mcp.json");
+    expect(pruneOrphanSettings(new Set(), dir).sort()).toEqual(["dead-session-mcp.json", "dead-session.json"]);
+    expect(existsSync(path.join(dir, "dead-session.json"))).toBe(false);
+    expect(existsSync(path.join(dir, "dead-session-mcp.json"))).toBe(false);
+  });
+
+  // The whole point of the liveIds argument: a tmux-backed session is still running with the
+  // settings it was started with, so taking its file away is the one thing this must not do.
+  it("keeps the files of a session that survived", () => {
+    const dir = tmpDir();
+    write(dir, "alive.json");
+    write(dir, "alive-mcp.json");
+    expect(pruneOrphanSettings(new Set(["alive"]), dir)).toEqual([]);
+    expect(existsSync(path.join(dir, "alive.json"))).toBe(true);
+    expect(existsSync(path.join(dir, "alive-mcp.json"))).toBe(true);
+  });
+
+  it("leaves anything that is not one of ours alone", () => {
+    const dir = tmpDir();
+    write(dir, "notes.txt");
+    write(dir, "README.md");
+    expect(pruneOrphanSettings(new Set(), dir)).toEqual([]);
+    expect(existsSync(path.join(dir, "notes.txt"))).toBe(true);
+  });
+
+  it("is a no-op when nothing has ever been written", () => {
+    expect(pruneOrphanSettings(new Set(), path.join(tmpDir(), "never-created"))).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

耐久性の穴を2件直しました。**どちらも「リポジトリに答えは既にあるのに、いちばん必要な場所が使っていない」**という、今日繰り返し出てきた形です。

## 1. 設定の保存が設定を壊し得る

```ts
// server/config/app-config.ts (before)
writeFileSync(file, JSON.stringify(toPublicAppConfig(config), null, 2));
```

`writeFileSync` は**対象を truncate してから書きます**。書き込み中にクラッシュ / kill / ディスク満杯が起きると `config.json` は**半端な状態**で残り、次回起動時に "corrupt" 判定 → 寛容ローダーが空設定を返す → **provider / launcher / ヘッダボタンが全部消えます**。

`server/files/atomic-write.ts` は**まさにこのために存在します**:

> Write a state file so a crash mid-write can't leave a truncated one behind

使っていたのは `feeds.ts` と `scheduled-sessions.ts` の2箇所だけで、**失って一番痛いファイルが使っていませんでした**。同期版 `writeFileAtomicSync` を同じモジュールに足し、`saveAppConfig` と cwd presets を通しました。

## 2. クラッシュすると API トークンがディスクに残り続ける

`cleanupSessionSettings` は `reap()` からしか呼ばれず、**クラッシュはそこに到達しません**。そして残るファイルは無害ではありません — #579 でこの仕組みが入った理由そのもので、**provider セッションの settings ファイルには API トークンが入っています**。つまりトークンが:

- セッションより長生きし、
- **ローテーション / 失効させても古い写しが残り**、
- provider を設定から消しても残ります。

起動時に「**生き残った tmux セッションに紐づかない settings ファイル**」を掃除するようにしました。それ以外を読んでいるものは存在し得ません — tmux 無しの PTY は、それを所有していたサーバと一緒に死んでいるためです。

## Items to Confirm / Review

- **同期版に再試行ループを入れていません。** 非同期版は Windows のロックを待てますが、**同期の呼び出し元はイベントループを止められません**。競合した rename は throw し、呼び出し元は既にそれを「保存失敗」として扱います — **古いファイルはディスクに残ったまま**で、それがこの変更の要点です。
- **`writeFileAtomicSync` は writer / renamer を注入可能**にしました。**肝心の性質（宛先を書き込み用に開かない）は外から観測できません** — プロセスが2つの呼び出しの間で死なないと差が出ないためです。実際、**最初に書いたテスト群は plain な `writeFileSync` に差し替えても全部通ってしまいました**。呼び出しそのものを assert する形にして、ようやく mutation で落ちるようになっています。
- **孤児掃除の安全性**: `liveIds` に入っているセッション（＝生きている tmux）のファイルは消しません。ここを間違えると**動作中のセッションから設定を取り上げる**ことになるので、テストで固定しています。自分たちが書いた `<id>.json` / `<id>-mcp.json` 以外のファイルにも触りません。

## User Prompt

> 一旦マージしてさらに探す／もっとない?／あ やる pr

## テスト

- `test/server/files/atomic-write-sync.spec.ts`（新規7ケース）— 親ディレクトリ作成、置換、**temp を残さない**、**rename 失敗時も temp を残さない**、**別の場所に書いてから rename する**（性質そのもの）、`saveAppConfig` の往復と失敗時に既存ファイルが無事なこと
- `test/server/session/session-settings.spec.ts` — 孤児掃除4ケース（両方のファイルを消す / **生存セッションのものは消さない** / 自分たちのもの以外に触らない / ディレクトリ未作成でも no-op）
- 実装を壊すとテストが落ちることを確認（宛先に直接書くようにすると1件赤）
- `yarn format` / `lint` / `typecheck` ×3 / `build` / `test` / `knip` — **すべて終了コード 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
