### PR TITLE
test: flake が落ちたときに原因が判るようにする (#903)

### DIFF
--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -386,8 +386,13 @@ describe("TerminalCell", () => {
     try {
       const w = mountCell(null, { defaultCwd: "/def", presets: [{ label: "x", path: "/x" }] });
       await flushPromises();
-      const sessionCalls = () =>
-        (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter((c) => String(c[0]).includes("/api/sessions")).length;
+      // The URLs, not just the count: this assertion fails intermittently on a loaded CI
+      // runner, and "expected 2 to be 1" says nothing about WHY. WHICH dir the extra fetch
+      // asked for separates the two candidates — `/typed` means the pending debounce was
+      // never cancelled, `/x` means something re-scheduled one after the fill.
+      const sessionUrls = () =>
+        (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0])).filter((u) => u.includes("/api/sessions"));
+      const sessionCalls = () => sessionUrls().length;
 
       await w.find('[data-testid="cell-dir-input"]').setValue("/typed"); // schedules a 300ms debounced load
       const before = sessionCalls();
@@ -402,8 +407,9 @@ describe("TerminalCell", () => {
       await flushPromises();
       const total = sessionCalls() - before;
 
-      expect(afterClick).toBe(1); // the fill's own immediate load
-      expect(total).toBe(1); // the pending typed-dir debounce was cancelled — no second fetch
+      expect(afterClick, `session fetches so far: ${JSON.stringify(sessionUrls())}`).toBe(1); // the fill's own immediate load
+      // The pending typed-dir debounce was cancelled — no second fetch.
+      expect(total, `session fetches after the 400ms advance: ${JSON.stringify(sessionUrls())}`).toBe(1);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary

`TerminalCell.spec.ts` の debounce テストが負荷時にたまに落ちます（今日2回、いずれも再実行で green）。`expected 2 to be 1` だけでは原因が分からないので、**余分に飛んだ `/api/sessions` の URL を失敗メッセージに載せます**。

- 余分な fetch が **`/typed`** を要求 → デバウンスが取り消されていない
- **`/x`** を要求 → fill のあとに何かが再スケジュールした

この1点で候補が二分されるので、次に CI が落ちたときログだけで経路が確定します。

Refs #903

## Items to Confirm / Review

1. **製品コードは触っていません。** 原因が取れていない状態で `flush: "sync"` などを入れると、テストだけ緑になって原因が残ります
2. **再現できていません** — 単独12回 / ファイル8回 / `test/src` 3回 / 全スイート4回、いずれも 0 失敗。落ちたのは並列ワーカーで負荷が高いとき（手元の重い同時実行と CI の共有ランナー）だけです
3. 調査の内訳と、確認済みで除外できた経路は #903 に書きました

## User Prompt

> はい、両方お願い
>
> （直前: 「この flake は今日2回目です。…リリース後に別 issue として直しますか？」に対して）