### PR TITLE
fix(ci): Windows で preset パスの期待値を解決する（#1002 の漏れ）

### DIFF
--- a/test/server/config/app-config.spec.ts
+++ b/test/server/config/app-config.spec.ts
@@ -269,7 +269,9 @@ describe("loadAppConfig / saveAppConfig", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
     const cfg = {
-      cwdPresets: [{ label: "x", path: "/x" }],
+      // Canonical already: saving canonicalises (#1002), and on Windows that adds the current
+      // drive — a POSIX literal here would not survive its own round trip.
+      cwdPresets: [{ label: "x", path: path.resolve("/x") }],
       soundFile: "/s.wav",
       soundKinds: [...DEFAULT_SOUND_KINDS],
       sounds: {},
@@ -326,7 +328,7 @@ describe("loadAppConfig / saveAppConfig", () => {
       }),
     );
     expect(loadAppConfig(file)).toEqual({
-      cwdPresets: [{ label: "a", path: "/a" }],
+      cwdPresets: [{ label: "a", path: path.resolve("/a") }],
       soundFile: null,
       soundKinds: [...DEFAULT_SOUND_KINDS],
       sounds: {},
@@ -366,7 +368,7 @@ describe("loadAppConfig / saveAppConfig", () => {
     const dir = tmp();
     const file = path.join(dir, "config.json");
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }] }));
-    expect(loadAppConfig(file)).toEqual({ ...base, cwdPresets: [{ label: "a", path: "/a" }] });
+    expect(loadAppConfig(file)).toEqual({ ...base, cwdPresets: [{ label: "a", path: path.resolve("/a") }] });
     rmSync(dir, { recursive: true, force: true });
   });
 });
@@ -393,7 +395,7 @@ describe("loadAppConfigResult (missing vs corrupt vs ok)", () => {
     const file = path.join(dir, "config.json");
     writeFileSync(file, JSON.stringify({ cwdPresets: [{ label: "a", path: "/a" }], pushEnabled: true }));
     const loaded = loadAppConfigResult(file);
-    expect(loaded).toMatchObject({ status: "ok", config: { cwdPresets: [{ label: "a", path: "/a" }], pushEnabled: true } });
+    expect(loaded).toMatchObject({ status: "ok", config: { cwdPresets: [{ label: "a", path: path.resolve("/a") }], pushEnabled: true } });
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -433,7 +435,7 @@ describe("backupCorruptConfig", () => {
 // that a merge writes back. This is what a POST /api/config write path must do.
 describe("#741 corrupt config is not silently wiped by a partial update", () => {
   const richConfig = {
-    cwdPresets: [{ label: "proj", path: "/proj" }],
+    cwdPresets: [{ label: "proj", path: path.resolve("/proj") }],
     soundFile: null,
     soundKinds: [...DEFAULT_SOUND_KINDS],
     sounds: {},

--- a/test/server/config/cwd-presets.spec.ts
+++ b/test/server/config/cwd-presets.spec.ts
@@ -31,7 +31,10 @@ describe("savePresets / loadPresets", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
     expect(savePresets(file, [{ label: "x", path: "/x" }])).toBe(true);
-    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ cwdPresets: [{ label: "x", path: path.resolve("/x") }] });
+    // savePresets writes what it is given; canonicalisation happens on the way back IN
+    // (sanitizePresets, #1002). So the file keeps the literal, and only the load is resolved —
+    // which on Windows is where `/x` picks up the current drive.
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ cwdPresets: [{ label: "x", path: "/x" }] });
     expect(loadPresets(file)).toEqual([{ label: "x", path: path.resolve("/x") }]);
     rmSync(dir, { recursive: true, force: true });
   });

--- a/test/server/config/cwd-presets.spec.ts
+++ b/test/server/config/cwd-presets.spec.ts
@@ -31,8 +31,8 @@ describe("savePresets / loadPresets", () => {
     const dir = tmp();
     const file = path.join(dir, "nested", "config.json"); // nested → mkdir is exercised
     expect(savePresets(file, [{ label: "x", path: "/x" }])).toBe(true);
-    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ cwdPresets: [{ label: "x", path: "/x" }] });
-    expect(loadPresets(file)).toEqual([{ label: "x", path: "/x" }]);
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ cwdPresets: [{ label: "x", path: path.resolve("/x") }] });
+    expect(loadPresets(file)).toEqual([{ label: "x", path: path.resolve("/x") }]);
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/test/server/config/unknown-config-keys.spec.ts
+++ b/test/server/config/unknown-config-keys.spec.ts
@@ -117,7 +117,7 @@ describe("carrying unknown keys through a save (#966)", () => {
       const onDisk = JSON.parse(readFileSync(file, "utf8"));
       expect(onDisk.futureFeature).toEqual({ mode: "fast" }); // the whole point
       expect(onDisk.prRepos).toEqual(["o/r"]); // and the known fields still round-trip
-      expect(onDisk.cwdPresets).toEqual([{ label: "x", path: "/x" }]);
+      expect(onDisk.cwdPresets).toEqual([{ label: "x", path: path.resolve("/x") }]);
     });
   });
 

