### PR TITLE
fix(phone): 再起動を生き延びたセッションの cwd を覚える (#1021)

### DIFF
--- a/plans/fix-1021-remember-session-cwd.md
+++ b/plans/fix-1021-remember-session-cwd.md
@@ -1,0 +1,50 @@
+# 再起動を生き延びたセッションの cwd を覚える
+
+Issue: #1021
+
+## 症状
+
+スマホのセッション一覧で、tmux にだけ残っているセッション（サーバ再起動を生き延びたもの）は
+`cwd` が空で、#1014 で足した `work`（取り組んでいる issue / PR）も付かない。
+
+## 原因
+
+サーバが cwd を覚えていない。`detailOf` は `ptys.get(id)?.cwd ?? ""` で、`ptys` はこのプロセスが
+spawn した PTY の表。永続化しているのは **ID だけ**（`dev-terminal-sessions.json` は 1 行 1 ID の
+追記ログ）で、`KnownSession` も `{ createdAt, title }`。
+
+## 直し方
+
+**記録するときに cwd も残す。** `markDevTerminalSession()` の呼び出し元（`ws-routes.ts`）は
+すぐ隣で `wsConnectionContext(req)` から cwd を受け取っているので、渡すだけ。
+
+### 既存ファイルは触らない（重要）
+
+`dev-terminal-sessions.json` は**複数バージョンが共有する追記専用ファイル**。形式を
+`[{id, cwd}]` に変えると古い版のパーサが文字列以外を落とし、古い版から見てグリッドの
+セッションが 0 件になる = このファイルが防いでいる「グリッドの transcript がチャットに漏れる」
+状態そのものになる（#966 と同じ種類の罠）。
+
+**cwd は別ファイル `dev-terminal-cwds.json`** に、同じ追記ログ形式で持つ。古い版は知らない
+ファイルを無視し、新しい版だけが読む。移行コードは不要。
+
+## 変更
+
+1. `server/session/dev-terminal-cwds.ts`（新規）— 1 行 1 レコードの追記ログの読み書き。
+   純関数（parse / line 生成）を分けて単体テストする。同じ id が複数行あるときは**最後が勝つ**
+   （同じセルが別ディレクトリで作り直された場合、新しいほうが正しい）。
+2. `registry.ts` — `markDevTerminalSession(id, cwd)` に cwd を足し、ログに追記。boot で
+   hydrate して `sessionCwd(id)` で引けるようにする。
+3. `ws-routes.ts` の 3 か所の呼び出しに cwd を渡す。
+4. `server/index.ts` の `detailOf` — `ptys.get(id)?.cwd ?? sessionCwd(id) ?? ""`。
+   **live が優先**（PTY の cwd が真実。reattach で ?cwd= を無視するのと同じ理由）。
+   `workByCwd` に渡す cwd も同じ経路になるので、work も自然に付く。
+
+## テスト
+
+- パーサ: 1 行 1 レコード / 壊れた行を捨てる / 同じ id は最後が勝つ / 空ファイル
+- 追記行: 改行が**先頭**（既存ファイルの末尾に welded しないため。ID 側と同じ理由）
+- `sessionCwd`: 覚えていない id は null
+- 一覧: live は PTY の cwd、tmux だけのセッションは覚えた cwd、どちらも無ければ空
+- **古い版が読めること**: ID のファイルは形式が変わっていない（このファイルに触っていないことを
+  spec で固定する意味は薄いので、代わりに「cwd ログのパーサは ID ログを読まない」を確認）

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,7 +46,7 @@ import { generateHeaderTitle } from "./config/header-title.js";
 import { mountTerminalWebSockets } from "./routes/ws-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
-import { activity, aiTitles, devTerminalSessions, hiddenSessions, knownSessions, lastPrompts, ptys } from "./session/registry.js";
+import { activity, aiTitles, devTerminalSessions, hiddenSessions, knownSessions, lastPrompts, ptys, sessionCwd } from "./session/registry.js";
 import { runWithHiddenMarker } from "./session/hiddenMarker.js";
 import { createToolStores } from "./session/tool-store.js";
 import { writeDecisionDigest } from "./session/decision-digest-file.js";
@@ -441,8 +441,11 @@ const workByCwd = async (cwds: readonly string[]): Promise<Map<string, SessionWo
 };
 
 const remoteHostListTerminalSessions = async () => {
-  const cwdOfSession = (id: string) => ptys.get(id)?.cwd ?? "";
-  const work = await workByCwd([...ptys.keys()].map(cwdOfSession));
+  // A live PTY knows where claude actually runs, so it wins. A session that outlived this process
+  // has none — that is what the remembered cwd is for (#1021), and without it the phone shows the
+  // row with no directory and no work item.
+  const cwdOfSession = (id: string) => ptys.get(id)?.cwd ?? sessionCwd(id) ?? "";
+  const work = await workByCwd([...new Set([...ptys.keys(), ...tmuxListSessionIds()])].map(cwdOfSession));
   return buildSessionList({
     liveIds: [...ptys.keys()],
     tmuxIds: tmuxListSessionIds(),

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -235,7 +235,7 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: { u
   // it's excluded from the chat sidebar (see devTerminalSessions). This is the single
   // choke point for every grid attach — new, resumed, or reattached — so the mark is
   // recorded (and re-recorded after a reboot when the cell reconnects) exactly once.
-  if (!attachGuiMcp) markDevTerminalSession(sessionId);
+  if (!attachGuiMcp) markDevTerminalSession(sessionId, cwd);
 
   // Tell the browser which session this is (it learns the id of new sessions) and
   // the EFFECTIVE cwd — where claude really runs. On reattach that's the live
@@ -307,7 +307,7 @@ function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: s
   const resolved = resolveLaunchSession(deps, requested, index, shell);
   if (!resolved) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
   const { sessionId, live, command } = resolved;
-  markDevTerminalSession(sessionId);
+  markDevTerminalSession(sessionId, cwd);
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
   let entry: PtyEntry;
@@ -330,7 +330,7 @@ function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: st
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
-  if (!attachGuiMcp) markDevTerminalSession(sessionId);
+  if (!attachGuiMcp) markDevTerminalSession(sessionId, cwd);
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
   let entry: PtyEntry;

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -71,6 +71,19 @@ function resolveClaudeSession(requested: string | null, cwd: string): SessionRes
 // session id, and the resolved cwd. A non-UUID session id is treated as "no
 // session" — it could otherwise smuggle path/flag fragments into
 // sessionExistsOnDisk / --resume — and cwd (?cwd=<abs>) falls back to CLAUDE_CWD.
+/**
+ * Where a session actually runs, for the value that gets REMEMBERED (#1021).
+ *
+ * A reattach often carries no `?cwd=` — and `resolveWorkspace` answers the default workspace when
+ * it is missing, so trusting the request would record CLAUDE_CWD for a session running somewhere
+ * else entirely, and the phone would later show that directory's PR (found by Codex review). The
+ * live PTY knows where claude really is; the request only decides where a NEW one will spawn.
+ * Same rule the `session` message already follows when it reports the cwd back to the browser.
+ */
+export function effectiveSessionCwd(liveCwd: string | undefined, requestCwd: string): string {
+  return liveCwd ?? requestCwd;
+}
+
 function wsConnectionContext(req: { url?: string }): { url: URL; requested: string | null; cwd: string } {
   const url = new URL(req.url ?? "/", "http://localhost");
   const raw = url.searchParams.get("session");
@@ -235,7 +248,7 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: { u
   // it's excluded from the chat sidebar (see devTerminalSessions). This is the single
   // choke point for every grid attach — new, resumed, or reattached — so the mark is
   // recorded (and re-recorded after a reboot when the cell reconnects) exactly once.
-  if (!attachGuiMcp) markDevTerminalSession(sessionId, cwd);
+  if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
 
   // Tell the browser which session this is (it learns the id of new sessions) and
   // the EFFECTIVE cwd — where claude really runs. On reattach that's the live
@@ -307,7 +320,7 @@ function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: s
   const resolved = resolveLaunchSession(deps, requested, index, shell);
   if (!resolved) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
   const { sessionId, live, command } = resolved;
-  markDevTerminalSession(sessionId, cwd);
+  markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
   let entry: PtyEntry;
@@ -330,7 +343,7 @@ function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: st
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
-  if (!attachGuiMcp) markDevTerminalSession(sessionId, cwd);
+  if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
   let entry: PtyEntry;

--- a/server/session/dev-terminal-cwds.ts
+++ b/server/session/dev-terminal-cwds.ts
@@ -45,6 +45,19 @@ export function parseDevTerminalCwds(contents: string, isValidId: (id: string) =
 }
 
 /**
+ * Fill `target` from a log, WITHOUT overwriting what is already there.
+ *
+ * Hydration is async and a reconnect can record a cwd before it finishes; the in-memory value then
+ * came from a live connection and the file's is older by definition. Overwriting it would answer
+ * with the directory a session used to be in (found by Codex review).
+ */
+export function hydrateCwdsInto(target: Map<string, string>, contents: string, isValidId: (id: string) => boolean): void {
+  parseDevTerminalCwds(contents, isValidId).forEach((cwd, id) => {
+    if (!target.has(id)) target.set(id, cwd);
+  });
+}
+
+/**
  * What to append for a session.
  *
  * The newline goes BEFORE the record, exactly as in the id log: a file that ended without one

--- a/server/session/dev-terminal-cwds.ts
+++ b/server/session/dev-terminal-cwds.ts
@@ -1,0 +1,55 @@
+// Which directory each grid session was started in, as it is read from and written back to disk.
+//
+// The phone's session list shows a directory, and #1014 resolves the cell's PR/issue from it — but
+// both read `ptys`, the table of PTYs THIS process spawned. A session that outlived a restart is
+// not in it, so it arrived on the phone with no directory and no work item (#1021). Nothing else
+// remembered where it was running: the id log next door stores ids and nothing more.
+//
+// A SEPARATE file from that id log, deliberately. Both are shared between instances — and between
+// VERSIONS, since ~/.mulmoterminal is one directory for every server on the machine. Widening the
+// id log's lines to carry a cwd would make an older build's parser drop every line (it keeps
+// strings only), and that log exists to keep grid transcripts out of the chat sidebar: an older
+// build would quietly bring that bug back. A new file it has never heard of is simply ignored.
+//
+// Same append-log shape as the id log, for the same reason: two instances writing at once cannot
+// lose each other's entries when nobody reads before writing.
+
+export interface DevTerminalCwd {
+  id: string;
+  cwd: string;
+}
+
+/** One line: `<id> <absolute path>`. The id cannot contain a space, so the first one splits it. */
+function recordFromLine(line: string, isValidId: (id: string) => boolean): DevTerminalCwd | null {
+  const text = line.trim();
+  const at = text.indexOf(" ");
+  if (at <= 0) return null;
+  const id = text.slice(0, at);
+  const cwd = text.slice(at + 1).trim();
+  return isValidId(id) && cwd !== "" ? { id, cwd } : null;
+}
+
+/**
+ * The directories a file holds, id → cwd.
+ *
+ * The LAST entry for an id wins: the same cell can be relaunched somewhere else, and the log only
+ * ever grows, so the newest line is the current answer.
+ */
+export function parseDevTerminalCwds(contents: string, isValidId: (id: string) => boolean): Map<string, string> {
+  const out = new Map<string, string>();
+  contents.split("\n").forEach((line) => {
+    const record = recordFromLine(line, isValidId);
+    if (record) out.set(record.id, record.cwd);
+  });
+  return out;
+}
+
+/**
+ * What to append for a session.
+ *
+ * The newline goes BEFORE the record, exactly as in the id log: a file that ended without one
+ * would otherwise weld this record onto the previous line and lose both.
+ */
+export function devTerminalCwdLine(id: string, cwd: string): string {
+  return `\n${id} ${cwd}`;
+}

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -14,6 +14,7 @@ import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { devTerminalSessionLine, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
+import { devTerminalCwdLine, parseDevTerminalCwds } from "./dev-terminal-cwds.js";
 import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET, type SessionToolGroup } from "./session-tool-groups.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
@@ -138,10 +139,42 @@ function appendDevTerminalSession(id: string): void {
 // Record a grid/dev-terminal session id, then persist. A no-op once the id is known,
 // so repeated reattaches of the same cell — or a reconnect after a reboot — don't
 // rewrite the file.
-export function markDevTerminalSession(id: string): void {
+export function markDevTerminalSession(id: string, cwd?: string): void {
+  // The cwd is recorded even for an id we already knew: this is the one place that sees a cell's
+  // directory, and a session relaunched somewhere else must not keep answering with the old one.
+  if (SESSION_ID_RE.test(id) && cwd) rememberSessionCwd(id, cwd);
   if (!SESSION_ID_RE.test(id) || devTerminalSessions.has(id)) return;
   devTerminalSessions.add(id);
   appendDevTerminalSession(id);
+}
+
+// Where each grid session was started, for the sessions this process did not spawn (#1021). Live
+// ones answer from `ptys`, which is the truer source — it knows where claude actually runs.
+const sessionCwds = new Map<string, string>();
+const DEV_TERMINAL_CWDS_FILE = path.join(MULMOTERMINAL_HOME, "dev-terminal-cwds.json");
+
+export const devTerminalCwdsHydrated: Promise<void> = (async () => {
+  try {
+    const contents = await fs.readFile(DEV_TERMINAL_CWDS_FILE, "utf8");
+    parseDevTerminalCwds(contents, isValidSessionId).forEach((cwd, id) => sessionCwds.set(id, cwd));
+  } catch {
+    // absent on first run, unreadable => nothing remembered; the list degrades to today's behaviour
+  }
+})();
+
+/** The remembered directory for a session, or null. */
+export function sessionCwd(id: string): string | null {
+  return sessionCwds.get(id) ?? null;
+}
+
+let devTerminalCwdPersist: Promise<void> = Promise.resolve();
+function rememberSessionCwd(id: string, cwd: string): void {
+  if (sessionCwds.get(id) === cwd) return; // already the answer; appending would only grow the log
+  sessionCwds.set(id, cwd);
+  devTerminalCwdPersist = devTerminalCwdPersist
+    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+    .then(() => fs.appendFile(DEV_TERMINAL_CWDS_FILE, devTerminalCwdLine(id, cwd)))
+    .catch((e) => console.error(`[dev-terminal-cwds] failed to persist: ${messageOf(e)}`));
 }
 
 // Which GUI tool groups a session actually has. Learned from the group URLs it connects to

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -14,7 +14,7 @@ import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { devTerminalSessionLine, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
-import { devTerminalCwdLine, parseDevTerminalCwds } from "./dev-terminal-cwds.js";
+import { devTerminalCwdLine, hydrateCwdsInto } from "./dev-terminal-cwds.js";
 import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET, type SessionToolGroup } from "./session-tool-groups.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
 import type { Activity, KnownSession, PtyEntry } from "./types.js";
@@ -155,8 +155,7 @@ const DEV_TERMINAL_CWDS_FILE = path.join(MULMOTERMINAL_HOME, "dev-terminal-cwds.
 
 export const devTerminalCwdsHydrated: Promise<void> = (async () => {
   try {
-    const contents = await fs.readFile(DEV_TERMINAL_CWDS_FILE, "utf8");
-    parseDevTerminalCwds(contents, isValidSessionId).forEach((cwd, id) => sessionCwds.set(id, cwd));
+    hydrateCwdsInto(sessionCwds, await fs.readFile(DEV_TERMINAL_CWDS_FILE, "utf8"), isValidSessionId);
   } catch {
     // absent on first run, unreadable => nothing remembered; the list degrades to today's behaviour
   }

--- a/test/server/routes/effective-session-cwd.spec.ts
+++ b/test/server/routes/effective-session-cwd.spec.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+// Which directory gets REMEMBERED for a session (#1021). A reattach usually carries no `?cwd=`,
+// and the resolver answers the default workspace when it is missing — so recording the request's
+// value would file a session under CLAUDE_CWD while claude runs somewhere else, and the phone
+// would then show that directory's PR (found by Codex review).
+import { describe, it, expect } from "vitest";
+import { effectiveSessionCwd } from "../../../server/routes/ws-routes";
+
+describe("effectiveSessionCwd", () => {
+  it("takes the live PTY's directory when there is one", () => {
+    expect(effectiveSessionCwd("/work/real", "/home/me/workspace")).toBe("/work/real");
+  });
+
+  // A brand-new session has no PTY yet; the request decides where it will spawn.
+  it("falls back to the request's directory for a new session", () => {
+    expect(effectiveSessionCwd(undefined, "/work/new")).toBe("/work/new");
+  });
+
+  it("prefers the live directory even when the two agree", () => {
+    expect(effectiveSessionCwd("/work/same", "/work/same")).toBe("/work/same");
+  });
+});

--- a/test/server/session/dev-terminal-cwds.spec.ts
+++ b/test/server/session/dev-terminal-cwds.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+// The log that remembers where each grid session was started (#1021). It is read by a build that
+// may be older or newer than the one that wrote it, and appended to by several instances at once,
+// so what a line means — and what an unusable one costs — is pinned here.
+import { describe, it, expect } from "vitest";
+import { devTerminalCwdLine, parseDevTerminalCwds } from "../../../server/session/dev-terminal-cwds";
+
+const ID_A = "bf488420-850f-4dcb-931c-727614d6eaf7";
+const ID_B = "33149419-234b-4d31-bd8c-341290f4c090";
+const isValidId = (id: string) => /^[0-9a-f-]{36}$/.test(id);
+
+describe("parseDevTerminalCwds", () => {
+  it("reads one record per line", () => {
+    const log = `${devTerminalCwdLine(ID_A, "/work/one")}${devTerminalCwdLine(ID_B, "/work/two")}`;
+    expect([...parseDevTerminalCwds(log, isValidId)]).toEqual([
+      [ID_A, "/work/one"],
+      [ID_B, "/work/two"],
+    ]);
+  });
+
+  // The log only grows, so a cell relaunched somewhere else appends a second line for the same id.
+  it("lets the last entry for an id win", () => {
+    const log = `${devTerminalCwdLine(ID_A, "/work/old")}${devTerminalCwdLine(ID_A, "/work/new")}`;
+    expect(parseDevTerminalCwds(log, isValidId).get(ID_A)).toBe("/work/new");
+  });
+
+  it("keeps a path that contains spaces", () => {
+    expect(parseDevTerminalCwds(devTerminalCwdLine(ID_A, "/work/my project"), isValidId).get(ID_A)).toBe("/work/my project");
+  });
+
+  it.each([
+    ["an empty file", ""],
+    ["blank lines", "\n\n   \n"],
+    ["an id with no path", ID_A],
+    ["a path with no id", " /work/one"],
+    ["something that is not a session id", "not-an-id /work/one"],
+  ])("drops %s rather than guessing", (_label, contents) => {
+    expect([...parseDevTerminalCwds(contents, isValidId)]).toEqual([]);
+  });
+
+  // The two logs live side by side in ~/.mulmoterminal. Reading the wrong one must yield nothing
+  // rather than nonsense — an id log line is a bare id, which has no path to take.
+  it("reads nothing out of the id log next door", () => {
+    expect([...parseDevTerminalCwds(`\n${ID_A}\n${ID_B}`, isValidId)]).toEqual([]);
+  });
+
+  it("survives a torn last line", () => {
+    const log = `${devTerminalCwdLine(ID_A, "/work/one")}\n${ID_B} `;
+    expect([...parseDevTerminalCwds(log, isValidId)]).toEqual([[ID_A, "/work/one"]]);
+  });
+});
+
+describe("devTerminalCwdLine", () => {
+  // Same rule as the id log: a file that ended without a newline would otherwise weld this record
+  // onto the previous line and lose both.
+  it("starts its own line", () => {
+    expect(devTerminalCwdLine(ID_A, "/work/one").startsWith("\n")).toBe(true);
+  });
+
+  it("round-trips through the parser", () => {
+    const line = devTerminalCwdLine(ID_A, "/work/one");
+    expect(parseDevTerminalCwds(`existing content${line}`, isValidId).get(ID_A)).toBe("/work/one");
+  });
+});

--- a/test/server/session/dev-terminal-cwds.spec.ts
+++ b/test/server/session/dev-terminal-cwds.spec.ts
@@ -3,7 +3,7 @@
 // may be older or newer than the one that wrote it, and appended to by several instances at once,
 // so what a line means — and what an unusable one costs — is pinned here.
 import { describe, it, expect } from "vitest";
-import { devTerminalCwdLine, parseDevTerminalCwds } from "../../../server/session/dev-terminal-cwds";
+import { devTerminalCwdLine, hydrateCwdsInto, parseDevTerminalCwds } from "../../../server/session/dev-terminal-cwds";
 
 const ID_A = "bf488420-850f-4dcb-931c-727614d6eaf7";
 const ID_B = "33149419-234b-4d31-bd8c-341290f4c090";
@@ -60,5 +60,31 @@ describe("devTerminalCwdLine", () => {
   it("round-trips through the parser", () => {
     const line = devTerminalCwdLine(ID_A, "/work/one");
     expect(parseDevTerminalCwds(`existing content${line}`, isValidId).get(ID_A)).toBe("/work/one");
+  });
+});
+
+// Hydration reads the file asynchronously at boot, and a cell reconnecting in that window records
+// its cwd first. The file's value is older by definition — overwriting the fresh one would answer
+// with the directory a session used to be in (found by Codex review).
+describe("hydrateCwdsInto", () => {
+  it("fills what is missing", () => {
+    const target = new Map<string, string>();
+    hydrateCwdsInto(target, devTerminalCwdLine(ID_A, "/work/one"), isValidId);
+    expect(target.get(ID_A)).toBe("/work/one");
+  });
+
+  it("does not overwrite a cwd recorded while it was reading", () => {
+    const target = new Map([[ID_A, "/work/live"]]);
+    hydrateCwdsInto(target, devTerminalCwdLine(ID_A, "/work/from-disk"), isValidId);
+    expect(target.get(ID_A)).toBe("/work/live");
+  });
+
+  it("still fills the OTHER ids in the same file", () => {
+    const target = new Map([[ID_A, "/work/live"]]);
+    hydrateCwdsInto(target, `${devTerminalCwdLine(ID_A, "/work/from-disk")}${devTerminalCwdLine(ID_B, "/work/two")}`, isValidId);
+    expect([...target]).toEqual([
+      [ID_A, "/work/live"],
+      [ID_B, "/work/two"],
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

サーバ再起動を生き延びた（tmux にだけ残っている）セッションが、スマホの一覧で **cwd も `work` も持たない**問題（#1021）。原因は tmux に聞けないことではなく、**サーバが cwd を覚えていない**ことでした。

`markDevTerminalSession()` の呼び出し元は `wsConnectionContext(req)` から **cwd を既に受け取っています**。渡す先を増やして記録するだけで、新しい情報源は要りません。

Fixes #1021

## Items to Confirm / Review

1. **既存の `dev-terminal-sessions.json` には触っていません。** あれは複数バージョンが共有する追記ログで、行の形を `[{id, cwd}]` のように変えると**古い版のパーサが全行を落とし**、あのファイルが防いでいる「グリッドの transcript がチャット一覧に漏れる」状態そのものになります（#966 と同じ種類の罠）。cwd は**別ファイル**に同じ追記ログ形式で持たせたので、古い版は知らないファイルを無視し、**移行コードも要りません**。
2. **live なセッションは今までどおり PTY の cwd が勝ちます。** claude が実際に走っている場所が真実で、reattach 時に `?cwd=` を無視するのと同じ理由です。覚えた cwd はそれが無いときだけ使います。
3. **当初この issue には「tmux に `#{pane_current_path}` を聞く」と書いていました。** そちらは (a) セッションごとの問い合わせが 1 セット増える、(b) **cwd の意味が「始めた場所」から「今いる場所」に変わる**（セッション内で `cd` すると別リポジトリの PR が出る）、(c) `gh` も増える、の 3 つがついてきます。覚えれば 3 つとも消えるので切り替えました。issue にも経緯を残してあります。

## User Prompt

> あーー、結構複雑なことになるの？普通にapiをよいかとおもったけど、良く考えたらコマンドベースなんだよね。って今の課題と関係ある？
>
> はい。書き直してすすめてください

## 変更

| ファイル | 中身 |
| --- | --- |
| `server/session/dev-terminal-cwds.ts`（新規） | 1 行 1 レコード（`<id> <path>`）の追記ログ。パーサと行生成の純関数 |
| `server/session/registry.ts` | `markDevTerminalSession(id, cwd?)`、boot での hydrate、`sessionCwd(id)` |
| `server/routes/ws-routes.ts` | 3 か所の呼び出しに cwd を渡す |
| `server/index.ts` | `ptys.get(id)?.cwd ?? sessionCwd(id) ?? ""`。`work` の解決対象も tmux のセッションまで広げる |

同じ id の行が複数あれば**最後が勝ちます**（同じセルが別ディレクトリで作り直された場合、新しいほうが正しい）。

## テスト（新規 12 件）

- 1 行 1 レコードで読める / **最後の行が勝つ** / パスに空白が含まれても壊れない
- 使えない行は捨てる（id だけ・パスだけ・id の形式違い・空・空白行）
- **隣の ID ログを読んでも何も出てこない**（2 つのファイルが同じディレクトリに並ぶため）
- 途中で切れた最終行を無視して、その前までは読める
- 追記行が**改行で始まる**（既存ファイルの末尾に welded しないため。ID ログと同じ規則）

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（5663 passed）/ `build` 実行済み。

## 確認していないこと

**実際に再起動をまたいだ表示は見ていません。** ローカルで再起動を挟むと、あなたの動いているインスタンスに影響しかねないためです。ログの読み書きとフォールバックの順序はテストで固定してあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
