### PR TITLE
feat: grid の拡大セルでも Canvas を出す

### DIFF
--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -1,0 +1,67 @@
+// The GUI MCP is served at one URL per GROUP of tools, so a user can turn a subset on for a
+// directory with Claude Code's own per-folder MCP config (`.mcp.json` / `claude mcp add -s
+// local`) instead of a MulmoTerminal setting. `.mcp.json` only switches whole SERVERS on and
+// off — splitting the URL is what turns that into tool granularity.
+//
+// These names appear in the URL path AND in the server id users write in their own config
+// (`mulmoterminal-<group>`), so they are effectively public API: renaming one breaks every
+// config already written against it.
+
+// The groups, ordered by how much damage a call can do.
+//   render   — draws into the Canvas panel and stops there. No side effect outside it.
+//   data     — reads/writes the workspace's structured data (collections, accounting).
+//   media    — generation that is slow, costly, and lands files on disk.
+//   external — reaches a third-party account or API.
+export const TOOL_GROUPS = ["render", "data", "media", "external"] as const;
+
+export type ToolGroup = (typeof TOOL_GROUPS)[number];
+
+export const isToolGroup = (value: unknown): value is ToolGroup => TOOL_GROUPS.some((group) => group === value);
+
+// Which group each GUI tool belongs to.
+//
+// A tool that is absent belongs to NO group and is therefore reachable only through the
+// all-tools URL (`/api/mcp/:sessionId`, the single view). That is the deliberate failure
+// mode: forgetting to classify a newly added plugin withholds it from the group URLs rather
+// than leaking it into one — the map can go stale, but only ever closed.
+//
+// `spawnBackgroundChat` is absent ON PURPOSE, not by omission: it starts another session,
+// which is neither drawing, data, media, nor an external call, and a grid cell has no
+// business doing it silently.
+// A Map, not a plain object — the same reason the plugin dispatch map is one: object index
+// access reads through the prototype chain, so `constructor` / `__proto__` / `toString` would
+// resolve to an Object.prototype member and report a truthy "group". Map.get only ever returns
+// own entries.
+const GROUP_BY_TOOL = new Map<string, ToolGroup>([
+  ["presentDocument", "render"],
+  ["presentForm", "render"],
+  ["presentChart", "render"],
+  ["presentHtml", "render"],
+
+  // presentCollection RENDERS, but it renders collection data and only makes sense next to
+  // manageCollection — a cell offered the view without the store gets a tool it cannot fill.
+  ["presentCollection", "data"],
+  ["manageCollection", "data"],
+  ["manageAccounting", "data"],
+
+  ["generateImage", "media"],
+  ["presentMulmoScript", "media"],
+
+  ["google", "external"],
+  ["readXPost", "external"],
+  ["searchX", "external"],
+]);
+
+export const groupOfTool = (toolName: string): ToolGroup | null => GROUP_BY_TOOL.get(toolName) ?? null;
+
+// The MCP server id a group is expected to be registered under. `--allowedTools` matches on
+// `mcp__<server id>__<tool>`, and the id comes from the USER's config key — so this is a
+// convention the enable-it-for-this-folder affordance has to write, and a user who registers
+// the same URL under another name simply gets permission prompts (nothing breaks).
+export const toolGroupServerId = (group: ToolGroup): string => `mulmoterminal-${group}`;
+
+// Groups whose tools MulmoTerminal pre-approves via `--allowedTools`, so they run without a
+// permission prompt. Only `render`: it cannot touch anything outside the Canvas panel, so
+// silent execution is the point. Everything else goes through Claude Code's normal prompt —
+// which is the whole reason the groups are split by blast radius above.
+export const AUTO_ALLOWED_TOOL_GROUPS: readonly ToolGroup[] = ["render"];

--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -18,6 +18,12 @@ export type ToolGroup = (typeof TOOL_GROUPS)[number];
 
 export const isToolGroup = (value: unknown): value is ToolGroup => TOOL_GROUPS.some((group) => group === value);
 
+// The group the Canvas pane is made of. The launcher switch registers it, the panel's
+// availability is decided by it, and the server routes on it — named here rather than written
+// as `"render"` at each of those sites, so a rename cannot leave one of them silently pointing
+// at a group that no longer exists.
+export const CANVAS_TOOL_GROUP: ToolGroup = "render";
+
 // Which group each GUI tool belongs to.
 //
 // A tool that is absent belongs to NO group and is therefore reachable only through the

--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -60,8 +60,15 @@ export const groupOfTool = (toolName: string): ToolGroup | null => GROUP_BY_TOOL
 // the same URL under another name simply gets permission prompts (nothing breaks).
 export const toolGroupServerId = (group: ToolGroup): string => `mulmoterminal-${group}`;
 
-// Groups whose tools MulmoTerminal pre-approves via `--allowedTools`, so they run without a
-// permission prompt. Only `render`: it cannot touch anything outside the Canvas panel, so
-// silent execution is the point. Everything else goes through Claude Code's normal prompt —
-// which is the whole reason the groups are split by blast radius above.
-export const AUTO_ALLOWED_TOOL_GROUPS: readonly ToolGroup[] = ["render"];
+// The tools MulmoTerminal pre-approves via `--allowedTools`, so they run without a permission
+// prompt. A list of TOOLS, not of groups: a group says which tools a directory can reach, and
+// that is not the same question as which may run unattended.
+//
+// `presentDocument` is the case that forces them apart, and it is deliberately ABSENT. Its
+// execute runs `fillImages` before saving, which resolves every image placeholder in the
+// markdown through the image backend — a PAID generation call. Auto-allowing it would let a
+// model spend money silently under a switch the UI presents as "let the agent draw", so it
+// keeps Claude Code's prompt (answer it once per project and the prompt stops).
+//
+// The three below save an artifact and draw it, and call nothing external.
+export const AUTO_ALLOWED_TOOLS: readonly string[] = ["presentForm", "presentChart", "presentHtml"];

--- a/plans/feat-canvas-in-grid.md
+++ b/plans/feat-canvas-in-grid.md
@@ -1,6 +1,6 @@
 # feat — grid の拡大セルでも Canvas を出す
 
-grid のセルで走っているエージェントが `presentDocument` / `presentHTML` / `presentForm` /
+grid のセルで走っているエージェントが `presentDocument` / `presentHtml` / `presentForm` /
 `presentMulmoScript` を呼んでも、今は**どこにも出ない**。Canvas は single view 専用で、
 `GuiPanel` はそこに 1 つだけマウントされている（`App.vue:389`）。
 
@@ -63,7 +63,7 @@ grid は `--strict-mcp-config` を付けないので、ユーザーの `.mcp.jso
 
 | グループ | URL | 中身 | 性質 | `--allowedTools` |
 |---|---|---|---|---|
-| **render** | `/api/mcp/render/:sessionId` | markdown・html・form・chart | Canvas に描いて終わる。パネル外に副作用なし | **自動許可** |
+| **render** | `/api/mcp/render/:sessionId` | presentDocument・presentHtml・presentForm・presentChart | Canvas に描く。ただし presentDocument だけは fillImages を通す（有料生成） | **presentDocument 以外を自動許可** |
 | **data** | `/api/mcp/data/:sessionId` | `manageCollection`・`manageAccounting` | workspace の構造化データを読み書き | プロンプト |
 | **media** | `/api/mcp/media/:sessionId` | generate-image・mulmoscript | 生成が高価。ファイルを産む | プロンプト |
 | **external** | `/api/mcp/external/:sessionId` | google・x | third-party のアカウント / API | プロンプト |
@@ -97,7 +97,7 @@ plugins, workerTool)` は**プラグインのリストを受け取る**ので、
 
 | | 置き場所 | MulmoClaude への影響 |
 |---|---|---|
-| **A（採用）** | MulmoTerminal 内のマッピング表（`server/infra/tool-groups.ts` を 1 枚） | **なし。** ローカル変更のみ |
+| **A（採用）** | MulmoTerminal 内のマッピング表（`common/toolGroups.ts` を 1 枚） | **なし。** ローカル変更のみ |
 | B | `ToolDefinition` に `group` を足し各プラグインが自己申告 | protocol + プラグイン 10 個の変更・bump・publish、MulmoClaude 側の取り込み |
 
 B の方が設計としては綺麗（プラグイン自身が自分の性質を知っている）が、コストが釣り合わない。

--- a/plans/feat-canvas-in-grid.md
+++ b/plans/feat-canvas-in-grid.md
@@ -1,0 +1,244 @@
+# feat — grid の拡大セルでも Canvas を出す
+
+grid のセルで走っているエージェントが `presentDocument` / `presentHTML` / `presentForm` /
+`presentMulmoScript` を呼んでも、今は**どこにも出ない**。Canvas は single view 専用で、
+`GuiPanel` はそこに 1 つだけマウントされている（`App.vue:389`）。
+
+拡大中のセルの右に Canvas を出す。**single view の挙動は一切変えない。**
+
+## 障害は UI ではなく、grid セルが GUI MCP を知らないこと
+
+`GuiPanel` を置くだけでは永久に空になる。grid セルの claude は GUI MCP を渡されていない
+（`ws-routes.ts:217` の `?gui=0` → `attachGuiMcp=false` → `claude-args.ts:46` を通らない）ので、
+`presentDocument` という道具を知らない。
+
+`attachGuiMcp` は 4 つの意味を兼ねている:
+
+| # | 意味 | 参照 |
+|---|---|---|
+| 1 | GUI MCP + `--strict-mcp-config` + `--allowedTools` | `claude-args.ts:46` |
+| 2 | Docker サンドボックスを走らせるか | `pty-spawn.ts:47` |
+| 3 | dev terminal として記録（チャット一覧から除外・永続） | `ws-routes.ts:238` |
+| 4 | `entry.active` の初期値 | `ws-routes.ts:283` |
+
+**この変数の正体は `isSingleView`。** だから grid でこれを立てると、GUI MCP と一緒に
+サンドボックスまで付いてくる（2）── grid セル全部が Docker の中で動き出す。
+
+## 解 — GUI MCP を Claude Code 自身の per-folder MCP 設定に置く
+
+**`attachGuiMcp` を触らない。** grid は今のまま `false`（`--mcp-config` を渡さない、
+`--strict-mcp-config` を付けない、サンドボックスしない）。代わりに、GUI MCP を
+**ユーザー側の MCP 設定から**接続させる。
+
+Claude Code は MCP config の URL 内の `${VAR}` を**接続時に展開する**（実測で確認）:
+
+```json
+{"mcpServers":{"mulmoterminal-render":{
+  "type":"http",
+  "url":"http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/render/${MULMOTERMINAL_SESSION_ID}"}}}
+```
+
+MulmoTerminal は spawn 時の env を制御できるので、この 2 つを渡すだけでよい。**URL が
+セッションごとに変わることは、静的な設定ファイルに置けない理由にならない。**
+
+grid は `--strict-mcp-config` を付けないので、ユーザーの `.mcp.json` / `local` scope /
+`user` scope がそのまま載る ── **フォルダごとの on/off は Claude Code の既存機構が全部やる。**
+
+これで不要になるもの: `.mulmoterminal.json` の `gui` キー、設定 UI、per-dir config の
+書き込みルート（"workspace がデータベース" の不変条件も無傷）、`writableDirConfigSchema` の
+変更、スキーマ再生成、`mulmoterminal-config` SKILL.md の更新。
+
+### 実測メモ
+
+- `--mcp-config` にインラインで渡した `${MT_SESSION_ID}` は展開された（プローブサーバーに
+  `POST /api/mcp/abc123` が届いた）
+- `claude mcp add -s local` 経由でも展開された（`POST /api/mcp/localscope99`）
+- **`claude mcp add` は保存時に `${}` を URL エンコードする**（`$%7BMT_SESSION_ID%7D`）。
+  それでも展開は効くが、`claude mcp get` の表示が壊れて見えるので docs に一言要る
+
+## URL をグループで分ける
+
+`.mcp.json` が与えるのはサーバー単位の on/off だけ。ならば**サーバーを分ければ**ツールの
+粒度が手に入る。
+
+| グループ | URL | 中身 | 性質 | `--allowedTools` |
+|---|---|---|---|---|
+| **render** | `/api/mcp/render/:sessionId` | markdown・html・form・chart | Canvas に描いて終わる。パネル外に副作用なし | **自動許可** |
+| **data** | `/api/mcp/data/:sessionId` | `manageCollection`・`manageAccounting` | workspace の構造化データを読み書き | プロンプト |
+| **media** | `/api/mcp/media/:sessionId` | generate-image・mulmoscript | 生成が高価。ファイルを産む | プロンプト |
+| **external** | `/api/mcp/external/:sessionId` | google・x | third-party のアカウント / API | プロンプト |
+| *(既存)* | `/api/mcp/:sessionId` | 全部 | single view 用・後方互換 | **変更なし** |
+
+**URL はユーザーの設定ファイルに書かれる＝実質的な公開 API。** 後から変えにくいので、
+この 5 本を最初に決め切る。
+
+`spawnBackgroundChat`（`HOST_TOOL_DEFINITIONS` の 3 つ目）は**どのグループにも入れない** ──
+描画でもデータでも外部でもない制御系で、grid セルが別セッションを勝手に起こす必要は薄い。
+全部入りの既存 URL でだけ使える。
+
+### 実装は既存の継ぎ目に乗る
+
+`mcp-routes.ts:25` はリクエストごとに `buildGuiMcpServer(sessionId, baseUrl, { submitTranslationTool })`
+を作る ── **オプション引数が既にある**。`tool-gate.ts` の `offeredTools(isTranslationWorker,
+plugins, workerTool)` は**プラグインのリストを受け取る**ので、絞り込みはそこ 1 箇所。
+
+`tool-gate.ts` にはこの用途の前例がある。翻訳ワーカーは `submitTranslation` 1 つだけを提示され、
+それ以外は*提示していなくても*拒否される:
+
+> Two layers, because the first one is only a list and a model can name a tool it was not shown.
+
+グループ絞り込みも同じ関数を通せば、**この 2 層の防御をそのまま継承できる**。「提示しない」
+だけでは、モデルが名前を言い当てたときに素通りする。
+
+ルートは `/api/mcp/:sessionId`（全部・現状のまま）と `/api/mcp/:group/:sessionId` の 2 本。
+セグメント数で区別できる。
+
+### グループ表は MulmoTerminal 側に置く — MulmoClaude に波及させない
+
+| | 置き場所 | MulmoClaude への影響 |
+|---|---|---|
+| **A（採用）** | MulmoTerminal 内のマッピング表（`server/infra/tool-groups.ts` を 1 枚） | **なし。** ローカル変更のみ |
+| B | `ToolDefinition` に `group` を足し各プラグインが自己申告 | protocol + プラグイン 10 個の変更・bump・publish、MulmoClaude 側の取り込み |
+
+B の方が設計としては綺麗（プラグイン自身が自分の性質を知っている）が、コストが釣り合わない。
+共有パッケージを触ると両アプリの版ズレリスクが出る（同じ workspace データを触るので skew は
+実データの不具合になり得る）うえ、**MulmoClaude はこの分類を使わない** ── チャット主体で全ツール
+常時 on の設計なので subset する動機がない。払っても受け取る側がいない。
+
+そもそもブローカーは別実装 ── MulmoTerminal は in-process の Streamable HTTP
+（`server/mcp/broker.ts` + `mcp-routes.ts`）、MulmoClaude は stdio JSON-RPC
+（`server/agent/mcp-server.ts`）。broker.ts のコメントどおり *"the same shape"* の別物なので、
+URL 分割は構造的に波及しない。
+
+A の代償は「プラグインを足したときに表の更新を忘れうる」こと。**未分類のツールはどのグループ
+にも入らない**を既定にしておけば、忘れても安全側に倒れる。
+
+## `--allowedTools` — on/off はユーザー、自動許可は MulmoTerminal
+
+MulmoTerminal はユーザーが何を登録したか知らないが、**知る必要がない**。`render` グループの
+完全修飾名（`mcp__mulmoterminal-render__*`）を常に `--allowedTools` に入れておけばよい ──
+登録されていなければ無害、登録されていれば無確認で描画できる。他のグループは通常の許可
+プロンプトが門番になる。
+
+**on/off はユーザーが Claude Code で決め、何を無確認で走らせるかは MulmoTerminal が決める。**
+
+サーバー名は `mcp__<サーバー名>__<tool>` の形で `--allowedTools` と結合しているので、**名前を
+規約として固定する**こと。ユーザーが別名で登録すると自動許可が外れて毎回プロンプトになる。
+UI から登録する導線（下記）を主経路にすれば、その事故は起きない。
+
+### `claude-args.ts` の変更 — 単独で渡して問題ないことを実測済み
+
+grid でも `--allowedTools` を出す必要がある。現状それは `attachGuiMcp` のブロック内にしかなく、
+`--strict-mcp-config` と同時にしか渡されたことがない。単独時の挙動を実測した:
+
+| | 条件 | 結果 |
+|---|---|---|
+| E | local scope に登録した MCP ツール、`--allowedTools` なし | **拒否**（`-p` なのでプロンプトが出せず deny） |
+| F | 同じツール、`--allowedTools "mcp__probe__probePing"` のみ（`--mcp-config` も `--strict` もなし） | **無確認で実行された** |
+| G | F と同じ条件で `Read` も併用 | **両方成功** ── `--allowedTools` は排他リストではない |
+| B | `--allowedTools` に無関係な MCP ツール名だけを渡して `Read` | **成功** ── named 以外を締め出さない |
+
+結論: **`--allowedTools` は「これだけ許す」ではなく「これは無確認でよい」の加算的な事前承認**で、
+`--strict-mcp-config` なしの単独指定で正しく働き、ユーザー自身の local scope から来た MCP
+サーバーのツールもこれで自動許可できる。**本 plan の前提どおり。**
+
+`claude-args.ts` は冒頭コメントどおり「このフラグ集合を PTY なしで単体テストするため」の
+純関数なので、差分は小さくテストも書ける。
+
+## 有効化の導線
+
+主経路は **grid で `+` を押した後の画面**（`TerminalCell.vue:1412` の `cell-launch`）に
+「このフォルダで Canvas を有効にする」を置き、`claude mcp add -s local` 相当を実行する。
+
+- `local` scope（`~/.claude.json` にパス単位）── **repo の外・承認不要・自分だけ**。既定はこれ
+- `.mcp.json`（project scope）── repo 共有・承認ゲートあり。チームで使うなら
+
+起動前の画面に置くのが要点。**spawn 時に確定するフラグなので、決めてから起動するという順序が
+自然に守られる。** 発見の問題も、起動のたびに目に入るので解ける。
+
+すでに走っているセルには後から効かない。`claude mcp list` の結果と実際のセッションが食い違う
+場合に、セルヘッダに**「再起動で有効」バッジ**を出す。
+
+## セッションが持っているツールを記録する
+
+`ToolsPane` の per-session 表示、右ペインのトグル出し分け、未拡大 grid のチップが**すべて
+「このセッションは何を持っているか」を見る**。`devTerminalSessions`（= grid セッション）はもう
+その答えにならない（grid でも持つセルが出るので）。
+
+resume されるセルも以前の状態を知る必要があるため、**セッションごとのツール集合を永続化する**
+（`devTerminalSessions` が既にファイルに書き出されているので同じ扱い）。抜けるとリロードの
+たびに Canvas の有無が揺れる。
+
+## UI — 拡大時の右ペイン、3 択排他
+
+拡大時のレイアウトは `[roster 360px | terminal | FilesPane]`（`listMode`）と strip モードの
+2 形態があり、**`feat-910-phase1-files-pane.md` が敷いた row ラッパと `clampPaneWidth` を
+そのまま流用する**。3 カラムで既に狭いので、**右枠は Files ⇄ Canvas ⇄ Tools の 3 択排他**
+（roster は左に残す）。4 カラムは laptop で破綻する。
+
+`GuiPanel` は既に `sessionId` でパラメータ化されているので、2 つ目のマウントはほぼ追加コスト
+なし。`expandedUid` への追従は FilesPane が前例だが、**Canvas には未保存編集がないので無条件
+追従でよい**（`paneUid` / `paneCwd` の「re-root を断られたら前のルートに留まる」分岐は不要）。
+
+注意: 同一セッションに single と grid の両方が Canvas をマウントし得る。`GuiPanel` の
+`persistOnly` エコー抑制（2 つ目のビューが view-state 更新をライブで受け取らない）がそこで
+顔を出す。
+
+**トグルは無条件に出さない。** 描画系を持たないセルで空の Canvas を見せるのが最悪:
+
+- render グループを持って起動した → Files ⇄ Canvas ⇄ Tools の 3 択
+- 持たずに起動した → Canvas のトグルを出さない（`ToolsPane` は出してよい ── そのセルが何を
+  持っているかを read-only で示す面なので）
+
+`ToolsPane` も今は single view 専用。末尾の **"Available tools are the same for every session;
+load once" という前提は成り立たなくなる**ので直す（per-session 表示に。read-only は維持）。
+名前と説明は `/api/tools`（`toolSummaries`）から取れる。
+
+## 未拡大の grid — 合図だけ
+
+セルの中に Canvas は置かない。2×2 でも狭く、3×3 では成立しない。そして grid の仕事は
+**トリアージであって読むことではない**（読ませ始めると grid がダッシュボードに変質する）。
+
+代わりに、**Canvas 出力が出たことを合図する**。今は出ても grid 側に痕跡がなく、拡大するまで
+存在に気づけない ── 「見落とさないための道具」としては穴。
+
+- ヘッダに未見チップを 1 つ（`◧ 3`）。model / context% / token / branch のチップと同じ語彙に
+  乗せ、新しい UI 概念を持ち込まない
+- 既存の状態色に**弱く**参加させる。**amber（要対応）に昇格させない** ── 出力があることは
+  緊急ではなく、混ぜると amber の意味が薄まる。実装前に `notifyKinds.ts` と既存の agent state
+  定義を見て既存概念に寄せる
+- チップをクリック → そのセルを拡大 + Canvas を開いた状態で開く（ズームの FLIP は既存）
+
+## やらないこと
+
+- **single view の挙動変更いっさい。** 関連して調査中に見つけた事実を記録として残す ──
+  サンドボックスは `MULMOTERMINAL_SANDBOX=1|true` の明示設定が必要で**既定 off**、かつ
+  `darwin` 限定（Linux は明示的に gate off）。一方 `--strict-mcp-config` は `attachGuiMcp`
+  （= single view か）に紐付いているので、**env を立てた macOS ユーザー以外の全員**にとって
+  single view はサンドボックス無しで `--strict` だけが付き、そのプロジェクトの `.mcp.json` /
+  local scope MCP が落ちている。意図的な隔離である可能性もあるため、本 plan では触らない
+- grid セル内への Canvas 描画（トリアージ盤を壊す）
+- MulmoTerminal 独自の per-dir `mcpServers`（Claude Code の 3 scope に任せる）
+- グローバル `userMcpServers` の stdio 対応（HTTP のみのまま。stdio が要るなら `claude mcp add`）
+- `ToolDefinition` への `group` フィールド追加（MulmoClaude への波及を避ける。A を採用）
+
+## 検証状況
+
+`--allowedTools` の単独指定は実測済み（上記 E–G / B）。実装後、走らせたサーバーに対して確認:
+
+| | 結果 |
+|---|---|
+| `/api/mcp/render/:id` の `tools/list` | `presentDocument presentForm presentChart presentHtml` |
+| `/api/mcp/data/:id` | `presentCollection manageAccounting manageCollection` |
+| `/api/mcp/media/:id` | `generateImage presentMulmoScript` |
+| `/api/mcp/external/:id` | `google readXPost searchX` |
+| `/api/mcp/:id`（既存 URL） | 13 個すべて。**無傷** |
+| 未知のグループ | 404 |
+| render URL で `manageCollection` を `tools/call` | 拒否（2 層目が効いている） |
+| render URL で `spawnBackgroundChat` | 拒否 |
+| `/api/tools?sessionId=` | 学習済みグループのぶんだけ返し、未分類の `spawnBackgroundChat` を除外 |
+| `~/.mulmoterminal/session-tool-groups.json` | `<id> <group>` が 1 行ずつ追記される |
+
+**まだ実機で見ていないもの:** MulmoTerminal が実際に起こした grid セル（tmux 経由の PTY）で
+`${MULMOTERMINAL_PORT}` / `${MULMOTERMINAL_SESSION_ID}` の展開が効くか。CLI 直叩きでは確認済み
+だが spawn 経路が違う ── ブラウザでセルを 1 つ起こせば確定する。

