### PR TITLE
test: マウントしたコンポーネントを全 spec で後始末する (#903)

### DIFF
--- a/test/setup-auto-unmount.ts
+++ b/test/setup-auto-unmount.ts
@@ -1,0 +1,15 @@
+// Every spec that mounts a component gets its wrappers torn down after each test.
+//
+// Without this a mounted component OUTLIVES the test that created it: its watchers keep
+// running and its pending timers keep ticking on the real clock. The counters specs read
+// (fetch mocks, emitted events) are global, so a leftover component's late work is counted
+// as the NEXT test's — which is what made the TerminalCell debounce case fail only on a
+// loaded runner, where a later test's measurement window stretches far enough to overlap a
+// previous test's 300ms debounce (#903).
+//
+// Global rather than per-file: 18 spec files mounted without ever unmounting, and the next
+// one written would have joined them.
+import { enableAutoUnmount } from "@vue/test-utils";
+import { afterEach } from "vitest";
+
+enableAutoUnmount(afterEach);

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -95,7 +95,6 @@ function mountCell(
       openCwds: opts.openCwds ?? [],
     },
   });
-  return wrapper;
 }
 
 describe("TerminalCell", () => {

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalCell from "../../../src/components/TerminalCell.vue";
@@ -60,10 +60,22 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+// Every cell this file mounts stays alive unless it is torn down: its `dirInput` watcher and
+// its 300ms resume debounce keep running, and the fetch counter these tests read is GLOBAL.
+// A cell left over from an earlier test fires its debounce on the REAL clock, so on a loaded
+// runner it can land inside a later test's measurement window and add an `/api/sessions` call
+// that test never made — which is what made the debounce case flaky (#903).
+const mounted: { unmount: () => void }[] = [];
+
 beforeEach(() => {
   captured = null;
   reconnect = null;
   mockFetch();
+});
+
+afterEach(() => {
+  // onUnmounted clears the pending debounce, so nothing survives into the next test.
+  mounted.splice(0).forEach((w) => w.unmount());
 });
 
 function mountCell(
@@ -80,7 +92,7 @@ function mountCell(
     zoomed?: boolean;
   } = {},
 ) {
-  return mount(TerminalCell, {
+  const wrapper = mount(TerminalCell, {
     props: {
       uid: 1,
       expanded: opts.expanded ?? false,
@@ -95,6 +107,8 @@ function mountCell(
       openCwds: opts.openCwds ?? [],
     },
   });
+  mounted.push(wrapper);
+  return wrapper;
 }
 
 describe("TerminalCell", () => {

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalCell from "../../../src/components/TerminalCell.vue";
@@ -60,22 +60,10 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-// Every cell this file mounts stays alive unless it is torn down: its `dirInput` watcher and
-// its 300ms resume debounce keep running, and the fetch counter these tests read is GLOBAL.
-// A cell left over from an earlier test fires its debounce on the REAL clock, so on a loaded
-// runner it can land inside a later test's measurement window and add an `/api/sessions` call
-// that test never made — which is what made the debounce case flaky (#903).
-const mounted: { unmount: () => void }[] = [];
-
 beforeEach(() => {
   captured = null;
   reconnect = null;
   mockFetch();
-});
-
-afterEach(() => {
-  // onUnmounted clears the pending debounce, so nothing survives into the next test.
-  mounted.splice(0).forEach((w) => w.unmount());
 });
 
 function mountCell(
@@ -92,7 +80,7 @@ function mountCell(
     zoomed?: boolean;
   } = {},
 ) {
-  const wrapper = mount(TerminalCell, {
+  return mount(TerminalCell, {
     props: {
       uid: 1,
       expanded: opts.expanded ?? false,
@@ -107,7 +95,6 @@ function mountCell(
       openCwds: opts.openCwds ?? [],
     },
   });
-  mounted.push(wrapper);
   return wrapper;
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   plugins: [vue()],
   test: {
     environment: "jsdom",
+    // Tears down every mounted component after each test — see the file for why.
+    setupFiles: ["./test/setup-auto-unmount.ts"],
     include: ["src/**/*.spec.ts", "test/**/*.spec.ts", "server/**/*.spec.ts", "bin/**/*.spec.ts"],
     // The suite runs files in parallel across all cores. On a machine also running a build
     // (a dev's `yarn build` alongside `yarn test`) the cores are oversubscribed, so an


### PR DESCRIPTION
## Summary

#903 の flake の**原因が取れました**。製品コードは正常で、原因は**テストの後始末漏れ**です。

マウントしたコンポーネントは、それを作ったテストより長生きします。watcher は回り続け、保留中のタイマーは**実時間**で動き続けます。spec が読むカウンタ（fetch モック、emit）は**グローバル**なので、居残ったコンポーネントの遅れた仕事が「次のテストのもの」として数えられます。

`enableAutoUnmount(afterEach)` を **setupFiles 1本**で全体に効かせます。

Closes #903

## なぜ負荷時にだけ落ちたのか

計測窓（`before` を取ってから数えるまで）が伸びて、**残存タイマーの発火時刻を跨ぐ**ようになるためです。窓が短いうちは、残存タイマーはテストが終わったあとに発火するので誰にも観測されません。単独実行で落ちないのも同じ理由で、先行するセルが存在しません。

## 実コンポーネントで効果を確認

テストAが dir を打って 300ms デバウンスを仕掛け、テストBが実時間 400ms 待って `/api/sessions` を数える probe を書き、設定の有無だけを変えて比較しました。

| | 結果 |
|---|---|
| **掃除なし** | ✗ `leaked fetches: ["/api/sessions?cwd=%2Fleaked-dir"]` — **A が打った dir が B の計測に現れる** |
| **掃除あり（本PR）** | ✓ 漏れゼロ |

これが `expected 2 to be 1` の正体です。2件目は前のテストのセルが出した fetch で、デバウンスのキャンセル自体は正しく動いています。

## なぜ per-file ではなく setupFiles か

**18 の spec ファイルが mount しっぱなし**でした（合計 38 箇所）。1ファイルずつ直しても、次に書かれる spec が同じ列に加わるだけです。1箇所で全体に効かせ、将来書かれるものにも自動的に効くようにしました。

## Items to Confirm / Review

1. **製品コードは変更していません** — `flush: "sync"` などの推測修正は入れていません
2. **全 spec の挙動が変わります**（マウントしたものが毎回破棄される）。4597 件すべて green で、副作用は観測されていませんが、性質としては横断的な変更です
3. #904 で入れた URL 診断はそのまま残しています（別の経路で再発したときに効きます）

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/903 調査できる？
>
> はい、副作用ない範囲で全部なおして PR ーマージまで。

## 検証

- フルスイート **4597 件** green
- **6 並列**（CPU 競合）で 0 失敗
- `yarn lint` 0 errors / `yarn typecheck` ×3 通過
- 掃除の有無での比較（上表）