### PR TITLE
fix: Opus 5 の ctx が 100% を超える — CONTEXT_WINDOWS に opus-5 を追加し、ありえない % は表示しない

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,7 +876,9 @@ Each grid cell's header shows two badges for its session, refreshed when a turn 
   current-gen Opus / Sonnet / Fable / Mythos, **200k** otherwise). A session running on a
   [provider model](#agents-claude--codex) shows that model's name and its published window
   (`Kimi K2.7 Code · ctx 12%`); a model in neither list keeps the label and hides the %,
-  since the window is never guessed.
+  since the window is never guessed. A reading **past 100%** shows `ctx ?` instead of the
+  number: the window is a hard cap, so an impossible percentage means the built-in window
+  table is out of date for that model rather than that the session is over-full.
 - **Token badge** — `⇡<in> ⇣<out>`: cumulative input (fresh + cache-read + cache-creation)
   and output tokens for the session, k/M-formatted, with a full breakdown in the tooltip.
 

--- a/plans/fix-985-context-window-opus-5.md
+++ b/plans/fix-985-context-window-opus-5.md
@@ -1,0 +1,52 @@
+# `ctx` reads above 100% because the window table has no `opus-5`
+
+Issue: #985
+
+## What it is
+
+`Opus · ctx 290%` on a real session. `CONTEXT_WINDOWS` in `ModelContextBadge.vue` is an ordered
+substring list, first hit wins, and `claude-opus-5` matches none of `opus-4-6` / `opus-4-7` /
+`opus-4-8`. It falls through to the `{ match: "opus", tokens: 200k }` fallback and is divided by
+200,000 instead of 1,000,000 — exactly 5× too large, which is where 580k used reads as 290%.
+
+`sonnet-5` is in the list. `opus-5` was never added alongside it.
+
+The file's own comment predicted this: *"Add new 1M model ids here when they ship — otherwise a
+full session over-reports (e.g. a 1M model shown against 200k reads as ~500%)."* The mechanism is
+working as designed; the table was not kept current.
+
+## The fix
+
+1. **`{ match: "opus-5", tokens: MILLION_TOKENS }`, before the `opus` fallback.** Order is load
+   bearing in a first-hit list.
+2. **A percentage over 100% is treated as a gap in the table, not as a number.** The badge shows
+   `ctx ?` and the tooltip says the window is unknown.
+
+Point 2 is the part worth arguing about, so: this table needs a hand edit every time a model
+generation ships, and the next omission is a matter of when. Three ways to fail, and only one of
+them is acceptable:
+
+- **Print the wrong number** (today). 290% is confidently, precisely wrong. A reader who trusts
+  the badge mismanages a session on it.
+- **Clamp to 100%.** Worse than today — the failure becomes invisible, and "full" is a plausible
+  enough reading that nobody files an issue.
+- **Say we don't know.** `ctx ?` is visibly odd, so it still gets reported (this bug was found
+  precisely *because* 290% looked wrong), but nobody acts on it as if it were a measurement.
+
+We already refuse to guess a window for an unknown model — no `ctx` at all in that case. An
+impossible percentage is the same admission arriving later, so it gets the same answer.
+
+## Audit of the rest of the table
+
+Checked against the current model list rather than fixed one row and moved on. `opus-5` is the only
+gap: Fable 5, Mythos 5, Opus 4.6/4.7/4.8 and Sonnet 4.6/5 are all present at 1M; Haiku 4.5 (200k)
+and the pre-4.6 Opus/Sonnet generations (200k) are correctly served by the fallbacks.
+
+## Where the code goes
+
+The decision — which window, what percentage, what to show when neither is knowable — moves out of
+`ModelContextBadge.vue` into `src/components/modelContextBadge.ts` and is unit tested directly, per
+CLAUDE.md's rule that logic must not live where only a mount can reach it. The component keeps the
+markup and the three `computed`s that read the result. The existing mount spec keeps the wiring
+assertions (renders / does not render, tooltip is attached); the table and the arithmetic are
+tested without mounting.

--- a/plans/fix-985-context-window-opus-5.md
+++ b/plans/fix-985-context-window-opus-5.md
@@ -45,8 +45,13 @@ and the pre-4.6 Opus/Sonnet generations (200k) are correctly served by the fallb
 ## Where the code goes
 
 The decision — which window, what percentage, what to show when neither is knowable — moves out of