--- a/server/agents/claude-args.ts
+++ b/server/agents/claude-args.ts
@@ -15,10 +15,16 @@ export interface ClaudeArgsInput {
   // true  (single view): attach the in-process GUI MCP, auto-allow its tools, and
   //        isolate to it with --strict-mcp-config (main's classic behavior).
   // false (grid dev terminal): no GUI MCP and no --strict-mcp-config, so the user's
-  //        + project's MCP servers load normally.
+  //        + project's MCP servers load normally — INCLUDING a GUI tool group the
+  //        directory registered itself (see common/toolGroups.ts).
   attachGuiMcp: boolean;
   mcpConfig: string; // GUI MCP config JSON (--mcp-config), used only when attachGuiMcp
-  guiMcpTools: string; // comma-joined GUI tool names (--allowedTools), used only when attachGuiMcp
+  // Comma-joined fully-qualified tool names for --allowedTools. Passed in BOTH modes: a grid
+  // cell gets no --mcp-config, but still needs its render-group tools pre-approved so they
+  // don't stop at a permission prompt on every call. Verified that --allowedTools alone (no
+  // --mcp-config, no --strict-mcp-config) pre-approves without restricting anything else —
+  // it is an additive allowlist, not "only these".
+  allowedTools: string;
   // What this session runs (#579): an alias (sonnet/opus/haiku) or a backend's own model
   // name. Null leaves the choice to Claude Code. `--model` outranks both the settings
   // `model` key and ANTHROPIC_MODEL, so it is the one place the decision has to be made.
@@ -44,8 +50,12 @@ export function buildClaudeArgs(input: ClaudeArgsInput): string[] {
   guiArgs.push("--append-system-prompt", appended);
   if (input.model) guiArgs.push("--model", input.model);
   if (input.attachGuiMcp) {
-    guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config", "--allowedTools", input.guiMcpTools);
+    guiArgs.push("--mcp-config", input.mcpConfig, "--strict-mcp-config");
   }
+  // Outside the block: --strict-mcp-config is what makes --mcp-config the ONLY source, and a
+  // grid cell wants neither — but it does want its render-group tools auto-allowed, and those
+  // reach it through the user's own MCP config. Empty means nothing to pre-approve.
+  if (input.allowedTools) guiArgs.push("--allowedTools", input.allowedTools);
   // LAST, and one flag for the whole list: `--add-dir` is variadic (`<directories...>`), so a
   // flag placed after it would be fine but a VALUE would be swallowed. Keeping it at the end
   // means nothing can ever follow it.

--- a/server/index.ts
+++ b/server/index.ts
@@ -78,6 +78,7 @@ import { initMulmoScriptBackend } from "./backends/mulmoscript.js";
 import { createSessionLifecycle, SESSIONS_CHANNEL } from "./session/lifecycle.js";
 import { mountAppRoutes } from "./routes/app-routes.js";
 import { allowedToolNames } from "./infra/plugins-registry.js";
+import { AUTO_ALLOWED_TOOL_GROUPS } from "../common/toolGroups.js";
 import { resumableSessionPredicate } from "./session/resumable-sessions.js";
 import { installProcessGuards } from "./infra/process-guards.js";
 import { pruneOrphanSettings } from "./session/session-settings.js";
@@ -136,6 +137,14 @@ const sessionChannel = (id: string) => `session:${id}`;
 // only hidden translation workers are actually shown it, see the /mcp route) so the
 // worker can call it without a permission prompt.
 const GUI_MCP_TOOLS = [...allowedToolNames(), "mcp__mulmoterminal-gui__submitTranslation"].join(",");
+
+// What a GRID cell pre-approves. A grid cell is never handed --mcp-config: its GUI tools come
+// from the user's OWN per-folder MCP config (`claude mcp add -s local`, `.mcp.json`), so
+// MulmoTerminal cannot know which groups a directory registered — and does not need to. It
+// names the auto-allowed groups unconditionally; entries for a server the session didn't
+// register match nothing. Only `render` is here: it cannot act outside the Canvas panel, so
+// running it without a prompt is the point. Every other group keeps Claude Code's own prompt.
+const GRID_MCP_TOOLS = AUTO_ALLOWED_TOOL_GROUPS.flatMap((group) => allowedToolNames(group)).join(",");
 
 // The panel's per-session stores. `publish` is a closure rather than the pubsub object
 // because pub/sub only exists once the HTTP server does, and these are built before it.
@@ -213,6 +222,7 @@ const spawnDeps: SpawnDeps = {
   codexModel: CODEX_MODEL,
   permissionMode: CLAUDE_PERMISSION_MODE,
   guiMcpTools: GUI_MCP_TOOLS,
+  gridMcpTools: GRID_MCP_TOOLS,
   outputBufferLimit: OUTPUT_BUFFER_LIMIT,
   hookSettingsJson: (host, sessionId, env) => hookSettingsJson({ host, port: PORT, sessionId, env }),
   // The user's MCP servers are read per spawn, so a settings edit applies to the next session.

--- a/server/index.ts
+++ b/server/index.ts
@@ -77,8 +77,8 @@ import type { TaskDefinition } from "@mulmoclaude/core/scheduler";
 import { initMulmoScriptBackend } from "./backends/mulmoscript.js";
 import { createSessionLifecycle, SESSIONS_CHANNEL } from "./session/lifecycle.js";
 import { mountAppRoutes } from "./routes/app-routes.js";
-import { allowedToolNames } from "./infra/plugins-registry.js";
-import { AUTO_ALLOWED_TOOL_GROUPS } from "../common/toolGroups.js";
+import { allowedToolNames, autoAllowedToolNames } from "./infra/plugins-registry.js";
+
 import { resumableSessionPredicate } from "./session/resumable-sessions.js";
 import { installProcessGuards } from "./infra/process-guards.js";
 import { pruneOrphanSettings } from "./session/session-settings.js";
@@ -144,7 +144,7 @@ const GUI_MCP_TOOLS = [...allowedToolNames(), "mcp__mulmoterminal-gui__submitTra
 // names the auto-allowed groups unconditionally; entries for a server the session didn't
 // register match nothing. Only `render` is here: it cannot act outside the Canvas panel, so
 // running it without a prompt is the point. Every other group keeps Claude Code's own prompt.
-const GRID_MCP_TOOLS = AUTO_ALLOWED_TOOL_GROUPS.flatMap((group) => allowedToolNames(group)).join(",");
+const GRID_MCP_TOOLS = autoAllowedToolNames().join(",");
 
 // The panel's per-session stores. `publish` is a closure rather than the pubsub object
 // because pub/sub only exists once the HTTP server does, and these are built before it.

--- a/server/infra/gui-mcp-registration.ts
+++ b/server/infra/gui-mcp-registration.ts
@@ -1,0 +1,61 @@
+// Turning a directory's GUI tool group on and off, through Claude Code's OWN per-folder MCP
+// config rather than a MulmoTerminal setting.
+//
+// MulmoTerminal deliberately stores nothing about this: `claude mcp add -s local` writes the
+// registration into ~/.claude.json keyed by the directory, which is already the mechanism for
+// "this folder gets that MCP server" — a second registry here would be one more place to look,
+// with no approval gate and no `claude mcp list` to see it in.
+//
+// `local` scope, not `project`: it lands in the user's own file rather than a `.mcp.json`
+// committed to their repo, so enabling a tool group for yourself never shows up in a diff.
+//
+// The url is a TEMPLATE, not a resolved address. Claude Code expands `${VAR}` in an MCP url at
+// connect time, and the two moving parts (our port, the session id) are only known per spawn —
+// they are set on each session's environment (see session/mcp-config.ts guiMcpEnv).
+import { spawnCapture } from "./spawnCapture.js";
+import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
+
+export const guiMcpUrlTemplate = (group: ToolGroup): string => `http://127.0.0.1:\${MULMOTERMINAL_PORT}/api/mcp/${group}/\${MULMOTERMINAL_SESSION_ID}`;
+
+export interface GuiMcpRegistration {
+  ok: boolean;
+  /** stdout+stderr from the CLI, so a failure can be shown rather than guessed at. */
+  message: string;
+}
+
+// `cwd` is what makes it per-folder: local scope is keyed by the directory the CLI runs in.
+function claudeMcp(bin: string, cwd: string, args: string[]): GuiMcpRegistration {
+  // Both streams: the CLI explains a refusal on stderr, and "it failed" with an empty message
+  // is the one thing this route must never answer.
+  const { status, stdout, stderr } = spawnCapture(bin, ["mcp", ...args], cwd);
+  return { ok: status === 0, message: [stdout, stderr].filter(Boolean).join("\n").trim() };
+}
+
+export function registerGuiMcpGroup(bin: string, cwd: string, group: ToolGroup): GuiMcpRegistration {
+  const id = toolGroupServerId(group);
+  // Remove first so re-enabling repairs a registration written against an older url (the
+  // template changes only when the route does, but a user may also have edited it). `remove`
+  // failing means it was not there, which is the normal case — its status is deliberately
+  // ignored rather than reported as the operation's.
+  claudeMcp(bin, cwd, ["remove", id, "-s", "local"]);
+  return claudeMcp(bin, cwd, ["add", "-s", "local", "--transport", "http", id, guiMcpUrlTemplate(group)]);
+}
+
+export function unregisterGuiMcpGroup(bin: string, cwd: string, group: ToolGroup): GuiMcpRegistration {
+  return claudeMcp(bin, cwd, ["remove", toolGroupServerId(group), "-s", "local"]);
+}
+
+// Which groups this directory has registered, read back from the CLI rather than remembered:
+// the user can add or remove one with `claude mcp` behind our back, and a cached answer would
+// then describe a directory that no longer exists as described.
+export function registeredGuiMcpGroups(bin: string, cwd: string, groups: readonly ToolGroup[]): ToolGroup[] {
+  const { status, stdout } = spawnCapture(bin, ["mcp", "list"], cwd);
+  if (status !== 0) return [];
+  return groups.filter((group) => listMentionsServer(stdout, toolGroupServerId(group)));
+}
+
+// `claude mcp list` prints `<id>: <command or url> - <status>` per line. Matched at the start of
+// a line so a server whose URL happens to contain another group's id is not counted twice.
+export function listMentionsServer(listOutput: string, serverId: string): boolean {
+  return listOutput.split("\n").some((line) => line.trimStart().startsWith(`${serverId}:`));
+}

--- a/server/infra/gui-mcp-registration.ts
+++ b/server/infra/gui-mcp-registration.ts
@@ -12,7 +12,7 @@
 // The url is a TEMPLATE, not a resolved address. Claude Code expands `${VAR}` in an MCP url at
 // connect time, and the two moving parts (our port, the session id) are only known per spawn —
 // they are set on each session's environment (see session/mcp-config.ts guiMcpEnv).
-import { spawnCapture } from "./spawnCapture.js";
+import { spawnCaptureAsync } from "./spawnCapture.js";
 import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 
 export const guiMcpUrlTemplate = (group: ToolGroup): string => `http://127.0.0.1:\${MULMOTERMINAL_PORT}/api/mcp/${group}/\${MULMOTERMINAL_SESSION_ID}`;
@@ -24,32 +24,32 @@ export interface GuiMcpRegistration {
 }
 
 // `cwd` is what makes it per-folder: local scope is keyed by the directory the CLI runs in.
-function claudeMcp(bin: string, cwd: string, args: string[]): GuiMcpRegistration {
+async function claudeMcp(bin: string, cwd: string, args: string[]): Promise<GuiMcpRegistration> {
   // Both streams: the CLI explains a refusal on stderr, and "it failed" with an empty message
   // is the one thing this route must never answer.
-  const { status, stdout, stderr } = spawnCapture(bin, ["mcp", ...args], cwd);
+  const { status, stdout, stderr } = await spawnCaptureAsync(bin, ["mcp", ...args], { cwd });
   return { ok: status === 0, message: [stdout, stderr].filter(Boolean).join("\n").trim() };
 }
 
-export function registerGuiMcpGroup(bin: string, cwd: string, group: ToolGroup): GuiMcpRegistration {
+export async function registerGuiMcpGroup(bin: string, cwd: string, group: ToolGroup): Promise<GuiMcpRegistration> {
   const id = toolGroupServerId(group);
   // Remove first so re-enabling repairs a registration written against an older url (the
   // template changes only when the route does, but a user may also have edited it). `remove`
   // failing means it was not there, which is the normal case — its status is deliberately
   // ignored rather than reported as the operation's.
-  claudeMcp(bin, cwd, ["remove", id, "-s", "local"]);
+  await claudeMcp(bin, cwd, ["remove", id, "-s", "local"]);
   return claudeMcp(bin, cwd, ["add", "-s", "local", "--transport", "http", id, guiMcpUrlTemplate(group)]);
 }
 
-export function unregisterGuiMcpGroup(bin: string, cwd: string, group: ToolGroup): GuiMcpRegistration {
+export function unregisterGuiMcpGroup(bin: string, cwd: string, group: ToolGroup): Promise<GuiMcpRegistration> {
   return claudeMcp(bin, cwd, ["remove", toolGroupServerId(group), "-s", "local"]);
 }
 
 // Which groups this directory has registered, read back from the CLI rather than remembered:
 // the user can add or remove one with `claude mcp` behind our back, and a cached answer would
 // then describe a directory that no longer exists as described.
-export function registeredGuiMcpGroups(bin: string, cwd: string, groups: readonly ToolGroup[]): ToolGroup[] {
-  const { status, stdout } = spawnCapture(bin, ["mcp", "list"], cwd);
+export async function registeredGuiMcpGroups(bin: string, cwd: string, groups: readonly ToolGroup[]): Promise<ToolGroup[]> {
+  const { status, stdout } = await spawnCaptureAsync(bin, ["mcp", "list"], { cwd });
   if (status !== 0) return [];
   return groups.filter((group) => listMentionsServer(stdout, toolGroupServerId(group)));
 }

--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -32,6 +32,7 @@ import { artifactsFileOps } from "../backends/artifacts.js";
 import { createPluginRuntime } from "./pluginRuntime.js";
 import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
+import { groupOfTool, toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 import { missingRequiredEnv, soleExecutor } from "./server-tool-load.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -224,6 +225,14 @@ export function mountAllRoutes(app: Express) {
 
 // Fully-qualified MCP tool names for claude's --allowedTools (auto-run, no prompt).
 // Includes host tools so they run without a permission prompt too.
-export function allowedToolNames() {
-  return toolDefinitions.map((d) => `mcp__${MCP_SERVER_NAME}__${d.name}`);
+//
+// `group` names one of the per-group URLs instead of the all-tools surface. The prefix has to
+// change with it: --allowedTools matches on `mcp__<server id>__<tool>`, and a group is
+// registered under its own id (common/toolGroups.ts). Passing a group the session may not
+// even have registered is harmless — an allowlist entry for a server that isn't there matches
+// nothing, which is exactly what lets the grid pass `render` unconditionally.
+export function allowedToolNames(group: ToolGroup | null = null) {
+  const serverId = group === null ? MCP_SERVER_NAME : toolGroupServerId(group);
+  const defs = group === null ? toolDefinitions : toolDefinitions.filter((d) => groupOfTool(d.name) === group);
+  return defs.map((d) => `mcp__${serverId}__${d.name}`);
 }

--- a/server/infra/plugins-registry.ts
+++ b/server/infra/plugins-registry.ts
@@ -32,7 +32,7 @@ import { artifactsFileOps } from "../backends/artifacts.js";
 import { createPluginRuntime } from "./pluginRuntime.js";
 import { resolvePluginTools } from "./tool-precedence.js";
 import { HOST_TOOL_DEFINITIONS } from "./host-tools.js";
-import { groupOfTool, toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
+import { groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOLS, type ToolGroup } from "../../common/toolGroups.js";
 import { missingRequiredEnv, soleExecutor } from "./server-tool-load.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -235,4 +235,15 @@ export function allowedToolNames(group: ToolGroup | null = null) {
   const serverId = group === null ? MCP_SERVER_NAME : toolGroupServerId(group);
   const defs = group === null ? toolDefinitions : toolDefinitions.filter((d) => groupOfTool(d.name) === group);
   return defs.map((d) => `mcp__${serverId}__${d.name}`);
+}
+
+// The fully-qualified names a GRID cell pre-approves: the auto-allowed tools, each under the
+// server id of the group it belongs to. Derived per TOOL rather than per group because "which
+// tools may this directory reach" and "which may run without asking" are different questions —
+// see AUTO_ALLOWED_TOOLS for the one that forces them apart.
+export function autoAllowedToolNames() {
+  return AUTO_ALLOWED_TOOLS.flatMap((name) => {
+    const group = groupOfTool(name);
+    return group === null ? [] : [`mcp__${toolGroupServerId(group)}__${name}`];
+  });
 }

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -1,11 +1,51 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync, execFile } from "node:child_process";
+import { promisify } from "node:util";
 
-// `cwd` matters for tools whose answer depends on the directory they run in — `claude mcp`
-// reads and writes LOCAL-scope config keyed by exactly that. Omitted, the child inherits ours.
+const execFileAsync = promisify(execFile);
+
+// Long enough for `claude mcp list`, which health-checks every registered server, and short
+// enough that a hung CLI surfaces as an error the UI can show rather than a request that never
+// answers.
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export interface Captured {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+// SYNCHRONOUS, and therefore only for callers that run at boot or between requests — a docker
+// label, a tmux probe, a keychain read. It blocks the event loop for as long as the child runs,
+// so anything reachable from an HTTP handler must use spawnCaptureAsync below instead.
 //
 // stderr is returned SEPARATELY, never folded in: callers here read stdout as data (a keychain
 // secret, a docker label), and a warning printed alongside a successful run would corrupt it.
-export function spawnCapture(bin: string, args: string[], cwd?: string): { status: number | null; stdout: string; stderr: string } {
-  const r = spawnSync(bin, args, { encoding: "utf8", cwd });
+export function spawnCapture(bin: string, args: string[]): Captured {
+  const r = spawnSync(bin, args, { encoding: "utf8" });
   return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+// The request-facing form. `claude mcp` is reached from GET and POST handlers, and the CLI can
+// stall (a slow MCP health check, a hung OAuth refresh) — synchronously that would freeze every
+// other request on this server, not just the one waiting.
+//
+// `cwd` matters for tools whose answer depends on the directory they run in: `claude mcp` reads
+// and writes LOCAL-scope config keyed by exactly that. Omitted, the child inherits ours.
+//
+// execFile, not exec: the arguments stay an array, so nothing built from a request body is ever
+// parsed by a shell. The timeout kills the child rather than waiting on it forever.
+export async function spawnCaptureAsync(bin: string, args: string[], options: { cwd?: string; timeoutMs?: number } = {}): Promise<Captured> {
+  try {
+    const { stdout, stderr } = await execFileAsync(bin, args, { encoding: "utf8", cwd: options.cwd, timeout: options.timeoutMs ?? DEFAULT_TIMEOUT_MS });
+    return { status: 0, stdout, stderr };
+  } catch (e) {
+    // A non-zero exit and a timeout both land here; both carry whatever the child managed to
+    // print, which is what the caller reports to the user.
+    const err = e as { code?: unknown; stdout?: string; stderr?: string; message?: string };
+    return {
+      status: typeof err.code === "number" ? err.code : 1,
+      stdout: err.stdout ?? "",
+      stderr: err.stderr || err.message || "",
+    };
+  }
 }

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -1,6 +1,11 @@
 import { spawnSync } from "node:child_process";
 
-export function spawnCapture(bin: string, args: string[]): { status: number | null; stdout: string } {
-  const r = spawnSync(bin, args, { encoding: "utf8" });
-  return { status: r.status, stdout: r.stdout ?? "" };
+// `cwd` matters for tools whose answer depends on the directory they run in — `claude mcp`
+// reads and writes LOCAL-scope config keyed by exactly that. Omitted, the child inherits ours.
+//
+// stderr is returned SEPARATELY, never folded in: callers here read stdout as data (a keychain
+// secret, a docker label), and a warning printed alongside a successful run would corrupt it.
+export function spawnCapture(bin: string, args: string[], cwd?: string): { status: number | null; stdout: string; stderr: string } {
+  const r = spawnSync(bin, args, { encoding: "utf8", cwd });
+  return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -240,8 +240,16 @@ export const tmuxSessionName = (id: string): string => `${SESSION_PREFIX}${id}`;
 // it doesn't exist, else ATTACH to the running one (the command is ignored). This one
 // primitive covers both first launch and reattach-after-restart. Returned as the args
 // for pty.spawn("tmux", ...).
-export function tmuxNewSessionArgs(id: string, file: string, args: string[], cwd: string): string[] {
-  return ["-L", SERVER_SOCKET, "-f", CONF_FILE, "new-session", "-A", "-s", tmuxSessionName(id), "-c", cwd, "--", file, ...args];
+// `env` is set on the new session with `-e`, NOT inherited from our own process: a tmux pane
+// takes the tmux SERVER's environment, and that server outlives any one session, so a variable
+// exported here would either be missing or — worse — hold a previous session's value.
+//
+// With `-A` the flag only applies when the session is CREATED; reattaching an existing one
+// keeps the environment it was created with, which is what we want (its claude process is
+// already running with the value it was given).
+export function tmuxNewSessionArgs(id: string, file: string, args: string[], cwd: string, env: Readonly<Record<string, string>> = {}): string[] {
+  const envArgs = Object.entries(env).flatMap(([key, value]) => ["-e", `${key}=${value}`]);
+  return ["-L", SERVER_SOCKET, "-f", CONF_FILE, "new-session", "-A", "-s", tmuxSessionName(id), "-c", cwd, ...envArgs, "--", file, ...args];
 }
 
 // Is a persistent session for this id currently alive in our tmux server?

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -28,6 +28,7 @@ import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprot
 import { randomUUID } from "node:crypto";
 import { toolDefinitions } from "../infra/plugins-registry.js";
 import { offeredTools, routeToolCall, SUBMIT_TRANSLATION_TOOL_NAME } from "./tool-gate.js";
+import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 import { interpretToolEnvelope } from "./tool-envelope.js";
 import { isRecord } from "../../common/isRecord.js";
 
@@ -71,21 +72,28 @@ const SUBMIT_TRANSLATION_TOOL = {
  * @param baseUrl    the mulmoterminal host origin to POST plugin dispatch + results to
  * @param opts.submitTranslationTool  expose the worker-only `submitTranslation` tool
  *                                    (set only for hidden translation-worker sessions)
+ * @param opts.group  serve only one GROUP of the GUI tools (the `/api/mcp/<group>/<id>` URLs,
+ *                    which exist so a directory can enable a subset through Claude Code's own
+ *                    per-folder MCP config). Null/absent = every tool, the single view's URL.
  */
-export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { submitTranslationTool?: boolean } = {}): Server {
-  const server = new Server({ name: "mulmoterminal-gui", version: "0.0.0" }, { capabilities: { tools: {} } });
+export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { submitTranslationTool?: boolean; group?: ToolGroup | null } = {}): Server {
+  const group = opts.group ?? null;
+  // The advertised server name follows the id a group is expected to be registered under, so
+  // what a user sees in `claude mcp list` matches what they wrote in their own config.
+  const serverName = group === null ? "mulmoterminal-gui" : toolGroupServerId(group);
+  const server = new Server({ name: serverName, version: "0.0.0" }, { capabilities: { tools: {} } });
 
-  // Both layers of the worker gate live in mcp/tool-gate.ts (pure/tested): a worker is
-  // offered submitTranslation alone, and anything else it names is refused below.
+  // Both layers of the worker AND group gates live in mcp/tool-gate.ts (pure/tested): the
+  // offer is filtered here, and anything outside it that gets named anyway is refused below.
   const isWorker = !!opts.submitTranslationTool;
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: offeredTools(isWorker, toolDefinitions, SUBMIT_TRANSLATION_TOOL),
+    tools: offeredTools(isWorker, toolDefinitions, SUBMIT_TRANSLATION_TOOL, group),
   }));
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
-    const route = routeToolCall(name, isWorker);
+    const route = routeToolCall(name, isWorker, group);
 
     // Worker-only result tool: deliver the structured translations back to the
     // waiting request (keyed by session id), bypassing the plugin dispatch path.

--- a/server/mcp/tool-gate.ts
+++ b/server/mcp/tool-gate.ts
@@ -8,9 +8,16 @@
 // even though it was never advertised. Two layers, because the first one is only a list and
 // a model can name a tool it was not shown.
 //
+// The GROUP gate below is the same two-layer shape for a different reason. A group URL
+// (`/api/mcp/render/:id`) exists so a directory can switch a SUBSET of the GUI tools on
+// through Claude Code's own per-folder MCP config; a session that reached us through it must
+// not be able to call outside its group by naming a tool it was never offered — same
+// assumption, same second layer.
+//
 // Split out of broker.ts because both rules previously lived inside MCP request handlers,
 // reachable only by standing up a server and speaking JSON-RPC to it — so neither had a
 // test (#611 A1).
+import { groupOfTool, type ToolGroup } from "../../common/toolGroups.js";
 
 // The shape the broker registers, structurally rather than by import, so this file stays
 // free of the plugin registry (and of everything the registry loads).
@@ -37,9 +44,18 @@ const NO_PARAMETERS = { type: "object", properties: {} };
 // model receives, so it is folded into the description or the model never sees it.
 export const describeTool = (def: PluginToolDefinition): string => [def.description, def.prompt].filter(Boolean).join("\n\n");
 
-export function offeredTools(isTranslationWorker: boolean, plugins: readonly PluginToolDefinition[], workerTool: OfferedTool): OfferedTool[] {
+// `group` null means the all-tools surface (the single view's URL, unchanged). A group filters
+// the offer down to the tools classified into it — and an UNCLASSIFIED tool is in no group, so
+// it never reaches a group URL (see common/toolGroups.ts for why that direction is deliberate).
+export function offeredTools(
+  isTranslationWorker: boolean,
+  plugins: readonly PluginToolDefinition[],
+  workerTool: OfferedTool,
+  group: ToolGroup | null = null,
+): OfferedTool[] {
   if (isTranslationWorker) return [workerTool];
-  return plugins.map((def) => ({ name: def.name, description: describeTool(def), inputSchema: def.parameters ?? NO_PARAMETERS }));
+  const offered = group === null ? plugins : plugins.filter((def) => groupOfTool(def.name) === group);
+  return offered.map((def) => ({ name: def.name, description: describeTool(def), inputSchema: def.parameters ?? NO_PARAMETERS }));
 }
 
 export type ToolRoute =
@@ -48,7 +64,7 @@ export type ToolRoute =
   // Hand off to the plugin dispatch route.
   | { kind: "dispatch" };
 
-export function routeToolCall(name: string, isTranslationWorker: boolean): ToolRoute {
+export function routeToolCall(name: string, isTranslationWorker: boolean, group: ToolGroup | null = null): ToolRoute {
   const isWorkerTool = name === SUBMIT_TRANSLATION_TOOL_NAME;
   if (isTranslationWorker) {
     if (isWorkerTool) return { kind: "submit-translation" };
@@ -59,5 +75,10 @@ export function routeToolCall(name: string, isTranslationWorker: boolean): ToolR
   // translation pending, which is a 404 from another module rather than a decision made here
   // — and the layer above already assumes a model can name a tool it was never shown.
   if (isWorkerTool) return { kind: "refused", message: `Tool "${name}" is not available.` };
+  // Second layer of the group gate. Refused, not dispatched: the dispatch route would happily
+  // run any registered plugin, so "we never offered it" is not a control.
+  if (group !== null && groupOfTool(name) !== group) {
+    return { kind: "refused", message: `Tool "${name}" is not available on the "${group}" tool group.` };
+  }
   return { kind: "dispatch" };
 }

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -22,6 +22,7 @@ import { mountSessionRoutes } from "../routes/session-routes.js";
 import { mountToolRoutes } from "../routes/tool-routes.js";
 import { mountRepoRoutes } from "../routes/repo-routes.js";
 import { mountDirRoutes } from "../routes/dir-routes.js";
+import { mountGuiMcpRoutes } from "../routes/gui-mcp-routes.js";
 import { mountOpenDirRoute } from "../files/open-dir.js";
 import { mountGitRemoteRoute } from "../git/gitRemote.js";
 import { mountWorktreeRoutes } from "../git/worktree-routes.js";
@@ -39,7 +40,7 @@ import { mountNotificationRoutes } from "../backends/notifier.js";
 import { mountWhisperRoutes } from "../backends/whisper.js";
 import { mountSchedulerRoutes } from "../backends/scheduler.js";
 import { mountFilesRoutes } from "../backends/files.js";
-import { ptys } from "../session/registry.js";
+import { ptys, sessionToolGroups, sessionToolGroupsHydrated, devTerminalSessions, devTerminalSessionsHydrated } from "../session/registry.js";
 import { mountShortcutsRoutes } from "../backends/shortcuts.js";
 import { mountTranslationRoutes } from "../backends/translation.js";
 import { mountHtmlDispatchRoute, mountHtmlPreviewRoute } from "../backends/html.js";
@@ -212,6 +213,10 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
   mountToolRoutes(app, {
     stores: deps.toolStores,
     toolSummaries: deps.toolSummaries,
+    sessionToolGroups,
+    sessionToolGroupsHydrated,
+    isGridSession: (id) => devTerminalSessions.has(id),
+    devTerminalSessionsHydrated,
     publish: (c, d) => deps.publish(c, d),
     sessionChannel: deps.sessionChannel,
   });
@@ -232,6 +237,7 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
   // Directory-scoped reads for a terminal cell: scripts, skills, dir config, git status,
   // PR phase, resolved header, custom sound. All keyed by ?cwd= (see routes/dir-routes.ts).
   mountDirRoutes(app);
+  mountGuiMcpRoutes(app);
 
   // GRID-ONLY (dev_tool): POST /api/open-dir reveals a cell's working directory in the
   // OS file manager (a browser tab can't, but this local server can).

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -170,7 +170,7 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
 
   // The agent-facing MCP surface (routes/mcp-routes.ts): the in-process GUI MCP server over
   // Streamable HTTP, and the worker-only landing point the hidden translation worker reports to.
-  mountMcpRoutes(app);
+  mountMcpRoutes(app, { publish: (c, d) => deps.publish(c, d) });
 
   // Serve Vite build output
   app.use(express.static(path.join(clientDir, "../dist")));

--- a/server/routes/gui-mcp-routes.ts
+++ b/server/routes/gui-mcp-routes.ts
@@ -1,0 +1,38 @@
+// Turning a directory's GUI tool groups on and off. Its own module rather than another
+// /api/dir-* route: those all READ something about a directory from files we own, while these
+// two read and WRITE Claude Code's own MCP config by shelling out to its CLI.
+import type { Express } from "express";
+import { existingWorkspace, existingWorkspaceFromQuery } from "../config/workspace.js";
+import { claudeAdapter } from "../agents/claude.js";
+import { TOOL_GROUPS, isToolGroup } from "../../common/toolGroups.js";
+import { registerGuiMcpGroup, unregisterGuiMcpGroup, registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
+
+export function mountGuiMcpRoutes(app: Express): void {
+  // Which GUI tool groups this directory has registered with Claude Code, so the launcher can
+  // show the Canvas switch in the right position. Read back from `claude mcp list` per request
+  // rather than remembered — the user can add or remove one with the CLI behind our back.
+  //
+  // Same no-fallback rule as /api/dir-config-detail: this REPORTS ON the directory it was asked
+  // about, and answering about the default workspace under another directory's name is worse
+  // than answering "unknown".
+  app.get("/api/gui-mcp-groups", (req, res) => {
+    const cwd = existingWorkspaceFromQuery(req.query.cwd);
+    if (!cwd) return res.json({ groups: [] });
+    res.json({ groups: registeredGuiMcpGroups(claudeAdapter.bin(), cwd, TOOL_GROUPS) });
+  });
+
+  // Turn a group on or off for this directory. Writes through `claude mcp` into LOCAL scope —
+  // the user's own file, keyed by the directory — so MulmoTerminal stores nothing of its own
+  // and `claude mcp list` stays the one place the registration can be seen.
+  //
+  // It takes effect on the cell's NEXT start: the tools are handed to claude when the session
+  // spawns, so a session already running keeps whatever it was given.
+  app.post("/api/gui-mcp-groups", (req, res) => {
+    const cwd = existingWorkspace(typeof req.body?.cwd === "string" ? req.body.cwd : null);
+    const { group, enabled } = req.body ?? {};
+    if (!cwd) return res.status(400).json({ ok: false, message: "unknown directory" });
+    if (!isToolGroup(group)) return res.status(400).json({ ok: false, message: `unknown tool group: ${group}` });
+    const result = enabled ? registerGuiMcpGroup(claudeAdapter.bin(), cwd, group) : unregisterGuiMcpGroup(claudeAdapter.bin(), cwd, group);
+    res.json(result);
+  });
+}

--- a/server/routes/gui-mcp-routes.ts
+++ b/server/routes/gui-mcp-routes.ts
@@ -15,10 +15,10 @@ export function mountGuiMcpRoutes(app: Express): void {
   // Same no-fallback rule as /api/dir-config-detail: this REPORTS ON the directory it was asked
   // about, and answering about the default workspace under another directory's name is worse
   // than answering "unknown".
-  app.get("/api/gui-mcp-groups", (req, res) => {
+  app.get("/api/gui-mcp-groups", async (req, res) => {
     const cwd = existingWorkspaceFromQuery(req.query.cwd);
     if (!cwd) return res.json({ groups: [] });
-    res.json({ groups: registeredGuiMcpGroups(claudeAdapter.bin(), cwd, TOOL_GROUPS) });
+    res.json({ groups: await registeredGuiMcpGroups(claudeAdapter.bin(), cwd, TOOL_GROUPS) });
   });
 
   // Turn a group on or off for this directory. Writes through `claude mcp` into LOCAL scope —
@@ -27,12 +27,16 @@ export function mountGuiMcpRoutes(app: Express): void {
   //
   // It takes effect on the cell's NEXT start: the tools are handed to claude when the session
   // spawns, so a session already running keeps whatever it was given.
-  app.post("/api/gui-mcp-groups", (req, res) => {
+  app.post("/api/gui-mcp-groups", async (req, res) => {
     const cwd = existingWorkspace(typeof req.body?.cwd === "string" ? req.body.cwd : null);
     const { group, enabled } = req.body ?? {};
     if (!cwd) return res.status(400).json({ ok: false, message: "unknown directory" });
     if (!isToolGroup(group)) return res.status(400).json({ ok: false, message: `unknown tool group: ${group}` });
-    const result = enabled ? registerGuiMcpGroup(claudeAdapter.bin(), cwd, group) : unregisterGuiMcpGroup(claudeAdapter.bin(), cwd, group);
+    // Checked rather than coerced: this writes to the user's Claude Code config, and a missing
+    // or misspelled field arriving as falsy would silently REMOVE a registration the caller
+    // meant to add.
+    if (typeof enabled !== "boolean") return res.status(400).json({ ok: false, message: "enabled must be a boolean" });
+    const result = await (enabled ? registerGuiMcpGroup(claudeAdapter.bin(), cwd, group) : unregisterGuiMcpGroup(claudeAdapter.bin(), cwd, group));
     res.json(result);
   });
 }

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -11,7 +11,8 @@ import type { Express, Request, Response } from "express";
 
 import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { buildGuiMcpServer } from "../mcp/broker.js";
-import { translationWorkerIds } from "../session/registry.js";
+import { translationWorkerIds, markSessionToolGroup } from "../session/registry.js";
+import { isToolGroup, type ToolGroup } from "../../common/toolGroups.js";
 import { submitTranslation } from "../session/translation-worker.js";
 import { translationSubmitOutcome } from "../session/translation-submit.js";
 
@@ -22,14 +23,16 @@ export function mountMcpRoutes(app: Express): void {
   // We run in STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
   // request, no session header and no initialize handshake required across requests. The SDK
   // forbids reusing a stateless transport, so it is never cached.
-  app.post("/api/mcp/:sessionId", async (req, res) => {
-    const { sessionId } = req.params;
+  async function handleMcpRequest(req: Request, res: Response, sessionId: string, group: ToolGroup | null) {
     if (!SESSION_ID_RE.test(sessionId)) {
       return res.status(400).json({ error: "invalid sessionId" });
     }
     // Hidden translation workers (and only they) get the worker-only submitTranslation
     // tool, so a normal chat's tool list stays clean.
-    const server = buildGuiMcpServer(sessionId, `http://127.0.0.1:${PORT}`, { submitTranslationTool: translationWorkerIds.has(sessionId) });
+    const server = buildGuiMcpServer(sessionId, `http://127.0.0.1:${PORT}`, {
+      submitTranslationTool: translationWorkerIds.has(sessionId),
+      group,
+    });
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on("close", () => {
       transport.close();
@@ -42,9 +45,28 @@ export function mountMcpRoutes(app: Express): void {
       console.error(`[mcp] request failed for ${sessionId}:`, err);
       if (!res.headersSent) res.status(500).json({ error: "mcp error" });
     }
-  });
+  }
+
+  app.post("/api/mcp/:sessionId", (req, res) => handleMcpRequest(req, res, req.params.sessionId, null));
   app.get("/api/mcp/:sessionId", rejectNonPost);
   app.delete("/api/mcp/:sessionId", rejectNonPost);
+
+  // One URL per tool group. Registered SECOND so the single-segment route above keeps its
+  // meaning ("every tool") — Express matches on segment count, so the two never collide.
+  //
+  // An unknown group is a 404 rather than a fallback to the all-tools surface: a typo in a
+  // user's own `.mcp.json` must not silently hand a directory every tool there is.
+  app.post("/api/mcp/:group/:sessionId", (req, res) => {
+    const { group, sessionId } = req.params;
+    if (!isToolGroup(group)) return res.status(404).json({ error: `unknown tool group: ${group}` });
+    // Reaching us here IS the evidence that this session has the group — nothing else tells
+    // us, since the registration lives in the user's own MCP config. Marked before the request
+    // is served so a panel asking right after the first ListTools already sees it.
+    if (SESSION_ID_RE.test(sessionId)) markSessionToolGroup(sessionId, group);
+    return handleMcpRequest(req, res, sessionId, group);
+  });
+  app.get("/api/mcp/:group/:sessionId", rejectNonPost);
+  app.delete("/api/mcp/:group/:sessionId", rejectNonPost);
 
   // The array is handed to the waiting request as-is; translateViaHiddenChat validates it.
   app.post("/api/translation/submit", (req, res) => {

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -11,7 +11,7 @@ import type { Express, Request, Response } from "express";
 
 import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { buildGuiMcpServer } from "../mcp/broker.js";
-import { translationWorkerIds, markSessionToolGroup } from "../session/registry.js";
+import { translationWorkerIds, markSessionToolGroup, sessionToolGroups } from "../session/registry.js";
 import { isToolGroup, type ToolGroup } from "../../common/toolGroups.js";
 import { submitTranslation } from "../session/translation-worker.js";
 import { translationSubmitOutcome } from "../session/translation-submit.js";
@@ -19,7 +19,21 @@ import { translationSubmitOutcome } from "../session/translation-submit.js";
 // No SSE stream and no session teardown in stateless mode, so everything but POST is refused.
 const rejectNonPost = (_req: Request, res: Response) => res.status(405).set("Allow", "POST").json({ error: "method not allowed" });
 
-export function mountMcpRoutes(app: Express): void {
+// A session's tool groups are LEARNED, and the client cannot predict when: the browser is
+// handed the session id before claude is even spawned, so the panel's first question about it
+// is normally asked before claude's MCP client has connected. Without a push, that first "no"
+// would stand until the user collapsed and re-expanded the cell.
+//
+// Its own channel rather than the `sessions` one: that channel's consumer guards with
+// `"id" in d` and feeds whatever passes to applyActivity, so a foreign message shaped like
+// this would be read as an activity update.
+export const TOOL_GROUPS_CHANNEL = "tool-groups";
+
+export interface McpRouteDeps {
+  publish: (channel: string, data: unknown) => void;
+}
+
+export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
   // We run in STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
   // request, no session header and no initialize handshake required across requests. The SDK
   // forbids reusing a stateless transport, so it is never cached.
@@ -62,7 +76,12 @@ export function mountMcpRoutes(app: Express): void {
     // Reaching us here IS the evidence that this session has the group — nothing else tells
     // us, since the registration lives in the user's own MCP config. Marked before the request
     // is served so a panel asking right after the first ListTools already sees it.
-    if (SESSION_ID_RE.test(sessionId)) markSessionToolGroup(sessionId, group);
+    if (SESSION_ID_RE.test(sessionId) && !sessionToolGroups(sessionId).includes(group)) {
+      markSessionToolGroup(sessionId, group);
+      // Announced only on the transition, so the panel is told once per handshake rather than
+      // on every tool call for the life of the session.
+      deps.publish(TOOL_GROUPS_CHANNEL, { sessionId, groups: sessionToolGroups(sessionId) });
+    }
     return handleMcpRequest(req, res, sessionId, group);
   });
   app.get("/api/mcp/:group/:sessionId", rejectNonPost);

--- a/server/routes/tool-routes.ts
+++ b/server/routes/tool-routes.ts
@@ -6,13 +6,50 @@ import type { Express } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
 import type { createToolStores } from "../session/tool-store.js";
 import { planToolResultUpdate } from "./toolResultPlan.js";
+import { groupOfTool, type ToolGroup } from "../../common/toolGroups.js";
+
+export interface ToolSummary {
+  toolName: string;
+  title: string;
+  description?: string;
+}
 
 export interface ToolRouteDeps {
   stores: ReturnType<typeof createToolStores>;
   /** The GUI plugin tools this server exposes, for the pane's "Available Tools" list. */
-  toolSummaries: unknown;
+  toolSummaries: ToolSummary[];
+  /** Which tool groups a session actually reached us on — see session/session-tool-groups.ts. */
+  sessionToolGroups: (sessionId: string) => ToolGroup[];
+  sessionToolGroupsHydrated: Promise<void>;
+  /**
+   * Is this a GRID cell? The two kinds of session get their GUI tools by different routes, and
+   * "no groups learned" means the opposite thing for each — see narrowedTools.
+   */
+  isGridSession: (sessionId: string) => boolean;
+  devTerminalSessionsHydrated: Promise<void>;
   publish: (channel: string, data: unknown) => void;
   sessionChannel: (id: string) => string;
+}
+
+// An UNGROUPED tool (spawnBackgroundChat) belongs to no group URL, so it cannot have reached a
+// grid cell — it is listed only for a session we did not narrow at all.
+const hasGroup = (group: ToolGroup | null, groups: readonly ToolGroup[]): boolean => group !== null && groups.includes(group);
+
+/**
+ * The tools a session actually has.
+ *
+ * The rule that matters: an EMPTY group list means opposite things for the two kinds of session,
+ * and conflating them is what let a grid cell with no MCP registered report every tool — and so
+ * offer a Canvas button that opened a panel nothing could ever fill.
+ *
+ *   single view — carries the whole GUI MCP on --mcp-config and never connects to a group URL,
+ *                 so it learns no groups and nonetheless has everything.
+ *   grid cell   — has exactly what its directory registered with Claude Code. Nothing
+ *                 registered, nothing learned, nothing available.
+ */
+export function narrowedTools(tools: readonly ToolSummary[], groups: readonly ToolGroup[], isGrid: boolean): ToolSummary[] {
+  if (!isGrid) return [...tools];
+  return tools.filter((tool) => hasGroup(groupOfTool(tool.toolName), groups));
 }
 
 export function mountToolRoutes(app: Express, deps: ToolRouteDeps): void {
@@ -46,11 +83,23 @@ export function mountToolRoutes(app: Express, deps: ToolRouteDeps): void {
     res.json({ sessionId, toolResults: await deps.stores.toolResultsStore.get(sessionId) });
   });
 
-  // The GUI plugin tools available this session (for the tools pane's "Available
-  // Tools" list). The full set claude can call — built-ins, other MCP — is not
-  // enumerable server-side; those still show up in the tool-call history below.
-  app.get("/api/tools", (_req, res) => {
-    res.json({ tools: deps.toolSummaries });
+  // The GUI plugin tools, for the tools pane's "Available Tools" list. The full set claude
+  // can call — built-ins, other MCP — is not enumerable server-side; those still show up in
+  // the tool-call history below.
+  //
+  // `?sessionId=` narrows it to what THAT session actually has. It is no longer the same for
+  // every session: a grid cell reaches the GUI tools through one URL per group, registered in
+  // the user's own per-folder MCP config, so two cells can differ. Without the parameter the
+  // answer stays the whole set (the single view, which carries every tool).
+  app.get("/api/tools", async (req, res) => {
+    const sessionId = typeof req.query.sessionId === "string" ? req.query.sessionId : null;
+    if (sessionId === null || !SESSION_ID_RE.test(sessionId)) return res.json({ tools: deps.toolSummaries });
+    // Both sets are persisted and hydrated at boot; asked before either resolves, a grid cell
+    // would read as having nothing and a resumed one as having lost its groups.
+    await Promise.all([deps.sessionToolGroupsHydrated, deps.devTerminalSessionsHydrated]);
+    const groups = deps.sessionToolGroups(sessionId);
+    const isGrid = deps.isGridSession(sessionId);
+    res.json({ tools: narrowedTools(deps.toolSummaries, groups, isGrid), groups });
   });
 
   // Replay a session's tool-call history (every tool, via the Pre/PostToolUse hooks)

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -24,6 +24,19 @@ export interface McpConfigInput {
 const DEFAULT_HOST = "127.0.0.1";
 const GUI_SERVER_ID = "mulmoterminal-gui";
 
+// The counterpart for GRID cells, which are handed no --mcp-config at all: their GUI tools
+// come from the user's OWN per-folder MCP config (`claude mcp add -s local`, `.mcp.json`),
+// where the URL is a static string and cannot carry a session id. Claude Code expands
+// `${VAR}` in an MCP url at connect time, so the two moving parts ride in the environment:
+//
+//   "url": "http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/render/${MULMOTERMINAL_SESSION_ID}"
+//
+// Set on every claude spawn, not just grid ones — the single view carries its own config and
+// simply never reads these, and a session that starts in one view is not worth special-casing.
+export function guiMcpEnv(sessionId: string, port: string | number): Record<string, string> {
+  return { MULMOTERMINAL_PORT: String(port), MULMOTERMINAL_SESSION_ID: sessionId };
+}
+
 export function mcpConfigJson({ sessionId, host = DEFAULT_HOST, port, userMcpServers, sandbox = false }: McpConfigInput): string {
   const mcpServers: Record<string, { type: string; url: string }> = {};
   // The user's servers go in FIRST so the built-in GUI entry below always wins on a clashing

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -32,8 +32,10 @@ const PTY_ROWS = 30;
 // `unset` drops variables the session must NOT inherit — ANTHROPIC_API_KEY for a provider
 // session, which would silently outrank its auth token (#579). It cannot be expressed in
 // the settings `env` block, which can set a variable but not remove one.
-export function spawnPty(bin: string, args: string[], cwd: string, unset: readonly string[] = []): IPty {
-  const env = withoutUnset(sanitizePtyEnv(process.env, path.delimiter), unset);
+// `extra` is set on the spawned process ON TOP of the sanitized inherited environment —
+// per-session values the child needs and our own process cannot carry (a session id).
+export function spawnPty(bin: string, args: string[], cwd: string, unset: readonly string[] = [], extra: Readonly<Record<string, string>> = {}): IPty {
+  const env = { ...withoutUnset(sanitizePtyEnv(process.env, path.delimiter), unset), ...extra };
   // On Windows neither the name nor the arguments reach node-pty as they are: its PATH
   // lookup ignores executable extensions (so `claude` misses claude.exe, #794), and a batch
   // shim has to be run through cmd.exe (#798). See infra/resolve-bin.ts.
@@ -48,6 +50,14 @@ export function sandboxWouldRun(attachGuiMcp: boolean): boolean {
   return sandboxEnabled() && sandboxPlatformSupported() && attachGuiMcp && dockerAvailable() && sandboxImageExists();
 }
 
+/** How a spawn's environment differs from ours. One object so ptySpawn keeps a readable arity. */
+export interface PtySpawnEnv {
+  /** Variables the session must NOT inherit (a provider session's ANTHROPIC_API_KEY). */
+  unset?: readonly string[];
+  /** Per-session variables to set on top of the inherited environment. */
+  env?: Readonly<Record<string, string>>;
+}
+
 // Spawn a terminal, wrapping it in a persistent tmux session when tmux is available and
 // `persistent` is set, so it survives the server dying. `tmux new-session -A` creates it
 // (running file+args) or reattaches the surviving one. Returns whether tmux backs it.
@@ -57,15 +67,17 @@ export function ptySpawn(
   args: string[],
   cwd: string,
   persistent: boolean,
-  unset: readonly string[] = [],
+  options: PtySpawnEnv = {},
 ): { term: IPty; tmux: boolean } {
+  const { unset = [], env = {} } = options;
   if (persistent && tmuxAvailable()) {
     // A pane inherits the tmux SERVER's environment, so stripping our own copy is not
-    // enough — the server may already carry the name from an earlier session.
+    // enough — the server may already carry the name from an earlier session. For the same
+    // reason `env` goes to `new-session -e` rather than onto the tmux CLIENT we spawn here.
     if (unset.length > 0) tmuxScrubEnvNames(unset);
-    return { term: spawnPty("tmux", tmuxNewSessionArgs(sessionId, file, args, cwd), cwd, unset), tmux: true };
+    return { term: spawnPty("tmux", tmuxNewSessionArgs(sessionId, file, args, cwd, env), cwd, unset), tmux: true };
   }
-  return { term: spawnPty(file, args, cwd, unset), tmux: false };
+  return { term: spawnPty(file, args, cwd, unset, env), tmux: false };
 }
 
 // Spawn the single-view session inside a Docker container (the sandbox path). Exports the

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -14,7 +14,7 @@ import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { devTerminalSessionLine, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
-import { parseSessionToolGroups, sessionToolGroupLine, type SessionToolGroup } from "./session-tool-groups.js";
+import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET, type SessionToolGroup } from "./session-tool-groups.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
 
@@ -188,6 +188,22 @@ export function markSessionToolGroup(sessionId: string, group: ToolGroup): void 
 
 export function sessionToolGroups(sessionId: string): ToolGroup[] {
   return [...(toolGroupsBySession.get(sessionId) ?? [])];
+}
+
+// Forget what a session had, because it is being replaced. Called on every claude spawn for the
+// id: the new process gets whatever the user's MCP config says NOW, so carrying the old answer
+// forward would keep asserting a capability the user may have just switched off. The marker is
+// appended rather than the file rewritten, for the same reason nothing else here is rewritten.
+export function resetSessionToolGroups(sessionId: string): void {
+  if (!SESSION_ID_RE.test(sessionId)) return;
+  // Nothing learned yet: a marker would say the same as the absence, and every fresh session
+  // would append one.
+  if (!toolGroupsBySession.has(sessionId)) return;
+  toolGroupsBySession.set(sessionId, new Set());
+  toolGroupsPersist = toolGroupsPersist
+    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+    .then(() => fs.appendFile(SESSION_TOOL_GROUPS_FILE, sessionToolGroupLine(sessionId, TOOL_GROUP_RESET)))
+    .catch((e) => console.error(`[session-tool-groups] failed to persist reset: ${messageOf(e)}`));
 }
 
 // Restore the `working` + blocked/done (`waiting`) flags across a server restart (e.g. a

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -159,8 +159,16 @@ async function readPersistedToolGroups(): Promise<SessionToolGroup[]> {
   }
 }
 
+// Ids a spawn has already superseded this process. Hydration reads the log as it was BEFORE
+// that spawn's reset marker could be appended, so without this it would put the old groups
+// back — the reset would win in the file and lose in memory.
+const resetToolGroupSessions = new Set<string>();
+
 export const sessionToolGroupsHydrated: Promise<void> = (async () => {
-  for (const { sessionId, group } of await readPersistedToolGroups()) addToolGroupInMemory(sessionId, group);
+  for (const { sessionId, group } of await readPersistedToolGroups()) {
+    if (resetToolGroupSessions.has(sessionId)) continue;
+    addToolGroupInMemory(sessionId, group);
+  }
 })();
 
 let toolGroupsPersist: Promise<void> = Promise.resolve();
@@ -194,11 +202,16 @@ export function sessionToolGroups(sessionId: string): ToolGroup[] {
 // id: the new process gets whatever the user's MCP config says NOW, so carrying the old answer
 // forward would keep asserting a capability the user may have just switched off. The marker is
 // appended rather than the file rewritten, for the same reason nothing else here is rewritten.
+// UNCONDITIONAL, and that is the point. Skipping the marker when the in-memory set looks empty
+// was wrong twice over on a resume at boot: hydration may not have run yet, so "empty" means
+// "not read yet" rather than "nothing there" — and the marker is the only thing that survives to
+// the NEXT restart, where a process-local memo would be gone and the log replayed from scratch.
+// One line per claude spawn, in a file that already grows per learned group.
 export function resetSessionToolGroups(sessionId: string): void {
   if (!SESSION_ID_RE.test(sessionId)) return;
-  // Nothing learned yet: a marker would say the same as the absence, and every fresh session
-  // would append one.
-  if (!toolGroupsBySession.has(sessionId)) return;
+  // Both flags set synchronously, before any await: a read landing between here and the append
+  // must not see the replaced process's capabilities, and hydration must not restore them.
+  resetToolGroupSessions.add(sessionId);
   toolGroupsBySession.set(sessionId, new Set());
   toolGroupsPersist = toolGroupsPersist
     .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -14,6 +14,8 @@ import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { devTerminalSessionLine, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
+import { parseSessionToolGroups, sessionToolGroupLine, type SessionToolGroup } from "./session-tool-groups.js";
+import type { ToolGroup } from "../../common/toolGroups.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
 
 // Per-session "working" state, driven by Claude hooks (see /api/hook):
@@ -140,6 +142,52 @@ export function markDevTerminalSession(id: string): void {
   if (!SESSION_ID_RE.test(id) || devTerminalSessions.has(id)) return;
   devTerminalSessions.add(id);
   appendDevTerminalSession(id);
+}
+
+// Which GUI tool groups a session actually has. Learned from the group URLs it connects to
+// (see session-tool-groups.ts) rather than configured here — a grid cell's GUI tools come
+// from the user's own per-folder MCP config, which we do not read. Read it through
+// sessionToolGroups() so callers can't mutate the stored set.
+const toolGroupsBySession = new Map<string, Set<ToolGroup>>();
+const SESSION_TOOL_GROUPS_FILE = path.join(MULMOTERMINAL_HOME, "session-tool-groups.json");
+
+async function readPersistedToolGroups(): Promise<SessionToolGroup[]> {
+  try {
+    return parseSessionToolGroups(await fs.readFile(SESSION_TOOL_GROUPS_FILE, "utf8"), isValidSessionId);
+  } catch {
+    return [];
+  }
+}
+
+export const sessionToolGroupsHydrated: Promise<void> = (async () => {
+  for (const { sessionId, group } of await readPersistedToolGroups()) addToolGroupInMemory(sessionId, group);
+})();
+
+let toolGroupsPersist: Promise<void> = Promise.resolve();
+function appendSessionToolGroup(sessionId: string, group: ToolGroup): void {
+  toolGroupsPersist = toolGroupsPersist
+    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+    .then(() => fs.appendFile(SESSION_TOOL_GROUPS_FILE, sessionToolGroupLine(sessionId, group)))
+    .catch((e) => console.error(`[session-tool-groups] failed to persist: ${messageOf(e)}`));
+}
+
+function addToolGroupInMemory(sessionId: string, group: ToolGroup): boolean {
+  const groups = toolGroupsBySession.get(sessionId) ?? new Set<ToolGroup>();
+  if (groups.has(group)) return false;
+  groups.add(group);
+  toolGroupsBySession.set(sessionId, groups);
+  return true;
+}
+
+// Note that a session reached us on a group's URL, then persist. A no-op once known, so the
+// per-request MCP calls (one server is built per request) don't append on every tool call.
+export function markSessionToolGroup(sessionId: string, group: ToolGroup): void {
+  if (!SESSION_ID_RE.test(sessionId)) return;
+  if (addToolGroupInMemory(sessionId, group)) appendSessionToolGroup(sessionId, group);
+}
+
+export function sessionToolGroups(sessionId: string): ToolGroup[] {
+  return [...(toolGroupsBySession.get(sessionId) ?? [])];
 }
 
 // Restore the `working` + blocked/done (`waiting`) flags across a server restart (e.g. a

--- a/server/session/session-tool-groups.ts
+++ b/server/session/session-tool-groups.ts
@@ -17,35 +17,56 @@
 
 import { isToolGroup, type ToolGroup } from "../../common/toolGroups.js";
 
-/** One entry of the log: `<session id> <group>`. */
+/**
+ * A session's RESET marker. What a session has is decided by the claude process currently
+ * running for it, and that process is replaced on every restart/resume — with whatever the
+ * user's MCP config says at THAT moment. Without this, disabling Canvas and restarting the same
+ * session id would leave the old capability asserted for the life of the log, so the panel
+ * would keep offering tools the new process cannot call.
+ *
+ * A marker rather than rewriting the file: the log is append-only because MULMOTERMINAL_HOME is
+ * shared between server instances, and a read-merge-write loses whichever finishes first.
+ */
+export const TOOL_GROUP_RESET = "-";
+
+/** One entry of the log: `<session id> <group>`, or `<session id> -` for a restart. */
 export interface SessionToolGroup {
   sessionId: string;
   group: ToolGroup;
 }
 
-function entryFromLine(line: string, isValidId: (id: string) => boolean): SessionToolGroup[] {
+type Entry = { sessionId: string; group: ToolGroup | null };
+
+function entryFromLine(line: string, isValidId: (id: string) => boolean): Entry[] {
   const [sessionId, group, ...rest] = line.trim().split(/\s+/);
   // `rest` non-empty means the line has more than the two fields it should — a truncated
   // append or a hand-edit. Dropped rather than guessed at, like the legacy parser does.
-  if (rest.length > 0 || !sessionId || !isValidId(sessionId) || !isToolGroup(group)) return [];
-  return [{ sessionId, group }];
+  if (rest.length > 0 || !sessionId || !isValidId(sessionId)) return [];
+  if (group === TOOL_GROUP_RESET) return [{ sessionId, group: null }];
+  return isToolGroup(group) ? [{ sessionId, group }] : [];
 }
 
 /**
- * The entries a file holds. Anything unusable is dropped rather than carried along — a bad
- * session id would end up compared against real ones, and a bad group name against a real URL.
+ * The entries a file holds, replayed IN ORDER so a reset drops what came before it for that
+ * session — the ordering is the whole reason this is not a set union.
+ *
+ * Anything unusable is dropped rather than carried along: a bad session id would end up
+ * compared against real ones, and a bad group name against a real URL.
  */
 export function parseSessionToolGroups(contents: string, isValidId: (id: string) => boolean): SessionToolGroup[] {
-  const seen = new Set<string>();
-  return contents.split("\n").flatMap((line) => {
-    const entries = entryFromLine(line, isValidId);
-    return entries.filter(({ sessionId, group }) => {
-      const key = `${sessionId} ${group}`;
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
-  });
+  const bySession = new Map<string, Set<ToolGroup>>();
+  for (const line of contents.split("\n")) {
+    for (const { sessionId, group } of entryFromLine(line, isValidId)) {
+      if (group === null) {
+        bySession.set(sessionId, new Set());
+        continue;
+      }
+      const groups = bySession.get(sessionId) ?? new Set<ToolGroup>();
+      groups.add(group);
+      bySession.set(sessionId, groups);
+    }
+  }
+  return [...bySession].flatMap(([sessionId, groups]) => [...groups].map((group) => ({ sessionId, group })));
 }
 
 /**
@@ -53,6 +74,6 @@ export function parseSessionToolGroups(contents: string, isValidId: (id: string)
  * reason it does in dev-terminal-sessions.ts: whatever the file ended with, an appended entry
  * starts its own line, so a file that was cut off mid-write costs one entry and not the rest.
  */
-export function sessionToolGroupLine(sessionId: string, group: ToolGroup): string {
+export function sessionToolGroupLine(sessionId: string, group: ToolGroup | typeof TOOL_GROUP_RESET): string {
   return `\n${sessionId} ${group}`;
 }

--- a/server/session/session-tool-groups.ts
+++ b/server/session/session-tool-groups.ts
@@ -1,0 +1,58 @@
+// Which GUI tool groups each session actually has, as it is read from and written back to disk.
+//
+// MulmoTerminal cannot know this from its own config: a grid cell's GUI tools come from the
+// USER's per-folder MCP config (`claude mcp add -s local`, `.mcp.json`), which we neither
+// write nor read. So it is LEARNED — a request arriving on `/api/mcp/<group>/<id>` is proof
+// that this session has that group, and there is no earlier or more reliable signal. The
+// client's first ListTools lands within a second of the session starting.
+//
+// Persisted for the same reason the dev-terminal set is: the learning happens in memory, and a
+// server restart (a --watch reload) would otherwise forget it while the claude process keeps
+// running in tmux — already past its ListTools and with no reason to call again. The panel
+// would then decide the cell has no Canvas and hide it on a session that is still drawing.
+//
+// Same APPEND LOG shape as dev-terminal-sessions.ts, for the same reason: MULMOTERMINAL_HOME
+// is shared by every server on the machine, so a read-merge-write loses whichever of two
+// instances finishes first. Nothing is ever removed, so appending needs no read.
+
+import { isToolGroup, type ToolGroup } from "../../common/toolGroups.js";
+
+/** One entry of the log: `<session id> <group>`. */
+export interface SessionToolGroup {
+  sessionId: string;
+  group: ToolGroup;
+}
+
+function entryFromLine(line: string, isValidId: (id: string) => boolean): SessionToolGroup[] {
+  const [sessionId, group, ...rest] = line.trim().split(/\s+/);
+  // `rest` non-empty means the line has more than the two fields it should — a truncated
+  // append or a hand-edit. Dropped rather than guessed at, like the legacy parser does.
+  if (rest.length > 0 || !sessionId || !isValidId(sessionId) || !isToolGroup(group)) return [];
+  return [{ sessionId, group }];
+}
+
+/**
+ * The entries a file holds. Anything unusable is dropped rather than carried along — a bad
+ * session id would end up compared against real ones, and a bad group name against a real URL.
+ */
+export function parseSessionToolGroups(contents: string, isValidId: (id: string) => boolean): SessionToolGroup[] {
+  const seen = new Set<string>();
+  return contents.split("\n").flatMap((line) => {
+    const entries = entryFromLine(line, isValidId);
+    return entries.filter(({ sessionId, group }) => {
+      const key = `${sessionId} ${group}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  });
+}
+
+/**
+ * What to append for a newly learned pair. The newline leads rather than trails for the same
+ * reason it does in dev-terminal-sessions.ts: whatever the file ended with, an appended entry
+ * starts its own line, so a file that was cut off mid-write costs one entry and not the rest.
+ */
+export function sessionToolGroupLine(sessionId: string, group: ToolGroup): string {
+  return `\n${sessionId} ${group}`;
+}

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -2,7 +2,8 @@
 // piece of index.ts (#548 step 3c): it spans the sandbox decision, the CLI args, the
 // sidebar's optimistic row, the draft typed into the input box, and teardown on exit.
 import type { WebSocket } from "ws";
-import { CLAUDE_CWD } from "../config/env.js";
+import { CLAUDE_CWD, PORT } from "../config/env.js";
+import { guiMcpEnv } from "./mcp-config.js";
 import { getUserMcpServers, getPrWorkdirFooter } from "../config/config-routes.js";
 import { SANDBOX_HOST } from "../infra/sandbox.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
@@ -108,9 +109,13 @@ export function createClaudeSpawner(deps: SpawnDeps) {
       permissionMode: deps.permissionMode,
       attachGuiMcp,
       mcpConfig,
-      // Auto-allow the GUI tools + the user's own configured MCP servers (mcp__<id>), so
-      // their tools don't trip a permission prompt on every call.
-      guiMcpTools: [deps.guiMcpTools, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(","),
+      // Single view: auto-allow the GUI tools + the user's own configured MCP servers
+      // (mcp__<id>), so their tools don't trip a permission prompt on every call.
+      // Grid: no --mcp-config at all, so there is nothing of ours to name — except the tool
+      // GROUPS the directory may have registered itself, which we pre-approve blind
+      // (see GRID_MCP_TOOLS). The user's own servers keep their normal prompts there, since
+      // that path never went through our allowlist before.
+      allowedTools: attachGuiMcp ? [deps.guiMcpTools, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(",") : deps.gridMcpTools,
       addDirs: dir.addDirs,
       workdirFooter: sessionWorkdirFooter(cwd),
     });
@@ -126,7 +131,7 @@ export function createClaudeSpawner(deps: SpawnDeps) {
 
     function spawnEntry(): PtyEntry {
       if (sandbox) return spawnSandboxEntry(sessionId, args, cwd, ws, dir.addDirs);
-      const { term, tmux } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true, resolved.unset);
+      const { term, tmux } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true, { unset: resolved.unset, env: guiMcpEnv(sessionId, PORT) });
       console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);
       return { term, ws, buffer: "", cwd, tmux, active: false, agent: "claude" };
     }

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -7,7 +7,7 @@ import { guiMcpEnv } from "./mcp-config.js";
 import { getUserMcpServers, getPrWorkdirFooter } from "../config/config-routes.js";
 import { SANDBOX_HOST } from "../infra/sandbox.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
-import { knownSessions, launchChoices, ptys } from "./registry.js";
+import { knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
 import { ptySpawn, sandboxWouldRun, spawnSandboxEntry } from "./pty-spawn.js";
 import { attachDraftInjection } from "./draft-injection.js";
 import { sendExitAndClose, sendFrame } from "./ws-frames.js";
@@ -89,6 +89,10 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     // Falls back to the host spawn if the Docker daemon isn't reachable.
     const sandbox = sandboxWouldRun(attachGuiMcp) && ws !== null;
     const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
+
+    // The process about to start gets whatever the user's MCP config says NOW, so anything this
+    // id learned under a previous one is stale — including a group the user has since removed.
+    resetSessionToolGroups(sessionId);
 
     const { dir, resolved } = resolveSessionBackend({ cwd, sessionId, launch, canResume, sandbox });
 

--- a/server/session/spawn-deps.ts
+++ b/server/session/spawn-deps.ts
@@ -8,6 +8,9 @@ export interface SpawnDeps {
   permissionMode: string;
   /** Tool names auto-allowed for every session, already comma-joined. */
   guiMcpTools: string;
+  // The --allowedTools list for a GRID cell, whose GUI tools come from the user's own
+  // per-folder MCP config rather than from --mcp-config. See GRID_MCP_TOOLS in index.ts.
+  gridMcpTools: string;
   /** Bytes of pty output kept for a client that reattaches later. */
   outputBufferLimit: number;
   hookSettingsJson: (host: string, sessionId: string, env?: Record<string, string>) => string;

--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -9,10 +9,28 @@
 //
 // No `.stop` on the clicks: the enclosing header's zoom gesture already ignores anything
 // inside a button (shouldZoomOnHeaderClick), and stopping here would only hide that.
-import { CELL_BTN, CELL_CLOSE_BTN } from "./cellChromeClasses";
+import { computed } from "vue";
+import { CELL_BTN, CELL_BTN_DISABLEABLE, CELL_CLOSE_BTN } from "./cellChromeClasses";
 
-defineProps<{ expanded: boolean; filesOpen?: boolean }>();
-const emit = defineEmits<{ (e: "toggle-expand" | "close" | "toggle-files"): void }>();
+const props = defineProps<{
+  expanded: boolean;
+  filesOpen?: boolean;
+  // Which side pane this cell is showing, so each button can read as pressed. The three share
+  // one slot beside the enlarged terminal, so at most one is ever pressed.
+  rightPane?: "files" | "canvas" | "tools" | null;
+  // Whether this cell's session actually has the drawing tools — i.e. whether its directory has
+  // the `render` MCP group registered with Claude Code. False disables the button rather than
+  // removing it: the pane would open empty, and that is worth SAYING rather than hiding.
+  canvasAvailable?: boolean;
+}>();
+const emit = defineEmits<{ (e: "toggle-expand" | "close" | "toggle-files" | "toggle-canvas" | "toggle-tools"): void }>();
+
+// The unavailable case names the fix, not just the state: the registration is per directory and
+// only read when a session starts, so it takes a restart even once switched on.
+const canvasTitle = computed(() => {
+  if (!props.canvasAvailable) return "No render MCP for this directory — turn on Canvas in the launcher, then restart this cell";
+  return props.rightPane === "canvas" ? "Hide canvas" : "Show canvas";
+});
 </script>
 
 <template>
@@ -38,6 +56,33 @@ const emit = defineEmits<{ (e: "toggle-expand" | "close" | "toggle-files"): void
     @click="emit('toggle-files')"
   >
     <span class="material-symbols-outlined" aria-hidden="true">folder_open</span>
+  </button>
+  <!-- Shown but DISABLED when this session has no render MCP: the pane would open empty and
+       never fill, and hiding the button outright leaves nothing to explain why. The title is
+       where the fix goes, since a disabled control is the moment someone asks. -->
+  <button
+    v-if="expanded"
+    data-testid="cell-canvas-btn"
+    class="cell-btn"
+    :class="CELL_BTN_DISABLEABLE"
+    :disabled="!canvasAvailable"
+    :aria-pressed="rightPane === 'canvas'"
+    :title="canvasTitle"
+    :aria-label="canvasTitle"
+    @click="emit('toggle-canvas')"
+  >
+    <span class="material-symbols-outlined" aria-hidden="true">draw</span>
+  </button>
+  <button
+    v-if="expanded"
+    class="cell-btn"
+    :class="CELL_BTN"
+    :aria-pressed="rightPane === 'tools'"
+    :title="rightPane === 'tools' ? 'Hide tools' : 'Show tools'"
+    :aria-label="rightPane === 'tools' ? 'Hide tools' : 'Show tools'"
+    @click="emit('toggle-tools')"
+  >
+    <span class="material-symbols-outlined" aria-hidden="true">build</span>
   </button>
   <button class="cell-btn cell-close" :class="CELL_CLOSE_BTN" title="Close terminal" aria-label="Close terminal" @click="emit('close')">
     <span class="material-symbols-outlined" aria-hidden="true">close</span>

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -201,8 +201,12 @@ function onHeaderClick(event: MouseEvent) {
           <CellChromeButtons
             :expanded="expanded"
             :files-open="filesOpen"
+            :right-pane="rightPane"
+            :canvas-available="canvasAvailable"
             @toggle-expand="emit('toggle-expand')"
             @toggle-files="emit('toggle-files')"
+            @toggle-canvas="emit('toggle-canvas')"
+            @toggle-tools="emit('toggle-tools')"
             @close="emit('close')"
           />
         </span>

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -23,6 +23,12 @@ const props = defineProps<{
   sessionId: string | null;
   sendTextMessage: (text: string) => boolean;
   toolsOpen?: boolean;
+  // Why this panel cannot show anything, when that is knowable. The pane outlives the cell it
+  // was opened on — walking the zoom to a launcher or to a directory with no render MCP leaves
+  // it mounted — and the empty-state hint below ("ask Claude to use presentDocument") is a LIE
+  // in both cases: there is nothing to ask, or nothing that could answer. Absent/null means the
+  // panel is usable, which keeps the single view (where it always is) unchanged.
+  unavailable?: "no-session" | "no-render-mcp" | null;
 }>();
 const emit = defineEmits<{ toggleTools: [] }>();
 
@@ -35,6 +41,10 @@ const { upsert } = useSessionFeed(results, {
   historyKey: "toolResults",
   channel: (id) => `session:${id}`,
   identify: (result) => result.uuid,
+  // Drop the previous session's views the moment the session changes, rather than when its
+  // replacement's history arrives: until then the panel would still be showing another cell's
+  // drawings under this cell's name.
+  onSessionChange: () => (results.value = []),
 });
 
 // A plugin view changed its state (e.g. a form field edited / submitted). Per the
@@ -83,12 +93,29 @@ const hasContent = computed(() => results.value.length > 0);
       </button>
     </div>
     <div class="flex-1 overflow-y-auto px-4 py-3 font-sans text-[14px] leading-normal text-fg">
-      <div v-if="!hasContent" class="text-[13px] text-dim">
+      <!-- Unavailable outranks empty: both look like "nothing here", but only one of them is
+           something the user can act on by talking to the agent. -->
+      <div v-if="unavailable" data-testid="canvas-unavailable" class="text-[13px] text-dim">
+        <template v-if="unavailable === 'no-session'">
+          <div class="font-medium text-secondary">No session here</div>
+          <p class="mt-1">This cell has no terminal running yet. Start one and its drawings will appear here.</p>
+        </template>
+        <template v-else>
+          <div class="font-medium text-secondary">Canvas is not enabled for this directory</div>
+          <p class="mt-1">
+            Its agent has no drawing tools, so nothing can appear here. Turn on
+            <span class="whitespace-nowrap font-medium">CANVAS (render MCPs)</span> in this cell's launcher, then restart the cell.
+          </p>
+        </template>
+      </div>
+      <div v-else-if="!hasContent" class="text-[13px] text-dim">
         Ask Claude to use <code class="rounded-[4px] bg-subtle px-[5px] py-px">presentDocument</code> or
         <code class="rounded-[4px] bg-subtle px-[5px] py-px">presentForm</code>
         to render content here.
       </div>
-      <template v-for="r in results" :key="r.uuid">
+      <!-- Guarded as well as cleared on session change: a stale view rendered under an
+           "unavailable" heading would contradict it. -->
+      <template v-for="r in unavailable ? [] : results" :key="r.uuid">
         <PluginFrame v-if="getPlugin(r.toolName)" class="frame" :css="getPlugin(r.toolName)!.css" :height="getPlugin(r.toolName)!.height">
           <component
             :is="getPlugin(r.toolName)!.viewComponent"

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -106,8 +106,12 @@ function relaunch() {
           <CellChromeButtons
             :expanded="expanded"
             :files-open="filesOpen"
+            :right-pane="rightPane"
+            :canvas-available="canvasAvailable"
             @toggle-expand="emit('toggle-expand')"
             @toggle-files="emit('toggle-files')"
+            @toggle-canvas="emit('toggle-canvas')"
+            @toggle-tools="emit('toggle-tools')"
             @close="emit('close')"
           />
         </span>

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -8,6 +8,7 @@ import { useGitStatus } from "../composables/useGitStatus";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import DirBadge from "./DirBadge.vue";
 import { isCellContext, isCellUsage, type CellContext, type CellUsage } from "./cellPayload";
+import { CANVAS_TOOL_GROUP } from "../../common/toolGroups";
 import { unsavedWork } from "./unsavedWork";
 import { relativeTime as relativeTimeFrom, usageBadge } from "./cellDisplay";
 import { applyActivityPush, cellHeaderText } from "./cellActivity";
@@ -521,7 +522,6 @@ let worktreesReq = 0;
 // it is a `render`-group MCP server registered in Claude Code's own local-scope config for this
 // directory, so the switch reads and writes through /api/gui-mcp-groups and `claude mcp list`
 // stays the one place it can be seen. Read per directory, like the worktree list above.
-const CANVAS_GROUP = "render";
 const canvasDir = ref<string | null>(null);
 const canvasEnabled = ref(false);
 const canvasBusy = ref(false);
@@ -543,7 +543,7 @@ async function loadCanvasEnabled() {
     // the new directory's name.
     if (reqId !== canvasReq) return;
     canvasDir.value = dir;
-    canvasEnabled.value = Array.isArray(data.groups) && data.groups.includes(CANVAS_GROUP);
+    canvasEnabled.value = Array.isArray(data.groups) && data.groups.includes(CANVAS_TOOL_GROUP);
     canvasError.value = null;
   } catch {
     // No switch rather than one whose position is a guess — flipping a wrong "off" would run
@@ -564,7 +564,7 @@ async function applyCanvas() {
     const res = await fetch("/api/gui-mcp-groups", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwd: dir, group: CANVAS_GROUP, enabled: wanted }),
+      body: JSON.stringify({ cwd: dir, group: CANVAS_TOOL_GROUP, enabled: wanted }),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
@@ -641,7 +641,7 @@ async function carryCanvasInto(worktreePath: string) {
     await fetch("/api/gui-mcp-groups", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwd: worktreePath, group: CANVAS_GROUP, enabled: true }),
+      body: JSON.stringify({ cwd: worktreePath, group: CANVAS_TOOL_GROUP, enabled: true }),
     });
   } catch {
     // best-effort — a worktree without the registration still launches, just without Canvas

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -615,6 +615,7 @@ async function createWorktreeAndLaunch() {
     const wt = await res.json();
     if (typeof wt.path === "string") {
       worktreeTask.value = "";
+      await carryCanvasInto(wt.path);
       launchIn(wt.path);
     }
   } catch {
@@ -622,7 +623,30 @@ async function createWorktreeAndLaunch() {
   }
 }
 
-const reuseWorktree = (w: Worktree) => launchIn(w.path);
+const reuseWorktree = async (w: Worktree) => {
+  await carryCanvasInto(w.path);
+  launchIn(w.path);
+};
+
+// Claude Code keys local-scope MCP config by the CLI's working directory, and a worktree launch
+// starts claude in the WORKTREE — not in the repository the switch above was set for. Without
+// this the session gets no render tools even though the launcher plainly says Canvas is on.
+//
+// Copied rather than moved: the repository keeps its own registration, and a worktree is a
+// throwaway room that should start out like the repo it came from. Failures are swallowed —
+// the launch itself is what the user asked for, and the Canvas button will report the truth.
+async function carryCanvasInto(worktreePath: string) {
+  if (!canvasEnabled.value || !canvasDir.value || worktreePath === canvasDir.value) return;
+  try {
+    await fetch("/api/gui-mcp-groups", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cwd: worktreePath, group: CANVAS_GROUP, enabled: true }),
+    });
+  } catch {
+    // best-effort — a worktree without the registration still launches, just without Canvas
+  }
+}
 
 // Remove a managed worktree (＋ its branch). A dirty one is confirmed first so work
 // is never discarded silently.

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -285,6 +285,41 @@ async function refreshUsage() {
   if (data && badgeReq === latestBadgeReq) applyBadges(data);
 }
 
+// Canvas output this cell has produced that nobody has looked at. The grid is a TRIAGE board,
+// so the drawing itself stays in the expanded view — but without a signal here, output on an
+// un-expanded cell leaves no trace at all and is only discovered by expanding it. A count, not
+// a preview: reading belongs in the pane.
+//
+// Counted from LIVE arrivals only, with no history replay: "unseen" means "since you last
+// looked", and nine cells each fetching a session's stored results to compute a badge would
+// cost more than the badge is worth.
+//
+// Deliberately NOT folded into the attention colours: an unread drawing is not the same as an
+// agent blocked on a permission prompt, and letting it raise amber would spend the one signal
+// that means "you are needed here".
+const unseenCanvas = ref(0);
+let unsubscribeCanvas: (() => void) | undefined;
+
+function watchCanvasOutput(id: string | null) {
+  unsubscribeCanvas?.();
+  unsubscribeCanvas = undefined;
+  unseenCanvas.value = 0;
+  if (!id) return;
+  unsubscribeCanvas = subscribe(`session:${id}`, () => {
+    // Already looking at it: arrivals land in a pane the user can see, so nothing is unseen.
+    if (props.expanded && props.rightPane === "canvas") return;
+    unseenCanvas.value += 1;
+  });
+}
+watch(sessionId, watchCanvasOutput, { immediate: true });
+// Opening the pane on this cell clears the count — that IS having looked.
+watch(
+  () => props.expanded && props.rightPane === "canvas",
+  (looking) => {
+    if (looking) unseenCanvas.value = 0;
+  },
+);
+
 onMounted(() => {
   unsubscribe = subscribe("sessions", (d) => {
     if (isActivityMsg(d) && d.id === sessionId.value) applyActivity(d);
@@ -303,10 +338,12 @@ onMounted(() => {
     loadResumable();
     loadScripts();
     loadWorktrees();
+    loadCanvasEnabled();
   }
 });
 onUnmounted(() => {
   unsubscribe?.();
+  unsubscribeCanvas?.();
   offReconnect?.();
   if (resumableTimer) clearTimeout(resumableTimer);
 });
@@ -369,6 +406,7 @@ function fillDir(path: string) {
   loadResumable();
   loadScripts();
   loadWorktrees();
+  loadCanvasEnabled();
 }
 
 // The folder button: the browser can't open a native folder chooser, so the local server does
@@ -479,6 +517,66 @@ const worktrees = ref<Worktree[]>([]);
 const worktreeTask = ref("");
 let worktreesReq = 0;
 
+// Whether this directory lets its agents draw into the Canvas panel. NOT MulmoTerminal state:
+// it is a `render`-group MCP server registered in Claude Code's own local-scope config for this
+// directory, so the switch reads and writes through /api/gui-mcp-groups and `claude mcp list`
+// stays the one place it can be seen. Read per directory, like the worktree list above.
+const CANVAS_GROUP = "render";
+const canvasDir = ref<string | null>(null);
+const canvasEnabled = ref(false);
+const canvasBusy = ref(false);
+const canvasError = ref<string | null>(null);
+let canvasReq = 0;
+
+async function loadCanvasEnabled() {
+  const dir = dirInput.value.trim() || props.defaultCwd;
+  const reqId = ++canvasReq;
+  if (launched.value || !dir) {
+    canvasDir.value = null;
+    return;
+  }
+  try {
+    const res = await fetch(`/api/gui-mcp-groups?cwd=${encodeURIComponent(dir)}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    // A slower reply for a directory the user has since moved off would show its answer under
+    // the new directory's name.
+    if (reqId !== canvasReq) return;
+    canvasDir.value = dir;
+    canvasEnabled.value = Array.isArray(data.groups) && data.groups.includes(CANVAS_GROUP);
+    canvasError.value = null;
+  } catch {
+    // No switch rather than one whose position is a guess — flipping a wrong "off" would run
+    // `claude mcp remove` on a registration the user may actually have.
+    if (reqId === canvasReq) canvasDir.value = null;
+  }
+}
+
+// Writes into the user's Claude Code config, so a failure is surfaced and the checkbox is put
+// back — a switch that shows "on" for a registration that was never written is the worst state.
+async function applyCanvas() {
+  const dir = canvasDir.value;
+  if (!dir) return;
+  const wanted = canvasEnabled.value;
+  canvasBusy.value = true;
+  canvasError.value = null;
+  try {
+    const res = await fetch("/api/gui-mcp-groups", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ cwd: dir, group: CANVAS_GROUP, enabled: wanted }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    if (!data.ok) throw new Error(data.message || "claude mcp failed");
+  } catch (e) {
+    canvasEnabled.value = !wanted;
+    canvasError.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    canvasBusy.value = false;
+  }
+}
+
 async function loadWorktrees() {
   const dir = dirInput.value.trim() || props.defaultCwd;
   const reqId = ++worktreesReq;
@@ -557,6 +655,7 @@ watch([dirInput, () => props.defaultCwd], () => {
     loadResumable();
     loadScripts();
     loadWorktrees();
+    loadCanvasEnabled();
   }, 300);
 });
 
@@ -756,6 +855,7 @@ function teardown() {
   loadResumable();
   loadScripts();
   loadWorktrees();
+  loadCanvasEnabled();
 }
 
 // Closing a WORKTREE cell offers to keep or remove the room first (never silently
@@ -1031,8 +1131,12 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             <CellChromeButtons
               :expanded="expanded"
               :files-open="filesOpen"
+              :right-pane="rightPane"
+              :canvas-available="canvasAvailable"
               @toggle-expand="emit('toggle-expand')"
               @toggle-files="emit('toggle-files')"
+              @toggle-canvas="emit('toggle-canvas')"
+              @toggle-tools="emit('toggle-tools')"
               @close="close"
             />
           </span>
@@ -1075,6 +1179,20 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
                thumbnail, leaving only dir + what it's doing + a zoom button. -->
             <template v-if="!filmstrip">
               <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />
+              <!-- Unread Canvas output. Same chip vocabulary as the branch / context / token
+                   chips beside it, deliberately: this is one more thing to triage at a glance,
+                   not a new kind of alert. Clicking expands the cell with the pane open. -->
+              <button
+                v-if="unseenCanvas > 0"
+                type="button"
+                data-testid="cell-canvas-chip"
+                class="inline-flex flex-none cursor-pointer items-center gap-1 rounded-[10px] border border-border bg-elevated px-[7px] py-px font-mono text-[11px] hover:bg-hover"
+                :title="`${unseenCanvas} unread from the agent — open the canvas`"
+                :aria-label="`${unseenCanvas} unread canvas results`"
+                @click.stop="emit('open-canvas')"
+              >
+                <span class="material-symbols-outlined text-[13px]" aria-hidden="true">draw</span>{{ unseenCanvas }}
+              </button>
               <template v-for="chip in cellChips" :key="chip.key">
                 <GitBranchChip v-if="chip.builtin === 'git'" :status="gitStatus" :hide-dirty="isWorktreeCell" />
                 <button
@@ -1124,8 +1242,12 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
             <CellChromeButtons
               :expanded="expanded"
               :files-open="filesOpen"
+              :right-pane="rightPane"
+              :canvas-available="canvasAvailable"
               @toggle-expand="emit('toggle-expand')"
               @toggle-files="emit('toggle-files')"
+              @toggle-canvas="emit('toggle-canvas')"
+              @toggle-tools="emit('toggle-tools')"
               @close="close"
             />
           </span>
@@ -1545,6 +1667,31 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         </label>
         <!-- Codex has its own model configuration and doesn't read this one. -->
         <ModelPicker v-if="agent === 'claude'" v-model="launchChoice" />
+        <!-- Canvas is a per-DIRECTORY registration in Claude Code's own MCP config, not a
+             per-launch choice — but it only takes effect when a session starts, so this is
+             where it belongs: decided before the thing it configures exists. Claude only;
+             codex reaches the GUI tools by another route. -->
+        <label v-if="agent === 'claude' && canvasDir" class="flex w-full max-w-[360px] items-center justify-between gap-2">
+          <!-- The group is named, not just the feature: the switch registers ONE MCP server
+               (`mulmoterminal-render`) and the other groups are added with `claude mcp add`, so
+               a label reading only "Canvas" would suggest it covers all of them. `normal-case`
+               on the suffix — the section labels around it are uppercased by class, and
+               "(RENDER MCPS)" reads as a different thing than the server it names. -->
+          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Canvas <span class="normal-case">(render MCPs)</span></span>
+          <span class="flex items-center gap-2">
+            <span v-if="canvasBusy" class="font-sans text-[11px] text-dim">saving…</span>
+            <span v-else-if="canvasError" class="font-sans text-[11px] text-err-text" :title="canvasError">failed</span>
+            <input
+              v-model="canvasEnabled"
+              data-testid="cell-canvas-toggle"
+              type="checkbox"
+              class="h-3.5 w-3.5 cursor-pointer accent-accent"
+              :disabled="canvasBusy"
+              :aria-label="`Register the render MCP group so the agent can draw in ${canvasDir}`"
+              @change="applyCanvas"
+            />
+          </span>
+        </label>
         <div v-if="isGitRepo" data-testid="cell-worktrees" class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5">
           <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
           <div class="flex gap-1.5">

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -22,6 +22,8 @@ import ToolsPane from "./ToolsPane.vue";
 import { clampPaneWidth, splitterKeyWidth, MIN_GUI, MIN_TERMINAL } from "./splitterWidth";
 import { setFilesPaneOpener } from "../composables/filesPaneOpener";
 import { paneCanShowClick } from "./paneClickTarget";
+import { usePubSub } from "../composables/usePubSub";
+import { TOOL_GROUPS_CHANNEL } from "../toolGroupsChannel";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 
@@ -261,6 +263,19 @@ watch(
   },
   { immediate: true },
 );
+
+// The answer above is normally asked BEFORE it can be true: the browser is handed a session id
+// while claude is still being spawned, so its MCP client has not connected yet. Waiting for the
+// server to say so is what stops that first "no" from standing until the user collapses and
+// re-expands the cell.
+const { subscribe: subscribeToolGroups } = usePubSub();
+const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
+  const msg = data as { sessionId?: string; groups?: string[] };
+  if (!msg?.sessionId || msg.sessionId !== expandedSessionId.value) return;
+  canvasAvailable.value = Array.isArray(msg.groups) && msg.groups.includes("render");
+  canvasChecked.value = true;
+});
+onBeforeUnmount(() => offToolGroups());
 
 // What the Canvas pane should say instead of its "ask Claude to draw something" hint. The pane
 // outlives the cell it was opened on, so walking the zoom lands it on cells that can never fill

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -17,9 +17,12 @@ import type { Launcher, LaunchPick } from "./launchers";
 import { shouldFlipZoom } from "./cellChromeRules";
 import { formatCwd } from "./cwdDisplay";
 import FilesPane, { type FilesPaneState } from "./FilesPane.vue";
+import GuiPanel from "./GuiPanel.vue";
+import ToolsPane from "./ToolsPane.vue";
 import { clampPaneWidth, splitterKeyWidth, MIN_GUI, MIN_TERMINAL } from "./splitterWidth";
 import { setFilesPaneOpener } from "../composables/filesPaneOpener";
 import { paneCanShowClick } from "./paneClickTarget";
+import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 
 // Renders the grid, auto-sized to the cell count, fully controlled by GridView:
@@ -140,7 +143,19 @@ const remember = (key: string, value: string): void => {
     // storage blocked: the pane still works this session, it just isn't remembered
   }
 };
-const filesOpen = ref(stored(PANE_OPEN_KEY) === "1");
+// Which pane holds the one slot beside the enlarged terminal (see gridCell.ts):
+//   files  — the file tree/editor (the original occupant).
+//   canvas — what the agent DREW: the GUI plugin views for this cell's session.
+//   tools  — which GUI tools this session actually has, read-only.
+const isRightPane = (value: string | null): value is RightPane => value === "files" || value === "canvas" || value === "tools";
+// The key used to hold a boolean, where "1" meant the files pane was open — so an existing
+// browser is migrated rather than silently starting closed.
+function restoredPane(value: string | null): RightPane | null {
+  if (isRightPane(value)) return value;
+  return value === "1" ? "files" : null;
+}
+const rightPane = ref<RightPane | null>(restoredPane(stored(PANE_OPEN_KEY)));
+const filesOpen = computed(() => rightPane.value === "files");
 const paneWidth = ref(Number(stored(PANE_WIDTH_KEY)) || PANE_WIDTH_DEFAULT);
 const zoomRow = ref<HTMLElement | null>(null);
 const rowWidth = () => zoomRow.value?.clientWidth ?? 0;
@@ -152,30 +167,95 @@ const paneMax = computed(() => Math.max(0, rowWidthNow.value - MIN_TERMINAL));
 const paneMin = computed(() => Math.min(MIN_GUI, paneMax.value));
 
 function setFilesOpen(open: boolean): void {
-  if (!open) rememberPaneState(paneUid.value);
-  filesOpen.value = open;
-  // Closing drops the cell it was on, so re-opening lands on whichever cell is enlarged THEN
-  // rather than resuming a directory the user has since walked away from.
-  if (!open) {
+  setRightPane(open ? "files" : null);
+}
+
+// Switching panes is the same event as closing the files one, because the files pane unmounts
+// either way — so its buffer has to be saved on both paths, not just on close.
+function setRightPane(pane: RightPane | null): void {
+  const leavingFiles = filesOpen.value && pane !== "files";
+  if (leavingFiles) rememberPaneState(paneUid.value);
+  rightPane.value = pane;
+  // Leaving files drops the cell it was on, so coming back lands on whichever cell is enlarged
+  // THEN rather than resuming a directory the user has since walked away from.
+  if (leavingFiles) {
     paneCwd.value = null;
     paneUid.value = null;
   }
-  remember(PANE_OPEN_KEY, open ? "1" : "0");
+  remember(PANE_OPEN_KEY, pane ?? "");
 }
 
 // The header toggle. Closing unmounts the pane, buffer and all, so the buffer is saved on the
 // way out — the pane's OWN close button has already flushed by the time it emits, which is why
 // that path stays separate rather than routing through here.
 async function toggleFiles(): Promise<void> {
-  // Closing unmounts the buffer with the pane, so a buffer that could be neither saved nor
-  // backed up keeps the pane open — the error is visible in it.
+  await toggleRightPane("files");
+}
+
+// The unread-canvas chip on a tiled cell: enlarge that cell AND put the pane beside it, in one
+// click. Two steps because the pane only exists while a cell is enlarged — asking the user to
+// expand first and then find the button is the gesture this chip exists to remove.
+async function openCanvasFor(uid: number): Promise<void> {
   if (filesOpen.value && (await filesPane.value?.flush()) === false) return;
-  setFilesOpen(!filesOpen.value);
+  if (props.expandedUid !== uid) emit("toggle-expand", uid);
+  setRightPane("canvas");
+}
+
+// A pane button: opens its pane, or closes it when it is already the one showing.
+async function toggleRightPane(pane: RightPane): Promise<void> {
+  // Leaving files unmounts the buffer with the pane, so a buffer that could be neither saved
+  // nor backed up keeps it open — the error is visible in it. Checked whichever pane was asked
+  // for: files unmounts when another pane takes the slot exactly as it does when closed.
+  if (filesOpen.value && (await filesPane.value?.flush()) === false) return;
+  setRightPane(rightPane.value === pane ? null : pane);
 }
 
 // The enlarged cell's project dir — what the pane browses. A cell that hasn't reported one yet
 // (a launcher, a session still starting) falls back to the grid's default.
 const expandedCwd = computed(() => props.cells.find((c) => c.uid === props.expandedUid)?.cwd ?? props.defaultCwd);
+
+// The enlarged cell's session — what Canvas and Tools read. Null for a cell with no session
+// yet (a launcher, a command cell), which both panes already render as empty.
+const expandedSessionId = computed(() => props.cells.find((c) => c.uid === props.expandedUid)?.session ?? null);
+
+// GUI -> LLM for the enlarged cell (a submitted form's answer). App.vue routes this through the
+// single view's Terminal ref; here the slot key is derivable from the uid, so the connection
+// runtime can be addressed directly rather than threading a component ref through the Teleport.
+function sendToExpandedCell(text: string): boolean {
+  return props.expandedUid === null ? false : conn.submitText(`cell-${props.expandedUid}`, text);
+}
+
+// Does the enlarged cell's session have the drawing tools? Only the server knows: a grid cell
+// reaches them through the user's own per-folder MCP config, and the server learns which groups
+// a session has from the URLs it connects to.
+//
+// Re-asked on every expand, not only when the session id changes: a cell that has just started
+// may not have connected its MCP client yet, and re-expanding is how a user retries anything.
+const canvasAvailable = ref(false);
+watch(
+  [expandedSessionId, () => props.expandedUid],
+  async ([sessionId]) => {
+    if (!sessionId) {
+      canvasAvailable.value = false;
+      return;
+    }
+    try {
+      const res = await fetch(`/api/tools?sessionId=${encodeURIComponent(sessionId)}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = await res.json();
+      // Late reply for a cell we have since walked away from would show the wrong button.
+      if (sessionId !== expandedSessionId.value) return;
+      // The GROUPS, not the tool names. Every cell here is a grid cell, so "has render" is the
+      // whole question — and matching on a `present*` prefix would count presentCollection,
+      // which belongs to `data` and draws nothing without the collection store behind it.
+      canvasAvailable.value = Array.isArray(body.groups) && body.groups.includes("render");
+    } catch {
+      // Unreachable server: no button rather than one that opens an empty panel.
+      if (sessionId === expandedSessionId.value) canvasAvailable.value = false;
+    }
+  },
+  { immediate: true },
+);
 const filesPane = ref<InstanceType<typeof FilesPane> | null>(null);
 // What the pane looked like in each cell, so coming back to a terminal doesn't mean opening
 // the same three directories again. Saved state only — the buffer went to disk on the way out
@@ -491,21 +571,22 @@ watch(
          in both. Hidden outright when nothing is zoomed, like .zoom-main itself. -->
     <div ref="zoomRow" :class="zoomed ? 'flex min-h-0 min-w-0 flex-auto' : 'hidden'">
       <div ref="zoomMain" class="zoom-main" />
-      <template v-if="filesOpen">
+      <template v-if="rightPane">
         <div
           class="w-[5px] flex-none cursor-col-resize bg-border hover:bg-accent focus-visible:bg-accent"
           role="separator"
           aria-orientation="vertical"
-          aria-label="Resize file pane"
+          aria-label="Resize side pane"
           :aria-valuenow="paneWidth"
           :aria-valuemin="paneMin"
           :aria-valuemax="paneMax"
-          title="Drag (or use arrow keys) to resize the file pane"
+          title="Drag (or use arrow keys) to resize the side pane"
           tabindex="0"
           @pointerdown.prevent="onSplitterDown"
           @keydown="onSplitterKey"
         />
         <FilesPane
+          v-if="rightPane === 'files'"
           ref="filesPane"
           :cwd="paneCwd"
           :initial-state="paneState"
@@ -520,6 +601,23 @@ watch(
             <span class="truncate font-mono text-[11px] text-muted" :title="paneCwd ?? ''">{{ formatCwd(paneCwd, home) }}</span>
           </template>
         </FilesPane>
+        <!-- Canvas and Tools follow the enlarged cell's SESSION, not its directory, and neither
+             holds an unsaved buffer — so unlike the files pane they re-root unconditionally and
+             need none of its decline-a-re-root machinery. -->
+        <GuiPanel
+          v-else-if="rightPane === 'canvas'"
+          :session-id="expandedSessionId"
+          :send-text-message="sendToExpandedCell"
+          :style="{ flex: `0 0 ${paneWidth}px` }"
+          @toggle-tools="toggleRightPane('tools')"
+        />
+        <ToolsPane
+          v-else-if="rightPane === 'tools'"
+          :session-id="expandedSessionId"
+          :style="{ flex: `0 0 ${paneWidth}px` }"
+          class="border-l border-border"
+          @close="setRightPane(null)"
+        />
       </template>
     </div>
     <div class="grid" :style="gridStyle">
@@ -530,12 +628,17 @@ watch(
           :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
           :files-open="filesOpen"
+          :right-pane="rightPane"
+          :canvas-available="canvasAvailable"
           :zoomed="zoomed"
           :command="cell.command"
           :home="home"
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @toggle-files="toggleFiles"
+          @toggle-canvas="toggleRightPane('canvas')"
+          @open-canvas="openCanvasFor(cell.uid)"
+          @toggle-tools="toggleRightPane('tools')"
           @close="emit('close', cell.uid)"
           @move="(dir) => emit('move', cell.uid, dir)"
           @status="(s) => emit('status', cell.uid, s)"
@@ -547,6 +650,8 @@ watch(
           :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
           :files-open="filesOpen"
+          :right-pane="rightPane"
+          :canvas-available="canvasAvailable"
           :zoomed="zoomed"
           :launcher="cell.launcher"
           :session="cell.session"
@@ -555,6 +660,9 @@ watch(
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @toggle-files="toggleFiles"
+          @toggle-canvas="toggleRightPane('canvas')"
+          @open-canvas="openCanvasFor(cell.uid)"
+          @toggle-tools="toggleRightPane('tools')"
           @close="emit('close', cell.uid)"
           @move="(dir) => emit('move', cell.uid, dir)"
           @status="(s) => emit('status', cell.uid, s)"
@@ -567,6 +675,8 @@ watch(
           :class="cellClass(cell.uid)"
           :expanded="cell.uid === expandedUid"
           :files-open="filesOpen"
+          :right-pane="rightPane"
+          :canvas-available="canvasAvailable"
           :zoomed="zoomed"
           :initial-session-id="cell.session"
           :initial-cwd="cell.cwd"
@@ -581,6 +691,9 @@ watch(
           :reorderable="reorderable"
           @toggle-expand="emit('toggle-expand', cell.uid)"
           @toggle-files="toggleFiles"
+          @toggle-canvas="toggleRightPane('canvas')"
+          @open-canvas="openCanvasFor(cell.uid)"
+          @toggle-tools="toggleRightPane('tools')"
           @session="(id) => emit('session', cell.uid, id)"
           @agent="(a) => emit('agent', cell.uid, a)"
           @cwd="(c) => emit('cwd', cell.uid, c)"

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -232,13 +232,16 @@ function sendToExpandedCell(text: string): boolean {
 // Re-asked on every expand, not only when the session id changes: a cell that has just started
 // may not have connected its MCP client yet, and re-expanding is how a user retries anything.
 const canvasAvailable = ref(false);
+// Whether the answer above has come back yet for the CURRENT cell. Without it the panel says
+// "not enabled for this directory" for the moment between switching cells and the reply landing
+// — a wrong explanation is worse than none, so nothing is claimed until it is known.
+const canvasChecked = ref(false);
 watch(
   [expandedSessionId, () => props.expandedUid],
   async ([sessionId]) => {
-    if (!sessionId) {
-      canvasAvailable.value = false;
-      return;
-    }
+    canvasAvailable.value = false;
+    canvasChecked.value = false;
+    if (!sessionId) return;
     try {
       const res = await fetch(`/api/tools?sessionId=${encodeURIComponent(sessionId)}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -249,13 +252,24 @@ watch(
       // whole question — and matching on a `present*` prefix would count presentCollection,
       // which belongs to `data` and draws nothing without the collection store behind it.
       canvasAvailable.value = Array.isArray(body.groups) && body.groups.includes("render");
+      canvasChecked.value = true;
     } catch {
-      // Unreachable server: no button rather than one that opens an empty panel.
+      // Unreachable server: no button rather than one that opens an empty panel. Left unchecked
+      // so the panel does not blame the directory for what is our own failure to ask.
       if (sessionId === expandedSessionId.value) canvasAvailable.value = false;
     }
   },
   { immediate: true },
 );
+
+// What the Canvas pane should say instead of its "ask Claude to draw something" hint. The pane
+// outlives the cell it was opened on, so walking the zoom lands it on cells that can never fill
+// it — a launcher or a command cell (no session), or a directory with no render MCP.
+const canvasUnavailable = computed<"no-session" | "no-render-mcp" | null>(() => {
+  if (!expandedSessionId.value) return "no-session";
+  if (canvasChecked.value && !canvasAvailable.value) return "no-render-mcp";
+  return null;
+});
 const filesPane = ref<InstanceType<typeof FilesPane> | null>(null);
 // What the pane looked like in each cell, so coming back to a terminal doesn't mean opening
 // the same three directories again. Saved state only — the buffer went to disk on the way out
@@ -608,6 +622,7 @@ watch(
           v-else-if="rightPane === 'canvas'"
           :session-id="expandedSessionId"
           :send-text-message="sendToExpandedCell"
+          :unavailable="canvasUnavailable"
           :style="{ flex: `0 0 ${paneWidth}px` }"
           @toggle-tools="toggleRightPane('tools')"
         />

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -24,6 +24,7 @@ import { setFilesPaneOpener } from "../composables/filesPaneOpener";
 import { paneCanShowClick } from "./paneClickTarget";
 import { usePubSub } from "../composables/usePubSub";
 import { TOOL_GROUPS_CHANNEL } from "../toolGroupsChannel";
+import { CANVAS_TOOL_GROUP } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 
@@ -253,7 +254,7 @@ watch(
       // The GROUPS, not the tool names. Every cell here is a grid cell, so "has render" is the
       // whole question — and matching on a `present*` prefix would count presentCollection,
       // which belongs to `data` and draws nothing without the collection store behind it.
-      canvasAvailable.value = Array.isArray(body.groups) && body.groups.includes("render");
+      canvasAvailable.value = Array.isArray(body.groups) && body.groups.includes(CANVAS_TOOL_GROUP);
       canvasChecked.value = true;
     } catch {
       // Unreachable server: no button rather than one that opens an empty panel. Left unchecked
@@ -272,7 +273,7 @@ const { subscribe: subscribeToolGroups } = usePubSub();
 const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
   const msg = data as { sessionId?: string; groups?: string[] };
   if (!msg?.sessionId || msg.sessionId !== expandedSessionId.value) return;
-  canvasAvailable.value = Array.isArray(msg.groups) && msg.groups.includes("render");
+  canvasAvailable.value = Array.isArray(msg.groups) && msg.groups.includes(CANVAS_TOOL_GROUP);
   canvasChecked.value = true;
 });
 onBeforeUnmount(() => offToolGroups());

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onUnmounted } from "vue";
+import { ref, watch, onUnmounted } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 
 // The tools pane mirrors MulmoClaude's right sidebar: an "Available Tools" list
@@ -31,17 +31,29 @@ const toolCalls = ref<ToolCall[]>([]);
 const expandedTools = ref<Set<string>>(new Set());
 const expandedCalls = ref<Set<string>>(new Set());
 
-// Available tools are the same for every session; load once.
-async function loadAvailableTools() {
+// NOT the same for every session any more. A grid cell reaches the GUI tools through one URL
+// per group, registered in the USER's own per-folder MCP config — so two cells can have
+// different tools, and the list has to be asked for per session. Without a session id the
+// server answers with the whole set (the single view, which carries every tool).
+//
+// Reloaded on every session change rather than cached per id: the server learns a session's
+// groups from the connections it makes, so the answer for one id can go from "everything" to
+// the real subset within a second of that session starting.
+async function loadAvailableTools(sessionId: string | null) {
+  const url = sessionId ? `/api/tools?sessionId=${encodeURIComponent(sessionId)}` : "/api/tools";
   try {
-    const res = await fetch("/api/tools");
+    const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    availableTools.value = (await res.json()).tools ?? [];
+    const body = await res.json();
+    // Late reply for a session we have since switched away from: dropping it keeps the list
+    // from showing another cell's tools.
+    if (sessionId !== props.sessionId) return;
+    availableTools.value = body.tools ?? [];
   } catch {
-    availableTools.value = [];
+    if (sessionId === props.sessionId) availableTools.value = [];
   }
 }
-loadAvailableTools();
+watch(() => props.sessionId, loadAvailableTools, { immediate: true });
 
 function callKey(c: ToolCall, i: number): string {
   return c.toolUseId ?? `${c.toolName}-${i}`;

--- a/src/components/cellChromeClasses.ts
+++ b/src/components/cellChromeClasses.ts
@@ -45,6 +45,11 @@ export const CELL_BTN_BOX = "inline-flex items-center justify-center rounded-md 
 export const CELL_BTN_SIZE = "h-[26px] w-7 text-[16px]";
 export const CELL_BTN_INK = "cursor-pointer text-[var(--cell-btn,var(--text-secondary))] hover:bg-hover hover:text-fg";
 export const CELL_BTN = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} ${CELL_BTN_INK}`;
+// Ink for a button that can be DISABLED. The hover affordances are `enabled:`-prefixed, or a
+// button that cannot be pressed still lights up under the cursor and reads as pressable; the
+// dimming is what says it is there but unavailable. Same idiom as the launcher's ▶ button.
+export const CELL_BTN_INK_DISABLEABLE = `enabled:cursor-pointer text-[var(--cell-btn,var(--text-secondary))] enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40`;
+export const CELL_BTN_DISABLEABLE = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} ${CELL_BTN_INK_DISABLEABLE}`;
 export const CELL_CLOSE_BTN = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} cursor-pointer text-[var(--cell-btn,var(--text-secondary))] hover:bg-[var(--err-hover-bg)] hover:text-err-text`;
 
 // A path clipped from the FRONT: `rtl` puts the ellipsis at the start so the tail — the

--- a/src/components/gridCell.ts
+++ b/src/components/gridCell.ts
@@ -9,6 +9,12 @@
 // change to what the grid needs cannot land in two of the three.
 import type { CellStatus } from "./gridTabs";
 
+// The pane showing beside the ENLARGED cell. One slot, three possible occupants, never two at
+// once — the row is already `roster | terminal | pane`, and a fourth column leaves the terminal
+// unreadable on a laptop. Declared with the rest of the grid's contract because every cell type
+// renders the toggles and none of them owns the state.
+export type RightPane = "files" | "canvas" | "tools";
+
 export interface GridCellProps {
   expanded: boolean;
   // True while SOME cell in the grid is zoomed → this cell is a filmstrip thumbnail
@@ -17,11 +23,22 @@ export interface GridCellProps {
   // Whether the file pane is showing beside the enlarged cell, so its toggle can read as
   // pressed. Grid state, not the cell's: only the expanded cell renders the toggle.
   filesOpen?: boolean;
+  // Which of the three side panes is showing, so each toggle can read as pressed without three
+  // booleans that could disagree. Grid state for the same reason filesOpen is.
+  rightPane?: RightPane | null;
+  // Whether the ENLARGED cell's session has the drawing tools at all — i.e. whether its
+  // directory registered the `render` MCP group. False leaves the Canvas button in place but
+  // DISABLED: the pane would open empty, and a button that explains why beats one that isn't
+  // there to ask about.
+  canvasAvailable?: boolean;
   home: string | null;
 }
 
 export interface GridCellEmits {
-  (e: "toggle-expand" | "close" | "toggle-files"): void;
+  // `open-canvas` is the unread-canvas chip on an UN-expanded cell: enlarge me AND open the
+  // pane, in one gesture. Distinct from `toggle-canvas`, which toggles the pane on the cell
+  // that is already enlarged.
+  (e: "toggle-expand" | "close" | "toggle-files" | "toggle-canvas" | "toggle-tools" | "open-canvas"): void;
   // Swap this cell left (-1) or right (+1) in manual sort mode.
   (e: "move", dir: -1 | 1): void;
   // Report activity up so the grid can attention-sort in auto mode.

--- a/src/toolGroupsChannel.ts
+++ b/src/toolGroupsChannel.ts
@@ -1,0 +1,8 @@
+// The pub/sub channel the server announces a session's newly learned tool groups on.
+//
+// Its own channel rather than the `sessions` one: that channel's consumer admits anything with
+// an `id` and feeds it to applyActivity, so a message shaped like this would be read as an
+// activity update. Kept in src/ rather than common/ because the server names it in
+// routes/mcp-routes.ts, and a shared constant either side could edit is the thing the two-copy
+// comment usually precedes — this one is pinned by a spec instead.
+export const TOOL_GROUPS_CHANNEL = "tool-groups";

--- a/test/common/toolGroups.spec.ts
+++ b/test/common/toolGroups.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { TOOL_GROUPS, isToolGroup, groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOLS } from "../../common/toolGroups.js";
+import { TOOL_GROUPS, isToolGroup, groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOLS, CANVAS_TOOL_GROUP } from "../../common/toolGroups.js";
 
 describe("tool groups", () => {
   it("classifies the drawing tools as render", () => {
@@ -62,5 +62,19 @@ describe("tool groups", () => {
     expect(isToolGroup("render")).toBe(true);
     expect(isToolGroup("gui")).toBe(false);
     expect(isToolGroup(undefined)).toBe(false);
+  });
+});
+
+// The launcher switch, the panel's availability check and the server all decide on this same
+// group. Written as a literal at each site, a rename would break Canvas detection silently and
+// with no type error — which is what the repo's "shared wire values live in common/" rule is for.
+describe("CANVAS_TOOL_GROUP", () => {
+  it("names a real group", () => {
+    expect(TOOL_GROUPS).toContain(CANVAS_TOOL_GROUP);
+  });
+
+  it("is the group the drawing tools belong to", () => {
+    expect(groupOfTool("presentDocument")).toBe(CANVAS_TOOL_GROUP);
+    expect(groupOfTool("presentHtml")).toBe(CANVAS_TOOL_GROUP);
   });
 });

--- a/test/common/toolGroups.spec.ts
+++ b/test/common/toolGroups.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import { TOOL_GROUPS, isToolGroup, groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOL_GROUPS } from "../../common/toolGroups.js";
+
+describe("tool groups", () => {
+  it("classifies the drawing tools as render", () => {
+    expect(groupOfTool("presentDocument")).toBe("render");
+    expect(groupOfTool("presentForm")).toBe("render");
+    expect(groupOfTool("presentChart")).toBe("render");
+    expect(groupOfTool("presentHtml")).toBe("render");
+  });
+
+  // The blast-radius split is the whole point of the grouping: only `render` is auto-allowed,
+  // so a tool landing in the wrong group is a tool running without a permission prompt.
+  it("keeps the tools with side effects out of render", () => {
+    expect(groupOfTool("manageCollection")).toBe("data");
+    expect(groupOfTool("manageAccounting")).toBe("data");
+    expect(groupOfTool("generateImage")).toBe("media");
+    expect(groupOfTool("presentMulmoScript")).toBe("media");
+    expect(groupOfTool("google")).toBe("external");
+    expect(groupOfTool("readXPost")).toBe("external");
+    expect(groupOfTool("searchX")).toBe("external");
+  });
+
+  // Absent on purpose, not by omission — it starts another session, which no group describes.
+  it("leaves spawnBackgroundChat in no group", () => {
+    expect(groupOfTool("spawnBackgroundChat")).toBeNull();
+  });
+
+  it("reports an unknown tool as ungrouped rather than throwing", () => {
+    expect(groupOfTool("somePluginAddedTomorrow")).toBeNull();
+  });
+
+  // A prototype-chain lookup would resolve these to a function and hand back a truthy
+  // "group" — the same trap the plugin dispatch map documents.
+  it("does not resolve prototype members as a group", () => {
+    expect(groupOfTool("constructor")).toBeNull();
+    expect(groupOfTool("__proto__")).toBeNull();
+    expect(groupOfTool("toString")).toBeNull();
+  });
+
+  it("names each group's expected MCP server id", () => {
+    expect(toolGroupServerId("render")).toBe("mulmoterminal-render");
+    expect(TOOL_GROUPS.map(toolGroupServerId)).toEqual(["mulmoterminal-render", "mulmoterminal-data", "mulmoterminal-media", "mulmoterminal-external"]);
+  });
+
+  it("auto-allows render and nothing else", () => {
+    expect(AUTO_ALLOWED_TOOL_GROUPS).toEqual(["render"]);
+  });
+
+  it("accepts only the real group names", () => {
+    expect(isToolGroup("render")).toBe(true);
+    expect(isToolGroup("gui")).toBe(false);
+    expect(isToolGroup(undefined)).toBe(false);
+  });
+});

--- a/test/common/toolGroups.spec.ts
+++ b/test/common/toolGroups.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { TOOL_GROUPS, isToolGroup, groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOL_GROUPS } from "../../common/toolGroups.js";
+import { TOOL_GROUPS, isToolGroup, groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOLS } from "../../common/toolGroups.js";
 
 describe("tool groups", () => {
   it("classifies the drawing tools as render", () => {
@@ -44,8 +44,18 @@ describe("tool groups", () => {
     expect(TOOL_GROUPS.map(toolGroupServerId)).toEqual(["mulmoterminal-render", "mulmoterminal-data", "mulmoterminal-media", "mulmoterminal-external"]);
   });
 
-  it("auto-allows render and nothing else", () => {
-    expect(AUTO_ALLOWED_TOOL_GROUPS).toEqual(["render"]);
+  // Per TOOL, not per group: "which tools may this directory reach" and "which may run without
+  // asking" are different questions, and presentDocument is the case that forces them apart —
+  // its execute resolves image placeholders through the image backend, a PAID call. Auto-
+  // allowing it would let a model spend money under a switch labelled "let the agent draw".
+  it("auto-allows only tools that call nothing external", () => {
+    expect(AUTO_ALLOWED_TOOLS).toEqual(["presentForm", "presentChart", "presentHtml"]);
+    expect(AUTO_ALLOWED_TOOLS).not.toContain("presentDocument");
+  });
+
+  // They still have to BE render tools — a directory that enabled Canvas is what grants them.
+  it("auto-allows nothing outside the render group", () => {
+    for (const name of AUTO_ALLOWED_TOOLS) expect(groupOfTool(name)).toBe("render");
   });
 
   it("accepts only the real group names", () => {

--- a/test/server/agents/claude-args.spec.ts
+++ b/test/server/agents/claude-args.spec.ts
@@ -10,7 +10,7 @@ const base: ClaudeArgsInput = {
   permissionMode: "auto",
   attachGuiMcp: true,
   mcpConfig: "{gui-mcp}",
-  guiMcpTools: "mcp__gui__a,mcp__gui__b",
+  allowedTools: "mcp__gui__a,mcp__gui__b",
 };
 
 const cfg = (over: Partial<ClaudeArgsInput> = {}): ClaudeArgsInput => ({ ...base, ...over });
@@ -35,7 +35,10 @@ describe("buildClaudeArgs", () => {
     ]);
   });
 
-  it("grid dev terminal (attachGuiMcp=false): no GUI MCP, no --strict-mcp-config, no --allowedTools", () => {
+  // A grid cell's GUI tools arrive through the USER's own per-folder MCP config, so it must
+  // get neither --mcp-config nor --strict-mcp-config (which would ignore that config) — but it
+  // still pre-approves the render group, or every draw stops at a permission prompt.
+  it("grid dev terminal (attachGuiMcp=false): no GUI MCP, no --strict-mcp-config, but keeps --allowedTools", () => {
     const args = buildClaudeArgs({ ...base, attachGuiMcp: false });
     expect(args).toEqual([
       "--session-id",
@@ -46,9 +49,15 @@ describe("buildClaudeArgs", () => {
       "auto",
       "--append-system-prompt",
       SESSION_SUMMARY_PROMPT,
+      "--allowedTools",
+      "mcp__gui__a,mcp__gui__b",
     ]);
     expect(args).not.toContain("--mcp-config");
     expect(args).not.toContain("--strict-mcp-config");
+  });
+
+  it("omits --allowedTools entirely when there is nothing to pre-approve", () => {
+    const args = buildClaudeArgs({ ...base, attachGuiMcp: false, allowedTools: "" });
     expect(args).not.toContain("--allowedTools");
   });
 

--- a/test/server/config/add-dirs.spec.ts
+++ b/test/server/config/add-dirs.spec.ts
@@ -86,7 +86,7 @@ describe("buildClaudeArgs with addDirs", () => {
     permissionMode: "auto",
     attachGuiMcp: false,
     mcpConfig: "{}",
-    guiMcpTools: "",
+    allowedTools: "",
   };
 
   it("passes one variadic flag holding every directory", () => {
@@ -97,7 +97,7 @@ describe("buildClaudeArgs with addDirs", () => {
 
   // `--add-dir <directories...>` is variadic: a VALUE after it would be swallowed into the list.
   it("puts the flag last, so nothing can follow it", () => {
-    const args = buildClaudeArgs({ ...base, addDirs: ["/a"], model: "opus", attachGuiMcp: true, guiMcpTools: "t" });
+    const args = buildClaudeArgs({ ...base, addDirs: ["/a"], model: "opus", attachGuiMcp: true, allowedTools: "t" });
     expect(args[args.length - 2]).toBe("--add-dir");
     expect(args[args.length - 1]).toBe("/a");
   });
@@ -158,7 +158,7 @@ describe("path resolution parity", () => {
       permissionMode: "auto",
       attachGuiMcp: false,
       mcpConfig: "{}",
-      guiMcpTools: "",
+      allowedTools: "",
       addDirs: dirs,
     });
     const flagged = args.slice(args.indexOf("--add-dir") + 1);

--- a/test/server/config/dir-model-choice.spec.ts
+++ b/test/server/config/dir-model-choice.spec.ts
@@ -129,7 +129,7 @@ describe("what actually reaches argv", () => {
       permissionMode: "auto",
       attachGuiMcp: false,
       mcpConfig: "{}",
-      guiMcpTools: "",
+      allowedTools: "",
     });
 
   it("passes a usable id through as the --model value", () => {

--- a/test/server/infra/gui-mcp-registration.spec.ts
+++ b/test/server/infra/gui-mcp-registration.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+
+import { guiMcpUrlTemplate, listMentionsServer } from "../../../server/infra/gui-mcp-registration.js";
+
+// The url is registered ONCE, into the user's own Claude Code config, and then read at every
+// connect. It has to stay a template: the port and session id are only known per spawn, and
+// Claude Code is what expands them (verified against the real CLI).
+describe("guiMcpUrlTemplate", () => {
+  it("leaves the port and session id as ${VAR} for Claude Code to expand", () => {
+    expect(guiMcpUrlTemplate("render")).toBe("http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/render/${MULMOTERMINAL_SESSION_ID}");
+  });
+
+  it("puts the group in the path, so one server id maps to one group", () => {
+    expect(guiMcpUrlTemplate("data")).toContain("/api/mcp/data/");
+    expect(guiMcpUrlTemplate("external")).toContain("/api/mcp/external/");
+  });
+
+  // 127.0.0.1 rather than localhost, for the same reason mcp-config.ts uses it: an IPv6/IPv4
+  // resolution mismatch against the server's listen address.
+  it("addresses the loopback numerically", () => {
+    expect(guiMcpUrlTemplate("render").startsWith("http://127.0.0.1:")).toBe(true);
+  });
+});
+
+describe("listMentionsServer", () => {
+  const list = ["mulmoterminal-render: http://127.0.0.1:34567/api/mcp/render/x - ✓ Connected", "playwright: npx @playwright/mcp - ✓ Connected"].join("\n");
+
+  it("finds a registered server", () => {
+    expect(listMentionsServer(list, "mulmoterminal-render")).toBe(true);
+  });
+
+  it("does not find one that is absent", () => {
+    expect(listMentionsServer(list, "mulmoterminal-data")).toBe(false);
+  });
+
+  // The id also appears INSIDE the url of the line above it. Matching anywhere in the output
+  // would report every group as registered as soon as one was.
+  it("matches the id at the start of a line, not inside another server's url", () => {
+    expect(listMentionsServer("other: http://x/api/mcp/render/y - ok", "render")).toBe(false);
+  });
+
+  it("tolerates indentation", () => {
+    expect(listMentionsServer("   mulmoterminal-render: http://x - ok", "mulmoterminal-render")).toBe(true);
+  });
+
+  it("reads empty output as nothing registered", () => {
+    expect(listMentionsServer("", "mulmoterminal-render")).toBe(false);
+  });
+});

--- a/test/server/infra/gui-mcp-registration.spec.ts
+++ b/test/server/infra/gui-mcp-registration.spec.ts
@@ -23,7 +23,7 @@ describe("guiMcpUrlTemplate", () => {
 });
 
 describe("listMentionsServer", () => {
-  const list = ["mulmoterminal-render: http://127.0.0.1:34567/api/mcp/render/x - ✓ Connected", "playwright: npx @playwright/mcp - ✓ Connected"].join("\n");
+  const list = ["mulmoterminal-render: http://127.0.0.1:34567/api/mcp/render/x - connected", "playwright: npx @playwright/mcp - connected"].join("\n");
 
   it("finds a registered server", () => {
     expect(listMentionsServer(list, "mulmoterminal-render")).toBe(true);

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -33,6 +33,29 @@ describe("tmuxNewSessionArgs", () => {
     expect(dashdash).toBeGreaterThan(0);
     expect(args.slice(dashdash + 1)).toEqual(["/bin/zsh", "-lc", "exec codex"]);
   });
+
+  it("passes no -e when there is no per-session environment", () => {
+    expect(args).not.toContain("-e");
+  });
+
+  // A pane takes the tmux SERVER's environment, which outlives any one session — so a
+  // per-session value has to be set ON the session with -e, never exported into our own env.
+  describe("with a per-session environment", () => {
+    const withEnv = tmuxNewSessionArgs("id1", "/bin/zsh", ["-lc", "exec claude"], "/proj", { MULMOTERMINAL_PORT: "34567", MULMOTERMINAL_SESSION_ID: "abc" });
+
+    it("sets each variable with -e KEY=VALUE", () => {
+      expect(withEnv).toContain("-e");
+      expect(withEnv).toContain("MULMOTERMINAL_PORT=34567");
+      expect(withEnv).toContain("MULMOTERMINAL_SESSION_ID=abc");
+    });
+
+    // After `--` they would be arguments to the program, not tmux flags.
+    it("keeps them before `--`, and the program after it", () => {
+      const dashdash = withEnv.indexOf("--");
+      expect(withEnv.indexOf("MULMOTERMINAL_PORT=34567")).toBeLessThan(dashdash);
+      expect(withEnv.slice(dashdash + 1)).toEqual(["/bin/zsh", "-lc", "exec claude"]);
+    });
+  });
 });
 
 describe("TMUX_CONF_LINES", () => {

--- a/test/server/infra/tool-group-map.spec.ts
+++ b/test/server/infra/tool-group-map.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+
+import { TOOL_GROUPS, groupOfTool } from "../../../common/toolGroups.js";
+import { toolSummaries } from "../../../server/infra/plugins-registry.js";
+
+// The map is hand-maintained against the registry, so it can silently fall behind. This is the
+// one check that notices — it does not force a classification (ungrouped is a legal answer),
+// it only pins WHICH tools are currently unclassified, so adding a plugin without deciding
+// where it belongs fails here rather than quietly never appearing on a group URL.
+describe("the group map against the real registry", () => {
+  it("leaves exactly the tools we meant to leave ungrouped", () => {
+    const ungrouped = toolSummaries.map((t) => t.toolName).filter((name) => groupOfTool(name) === null);
+    expect(ungrouped).toEqual(["spawnBackgroundChat"]);
+  });
+
+  it("classifies every tool it does classify into a real group", () => {
+    for (const { toolName } of toolSummaries) {
+      const group = groupOfTool(toolName);
+      if (group !== null) expect(TOOL_GROUPS).toContain(group);
+    }
+  });
+});

--- a/test/server/mcp/tool-gate.spec.ts
+++ b/test/server/mcp/tool-gate.spec.ts
@@ -136,3 +136,63 @@ describe("describeTool", () => {
     expect(describeTool({ name: "x" })).toBe("");
   });
 });
+
+// A group URL exists so a directory can switch a SUBSET of the GUI tools on through Claude
+// Code's own per-folder MCP config. Both layers matter for the same reason they do for the
+// worker gate: not offering a tool is not a control, because a model can name one it was
+// never shown.
+describe("the tool-group gate", () => {
+  describe("what a group URL offers", () => {
+    it("offers only the group's tools", () => {
+      expect(names(offeredTools(false, PLUGINS, WORKER_TOOL, "render"))).toEqual(["presentHtml"]);
+      expect(names(offeredTools(false, PLUGINS, WORKER_TOOL, "data"))).toEqual(["manageCollection"]);
+    });
+
+    it("offers nothing for a group none of the tools belong to", () => {
+      expect(names(offeredTools(false, PLUGINS, WORKER_TOOL, "media"))).toEqual([]);
+    });
+
+    // The map can go stale when a plugin is added; this is the direction it fails in.
+    it("withholds an unclassified tool from every group", () => {
+      for (const group of ["render", "data", "media", "external"] as const) {
+        expect(names(offeredTools(false, PLUGINS, WORKER_TOOL, group))).not.toContain("spawnBackgroundChat");
+      }
+    });
+
+    // The single view's URL, which must keep offering everything.
+    it("offers every tool when no group is given", () => {
+      expect(names(offeredTools(false, PLUGINS, WORKER_TOOL))).toEqual(["manageCollection", "presentHtml", "spawnBackgroundChat"]);
+    });
+
+    // The worker gate is the narrower one and has to win: a translation worker reached through
+    // a group URL still gets its one tool, never the group's.
+    it("still gives a translation worker submitTranslation alone", () => {
+      expect(names(offeredTools(true, PLUGINS, WORKER_TOOL, "render"))).toEqual([SUBMIT_TRANSLATION_TOOL_NAME]);
+    });
+  });
+
+  describe("what a group URL will actually run", () => {
+    it("dispatches a tool that is in the group", () => {
+      expect(routeToolCall("presentHtml", false, "render")).toEqual({ kind: "dispatch" });
+    });
+
+    it("refuses a real tool from another group, even though it was never offered", () => {
+      const route = routeToolCall("manageCollection", false, "render");
+      expect(route.kind).toBe("refused");
+      expect(route.kind === "refused" && route.message).toContain("render");
+    });
+
+    it("refuses an unclassified tool", () => {
+      expect(routeToolCall("spawnBackgroundChat", false, "render").kind).toBe("refused");
+    });
+
+    it("dispatches anything when no group is given", () => {
+      expect(routeToolCall("manageCollection", false)).toEqual({ kind: "dispatch" });
+      expect(routeToolCall("spawnBackgroundChat", false)).toEqual({ kind: "dispatch" });
+    });
+
+    it("refuses the worker's tool on a group URL like it does anywhere else", () => {
+      expect(routeToolCall(SUBMIT_TRANSLATION_TOOL_NAME, false, "render").kind).toBe("refused");
+    });
+  });
+});

--- a/test/server/routes/narrowed-tools.spec.ts
+++ b/test/server/routes/narrowed-tools.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import { narrowedTools, type ToolSummary } from "../../../server/routes/tool-routes.js";
+
+const TOOLS: ToolSummary[] = [
+  { toolName: "presentDocument", title: "presentDocument" },
+  { toolName: "presentHtml", title: "presentHtml" },
+  { toolName: "manageCollection", title: "manageCollection" },
+  { toolName: "generateImage", title: "generateImage" },
+  { toolName: "spawnBackgroundChat", title: "spawnBackgroundChat" },
+];
+const names = (tools: ToolSummary[]) => tools.map((t) => t.toolName);
+
+describe("narrowedTools", () => {
+  // REGRESSION. An empty group list means opposite things for the two kinds of session, and
+  // treating both as "cannot narrow, answer with everything" reported the full tool list for a
+  // grid cell whose directory had registered no MCP at all — so the UI offered a Canvas button
+  // that opened a panel nothing could ever fill.
+  it("gives a grid cell with nothing registered nothing", () => {
+    expect(narrowedTools(TOOLS, [], true)).toEqual([]);
+  });
+
+  // The single view carries the whole GUI MCP on --mcp-config and never connects to a group
+  // URL, so it learns no groups and nonetheless has every tool. Same empty list, opposite answer.
+  it("gives a non-grid session everything, groups or not", () => {
+    expect(names(narrowedTools(TOOLS, [], false))).toEqual(names(TOOLS));
+  });
+
+  it("gives a grid cell exactly the groups it reached us on", () => {
+    expect(names(narrowedTools(TOOLS, ["render"], true))).toEqual(["presentDocument", "presentHtml"]);
+    expect(names(narrowedTools(TOOLS, ["render", "media"], true))).toEqual(["presentDocument", "presentHtml", "generateImage"]);
+  });
+
+  // Ungrouped tools reach no group URL, so a grid cell cannot have one however many groups it
+  // registered — only the un-narrowed answer lists them.
+  it("never gives a grid cell an ungrouped tool", () => {
+    const all = narrowedTools(TOOLS, ["render", "data", "media", "external"], true);
+    expect(names(all)).not.toContain("spawnBackgroundChat");
+    expect(names(narrowedTools(TOOLS, [], false))).toContain("spawnBackgroundChat");
+  });
+
+  it("does not mutate the list it was given", () => {
+    narrowedTools(TOOLS, ["render"], true);
+    expect(TOOLS).toHaveLength(5);
+  });
+});

--- a/test/server/session/mcp-config.spec.ts
+++ b/test/server/session/mcp-config.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { mcpConfigJson } from "../../../server/session/mcp-config.js";
+import { mcpConfigJson, guiMcpEnv } from "../../../server/session/mcp-config.js";
 import { SANDBOX_HOST } from "../../../server/infra/sandbox.js";
 
 const SESSION = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
@@ -85,5 +85,18 @@ describe("mcpConfigJson", () => {
 
   it("produces parseable JSON", () => {
     expect(() => JSON.parse(mcpConfigJson({ sessionId: SESSION, port: 34567, userMcpServers: [] }))).not.toThrow();
+  });
+});
+
+// A grid cell gets no --mcp-config: its GUI tools come from the user's own per-folder MCP
+// config, where the url is a static string. Claude Code expands ${VAR} in it at connect time,
+// so the session id and port reach the url through the environment instead.
+describe("guiMcpEnv", () => {
+  it("carries the port and session id the url template interpolates", () => {
+    expect(guiMcpEnv("abc-123", 34567)).toEqual({ MULMOTERMINAL_PORT: "34567", MULMOTERMINAL_SESSION_ID: "abc-123" });
+  });
+
+  it("stringifies a port given as a string too", () => {
+    expect(guiMcpEnv("abc-123", "8080").MULMOTERMINAL_PORT).toBe("8080");
   });
 });

--- a/test/server/session/pty-spawn-env.spec.ts
+++ b/test/server/session/pty-spawn-env.spec.ts
@@ -51,13 +51,13 @@ describe("spawnPty — the environment it hands the pty", () => {
 // there is what actually protects it — but the non-tmux path has only this.
 describe("ptySpawn — carries the removal down both paths", () => {
   it("applies it on the direct spawn", () => {
-    ptySpawn("s1", "claude", [], "/tmp", false, ["ANTHROPIC_API_KEY"]);
+    ptySpawn("s1", "claude", [], "/tmp", false, { unset: ["ANTHROPIC_API_KEY"] });
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
   });
 
   it("applies it on the tmux spawn too", () => {
     tmuxOn = true;
-    const result = ptySpawn("s1", "claude", [], "/tmp", true, ["ANTHROPIC_API_KEY"]);
+    const result = ptySpawn("s1", "claude", [], "/tmp", true, { unset: ["ANTHROPIC_API_KEY"] });
     expect(result.tmux).toBe(true);
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
   });
@@ -69,7 +69,7 @@ describe("ptySpawn — carries the removal down both paths", () => {
 describe("ptySpawn — the tmux server's own environment", () => {
   it("scrubs the names from the running server before a provider spawn", () => {
     tmuxOn = true;
-    ptySpawn("s1", "claude", [], "/tmp", true, ["ANTHROPIC_API_KEY"]);
+    ptySpawn("s1", "claude", [], "/tmp", true, { unset: ["ANTHROPIC_API_KEY"] });
     expect(scrub).toHaveBeenCalledWith(["ANTHROPIC_API_KEY"]);
   });
 

--- a/test/server/session/session-settings.spec.ts
+++ b/test/server/session/session-settings.spec.ts
@@ -145,7 +145,7 @@ describe("the argv a Windows spawn ends up with", () => {
       permissionMode: "auto",
       attachGuiMcp: true,
       mcpConfig,
-      guiMcpTools: "mulmoterminal_readXPost,mulmoterminal_searchX",
+      allowedTools: "mulmoterminal_readXPost,mulmoterminal_searchX",
     });
     expect(args.filter((a) => a.includes('"'))).toEqual([]);
   });

--- a/test/server/session/session-tool-groups.spec.ts
+++ b/test/server/session/session-tool-groups.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+
+import { parseSessionToolGroups, sessionToolGroupLine } from "../../../server/session/session-tool-groups.js";
+
+const ID = "11111111-1111-1111-1111-111111111111";
+const ID2 = "22222222-2222-2222-2222-222222222222";
+const isValidId = (id: string) => /^[0-9a-f-]{36}$/i.test(id);
+
+describe("parseSessionToolGroups", () => {
+  it("reads one entry per line", () => {
+    expect(parseSessionToolGroups(`${ID} render\n${ID} data\n${ID2} media`, isValidId)).toEqual([
+      { sessionId: ID, group: "render" },
+      { sessionId: ID, group: "data" },
+      { sessionId: ID2, group: "media" },
+    ]);
+  });
+
+  // The log is appended to on every learn, and the same pair is learned again after a restart.
+  it("collapses a repeated pair", () => {
+    expect(parseSessionToolGroups(`${ID} render\n${ID} render`, isValidId)).toEqual([{ sessionId: ID, group: "render" }]);
+  });
+
+  it("ignores blank lines and surrounding whitespace", () => {
+    expect(parseSessionToolGroups(`\n  ${ID}   render  \n\n`, isValidId)).toEqual([{ sessionId: ID, group: "render" }]);
+  });
+
+  // A bad id would be compared against real ones; a bad group against a real URL. Neither is
+  // worth guessing at, and a torn append is the ordinary way to get one.
+  it("drops an unusable session id", () => {
+    expect(parseSessionToolGroups(`not-an-id render\n${ID} render`, isValidId)).toEqual([{ sessionId: ID, group: "render" }]);
+  });
+
+  it("drops an unknown group", () => {
+    expect(parseSessionToolGroups(`${ID} everything\n${ID} data`, isValidId)).toEqual([{ sessionId: ID, group: "data" }]);
+  });
+
+  it("drops a line carrying more than the two fields", () => {
+    expect(parseSessionToolGroups(`${ID} render extra`, isValidId)).toEqual([]);
+  });
+
+  it("reads an empty file as nothing", () => {
+    expect(parseSessionToolGroups("", isValidId)).toEqual([]);
+  });
+});
+
+describe("sessionToolGroupLine", () => {
+  // Leading newline, like dev-terminal-sessions.ts: whatever the file ended with — including a
+  // write cut off mid-line — an appended entry starts its own line, so the damage is one entry.
+  it("leads with the newline so an append always starts its own line", () => {
+    expect(sessionToolGroupLine(ID, "render")).toBe(`\n${ID} render`);
+  });
+
+  it("round-trips through the parser", () => {
+    const file = sessionToolGroupLine(ID, "render") + sessionToolGroupLine(ID2, "external");
+    expect(parseSessionToolGroups(file, isValidId)).toEqual([
+      { sessionId: ID, group: "render" },
+      { sessionId: ID2, group: "external" },
+    ]);
+  });
+
+  // A file written by the previous version of this log, or a torn last line, must not take the
+  // earlier entries with it.
+  it("keeps earlier entries when the last line is truncated", () => {
+    const file = `${sessionToolGroupLine(ID, "render")}\n${ID2} ren`;
+    expect(parseSessionToolGroups(file, isValidId)).toEqual([{ sessionId: ID, group: "render" }]);
+  });
+});

--- a/test/server/session/session-tool-groups.spec.ts
+++ b/test/server/session/session-tool-groups.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { parseSessionToolGroups, sessionToolGroupLine } from "../../../server/session/session-tool-groups.js";
+import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET } from "../../../server/session/session-tool-groups.js";
 
 const ID = "11111111-1111-1111-1111-111111111111";
 const ID2 = "22222222-2222-2222-2222-222222222222";
@@ -63,5 +63,34 @@ describe("sessionToolGroupLine", () => {
   it("keeps earlier entries when the last line is truncated", () => {
     const file = `${sessionToolGroupLine(ID, "render")}\n${ID2} ren`;
     expect(parseSessionToolGroups(file, isValidId)).toEqual([{ sessionId: ID, group: "render" }]);
+  });
+});
+
+// What a session HAS is decided by the claude process currently running for it, and that is
+// replaced on every restart/resume — with whatever the user's MCP config says at that moment.
+// Without a reset, disabling Canvas and restarting the same id would leave the old capability
+// asserted for the life of the log.
+describe("the reset marker", () => {
+  it("drops what the session learned before it", () => {
+    expect(parseSessionToolGroups(`${ID} render\n${ID} data\n${ID} -`, isValidId)).toEqual([]);
+  });
+
+  it("keeps what the session learns after it", () => {
+    expect(parseSessionToolGroups(`${ID} render\n${ID} -\n${ID} data`, isValidId)).toEqual([{ sessionId: ID, group: "data" }]);
+  });
+
+  // The log is shared, so one session's restart must not disturb another's.
+  it("resets only the session it names", () => {
+    expect(parseSessionToolGroups(`${ID} render\n${ID2} render\n${ID} -`, isValidId)).toEqual([{ sessionId: ID2, group: "render" }]);
+  });
+
+  it("is written by the same line builder", () => {
+    expect(sessionToolGroupLine(ID, TOOL_GROUP_RESET)).toBe(`\n${ID} -`);
+  });
+
+  // Replay ORDER is what makes a reset mean anything — a set union of the file would not.
+  it("survives a round trip through the builder", () => {
+    const file = sessionToolGroupLine(ID, "render") + sessionToolGroupLine(ID, TOOL_GROUP_RESET) + sessionToolGroupLine(ID, "media");
+    expect(parseSessionToolGroups(file, isValidId)).toEqual([{ sessionId: ID, group: "media" }]);
   });
 });

--- a/test/server/session/tool-group-reset.spec.ts
+++ b/test/server/session/tool-group-reset.spec.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+//
+// The reset's one hard case: a session RESUMED while the server is still hydrating.
+//
+// Hydration reads the log as it was before this spawn's reset marker could be appended, so
+// unless the reset is remembered synchronously, hydration puts the superseded groups straight
+// back — /api/tools then reports capabilities the newly spawned process does not have, and the
+// Canvas button stays on after the user switched it off.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ID = "11111111-2222-4333-8444-555555555555";
+const OTHER = "99999999-8888-4777-8666-555555555555";
+
+const appended: string[] = [];
+
+vi.mock("node:fs", () => {
+  const promises = {
+    // Every hydrator in the registry reads through this; only the tool-group log has content.
+    readFile: vi.fn(async (file: string) => (String(file).endsWith("session-tool-groups.json") ? `${ID} render\n${OTHER} data` : "")),
+    appendFile: vi.fn(async (_file: string, data: string) => {
+      appended.push(data);
+    }),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  return { promises, default: { promises } };
+});
+
+async function freshRegistry() {
+  vi.resetModules();
+  appended.length = 0;
+  return import("../../../server/session/registry.js");
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("resetSessionToolGroups against hydration", () => {
+  // The race Codex found: the reset lands first, hydration second.
+  it("keeps hydration from restoring what a spawn already superseded", async () => {
+    const registry = await freshRegistry();
+    // Synchronously, exactly as spawnClaudePty calls it — before hydration has resolved.
+    registry.resetSessionToolGroups(ID);
+    await registry.sessionToolGroupsHydrated;
+    expect(registry.sessionToolGroups(ID)).toEqual([]);
+  });
+
+  // The marker is what survives to the NEXT restart, where a process-local memo is gone and the
+  // log is replayed from scratch. Skipping it when memory "looks empty" was the bug.
+  it("writes the marker even though nothing was learned in this process yet", async () => {
+    const registry = await freshRegistry();
+    registry.resetSessionToolGroups(ID);
+    await registry.sessionToolGroupsHydrated;
+    await new Promise((r) => setImmediate(r)); // let the append chain drain
+    expect(appended).toContain(`\n${ID} -`);
+  });
+
+  it("leaves other sessions' hydrated groups alone", async () => {
+    const registry = await freshRegistry();
+    registry.resetSessionToolGroups(ID);
+    await registry.sessionToolGroupsHydrated;
+    expect(registry.sessionToolGroups(OTHER)).toEqual(["data"]);
+  });
+
+  // A cell whose MCP client connects fast can learn a group before hydration finishes; that is
+  // the NEW process's capability and must not be swept away with the old one's.
+  it("keeps a group learned after the reset", async () => {
+    const registry = await freshRegistry();
+    registry.resetSessionToolGroups(ID);
+    registry.markSessionToolGroup(ID, "media");
+    await registry.sessionToolGroupsHydrated;
+    expect(registry.sessionToolGroups(ID)).toEqual(["media"]);
+  });
+});

--- a/test/src/components/CellChromeButtons.spec.ts
+++ b/test/src/components/CellChromeButtons.spec.ts
@@ -74,3 +74,49 @@ describe("CellChromeButtons — the file pane toggle", () => {
     expect(buttons[1].attributes("aria-label")).toBe("Show files");
   });
 });
+
+// The Canvas pane can only fill for a session whose directory registered the `render` MCP
+// group. Absent, the pane opens empty — so the button stays and explains itself instead of
+// disappearing, which would leave nothing to ask about.
+describe("the canvas button", () => {
+  const canvasButton = (props: Record<string, unknown>) =>
+    mount(CellChromeButtons, { props: { expanded: true, ...props } }).find('[data-testid="cell-canvas-btn"]');
+
+  it("is absent until the cell is enlarged (the pane needs the room)", () => {
+    const w = mount(CellChromeButtons, { props: { expanded: false, canvasAvailable: true } });
+    expect(w.find('[data-testid="cell-canvas-btn"]').exists()).toBe(false);
+  });
+
+  it("is enabled when the session has the render tools", () => {
+    const btn = canvasButton({ canvasAvailable: true });
+    expect(btn.exists()).toBe(true);
+    expect(btn.attributes("disabled")).toBeUndefined();
+    expect(btn.attributes("title")).toBe("Show canvas");
+  });
+
+  it("is present but disabled when it does not", () => {
+    const btn = canvasButton({ canvasAvailable: false });
+    expect(btn.exists()).toBe(true);
+    expect(btn.attributes("disabled")).toBeDefined();
+  });
+
+  // A disabled control is exactly when someone asks why — so the title carries the fix, and
+  // names the restart, which is easy to miss because every other dir setting applies live.
+  it("says how to fix it, restart included", () => {
+    const title = canvasButton({ canvasAvailable: false }).attributes("title") ?? "";
+    expect(title).toContain("Canvas");
+    expect(title).toContain("restart");
+  });
+
+  // Without `enabled:`-prefixed hovers a disabled button still lights up under the cursor and
+  // reads as pressable.
+  it("does not offer hover affordances while disabled", () => {
+    expect(canvasButton({ canvasAvailable: false }).classes()).not.toContain("hover:bg-hover");
+    expect(canvasButton({ canvasAvailable: false }).classes()).toContain("disabled:opacity-40");
+  });
+
+  it("reads as pressed while the canvas pane is the one showing", () => {
+    expect(canvasButton({ canvasAvailable: true, rightPane: "canvas" }).attributes("aria-pressed")).toBe("true");
+    expect(canvasButton({ canvasAvailable: true, rightPane: "files" }).attributes("aria-pressed")).toBe("false");
+  });
+});

--- a/test/src/components/GuiPanelUnavailable.spec.ts
+++ b/test/src/components/GuiPanelUnavailable.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import GuiPanel from "../../../src/components/GuiPanel.vue";
+
+// The Canvas pane outlives the cell it was opened on: walking the zoom lands it on a launcher
+// with no session, or on a directory whose agent has no drawing tools. Its normal empty state
+// says "ask Claude to use presentDocument" — an instruction that cannot be followed in either
+// case, which is worse than saying nothing.
+vi.mock("../../../src/composables/usePubSub", () => ({ usePubSub: () => ({ subscribe: () => () => {} }) }));
+
+const mountPanel = (props: Record<string, unknown> = {}) =>
+  mount(GuiPanel, { props: { sessionId: null, sendTextMessage: () => true, ...props }, global: { stubs: { PluginFrame: true } } });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ toolResults: [] }) })),
+  );
+});
+
+describe("the canvas pane's unavailable states", () => {
+  it("keeps the ask-Claude hint when the panel is usable", async () => {
+    const w = mountPanel({ sessionId: "s1" });
+    await flushPromises();
+    expect(w.find('[data-testid="canvas-unavailable"]').exists()).toBe(false);
+    expect(w.text()).toContain("presentDocument");
+  });
+
+  // A launcher / command cell. There is no agent to ask, so the hint names a conversation that
+  // cannot happen.
+  it("says there is no session rather than telling you to ask an agent that isn't there", async () => {
+    const w = mountPanel({ unavailable: "no-session" });
+    await flushPromises();
+    expect(w.find('[data-testid="canvas-unavailable"]').exists()).toBe(true);
+    expect(w.text()).toContain("No session here");
+    expect(w.text()).not.toContain("presentDocument");
+  });
+
+  // The tools were never registered for this directory, so asking would fail every time.
+  it("names the directory's missing render MCP, and how to fix it", async () => {
+    const w = mountPanel({ sessionId: "s1", unavailable: "no-render-mcp" });
+    await flushPromises();
+    const text = w.text();
+    expect(text).toContain("not enabled for this directory");
+    expect(text).toContain("CANVAS (render MCPs)");
+    expect(text).toContain("restart");
+    expect(text).not.toContain("presentDocument");
+  });
+
+  // A view left over from the previous cell rendered under an "unavailable" heading would
+  // contradict it outright.
+  it("shows no plugin views while unavailable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ toolResults: [{ uuid: "u1", toolName: "presentDocument", data: {} }] }) })),
+    );
+    const w = mountPanel({ sessionId: "s1", unavailable: "no-render-mcp" });
+    await flushPromises();
+    expect(w.find(".frame").exists()).toBe(false);
+    expect(w.find('[data-testid="canvas-unavailable"]').exists()).toBe(true);
+  });
+});

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -648,7 +648,8 @@ describe("file pane beside the enlarged cell", () => {
   it("remembers being open across a remount, and the pane's own close puts it away", async () => {
     const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     await openPane(w);
-    expect(localStorage.getItem("files_pane_open")).toBe("1");
+    // The key now names WHICH pane holds the slot, not just whether the files one is open.
+    expect(localStorage.getItem("files_pane_open")).toBe("files");
 
     const reopened = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     expect(paneOf(reopened).exists()).toBe(true);
@@ -656,7 +657,16 @@ describe("file pane beside the enlarged cell", () => {
     await paneOf(reopened).vm.$emit("close");
     await nextTick();
     expect(paneOf(reopened).exists()).toBe(false);
-    expect(localStorage.getItem("files_pane_open")).toBe("0");
+    expect(localStorage.getItem("files_pane_open")).toBe("");
+  });
+
+  // The key held "1" before the slot could hold anything but files, so an existing browser
+  // would otherwise come back with the pane closed for no reason it could explain.
+  it("migrates the old boolean value", async () => {
+    localStorage.setItem("files_pane_open", "1");
+    const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
+    await flushPromises();
+    expect(paneOf(w).exists()).toBe(true);
   });
 });
 
@@ -691,7 +701,7 @@ describe("file pane width restored from storage", () => {
     localStorage.setItem("files_pane_width", "400");
     const w = mountCockpit([cell(1, "s1", "/proj"), cell(2)], 1, []);
     await flushPromises();
-    const sep = w.find('[role="separator"][aria-label="Resize file pane"]');
+    const sep = w.find('[role="separator"][aria-label="Resize side pane"]');
     expect(sep.attributes("aria-valuenow")).toBe("400");
     expect(sep.attributes("aria-valuemin")).toBe("360"); // MIN_GUI, there being room for it
     expect(sep.attributes("aria-valuemax")).toBe(String(ROW - 320)); // the terminal keeps MIN_TERMINAL


### PR DESCRIPTION
grid のセルで走るエージェントが `presentDocument` などを呼んでも、これまでは**どこにも出なかった**。Canvas は single view 専用だったため。

拡大中のセルの右に Canvas を出す。**single view の挙動は変えていない。**

## 設計 — MulmoTerminal 側に設定を作らない

どのツールを有効にするかは、**Claude Code 自身の per-folder MCP 設定**に委ねる:

```bash
claude mcp add -s local --transport http mulmoterminal-render \
  'http://127.0.0.1:${MULMOTERMINAL_PORT}/api/mcp/render/${MULMOTERMINAL_SESSION_ID}'
```

`.mcp.json` / local scope はサーバー単位の on/off しか持たないので、**GUI MCP の URL をグループごとに分けて**ツールの粒度を得ている。`.mulmoterminal.json` に新しいキーは足していない。

| グループ | URL | ツール | `--allowedTools` |
|---|---|---|---|
| `render` | `/api/mcp/render/:id` | presentDocument / presentForm / presentChart / presentHtml | **自動許可** |
| `data` | `/api/mcp/data/:id` | presentCollection / manageCollection / manageAccounting | プロンプト |
| `media` | `/api/mcp/media/:id` | generateImage / presentMulmoScript | プロンプト |
| `external` | `/api/mcp/external/:id` | google / readXPost / searchX | プロンプト |
| *(既存)* | `/api/mcp/:id` | 全部 | **変更なし** |

on/off はユーザーが Claude Code で決め、何を無確認で走らせるかは MulmoTerminal が決める。パネルの外に影響しない `render` だけを自動許可し、他は通常の許可プロンプトに委ねる。

URL の可変部（port とセッション ID）は `${VAR}` のまま登録し、Claude Code が接続時に展開する。spawn 時の env で渡す（tmux は pane が tmux サーバの env を継承するため `new-session -e`）。

## 主な変更

- **絞り込みは 2 層** — 提示を絞り、圏外の名前は呼ばれても拒否する。翻訳ワーカーのゲートと同じ形で、「提示していない」を防御とみなさない
- **グループ表は `common/toolGroups.ts`** に置き、プラグインの `ToolDefinition` には足さない（MulmoClaude への publish カスケードを避ける）。未分類のツールはどのグループにも入らない = fail closed
- **セッションが持つグループは接続してきた URL から学習**して永続化する。MulmoTerminal は per-folder の登録を読まないので、これが唯一の手がかり
- **拡大時の右ペインは Files / Canvas / Tools の 3 択排他**（roster は残す）。4 カラムは laptop で破綻する
- **未拡大セルには未読チップだけ**。grid はトリアージ盤なので中身は読ませない。amber（要対応）には昇格させない
- **起動前フォームに「CANVAS (render MCPs)」トグル**。spawn 時に確定する設定なので、起動する前に決める場所に置く
- **Canvas を出せないセルでは理由を表示**。ペインは開いたセルより長生きするので、セッションのないランチャーや render MCP のないディレクトリの上に残る ── そこで「presentDocument を使うよう頼め」と出すのは実行不可能な指示になる

## single view について

`App.vue` / `GuiPanel.vue` の構成、`--strict-mcp-config`・サンドボックス・`attachGuiMcp` の判定はすべて元のまま。`buildClaudeArgs` の argv は既存テストが厳密配列で pin しており同一。共有部分で差があるのは 2 点だけで、いずれも挙動は変わらない:

- spawn 時に `MULMOTERMINAL_PORT` / `MULMOTERMINAL_SESSION_ID` が env に増える（single view はこれを読まない）
- `ToolsPane` が `?sessionId=` 付きで取得するようになった（grid セッションではないので全ツールが返る）

## 確認

`yarn lint`（エラー 0）/ `typecheck`・`typecheck:server`・`typecheck:test` / `yarn test`（**5242 passed**）/ `yarn build`。テスト 63 件追加。

実サーバーに対して実セッション ID で確認:

| | 結果 |
|---|---|
| 各グループ URL の `tools/list` | 上表のとおり。既存の全部入り URL は 13 個すべて維持 |
| 未知のグループ | 404 |
| render URL で `manageCollection` を `tools/call` | 拒否（2 層目が効いている） |
| grid セル・登録なしの `/api/tools` | ツール 0 件 |
| grid でないセッション | 全 13 ツール |

**未確認**: tmux 経由で起動した実 grid セルでの `${VAR}` 展開。CLI 直叩きでは実測済みだが spawn 経路が違う。

設計の経緯は `plans/feat-canvas-in-grid.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Canvas support for expanded grid sessions, with Files, Canvas, and Tools pane switching.
  * Added per-directory Canvas (render) enablement controls.
  * Added session-specific tool visibility and grouped tool access.
  * Added an unread Canvas indicator when new render output arrives.
* **Bug Fixes**
  * Canvas now clears stale content when switching sessions and explains unavailable states.
  * Improved pane-state persistence and migration for existing layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->