### PR TITLE
feat(terminal): パスを持たないドロップ・貼り付けをサーバー側に保存して読ませる

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -101,6 +101,30 @@ change one and change the other (#834).
 - xterm exposes no pixel-to-cell mapping, so cell coordinates are derived from `.xterm-screen`'s
   own box. Reaching into `_core._renderService.dimensions` instead would need an `any`.
 
+### Dropped and pasted files — path first, bytes as the fallback
+
+A file dropped on the terminal inserts its **absolute path** (`dropPaths.ts`), because the agent
+reads the file itself — the path is the useful thing, not the bytes. The path is only reachable
+through the drag's `text/uri-list`; the `File` object hides it.
+
+Two cases have no path to insert, and both fall back to staging the bytes server-side
+(`files/dropped-files.ts`, `POST /api/files/dropped`) and inserting *that* path instead:
+
+- **Chrome withholds `text/uri-list`** on a file drop, so the path route yields nothing. Before the
+  fallback, dropping a screenshot on the browser most people use did nothing but show a hint.
+- **A pasted screenshot** (macOS ⌘⌃⇧4 → clipboard) has no file on disk in *any* browser.
+
+Staged under `~/.mulmoterminal/drops/<date>/<random>/<original name>` — deliberately **not** inside
+the session's working directory, so a screenshot dropped while working in a repo never turns up as
+an untracked file in someone's diff. The random parent is what makes the path unique; the original
+name is kept because it is often the only clue about what the file is. Swept after 7 days.
+
+Caps: 25 MiB per file (checked client-side too, so an oversized file fails before the upload),
+10 files per drop, and the raw data-URL bound is checked *before* decoding — the same ordering rule
+`audioAdmission.ts` uses, so a huge payload is refused without first being expanded into memory.
+
+A **text** paste is never intercepted: it must reach xterm natively, which is the common case.
+
 ### A terminal xterm has killed can only be replaced (#846)
 
 `Buffer.resize` in xterm 6.0.0 can finish with fewer lines than the viewport needs
@@ -189,6 +213,7 @@ looking) — flag them for QA on the release.
 | OSC 8 links | tmux `terminal-features '*:hyperlinks'` present; xterm `linkHandler` set | click Claude statusline `PR #NNNN` → opens the PR (no confirm dialog) |
 | OSC 52 clipboard | tmux `Ms` override + `set-clipboard on` present (`planMsOverride`) | Claude auto-copy reaches the browser clipboard |
 | File-path links | `registerFilePathLinks` order vs WebLinks; `/api/files/raw` cwd containment | click a generated file path → previews the file |
+| Drop / paste files | `dropPaths.ts` uri-list route, then the `POST /api/files/dropped` byte fallback | drop a file → path inserted (Safari); drop or paste a screenshot in Chrome → staged path inserted; a TEXT paste still reaches xterm untouched |
 | Enter / newline | `terminalSubmit` mapping + `isComposing` guard; `macOptionIsMeta` | Enter submits, Shift+Enter newlines; IME confirm not eaten; both `cr` and `esc-cr` |
 | Mouse / wheel | `guardMouseTracking` swallow set (1000/1002/1003/1006); wheel→SGR in alt buffer | wheel scrolls transcript (not prompt history); drag selects, doesn't emit mouse reports |
 | Reattach | `stripTerminalQueries` patterns; replay buffer size | reattaching a session doesn't leak `0;276;0c`-style junk; scrollback survives |

--- a/server/backends/files.ts
+++ b/server/backends/files.ts
@@ -25,9 +25,32 @@ import { parseByteRange } from "./byte-range.js";
 import { rawServingPlan } from "./rawServingPlan.js";
 import { streamFileToResponse } from "./streamFile.js";
 import { authorizedServingBase, resolveContained } from "../files/pathContainment.js";
