### PR TITLE
fix: サブエージェント完了を「呼ばれている」通知にしない（通知の嵐の原因）

### DIFF
--- a/plans/fix-874-subagent-completion-push.md
+++ b/plans/fix-874-subagent-completion-push.md
@@ -1,0 +1,61 @@
+# A finished subagent is not a session waiting on you
+
+Issue: #874 (and the half of #850 that "it's by design" did not actually cover)
+
+## What was measured
+
+An interactive session was run with every hook pointed at a capture server, and the payloads were
+recorded verbatim. One subagent produced:
+
+```
+05:10:02.536  Stop                                       -> ✅ finished push
+05:10:03.650  Notification  type=agent_completed         -> ❓ waiting push, 1.1s later
+                            msg='execute-date-command finished'
+                            agent_id=None
+```
+
+Two pushes for one turn, from one subagent. Eight parallel sessions with several subagents each is
+the reported storm, and it is not a matter of taste: the second push says *the agent is blocked on
+you* when nothing is blocked.
+
+The payload's fields settle the design:
+
+- **`notification_type` is present** — `agent_completed`.
+- **`agent_id` is NOT** present on Notification (it is on `SubagentStart` / `SubagentStop` / the
+  subagent's own `PreToolUse`, but those are not registered hooks). So an earlier guess that this
+  could be filtered by `agent_id` was wrong; the type is the only usable signal.
+
+## Three symptoms, one misclassification
+
+`Notification` was mapped to "the user is needed" in two places, and the beep follows the second:
+
+| | before | after |
+|---|---|---|
+| Web Push (`pushKindFor`) | always `waiting` | `waiting` unless informational |
+| Grid attention + beep (`activityHookEffects`) | always `waiting: true` | same rule |
+
+Fixing only the push would have left the cell flashing and beeping for a finished subagent, which
+is most of what "notification storm" means in practice.
+
+## Denylist, not allowlist
+
+Suppressed: `agent_completed`, `auth_success`, `elicitation_complete`, `elicitation_response` —
+each reports something that already happened.
+
+Everything else notifies, including a type this code has never seen and the absent-type case (an
+older Claude Code sends none). The asymmetry is the whole argument: a spurious ping is an
+annoyance, a swallowed "your agent is blocked" is precisely what the feature exists to prevent, and
+a user cannot discover a stuck session any other way. That is also why #850's answer — turn
+`waiting` off — was not a fix: it removes the valuable notification along with the noise.
+
+## Not in scope
+
+`SubagentStart` / `SubagentStop` remain unregistered. They would allow a "suppress everything while
+a subagent runs" rule (option C on the issue), but that is a bigger behavioural change and this one
+is precise: `agent_completed` is a completion, so calling it "waiting" was simply wrong.
+
+## Verification
+
+The specs were confirmed to fail against the unfixed code. Re-checking the real behaviour needs an
+interactive session — `Notification` does not fire under `claude -p` — using the same capture-server
+method recorded on the issue.

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -32,8 +32,8 @@ export interface HookDeps extends SessionActivityDeps {
 // Activity hooks update a session's working / needs-attention flags. `active` (this
 // session is the user's actively-viewed pane) suppresses the attention flag — see
 // activityHookEffects for why a mere attached socket doesn't count in the grid.
-function handleActivityHook(deps: HookDeps, sessionId: string, event: string, active: boolean, message: string) {
-  for (const eff of activityHookEffects(event, active)) {
+function handleActivityHook(deps: HookDeps, sessionId: string, event: string, active: boolean, message: string, notificationType?: string) {
+  for (const eff of activityHookEffects(event, active, notificationType)) {
     if (eff.kind === "working") deps.setWorking(sessionId, eff.value, event);
     else deps.setWaiting(sessionId, eff.value, event);
   }
@@ -41,7 +41,7 @@ function handleActivityHook(deps: HookDeps, sessionId: string, event: string, ac
   // A finished turn (Stop) and a blocked one (Notification) both reach here; the kind
   // decides the wording. Stop is one event per finished turn, so this fires once even
   // though a background Stop publishes twice.
-  const kind = pushKindFor(event);
+  const kind = pushKindFor(event, notificationType);
   if (kind) void notifyTaskFinished(sessionId, kind, message, deps.uiPort);
 }
 
@@ -137,7 +137,16 @@ async function handleHookRequest(deps: HookDeps, req: Request, res: Response) {
     // pty — so tracking an id with no pty (any well-formed uuid may be posted here) would never be
     // reclaimed. A session whose pty is gone simply reports no phase, as it does before its first tool.
     if (entry) deps.noteWorkPhase(sessionId, event, typeof body.tool_name === "string" ? body.tool_name : undefined);
-    handleActivityHook(deps, sessionId, event, active, typeof body.message === "string" ? body.message : "");
+    handleActivityHook(
+      deps,
+      sessionId,
+      event,
+      active,
+      typeof body.message === "string" ? body.message : "",
+      // Which KIND of notification — a subagent finishing arrives here as
+      // `agent_completed`, and must not be read as the agent waiting on the user (#874).
+      typeof body.notification_type === "string" ? body.notification_type : undefined,
+    );
     await handleToolHook(deps, sessionId, event, body, cwd);
     // A hidden translation worker that ends its turn while still pending never called
     // submitTranslation — fail it now rather than hang until the timeout. (When it DID

--- a/server/session/activity-hook.ts
+++ b/server/session/activity-hook.ts
@@ -21,7 +21,26 @@ export type ActivityEffect = { kind: "working" | "waiting"; value: boolean };
 // no-ops when the flag is already true, so this re-asserts only after a loss, never spams.
 const WORKING_EVENTS = new Set(["UserPromptSubmit", "PreToolUse", "PostToolUse", "PostToolUseFailure"]);
 
-export function activityHookEffects(event: string, active: boolean): ActivityEffect[] {
+// Notification types that report something that ALREADY HAPPENED rather than something the user
+// must answer. `agent_completed` is the one this was written for: a subagent finishing fires it,
+// and treating every Notification as "blocked on you" made a finished subagent flag the cell for
+// attention, beep, and push — once per subagent, while the main turn was still running (#874).
+// Measured, not assumed: the payload carries `notification_type: "agent_completed"` and no
+// `agent_id`, so the TYPE is the only thing that distinguishes it.
+//
+// A DENYLIST, not an allowlist, and the asymmetry is the reason: Claude Code adds notification
+// types over time, an unrecognised one still notifies, and the two failure modes are not equal.
+// One spurious ping is an annoyance; a swallowed "your agent is blocked" is exactly what this
+// feature exists to prevent, and a user cannot discover a stuck session any other way.
+const INFORMATIONAL_NOTIFICATIONS: ReadonlySet<string> = new Set(["agent_completed", "auth_success", "elicitation_complete", "elicitation_response"]);
+
+// A Notification the user should actually be told about. An absent type means an older Claude
+// Code that doesn't send one — those keep the previous behaviour rather than going silent.
+export function isActionableNotification(notificationType?: string): boolean {
+  return !notificationType || !INFORMATIONAL_NOTIFICATIONS.has(notificationType);
+}
+
+export function activityHookEffects(event: string, active: boolean, notificationType?: string): ActivityEffect[] {
   if (WORKING_EVENTS.has(event)) return [{ kind: "working", value: true }];
   // A finished turn (Stop) has unseen output; a paused turn (Notification) waits on the
   // user. Either flags the session for attention UNLESS it's the actively-viewed pane.
@@ -33,7 +52,7 @@ export function activityHookEffects(event: string, active: boolean): ActivityEff
           { kind: "working", value: false },
         ];
   }
-  if (event === "Notification") return active ? [] : [{ kind: "waiting", value: true }];
+  if (event === "Notification") return active || !isActionableNotification(notificationType) ? [] : [{ kind: "waiting", value: true }];
   return [];
 }
 
@@ -48,9 +67,9 @@ export function activityHookEffects(event: string, active: boolean): ActivityEff
 // fire regardless of `active` — the phone is elsewhere. pushEnabled / hidden /
 // translation gates stay with the caller.
 
-export function pushKindFor(event: string): PushKind | null {
+export function pushKindFor(event: string, notificationType?: string): PushKind | null {
   if (event === "Stop") return "finished";
-  if (event === "Notification") return "waiting";
+  if (event === "Notification") return isActionableNotification(notificationType) ? "waiting" : null;
   return null;
 }
 

--- a/test/server/session/activity-hook.spec.ts
+++ b/test/server/session/activity-hook.spec.ts
@@ -203,3 +203,51 @@ describe("resolveHookCwd", () => {
     expect(dirConfigWriteTarget("Write", { file_path: ".mulmoterminal.json" }, cwd ?? null)).toBe(liveCwd);
   });
 });
+
+// #874: a subagent finishing arrives as `Notification` with `notification_type:
+// "agent_completed"` — measured from a real session, where the payload carried that type and NO
+// `agent_id`, so the type is the only distinguishing field. Treating every Notification as
+// "blocked on you" made each finished subagent flag the cell, beep, and push while the main turn
+// was still running. With 8 parallel sessions that is the reported "notification storm".
+describe("Notification kinds — informational vs actually blocked (#874)", () => {
+  const INFORMATIONAL = ["agent_completed", "auth_success", "elicitation_complete", "elicitation_response"];
+  const ACTIONABLE = ["permission_prompt", "idle_prompt", "agent_needs_input", "elicitation_dialog"];
+
+  it("does not push or flag for a notification that only reports something finished", () => {
+    INFORMATIONAL.forEach((type) => {
+      expect(pushKindFor("Notification", type)).toBeNull();
+      expect(activityHookEffects("Notification", false, type)).toEqual([]);
+    });
+  });
+
+  it("still pushes and flags when the agent is genuinely blocked on the user", () => {
+    ACTIONABLE.forEach((type) => {
+      expect(pushKindFor("Notification", type)).toBe("waiting");
+      expect(activityHookEffects("Notification", false, type)).toEqual([{ kind: "waiting", value: true }]);
+    });
+  });
+
+  // A DENYLIST on purpose. Claude Code adds notification types over time and the failure modes are
+  // not symmetric: one spurious ping is an annoyance, a swallowed "your agent is blocked" is the
+  // thing this feature exists to prevent — and a user cannot discover a stuck session another way.
+  it("notifies for a type it has never seen", () => {
+    expect(pushKindFor("Notification", "some_future_type")).toBe("waiting");
+    expect(activityHookEffects("Notification", false, "some_future_type")).toEqual([{ kind: "waiting", value: true }]);
+  });
+
+  // An older Claude Code sends no type at all; those must keep notifying rather than go silent.
+  it("keeps the previous behaviour when no type is sent", () => {
+    expect(pushKindFor("Notification")).toBe("waiting");
+    expect(activityHookEffects("Notification", false)).toEqual([{ kind: "waiting", value: true }]);
+  });
+
+  // The type must not leak into the other events — a Stop is a finished turn regardless.
+  it("leaves Stop alone", () => {
+    expect(pushKindFor("Stop", "agent_completed")).toBe("finished");
+  });
+
+  // The actively-viewed pane never raises attention, whatever the type — unchanged by #874.
+  it("still suppresses the flag on the active pane", () => {
+    expect(activityHookEffects("Notification", true, "permission_prompt")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

サブエージェントの完了（`Notification` / `notification_type: "agent_completed"`）を、
**「ユーザが呼ばれている」として扱わない**ようにします。Closes #874。

## 実測してから直しました

全フックを捕獲用サーバへ向けた**対話セッション**を回し、payload を丸ごと記録。サブエージェント **1 個**で:

```
05:10:02.536  Stop                                 → ✅ finished push
05:10:03.650  Notification type=agent_completed    → ❓ waiting push（1.1 秒後）
                           msg='execute-date-command finished'
                           agent_id=None
```

**1 ターンで 2 発。** 8 並列 × 複数サブエージェントが「嵐」の正体です。しかも 2 発目は単なる余分ではなく、
**何も詰まっていないのに「詰まっている」と言っている**点が問題です。

## payload が設計を決めました

| フィールド | 有無 |
|---|---|
| `notification_type` | **あり**（`agent_completed`） |
| `agent_id` | **なし** |

`agent_id` は `SubagentStart` / `SubagentStop` / サブエージェント自身の `PreToolUse` に付きますが、
**そのどれも登録フックではありません**。issue で私が「`agent_id` で判別できるかも」と書いたのは**誤り**で、
そちらは訂正済みです。使えるのは `notification_type` だけです。

## 症状は 3 つ、原因は 1 つ

`Notification` を「ユーザが必要」と解釈している箇所が **2 つ**あり、通知音は後者に従います。

| | 修正前 | 修正後 |
|---|---|---|
| Web Push（`pushKindFor`） | 常に `waiting` | 情報系なら通知しない |
| グリッドの注目状態 + 通知音（`activityHookEffects`） | 常に `waiting: true` | 同じ規則 |

**push だけ直すとセルの点滅と通知音は残ります。** 実感としての「嵐」の大半はそちらなので、まとめて直しました。

## denylist にした理由（allowlist ではなく）

抑制するのは `agent_completed` / `auth_success` / `elicitation_complete` / `elicitation_response` —
いずれも**すでに起きたこと**の報告です。

それ以外は**未知の種別も、種別が無い場合（古い Claude Code）も通知します。**

失敗の重さが非対称だからです。**余計な 1 発は煩わしいだけ**ですが、**「エージェントが詰まっている」を握り潰すのは
この機能の存在意義そのものを壊します** — 止まったセッションに気づく手段が他にありません。

これは #850 の回答（`waiting` を切る）が解決になっていなかった理由でもあります。ノイズと一緒に**一番価値のある通知が消える**ため。

## Items to Confirm / Review

1. **denylist の中身。** `auth_success` / `elicitation_complete` / `elicitation_response` は
   ドキュメントの種別一覧からの分類で、**実測したのは `agent_completed` だけ**です。他の 3 つは
   「すでに起きたことの報告」という読みに基づく判断なので、異論があれば外せます。
2. **`SubagentStart` / `SubagentStop` は未登録のまま**にしました。登録すれば「サブエージェント稼働中は全部抑制」
   （issue の案 C）ができますが、より大きな挙動変更になります。今回は「完了を待機と呼ぶのは単純に誤り」という
   一点に絞っています。

## Tests

`test/server/session/activity-hook.spec.ts` に 6 ケース追加。情報系は push もフラグも立てない / 実際に
ブロックされている種別は従来どおり / **未知の種別は通知する** / 種別なしも通知する / `Stop` は無影響 /
アクティブなペインは従来どおり抑制。

**修正を外すと落ちることを確認済み**です。

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test` すべて exit=0、
**4639 tests passing**。

### 再確認について

`Notification` は **`claude -p` では発火しません**（UI 由来のため）。実機での再確認には対話セッションが必要で、
手順は issue にコメントとして残してあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
