### PR TITLE
fix: 履歴タブのアイドル状態に背景色を明示して可読性を戻す

### DIFF
--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -42,11 +42,16 @@ const visibleSessions = computed(() => filteredSessions.value.slice(0, MAX_TABS)
     </div>
 
     <div class="flex min-w-0 flex-1 gap-1.5 overflow-hidden">
+      <!-- Both branches set a background: there is no Tailwind preflight (src/tailwind.css), so a
+           <button> with no bg-* falls back to the UA's ButtonFace — a light grey pill that made
+           the idle tabs' text-secondary near-unreadable on every dark theme. It stays in the
+           branches rather than the static class so two bg-* utilities never compete on one
+           element (see cellChromeClasses.ts). -->
       <button
         v-for="s in visibleSessions"
         :key="s.id"
         class="relative flex h-7 min-w-0 max-w-[200px] flex-1 cursor-pointer items-center gap-[5px] rounded-md border px-2.5 text-[12px] text-secondary transition-[background] duration-[120ms] ease-[ease]"
-        :class="s.id === props.activeId ? 'border-accent bg-subtle' : 'border-transparent hover:bg-subtle'"
+        :class="s.id === props.activeId ? 'border-accent bg-subtle' : 'border-transparent bg-transparent hover:bg-subtle'"
         :title="s.title"
         :aria-current="s.id === props.activeId ? 'page' : undefined"
         @click="emit('select', s.id, s.agent ?? 'claude')"

--- a/test/src/components/SessionTabBar.spec.ts
+++ b/test/src/components/SessionTabBar.spec.ts
@@ -1,0 +1,39 @@
+// The app builds Tailwind WITHOUT preflight (src/tailwind.css), so a <button> that sets no
+// bg-* utility falls back to the UA's ButtonFace — a light grey pill. The idle history tabs
+// did exactly that: light-grey button under text-secondary, unreadable on every dark theme.
+// A visual-only defect, so nothing else here can catch it; this pins the explicit background
+// on BOTH tab states.
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SessionTabBar from "../../../src/components/SessionTabBar.vue";
+import type { Session } from "../../../src/composables/useSessions";
+
+function session(id: string, over: Partial<Session> = {}): Session {
+  return { id, title: `session ${id}`, mtime: 1, working: false, waiting: false, ...over };
+}
+
+function mountBar(activeId: string | null) {
+  return mount(SessionTabBar, {
+    props: { sessions: [session("a"), session("b")], activeId, filter: "all" as const },
+  });
+}
+
+describe("SessionTabBar tab background", () => {
+  it("gives every tab an explicit background, active or not", () => {
+    const tabs = mountBar("a").findAll("button[title^='session']");
+    expect(tabs).toHaveLength(2);
+    for (const tab of tabs) {
+      // Not `hover:bg-*`, which leaves the resting state to the UA.
+      const resting = tab.classes().filter((c) => /^bg-/.test(c));
+      expect(resting, `tab ${tab.attributes("title")} has no resting bg-* utility`).not.toEqual([]);
+    }
+  });
+
+  it("sets exactly one bg-* per tab, so two fills never compete", () => {
+    for (const activeId of ["a", null]) {
+      for (const tab of mountBar(activeId).findAll("button[title^='session']")) {
+        expect(tab.classes().filter((c) => /^bg-/.test(c))).toHaveLength(1);
+      }
+    }
+  });
+});

--- a/test/src/components/SessionTabBar.spec.ts
+++ b/test/src/components/SessionTabBar.spec.ts
@@ -36,4 +36,14 @@ describe("SessionTabBar tab background", () => {
       }
     }
   });
+
+  // Which fill lands on which tab, not just that both have one — the checks above would be
+  // satisfied by giving the idle tabs bg-subtle too, which reads as "everything is selected".
+  it("fills only the active tab, and leaves the rest showing the bar through", () => {
+    const bar = mountBar("a");
+    expect(bar.find("button[title='session a']").classes()).toContain("bg-subtle");
+    expect(bar.find("button[title='session b']").classes()).toContain("bg-transparent");
+    // The idle tab still lights up under the cursor; bg-transparent must not have replaced that.
+    expect(bar.find("button[title='session b']").classes()).toContain("hover:bg-subtle");
+  });
 });


### PR DESCRIPTION
## 症状

履歴タブ（上から2番目のツールバー）のセッションタブが、白っぽい背景に薄いグレーの文字で描画され、ほとんど読めない。

## 原因

このアプリは **preflight なしで Tailwind をビルドしている**（`src/tailwind.css:1-9`。既存コンポーネントが全て scoped CSS なので、base リセットを入れると全部を塗り替えてしまうため、意図的にそうしてある）。`src/style.css` 側の独自リセットにも `button` のルールはない。

結果として、`bg-*` を持たない `<button>` は **UA 既定の `ButtonFace`（薄いグレーの角丸）** にフォールバックする。

`SessionTabBar.vue:49` は active 側にしか背景を指定しておらず、非 active 側は `hover:bg-subtle` だけだった。hover は静止状態には効かないので、アイドルのタブが薄グレーの UA ボタンとして描画され、その上に `text-secondary`（Midnight では `#c7cdf0`）が乗る。これが「白地に薄いグレー文字」の正体。ダークテーマ4つ全てで起きる。

## 修正

非 active 側に `bg-transparent` を足し、バーの `bg-panel` を透かせる。

静的な `class` ではなく**分岐側**に置いてある。1つの要素に `bg-*` が2つ載ると、どちらが勝つかは書いた順ではなく Tailwind の出力順で決まるため — `cellChromeClasses.ts:18-20` に既にある方針に合わせた。

## 調査範囲

`src/` の `<button>` を全て監査した。背景指定の漏れは**ここだけ**。

- グリッドのセルボタン → `CELL_BTN_BOX` から `bg-transparent` を受け取っている
- 縦型 `Sidebar` の行 → `<button>` ではなく `<li>` なので元から影響なし
- `SettingsButton` / `FilterChip` → 両分岐とも背景あり

## テスト

見た目だけの不具合で他のどのテストにも映らないため、`test/src/components/SessionTabBar.spec.ts` で両状態の静止時背景を固定した。**修正を revert すると落ちることを確認済み**（`tab session b has no resting bg-* utility`）。

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` 全て通過。`yarn test` は 4645 passed。`test/server/backends/docPath.spec.ts > zero-pads the month` が1件落ちるが、**この変更とは無関係の既存の失敗**（`new Date("2026-03-01T00:00:00Z")` が Pacific では2月28日になるテスト自身のタイムゾーンバグ）で、main でも同じく落ちる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session tab backgrounds across themes.
  * Active tabs now display a consistent background, while inactive tabs remain transparent and gain a background on hover.
  * Prevented conflicting background styles and browser-default button styling.

* **Tests**
  * Added coverage to verify each session tab has exactly one background style in its resting state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->