+import { admitDroppedFile, saveDroppedFile, sweepOldDrops } from "../files/dropped-files.js";
 
 export function mountFilesRoutes(app: Express, deps: { workspace: string; sessionCwds: () => Iterable<string> }): void {
   const root = path.resolve(deps.workspace);
+
+  // POST /api/files/dropped — stage bytes that arrived without a path and answer with the path
+  // to insert. The fallback for a drop whose path the browser withheld (Chrome) and the ONLY
+  // route for a pasted screenshot, which has no file on disk to name. See files/dropped-files.ts
+  // for where it lands and why that is outside the session's working directory.
+  app.post("/api/files/dropped", (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as { dataUrl?: unknown; name?: unknown };
+    const admitted = admitDroppedFile(body.dataUrl, body.name);
+    if (!admitted.ok) {
+      res.status(admitted.status).json({ error: admitted.error });
+      return;
+    }
+    try {
+      const file = saveDroppedFile(admitted);
+      // After the write, not before: the user's drop lands even if the sweep throws, and a
+      // failed sweep is not worth a failed drop.
+      sweepOldDrops(new Date());
+      res.json({ path: file });
+    } catch (err) {
+      res.status(500).json({ error: err instanceof Error ? err.message : "failed to stage the dropped file" });
+    }
+  });
 
   app.get("/api/files/raw", (req: Request, res: Response) => {
     const rel = typeof req.query.path === "string" ? req.query.path : "";

--- a/server/files/dropped-files.ts
+++ b/server/files/dropped-files.ts
@@ -1,0 +1,110 @@
+// Staging for files that arrive as BYTES rather than as a path.
+//
+// Dropping a file on the terminal normally inserts its absolute path (dropPaths.ts) — the agent
+// then reads it itself, which is the whole point. But the path is only reachable through the
+// drag's `text/uri-list`, and Chrome withholds it, so on the browser most people use, dropping a
+// screenshot does nothing but show a hint. A pasted screenshot (⌘⌃⇧4 → clipboard) has no path at
+// ALL, in any browser: there is no file on disk to name.
+//
+// Both cases have the bytes. Writing them somewhere real and inserting THAT path turns "nothing
+// happened" into the same outcome the path drop already produces, without the agent needing any
+// new concept — it still just reads a file.
+//
+// Staged under ~/.mulmoterminal/drops/<date>/<random>/<original name>, never inside the session's
+// working directory: a screenshot dropped while working in a repo must not become an untracked
+// file in someone's diff. The original name is preserved (it is often the only clue about what
+// the file is) and the random parent is what makes the path unique.
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseDataUrl, approxBytes, type AudioParts } from "../backends/audioAdmission.js";
+
+// A retina screenshot is a few MB; a phone photo can be 10+. 25 MiB leaves room without letting
+// one paste write an arbitrarily large file into the home dir.
+export const MAX_DROP_BYTES = 25 * 1024 * 1024;
+// base64 is ~+33%; a loose pre-decode bound so an oversized payload is refused before it is
+// expanded into memory (same ordering rule as audioAdmission).
+export const MAX_DROP_DATAURL_CHARS = MAX_DROP_BYTES * 3;
+// Staged files are a transient hand-off, not a library. A week is long enough to re-reference
+// something from yesterday's session and short enough that the directory doesn't grow forever.
+export const DROP_RETENTION_DAYS = 7;
+
+const BAD_REQUEST = 400;
+const PAYLOAD_TOO_LARGE = 413;
+
+const MIME_EXTENSIONS: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "image/heic": ".heic",
+  "application/pdf": ".pdf",
+  "text/plain": ".txt",
+};
+
+export const dropsRoot = (): string => path.join(os.homedir(), ".mulmoterminal", "drops");
+
+/** A filename safe to join onto a directory we chose. Everything structural is stripped rather
+ *  than escaped — a name is display sugar here, and the random parent already guarantees
+ *  uniqueness, so there is nothing to lose by being blunt about it. */
+export function safeDropName(name: unknown, mimeType: string): string {
+  const raw = typeof name === "string" ? name : "";
+  // basename first: a name of "../../x" must not climb, and a browser may send a full path.
+  const base = path.basename(raw.replace(/\\/g, "/")).trim();
+  const cleaned = base
+    .replace(/[^A-Za-z0-9._-]/g, "-") // keep it boring: no spaces, no quotes, no shell characters
+    .replace(/^[.-]+/, "") // a leading dot would hide it; a leading dash reads as a flag
+    .slice(0, 80);
+  if (cleaned) return cleaned;
+  // No usable name (a pasted screenshot has none) — synthesize one from the type, so the
+  // inserted path still tells the reader what they are looking at.
+  return `pasted${MIME_EXTENSIONS[mimeType] ?? ""}`;
+}
+
+export type DropAdmission = { ok: true; parts: AudioParts; name: string } | { ok: false; status: number; error: string };
+
+/** Size and shape checks, in the order that keeps a huge payload from being decoded first. */
+export function admitDroppedFile(dataUrl: unknown, name: unknown): DropAdmission {
+  if (typeof dataUrl !== "string" || !dataUrl) return { ok: false, status: BAD_REQUEST, error: "dataUrl is required" };
+  if (dataUrl.length > MAX_DROP_DATAURL_CHARS) return { ok: false, status: PAYLOAD_TOO_LARGE, error: "file exceeds the size limit" };
+  const parts = parseDataUrl(dataUrl);
+  if (!parts) return { ok: false, status: BAD_REQUEST, error: "dataUrl must be a base64 data: URI" };
+  if (approxBytes(parts.base64) > MAX_DROP_BYTES) return { ok: false, status: PAYLOAD_TOO_LARGE, error: "file exceeds the size limit" };
+  return { ok: true, parts, name: safeDropName(name, parts.mimeType) };
+}
+
+const dateDir = (now: Date): string => now.toISOString().slice(0, 10); // YYYY-MM-DD, stable across timezones
+
+/** Delete staged directories older than the retention window. Best-effort: a drop that can't be
+ *  swept is not a reason to fail the drop the user is making right now. */
+export function sweepOldDrops(now: Date, root: string = dropsRoot()): void {
+  const cutoff = new Date(now.getTime() - DROP_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+  const oldest = dateDir(cutoff);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(root);
+  } catch {
+    return; // nothing staged yet
+  }
+  for (const entry of entries) {
+    // Only touch names this module creates. A stray file or a hand-made directory is left alone
+    // rather than deleted by a rule it was never subject to.
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(entry) || entry >= oldest) continue;
+    try {
+      fs.rmSync(path.join(root, entry), { recursive: true, force: true });
+    } catch {
+      // keep going: one undeletable directory must not stop the rest
+    }
+  }
+}
+
+/** Write the admitted bytes and return the absolute path to insert. */
+export function saveDroppedFile(admitted: Extract<DropAdmission, { ok: true }>, now: Date = new Date(), root: string = dropsRoot()): string {
+  const dir = path.join(root, dateDir(now), crypto.randomBytes(4).toString("hex"));
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, admitted.name);
+  fs.writeFileSync(file, Buffer.from(admitted.parts.base64, "base64"));
+  return file;
+}

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -4,6 +4,7 @@ import { type ITheme } from "@xterm/xterm";
 import { FLIP_MS, shouldRefocusOnZoomChange } from "./cellFlip";
 import { terminalManagesAttention, terminalViewActive } from "./terminalViewActive";
 import { dragCarriesFiles, dropTextFromUriList } from "./dropPaths";
