### PR TITLE
fix(test): パス解決を通す spec すべてで temp dir の綴りを揃える

### DIFF
--- a/server/backends/mulmoscript.spec.ts
+++ b/server/backends/mulmoscript.spec.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll } from "vitest";
+import { makeTempDir } from "../../test/support/tempDir.js";
 import express, { type Express } from "express";
 import request from "supertest";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { initArtifactsBackend } from "./artifacts.js";
 import { initMulmoScriptBackend, mountMulmoScriptDispatchRoute, mountMulmoScriptMediaRoute } from "./mulmoscript.js";
@@ -31,7 +31,7 @@ describe("mulmoscript backend", () => {
   let workspace: string;
 
   beforeAll(() => {
-    workspace = fs.mkdtempSync(path.join(os.tmpdir(), "mt-mulmoscript-"));
+    workspace = makeTempDir("mt-mulmoscript-");
     initArtifactsBackend({ workspace });
     initMulmoScriptBackend({ workspace, pubsub: null });
     app = makeApp();
@@ -107,7 +107,7 @@ describe("mulmoscript backend", () => {
 // above (vitest runs describes in file order within a file).
 describe("autoGenerateMovie without ffmpeg", () => {
   it("saves the script but reports that movie generation was not started", async () => {
-    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "mt-mulmoscript-noffmpeg-"));
+    const workspace = makeTempDir("mt-mulmoscript-noffmpeg-");
     initArtifactsBackend({ workspace });
     initMulmoScriptBackend({ workspace, pubsub: null, isFfmpegAvailable: () => false });
     const app = makeApp();

--- a/test/scripts/dev-server.spec.ts
+++ b/test/scripts/dev-server.spec.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
 import { describe, it, expect, afterEach } from "vitest";
+import { makeTempDir } from "../support/tempDir.js";
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, realpathSync } from "node:fs";
+import { writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
 import path from "node:path";
-import os from "node:os";
 import { fileURLToPath } from "node:url";
 
 // The supervisor's whole reason to exist: unlike `node --watch`, it must RESTART the backend
@@ -25,12 +25,12 @@ const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 describe("dev-server supervisor", () => {
   it("restarts the backend after it crashes on boot", async () => {
-    dir = mkdtempSync(path.join(os.tmpdir(), "dev-server-test-"));
+    dir = makeTempDir("dev-server-test-");
     const boots = path.join(dir, "boots.log");
     const stub = path.join(dir, "stub.mjs");
     // Each boot appends its pid, then crashes immediately — so a second line proves a restart.
     writeFileSync(stub, `import { appendFileSync } from "node:fs";\nappendFileSync(${JSON.stringify(boots)}, process.pid + "\\n");\nprocess.exit(1);\n`);
-    const watchDir = mkdtempSync(path.join(os.tmpdir(), "dev-server-watch-")); // empty — isolates crash-restart from reload
+    const watchDir = makeTempDir("dev-server-watch-"); // empty — isolates crash-restart from reload
 
     child = spawn(process.execPath, [SUPERVISOR], {
       env: { ...process.env, DEV_SERVER_ENTRY: stub, DEV_SERVER_WATCH: watchDir },
@@ -60,7 +60,7 @@ describe("dev-server supervisor", () => {
   it.skipIf(process.platform === "win32")(
     "restarts the backend when a watched source file changes",
     async () => {
-      dir = mkdtempSync(path.join(os.tmpdir(), "dev-server-test-"));
+      dir = makeTempDir("dev-server-test-");
       const boots = path.join(dir, "boots.log");
       const stub = path.join(dir, "stub.mjs");
       // A backend that boots (records its pid) and STAYS ALIVE — so a second boot can only come
@@ -71,7 +71,7 @@ describe("dev-server supervisor", () => {
       );
       // realpathSync expands a Windows 8.3 short path (os.tmpdir() → C:\Users\RUNNER~1\…), which
       // fs.watch is unreliable on (see docs/windows-gotchas.md).
-      const watchDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), "dev-server-watch-")));
+      const watchDir = makeTempDir("dev-server-watch-");
 
       child = spawn(process.execPath, [SUPERVISOR], {
         env: { ...process.env, DEV_SERVER_ENTRY: stub, DEV_SERVER_WATCH: watchDir },

--- a/test/server/backends/fileOps.spec.ts
+++ b/test/server/backends/fileOps.spec.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { makeTempDir } from "../../support/tempDir.js";
+import { mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
 import path from "node:path";
 
 import { createFileOps } from "../../../server/backends/fileOps.js";
@@ -12,7 +12,7 @@ describe("createFileOps", () => {
   let ops: ReturnType<typeof createFileOps>;
 
   beforeEach(() => {
-    base = mkdtempSync(path.join(tmpdir(), "mt-fileops-"));
+    base = makeTempDir("mt-fileops-");
     root = path.join(base, "root");
     mkdirSync(root);
     ops = createFileOps(() => root, "test");

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { makeTempDir } from "../../support/tempDir.js";
+import { writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import path from "node:path";
 import {
   resolveDirSound,
@@ -14,7 +14,7 @@ import {
 import { DIR_CONFIG_KEYS } from "../../../common/dirConfigSource";
 import { resolveWorkspace } from "../../../server/config/workspace";
 
-const tmp = () => mkdtempSync(path.join(tmpdir(), "mt-dircfg-"));
+const tmp = () => makeTempDir("mt-dircfg-");
 const EMPTY = {
   name: null,
   badgeColor: null,

--- a/test/server/config/workspace.spec.ts
+++ b/test/server/config/workspace.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { makeTempDirAsync } from "../../support/tempDir.js";
 import { promises as fs } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { resolveWorkspace, workspaceFromQuery, existingWorkspace, existingWorkspaceFromQuery } from "../../../server/config/workspace.js";
 import { CLAUDE_CWD } from "../../../server/config/env.js";
@@ -12,7 +12,7 @@ describe("resolveWorkspace", () => {
   let file = "";
 
   beforeAll(async () => {
-    dir = await fs.mkdtemp(path.join(os.tmpdir(), "mt-ws-"));
+    dir = await makeTempDirAsync("mt-ws-");
     file = path.join(dir, "a-file");
     await fs.writeFile(file, "");
   });
@@ -47,7 +47,7 @@ describe("resolveWorkspace", () => {
 
 describe("workspaceFromQuery", () => {
   it("resolves a string query", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "mt-wsq-"));
+    const dir = await makeTempDirAsync("mt-wsq-");
     expect(workspaceFromQuery(dir)).toBe(dir);
     await fs.rm(dir, { recursive: true, force: true });
   });
@@ -96,7 +96,7 @@ describe("canonical spelling of the accepted directory", () => {
   let dir = "";
 
   beforeAll(async () => {
-    dir = await fs.mkdtemp(path.join(os.tmpdir(), "mt-ws-canon-"));
+    dir = await makeTempDirAsync("mt-ws-canon-");
   });
   afterAll(async () => {
     await fs.rm(dir, { recursive: true, force: true });

--- a/test/server/git/git-status.spec.ts
+++ b/test/server/git/git-status.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { makeTempDir } from "../../support/tempDir.js";
+import { rmSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { gitStatus } from "../../../server/git/git-status.js";
 
@@ -22,7 +22,7 @@ describe("gitStatus", () => {
     execFileSync("git", ["-C", dir, ...a], { stdio: "ignore" });
 
   beforeEach(() => {
-    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-gitstatus-")));
+    repo = makeTempDir("mt-gitstatus-");
     if (!hasGit) return;
     g(repo, "init", "-b", "main");
     g(repo, "config", "user.email", "t@t.t");
@@ -36,7 +36,7 @@ describe("gitStatus", () => {
   });
 
   it("reports repo:false for a non-git dir", async () => {
-    const outside = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-nogit-")));
+    const outside = makeTempDir("mt-nogit-");
     const s = await gitStatus(outside);
     expect(s.repo).toBe(false);
     rmSync(outside, { recursive: true, force: true });
@@ -52,7 +52,7 @@ describe("gitStatus", () => {
   });
 
   it.skipIf(!hasGit)("shows the branch on an unborn branch (git init, no commit yet)", async () => {
-    const fresh = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-unborn-")));
+    const fresh = makeTempDir("mt-unborn-");
     g(fresh, "init", "-b", "main"); // no commit — unborn HEAD
     const s = await gitStatus(fresh);
     expect(s.repo).toBe(true);
@@ -80,7 +80,7 @@ describe("gitStatus", () => {
 
   it.skipIf(!hasGit)("reports ahead vs a local upstream", async () => {
     // A second clone acting as the "remote" so HEAD has an upstream to be ahead of.
-    const remote = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-remote-")));
+    const remote = makeTempDir("mt-remote-");
     g(repo, "clone", "--bare", repo, remote);
     g(repo, "remote", "add", "origin", remote);
     g(repo, "push", "-u", "origin", "main");

--- a/test/server/git/repo-root-sync.spec.ts
+++ b/test/server/git/repo-root-sync.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { makeTempDir } from "../../support/tempDir.js";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import { repoRootSync } from "../../../server/git/repo-root-sync";
 import { repoRoot } from "../../../server/git/worktrees";
@@ -15,7 +15,7 @@ let worktree = "";
 beforeAll(() => {
   // `.native`, not plain realpathSync: on a Windows runner os.tmpdir() is the 8.3 short form
   // (C:\Users\RUNNER~1\…) and only the native resolver expands it to the long name git reports.
-  base = realpathSync.native(mkdtempSync(path.join(tmpdir(), "mt-reporoot-")));
+  base = makeTempDir("mt-reporoot-");
   main = path.join(base, "myrepo");
   mkdirSync(main);
   const git = (args: string[], cwd = main) =>
@@ -57,7 +57,7 @@ describe("repoRootSync", () => {
   });
 
   it("returns null outside a repository", () => {
-    const plain = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-norepo-")));
+    const plain = makeTempDir("mt-norepo-");
     expect(repoRootSync(plain)).toBeNull();
     rmSync(plain, { recursive: true, force: true });
   });

--- a/test/server/git/worktree-diff.spec.ts
+++ b/test/server/git/worktree-diff.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, realpathSync } from "node:fs";
+import { makeTempDir } from "../../support/tempDir.js";
+import { rmSync, writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { createWorktree } from "../../../server/git/worktrees.js";
 import { worktreeDiff } from "../../../server/git/worktree-diff.js";
@@ -24,9 +24,9 @@ describe("worktreeDiff", () => {
     execFileSync("git", ["-C", dir, ...a], { stdio: "ignore" });
 
   beforeEach(() => {
-    home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-diff-home-")));
+    home = makeTempDir("mt-diff-home-");
     process.env.MULMOTERMINAL_HOME = home;
-    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-diff-repo-")));
+    repo = makeTempDir("mt-diff-repo-");
     if (!hasGit) return;
     g(repo, "init", "-b", "main");
     g(repo, "config", "user.email", "t@t.t");

--- a/test/server/git/worktree-pr.spec.ts
+++ b/test/server/git/worktree-pr.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, realpathSync } from "node:fs";
+import { makeTempDir } from "../../support/tempDir.js";
+import { writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { createWorktree, gitTopLevel } from "../../../server/git/worktrees.js";
 import { compareUrl, pushWorktree, createOrOpenPR } from "../../../server/git/worktree-pr.js";
@@ -34,10 +34,10 @@ describe("push / PR actions", () => {
     execFileSync("git", ["-C", dir, ...a], { stdio: "ignore" });
 
   beforeEach(async () => {
-    home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-home-")));
+    home = makeTempDir("mt-pr-home-");
     process.env.MULMOTERMINAL_HOME = home;
-    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-repo-")));
-    remote = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-pr-remote-")));
+    repo = makeTempDir("mt-pr-repo-");
+    remote = makeTempDir("mt-pr-remote-");
     if (!hasGit) return;
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
     execFileSync("git", ["init", "--bare", "-b", "main", remote], { stdio: "ignore" });

--- a/test/server/git/worktree-routes.spec.ts
+++ b/test/server/git/worktree-routes.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { makeTempDir } from "../../support/tempDir.js";
 import type { Express } from "express";
-import { mkdtempSync, writeFileSync, realpathSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { mountWorktreeRoutes } from "../../../server/git/worktree-routes.js";
 import { createWorktree, worktreesRoot, gitTopLevel } from "../../../server/git/worktrees.js";
@@ -98,7 +98,7 @@ describe("worktree routes: origin guard + validation", () => {
   });
 
   it("reports isGit:false for a non-git dir", async () => {
-    const dir = mkdtempSync(path.join(tmpdir(), "wt-routes-plain-"));
+    const dir = makeTempDir("wt-routes-plain-");
     try {
       const res = makeRes();
       await routes(allow)["GET /api/worktrees"]({ headers: {}, query: { cwd: dir } }, res);
@@ -135,9 +135,9 @@ describe("worktree routes: create → list → remove lifecycle", () => {
   })();
 
   beforeEach(async () => {
-    home = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-home-")));
+    home = makeTempDir("wt-routes-home-");
     process.env.MULMOTERMINAL_HOME = home;
-    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-repo-")));
+    repo = makeTempDir("wt-routes-repo-");
     if (!hasGit) return;
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
     const g = (...a: string[]) => execFileSync("git", ["-C", repo, ...a], { stdio: "ignore" });
@@ -255,7 +255,7 @@ describe("worktree routes: create → list → remove lifecycle", () => {
       expect(noRemote.statusCode).toBe(409);
       expect(noRemote.payload).toMatchObject({ ok: false, reason: "no-remote" });
 
-      const remote = realpathSync(mkdtempSync(path.join(tmpdir(), "wt-routes-remote-")));
+      const remote = makeTempDir("wt-routes-remote-");
       try {
         // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
         execFileSync("git", ["init", "--bare", "-b", "main", remote], { stdio: "ignore" });

--- a/test/server/git/worktrees.spec.ts
+++ b/test/server/git/worktrees.spec.ts
@@ -1,8 +1,8 @@
 import { canSymlink } from "../../support/canSymlink.js";
+import { makeTempDir } from "../../support/tempDir.js";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, existsSync, realpathSync, symlinkSync } from "node:fs";
+import { writeFileSync, existsSync, symlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { tmpdir } from "node:os";
 import path from "node:path";
 import { rmDirRetrying, GIT_TEST_TIMEOUT_MS } from "./wtTestUtil.js";
 import {
@@ -69,9 +69,9 @@ describe("git worktree lifecycle", () => {
   beforeEach(async () => {
     // realpath: git resolves symlinks (macOS /tmp -> /private/var), and the engine
     // keys the managed root off git's toplevel, so the test dirs must match that.
-    home = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-home-")));
+    home = makeTempDir("mt-wt-home-");
     process.env.MULMOTERMINAL_HOME = home;
-    repo = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-repo-")));
+    repo = makeTempDir("mt-wt-repo-");
     if (!hasGit) return;
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' from PATH in a test; argv only, no shell
     const g = (...a: string[]) => execFileSync("git", ["-C", repo, ...a], { stdio: "ignore" });
@@ -163,7 +163,7 @@ describe("git worktree lifecycle", () => {
       const wt = await createWorktree(repo, "real"); // creates the managed root dir
       if (!wt) throw new Error("expected a worktree");
       const root = worktreesRoot(repo);
-      const outside = realpathSync(mkdtempSync(path.join(tmpdir(), "mt-wt-outside-")));
+      const outside = makeTempDir("mt-wt-outside-");
       const link = path.join(root, "escape");
       symlinkSync(outside, link); // <root>/escape -> /outside (canonicalizes out of the root)
       try {
@@ -178,7 +178,7 @@ describe("git worktree lifecycle", () => {
   );
 
   it("gitTopLevel returns null for a non-repo dir", async () => {
-    const plain = mkdtempSync(path.join(tmpdir(), "mt-wt-plain-"));
+    const plain = makeTempDir("mt-wt-plain-");
     expect(await gitTopLevel(plain)).toBeNull();
     rmDirRetrying(plain);
   });

--- a/test/server/infra/gui-mcp-registration.spec.ts
+++ b/test/server/infra/gui-mcp-registration.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync, realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { makeTempDir } from "../../support/tempDir.js";
+import { rmSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";
 import path from "node:path";
 
 import { guiMcpUrlTemplate, registeredGuiMcpGroups } from "../../../server/infra/gui-mcp-registration.js";
@@ -46,7 +46,7 @@ describe("registeredGuiMcpGroups", () => {
     // the code under test resolves, and the comparison fails for a reason that has nothing to do
     // with symlinks. On macOS both expand /var -> /private/var, which is why this was already
     // realpath'd at all.
-    root = realpathSync.native(mkdtempSync(path.join(tmpdir(), "gui-mcp-")));
+    root = makeTempDir("gui-mcp-");
     home = path.join(root, "home");
     cwd = path.join(root, "repo");
     mkdirSync(home);

--- a/test/support/tempDir.ts
+++ b/test/support/tempDir.ts
@@ -16,3 +16,10 @@ import path from "node:path";
 export function makeTempDir(prefix: string): string {
   return realpathSync.native(mkdtempSync(path.join(tmpdir(), prefix)));
 }
+
+/** The same, for a spec that creates its directory with the promises API. Resolving stays sync —
+ *  `fs/promises` has no `.native`, and this is one stat on a directory just created. */
+export async function makeTempDirAsync(prefix: string): Promise<string> {
+  const { mkdtemp } = await import("node:fs/promises");
+  return realpathSync.native(await mkdtemp(path.join(tmpdir(), prefix)));
+}


### PR DESCRIPTION
## Summary

#1056 は**落ちていた 2 spec だけ**を `makeTempDir` に通し、残りは「今は落ちていない」として置いた。
その「残り」を**思い込みではなく調べた**結果、**やる価値があった**ので一掃する。

## 調べた結果

temp dir を作る spec は **64 個**。うち**パス解決を実際に通すのは 12 個**（`realpath` /
`resolveContained` / `isWithin` / `existingWorkspace` / `safeAbs` / `canonicalDir` 等を呼ぶもの）。
その 12 個の内訳:

| 綴り方 | 件数 | 問題 |
| --- | --- | --- |
| `realpathSync(mkdtempSync(...))` | **6** | **JS の `realpathSync` は Windows の 8.3 を展開しない**（`.native` だけが展開する） |
| 生の `mkdtempSync(...)` | **4** | 正規化なし |
| `.native` 済み | 2 | OK |

**10 個が、実装がもう返さない綴りを期待していた。**

## なぜ今やるか

これらが今通っているのは、**まだ「解決済みパスとの比較」をしていないから**にすぎない。
実装側は #1052 で `.native` に移ったので、**この 10 個はどれも 1 行の編集で
「Windows でだけ再現する失敗」に変わる**。今回まさにその形で 6 件踏んだばかりで、
原因特定に CI への probe を 4 往復要した。**一番高くつく種類の失敗**なので、先に潰す。

## Items to Confirm / Review

- **12 個すべてを `test/support/tempDir.ts` 経由にした。** 加えて、promises API で
  ディレクトリを作る 1 個（`workspace.spec.ts`）のために `makeTempDirAsync` を足した
  （解決自体は同期のまま — `fs/promises` に `.native` は無く、作ったばかりのディレクトリへの stat 1 回）。
- **構造で確認している**: 「パス解決を通すのにヘルパーを使っていない spec」を grep すると**ゼロ**。
  件数を数えるのではなく、この grep が空であることが完了条件。
- **残り 52 個には触れていない。** パス解決を通さないので、正規化しても意味が無い。
  必要になった時点でヘルパーを使えばよい。
- テストのみの変更。実装には触れていない。

## User Prompt

> やらなかったことってやる必要あり？であればマージまで一気に！！

## Verification

`yarn format` / `lint` / `typecheck` ×3 / `test`（5960 passed、macOS）。
**Windows は手動 dispatch した run で確認する。**

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
