### PR TITLE
fix(ci): ハングした codex review を短時間で打ち切って 1 回リトライする (#1020)

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -244,9 +244,12 @@ jobs:
             if [ "$status" -eq 0 ]; then
               exit 0
             fi
-            # 124 is timeout(1)'s own code for "deadline hit" — the hang. Anything else is codex
-            # failing on its own terms (bad key, gh error), which a retry is unlikely to fix.
-            if [ "$status" -ne 124 ]; then
+            # Both codes mean the deadline was hit: 124 when the child dies on TERM, 137 when it
+            # ignores TERM and `--kill-after` has to SIGKILL it. 137 is the one that matters here —
+            # a process wedged waiting on the model is exactly the kind that does not take TERM
+            # (measured: a child trapping TERM exits 137, not 124). Anything else is codex failing
+            # on its own terms (bad key, gh error), which a retry is unlikely to fix.
+            if [ "$status" -ne 124 ] && [ "$status" -ne 137 ]; then
               echo "::error::codex exec failed with status $status (not a timeout) — not retrying"
               exit "$status"
             fi

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -196,7 +196,11 @@ jobs:
           Before posting your own findings, look at what's already
           on the PR — this PR may have had earlier review iterations
           (yours or another bot's) that are already addressed by
-          later commits. Read the existing thread:
+          later commits. An earlier ATTEMPT OF THIS SAME RUN may also
+          have posted before it was cut short, so if you find comments
+          that already say what you were going to say about the
+          current commit, leave them alone rather than repeating them.
+          Read the existing thread:
             gh api repos/${REPO}/issues/${PR_NUMBER}/comments --paginate
             gh api repos/${REPO}/pulls/${PR_NUMBER}/comments --paginate
           For every prior 'CODEX VERDICT: CHANGES REQUESTED' bullet,
@@ -237,20 +241,24 @@ jobs:
           # about a minute on a plain rerun of the same commit.
           for attempt in 1 2; do
             # `|| status=$?` rather than `if …; then`: after an `if`, $? is the IF statement's
-            # status (0), not the command's — the 124 below would never be seen.
+            # status (0), not the command's — the codes below would never be seen.
+            started=$SECONDS
             status=0
             timeout --signal=TERM --kill-after=30s "${CODEX_TIMEOUT_SECONDS}" \
               codex exec --sandbox danger-full-access "$PROMPT_TEXT" || status=$?
+            elapsed=$(( SECONDS - started ))
             if [ "$status" -eq 0 ]; then
               exit 0
             fi
-            # Both codes mean the deadline was hit: 124 when the child dies on TERM, 137 when it
-            # ignores TERM and `--kill-after` has to SIGKILL it. 137 is the one that matters here —
-            # a process wedged waiting on the model is exactly the kind that does not take TERM
-            # (measured: a child trapping TERM exits 137, not 124). Anything else is codex failing
-            # on its own terms (bad key, gh error), which a retry is unlikely to fix.
-            if [ "$status" -ne 124 ] && [ "$status" -ne 137 ]; then
-              echo "::error::codex exec failed with status $status (not a timeout) — not retrying"
+            # A deadline hit is 124 (child died on TERM) or 137 (it ignored TERM, so --kill-after
+            # SIGKILLed it). 137 is the one that matters — a process wedged on a model call is
+            # exactly the kind that does not take TERM (measured: a child trapping TERM exits 137).
+            #
+            # But timeout(1) cannot tell ITS deadline from the child exiting 124/137 on its own,
+            # so the elapsed time decides: a run that gave up early was codex failing, not a hang,
+            # and retrying it would spend the deadline again to reach the same answer.
+            if { [ "$status" -ne 124 ] && [ "$status" -ne 137 ]; } || [ "$elapsed" -lt "${CODEX_TIMEOUT_SECONDS}" ]; then
+              echo "::error::codex exec failed with status $status after ${elapsed}s (not a timeout) — not retrying"
               exit "$status"
             fi
             echo "::warning::codex exec hit the ${CODEX_TIMEOUT_SECONDS}s deadline on attempt $attempt (see #1020)"

--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -173,6 +173,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           REPO: ${{ github.repository }}
+          # Per-attempt deadline. Well above a healthy review (30s-2min) and far below the job's
+          # own cap, so a hang is cut short and retried instead of eating the whole budget.
+          CODEX_TIMEOUT_SECONDS: "300"
         run: |
           # `--sandbox danger-full-access` skips bubblewrap entirely.
           # The default `workspace-write` sandbox tries to create a
@@ -183,7 +186,7 @@ jobs:
           # spawn ANY shell command, including `gh`. The runner VM
           # is itself ephemeral + isolated per job, so dropping the
           # nested sandbox is safe in this context.
-          codex exec --sandbox danger-full-access "$(cat <<PROMPT
+          PROMPT_TEXT="$(cat <<PROMPT
           Review PR #${PR_NUMBER} in ${REPO}.
 
           Use the gh CLI to inspect the diff:
@@ -225,3 +228,29 @@ jobs:
           Do not apply any fixes yourself — only review and post findings.
           PROMPT
           )"
+
+          # `codex exec` HANGS rather than running slow (#1020): on a bad run it reads the PR
+          # thread, goes quiet waiting on the model, and never returns — the job then burns the
+          # whole `timeout-minutes` and leaves an orphan `codex` process behind. Raising the cap
+          # only lengthens the wait, so the call gets its OWN, much shorter deadline and one
+          # retry. A healthy review takes 30s-2min, and every hung run so far has succeeded in
+          # about a minute on a plain rerun of the same commit.
+          for attempt in 1 2; do
+            # `|| status=$?` rather than `if …; then`: after an `if`, $? is the IF statement's
+            # status (0), not the command's — the 124 below would never be seen.
+            status=0
+            timeout --signal=TERM --kill-after=30s "${CODEX_TIMEOUT_SECONDS}" \
+              codex exec --sandbox danger-full-access "$PROMPT_TEXT" || status=$?
+            if [ "$status" -eq 0 ]; then
+              exit 0
+            fi
+            # 124 is timeout(1)'s own code for "deadline hit" — the hang. Anything else is codex
+            # failing on its own terms (bad key, gh error), which a retry is unlikely to fix.
+            if [ "$status" -ne 124 ]; then
+              echo "::error::codex exec failed with status $status (not a timeout) — not retrying"
+              exit "$status"
+            fi
+            echo "::warning::codex exec hit the ${CODEX_TIMEOUT_SECONDS}s deadline on attempt $attempt (see #1020)"
+          done
+          echo "::error::codex exec hung twice; giving up"
+          exit 1

--- a/plans/fix-1020-codex-hang.md
+++ b/plans/fix-1020-codex-hang.md
@@ -7,7 +7,7 @@ Issue: #1020
 `codex exec` does not run slow on a bad run — it **stops**. The log of the timed-out attempt on
 #974 reads:
 
-```
+```text
 22:52:27  [{"url":".../issues/comments/5097680212", …   ← finished reading the PR thread
           (fifteen minutes with no output at all)
 23:07:24  ##[error]The operation was canceled.
@@ -61,16 +61,30 @@ case per branch:
 | stub | result |
 | --- | --- |
 | hangs forever | two attempts, then fail (exit 1) |
+| ignores TERM, hangs forever | two attempts (137 each), then fail |
+| **exits 124 itself, immediately** | **no retry** — not a deadline, see below |
+| **exits 137 itself, immediately** | **no retry** |
 | exits 3 immediately | **no retry**, exit 3 |
 | succeeds | exit 0, one attempt |
 | hangs once, then succeeds | **exit 0 on attempt 2** — the case actually being hit |
-| ignores TERM, hangs forever | two attempts (137 each), then fail |
 | ignores TERM once, then succeeds | **exit 0 on attempt 2** |
 
 Plus `bash -n` on the step's script and a YAML parse asserting the prompt still carries the
 `CODEX VERDICT:` marker the `gh-review-loop` skill reads.
 
 ## Review follow-up
+
+**CodeRabbit: `timeout` cannot tell its own deadline from the child exiting 124/137.** True — the
+codes are indistinguishable, so the *elapsed time* decides instead: a run that gave up before the
+deadline was codex failing on its own terms, not a hang, and retrying it would spend another five
+minutes reaching the same answer. Two stub cases pin it.
+
+**CodeRabbit: a retry can duplicate comments.** Real: if an attempt posts findings and then hangs,
+the retry runs the same prompt again. The prompt already tells the review to read the existing
+thread before posting; it now also says that an earlier attempt **of this same run** may have
+posted before being cut short, and to leave those comments alone rather than repeat them. Not
+airtight — a truly idempotent poster would need a per-run marker — but the observed hang (#974)
+happens *before* anything is posted, so this covers the case at hand without adding machinery.
 
 **Codex: 137 was being treated as "not a timeout".** Correct, and it would have defeated the whole
 change: with `--kill-after` set, a child that ignores TERM exits 137, and a process wedged on a

--- a/plans/fix-1020-codex-hang.md
+++ b/plans/fix-1020-codex-hang.md
@@ -1,0 +1,72 @@
+# Cut a hung review short instead of waiting out the cap
+
+Issue: #1020
+
+## Why
+
+`codex exec` does not run slow on a bad run — it **stops**. The log of the timed-out attempt on
+#974 reads:
+
+```
+22:52:27  [{"url":".../issues/comments/5097680212", …   ← finished reading the PR thread
+          (fifteen minutes with no output at all)
+23:07:24  ##[error]The operation was canceled.
+23:07:24  Terminate orphan process: pid (2418) (codex)
+```
+
+It got as far as the "read the existing thread" step the prompt asks for, went to the model, and
+never came back. The job then burned its whole `timeout-minutes` and left an orphan `codex` behind.
+
+That reframes #960, which raised the cap from 10 to 15 minutes on the theory that reviews were
+occasionally slow. **A hang always reaches the cap**, whatever it is set to — so that change bought
+five more minutes of waiting and nothing else. It happened four times in two days (#945, #951,
+#952, #974), and every rerun of the same commit finished in about a minute.
+
+## What
+
+The `codex exec` call gets its own deadline (`CODEX_TIMEOUT_SECONDS`, 300) and one retry. A healthy
+review takes 30s–2min, so five minutes is well clear of normal and far below the job's cap.
+
+Only a **timeout** is retried. `timeout(1)` reports 124 for its own deadline; any other non-zero
+status is codex failing on its own terms (a bad key, a `gh` error) and a retry would just spend
+another five minutes reaching the same conclusion.
+
+The job's 15-minute cap stays as the backstop — two attempts plus overhead fit inside it.
+
+## The bug I nearly shipped
+
+The first draft wrote:
+
+```bash
+if timeout … codex exec …; then exit 0; fi
+status=$?
+```
+
+After an `if`, `$?` is the **if statement's** status, not the command's — so `status` would have
+been 0 every time and the 124 check would never have fired. It reads correct and is wrong. Now:
+
+```bash
+status=0
+timeout … codex exec … || status=$?
+```
+
+## How this was checked
+
+Workflow changes only run in CI, so the retry block was extracted and run locally against stubs, a
+case per branch:
+
+| stub | result |
+| --- | --- |
+| hangs forever | two attempts, then fail (exit 1) |
+| exits 3 immediately | **no retry**, exit 3 |
+| succeeds | exit 0, one attempt |
+| hangs once, then succeeds | **exit 0 on attempt 2** — the case actually being hit |
+
+Plus `bash -n` on the step's script and a YAML parse asserting the prompt still carries the
+`CODEX VERDICT:` marker the `gh-review-loop` skill reads.
+
+## What this does not do
+
+It does not explain **why** codex hangs — whether the model call is left hanging with no client-side
+timeout, or something upstream stalls. That stays open in #1020. This only stops a hang from
+costing fifteen minutes and a manual rerun.

--- a/plans/fix-1020-codex-hang.md
+++ b/plans/fix-1020-codex-hang.md
@@ -27,9 +27,12 @@ five more minutes of waiting and nothing else. It happened four times in two day
 The `codex exec` call gets its own deadline (`CODEX_TIMEOUT_SECONDS`, 300) and one retry. A healthy
 review takes 30s–2min, so five minutes is well clear of normal and far below the job's cap.
 
-Only a **timeout** is retried. `timeout(1)` reports 124 for its own deadline; any other non-zero
-status is codex failing on its own terms (a bad key, a `gh` error) and a retry would just spend
-another five minutes reaching the same conclusion.
+Only a **timeout** is retried, and that means **124 or 137**. `timeout(1)` reports 124 when the
+child dies on TERM and 137 when it ignores TERM and `--kill-after` has to SIGKILL it. 137 is the
+one that matters here: a process wedged waiting on the model is exactly the kind that does not take
+TERM. Measured — a child trapping TERM exits 137, not 124. Any other non-zero status is codex
+failing on its own terms (a bad key, a `gh` error), where a retry would just spend another five
+minutes reaching the same conclusion.
 
 The job's 15-minute cap stays as the backstop — two attempts plus overhead fit inside it.
 
@@ -61,9 +64,19 @@ case per branch:
 | exits 3 immediately | **no retry**, exit 3 |
 | succeeds | exit 0, one attempt |
 | hangs once, then succeeds | **exit 0 on attempt 2** — the case actually being hit |
+| ignores TERM, hangs forever | two attempts (137 each), then fail |
+| ignores TERM once, then succeeds | **exit 0 on attempt 2** |
 
 Plus `bash -n` on the step's script and a YAML parse asserting the prompt still carries the
 `CODEX VERDICT:` marker the `gh-review-loop` skill reads.
+
+## Review follow-up
+
+**Codex: 137 was being treated as "not a timeout".** Correct, and it would have defeated the whole
+change: with `--kill-after` set, a child that ignores TERM exits 137, and a process wedged on a
+model call is precisely one that ignores TERM. The first version retried only on 124, so the most
+likely real-world hang would have been classified as a genuine failure and not retried. Measured
+both paths locally before fixing, and added the two TERM-ignoring cases to the table above.
 
 ## What this does not do
 


### PR DESCRIPTION
## Summary

Closes #1020。

`codex exec` は**遅いのではなく止まる**。ハングした実行のログ（#974、1 回目）:

```
22:52:27  [{"url":".../issues/comments/5097680212", …   ← PR スレッドの読み込みが完了
          （15 分間、出力が 1 行も無い）
23:07:24  ##[error]The operation was canceled.
23:07:24  Terminate orphan process: pid (2418) (codex)
```

プロンプトが指示する「既存スレッドを読む」ところまで進み、モデルを呼びに行って戻ってこない。
ジョブは `timeout-minutes` を丸ごと使い切り、`codex` プロセスが orphan として残る。

**これは #960 の前提を覆す。** あの対応は「たまにレビューが遅い」という理解で上限を 10 → 15 分に
上げたが、**ハングは上限が何分でも必ずそこまで行く**。結果として**待ち時間を 5 分増やしただけ**だった。
2 日で 4 回発生（#945 / #951 / #952 / #974）、いずれも**同じコミットの rerun が約 1 分で成功**している。

## 変更

`codex exec` に**独自の期限**（`CODEX_TIMEOUT_SECONDS` = 300）と**1 回のリトライ**を付けた。
正常なレビューは 30 秒〜2 分なので、5 分は通常の外側で、ジョブの上限より十分内側。

**リトライするのはタイムアウトのときだけ。** `timeout(1)` は自身の期限切れを 124 で返す。
それ以外の非ゼロは codex 自身の失敗（キー不正、`gh` のエラー）で、リトライしても
同じ結論に 5 分かけるだけなので即座に諦める。

ジョブの 15 分は保険として残す（2 回分＋オーバーヘッドが収まる）。

## Items to Confirm / Review

- **危うく入れかけたバグを 1 つ潰した。** 最初の版はこう書いていた:

  ```bash
  if timeout … codex exec …; then exit 0; fi
  status=$?
  ```

  `if` の後の `$?` は**コマンドではなく if 文自体**のステータス（0）なので、**124 の判定が
  一度も効かない**。読むと正しく見えて、実際は動かない。`|| status=$?` で捕捉する形に直した。

- **ワークフローは CI でしか動かないので、リトライ部分を抜き出してローカルで実行**して確かめた
  （分岐ごとにスタブ）:

  | スタブ | 結果 |
  | --- | --- |
  | ずっとハング | 2 回試して失敗（exit 1） |
  | 即 exit 3 | **リトライせず** exit 3 |
  | 成功 | 1 回で exit 0 |
  | 1 回ハング→2 回目成功 | **attempt 2 で exit 0** ← 実際に踏んでいたケース |

  加えて step のスクリプトに `bash -n`、YAML をパースして
  **`CODEX VERDICT:` マーカーがプロンプトに残っている**こと（`gh-review-loop` スキルが読む契約）を確認。

- **これはハングの原因を説明していない。** モデル呼び出しにクライアント側タイムアウトが無いのか、
  上流で詰まっているのかは #1020 に残る。この PR は**ハングが 15 分と手動 rerun を要求するのをやめさせる**だけ。

- 300 秒という数字に強い根拠はない（観測された正常値は 30 秒〜2 分）。1 行で変えられる。

## User Prompt

> ん？どうなの？fixしているの？PR

（直前に #1020 を issue 化したが実装していなかった流れ）

## Verification

`bash -n` / YAML パース / リトライロジックの 4 分岐をローカル実行。
アプリのコードには触れていないので `yarn` 系のチェックは対象外。

**この PR 自身の `codex-review` が新しいロジックで走るので、それが通ること自体が動作確認になる。**

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated review reliability by detecting stalled operations earlier.
  * Added a controlled retry when a review attempt times out.
  * Prevented non-timeout failures from being silently retried.

* **Documentation**
  * Added implementation guidance, validation notes, and follow-up information for handling stalled reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->