### PR TITLE
docs: chip-colour plan に残った 3px の古い記述を削除する

### DIFF
--- a/plans/feat-949-chip-dir-colors.md
+++ b/plans/feat-949-chip-dir-colors.md
@@ -12,9 +12,8 @@ chip's label (a bare basename — `proj`, `web`, `api`) is doing the work alone.
 
 ## What
 
-Each chip gets a 3px stripe down its leading edge in that directory's colour.
-
-A 6px stripe, plus a wash over the chip's background and border in the same colour.
+A 6px stripe down each chip's leading edge in that directory's colour, plus a wash over its
+background and border in the same colour.
 
 **The wash is dropped while a session is running there.** That chip's blue means "a session is
 already here" — a state, not an identity. Two meanings on one background is how both stop being


### PR DESCRIPTION
## Summary

`plans/feat-949-chip-dir-colors.md`（#951 でマージ済み）の "What" が、**実装と食い違う古い一文**で
始まっていた。

ストライプを 3px → 6px に太くしたとき、新しい記述を足したまま**置き換えたはずの文を消し忘れた**ため、

```
Each chip gets a 3px stripe down its leading edge in that directory's colour.

A 6px stripe, plus a wash over the chip's background and border in the same colour.
```

と 2 つ並んでいた。前者を削除して 1 文に統合する。

## Items to Confirm / Review

- **同じ段落の下にある「最初は 3px だった、実機で見て太くした」という経緯の記述はそのまま残している。**
  plan file は「なぜそうしたか」の記録なので、変更の経緯は残すべきで、消すべきなのは
  **現在の実装を誤って説明している行**だけ、という切り分け。
- ドキュメントのみの変更。コードには一切触れていない。

## User Prompt

> なおして。

（直前に、`plans/feat-949-chip-dir-colors.md` に 3px の古い記述が残って現在の実装と矛盾している旨を
報告し、直すかどうか確認した流れ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2