### PR TITLE
fix: 全体走査 3 つを行ストリームにする (#998 Phase 3)

### DIFF
--- a/plans/refactor-998-jsonl-readers.md
+++ b/plans/refactor-998-jsonl-readers.md
@@ -182,3 +182,24 @@ correct but cheaper — RSS fell from 475 MB to 378 MB.
 The reply and model use `?? previous` rather than an unconditional assign: an assistant record
 carrying only a `tool_use` has no text and no model, and must not blank out what the user is
 looking at.
+
+
+## Review follow-up 2: the fallbacks a "newest X" fold loses
+
+Codex, second round — two more places where remembering "the newest X" is not the same as running
+the rule:
+
+**`lastPrompt` lost the `last-prompt` fallback.** The rule prefers real `user` lines but falls back
+to a `last-prompt` record (written by a hook) when a transcript has none. Keeping only `user`
+records dropped that entirely, so such a transcript reported `null`. Both record types are kept now.
+
+**`context` drifted.** The rule takes the LAST assistant message and reads model and tokens off it
+**as a unit**, deliberately — "so a new model is never shown with a prior turn's context tokens".
+Remembering the last context that *named a model* is a different thing: a final turn with no model
+would report an earlier turn's. The scan keeps the last assistant record and runs the rule on it.
+
+Checked `lastResponse` for the same class of mistake and it is safe: its rule resolves within a
+single record.
+
+The lesson each time is the same — the fold has to be the RULE applied to a smaller window, never a
+paraphrase of what the rule seemed to do.

--- a/plans/refactor-998-jsonl-readers.md
+++ b/plans/refactor-998-jsonl-readers.md
@@ -54,7 +54,6 @@ file fits in the window.
 
 ## Next
 
-3. the three whole-file scans → line stream
 4. the title reader → head
 
 ---
@@ -106,3 +105,54 @@ Real content, 13 ms. Before this it was an exception caught into an empty turn.
 The 64 MB refusal existed because reading whole was unaffordable. Nothing sets `tooLarge` any more.
 The constant and the flag stay for the moment: `tooLarge` reaches the UI (`useHandoff`,
 `codeBlockCopy`), and removing a wire field is its own change rather than a rider on this one.
+
+
+---
+
+# Phase 3 — the three whole-file scans
+
+`readSessionSummary`, `sessionTimeline` and `readFileCost` each needed every record, so a tail
+cannot serve them. They stream instead.
+
+## Nothing re-implements a rule
+
+Every one of these was already a fold over records; the only thing holding it to an array was
+`parseJsonl(readFile(...))`. So each existing `…FromParsed` rule is kept exactly as it is and fed a
+window instead of the file:
+
+- **`createSummaryScan`** — the fields that need every record (usage, user turns, the AI title)
+  accumulate as records arrive; the ones describing the END of the session (last prompt, last reply,
+  model/context, current tools) read a bounded 400-record tail. Each is still computed by the
+  original function, on a one-record or tail-sized window.
+- **`timelineEventsIn(record)`** — the per-record half of `timelineFromJsonl`, which now calls it.
+  The caller keeps only the newest 300 events, which the payload was already capped to: holding the
+  whole transcript in order to throw most of it away was the expensive part.
+- **`createCostScan`** — the same accumulation one record at a time. `costForUsage` is untouched,
+  so pricing lives in one place.
+
+## Equivalence is the test
+
+`summary-scan.spec.ts` asserts the scan against **the original functions on the same records**
+rather than against hand-written expectations, so the two cannot drift: empty session, one exchange,
+several turns, a turn in progress, competing AI titles, records that are neither user nor assistant,
+an assistant turn with no usage — and the two properties that pull in opposite directions:
+
+- usage and turn counts must see **every** record (a tail-only fold would under-report a long
+  session's cost)
+- last prompt / last reply must describe the **end** (and not be dragged back by what came before)
+
+## Measured on the real file
+
+One pass over the 585 MB transcript, all three scans at once:
+
+```text
+2557ms, RSS 475MB
+  userTurns : 95
+  usage in  : 6,107 tokens
+  model     : claude-opus-4-8  ctx=69,820
+  cost      : $1072.63 (0 unpriced)
+  timeline  : 1539 events
+```
+
+Every one of those was empty or zero before — including the cost, which #998 noted was being
+summed into the project total as **$0**.

--- a/plans/refactor-998-jsonl-readers.md
+++ b/plans/refactor-998-jsonl-readers.md
@@ -120,10 +120,12 @@ Every one of these was already a fold over records; the only thing holding it to
 `parseJsonl(readFile(...))`. So each existing `…FromParsed` rule is kept exactly as it is and fed a
 window instead of the file:
 
-- **`createSummaryScan`** — the fields that need every record (usage, user turns, the AI title)
-  accumulate as records arrive; the ones describing the END of the session (last prompt, last reply,
-  model/context, current tools) read a bounded 400-record tail. Each is still computed by the
-  original function, on a one-record or tail-sized window.
+- **`createSummaryScan`** — every field folds over every record, keeping only what it needs: counts
+  as running numbers, "the newest X" as the last one seen, the current turn's tools reset on each
+  user prompt. Each is still computed by its original function, fed a one-record window.
+
+  The first draft read the "recent" fields off a 400-record tail instead. That was wrong — see the
+  review follow-up below.
 - **`timelineEventsIn(record)`** — the per-record half of `timelineFromJsonl`, which now calls it.
   The caller keeps only the newest 300 events, which the payload was already capped to: holding the
   whole transcript in order to throw most of it away was the expensive part.
@@ -156,3 +158,27 @@ One pass over the 585 MB transcript, all three scans at once:
 
 Every one of those was empty or zero before — including the cost, which #998 noted was being
 summed into the project total as **$0**.
+
+
+## Review follow-up: no windows
+
+**Codex: a fixed 400-record window drops a long turn's early tool calls**, regressing `workPhase`
+from `implementing` to `planning`. Correct, and measurable: across the eight largest transcripts
+here the longest single turn spans **3,615 records**. A turn has no bound, so no window is safe.
+
+Fixing that exposed two more of the same, each caught by writing the test first:
+
+| field | what a window loses |
+| --- | --- |
+| current tools | a turn's early `Edit`, so the phase reads as planning |
+| last prompt | the prompt itself, once its turn runs long — the summary reported `null` |
+| last reply / model | a reply that preceded a long run of tool results |
+
+So the tail is gone entirely. Each field now keeps its own minimum: user records for the prompt
+rule (far fewer than records), the last non-empty assistant text, the last context that named a
+model, and the tool scan that empties itself every turn. On the real 585 MB file this is not just
+correct but cheaper — RSS fell from 475 MB to 378 MB.
+
+The reply and model use `?? previous` rather than an unconditional assign: an assistant record
+carrying only a `tool_use` has no text and no model, and must not blank out what the user is
+looking at.

--- a/server/infra/jsonl-file.ts
+++ b/server/infra/jsonl-file.ts
@@ -32,6 +32,21 @@ export async function forEachJsonlLine(file: string, onLine: (line: string) => v
   }
 }
 
+/** Every record in a JSONL file, one at a time — the whole-file counterpart to readTailRecords.
+ *  Nothing is kept: `onRecord` decides what survives, which is how a summary distils hundreds of
+ *  megabytes into a handful of fields. Malformed and non-object lines are skipped. */
+export async function forEachJsonlRecord(file: string, onRecord: (record: Record<string, unknown>) => void): Promise<void> {
+  await forEachJsonlLine(file, (line) => {
+    if (!line.trim()) return;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isRecord(parsed)) onRecord(parsed);
+    } catch {
+      // Skip malformed lines, exactly as parseJsonl does.
+    }
+  });
+}
+
 /** The parsed records at the END of a JSONL file — what every "what happened last" reader wants.
  *  Bounded: it reads `tailBytes`, so a 585 MB transcript costs the same as a 1 KB one. Malformed
  *  lines are skipped, which also covers the partial line a mid-file read can leave behind. */

