### PR TITLE
fix(ci): Codex auto-review の timeout を 15 分に上げる

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -79,7 +79,11 @@ jobs:
     # lint_test / smoke) gate them.
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 10 wasn't enough: the review step hit it and was cancelled on #945, #951 and #952 within
+    # two days, each time passing in ~1-2 minutes on a plain rerun of the same commit. The job
+    # is not hanging — it is occasionally slow — so the cap only has to sit above the slow tail,
+    # and cancelling costs a full re-review round trip on a PR that was ready to merge.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:

--- a/plans/fix-960-codex-review-timeout.md
+++ b/plans/fix-960-codex-review-timeout.md
@@ -1,0 +1,22 @@
+# Raise the Codex review job's timeout
+
+Issue: #960
+
+## Why
+
+`timeout-minutes: 10` cancelled the review step on #945, #951 and #952 inside two days. Each time
+a plain rerun of the **same commit** finished in one to two minutes (#952's took 1m56s), and the
+ordinary runs on other branches finish in well under that.
+
+So the job is not hanging — it is occasionally slow, and the cap is sitting inside the slow tail
+rather than above it. What a timeout is for is stopping a hang; cutting off a run that would have
+finished costs a full re-review round trip on a PR that was otherwise ready to merge, and shows it
+as a red check in the meantime.
+
+## What
+
+15 minutes, with the three cancellations recorded in a comment beside it so the next person to
+consider lowering it knows what the number is holding back.
+
+Nothing else changes: the step, its concurrency group, and the `CODEX VERDICT` contract the
+`gh-review-loop` skill reads are untouched.


### PR DESCRIPTION
## Summary

Closes #960.

`Codex auto-review` の `timeout-minutes` を **10 → 15** に上げる。

10 分では足りず、この 2 日で **#945 / #951 / #952 の 3 回**、レビューのステップが打ち切られて
`codex-review` が fail 表示になっていた。

## Items to Confirm / Review

- **ハングではなく「たまに遅い」と判断した根拠**: 3 件とも**同じコミットのまま rerun するだけで
  1〜2 分で成功**している（#952 の rerun は 1m56s）。通常の run も数十秒〜2 分程度。
  タイムアウトの役目はハングの打ち切りなので、上限は遅い側の裾より**上**にあるべき、という判断。
- **15 という数字に強い根拠はない**。観測された成功時間（〜2 分）から見て十分な余裕がありつつ、
  本当にハングしたときに 15 分で止まる、という程度の意味。もっと短く/長くしたい場合は 1 行。
- コメントを併記して、次にこの数字を下げようとした人が何を踏むか分かるようにした。
- ステップ本体・concurrency・`CODEX VERDICT` の契約（`gh-review-loop` スキルが読む）は変更なし。

## User Prompt

> timeout 15分にするか。。べつPRで。

（直前のやり取りで、#945 / #951 / #952 で codex-review が 10 分のタイムアウトに当たって
cancelled になっていることを報告し、timeout を上げる PR を出すか確認した流れ）

## Verification

ワークフロー定義のみの変更。`yarn format` は通し、アプリ側のコードには一切触れていない。
このワークフローは本 PR 自身の CI で走るので、**この PR の `codex-review` チェックが
新しい上限で通ること自体が動作確認**になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2