+import { stagedInsertText, filesFromClipboard } from "../composables/useStagedFiles";
 import { translateUiSentence } from "../utils/translateUi";
 import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
 import { badgeStyleFor } from "./dirBadge";
@@ -310,16 +311,49 @@ function insertText(text: string) {
 // Drop a file onto the terminal to insert its absolute path, like a native
 // terminal. Browsers expose the real path only via the drag's file:// URIs
 // (text/uri-list); the File object hides it. Browsers that withhold the path
-// (e.g. Chrome) yield no URIs — instead of silently inserting nothing, point the
-// user at the 📎 file-picker button, which is the path-in-Chrome route.
-function onDrop(e: DragEvent) {
+// (e.g. Chrome) yield no URIs — there we fall back to staging the BYTES server-side
+// and inserting that path instead, so the drop does the same thing either way. Only
+// when both routes come up empty do we point at the 📎 file-picker button.
+async function onDrop(e: DragEvent) {
   dragOver.value = false;
   const dt = e.dataTransfer;
   if (!dt || !dragCarriesFiles(dt.types)) return; // not a file drop — leave text drags alone
   e.preventDefault();
   const text = dropTextFromUriList(dt.getData("text/uri-list") || dt.getData("text/plain"));
-  if (text) insertText(text);
-  else showDropHint();
+  if (text) {
+    insertText(text);
+    return;
+  }
+  // No path from the browser. Stage the files instead — this is the Chrome path.
+  const files = Array.from(dt.files ?? []);
+  if (!files.length) {
+    showDropHint();
+    return;
+  }
+  staging.value = true;
+  try {
+    const staged = await stagedInsertText(files);
+    if (staged) insertText(staged);
+    else showDropHint();
+  } finally {
+    staging.value = false;
+  }
+}
+
+// A pasted screenshot (⌘⌃⇧4 → clipboard) has no file on disk in ANY browser, so the path
+// route can't apply — staging the bytes is the only way it can reach the agent. A text
+// paste is left entirely alone: it must reach xterm natively, which is the common case.
+async function onPaste(e: ClipboardEvent) {
+  const files = filesFromClipboard(e.clipboardData);
+  if (!files.length) return;
+  e.preventDefault();
+  staging.value = true;
+  try {
+    const staged = await stagedInsertText(files);
+    if (staged) insertText(staged);
+  } finally {
+    staging.value = false;
+  }
 }
 
 function onDragOver(e: DragEvent) {
@@ -335,6 +369,9 @@ function onDragOver(e: DragEvent) {
 // fall back to advice that always holds.
 const DROP_HINT_PICKER_EN = "This browser doesn't share a dropped file's path. Use the 📎 button in the header (Insert a file path) instead.";
 const DROP_HINT_TYPE_EN = "This browser doesn't share a dropped file's path — type or paste the path instead.";
+// True while dropped/pasted bytes are being written server-side. A multi-megabyte screenshot
+// takes a beat, and without a sign the terminal looks like it swallowed the drop.
+const staging = ref(false);
 const dropHint = ref(false);
 const dropHintText = ref("");
 const DROP_HINT_MS = 6000;
@@ -417,6 +454,7 @@ onUnmounted(() => {
       @dragover="onDragOver"
       @dragleave="dragOver = false"
       @drop="onDrop"
+      @paste="onPaste"
     />
     <Transition
       enter-active-class="transition-opacity duration-200 ease-[ease]"
@@ -433,6 +471,18 @@ onUnmounted(() => {
         <span>{{ dropHintText }}</span>
       </div>
     </Transition>
+    <!-- Staging can take a beat for a multi-megabyte screenshot; without this the terminal
+         looks like it swallowed the drop. Same placement as the hint, which it never shares
+         the screen with (one is "working", the other "that didn't work"). -->
+    <div
+      v-if="staging"
+      class="pointer-events-none absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2 rounded-lg border border-border bg-elevated px-4 py-2.5 font-sans text-[13px] leading-[1.4] text-fg shadow-[0_4px_16px_rgba(0,0,0,0.45)]"
+      role="status"
+      data-testid="staging-indicator"
+    >
+      <span class="material-symbols-outlined shrink-0 animate-spin text-[18px]" aria-hidden="true">progress_activity</span>
+      <span>Saving file…</span>
+    </div>
   </div>
 </template>
 

--- a/src/composables/useStagedFiles.ts
+++ b/src/composables/useStagedFiles.ts
@@ -1,0 +1,68 @@
+// Turn File objects into paths the agent can read.
+//
+// The terminal's happy path inserts a dropped file's own path (dropPaths.ts). This is the
+// fallback for the two cases where there is no path to insert:
+//
+//   - Chrome withholds `text/uri-list` on a file drop, so the path route yields nothing.
+//   - A pasted screenshot (⌘⌃⇧4) never had a file on disk in the first place.
+//
+// Both still carry the bytes, so we send them to the server, which writes them somewhere real
+// and answers with that path. The terminal inserts it exactly as it would a dropped path — the
+// agent sees no difference.
+
+import { toInsertText } from "../components/dropPaths";
+
+// Mirrors MAX_DROP_BYTES on the server. Checked here too so an oversized file fails instantly
+// instead of after uploading megabytes only to be refused.
+export const MAX_STAGED_BYTES = 25 * 1024 * 1024;
+// One drop can carry a folder's worth of files; past a handful the inserted line is unreadable
+// anyway, and the user is better served by a picker.
+export const MAX_STAGED_FILES = 10;
+
+const readAsDataUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error("could not read the file"));
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.readAsDataURL(file);
+  });
+
+/** Upload one file, resolving to the absolute path the server staged it at, or null on any
+ *  failure. Null rather than a throw: one unreadable file in a multi-file drop shouldn't
+ *  discard the others, and the caller's fallback (the drop hint) is the same either way. */
+export async function stageFile(file: File): Promise<string | null> {
+  if (file.size > MAX_STAGED_BYTES) return null;
+  try {
+    const dataUrl = await readAsDataUrl(file);
+    const res = await fetch("/api/files/dropped", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ dataUrl, name: file.name }),
+    });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    const staged = (body as { path?: unknown })?.path;
+    return typeof staged === "string" && staged ? staged : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Stage every file and return the text to insert (`''` when none survived). Sequential, not
+ *  parallel: these are multi-megabyte bodies, and a folder drop firing ten at once would
+ *  compete with the very sessions the user is watching. */
+export async function stagedInsertText(files: readonly File[]): Promise<string> {
+  const paths: string[] = [];
+  for (const file of files.slice(0, MAX_STAGED_FILES)) {
+    const staged = await stageFile(file);
+    if (staged) paths.push(staged);
+  }
+  return toInsertText(paths);
+}
+
+/** The files carried by a paste. Only the clipboard's file entries — a text paste must fall
+ *  through to xterm untouched, which is the overwhelmingly common case. */
+export function filesFromClipboard(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  return Array.from(data.files ?? []);
+}

--- a/test/server/files/dropped-files.spec.ts
+++ b/test/server/files/dropped-files.spec.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { safeDropName, admitDroppedFile, saveDroppedFile, sweepOldDrops, MAX_DROP_BYTES, MAX_DROP_DATAURL_CHARS, DROP_RETENTION_DAYS } from "../../../server/files/dropped-files.js";
+
+const pngUrl = (payload = "aGVsbG8=") => `data:image/png;base64,${payload}`;
+
+describe("safeDropName", () => {
+  it("keeps an ordinary name", () => {
+    expect(safeDropName("Screenshot-2026.png", "image/png")).toBe("Screenshot-2026.png");
+  });
+
+  // The name is joined onto a directory we chose, so anything structural has to go.
+  it("cannot climb out of the staging directory", () => {
+    expect(safeDropName("../../etc/passwd", "text/plain")).toBe("passwd");
+    expect(safeDropName("/etc/passwd", "text/plain")).toBe("passwd");
+    expect(safeDropName("..\\..\\win.ini", "text/plain")).toBe("win.ini");
+  });
+
+  it("replaces characters that would need quoting in a shell", () => {
+    expect(safeDropName("my file 'v2'.png", "image/png")).toBe("my-file--v2-.png");
+  });
+
+  it("drops a leading dot so the staged file is not hidden", () => {
+    expect(safeDropName(".bashrc", "text/plain")).toBe("bashrc");
+  });
+
+  it("drops a leading dash, which would read as a flag", () => {
+    expect(safeDropName("-rf.png", "image/png")).toBe("rf.png");
+  });
+
+  it("caps the length", () => {
+    expect(safeDropName(`${"a".repeat(200)}.png`, "image/png")).toHaveLength(80);
+  });
+
+  // A pasted screenshot carries no name at all — the type is the only clue we can give.
+  it("synthesizes a name from the mime type when there is none", () => {
+    expect(safeDropName("", "image/png")).toBe("pasted.png");
+    expect(safeDropName(undefined, "image/jpeg")).toBe("pasted.jpg");
+    expect(safeDropName(null, "application/pdf")).toBe("pasted.pdf");
+  });
+
+  it("synthesizes a bare name for a type it has no extension for", () => {
+    expect(safeDropName("", "application/x-thing")).toBe("pasted");
+  });
+});
+
+describe("admitDroppedFile", () => {
+  it("admits a base64 data URL and derives the name", () => {
+    const out = admitDroppedFile(pngUrl(), "shot.png");
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.name).toBe("shot.png");
+      expect(out.parts.mimeType).toBe("image/png");
+    }
+  });
+
+  it("refuses a missing or non-string dataUrl", () => {
+    for (const bad of [undefined, null, "", 42, {}]) {
+      const out = admitDroppedFile(bad, "x.png");
+      expect(out.ok).toBe(false);
+      if (!out.ok) expect(out.status).toBe(400);
+    }
+  });
+
+  it("refuses something that is not a base64 data URL", () => {
+    const out = admitDroppedFile("https://example.com/x.png", "x.png");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.status).toBe(400);
+  });
+
+  // Ordering matters: the raw cap runs BEFORE decoding, so an oversized payload is refused
+  // without first being expanded into memory.
+  it("refuses an oversized payload before decoding it", () => {
+    const out = admitDroppedFile(`data:image/png;base64,${"a".repeat(MAX_DROP_DATAURL_CHARS + 1)}`, "x.png");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.status).toBe(413);
+  });
+
+  it("refuses a payload whose decoded size exceeds the cap", () => {
+    // Under the pre-decode char cap, over the decoded byte cap.
+    const chars = Math.ceil(((MAX_DROP_BYTES + 1024) * 4) / 3);
+    const out = admitDroppedFile(`data:image/png;base64,${"a".repeat(chars)}`, "x.png");
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.status).toBe(413);
+  });
+});
+
+describe("saveDroppedFile / sweepOldDrops", () => {
+  let root: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "mt-drops-"));
+  });
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  const admit = (name: string, payload = "aGVsbG8=") => {
+    const out = admitDroppedFile(pngUrl(payload), name);
+    if (!out.ok) throw new Error("fixture should admit");
+    return out;
+  };
+
+  it("writes the bytes and returns the path", () => {
+    const file = saveDroppedFile(admit("shot.png"), new Date("2026-07-26T10:00:00Z"), root);
+    expect(fs.readFileSync(file, "utf8")).toBe("hello");
+    expect(path.basename(file)).toBe("shot.png");
+    expect(file.startsWith(root)).toBe(true);
+  });
+
+  it("files it under the date, so the sweep can find it later", () => {
+    const file = saveDroppedFile(admit("shot.png"), new Date("2026-07-26T10:00:00Z"), root);
+    expect(path.relative(root, file).split(path.sep)[0]).toBe("2026-07-26");
+  });
+
+  // The name is preserved for the reader; the random parent is what keeps two same-named
+  // screenshots from overwriting each other.
+  it("keeps two identically named files apart", () => {
+    const now = new Date("2026-07-26T10:00:00Z");
+    const a = saveDroppedFile(admit("shot.png", "YQ=="), now, root);
+    const b = saveDroppedFile(admit("shot.png", "Yg=="), now, root);
+    expect(a).not.toBe(b);
+    expect(fs.readFileSync(a, "utf8")).toBe("a");
+    expect(fs.readFileSync(b, "utf8")).toBe("b");
+  });
+
+  it("deletes staged directories past the retention window and keeps the rest", () => {
+    const now = new Date("2026-07-26T10:00:00Z");
+    const old = new Date(now.getTime() - (DROP_RETENTION_DAYS + 2) * 24 * 60 * 60 * 1000);
+    const stale = saveDroppedFile(admit("old.png"), old, root);
+    const fresh = saveDroppedFile(admit("new.png"), now, root);
+    sweepOldDrops(now, root);
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  // Only names this module creates are subject to the rule — anything else a user put there
+  // was never covered by the retention window.
+  it("leaves entries that are not date directories alone", () => {
+    fs.writeFileSync(path.join(root, "notes.txt"), "keep me");
+    fs.mkdirSync(path.join(root, "my-stuff"));
+    sweepOldDrops(new Date("2036-01-01T00:00:00Z"), root);
+    expect(fs.existsSync(path.join(root, "notes.txt"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "my-stuff"))).toBe(true);
+  });
+
+  it("does nothing when nothing has been staged yet", () => {
+    expect(() => sweepOldDrops(new Date(), path.join(root, "absent"))).not.toThrow();
+  });
+});

