### PR TITLE
docs: アイコン名の検証はフォント実体に対して行う

### DIFF
--- a/docs/styling.md
+++ b/docs/styling.md
@@ -102,6 +102,20 @@ Spacing/radius use Tailwind's scale on a 4px base: `px-2` = 8px, `px-2.5` = 10px
 - **Verify that a utility *wins*, not just that it exists.** Grepping the built CSS for
   `.px-2\.5{…}` only proves it was generated. Confirm the rendered `getComputedStyle`
   matches the original declaration — that is what catches a cascade-layer loss.
+- **An icon name that isn't in the font renders as its own text.** `<span
+  class="material-symbols-outlined">folder_opne</span>` shows the literal word — a typo is a
+  visible bug, not a blank. The list to check a name against is the **font**, not the
+  package's TypeScript names: `material-symbols@0.45.9`'s `index.d.ts` union omits
+  `auto_awesome` even though the shipped `material-symbols-outlined.woff2` carries the
+  ligature, so validating against the types reports working icons as broken. Read the font —
+  the fiddly part is finding where the brotli stream starts, so scan for it:
+
+  ```bash
+  node -e 'const z=require("node:zlib"),f=require("node:fs");
+  const b=f.readFileSync("node_modules/material-symbols/material-symbols-outlined.woff2");
+  for(let o=48;o<4000;o++){try{const d=z.brotliDecompressSync(b.subarray(o));
+  if(d.length>1e5){console.log(d.toString("latin1").includes(process.argv[1]));break;}}catch{}}' auto_awesome
+  ```
 
 ## Migrating an existing component
 


### PR DESCRIPTION
## Summary

`docs/styling.md` の「Gotchas (learned the hard way)」に1項目追加。**アイコン名の検証は型定義ではなくフォント実体に対して行う**、という知見。

#875（UI の emoji を Material Symbols に置き換える）のレビュー中に見つけたものです。

## なぜ書くか

`material-symbols` パッケージの `index.d.ts` は約3900個の名前の union を export していますが、**これはフォントが持つアイコンの一覧ではありません**。0.45.9 の union には `auto_awesome` が入っていないのに、同梱の `material-symbols-outlined.woff2` にはリガチャがあります。

つまり型定義に対してアイコン名を機械的に検証すると、**正常に描画されるアイコンを「存在しない」と報告します**（レビュー中に実際にこれで誤検知しました）。逆方向の危険もあります — 型定義にあってフォントに無い名前があれば、検証を通り抜けて壊れたまま出ます。

存在しないアイコン名は空白ではなく**その名前自体が文字として表示される**ので、タイポは目に見える不具合になります。

## 何を書いたか

- 検証はフォントに対して行うこと、その理由（`auto_awesome` の実例）
- woff2 を読むワンライナー。brotli ストリームの開始位置を探すところが面倒なので、走査するコードごと残しました

記載したスニペットをそのまま実行して確認済み:

```
auto_awesome  -> true
folder_opne   -> false   （本文でタイポ例に使っている名前）
```

## User Prompt

> その知見はdocumentにかいておいて。

（直前のやり取り: #875 のレビューで「`material-symbols` の型定義はアイコン名の完全な一覧ではない。検証は woff2 のリガチャ表を見る必要がある」という知見が出たので、それを文書に残す。）

## 置き場所について

`docs/styling.md` にした理由:

- 同ファイルの Gotchas に既に Material Symbols の項（`@layer base` に入れないとアイコンの `text-*` が効かない件）があり、隣に並べるのが自然
- `CLAUDE.md` にも書けますが、#875 が同ファイルに「No emojis」節を新設する PR として未マージなので、そちらと競合させないため。#875 がマージされたあと、その節からここへ1行リンクするのが良いと思います

