### PR TITLE
feat(remote-host): スマホのセッション画面から GitHub へリンクする

### DIFF
--- a/plans/feat-remote-host-github-link.md
+++ b/plans/feat-remote-host-github-link.md
@@ -1,0 +1,67 @@
+# feat(remote-host): スマホの画面から GitHub へリンクする
+
+Issue: #832 / スマホ側: receptron/mulmoserver#110
+
+## やること
+
+スマホのリモートターミナル画面が表示している dir が GitHub リポジトリなら、GitHub へ飛べる
+URL を一緒に渡す。`SessionScreenMeta` に `githubUrl?: string` を足すだけで、ハンドラは無改造。
+
+## リンク先の決定ルール
+
+**upstream があれば `/tree/<branch>`、無ければリポジトリのトップ。**
+
+`/tree/<branch>` を無条件に使えない理由は、**未 push のブランチが 404 になる**ため。managed
+worktree は `agent/<slug>` を切った直後で、そのブランチはローカルにしか存在しない。upstream の
+有無がそのまま「GitHub にこのブランチがあるか」の判定になる。
+
+`git-status.ts` の `aheadBehind` が既に `upstream` を持っていたが private かつ ahead/behind の
+カウントまで計算するので、`hasUpstream(cwd)` を1 git 呼び出しで切り出して export した。
+
+## 実装
+
+| ファイル | 変更 |
+|---|---|
+| `server/git/githubBranchUrl.ts`（新規） | 純粋関数。`(repoUrl, branch, hasUpstream) -> string \| null` |
+| `server/git/git-status.ts` | `hasUpstream(cwd)` を追加・export |
+| `server/backends/remoteHost/terminalScreen.ts` | `SessionScreenMeta.githubUrl?: string` |
+| `server/index.ts` | `remoteHostSessionScreenMeta` で3つの git 読みを `Promise.all` |
+
+判断（ルール）は純粋関数に閉じ込め、I/O は呼び出し側に残す。ハンドラは既存コメントどおり
+`SessionScreen` が wire shape なので触っていない。
+
+### ブランチ名のエンコード
+
+`agent/foo` の `/` は GitHub 上のパス区切りなので**残さなければならない**。
+`encodeURIComponent("agent/foo")` は `agent%2Ffoo` になり 404 する。セグメントごとに
+エンコードして `/` で繋ぐ。
+
+### レイテンシ
+
+`remoteHostSessionScreenMeta` は git を spawn する。今回 `resolveGithubUrl` と `hasUpstream` が
+増えて 1 → 3 になるので、`Promise.all` で並列化し、**待ち時間は spawn 1回分に保つ**。
+`captureSessionScreen` が screen 読みと meta 読みを既に `Promise.all` している意図を壊さない。
+
+remote URL は dir ごとにまず変わらないので `server/git/ttl-cache.ts` でキャッシュする余地があるが、
+リンクに陳腐化の窓が生まれるうえ計測もしていないので今回は入れない。
+
+## 対象外
+
+- **GitHub Enterprise** — `parseGithubWebUrl` は github.com 決め打ち。広げるとホスト許可リストの
+  設定項目が要る（今は設定不要で動くのが利点）。別 issue。
+- **grid 側** — `header-config.ts:45` に "Open on GitHub" が既にある。
+
+## テスト
+
+- `test/server/git/githubBranchUrl.spec.ts` — ルール8ケース（upstream 有無・detached・空・
+  `/` を保つ・その他のエスケープ・非 GitHub）
+- `test/server/git/hasUpstream.spec.ts` — **実 git**。bare リポジトリをローカルに作るので
+  ネットワーク不要。未 push / push 済み / push 済みリポの新規ローカルブランチ / detached /
+  **worktree（push 前後）** / 非リポジトリ
+- `terminalScreen.spec.ts` — 非 GitHub で `githubUrl` のキーごと落ちること
+
+### ミューテーション確認（すべて赤になることを確認済み）
+
+1. upstream ガードを外す → 1件赤
+2. ブランチ名全体を `encodeURIComponent` → 2件赤
+3. `hasUpstream` を常に `true` → 5件赤

--- a/plans/feat-remote-host-github-link.md
+++ b/plans/feat-remote-host-github-link.md
@@ -9,21 +9,42 @@ URL を一緒に渡す。`SessionScreenMeta` に `githubUrl?: string` を足す�
 
 ## リンク先の決定ルール
 
-**upstream があれば `/tree/<branch>`、無ければリポジトリのトップ。**
+**ブランチが origin 上にあれば `/tree/<branch>`、無ければリポジトリのトップ。**
 
