### PR TITLE
fix: init 完了後に案内する起動コマンドを @latest にする

### DIFF
--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -155,7 +155,10 @@ async function runInit(initArgs) {
     return;
   }
   if (hasClaude) log("Later: run `claude` in any project and use  /mulmoterminal-config");
-  log("Setup done. Start MulmoTerminal:  npx mulmoterminal");
+  // Pinned to @latest: an unpinned `npx` reuses whatever it already has cached, so the very
+  // command printed for someone to type next would start an older version than the one they
+  // just set up with.
+  log("Setup done. Start MulmoTerminal:  npx mulmoterminal@latest");
 }
 
 // `npx mulmoterminal google <command>` — Google account linking. Consent needs a


### PR DESCRIPTION
## Summary

`npx mulmoterminal init` の最後に出るこの行を `@latest` に直します。

```
Setup done. Start MulmoTerminal:  npx mulmoterminal
```

**まさにこれから打つコマンドを見せている行**で、バージョン未指定の `npx` は `~/.npm/_npx` に残っている古いコピーをそのまま使うので、**今セットアップしたものより古い版が起動する**案内になっていました。

#1035（README・guide の統一）で範囲外とした 3 箇所のうち、一番実害の大きい 1 つです。

## Items to Confirm / Review

- **テストは足していません。** `runInit` の出力を検証している既存テストが無く、この 1 行のためにテストハーネスを作るのは釣り合いません。文字列そのものを assert する形は「ファイルの中身」を見るだけで振る舞いを見ていないので、値のわりに壊れやすいと判断しました。異論があれば入れます。
- **なぜ `@latest` なのかをコメントに残しました。** 素の `npx` に戻す「整理」が起きうる箇所なので、理由（キャッシュを再利用する）が無いと判断できません。
- **残る 2 箇所は手を付けていません**（今回の指示は 1 つ目のみ）:
  - `bin/mulmoterminal.js:322` / `server/cli-google.ts:48` — `Usage: npx mulmoterminal [command] [options]`
  - `src/components/SettingsModal.vue:618` — Settings の `npx mulmoterminal google login`

  Usage 行は「すでに動いている mulmoterminal 自身が出す説明」なので優先度は低め、Settings の方は打つコマンドなので #1035 の 1 つ目と同じ性質です。

## User Prompt

> はい、１つ目は直そう

（#1035 のレポートで挙げた「コード側に残る 3 箇所」の 1 つ目 = `bin/mulmoterminal.js:158`）

## Test plan

- `yarn format` / `lint` / `typecheck:server` / `test`（5785 passed）
- 変更は 1 行の文字列 + コメント。既存テストに `Setup done` を参照するものが無いことを確認済み

Refs #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)