### PR TITLE
fix(ci): テストの temp dir を実装と同じ綴りにする（#1052 の対）

### DIFF
--- a/test/server/files/files-browse.spec.ts
+++ b/test/server/files/files-browse.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, readdirSync, realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { makeTempDir } from "../../support/tempDir.js";
+import { writeFileSync, mkdirSync, rmSync, readFileSync, readdirSync, realpathSync } from "node:fs";
 import path from "node:path";
 import express from "express";
 import request from "supertest";
 import { currentVersion, listEntries, mdToHtmlDoc, mountFilesBrowseRoutes, MAX_EDIT_BYTES } from "../../../server/files/files-browse";
 import { backupDirFor } from "../../../server/files/backup-store";
 
-const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-files-"));
+const tmp = () => makeTempDir("mt-files-");
 
 describe("listEntries", () => {
   it("lists directories first, then files, each alphabetical, with sizes", () => {
@@ -209,8 +209,8 @@ describe("currentVersion", () => {
 // user resolves by dropping one side — happens to content nobody deliberately threw away.
 describe("browse routes keep backups", () => {
   const withStore = async (run: (app: express.Express, dir: string, backups: string) => Promise<void>) => {
-    const dir = mkdtempSync(path.join(tmpdir(), "mt-files-"));
-    const backups = mkdtempSync(path.join(tmpdir(), "mt-backups-"));
+    const dir = makeTempDir("mt-files-");
+    const backups = makeTempDir("mt-backups-");
     writeFileSync(path.join(dir, "a.md"), "one");
     const app = express();
     app.use(express.json());
@@ -283,7 +283,7 @@ describe("browse routes keep backups", () => {
 
   // Refusing a save because the BACKUP failed would be exactly backwards.
   it("still reads and writes when the backup store is unusable", async () => {
-    const dir = mkdtempSync(path.join(tmpdir(), "mt-files-"));
+    const dir = makeTempDir("mt-files-");
     writeFileSync(path.join(dir, "a.md"), "one");
     const blocked = path.join(dir, "blocked");
     writeFileSync(blocked, "a file where the backup root should be");

--- a/test/server/files/pathContainment.spec.ts
+++ b/test/server/files/pathContainment.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { makeTempDir } from "../../support/tempDir.js";
+import { writeFileSync, mkdirSync, rmSync, symlinkSync, realpathSync } from "node:fs";
 import path from "node:path";
 import {
   containedPath,
@@ -12,7 +12,7 @@ import {
   namesAWindowsDevice,
 } from "../../../server/files/pathContainment";
 
-const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-files-"));
+const tmp = () => makeTempDir("mt-files-");
 
 describe("containedPath (write/read containment)", () => {
   const base = "/proj/root";

--- a/test/support/tempDir.ts
+++ b/test/support/tempDir.ts
@@ -1,0 +1,18 @@
+import { mkdtempSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// A temp directory spelled the way the production code will resolve it.
+//
+// Two platforms rewrite the path `mkdtemp` hands back, and a fixture that skips this compares a
+// path the code under test never produces:
+//
+//   macOS   /var/... -> /private/var/...        (the temp dir is itself behind a symlink)
+//   Windows C:\Users\RUNNER~1\... -> ...\runneradmin\...   (an 8.3 short component)
+//
+// `.native` matters on Windows: Node's JS realpathSync leaves the 8.3 component alone while the
+// native call expands it, so only the native one agrees with what the server resolves
+// (server/git/worktrees.ts says the same, and #1052 is the CI failure that proved it).
+export function makeTempDir(prefix: string): string {
+  return realpathSync.native(mkdtempSync(path.join(tmpdir(), prefix)));
+}


### PR DESCRIPTION
## Summary

**#1052 の続き。単独では main が壊れている状態なので、これが対になる。**

#1052 は実装側を `realpathSync.native` に統一した（Windows の 8.3 短縮パスを展開する）。
**その対になるテスト側の修正が、#1052 がマージされた時点でまだ入っていなかった。**

いま main は:

- 実装 → **長い形**を返す（`C:\Users\runneradmin\...`）
- テストの fixture → 生の `mkdtempSync` なので **短縮形**（`C:\Users\RUNNER~1\...`）

なので **Windows CI は `pathContainment` / `files-browse` の 6 件で落ちる**。これで揃う。

## 変更

`test/support/tempDir.ts` — **`mkdtemp` の戻り値を書き換えるプラットフォームが 2 つある**ことを
1 箇所に集約した:

| | 書き換え |
| --- | --- |
| macOS | `/var/...` → `/private/var/...`（temp dir 自体が symlink の先） |
| Windows | `C:\Users\RUNNER~1\...` → `...\runneradmin\...`（8.3 短縮形） |

**`.native` が要る**のは Windows のため。Node の JS 版 `realpathSync` は 8.3 を展開せず、
native 版だけが展開する（`server/git/worktrees.ts` が同じことを書いている）。

## Items to Confirm / Review

- **スコープを絞っている。** temp dir を使う spec は **64 個あり、正規化しているのは 8 個**。
  残りは今のところ「解決済みパスとの比較」をしていないので落ちていない。
  **全部を一掃するのは CI 修正への付け足しにすべきでない**と判断し、実際に落ちている
  2 ファイルだけをヘルパー経由にした。掃除が要るなら別 PR で。
- **#1052 で残っていた 24.x の 1 件（`worktree-pr.spec.ts`）はこれとは無関係。**
  パス問題ではなく **30 秒のテストタイムアウト**で、22.x では通っている。
  私の変更はそのファイルにも `worktree-pr.ts` にも触れていない。同一コミットで再実行して
  flaky か切り分け中。

## User Prompt

> https://github.com/receptron/mulmoterminal/actions/runs/30399221898
>
> 間違ってマージされてかも。別ブランチで続けて。

## Verification

`yarn format` / `lint` / `typecheck` ×3 / `test`（5960 passed、macOS）。
**Windows は手動 dispatch した run で確認する。**

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
