### PR TITLE
fix: readSessionMeta もストリームにする — #998 の表に無かった経路

### DIFF
--- a/plans/refactor-998-jsonl-readers.md
+++ b/plans/refactor-998-jsonl-readers.md
@@ -234,3 +234,22 @@ prompt to model (754 chars)
 The spec's fake generator took `(raw: string)`; it takes `ConversationTurn[]` now, and a new case
 asserts that what reaches the generator is what came out of the stream. Without that, the contract
 change would have been invisible to the tests.
+
+
+---
+
+# Phase 5 — the one the issue missed
+
+`readSessionMeta` also read the transcript whole. It is not in #998's table, which listed seven
+call sites; grepping for `fs.readFile` after phase 4 found it as the last one standing.
+
+It reads **three fields** — the AI title, the last prompt, the first user message — to build the
+session list's label. On a 585 MB transcript the read threw, was caught upstream, and the session
+appeared with no title.
+
+Streamed like the rest. With it, `parseJsonl` and `fs.readFile` are both **gone from
+session-reads.ts entirely**, which is the check worth keeping: not "did we fix the seven listed",
+but "does this module still hold a transcript in a string anywhere". It does not.
+
+Measured: 2624 ms on the 585 MB file, and the title comes back — `"Fix schema.json validation
+errors for shopping-lis…"` where before there was none.

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -14,7 +14,6 @@ import os from "node:os";
 import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
 import {
-  parseJsonl,
   userPromptText,
   latestMeaningfulUserPromptFromParsed,
   latestAssistantTextFromParsed,
@@ -221,19 +220,25 @@ export async function sessionLastTurn(cwd: string, id: string, agent: "claude" |
 // Scan a session JSONL for a human-friendly title and last activity.
 export async function readSessionMeta(dir: string, file: string): Promise<SessionMeta> {
   const full = path.join(dir, file);
-  const [raw, stat] = await Promise.all([fs.readFile(full, "utf8"), fs.stat(full)]);
 
   let aiTitle: string | null = null;
   let lastPrompt: string | null = null;
   let firstUserMsg: string | null = null;
 
-  for (const o of parseJsonl(raw)) {
-    if (o.type === "ai-title" && o.aiTitle) aiTitle = String(o.aiTitle);
-    else if (o.type === "last-prompt" && o.lastPrompt) lastPrompt = String(o.lastPrompt);
-    else if (o.type === "user" && firstUserMsg === null) {
-      firstUserMsg = userPromptText(isRecord(o.message) ? o.message.content : undefined);
-    }
-  }
+  // Streamed like every other transcript reader (#998). This one was missed by that issue's own
+  // table, which is a fair warning about how easy the whole-file read is to reach for: three
+  // fields out of a file that reaches 585 MB, where reading it whole throws and the session list
+  // then shows a title of "(no title)".
+  const [, stat] = await Promise.all([
+    forEachJsonlRecord(full, (o) => {
+      if (o.type === "ai-title" && o.aiTitle) aiTitle = String(o.aiTitle);
+      else if (o.type === "last-prompt" && o.lastPrompt) lastPrompt = String(o.lastPrompt);
+      else if (o.type === "user" && firstUserMsg === null) {
+        firstUserMsg = userPromptText(isRecord(o.message) ? o.message.content : undefined);
+      }
+    }),
+    fs.stat(full),
+  ]);
 
   const id = path.basename(file, ".jsonl");
   const title = sessionListTitle({ liveAiTitle: aiTitles.get(id), diskAiTitle: aiTitle, diskLastPrompt: lastPrompt, firstUserMsg });


### PR DESCRIPTION
## Summary

#998 の**取りこぼし**。Phase 4 の後に `fs.readFile` を grep したら、**8 つ目の経路**が残っていた。

`readSessionMeta` は **3 つのフィールド**（AI タイトル / 最後のプロンプト / 最初のユーザーメッセージ）を
読んでセッション一覧のラベルを作るのに、**transcript 全体を文字列で読んでいた**。
585MB では read が throw → 上流で catch → **タイトル無しでセッションが並ぶ**。

**#998 の表には無い**（あの表は 7 経路を挙げていた）。

## 実測（585MB の実ファイル）

```text
2624ms  title="Fix schema.json validation errors for shopping-lis…"
```

**タイトルが返ってくる。** 従来は空だった。

## Items to Confirm / Review

- **確認方法を「表の 7 件を直したか」から「このモジュールがまだ transcript を文字列で持つか」に変えた。**
  結果として `session-reads.ts` から **`parseJsonl` と `fs.readFile` の両方が完全に消えた**
  （未使用 import として typecheck が教えてくれた）。今後の回帰チェックはこちらの方が確実。
- `fs.stat` と並行実行する形は維持している（`Promise.all` の中身がストリームに変わっただけ）。
- サーバー側テスト 3131 件はそのまま通る。
- テストが 1 回 flaky で落ちたが、2 回連続で再実行して全件通ることを確認（今日 2 度目の flaky）。

## User Prompt

> これ直せる？？ https://github.com/receptron/mulmoterminal/issues/998
>
> １から順に。

## これで #998 は完了

| Phase | PR | 内容 |
| --- | --- | --- |
| 1 | #1033 | 共有ヘルパー（行ストリーム / tail） |
| 2 | #1034 | 最新ターン系 4 つ → tail |
| 3 | #1037 | 全体走査 3 つ → 行ストリーム |
| 4 | #1041 | タイトル → ストリーム |
| **5** | **これ** | **表に無かった 8 つ目** |

## Verification

`yarn format` / `lint` / `typecheck` ×3 / `test`（5867 passed）/ **585MB の実ファイルで実測**。

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