-`ModelContextBadge.vue` into `src/components/modelContextBadge.ts` and is unit tested directly, per
+`ModelContextBadge.vue` into `src/components/modelBadge.ts` and is unit tested directly, per
 CLAUDE.md's rule that logic must not live where only a mount can reach it. The component keeps the
-markup and the three `computed`s that read the result. The existing mount spec keeps the wiring
-assertions (renders / does not render, tooltip is attached); the table and the arithmetic are
-tested without mounting.
+markup and one `computed` that reads the result. The existing mount spec keeps the wiring assertions
+(renders / does not render, tooltip is attached); the table and the arithmetic are tested without
+mounting.
+
+`modelBadge.ts` rather than `modelContextBadge.ts`, because its spec would then be
+`modelContextBadge.spec.ts` — the same file as `ModelContextBadge.spec.ts` on a case-insensitive
+filesystem. macOS would silently merge the two; Linux CI would not, so the break would only ever
+show up on a developer's machine.

--- a/src/components/ModelContextBadge.vue
+++ b/src/components/ModelContextBadge.vue
@@ -1,83 +1,20 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { presetFor } from "./modelOption";
+import { modelBadge, type BadgeAgent } from "./modelBadge";
 
-// Which model is running + how full its context is, e.g. `Opus · ctx 35%`. Model
-// and contextTokens come from the transcript (server /api/session/:id); the agent
-// kind is known client-side. Unknown models keep the label but hide the %.
+// Which model is running + how full its context is, e.g. `Opus · ctx 35%`. Nothing renders until
+// the transcript has told us the model; the text and tooltip are decided in ./modelBadge.
 const props = defineProps<{
-  agent: "claude" | "codex";
+  agent: BadgeAgent;
   model: string | null;
   contextTokens: number;
 }>();
 
-// Substring → short label for Claude's model families; matched case-insensitively.
-// Anything else (a codex model, a future provider) falls back to the id's tail.
-const CLAUDE_FAMILIES = [
-  { match: "opus", label: "Opus" },
-  { match: "sonnet", label: "Sonnet" },
-  { match: "haiku", label: "Haiku" },
-  { match: "fable", label: "Fable" },
-  { match: "mythos", label: "Mythos" },
-];
-
-const MILLION_TOKENS = 1_000_000;
-const K200_TOKENS = 200_000;
-// Context window per model, matched as an ordered substring list (first hit wins) against the
-// lowercased model id. The current Claude generation ships a 1M window — Opus 4.6+, Sonnet 4.6+,
-// Fable, Mythos — so those are listed explicitly; everything else (older Opus/Sonnet, all Haiku)
-// falls through to the 200k default. Add new 1M model ids here when they ship — otherwise a
-// full session over-reports (e.g. a 1M model shown against 200k reads as ~500%). A model matched
-// by neither list (a codex/other-provider id) shows its label but no % — we never guess a window.
-const CONTEXT_WINDOWS: { match: string; tokens: number }[] = [
-  { match: "opus-4-6", tokens: MILLION_TOKENS },
-  { match: "opus-4-7", tokens: MILLION_TOKENS },
-  { match: "opus-4-8", tokens: MILLION_TOKENS },
-  { match: "sonnet-4-6", tokens: MILLION_TOKENS },
-  { match: "sonnet-5", tokens: MILLION_TOKENS },
-  { match: "fable", tokens: MILLION_TOKENS },
-  { match: "mythos", tokens: MILLION_TOKENS },
-  { match: "opus", tokens: K200_TOKENS },
-  { match: "sonnet", tokens: K200_TOKENS },
-  { match: "haiku", tokens: K200_TOKENS },
-];
-const PERCENT = 100;
-
-const AGENT_NAME: Record<"claude" | "codex", string> = { claude: "Claude", codex: "Codex" };
-
-function shortModelLabel(model: string): string {
-  const preset = presetFor(model);
-  if (preset) return preset.label;
-  const lower = model.toLowerCase();
-  const family = CLAUDE_FAMILIES.find((f) => lower.includes(f.match));
-  return family ? family.label : (model.split("/").pop() ?? model);
-}
-
-function contextWindowTokens(model: string): number | null {
-  // A preset carries the window its provider publishes, so a session on one shows a real
-  // % instead of nothing — the substring lists below only know Claude's own families.
-  const preset = presetFor(model);
-  if (preset?.contextLength) return preset.contextLength;
-  const lower = model.toLowerCase();
-  const entry = CONTEXT_WINDOWS.find((w) => lower.includes(w.match));
-  return entry ? entry.tokens : null;
-}
-
-const label = computed(() => (props.model ? shortModelLabel(props.model) : null));
-const windowTokens = computed(() => (props.model ? contextWindowTokens(props.model) : null));
-const ctxPercent = computed(() => (windowTokens.value ? Math.round((props.contextTokens / windowTokens.value) * PERCENT) : null));
-const badgeText = computed(() => (ctxPercent.value !== null ? `${label.value} · ctx ${ctxPercent.value}%` : label.value));
-
-const title = computed(() => {
-  if (!props.model) return "";
-  const used = props.contextTokens.toLocaleString();
-  const window = windowTokens.value ? ` / ${windowTokens.value.toLocaleString()} (${ctxPercent.value}%)` : "";
-  return `${AGENT_NAME[props.agent]} · ${props.model} · context ${used}${window} tokens`;
-});
+const badge = computed(() => (props.model ? modelBadge(props.agent, props.model, props.contextTokens) : null));
 </script>
 
 <template>
