### PR TITLE
fix: 死んだターミナルを reload なしで復帰させる（xterm 6.0.0 のバッファ破損, #846）

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -101,6 +101,30 @@ change one and change the other (#834).
 - xterm exposes no pixel-to-cell mapping, so cell coordinates are derived from `.xterm-screen`'s
   own box. Reaching into `_core._renderService.dimensions` instead would need an `any`.
 
+### A terminal xterm has killed can only be replaced (#846)
+
+`Buffer.resize` in xterm 6.0.0 can finish with fewer lines than the viewport needs
+(upstream [xtermjs/xterm.js#6063](https://github.com/xtermjs/xterm.js/issues/6063), **unfixed**);
+the next write to a bottom row then throws in `lineFeed` / `_eraseInBufferLine`, which dereference
+`lines.get(…)` with no null check. Three things about that failure decide how it is handled here —
+all confirmed against `@xterm/headless@6.0.0` by reproducing the upstream flight-recorder state:
+
+- **The throw is out of reach.** It happens inside the WriteBuffer's own `setTimeout`, not under
+  our `term.write()` call, so no try/catch of ours can see it. The state has to be found by
+  looking, not by catching — hence the probe in `terminalBufferHealth.ts`, run on `fit()` and on
+  each output message.
+- **The write queue stays stuck forever.** `WriteBuffer.write()` only starts the drain when the
+  queue *was* empty, so the entries a throw left behind are never parsed. This is why the cell
+  freezes until a page reload.
+- **`term.reset()` does not clear it.** Reset rebuilds the buffers (so the buffer invariant is
+  restored) but leaves the write queue stuck — a terminal that has thrown never processes input
+  again. `connect()` alone is therefore not a repair: the slot needs a **new `Terminal`**, which
+  is what `rebuildTerminal()` does before re-attaching. The session is server-side, so the replay
+  brings the content back and the user sees the cell blink.
+
+Rendering itself survives: `RenderDebouncer._innerRefresh` clears its animation frame *before*
+calling the render callback, so a renderer that throws still repaints on the next refresh.
+
 ### Renderer (canvas vs DOM)
 
 The **canvas renderer** (`@xterm/addon-canvas`, added to fix CJK glyph drift — long Japanese lines

--- a/plans/fix-846-recover-dead-terminal.md
+++ b/plans/fix-846-recover-dead-terminal.md
@@ -1,0 +1,92 @@
+# fix #846 — 死んだターミナルを reload なしで復帰させる
+
+リサイズ後にセルが真っ白になり、以後そのセルは一切更新されなくなる（#846）。根本原因は
+xterm 6.0.0 本体の `Buffer.resize` バグ（本家 xtermjs/xterm.js#6063、未修正）なので**こちらでは
+直せない**。直せるのは「ユーザーが reload するしかない」状態のほうで、本 PR はそれをやる。
+
+## 実測で分かったこと（headless 6.0.0 で upstream の状態を再現して確認）
+
+upstream のフライトレコーダの値（`ybase=5, y=13, lines.length=18` の状態で 39x18 → 37x23）を
+再現すると、こちらでも同じ例外（`_eraseInBufferLine` の `replaceCells`）が出る。そのうえで:
+
+| 状態 | `write` の callback | バッファ不変条件 |
+|---|---|---|
+| 正常 | 発火 | ok |
+| クラッシュ後 | **発火しない** | 壊れている |
+| `term.reset()` 後（＝`connect()` がすること） | **発火しない** | 直る |
+| Terminal を作り直す | 発火 | ok |
+
+- **例外は xterm の内部タスク（`_innerWrite` の setTimeout）で投げられる**ので、`term.write()` の
+  呼び出し側 try/catch では捕まえられない。だから「例外を捕まえて直す」方式は取れない
+- **`WriteBuffer` が永久に止まる**: `write()` はキューが空だったときしか `_innerWrite` を起こさない
+  （`if (this._writeBuffer.length === 1)`）。throw で残ったキューは二度と流れない。これが
+  「以後そのセルは一切更新されない」の正体
+- `term.reset()` はバッファを作り直す（`fillViewportRows`）ので不変条件は直るが、
+  **WriteBuffer は直らない**。つまり `connect()`（reset + 再接続）だけでは復帰しない
+- 描画ループは例外で止まらない（`RenderDebouncer._innerRefresh` は `_animationFrame` を先に
+  クリアしてから描画コールバックを呼ぶ）。復帰後は次のフレームで描き直される
+
+## 方針: 壊れたバッファを検知して、そのスロットの Terminal を作り直す
+
+PTY はサーバ側で生きており、再アタッチでバッファ末尾が replay される（`terminal-replay.ts`）。
+つまり Terminal を捨てて作り直し、同じセッションに再接続すれば、ユーザーから見て**セルが一瞬
+またたいて戻る**。失うのは replay 範囲外のスクロールバックだけ。
+
+### 1. 検知（`src/composables/terminalBufferHealth.ts` 新規）
+
+純関数で、public API から読める値だけを見る:
+
+```ts
+bufferIsShort({ length, baseY, cursorY, rows })
+  = length < baseY + rows   // レンダラが読む行が無い
+  || length <= baseY + cursorY  // InputHandler が書く行が無い
+```
+
+upstream が壊すのはまさにこの不変条件で、フライトレコーダの記録では**致命的な resize の前**から
+既に壊れている（マスクされていただけ）。つまり多くの場合、**クラッシュする前に検知できる**。
+
+呼ぶ場所は 2 箇所:
+
+- `fit()` の直後 — リサイズがトリガーなので、壊れた直後に気付ける
+- 出力メッセージ受信時（`handleMessage`）— リサイズが続かないケースを拾う。読むのは 4 プロパティだけ
+
+**誤検知したら復帰動作が破壊的**なので、初回検知では直さず**次のマクロタスクで再確認**する。
+パース途中の一時的な状態はそこで消えるが、本当に死んでいれば状態は動かない。
+
+### 2. 復帰（`useTerminalConnections.ts`）
+
+`ensure()` の Terminal 生成部分を `buildTerminal()` に切り出し、`rebuildTerminal(c)` から再利用する:
+
+1. 新しい Terminal + addon + host を作る（`swallowedMouseModes` は Conn のものを引き継ぐ）
+2. `registerFilePathLinks` / `wireTerminalInput` を張り直し、テーマを再適用
+3. 新 host を `attachedEl` に挿し、旧 host を外して旧 Terminal を dispose
+4. `connect(c)` — 同じセッションに再接続 → サーバが末尾を replay
+5. `fitAndSyncSize(c)` — 新しい Terminal を実サイズに合わせ、PTY にも伝える
+
+フォーカスは、旧 host がフォーカスを持っていたときだけ復元する（他セルからフォーカスを奪わない）。
+
+**やらないケース**:
+
+- `c.sawExit` のスロット（終了済みセッション）— 再接続はコマンドを再実行しかねないし、replay の
+  無い空のターミナルは「固まったが読める画面」より悪い
+- 直近 `REBUILD_COOLDOWN_MS` 以内に作り直したスロット — 検知が続いても暴走させない
+
+### 3. テスト
+
+- `test/src/composables/terminalBufferHealth.spec.ts`
+  - 純関数: 健全な状態、upstream のフライトレコーダの実値（`length=18, ybase=5, y=13, rows=18` と
+    resize 後の `length=18, ybase=0, y=18, rows=23`）、境界値
+  - **誤検知しないこと**: 実 headless Terminal に write / resize / reset / alt 画面切替 / scroll を
+    ランダムに流し、プローブが一度も鳴らないことを固定する。誤検知は破壊的な復帰動作を招くので、
+    ここが一番大事なテスト
+
+### 4. ドキュメント
+
+`docs/terminal-notes.md` に、この故障モード（WriteBuffer が止まる／reset では直らない／Terminal を
+作り直す）と upstream issue へのリンクを書く。
+
+## スコープ外
+
+- `fitAndSyncSize` の退化ボックスガード（#846 の対策 2）。トリガーである確証が無く、本 PR の
+  復帰機構とは独立に判断できる
+- upstream バグ自体の回避（`Buffer.resize` の穴は xtermjs/xterm.js#6063 待ち）

--- a/src/composables/terminalBufferHealth.ts
+++ b/src/composables/terminalBufferHealth.ts
@@ -1,0 +1,41 @@
+// Detects the xterm 6.0.0 buffer corruption that kills a terminal outright (#846, upstream
+// xtermjs/xterm.js#6063): `Buffer.resize` can finish with fewer lines than the viewport needs,
+// and the next write to a bottom row then throws inside xterm's own task —
+// `lineFeed`/`_eraseInBufferLine` dereference `lines.get(...)` without a null check.
+//
+// The throw is unreachable from here (it happens in the WriteBuffer's setTimeout, not under our
+// call), and it leaves the write queue permanently stuck: WriteBuffer.write() only starts the
+// drain when the queue WAS empty, so nothing the app writes afterwards is ever parsed. That is
+// why the cell freezes until a page reload — and why the state has to be found by looking rather
+// than by catching.
+//
+// Upstream's own flight recorder shows the buffer already short BEFORE the resize that made it
+// fatal (stale CircularList slots mask it), so this probe usually fires while the terminal is
+// still alive.
+
+/** What the probe reads. All of it is public API — no `_core` internals. */
+export interface BufferShape {
+  length: number;
+  baseY: number;
+  cursorY: number;
+  rows: number;
+}
+
+/** The slice of a terminal the probe needs. Structural rather than `Terminal`, so the headless
+ *  build — the one the spec can drive through hundreds of resizes — satisfies it too. */
+export interface MeasurableTerminal {
+  rows: number;
+  buffer: { active: { length: number; baseY: number; cursorY: number } };
+}
+
+/** True when the buffer has fewer lines than the terminal is about to address:
+ *  the renderer reads `lines.get(ydisp + row)` for every viewport row, and the input handler
+ *  writes `lines.get(ybase + y)`. Either one missing is a terminal that is dead or about to be. */
+export function bufferIsShort({ length, baseY, cursorY, rows }: BufferShape): boolean {
+  return length < baseY + rows || length <= baseY + cursorY;
+}
+
+export function readBufferShape(term: MeasurableTerminal): BufferShape {
+  const buffer = term.buffer.active;
+  return { length: buffer.length, baseY: buffer.baseY, cursorY: buffer.cursorY, rows: term.rows };
+}

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -34,6 +34,7 @@ import { ClipboardAddon, type IClipboardProvider } from "@xterm/addon-clipboard"
 import { swallowsMouseTracking } from "./mouseTrackingModes";
 import { clearResetModes, recordSwallowedModes } from "./mouseReports";
 import { guardMouseClicks, guardMouseWheel } from "./terminalMouseInput";
+import { bufferIsShort, readBufferShape } from "./terminalBufferHealth";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import "@xterm/xterm/css/xterm.css";
 import { connWsUrl, type LaunchChoice } from "../components/wsUrl";
@@ -130,7 +131,13 @@ interface Conn {
   // dies without sending DECRST must not leave the next one looking like it asked for mouse
   // reports, or its wheel would get synthesized reports it never wanted.
   swallowedMouseModes: Set<number>;
+  theme: ITheme | undefined; // last applied, so a rebuilt terminal keeps the cell's colours
+  lastRebuildMs: number; // rate-limits the #846 recovery so a stuck reading can't spin
 }
+
+// A rebuild costs a re-attach and the client-side scrollback, so a slot gets at most one per
+// window — enough for a real recovery, not enough to loop if the reading never clears.
+const REBUILD_COOLDOWN_MS = 10_000;
 
 // The heavy per-slot runtime (non-reactive — Vue never needs to track these).
 const conns = new Map<string, Conn>();
@@ -235,12 +242,16 @@ function registerFilePathLinks(term: Terminal, c: Conn): void {
   );
 }
 
-function ensure(key: string, target: ConnTarget): Conn {
-  const existing = conns.get(key);
-  if (existing) {
-    existing.target = target;
-    return existing;
-  }
+interface TerminalRuntime {
+  term: Terminal;
+  fitAddon: FitAddon;
+  host: HTMLDivElement;
+}
+
+// Everything a slot's xterm is made of. Built here rather than inline in ensure() because a
+// terminal that xterm has killed can only be replaced, never revived (see rebuildTerminal).
+// The mouse-mode record is passed in: it belongs to the connection and outlives any one terminal.
+function buildTerminal(swallowedMouseModes: Set<number>): TerminalRuntime {
   const term = new Terminal({
     cursorBlink: true,
     fontSize: 14,
@@ -265,7 +276,6 @@ function ensure(key: string, target: ConnTarget): Conn {
       },
     },
   });
-  const swallowedMouseModes = new Set<number>();
   guardMouseTracking(term, swallowedMouseModes);
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
@@ -296,7 +306,24 @@ function ensure(key: string, target: ConnTarget): Conn {
   } catch (err) {
     console.warn("[terminal] canvas renderer unavailable — falling back to the DOM renderer", err);
   }
+  return { term, fitAddon, host };
+}
 
+// The wiring that needs the connection itself, so it is re-applied to every terminal a slot owns.
+function wireTerminalToConn(term: Terminal, c: Conn): void {
+  registerFilePathLinks(term, c);
+  wireTerminalInput(term, c);
+  if (c.theme) term.options.theme = c.theme;
+}
+
+function ensure(key: string, target: ConnTarget): Conn {
+  const existing = conns.get(key);
+  if (existing) {
+    existing.target = target;
+    return existing;
+  }
+  const swallowedMouseModes = new Set<number>();
+  const { term, fitAddon, host } = buildTerminal(swallowedMouseModes);
   const c: Conn = {
     key,
     term,
@@ -313,12 +340,51 @@ function ensure(key: string, target: ConnTarget): Conn {
     reconnectTimer: null,
     attachedEl: null,
     swallowedMouseModes,
+    theme: undefined,
+    lastRebuildMs: 0,
   };
   conns.set(key, c);
   connView.set(key, { status: "connecting", serverCwd: target.cwd });
-  registerFilePathLinks(term, c);
-  wireTerminalInput(term, c);
+  wireTerminalToConn(term, c);
   return c;
+}
+
+// A terminal xterm has killed cannot be revived, so the slot gets a new one (#846). The upstream
+// buffer bug (xtermjs/xterm.js#6063) throws inside xterm's own write task, which leaves the write
+// queue permanently stuck — nothing written afterwards is ever parsed, and term.reset() does not
+// clear it. The session itself is fine: it lives on the server, and re-attaching replays its tail
+// into the fresh terminal, so the user sees the cell blink rather than a dead panel.
+function rebuildTerminal(c: Conn): void {
+  const deadTerm = c.term;
+  const deadHost = c.host;
+  const hadFocus = deadHost.contains(document.activeElement);
+  console.warn(`[terminal] slot ${c.key}: xterm buffer corrupted (xtermjs/xterm.js#6063) — rebuilding the terminal and re-attaching`);
+  const { term, fitAddon, host } = buildTerminal(c.swallowedMouseModes);
+  c.term = term;
+  c.fitAddon = fitAddon;
+  c.host = host;
+  c.lastRebuildMs = Date.now();
+  wireTerminalToConn(term, c);
+  c.attachedEl?.appendChild(host);
+  deadHost.remove();
+  deadTerm.dispose();
+  connect(c);
+  fitAndSyncSize(c);
+  if (hadFocus) term.focus();
+}
+
+// A slot whose buffer went short is on its way to freezing, so it is replaced — but only once the
+// state survives a task. Mid-parse the app can observe a buffer that xterm is still growing, and
+// the repair costs the session's client-side scrollback, so a single sighting is not enough.
+// A terminal that is genuinely dead cannot recover on its own: the reading will not change.
+function guardBufferHealth(c: Conn): void {
+  if (c.released || c.sawExit || Date.now() - c.lastRebuildMs < REBUILD_COOLDOWN_MS) return;
+  if (!bufferIsShort(readBufferShape(c.term))) return;
+  const suspect = c.term;
+  setTimeout(() => {
+    if (c.term !== suspect || c.released || c.sawExit) return;
+    if (bufferIsShort(readBufferShape(c.term))) rebuildTerminal(c);
+  });
 }
 
 function scheduleReconnect(c: Conn) {
@@ -383,6 +449,9 @@ function connect(c: Conn) {
 function handleMessage(c: Conn, event: MessageEvent) {
   const msg = JSON.parse(event.data);
   if (msg.type === "output") {
+    // Checked here as well as on fit() because a slot that is only receiving output would
+    // otherwise sit frozen until something happened to resize it (#846).
+    guardBufferHealth(c);
     c.term.write(msg.data);
   } else if (msg.type === "session") {
     // Server reports the live session id — remember it so a later reconnect resumes
@@ -425,7 +494,10 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   if (c.knownSessionId) handlers.onSession?.(c.knownSessionId);
   if (c.knownCwd) handlers.onCwd?.(c.knownCwd);
   el.appendChild(c.host);
-  if (theme) c.term.options.theme = theme;
+  if (theme) {
+    c.theme = theme;
+    c.term.options.theme = theme;
+  }
   if (created) connect(c);
   fitAndSyncSize(c);
   c.term.focus();
@@ -613,6 +685,9 @@ export function fit(key: string) {
   const c = conns.get(key);
   if (!c || !c.attachedEl) return;
   fitAndSyncSize(c);
+  // A resize is what trips the upstream buffer bug, so this is where a short buffer shows up
+  // first — usually while the terminal is still alive (#846).
+  guardBufferHealth(c);
   // Force the canvas renderer to repaint. `fit()` only redraws when cols/rows actually change, so a
   // re-parent / KeepAlive reactivation with the SAME size (attach, onActivated) would otherwise leave
   // the viewport blank until a scroll. The buffer is intact — this just repaints it.
@@ -621,5 +696,7 @@ export function fit(key: string) {
 
 export function setTheme(key: string, theme: ITheme) {
   const c = conns.get(key);
-  if (c) c.term.options.theme = theme;
+  if (!c) return;
+  c.theme = theme;
+  c.term.options.theme = theme;
 }

--- a/test/src/composables/terminalBufferHealth.spec.ts
+++ b/test/src/composables/terminalBufferHealth.spec.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+//
+// Two jobs. First, that the probe recognises the upstream corruption (xtermjs/xterm.js#6063) —
+// pinned against the real numbers from that issue's flight recorder, not invented ones. Second,
+// and more important: that it NEVER fires on a healthy terminal. A false positive rebuilds a live
+// terminal and costs the user their client-side scrollback, so the negative case is driven
+// against a real xterm through the operation mix a live slot actually sees.
+import { describe, it, expect } from "vitest";
+import { Terminal } from "@xterm/headless";
+import { bufferIsShort, readBufferShape } from "../../../src/composables/terminalBufferHealth";
+
+const write = (term: Terminal, data: string) => new Promise<void>((resolve) => term.write(data, resolve));
+
+describe("bufferIsShort", () => {
+  it("passes a healthy buffer", () => {
+    expect(bufferIsShort({ length: 23, baseY: 5, cursorY: 13, rows: 18 })).toBe(false);
+  });
+
+  // The masked state upstream recorded before the fatal fit: 39x18 with ybase=5, y=13, and a
+  // logical length already below ybase + rows. Stale CircularList slots hid it from xterm.
+  it("catches the upstream state before the resize that makes it fatal", () => {
+    expect(bufferIsShort({ length: 18, baseY: 5, cursorY: 13, rows: 18 })).toBe(true);
+  });
+
+  // ...and the end state after that resize, where viewport rows 18-22 have no line at all.
+  it("catches the upstream state after the resize", () => {
+    expect(bufferIsShort({ length: 18, baseY: 0, cursorY: 18, rows: 23 })).toBe(true);
+  });
+
+  it("accepts a buffer that exactly covers the viewport", () => {
+    expect(bufferIsShort({ length: 24, baseY: 0, cursorY: 23, rows: 24 })).toBe(false);
+  });
+
+  it("catches a buffer one line short of the viewport", () => {
+    expect(bufferIsShort({ length: 23, baseY: 0, cursorY: 0, rows: 24 })).toBe(true);
+  });
+
+  // The renderer and the input handler read different rows, so the cursor row is checked too:
+  // this buffer covers the viewport (6 + 24 = 30) but has no line at the cursor, which is where
+  // the next line feed writes.
+  it("catches a missing cursor row even when the viewport is covered", () => {
+    expect(bufferIsShort({ length: 30, baseY: 6, cursorY: 24, rows: 24 })).toBe(true);
+  });
+});
+
+// The operations a live slot performs: PTY output, fit()'s resize, connect()'s reset, a TUI
+// entering and leaving the alternate buffer, and wheel scrolling.
+const mkRng = (seed: number) => () => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff), seed / 0x7fffffff);
+const noise = (rows: number, width: number) => Array.from({ length: rows }, (_, i) => `r${i} ` + "z".repeat(width)).join("\r\n");
+
+describe("bufferIsShort on a real terminal", () => {
+  it("stays quiet through a fresh terminal's first fit and first output", async () => {
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+    expect(bufferIsShort(readBufferShape(term))).toBe(false);
+    term.resize(120, 40);
+    expect(bufferIsShort(readBufferShape(term))).toBe(false);
+    await write(term, noise(10, 30));
+    expect(bufferIsShort(readBufferShape(term))).toBe(false);
+    term.dispose();
+  });
+
+  it("stays quiet across writes, resizes, resets, alt-buffer switches and scrolling", async () => {
+    const SEEDS = 25;
+    const OPS_PER_SEED = 60;
+    for (let seed = 1; seed <= SEEDS; seed++) {
+      const rnd = mkRng(seed);
+      const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true, scrollback: 1000 });
+      let inAltBuffer = false;
+      for (let step = 0; step < OPS_PER_SEED; step++) {
+        const pick = rnd();
+        if (pick < 0.35) {
+          term.write(noise(1 + Math.floor(rnd() * 120), 10 + Math.floor(rnd() * 200)));
+        } else if (pick < 0.7) {
+          term.resize(2 + Math.floor(rnd() * 200), 1 + Math.floor(rnd() * 70));
+        } else if (pick < 0.78) {
+          term.reset();
+          inAltBuffer = false;
+        } else if (pick < 0.9) {
+          inAltBuffer = !inAltBuffer;
+          term.write(inAltBuffer ? "\x1b[?1049h" : "\x1b[?1049l");
+        } else {
+          term.scrollLines(Math.floor(rnd() * 40) - 20);
+        }
+        // Both the state the app can observe synchronously and the settled one, since the probe
+        // runs on output (mid-stream) and on fit(), and confirms itself a task later.
+        expect(bufferIsShort(readBufferShape(term)), `seed ${seed} step ${step}: synchronous`).toBe(false);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(bufferIsShort(readBufferShape(term)), `seed ${seed} step ${step}: settled`).toBe(false);
+      }
+      term.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

セルが真っ白になって以後一切更新されなくなり、**reload しないと戻らない**（#846）— この「戻らない」ほうを直します。

根本原因は xterm 6.0.0 本体の `Buffer.resize` バグ（本家 [xtermjs/xterm.js#6063](https://github.com/xtermjs/xterm.js/issues/6063)、**未修正**）なのでこちらでは直せません。直せるのは復帰のほうで、**壊れたバッファを検知したらそのスロットの Terminal を作り直して再アタッチ**します。PTY はサーバ側で生きていて末尾が replay されるので、ユーザーから見ると**セルが一瞬またたいて戻る**だけになります。

## Items to Confirm / Review

1. **誤検知が最大のリスク**。プローブが誤って鳴ると生きているターミナルを作り直し、クライアント側のスクロールバックを失います。対策は2つ入れています:
   - 初回検知では直さず、**次のマクロタスクで再確認**してから作り直す（パース途中の一時状態はそこで消える。本当に死んでいれば状態は動かない）
   - spec で**実 headless ターミナルに 1500 操作**（write / resize / reset / alt画面切替 / scroll）を流し、一度も鳴らないことを固定
2. **`sawExit` のスロットは対象外**にしています。終了済みセッションを再接続するとコマンドを再実行しかねず、replay の無い空のターミナルは「固まったが読める画面」より悪いため。この判断で良いか
3. **`REBUILD_COOLDOWN_MS = 10s`** のレート制限。検知が続いても暴走しないため
4. **復帰動作そのものは実機未検証**です。上流バグの発生条件（実ブラウザの fit 系列）が特定されておらず、狙って再現できません。headless で「Terminal を作り直せば生き返る」ことは確認済みですが、実アプリでの復帰は次に #846 が起きたときに確認することになります
5. `Conn` に `theme` を持たせました（作り直した Terminal に色を再適用するため）。`attach` / `setTheme` の両方で更新しています

## User Prompt

- #846 に残した2つの対策案のうち「1」（reload 不要にする＝fit 直後に不変条件をプローブし、壊れていたらそのスロットの xterm を作り直して再接続）を実装する

## 実測して分かったこと（設計の根拠）

upstream のフライトレコーダの値（`ybase=5, y=13, lines.length=18` の状態で 39x18 → 37x23）を `@xterm/headless@6.0.0` で再現し、同じ例外（`_eraseInBufferLine` の `replaceCells`）が出ることを確認したうえで:

| 状態 | `write` の callback | バッファ不変条件 |
|---|---|---|
| 正常 | 発火 | ok |
| クラッシュ後 | **発火しない** | 壊れている |
| `term.reset()` 後（＝`connect()` がすること） | **発火しない** | 直る |
| Terminal を作り直す | 発火 | ok |

- **例外は xterm の内部タスク（`_innerWrite` の setTimeout）で投げられる**ので、`term.write()` の呼び出し側 try/catch では捕まえられない → 「例外を捕まえて直す」方式は取れず、**見に行く**しかない
- **`WriteBuffer` が永久に止まる**: `write()` はキューが空だったときしか `_innerWrite` を起こさない（`if (this._writeBuffer.length === 1)`）。throw で残ったキューは二度と流れない。これが「以後そのセルは一切更新されない」の正体
- **`term.reset()` では直らない**: バッファは作り直される（`fillViewportRows`）が WriteBuffer は止まったまま。つまり **`connect()`（reset + 再接続）だけでは復帰しない** → Terminal オブジェクトごと作り直す必要がある
- 描画ループは例外で止まらない（`RenderDebouncer._innerRefresh` は `_animationFrame` を先にクリアしてから描画コールバックを呼ぶ）ので、バッファさえ直れば次のフレームで描き直される

また、upstream のフライトレコーダでは**致命的な resize の前から既にバッファが短い**（stale な CircularList スロットに隠されていただけ）ので、多くの場合**クラッシュ前に検知できます**。

## 実装

| ファイル | 内容 |
|---|---|
| `src/composables/terminalBufferHealth.ts`（新規） | プローブ。`bufferIsShort({length, baseY, cursorY, rows})` = レンダラが読む行（`baseY + rows`）か InputHandler が書く行（`baseY + cursorY`）が無い。public API だけを読み、`_core` には触らない |
| `src/composables/useTerminalConnections.ts` | `ensure()` の Terminal 生成を `buildTerminal()` に切り出し、`rebuildTerminal(c)` から再利用。`guardBufferHealth(c)` を `fit()` 直後と出力メッセージ受信時に呼ぶ |
| `docs/terminal-notes.md` | この故障モード（例外が届かない / WriteBuffer が止まる / reset では直らない / 描画は生きている）を記録 |
| `plans/fix-846-recover-dead-terminal.md` | 設計メモ |

`rebuildTerminal` の手順: 新 Terminal + addon + host を作る（`swallowedMouseModes` は Conn のものを引き継ぎ、`connect()` がクリアする）→ リンク/入力配線とテーマを張り直す → 新 host を `attachedEl` に挿して旧 host を外し旧 Terminal を dispose → `connect(c)` で同じセッションに再接続（サーバが末尾を replay）→ `fitAndSyncSize(c)`。フォーカスは**旧 host が持っていたときだけ**復元します（他セルから奪わないため）。

プローブを 2 箇所で呼ぶ理由: `fit()` はリサイズがトリガーなので壊れた直後に気付ける。出力メッセージ側は、リサイズが続かないスロットが固まったままになるのを防ぐため（読むのは 4 プロパティだけ）。

## テスト

`test/src/composables/terminalBufferHealth.spec.ts`

- 純関数: 健全な状態、**upstream のフライトレコーダの実値**（resize 前 `length=18, ybase=5, y=13, rows=18` / resize 後 `length=18, ybase=0, y=18, rows=23`）、ちょうど覆えている境界、1行足りない境界、ビューポートは足りているがカーソル行が無いケース
- 誤検知しないこと: 実 headless Terminal を 25 seed × 60 操作（write / resize / reset / alt画面切替 / scroll）流し、**同期時点と1タスク後の両方**で一度も鳴らないことを固定（1500 操作、2.2s）

`yarn format` / `lint`（変更ファイルに指摘なし）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test`（4313 passed）通過。

## スコープ外

- `fitAndSyncSize` の退化ボックスガード（#846 の対策 2）。トリガーである確証が無く、本 PR の復帰機構とは独立に判断できる
- upstream バグ自体の回避。`Buffer.resize` の穴は xtermjs/xterm.js#6063 待ち（本日時点で main も未修正・コメント0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
