### PR TITLE
Replace every emoji in the UI with Material Symbols

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,22 @@ anything not covered here.
 - `yarn test` — **Vitest** (`test/**/*.spec.ts`). Mock external APIs; tests must run without API keys.
 - `yarn dev` — server + Vite together (local development).
 
+## No emojis
+**Never use emojis anywhere in this project** — UI, source comments, docs, changelog, commit
+messages, skills, CLI output. Icons are **Material Symbols (outlined)**, self-hosted via the
+`material-symbols` npm package: `<span class="material-symbols-outlined">icon_name</span>`.
+A global rule in `src/style.css` gives them `font-size: inherit`, so size them on the parent.
+
+- A header button in config (`server/config/header-config.ts`) takes **`icon`**, not `emoji`.
+  The `emoji` field still exists for end-user configs and wins over `icon` when both are set —
+  don't use it in anything this repo ships.
+- Three deliberate exceptions, all functional. Don't "fix" them:
+  - `server/session/screen-rows.ts` — `/^\s*[❯›]\s/u` parses Claude Code's real terminal output.
+  - `src/composables/useDynamicFavicon.ts` — the `❯` chevron drawn on canvas as the favicon mark.
+  - `bin/mulmoterminal.js` — the CLI doctor's `✓ / ✗ / ○` (a terminal can't render an icon font).
+- Compact status **notation** stays text, not icons: `⎇ main ●3 ↑2`, `●` unsaved dots, `−12` diff
+  counts. Icons there are bigger and slower to scan.
+
 ## Layout
 - `server/` — backend (PTY sessions, config, agents, backends). Ships user-facing skills in `server/skills/`.
 - `src/` — Vue web UI (App.vue, components, composables, router).
@@ -64,7 +80,8 @@ procedure: open this file, paste this, restart what, how to tell it worked, what
   guide holds the reference — do not duplicate the reference.
 - A fix-only release still gets a page: "nothing to configure", what was broken, and **how to
   tell you have the fix**. That is what an upgrader actually wants to know.
-- **Link it from the changelog entry** (a `> 📘` line right under the heading). Before this
+- **Link it from the changelog entry** (a `> **Setup guide:**` blockquote line right under the
+  heading — the old convention used a book emoji, dropped per **No emojis** above). Before this
   existed the changelog had one link into the guide in 717 lines, which is why nobody found the
   manual.
 - **Verify before committing**: every internal link resolves to a real page *and anchor*, and any

