### PR TITLE
refactor: isRecord を common/ の 1 本に集約し、配列を弾くようにする (#828)

### DIFF
--- a/common/isRecord.ts
+++ b/common/isRecord.ts
@@ -1,0 +1,13 @@
+import { isObject } from "graphai";
+
+// The guard both sides use before reading named fields off parsed JSON (config files, API
+// responses, JSONL transcripts, request bodies). It was hand-copied into 29 files before this.
+//
+// Arrays are excluded deliberately, and that is not a nicety: TypeScript itself refuses
+// `const r: Record<string, unknown> = []` ("index signature for type 'string' is missing"), so a
+// guard that narrows an array to Record is telling the compiler something untrue — and callers
+// that go on to `Object.entries()` the value would silently walk array indices as field names.
+//
+// graphai's own `isPlainObject` is exactly this (it also rejects Map/Date/class instances), but
+// it is not exported from the package root, so the array check stays here.
+export const isRecord = (value: unknown): value is Record<string, unknown> => isObject(value) && !Array.isArray(value);

--- a/common/remoteHostHealth.ts
+++ b/common/remoteHostHealth.ts
@@ -1,4 +1,3 @@
-import { isRecord } from "./isRecord.js";
 // Health of the remote-host command channel, as reported by the server's resilient
 // runner and rendered by the toolbar control. Shared across the build boundary so the
 // two sides cannot drift on the state names.
@@ -7,6 +6,8 @@ import { isRecord } from "./isRecord.js";
 //   reconnecting — it died and is being re-subscribed with backoff (self-healing)
 //   offline      — re-subscribing stopped helping, or nothing is connected at all;
 //                  recovering needs a re-auth from the browser's parked session
+
+import { isRecord } from "./isRecord.js";
 export const RUNNER_HEALTH_STATES = ["online", "reconnecting", "offline"] as const;
 export type RunnerHealthState = (typeof RUNNER_HEALTH_STATES)[number];
 

--- a/common/remoteHostHealth.ts
+++ b/common/remoteHostHealth.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "./isRecord.js";
 // Health of the remote-host command channel, as reported by the server's resilient
 // runner and rendered by the toolbar control. Shared across the build boundary so the
 // two sides cannot drift on the state names.
@@ -16,8 +17,6 @@ export interface RunnerHealth {
   /** ms epoch of the last state change, so the UI can say how long it has been down. */
   changedAt: number;
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 export const isRunnerHealthState = (value: unknown): value is RunnerHealthState => RUNNER_HEALTH_STATES.some((state) => state === value);
 

--- a/plans/refactor-828-share-is-record.md
+++ b/plans/refactor-828-share-is-record.md
@@ -1,0 +1,70 @@
+# refactor #828 — `isRecord` を `common/` の 1 本に集約する
+
+`isRecord` が 29 ファイル（`test/` を入れると 32）で個別に定義されている。#826 でスコープ外にした分。
+
+## 調査結果
+
+### 定義は同一ではなかった
+
+31 個の定義を集計すると:
+
+| 実装 | 個数 |
+|---|---|
+| `(v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null` | 23 |
+| 同じロジックで引数名が `value` / `d` | 5 |
+| `function` 宣言形式 | 2 |
+| **`&& !Array.isArray(v)` 付き**（`server/config/header-config.ts`） | **1** |
+
+### 配列を除外するのが正しい
+
+TypeScript 自身が配列を `Record<string, unknown>` として扱わない:
+
+```
+TS2322: Type 'unknown[]' is not assignable to type 'Record<string, unknown>'.
+  Index signature for type 'string' is missing in type 'unknown[]'.
+```
+
+つまり配列除外なしの 30 個は**型の嘘**を吐いている。`header-config.ts` だけが自力で気づいて除外していた。
+
+### 厳格化は安全
+
+呼び出しは 100 箇所。ほぼ全てが `isRecord(x) && typeof x.field === "..."` の形で、配列が来ても
+現状すでに false になる。値を列挙しているのは `server/session/activity-state.ts` だけで、これは
+JSON ファイルの読み込み（トップレベル配列は不正入力で、続く `isValidId` が弾く）。挙動が変わるのは
+「不正入力をより早く弾く」方向のみ。
+
+### graphai の扱い
+
+グローバル CLAUDE.md は「自前実装より既存ライブラリのユーティリティ（例: graphai の `isObject`）」と
+指示している。graphai は `dependencies` にあり、`src/composables/collectionUiRules.ts` 経由で
+**既にブラウザバンドルに入っている**（本変更前後でバンドルサイズは 3920 KB のまま）。
+
+- `isObject` — root から export されているが `x !== null && typeof x === "object"` で、上記の型の嘘を持つ
+- `isPlainObject` — 配列・Map・Date・クラスインスタンスを弾く理想形だが、**パッケージ root から
+  export されていない**（実行時 `undefined`）。内部パス（`graphai/lib/utils/utils`）に依存するのは不可
+
+→ **`isObject` に乗せたうえで、配列除外だけこちら側で足す。**
+
+## 変更
+
+```ts
+// common/isRecord.ts
+import { isObject } from "graphai";
+export const isRecord = (value: unknown): value is Record<string, unknown> => isObject(value) && !Array.isArray(value);
+```
+
+- 名前は `isRecord` のまま → 呼び出し 100 箇所は無変更。各ファイルは定義行を消して import を足すだけ
+- import の拡張子は各ツリーの規約に従う（`server/` `test/server/` `common/` は `.js`、`src/` は無し）
+- `server/session/transcript.ts` が `export` していた分の import 元（`cost.ts` / `last-turn.ts` /
+  `session-reads.ts` / `plugin-*.ts` / `toolResultPlan.ts` / `dirRequest.ts` / `codex-activity.ts`）と、
+  `server/git/ghItem.ts` から import していた `prs.ts` も `common/` に向け直す
+
+## テスト
+
+`test/common/isRecord.spec.ts` — 通常のオブジェクト、**配列（今回変わる挙動）**、null/undefined、
+プリミティブ、関数、Date/Map（弾かないという既知の割り切り）、`JSON.parse` 結果の絞り込み。
+
+## スコープ外
+
+- `src/composables/collectionUiRules.ts` が graphai の `isObject` を直接使っている箇所（同じ概念の
+  もう 1 つのコピーだが、#828 は `isRecord` の重複が対象）

--- a/server/agents/codex-activity.ts
+++ b/server/agents/codex-activity.ts
@@ -5,7 +5,7 @@
 //
 // Everything here is pure: the tailing itself lives in session/codex-activity-watch.ts.
 
-import { isRecord } from "../session/transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 import { activityHookEffects, pushKindFor, type ActivityEffect, type PushKind } from "../session/activity-hook.js";
 
 export type CodexTurnBoundary = "started" | "completed";

--- a/server/agents/codex-session.ts
+++ b/server/agents/codex-session.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { isRecord } from "../../common/isRecord.js";
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
@@ -19,8 +20,6 @@ export function codexSessionsRoot(): string {
   const home = process.env.CODEX_HOME || path.join(os.homedir(), ".codex");
   return path.join(home, "sessions");
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 // The first line of every rollout is a `session_meta` record carrying the id codex minted for
 // itself (mulmoterminal can't force one) and the cwd it resolved.

--- a/server/agents/codex-sessions.ts
+++ b/server/agents/codex-sessions.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import { open } from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "../../common/isRecord.js";
 
 const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -19,8 +20,6 @@ interface RolloutHead {
   cwd: string | null;
   title: string;
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 function parseJsonRecord(line: string): Record<string, unknown> | null {
   if (!line) return null;

--- a/server/backends/remoteHost/routes.ts
+++ b/server/backends/remoteHost/routes.ts
@@ -15,6 +15,7 @@
 import type { Express, Request, Response } from "express";
 import type { RemoteHostLifecycle, RemoteHostStatus } from "@mulmoclaude/core/remote-host/server";
 import type { RunnerHealth } from "../../../common/remoteHostHealth.js";
+import { isRecord } from "../../../common/isRecord.js";
 
 interface StatusResponse {
   status: RemoteHostStatus;
@@ -35,8 +36,6 @@ export interface RemoteHostRouteDeps {
   reconnectErrorStatus: (err: unknown) => number;
   currentHealth: () => RunnerHealth;
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 const errorText = (err: unknown): string => (err instanceof Error ? err.message : String(err));
 
 export function mountRemoteHostRoutes(app: Express, deps: RemoteHostRouteDeps): void {

--- a/server/backends/scheduler.ts
+++ b/server/backends/scheduler.ts
@@ -21,6 +21,7 @@ import { SCHEDULE_TYPES } from "@receptron/task-scheduler";
 import { createTaskManager } from "@mulmoclaude/core/scheduler";
 import type { TaskDefinition, TaskSchedule } from "@mulmoclaude/core/scheduler";
 import { readTextFile } from "../infra/read-text-file.js";
+import { isRecord } from "../../common/isRecord.js";
 
 const log = {
   info: (message: string, data?: Record<string, unknown>) => console.log(`[scheduler] ${message}`, data ?? ""),
@@ -38,10 +39,6 @@ export interface PersistedUserTask {
   enabled?: boolean;
   roleId?: string;
   prompt: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }
 
 function allDigits(value: string): boolean {

--- a/server/config/cwd-presets.ts
+++ b/server/config/cwd-presets.ts
@@ -5,8 +5,7 @@ import path from "node:path";
 import { type CwdPreset } from "./config-schema.js";
 import { readJsonFile } from "../infra/read-text-file.js";
 import { writeFileAtomicSync } from "../files/atomic-write.js";
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+import { isRecord } from "../../common/isRecord.js";
 const isPreset = (v: unknown): v is CwdPreset => isRecord(v) && typeof v.label === "string" && typeof v.path === "string";
 
 // Normalize arbitrary input into clean presets: keep only {label,path} objects,

--- a/server/config/dir-config.ts
+++ b/server/config/dir-config.ts
@@ -10,6 +10,7 @@ import { sanitizeButtons, sanitizeChips } from "./header-config.js";
 import { EMPTY_DIR_CHROME, type DirChrome } from "../../common/dirChrome.js";
 import { isWithin } from "../infra/path-within.js";
 import { readJsonFile } from "../infra/read-text-file.js";
+import { isRecord } from "../../common/isRecord.js";
 import {
   dirNameField,
   dirColorField,
@@ -56,8 +57,6 @@ export interface PublicDirConfig extends DirChrome {
   colors: Record<string, string> | null;
   hasSound: boolean;
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 // Claude's tool hooks already report every write, so they double as the live-reload signal — no
 // filesystem watchers (cwds are scattered, so a watcher can't be shared across terminals).

--- a/server/config/header-config.ts
+++ b/server/config/header-config.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../../common/isRecord.js";
 // The user-configurable terminal header: action buttons + display chips. Read from the global
 // AppConfig (~/.mulmoterminal/config.json) and the per-dir DirConfig (<cwd>/.mulmoterminal.json),
 // merged, then RESOLVED per session (evaluate `when`, substitute ${vars}) before the client renders.
@@ -85,8 +86,6 @@ export interface ResolvedHeader {
 const RUN_TYPE_SET = new Set<string>(RUN_TYPES);
 const VIEW_SET = new Set<string>(VIEW_TARGETS);
 const BUILTIN_SET = new Set<string>(BUILTIN_CHIPS);
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
 const str = (v: unknown): string | undefined => (typeof v === "string" && v.trim() ? v.trim() : undefined);
 const isRunType = (s: string): s is RunType => RUN_TYPE_SET.has(s);
 const isViewTarget = (s: string): s is ViewTarget => VIEW_SET.has(s);

--- a/server/config/header-config.ts
+++ b/server/config/header-config.ts
@@ -1,4 +1,3 @@
-import { isRecord } from "../../common/isRecord.js";
 // The user-configurable terminal header: action buttons + display chips. Read from the global
 // AppConfig (~/.mulmoterminal/config.json) and the per-dir DirConfig (<cwd>/.mulmoterminal.json),
 // merged, then RESOLVED per session (evaluate `when`, substitute ${vars}) before the client renders.
@@ -10,6 +9,8 @@ import { isRecord } from "../../common/isRecord.js";
 // Hard rule: absent config == today's header. `sanitizeChips` returns null when unconfigured, and the
 // resolver passes that through so the client keeps its hardcoded default chips; empty `buttons` means
 // only the built-in buttons show.
+
+import { isRecord } from "../../common/isRecord.js";
 
 import {
   RUN_TYPES,

--- a/server/files/dirRequest.ts
+++ b/server/files/dirRequest.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { statSync } from "node:fs";
 import path from "node:path";
-import { isRecord } from "../session/transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // Validate a POST { path } request that names a local directory: same-origin,
 // absolute, existing. Returns the directory, or null after sending the matching

--- a/server/files/pick-file.ts
+++ b/server/files/pick-file.ts
@@ -1,8 +1,7 @@
 import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
 import path from "node:path";
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+import { isRecord } from "../../common/isRecord.js";
 
 // A native "open file/folder" dialog per platform whose stdout is the selection's
 // absolute path(s), newline-separated. Browsers can't hand the terminal a real

--- a/server/files/scripts.ts
+++ b/server/files/scripts.ts
@@ -6,6 +6,7 @@
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { readJsonFile } from "../infra/read-text-file.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export interface ScriptDef {
   label: string;
@@ -16,8 +17,6 @@ export interface ScriptDef {
 }
 
 const SCRIPTS_FILE = "script.json";
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const isScriptDef = (v: unknown): v is ScriptDef =>
   isRecord(v) && typeof v.label === "string" && typeof v.command === "string" && (v.cwd === undefined || typeof v.cwd === "string");
 

--- a/server/git/ghItem.ts
+++ b/server/git/ghItem.ts
@@ -2,8 +2,7 @@
 // itself is the wire contract and lives in common/ghItems.ts; issues.ts / prs.ts layer
 // their own extra fields on top of this base.
 import type { GhItemBase } from "../../common/ghItems.js";
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+import { isRecord } from "../../common/isRecord.js";
 const asString = (v: unknown): string => (typeof v === "string" ? v : "");
 
 // Returns null when the row lacks the identity fields (number + url) — a row we can't

--- a/server/git/prPhase.ts
+++ b/server/git/prPhase.ts
@@ -12,6 +12,7 @@ import { runGh } from "./gh.js";
 import { rollupCiState } from "./prs.js";
 import { createTtlCache } from "./ttl-cache.js";
 import { branchQuery, type BranchQueryDeps } from "./branch-query.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // Ordered roughly along the lifecycle so the client can pick a colour/label per phase.
 // `none` = no PR for this branch yet (still local work); `ready` = open, CI green, no
@@ -25,8 +26,6 @@ export interface ParsedPr {
   ci: CiState; // passing | failing | pending | none
   url: string | null;
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 const toParsedPr = (o: Record<string, unknown>): ParsedPr => ({
   state: typeof o.state === "string" ? o.state : "",

--- a/server/git/prs.ts
+++ b/server/git/prs.ts
@@ -4,7 +4,8 @@
 // the whole view. The pure normalize/rollup helpers are unit-tested without gh.
 import type { CiState, PrItem, RepoPrs } from "../../common/ghItems.js";
 import { runGh } from "./gh";
-import { isRecord, normalizeGhItemBase } from "./ghItem";
+import { normalizeGhItemBase } from "./ghItem";
+import { isRecord } from "../../common/isRecord.js";
 
 // Per-repo cap. High enough for a review dashboard; a repo that hits it is flagged
 // `truncated` rather than silently cut.

--- a/server/infra/sandbox.ts
+++ b/server/infra/sandbox.ts
@@ -18,8 +18,7 @@ import os from "node:os";
 import pty from "node-pty";
 import { spawnCapture } from "./spawnCapture.js";
 import { removeQuietly } from "./fs-cleanup.js";
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+import { isRecord } from "../../common/isRecord.js";
 
 const IMAGE = process.env.MULMOTERMINAL_SANDBOX_IMAGE || "mulmoterminal-sandbox";
 const CONTAINER_HOME = "/home/node";

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -29,10 +29,10 @@ import { randomUUID } from "node:crypto";
 import { toolDefinitions } from "../infra/plugins-registry.js";
 import { offeredTools, routeToolCall, SUBMIT_TRANSLATION_TOOL_NAME } from "./tool-gate.js";
 import { interpretToolEnvelope } from "./tool-envelope.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // Shape of the dispatch route's response (POST /api/plugin/<tool>). `data` gates
 // whether a toolResult is published to the GUI; the rest is narration/metadata.
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 async function postJson(url: string, body: unknown) {
   const res = await fetch(url, {

--- a/server/routes/plugin-narration.ts
+++ b/server/routes/plugin-narration.ts
@@ -8,7 +8,7 @@
 // Each route keeps its own wording, since that sentence is what the agent reads; only the
 // rule for reading an upstream router's error is shared, and it lives here because it is the
 // part with a decision in it (#548).
-import { isRecord } from "../session/transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // The routers 4xx their domain errors as `{ error }` — prefer that sentence, which names the
 // actual problem, over anything this side could invent. The status-only fallback covers a

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -9,7 +9,7 @@ import type { Express } from "express";
 
 import { CLAUDE_CWD, PORT } from "../config/env.js";
 import { messageOf } from "../errors.js";
-import { isRecord } from "../session/transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 import { hiddenSessions } from "../session/registry.js";
 import { runWithHiddenMarker } from "../session/hiddenMarker.js";
 import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../session/background-chat.js";

--- a/server/routes/toolResultPlan.ts
+++ b/server/routes/toolResultPlan.ts
@@ -2,7 +2,7 @@
 // without booting the server (#676). The route keeps the store write and the publish; this
 // only validates the body and decides what to store and whether to publish.
 import { SESSION_ID_RE } from "../config/env.js";
-import { isRecord } from "../session/transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 import type { ToolResult } from "../session/types.js";
 
 export type ToolResultPlan = { ok: false; error: string } | { ok: true; stored: ToolResult; publish: boolean; sessionId: string; toolName: string };

--- a/server/session/activity-state.ts
+++ b/server/session/activity-state.ts
@@ -1,10 +1,11 @@
-import { isRecord } from "../../common/isRecord.js";
 // Pure transforms for the restart-persisted attention state (see ACTIVITY_STATE_FILE in
 // index.ts). Split out so the snapshot/restore rules are unit-testable. BOTH `working` and
 // `waiting` (blocked/done) are persisted so a server restart (e.g. a --watch hot reload)
 // doesn't drop a live session to idle. A restored `working` self-corrects: the session's
 // next Stop hook clears it (the only stale case is a turn that finished during the restart
 // window, whose Stop was lost — corrected on the user's next turn).
+
+import { isRecord } from "../../common/isRecord.js";
 
 export interface RestartActivity {
   working?: boolean;

--- a/server/session/activity-state.ts
+++ b/server/session/activity-state.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "../../common/isRecord.js";
 // Pure transforms for the restart-persisted attention state (see ACTIVITY_STATE_FILE in
 // index.ts). Split out so the snapshot/restore rules are unit-testable. BOTH `working` and
 // `waiting` (blocked/done) are persisted so a server restart (e.g. a --watch hot reload)
@@ -16,8 +17,6 @@ export interface PersistedActivity {
   waiting: boolean;
   event: string | null;
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 // The sessions to persist across a restart: those that are working OR waiting (blocked/done),
 // minus hidden translation workers (they flag waiting internally but must never surface, and

--- a/server/session/command-summary.ts
+++ b/server/session/command-summary.ts
@@ -6,6 +6,7 @@
 import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
 import { claudeAdapter } from "../agents/claude.js";
+import { isRecord } from "../../common/isRecord.js";
 
 const BYTES_PER_KB = 1024;
 // Cap the log we send to claude. The tail is what matters (errors + the exit line
@@ -13,8 +14,6 @@ const BYTES_PER_KB = 1024;
 export const MAX_LOG_KB = 32;
 const SUMMARY_TIMEOUT_MS = 60_000;
 const EMPTY_OUTPUT_SUMMARY = "No command output to summarize yet.";
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const messageOf = (e: unknown): string => (e instanceof Error ? e.message : String(e));
 
 export interface TruncatedLog {

--- a/server/session/cost.ts
+++ b/server/session/cost.ts
@@ -5,7 +5,8 @@
 import path from "node:path";
 import fs from "node:fs/promises";
 import type { Express } from "express";
-import { isRecord, parseJsonl } from "./transcript.js";
+import { parseJsonl } from "./transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 import { projectSessionsDir } from "./project-dir.js";
 
 const TOKENS_PER_MILLION = 1_000_000;

--- a/server/session/last-turn.ts
+++ b/server/session/last-turn.ts
@@ -4,7 +4,8 @@
 // flight is skipped: codex writes its rollout lazily, so "what it is saying right now"
 // simply isn't on disk (#254).
 
-import { conversationTurnsFromParsed, parseJsonl, isRecord } from "./transcript.js";
+import { conversationTurnsFromParsed, parseJsonl } from "./transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export interface LastTurn {
   prompt: string | null;

--- a/server/session/scheduled-sessions.ts
+++ b/server/session/scheduled-sessions.ts
@@ -18,6 +18,7 @@ import os from "node:os";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { writeFileAtomic } from "../files/atomic-write.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export interface ScheduledSessionRecord {
   id: string;
@@ -51,8 +52,6 @@ export function selectExpiredScheduledSessions(
   });
   return { keep, expire };
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 /** Read one session's entry, or null when it is malformed — a corrupt or hand-edited file
  *  must not smuggle a bad id into a `tmux kill-session` argument. */

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -12,8 +12,8 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isRecord } from "../../common/isRecord.js";
 import {
-  isRecord,
   parseJsonl,
   userPromptText,
   aiTitleFromParsed,

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -1,8 +1,7 @@
+import { isRecord } from "../../common/isRecord.js";
 // Pure helpers for reading Claude session transcripts (the per-project .jsonl
 // files). Kept separate from index.ts so they're unit-testable without the server's
 // startup side effects.
-
-export const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 // A real user prompt from a JSONL "user" line's content, or null if it's a
 // slash-/local-command wrapper rather than a typed prompt. Content may be a plain

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -1,7 +1,8 @@
-import { isRecord } from "../../common/isRecord.js";
 // Pure helpers for reading Claude session transcripts (the per-project .jsonl
 // files). Kept separate from index.ts so they're unit-testable without the server's
 // startup side effects.
+
+import { isRecord } from "../../common/isRecord.js";
 
 // A real user prompt from a JSONL "user" line's content, or null if it's a
 // slash-/local-command wrapper rather than a typed prompt. Content may be a plain

--- a/server/session/translation-submit.ts
+++ b/server/session/translation-submit.ts
@@ -7,7 +7,7 @@
 //
 // The hand-off is passed in rather than imported so the decision can be tested without a
 // worker in flight; it is the one thing here that is not a decision (#548).
-import { isRecord } from "./transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export type TranslationSubmitOutcome = { status: 200; body: { ok: true } } | { status: 400 | 404; body: { error: string } };
 

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -7,6 +7,7 @@ import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import type { GridCellEmits, GridCellProps } from "./gridCell";
 import { browserLocale } from "../utils/browserLocale";
+import { isRecord } from "../../common/isRecord";
 import {
   CELL_ACTIONS,
   CELL_BTN,
@@ -77,10 +78,6 @@ const showSummary = ref(false);
 const SUMMARY_FETCH_TIMEOUT_MS = 90_000;
 // Client-side cap on the bytes sent (the server re-caps to its own tail limit).
 const MAX_SEND_CHARS = 64 * 1024;
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === "object" && v !== null;
-}
 
 // The summary language follows the browser's base language — MulmoTerminal has no
 // locale picker (same signal as useVoiceInput / accountingUi / App.vue).

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -14,6 +14,7 @@ import type { QuickCommand } from "../../common/quickCommands";
 import { SESSION_AGENTS, type SessionAgent } from "../../common/sessionAgent";
 import { canAddLauncher, canAddMcpServer, canAddQuickCommand, canAddRepo } from "./settingsValidators";
 import { formatUsd } from "./formatUsd";
+import { isRecord } from "../../common/isRecord";
 
 const props = defineProps<{
   soundFile?: string | null;
@@ -148,7 +149,6 @@ watch(
   () => props.soundFile,
   (f) => (soundPath.value = f ?? ""),
 );
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 function applySound() {
   emit("update-sound", soundPath.value.trim() || null);

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -4,6 +4,7 @@
 // 🕘 button so you can see "what did it do?" without scrolling the raw transcript.
 import { ref, watch, onUnmounted, nextTick } from "vue";
 import { trapTabKey } from "../utils/focusTrap";
+import { isRecord } from "../../common/isRecord";
 
 interface TimelineEvent {
   ts: string;
@@ -18,8 +19,6 @@ const events = ref<TimelineEvent[]>([]);
 const truncated = ref(false);
 const loading = ref(false);
 const error = ref(false);
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const isTimeline = (v: unknown): v is { events: TimelineEvent[]; truncated: boolean } => isRecord(v) && Array.isArray(v.events);
 
 // Bumped per load so a slow fetch for a previously-opened session can't overwrite the

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -1,4 +1,5 @@
 import type { RunCommand } from "./runCommand";
+import { isRecord } from "../../common/isRecord";
 
 // The grid is ONE flat, ordered list of terminal cells, split into pages of 9
 // (the tabs). Closing a cell reflows the whole list so later pages pack forward
@@ -292,7 +293,6 @@ const isUuid = (s: unknown): s is string => typeof s === "string" && UUID_RE.tes
 const asSortMode = (v: unknown): SortMode => (v === "auto" ? "auto" : "manual");
 // Keep a persisted launcher only if well-formed; anything else drops to null so a
 // reloaded cell reconnects as a plain (Claude) session instead of a broken launcher.
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const asLauncher = (v: unknown): CellLauncher | null => {
   if (!isRecord(v) || typeof v.label !== "string") return null;
   if (v.shell === true) return { shell: true, label: v.label };

--- a/src/composables/useCost.ts
+++ b/src/composables/useCost.ts
@@ -1,4 +1,5 @@
 import { ref } from "vue";
+import { isRecord } from "../../common/isRecord";
 
 // The /api/cost payload: estimated $ spend for the current session plus today /
 // month roll-ups. `session` is absent when no session id was requested.
@@ -12,8 +13,6 @@ export interface CostRollup {
 }
 
 const COST_FETCH_TIMEOUT_MS = 8000;
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const finiteNumber = (v: unknown): number | undefined => (typeof v === "number" && Number.isFinite(v) ? v : undefined);
 
 function parseCost(data: unknown): CostRollup | null {

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -5,6 +5,7 @@ import { isThemeId, type ThemeId } from "./useTheme";
 // Shared with the server config schema so the two can't drift — see common/themeColors.ts.
 import { THEME_COLOR_KEYS } from "../../common/themeColors";
 import { EMPTY_DIR_CHROME, type DirChrome } from "../../common/dirChrome";
+import { isRecord } from "../../common/isRecord";
 
 // The per-directory overrides a terminal adopts when its cwd holds a
 // `.mulmoterminal.json` (served by GET /api/dir-config). The raw sound path stays
@@ -50,8 +51,6 @@ const bound = new Map<string, Set<(config: DirConfig) => void>>();
 // overwrite a newer config, so a fetch only applies while its generation is current.
 const generation = new Map<string, number>();
 const generationOf = (cwd: string): number => generation.get(cwd) ?? 0;
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 function parse(c: unknown): DirConfig {
   if (!isRecord(c)) return EMPTY;

--- a/src/composables/useFaviconState.ts
+++ b/src/composables/useFaviconState.ts
@@ -9,6 +9,7 @@ import { computed, onUnmounted, ref, watch, type Ref } from "vue";
 import { usePubSub } from "./usePubSub";
 import { useDynamicFavicon } from "./useDynamicFavicon";
 import type { Session } from "./useSessions";
+import { isRecord } from "../../common/isRecord";
 
 export type FaviconState = "idle" | "working" | "attention";
 
@@ -22,7 +23,6 @@ interface ActivityMsg {
   waiting?: boolean;
   event?: string | null;
 }
-const isRecord = (d: unknown): d is Record<string, unknown> => typeof d === "object" && d !== null;
 const isActivityMsg = (d: unknown): d is ActivityMsg => isRecord(d) && "id" in d;
 
 // attention(waiting) wins over working wins over idle — matching the grid cell's own

--- a/src/composables/useGitStatus.ts
+++ b/src/composables/useGitStatus.ts
@@ -4,10 +4,9 @@
 // exposed so a caller can force an update right after a turn finishes.
 import { ref, watch, onMounted, onUnmounted, type Ref } from "vue";
 import type { GitStatus } from "../../common/gitStatus";
+import { isRecord } from "../../common/isRecord";
 
 const POLL_MS = 10_000;
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const isGitStatus = (v: unknown): v is GitStatus => isRecord(v) && typeof v.repo === "boolean";
 
 export function useGitStatus(cwd: Ref<string | null>) {

--- a/src/composables/useGoogleLink.ts
+++ b/src/composables/useGoogleLink.ts
@@ -1,4 +1,5 @@
 import { ref } from "vue";
+import { isRecord } from "../../common/isRecord";
 
 // The /api/google/status payload. `linked` reflects a stored refresh token — the
 // token itself never leaves the host. `pending` is true while a consent flow is
@@ -16,8 +17,6 @@ export interface GoogleStatus {
 const REQUEST_TIMEOUT_MS = 8000;
 const STATUS_POLL_INTERVAL_MS = 2000;
 const MAX_POLL_BACKOFF_MS = 30_000;
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 const isPresence = (v: unknown): v is ClientSecretPresence => v === "found" || v === "missing" || v === "ambiguous";
 

--- a/src/composables/useHandoff.ts
+++ b/src/composables/useHandoff.ts
@@ -10,6 +10,7 @@
 import { pasteText, listSlots } from "./useTerminalConnections";
 import type { SlotInfo } from "./readableSlot";
 import { formatCwd } from "../components/cwdDisplay";
+import { isRecord } from "../../common/isRecord";
 
 // A terminal whose last exchange can be pulled: how to name it in the menu, and what
 // the server needs to find its log.
@@ -24,8 +25,6 @@ export interface HandoffSource {
   cwd: string | null;
   agent: "claude" | "codex";
 }
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 // Slot keys are `cell-<uid>`; the uid is what the user sees on the cell, so a menu
 // entry reads the same way the grid does.

--- a/src/composables/useHeaderAction.ts
+++ b/src/composables/useHeaderAction.ts
@@ -11,10 +11,9 @@ import { submitText, insertText } from "./useTerminalConnections";
 import { openTerminalAt } from "./useNewTerminal";
 import { toInsertText } from "../components/dropPaths";
 import type { HeaderButton, OpenTarget } from "./useHeaderButtons";
+import { isRecord } from "../../common/isRecord";
 
 const OPEN_URL_SCHEMES: ReadonlySet<string> = new Set(["http:", "https:"]);
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 // Open the OS file dialog (server-side, since the browser can't read a real path) and insert the chosen
 // path(s) at the session's cursor. slotKey identifies which terminal receives the text.

--- a/test/common/isRecord.spec.ts
+++ b/test/common/isRecord.spec.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+//
+// The guard replaced 29 hand-copied definitions, 28 of which let arrays through (#828). What is
+// pinned here is the behaviour that differs from those copies — an array is NOT a record — plus
+// the everyday cases every call site depends on.
+import { describe, it, expect } from "vitest";
+import { isRecord } from "../../common/isRecord.js";
+
+describe("isRecord", () => {
+  it("accepts an object literal, empty or not", () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  // The reason the shared version excludes arrays: TypeScript itself refuses
+  // `const r: Record<string, unknown> = []`, so narrowing an array to Record is a lie — and a
+  // caller that goes on to Object.entries() the value would walk array indices as field names.
+  it("rejects an array, empty or not", () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([{ a: 1 }])).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+  });
+
+  it("rejects primitives", () => {
+    expect(isRecord("")).toBe(false);
+    expect(isRecord("{}")).toBe(false);
+    expect(isRecord(0)).toBe(false);
+    expect(isRecord(false)).toBe(false);
+  });
+
+  it("rejects a function", () => {
+    expect(isRecord(() => ({}))).toBe(false);
+  });
+
+  // Known and accepted: only arrays are singled out. graphai's isPlainObject would reject these
+  // too, but it is not exported from the package root, and no caller feeds them in — every input
+  // is JSON.parse output or a request body.
+  it("accepts other object instances, which no call site feeds it", () => {
+    expect(isRecord(new Date())).toBe(true);
+    expect(isRecord(new Map())).toBe(true);
+  });
+
+  it("narrows so a field can be read without a cast", () => {
+    const parsed: unknown = JSON.parse('{"cwd":"/tmp"}');
+    expect(isRecord(parsed) && typeof parsed.cwd === "string" ? parsed.cwd : null).toBe("/tmp");
+  });
+
+  it("keeps a JSON array out of the record branch", () => {
+    const parsed: unknown = JSON.parse("[1,2,3]");
+    expect(isRecord(parsed)).toBe(false);
+  });
+});

--- a/test/server/backends/collections.spec.ts
+++ b/test/server/backends/collections.spec.ts
@@ -24,6 +24,7 @@ vi.mock("@mulmoclaude/core/collection/registry/server", () => ({
 // exist on disk (the schema refine rejects it), yet the route's defensive 400
 // must still be covered.
 import { buildWorkspaceOntology, deleteCollection, deleteCustomView, loadCollection } from "@mulmoclaude/core/collection/server";
+import { isRecord } from "../../../common/isRecord.js";
 vi.mock("@mulmoclaude/core/collection/server", async (importOriginal) => {
   const orig = await importOriginal<typeof import("@mulmoclaude/core/collection/server")>();
   return {
@@ -672,8 +673,6 @@ describe("collection / view delete routes", () => {
     expect((await fetch(`${base}/api/collections/testcol/views/v1`, { method: "DELETE" })).status).toBe(404);
   });
 });
-
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
 
 const readJson = async <T>(res: Response, isBody: (value: unknown) => value is T): Promise<T> => {
   const body: unknown = await res.json();

--- a/test/server/config/config-schema.spec.ts
+++ b/test/server/config/config-schema.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { isRecord } from "../../../common/isRecord.js";
 import {
   dirNameField,
   dirColorField,
@@ -78,8 +79,6 @@ describe("item schemas (strict shape)", () => {
     expect(cwdPresetSchema.safeParse({ label: "x" }).success).toBe(false);
   });
 });
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 
 describe("dirConfigJsonSchema", () => {
   it("emits an object schema with every writable property", () => {

--- a/test/server/infra/install-bundled-skills.spec.ts
+++ b/test/server/infra/install-bundled-skills.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { BUNDLED_SKILL_NAMES, installOwnedSkill, SCHEMA_ASSET_FILE } from "../../../server/infra/install-bundled-skills";
 import { loadDirConfig } from "../../../server/config/dir-config";
+import { isRecord } from "../../../common/isRecord.js";
 
 const NAME = "mulmoterminal-config";
 const MARKER = ".mt-owned";
@@ -86,8 +87,6 @@ describe("installOwnedSkill", () => {
     expect(SCHEMA_ASSET_FILE).not.toBe("schema.json");
   });
 });
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const CHROME_KEYS = ["badgeColor", "headerColor", "headerTextColor", "cellColor", "cellBorderColor", "dotColor", "buttonColor"] as const;
 const META_KEYS = ["id", "vibe", "label", "description"];
 


### PR DESCRIPTION
## Summary

`isRecord` の 29 個（`test/` 込みで 32 個）の手写しコピーを `common/isRecord.ts` の 1 本に集約します（#828）。

```ts
import { isObject } from "graphai";
export const isRecord = (value: unknown): value is Record<string, unknown> => isObject(value) && !Array.isArray(value);
```

名前は `isRecord` のままなので、**呼び出し 100 箇所は無変更**です。各ファイルは定義行が消えて import が 1 行増えるだけ。

## Items to Confirm / Review

1. **配列を除外する = 唯一の挙動変更**。これがこの PR の実質的な判断です。根拠は「TypeScript 自身が配列を `Record<string, unknown>` と認めない」こと:
   ```
   TS2322: Type 'unknown[]' is not assignable to type 'Record<string, unknown>'.
     Index signature for type 'string' is missing in type 'unknown[]'.
   ```
   つまり配列除外なしの 28 コピーは**型の嘘**でした。`server/config/header-config.ts` だけが自力で気づいて除外していたので、共通版はそちらに揃えています。
2. **厳格化が安全である根拠**: 呼び出し 100 箇所のうち 99 は `isRecord(x) && typeof x.field === "..."` の形で、配列なら現状でも false。唯一値を列挙する `server/session/activity-state.ts` は JSON ファイル読み込みで、トップレベル配列は不正入力（続く `isValidId` が弾く）。挙動が変わるのは「不正入力をより早く弾く」方向だけです
3. **graphai に乗せた判断**。グローバル CLAUDE.md の「既存ライブラリのユーティリティを使う」に従いました。理想は graphai の `isPlainObject`（配列・Map・Date・クラスインスタンスを弾く）ですが、**パッケージ root から export されていない**（実行時 `undefined`）ため内部パス依存になるので不採用。配列除外だけこちら側で足しています。Date/Map を弾かないのは既知の割り切りで、spec に明記しました
4. **バンドルへの影響なし**。graphai は `collectionUi.ts → collectionUiRules.ts` 経由で既にブラウザバンドルに入っており、**変更前後とも 3920 KB で同一**（実測）

## User Prompt

- #828 が誰か着手しているか確認してほしい（main をきちんと更新したうえで）
- 手つかずなら、配列除外の 1 個をどう扱うかを含めて**調査して決めてから**実装してほしい

## 調査結果

31 個の定義の内訳:

| 実装 | 個数 |
|---|---|
| `(v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null` | 23 |
| 同じロジックで引数名が `value` / `d` | 5 |
| `function` 宣言形式 | 2 |
| **`&& !Array.isArray(v)` 付き**（`server/config/header-config.ts`） | 1 |

着手状況の確認（main を `c5bcfde` まで更新して実施）: assignee なし / コメント 0 / `#828` に言及するコミットは全ブランチで 0 件 / `common/` への型ガード追加も 0 件 / 並行チェックアウト（`mulmoterminal` = #843、`mulmoterminal2` = main）も別作業。**完全に手つかず**でした。

## 実装

- `common/isRecord.ts` を追加（`common/` は両方の tsconfig に include されているので server/src 双方から使える）
- 32 ファイルの定義を削除し import に置換。拡張子は各ツリーの規約に従う（`server/` `test/server/` `common/` は `.js`、`src/` は無し）
- `server/session/transcript.ts` が `export` していた分の import 元 8 ファイル（`cost.ts` / `last-turn.ts` / `session-reads.ts` / `plugin-narration.ts` / `plugin-routes.ts` / `toolResultPlan.ts` / `dirRequest.ts` / `codex-activity.ts`）と、`server/git/ghItem.ts` から import していた `prs.ts` も `common/` に向け直し

## テスト

`test/common/isRecord.spec.ts` — 通常のオブジェクト、**配列（今回変わる挙動）**、null/undefined、プリミティブ、関数、Date/Map（弾かない割り切り）、`JSON.parse` 結果の絞り込みと型の絞り込み。

`yarn format` / `lint`（0 error）/ `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test`（4321 passed）通過。

## スコープ外

- `src/composables/collectionUiRules.ts` が graphai の `isObject` を直接使っている箇所。同じ概念のもう 1 つのコピーですが、#828 の対象は `isRecord` の重複なので触っていません

Closes #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)
