### PR TITLE
fix: one same-origin gate for every state-changing request

### DIFF
--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -9,6 +9,7 @@
 // What arrives as deps is what index.ts owns: the spawners, the session lifecycle, the title
 // manager, the tool stores, and `publish` (pub/sub exists only once the HTTP server does).
 import path from "node:path";
+import { sameOriginGuard } from "./same-origin-guard.js";
 import express, { type Express } from "express";
 import { mountAllRoutes } from "../infra/plugins-registry.js";
 import { mountConfigRoutes } from "../config/config-routes.js";
@@ -74,6 +75,11 @@ const DIR_CONFIG_CHANNEL = "dir-config";
 export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
   const clientDir = deps.clientDir;
   app.use(express.json({ limit: "25mb" }));
+
+  // Before any route: one same-origin gate for every state-changing request, so a site the
+  // user visits cannot drive this server through their browser. Individual routes keep their
+  // own checks — this is the floor, not a replacement.
+  app.use(sameOriginGuard(deps.isAllowedOrigin));
 
   // The GUI-plugin tool routes this server answers itself: spawnBackgroundChat,
   // manageAccounting, manageCollection (routes/plugin-routes.ts). ALL of them must precede

--- a/server/routes/same-origin-guard.ts
+++ b/server/routes/same-origin-guard.ts
@@ -10,8 +10,16 @@ import type { NextFunction, Request, Response } from "express";
 // covered some of that surface and not the rest, which is the failure mode a central gate
 // removes: a route added tomorrow is covered by default rather than by memory.
 //
-// Safe methods are left alone. They change nothing, and gating them would break the
-// `<img>`/`<video>` loads that cannot send an Authorization header anyway.
+// Safe methods are left alone — but not because they are guaranteed side-effect free. Gating
+// them by origin would achieve nothing: a cross-site `<img src=http://localhost:.../>` sends NO
+// Origin header, exactly like a legitimate local fetch, so the predicate cannot tell them
+// apart. It would only break the media loads that cannot send a header.
+//
+// That makes "a GET must not change anything" a rule this file relies on and cannot enforce.
+// One route already bends it: GET /api/session/:id calls freshenRosterTitle, which may spawn
+// an LLM title generation. It is rate-limited and needs a server-generated session UUID the
+// caller would have to know, so the cost of the bend is small — but a NEW side effect added to
+// a GET is unprotected by anything here, and belongs in a POST.
 const STATE_CHANGING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
 
 // The one deliberate cross-origin caller: a custom collection view is LLM-authored HTML in a

--- a/server/routes/same-origin-guard.ts
+++ b/server/routes/same-origin-guard.ts
@@ -1,0 +1,34 @@
+import type { NextFunction, Request, Response } from "express";
+
+// A single same-origin gate for every state-changing request, instead of each route
+// remembering to ask.
+//
+// Why it is needed even though the server binds to loopback: loopback is reachable from the
+// user's OWN browser, so a site they happen to visit can POST to http://localhost:34567. It
+// cannot READ the reply cross-origin, but the side effect still happens — and among these
+// routes are ones that spawn an agent, rewrite the config, and write files. Per-route guards
+// covered some of that surface and not the rest, which is the failure mode a central gate
+// removes: a route added tomorrow is covered by default rather than by memory.
+//
+// Safe methods are left alone. They change nothing, and gating them would break the
+// `<img>`/`<video>` loads that cannot send an Authorization header anyway.
+const STATE_CHANGING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+// The one deliberate cross-origin caller: a custom collection view is LLM-authored HTML in a
+// sandboxed iframe, so its origin is opaque (`null`) by construction. It carries its own
+// HMAC-signed capability token, scoped to one slug and to read/write — a stronger check than
+// origin, and the reason these paths must not be judged by origin at all.
+const VIEW_DATA = /^\/api\/collections\/[^/]+\/view-data(\/|$)/;
+
+export function needsSameOrigin(method: string, path: string): boolean {
+  if (!STATE_CHANGING.has(method.toUpperCase())) return false;
+  return !VIEW_DATA.test(path);
+}
+
+export function sameOriginGuard(isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!needsSameOrigin(req.method, req.path)) return next();
+    if (isAllowedOrigin(req.headers.origin, req.socket?.remoteAddress)) return next();
+    res.status(403).json({ error: "forbidden origin" });
+  };
+}

