### PR TITLE
feat(remote-host): スマホから、今見ているセッションの dir で新規ターミナルを起動する

### DIFF
--- a/common/launchAgent.ts
+++ b/common/launchAgent.ts
@@ -1,0 +1,15 @@
+// What the phone may ask the grid to start in a session's directory (#831). The host
+// validates against this list and the grid turns each into a cell, so both sides read it.
+//
+// Deliberately NOT the configured `launchers` list: those are arbitrary user commands, and
+// the phone picks from a fixed set the host can name. "shell" is the OS default shell, the
+// same thing the header's new-terminal button opens.
+export const LAUNCH_AGENTS = ["shell", "claude", "codex"] as const;
+
+export type LaunchAgent = (typeof LAUNCH_AGENTS)[number];
+
+export const isLaunchAgent = (value: unknown): value is LaunchAgent => LAUNCH_AGENTS.some((agent) => agent === value);
+
+// The pub/sub channel the grid listens on for these requests. The grid is browser state, so
+// the host cannot open a cell itself — it asks whichever tab is connected.
+export const LAUNCH_TERMINAL_CHANNEL = "launch-terminal";

--- a/plans/feat-831-launch-from-phone.md
+++ b/plans/feat-831-launch-from-phone.md
@@ -1,0 +1,105 @@
+# feat(remote-host): スマホから、今見ているターミナルの dir で新規ターミナルを起動する
+
+Issue: #831 / スマホ側: receptron/mulmoserver#114
+
+## 調査で判明した制約（設計案が素直には通らなかった）
+
+issue の設計案は「リモートハンドラを足して起動する」だったが、**サーバ側から grid セッションを
+作る経路が存在しない**。
+
+- `markDevTerminalSession()` の呼び出しは **`server/routes/ws-routes.ts` の3箇所だけ**。
+  同ファイルのコメントが "the single choke point for every grid attach" と明記している。
+  つまりセッションが「グリッドのセル」になるのは**ブラウザが WebSocket を開いたとき**だけ。
+- グリッドのセル一覧（`gridTabs.ts` の `GridState`）は**ブラウザの状態**で、サーバは持たない。
+- しかもこれは**スマホ自身の一覧にも効く** — `listTerminalSessions` は
+  `isGridSession: (id) => devTerminalSessions.has(id)` で絞っている。
+
+つまり「サーバが直接 spawn する」を選ぶと、**PC の grid に出ないセッション**ができる。
+
+## 決めたこと（ユーザ確認済み）
+
+| 論点 | 決定 |
+|---|---|
+| 方式 | **ブラウザに依頼（pubsub）**。grid にもスマホにも正しく出る。ブラウザ不在時は起動不可 |
+| 起動対象 | **shell / codex / claude の3つ固定** |
+| cwd | **今見ているセッションの dir 固定**。スマホからパスは受け取らない（後述） |
+| 認可 | 既存ハンドラと同じ（remote-host 接続済みユーザ）。後述の根拠あり |
+| 簡易版の範囲 | worktree 作成・モデル選択は**落とす** |
+
+### cwd をスマホから受け取らない理由
+
+スマホが送るのは **`sessionId` だけ**で、cwd はホストが `ptys.get(id)?.cwd` から引く。
+パス文字列を受け付けると、リモートから任意ディレクトリでプロセスを起動できてしまう。
+issue の推奨（自由入力は許さない）をさらに進め、**パスを一切受け取らない**形にした。
+
+### 認可を既存ハンドラと同じにした根拠
+
+`sendTerminalInput` は既に**任意のテキストを Claude セッションに打ち込める**。エージェントは
+そのテキストに従って任意のコマンドを実行しうるので、「既存セッションの dir で shell を開く」は
+権限の格上げにならない。よって追加のゲートは設けない。
+
+## 設計
+
+### ブラウザ側の継ぎ目は既にある
+
+`src/composables/useNewTerminal.ts` が **"A seam for opening a new grid terminal cell from
+anywhere"** として存在し、グリッド未マウント時のキュー＋画面遷移まで持っている。今は $SHELL
+固定なので、`agent` を運べるように広げる。
+
+セルの形は3種類とも既存の型で表現できる（`gridTabs.ts` の `Cell`）:
+
+| 対象 | Cell |
+|---|---|
+| shell | `launcher: { shell: true, label: "shell" }`（= 既存の `shellCell`） |
+| claude | 何も付けない（Claude が既定） |
+| codex | `agent: "codex"` |
+
+### ブラウザ不在をスマホに伝える
+
+pubsub は socket.io の room なので、`io.sockets.adapter.rooms.get(channel)?.size` で
+**購読者数が取れる**。0 ならハンドラがエラーを返し、スマホは「PC でブラウザを開いてください」と
+出せる。publish しっぱなしで無言になるのが最悪なので、ここは明示する。
+
+## 実装
+
+| ファイル | 変更 |
+|---|---|
+| `server/infra/pubsub.ts` | `subscriberCount(channel)` を追加 |
+| `common/launchAgent.ts`（新規） | `LAUNCH_AGENTS` / `LaunchAgent`（サーバもUIも読む） |
+| `server/backends/remoteHost/launchTerminal.ts`（新規） | 純粋な判定（対象の検証・cwd 解決の可否） |
+| `server/backends/remoteHost/handlers.ts` | `launchTerminal` ハンドラ |
+| `server/index.ts` | 配線 |
+| `src/composables/useNewTerminal.ts` | `agent` を運ぶ |
+| `src/components/GridView.vue` | `agent` ごとにセルを作る／pubsub 購読 |
+
+## 対象外
+
+- スマホ側の起動画面（別 issue）
+- worktree 作成・モデル選択
+- `MAX_TERMINALS`(81) 到達時の扱い — ブラウザ側 `insertCellAfter` が既に上限で無変更を返す
+  ので**黙って何も起きない**。スマホへの通知は pubsub が一方向なので今回は入れない（要検討）
+
+## 実装中に判明したこと（追記）
+
+### 購読は App.vue に置く（GridView ではない）
+
+最初 GridView に購読を置いたが、`App.vue` は
+`<KeepAlive><GridView v-if="isGrid" /></KeepAlive>` なので **一度も `/terminals` を開いて
+いないと GridView は存在しない**。その状態ではブラウザが開いていても「開いていない」と
+判定されてしまう。
+
+`useNewTerminal.openTerminalAt` は「グリッド未マウントならキューして `/terminals` へ遷移」を
+既に持っているので、常時マウントされる `App.vue` で購読して `openTerminalAt` を呼ぶのが正しい。
+
+### `Publisher` 型を切り出した
+
+`subscriberCount` を足したことで、**publish しか使わない `fileChange.ts` / `notifier.ts` と
+そのテスト偽物にも実装を強制**してしまった。`publish` だけの `Publisher` を切り出して両者を
+そちらに向けた。今後 pubsub にメソッドが増えても波及しない。
+
+### ミューテーション確認
+
+| 壊し方 | 結果 |
+|---|---|
+| listener 数のガードを外す | 1件赤 |
+| cwd 不明のガードを外す | 1件赤 |

