### PR TITLE
docs: CLAUDE.md に typecheck が3本ある事実を書く（spec は typecheck:test だけが見る）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,11 @@ anything not covered here.
 ## Run after changes
 - `yarn format` — Prettier. `.prettierignore` excludes `*.md`, so Markdown is not reformatted.
 - `yarn lint` — ESLint.
-- `yarn typecheck` — `vue-tsc -b`.
+- `yarn typecheck` — `vue-tsc -b`. **App code only — it does NOT compile the specs.**
+- `yarn typecheck:server` / `yarn typecheck:test` — CI runs these too. `typecheck:test`
+  (`tsconfig.test.json` + `tsconfig.test-server.json`) is the one that type-checks the specs,
+  including the ones colocated under `server/` rather than in `test/`. Change a shared type or
+  a wire shape and run **all three**: `yarn typecheck` alone passes while CI fails.
 - `yarn build` — `vue-tsc -b && vite build`.
 - `yarn test` — **Vitest** (`test/**/*.spec.ts`). Mock external APIs; tests must run without API keys.
 - `yarn dev` — server + Vite together (local development).


### PR DESCRIPTION
## Summary

`CLAUDE.md` の「Run after changes」が `yarn typecheck` **1本**しか挙げていませんでしたが、CI は **3本**回します。しかも **spec を型チェックするのは `typecheck:test` だけ**です。

この記載漏れが実際に CI を1往復無駄にしました（#840）。

## 何が起きたか

`yarn typecheck`（`vue-tsc -b`）は**アプリコードだけ**で spec を見ません。CI の `Typecheck (tests)` は `tsconfig.test.json` + `tsconfig.test-server.json` を使い spec も対象にします。

`CLAUDE.md` の記載どおり `yarn typecheck` だけ回して「全ゲート green」と判断した結果、CI で**型エラー10件**で落ちました。共有型を `common/` に移したことで、旧い形を組み立てていた spec が全滅していたのに、`vue-tsc -b` からは**見えなかった**ためです。

見落としやすかった点として、壊れた spec の一部は `test/` ではなく **`server/` に同居**していました（`server/backends/remoteHost/handlers.spec.ts` など）。

## 変更

```diff
- - `yarn typecheck` — `vue-tsc -b`.
+ - `yarn typecheck` — `vue-tsc -b`. **App code only — it does NOT compile the specs.**
+ - `yarn typecheck:server` / `yarn typecheck:test` — CI runs these too. `typecheck:test`
+   (`tsconfig.test.json` + `tsconfig.test-server.json`) is the one that type-checks the specs,
+   including the ones colocated under `server/` rather than in `test/`. Change a shared type or
+   a wire shape and run **all three**: `yarn typecheck` alone passes while CI fails.
```

## Items to Confirm / Review

- **グローバルの `~/.claude/CLAUDE.md` は変更していません。** あちらには既に一般則（「typecheck が定義されていれば必ず回せ／build が通っても typecheck は落ちうる」）があり正しく機能しています。今回足りなかったのは**このリポジトリ固有の事実**（3本に分かれている・spec を見るのはどれか）なので、プロジェクト側にだけ書きました。
- `package.json` の実際のスクリプトと突き合わせ済みです:
  - `typecheck` = `vue-tsc -b`
  - `typecheck:server` = `tsc -p tsconfig.server.json`
  - `typecheck:test` = `vue-tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.test-server.json`

## User Prompt

> このclaude.mdって~/.claudeの？もしそうなら、ここにはproject固有なのは追加しないでね

（その前段として、#840 の CI 失敗を受けて「CLAUDE.md を実態に合わせるか」を提案し、対象がプロジェクト側であることを確認したうえでの変更です）

ドキュメントのみの変更で、コードへの影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)