### PR TITLE
feat: ランチャーに Canvas (media MCPs) を足し、空の Canvas にそのセッションの GUI ツールを全部並べる

### DIFF
--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -18,11 +18,24 @@ export type ToolGroup = (typeof TOOL_GROUPS)[number];
 
 export const isToolGroup = (value: unknown): value is ToolGroup => TOOL_GROUPS.some((group) => group === value);
 
-// The group the Canvas pane is made of. The launcher switch registers it, the panel's
-// availability is decided by it, and the server routes on it — named here rather than written
-// as `"render"` at each of those sites, so a rename cannot leave one of them silently pointing
-// at a group that no longer exists.
-export const CANVAS_TOOL_GROUP: ToolGroup = "render";
+// The groups the Canvas pane is made of. The launcher offers a switch per group, the panel's
+// availability is decided by them, and the server routes on them — named here rather than
+// written as `"render"` / `"media"` at each of those sites, so a rename cannot leave one of them
+// silently pointing at a group that no longer exists.
+//
+// `media` is in because its tools DRAW: generateImage and presentMulmoScript land in the same
+// panel a render tool does. It is a separate switch rather than part of one because the two
+// differ in what a call costs — render stops at the pane, media is slow, paid and writes files —
+// and that is exactly the line the grouping exists to draw. Neither media tool is in
+// AUTO_ALLOWED_TOOLS, so enabling the group still leaves Claude Code's permission prompt in
+// front of the spend (same reasoning as presentDocument below).
+export const CANVAS_TOOL_GROUPS: readonly ToolGroup[] = ["render", "media"];
+
+// Does a session/directory reach the Canvas at all? Asked of the group list the server reports,
+// whose members arrive as plain strings — validated rather than cast, since an unknown name from
+// a newer server must not count as a canvas group.
+export const hasCanvasGroup = (groups: unknown): boolean =>
+  Array.isArray(groups) && groups.some((group) => isToolGroup(group) && CANVAS_TOOL_GROUPS.includes(group));
 
 // Which group each GUI tool belongs to.
 //

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { ref, computed, watch, onBeforeUnmount } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
+import { usePubSub } from "../composables/usePubSub";
 import { getPlugin } from "../plugins-registry";
 import PluginFrame from "./PluginFrame.vue";
-import { TOOL_GROUPS, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
+import { TOOL_GROUPS, groupOfTool, toolsInGroup } from "../../common/toolGroups";
+import { TOOL_GROUPS_CHANNEL } from "../toolGroupsChannel";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -30,11 +32,6 @@ const props = defineProps<{
   // both cases: there is nothing to ask, or nothing that could answer. Absent/null means the
   // panel is usable, which keeps the single view (where it always is) unchanged.
   unavailable?: "no-session" | "no-canvas-mcp" | null;
-  // The GUI tool groups this session actually reached us on, so the empty state lists what THIS
-  // terminal can be asked for rather than a fixed set — a cell with only `render` registered
-  // should not be told to ask for generateImage. Absent means "everything": the single view
-  // connects on the all-tools URL, where no group was ever selected (common/toolGroups.ts).
-  groups?: ToolGroup[];
 }>();
 const emit = defineEmits<{ toggleTools: [] }>();
 
@@ -104,19 +101,56 @@ const TOOL_HINTS = new Map<string, string>([
   ["searchX", "recent posts on X matching a query"],
 ]);
 
-// Every group this session has, each with ALL its members — the whole of what the terminal can
-// be asked for, not a sample. This is the only place the tools are named, and a user reading
-// "presentDocument or presentForm" has no way to learn that a chart, a web page or an image is
-// also on offer. Ordered by TOOL_GROUPS (blast radius, least first) rather than by the order the
-// session happened to connect its MCP clients in, so the list does not reshuffle between cells.
-const toolSections = computed(() => {
-  const session = props.groups;
-  const groups = session ? TOOL_GROUPS.filter((group) => session.includes(group)) : TOOL_GROUPS;
-  return groups.map((group) => ({
-    group,
-    tools: toolsInGroup(group).map((name) => ({ name, hint: TOOL_HINTS.get(name) ?? "" })),
-  }));
+// The tools the SERVER says this session has, asked for rather than reconstructed from the group
+// table. Two things make the static answer wrong: a grid cell reaches only the groups its
+// directory registered, and a plugin whose requiredEnv is unmet (searchX without X_BEARER_TOKEN)
+// is dropped at load — naming either in the hint below sends the user to a tool that was never
+// offered. `null` until the answer lands, which is NOT the same as "no tools": see toolSections.
+const availableTools = ref<string[] | null>(null);
+
+async function loadAvailableTools(sessionId: string | null) {
+  availableTools.value = null;
+  try {
+    const res = await fetch(sessionId ? `/api/tools?sessionId=${encodeURIComponent(sessionId)}` : "/api/tools");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const body = await res.json();
+    // Late reply for a session we have since walked away from would list another cell's tools.
+    if (sessionId !== props.sessionId) return;
+    if (!Array.isArray(body.tools)) return;
+    availableTools.value = body.tools.map((tool: { toolName?: unknown }) => tool?.toolName).filter((name: unknown): name is string => typeof name === "string");
+  } catch {
+    // Leave it unknown rather than empty — the hint falls back to the full list, which is a
+    // better answer than telling a working session it has nothing.
+  }
+}
+watch(() => props.sessionId, loadAvailableTools, { immediate: true });
+
+// The answer above is normally asked BEFORE it can be true: the browser is handed a session id
+// while claude is still being spawned, so its MCP client has not connected to the group URLs yet
+// and the server has not learned which tools this cell got. The same channel the grid's Canvas
+// button waits on says when that changes.
+const { subscribe: subscribeToolGroups } = usePubSub();
+const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
+  const msg = data as { sessionId?: string };
+  if (msg?.sessionId && msg.sessionId === props.sessionId) loadAvailableTools(props.sessionId);
 });
+onBeforeUnmount(() => offToolGroups());
+
+// What this session can be asked for, grouped. Ordered by TOOL_GROUPS (blast radius, least
+// first) rather than by the order the server happened to list them, so the hint does not
+// reshuffle between cells, and a group with nothing available drops out entirely.
+//
+// While the answer is unknown, every group's members — the full list is what the panel showed
+// before it could ask at all, and it beats an empty one during the moment after a cell switch.
+const toolSections = computed(() =>
+  TOOL_GROUPS.map((group) => {
+    const known = availableTools.value;
+    const names = known ? known.filter((name) => groupOfTool(name) === group) : toolsInGroup(group);
+    // toolsInGroup order, not the server's: the group table is where the reading order was chosen.
+    const ordered = toolsInGroup(group).filter((name) => names.includes(name));
+    return { group, tools: ordered.map((name) => ({ name, hint: TOOL_HINTS.get(name) ?? "" })) };
+  }).filter((section) => section.tools.length > 0),
+);
 
 // A session with no GUI tools at all. The grid never reaches this — it reports `unavailable`
 // first, and that outranks — but "ask Claude to use one of these:" above an EMPTY list is a

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -117,6 +117,11 @@ const toolSections = computed(() => {
     tools: toolsInGroup(group).map((name) => ({ name, hint: TOOL_HINTS.get(name) ?? "" })),
   }));
 });
+
+// A session with no GUI tools at all. The grid never reaches this — it reports `unavailable`
+// first, and that outranks — but "ask Claude to use one of these:" above an EMPTY list is a
+// dead end for any caller that does, so the hint is dropped rather than left dangling.
+const hasTools = computed(() => toolSections.value.some((section) => section.tools.length > 0));
 </script>
 
 <template>