--- a/server/backends/fileChange.ts
+++ b/server/backends/fileChange.ts
@@ -9,10 +9,10 @@
 // the plugin-scoped channels are published.
 import path from "node:path";
 import { configureFileChangePublisher, publishFileChange } from "@mulmoclaude/core/file-change";
-import type { createPubSub } from "../infra/pubsub.js";
+import type { Publisher } from "../infra/pubsub.js";
 import { isDocPath } from "./docPath.js";
 
-type PubSub = ReturnType<typeof createPubSub>;
+type PubSub = Publisher;
 
 const log = {
   warn: (message: string, data?: Record<string, unknown>) => console.warn(`[file-change] ${message}`, data ?? ""),

--- a/server/backends/notifier.ts
+++ b/server/backends/notifier.ts
@@ -8,9 +8,9 @@ import fs from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import type { Express, Request, Response } from "express";
 import { configureNotifier, setNotifierFilePaths, listAll, listHistory, clear } from "@mulmoclaude/core/notifier";
-import type { createPubSub } from "../infra/pubsub.js";
+import type { Publisher } from "../infra/pubsub.js";
 
-type PubSub = ReturnType<typeof createPubSub>;
+type PubSub = Publisher;
 
 /** Pubsub channel the engine fans out on; the frontend bell subscribes to the same
  *  string (mirrored in src/composables/useNotifications.ts). */

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -62,6 +62,7 @@ describe("createRemoteHostHandlers · getFeed", () => {
       writeToSession: () => false,
       canClearBox: () => false,
       submitSequence: () => "\r",
+      launchTerminal: () => ({ ok: true }) as const,
     });
   });
   afterEach(() => vi.mocked(listFeeds).mockReset());

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -14,6 +14,7 @@ const unusedTerminalDeps = {
   writeToSession: () => false,
   canClearBox: () => false,
   submitSequence: () => "\r",
+  launchTerminal: () => ({ ok: true }) as const,
 };
 
 describe("createRemoteHostHandlers", () => {

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -54,6 +54,10 @@ export interface RemoteHostHandlerDeps {
   // sends only text; which byte commits it is the host's Claude binding — but only for a
   // Claude session, so this is resolved per session id (shell/codex stay on plain CR).
   submitSequence: (sessionId: string) => string;
+  // Open a new grid terminal in the directory of the session the phone is looking at
+  // (#831). Answered in server/index.ts, which owns the PTY table and the pub/sub the
+  // grid listens on. Resolves to an error string when it could not be started.
+  launchTerminal: (agent: unknown, sessionId: unknown) => { ok: true } | { ok: false; error: string };
 }
 
 // Parse the optional `attachments` param ([{ storage_id }]) into storage ids. A
@@ -152,7 +156,10 @@ const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (par
 // since #445 — type into it. Screens are bounded by the terminal's own geometry
 // (rows x cols), so unlike collections they need no paging to stay under the 1 MiB
 // command-doc ceiling.
-type TerminalScreenDeps = Pick<RemoteHostHandlerDeps, "listTerminalSessions" | "captureTerminalScreen" | "writeToSession" | "canClearBox" | "submitSequence">;
+type TerminalScreenDeps = Pick<
+  RemoteHostHandlerDeps,
+  "listTerminalSessions" | "captureTerminalScreen" | "writeToSession" | "canClearBox" | "submitSequence" | "launchTerminal"
+>;
 
 const terminalScreenHandlers = ({
   listTerminalSessions,
@@ -160,6 +167,7 @@ const terminalScreenHandlers = ({
   writeToSession,
   canClearBox,
   submitSequence,
+  launchTerminal,
 }: TerminalScreenDeps): CommandHandlers => {
   // One sender per host, so its per-session ordering actually spans every command.
   const sendInput = createTerminalInputSender({ writeToSession, canClearBox, submitSequence });
@@ -185,6 +193,19 @@ const terminalScreenHandlers = ({
       if (!sessionId) throw new Error("sessionId is required");
       const text = typeof params.text === "string" ? params.text : "";
       return (await sendInput(sessionId, text)) as unknown as JsonObject;
+    },
+
+    // Open a NEW grid terminal in the directory of the session the phone is viewing (#831).
+    // The phone names the session, never a path: the host looks the directory up, so a
+    // remote client cannot choose where a process starts.
+    //
+    // Throwing rather than returning the error is what puts the reason on the phone's
+    // screen — the command layer turns a rejection into the message it shows, and the
+    // most likely failure ("no browser is open") is one the user can act on.
+    launchTerminal: async (params: JsonObject) => {
+      const result = launchTerminal(params.agent, params.sessionId);
+      if (!result.ok) throw new Error(result.error);
+      return { ok: true } as unknown as JsonObject;
     },
   };
 };

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -86,6 +86,7 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
       writeToSession: deps.writeToSession,
       canClearBox: deps.canClearBox,
       submitSequence: deps.submitSequence,
+      launchTerminal: deps.launchTerminal,
     }),
     log: { ...log, debug: () => undefined },
   });

--- a/server/backends/remoteHost/launchTerminal.ts
+++ b/server/backends/remoteHost/launchTerminal.ts
@@ -24,11 +24,15 @@ export interface LaunchTerminalInput {
   listenerCount: number;
 }
 
+// Shared with the caller: the listener count is read before publishing, so a tab that closes
+// in between makes delivery fail after this said yes. Both paths report the same thing.
+export const NO_BROWSER_ERROR = "no MulmoTerminal browser is open — the grid opens the terminal, so a tab must be connected";
+
 export function decideLaunchTerminal({ agent, sessionId, cwdOf, listenerCount }: LaunchTerminalInput): LaunchTerminalDecision {
   if (!isLaunchAgent(agent)) return { ok: false, error: "agent must be one of: shell, claude, codex" };
   if (typeof sessionId !== "string" || !sessionId) return { ok: false, error: "sessionId is required" };
   const cwd = cwdOf(sessionId);
   if (!cwd) return { ok: false, error: `no working directory known for session '${sessionId}'` };
-  if (listenerCount < 1) return { ok: false, error: "no MulmoTerminal browser is open — the grid opens the terminal, so a tab must be connected" };
+  if (listenerCount < 1) return { ok: false, error: NO_BROWSER_ERROR };
   return { ok: true, request: { agent, cwd } };
 }

--- a/server/backends/remoteHost/launchTerminal.ts
+++ b/server/backends/remoteHost/launchTerminal.ts
@@ -1,0 +1,34 @@
+// Whether the phone's "open a terminal here" request can be served, and what to publish
+// (#831). Pure (no I/O) so every refusal is unit-tested; the caller supplies the session's
+// directory and how many browsers are listening.
+import { isLaunchAgent, type LaunchAgent } from "../../../common/launchAgent.js";
+
+// What the grid needs to open the cell. The cwd is the HOST's answer for the session the
+// phone was looking at — the phone never sends a path, so a remote client cannot name a
+// directory to start a process in.
+export interface LaunchTerminalRequest {
+  agent: LaunchAgent;
+  cwd: string;
+}
+
+export type LaunchTerminalDecision = { ok: true; request: LaunchTerminalRequest } | { ok: false; error: string };
+
+export interface LaunchTerminalInput {
+  agent: unknown;
+  sessionId: unknown;
+  // The session's working directory, or null when the host has none for it — a session that
+  // outlived a restart exists only in tmux and no PtyEntry remembers where it runs.
+  cwdOf: (sessionId: string) => string | null;
+  // Browsers subscribed to the launch channel. The grid is browser state, so with none
+  // listening nothing can open the cell and the phone must be told, not left waiting.
+  listenerCount: number;
+}
+
+export function decideLaunchTerminal({ agent, sessionId, cwdOf, listenerCount }: LaunchTerminalInput): LaunchTerminalDecision {
+  if (!isLaunchAgent(agent)) return { ok: false, error: "agent must be one of: shell, claude, codex" };
+  if (typeof sessionId !== "string" || !sessionId) return { ok: false, error: "sessionId is required" };
+  const cwd = cwdOf(sessionId);
+  if (!cwd) return { ok: false, error: `no working directory known for session '${sessionId}'` };
+  if (listenerCount < 1) return { ok: false, error: "no MulmoTerminal browser is open — the grid opens the terminal, so a tab must be connected" };
+  return { ok: true, request: { agent, cwd } };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -48,7 +48,7 @@ import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen, type SessionScreenMeta } from "./backends/remoteHost/terminalScreen.js";
 import type { SessionAgent } from "../common/sessionAgent.js";
 import { quickCommandsForAgent } from "./backends/remoteHost/quickCommands.js";
-import { decideLaunchTerminal } from "./backends/remoteHost/launchTerminal.js";
+import { decideLaunchTerminal, NO_BROWSER_ERROR } from "./backends/remoteHost/launchTerminal.js";
 import { LAUNCH_TERMINAL_CHANNEL } from "../common/launchAgent.js";
 import { currentBranch } from "./git/git-status.js";
 import { resolveGithubUrl } from "./git/gitRemote.js";
@@ -443,8 +443,11 @@ const remoteHostLaunchTerminal = (agent: unknown, sessionId: unknown) => {
     listenerCount: pubsub?.subscriberCount(LAUNCH_TERMINAL_CHANNEL) ?? 0,
   });
   if (!decision.ok) return decision;
