### PR TITLE
test: フォント変更が PTY に届くことを検証する（#860/#864 の要が未検証だった）

### DIFF
--- a/test/src/composables/useTerminalConnections.spec.ts
+++ b/test/src/composables/useTerminalConnections.spec.ts
@@ -23,6 +23,9 @@ vi.mock("@xterm/xterm", () => ({
     cols = 80;
     rows = 24;
     constructor(opts: Record<string, unknown>) {
+      // The SAME object, not a copy: setFont/setTheme mutate `term.options` after construction,
+      // and a test that only saw the constructor argument could not tell whether they landed.
+      this.options = opts;
       mockTermState.options = opts;
     }
     // ensure() registers the mouse-tracking guards through this (#729); the guards' own behaviour
@@ -547,5 +550,67 @@ describe("isClaudeTarget", () => {
     expect(conn.isClaudeTarget({ ...base, codex: true })).toBe(false);
     expect(conn.isClaudeTarget({ ...base, command: { source: "script", index: 0, label: "dev", cwd: null } })).toBe(false);
     expect(conn.isClaudeTarget({ ...base, devTerminal: true })).toBe(false);
+  });
+});
+
+// The load-bearing half of #860/#864, and the half nothing asserted until now: changing the font
+// changes the CELL METRICS, so cols/rows change and the PTY has to be told. Delete the re-fit from
+// setFont and every other test in this repo still passes, while the bug #860 was filed for — a
+// canvas grid the shell disagrees with, so the cursor and wrap points drift — comes silently back.
+//
+// The observable contract is the resize frame on the wire, not a call count, so that is what these
+// assert.
+describe("setFont — a font change must reach the PTY, not just the canvas", () => {
+  const FONT = { size: 14, family: "'JetBrains Mono', monospace" };
+  const resizes = (ws: FakeWebSocket) => ws.sent.filter((m) => JSON.parse(m).type === "resize");
+
+  function attachOpenSlot(key: string) {
+    FakeWebSocket.instances.length = 0;
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    conn.attach(key, target(null), { onSession: vi.fn(), onCwd: vi.fn() }, document.createElement("div"), undefined, FONT);
+    const ws = FakeWebSocket.instances.at(-1);
+    if (!ws) throw new Error("no socket created");
+    ws.onopen?.(); // open, so fitAndSyncSize's readyState guard lets the resize through
+    ws.sent.length = 0; // ignore the frames attach() itself produced
+    return ws;
+  }
+
+  afterEach(() => {
+    conn.release("cell-font");
+  });
+
+  it("applies BOTH options and pushes the new geometry to the PTY", () => {
+    const ws = attachOpenSlot("cell-font");
+
+    conn.setFont("cell-font", { size: 24, family: "'Songti SC', monospace" });
+
+    expect(mockTermState.options.fontSize).toBe(24);
+    expect(mockTermState.options.fontFamily).toBe("'Songti SC', monospace");
+    expect(resizes(ws)).toHaveLength(1);
+  });
+
+  // A family alone moves the advance width just as a size does, so it must re-fit too — the case
+  // #864 added and the one a size-only implementation would quietly miss.
+  it("re-fits for a family change on its own, not only a size change", () => {
+    const ws = attachOpenSlot("cell-font");
+
+    conn.setFont("cell-font", { size: FONT.size, family: "'Songti SC', monospace" });
+
+    expect(mockTermState.options.fontFamily).toBe("'Songti SC', monospace");
+    expect(resizes(ws)).toHaveLength(1);
+  });
+
+  // Terminal.vue's watcher fires on every dir-config resolution, and most directories pin no font
+  // at all. Re-fitting there would churn every terminal on every load for nothing.
+  it("does nothing when the font is unchanged", () => {
+    const ws = attachOpenSlot("cell-font");
+
+    conn.setFont("cell-font", { ...FONT });
+
+    expect(resizes(ws)).toHaveLength(0);
+  });
+
+  it("ignores a slot that does not exist rather than throwing", () => {
+    expect(() => conn.setFont("cell-not-here", { size: 20, family: "monospace" })).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

`setFont` が**再フィットして PTY に新しいジオメトリを伝えること**を検証するテストを追加しました。
#860 / #864 の要（かなめ）でありながら、**何も検証していなかった**箇所です。

テストのみの変更です（`src/` は無変更）。

## なぜこれが穴だったか

フォントを変えるとセルの寸法が変わり、`cols`/`rows` が変わるので **PTY に伝える必要があります**。
`setFont` から `fitAndSyncSize(c)` を消すと、**このコミット以前はリポジトリの全テストが通ったまま**、
#860 で報告されたバグが静かに戻ります — キャンバスのグリッドとシェルの認識がずれ、カーソル位置と
折り返しが崩れる。ブラウザズームが回避策にならなかったのと同じ現象です。

diff を読んでいて気づける類の欠落ではありません。

## 主張を検証してから残しています

アサーションを信用せず、**退行を実際に作って**確認しました。

```
再フィットを削除 → 2 件 FAIL
復元           → 33 件すべて PASS
```

## ワイヤ上の resize フレームを見ています

`fit()` の呼び出し回数ではありません。観測可能な契約は「**プロセスが新しいジオメトリを知ること**」で、
呼び出し回数は実装詳細です。回数を数えると、テストが脆くなるだけで強くはなりません。

## 4 ケース

| ケース | 意図 |
|---|---|
| 両オプション適用 + resize 送信 | 基本契約 |
| **family だけの変更**でも再フィット | #864 が追加したケース。size 専用実装なら静かに落とす |
| 同一フォントなら何もしない | `Terminal.vue` の watcher は dir-config 解決のたびに発火し、大半のディレクトリはフォントを指定しない。ここを誤ると**全ターミナルが毎回リフローする** |
| 存在しないスロットで throw しない | |

## モックの変更点

`Terminal` モックが options オブジェクトを**コピーせず 1 つ保持**するようにしました。
`setFont` / `setTheme` は構築後に `term.options` を書き換えるため、コンストラクタ引数しか見えないモックでは
**適用されたかどうか判定できません**。既存 29 テストはそのまま通ります。

## Tests

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` すべて exit=0、
**4606 tests passing**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
