### PR TITLE
feat: undefined ガードで「バグ」と「許容」を区別する

### DIFF
--- a/server/backends/remoteHost/firestoreSafeResult.ts
+++ b/server/backends/remoteHost/firestoreSafeResult.ts
@@ -11,8 +11,13 @@
 // log line below names `result.sessions.3.work`.
 //
 // Strip rather than throw: a missing optional field costs one row's worth of detail, while a
-// throw costs the user every session in the list — the very outcome this exists to prevent. The
-// warning is what keeps it from being silent, because a stripped key IS a bug on the sending side.
+// throw costs the user every session in the list — the very outcome this exists to prevent.
+//
+// Whether that removal is WORTH SAYING OUT LOUD is a separate question, and it has two answers.
+// An `undefined` where none belongs is a bug in the sender and has to be findable. An optional
+// field that simply has no value this time is normal, and warning about it every poll teaches
+// everyone to ignore the log. So the caller declares which paths are the second kind; everything
+// else is treated as the first.
 //
 // NOT `ignoreUndefinedProperties` on the Firestore instance: that setting makes this class of bug
 // disappear into "the value just doesn't arrive", with nothing logged and nothing to grep for.
@@ -51,22 +56,50 @@ export function stripUndefined<T>(value: T): T {
  * Applied to the whole table rather than to the one handler that broke: the reply is free-form
  * JSON from any of them, so the next `undefined` will come from somewhere else.
  */
+/**
+ * Does `path` match `pattern`? `*` stands for exactly one segment, which is what makes an array
+ * index expressible: `sessions.*.work` covers `sessions.0.work` and every sibling.
+ */
+export function matchesPath(pattern: string, path: string): boolean {
+  const patternParts = pattern.split(".");
+  const pathParts = path.split(".");
+  return patternParts.length === pathParts.length && patternParts.every((part, i) => part === "*" || part === pathParts[i]);
+}
+
+export interface FirestoreSafeOptions {
+  warn?: (message: string) => void;
+  /**
+   * Per handler, the paths where `undefined` is a legitimate "no value this time" rather than a
+   * bug. Those are stripped in silence; everything else is stripped AND reported.
+   *
+   * Keyed by handler name so the declaration reads as a property of that reply's shape, and so two
+   * handlers that happen to share a field name do not silence each other.
+   */
+  expectedUndefined?: Readonly<Record<string, readonly string[]>>;
+}
+
 // `...args: never[]` rather than a single param: a handler that ignores its params is written
 // without one, and it still has to fit here.
 type AnyHandler = (...args: never[]) => unknown;
 
-export function firestoreSafeHandlers<T extends Record<string, AnyHandler>>(handlers: T, warn: (message: string) => void = console.warn): T {
-  const wrapped = Object.entries(handlers).map(([name, handler]) => [
-    name,
-    async (...args: never[]) => {
-      const result: unknown = await (handler as AnyHandler)(...args);
-      const paths = undefinedPaths(result);
-      if (paths.length > 0) {
-        warn(`[remote-host] ${name} returned undefined at ${paths.join(", ")} — dropped, because Firestore refuses the whole write`);
-        return stripUndefined(result);
-      }
-      return result;
-    },
-  ]);
-  return Object.fromEntries(wrapped) as T;
+/** The paths worth reporting: those the caller did not declare as legitimately absent. */
+function unexpectedPaths(paths: readonly string[], expected: readonly string[]): string[] {
+  return paths.filter((path) => !expected.some((pattern) => matchesPath(pattern, path)));
+}
+
+function guardOne(name: string, handler: AnyHandler, options: FirestoreSafeOptions): AnyHandler {
+  const warn = options.warn ?? console.warn;
+  const expected = options.expectedUndefined?.[name] ?? [];
+  return async (...args: never[]) => {
+    const result: unknown = await handler(...args);
+    const unexpected = unexpectedPaths(undefinedPaths(result), expected);
+    if (unexpected.length > 0) {
+      warn(`[remote-host] ${name} returned undefined at ${unexpected.join(", ")} — dropped, because Firestore refuses the whole write`);
+    }
+    return stripUndefined(result);
+  };
+}
+
+export function firestoreSafeHandlers<T extends Record<string, AnyHandler>>(handlers: T, options: FirestoreSafeOptions = {}): T {
+  return Object.fromEntries(Object.entries(handlers).map(([name, handler]) => [name, guardOne(name, handler as AnyHandler, options)])) as T;
 }

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -95,7 +95,7 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
         submitSequence: deps.submitSequence,
         launchTerminal: deps.launchTerminal,
       }),
-      (message) => log.warn(message),
+      { warn: (message) => log.warn(message) },
     ),
     log: { ...log, debug: () => undefined },
   });