-  <span v-if="label" data-testid="model-badge" class="flex-none font-mono text-[10px] text-dim whitespace-nowrap tracking-[0.02em]" :title="title">{{
-    badgeText
+  <span v-if="badge" data-testid="model-badge" class="flex-none font-mono text-[10px] text-dim whitespace-nowrap tracking-[0.02em]" :title="badge.title">{{
+    badge.text
   }}</span>
 </template>

--- a/src/components/modelBadge.ts
+++ b/src/components/modelBadge.ts
@@ -1,0 +1,90 @@
+// What the model badge says: which model a cell is running, and how full its context is.
+// The model id and token count come from the transcript (server /api/session/:id); the agent kind
+// is known client-side.
+import { presetFor } from "./modelOption";
+
+// Substring → short label for Claude's model families, matched case-insensitively. Anything else
+// (a codex model, a future provider) falls back to the id's tail.
+const CLAUDE_FAMILIES = [
+  { match: "opus", label: "Opus" },
+  { match: "sonnet", label: "Sonnet" },
+  { match: "haiku", label: "Haiku" },
+  { match: "fable", label: "Fable" },
+  { match: "mythos", label: "Mythos" },
+];
+
+const MILLION_TOKENS = 1_000_000;
+const K200_TOKENS = 200_000;
+// Context window per model, an ordered substring list (first hit wins) against the lowercased id.
+// The current Claude generation ships a 1M window — Opus 4.6+ and 5, Sonnet 4.6+ and 5, Fable,
+// Mythos — so those are listed explicitly; older Opus/Sonnet and every Haiku fall through to the
+// 200k entries. Add new 1M ids here when they ship, ahead of the bare-family fallbacks, or the
+// fallback claims them and the reading comes out 5x too large (#985).
+const CONTEXT_WINDOWS: { match: string; tokens: number }[] = [
+  { match: "opus-4-6", tokens: MILLION_TOKENS },
+  { match: "opus-4-7", tokens: MILLION_TOKENS },
+  { match: "opus-4-8", tokens: MILLION_TOKENS },
+  { match: "opus-5", tokens: MILLION_TOKENS },
+  { match: "sonnet-4-6", tokens: MILLION_TOKENS },
+  { match: "sonnet-5", tokens: MILLION_TOKENS },
+  { match: "fable", tokens: MILLION_TOKENS },
+  { match: "mythos", tokens: MILLION_TOKENS },
+  { match: "opus", tokens: K200_TOKENS },
+  { match: "sonnet", tokens: K200_TOKENS },
+  { match: "haiku", tokens: K200_TOKENS },
+];
+const PERCENT = 100;
+
+const AGENT_NAME = { claude: "Claude", codex: "Codex" } as const;
+export type BadgeAgent = keyof typeof AGENT_NAME;
+
+export function shortModelLabel(model: string): string {
+  const preset = presetFor(model);
+  if (preset) return preset.label;
+  const lower = model.toLowerCase();
+  const family = CLAUDE_FAMILIES.find((f) => lower.includes(f.match));
+  return family ? family.label : (model.split("/").pop() ?? model);
+}
+
+function contextWindowTokens(model: string): number | null {
+  // A preset carries the window its provider publishes, so a session on one shows a real % instead
+  // of nothing — the substring list only knows Claude's own families.
+  const preset = presetFor(model);
+  if (preset?.contextLength) return preset.contextLength;
+  const lower = model.toLowerCase();
+  const entry = CONTEXT_WINDOWS.find((w) => lower.includes(w.match));
+  return entry ? entry.tokens : null;
+}
+
+type ContextReading = { kind: "measured"; windowTokens: number; percent: number } | { kind: "overflow"; windowTokens: number } | { kind: "no-window" };
+
+// Over 100% is not a measurement: the window is a hard cap, so the only thing an impossible
+// percentage tells us is that CONTEXT_WINDOWS has the wrong window for this model. Reported as
+// unknown rather than clamped — a precise wrong number gets acted on, and a clamp would hide the
+// gap entirely (#985).
+function readContext(model: string, contextTokens: number): ContextReading {
+  const windowTokens = contextWindowTokens(model);
+  if (windowTokens === null) return { kind: "no-window" };
+  const percent = Math.round((contextTokens / windowTokens) * PERCENT);
+  return percent > PERCENT ? { kind: "overflow", windowTokens } : { kind: "measured", windowTokens, percent };
+}
+
+function badgeText(label: string, reading: ContextReading): string {
+  if (reading.kind === "measured") return `${label} · ctx ${reading.percent}%`;
+  if (reading.kind === "overflow") return `${label} · ctx ?`;
+  return label;
+}
+
+function badgeTitle(agent: BadgeAgent, model: string, contextTokens: number, reading: ContextReading): string {
+  const head = `${AGENT_NAME[agent]} · ${model} · context ${contextTokens.toLocaleString()}`;
+  if (reading.kind === "measured") return `${head} / ${reading.windowTokens.toLocaleString()} (${reading.percent}%) tokens`;
+  if (reading.kind === "overflow") return `${head} tokens · more than the ${reading.windowTokens.toLocaleString()} window recorded for this model, so no %`;
+  return `${head} tokens`;
+}
+
+export type ModelBadge = { text: string; title: string };
+
+export function modelBadge(agent: BadgeAgent, model: string, contextTokens: number): ModelBadge {
+  const reading = readContext(model, contextTokens);
+  return { text: badgeText(shortModelLabel(model), reading), title: badgeTitle(agent, model, contextTokens, reading) };
+}

--- a/test/src/components/ModelContextBadge.spec.ts
+++ b/test/src/components/ModelContextBadge.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
 import ModelContextBadge from "../../../src/components/ModelContextBadge.vue";
 
+// Wiring only — which window a model has, and what the badge says when we cannot know, is decided
+// in src/components/modelBadge.ts and tested in modelBadge.spec.ts without mounting anything.
 function mountBadge(props: { agent?: "claude" | "codex"; model: string | null; contextTokens?: number }) {
   return mount(ModelContextBadge, {
     props: { agent: props.agent ?? "claude", model: props.model, contextTokens: props.contextTokens ?? 0 },
@@ -9,54 +11,13 @@ function mountBadge(props: { agent?: "claude" | "codex"; model: string | null; c
 }
 
 describe("ModelContextBadge", () => {
-  it("shows the short family label + ctx% for a known Claude model (70k / 200k = 35%)", () => {
-    const w = mountBadge({ model: "claude-opus-4-20250514", contextTokens: 70_000 });
-    expect(w.find('[data-testid="model-badge"]').text()).toBe("Opus · ctx 35%");
-  });
-
-  it("maps sonnet and haiku ids to their short labels", () => {
-    expect(mountBadge({ model: "claude-3-5-sonnet-20241022", contextTokens: 0 }).find("span").text()).toBe("Sonnet · ctx 0%");
-    expect(mountBadge({ model: "claude-haiku-4-20250101", contextTokens: 20_000 }).find("span").text()).toBe("Haiku · ctx 10%");
-  });
-
-  it("uses a 1M window for current-generation models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos)", () => {
-    // Regression: a full opus-4-8 session (~999k ctx) reads as ~100%, not ~500% against a 200k window.
-    expect(mountBadge({ model: "claude-opus-4-8", contextTokens: 999_606 }).find("span").text()).toBe("Opus · ctx 100%");
-    expect(mountBadge({ model: "claude-sonnet-5", contextTokens: 500_000 }).find("span").text()).toBe("Sonnet · ctx 50%");
-    expect(mountBadge({ model: "claude-sonnet-4-6", contextTokens: 100_000 }).find("span").text()).toBe("Sonnet · ctx 10%");
-    expect(mountBadge({ model: "claude-fable-5", contextTokens: 250_000 }).find("span").text()).toBe("Fable · ctx 25%");
-  });
-
-  it("keeps the 200k window for older Opus/Sonnet (pre-4.6)", () => {
-    expect(mountBadge({ model: "claude-opus-4-5-20251101", contextTokens: 100_000 }).find("span").text()).toBe("Opus · ctx 50%");
-    expect(mountBadge({ model: "claude-sonnet-4-5-20250929", contextTokens: 100_000 }).find("span").text()).toBe("Sonnet · ctx 50%");
-  });
-
-  it("shows the model tail but NO % for an unknown model (never guesses a window)", () => {
-    const w = mountBadge({ agent: "codex", model: "gpt-5-codex", contextTokens: 999_999 });
-    expect(w.find('[data-testid="model-badge"]').text()).toBe("gpt-5-codex");
-    expect(w.find('[data-testid="model-badge"]').text()).not.toContain("ctx");
-  });
-
-  it("uses the last path segment for a provider-prefixed unknown id", () => {
-    const w = mountBadge({ agent: "codex", model: "openai/o3-pro", contextTokens: 1000 });
-    expect(w.find('[data-testid="model-badge"]').text()).toBe("o3-pro");
+  it("renders the badge text, with the tooltip on the same element", () => {
+    const badge = mountBadge({ model: "claude-opus-4-20250514", contextTokens: 70_000 }).find('[data-testid="model-badge"]');
+    expect(badge.text()).toBe("Opus · ctx 35%");
+    expect(badge.attributes("title")).toContain("70,000 / 200,000 (35%)");
   });
 
   it("renders nothing when the model is unknown/null (no transcript model yet)", () => {
     expect(mountBadge({ model: null, contextTokens: 1000 }).find("span").exists()).toBe(false);
-  });
-
-  it("rounds the percentage", () => {
-    // 51,234 / 200,000 = 25.617% → 26%
-    expect(mountBadge({ model: "claude-opus-4", contextTokens: 51_234 }).find("span").text()).toBe("Opus · ctx 26%");
-  });
-
-  it("puts the agent name, full model id and raw token counts in the tooltip", () => {
-    const w = mountBadge({ agent: "claude", model: "claude-opus-4-20250514", contextTokens: 70_000 });
-    const title = w.find('[data-testid="model-badge"]').attributes("title");
-    expect(title).toContain("Claude");
-    expect(title).toContain("claude-opus-4-20250514");
-    expect(title).toContain("70,000 / 200,000 (35%)");
   });
 });

--- a/test/src/components/modelBadge.spec.ts
+++ b/test/src/components/modelBadge.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { modelBadge, shortModelLabel } from "../../../src/components/modelBadge";
+
+const textFor = (model: string, contextTokens: number) => modelBadge("claude", model, contextTokens).text;
+
+describe("shortModelLabel", () => {
+  it("maps a Claude id to its family", () => {
+    expect(shortModelLabel("claude-opus-4-20250514")).toBe("Opus");
+    expect(shortModelLabel("claude-3-5-sonnet-20241022")).toBe("Sonnet");
+    expect(shortModelLabel("claude-haiku-4-5-20251001")).toBe("Haiku");
+    expect(shortModelLabel("claude-fable-5")).toBe("Fable");
+  });
+
+  it("falls back to the id's last path segment for a non-Claude model", () => {
+    expect(shortModelLabel("gpt-5-codex")).toBe("gpt-5-codex");
+    expect(shortModelLabel("openai/o3-pro")).toBe("o3-pro");
+  });
+
+  it("prefers a preset's own label when the id is one we launch with", () => {
+    expect(shortModelLabel("qwen/qwen3-235b-a22b-2507")).toBe("Qwen3 235B A22B");
+  });
+});
+
+describe("modelBadge — the context window per model", () => {
+  it("gives Opus 5 its 1M window (#985: it fell through to the 200k `opus` entry and read 290%)", () => {
+    expect(textFor("claude-opus-5", 580_000)).toBe("Opus · ctx 58%");
+  });
+
+  it("does not let the `opus-5` entry claim Opus 4.5, which really is 200k", () => {
+    expect(textFor("claude-opus-4-5-20251101", 100_000)).toBe("Opus · ctx 50%");
+  });
+
+  it("uses 1M for the rest of the current generation", () => {
+    expect(textFor("claude-opus-4-6", 100_000)).toBe("Opus · ctx 10%");
+    expect(textFor("claude-opus-4-7", 100_000)).toBe("Opus · ctx 10%");
+    expect(textFor("claude-opus-4-8", 999_606)).toBe("Opus · ctx 100%");
+    expect(textFor("claude-sonnet-4-6", 100_000)).toBe("Sonnet · ctx 10%");
+    expect(textFor("claude-sonnet-5", 500_000)).toBe("Sonnet · ctx 50%");
+    expect(textFor("claude-fable-5", 250_000)).toBe("Fable · ctx 25%");
+    expect(textFor("claude-mythos-5", 250_000)).toBe("Mythos · ctx 25%");
+  });
+
+  it("keeps 200k for the older generations and for every Haiku", () => {
+    expect(textFor("claude-opus-4-20250514", 70_000)).toBe("Opus · ctx 35%");
+    expect(textFor("claude-sonnet-4-5-20250929", 100_000)).toBe("Sonnet · ctx 50%");
+    expect(textFor("claude-haiku-4-5-20251001", 20_000)).toBe("Haiku · ctx 10%");
+  });
+
+  it("takes the window from a preset when the model is one of ours", () => {
+    expect(textFor("qwen/qwen3-235b-a22b-2507", 131_072)).toBe("Qwen3 235B A22B · ctx 50%");
+  });
+
+  it("rounds the percentage", () => {
+    expect(textFor("claude-opus-4", 51_234)).toBe("Opus · ctx 26%"); // 25.617%
+  });
+});
+
+describe("modelBadge — what it shows when it cannot know", () => {
+  it("shows no ctx at all for a model with no known window", () => {
+    const badge = modelBadge("codex", "gpt-5-codex", 999_999);
+    expect(badge.text).toBe("gpt-5-codex");
+    expect(badge.title).toBe("Codex · gpt-5-codex · context 999,999 tokens");
+  });
+
+  it("shows `ctx ?` rather than an impossible percentage, and says so in the tooltip", () => {
+    // The window is a hard cap, so past 100% the only thing the number reports is that our table
+    // has the wrong window for this model — the exact shape #985 arrived in. Not clamped to 100%:
+    // that would hide the gap instead of showing it.
+    const badge = modelBadge("claude", "claude-opus-9", 580_000);
+    expect(badge.text).toBe("Opus · ctx ?");
+    expect(badge.title).toContain("580,000 tokens");
+    expect(badge.title).toContain("200,000 window recorded for this model");
+  });
+
+  it("still reports a session sitting exactly at the window", () => {
+    expect(textFor("claude-opus-4", 200_000)).toBe("Opus · ctx 100%");
+  });
+
+  it("tolerates a hair over the window, since the two token counts need not agree exactly", () => {
+    expect(textFor("claude-opus-4", 200_800)).toBe("Opus · ctx 100%"); // 100.4% → 100%
+    expect(textFor("claude-opus-4", 202_000)).toBe("Opus · ctx ?"); // 101%
+  });
+});
+
+describe("modelBadge — the tooltip", () => {
+  it("carries the agent, the full model id and the raw token counts", () => {
+    expect(modelBadge("claude", "claude-opus-4-20250514", 70_000).title).toBe("Claude · claude-opus-4-20250514 · context 70,000 / 200,000 (35%) tokens");
+  });
+});


### PR DESCRIPTION
## Summary

`Opus · ctx 290%` の原因は 1 行の欠落でした。`CONTEXT_WINDOWS` は**先頭一致の順序つき一覧**で、`claude-opus-5` は `opus-4-6/4-7/4-8` のどれにも当たらず、フォールバックの `opus`（200k）に落ちて **200,000 で割られて**いました。実際のウィンドウは 1M なので、ちょうど 5 倍です（580k 使用 → 290%）。

3 つ入っています。

1. **`{ match: "opus-5", tokens: MILLION_TOKENS }` を `opus` フォールバックより前に追加。** 先頭一致なので順序が意味を持ちます。
2. **表全体を現行モデル一覧と突き合わせて監査。** 漏れは `opus-5` だけでした（Fable 5 / Mythos 5 / Opus 4.6・4.7・4.8 / Sonnet 4.6・5 は 1M で登録済み、Haiku 4.5 と 4.6 以前の Opus/Sonnet は 200k のフォールバックで正しい）。
3. **100% を超えた値は数字として出さず `ctx ?` にする。** ウィンドウは上限なので、100% 超は「セッションが溢れている」ではなく「表がこのモデルを知らない」という意味しか持ちません。

ついでに、この判断（どのウィンドウか・何 % か・分からないとき何を出すか）を `.vue` から `src/components/modelBadge.ts` に出し、マウントせずに直接ユニットテストしています（CLAUDE.md の Vue ルール）。

## Items to Confirm / Review

- **`ctx ?` を入れたこと自体**が、issue で「検討したい」と書いた側の判断です。理由は PR 本文下部と `plans/fix-985-context-window-opus-5.md` に書きました。**clamp（100% で止める）を選ばなかった**のは、そちらだと次の世代で漏れたときに完全に不可視になるためです。今回のバグは 290% が「明らかに変」だったから発見されました。異論があればここです。
- **100% 超の判定は丸めた後の値で行っています。** つまり 100.4% は `ctx 100%` のまま、101% から `ctx ?` です。トランスクリプトのトークン数とモデルのウィンドウの数え方が完全一致する保証はないので、ぴったり上限のセッションを `?` にしないための余裕です。この 0.5% の許容が妥当かどうか。
- **`opus-5` が `claude-opus-4-5` を横取りしないこと**は回帰テストで固定しています（`opus-4-5` に `opus-5` は含まれない）。
- **ファイル名**: 新モジュールは `modelBadge.ts` にしました。`modelContextBadge.ts` だと spec が `ModelContextBadge.spec.ts` と macOS の大文字小文字を区別しないファイルシステムで**衝突**します（Linux では別ファイルになるので CI では気づけません）。
- UI の見た目は変わりません（正しいモデルでは数字が正しくなるだけ）。`ctx ?` は表が古いときだけ出ます。

## User Prompt

> ctx は実装時からおかしい。issue 化して後で直す？
>
> 985 進めよう

## 直し方の詳細

`CONTEXT_WINDOWS` のコメントが、この症状をそのまま予言していました。

> Add new 1M model ids here when they ship — otherwise a full session over-reports (e.g. a 1M model shown against 200k reads as ~500%).

仕組みは意図どおりで、**表の更新が漏れていただけ**です。ただしこの表は世代が出るたびに手で足す必要があり、次に漏れるのは時間の問題です。失敗の仕方は 3 通りあって、許容できるのは 1 つだけでした。

| | |
|---|---|
| **間違った数字を出す**（現状） | 290% は精密に間違っている。バッジを信じた人はそれを根拠に判断を誤る |
| **100% で clamp する** | 現状より悪い。失敗が不可視になり、「満杯」はもっともらしいので誰も報告しない |
| **分からないと言う**（本 PR） | `ctx ?` は明らかに変なので報告はされるが、誰もそれを測定値として扱わない |

未知のモデルにはすでに「ウィンドウを推測しない」（`ctx` を出さない）方針があります。ありえない % は、同じ告白が後から届いただけなので、同じ扱いにしました。

## Test plan

- `test/src/components/modelBadge.spec.ts`（新規、マウントなし）— #985 の回帰（`claude-opus-5` @ 580k → `ctx 58%`）、`opus-5` が `opus-4-5` を横取りしないこと、現行世代 1M / 旧世代 200k / Haiku 200k、プリセット由来のウィンドウ、丸め、100% ちょうど、100% 超の `ctx ?` とツールチップ、未知モデルの `ctx` 非表示
- `test/src/components/ModelContextBadge.spec.ts` — 配線のみに縮小（描画される / されない、tooltip が同じ要素に付く）
- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` / `yarn test`（5353 passed）

Fixes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model badges with clearer model names, context usage percentages, token counts, and tooltips.
  * Added support for accurately recognizing newer model context windows.
* **Bug Fixes**
  * Context usage exceeding the known window now displays `ctx ?` with an explanatory tooltip instead of an incorrect percentage.
  * Improved accuracy when distinguishing between model generations and context limits.
* **Documentation**
  * Updated guidance explaining context percentage behavior and unknown context windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->