### PR TITLE
fix: Shell（launcher）/ Command セルにもディレクトリ設定のテーマ・フォントを適用する

### DIFF
--- a/plans/fix-902-dir-config-launcher-command.md
+++ b/plans/fix-902-dir-config-launcher-command.md
@@ -1,0 +1,47 @@
+# Directory config for launcher and command cells
+
+Issue: #902 (found while verifying #864 / PR #870 in the browser)
+
+## The bug
+
+`.mulmoterminal.json` reaches **two** of the four components that render a terminal:
+
+| Component | `useDirConfig` | `dir-*` props |
+|---|---|---|
+| `src/App.vue` (single view) | yes | yes |
+| `src/components/TerminalCell.vue` (grid, Claude) | yes | yes |
+| `src/components/LauncherCell.vue` (shell / codex / any launcher) | **no** | **no** |
+| `src/components/CommandCell.vue` (a `script.json` run) | **no** | **no** |
+
+So a Shell cell opened in a themed directory ignores `theme`, `colors`, `fontSize`, and
+`fontFamily` entirely. It predates this work — `git show origin/main:src/components/LauncherCell.vue
+| grep -c dir-font-size` was `0` before #870 too, so #860/#866 shipped with the same hole.
+
+Why it went unnoticed: the two cells that *do* work are the ones anyone demoing a directory theme
+reaches for. The gap only shows if you open a plain shell in a directory you have themed — and then
+it reads as "the setting is broken", not "this cell type is unwired".
+
+## The fix
+
+Call `useDirConfig` in both components and hand the same four terminal props down. `Terminal.vue`
+already accepts and applies them, so the change is entirely on the calling side.
+
+- **`LauncherCell.vue`** — `useDirConfig(toRef(props, "cwd"))`.
+- **`CommandCell.vue`** — the cwd lives one level in, at `props.command.cwd`, so a getter ref.
+
+## Deliberately NOT in scope
+
+**The name badge and header colours.** `TerminalCell` renders `dirConfig.name` as a badge and tints
+its header from `headerColor` / `buttonColor`; these two components have their own, different header
+markup (a launcher shows its command label, a command cell its summary panel). Fitting a badge into
+them is a design question, not a wiring one, and the terminal-side gap is what makes the feature look
+broken. Recorded on the issue rather than guessed at here.
+
+That means after this change a Shell cell adopts the directory's **font and palette** but still shows
+no name badge — worth stating plainly so the next person doesn't read it as a half-applied fix.
+
+## Tests
+
+`test/src/components/TerminalCellDirFont.spec.ts` already pins this wiring for `TerminalCell` — the
+same shape, one component over. Add the launcher and command equivalents so the hole cannot reopen in
+either.

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref, toRef, watch } from "vue";
 import TerminalView from "./Terminal.vue";
+import { useDirConfig } from "../composables/useDirConfig";
 import CellChromeButtons from "./CellChromeButtons.vue";
 import type { RunCommand } from "./runCommand";
 import { formatCwd } from "./cwdDisplay";
@@ -50,6 +51,10 @@ const emit = defineEmits<GridCellEmits>();
 const connectKey = ref(0);
 const finished = ref(false);
 const termRef = ref<InstanceType<typeof TerminalView>>();
+
+// Same as LauncherCell (#902): a command runs in a directory, so its terminal takes that
+// directory's palette and font. A getter ref because the cwd lives inside the `command` object.
+const { config: dirConfig } = useDirConfig(toRef(() => props.command.cwd));
 
 const dirDisplay = computed(() => formatCwd(props.command.cwd, props.home));
 
@@ -195,6 +200,10 @@ function onHeaderClick(event: MouseEvent) {
       :connect-key="connectKey"
       :cwd="command.cwd"
       :command="command"
+      :dir-theme="dirConfig.theme"
+      :dir-colors="dirConfig.colors"
+      :dir-font-size="dirConfig.fontSize"
+      :dir-font-family="dirConfig.fontFamily"
       :expanded="expanded"
       :zoomed="zoomed"
       @exit="onExit"

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref, toRef, watch } from "vue";
 import TerminalView from "./Terminal.vue";
