### PR TITLE
feat: let the user pick the language they dictate in

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -8,6 +8,7 @@ import { useCost } from "../composables/useCost";
 import { activeKeymap } from "../composables/activeKeymap";
 import { keymapRows } from "./keymapLabels";
 import { useGoogleLink } from "../composables/useGoogleLink";
+import { VOICE_LANGUAGES, voiceLanguage } from "../composables/voiceLanguage";
 import SettingsButton from "./SettingsButton.vue";
 import SettingsField from "./SettingsField.vue";
 import GuideLinks from "./GuideLinks.vue";
@@ -262,6 +263,21 @@ function onThemeKey(e: KeyboardEvent, index: number) {
   themesEl.value?.querySelectorAll<HTMLElement>('[role="radio"]')[next]?.focus();
 }
 
+// Voice input's language mode. The setting is a singleton ref (localStorage-backed), so it
+// needs no prop/emit plumbing — but the section is only worth showing on a machine that can
+// transcribe at all, and capability lives on the server. One cheap GET when the modal opens;
+// a failed/absent probe leaves the section hidden rather than offering a setting for a mic
+// that will never appear.
+const voiceCapable = ref(false);
+async function refreshVoiceCapable() {
+  try {
+    const res = await fetch("/api/transcribe/model");
+    voiceCapable.value = res.ok && (((await res.json()) as { capable?: boolean }).capable ?? false);
+  } catch {
+    voiceCapable.value = false;
+  }
+}
+
 // Read-only estimated cost (Session / Today / Month), loaded when the modal opens.
 const { cost, error: costError, load: loadCost } = useCost();
 