--- a/server/config/header-config.ts
+++ b/server/config/header-config.ts
@@ -38,13 +38,13 @@ export interface HeaderConfig {
 // the branch has no open PR, so they self-hide where they don't apply.
 export const DEFAULT_BUTTONS: HeaderButton[] = [
   { id: "pick-file", icon: "attach_file", label: "Insert a file path", run: "open", open: { pickFile: true } },
-  { id: "reveal", emoji: "📂", label: "Reveal in the file manager", run: "open", open: { reveal: "${dir}" } },
+  { id: "reveal", icon: "folder", label: "Reveal in the file manager", run: "open", open: { reveal: "${dir}" } },
   { id: "files", icon: "folder_open", label: "Browse files in the app", run: "open", open: { files: "${dir}" } },
-  { id: "terminal", emoji: "🖥", label: "New terminal here", run: "open", open: { terminal: "${dir}" } },
-  { id: "pr", emoji: "🔗", label: "Open this branch's PR", run: "open", when: "isGitRepo", open: { pr: true } },
+  { id: "terminal", icon: "terminal", label: "New terminal here", run: "open", open: { terminal: "${dir}" } },
+  { id: "pr", icon: "merge", label: "Open this branch's PR", run: "open", when: "isGitRepo", open: { pr: true } },
   // `repo != ` gates on a resolvable GitHub owner/repo (ctx.repo is null for non-GitHub or remoteless
   // repos), so this never renders a broken `https://github.com/` link.
-  { id: "gh", emoji: "🌐", label: "Open on GitHub", run: "open", when: "repo != ", open: { url: "https://github.com/${repo}" } },
+  { id: "gh", icon: "public", label: "Open on GitHub", run: "open", when: "repo != ", open: { url: "https://github.com/${repo}" } },
 ];
 
 // The live context a header is resolved against — all trusted server-side session state.

--- a/server/index.ts
+++ b/server/index.ts
@@ -478,7 +478,7 @@ startCollectionCompletionWatchers().catch((err) => {
 // nudge). The run-binding spawns a VISIBLE session so the user sees the result.
 // Non-fatal: a scheduler failure must never abort startup.
 //
-// Nobody ever presses ✕ on a scheduled session, and one blocked on a permission prompt
+// Nobody ever presses close on a scheduled session, and one blocked on a permission prompt
 // never finishes a turn, so the hook-driven reap can miss it entirely — hence the
 // registry, which bounds them by count and age whatever their hooks did (#541).
 

--- a/server/infra/tmux-routes.ts
+++ b/server/infra/tmux-routes.ts
@@ -31,7 +31,7 @@ export function orphanReapable(resumable: boolean, attachedCount: number | null)
 }
 
 export function mountTmuxRoutes(app: Express, deps: TmuxRouteDeps): void {
-  // Explicit close (the cell's ✕): reap NOW — kill the pty AND its tmux — instead of
+  // Explicit close (the cell's close button): reap NOW — kill the pty AND its tmux — instead of
   // leaving it for the disconnect grace. Works even when the WS is down, and kills a tmux
   // orphaned by a prior server restart (reap alone is a no-op without a live entry).
   app.post("/api/session/:id/terminate", (req, res) => {

--- a/server/session/pty-connection.ts
+++ b/server/session/pty-connection.ts
@@ -86,7 +86,7 @@ export function createConnectionHandlers(deps: ConnectionDeps) {
     }
     try {
       if (msg.type === "terminate") {
-        // Explicit close (the cell's ✕) — reap now instead of waiting out the
+        // Explicit close (the cell's close button) — reap now instead of waiting out the
         // disconnect grace window, so the session slot frees immediately.
         deps.reap(sessionId);
       } else if (msg.type === "view" && typeof msg.active === "boolean") {

--- a/server/session/scheduled-sessions.ts
+++ b/server/session/scheduled-sessions.ts
@@ -1,5 +1,5 @@
 // Registry of the sessions the scheduler spawned (worklog / config/scheduler/tasks.json).
-// Nobody watches these — no ✕ is ever pressed, and a background session blocked on a
+// Nobody watches these — no close button is ever pressed, and a background session blocked on a
 // permission prompt never finishes a turn — so the hook-driven reap machinery can miss
 // them entirely and their tmux sessions pile up (#541: 76 sessions / 41.8 GB).
 //
@@ -146,7 +146,7 @@ export function createScheduledSessionRegistry(deps: ScheduledSessionRegistryDep
   };
 
   // The expired session may be live (kill the pty + its tmux), or a tmux left behind by a
-  // previous server run (kill it directly) — the same two-step the ✕ / terminate route uses.
+  // previous server run (kill it directly) — the same two-step the close button / terminate route uses.
   // Reports whether it actually went, since the in-use check can spare it.
   const evict = async (record: ScheduledSessionRecord): Promise<boolean> => {
     // Checked HERE rather than over the whole set first: sweeping several sessions costs a

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -51,7 +51,7 @@ Mention them when the user's complaint matches one (see each section below).
 
 Read `palettes.json`. Ask for the **vibe** first (four options, one question):
 
-**☀️ Warm** · **❄️ Cool** · **🎨 Bold** · **⚪ Neutral**
+**Warm** · **Cool** · **Bold** · **Neutral**
 
 Describe each preset in that vibe (below), ask which one they want, then apply it. That's the
 big-picture decision; the details come after.
@@ -211,7 +211,7 @@ An array (≤ 16) of display chips, or **omit** the key entirely to keep the def
 
 ### Skill menu — `skills`
 
-The header's **⚡ Skill ▾** dropdown lists this directory's Claude skills (`.claude/skills`,
+The header's **Skill** dropdown lists this directory's Claude skills (`.claude/skills`,
 user + project scope) and runs the picked one in the session. `skills` is an **allowlist
 that also sets the order**: an array (≤ 100) of skill slugs — only these appear, in this
 order. **Omit `skills`** to show every discovered skill (working-dir skills first). Slugs

--- a/server/skills/mulmoterminal-config/SKILL.md
+++ b/server/skills/mulmoterminal-config/SKILL.md
@@ -65,8 +65,8 @@ the user sees nothing. Verified — don't waste a turn on it.
 What to do instead:
 
 1. **Name the colours.** For each candidate give its hex values and one line on how it feels
-   ("terracotta on near-black — cosy, low glare"). Optionally add a rough emoji swatch (🟫 🟦 🟩 ⬛)
-   so there's something to look at.
+   ("terracotta on near-black — cosy, low glare"). Don't try to draw a swatch — apply it (step 2)
+   and let them look at the real cell, which is the only accurate preview anyway.
 2. **Apply, then look at the real thing.** Write the config — the cells for that directory recolour
    **immediately**, no page reload and no server restart. (Writing the file with your Write/Edit tool
    is what tells MulmoTerminal to re-read it, so always write it rather than asking the user to.)
@@ -179,7 +179,7 @@ Absolute paths and `../` escapes are rejected. Omit for the built-in chime.
 An array (≤ 32) of action buttons for a running session's header. Each:
 
 ```json
-{ "id": "build", "emoji": "🔨", "label": "Build", "run": "shell", "cmd": "yarn build", "when": "isGitRepo", "order": 10 }
+{ "id": "build", "icon": "build", "label": "Build", "run": "shell", "cmd": "yarn build", "when": "isGitRepo", "order": 10 }
 ```
 
 **Omit `buttons` entirely** to keep the built-in defaults (a file-path picker + an OS file-manager
@@ -188,7 +188,8 @@ array you write is the whole button row; re-add the file picker with `{ "run": "
 or the in-app file explorer with `{ "run": "open", "open": { "files": "${dir}" } }` if you want them.
 
 - `id` (required, unique), `label` (required), `run` (required): one of `"shell"` / `"input"` / `"open"`.
-- `emoji` or `icon` (a material-symbol name) — optional.
+- `icon` — optional: a [Material Symbols](https://fonts.google.com/icons) name (`build`, `folder`, `bar_chart`).
+  Prefer it. An `emoji` field also exists and wins when both are set, but this project uses icons only.
 - Payload by `run`:
   - `"shell"` → `cmd`: run this command in a command cell (server-resolved by id; never sent to the browser).
   - `"input"` → `text`: send this text to the running Claude/Codex (e.g. `"/compact"`).
@@ -328,7 +329,7 @@ below, and the guide documents them at
 - **`terminal-close` ends the session with no confirmation.** Only bind it if the user asks, and
   suggest a combination they will not hit by accident.
 - This is a partial `POST /api/config` merge — write only `keymap`, so their other settings survive.
-- After writing, tell the user they can check the result in **⚙ Settings → Keyboard shortcuts**, which
+- After writing, tell the user they can check the result in **Settings → Keyboard shortcuts**, which
   lists every action and its binding (read-only).
 - The browser reads the keymap on page load: **reload the tab** after writing. A hand-edit made while
   the server is running also needs a server restart before it reaches the page.
@@ -380,16 +381,16 @@ A warm-clay project with buttons chosen to match what the directory supports:
 
 ```json
 {
-  "name": "✳ my-project",
+  "name": "my-project",
   "badgeColor": "#d97757",
   "headerColor": "#2b1a12",
   "headerTextColor": "#f7e6dc",
   "theme": "midnight",
   "colors": { "background": "#171210", "foreground": "#ece2dc", "cursor": "#d97757" },
   "buttons": [
-    { "id": "compact", "emoji": "🗜️", "label": "Compact", "run": "input", "text": "/compact", "when": "agent == claude" },
-    { "id": "diff", "emoji": "📊", "label": "Diff", "run": "open", "open": { "view": "diff" }, "when": "isGitRepo" },
-    { "id": "reveal", "emoji": "📁", "label": "Reveal", "run": "open", "open": { "reveal": "${dir}" } }
+    { "id": "compact", "icon": "compress", "label": "Compact", "run": "input", "text": "/compact", "when": "agent == claude" },
+    { "id": "diff", "icon": "difference", "label": "Diff", "run": "open", "open": { "view": "diff" }, "when": "isGitRepo" },
+    { "id": "reveal", "icon": "folder", "label": "Reveal", "run": "open", "open": { "reveal": "${dir}" } }
   ]
 }
 ```

--- a/server/skills/mulmoterminal-config/palettes.json
+++ b/server/skills/mulmoterminal-config/palettes.json
@@ -4,7 +4,7 @@
     {
       "id": "warm-clay",
       "vibe": "warm",
-      "label": "☀️ Warm clay",
+      "label": "Warm clay",
       "description": "Terracotta on near-black. Cosy, low-glare, easy on long sessions.",
       "badgeColor": "#d97757",
       "headerColor": "#2b1a12",
@@ -31,7 +31,7 @@
     {
       "id": "tropical",
       "vibe": "warm",
-      "label": "🌴 Tropical",
+      "label": "Tropical",
       "description": "Teal lagoon with coral and sand. Vivid without being harsh.",
       "badgeColor": "#ff6f5e",
       "headerColor": "#06373d",
@@ -58,7 +58,7 @@
     {
       "id": "deep-sea",
       "vibe": "cool",
-      "label": "🌌 Deep sea",
+      "label": "Deep sea",
       "description": "Midnight navy with a clear blue accent. Calm and focused.",
       "badgeColor": "#5aa9e6",
       "headerColor": "#0b1a33",
@@ -85,7 +85,7 @@
     {
       "id": "nordic-frost",
       "vibe": "cool",
-      "label": "❄️ Nordic frost",
+      "label": "Nordic frost",
       "description": "Muted slate blues. Soft contrast, the gentlest on the eyes.",
       "badgeColor": "#88c0d0",
       "headerColor": "#2e3440",
@@ -112,7 +112,7 @@
     {
       "id": "mondrian",
       "vibe": "bold",
-      "label": "🎨 Bold primaries",
+      "label": "Bold primaries",
       "description": "Black, white and primary blocks. Maximum tell-apart in a crowded grid.",
       "badgeColor": "#f5d90a",
       "headerColor": "#0a0a0a",
@@ -139,7 +139,7 @@
     {
       "id": "mono-slate",
       "vibe": "neutral",
-      "label": "⚪ Mono slate",
+      "label": "Mono slate",
       "description": "Greys with barely-there colour. Stays out of the way.",
       "badgeColor": "#9aa4b2",
       "headerColor": "#1b1f24",

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
   addTerminalActive?: boolean;
   autoSort?: boolean;
   statusCounts?: StatusCounts;
-  // Grid zoom state, so the header can host the roster ⇄ strip toggle (shown only while zoomed).
+  // Grid zoom state, so the header can host the roster / strip toggle (shown only while zoomed).
   showViewToggle?: boolean;
   listMode?: boolean;
 }>();
@@ -145,8 +145,8 @@ function showPrs(): void {
         :icon="autoSort ? 'sort' : 'swap_horiz'"
         :title="
           autoSort
-            ? 'Auto order: attention-first — needs-attention cells float up (click for manual ◀▶ ordering)'
-            : 'Manual order: reorder cells with ◀▶ (click for auto attention-sort)'
+            ? 'Auto order: attention-first — needs-attention cells float up (click for manual arrow ordering)'
+            : 'Manual order: reorder cells with the arrow buttons (click for auto attention-sort)'
         "
         label="Toggle grid cell ordering"
         :active="autoSort"

--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -23,7 +23,9 @@ const emit = defineEmits<{ (e: "toggle-expand" | "close"): void }>();
     :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
     @click="emit('toggle-expand')"
   >
-    {{ expanded ? "⤡" : "⤢" }}
+    <span class="material-symbols-outlined">{{ expanded ? "close_fullscreen" : "open_in_full" }}</span>
   </button>
-  <button class="cell-btn cell-close" :class="CELL_CLOSE_BTN" title="Close terminal" aria-label="Close terminal" @click="emit('close')">✕</button>
+  <button class="cell-btn cell-close" :class="CELL_CLOSE_BTN" title="Close terminal" aria-label="Close terminal" @click="emit('close')">
+    <span class="material-symbols-outlined">close</span>
+  </button>
 </template>

--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -23,9 +23,9 @@ const emit = defineEmits<{ (e: "toggle-expand" | "close"): void }>();
     :aria-label="expanded ? 'Restore terminal' : 'Expand terminal'"
     @click="emit('toggle-expand')"
   >
-    <span class="material-symbols-outlined">{{ expanded ? "close_fullscreen" : "open_in_full" }}</span>
+    <span class="material-symbols-outlined" aria-hidden="true">{{ expanded ? "close_fullscreen" : "open_in_full" }}</span>
   </button>
   <button class="cell-btn cell-close" :class="CELL_CLOSE_BTN" title="Close terminal" aria-label="Close terminal" @click="emit('close')">
-    <span class="material-symbols-outlined">close</span>
+    <span class="material-symbols-outlined" aria-hidden="true">close</span>
   </button>
 </template>

--- a/src/components/CockpitRowMenu.vue
+++ b/src/components/CockpitRowMenu.vue
@@ -68,7 +68,7 @@ onBeforeUnmount(close);
       title="並べ替え"
       @click="toggle"
     >
-      <span class="material-symbols-outlined">more_vert</span>
+      <span class="material-symbols-outlined" aria-hidden="true">more_vert</span>
     </button>
     <Teleport to="body">
       <div
@@ -88,7 +88,7 @@ onBeforeUnmount(close);
           :disabled="!canUp"
           @click="pick(-1)"
         >
-          <span class="material-symbols-outlined w-3.5 text-center text-[#4a9eff]">arrow_upward</span> 上へ移動
+          <span class="material-symbols-outlined w-3.5 text-center text-[#4a9eff]" aria-hidden="true">arrow_upward</span> 上へ移動
         </button>
         <button
           type="button"
@@ -98,7 +98,7 @@ onBeforeUnmount(close);
           :disabled="!canDown"
           @click="pick(1)"
         >
-          <span class="material-symbols-outlined w-3.5 text-center text-[#4a9eff]">arrow_downward</span> 下へ移動
+          <span class="material-symbols-outlined w-3.5 text-center text-[#4a9eff]" aria-hidden="true">arrow_downward</span> 下へ移動
         </button>
       </div>
     </Teleport>

--- a/src/components/CockpitRowMenu.vue
+++ b/src/components/CockpitRowMenu.vue
@@ -68,7 +68,7 @@ onBeforeUnmount(close);
       title="並べ替え"
       @click="toggle"
     >
-      ⋮
+      <span class="material-symbols-outlined">more_vert</span>
     </button>
     <Teleport to="body">
       <div
@@ -88,7 +88,7 @@ onBeforeUnmount(close);
           :disabled="!canUp"
           @click="pick(-1)"
         >
-          <span class="w-3.5 text-center font-mono text-[#4a9eff]">↑</span> 上へ移動
+          <span class="material-symbols-outlined w-3.5 text-center text-[#4a9eff]">arrow_upward</span> 上へ移動
         </button>
         <button
           type="button"
@@ -98,7 +98,7 @@ onBeforeUnmount(close);
           :disabled="!canDown"
           @click="pick(1)"
         >
-          <span class="w-3.5 text-center font-mono text-[#4a9eff]">↓</span> 下へ移動
+          <span class="material-symbols-outlined w-3.5 text-center text-[#4a9eff]">arrow_downward</span> 下へ移動
         </button>
       </div>
     </Teleport>

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -26,7 +26,7 @@ import {
   CELL_TERM,
 } from "./cellChromeClasses";
 
-// The summarize button's own colours, and the smaller ✕ on the summary panel. One complete
+// The summarize button's own colours, and the smaller close button on the summary panel. One complete
 // string per state rather than a base plus an override: two utilities for the same property
 // on one element are resolved by Tailwind's output order, not by the order written here.
 const SUMMARIZE_READY = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} cursor-pointer text-[#9db4ff] hover:bg-[#24305c] hover:text-[#cdd8ff]`;
@@ -40,7 +40,7 @@ const SUMMARY_CLOSE_BTN = `${CELL_BTN_BOX} h-[22px] w-[22px] text-[13px] ${CELL_
 const props = defineProps<
   GridCellProps & {
     command: RunCommand;
-    // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+    // Manual sort mode: show move buttons to swap this cell with its neighbour.
     reorderable?: boolean;
   }
 >();
@@ -163,11 +163,17 @@ function onHeaderClick(event: MouseEvent) {
       <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="command.cwd ?? ''"
         ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
       >
-      <span class="cell-cmd" :class="CELL_CMD">▶ {{ command.label }}</span>
+      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined">play_arrow</span> {{ command.label }}</span>
       <span class="cell-actions" :class="CELL_ACTIONS">
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move command left" @click="emit('move', -1)">◀</button>
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move command right" @click="emit('move', 1)">▶</button>
-        <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Re-run" aria-label="Re-run command" @click="rerun">↻</button>
+        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move command left" @click="emit('move', -1)">
+          <span class="material-symbols-outlined">chevron_left</span>
+        </button>
+        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move command right" @click="emit('move', 1)">
+          <span class="material-symbols-outlined">chevron_right</span>
+        </button>
+        <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Re-run" aria-label="Re-run command" @click="rerun">
+          <span class="material-symbols-outlined">refresh</span>
+        </button>
         <button
           class="cell-btn cell-summarize"
           :class="summaryState === 'loading' ? `is-busy ${SUMMARIZE_BUSY}` : SUMMARIZE_READY"
@@ -176,7 +182,7 @@ function onHeaderClick(event: MouseEvent) {
           :disabled="summaryState === 'loading'"
           @click="summarize"
         >
-          {{ summaryState === "loading" ? "⋯" : "✦" }}
+          <span class="material-symbols-outlined">{{ summaryState === "loading" ? "more_horiz" : "auto_awesome" }}</span>
         </button>
         <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
       </span>
@@ -195,9 +201,11 @@ function onHeaderClick(event: MouseEvent) {
     />
     <div v-if="showSummary" data-testid="cell-summary" class="flex max-h-[40%] min-h-0 flex-none flex-col border-t border-t-[#2a2a4e] bg-[#141b33]">
       <div class="flex flex-none items-center justify-between border-b border-b-[#232a48] py-0.5 pl-2.5 pr-1.5">
-        <span class="font-sans text-[11px] font-semibold text-[#9db4ff]">✦ Summary</span>
+        <span class="inline-flex items-center gap-1 font-sans text-[11px] font-semibold text-[#9db4ff]"
+          ><span class="material-symbols-outlined">auto_awesome</span> Summary</span
+        >
         <button class="cell-btn cell-summary-close" :class="SUMMARY_CLOSE_BTN" title="Dismiss summary" aria-label="Dismiss summary" @click="closeSummary">
-          ✕
+          <span class="material-symbols-outlined">close</span>
         </button>
       </div>
       <div class="min-h-0 flex-auto overflow-auto px-2.5 pb-2 pt-1.5">
@@ -224,11 +232,11 @@ function onHeaderClick(event: MouseEvent) {
             <button
               type="button"
               data-testid="cell-summary-continue"
-              class="cursor-pointer rounded-md border border-[#3b4a7a] bg-[#232a45] px-2.5 py-1 font-sans text-[12px] text-[#cdd6ff] hover:bg-[#2c355a]"
+              class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-[#3b4a7a] bg-[#232a45] px-2.5 py-1 font-sans text-[12px] text-[#cdd6ff] hover:bg-[#2c355a]"
               title="Copy this as a prompt to paste into a Claude session"
               @click="copyPrompt"
             >
-              {{ copied ? "✓ Copied" : "⧉ Copy as prompt" }}
+              <span class="material-symbols-outlined">{{ copied ? "check" : "content_copy" }}</span> {{ copied ? "Copied" : "Copy as prompt" }}
             </button>
           </div>
         </template>

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -163,16 +163,16 @@ function onHeaderClick(event: MouseEvent) {
       <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="command.cwd ?? ''"
         ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
       >
-      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined">play_arrow</span> {{ command.label }}</span>
+      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ command.label }}</span>
       <span class="cell-actions" :class="CELL_ACTIONS">
         <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move command left" @click="emit('move', -1)">
-          <span class="material-symbols-outlined">chevron_left</span>
+          <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
         </button>
         <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move command right" @click="emit('move', 1)">
-          <span class="material-symbols-outlined">chevron_right</span>
+          <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
         </button>
         <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Re-run" aria-label="Re-run command" @click="rerun">
-          <span class="material-symbols-outlined">refresh</span>
+          <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
         </button>
         <button
           class="cell-btn cell-summarize"
@@ -182,7 +182,7 @@ function onHeaderClick(event: MouseEvent) {
           :disabled="summaryState === 'loading'"
           @click="summarize"
         >
-          <span class="material-symbols-outlined">{{ summaryState === "loading" ? "more_horiz" : "auto_awesome" }}</span>
+          <span class="material-symbols-outlined" aria-hidden="true">{{ summaryState === "loading" ? "more_horiz" : "auto_awesome" }}</span>
         </button>
         <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
       </span>
@@ -202,10 +202,10 @@ function onHeaderClick(event: MouseEvent) {
     <div v-if="showSummary" data-testid="cell-summary" class="flex max-h-[40%] min-h-0 flex-none flex-col border-t border-t-[#2a2a4e] bg-[#141b33]">
       <div class="flex flex-none items-center justify-between border-b border-b-[#232a48] py-0.5 pl-2.5 pr-1.5">
         <span class="inline-flex items-center gap-1 font-sans text-[11px] font-semibold text-[#9db4ff]"
-          ><span class="material-symbols-outlined">auto_awesome</span> Summary</span
+          ><span class="material-symbols-outlined" aria-hidden="true">auto_awesome</span> Summary</span
         >
         <button class="cell-btn cell-summary-close" :class="SUMMARY_CLOSE_BTN" title="Dismiss summary" aria-label="Dismiss summary" @click="closeSummary">
-          <span class="material-symbols-outlined">close</span>
+          <span class="material-symbols-outlined" aria-hidden="true">close</span>
         </button>
       </div>
       <div class="min-h-0 flex-auto overflow-auto px-2.5 pb-2 pt-1.5">
@@ -236,7 +236,8 @@ function onHeaderClick(event: MouseEvent) {
               title="Copy this as a prompt to paste into a Claude session"
               @click="copyPrompt"
             >
-              <span class="material-symbols-outlined">{{ copied ? "check" : "content_copy" }}</span> {{ copied ? "Copied" : "Copy as prompt" }}
+              <span class="material-symbols-outlined" aria-hidden="true">{{ copied ? "check" : "content_copy" }}</span>
+              {{ copied ? "Copied" : "Copy as prompt" }}
             </button>
           </div>
         </template>

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -253,7 +253,7 @@ onBeforeUnmount(() => {
         aria-label="Reload tree"
         @click="loadRoot"
       >
-        ↻
+        <span class="material-symbols-outlined">refresh</span>
       </button>
       <button
         type="button"
@@ -262,7 +262,7 @@ onBeforeUnmount(() => {
         aria-label="Close files"
         @click="requestClose"
       >
-        ✕
+        <span class="material-symbols-outlined">close</span>
       </button>
     </header>
     <div class="flex min-h-0 flex-auto">
@@ -279,8 +279,10 @@ onBeforeUnmount(() => {
           :style="{ paddingLeft: `${8 + depth * 14}px` }"
           @click="openFile(node)"
         >
-          <span class="w-2.5 flex-none text-dim">{{ node.dir ? (node.expanded ? "▾" : "▸") : "" }}</span>
-          <span class="flex-none">{{ node.dir ? "📁" : "📄" }}</span>
+          <span class="w-3.5 flex-none text-dim">
+            <span v-if="node.dir" class="material-symbols-outlined">{{ node.expanded ? "expand_more" : "chevron_right" }}</span>
+          </span>
+          <span class="material-symbols-outlined flex-none">{{ node.dir ? "folder" : "description" }}</span>
           <span class="truncate">{{ node.name }}</span>
         </button>
       </nav>

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -253,7 +253,7 @@ onBeforeUnmount(() => {
         aria-label="Reload tree"
         @click="loadRoot"
       >
-        <span class="material-symbols-outlined">refresh</span>
+        <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
       </button>
       <button
         type="button"
@@ -262,7 +262,7 @@ onBeforeUnmount(() => {
         aria-label="Close files"
         @click="requestClose"
       >
-        <span class="material-symbols-outlined">close</span>
+        <span class="material-symbols-outlined" aria-hidden="true">close</span>
       </button>
     </header>
     <div class="flex min-h-0 flex-auto">
@@ -280,9 +280,9 @@ onBeforeUnmount(() => {
           @click="openFile(node)"
         >
           <span class="w-3.5 flex-none text-dim">
-            <span v-if="node.dir" class="material-symbols-outlined">{{ node.expanded ? "expand_more" : "chevron_right" }}</span>
+            <span v-if="node.dir" class="material-symbols-outlined" aria-hidden="true">{{ node.expanded ? "expand_more" : "chevron_right" }}</span>
           </span>
-          <span class="material-symbols-outlined flex-none">{{ node.dir ? "folder" : "description" }}</span>
+          <span class="material-symbols-outlined flex-none" aria-hidden="true">{{ node.dir ? "folder" : "description" }}</span>
           <span class="truncate">{{ node.name }}</span>
         </button>
       </nav>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -267,7 +267,7 @@ const syncPoll = () => (rosterVisible() ? startPoll() : stopPoll());
 // immediate: a reload that restores a zoomed grid sets expandedUid up front (no "change"
 // to react to), so start here too, or the roster would freeze at its first snapshot.
 watch(expandedUid, syncPoll, { immediate: true });
-// The header's view toggle (shown only while zoomed) flips roster ⇄ thumbnail strip; the poll
+// The header's view toggle (shown only while zoomed) flips roster / thumbnail strip; the poll
 // follows since the roster is its sole consumer.
 const toggleListMode = () => {
   listModeOn.value = !listModeOn.value;
@@ -301,7 +301,7 @@ const listRows = computed(() =>
   }),
 );
 // The cancelable trailing launch cell's uid (null when there's nothing to cancel):
-// drives both the toolbar's cancel state and the launcher's in-cell ✕.
+// drives both the toolbar's cancel state and the launcher's in-cell close button.
 const cancelUid = computed(() => cancelableLaunchUid(state.value));
 const launchOpen = computed(() => cancelUid.value !== null);
 // Session ids currently held by cells (across all pages — off-page cells stay

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -79,7 +79,7 @@ const hasContent = computed(() => results.value.length > 0);
         aria-label="Open tools pane"
         @click="emit('toggleTools')"
       >
-        <span class="material-symbols-outlined">build</span>
+        <span class="material-symbols-outlined" aria-hidden="true">build</span>
       </button>
     </div>
     <div class="flex-1 overflow-y-auto px-4 py-3 font-sans text-[14px] leading-normal text-fg">

--- a/src/components/GuideLinks.vue
+++ b/src/components/GuideLinks.vue
@@ -11,7 +11,7 @@ const LINK_CLASS = "font-medium text-accent hover:underline";
 
 <template>
   <p class="m-0 font-sans text-[12px] text-dim">
-    <span class="material-symbols-outlined">menu_book</span> Not sure how to use MulmoTerminal? Read the guide —
+    <span class="material-symbols-outlined" aria-hidden="true">menu_book</span> Not sure how to use MulmoTerminal? Read the guide —
     <a :class="LINK_CLASS" :href="GUIDE_JA" target="_blank" rel="noopener noreferrer">日本語</a>
     <span aria-hidden="true"> · </span>
     <a :class="LINK_CLASS" :href="GUIDE_EN" target="_blank" rel="noopener noreferrer">English</a>

--- a/src/components/GuideLinks.vue
+++ b/src/components/GuideLinks.vue
@@ -11,7 +11,7 @@ const LINK_CLASS = "font-medium text-accent hover:underline";
 
 <template>
   <p class="m-0 font-sans text-[12px] text-dim">
-    📖 Not sure how to use MulmoTerminal? Read the guide —
+    <span class="material-symbols-outlined">menu_book</span> Not sure how to use MulmoTerminal? Read the guide —
     <a :class="LINK_CLASS" :href="GUIDE_JA" target="_blank" rel="noopener noreferrer">日本語</a>
     <span aria-hidden="true"> · </span>
     <a :class="LINK_CLASS" :href="GUIDE_EN" target="_blank" rel="noopener noreferrer">English</a>

--- a/src/components/LauncherButton.vue
+++ b/src/components/LauncherButton.vue
@@ -21,6 +21,6 @@ defineEmits<{ (e: "click"): void }>();
     :aria-pressed="ariaPressed"
     @click="$emit('click')"
   >
-    <span class="material-symbols-outlined text-[19px] leading-none">{{ icon }}</span>
+    <span class="material-symbols-outlined text-[19px] leading-none" aria-hidden="true">{{ icon }}</span>
   </button>
 </template>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -33,7 +33,7 @@ const props = defineProps<
     launcher: CellLauncher;
     session: string | null;
     cwd: string | null;
-    // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+    // Manual sort mode: show move buttons to swap this cell with its neighbour.
     reorderable?: boolean;
   }
 >();
@@ -83,11 +83,17 @@ function relaunch() {
       <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="cwd ?? ''"
         ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
       >
-      <span class="cell-cmd" :class="CELL_CMD">⌘ {{ launcher.label }}</span>
+      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined">rocket_launch</span> {{ launcher.label }}</span>
       <span class="cell-actions" :class="CELL_ACTIONS">
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">◀</button>
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move launcher right" @click="emit('move', 1)">▶</button>
-        <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Relaunch" aria-label="Relaunch" @click="relaunch">↻</button>
+        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">
+          <span class="material-symbols-outlined">chevron_left</span>
+        </button>
+        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move launcher right" @click="emit('move', 1)">
+          <span class="material-symbols-outlined">chevron_right</span>
+        </button>
+        <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Relaunch" aria-label="Relaunch" @click="relaunch">
+          <span class="material-symbols-outlined">refresh</span>
+        </button>
         <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
       </span>
     </div>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -83,16 +83,16 @@ function relaunch() {
       <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="cwd ?? ''"
         ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
       >
-      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined">rocket_launch</span> {{ launcher.label }}</span>
+      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">rocket_launch</span> {{ launcher.label }}</span>
       <span class="cell-actions" :class="CELL_ACTIONS">
         <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">
-          <span class="material-symbols-outlined">chevron_left</span>
+          <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
         </button>
         <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move launcher right" @click="emit('move', 1)">
-          <span class="material-symbols-outlined">chevron_right</span>
+          <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
         </button>
         <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Relaunch" aria-label="Relaunch" @click="relaunch">
-          <span class="material-symbols-outlined">refresh</span>
+          <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
         </button>
         <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
       </span>

--- a/src/components/ModelSetupHelp.vue
+++ b/src/components/ModelSetupHelp.vue
@@ -62,7 +62,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
       <div class="flex items-start justify-between gap-3">
         <h2 class="m-0 font-sans text-[15px] font-semibold text-fg">Running a session on another model</h2>
         <button type="button" class="cursor-pointer border-none bg-transparent p-0 text-dim hover:text-fg" aria-label="Close" @click="emit('close')">
-          <span class="material-symbols-outlined text-[20px]">close</span>
+          <span class="material-symbols-outlined text-[20px]" aria-hidden="true">close</span>
         </button>
       </div>
 

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -94,7 +94,7 @@ function bellColorClass(severity: NotifierSeverity): string {
           aria-label="Dismiss notification"
           @click.stop="dismiss(entry.id)"
         >
-          <span class="material-symbols-outlined text-[16px] leading-none">close</span>
+          <span class="material-symbols-outlined text-[16px] leading-none" aria-hidden="true">close</span>
         </button>
       </li>
     </ul>

--- a/src/components/NotificationBell.vue
+++ b/src/components/NotificationBell.vue
@@ -10,7 +10,7 @@ import { shortPkg } from "./shortPkg";
 // per row, title + lifecycle tag, a "relative-time · source" meta line, an
 // "Active (N)" header) in MulmoTerminal's dark palette. A row click navigates to the
 // entry's target (a completion bell's pending record) WITHOUT clearing it — the
-// watcher clears it when the record is done; the ✕ dismisses it explicitly.
+// watcher clears it when the record is done; the close button dismisses it explicitly.
 const { count, topSeverity, sorted, dismiss, activate } = useNotifications();
 
 const popoverRef = useTemplateRef<InstanceType<typeof ToolbarPopover>>("popover");

--- a/src/components/PinToggle.vue
+++ b/src/components/PinToggle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-// The ★ favorite toggle the collection plugin renders (via the binding's
+// The favorite toggle the collection plugin renders (via the binding's
 // `pinToggle`) on index cards + the view header. Talks to the useShortcuts
 // singleton directly — a parent only supplies the target's identity + cached
 // label/icon. Click/keyboard activation are stopped so toggling never also opens

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -82,7 +82,7 @@ useEscapeToClose(isOpen, close);
         aria-label="Reload PR and issue list"
         @click="load"
       >
-        <span class="material-symbols-outlined">refresh</span>
+        <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
       </button>
       <span v-if="loading" class="text-[12px] text-muted">Loading…</span>
     </header>

--- a/src/components/PrsOverlay.vue
+++ b/src/components/PrsOverlay.vue
@@ -82,13 +82,13 @@ useEscapeToClose(isOpen, close);
         aria-label="Reload PR and issue list"
         @click="load"
       >
-        ↻
+        <span class="material-symbols-outlined">refresh</span>
       </button>
       <span v-if="loading" class="text-[12px] text-muted">Loading…</span>
     </header>
     <div class="flex-auto overflow-y-auto px-4 pb-16 pt-3">
       <p v-if="!loading && !prsError && !issuesError && repos.length === 0 && issueRepos.length === 0" class="px-1 py-6 text-[13px] text-muted">
-        No repositories configured. Add <code>owner/repo</code> entries under Settings (⚙) → Pull request repos.
+        No repositories configured. Add <code>owner/repo</code> entries under Settings → Pull request repos.
       </p>
       <template v-else>
         <h2

--- a/src/components/RemoteHostControl.vue
+++ b/src/components/RemoteHostControl.vue
@@ -167,7 +167,7 @@ onUnmounted(() => stopSelfHeal?.());
     @open="onPopoverOpen"
   >
     <div class="flex items-center gap-1.5">
-      <span class="material-symbols-outlined text-[16px] leading-none" :class="view.toneClass">
+      <span class="material-symbols-outlined text-[16px] leading-none" :class="view.toneClass" aria-hidden="true">
         {{ view.icon }}
       </span>
       <span class="text-[12px] font-semibold text-fg">{{ view.label }}</span>
@@ -186,7 +186,7 @@ onUnmounted(() => stopSelfHeal?.());
       :disabled="busy"
       @click="onConnect"
     >
-      <span class="material-symbols-outlined text-[16px] leading-none">login</span>
+      <span class="material-symbols-outlined text-[16px] leading-none" aria-hidden="true">login</span>
       {{ busy ? "Connecting…" : "Connect (Google sign-in)" }}
     </button>
     <button
@@ -196,7 +196,7 @@ onUnmounted(() => stopSelfHeal?.());
       :disabled="busy"
       @click="onDisconnect"
     >
-      <span class="material-symbols-outlined text-[16px] leading-none">logout</span>
+      <span class="material-symbols-outlined text-[16px] leading-none" aria-hidden="true">logout</span>
       {{ busy ? "Disconnecting…" : "Disconnect" }}
     </button>
 

--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -63,13 +63,14 @@ function pick(s: RunnableScript) {
 <template>
   <div v-if="scripts.length" ref="root" class="relative inline-flex">
     <button
-      class="border border-border bg-base text-secondary font-sans text-[12px] leading-none py-[5px] px-2.5 rounded-md cursor-pointer hover:bg-hover hover:text-fg aria-expanded:bg-hover aria-expanded:text-fg"
+      class="inline-flex items-center gap-1 border border-border bg-base text-secondary font-sans text-[12px] leading-none py-[5px] px-2.5 rounded-md cursor-pointer hover:bg-hover hover:text-fg aria-expanded:bg-hover aria-expanded:text-fg"
       :aria-expanded="open"
       aria-haspopup="menu"
       title="Run a script in a spare terminal"
       @click="toggle"
     >
-      ▶ Run ▾
+      <span class="material-symbols-outlined">play_arrow</span> Run
+      <span class="material-symbols-outlined">{{ open ? "expand_less" : "expand_more" }}</span>
     </button>
     <div
       v-if="open"
@@ -79,12 +80,12 @@ function pick(s: RunnableScript) {
       <button
         v-for="s in scripts"
         :key="s.index"
-        class="text-left border-0 bg-transparent text-secondary font-mono text-[12px] py-1.5 px-2 rounded cursor-pointer whitespace-nowrap hover:bg-hover hover:text-fg"
+        class="inline-flex items-center gap-1 text-left border-0 bg-transparent text-secondary font-mono text-[12px] py-1.5 px-2 rounded cursor-pointer whitespace-nowrap hover:bg-hover hover:text-fg"
         role="menuitem"
         :title="s.command"
         @click="pick(s)"
       >
-        ▶ {{ s.label }}
+        <span class="material-symbols-outlined">play_arrow</span> {{ s.label }}
       </button>
     </div>
   </div>

--- a/src/components/RunMenu.vue
+++ b/src/components/RunMenu.vue
@@ -69,8 +69,8 @@ function pick(s: RunnableScript) {
       title="Run a script in a spare terminal"
       @click="toggle"
     >
-      <span class="material-symbols-outlined">play_arrow</span> Run
-      <span class="material-symbols-outlined">{{ open ? "expand_less" : "expand_more" }}</span>
+      <span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> Run
+      <span class="material-symbols-outlined" aria-hidden="true">{{ open ? "expand_less" : "expand_more" }}</span>
     </button>
     <div
       v-if="open"
@@ -85,7 +85,7 @@ function pick(s: RunnableScript) {
         :title="s.command"
         @click="pick(s)"
       >
-        <span class="material-symbols-outlined">play_arrow</span> {{ s.label }}
+        <span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ s.label }}
       </button>
     </div>
   </div>

--- a/src/components/SessionFilters.vue
+++ b/src/components/SessionFilters.vue
@@ -26,6 +26,6 @@ const emit = defineEmits<{
     aria-label="Sort by most recent"
     @click="emit('refresh')"
   >
-    <span class="material-symbols-outlined">refresh</span>
+    <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
   </button>
 </template>

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -26,7 +26,7 @@ const visibleSessions = computed(() => filteredSessions.value.slice(0, MAX_TABS)
       aria-label="New session"
       @click="emit('new')"
     >
-      <span class="material-symbols-outlined">add</span>
+      <span class="material-symbols-outlined" aria-hidden="true">add</span>
     </button>
     <button
       class="h-[26px] w-[26px] shrink-0 cursor-pointer rounded-md border-0 bg-selected text-[12px] font-semibold uppercase leading-none text-secondary hover:bg-selected-hover"
@@ -69,7 +69,7 @@ const visibleSessions = computed(() => filteredSessions.value.slice(0, MAX_TABS)
         aria-label="Switch to vertical sidebar"
         @click="emit('toggle-layout')"
       >
-        <span class="material-symbols-outlined">dock_to_right</span>
+        <span class="material-symbols-outlined" aria-hidden="true">dock_to_right</span>
       </button>
     </div>
   </div>

--- a/src/components/SettingsButton.vue
+++ b/src/components/SettingsButton.vue
@@ -8,7 +8,7 @@ defineProps<{ primary?: boolean }>();
 <template>
   <button
     type="button"
-    class="cursor-pointer rounded-md border px-3.5 py-1.5 text-[13px] disabled:cursor-default disabled:opacity-60"
+    class="inline-flex cursor-pointer items-center gap-1 rounded-md border px-3.5 py-1.5 text-[13px] disabled:cursor-default disabled:opacity-60"
     :class="
       primary ? 'border-accent bg-accent-bg text-on-accent hover:bg-accent-bg-hover' : 'border-border bg-elevated text-secondary hover:bg-hover hover:text-fg'
     "

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -172,8 +172,8 @@ function onPushToggle(e: Event) {
 // a blocked agent raises. Editable list mirroring the saved value, like the other lists here.
 const PUSH_KIND_LABEL: Record<PushKind, string> = { finished: "Turn finished", waiting: "Waiting for you" };
 const PUSH_KIND_HELP: Record<PushKind, string> = {
-  finished: "the agent replied and the output is unread (✅)",
-  waiting: "it stopped to ask — a permission prompt or a question (❓). Fires once per prompt, so a task that asks a lot pushes a lot",
+  finished: "the agent replied and the output is unread",
+  waiting: "it stopped to ask — a permission prompt or a question. Fires once per prompt, so a task that asks a lot pushes a lot",
 };
 const pushKindList = ref<PushKind[]>([...(props.pushKinds ?? [])]);
 watch(
@@ -310,7 +310,7 @@ onUnmounted(() => {
           aria-label="Close settings"
           @click="emit('close')"
         >
-          ✕
+          <span class="material-symbols-outlined">close</span>
         </button>
       </div>
 
@@ -342,7 +342,7 @@ onUnmounted(() => {
         Launch the <code>mulmoterminal-config</code> skill to style a directory — name badge, colors, terminal palette, header buttons. It configures the
         focused session's directory, or lets you pick from your recent directories.
       </p>
-      <SettingsButton @click="emit('configure-appearance')">🎨 Configure appearance…</SettingsButton>
+      <SettingsButton @click="emit('configure-appearance')"><span class="material-symbols-outlined">palette</span> Configure appearance…</SettingsButton>
 
       <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Notification sound</h3>
       <p class="mb-3 mt-1.5 text-[12px] text-dim">
@@ -360,7 +360,7 @@ onUnmounted(() => {
         <SettingsButton @click="browseSound">Browse…</SettingsButton>
       </div>
       <div class="mt-2 flex gap-2">
-        <SettingsButton title="Play the current sound" @click="testSound">▶ Test</SettingsButton>
+        <SettingsButton title="Play the current sound" @click="testSound"><span class="material-symbols-outlined">play_arrow</span> Test</SettingsButton>
         <SettingsButton :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</SettingsButton>
       </div>
 
@@ -424,7 +424,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${r}`"
             @click="removeRepo(r)"
           >
-            ✕
+            <span class="material-symbols-outlined">close</span>
           </button>
         </li>
       </ul>
@@ -456,7 +456,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${l.label}`"
             @click="removeLauncher(l.label)"
           >
-            ✕
+            <span class="material-symbols-outlined">close</span>
           </button>
         </li>
       </ul>
@@ -498,7 +498,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${c.label}`"
             @click="removeQuickCommand(c.label)"
           >
-            ✕
+            <span class="material-symbols-outlined">close</span>
           </button>
         </li>
       </ul>
@@ -553,7 +553,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${s.id}`"
             @click="removeMcpServer(s.id)"
           >
-            ✕
+            <span class="material-symbols-outlined">close</span>
           </button>
         </li>
       </ul>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -310,7 +310,7 @@ onUnmounted(() => {
           aria-label="Close settings"
           @click="emit('close')"
         >
-          <span class="material-symbols-outlined">close</span>
+          <span class="material-symbols-outlined" aria-hidden="true">close</span>
         </button>
       </div>
 
@@ -342,7 +342,9 @@ onUnmounted(() => {
         Launch the <code>mulmoterminal-config</code> skill to style a directory — name badge, colors, terminal palette, header buttons. It configures the
         focused session's directory, or lets you pick from your recent directories.
       </p>
-      <SettingsButton @click="emit('configure-appearance')"><span class="material-symbols-outlined">palette</span> Configure appearance…</SettingsButton>
+      <SettingsButton @click="emit('configure-appearance')"
+        ><span class="material-symbols-outlined" aria-hidden="true">palette</span> Configure appearance…</SettingsButton
+      >
 
       <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Notification sound</h3>
       <p class="mb-3 mt-1.5 text-[12px] text-dim">
@@ -360,7 +362,9 @@ onUnmounted(() => {
         <SettingsButton @click="browseSound">Browse…</SettingsButton>
       </div>
       <div class="mt-2 flex gap-2">
-        <SettingsButton title="Play the current sound" @click="testSound"><span class="material-symbols-outlined">play_arrow</span> Test</SettingsButton>
+        <SettingsButton title="Play the current sound" @click="testSound"
+          ><span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> Test</SettingsButton
+        >
         <SettingsButton :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</SettingsButton>
       </div>
 
@@ -424,7 +428,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${r}`"
             @click="removeRepo(r)"
           >
-            <span class="material-symbols-outlined">close</span>
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
           </button>
         </li>
       </ul>
@@ -456,7 +460,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${l.label}`"
             @click="removeLauncher(l.label)"
           >
-            <span class="material-symbols-outlined">close</span>
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
           </button>
         </li>
       </ul>
@@ -498,7 +502,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${c.label}`"
             @click="removeQuickCommand(c.label)"
           >
-            <span class="material-symbols-outlined">close</span>
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
           </button>
         </li>
       </ul>
@@ -553,7 +557,7 @@ onUnmounted(() => {
             :aria-label="`Remove ${s.id}`"
             @click="removeMcpServer(s.id)"
           >
-            <span class="material-symbols-outlined">close</span>
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
           </button>
         </li>
       </ul>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -28,7 +28,7 @@ const { unreadCount, filteredSessions, isUnread } = useSessionFilter(props);
         aria-label="Switch to horizontal tabs"
         @click="emit('toggle-layout')"
       >
-        <span class="material-symbols-outlined">toolbar</span>
+        <span class="material-symbols-outlined" aria-hidden="true">toolbar</span>
       </button>
     </div>
 
@@ -37,14 +37,14 @@ const { unreadCount, filteredSessions, isUnread } = useSessionFilter(props);
         class="flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md border-0 bg-selected p-2 text-[13px] text-secondary hover:bg-selected-hover"
         @click="emit('new')"
       >
-        <span class="material-symbols-outlined text-[18px]">add</span> New session
+        <span class="material-symbols-outlined text-[18px]" aria-hidden="true">add</span> New session
       </button>
       <button
         class="flex cursor-pointer items-center justify-center gap-1.5 rounded-md border-0 bg-selected p-2 text-[13px] text-secondary hover:bg-selected-hover"
         title="New Codex session"
         @click="emit('new-codex')"
       >
-        <span class="material-symbols-outlined text-[18px]">add</span> Codex
+        <span class="material-symbols-outlined text-[18px]" aria-hidden="true">add</span> Codex
       </button>
     </div>
 

--- a/src/components/SkillMenu.vue
+++ b/src/components/SkillMenu.vue
@@ -61,8 +61,8 @@ function pick(s: DiscoveredSkill) {
       title="Run a skill in the current session"
       @click="toggle"
     >
-      <span class="material-symbols-outlined">bolt</span> Skill
-      <span class="material-symbols-outlined">{{ open ? "expand_less" : "expand_more" }}</span>
+      <span class="material-symbols-outlined" aria-hidden="true">bolt</span> Skill
+      <span class="material-symbols-outlined" aria-hidden="true">{{ open ? "expand_less" : "expand_more" }}</span>
     </button>
     <div
       v-if="open"
@@ -77,7 +77,7 @@ function pick(s: DiscoveredSkill) {
         :title="s.description"
         @click="pick(s)"
       >
-        <span class="material-symbols-outlined">bolt</span> {{ s.slug }}
+        <span class="material-symbols-outlined" aria-hidden="true">bolt</span> {{ s.slug }}
       </button>
     </div>
   </div>

--- a/src/components/SkillMenu.vue
+++ b/src/components/SkillMenu.vue
@@ -55,13 +55,14 @@ function pick(s: DiscoveredSkill) {
 <template>
   <div v-if="skills.length" ref="root" class="relative inline-flex">
     <button
-      class="border border-border bg-base text-secondary font-sans text-[12px] leading-none py-[5px] px-2.5 rounded-md cursor-pointer hover:bg-hover hover:text-fg aria-expanded:bg-hover aria-expanded:text-fg"
+      class="inline-flex items-center gap-1 border border-border bg-base text-secondary font-sans text-[12px] leading-none py-[5px] px-2.5 rounded-md cursor-pointer hover:bg-hover hover:text-fg aria-expanded:bg-hover aria-expanded:text-fg"
       :aria-expanded="open"
       aria-haspopup="menu"
       title="Run a skill in the current session"
       @click="toggle"
     >
-      ⚡ Skill ▾
+      <span class="material-symbols-outlined">bolt</span> Skill
+      <span class="material-symbols-outlined">{{ open ? "expand_less" : "expand_more" }}</span>
     </button>
     <div
       v-if="open"
@@ -71,12 +72,12 @@ function pick(s: DiscoveredSkill) {
       <button
         v-for="s in skills"
         :key="s.slug"
-        class="text-left border-0 bg-transparent text-secondary font-mono text-[12px] py-1.5 px-2 rounded cursor-pointer whitespace-nowrap hover:bg-hover hover:text-fg"
+        class="inline-flex items-center gap-1 text-left border-0 bg-transparent text-secondary font-mono text-[12px] py-1.5 px-2 rounded cursor-pointer whitespace-nowrap hover:bg-hover hover:text-fg"
         role="menuitem"
         :title="s.description"
         @click="pick(s)"
       >
-        ⚡ {{ s.slug }}
+        <span class="material-symbols-outlined">bolt</span> {{ s.slug }}
       </button>
     </div>
   </div>

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -31,9 +31,9 @@ import type { LaunchChoice } from "./wsUrl";
 // `command` switches the terminal to a plain shell command (the grid's Run menu):
 // it connects to /ws/run with the script index instead of resuming a Claude
 // session, and never auto-reconnects (the ephemeral process can't be resumed).
-// `runMenu` adds a ▶ Run dropdown to the header (the single view) that lists the
+// `runMenu` adds a Run dropdown to the header (the single view) that lists the
 // open project's script.json and emits the picked command for the parent to run,
-// plus a ⚡ Skill dropdown that lists the project's .claude/skills and invokes the
+// plus a Skill dropdown that lists the project's .claude/skills and invokes the
 // picked one in this session (types its /<slug>).
 // `persistKey` opts this terminal into a durable connection (kept alive across
 // unmount via useTerminalConnections, keyed by this stable slot id — the grid cell's
@@ -287,7 +287,7 @@ watch(
 onUnmounted(() => clearTimeout(refocusTimer));
 
 // Submit a GUI-originated message into the PTY (the GUI->LLM feedback path) and the
-// explicit ✕ close. Both delegate to the slot's durable runtime.
+// explicit close-button close. Both delegate to the slot's durable runtime.
 function submitText(text: string): boolean {
   return conn.submitText(slotKey, text);
 }
@@ -311,7 +311,7 @@ function insertText(text: string) {
 // terminal. Browsers expose the real path only via the drag's file:// URIs
 // (text/uri-list); the File object hides it. Browsers that withhold the path
 // (e.g. Chrome) yield no URIs — instead of silently inserting nothing, point the
-// user at the 📎 file-picker button, which is the path-in-Chrome route.
+// user at the file-picker button, which is the path-in-Chrome route.
 function onDrop(e: DragEvent) {
   dragOver.value = false;
   const dt = e.dataTransfer;
@@ -330,10 +330,10 @@ function onDragOver(e: DragEvent) {
 
 // Shown when a file was dropped but the browser withheld its path — the drop can't do
 // anything, so tell the user how to insert the path rather than leaving the failed drop
-// looking like nothing happened. The guidance depends on the header: point at the 📎 picker
+// looking like nothing happened. The guidance depends on the header: point at the file picker
 // only when it's actually present (buttons are configurable and it can be removed), otherwise
 // fall back to advice that always holds.
-const DROP_HINT_PICKER_EN = "This browser doesn't share a dropped file's path. Use the 📎 button in the header (Insert a file path) instead.";
+const DROP_HINT_PICKER_EN = "This browser doesn't share a dropped file's path. Use the paperclip button in the header (Insert a file path) instead.";
 const DROP_HINT_TYPE_EN = "This browser doesn't share a dropped file's path — type or paste the path instead.";
 const dropHint = ref(false);
 const dropHintText = ref("");

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -390,7 +390,7 @@ onUnmounted(() => {
           @click="onHeaderButton(b)"
         >
           <span v-if="b.emoji" class="text-[15px] leading-none">{{ b.emoji }}</span>
-          <span v-else class="material-symbols-outlined text-[18px]">{{ b.icon || "bolt" }}</span>
+          <span v-else class="material-symbols-outlined text-[18px]" aria-hidden="true">{{ b.icon || "bolt" }}</span>
         </button>
         <button
           v-if="voice.capable.value"
@@ -401,7 +401,7 @@ onUnmounted(() => {
           :aria-label="voiceTitle()"
           @click="voice.toggle()"
         >
-          <span class="material-symbols-outlined text-[18px]">{{ voiceIcon() }}</span>
+          <span class="material-symbols-outlined text-[18px]" aria-hidden="true">{{ voiceIcon() }}</span>
         </button>
         <!-- The file-path picker and file explorer are now DEFAULT_BUTTONS (server-resolved into
              headerButtons above), so the user can drop/reorder/replace them via config. -->

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1191,7 +1191,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               :aria-expanded="askMenuOpen"
               @click="openAskMenu"
             >
-              <span class="material-symbols-outlined">forum</span>
+              <span class="material-symbols-outlined" aria-hidden="true">forum</span>
             </button>
             <div
               v-if="askMenuOpen"
@@ -1218,7 +1218,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
                   title="Send this cell's turn there and bring the answer back, both submitted"
                   @click="exchangeWith(target)"
                 >
-                  <span class="material-symbols-outlined">swap_horiz</span>
+                  <span class="material-symbols-outlined" aria-hidden="true">swap_horiz</span>
                 </button>
               </div>
               <p v-if="!askTargets.length" class="m-0 px-2 py-1.5 font-sans text-[12px] text-dim">No other terminal to read</p>
@@ -1231,7 +1231,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               class="absolute right-0 top-full z-20 mt-1 cursor-pointer whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1.5 font-sans text-[12px] text-secondary shadow-[0_6px_18px_rgba(0,0,0,0.35)] hover:text-fg"
               @click="stopExchange"
             >
-              <span class="material-symbols-outlined">swap_horiz</span> exchanging — stop
+              <span class="material-symbols-outlined" aria-hidden="true">swap_horiz</span> exchanging — stop
             </button>
             <p
               v-else-if="askMsg"
@@ -1250,13 +1250,13 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             aria-label="Show activity timeline"
             @click="timelineOpen = true"
           >
-            <span class="material-symbols-outlined">history</span>
+            <span class="material-symbols-outlined" aria-hidden="true">history</span>
           </button>
           <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">
-            <span class="material-symbols-outlined">chevron_left</span>
+            <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
           </button>
           <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">
-            <span class="material-symbols-outlined">chevron_right</span>
+            <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
           </button>
         </template>
       </TerminalView>
@@ -1269,7 +1269,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <span class="font-sans text-[12px] font-semibold text-fg">Changes vs {{ diff?.base ?? "base" }}</span>
           <span class="flex-auto font-sans text-[11px] text-dim">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>
           <button class="cell-btn" :class="CELL_BTN" title="Close diff" aria-label="Close diff" @click="diffOpen = false">
-            <span class="material-symbols-outlined">close</span>
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
           </button>
         </div>
         <div v-if="diff && diff.files.length" class="max-h-[35%] flex-none overflow-y-auto border-b border-b-border px-2 py-1">
@@ -1297,7 +1297,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :title="(diff?.dirty ?? 0) === 0 ? 'No uncommitted changes' : working ? 'Wait for the session to finish' : 'Ask Claude to commit the changes'"
             @click="commitViaClaude"
           >
-            <span class="material-symbols-outlined">check</span> Commit
+            <span class="material-symbols-outlined" aria-hidden="true">check</span> Commit
           </button>
           <button
             data-testid="cell-diff-btn"
@@ -1306,7 +1306,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes first' : 'git push -u origin'"
             @click="pushBranch"
           >
-            <span class="material-symbols-outlined">arrow_upward</span> Push
+            <span class="material-symbols-outlined" aria-hidden="true">arrow_upward</span> Push
           </button>
           <button
             data-testid="cell-diff-btn"
@@ -1315,7 +1315,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'Push and open a pull request'"
             @click="openPR"
           >
-            <span class="material-symbols-outlined">open_in_new</span> Open PR
+            <span class="material-symbols-outlined" aria-hidden="true">open_in_new</span> Open PR
           </button>
           <span v-if="prMsg" data-testid="cell-diff-msg" class="min-w-0 flex-auto truncate font-sans text-[11px] text-dim">{{ prMsg }}</span>
         </div>
@@ -1391,7 +1391,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         aria-label="Cancel new terminal"
         @click="emit('close')"
       >
-        <span class="material-symbols-outlined">close</span>
+        <span class="material-symbols-outlined" aria-hidden="true">close</span>
       </button>
       <div v-if="presets.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
         <span
@@ -1432,7 +1432,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             "
             @click="selectPreset(p)"
           >
-            <span class="material-symbols-outlined text-[14px]">play_arrow</span>
+            <span class="material-symbols-outlined text-[14px]" aria-hidden="true">play_arrow</span>
           </button>
           <button
             type="button"
@@ -1442,7 +1442,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :aria-label="`Remove ${p.path} from the list`"
             @click="emit('remove-preset', p.path)"
           >
-            <span class="material-symbols-outlined">close</span>
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
           </button>
         </span>
       </div>
@@ -1488,7 +1488,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             aria-label="Choose the working directory"
             @click="pickDir"
           >
-            <span class="material-symbols-outlined text-[18px]">folder_open</span>
+            <span class="material-symbols-outlined text-[18px]" aria-hidden="true">folder_open</span>
           </button>
           <button
             type="button"
@@ -1499,7 +1499,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             aria-label="Start a new terminal here"
             @click="launch"
           >
-            <span class="material-symbols-outlined text-[18px]">play_arrow</span>
+            <span class="material-symbols-outlined text-[18px]" aria-hidden="true">play_arrow</span>
           </button>
         </span>
       </label>
@@ -1524,7 +1524,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :disabled="!worktreeTask.trim()"
             @click="createWorktreeAndLaunch"
           >
-            <span class="material-symbols-outlined">add</span> New worktree
+            <span class="material-symbols-outlined" aria-hidden="true">add</span> New worktree
           </button>
         </div>
         <div v-for="w in worktrees" :key="w.path" class="flex items-center gap-1.5">
@@ -1543,7 +1543,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             aria-label="Remove worktree"
             @click="removeWorktree(w)"
           >
-            <span class="material-symbols-outlined">delete</span>
+            <span class="material-symbols-outlined" aria-hidden="true">delete</span>
           </button>
         </div>
       </div>
@@ -1558,7 +1558,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :title="s.command"
             @click="runScript(s)"
           >
-            <span class="material-symbols-outlined">play_arrow</span> {{ s.label }}
+            <span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ s.label }}
           </button>
         </div>
       </div>
@@ -1573,7 +1573,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :title="l.command"
             @click="launchProgram(i, l)"
           >
-            <span class="material-symbols-outlined">rocket_launch</span> {{ l.label }}
+            <span class="material-symbols-outlined" aria-hidden="true">rocket_launch</span> {{ l.label }}
           </button>
         </div>
       </div>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -39,7 +39,7 @@ const termRef = useTemplateRef<InstanceType<typeof TerminalView>>("termRef");
 
 // Clicking the header background zooms this cell (mirrors clicking the terminal body) —
 // in the tiled grid and as a filmstrip thumbnail alike. Only the already-expanded cell
-// stays inert (restore via the ⤡ button). Header buttons keep their action.
+// stays inert (restore via the restore button). Header buttons keep their action.
 function onHeaderClick(event: MouseEvent) {
   if (shouldZoomOnHeaderClick(event.target, props.expanded)) emit("toggle-expand");
 }
@@ -69,16 +69,16 @@ const props = defineProps<
     // Dirs with a running session in another cell, so the launcher can tint preset
     // chips whose dir is already in use.
     openCwds?: string[];
-    // An added (not the sole entry) launcher: show a ✕ to dismiss it before launching.
+    // An added (not the sole entry) launcher: show a close button to dismiss it before launching.
     cancellable?: boolean;
-    // Manual sort mode: show ◀▶ to swap this cell with its neighbour.
+    // Manual sort mode: show move buttons to swap this cell with its neighbour.
     reorderable?: boolean;
   }
 >();
 const emit = defineEmits<
   GridCellEmits & {
     // `record-cwd`: auto-record a fresh launch's server-confirmed cwd as a preset.
-    // `remove-preset`: drop a preset (its ✕) from the shared list — value is the path.
+    // `remove-preset`: drop a preset (its close button) from the shared list — value is the path.
     (e: "session" | "cwd" | "record-cwd" | "remove-preset", value: string): void;
     // `run` launches in THIS (empty) cell from the launcher; `runSpare` is the running
     // terminal's header menu, which must NOT replace the session — it runs in a new cell.
@@ -112,7 +112,7 @@ const cellStyle = computed(() =>
 // Live git status (branch/dirty/ahead·behind) for the header chip. `refreshGit`
 // is called alongside loadDiff() so a finished turn's changes show immediately.
 const { status: gitStatus, refresh: refreshGit } = useGitStatus(cwd);
-// Activity timeline overlay (the header 🕘) — only meaningful for a Claude session.
+// Activity timeline overlay (the header history button) — only meaningful for a Claude session.
 const timelineOpen = ref(false);
 // A small filmstrip thumbnail (some OTHER cell is zoomed): strip the header to just
 // dir + what it's doing + a zoom button, and hide the second (terminal) header row.
@@ -328,7 +328,7 @@ function launchProgram(index: number, l: Launcher) {
   emit("launch", { index, label: l.label, cwd: dirInput.value.trim() || props.defaultCwd });
 }
 
-// The chip's ▶ button: a one-click quick launch — fill the field and jump straight
+// The chip's launch button: a one-click quick launch — fill the field and jump straight
 // into a fresh session in that dir.
 function selectPreset(p: CwdPreset) {
   dirInput.value = p.path;
@@ -340,7 +340,7 @@ function selectPreset(p: CwdPreset) {
 // click / folder pick would fetch the lists twice.
 let skipDirWatch = false;
 
-// The chip's main click (and the 📁 folder picker): fill the field WITHOUT launching,
+// The chip's main click (and the folder picker): fill the field WITHOUT launching,
 // and refresh the resume / script / worktree lists for that dir so the user can pick a
 // session to resume — or start fresh — instead of launching immediately.
 function fillDir(path: string) {
@@ -355,7 +355,7 @@ function fillDir(path: string) {
   loadWorktrees();
 }
 
-// The 📁 button: the browser can't open a native folder chooser, so the local server does
+// The folder button: the browser can't open a native folder chooser, so the local server does
 // (POST /api/pick-file { directory: true }). Fill the Working-directory field with the pick.
 async function pickDir() {
   try {
@@ -717,7 +717,7 @@ function teardown() {
   const id = sessionId.value; // capture before the reset below nulls it
   termRef.value?.terminate();
   // Reap on the server over HTTP too — the WS `terminate` only reaches the server while
-  // the socket is open, so a disconnected cell's ✕ would otherwise leave its tmux alive.
+  // the socket is open, so a disconnected cell's close button would otherwise leave its tmux alive.
   if (id) fetch(`/api/session/${encodeURIComponent(id)}/terminate`, { method: "POST" }).catch(() => {});
   launched.value = false;
   recordNextCwd = false; // drop any pending fresh-launch record from a torn-down session
@@ -1191,7 +1191,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               :aria-expanded="askMenuOpen"
               @click="openAskMenu"
             >
-              💬
+              <span class="material-symbols-outlined">forum</span>
             </button>
             <div
               v-if="askMenuOpen"
@@ -1218,7 +1218,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
                   title="Send this cell's turn there and bring the answer back, both submitted"
                   @click="exchangeWith(target)"
                 >
-                  ⇄
+                  <span class="material-symbols-outlined">swap_horiz</span>
                 </button>
               </div>
               <p v-if="!askTargets.length" class="m-0 px-2 py-1.5 font-sans text-[12px] text-dim">No other terminal to read</p>
@@ -1231,7 +1231,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
               class="absolute right-0 top-full z-20 mt-1 cursor-pointer whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1.5 font-sans text-[12px] text-secondary shadow-[0_6px_18px_rgba(0,0,0,0.35)] hover:text-fg"
               @click="stopExchange"
             >
-              ⇄ exchanging — stop
+              <span class="material-symbols-outlined">swap_horiz</span> exchanging — stop
             </button>
             <p
               v-else-if="askMsg"
@@ -1250,10 +1250,14 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             aria-label="Show activity timeline"
             @click="timelineOpen = true"
           >
-            🕘
+            <span class="material-symbols-outlined">history</span>
           </button>
-          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">◀</button>
-          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">▶</button>
+          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">
+            <span class="material-symbols-outlined">chevron_left</span>
+          </button>
+          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">
+            <span class="material-symbols-outlined">chevron_right</span>
+          </button>
         </template>
       </TerminalView>
       <div
@@ -1264,7 +1268,9 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <div class="flex flex-none items-center gap-2 border-b border-b-border bg-panel px-2 py-1.5">
           <span class="font-sans text-[12px] font-semibold text-fg">Changes vs {{ diff?.base ?? "base" }}</span>
           <span class="flex-auto font-sans text-[11px] text-dim">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>
-          <button class="cell-btn" :class="CELL_BTN" title="Close diff" aria-label="Close diff" @click="diffOpen = false">✕</button>
+          <button class="cell-btn" :class="CELL_BTN" title="Close diff" aria-label="Close diff" @click="diffOpen = false">
+            <span class="material-symbols-outlined">close</span>
+          </button>
         </div>
         <div v-if="diff && diff.files.length" class="max-h-[35%] flex-none overflow-y-auto border-b border-b-border px-2 py-1">
           <div v-for="f in diff.files" :key="f.path" data-testid="cell-diff-file" class="flex items-baseline gap-2 py-px font-mono text-[11px]">
@@ -1286,30 +1292,30 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <div class="flex flex-none items-center gap-2 border-t border-t-border bg-panel px-2 py-1.5">
           <button
             data-testid="cell-diff-btn"
-            class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="prBusy || working || (diff?.dirty ?? 0) === 0"
             :title="(diff?.dirty ?? 0) === 0 ? 'No uncommitted changes' : working ? 'Wait for the session to finish' : 'Ask Claude to commit the changes'"
             @click="commitViaClaude"
           >
-            ✓ Commit
+            <span class="material-symbols-outlined">check</span> Commit
           </button>
           <button
             data-testid="cell-diff-btn"
-            class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="prBusy || (diff?.ahead ?? 0) === 0"
             :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes first' : 'git push -u origin'"
             @click="pushBranch"
           >
-            ⬆ Push
+            <span class="material-symbols-outlined">arrow_upward</span> Push
           </button>
           <button
             data-testid="cell-diff-btn"
-            class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="prBusy || (diff?.ahead ?? 0) === 0"
             :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'Push and open a pull request'"
             @click="openPR"
           >
-            ⧉ Open PR
+            <span class="material-symbols-outlined">open_in_new</span> Open PR
           </button>
           <span v-if="prMsg" data-testid="cell-diff-msg" class="min-w-0 flex-auto truncate font-sans text-[11px] text-dim">{{ prMsg }}</span>
         </div>
@@ -1385,7 +1391,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         aria-label="Cancel new terminal"
         @click="emit('close')"
       >
-        ✕
+        <span class="material-symbols-outlined">close</span>
       </button>
       <div v-if="presets.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
         <span
@@ -1436,7 +1442,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             :aria-label="`Remove ${p.path} from the list`"
             @click="emit('remove-preset', p.path)"
           >
-            ✕
+            <span class="material-symbols-outlined">close</span>
           </button>
         </span>
       </div>
@@ -1514,11 +1520,11 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           />
           <button
             data-testid="wt-start"
-            class="cursor-pointer rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary flex-none whitespace-nowrap hover:bg-hover hover:text-fg"
+            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary flex-none whitespace-nowrap hover:bg-hover hover:text-fg"
             :disabled="!worktreeTask.trim()"
             @click="createWorktreeAndLaunch"
           >
-            ＋ New worktree
+            <span class="material-symbols-outlined">add</span> New worktree
           </button>
         </div>
         <div v-for="w in worktrees" :key="w.path" class="flex items-center gap-1.5">
@@ -1537,7 +1543,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             aria-label="Remove worktree"
             @click="removeWorktree(w)"
           >
-            🗑
+            <span class="material-symbols-outlined">delete</span>
           </button>
         </div>
       </div>
@@ -1548,11 +1554,11 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             v-for="s in scripts"
             :key="s.index"
             data-testid="cell-script-item"
-            class="cursor-pointer rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
+            class="inline-flex cursor-pointer items-center gap-1 rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
             :title="s.command"
             @click="runScript(s)"
           >
-            ▶ {{ s.label }}
+            <span class="material-symbols-outlined">play_arrow</span> {{ s.label }}
           </button>
         </div>
       </div>
@@ -1563,11 +1569,11 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             v-for="(l, i) in launchers"
             :key="l.label"
             data-testid="cell-script-item"
-            class="cursor-pointer rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
+            class="inline-flex cursor-pointer items-center gap-1 rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
             :title="l.command"
             @click="launchProgram(i, l)"
           >
-            ⌘ {{ l.label }}
+            <span class="material-symbols-outlined">rocket_launch</span> {{ l.label }}
           </button>
         </div>
       </div>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -47,7 +47,7 @@ const props = defineProps<{
   presets: CwdPreset[];
   launchers: Launcher[];
   home: string | null;
-  // Manual sort mode: each cell shows ◀▶ to reorder.
+  // Manual sort mode: each cell shows move buttons to reorder.
   reorderable?: boolean;
   openSessionIds: string[];
   openCwds: string[];

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // A read-only activity timeline for one session: the tools the agent ran (newest
 // first), fetched from GET /api/transcript/timeline. Opened from the cell header's
-// 🕘 button so you can see "what did it do?" without scrolling the raw transcript.
+// history button so you can see "what did it do?" without scrolling the raw transcript.
 import { ref, watch, onUnmounted, nextTick } from "vue";
 import { trapTabKey } from "../utils/focusTrap";
 import { isRecord } from "../../common/isRecord";
@@ -118,7 +118,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           aria-label="Close timeline"
           @click="emit('close')"
         >
-          ✕
+          <span class="material-symbols-outlined">close</span>
         </button>
       </div>
       <div class="overflow-y-auto py-1.5">

--- a/src/components/TimelineOverlay.vue
+++ b/src/components/TimelineOverlay.vue
@@ -118,7 +118,7 @@ onUnmounted(() => document.removeEventListener("keydown", onKeydown));
           aria-label="Close timeline"
           @click="emit('close')"
         >
-          <span class="material-symbols-outlined">close</span>
+          <span class="material-symbols-outlined" aria-hidden="true">close</span>
         </button>
       </div>
       <div class="overflow-y-auto py-1.5">

--- a/src/components/ToolbarPopover.vue
+++ b/src/components/ToolbarPopover.vue
@@ -35,7 +35,7 @@ defineExpose({ close });
       :aria-label="triggerLabel"
       @click="toggle"
     >
-      <span class="material-symbols-outlined">{{ icon }}</span>
+      <span class="material-symbols-outlined" aria-hidden="true">{{ icon }}</span>
       <slot name="trigger-extra" />
     </button>
 

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -120,7 +120,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
         aria-label="Close tools pane"
         @click="emit('close')"
       >
-        <span class="material-symbols-outlined">close</span>
+        <span class="material-symbols-outlined" aria-hidden="true">close</span>
       </button>
     </div>
     <div class="flex-1 overflow-y-auto font-sans text-[13px] text-fg">
@@ -139,7 +139,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
               class="rounded-[4px] bg-subtle px-1.5 py-0.5 font-['JetBrains_Mono',_monospace] text-[12px] break-all text-secondary"
               >{{ tool.toolName }}</code
             >
-            <span v-if="tool.description" class="material-symbols-outlined text-[18px] text-dim">{{
+            <span v-if="tool.description" class="material-symbols-outlined text-[18px] text-dim" aria-hidden="true">{{
               expandedTools.has(tool.toolName) ? "expand_less" : "expand_more"
             }}</span>
           </button>
@@ -161,7 +161,7 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
             :aria-label="historyCopied ? 'Copied!' : 'Copy all call history'"
             @click="copyHistory"
           >
-            <span class="material-symbols-outlined text-[14px] transition-[color,background] duration-150 ease-[ease]">{{
+            <span class="material-symbols-outlined text-[14px] transition-[color,background] duration-150 ease-[ease]" aria-hidden="true">{{
               historyCopied ? "check" : "content_copy"
             }}</span>
             {{ historyCopied ? "Copied" : "Copy all" }}

--- a/src/components/cellHeaderZoom.ts
+++ b/src/components/cellHeaderZoom.ts
@@ -2,8 +2,8 @@
 // grid — in BOTH the tiled grid and while it's a filmstrip thumbnail (some other cell
 // is already zoomed), the easy "switch to this terminal" gesture that mirrors clicking
 // the terminal body. The EXPANDED cell itself is excluded: its header stays inert so a
-// stray click while reading the big terminal doesn't restore it (use the ⤡ button).
-// The header's own controls (dir / GitHub / ⤢ / ✕ / ◀▶) always keep their action.
+// stray click while reading the big terminal doesn't restore it (use the restore button).
+// The header's own controls (dir / GitHub / expand / close / move) always keep their action.
 export function shouldZoomOnHeaderClick(target: EventTarget | null, expanded: boolean): boolean {
   if (expanded) return false;
   // `Element` (not `HTMLElement`): a click can land on an SVG icon inside a button

--- a/src/components/gridTabs.ts
+++ b/src/components/gridTabs.ts
@@ -30,7 +30,7 @@ export interface Cell {
   // The agent this cell runs. "codex" reconnects via /ws/codex; absent = Claude (the default).
   agent?: "codex";
 }
-// How the grid orders its cells. "manual": the user's hand-arranged order (◀▶);
+// How the grid orders its cells. "manual": the user's hand-arranged order (the move buttons);
 // "auto": attention-first, recomputed from each cell's live status.
 export type SortMode = "manual" | "auto";
 // A cell's live activity, reported up from the cell. Drives the "auto" order and the
@@ -93,7 +93,7 @@ export function addCell(state: GridState): GridState {
   return { ...state, cells, nextUid: state.nextUid + 1, page: pageCount(cells.length) - 1, expanded };
 }
 
-// The uid of the trailing launch cell that "+ Terminal" (and the launcher's own ✕)
+// The uid of the trailing launch cell that "+ Terminal" (and the launcher's own close button)
 // cancels, or null when there's nothing to cancel. The sole entry cell is never
 // cancelable, so it's excluded.
 export function cancelableLaunchUid(state: GridState): number | null {
@@ -242,7 +242,7 @@ const pageHolding = (order: readonly number[], uid: number, fallback: number): n
 
 // The keyboard's way in and out of the zoom (#829). Every other zoom action needs something
 // already enlarged, so without this one a keymap cannot be used at all without first reaching
-// for the ⤢ button.
+// for the expand button.
 //
 // Un-zoomed there is no "current" cell to enlarge, so it takes the first one ON THE PAGE THE
 // USER IS LOOKING AT — `order` is the whole un-paged list, so index 0 would be a cell from the
@@ -317,7 +317,7 @@ function nextCandidate(state: GridState, order: readonly number[], statusByUid: 
 }
 
 // Zooming shows one cell big with the others as a filmstrip beside it, so it only means
-// anything when there IS another cell to switch to. With a single occupied cell the ⤢ button
+// anything when there IS another cell to switch to. With a single occupied cell the expand button
 // used to swap a working layout for a filmstrip containing nothing, and squeeze the
 // terminal's status bar and input off the bottom of the viewport for no gain (#374).
 //

--- a/src/components/presets.ts
+++ b/src/components/presets.ts
@@ -2,7 +2,7 @@ import { worktreeLabel } from "./cwdDisplay";
 
 // A directory preset offered as a one-click chip in the cell launch form.
 // The list is auto-populated from the dirs the user launches in (see
-// useAppConfig.recordPreset) and pruned with the chip's ✕.
+// useAppConfig.recordPreset) and pruned with the chip's close button.
 export interface CwdPreset {
   label: string;
   path: string;

--- a/src/composables/useAppConfig.ts
+++ b/src/composables/useAppConfig.ts
@@ -88,7 +88,7 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
   // to the FRONT (most-recently-used) on every launch so the list reflects launch order. A
   // re-launched dir keeps its existing (possibly manual) label; a new dir is prepended with
   // its basename. Already at the front → no write. No cap: the user prunes the list with the
-  // chip's ✕. Called with the server-confirmed (effective) cwd so we only remember dirs that
+  // chip's close button. Called with the server-confirmed (effective) cwd so we only remember dirs that
   // actually ran.
   function recordPreset(path: string | null): Promise<void> {
     if (!path) return Promise.resolve();
@@ -100,7 +100,7 @@ function createPresetMutations(presets: Ref<CwdPreset[]>, savePresets: (next: Cw
     });
   }
 
-  // Drop one preset (the chip's ✕). No-op when the path isn't present.
+  // Drop one preset (the chip's close button). No-op when the path isn't present.
   function removePreset(path: string): Promise<void> {
     return serialize(async () => {
       if (!presets.value.some((p) => p.path === path)) return;

--- a/src/composables/useAttentionSound.ts
+++ b/src/composables/useAttentionSound.ts
@@ -195,7 +195,7 @@ export async function previewAttention(soundFile: string | null) {
 
 // Beep when any session transitions into `waiting` (needs attention), across every
 // page/view, by listening to the same "sessions" activity stream the cells use — so
-// the beep tracks the amber header exactly. `enabled` gates it (the 🔔 toggle);
+// the beep tracks the amber header exactly. `enabled` gates it (the sound toggle);
 // `soundFile`, when set, plays the user's chosen file instead of the chime.
 export function useAttentionSound(enabled: Ref<boolean>, soundFile?: Ref<string | null>) {
   armUnlock();

--- a/src/composables/useHeaderButtons.ts
+++ b/src/composables/useHeaderButtons.ts
@@ -28,7 +28,7 @@ export type ResolvedChip = { kind: "builtin"; id: string } | { kind: "custom"; l
 
 // Whether the resolved header offers a file-path picker (an `open` button with `pickFile`).
 // Header buttons are user-configurable and the default picker can be removed, so anything that
-// points the user at "the 📎 button" must first confirm it is actually present.
+// points the user at "the file-picker button" must first confirm it is actually present.
 export function hasPickFileButton(buttons: readonly HeaderButton[]): boolean {
   return buttons.some((b) => b.run === "open" && b.open?.pickFile === true);
 }

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -157,7 +157,7 @@ export function useNotifications() {
     }),
   );
 
-  /** Dismiss (clear) a notification: the ✕ action. Optimistically drops it, then
+  /** Dismiss (clear) a notification: the close button action. Optimistically drops it, then
    *  asks the server to clear; on failure we resync from the server. */
   async function dismiss(id: string): Promise<void> {
     remove(id);

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -565,7 +565,7 @@ export function release(key: string) {
   connView.delete(key);
 }
 
-// Explicit close (the cell's ✕): tell the server to reap this session NOW instead
+// Explicit close (the cell's close button): tell the server to reap this session NOW instead
 // of holding it through the disconnect grace window, then tear the slot down.
 export function terminate(key: string) {
   const c = conns.get(key);

--- a/test/src/components/CellChromeButtons.spec.ts
+++ b/test/src/components/CellChromeButtons.spec.ts
@@ -28,9 +28,9 @@ describe("CellChromeButtons", () => {
   });
 
   it("offers expand while tiled and restore while expanded", () => {
-    expect(mountButtons(false).find(".cell-btn").text()).toBe("⤢");
+    expect(mountButtons(false).find(".cell-btn").text()).toBe("open_in_full");
     const expanded = mountButtons(true);
-    expect(expanded.find(".cell-btn").text()).toBe("⤡");
+    expect(expanded.find(".cell-btn").text()).toBe("close_fullscreen");
     expect(expanded.find(".cell-btn").attributes("title")).toBe("Restore");
     expect(expanded.find('[aria-label="Restore terminal"]').exists()).toBe(true);
   });


### PR DESCRIPTION
## Why

The Material Symbols convention was set in June but only reached the app chrome. The grid cells still drew their toolbars with emoji and unicode glyphs, so one header row mixed `attach_file` and `folder_open` with a literal folder emoji sitting right beside them.

Noticed while reading a grid cell's toolbar: two Material Symbols, four emoji, and an inline SVG, all in the same cluster.

## What changed

Every button keeps its `title` and `aria-label` — only the glyph changed.

- **`DEFAULT_BUTTONS`** (`server/config/header-config.ts`) — `emoji` to `icon` for reveal / terminal / pr / gh. The `emoji` field stays in the schema for end-user configs and still wins over `icon` when both are set; nothing this repo ships uses it now.
- **Grid cells, all three types** — ask, timeline, move, exchange, expand/restore/close, the diff panel's commit / push / open-PR, re-run, summarize, worktree add/delete. Converting only `TerminalCell` would have left chevrons in one cell and the old `◀▶` in the command cell next to it.
- **Overlays and modals** — files (incl. the tree twisty and folder/file icons), PRs, timeline, settings, cockpit row menu.
- **Run / Skill dropdowns** — carets now flip `expand_more` / `expand_less` with the menu rather than drawing a static triangle.
- **Text that named a button by its emoji** — one UI string ("the paperclip button") and ~24 source comments ("restore via the expand button"), which otherwise pointed at glyphs that no longer exist.
- **`CLAUDE.md`** — new **No emojis** section. Its own changelog convention prescribed a book emoji under each entry heading; that is now a `> **Setup guide:**` line.

## Deliberately not converted

Documented in `CLAUDE.md` so a later sweep doesn't break them:

| Kept | Why |
|---|---|
| `/^\s*[❯›]\s/u` in `screen-rows.ts` | Parses Claude Code's real terminal output |
| The favicon's `❯` chevron | Drawn on canvas as the app's identity mark |
| CLI doctor's `✓ / ✗ / ○` | A terminal can't render an icon font |
| `⎇ main ●3 ↑2`, `●` dots, `−12` counts | Dense notation; icons are bigger and slower to scan |

## Testing

- `yarn test` — 4428 pass. One pre-existing failure, `docPath.spec.ts` "zero-pads the month", which is a timezone bug (`2026-03-01T00:00:00Z` lands on Feb 28 locally) and **also fails on a clean tree** — confirmed by stashing.
- `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test` — clean.
- `yarn lint` — 0 errors (6 pre-existing warnings in untouched files).
- Verified in the running app after `yarn build`.

One spec updated: `CellChromeButtons.spec.ts` asserted the literal `⤢`/`⤡` text.

## Follow-up, not in this PR

`docs/`, `plans/`, and `README.md` still hold ~453 emoji, and `docs/ChangeLog.md` has existing `> 📘` lines from the old convention. The new rule implicates them, but sweeping prose is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced emoji and text glyphs throughout the interface with consistent Material Symbols icons.
  * Updated terminal, grid, file, settings, timeline, menu, launcher, and action controls with clearer visual indicators.
  * Improved button spacing and alignment for icon-and-label controls.
  * Refined labels and tooltips to describe actions such as closing, reordering, expanding, and file insertion more clearly.

* **Documentation**
  * Updated guidance and release documentation to follow the no-emoji convention and use clearer icon terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->