### PR TITLE
feat(cockpit): ロスター各行の表示行数を設定可能にする

### DIFF
--- a/common/cockpitLines.ts
+++ b/common/cockpitLines.ts
@@ -1,0 +1,48 @@
+// How many lines each row of the cockpit roster (the list beside a zoomed terminal) shows before
+// it clamps. The roster trades two things against each other: how many sessions fit on screen,
+// and how much of each one you can actually read. 2/2/3 is the tight end — it fits a long roster,
+// but a summary written as a full sentence is cut mid-thought, which is exactly when you wanted
+// to read it. One knob per field, because the three are worth different amounts: a summary says
+// what a session is doing NOW, while the prompt is usually short enough at two lines.
+//
+// Shared across the build boundary: the server sanitizes and serves it, the grid renders from it.
+
+export interface CockpitLines {
+  summary: number;
+  prompt: number;
+  response: number;
+}
+
+export const DEFAULT_COCKPIT_LINES: CockpitLines = { summary: 2, prompt: 2, response: 3 };
+
+// 1 is "one line, still clamped"; past ~20 a single row fills the column and the roster stops
+// being a roster. Anything outside, or not a whole number, falls back to that field's default.
+export const COCKPIT_LINES_MIN = 1;
+export const COCKPIT_LINES_MAX = 20;
+
+const oneField = (input: unknown, fallback: number): number => {
+  if (typeof input !== "number" || !Number.isFinite(input)) return fallback;
+  const whole = Math.floor(input);
+  if (whole < COCKPIT_LINES_MIN || whole > COCKPIT_LINES_MAX) return fallback;
+  return whole;
+};
+
+/** Per field, so one bad number can't discard the other two the user set correctly. */
+export function sanitizeCockpitLines(input: unknown): CockpitLines {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) return DEFAULT_COCKPIT_LINES;
+  const o = input as Record<string, unknown>;
+  return {
+    summary: oneField(o.summary, DEFAULT_COCKPIT_LINES.summary),
+    prompt: oneField(o.prompt, DEFAULT_COCKPIT_LINES.prompt),
+    response: oneField(o.response, DEFAULT_COCKPIT_LINES.response),
+  };
+}
+
+/** The inline style that clamps to `lines`. Inline rather than Tailwind's `line-clamp-N`: the
+ *  count is a runtime value, and those classes only exist for the literals in the source. */
+export const clampStyle = (lines: number): Record<string, string> => ({
+  display: "-webkit-box",
+  "-webkit-box-orient": "vertical",
+  "-webkit-line-clamp": String(lines),
+  overflow: "hidden",
+});

