### PR TITLE
feat: グリッドの codex セルにも GUI ツール（Canvas の MCP グループ）を渡す

### DIFF
--- a/server/agents/codex-args.ts
+++ b/server/agents/codex-args.ts
@@ -2,13 +2,27 @@
 // (there is no `--session-id` like claude has), so a fresh session passes no id — the id is read
 // back from the rollout file afterwards — while resume replays a known rollout id via the
 // `resume` subcommand. Global flags precede the subcommand (codex's clap layout).
+export interface GuiMcpServer {
+  /** The MCP server id codex registers it under — `mulmoterminal-gui`, or `mulmoterminal-<group>`. */
+  id: string;
+  url: string;
+}
+
 export interface CodexArgsInput {
   // A codex rollout id to resume, or null to start a fresh session.
   resume: string | null;
   // Model override (--model), or null to use codex's own configured default.
   model: string | null;
-  // The in-process GUI MCP endpoint to attach (single view), or null (grid dev terminal / no GUI).
-  guiMcpUrl: string | null;
+  // The in-process GUI MCP endpoints to attach, or empty (no GUI tools).
+  //
+  // One entry for the single view (`mulmoterminal-gui`, every tool) and one PER GROUP for a grid
+  // cell, because that is the shape of the two surfaces: the single view carries the whole GUI
+  // MCP, while a grid cell gets exactly the groups its directory registered.
+  //
+  // claude reaches the same group URLs through its own per-folder config, where the URL may
+  // contain `${VAR}` and is expanded at connect time. codex has no such expansion, so these
+  // arrive already resolved — the port and session id are known by the time we spawn.
+  guiMcpServers: readonly GuiMcpServer[];
 }
 
 // NOTE: a seed prompt is NOT passed here as a positional [PROMPT] — a long collection-action prompt
