### PR TITLE
feat: Shell / Command セルにも名前バッジを出す（グリッド 3 セルで DirBadge を共通化）

### DIFF
--- a/plans/feat-914-dir-badge-launcher-command.md
+++ b/plans/feat-914-dir-badge-launcher-command.md
@@ -1,0 +1,53 @@
+# The directory name badge on every grid cell
+
+Issue: #914 (follows #902 / #906 / #909)
+
+## The gap
+
+`.mulmoterminal.json`'s `name` renders as a coloured chip in a cell header. It appeared on Claude
+cells and the single view only; a **shell or command cell in the same directory showed nothing**.
+
+Not a regression — `git log -S "dirConfig.name" -- src/components/LauncherCell.vue` returns nothing.
+It was never written. #906 gave those cells the terminal's palette and font but left the badge out,
+which produced the odd half-state: the colours and font change, the project label doesn't.
+
+It also cost real debugging time. A missing badge and a missing config look identical from the
+outside, which is part of why #902 took several rounds to read correctly.
+
+## Why a component rather than two more copies
+
+The markup existed twice. Adding it to two more cells would make four. CLAUDE.md is explicit:
+repeated utility runs are extracted as a shared **component**, never re-pasted.
+
+`src/components/DirBadge.vue` takes `name` + `color` and renders nothing without a name. The three
+grid cells use it; `badgeStyleFor` (`dirBadge.ts`) keeps doing the contrast maths it already did.
+
+`TerminalCell`'s own `dirBadgeStyle` computed died with the change and is removed — knip would have
+caught it, but it is worth not leaving behind.
+
+### The single view keeps its own
+
+`Terminal.vue`'s badge is `max-w-[16ch] px-2 leading-[1.6]`; the grid's is
+`max-w-[14ch] flex-none px-[7px] font-sans`. That difference is deliberate — the single view's
+header has more room. Forcing one component onto both would change how it looks, which is not what
+this issue asked for. Two variants, honestly labelled, beats one variant that silently restyles a
+screen.
+
+## `useDirConfig` comes back to two cells
+
+#911 removed it from `LauncherCell` / `CommandCell` because the terminal resolves its own canvas
+settings now. The badge is **chrome**, and #911's line was explicit that chrome stays the host's
+job — which is exactly why `TerminalCell` and `App.vue` kept theirs. So this is that line being
+applied, not walked back.
+
+## Tests
+
+`test/src/components/dirBadgeCells.spec.ts` — the component (renders, disappears without a name,
+derives a readable text colour) plus one spec per grid cell asserting the badge actually reaches
+the header.
+
+Named `dirBadgeCells` deliberately: `dirBadge.spec.ts` already exists for the style helper, and on
+a case-insensitive filesystem `DirBadge.spec.ts` would have silently overwritten it while remaining
+a separate file on Linux CI.
+
+The two cell specs were confirmed to **fail without the wiring** before being kept.

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref, toRef, watch } from "vue";
+import DirBadge from "./DirBadge.vue";
+import { useDirConfig } from "../composables/useDirConfig";
 import TerminalView from "./Terminal.vue";
 import CellChromeButtons from "./CellChromeButtons.vue";
 import type { RunCommand } from "./runCommand";
@@ -50,6 +52,10 @@ const emit = defineEmits<GridCellEmits>();
 const connectKey = ref(0);
 const finished = ref(false);
 const termRef = ref<InstanceType<typeof TerminalView>>();
+
+// Same as LauncherCell (#914): the badge belongs to this cell's header, so it reads the config
+// here. A getter ref because the cwd lives inside the `command` object.
+const { config: dirConfig } = useDirConfig(toRef(() => props.command.cwd));
 
 const dirDisplay = computed(() => formatCwd(props.command.cwd, props.home));
 
@@ -163,6 +169,7 @@ function onHeaderClick(event: MouseEvent) {
       <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="command.cwd ?? ''"
         ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
       >
+      <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
       <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ command.label }}</span>
       <span class="cell-actions" :class="CELL_ACTIONS">
         <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move command left" @click="emit('move', -1)">