@@ -158,6 +163,7 @@ const toolSections = computed(() => {
       <!-- Grouped, and the group is named: the switches in the launcher are per group, so a user
            who wants a tool that isn't listed needs to know WHICH one to turn on. The heading is
            dropped when there is only one — naming a division of one explains nothing. -->
+      <div v-else-if="!hasContent && !hasTools" data-testid="canvas-no-tools" class="text-[13px] text-dim">This session has no GUI tools.</div>
       <div v-else-if="!hasContent" data-testid="canvas-empty" class="text-[13px] text-dim">
         Ask Claude to use one of these:
         <div v-for="section in toolSections" :key="section.group" class="mt-1.5">

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -3,7 +3,7 @@ import { ref, computed } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { getPlugin } from "../plugins-registry";
 import PluginFrame from "./PluginFrame.vue";
-import { CANVAS_TOOL_GROUP, toolsInGroup } from "../../common/toolGroups";
+import { TOOL_GROUPS, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -29,7 +29,12 @@ const props = defineProps<{
   // it mounted — and the empty-state hint below ("ask Claude to use one of these") is a LIE in
   // both cases: there is nothing to ask, or nothing that could answer. Absent/null means the
   // panel is usable, which keeps the single view (where it always is) unchanged.
-  unavailable?: "no-session" | "no-render-mcp" | null;
+  unavailable?: "no-session" | "no-canvas-mcp" | null;
+  // The GUI tool groups this session actually reached us on, so the empty state lists what THIS
+  // terminal can be asked for rather than a fixed set — a cell with only `render` registered
+  // should not be told to ask for generateImage. Absent means "everything": the single view
+  // connects on the all-tools URL, where no group was ever selected (common/toolGroups.ts).
+  groups?: ToolGroup[];
 }>();
 const emit = defineEmits<{ toggleTools: [] }>();
 
@@ -77,19 +82,41 @@ async function onUpdateResult(existing: ToolResult, update: Partial<ToolResult>)
 
 const hasContent = computed(() => results.value.length > 0);
 
-// What each drawing tool produces, so the empty state says what asking for one would get rather
-// than only naming it. A Map for the same reason common/toolGroups.ts uses one, and consulted
-// with a fallback: the NAMES come from the group table, so a render tool added there shows up
-// here immediately — unnamed rather than missing, which is the failure that is noticed.
-const CANVAS_TOOL_HINTS = new Map<string, string>([
+// What each tool produces, so the empty state says what asking for one would get rather than
+// only naming it. A Map for the same reason common/toolGroups.ts uses one, and consulted with a
+// fallback: the NAMES come from the group table, so a tool added there shows up here
+// immediately — unnamed rather than missing, which is the failure that is noticed.
+const TOOL_HINTS = new Map<string, string>([
   ["presentDocument", "a formatted document, written in markdown"],
   ["presentForm", "a form to fill in and send back"],
   ["presentChart", "a chart from a set of data"],
   ["presentHtml", "a self-contained web page"],
+
+  ["presentCollection", "a collection from this workspace, laid out to browse"],
+  ["manageCollection", "reads and writes those collections and their schemas"],
+  ["manageAccounting", "reads and writes the workspace's books"],
+
+  ["generateImage", "an image generated from a prompt"],
+  ["presentMulmoScript", "a MulmoScript presentation, built and played here"],
+
+  ["google", "your linked Google account: Calendar, Tasks, Drive"],
+  ["readXPost", "one post on X, fetched by URL or id"],
+  ["searchX", "recent posts on X matching a query"],
 ]);
 
-// The complete render group, not a sample of it.
-const canvasTools = computed(() => toolsInGroup(CANVAS_TOOL_GROUP).map((name) => ({ name, hint: CANVAS_TOOL_HINTS.get(name) ?? "" })));
+// Every group this session has, each with ALL its members — the whole of what the terminal can
+// be asked for, not a sample. This is the only place the tools are named, and a user reading
+// "presentDocument or presentForm" has no way to learn that a chart, a web page or an image is
+// also on offer. Ordered by TOOL_GROUPS (blast radius, least first) rather than by the order the
+// session happened to connect its MCP clients in, so the list does not reshuffle between cells.
+const toolSections = computed(() => {
+  const session = props.groups;
+  const groups = session ? TOOL_GROUPS.filter((group) => session.includes(group)) : TOOL_GROUPS;
+  return groups.map((group) => ({
+    group,
+    tools: toolsInGroup(group).map((name) => ({ name, hint: TOOL_HINTS.get(name) ?? "" })),
+  }));
+});
 </script>
 
 <template>
@@ -123,21 +150,25 @@ const canvasTools = computed(() => toolsInGroup(CANVAS_TOOL_GROUP).map((name) =>
           <div class="font-medium text-secondary">Canvas is not enabled for this session</div>
           <p class="mt-1">
             Its agent was started without the drawing tools, so nothing can appear here. They are handed out at startup: turn on
-            <span class="whitespace-nowrap font-medium">CANVAS (render MCPs)</span> in this cell's launcher, then restart the cell.
+            <span class="whitespace-nowrap font-medium">CANVAS (render MCPs)</span> — or <span class="whitespace-nowrap font-medium">CANVAS (media MCPs)</span>,
+            for generated images and MulmoScript — in this cell's launcher, then restart the cell.
           </p>
         </template>
       </div>
-      <!-- The whole group is listed rather than an example or two: this is the only place the
-           tools are named, and a user reading "presentDocument or presentForm" has no way to
-           learn that a chart or a web page is also on offer. -->
+      <!-- Grouped, and the group is named: the switches in the launcher are per group, so a user
+           who wants a tool that isn't listed needs to know WHICH one to turn on. The heading is
+           dropped when there is only one — naming a division of one explains nothing. -->
       <div v-else-if="!hasContent" data-testid="canvas-empty" class="text-[13px] text-dim">
-        Ask Claude to use one of these to render content here:
-        <ul class="mt-1.5 list-disc space-y-1 pl-4 marker:text-border">
-          <li v-for="tool in canvasTools" :key="tool.name">
-            <code class="rounded-[4px] bg-subtle px-[5px] py-px">{{ tool.name }}</code>
-            <template v-if="tool.hint"> &mdash; {{ tool.hint }}</template>
-          </li>
-        </ul>
+        Ask Claude to use one of these:
+        <div v-for="section in toolSections" :key="section.group" class="mt-1.5">
+          <div v-if="toolSections.length > 1" class="text-[11px] uppercase tracking-[0.05em] text-muted">{{ section.group }}</div>
+          <ul class="mt-1 list-disc space-y-1 pl-4 marker:text-border">
+            <li v-for="tool in section.tools" :key="tool.name">
+              <code class="rounded-[4px] bg-subtle px-[5px] py-px">{{ tool.name }}</code>
+              <template v-if="tool.hint"> &mdash; {{ tool.hint }}</template>
+            </li>
+          </ul>
+        </div>
       </div>
       <!-- Guarded as well as cleared on session change: a stale view rendered under an
            "unavailable" heading would contradict it. -->

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -11,6 +11,7 @@ import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import DirBadge from "./DirBadge.vue";
 import { isCellContext, isCellUsage, type CellContext, type CellUsage } from "./cellPayload";
 import { CANVAS_TOOL_GROUPS, toolGroupServerId, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
+import { queueCanvasWrite } from "./canvasWriteQueue";
 import { unsavedWork } from "./unsavedWork";
 import { relativeTime as relativeTimeFrom, usageBadge } from "./cellDisplay";
 import { applyActivityPush, cellHeaderText } from "./cellActivity";
@@ -573,7 +574,11 @@ async function loadCanvasEnabled() {
 
 // Writes into the user's Claude Code config, so a failure is surfaced and the checkbox is put
 // back — a switch that shows "on" for a registration that was never written is the worst state.
-async function applyCanvas(group: ToolGroup) {
+function applyCanvas(group: ToolGroup): Promise<void> {
+  return queueCanvasWrite(() => writeCanvasGroup(group));
+}
+
+async function writeCanvasGroup(group: ToolGroup) {
   const dir = canvasDir.value;
   if (!dir) return;
   const wanted = canvasEnabled.value[group];
@@ -660,18 +665,20 @@ const reuseWorktree = async (w: Worktree) => {
 async function carryCanvasInto(worktreePath: string) {
   if (!canvasDir.value || worktreePath === canvasDir.value) return;
   const enabled = CANVAS_TOOL_GROUPS.filter((group) => canvasEnabled.value[group]);
-  try {
-    // Serially, not Promise.all: each POST shells out to `claude mcp add`, which read-modify-
-    // writes the SAME local-scope config file — two in flight can lose one of the two entries.
-    for (const group of enabled) {
-      await fetch("/api/gui-mcp-groups", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ cwd: worktreePath, group, enabled: true }),
-      });
-    }
-  } catch {
-    // best-effort — a worktree without the registration still launches, just without Canvas
+  // Through the same queue as the switches, one group at a time: a launch that fires while a
+  // checkbox is still saving would otherwise be the very concurrent write the queue exists for.
+  for (const group of enabled) {
+    await queueCanvasWrite(async () => {
+      try {
+        await fetch("/api/gui-mcp-groups", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ cwd: worktreePath, group, enabled: true }),
+        });
+      } catch {
+        // best-effort — a worktree without the registration still launches, just without Canvas
+      }
+    });
   }
 }
 

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -10,7 +10,7 @@ import { useWorkItem } from "../composables/useWorkItem";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import DirBadge from "./DirBadge.vue";
 import { isCellContext, isCellUsage, type CellContext, type CellUsage } from "./cellPayload";
-import { CANVAS_TOOL_GROUP } from "../../common/toolGroups";
+import { CANVAS_TOOL_GROUPS, toolGroupServerId, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
 import { unsavedWork } from "./unsavedWork";
 import { relativeTime as relativeTimeFrom, usageBadge } from "./cellDisplay";
 import { applyActivityPush, cellHeaderText } from "./cellActivity";
@@ -520,15 +520,30 @@ const worktrees = ref<Worktree[]>([]);
 const worktreeTask = ref("");
 let worktreesReq = 0;
 
-// Whether this directory lets its agents draw into the Canvas panel. NOT MulmoTerminal state:
-// it is a `render`-group MCP server registered in Claude Code's own local-scope config for this
-// directory, so the switch reads and writes through /api/gui-mcp-groups and `claude mcp list`
-// stays the one place it can be seen. Read per directory, like the worktree list above.
+// Whether this directory lets its agents draw into the Canvas panel, per Canvas GROUP (render,
+// media). NOT MulmoTerminal state: each is an MCP server registered in Claude Code's own
+// local-scope config for this directory, so the switches read and write through
+// /api/gui-mcp-groups and `claude mcp list` stays the one place they can be seen. Read per
+// directory, like the worktree list above.
+//
+// One record per group rather than a flag per group: the two switches differ only in the group
+// they name, so adding a third to CANVAS_TOOL_GROUPS should not mean a third copy of this block.
+const byCanvasGroup = <T,>(value: T): Record<ToolGroup, T> => Object.fromEntries(CANVAS_TOOL_GROUPS.map((group) => [group, value])) as Record<ToolGroup, T>;
+
 const canvasDir = ref<string | null>(null);
-const canvasEnabled = ref(false);
-const canvasBusy = ref(false);
-const canvasError = ref<string | null>(null);
+const canvasEnabled = ref(byCanvasGroup(false));
+const canvasBusy = ref(byCanvasGroup(false));
+const canvasError = ref(byCanvasGroup<string | null>(null));
 let canvasReq = 0;
+
+// What the switch actually does, spelled out for the hover: the MCP SERVER ID it registers and
+// the tools that id brings with it. The row's visible label can only name the group, and the
+// group name alone ("render", "media") does not say which server appears in `claude mcp list`
+// nor what the agent gains — that is exactly what a user checking the box wants to know.
+// Derived from toolGroups.ts rather than written out, so a tool added to a group shows up here
+// without a second edit (the Canvas empty state names them the same way).
+const canvasTitle = (group: ToolGroup): string =>
+  `Registers the MCP server "${toolGroupServerId(group)}" for this directory — tools: ${toolsInGroup(group).join(", ")}`;
 
 async function loadCanvasEnabled() {
   const dir = dirInput.value.trim() || props.defaultCwd;
@@ -545,8 +560,10 @@ async function loadCanvasEnabled() {
     // the new directory's name.
     if (reqId !== canvasReq) return;
     canvasDir.value = dir;
-    canvasEnabled.value = Array.isArray(data.groups) && data.groups.includes(CANVAS_TOOL_GROUP);
-    canvasError.value = null;
+    const registered: unknown[] = Array.isArray(data.groups) ? data.groups : [];
+    canvasEnabled.value = byCanvasGroup(false);
+    for (const group of CANVAS_TOOL_GROUPS) canvasEnabled.value[group] = registered.includes(group);
+    canvasError.value = byCanvasGroup(null);
   } catch {
     // No switch rather than one whose position is a guess — flipping a wrong "off" would run
     // `claude mcp remove` on a registration the user may actually have.
@@ -556,26 +573,26 @@ async function loadCanvasEnabled() {
 
 // Writes into the user's Claude Code config, so a failure is surfaced and the checkbox is put
 // back — a switch that shows "on" for a registration that was never written is the worst state.
-async function applyCanvas() {
+async function applyCanvas(group: ToolGroup) {
   const dir = canvasDir.value;
   if (!dir) return;
-  const wanted = canvasEnabled.value;
-  canvasBusy.value = true;
-  canvasError.value = null;
+  const wanted = canvasEnabled.value[group];
+  canvasBusy.value[group] = true;
+  canvasError.value[group] = null;
   try {
     const res = await fetch("/api/gui-mcp-groups", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwd: dir, group: CANVAS_TOOL_GROUP, enabled: wanted }),
+      body: JSON.stringify({ cwd: dir, group, enabled: wanted }),
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     if (!data.ok) throw new Error(data.message || "claude mcp failed");
   } catch (e) {
-    canvasEnabled.value = !wanted;
-    canvasError.value = e instanceof Error ? e.message : String(e);
+    canvasEnabled.value[group] = !wanted;
+    canvasError.value[group] = e instanceof Error ? e.message : String(e);
   } finally {
-    canvasBusy.value = false;
+    canvasBusy.value[group] = false;
   }
 }
 
@@ -631,20 +648,28 @@ const reuseWorktree = async (w: Worktree) => {
 };
 
 // Claude Code keys local-scope MCP config by the CLI's working directory, and a worktree launch
-// starts claude in the WORKTREE — not in the repository the switch above was set for. Without
+// starts claude in the WORKTREE — not in the repository the switches above were set for. Without
 // this the session gets no render tools even though the launcher plainly says Canvas is on.
+//
+// Every group that is on, not just render: a worktree that inherited half the switches would be
+// a launcher telling the truth about the repo and a lie about the room it just opened.
 //
 // Copied rather than moved: the repository keeps its own registration, and a worktree is a
 // throwaway room that should start out like the repo it came from. Failures are swallowed —
 // the launch itself is what the user asked for, and the Canvas button will report the truth.
 async function carryCanvasInto(worktreePath: string) {
-  if (!canvasEnabled.value || !canvasDir.value || worktreePath === canvasDir.value) return;
+  if (!canvasDir.value || worktreePath === canvasDir.value) return;
+  const enabled = CANVAS_TOOL_GROUPS.filter((group) => canvasEnabled.value[group]);
   try {
-    await fetch("/api/gui-mcp-groups", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ cwd: worktreePath, group: CANVAS_TOOL_GROUP, enabled: true }),
-    });
+    // Serially, not Promise.all: each POST shells out to `claude mcp add`, which read-modify-
+    // writes the SAME local-scope config file — two in flight can lose one of the two entries.
+    for (const group of enabled) {
+      await fetch("/api/gui-mcp-groups", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cwd: worktreePath, group, enabled: true }),
+      });
+    }
   } catch {
     // best-effort — a worktree without the registration still launches, just without Canvas
   }
@@ -1696,28 +1721,43 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <!-- Canvas is a per-DIRECTORY registration in Claude Code's own MCP config, not a
              per-launch choice — but it only takes effect when a session starts, so this is
              where it belongs: decided before the thing it configures exists. Claude only;
-             codex reaches the GUI tools by another route. -->
-        <label v-if="agent === 'claude' && canvasDir" class="flex w-full max-w-[360px] items-center justify-between gap-2">
-          <!-- The group is named, not just the feature: the switch registers ONE MCP server
-               (`mulmoterminal-render`) and the other groups are added with `claude mcp add`, so
-               a label reading only "Canvas" would suggest it covers all of them. `normal-case`
-               on the suffix — the section labels around it are uppercased by class, and
-               "(RENDER MCPS)" reads as a different thing than the server it names. -->
-          <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">Canvas <span class="normal-case">(render MCPs)</span></span>
-          <span class="flex items-center gap-2">
-            <span v-if="canvasBusy" class="font-sans text-[11px] text-dim">saving…</span>
-            <span v-else-if="canvasError" class="font-sans text-[11px] text-err-text" :title="canvasError">failed</span>
-            <input
-              v-model="canvasEnabled"
-              data-testid="cell-canvas-toggle"
-              type="checkbox"
-              class="h-3.5 w-3.5 cursor-pointer accent-accent"
-              :disabled="canvasBusy"
-              :aria-label="`Register the render MCP group so the agent can draw in ${canvasDir}`"
-              @change="applyCanvas"
-            />
-          </span>
-        </label>
+             codex reaches the GUI tools by another route.
+             One row per Canvas group: both draw into the same pane, and they are separate
+             switches because a media call is slow, paid and writes files where a render call
+             stops at the pane (see common/toolGroups.ts). -->
+        <template v-if="agent === 'claude' && canvasDir">
+          <!-- The hover names the server id and its tools (canvasTitle); it sits on the ROW so
+               the text is reachable from the label as well as the box. -->
+          <label
+            v-for="group in CANVAS_TOOL_GROUPS"
+            :key="group"
+            class="flex w-full max-w-[360px] items-center justify-between gap-2"
+            :title="canvasTitle(group)"
+          >
+            <!-- The group is named, not just the feature: each switch registers ONE MCP server
+               (`mulmoterminal-<group>`) and the remaining groups are added with `claude mcp
+               add`, so a label reading only "Canvas" would suggest it covers all of them.
+               `normal-case` on the suffix — the section labels around it are uppercased by
+               class, and "(RENDER MCPS)" reads as a different thing than the server it names. -->
+            <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim"
+              >Canvas <span class="normal-case">({{ group }} MCPs)</span></span
+            >
+            <span class="flex items-center gap-2">
+              <span v-if="canvasBusy[group]" class="font-sans text-[11px] text-dim">saving…</span>
+              <span v-else-if="canvasError[group]" class="font-sans text-[11px] text-err-text" :title="canvasError[group]!">failed</span>
+              <input
+                v-model="canvasEnabled[group]"
+                :data-testid="`cell-canvas-toggle-${group}`"
+                type="checkbox"
+                class="h-3.5 w-3.5 cursor-pointer accent-accent"
+                :disabled="canvasBusy[group]"
+                :title="canvasTitle(group)"
+                :aria-label="`Register the MCP server ${toolGroupServerId(group)} (${toolsInGroup(group).join(', ')}) so the agent can draw in ${canvasDir}`"
+                @change="applyCanvas(group)"
+              />
+            </span>
+          </label>
+        </template>
         <div v-if="isGitRepo" data-testid="cell-worktrees" class="flex w-full max-w-[360px] flex-col items-stretch gap-1.5">
           <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim">or isolate in a worktree (git repo)</span>
           <div class="flex gap-1.5">

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -574,16 +574,26 @@ async function loadCanvasEnabled() {
 
 // Writes into the user's Claude Code config, so a failure is surfaced and the checkbox is put
 // back — a switch that shows "on" for a registration that was never written is the worst state.
+//
+// Busy is set HERE, when the write is queued, not when it starts running. Marking it at the
+// front of the queued callback would leave the checkbox live while it waits behind another
+// group's save: a second flip would queue a second write, and since a failed write puts its
+// checkbox back, the earlier failure's rollback would land on top of the later intent — flip on,
+// flip off, end up on. Disabled from the flip until the write settles, there is only ever one.
 function applyCanvas(group: ToolGroup): Promise<void> {
-  return queueCanvasWrite(() => writeCanvasGroup(group));
-}
-
-async function writeCanvasGroup(group: ToolGroup) {
-  const dir = canvasDir.value;
-  if (!dir) return;
+  if (!canvasDir.value) return Promise.resolve();
   const wanted = canvasEnabled.value[group];
   canvasBusy.value[group] = true;
   canvasError.value[group] = null;
+  return queueCanvasWrite(() => writeCanvasGroup(group, wanted));
+}
+
+async function writeCanvasGroup(group: ToolGroup, wanted: boolean) {
+  const dir = canvasDir.value;
+  if (!dir) {
+    canvasBusy.value[group] = false;
+    return;
+  }
   try {
     const res = await fetch("/api/gui-mcp-groups", {
       method: "POST",

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -580,20 +580,20 @@ async function loadCanvasEnabled() {
 // group's save: a second flip would queue a second write, and since a failed write puts its
 // checkbox back, the earlier failure's rollback would land on top of the later intent — flip on,
 // flip off, end up on. Disabled from the flip until the write settles, there is only ever one.
+// The DIRECTORY is captured here too, for the same reason: a queued write can run long after the
+// flip, and the launcher's directory field is editable the whole time. Read at execution time, a
+// switch ticked for A would register the MCP server against whatever B the user had typed by
+// then — a silent write to a folder they never touched the switch in.
 function applyCanvas(group: ToolGroup): Promise<void> {
-  if (!canvasDir.value) return Promise.resolve();
+  const dir = canvasDir.value;
+  if (!dir) return Promise.resolve();
   const wanted = canvasEnabled.value[group];
   canvasBusy.value[group] = true;
   canvasError.value[group] = null;
-  return queueCanvasWrite(() => writeCanvasGroup(group, wanted));
+  return queueCanvasWrite(() => writeCanvasGroup(group, dir, wanted));
 }
 
-async function writeCanvasGroup(group: ToolGroup, wanted: boolean) {
-  const dir = canvasDir.value;
-  if (!dir) {
-    canvasBusy.value[group] = false;
-    return;
-  }
+async function writeCanvasGroup(group: ToolGroup, dir: string, wanted: boolean) {
   try {
     const res = await fetch("/api/gui-mcp-groups", {
       method: "POST",
@@ -604,8 +604,13 @@ async function writeCanvasGroup(group: ToolGroup, wanted: boolean) {
     const data = await res.json();
     if (!data.ok) throw new Error(data.message || "claude mcp failed");
   } catch (e) {
-    canvasEnabled.value[group] = !wanted;
-    canvasError.value[group] = e instanceof Error ? e.message : String(e);
+    // Only if the switches still belong to the directory this write was for. Moved on, they are
+    // showing what the NEW directory has registered, and putting one back would report another
+    // folder's failure as that directory's state.
+    if (canvasDir.value === dir) {
+      canvasEnabled.value[group] = !wanted;
+      canvasError.value[group] = e instanceof Error ? e.message : String(e);
+    }
   } finally {
     canvasBusy.value[group] = false;
   }

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -242,6 +242,10 @@ const canvasChecked = ref(false);
 // EVERY group this session reached us on, not only the canvas ones: the pane's empty state lists
 // the GUI tools this terminal actually has, and a cell that also registered `data` or `external`
 // can be asked for those in the same conversation.
+//
+// Only handed to the panel once `canvasChecked` (see the template): until the reply lands this is
+// the starting `[]`, which as a group list means "this session has NO GUI tools" — a narrower
+// claim than we can make yet, and one the panel would answer with a dead end.
 const sessionGroups = ref<ToolGroup[]>([]);
 const readGroups = (groups: unknown): ToolGroup[] => (Array.isArray(groups) ? groups.filter(isToolGroup) : []);
 watch(
@@ -648,7 +652,7 @@ watch(
           :session-id="expandedSessionId"
           :send-text-message="sendToExpandedCell"
           :unavailable="canvasUnavailable"
-          :groups="sessionGroups"
+          :groups="canvasChecked ? sessionGroups : undefined"
           :style="{ flex: `0 0 ${paneWidth}px` }"
           @toggle-tools="toggleRightPane('tools')"
         />

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -24,7 +24,7 @@ import { setFilesPaneOpener } from "../composables/filesPaneOpener";
 import { paneCanShowClick } from "./paneClickTarget";
 import { usePubSub } from "../composables/usePubSub";
 import { TOOL_GROUPS_CHANNEL } from "../toolGroupsChannel";
-import { hasCanvasGroup, isToolGroup, type ToolGroup } from "../../common/toolGroups";
+import { hasCanvasGroup } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 
@@ -239,21 +239,11 @@ const canvasAvailable = ref(false);
 // "not enabled for this session" for the moment between switching cells and the reply landing
 // — a wrong explanation is worse than none, so nothing is claimed until it is known.
 const canvasChecked = ref(false);
-// EVERY group this session reached us on, not only the canvas ones: the pane's empty state lists
-// the GUI tools this terminal actually has, and a cell that also registered `data` or `external`
-// can be asked for those in the same conversation.
-//
-// Only handed to the panel once `canvasChecked` (see the template): until the reply lands this is
-// the starting `[]`, which as a group list means "this session has NO GUI tools" — a narrower
-// claim than we can make yet, and one the panel would answer with a dead end.
-const sessionGroups = ref<ToolGroup[]>([]);
-const readGroups = (groups: unknown): ToolGroup[] => (Array.isArray(groups) ? groups.filter(isToolGroup) : []);
 watch(
   [expandedSessionId, () => props.expandedUid],
   async ([sessionId]) => {
     canvasAvailable.value = false;
     canvasChecked.value = false;
-    sessionGroups.value = [];
     if (!sessionId) return;
     try {
       const res = await fetch(`/api/tools?sessionId=${encodeURIComponent(sessionId)}`);
@@ -266,7 +256,6 @@ watch(
       // presentCollection, which belongs to `data` and draws nothing without the collection
       // store behind it.
       canvasAvailable.value = hasCanvasGroup(body.groups);
-      sessionGroups.value = readGroups(body.groups);
       canvasChecked.value = true;
     } catch {
       // Unreachable server: no button rather than one that opens an empty panel. Left unchecked
@@ -286,7 +275,6 @@ const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
   const msg = data as { sessionId?: string; groups?: string[] };
   if (!msg?.sessionId || msg.sessionId !== expandedSessionId.value) return;
   canvasAvailable.value = hasCanvasGroup(msg.groups);
-  sessionGroups.value = readGroups(msg.groups);
   canvasChecked.value = true;
 });
 onBeforeUnmount(() => offToolGroups());
@@ -652,7 +640,6 @@ watch(
           :session-id="expandedSessionId"
           :send-text-message="sendToExpandedCell"
           :unavailable="canvasUnavailable"
-          :groups="canvasChecked ? sessionGroups : undefined"
           :style="{ flex: `0 0 ${paneWidth}px` }"
           @toggle-tools="toggleRightPane('tools')"
         />

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -24,7 +24,7 @@ import { setFilesPaneOpener } from "../composables/filesPaneOpener";
 import { paneCanShowClick } from "./paneClickTarget";
 import { usePubSub } from "../composables/usePubSub";
 import { TOOL_GROUPS_CHANNEL } from "../toolGroupsChannel";
-import { CANVAS_TOOL_GROUP } from "../../common/toolGroups";
+import { hasCanvasGroup, isToolGroup, type ToolGroup } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
 
@@ -239,11 +239,17 @@ const canvasAvailable = ref(false);
 // "not enabled for this session" for the moment between switching cells and the reply landing
 // — a wrong explanation is worse than none, so nothing is claimed until it is known.
 const canvasChecked = ref(false);
+// EVERY group this session reached us on, not only the canvas ones: the pane's empty state lists
+// the GUI tools this terminal actually has, and a cell that also registered `data` or `external`
+// can be asked for those in the same conversation.
+const sessionGroups = ref<ToolGroup[]>([]);
+const readGroups = (groups: unknown): ToolGroup[] => (Array.isArray(groups) ? groups.filter(isToolGroup) : []);
 watch(
   [expandedSessionId, () => props.expandedUid],
   async ([sessionId]) => {
     canvasAvailable.value = false;
     canvasChecked.value = false;
+    sessionGroups.value = [];
     if (!sessionId) return;
     try {
       const res = await fetch(`/api/tools?sessionId=${encodeURIComponent(sessionId)}`);
@@ -251,10 +257,12 @@ watch(
       const body = await res.json();
       // Late reply for a cell we have since walked away from would show the wrong button.
       if (sessionId !== expandedSessionId.value) return;
-      // The GROUPS, not the tool names. Every cell here is a grid cell, so "has render" is the
-      // whole question — and matching on a `present*` prefix would count presentCollection,
-      // which belongs to `data` and draws nothing without the collection store behind it.
-      canvasAvailable.value = Array.isArray(body.groups) && body.groups.includes(CANVAS_TOOL_GROUP);
+      // The GROUPS, not the tool names. Every cell here is a grid cell, so "has a canvas group"
+      // is the whole question — and matching on a `present*` prefix would count
+      // presentCollection, which belongs to `data` and draws nothing without the collection
+      // store behind it.
+      canvasAvailable.value = hasCanvasGroup(body.groups);
+      sessionGroups.value = readGroups(body.groups);
       canvasChecked.value = true;
     } catch {
       // Unreachable server: no button rather than one that opens an empty panel. Left unchecked
@@ -273,7 +281,8 @@ const { subscribe: subscribeToolGroups } = usePubSub();
 const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
   const msg = data as { sessionId?: string; groups?: string[] };
   if (!msg?.sessionId || msg.sessionId !== expandedSessionId.value) return;
-  canvasAvailable.value = Array.isArray(msg.groups) && msg.groups.includes(CANVAS_TOOL_GROUP);
+  canvasAvailable.value = hasCanvasGroup(msg.groups);
+  sessionGroups.value = readGroups(msg.groups);
   canvasChecked.value = true;
 });
 onBeforeUnmount(() => offToolGroups());
@@ -281,9 +290,9 @@ onBeforeUnmount(() => offToolGroups());
 // What the Canvas pane should say instead of its "ask Claude to draw something" hint. The pane
 // outlives the cell it was opened on, so walking the zoom lands it on cells that can never fill
 // it — a launcher or a command cell (no session), or a directory with no render MCP.
-const canvasUnavailable = computed<"no-session" | "no-render-mcp" | null>(() => {
+const canvasUnavailable = computed<"no-session" | "no-canvas-mcp" | null>(() => {
   if (!expandedSessionId.value) return "no-session";
-  if (canvasChecked.value && !canvasAvailable.value) return "no-render-mcp";
+  if (canvasChecked.value && !canvasAvailable.value) return "no-canvas-mcp";
   return null;
 });
 const filesPane = ref<InstanceType<typeof FilesPane> | null>(null);
@@ -639,6 +648,7 @@ watch(
           :session-id="expandedSessionId"
           :send-text-message="sendToExpandedCell"
           :unavailable="canvasUnavailable"
+          :groups="sessionGroups"
           :style="{ flex: `0 0 ${paneWidth}px` }"
           @toggle-tools="toggleRightPane('tools')"
         />

--- a/src/components/canvasWriteQueue.ts
+++ b/src/components/canvasWriteQueue.ts
@@ -1,0 +1,23 @@
+// One write at a time to Claude Code's MCP config.
+//
+// Every Canvas switch in the launcher POSTs to /api/gui-mcp-groups, which shells out to
+// `claude mcp add` / `claude mcp remove`. Those read-modify-write Claude Code's own config, so
+// two in flight can lose one of the two registrations — leaving a checkbox showing "on" for a
+// server that was never written, which is the one state the switch must never reach.
+//
+// The queue is MODULE level, not per component: the file being written is Claude Code's, shared
+// by every directory, so two cells saving at once race exactly as two checkboxes in one cell do.
+export type CanvasWriteQueue = (write: () => Promise<void>) => Promise<void>;
+
+export function createCanvasWriteQueue(): CanvasWriteQueue {
+  let chain: Promise<void> = Promise.resolve();
+  return (write) => {
+    // The SAME callback for both settlements, rather than `.then(write).catch(...)`: a rejected
+    // link must not become every later write's rejection, and a failed write must not stop the
+    // next one from running. Each write reports its own failure.
+    chain = chain.then(write, write);
+    return chain;
+  };
+}
+
+export const queueCanvasWrite: CanvasWriteQueue = createCanvasWriteQueue();

--- a/test/common/toolGroups.spec.ts
+++ b/test/common/toolGroups.spec.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect } from "vitest";
 
-import { TOOL_GROUPS, isToolGroup, groupOfTool, toolsInGroup, toolGroupServerId, AUTO_ALLOWED_TOOLS, CANVAS_TOOL_GROUP } from "../../common/toolGroups.js";
+import {
+  TOOL_GROUPS,
+  isToolGroup,
+  groupOfTool,
+  toolsInGroup,
+  toolGroupServerId,
+  AUTO_ALLOWED_TOOLS,
+  CANVAS_TOOL_GROUPS,
+  hasCanvasGroup,
+} from "../../common/toolGroups.js";
 
 describe("tool groups", () => {
   it("classifies the drawing tools as render", () => {
@@ -80,16 +89,38 @@ describe("tool groups", () => {
   });
 });
 
-// The launcher switch, the panel's availability check and the server all decide on this same
-// group. Written as a literal at each site, a rename would break Canvas detection silently and
+// The launcher switches, the panel's availability check and the server all decide on these same
+// groups. Written as literals at each site, a rename would break Canvas detection silently and
 // with no type error — which is what the repo's "shared wire values live in common/" rule is for.
-describe("CANVAS_TOOL_GROUP", () => {
-  it("names a real group", () => {
-    expect(TOOL_GROUPS).toContain(CANVAS_TOOL_GROUP);
+describe("CANVAS_TOOL_GROUPS", () => {
+  it("names only real groups", () => {
+    for (const group of CANVAS_TOOL_GROUPS) expect(TOOL_GROUPS).toContain(group);
   });
 
-  it("is the group the drawing tools belong to", () => {
-    expect(groupOfTool("presentDocument")).toBe(CANVAS_TOOL_GROUP);
-    expect(groupOfTool("presentHtml")).toBe(CANVAS_TOOL_GROUP);
+  // Both groups DRAW into the same pane; they are two switches because a media call costs money
+  // and writes files where a render call stops at the pane.
+  it("covers the drawing tools of both groups", () => {
+    expect(CANVAS_TOOL_GROUPS).toContain(groupOfTool("presentHtml"));
+    expect(CANVAS_TOOL_GROUPS).toContain(groupOfTool("presentDocument"));
+    expect(CANVAS_TOOL_GROUPS).toContain(groupOfTool("generateImage"));
+    expect(CANVAS_TOOL_GROUPS).toContain(groupOfTool("presentMulmoScript"));
+  });
+
+  // The groups a session cannot draw with. Counting one of them would open a Canvas pane that
+  // nothing can ever fill.
+  it("leaves out the groups that draw nothing", () => {
+    expect(CANVAS_TOOL_GROUPS).not.toContain("data");
+    expect(CANVAS_TOOL_GROUPS).not.toContain("external");
+  });
+
+  // Asked of whatever the server reported, which arrives as untyped JSON.
+  it("detects a canvas group in a reported group list", () => {
+    expect(hasCanvasGroup(["render"])).toBe(true);
+    expect(hasCanvasGroup(["data", "media"])).toBe(true);
+    expect(hasCanvasGroup(["data", "external"])).toBe(false);
+    expect(hasCanvasGroup([])).toBe(false);
+    expect(hasCanvasGroup(["renderer"])).toBe(false);
+    expect(hasCanvasGroup(undefined)).toBe(false);
+    expect(hasCanvasGroup("render")).toBe(false);
   });
 });

--- a/test/src/components/GuiPanelEmptyState.spec.ts
+++ b/test/src/components/GuiPanelEmptyState.spec.ts
@@ -67,6 +67,17 @@ describe("the canvas pane's empty state", () => {
     expect(itemsOf(w)).toHaveLength(TOOL_GROUPS.flatMap(toolsInGroup).length);
   });
 
+  // The boundary between the two meanings of "no groups": `undefined` is the single view, which
+  // reaches everything; `[]` is a session that reached nothing. Answering the second with the
+  // hint's heading and no list under it is a dead end, so the hint goes entirely.
+  it("drops the hint rather than heading an empty list when the session has no groups", async () => {
+    const w = mountPanel([]);
+    await flushPromises();
+    expect(w.find('[data-testid="canvas-empty"]').exists()).toBe(false);
+    expect(w.find('[data-testid="canvas-no-tools"]').exists()).toBe(true);
+    expect(w.text()).not.toContain("presentDocument");
+  });
+
   // Naming a tool says nothing about what asking for it would get.
   it("says what each one produces", async () => {
     const w = mountPanel();

--- a/test/src/components/GuiPanelEmptyState.spec.ts
+++ b/test/src/components/GuiPanelEmptyState.spec.ts
@@ -1,77 +1,104 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import GuiPanel from "../../../src/components/GuiPanel.vue";
-import { TOOL_GROUPS, toolsInGroup, type ToolGroup } from "../../../common/toolGroups";
+import { TOOL_GROUPS, toolsInGroup } from "../../../common/toolGroups";
 
 // The empty Canvas is the only place the GUI tools are named, so the list is the feature's
 // documentation. It named two of the four, and a user reading it had no way to learn that a chart
 // or a web page was also on offer.
 vi.mock("../../../src/composables/usePubSub", () => ({ usePubSub: () => ({ subscribe: () => () => {} }) }));
 
-const mountPanel = (groups?: ToolGroup[]) =>
-  mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true, groups }, global: { stubs: { PluginFrame: true } } });
-
-beforeEach(() => {
+// The panel asks the SERVER which tools this session has (/api/tools) rather than rebuilding the
+// list from the group table: a grid cell reaches only its registered groups, and a plugin whose
+// requiredEnv is unmet is dropped at load. `tools: null` stands for a request that never answers.
+const mockServer = (tools: string[] | null) => {
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => ({ ok: true, json: async () => ({ toolResults: [] }) })),
+    vi.fn(async (url: string) => {
+      if (String(url).includes("/api/tools")) {
+        if (tools === null) return { ok: false, status: 500, json: async () => ({}) };
+        return { ok: true, json: async () => ({ tools: tools.map((toolName) => ({ toolName, title: toolName })) }) };
+      }
+      return { ok: true, json: async () => ({ toolResults: [] }) };
+    }),
   );
-});
+};
 
+const mountPanel = () => mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true }, global: { stubs: { PluginFrame: true } } });
 const itemsOf = (w: ReturnType<typeof mountPanel>) => w.findAll('[data-testid="canvas-empty"] li').map((li) => li.text());
+
+beforeEach(() => {
+  mockServer(TOOL_GROUPS.flatMap(toolsInGroup));
+});
 
 describe("the canvas pane's empty state", () => {
   // Compared against the group table rather than a list repeated here: a copy would go stale in
   // exactly the way this test exists to catch.
-  it("names every tool in the session's groups", async () => {
-    const w = mountPanel(["render", "media"]);
+  it("names every tool the session actually has", async () => {
+    const tools = [...toolsInGroup("render"), ...toolsInGroup("media")];
+    mockServer(tools);
+    const w = mountPanel();
     await flushPromises();
     const items = itemsOf(w);
-    const tools = [...toolsInGroup("render"), ...toolsInGroup("media")];
     expect(tools.length).toBeGreaterThan(1);
     expect(items).toHaveLength(tools.length);
     for (const tool of tools) expect(items.some((item) => item.includes(tool))).toBe(true);
   });
 
-  // The switches are per group, so a list that mixes them gives no clue which one to turn on.
+  // The switches in the launcher are per group, so a list that mixes them gives no clue which one
+  // to turn on for a tool that isn't there.
   it("names the group each tool came from once there is more than one", async () => {
-    const w = mountPanel(["render", "media"]);
+    mockServer([...toolsInGroup("render"), ...toolsInGroup("media")]);
+    const w = mountPanel();
     await flushPromises();
     expect(w.find('[data-testid="canvas-empty"]').text()).toContain("media");
   });
 
   // Whatever the terminal registered, and nothing else: a cell without the media group told to
   // ask for generateImage is being sent to a tool its agent was never handed.
-  it("lists only the groups this session has", async () => {
-    const w = mountPanel(["render"]);
+  it("lists only what the server offered", async () => {
+    mockServer(toolsInGroup("render"));
+    const w = mountPanel();
     await flushPromises();
     const items = itemsOf(w);
     expect(items.some((item) => item.includes("presentHtml"))).toBe(true);
     expect(items.some((item) => item.includes("generateImage"))).toBe(false);
   });
 
+  // The case the static group table gets wrong on its own: searchX / readXPost are dropped at
+  // load when X_BEARER_TOKEN is absent, so the group's OTHER members must still list without them.
+  it("leaves out a group member the server withheld", async () => {
+    mockServer(["presentHtml", "google"]);
+    const w = mountPanel();
+    await flushPromises();
+    const items = itemsOf(w);
+    expect(items.some((item) => item.includes("google"))).toBe(true);
+    expect(items.some((item) => item.includes("searchX"))).toBe(false);
+  });
+
   // A session that reached data / external tools can be asked for those in the same
   // conversation, and this list is the only place they are named.
   it("lists the non-drawing groups too when the session has them", async () => {
-    const w = mountPanel(["render", "data", "external"]);
+    const w = mountPanel();
     await flushPromises();
     const items = itemsOf(w);
     expect(items.some((item) => item.includes("manageCollection"))).toBe(true);
     expect(items.some((item) => item.includes("searchX"))).toBe(true);
   });
 
-  // The single view connects on the all-tools URL, where no group was ever selected.
-  it("falls back to every group when the caller names none", async () => {
+  // "No tools" and "not asked yet" are different answers. An unreachable /api/tools is our
+  // failure, and answering it with an empty pane blames the session for it.
+  it("falls back to the full list when the server cannot be asked", async () => {
+    mockServer(null);
     const w = mountPanel();
     await flushPromises();
     expect(itemsOf(w)).toHaveLength(TOOL_GROUPS.flatMap(toolsInGroup).length);
   });
 
-  // The boundary between the two meanings of "no groups": `undefined` is the single view, which
-  // reaches everything; `[]` is a session that reached nothing. Answering the second with the
-  // hint's heading and no list under it is a dead end, so the hint goes entirely.
-  it("drops the hint rather than heading an empty list when the session has no groups", async () => {
-    const w = mountPanel([]);
+  // "Ask Claude to use one of these:" above an EMPTY list is a dead end.
+  it("drops the hint rather than heading an empty list when the session has no tools", async () => {
+    mockServer([]);
+    const w = mountPanel();
     await flushPromises();
     expect(w.find('[data-testid="canvas-empty"]').exists()).toBe(false);
     expect(w.find('[data-testid="canvas-no-tools"]').exists()).toBe(true);
@@ -88,7 +115,10 @@ describe("the canvas pane's empty state", () => {
   it("is replaced once something has been drawn", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({ ok: true, json: async () => ({ toolResults: [{ uuid: "u1", toolName: "presentHtml", data: {} }] }) })),
+      vi.fn(async (url: string) => {
+        if (String(url).includes("/api/tools")) return { ok: true, json: async () => ({ tools: [] }) };
+        return { ok: true, json: async () => ({ toolResults: [{ uuid: "u1", toolName: "presentHtml", data: {} }] }) };
+      }),
     );
     const w = mountPanel();
     await flushPromises();

--- a/test/src/components/GuiPanelEmptyState.spec.ts
+++ b/test/src/components/GuiPanelEmptyState.spec.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import GuiPanel from "../../../src/components/GuiPanel.vue";
-import { CANVAS_TOOL_GROUP, toolsInGroup } from "../../../common/toolGroups";
+import { TOOL_GROUPS, toolsInGroup, type ToolGroup } from "../../../common/toolGroups";
 
-// The empty Canvas is the only place the drawing tools are named, so the list is the feature's
+// The empty Canvas is the only place the GUI tools are named, so the list is the feature's
 // documentation. It named two of the four, and a user reading it had no way to learn that a chart
 // or a web page was also on offer.
 vi.mock("../../../src/composables/usePubSub", () => ({ usePubSub: () => ({ subscribe: () => () => {} }) }));
 
-const mountPanel = () => mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true }, global: { stubs: { PluginFrame: true } } });
+const mountPanel = (groups?: ToolGroup[]) =>
+  mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true, groups }, global: { stubs: { PluginFrame: true } } });
 
 beforeEach(() => {
   vi.stubGlobal(
@@ -17,25 +18,60 @@ beforeEach(() => {
   );
 });
 
+const itemsOf = (w: ReturnType<typeof mountPanel>) => w.findAll('[data-testid="canvas-empty"] li').map((li) => li.text());
+
 describe("the canvas pane's empty state", () => {
   // Compared against the group table rather than a list repeated here: a copy would go stale in
   // exactly the way this test exists to catch.
-  it("names every tool in the render group", async () => {
-    const w = mountPanel();
+  it("names every tool in the session's groups", async () => {
+    const w = mountPanel(["render", "media"]);
     await flushPromises();
-    const items = w.findAll('[data-testid="canvas-empty"] li').map((li) => li.text());
-    const tools = toolsInGroup(CANVAS_TOOL_GROUP);
+    const items = itemsOf(w);
+    const tools = [...toolsInGroup("render"), ...toolsInGroup("media")];
     expect(tools.length).toBeGreaterThan(1);
     expect(items).toHaveLength(tools.length);
     for (const tool of tools) expect(items.some((item) => item.includes(tool))).toBe(true);
+  });
+
+  // The switches are per group, so a list that mixes them gives no clue which one to turn on.
+  it("names the group each tool came from once there is more than one", async () => {
+    const w = mountPanel(["render", "media"]);
+    await flushPromises();
+    expect(w.find('[data-testid="canvas-empty"]').text()).toContain("media");
+  });
+
+  // Whatever the terminal registered, and nothing else: a cell without the media group told to
+  // ask for generateImage is being sent to a tool its agent was never handed.
+  it("lists only the groups this session has", async () => {
+    const w = mountPanel(["render"]);
+    await flushPromises();
+    const items = itemsOf(w);
+    expect(items.some((item) => item.includes("presentHtml"))).toBe(true);
+    expect(items.some((item) => item.includes("generateImage"))).toBe(false);
+  });
+
+  // A session that reached data / external tools can be asked for those in the same
+  // conversation, and this list is the only place they are named.
+  it("lists the non-drawing groups too when the session has them", async () => {
+    const w = mountPanel(["render", "data", "external"]);
+    await flushPromises();
+    const items = itemsOf(w);
+    expect(items.some((item) => item.includes("manageCollection"))).toBe(true);
+    expect(items.some((item) => item.includes("searchX"))).toBe(true);
+  });
+
+  // The single view connects on the all-tools URL, where no group was ever selected.
+  it("falls back to every group when the caller names none", async () => {
+    const w = mountPanel();
+    await flushPromises();
+    expect(itemsOf(w)).toHaveLength(TOOL_GROUPS.flatMap(toolsInGroup).length);
   });
 
   // Naming a tool says nothing about what asking for it would get.
   it("says what each one produces", async () => {
     const w = mountPanel();
     await flushPromises();
-    const items = w.findAll('[data-testid="canvas-empty"] li').map((li) => li.text());
-    for (const item of items) expect(item.length).toBeGreaterThan("presentDocument".length + 4);
+    for (const item of itemsOf(w)) expect(item.length).toBeGreaterThan("presentDocument".length + 4);
   });
 
   it("is replaced once something has been drawn", async () => {

--- a/test/src/components/GuiPanelUnavailable.spec.ts
+++ b/test/src/components/GuiPanelUnavailable.spec.ts
@@ -40,13 +40,16 @@ describe("the canvas pane's unavailable states", () => {
   // the SESSION rather than the directory: the switch is per directory but takes effect at
   // startup, so a session older than the switch lacks the tools while the directory has them —
   // blaming the directory would send the user to a switch that is already on.
-  it("names the session's missing render MCP, and how to fix it", async () => {
-    const w = mountPanel({ sessionId: "s1", unavailable: "no-render-mcp" });
+  it("names the session's missing canvas MCPs, and how to fix it", async () => {
+    const w = mountPanel({ sessionId: "s1", unavailable: "no-canvas-mcp" });
     await flushPromises();
     const text = w.text();
     expect(text).toContain("not enabled for this session");
     expect(text).not.toContain("not enabled for this directory");
+    // Both switches, since either one fills the pane — naming only render sends someone who
+    // wants a generated image to the wrong checkbox.
     expect(text).toContain("CANVAS (render MCPs)");
+    expect(text).toContain("CANVAS (media MCPs)");
     expect(text).toContain("restart");
     expect(text).not.toContain("presentDocument");
   });
@@ -58,7 +61,7 @@ describe("the canvas pane's unavailable states", () => {
       "fetch",
       vi.fn(async () => ({ ok: true, json: async () => ({ toolResults: [{ uuid: "u1", toolName: "presentDocument", data: {} }] }) })),
     );
-    const w = mountPanel({ sessionId: "s1", unavailable: "no-render-mcp" });
+    const w = mountPanel({ sessionId: "s1", unavailable: "no-canvas-mcp" });
     await flushPromises();
     expect(w.find(".frame").exists()).toBe(false);
     expect(w.find('[data-testid="canvas-unavailable"]').exists()).toBe(true);

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1871,4 +1871,54 @@ describe("TerminalCell", () => {
     expect((w.find('[data-testid="cell-canvas-toggle-render"]').element as HTMLInputElement).checked).toBe(false);
     expect(w.text()).toContain("failed");
   });
+
+  // A queued write can run long after the flip, and the launcher's directory field is editable
+  // the whole time. The write below waits behind another group's save; read at execution time,
+  // the switch ticked for alpha would register the MCP server against beta — a silent write to a
+  // folder the user never touched the switch in.
+  it("writes a queued Canvas registration to the directory it was flipped in", async () => {
+    const first = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    const posted: { cwd: string; group: string; enabled: boolean }[] = [];
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) {
+        if (init?.method === "POST") {
+          posted.push(JSON.parse(String(init.body)));
+          // Only the FIRST write hangs; the second is what has to wait behind it.
+          return posted.length === 1 ? first.promise : { ok: true, json: async () => ({ ok: true }) };
+        }
+        return { ok: true, json: async () => ({ groups: [] }) };
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: false, worktrees: [] }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/home/me/proj", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(null, { defaultCwd: "/home/me/alpha" });
+    await flushPromises();
+
+    // media goes first and hangs; render queues behind it, both flipped in alpha.
+    await w.find('[data-testid="cell-canvas-toggle-media"]').setValue(true);
+    await w.find('[data-testid="cell-canvas-toggle-render"]').setValue(true);
+    expect(posted).toHaveLength(1);
+
+    // The user retypes the directory while render's write is still queued. The launcher reloads
+    // the switches for the new directory behind a 300ms debounce, so let it fire — that reload is
+    // what moves canvasDir off alpha, and it is exactly what the queued write must not pick up.
+    vi.useFakeTimers();
+    try {
+      await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/beta");
+      await vi.advanceTimersByTimeAsync(400);
+
+      first.resolve({ ok: true, json: async () => ({ ok: true }) });
+      await vi.advanceTimersByTimeAsync(0);
+    } finally {
+      vi.useRealTimers();
+    }
+    await flushPromises();
+
+    expect(posted).toHaveLength(2);
+    expect(posted.map((body) => body.cwd)).toEqual(["/home/me/alpha", "/home/me/alpha"]);
+  });
 });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1811,4 +1811,64 @@ describe("TerminalCell", () => {
     expect(bare?.find('[data-testid="cell-chip-color"]').exists()).toBe(false);
     expect(bare?.attributes("style") ?? "").not.toContain("color-mix");
   });
+
+  // The two Canvas switches write to ONE file (Claude Code's MCP config, via `claude mcp
+  // add/remove`), so their POSTs are queued one behind the other. That queue is only half the
+  // guard: a checkbox left live while its write waits its turn can be flipped again, and since a
+  // failed write puts its own checkbox back, the earlier rollback would land on top of the later
+  // intent — flip on, flip off, end up on. So the flip disables the box immediately.
+  it("disables a Canvas switch from the flip until its write settles", async () => {
+    const write = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string }) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) {
+        if (init?.method === "POST") return write.promise;
+        return { ok: true, json: async () => ({ groups: [] }) };
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: false, worktrees: [] }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/home/me/proj", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(null);
+    await flushPromises();
+
+    const box = w.find('[data-testid="cell-canvas-toggle-render"]');
+    expect(box.exists()).toBe(true);
+    await box.setValue(true);
+    // Disabled while the write is in flight — not merely once it reaches the front of the queue.
+    expect(box.attributes("disabled")).toBeDefined();
+
+    write.resolve({ ok: true, json: async () => ({ ok: true }) });
+    await flushPromises();
+    await nextTick();
+    expect(w.find('[data-testid="cell-canvas-toggle-render"]').attributes("disabled")).toBeUndefined();
+  });
+
+  // A rejected write is the case the lock exists for: the checkbox goes back to where it was,
+  // and it must be the flip that was actually attempted.
+  it("puts the Canvas switch back when its write fails", async () => {
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string }) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) {
+        if (init?.method === "POST") return { ok: false, status: 500, json: async () => ({}) };
+        return { ok: true, json: async () => ({ groups: [] }) };
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: false, worktrees: [] }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/home/me/proj", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(null);
+    await flushPromises();
+    const box = w.find('[data-testid="cell-canvas-toggle-render"]');
+    await box.setValue(true);
+    await flushPromises();
+    await nextTick();
+
+    expect((w.find('[data-testid="cell-canvas-toggle-render"]').element as HTMLInputElement).checked).toBe(false);
+    expect(w.text()).toContain("failed");
+  });
 });

--- a/test/src/components/canvasWriteQueue.spec.ts
+++ b/test/src/components/canvasWriteQueue.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { createCanvasWriteQueue } from "../../../src/components/canvasWriteQueue";
+
+// Each Canvas switch POSTs to /api/gui-mcp-groups, which shells out to `claude mcp add/remove` —
+// a read-modify-write of one config file. Only the flipped group's own checkbox is disabled while
+// it saves, so ticking render and media in quick succession fires two writes at once and one
+// registration is lost while both switches show "on". The queue is what stops that.
+describe("the canvas write queue", () => {
+  const deferred = () => {
+    let resolve!: () => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
+
+  it("does not start the second write until the first has finished", async () => {
+    const queue = createCanvasWriteQueue();
+    const first = deferred();
+    const started: string[] = [];
+
+    const a = queue(async () => {
+      started.push("render");
+      await first.promise;
+    });
+    const b = queue(async () => {
+      started.push("media");
+    });
+
+    // The second write must still be waiting while the first is in flight.
+    await Promise.resolve();
+    expect(started).toEqual(["render"]);
+
+    first.resolve();
+    await a;
+    await b;
+    expect(started).toEqual(["render", "media"]);
+  });
+
+  // A failed write reports itself (the checkbox goes back); it must not take the queue with it,
+  // or one server error would silently drop every later registration.
+  it("runs the next write after one fails", async () => {
+    const queue = createCanvasWriteQueue();
+    const started: string[] = [];
+
+    const failing = queue(async () => {
+      started.push("render");
+      throw new Error("HTTP 500");
+    });
+    const after = queue(async () => {
+      started.push("media");
+    });
+
+    await expect(failing).rejects.toThrow("HTTP 500");
+    await after;
+    expect(started).toEqual(["render", "media"]);
+  });
+
+  // Each caller awaits its OWN write. A rejection travelling down the chain would surface on an
+  // unrelated later caller, which would then put the wrong checkbox back.
+  it("does not reject a later write with an earlier one's failure", async () => {
+    const queue = createCanvasWriteQueue();
+    queue(async () => {
+      throw new Error("HTTP 500");
+    }).catch(() => {});
+    await expect(queue(async () => {})).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
ランチャーの Canvas スイッチは `render` グループだけを登録していた。`media` グループ（`generateImage` / `presentMulmoScript`）も同じ Canvas ペインに描くのに UI からは有効にできず、ペインの可用性判定も `render` だけを見ていたので、`media` だけ登録したセルは持っているツールを使えるのに Canvas ボタンすら出なかった。

## 変更

**`common/toolGroups.ts`**
- `CANVAS_TOOL_GROUP`（単数）→ `CANVAS_TOOL_GROUPS = ["render", "media"]`、判定は `hasCanvasGroup(groups)` に集約。サーバーが返す untyped な文字列配列に対して聞くので、未知のグループ名は数えない。
- `media` を別スイッチのままにしたのは、`render` がペインで止まるのに対し `media` は遅く・課金され・ファイルを書くから — グルーピングが引きたかった線そのもの。`AUTO_ALLOWED_TOOLS` には入れていないので、許可プロンプトは支出の前に残る（`presentDocument` を外してあるのと同じ理由）。

**`src/components/TerminalCell.vue`**
- ランチャーのスイッチをグループごとのレコードに一般化し、`Canvas (render MCPs)` / `Canvas (media MCPs)` の 2 行を `v-for` で描画。saving / failed 表示もグループ単位。
- worktree 起動時の引き継ぎは ON のグループを全部運ぶ。ただし **直列** に POST する: 各 POST は `claude mcp add` を叩き、同じ local-scope 設定ファイルを read-modify-write するので、並列だと片方の登録が消える。

**`src/components/TerminalGrid.vue`**
- 可用性を `hasCanvasGroup` に変更（`render || media`）。あわせてセッションが実際に接続してきた全グループを保持し、Canvas パネルへ渡す。

**`src/components/GuiPanel.vue`**
- 空の Canvas が、そのターミナルで有効なグループのツールをグループ見出し付きで全部並べるように。ここはツール名が読める唯一の場所で、スイッチはグループ単位なので「足りないツールを出すにはどれを入れればいいか」が要る。順序は `TOOL_GROUPS`（blast radius 順）固定で、MCP クライアントの接続順で並び替わらない。
- `groups` 未指定は「全部」= all-tools URL に繋ぐ単一ビュー。
- 未接続時の状態名を `no-render-mcp` → `no-canvas-mcp` にリネーム、案内文も両方のスイッチを挙げるように。

## テスト

`test/common/toolGroups.spec.ts`（`CANVAS_TOOL_GROUPS` / `hasCanvasGroup`）、`GuiPanelEmptyState.spec.ts`（グループ別リスト・セッションが持つグループのみ・フォールバック・非描画グループも並ぶこと）、`GuiPanelUnavailable.spec.ts`（両スイッチを案内）を更新。

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（394 files, 5759 tests）/ `build` 通過。

**未検証**: 実ブラウザでチェックボックスを操作して `claude mcp` 登録が書かれること、`media` だけ ON のセルで Canvas が開くことは未確認。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canvas support now includes both rendering and media tools.
  * Canvas settings can be enabled independently for each supported tool group.
  * Canvas panels and empty states now reflect the tool groups available in each session.
  * Worktree launches preserve enabled Canvas settings across all supported groups.

* **Bug Fixes**
  * Improved Canvas availability handling and messaging when required tools are unavailable.
  * Added safer handling for invalid or missing tool-group information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->