### PR TITLE
feat: 拡大中のセルの隣に file explorer / viewer を出す (#910 Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,10 +716,20 @@ tree; clicking a file opens it in a **CodeMirror** editor (Markdown / JS-TS / JS
 highlighting, everything else as plain text). Markdown files get a **Preview** toggle
 that renders via the server's sandboxed `…/md` HTML. **Save** (or ⌘/Ctrl-S) writes back.
 
+**Beside an enlarged terminal, not only full-screen.** Expand a grid cell (**⤢**) and its
+header gains a **folder** toggle that splits the enlarged area in two: terminal on the left,
+the same explorer + editor on the right, rooted at that cell's directory. Drag the divider
+(or focus it and use ←/→, Home, End) to resize — the terminal keeps a floor, so a squeeze
+shrinks the pane rather than reflowing xterm into garbage. It works in both zoomed layouts
+(cockpit roster and thumbnail filmstrip), the pane re-roots as you walk the zoom between
+terminals, and whether it's open plus how wide it is are remembered per browser.
+
 All reads and writes go through `GET/PUT /api/files/browse/*?cwd=&path=`, and every
 `path` is **contained within the project root** (server-side) — `..`/absolute escapes
 are rejected for reads and writes alike, so editing can't reach outside the directory
-the terminal is pointed at.
+the terminal is pointed at. A save sends the version the file had when it was opened, so
+it is **refused (409) rather than silently overwriting** an agent that edited the same
+file meanwhile; the editor then offers to reload or to overwrite deliberately.
 
 ---
 

--- a/plans/feat-910-phase1-files-pane.md
+++ b/plans/feat-910-phase1-files-pane.md
@@ -1,0 +1,84 @@
+# feat #910 Phase 1 — 拡大中のセルの隣に file explorer / viewer を出す
+
+ズーム中（セルを拡大している状態）に、広がったターミナル領域を左右に分割して右に
+explorer / viewer を出す。今は専用の全画面ビューが開くだけで、ターミナルと同時に見られない。
+
+## 中身は作らない — 全画面 Files view を共通化する
+
+ツリー＋CodeMirror＋md プレビュー＋未保存ガード＋409 バナーは、全画面 Files view として
+すでに全部動いている。**`FilesPane.vue` に抽出し、全画面版（`FilesOverlay.vue`）はその薄い
+ラッパにする。** サーバ API は追加ゼロ（Phase 0 の `version` / `baseVersion` をそのまま使う）。
+
+### 分割線をどこに引いたか
+
+| 置き場所 | 何を持つか |
+|---|---|
+| `FilesPane.vue` | ツリー、エディタ、保存、409 バナー、自分の未保存ガード |
+| `FilesOverlay.vue` | ルート結合（`useFilesView`）、`fixed` の枠、ルート離脱時のガード |
+| `TerminalGrid.vue` | ペインの開閉・幅、スプリッタ、どのセルの dir を見せるか |
+
+**ペインは `cwd` の変化に自分では反応しない。** 反応させると、ホストがまだユーザーに確認して
+いる最中のバッファを捨ててしまう。ホストが「ルート変更はガードを通った」と判断してから
+`reload()` を呼ぶ。全画面版のルートガード（`reverting` / `bypassGuard`）はこの前提で今の
+挙動をそのまま保っている（既存 12 テストが green のままなのが確認）。
+
+未保存かどうかはホストも知る必要があるので `dirty` を emit する。
+
+## レイアウト — 行ラッパ 1 つで両モードに効かせる
+
+ズームには 2 つの形があり、**`listMode` の既定は `true`（ロースター）**。strip だけ対応すると
+既定のユーザーには何も出ないので、最初から両方に出す。
+
+- list モード: stage が **row** → `roster | terminal`
+- strip モード: stage が **column** → `terminal / filmstrip`
+
+`zoom-main` を stage の直下に並べたままペインを足すと、strip モードでは**ターミナルの下**に
+入ってしまう。`zoom-main` とペインを **row のラッパで包む**と、stage がどちら向きでも
+「ターミナルの右」になる。ラッパは Tailwind のみ（`zoomed ? 'flex …' : 'hidden'`）で、既存の
+`.zoom-main` の CSS には触っていない。
+
+## 幅の規則は単一ビューのスプリッタを流用
+
+`splitterWidth.ts` に `clampPaneWidth(paneWidth, available)` を 1 行足す。中身は
+`available - clampTerminalWidth(available - paneWidth, available)` — **同じ規則を反対側から
+読んだだけ**にすることで、2 つのスプリッタが別々に育つのを防ぐ。狭いときにターミナルの下限が
+勝ち、ペインが自分の下限を諦めるのもそのまま継承される（3 カラムになる list モードで効く）。
+
+キーボード操作も `splitterKeyWidth` をそのまま使う（ターミナル幅で話す API なので、ペイン幅は
+その残り）。
+
+## 入口
+
+セルヘッダの `CellChromeButtons` にトグルを 1 つ。**拡大中のセルにだけ出す**（タイルや
+フィルムストリップのサムネイルには分割する余地がない）。expand/restore の**後ろ**に置いた —
+複数のテストと grid が最初の `.cell-btn` を掴んでいるため。
+
+`toggle-files` は `gridCell.ts` の `GridCellEmits` に足したので、3 種類のセル全部が同じ形で
+持つ。開閉状態と幅は `TerminalGrid` が持ち、localStorage に覚える（**セルごとの記憶は
+Phase 2**）。
+
+## その他
+
+- `⌘S` はペインの**自分のサブツリー**に束ねた。window だと、隣のターミナルに打ち込んでいる
+  最中の `⌘S` で保存が走る
+- `.cm-editor` の高さ指定を `<style scoped>` から `src/style.css` の `@layer base` へ移した。
+  CodeMirror が実行時に注入する要素なのでユーティリティでは届かず、かつ全画面版とペインの
+  両方から使うため（CLAUDE.md の「utility にできないものはグローバル 1 箇所へ」）
+
+## テスト
+
+- `FilesPane.spec.ts`（新規 5 件）— cwd プロップだけで動く / `dirty` を上げる / `⌘S` は
+  ペイン内だけ効き window では効かない / 未保存の close を確認する / **`cwd` 変更では
+  読み直さず `reload()` でだけ読み直す**
+- `TerminalGrid.spec.ts`（新規 5 件）— 拡大するまで出ない / **list と strip の両モードで
+  ターミナルと同じ行に入る** / 拡大中のセルの dir を見る（無ければ既定にフォールバック）/
+  ズームを移してもペインは 1 つのまま張り替わる / 開閉が localStorage に残る
+- `CellChromeButtons.spec.ts`（新規 4 件）— 拡大中だけ出る / `aria-pressed` / emit するだけ /
+  expand の後ろにいる
+- `splitterWidth.spec.ts`（新規 4 件）— `clampPaneWidth` の下限とタイブレーク
+- `FilesOverlay.spec.ts` は**無改造で 12 件 green** — 抽出のリグレッションゲート
+
+## やらないこと（#910 の後続）
+
+- 自動保存＋3 世代バックアップ＋セルごとの記憶 — Phase 2
+- 外部変更の検知（hook ＋ 30 秒ポーリング）— Phase 3

--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -11,8 +11,8 @@
 // inside a button (shouldZoomOnHeaderClick), and stopping here would only hide that.
 import { CELL_BTN, CELL_CLOSE_BTN } from "./cellChromeClasses";
 
-defineProps<{ expanded: boolean }>();
-const emit = defineEmits<{ (e: "toggle-expand" | "close"): void }>();
+defineProps<{ expanded: boolean; filesOpen?: boolean }>();
+const emit = defineEmits<{ (e: "toggle-expand" | "close" | "toggle-files"): void }>();
 </script>
 
 <template>
@@ -24,6 +24,20 @@ const emit = defineEmits<{ (e: "toggle-expand" | "close"): void }>();
     @click="emit('toggle-expand')"
   >
     <span class="material-symbols-outlined" aria-hidden="true">{{ expanded ? "close_fullscreen" : "open_in_full" }}</span>