-`/tree/<branch>` を無条件に使えない理由は、**未 push のブランチが 404 になる**ため。managed
-worktree は `agent/<slug>` を切った直後で、そのブランチはローカルにしか存在しない。upstream の
-有無がそのまま「GitHub にこのブランチがあるか」の判定になる。
+`/tree/<branch>` を無条件に使えない理由は、**GitHub に無いブランチが 404 になる**ため。managed
+worktree は `agent/<slug>` を切った直後で、そのブランチはローカルにしか存在しない。
 
 `git-status.ts` の `aheadBehind` が既に `upstream` を持っていたが private かつ ahead/behind の
-カウントまで計算するので、`hasUpstream(cwd)` を1 git 呼び出しで切り出して export した。
+カウントまで計算するので、1 git 呼び出しの述語を切り出して export した。
+
+### 「upstream の有無」では不十分だった（レビューで発見・実測で確認）
+
+最初の実装は `rev-parse --verify --quiet @{upstream}` で「upstream があるか」を見ていたが、
+これは **origin 以外のリモートを追跡するブランチを true にしてしまう**。`resolveGithubUrl` は
+`remote.origin.url` を読むので、リンクは「origin のリポジトリ + origin に無いブランチ名」に
+なり 404 する — チェックが防ぐはずだった失敗そのもの。fork 運用（origin=fork / upstream=本家）や
+2つ目の push 先がある構成で普通に踏む。
+
+`rev-parse --abbrev-ref --symbolic-full-name @{upstream}` に変更し、出力が `origin/` で
+始まるかを見る。**1回の git 呼び出しのまま**、以下すべてを false にできる（実測で確認）:
+
+| ケース | 結果 |
+|---|---|
+| upstream 未設定 / 未 push | コマンドが非ゼロ → false |
+| `other/feature/x` を追跡 | `origin/` で始まらない → false |
+| 設定は残るが tracking ref が消えている | コマンドが非ゼロ → false |
+| detached HEAD | コマンドが非ゼロ → false |
+| `origin2` という別リモート | `origin2/...` は `origin/` で始まらない → false |
+
+`aheadBehind` の `upstream`（どのリモートでも true）は**意図的に別の問い**なので変更しない。
+ahead/behind は追跡先が何であれ意味がある。この非対称はコメントで明記した。
 
 ## 実装
 
 | ファイル | 変更 |
 |---|---|
-| `server/git/githubBranchUrl.ts`（新規） | 純粋関数。`(repoUrl, branch, hasUpstream) -> string \| null` |
-| `server/git/git-status.ts` | `hasUpstream(cwd)` を追加・export |
+| `server/git/githubBranchUrl.ts`（新規） | 純粋関数。`(repoUrl, branch, branchIsOnOrigin) -> string \| null` |
+| `server/git/git-status.ts` | `tracksOriginBranch(cwd)` を追加・export |
 | `server/backends/remoteHost/terminalScreen.ts` | `SessionScreenMeta.githubUrl?: string` |
 | `server/index.ts` | `remoteHostSessionScreenMeta` で3つの git 読みを `Promise.all` |
 
@@ -38,8 +59,9 @@ worktree は `agent/<slug>` を切った直後で、そのブランチはロー�
 
 ### レイテンシ
 
-`remoteHostSessionScreenMeta` は git を spawn する。今回 `resolveGithubUrl` と `hasUpstream` が
-増えて 1 → 3 になるので、`Promise.all` で並列化し、**待ち時間は spawn 1回分に保つ**。
+`remoteHostSessionScreenMeta` は git を spawn する。今回 `resolveGithubUrl` と
+`tracksOriginBranch` が増えて 1 → 3 になるので、`Promise.all` で並列化し、
+**待ち時間は spawn 1回分に保つ**。
 `captureSessionScreen` が screen 読みと meta 読みを既に `Promise.all` している意図を壊さない。
 
 remote URL は dir ごとにまず変わらないので `server/git/ttl-cache.ts` でキャッシュする余地があるが、