--- a/src/components/DirBadge.vue
+++ b/src/components/DirBadge.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { badgeStyleFor } from "./dirBadge";
+
+// The directory's `name` from .mulmoterminal.json, as the coloured chip in a GRID cell's header.
+// Shared by all three grid cells (Claude/codex, launcher, command) so a project reads the same
+// wherever it is running — before this they had 1, 0 and 0 copies of it respectively (#914).
+//
+// The single view's badge (Terminal.vue) is deliberately NOT this component: its header has more
+// room and uses a wider cap and looser leading, and unifying them would change how it looks.
+defineProps<{ name: string | null | undefined; color: string | null | undefined }>();
+</script>
+
+<template>
+  <span
+    v-if="name"
+    class="max-w-[14ch] flex-none truncate rounded-[10px] px-[7px] py-px font-sans text-[11px] font-semibold"
+    :style="badgeStyleFor(color)"
+    :title="name"
+    >{{ name }}</span
+  >
+</template>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref, toRef, watch } from "vue";
+import DirBadge from "./DirBadge.vue";
+import { useDirConfig } from "../composables/useDirConfig";
 import TerminalView from "./Terminal.vue";
 import CellChromeButtons from "./CellChromeButtons.vue";
 import { formatCwd } from "./cwdDisplay";
