### PR TITLE
docs: コメント内の issue 参照を実在する記録に向ける

### DIFF
--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -73,7 +73,7 @@ async function copyUpdateCommand(): Promise<void> {
   }
 }
 
-// TWO different questions, and answering both with one flag is what broke #889.
+// TWO different questions, and answering both with one flag is what broke #892.
 //   - which buttons the header OFFERS: the view underneath, so an overlay opened from the
 //     grid keeps the grid's buttons instead of hiding the one just clicked
 //   - which button is HIGHLIGHTED, and whether the grid is the screen: the route itself,

--- a/test/src/components/AppToolbar.spec.ts
+++ b/test/src/components/AppToolbar.spec.ts
@@ -66,7 +66,7 @@ describe("AppToolbar per-view buttons", () => {
 
   // The overlays render BELOW the header (`top-10`), so the header stays on screen while one
   // is open. Switching to the other view's buttons there would take away the very button the
-  // user just clicked — and would swap the shell behind the panel (#889).
+  // user just clicked — and would swap the shell behind the panel (#892).
   it("keeps the grid buttons while an overlay opened FROM the grid is on screen", async () => {
     await router.push("/terminals");
     await settle();
@@ -93,7 +93,7 @@ describe("AppToolbar per-view buttons", () => {
   // Regression: the button SET follows the view underneath, but the HIGHLIGHT follows the
   // route. Answering both with one flag lit up Grid view AND Pull requests at once — and,
   // because the overlays live inside App.vue's `!isGrid` block, also stopped the panel
-  // rendering at all: the URL changed and the grid just stayed on screen (#889).
+  // rendering at all: the URL changed and the grid just stayed on screen (#892).
   const activeLabels = (wrapper: ReturnType<typeof mount>): string[] =>
     wrapper
       .findAll("nav[aria-label='Views'] button")

--- a/test/src/composables/overlayOrigin.spec.ts
+++ b/test/src/composables/overlayOrigin.spec.ts
@@ -94,7 +94,7 @@ describe("overlay return-to-origin", () => {
 
   // Hopping straight from one overlay to another (grid → PRs → Worklog) must keep the view
   // UNDERNEATH as the return target. Recording the previous overlay instead is what made the
-  // header follow Worklog back to the single view (#889) — and only a real click-through
+  // header follow Worklog back to the single view (#892) — and only a real click-through
   // found it, because every earlier case opened exactly one overlay.
   it("carries the underlying view across an overlay-to-overlay hop", async () => {
     await router.push("/terminals");


### PR DESCRIPTION
## Summary

コード内コメントで、ヘッダーの不具合の参照として `#889` と書いていました。**#889 は無関係な issue**（"Update package20260727"）です。この不具合は issue を立てておらず、経緯が残っているのは PR #892 なので、参照先をそちらに変えます。

コメントのみの変更で、5箇所（`AppToolbar.vue` 1、`AppToolbar.spec.ts` 2、`overlayOrigin.spec.ts` 2）。

## Items to Confirm / Review

- コミットメッセージ側の `#889` は既にマージ済みなので直せません。コード内の参照だけを直しています