### PR TITLE
fix: 最新ターンを tail から読む (#998 Phase 2)

### DIFF
--- a/plans/refactor-998-jsonl-readers.md
+++ b/plans/refactor-998-jsonl-readers.md
@@ -54,6 +54,55 @@ file fits in the window.
 
 ## Next
 
-2. the four "last turn" readers → tail
 3. the three whole-file scans → line stream
 4. the title reader → head
+
+---
+
+# Phase 2 — the four "last turn" readers
+
+`readLatestResponse`, `latestUserPrompt`, `sessionLastTurn` and `codexLastTurn` all wanted the newest
+turn and all read the whole file to find it. They now read the tail.
+
+`session-reads.ts` already said this was the answer, in a comment written for #865:
+
+> Reading only the file's tail would lift the cap altogether and is the obvious next step if anyone
+> hits this in practice.
+
+Someone did.
+
+## The window is 4 MB, not 256 KB
+
+The tail reader came from the codex rollout, where 256 KB was plenty. On a **Claude** transcript it
+is not: one record can hold an entire tool_result, and on the 585 MB file here the last 256 KB is
+**nine records — not one complete turn**. Measured:
+
+| window | records | last turn found |
+| --- | --- | --- |
+| 256 KB | 9 | no |
+| 1 MB | 9 | no |
+| **4 MB** | **139** | **yes, in 15 ms** |
+| 16 MB | 612 | yes, 59 ms |
+
+Across the six largest transcripts on this machine 4 MB yields 110–1000 records, so it covers a turn
+with room to spare. A spec pins this with deliberately fat records, since the failure it prevents —
+a window that is technically working but too small to contain an answer — looks exactly like an
+empty session.
+
+## Measured on the real file
+
+The 585 MB transcript, which `readFile` cannot open at all:
+
+```text
+records=139 in 13ms
+prompt: "This session is being continued from a previous conversation that ran "
+reply : "Push 完了。PR コメントを投稿し、並行して他の全 open PR の失敗状況を確認します。"
+```
+
+Real content, 13 ms. Before this it was an exception caught into an empty turn.
+
+## `LAST_TURN_MAX_BYTES` is now dead
+
+The 64 MB refusal existed because reading whole was unaffordable. Nothing sets `tooLarge` any more.
+The constant and the flag stay for the moment: `tooLarge` reaches the UI (`useHandoff`,
+`codeBlockCopy`), and removing a wire field is its own change rather than a rider on this one.

--- a/server/infra/jsonl-file.ts
+++ b/server/infra/jsonl-file.ts
@@ -10,9 +10,13 @@
 // so a reader picks one instead of writing a third.
 import { createReadStream, closeSync, openSync, readSync, statSync } from "node:fs";
 import readline from "node:readline";
+import { isRecord } from "../../common/isRecord.js";
 
-/** Enough of the end to hold the last turn, with room to spare. */
-const DEFAULT_TAIL_BYTES = 256 * 1024;
+// How much of the end to read. 256 KB was the codex rollout's window and is nowhere near enough
+// for a Claude transcript: one record holds a whole tool_result, so on the 585 MB file here the
+// last 256 KB is NINE records — not one complete turn. Measured across the six largest transcripts
+// on this machine, 4 MB yields 110-1000 records, which covers a turn with room to spare.
+const DEFAULT_TAIL_BYTES = 4 * 1024 * 1024;
 
 /** Every line, in order, without ever materialising the file. `onLine` is called with each line
  *  as it arrives, so the caller decides what to keep — which is the point: a summary keeps a
@@ -26,6 +30,23 @@ export async function forEachJsonlLine(file: string, onLine: (line: string) => v
     lines.close();
     input.destroy();
   }
+}
+
+/** The parsed records at the END of a JSONL file — what every "what happened last" reader wants.
+ *  Bounded: it reads `tailBytes`, so a 585 MB transcript costs the same as a 1 KB one. Malformed
+ *  lines are skipped, which also covers the partial line a mid-file read can leave behind. */
+export function readTailRecords(file: string, tailBytes?: number): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (const line of readTailLines(file, tailBytes)) {
+    if (!line.trim()) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isRecord(parsed)) out.push(parsed);
+    } catch {
+      // Not JSON — a half line from the read boundary, or a corrupt one. Either way, skip it.
+    }
+  }
+  return out;
 }
 
 /** The last lines of a file. The first is dropped when the read started mid-file: that boundary

--- a/server/session/last-turn.ts
+++ b/server/session/last-turn.ts
@@ -77,7 +77,12 @@ function codexPromptForTurn(docs: Record<string, unknown>[], completeIndex: numb
 // agent_message rows never need reassembling. A turn that completed without one (an
 // interrupt, an approval bounce) is skipped for the exchange before it.
 export function lastTurnFromCodexRollout(raw: string): LastTurn {
-  const docs = parseJsonl(raw);
+  return lastTurnFromCodexRolloutDocs(parseJsonl(raw));
+}
+
+/** The same, from records already parsed — so a caller that read only the file's tail (#998)
+ *  doesn't have to rebuild a string just to hand it back. */
+export function lastTurnFromCodexRolloutDocs(docs: Record<string, unknown>[]): LastTurn {
   for (let i = docs.length - 1; i >= 0; i--) {
     const complete = eventPayload(docs[i], "task_complete");
     if (!complete) continue;

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -8,7 +8,7 @@
 // own module: the dependency runs one way. One of them also WRITES — collectPendingSessions
 // drops a session from knownSessions once disk has it — so "reads" describes the direction
 // of the data, not a guarantee of purity.
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -18,9 +18,7 @@ import {
   userPromptText,
   aiTitleFromParsed,
   countUserTurnsFromParsed,
-  latestMeaningfulUserPromptFromJsonl,
   latestMeaningfulUserPromptFromParsed,
-  latestAssistantTextFromJsonl,
   latestAssistantTextFromParsed,
   sessionUsageFromParsed,
   latestTurnContextFromParsed,
@@ -35,7 +33,8 @@ import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
 import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRolloutIds, hiddenSessions, knownSessions } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
-import { lastTurnFromClaudeParsed, lastTurnFromCodexRollout, EMPTY_TURN, type LastTurn } from "./last-turn.js";
+import { lastTurnFromClaudeParsed, lastTurnFromCodexRolloutDocs, EMPTY_TURN, type LastTurn } from "./last-turn.js";
+import { readTailRecords } from "../infra/jsonl-file.js";
 import { partitionPending } from "./partitionPending.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
@@ -50,8 +49,9 @@ export const LAST_RESPONSE_MAX = 400;
 // the PREVIOUS turn's text — for that caller, null has to stay null.
 export function readLatestResponse(id: string, cwd: string): string | null {
   try {
-    const raw = readFileSync(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
-    const text = latestAssistantTextFromJsonl(raw);
+    // The tail, not the file: a transcript reaches 585 MB, which readFile cannot hold at all —
+    // and the newest reply is in the last few lines either way (#998).
+    const text = latestAssistantTextFromParsed(readTailRecords(path.join(projectSessionsDir(cwd), `${id}.jsonl`)));
     return text ? text.slice(0, LAST_RESPONSE_MAX) : null;
   } catch {
     return null; // no transcript yet / unreadable
@@ -93,8 +93,7 @@ export function claudeOnDiskSessionIds(): Set<string> {
 // there's no transcript yet (a never-prompted session) or it can't be read.
 export async function latestUserPrompt(cwd: string, id: string): Promise<string | null> {
   try {
-    const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
-    return latestMeaningfulUserPromptFromJsonl(raw);
+    return latestMeaningfulUserPromptFromParsed(readTailRecords(path.join(projectSessionsDir(cwd), `${id}.jsonl`)));
   } catch {
     return null;
   }
@@ -180,32 +179,32 @@ async function codexLastTurn(sessionKey: string): Promise<LastTurn> {
   const file = codexRolloutPath(codexSessionsRoot(), rolloutId);
   if (!file) return EMPTY_TURN;
   try {
-    return lastTurnFromCodexRollout(await fs.readFile(file, "utf8"));
+    // Same reasoning as the Claude path below: the newest turn is at the end, so a rollout that
+    // grew past what a string can hold no longer takes the feature with it (#998).
+    return lastTurnFromCodexRolloutDocs(readTailRecords(file));
   } catch {
     return EMPTY_TURN;
   }
 }
 
-// Reading a transcript costs its whole size: the file is slurped as one string and every line
-// is JSON.parsed, all synchronously once the read resolves. Measured over 10,506 real
-// transcripts the median is 0.1 MB — but 13 exceed 100 MB, the largest is 585 MB, and a 440 MB
-// one took 1930 ms to yield a 334-character reply. That is 1.9 seconds with the event loop
-// stopped, i.e. every terminal in the app frozen. Past ~512 MB the read cannot even complete —
-// it exceeds V8's maximum string length and throws, which the catch below turns into an empty
-// turn, so the user sees a button that does nothing (#865).
+// The tail, not the whole file — which is what #865 said the fix would be and #998 forced.
 //
-// So: refuse loudly instead. `tooLarge` lets the caller say WHY nothing came back, which is the
-// difference between a bug report and a known limit. Reading only the file's tail would lift the
-// cap altogether and is the obvious next step if anyone hits this in practice.
+// Reading it whole cost its full size: measured over 10,506 real transcripts the median is 0.1 MB,
+// but 13 exceed 100 MB, the largest is 585 MB, and a 440 MB one took 1930 ms to yield a
+// 334-character reply — 1.9 seconds with the event loop stopped, every terminal in the app frozen.
+// Past ~512 MB the read could not complete at all (V8's maximum string length), so the button did
+// nothing. The last turn is in the last few lines either way, so the size of the file behind it
+// stopped mattering: the same read now costs 256 KB whatever the transcript weighs.
+//
+// `LAST_TURN_MAX_BYTES` / `tooLarge` are consequently dead as a limit. They stay for now because
+// `tooLarge` reaches the UI (useHandoff, codeBlockCopy) and removing a wire field is its own
+// change; nothing sets it any more.
 export const LAST_TURN_MAX_BYTES = 64 * 1024 * 1024;
 
 export async function sessionLastTurn(cwd: string, id: string, agent: "claude" | "codex"): Promise<LastTurn> {
   if (agent === "codex") return codexLastTurn(id);
-  const file = path.join(projectSessionsDir(cwd), `${id}.jsonl`);
   try {
-    const { size } = await fs.stat(file);
-    if (size > LAST_TURN_MAX_BYTES) return { ...EMPTY_TURN, tooLarge: true };
-    return lastTurnFromClaudeParsed(parseJsonl(await fs.readFile(file, "utf8")));
+    return lastTurnFromClaudeParsed(readTailRecords(path.join(projectSessionsDir(cwd), `${id}.jsonl`)));
   } catch {
     return EMPTY_TURN; // no transcript on disk yet
   }

--- a/test/server/infra/jsonl-file.spec.ts
+++ b/test/server/infra/jsonl-file.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { forEachJsonlLine, readTailLines } from "../../../server/infra/jsonl-file.js";
+import { forEachJsonlLine, readTailLines, readTailRecords } from "../../../server/infra/jsonl-file.js";
 
 // These two exist because `fs.readFile(file, "utf8")` throws past ~512 MB whatever the file holds,
 // which silently emptied the longest sessions (#998). What matters in a spec is therefore the
@@ -100,5 +100,41 @@ describe("readTailLines", () => {
   // rotated away must not take the roster down with it.
   it("returns no lines for a file that isn't there", () => {
     expect(readTailLines(path.join(dir, "missing.jsonl"))).toEqual([]);
+  });
+});
+
+describe("readTailRecords", () => {
+  it("parses the records at the end", () => {
+    const file = write("recs.jsonl", '{"n":1}\n{"n":2}\n{"n":3}\n');
+    expect(readTailRecords(file)).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+  });
+
+  // The partial first line a mid-file read leaves behind is not JSON, and neither is a corrupt
+  // one. Both are skipped rather than taking the whole read down.
+  it("skips a line that will not parse", () => {
+    const file = write("partial.jsonl", '{"n":1}\nnot json\n{"n":2}\n');
+    expect(readTailRecords(file)).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  it("skips a JSON line that is not an object", () => {
+    const file = write("scalar.jsonl", '{"n":1}\n42\n"text"\n[1,2]\n{"n":2}\n');
+    expect(readTailRecords(file)).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  it("has no records for an empty or missing file", () => {
+    expect(readTailRecords(write("none.jsonl", ""))).toEqual([]);
+    expect(readTailRecords(path.join(dir, "gone.jsonl"))).toEqual([]);
+  });
+
+  // The window has to hold a whole TURN, and one Claude record can carry an entire tool_result.
+  // On the 585 MB transcript here the last 256 KB was nine records — not one complete turn — which
+  // is why the default is 4 MB and not the codex rollout's 256 KB (#998).
+  it("reads far enough back to cover records that are individually huge", () => {
+    const fat = (i: number) => JSON.stringify({ i, blob: "x".repeat(200 * 1024) });
+    const file = write("fat.jsonl", `${[0, 1, 2, 3, 4, 5].map(fat).join("\n")}\n`);
+    const recs = readTailRecords(file);
+    // At 256 KB only the last record would survive; the default window keeps several.
+    expect(recs.length).toBeGreaterThan(1);
+    expect(recs.at(-1)).toMatchObject({ i: 5 });
   });
 });


### PR DESCRIPTION
## Summary

#998 の **Phase 2 / 4**。最新ターン系 4 つ（`readLatestResponse` / `latestUserPrompt` /
`sessionLastTurn` / `codexLastTurn`）を **tail 読み**にする。

いずれも「最新のターン」しか要らないのに**ファイル全体**を読んでいたので、
~512MB を超える transcript では throw → catch → **空のターン**になっていた。

`session-reads.ts` のコメントが #865 の時点でこの答えを書いていた:

> Reading only the file's tail would lift the cap altogether and is the obvious next step
> if anyone hits this in practice.

踏んだので、やる。

## 実測（585MB の実ファイル）

```text
records=139 in 13ms
prompt: "This session is being continued from a previous conversation that ran "
reply : "Push 完了。PR コメントを投稿し、並行して他の全 open PR の失敗状況を確認します。"
```

**本物の最新ターンが 13 ミリ秒で取れる。** 従来は例外を catch して空。

## Items to Confirm / Review

- **ウィンドウは 256KB ではなく 4MB にした。ここが今回一番重要な判断。**
  tail reader は codex rollout 由来で、あちらは 256KB で十分だった。**Claude の transcript は違う** —
  1 レコードが tool_result を丸ごと抱えるため、585MB のファイルでは**末尾 256KB が 9 レコード**しかなく、
  **1 ターンにすら届かない**。実測:

  | ウィンドウ | レコード数 | ターンが取れるか |
  | --- | --- | --- |
  | 256KB | 9 | ✗ |
  | 1MB | 9 | ✗ |
  | **4MB** | **139** | **✓ 15ms** |
  | 16MB | 612 | ✓ 59ms |

  このマシンの上位 6 ファイルで 4MB なら 110〜1000 レコード。**実データを見なければ 256KB のまま
  「動いているが答えが入っていない」状態で出していた**（見た目は空セッションと区別が付かない）。
  意図的に巨大なレコードを並べた spec で固定した。

- **`LAST_TURN_MAX_BYTES` / `tooLarge` は実質的に死んだ。** 64MB の拒否は「全体を読むのが高すぎる」
  ための仕組みで、tail 読みなら不要。**ただし今回は消していない** — `tooLarge` は UI まで届いており
  （`useHandoff` / `codeBlockCopy`）、wire のフィールドを削るのは別の変更として扱うべきなので。
  現状は誰もセットしない。次のフェーズか別 PR で。

- `lastTurnFromCodexRollout` に `…Docs(records)` 版を足した。tail で読んだレコードを、
  文字列に戻してから再パースさせないため。

- 既存の session 系テスト 929 件はそのまま通る。

## User Prompt

> これ直せる？？ https://github.com/receptron/mulmoterminal/issues/998
>
> １から順に。

## Verification

`yarn format` / `lint` / `typecheck` ×3 / `test`（5785 passed）/ **585MB の実ファイルで実測**。

## 残り

3. 全体走査 3 つ（`readSessionSummary` / `sessionTimeline` / `readFileCost`）→ 行ストリーム
4. タイトル（`generateAndStoreTitle`）→ 先頭のみ

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
