### PR TITLE
feat: マウス/トラックパッドのズームでビューが拡大しないようにする (#896)

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,11 @@ Favorited collections get their own toolbar buttons.
   **Option** is treated as Meta so Claude's Alt-key bindings work. If your Claude Code is
   rebound so Enter and Shift+Enter behave backwards, flip them with
   [`terminalSubmit`](https://receptron.github.io/mulmoterminal/guide/en/config.html#terminal-submit).
+- **No accidental page zoom** — `Ctrl`+wheel and a trackpad pinch would rescale the whole
+  page and drag the layout and the terminal's fit along with it, so both are ignored.
+  Keyboard zoom (`Cmd`/`Ctrl` `+` / `-`) still works when you mean it, and a phone's finger
+  pinch is untouched. To make terminal text bigger for real, use the font size in Settings
+  (or a directory's `fontSize`) — that re-fits the PTY instead of leaving it disagreeing.
 
 ---
 

--- a/plans/feat-896-lock-view-zoom.md
+++ b/plans/feat-896-lock-view-zoom.md
@@ -1,0 +1,39 @@
+# feat #896 — マウス/トラックパッドのズームでビューが拡大しないようにする
+
+ターミナル操作中に `ctrl + ホイール`（トラックパッドのピンチはこの形で届く）でブラウザの
+ページズームが効いてしまう。ズーム倍率が変わるとレイアウトも xterm の fit もずれるので、
+うっかり触った拡大は事故でしかない。
+
+## 何を止めて、何を残すか
+
+| 入力 | 扱い | 理由 |
+|---|---|---|
+| `wheel` + `ctrlKey` | 止める | Chrome / Firefox / Edge のピンチ・`ctrl+ホイール` はこれ |
+| `gesturestart` / `gesturechange` / `gestureend` | 止める | WebKit のトラックパッドピンチ。Safari は wheel を出さない経路がある |
+| `Cmd/Ctrl` + `+` `-` `0` | **残す** | 意図的な拡大の逃げ道。うっかり押す入力ではない |
+| スマホの指ピンチ | **残す** | `index.html` の viewport meta は触らない。電話から見るときに拡大できないのは困る |
+
+「うっかり」だけを潰して、意図した拡大は残す、という切り分け。読みづらいときの手段としては
+アプリ内のターミナルフォントサイズ設定（`useTerminalFontSize`）もある。
+
+## 実装
+
+`src/composables/usePageZoomGuard.ts` — `installFileDropGuard` と同じ形の window レベルガード。
+
+- `main.ts` で mount 前に install（両ビューとその隙間を丸ごとカバーするため）
+- `wheel` は `{ passive: false }` 必須。Chrome は window/document の wheel を既定で passive
+  扱いにするので、付けないと `preventDefault()` が黙って無視される
+- window の bubble 段で止める。ターミナル自身の wheel ハンドラ（`terminalMouseInput` の SGR
+  レポート）は子から先に走るので、そちらの動作は変わらない
+- `gesture*` は WebKit 独自イベントで `WindowEventMap` に無い。`preventDefault()` しか
+  使わないので `Event` のまま扱えばキャストは要らない
+
+## テスト
+
+`test/src/composables/usePageZoomGuard.spec.ts`
+
+- ctrl 付き wheel は preventDefault される / ctrl なしは素通り
+- gesture 3 種が preventDefault される
+- wheel は `{ passive: false }` で登録されている（これが抜けると Chrome で無言で効かなくなる）
+- teardown で全リスナが外れる
+- 実 window に dispatch して `defaultPrevented` を見る統合ケース

--- a/src/composables/usePageZoomGuard.ts
+++ b/src/composables/usePageZoomGuard.ts
@@ -1,0 +1,28 @@
+// Browser page zoom is an accident waiting to happen in a terminal: ctrl+wheel — which is
+// also what a trackpad pinch arrives as — rescales the whole page, and the layout and xterm's
+// fit go with it. This window-level net cancels the pointer-driven paths only. Keyboard zoom
+// (Cmd/Ctrl +/-/0) and a phone's finger pinch are deliberate, so they are left working.
+type ZoomTarget = Pick<Window, "addEventListener" | "removeEventListener">;
+
+// WebKit's trackpad pinch. Non-standard, absent from WindowEventMap, and Safari does not
+// always mirror it as a ctrl-wheel, so the wheel path alone would miss it.
+const GESTURE_EVENTS = ["gesturestart", "gesturechange", "gestureend"];
+
+// Chrome treats a window-level wheel listener as passive unless told otherwise, and a passive
+// listener's preventDefault() is ignored without so much as a warning.
+const WHEEL_OPTIONS: AddEventListenerOptions = { passive: false };
+
+export function installPageZoomGuard(target: ZoomTarget = window): () => void {
+  const cancelGesture = (event: Event) => event.preventDefault();
+  // Only a ctrl-modified wheel zooms; a plain wheel is scrolling and must reach the terminal.
+  const cancelZoomWheel = (event: WheelEvent) => {
+    if (event.ctrlKey) event.preventDefault();
+  };
+
+  target.addEventListener("wheel", cancelZoomWheel, WHEEL_OPTIONS);
+  GESTURE_EVENTS.forEach((type) => target.addEventListener(type, cancelGesture));
+  return () => {
+    target.removeEventListener("wheel", cancelZoomWheel, WHEEL_OPTIONS);
+    GESTURE_EVENTS.forEach((type) => target.removeEventListener(type, cancelGesture));
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import "./composables/collectionUi";
 import "./composables/accountingUi";
 import { initTheme } from "./composables/useTheme";
 import { installFileDropGuard } from "./composables/useFileDropGuard";
+import { installPageZoomGuard } from "./composables/usePageZoomGuard";
 import { router } from "./router";
 import App from "./App.vue";
 
@@ -20,6 +21,11 @@ initTheme();
 // page to the file and lose every session. Installed on window, before mount, so it
 // covers both views and any area between them.
 installFileDropGuard();
+
+// A ctrl+wheel or trackpad pinch anywhere in the tab would page-zoom the browser, moving the
+// layout and xterm's fit out from under the user. Same window-level shape as the drop guard;
+// keyboard zoom stays available for anyone who wants it on purpose.
+installPageZoomGuard();
 
 // Mount only AFTER the router's initial (async) navigation resolves. On a hard
 // reload / deep-link to /terminals, mounting eagerly would first render the single

--- a/test/src/composables/usePageZoomGuard.spec.ts
+++ b/test/src/composables/usePageZoomGuard.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { installPageZoomGuard } from "../../../src/composables/usePageZoomGuard";
+
+// A minimal window double: records listeners (with the options they were registered under, so
+// the passive:false contract is testable) and drops them on removeEventListener.
+function fakeTarget() {
+  const listeners = new Map<string, { fn: EventListener; options?: AddEventListenerOptions }>();
+  return {
+    addEventListener: (type: string, fn: EventListener, options?: AddEventListenerOptions) => listeners.set(type, { fn, options }),
+    removeEventListener: (type: string, fn: EventListener) => {
+      if (listeners.get(type)?.fn === fn) listeners.delete(type);
+    },
+    fire: (type: string, init: { ctrlKey?: boolean } = {}) => {
+      const preventDefault = vi.fn();
+      listeners.get(type)?.fn({ ...init, preventDefault } as unknown as Event);
+      return preventDefault;
+    },
+    optionsOf: (type: string) => listeners.get(type)?.options,
+    has: (type: string) => listeners.has(type),
+  };
+}
+
+const GESTURES = ["gesturestart", "gesturechange", "gestureend"];
+
+describe("installPageZoomGuard", () => {
+  it("prevents the default on a ctrl+wheel, so the browser won't page-zoom", () => {
+    const target = fakeTarget();
+    installPageZoomGuard(target);
+    expect(target.fire("wheel", { ctrlKey: true })).toHaveBeenCalled();
+  });
+
+  it("leaves a plain wheel alone, so scrolling still reaches the terminal", () => {
+    const target = fakeTarget();
+    installPageZoomGuard(target);
+    expect(target.fire("wheel", { ctrlKey: false })).not.toHaveBeenCalled();
+  });
+
+  it("prevents the default on every WebKit pinch gesture event", () => {
+    const target = fakeTarget();
+    installPageZoomGuard(target);
+    GESTURES.forEach((type) => expect(target.fire(type), type).toHaveBeenCalled());
+  });
+
+  // Without passive:false Chrome ignores the preventDefault silently, so the guard would look
+  // installed and do nothing.
+  it("registers the wheel listener as non-passive", () => {
+    const target = fakeTarget();
+    installPageZoomGuard(target);
+    expect(target.optionsOf("wheel")?.passive).toBe(false);
+  });
+
+  it("removes every listener on teardown", () => {
+    const target = fakeTarget();
+    const uninstall = installPageZoomGuard(target);
+    uninstall();
+    expect(target.has("wheel")).toBe(false);
+    GESTURES.forEach((type) => expect(target.has(type), type).toBe(false));
+  });
+
+  // The unit tests above assert preventDefault is CALLED; this drives the real window so the
+  // browser-observable effect — a cancelled event, i.e. no zoom — is what's verified.
+  it("cancels a real ctrl+wheel dispatched on window, and only that", () => {
+    const uninstall = installPageZoomGuard(window);
+    const zoom = new WheelEvent("wheel", { ctrlKey: true, cancelable: true, bubbles: true });
+    window.dispatchEvent(zoom);
+    expect(zoom.defaultPrevented).toBe(true);
+
+    const scroll = new WheelEvent("wheel", { deltaY: 120, cancelable: true, bubbles: true });
+    window.dispatchEvent(scroll);
+    expect(scroll.defaultPrevented).toBe(false);
+
+    const pinch = new Event("gesturechange", { cancelable: true, bubbles: true });
+    window.dispatchEvent(pinch);
+    expect(pinch.defaultPrevented).toBe(true);
+    uninstall();
+  });
+});


### PR DESCRIPTION
## Summary

マウス/トラックパッド操作でうっかりブラウザのページズームが効き、ビュー全体が拡大される問題の修正 (#896)。
ページズームが変わるとレイアウトも xterm の fit もずれるので、意図しない拡大は事故でしかない。

`src/composables/usePageZoomGuard.ts` を追加し、`main.ts` で mount 前に install。
`installFileDropGuard` と同じ window レベルのガード。

| 入力 | 扱い |
|---|---|
| `wheel` + `ctrlKey`（Chrome / Firefox / Edge のピンチ・ctrl+ホイール） | **止める** |
| `gesturestart` / `gesturechange` / `gestureend`（WebKit のピンチ） | **止める** |
| `Cmd`/`Ctrl` + `+` `-` `0`（キーボード） | 残す |
| スマホの指ピンチ（`index.html` の viewport meta） | 残す・**変更なし** |

「うっかり」だけを潰して、意図した拡大の逃げ道は残す、という切り分けです（スコープはユーザーと確認済み）。

## Items to Confirm / Review

1. **`{ passive: false }` が生命線です** — Chrome は window レベルの `wheel` リスナを既定で passive
   扱いにするため、これが無いと `preventDefault()` が**警告も例外もなく無視**されます。テストで
   登録オプションを直接検証していますが、リファクタで落とすと無言で機能しなくなる箇所です。
2. **ctrl なしのホイールは素通し** — xterm のスクロールと `terminalMouseInput` の SGR マウスレポート
   (#737) に影響が無いことを意図しています。ここの判定が逆になっていないかご確認ください。
3. **命名** — グリッドの「Zoom（⤢ セル拡大）」と紛らわしいので、ブラウザのページズームであることを
   明示して `usePageZoomGuard` にしました。
4. **キーボードズームを塞いでいない**のは意図的です。うっかり押す入力ではなく、拡大したい人の
   逃げ道（アクセシビリティ）として残しています。

## User Prompt

> mouse でうっかり view を拡大しないように viewport とかで固定してほしい

スコープの確認に対して「マウス/トラックパッドのみ」を選択（キーボードズームとスマホの指ピンチは残す）。

## 実装

- `src/composables/usePageZoomGuard.ts` — window レベルのガード。install が teardown 関数を返す形も
  `useFileDropGuard` に合わせています
  - `wheel` は `{ passive: false }` で登録。`ctrlKey` が立っているものだけ `preventDefault`
  - `gesture*` は WebKit 独自イベントで `WindowEventMap` に無い。`preventDefault()` しか使わないので
    `Event` のまま扱えばキャストは不要
  - window の bubble 段で止めるので、ターミナル自身の wheel ハンドラ（子）は先に走り、動作は変わりません
- `src/main.ts` — mount 前に install（両ビューとその隙間を丸ごとカバーするため）
- `README.md` — More features に 1 項目。既存の `fontSize` の記述（「browser zoom はターミナルと
  PTY を食い違わせる」）と噛み合う内容にしています
- `plans/feat-896-lock-view-zoom.md` — 設計メモ

## 検証

- **実機で動作確認済み**（ユーザーによる確認: ctrl+ホイール / トラックパッドピンチでページが拡大しない）
- ユニットテスト 6 件（`test/src/composables/usePageZoomGuard.spec.ts`）
  - ctrl 付き wheel は `preventDefault` される / ctrl なしは素通り
  - `gesture*` 3 種が `preventDefault` される
  - `wheel` が `{ passive: false }` で登録されている
  - teardown で全リスナが外れる
  - 実 `window` に dispatch して `defaultPrevented` を見る統合ケース
- `yarn format` / `yarn lint`（既存の warning 1 件のみ）/ `yarn typecheck` `typecheck:server`
  `typecheck:test` / `yarn build` / `yarn test`（4541 passed, 38 skipped）

Closes #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
