### PR TITLE
feat(windows): フォルダ選択をエクスプローラー型ダイアログにする (#1003)

### DIFF
--- a/plans/feat-1003-modern-folder-dialog.md
+++ b/plans/feat-1003-modern-folder-dialog.md
@@ -1,0 +1,50 @@
+# Windows のフォルダ選択をエクスプローラー型にする
+
+Issue: #1003（外部からの報告。原因箇所まで特定されていた）
+
+## 症状
+
+Windows でランチャーの「WORKING DIRECTORY」のフォルダアイコンを押すと、旧ツリー型の
+「フォルダーの参照」が開く。アドレスバーもパス入力も無く、目的のフォルダまで階層を辿るしかない。
+
+## 原因（確認済み）
+
+`server/files/pick-file.ts` の `winArgs()` が `powershell`（= Windows PowerShell 5.1、
+.NET Framework）で `System.Windows.Forms.FolderBrowserDialog` を開いている。.NET Framework 上の
+このダイアログにモダン表示のモードは無い。報告者の指摘どおり。
+
+ファイル選択のほうは `OpenFileDialog` で、Vista 以降エクスプローラー型で描かれている。
+**フォルダ選択だけが取り残されていた。**
+
+## 採る解
+
+issue の案B。シェル自身の `IFileOpenDialog` を `FOS_PICKFOLDERS` で開く。
+
+案A（`pwsh` を使う）を採らない理由: PowerShell 7 は Windows 11 に標準で入っていないので、
+「PS7 を入れている人だけ直る」修正になる。報告者の環境で直る保証が無い。
+
+## 設計上の要点
+
+1. **メンバーの宣言順が vtable そのもの。** COM はスロットで呼ぶので、1 つ動かすと別の関数が
+   呼ばれる。`IFileDialog` / `IShellItem` の全メソッドを MSDN の順で宣言する（このコードで
+   使わないものも含めて）。「使っていないから削る」が事故になる。
+2. **失敗の落ち先を作る。** 実装者は Windows で検証できない。interop を try/catch で包み、
+   失敗したら従来の `FolderBrowserDialog` に落ちる。フラグ違い、Add-Type がコンパイルできない
+   環境、ロックダウンされたランタイム —— どれもモダンなダイアログを失うだけで、
+   「フォルダを選べない」にはならない。
+3. スクリプトは `server/files/win-folder-dialog.ts` に分ける。`pick-file.ts` に 70 行の C# を
+   埋めると、プラットフォーム分岐が読めなくなる。
+
+## テスト
+
+対話ダイアログなので CI では動かせない。固定できるのは `pickFileCommand` が返す argv:
+
+- CLSID_FileOpenDialog と `0x20`（FOS_PICKFOLDERS）が入っている
+- `FolderBrowserDialog` が **catch の中にだけ**ある
+- `IFileDialog` の主要メンバーが宣言順に並んでいる（vtable 依存の回帰防止）
+- here-string の終端 `'@` が行頭にある（prettier の整形で崩れると全体が構文エラーになるが、
+  ほかのテストは何も言わない）
+
+## 実機確認
+
+macOS では確認できない。**PR で報告者に確認を依頼する。** それまでマージしない。

--- a/server/files/pick-file.ts
+++ b/server/files/pick-file.ts
@@ -2,6 +2,7 @@ import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
+import { winFolderDialogScript } from "./win-folder-dialog.js";
 
 // A native "open file/folder" dialog per platform whose stdout is the selection's
 // absolute path(s), newline-separated. Browsers can't hand the terminal a real
@@ -31,10 +32,11 @@ function macArgs(directory: boolean): string[] {
   ];
 }
 
+// The FILE dialog needs nothing special: `OpenFileDialog` has been the Explorer-style one since
+// Vista. Only the FOLDER dialog is stuck on the legacy tree, so only it goes through COM (#1003).
 function winArgs(directory: boolean): string[] {
-  const dialog = directory
-    ? "$d = New-Object System.Windows.Forms.FolderBrowserDialog; if ($d.ShowDialog() -eq 'OK') { $d.SelectedPath }"
-    : "$d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join \"`n\" }";
+  if (directory) return ["-NoProfile", "-STA", "-Command", winFolderDialogScript(DIR_PROMPT)];
+  const dialog = `$d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join "\`n" }`;
   return ["-NoProfile", "-STA", "-Command", `Add-Type -AssemblyName System.Windows.Forms; ${dialog}`];
 }
 