--- a/server/config/app-config.ts
+++ b/server/config/app-config.ts
@@ -22,6 +22,7 @@ import { DEFAULT_TERMINAL_SUBMIT_MODE, isTerminalSubmitMode, type TerminalSubmit
 import type { QuickCommand } from "../../common/quickCommands.js";
 import { DEFAULT_PUSH_KINDS, PUSH_KINDS, type PushKind } from "../../common/pushKinds.js";
 import { sanitizeKeymap, type Keymap } from "../../common/keymap.js";
+import { sanitizeCockpitLines, DEFAULT_COCKPIT_LINES, type CockpitLines } from "../../common/cockpitLines.js";
 import { readTextFile } from "../infra/read-text-file.js";
 import { writeFileAtomicSync } from "../files/atomic-write.js";
 
@@ -66,6 +67,9 @@ export interface AppConfig {
   // User-defined keyboard shortcuts (#829). NO defaults: an empty map means the shortcuts
   // are off, because every binding takes that key away from the terminal underneath.
   keymap: Keymap;
+  // How many lines each cockpit-roster row shows before clamping. Defaults keep the previous
+  // 2/2/3; raising `summary` trades roster length for reading a long one without opening the cell.
+  cockpitLines: CockpitLines;
 }
 
 // `id` becomes an MCP server name + `mcp__<id>` tool prefix, so restrict to a plain
@@ -216,6 +220,7 @@ export const emptyConfig = (): AppConfig => ({
   chips: null,
   pushEnabled: false,
   pushKinds: [...DEFAULT_PUSH_KINDS],
+  cockpitLines: DEFAULT_COCKPIT_LINES,
   worklogEnabled: false,
   worklogIntervalHours: DEFAULT_WORKLOG_INTERVAL_HOURS,
   providers: [],
@@ -249,6 +254,7 @@ function sanitizeAppConfig(raw: unknown): AppConfig {
     chips: sanitizeChips(o.chips),
     pushEnabled: sanitizePushEnabled(o.pushEnabled),
     pushKinds: sanitizePushKinds(o.pushKinds),
+    cockpitLines: sanitizeCockpitLines(o.cockpitLines),
     worklogEnabled: sanitizeWorklogEnabled(o.worklogEnabled),
     worklogIntervalHours: sanitizeWorklogIntervalHours(o.worklogIntervalHours),
     providers: sanitizeProviders(o.providers),

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -355,6 +355,23 @@ button only type the text without submitting it.
 - Takes effect after a **tab reload** (keyboard) and a **server restart** (phone remote view).
 - Partial `POST /api/config` merge — write only `terminalSubmit`.
 
+## Cockpit roster line counts — `cockpitLines` in `~/.mulmoterminal/config.json`
+
+The roster beside a zoomed terminal shows three lines per session — **summary** (what it's doing
+now), **prompt**, **reply** — each clamped so a long roster still fits. The clamp is a trade: more
+lines each means fewer sessions on screen. Defaults are `2 / 2 / 3`, unchanged from before the
+setting existed.
+
+```json
+{ "cockpitLines": { "summary": 6, "prompt": 2, "response": 3 } }
+```
+
+- Each field is a whole number in **1–20**. Out of range, fractional, or non-numeric falls back to
+  that field's default — **per field**, so one typo doesn't discard the others.
+- Hovering a line shows the full text regardless, so raising the clamp is a convenience.
+- This is a **global** setting (`~/.mulmoterminal/config.json`), not per-directory: the roster
+  mixes sessions from every directory, so a per-directory value would make rows disagree.
+
 ## Dev-work log — `worklogEnabled` / `worklogIntervalHours`
 
 A built-in scheduled task, **off by default**. When on, it fires every `worklogIntervalHours` and

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -7,6 +7,8 @@ import CockpitRowMenu from "./CockpitRowMenu.vue";
 import CockpitHeader from "./CockpitHeader.vue";
 import * as conn from "../composables/useTerminalConnections";
 import { trackStyle, layoutForCount } from "./gridLayout";
+import { clampStyle } from "../../common/cockpitLines";
+import { useCockpitLines } from "../composables/cockpitLines";
 import { flipKeyframes, flipPairs, onScreen, FLIP_MS, FLIP_EASING } from "./cellFlip";
 import { canMoveCell, type Cell, type CellStatus } from "./gridTabs";
 import type { RunCommand } from "./runCommand";
@@ -68,6 +70,11 @@ const emit = defineEmits<{
 }>();
 
 const gridStyle = computed(() => trackStyle(layoutForCount(props.cells.length)));
+
+// How far each roster line clamps (config.json `cockpitLines`; 2/2/3 by default). A `title` on
+// each line carries the rest, so raising the clamp is a convenience rather than the only way to
+// read a long summary.
+const cockpitLines = useCockpitLines();
 
 // The keyboard-focused cell, so it can lift + zoom slightly in place. `focusin` bubbles from the
 // xterm textarea up to the grid, so one delegated listener suffices. It's sticky: focus moving to
@@ -239,13 +246,13 @@ watch(
             @move="(dir) => emit('move', row.uid, dir)"
           />
         </CockpitHeader>
-        <span v-if="row.summary" data-testid="cockpit-line" class="line-clamp-2 overflow-hidden text-[12px] leading-[1.35]"
+        <span v-if="row.summary" data-testid="cockpit-line" class="text-[12px] leading-[1.35]" :style="clampStyle(cockpitLines.summary)" :title="row.summary"
           ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">summary</b> {{ row.summary }}</span
         >
-        <span data-testid="cockpit-line" class="line-clamp-2 overflow-hidden text-[12px] leading-[1.35]"
+        <span data-testid="cockpit-line" class="text-[12px] leading-[1.35]" :style="clampStyle(cockpitLines.prompt)" :title="row.prompt || row.fallback || ''"
           ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">prompt</b> {{ row.prompt || row.fallback || "—" }}</span
         >
-        <span v-if="row.response" data-testid="cockpit-line" class="line-clamp-3 overflow-hidden text-[12px] leading-[1.35] text-dim"
+        <span v-if="row.response" data-testid="cockpit-line" class="text-[12px] leading-[1.35] text-dim" :style="clampStyle(cockpitLines.response)" :title="row.response"
           ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">reply</b> {{ row.response }}</span
         >
       </div>

--- a/src/composables/cockpitLines.ts
+++ b/src/composables/cockpitLines.ts
@@ -1,0 +1,14 @@
+import { ref } from "vue";
+import { DEFAULT_COCKPIT_LINES, type CockpitLines } from "../../common/cockpitLines";
+
+// The active cockpit clamp, hydrated once from /api/config. A SINGLETON ref for the same reason
+// the other config values are: the settings load happens in useAppConfig, while the roster that
+// renders from it lives in TerminalGrid — a per-caller ref would leave the grid on the defaults.
+// A ref rather than a plain value (unlike terminalSubmitMode): this one is read from a template,
+// so it has to re-render when the config arrives.
+const cockpitLines = ref<CockpitLines>(DEFAULT_COCKPIT_LINES);
+
+export const useCockpitLines = () => cockpitLines;
+export const setCockpitLines = (lines: CockpitLines): void => {
+  cockpitLines.value = lines;
+};

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -7,6 +7,8 @@ import type { PushKind } from "../../common/pushKinds";
 import { DEFAULT_TERMINAL_SUBMIT_MODE, isTerminalSubmitMode } from "../../common/terminalSubmit";
 import { setTerminalSubmitMode } from "./terminalSubmitMode";
 import { setActiveKeymap } from "./activeKeymap";
+import { setCockpitLines } from "./cockpitLines";
+import { sanitizeCockpitLines } from "../../common/cockpitLines";
 
 // The custom attention-sound file is a SINGLETON ref shared across every
 // useAppConfig() caller — the beep player lives in the single view while the
@@ -249,6 +251,8 @@ export function useAppConfig() {
       // Keyboard shortcuts are opt-in: no `keymap` in config.json leaves this empty and
       // every shortcut stays off.
       setActiveKeymap(c.keymap);
+      // How far the cockpit roster clamps each line (config.json-only; unset keeps 2/2/3).
+      setCockpitLines(sanitizeCockpitLines(c.cockpitLines));
       await migrateLegacyRecents();
     } catch {
       // the app still works; presets are just unavailable

--- a/test/common/cockpitLines.spec.ts
+++ b/test/common/cockpitLines.spec.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { sanitizeCockpitLines, clampStyle, DEFAULT_COCKPIT_LINES, COCKPIT_LINES_MIN, COCKPIT_LINES_MAX } from "../../common/cockpitLines";
+
+describe("sanitizeCockpitLines", () => {
+  it("keeps whole numbers inside the range", () => {
+    expect(sanitizeCockpitLines({ summary: 8, prompt: 1, response: 20 })).toEqual({ summary: 8, prompt: 1, response: 20 });
+  });
+
+  it("falls back to 2/2/3 when nothing is configured", () => {
+    expect(sanitizeCockpitLines(undefined)).toEqual(DEFAULT_COCKPIT_LINES);
+    expect(sanitizeCockpitLines({})).toEqual(DEFAULT_COCKPIT_LINES);
+  });
+
+  it("rejects a non-object, so a stray string can't blank the roster", () => {
+    for (const bad of ["8", 8, null, [], [8]]) expect(sanitizeCockpitLines(bad)).toEqual(DEFAULT_COCKPIT_LINES);
+  });
+
+  // Per field: one typo shouldn't discard the two the user set correctly.
+  it("falls back only for the bad field", () => {
+    expect(sanitizeCockpitLines({ summary: 6, prompt: "x", response: 0 })).toEqual({
+      summary: 6,
+      prompt: DEFAULT_COCKPIT_LINES.prompt,
+      response: DEFAULT_COCKPIT_LINES.response,
+    });
+  });
+
+  it("rejects out-of-range values at both ends", () => {
+    const out = sanitizeCockpitLines({ summary: COCKPIT_LINES_MIN - 1, prompt: COCKPIT_LINES_MAX + 1, response: -5 });
+    expect(out).toEqual(DEFAULT_COCKPIT_LINES);
+  });
+
+  it("rejects NaN and Infinity rather than rendering them", () => {
+    expect(sanitizeCockpitLines({ summary: Number.NaN, prompt: Number.POSITIVE_INFINITY })).toEqual(DEFAULT_COCKPIT_LINES);
+  });
+
+  it("floors a fractional count", () => {
+    expect(sanitizeCockpitLines({ summary: 4.9 }).summary).toBe(4);
+  });
+});
+
+describe("clampStyle", () => {
+  it("clamps to the given number of lines", () => {
+    expect(clampStyle(5)).toEqual({
+      display: "-webkit-box",
+      "-webkit-box-orient": "vertical",
+      "-webkit-line-clamp": "5",
+      overflow: "hidden",
+    });
+  });
+
+  // The count is a runtime value, so Tailwind's line-clamp-N (which only exists for literals
+  // present in the source) can't express it — the style has to carry the number as a string.
+  it("renders the count as a string, which is what the DOM style property needs", () => {
+    expect(clampStyle(12)["-webkit-line-clamp"]).toBe("12");
+  });
+});


### PR DESCRIPTION
## 課題

ロスターは summary / prompt / reply を 2 / 2 / 3 行で打ち切ります。文章として書かれた summary は途中で切れますが、**まさにその summary こそ読みたい場面**が多くあります。

一方で行数を増やせば画面に載るセッション数は減ります。つまりこれは「直すべき不具合」ではなく、**使う人が決めるトレードオフ**だと考えました。

## 変更

`~/.mulmoterminal/config.json` に `cockpitLines` を追加します。

```json
{ "cockpitLines": { "summary": 6, "prompt": 2, "response": 3 } }
```

- 既定は **2 / 2 / 3** のまま。未設定なら**現在とまったく同じ挙動**です。
- 各項目 1〜20 の整数。範囲外・小数・非数値は**項目ごとに**既定へ戻すので、1つの書き間違いが他の2つを巻き添えにしません。
- 各行に `title` を付けたので、打ち切られていてもホバーで全文が読めます。
- ディレクトリ単位ではなく**全体設定**にしました。ロスターは複数のディレクトリのセッションを混ぜて並べるため、ディレクトリ単位だと行ごとに高さの根拠が食い違います。

設定 UI は持たせていません（`keymap` や `terminalSubmit` と同じく config.json のみ）。必要でしたら追加します。

## テスト

9件。sanitizer の各分岐と、clamp のスタイル生成。