@@ -53,15 +75,17 @@ remote URL は dir ごとにまず変わらないので `server/git/ttl-cache.ts
 
 ## テスト
 
-- `test/server/git/githubBranchUrl.spec.ts` — ルール8ケース（upstream 有無・detached・空・
+- `test/server/git/githubBranchUrl.spec.ts` — ルール8ケース（origin 上か・detached・空・
   `/` を保つ・その他のエスケープ・非 GitHub）
-- `test/server/git/hasUpstream.spec.ts` — **実 git**。bare リポジトリをローカルに作るので
+- `test/server/git/tracksOriginBranch.spec.ts` — **実 git**。bare リポジトリをローカルに作るので
   ネットワーク不要。未 push / push 済み / push 済みリポの新規ローカルブランチ / detached /
-  **worktree（push 前後）** / 非リポジトリ
+  **worktree（push 前後）** / **origin 以外を追跡** / **tracking ref だけ消えた状態** /
+  **`origin2` という紛らわしいリモート名** / 非リポジトリ
 - `terminalScreen.spec.ts` — 非 GitHub で `githubUrl` のキーごと落ちること
 
 ### ミューテーション確認（すべて赤になることを確認済み）
 
-1. upstream ガードを外す → 1件赤
+1. origin ガードを外す → 1件赤
 2. ブランチ名全体を `encodeURIComponent` → 2件赤
-3. `hasUpstream` を常に `true` → 5件赤
+3. `tracksOriginBranch` を常に `true` → 5件赤
+4. `tracksOriginBranch` をレビュー前の「upstream があるか」に戻す → 2件赤

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -98,6 +98,10 @@ export interface SessionScreenMeta {
   branch?: string;
   summary?: string;
   prompt?: string;
+  // The dir's page on GitHub, so the phone can link out to it (#832). Absent for every dir
+  // the host can't place there — not a repo, no origin, or an origin that isn't github.com
+  // — which is why the phone only ever has to decide "link or no link".
+  githubUrl?: string;
 }
 
 export interface SessionScreen extends SessionScreenMeta {

--- a/server/git/git-status.ts
+++ b/server/git/git-status.ts
@@ -25,12 +25,16 @@ export async function currentBranch(cwd: string): Promise<{ branch: string | nul
   return { branch: null, detached: head.ok };
 }
 
-// Whether HEAD tracks a remote branch. Exported for the callers that need only that —
-// one git call instead of aheadBehind's counts — and false for every case that makes
-// `@{upstream}` unresolvable: no upstream, a detached HEAD, or a non-repo dir.
-export async function hasUpstream(cwd: string): Promise<boolean> {
-  const res = await git(["rev-parse", "--verify", "--quiet", "@{upstream}"], cwd);
-  return res.ok;
+// Whether HEAD tracks a branch ON ORIGIN — deliberately narrower than aheadBehind's
+// `upstream` below, which counts whatever remote the branch follows because that is what
+// ahead/behind is measured against. A caller that pairs this with origin's URL needs the
+// stricter question: a branch tracking a second remote (a fork's `upstream`, another push
+// target) is absent from origin, so a link built from origin + this branch name would 404.
+// False too for a detached HEAD, an unpushed branch, a non-repo dir, and a tracking ref
+// that is still configured but no longer fetched — `--abbrev-ref` fails on all of them.
+export async function tracksOriginBranch(cwd: string): Promise<boolean> {
+  const res = await git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], cwd);
+  return res.ok && res.stdout.trim().startsWith("origin/");
 }
 
 // ahead/behind vs the tracking branch. `--left-right @{upstream}...HEAD` prints

--- a/server/git/git-status.ts
+++ b/server/git/git-status.ts
@@ -25,6 +25,14 @@ export async function currentBranch(cwd: string): Promise<{ branch: string | nul
   return { branch: null, detached: head.ok };
 }
 
+// Whether HEAD tracks a remote branch. Exported for the callers that need only that —
+// one git call instead of aheadBehind's counts — and false for every case that makes
+// `@{upstream}` unresolvable: no upstream, a detached HEAD, or a non-repo dir.
+export async function hasUpstream(cwd: string): Promise<boolean> {
+  const res = await git(["rev-parse", "--verify", "--quiet", "@{upstream}"], cwd);
+  return res.ok;
+}
+
 // ahead/behind vs the tracking branch. `--left-right @{upstream}...HEAD` prints
 // "<behind>\t<ahead>"; a missing upstream makes the command fail → upstream:false.
 async function aheadBehind(cwd: string): Promise<{ ahead: number; behind: number; upstream: boolean }> {

--- a/server/git/githubBranchUrl.ts
+++ b/server/git/githubBranchUrl.ts
@@ -1,0 +1,15 @@
+// Where a session's working dir points on GitHub. Pure (no I/O) so the rule is exhaustively
+// unit-tested; the caller supplies the repository URL, branch and upstream flag.
+
+// A branch earns /tree/<branch> only once it has an upstream. A managed worktree starts on a
+// fresh `agent/<slug>` that exists nowhere but this machine, so linking to it would 404 —
+// and so would any branch the user hasn't pushed yet. The repository root always resolves.
+export function githubBranchUrl(repoUrl: string | null, branch: string | null, hasUpstream: boolean): string | null {
+  if (!repoUrl) return null;
+  if (!branch || !hasUpstream) return repoUrl;
+  return `${repoUrl}/tree/${encodeBranchPath(branch)}`;
+}
+
+// Slashes in a branch name are path separators on GitHub (`agent/foo` → `/tree/agent/foo`),
+// so they must survive encoding; everything else is escaped per segment.
+const encodeBranchPath = (branch: string): string => branch.split("/").map(encodeURIComponent).join("/");

--- a/server/git/githubBranchUrl.ts
+++ b/server/git/githubBranchUrl.ts
@@ -1,12 +1,14 @@
 // Where a session's working dir points on GitHub. Pure (no I/O) so the rule is exhaustively
-// unit-tested; the caller supplies the repository URL, branch and upstream flag.
+// unit-tested; the caller supplies the repository URL, branch and whether that branch is on
+// the same remote the URL came from.
 
-// A branch earns /tree/<branch> only once it has an upstream. A managed worktree starts on a
-// fresh `agent/<slug>` that exists nowhere but this machine, so linking to it would 404 —
-// and so would any branch the user hasn't pushed yet. The repository root always resolves.
-export function githubBranchUrl(repoUrl: string | null, branch: string | null, hasUpstream: boolean): string | null {
+// A branch earns /tree/<branch> only once it is on origin. A managed worktree starts on a
+// fresh `agent/<slug>` that exists nowhere but this machine, and a branch tracking a second
+// remote is missing from origin just the same — linking to either would 404. The repository
+// root always resolves.
+export function githubBranchUrl(repoUrl: string | null, branch: string | null, branchIsOnOrigin: boolean): string | null {
   if (!repoUrl) return null;
-  if (!branch || !hasUpstream) return repoUrl;
+  if (!branch || !branchIsOnOrigin) return repoUrl;
   return `${repoUrl}/tree/${encodeBranchPath(branch)}`;
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -44,7 +44,7 @@ import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen, type SessionScreenMeta } from "./backends/remoteHost/terminalScreen.js";
-import { currentBranch, hasUpstream } from "./git/git-status.js";
+import { currentBranch, tracksOriginBranch } from "./git/git-status.js";
 import { resolveGithubUrl } from "./git/gitRemote.js";
 import { githubBranchUrl } from "./git/githubBranchUrl.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
@@ -376,7 +376,11 @@ const remoteHostCanClearBox = (sessionId: string): boolean => canClearInputBox(p
 const remoteHostSessionScreenMeta = async (sessionId: string): Promise<SessionScreenMeta> => {
   const cwd = ptys.get(sessionId)?.cwd ?? "";
   // The three git reads are independent, so the phone waits for one spawn rather than three.
-  const [head, repoUrl, upstream] = await Promise.all([cwd ? currentBranch(cwd) : null, cwd ? resolveGithubUrl(cwd) : null, cwd ? hasUpstream(cwd) : false]);
+  const [head, repoUrl, upstream] = await Promise.all([
+    cwd ? currentBranch(cwd) : null,
+    cwd ? resolveGithubUrl(cwd) : null,
+    cwd ? tracksOriginBranch(cwd) : false,
+  ]);
   return {
     cwd,
     branch: head?.branch ?? "",

--- a/server/index.ts
+++ b/server/index.ts
@@ -376,7 +376,7 @@ const remoteHostCanClearBox = (sessionId: string): boolean => canClearInputBox(p
 const remoteHostSessionScreenMeta = async (sessionId: string): Promise<SessionScreenMeta> => {
   const cwd = ptys.get(sessionId)?.cwd ?? "";
   // The three git reads are independent, so the phone waits for one spawn rather than three.
-  const [head, repoUrl, upstream] = await Promise.all([
+  const [head, repoUrl, onOrigin] = await Promise.all([
     cwd ? currentBranch(cwd) : null,
     cwd ? resolveGithubUrl(cwd) : null,
     cwd ? tracksOriginBranch(cwd) : false,
@@ -386,7 +386,7 @@ const remoteHostSessionScreenMeta = async (sessionId: string): Promise<SessionSc
     branch: head?.branch ?? "",
     summary: aiTitles.get(sessionId) ?? "",
     prompt: lastPrompts.get(sessionId) ?? "",
-    githubUrl: githubBranchUrl(repoUrl, head?.branch ?? null, upstream) ?? "",
+    githubUrl: githubBranchUrl(repoUrl, head?.branch ?? null, onOrigin) ?? "",
   };
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -44,7 +44,9 @@ import { claudeAdapter } from "./agents/claude.js";
 import { codexAdapter } from "./agents/codex.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen, type SessionScreenMeta } from "./backends/remoteHost/terminalScreen.js";
-import { currentBranch } from "./git/git-status.js";
+import { currentBranch, hasUpstream } from "./git/git-status.js";
+import { resolveGithubUrl } from "./git/gitRemote.js";
+import { githubBranchUrl } from "./git/githubBranchUrl.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
 import { initCollectionsBackend } from "./backends/collections.js";
 import { initGoogleBackend } from "./backends/google.js";
@@ -373,12 +375,14 @@ const remoteHostCanClearBox = (sessionId: string): boolean => canClearInputBox(p
 // no branch to look up — those fields are simply absent, and the phone shows the screen alone.
 const remoteHostSessionScreenMeta = async (sessionId: string): Promise<SessionScreenMeta> => {
   const cwd = ptys.get(sessionId)?.cwd ?? "";
-  const head = cwd ? await currentBranch(cwd) : null;
+  // The three git reads are independent, so the phone waits for one spawn rather than three.
+  const [head, repoUrl, upstream] = await Promise.all([cwd ? currentBranch(cwd) : null, cwd ? resolveGithubUrl(cwd) : null, cwd ? hasUpstream(cwd) : false]);
   return {
     cwd,
     branch: head?.branch ?? "",
     summary: aiTitles.get(sessionId) ?? "",
     prompt: lastPrompts.get(sessionId) ?? "",
+    githubUrl: githubBranchUrl(repoUrl, head?.branch ?? null, upstream) ?? "",
   };
 };
 

--- a/test/server/backends/remoteHost/terminalScreen.spec.ts
+++ b/test/server/backends/remoteHost/terminalScreen.spec.ts
@@ -262,6 +262,16 @@ describe("definedScreenMeta", () => {
     expect(definedScreenMeta({})).toEqual({});
   });
 
+  // The phone's whole rule for the GitHub link is "render it if the key is there" (#832), so
+  // a dir that isn't a GitHub repo must lose the key rather than arrive as "".
+  it("drops githubUrl for a dir the host can't place on GitHub, and keeps a real one", () => {
+    expect(definedScreenMeta({ cwd: "/repo", githubUrl: "" })).toEqual({ cwd: "/repo" });
+    expect(definedScreenMeta({ cwd: "/repo", githubUrl: "https://github.com/o/r/tree/main" })).toEqual({
+      cwd: "/repo",
+      githubUrl: "https://github.com/o/r/tree/main",
+    });
+  });
+
   // Emptiness is judged on the trimmed value, but the value itself is passed through as-is:
   // a prompt's own leading spaces are the user's text, not ours to edit.
   it("passes a value with surrounding whitespace through unchanged", () => {

--- a/test/server/git/githubBranchUrl.spec.ts
+++ b/test/server/git/githubBranchUrl.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { githubBranchUrl } from "../../../server/git/githubBranchUrl.js";
+
+const REPO = "https://github.com/owner/repo";
+
+describe("githubBranchUrl", () => {
+  it("links to the branch tree when it has an upstream", () => {
+    expect(githubBranchUrl(REPO, "main", true)).toBe(`${REPO}/tree/main`);
+  });
+
+  it("falls back to the repository root when the branch has no upstream", () => {
+    // The case that decided the design: a managed worktree starts on an agent/<slug> that
+    // exists only locally, so /tree/<branch> would 404 until it is pushed.
+    expect(githubBranchUrl(REPO, "agent/fix-the-thing", false)).toBe(REPO);
+  });
+
+  it("keeps a branch name's slashes as path separators", () => {
+    // encodeURIComponent on the whole name would emit agent%2Ffoo, which GitHub 404s.
+    expect(githubBranchUrl(REPO, "agent/foo", true)).toBe(`${REPO}/tree/agent/foo`);
+    expect(githubBranchUrl(REPO, "a/b/c", true)).toBe(`${REPO}/tree/a/b/c`);
+  });
+
+  it("escapes everything else in a segment", () => {
+    expect(githubBranchUrl(REPO, "fix/a b", true)).toBe(`${REPO}/tree/fix/a%20b`);
+    expect(githubBranchUrl(REPO, "feat/#42", true)).toBe(`${REPO}/tree/feat/%2342`);
+    expect(githubBranchUrl(REPO, "feat/a?b", true)).toBe(`${REPO}/tree/feat/a%3Fb`);
+    expect(githubBranchUrl(REPO, "日本語", true)).toBe(`${REPO}/tree/${encodeURIComponent("日本語")}`);
+  });
+
+  it("returns null when the dir is not a GitHub repo", () => {
+    expect(githubBranchUrl(null, "main", true)).toBeNull();
+    expect(githubBranchUrl(null, null, false)).toBeNull();
+  });
+
+  it("returns the root for a detached HEAD, which has no branch to link to", () => {
+    expect(githubBranchUrl(REPO, null, true)).toBe(REPO);
+    expect(githubBranchUrl(REPO, null, false)).toBe(REPO);
+  });
+
+  it("treats an empty branch name as no branch", () => {
+    expect(githubBranchUrl(REPO, "", true)).toBe(REPO);
+  });
+
+  it("does not care what shape the repo URL is — it only appends", () => {
+    // The caller's parseGithubWebUrl is what guarantees the base; this stays a pure join so
+    // a future GitHub Enterprise base needs no change here.
+    expect(githubBranchUrl("https://github.example.com/o/r", "main", true)).toBe("https://github.example.com/o/r/tree/main");
+  });
+});

--- a/test/server/git/hasUpstream.spec.ts
+++ b/test/server/git/hasUpstream.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { hasUpstream } from "../../../server/git/git-status.js";
+
+// Drives real git: the question is what `@{upstream}` resolves to, which a stub could only
+// restate. The remote is a bare repo on disk, so nothing here touches the network.
+describe("hasUpstream", () => {
+  let dir: string;
+  let repo: string;
+  let bare: string;
+
+  // The single place this file shells out, so the PATH exemption is stated once.
+  // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
+  const runGit = (...args: string[]): string => execFileSync("git", args, { stdio: ["ignore", "pipe", "ignore"] }).toString();
+
+  const hasGit = (() => {
+    try {
+      runGit("--version");
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  const g = (cwd: string, ...a: string[]) => runGit("-C", cwd, ...a);
+
+  beforeEach(() => {
+    dir = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-upstream-")));
+    repo = path.join(dir, "repo");
+    bare = path.join(dir, "remote.git");
+    if (!hasGit) return;
+    runGit("init", "-q", "--bare", "-b", "main", bare);
+    runGit("init", "-q", "-b", "main", repo);
+    g(repo, "config", "user.email", "t@t.t");
+    g(repo, "config", "user.name", "t");
+    g(repo, "remote", "add", "origin", bare);
+    writeFileSync(path.join(repo, "README.md"), "hi\n");
+    g(repo, "add", "-A");
+    g(repo, "commit", "-q", "-m", "init");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it.skipIf(!hasGit)("is false for a branch that has never been pushed", async () => {
+    expect(await hasUpstream(repo)).toBe(false);
+  });
+
+  it.skipIf(!hasGit)("is true once the branch tracks a remote branch", async () => {
+    g(repo, "push", "-q", "-u", "origin", "main");
+    expect(await hasUpstream(repo)).toBe(true);
+  });
+
+  // The case the feature exists for: a worktree's fresh agent/<slug> is local-only even
+  // though the repo it came from is fully pushed.
+  it.skipIf(!hasGit)("is false on a new local branch in a repo whose main is pushed", async () => {
+    g(repo, "push", "-q", "-u", "origin", "main");
+    g(repo, "checkout", "-q", "-b", "agent/fix-the-thing");
+    expect(await hasUpstream(repo)).toBe(false);
+  });
+
+  it.skipIf(!hasGit)("is false on a detached HEAD", async () => {
+    g(repo, "push", "-q", "-u", "origin", "main");
+    const head = g(repo, "rev-parse", "HEAD").trim();
+    g(repo, "checkout", "-q", head);
+    expect(await hasUpstream(repo)).toBe(false);
+  });
+
+  it.skipIf(!hasGit)("is false in a worktree until its branch is pushed, then true", async () => {
+    g(repo, "push", "-q", "-u", "origin", "main");
+    const wt = path.join(dir, "wt");
+    g(repo, "worktree", "add", "-q", wt, "-b", "agent/task");
+    expect(await hasUpstream(wt)).toBe(false);
+    g(wt, "push", "-q", "-u", "origin", "agent/task");
+    expect(await hasUpstream(wt)).toBe(true);
+  });
+
+  it("is false for a dir that is not a repo at all", async () => {
+    expect(await hasUpstream(dir)).toBe(false);
+  });
+});

--- a/test/server/git/tracksOriginBranch.spec.ts
+++ b/test/server/git/tracksOriginBranch.spec.ts
@@ -3,14 +3,15 @@ import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { hasUpstream } from "../../../server/git/git-status.js";
+import { tracksOriginBranch } from "../../../server/git/git-status.js";
 
 // Drives real git: the question is what `@{upstream}` resolves to, which a stub could only
 // restate. The remote is a bare repo on disk, so nothing here touches the network.
-describe("hasUpstream", () => {
+describe("tracksOriginBranch", () => {
   let dir: string;
   let repo: string;
   let bare: string;
+  let otherBare: string;
 
   // The single place this file shells out, so the PATH exemption is stated once.
   // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
@@ -31,12 +32,15 @@ describe("hasUpstream", () => {
     dir = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-upstream-")));
     repo = path.join(dir, "repo");
     bare = path.join(dir, "remote.git");
+    otherBare = path.join(dir, "other.git");
     if (!hasGit) return;
     runGit("init", "-q", "--bare", "-b", "main", bare);
+    runGit("init", "-q", "--bare", "-b", "main", otherBare);
     runGit("init", "-q", "-b", "main", repo);
     g(repo, "config", "user.email", "t@t.t");
     g(repo, "config", "user.name", "t");
     g(repo, "remote", "add", "origin", bare);
+    g(repo, "remote", "add", "other", otherBare);
     writeFileSync(path.join(repo, "README.md"), "hi\n");
     g(repo, "add", "-A");
     g(repo, "commit", "-q", "-m", "init");
@@ -47,12 +51,12 @@ describe("hasUpstream", () => {
   });
 
   it.skipIf(!hasGit)("is false for a branch that has never been pushed", async () => {
-    expect(await hasUpstream(repo)).toBe(false);
+    expect(await tracksOriginBranch(repo)).toBe(false);
   });
 
   it.skipIf(!hasGit)("is true once the branch tracks a remote branch", async () => {
     g(repo, "push", "-q", "-u", "origin", "main");
-    expect(await hasUpstream(repo)).toBe(true);
+    expect(await tracksOriginBranch(repo)).toBe(true);
   });
 
   // The case the feature exists for: a worktree's fresh agent/<slug> is local-only even
@@ -60,26 +64,54 @@ describe("hasUpstream", () => {
   it.skipIf(!hasGit)("is false on a new local branch in a repo whose main is pushed", async () => {
     g(repo, "push", "-q", "-u", "origin", "main");
     g(repo, "checkout", "-q", "-b", "agent/fix-the-thing");
-    expect(await hasUpstream(repo)).toBe(false);
+    expect(await tracksOriginBranch(repo)).toBe(false);
   });
 
   it.skipIf(!hasGit)("is false on a detached HEAD", async () => {
     g(repo, "push", "-q", "-u", "origin", "main");
     const head = g(repo, "rev-parse", "HEAD").trim();
     g(repo, "checkout", "-q", head);
-    expect(await hasUpstream(repo)).toBe(false);
+    expect(await tracksOriginBranch(repo)).toBe(false);
   });
 
   it.skipIf(!hasGit)("is false in a worktree until its branch is pushed, then true", async () => {
     g(repo, "push", "-q", "-u", "origin", "main");
     const wt = path.join(dir, "wt");
     g(repo, "worktree", "add", "-q", wt, "-b", "agent/task");
-    expect(await hasUpstream(wt)).toBe(false);
+    expect(await tracksOriginBranch(wt)).toBe(false);
     g(wt, "push", "-q", "-u", "origin", "agent/task");
-    expect(await hasUpstream(wt)).toBe(true);
+    expect(await tracksOriginBranch(wt)).toBe(true);
+  });
+
+  // The reason this asks about origin rather than "any upstream": resolveGithubUrl reads
+  // remote.origin.url, so a branch pushed to a SECOND remote is absent from the repo the
+  // link is built for. Answering "it has an upstream" here produces a 404 — the exact
+  // failure the check exists to prevent.
+  it.skipIf(!hasGit)("is false for a branch tracking a remote that isn't origin", async () => {
+    g(repo, "push", "-q", "-u", "origin", "main");
+    g(repo, "checkout", "-q", "-b", "feature/x");
+    g(repo, "push", "-q", "-u", "other", "feature/x");
+    expect(g(repo, "rev-parse", "--abbrev-ref", "@{upstream}").trim()).toBe("other/feature/x");
+    expect(await tracksOriginBranch(repo)).toBe(false);
+  });
+
+  // A branch whose tracking ref was configured but has since been pruned (the remote branch
+  // was deleted, or this clone never fetched it) is not on origin either.
+  it.skipIf(!hasGit)("is false when the tracking ref is configured but no longer present", async () => {
+    g(repo, "push", "-q", "-u", "origin", "main");
+    g(repo, "update-ref", "-d", "refs/remotes/origin/main");
+    expect(g(repo, "config", "--get", "branch.main.remote").trim()).toBe("origin");
+    expect(await tracksOriginBranch(repo)).toBe(false);
+  });
+
+  // A remote whose name merely starts with "origin" is a different remote.
+  it.skipIf(!hasGit)("does not mistake an origin-prefixed remote name for origin", async () => {
+    g(repo, "remote", "add", "origin2", otherBare);
+    g(repo, "push", "-q", "-u", "origin2", "main");
+    expect(await tracksOriginBranch(repo)).toBe(false);
   });
 
   it("is false for a dir that is not a repo at all", async () => {
-    expect(await hasUpstream(dir)).toBe(false);
+    expect(await tracksOriginBranch(dir)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

スマホのリモートターミナル画面は cwd と branch を表示している（#786）のに、そのリポジトリへ**行く手段が無かった**。`SessionScreenMeta` に `githubUrl` を足して解決する。ハンドラは無改造（`SessionScreen` 全体が wire shape なため）。

**リンク先は「upstream があれば `/tree/<branch>`、無ければリポジトリのトップ」。** ご指示のルールです。

## Items to Confirm / Review

1. **`hasUpstream` を新設した判断** — `git-status.ts` の `aheadBehind` が既に `upstream` を知っていましたが、private かつ ahead/behind のカウントまで計算します。今回必要なのは真偽値だけなので、`rev-parse --verify --quiet @{upstream}` 1回の `hasUpstream` を切り出して export しました。`aheadBehind` は変更していません（重複といえば重複なので、統合すべきかご判断ください）。
2. **git spawn が 1 → 3 に増える点** — スマホがポーリングする画面なので、`Promise.all` で並列化し**待ち時間は spawn 1回分**に保っています。プロセス数自体は3倍です。`server/git/ttl-cache.ts`（既存）で remote URL をキャッシュする案もありますが、**リンクに陳腐化の窓が生まれるうえ計測もしていないので今回は入れていません**。入れるべきならお知らせください。
3. **ブランチ名のエンコード** — `agent/foo` の `/` は GitHub 上のパス区切りなので残す必要があり、`encodeURIComponent` を名前全体にかけると `agent%2Ffoo` で 404 します。セグメントごとにエンコードしています。ここはテストで固定済みです。
4. **detached HEAD はトップに落とす** — ブランチが無いのでツリーを指せません。コミット SHA で `/tree/<sha>` を指す手もありますが、未 push だと同じく 404 なので採っていません。
5. **GitHub Enterprise は対象外**（issue で合意済み）。`githubBranchUrl` 自体はベース URL を問わない純粋な結合なので、`parseGithubWebUrl` を広げれば追随します。

## 実装

| ファイル | 変更 |
|---|---|
| `server/git/githubBranchUrl.ts`（新規） | 純粋関数 `(repoUrl, branch, hasUpstream) -> string \| null` |
| `server/git/git-status.ts` | `hasUpstream(cwd)` を追加・export |
| `server/backends/remoteHost/terminalScreen.ts` | `SessionScreenMeta.githubUrl?: string` |
| `server/index.ts` | `remoteHostSessionScreenMeta` で3つの git 読みを `Promise.all` |

判断（ルール）は純粋関数に閉じ込め、I/O は呼び出し側に残しています。非 GitHub の dir では `definedScreenMeta` が**キーごと落とす**ので、スマホ側は「あればリンクにする」だけで済みます（= `receptron/mulmoserver#110` の前提）。