-  pubsub?.publish(LAUNCH_TERMINAL_CHANNEL, decision.request);
-  return { ok: true as const };
+  // ONE tab, not every tab: this asks for a terminal to be opened, so a broadcast would open
+  // one per connected browser. Delivery is also the authority on whether anyone was there —
+  // the count above was read a moment earlier and that tab may have closed since.
+  const delivered = pubsub?.publishToOne(LAUNCH_TERMINAL_CHANNEL, decision.request) ?? false;
+  return delivered ? { ok: true as const } : { ok: false as const, error: NO_BROWSER_ERROR };
 };
 
 initRemoteHostBackend({

--- a/server/index.ts
+++ b/server/index.ts
@@ -48,6 +48,8 @@ import { renderScreen } from "./session/headlessScreen.js";
 import { agentFromPaneCommand, buildSessionList, captureSessionScreen, type SessionScreenMeta } from "./backends/remoteHost/terminalScreen.js";
 import type { SessionAgent } from "../common/sessionAgent.js";
 import { quickCommandsForAgent } from "./backends/remoteHost/quickCommands.js";
+import { decideLaunchTerminal } from "./backends/remoteHost/launchTerminal.js";
+import { LAUNCH_TERMINAL_CHANNEL } from "../common/launchAgent.js";
 import { currentBranch } from "./git/git-status.js";
 import { resolveGithubUrl } from "./git/gitRemote.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
@@ -429,9 +431,26 @@ const remoteHostCaptureTerminalScreen = (sessionId: string) =>
     quickCommandsOf: (id) => quickCommandsForAgent(getQuickCommands(), agentOfSession(id)),
   });
 
