### PR TITLE
fix: フォーカスセルの zoom で文字がぼやけないようにする (#965)

### DIFF
--- a/plans/fix-965-focus-zoom-blur.md
+++ b/plans/fix-965-focus-zoom-blur.md
@@ -1,0 +1,68 @@
+# フォーカスセルの in-place zoom で文字がぼやける
+
+Issue: #965
+
+## 症状
+
+グリッドでセルをフォーカスすると `transform: scale(1.03)` で浮き上がるが、その間ターミナルの
+文字がぼやける。フォーカスを外すと戻る。
+
+## 原因
+
+#309 の設計メモ (`plans/feat-grid-active-zoom.md:12`) は「このアプリは xterm を **DOM レンダラ**
+（canvas 無し）で描くので、実 DOM テキストを拡大しても crisp のまま」を根拠にしていた。zoom が
+入った `535fe68`（2026-07-11 19:34）の時点では正しい。
+
+その 8 時間後、`b12cc48`（2026-07-12 03:47 "render the terminal with the canvas renderer to stop
+CJK drift"）で **CanvasAddon** が入り（`src/composables/useTerminalConnections.ts:421`）、
+ターミナルの中身は解像度固定のビットマップになった。canvas のバッキングストアは
+「CSS サイズ × devicePixelRatio」で決まり、CSS transform では再描画されない。よって
+`transform: scale(1.03)` はビットマップを 1.03 倍に引き伸ばすだけで、非整数倍率の再サンプリングが
+にじみになる。前提が別コミットで崩れた形で、zoom 側にも canvas 側にも単体の誤りは無い。
+
+## 方針（ユーザー判断）
+
+**zoom は維持する。** セルの枠は今まで通り 1.03 倍に育てる。ただしセルの中身をまとめて
+1/1.03 で逆スケールし、**中身に掛かる合成変換を厳密に恒等**にする。canvas は 1:1 で
+ラスタライズされたまま、枠だけが育つ。文字サイズは変わらない。
+
+## Chromium で実測して選んだ（scratchpad の puppeteer + sharp）
+
+同じ canvas を同じページ座標に描き、変換なしの基準画像とピクセル比較（DPR 2、内側 6px を除いた
+テキスト領域）:
+
+| 変え方 | 基準と異なるチャンネル |
+|---|---|
+| 今の `scale(1.03)` のみ | **21.85%**（平均差 24.1）|
+| 中身を「自分の中心」で 1/1.03 逆スケール | **13.96%** |
+| 中身を「セルの中心」で 1/1.03 逆スケール | **0.000%** |
+| セルは拡大せず枠レイヤーだけ拡大 | **0.000%** |
+
+逆スケールの**中心がずれると直らない**のが要点。ヘッダの下から始まるラッパーを逆スケールすると
+合成変換に 0.4px 程度の並進が残り、それだけで 14% のピクセルが変わる。
+
+## 実装
+
+1. `src/style.css` にトークンを 1 つ: `--focus-zoom: 1.03`。逆数は別トークンにせず
+   `calc(1 / var(--focus-zoom))` で書く（2 つ置くと数値がずれ得るが、1 つなら構造的にずれない）。
+2. `TerminalGrid.vue` の `.focused` は `scale(var(--focus-zoom))`（数値リテラルをやめる）。
+3. `cellChromeClasses.ts` に `CELL_INNER` を追加。`group-[.focused]/cell:scale-[calc(1/var(--focus-zoom))]`。
+   セルの子を**全部**（ヘッダも含めて）1 枚のラッパーに入れるのが、中心を一致させる方法。
+   `CELL_FRAME` と TerminalCell のルートに `group/cell` を足す。
+4. 3 つのセル（TerminalCell / CommandCell / LauncherCell）の中身をこのラッパーで包む。
+   scoped CSS で子コンポーネント内部を狙うことはできない（#787、`cellChromeClasses.ts` 冒頭に
+   その理由が書いてある）ので、ユーティリティで持たせる。
+
+レイアウトサイズは transform では変わらないので、xterm の refit も PTY のリサイズも起きない
+（#309 の性質はそのまま）。
+
+## テスト
+
+- `TerminalGrid.vue` の `.focused` がリテラルの `scale(1.` ではなくトークンを使い、`CELL_INNER` が
+  同じトークンの逆数で打ち消している。#331 のように倍率を触るときの防波堤。
+- 3 つのセルが `CELL_INNER` ラッパーを 1 枚だけ持ち、ルートが `group/cell` を持つ（mount）。
+
+## 見た目の確認
+
+ピクセル比較は「文字がぼけない」ことしか保証しない。「枠が育って中身が据え置き」が意図通りかは
+人が見る必要があるので、PR では `/pr-ui-test` かユーザーの目視を求める。

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -24,6 +24,7 @@ import {
   CELL_DOT_IDLE,
   CELL_DOT_WORKING,
   CELL_FRAME,
+  CELL_INNER,
   CELL_HEADER,
   CELL_HEADER_ZOOMABLE,
   CELL_TERM,
@@ -165,100 +166,102 @@ function onHeaderClick(event: MouseEvent) {
 
 <template>
   <div class="cell" :class="CELL_FRAME">
-    <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" @click="onHeaderClick">
-      <span
-        class="cell-dot"
-        :class="[CELL_DOT, finished ? `is-idle ${CELL_DOT_IDLE}` : `is-working ${CELL_DOT_WORKING}`]"
-        :title="finished ? 'Finished' : 'Running…'"
-      />
-      <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="command.cwd ?? ''"
-        ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
-      >
-      <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
-      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ command.label }}</span>
-      <span class="cell-actions" :class="CELL_ACTIONS">
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move command left" @click="emit('move', -1)">
-          <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
-        </button>
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move command right" @click="emit('move', 1)">
-          <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
-        </button>
-        <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Re-run" aria-label="Re-run command" @click="rerun">
-          <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
-        </button>
-        <button
-          class="cell-btn cell-summarize"
-          :class="summaryState === 'loading' ? `is-busy ${SUMMARIZE_BUSY}` : SUMMARIZE_READY"
-          title="Summarize output (AI)"
-          aria-label="Summarize command output"
-          :disabled="summaryState === 'loading'"
-          @click="summarize"
-        >
-          <span class="material-symbols-outlined" aria-hidden="true">{{ summaryState === "loading" ? "more_horiz" : "auto_awesome" }}</span>
-        </button>
-        <CellChromeButtons
-          :expanded="expanded"
-          :files-open="filesOpen"
-          @toggle-expand="emit('toggle-expand')"
-          @toggle-files="emit('toggle-files')"
-          @close="emit('close')"
+    <div :class="CELL_INNER">
+      <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" @click="onHeaderClick">
+        <span
+          class="cell-dot"
+          :class="[CELL_DOT, finished ? `is-idle ${CELL_DOT_IDLE}` : `is-working ${CELL_DOT_WORKING}`]"
+          :title="finished ? 'Finished' : 'Running…'"
         />
-      </span>
-    </div>
-    <TerminalView
-      ref="termRef"
-      class="cell-term"
-      :class="CELL_TERM"
-      :session-id="null"
-      :connect-key="connectKey"
-      :cwd="command.cwd"
-      :command="command"
-      :expanded="expanded"
-      :zoomed="zoomed"
-      @exit="onExit"
-    />
-    <div v-if="showSummary" data-testid="cell-summary" class="flex max-h-[40%] min-h-0 flex-none flex-col border-t border-t-[#2a2a4e] bg-[#141b33]">
-      <div class="flex flex-none items-center justify-between border-b border-b-[#232a48] py-0.5 pl-2.5 pr-1.5">
-        <span class="inline-flex items-center gap-1 font-sans text-[11px] font-semibold text-[#9db4ff]"
-          ><span class="material-symbols-outlined" aria-hidden="true">auto_awesome</span> Summary</span
+        <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="command.cwd ?? ''"
+          ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
         >
-        <button class="cell-btn cell-summary-close" :class="SUMMARY_CLOSE_BTN" title="Dismiss summary" aria-label="Dismiss summary" @click="closeSummary">
-          <span class="material-symbols-outlined" aria-hidden="true">close</span>
-        </button>
+        <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
+        <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ command.label }}</span>
+        <span class="cell-actions" :class="CELL_ACTIONS">
+          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move command left" @click="emit('move', -1)">
+            <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+          </button>
+          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move command right" @click="emit('move', 1)">
+            <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
+          </button>
+          <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Re-run" aria-label="Re-run command" @click="rerun">
+            <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
+          </button>
+          <button
+            class="cell-btn cell-summarize"
+            :class="summaryState === 'loading' ? `is-busy ${SUMMARIZE_BUSY}` : SUMMARIZE_READY"
+            title="Summarize output (AI)"
+            aria-label="Summarize command output"
+            :disabled="summaryState === 'loading'"
+            @click="summarize"
+          >
+            <span class="material-symbols-outlined" aria-hidden="true">{{ summaryState === "loading" ? "more_horiz" : "auto_awesome" }}</span>
+          </button>
+          <CellChromeButtons
+            :expanded="expanded"
+            :files-open="filesOpen"
+            @toggle-expand="emit('toggle-expand')"
+            @toggle-files="emit('toggle-files')"
+            @close="emit('close')"
+          />
+        </span>
       </div>
-      <div class="min-h-0 flex-auto overflow-auto px-2.5 pb-2 pt-1.5">
-        <span v-if="summaryState === 'loading'" class="font-sans text-[12px] text-[#7f88ad]">Summarizing…</span>
-        <p
-          v-else-if="summaryState === 'error'"
-          data-testid="cell-summary-error"
-          class="m-0 font-mono text-[12px] text-[#ff8a8a] whitespace-pre-wrap [word-break:break-word]"
-        >
-          {{ summaryError }}
-        </p>
-        <template v-else>
-          <!-- v-text (not {{ }}): keeps the summary's exact bytes and is immune to a
-               formatter wrapping the interpolation onto its own indented line inside <pre>. -->
-          <pre
-            data-testid="cell-summary-text"
-            class="m-0 font-mono text-[12px] leading-[1.5] text-[#d6dcf5] whitespace-pre-wrap [word-break:break-word]"
-            v-text="summaryText"
-          ></pre>
-          <p v-if="summaryTruncated" data-testid="cell-summary-note" class="mt-1.5 font-sans text-[11px] text-[#7f88ad]">
-            (long output — summarized the tail only)
+      <TerminalView
+        ref="termRef"
+        class="cell-term"
+        :class="CELL_TERM"
+        :session-id="null"
+        :connect-key="connectKey"
+        :cwd="command.cwd"
+        :command="command"
+        :expanded="expanded"
+        :zoomed="zoomed"
+        @exit="onExit"
+      />
+      <div v-if="showSummary" data-testid="cell-summary" class="flex max-h-[40%] min-h-0 flex-none flex-col border-t border-t-[#2a2a4e] bg-[#141b33]">
+        <div class="flex flex-none items-center justify-between border-b border-b-[#232a48] py-0.5 pl-2.5 pr-1.5">
+          <span class="inline-flex items-center gap-1 font-sans text-[11px] font-semibold text-[#9db4ff]"
+            ><span class="material-symbols-outlined" aria-hidden="true">auto_awesome</span> Summary</span
+          >
+          <button class="cell-btn cell-summary-close" :class="SUMMARY_CLOSE_BTN" title="Dismiss summary" aria-label="Dismiss summary" @click="closeSummary">
+            <span class="material-symbols-outlined" aria-hidden="true">close</span>
+          </button>
+        </div>
+        <div class="min-h-0 flex-auto overflow-auto px-2.5 pb-2 pt-1.5">
+          <span v-if="summaryState === 'loading'" class="font-sans text-[12px] text-[#7f88ad]">Summarizing…</span>
+          <p
+            v-else-if="summaryState === 'error'"
+            data-testid="cell-summary-error"
+            class="m-0 font-mono text-[12px] text-[#ff8a8a] whitespace-pre-wrap [word-break:break-word]"
+          >
+            {{ summaryError }}
           </p>
