### PR TITLE
fix: 末尾スラッシュ付き cwd のセルにライブリロードが届かない (#1002)

### DIFF
--- a/plans/fix-1002-cwd-trailing-slash.md
+++ b/plans/fix-1002-cwd-trailing-slash.md
@@ -1,0 +1,100 @@
+# fix: 末尾スラッシュ付き cwd のセルにライブリロードが届かない (#1002)
+
+## 症状
+
+`.mulmoterminal.json` を書いてもセルの色・名前バッジが変わらない。リロードすると反映される。
+末尾スラッシュ付きの cwd で開いたセルでだけ起きる。
+
+## 真因 — 検証はするのに正規化しない
+
+issue は publish 側（`path.dirname` で必ずスラッシュが落ちる）と subscribe 側（cwd 完全一致の
+Map）の表記ゆれまで特定していた。**その手前に発生源がある。**
+
+`server/config/workspace.ts` の `existingWorkspace`:
+
+```ts
+if (!cwd || !path.isAbsolute(cwd)) return null;
+return statSync(cwd).isDirectory() ? cwd : null;   // 検証は通すが、入力をそのまま返す
+```
+
+`/a/b/` は `isAbsolute` も `isDirectory` も通るので、**そのまま実効 cwd になる**。この戻り値は
+下流で「そのディレクトリの ID」として使われる — PTY の cwd、セルへ返す cwd、dir-config の購読
+キー、プリセットに記録するパス。つまり 1 つのディレクトリが 2 つの名前を持つ。
+
+実測:
+
+```
+入力           "/Users/…/proj/"
+isAbsolute     true
+statSync isDir true
+publish 側     "/Users/…/proj"    ← path.dirname
+一致           false
+```
+
+`sanitizePresets` も空白を trim するだけでパスに触れないため、シェルの補完が付けた末尾
+スラッシュが `cwdPresets` に永久に残る。
+
+## 修正 — 入口 1 か所
+
+`resolveWorkspace` は 7 か所（`session-routes.ts` ×5、`ws-routes.ts` ×2）から呼ばれる唯一の
+関門で、WS 接続もここを通る。ここを正規形にすると連鎖で片付く:
+
+1. セッションの cwd が正規形になる
+2. サーバがそれをセルへ返す → `serverCwd` → `Terminal.vue` の `dirConfigCwd` = 購読キーが
+   publish と一致する
+3. `recordPreset` は**サーバ確定の cwd で呼ばれる**（`TerminalCell.vue` の `onServerCwd`）ので、
+   既存の末尾スラッシュ付きプリセットは次回起動時に書き直される
+
+issue の Suggested fix は「publish / subscribe / fetch の全部を正規化」だったが、subscribe 側は
+2 の連鎖で直り、fetch 側はもともと壊れていない。
+
+### 共有ヘルパーは `path-within.ts` へ
+
+`canonicalDir()` を `server/infra/path-within.ts` に置いた。あのファイルは "One rule, one place"
+として #802（**未 resolve のパスを resolve 済みと比較していた**＝同じ族のバグ）から生まれた場所で、
+既に同じ `platformPath(platform).resolve` を内部に持っている。
+
+**大文字小文字は畳まない。** 同ファイル内の private `normalize` は Windows で lowercase するが、
+あれは*比較*用。こちらは PTY に渡り、UI に出て、config.json に書かれる*保存*値なので、畳むと
+3 つとも壊れる。
+
+**絶対パス限定。** `path.resolve` は相対文字列をサーバ自身の cwd に接ぎ木してしまう。呼び出し側は
+どちらも先に `isAbsolute` を見ている。
+
+## プリセットの重複 — 自分の修正が生む回帰
+
+`recordPreset` はパス文字列の**完全一致**でチップを探す。上の修正だけ入れると、保存済みの
+`/a/b/` に対してサーバが `/a/b` を返すので `existing` が見つからず、**同じディレクトリのチップが
+2 つ並ぶ**。これは推測ではなく `useAppConfig.ts:122` のコードそのもの。
+
+そこで `sanitizePresets` でもパスを正規化し、正規化後に重複を潰す。**先勝ち**（リストは MRU 順
+なので、残るのが新しい方＝ユーザーが付け替えたラベルも残る）。`sanitizePresets` は読み取り
+（`loadPresets`）と書き込み（`mergeConfigUpdate`）の両方を通るので、既存の config.json も
+次の書き込みで自己修復する。
+
+## 掃いたが直さなかったもの
+
+`server/files/pathContainment.ts` の `resolveBase` が**同じ形**（検証だけして verbatim 返し、
+コメントにも "mirrors index.ts resolveWorkspace"）。ただし消費側が全員 `path.resolve` を
+掛け直している（`containedPath`、`authorizedServingBase`）ため、現状は無害。#1002 の原因では
+ないので触っていない。**見落としではなく判断**として記録しておく。
+
+## テスト
+
+対照実験で修正を外すと 5 本が赤、戻すと緑（`workspace.spec` 1 / `cwd-presets.spec` 3 /
+`dir-config.spec` 1）。
+
+いちばん効くのは `dir-config.spec` の 1 本で、**publish 側と subscribe 側が同じ文字列を作る**
+という不変条件を直接押さえている:
+
+```ts
+const announced = dirConfigWriteTarget("Write", { file_path: … }, dir + path.sep);
+expect(announced).toBe(resolveWorkspace(dir + path.sep));
+```
+
+この 2 つは別のコード（`path.dirname` と workspace ガード）が作り、クライアントは完全一致で
+突き合わせる。綴りを揃え続けるものが他に無い。
+
+なお既存の `sanitizePresets` テストが `path: "/a"` という POSIX リテラルを期待していた。
+**Windows では `/a` はドライブ相対で `C:\a` に解決される**ため、正規化を入れた時点で非可搬に
+なる。期待値を `path.resolve` 経由に直した（CI は ubuntu/macOS のみだが、Windows は対応対象）。

--- a/plans/fix-1002-cwd-trailing-slash.md
+++ b/plans/fix-1002-cwd-trailing-slash.md
@@ -98,3 +98,34 @@ expect(announced).toBe(resolveWorkspace(dir + path.sep));
 なお既存の `sanitizePresets` テストが `path: "/a"` という POSIX リテラルを期待していた。
 **Windows では `/a` はドライブ相対で `C:\a` に解決される**ため、正規化を入れた時点で非可搬に
 なる。期待値を `path.resolve` 経由に直した（CI は ubuntu/macOS のみだが、Windows は対応対象）。
+
+## レビューで直したところ: stat と resolve の順序 (#1016, Codex)
+
+最初の実装は **stat してから canonicalize** していた。Codex の指摘どおり、これは
+**検証していないパスを返し得る**回帰だった。
+
+`stat` はカーネルが symlink を辿り、`path.resolve` は純粋に字句的なので、**symlink の直後に
+`..` が来た瞬間に両者は別の場所を指す**:
+
+```
+<dir>/link -> <dir>/sub/target
+<dir>/link/../sibling   カーネル: link -> sub/target, .. -> sub  =>  <dir>/sub/sibling（存在する）
+                        字句    :                                    <dir>/sibling    （存在しない）
+```
+
+stat→resolve だと入力は受理され、`<dir>/sibling` が返る。誰も検証しておらず、たいてい存在しない。
+
+**canonicalize してから stat する**順に変えた。返す値が検証した値そのものになる。
+
+`realpath` は使わない。announce 側は `path.dirname`（字句）で綴るので、片側だけ物理解決すると
+#1002 の不一致が別の形で戻る。
+
+### テストのフィクスチャが 2 回間違っていた
+
+1 回目は symlink の親と対象の親が同じで、字句解決と一致してしまい**両方の順序で緑**だった。
+2 回目は `path.join(link, "..", "sibling")` と書いたが、**`path.join` は構築時に `..` を畳む**ので
+symlink を前に置いたままカーネルへ渡らず、フィクスチャ自体が ENOENT で落ちた。文字列連結で
+組み直して初めて対照実験が成立した（修正版=緑、stat→resolve=赤）。
+
+そのためテスト内にフィクスチャ自身のガードを入れてある — 乖離が本当に起きていることを
+先に assert しないと、本命の assert が空振りしても気づけない。

--- a/server/config/cwd-presets.ts
+++ b/server/config/cwd-presets.ts
@@ -6,16 +6,39 @@ import { type CwdPreset } from "./config-schema.js";
 import { readJsonFile } from "../infra/read-text-file.js";
 import { writeFileAtomicSync } from "../files/atomic-write.js";
 import { isRecord } from "../../common/isRecord.js";
+import { canonicalDir } from "../infra/path-within.js";
 const isPreset = (v: unknown): v is CwdPreset => isRecord(v) && typeof v.label === "string" && typeof v.path === "string";
 
-// Normalize arbitrary input into clean presets: keep only {label,path} objects,
-// trim, drop entries missing either field, and cap the count.
+// A preset's path in the one spelling the rest of the app uses. Trailing separators are what a
+// shell's tab-completion leaves on a path the user pastes into the launch form, and they used to
+// be stored verbatim — so once the server started reporting the canonical cwd back (#1002), the
+// same directory would be recorded a SECOND time and show two chips.
+//
+// Absolute only: `path.resolve` would splice a relative entry onto the server's own cwd and
+// invent a directory the user never named. A relative preset can't launch anyway (the workspace
+// guard rejects it), so it is left exactly as written rather than silently repointed.
+const presetPath = (raw: string): string => {
+  const trimmed = raw.trim();
+  return path.isAbsolute(trimmed) ? canonicalDir(trimmed) : trimmed;
+};
+
+// Normalize arbitrary input into clean presets: keep only {label,path} objects, trim, canonicalize
+// the path, drop entries missing either field, collapse duplicates, and cap the count.
 export function sanitizePresets(input: unknown, max = 50): CwdPreset[] {
   if (!Array.isArray(input)) return [];
-  return input
+  const cleaned = input
     .filter(isPreset)
-    .map((p) => ({ label: p.label.trim(), path: p.path.trim() }))
-    .filter((p) => p.label && p.path)
+    .map((p) => ({ label: p.label.trim(), path: presetPath(p.path) }))
+    .filter((p) => p.label && p.path);
+  // Deduped AFTER canonicalizing, keeping the first: the list is most-recently-used order, so the
+  // survivor is the newer entry and its label (which the user may have renamed) is the one kept.
+  const seen = new Set<string>();
+  return cleaned
+    .filter((p) => {
+      if (seen.has(p.path)) return false;
+      seen.add(p.path);
+      return true;
+    })
     .slice(0, max);
 }
 

--- a/server/config/workspace.ts
+++ b/server/config/workspace.ts
@@ -1,6 +1,7 @@
 import { statSync } from "node:fs";
 import path from "node:path";
 import { CLAUDE_CWD } from "./env.js";
+import { canonicalDir } from "../infra/path-within.js";
 
 // Validate a client-supplied workspace dir: must be an absolute, existing
 // directory. Anything else (relative, missing, a file) falls back to CLAUDE_CWD,
@@ -13,10 +14,15 @@ export function resolveWorkspace(cwd: string | null): string {
 // asked about. Falling back there is a correctness bug rather than a safe default: the caller
 // would render another directory's answer under the requested directory's name — and a stale
 // preset (a project since deleted) is exactly when it happens.
+// Canonical, not verbatim: this return value is the identity a directory is known by everywhere
+// downstream — the PTY's cwd, the cwd echoed back to the cell, the key its dir-config
+// subscription uses, and the path recorded as a launcher preset. `/a/b/` passes both guards
+// below, so returning it unchanged made one directory into two names, and a `.mulmoterminal.json`
+// change announced as `/a/b` never reached a cell that had launched as `/a/b/` (#1002).
 export function existingWorkspace(cwd: string | null): string | null {
   if (!cwd || !path.isAbsolute(cwd)) return null;
   try {
-    return statSync(cwd).isDirectory() ? cwd : null;
+    return statSync(cwd).isDirectory() ? canonicalDir(cwd) : null;
   } catch {
     return null; // not a dir / doesn't exist
   }

--- a/server/config/workspace.ts
+++ b/server/config/workspace.ts
@@ -19,10 +19,19 @@ export function resolveWorkspace(cwd: string | null): string {
 // subscription uses, and the path recorded as a launcher preset. `/a/b/` passes both guards
 // below, so returning it unchanged made one directory into two names, and a `.mulmoterminal.json`
 // change announced as `/a/b` never reached a cell that had launched as `/a/b/` (#1002).
+// Canonicalize BEFORE the stat, so the directory that is checked is the one that is returned.
+// The two disagree: `stat` resolves symlinks in the kernel, `path.resolve` is purely lexical, so
+// `/x/link/../var` stats as `/var` (link -> /etc) while resolving to `/x/var`. Stat-then-resolve
+// would hand back a path nothing had validated, and usually one that does not exist.
+//
+// Lexical and NOT realpath, deliberately: the announcing side of the dir-config channel spells
+// the directory with `path.dirname`, which is lexical too, and canonicalizing only one side
+// physically would re-open the very mismatch below.
 export function existingWorkspace(cwd: string | null): string | null {
   if (!cwd || !path.isAbsolute(cwd)) return null;
+  const dir = canonicalDir(cwd);
   try {
-    return statSync(cwd).isDirectory() ? canonicalDir(cwd) : null;
+    return statSync(dir).isDirectory() ? dir : null;
   } catch {
     return null; // not a dir / doesn't exist
   }

--- a/server/infra/path-within.ts
+++ b/server/infra/path-within.ts
@@ -29,6 +29,20 @@ const normalize = (p: string, platform: NodeJS.Platform): string => {
   return platform === "win32" ? resolved.toLowerCase() : resolved;
 };
 
+/** One spelling per directory, for a path that is STORED rather than compared: `/a/b/` and
+ *  `/a/b` name one directory, and `path.resolve` is the whole rule (it drops the trailing
+ *  separator except on a filesystem root, and collapses `.` / `..`).
+ *
+ *  Case is deliberately NOT folded here, unlike `normalize` above. That one exists to compare;
+ *  this value is handed to a PTY, shown in the UI, and written to config.json, and lowercasing
+ *  a Windows path would corrupt all three. Fold when comparing (`isSamePath`), never when keeping.
+ *
+ *  **Absolute input only** — `path.resolve` splices a relative string onto the server's own cwd,
+ *  which invents a directory the caller never named. Every caller checks `isAbsolute` first. */
+export function canonicalDir(dir: string, platform: NodeJS.Platform = process.platform): string {
+  return platformPath(platform).resolve(dir);
+}
+
 /** Do these name the same path? Both sides are resolved first, so a drive-relative or
  *  un-normalized spelling of the same directory still matches. */
 export function isSamePath(a: string, b: string, platform: NodeJS.Platform = process.platform): boolean {

--- a/test/server/config/cwd-presets.spec.ts
+++ b/test/server/config/cwd-presets.spec.ts
@@ -7,9 +7,11 @@ import { sanitizePresets, loadPresets, savePresets, extractCwdFromTranscript, de
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-presets-"));
 
 describe("sanitizePresets", () => {
+  // Expectations built through `path`, not written as POSIX literals: paths are canonicalized
+  // now, and on Windows `/a` is drive-relative — it resolves to `C:\a`, not `/a`.
   it("keeps valid {label,path}, trims, and drops incomplete/junk rows", () => {
     expect(sanitizePresets([{ label: " a ", path: " /a " }, { label: "", path: "/b" }, { label: "c", path: "" }, { nope: 1 }, "x"])).toEqual([
-      { label: "a", path: "/a" },
+      { label: "a", path: path.resolve("/a") },
     ]);
   });
 
@@ -92,5 +94,50 @@ describe("deriveCwdPresets", () => {
 
   it("is empty when nothing exists", () => {
     expect(deriveCwdPresets([{ cwd: "/gone", mtimeMs: 1 }], () => false)).toEqual([]);
+  });
+});
+
+// #1002. The launcher chips are matched by exact path string (useAppConfig's recordPreset), and
+// the cwd handed to it is the SERVER-confirmed one — now canonical. A stored `/a/b/` would then
+// never match, so relaunching that directory prepended a second chip for it instead of moving
+// the existing one to the front.
+describe("sanitizePresets — one spelling per directory", () => {
+  const dir = path.resolve("/Users/me/proj");
+
+  it("canonicalizes a trailing separator, so it matches the cwd the server reports", () => {
+    expect(sanitizePresets([{ label: "proj", path: dir + path.sep }])).toEqual([{ label: "proj", path: dir }]);
+  });
+
+  it("collapses two spellings of one directory into a single chip", () => {
+    const presets = sanitizePresets([
+      { label: "newest", path: dir },
+      { label: "older", path: dir + path.sep },
+    ]);
+    expect(presets).toEqual([{ label: "newest", path: dir }]);
+  });
+
+  // The list is most-recently-used order, and a user may have renamed the chip they kept.
+  it("keeps the FIRST of the duplicates, label and all", () => {
+    const presets = sanitizePresets([
+      { label: "My Project", path: dir + path.sep },
+      { label: "proj", path: dir },
+    ]);
+    expect(presets).toEqual([{ label: "My Project", path: dir }]);
+  });
+
+  it("collapses . and .. rather than storing a path that only looks different", () => {
+    expect(sanitizePresets([{ label: "p", path: path.join(dir, "sub", "..") }])).toEqual([{ label: "p", path: dir }]);
+  });
+
+  // path.resolve on a relative string would splice it onto the SERVER's cwd and invent a
+  // directory the user never named. Such an entry can't launch anyway — the workspace guard
+  // rejects it — so it is kept exactly as written instead of being silently repointed.
+  it("leaves a relative path alone instead of resolving it against the server's cwd", () => {
+    expect(sanitizePresets([{ label: "rel", path: "some/where" }])).toEqual([{ label: "rel", path: "some/where" }]);
+  });
+
+  it("still caps the count after deduping", () => {
+    const many = Array.from({ length: 5 }, (_, i) => ({ label: `p${i}`, path: path.resolve(`/tmp/p${i}`) }));
+    expect(sanitizePresets([...many, ...many], 3)).toHaveLength(3);
   });
 });

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -12,6 +12,7 @@ import {
   MISSING_DIR_CONFIG_DETAIL,
 } from "../../../server/config/dir-config";
 import { DIR_CONFIG_KEYS } from "../../../common/dirConfigSource";
+import { resolveWorkspace } from "../../../server/config/workspace";
 
 const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
 const EMPTY = {
@@ -248,6 +249,20 @@ describe("dirConfigWriteTarget", () => {
     for (const tool of ["Write", "Edit", "MultiEdit"]) {
       expect(dirConfigWriteTarget(tool, { file_path: file })).toBe(projDir);
     }
+  });
+
+  // #1002 — the invariant the live reload rests on: the cwd ANNOUNCED when a .mulmoterminal.json
+  // is written has to be the same STRING as the cwd the cell showing that directory is keyed by.
+  // The two are produced by different code (path.dirname here, the workspace guard there) and are
+  // matched by exact equality on the client, so nothing but this keeps them spelled the same.
+  // A directory launched as `/a/b/` — what a shell's tab-completion leaves in the launch form —
+  // was announced as `/a/b`, and the cell never heard about its own config file.
+  it("announces the same cwd string the workspace guard hands the cell", () => {
+    const dir = tmp();
+    const launchedAs = dir + path.sep;
+    const announced = dirConfigWriteTarget("Write", { file_path: path.join(dir, ".mulmoterminal.json") }, launchedAs);
+    expect(announced).toBe(resolveWorkspace(launchedAs));
+    expect(announced).toBe(dir);
   });
 
   it("resolves a relative path against the SESSION cwd, not the server's", () => {

--- a/test/server/config/workspace.spec.ts
+++ b/test/server/config/workspace.spec.ts
@@ -86,3 +86,47 @@ describe("existingWorkspace", () => {
     expect(existingWorkspaceFromQuery(undefined)).toBeNull();
   });
 });
+
+// #1002. These guards let `/a/b/` through — it is absolute and it stats as a directory — and the
+// value they return is the identity the directory is known by from then on: the PTY's cwd, the cwd
+// echoed back to the cell, the key its dir-config subscription uses, and the recorded preset.
+// Returned verbatim, one directory had two names, and a `.mulmoterminal.json` change announced on
+// the canonical one never reached a cell launched from the other.
+describe("canonical spelling of the accepted directory", () => {
+  let dir = "";
+
+  beforeAll(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "mt-ws-canon-"));
+  });
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("drops a trailing separator — the shape tab-completion leaves behind", () => {
+    expect(resolveWorkspace(dir + path.sep)).toBe(dir);
+    expect(existingWorkspace(dir + path.sep)).toBe(dir);
+    expect(workspaceFromQuery(dir + path.sep)).toBe(dir);
+    expect(existingWorkspaceFromQuery(dir + path.sep)).toBe(dir);
+  });
+
+  it("collapses . and .. inside an absolute path", () => {
+    expect(resolveWorkspace(path.join(dir, "sub", ".."))).toBe(dir);
+    expect(resolveWorkspace(path.join(dir, "."))).toBe(dir);
+  });
+
+  it("leaves an already-canonical path untouched", () => {
+    expect(resolveWorkspace(dir)).toBe(dir);
+  });
+
+  // The guard order matters: canonicalizing BEFORE the isAbsolute check would splice a relative
+  // string onto the server's own cwd and hand back a directory the client never asked for.
+  it("still refuses a relative path rather than resolving it against the server's cwd", () => {
+    expect(existingWorkspace("server")).toBeNull();
+    expect(existingWorkspace("./server")).toBeNull();
+  });
+
+  it("keeps the filesystem root, whose separator is not trailing", () => {
+    const root = path.parse(dir).root;
+    expect(resolveWorkspace(root)).toBe(root);
+  });
+});

--- a/test/server/config/workspace.spec.ts
+++ b/test/server/config/workspace.spec.ts
@@ -125,6 +125,35 @@ describe("canonical spelling of the accepted directory", () => {
     expect(existingWorkspace("./server")).toBeNull();
   });
 
+  // Codex review of #1016. Canonicalizing AFTER the stat returns a path nothing checked: `stat`
+  // resolves symlinks in the kernel, `path.resolve` is purely lexical, and the two part ways as
+  // soon as a `..` follows a symlink into a DIFFERENT parent.
+  //
+  //   <dir>/link -> <dir>/sub/target
+  //   <dir>/link/../sibling   kernel: link -> sub/target, .. -> sub  =>  <dir>/sub/sibling (exists)
+  //                           lexical:                                   <dir>/sibling     (does not)
+  //
+  // Stat-then-resolve therefore accepts the input and hands back <dir>/sibling, which was never
+  // validated and is not there. The invariant: whatever comes back was the thing that was checked.
+  it.skipIf(process.platform === "win32")("never returns a directory it did not stat", async () => {
+    const target = path.join(dir, "sub", "target");
+    const sibling = path.join(dir, "sub", "sibling");
+    await fs.mkdir(target, { recursive: true });
+    await fs.mkdir(sibling, { recursive: true });
+    const link = path.join(dir, "link");
+    await fs.symlink(target, link);
+
+    // Concatenated, NOT path.join: join collapses the `..` itself, so the string would never
+    // reach the kernel with a symlink still in front of it and the fixture would test nothing.
+    const viaLink = `${link}${path.sep}..${path.sep}sibling`;
+    // Guard the fixture itself: the divergence has to be real, or the assertion below is vacuous.
+    expect((await fs.stat(viaLink)).isDirectory()).toBe(true);
+    expect(path.resolve(viaLink)).toBe(path.join(dir, "sibling"));
+
+    const answer = existingWorkspace(viaLink);
+    expect(answer).toBeNull();
+  });
+
   it("keeps the filesystem root, whose separator is not trailing", () => {
     const root = path.parse(dir).root;
     expect(resolveWorkspace(root)).toBe(root);


### PR DESCRIPTION
Fixes #1002

## Summary

`.mulmoterminal.json` を書いてもセルに反映されない件。issue は publish 側と subscribe 側の表記ゆれまで特定していましたが、**その手前に発生源**がありました。`server/config/workspace.ts` の `existingWorkspace` が、パスを**検証するのに正規化せず入力をそのまま返して**いたためです。

```ts
if (!cwd || !path.isAbsolute(cwd)) return null;
return statSync(cwd).isDirectory() ? cwd : null;   // ← verbatim
```

`/a/b/` は両方のガードを通るので、そのまま実効 cwd になります。この戻り値は下流で「そのディレクトリの ID」として使われる — PTY の cwd、セルへ返す cwd、dir-config の購読キー、プリセットに記録するパス。1 つのディレクトリが 2 つの名前を持ち、publish 側（`path.dirname` で必ずスラッシュが落ちる）が announce した `/a/b` は `/a/b/` で開いたセルに届きません。

**入口 1 か所を正規形にすると連鎖で片付きます。** `resolveWorkspace` は 7 か所（`session-routes.ts` ×5、`ws-routes.ts` ×2）から呼ばれる唯一の関門で、WS 接続もここを通ります。

## Items to Confirm / Review

- **プリセット重複の回帰を潰すため `sanitizePresets` も変更しています。** これは推測ではなく `useAppConfig.ts:122` の `recordPreset` がパス完全一致でチップを探すためで、workspace だけ直すと保存済み `/a/b/` に対しサーバが `/a/b` を返し、**同じディレクトリのチップが 2 つ並びます**。重複解消は先勝ち（MRU 順なので新しい方とそのラベルが残る）にしましたが、この選択でよいか見てください。
- **`pathContainment.ts` の `resolveBase` は同じ形ですが直していません。** 消費側が全員 `path.resolve` を掛け直しているため現状は無害で、#1002 の原因でもないためです。見落としではなく判断として plan にも記録しました。触るべきなら別 PR で。
- **大文字小文字を畳まない判断。** `canonicalDir` を置いた `path-within.ts` には Windows で lowercase する private `normalize` が同居しますが、あれは*比較*用です。こちらは PTY に渡り UI に出て config.json に書かれる*保存*値なので畳んでいません。
- **既存テストを 1 行変更しています。** `sanitizePresets` のテストが `path: "/a"` という POSIX リテラルを期待していました。Windows では `/a` はドライブ相対で `C:\a` に解決されるため、正規化を入れた時点で非可搬になります（CI は ubuntu/macOS のみですが Windows は対応対象）。

## User Prompt

- https://github.com/receptron/mulmoterminal/issues/1002 これって原因わかる？
- 直して！reviewまで。

## 修正内容

**1. `server/infra/path-within.ts` — 共有ヘルパー `canonicalDir()`**

置き場所として選んだのは、あのファイルが #802（**未 resolve のパスを resolve 済みと比較していた**＝同じ族のバグ）から生まれた "One rule, one place" であり、同じ `platformPath(platform).resolve` を既に内部に持っているためです。

絶対パス限定にしています — `path.resolve` は相対文字列をサーバ自身の cwd に接ぎ木し、呼び出し側が名指ししていないディレクトリを作ってしまいます。呼び出し側はどちらも先に `isAbsolute` を見ています。

**2. `server/config/workspace.ts` — `existingWorkspace` が正規形を返す**

**3. `server/config/cwd-presets.ts` — `sanitizePresets` が正規化 + 重複解消**

`sanitizePresets` は読み取り（`loadPresets`）と書き込み（`mergeConfigUpdate`）の両方を通るので、**既存の config.json も次の書き込みで自己修復**します。

## なぜ issue の Suggested fix（3 か所を正規化）より狭いか

subscribe 側は連鎖で直ります: サーバがセルへ返す cwd が正規形になる → `Terminal.vue` の `dirConfigCwd` が正規形 → 購読キーが publish と一致。fetch 側はもともと壊れていません。

なお issue の「`/api/dir-config` はサーバ側で `path.resolve` するため、どちらの表記でも正しい値を返す」は**機序が違います**。実際は `publicDirConfig` が `path.join(base, DIR_CONFIG_FILE)` を使っており、`path.join` が両表記を同じ結果にするためです。結論（fetch は壊れていない）は正しいので実害はありませんが、「resolve しているから安全」と信じて入口の正規化を省くと直りません。

## テスト

**対照実験で修正を外すと 5 本が赤、戻すと緑**（`workspace.spec` 1 / `cwd-presets.spec` 3 / `dir-config.spec` 1）。

いちばん効くのは `dir-config.spec` の 1 本で、**publish 側と subscribe 側が同じ文字列を作る**という不変条件を直接押さえています。

```ts
const announced = dirConfigWriteTarget("Write", { file_path: … }, dir + path.sep);
expect(announced).toBe(resolveWorkspace(launchedAs));
```

この 2 つは別のコード（`path.dirname` と workspace ガード）が作り、クライアントは完全一致で突き合わせます。綴りを揃え続けるものが他にありません。

ローカル: lint 0 errors / typecheck 3 本 / build / `yarn test` 5538 passed（4 回連続）。

## 未確認

**実機での再現・修正確認はしていません。** 末尾スラッシュ付きプリセットから起動して `.mulmoterminal.json` を書く手順は踏んでおらず、コードと単体テストまでです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)