+  </button>
+  <!-- Only while enlarged: the pane splits the enlarged cell's room, which a tiled cell or a
+       filmstrip thumbnail does not have. After expand/restore so the first `.cell-btn` keeps
+       meaning what it always did. -->
+  <button
+    v-if="expanded"
+    class="cell-btn"
+    :class="CELL_BTN"
+    :aria-pressed="!!filesOpen"
+    :title="filesOpen ? 'Hide files' : 'Show files'"
+    :aria-label="filesOpen ? 'Hide files' : 'Show files'"
+    @click="emit('toggle-files')"
+  >
+    <span class="material-symbols-outlined" aria-hidden="true">folder_open</span>
   </button>
   <button class="cell-btn cell-close" :class="CELL_CLOSE_BTN" title="Close terminal" aria-label="Close terminal" @click="emit('close')">
     <span class="material-symbols-outlined" aria-hidden="true">close</span>

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -191,7 +191,13 @@ function onHeaderClick(event: MouseEvent) {
         >
           <span class="material-symbols-outlined" aria-hidden="true">{{ summaryState === "loading" ? "more_horiz" : "auto_awesome" }}</span>
         </button>
-        <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
+        <CellChromeButtons
+          :expanded="expanded"
+          :files-open="filesOpen"
+          @toggle-expand="emit('toggle-expand')"
+          @toggle-files="emit('toggle-files')"
+          @close="emit('close')"
+        />
       </span>
     </div>
     <TerminalView

--- a/src/components/FilesOverlay.vue
+++ b/src/components/FilesOverlay.vue
@@ -1,364 +1,61 @@
 <script setup lang="ts">
-// Full-screen file explorer + editor, a sibling of PrsOverlay. Driven by useFilesView
-// (the /files?cwd= route). Left: a lazy-loaded directory tree rooted at the project dir.
-// Right: a CodeMirror editor for the opened file, with a Markdown preview toggle that
-// reuses the server's sandboxed md→HTML iframe. Writes go through PUT .../write, which
-// contains the path within the project root.
-import { onBeforeUnmount, onMounted, ref, computed, nextTick, watch } from "vue";
+// The full-screen Files view: FilesPane in a fixed frame, driven by the /files?cwd= route
+// (useFilesView). Everything about browsing and editing lives in the pane — what is here is
+// the route coupling, which the pane beside a zoomed grid cell does not have.
+import { ref, watch } from "vue";
 import { useFilesView, filesGotoIndex } from "../composables/useFilesView";
-import { createEditor, langKindForFilename, type CmEditor } from "./cmEditor";
-
-interface Node {
-  name: string;
-  path: string; // relative to the project root
-  dir: boolean;
-  size: number;
-  expanded: boolean;
-  loaded: boolean;
-  children: Node[];
-}
-interface Entry {
-  name: string;
-  dir: boolean;
-  size: number;
-}
+import FilesPane from "./FilesPane.vue";
 
 const { isOpen, cwd, requestedPath, close } = useFilesView();
 
-const roots = ref<Node[]>([]);
-const treeError = ref<string | null>(null);
-const openPath = ref<string | null>(null);
-const openName = computed(() => (openPath.value ? (openPath.value.split("/").pop() ?? "") : ""));
+const pane = ref<InstanceType<typeof FilesPane> | null>(null);
 const dirty = ref(false);
-const saving = ref(false);
-const fileError = ref<string | null>(null);
-// The version the open buffer was loaded from; sent back on save so the server can refuse a
-// write that would clobber someone else's (null = the file didn't exist).
-const baseVersion = ref<string | null>(null);
-// Set when a save came back 409, holding the version now on disk — what "Overwrite" re-sends.
-const conflict = ref<{ version: string | null } | null>(null);
-const showPreview = ref(false);
-const isMarkdown = computed(() => langKindForFilename(openName.value) === "markdown");
-
-const editorHost = ref<HTMLDivElement>();
-let editor: CmEditor | null = null;
-let reqId = 0;
 // `reverting`: a route change WE triggered to undo a declined leave/root-switch — skip
-// its own watcher fire. `bypassGuard`: the close was already confirmed (requestClose),
-// so the watcher must not prompt again.
+// its own watcher fire. `bypassGuard`: the close was already confirmed by the pane, so
+// the watcher must not prompt again.
 let reverting = false;
 let bypassGuard = false;
 
-function qs(pathRel: string): string {
-  const p = new URLSearchParams();
-  if (cwd.value) p.set("cwd", cwd.value);
-  p.set("path", pathRel);
-  return p.toString();
-}
-const previewSrc = computed(() => (openPath.value ? `/api/files/browse/md?${qs(openPath.value)}` : ""));
+// Guard any navigation that would drop the open buffer's unsaved edits. Same prompt the
+// pane uses for its own actions, asked from the side that owns the route.
+const confirmDiscard = (): boolean => !dirty.value || window.confirm("Discard unsaved changes?");
 
-function makeNode(e: Entry, parentPath: string): Node {
-  return { name: e.name, path: parentPath ? `${parentPath}/${e.name}` : e.name, dir: e.dir, size: e.size, expanded: false, loaded: false, children: [] };
-}
-
-async function fetchEntries(pathRel: string): Promise<Entry[]> {
-  const res = await fetch(`/api/files/browse/list?${qs(pathRel)}`);
-  if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  const data = await res.json();
-  return Array.isArray(data.entries) ? data.entries : [];
-}
-
-async function loadRoot(): Promise<void> {
-  const id = ++reqId;
-  treeError.value = null;
-  try {
-    const entries = await fetchEntries("");
-    if (id === reqId) roots.value = entries.map((e) => makeNode(e, ""));
-  } catch (e) {
-    if (id === reqId) treeError.value = e instanceof Error ? e.message : String(e);
-  }
-}
-
-async function toggleDir(node: Node): Promise<void> {
-  node.expanded = !node.expanded;
-  if (node.expanded && !node.loaded) {
-    try {
-      node.children = (await fetchEntries(node.path)).map((e) => makeNode(e, node.path));
-      node.loaded = true;
-    } catch {
-      node.expanded = false; // couldn't read — collapse again
-    }
-  }
-}
-
-// Depth-first flatten of the currently-visible rows (only descending into expanded
-// dirs), so the template renders a flat list without a recursive component.
-const rows = computed(() => {
-  const out: { node: Node; depth: number }[] = [];
-  const walk = (nodes: Node[], depth: number) => {
-    for (const node of nodes) {
-      out.push({ node, depth });
-      if (node.dir && node.expanded) walk(node.children, depth + 1);
-    }
-  };
-  walk(roots.value, 0);
-  return out;
-});
-
-// Guard any action that would drop the open buffer's unsaved edits (switching files,
-// closing the view). Returns true to proceed.
-function confirmDiscard(): boolean {
-  return !dirty.value || window.confirm("Discard unsaved changes?");
-}
-
-async function openFile(node: Node): Promise<void> {
-  if (node.dir) return toggleDir(node);
-  await loadFile(node.path);
-}
-
-// Open a project-relative path in the editor. Split out from openFile because the other way
-// in has no tree node to hand over: a clicked source path in terminal output arrives as
-// ?path= and opens the same file (#808).
-// `force` re-reads the file already open and skips the unsaved-edits prompt — the
-// conflict banner's "Reload", where discarding is the button the user just pressed.
-async function loadFile(pathRel: string, force = false): Promise<void> {
-  if (!force) {
-    if (pathRel === openPath.value) return; // already open — no reload, no prompt
-    if (!confirmDiscard()) return;
-  }
-  const id = ++reqId;
-  fileError.value = null;
-  conflict.value = null;
-  showPreview.value = false;
-  try {
-    const res = await fetch(`/api/files/browse/text?${qs(pathRel)}`);
-    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || `HTTP ${res.status}`);
-    const data = await res.json();
-    if (id !== reqId) return;
-    openPath.value = pathRel;
-    baseVersion.value = typeof data.version === "string" ? data.version : null;
-    editor?.setDoc(typeof data.text === "string" ? data.text : "", pathRel.split("/").pop() ?? pathRel);
-    dirty.value = false;
-  } catch (e) {
-    if (id === reqId) fileError.value = e instanceof Error ? e.message : String(e);
-  }
-}
-
-async function save(): Promise<void> {
-  if (!openPath.value || !editor || saving.value) return;
-  saving.value = true;
-  fileError.value = null;
-  try {
-    const res = await fetch(`/api/files/browse/write?${qs(openPath.value)}`, {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ text: editor.getDoc(), baseVersion: baseVersion.value }),
-    });
-    const data = await res.json().catch(() => ({}));
-    // 409: the file moved on under us (the agent working in this very directory is the
-    // likeliest author). Nothing was written — offer the choice instead of picking a loser.
-    if (res.status === 409) {
-      conflict.value = { version: typeof data.version === "string" ? data.version : null };
-      return;
-    }
-    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
-    baseVersion.value = typeof data.version === "string" ? data.version : null;
-    dirty.value = false;
-    conflict.value = null;
-  } catch (e) {
-    fileError.value = e instanceof Error ? e.message : String(e);
-  } finally {
-    saving.value = false;
-  }
-}
-
-/** Conflict banner — take the disk's copy, dropping the buffer. */
-function discardAndReload(): void {
-  if (openPath.value) loadFile(openPath.value, true);
-}
-
-/** Conflict banner — keep the buffer, adopting the disk's version as the new baseline so the
- *  retry is a deliberate overwrite rather than another conflict. */
-function overwrite(): void {
-  if (!conflict.value) return;
-  baseVersion.value = conflict.value.version;
-  conflict.value = null;
-  save();
-}
-
-function requestClose(): void {
-  if (!confirmDiscard()) return;
-  bypassGuard = true; // already confirmed — don't let the isOpen watcher prompt again
+function onPaneClose(): void {
+  bypassGuard = true; // the pane already confirmed — don't let the isOpen watcher prompt again
   close();
 }
 
-function onKeydown(e: KeyboardEvent): void {
-  if (!isOpen.value) return;
-  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
-    e.preventDefault();
-    save();
+watch([isOpen, cwd], ([open, curCwd], prev) => {
+  if (reverting) {
+    reverting = false;
+    return;
   }
-}
-
-// The editor host only exists while the overlay is open (v-if), so create/destroy the
-// CodeMirror instance and (re)load the tree as the view opens/closes or its root changes.
-function teardown(): void {
-  editor?.destroy();
-  editor = null;
-  roots.value = [];
-  openPath.value = null;
-  dirty.value = false;
-  baseVersion.value = null;
-  conflict.value = null;
-  showPreview.value = false;
-}
-watch(
-  [isOpen, cwd],
-  async ([open, curCwd], prev) => {
-    if (reverting) {
-      reverting = false;
-      return;
-    }
-    // Leaving the view (external nav / Back) OR changing root (?cwd=) mid-edit with
-    // unsaved changes → confirm before discarding; declining restores the previous
-    // route (re-opens /files at prevCwd) so the editor + buffer stay put. An explicit
-    // Close already confirmed (bypassGuard), so don't prompt twice.
-    const wasOpen = prev?.[0] ?? false;
-    const prevCwd = prev?.[1] ?? null;
-    const leaving = wasOpen && !open;
-    const rootChanged = open && curCwd !== prevCwd;
-    if (!bypassGuard && (leaving || rootChanged) && !confirmDiscard()) {
-      reverting = true;
-      filesGotoIndex(prevCwd);
-      return;
-    }
-    bypassGuard = false;
-    teardown();
-    if (!open) return;
-    await nextTick();
-    if (editorHost.value) editor = createEditor(editorHost.value, () => (dirty.value = true));
-    loadRoot();
-    if (requestedPath.value) loadFile(requestedPath.value);
-  },
-  { immediate: true },
-);
-
-// A second clicked path while the view is already open: the route changes but the setup
-// watcher above sees no change in [isOpen, cwd], so the file would never open.
-watch(requestedPath, (pathRel) => {
-  if (isOpen.value && pathRel) loadFile(pathRel);
-});
-
-onMounted(() => window.addEventListener("keydown", onKeydown));
-onBeforeUnmount(() => {
-  window.removeEventListener("keydown", onKeydown);
-  teardown();
+  // Leaving the view (external nav / Back) OR changing root (?cwd=) mid-edit with unsaved
+  // changes → confirm before discarding; declining restores the previous route (re-opens
+  // /files at prevCwd) so the editor + buffer stay put.
+  const wasOpen = prev?.[0] ?? false;
+  const prevCwd = prev?.[1] ?? null;
+  const leaving = wasOpen && !open;
+  const rootChanged = open && curCwd !== prevCwd;
+  if (!bypassGuard && (leaving || rootChanged) && !confirmDiscard()) {
+    reverting = true;
+    filesGotoIndex(prevCwd);
+    return;
+  }
+  bypassGuard = false;
+  // The pane is mounted per `isOpen`, so opening/closing already starts it fresh. A root
+  // change keeps it mounted, and only THIS side knows the change survived the guard.
+  if (open && wasOpen && rootChanged) pane.value?.reload();
 });
 </script>
 
 <template>
   <div v-if="isOpen" class="fixed inset-x-0 top-10 bottom-0 z-50 bg-deep flex flex-col" role="region" aria-label="Files">
-    <header class="flex flex-none items-center gap-2.5 border-b border-border bg-panel px-4 py-2">
-      <span class="text-[14px] font-[650] text-fg">Files</span>
-      <span class="max-w-[40%] truncate font-mono text-[11px] text-muted" :title="cwd ?? ''">{{ cwd ?? "(default workspace)" }}</span>
-      <span class="flex-auto" />
-      <span v-if="openPath" class="font-mono text-[12px]" :class="dirty ? 'text-fg' : 'text-secondary'"
-        >{{ openName }}<span v-if="dirty" class="ml-1 text-amber" title="Unsaved">●</span></span
-      >
-      <button
-        v-if="openPath && isMarkdown"
-        type="button"
-        class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
-        @click="showPreview = !showPreview"
-      >
-        {{ showPreview ? "Edit" : "Preview" }}
-      </button>
-      <button
-        v-if="openPath"
-        type="button"
-        class="h-[26px] cursor-pointer rounded-md border border-accent bg-accent-bg px-2.5 py-1 text-[12px] text-on-accent enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
-        :disabled="!dirty || saving"
-        @click="save"
-      >
-        {{ saving ? "Saving…" : "Save" }}
-      </button>
-      <button
-        type="button"
-        class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
-        title="Reload tree"
-        aria-label="Reload tree"
-        @click="loadRoot"
-      >
-        <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
-      </button>
-      <button
-        type="button"
-        class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
-        title="Close"
-        aria-label="Close files"
-        @click="requestClose"
-      >
-        <span class="material-symbols-outlined" aria-hidden="true">close</span>
-      </button>
-    </header>
-    <div class="flex min-h-0 flex-auto">
-      <nav class="basis-[clamp(200px,24%,340px)] shrink-0 grow-0 overflow-auto border-r border-border py-1.5" aria-label="File tree">
-        <p v-if="treeError" class="p-4 text-[13px] text-err">{{ treeError }}</p>
-        <p v-else-if="roots.length === 0" class="p-4 text-[13px] text-muted">Empty directory.</p>
-        <button
-          v-for="{ node, depth } in rows"
-          :key="node.path"
-          type="button"
-          data-testid="files-row"
-          class="flex w-full cursor-pointer items-center gap-1 whitespace-nowrap border-0 bg-transparent px-2 py-[3px] text-left font-mono text-[12px]"
-          :class="node.path === openPath ? 'bg-hover text-fg' : 'text-secondary hover:bg-hover hover:text-fg'"
-          :style="{ paddingLeft: `${8 + depth * 14}px` }"
-          @click="openFile(node)"
-        >
-          <span class="w-3.5 flex-none text-dim">
-            <span v-if="node.dir" class="material-symbols-outlined" aria-hidden="true">{{ node.expanded ? "expand_more" : "chevron_right" }}</span>
-          </span>
-          <span class="material-symbols-outlined flex-none" aria-hidden="true">{{ node.dir ? "folder" : "description" }}</span>
-          <span class="truncate">{{ node.name }}</span>
-        </button>
-      </nav>
-      <section class="relative flex min-w-0 flex-auto">
-        <div
-          v-if="conflict"
-          role="alert"
-          data-testid="files-conflict"
-          class="absolute inset-x-0 top-0 z-10 flex flex-wrap items-center gap-2 border-b border-amber bg-[var(--warn-bg-subtle)] px-4 py-2 text-[13px] text-warn"
-        >
-          <span class="material-symbols-outlined" aria-hidden="true">warning</span>
-          <span class="flex-auto">This file changed on disk. Nothing was saved.</span>
-          <button
-            type="button"
-            class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary hover:bg-hover hover:text-fg"
-            @click="discardAndReload"
-          >
-            Reload (discard your edits)
-          </button>
-          <button
-            type="button"
-            class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary hover:bg-hover hover:text-fg"
-            @click="overwrite"
-          >
-            Overwrite anyway
-          </button>
-        </div>
-        <p v-if="fileError" class="p-4 text-[13px] text-err">{{ fileError }}</p>
-        <p v-if="!openPath" class="m-auto p-4 text-[13px] text-muted">Select a file to view or edit.</p>
-        <iframe v-show="openPath && showPreview" class="flex-auto border-0 bg-white" :src="previewSrc" sandbox="" title="Markdown preview" />
-        <div v-show="openPath && !showPreview" ref="editorHost" class="files-editor min-w-0 flex-auto overflow-hidden" />
-      </section>
-    </div>
+    <FilesPane ref="pane" :cwd="cwd" :requested-path="requestedPath" @close="onPaneClose" @dirty="dirty = $event">
+      <template #title>
+        <span class="text-[14px] font-[650] text-fg">Files</span>
+        <span class="max-w-[40%] truncate font-mono text-[11px] text-muted" :title="cwd ?? ''">{{ cwd ?? "(default workspace)" }}</span>
+      </template>
+    </FilesPane>
   </div>
 </template>
-
-<!-- The CodeMirror editor is injected into .files-editor at runtime, so its root
-     can't carry a utility and must be sized via :deep. -->
-<style scoped>
-.files-editor :deep(.cm-editor) {
-  height: 100%;
-}
-</style>

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -1,0 +1,341 @@
+<script setup lang="ts">
+// The file explorer + editor itself, independent of where it is shown: the full-screen
+// Files view (FilesOverlay) and the pane beside a zoomed grid cell mount the same thing.
+// Left: a lazy-loaded directory tree rooted at `cwd`. Right: a CodeMirror editor, with a
+// Markdown preview toggle that reuses the server's sandboxed md→HTML iframe. Writes go
+// through PUT .../write, whose `path` the server contains within the project root.
+//
+// It owns no notion of routes or of being open — the host decides when it exists, and
+// calls `reload()` after a root change it has already cleared with the user.
+import { onBeforeUnmount, onMounted, ref, computed, nextTick, watch } from "vue";
+import { createEditor, langKindForFilename, type CmEditor } from "./cmEditor";
+
+interface Node {
+  name: string;
+  path: string; // relative to the project root
+  dir: boolean;
+  size: number;
+  expanded: boolean;
+  loaded: boolean;
+  children: Node[];
+}
+interface Entry {
+  name: string;
+  dir: boolean;
+  size: number;
+}
+
+const props = defineProps<{ cwd: string | null; requestedPath?: string | null }>();
+const emit = defineEmits<{ close: []; dirty: [boolean] }>();
+
+const roots = ref<Node[]>([]);
+const treeError = ref<string | null>(null);
+const openPath = ref<string | null>(null);
+const openName = computed(() => (openPath.value ? (openPath.value.split("/").pop() ?? "") : ""));
+const dirty = ref(false);
+const saving = ref(false);
+const fileError = ref<string | null>(null);
+// The version the open buffer was loaded from; sent back on save so the server can refuse a
+// write that would clobber someone else's (null = the file didn't exist).
+const baseVersion = ref<string | null>(null);
+// Set when a save came back 409, holding the version now on disk — what "Overwrite" re-sends.
+const conflict = ref<{ version: string | null } | null>(null);
+const showPreview = ref(false);
+const isMarkdown = computed(() => langKindForFilename(openName.value) === "markdown");
+
+const editorHost = ref<HTMLDivElement>();
+let editor: CmEditor | null = null;
+let reqId = 0;
+
+// The host guards its own navigation on this, so it has to hear every change.
+watch(dirty, (value) => emit("dirty", value));
+
+function qs(pathRel: string): string {
+  const p = new URLSearchParams();
+  if (props.cwd) p.set("cwd", props.cwd);
+  p.set("path", pathRel);
+  return p.toString();
+}
+const previewSrc = computed(() => (openPath.value ? `/api/files/browse/md?${qs(openPath.value)}` : ""));
+
+function makeNode(e: Entry, parentPath: string): Node {
+  return { name: e.name, path: parentPath ? `${parentPath}/${e.name}` : e.name, dir: e.dir, size: e.size, expanded: false, loaded: false, children: [] };
+}
+
+async function fetchEntries(pathRel: string): Promise<Entry[]> {
+  const res = await fetch(`/api/files/browse/list?${qs(pathRel)}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return Array.isArray(data.entries) ? data.entries : [];
+}
+
+async function loadRoot(): Promise<void> {
+  const id = ++reqId;
+  treeError.value = null;
+  try {
+    const entries = await fetchEntries("");
+    if (id === reqId) roots.value = entries.map((e) => makeNode(e, ""));
+  } catch (e) {
+    if (id === reqId) treeError.value = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function toggleDir(node: Node): Promise<void> {
+  node.expanded = !node.expanded;
+  if (node.expanded && !node.loaded) {
+    try {
+      node.children = (await fetchEntries(node.path)).map((e) => makeNode(e, node.path));
+      node.loaded = true;
+    } catch {
+      node.expanded = false; // couldn't read — collapse again
+    }
+  }
+}
+
+// Depth-first flatten of the currently-visible rows (only descending into expanded
+// dirs), so the template renders a flat list without a recursive component.
+const rows = computed(() => {
+  const out: { node: Node; depth: number }[] = [];
+  const walk = (nodes: Node[], depth: number) => {
+    for (const node of nodes) {
+      out.push({ node, depth });
+      if (node.dir && node.expanded) walk(node.children, depth + 1);
+    }
+  };
+  walk(roots.value, 0);
+  return out;
+});
+
+// Guard any action that would drop the open buffer's unsaved edits (switching files,
+// closing the view). Returns true to proceed.
+function confirmDiscard(): boolean {
+  return !dirty.value || window.confirm("Discard unsaved changes?");
+}
+
+async function openFile(node: Node): Promise<void> {
+  if (node.dir) return toggleDir(node);
+  await loadFile(node.path);
+}
+
+// Open a project-relative path in the editor. Split out from openFile because the other way
+// in has no tree node to hand over: a clicked source path in terminal output arrives as
+// ?path= and opens the same file (#808).
+// `force` re-reads the file already open and skips the unsaved-edits prompt — the
+// conflict banner's "Reload", where discarding is the button the user just pressed.
+async function loadFile(pathRel: string, force = false): Promise<void> {
+  if (!force) {
+    if (pathRel === openPath.value) return; // already open — no reload, no prompt
+    if (!confirmDiscard()) return;
+  }
+  const id = ++reqId;
+  fileError.value = null;
+  conflict.value = null;
+  showPreview.value = false;
+  try {
+    const res = await fetch(`/api/files/browse/text?${qs(pathRel)}`);
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || `HTTP ${res.status}`);
+    const data = await res.json();
+    if (id !== reqId) return;
+    openPath.value = pathRel;
+    baseVersion.value = typeof data.version === "string" ? data.version : null;
+    editor?.setDoc(typeof data.text === "string" ? data.text : "", pathRel.split("/").pop() ?? pathRel);
+    dirty.value = false;
+  } catch (e) {
+    if (id === reqId) fileError.value = e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function save(): Promise<void> {
+  if (!openPath.value || !editor || saving.value) return;
+  saving.value = true;
+  fileError.value = null;
+  try {
+    const res = await fetch(`/api/files/browse/write?${qs(openPath.value)}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text: editor.getDoc(), baseVersion: baseVersion.value }),
+    });
+    const data = await res.json().catch(() => ({}));
+    // 409: the file moved on under us (the agent working in this very directory is the
+    // likeliest author). Nothing was written — offer the choice instead of picking a loser.
+    if (res.status === 409) {
+      conflict.value = { version: typeof data.version === "string" ? data.version : null };
+      return;
+    }
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    baseVersion.value = typeof data.version === "string" ? data.version : null;
+    dirty.value = false;
+    conflict.value = null;
+  } catch (e) {
+    fileError.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    saving.value = false;
+  }
+}
+
+/** Conflict banner — take the disk's copy, dropping the buffer. */
+function discardAndReload(): void {
+  if (openPath.value) loadFile(openPath.value, true);
+}
+
+/** Conflict banner — keep the buffer, adopting the disk's version as the new baseline so the
+ *  retry is a deliberate overwrite rather than another conflict. */
+function overwrite(): void {
+  if (!conflict.value) return;
+  baseVersion.value = conflict.value.version;
+  conflict.value = null;
+  save();
+}
+
+function requestClose(): void {
+  if (confirmDiscard()) emit("close");
+}
+
+// Bound to this pane's own subtree, not to window: with a pane open beside a terminal,
+// a window-level ⌘S would save while the user is typing into the terminal.
+function onKeydown(e: KeyboardEvent): void {
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") {
+    e.preventDefault();
+    save();
+  }
+}
+
+function teardown(): void {
+  editor?.destroy();
+  editor = null;
+  roots.value = [];
+  openPath.value = null;
+  dirty.value = false;
+  baseVersion.value = null;
+  conflict.value = null;
+  showPreview.value = false;
+}
+
+async function start(): Promise<void> {
+  await nextTick();
+  if (editorHost.value) editor = createEditor(editorHost.value, () => (dirty.value = true));
+  loadRoot();
+  if (props.requestedPath) loadFile(props.requestedPath);
+}
+
+// A second clicked path while the pane is already showing: nothing else changes, so
+// without this the file would never open.
+watch(
+  () => props.requestedPath,
+  (pathRel) => {
+    if (pathRel) loadFile(pathRel);
+  },
+);
+
+onMounted(start);
+onBeforeUnmount(teardown);
+
+// `reload` is the host's way to say "the root changed and I have already cleared it with the
+// user" — the pane never watches `cwd` itself, because reacting to it would discard a buffer
+// the host may still be asking about.
+defineExpose({
+  reload: async () => {
+    teardown();
+    await start();
+  },
+  confirmDiscard,
+});
+</script>
+
+<template>
+  <div class="flex min-h-0 min-w-0 flex-auto flex-col" @keydown="onKeydown">
+    <header class="flex flex-none items-center gap-2.5 border-b border-border bg-panel px-4 py-2">
+      <slot name="title" />
+      <span class="flex-auto" />
+      <span v-if="openPath" class="min-w-0 truncate font-mono text-[12px]" :class="dirty ? 'text-fg' : 'text-secondary'"
+        >{{ openName }}<span v-if="dirty" class="ml-1 text-amber" title="Unsaved">●</span></span
+      >
+      <button
+        v-if="openPath && isMarkdown"
+        type="button"
+        class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
+        @click="showPreview = !showPreview"
+      >
+        {{ showPreview ? "Edit" : "Preview" }}
+      </button>
+      <button
+        v-if="openPath"
+        type="button"
+        class="h-[26px] cursor-pointer rounded-md border border-accent bg-accent-bg px-2.5 py-1 text-[12px] text-on-accent enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
+        :disabled="!dirty || saving"
+        @click="save"
+      >
+        {{ saving ? "Saving…" : "Save" }}
+      </button>
+      <button
+        type="button"
+        class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
+        title="Reload tree"
+        aria-label="Reload tree"
+        @click="loadRoot"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
+      </button>
+      <button
+        type="button"
+        class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-50"
+        title="Close"
+        aria-label="Close files"
+        @click="requestClose"
+      >
+        <span class="material-symbols-outlined" aria-hidden="true">close</span>
+      </button>
+    </header>
+    <div class="flex min-h-0 flex-auto">
+      <nav class="basis-[clamp(160px,24%,340px)] shrink-0 grow-0 overflow-auto border-r border-border py-1.5" aria-label="File tree">
+        <p v-if="treeError" class="p-4 text-[13px] text-err">{{ treeError }}</p>
+        <p v-else-if="roots.length === 0" class="p-4 text-[13px] text-muted">Empty directory.</p>
+        <button
+          v-for="{ node, depth } in rows"
+          :key="node.path"
+          type="button"
+          data-testid="files-row"
+          class="flex w-full cursor-pointer items-center gap-1 whitespace-nowrap border-0 bg-transparent px-2 py-[3px] text-left font-mono text-[12px]"
+          :class="node.path === openPath ? 'bg-hover text-fg' : 'text-secondary hover:bg-hover hover:text-fg'"
+          :style="{ paddingLeft: `${8 + depth * 14}px` }"
+          @click="openFile(node)"
+        >
+          <span class="w-3.5 flex-none text-dim">
+            <span v-if="node.dir" class="material-symbols-outlined" aria-hidden="true">{{ node.expanded ? "expand_more" : "chevron_right" }}</span>
+          </span>
+          <span class="material-symbols-outlined flex-none" aria-hidden="true">{{ node.dir ? "folder" : "description" }}</span>
+          <span class="truncate">{{ node.name }}</span>
+        </button>
+      </nav>
+      <section class="relative flex min-w-0 flex-auto">
+        <div
+          v-if="conflict"
+          role="alert"
+          data-testid="files-conflict"
+          class="absolute inset-x-0 top-0 z-10 flex flex-wrap items-center gap-2 border-b border-amber bg-[var(--warn-bg-subtle)] px-4 py-2 text-[13px] text-warn"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">warning</span>
+          <span class="flex-auto">This file changed on disk. Nothing was saved.</span>
+          <button
+            type="button"
+            class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary hover:bg-hover hover:text-fg"
+            @click="discardAndReload"
+          >
+            Reload (discard your edits)
+          </button>
+          <button
+            type="button"
+            class="h-[26px] cursor-pointer rounded-md border border-border bg-base px-2.5 py-1 text-[12px] text-secondary hover:bg-hover hover:text-fg"
+            @click="overwrite"
+          >
+            Overwrite anyway
+          </button>
+        </div>
+        <p v-if="fileError" class="p-4 text-[13px] text-err">{{ fileError }}</p>
+        <p v-if="!openPath" class="m-auto p-4 text-[13px] text-muted">Select a file to view or edit.</p>
+        <iframe v-show="openPath && showPreview" class="flex-auto border-0 bg-white" :src="previewSrc" sandbox="" title="Markdown preview" />
+        <div v-show="openPath && !showPreview" ref="editorHost" class="files-editor min-w-0 flex-auto overflow-hidden" />
+      </section>
+    </div>
+  </div>
+</template>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -101,7 +101,13 @@ function relaunch() {
         <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Relaunch" aria-label="Relaunch" @click="relaunch">
           <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
         </button>
-        <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="emit('close')" />
+        <CellChromeButtons
+          :expanded="expanded"
+          :files-open="filesOpen"
+          @toggle-expand="emit('toggle-expand')"
+          @toggle-files="emit('toggle-files')"
+          @close="emit('close')"
+        />
       </span>
     </div>
     <TerminalView

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1010,7 +1010,13 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         @click="onHeaderClick"
       >
         <span class="cell-actions" :class="CELL_ACTIONS">
-          <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="close" />
+          <CellChromeButtons
+            :expanded="expanded"
+            :files-open="filesOpen"
+            @toggle-expand="emit('toggle-expand')"
+            @toggle-files="emit('toggle-files')"
+            @close="close"
+          />
         </span>
       </CockpitHeader>
       <!-- Row 1 — INFO only (normal grid / expanded): dir + git + model/token + what it's doing.
@@ -1092,7 +1098,13 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
              track, so they're always pinned top-right. `.stop` so they don't trigger the
              header's click-to-zoom. -->
         <span class="cell-actions" :class="CELL_ACTIONS">
-          <CellChromeButtons :expanded="expanded" @toggle-expand="emit('toggle-expand')" @close="close" />
+          <CellChromeButtons
+            :expanded="expanded"
+            :files-open="filesOpen"
+            @toggle-expand="emit('toggle-expand')"
+            @toggle-files="emit('toggle-files')"
+            @close="close"
+          />
         </span>
       </div>
       <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -15,6 +15,7 @@ import type { PrPhase, WorkPhase } from "./rosterPhase";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { shouldFlipZoom } from "./cellChromeRules";
+import { formatCwd } from "./cwdDisplay";
 import FilesPane from "./FilesPane.vue";
 import { clampPaneWidth, splitterKeyWidth } from "./splitterWidth";
 
@@ -141,15 +142,47 @@ const rowWidth = () => zoomRow.value?.clientWidth ?? 0;
 
 function toggleFiles(): void {
   filesOpen.value = !filesOpen.value;
+  // Closing drops the root it was on, so re-opening lands on whichever cell is enlarged THEN
+  // rather than resuming a directory the user has since walked away from.
+  if (!filesOpen.value) paneCwd.value = null;
   remember(PANE_OPEN_KEY, filesOpen.value ? "1" : "0");
 }
 
 // The enlarged cell's project dir — what the pane browses. A cell that hasn't reported one yet
 // (a launcher, a session still starting) falls back to the grid's default.
 const expandedCwd = computed(() => props.cells.find((c) => c.uid === props.expandedUid)?.cwd ?? props.defaultCwd);
+const filesPane = ref<InstanceType<typeof FilesPane> | null>(null);
+// The root the pane is ACTUALLY on. Normally `expandedCwd`, but it stays behind when a re-root
+// is declined over unsaved edits — and it, not `expandedCwd`, is what the pane is handed, so a
+// file opened from a tree that stayed put still resolves against the directory it came from.
+const paneCwd = ref<string | null>(null);
+
+// Walking the zoom to another terminal has to re-root the pane: the pane deliberately ignores
+// its `cwd` prop (see its defineExpose contract), so nothing else would move it. Asking first
+// is what keeps an unsaved buffer from vanishing with the enlargement.
+watch(
+  [filesOpen, zoomed, expandedCwd],
+  async ([open, isZoomed]) => {
+    if (!open || !isZoomed || paneCwd.value === expandedCwd.value) return;
+    // First showing: the pane is about to mount against this root, so there is nothing to re-read.
+    if (paneCwd.value === null) {
+      paneCwd.value = expandedCwd.value;
+      return;
+    }
+    if (!filesPane.value?.confirmDiscard()) return; // declined — stay on the old root
+    paneCwd.value = expandedCwd.value;
+    await nextTick(); // the pane reads its `cwd` prop when reloading, so let the new one land
+    filesPane.value?.reload();
+  },
+  { immediate: true },
+);
 
 function setPaneWidth(width: number): void {
-  paneWidth.value = clampPaneWidth(width, rowWidth());
+  const available = rowWidth();
+  // Before the row is laid out there is nothing to clamp against, and clamping against zero
+  // would "correct" the width to a negative one.
+  if (available <= 0) return;
+  paneWidth.value = clampPaneWidth(width, available);
 }
 function onSplitterDown(e: PointerEvent): void {
   const startX = e.clientX;
@@ -179,6 +212,15 @@ function onSplitterKey(e: KeyboardEvent): void {
 const reclampPane = () => filesOpen.value && setPaneWidth(paneWidth.value);
 onMounted(() => window.addEventListener("resize", reclampPane));
 onBeforeUnmount(() => window.removeEventListener("resize", reclampPane));
+
+// A width restored from storage was clamped against WHATEVER row existed when it was stored —
+// a wider window, or the other zoom mode. Re-clamp once the row is actually on screen, or a
+// remembered 900px opens against a 1000px row and leaves the terminal 100px wide.
+watch([filesOpen, zoomed, () => props.listMode], async ([open, isZoomed]) => {
+  if (!open || !isZoomed) return;
+  await nextTick();
+  setPaneWidth(paneWidth.value);
+});
 
 const stage = ref<HTMLElement | null>(null);
 // The cells currently flying between slots. Also gates the stylesheet: the cells not in
@@ -353,7 +395,14 @@ watch(
           @pointerdown.prevent="onSplitterDown"
           @keydown="onSplitterKey"
         />
-        <FilesPane :cwd="expandedCwd" :style="{ flex: `0 0 ${paneWidth}px` }" class="border-l border-border bg-deep" @close="toggleFiles" />
+        <FilesPane ref="filesPane" :cwd="paneCwd" :style="{ flex: `0 0 ${paneWidth}px` }" class="border-l border-border bg-deep" @close="toggleFiles">
+          <!-- Which directory the tree is actually rooted at. It normally follows the enlarged
+               cell, but declining a re-root leaves it behind — and then this is the only thing
+               that says so. -->
+          <template #title>
+            <span class="truncate font-mono text-[11px] text-muted" :title="expandedCwd ?? ''">{{ formatCwd(paneCwd, home) }}</span>
+          </template>
+        </FilesPane>
       </template>
     </div>
     <div class="grid" :style="gridStyle">

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -419,7 +419,7 @@ watch(
                cell, but declining a re-root leaves it behind — and then this is the only thing
                that says so. -->
           <template #title>
-            <span class="truncate font-mono text-[11px] text-muted" :title="expandedCwd ?? ''">{{ formatCwd(paneCwd, home) }}</span>
+            <span class="truncate font-mono text-[11px] text-muted" :title="paneCwd ?? ''">{{ formatCwd(paneCwd, home) }}</span>
           </template>
         </FilesPane>
       </template>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -140,12 +140,20 @@ const paneWidth = ref(Number(stored(PANE_WIDTH_KEY)) || PANE_WIDTH_DEFAULT);
 const zoomRow = ref<HTMLElement | null>(null);
 const rowWidth = () => zoomRow.value?.clientWidth ?? 0;
 
-function toggleFiles(): void {
-  filesOpen.value = !filesOpen.value;
+function setFilesOpen(open: boolean): void {
+  filesOpen.value = open;
   // Closing drops the root it was on, so re-opening lands on whichever cell is enlarged THEN
   // rather than resuming a directory the user has since walked away from.
-  if (!filesOpen.value) paneCwd.value = null;
-  remember(PANE_OPEN_KEY, filesOpen.value ? "1" : "0");
+  if (!open) paneCwd.value = null;
+  remember(PANE_OPEN_KEY, open ? "1" : "0");
+}
+
+// The header toggle. Closing unmounts the pane, buffer and all, so it asks first — the pane's
+// OWN close button has already asked by the time it emits, which is why that path is separate
+// rather than routed through here (it would prompt twice).
+function toggleFiles(): void {
+  if (filesOpen.value && !filesPane.value?.confirmDiscard()) return;
+  setFilesOpen(!filesOpen.value);
 }
 
 // The enlarged cell's project dir — what the pane browses. A cell that hasn't reported one yet
@@ -395,7 +403,7 @@ watch(
           @pointerdown.prevent="onSplitterDown"
           @keydown="onSplitterKey"
         />
-        <FilesPane ref="filesPane" :cwd="paneCwd" :style="{ flex: `0 0 ${paneWidth}px` }" class="border-l border-border bg-deep" @close="toggleFiles">
+        <FilesPane ref="filesPane" :cwd="paneCwd" :style="{ flex: `0 0 ${paneWidth}px` }" class="border-l border-border bg-deep" @close="setFilesOpen(false)">
           <!-- Which directory the tree is actually rooted at. It normally follows the enlarged
                cell, but declining a re-root leaves it behind — and then this is the only thing
                that says so. -->

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -17,7 +17,7 @@ import type { Launcher, LaunchPick } from "./launchers";
 import { shouldFlipZoom } from "./cellChromeRules";
 import { formatCwd } from "./cwdDisplay";
 import FilesPane from "./FilesPane.vue";
-import { clampPaneWidth, splitterKeyWidth } from "./splitterWidth";
+import { clampPaneWidth, splitterKeyWidth, MIN_GUI, MIN_TERMINAL } from "./splitterWidth";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -139,6 +139,12 @@ const filesOpen = ref(stored(PANE_OPEN_KEY) === "1");
 const paneWidth = ref(Number(stored(PANE_WIDTH_KEY)) || PANE_WIDTH_DEFAULT);
 const zoomRow = ref<HTMLElement | null>(null);
 const rowWidth = () => zoomRow.value?.clientWidth ?? 0;
+// Mirrored into a ref so the separator can announce its range (a plain function call would not
+// re-render when the row resizes). The pane's floor gives way to the terminal's on a narrow row,
+// which is why the minimum is itself clamped.
+const rowWidthNow = ref(0);
+const paneMax = computed(() => Math.max(0, rowWidthNow.value - MIN_TERMINAL));
+const paneMin = computed(() => Math.min(MIN_GUI, paneMax.value));
 
 function setFilesOpen(open: boolean): void {
   filesOpen.value = open;
@@ -187,6 +193,7 @@ watch(
 
 function setPaneWidth(width: number): void {
   const available = rowWidth();
+  rowWidthNow.value = available;
   // Before the row is laid out there is nothing to clamp against, and clamping against zero
   // would "correct" the width to a negative one.
   if (available <= 0) return;
@@ -399,6 +406,10 @@ watch(
           role="separator"
           aria-orientation="vertical"
           aria-label="Resize file pane"
+          :aria-valuenow="paneWidth"
+          :aria-valuemin="paneMin"
+          :aria-valuemax="paneMax"
+          title="Drag (or use arrow keys) to resize the file pane"
           tabindex="0"
           @pointerdown.prevent="onSplitterDown"
           @keydown="onSplitterKey"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onActivated, watch, nextTick, useTemplateRef } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount, onActivated, watch, nextTick, useTemplateRef } from "vue";
 import TerminalCell from "./TerminalCell.vue";
 import CommandCell from "./CommandCell.vue";
 import LauncherCell from "./LauncherCell.vue";
@@ -15,6 +15,8 @@ import type { PrPhase, WorkPhase } from "./rosterPhase";
 import type { CwdPreset } from "./presets";
 import type { Launcher, LaunchPick } from "./launchers";
 import { shouldFlipZoom } from "./cellChromeRules";
+import FilesPane from "./FilesPane.vue";
+import { clampPaneWidth, splitterKeyWidth } from "./splitterWidth";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
 // `cells` is the active page's slice (≤9) when nothing is zoomed, and `expandedUid`
@@ -110,6 +112,73 @@ const zoomMain = ref<HTMLElement | null>(null);
 const mounted = ref(false);
 onMounted(() => (mounted.value = true));
 const zoomed = computed(() => props.expandedUid !== null && mounted.value);
+
+// The file pane beside the enlarged cell. ONE pane, not one per cell: it re-roots to whichever
+// cell is enlarged, so walking the zoom doesn't accumulate editors. Open-state and width are
+// per-browser (localStorage), like the single view's splitter and the terminal font size.
+const PANE_OPEN_KEY = "files_pane_open";
+const PANE_WIDTH_KEY = "files_pane_width";
+const PANE_WIDTH_DEFAULT = 480;
+// Storage can throw (private mode / storage-blocked contexts), so both reads are best-effort.
+const stored = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+const remember = (key: string, value: string): void => {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // storage blocked: the pane still works this session, it just isn't remembered
+  }
+};
+const filesOpen = ref(stored(PANE_OPEN_KEY) === "1");
+const paneWidth = ref(Number(stored(PANE_WIDTH_KEY)) || PANE_WIDTH_DEFAULT);
+const zoomRow = ref<HTMLElement | null>(null);
+const rowWidth = () => zoomRow.value?.clientWidth ?? 0;
+
+function toggleFiles(): void {
+  filesOpen.value = !filesOpen.value;
+  remember(PANE_OPEN_KEY, filesOpen.value ? "1" : "0");
+}
+
+// The enlarged cell's project dir — what the pane browses. A cell that hasn't reported one yet
+// (a launcher, a session still starting) falls back to the grid's default.
+const expandedCwd = computed(() => props.cells.find((c) => c.uid === props.expandedUid)?.cwd ?? props.defaultCwd);
+
+function setPaneWidth(width: number): void {
+  paneWidth.value = clampPaneWidth(width, rowWidth());
+}
+function onSplitterDown(e: PointerEvent): void {
+  const startX = e.clientX;
+  const startWidth = paneWidth.value;
+  // Dragging LEFT grows the pane, so the delta is subtracted.
+  const onMove = (ev: PointerEvent) => setPaneWidth(startWidth - (ev.clientX - startX));
+  const onUp = () => {
+    window.removeEventListener("pointermove", onMove);
+    window.removeEventListener("pointerup", onUp);
+    remember(PANE_WIDTH_KEY, String(paneWidth.value));
+  };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp);
+}
+// The keys act on the TERMINAL's width (ArrowLeft shrinks it, growing the pane), which is what
+// splitterKeyWidth speaks — the pane's width is the remainder. Returning null means the key
+// isn't ours, and the separator must not swallow Tab or Escape.
+function onSplitterKey(e: KeyboardEvent): void {
+  const available = rowWidth();
+  const next = splitterKeyWidth(e.key, available - paneWidth.value, available);
+  if (next === null) return;
+  e.preventDefault();
+  setPaneWidth(available - next);
+  remember(PANE_WIDTH_KEY, String(paneWidth.value));
+}
+// A window that shrank below the two floors would otherwise leave the pane wider than the row.
+const reclampPane = () => filesOpen.value && setPaneWidth(paneWidth.value);
+onMounted(() => window.addEventListener("resize", reclampPane));
+onBeforeUnmount(() => window.removeEventListener("resize", reclampPane));
 
 const stage = ref<HTMLElement | null>(null);
 // The cells currently flying between slots. Also gates the stylesheet: the cells not in
@@ -268,7 +337,25 @@ watch(
         >
       </div>
     </aside>
-    <div ref="zoomMain" class="zoom-main" />
+    <!-- The enlarged cell and its file pane, side by side. A row wrapper rather than two more
+         siblings of the stage: the stage is a ROW in list mode (roster | terminal) and a COLUMN
+         in strip mode (terminal / filmstrip), so only nesting puts the pane beside the terminal
+         in both. Hidden outright when nothing is zoomed, like .zoom-main itself. -->
+    <div ref="zoomRow" :class="zoomed ? 'flex min-h-0 min-w-0 flex-auto' : 'hidden'">
+      <div ref="zoomMain" class="zoom-main" />
+      <template v-if="filesOpen">
+        <div
+          class="w-[5px] flex-none cursor-col-resize bg-border hover:bg-accent focus-visible:bg-accent"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize file pane"
+          tabindex="0"
+          @pointerdown.prevent="onSplitterDown"
+          @keydown="onSplitterKey"
+        />
+        <FilesPane :cwd="expandedCwd" :style="{ flex: `0 0 ${paneWidth}px` }" class="border-l border-border bg-deep" @close="toggleFiles" />
+      </template>
+    </div>
     <div class="grid" :style="gridStyle">
       <Teleport v-for="cell in cells" :key="cell.uid" :to="zoomMain" :disabled="!(zoomed && cell.uid === expandedUid)">
         <CommandCell
@@ -276,11 +363,13 @@ watch(
           :data-uid="cell.uid"
           :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
+          :files-open="filesOpen"
           :zoomed="zoomed"
           :command="cell.command"
           :home="home"
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
+          @toggle-files="toggleFiles"
           @close="emit('close', cell.uid)"
           @move="(dir) => emit('move', cell.uid, dir)"
           @status="(s) => emit('status', cell.uid, s)"
@@ -291,6 +380,7 @@ watch(
           :data-uid="cell.uid"
           :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
+          :files-open="filesOpen"
           :zoomed="zoomed"
           :launcher="cell.launcher"
           :session="cell.session"
@@ -298,6 +388,7 @@ watch(
           :home="home"
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
+          @toggle-files="toggleFiles"
           @close="emit('close', cell.uid)"
           @move="(dir) => emit('move', cell.uid, dir)"
           @status="(s) => emit('status', cell.uid, s)"
@@ -309,6 +400,7 @@ watch(
           :data-uid="cell.uid"
           :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
+          :files-open="filesOpen"
           :zoomed="zoomed"
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"
@@ -322,6 +414,7 @@ watch(
           :cancellable="cell.uid === cancelUid"
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
+          @toggle-files="toggleFiles"
           @session="(id) => emit('session', cell.uid, id)"
           @agent="(a) => emit('agent', cell.uid, a)"
           @cwd="(c) => emit('cwd', cell.uid, c)"

--- a/src/components/gridCell.ts
+++ b/src/components/gridCell.ts
@@ -14,11 +14,14 @@ export interface GridCellProps {
   // True while SOME cell in the grid is zoomed → this cell is a filmstrip thumbnail
   // (unless it's the zoomed one). Only then does a header-background click zoom it.
   zoomed?: boolean;
+  // Whether the file pane is showing beside the enlarged cell, so its toggle can read as
+  // pressed. Grid state, not the cell's: only the expanded cell renders the toggle.
+  filesOpen?: boolean;
   home: string | null;
 }
 
 export interface GridCellEmits {
-  (e: "toggle-expand" | "close"): void;
+  (e: "toggle-expand" | "close" | "toggle-files"): void;
   // Swap this cell left (-1) or right (+1) in manual sort mode.
   (e: "move", dir: -1 | 1): void;
   // Report activity up so the grid can attention-sort in auto mode.

--- a/src/components/splitterWidth.ts
+++ b/src/components/splitterWidth.ts
@@ -20,6 +20,13 @@ export function clampTerminalWidth(width: number, viewport: number): number {
   return Math.max(MIN_TERMINAL, Math.min(width, maxTerminalWidth(viewport)));
 }
 
+/** The same rule read from the other side, for a splitter that stores the RIGHT pane's width
+ *  (the file pane beside a zoomed grid cell) rather than the terminal's. Stating it in terms
+ *  of `clampTerminalWidth` is what keeps the two splitters from drifting apart. */
+export function clampPaneWidth(paneWidth: number, available: number): number {
+  return available - clampTerminalWidth(available - paneWidth, available);
+}
+
 // The width a key produces, or null when the key is not ours — the caller must NOT
 // preventDefault on null, or the separator would swallow Tab and Escape while focused.
 export function splitterKeyWidth(key: string, current: number, viewport: number): number | null {

--- a/src/style.css
+++ b/src/style.css
@@ -166,6 +166,13 @@
     overflow: hidden;
   }
 
+  /* CodeMirror injects `.cm-editor` into the host at runtime, so no utility can reach it
+     and this cannot live on an element we render. Global rather than scoped: the same
+     editor is mounted by the full-screen Files view and by the pane beside a zoomed cell. */
+  .files-editor .cm-editor {
+    height: 100%;
+  }
+
   /* Project-wide icon convention: Material Symbols (outlined). Icons inherit the
      surrounding text size by default; set font-size on the element to scale, and
      the optical-size axis (opsz) follows so weight stays balanced. */

--- a/test/src/components/CellChromeButtons.spec.ts
+++ b/test/src/components/CellChromeButtons.spec.ts
@@ -43,3 +43,34 @@ describe("CellChromeButtons", () => {
     expect(w.emitted("close")).toHaveLength(1);
   });
 });
+
+// The file pane splits the ENLARGED cell's room, so its toggle only exists there — a tiled
+// cell or a filmstrip thumbnail has nowhere to put it.
+describe("CellChromeButtons — the file pane toggle", () => {
+  it("is absent until the cell is enlarged", () => {
+    expect(mountButtons(false).find('[aria-label="Show files"]').exists()).toBe(false);
+    expect(mountButtons(true).find('[aria-label="Show files"]').exists()).toBe(true);
+  });
+
+  it("reads as pressed, and renames itself, while the pane is open", () => {
+    const open = mount(CellChromeButtons, { props: { expanded: true, filesOpen: true } });
+    const btn = open.find('[aria-label="Hide files"]');
+    expect(btn.exists()).toBe(true);
+    expect(btn.attributes("aria-pressed")).toBe("true");
+    expect(mountButtons(true).find('[aria-label="Show files"]').attributes("aria-pressed")).toBe("false");
+  });
+
+  it("emits the intent and never acts on it, like its neighbours", async () => {
+    const w = mountButtons(true);
+    await w.find('[aria-label="Show files"]').trigger("click");
+    expect(w.emitted("toggle-files")).toHaveLength(1);
+    expect(w.emitted("toggle-expand")).toBeUndefined();
+  });
+
+  // Expand/restore stays first: several specs and the grid select the first `.cell-btn`.
+  it("sits after expand/restore, not before it", () => {
+    const buttons = mountButtons(true).findAll(".cell-btn");
+    expect(buttons[0].attributes("aria-label")).toBe("Restore terminal");
+    expect(buttons[1].attributes("aria-label")).toBe("Show files");
+  });
+});

--- a/test/src/components/FilesPane.spec.ts
+++ b/test/src/components/FilesPane.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import FilesPane from "../../../src/components/FilesPane.vue";
+
+// Don't instantiate real CodeMirror (needs a full DOM); capture the change callback so a
+// user edit can be simulated.
+let onChange: () => void = () => {};
+const fakeEditor = { setDoc: vi.fn(), getDoc: vi.fn(() => "edited text"), destroy: vi.fn() };
+vi.mock("../../../src/components/cmEditor", async (orig) => {
+  const actual = await orig<typeof import("../../../src/components/cmEditor")>();
+  return { ...actual, createEditor: (_host: HTMLElement, cb: () => void) => ((onChange = cb), fakeEditor) };
+});
+
+function mockFs() {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes("/list")) return { ok: true, json: async () => ({ entries: [{ name: "README.md", dir: false, size: 10 }] }) };
+    if (url.includes("/text")) return { ok: true, json: async () => ({ text: "# hello", version: "v1" }) };
+    return { ok: true, json: async () => ({ ok: true, version: "v2" }), _init: init };
+  }) as unknown as typeof fetch;
+}
+
+const writeCalls = () => (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter((c) => String(c[0]).includes("/write"));
+
+async function openFileAndEdit(cwd: string | null = "/proj") {
+  const w = mount(FilesPane, { props: { cwd } });
+  await flushPromises();
+  await w.findAll('[data-testid="files-row"]')[0].trigger("click");
+  await flushPromises();
+  onChange();
+  await flushPromises();
+  return w;
+}
+
+describe("FilesPane", () => {
+  beforeEach(() => {
+    fakeEditor.setDoc.mockClear();
+    mockFs();
+  });
+
+  // The pane beside a zoomed grid cell has no route, no ?cwd= and no "is it open" — it is
+  // handed a directory and mounted. That the overlay ALSO uses it is covered by its own spec.
+  it("browses and opens a file from nothing but a cwd prop", async () => {
+    const w = mount(FilesPane, { props: { cwd: "/proj" } });
+    await flushPromises();
+    expect(w.text()).toContain("README.md");
+
+    await w.findAll('[data-testid="files-row"]')[0].trigger("click");
+    await flushPromises();
+    expect(fakeEditor.setDoc).toHaveBeenCalledWith("# hello", "README.md");
+    const read = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.find((c) => String(c[0]).includes("/text"));
+    expect(String(read?.[0])).toContain(encodeURIComponent("/proj"));
+  });
+
+  // The host guards its own navigation on this; a missed event means it guards on a stale answer.
+  it("reports the buffer going dirty, and clean again after a save", async () => {
+    const w = await openFileAndEdit();
+    expect(w.emitted("dirty")?.at(-1)).toEqual([true]);
+
+    await w
+      .findAll("button")
+      .find((b) => b.text().startsWith("Save"))
+      ?.trigger("click");
+    await flushPromises();
+    expect(w.emitted("dirty")?.at(-1)).toEqual([false]);
+  });
+
+  // Bound to the pane's own subtree, not to window: with a pane open beside a terminal, a
+  // window-level handler would save whenever the user pressed ⌘S while typing INTO the terminal.
+  it("saves on ⌘S inside the pane, and ignores one raised outside it", async () => {
+    const w = await openFileAndEdit();
+    expect(writeCalls()).toHaveLength(0);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "s", metaKey: true, bubbles: true }));
+    await flushPromises();
+    expect(writeCalls()).toHaveLength(0);
+
+    await w.trigger("keydown", { key: "s", metaKey: true });
+    await flushPromises();
+    expect(writeCalls()).toHaveLength(1);
+  });
+
+  it("asks before closing on top of unsaved edits, and stays put when refused", async () => {
+    const w = await openFileAndEdit();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    await w.find('[aria-label="Close files"]').trigger("click");
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(w.emitted("close")).toBeUndefined();
+
+    confirmSpy.mockReturnValue(true);
+    await w.find('[aria-label="Close files"]').trigger("click");
+    expect(w.emitted("close")).toHaveLength(1);
+    confirmSpy.mockRestore();
+  });
+
+  // reload() is how the host says "the root changed and I already cleared it with the user" —
+  // the pane never reacts to `cwd` itself, or it would discard a buffer still being asked about.
+  it("re-reads the tree only when the host calls reload, not when cwd changes", async () => {
+    const w = mount(FilesPane, { props: { cwd: "/proj" } });
+    await flushPromises();
+    const listCalls = () => (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.filter((c) => String(c[0]).includes("/list"));
+    expect(listCalls()).toHaveLength(1);
+
+    await w.setProps({ cwd: "/other" });
+    await flushPromises();
+    expect(listCalls()).toHaveLength(1);
+
+    await (w.vm as unknown as { reload: () => Promise<void> }).reload();
+    await flushPromises();
+    expect(listCalls()).toHaveLength(2);
+    expect(String(listCalls()[1][0])).toContain(encodeURIComponent("/other"));
+  });
+});

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -459,6 +459,51 @@ describe("file pane beside the enlarged cell", () => {
     expect(paneOf(w).props("cwd")).toBe("/one");
   });
 
+  // Closing unmounts the pane, buffer and all — so the toggle asks. The pane's own close button
+  // has already asked by the time it emits, and must not be asked again on the way out.
+  it("asks before the header toggle closes a pane with unsaved edits", async () => {
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await openPane(w);
+
+    paneStub.confirmDiscard.mockReturnValueOnce(false);
+    await w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
+    await nextTick();
+    expect(paneOf(w).exists()).toBe(true); // refused — the pane and its buffer stay
+
+    paneStub.confirmDiscard.mockReturnValueOnce(true);
+    await w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
+    await nextTick();
+    expect(paneOf(w).exists()).toBe(false);
+  });
+
+  it("does not re-ask when the pane itself reports it is closing", async () => {
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await openPane(w);
+    paneStub.confirmDiscard.mockClear();
+
+    await paneOf(w).vm.$emit("close");
+    await nextTick();
+    expect(paneStub.confirmDiscard).not.toHaveBeenCalled();
+    expect(paneOf(w).exists()).toBe(false);
+  });
+
+  // Collapsing the zoom only HIDES the row; the pane stays mounted, so an unsaved buffer is
+  // still there when the cell is enlarged again. (Codex read this as an unguarded discard.)
+  it("keeps the pane and its buffer mounted while the zoom is collapsed", async () => {
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await openPane(w);
+    const before = paneOf(w).element;
+
+    await w.setProps({ expandedUid: null });
+    await flushPromises();
+    expect(paneOf(w).exists()).toBe(true);
+    expect(w.find(".zoom-main").element.parentElement?.className).toContain("hidden");
+
+    await w.setProps({ expandedUid: 1 });
+    await flushPromises();
+    expect(paneOf(w).element).toBe(before); // same instance, never torn down
+  });
+
   it("remembers being open across a remount, and the pane's own close puts it away", async () => {
     const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     await openPane(w);

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises, DOMWrapper } from "@vue/test-utils";
-import { h, nextTick } from "vue";
+import { h, nextTick, type VNode } from "vue";
 import TerminalGrid, { type CockpitRow } from "../../../src/components/TerminalGrid.vue";
 import type { Cell } from "../../../src/components/gridTabs.js";
 import type { RunCommand } from "../../../src/components/runCommand.js";
@@ -15,9 +15,9 @@ vi.mock("../../../src/components/FilesPane.vue", () => ({
     name: "FilesPane",
     props: ["cwd", "requestedPath"],
     emits: ["close", "dirty"],
-    setup: (_p: unknown, { expose, slots }: { expose: (e: Record<string, unknown>) => void; slots: Record<string, (() => unknown) | undefined> }) => {
+    setup: (_p: unknown, { expose, slots }: { expose: (e: Record<string, unknown>) => void; slots: { title?: () => VNode[] } }) => {
       expose({ reload: paneStub.reload, confirmDiscard: paneStub.confirmDiscard });
-      return () => h("div", { class: "stub-files-pane" }, [slots.title?.()]);
+      return () => h("div", { class: "stub-files-pane" }, slots.title?.());
     },
   },
 }));

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -1,14 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount, DOMWrapper } from "@vue/test-utils";
-import { nextTick } from "vue";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises, DOMWrapper } from "@vue/test-utils";
+import { h, nextTick } from "vue";
 import TerminalGrid, { type CockpitRow } from "../../../src/components/TerminalGrid.vue";
 import type { Cell } from "../../../src/components/gridTabs.js";
 import type { RunCommand } from "../../../src/components/runCommand.js";
 import { setCockpitLines } from "../../../src/composables/cockpitLines";
 
 // Stub the cells so the page renderer can be tested without Terminal/xterm/pub-sub.
+// The host drives the pane through reload()/confirmDiscard(); spies here are what let the
+// contract be asserted rather than the prop that merely claims it.
+const paneStub = vi.hoisted(() => ({ reload: vi.fn(), confirmDiscard: vi.fn(() => true) }));
 vi.mock("../../../src/components/FilesPane.vue", () => ({
-  default: { name: "FilesPane", props: ["cwd", "requestedPath"], emits: ["close", "dirty"], template: '<div class="stub-files-pane" />' },
+  default: {
+    name: "FilesPane",
+    props: ["cwd", "requestedPath"],
+    emits: ["close", "dirty"],
+    setup: (_p: unknown, { expose }: { expose: (e: Record<string, unknown>) => void }) => {
+      expose({ reload: paneStub.reload, confirmDiscard: paneStub.confirmDiscard });
+      return () => h("div", { class: "stub-files-pane" });
+    },
+  },
 }));
 vi.mock("../../../src/components/TerminalCell.vue", () => ({
   default: {
@@ -370,6 +381,8 @@ describe("file pane beside the enlarged cell", () => {
   // enlargement, so they trip over it where the older ones never did.
   beforeEach(() => {
     localStorage.clear();
+    paneStub.reload.mockClear();
+    paneStub.confirmDiscard.mockReturnValue(true);
     if (!window.matchMedia) {
       window.matchMedia = ((query: string) => ({
         matches: false,
@@ -416,16 +429,34 @@ describe("file pane beside the enlarged cell", () => {
     expect(paneOf(noCwd).props("cwd")).toBe("/work");
   });
 
-  it("re-roots to whichever cell is enlarged rather than opening a second pane", async () => {
+  // The pane ignores its `cwd` prop by design, so asserting the prop alone would pass while the
+  // tree still showed the previous cell — the host has to re-read, and that is what is checked.
+  it("re-roots the one pane when the zoom moves to another cell", async () => {
     const cells = [cell(1, "s1", "/one"), cell(2, "s2", "/two")];
     const w = mountCockpit(cells, 1, []);
     await openPane(w);
     expect(w.findAllComponents({ name: "FilesPane" })).toHaveLength(1);
+    expect(paneOf(w).props("cwd")).toBe("/one");
+    expect(paneStub.reload).not.toHaveBeenCalled(); // it mounted on /one; nothing to re-read
 
     await w.setProps({ expandedUid: 2 });
-    await nextTick();
+    await flushPromises();
     expect(w.findAllComponents({ name: "FilesPane" })).toHaveLength(1);
     expect(paneOf(w).props("cwd")).toBe("/two");
+    expect(paneStub.reload).toHaveBeenCalledTimes(1);
+  });
+
+  // Declining the prompt has to leave the pane WHOLE — same root, same buffer. Handing it the
+  // new cwd while keeping the old tree would resolve the next file open against the wrong dir.
+  it("keeps the old root, prop and all, when the re-root is refused over unsaved edits", async () => {
+    paneStub.confirmDiscard.mockReturnValueOnce(false);
+    const w = mountCockpit([cell(1, "s1", "/one"), cell(2, "s2", "/two")], 1, []);
+    await openPane(w);
+
+    await w.setProps({ expandedUid: 2 });
+    await flushPromises();
+    expect(paneStub.reload).not.toHaveBeenCalled();
+    expect(paneOf(w).props("cwd")).toBe("/one");
   });
 
   it("remembers being open across a remount, and the pane's own close puts it away", async () => {
@@ -440,5 +471,38 @@ describe("file pane beside the enlarged cell", () => {
     await nextTick();
     expect(paneOf(reopened).exists()).toBe(false);
     expect(localStorage.getItem("files_pane_open")).toBe("0");
+  });
+});
+
+// A remembered width was clamped against WHATEVER row existed when it was stored — a wider
+// window, or the other zoom mode. Without a clamp at open time it is applied as-is, and a
+// remembered 900px against a 1000px row leaves the terminal 100px wide (xterm reflow garbage).
+describe("file pane width restored from storage", () => {
+  const ROW = 1000;
+  let clientWidth: PropertyDescriptor | undefined;
+  beforeEach(() => {
+    localStorage.clear();
+    clientWidth = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, "clientWidth");
+    Object.defineProperty(window.HTMLElement.prototype, "clientWidth", { configurable: true, get: () => ROW });
+  });
+  afterEach(() => {
+    if (clientWidth) Object.defineProperty(window.HTMLElement.prototype, "clientWidth", clientWidth);
+  });
+
+  it("clamps to the terminal's floor as soon as the pane is on screen", async () => {
+    localStorage.setItem("files_pane_open", "1");
+    localStorage.setItem("files_pane_width", "900");
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await flushPromises();
+    // 1000 wide, terminal keeps MIN_TERMINAL (320) → the pane gets the remaining 680.
+    expect(w.findComponent({ name: "FilesPane" }).attributes("style")).toContain("680px");
+  });
+
+  it("leaves a width that already fits alone", async () => {
+    localStorage.setItem("files_pane_open", "1");
+    localStorage.setItem("files_pane_width", "400");
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await flushPromises();
+    expect(w.findComponent({ name: "FilesPane" }).attributes("style")).toContain("400px");
   });
 });

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -543,6 +543,19 @@ describe("file pane width restored from storage", () => {
     expect(w.findComponent({ name: "FilesPane" }).attributes("style")).toContain("680px");
   });
 
+  // The single view's splitter announces its range; a screen-reader user resizing this one gets
+  // nothing without the same three attributes.
+  it("announces its value and range on the separator", async () => {
+    localStorage.setItem("files_pane_open", "1");
+    localStorage.setItem("files_pane_width", "400");
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await flushPromises();
+    const sep = w.find('[role="separator"][aria-label="Resize file pane"]');
+    expect(sep.attributes("aria-valuenow")).toBe("400");
+    expect(sep.attributes("aria-valuemin")).toBe("360"); // MIN_GUI, there being room for it
+    expect(sep.attributes("aria-valuemax")).toBe(String(ROW - 320)); // the terminal keeps MIN_TERMINAL
+  });
+
   it("leaves a width that already fits alone", async () => {
     localStorage.setItem("files_pane_open", "1");
     localStorage.setItem("files_pane_width", "400");

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, DOMWrapper } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalGrid, { type CockpitRow } from "../../../src/components/TerminalGrid.vue";
@@ -7,11 +7,14 @@ import type { RunCommand } from "../../../src/components/runCommand.js";
 import { setCockpitLines } from "../../../src/composables/cockpitLines";
 
 // Stub the cells so the page renderer can be tested without Terminal/xterm/pub-sub.
+vi.mock("../../../src/components/FilesPane.vue", () => ({
+  default: { name: "FilesPane", props: ["cwd", "requestedPath"], emits: ["close", "dirty"], template: '<div class="stub-files-pane" />' },
+}));
 vi.mock("../../../src/components/TerminalCell.vue", () => ({
   default: {
     name: "TerminalCell",
     props: ["expanded", "initialSessionId", "initialCwd", "defaultCwd", "presets", "home", "openSessionIds", "cancellable", "reorderable"],
-    emits: ["toggle-expand", "session", "cwd", "run", "close", "move", "status"],
+    emits: ["toggle-expand", "toggle-files", "session", "cwd", "run", "close", "move", "status"],
     template: '<div class="stub-cell" />',
   },
 }));
@@ -346,5 +349,96 @@ describe("grid cockpit (list view)", () => {
     const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { status: "idle", workPhase: "implementing" })]);
     await nextTick();
     expect(w.find('[data-testid="cockpit-badge"]').text()).toBe("idle");
+  });
+});
+
+// The file pane splits the ENLARGED cell's room in two. The zoomed stage has two shapes —
+// roster | terminal (list mode) and terminal / filmstrip (strip mode) — and the pane has to
+// land beside the terminal in both, which is the whole reason it lives in a row wrapper
+// rather than as another child of the stage.
+describe("file pane beside the enlarged cell", () => {
+  const paneOf = (w: ReturnType<typeof mount>) => w.findComponent({ name: "FilesPane" });
+  // Idempotent: the open state persists, so a second mount in the same test may already
+  // have it, and a blind toggle would close it.
+  const openPane = async (w: ReturnType<typeof mount>) => {
+    if (paneOf(w).exists()) return;
+    await w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
+    await nextTick();
+  };
+
+  // The zoom FLIP asks for prefers-reduced-motion, which jsdom omits; these tests move the
+  // enlargement, so they trip over it where the older ones never did.
+  beforeEach(() => {
+    localStorage.clear();
+    if (!window.matchMedia) {
+      window.matchMedia = ((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener() {},
+        removeListener() {},
+        addEventListener() {},
+        removeEventListener() {},
+        dispatchEvent: () => false,
+      })) as typeof window.matchMedia;
+    }
+  });
+
+  it("stays hidden until a cell is enlarged", async () => {
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    expect(paneOf(w).exists()).toBe(false); // closed by default
+    await openPane(w);
+    expect(paneOf(w).exists()).toBe(true);
+
+    // Nothing zoomed: the row it lives in is hidden outright, pane and all.
+    const flat = mountGrid([cell(1, "s1", "/proj")], null);
+    expect(flat.find(".zoom-main").element.parentElement?.className).toContain("hidden");
+  });
+
+  it.each([
+    ["list", true],
+    ["strip", false],
+  ])("puts the pane beside the enlarged terminal in %s mode", async (_name, listMode) => {
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, [], false, listMode);
+    await openPane(w);
+    const row = w.find(".zoom-main").element.parentElement;
+    expect(row?.contains(paneOf(w).element)).toBe(true);
+  });
+
+  it("browses the enlarged cell's directory, falling back to the grid default", async () => {
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await openPane(w);
+    expect(paneOf(w).props("cwd")).toBe("/proj");
+
+    // A launcher / still-starting session has reported no cwd yet.
+    const noCwd = mountCockpit([cell(1), cell(2)], 1, []);
+    await openPane(noCwd);
+    expect(paneOf(noCwd).props("cwd")).toBe("/work");
+  });
+
+  it("re-roots to whichever cell is enlarged rather than opening a second pane", async () => {
+    const cells = [cell(1, "s1", "/one"), cell(2, "s2", "/two")];
+    const w = mountCockpit(cells, 1, []);
+    await openPane(w);
+    expect(w.findAllComponents({ name: "FilesPane" })).toHaveLength(1);
+
+    await w.setProps({ expandedUid: 2 });
+    await nextTick();
+    expect(w.findAllComponents({ name: "FilesPane" })).toHaveLength(1);
+    expect(paneOf(w).props("cwd")).toBe("/two");
+  });
+
+  it("remembers being open across a remount, and the pane's own close puts it away", async () => {
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await openPane(w);
+    expect(localStorage.getItem("files_pane_open")).toBe("1");
+
+    const reopened = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    expect(paneOf(reopened).exists()).toBe(true);
+
+    await paneOf(reopened).vm.$emit("close");
+    await nextTick();
+    expect(paneOf(reopened).exists()).toBe(false);
+    expect(localStorage.getItem("files_pane_open")).toBe("0");
   });
 });

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -15,9 +15,9 @@ vi.mock("../../../src/components/FilesPane.vue", () => ({
     name: "FilesPane",
     props: ["cwd", "requestedPath"],
     emits: ["close", "dirty"],
-    setup: (_p: unknown, { expose }: { expose: (e: Record<string, unknown>) => void }) => {
+    setup: (_p: unknown, { expose, slots }: { expose: (e: Record<string, unknown>) => void; slots: Record<string, (() => unknown) | undefined> }) => {
       expose({ reload: paneStub.reload, confirmDiscard: paneStub.confirmDiscard });
-      return () => h("div", { class: "stub-files-pane" });
+      return () => h("div", { class: "stub-files-pane" }, [slots.title?.()]);
     },
   },
 }));
@@ -457,6 +457,11 @@ describe("file pane beside the enlarged cell", () => {
     await flushPromises();
     expect(paneStub.reload).not.toHaveBeenCalled();
     expect(paneOf(w).props("cwd")).toBe("/one");
+    // The header names the root it stayed on — label AND tooltip, or the tooltip would quietly
+    // claim the directory the pane refused to move to.
+    const label = w.find(".stub-files-pane span");
+    expect(label.text()).toContain("one");
+    expect(label.attributes("title")).toBe("/one");
   });
 
   // Closing unmounts the pane, buffer and all — so the toggle asks. The pane's own close button

--- a/test/src/components/splitterWidth.spec.ts
+++ b/test/src/components/splitterWidth.spec.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
 
-import { clampTerminalWidth, maxTerminalWidth, MIN_GUI, MIN_TERMINAL, splitterKeyWidth, SPLITTER_STEP } from "../../../src/components/splitterWidth";
+import {
+  clampPaneWidth,
+  clampTerminalWidth,
+  maxTerminalWidth,
+  MIN_GUI,
+  MIN_TERMINAL,
+  splitterKeyWidth,
+  SPLITTER_STEP,
+} from "../../../src/components/splitterWidth";
 
 const WIDE = 1600;
 
@@ -61,5 +69,29 @@ describe("splitterKeyWidth", () => {
   // separator swallows Tab and Escape whenever it has focus.
   it.each([["Tab"], ["Escape"], ["Enter"], [" "], ["ArrowUp"], ["ArrowDown"], ["a"], ["arrowleft"]])("does not claim %j", (key) => {
     expect(splitterKeyWidth(key, 560, WIDE)).toBeNull();
+  });
+});
+
+// The file pane beside a zoomed grid cell stores ITS width, not the terminal's, so the same
+// rule has to hold read from the other side.
+describe("clampPaneWidth", () => {
+  it("leaves a width alone when both sides fit", () => {
+    expect(clampPaneWidth(500, 1600)).toBe(500);
+  });
+
+  it("stops the pane from pushing the terminal below its floor", () => {
+    // 1000 wide: the terminal keeps MIN_TERMINAL, so the pane can have the rest.
+    expect(clampPaneWidth(900, 1000)).toBe(1000 - MIN_TERMINAL);
+  });
+
+  it("gives the pane its own floor when there is room for both", () => {
+    expect(clampPaneWidth(10, 1600)).toBe(MIN_GUI);
+  });
+
+  // The documented tie-break: too narrow for both floors, and the TERMINAL's wins — a terminal
+  // below its minimum reflows xterm into garbage, a squeezed pane is merely cramped.
+  it("surrenders the pane's floor before the terminal's", () => {
+    const available = MIN_TERMINAL + 100;
+    expect(clampPaneWidth(MIN_GUI, available)).toBe(100);
   });
 });


### PR DESCRIPTION
## Summary

**ズーム中（セルを拡大している状態）に、広がったターミナル領域を左右に分割して、右に file explorer / viewer を出す。** これまでは専用の全画面ビューが開くだけで、ターミナルと同時に見られなかった (#910 Phase 1)。

拡大したセルのヘッダにフォルダのトグルが増え、押すと `ターミナル | ペイン` になる。区切りはドラッグでもキーボード（←/→, Home, End）でも動かせる。

**中身は作っていない。** ツリー・CodeMirror・md プレビュー・未保存ガード・409 バナーは全画面 Files view として全部動いていたので、実体を `FilesPane.vue` に抽出し、`FilesOverlay.vue` をその薄いラッパにした。**サーバ API の追加はゼロ。**

## Items to Confirm / Review

1. **実機未確認です。** ユニットテスト 18 件（うち既存 12 件が抽出のリグレッションゲート）は通っていますが、画面は見ていません。特に **3 カラムになる list モードの幅**（ロースター＋ターミナル＋ペイン）はノート PC 幅だと窮屈なはずで、実際どう見えるかは触ってみないと分かりません
2. **`FilesOverlay.spec.ts` を 1 行も変えずに 12 件 green** なのが、この抽出の主な安全確認です。特にルート離脱ガード（`reverting` / `bypassGuard`）の挙動が変わっていないこと
3. **ペインが `cwd` の変化に自分では反応しない**のは意図的です。反応させると、ホストがまだユーザーに確認している最中のバッファを捨てます。ホストがガードを通してから `reload()` を呼ぶ、という契約にしていて、テストで固定しています
4. **`⌘S` をペインのサブツリーに束ね直しました**（旧: window ＋ `isOpen` ガード）。隣のターミナルに打ち込んでいる最中の `⌘S` で保存が走らないようにするためですが、全画面版の挙動も変わります（ツリーにフォーカスがあっても効くのは同じ、ペインの外にフォーカスがあると効かない）
5. `.cm-editor` の高さ指定を `<style scoped>` から `src/style.css` に移しました。CodeMirror が実行時に注入する要素でユーティリティが届かないためで、CLAUDE.md の「utility にできないものはグローバル 1 箇所へ」に従っています

## User Prompt

> UI の改良が最優先かな。いまは専用 UI が開くので。expand で２つになるように。

（#910 の設計で決めた「既存 Files view を共通コンポーネントに切り出す」「ズーム中のヘッダにトグル」「セルごとの記憶なし＝開閉と幅だけ」という Phase 1 の範囲）

## 実装

### 分割線をどこに引いたか

| 置き場所 | 何を持つか |
|---|---|
| `FilesPane.vue` | ツリー、エディタ、保存、409 バナー、自分の未保存ガード |
| `FilesOverlay.vue` | ルート結合 (`useFilesView`)、`fixed` の枠、ルート離脱時のガード |
| `TerminalGrid.vue` | ペインの開閉・幅、スプリッタ、どのセルの dir を見せるか |

未保存かどうかはホストも知る必要があるので、ペインは `dirty` を emit する。

### 行ラッパ 1 つで両ズームモードに効かせた

ズームには 2 つの形があり、**`listMode` の既定は `true`（ロースター）**。strip モードだけ対応すると既定のユーザーには何も出ないので、最初から両方に出している。

- list モード: stage が **row** → `roster | terminal`
- strip モード: stage が **column** → `terminal / filmstrip`

`zoom-main` を stage 直下に並べたままペインを足すと、strip モードでは**ターミナルの下**に入る。`zoom-main` とペインを **row のラッパで包む**と、stage がどちら向きでも「ターミナルの右」になる。ラッパは Tailwind のみで、既存の `.zoom-main` の CSS には触っていない。

### 幅の規則は単一ビューのスプリッタを流用

`splitterWidth.ts` に 1 行:

```ts
export function clampPaneWidth(paneWidth: number, available: number): number {
  return available - clampTerminalWidth(available - paneWidth, available);
}
```

**同じ規則を反対側から読んだだけ**にすることで、2 つのスプリッタが別々に育つのを防ぐ。狭いときに「ターミナルの下限が勝ち、ペインが自分の下限を諦める」という既存のタイブレークもそのまま継承される（3 カラムになる list モードで効く）。

### その他

- `toggle-files` は `gridCell.ts` の `GridCellEmits` に追加。3 種類のセル全部が同じ形で持つ
- トグルは expand/restore の**後ろ**（複数のテストと grid が最初の `.cell-btn` を掴んでいる）
- 開閉状態と幅は `TerminalGrid` が持ち localStorage に記憶。**セルごとの記憶は Phase 2**

## 検証

- `FilesPane.spec.ts`（新規 5 件）— cwd プロップだけで動く / `dirty` を上げる / `⌘S` はペイン内だけ効き window では効かない / 未保存の close を確認する / **`cwd` 変更では読み直さず `reload()` でだけ読み直す**
- `TerminalGrid.spec.ts`（新規 5 件）— 拡大するまで出ない / **list と strip の両モードでターミナルと同じ行に入る** / 拡大中のセルの dir を見る（無ければ既定にフォールバック）/ ズームを移してもペインは 1 つのまま張り替わる / 開閉が localStorage に残る
- `CellChromeButtons.spec.ts`（新規 4 件）、`splitterWidth.spec.ts`（新規 4 件）
- `yarn format` / `lint`（既存 warning 1 件のみ）/ `typecheck` `typecheck:server` `typecheck:test` / `build` / `test`（4663 passed, 38 skipped）

## 続き（#910）

- **Phase 2**: 自動保存＋3 世代バックアップ＋セルごとの記憶
- **Phase 3**: 外部変更の検知（PostToolUse hook ＋ 30 秒ポーリング）

Refs #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)