--- a/test/src/composables/useStagedFiles.spec.ts
+++ b/test/src/composables/useStagedFiles.spec.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { stageFile, stagedInsertText, filesFromClipboard, MAX_STAGED_BYTES, MAX_STAGED_FILES } from "../../../src/composables/useStagedFiles";
+
+// A File stand-in: the composable only reads `size` and `name`, and hands the object to
+// FileReader — which is stubbed below. Avoids needing a DOM for logic that has none.
+const fakeFile = (name: string, size = 10) => ({ name, size }) as unknown as File;
+
+// Minimal FileReader: resolves every read to a fixed data URL, or errors when told to.
+function installFileReader(mode: "ok" | "error" = "ok") {
+  class StubReader {
+    result: string | null = null;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    readAsDataURL() {
+      queueMicrotask(() => {
+        if (mode === "error") this.onerror?.();
+        else {
+          this.result = "data:image/png;base64,aGVsbG8=";
+          this.onload?.();
+        }
+      });
+    }
+  }
+  vi.stubGlobal("FileReader", StubReader);
+}
+
+const okFetch = (staged: string) => vi.fn(async () => ({ ok: true, json: async () => ({ path: staged }) }) as unknown as Response);
+
+describe("stageFile", () => {
+  beforeEach(() => installFileReader());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("returns the path the server staged the bytes at", async () => {
+    vi.stubGlobal("fetch", okFetch("/staged/a.png"));
+    expect(await stageFile(fakeFile("a.png"))).toBe("/staged/a.png");
+  });
+
+  it("posts the file's name alongside the data URL", async () => {
+    const fetchMock = okFetch("/staged/a.png");
+    vi.stubGlobal("fetch", fetchMock);
+    await stageFile(fakeFile("shot.png"));
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.name).toBe("shot.png");
+    expect(body.dataUrl.startsWith("data:image/png;base64,")).toBe(true);
+  });
+
+  // Checked client-side too, so an oversized file fails instantly instead of after uploading
+  // megabytes only to be refused.
+  it("refuses an oversized file without calling the server", async () => {
+    const fetchMock = okFetch("/staged/a.png");
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await stageFile(fakeFile("big.png", MAX_STAGED_BYTES + 1))).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the server refuses", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, json: async () => ({ error: "too big" }) }) as unknown as Response));
+    expect(await stageFile(fakeFile("a.png"))).toBeNull();
+  });
+
+  it("returns null when the request throws", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => { throw new Error("offline"); }));
+    expect(await stageFile(fakeFile("a.png"))).toBeNull();
+  });
+
+  it("returns null when the response has no path", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({}) }) as unknown as Response));
+    expect(await stageFile(fakeFile("a.png"))).toBeNull();
+  });
+
+  it("returns null when the file cannot be read", async () => {
+    installFileReader("error");
+    vi.stubGlobal("fetch", okFetch("/staged/a.png"));
+    expect(await stageFile(fakeFile("a.png"))).toBeNull();
+  });
+});
+
+describe("stagedInsertText", () => {
+  beforeEach(() => installFileReader());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("joins the staged paths into insertable text", async () => {
+    let n = 0;
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({ path: `/staged/${++n}.png` }) }) as unknown as Response));
+    expect(await stagedInsertText([fakeFile("a.png"), fakeFile("b.png")])).toBe("/staged/1.png /staged/2.png");
+  });
+
+  it("quotes a staged path that needs it", async () => {
+    vi.stubGlobal("fetch", okFetch("/staged/my file.png"));
+    expect(await stagedInsertText([fakeFile("a.png")])).toBe("'/staged/my file.png'");
+  });
+
+  // One unreadable file in a multi-file drop shouldn't discard the others.
+  it("keeps the files that succeeded when one fails", async () => {
+    let n = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        n++;
+        return (n === 1 ? { ok: false, json: async () => ({}) } : { ok: true, json: async () => ({ path: "/staged/b.png" }) }) as unknown as Response;
+      }),
+    );
+    expect(await stagedInsertText([fakeFile("a.png"), fakeFile("b.png")])).toBe("/staged/b.png");
+  });
+
+  it("returns an empty string when nothing survived", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, json: async () => ({}) }) as unknown as Response));
+    expect(await stagedInsertText([fakeFile("a.png")])).toBe("");
+  });
+
+  it("caps how many files one drop stages", async () => {
+    const fetchMock = okFetch("/staged/a.png");
+    vi.stubGlobal("fetch", fetchMock);
+    const many = Array.from({ length: MAX_STAGED_FILES + 5 }, (_, i) => fakeFile(`f${i}.png`));
+    await stagedInsertText(many);
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_STAGED_FILES);
+  });
+
+  it("does nothing for an empty list", async () => {
+    const fetchMock = okFetch("/staged/a.png");
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await stagedInsertText([])).toBe("");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("filesFromClipboard", () => {
+  it("returns the clipboard's files", () => {
+    const a = fakeFile("a.png");
+    expect(filesFromClipboard({ files: [a] } as unknown as DataTransfer)).toEqual([a]);
+  });
+
+  // A text paste has to fall through to xterm untouched — that is the common case, and
+  // intercepting it would break ordinary pasting.
+  it("returns nothing for a text-only paste", () => {
+    expect(filesFromClipboard({ files: [] } as unknown as DataTransfer)).toEqual([]);
+    expect(filesFromClipboard(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
> #262 で提案され、開発リポジトリ側（yuki0627/kanban-terminal#36）で OPEN のままの機能です。**もし着手済みでしたら遠慮なく閉じてください。** 手元で必要になり実装したので、お役に立つならと思い出しています。

## 課題

ファイルのドロップは絶対パスを挿入します（エージェント自身が読むので、パスこそが要る情報です）。ただしパスは drag の `text/uri-list` からしか取れず、**取れない場面が2つ**あります。

- **Chrome は `text/uri-list` を渡しません。** 多くの人が使うブラウザで、スクショを落としても「📎 を使ってください」というヒントが出るだけです。
- **貼り付けたスクショ**（macOS ⌘⌃⇧4）は、どのブラウザでもディスク上にファイルがありません。指せるパスが存在しません。

## 変更

どちらもバイト列は持っています。`POST /api/files/dropped` が実体を書き出し、そのパスを返し、ターミナルはドロップされたパスと同じように挿入します。**エージェント側に新しい概念は増えません** — 従来どおりファイルを読むだけです。

保存先は `~/.mulmoterminal/drops/<日付>/<乱数>/<元の名前>`：

- **セッションの作業ディレクトリには置きません。** リポジトリで作業中に落としたスクショが、未追跡ファイルとして diff に出てはいけないためです。
- 元の名前を残します（中身を示す唯一の手がかりであることが多いため）。一意性は乱数の親ディレクトリが担保します。
- 7日で掃除します。

上限は 1ファイル 25 MiB（クライアント側でも検査するので、大きすぎるファイルはアップロード前に落ちます）、1回 10ファイル。data URL の長さ検査は**復号より前**に行います — `audioAdmission.ts` が明文化している順序に合わせ、巨大な入力をメモリに展開せずに弾きます。

**テキストの貼り付けには一切触れません。** 従来どおり xterm がそのまま処理します。

## テスト

34件（サーバー19・クライアント15）。ファイル名のパストラバーサル（`../../etc/passwd` → `passwd`）、先頭のドット/ハイフン、スクショ用の名前の合成、両方のサイズ上限、保持期間の掃除（日付ディレクトリ以外は触らないこと）、複数ファイル中1つが失敗しても他が残ること、テキストのみの貼り付けが素通りすること、を含みます。
