### PR TITLE
fix: 境界を越えるオブジェクトに undefined のキーを残さない（#1042 と同じ形が 5 か所）

### DIFF
--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -626,7 +626,8 @@ const remoteViewMutateHandler: RequestHandler<{ slug: string; viewId: string }> 
 // data (real thumbnails) the phone gets.
 const remoteViewItemsHandler: RequestHandler<{ slug: string; viewId: string }> = async (req, res) => {
   const { slug, viewId } = req.params;
-  const request = { offset: clampViewOffset(req.query.offset), limit: clampViewLimit(req.query.limit), fields: normalizeFields(csvParam(req.query.fields)) };
+  const fields = normalizeFields(csvParam(req.query.fields));
+  const request = { offset: clampViewOffset(req.query.offset), limit: clampViewLimit(req.query.limit), ...(fields ? { fields } : {}) };
   const collection = await resolveCollection(res, slug);
   if (!collection) return;
   const result = await remoteViewItems(collection, viewId, request);

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -132,7 +132,8 @@ const getRemoteView: CommandHandlers["getRemoteView"] = async (params: JsonObjec
 const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (params: JsonObject) => {
   const slug = String(params.slug ?? "");
   const viewId = String(params.viewId ?? "");
-  const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), fields: normalizeFields(params.fields) };
+  const fields = normalizeFields(params.fields);
+  const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), ...(fields ? { fields } : {}) };
   const collection = await loadCollection(slug);
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await remoteViewItems(collection, viewId, request);

--- a/server/index.ts
+++ b/server/index.ts
@@ -507,12 +507,17 @@ const remoteHostListTerminalSessions = async () => {
     isGridSession: (id) => devTerminalSessions.has(id),
     // Empty title rather than the id as a fallback — buildSessionList uses "nameless"
     // to drop the long tail of finished sessions the phone can't meaningfully offer.
-    detailOf: (id) => ({
-      title: aiTitles.get(id) ?? knownSessions.get(id)?.title ?? "",
-      cwd: cwdOfSession(id),
-      agent: agentOfSession(id),
-      work: work.get(cwdOfSession(id)),
-    }),
+    detailOf: (id) => {
+      // Spread the work item in only when there IS one. `work: map.get(...)` leaves the key behind
+      // holding undefined, and Firestore then refuses the entire reply rather than that one field.
+      const summary = work.get(cwdOfSession(id));
+      return {
+        title: aiTitles.get(id) ?? knownSessions.get(id)?.title ?? "",
+        cwd: cwdOfSession(id),
+        agent: agentOfSession(id),
+        ...(summary ? { work: summary } : {}),
+      };
+    },
   });
 };
 

--- a/server/infra/web-push.ts
+++ b/server/infra/web-push.ts
@@ -9,4 +9,4 @@ import { currentIdToken } from "../backends/remoteHost/session.js";
 // session the push came from rather than the home screen (mulmoserver#75). It is
 // never a replacement for the notification: both receivers drop a data-only message.
 export const sendWebPush = (title: string, body: string, data?: Record<string, string>): Promise<SendPushResult | null> =>
-  sendPush(title, body, { getIdToken: currentIdToken, data });
+  sendPush(title, body, { getIdToken: currentIdToken, ...(data ? { data } : {}) });

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -47,7 +47,7 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
       submitTranslationTool: translationWorkerIds.has(sessionId),
       group,
     });
-    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    const transport = new StreamableHTTPServerTransport({});
     res.on("close", () => {
       transport.close();
       server.close();


### PR DESCRIPTION
## Summary

#1042 と**同じ形が 5 か所**にありました。`key: maybeUndefined` はキーを残したまま `undefined` を入れるので、Firestore に渡ると 1 つで書き込み全体が落ちます。値が無いときはキーごと落とします。

| 場所 | 何が undefined になりうるか |
| --- | --- |
| `server/index.ts` | セッション一覧の `work` — **#1042 の現場そのもの** |
| `collections.ts` / `remoteHost/handlers.ts` | remote view の `fields` |
| `infra/web-push.ts` | FCM の `data` |
| `routes/mcp-routes.ts` | `sessionIdGenerator` を明示的に `undefined` で渡していた |

Refs #1048

## Items to Confirm / Review

1. **`mcp-routes.ts` だけ挙動の判断が入っています。** `{ sessionIdGenerator: undefined }` を `{}` に変えました。SDK の実装を読んで確認済みで、`this.sessionIdGenerator = options.sessionIdGenerator`（`webStandardStreamableHttp.js:72`）としか読まないため、**キーを省いても同じステートレスモード**になります。型の都合ではなく実装を確認したうえでの変更です。
2. **`exactOptionalPropertyTypes` の有効化はこの PR に含めていません。** 試した結果ブロッカーが 2 つ出たので、下に書いて #1048 にも記録します。

## User Prompt

> 両方必要だよね。型もガードも。coreのほうはissueたてたので後で直す。こちらで対策できるものは対策しよう
>
> 型の PR も進めて

## `exactOptionalPropertyTypes` を試した結果（#1048 への報告）

実際に有効にして **35 件 → 7 件**まで潰しました。その過程で、issue に書いていなかった**ブロッカーが 2 つ**見つかりました。

### ブロッカー 1: `sonarjs/no-redundant-optional` と正面衝突する

フラグを有効にすると、「undefined が正常」なフィールドは `x?: T | undefined` と書くのが正解になります。ところが lint がこれを禁じます。

```
error  Consider removing 'undefined' type or '?' specifier, one of them is redundant
       sonarjs/no-redundant-optional
```

このルールは**フラグが OFF である前提**（`?: T` が既に `| undefined` を含む）で書かれています。フラグを入れるなら、**このルールを外すことが前提条件**です。18 ファイルすべてでこれに当たりました。

### ブロッカー 2: 残り 7 件は published package の型との境界

```
server/backends/collections.ts:496        ActionWithWhen
server/backends/feeds.ts:44               LoadedCollection → FeedLike
server/backends/remoteHost/googleCalendar.ts:87, 99
server/backends/remoteHost/handlers.ts:249  LoadedCollection → FeedLike
server/infra/collection-tool.ts:34        gui-chat-protocol の ToolDefinition
server/routes/mcp-routes.ts:56            MCP SDK の transport
```

`fields` / `data` のような**単一フィールド**は呼び出し側の条件付きスプレッドで解決できたので、この PR に含めました。残るのは `LoadedCollection → FeedLike` のような**オブジェクト全体の不一致**で、こちらは相手の型が変わらないと閉じません（receptron/mulmoclaude#2634）。

### つまり

**この 2 つが片付くまでフラグは入れられません。** 順序としては、(1) lint ルールを外す判断 → (2) core 側の型 → (3) フラグ有効化、になります。型宣言を `| undefined` に変える作業は**フラグ無しでは lint エラーにしかならない**ので、この PR には残していません。

一方、**キーを落とす修正はフラグと無関係に価値がある**ので、それだけを取り出したのがこの PR です。

## 確認していないこと

**実機での動作は見ていません。** `mcp-routes.ts` の変更は GUI パネルの MCP 接続に触るので、そこだけ動かして確認していただけると確実です（実装は読んで確認済みですが、読んだだけです）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