@@ -17,7 +31,7 @@ export interface CodexArgsInput {
 export function buildCodexArgs(input: CodexArgsInput): string[] {
   const args: string[] = [];
   if (input.model) args.push("--model", input.model);
-  if (input.guiMcpUrl) {
+  for (const server of input.guiMcpServers) {
     // Attach the GUI MCP over streamable HTTP and auto-approve its tools so codex can drive the
     // GUI panel without a per-call permission prompt. `-c` takes dotted TOML keys; the value is
     // parsed as TOML, so the quotes are part of the value's syntax and have to arrive intact.
@@ -26,8 +40,12 @@ export function buildCodexArgs(input: CodexArgsInput): string[] {
     // launched through cmd.exe (#801), which puts a second parser between here and codex. The
     // Windows spec spawns these exact arguments through a shim and compares the argv that
     // comes out — lose the quotes and the value stops being a TOML string.
-    args.push("-c", `mcp_servers.mulmoterminal-gui.url="${input.guiMcpUrl}"`);
-    args.push("-c", `mcp_servers.mulmoterminal-gui.default_tools_approval_mode="approve"`);
+    //
+    // Auto-approval is per server id, so it is repeated rather than set once: a group the user
+    // enabled and codex then asks permission for on every call is the same friction the single
+    // view was given this flag to avoid.
+    args.push("-c", `mcp_servers.${server.id}.url="${server.url}"`);
+    args.push("-c", `mcp_servers.${server.id}.default_tools_approval_mode="approve"`);
   }
   if (input.resume) args.push("resume", input.resume);
   return args;

--- a/server/agents/codex-args.ts
+++ b/server/agents/codex-args.ts
@@ -6,6 +6,12 @@ export interface GuiMcpServer {
   /** The MCP server id codex registers it under — `mulmoterminal-gui`, or `mulmoterminal-<group>`. */
   id: string;
   url: string;
+  /**
+   * Run this server's tools without asking. codex approves per SERVER, not per tool, so this may
+   * only be set for a server whose every tool is in AUTO_ALLOWED_TOOLS — see codexGuiMcpServers,
+   * which is where that judgement is made.
+   */
+  autoApprove: boolean;
 }
 
 export interface CodexArgsInput {
@@ -41,11 +47,12 @@ export function buildCodexArgs(input: CodexArgsInput): string[] {
     // Windows spec spawns these exact arguments through a shim and compares the argv that
     // comes out — lose the quotes and the value stops being a TOML string.
     //
-    // Auto-approval is per server id, so it is repeated rather than set once: a group the user
-    // enabled and codex then asks permission for on every call is the same friction the single
-    // view was given this flag to avoid.
+    // Auto-approval is per server id, so it is repeated rather than set once — and it is a
+    // property of the server rather than a blanket setting, because codex cannot express
+    // claude's per-TOOL `--allowedTools`. A server holding one tool that spends money is
+    // therefore approved as a whole or not at all; see codexGuiMcpServers.
     args.push("-c", `mcp_servers.${server.id}.url="${server.url}"`);
-    args.push("-c", `mcp_servers.${server.id}.default_tools_approval_mode="approve"`);
+    if (server.autoApprove) args.push("-c", `mcp_servers.${server.id}.default_tools_approval_mode="approve"`);
   }
   if (input.resume) args.push("resume", input.resume);
   return args;

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -44,7 +44,7 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
     try {
       runWithHiddenMarker(hidden, sessionId, hiddenSessions, () => {
         const mode = spawnModeFor(agent, draft);
-        if (mode === "codex-run") deps.spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, codexifySkillSeed(message));
+        if (mode === "codex-run") deps.spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, { initialPrompt: codexifySkillSeed(message) });
         else if (mode === "claude-draft") deps.spawnClaudePty(sessionId, null, null, { draft: message });
         else deps.spawnClaudePty(sessionId, null, null, { initialPrompt: message });
       });

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -10,7 +10,7 @@ import { WebSocketServer, WebSocket } from "ws";
 import type { Server } from "node:http";
 import { randomUUID } from "node:crypto";
 import { messageOf } from "../errors.js";
-import { SESSION_ID_RE } from "../config/env.js";
+import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { resolveWorkspace } from "../config/workspace.js";
 import { getHeaderConfig } from "../config/config-routes.js";
 import { buildHeaderContext, loadHeaderConfig } from "../config/header-context.js";
@@ -24,6 +24,8 @@ import { codexRolloutExists } from "../agents/codex-sessions.js";
 import { codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
 import { sandboxWouldRun } from "../session/pty-spawn.js";
 import { bufferEarlyFrames } from "../session/early-frames.js";
+import { launcherCommandWithGuiMcp } from "../session/launcher-gui-mcp.js";
+import { codexGuiMcpServers } from "../session/mcp-config.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { handleCommandFrame } from "../session/pty-connection.js";
@@ -320,7 +322,7 @@ function handleRunConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: stri
 // configured launch command as a persistent, reattachable PTY. Reuses the /ws session
 // lifecycle (reattach + reap grace + handleClientClose) but with no hooks/transcript,
 // and is marked a dev-terminal session so it stays out of the chat sidebar.
-function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: string; headers?: unknown }) {
+async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: string; headers?: unknown }) {
   const { url, requested, cwd } = wsConnectionContext(req);
   const index = parseIndexParam(url.searchParams.get("launcher"));
   const shell = url.searchParams.get("shell") === "1";
@@ -331,16 +333,33 @@ function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: s
   markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
+  // Same reason as the codex path below — the browser's first frame is the terminal's geometry
+  // and it arrives while this is still reading files.
+  const early = bufferEarlyFrames<{ toString(): string }>(ws);
+
+  // A launcher that runs codex gets the directory's registered tool groups too. The chip and the
+  // agent toggle land in the same cell and look the same, so a Canvas that lights up for one and
+  // never for the other reads as a broken feature. Only for a spawn, and only for codex — every
+  // other command is passed through untouched (see launcher-gui-mcp.ts).
+  const groups = live ? [] : await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []);
+  const launchCommand = launcherCommandWithGuiMcp(command, codexGuiMcpServers({ sessionId, port: PORT, groups, allTools: false }), process.platform);
+  if (ws.readyState !== ws.OPEN) {
+    console.log(`[ws/launch] client left before spawn — abandoning ${sessionId}`);
+    return early.discard();
+  }
+
   let entry: PtyEntry;
   try {
-    entry = startLaunchEntry(deps, sessionId, ws, live, command, cwd);
+    entry = startLaunchEntry(deps, sessionId, ws, live, launchCommand, cwd);
   } catch (err) {
     console.error(`[ws/launch] failed to start ${sessionId}: ${messageOf(err)}`);
+    early.discard();
     return closeWithError(ws, "Failed to start the launch command.");
   }
 
   ws.on("message", (raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
   ws.on("close", () => deps.handleClientClose(entry, ws, sessionId));
+  early.release((raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
 }
 
 // codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume). ?gui=0 (grid dev terminal) runs
@@ -423,6 +442,6 @@ export function mountTerminalWebSockets(deps: WsRouteDeps) {
 
   wss.on("connection", (ws, req) => void handleClaudeConnection(deps, ws, req));
   runWss.on("connection", (ws, req) => handleRunConnection(deps, ws, req));
-  runLaunchWss.on("connection", (ws, req) => handleLaunchConnection(deps, ws, req));
+  runLaunchWss.on("connection", (ws, req) => void handleLaunchConnection(deps, ws, req));
   runCodexWss.on("connection", (ws, req) => void handleCodexConnection(deps, ws, req));
 }

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -23,6 +23,7 @@ import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
 import { codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
 import { sandboxWouldRun } from "../session/pty-spawn.js";
+import { bufferEarlyFrames } from "../session/early-frames.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { handleCommandFrame } from "../session/pty-connection.js";
@@ -353,6 +354,11 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { ur
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
+  // The browser sends its first frame — the terminal's real geometry — as soon as the socket
+  // opens, and the read below is the first thing on this path that waits. Collected from here so
+  // that frame is replayed into the pty rather than dropped on the floor (see early-frames.ts).
+  const early = bufferEarlyFrames<{ toString(): string }>(ws);
+
   // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
   // cells read, in the same file. claude picks them up itself; codex is handed resolved URLs at
   // spawn, so the answer has to be read here, before the pty exists. Only for a spawn: a reattach
@@ -362,7 +368,7 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { ur
   // reaps, because the close handlers below are not wired yet (same guard as the claude path).
   if (ws.readyState !== ws.OPEN) {
     console.log(`[ws/codex] client left before spawn — abandoning ${sessionId}`);
-    return;
+    return early.discard();
   }
 
   let entry: PtyEntry;
@@ -370,11 +376,14 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { ur
     entry = startCodexEntry(deps, ws, { sessionId, live, resumeRolloutId, cwd, attachGuiMcp, mcpGroups });
   } catch (err) {
     console.error(`[ws/codex] failed to start ${sessionId}: ${messageOf(err)}`);
+    early.discard();
     return closeWithError(ws, "Failed to start codex. Is the `codex` CLI installed and on your PATH?");
   }
 
   ws.on("message", (raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
   ws.on("close", () => deps.handleClientClose(entry, ws, sessionId));
+  // After the real listener is installed, so ordering holds for a frame that lands mid-replay.
+  early.release((raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
 }
 
 export function mountTerminalWebSockets(deps: WsRouteDeps) {

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -23,6 +23,8 @@ import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
 import { codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
 import { sandboxWouldRun } from "../session/pty-spawn.js";
+import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
+import { TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { handleCommandFrame } from "../session/pty-connection.js";
 import { closeWithError } from "../session/ws-frames.js";
 import { ProviderRefusedError } from "../session/provider-env.js";
@@ -200,17 +202,22 @@ function resolveCodexSession(requested: string | null): { sessionId: string; liv
   return { sessionId, live, resumeRolloutId };
 }
 
-function startCodexEntry(
-  deps: WsRouteDeps,
-  sessionId: string,
-  ws: WebSocket,
-  live: PtyEntry | undefined,
-  resumeRolloutId: string | null,
-  cwd: string,
-  attachGuiMcp: boolean,
-): PtyEntry {
+// Grouped rather than eight positional arguments: what this needs is a session to (re)attach,
+// a directory, and the GUI-tool decision — the last of which is now two values that only make
+// sense together (attach everything, or exactly these groups).
+interface CodexStart {
+  sessionId: string;
+  live: PtyEntry | undefined;
+  resumeRolloutId: string | null;
+  cwd: string;
+  attachGuiMcp: boolean;
+  mcpGroups: readonly ToolGroup[];
+}
+
+function startCodexEntry(deps: WsRouteDeps, ws: WebSocket, start: CodexStart): PtyEntry {
+  const { sessionId, live, resumeRolloutId, cwd, attachGuiMcp, mcpGroups } = start;
   if (live) return deps.reattachPty(live, ws, sessionId);
-  return deps.spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp, null); // interactive: no seed
+  return deps.spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp, { mcpGroups }); // interactive: no seed
 }
 
 async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: string; headers?: unknown }) {
@@ -338,7 +345,7 @@ function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: s
 // codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume). ?gui=0 (grid dev terminal) runs
 // codex without the GUI MCP and keeps it out of the sidebar; absent (single view) attaches the GUI
 // MCP so codex drives the GUI panel like claude.
-function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: string; headers?: unknown }) {
+async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: string; headers?: unknown }) {
   const { url, requested, cwd } = wsConnectionContext(req);
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
@@ -346,9 +353,21 @@ function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: st
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
   ws.send(JSON.stringify({ type: "session", id: sessionId, cwd: live?.cwd ?? cwd }));
 
+  // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
+  // cells read, in the same file. claude picks them up itself; codex is handed resolved URLs at
+  // spawn, so the answer has to be read here, before the pty exists. Only for a spawn: a reattach
+  // keeps the tools its running process was started with.
+  const mcpGroups = !attachGuiMcp && !live ? await registeredGuiMcpGroups(cwd, TOOL_GROUPS).catch(() => []) : [];
+  // Reading files can take a moment; a client that left in that window would leave a pty nobody
+  // reaps, because the close handlers below are not wired yet (same guard as the claude path).
+  if (ws.readyState !== ws.OPEN) {
+    console.log(`[ws/codex] client left before spawn — abandoning ${sessionId}`);
+    return;
+  }
+
   let entry: PtyEntry;
   try {
-    entry = startCodexEntry(deps, sessionId, ws, live, resumeRolloutId, cwd, attachGuiMcp);
+    entry = startCodexEntry(deps, ws, { sessionId, live, resumeRolloutId, cwd, attachGuiMcp, mcpGroups });
   } catch (err) {
     console.error(`[ws/codex] failed to start ${sessionId}: ${messageOf(err)}`);
     return closeWithError(ws, "Failed to start codex. Is the `codex` CLI installed and on your PATH?");
@@ -396,5 +415,5 @@ export function mountTerminalWebSockets(deps: WsRouteDeps) {
   wss.on("connection", (ws, req) => void handleClaudeConnection(deps, ws, req));
   runWss.on("connection", (ws, req) => handleRunConnection(deps, ws, req));
   runLaunchWss.on("connection", (ws, req) => handleLaunchConnection(deps, ws, req));
-  runCodexWss.on("connection", (ws, req) => handleCodexConnection(deps, ws, req));
+  runCodexWss.on("connection", (ws, req) => void handleCodexConnection(deps, ws, req));
 }

--- a/server/session/early-frames.ts
+++ b/server/session/early-frames.ts
@@ -1,0 +1,39 @@
+// Frames that arrive before the session they belong to exists.
+//
+// The browser treats a WebSocket as usable the moment it opens and sends its first frame right
+// away — a `resize` carrying the terminal's real geometry (see useTerminalConnections). The
+// server, meanwhile, may still be deciding what to spawn: a grid codex cell reads its directory's
+// registered tool groups off disk first. Anything that lands in that window is delivered to a
+// listener that does not exist yet and is simply lost, and a lost resize leaves the pty on its
+// default 80x24 while the browser draws the real size.
+//
+// So the socket is listened to from the start, into a buffer, and the buffer is replayed in
+// arrival order once there is a pty to give it to.
+import type { WebSocket } from "ws";
+
+export interface EarlyFrames<T> {
+  /** Replay what arrived, in order, and stop buffering. Safe to call when nothing arrived. */
+  release: (deliver: (raw: T) => void) => void;
+  /** Drop what arrived and stop buffering — for a connection that never gets its session. */
+  discard: () => void;
+}
+
+export function bufferEarlyFrames<T>(ws: Pick<WebSocket, "on" | "off">): EarlyFrames<T> {
+  const pending: T[] = [];
+  const collect = (raw: T) => pending.push(raw);
+  ws.on("message", collect as (...args: unknown[]) => void);
+  const stop = () => ws.off("message", collect as (...args: unknown[]) => void);
+  return {
+    release(deliver) {
+      // Detached BEFORE the replay: a frame arriving mid-replay must reach the real listener the
+      // caller is about to install, not land back in a buffer nobody drains again.
+      stop();
+      for (const raw of pending) deliver(raw);
+      pending.length = 0;
+    },
+    discard() {
+      stop();
+      pending.length = 0;
+    },
+  };
+}

--- a/server/session/launcher-gui-mcp.ts
+++ b/server/session/launcher-gui-mcp.ts
@@ -1,0 +1,49 @@
+// Giving a LAUNCHER's codex the same GUI tools the agent toggle's codex gets.
+//
+// A launcher is a command string the user configured (`{label: "Codex", command: "codex"}`), run
+// through the login shell — so unlike the first-class codex path there is no argv to add to, only
+// text. The two look alike in the grid and land in the same cell, and a Canvas that lights up for
+// one and never for the other reads as a broken feature; that is exactly how it was first
+// reported.
+//
+// Only codex is touched, and only when it is the program being run. Everything else — a shell, a
+// REPL, another agent — is passed through untouched: this rewrites a command the user wrote, so it
+// has to be a narrow, recognisable case rather than a guess.
+import path from "node:path";
+import { shellQuoteFor } from "../config/header-resolve.js";
+import type { GuiMcpServer } from "../agents/codex-args.js";
+
+// The program a command line runs, without its directory or a Windows extension: `codex`,
+// `/opt/homebrew/bin/codex` and `codex.cmd` are the same program. A quoted or env-prefixed
+// invocation (`FOO=1 codex`, `"my codex"`) is deliberately NOT unwrapped — an unrecognised shape
+// means "leave it alone", which is the safe direction for rewriting someone's own command.
+export function launcherProgram(command: string): string {
+  const [first = ""] = command.trim().split(/\s+/, 1);
+  return path.basename(first).replace(/\.(exe|cmd|bat)$/i, "");
+}
+
+/**
+ * The command to actually run, with codex's MCP overrides inserted when this launcher runs codex.
+ *
+ * The flags go directly after the program: codex's clap layout takes global options before the
+ * subcommand, so appending them at the end would break `codex resume`-style invocations.
+ */
+export function launcherCommandWithGuiMcp(command: string, servers: readonly GuiMcpServer[], platform: NodeJS.Platform): string {
+  if (servers.length === 0 || launcherProgram(command) !== "codex") return command;
+  const quote = shellQuoteFor(platform);
+  const flags = servers.flatMap((server) => {
+    // Quoted as ONE shell word each, because this is text handed to a shell rather than an argv
+    // element. The inner double quotes are codex's, not the shell's — `-c key="value"` is parsed
+    // as TOML and the value stops being a string without them.
+    const parts = [`-c`, quote(`mcp_servers.${server.id}.url="${server.url}"`)];
+    if (server.autoApprove) parts.push(`-c`, quote(`mcp_servers.${server.id}.default_tools_approval_mode="approve"`));
+    return parts;
+  });
+  // Sliced rather than split-and-rejoined: everything after the program is the user's text,
+  // quoting and spacing included, and it is put back byte for byte.
+  const trimmed = command.trim();
+  const boundary = trimmed.search(/\s/);
+  const program = boundary === -1 ? trimmed : trimmed.slice(0, boundary);
+  const rest = boundary === -1 ? "" : trimmed.slice(boundary);
+  return `${program} ${flags.join(" ")}${rest}`;
+}

--- a/server/session/launcher-gui-mcp.ts
+++ b/server/session/launcher-gui-mcp.ts
@@ -39,11 +39,17 @@ export function launcherCommandWithGuiMcp(command: string, servers: readonly Gui
     if (server.autoApprove) parts.push(`-c`, quote(`mcp_servers.${server.id}.default_tools_approval_mode="approve"`));
     return parts;
   });
-  // Sliced rather than split-and-rejoined: everything after the program is the user's text,
-  // quoting and spacing included, and it is put back byte for byte.
-  const trimmed = command.trim();
-  const boundary = trimmed.search(/\s/);
-  const program = boundary === -1 ? trimmed : trimmed.slice(0, boundary);
-  const rest = boundary === -1 ? "" : trimmed.slice(boundary);
-  return `${program} ${flags.join(" ")}${rest}`;
+  // Scanned rather than split-and-rejoined: everything around the program is the user's text —
+  // quoting, spacing, and a trailing backslash-newline continuation included — and it is put back
+  // byte for byte. Trimming the tail would turn such a continuation into an unterminated command.
+  //
+  // Two index walks rather than one anchored regex: `^(\s*)(\S+)([\s\S]*)$` backtracks
+  // super-linearly on a long command (sonarjs flags it), and this says the same thing.
+  const isSpace = (index: number): boolean => /\s/.test(command[index]);
+  let start = 0;
+  while (start < command.length && isSpace(start)) start++;
+  if (start === command.length) return command; // whitespace only — nothing to run
+  let end = start;
+  while (end < command.length && !isSpace(end)) end++;
+  return `${command.slice(0, end)} ${flags.join(" ")}${command.slice(end)}`;
 }

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -8,7 +8,8 @@
 // so the precedence rule below could not be tested without booting the server (#548).
 import { rewriteLoopbackForDocker } from "../infra/sandbox.js";
 import type { UserMcpServer } from "../config/config-schema.js";
-import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
+import { toolGroupServerId, toolsInGroup, AUTO_ALLOWED_TOOLS, type ToolGroup } from "../../common/toolGroups.js";
+import type { GuiMcpServer } from "../agents/codex-args.js";
 
 export interface McpConfigInput {
   sessionId: string;
@@ -45,6 +46,17 @@ export function guiMcpEnv(sessionId: string, port: string | number): Record<stri
 // The GROUPS are the directory's, read from Claude Code's config by the caller: one switch in the
 // launcher, both agents. A grid cell whose directory registered nothing gets an empty list and
 // therefore no GUI tools, which is what it had before.
+//
+// AUTO-APPROVAL is the part that does not carry over cleanly. claude is handed a list of TOOLS
+// (`--allowedTools` from AUTO_ALLOWED_TOOLS), and that list deliberately withholds the ones that
+// can spend money or write files — presentDocument resolves image placeholders through the image
+// backend, and the whole `media` group generates. codex approves per SERVER, so a group can only
+// be waved through when EVERY tool in it is on that list. Today none are, so a grid cell answers
+// codex's prompt instead — which is the same question claude asks, not a new obstacle.
+//
+// The single view is left as it was: it carries the whole GUI MCP under one id and has been
+// approved wholesale since it was wired, and narrowing it here would take a working setup and
+// start prompting in it. Deliberate divergence, not an oversight.
 export function codexGuiMcpServers({
   sessionId,
   host = DEFAULT_HOST,
@@ -58,10 +70,16 @@ export function codexGuiMcpServers({
   groups: readonly ToolGroup[];
   /** The single view, which carries every tool on one URL rather than a URL per group. */
   allTools: boolean;
-}): { id: string; url: string }[] {
+}): GuiMcpServer[] {
   const base = `http://${host}:${port}/api/mcp`;
-  if (allTools) return [{ id: GUI_SERVER_ID, url: `${base}/${sessionId}` }];
-  return groups.map((group) => ({ id: toolGroupServerId(group), url: `${base}/${group}/${sessionId}` }));
+  if (allTools) return [{ id: GUI_SERVER_ID, url: `${base}/${sessionId}`, autoApprove: true }];
+  return groups.map((group) => ({
+    id: toolGroupServerId(group),
+    url: `${base}/${group}/${sessionId}`,
+    // Every tool, not any: one unlisted member is enough to make approving the server a way to
+    // run it without asking.
+    autoApprove: toolsInGroup(group).every((tool) => AUTO_ALLOWED_TOOLS.includes(tool)),
+  }));
 }
 
 export function mcpConfigJson({ sessionId, host = DEFAULT_HOST, port, userMcpServers, sandbox = false }: McpConfigInput): string {

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -8,7 +8,7 @@
 // so the precedence rule below could not be tested without booting the server (#548).
 import { rewriteLoopbackForDocker } from "../infra/sandbox.js";
 import type { UserMcpServer } from "../config/config-schema.js";
-import { toolGroupServerId, toolsInGroup, AUTO_ALLOWED_TOOLS, type ToolGroup } from "../../common/toolGroups.js";
+import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 import type { GuiMcpServer } from "../agents/codex-args.js";
 
 export interface McpConfigInput {
@@ -47,16 +47,21 @@ export function guiMcpEnv(sessionId: string, port: string | number): Record<stri
 // launcher, both agents. A grid cell whose directory registered nothing gets an empty list and
 // therefore no GUI tools, which is what it had before.
 //
-// AUTO-APPROVAL is the part that does not carry over cleanly. claude is handed a list of TOOLS
-// (`--allowedTools` from AUTO_ALLOWED_TOOLS), and that list deliberately withholds the ones that
-// can spend money or write files — presentDocument resolves image placeholders through the image
-// backend, and the whole `media` group generates. codex approves per SERVER, so a group can only
-// be waved through when EVERY tool in it is on that list. Today none are, so a grid cell answers
-// codex's prompt instead — which is the same question claude asks, not a new obstacle.
+// AUTO-APPROVAL does not carry over cleanly, and the difference is decided here. claude is handed
+// a list of TOOLS (`--allowedTools`, from AUTO_ALLOWED_TOOLS) and that list deliberately withholds
+// the ones that can spend money — presentDocument resolves image placeholders through the image
+// backend, and the whole `media` group generates. codex approves per SERVER, so the same list
+// cannot be expressed: a group is waved through as a whole, or every call in it asks.
 //
-// The single view is left as it was: it carries the whole GUI MCP under one id and has been
-// approved wholesale since it was wired, and narrowing it here would take a working setup and
-// start prompting in it. Deliberate divergence, not an oversight.
+// It is waved through, by the owner's decision (2026-07-28). Prompting on every drawing call is
+// what the flag was added to the single view to avoid, and the single view has carried the whole
+// GUI MCP — generateImage included — approved wholesale since it was wired. So a codex cell can
+// spend on presentDocument / generateImage / presentMulmoScript without asking, and a claude cell
+// in the same directory still asks. That asymmetry is intentional and it is codex's approval
+// model, not an oversight.
+//
+// If it should ever be narrowed, this is the one place: `autoApprove` is a per-server property so
+// the policy stays a value here rather than a flag scattered through the argv builder.
 export function codexGuiMcpServers({
   sessionId,
   host = DEFAULT_HOST,
@@ -73,13 +78,7 @@ export function codexGuiMcpServers({
 }): GuiMcpServer[] {
   const base = `http://${host}:${port}/api/mcp`;
   if (allTools) return [{ id: GUI_SERVER_ID, url: `${base}/${sessionId}`, autoApprove: true }];
-  return groups.map((group) => ({
-    id: toolGroupServerId(group),
-    url: `${base}/${group}/${sessionId}`,
-    // Every tool, not any: one unlisted member is enough to make approving the server a way to
-    // run it without asking.
-    autoApprove: toolsInGroup(group).every((tool) => AUTO_ALLOWED_TOOLS.includes(tool)),
-  }));
+  return groups.map((group) => ({ id: toolGroupServerId(group), url: `${base}/${group}/${sessionId}`, autoApprove: true }));
 }
 
 export function mcpConfigJson({ sessionId, host = DEFAULT_HOST, port, userMcpServers, sandbox = false }: McpConfigInput): string {

--- a/server/session/mcp-config.ts
+++ b/server/session/mcp-config.ts
@@ -8,6 +8,7 @@
 // so the precedence rule below could not be tested without booting the server (#548).
 import { rewriteLoopbackForDocker } from "../infra/sandbox.js";
 import type { UserMcpServer } from "../config/config-schema.js";
+import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 
 export interface McpConfigInput {
   sessionId: string;
@@ -35,6 +36,32 @@ const GUI_SERVER_ID = "mulmoterminal-gui";
 // simply never reads these, and a session that starts in one view is not worth special-casing.
 export function guiMcpEnv(sessionId: string, port: string | number): Record<string, string> {
   return { MULMOTERMINAL_PORT: String(port), MULMOTERMINAL_SESSION_ID: sessionId };
+}
+
+// The same two surfaces, spelled for CODEX, which takes them as `-c mcp_servers.<id>.url=` at
+// spawn instead of reading a config file. It has no `${VAR}` expansion, so unlike the template
+// above these are resolved here — which is possible precisely because they are built per spawn.
+//
+// The GROUPS are the directory's, read from Claude Code's config by the caller: one switch in the
+// launcher, both agents. A grid cell whose directory registered nothing gets an empty list and
+// therefore no GUI tools, which is what it had before.
+export function codexGuiMcpServers({
+  sessionId,
+  host = DEFAULT_HOST,
+  port,
+  groups,
+  allTools,
+}: {
+  sessionId: string;
+  host?: string;
+  port: string | number;
+  groups: readonly ToolGroup[];
+  /** The single view, which carries every tool on one URL rather than a URL per group. */
+  allTools: boolean;
+}): { id: string; url: string }[] {
+  const base = `http://${host}:${port}/api/mcp`;
+  if (allTools) return [{ id: GUI_SERVER_ID, url: `${base}/${sessionId}` }];
+  return groups.map((group) => ({ id: toolGroupServerId(group), url: `${base}/${group}/${sessionId}` }));
 }
 
 export function mcpConfigJson({ sessionId, host = DEFAULT_HOST, port, userMcpServers, sandbox = false }: McpConfigInput): string {

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -4,6 +4,8 @@
 import type { WebSocket } from "ws";
 import { PORT } from "../config/env.js";
 import { buildCodexArgs } from "../agents/codex-args.js";
+import type { ToolGroup } from "../../common/toolGroups.js";
+import { codexGuiMcpServers } from "./mcp-config.js";
 import { codexSessionsRoot, snapshotSessions, watchForCodexSession } from "../agents/codex-session.js";
 import { codexRolloutPath } from "../agents/codex-sessions.js";
 import { trackCodexActivity } from "./codex-activity-track.js";
@@ -61,14 +63,27 @@ export function createCodexSpawner(deps: SpawnDeps) {
     resumeRolloutId: string | null,
     cwd: string,
     attachGuiMcp: boolean,
-    initialPrompt: string | null,
+    // The two things only some callers have. An object rather than two more positional
+    // arguments: seven of those is past the point where a call site can be read.
+    options: {
+      /** Typed into codex's input box once it settles, for a session started to run something. */
+      initialPrompt?: string | null;
+      /** The tool groups this cell's DIRECTORY has registered, for a grid cell (gui=0). Read by
+       *  the caller because the lookup reads Claude Code's config files, and this is sync. */
+      mcpGroups?: readonly ToolGroup[];
+    } = {},
   ): PtyEntry {
+    const { initialPrompt = null, mcpGroups = [] } = options;
     const root = codexSessionsRoot();
     const before = snapshotSessions(root);
-    // Single view: point codex at the in-process GUI MCP (same per-session URL as claude's) so it
-    // can drive the GUI panel. Grid dev terminals pass gui=0 → no MCP.
-    const guiMcpUrl = attachGuiMcp ? `http://127.0.0.1:${PORT}/api/mcp/${sessionId}` : null;
-    const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpUrl });
+    // Two surfaces, the same two claude has:
+    //   single view (gui) — the whole GUI MCP on one per-session URL.
+    //   grid cell (gui=0) — one URL per tool group the DIRECTORY registered, which the caller
+    //     read from the same config claude's own switches write (see the launcher's Canvas
+    //     rows). codex cannot read that config itself, so the groups arrive resolved here.
+    // A grid cell whose directory registered nothing gets no MCP at all, exactly as before.
+    const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools: attachGuiMcp });
+    const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpServers });
     const { term, tmux } = ptySpawn(sessionId, deps.codexBin, args, cwd, true);
     const via = tmux ? " via tmux" : "";
     const resumeNote = resumeRolloutId ? ` (resume ${resumeRolloutId})` : "";

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -1742,12 +1742,15 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         <ModelPicker v-if="agent === 'claude'" v-model="launchChoice" />
         <!-- Canvas is a per-DIRECTORY registration in Claude Code's own MCP config, not a
              per-launch choice — but it only takes effect when a session starts, so this is
-             where it belongs: decided before the thing it configures exists. Claude only;
-             codex reaches the GUI tools by another route.
+             where it belongs: decided before the thing it configures exists.
+             BOTH agents: claude reads that config itself, and a codex cell is handed the same
+             groups as resolved URLs at spawn (server/session/spawn-codex.ts), so one switch
+             answers for both. It is still Claude Code's file — writing it needs the `claude`
+             CLI on PATH, which is why a failure here says so rather than silently doing nothing.
              One row per Canvas group: both draw into the same pane, and they are separate
              switches because a media call is slow, paid and writes files where a render call
              stops at the pane (see common/toolGroups.ts). -->
-        <template v-if="agent === 'claude' && canvasDir">
+        <template v-if="canvasDir">
           <!-- The hover names the server id and its tools (canvasTitle); it sits on the ROW so
                the text is reachable from the label as well as the box. -->
           <label

--- a/test/server/agents/codex-args.spec.ts
+++ b/test/server/agents/codex-args.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildCodexArgs } from "../../../server/agents/codex-args.js";
 
-const base = { resume: null, model: null, guiMcpUrl: null };
+const base = { resume: null, model: null, guiMcpServers: [] };
 
 describe("buildCodexArgs", () => {
   it("passes no id for a fresh session (codex mints its own)", () => {
@@ -24,7 +24,7 @@ describe("buildCodexArgs", () => {
     // Opaque endpoint token — buildCodexArgs embeds it verbatim (the real value is an
     // interpolated loopback URL; a static http literal here trips no-clear-text-protocols).
     const url = "gui-mcp-endpoint";
-    expect(buildCodexArgs({ ...base, guiMcpUrl: url })).toEqual([
+    expect(buildCodexArgs({ ...base, guiMcpServers: [{ id: "mulmoterminal-gui", url }] })).toEqual([
       "-c",
       `mcp_servers.mulmoterminal-gui.url="${url}"`,
       "-c",
@@ -32,8 +32,31 @@ describe("buildCodexArgs", () => {
     ]);
   });
 
+  // A GRID cell gets one server per tool group its directory registered, not the all-tools URL.
+  // Auto-approval is per server id, so every group needs its own line — a group the user enabled
+  // and codex then asks permission for on every call is the friction this flag exists to remove.
+  it("injects one server per group, each auto-approved", () => {
+    const args = buildCodexArgs({
+      ...base,
+      guiMcpServers: [
+        { id: "mulmoterminal-render", url: "render-endpoint" },
+        { id: "mulmoterminal-media", url: "media-endpoint" },
+      ],
+    });
+    expect(args).toEqual([
+      "-c",
+      `mcp_servers.mulmoterminal-render.url="render-endpoint"`,
+      "-c",
+      `mcp_servers.mulmoterminal-render.default_tools_approval_mode="approve"`,
+      "-c",
+      `mcp_servers.mulmoterminal-media.url="media-endpoint"`,
+      "-c",
+      `mcp_servers.mulmoterminal-media.default_tools_approval_mode="approve"`,
+    ]);
+  });
+
   it("orders model, GUI MCP, then the resume subcommand (no positional prompt)", () => {
-    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpUrl: "gui-mcp-endpoint" });
+    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpServers: [{ id: "mulmoterminal-gui", url: "gui-mcp-endpoint" }] });
     expect(args.slice(0, 2)).toEqual(["--model", "gpt-5.4"]);
     expect(args).toContain("-c");
     expect(args.slice(-2)).toEqual(["resume", "id1"]);

--- a/test/server/agents/codex-args.spec.ts
+++ b/test/server/agents/codex-args.spec.ts
@@ -24,7 +24,7 @@ describe("buildCodexArgs", () => {
     // Opaque endpoint token — buildCodexArgs embeds it verbatim (the real value is an
     // interpolated loopback URL; a static http literal here trips no-clear-text-protocols).
     const url = "gui-mcp-endpoint";
-    expect(buildCodexArgs({ ...base, guiMcpServers: [{ id: "mulmoterminal-gui", url }] })).toEqual([
+    expect(buildCodexArgs({ ...base, guiMcpServers: [{ id: "mulmoterminal-gui", url, autoApprove: true }] })).toEqual([
       "-c",
       `mcp_servers.mulmoterminal-gui.url="${url}"`,
       "-c",
@@ -39,8 +39,8 @@ describe("buildCodexArgs", () => {
     const args = buildCodexArgs({
       ...base,
       guiMcpServers: [
-        { id: "mulmoterminal-render", url: "render-endpoint" },
-        { id: "mulmoterminal-media", url: "media-endpoint" },
+        { id: "mulmoterminal-render", url: "render-endpoint", autoApprove: true },
+        { id: "mulmoterminal-media", url: "media-endpoint", autoApprove: true },
       ],
     });
     expect(args).toEqual([
@@ -56,9 +56,17 @@ describe("buildCodexArgs", () => {
   });
 
   it("orders model, GUI MCP, then the resume subcommand (no positional prompt)", () => {
-    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpServers: [{ id: "mulmoterminal-gui", url: "gui-mcp-endpoint" }] });
+    const args = buildCodexArgs({ resume: "id1", model: "gpt-5.4", guiMcpServers: [{ id: "mulmoterminal-gui", url: "gui-mcp-endpoint", autoApprove: true }] });
     expect(args.slice(0, 2)).toEqual(["--model", "gpt-5.4"]);
     expect(args).toContain("-c");
     expect(args.slice(-2)).toEqual(["resume", "id1"]);
+  });
+
+  // codex approves per server, so a group holding a tool that is not auto-allowed gets the url
+  // and nothing else — the prompt is the point. See codexGuiMcpServers.
+  it("omits the approval line for a server that is not auto-approved", () => {
+    const args = buildCodexArgs({ ...base, guiMcpServers: [{ id: "mulmoterminal-media", url: "media-endpoint", autoApprove: false }] });
+    expect(args).toEqual(["-c", `mcp_servers.mulmoterminal-media.url="media-endpoint"`]);
+    expect(args.join(" ")).not.toContain("approval_mode");
   });
 });

--- a/test/server/session/early-frames.spec.ts
+++ b/test/server/session/early-frames.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { bufferEarlyFrames } from "../../../server/session/early-frames.js";
+
+// The browser sends the terminal's real geometry the instant the socket opens. A grid codex
+// connection reads its directory's registered tool groups off disk before it can spawn, and
+// anything arriving in that window used to reach a listener that did not exist yet — a lost
+// resize leaves the pty at 80x24 while the browser draws the real size.
+class FakeSocket {
+  private listeners: ((raw: unknown) => void)[] = [];
+  on(event: string, cb: (raw: unknown) => void) {
+    if (event === "message") this.listeners.push(cb);
+    return this;
+  }
+  off(event: string, cb: (raw: unknown) => void) {
+    if (event === "message") this.listeners = this.listeners.filter((l) => l !== cb);
+    return this;
+  }
+  emit(raw: unknown) {
+    for (const l of [...this.listeners]) l(raw);
+  }
+  get listenerCount() {
+    return this.listeners.length;
+  }
+}
+
+const socket = () => new FakeSocket() as unknown as FakeSocket & Parameters<typeof bufferEarlyFrames>[0];
+
+describe("bufferEarlyFrames", () => {
+  it("replays what arrived before the session existed, in order", () => {
+    const ws = socket();
+    const early = bufferEarlyFrames<string>(ws);
+    ws.emit("resize-80x24");
+    ws.emit("input-a");
+
+    const delivered: string[] = [];
+    early.release((raw) => delivered.push(raw));
+    expect(delivered).toEqual(["resize-80x24", "input-a"]);
+  });
+
+  // Releasing must also STOP collecting, or every later frame would pile up in a buffer nobody
+  // drains again — the terminal would go dead after its first keystroke.
+  it("stops collecting once released", () => {
+    const ws = socket();
+    const early = bufferEarlyFrames<string>(ws);
+    early.release(() => {});
+    expect(ws.listenerCount).toBe(0);
+  });
+
+  it("delivers nothing when nothing arrived", () => {
+    const ws = socket();
+    const early = bufferEarlyFrames<string>(ws);
+    const delivered: string[] = [];
+    early.release((raw) => delivered.push(raw));
+    expect(delivered).toEqual([]);
+  });
+
+  // A connection whose spawn failed has no pty to replay into.
+  it("drops what it holds when discarded", () => {
+    const ws = socket();
+    const early = bufferEarlyFrames<string>(ws);
+    ws.emit("input-a");
+    early.discard();
+    expect(ws.listenerCount).toBe(0);
+
+    const delivered: string[] = [];
+    early.release((raw) => delivered.push(raw));
+    expect(delivered).toEqual([]);
+  });
+});

--- a/test/server/session/launcher-gui-mcp.spec.ts
+++ b/test/server/session/launcher-gui-mcp.spec.ts
@@ -52,6 +52,17 @@ describe("launcherCommandWithGuiMcp", () => {
     for (const word of words) expect(word).toContain('="');
   });
 
+  // "Byte for byte" has to include the tail. A trailing backslash-newline continuation that gets
+  // trimmed away leaves the shell reading an unterminated command.
+  it("keeps trailing text the command line depends on", () => {
+    const out = rewrite("codex --model gpt-5 \\\n  --search");
+    expect(out.endsWith(" --model gpt-5 \\\n  --search")).toBe(true);
+  });
+
+  it("keeps the command's own leading whitespace", () => {
+    expect(rewrite("  codex").startsWith("  codex -c ")).toBe(true);
+  });
+
   it("leaves a command that is not codex alone", () => {
     expect(rewrite("$SHELL")).toBe("$SHELL");
     expect(rewrite("claude")).toBe("claude");

--- a/test/server/session/launcher-gui-mcp.spec.ts
+++ b/test/server/session/launcher-gui-mcp.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { launcherProgram, launcherCommandWithGuiMcp } from "../../../server/session/launcher-gui-mcp.js";
+
+// The "Codex" launcher chip and the Claude|Codex agent toggle land in the same grid cell and look
+// the same, but the chip runs a COMMAND STRING through the login shell — there is no argv to add
+// the GUI MCP to. The first "Canvas doesn't light up for codex" report was exactly this.
+const SERVERS = [
+  { id: "mulmoterminal-render", url: "http://127.0.0.1:34567/api/mcp/render/s1", autoApprove: true },
+  { id: "mulmoterminal-media", url: "http://127.0.0.1:34567/api/mcp/media/s1", autoApprove: false },
+];
+
+const rewrite = (command: string, servers = SERVERS) => launcherCommandWithGuiMcp(command, servers, "darwin");
+
+describe("launcherProgram", () => {
+  it("ignores the path and a Windows extension", () => {
+    expect(launcherProgram("codex")).toBe("codex");
+    expect(launcherProgram("/opt/homebrew/bin/codex --model gpt-5")).toBe("codex");
+    expect(launcherProgram("codex.cmd")).toBe("codex");
+    expect(launcherProgram("  codex  ")).toBe("codex");
+  });
+
+  // An unrecognised shape means "leave it alone" — this rewrites the user's own command, so
+  // guessing at env prefixes or quoting is the wrong direction.
+  it("does not try to see through a wrapper", () => {
+    expect(launcherProgram("FOO=1 codex")).not.toBe("codex");
+    expect(launcherProgram("$SHELL")).toBe("$SHELL");
+  });
+});
+
+describe("launcherCommandWithGuiMcp", () => {
+  it("adds each server's url, and the approval only where it was granted", () => {
+    expect(rewrite("codex")).toBe(
+      `codex -c 'mcp_servers.mulmoterminal-render.url="http://127.0.0.1:34567/api/mcp/render/s1"' ` +
+        `-c 'mcp_servers.mulmoterminal-render.default_tools_approval_mode="approve"' ` +
+        `-c 'mcp_servers.mulmoterminal-media.url="http://127.0.0.1:34567/api/mcp/media/s1"'`,
+    );
+  });
+
+  // codex's clap layout takes global options BEFORE the subcommand, so appending would break
+  // `codex resume`. The user's own text after the program is put back byte for byte.
+  it("inserts the flags after the program and keeps the rest verbatim", () => {
+    const out = rewrite(`codex --model "gpt 5" resume`);
+    expect(out.startsWith("codex -c ")).toBe(true);
+    expect(out.endsWith(` --model "gpt 5" resume`)).toBe(true);
+  });
+
+  // The inner double quotes are codex's — `-c key="value"` is parsed as TOML and the value stops
+  // being a string without them — so the whole thing has to survive as ONE shell word.
+  it("wraps each override in a single shell word", () => {
+    const words = rewrite("codex").match(/'[^']*'/g) ?? [];
+    expect(words).toHaveLength(3);
+    for (const word of words) expect(word).toContain('="');
+  });
+
+  it("leaves a command that is not codex alone", () => {
+    expect(rewrite("$SHELL")).toBe("$SHELL");
+    expect(rewrite("claude")).toBe("claude");
+    expect(rewrite("FOO=1 codex")).toBe("FOO=1 codex");
+  });
+
+  // A directory that registered nothing must run the command the user configured, unchanged.
+  it("leaves codex alone when the directory registered no groups", () => {
+    expect(launcherCommandWithGuiMcp("codex", [], "darwin")).toBe("codex");
+  });
+
+  // Windows runs the command through powershell, which doubles a quote instead of escaping it.
+  it("quotes for the platform it will run on", () => {
+    const out = launcherCommandWithGuiMcp("codex", [SERVERS[0]], "win32");
+    expect(out).toContain(`-c 'mcp_servers.mulmoterminal-render.url="http://127.0.0.1:34567/api/mcp/render/s1"'`);
+  });
+});

--- a/test/server/session/mcp-config.spec.ts
+++ b/test/server/session/mcp-config.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 
-import { mcpConfigJson, guiMcpEnv } from "../../../server/session/mcp-config.js";
+import { mcpConfigJson, guiMcpEnv, codexGuiMcpServers } from "../../../server/session/mcp-config.js";
 import { SANDBOX_HOST } from "../../../server/infra/sandbox.js";
+import { guiMcpUrlTemplate } from "../../../server/infra/gui-mcp-registration.js";
 
 const SESSION = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
 const GUI = "mulmoterminal-gui";
@@ -98,5 +99,43 @@ describe("guiMcpEnv", () => {
 
   it("stringifies a port given as a string too", () => {
     expect(guiMcpEnv("abc-123", "8080").MULMOTERMINAL_PORT).toBe("8080");
+  });
+});
+
+// codex takes its MCP servers as `-c mcp_servers.<id>.url=` at spawn rather than from a config
+// file, and has no `${VAR}` expansion — so unlike claude's grid template these are resolved here.
+// The two agents must land on the SAME urls: the group URL is what tells the server a session has
+// that group (see mcp-routes), and a codex cell that spelled it differently would light no Canvas.
+describe("codexGuiMcpServers", () => {
+  it("gives the single view the all-tools url under the gui server id", () => {
+    expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: [], allTools: true })).toEqual([
+      { id: GUI, url: `http://127.0.0.1:34567/api/mcp/${SESSION}` },
+    ]);
+  });
+
+  // The single view carries every tool on one URL, so a group list is not consulted there —
+  // passing both must not produce five servers.
+  it("ignores the groups when the whole GUI MCP is attached", () => {
+    expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: ["render", "media"], allTools: true })).toHaveLength(1);
+  });
+
+  it("gives a grid cell one url per registered group", () => {
+    expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: ["render", "media"], allTools: false })).toEqual([
+      { id: "mulmoterminal-render", url: `http://127.0.0.1:34567/api/mcp/render/${SESSION}` },
+      { id: "mulmoterminal-media", url: `http://127.0.0.1:34567/api/mcp/media/${SESSION}` },
+    ]);
+  });
+
+  // The url claude's own registration expands to, modulo the two values it takes from the
+  // environment. Spelled out rather than derived, so a change to either side shows up here.
+  it("matches the shape claude's grid template expands to", () => {
+    const [{ url }] = codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: ["render"], allTools: false });
+    expect(guiMcpUrlTemplate("render").replace("${MULMOTERMINAL_PORT}", "34567").replace("${MULMOTERMINAL_SESSION_ID}", SESSION)).toBe(url);
+  });
+
+  // Nothing registered means no GUI tools, which is exactly what a grid codex cell had before
+  // the groups were wired — not a silent fallback to everything.
+  it("gives a directory that registered nothing no servers at all", () => {
+    expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: [], allTools: false })).toEqual([]);
   });
 });

--- a/test/server/session/mcp-config.spec.ts
+++ b/test/server/session/mcp-config.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import { mcpConfigJson, guiMcpEnv, codexGuiMcpServers } from "../../../server/session/mcp-config.js";
 import { SANDBOX_HOST } from "../../../server/infra/sandbox.js";
 import { guiMcpUrlTemplate } from "../../../server/infra/gui-mcp-registration.js";
+import { TOOL_GROUPS, toolsInGroup, toolGroupServerId, AUTO_ALLOWED_TOOLS, type ToolGroup } from "../../../common/toolGroups.js";
 
 const SESSION = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
 const GUI = "mulmoterminal-gui";
@@ -109,7 +110,7 @@ describe("guiMcpEnv", () => {
 describe("codexGuiMcpServers", () => {
   it("gives the single view the all-tools url under the gui server id", () => {
     expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: [], allTools: true })).toEqual([
-      { id: GUI, url: `http://127.0.0.1:34567/api/mcp/${SESSION}` },
+      { id: GUI, url: `http://127.0.0.1:34567/api/mcp/${SESSION}`, autoApprove: true },
     ]);
   });
 
@@ -120,9 +121,9 @@ describe("codexGuiMcpServers", () => {
   });
 
   it("gives a grid cell one url per registered group", () => {
-    expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: ["render", "media"], allTools: false })).toEqual([
-      { id: "mulmoterminal-render", url: `http://127.0.0.1:34567/api/mcp/render/${SESSION}` },
-      { id: "mulmoterminal-media", url: `http://127.0.0.1:34567/api/mcp/media/${SESSION}` },
+    expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: ["render", "media"], allTools: false }).map((s) => [s.id, s.url])).toEqual([
+      ["mulmoterminal-render", `http://127.0.0.1:34567/api/mcp/render/${SESSION}`],
+      ["mulmoterminal-media", `http://127.0.0.1:34567/api/mcp/media/${SESSION}`],
     ]);
   });
 
@@ -137,5 +138,34 @@ describe("codexGuiMcpServers", () => {
   // the groups were wired — not a silent fallback to everything.
   it("gives a directory that registered nothing no servers at all", () => {
     expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: [], allTools: false })).toEqual([]);
+  });
+});
+
+// codex approves per SERVER; claude is handed a list of TOOLS. AUTO_ALLOWED_TOOLS deliberately
+// withholds the ones that spend money or write files (presentDocument resolves image placeholders
+// through the image backend; the whole media group generates), so waving a group through would
+// hand codex what that list exists to keep behind a prompt.
+describe("codexGuiMcpServers auto-approval", () => {
+  const groupsOf = (groups: ToolGroup[]) => codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups, allTools: false });
+
+  it("does not auto-approve a group holding a tool that is not auto-allowed", () => {
+    for (const server of groupsOf([...TOOL_GROUPS])) expect(server.autoApprove).toBe(false);
+  });
+
+  // Stated as the RULE rather than the current answer: if presentDocument ever joins the list,
+  // render becomes approvable and this keeps agreeing with AUTO_ALLOWED_TOOLS instead of a
+  // hardcoded false.
+  it("follows AUTO_ALLOWED_TOOLS rather than a fixed answer", () => {
+    for (const group of TOOL_GROUPS) {
+      const [server] = groupsOf([group]);
+      expect(server.id).toBe(toolGroupServerId(group));
+      expect(server.autoApprove).toBe(toolsInGroup(group).every((tool) => AUTO_ALLOWED_TOOLS.includes(tool)));
+    }
+  });
+
+  // The single view carries every tool under one id and has been approved wholesale since it was
+  // wired; narrowing it here would start prompting in a setup that works today.
+  it("leaves the single view approved", () => {
+    expect(codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups: [], allTools: true })[0].autoApprove).toBe(true);
   });
 });

--- a/test/server/session/mcp-config.spec.ts
+++ b/test/server/session/mcp-config.spec.ts
@@ -141,26 +141,27 @@ describe("codexGuiMcpServers", () => {
   });
 });
 