@@ -290,6 +306,7 @@ onMounted(() => {
   nextTick(() => modalEl.value?.querySelector<HTMLElement>("input, button")?.focus());
   refreshCost();
   refreshGoogle();
+  refreshVoiceCapable();
 });
 watch([() => props.cwd, () => props.sessionId], refreshCost);
 onUnmounted(() => {
@@ -398,6 +415,25 @@ onUnmounted(() => {
         >
         <SettingsButton :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</SettingsButton>
       </div>
+
+      <template v-if="voiceCapable">
+        <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Voice input</h3>
+        <p class="mb-3 mt-1.5 text-[12px] text-dim">
+          The language you dictate in. Speaking a language the mic is not expecting comes back <strong>translated</strong> into the expected one — so pick the
+          one you actually speak rather than leaving it on your browser's.
+        </p>
+        <select
+          v-model="voiceLanguage"
+          aria-label="Language for voice input"
+          class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] text-[12px] text-fg focus:border-accent focus:outline-none"
+        >
+          <option value="locale">My browser's language</option>
+          <option value="auto">Detect from what I say</option>
+          <optgroup label="Always this language">
+            <option v-for="lang in VOICE_LANGUAGES" :key="lang.code" :value="lang.code">{{ lang.label }}</option>
+          </optgroup>
+        </select>
+      </template>
 
       <h3 class="mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted">Web Push notifications</h3>
       <p class="mb-3 mt-1.5 text-[12px] text-dim">

--- a/src/composables/useVoiceInput.ts
+++ b/src/composables/useVoiceInput.ts
@@ -13,6 +13,7 @@ import { onScopeDispose, ref, type Ref } from "vue";
 import { createVoiceCapture, localeToWhisperLanguage, type VoiceCaptureTransport } from "@mulmoclaude/core/whisper/client";
 import { browserLocale } from "../utils/browserLocale";
 import { modelReadiness, voiceAction } from "./voiceAction";
+import { resolveVoiceLanguage, voiceLanguage } from "./voiceLanguage";
 
 interface VoiceModelStatusResponse {
   capable: boolean;
@@ -85,7 +86,10 @@ export function useVoiceInput(opts: UseVoiceInputOptions): UseVoiceInput {
   const error = ref<string | null>(null);
 
   const transport = createVoiceTransport(capable, downloading);
-  const capture = createVoiceCapture(transport, () => localeToWhisperLanguage(browserLocale()), {
+  // Read per segment (the controller calls this getter per clip), so flipping the setting
+  // takes effect on the next thing you say rather than on the next reload.
+  const language = () => resolveVoiceLanguage(voiceLanguage.value, localeToWhisperLanguage(browserLocale()));
+  const capture = createVoiceCapture(transport, language, {
     onTranscript: (text) => {
       error.value = null;
       opts.onTranscript(text);

--- a/src/composables/voiceLanguage.ts
+++ b/src/composables/voiceLanguage.ts
@@ -1,0 +1,56 @@
+import { ref, watch } from "vue";
+
+// Which language voice input tells whisper to expect.
+//
+//   locale   — the browser's language (the default, and what this has always done)
+//   auto     — let whisper detect it from the audio
+//   <code>   — a language you picked, whatever the browser is set to
+//
+// The setting exists because forcing a language whisper does NOT hear is not a no-op:
+// given `language=en` and Japanese speech, the multilingual model emits an English
+// *translation* rather than a Japanese transcript. Saying which language you are about
+// to speak is both the fix for that and better than detection — per-segment detection
+// can guess wrong on a short or noisy clip, and a wrong guess costs you the same
+// translation you were trying to avoid.
+//
+// Per-browser (localStorage), like the terminal font size and the attention sound: the
+// mic and the language it hears belong to the device you are speaking into, not to the
+// server's config.
+const STORAGE_KEY = "voice_language";
+
+/** The languages offered in the picker. Deliberately the set the app already recognizes
+ *  as UI locales rather than whisper's full ~99 — every extra row is one more thing to
+ *  scroll past, and the codes are plain ISO-639-1, so adding one here is a one-line
+ *  change if someone needs it. */
+export const VOICE_LANGUAGES: ReadonlyArray<{ code: string; label: string }> = [
+  { code: "en", label: "English" },
+  { code: "ja", label: "Japanese" },
+  { code: "zh", label: "Chinese" },
+  { code: "ko", label: "Korean" },
+  { code: "es", label: "Spanish" },
+  { code: "pt", label: "Portuguese" },
+  { code: "fr", label: "French" },
+  { code: "de", label: "German" },
+];
+
+export const VOICE_LANGUAGE_LOCALE = "locale";
+export const VOICE_LANGUAGE_AUTO = "auto";
+
+/** Stored values are validated on the way in, not trusted: an unknown code would otherwise
+ *  reach whisper as a language token and quietly mistranscribe every clip. */
+export function parseVoiceLanguage(raw: string | null): string {
+  if (raw === VOICE_LANGUAGE_AUTO) return VOICE_LANGUAGE_AUTO;
+  if (raw && VOICE_LANGUAGES.some((l) => l.code === raw)) return raw;
+  return VOICE_LANGUAGE_LOCALE;
+}
+
+/** The `language` value for `/api/transcribe`. `localeLanguage` is the browser locale
+ *  already mapped to a whisper code, so this stays free of the locale table. */
+export function resolveVoiceLanguage(setting: string, localeLanguage: string): string {
+  return setting === VOICE_LANGUAGE_LOCALE ? localeLanguage : setting;
+}
+
+/** A singleton so the settings modal and every terminal's mic read the same value; the
+ *  language is re-read per audio segment, so a change applies without restarting. */
+export const voiceLanguage = ref<string>(parseVoiceLanguage(localStorage.getItem(STORAGE_KEY)));
+watch(voiceLanguage, (setting) => localStorage.setItem(STORAGE_KEY, setting));

--- a/test/src/composables/voiceLanguage.spec.ts
+++ b/test/src/composables/voiceLanguage.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { VOICE_LANGUAGES, parseVoiceLanguage, resolveVoiceLanguage } from "../../../src/composables/voiceLanguage";
+
+describe("parseVoiceLanguage", () => {
+  it("defaults to the browser's language when nothing is stored", () => {
+    expect(parseVoiceLanguage(null)).toBe("locale");
+  });
+
+  it("reads back an explicit detect choice", () => {
+    expect(parseVoiceLanguage("auto")).toBe("auto");
+  });
+
+  it("reads back every offered language", () => {
+    for (const lang of VOICE_LANGUAGES) expect(parseVoiceLanguage(lang.code)).toBe(lang.code);
+  });
+
+  // An unrecognized code must not reach whisper as a language token: it would be accepted by
+  // the route's length check and then mistranscribe every clip.
+  it("falls back to the default for a code that is not offered", () => {
+    expect(parseVoiceLanguage("xx")).toBe("locale");
+    expect(parseVoiceLanguage("")).toBe("locale");
+  });
+});
+
+describe("resolveVoiceLanguage", () => {
+  // The default must stay bit-for-bit what it always was: whatever the browser locale maps to
+  // is what whisper is told, translation quirk included.
+  it("uses the locale's language on the default setting", () => {
+    expect(resolveVoiceLanguage("locale", "en")).toBe("en");
+    expect(resolveVoiceLanguage("locale", "ja")).toBe("ja");
+  });
+
+  it("passes the locale's own fallback through untouched", () => {
+    expect(resolveVoiceLanguage("locale", "auto")).toBe("auto");
+  });
+
+  it("sends the picked language whatever the browser locale is", () => {
+    expect(resolveVoiceLanguage("ja", "en")).toBe("ja");
+    expect(resolveVoiceLanguage("en", "ja")).toBe("en");
+  });
+
+  it("asks whisper to detect on the auto setting", () => {
+    expect(resolveVoiceLanguage("auto", "en")).toBe("auto");
+  });
+});


### PR DESCRIPTION
## Why

Voice input asked whisper for **the browser's** language — `navigator.language`, mapped through `localeToWhisperLanguage`. Forcing a language whisper does *not* hear is not a no-op: given `language=en` and Japanese speech, the multilingual model emits an English **translation** rather than a Japanese transcript. So on an English browser, dictating in Japanese silently came back translated, with no way to say otherwise. (No `--translate` flag is involved — the forced language token is the whole cause.)

## What

A **Voice input** picker in Settings:

- **My browser's language** — the default; unchanged behaviour for anyone it already suited
- **Detect from what I say** — whisper detects per segment
- **Always this language** — en / ja / zh / ko / es / pt / fr / de

An explicit choice beats detection when you know what you are about to speak: per-segment detection can guess wrong on a short or noisy clip, and a wrong guess costs the same translation this is meant to avoid.

## Notes

- **Per-browser (localStorage)**, like the terminal font size — the mic belongs to the device you speak into, not to the server's config. No prop/emit plumbing: the setting is a singleton ref, as theme and font size already are.
- **Resolved per audio segment**, so a change applies to the next thing you say rather than the next reload.
- **Stored values are validated on read.** `/api/transcribe` only length-checks the language code, so an unrecognized one would reach whisper as a language token and quietly mistranscribe every clip; anything not offered falls back to the default.
- **The section is gated on `GET /api/transcribe/model`** — hidden where transcription is unavailable (non-macOS, or no `whisper-server` / `ffmpeg`), rather than offering a setting for a mic that never appears.
- The list is the eight languages the app already recognizes as UI locales, not whisper's full ~99. Adding one is a single line in `VOICE_LANGUAGES`.

## Test

8 new specs in `test/src/composables/voiceLanguage.spec.ts`: the default, round-tripping every offered code, the bad-code fallback, and each resolve path. `yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` pass. Verified live in the browser — Japanese dictation now transcribes as Japanese.

`test/server/backends/docPath.spec.ts` ("zero-pads the month") fails on this machine and is unrelated to this branch: it builds a `Date` from a UTC string and asserts a local-time month, so it fails outside UTC and passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Voice input setting for selecting the browser language, automatic language detection, or a specific supported language.
  * Voice input settings are shown only when transcription is available.
  * Selected voice language preferences are saved and applied to transcription.

* **Tests**
  * Added coverage for language selection, validation, fallback behavior, and locale handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->