--- a/test/server/infra/read-text-file.spec.ts
+++ b/test/server/infra/read-text-file.spec.ts
@@ -82,7 +82,7 @@ describe("the config readers, given a BOM", () => {
     const dir = tmp();
     const file = path.join(dir, "presets.json");
     writeFileSync(file, `${BOM}${JSON.stringify({ cwdPresets: [{ label: "repo", path: "/Users/me/repo" }] })}`, "utf8");
-    expect(loadPresets(file)).toEqual([{ label: "repo", path: "/Users/me/repo" }]);
+    expect(loadPresets(file)).toEqual([{ label: "repo", path: path.resolve("/Users/me/repo") }]);
   });
 
   // This one had the worst failure mode: the whole app config — providers, launchers, header


### PR DESCRIPTION
## Summary

`Windows (daily)` が main で失敗している（[run 30364110064](https://github.com/receptron/mulmoterminal/actions/runs/30364110064)）のを直す。**テストのみの変更。**

## 原因

`sanitizePresets` は preset のパスを正規化する（#1002。末尾スラッシュで同じディレクトリが
2 つのチップになるのを防ぐため）。その正規化は `canonicalDir` → `path.resolve`。

**Windows では `path.resolve("/x")` がカレントドライブを継ぎ足して `D:\x` になる。**
POSIX では `path.resolve("/x") === "/x"`（恒等）なので、Linux / macOS の CI では差が出ない。

```text
AssertionError: expected [ { label: 'x', path: 'D:\x' } ] to deeply equal [ { label: 'x', path: '/x' } ]
```

**#1002 は同じ問題を 1 箇所だけ直していた**（`cwd-presets.spec.ts:14` は既に `path.resolve("/a")` を
期待値にしている）。残りが漏れ、POSIX の CI では検出できないまま main に入った。

## 直し方

壊れ方が 2 種類あったので、それぞれ別に直した。

1. **読み込んだ preset を literal と比較している期待値** → ローダーと同じように `path.resolve` する
2. **保存してから読み戻す fixture**（round-trip の `cfg`、`richConfig`）→ **最初から正規形で書く**。
   そうしないと自分自身の round trip を通らない

## Items to Confirm / Review

- **`path.resolve` と `canonicalDir` が同じ結果になる根拠**: `canonicalDir` は
  `platformPath(platform).resolve` で、`platformPath` は `win32 ? path.win32 : path.posix`。
  一方テストの `path.resolve` は各 OS でその同じ実装を指すので、プラットフォームによらず一致する。
- **macOS では変更前後で挙動が同じ**（`path.resolve` が恒等）。つまりローカルのテストは
  「壊していないこと」しか示せない。**Windows のワークフローをこのブランチで手動実行して確認する**
  （`workflow_dispatch` があるので待たずに回せる）。
- 実装（`sanitizePresets` / `canonicalDir`）には触っていない。正規化そのものは #1002 の意図どおり。

## User Prompt

> fix https://github.com/receptron/mulmoterminal/actions/runs/30364110064

## Verification

`yarn format` / `lint` / `typecheck:test` / `test`（5734 passed、macOS）。
**Windows は手動 dispatch した run の結果で確認する。**

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated configuration and presets round-trip tests to match cross-platform path canonicalization, asserting saved values keep the provided literal path while loaded values return resolved absolute paths.
  * Adjusted expectations for cases including unknown keys, legacy presets shape, BOM-prefixed files, junk preset sanitization, and corrupt-config regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->