### PR TITLE
test: docPath の日付フィクスチャをローカル時刻で組む

### DIFF
--- a/test/server/backends/docPath.spec.ts
+++ b/test/server/backends/docPath.spec.ts
@@ -104,17 +104,58 @@ describe("sanitizeDocPrefix", () => {
 describe("buildDocPath", () => {
   const rand = "ab12cd34";
 
+  // buildDocPath reads the LOCAL calendar (getFullYear/getMonth), because a document written at
+  // 16:00 on Feb 28 in California belongs in its author's /02/, not in /03/ because it was
+  // already past midnight in London. So the fixtures have to be built in local time too.
+  //
+  // `new Date("2026-03-01T00:00:00Z")` does NOT mean "March 1st" — it is an instant, and midnight
+  // UTC on the 1st is still the PREVIOUS month everywhere west of Greenwich. Written that way,
+  // this suite passed in CI (UTC) and failed on a developer machine in US/Pacific.
+  //
+  // Month is 1-based here; Date's own argument is not, which is the other half of the trap.
+  const localDate = (year: number, month: number, day: number) => new Date(year, month - 1, day);
+
   it("composes a dated path under the documents directory", () => {
-    expect(buildDocPath("notes", new Date("2026-07-23T00:00:00Z"), rand)).toBe(`${DOCS_DIR}/2026/07/notes-${rand}.md`);
+    expect(buildDocPath("notes", localDate(2026, 7, 23), rand)).toBe(`${DOCS_DIR}/2026/07/notes-${rand}.md`);
   });
 
   it("zero-pads the month", () => {
-    expect(buildDocPath("x", new Date("2026-03-01T00:00:00Z"), rand)).toContain("/2026/03/");
+    expect(buildDocPath("x", localDate(2026, 3, 1), rand)).toContain("/2026/03/");
   });
 
   // The whole chain: whatever the title, the result is a path isDocPath will accept — which
   // is what keeps the write inside the workspace and lets the saved doc load afterwards.
   it.each([["../../escape"], ["foo/bar"], [""], ["!!!"], ["a".repeat(200)]])("always produces a path isDocPath accepts, for %j", (title) => {
-    expect(isDocPath(buildDocPath(title, new Date("2026-07-23T00:00:00Z"), rand))).toBe(true);
+    expect(isDocPath(buildDocPath(title, localDate(2026, 7, 23), rand))).toBe(true);
+  });
+
+  // The above only prove the fixtures are right on THIS machine. Since the whole defect was a
+  // clock the suite never controlled, drive the real function under both extremes: a date is
+  // filed by its local calendar or not, and either way every machine has to agree.
+  describe("files by the local calendar, wherever the machine is", () => {
+    function underTz<T>(tz: string, fn: () => T): T {
+      const before = process.env.TZ;
+      process.env.TZ = tz;
+      try {
+        return fn();
+      } finally {
+        // Restore rather than delete: a TZ this process inherited must survive the test.
+        if (before === undefined) delete process.env.TZ;
+        else process.env.TZ = before;
+      }
+    }
+
+    // UTC-14 through UTC+14 — the two ends that a UTC-only CI can never exercise.
+    it.each([["Pacific/Midway"], ["Pacific/Kiritimati"], ["UTC"]])("puts a local March 1st under /2026/03/ in %s", (tz) => {
+      expect(underTz(tz, () => buildDocPath("x", localDate(2026, 3, 1), rand))).toContain("/2026/03/");
+    });
+
+    // The converse, stated as the behaviour rather than an accident: the same INSTANT is filed
+    // under different months by design, because the two authors are on different days.
+    it("files one instant by each author's own month", () => {
+      const midnightUtcMar1 = new Date("2026-03-01T00:00:00Z");
+      expect(underTz("America/Los_Angeles", () => buildDocPath("x", midnightUtcMar1, rand))).toContain("/2026/02/");
+      expect(underTz("Asia/Tokyo", () => buildDocPath("x", midnightUtcMar1, rand))).toContain("/2026/03/");
+    });
   });
 });

--- a/test/server/backends/docPath.spec.ts
+++ b/test/server/backends/docPath.spec.ts
@@ -145,8 +145,11 @@ describe("buildDocPath", () => {
       }
     }
 
-    // UTC-14 through UTC+14 — the two ends that a UTC-only CI can never exercise.
-    it.each([["Pacific/Midway"], ["Pacific/Kiritimati"], ["UTC"]])("puts a local March 1st under /2026/03/ in %s", (tz) => {
+    // The full span of real offsets, UTC-12 (Etc/GMT+12, the tz database's minimum) through
+    // UTC+14 (Kiritimati) — the ends a UTC-only CI can never exercise. Pacific/Midway (UTC-11)
+    // is the westmost INHABITED zone, and the one whose shape matches the machine this bug
+    // was found on, so it is worth keeping alongside the synthetic extreme.
+    it.each([["Etc/GMT+12"], ["Pacific/Midway"], ["Pacific/Kiritimati"], ["UTC"]])("puts a local March 1st under /2026/03/ in %s", (tz) => {
       expect(underTz(tz, () => buildDocPath("x", localDate(2026, 3, 1), rand))).toContain("/2026/03/");
     });
 


### PR DESCRIPTION
## 症状

`yarn test` が **US/Pacific の開発機でだけ**落ちる。CI (UTC) は緑。

```
FAIL  test/server/backends/docPath.spec.ts > buildDocPath > zero-pads the month
expected 'artifacts/documents/2026/02/x-ab12cd34.md' to contain '/2026/03/'
```

## 原因

`buildDocPath` は**ローカルの暦**で保存先を決める（`server/backends/docPath.ts:50-51`）。

```ts
const yyyy = String(now.getFullYear());
const mm = String(now.getMonth() + 1).padStart(2, "0");
```

対して spec 側は入力を **UTC の瞬間**で与えていた。

```ts
buildDocPath("x", new Date("2026-03-01T00:00:00Z"), rand)
```

`new Date("…Z")` は「3月1日」ではなく**一つの時刻**であって、`getMonth()` が何を返すかは実行機のタイムゾーンで変わる。**UTC 深夜0時の1日は、グリニッジより西では前月のまま。**

| TZ | その瞬間のローカル時刻 | 保存先 |
|---|---|---|
| UTC | Mar 01 00:00 | `2026/03` |
| Asia/Tokyo (+9) | Mar 01 09:00 | `2026/03` |
| America/Los_Angeles (−8) | **Feb 28 16:00** | `2026/02` ← 失敗 |

## 直したのは spec 側で、実装ではない

実装のローカル時刻参照は**意図的で正しい**。カリフォルニアで 2/28 16:00 に書いた文書は、ロンドンでは日付が変わっているからといって `/03/` ではなく著者の `/02/` に入るべき。`getUTCMonth()` に変えればテストは通るが、南北アメリカの全ユーザーで保存先の月がずれる — テストのために挙動を壊すことになる。

そこで日付リテラル3箇所を `localDate(年, 月, 日)` に置き換えた（月は **1始まり**にしてある。`Date` の引数が0始まりなのが罠のもう半分なので）。

## 落ちていなかった残り2箇所も直した

失敗していたのは1件だが、他の `new Date("2026-07-23T00:00:00Z")` を使う箇所も同じ脆さを持っていた。Pacific では7月**22日**になるが、月は7月のままなので**たまたま**通っていただけ。月初に固定した瞬間、あるいは UTC+13 の機械で同じように壊れる。

## 回帰テスト

この不具合の本体は「suite が一度も制御していない時計」だったので、リテラルの訂正だけでは同じ穴が残る。UTC−11 と UTC+14 の両端で実機の `buildDocPath` を回し、**同じ瞬間が著者ごとに別の月に入ることを事故ではなく仕様として明示**するテストを足した。

**歯があることを確認済み**: 実装を `getUTC*` に差し替えると、**UTC 環境でも** 2件落ちる。つまり今回のような「テストのための誤った修正」を CI が止められる。

## 検証

- **5つの TZ で 37 tests 全通過**: UTC / America/Los_Angeles / Asia/Tokyo / Pacific/Kiritimati / Pacific/Midway
- `yarn test` 全体: **4940 passed / 0 failed**（ローカルで初めて全緑）
- `yarn format` / `lint`（0 errors）/ `typecheck` / `typecheck:test` 通過

変更は spec のみ。プロダクションコードは触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-based document organization across different time zones, helping ensure documents are placed in the correct month directory according to the author’s local calendar date.

* **Tests**
  * Expanded coverage for date handling across multiple time zones, including cases where the same moment falls in different calendar months.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->