設計の詳細は `plans/feat-remote-host-github-link.md`。

## テスト（+15、合計 4205 passed）

- `test/server/git/githubBranchUrl.spec.ts`（8）— upstream 有無 / detached / 空ブランチ / `/` を保つ / その他のエスケープ（空白・`#`・`?`・日本語）/ 非 GitHub
- `test/server/git/hasUpstream.spec.ts`（6）— **実 git**。bare リポジトリをローカルに作るので**ネットワーク不要**。未 push / push 済み / **push 済みリポの新規ローカルブランチ** / detached / **worktree（push 前後で false → true）** / 非リポジトリ
- `terminalScreen.spec.ts` — 空の `githubUrl` がキーごと落ちること

### ミューテーション確認（実装を壊すとテストが赤になることを確認済み）

| 壊し方 | 結果 |
|---|---|
| upstream ガードを外す | 1件赤 |
| ブランチ名全体を `encodeURIComponent` | 2件赤 |
| `hasUpstream` を常に `true` | 5件赤 |

なお **worktree で origin が引けること**は、使い捨てリポジトリを作って実測で確認したうえで設計しています（worktree は本体の `.git/config` を共有する）。この挙動は上記 worktree テストで固定されています。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/832 これできる？必要ならserverにもissueを追加してね
- upstream があれば /tree/branch で実装して

## 検証

`yarn format`（エラー0）/ `yarn lint`（0 errors、warning 4件は既存）/ `yarn typecheck` 0 / `yarn build` 0 / `yarn test` **4205 passed**

## 関連

- receptron/mulmoserver#110（スマホ側のリンク描画）
- #786 セッションの cwd / branch / summary / prompt をスマホへ渡す

Refs #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)