@@ -54,6 +56,10 @@ function onHeaderClick(event: MouseEvent) {
 const connectKey = ref(0);
 const finished = ref(false);
 
+// The name badge is CHROME — this cell's own header, not the terminal canvas (#914). The
+// canvas side resolves itself inside Terminal.vue (#911); this is the other half of that line.
+const { config: dirConfig } = useDirConfig(toRef(props, "cwd"));
+
 const dirDisplay = computed(() => formatCwd(props.cwd, props.home));
 const target = computed(() => (isShellLauncher(props.launcher) ? { shell: true as const } : { index: props.launcher.index }));
 
@@ -83,6 +89,7 @@ function relaunch() {
       <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="cwd ?? ''"
         ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
       >
+      <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
       <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">rocket_launch</span> {{ launcher.label }}</span>
       <span class="cell-actions" :class="CELL_ACTIONS">
         <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -5,7 +5,7 @@ import { usePubSub } from "../composables/usePubSub";
 import { useDirConfig } from "../composables/useDirConfig";
 import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
-import { badgeStyleFor } from "./dirBadge";
+import DirBadge from "./DirBadge.vue";
 import { isCellContext, isCellUsage, type CellContext, type CellUsage } from "./cellPayload";
 import { unsavedWork } from "./unsavedWork";
 import { relativeTime as relativeTimeFrom, usageBadge } from "./cellDisplay";
@@ -104,7 +104,6 @@ const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
 // Per-directory overrides (<cwd>/.mulmoterminal.json): pins this cell's terminal
 // palette and shows a project badge. Re-fetched when the effective cwd changes.
 const { config: dirConfig } = useDirConfig(cwd);
-const dirBadgeStyle = computed(() => badgeStyleFor(dirConfig.value.badgeColor));
 const headerStyle = computed(() => headerStyleFor(dirConfig.value.headerColor, dirConfig.value.headerTextColor));
 const cellStyle = computed(() =>
   cellStyleFor(dirConfig.value.cellColor, dirConfig.value.cellBorderColor, dirConfig.value.dotColor, dirConfig.value.buttonColor),
@@ -1051,13 +1050,7 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           <!-- Info (dir badge / git / diff / model / tokens) is dropped on a filmstrip
                thumbnail, leaving only dir + what it's doing + a zoom button. -->
           <template v-if="!filmstrip">
-            <span
-              v-if="dirConfig.name"
-              class="max-w-[14ch] flex-none truncate rounded-[10px] px-[7px] py-px font-sans text-[11px] font-semibold"
-              :style="dirBadgeStyle"
-              :title="dirConfig.name"
-              >{{ dirConfig.name }}</span
-            >
+            <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
             <template v-for="chip in cellChips" :key="chip.key">
               <GitBranchChip v-if="chip.builtin === 'git'" :status="gitStatus" :hide-dirty="isWorktreeCell" />
               <button

--- a/test/src/components/dirBadgeCells.spec.ts
+++ b/test/src/components/dirBadgeCells.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import DirBadge from "../../../src/components/DirBadge.vue";
+import LauncherCell from "../../../src/components/LauncherCell.vue";
+import CommandCell from "../../../src/components/CommandCell.vue";
+import TerminalCell from "../../../src/components/TerminalCell.vue";
+
+// `dirBadge.spec.ts` next to this one covers badgeStyleFor (the contrast maths). This file covers
+// the COMPONENT and, more importantly, that all three grid cells actually render it.
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+
+vi.mock("../../../src/components/Terminal.vue", () => ({
+  default: { name: "TerminalView", props: ["sessionId", "connectKey", "cwd", "launcher", "command", "hideHeader"], template: "<div />" },
+}));
+
+function serveDirConfig(dirConfig: Record<string, unknown>) {
+  globalThis.fetch = vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u.includes("/api/dir-config")) return { ok: true, json: async () => dirConfig };
+    if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/x", scripts: [] }) };
+    if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+    return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+  }) as unknown as typeof fetch;
+}
+
+describe("DirBadge", () => {
+  it("renders the name, and nothing at all without one", () => {
+    expect(mount(DirBadge, { props: { name: "PROD", color: "#cf222e" } }).text()).toBe("PROD");
+    // `v-if`, not an empty span: an unnamed directory must not leave a gap in the header row.
+    expect(mount(DirBadge, { props: { name: null, color: null } }).html()).toBe("<!--v-if-->");
+    expect(mount(DirBadge, { props: { name: "", color: null } }).html()).toBe("<!--v-if-->");
+  });
+
+  // The background is the directory's; the TEXT colour is derived for contrast — the part a
+  // hand-written fourth copy of this badge would most likely have dropped.
+  it("uses the directory's colour with a readable text colour on top", () => {
+    const style = mount(DirBadge, { props: { name: "P", color: "#190a23" } }).attributes("style");
+    expect(style).toContain("background: rgb(25, 10, 35)");
+    expect(style).toContain("color: rgb(255, 255, 255)");
+  });
+});
+
+// The point of #914. The badge is how a user tells parallel projects apart, and it appeared on
+// Claude cells only — a shell cell in the same directory showed nothing. That also made #902 hard
+// to read, since a missing badge looks exactly like a missing config.
+describe("every grid cell shows the directory's badge", () => {
+  const DIR = { name: "PROD", badgeColor: "#cf222e" };
+
+  it("LauncherCell", async () => {
+    serveDirConfig(DIR);
+    const w = mount(LauncherCell, {
+      props: {
+        uid: 1,
+        expanded: false,
+        zoomed: false,
+        launcher: { shell: true, label: "Shell" },
+        session: null,
+        cwd: "/proj/badge-launcher",
+        home: "/home/me",
+      },
+    });
+    await flushPromises();
+    expect(w.findComponent(DirBadge).text()).toBe("PROD");
+    w.unmount();
+  });
+
+  it("CommandCell", async () => {
+    serveDirConfig(DIR);
+    const w = mount(CommandCell, {
+      props: {
+        uid: 2,
+        expanded: false,
+        zoomed: false,
+        command: { source: "script" as const, index: 0, label: "build", cwd: "/proj/badge-command" },
+        home: "/home/me",
+      },
+    });
+    await flushPromises();
+    expect(w.findComponent(DirBadge).text()).toBe("PROD");
+    w.unmount();
+  });
+
+  it("TerminalCell", async () => {
+    serveDirConfig(DIR);
+    const w = mount(TerminalCell, {
+      props: {
+        uid: 3,
+        expanded: false,
+        zoomed: false,
+        initialSessionId: "11111111-1111-1111-1111-111111111111",
+        initialCwd: "/proj/badge-terminal",
+        defaultCwd: "/proj/badge-terminal",
+        presets: [],
+        home: "/home/me",
+        cancellable: false,
+        openSessionIds: [],
+        openCwds: [],
+      },
+    });
+    await flushPromises();
+    expect(w.findComponent(DirBadge).text()).toBe("PROD");
+    w.unmount();
+  });
+});


