### PR TITLE
feat: configurable terminal font size, globally and per directory (#860)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The Settings modal (⚙) persists per-user UI choices to `~/.mulmoterminal/confi
 
 ![The Settings modal — theme, notification sound, PR repos, launch commands, and MCP servers](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/settings.png)
 
-*Open it from the ⚙ button in the toolbar. Pick a **theme**, set a custom **attention sound**, list the repos the cross-repo **PRs & Issues** view should aggregate, add **launch commands** for grid cells, and register your own **MCP servers** — no need to hand-edit the config file.*
+*Open it from the ⚙ button in the toolbar. Pick a **theme**, set the **terminal font size**, set a custom **attention sound**, list the repos the cross-repo **PRs & Issues** view should aggregate, add **launch commands** for grid cells, and register your own **MCP servers** — no need to hand-edit the config file.*
 
 | Field        | Meaning |
 | ------------ | ------- |
@@ -527,6 +527,7 @@ malformed file is ignored.
   "buttonColor": "#c7cdf0",             // header icon buttons (hex #rrggbb)
   "theme": "nord",                      // terminal palette: midnight | nord | daylight | solarized
   "colors": { "background": "#190a23", "cursor": "#ff2e63" }, // per-key palette overrides
+  "fontSize": 16,                       // terminal font size in px (8–32); overrides Settings
   "sound": "./.mulmoterminal/alert.mp3" // attention sound, RELATIVE to this directory
 }
 ```
@@ -547,6 +548,7 @@ malformed file is ignored.
 | `buttonColor` | Header **icon button** color (`#rrggbb`) — expand / close / attach / folder / etc., across both header rows. |
 | `theme`      | xterm palette for terminals in this directory (one of the built-in theme ids). |
 | `colors`     | Per-key xterm palette overrides applied on top of `theme` (or the app theme when `theme` is unset). Keys are xterm `ITheme` names (`background`, `foreground`, `cursor`, `selectionBackground`, the 16 ANSI colors, …); values are hex (`#rgb` / `#rrggbb` / `#rrggbbaa`). Unknown keys / bad values are dropped. |
+| `fontSize`   | Terminal font size in px for this directory (8–32), overriding the Settings value. A size outside the range is clamped; a non-number is ignored. Changing it re-fits the terminal, so the PTY learns the new width — unlike browser zoom, which leaves the two disagreeing. |
 | `sound`      | Attention sound for this directory's sessions, a path **relative to the directory** (served at `GET /api/dir-sound`). |
 
 **Security.** `sound` is a directory-relative path only — absolute paths and any

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The Settings modal (⚙) persists per-user UI choices to `~/.mulmoterminal/confi
 
 ![The Settings modal — theme, notification sound, PR repos, launch commands, and MCP servers](https://raw.githubusercontent.com/receptron/mulmoterminal/main/docs/guide/images/settings.png)
 
-*Open it from the ⚙ button in the toolbar. Pick a **theme**, set the **terminal font size**, set a custom **attention sound**, list the repos the cross-repo **PRs & Issues** view should aggregate, add **launch commands** for grid cells, and register your own **MCP servers** — no need to hand-edit the config file.*
+*Open it from the ⚙ button in the toolbar. Pick a **theme**, set the **terminal font size**, set a custom **attention sound**, list the repos the cross-repo **PRs & Issues** view should aggregate, add **launch commands** for grid cells, and register your own **MCP servers** — no need to hand-edit the config file. Note that **theme and font size are stored per browser** (they're display preferences, so a phone and a desktop keep their own); the rest live in `~/.mulmoterminal/config.json` and are shared by every client.*
 
 | Field        | Meaning |
 | ------------ | ------- |

--- a/common/dirChrome.ts
+++ b/common/dirChrome.ts
@@ -1,4 +1,4 @@
-// The name + fixed-color fields a `.mulmoterminal.json` may set. Shared across the
+// The `.mulmoterminal.json` fields whose type is the SAME on both sides. Shared across the
 // build boundary: the server's DirConfig/PublicDirConfig and the client's DirConfig
 // all extend this, so a field added on one side can't go missing on the other.
 // `theme` and `colors` stay out of it — each side declares them with its own type
@@ -17,6 +17,10 @@ export interface DirChrome {
   cellBorderColor: string | null;
   dotColor: string | null;
   buttonColor: string | null;
+  // xterm font size in px for terminals opened here, or null to use the global setting.
+  // Unlike the colors above, this changes the cell metrics — every path that applies it has
+  // to re-fit and push the new cols/rows to the PTY, or the grid drifts from the canvas.
+  fontSize: number | null;
 }
 
 // "Nothing configured" — the base every DirConfig/PublicDirConfig empty spreads, so adding
@@ -32,4 +36,5 @@ export const EMPTY_DIR_CHROME: Readonly<DirChrome> = {
   cellBorderColor: null,
   dotColor: null,
   buttonColor: null,
+  fontSize: null,
 };

--- a/common/terminalFontSize.ts
+++ b/common/terminalFontSize.ts
@@ -1,0 +1,20 @@
+// The xterm font size, in px. Shared because all three sides decide from the same numbers:
+// the server validates `.mulmoterminal.json`, the Settings stepper bounds its own buttons, and
+// the client validates what it reads back out of localStorage.
+export const TERMINAL_FONT_SIZE_DEFAULT = 14;
+// Below ~8px the canvas renderer's glyphs stop being legible; above ~32px a grid cell holds so
+// few columns that Claude's output wraps into noise. Neither is a hard xterm limit — they bound
+// the stepper and reject a value that would leave the terminal unusable.
+export const TERMINAL_FONT_SIZE_MIN = 8;
+export const TERMINAL_FONT_SIZE_MAX = 32;
+export const TERMINAL_FONT_SIZE_STEP = 1;
+
+// Clamp rather than reject an out-of-range number: for a size, honouring the direction the user
+// asked for reads as working, where falling back to the default reads as ignored. Non-numeric
+// input is a different thing — "nothing configured here" — so it stays null and lets the caller
+// fall back. Fractional sizes round: xterm accepts them, but they make cell metrics drift from
+// the integer the UI shows.
+export function normalizeFontSize(input: unknown): number | null {
+  if (typeof input !== "number" || !Number.isFinite(input)) return null;
+  return Math.min(TERMINAL_FONT_SIZE_MAX, Math.max(TERMINAL_FONT_SIZE_MIN, Math.round(input)));
+}

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -37,6 +37,7 @@ Open it from the ⚙ in the toolbar.
 | Item | Description |
 |---|---|
 | **THEME** | Midnight / Nord / Daylight / Solarized Light |
+| **TERMINAL FONT SIZE** | The xterm font size in px (8–32). Applies to every terminal **in this browser** — a phone and a desktop each keep their own. A directory can override it with `fontSize` ([below](#per-dir)) |
 | **DIRECTORY APPEARANCE** | "🎨 Configure appearance…" — set a directory's name badge, colors, and header interactively |
 | **NOTIFICATION SOUND** | The sound played when a cell needs you (empty for the built-in chime, or any audio file) |
 | **WEB PUSH NOTIFICATIONS** | The "Notify my devices when a task finishes" toggle (off by default → [Mobile notifications](notifications.html)) |
@@ -399,6 +400,22 @@ itself (xterm)**. `colors` overrides xterm's ITheme — `background` / `foregrou
 Set `theme` to `midnight` / `nord` / `daylight` / `solarized` for a preset palette; `colors` layers per-key
 overrides on top. The color-coding screenshot in [Scenario 6](scenarios.html) combines header colors with `colors` to
 paint each project — **from the header down to the terminal body**.
