### PR TITLE
fix: Windows CI が落ちる POSIX パスリテラルを spec から外す (#934)

### DIFF
--- a/test/server/files/backup-store.spec.ts
+++ b/test/server/files/backup-store.spec.ts
@@ -10,19 +10,25 @@ const backupsIn = (dir: string) =>
     .filter((n) => n.endsWith(".bak"))
     .sort();
 
+// Resolved, not POSIX literals: on Windows an absolute path is drive-qualified, so an
+// expectation written as "/backups" only agrees on the developer's machine.
+const ROOT = path.resolve("/backups");
+const FILE = path.resolve("/proj/a.md");
+// Built by hand rather than with path.join, which would normalize away the `..` this is about.
+const MESSY_FILE = [path.dirname(FILE), "sub", "..", path.basename(FILE)].join(path.sep);
+
 describe("backupDirFor", () => {
   it("gives each file its own stable directory", () => {
-    const root = "/backups";
-    expect(backupDirFor("/proj/a.md", root)).toBe(backupDirFor("/proj/a.md", root));
-    expect(backupDirFor("/proj/a.md", root)).not.toBe(backupDirFor("/proj/b.md", root));
+    expect(backupDirFor(FILE, ROOT)).toBe(backupDirFor(FILE, ROOT));
+    expect(backupDirFor(FILE, ROOT)).not.toBe(backupDirFor(path.resolve("/proj/b.md"), ROOT));
     // Same file reached by a messier path is the same file.
-    expect(backupDirFor("/proj/sub/../a.md", root)).toBe(backupDirFor("/proj/a.md", root));
+    expect(backupDirFor(MESSY_FILE, ROOT)).toBe(backupDirFor(FILE, ROOT));
   });
 
   // A path can't BE a directory name: separators, case folding and length limits all break it.
   it("names it with a hash, not the path", () => {
-    const dir = backupDirFor("/proj/a.md", "/backups");
-    expect(path.dirname(dir)).toBe("/backups");
+    const dir = backupDirFor(FILE, ROOT);
+    expect(path.dirname(dir)).toBe(ROOT);
     expect(path.basename(dir)).toMatch(/^[0-9a-f]{16}$/);
   });
 });


### PR DESCRIPTION
## Summary

Windows (daily) が main で赤い状態を直す。テスト 1 件のみの修正で、プロダクトコードは変更していない。

[run 30243431977](https://github.com/receptron/mulmoterminal/actions/runs/30243431977) の失敗は 4887 件中 1 件:

```
FAIL  test/server/files/backup-store.spec.ts > backupDirFor > names it with a hash, not the path
AssertionError: expected '\backups' to be '/backups'
```

`backupDirFor()` は `path.join(root, hash)` を返す。spec が期待値を POSIX リテラルで書いていたため、Windows では `path.join("/backups", hash)` が `\backups\<hash>` になり、`path.dirname()` の `\backups` が `"/backups"` と一致しなかった。

`docs/cross-platform-ci.md` の「Tests that handle paths」が禁じているパターンそのもの。期待値も `path.resolve()` で組み立てるよう直した。macOS/Linux では両辺が一致してしまうため、ローカルの `yarn test` では見えない種類のバグ。

## Items to Confirm / Review

- **`MESSY_FILE` の組み立て方**。「汚いパスでも同じファイル」を確かめるケースは `..` が残っていないと意味がないが、`path.join` を使うと正規化されて `..` が消え、テストが何も検証しなくなる。そのため `[path.dirname(FILE), "sub", "..", path.basename(FILE)].join(path.sep)` と区切り文字を明示して組んでいる。ここは意図的に `path.join` を避けている点をレビューしてほしい。
- **Windows 上での検証方法**。手元は macOS なので、`path.win32` セマンティクスで同じ表明を再現するスクリプトを書いて確認した（`ROOT=D:\backups` / `FILE=D:\proj\a.md` / `MESSY=D:\proj\sub\..\a.md` を与え、dirname が ROOT に一致し、messy と FILE が同じハッシュに落ちることを assert）。win32・posix の両方で通ることは確認済みだが、実機 Windows での確認は本 PR の CI に委ねている。
- **プロダクトコードを直していない判断**。実運用の `backupRoot` は `path.join(MULMOTERMINAL_HOME, "backups")`（`server/routes/app-routes.ts:228`）で OS ネイティブな絶対パスなので、Windows でも `backupDirFor` の挙動は正しい。バグはテスト側だけという判断。

## User Prompt

> https://github.com/receptron/mulmoterminal/actions/runs/30243431977 なおして

## 実装

`test/server/files/backup-store.spec.ts` の `describe("backupDirFor")` のみ:

- `ROOT` / `FILE` を `path.resolve()` で組み立てた定数に切り出し、POSIX リテラルとの比較をやめた
- `MESSY_FILE` を `path.sep` で明示的に組み立て（`path.join` だと `..` が消えるため）
- 期待値 `toBe("/backups")` を `toBe(ROOT)` に

## 検証

- `yarn test` — 334 files / 4866 tests 全部グリーン
- `yarn lint` — エラー 0（`startCodexEntry` の max-params warning は本 PR と無関係の既存のもの）
- `yarn typecheck` / `typecheck:server` / `typecheck:test` — 全部通過
- `yarn build` — 成功

なお `yarn test` の 1 回目で `google.spec.ts` が `Parse Error: Expected HTTP/, RTSP/ or ICE/` で落ちたが、単体では通り、2 回目のフル実行でも通った。CI でも通っている既存の flake で、本 PR とは無関係。

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)