### PR TITLE
fix: 狭いセルで git チップが潰れて「空のバッジ」に見えるのを直す

### DIFF
--- a/src/components/GitBranchChip.vue
+++ b/src/components/GitBranchChip.vue
@@ -23,7 +23,7 @@ const title = computed(() => {
   <span
     v-if="status?.repo && (status.branch || status.detached)"
     data-testid="git-chip"
-    class="inline-flex items-center gap-[0.25em] px-[0.4em] h-[1.5em] rounded-[0.75em] text-[0.72rem] leading-[1.5em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] opacity-85 whitespace-nowrap max-w-[16ch] overflow-hidden"
+    class="inline-flex flex-none items-center gap-[0.25em] px-[0.4em] h-[1.5em] rounded-[0.75em] text-[0.72rem] leading-[1.5em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] opacity-85 whitespace-nowrap max-w-[16ch] overflow-hidden"
     :class="status.detached ? 'text-[#d19a66]' : 'text-inherit'"
     :title="title"
   >

--- a/test/src/components/GitBranchChip.spec.ts
+++ b/test/src/components/GitBranchChip.spec.ts
@@ -50,4 +50,15 @@ describe("GitBranchChip", () => {
     const w = render({ ...base, branch: null, detached: true });
     expect(w.find('[data-testid="git-branch"]').text()).toContain("detached");
   });
+
+  // #921: the chip sits in a `flex ... overflow-hidden` header row, where a flex item shrinks by
+  // default. Without this it collapsed in a narrow grid cell and the clipped text left just the
+  // padded, rounded background — reported as "an empty badge", which is a much harder thing to
+  // diagnose than a missing one. Every other item in that row already carried flex-none.
+  //
+  // jsdom does no layout, so the class is the only thing assertable here — and the class IS the
+  // fix. Width capping stays `max-w-[16ch]` + the inner ellipsis, so a long branch still truncates.
+  it("does not shrink in a tight header row", () => {
+    expect(render(base).find('[data-testid="git-chip"]').classes()).toContain("flex-none");
+  });
 });


### PR DESCRIPTION
## Summary

グリッドのセルが狭いとき、git チップが**枠だけの空のバッジ**に見える問題の修正。

`GitBranchChip` のルート span に `flex-none` を 1 つ足すだけです。Closes #921.

## 空だったのではなく、潰れていた

これが診断の要でした。**中身はずっとありました。**

ヘッダー行はこうです。

```html
<!-- TerminalCell.vue:1029 -->
<div data-testid="cell-header-main" class="flex min-w-0 flex-auto items-center gap-2 overflow-hidden">
```

flex アイテムは既定で縮むので、狭いセルではチップが縮み、`overflow-hidden` が文字を切り落とす。
残るのは `px-[0.4em]` のパディングと `rounded-[0.75em]` の背景 — つまり**意図的に置かれた空要素に見える**。

「無い」より「空で在る」ほうが原因を絞りにくく、実際に `DirBadge` / diff / ctx / usage / custom を
順に潰していってようやく辿り着きました。

## なぜこのチップだけか

同じ行の他の要素は**全て `flex-none` を持っていました**。

| 要素 | `flex-none` |
|---|---|
| `DirBadge` | ✅ |
| diff ボタン | ✅ |
| `ModelContextBadge` | ✅ |
| usage span | ✅ |
| custom chip | ✅ |
| **`GitBranchChip`** | ❌ ← これだけ |

## 幅の制御は変わりません

`max-w-[16ch]` と内側 span の `overflow-hidden text-ellipsis` はそのままなので、**長いブランチ名は
これまで通り省略記号で切れます**。`flex-none` が止めるのは「中身より小さく潰れること」だけで、
行を押し広げるようにはなりません。

単一ビュー（`Terminal.vue:418`）も同じコンポーネントなので、同じ理由で修正が効きます。

## #915 とは無関係です

バッジ作業でそのヘッダーを見ていたので気づきましたが、原因は別です。サーバは終始正しく返していました。

```
$ curl "localhost:34567/api/git-status?cwd=…/mulmoterminal4"
{"repo":true,"branch":"main","detached":false,"dirty":0,"ahead":0,"behind":0,"upstream":true}
```

**純粋にクライアント側のレイアウト**の問題です。

## Items to Confirm / Review

- **狭いセルでブランチ名が長いときの見え方**を一度確認いただきたいです。`max-w-[16ch]` で切れるはずですが、
  jsdom ではレイアウトが走らないので実機の確認はしていません。

## Tests

jsdom はレイアウトを行わないため、spec はクラスの存在を検証しています。**ここではクラスそのものが修正**で、
外すと落ちることを確認済みです（`flex-none` を戻すと 1 件 FAIL）。

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` すべて exit=0、
**4633 tests passing**（main を取り込み済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
