### PR TITLE
fix: タイトルが読む transcript をストリームにする (#998 Phase 4 / 完)

### DIFF
--- a/plans/refactor-998-jsonl-readers.md
+++ b/plans/refactor-998-jsonl-readers.md
@@ -52,9 +52,7 @@ file, a missing file (tail returns none, the stream rejects), and the boundary c
 thing exists for — a tail that starts mid-file drops its first, partial line, but keeps it when the
 file fits in the window.
 
-## Next
-
-4. the title reader → head
+All four phases are done.
 
 ---
 
@@ -203,3 +201,36 @@ single record.
 
 The lesson each time is the same — the fold has to be the RULE applied to a smaller window, never a
 paraphrase of what the rule seemed to do.
+
+
+---
+
+# Phase 4 — the title reader
+
+`generateAndStoreTitle` read the transcript whole and passed the string to `generateTitle`, which
+then took `titleWindow(...)` of it — the last few user turns plus the last assistant reply. So the
+whole file was held in order to keep six turns.
+
+It streams now, and the contract changes with it: `TitleDeps.generateTitle` takes **turns**, not a
+raw transcript. `generateTitleFromTurns` is the entry point; `generateHeaderTitle(raw)` stays for
+callers that already have a string, and simply parses then delegates.
+
+One streamed pass yields both things the caller needs — the turns for the title, and the user-turn
+count for the "has it moved on enough to re-title" bookkeeping, which used to be a second full
+parse via `countUserTurnsFromJsonl`.
+
+## Measured on the real file
+
+```text
+2498ms  turns=1097 -> window=6
+userTurns=95
+prompt to model (754 chars)
+```
+
+585 MB in, 754 characters out. Before this the read threw and the session was never titled.
+
+## Note
+
+The spec's fake generator took `(raw: string)`; it takes `ConversationTurn[]` now, and a new case
+asserts that what reaches the generator is what came out of the stream. Without that, the contract
+change would have been invisible to the tests.

--- a/server/config/header-title.ts
+++ b/server/config/header-title.ts
@@ -111,7 +111,13 @@ export interface GenerateTitleDeps {
 // to title yet. Never throws — a failed/timed-out CLI yields null so the header falls
 // back to the last prompt.
 export async function generateHeaderTitle(rawTranscript: string, deps: GenerateTitleDeps = {}): Promise<string | null> {
-  const turns = titleWindow(conversationTurnsFromJsonl(rawTranscript));
+  return generateTitleFromTurns(conversationTurnsFromJsonl(rawTranscript), deps);
+}
+
+/** The same, from turns already extracted — so a caller that streamed the transcript (#998) is not
+ *  forced to rebuild it as one string, which past ~512 MB it cannot do at all. */
+export async function generateTitleFromTurns(allTurns: ConversationTurn[], deps: GenerateTitleDeps = {}): Promise<string | null> {
+  const turns = titleWindow(allTurns);
   if (turns.length === 0) return null;
   const runClaude = deps.runClaude ?? runClaudeHeadless;
   try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -45,7 +45,7 @@ import { createCodexSpawner } from "./session/spawn-codex.js";
 import { createShellSpawners } from "./session/spawn-shell.js";
 import { createTranslationWorker } from "./session/translation-worker.js";
 import { createTitleManager } from "./session/session-title.js";
-import { generateHeaderTitle } from "./config/header-title.js";
+import { generateTitleFromTurns } from "./config/header-title.js";
 import { mountTerminalWebSockets } from "./routes/ws-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
@@ -229,7 +229,7 @@ const { cancelReap, reap, armReapForDetached, publishActivity, setWorking, setWa
 const { forgetTitle, noteTitleTurn, maybeGenerateTitle, freshenRosterTitle } = createTitleManager({
   publishActivity: (id) => publishActivity(id),
   now: () => Date.now(),
-  generateTitle: (raw) => generateHeaderTitle(raw),
+  generateTitle: (turns) => generateTitleFromTurns(turns),
 });
 
 // The PTY spawners (session/spawn-*.ts). They take what index.ts still owns — the session

--- a/server/session/session-title.ts
+++ b/server/session/session-title.ts
@@ -7,9 +7,9 @@
 // title generated across a /clear, an in-flight set so a Stop hook and a roster view do
 // not both summarize, and a retry floor so a viewed-but-failing session is not
 // re-summarized on every poll.
-import { promises as fs } from "node:fs";
 import path from "node:path";
-import { countUserTurnsFromJsonl, isTrivialPrompt } from "./transcript.js";
+import { conversationTurnsFromParsed, isTrivialPrompt, type ConversationTurn } from "./transcript.js";
+import { forEachJsonlRecord } from "../infra/jsonl-file.js";
 import { shouldFreshenViewedTitle, shouldRegenerateTitle, TITLE_REGEN_EVERY_TURNS, VIEW_TITLE_REGEN_TURNS } from "../config/header-title.js";
 import { aiTitles, lastTitleAttemptMs, lastTitledUserTurns, titleEpoch, titleInFlight, titlePending, titleTurnCounts } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
@@ -25,7 +25,9 @@ export interface TitleDeps {
   now: () => number;
   /** Summarize a transcript into a title. Injected because the real one shells out to
    *  the claude CLI, which a unit test must never do. */
-  generateTitle: (rawTranscript: string) => Promise<string | null>;
+  // Turns, not the raw transcript: the file reaches 585 MB here and cannot be held as a string
+  // at all (#998). The title only reads the last few turns anyway.
+  generateTitle: (turns: ConversationTurn[]) => Promise<string | null>;
 }
 
 export function createTitleManager(deps: TitleDeps) {
@@ -62,12 +64,18 @@ export function createTitleManager(deps: TitleDeps) {
     titleInFlight.add(sessionId);
     const epoch = titleEpoch.get(sessionId) ?? 0;
     try {
-      const raw = await fs.readFile(path.join(projectSessionsDir(cwd), `${sessionId}.jsonl`), "utf8").catch(() => null);
-      const title = raw ? await deps.generateTitle(raw) : null;
+      // One streamed pass yields both what the title needs (the turns) and what the bookkeeping
+      // needs (how many user turns there were), so the transcript is never held as a string.
+      const turns: ConversationTurn[] = [];
+      let read = true;
+      await forEachJsonlRecord(path.join(projectSessionsDir(cwd), `${sessionId}.jsonl`), (record) => {
+        turns.push(...conversationTurnsFromParsed([record]));
+      }).catch(() => (read = false));
+      const title = read && turns.length ? await deps.generateTitle(turns) : null;
       if (title && (titleEpoch.get(sessionId) ?? 0) === epoch) {
         aiTitles.set(sessionId, title);
         titleTurnCounts.set(sessionId, 0);
-        lastTitledUserTurns.set(sessionId, raw ? countUserTurnsFromJsonl(raw) : 0);
+        lastTitledUserTurns.set(sessionId, turns.filter((t) => t.role === "user").length);
         deps.publishActivity(sessionId);
       }
     } finally {

--- a/test/server/session/session-title.spec.ts
+++ b/test/server/session/session-title.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { ConversationTurn } from "../../../server/session/transcript.js";
 import { createTitleManager } from "../../../server/session/session-title.js";
 import {
   aiTitles,
@@ -51,15 +52,17 @@ afterEach(async () => {
 
 // The real generator shells out to the claude CLI; the fake keeps these tests fast,
 // deterministic, and runnable without an API key.
-function setup(now = () => 1_000_000, generateTitle: (raw: string) => Promise<string | null> = async () => "Generated title") {
+function setup(now = () => 1_000_000, generateTitle: (turns: ConversationTurn[]) => Promise<string | null> = async () => "Generated title") {
   const published: string[] = [];
-  const summarized: string[] = [];
+  // Turns, not a raw transcript — the manager streams the file now (#998), so what the generator
+  // receives is what came out of that stream.
+  const summarized: ConversationTurn[][] = [];
   const mgr = createTitleManager({
     publishActivity: (id) => published.push(id),
     now,
-    generateTitle: (raw) => {
-      summarized.push(raw);
-      return generateTitle(raw);
+    generateTitle: (turns) => {
+      summarized.push(turns);
+      return generateTitle(turns);
     },
   });
   return { ...mgr, published, summarized };
@@ -204,6 +207,21 @@ describe("maybeGenerateTitle", () => {
     release("Generated title");
     await first;
     expect(published).toEqual([SESSION]);
+  });
+
+  // The generator is handed the transcript's TURNS, read by streaming the file (#998) rather than
+  // slurping it — which is what lets a session past ~512 MB be titled at all.
+  it("hands the generator the turns it streamed out of the transcript", async () => {
+    const { maybeGenerateTitle, summarized } = setup();
+    const assistantTurn = JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Added it." }] } });
+    await writeTranscript([userTurn("add a retry to the uploader"), assistantTurn]);
+    titlePending.add(SESSION);
+    await maybeGenerateTitle(SESSION, cwd);
+    await vi.waitFor(() => expect(summarized).toHaveLength(1));
+    expect(summarized[0]).toEqual([
+      { role: "user", text: "add a retry to the uploader" },
+      { role: "assistant", text: "Added it." },
+    ]);
   });
 
   it("clears the in-flight mark even when generation fails", async () => {


### PR DESCRIPTION
## Summary

#998 の **Phase 4 / 4（最後）**。タイトル生成が読む transcript をストリームにする。

`generateAndStoreTitle` は**ファイル全体を文字列で読んで** `generateTitle` に渡し、
その中で `titleWindow(...)` が**直近の数ターン**だけを取り出していた。
つまり**6 ターンを得るために 585MB を保持**していて、~512MB を超えると read が throw するので
**そのセッションには永久にタイトルが付かなかった**。

## 実測（585MB の実ファイル）

```text
2498ms  turns=1097 -> window=6
userTurns=95
prompt to model (754 chars)
```

**585MB 入力 → 754 文字出力。** 従来は read が例外を投げて終わり。

## Items to Confirm / Review

- **`TitleDeps.generateTitle` の契約を変えた**: 生の transcript 文字列 → `ConversationTurn[]`。
  `generateTitleFromTurns` を入口にし、文字列を持っている呼び出し元のために
  `generateHeaderTitle(raw)` は残して委譲する形にした。
- **1 パスで 2 つ賄っている**: タイトル用のターン列と、「再タイトル付けするほど進んだか」の
  ユーザーターン数。後者は従来 `countUserTurnsFromJsonl` で**もう一度全体を parse** していた。
- **spec のフェイク generator が `(raw: string)` のままだと契約変更に気づけない**ので、
  `ConversationTurn[]` に変え、**ストリームから出たものがそのまま generator に届く**ことを
  検証するケースを追加した。これが無いとテストからは変更が不可視だった。
- 途中 `@codemirror/lang-yaml` 等で typecheck とテストが 15 件落ちたが、**main でも同じく落ちる**
  （#1038 が追加した依存が未インストールだった）ので `yarn install` で解消。私の変更とは無関係。

## これで #998 の 4 段階が完了

| Phase | PR | 内容 |
| --- | --- | --- |
| 1 | #1033 | 共有ヘルパー（行ストリーム / tail）を 1 箇所に |
| 2 | #1034 | 最新ターン系 4 つ → tail 読み |
| 3 | #1037 | 全体走査 3 つ → 行ストリーム |
| **4** | **これ** | **タイトル → ストリーム** |

`readFile(file, "utf8")` で transcript 全体を読む経路は**もう残っていない**。

## User Prompt

> これ直せる？？ https://github.com/receptron/mulmoterminal/issues/998
>
> １から順に。

## Verification

`yarn format` / `lint` / `typecheck` ×3 / `test`（5842 passed）/ **585MB の実ファイルで実測**。

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
