### PR TITLE
fix: セッション要約が loop / skill を止める理由にならないようにする (#1027)

### DIFF
--- a/server/agents/session-summary-prompt.ts
+++ b/server/agents/session-summary-prompt.ts
@@ -15,6 +15,10 @@
 //     then skipped a finished one-file task too, which is exactly the moment worth summarizing.
 //   - The request to state is the conversation's, not the last message's. Refining details
 //     over several turns must not overwrite what was asked in the first place.
+//   - The summary must never read as a REASON to stop (#1027). Stating only when to write one
+//     left the direction of causality open, and the model took writing one as licence to hand
+//     back — mid-/loop, mid-skill, wherever the work reached a checkpoint that looked tidy.
+//     Those runs have many such checkpoints, so the misfire was routine rather than rare.
 //
 // One constraint on the CHARACTERS, not the wording: no ASCII double quote. This text rides in
 // the argv of a Windows spawn, where the whole point of moving the JSON payloads to files was
@@ -32,6 +36,12 @@ Two things disqualify a reply, and only these two. You are still working — mor
 coming, a plan half executed. Or there was no work to speak of: a factual question you answered
 from knowledge, a greeting, an acknowledgement. A small task still gets a summary; “it was only
 one file” is not a reason to skip it.
+
+The summary reports that you stopped; it never causes you to stop. Settle whether the work is
+finished first, and write it only then. While a run is still going — one turn of a /loop, a step
+inside a skill, a background task you are waiting on — control has not come back to the user, so
+there is nothing to close: keep working and summarize once the whole run is done. Reaching a tidy
+checkpoint is not a reason to stop, and neither is having something worth reporting.
 
 What it says, one or two sentences each:
 


### PR DESCRIPTION
## Summary

#942 で入れた `SESSION_SUMMARY_PROMPT`（全セッションの system prompt に注入される 3 行要約の指示）に、**loop や skill の実行中に要約を出してそこで止まる**という副作用が出ていました。

**原因は除外条件の不足ではなく、因果の向きが書かれていないことです。**

今の文面は「要約を出す条件」と「出さない 2 つの場合」しか言っておらず、**要約は停止の報告であって停止の原因ではない**、と言っていません。そのため「要約を書ける」こと自体が手を止める口実になります。`/loop` や skill には**区切りが良く見える中間地点**が何度もあるので、誤発火は例外ではなく日常でした。

足した段落:

> The summary reports that you stopped; it never causes you to stop. Settle whether the work is
> finished first, and write it only then. While a run is still going — one turn of a /loop, a step
> inside a skill, a background task you are waiting on — control has not come back to the user, so
> there is nothing to close: keep working and summarize once the whole run is done. Reaching a tidy
> checkpoint is not a reason to stop, and neither is having something worth reporting.

## Items to Confirm / Review

- **除外条件を増やしていません。** モジュールのコメントが「除外は CLOSED であり、大きさではなく返信の性質で決まる」を守れと書いており、以前「迷ったら省く」を足したら**終わった一ファイルの作業まで省くようになった**という記録があります。今回は除外ではなく因果を書く形にしました
- **`/loop` と skill を名指し**しました。抽象的に「作業中は出すな」と書くだけでは今回の誤発火が防げていなかったので、実際に誤発火する場所を文中に置いています
- **予算**: 2069 バイト（spec の上限 4096）。全リクエストに乗るので、増やしたのは 5 行だけです
- ASCII ダブルクォートなし（Windows argv、#813）、絵文字なし — spec が両方固定しています
- **効果の確認は実運用でしかできません。** プロンプトの文面変更なので、テストで証明できるのは不変条件（サイズ・文字種）だけです。しばらく loop を回して、途中で止まらなくなったか見てください

## User Prompt

> 今日くらいに、システムプロンプトに、loop の最後などに 3 行でまとめを出すように指示追加したけど、loop 中にまとめを出して止まるケースがある。loop/skill は最後までやりきってからレポートしてほしい。途中で止めないで。という変更できそう？

## Test plan

- `test/server/agents/session-summary-prompt.spec.ts`（4 件、既存）— サイズ上限・絵文字なし・単一 argv として無事・ASCII ダブルクォートなし。文面そのものは**意図的にテストしていません**（spec の方針: 「言うべきこと」はモジュールのコメント、「なってはいけない形」がテスト）
- `yarn format` / `lint` / `typecheck:server` / `typecheck:test` / `test`（5651 passed）

Fixes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)