--- a/server/session/cost.ts
+++ b/server/session/cost.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import fs from "node:fs/promises";
 import type { Express } from "express";
+import { forEachJsonlRecord } from "../infra/jsonl-file.js";
 import { parseJsonl } from "./transcript.js";
 import { isRecord } from "../../common/isRecord.js";
 import { projectSessionsDir } from "./project-dir.js";
@@ -97,16 +98,26 @@ function assistantUsageTurn(o: Record<string, unknown>): UsageTurn | null {
 // Total dollar cost of a transcript, summed per assistant turn. Turns whose model
 // has no known price are excluded from usd and counted in `unpricedTurns`.
 export function costFromJsonl(raw: string): JsonlCost {
-  const turns = parseJsonl(raw)
-    .map(assistantUsageTurn)
-    .filter((t): t is UsageTurn => t !== null);
-  return turns.reduce<JsonlCost>(
-    (acc, turn) => {
-      const { usd, priced } = costForUsage(turn.usage, turn.model);
-      return priced ? { usd: acc.usd + usd, unpricedTurns: acc.unpricedTurns } : { usd: acc.usd, unpricedTurns: acc.unpricedTurns + 1 };
+  const scan = createCostScan();
+  parseJsonl(raw).forEach((record) => scan.add(record));
+  return scan.total();
+}
+
+/** The same accumulation, fed one record at a time — for a caller streaming a transcript too
+ *  large to hold as a string (#998). The pricing rule stays in costForUsage either way. */
+export function createCostScan() {
+  let usd = 0;
+  let unpricedTurns = 0;
+  return {
+    add(record: Record<string, unknown>) {
+      const turn = assistantUsageTurn(record);
+      if (!turn) return;
+      const priced = costForUsage(turn.usage, turn.model);
+      if (priced.priced) usd += priced.usd;
+      else unpricedTurns += 1;
     },
-    { usd: 0, unpricedTurns: 0 },
-  );
+    total: (): JsonlCost => ({ usd, unpricedTurns }),
+  };
 }
 
 // ── project-scoped aggregation (today / month) ─────────────────────────────────
@@ -143,7 +154,9 @@ async function statJsonlFiles(dir: string): Promise<FileStat[]> {
 
 async function readFileCost(dir: string, file: string): Promise<JsonlCost> {
   try {
-    return costFromJsonl(await fs.readFile(path.join(dir, file), "utf8"));
+    const scan = createCostScan();
+    await forEachJsonlRecord(path.join(dir, file), (record) => scan.add(record));
+    return scan.total();
   } catch {
     return { usd: 0, unpricedTurns: 0 };
   }

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -16,14 +16,9 @@ import { isRecord } from "../../common/isRecord.js";
 import {
   parseJsonl,
   userPromptText,
-  aiTitleFromParsed,
-  countUserTurnsFromParsed,
   latestMeaningfulUserPromptFromParsed,
   latestAssistantTextFromParsed,
-  sessionUsageFromParsed,
-  latestTurnContextFromParsed,
-  timelineFromJsonl,
-  currentTurnToolNamesFromParsed,
+  timelineEventsIn,
   type SessionUsage,
   type LatestTurnContext,
   type TimelineEvent,
@@ -34,7 +29,8 @@ import { sessionListTitle } from "./sessionListTitle.js";
 import { activity, aiTitles, codexRolloutIds, hiddenSessions, knownSessions } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
 import { lastTurnFromClaudeParsed, lastTurnFromCodexRolloutDocs, EMPTY_TURN, type LastTurn } from "./last-turn.js";
-import { readTailRecords } from "../infra/jsonl-file.js";
+import { forEachJsonlRecord, readTailRecords } from "../infra/jsonl-file.js";
+import { createSummaryScan } from "./summary-scan.js";
 import { partitionPending } from "./partitionPending.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
@@ -138,20 +134,23 @@ export async function readSessionSummary(cwd: string, id: string): Promise<Sessi
   }
   const cached = sessionSummaryCache.get(file, stamp);
   if (cached) return cached;
-  let records: Record<string, unknown>[];
+  // Streamed, never held: the transcript reaches 585 MB here, which is past what one string can
+  // be — and reading it whole is what emptied the longest sessions (#998).
+  const scan = createSummaryScan();
   try {
-    records = parseJsonl(await fs.readFile(file, "utf8"));
+    await forEachJsonlRecord(file, (record) => scan.add(record));
   } catch {
     return EMPTY_SUMMARY;
   }
+  const parts = scan.finish(LAST_RESPONSE_MAX);
   const summary: SessionSummary = {
-    lastPrompt: latestMeaningfulUserPromptFromParsed(records),
-    aiTitle: aiTitleFromParsed(records),
-    lastResponse: latestAssistantTextFromParsed(records)?.slice(0, LAST_RESPONSE_MAX) ?? null,
-    userTurns: countUserTurnsFromParsed(records),
-    usage: sessionUsageFromParsed(records),
-    context: latestTurnContextFromParsed(records),
-    workPhase: classifyWorkPhase(currentTurnToolNamesFromParsed(records)),
+    lastPrompt: parts.lastPrompt,
+    aiTitle: parts.aiTitle,
+    lastResponse: parts.lastResponse,
+    userTurns: parts.userTurns,
+    usage: parts.usage,
+    context: parts.context,
+    workPhase: classifyWorkPhase(parts.toolNames),
   };
   sessionSummaryCache.set(file, stamp, summary);
   return summary;
@@ -161,13 +160,22 @@ export async function readSessionSummary(cwd: string, id: string): Promise<Sessi
 // payload stays bounded on a long session. A missing transcript is an empty list.
 const TIMELINE_MAX_EVENTS = 300;
 export async function sessionTimeline(cwd: string, id: string): Promise<{ events: TimelineEvent[]; truncated: boolean }> {
+  // Streamed, and only the newest TIMELINE_MAX_EVENTS are kept — the payload was already capped,
+  // so holding the whole transcript to then throw most of it away was the expensive part (#998).
+  const events: TimelineEvent[] = [];
+  let total = 0;
   try {
-    const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${id}.jsonl`), "utf8");
-    const all = timelineFromJsonl(raw);
-    return { events: all.slice(-TIMELINE_MAX_EVENTS), truncated: all.length > TIMELINE_MAX_EVENTS };
+    await forEachJsonlRecord(path.join(projectSessionsDir(cwd), `${id}.jsonl`), (record) => {
+      for (const event of timelineEventsIn(record)) {
+        total += 1;
+        events.push(event);
+        if (events.length > TIMELINE_MAX_EVENTS) events.shift();
+      }
+    });
   } catch {
     return { events: [], truncated: false };
   }
+  return { events, truncated: total > TIMELINE_MAX_EVENTS };
 }
 
 // A session's last COMPLETED exchange, read from whichever log its agent keeps: Claude's

--- a/server/session/summary-scan.ts
+++ b/server/session/summary-scan.ts
@@ -1,0 +1,75 @@
+// Building a session's summary from a stream of records instead of an array of them.
+//
+// `readSessionSummary` produced all seven fields in one pass over `parseJsonl(readFile(...))`,
+// which is the pass that cannot run at all on a transcript past ~512 MB (#998). Each field was
+// already a fold over the records — the only thing holding them together was the array.
+//
+// So this keeps every existing `…FromParsed` rule exactly as it is and feeds each one a window
+// rather than the file: the fields that genuinely need every record (usage, turn counts, the AI
+// title) accumulate as records arrive, and the ones that only describe the END of the session
+// (last prompt, last reply, model/context, current tools) read a bounded tail buffer. Nothing here
+// re-implements a rule; splitting them apart is the whole change.
+import {
+  aiTitleFromParsed,
+  countUserTurnsFromParsed,
+  currentTurnToolNamesFromParsed,
+  latestAssistantTextFromParsed,
+  latestMeaningfulUserPromptFromParsed,
+  latestTurnContextFromParsed,
+  sessionUsageFromParsed,
+} from "./transcript.js";
+import type { LatestTurnContext, SessionUsage } from "./transcript.js";
+
+// How many records to keep for the "what happened at the end" fields. A turn spans several
+// records (prompt, assistant text, tool calls, results), and `currentTurnToolNames` walks back to
+// the last user prompt — 400 covers that with room to spare while staying a fixed cost.
+const TAIL_RECORDS = 400;
+
+export interface SummaryParts {
+  lastPrompt: string | null;
+  aiTitle: string | null;
+  lastResponse: string | null;
+  userTurns: number;
+  usage: SessionUsage;
+  context: LatestTurnContext;
+  toolNames: string[];
+}
+
+export function createSummaryScan() {
+  // Whole-file folds, kept as running state.
+  const usage: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
+  let userTurns = 0;
+  let aiTitle: string | null = null;
+  // Ring of the most recent records, for the end-of-session fields.
+  const tail: Record<string, unknown>[] = [];
+
+  return {
+    add(record: Record<string, unknown>) {
+      // One-record windows: each rule still decides for itself what counts, so "what is a user
+      // turn" or "which usage fields exist" lives in one place, not two.
+      const one = [record];
+      userTurns += countUserTurnsFromParsed(one);
+      const perRecord = sessionUsageFromParsed(one);
+      usage.inputTokens += perRecord.inputTokens;
+      usage.outputTokens += perRecord.outputTokens;
+      usage.cacheReadTokens += perRecord.cacheReadTokens;
+      usage.cacheCreationTokens += perRecord.cacheCreationTokens;
+      aiTitle = aiTitleFromParsed(one) ?? aiTitle;
+
+      tail.push(record);
+      if (tail.length > TAIL_RECORDS) tail.shift();
+    },
+
+    finish(responseMax: number): SummaryParts {
+      return {
+        lastPrompt: latestMeaningfulUserPromptFromParsed(tail),
+        aiTitle,
+        lastResponse: latestAssistantTextFromParsed(tail)?.slice(0, responseMax) ?? null,
+        userTurns,
+        usage,
+        context: latestTurnContextFromParsed(tail),
+        toolNames: currentTurnToolNamesFromParsed(tail),
+      };
+    },
+  };
+}

--- a/server/session/summary-scan.ts
+++ b/server/session/summary-scan.ts
@@ -4,26 +4,32 @@
 // which is the pass that cannot run at all on a transcript past ~512 MB (#998). Each field was
 // already a fold over the records — the only thing holding them together was the array.
 //
-// So this keeps every existing `…FromParsed` rule exactly as it is and feeds each one a window
-// rather than the file: the fields that genuinely need every record (usage, turn counts, the AI
-// title) accumulate as records arrive, and the ones that only describe the END of the session
-// (last prompt, last reply, model/context, current tools) read a bounded tail buffer. Nothing here
-// re-implements a rule; splitting them apart is the whole change.
+// **No windows.** The first draft kept a tail of the last N records and read the "what happened
+// recently" fields off it. That is wrong, and Codex caught the first instance: a turn has no
+// bound — measured across the eight largest transcripts on this machine, the longest spans 3,615
+// records — so a window silently drops a turn's early tool calls, then its prompt, then the reply
+// and model that preceded a long run of tool results. Every field here therefore folds over every
+// record, keeping only what it needs:
+//
+//   - counts and totals → running numbers
+//   - "the newest X"    → the last X seen, replaced as it arrives
+//   - the current turn  → reset on each user prompt (the rule already works that way)
+//
+// The per-record memory is a handful of strings and one array that empties every turn, so a
+// 585 MB transcript costs the same as a small one.
+//
+// Every rule still lives in its `…FromParsed` function: each is fed a one-record or few-record
+// window rather than reimplemented here.
 import {
   aiTitleFromParsed,
   countUserTurnsFromParsed,
-  currentTurnToolNamesFromParsed,
+  createCurrentTurnToolScan,
   latestAssistantTextFromParsed,
   latestMeaningfulUserPromptFromParsed,
   latestTurnContextFromParsed,
   sessionUsageFromParsed,
 } from "./transcript.js";
 import type { LatestTurnContext, SessionUsage } from "./transcript.js";
-
-// How many records to keep for the "what happened at the end" fields. A turn spans several
-// records (prompt, assistant text, tool calls, results), and `currentTurnToolNames` walks back to
-// the last user prompt — 400 covers that with room to spare while staying a fixed cost.
-const TAIL_RECORDS = 400;
 
 export interface SummaryParts {
   lastPrompt: string | null;
@@ -36,12 +42,16 @@ export interface SummaryParts {
 }
 
 export function createSummaryScan() {
-  // Whole-file folds, kept as running state.
   const usage: SessionUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0 };
   let userTurns = 0;
   let aiTitle: string | null = null;
-  // Ring of the most recent records, for the end-of-session fields.
-  const tail: Record<string, unknown>[] = [];
+  const toolScan = createCurrentTurnToolScan();
+  // User records only — `latestMeaningfulUserPrompt` walks back for the newest NON-trivial one, so
+  // it needs them all, and a session has far fewer user turns than records.
+  const userRecords: Record<string, unknown>[] = [];
+  // Whatever produced these most recently, so a long run of tool calls afterwards cannot bury them.
+  let lastAssistantText: string | null = null;
+  let lastContext: LatestTurnContext | null = null;
 
   return {
     add(record: Record<string, unknown>) {
@@ -55,20 +65,24 @@ export function createSummaryScan() {
       usage.cacheReadTokens += perRecord.cacheReadTokens;
       usage.cacheCreationTokens += perRecord.cacheCreationTokens;
       aiTitle = aiTitleFromParsed(one) ?? aiTitle;
-
-      tail.push(record);
-      if (tail.length > TAIL_RECORDS) tail.shift();
+      toolScan.add(record);
+      if (record.type === "user") userRecords.push(record);
+      // `?? previous` rather than an unconditional assign: an assistant record carrying only a
+      // tool_use has no text, and must not blank out the reply the user is looking at.
+      lastAssistantText = latestAssistantTextFromParsed(one) ?? lastAssistantText;
+      const context = latestTurnContextFromParsed(one);
+      if (context.model !== null) lastContext = context;
     },
 
     finish(responseMax: number): SummaryParts {
       return {
-        lastPrompt: latestMeaningfulUserPromptFromParsed(tail),
+        lastPrompt: latestMeaningfulUserPromptFromParsed(userRecords),
         aiTitle,
-        lastResponse: latestAssistantTextFromParsed(tail)?.slice(0, responseMax) ?? null,
+        lastResponse: lastAssistantText?.slice(0, responseMax) ?? null,
         userTurns,
         usage,
-        context: latestTurnContextFromParsed(tail),
-        toolNames: currentTurnToolNamesFromParsed(tail),
+        context: lastContext ?? latestTurnContextFromParsed([]),
+        toolNames: toolScan.names(),
       };
     },
   };

--- a/server/session/summary-scan.ts
+++ b/server/session/summary-scan.ts
@@ -30,6 +30,7 @@ import {
   sessionUsageFromParsed,
 } from "./transcript.js";
 import type { LatestTurnContext, SessionUsage } from "./transcript.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export interface SummaryParts {
   lastPrompt: string | null;
@@ -46,12 +47,16 @@ export function createSummaryScan() {
   let userTurns = 0;
   let aiTitle: string | null = null;
   const toolScan = createCurrentTurnToolScan();
-  // User records only — `latestMeaningfulUserPrompt` walks back for the newest NON-trivial one, so
-  // it needs them all, and a session has far fewer user turns than records.
-  const userRecords: Record<string, unknown>[] = [];
+  // The records the prompt rule reads: `user` lines, and the `last-prompt` record it falls back to
+  // when a transcript has none (a hook writes that one). Keeping user records alone dropped the
+  // fallback and reported null — Codex caught it. Still far fewer than the transcript.
+  const promptRecords: Record<string, unknown>[] = [];
   // Whatever produced these most recently, so a long run of tool calls afterwards cannot bury them.
   let lastAssistantText: string | null = null;
-  let lastContext: LatestTurnContext | null = null;
+  // The last assistant MESSAGE, not the last context that named a model: the rule reads model and
+  // tokens off the same final turn as a unit, so a turn naming no model reports null rather than
+  // an earlier turn's model (Codex).
+  let lastAssistantRecord: Record<string, unknown> | null = null;
 
   return {
     add(record: Record<string, unknown>) {
@@ -66,22 +71,21 @@ export function createSummaryScan() {
       usage.cacheCreationTokens += perRecord.cacheCreationTokens;
       aiTitle = aiTitleFromParsed(one) ?? aiTitle;
       toolScan.add(record);
-      if (record.type === "user") userRecords.push(record);
+      if (record.type === "user" || record.type === "last-prompt") promptRecords.push(record);
       // `?? previous` rather than an unconditional assign: an assistant record carrying only a
       // tool_use has no text, and must not blank out the reply the user is looking at.
       lastAssistantText = latestAssistantTextFromParsed(one) ?? lastAssistantText;
-      const context = latestTurnContextFromParsed(one);
-      if (context.model !== null) lastContext = context;
+      if (record.type === "assistant" && isRecord(record.message)) lastAssistantRecord = record;
     },
 
     finish(responseMax: number): SummaryParts {
       return {
-        lastPrompt: latestMeaningfulUserPromptFromParsed(userRecords),
+        lastPrompt: latestMeaningfulUserPromptFromParsed(promptRecords),
         aiTitle,
         lastResponse: lastAssistantText?.slice(0, responseMax) ?? null,
         userTurns,
         usage,
-        context: lastContext ?? latestTurnContextFromParsed([]),
+        context: latestTurnContextFromParsed(lastAssistantRecord ? [lastAssistantRecord] : []),
         toolNames: toolScan.names(),
       };
     },

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -339,16 +339,29 @@ export function timelineEventsIn(o: Record<string, unknown>): TimelineEvent[] {
 // A fresh user prompt resets; tool-result user turns don't (userPromptText is null for them).
 // Reuses readSessionSummary's single parse.
 export function currentTurnToolNamesFromParsed(records: Record<string, unknown>[]): string[] {
+  const scan = createCurrentTurnToolScan();
+  records.forEach((o) => scan.add(o));
+  return scan.names();
+}
+
+/** The same rule, fed one record at a time. It is already a fold — reset on a user prompt, append
+ *  on a tool_use — so a streaming caller (#998) keeps the exact semantics rather than approximating
+ *  them with a window. That matters: measured across the eight largest transcripts here, the
+ *  longest single turn spans 3,615 records, so ANY fixed window would drop a turn's early edits and
+ *  report `planning` for a turn that has already been implementing. */
+export function createCurrentTurnToolScan() {
   let names: string[] = [];
-  for (const o of records) {
-    if (o.type === "user" && userPromptText(isRecord(o.message) ? o.message.content : undefined) !== null) {
-      names = []; // a fresh user prompt starts a new turn
-      continue;
-    }
-    if (o.type !== "assistant" || !isRecord(o.message) || !Array.isArray(o.message.content)) continue;
-    for (const block of o.message.content) {
-      if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") names.push(block.name);
-    }
-  }
-  return names;
+  return {
+    add(o: Record<string, unknown>) {
+      if (o.type === "user" && userPromptText(isRecord(o.message) ? o.message.content : undefined) !== null) {
+        names = []; // a fresh user prompt starts a new turn
+        return;
+      }
+      if (o.type !== "assistant" || !isRecord(o.message) || !Array.isArray(o.message.content)) return;
+      for (const block of o.message.content) {
+        if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") names.push(block.name);
+      }
+    },
+    names: (): string[] => names,
+  };
 }

--- a/server/session/transcript.ts
+++ b/server/session/transcript.ts
@@ -318,17 +318,17 @@ function summarizeToolInput(input: unknown): string {
 // Chronological tool_use events from a transcript, for the activity timeline. Each
 // assistant turn may carry several tool_use blocks; text blocks are ignored.
 export function timelineFromJsonl(raw: string): TimelineEvent[] {
-  const events: TimelineEvent[] = [];
-  for (const o of parseJsonl(raw)) {
-    if (o.type !== "assistant" || !isRecord(o.message) || !Array.isArray(o.message.content)) continue;
-    const ts = typeof o.timestamp === "string" ? o.timestamp : "";
-    for (const block of o.message.content) {
-      if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") {
-        events.push({ ts, tool: block.name, summary: summarizeToolInput(block.input) });
-      }
-    }
-  }
-  return events;
+  return parseJsonl(raw).flatMap(timelineEventsIn);
+}
+
+/** The events one record contributes — so a caller streaming a transcript (#998) applies the same
+ *  rule per record instead of restating it. */
+export function timelineEventsIn(o: Record<string, unknown>): TimelineEvent[] {
+  if (o.type !== "assistant" || !isRecord(o.message) || !Array.isArray(o.message.content)) return [];
+  const ts = typeof o.timestamp === "string" ? o.timestamp : "";
+  return o.message.content.flatMap((block) =>
+    isRecord(block) && block.type === "tool_use" && typeof block.name === "string" ? [{ ts, tool: block.name, summary: summarizeToolInput(block.input) }] : [],
+  );
 }
 
 // The tool names the agent ran in the CURRENT turn — since the last real user prompt —

--- a/test/server/session/summary-scan.spec.ts
+++ b/test/server/session/summary-scan.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { createSummaryScan } from "../../../server/session/summary-scan.js";
+import {
+  aiTitleFromParsed,
+  countUserTurnsFromParsed,
+  currentTurnToolNamesFromParsed,
+  latestAssistantTextFromParsed,
+  latestMeaningfulUserPromptFromParsed,
+  latestTurnContextFromParsed,
+  sessionUsageFromParsed,
+} from "../../../server/session/transcript.js";
+
+// The scan replaced "parse the whole file, then fold it seven ways" (#998). What has to hold is
+// that it produces the SAME answers — so every case here is asserted against the original
+// functions on the same records, rather than against hand-written expectations that could drift.
+
+const RESPONSE_MAX = 400;
+
+const user = (text: string) => ({ type: "user", message: { role: "user", content: [{ type: "text", text }] } });
+const assistant = (text: string, over: Record<string, unknown> = {}) => ({
+  type: "assistant",
+  message: {
+    role: "assistant",
+    model: "claude-opus-5",
+    content: [{ type: "text", text }],
+    usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 2, cache_creation_input_tokens: 1 },
+    ...over,
+  },
+});
+const toolCall = (name: string) => ({
+  type: "assistant",
+  message: { role: "assistant", model: "claude-opus-5", content: [{ type: "tool_use", name, input: {} }] },
+});
+
+const scanned = (records: Record<string, unknown>[]) => {
+  const scan = createSummaryScan();
+  records.forEach((r) => scan.add(r));
+  return scan.finish(RESPONSE_MAX);
+};
+
+const folded = (records: Record<string, unknown>[]) => ({
+  lastPrompt: latestMeaningfulUserPromptFromParsed(records),
+  aiTitle: aiTitleFromParsed(records),
+  lastResponse: latestAssistantTextFromParsed(records)?.slice(0, RESPONSE_MAX) ?? null,
+  userTurns: countUserTurnsFromParsed(records),
+  usage: sessionUsageFromParsed(records),
+  context: latestTurnContextFromParsed(records),
+  toolNames: currentTurnToolNamesFromParsed(records),
+});
+
+describe("createSummaryScan agrees with the whole-array fold", () => {
+  it.each([
+    ["an empty session", []],
+    ["one exchange", [user("hello"), assistant("hi")]],
+    ["several turns", [user("one"), assistant("a"), user("two"), assistant("b"), user("three"), assistant("c")]],
+    ["a turn still in progress", [user("do it"), toolCall("Read"), toolCall("Edit")]],
+    ["an AI title, which the newest wins", [user("q"), { type: "ai-title", aiTitle: "first" }, assistant("a"), { type: "ai-title", aiTitle: "second" }]],
+    ["records that are neither user nor assistant", [{ type: "system", note: "x" }, user("q"), { type: "summary" }, assistant("a")]],
+    ["an assistant turn carrying no usage", [user("q"), assistant("a", { usage: undefined })]],
+  ])("on %s", (_case, records) => {
+    expect(scanned(records as Record<string, unknown>[])).toEqual(folded(records as Record<string, unknown>[]));
+  });
+
+  // Usage is the one field that must see EVERY record — a fold that only looked at a tail window
+  // would quietly under-report the cost of a long session.
+  it("totals usage across more records than the tail window keeps", () => {
+    const many = Array.from({ length: 1200 }, (_, i) => (i % 2 === 0 ? user(`q${i}`) : assistant(`a${i}`)));
+    const result = scanned(many);
+    expect(result).toEqual(folded(many));
+    expect(result.usage.inputTokens).toBe(600 * 10);
+    expect(result.userTurns).toBe(600);
+  });
+
+  // …while the end-of-session fields describe the END, so they must not be dragged back by
+  // everything that came before.
+  it("reports the newest prompt and reply from a long session", () => {
+    const many = [
+      ...Array.from({ length: 1200 }, (_, i) => (i % 2 === 0 ? user(`q${i}`) : assistant(`a${i}`))),
+      user("the last question"),
+      assistant("the last answer"),
+    ];
+    const result = scanned(many);
+    expect(result.lastPrompt).toBe("the last question");
+    expect(result.lastResponse).toBe("the last answer");
+    expect(result).toEqual(folded(many));
+  });
+
+  it("truncates a long reply at the caller's cap", () => {
+    const long = "x".repeat(RESPONSE_MAX + 50);
+    expect(scanned([user("q"), assistant(long)]).lastResponse).toHaveLength(RESPONSE_MAX);
+  });
+});

--- a/test/server/session/summary-scan.spec.ts
+++ b/test/server/session/summary-scan.spec.ts
@@ -112,6 +112,27 @@ describe("createSummaryScan agrees with the whole-array fold", () => {
     expect(result).toEqual(folded(records));
   });
 
+  // Codex on #1037, round 2. Both of these are fallbacks the original rules have and a naive
+  // "remember the newest X" loses.
+  it("uses a last-prompt record when the transcript has no user line", () => {
+    const records = [{ type: "last-prompt", lastPrompt: "recorded by the hook" }, assistant("a")];
+    expect(scanned(records).lastPrompt).toBe("recorded by the hook");
+    expect(scanned(records)).toEqual(folded(records));
+  });
+
+  it("prefers a real user line over a last-prompt record", () => {
+    const records = [{ type: "last-prompt", lastPrompt: "recorded" }, user("typed"), assistant("a")];
+    expect(scanned(records).lastPrompt).toBe("typed");
+  });
+
+  // The context comes from the LAST assistant message as a unit — model and tokens together. A
+  // final turn that names no model reports null, not the model from an earlier turn.
+  it("reports the last assistant turn's context even when that turn names no model", () => {
+    const records = [user("q"), assistant("a"), assistant("b", { model: undefined })];
+    expect(scanned(records).context).toEqual(folded(records).context);
+    expect(scanned(records).context.model).toBeNull();
+  });
+
   it("truncates a long reply at the caller's cap", () => {
     const long = "x".repeat(RESPONSE_MAX + 50);
     expect(scanned([user("q"), assistant(long)]).lastResponse).toHaveLength(RESPONSE_MAX);

--- a/test/server/session/summary-scan.spec.ts
+++ b/test/server/session/summary-scan.spec.ts
@@ -85,6 +85,33 @@ describe("createSummaryScan agrees with the whole-array fold", () => {
     expect(result).toEqual(folded(many));
   });
 
+  // Codex on #1037: the current turn's tools were read from a fixed 400-record window, so a long
+  // turn's early edits fell out of it and workPhase regressed from implementing to planning. A turn
+  // has no bound — measured across the eight largest transcripts here, the longest spans 3,615
+  // records — so this asserts a turn far past any window keeps the tool it opened with.
+  it("keeps a tool from the START of a turn that runs longer than the tail window", () => {
+    const records = [user("do the thing"), toolCall("Edit"), ...Array.from({ length: 900 }, () => toolCall("Read"))];
+    const result = scanned(records);
+    expect(result.toolNames[0]).toBe("Edit");
+    expect(result).toEqual(folded(records));
+  });
+
+  // …and the reset still happens: a NEW prompt drops the previous turn's tools however long ago.
+  it("forgets the previous turn's tools once a new prompt arrives", () => {
+    const records = [user("first"), toolCall("Edit"), ...Array.from({ length: 900 }, () => toolCall("Read")), user("second"), toolCall("Grep")];
+    expect(scanned(records).toolNames).toEqual(["Grep"]);
+  });
+
+  // The same trap as the prompt and the tools: a reply or a model that only appears BEFORE a long
+  // run of tool calls must still be reported. Reaching for a record window loses all three.
+  it("reports the reply and model from a turn that then ran far past the window", () => {
+    const records = [user("q"), assistant("the answer"), ...Array.from({ length: 900 }, () => toolCall("Read"))];
+    const result = scanned(records);
+    expect(result.lastResponse).toBe("the answer");
+    expect(result.context.model).toBe("claude-opus-5");
+    expect(result).toEqual(folded(records));
+  });
+
   it("truncates a long reply at the caller's cap", () => {
     const long = "x".repeat(RESPONSE_MAX + 50);
     expect(scanned([user("q"), assistant(long)]).lastResponse).toHaveLength(RESPONSE_MAX);


### PR DESCRIPTION
## Summary

#998 の **Phase 3 / 4**。全体走査 3 つ（`readSessionSummary` / `sessionTimeline` / `readFileCost`）を
**行ストリーム**にする。これらは全レコードが要るので tail では代替できない。

~512MB を超える transcript ではこのパス自体が走らず、**バッジ無し・タイムライン空・コスト 0 円**になっていた。

## 実測（585MB の実ファイル、3 つ同時に 1 パス）

```text
2557ms, RSS 475MB
  userTurns : 95
  usage in  : 6,107 tokens
  model     : claude-opus-4-8  ctx=69,820
  cost      : $1072.63 (0 unpriced)
  timeline  : 1539 events
```

**すべて従来は空か 0**。とくにコストは、issue が「0 円として集計に入る」と書いていたもの。

## Items to Confirm / Review

- **ルールを 1 つも書き直していない。** どれも元々「レコード列の畳み込み」で、配列に縛っていたのは
  `parseJsonl(readFile(...))` だけだった。既存の `…FromParsed` はそのまま使い、**渡すものを
  ファイルから窓に変えた**だけ:
  - `createSummaryScan` — 全レコードが要る項目（usage / turn 数 / AI title）は到着順に積み、
    **末尾の状態を表す項目**（最新プロンプト・返信・model/context・現在のツール）は 400 件の tail から。
    どちらも計算しているのは元の関数。
  - `timelineEventsIn(record)` — `timelineFromJsonl` の 1 レコード分。本体はこれを呼ぶ形に。
    保持は最新 300 件だけ（**元々ペイロードはそこで cap されていた**ので、全部読んでから捨てるのが無駄だった）。
  - `createCostScan` — 1 レコードずつ同じ加算。`costForUsage` は無変更なので価格ルールは 1 箇所のまま。

- **等価性をテストにした。** `summary-scan.spec.ts` は**元の関数に同じレコードを渡した結果**と
  突き合わせている（手書きの期待値ではない）ので、両者がずれない。空セッション / 1 往復 / 複数ターン /
  進行中のターン / AI title の競合 / user でも assistant でもないレコード / usage の無い assistant。
  加えて**互いに逆方向の 2 性質**を固定した:
  - usage と turn 数は**全レコード**を見る必要がある（tail だけだと長いセッションのコストを過少計上する）
  - 最新プロンプト・返信は**末尾**を表す必要がある（過去に引きずられない）

- 既存の session 系テストはそのまま通る。

## User Prompt

> これ直せる？？ https://github.com/receptron/mulmoterminal/issues/998
>
> １から順に。

## Verification

`yarn format` / `lint` / `typecheck` ×3 / `test`（5795 passed）/ **585MB の実ファイルで 3 経路とも実測**。

## 残り

4. タイトル（`generateAndStoreTitle`）→ 先頭のみ

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
