### PR TITLE
fix: grid の Canvas まわり — 判定の不具合 2 件と UI の不明瞭さ 3 件

### DIFF
--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -60,6 +60,11 @@ const GROUP_BY_TOOL = new Map<string, ToolGroup>([
 
 export const groupOfTool = (toolName: string): ToolGroup | null => GROUP_BY_TOOL.get(toolName) ?? null;
 
+// Every tool in a group, in the order declared above. The Canvas panel's empty state names them,
+// so a tool added to a group here reaches that list without a second edit — the list had been
+// written out by hand and named two of the four.
+export const toolsInGroup = (group: ToolGroup): string[] => [...GROUP_BY_TOOL].filter(([, g]) => g === group).map(([name]) => name);
+
 // The MCP server id a group is expected to be registered under. `--allowedTools` matches on
 // `mcp__<server id>__<tool>`, and the id comes from the USER's config key — so this is a
 // convention the enable-it-for-this-folder affordance has to write, and a user who registers

--- a/server/infra/gui-mcp-registration.ts
+++ b/server/infra/gui-mcp-registration.ts
@@ -77,6 +77,29 @@ const ownProp = (obj: unknown, key: string): unknown =>
 // — a per-directory entry under `projects` included.
 const scopeServerIds = (scope: unknown): string[] => serverIdsIn(ownProp(scope, "mcpServers"));
 
+// Every `.mcp.json` a session started in these directories would pick up.
+//
+// Project scope is NOT `<cwd>/.mcp.json` alone: Claude Code walks UP from its working directory
+// and takes every one it finds on the way. Measured against the real CLI — a file two levels up
+// is listed, one ABOVE the enclosing git root is listed (so this is a directory walk, not a repo
+// lookup), and a nearer file does not shadow a farther one, they merge. A cell launched in
+// `/repo/packages/app` therefore receives what `/repo/.mcp.json` registers, and reading only the
+// leaf reported the Canvas switch as off on a directory that has it.
+//
+// Both spellings of the directory, for the symlink reason above: Claude walks from its resolved
+// cwd, whose ancestors can differ from the lexical ones. Deduped, so the usual case (they are the
+// same path) reads each file once.
+function projectMcpFiles(...dirs: readonly string[]): string[] {
+  const files = new Set<string>();
+  for (const dir of dirs) {
+    for (let current = dir, parent = path.dirname(current); ; current = parent, parent = path.dirname(current)) {
+      files.add(path.join(current, ".mcp.json"));
+      if (parent === current) break; // reached the filesystem root
+    }
+  }
+  return [...files];
+}
+
 // Which groups this directory has registered. Read from Claude Code's config FILES, not from
 // `claude mcp list`: that command health-checks every registered server before it prints, which
 // costs seconds of network round-trips (more when one of the user's servers is down) — and the
@@ -85,22 +108,20 @@ const scopeServerIds = (scope: unknown): string[] => serverIdsIn(ownProp(scope, 
 // answer still follows a registration the user made with the CLI behind our back.
 //
 // All three scopes, because that is what the CLI shows and what the session will actually get:
-// local (ours, keyed by directory), project (`.mcp.json` in the repo), user (global).
+// local (ours, keyed by directory), project (every `.mcp.json` up the tree), user (global).
 export async function registeredGuiMcpGroups(cwd: string, groups: readonly ToolGroup[]): Promise<ToolGroup[]> {
   // Claude Code keys local scope by its OWN process.cwd(), which the OS resolves symlinks in,
   // while the path we are asked about is canonicalized only lexically (see existingWorkspace).
   // Both spellings are looked up so a directory reached through a symlink still matches.
-  const [config, project, real] = await Promise.all([
-    readJsonObject(claudeConfigFile()),
-    readJsonObject(path.join(cwd, ".mcp.json")),
-    realpath(cwd).catch(() => cwd),
-  ]);
+  const real = await realpath(cwd).catch(() => cwd);
+  const projectFiles = projectMcpFiles(cwd, real);
+  const [config, ...projects] = await Promise.all([claudeConfigFile(), ...projectFiles].map(readJsonObject));
   const perDir = ownProp(config, "projects");
   const ids = new Set([
     ...scopeServerIds(config),
     ...scopeServerIds(ownProp(perDir, cwd)),
     ...(real === cwd ? [] : scopeServerIds(ownProp(perDir, real))),
-    ...scopeServerIds(project),
+    ...projects.flatMap(scopeServerIds),
   ]);
   return groups.filter((group) => ids.has(toolGroupServerId(group)));
 }

--- a/server/infra/gui-mcp-registration.ts
+++ b/server/infra/gui-mcp-registration.ts
@@ -12,6 +12,9 @@
 // The url is a TEMPLATE, not a resolved address. Claude Code expands `${VAR}` in an MCP url at
 // connect time, and the two moving parts (our port, the session id) are only known per spawn —
 // they are set on each session's environment (see session/mcp-config.ts guiMcpEnv).
+import { readFile, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
 import { spawnCaptureAsync } from "./spawnCapture.js";
 import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 
@@ -45,17 +48,59 @@ export function unregisterGuiMcpGroup(bin: string, cwd: string, group: ToolGroup
   return claudeMcp(bin, cwd, ["remove", toolGroupServerId(group), "-s", "local"]);
 }
 
-// Which groups this directory has registered, read back from the CLI rather than remembered:
-// the user can add or remove one with `claude mcp` behind our back, and a cached answer would
-// then describe a directory that no longer exists as described.
-export async function registeredGuiMcpGroups(bin: string, cwd: string, groups: readonly ToolGroup[]): Promise<ToolGroup[]> {
-  const { status, stdout } = await spawnCaptureAsync(bin, ["mcp", "list"], { cwd });
-  if (status !== 0) return [];
-  return groups.filter((group) => listMentionsServer(stdout, toolGroupServerId(group)));
+// Claude Code's own config file, which is where `claude mcp add -s local` writes. It defaults to
+// ~/.claude.json and moves WITH CLAUDE_CONFIG_DIR — a user who relocated their Claude Code config
+// must not see every directory reported as having nothing registered.
+const claudeConfigFile = (): string => path.join(process.env.CLAUDE_CONFIG_DIR?.trim() || homedir(), ".claude.json");
+
+async function readJsonObject(file: string): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(file, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    // Absent, unreadable or half-written (Claude Code rewrites this file live). Nothing
+    // registered is the honest answer, and it is also the safe one: the switch renders OFF, and
+    // turning it on re-registers rather than removing anything.
+    return null;
+  }
 }
 
-// `claude mcp list` prints `<id>: <command or url> - <status>` per line. Matched at the start of
-// a line so a server whose URL happens to contain another group's id is not counted twice.
-export function listMentionsServer(listOutput: string, serverId: string): boolean {
-  return listOutput.split("\n").some((line) => line.trimStart().startsWith(`${serverId}:`));
+// `mcpServers` is a JSON object keyed by server id. Read with Object.keys on an own-property
+// check rather than indexed lookups, so a key like `constructor` in the user's file cannot
+// resolve through Object.prototype (same reason common/toolGroups.ts uses a Map).
+const serverIdsIn = (value: unknown): string[] => (value && typeof value === "object" && !Array.isArray(value) ? Object.keys(value as object) : []);
+
+const ownProp = (obj: unknown, key: string): unknown =>
+  obj && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key) ? (obj as Record<string, unknown>)[key] : undefined;
+
+// The servers a scope holds. Every scope spells them the same way — `{ mcpServers: { <id>: … } }`
+// — a per-directory entry under `projects` included.
+const scopeServerIds = (scope: unknown): string[] => serverIdsIn(ownProp(scope, "mcpServers"));
+
+// Which groups this directory has registered. Read from Claude Code's config FILES, not from
+// `claude mcp list`: that command health-checks every registered server before it prints, which
+// costs seconds of network round-trips (more when one of the user's servers is down) — and the
+// launcher runs this every time it opens, so the Canvas switch appeared late and moved the rows
+// under it. The files are the same source `claude mcp list` reads, minus the probing, so the
+// answer still follows a registration the user made with the CLI behind our back.
+//
+// All three scopes, because that is what the CLI shows and what the session will actually get:
+// local (ours, keyed by directory), project (`.mcp.json` in the repo), user (global).
+export async function registeredGuiMcpGroups(cwd: string, groups: readonly ToolGroup[]): Promise<ToolGroup[]> {
+  // Claude Code keys local scope by its OWN process.cwd(), which the OS resolves symlinks in,
+  // while the path we are asked about is canonicalized only lexically (see existingWorkspace).
+  // Both spellings are looked up so a directory reached through a symlink still matches.
+  const [config, project, real] = await Promise.all([
+    readJsonObject(claudeConfigFile()),
+    readJsonObject(path.join(cwd, ".mcp.json")),
+    realpath(cwd).catch(() => cwd),
+  ]);
+  const perDir = ownProp(config, "projects");
+  const ids = new Set([
+    ...scopeServerIds(config),
+    ...scopeServerIds(ownProp(perDir, cwd)),
+    ...(real === cwd ? [] : scopeServerIds(ownProp(perDir, real))),
+    ...scopeServerIds(project),
+  ]);
+  return groups.filter((group) => ids.has(toolGroupServerId(group)));
 }

--- a/server/infra/spawnCapture.ts
+++ b/server/infra/spawnCapture.ts
@@ -3,7 +3,7 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-// Long enough for `claude mcp list`, which health-checks every registered server, and short
+// Long enough for `claude mcp add`, which validates the server it is registering, and short
 // enough that a hung CLI surfaces as an error the UI can show rather than a request that never
 // answers.
 const DEFAULT_TIMEOUT_MS = 15_000;

--- a/server/routes/gui-mcp-routes.ts
+++ b/server/routes/gui-mcp-routes.ts
@@ -9,8 +9,10 @@ import { registerGuiMcpGroup, unregisterGuiMcpGroup, registeredGuiMcpGroups } fr
 
 export function mountGuiMcpRoutes(app: Express): void {
   // Which GUI tool groups this directory has registered with Claude Code, so the launcher can
-  // show the Canvas switch in the right position. Read back from `claude mcp list` per request
-  // rather than remembered — the user can add or remove one with the CLI behind our back.
+  // show the Canvas switch in the right position. Read from Claude Code's config files per
+  // request rather than remembered — the user can add or remove one with the CLI behind our
+  // back — but WITHOUT shelling out to `claude mcp list`, whose health check made the launcher
+  // wait seconds for a switch position that is sitting in a file.
   //
   // Same no-fallback rule as /api/dir-config-detail: this REPORTS ON the directory it was asked
   // about, and answering about the default workspace under another directory's name is worse
@@ -18,7 +20,7 @@ export function mountGuiMcpRoutes(app: Express): void {
   app.get("/api/gui-mcp-groups", async (req, res) => {
     const cwd = existingWorkspaceFromQuery(req.query.cwd);
     if (!cwd) return res.json({ groups: [] });
-    res.json({ groups: await registeredGuiMcpGroups(claudeAdapter.bin(), cwd, TOOL_GROUPS) });
+    res.json({ groups: await registeredGuiMcpGroups(cwd, TOOL_GROUPS) });
   });
 
   // Turn a group on or off for this directory. Writes through `claude mcp` into LOCAL scope —

--- a/server/session/pty-spawn.ts
+++ b/server/session/pty-spawn.ts
@@ -9,7 +9,7 @@ import type { WebSocket } from "ws";
 import { sanitizePtyEnv } from "../infra/pty-env.js";
 import { resolvePtyLaunchForEnv } from "../infra/resolve-bin.js";
 import { withoutUnset } from "./provider-env.js";
-import { tmuxAvailable, tmuxNewSessionArgs, tmuxScrubEnvNames } from "../infra/tmux.js";
+import { tmuxAvailable, tmuxHasSession, tmuxNewSessionArgs, tmuxScrubEnvNames } from "../infra/tmux.js";
 import {
   sandboxEnabled,
   sandboxPlatformSupported,
@@ -56,6 +56,18 @@ export interface PtySpawnEnv {
   unset?: readonly string[];
   /** Per-session variables to set on top of the inherited environment. */
   env?: Readonly<Record<string, string>>;
+}
+
+// Would ptySpawn ATTACH to a program that is already running, rather than start a new one?
+// `new-session -A` hides the difference — it returns a terminal either way — so a caller that
+// needs to know has to ask before calling.
+//
+// It matters to anything a caller does "because a new process is about to read the user's
+// config": on the attach path nothing is re-read, because nothing is re-started. The surviving
+// process is exactly the one that was there before, and it is past every decision it made at
+// startup. Must stay in lockstep with the branch below.
+export function ptyWouldReattach(sessionId: string, persistent: boolean): boolean {
+  return persistent && tmuxAvailable() && tmuxHasSession(sessionId);
 }
 
 // Spawn a terminal, wrapping it in a persistent tmux session when tmux is available and

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -8,7 +8,7 @@ import { getUserMcpServers, getPrWorkdirFooter } from "../config/config-routes.j
 import { SANDBOX_HOST } from "../infra/sandbox.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
 import { knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
-import { ptySpawn, sandboxWouldRun, spawnSandboxEntry } from "./pty-spawn.js";
+import { ptySpawn, ptyWouldReattach, sandboxWouldRun, spawnSandboxEntry } from "./pty-spawn.js";
 import { attachDraftInjection } from "./draft-injection.js";
 import { sendExitAndClose, sendFrame } from "./ws-frames.js";
 import { appendBoundedOutput } from "./terminal-replay.js";
@@ -90,9 +90,17 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     const sandbox = sandboxWouldRun(attachGuiMcp) && ws !== null;
     const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
 
-    // The process about to start gets whatever the user's MCP config says NOW, so anything this
-    // id learned under a previous one is stale — including a group the user has since removed.
-    resetSessionToolGroups(sessionId);
+    // A NEW claude process gets whatever the user's MCP config says NOW, so anything this id
+    // learned under a previous one is stale — including a group the user has since removed.
+    //
+    // But this function is also the REATTACH path: after the server restarts (a --watch reload
+    // included), the pty map is empty while the tmux session and its claude are still running, so
+    // ws-routes comes back through here and `new-session -A` picks the same process back up.
+    // Nothing is re-read there, and an MCP client that connected once will not connect again — so
+    // resetting would drop a capability with no way left to relearn it, and the panel would tell a
+    // cell that is still drawing that Canvas is not enabled for it. Surviving exactly that is what
+    // the persisted log is FOR; the unconditional reset was undoing it on every restart.
+    if (sandbox || !ptyWouldReattach(sessionId, true)) resetSessionToolGroups(sessionId);
 
     const { dir, resolved } = resolveSessionBackend({ cwd, sessionId, launch, canResume, sandbox });
 

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -90,18 +90,6 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     const sandbox = sandboxWouldRun(attachGuiMcp) && ws !== null;
     const canResume = resume !== null && sessionExistsOnDisk(resume, cwd);
 
-    // A NEW claude process gets whatever the user's MCP config says NOW, so anything this id
-    // learned under a previous one is stale — including a group the user has since removed.
-    //
-    // But this function is also the REATTACH path: after the server restarts (a --watch reload
-    // included), the pty map is empty while the tmux session and its claude are still running, so
-    // ws-routes comes back through here and `new-session -A` picks the same process back up.
-    // Nothing is re-read there, and an MCP client that connected once will not connect again — so
-    // resetting would drop a capability with no way left to relearn it, and the panel would tell a
-    // cell that is still drawing that Canvas is not enabled for it. Surviving exactly that is what
-    // the persisted log is FOR; the unconditional reset was undoing it on every restart.
-    if (sandbox || !ptyWouldReattach(sessionId, true)) resetSessionToolGroups(sessionId);
-
     const { dir, resolved } = resolveSessionBackend({ cwd, sessionId, launch, canResume, sandbox });
 
     const hookSettings = deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, resolved.env);
@@ -141,7 +129,29 @@ export function createClaudeSpawner(deps: SpawnDeps) {
     // where the cleanup normally happens (#579).
     const entry = withSettingsCleanup(sessionId, spawnEntry);
 
+    // A NEW claude process gets whatever the user's MCP config says NOW, so anything this id
+    // learned under a previous one is stale — including a group the user has since removed.
+    //
+    // But this function is also the REATTACH path: after the server restarts (a --watch reload
+    // included), the pty map is empty while the tmux session and its claude are still running, so
+    // ws-routes comes back through here and `new-session -A` picks the same process back up.
+    // Nothing is re-read there, and an MCP client that connected once will not connect again — so
+    // resetting would drop a capability with no way left to relearn it, and the panel would tell a
+    // cell that is still drawing that Canvas is not enabled for it. Surviving exactly that is what
+    // the persisted log is FOR; the unconditional reset was undoing it on every restart.
+    //
+    // Asked HERE, one statement before the spawn, rather than up with the other decisions: the
+    // answer stops being true the moment the tmux session ends, and everything between the two
+    // (the provider resolution, the git probes, the settings file) is time in which it can. The
+    // remaining window is irreducible without tmux reporting which branch `-A` took, and what
+    // survives it is an over-reported group on a session that lost it — the next genuinely new
+    // process clears that, whereas the reverse mistake could not be undone at all.
+    function resetToolGroupsUnlessReattaching(): void {
+      if (sandbox || !ptyWouldReattach(sessionId, true)) resetSessionToolGroups(sessionId);
+    }
+
     function spawnEntry(): PtyEntry {
+      resetToolGroupsUnlessReattaching();
       if (sandbox) return spawnSandboxEntry(sessionId, args, cwd, ws, dir.addDirs);
       const { term, tmux } = ptySpawn(sessionId, deps.claudeBin, args, cwd, true, { unset: resolved.unset, env: guiMcpEnv(sessionId, PORT) });
       console.log(`[pty] spawned claude (pid=${term.pid}${tmux ? " via tmux" : ""}) in ${cwd}`);

--- a/src/components/CellChromeButtons.vue
+++ b/src/components/CellChromeButtons.vue
@@ -10,7 +10,7 @@
 // No `.stop` on the clicks: the enclosing header's zoom gesture already ignores anything
 // inside a button (shouldZoomOnHeaderClick), and stopping here would only hide that.
 import { computed } from "vue";
-import { CELL_BTN, CELL_BTN_DISABLEABLE, CELL_CLOSE_BTN } from "./cellChromeClasses";
+import { CELL_BTN, CELL_BTN_ACTIVE, CELL_BTN_DISABLEABLE, CELL_CLOSE_BTN } from "./cellChromeClasses";
 
 const props = defineProps<{
   expanded: boolean;
@@ -31,6 +31,16 @@ const canvasTitle = computed(() => {
   if (!props.canvasAvailable) return "No render MCP for this directory — turn on Canvas in the launcher, then restart this cell";
   return props.rightPane === "canvas" ? "Hide canvas" : "Show canvas";
 });
+
+// Pressed buttons get a DIFFERENT class string, not an extra one: the two carry competing `bg-*`
+// utilities, and appending would leave which of them wins to Tailwind's output order.
+//
+// Which pane is open was only in `aria-pressed` and the tooltip before — true for a screen reader
+// and for whoever hovers, invisible to everyone looking at the header.
+const filesClass = computed(() => (props.filesOpen ? CELL_BTN_ACTIVE : CELL_BTN));
+// A disabled Canvas cannot be the open pane, so the pressed style never has to survive `disabled:`.
+const canvasClass = computed(() => (props.rightPane === "canvas" ? CELL_BTN_ACTIVE : CELL_BTN_DISABLEABLE));
+const toolsClass = computed(() => (props.rightPane === "tools" ? CELL_BTN_ACTIVE : CELL_BTN));
 </script>
 
 <template>
@@ -49,7 +59,7 @@ const canvasTitle = computed(() => {
   <button
     v-if="expanded"
     class="cell-btn"
-    :class="CELL_BTN"
+    :class="filesClass"
     :aria-pressed="!!filesOpen"
     :title="filesOpen ? 'Hide files' : 'Show files'"
     :aria-label="filesOpen ? 'Hide files' : 'Show files'"
@@ -64,7 +74,7 @@ const canvasTitle = computed(() => {
     v-if="expanded"
     data-testid="cell-canvas-btn"
     class="cell-btn"
-    :class="CELL_BTN_DISABLEABLE"
+    :class="canvasClass"
     :disabled="!canvasAvailable"
     :aria-pressed="rightPane === 'canvas'"
     :title="canvasTitle"
@@ -76,7 +86,7 @@ const canvasTitle = computed(() => {
   <button
     v-if="expanded"
     class="cell-btn"
-    :class="CELL_BTN"
+    :class="toolsClass"
     :aria-pressed="rightPane === 'tools'"
     :title="rightPane === 'tools' ? 'Hide tools' : 'Show tools'"
     :aria-label="rightPane === 'tools' ? 'Hide tools' : 'Show tools'"

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -3,6 +3,7 @@ import { ref, computed } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { getPlugin } from "../plugins-registry";
 import PluginFrame from "./PluginFrame.vue";
+import { CANVAS_TOOL_GROUP, toolsInGroup } from "../../common/toolGroups";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -25,8 +26,8 @@ const props = defineProps<{
   toolsOpen?: boolean;
   // Why this panel cannot show anything, when that is knowable. The pane outlives the cell it
   // was opened on — walking the zoom to a launcher or to a directory with no render MCP leaves
-  // it mounted — and the empty-state hint below ("ask Claude to use presentDocument") is a LIE
-  // in both cases: there is nothing to ask, or nothing that could answer. Absent/null means the
+  // it mounted — and the empty-state hint below ("ask Claude to use one of these") is a LIE in
+  // both cases: there is nothing to ask, or nothing that could answer. Absent/null means the
   // panel is usable, which keeps the single view (where it always is) unchanged.
   unavailable?: "no-session" | "no-render-mcp" | null;
 }>();
@@ -75,6 +76,20 @@ async function onUpdateResult(existing: ToolResult, update: Partial<ToolResult>)
 }
 
 const hasContent = computed(() => results.value.length > 0);
+
+// What each drawing tool produces, so the empty state says what asking for one would get rather
+// than only naming it. A Map for the same reason common/toolGroups.ts uses one, and consulted
+// with a fallback: the NAMES come from the group table, so a render tool added there shows up
+// here immediately — unnamed rather than missing, which is the failure that is noticed.
+const CANVAS_TOOL_HINTS = new Map<string, string>([
+  ["presentDocument", "a formatted document, written in markdown"],
+  ["presentForm", "a form to fill in and send back"],
+  ["presentChart", "a chart from a set of data"],
+  ["presentHtml", "a self-contained web page"],
+]);
+
+// The complete render group, not a sample of it.
+const canvasTools = computed(() => toolsInGroup(CANVAS_TOOL_GROUP).map((name) => ({ name, hint: CANVAS_TOOL_HINTS.get(name) ?? "" })));
 </script>
 
 <template>
@@ -112,10 +127,17 @@ const hasContent = computed(() => results.value.length > 0);
           </p>
         </template>
       </div>
-      <div v-else-if="!hasContent" class="text-[13px] text-dim">
-        Ask Claude to use <code class="rounded-[4px] bg-subtle px-[5px] py-px">presentDocument</code> or
-        <code class="rounded-[4px] bg-subtle px-[5px] py-px">presentForm</code>
-        to render content here.
+      <!-- The whole group is listed rather than an example or two: this is the only place the
+           tools are named, and a user reading "presentDocument or presentForm" has no way to
+           learn that a chart or a web page is also on offer. -->
+      <div v-else-if="!hasContent" data-testid="canvas-empty" class="text-[13px] text-dim">
+        Ask Claude to use one of these to render content here:
+        <ul class="mt-1.5 list-disc space-y-1 pl-4 marker:text-border">
+          <li v-for="tool in canvasTools" :key="tool.name">
+            <code class="rounded-[4px] bg-subtle px-[5px] py-px">{{ tool.name }}</code>
+            <template v-if="tool.hint"> &mdash; {{ tool.hint }}</template>
+          </li>
+        </ul>
       </div>
       <!-- Guarded as well as cleared on session change: a stale view rendered under an
            "unavailable" heading would contradict it. -->

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -101,9 +101,13 @@ const hasContent = computed(() => results.value.length > 0);
           <p class="mt-1">This cell has no terminal running yet. Start one and its drawings will appear here.</p>
         </template>
         <template v-else>
-          <div class="font-medium text-secondary">Canvas is not enabled for this directory</div>
+          <!-- The SESSION, not the directory. The tools are handed to the agent when it starts,
+               so a session begun before the switch was turned on has none of them while the
+               directory it runs in is enabled — saying "directory" there sends the user to a
+               switch that is already on. -->
+          <div class="font-medium text-secondary">Canvas is not enabled for this session</div>
           <p class="mt-1">
-            Its agent has no drawing tools, so nothing can appear here. Turn on
+            Its agent was started without the drawing tools, so nothing can appear here. They are handed out at startup: turn on
             <span class="whitespace-nowrap font-medium">CANVAS (render MCPs)</span> in this cell's launcher, then restart the cell.
           </p>
         </template>

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -236,7 +236,7 @@ function sendToExpandedCell(text: string): boolean {
 // may not have connected its MCP client yet, and re-expanding is how a user retries anything.
 const canvasAvailable = ref(false);
 // Whether the answer above has come back yet for the CURRENT cell. Without it the panel says
-// "not enabled for this directory" for the moment between switching cells and the reply landing
+// "not enabled for this session" for the moment between switching cells and the reply landing
 // — a wrong explanation is worse than none, so nothing is claimed until it is known.
 const canvasChecked = ref(false);
 watch(
@@ -258,7 +258,7 @@ watch(
       canvasChecked.value = true;
     } catch {
       // Unreachable server: no button rather than one that opens an empty panel. Left unchecked
-      // so the panel does not blame the directory for what is our own failure to ask.
+      // so the panel does not blame the session for what is our own failure to ask.
       if (sessionId === expandedSessionId.value) canvasAvailable.value = false;
     }
   },

--- a/src/components/cellChromeClasses.ts
+++ b/src/components/cellChromeClasses.ts
@@ -41,7 +41,11 @@ export const CELL_ACTIONS = "flex flex-none gap-1";
 // Split into box / size / ink for the same reason as the dot: a caller that resizes a button
 // or gives it its own colours swaps ONE piece instead of layering a second utility for a
 // property that is already set.
-export const CELL_BTN_BOX = "inline-flex items-center justify-center rounded-md border-none bg-transparent leading-none";
+// Shape WITHOUT a fill, so the idle and pressed variants can each name their own `bg-*` instead
+// of layering one over `bg-transparent` — which of two competing utilities wins is decided by
+// Tailwind's output order, not by the order they are written in (the same rule as the dot above).
+export const CELL_BTN_SHAPE = "inline-flex items-center justify-center rounded-md border-none leading-none";
+export const CELL_BTN_BOX = `${CELL_BTN_SHAPE} bg-transparent`;
 export const CELL_BTN_SIZE = "h-[26px] w-7 text-[16px]";
 export const CELL_BTN_INK = "cursor-pointer text-[var(--cell-btn,var(--text-secondary))] hover:bg-hover hover:text-fg";
 export const CELL_BTN = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} ${CELL_BTN_INK}`;
@@ -50,6 +54,17 @@ export const CELL_BTN = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} ${CELL_BTN_INK}`;
 // dimming is what says it is there but unavailable. Same idiom as the launcher's ▶ button.
 export const CELL_BTN_INK_DISABLEABLE = `enabled:cursor-pointer text-[var(--cell-btn,var(--text-secondary))] enabled:hover:bg-hover enabled:hover:text-fg disabled:cursor-default disabled:opacity-40`;
 export const CELL_BTN_DISABLEABLE = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} ${CELL_BTN_INK_DISABLEABLE}`;
+
+// The header button whose pane is CURRENTLY OPEN. Files, Canvas and Tools share one slot beside
+// the enlarged terminal, so exactly one of them can be in this state — and which one has to be
+// readable without moving the pointer. Idle chrome differs from hover by a background alone,
+// which says nothing once the cursor is elsewhere, so this fills AND recolours the ink.
+//
+// The same --bg-selected the rest of the app marks a selection with, rather than a colour of its
+// own: a header button is not a new kind of selected thing. Note it is not `--cell-btn`-tinted —
+// a directory's chrome colour drives the IDLE ink, and letting it drive this one too would make
+// "selected" mean a different shade per directory.
+export const CELL_BTN_ACTIVE = `${CELL_BTN_SHAPE} ${CELL_BTN_SIZE} cursor-pointer bg-selected text-accent hover:bg-selected-hover hover:text-accent`;
 export const CELL_CLOSE_BTN = `${CELL_BTN_BOX} ${CELL_BTN_SIZE} cursor-pointer text-[var(--cell-btn,var(--text-secondary))] hover:bg-[var(--err-hover-bg)] hover:text-err-text`;
 
 // A path clipped from the FRONT: `rtl` puts the ellipsis at the start so the tail — the

--- a/test/common/toolGroups.spec.ts
+++ b/test/common/toolGroups.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { TOOL_GROUPS, isToolGroup, groupOfTool, toolGroupServerId, AUTO_ALLOWED_TOOLS, CANVAS_TOOL_GROUP } from "../../common/toolGroups.js";
+import { TOOL_GROUPS, isToolGroup, groupOfTool, toolsInGroup, toolGroupServerId, AUTO_ALLOWED_TOOLS, CANVAS_TOOL_GROUP } from "../../common/toolGroups.js";
 
 describe("tool groups", () => {
   it("classifies the drawing tools as render", () => {
@@ -20,6 +20,21 @@ describe("tool groups", () => {
     expect(groupOfTool("google")).toBe("external");
     expect(groupOfTool("readXPost")).toBe("external");
     expect(groupOfTool("searchX")).toBe("external");
+  });
+
+  // The Canvas panel's empty state is built from this, so a group that under-reports its members
+  // silently drops a tool from the only place the user can read about it.
+  it("lists a group's members, and agrees with groupOfTool", () => {
+    const render = toolsInGroup("render");
+    expect(render).toContain("presentHtml");
+    expect(render).toContain("presentChart");
+    for (const tool of render) expect(groupOfTool(tool)).toBe("render");
+    for (const group of TOOL_GROUPS) expect(toolsInGroup(group).length).toBeGreaterThan(0);
+  });
+
+  it("puts no tool in two groups", () => {
+    const all = TOOL_GROUPS.flatMap((group) => toolsInGroup(group));
+    expect(new Set(all).size).toBe(all.length);
   });
 
   // Absent on purpose, not by omission — it starts another session, which no group describes.

--- a/test/server/infra/gui-mcp-registration.spec.ts
+++ b/test/server/infra/gui-mcp-registration.spec.ts
@@ -72,6 +72,26 @@ describe("registeredGuiMcpGroups", () => {
     expect((await registeredGuiMcpGroups(cwd, TOOL_GROUPS)).sort()).toEqual(["data", "media"]);
   });
 
+  // Project scope is a WALK, not a single file: measured against the real CLI, a cell launched in
+  // /repo/packages/app is served by /repo/.mcp.json. Reading only the leaf reported the switch as
+  // off on a directory that has it.
+  it("finds a .mcp.json in an ancestor directory", async () => {
+    const deep = path.join(cwd, "packages", "app");
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(path.join(cwd, ".mcp.json"), JSON.stringify({ mcpServers: { "mulmoterminal-render": {} } }));
+    expect(await registeredGuiMcpGroups(deep, TOOL_GROUPS)).toEqual(["render"]);
+  });
+
+  // Also measured: a nearer file does not shadow a farther one, they merge — and the walk crosses
+  // above a git root, so it is a directory walk rather than a repo lookup.
+  it("merges the files up the tree rather than stopping at the nearest", async () => {
+    const deep = path.join(cwd, "packages", "app");
+    mkdirSync(deep, { recursive: true });
+    writeFileSync(path.join(cwd, ".mcp.json"), JSON.stringify({ mcpServers: { "mulmoterminal-render": {} } }));
+    writeFileSync(path.join(deep, ".mcp.json"), JSON.stringify({ mcpServers: { "mulmoterminal-data": {} } }));
+    expect((await registeredGuiMcpGroups(deep, TOOL_GROUPS)).sort()).toEqual(["data", "render"]);
+  });
+
   // Claude Code keys local scope by its own resolved cwd; ours is canonicalized only lexically.
   it("matches a directory reached through a symlink", async () => {
     const link = path.join(root, "link");

--- a/test/server/infra/gui-mcp-registration.spec.ts
+++ b/test/server/infra/gui-mcp-registration.spec.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
-import { guiMcpUrlTemplate, listMentionsServer } from "../../../server/infra/gui-mcp-registration.js";
+import { guiMcpUrlTemplate, registeredGuiMcpGroups } from "../../../server/infra/gui-mcp-registration.js";
+import { TOOL_GROUPS } from "../../../common/toolGroups.js";
 
 // The url is registered ONCE, into the user's own Claude Code config, and then read at every
 // connect. It has to stay a template: the port and session id are only known per spawn, and
@@ -22,28 +26,71 @@ describe("guiMcpUrlTemplate", () => {
   });
 });
 
-describe("listMentionsServer", () => {
-  const list = ["mulmoterminal-render: http://127.0.0.1:34567/api/mcp/render/x - connected", "playwright: npx @playwright/mcp - connected"].join("\n");
+// Read from the config FILES, never by running `claude mcp list` — that command health-checks
+// every registered server first, and the launcher was paying that wait before it could draw the
+// Canvas switch.
+describe("registeredGuiMcpGroups", () => {
+  let root = "";
+  let home = "";
+  let cwd = "";
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
 
-  it("finds a registered server", () => {
-    expect(listMentionsServer(list, "mulmoterminal-render")).toBe(true);
+  const writeClaudeConfig = (value: unknown) => writeFileSync(path.join(home, ".claude.json"), JSON.stringify(value));
+
+  beforeEach(() => {
+    // realpath'd: on macOS the temp dir is itself behind a symlink (/var -> /private/var), which
+    // would make every path in here exercise the symlink case by accident.
+    root = realpathSync(mkdtempSync(path.join(tmpdir(), "gui-mcp-")));
+    home = path.join(root, "home");
+    cwd = path.join(root, "repo");
+    mkdirSync(home);
+    mkdirSync(cwd);
+    process.env.CLAUDE_CONFIG_DIR = home;
   });
 
-  it("does not find one that is absent", () => {
-    expect(listMentionsServer(list, "mulmoterminal-data")).toBe(false);
+  afterEach(() => {
+    if (previousConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+    rmSync(root, { recursive: true, force: true });
   });
 
-  // The id also appears INSIDE the url of the line above it. Matching anywhere in the output
-  // would report every group as registered as soon as one was.
-  it("matches the id at the start of a line, not inside another server's url", () => {
-    expect(listMentionsServer("other: http://x/api/mcp/render/y - ok", "render")).toBe(false);
+  it("reports the groups registered for this directory in local scope", async () => {
+    writeClaudeConfig({ projects: { [cwd]: { mcpServers: { "mulmoterminal-render": { type: "http" } } } } });
+    expect(await registeredGuiMcpGroups(cwd, TOOL_GROUPS)).toEqual(["render"]);
   });
 
-  it("tolerates indentation", () => {
-    expect(listMentionsServer("   mulmoterminal-render: http://x - ok", "mulmoterminal-render")).toBe(true);
+  // Local scope is keyed by directory: another project's registration is not this one's.
+  it("does not report a group registered for a different directory", async () => {
+    writeClaudeConfig({ projects: { [path.join(root, "elsewhere")]: { mcpServers: { "mulmoterminal-render": {} } } } });
+    expect(await registeredGuiMcpGroups(cwd, TOOL_GROUPS)).toEqual([]);
   });
 
-  it("reads empty output as nothing registered", () => {
-    expect(listMentionsServer("", "mulmoterminal-render")).toBe(false);
+  // The three scopes `claude mcp list` merges are the three the session will actually get.
+  it("also counts user scope and the repo's .mcp.json", async () => {
+    writeClaudeConfig({ mcpServers: { "mulmoterminal-media": {} } });
+    writeFileSync(path.join(cwd, ".mcp.json"), JSON.stringify({ mcpServers: { "mulmoterminal-data": {} } }));
+    expect((await registeredGuiMcpGroups(cwd, TOOL_GROUPS)).sort()).toEqual(["data", "media"]);
+  });
+
+  // Claude Code keys local scope by its own resolved cwd; ours is canonicalized only lexically.
+  it("matches a directory reached through a symlink", async () => {
+    const link = path.join(root, "link");
+    symlinkSync(cwd, link);
+    writeClaudeConfig({ projects: { [cwd]: { mcpServers: { "mulmoterminal-render": {} } } } });
+    expect(await registeredGuiMcpGroups(link, TOOL_GROUPS)).toEqual(["render"]);
+  });
+
+  // The file is rewritten live by Claude Code, so a read can land mid-write.
+  it("reads a missing or unparsable config as nothing registered", async () => {
+    expect(await registeredGuiMcpGroups(cwd, TOOL_GROUPS)).toEqual([]);
+    writeFileSync(path.join(home, ".claude.json"), "{ half-writ");
+    expect(await registeredGuiMcpGroups(cwd, TOOL_GROUPS)).toEqual([]);
+  });
+
+  // An indexed lookup would resolve these through Object.prototype and report a group that the
+  // user never registered.
+  it("does not read inherited object members as registrations", async () => {
+    writeClaudeConfig({ projects: { [cwd]: { mcpServers: { constructor: {}, toString: {} } } } });
+    expect(await registeredGuiMcpGroups(cwd, TOOL_GROUPS)).toEqual([]);
   });
 });

--- a/test/server/session/pty-spawn-env.spec.ts
+++ b/test/server/session/pty-spawn-env.spec.ts
@@ -8,13 +8,15 @@ vi.mock("node-pty", () => ({ default: { spawn: (...args: unknown[]) => spawn(...
 const scrub = vi.fn();
 vi.mock("../../../server/infra/tmux.js", () => ({
   tmuxAvailable: () => tmuxOn,
+  tmuxHasSession: (id: string) => liveTmuxSessions.has(id),
   tmuxNewSessionArgs: (id: string, file: string, args: string[]) => ["new-session", id, file, ...args],
   tmuxScrubEnvNames: (names: readonly string[]) => scrub(names),
 }));
 
 let tmuxOn = false;
+const liveTmuxSessions = new Set<string>();
 
-const { spawnPty, ptySpawn } = await import("../../../server/session/pty-spawn.js");
+const { spawnPty, ptySpawn, ptyWouldReattach } = await import("../../../server/session/pty-spawn.js");
 
 const envOf = (call: number = 0): NodeJS.ProcessEnv => (spawn.mock.calls[call] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
 
@@ -22,6 +24,7 @@ beforeEach(() => {
   spawn.mockClear();
   scrub.mockClear();
   tmuxOn = false;
+  liveTmuxSessions.clear();
   process.env.ANTHROPIC_API_KEY = "sk-ant-leftover";
   process.env.MT_KEEP_ME = "kept";
 });
@@ -44,6 +47,32 @@ describe("spawnPty — the environment it hands the pty", () => {
   it("leaves the environment alone when nothing is named", () => {
     spawnPty("claude", [], "/tmp");
     expect(envOf().ANTHROPIC_API_KEY).toBe("sk-ant-leftover");
+  });
+});
+
+// `new-session -A` returns a terminal whether it created one or picked up a survivor, so a
+// caller that must not treat the second as a fresh start has to ask beforehand. What hangs on
+// it: a reattached claude never re-reads the user's MCP config, so resetting its learned tool
+// groups there would drop them with nothing left to relearn from.
+describe("ptyWouldReattach", () => {
+  it("is true only when tmux is holding this exact session", () => {
+    tmuxOn = true;
+    liveTmuxSessions.add("s1");
+    expect(ptyWouldReattach("s1", true)).toBe(true);
+    expect(ptyWouldReattach("s2", true)).toBe(false);
+  });
+
+  it("is false without tmux — every spawn there starts a new process", () => {
+    tmuxOn = false;
+    liveTmuxSessions.add("s1");
+    expect(ptyWouldReattach("s1", true)).toBe(false);
+  });
+
+  // Matches ptySpawn's own branch: a non-persistent spawn never consults tmux at all.
+  it("is false for a non-persistent spawn", () => {
+    tmuxOn = true;
+    liveTmuxSessions.add("s1");
+    expect(ptyWouldReattach("s1", false)).toBe(false);
   });
 });
 

--- a/test/server/session/tool-group-reattach.spec.ts
+++ b/test/server/session/tool-group-reattach.spec.ts
@@ -19,9 +19,19 @@ let reattaching = false;
 let sandboxRuns = false;
 const resetSessionToolGroups = vi.fn();
 
+// Hooks so the ORDER of probe / reset / spawn can be asserted, not just their arguments.
+let probed = () => {};
+let spawned = () => {};
+
 vi.mock("../../../server/session/pty-spawn.js", () => ({
-  ptySpawn: () => ({ term: fakeTerm(), tmux: true }),
-  ptyWouldReattach: () => reattaching,
+  ptySpawn: () => {
+    spawned();
+    return { term: fakeTerm(), tmux: true };
+  },
+  ptyWouldReattach: () => {
+    probed();
+    return reattaching;
+  },
   sandboxWouldRun: () => sandboxRuns,
   spawnSandboxEntry: () => ({ term: fakeTerm(), ws: null, buffer: "", cwd: "/tmp", sandbox: true, active: false, agent: "claude" }),
 }));
@@ -66,9 +76,11 @@ const fakeWs = { readyState: 1, send: vi.fn(), close: vi.fn(), on: vi.fn() } as 
 const spawn = (options: Record<string, unknown>, ws: typeof fakeWs = null) => createClaudeSpawner(deps).spawnClaudePty(ID, null, ws, options);
 
 beforeEach(() => {
-  resetSessionToolGroups.mockClear();
+  resetSessionToolGroups.mockReset();
   reattaching = false;
   sandboxRuns = false;
+  probed = () => {};
+  spawned = () => {};
 });
 
 describe("spawnClaudePty and the tool-group reset", () => {
@@ -92,5 +104,17 @@ describe("spawnClaudePty and the tool-group reset", () => {
     sandboxRuns = true;
     spawn({ cwd: process.cwd(), attachGuiMcp: true }, fakeWs);
     expect(resetSessionToolGroups).toHaveBeenCalledWith(ID);
+  });
+
+  // The probe's answer expires the moment the tmux session ends, so it is taken one statement
+  // before the spawn rather than up with the other decisions — the provider resolution, the git
+  // probes and the settings file all sit between, and each is time the session can end in.
+  it("asks immediately before spawning, not before the rest of the setup", () => {
+    const order: string[] = [];
+    resetSessionToolGroups.mockImplementation(() => order.push("reset"));
+    probed = () => order.push("probe");
+    spawned = () => order.push("spawn");
+    spawn({ cwd: process.cwd(), attachGuiMcp: false });
+    expect(order).toEqual(["probe", "reset", "spawn"]);
   });
 });

--- a/test/server/session/tool-group-reattach.spec.ts
+++ b/test/server/session/tool-group-reattach.spec.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+//
+// A session's learned tool groups must survive a REATTACH.
+//
+// spawnClaudePty is both paths: a genuinely new claude, and the one ws-routes comes back through
+// after the server restarts while the tmux session (and its claude) kept running. The reset exists
+// for the first — a new process reads the user's MCP config now, so what the id learned under an
+// older one is stale. On the second nothing is re-read, and an MCP client that connected once will
+// not connect again: resetting there drops a capability with no way left to relearn it, and the
+// panel then reports "Canvas is not enabled for this session" on a cell that is still drawing.
+//
+// That is exactly what session-tool-groups.ts persists the log for, and the unconditional reset
+// was undoing it on every server restart.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ID = "11111111-2222-4333-8444-555555555555";
+
+let reattaching = false;
+let sandboxRuns = false;
+const resetSessionToolGroups = vi.fn();
+
+vi.mock("../../../server/session/pty-spawn.js", () => ({
+  ptySpawn: () => ({ term: fakeTerm(), tmux: true }),
+  ptyWouldReattach: () => reattaching,
+  sandboxWouldRun: () => sandboxRuns,
+  spawnSandboxEntry: () => ({ term: fakeTerm(), ws: null, buffer: "", cwd: "/tmp", sandbox: true, active: false, agent: "claude" }),
+}));
+
+vi.mock("../../../server/session/registry.js", () => ({
+  knownSessions: new Map(),
+  launchChoices: new Map(),
+  ptys: new Map(),
+  resetSessionToolGroups: (id: string) => resetSessionToolGroups(id),
+}));
+
+// The transcript check decides --resume; irrelevant here and it would touch the real disk.
+vi.mock("../../../server/session/session-reads.js", () => ({ sessionExistsOnDisk: () => false }));
+
+const fakeTerm = () => ({ pid: 1, onData: vi.fn(), onExit: vi.fn(), write: vi.fn(), kill: vi.fn(), resize: vi.fn() });
+
+const { createClaudeSpawner } = await import("../../../server/session/spawn-claude.js");
+
+const deps = {
+  claudeBin: "claude",
+  codexBin: "codex",
+  codexModel: null,
+  permissionMode: "default",
+  guiMcpTools: "mcp__mulmoterminal-gui",
+  gridMcpTools: "mcp__mulmoterminal-render__presentHtml",
+  outputBufferLimit: 1000,
+  hookSettingsJson: () => "{}",
+  mcpConfigJson: () => "{}",
+  reap: vi.fn(),
+  setWorking: vi.fn(),
+  setWaiting: vi.fn(),
+  uiPort: "3000",
+  publishSessionCreated: vi.fn(),
+};
+
+// The sandbox only runs for a session with a viewer attached (`ws !== null`), so the socket is
+// part of what the third case is testing rather than incidental.
+const fakeWs = { readyState: 1, send: vi.fn(), close: vi.fn(), on: vi.fn() } as unknown as Parameters<
+  ReturnType<typeof createClaudeSpawner>["spawnClaudePty"]
+>[2];
+
+const spawn = (options: Record<string, unknown>, ws: typeof fakeWs = null) => createClaudeSpawner(deps).spawnClaudePty(ID, null, ws, options);
+
+beforeEach(() => {
+  resetSessionToolGroups.mockClear();
+  reattaching = false;
+  sandboxRuns = false;
+});
+
+describe("spawnClaudePty and the tool-group reset", () => {
+  it("resets when a new claude process is about to start", () => {
+    spawn({ cwd: process.cwd(), attachGuiMcp: false });
+    expect(resetSessionToolGroups).toHaveBeenCalledWith(ID);
+  });
+
+  // The regression: the server restarted, the pty map is empty, but tmux still holds the SAME
+  // claude. Nothing re-reads the MCP config, so nothing can be relearned.
+  it("does NOT reset when reattaching to a surviving process", () => {
+    reattaching = true;
+    spawn({ cwd: process.cwd(), attachGuiMcp: false });
+    expect(resetSessionToolGroups).not.toHaveBeenCalled();
+  });
+
+  // A sandbox spawn starts a fresh container every time — a leftover tmux session for the id
+  // says nothing about it.
+  it("resets a sandbox spawn even when tmux has the id", () => {
+    reattaching = true;
+    sandboxRuns = true;
+    spawn({ cwd: process.cwd(), attachGuiMcp: true }, fakeWs);
+    expect(resetSessionToolGroups).toHaveBeenCalledWith(ID);
+  });
+});

--- a/test/src/components/CellChromeButtons.spec.ts
+++ b/test/src/components/CellChromeButtons.spec.ts
@@ -120,3 +120,49 @@ describe("the canvas button", () => {
     expect(canvasButton({ canvasAvailable: true, rightPane: "files" }).attributes("aria-pressed")).toBe("false");
   });
 });
+
+// Files, Canvas and Tools share ONE slot beside the enlarged terminal, so which of the three is
+// open is a choice the header has to show. It was carried only by `aria-pressed` and the tooltip
+// — read by a screen reader, and by whoever happens to hover — while the three buttons looked
+// identical to anyone just looking at them.
+describe("the open pane's button, seen", () => {
+  const header = (props: Record<string, unknown>) => mount(CellChromeButtons, { props: { expanded: true, canvasAvailable: true, ...props } });
+  const button = (props: Record<string, unknown>, testid: string) => header(props).find(testid);
+  const FILES = '[aria-label="Show files"], [aria-label="Hide files"]';
+  const TOOLS = '[aria-label="Show tools"], [aria-label="Hide tools"]';
+  const CANVAS = '[data-testid="cell-canvas-btn"]';
+  const isMarked = (classes: string[]) => classes.includes("bg-selected") && classes.includes("text-accent");
+
+  it("fills and recolours the button whose pane is open", () => {
+    expect(isMarked(button({ rightPane: "files", filesOpen: true }, FILES).classes())).toBe(true);
+    expect(isMarked(button({ rightPane: "canvas" }, CANVAS).classes())).toBe(true);
+    expect(isMarked(button({ rightPane: "tools" }, TOOLS).classes())).toBe(true);
+  });
+
+  it("leaves the other two alone", () => {
+    const w = header({ rightPane: "canvas" });
+    expect(isMarked(w.find(FILES).classes())).toBe(false);
+    expect(isMarked(w.find(TOOLS).classes())).toBe(false);
+  });
+
+  // The slot holds one pane, so two buttons marked at once would describe a layout that cannot
+  // happen — and the user would have no way to tell which one the pane belongs to.
+  it("marks exactly one at a time, and none when the slot is empty", () => {
+    for (const pane of ["files", "canvas", "tools"]) {
+      const w = header({ rightPane: pane, filesOpen: pane === "files" });
+      expect(w.findAll("button").filter((b) => isMarked(b.classes()))).toHaveLength(1);
+    }
+    expect(
+      header({ rightPane: null })
+        .findAll("button")
+        .filter((b) => isMarked(b.classes())),
+    ).toHaveLength(0);
+  });
+
+  // Appending the pressed classes would leave `bg-transparent` on the element too, and which of
+  // two competing utilities wins is Tailwind's output order rather than the order written here.
+  it("swaps the idle fill out rather than layering over it", () => {
+    expect(button({ rightPane: "tools" }, TOOLS).classes()).not.toContain("bg-transparent");
+    expect(button({ rightPane: "files" }, TOOLS).classes()).toContain("bg-transparent");
+  });
+});

--- a/test/src/components/GuiPanelEmptyState.spec.ts
+++ b/test/src/components/GuiPanelEmptyState.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import GuiPanel from "../../../src/components/GuiPanel.vue";
+import { CANVAS_TOOL_GROUP, toolsInGroup } from "../../../common/toolGroups";
+
+// The empty Canvas is the only place the drawing tools are named, so the list is the feature's
+// documentation. It named two of the four, and a user reading it had no way to learn that a chart
+// or a web page was also on offer.
+vi.mock("../../../src/composables/usePubSub", () => ({ usePubSub: () => ({ subscribe: () => () => {} }) }));
+
+const mountPanel = () => mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true }, global: { stubs: { PluginFrame: true } } });
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ toolResults: [] }) })),
+  );
+});
+
+describe("the canvas pane's empty state", () => {
+  // Compared against the group table rather than a list repeated here: a copy would go stale in
+  // exactly the way this test exists to catch.
+  it("names every tool in the render group", async () => {
+    const w = mountPanel();
+    await flushPromises();
+    const items = w.findAll('[data-testid="canvas-empty"] li').map((li) => li.text());
+    const tools = toolsInGroup(CANVAS_TOOL_GROUP);
+    expect(tools.length).toBeGreaterThan(1);
+    expect(items).toHaveLength(tools.length);
+    for (const tool of tools) expect(items.some((item) => item.includes(tool))).toBe(true);
+  });
+
+  // Naming a tool says nothing about what asking for it would get.
+  it("says what each one produces", async () => {
+    const w = mountPanel();
+    await flushPromises();
+    const items = w.findAll('[data-testid="canvas-empty"] li').map((li) => li.text());
+    for (const item of items) expect(item.length).toBeGreaterThan("presentDocument".length + 4);
+  });
+
+  it("is replaced once something has been drawn", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({ toolResults: [{ uuid: "u1", toolName: "presentHtml", data: {} }] }) })),
+    );
+    const w = mountPanel();
+    await flushPromises();
+    expect(w.find('[data-testid="canvas-empty"]').exists()).toBe(false);
+  });
+});

--- a/test/src/components/GuiPanelUnavailable.spec.ts
+++ b/test/src/components/GuiPanelUnavailable.spec.ts
@@ -36,12 +36,16 @@ describe("the canvas pane's unavailable states", () => {
     expect(w.text()).not.toContain("presentDocument");
   });
 
-  // The tools were never registered for this directory, so asking would fail every time.
-  it("names the directory's missing render MCP, and how to fix it", async () => {
+  // This session's agent was started without the tools, so asking would fail every time. Said of
+  // the SESSION rather than the directory: the switch is per directory but takes effect at
+  // startup, so a session older than the switch lacks the tools while the directory has them —
+  // blaming the directory would send the user to a switch that is already on.
+  it("names the session's missing render MCP, and how to fix it", async () => {
     const w = mountPanel({ sessionId: "s1", unavailable: "no-render-mcp" });
     await flushPromises();
     const text = w.text();
-    expect(text).toContain("not enabled for this directory");
+    expect(text).toContain("not enabled for this session");
+    expect(text).not.toContain("not enabled for this directory");
     expect(text).toContain("CANVAS (render MCPs)");
     expect(text).toContain("restart");
     expect(text).not.toContain("presentDocument");

--- a/test/src/components/GuiPanelUnavailable.spec.ts
+++ b/test/src/components/GuiPanelUnavailable.spec.ts
@@ -4,8 +4,8 @@ import GuiPanel from "../../../src/components/GuiPanel.vue";
 
 // The Canvas pane outlives the cell it was opened on: walking the zoom lands it on a launcher
 // with no session, or on a directory whose agent has no drawing tools. Its normal empty state
-// says "ask Claude to use presentDocument" — an instruction that cannot be followed in either
-// case, which is worse than saying nothing.
+// says "ask Claude to use one of these" and lists them — an instruction that cannot be followed
+// in either case, which is worse than saying nothing.
 vi.mock("../../../src/composables/usePubSub", () => ({ usePubSub: () => ({ subscribe: () => () => {} }) }));
 
 const mountPanel = (props: Record<string, unknown> = {}) =>


### PR DESCRIPTION
#1000 で入った Canvas in grid の後追い。判定の不具合 2 件と、UI の不明瞭さ 2 件。

## 1. 起動フォームの Canvas チェックボックスが出るまで待たされる (`94be3ffe`)

`GET /api/gui-mcp-groups` が `claude mcp list` を叩いていた。この CLI は印字の前に
**登録済み MCP サーバーを全部 health check する** ── 実測 1.6 秒、ユーザーのサーバーが
1 本落ちていればもっと長い。スイッチは `v-if` で出るので、遅れて現れたぶん下の行がずれる。

`claude mcp list` が読むのと同じ設定ファイルを直接読む。probe をしないだけで情報源は同じなので、
「ユーザーが CLI で登録した」も従来どおり拾う。

| | |
|---|---|
| `claude mcp list` (旧) | **1608 ms** |
| ファイル読み (新) | **0.93 ms** |

- 3 スコープすべて (local / project `.mcp.json` / user)。CLI が見せるのがこの 3 つで、
  セッションが実際に受け取るのもこの 3 つ
- `CLAUDE_CONFIG_DIR` に追従する
- 渡されたパスと realpath の両方を引く。Claude Code は自身の `process.cwd()`
  (OS がシンボリックリンクを解決した形) で local scope を keying するが、
  `existingWorkspace` の正規化は字句的なので両者はずれ得る
- own property のみを見る (`common/toolGroups.ts` が Map を使うのと同じ理由)
- 読めない/壊れたファイルは「未登録」と読む。スイッチは off で描かれ、それを on にするのは
  再登録であって削除ではない

**書き込みは従来どおり `claude mcp add/remove` を通す。** ユーザーのファイルを我々が直接
書き換えてはいけない。CLI 出力をパースする箇所が無くなったので `listMentionsServer` を削除。

実サーバーに対し、登録あり/なしの両方で `claude mcp list` と一致することを確認した。

## 2. Canvas 有効なのに「無効」と判定されることが頻繁にある (`a4c90d7a`)

`spawnClaudePty` は 2 つの経路を兼ねている。新しい claude を起こす経路と、**サーバーが
再起動した後 ws-routes が戻ってくる経路** ── 後者では `ptys` が空なだけで tmux セッションと
claude はまだ生きており、`new-session -A` は同じプロセスを拾い直す。

reset は前者のためにある。新しいプロセスはその時点のユーザーの MCP 設定を読むので、この id が
古いプロセスの下で学習したものは無効になる。だが後者では何も読み直されない。**一度接続した
MCP クライアントは二度と接続してこない**ので、ここで reset すると学習し直す手段が無いまま
capability が消える。結果、まだ描けるセルに対してパネルが「無効」と言う。

`session-tool-groups.ts` が追記ログを永続化しているのは、まさにこの
「サーバーは再起動したが claude は tmux で生きている」を生き延びるためだった
(同ファイル冒頭のコメントがそう書いている)。無条件の reset がそれを毎回打ち消していた。

- `pty-spawn` に `ptyWouldReattach()` を出す。`new-session -A` は作成と再接続を同じ形で
  返すので、区別が要る呼び出し側は事前に聞くしかない
- サンドボックスは毎回新しいコンテナなので、id に対する tmux セッションの有無とは無関係に reset する
- **テストが旧挙動で落ちることを確認済み**

## 3. 「Canvas is not enabled for this **directory**」→ **session** (`2d0fa0d5`)

判定しているのは `/api/tools?sessionId=` ── そのセッションが持っているツールであって、
ディレクトリの登録ではない。ツールは起動時に渡されるので、スイッチを入れる前から走っている
セッションは「ディレクトリは有効なのにツールを持たない」状態になる。そこで「このディレクトリでは
無効」と出すのは、**既に on になっているスイッチへユーザーを送る**ことになる。

本文にも「起動時に渡される」ことを明示し、再起動が必要な理由が読めるようにした。

## 4. 空の Canvas が描画ツールを 2 つしか挙げていない (`1403cd76`)

「presentDocument か presentForm を使うよう頼め」と出していたが、render グループは 4 つある。
ここはツール名が出る唯一の場所なので、この文言を読んだ人にはチャートや Web ページも頼めることを
知る手段がない。グループ全体を箇条書きにし、各ツールが何を出すかを添える。

名前は `common/toolGroups.ts` の新しい `toolsInGroup()` から取る ── **手書きの列挙が古くなったのが
今回の不具合そのもの**なので、グループに足したツールは 2 箇所目を編集しなくてもここに出る。
テストもグループ表と突き合わせる (spec 側で列挙を書き写すと、そのテストが捕まえたいズレを
テスト自身が起こす)。

## 5. どのペインが開いているか見て分からない (`f5720904`)

Files / Canvas / Tools は拡大セルの右の 1 枠を取り合う排他選択なのに、どれが開いているかは
`aria-pressed` と tooltip にしか出ていなかった。アイドル時とホバー時の違いは背景だけなので、
カーソルが離れれば何も残らない。

選択中のボタンを塗り、インクを accent にする。色は `--bg-selected` ── アプリの他の場所が選択を
示すのと同じトークン。ディレクトリの chrome 色 (`--cell-btn`) は使わない。アイドルのインクは
それで着色されるが、選択色まで連動させると「選択中」がディレクトリごとに違う色になる。

- 追加ではなく別のクラス文字列に差し替える。両者は競合する `bg-*` を持つので、重ねるとどちらが
  勝つかは Tailwind の出力順が決めることになる (`CELL_DOT` の既存コメントと同じ理由)
- ビルド後の CSS に `.bg-selected` / `.hover\:bg-selected-hover` / `.text-accent` が
  出ていることを確認済み (`bg-selected` はこれまでアプリ内で未使用だった)
- 同時に 2 つ光らないことをテストで押さえる

## 確認

`yarn format` / `lint` (エラー 0) / `typecheck`・`typecheck:server`・`typecheck:test` /
`yarn test` (**5750 passed**、テスト 21 件追加) / `yarn build`。

**未確認**: 5 のブラウザでの目視。この環境に Playwright が無く、見た目の変更なので実機で
見ないと塗りの強さは判断できない。1 と 2 は実サーバー / 旧挙動での失敗確認まで済んでいる。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas empty states now list all available rendering tools with helpful descriptions.
  * Files, Canvas, and Tools controls now clearly indicate the currently selected pane.
  * Persistent sessions can reattach without unnecessarily resetting their tool configuration.
  * GUI tool availability is detected from local configuration across supported workspace scopes.

* **Bug Fixes**
  * Updated Canvas availability messaging to refer to the current session.
  * Improved handling of symlinked workspaces and malformed configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->