### PR TITLE
fix: ユーザーに見える残りの npx も @latest にする

### DIFF
--- a/bin/mulmoterminal.js
+++ b/bin/mulmoterminal.js
@@ -322,7 +322,7 @@ function runServer(port, noOpen, cwd, onChild) {
 
 function printHelp() {
   console.log(`
-Usage: npx mulmoterminal [command] [options]
+Usage: npx mulmoterminal@latest [command] [options]
 
 Commands:
   (none)            Start the server (default)

--- a/server/cli-google.ts
+++ b/server/cli-google.ts
@@ -45,7 +45,7 @@ async function login(): Promise<number> {
 
 function printHelp(): void {
   console.log(`
-Usage: npx mulmoterminal google <command>
+Usage: npx mulmoterminal@latest google <command>
 
 Commands:
   login    Link a Google account (browser consent, on this machine)

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -615,7 +615,7 @@ onUnmounted(() => {
       <p class="mb-3 mt-1.5 text-[12px] text-dim">
         Link a Google account so the <code>google</code> tool and your phone can read and create <strong>Calendar</strong> events. Sign-in opens in a new tab
         and finishes on <strong>this machine</strong>, so use a browser here — over a remote connection, run
-        <code>npx mulmoterminal google login</code> instead. The link is shared with MulmoClaude.
+        <code>npx mulmoterminal@latest google login</code> instead. The link is shared with MulmoClaude.
       </p>
       <p v-if="googleSecretHint" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-err-text">{{ googleSecretHint }}</p>
       <div class="mb-3 flex items-center gap-2.5">


### PR DESCRIPTION
## Summary

#1035（README・guide）と #1036（init 完了メッセージ）で片付けた残りです。ユーザーに**打つコマンドとして提示している** 3 箇所を `@latest` にします。

| 場所 | 変更前 |
|---|---|
| `bin/mulmoterminal.js:325` | `Usage: npx mulmoterminal [command] [options]` |
| `server/cli-google.ts:48` | `Usage: npx mulmoterminal google <command>` |
| `src/components/SettingsModal.vue:618` | Settings の Google account 節、`npx mulmoterminal google login` |

バージョン未指定の `npx` は `~/.npm/_npx` のキャッシュをそのまま使うため、これらを読んで打つと古い版が起動します。

**ソースコメント内の `npx mulmoterminal` は触っていません**（`bin/cli-args.js:54`、`bin/mulmoterminal.js:3` など）。エントリポイントの名前としての言及で、打つコマンドではないためです。#1035 で本文と実行コマンドを切り分けたのと同じ基準です。

## Items to Confirm / Review

- **Settings の 1 行が一番実害があります。** 「リモート越しならこれを打て」と案内している箇所なので、まさに古い版を掴む経路でした
- Usage 行は「すでに動いている本体が出す説明」なので優先度は下がりますが、コピーされる文字列であることに変わりはありません
- **テストは足していません。** これらの文字列を検証している既存テストが無く、1 行の文言に対してハーネスを作るのは釣り合いません（#1036 と同じ判断）

## 手元で 1 件、引っかかった話（この PR とは無関係）

作業開始時に `yarn test` が 15 件落ちました。差分は 1 行 × 3 だけなので main 側を疑い、**未変更の main で走らせて同じ 15 件が落ちること**を確認したうえで原因を追ったところ、`@codemirror/lang-*` が `package.json` にあって `node_modules` に無い状態でした（宣言 14 / 実体 6）。**手元の依存が古かっただけ**で、`yarn install` で解消しています。`yarn.lock` は変わっていません。**リポジトリも CI も壊れていません。**

## User Prompt

> 検証できないけど、問題なければマージして。SettingsModal の残り 2 箇所も直して

## Test plan

- `yarn format` / `lint` / `typecheck` ×3 / `build` / `test`（5960 passed）
- 置換後、ユーザーに見える文字列に素の `npx mulmoterminal` が残っていないことを確認（残るのはソースコメントのみ）

Refs #1035, #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)