### PR TITLE
fix: launcher が NODE_ENV=production を全ターミナルに漏らすのをやめる (#955)

### DIFF
--- a/bin/cli-args.d.ts
+++ b/bin/cli-args.d.ts
@@ -10,3 +10,4 @@ export declare const SECOND_INSTANCE_NOTE: string;
 export declare const MIN_NODE_LABEL: string;
 export declare function nodeMeetsMinimum(version: string): boolean;
 export declare function serverNodeArgs(serverEntry: string, launchDir: string): string[];
+export declare function serverSpawnEnv(env: Record<string, string | undefined>, port: number, cwd: string): Record<string, string | undefined>;

--- a/bin/cli-args.js
+++ b/bin/cli-args.js
@@ -150,3 +150,19 @@ export function nodeMeetsMinimum(version) {
 export function serverNodeArgs(serverEntry, launchDir) {
   return ["--import", "tsx", `--env-file-if-exists=${join(launchDir, ".env")}`, serverEntry];
 }
+
+/**
+ * The environment the launcher spawns the server with.
+ *
+ * Only the two values the server cannot work out for itself. In particular NOT `NODE_ENV`:
+ * the server hands its own environment to every PTY it spawns, so a `NODE_ENV=production`
+ * set here reaches every terminal in every cell — where yarn v1 reads it and installs
+ * WITHOUT devDependencies while still reporting success (#955). Express is pinned to
+ * production separately, in the server, so nothing here needs to say it.
+ *
+ * A `NODE_ENV` the user exported themselves passes through untouched: this decides what the
+ * launcher adds, not what it removes.
+ */
+export function serverSpawnEnv(env, port, cwd) {
+  return { ...env, PORT: String(port), CLAUDE_CWD: cwd };
+}

--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -26,6 +26,7 @@ import {
   nodeMeetsMinimum,
   MIN_NODE_LABEL,
   serverNodeArgs,
+  serverSpawnEnv,
 } from "./cli-args.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -272,7 +273,7 @@ function runServer(port, noOpen, cwd, onChild) {
     // package directory, so serverNodeArgs makes that path absolute (#795).
     const server = spawn(process.execPath, serverNodeArgs(SERVER_ENTRY, process.cwd()), {
       cwd: PKG_DIR,
-      env: { ...process.env, NODE_ENV: "production", PORT: String(port), CLAUDE_CWD: cwd },
+      env: serverSpawnEnv(process.env, port, cwd),
       stdio: ["inherit", "inherit", "pipe"],
     });
     let stderrTail = "";

--- a/plans/fix-955-node-env-leak.md
+++ b/plans/fix-955-node-env-leak.md
@@ -1,0 +1,70 @@
+# `NODE_ENV=production` がセル内の全ターミナルに漏れる
+
+Issue: #955
+
+## 症状
+
+npx で起動した MulmoTerminal のセルで `yarn install` すると devDependencies が入らない。
+yarn は成功を報告するので失敗として現れず、「node_modules が壊れた」と誤診される。
+
+## 原因（検証済み）
+
+1. `bin/mulmoterminal.js:275` — launcher がサーバを `NODE_ENV: "production"` で spawn する。
+2. `server/session/pty-spawn.ts:36` — PTY の env は `sanitizePtyEnv(process.env, …)`。落とすのは
+   launcher 由来と分かっている名前（`server/infra/pty-env.ts` の `REMOVED_NAMES`）だけで、
+   `NODE_ENV` は入っていない。結果、セルの全ターミナルが `NODE_ENV=production` を持つ。
+3. yarn 1.22.22 (`lib/cli.js`) は
+   `production = getOption('production') || NODE_ENV === 'production' && NPM_CONFIG_PRODUCTION !== 'false' && YARN_PRODUCTION !== 'false'`
+   と決めるので devDependencies を飛ばす。
+
+`yarn dev` は launcher を通らないので再現しない。npm 11 は install の省略に `NODE_ENV` を見ない。
+
+## 採る解（issue のアプローチ 1）
+
+**発生源を断つ**。launcher が `NODE_ENV` を渡すのをやめる。
+
+アプローチ 2（`sanitizePtyEnv` で落とす）は採らない。`test/server/infra/pty-env.spec.ts` の
+"keeps real user environment" が `NODE_ENV` を**残すべき変数**として assert しており、
+サニタイザは「NODE_ENV はユーザー由来」という前提で設計されている。落とすと、自分で
+`NODE_ENV` を export しているユーザーの環境まで壊す。
+
+## `NODE_ENV=production` を消して失うもの
+
+リポジトリ内に `NODE_ENV` を読む箇所は無い（書くのは launcher の 1 行だけ）。実際の消費者は
+express 5 だけで、影響は 1 つ:
+
+- `express/lib/application.js` が `process.env.NODE_ENV || 'development'` を `env` 設定に入れ、
+  `application.js:154-155` がそれを finalhandler に渡す。`finalhandler/index.js:160` は
+  `env !== 'production'` のときエラー応答に**スタックトレースを載せる**。
+- view cache も production 依存だが、このアプリはビューを使わないので無関係。
+
+なので消すだけでは、npx 起動時に今まで隠れていたスタックトレースが HTTP 応答に出るようになる
+（`yarn dev` では今も出ている）。これを環境変数から切り離して固定する。
+
+## 変更
+
+1. **`bin/cli-args.js` に `serverSpawnEnv(env, port, cwd)` を足す** — `{ ...env, PORT, CLAUDE_CWD }`。
+   `NODE_ENV` を入れない理由をここに書く。このファイルの役割（launcher の判断を実行ファイルの外に
+   出して検査可能にする）にそのまま乗る。`bin/cli-args.d.ts` に型を追加。
+2. **`bin/mulmoterminal.js`** — spawn の `env:` をこの関数の呼び出しに置き換える。
+3. **`server/infra/hide-error-stacks.ts`（新規）** — `hideErrorStacks(app)` が `app.set("env", "production")`
+   する。`server/index.ts` の `const app = express()` 直後で呼ぶ。これで起動経路によらず
+   スタックトレースは応答に出ない。
+
+## テスト
+
+- `test/bin/server-spawn-env.spec.ts`
+  - `NODE_ENV` を注入しない（親に無ければ子にも無い）
+  - ユーザー自身の `NODE_ENV` は production/development のどちらもそのまま通す
+  - `PORT` は文字列、`CLAUDE_CWD` が入る
+  - 入力の env を破壊しない
+  - 回帰の芯: 返り値のキーに `NODE_ENV` が現れない（#955）
+- `test/server/infra/hide-error-stacks.spec.ts`（supertest）
+  - throw するルートの 500 応答にスタックが出ない — `NODE_ENV` 未設定でも、`development` でも
+  - `app.get("env") === "production"`
+- `test/server/infra/pty-env.spec.ts` — 既存の "keeps real user environment" に、なぜ `NODE_ENV` を
+  ここで落とさないのか（#955 は発生源を断って直した）をコメントで残す。
+
+## ドキュメント
+
+README / docs に `NODE_ENV` の記述は無いので更新なし。changelog はリリース時（`/publish`）。

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import fs from "fs/promises";
 import { randomUUID } from "crypto";
 import { fileURLToPath } from "url";
 import { createPubSub } from "./infra/pubsub.js";
+import { hideErrorStacks } from "./infra/hide-error-stacks.js";
 import { toolSummaries } from "./infra/plugins-registry.js";
 import { initMarkdownBackend } from "./backends/markdown.js";
 import { initArtifactsBackend } from "./backends/artifacts.js";
@@ -254,6 +255,7 @@ enforceKeymap(APP_CONFIG_FILE, {
 });
 
 const app = express();
+hideErrorStacks(app);
 // Generous body limit: PostToolUse hook payloads carry the tool's full output
 // (a big Read/Bash result can blow past Express's 100kb default, which would 413
 // the hook and leave its tool-call entry stuck on "running").

--- a/server/infra/hide-error-stacks.ts
+++ b/server/infra/hide-error-stacks.ts
@@ -1,0 +1,15 @@
+import type { Express } from "express";
+
+// Keep stack traces out of HTTP responses, whatever the environment says.
+//
+// Express reads `process.env.NODE_ENV` once, into its `env` setting, and hands that setting to
+// finalhandler — which puts the thrown error's stack in the response body for any value other
+// than "production". The launcher used to guarantee that value by exporting NODE_ENV=production
+// for the server process, but the server passes its own environment to every PTY it spawns, so
+// that guarantee arrived in every user terminal and made yarn v1 skip devDependencies (#955).
+//
+// Setting it on the app instead makes the two independent: a `yarn dev` run hides stacks too
+// (it did not before), and nothing about how the server was started can put one in a response.
+export function hideErrorStacks(app: Express): void {
+  app.set("env", "production");
+}

--- a/test/bin/server-spawn-env.spec.ts
+++ b/test/bin/server-spawn-env.spec.ts
@@ -1,0 +1,44 @@
+// What the launcher adds to the server's environment — and, the reason this file exists, what
+// it must NOT add. The server hands its own environment to every PTY it spawns, so anything
+// set here is set in every terminal of every cell: NODE_ENV=production shipped from the first
+// npx release until #955, where yarn v1 read it and installed without devDependencies while
+// still printing "Done".
+import { describe, it, expect } from "vitest";
+import { serverSpawnEnv } from "../../bin/cli-args.js";
+
+const PORT = 34567;
+const CWD = "/Users/u/project";
+
+describe("serverSpawnEnv", () => {
+  it("adds the port as a string and the launch directory", () => {
+    const env = serverSpawnEnv({ HOME: "/Users/u" }, PORT, CWD);
+    expect(env.PORT).toBe("34567");
+    expect(env.CLAUDE_CWD).toBe(CWD);
+  });
+
+  it("carries the rest of the environment through", () => {
+    const env = serverSpawnEnv({ HOME: "/Users/u", PATH: "/usr/bin", ANTHROPIC_API_KEY: "sk-x" }, PORT, CWD);
+    expect(env.HOME).toBe("/Users/u");
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-x");
+  });
+
+  // Regression (#955): the whole bug was one extra key here.
+  it("does not invent a NODE_ENV", () => {
+    const env = serverSpawnEnv({ HOME: "/Users/u" }, PORT, CWD);
+    expect("NODE_ENV" in env).toBe(false);
+    expect(Object.keys(env).sort()).toEqual(["CLAUDE_CWD", "HOME", "PORT"]);
+  });
+
+  // The launcher decides what it ADDS. A user who runs their whole shell in one mode keeps it —
+  // stripping it here would be the same bug pointed the other way.
+  it.each(["production", "development", "test"])("passes a user's own NODE_ENV=%s through untouched", (value) => {
+    expect(serverSpawnEnv({ NODE_ENV: value }, PORT, CWD).NODE_ENV).toBe(value);
+  });
+
+  it("never mutates the environment it was given", () => {
+    const original = { HOME: "/Users/u" };
+    serverSpawnEnv(original, PORT, CWD);
+    expect(original).toEqual({ HOME: "/Users/u" });
+  });
+});

--- a/test/server/infra/hide-error-stacks.spec.ts
+++ b/test/server/infra/hide-error-stacks.spec.ts
@@ -1,0 +1,49 @@
+// Express decides whether a thrown error's stack goes into the response body, and it decides it
+// from NODE_ENV at app creation. #955 removed the launcher's NODE_ENV=production — which was
+// leaking into every user terminal — so the guarantee has to come from the app itself now.
+// These check the guarantee against the real express, not against the docs: an express upgrade
+// that changed the rule would change what an error response tells a page about this machine.
+import { describe, it, expect, afterEach, vi } from "vitest";
+import express, { type Express } from "express";
+import request from "supertest";
+import { hideErrorStacks } from "../../../server/infra/hide-error-stacks.js";
+
+// A path unique enough that finding it in a response body can only mean the stack leaked.
+const SECRET = "boom-from-a-real-file-path";
+
+function throwingApp(configure: (app: Express) => void): Express {
+  const app = express();
+  configure(app);
+  app.get("/boom", () => {
+    throw new Error(SECRET);
+  });
+  return app;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("hideErrorStacks", () => {
+  it("keeps the stack out of the response when a route throws", async () => {
+    const res = await request(throwingApp(hideErrorStacks)).get("/boom");
+    expect(res.status).toBe(500);
+    expect(res.text).not.toContain(SECRET);
+    expect(res.text).not.toContain("at ");
+  });
+
+  it("wins over a NODE_ENV that says otherwise", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const app = throwingApp(hideErrorStacks);
+    expect(app.get("env")).toBe("production");
+    expect((await request(app).get("/boom")).text).not.toContain(SECRET);
+  });
+
+  // The control, and the reason the module exists: express really does put the stack in the
+  // body otherwise. If this ever stops being true, the helper is no longer load-bearing.
+  it("pins what express does without it", async () => {
+    const res = await request(throwingApp((app) => app.set("env", "development"))).get("/boom");
+    expect(res.status).toBe(500);
+    expect(res.text).toContain(SECRET);
+  });
+});

--- a/test/server/infra/pty-env.spec.ts
+++ b/test/server/infra/pty-env.spec.ts
@@ -29,6 +29,9 @@ describe("isLauncherEnvVar", () => {
     }
   });
 
+  // NODE_ENV stays on this list on purpose. It reached PTYs as "production" until #955, which
+  // was the launcher exporting it — fixed there. Adding it here instead would take away the
+  // NODE_ENV of a user who exports one, which is a different bug with the same shape.
   it("keeps real user environment, including other *_PREFIX vars", () => {
     for (const name of ["HOMEBREW_PREFIX", "CONDA_PREFIX", "HOME", "SHELL", "PATH", "NVM_DIR", "NODE_ENV", "NODE_OPTIONS"]) {
       expect(isLauncherEnvVar(name), name).toBe(false);


### PR DESCRIPTION
## Summary

npx で起動した MulmoTerminal のセル内の全ターミナルに `NODE_ENV=production` が入っており、yarn v1 がそれを読んで **devDependencies を入れずに成功を報告**していた（#955）。発生源は launcher の 1 行なので、そこを断つ。

- `bin/cli-args.js` に `serverSpawnEnv(env, port, cwd)` を追加。launcher が足すのは `PORT` と `CLAUDE_CWD` だけになり、`NODE_ENV` は付けない。ユーザー自身が export した `NODE_ENV` はそのまま通る
- `server/infra/hide-error-stacks.ts`（新規）で `app.set("env", "production")` を明示。エラー応答にスタックトレースが出ない保証を `NODE_ENV` から切り離す

Fixes #955

## Items to Confirm / Review

1. **`sanitizePtyEnv` を触っていないこと。** issue のアプローチ 2（PTY 側で `NODE_ENV` を落とす）は採っていません。`test/server/infra/pty-env.spec.ts` の "keeps real user environment" が `NODE_ENV` を**残すべき変数**として assert しており、落とすと自分で `NODE_ENV` を export しているユーザーの環境を壊すためです。同じ場所に、なぜここで落とさないかのコメントを残しました。
2. **`app.set("env", "production")` を無条件にしたこと。** `yarn dev` でもエラー応答にスタックが出なくなります（今までは出ていた）。express の `env` 設定はビューキャッシュとエラー応答の 2 つにしか効かず、このアプリはビューを使わないため、実質の差はスタック秘匿だけです。dev では出したい、という判断なら条件分岐に変えられます。
3. **`serverSpawnEnv` という薄い関数を足したこと。** 中身は 1 行ですが、`bin/cli-args.js` の役割（launcher の判断を実行ファイルの外に出して検査可能にする）に合わせ、「なぜ `NODE_ENV` を入れないか」の理由とテストをそこに置くためです。

## User Prompt

> これって原因わかる？
> https://github.com/receptron/mulmoterminal/issues/955

> では修正しよう

## 原因（実コードで検証）

1. `bin/mulmoterminal.js:275` — launcher がサーバを `NODE_ENV: "production"` で spawn していた
2. `server/session/pty-spawn.ts:36` — PTY の env は `sanitizePtyEnv(process.env, …)`。落とすのは launcher 由来と分かっている名前（`REMOVED_NAMES`）だけで `NODE_ENV` は対象外 → セルの全ターミナルに入る
3. yarn 1.22.22 (`lib/cli.js`): `production = getOption('production') || NODE_ENV === 'production' && NPM_CONFIG_PRODUCTION !== 'false' && YARN_PRODUCTION !== 'false'` → devDependencies を飛ばす

実関数（`serverSpawnEnv` + `sanitizePtyEnv`）を launcher と同じ spawn 形で繋いで確認:

```
BEFORE (old launcher line):        server sees NODE_ENV=production   PTY gets NODE_ENV=production
AFTER  (serverSpawnEnv):           server sees NODE_ENV=(unset)      PTY gets NODE_ENV=(unset)
AFTER, user exported NODE_ENV:     server sees NODE_ENV=production   PTY gets NODE_ENV=production
```

## `NODE_ENV=production` を消して失うもの

リポジトリ内に `NODE_ENV` を読む箇所は無い（書いていたのは launcher の 1 行だけ）。実消費者は express 5 だけで、`lib/application.js:91` が `env` 設定を決め、`application.js:154-155` がそれを finalhandler に渡し、`finalhandler/index.js:160` が `env !== 'production'` のときエラー応答にスタックを載せる。ビューキャッシュはビュー未使用なので無関係。

よって「消すだけ」では npx 起動時にスタックが応答に出るようになるため、`app.set("env", "production")` で環境変数から切り離して固定した。

## テスト

- `test/bin/server-spawn-env.spec.ts` — `NODE_ENV` を注入しない（キー集合まで固定）/ ユーザーの `NODE_ENV` は production・development・test のいずれもそのまま通る / `PORT` は文字列 / 入力 env を破壊しない
- `test/server/infra/hide-error-stacks.spec.ts` — throw するルートの 500 応答にスタックが出ない、`NODE_ENV=development` を stub しても勝つ、そして**それが無ければ express は本当に載せる**という対照（express 側の挙動が変わったら気づけるように）
- `test/server/infra/pty-env.spec.ts` — なぜここで `NODE_ENV` を落とさないかのコメントを追記

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（5031 passed）/ `build` 実行済み。

## 影響範囲

- `yarn dev` 経路は launcher を通らないので元から非該当
- npm 11 は install の省略に `NODE_ENV` を見ないので非該当。pnpm / yarn berry は未検証
- 回避策として周知されていた `NODE_ENV=development yarn install` は不要になる（yarn の条件から `YARN_PRODUCTION=false` / `NPM_CONFIG_PRODUCTION=false` も効くことが分かったので、旧版を使い続ける人にはそちらも案内可）

## ドキュメント

README / docs に `NODE_ENV` の記述は無いため更新なし。changelog はリリース時（`/publish`）。設計メモは `plans/fix-955-node-env-leak.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