+
+### Terminal font size (`fontSize`)
+
+`fontSize` sets the px size of the terminal font for this directory, overriding the Settings value:
+
+```json
+{ "fontSize": 16 }
+```
+
+Valid range is **8–32**. A size outside it is clamped to the nearest end (so `99` becomes 32 rather than
+being ignored); a non-number is ignored and the Settings value applies.
+
+Use this rather than the browser's zoom (Ctrl +/−). Zoom scales the page without telling the terminal, so
+xterm's character grid stops matching what the shell believes the window to be, and the cursor and line
+wraps drift. Setting `fontSize` re-fits the terminal and sends the new width/height to the process, so
+everything stays aligned.
 
 ### Customizing the header (buttons / chips) {#header}
 

--- a/docs/guide/en/features.md
+++ b/docs/guide/en/features.md
@@ -70,6 +70,7 @@ MulmoTerminal's features, organized by the **four pillars** (Supervise / See / A
 | Name badge / colors | Per-directory name and per-element colors in `.mulmoterminal.json` |
 | Launchers / cwd presets / PR repos | Extend launch commands, working-directory suggestions, and cross-repo PR targets in settings |
 | Themes | Midnight / Nord / Daylight / Solarized Light |
+| Terminal font size | Adjustable in settings (per browser), or pinned per directory with `fontSize` in `.mulmoterminal.json` |
 
 > **Do nothing and it works as before** — buttons/chips/colors only take effect for what you add, and the default look is unchanged.
 > For details, see [Configuration](config.html).

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -37,6 +37,7 @@ nav_order: 4
 | 項目 | 内容 |
 |---|---|
 | **THEME** | Midnight / Nord / Daylight / Solarized Light |
