### PR TITLE
feat(toolbar): ビュー切り替えを縦線で他のメニューから分ける (#941)

### DIFF
--- a/plans/feat-941-toolbar-view-switch-separator.md
+++ b/plans/feat-941-toolbar-view-switch-separator.md
@@ -1,0 +1,33 @@
+# feat: grid / single のビュー切り替えを他のメニュー項目と視覚的に分ける (#941)
+
+## 問題
+
+ヘッダー左のナビに、性質の違う 2 種類が等間隔で並んでいて見分けがつかない。
+
+- **どのビューにいるかを変える**もの: Chat / Grid view
+- **今いるビューの中で何かを出す**もの: Collections / Accounting / Wiki / お気に入り /
+  Pull requests / Worklog / New terminal / 並び替え
+
+## 決めたこと
+
+| 論点 | 決定 | 理由 |
+|---|---|---|
+| 分け方 | **縦線**（案 A） | 同じ `<nav>` の反対端にあるステータス集計が既に `border-l border-border pl-2.5` で区切られている。表現を増やさず揃える |
+| 区切りの位置 | **右だけ** | 左はヘッダーのロゴが境界になっている |
+| a11y | `role="group"` + `aria-label="Switch view"` | 視覚的なグループ分けを支援技術にも伝える。見た目だけの区切りは読み上げに出ない |
+| 実装 | 2 つを `<span>` で包む | ナビは flex なので包んだ span が 1 つの flex item になる。中で `gap-[3px]` を張り直し、`flex-none` で overflow 時に潰れないようにする（#921 と同じ理由） |
+
+## 実装
+
+`src/components/AppToolbar.vue` の 1 箇所のみ。ロジック変更なし。
+
+```
+<span class="mr-1.5 inline-flex flex-none items-center gap-[3px] border-r border-border pr-2.5"
+      role="group" aria-label="Switch view">
+  Chat / Grid view
+</span>
+```
+
+既存の `AppToolbar.spec.ts` は `nav[aria-label='Views'] button` を数えているので、
+span で包んでも nav の子孫であることは変わらず、そのまま通る。
+グループが存在することを固定するテストを 1 本足す。

--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -128,9 +128,14 @@ function showPrs(): void {
   <header class="flex h-10 flex-none items-center border-b border-border bg-panel px-4">
     <span class="font-sans text-[14px] font-semibold tracking-[0.02em] text-fg">MulmoTerminal</span>
     <nav class="ml-4 flex min-w-0 items-center gap-[3px] overflow-x-auto" aria-label="Views">
-      <!-- Both views: the pair that switches between them. -->
-      <LauncherButton icon="chat" title="Chat" label="Chat" :active="chatActive" @click="showChat" />
-      <LauncherButton icon="grid_view" title="Grid (multiple terminals)" label="Grid view" :active="onGridRoute" @click="showGrid" />
+      <!-- Both views: the pair that switches between them. Fenced off with a rule because it is
+           the only group here that changes WHICH VIEW you are in — everything to its right acts
+           within the current one, and a flat row of equal buttons hid that (#941). Same rule
+           treatment as the status tally at the other end of the nav. -->
+      <span class="mr-1.5 inline-flex flex-none items-center gap-[3px] border-r border-border pr-2.5" role="group" aria-label="Switch view">
+        <LauncherButton icon="chat" title="Chat" label="Chat" :active="chatActive" @click="showChat" />
+        <LauncherButton icon="grid_view" title="Grid (multiple terminals)" label="Grid view" :active="onGridRoute" @click="showGrid" />
+      </span>
       <!-- Single view only (#886): the content surfaces. The grid is for supervising agents,
            and every one of these replaces the whole screen anyway. -->
       <LauncherButton v-if="!inGrid" icon="apps" title="Collections" label="Collections" :active="collectionsActive" @click="showCollections" />

--- a/test/src/components/AppToolbar.spec.ts
+++ b/test/src/components/AppToolbar.spec.ts
@@ -116,3 +116,30 @@ describe("AppToolbar per-view buttons", () => {
     expect(activeLabels(onPrs)).toEqual(["Pull requests"]);
   });
 });
+
+// #941: the view switch is the only group in the nav that changes WHICH VIEW you are in. It is
+// fenced off with a rule; the group makes that structure reach a screen reader too, which a
+// border alone never does.
+describe("AppToolbar view-switch grouping", () => {
+  const switchGroup = (wrapper: ReturnType<typeof mount>) => wrapper.find("nav[aria-label='Views'] [role='group'][aria-label='Switch view']");
+
+  it.each(["/chat", "/terminals"])("groups exactly Chat and Grid view, in both views (%s)", async (path) => {
+    const group = switchGroup(await mountAt(path));
+    expect(group.exists()).toBe(true);
+    expect(group.findAll("button").map((b) => b.attributes("aria-label"))).toEqual(["Chat", "Grid view"]);
+  });
+
+  // The rule is the separator. Losing it turns the nav back into one undifferentiated row,
+  // which is the whole bug — and a class change is exactly the edit that would do it silently.
+  it("carries the separating rule", async () => {
+    expect(switchGroup(await mountAt("/chat")).classes()).toContain("border-r");
+  });
+
+  // Everything else stays OUTSIDE the group — a content surface swept in would read as a view
+  // switch to a screen reader and sit on the wrong side of the rule.
+  it("leaves the content surfaces out of the group", async () => {
+    const wrapper = await mountAt("/chat");
+    const grouped = switchGroup(wrapper).findAll("button").length;
+    expect(wrapper.findAll("nav[aria-label='Views'] button").length).toBeGreaterThan(grouped);
+  });
+});


### PR DESCRIPTION
## Summary

ヘッダー左のナビで、**ビューを切り替える 2 つ**（Chat / Grid view）を縦線で囲い、
その右の「今いるビューの中で何かを出す」ボタン群と視覚的に分ける。

Chat / Grid view は「どのビューにいるか」を変える唯一の組で、その右にあるものは
すべて今いるビューの中で動く。等間隔に並んだ 1 列がその違いを隠していた。

Closes #941

## Items to Confirm / Review

AI 生成コードです。人に見てほしい点:

1. **見た目そのもの。** 縦線 1 本の話なので、実物を見た判断が要る。
   狭いウィンドウで `overflow-x-auto` がかかった状態も含めて見てほしい。
2. **区切りは右だけ**にした。左はヘッダーのロゴが境界になっているという判断。
3. **グリッド表示中はナビの反対端にステータス集計の縦線も出る**ので、
   条件によっては縦線が 2 本並ぶ。許容と判断したが、見え方は実物で確認したい。
4. `aria-label="Switch view"` の文言。

## User Prompt

> grid view/ single viewの切り替えがメニューでまざっている。切り替えだけは別だとわかるな
> レイアウトにしたい。縦線入れるか、はなすか。

## 実装

`src/components/AppToolbar.vue` の 1 箇所のみ。**ロジック変更なし。**

```
<span class="mr-1.5 inline-flex flex-none items-center gap-[3px] border-r border-border pr-2.5"
      role="group" aria-label="Switch view">
  Chat / Grid view
</span>
```

| 決めたこと | 内容 | 理由 |
|---|---|---|
| 分け方 | 縦線（余白のみ・nav 外出しは不採用） | 同じ `<nav>` の反対端にあるステータス集計が既に `border-l border-border pl-2.5` で区切られている。表現を増やさず揃えた |
| 位置 | 右だけ | 左はロゴが境界 |
| a11y | `role="group"` + `aria-label` | 境界線だけでは支援技術に何も伝わらない |
| 実装 | `<span>` で包む | nav は flex なので包んだ span が 1 つの flex item になる。中で `gap-[3px]` を張り直し、`flex-none` で overflow 時に潰れないようにする（#921 と同じ理由） |

余白のみ（案 B）は、狭い幅で `overflow-x-auto` がかかると余白が潰れて意味を失うため不採用。
nav の外に出す（案 C）は、狭幅時のスクロール挙動を作り直す必要があるため不採用。

## テスト

`test/src/components/AppToolbar.spec.ts` に 3 本追加:

- 単一ビュー / グリッドの**両方**で、グループの中身がちょうど Chat と Grid view であること
- 区切りの `border-r` が付いていること（クラスを消す編集は静かに通ってしまうため）
- 内容系のボタンがグループの**外**にあること（中に入るとスクリーンリーダーにビュー切り替えとして読まれ、縦線の側も間違う）

既存の spec は `nav[aria-label='Views'] button` を数えているので、span で包んでも
nav の子孫であることは変わらず、そのまま通る。

## 確認したこと

`yarn format` / `yarn lint`（エラー 0、既存 warning 1 件のみ）/ `yarn typecheck` +
`typecheck:test` / `yarn test`（4909 passed）/ `yarn build` すべて green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
