### PR TITLE
chore: clear the dead type and the two actionable lint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -102,6 +102,11 @@ export default [
     rules: {
       "max-lines-per-function": "off",
       "max-nested-callbacks": "off",
+      // Same reasoning for components: a spec defines throwaway stubs next to the case that
+      // uses them (useCaptureKeydown, useNewTerminal). Splitting one-line stubs into their own
+      // files would put the fixture further from the assertion, which is the opposite of what
+      // the rule is for — it exists to keep SHIPPED components findable.
+      "vue/one-component-per-file": "off",
     },
   },
   {

--- a/src/components/WikiBrowseOverlay.vue
+++ b/src/components/WikiBrowseOverlay.vue
@@ -153,7 +153,7 @@ useEscapeToClose(isOpen, close);
         <WikiPageView v-else-if="view.mode === 'page' && page" :slug="view.slug" :page="page" :graph="graph" />
         <WikiGraphView v-else-if="view.mode === 'graph' && graph" :graph="graph" />
         <!-- eslint-disable-next-line vue/no-v-html -- sanitized in renderWikiHtml -->
-        <div class="wiki-lint mx-auto max-w-[820px] px-7 pt-6 pb-16 text-[14px] leading-[1.6] text-fg" v-else-if="view.mode === 'lint'" v-html="lintHtml"></div>
+        <div v-else-if="view.mode === 'lint'" class="wiki-lint mx-auto max-w-[820px] px-7 pt-6 pb-16 text-[14px] leading-[1.6] text-fg" v-html="lintHtml"></div>
       </template>
     </div>
   </div>

--- a/src/composables/serverMessage.ts
+++ b/src/composables/serverMessage.ts
@@ -7,14 +7,6 @@
 // cell offers to re-run a session that is alive in another tab — and if it were treated as
 // retryable, the two tabs would evict each other forever. This is exactly why it wants a test.
 
-export interface ParsedServerMessage {
-  type?: string;
-  data?: unknown;
-  id?: unknown;
-  cwd?: unknown;
-  message?: unknown;
-}
-
 // The non-output effects of a message. `output` is handled directly (a hot path, just a
 // write) and is not modelled here.
 export interface MessageEffect {


### PR DESCRIPTION
## Summary

Three leftovers found while triaging #866. **No behaviour changes** — one dead type, one attribute order, one lint scope.

| # | What | Why it's safe |
|---|---|---|
| 1 | Remove `ParsedServerMessage` (`src/composables/serverMessage.ts`) | Exported, referenced **nowhere** — not even inside its own file — since #611 added it. knip was reporting it |
| 2 | `v-else-if` before `class` (`WikiBrowseOverlay.vue:156`) | `eslint --fix`; its three sibling branches already lead with the directive. Identical render |
| 3 | `vue/one-component-per-file` off **for test files only** | 4 warnings, all specs defining throwaway stubs next to the case using them |

**Result: lint goes 6 warnings → 1.** knip's report is empty again (only its pre-existing `.css` configuration hint remains).

## Items to Confirm / Review

- **#3 is a config override, not a disable comment.** CLAUDE.md forbids silencing with `eslint-disable`, so it went into `eslint.config.js` beside the existing test-file relaxations (`max-lines-per-function`, `max-nested-callbacks`), which exist for the same reason. The rationale: that rule exists to keep **shipped** components findable — moving a one-line stub into its own file would put the fixture further from its assertion, which is the opposite of what it's for. If you'd rather the specs were restructured instead, say so and I'll revert this hunk.
- **#1 — worth a second look that it really is dead.** `grep -rn ParsedServerMessage src/ test/ server/` returns only the declaration. It described the raw WS message shape; `messageEffect()` takes its argument as `unknown` and narrows internally, so nothing ever referenced the interface.

## Deliberately NOT included

`startCodexEntry` (`server/routes/ws-routes.ts:190`) has 7 parameters against a max of 6 — the one remaining warning. Collapsing those into an argument object is a real refactor of the codex session launch path, needing tests and a live launch check, so it does not belong in a cleanup PR. Excluded at the user's direction.

## User Prompt

> 2. vue-i18n が未使用の依存 — 削除するか i18n を導入するか ってなに？
> CodeRabbit のバグは直そう。
> 別PR? 他、問題あればまとめて直して

Two corrections came out of that:

- **`vue-i18n` is NOT unused — I was wrong**, and nothing here touches it. It is a **peerDependency** of `@mulmoclaude/accounting-plugin`, `@mulmoclaude/collection-plugin` and `@mulmoclaude/core`, so the host app has to provide it; `vite.config.ts` carries a dedicated `optimizeDeps.exclude` + `__VUE_I18N_*__` defines for it. Removing it would break those plugin views. knip was right and my grep was wrong — it only proved *our* source never calls `$t()`, while the actual consumer is plugin-side. It also follows that the host having no i18n is deliberate and documented (`App.vue:241`, `collectionUi.ts:130`), so English literals in the host UI are correct here.
- **The CodeRabbit bug was already fixed**, in `fbac2e1` and merged as `978b966` — the blank-`localStorage` value that started the terminal at 8px. Nothing outstanding.

## Verification

`format`, `lint` (0 errors, 1 warning — the excluded one), `typecheck`, `typecheck:server`, `typecheck:test`, `build`, `knip`, `test` — **4450 passed**, unchanged from main, as expected for a no-behaviour-change PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)