### PR TITLE
fix: ガードが Firestore の正当な値を壊していた + activity の書き込みが無防備だった

### DIFF
--- a/server/backends/remoteHost/firestoreSafeResult.ts
+++ b/server/backends/remoteHost/firestoreSafeResult.ts
@@ -22,6 +22,15 @@
 // NOT `ignoreUndefinedProperties` on the Firestore instance: that setting makes this class of bug
 // disappear into "the value just doesn't arrive", with nothing logged and nothing to grep for.
 
+// Only a PLAIN object or an array is walked into. Firestore stores a Date, a Timestamp, a
+// GeoPoint, a DocumentReference and Bytes as themselves, and rebuilding one of those from its
+// entries turns it into `{}` — the guard would then destroy a valid value while looking for an
+// invalid one. Anything with a prototype of its own is left exactly as it came.
+const isPlainObject = (value: object): boolean => {
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
 /** Every path holding `undefined`, in `a.b.0.c` form. Empty when the value is safe to write. */
 export function undefinedPaths(value: unknown, prefix = ""): string[] {
   if (value === undefined) return [prefix || "(root)"];
@@ -29,6 +38,7 @@ export function undefinedPaths(value: unknown, prefix = ""): string[] {
   // Array.from, not flatMap: a SPARSE array's holes are skipped by flatMap/map, so `[1, , 3]`
   // would be reported clean and then written with a hole Firestore rejects (CodeRabbit review).
   if (Array.isArray(value)) return Array.from(value).flatMap((item, i) => undefinedPaths(item, prefix ? `${prefix}.${i}` : String(i)));
+  if (!isPlainObject(value)) return []; // a Date/Timestamp/Bytes holds no undefined to find
   return Object.entries(value).flatMap(([key, item]) => undefinedPaths(item, prefix ? `${prefix}.${key}` : key));
 }
 
@@ -43,6 +53,7 @@ export function stripUndefined<T>(value: T): T {
   if (value === undefined) return null as T;
   if (value === null || typeof value !== "object") return value;
   if (Array.isArray(value)) return Array.from(value, (item) => (item === undefined ? null : stripUndefined(item))) as T;
+  if (!isPlainObject(value)) return value; // rebuilding a Date from its entries would yield {}
   const out: Record<string, unknown> = {};
   Object.entries(value as Record<string, unknown>).forEach(([key, item]) => {
     if (item !== undefined) out[key] = stripUndefined(item);
@@ -57,8 +68,9 @@ export function stripUndefined<T>(value: T): T {
  * JSON from any of them, so the next `undefined` will come from somewhere else.
  */
 /**
- * Does `path` match `pattern`? `*` stands for exactly one segment, which is what makes an array
- * index expressible: `sessions.*.work` covers `sessions.0.work` and every sibling.
+ * Does `path` match `pattern`? `*` stands for exactly one segment — ANY segment, not just a
+ * numeric index, though an index is what it was added for (`sessions.*.work`). One segment and
+ * not more, so `a.*` cannot silence everything beneath `a`.
  */
 export function matchesPath(pattern: string, path: string): boolean {
   const patternParts = pattern.split(".");

--- a/server/backends/remoteHost/firestoreSafeResult.ts
+++ b/server/backends/remoteHost/firestoreSafeResult.ts
@@ -26,6 +26,12 @@
 // GeoPoint, a DocumentReference and Bytes as themselves, and rebuilding one of those from its
 // entries turns it into `{}` — the guard would then destroy a valid value while looking for an
 // invalid one. Anything with a prototype of its own is left exactly as it came.
+//
+// An object literal from ANOTHER realm (vm, a worker) has a different Object.prototype and so
+// reads as "not plain" here, and its `undefined` would go unreported. That is the safe direction
+// to be wrong in: skipping one means a write fails loudly at Firestore, while recursing into a
+// sentinel replaces a real value with {} and nobody ever hears about it. Replies are built in this
+// realm and JSON.parse returns this realm's objects, so nothing takes that path today.
 const isPlainObject = (value: object): boolean => {
   const proto: unknown = Object.getPrototypeOf(value);
   return proto === Object.prototype || proto === null;

--- a/server/backends/remoteHost/sessionActivity.ts
+++ b/server/backends/remoteHost/sessionActivity.ts
@@ -10,6 +10,7 @@
 // Deliberately fire-and-forget: the caller sits on the synchronous hook path that
 // serves Claude Code's own requests, and a Firestore hiccup must never disturb it.
 import { deleteDoc, doc, serverTimestamp, setDoc, type DocumentReference, type Firestore } from "firebase/firestore";
+import { stripUndefined } from "./firestoreSafeResult.js";
 import type { WorkPhase } from "../../session/workPhase.js";
 
 export interface SessionActivity {
@@ -76,7 +77,12 @@ export function createSessionActivityPublisher(deps: SessionActivityPublisherDep
     published.set(sessionId, key);
     const rev = (revisions.get(sessionId) ?? 0) + 1;
     revisions.set(sessionId, rev);
-    deps.store.write(uid, deps.hostId, sessionId, { ...activity, rev, at: serverTimestamp() }).catch((error: unknown) => {
+    // The other write that reaches Firestore. `SessionActivity` has optional fields, so an
+    // `event: undefined` from any caller would take this doc down the same way a stray undefined
+    // took down the session list — and here the loss is silent, since nothing awaits the result.
+    // `serverTimestamp()` is a sentinel object, which is why the guard only walks plain objects.
+    const payload = stripUndefined({ ...activity, rev, at: serverTimestamp() });
+    deps.store.write(uid, deps.hostId, sessionId, payload).catch((error: unknown) => {
       // The dedup entry is recorded optimistically, so a failed write would otherwise
       // swallow every later publish of the SAME state and leave the phone stale until
       // some different transition happened. Release it so the next one retries —

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -47,7 +47,7 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
       submitTranslationTool: translationWorkerIds.has(sessionId),
       group,
     });
-    const transport = new StreamableHTTPServerTransport({});
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on("close", () => {
       transport.close();
       server.close();

--- a/test/server/backends/firestore-safe-result.spec.ts
+++ b/test/server/backends/firestore-safe-result.spec.ts
@@ -232,3 +232,39 @@ describe("buildSessionList — the shape that reached Firestore (#1042)", () => 
     expect(undefinedPaths({ sessions: listWith(new Map()) })).toEqual([]);
   });
 });
+
+// Firestore stores a Date, a Timestamp, a GeoPoint, a DocumentReference and Bytes as themselves.
+// Rebuilding one from its entries turns it into `{}` — the guard would then destroy a valid value
+// while hunting an invalid one (found by a local codex review; CodeRabbit was rate-limited).
+describe("values Firestore stores as themselves", () => {
+  const AT = new Date("2026-07-29T00:00:00Z");
+
+  it("hands a Date back as the same Date, not an empty object", () => {
+    expect(stripUndefined(AT)).toBeInstanceOf(Date);
+    expect(stripUndefined({ at: AT }).at).toBeInstanceOf(Date);
+  });
+
+  // A Firestore sentinel (serverTimestamp) is an ordinary class instance to us, so this is what
+  // stops the guard from flattening it on the activity-publish path.
+  it("hands any class instance back untouched", () => {
+    class Sentinel {
+      readonly kind = "serverTimestamp";
+    }
+    const sentinel = new Sentinel();
+    expect(stripUndefined({ at: sentinel }).at).toBe(sentinel);
+    expect(stripUndefined(new Map([["a", 1]]))).toBeInstanceOf(Map);
+  });
+
+  it("finds no undefined to report inside one", () => {
+    expect(undefinedPaths({ at: AT, bad: undefined })).toEqual(["bad"]);
+  });
+
+  // The point of the narrowing is to leave the ordinary case alone.
+  it("still cleans a plain object beside it", () => {
+    expect(stripUndefined({ at: AT, gone: undefined, keep: 1 })).toEqual({ at: AT, keep: 1 });
+  });
+
+  it("still walks a plain object nested under one", () => {
+    expect(undefinedPaths({ outer: { inner: undefined } })).toEqual(["outer.inner"]);
+  });
+});

--- a/test/server/backends/firestore-safe-result.spec.ts
+++ b/test/server/backends/firestore-safe-result.spec.ts
@@ -4,6 +4,7 @@
 // is what emptied the phone's session list in #1042. These pin the guard that stands in front of
 // the write, and the shape of the session list that tripped it.
 import { describe, it, expect, vi } from "vitest";
+import { runInNewContext } from "node:vm";
 import { undefinedPaths, stripUndefined, firestoreSafeHandlers, matchesPath } from "../../../server/backends/remoteHost/firestoreSafeResult";
 import { buildSessionList } from "../../../server/backends/remoteHost/terminalScreen";
 
@@ -266,5 +267,15 @@ describe("values Firestore stores as themselves", () => {
 
   it("still walks a plain object nested under one", () => {
     expect(undefinedPaths({ outer: { inner: undefined } })).toEqual(["outer.inner"]);
+  });
+
+  // Pins the direction the narrowing is allowed to be wrong in. An object from another realm reads
+  // as "not plain", so its undefined goes unreported — which fails the write loudly at Firestore.
+  // The opposite mistake, recursing into a sentinel, replaces a real value with {} in silence.
+  // Nothing takes this path today (replies are built here; JSON.parse returns this realm).
+  it("skips a foreign-realm object rather than risking a sentinel", () => {
+    const foreign: unknown = runInNewContext("({ a: 1, bad: undefined })");
+    expect(undefinedPaths(foreign)).toEqual([]);
+    expect(stripUndefined({ nested: foreign })).toEqual({ nested: foreign });
   });
 });

--- a/test/server/backends/remoteHost/sessionActivity.spec.ts
+++ b/test/server/backends/remoteHost/sessionActivity.spec.ts
@@ -194,3 +194,46 @@ describe("createSessionActivityPublisher", () => {
     ]);
   });
 });
+
+// The OTHER write that reaches Firestore. `SessionActivity` has optional fields, so a caller
+// passing `event: undefined` would take this doc down the way a stray undefined took down the
+// session list (#1042) — and here the loss is silent, since nothing awaits the result. The
+// `at: serverTimestamp()` sentinel has to survive that cleaning (local codex review).
+describe("what actually reaches the store", () => {
+  const raw = () => {
+    const payloads: unknown[] = [];
+    const store: SessionActivityStore = {
+      write: async (_uid, _hostId, _sessionId, payload) => {
+        payloads.push(payload);
+      },
+      remove: async () => undefined,
+    };
+    return { payloads, store };
+  };
+
+  it("carries no undefined key, whatever the caller passed", () => {
+    const { payloads, store } = raw();
+    publisher(store).publish("s1", { working: true, waiting: false, event: undefined, workPhase: undefined });
+    const written = payloads[0] as Record<string, unknown>;
+    expect(Object.hasOwn(written, "event")).toBe(false);
+    expect(Object.hasOwn(written, "workPhase")).toBe(false);
+    expect(written.working).toBe(true);
+  });
+
+  // serverTimestamp() is a class instance; flattening it would replace the timestamp with {}.
+  it("leaves the server-timestamp sentinel intact", () => {
+    const { payloads, store } = raw();
+    publisher(store).publish("s1", { working: true, waiting: false });
+    const written = payloads[0] as Record<string, unknown>;
+    expect(written.at).toBeTruthy();
+    expect(Object.keys(written.at as object).length > 0 || typeof written.at !== "object").toBe(true);
+  });
+
+  it("keeps a null apart from an absent key", () => {
+    const { payloads, store } = raw();
+    publisher(store).publish("s1", { working: false, waiting: true, event: null });
+    const written = payloads[0] as Record<string, unknown>;
+    expect(Object.hasOwn(written, "event")).toBe(true);
+    expect(written.event).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

#1051 / #1053 は **CodeRabbit がレート制限でレビューできないままマージ**されたので、ローカルで codex review を回しました。指摘 3 件、**すべて実際に再現を確認**したうえで直しています。

| # | 指摘 | 実測 |
| --- | --- | --- |
| 1 | ガードが Firestore の正当な値を壊す | `stripUndefined(new Date())` → `{}` |
| 2 | activity の書き込みが無防備 | 別の `setDoc` 経路でガード対象外 |
| 3 | `mcp-routes` の変更は戻すべき | フラグを入れない以上、意図が薄れるだけ |

## Items to Confirm / Review

### 1. ガードが有効な値を壊していた（一番効く）

`typeof value === "object"` で一律に再帰コピーしていました。**Firestore は Date / Timestamp / GeoPoint / DocumentReference / Bytes をそのまま格納する**ので、無効な値を探していて有効な値を壊す状態でした。

```
stripUndefined(new Date())          → {}
stripUndefined(new Map([["a",1]]))  → {}
stripUndefined(Buffer.from("x"))    → {"0":120}
```

プレーンオブジェクトと配列だけを走査するようにしました（プロトタイプが `Object.prototype` か `null` のもの）。**今のハンドラが Date を返していないので発火はしていませんでしたが**、「free-form JSON を守る」と書いておきながら壊す作りでした。

### 2. `sessionActivity` の書き込みが無防備だった

ガードが守るのは**ハンドラの戻り値だけ**で、`sessionActivity` は別の `setDoc` 経路です。`SessionActivity` は optional フィールドを持つので、呼び出し側が `event: undefined` を渡せば #1042 と同じように落ちます。しかも**結果を誰も await していない**ので、失敗しても黙って消えます。

ここで 1 の修正が前提になります。`at: serverTimestamp()` は**センチネル（クラスインスタンス）**なので、修正前のガードを通すと潰れていました。

### 3. `mcp-routes` の変更を戻しました

`{ sessionIdGenerator: undefined }` → `{}` は `exactOptionalPropertyTypes` のための変更でしたが、**そのフラグは入れないことになりました**（#1048 のブロッカー 2 件）。挙動は同じですが、明示的な `undefined` のほうがステートレスモードの意図を示すので、レビューの助言どおり戻します。

## User Prompt

> 間違ってマージされた。別ブランチでたいおう。とりあえず、現状で問題なければ進める。
>
> ここの型ガードので問題ない？reviewまわってなければ、一回localでcodex reviewして。

## テスト（新規 8 件）

- Date / クラスインスタンス / Map がそのまま返る（ネストしていても）
- それらの中に undefined を探しに行かない
- **隣のプレーンオブジェクトは今までどおり掃除される**（絞りすぎていないことの担保）
- activity: 呼び出し側が undefined を渡してもキーが残らない / **センチネルが潰れない** / `null` は「キーが無い」と区別される

**3 つとも、修正を外すとテストが落ちることを確認済み**です。

## 採らなかった指摘

`*` が「配列の添字専用ではなく任意の1セグメント」である点を、数字に限定してはどうか、という指摘がありました。**採っていません** — パスのセグメントはオブジェクトのキーでもありうるので、数字に限ると正当なパターンが書けなくなります。代わりにコメントで「任意の1セグメント」であることを明示しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
