### PR TITLE
docs: ドキュメントサイトのリンクを README の先頭に置く

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 **Run a whole team of coding agents from your browser — and actually keep up with them.**
 
+### 📖 Documentation — **[receptron.github.io/mulmoterminal](https://receptron.github.io/mulmoterminal/)**
+
+- **User guide:** [English](https://receptron.github.io/mulmoterminal/guide/en/) — the grid
+  view, everyday workflows, the full feature list, configuration, and mobile push notifications.
+- **ユーザーガイド:** [日本語](https://receptron.github.io/mulmoterminal/guide/ja/) —
+  グリッドの使い方・日々のワークフロー・機能一覧・設定・スマホ通知の設定はこちら。
+
 ![MulmoTerminal — a grid of live Claude Code sessions, each color-coded by state, updating in real time](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/hero.gif)
 
 MulmoTerminal turns [Claude Code](https://claude.com/claude-code) (and OpenAI's **Codex**)
@@ -13,12 +20,6 @@ ping to your phone when a task finishes. One `npx` command, no Electron, no conf
 ```bash
 npx mulmoterminal        # starts on http://localhost:34567 and opens your browser
 ```
-
-- 📖 **User guide:** [English](https://receptron.github.io/mulmoterminal/guide/en/) — the
-  grid view, everyday workflows, the full feature list, configuration, and mobile push
-  notifications.
-- 📖 **ユーザーガイド:** [日本語](https://receptron.github.io/mulmoterminal/guide/ja/) —
-  グリッドの使い方・日々のワークフロー・機能一覧・設定・スマホ通知の設定はこちら。
 
 ![MulmoTerminal's grid view — four live Claude sessions running side by side, each in its own color-coded project](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/grid-2x2-live.png)
 


### PR DESCRIPTION
## Summary

`https://receptron.github.io/mulmoterminal/`（サイトのルート）へのリンクを README の**先頭・タグラインの直下**に置きました。

調べたところ、**サイトルートへのリンクは README に1つも存在していませんでした** — あったのは `/guide/en/` と `/guide/ja/` の2つだけで、しかも npx コマンドより下（17行目付近）でした。

## 変更

タグラインの直下・ヒーロー GIF の**上**に移動:

```
# mulmoterminal

**Run a whole team of coding agents from your browser — and actually keep up with them.**

### 📖 Documentation — **receptron.github.io/mulmoterminal**

- **User guide:** English — the grid view, everyday workflows, ...
- **ユーザーガイド:** 日本語 — グリッドの使い方・日々のワークフロー・...

![hero gif]
```

元の位置（npx コマンドの下）にあった同じ2リンクは**削除**しました。7行離れた場所に同じリンクが2度出るのを避けるためで、説明文は上のブロックに畳み込んでいるので情報は失われていません。

## Items to Confirm / Review

- **見出しレベルを `###` にした点** — `##` だと "Why you'll want it" などの本文セクションと同格になり目次が乱れます。`###` はタグライン直下で十分目立ちつつ、章立てを壊しません。
- **ヒーロー GIF より上に置いた点** — 「目立つように」を優先しました。GIF を先に見せたい場合は下げられます。
- 変更は README のみ、コードへの影響はありません（`.prettierignore` が `*.md` を除外しているため `yarn format` の対象外）。

## User Prompt

> 別件で、README の https://receptron.github.io/mulmoterminal/ リンク、topのほうにおこう。目立つように。

🤖 Generated with [Claude Code](https://claude.com/claude-code)