### PR TITLE
fix: give the buffer-health fuzz test the wall-clock its yields need (#858)

### DIFF
--- a/plans/fix-windows-buffer-health-fuzz-timeout.md
+++ b/plans/fix-windows-buffer-health-fuzz-timeout.md
@@ -1,0 +1,74 @@
+# Windows CI: the buffer-health fuzz test needs its own timeout
+
+Issue: #858
+
+## What was red
+
+`Windows (daily)` failed on main four times today, always on the same test and always the same way:
+
+```
+FAIL test/src/composables/terminalBufferHealth.spec.ts > bufferIsShort on a real terminal
+     > stays quiet across writes, resizes, resets, alt-buffer switches and scrolling
+Error: Test timed out in 15000ms.
+```
+
+The leg that fails alternates between node 22.x and 24.x — whichever is slower on that run. Everything
+else passes (`1 failed | 4462 passed`).
+
+The run originally reported (30196880838) was **cancelled by concurrency**, not failed; the genuine
+failure is the run that superseded it (30197339335).
+
+## Why this is wall-clock, not a defect
+
+Two things separate a slow test from a broken one, and both point the same way here:
+
+- The failure is **always a timeout, never an assertion**. The test's real job is to prove
+  `bufferIsShort` never fires on a healthy terminal — a false positive rebuilds a live terminal and
+  costs the user their scrollback. That guard never tripped.
+- **Linux CI is green on the identical commits.** Only the Windows runner misses the deadline.
+
+## Root cause
+
+The fuzz loop is `SEEDS = 25` × `OPS_PER_SEED = 60` = 1500 steps. Each step asserts the synchronous
+buffer shape, then `await`s a `setTimeout(…, 0)` and asserts the settled one — because the probe runs
+both mid-stream (on output) and a task later (confirming itself after `fit()`).
+
+So the test's floor is **1500 sequential timer yields**, and a yield costs scheduling latency, not
+work. Measured on macOS:
+
+| | |
+|---|---|
+| 1500 sequential `setTimeout(0)` yields | 1719 ms |
+| whole spec file | 2320 ms |
+
+~74% of the runtime is the yields; the xterm operations and assertions are the small remainder. A
+Windows runner pays enough more per yield that the floor alone crosses 15s, with the actual work
+barely started. That also explains the 22.x/24.x alternation: nothing about the test is
+version-sensitive, it is just whichever leg is slower.
+
+## Options considered
+
+1. **Swap `setTimeout(0)` for `setImmediate`** — rejected. xterm continues a long write via
+   `setTimeout` internally (`_innerWrite` re-schedules itself), so a check-phase yield resolves
+   *before* that pending continuation. The test would keep passing while quietly no longer testing
+   the settled state its name claims. A test name that lies is worse than a slow test.
+2. **Cut `SEEDS` / `OPS_PER_SEED`** — rejected. That buys the time back out of the fuzz coverage,
+   which is the entire reason the negative case is driven against a real xterm instead of hand-built
+   shapes.
+3. **Run the 25 seeds concurrently** — plausible follow-up, not taken now. The seeds are independent
+   (own `Terminal`, and the probe is pure), and overlapping their yield latency would cut wall-clock
+   sharply. It restructures a test that is currently correct, for speed we do not need yet; noted in
+   the PR rather than bundled into a red-CI fix.
+4. **An explicit per-test timeout** — taken.
+
+## The change
+
+One line: `}, 60_000)` on that test, with a comment recording why the baseline does not fit it.
+
+`vitest.config.ts` sets `testTimeout: 15_000`, and its comment says what that number is for — absorbing
+load spikes when a dev builds and tests at once, for tests that normally finish in milliseconds. This
+test is a different shape: seconds of legitimate work by construction. It wants its own budget rather
+than a raised global one, which would dull the ceiling for all 4462 other tests.
+
+60s gives roughly 3x headroom over the worst plausible Windows cost while still catching a genuine
+hang, and the job keeps its own 30-minute cap.

--- a/test/src/composables/terminalBufferHealth.spec.ts
+++ b/test/src/composables/terminalBufferHealth.spec.ts
@@ -89,5 +89,10 @@ describe("bufferIsShort on a real terminal", () => {
       }
       term.dispose();
     }
-  });
+    // A per-test timeout, not the 15s baseline: the floor here is SEEDS * OPS_PER_SEED sequential
+    // timer yields, and a yield costs latency rather than work — 1500 of them are already ~1.7s of
+    // this file's ~2.3s on macOS, and enough more on a Windows runner to cross 15s with the
+    // assertions barely started. Trimming the seeds would buy the time back out of the fuzz
+    // coverage, which is the one thing this test exists for.
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary

`Windows (daily)` has been red on main all day, always on one test and always as a **timeout, never an assertion**:

```
FAIL test/src/composables/terminalBufferHealth.spec.ts > bufferIsShort on a real terminal
     > stays quiet across writes, resizes, resets, alt-buffer switches and scrolling
Error: Test timed out in 15000ms.
```

Root cause is wall-clock, not behaviour. The fuzz loop is 25 seeds × 60 ops = 1500 steps, and every step `await`s a `setTimeout(…, 0)` to check the settled buffer shape as well as the synchronous one. That makes the floor **1500 sequential timer yields**, and a yield costs scheduling latency rather than work — measured locally, those yields are **1719 ms of the file's 2320 ms** (~74%). A Windows runner pays enough more per yield to cross 15s with the assertions barely started.

The fix is one line: an explicit `60_000` timeout on that test, plus a comment recording why the baseline does not fit it.

Closes #858.

## Items to Confirm / Review

- **The judgement call.** I gave the test more time instead of trimming `SEEDS`/`OPS_PER_SEED`. The trim would have been smaller, but it pays for CI time with the fuzz coverage that is the whole reason the negative case runs against a real xterm. Please sanity-check that priority.
- **Why not `setImmediate`.** It would be cheaper, and it would be wrong: xterm re-schedules a long write via `setTimeout` internally (`_innerWrite` calls itself through a timer), so a check-phase yield resolves *before* that pending continuation. The test would keep passing while silently no longer covering the settled state its name claims. I verified this against the shipped `@xterm/headless` bundle rather than assuming.
- **Is 60s the right number?** The Windows runs died at the 15s ceiling, so the true cost there is unknown — only that it exceeds 15s. 60s is ~3x headroom over the worst plausible cost while still catching a genuine hang, and the job keeps its own 30-minute cap. If you would rather it be tighter, 30s is probably still safe.
- **A per-test timeout rather than a raised global.** `vitest.config.ts` sets `testTimeout: 15_000`, and its comment says that number exists to absorb load spikes for tests that normally finish in milliseconds. Raising it globally would dull the ceiling for the other 4462 tests.
- **Follow-up not taken here** (see the plan file): the 25 seeds are independent — own `Terminal`, and the probe is pure — so running them concurrently would overlap the yield latency and make the test genuinely fast rather than merely permitted to be slow. I left it out on purpose; restructuring a correct test does not belong in a red-CI fix. Happy to do it as its own PR.

## User Prompt

> fix https://github.com/receptron/mulmoterminal/actions/runs/30196880838

Worth recording: **that run was cancelled, not failed** — `Canceling since a higher priority waiting request for windows-daily-refs/heads/main exists`, from the workflow's own `cancel-in-progress: true`. The genuine failure is the run that superseded it, [30197339335](https://github.com/receptron/mulmoterminal/actions/runs/30197339335), plus [30187277283](https://github.com/receptron/mulmoterminal/actions/runs/30187277283), [30184565395](https://github.com/receptron/mulmoterminal/actions/runs/30184565395) and [30184148043](https://github.com/receptron/mulmoterminal/actions/runs/30184148043) earlier today — all the same test, all the same timeout.

## Evidence this is wall-clock, not a defect

- The failure is **always a timeout, never an assertion**. The test's real job is proving `bufferIsShort` never fires on a healthy terminal (a false positive rebuilds a live terminal and costs the user their scrollback). That guard never tripped.
- **Linux CI is green on the identical commits** — runs 30197339352, 30196880853.
- The failing matrix leg **alternates between 22.x and 24.x**, whichever is slower on the day. Nothing in the test is version-sensitive.

## Verification

- `yarn format`, `yarn lint` (0 errors; 6 pre-existing warnings), `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test`, `yarn build` — all clean.
- `yarn test` — **300 files passed / 2 skipped, 4429 tests passed**.
- **The override actually takes effect**, rather than being an ignored third argument: running the file with `--testTimeout=100` passes with the change, and reproduces the CI signature without it (`Error: Test timed out in 100ms.`, `1 failed | 7 passed`). That is the CI failure mode in miniature, and it confirms only this one test needed the budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)