--- a/server/files/win-folder-dialog.ts
+++ b/server/files/win-folder-dialog.ts
@@ -1,0 +1,112 @@
+// The Windows folder picker, in the dialog Explorer actually uses (#1003).
+//
+// `System.Windows.Forms.FolderBrowserDialog` — what this used to open, and what the fallback at
+// the bottom still opens — is the legacy tree: no address bar, no path box, no favourites, so
+// reaching a project means clicking down the hierarchy. On .NET Framework (which the stock
+// `powershell` 5.1 runs on) it has no modern mode; the shell's own `IFileOpenDialog` with
+// FOS_PICKFOLDERS is the only way to get the Explorer-style one without requiring PowerShell 7.
+//
+// Hence the COM interop below. Two things about it are load-bearing:
+//
+//  1. **The member order IS the vtable.** COM dispatches by slot, not by name, so moving or
+//     dropping a single method silently calls the wrong function. Every method of IFileDialog and
+//     IShellItem is declared, in MSDN's order, even the ones unused here — that is why they are
+//     listed rather than trimmed.
+//  2. **Failure must land somewhere safe.** This runs on a machine the author cannot test on, so
+//     the script wraps the interop in try/catch and falls back to the old dialog. A wrong flag, a
+//     locked-down runtime, or an `Add-Type` that cannot compile then costs the user the nicer
+//     dialog — not the ability to choose a folder.
+
+// FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM | FOS_PATHMUSTEXIST: a real directory on a real
+// filesystem, so the caller always gets a path it can hand to a shell.
+const FOS_FLAGS = "0x20 | 0x40 | 0x800";
+const CLSID_FILE_OPEN_DIALOG = "DC1C5A9C-E88A-4dde-A5A1-60F82A20AEF7";
+const IID_IFILE_DIALOG = "42f85136-db7e-439c-85f1-e4075d135fc8";
+const IID_ISHELL_ITEM = "43826d1e-e718-42ee-bc55-a1e261c37bfe";
+// SIGDN_FILESYSPATH — the display name as a filesystem path rather than a pretty name.
+const SIGDN_FILESYSPATH = "0x80058000";
+
+// The COM declarations, kept out of the script template so the PowerShell around them stays
+// readable — and so the arrow function below is a few lines rather than eighty.
+const FOLDER_PICKER_CSHARP = `using System;
+using System.Runtime.InteropServices;
+namespace MtPicker {
+  [ComImport, Guid("${IID_ISHELL_ITEM}"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  public interface IShellItem {
+    void BindToHandler(IntPtr pbc, ref Guid bhid, ref Guid riid, out IntPtr ppv);
+    void GetParent(out IShellItem ppsi);
+    void GetDisplayName(uint sigdnName, out IntPtr ppszName);
+    void GetAttributes(uint sfgaoMask, out uint psfgaoAttribs);
+    void Compare(IShellItem psi, uint hint, out int piOrder);
+  }
+  [ComImport, Guid("${IID_IFILE_DIALOG}"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+  public interface IFileDialog {
+    [PreserveSig] int Show(IntPtr parent);
+    void SetFileTypes(uint cFileTypes, IntPtr rgFilterSpec);
+    void SetFileTypeIndex(uint iFileType);
+    void GetFileTypeIndex(out uint piFileType);
+    void Advise(IntPtr pfde, out uint pdwCookie);
+    void Unadvise(uint dwCookie);
+    void SetOptions(uint fos);
+    void GetOptions(out uint fos);
+    void SetDefaultFolder(IShellItem psi);
+    void SetFolder(IShellItem psi);
+    void GetFolder(out IShellItem ppsi);
+    void GetCurrentSelection(out IShellItem ppsi);
+    void SetFileName([MarshalAs(UnmanagedType.LPWStr)] string pszName);
+    void GetFileName(out IntPtr pszName);
+    void SetTitle([MarshalAs(UnmanagedType.LPWStr)] string pszTitle);
+    void SetOkButtonLabel([MarshalAs(UnmanagedType.LPWStr)] string pszText);
+    void SetFileNameLabel([MarshalAs(UnmanagedType.LPWStr)] string pszLabel);
+    void GetResult(out IShellItem ppsi);
+    void AddPlace(IShellItem psi, int fdap);
+    void SetDefaultExtension([MarshalAs(UnmanagedType.LPWStr)] string pszDefaultExtension);
+    void Close(int hr);
+    void SetClientGuid(ref Guid guid);
+    void ClearClientData();
+    void SetFilter(IntPtr pFilter);
+  }
+  public static class Folder {
+    public static string Pick(string title) {
+      Type type = Type.GetTypeFromCLSID(new Guid("${CLSID_FILE_OPEN_DIALOG}"));
+      IFileDialog dialog = (IFileDialog)Activator.CreateInstance(type);
+      try {
+        uint options;
+        dialog.GetOptions(out options);
+        dialog.SetOptions(options | ${FOS_FLAGS});
+        dialog.SetTitle(title);
+        if (dialog.Show(IntPtr.Zero) != 0) return null;
+        IShellItem item;
+        dialog.GetResult(out item);
+        IntPtr buffer;
+        item.GetDisplayName(${SIGDN_FILESYSPATH}, out buffer);
+        try { return Marshal.PtrToStringUni(buffer); }
+        finally { Marshal.FreeCoTaskMem(buffer); }
+      } finally {
+        Marshal.ReleaseComObject(dialog);
+      }
+    }
+  }
+}`;
+
+// NOTE: the `'@` terminator of a PowerShell here-string must start its own line, or the script is
+// a syntax error. A spec pins that, because prettier reflowing this template would not fail
+// anything else.
+export const winFolderDialogScript = (prompt: string): string => `
+$ErrorActionPreference = 'Stop'
+function Get-MtModernFolder {
+  Add-Type -TypeDefinition @'
+${FOLDER_PICKER_CSHARP}
+'@
+  return [MtPicker.Folder]::Pick('${prompt}')
+}
+try {
+  $picked = Get-MtModernFolder
+  if ($picked) { $picked }
+} catch {
+  Add-Type -AssemblyName System.Windows.Forms
+  $legacy = New-Object System.Windows.Forms.FolderBrowserDialog
+  $legacy.Description = '${prompt}'
+  if ($legacy.ShowDialog() -eq 'OK') { $legacy.SelectedPath }
+}
+`;

