### PR TITLE
fix: クローム色を全セル種別に届ける — 配線を 1 か所に集約する (#1006)

### DIFF
--- a/plans/fix-1006-cell-chrome.md
+++ b/plans/fix-1006-cell-chrome.md
@@ -1,0 +1,57 @@
+# One place a cell gets its directory's chrome
+
+Issue: #1006
+
+## Why
+
+The six chrome colours (`headerColor` / `headerTextColor` / `cellColor` / `cellBorderColor` /
+`dotColor` / `buttonColor`) reached the Claude cell and nothing else. In the Shell (launcher) and
+Command cells only `name` and `badgeColor` applied — the CSS variables they read were never
+defined, so every class fell through to its `var()` default.
+
+The report is precise about the mechanism, and it is worth naming the pattern rather than the bug:
+
+- #279 / #281 added the colours, wired into the Claude cell
+- #902 found the same hole for `theme` / `colors` / `fontSize` / `fontFamily`
+- #914 found it for the name badge
+- #1006 found it for these six
+
+**Three times, the same omission.** Not carelessness — the design was "each cell type remembers to
+wire it up", and forgetting is silent: nothing throws, nothing fails, the colour just isn't there.
+`Terminal.vue` already said so in a comment, about the props #909 removed: *forgetting one costs a
+silently dead setting*.
+
+So the fix is not "add the missing lines to two files". It is to remove the opportunity.
+
+## What
+
+**`useCellChrome(cwd)`** — a cell asks for its chrome and gets all of it: the config, the frame's
+CSS variables, the header's. The three cell types are now one identical line each.
+
+**`Terminal.vue` resolves the header colours from its own `dirConfig`**, like the theme and font it
+already resolved (#909). The three `dir-*` props are deleted, and with them the two call sites that
+had to remember to pass them (`App.vue`, `TerminalCell.vue`). `dirHeaderColor` no longer appears in
+the source at all.
+
+That is what closes the pattern: a new cell type cannot forget to pass something that is no longer
+passed, and cannot forget to assemble something it asks for by name.
+
+## Tests
+
+`cellChromeColors.spec.ts` is stated as a grid — **per colour × per cell type**. A cell that misses
+the wiring fails saying which colour and which cell. Written before the fix and confirmed failing
+for exactly the two cells the issue names, then green after.
+
+The "directory configures nothing" case is there too: no variables at all, so the classes fall
+through to the theme.
+
+One trap worth recording: `useDirConfig`'s fetch cache is module-level and outlives a test, so each
+case takes a fresh directory. Reusing one cwd served an earlier case's config to a later one and
+made the "configures nothing" case fail for the wrong reason.
+
+## Note on the issue's suggested fix
+
+The report offers "add the three sites to both cells", and notes #909 might make the third
+unnecessary. As it stood it would NOT have: `Terminal.vue` kept its own `dirConfig` for theme and
+font but still built `headerStyle` from props, so the third site was still load-bearing. Finishing
+#909 for the colours is what makes it go away.

--- a/src/App.vue
+++ b/src/App.vue
@@ -365,9 +365,6 @@ function onSession(id: string) {
           :dir-cwd="effectiveCwd"
           :dir-name="singleDirConfig.name"
           :dir-badge-color="singleDirConfig.badgeColor"
-          :dir-header-color="singleDirConfig.headerColor"
-          :dir-header-text-color="singleDirConfig.headerTextColor"
-          :dir-button-color="singleDirConfig.buttonColor"
           run-menu
           @session="onSession"
           @cwd="(c) => (activeCwd = c)"

--- a/src/components/CommandCell.vue
+++ b/src/components/CommandCell.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, toRef, watch } from "vue";
 import DirBadge from "./DirBadge.vue";
-import { useDirConfig } from "../composables/useDirConfig";
+import { useCellChrome } from "../composables/useCellChrome";
 import TerminalView from "./Terminal.vue";
 import CellChromeButtons from "./CellChromeButtons.vue";
 import type { RunCommand } from "./runCommand";
@@ -57,7 +57,7 @@ const termRef = ref<InstanceType<typeof TerminalView>>();
 
 // Same as LauncherCell (#914): the badge belongs to this cell's header, so it reads the config
 // here. A getter ref because the cwd lives inside the `command` object.
-const { config: dirConfig } = useDirConfig(toRef(() => props.command.cwd));
+const { config: dirConfig, cellStyle, headerStyle } = useCellChrome(toRef(() => props.command.cwd));
 
 const dirDisplay = computed(() => formatCwd(props.command.cwd, props.home));
 
@@ -165,9 +165,9 @@ function onHeaderClick(event: MouseEvent) {
 </script>
 
 <template>
-  <div class="cell" :class="CELL_FRAME">
+  <div class="cell" :class="CELL_FRAME" :style="cellStyle">
     <div :class="CELL_INNER">
-      <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" @click="onHeaderClick">
+      <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" :style="headerStyle" @click="onHeaderClick">
         <span
           class="cell-dot"
           :class="[CELL_DOT, finished ? `is-idle ${CELL_DOT_IDLE}` : `is-working ${CELL_DOT_WORKING}`]"

--- a/src/components/LauncherCell.vue
+++ b/src/components/LauncherCell.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, toRef, watch } from "vue";
 import DirBadge from "./DirBadge.vue";
-import { useDirConfig } from "../composables/useDirConfig";
+import { useCellChrome } from "../composables/useCellChrome";
 import TerminalView from "./Terminal.vue";
 import CellChromeButtons from "./CellChromeButtons.vue";
 import { formatCwd } from "./cwdDisplay";
@@ -59,7 +59,7 @@ const finished = ref(false);
 
 // The name badge is CHROME — this cell's own header, not the terminal canvas (#914). The
 // canvas side resolves itself inside Terminal.vue (#911); this is the other half of that line.
-const { config: dirConfig } = useDirConfig(toRef(props, "cwd"));
+const { config: dirConfig, cellStyle, headerStyle } = useCellChrome(toRef(props, "cwd"));
 
 const dirDisplay = computed(() => formatCwd(props.cwd, props.home));
 const target = computed(() => (isShellLauncher(props.launcher) ? { shell: true as const } : { index: props.launcher.index }));
@@ -80,9 +80,9 @@ function relaunch() {
 </script>
 
 <template>
-  <div class="cell" :class="CELL_FRAME">
+  <div class="cell" :class="CELL_FRAME" :style="cellStyle">
     <div :class="CELL_INNER">
-      <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" @click="onHeaderClick">
+      <div class="cell-header" :class="[CELL_HEADER, expanded ? '' : `is-zoomable ${CELL_HEADER_ZOOMABLE}`]" :style="headerStyle" @click="onHeaderClick">
         <span
           class="cell-dot"
           :class="[CELL_DOT, finished ? `is-idle ${CELL_DOT_IDLE}` : `is-working ${CELL_DOT_WORKING}`]"

--- a/src/components/Terminal.vue
+++ b/src/components/Terminal.vue
@@ -78,9 +78,6 @@ const props = defineProps<{
   dirBadgeColor?: string | null;
   // The header row's own colors (matches the grid cell's row-1 header): background,
   // text, and the icon buttons. Hex #rrggbb or null for the theme default.
-  dirHeaderColor?: string | null;
-  dirHeaderTextColor?: string | null;
-  dirButtonColor?: string | null;
 }>();
 const emit = defineEmits<{
   (e: "session" | "cwd", value: string): void;
@@ -195,7 +192,10 @@ function effectiveFont(): conn.TerminalFont {
   return { size: dirSize ?? fontSize.value, family: dirFamily ?? globalFontFamily.value };
 }
 const dirBadgeStyle = computed(() => badgeStyleFor(props.dirBadgeColor));
-const headerStyle = computed(() => terminalHeaderStyleFor(props.dirHeaderColor, props.dirHeaderTextColor, props.dirButtonColor));
+// From this terminal's OWN dirConfig, like the theme and font above (#909). Handing these down as
+// props is what left the Shell and Command cells uncoloured for three releases (#1006): a host
+// that forgets one gets a silently dead setting, and nothing fails.
+const headerStyle = computed(() => terminalHeaderStyleFor(dirConfig.value.headerColor, dirConfig.value.headerTextColor, dirConfig.value.buttonColor));
 
 // Voice input: a mic in the header transcribes speech (locally, via whisper.cpp)
 // and inserts it at the prompt for the user to review and submit — same channel as

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -2,7 +2,8 @@
 import { ref, computed, watch, onMounted, onUnmounted, useTemplateRef } from "vue";
 import TerminalView from "./Terminal.vue";
 import { usePubSub } from "../composables/usePubSub";
-import { useDirConfig, useDirColors } from "../composables/useDirConfig";
+import { useDirColors } from "../composables/useDirConfig";
+import { useCellChrome } from "../composables/useCellChrome";
 import { dirChipTint } from "./dirChipColor";
 import { useGitStatus } from "../composables/useGitStatus";
 import { useWorkItem } from "../composables/useWorkItem";
@@ -13,7 +14,6 @@ import { unsavedWork } from "./unsavedWork";
 import { relativeTime as relativeTimeFrom, usageBadge } from "./cellDisplay";
 import { applyActivityPush, cellHeaderText } from "./cellActivity";
 import { preferredLaunchDir, shouldSyncLaunchDir } from "./launchDir";
-import { headerStyleFor, cellStyleFor } from "./cellHeaderStyle";
 import GitBranchChip from "./GitBranchChip.vue";
 import WorkItemChip from "./WorkItemChip.vue";
 import ModelContextBadge from "./ModelContextBadge.vue";
@@ -117,11 +117,7 @@ const connectKey = ref(0);
 const cwd = ref<string | null>(props.initialCwd ?? props.defaultCwd);
 // Per-directory overrides (<cwd>/.mulmoterminal.json): pins this cell's terminal
 // palette and shows a project badge. Re-fetched when the effective cwd changes.
-const { config: dirConfig } = useDirConfig(cwd);
-const headerStyle = computed(() => headerStyleFor(dirConfig.value.headerColor, dirConfig.value.headerTextColor));
-const cellStyle = computed(() =>
-  cellStyleFor(dirConfig.value.cellColor, dirConfig.value.cellBorderColor, dirConfig.value.dotColor, dirConfig.value.buttonColor),
-);
+const { config: dirConfig, cellStyle, headerStyle } = useCellChrome(cwd);
 // What this cell is working on (PR + issue), for the `work` chip. Same directory, same kind of
 // poll as the git status below.
 const { item: workItem, refresh: refreshWorkItem } = useWorkItem(cwd);
@@ -1148,9 +1144,6 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
           :cwd="cwd"
           :codex="agent === 'codex'"
           :launch="launchChoice"
-          :dir-header-color="dirConfig.headerColor"
-          :dir-header-text-color="dirConfig.headerTextColor"
-          :dir-button-color="dirConfig.buttonColor"
           :hide-header="filmstrip"
           :expanded="expanded"
           :zoomed="zoomed"

--- a/src/composables/useCellChrome.ts
+++ b/src/composables/useCellChrome.ts
@@ -1,0 +1,21 @@
+import { computed, type Ref } from "vue";
+import { useDirConfig } from "./useDirConfig";
+import { cellStyleFor, headerStyleFor } from "../components/cellHeaderStyle";
+
+// A grid cell's directory-driven chrome, in one place: the config, the frame's CSS variables and
+// the header's.
+//
+// Every cell type used to assemble these itself, and each new one had to remember all of it. It
+// didn't: #902 found theme/font missing from the Shell and Command cells, #914 the name badge,
+// #1006 the six chrome colours — the same omission three times over, because "remember to wire it
+// up" WAS the design. A cell now asks for its chrome and gets all of it.
+export function useCellChrome(cwd: Ref<string | null | undefined>) {
+  const { config } = useDirConfig(cwd);
+  return {
+    config,
+    // Emitted as variables rather than plain background/border, so a status tint (working /
+    // blocked) still overrides while idle keeps the directory's colour.
+    cellStyle: computed(() => cellStyleFor(config.value.cellColor, config.value.cellBorderColor, config.value.dotColor, config.value.buttonColor)),
+    headerStyle: computed(() => headerStyleFor(config.value.headerColor, config.value.headerTextColor)),
+  };
+}

--- a/test/src/components/cellChromeColors.spec.ts
+++ b/test/src/components/cellChromeColors.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// A directory's chrome colours have to reach EVERY kind of grid cell, not just the Claude one.
+// They were added for the Claude cell (#279/#281) and each later cell type had to remember to
+// wire them up; #902 found that hole for theme/font, #914 for the name badge, and #1006 for these
+// six colours — the same omission three times, because "remember to pass it" is the design.
+//
+// So this spec is stated per COLOUR and per CELL TYPE, as a grid: a new cell type that forgets the
+// wiring fails here, and it fails saying which colour and which cell.
+
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+}));
+
+// The terminal itself is not what this is about — only the chrome the cell draws around it.
+vi.mock("../../../src/components/Terminal.vue", () => ({
+  default: {
+    name: "TerminalView",
+    props: ["cwd", "persistKey", "sessionId", "connectKey", "launcher", "expanded", "zoomed", "hideHeader"],
+    template: "<div />",
+  },
+}));
+
+const CHROME = {
+  name: "proj",
+  badgeColor: "#ff6f5e",
+  headerColor: "#06373d",
+  headerTextColor: "#d8fff6",
+  cellColor: "#04262a",
+  cellBorderColor: "#0b6b6b",
+  dotColor: "#ffd166",
+  buttonColor: "#7fe3d0",
+};
+
+beforeEach(() => {
+  globalThis.fetch = vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u.includes("/api/dir-config")) return { ok: true, json: async () => CHROME };
+    if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+    if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/proj/a", scripts: [] }) };
+    return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+  }) as unknown as typeof fetch;
+});
+
+async function mountClaudeCell(cwd: string) {
+  const TerminalCell = (await import("../../../src/components/TerminalCell.vue")).default;
+  return mount(TerminalCell, {
+    props: {
+      uid: 1,
+      expanded: false,
+      zoomed: false,
+      initialSessionId: "11111111-1111-1111-1111-111111111111",
+      initialCwd: cwd,
+      defaultCwd: cwd,
+      presets: [],
+      home: "/home/me",
+      cancellable: false,
+      openSessionIds: [],
+      openCwds: [],
+    },
+  });
+}
+
+async function mountLauncherCell(cwd: string) {
+  const LauncherCell = (await import("../../../src/components/LauncherCell.vue")).default;
+  return mount(LauncherCell, {
+    props: { uid: 2, expanded: false, zoomed: false, launcher: { index: 0, label: "shell" }, session: null, cwd, home: "/home/me" },
+  });
+}
+
+async function mountCommandCell(cwd: string) {
+  const CommandCell = (await import("../../../src/components/CommandCell.vue")).default;
+  return mount(CommandCell, {
+    props: { uid: 3, expanded: false, zoomed: false, command: { source: "script", index: 0, label: "build", cwd }, home: "/home/me" },
+  });
+}
+
+const CELLS: [string, (cwd: string) => Promise<ReturnType<typeof mount>>][] = [
+  ["the Claude cell", mountClaudeCell],
+  ["the Shell (launcher) cell", mountLauncherCell],
+  ["the Command cell", mountCommandCell],
+];
+
+// The style is emitted as CSS VARIABLES rather than plain background/color, so a status tint can
+// still override while idle keeps the directory's colour — which is why these assert on the
+// variable, not on a computed background.
+const styleOf = (w: ReturnType<typeof mount>, selector: string) => w.find(selector).attributes("style") ?? "";
+
+// A distinct directory per case: useDirConfig's fetch cache is module-level and outlives a test,
+// so reusing one cwd would serve an earlier case's config to a later one.
+let dirSeq = 0;
+const freshCwd = () => `/proj/chrome-${++dirSeq}`;
+
+describe.each(CELLS)("directory chrome colours reach %s", (_case, mountCell) => {
+  it("tints the cell frame: background, border, idle dot and header buttons", async () => {
+    const w = await mountCell(freshCwd());
+    await flushPromises();
+    const style = styleOf(w, ".cell");
+    expect(style).toContain(`--cell-bg: ${CHROME.cellColor}`);
+    expect(style).toContain(`--cell-border: ${CHROME.cellBorderColor}`);
+    expect(style).toContain(`--cell-dot: ${CHROME.dotColor}`);
+    expect(style).toContain(`--cell-btn: ${CHROME.buttonColor}`);
+  });
+
+  it("tints the header: background and text", async () => {
+    const w = await mountCell(freshCwd());
+    await flushPromises();
+    const style = styleOf(w, ".cell-header");
+    expect(style).toContain(`--cell-header-bg: ${CHROME.headerColor}`);
+    expect(style).toContain(`--cell-header-fg: ${CHROME.headerTextColor}`);
+  });
+
+  // Already true before #1006 — kept so a refactor of the shared wiring can't drop it.
+  it("still names the directory on its badge", async () => {
+    const w = await mountCell(freshCwd());
+    await flushPromises();
+    expect(w.text()).toContain(CHROME.name);
+  });
+});
+
+describe("a directory that configures nothing", () => {
+  it.each(CELLS)("leaves %s on the theme defaults", async (_case, mountCell) => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/proj/bare", scripts: [] }) };
+      return { ok: true, json: async () => ({}) };
+    }) as unknown as typeof fetch;
+
+    const w = await mountCell(freshCwd());
+    await flushPromises();
+    // No variables at all — the classes then fall through to their var() defaults.
+    expect(styleOf(w, ".cell")).not.toContain("--cell-bg");
+    expect(styleOf(w, ".cell-header")).not.toContain("--cell-header-bg");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1006。

`.mulmoterminal.json` のクローム色 6 キーが **Claude セルにしか効いていなかった**問題。
Shell（launcher）/ Command セルでは CSS 変数が一度も定義されず、全部フォールバックに落ちていた。

**ただし「2 ファイルに足りない行を足す」ではなく、足し忘れが起きる構造そのものを消した。**

## なぜ配線を足すだけにしなかったか

同じ穴が**3 回**見つかっている:

- #279 / #281 — クローム色 6 キーを追加（Claude セルに配線）
- #902 — `theme` / `colors` / `fontSize` / `fontFamily` が他セルに無い
- #914 — 名前バッジが他セルに無い
- **#1006 — クローム色 6 キーが他セルに無い**

不注意ではなく、**設計が「各セル種別が配線を憶えている」形**だったのが原因。そして忘れても
**何も落ちない・何も throw しない・色が付かないだけ**。`Terminal.vue` のコメントは #909 で消した
プロップについて、まさにそう書いていた — *forgetting one costs a silently dead setting*。

## 何をしたか

1. **`useCellChrome(cwd)`（新規）** — セルは「自分のクロームをくれ」と言えば、config・フレームの
   CSS 変数・ヘッダーの CSS 変数を**まとめて**受け取る。3 セルとも**同じ 1 行**になった。
2. **`Terminal.vue` がヘッダー色を自分の `dirConfig` から解決する** — 既に theme / font はそうしていた
   （#909）。`dir-header-color` / `dir-header-text-color` / `dir-button-color` の 3 プロップを削除し、
   それを渡していた 2 か所（`App.vue` / `TerminalCell.vue`）も消えた。
   **`dirHeaderColor` はソースから 0 件**になった。

新しいセル種別は、**もう渡されないものを渡し忘れることも、名前で요求するものを組み立て忘れることもできない**。

## Items to Confirm / Review

- **issue の Suggested fix と結論が違う。** レポートは「3 か所を両セルにコピー、#909 に寄せるなら
  3 番目は不要かも」としていたが、**現状では 3 番目も必要だった** — `Terminal.vue` は自前の
  `dirConfig` を持ちながら `headerStyle` は props から作っていたため。色について #909 を完遂したことで、
  はじめて不要になった。
- **テストは「色 × セル種別」のグリッド**にした。配線を忘れたセルは
  **どの色がどのセルで落ちたか**を言って失敗する。**修正前に書いて、issue が名指しした 2 セルで
  ちょうど落ちることを確認済み**。
- 「何も設定しないディレクトリ」のケースも入れた（変数が 1 つも出ないこと）。
- テストの罠を 1 つ記録した: `useDirConfig` の fetch キャッシュはモジュールレベルでテストを跨ぐので、
  ケースごとに別ディレクトリを使っている。使い回すと前のケースの config が後のケースに出る。
- `yarn typecheck:test` が `RunCommand` のプロップ違いを捕まえた（vitest だけでは通っていた）。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1006 これ確認して！
>
> ちょっと詳しくわからないがDRYになって根本が直せて、コードがきれいなようにして。

## Verification

`yarn format` / `lint` / `typecheck` ×3 / `test`（5376 passed）/ `build` すべて green。

実機での確認は未実施（このクローンの dev サーバーは動いていないため）。
確認するなら、`.mulmoterminal.json` に色を設定したディレクトリで **Shell セル**を開き、
ヘッダー背景・枠・idle ドットが設定色になることを見てください。

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
