### PR TITLE
fix(terminal): CJK フォントを明示して日本語が下線に化けるのを直す

### DIFF
--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -255,7 +255,13 @@ function buildTerminal(swallowedMouseModes: Set<number>): TerminalRuntime {
   const term = new Terminal({
     cursorBlink: true,
     fontSize: 14,
-    fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
+    // CJK fonts are named EXPLICITLY. None of the three coding fonts above carries a CJK glyph,
+    // and the canvas renderer does not fall back per-glyph the way the DOM one does — it draws a
+    // placeholder instead, so a Japanese line renders as a row of underscores while ASCII beside
+    // it is fine. Naming a font that HAS the glyph is what makes the atlas able to rasterize it.
+    // Ordered per-platform (macOS / Noto / Windows-JP / Windows-CN / Korean); the generic
+    // `monospace` still ends the list for anything none of them cover.
+    fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', 'Hiragino Sans', 'Noto Sans CJK JP', 'Yu Gothic', 'Microsoft YaHei', 'Apple SD Gothic Neo', monospace",
     // Treat macOS Option as Meta so Claude's Alt bindings reach the PTY — Alt+Enter
     // (newline), Alt+B/F (word nav), Alt+Backspace (delete word). The cost is Option
     // dead-key accent entry (é etc.), which a coding terminal doesn't need.


### PR DESCRIPTION
## 症状

macOS + Chrome で、ターミナル内の日本語の行が丸ごと下線（`______`）になります。隣の ASCII は正常で、リロードしても直りません。

## 原因

`fontFamily` が `'JetBrains Mono', 'Fira Code', 'Menlo', monospace` の3つだけで、**いずれも CJK のグリフを持っていません**。DOM renderer はグリフ単位でフォールバックしますが、**canvas renderer はしません** — グリフが無いとプレースホルダを描くため、下線の行になります。

## 変更

グリフを実際に持つフォントを名前で指定します。プラットフォーム順に並べ、末尾の generic な `monospace` は従来どおり残しています。

```
'JetBrains Mono', 'Fira Code', 'Menlo',
'Hiragino Sans', 'Noto Sans CJK JP', 'Yu Gothic', 'Microsoft YaHei', 'Apple SD Gothic Neo',
monospace
```

## 確認

macOS 26.2 / Chrome 150 で、日本語が正しく描画されること・ASCII に変化がないことを確認しました。1行の変更で、既に描画できていた環境の挙動は変わりません。

なお #314（CJK の行が右端にはみ出す）で canvas renderer が導入されていますが、本件はそれとは別で「グリフが無い」ことによるものです。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text rendering for Japanese and other CJK characters.
  * Added CJK-compatible font fallbacks to prevent missing or placeholder glyphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->