### PR TITLE
docs: パスを扱うテストの移植性を windows-gotchas に足す

### DIFF
--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -53,6 +53,31 @@ separator is what makes the check a boundary.
 rather than hand-rolling `target.startsWith(base + path.sep)`; several callers are security
 boundaries, and the lexical answer still needs a realpath pass for symlinks.
 
+## Tests that handle paths
+
+**Build the EXPECTED path with `path.resolve` too, never as a POSIX literal.** A rule that
+resolves with the platform's own `path` produces `\shared-lib` on Windows and `/shared-lib`
+elsewhere, so an expectation written as `"/shared-lib"` matches on the developer's machine and
+nowhere else. `yarn test` stays green locally and the daily Windows job goes red — #912's
+`resolveAddDirs` spec cost exactly that.
+
+**A stubbed predicate that compares paths has the same problem, and it fails silently.** That
+spec's EACCES case asked `p === "/denied"`, which on Windows never matched — so nothing threw,
+both entries survived, and the property under test ("a throwing check drops only its own
+entry") was not being tested there at all. A path-comparing stub is a path comparison: resolve
+its operand as well.
+
+```ts
+const BASE = path.resolve("/repo");            // C:\repo on Windows, /repo elsewhere
+const SIBLING = path.resolve(BASE, "../lib");  // the expectation, computed the same way
+```
+
+→ `test/server/config/add-dirs.spec.ts` for the shape.
+
+**Verify on the real runner before merging**, with the dispatch at the top of this file. Local
+`yarn test` on macOS/Linux cannot see any of this — the whole class only appears where the
+separator and the drive letter differ.
+
 ## Filesystem watching
 
 **`fs.watch` on an 8.3 short path is unreliable, and can abort the process.** `os.tmpdir()`

--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -56,9 +56,9 @@ boundaries, and the lexical answer still needs a realpath pass for symlinks.
 ## Tests that handle paths
 
 **Build the EXPECTED path with `path.resolve` too, never as a POSIX literal.** A rule that
-resolves with the platform's own `path` produces `\shared-lib` on Windows and `/shared-lib`
-elsewhere, so an expectation written as `"/shared-lib"` matches on the developer's machine and
-nowhere else. `yarn test` stays green locally and the daily Windows job goes red — #912's
+resolves with the platform's own `path` produces `<drive>:\shared-lib` on Windows (drive-qualified,
+per the section above — the CI failure read `D:\shared-lib`) and `/shared-lib` elsewhere, so an
+expectation written as `"/shared-lib"` matches on the developer's machine and nowhere else. `yarn test` stays green locally and the daily Windows job goes red — #912's
 `resolveAddDirs` spec cost exactly that.
 
 **A stubbed predicate that compares paths has the same problem, and it fails silently.** That


### PR DESCRIPTION
## Summary

#912 のテストが POSIX 絶対パスをハードコードして daily の Windows ジョブを赤くしました（#923 で修正済み）。`docs/windows-gotchas.md` は「実際に踏んだ罠」を記録する場所なので、そこに残します。

## 書いたこと

1. **期待値も `path.resolve` で作る** — ルールが実行環境の `path` で解決する以上、`"/shared-lib"` と書いた期待値は開発機でだけ一致します。`yarn test` はローカルで緑のまま、daily の Windows だけ赤くなります
2. **パスを比較するスタブも同じ問題を持ち、しかも黙って壊れる** — #912 の EACCES ケースは `p === "/denied"` で比較していたため Windows では一致せず、**throw すら起きませんでした**。「throw しても1件だけ捨てる」という検証したかった性質が、そこでは検証されていなかったことになります
3. **マージ前に実機で確認する** — 冒頭に既にある dispatch コマンドへの導線

## Items to Confirm / Review

- ドキュメントのみの変更です
- 参照先（`test/server/config/add-dirs.spec.ts`、冒頭の dispatch コマンド）が実在することは確認済み

## User Prompt

> はい、docs追加
>
> （直前: 「手元が macOS のみだと path.resolve を使うテストの移植性はローカルでは検出できない。具体則と dispatch の手順を足すと次に同じ轍を踏みにくい。追記しますか？」に対して）