--- a/test/server/backends/firestore-safe-result.spec.ts
+++ b/test/server/backends/firestore-safe-result.spec.ts
@@ -4,7 +4,7 @@
 // is what emptied the phone's session list in #1042. These pin the guard that stands in front of
 // the write, and the shape of the session list that tripped it.
 import { describe, it, expect, vi } from "vitest";
-import { undefinedPaths, stripUndefined, firestoreSafeHandlers } from "../../../server/backends/remoteHost/firestoreSafeResult";
+import { undefinedPaths, stripUndefined, firestoreSafeHandlers, matchesPath } from "../../../server/backends/remoteHost/firestoreSafeResult";
 import { buildSessionList } from "../../../server/backends/remoteHost/terminalScreen";
 
 // A REAL hole, not `[1, undefined, 3]` — the two behave differently under map/flatMap, and the
@@ -82,10 +82,34 @@ describe("stripUndefined", () => {
   });
 });
 
+describe("matchesPath", () => {
+  it("matches an exact path", () => {
+    expect(matchesPath("a.b", "a.b")).toBe(true);
+    expect(matchesPath("a.b", "a.c")).toBe(false);
+  });
+
+  // The reason `*` exists: an array index cannot be written out.
+  it("lets * stand for one segment", () => {
+    expect(matchesPath("sessions.*.work", "sessions.0.work")).toBe(true);
+    expect(matchesPath("sessions.*.work", "sessions.17.work")).toBe(true);
+  });
+
+  // One segment, not many — or `a.*` would silence everything beneath `a`.
+  it("does not let * span segments", () => {
+    expect(matchesPath("a.*", "a.b.c")).toBe(false);
+    expect(matchesPath("a.*.c", "a.c")).toBe(false);
+  });
+
+  it("requires the same depth", () => {
+    expect(matchesPath("a.b", "a.b.c")).toBe(false);
+    expect(matchesPath("a.b.c", "a.b")).toBe(false);
+  });
+});
+
 describe("firestoreSafeHandlers", () => {
   it("passes a clean reply straight through, with no warning", async () => {
     const warn = vi.fn();
-    const handlers = firestoreSafeHandlers({ list: () => ({ sessions: [{ id: "a" }] }) }, warn);
+    const handlers = firestoreSafeHandlers({ list: () => ({ sessions: [{ id: "a" }] }) }, { warn });
     expect(await handlers.list()).toEqual({ sessions: [{ id: "a" }] });
     expect(warn).not.toHaveBeenCalled();
   });
@@ -94,7 +118,7 @@ describe("firestoreSafeHandlers", () => {
   // the outcome this exists to prevent.
   it("strips a bad reply and says where it was", async () => {
     const warn = vi.fn();
-    const handlers = firestoreSafeHandlers({ list: () => ({ sessions: [{ id: "a", work: undefined }] }) }, warn);
+    const handlers = firestoreSafeHandlers({ list: () => ({ sessions: [{ id: "a", work: undefined }] }) }, { warn });
     expect(await handlers.list()).toEqual({ sessions: [{ id: "a" }] });
     expect(warn).toHaveBeenCalledOnce();
     expect(String(warn.mock.calls[0][0])).toContain("sessions.0.work");
@@ -103,14 +127,14 @@ describe("firestoreSafeHandlers", () => {
 
   it("awaits an async handler before checking it", async () => {
     const warn = vi.fn();
-    const handlers = firestoreSafeHandlers({ list: () => Promise.resolve({ a: undefined }) }, warn);
+    const handlers = firestoreSafeHandlers({ list: () => Promise.resolve({ a: undefined }) }, { warn });
     expect(await handlers.list()).toEqual({});
     expect(warn).toHaveBeenCalledOnce();
   });
 
   it("covers every handler in the table, not just the one that broke", async () => {
     const warn = vi.fn();
-    const handlers = firestoreSafeHandlers({ one: () => ({ a: undefined }), two: () => ({ b: undefined }) }, warn);
+    const handlers = firestoreSafeHandlers({ one: () => ({ a: undefined }), two: () => ({ b: undefined }) }, { warn });
     await handlers.one();
     await handlers.two();
     expect(warn).toHaveBeenCalledTimes(2);
@@ -118,9 +142,56 @@ describe("firestoreSafeHandlers", () => {
 
   it("returns null when the handler returns nothing at all", async () => {
     const warn = vi.fn();
-    const handlers = firestoreSafeHandlers({ list: () => undefined }, warn);
+    const handlers = firestoreSafeHandlers({ list: () => undefined }, { warn });
     expect(await handlers.list()).toBeNull();
     expect(String(warn.mock.calls[0][0])).toContain("(root)");
+  });
+
+  // Two kinds of undefined. One is a bug in the sender and has to be findable; the other is an
+  // optional field with no value this time, and warning about it every poll teaches everyone to
+  // ignore the log. Both are stripped — Firestore leaves no choice — but only one is reported.
+  it("strips a declared-optional path without saying anything", async () => {
+    const warn = vi.fn();
+    const handlers = firestoreSafeHandlers(
+      { list: () => ({ sessions: [{ id: "a", work: undefined }] }) },
+      { warn, expectedUndefined: { list: ["sessions.*.work"] } },
+    );
+    expect(await handlers.list()).toEqual({ sessions: [{ id: "a" }] });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("still reports the paths that were NOT declared", async () => {
+    const warn = vi.fn();
+    const handlers = firestoreSafeHandlers(
+      { list: () => ({ sessions: [{ id: "a", work: undefined, oops: undefined }] }) },
+      { warn, expectedUndefined: { list: ["sessions.*.work"] } },
+    );
+    await handlers.list();
+    expect(warn).toHaveBeenCalledOnce();
+    const message = String(warn.mock.calls[0][0]);
+    expect(message).toContain("sessions.0.oops");
+    expect(message).not.toContain("sessions.0.work"); // the declared one is not noise
+  });
+
+  // The declaration is a property of ONE reply's shape; two handlers sharing a field name must not
+  // silence each other.
+  it("does not let one handler's declaration cover another's", async () => {
+    const warn = vi.fn();
+    const handlers = firestoreSafeHandlers(
+      { list: () => ({ work: undefined }), other: () => ({ work: undefined }) },
+      { warn, expectedUndefined: { list: ["work"] } },
+    );
+    await handlers.list();
+    expect(warn).not.toHaveBeenCalled();
+    await handlers.other();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("warns about everything when nothing is declared", async () => {
+    const warn = vi.fn();
+    const handlers = firestoreSafeHandlers({ list: () => ({ a: undefined }) }, { warn });
+    await handlers.list();
+    expect(warn).toHaveBeenCalledOnce();
   });
 
   it("keeps the handler names the runner advertises as capabilities", () => {


### PR DESCRIPTION
## Summary

#1044 で入れた undefined ガードは、**すべての `undefined` を一律で警告**していました。実際には 2 種類あります。

- **バグ** — 送り手が入れてはいけない場所に入れた。見つけられる必要がある
- **正常** — optional なフィールドに今回は値が無いだけ。毎回警告すると誰もログを読まなくなり、**本物のバグがその中に埋もれます**

どちらも Firestore の都合で除去は必要ですが、**報告すべきなのは前者だけ**です。ハンドラごとに「ここは `undefined` でよい」パスを宣言できるようにしました。

```ts
firestoreSafeHandlers(handlers, {
  warn,
  expectedUndefined: { listTerminalSessions: ["sessions.*.work"] },
});
```

宣言されたパスは黙って除去、それ以外は従来どおり警告します。

## Items to Confirm / Review

1. **宣言をハンドラ名で引く形にしました。** それが「その返信の形の性質」だからです。2 つのハンドラがたまたま同じフィールド名を持っていても、片方の宣言がもう片方を黙らせません（テストで固定）。
2. **`*` は 1 セグメントに限定**しています。`a.*` が `a.b.c` にも当たると**配下すべてを黙らせて**しまうためです。`*` があるのは配列の添字を書けないからで（`sessions.*.work`）、それ以上の意味は持たせていません。
3. **今のところ宣言は空です。** #1044 で `buildSessionList` がキーごと落とすようにしたので、現時点で「正常な undefined」を送っている経路はありません。これは**必要になったときのための仕組み**で、その判断は宣言する人が一箇所で下せます。

## User Prompt

> 両方必要だよね。型もガードも。coreのほうはissueたてたので後で直す。こちらで対策できるものは対策しよう
> undefinedがバグのばあいと、許容する場合の療法があるだろうから、両方に対応出るようにガードが欲しいね

## テスト（新規 8 件）

- `matchesPath`: 完全一致 / `*` が 1 セグメントに当たる / **`*` がセグメントを跨がない** / 深さが違えば不一致
- 宣言されたパスは**警告なしで除去** / 宣言されていないパスは従来どおり報告 / **同じ返信に両方あれば、宣言されていない方だけを報告する** / **一方のハンドラの宣言が他方を黙らせない** / 何も宣言しなければ全部報告

## 型の側（#1048）は別 PR にします

「型もガードも」というのはそのとおりで、`exactOptionalPropertyTypes` は測ったところ **server 35 件 / app 19 件**でした。うち **published package 境界は 5 件**（core の issue: receptron/mulmoclaude#2634）、残り 30 件が自分たちのコードです。

**別 PR にする理由は、30 件それぞれに判断が要るからです。**

- **Firestore / 直列化に届く経路** → キーごと落とす（`| undefined` を足すとバグを戻すことになる）
- **内部の受け渡しだけ** → `| undefined` を型に足すのが正直

この判断が 30 回入る diff と、ガードの設計変更を同じ PR に混ぜると、レビューで両方が薄くなります。続けて出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