### PR DESCRIPTION
## Summary

`.mulmoterminal.json` の `name` バッジを、**Shell（launcher）セルと Command セルのヘッダーにも表示**します。
マークアップを 4 箇所に増やす代わりに、グリッド 3 セル分を共通コンポーネント `DirBadge.vue` に抽出しました。

Closes #914.

## デグレではありません

念のため履歴で確認済みです。

```
$ git log -S "dirConfig.name" -- src/components/LauncherCell.vue
（該当コミットなし）
```

**一度も書かれたことがない**機能です。#906 でこの 2 セルに端末側の設定（パレット・フォント）は届くように
なりましたが、バッジは範囲外にしたままだったので、「色とフォントは変わるのにプロジェクト名だけ出ない」
という中途半端な状態になっていました。

デバッグコストも実際に払っています — **バッジが無い状態と設定が届いていない状態は外から見分けがつかず**、
#902 の切り分けが何往復もかかった一因でした。

## 貼り足しではなく抽出した理由

同じマークアップが既に 2 箇所にあり、素直に足すと 4 箇所になります。CLAUDE.md は
「繰り返すユーティリティ列は共通**コンポーネント**に抽出、CSS クラス共有は不可」と明記しています。

- `src/components/DirBadge.vue` — `name` / `color` を受け取り、`name` が無ければ `v-if` で**何も描かない**
- `badgeStyleFor`（`dirBadge.ts`）はそのまま。コントラスト計算は既に共通でした
- `TerminalCell` の `dirBadgeStyle` computed は不要になったので削除（knip が拾う前に）

### 単一ビューは共通化していません

| | クラス |
|---|---|
| 単一ビュー（`Terminal.vue`） | `max-w-[16ch] px-2 leading-[1.6]` |
| グリッド 3 セル | `max-w-[14ch] flex-none px-[7px] font-sans` |

ヘッダーの余白制約が違うための**意図的な差**です。1 つに統合すると単一ビューの見た目が変わってしまい、
この issue が求めていないことをすることになります。**ラベル付きの 2 バリアント**のほうが、
黙って別画面を作り替える 1 バリアントより良いという判断です。

## #911 との関係（walk back ではありません）

#911 で `LauncherCell` / `CommandCell` から `useDirConfig` を外しましたが、今回戻しています。

#911 が引いた線は「**端末のキャンバスは `Terminal.vue` の責務、周囲のクロームはホストの責務**」で、
`TerminalCell` / `App.vue` が `useDirConfig` を保持しているのも同じ理由です。バッジはクロームなので、
これはその線を**適用**したものであって、撤回ではありません。

## Items to Confirm / Review

1. **バッジの位置。** launcher/command セルではパス表示の直後、コマンド名ラベルの直前に置きました
   （`TerminalCell` と同じ並び）。ヘッダーが狭いセルでの見え方は一度見ていただきたいです。
2. **単一ビューを別実装のまま残した判断**（上記）。統合したいなら別 PR にします。

## Tests

`test/src/components/dirBadgeCells.spec.ts`:

- コンポーネント — 描画される / 名前が無ければ `<!--v-if-->` で消える / 背景色に対して**読める文字色**になる
- グリッド 3 セルそれぞれで、バッジが実際にヘッダーへ到達すること

**launcher / command の 2 spec は、配線を外した状態で FAIL することを確認**してから残しています。

ファイル名が `dirBadgeCells.spec.ts` なのは意図的です。`dirBadge.spec.ts`（スタイル関数用）が既にあり、
case-insensitive なファイルシステムでは `DirBadge.spec.ts` が**それを黙って上書き**しつつ
Linux CI では別ファイルとして残る、という事故になるためです（実際に一度踏みかけました）。

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` すべて
exit=0、**4579 tests passing**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