+// The phone asked for a new terminal in the directory of the session it was viewing (#831).
+// The grid lives in the browser — markDevTerminalSession is only ever reached through the
+// terminal WebSocket — so the host cannot open the cell, and publishes the request to
+// whichever tab is connected instead. The phone sends a session id, never a path.
+const remoteHostLaunchTerminal = (agent: unknown, sessionId: unknown) => {
+  const decision = decideLaunchTerminal({
+    agent,
+    sessionId,
+    cwdOf: (id) => ptys.get(id)?.cwd ?? null,
+    listenerCount: pubsub?.subscriberCount(LAUNCH_TERMINAL_CHANNEL) ?? 0,
+  });
+  if (!decision.ok) return decision;
+  pubsub?.publish(LAUNCH_TERMINAL_CHANNEL, decision.request);
+  return { ok: true as const };
+};
+
 initRemoteHostBackend({
   workspace: CLAUDE_CWD,
   spawnChat: remoteHostSpawnChat,
+  launchTerminal: remoteHostLaunchTerminal,
   listTerminalSessions: remoteHostListTerminalSessions,
   captureTerminalScreen: remoteHostCaptureTerminalScreen,
   writeToSession: remoteHostWriteToSession,

--- a/server/infra/pubsub.ts
+++ b/server/infra/pubsub.ts
@@ -46,5 +46,18 @@ export function createPubSub(server: HttpServer, isAllowedOrigin: (origin?: stri
     subscriberCount(channel: string): number {
       return io.sockets.adapter.rooms.get(channel)?.size ?? 0;
     },
+    // Deliver to exactly ONE subscriber, and say whether anyone got it.
+    //
+    // `publish` broadcasts, which is right for the channels that announce a fact — a dir's
+    // config changed, a session became active — since every tab reacting is the point and
+    // reacting twice costs nothing. A message that asks for an ACTION is the opposite: with
+    // two MulmoTerminal tabs open, a broadcast would have each of them open a terminal, so
+    // one tap on the phone spawns as many PTYs as there are tabs.
+    publishToOne(channel: string, data: unknown): boolean {
+      const [first] = io.sockets.adapter.rooms.get(channel) ?? [];
+      if (!first) return false;
+      io.to(first).emit("data", { channel, data });
+      return true;
+    },
   };
 }

--- a/server/infra/pubsub.ts
+++ b/server/infra/pubsub.ts
@@ -5,6 +5,13 @@ import type { Server as HttpServer } from "node:http";
 // Channel names are socket.io rooms — subscribe/unsubscribe map to
 // socket.join / socket.leave, and publish broadcasts to the room.
 // socket.io handles reconnect / heartbeat / transport for us.
+// What a module that only ANNOUNCES needs. Depending on the whole createPubSub return type
+// instead means every such module — and every test fake — has to grow a method it never
+// calls each time this file gains one.
+export interface Publisher {
+  publish(channel: string, data: unknown): void;
+}
+
 export function createPubSub(server: HttpServer, isAllowedOrigin: (origin?: string) => boolean = () => true) {
   const io = new IOServer(server, {
     path: "/ws/pubsub",
@@ -31,6 +38,13 @@ export function createPubSub(server: HttpServer, isAllowedOrigin: (origin?: stri
   return {
     publish(channel: string, data: unknown) {
       io.to(channel).emit("data", { channel, data });
+    },
+    // How many sockets are in the room. A publish is fire-and-forget, so a caller that
+    // NEEDS someone to act on the message (the phone asking the grid to open a terminal,
+    // #831) has to check first — otherwise "no browser is open" is indistinguishable from
+    // success, and the phone reports a launch that never happened.
+    subscriberCount(channel: string): number {
+      return io.sockets.adapter.rooms.get(channel)?.size ?? 0;
     },
   };
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,12 +26,33 @@ import { useSoundEnabled } from "./composables/useSoundEnabled";
 import { useAttentionSound } from "./composables/useAttentionSound";
 import { useUnloadGuard, reportActiveTerminals } from "./composables/useUnloadGuard";
 import { browserLocale } from "./utils/browserLocale";
+import { usePubSub } from "./composables/usePubSub";
+import { openTerminalAt } from "./composables/useNewTerminal";
+import { LAUNCH_TERMINAL_CHANNEL, isLaunchAgent, type LaunchAgent } from "../common/launchAgent";
 import { clampTerminalWidth, maxTerminalWidth, MIN_TERMINAL, splitterKeyWidth } from "./components/splitterWidth";
 
 // View mode is now the URL: the multi-terminal grid is /terminals, everything else
 // (chat + the collection/accounting overlays) lives under the single-view shell.
 const route = useRoute();
 const isGrid = computed(() => route.name === "terminals");
+
+// The phone asked for a new terminal in a session's directory (#831). The grid is browser
+// state — the host can only ask — so SOMETHING has to be listening for this to be servable,
+// and the host tells the phone outright when nothing is. Subscribed here rather than in
+// GridView because GridView is `v-if`d on the route and so does not exist until the user has
+// visited /terminals once; openTerminalAt already queues the request and navigates there.
+const launchRequestOf = (data: unknown): { cwd: string; agent: LaunchAgent } | null => {
+  if (typeof data !== "object" || data === null) return null;
+  const { cwd, agent } = data as { cwd?: unknown; agent?: unknown };
+  return typeof cwd === "string" && cwd && isLaunchAgent(agent) ? { cwd, agent } : null;
+};
+// Appended at the end of the grid: the phone has no notion of which desktop cell is
+// "current", and guessing would drop the terminal somewhere arbitrary.
+const unsubscribeLaunch = usePubSub().subscribe(LAUNCH_TERMINAL_CHANNEL, (data) => {
+  const request = launchRequestOf(data);
+  if (request) openTerminalAt(request.cwd, null, request.agent);
+});
+onUnmounted(unsubscribeLaunch);
 
 // A script picked from the terminal header's Run menu runs in the grid (command
 // cells live only there): stash it and switch to the grid, which picks it up.

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -53,6 +53,7 @@ import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
 import { fetchDirConfig, invalidateDirConfig } from "../composables/useDirConfig";
 import { usePubSub } from "../composables/usePubSub";
+import type { LaunchAgent } from "../../common/launchAgent";
 
 // The multi-terminal grid view, shown at /terminals. Leaving the grid is just a
 // route push from the shared toolbar (Chat / Collections / a favorite), so there's
@@ -351,10 +352,19 @@ onMounted(() => {
 // grid instead of routing here. openTerminalAt then queues + navigates while we're deactivated.
 const SLOT_UID_RE = /^cell-(\d+)$/;
 let offNewTerminal: (() => void) | null = null;
-const openNewTerminal = ({ cwd, afterSlotKey }: NewTerminalRequest) => {
+// Each kind is already expressible as a cell: a shell is a shell launcher, codex is marked
+// with `agent`, and Claude is the plain default. The session id arrives from the server once
+// the cell opens its socket, so all three persist and reconnect like any other cell.
+const cellForAgent = (cwd: string, agent: LaunchAgent | undefined): Omit<Cell, "uid"> => {
+  if (agent === "claude") return { session: null, cwd };
+  if (agent === "codex") return { session: null, cwd, agent: "codex" };
+  return shellCell(cwd);
+};
+
+const openNewTerminal = ({ cwd, afterSlotKey, agent }: NewTerminalRequest) => {
   const match = afterSlotKey?.match(SLOT_UID_RE);
   const afterUid = match ? Number(match[1]) : NO_ORIGIN_UID;
-  state.value = insertCellAfter(state.value, afterUid, shellCell(cwd));
+  state.value = insertCellAfter(state.value, afterUid, cellForAgent(cwd, agent));
 };
 const detachNewTerminal = () => {
   offNewTerminal?.();

--- a/src/composables/useNewTerminal.ts
+++ b/src/composables/useNewTerminal.ts
@@ -8,10 +8,14 @@
 // app switches to /terminals; GridView drains the queue when it registers on mount — mirroring
 // usePendingScript for the single view's Run menu.
 import { router } from "../router";
+import type { LaunchAgent } from "../../common/launchAgent";
 
 export interface NewTerminalRequest {
   cwd: string;
   afterSlotKey: string | null;
+  // What the new cell runs. Omitted means the OS default shell, which is what the header
+  // button has always opened; the phone can also ask for claude or codex (#831).
+  agent?: LaunchAgent;
 }
 type Handler = (req: NewTerminalRequest) => void;
 
@@ -32,10 +36,10 @@ export function registerNewTerminalHandler(h: Handler): () => void {
   };
 }
 
-// Open a new terminal cell running $SHELL in `cwd`, next to `afterSlotKey`'s cell. If the grid isn't
-// mounted yet, queue the request and switch to it.
-export function openTerminalAt(cwd: string, afterSlotKey: string | null): void {
-  const req: NewTerminalRequest = { cwd, afterSlotKey };
+// Open a new terminal cell in `cwd`, next to `afterSlotKey`'s cell — running `agent`, or the OS
+// default shell when it is omitted. If the grid isn't mounted yet, queue the request and switch to it.
+export function openTerminalAt(cwd: string, afterSlotKey: string | null, agent?: LaunchAgent): void {
+  const req: NewTerminalRequest = { cwd, afterSlotKey, agent };
   if (handler) {
     handler(req);
     return;

--- a/src/composables/useNewTerminal.ts
+++ b/src/composables/useNewTerminal.ts
@@ -7,6 +7,11 @@
 // When the grid isn't mounted (the button pressed from the single view), the request is QUEUED and the
 // app switches to /terminals; GridView drains the queue when it registers on mount — mirroring
 // usePendingScript for the single view's Run menu.
+//
+// The queue holds EVERY waiting request, not just the newest. One slot was enough while the only
+// caller was a button — a person cannot press it twice before the route changes — but the phone
+// asks over pub/sub (#831) and the host answers each command with success, so a dropped request
+// would be a launch reported as done that never happened.
 import { router } from "../router";
 import type { LaunchAgent } from "../../common/launchAgent";
 
@@ -20,17 +25,18 @@ export interface NewTerminalRequest {
 type Handler = (req: NewTerminalRequest) => void;
 
 let handler: Handler | null = null;
-let pending: NewTerminalRequest | null = null;
+let pending: NewTerminalRequest[] = [];
 
-// GridView registers its opener; a queued request (from before it mounted) drains immediately.
-// The returned function unregisters it (call in onBeforeUnmount).
+// GridView registers its opener; every request queued before it mounted drains immediately, in
+// arrival order. The returned function unregisters it (call in onBeforeUnmount).
 export function registerNewTerminalHandler(h: Handler): () => void {
   handler = h;
-  if (pending) {
-    const req = pending;
-    pending = null;
-    h(req);
-  }
+  // Taken before dispatching: a handler that itself queues (it can reach openTerminalAt through
+  // the grid) would otherwise have its request dropped by the clear below.
+  const queued = pending;
+  pending = [];
+  // Not `queued.forEach(h)`: forEach would hand the handler the index and the array too.
+  queued.forEach((req) => h(req));
   return () => {
     if (handler === h) handler = null;
   };
@@ -44,6 +50,6 @@ export function openTerminalAt(cwd: string, afterSlotKey: string | null, agent?:
     handler(req);
     return;
   }
-  pending = req;
+  pending.push(req);
   router.push("/terminals").catch(() => {});
 }

--- a/test/server/backends/remoteHost/launchTerminal.spec.ts
+++ b/test/server/backends/remoteHost/launchTerminal.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { decideLaunchTerminal } from "../../../../server/backends/remoteHost/launchTerminal.js";
+
+const input = (over: Partial<Parameters<typeof decideLaunchTerminal>[0]> = {}) => ({
+  agent: "shell",
+  sessionId: "abc",
+  cwdOf: () => "/repo",
+  listenerCount: 1,
+  ...over,
+});
+
+describe("decideLaunchTerminal", () => {
+  it("accepts each of the three kinds the phone may ask for", () => {
+    for (const agent of ["shell", "claude", "codex"]) {
+      expect(decideLaunchTerminal(input({ agent }))).toEqual({ ok: true, request: { agent, cwd: "/repo" } });
+    }
+  });
+
+  // The phone names a SESSION; the host answers with the directory. A path from the phone
+  // would let a remote client pick where a process starts.
+  it("takes the directory from the host, for the session the phone named", () => {
+    const decision = decideLaunchTerminal(input({ sessionId: "s1", cwdOf: (id) => (id === "s1" ? "/from/host" : "/wrong") }));
+    expect(decision).toEqual({ ok: true, request: { agent: "shell", cwd: "/from/host" } });
+  });
+
+  it("refuses an agent that is not one of the three", () => {
+    for (const agent of ["bash", "", null, 42, undefined, { agent: "shell" }]) {
+      expect(decideLaunchTerminal(input({ agent }))).toEqual({ ok: false, error: expect.stringContaining("shell, claude, codex") });
+    }
+  });
+
+  it("refuses a missing or non-string session id", () => {
+    for (const sessionId of ["", null, undefined, 7]) {
+      expect(decideLaunchTerminal(input({ sessionId }))).toEqual({ ok: false, error: "sessionId is required" });
+    }
+  });
+
+  // A session that outlived a restart lives only in tmux; no PtyEntry remembers its dir, so
+  // there is nowhere to start the new terminal.
+  it("refuses when the host has no directory for that session", () => {
+    const decision = decideLaunchTerminal(input({ sessionId: "gone", cwdOf: () => null }));
+    expect(decision).toEqual({ ok: false, error: expect.stringContaining("'gone'") });
+  });
+
+  // The grid is browser state. With no tab subscribed nothing can open the cell, and the
+  // phone has to be told rather than left believing it worked.
+  it("refuses when no browser is listening", () => {
+    expect(decideLaunchTerminal(input({ listenerCount: 0 }))).toEqual({ ok: false, error: expect.stringContaining("no MulmoTerminal browser is open") });
+  });
+
+  // Order matters: a bad agent is reported as such even when the browser is also missing,
+  // so the phone shows the fault the user can actually fix.
+  it("reports the request's own fault before the environment's", () => {
+    expect(decideLaunchTerminal(input({ agent: "bash", listenerCount: 0 }))).toEqual({
+      ok: false,
+      error: expect.stringContaining("shell, claude, codex"),
+    });
+  });
+
+  it("does not consult the host for a request it has already rejected", () => {
+    let asked = 0;
+    decideLaunchTerminal(
+      input({
+        agent: "nope",
+        cwdOf: () => {
+          asked += 1;
+          return "/repo";
+        },
+      }),
+    );
+    expect(asked).toBe(0);
+  });
+});

--- a/test/src/composables/useNewTerminal.spec.ts
+++ b/test/src/composables/useNewTerminal.spec.ts
@@ -77,4 +77,41 @@ describe("useNewTerminal", () => {
     expect(handler).toHaveBeenCalledWith({ cwd: "/b", afterSlotKey: "single" });
     wrapper.unmount();
   });
+
+  // The phone drives this over pub/sub (#831) and the host answers each command with success,
+  // so a request dropped here is a launch reported as done that never happened. One slot was
+  // enough only while a person pressing a button was the sole caller.
+  it("drains EVERY request queued while the grid was away, in arrival order", () => {
+    openTerminalAt("/first", null, "shell");
+    openTerminalAt("/second", null, "claude");
+    openTerminalAt("/third", null, "codex");
+    const h = vi.fn();
+    const off = registerNewTerminalHandler(h);
+    expect(h).toHaveBeenCalledTimes(3);
+    expect(h.mock.calls.map(([req]) => [req.cwd, req.agent])).toEqual([
+      ["/first", "shell"],
+      ["/second", "claude"],
+      ["/third", "codex"],
+    ]);
+    off();
+  });
+
+  it("carries the agent through to a live handler, and leaves it unset for the shell button", () => {
+    const h = vi.fn();
+    const off = registerNewTerminalHandler(h);
+    openTerminalAt("/proj", null, "codex");
+    expect(h).toHaveBeenCalledWith({ cwd: "/proj", afterSlotKey: null, agent: "codex" });
+    openTerminalAt("/proj", null);
+    expect(h).toHaveBeenLastCalledWith({ cwd: "/proj", afterSlotKey: null, agent: undefined });
+    off();
+  });
+
+  it("empties the queue once drained, so a later register replays nothing", () => {
+    openTerminalAt("/once", null);
+    registerNewTerminalHandler(vi.fn())();
+    const second = vi.fn();
+    const off = registerNewTerminalHandler(second);
+    expect(second).not.toHaveBeenCalled();
+    off();
+  });
 });


### PR DESCRIPTION
## Summary

スマホから shell / codex / claude を、**今見ているセッションの dir を引き継いで**起動できるようにします。

**issue の設計案（ハンドラが直接 spawn する）は成立しませんでした。** 調査で分かった制約に合わせて方式を変えており、そこが最大のレビューポイントです。

## Items to Confirm / Review

1. **なぜサーバが直接 spawn しないのか** — `markDevTerminalSession()` の呼び出しは `server/routes/ws-routes.ts` の**3箇所だけ**で、同ファイルのコメントが "the single choke point for every grid attach" と明記しています。さらにセル一覧（`gridTabs.ts` の `GridState`）は**ブラウザの状態**です。サーバが直接 spawn すると **PC の grid にも、スマホの一覧にも出ないセッション**ができます（`listTerminalSessions` が `isGridSession: (id) => devTerminalSessions.has(id)` で絞っているため）。
   → **pubsub でブラウザに依頼**し、既存の起動経路をそのまま通す方式にしました。

2. **ブラウザ不在時に無言で失敗しない設計** — pubsub は publish しっぱなしなので、`subscriberCount()` を足して**購読者0なら明示的に拒否**します。スマホには `no MulmoTerminal browser is open — the grid opens the terminal, so a tab must be connected` が出ます。「成功したのに何も起きない」が最悪なので、ここは意図的に足しました。

3. **購読を `App.vue` に置いた理由** — 最初 GridView に置きましたが、`<KeepAlive><GridView v-if="isGrid" /></KeepAlive>` なので **一度も `/terminals` を開いていないと GridView は存在せず**、ブラウザが開いていても「開いていない」と判定されてしまいます。`openTerminalAt` が「未マウントならキューして遷移」を既に持っているので、常時マウントの `App.vue` が正しい置き場所です。

4. **パスを一切受け取らない** — スマホが送るのは `sessionId` だけで、cwd はホストが `ptys.get(id)?.cwd` から引きます。issue の推奨（自由入力は許さない）をさらに進めた形です。**認可は既存ハンドラと同じ**にしました。根拠は、`sendTerminalInput` が既に任意テキストを Claude に打ち込めて任意コマンドを実行させうるため、「既存セッションの dir で shell を開く」は権限の格上げにならない、というものです。ここは異論があれば伺いたい点です。

5. **`Publisher` 型の切り出し（副次的変更）** — `subscriberCount` を足したことで、publish しか使わない `fileChange.ts` / `notifier.ts` とそのテスト偽物にまで実装を強制してしまいました。`publish` だけの型に向け直しています。今回の機能とは直接関係ない変更なので、切り分けたい場合は言ってください。

6. **`MAX_TERMINALS`(81) 到達時は黙って何も起きません** — ブラウザ側 `insertCellAfter` が上限で無変更を返すためです。pubsub が一方向なのでスマホに伝える手段が今はなく、今回は対象外にしました（plan に記載）。

## 決めたこと（事前確認済み）

| 論点 | 決定 |
|---|---|
| 方式 | ブラウザに依頼（pubsub） |
| 起動対象 | shell / codex / claude の3つ固定 |
| cwd | 今見ているセッションの dir 固定（パスは受け取らない） |
| 簡易版の範囲 | worktree 作成・モデル選択は落とす |

## 実装

| ファイル | 変更 |
|---|---|
| `common/launchAgent.ts`（新規） | `LAUNCH_AGENTS` / `LaunchAgent` / チャンネル名（サーバもUIも読む） |
| `server/backends/remoteHost/launchTerminal.ts`（新規） | **純粋な判定**。検証・cwd 解決・購読者確認 |
| `server/infra/pubsub.ts` | `subscriberCount()` と `Publisher` 型 |
| `server/backends/remoteHost/handlers.ts` | `launchTerminal` ハンドラ（拒否は throw してスマホに文言が出る） |
| `server/index.ts` | 配線 |
| `src/composables/useNewTerminal.ts` | 既存の seam に `agent` を運ばせる |
| `src/components/GridView.vue` | agent ごとのセル生成 |
| `src/App.vue` | pubsub 購読 |

3種類とも既存のセル型で表現できました（shell = shell launcher / claude = 既定 / codex = `agent: "codex"`）。

## テスト（+8、合計 4279 passed）

`launchTerminal.spec.ts` — 3種すべて受理 / dir はホストが答える / 不正な agent 6パターン / 不正な sessionId 4パターン / dir 不明 / **購読者0** / エラーの優先順位 / **拒否した要求でホストに問い合わせない**

### ミューテーション確認

| 壊し方 | 結果 |
|---|---|
| 購読者数のガードを外す | 1件赤 |
| cwd 不明のガードを外す | 1件赤 |

## 検証

`yarn format`（エラー0）/ `yarn lint` 0 / **`yarn typecheck` `typecheck:server` `typecheck:test` すべて 0** / `yarn build` 0 / `yarn test` **4279 passed**

（前回 `typecheck:test` の回し漏れで CI を落としたので、今回は3本とも push 前に実行しています）

## 関連

- receptron/mulmoserver#114（スマホ側の起動画面）
- #781 スマホから生キーを送る

Refs #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)