+| **TERMINAL FONT SIZE** | ターミナル（xterm）のフォントサイズ（px, 8〜32）。**このブラウザ**の全ターミナルに適用され、スマホと PC でそれぞれ別の値を保持します。ディレクトリ側の `fontSize`（[後述](#per-dir)）が優先されます |
 | **DIRECTORY APPEARANCE** | 「🎨 Configure appearance…」— ディレクトリの名前バッジ・色・ヘッダーを対話的に設定 |
 | **NOTIFICATION SOUND** | 要対応時に鳴らす音（空なら内蔵チャイム、または任意の音声ファイル） |
 | **WEB PUSH NOTIFICATIONS** | 「Notify my devices when a task finishes」トグル（既定 OFF → [スマホ通知](notifications.html)） |
@@ -393,6 +394,21 @@ Anthropic のまま別のモデルを指定できます。→ [OpenRouter で別
 
 `theme` に `midnight` / `nord` / `daylight` / `solarized` を指定するとプリセットのパレットになり、`colors` はその上へ部分上書き。
 [応用編 6](scenarios.html) の色分けスクショは、ヘッダー色と `colors` を組み合わせて**ヘッダーから端末の中身まで**プロジェクトごとに染めた例です。
+
+### ターミナルのフォントサイズ（`fontSize`）
+
+`fontSize` はこのディレクトリのターミナルのフォントサイズ（px）で、設定モーダルの値を上書きします。
+
+```json
+{ "fontSize": 16 }
+```
+
+有効範囲は **8〜32**。範囲外の値は近い端に丸められます（`99` は無視されず 32 になります）。数値でない値は無視され、
+設定モーダルの値が使われます。
+
+ブラウザのズーム（Ctrl +/−）ではなくこちらを使ってください。ズームはターミナルに知らせずページを拡大するため、
+xterm の文字グリッドとシェルが認識しているウィンドウサイズがずれ、カーソル位置や折り返し位置が崩れます。
+`fontSize` はターミナルを再フィットして新しい桁数・行数をプロセスに送るので、ずれが起きません。
 
 ### ヘッダーのカスタマイズ（ボタン / チップ） {#header}
 

--- a/docs/guide/ja/features.md
+++ b/docs/guide/ja/features.md
@@ -70,6 +70,7 @@ MulmoTerminal の機能を **4 本柱**（監督 / 可視化 / 自動化・調�
 | 名前バッジ / 色 | `.mulmoterminal.json` でディレクトリごとに名前・各所の色 |
 | ランチャ / cwd presets / PR repos | 設定で起動コマンド・作業ディレクトリ候補・横断 PR 対象を拡張 |
 | テーマ | Midnight / Nord / Daylight / Solarized Light |
+| ターミナルのフォントサイズ | 設定モーダルで調整（ブラウザごと）、または `.mulmoterminal.json` の `fontSize` でディレクトリごとに固定 |
 
 > **設定なしなら従来どおり**——ボタン/チップ/色は足したぶんだけ効き、既定の見た目は変わりません。
 > 詳細は[設定方法](config.html)へ。

--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -52,6 +52,16 @@ server   ── node-pty  ── tmux (persistence)  ── agent (claude / code
 - `linkHandler` (#783/#785) — opens OSC 8 hyperlinks (e.g. Claude's statusline `PR #123`) on
   click, restricted to `http(s)://` (a program could emit a `javascript:` link). Without it xterm
   falls back to a `confirm()` dialog. **Necessary but not sufficient** — see the tmux rule.
+- `fontSize` (#860) — no longer a constant. Resolved per terminal as **dir pin
+  (`.mulmoterminal.json` `fontSize`) → app-wide Settings value (`localStorage.terminalFontSize`) →
+  `TERMINAL_FONT_SIZE_DEFAULT`**, and clamped to 8–32 by `normalizeFontSize`
+  (`common/terminalFontSize.ts`), which both sides share.
+  **Anything that changes it MUST re-fit.** The size changes the cell metrics, so `cols`/`rows`
+  change and the PTY has to be told — `setFontSize()` therefore calls `fitAndSyncSize()`, and
+  `attach()` applies a changed size *before* its own fit. Setting the option alone reproduces the
+  bug that made browser zoom useless as a workaround in #860: xterm's grid and the PTY disagree,
+  so the cursor and the wrap points drift. `Conn.fontSize` remembers the applied value so a
+  rebuilt terminal (#846) doesn't snap back to the default.
 
 ### Submit vs newline — `terminalSubmit` (#772/#780)
 

--- a/plans/feat-860-terminal-font-size.md
+++ b/plans/feat-860-terminal-font-size.md
@@ -1,0 +1,91 @@
+# Configurable terminal font size
+
+Issue: #860
+
+## The ask
+
+`fontSize: 14` is hardcoded in the xterm constructor (`src/composables/useTerminalConnections.ts`),
+and neither `~/.mulmoterminal/config.json` nor `<dir>/.mulmoterminal.json` has a key for it. Browser
+zoom is not a workaround — it desynchronises xterm's cell grid from the canvas, so the cursor and the
+wrap points drift.
+
+Requested shape, in the user's words: **"like color, a global setting and a per-repository setting.
+If per-repository is hard, global only for now."**
+
+Per-repository is *not* hard — the `.mulmoterminal.json` plumbing already runs end to end for
+`theme`/`colors`, so `fontSize` rides the same route. Both are in scope.
+
+## Following the color precedent
+
+`theme` is the model to copy, so it is worth writing down what it actually does:
+
+| | Global | Per-repo |
+|---|---|---|
+| storage | `localStorage["theme"]` | `.mulmoterminal.json` → `theme` / `colors` |
+| authored via | Settings modal swatch picker | editing the JSON |
+| server side | *none* — never touches `AppConfig` | `dir-config.ts` → `PublicDirConfig` |
+| client side | `useTheme()` → `currentTermTheme()` | `useDirConfig()` → props |
+| precedence | fallback | wins (`Terminal.vue:166`) |
+| live update | `watch([themeId, dirTheme, dirColors])` → `conn.setTheme` | same watcher |
+
+So "global" here means **Settings UI + localStorage, not `config.json`** — confirmed with the user,
+who chose it over the `config.json` wording in the issue body. That also happens to be the better fit
+for a font size: localStorage is per-browser, so a phone and a desktop can each hold their own size,
+which one shared `config.json` value could not express.
+
+## The one thing color does not have to do
+
+Changing the palette does not move anything. Changing the font size changes the **cell metrics**, so
+`cols`/`rows` change and the PTY has to be told. Setting `term.options.fontSize` alone reproduces
+exactly the bug the issue reports about browser zoom — a canvas whose cell grid disagrees with the
+PTY's idea of the window, i.e. drifting cursor and wrap points.
+
+Every path that changes the size therefore has to re-fit and push the new size:
+`term.options.fontSize = n` → `fitAndSyncSize(c)` (which already runs `fitAddon.fit()` and sends the
+resize). This is the load-bearing part of the change; the rest is plumbing.
+
+## Shape
+
+Shared constants + the clamp live in `common/` because **all three** sides decide from them (server
+validation, the Settings UI's bounds, the client's localStorage read). Per the repo's own rule, a
+value both sides use belongs in `common/`, never mirrored.
+
+- **`common/terminalFontSize.ts`** (new) — `TERMINAL_FONT_SIZE_DEFAULT = 14`, `_MIN = 8`, `_MAX = 32`,
+  and `normalizeFontSize(input: unknown): number | null` (round, clamp to range, null for anything
+  non-numeric). A pure function in its own file, so it is directly testable.
+- **`common/dirChrome.ts`** — add `fontSize: number | null` to `DirChrome` + `EMPTY_DIR_CHROME`.
+  That interface exists precisely for fields whose type is identical on both sides (`theme`/`colors`
+  are excluded only because each side types them differently, which does not apply to a number), and
+  all three `DirConfig`s extend it — so adding it here makes it impossible for one side to omit it.
+- **`server/config/config-schema.ts`** — `dirFontSizeField` (lenient: clamp, null on garbage) and
+  `fontSize` in `writableDirConfigSchema` (strict `int().min().max()`, so the generated
+  `dir-config.schema.json` tells an editor the real range at authoring time).
+- **`server/config/dir-config.ts`** — parse it in `loadDirConfig`, pass it through `publicDirConfig`.
+- **`src/composables/useDirConfig.ts`** — parse it off the wire.
+- **`src/composables/useTerminalFontSize.ts`** (new) — mirrors `useTheme`: a module-level `ref`,
+  `localStorage["terminalFontSize"]`, validated through `normalizeFontSize` on read.
+- **`src/composables/useTerminalConnections.ts`** — `buildTerminal` takes the size; `Conn` remembers
+  it (so a rebuilt terminal keeps it, like `c.theme` at line 316); new `setFontSize(key, size)` that
+  sets the option **and re-fits**.
+- **`src/components/Terminal.vue`** — `dirFontSize` prop, `effectiveFontSize()` =
+  `props.dirFontSize ?? global`, passed to `attach()`, plus a watcher mirroring the theme watcher.
+- **`src/App.vue:360` / `src/components/TerminalCell.vue:1116`** — the two sites that already pass
+  `:dir-theme` also pass `:dir-font-size`.
+- **`src/components/SettingsModal.vue`** — a −/＋ stepper next to the theme picker.
+
+Clamp rather than reject on the lenient path: for a continuous numeric preference, honouring the
+direction the user asked for beats silently falling back to 14 and looking broken. The strict schema
+still flags an out-of-range value where it can be fixed — at authoring time.
+
+## Docs
+
+- `README.md`, `docs/guide/{en,ja}/config.md` (both languages).
+- `server/skills/mulmoterminal-config/SKILL.md` — it documents the `.mulmoterminal.json` keys and
+  ships the generated JSON Schema, so a new key belongs in its reference.
+
+## Tests
+
+- `normalizeFontSize`: valid, fractional, below/above range, zero, negative, `null`, string, `NaN`.
+- `dirFontSizeField` + `dirConfigJsonSchema()` carries `fontSize` with its bounds.
+- `loadDirConfig` / `publicDirConfig` round-trip the key; a garbage value falls back to null.
+- Resolution: `dirFontSize` wins over the global value; absent dir value falls back.

--- a/server/config/config-schema.ts
+++ b/server/config/config-schema.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 import { THEME_COLOR_KEYS } from "../../common/themeColors.js";
 import { THEME_IDS } from "../../common/themeIds.js";
 import { isUsableModelId } from "../../common/modelIds.js";
+import { normalizeFontSize, TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN } from "../../common/terminalFontSize.js";
 import { SESSION_AGENTS } from "../../common/sessionAgent.js";
 import type { QuickCommand } from "../../common/quickCommands.js";
 
@@ -123,6 +124,15 @@ export type UserMcpServer = z.infer<typeof userMcpServerSchema>;
 
 export const dirColorField = hexColor.nullable().catch(null);
 export const dirThemeField = themeIdSchema.nullable().catch(null);
+// Clamped, not range-checked: normalizeFontSize keeps an out-of-range number at the nearest
+// usable size instead of discarding it, so `fontSize: 99` reads as "as big as allowed" rather
+// than silently falling back to the global size. writableDirConfigSchema below is the strict
+// one, so an out-of-range value is still reported where it can be fixed — at authoring time.
+export const dirFontSizeField = z
+  .unknown()
+  .transform((value) => normalizeFontSize(value))
+  .nullable()
+  .catch(null);
 export const dirNameField = z
   .string()
   .trim()
@@ -265,6 +275,8 @@ const writableDirConfigSchema = z.object({
   // one color) with 22 missing-key errors. partialRecord keeps the same runtime key + value
   // validation but leaves the keys optional in the generated schema.
   colors: z.partialRecord(z.enum(THEME_COLOR_KEYS), z.string().regex(PALETTE_COLOR_RE)).optional(),
+  // xterm font size in px for this directory's terminals. Omit to follow the Settings value.
+  fontSize: z.number().int().min(TERMINAL_FONT_SIZE_MIN).max(TERMINAL_FONT_SIZE_MAX).optional(),
   sound: nonEmptyText.optional(),
   buttons: z.array(writableHeaderButtonSchema).max(MAX_BUTTONS).optional(),
   chips: z.array(writableHeaderChipSchema).max(MAX_CHIPS).optional(),

--- a/server/config/dir-config.ts
+++ b/server/config/dir-config.ts
@@ -16,6 +16,7 @@ import {
   dirColorField,
   dirThemeField,
   dirColorsField,
+  dirFontSizeField,
   dirSkillsField,
   dirProviderField,
   dirModelField,
@@ -124,6 +125,7 @@ export function loadDirConfig(cwd: string): DirConfig {
       cellBorderColor: dirColorField.parse(raw.cellBorderColor),
       dotColor: dirColorField.parse(raw.dotColor),
       buttonColor: dirColorField.parse(raw.buttonColor),
+      fontSize: dirFontSizeField.parse(raw.fontSize),
       theme: dirThemeField.parse(raw.theme),
       colors: dirColorsField.parse(raw.colors),
       sound: resolveDirSound(base, raw.sound),
@@ -139,8 +141,22 @@ export function loadDirConfig(cwd: string): DirConfig {
 }
 
 export function publicDirConfig(cwd: string): PublicDirConfig {
-  const { name, badgeColor, headerColor, headerTextColor, cellColor, cellBorderColor, dotColor, buttonColor, theme, colors, sound } = loadDirConfig(cwd);
-  return { name, badgeColor, headerColor, headerTextColor, cellColor, cellBorderColor, dotColor, buttonColor, theme, colors, hasSound: sound !== null };
+  const { name, badgeColor, headerColor, headerTextColor, cellColor, cellBorderColor, dotColor, buttonColor, fontSize, theme, colors, sound } =
+    loadDirConfig(cwd);
+  return {
+    name,
+    badgeColor,
+    headerColor,
+    headerTextColor,
+    cellColor,
+    cellBorderColor,
+    dotColor,
+    buttonColor,
+    fontSize,
+    theme,
+    colors,
+    hasSound: sound !== null,
+  };
 }
 
 export function dirSoundFile(cwd: string): string | null {

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mulmoterminal-config
-description: Create or edit a .mulmoterminal.json to customize how a directory looks and behaves in MulmoTerminal — its name badge, chrome colors, xterm palette, attention sound, header buttons/chips, and which model/provider its sessions run on. Also configures the settings that have NO Settings-modal UI and live only in the global `~/.mulmoterminal/config.json`: an Anthropic-compatible backend (OpenRouter, Moonshot, a gateway), keyboard shortcuts (`keymap`), the Enter-vs-newline binding (`terminalSubmit`, the fix for "Shift+Enter submits instead of adding a line"), and the periodic dev-work log. Walks a beginner through it: pick directories with checkboxes, start from a colour preset (warm / tropical / cool / bold), apply it and look at the real cell, then refine. Configures the current directory OR several of your recent MulmoTerminal directories at once. Use when the user wants to configure, theme, color-code, rename, add header buttons/chips, or bind keyboard shortcuts for a project's terminal — for one project or across many — or when Enter/Shift+Enter behaves wrongly in the terminal.
+description: Create or edit a .mulmoterminal.json to customize how a directory looks and behaves in MulmoTerminal — its name badge, chrome colors, xterm palette, terminal font size, attention sound, header buttons/chips, and which model/provider its sessions run on. Also configures the settings that have NO Settings-modal UI and live only in the global `~/.mulmoterminal/config.json`: an Anthropic-compatible backend (OpenRouter, Moonshot, a gateway), keyboard shortcuts (`keymap`), the Enter-vs-newline binding (`terminalSubmit`, the fix for "Shift+Enter submits instead of adding a line"), and the periodic dev-work log. Walks a beginner through it: pick directories with checkboxes, start from a colour preset (warm / tropical / cool / bold), apply it and look at the real cell, then refine. Configures the current directory OR several of your recent MulmoTerminal directories at once. Use when the user wants to configure, theme, color-code, rename, resize the terminal font, add header buttons/chips, or bind keyboard shortcuts for a project's terminal — for one project or across many — or when Enter/Shift+Enter behaves wrongly in the terminal, or the terminal text is too small/large (browser zoom is not the fix — it breaks xterm's grid alignment).
 ---
 
 # Configure a MulmoTerminal directory
@@ -168,6 +168,17 @@ start. Check the provider exists in the global config before writing `provider` 
   `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white`
   `brightBlack` `brightRed` `brightGreen` `brightYellow` `brightBlue` `brightMagenta` `brightCyan` `brightWhite`.
   Unknown keys are dropped.
+
+### Terminal font size — `fontSize`
+
+The xterm font size in px for this directory's terminals, overriding the user's Settings value.
+Integer, **8–32**. A value outside that range is clamped to the nearest end rather than dropped;
+a non-number is ignored. Omit unless the user asked about size — a directory that inherits the
+Settings value is the normal case.
+
+Reach for this when the user says the terminal text is too small or too big, and especially if
+they mention trying browser zoom: zoom desynchronises xterm's cell grid from the PTY (drifting
+cursor, wrong wrap points), while `fontSize` re-fits and tells the process its new size.
 
 ### Attention sound — `sound`
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -359,6 +359,7 @@ function onSession(id: string) {
           :connect-key="connectKey"
           :dir-theme="singleDirConfig.theme"
           :dir-colors="singleDirConfig.colors"
+          :dir-font-size="singleDirConfig.fontSize"
           :dir-name="singleDirConfig.name"
           :dir-badge-color="singleDirConfig.badgeColor"
           :dir-header-color="singleDirConfig.headerColor"

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { trapTabKey } from "../utils/focusTrap";
 import { useTheme } from "../composables/useTheme";
+import { useTerminalFontSize } from "../composables/useTerminalFontSize";
 import { previewAttention } from "../composables/useAttentionSound";
 import { useCost } from "../composables/useCost";
 import { activeKeymap } from "../composables/activeKeymap";
@@ -210,6 +211,10 @@ function testSound() {
 const { themeId, themes, setTheme } = useTheme();
 const themesEl = ref<HTMLElement>();
 
+// Terminal font size, applied immediately (like the theme). Per-browser, so a phone and a
+// desktop on the same server keep their own; a directory can pin its own in .mulmoterminal.json.
+const { fontSize, nudgeFontSize, min: fontSizeMin, max: fontSizeMax, step: fontSizeStep } = useTerminalFontSize();
+
 // Google account link. The modal is v-if'd, so a fresh load on mount also picks up
 // out-of-band changes (`mulmoterminal google login`, a deleted token file).
 const {
@@ -336,6 +341,32 @@ onUnmounted(() => {
           <span class="text-[12px]">{{ t.label }}</span>
         </button>
       </div>
+
+      <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Terminal font size</h3>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-border bg-elevated text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
+          :disabled="fontSize <= fontSizeMin"
+          aria-label="Decrease terminal font size"
+          @click="nudgeFontSize(-fontSizeStep)"
+        >
+          −
+        </button>
+        <span class="min-w-[56px] text-center text-[13px] text-fg" aria-live="polite">{{ fontSize }} px</span>
+        <button
+          type="button"
+          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-border bg-elevated text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
+          :disabled="fontSize >= fontSizeMax"
+          aria-label="Increase terminal font size"
+          @click="nudgeFontSize(fontSizeStep)"
+        >
+          ＋
+        </button>
+      </div>
+      <p class="mb-3 mt-1.5 text-[12px] text-dim">
+        Applies to every terminal on this browser. A directory can pin its own with <code>fontSize</code> in its <code>.mulmoterminal.json</code>.
+      </p>
 
       <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Directory appearance</h3>
       <p class="mb-3 mt-1.5 text-[12px] text-dim">

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -361,7 +361,7 @@ onUnmounted(() => {
           aria-label="Increase terminal font size"
           @click="nudgeFontSize(fontSizeStep)"
         >
-          ＋
+          +
         </button>
       </div>
       <p class="mb-3 mt-1.5 text-[12px] text-dim">

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -6,6 +6,7 @@ import { terminalManagesAttention, terminalViewActive } from "./terminalViewActi
 import { dragCarriesFiles, dropTextFromUriList } from "./dropPaths";
 import { translateUiSentence } from "../utils/translateUi";
 import { useTheme, currentTermTheme, termThemeFor, type ThemeId } from "../composables/useTheme";
+import { useTerminalFontSize } from "../composables/useTerminalFontSize";
 import { badgeStyleFor } from "./dirBadge";
 import { terminalHeaderStyleFor } from "./cellHeaderStyle";
 import { useVoiceInput } from "../composables/useVoiceInput";
@@ -68,6 +69,8 @@ const props = defineProps<{
   // `dirBadgeColor` render a project badge in the header.
   dirTheme?: ThemeId | null;
   dirColors?: Partial<ITheme> | null;
+  // Pins this terminal's xterm font size, overriding the app-wide Settings value.
+  dirFontSize?: number | null;
   dirName?: string | null;
   dirBadgeColor?: string | null;
   // The header row's own colors (matches the grid cell's row-1 header): background,
@@ -158,6 +161,7 @@ const gitCwd = computed(() => (props.devTerminal ? null : serverCwd.value));
 const { status: gitStatus } = useGitStatus(gitCwd);
 const dragOver = ref(false);
 const { themeId } = useTheme();
+const { fontSize } = useTerminalFontSize();
 
 // A dir-pinned theme wins over the app-wide selection for this terminal's canvas,
 // then per-key `dirColors` override on top (so a dir can tweak just the background
@@ -165,6 +169,11 @@ const { themeId } = useTheme();
 function effectiveTermTheme(): ITheme {
   const base = props.dirTheme ? termThemeFor(props.dirTheme) : currentTermTheme();
   return props.dirColors ? { ...base, ...props.dirColors } : base;
+}
+
+// Same precedence as the theme: a dir-pinned size wins, otherwise the app-wide setting.
+function effectiveFontSize(): number {
+  return props.dirFontSize ?? fontSize.value;
 }
 const dirBadgeStyle = computed(() => badgeStyleFor(props.dirBadgeColor));
 const headerStyle = computed(() => terminalHeaderStyleFor(props.dirHeaderColor, props.dirHeaderTextColor, props.dirButtonColor));
@@ -209,6 +218,7 @@ onMounted(() => {
     },
     container,
     effectiveTermTheme(),
+    effectiveFontSize(),
   );
 
   // Auto-resize: fit the slot's xterm to this container and push the size to the PTY.
@@ -264,6 +274,13 @@ onUnmounted(() => pushView(false));
 // dir-pinned theme ignores the app-wide change; a change to the pin itself repaints.
 watch([themeId, () => props.dirTheme, () => props.dirColors], () => {
   conn.setTheme(slotKey, effectiveTermTheme());
+});
+
+// The size, unlike the palette, changes the cell metrics — conn.setFontSize re-fits and pushes
+// the new cols/rows to the PTY, so the ResizeObserver above is not what reacts here (the host
+// element never resized; only what fits inside it did).
+watch([fontSize, () => props.dirFontSize], () => {
+  conn.setFontSize(slotKey, effectiveFontSize());
 });
 
 // Expanding/collapsing a grid cell teleports it in the DOM, which blurs the xterm textarea — so the

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1115,6 +1115,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         :launch="launchChoice"
         :dir-theme="dirConfig.theme"
         :dir-colors="dirConfig.colors"
+        :dir-font-size="dirConfig.fontSize"
         :dir-header-color="dirConfig.headerColor"
         :dir-header-text-color="dirConfig.headerTextColor"
         :dir-button-color="dirConfig.buttonColor"

--- a/src/composables/useDirConfig.ts
+++ b/src/composables/useDirConfig.ts
@@ -5,6 +5,7 @@ import { isThemeId, type ThemeId } from "./useTheme";
 // Shared with the server config schema so the two can't drift — see common/themeColors.ts.
 import { THEME_COLOR_KEYS } from "../../common/themeColors";
 import { EMPTY_DIR_CHROME, type DirChrome } from "../../common/dirChrome";
+import { normalizeFontSize } from "../../common/terminalFontSize";
 import { isRecord } from "../../common/isRecord";
 
 // The per-directory overrides a terminal adopts when its cwd holds a
@@ -63,6 +64,9 @@ function parse(c: unknown): DirConfig {
     cellBorderColor: typeof c.cellBorderColor === "string" ? c.cellBorderColor : null,
     dotColor: typeof c.dotColor === "string" ? c.dotColor : null,
     buttonColor: typeof c.buttonColor === "string" ? c.buttonColor : null,
+    // Re-clamped here rather than trusted: the server validates, but this parser is the
+    // boundary, and an out-of-range size reaches the canvas renderer if nothing checks.
+    fontSize: normalizeFontSize(c.fontSize),
     theme: isThemeId(c.theme) ? c.theme : null,
     colors: parseColors(c.colors),
     hasSound: c.hasSound === true,

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -43,6 +43,7 @@ import type { RunCommand } from "../components/runCommand";
 import { readableSlot, type SlotCandidate, type SlotInfo } from "./readableSlot";
 import { messageEffect } from "./serverMessage";
 import { enterKeyOverride, submitSequence, DEFAULT_TERMINAL_SUBMIT_MODE, type EnterKeyEvent, type TerminalSubmitMode } from "../../common/terminalSubmit";
+import { TERMINAL_FONT_SIZE_DEFAULT } from "../../common/terminalFontSize";
 import { getTerminalSubmitMode } from "./terminalSubmitMode";
 import { createFilePathLinkProvider } from "./terminalFilePathLinkProvider";
 import { filesGotoFile } from "./useFilesView";
@@ -132,6 +133,7 @@ interface Conn {
   // reports, or its wheel would get synthesized reports it never wanted.
   swallowedMouseModes: Set<number>;
   theme: ITheme | undefined; // last applied, so a rebuilt terminal keeps the cell's colours
+  fontSize: number; // same reason as `theme` — a rebuilt terminal must not snap back to the default
   lastRebuildMs: number; // rate-limits the #846 recovery so a stuck reading can't spin
 }
 
@@ -251,10 +253,10 @@ interface TerminalRuntime {
 // Everything a slot's xterm is made of. Built here rather than inline in ensure() because a
 // terminal that xterm has killed can only be replaced, never revived (see rebuildTerminal).
 // The mouse-mode record is passed in: it belongs to the connection and outlives any one terminal.
-function buildTerminal(swallowedMouseModes: Set<number>): TerminalRuntime {
+function buildTerminal(swallowedMouseModes: Set<number>, fontSize: number): TerminalRuntime {
   const term = new Terminal({
     cursorBlink: true,
-    fontSize: 14,
+    fontSize,
     fontFamily: "'JetBrains Mono', 'Fira Code', 'Menlo', monospace",
     // Treat macOS Option as Meta so Claude's Alt bindings reach the PTY — Alt+Enter
     // (newline), Alt+B/F (word nav), Alt+Backspace (delete word). The cost is Option
@@ -316,14 +318,14 @@ function wireTerminalToConn(term: Terminal, c: Conn): void {
   if (c.theme) term.options.theme = c.theme;
 }
 
-function ensure(key: string, target: ConnTarget): Conn {
+function ensure(key: string, target: ConnTarget, fontSize: number): Conn {
   const existing = conns.get(key);
   if (existing) {
     existing.target = target;
     return existing;
   }
   const swallowedMouseModes = new Set<number>();
-  const { term, fitAddon, host } = buildTerminal(swallowedMouseModes);
+  const { term, fitAddon, host } = buildTerminal(swallowedMouseModes, fontSize);
   const c: Conn = {
     key,
     term,
@@ -341,6 +343,7 @@ function ensure(key: string, target: ConnTarget): Conn {
     attachedEl: null,
     swallowedMouseModes,
     theme: undefined,
+    fontSize,
     lastRebuildMs: 0,
   };
   conns.set(key, c);
@@ -359,7 +362,7 @@ function rebuildTerminal(c: Conn): void {
   const deadHost = c.host;
   const hadFocus = deadHost.contains(document.activeElement);
   console.warn(`[terminal] slot ${c.key}: xterm buffer corrupted (xtermjs/xterm.js#6063) — rebuilding the terminal and re-attaching`);
-  const { term, fitAddon, host } = buildTerminal(c.swallowedMouseModes);
+  const { term, fitAddon, host } = buildTerminal(c.swallowedMouseModes, c.fontSize);
   c.term = term;
   c.fitAddon = fitAddon;
   c.host = host;
@@ -480,9 +483,16 @@ function handleMessage(c: Conn, event: MessageEvent) {
 // Mount a view onto a slot: create the runtime on first acquire (and connect),
 // otherwise reattach the persisted xterm to the new DOM host. Never reconnects an
 // already-live slot — that's the whole point (no cold resume on remount).
-export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, el: HTMLElement, theme?: ITheme) {
+export function attach(
+  key: string,
+  target: ConnTarget,
+  handlers: ConnHandlers,
+  el: HTMLElement,
+  theme?: ITheme,
+  fontSize: number = TERMINAL_FONT_SIZE_DEFAULT,
+) {
   const created = !conns.has(key);
-  const c = ensure(key, target);
+  const c = ensure(key, target, fontSize);
   c.released = false;
   c.handlers = handlers;
   c.attachedEl = el;
@@ -497,6 +507,13 @@ export function attach(key: string, target: ConnTarget, handlers: ConnHandlers, 
   if (theme) {
     c.theme = theme;
     c.term.options.theme = theme;
+  }
+  // A slot that was detached while the size changed (Settings edited from another view, or a
+  // different dir config) still holds the old metrics. The fitAndSyncSize below re-derives
+  // cols/rows from the new cell size, so this must land before it, not after.
+  if (c.fontSize !== fontSize) {
+    c.fontSize = fontSize;
+    c.term.options.fontSize = fontSize;
   }
   if (created) connect(c);
   fitAndSyncSize(c);
@@ -699,4 +716,16 @@ export function setTheme(key: string, theme: ITheme) {
   if (!c) return;
   c.theme = theme;
   c.term.options.theme = theme;
+}
+
+// Unlike setTheme, this changes the CELL SIZE, so the terminal's cols/rows no longer match the
+// host and the PTY still believes the old geometry. Without the re-fit the canvas grid and the
+// PTY disagree — the same misalignment (drifting cursor, wrong wrap points) that made browser
+// zoom useless as a workaround in #860.
+export function setFontSize(key: string, fontSize: number) {
+  const c = conns.get(key);
+  if (!c || c.fontSize === fontSize) return;
+  c.fontSize = fontSize;
+  c.term.options.fontSize = fontSize;
+  fitAndSyncSize(c);
 }

--- a/src/composables/useTerminalFontSize.ts
+++ b/src/composables/useTerminalFontSize.ts
@@ -1,0 +1,49 @@
+import { ref } from "vue";
+import {
+  normalizeFontSize,
+  TERMINAL_FONT_SIZE_DEFAULT,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
+  TERMINAL_FONT_SIZE_STEP,
+} from "../../common/terminalFontSize";
+
+// The app-wide xterm font size, in px. Kept in localStorage rather than config.json — the
+// same place the theme lives, and per-browser is the right grain for a size: a phone and a
+// desktop viewing the same server want different ones, which one shared value can't express.
+// A directory's `.mulmoterminal.json` fontSize overrides this per terminal.
+const STORAGE_KEY = "terminalFontSize";
+
+// Storage access can throw (private mode / storage-blocked contexts), so reading is
+// best-effort — a failure falls back to the default instead of breaking startup.
+function loadFontSize(): number {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return normalizeFontSize(stored === null ? null : Number(stored)) ?? TERMINAL_FONT_SIZE_DEFAULT;
+  } catch {
+    return TERMINAL_FONT_SIZE_DEFAULT;
+  }
+}
+
+const fontSize = ref<number>(loadFontSize());
+
+export function useTerminalFontSize() {
+  function setFontSize(next: number) {
+    const size = normalizeFontSize(next);
+    if (size === null) return;
+    fontSize.value = size;
+    try {
+      localStorage.setItem(STORAGE_KEY, String(size));
+    } catch {
+      // storage blocked: the size still applies for this session, just isn't persisted
+    }
+  }
+  const nudgeFontSize = (delta: number) => setFontSize(fontSize.value + delta);
+  return {
+    fontSize,
+    setFontSize,
+    nudgeFontSize,
+    min: TERMINAL_FONT_SIZE_MIN,
+    max: TERMINAL_FONT_SIZE_MAX,
+    step: TERMINAL_FONT_SIZE_STEP,
+  };
+}

--- a/src/composables/useTerminalFontSize.ts
+++ b/src/composables/useTerminalFontSize.ts
@@ -18,7 +18,10 @@ const STORAGE_KEY = "terminalFontSize";
 function loadFontSize(): number {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    return normalizeFontSize(stored === null ? null : Number(stored)) ?? TERMINAL_FONT_SIZE_DEFAULT;
+    // Blank has to be screened out BEFORE Number(): `Number("")` is 0, which is a finite number,
+    // so it would clamp to the minimum and start the app at 8px. Every other unusable value
+    // ("abc" -> NaN) already falls through to the default, and blank means the same thing.
+    return normalizeFontSize(stored?.trim() ? Number(stored) : null) ?? TERMINAL_FONT_SIZE_DEFAULT;
   } catch {
     return TERMINAL_FONT_SIZE_DEFAULT;
   }

--- a/test/common/terminalFontSize.spec.ts
+++ b/test/common/terminalFontSize.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { normalizeFontSize, TERMINAL_FONT_SIZE_DEFAULT, TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN } from "../../common/terminalFontSize";
+
+describe("normalizeFontSize", () => {
+  it("keeps a size inside the range", () => {
+    expect(normalizeFontSize(14)).toBe(14);
+    expect(normalizeFontSize(TERMINAL_FONT_SIZE_MIN)).toBe(TERMINAL_FONT_SIZE_MIN);
+    expect(normalizeFontSize(TERMINAL_FONT_SIZE_MAX)).toBe(TERMINAL_FONT_SIZE_MAX);
+  });
+
+  // Clamped rather than dropped: honouring the direction the user asked for reads as working,
+  // where falling back to the default reads as the setting being ignored.
+  it("clamps a size outside the range instead of discarding it", () => {
+    expect(normalizeFontSize(TERMINAL_FONT_SIZE_MAX + 100)).toBe(TERMINAL_FONT_SIZE_MAX);
+    expect(normalizeFontSize(1)).toBe(TERMINAL_FONT_SIZE_MIN);
+    expect(normalizeFontSize(0)).toBe(TERMINAL_FONT_SIZE_MIN);
+    expect(normalizeFontSize(-40)).toBe(TERMINAL_FONT_SIZE_MIN);
+  });
+
+  // xterm accepts a fractional size, but the cell metrics then disagree with the integer the
+  // Settings stepper shows — and the stepper is where the user reads the value back.
+  it("rounds a fractional size", () => {
+    expect(normalizeFontSize(14.4)).toBe(14);
+    expect(normalizeFontSize(14.5)).toBe(15);
+  });
+
+  // Non-numeric is a different thing from out-of-range: it means "nothing configured here",
+  // so the caller falls back rather than being handed a clamped guess.
+  it("returns null for anything that isn't a finite number", () => {
+    expect(normalizeFontSize(null)).toBeNull();
+    expect(normalizeFontSize(undefined)).toBeNull();
+    expect(normalizeFontSize("16")).toBeNull();
+    expect(normalizeFontSize(NaN)).toBeNull();
+    expect(normalizeFontSize(Infinity)).toBeNull();
+    expect(normalizeFontSize(-Infinity)).toBeNull();
+    expect(normalizeFontSize({})).toBeNull();
+    expect(normalizeFontSize([])).toBeNull();
+    expect(normalizeFontSize(true)).toBeNull();
+  });
+
+  it("has a default inside its own range", () => {
+    expect(TERMINAL_FONT_SIZE_DEFAULT).toBeGreaterThanOrEqual(TERMINAL_FONT_SIZE_MIN);
+    expect(TERMINAL_FONT_SIZE_DEFAULT).toBeLessThanOrEqual(TERMINAL_FONT_SIZE_MAX);
+  });
+});

--- a/test/server/config/config-schema.spec.ts
+++ b/test/server/config/config-schema.spec.ts
@@ -5,6 +5,7 @@ import {
   dirColorField,
   dirThemeField,
   dirColorsField,
+  dirFontSizeField,
   headerButtonSchema,
   headerChipSchema,
   cwdPresetSchema,
@@ -14,6 +15,7 @@ import {
   MAX_CHIPS,
   MAX_SKILL_FILTER,
 } from "../../../server/config/config-schema";
+import { TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN } from "../../../common/terminalFontSize.js";
 
 describe("dirNameField", () => {
   it("trims and caps at NAME_MAX_CHARS", () => {
@@ -80,6 +82,27 @@ describe("item schemas (strict shape)", () => {
   });
 });
 
+describe("dirFontSizeField", () => {
+  it("keeps a usable size and rounds a fractional one", () => {
+    expect(dirFontSizeField.parse(18)).toBe(18);
+    expect(dirFontSizeField.parse(17.6)).toBe(18);
+  });
+
+  // The lenient path clamps where the strict schema (writableDirConfigSchema) rejects, so a
+  // hand-edited `fontSize: 99` still enlarges the terminal instead of silently doing nothing.
+  it("clamps an out-of-range size", () => {
+    expect(dirFontSizeField.parse(99)).toBe(TERMINAL_FONT_SIZE_MAX);
+    expect(dirFontSizeField.parse(2)).toBe(TERMINAL_FONT_SIZE_MIN);
+  });
+
+  it("nulls a missing or non-numeric size so the global setting wins", () => {
+    expect(dirFontSizeField.parse(undefined)).toBeNull();
+    expect(dirFontSizeField.parse(null)).toBeNull();
+    expect(dirFontSizeField.parse("16")).toBeNull();
+    expect(dirFontSizeField.parse({})).toBeNull();
+  });
+});
+
 describe("dirConfigJsonSchema", () => {
   it("emits an object schema with every writable property", () => {
     const schema = dirConfigJsonSchema();
@@ -95,6 +118,16 @@ describe("dirConfigJsonSchema", () => {
   it("includes the keys that choose a backend, so the config skill can write them", () => {
     const props = isRecord(dirConfigJsonSchema().properties) ? dirConfigJsonSchema().properties : {};
     expect(Object.keys(isRecord(props) ? props : {})).toEqual(expect.arrayContaining(["provider", "model"]));
+  });
+
+  // Same reasoning as provider/model above: the config skill writes from this schema, so
+  // `fontSize` has to appear here or the skill refuses to write a key the runtime honours.
+  // The bounds come along so an editor flags an unusable size while it can still be fixed.
+  it("includes fontSize with its bounds, so the config skill can write it", () => {
+    const props = isRecord(dirConfigJsonSchema().properties) ? dirConfigJsonSchema().properties : {};
+    const fontSize = isRecord(props) && isRecord(props.fontSize) ? props.fontSize : {};
+    expect(fontSize.minimum).toBe(TERMINAL_FONT_SIZE_MIN);
+    expect(fontSize.maximum).toBe(TERMINAL_FONT_SIZE_MAX);
   });
 
   it("caps the skills allowlist at MAX_SKILL_FILTER", () => {

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -14,6 +14,7 @@ const EMPTY = {
   cellBorderColor: null,
   dotColor: null,
   buttonColor: null,
+  fontSize: null,
   theme: null,
   colors: null,
   sound: null,
@@ -113,6 +114,7 @@ describe("loadDirConfig", () => {
       cellBorderColor: "#2A2A4E",
       dotColor: "#00E676",
       buttonColor: "#C7CDF0",
+      fontSize: 17,
       theme: "nord",
       sound: "./a.mp3",
       skills: ["  review  ", "commit", "review", ""],
@@ -127,6 +129,7 @@ describe("loadDirConfig", () => {
       cellBorderColor: "#2a2a4e",
       dotColor: "#00e676",
       buttonColor: "#c7cdf0",
+      fontSize: 17,
       theme: "nord",
       colors: null,
       sound: path.join(dir, "a.mp3"),
@@ -249,7 +252,7 @@ describe("dirConfigWriteTarget", () => {
 
 describe("publicDirConfig / dirSoundFile", () => {
   it("exposes hasSound but not the raw path", () => {
-    const { dir, cleanup } = withConfig({ name: "x", sound: "./a.mp3" });
+    const { dir, cleanup } = withConfig({ name: "x", sound: "./a.mp3", fontSize: 20 });
     writeFileSync(path.join(dir, "a.mp3"), "x");
     expect(publicDirConfig(dir)).toEqual({
       name: "x",
@@ -260,6 +263,9 @@ describe("publicDirConfig / dirSoundFile", () => {
       cellBorderColor: null,
       dotColor: null,
       buttonColor: null,
+      // On the wire on purpose: the browser needs it to size the terminal, and unlike `sound`
+      // there is nothing sensitive about it.
+      fontSize: 20,
       theme: null,
       colors: null,
       hasSound: true,

--- a/test/src/composables/useDirConfig.spec.ts
+++ b/test/src/composables/useDirConfig.spec.ts
@@ -13,6 +13,7 @@ vi.mock("../../../src/composables/usePubSub", () => ({
 }));
 
 import { useDirConfig, boundDirCount, invalidateDirConfig } from "../../../src/composables/useDirConfig";
+import { TERMINAL_FONT_SIZE_MAX } from "../../../common/terminalFontSize";
 
 let served = "first";
 const flush = async () => {
@@ -26,6 +27,44 @@ beforeEach(() => {
     "fetch",
     vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ name: served }) })),
   );
+});
+
+describe("useDirConfig fontSize", () => {
+  const serve = (body: unknown) =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(body) })),
+    );
+  const read = async (cwd: string) => {
+    const scope = effectScope();
+    const config = scope.run(() => useDirConfig(ref(cwd)).config);
+    await flush();
+    const size = config?.value.fontSize;
+    scope.stop();
+    return size;
+  };
+
+  it("adopts the size the directory pins", async () => {
+    serve({ fontSize: 18 });
+    expect(await read("/proj/font-pinned")).toBe(18);
+  });
+
+  // The server already clamps, but this parser is the trust boundary — an out-of-range size
+  // that slipped through would otherwise reach the canvas renderer unchecked.
+  it("re-clamps an out-of-range size off the wire", async () => {
+    serve({ fontSize: 999 });
+    expect(await read("/proj/font-clamped")).toBe(TERMINAL_FONT_SIZE_MAX);
+  });
+
+  it("stays null when the directory pins nothing, so the Settings value wins", async () => {
+    serve({ name: "x" });
+    expect(await read("/proj/font-absent")).toBeNull();
+  });
+
+  it("stays null for a non-numeric size rather than guessing", async () => {
+    serve({ fontSize: "18" });
+    expect(await read("/proj/font-garbage")).toBeNull();
+  });
 });
 
 describe("useDirConfig live reload", () => {

--- a/test/src/composables/useTerminalFontSize.spec.ts
+++ b/test/src/composables/useTerminalFontSize.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { TERMINAL_FONT_SIZE_DEFAULT, TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN } from "../../../common/terminalFontSize";
+
+const STORAGE_KEY = "terminalFontSize";
+
+// The startup value is read once at module load, so each case needs a fresh module.
+const startupSizeWith = async (stored: string | null) => {
+  localStorage.clear();
+  if (stored !== null) localStorage.setItem(STORAGE_KEY, stored);
+  vi.resetModules();
+  const { useTerminalFontSize } = await import("../../../src/composables/useTerminalFontSize");
+  return useTerminalFontSize().fontSize.value;
+};
+
+describe("useTerminalFontSize startup value", () => {
+  it("adopts a stored size", async () => {
+    expect(await startupSizeWith("18")).toBe(18);
+  });
+
+  it("falls back to the default when nothing is stored", async () => {
+    expect(await startupSizeWith(null)).toBe(TERMINAL_FONT_SIZE_DEFAULT);
+  });
+
+  // Regression: `Number("")` is 0 — a finite number — so a blank value clamped to the minimum
+  // and the app started at 8px, while every other unusable value fell back to the default.
+  it("treats a blank stored value as unset rather than as zero", async () => {
+    expect(await startupSizeWith("")).toBe(TERMINAL_FONT_SIZE_DEFAULT);
+    expect(await startupSizeWith("   ")).toBe(TERMINAL_FONT_SIZE_DEFAULT);
+  });
+
+  it("falls back for a non-numeric stored value", async () => {
+    expect(await startupSizeWith("abc")).toBe(TERMINAL_FONT_SIZE_DEFAULT);
+  });
+
+  it("clamps a stored size that is out of range", async () => {
+    expect(await startupSizeWith("999")).toBe(TERMINAL_FONT_SIZE_MAX);
+    expect(await startupSizeWith("1")).toBe(TERMINAL_FONT_SIZE_MIN);
+  });
+});
+
+describe("useTerminalFontSize updates", () => {
+  const fresh = async () => {
+    localStorage.clear();
+    vi.resetModules();
+    const { useTerminalFontSize } = await import("../../../src/composables/useTerminalFontSize");
+    return useTerminalFontSize();
+  };
+
+  it("persists a set size so the next load keeps it", async () => {
+    const { setFontSize, fontSize } = await fresh();
+    setFontSize(20);
+    expect(fontSize.value).toBe(20);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("20");
+  });
+
+  it("steps by the given delta and stops at the bounds", async () => {
+    const { nudgeFontSize, fontSize } = await fresh();
+    nudgeFontSize(2);
+    expect(fontSize.value).toBe(TERMINAL_FONT_SIZE_DEFAULT + 2);
+    nudgeFontSize(1000);
+    expect(fontSize.value).toBe(TERMINAL_FONT_SIZE_MAX);
+    nudgeFontSize(-1000);
+    expect(fontSize.value).toBe(TERMINAL_FONT_SIZE_MIN);
+  });
+
+  it("ignores a non-finite size rather than storing it", async () => {
+    const { setFontSize, fontSize } = await fresh();
+    setFontSize(NaN);
+    expect(fontSize.value).toBe(TERMINAL_FONT_SIZE_DEFAULT);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`fontSize` was hardcoded in the xterm constructor. This adds it in two places, following exactly the shape `theme` already has:

| | Global | Per-directory |
|---|---|---|
| Where | Settings modal stepper → `localStorage["terminalFontSize"]` | `.mulmoterminal.json` → `fontSize` |
| Range | 8–32, default 14 | same; out-of-range **clamped**, non-number ignored |
| Precedence | fallback | **wins**, per terminal |

**The part that isn't plumbing:** a size change alters the *cell metrics*, so `cols`/`rows` change and the PTY has to be told. `setFontSize()` re-fits and syncs; `attach()` applies a changed size *before* its own fit. Setting the option alone would reproduce the exact bug that makes browser zoom useless here — xterm's grid and the PTY disagreeing, so the cursor and wrap points drift. `Conn.fontSize` remembers the applied value so a rebuilt terminal (#846) doesn't snap back to 14.

Closes #860.

## Items to Confirm / Review

- **localStorage, not `config.json`.** The issue body proposed `~/.mulmoterminal/config.json`; the user chose "same as color", which is localStorage + Settings UI. It is also the better grain for a *size* — per-display, so a phone and a desktop on one server keep their own, which one shared value can't express. Flagging it because it deviates from the issue text.
- **Clamp vs reject on the lenient path.** `fontSize: 99` becomes 32 rather than falling back to 14, so the setting reads as working rather than ignored. The strict schema (`writableDirConfigSchema`) still rejects out-of-range, so an editor flags it at authoring time. Both behaviours are pinned by tests — worth a sanity check that this is the trade you want.
- **`fontSize` went into `DirChrome`** (`common/dirChrome.ts`), whose stated invariant is "fields whose type is identical on both sides" — `theme`/`colors` are excluded only because each side types them differently, which doesn't apply to a number. All three `DirConfig`s extend it, so one side can no longer omit the field. I retitled the comment accordingly; say the word if you'd rather it were declared per side.
- **Bounds are a judgement call.** 8–32 px: below ~8 the canvas glyphs stop being legible, above ~32 a grid cell holds too few columns to be useful. Neither is an xterm limit.
- **i18n.** `SettingsModal.vue` has no `$t()` and the app wires no `createI18n` (`vue-i18n` is in package.json but unused anywhere in `src/`), so the new labels are plain strings like every other label in that file. This departs from the global "use vue-i18n" rule — raised separately rather than fixed here.

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/860
> 試してみたところ確かにサイズは変わる。色と同様に、global 設定とリポジトリごとの設定ができると良いかも。リポジトリごとが難しいなら一先ず global だけで。

Per-directory turned out **not** to be hard — the `.mulmoterminal.json` plumbing already ran end to end for `theme`/`colors`, so `fontSize` rides the same route. Both are included.

## Verification

Gates: `format`, `lint` (0 errors), `typecheck`, `typecheck:server`, `typecheck:test`, `build`, `test` — **4442 passed** (13 new).

**Driven in the running app** (own instance on a spare port), not just unit-tested:

| Check | Result |
|---|---|
| Stepper | 14 px → +10 → 24 px |
| Ceiling | stops at 32 px, ＋ disabled |
| Persistence | survives reload via localStorage |
| **PTY re-fit** | **67×47 @14px → 38×27 @24px**, one resize frame per press |

The screenshot at 24 px shows Claude Code's own output **re-wrapped to 38 columns** — the process received the new geometry and re-rendered. That is the behaviour browser zoom cannot produce.

Per-directory verified at the wire with `curl /api/dir-config`: `22` → `22`, `999` → `32` (clamped), `"22"` → `null`.

**Not verified:** the dir pin clicked through in the browser. The cwd-picking launcher lives in the grid cell and each attempt spawns a real session, so I stopped rather than spawn more. That path is covered by the wire check above plus 4 parser unit tests; the resolution itself is `props.dirFontSize ?? fontSize.value`, passed at both call sites (single view + grid cell).

## Docs

`useTerminalConnections.ts` carries a header requiring terminal changes to update the docs in the same commit — so: `docs/terminal-notes.md` (the resolution order and the must-re-fit rule), `README.md`, and `docs/guide/{en,ja}/config.md` + `features.md` in both languages. `server/skills/mulmoterminal-config/SKILL.md` gained the key and a trigger for "the text is too small", since that skill writes these files and would otherwise refuse to write a key the runtime honours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adjustable terminal font size controls in Settings.
  * Added per-directory font size overrides through configuration.
  * Font sizes are validated, rounded, and constrained to supported limits.
  * Terminal layout and cursor alignment now remain synchronized when font size changes.

* **Documentation**
  * Updated English and Japanese guides with configuration details and usage guidance.

* **Tests**
  * Added coverage for font-size validation, overrides, persistence, and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->