--- a/test/server/routes/same-origin-guard.spec.ts
+++ b/test/server/routes/same-origin-guard.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import type { NextFunction, Request, Response } from "express";
+import { needsSameOrigin, sameOriginGuard } from "../../../server/routes/same-origin-guard.js";
+
+describe("needsSameOrigin", () => {
+  it("gates every state-changing method", () => {
+    for (const m of ["POST", "PUT", "PATCH", "DELETE", "post", "delete"]) {
+      expect(needsSameOrigin(m, "/api/config"), m).toBe(true);
+    }
+  });
+
+  // Safe methods change nothing, and gating them would break the <img>/<video> loads that
+  // cannot send an Authorization header.
+  it("leaves safe methods alone", () => {
+    for (const m of ["GET", "HEAD", "OPTIONS"]) {
+      expect(needsSameOrigin(m, "/api/config"), m).toBe(false);
+    }
+  });
+
+  // A custom collection view is LLM-authored HTML in a sandboxed iframe, so its origin is
+  // opaque by construction. It carries an HMAC capability token instead — judging it by origin
+  // would break the feature while replacing a stronger check with a weaker one.
+  it("exempts the view-data endpoints, which authenticate by token", () => {
+    expect(needsSameOrigin("PUT", "/api/collections/notes/view-data")).toBe(false);
+    expect(needsSameOrigin("POST", "/api/collections/notes/view-data/query")).toBe(false);
+  });
+
+  it("does NOT exempt the collection's other routes", () => {
+    expect(needsSameOrigin("POST", "/api/collections/notes/items")).toBe(true);
+    expect(needsSameOrigin("DELETE", "/api/collections/notes")).toBe(true);
+    expect(needsSameOrigin("POST", "/api/collections/notes/view-token")).toBe(true);
+  });
+
+  // The exemption is a path shape, so it must not be reachable by dressing another route up
+  // to look like one.
+  it("cannot be smuggled past with a lookalike path", () => {
+    expect(needsSameOrigin("POST", "/api/collections/x/view-datastore")).toBe(true);
+    expect(needsSameOrigin("POST", "/api/collections/a/b/view-data")).toBe(true);
+    expect(needsSameOrigin("POST", "/api/evil/api/collections/x/view-data")).toBe(true);
+  });
+});
+
+describe("sameOriginGuard", () => {
+  const run = (method: string, path: string, allowed: boolean) => {
+    const next = vi.fn() as unknown as NextFunction;
+    const json = vi.fn();
+    const res = { status: vi.fn(() => ({ json })), json } as unknown as Response;
+    const req = { method, path, headers: { origin: "http://evil.example" }, socket: { remoteAddress: "127.0.0.1" } } as unknown as Request;
+    sameOriginGuard(() => allowed)(req, res, next);
+    return { next, res, json };
+  };
+
+  it("passes a request the predicate allows", () => {
+    const { next, res } = run("POST", "/api/config", true);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("rejects a state-changing request the predicate refuses", () => {
+    const { next, res } = run("POST", "/api/config", false);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("lets an exempt path through even when the predicate would refuse", () => {
+    const { next, res } = run("PUT", "/api/collections/notes/view-data", false);
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("lets a safe method through even when the predicate would refuse", () => {
+    const { next } = run("GET", "/api/config", false);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("hands the predicate both the origin and the peer", () => {
+    const predicate = vi.fn(() => true);
+    const req = {
+      method: "POST",
+      path: "/api/config",
+      headers: { origin: "http://localhost:1" },
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as Request;
+    sameOriginGuard(predicate)(req, {} as Response, vi.fn() as unknown as NextFunction);
+    expect(predicate).toHaveBeenCalledWith("http://localhost:1", "127.0.0.1");
+  });
+});

--- a/test/server/routes/same-origin-guard.spec.ts
+++ b/test/server/routes/same-origin-guard.spec.ts
@@ -11,6 +11,9 @@ describe("needsSameOrigin", () => {
 
   // Safe methods change nothing, and gating them would break the <img>/<video> loads that
   // cannot send an Authorization header.
+  // Pinned so the reason survives: gating GETs would not stop a cross-site <img>, which sends
+  // no Origin at all, and would break the media loads that cannot send a header. The guarantee
+  // that a GET is harmless has to come from the routes, not from here.
   it("leaves safe methods alone", () => {
     for (const m of ["GET", "HEAD", "OPTIONS"]) {
       expect(needsSameOrigin(m, "/api/config"), m).toBe(false);


### PR DESCRIPTION
状態変更メソッドの同一オリジン判定を全ルートの手前に集約しました（`view-data` はトークン認証のため除外）。