-          <div class="mt-2 flex justify-end">
-            <button
-              type="button"
-              data-testid="cell-summary-continue"
-              class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-[#3b4a7a] bg-[#232a45] px-2.5 py-1 font-sans text-[12px] text-[#cdd6ff] hover:bg-[#2c355a]"
-              title="Copy this as a prompt to paste into a Claude session"
-              @click="copyPrompt"
-            >
-              <span class="material-symbols-outlined" aria-hidden="true">{{ copied ? "check" : "content_copy" }}</span>
-              {{ copied ? "Copied" : "Copy as prompt" }}
-            </button>
-          </div>
-        </template>
+          <template v-else>
+            <!-- v-text (not {{ }}): keeps the summary's exact bytes and is immune to a
+               formatter wrapping the interpolation onto its own indented line inside <pre>. -->
+            <pre
+              data-testid="cell-summary-text"
+              class="m-0 font-mono text-[12px] leading-[1.5] text-[#d6dcf5] whitespace-pre-wrap [word-break:break-word]"
+              v-text="summaryText"
+            ></pre>
+            <p v-if="summaryTruncated" data-testid="cell-summary-note" class="mt-1.5 font-sans text-[11px] text-[#7f88ad]">
+              (long output — summarized the tail only)
+            </p>
+            <div class="mt-2 flex justify-end">
+              <button
+                type="button"
+                data-testid="cell-summary-continue"
+                class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-[#3b4a7a] bg-[#232a45] px-2.5 py-1 font-sans text-[12px] text-[#cdd6ff] hover:bg-[#2c355a]"
+                title="Copy this as a prompt to paste into a Claude session"
+                @click="copyPrompt"
+              >
+                <span class="material-symbols-outlined" aria-hidden="true">{{ copied ? "check" : "content_copy" }}</span>
+                {{ copied ? "Copied" : "Copy as prompt" }}
+              </button>
+            </div>
+          </template>
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -18,6 +18,7 @@ import {
   CELL_DOT_IDLE,
   CELL_DOT_WORKING,
   CELL_FRAME,
+  CELL_INNER,
   CELL_HEADER,
   CELL_HEADER_ZOOMABLE,
   CELL_TERM,
@@ -80,48 +81,50 @@ function relaunch() {
 
 <template>
   <div class="cell" :class="CELL_FRAME">
-    <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" @click="onHeaderClick">
-      <span
-        class="cell-dot"
-        :class="[CELL_DOT, finished ? `is-idle ${CELL_DOT_IDLE}` : `is-working ${CELL_DOT_WORKING}`]"
-        :title="finished ? 'Exited' : 'Running…'"
-      />
-      <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="cwd ?? ''"
-        ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
-      >
-      <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
-      <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">rocket_launch</span> {{ launcher.label }}</span>
-      <span class="cell-actions" :class="CELL_ACTIONS">
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">
-          <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
-        </button>
-        <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move launcher right" @click="emit('move', 1)">
-          <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
-        </button>
-        <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Relaunch" aria-label="Relaunch" @click="relaunch">
-          <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
-        </button>
-        <CellChromeButtons
-          :expanded="expanded"
-          :files-open="filesOpen"
-          @toggle-expand="emit('toggle-expand')"
-          @toggle-files="emit('toggle-files')"
-          @close="emit('close')"
+    <div :class="CELL_INNER">
+      <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" @click="onHeaderClick">
+        <span
+          class="cell-dot"
+          :class="[CELL_DOT, finished ? `is-idle ${CELL_DOT_IDLE}` : `is-working ${CELL_DOT_WORKING}`]"
+          :title="finished ? 'Exited' : 'Running…'"
         />
-      </span>
+        <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="cwd ?? ''"
+          ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
+        >
+        <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
+        <span class="cell-cmd" :class="CELL_CMD"><span class="material-symbols-outlined" aria-hidden="true">rocket_launch</span> {{ launcher.label }}</span>
+        <span class="cell-actions" :class="CELL_ACTIONS">
+          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move launcher left" @click="emit('move', -1)">
+            <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+          </button>
+          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move launcher right" @click="emit('move', 1)">
+            <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
+          </button>
+          <button v-if="finished" class="cell-btn" :class="CELL_BTN" title="Relaunch" aria-label="Relaunch" @click="relaunch">
+            <span class="material-symbols-outlined" aria-hidden="true">refresh</span>
+          </button>
+          <CellChromeButtons
+            :expanded="expanded"
+            :files-open="filesOpen"
+            @toggle-expand="emit('toggle-expand')"
+            @toggle-files="emit('toggle-files')"
+            @close="emit('close')"
+          />
+        </span>
+      </div>
+      <TerminalView
+        class="cell-term"
+        :class="CELL_TERM"
+        :persist-key="`cell-${uid}`"
+        :session-id="session"
+        :connect-key="connectKey"
+        :cwd="cwd"
+        :launcher="target"
+        :expanded="expanded"
+        :zoomed="zoomed"
+        @session="onSession"
+        @exit="onExit"
+      />
     </div>
-    <TerminalView
-      class="cell-term"
-      :class="CELL_TERM"
-      :persist-key="`cell-${uid}`"
-      :session-id="session"
-      :connect-key="connectKey"
-      :cwd="cwd"
-      :launcher="target"
-      :expanded="expanded"
-      :zoomed="zoomed"
-      @session="onSession"
-      @exit="onExit"
-    />
   </div>
 </template>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -35,6 +35,7 @@ import {
   CELL_DOT_IDLE,
   CELL_DOT_WORKING,
   CELL_HEADER_ZOOMABLE,
+  CELL_INNER,
   CELL_TERM,
   DIR_TRUNCATE_FRONT,
 } from "./cellChromeClasses";
@@ -1005,633 +1006,640 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
 
 <template>
   <div
-    class="cell relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border bg-[var(--cell-bg,var(--bg-base))]"
+    class="group/cell cell relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border bg-[var(--cell-bg,var(--bg-base))]"
     :class="[statusClass, cellStatusClass]"
     :style="cellStyle"
   >
-    <template v-if="launched">
-      <!-- Filmstrip thumbnail: the same roster header (CockpitHeader) — the dir colour is applied
+    <div :class="CELL_INNER">
+      <template v-if="launched">
+        <!-- Filmstrip thumbnail: the same roster header (CockpitHeader) — the dir colour is applied
            regardless of status (status is the dot + badge), so a thumbnail reads as its directory
            the way the roster row does. Expand/close go in its trailing slot. -->
-      <CockpitHeader
-        v-if="filmstrip"
-        class="cell-header flex-none border-b"
-        :class="[statusClass, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]"
-        :status="status"
-        :agent="agent"
-        :cwd="cwd"
-        :home="home"
-        :header-color="dirConfig.headerColor"
-        :header-text-color="dirConfig.headerTextColor"
-        @click="onHeaderClick"
-      >
-        <span class="cell-actions" :class="CELL_ACTIONS">
-          <CellChromeButtons
-            :expanded="expanded"
-            :files-open="filesOpen"
-            @toggle-expand="emit('toggle-expand')"
-            @toggle-files="emit('toggle-files')"
-            @close="close"
-          />
-        </span>
-      </CockpitHeader>
-      <!-- Row 1 — INFO only (normal grid / expanded): dir + git + model/token + what it's doing.
+        <CockpitHeader
+          v-if="filmstrip"
+          class="cell-header flex-none border-b"
+          :class="[statusClass, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]"
+          :status="status"
+          :agent="agent"
+          :cwd="cwd"
+          :home="home"
+          :header-color="dirConfig.headerColor"
+          :header-text-color="dirConfig.headerTextColor"
+          @click="onHeaderClick"
+        >
+          <span class="cell-actions" :class="CELL_ACTIONS">
+            <CellChromeButtons
+              :expanded="expanded"
+              :files-open="filesOpen"
+              @toggle-expand="emit('toggle-expand')"
+              @toggle-files="emit('toggle-files')"
+              @close="close"
+            />
+          </span>
+        </CockpitHeader>
+        <!-- Row 1 — INFO only (normal grid / expanded): dir + git + model/token + what it's doing.
            Every icon BUTTON lives on row 2 (the embedded terminal's header, via its slot). -->
-      <div
-        v-else
-        class="cell-header flex h-[34px] flex-none items-center gap-2 border-b px-2"
-        :class="[statusClass, headerStatusClass, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]"
-        :style="headerStyle"
-        @click="onHeaderClick"
-      >
-        <!-- All the info lives in one shrinkable, clipping track. The chips (badge / git /
+        <div
+          v-else
+          class="cell-header flex h-[34px] flex-none items-center gap-2 border-b px-2"
+          :class="[statusClass, headerStatusClass, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]"
+          :style="headerStyle"
+          @click="onHeaderClick"
+        >
+          <!-- All the info lives in one shrinkable, clipping track. The chips (badge / git /
              model / tokens / custom) don't shrink, so without this they would overflow and
              push the actions past the cell's `overflow: hidden` edge — the buttons must
              stay reachable no matter how much a dir's config crams in here. -->
-        <div data-testid="cell-header-main" class="flex min-w-0 flex-auto items-center gap-2 overflow-hidden">
-          <span class="cell-dot" :class="[CELL_DOT, statusClass, dotStatusClass]" :title="statusLabel" />
-          <!-- Normal grid: the dir is a button that opens it. As a filmstrip thumbnail the
+          <div data-testid="cell-header-main" class="flex min-w-0 flex-auto items-center gap-2 overflow-hidden">
+            <span class="cell-dot" :class="[CELL_DOT, statusClass, dotStatusClass]" :title="statusLabel" />
+            <!-- Normal grid: the dir is a button that opens it. As a filmstrip thumbnail the
                header's job is to zoom (switch to this terminal), so the dir is inert text
                and a click on it falls through to the header's zoom gesture. -->
-          <button
-            v-if="headerDir && !filmstrip"
-            type="button"
-            class="cell-dir flex-initial min-w-[16ch] max-w-[60%] cursor-pointer truncate border-none bg-transparent p-0 text-left font-mono text-[11px] text-[var(--cell-header-fg,var(--text-dim))] [direction:rtl] hover:text-muted hover:underline"
-            :title="cwd ? `Open ${cwd}` : ''"
-            @click="openDir"
-          >
-            <span class="cell-dir-path [unicode-bidi:plaintext]">{{ headerDir }}</span>
-          </button>
-          <span
-            v-else-if="headerDir"
-            class="cell-dir flex-initial min-w-[16ch] max-w-[60%] cursor-pointer truncate border-none bg-transparent p-0 text-left font-mono text-[11px] text-[var(--cell-header-fg,var(--text-dim))] [direction:rtl] hover:text-muted hover:underline"
-            :title="cwd ?? ''"
-          >
-            <span class="cell-dir-path [unicode-bidi:plaintext]">{{ headerDir }}</span>
-          </span>
-          <!-- Info (dir badge / git / diff / model / tokens) is dropped on a filmstrip
+            <button
+              v-if="headerDir && !filmstrip"
+              type="button"
+              class="cell-dir flex-initial min-w-[16ch] max-w-[60%] cursor-pointer truncate border-none bg-transparent p-0 text-left font-mono text-[11px] text-[var(--cell-header-fg,var(--text-dim))] [direction:rtl] hover:text-muted hover:underline"
+              :title="cwd ? `Open ${cwd}` : ''"
+              @click="openDir"
+            >
+              <span class="cell-dir-path [unicode-bidi:plaintext]">{{ headerDir }}</span>
+            </button>
+            <span
+              v-else-if="headerDir"
+              class="cell-dir flex-initial min-w-[16ch] max-w-[60%] cursor-pointer truncate border-none bg-transparent p-0 text-left font-mono text-[11px] text-[var(--cell-header-fg,var(--text-dim))] [direction:rtl] hover:text-muted hover:underline"
+              :title="cwd ?? ''"
+            >
+              <span class="cell-dir-path [unicode-bidi:plaintext]">{{ headerDir }}</span>
+            </span>
+            <!-- Info (dir badge / git / diff / model / tokens) is dropped on a filmstrip
                thumbnail, leaving only dir + what it's doing + a zoom button. -->
-          <template v-if="!filmstrip">
-            <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
-            <template v-for="chip in cellChips" :key="chip.key">
-              <GitBranchChip v-if="chip.builtin === 'git'" :status="gitStatus" :hide-dirty="isWorktreeCell" />
-              <button
-                v-else-if="chip.builtin === 'diff' && showDiffBadge && diff"
-                type="button"
-                data-testid="cell-wt-badge"
-                class="inline-flex flex-none cursor-pointer items-center gap-1.5 rounded-[10px] border border-border bg-elevated px-[7px] py-px font-mono text-[11px] hover:bg-hover"
-                :title="`View changes vs ${diff.base ?? 'base'}`"
-                @click="openDiff"
-              >
-                <span v-if="diff.ahead > 0" data-testid="wt-ahead" class="text-accent">+{{ diff.ahead }}</span>
-                <span v-if="diff.dirty > 0" data-testid="wt-dirty-count" class="text-[var(--warn-text,#e0a030)]">●{{ diff.dirty }}</span>
-              </button>
-              <ModelContextBadge v-else-if="chip.builtin === 'ctx' && context" :agent="agent" :model="context.model" :context-tokens="context.contextTokens" />
-              <span
-                v-else-if="chip.builtin === 'usage' && showUsage"
-                data-testid="cell-usage"
-                class="flex-none whitespace-nowrap font-mono text-[10px] tracking-[0.02em] text-dim"
-                :title="usageTitle"
-                >{{ usageLabel }}</span
-              >
-              <span
-                v-else-if="chip.custom"
-                data-testid="cell-hdr-chip"
-                class="flex-none whitespace-nowrap rounded-full border border-border px-1.5 py-px text-[10px] text-dim"
-                :title="chip.custom.label || chip.custom.text"
-                >{{ chip.custom.text }}</span
-              >
+            <template v-if="!filmstrip">
+              <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
+              <template v-for="chip in cellChips" :key="chip.key">
+                <GitBranchChip v-if="chip.builtin === 'git'" :status="gitStatus" :hide-dirty="isWorktreeCell" />
+                <button
+                  v-else-if="chip.builtin === 'diff' && showDiffBadge && diff"
+                  type="button"
+                  data-testid="cell-wt-badge"
+                  class="inline-flex flex-none cursor-pointer items-center gap-1.5 rounded-[10px] border border-border bg-elevated px-[7px] py-px font-mono text-[11px] hover:bg-hover"
+                  :title="`View changes vs ${diff.base ?? 'base'}`"
+                  @click="openDiff"
+                >
+                  <span v-if="diff.ahead > 0" data-testid="wt-ahead" class="text-accent">+{{ diff.ahead }}</span>
+                  <span v-if="diff.dirty > 0" data-testid="wt-dirty-count" class="text-[var(--warn-text,#e0a030)]">●{{ diff.dirty }}</span>
+                </button>
+                <ModelContextBadge
+                  v-else-if="chip.builtin === 'ctx' && context"
+                  :agent="agent"
+                  :model="context.model"
+                  :context-tokens="context.contextTokens"
+                />
+                <span
+                  v-else-if="chip.builtin === 'usage' && showUsage"
+                  data-testid="cell-usage"
+                  class="flex-none whitespace-nowrap font-mono text-[10px] tracking-[0.02em] text-dim"
+                  :title="usageTitle"
+                  >{{ usageLabel }}</span
+                >
+                <span
+                  v-else-if="chip.custom"
+                  data-testid="cell-hdr-chip"
+                  class="flex-none whitespace-nowrap rounded-full border border-border px-1.5 py-px text-[10px] text-dim"
+                  :title="chip.custom.label || chip.custom.text"
+                  >{{ chip.custom.text }}</span
+                >
+              </template>
             </template>
-          </template>
-          <span
-            data-testid="cell-prompt"
-            class="min-w-0 flex-auto truncate font-sans text-[12px] text-[var(--cell-header-fg,var(--text-secondary))]"
-            :title="lastPrompt || aiTitle || ''"
-            >{{ headerText }}</span
-          >
-        </div>
-        <!-- Expand/restore + close stay on row 1 (the info row) and OUTSIDE the info
+            <span
+              data-testid="cell-prompt"
+              class="min-w-0 flex-auto truncate font-sans text-[12px] text-[var(--cell-header-fg,var(--text-secondary))]"
+              :title="lastPrompt || aiTitle || ''"
+              >{{ headerText }}</span
+            >
+          </div>
+          <!-- Expand/restore + close stay on row 1 (the info row) and OUTSIDE the info
              track, so they're always pinned top-right. `.stop` so they don't trigger the
              header's click-to-zoom. -->
-        <span class="cell-actions" :class="CELL_ACTIONS">
-          <CellChromeButtons
-            :expanded="expanded"
-            :files-open="filesOpen"
-            @toggle-expand="emit('toggle-expand')"
-            @toggle-files="emit('toggle-files')"
-            @close="close"
-          />
-        </span>
-      </div>
-      <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
-      <TerminalView
-        ref="termRef"
-        class="cell-term"
-        :class="CELL_TERM"
-        :persist-key="`cell-${uid}`"
-        :session-id="sessionId"
-        :connect-key="connectKey"
-        :cwd="cwd"
-        :codex="agent === 'codex'"
-        :launch="launchChoice"
-        :dir-header-color="dirConfig.headerColor"
-        :dir-header-text-color="dirConfig.headerTextColor"
-        :dir-button-color="dirConfig.buttonColor"
-        :hide-header="filmstrip"
-        :expanded="expanded"
-        :zoomed="zoomed"
-        dev-terminal
-        run-menu
-        @session="onSession"
-        @cwd="onServerCwd"
-        @run="(cmd) => emit('runSpare', cmd)"
-      >
-        <!-- Row 2 — the cell's icon actions, gathered onto the terminal's header row. -->
-        <template #header-actions>
-          <span v-if="githubUrl" ref="ghWrap" class="relative inline-flex flex-none">
-            <button
-              type="button"
-              data-testid="cell-gh"
-              class="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-[4px] border-none bg-transparent p-0 text-dim hover:bg-hover hover:text-fg"
-              title="Open on GitHub"
-              aria-label="Open on GitHub"
-              aria-haspopup="true"
-              :aria-expanded="ghMenuOpen"
-              @click="ghMenuOpen = !ghMenuOpen"
-            >
-              <svg class="block h-[14px] w-[14px]" viewBox="0 0 16 16" aria-hidden="true">
-                <path
-                  fill-rule="evenodd"
-                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 4.6c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-                />
-              </svg>
-            </button>
-            <div
-              v-if="ghMenuOpen"
-              data-testid="cell-gh-menu"
-              class="absolute left-0 top-full z-20 mt-1 flex min-w-[132px] flex-col rounded-md border border-border bg-panel p-1 shadow-[0_6px_18px_rgba(0,0,0,0.35)]"
-              @keydown.escape="ghMenuOpen = false"
-            >
-              <button
-                type="button"
-                data-testid="cell-gh-item"
-                class="cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
-                @click="openGithub('')"
-              >
-                Repository
-              </button>
-              <button
-                type="button"
-                data-testid="cell-gh-item"
-                class="cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
-                @click="openGithub('/issues')"
-              >
-                Issues
-              </button>
-              <button
-                type="button"
-                data-testid="cell-gh-item"
-                class="cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
-                @click="openGithub('/pulls')"
-              >
-                Pull requests
-              </button>
-            </div>
+          <span class="cell-actions" :class="CELL_ACTIONS">
+            <CellChromeButtons
+              :expanded="expanded"
+              :files-open="filesOpen"
+              @toggle-expand="emit('toggle-expand')"
+              @toggle-files="emit('toggle-files')"
+              @close="close"
+            />
           </span>
-          <span v-if="sessionId" ref="askWrap" class="relative inline-flex flex-none">
-            <button
-              type="button"
-              data-testid="cell-ask"
-              class="cell-btn"
-              :class="CELL_BTN"
-              title="Bring another terminal's last turn into this input box"
-              aria-label="Bring another terminal's last turn here"
-              aria-haspopup="true"
-              :aria-expanded="askMenuOpen"
-              @click="openAskMenu"
-            >
-              <span class="material-symbols-outlined" aria-hidden="true">forum</span>
-            </button>
-            <div
-              v-if="askMenuOpen"
-              data-testid="cell-ask-menu"
-              class="absolute right-0 top-full z-20 mt-1 flex min-w-[180px] flex-col rounded-md border border-border bg-panel p-1 shadow-[0_6px_18px_rgba(0,0,0,0.35)]"
-              @keydown.escape="askMenuOpen = false"
-            >
-              <div v-for="target in askTargets" :key="target.key" class="flex items-center gap-1">
+        </div>
+        <TimelineOverlay :session-id="sessionId" :cwd="cwd" :open="timelineOpen" @close="timelineOpen = false" />
+        <TerminalView
+          ref="termRef"
+          class="cell-term"
+          :class="CELL_TERM"
+          :persist-key="`cell-${uid}`"
+          :session-id="sessionId"
+          :connect-key="connectKey"
+          :cwd="cwd"
+          :codex="agent === 'codex'"
+          :launch="launchChoice"
+          :dir-header-color="dirConfig.headerColor"
+          :dir-header-text-color="dirConfig.headerTextColor"
+          :dir-button-color="dirConfig.buttonColor"
+          :hide-header="filmstrip"
+          :expanded="expanded"
+          :zoomed="zoomed"
+          dev-terminal
+          run-menu
+          @session="onSession"
+          @cwd="onServerCwd"
+          @run="(cmd) => emit('runSpare', cmd)"
+        >
+          <!-- Row 2 — the cell's icon actions, gathered onto the terminal's header row. -->
+          <template #header-actions>
+            <span v-if="githubUrl" ref="ghWrap" class="relative inline-flex flex-none">
+              <button
+                type="button"
+                data-testid="cell-gh"
+                class="inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-[4px] border-none bg-transparent p-0 text-dim hover:bg-hover hover:text-fg"
+                title="Open on GitHub"
+                aria-label="Open on GitHub"
+                aria-haspopup="true"
+                :aria-expanded="ghMenuOpen"
+                @click="ghMenuOpen = !ghMenuOpen"
+              >
+                <svg class="block h-[14px] w-[14px]" viewBox="0 0 16 16" aria-hidden="true">
+                  <path
+                    fill-rule="evenodd"
+                    d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.6 7.6 0 0 1 8 4.6c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+                  />
+                </svg>
+              </button>
+              <div
+                v-if="ghMenuOpen"
+                data-testid="cell-gh-menu"
+                class="absolute left-0 top-full z-20 mt-1 flex min-w-[132px] flex-col rounded-md border border-border bg-panel p-1 shadow-[0_6px_18px_rgba(0,0,0,0.35)]"
+                @keydown.escape="ghMenuOpen = false"
+              >
                 <button
                   type="button"
-                  data-testid="cell-ask-item"
-                  class="flex-1 cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
-                  :title="`Bring ${target.label}'s last turn here`"
-                  @click="askCell(target)"
+                  data-testid="cell-gh-item"
+                  class="cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                  @click="openGithub('')"
                 >
-                  {{ target.label }}
+                  Repository
                 </button>
                 <button
                   type="button"
-                  data-testid="cell-exchange-item"
-                  :aria-label="`Exchange one turn with ${target.label}`"
-                  class="cursor-pointer rounded-[4px] border-none bg-transparent px-1.5 py-1.5 font-sans text-[12px] text-dim hover:bg-hover hover:text-fg disabled:cursor-default disabled:opacity-40"
-                  :disabled="exchanging"
-                  title="Send this cell's turn there and bring the answer back, both submitted"
-                  @click="exchangeWith(target)"
+                  data-testid="cell-gh-item"
+                  class="cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                  @click="openGithub('/issues')"
                 >
-                  <span class="material-symbols-outlined" aria-hidden="true">swap_horiz</span>
+                  Issues
+                </button>
+                <button
+                  type="button"
+                  data-testid="cell-gh-item"
+                  class="cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                  @click="openGithub('/pulls')"
+                >
+                  Pull requests
                 </button>
               </div>
-              <p v-if="!askTargets.length" class="m-0 px-2 py-1.5 font-sans text-[12px] text-dim">No other terminal to read</p>
-            </div>
-            <button
-              v-if="exchanging"
-              type="button"
-              data-testid="cell-exchange-stop"
-              aria-label="Stop the exchange in progress"
-              class="absolute right-0 top-full z-20 mt-1 cursor-pointer whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1.5 font-sans text-[12px] text-secondary shadow-[0_6px_18px_rgba(0,0,0,0.35)] hover:text-fg"
-              @click="stopExchange"
-            >
-              <span class="material-symbols-outlined" aria-hidden="true">swap_horiz</span> exchanging — stop
-            </button>
-            <p
-              v-else-if="askMsg"
-              data-testid="cell-ask-msg"
-              role="status"
-              class="absolute right-0 top-full z-20 m-0 mt-1 whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1.5 font-sans text-[12px] text-dim shadow-[0_6px_18px_rgba(0,0,0,0.35)]"
-            >
-              {{ askMsg }}
-            </p>
-          </span>
-          <button
-            v-if="sessionId && agent !== 'codex'"
-            class="cell-btn"
-            :class="CELL_BTN"
-            title="Activity timeline"
-            aria-label="Show activity timeline"
-            @click="timelineOpen = true"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">history</span>
-          </button>
-          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">
-            <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
-          </button>
-          <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">
-            <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
-          </button>
-        </template>
-      </TerminalView>
-      <div
-        v-if="diffOpen && diff"
-        data-testid="cell-diff"
-        class="absolute inset-x-0 bottom-0 top-[34px] z-[15] flex flex-col overflow-hidden border-t border-t-border bg-base"
-      >
-        <div class="flex flex-none items-center gap-2 border-b border-b-border bg-panel px-2 py-1.5">
-          <span class="font-sans text-[12px] font-semibold text-fg">Changes vs {{ diff?.base ?? "base" }}</span>
-          <span class="flex-auto font-sans text-[11px] text-dim">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>
-          <button class="cell-btn" :class="CELL_BTN" title="Close diff" aria-label="Close diff" @click="diffOpen = false">
-            <span class="material-symbols-outlined" aria-hidden="true">close</span>
-          </button>
-        </div>
-        <div v-if="diff && diff.files.length" class="max-h-[35%] flex-none overflow-y-auto border-b border-b-border px-2 py-1">
-          <div v-for="f in diff.files" :key="f.path" data-testid="cell-diff-file" class="flex items-baseline gap-2 py-px font-mono text-[11px]">
-            <span class="min-w-0 flex-auto text-secondary" :class="DIR_TRUNCATE_FRONT"
-              ><span :class="CELL_DIR_PATH">{{ f.path }}</span></span
-            >
-            <span v-if="f.status === 'untracked'" data-testid="df-new" class="flex-none text-[#3fae6b]">new</span>
-            <span v-else class="flex-none">
-              <span class="text-[#3fae6b]">+{{ f.additions < 0 ? "bin" : f.additions }}</span>
-              <span class="text-err-text">−{{ f.deletions < 0 ? "bin" : f.deletions }}</span>
             </span>
+            <span v-if="sessionId" ref="askWrap" class="relative inline-flex flex-none">
+              <button
+                type="button"
+                data-testid="cell-ask"
+                class="cell-btn"
+                :class="CELL_BTN"
+                title="Bring another terminal's last turn into this input box"
+                aria-label="Bring another terminal's last turn here"
+                aria-haspopup="true"
+                :aria-expanded="askMenuOpen"
+                @click="openAskMenu"
+              >
+                <span class="material-symbols-outlined" aria-hidden="true">forum</span>
+              </button>
+              <div
+                v-if="askMenuOpen"
+                data-testid="cell-ask-menu"
+                class="absolute right-0 top-full z-20 mt-1 flex min-w-[180px] flex-col rounded-md border border-border bg-panel p-1 shadow-[0_6px_18px_rgba(0,0,0,0.35)]"
+                @keydown.escape="askMenuOpen = false"
+              >
+                <div v-for="target in askTargets" :key="target.key" class="flex items-center gap-1">
+                  <button
+                    type="button"
+                    data-testid="cell-ask-item"
+                    class="flex-1 cursor-pointer rounded-[4px] border-none bg-transparent px-2 py-1.5 text-left font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                    :title="`Bring ${target.label}'s last turn here`"
+                    @click="askCell(target)"
+                  >
+                    {{ target.label }}
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="cell-exchange-item"
+                    :aria-label="`Exchange one turn with ${target.label}`"
+                    class="cursor-pointer rounded-[4px] border-none bg-transparent px-1.5 py-1.5 font-sans text-[12px] text-dim hover:bg-hover hover:text-fg disabled:cursor-default disabled:opacity-40"
+                    :disabled="exchanging"
+                    title="Send this cell's turn there and bring the answer back, both submitted"
+                    @click="exchangeWith(target)"
+                  >
+                    <span class="material-symbols-outlined" aria-hidden="true">swap_horiz</span>
+                  </button>
+                </div>
+                <p v-if="!askTargets.length" class="m-0 px-2 py-1.5 font-sans text-[12px] text-dim">No other terminal to read</p>
+              </div>
+              <button
+                v-if="exchanging"
+                type="button"
+                data-testid="cell-exchange-stop"
+                aria-label="Stop the exchange in progress"
+                class="absolute right-0 top-full z-20 mt-1 cursor-pointer whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1.5 font-sans text-[12px] text-secondary shadow-[0_6px_18px_rgba(0,0,0,0.35)] hover:text-fg"
+                @click="stopExchange"
+              >
+                <span class="material-symbols-outlined" aria-hidden="true">swap_horiz</span> exchanging — stop
+              </button>
+              <p
+                v-else-if="askMsg"
+                data-testid="cell-ask-msg"
+                role="status"
+                class="absolute right-0 top-full z-20 m-0 mt-1 whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1.5 font-sans text-[12px] text-dim shadow-[0_6px_18px_rgba(0,0,0,0.35)]"
+              >
+                {{ askMsg }}
+              </p>
+            </span>
+            <button
+              v-if="sessionId && agent !== 'codex'"
+              class="cell-btn"
+              :class="CELL_BTN"
+              title="Activity timeline"
+              aria-label="Show activity timeline"
+              @click="timelineOpen = true"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">history</span>
+            </button>
+            <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move left" aria-label="Move terminal left" @click="emit('move', -1)">
+              <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+            </button>
+            <button v-if="reorderable" class="cell-btn" :class="CELL_BTN" title="Move right" aria-label="Move terminal right" @click="emit('move', 1)">
+              <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
+            </button>
+          </template>
+        </TerminalView>
+        <div
+          v-if="diffOpen && diff"
+          data-testid="cell-diff"
+          class="absolute inset-x-0 bottom-0 top-[34px] z-[15] flex flex-col overflow-hidden border-t border-t-border bg-base"
+        >
+          <div class="flex flex-none items-center gap-2 border-b border-b-border bg-panel px-2 py-1.5">
+            <span class="font-sans text-[12px] font-semibold text-fg">Changes vs {{ diff?.base ?? "base" }}</span>
+            <span class="flex-auto font-sans text-[11px] text-dim">{{ diff?.ahead ?? 0 }} ahead · {{ diff?.dirty ?? 0 }} uncommitted</span>
+            <button class="cell-btn" :class="CELL_BTN" title="Close diff" aria-label="Close diff" @click="diffOpen = false">
+              <span class="material-symbols-outlined" aria-hidden="true">close</span>
+            </button>
+          </div>
+          <div v-if="diff && diff.files.length" class="max-h-[35%] flex-none overflow-y-auto border-b border-b-border px-2 py-1">
+            <div v-for="f in diff.files" :key="f.path" data-testid="cell-diff-file" class="flex items-baseline gap-2 py-px font-mono text-[11px]">
+              <span class="min-w-0 flex-auto text-secondary" :class="DIR_TRUNCATE_FRONT"
+                ><span :class="CELL_DIR_PATH">{{ f.path }}</span></span
+              >
+              <span v-if="f.status === 'untracked'" data-testid="df-new" class="flex-none text-[#3fae6b]">new</span>
+              <span v-else class="flex-none">
+                <span class="text-[#3fae6b]">+{{ f.additions < 0 ? "bin" : f.additions }}</span>
+                <span class="text-err-text">−{{ f.deletions < 0 ? "bin" : f.deletions }}</span>
+              </span>
+            </div>
+          </div>
+          <pre
+            v-if="diff && diff.patch"
+            data-testid="cell-diff-patch"
+            class="m-0 flex-auto overflow-auto whitespace-pre p-2 font-mono text-[11px] leading-[1.45] text-secondary [tab-size:2]"
+            >{{ diff.patch }}</pre>
+          <p v-if="diff && diff.truncated" class="m-0 p-2 font-sans text-[11px] text-dim">Diff truncated — open the worktree to see the rest.</p>
+          <p v-if="diff && !diff.files.length" class="m-0 p-2 font-sans text-[11px] text-dim">No changes yet.</p>
+          <div class="flex flex-none items-center gap-2 border-t border-t-border bg-panel px-2 py-1.5">
+            <button
+              data-testid="cell-diff-btn"
+              class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+              :disabled="prBusy || working || (diff?.dirty ?? 0) === 0"
+              :title="(diff?.dirty ?? 0) === 0 ? 'No uncommitted changes' : working ? 'Wait for the session to finish' : 'Ask Claude to commit the changes'"
+              @click="commitViaClaude"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">check</span> Commit
+            </button>
+            <button
+              data-testid="cell-diff-btn"
+              class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+              :disabled="prBusy || (diff?.ahead ?? 0) === 0"
+              :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes first' : 'git push -u origin'"
+              @click="pushBranch"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">arrow_upward</span> Push
+            </button>
+            <button
+              data-testid="cell-diff-btn"
+              class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
+              :disabled="prBusy || (diff?.ahead ?? 0) === 0"
+              :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'Push and open a pull request'"
+              @click="openPR"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">open_in_new</span> Open PR
+            </button>
+            <span v-if="prMsg" data-testid="cell-diff-msg" class="min-w-0 flex-auto truncate font-sans text-[11px] text-dim">{{ prMsg }}</span>
           </div>
         </div>
-        <pre
-          v-if="diff && diff.patch"
-          data-testid="cell-diff-patch"
-          class="m-0 flex-auto overflow-auto whitespace-pre p-2 font-mono text-[11px] leading-[1.45] text-secondary [tab-size:2]"
-          >{{ diff.patch }}</pre>
-        <p v-if="diff && diff.truncated" class="m-0 p-2 font-sans text-[11px] text-dim">Diff truncated — open the worktree to see the rest.</p>
-        <p v-if="diff && !diff.files.length" class="m-0 p-2 font-sans text-[11px] text-dim">No changes yet.</p>
-        <div class="flex flex-none items-center gap-2 border-t border-t-border bg-panel px-2 py-1.5">
-          <button
-            data-testid="cell-diff-btn"
-            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
-            :disabled="prBusy || working || (diff?.dirty ?? 0) === 0"
-            :title="(diff?.dirty ?? 0) === 0 ? 'No uncommitted changes' : working ? 'Wait for the session to finish' : 'Ask Claude to commit the changes'"
-            @click="commitViaClaude"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">check</span> Commit
-          </button>
-          <button
-            data-testid="cell-diff-btn"
-            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
-            :disabled="prBusy || (diff?.ahead ?? 0) === 0"
-            :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes first' : 'git push -u origin'"
-            @click="pushBranch"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">arrow_upward</span> Push
-          </button>
-          <button
-            data-testid="cell-diff-btn"
-            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-3 py-1 font-sans text-[12px] text-secondary enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-not-allowed disabled:opacity-50"
-            :disabled="prBusy || (diff?.ahead ?? 0) === 0"
-            :title="(diff?.ahead ?? 0) === 0 ? 'Commit changes in the terminal first' : 'Push and open a pull request'"
-            @click="openPR"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">open_in_new</span> Open PR
-          </button>
-          <span v-if="prMsg" data-testid="cell-diff-msg" class="min-w-0 flex-auto truncate font-sans text-[11px] text-dim">{{ prMsg }}</span>
-        </div>
-      </div>
-      <div
-        v-if="closeConfirm"
-        data-testid="cell-close-confirm"
-        class="absolute inset-0 z-[25] flex items-center justify-center bg-[color-mix(in_srgb,var(--bg-base)_82%,transparent)] p-4"
-        role="dialog"
-        aria-modal="true"
-        :aria-label="`Close worktree ${headerDir}`"
-      >
-        <div class="flex max-w-[320px] flex-col gap-2.5 rounded-lg border border-border bg-panel p-4 shadow-[0_8px_24px_rgba(0,0,0,0.4)]">
-          <p class="m-0 font-sans text-[13px] font-semibold text-fg">Close {{ headerDir }}</p>
-          <template v-if="!closeError">
-            <p v-if="hasUnsaved" data-testid="ccx-warn" class="m-0 font-sans text-[12px] text-[var(--warn-text,#e0a030)]">
-              {{ unsavedSummary }} will be discarded if you remove the worktree.
-            </p>
-            <p v-else class="m-0 font-sans text-[12px] text-dim">Keep the worktree to reuse it later, or remove it.</p>
-            <div class="flex flex-wrap gap-1.5">
-              <button
-                data-testid="ccx-keep"
-                class="cursor-pointer rounded-md border border-accent bg-elevated px-3 py-1.5 font-sans text-[12px] text-fg hover:bg-hover hover:text-fg"
-                @click="teardown"
-              >
-                Keep worktree
-              </button>
-              <button
-                data-testid="ccx-remove"
-                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-                :disabled="closeChecking"
-                @click="removeAndClose"
-              >
-                {{ closeChecking ? "Checking…" : hasUnsaved ? "Discard &amp; remove" : "Remove worktree" }}
-              </button>
-              <button
-                data-testid="ccx-cancel"
-                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
-                @click="cancelClose"
-              >
-                Cancel
-              </button>
-            </div>
-          </template>
-          <template v-else>
-            <p data-testid="ccx-warn" class="m-0 font-sans text-[12px] text-[var(--warn-text,#e0a030)]">{{ closeError }}</p>
-            <div class="flex flex-wrap gap-1.5">
-              <button
-                data-testid="ccx-remove"
-                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-                @click="removeAndClose"
-              >
-                Retry
-              </button>
-              <button
-                class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
-                @click="teardown"
-              >
-                Close cell
-              </button>
-            </div>
-          </template>
-        </div>
-      </div>
-    </template>
-    <div v-else data-testid="cell-launch" class="flex min-h-0 flex-1 flex-col items-center justify-start gap-2 overflow-y-auto p-4">
-      <button
-        v-if="cancellable"
-        type="button"
-        data-testid="cell-launch-cancel"
-        class="absolute right-1.5 top-1.5 inline-flex h-[26px] w-7 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-[16px] leading-none text-secondary hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-        title="Cancel new terminal"
-        aria-label="Cancel new terminal"
-        @click="emit('close')"
-      >
-        <span class="material-symbols-outlined" aria-hidden="true">close</span>
-      </button>
-      <div v-if="presets.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
-        <span
-          v-for="p in presets"
-          :key="p.label + p.path"
-          data-testid="cell-chip"
-          class="inline-flex items-stretch overflow-hidden rounded-[14px] border"
-          :class="[
-            { 'is-running': isCwdRunning(p.path) },
-            isCwdRunning(p.path)
-              ? 'border-[color-mix(in_srgb,#3b82f6_55%,var(--border))] bg-[color-mix(in_srgb,#3b82f6_14%,var(--bg-elevated))]'
-              : 'border-border bg-elevated',
-          ]"
-          :style="dirChipTint(presetColors[p.path] ?? null, isCwdRunning(p.path))"
+        <div
+          v-if="closeConfirm"
+          data-testid="cell-close-confirm"
+          class="absolute inset-0 z-[25] flex items-center justify-center bg-[color-mix(in_srgb,var(--bg-base)_82%,transparent)] p-4"
+          role="dialog"
+          aria-modal="true"
+          :aria-label="`Close worktree ${headerDir}`"
         >
-          <!-- The directory's colour: a solid stripe down the leading edge, plus a wash over the
+          <div class="flex max-w-[320px] flex-col gap-2.5 rounded-lg border border-border bg-panel p-4 shadow-[0_8px_24px_rgba(0,0,0,0.4)]">
+            <p class="m-0 font-sans text-[13px] font-semibold text-fg">Close {{ headerDir }}</p>
+            <template v-if="!closeError">
+              <p v-if="hasUnsaved" data-testid="ccx-warn" class="m-0 font-sans text-[12px] text-[var(--warn-text,#e0a030)]">
+                {{ unsavedSummary }} will be discarded if you remove the worktree.
+              </p>
+              <p v-else class="m-0 font-sans text-[12px] text-dim">Keep the worktree to reuse it later, or remove it.</p>
+              <div class="flex flex-wrap gap-1.5">
+                <button
+                  data-testid="ccx-keep"
+                  class="cursor-pointer rounded-md border border-accent bg-elevated px-3 py-1.5 font-sans text-[12px] text-fg hover:bg-hover hover:text-fg"
+                  @click="teardown"
+                >
+                  Keep worktree
+                </button>
+                <button
+                  data-testid="ccx-remove"
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+                  :disabled="closeChecking"
+                  @click="removeAndClose"
+                >
+                  {{ closeChecking ? "Checking…" : hasUnsaved ? "Discard &amp; remove" : "Remove worktree" }}
+                </button>
+                <button
+                  data-testid="ccx-cancel"
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                  @click="cancelClose"
+                >
+                  Cancel
+                </button>
+              </div>
+            </template>
+            <template v-else>
+              <p data-testid="ccx-warn" class="m-0 font-sans text-[12px] text-[var(--warn-text,#e0a030)]">{{ closeError }}</p>
+              <div class="flex flex-wrap gap-1.5">
+                <button
+                  data-testid="ccx-remove"
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:border-err-text hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+                  @click="removeAndClose"
+                >
+                  Retry
+                </button>
+                <button
+                  class="cursor-pointer rounded-md border border-border bg-elevated px-3 py-1.5 font-sans text-[12px] text-secondary hover:bg-hover hover:text-fg"
+                  @click="teardown"
+                >
+                  Close cell
+                </button>
+              </div>
+            </template>
+          </div>
+        </div>
+      </template>
+      <div v-else data-testid="cell-launch" class="flex min-h-0 flex-1 flex-col items-center justify-start gap-2 overflow-y-auto p-4">
+        <button
+          v-if="cancellable"
+          type="button"
+          data-testid="cell-launch-cancel"
+          class="absolute right-1.5 top-1.5 inline-flex h-[26px] w-7 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-[16px] leading-none text-secondary hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+          title="Cancel new terminal"
+          aria-label="Cancel new terminal"
+          @click="emit('close')"
+        >
+          <span class="material-symbols-outlined" aria-hidden="true">close</span>
+        </button>
+        <div v-if="presets.length" class="flex max-w-[360px] flex-wrap justify-center gap-1.5">
+          <span
+            v-for="p in presets"
+            :key="p.label + p.path"
+            data-testid="cell-chip"
+            class="inline-flex items-stretch overflow-hidden rounded-[14px] border"
+            :class="[
+              { 'is-running': isCwdRunning(p.path) },
+              isCwdRunning(p.path)
+                ? 'border-[color-mix(in_srgb,#3b82f6_55%,var(--border))] bg-[color-mix(in_srgb,#3b82f6_14%,var(--bg-elevated))]'
+                : 'border-border bg-elevated',
+            ]"
+            :style="dirChipTint(presetColors[p.path] ?? null, isCwdRunning(p.path))"
+          >
+            <!-- The directory's colour: a solid stripe down the leading edge, plus a wash over the
                chip when nothing is running there (dirChipTint). Not a wash while running — that
                background already means "a session is here", and a dir that configured no colour
                has to keep looking exactly as it did. -->
-          <span
-            v-if="presetColors[p.path]"
-            data-testid="cell-chip-color"
-            class="w-[6px] flex-none"
-            :style="{ background: presetColors[p.path] }"
-            aria-hidden="true"
-          />
-          <button
-            type="button"
-            data-testid="cell-chip-main"
-            class="cursor-pointer border-none bg-transparent px-2.5 py-1 font-sans text-[12px] hover:bg-hover hover:text-fg"
-            :class="isCwdRunning(p.path) ? 'text-fg' : 'text-secondary'"
-            :title="p.path"
-            :aria-label="`Use ${p.label} — fill the field to browse / resume here (without launching)`"
-            @click="fillDir(p.path)"
-          >
             <span
-              v-if="isCwdRunning(p.path)"
-              data-testid="cell-chip-dot"
-              class="mr-[5px] inline-block h-1.5 w-1.5 rounded-full bg-[#3b82f6] align-middle"
+              v-if="presetColors[p.path]"
+              data-testid="cell-chip-color"
+              class="w-[6px] flex-none"
+              :style="{ background: presetColors[p.path] }"
               aria-hidden="true"
-            />{{ p.label }}
-          </button>
-          <button
-            type="button"
-            data-testid="cell-chip-launch"
-            class="inline-flex cursor-pointer items-center border-0 border-l border-l-border bg-transparent px-[5px] text-secondary hover:bg-hover hover:text-fg"
-            :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here in another terminal` : `Launch a new terminal in ${p.path} now`"
-            :aria-label="
-              isCwdRunning(p.path) ? `${p.label} — a session is already running here in another terminal` : `Launch a new terminal in ${p.label} now`
-            "
-            @click="selectPreset(p)"
-          >
-            <span class="material-symbols-outlined text-[14px]" aria-hidden="true">play_arrow</span>
-          </button>
-          <button
-            type="button"
-            data-testid="cell-chip-del"
-            class="cursor-pointer border-0 border-l border-l-border bg-transparent px-[7px] text-[11px] text-secondary hover:bg-hover hover:text-[var(--danger,#e5484d)]"
-            :title="`Remove ${p.path} from the list`"
-            :aria-label="`Remove ${p.path} from the list`"
-            @click="emit('remove-preset', p.path)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">close</span>
-          </button>
-        </span>
-      </div>
-      <div class="inline-flex gap-0.5 self-start rounded-[7px] border border-border bg-deep p-0.5" role="radiogroup" aria-label="Agent">
-        <button
-          type="button"
-          class="cursor-pointer rounded-[5px] border-none px-3.5 py-1 font-sans text-[12px] font-medium"
-          :class="agent === 'claude' ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
-          role="radio"
-          :aria-checked="agent === 'claude'"
-          @click="agent = 'claude'"
-        >
-          Claude
-        </button>
-        <button
-          type="button"
-          class="cursor-pointer rounded-[5px] border-none px-3.5 py-1 font-sans text-[12px] font-medium"
-          :class="agent === 'codex' ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
-          role="radio"
-          :aria-checked="agent === 'codex'"
-          @click="agent = 'codex'"
-        >
-          Codex
-        </button>
-      </div>
-      <label class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
-        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Working directory</span>
-        <span class="flex w-full items-stretch gap-1.5">
-          <input
-            v-model="dirInput"
-            data-testid="cell-dir-input"
-            class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] font-mono text-[12px] text-fg focus:border-accent focus:outline-none min-w-0 flex-auto"
-            type="text"
-            placeholder="/path/to/project"
-            spellcheck="false"
-            @input="dirTouched = true"
-            @keydown.enter="launch"
-          />
-          <button
-            type="button"
-            class="flex-none inline-flex items-center justify-center px-2 rounded-md border border-border bg-elevated text-secondary cursor-pointer hover:bg-hover hover:text-fg hover:border-accent"
-            title="Choose a folder…"
-            aria-label="Choose the working directory"
-            @click="pickDir"
-          >
-            <span class="material-symbols-outlined text-[18px]" aria-hidden="true">folder_open</span>
-          </button>
-          <button
-            type="button"
-            data-testid="cell-dir-go"
-            class="inline-flex flex-none cursor-pointer items-center justify-center rounded-md border border-border bg-elevated px-2 text-secondary enabled:hover:border-accent enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40"
-            :disabled="!dirInput.trim()"
-            title="Start a new terminal here (or press Enter)"
-            aria-label="Start a new terminal here"
-            @click="launch"
-          >
-            <span class="material-symbols-outlined text-[18px]" aria-hidden="true">play_arrow</span>
-          </button>
-        </span>
-      </label>
-      <!-- Codex has its own model configuration and doesn't read this one. -->
-      <ModelPicker v-if="agent === 'claude'" v-model="launchChoice" />
-      <div v-if="isGitRepo" data-testid="cell-worktrees" class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5">
-        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
-        <div class="flex gap-1.5">
-          <input
-            v-model="worktreeTask"
-            data-testid="wt-task"
-            class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] font-mono text-[12px] text-fg focus:border-accent focus:outline-none w-auto min-w-0 flex-auto"
-            type="text"
-            placeholder="task name (e.g. fix-login)"
-            aria-label="Worktree task name"
-            spellcheck="false"
-            @keydown.enter="createWorktreeAndLaunch"
-          />
-          <button
-            data-testid="wt-start"
-            class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary flex-none whitespace-nowrap hover:bg-hover hover:text-fg"
-            :disabled="!worktreeTask.trim()"
-            @click="createWorktreeAndLaunch"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">add</span> New worktree
-          </button>
-        </div>
-        <div v-for="w in worktrees" :key="w.path" class="flex items-center gap-1.5">
-          <button
-            class="flex-auto min-w-0 text-left rounded-md border border-border bg-elevated text-secondary cursor-pointer font-mono text-[12px] py-[5px] px-2.5 truncate hover:bg-hover hover:text-fg"
-            data-testid="worktree-reuse"
-            :title="w.branch ?? w.path"
-            @click="reuseWorktree(w)"
-          >
-            ⎇ {{ w.task }}<span v-if="w.dirty" data-testid="wt-dirty" class="ml-1.5 text-[var(--warn-text,#e0a030)]" title="uncommitted changes">●</span>
-          </button>
-          <button
-            data-testid="wt-del"
-            class="flex-none cursor-pointer rounded-md border-none bg-transparent px-1.5 py-1 text-[13px] hover:bg-[var(--err-hover-bg)]"
-            title="Remove worktree"
-            aria-label="Remove worktree"
-            @click="removeWorktree(w)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">delete</span>
-          </button>
-        </div>
-      </div>
-      <div v-if="scripts.length" class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
-        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or run a script</span>
-        <div class="flex w-full flex-wrap justify-center gap-1.5">
-          <button
-            v-for="s in scripts"
-            :key="s.index"
-            data-testid="cell-script-item"
-            class="inline-flex cursor-pointer items-center gap-1 rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
-            :title="s.command"
-            @click="runScript(s)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ s.label }}
-          </button>
-        </div>
-      </div>
-      <div v-if="launchers && launchers.length" class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
-        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or launch</span>
-        <div class="flex w-full flex-wrap justify-center gap-1.5">
-          <button
-            v-for="(l, i) in launchers"
-            :key="l.label"
-            data-testid="cell-script-item"
-            class="inline-flex cursor-pointer items-center gap-1 rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
-            :title="l.command"
-            @click="launchProgram(i, l)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">rocket_launch</span> {{ l.label }}
-          </button>
-        </div>
-      </div>
-      <div v-if="resumable.length" data-testid="cell-resume" class="flex min-h-0 w-full max-w-[360px] flex-col items-center gap-1.5">
-        <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or resume here</span>
-        <div class="flex w-full flex-col gap-1">
-          <button
-            v-for="s in resumable"
-            :key="s.id"
-            data-testid="cell-resume-item"
-            class="flex cursor-pointer items-baseline justify-between gap-2 rounded-md border bg-deep px-2.5 py-[5px] text-left font-sans text-[12px] text-secondary hover:border-accent hover:bg-elevated"
-            :class="[{ 'is-open': sessionOpenElsewhere(s.id) }, sessionOpenElsewhere(s.id) ? 'border-amber' : 'border-border']"
-            :title="sessionOpenElsewhere(s.id) ? `${s.title} — already open in another terminal` : s.title"
-            @click="resume(s)"
-          >
-            <span data-testid="ri-title" class="truncate">{{ s.title }}</span>
-            <span
-              v-if="sessionOpenElsewhere(s.id)"
-              data-testid="ri-open"
-              class="flex-none whitespace-nowrap text-[11px] text-amber"
-              title="Already open in another terminal"
-              >● open</span
+            />
+            <button
+              type="button"
+              data-testid="cell-chip-main"
+              class="cursor-pointer border-none bg-transparent px-2.5 py-1 font-sans text-[12px] hover:bg-hover hover:text-fg"
+              :class="isCwdRunning(p.path) ? 'text-fg' : 'text-secondary'"
+              :title="p.path"
+              :aria-label="`Use ${p.label} — fill the field to browse / resume here (without launching)`"
+              @click="fillDir(p.path)"
             >
-            <span class="flex-none text-[11px] text-dim">{{ relativeTime(s.mtime) }}</span>
+              <span
+                v-if="isCwdRunning(p.path)"
+                data-testid="cell-chip-dot"
+                class="mr-[5px] inline-block h-1.5 w-1.5 rounded-full bg-[#3b82f6] align-middle"
+                aria-hidden="true"
+              />{{ p.label }}
+            </button>
+            <button
+              type="button"
+              data-testid="cell-chip-launch"
+              class="inline-flex cursor-pointer items-center border-0 border-l border-l-border bg-transparent px-[5px] text-secondary hover:bg-hover hover:text-fg"
+              :title="isCwdRunning(p.path) ? `${p.path} — a session is already running here in another terminal` : `Launch a new terminal in ${p.path} now`"
+              :aria-label="
+                isCwdRunning(p.path) ? `${p.label} — a session is already running here in another terminal` : `Launch a new terminal in ${p.label} now`
+              "
+              @click="selectPreset(p)"
+            >
+              <span class="material-symbols-outlined text-[14px]" aria-hidden="true">play_arrow</span>
+            </button>
+            <button
+              type="button"
+              data-testid="cell-chip-del"
+              class="cursor-pointer border-0 border-l border-l-border bg-transparent px-[7px] text-[11px] text-secondary hover:bg-hover hover:text-[var(--danger,#e5484d)]"
+              :title="`Remove ${p.path} from the list`"
+              :aria-label="`Remove ${p.path} from the list`"
+              @click="emit('remove-preset', p.path)"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">close</span>
+            </button>
+          </span>
+        </div>
+        <div class="inline-flex gap-0.5 self-start rounded-[7px] border border-border bg-deep p-0.5" role="radiogroup" aria-label="Agent">
+          <button
+            type="button"
+            class="cursor-pointer rounded-[5px] border-none px-3.5 py-1 font-sans text-[12px] font-medium"
+            :class="agent === 'claude' ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
+            role="radio"
+            :aria-checked="agent === 'claude'"
+            @click="agent = 'claude'"
+          >
+            Claude
           </button>
+          <button
+            type="button"
+            class="cursor-pointer rounded-[5px] border-none px-3.5 py-1 font-sans text-[12px] font-medium"
+            :class="agent === 'codex' ? 'bg-elevated text-fg' : 'bg-transparent text-dim hover:text-fg'"
+            role="radio"
+            :aria-checked="agent === 'codex'"
+            @click="agent = 'codex'"
+          >
+            Codex
+          </button>
+        </div>
+        <label class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Working directory</span>
+          <span class="flex w-full items-stretch gap-1.5">
+            <input
+              v-model="dirInput"
+              data-testid="cell-dir-input"
+              class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] font-mono text-[12px] text-fg focus:border-accent focus:outline-none min-w-0 flex-auto"
+              type="text"
+              placeholder="/path/to/project"
+              spellcheck="false"
+              @input="dirTouched = true"
+              @keydown.enter="launch"
+            />
+            <button
+              type="button"
+              class="flex-none inline-flex items-center justify-center px-2 rounded-md border border-border bg-elevated text-secondary cursor-pointer hover:bg-hover hover:text-fg hover:border-accent"
+              title="Choose a folder…"
+              aria-label="Choose the working directory"
+              @click="pickDir"
+            >
+              <span class="material-symbols-outlined text-[18px]" aria-hidden="true">folder_open</span>
+            </button>
+            <button
+              type="button"
+              data-testid="cell-dir-go"
+              class="inline-flex flex-none cursor-pointer items-center justify-center rounded-md border border-border bg-elevated px-2 text-secondary enabled:hover:border-accent enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40"
+              :disabled="!dirInput.trim()"
+              title="Start a new terminal here (or press Enter)"
+              aria-label="Start a new terminal here"
+              @click="launch"
+            >
+              <span class="material-symbols-outlined text-[18px]" aria-hidden="true">play_arrow</span>
+            </button>
+          </span>
+        </label>
+        <!-- Codex has its own model configuration and doesn't read this one. -->
+        <ModelPicker v-if="agent === 'claude'" v-model="launchChoice" />
+        <div v-if="isGitRepo" data-testid="cell-worktrees" class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5">
+          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
+          <div class="flex gap-1.5">
+            <input
+              v-model="worktreeTask"
+              data-testid="wt-task"
+              class="box-border w-full rounded-md border border-border bg-input px-2.5 py-[7px] font-mono text-[12px] text-fg focus:border-accent focus:outline-none w-auto min-w-0 flex-auto"
+              type="text"
+              placeholder="task name (e.g. fix-login)"
+              aria-label="Worktree task name"
+              spellcheck="false"
+              @keydown.enter="createWorktreeAndLaunch"
+            />
+            <button
+              data-testid="wt-start"
+              class="inline-flex cursor-pointer items-center gap-1 rounded-md border border-border bg-elevated px-4 py-[7px] font-sans text-[14px] font-medium text-secondary flex-none whitespace-nowrap hover:bg-hover hover:text-fg"
+              :disabled="!worktreeTask.trim()"
+              @click="createWorktreeAndLaunch"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">add</span> New worktree
+            </button>
+          </div>
+          <div v-for="w in worktrees" :key="w.path" class="flex items-center gap-1.5">
+            <button
+              class="flex-auto min-w-0 text-left rounded-md border border-border bg-elevated text-secondary cursor-pointer font-mono text-[12px] py-[5px] px-2.5 truncate hover:bg-hover hover:text-fg"
+              data-testid="worktree-reuse"
+              :title="w.branch ?? w.path"
+              @click="reuseWorktree(w)"
+            >
+              ⎇ {{ w.task }}<span v-if="w.dirty" data-testid="wt-dirty" class="ml-1.5 text-[var(--warn-text,#e0a030)]" title="uncommitted changes">●</span>
+            </button>
+            <button
+              data-testid="wt-del"
+              class="flex-none cursor-pointer rounded-md border-none bg-transparent px-1.5 py-1 text-[13px] hover:bg-[var(--err-hover-bg)]"
+              title="Remove worktree"
+              aria-label="Remove worktree"
+              @click="removeWorktree(w)"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">delete</span>
+            </button>
+          </div>
+        </div>
+        <div v-if="scripts.length" class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or run a script</span>
+          <div class="flex w-full flex-wrap justify-center gap-1.5">
+            <button
+              v-for="s in scripts"
+              :key="s.index"
+              data-testid="cell-script-item"
+              class="inline-flex cursor-pointer items-center gap-1 rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
+              :title="s.command"
+              @click="runScript(s)"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">play_arrow</span> {{ s.label }}
+            </button>
+          </div>
+        </div>
+        <div v-if="launchers && launchers.length" class="flex w-full max-w-[360px] flex-col items-center gap-1.5">
+          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or launch</span>
+          <div class="flex w-full flex-wrap justify-center gap-1.5">
+            <button
+              v-for="(l, i) in launchers"
+              :key="l.label"
+              data-testid="cell-script-item"
+              class="inline-flex cursor-pointer items-center gap-1 rounded-[14px] border border-[#2a4e3a] bg-[#16271d] px-2.5 py-1 font-sans text-[12px] text-[#b6e3c7] hover:border-[#3fae6b] hover:bg-[#1f3a2a] hover:text-white"
+              :title="l.command"
+              @click="launchProgram(i, l)"
+            >
+              <span class="material-symbols-outlined" aria-hidden="true">rocket_launch</span> {{ l.label }}
+            </button>
+          </div>
+        </div>
+        <div v-if="resumable.length" data-testid="cell-resume" class="flex min-h-0 w-full max-w-[360px] flex-col items-center gap-1.5">
+          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or resume here</span>
+          <div class="flex w-full flex-col gap-1">
+            <button
+              v-for="s in resumable"
+              :key="s.id"
+              data-testid="cell-resume-item"
+              class="flex cursor-pointer items-baseline justify-between gap-2 rounded-md border bg-deep px-2.5 py-[5px] text-left font-sans text-[12px] text-secondary hover:border-accent hover:bg-elevated"
+              :class="[{ 'is-open': sessionOpenElsewhere(s.id) }, sessionOpenElsewhere(s.id) ? 'border-amber' : 'border-border']"
+              :title="sessionOpenElsewhere(s.id) ? `${s.title} — already open in another terminal` : s.title"
+              @click="resume(s)"
+            >
+              <span data-testid="ri-title" class="truncate">{{ s.title }}</span>
+              <span
+                v-if="sessionOpenElsewhere(s.id)"
+                data-testid="ri-open"
+                class="flex-none whitespace-nowrap text-[11px] text-amber"
+                title="Already open in another terminal"
+                >● open</span
+              >
+              <span class="flex-none text-[11px] text-dim">{{ relativeTime(s.mtime) }}</span>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -697,7 +697,10 @@ watch(
 
 /* The keyboard-focused cell lifts and grows slightly, in place — tiled grid only, so it never
    applies to a filmstrip thumbnail (.stage.zoomed) or a cell mid-FLIP. The transform doesn't change
-   the cell's layout size, so xterm isn't refit and the PTY isn't resized. */
+   the cell's layout size, so xterm isn't refit and the PTY isn't resized.
+   What grows is the FRAME: the cell's content (CELL_INNER) cancels this scale out about the same
+   centre, because the terminal is a canvas and scaling a canvas resamples it (#965). The factor is
+   a token for that reason — a literal here would silently stop matching the inverse. */
 .stage:not(.zoomed) .grid > *:not(.flipping) {
   transition:
     transform 140ms ease,
@@ -705,7 +708,7 @@ watch(
 }
 
 .stage:not(.zoomed) .grid > .focused {
-  transform: scale(1.03);
+  transform: scale(var(--focus-zoom));
   z-index: 5;
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
 }

--- a/src/components/cellChromeClasses.ts
+++ b/src/components/cellChromeClasses.ts
@@ -8,7 +8,20 @@
 // styling now, so the specs that select on them aren't coupled to how a cell looks.
 
 export const CELL_FRAME =
-  "flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-[var(--cell-border,var(--border))] bg-[var(--cell-bg,var(--bg-base))]";
+  "group/cell flex min-h-0 min-w-0 flex-col overflow-hidden rounded-md border border-[var(--cell-border,var(--border))] bg-[var(--cell-bg,var(--bg-base))]";
+
+// Everything inside a cell lives in one wrapper so the focus zoom can cancel itself out.
+// The focused cell scales up by --focus-zoom (TerminalGrid's `.focused`); this scales back down by
+// the inverse OF THE SAME TOKEN, and because the wrapper's box is the cell's own box the two share
+// a centre — the content's composed transform is exactly identity, so the terminal's canvas keeps
+// its 1:1 rasterisation while the frame around it grows (#965).
+//
+// It has to wrap ALL of the cell's children, header included. A wrapper that starts below the
+// header has its own centre, and cancelling about the wrong centre leaves a sub-pixel translation
+// which blurs the canvas just the same — measured at 14% of the canvas's pixels changed, against
+// 0% for this.
+export const CELL_INNER =
+  "flex min-h-0 min-w-0 flex-1 flex-col transition-transform duration-[140ms] ease-[ease] group-[.focused]/cell:scale-[calc(1/var(--focus-zoom))] motion-reduce:transition-none";
 
 export const CELL_HEADER = "flex h-[34px] flex-none items-center gap-2 border-b border-b-border bg-[var(--cell-header-bg,var(--bg-panel))] px-2";
 

--- a/src/style.css
+++ b/src/style.css
@@ -128,6 +128,15 @@
   --err-hover-bg: #3a2030;
 }
 
+/* How much the keyboard-focused grid cell grows. The cell scales up by this; everything inside it
+   scales down by calc(1 / this) about the same centre (CELL_INNER), so the content ends up with an
+   identity transform and the terminal's canvas is still rasterised 1:1. A canvas composited at any
+   other scale is resampled — that was the blur in #965, where 1.03 alone changed 22% of the
+   canvas's pixels. One token so the two sides cannot drift apart. */
+:root {
+  --focus-zoom: 1.03;
+}
+
 /* Light themes: status pills become light-tinted with dark, saturated text so
    they stay legible on a bright background. */
 :root[data-theme="daylight"],

--- a/test/src/components/CommandCell.spec.ts
+++ b/test/src/components/CommandCell.spec.ts
@@ -30,6 +30,15 @@ const jsonResponse = (body: unknown, status = 200) => new Response(JSON.stringif
 describe("CommandCell", () => {
   afterEach(() => vi.unstubAllGlobals());
 
+  // #965: the whole cell — header included — sits in one wrapper, so the focus zoom can be
+  // cancelled about the cell's own centre. A second element child, or content left outside the
+  // wrapper, would scale with the frame and resample the terminal's canvas.
+  it("keeps its whole content in the focus-zoom wrapper", () => {
+    const root = mountCell().element;
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].className).toContain("group-[.focused]/cell:scale-[calc(1/var(--focus-zoom))]");
+  });
+
   it("shows the label + dir and runs the command in its directory", () => {
     const w = mountCell();
     expect(w.find(".cell-cmd").text()).toContain("Dev server");

--- a/test/src/components/LauncherCell.spec.ts
+++ b/test/src/components/LauncherCell.spec.ts
@@ -18,6 +18,15 @@ const baseProps = { uid: 7, expanded: false, launcher: LAUNCHER, session: null, 
 const mountCell = (extra: Record<string, unknown> = {}) => mount(LauncherCell, { props: { ...baseProps, ...extra } });
 
 describe("LauncherCell header zoom", () => {
+  // #965: the whole cell — header included — sits in one wrapper, so the focus zoom can be
+  // cancelled about the cell's own centre. A second element child, or content left outside the
+  // wrapper, would scale with the frame and resample the terminal's canvas.
+  it("keeps its whole content in the focus-zoom wrapper", () => {
+    const root = mountCell().element;
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].className).toContain("group-[.focused]/cell:scale-[calc(1/var(--focus-zoom))]");
+  });
+
   it("shows the label + dir and runs the configured launcher in its directory", () => {
     const w = mountCell();
     expect(w.find(".cell-cmd").text()).toContain("zsh");

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -98,6 +98,15 @@ function mountCell(
 }
 
 describe("TerminalCell", () => {
+  // #965: the whole cell — header included — sits in one wrapper, so the focus zoom can be
+  // cancelled about the cell's own centre. A second element child, or content left outside the
+  // wrapper, would scale with the frame and resample the terminal's canvas.
+  it("keeps its whole content in the focus-zoom wrapper", () => {
+    const root = mountCell(null).element;
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0].className).toContain("group-[.focused]/cell:scale-[calc(1/var(--focus-zoom))]");
+  });
+
   it("shows the ~-anchored workspace path in the header", async () => {
     const w = mountCell("11111111-1111-1111-1111-111111111111", { initialCwd: "/home/me/ss/my-project" });
     await flushPromises();

--- a/test/src/components/focusZoom.spec.ts
+++ b/test/src/components/focusZoom.spec.ts
@@ -1,0 +1,28 @@
+// The focused cell grows; its contents shrink by the inverse of the SAME token, so the composition
+// is identity and the terminal's canvas is still rasterised 1:1. Measured against Chromium, scaling
+// the canvas by 1.03 changes 22% of its pixels, and cancelling about the wrong centre still changes
+// 14% (#965) — so what these guard is that neither side grows a literal of its own. #331 already
+// retuned this scale once; the next tweak has to move one token and stay cancelled.
+import { describe, it, expect } from "vitest";
+import terminalGridSource from "../../../src/components/TerminalGrid.vue?raw";
+import terminalCellSource from "../../../src/components/TerminalCell.vue?raw";
+import { CELL_FRAME, CELL_INNER } from "../../../src/components/cellChromeClasses";
+
+describe("focus zoom", () => {
+  it("scales the focused cell by the token, not a literal", () => {
+    expect(terminalGridSource).toContain("transform: scale(var(--focus-zoom))");
+    expect(terminalGridSource).not.toMatch(/transform:\s*scale\(1\./);
+  });
+
+  it("cancels exactly that scale on the cell's contents", () => {
+    expect(CELL_INNER).toContain("scale-[calc(1/var(--focus-zoom))]");
+    expect(CELL_INNER).toContain("group-[.focused]/cell:");
+  });
+
+  // The variant above only matches inside an ancestor carrying the group name, so a cell that
+  // loses it keeps its contents at full size and blurs again — without failing anything else.
+  it("names the group on every cell's frame", () => {
+    expect(CELL_FRAME).toContain("group/cell");
+    expect(terminalCellSource).toContain("group/cell");
+  });
+});


### PR DESCRIPTION
## Summary

フォーカスしたセルの in-place zoom 中にターミナルの文字がぼやける問題（#965）。**zoom は残したまま、育てるのを枠だけにする**。セルは今まで通り `scale(1.03)` で拡大し、セルの中身は同じトークンの逆数で打ち消して合成変換を厳密に恒等にするので、canvas は 1:1 のまま描かれる。文字の大きさは変わらない。

Fixes #965

## Items to Confirm / Review

1. **見た目を人が見てほしい。** ピクセル比較が保証するのは「文字がぼけない」ことだけです。「枠が 3% 育って中身は据え置き（＝内側の余白が数 px 広がる）」が意図通りかは実機で見ないと分かりません。CI が回っている間に確認をお願いします。
2. **`.vue` の差分はほぼ全部インデントです。** 中身を 1 枚のラッパーで包んだので prettier が全体を 2 スペース寄せました。`git diff -w` だと 71 行の追加・5 行の削除で、そちらが本当の変更です。
3. **中身を全部（ヘッダ含めて）1 枚のラッパーに入れている**のは意図的です。ターミナルだけを逆スケールすると中心がセルの中心とずれ、0.4px の並進が残って canvas が再サンプリングされます（実測で 14% のピクセルが変化）。テストはこのラッパーがセルの唯一の子であることを固定しています。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/965
>
> zoomするのは維持したい

（どの直し方にするかは、枠だけ拡大 / 実サイズで拡大して refit / フォーカス中だけ DOM レンダラ の 3 案から「枠だけ拡大」を選択いただきました。）

## 原因

#309 の設計メモ (`plans/feat-grid-active-zoom.md:12`) は「このアプリは xterm を **DOM レンダラ**（canvas 無し）で描くので、実 DOM テキストを拡大しても crisp のまま」を根拠にしていました。zoom が入った `535fe68`（2026-07-11 19:34）の時点では正しい前提です。

その 8 時間後、`b12cc48`（2026-07-12 03:47 "render the terminal with the canvas renderer to stop CJK drift"）で **CanvasAddon** が入り（`src/composables/useTerminalConnections.ts:421`）、ターミナルの中身は解像度固定のビットマップになりました。canvas のバッキングストアは「CSS サイズ × devicePixelRatio」で決まり、CSS transform では再描画されません。`transform: scale(1.03)` はそのビットマップを引き伸ばすだけで、非整数倍率の再サンプリングがにじみになります。zoom 側にも canvas 側にも単体の誤りは無く、前提が別コミットで崩れた形です。

## Chromium で実測して選んだ

puppeteer + sharp で、同じ canvas を同じページ座標に描き、変換なしの基準画像とピクセル比較しました（DPR 2、枠の移動が混ざる外周 6px を除いたテキスト領域）:

| 変え方 | 基準と異なるチャンネル |
|---|---|
| 今の `scale(1.03)` のみ | **21.85%**（平均差 24.1）|
| 中身を「自分の中心」で逆スケール | **13.96%** |
| 中身を「セルの中心」で逆スケール（本 PR） | **0.000%** |
| セルは拡大せず枠レイヤーだけ拡大 | **0.000%** |

逆スケールの中心がずれると直らない、が要点です。

## 変更

- `src/style.css`: `--focus-zoom: 1.03` を 1 つだけ。逆数は別トークンにせず `calc(1 / var(--focus-zoom))` で導出（2 つ置くと数値がずれ得る）。
- `TerminalGrid.vue`: `.focused` は `scale(var(--focus-zoom))`。リテラルをやめたのは、#331 で一度この倍率を調整しており、片側だけ変わると静かににじみが戻るためです。
- `cellChromeClasses.ts`: `CELL_INNER` を追加し、`CELL_FRAME` と TerminalCell のルートに `group/cell`。scoped CSS では子コンポーネントの内部に届かない（#787、同ファイル冒頭に理由あり）ので、ユーティリティで持たせています。
- TerminalCell / CommandCell / LauncherCell: 中身を `CELL_INNER` のラッパーで包む。

レイアウトサイズは transform では変わらないので、xterm の refit も PTY のリサイズも起きません（#309 の性質はそのまま）。

## テスト

- `focusZoom.spec.ts` — grid 側がトークンで拡大していること、`CELL_INNER` が同じトークンの逆数で打ち消していること、`group/cell` が全セルのフレームにあること（変異の芯: 倍率をリテラルに戻す、片側だけ変える、group 名を落とす、のいずれもテストで落ちる）
- 3 つのセルの spec に「中身が 1 枚のラッパーに入っている」ことの mount テスト

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（5090 passed）/ `build` 実行済み。

## 別途見つかった既存不具合（この PR では直していません）

`TimelineOverlay`（履歴モーダル、`fixed inset-0`）はセルの中に描かれているため、**セルがフォーカス中は画面全体ではなくセルの矩形に押し込められます**。transform を持つ祖先が fixed の containing block になるためで、本 PR の前から同じ挙動です（実測: 変更前 800x600 → 328x245、変更後も同様）。別 issue を立てます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