--- a/test/server/files/pick-file.spec.ts
+++ b/test/server/files/pick-file.spec.ts
@@ -19,8 +19,32 @@ describe("pickFileCommand (directory mode)", () => {
     expect(cmd).toBe("osascript");
     expect(args.join(" ")).toContain("choose folder");
   });
-  it("Windows: FolderBrowserDialog", () => {
-    expect(pickFileCommand("win32", true).args.join(" ")).toContain("FolderBrowserDialog");
+  // #1003: the folder picker asks the shell for its own dialog (the Explorer-style one), and
+  // keeps the legacy tree only as the catch — so a runtime that cannot compile the interop still
+  // lets the user choose a directory.
+  it("Windows: the shell's IFileOpenDialog, with the legacy tree as the fallback", () => {
+    const script = pickFileCommand("win32", true).args.join(" ");
+    expect(script).toContain("DC1C5A9C-E88A-4dde-A5A1-60F82A20AEF7"); // CLSID_FileOpenDialog
+    expect(script).toContain("0x20"); // FOS_PICKFOLDERS — without it this picks files
+    expect(script).toContain("FolderBrowserDialog"); // the fallback, inside `catch`
+    expect(script).toMatch(/catch \{[\s\S]*FolderBrowserDialog/); // ...and only there
+  });
+
+  // COM dispatches by vtable slot, so the declaration order is behaviour: a missing or reordered
+  // member calls a different function than the name says. Pinning the two that this depends on
+  // catches a "tidy up the unused ones" edit.
+  it("Windows: keeps the IFileDialog vtable order the interop depends on", () => {
+    const script = pickFileCommand("win32", true).args.join(" ");
+    const order = ["int Show(", "SetFileTypes(", "SetOptions(", "GetOptions(", "GetResult("];
+    const positions = order.map((member) => script.indexOf(member));
+    expect(positions.every((at) => at > 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+  });
+
+  // A PowerShell here-string ends only at a `'@` that starts its own line. Reflow the template and
+  // the whole script becomes a syntax error — which nothing else here would notice.
+  it("Windows: closes its here-string at the start of a line", () => {
+    expect(pickFileCommand("win32", true).args[3]).toContain("\n'@");
   });
   it("Linux: zenity --directory", () => {
     expect(pickFileCommand("linux", true).args).toContain("--directory");


### PR DESCRIPTION
## Summary

Windows の「WORKING DIRECTORY」のフォルダ選択を、シェル自身の **`IFileOpenDialog`（エクスプローラー型）** で開きます（#1003）。アドレスバー・パス入力・クイックアクセスが使えます。

報告の診断はファイルと関数まで正確でした。`server/files/pick-file.ts` の `winArgs()` が `powershell`（= Windows PowerShell 5.1 / .NET Framework）で `FolderBrowserDialog` を開いており、.NET Framework 上のこのダイアログにモダン表示のモードはありません。ファイル選択は `OpenFileDialog` なので Vista 以降エクスプローラー型で、**フォルダ選択だけが取り残されていました**。

Fixes #1003

## Items to Confirm / Review

1. **Windows 実機での確認をお願いしたいです。** 私は macOS で、対話ダイアログは Windows CI（`windows-daily.yaml`）でも回せません。ユニットテストで固定できるのは `pickFileCommand` が返す argv までです。**確認できるまでマージしません。**
2. **案A（`pwsh`）を採らなかった理由。** PowerShell 7 なら `FolderBrowserDialog` が自動でモダンになる、という指摘は正しいのですが、`pwsh` は Windows 11 に標準では入っていません。「PS7 を入れている人だけ直る」修正になるため、5.1 でも効く案B を採りました。
3. **COM のメンバー宣言順が vtable そのもの**です。使っていないメソッドも MSDN の順で全部宣言してあり、「未使用だから削る」と別の関数が呼ばれます。順序を spec で固定しました。
4. **失敗の落ち先を用意しました。** 検証できない環境に出す以上、interop を try/catch で包み、失敗したら従来のダイアログに落とします。フラグ違い・`Add-Type` がコンパイルできない環境・ロックダウンされたランタイムでも、**最悪「今と同じ」**で止まり、フォルダが選べなくなることはありません。

## User Prompt

> 1003確認して
>
> （確認結果を提示したうえで、案B（COM）で実装、という判断をいただきました）

## 変更

| ファイル | 中身 |
| --- | --- |
| `server/files/win-folder-dialog.ts`（新規） | `IFileOpenDialog` + `FOS_PICKFOLDERS` を開く PowerShell。C# の COM 宣言は定数に分離 |
| `server/files/pick-file.ts` | フォルダモードだけこのスクリプトを使う。ファイルモードは無変更 |

FOS は `0x20`（PICKFOLDERS）` | 0x40`（FORCEFILESYSTEM）` | 0x800`（PATHMUSTEXIST）。返るのは必ず実在するファイルシステム上のパスなので、既存の `parsePickerOutput`（絶対パスのみ通す）もそのまま効きます。

## テスト

対話ダイアログは CI で動かせないので、`pickFileCommand` の argv を固定しました:

- CLSID_FileOpenDialog と `0x20` が入っている（後者が無いとファイル選択になる）
- `FolderBrowserDialog` が **`catch` の中にだけ**ある
- `IFileDialog` の主要メンバーが宣言順に並んでいる（vtable 依存の回帰防止）
- here-string の終端 `'@` が行頭にある — prettier がテンプレートを整形すると全体が構文エラーになりますが、ほかのテストは何も言わないため

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（5455 passed）/ `build` 実行済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