+import { useDirConfig } from "../composables/useDirConfig";
 import CellChromeButtons from "./CellChromeButtons.vue";
 import { formatCwd } from "./cwdDisplay";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
@@ -54,6 +55,11 @@ function onHeaderClick(event: MouseEvent) {
 const connectKey = ref(0);
 const finished = ref(false);
 
+// A launcher cell is still a terminal opened IN a directory, so it adopts that directory's palette
+// and font exactly as a Claude cell does (#902). The header badge/colours stay out: this cell has
+// its own header markup, and fitting a name badge into it is a design call, not wiring.
+const { config: dirConfig } = useDirConfig(toRef(props, "cwd"));
+
 const dirDisplay = computed(() => formatCwd(props.cwd, props.home));
 const target = computed(() => (isShellLauncher(props.launcher) ? { shell: true as const } : { index: props.launcher.index }));
 
@@ -105,6 +111,10 @@ function relaunch() {
       :connect-key="connectKey"
       :cwd="cwd"
       :launcher="target"
+      :dir-theme="dirConfig.theme"
+      :dir-colors="dirConfig.colors"
+      :dir-font-size="dirConfig.fontSize"
+      :dir-font-family="dirConfig.fontFamily"
       :expanded="expanded"
       :zoomed="zoomed"
       @session="onSession"

--- a/test/src/components/LauncherCommandDirFont.spec.ts
+++ b/test/src/components/LauncherCommandDirFont.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import LauncherCell from "../../../src/components/LauncherCell.vue";
+import CommandCell from "../../../src/components/CommandCell.vue";
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+
+// Declares the dir-* props so the test sees what each cell actually hands its terminal. These two
+// cells passed NONE of them before #902, so a directory's theme/font applied to Claude cells and
+// the single view but silently not here.
+let seen: Record<string, unknown> | null = null;
+vi.mock("../../../src/components/Terminal.vue", () => ({
+  default: {
+    name: "TerminalView",
+    props: ["sessionId", "connectKey", "cwd", "launcher", "command", "dirTheme", "dirColors", "dirFontSize", "dirFontFamily"],
+    created() {
+      seen = (this as unknown as { $props: Record<string, unknown> }).$props;
+    },
+    template: "<div />",
+  },
+}));
+
+// Reset through a function: assigning `seen = null` inline narrows it to `null` for the rest of the
+// test, and the mock factory's write back is invisible to control-flow analysis.
+function forgetSeen(): void {
+  seen = null;
+}
+
+// A distinct directory per test — useDirConfig caches per cwd at module level.
+const DIR_LAUNCHER = "/proj/launcher-dir-font";
+const DIR_COMMAND = "/proj/command-dir-font";
+
+function serve(dirConfig: Record<string, unknown>) {
+  globalThis.fetch = vi.fn(async (url: string) => {
+    if (String(url).includes("/api/dir-config")) return { ok: true, json: async () => dirConfig };
+    return { ok: true, json: async () => ({}) };
+  }) as unknown as typeof fetch;
+}
+
+const DIR_CONFIG = { name: "THEMED", theme: "nord", fontSize: 20, fontFamily: "Songti SC, monospace" };
+
+describe("LauncherCell passes the directory's terminal look down (#902)", () => {
+  it("adopts the directory's theme, size and font family", async () => {
+    forgetSeen();
+    serve(DIR_CONFIG);
+    const w = mount(LauncherCell, {
+      props: {
+        uid: 1,
+        expanded: false,
+        zoomed: false,
+        launcher: { shell: true, label: "Shell" },
+        session: null,
+        cwd: DIR_LAUNCHER,
+        home: "/home/me",
+      },
+    });
+    await flushPromises();
+
+    expect(seen?.dirTheme).toBe("nord");
+    expect(seen?.dirFontSize).toBe(20);
+    expect(seen?.dirFontFamily).toBe("Songti SC, monospace");
+    w.unmount();
+  });
+});
+
+describe("CommandCell passes the directory's terminal look down (#902)", () => {
+  // The cwd lives inside the `command` object here, not as a top-level prop — the one thing that
+  // differs from LauncherCell, and the reason this reads through a getter ref.
+  it("resolves the config from command.cwd", async () => {
+    forgetSeen();
+    serve(DIR_CONFIG);
+    const w = mount(CommandCell, {
+      props: {
+        uid: 2,
+        expanded: false,
+        zoomed: false,
+        command: { source: "script" as const, index: 0, label: "build", cwd: DIR_COMMAND },
+        home: "/home/me",
+      },
+    });
+    await flushPromises();
+
+    expect(seen?.dirTheme).toBe("nord");
+    expect(seen?.dirFontSize).toBe(20);
+    expect(seen?.dirFontFamily).toBe("Songti SC, monospace");
+    w.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

A directory's `.mulmoterminal.json` reached only **two** of the four components that render a
terminal. `LauncherCell.vue` (Shell / codex / any launcher) and `CommandCell.vue` (a `script.json`
run) never called `useDirConfig` and passed none of the `dir-*` props, so a plain Shell cell opened
in a themed directory ignored `theme`, `colors`, `fontSize` and `fontFamily` entirely.

`Terminal.vue` already accepts and applies these, so the fix is entirely on the calling side.

Closes #902.

## Items to Confirm / Review

1. **The name badge is deliberately still missing.** `TerminalCell` renders `dirConfig.name` as a
   badge and tints its header; these two components have their own header markup (a launcher shows
   its command label, a command cell its summary panel), so fitting a badge in is a design question,
   not wiring. **A Shell cell will now take the directory's font and palette but still show no
   badge** — please confirm that split is what you want, since the missing badge is what originally
   made this look broken.
2. **`CommandCell` cells are ephemeral.** Their terminal is torn down on unmount, so this only
   affects the run's own appearance. Worth a sanity check that adopting a dir palette there is
   wanted at all, rather than keeping runs visually neutral.
3. **Scope check.** I passed the same four props `TerminalCell` passes. I did **not** pass
   `dir-header-color` / `dir-header-text-color` / `dir-button-color`, which are chrome, not
   terminal — same reasoning as the badge.

## How this was found

While verifying #870 (`fontFamily`) in a browser. The feature applied correctly in a Claude cell and
not at all in a Shell cell next to it, which read as a bug in the new code. It was not: the same
directory's `name` badge was missing too, and `name` predates all of this.

Confirmed pre-existing rather than assumed:

```
$ git show origin/main:src/components/LauncherCell.vue | grep -c dir-font-size
0
```

So #860/#866 (`fontSize`) shipped with the identical hole, as did `theme`/`colors` before them.

## Why it stayed invisible

The two wired components are exactly the ones anyone demoing a directory theme reaches for. The gap
only surfaces if you open a **plain shell** in a directory you have themed — and at that point it
reads as "the setting is broken", not "this cell type is unwired".

## Tests

`test/src/components/LauncherCommandDirFont.spec.ts` — one spec per component, modelled on the
`TerminalCell` equivalent added in #870.

**Both were confirmed to FAIL against the unfixed components before being kept** (stash the two
`.vue` changes, run, watch them go red). A wiring test that passes either way proves nothing.

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` all
pass — 4570 tests. Exit codes checked individually.

> Note for anyone running this locally: `yarn typecheck:test` fails on a stale `node_modules` with
> `'timeZone' does not exist in type 'CalendarSummary'`. That is `@mulmoclaude/core` 1.6.0 against a
> `^1.7.0` requirement, not a code problem — `yarn install` clears it. `main` shows the same
> symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
