### PR TITLE
docs: canvas レンダラを #782 の容疑者として書いたままの記述を直す

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -32,7 +32,7 @@ server   ── node-pty  ── tmux (persistence)  ── agent (claude / code
 | Package | Pin | Why it's load-bearing |
 |---|---|---|
 | `@xterm/xterm` | `^6.0.0` | 6.0 changed the scrollbar (VS Code-style overlay) and internals. The DOM/link/scroll code assumes 6.x. |
-| `@xterm/addon-canvas` | `^0.7.0` | ⚠️ **Peers on `@xterm/xterm@^5`** — an xterm-5 renderer running on xterm-6. There is **no stable xterm-6 canvas addon** (even `0.8.0-beta` peers `^5`). Suspected cause of the scrollbar / selection-auto-scroll problems (#782). See [Renderer](#renderer-canvas-vs-dom). |
+| `@xterm/addon-canvas` | `^0.7.0` | **Peers on `@xterm/xterm@^5`** — an xterm-5 renderer running on xterm-6, deliberately. There is **no xterm-6 canvas addon** (even `0.8.0-beta` peers `^5`), so this cannot be repaired by bumping. It is not known to break anything; it was once blamed for #782/#783 and measurement cleared it. See [Renderer](#renderer-canvas-vs-dom) for what to move to when an xterm bump does break it. |
 | `@xterm/addon-web-links` | `^0.12.0` | Linkifies visible `http(s)://` URLs. |
 | `@xterm/addon-clipboard` | `^0.2.0` | OSC 52 clipboard write (auto-copy → browser clipboard). |
 | `@xterm/addon-fit` | `^0.11.0` | Size the grid to the container. |
@@ -168,9 +168,25 @@ calling the render callback, so a renderer that throws still repaints on the nex
 ### Renderer (canvas vs DOM)
 
 The **canvas renderer** (`@xterm/addon-canvas`, added to fix CJK glyph drift — long Japanese lines
-spilling off the right edge with the DOM renderer) draws each glyph in a fixed cell. But the addon
-is xterm-5-era on xterm-6 (see the version table), and is the suspected cause of #782. See the
-CAVEAT comment at the `loadAddon(new CanvasAddon())` site. **Debugging note:** the canvas renderer
+spilling off the right edge with the DOM renderer) draws each glyph in a fixed cell. The addon is
+xterm-5-era on xterm-6 (see the version table), which looks alarming and **has not actually broken
+anything**: it was once named the suspected cause of #782 and #783, and measurement disproved both
+(#782 is tmux owning the scrollback and reproduces with the addon off; #783 was tmux stripping
+hyperlinks, fixed in #785). WebGL was never evaluated against it — #314 needed a fixed grid, canvas
+gave one, and `@xterm/addon-webgl` has never been a dependency.
+
+**The mismatch still costs something, just not what was assumed.** There is no xterm-6 canvas
+release, so the day an xterm bump breaks this addon, bumping it is not an option — the move is
+forced rather than chosen. What to know before that day:
+
+| | |
+|---|---|
+| Move to | `@xterm/addon-webgl`. **`0.19.0` is stable and xterm-6 era** — published 51 s after `@xterm/xterm@6.0.0`, the same pairing as 5.4.0/0.17.0 and 5.5.0/0.18.0. No beta needed; the `0.20.0-beta` line peers `@xterm/xterm@^6.1.0-beta`, i.e. the NEXT core. (#782's first comment says "要 beta" — that is wrong.) |
+| Why not the DOM renderer | It drops the dependency, but re-opens the CJK drift #314 closed. That drift is **font-environment specific and does not reproduce headlessly**, so CI cannot protect it — it comes back as a user report. |
+| Settle first | The WebGL **context limit** (~16 concurrent in Chrome). `release()` runs only for ephemeral slots and the explicit close button, so terminals on other tabs stay live — the cap is reachable, and #965's reporter ran 22 cells. Needs `onContextLoss` handling and a decision about disposing off-screen terminals. |
+| Also | WebGL is unavailable on GPU blocklists / GPU-less VMs / some remote desktops. Keep the same best-effort load + DOM fallback this site already has. |
+
+**Debugging note:** the canvas renderer
 paints to `<canvas>`, so terminal text and link decorations are **not in the DOM** — headless
 inspection (`.xterm-rows`, `elementFromPoint`) sees nothing. To debug links/selection headlessly,
 force the DOM renderer or observe effects (`window.open`, buffer state) instead of reading the canvas.
@@ -202,10 +218,14 @@ or `terminal-overrides` capability. The isolation test: write the sequence **dir
 
 ## Known issues / open items
 
-- **#782 — scrollbar not shown / selection doesn't auto-scroll** (open). Likely the xterm-5 canvas
-  addon on xterm-6, but the scrollbar (auto-hide VS Code overlay) reproduced on the DOM renderer
-  too, so it may be two roots. Fix is a renderer decision (WebGL vs DOM), which needs on-device QA
-  (CJK drift, scrollbar, selection). See #782 for the full analysis.
+- **#782 — scrollbar not shown / selection doesn't auto-scroll** (open). **Root cause is tmux, not
+  the renderer** — every session runs inside tmux, tmux redraws the screen, so the outer xterm
+  receives only the visible screen and the scrollback lives in tmux's copy-mode. Hence nothing for
+  the scrollbar to show, and selection reaching only what is on screen. Measured: with tmux off the
+  same xterm keeps 305 lines and the scrollbar tracks; with the canvas addon off, nothing changes.
+  A fix is a design decision about handing the wheel to tmux copy-mode (see #782), which collides
+  with the #729/#737 mouse swallow. **Do not reach for a renderer swap** — that hypothesis is dead,
+  and this entry said otherwise until it was corrected.
 - **Selection & copy/paste** — several sharp edges:
   - macOS: selection is **Option+drag** (`macOptionClickForcesSelection`), not plain drag.
   - You can only select what's on screen: a Claude/Codex TUI runs in the **alternate buffer**,
@@ -224,7 +244,7 @@ looking) — flag them for QA on the release.
 
 | Area | Check in code | Needs user QA |
 |---|---|---|
-| Renderer / CJK | canvas addon still loads; `@xterm/addon-canvas` peer vs `@xterm/xterm` major (mismatch = red flag) | long Japanese line doesn't drift off the right edge |
+| Renderer / CJK | canvas addon still **loads** (the console warns when it falls back to DOM). The peer-major mismatch is expected and is not the check — a silent fallback is, because the CJK grid goes with it | long Japanese line doesn't drift off the right edge |
 | Scrollbar / selection | — (no unit coverage) | scrollbar visible + synced; Option+drag selects; selection auto-scrolls past the visible screen (#782) |
 | OSC 8 links | tmux `terminal-features '*:hyperlinks'` present; xterm `linkHandler` set | click Claude statusline `PR #NNNN` → opens the PR (no confirm dialog) |
 | OSC 52 clipboard | tmux `Ms` override + `set-clipboard on` present (`planMsOverride`) | Claude auto-copy reaches the browser clipboard |

--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -183,7 +183,7 @@ forced rather than chosen. What to know before that day:
 |---|---|
 | Move to | `@xterm/addon-webgl`. **`0.19.0` is stable and xterm-6 era** — published 51 s after `@xterm/xterm@6.0.0`, the same pairing as 5.4.0/0.17.0 and 5.5.0/0.18.0. No beta needed; the `0.20.0-beta` line peers `@xterm/xterm@^6.1.0-beta`, i.e. the NEXT core. (#782's first comment says "要 beta" — that is wrong.) |
 | Why not the DOM renderer | It drops the dependency, but re-opens the CJK drift #314 closed. That drift is **font-environment specific and does not reproduce headlessly**, so CI cannot protect it — it comes back as a user report. |
-| Settle first | The WebGL **context limit** (~16 concurrent in Chrome). `release()` runs only for ephemeral slots and the explicit close button, so terminals on other tabs stay live — the cap is reachable, and #965's reporter ran 22 cells. Needs `onContextLoss` handling and a decision about disposing off-screen terminals. |
+| Settle first | The WebGL **context limit** — browsers cap concurrent contexts and evict the oldest (order of ten; not measured here, so measure before relying on a number). This app is unusually exposed: a persisted slot **deliberately keeps its connection alive** when its view goes away (`Terminal.vue` calls `detach`, not `release` — that IS the persistence), so live terminals accumulate across tabs rather than tracking what is on screen. #965's reporter ran 22 cells. Needs `onContextLoss` handling and a decision about disposing off-screen terminals. |
 | Also | WebGL is unavailable on GPU blocklists / GPU-less VMs / some remote desktops. Keep the same best-effort load + DOM fallback this site already has. |
 
 **Debugging note:** the canvas renderer

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -415,12 +415,16 @@ function buildTerminal(swallowedMouseModes: Set<number>, font: TerminalFont): Te
   // A fixed-grid renderer makes that structurally impossible.
   //
   // CAVEAT — version mismatch: @xterm/addon-canvas is xterm-5 era (its peerDependency is
-  // `@xterm/xterm@^5`, and there is no stable xterm-6 build — even 0.8.0-beta still peers ^5), but the
-  // app runs @xterm/xterm@6. It renders, but this xterm-5 renderer on xterm-6 internals is the
-  // suspected cause of broken selection auto-scroll + scrollbar (#782) and OSC 8 link click (#783),
-  // all of which regressed when this was introduced. Don't just bump the addon; the real fix is a
-  // renderer decision — WebGL keeps the fixed grid (so the CJK drift above stays fixed), the DOM
-  // renderer drops the dependency but risks that drift. Read #782 before touching this.
+  // `@xterm/xterm@^5`, and there is no xterm-6 build — even 0.8.0-beta still peers ^5), but the app
+  // runs @xterm/xterm@6. It renders, and it is NOT known to break anything: an earlier version of
+  // this comment named it the suspected cause of #782 (selection auto-scroll + scrollbar) and #783
+  // (OSC 8 links), and measurement disproved both. #782 is tmux owning the scrollback — the outer
+  // xterm only ever receives the visible screen — and reproduced identically with the addon off.
+  // #783 was tmux stripping hyperlinks (fixed in #785). Neither is a reason to change renderer.
+  //
+  // What the mismatch DOES mean is that a future xterm bump cannot be repaired by bumping this
+  // addon, because no such release exists — see the Renderer section of docs/terminal-notes.md for
+  // what to move to on the day it breaks, and what to settle before moving.
   // Best-effort: if the canvas renderer can't initialise, xterm keeps the DOM renderer.
   try {
     term.loadAddon(new CanvasAddon());


### PR DESCRIPTION
## Summary

ソースの CAVEAT コメント（`useTerminalConnections.ts`）と `docs/terminal-notes.md` が、**#782 の調査が実測で否定した仮説**を今も載せていました。「canvas addon（xterm-5 世代）が #782/#783 の原因と疑われる」「修正は WebGL vs DOM の renderer 判断」という記述です。これを実際の結論（真因は tmux がスクロールバックを所有していること）に直し、あわせて今回の調査で分かった WebGL 側の事実を、**移行タスクではなく前提知識として** Renderer 節に残しました。

コードの変更はありません（コメントのみ）。

## Items to Confirm / Review

- **「移行しない」が結論であることが読み取れるか。** 移行手順を書くと「やるべきこと」に見えるため、「xterm を上げて canvas が壊れた日に、選択ではなく強制で移ることになる」という条件付きの形にしています。この温度感が適切か見てください。
- **WebGL 0.19.0 が xterm-6 世代である根拠は公開時刻の一致**（xterm 6.0.0 の 51 秒後、過去 2 世代も同じ組）です。0.19.0 は `peerDependencies` を宣言していないため、npm 上の明示的な保証はありません。状況証拠としては強いと判断しましたが、断定しすぎなら弱めます。
- コンテキスト上限の記述で `release()` の呼ばれ方（ephemeral スロットと明示的な閉じるボタンのみ）を根拠にしています。読み違えていないか。

## User Prompt

MulmoTerminal のフィードバック「分割セルでスクロールがカクカクと、文字が見にくい(太い？)」の原因調査から派生した作業です。ユーザーからの依頼は以下:

- このフィードバックの原因が分かるか。2.5.0 で改善しているものか、そうならそのうち直るのか
- WebGL か DOM に替える場合のリスクは何だったか
- なぜ WebGL にしなかったのか
- 「WebGL が使えない」のはどれくらいの割合か
- GL の話はどこかの issue にあるか。「GL 試す」issue を作って、terminal の確認事項・課題をチェックボックスで入れるか、それともこのままでよいか

最後の点について、**issue は作らず、陳腐化した記述の訂正と、WebGL の事実を Renderer 節へ移行条件として書き足す**方針で合意しました。

## なぜ直すのか

この記述を読んで、私自身が「#782 は renderer 移行で消える見込み」「WebGL が本命」という**誤った結論**をユーザーに報告しました。#782 の最初のコメントだけが同じ仮説を載せており、それを覆す実測は後続コメントにあります。ソース側と開発者ノートを読んだ人は同じ道を辿ります。

どちらも真因が確定した時刻より前に書かれ、その後更新されていません:

| | 書かれた時刻 | tmux 真因の確定（2026-07-25 03:35Z） |
|---|---|---|
| `useTerminalConnections.ts` の CAVEAT（8902c1f1） | 2026-07-24 23:05Z | 前 |
| `docs/terminal-notes.md`（fba3adc7） | 2026-07-25 02:56Z | 前 |

バグ報告 FAQ は #805 で tmux の説明に書き直されましたが、この 2 箇所は取り残されていました。

## 実際の結論（#782 の調査より）

- **#782 の真因は tmux。** 全セッションが tmux の中で動き、tmux が画面を再描画するので、外側の xterm には可視画面しか渡らない。スクロールバックは tmux の copy-mode 側にある。→ スクロールバーに表示するものが無く、選択も可視範囲しか届かない。実測では tmux を外すと同じ xterm が 305 行を保持しスクロールバーも追従、**canvas addon の ON/OFF では何も変わらない**。
- **#783 は tmux が hyperlinks を落としていただけ**で、#785 / 1.9.1 で解決済み。
- したがって **renderer を替える理由は現時点で無い**。

## 書き足した内容（Renderer 節）

移行が必要になった日に調べ直さずに済むように、事実だけを表で残しました。

- xterm-6 対応の canvas リリースは存在しない（最終 stable 2024-04-05）。バージョンを上げて直す道が無いので、xterm を上げて壊れた日は**移行が選択ではなく強制**になる
- 移行先は `@xterm/addon-webgl@0.19.0`（**stable**）。xterm 6.0.0 の 51 秒後に公開されており、5.4.0/0.17.0・5.5.0/0.18.0 と同じ組。**#782 の最初のコメントの「要 beta」は誤り**で、`0.20.0-beta` が peer にしているのは次のコア（`^6.1.0-beta`）
- 先に片付けるべきは **WebGL コンテキスト上限**（Chrome で概ね 16）。`release()` は ephemeral スロットと明示的な閉じるボタンでしか呼ばれず、他タブのターミナルは生き続けるため上限に届き得る（#965 の報告者は 22 セル稼働）。`onContextLoss` の扱いが要る
- **DOM に戻す道は #314 の CJK ドリフトが再発する。** フォント環境依存でヘッドレスに再現しないため CI では守れず、ユーザー報告として戻ってくる

## チェックリストの Renderer 行

peer メジャーの不一致は既知かつ意図的なので、それを赤信号として見張ると毎回誤検知します。見るべき点を「canvas が黙って DOM にフォールバックしていないか」に変えました（落ちると CJK のグリッドも一緒に失われるため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)