-// codex approves per SERVER; claude is handed a list of TOOLS. AUTO_ALLOWED_TOOLS deliberately
-// withholds the ones that spend money or write files (presentDocument resolves image placeholders
-// through the image backend; the whole media group generates), so waving a group through would
-// hand codex what that list exists to keep behind a prompt.
+// codex approves per SERVER; claude is handed a list of TOOLS (AUTO_ALLOWED_TOOLS, which withholds
+// the ones that can spend money). The same list cannot be expressed here — a group is waved through
+// as a whole, or every call in it asks — and the owner chose to wave it through (2026-07-28). So a
+// codex cell can spend on presentDocument / generateImage without asking while a claude cell in the
+// same directory still asks. Pinned because it is a deliberate asymmetry, not a leftover.
 describe("codexGuiMcpServers auto-approval", () => {
   const groupsOf = (groups: ToolGroup[]) => codexGuiMcpServers({ sessionId: SESSION, port: 34567, groups, allTools: false });
 
-  it("does not auto-approve a group holding a tool that is not auto-allowed", () => {
-    for (const server of groupsOf([...TOOL_GROUPS])) expect(server.autoApprove).toBe(false);
+  it("approves every group it attaches", () => {
+    const servers = groupsOf([...TOOL_GROUPS]);
+    expect(servers).toHaveLength(TOOL_GROUPS.length);
+    for (const server of servers) expect(server.autoApprove).toBe(true);
   });
 
-  // Stated as the RULE rather than the current answer: if presentDocument ever joins the list,
-  // render becomes approvable and this keeps agreeing with AUTO_ALLOWED_TOOLS instead of a
-  // hardcoded false.
-  it("follows AUTO_ALLOWED_TOOLS rather than a fixed answer", () => {
-    for (const group of TOOL_GROUPS) {
-      const [server] = groupsOf([group]);
-      expect(server.id).toBe(toolGroupServerId(group));
-      expect(server.autoApprove).toBe(toolsInGroup(group).every((tool) => AUTO_ALLOWED_TOOLS.includes(tool)));
-    }
+  // The group claude keeps entirely behind a prompt. Named rather than left to the loop above, so
+  // narrowing the policy later has to change a test that says what it is giving up.
+  it("approves media too, whose tools claude never auto-allows", () => {
+    const [media] = groupsOf(["media"]);
+    expect(media.id).toBe(toolGroupServerId("media"));
+    expect(media.autoApprove).toBe(true);
+    expect(toolsInGroup("media").some((tool) => AUTO_ALLOWED_TOOLS.includes(tool))).toBe(false);
   });
 
   // The single view carries every tool under one id and has been approved wholesale since it was

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -208,7 +208,7 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
   // escaping". That stopped being true when a `.cmd`-installed codex started going through
   // cmd.exe (#801): lose those quotes and the TOML value is no longer a string.
   it("round-trips codex's quoted TOML overrides through a .cmd shim", async () => {
-    const args = buildCodexArgs({ resume: null, model: "gpt-5", guiMcpUrl: "http://127.0.0.1:34567/api/mcp/abc-123" });
+    const args = buildCodexArgs({ resume: null, model: "gpt-5", guiMcpServers: [{ id: "mulmoterminal-gui", url: "http://127.0.0.1:34567/api/mcp/abc-123" }] });
     expect(args.some((a) => a.includes('"'))).toBe(true); // the case only exists while they are quoted
 
     rmSync(argsOut, { force: true });

--- a/test/server/session/pty-spawn-win.spec.ts
+++ b/test/server/session/pty-spawn-win.spec.ts
@@ -208,7 +208,11 @@ describe.skipIf(!isWindows)("spawnPty on Windows", () => {
   // escaping". That stopped being true when a `.cmd`-installed codex started going through
   // cmd.exe (#801): lose those quotes and the TOML value is no longer a string.
   it("round-trips codex's quoted TOML overrides through a .cmd shim", async () => {
-    const args = buildCodexArgs({ resume: null, model: "gpt-5", guiMcpServers: [{ id: "mulmoterminal-gui", url: "http://127.0.0.1:34567/api/mcp/abc-123" }] });
+    const args = buildCodexArgs({
+      resume: null,
+      model: "gpt-5",
+      guiMcpServers: [{ id: "mulmoterminal-gui", url: "http://127.0.0.1:34567/api/mcp/abc-123", autoApprove: true }],
+    });
     expect(args.some((a) => a.includes('"'))).toBe(true); // the case only exists while they are quoted
 
     rmSync(argsOut, { force: true });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1921,4 +1921,31 @@ describe("TerminalCell", () => {
     expect(posted).toHaveLength(2);
     expect(posted.map((body) => body.cwd)).toEqual(["/home/me/alpha", "/home/me/alpha"]);
   });
+
+  // The switch writes Claude Code's per-folder MCP config, but it is no longer only claude's:
+  // a codex grid cell is handed the SAME groups as resolved `-c mcp_servers.*` urls at spawn
+  // (server/session/spawn-codex.ts). Hiding the rows on codex left that path with no way to be
+  // turned on from the cell that uses it.
+  it("offers the Canvas switches for codex as well as claude", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) return { ok: true, json: async () => ({ groups: ["render"] }) };
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: false, worktrees: [] }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/home/me/proj", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(null);
+    await flushPromises();
+    const codexButton = w.findAll('[role="radio"]').find((b) => b.text() === "Codex");
+    expect(codexButton).toBeDefined();
+    await codexButton?.trigger("click");
+    await nextTick();
+
+    expect(w.find('[data-testid="cell-canvas-toggle-render"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-canvas-toggle-media"]').exists()).toBe(true);
+    // And it reads the same registration claude's rows do.
+    expect((w.find('[data-testid="cell-canvas-toggle-render"]').element as HTMLInputElement).checked).toBe(true);
+  });
 });


### PR DESCRIPTION
単一ビューの codex は前から全 GUI ツールを持っていた（`spawn-codex.ts` が `/api/mcp/<session>` を `-c mcp_servers.mulmoterminal-gui.url=` で渡す）。空白だったのは**グリッドのセル**（`gui=0`）で、claude のセルがディレクトリごとの登録を自分で読むのに対し、codex は設定ファイルを読まず spawn 時の `-c` しか見ないため、Canvas スイッチを入れても codex セルには何も届いていませんでした。

#1032 で入れたスイッチはそのまま使います。**登録の実体は変えません** — ランチャーが書いている Claude Code の per-folder 設定を読み、codex には解決済み URL として渡すだけです（codex に `${VAR}` 展開はないので、ポートと session id はここで埋める）。スイッチは 1 つのまま、両エージェントに効きます。

## 変更

- **`server/agents/codex-args.ts`** — `guiMcpUrl` 単数 → `guiMcpServers` の配列。auto-approve は**サーバー id ごと**なので各グループに付けます（付けないと、有効にしたグループが毎回許可を聞いてくる）。
- **`server/session/mcp-config.ts`** — `codexGuiMcpServers()` を追加し、2 つの URL 形（全ツール / グループ別）を 1 ファイルに集約。**claude の grid テンプレートと同じ URL になることをテストで固定**しました: グループ URL への接続がそのセッションのグループの証拠（`mcp-routes.ts`）なので、綴りがずれると codex セルの Canvas が永久に点きません。
- **`server/routes/ws-routes.ts`** — spawn 前に `registeredGuiMcpGroups(cwd, TOOL_GROUPS)` を読む。reattach では読みません（動いているプロセスは起動時のツールを持ち続けるため）。`await` 中にクライアントが去った場合は claude 側と同じガードで pty を作らずに抜けます。
- **`src/components/TerminalCell.vue`** — Canvas スイッチを codex でも表示。

Canvas パネルの点灯・ツールペインの絞り込みは既存の仕組み（接続してきたグループを記録 → `tool-groups` チャンネル）がそのまま効くので、サーバー側の追加はありません。

## 注意点

スイッチの**書き込み**は今も `claude mcp add -s local` 経由なので、`claude` CLI が PATH に無い環境では失敗します（失敗はそのまま "failed" として出ます）。読み出しはファイル直読みなので CLI 不要です。codex 単独運用を本気で支えるなら書き込み先を分ける議論が要りますが、保存先が 2 つに割れるため今回は見送りました。

引数が増えた 2 箇所は positional をやめてオブジェクトにしました（`startCodexEntry` の max-params 警告は元から出ていたので、あわせて解消しています）。

## 検証

`yarn format` / `lint`（警告 0）/ `typecheck` / `typecheck:server` / `typecheck:test` / `test`（5774 passed）/ `build` 通過。

**未検証**: 実際に codex のグリッドセルを起動して `presentHtml` などが呼べること、Canvas が点灯することは未確認です。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canvas configuration is now available for Codex cells as well as Claude cells.
  * Codex can attach to multiple GUI tool groups, with per-group tool approval behavior.
  * Codex sessions now preserve configured initial prompts and GUI/tool attachment settings across launch and resume.

* **Bug Fixes**
  * Improved Codex WebSocket/PTY handling to avoid leaked terminal processes on early disconnects.
  * Added buffering/replay of early client frames so initial rendering data isn’t dropped.

* **Tests**
  * Updated and added coverage for multi-server GUI MCP argument generation and launcher command rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->