### PR TITLE
fix(test): Windows daily の 3 件を直す — 8.3 短縮パスと USERPROFILE

### DIFF
--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -81,8 +81,10 @@ separator and the drive letter differ.
 ## Filesystem watching
 
 **`fs.watch` on an 8.3 short path is unreliable, and can abort the process.** `os.tmpdir()`
-returns `C:\Users\RUNNER~1\…` on a GitHub runner; expand it with `realpathSync` before
-watching. Even then Windows gives no delivery guarantee — the reload case in
+returns `C:\Users\RUNNER~1\…` on a GitHub runner; expand it with **`realpathSync.native`**
+before watching — plain `realpathSync` is the JS implementation and hands the short name straight
+back, which is how a spec that already called it still compared `RUNNER~1` against git's
+`runneradmin` (Windows daily, 2.5.1). Even then Windows gives no delivery guarantee — the reload case in
 `test/scripts/dev-server.spec.ts` is skipped there rather than left to flake.
 
 ## Environment

--- a/test/server/config/unknown-config-keys.spec.ts
+++ b/test/server/config/unknown-config-keys.spec.ts
@@ -149,7 +149,11 @@ describe("POST /api/config", () => {
   it("keeps an unknown key that was already in the file", async () => {
     const dir = tmp();
     try {
+      // Both, because `os.homedir()` reads USERPROFILE on Windows and HOME everywhere else —
+      // stubbing only HOME left the Windows run pointed at the real config, which is what the
+      // guard below caught (Windows daily CI on 2.5.1).
       vi.stubEnv("HOME", dir);
+      vi.stubEnv("USERPROFILE", dir);
       vi.resetModules();
       const { mountConfigRoutes, APP_CONFIG_FILE } = await import("../../../server/config/config-routes.js");
       // Guard before anything writes: a stub that didn't take would target the real config.

--- a/test/server/git/repo-root-sync.spec.ts
+++ b/test/server/git/repo-root-sync.spec.ts
@@ -13,7 +13,9 @@ let main = "";
 let worktree = "";
 
 beforeAll(() => {
-  base = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-reporoot-")));
+  // `.native`, not plain realpathSync: on a Windows runner os.tmpdir() is the 8.3 short form
+  // (C:\Users\RUNNER~1\…) and only the native resolver expands it to the long name git reports.
+  base = realpathSync.native(mkdtempSync(path.join(tmpdir(), "mt-reporoot-")));
   main = path.join(base, "myrepo");
   mkdirSync(main);
   const git = (args: string[], cwd = main) =>
@@ -31,23 +33,27 @@ beforeAll(() => {
 
 afterAll(() => rmSync(base, { recursive: true, force: true }));
 
+// git prints POSIX separators even on Windows, and these resolvers return whatever their input
+// used, so the two disagree on shape while naming the same directory. Compare the resolved form.
+const norm = (p: string | null): string | null => (p === null ? null : path.resolve(p));
+
 describe("repoRootSync", () => {
   it("finds the checkout a directory belongs to", () => {
-    expect(repoRootSync(main)).toBe(main);
+    expect(norm(repoRootSync(main))).toBe(norm(main));
     const nested = path.join(main, "a", "b");
     mkdirSync(nested, { recursive: true });
-    expect(repoRootSync(nested)).toBe(main);
+    expect(norm(repoRootSync(nested))).toBe(norm(main));
   });
 
   // The point of the whole thing: from inside a linked worktree the answer is the MAIN
   // checkout, because that is what names the clone (the branch is already on the PR).
   it("answers with the main checkout from inside a linked worktree", () => {
-    expect(repoRootSync(worktree)).toBe(main);
+    expect(norm(repoRootSync(worktree))).toBe(norm(main));
   });
 
   it("agrees with the async resolver the rest of the server uses", async () => {
-    expect(repoRootSync(main)).toBe(await repoRoot(main));
-    expect(repoRootSync(worktree)).toBe(await repoRoot(worktree));
+    expect(norm(repoRootSync(main))).toBe(norm(await repoRoot(main)));
+    expect(norm(repoRootSync(worktree))).toBe(norm(await repoRoot(worktree)));
   });
 
   it("returns null outside a repository", () => {


### PR DESCRIPTION
## Summary

2.5.1 のタグで **Windows daily が赤**（[run 30342628296](https://github.com/receptron/mulmoterminal/actions/runs/30342628296)）。3 件の失敗はいずれも**テスト側の Windows 前提漏れ**で、実装は 1 行も変えていません。

| 失敗 | 原因 |
| --- | --- |
| `repo-root-sync.spec.ts:45,49`（2 件） | `realpathSync` は JS 実装で **8.3 短縮名をそのまま返す**。ランナーの `C:\Users\RUNNER~1\…` が、git の報告する long name（`runneradmin`）と一致しなかった。さらに git は Windows でも **POSIX 区切り**を返すので、`repoRootSync`（入力の形をそのまま返す）との比較が形の違いで落ちる |
| `unknown-config-keys.spec.ts:156` | `os.homedir()` は **Windows では USERPROFILE を読む**。`HOME` だけ stub していたので、Windows では実 config を指したまま |

## Items to Confirm / Review

1. **2 番目は、テストに入れておいたガードが実 config への書き込みを止めた形です。** `expect(APP_CONFIG_FILE.startsWith(dir))` が書き込み前に落ちているので、ランナーの本物の `~/.mulmoterminal/config.json` は触られていません。ガードを入れておいて良かった例なので、消さずに残しています。
2. **実装は無変更です。** `repoRootSync` の戻り値は本番では basename しか使われません（PR フッタの clone 名）。短縮名・区切り文字の違いは production では無害なので、production 側を正規化する変更はしていません。
3. **`docs/windows-gotchas.md` を訂正しました。** 「`realpathSync` で展開できる」と書いてあり、**その記述どおりに書かれた spec が今回落ちています**。`realpathSync.native` が必要、と直しました。

## User Prompt

> https://github.com/receptron/mulmoterminal/actions/runs/30342628296 . fix

## 検証

macOS ではローカルの全ゲート（lint / typecheck / test 5455 件）が通ります。**Windows での確認はこの PR で `Windows (daily)` を `workflow_dispatch` で回して行います**（この workflow は `pull_request` では走らないため）。結果を追記します。

なお全体テスト中に `remoteHost/routes.spec.ts` の `POST /reconnect` が 1 度だけ落ちましたが、単体で 2 回、全体でもう 1 回回して再現せず、この PR の変更とも無関係（該当ファイルは触っていない）です。**flaky として記録**しておきます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
