### PR TITLE
test: 外部変更の「即時通知」経路を実際に動かす

### DIFF
--- a/test/src/components/FilesPane.spec.ts
+++ b/test/src/components/FilesPane.spec.ts
@@ -6,6 +6,18 @@ import FilesPane from "../../../src/components/FilesPane.vue";
 // user edit can be simulated.
 let onChange: () => void = () => {};
 const fakeEditor = { setDoc: vi.fn(), getDoc: vi.fn(() => "edited text"), destroy: vi.fn() };
+// Capture the pubsub handler so the IMMEDIATE path (Claude's write hook) can be driven — the
+// timer path alone leaves it untested, which is where a real defect would hide.
+const pubsub = vi.hoisted(() => ({ handlers: new Map<string, (data: unknown) => void>() }));
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, cb: (data: unknown) => void) => {
+      pubsub.handlers.set(channel, cb);
+      return () => pubsub.handlers.delete(channel);
+    },
+    onReconnect: () => () => {},
+  }),
+}));
 vi.mock("../../../src/components/cmEditor", async (orig) => {
   const actual = await orig<typeof import("../../../src/components/cmEditor")>();
   return { ...actual, createEditor: (_host: HTMLElement, cb: () => void) => ((onChange = cb), fakeEditor) };
@@ -411,5 +423,62 @@ describe("FilesPane noticing an external change", () => {
     serveVersion("v1"); // the version it was loaded at
     await check(w);
     expect(fakeEditor.setDoc).not.toHaveBeenCalled();
+  });
+});
+
+// The hook path is the one that makes this feel immediate; the 30s timer is only the backstop.
+describe("FilesPane reacting to the write hook", () => {
+  const fire = (file: string) => pubsub.handlers.get("file-write")?.({ file });
+
+  // The file is opened at v1, and only THEN does the agent rewrite it — anything else would be
+  // "no change" and prove nothing.
+  const server = { version: "v1", text: "# hello" };
+
+  beforeEach(() => {
+    fakeEditor.setDoc.mockClear();
+    pubsub.handlers.clear();
+    server.version = "v1";
+    server.text = "# hello";
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/version")) return { ok: true, json: async () => ({ version: server.version }) };
+      if (url.includes("/list")) return { ok: true, json: async () => ({ entries: [{ name: "README.md", dir: false, size: 10 }] }) };
+      if (url.includes("/text")) return { ok: true, json: async () => ({ text: server.text, version: server.version }) };
+      return { ok: true, json: async () => ({ ok: true, version: "v2" }) };
+    }) as unknown as typeof fetch;
+  });
+
+  const openReadme = async () => {
+    const w = mount(FilesPane, { props: { cwd: "/proj" } });
+    await flushPromises();
+    await w.findAll('[data-testid="files-row"]')[0].trigger("click");
+    await flushPromises();
+    fakeEditor.setDoc.mockClear();
+    // The agent rewrites it while it sits open.
+    server.version = "v9";
+    server.text = "# from the agent";
+    return w;
+  };
+
+  it("takes the new content as soon as the agent's write is announced", async () => {
+    const w = await openReadme();
+    fire("/proj/README.md");
+    await flushPromises();
+    expect(fakeEditor.setDoc).toHaveBeenCalledWith("# from the agent", "README.md");
+    w.unmount();
+  });
+
+  it("ignores a write to some other file", async () => {
+    const w = await openReadme();
+    fire("/proj/somewhere/else.ts");
+    await flushPromises();
+    expect(fakeEditor.setDoc).not.toHaveBeenCalled();
+    w.unmount();
+  });
+
+  it("stops listening once the pane is gone", async () => {
+    const w = await openReadme();
+    w.unmount();
+    expect(pubsub.handlers.has("file-write")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

**検知のテストがタイマー経路しか通っておらず、pubsub のハンドラは一度も実行されていませんでした。**

即時に感じられるのは hook 経路の方で、30 秒のタイマーはバックストップです。テストされていない側が本命だった、という状態でした。

`usePubSub` をモックしてハンドラを掴み、実際に発火させます:

- 開いているファイルへの書き込みが告げられたら新しい内容を取る
- 別のファイルへの書き込みは無視する
- unmount で購読を解く

## Items to Confirm / Review

1. **バグは見つかりませんでした。** 「動いていないかも」の調査で書いたテストですが、実装は正しく、**最初に書いたテストの方が間違っていました**（初期ロードと同じ version を `/version` が返す形になっていて、「変化なし」と判定されるのが正解）。実際の順序（v1 で開く → エージェントが書き換える → v9）にすると通ります
2. 調査で確認したこと: サーバーは正しく publish している（合成 hook を POST して pubsub で受信を確認）、`/version` も `/text` の version も出ている

## User Prompt

> save前に気がつくやつ、うごいてないかも。

Refs #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)