### PR TITLE
feat: バックグラウンドのワーカーを Background フィルタに分ける (#1060)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1414,6 +1414,16 @@ Key rules:
 - Brand-new sessions appear in the sidebar **immediately** (before their `.jsonl`
   exists) via the in-memory `knownSessions` registry + a `created` push; an
   unused one disappears when its PTY is reaped.
+- **Background workers get their own filter.** A session nobody started by hand —
+  a collection's scheduled refresh, or a plugin's `spawnBackgroundChat`
+  `hidden: true` — is listed under the **Background** chip instead of among the
+  chats, so a refresh schedule doesn't fill the history. It stays openable (a
+  MulmoTerminal session is a live terminal, so a row you can't reach is a process
+  you can't stop), and it is put on the same count+age retention as the
+  scheduler's own sessions. The chip appears only when there is one to show. A
+  **manual** collection Refresh is a normal visible session — unchanged. The
+  marking is persisted (`~/.mulmoterminal/background-sessions.json`), so a worker
+  stays out of the chat list after it finishes and after a restart.
 
 ---
 

--- a/plans/feat-1060-background-session-filter.md
+++ b/plans/feat-1060-background-session-filter.md
@@ -1,0 +1,95 @@
+# feat: 定期データ同期のセッションを Background フィルタに分ける (#1060)
+
+## 決めたこと
+
+issue #1060 は「バックグラウンドのデータ同期セッションを履歴から**丸ごと落とす**」（MulmoClaude の
+`origin: "system"` と同じ扱い）を提案していた。採らない。代わりに **MulmoClaude の履歴フィルタと同じく、
+チップで絞り込めるようにする**。
+
+- `All` = 人が始めたチャットのみ（バックグラウンドは既定で出ない）
+- `Background` = バックグラウンドのワーカーだけ
+- `Unread` は現状のまま（`isUnread` は元々 hidden を除外している）
+
+なぜ「消す」ではなく「フィルタ」か:
+
+MulmoTerminal のセッションは**チャット記録ではなく生きた端末**で、消すと開けなくなる＝止める手段も失う。
+チップの裏に置けば、既定の画面からは消えつつ、開いて中を見ることも止めることもできる。issue が挙げていた
+反対論（勘所4 の「間違えても正しく見える」を除く）はこれで解消する。
+
+## 現状の落とし穴 — フィルタ案でも永続化は要る
+
+`hiddenSessions`（`server/session/registry.ts`）は**メモリのみ**で、しかも
+`server/session/lifecycle.ts` の reap で削除される。つまりワイヤに乗る `hidden` フラグは
+**ワーカーが終わった瞬間／サーバ再起動で外れ、普通のチャットとして一覧に戻る**。
+
+フィルタにしても「除外したいものが除外されない」ので、`devTerminalSessions` と同じ
+**append ログによる永続セット**が必要になる。ここは issue の勘所1 と同じ。
+
+## 実装
+
+### サーバ
+
+1. **`server/session/dev-terminal-sessions.ts` → `server/session/session-id-log.ts`**
+   中身は「id を 1 行 1 個で追記するログ」の読み書きで、grid 固有のものは何もない。
+   2 つ目の同じ形のセットを足すのでモジュールごと一般化する
+   （`parseSessionIdLog` / `sessionIdLogLine`）。
+
+2. **`registry.ts` — 永続セット `backgroundSessions`**
+   - `~/.mulmoterminal/background-sessions.json`（append ログ）
+   - `backgroundSessionsHydrated` promise、`markBackgroundSession(id)`
+   - 追記ヘルパは grid 側と共通化（`idLogAppender(file, label)`）
+   - `isBackgroundSession(id)` = `hiddenSessions.has(id) || backgroundSessions.has(id)`
+   - `backgroundMarkers` — `runWithHiddenMarker` に渡す `{add, delete}` ファサード。
+     add で両方に入るので、**呼び出し側が 2 回書くことがない**（呼び出し側は 2 箇所ある）
+
+3. **`hiddenMarker.ts` の呼び出し側 2 箇所** — `hiddenSessions` ではなく `backgroundMarkers` を渡す。
+   `hidden:false`（手動 Refresh）は今までどおり何も印を付けない。
+
+4. **`session-reads.ts`** — ワイヤの `hidden` を `isBackgroundSession(id)` に切り替える
+   （on-disk 行と pending 行の両方）。副次的に「終了した hidden ワーカーが再び太字になる」既知の穴も塞がる。
+
+5. **`session-list.ts` — 上限をチャットと背景で分ける**
+   クライアントが既定で背景を隠すので、上限が 1 本だと**背景が増えるほど本物のチャットが押し出される**。
+   画面上は「リストが短くなった」だけで理由がどこにも出ない。
+   `isBackground` 述語 + `backgroundLimit` を足し、それぞれ別に上限を取ってから mtime で再マージする。
+
+6. **`session-routes.ts`** — 述語と `backgroundSessionsHydrated` の await を渡す。
+
+7. **刈り取りへの登録（issue 勘所2）** — 既定で見えなくなる以上、#541（76 セッション / 41.8GB）の
+   再発を防ぐ側もセットで入れる。
+   - `server/index.ts` `feedsSpawnWorker`: `hidden` のときだけ `scheduledSessions.register(id)`
+   - `server/routes/plugin-routes.ts` `spawnBackgroundChat`: 同じ理由で `hidden:true` を登録
+     （`PluginRouteDeps` にコールバックを 1 つ足す）
+   - 順序: `scheduledSessions` は `feedsSpawnWorker` より後で定義されるが、feeds の refresh を
+     起動するシステムタスクの登録はさらに後（`initUserTaskScheduler`）なので、呼ばれる時点では必ず初期化済み。
+
+### クライアント
+
+8. **`useSessions.ts`** — `Filter` に `"background"` を追加、`isBackground(s)`、
+   純粋関数 `matchesFilter(session, filter)`（`all` は背景を除外する、がここに書かれる）。
+
+9. **`sessionList.ts`** — `useSessionFilter` が `backgroundCount` も返す。空表示の文言は
+   フィルタ依存になるので `sessionListEmptyMessage(filter)` を切り出す。
+
+10. **`SessionFilters.vue`** — `Background` チップ。**件数 0 のときは出さない**
+    （コレクションを使わないユーザーに空のチップを見せない）。0 になった瞬間にチップが消えても
+    `All` は常にあるので詰まない。
+
+11. **`Sidebar.vue` / `SessionTabBar.vue`** — `backgroundCount` を渡す。Sidebar のハードコード
+    "No unread sessions" を `sessionListEmptyMessage` に置き換える。
+
+## テスト
+
+- `test/server/session/session-id-log.spec.ts`（改名）
+- `test/server/session/session-list.spec.ts` — 背景行が別枠で上限を持つこと、背景が増えても
+  チャットが押し出されないこと、cwd スコープ付きクエリでの挙動
+- `test/src/composables/useSessions.spec.ts` — `matchesFilter` の全分岐
+- `test/src/components/Sidebar.spec.ts` / `SessionTabBar.spec.ts` — チップの出し分けと既定の除外
+
+## やらないこと
+
+- **`onComplete` の接続（issue の PR 2）** — feeds エンジンは hidden ワーカー向けに
+  `onComplete` を受け取れるが、MulmoTerminal の runner は捨てている。繋ぐにはセッション層から
+  「終わった／失敗した」を渡す経路が要る。フィルタ案では失敗したセッション自体が Background チップの
+  裏に残って開けるので、PR 1 とセットである必然性がなくなった。別 PR とする。
+- 手動 Refresh（`hidden:false`）の扱いは変えない — デバッグできることが目的なので見えたまま。

--- a/server/index.ts
+++ b/server/index.ts
@@ -50,7 +50,7 @@ import { generateTitleFromTurns } from "./config/header-title.js";
 import { mountTerminalWebSockets } from "./routes/ws-routes.js";
 import { createConnectionHandlers } from "./session/pty-connection.js";
 import type { SpawnDeps } from "./session/spawn-deps.js";
-import { activity, aiTitles, devTerminalSessions, hiddenSessions, knownSessions, lastPrompts, ptys, sessionCwd } from "./session/registry.js";
+import { activity, aiTitles, backgroundMarkers, devTerminalSessions, knownSessions, lastPrompts, ptys, sessionCwd } from "./session/registry.js";
 import { runWithHiddenMarker } from "./session/hiddenMarker.js";
 import { createToolStores } from "./session/tool-store.js";
 import { writeDecisionDigest } from "./session/decision-digest-file.js";
@@ -402,6 +402,8 @@ mountAppRoutes(app, {
   noteWorkPhase: (id, event, toolName) => workPhaseTracker.note(id, event, toolName),
   maybeGenerateTitle,
   reap,
+  // Defined further down; reached only from a request, which cannot arrive before listen().
+  registerBackgroundSession: (id: string) => scheduledSessions.register(id),
   setWorking,
   setWaiting,
   publishActivity,
@@ -464,10 +466,16 @@ initAccountingBackend({ workspace: CLAUDE_CWD, pubsub });
 // the session layer. A MANUAL refresh spawns a VISIBLE session (hidden:false) the user can
 // watch; `onComplete` is honoured only for hidden (scheduled) workers, which MulmoTerminal
 // doesn't register yet, so it's unused for now. `roleId` is ignored (no role system).
+//
+// A hidden one goes on the scheduled-session retention (#541): the chat list keeps it behind
+// the Background filter, so nobody is watching for it to finish and nothing else would ever
+// end it. `scheduledSessions` is defined further down, which is safe because the system task
+// that calls this is registered later still (initUserTaskScheduler).
 const feedsSpawnWorker: AgentWorkerRunner = async ({ message, hidden }) => {
   const sessionId = randomUUID();
   try {
-    runWithHiddenMarker(hidden, sessionId, hiddenSessions, () => spawnClaudePty(sessionId, null, null, { initialPrompt: message }));
+    runWithHiddenMarker(hidden, sessionId, backgroundMarkers, () => spawnClaudePty(sessionId, null, null, { initialPrompt: message }));
+    if (hidden) scheduledSessions.register(sessionId);
     return { ok: true, chatId: sessionId };
   } catch (err) {
     return { ok: false, error: messageOf(err) };

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -74,6 +74,7 @@ export interface AppRouteDeps extends SessionActivityDeps {
   translateViaHiddenChat: ReturnType<typeof createTranslationWorker>["translateViaHiddenChat"];
   freshenRosterTitle: ReturnType<typeof createTitleManager>["freshenRosterTitle"];
   reap: (id: string) => void;
+  registerBackgroundSession: (id: string) => void;
 }
 
 // The channel a directory-config change is announced on.
@@ -98,7 +99,11 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
   // The GUI-plugin tool routes this server answers itself: spawnBackgroundChat,
   // manageAccounting, manageCollection (routes/plugin-routes.ts). ALL of them must precede
   // mountAllRoutes' /api/plugin/:toolName catch-all below, which would otherwise take them.
-  mountPluginRoutes(app, { spawnClaudePty: deps.spawnClaudePty, spawnCodexPty: deps.spawnCodexPty });
+  mountPluginRoutes(app, {
+    spawnClaudePty: deps.spawnClaudePty,
+    spawnCodexPty: deps.spawnCodexPty,
+    registerBackgroundSession: deps.registerBackgroundSession,
+  });
 
   // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
   // /api/plugin/presentHtml. MUST precede mountAllRoutes' /api/plugin/:toolName

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -10,7 +10,7 @@ import type { Express } from "express";
 import { CLAUDE_CWD, PORT } from "../config/env.js";
 import { messageOf } from "../errors.js";
 import { isRecord } from "../../common/isRecord.js";
-import { hiddenSessions } from "../session/registry.js";
+import { backgroundMarkers } from "../session/registry.js";
 import { runWithHiddenMarker } from "../session/hiddenMarker.js";
 import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../session/background-chat.js";
 import { codexifySkillSeed } from "../agents/codex-skills.js";
@@ -21,6 +21,11 @@ import type { SpawnClaudePty, SpawnCodexPty } from "../session/spawners.js";
 export interface PluginRouteDeps {
   spawnClaudePty: SpawnClaudePty;
   spawnCodexPty: SpawnCodexPty;
+  /** Put a hidden spawn on the scheduled-session retention (#541). Nobody watches a
+   *  background worker and the chat list keeps it behind a filter, so the hook-driven reap
+   *  is the only thing that would ever end it — and a worker blocked on a permission prompt
+   *  never fires the hook that starts it. */
+  registerBackgroundSession: (id: string) => void;
 }
 
 export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
@@ -28,8 +33,8 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
   // catch-all), it needs server internals — it spawns a brand-new interactive Claude
   // terminal session, seeded with `message`, that the user can open from the sidebar.
   // `role` is ignored (MulmoTerminal has no roles). `hidden:true` marks it a background
-  // worker: it still lists in the sidebar but never renders bold/unread when it
-  // finishes. `draft:true` makes `message` an editable DRAFT — typed into the input box
+  // worker: it still lists in the sidebar, but behind the Background filter and never
+  // bold/unread. `draft:true` makes `message` an editable DRAFT — typed into the input box
   // but NOT auto-submitted (the collection-plugin's startNewChatDraft / template cards),
   // so the user reviews and presses Enter.
   app.post("/api/plugin/spawnBackgroundChat", (req, res) => {
@@ -42,12 +47,13 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
     // typed into its input box. codex has no editable-draft path (no stable TUI ready-marker), so its
     // seed always auto-runs as codex's positional first-turn prompt, with the GUI MCP attached.
     try {
-      runWithHiddenMarker(hidden, sessionId, hiddenSessions, () => {
+      runWithHiddenMarker(hidden, sessionId, backgroundMarkers, () => {
         const mode = spawnModeFor(agent, draft);
         if (mode === "codex-run") deps.spawnCodexPty(sessionId, null, null, CLAUDE_CWD, true, { initialPrompt: codexifySkillSeed(message) });
         else if (mode === "claude-draft") deps.spawnClaudePty(sessionId, null, null, { draft: message });
         else deps.spawnClaudePty(sessionId, null, null, { initialPrompt: message });
       });
+      if (hidden) deps.registerBackgroundSession(sessionId);
     } catch (err) {
       console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);
       return res.json({ message: `Failed to spawn a new session: ${messageOf(err)}` });

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -15,8 +15,10 @@ import {
   activity,
   activityStateHydrated,
   aiTitles,
+  backgroundSessionsHydrated,
   devTerminalSessions,
   devTerminalSessionsHydrated,
+  isBackgroundSession,
   lastPrompts,
   lastResponses,
   translationWorkerIds,
@@ -40,6 +42,9 @@ import { sessionDetailView } from "../session/session-detail-view.js";
 // Only the most-recent N sessions are listed in the sidebar; older ones aren't
 // read or parsed, keeping /api/sessions cheap for projects with many sessions.
 const SESSION_LIST_LIMIT = 50;
+// Background workers are capped separately (see selectSessionRows) and are behind a filter
+// the user has to press, so only the recent handful is worth listing at all.
+const BACKGROUND_SESSION_LIST_LIMIT = 10;
 // Cap on ids per /api/activity request — a grid can't show more cells than this, and
 // it bounds the query string a client can make us parse.
 const ACTIVITY_IDS_LIMIT = 200;
@@ -125,8 +130,11 @@ async function sessionList(req: Request, res: Response) {
     const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
     const includePending = !cwdParam;
     // Wait for the persisted grid-session set before filtering (below), so a chat
-    // request racing server boot can't leak previously-hidden grid transcripts.
+    // request racing server boot can't leak previously-hidden grid transcripts. The
+    // background set is awaited for BOTH queries — it decides a flag on the row rather
+    // than whether the row is listed, and that flag is answered either way.
     if (includePending) await devTerminalSessionsHydrated;
+    await backgroundSessionsHydrated;
     const dir = projectSessionsDir(cwd);
     let files: string[] = [];
     try {
@@ -146,8 +154,10 @@ async function sessionList(req: Request, res: Response) {
     const top = selectSessionRows([...onDiskStats, ...pending], {
       isInternalHelper: (id) => translationWorkerIds.has(id) || isProbeSessionId(id),
       isDevTerminal: (id) => devTerminalSessions.has(id),
+      isBackground: (id) => isBackgroundSession(id),
       includePending,
       limit: SESSION_LIST_LIMIT,
+      backgroundLimit: BACKGROUND_SESSION_LIST_LIMIT,
     });
     const sessions = (
       await Promise.all(

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -13,7 +13,7 @@ import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
-import { devTerminalSessionLine, parseDevTerminalSessionIds } from "./dev-terminal-sessions.js";
+import { parseSessionIdLog, sessionIdLogLine } from "./session-id-log.js";
 import { devTerminalCwdLine, hydrateCwdsInto } from "./dev-terminal-cwds.js";
 import { parseSessionToolGroups, sessionToolGroupLine, TOOL_GROUP_RESET, type SessionToolGroup } from "./session-tool-groups.js";
 import type { ToolGroup } from "../../common/toolGroups.js";
@@ -42,10 +42,10 @@ export const knownSessions = new Map<string, KnownSession>(); // id -> { created
 // back to the directory's default, same as one this server never started.
 export const launchChoices = new Map<string, DirModelChoice>(); // id -> { provider, model }
 
-// Sessions spawned as hidden background workers (spawnBackgroundChat hidden:true).
-// They list normally but never render bold/unread. Process-lifetime only (not
-// persisted) — and tied to `activity`'s lifecycle in reap() so a finished hidden
-// worker that stays `waiting` doesn't lose its hidden flag and re-bold.
+// Sessions spawned as hidden background workers (spawnBackgroundChat hidden:true) that are
+// still LIVE. Process-lifetime only, and tied to `activity`'s lifecycle in reap(). Ask
+// `isBackgroundSession()` rather than this set when the question is "does this row belong
+// behind the Background filter" — that survives the reap and a restart; this does not.
 export const hiddenSessions = new Set<string>(); // id
 
 // Latest MEANINGFUL user prompt per session (from the UserPromptSubmit hook), shown
@@ -92,6 +92,37 @@ export const claimedCodexRollouts = new Set<string>();
 // a transient internal helper, not a chat the user should see in the sidebar.
 export const translationWorkerIds = new Set<string>();
 
+const isValidSessionId = (id: string) => SESSION_ID_RE.test(id);
+
+// Hydrate one id log once at boot (best-effort — absent on first run / unreadable => empty).
+// Exposed as a promise so readers/writers can wait for it: a request served (or a mark
+// persisted) before this resolves would otherwise see an empty set and either leak the
+// sessions the log exists to keep out or clobber the file with a snapshot missing the
+// on-disk ids.
+function hydrateIdLog(file: string, into: Set<string>): Promise<void> {
+  return (async () => {
+    try {
+      for (const id of parseSessionIdLog(await fs.readFile(file, "utf8"), isValidSessionId)) into.add(id);
+    } catch {
+      // absent on first run / unreadable => nothing remembered
+    }
+  })();
+}
+
+// Appended, never rewritten: another instance shares these files, and a read-merge-write
+// loses whichever of the two finishes first however small the window is made. An append
+// needs no read, and nothing here is ever removed. Each log gets its own chain so its
+// writes stay ordered and a failure is logged without stopping the next one.
+function idLogAppender(file: string, label: string): (id: string) => void {
+  let persist: Promise<void> = Promise.resolve();
+  return (id: string) => {
+    persist = persist
+      .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+      .then(() => fs.appendFile(file, sessionIdLogLine(id)))
+      .catch((e) => console.error(`[${label}] failed to persist: ${messageOf(e)}`));
+  };
+}
+
 // Session ids that belong to the multi-terminal GRID — dev terminals, spawned with
 // gui=0 (no GUI MCP; see the ?gui handling in the WS connection handler). They're
 // FILTERED OUT of the chat sidebar's /api/sessions so a grid terminal never surfaces
@@ -103,38 +134,8 @@ export const translationWorkerIds = new Set<string>();
 // resume picker (/api/sessions?cwd=…) must keep listing these so they stay resumable.
 export const devTerminalSessions = new Set<string>();
 const DEV_TERMINAL_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "dev-terminal-sessions.json");
-
-// Hydrate the set once at boot (best-effort — absent on first run / unreadable =>
-// empty). Exposed as a promise so readers/writers can wait for it: a request served
-// (or a mark persisted) before this resolves would otherwise see an empty set and
-// either leak hidden grid transcripts into chat or clobber the file with a snapshot
-// missing the on-disk ids.
-const isValidSessionId = (id: string) => SESSION_ID_RE.test(id);
-
-// Best-effort read of the shared file: absent or unreadable => nothing.
-async function readPersistedDevTerminalIds(): Promise<string[]> {
-  try {
-    return parseDevTerminalSessionIds(await fs.readFile(DEV_TERMINAL_SESSIONS_FILE, "utf8"), isValidSessionId);
-  } catch {
-    return [];
-  }
-}
-
-export const devTerminalSessionsHydrated: Promise<void> = (async () => {
-  for (const id of await readPersistedDevTerminalIds()) devTerminalSessions.add(id);
-})();
-
-// Appended, never rewritten: another instance shares this file, and a read-merge-write
-// loses whichever of the two finishes first however small the window is made. An append
-// needs no read, and nothing here is ever removed. Chained so our own writes stay ordered
-// and a failure is logged without stopping the next one.
-let devTerminalPersist: Promise<void> = Promise.resolve();
-function appendDevTerminalSession(id: string): void {
-  devTerminalPersist = devTerminalPersist
-    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
-    .then(() => fs.appendFile(DEV_TERMINAL_SESSIONS_FILE, devTerminalSessionLine(id)))
-    .catch((e) => console.error(`[dev-terminal-sessions] failed to persist: ${messageOf(e)}`));
-}
+export const devTerminalSessionsHydrated = hydrateIdLog(DEV_TERMINAL_SESSIONS_FILE, devTerminalSessions);
+const appendDevTerminalSession = idLogAppender(DEV_TERMINAL_SESSIONS_FILE, "dev-terminal-sessions");
 
 // Record a grid/dev-terminal session id, then persist. A no-op once the id is known,
 // so repeated reattaches of the same cell — or a reconnect after a reboot — don't
@@ -147,6 +148,46 @@ export function markDevTerminalSession(id: string, cwd?: string): void {
   devTerminalSessions.add(id);
   appendDevTerminalSession(id);
 }
+
+// Session ids spawned as background workers: the scheduled collection refresh, and any
+// `spawnBackgroundChat hidden:true`. The chat list keeps them, but behind the Background
+// filter rather than among the user's own chats (#1060).
+//
+// Persisted for the same reason the grid's set is: `hiddenSessions` is dropped on reap and
+// gone after a restart, so a live-only flag would put every finished worker BACK among the
+// chats the moment it completed — the one state the user is guaranteed to see it in.
+const backgroundSessions = new Set<string>();
+const BACKGROUND_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "background-sessions.json");
+export const backgroundSessionsHydrated = hydrateIdLog(BACKGROUND_SESSIONS_FILE, backgroundSessions);
+const appendBackgroundSession = idLogAppender(BACKGROUND_SESSIONS_FILE, "background-sessions");
+
+function markBackgroundSession(id: string): void {
+  if (!isValidSessionId(id) || backgroundSessions.has(id)) return;
+  backgroundSessions.add(id);
+  appendBackgroundSession(id);
+}
+
+/** Does this session belong behind the Background filter? Live workers answer from
+ *  `hiddenSessions`, everything else from the persisted log — a session that has been
+ *  background once stays background. */
+export function isBackgroundSession(id: string): boolean {
+  return hiddenSessions.has(id) || backgroundSessions.has(id);
+}
+
+/** What a hidden spawn marks itself with (see runWithHiddenMarker). Both halves of "hidden"
+ *  are set from ONE place because there are two spawn sites, and a site that remembered the
+ *  live flag but not the log would produce a worker that is background until it finishes and
+ *  an ordinary chat afterwards. `delete` only undoes the live half: the log is append-only,
+ *  and a spawn that threw never wrote a transcript, so its id never reaches a listing. */
+export const backgroundMarkers = {
+  add(id: string): void {
+    hiddenSessions.add(id);
+    markBackgroundSession(id);
+  },
+  delete(id: string): void {
+    hiddenSessions.delete(id);
+  },
+};
 
 // Where each grid session was started, for the sessions this process did not spawn (#1021). Live
 // ones answer from `ptys`, which is the truer source — it knows where claude actually runs.

--- a/server/session/session-id-log.ts
+++ b/server/session/session-id-log.ts
@@ -1,20 +1,21 @@
-// The set of grid/dev-terminal session ids, as it is read from and written back to disk.
+// A set of session ids, as it is read from and written back to disk. Two of them exist: the
+// grid/dev-terminal ids (keeping a grid cell's transcript out of the chat sidebar — the "chat
+// hijacked my multi-terminal session" bug) and the background-worker ids (keeping a scheduled
+// data sync behind the Background filter). Either way, an id going missing brings the noise
+// back.
 //
-// The set exists to keep a grid cell's transcript out of the chat sidebar — the "chat
-// hijacked my multi-terminal session" bug — so an id going missing brings that back.
-//
-// It is shared between INSTANCES, not just between requests. MULMOTERMINAL_HOME is
+// The file is shared between INSTANCES, not just between requests. MULMOTERMINAL_HOME is
 // ~/.mulmoterminal for every server on the machine, and launching twice is the ordinary way
 // to get two: the launcher falls back to another port when the default is busy.
 //
-// So the file is an APPEND LOG, one id per line, rather than a rewritten snapshot. That is
-// what makes it safe without a lock: a snapshot has to be read, merged and written back, and
-// two instances doing that at once lose whichever finishes first — narrowing the window does
-// not close it. Appending needs no read at all, and an id is the only thing ever added
-// (nothing removes one), so there is no ordering to get wrong (#611 B1).
+// So it is an APPEND LOG, one id per line, rather than a rewritten snapshot. That is what
+// makes it safe without a lock: a snapshot has to be read, merged and written back, and two
+// instances doing that at once lose whichever finishes first — narrowing the window does not
+// close it. Appending needs no read at all, and an id is the only thing ever added (nothing
+// removes one), so there is no ordering to get wrong (#611 B1).
 //
-// The old format was a single JSON array. It is still read, so an existing file keeps
-// working and simply stops being rewritten.
+// The dev-terminal file's old format was a single JSON array. It is still read, so an
+// existing file keeps working and simply stops being rewritten.
 
 /** One line of the log: a bare id, or the whole legacy JSON array. */
 function idsFromLine(line: string, isValidId: (id: string) => boolean): string[] {
@@ -35,7 +36,7 @@ function idsFromLine(line: string, isValidId: (id: string) => boolean): string[]
  * The ids a file holds, in either format. Anything unusable as a session id is dropped
  * rather than carried along — these end up as filenames elsewhere.
  */
-export function parseDevTerminalSessionIds(contents: string, isValidId: (id: string) => boolean): string[] {
+export function parseSessionIdLog(contents: string, isValidId: (id: string) => boolean): string[] {
   const ids = contents.split("\n").flatMap((line) => idsFromLine(line, isValidId));
   return [...new Set(ids)];
 }
@@ -43,12 +44,12 @@ export function parseDevTerminalSessionIds(contents: string, isValidId: (id: str
 /**
  * What to append for a newly marked id.
  *
- * The newline goes BEFORE the id, not after. An existing file holds the legacy JSON array
+ * The newline goes BEFORE the id, not after. An existing file may hold the legacy JSON array
  * with no trailing newline, so appending `<id>\n` would weld the first id onto the end of
  * that array — the line then parses as neither, and every previously hidden session is lost
  * on the next hydrate. Leading it instead means an appended id always starts its own line,
  * whatever the file ended with.
  */
-export function devTerminalSessionLine(id: string): string {
+export function sessionIdLogLine(id: string): string {
   return `\n${id}`;
 }

--- a/server/session/session-list.ts
+++ b/server/session/session-list.ts
@@ -14,22 +14,33 @@ export interface SessionRowFilter {
   isInternalHelper: (id: string) => boolean;
   /** Multi-terminal GRID sessions. */
   isDevTerminal: (id: string) => boolean;
+  /** Background workers (scheduled collection refresh, hidden spawnBackgroundChat). Listed,
+   *  but the client shows them under their own filter rather than among the chats. */
+  isBackground: (id: string) => boolean;
   /** True for the unscoped (chat sidebar) query, false for a cwd-scoped one. */
   includePending: boolean;
   limit: number;
+  /** Cap for background rows, counted separately from `limit`. */
+  backgroundLimit: number;
 }
 
 /** The rows a listing should render: newest first, capped, with the hidden kinds dropped.
  *  The dev-terminal exclusion applies ONLY to the unscoped chat query — the grid's own
  *  resume picker passes ?cwd= and must keep listing its sessions, or they stop being
  *  resumable. Pure so that rule can be pinned; it is one boolean away from silently
- *  hiding the grid's own sessions from itself. */
+ *  hiding the grid's own sessions from itself.
+ *
+ *  Background rows get their OWN cap rather than competing for `limit`. The client hides
+ *  them by default, so under one shared cap a busy collection schedule would push real
+ *  chats off the end — and all the user would see is a list that quietly got shorter. */
 export function selectSessionRows(rows: readonly SessionRow[], filter: SessionRowFilter): SessionRow[] {
-  return rows
+  const visible = rows
     .filter((row) => !filter.isInternalHelper(row.id))
     .filter((row) => !filter.includePending || !filter.isDevTerminal(row.id))
-    .sort((a, b) => b.mtime - a.mtime)
-    .slice(0, filter.limit);
+    .sort((a, b) => b.mtime - a.mtime);
+  const chats = visible.filter((row) => !filter.isBackground(row.id)).slice(0, filter.limit);
+  const background = visible.filter((row) => filter.isBackground(row.id)).slice(0, filter.backgroundLimit);
+  return [...chats, ...background].sort((a, b) => b.mtime - a.mtime);
 }
 
 /** The session ids an /api/activity poll may ask about: well-formed ones only, capped so a

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -25,7 +25,7 @@ import {
 import { createFileCache, type FileStamp } from "./file-cache.js";
 import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
 import { sessionListTitle } from "./sessionListTitle.js";
-import { activity, aiTitles, codexRolloutIds, hiddenSessions, knownSessions } from "./registry.js";
+import { activity, aiTitles, codexRolloutIds, isBackgroundSession, knownSessions } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
 import { lastTurnFromClaudeParsed, lastTurnFromCodexRolloutDocs, EMPTY_TURN, type LastTurn } from "./last-turn.js";
 import { forEachJsonlRecord, readTailRecords } from "../infra/jsonl-file.js";
@@ -250,7 +250,7 @@ export async function readSessionMeta(dir: string, file: string): Promise<Sessio
     working: a?.working ?? false,
     waiting: a?.waiting ?? false,
     event: a?.event ?? null,
-    hidden: hiddenSessions.has(id),
+    hidden: isBackgroundSession(id),
   };
 }
 
@@ -278,7 +278,7 @@ export function collectPendingSessions(onDisk: Set<string>, includePending: bool
     known,
     onDisk,
     (id) => activity.get(id),
-    (id) => hiddenSessions.has(id),
+    (id) => isBackgroundSession(id),
   );
   persisted.forEach((id) => knownSessions.delete(id));
   return keep;

--- a/server/session/session-tool-groups.ts
+++ b/server/session/session-tool-groups.ts
@@ -11,7 +11,7 @@
 // running in tmux — already past its ListTools and with no reason to call again. The panel
 // would then decide the cell has no Canvas and hide it on a session that is still drawing.
 //
-// Same APPEND LOG shape as dev-terminal-sessions.ts, for the same reason: MULMOTERMINAL_HOME
+// Same APPEND LOG shape as session-id-log.ts, for the same reason: MULMOTERMINAL_HOME
 // is shared by every server on the machine, so a read-merge-write loses whichever of two
 // instances finishes first. Nothing is ever removed, so appending needs no read.
 
@@ -71,7 +71,7 @@ export function parseSessionToolGroups(contents: string, isValidId: (id: string)
 
 /**
  * What to append for a newly learned pair. The newline leads rather than trails for the same
- * reason it does in dev-terminal-sessions.ts: whatever the file ended with, an appended entry
+ * reason it does in session-id-log.ts: whatever the file ended with, an appended entry
  * starts its own line, so a file that was cut off mid-write costs one entry and not the rest.
  */
 export function sessionToolGroupLine(sessionId: string, group: ToolGroup | typeof TOOL_GROUP_RESET): string {

--- a/server/session/task-push.ts
+++ b/server/session/task-push.ts
@@ -8,7 +8,7 @@ import { sendWebPush } from "../infra/web-push.js";
 import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
 import { buildPushText } from "./activity-hook.js";
 import type { PushKind } from "../../common/pushKinds.js";
-import { aiTitles, hiddenSessions, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
+import { aiTitles, isBackgroundSession, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
 import { sessionLastTurn, LAST_RESPONSE_MAX } from "./session-reads.js";
 import { buildPushDetail, pushWhere, shouldSuppressPush, wantsPushKind } from "./taskPushRules.js";
 
@@ -36,8 +36,11 @@ async function latestReply(sessionId: string, cwd: string): Promise<string | nul
 export async function notifyTaskFinished(sessionId: string, kind: PushKind, message: string, uiPort: string): Promise<void> {
   if (!wantsPushKind(getPushEnabled(), getPushKinds(), kind)) return;
   // Internal helper turns flow through /api/hook with active=false too — the suppression gate
-  // keeps those (hidden background workers, translation workers) from ever reaching the phone.
-  if (shouldSuppressPush(hiddenSessions.has(sessionId), translationWorkerIds.has(sessionId))) return;
+  // keeps those (background workers, translation workers) from ever reaching the phone. Asked
+  // of the DURABLE predicate, not the live set: tmux keeps a worker's agent running across a
+  // server restart, and the live set does not survive one — so the gate would open for exactly
+  // the long-running scheduled refresh it exists to silence.
+  if (shouldSuppressPush(isBackgroundSession(sessionId), translationWorkerIds.has(sessionId))) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = pushWhere(cwd);
   const reply = kind === "finished" && cwd ? await latestReply(sessionId, cwd) : null;

--- a/server/session/taskPushRules.ts
+++ b/server/session/taskPushRules.ts
@@ -21,10 +21,11 @@ export function buildPushDetail(input: PushDetailInput): string {
   return input.reply || input.lastPrompt || input.aiTitle || "";
 }
 
-// Hidden background workers and translation workers aren't real user tasks, so a turn ending
-// on one must never reach the phone.
-export function shouldSuppressPush(hidden: boolean, translationWorker: boolean): boolean {
-  return hidden || translationWorker;
+// Background workers and translation workers aren't real user tasks, so a turn ending on one
+// must never reach the phone. "never" is why the caller answers `background` from the durable
+// marking rather than from which sessions this process happens to have spawned.
+export function shouldSuppressPush(background: boolean, translationWorker: boolean): boolean {
+  return background || translationWorker;
 }
 
 // Whether the user asked to hear about THIS moment (#850). Two independent answers: the master

--- a/src/components/SessionFilters.vue
+++ b/src/components/SessionFilters.vue
@@ -2,12 +2,17 @@
 import type { Filter } from "../composables/useSessions";
 import FilterChip from "./FilterChip.vue";
 
-// The All / Unread chips + recency re-sort button, shared by the vertical
-// Sidebar and the horizontal SessionTabBar. `alignRefreshEnd` pushes the sort
-// button to the far end of the row (the vertical sidebar's full-width layout).
+// The filter chips + recency re-sort button, shared by the vertical Sidebar and the
+// horizontal SessionTabBar. `alignRefreshEnd` pushes the sort button to the far end of
+// the row (the vertical sidebar's full-width layout).
+//
+// Background appears only once there is one to show, so a setup with no collections never
+// carries a permanently empty chip — and stays while it is the ACTIVE chip, or the last
+// worker finishing would pull the selected filter out from under the user.
 defineProps<{
   filter: Filter;
   unreadCount: number;
+  backgroundCount: number;
   alignRefreshEnd?: boolean;
 }>();
 const emit = defineEmits<{
@@ -19,6 +24,13 @@ const emit = defineEmits<{
 <template>
   <FilterChip label="All" :active="filter === 'all'" @click="emit('update:filter', 'all')" />
   <FilterChip label="Unread" :count="unreadCount" :active="filter === 'unread'" @click="emit('update:filter', 'unread')" />
+  <FilterChip
+    v-if="backgroundCount > 0 || filter === 'background'"
+    label="Background"
+    :count="backgroundCount"
+    :active="filter === 'background'"
+    @click="emit('update:filter', 'background')"
+  />
   <button
     class="cursor-pointer border-0 bg-transparent text-[14px] leading-none text-muted hover:text-fg"
     :class="{ 'ml-auto': alignRefreshEnd }"

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -8,7 +8,7 @@ import SessionFilters from "./SessionFilters.vue";
 const props = defineProps<SessionListProps>();
 const emit = defineEmits<SessionListEmits>();
 
-const { unreadCount, filteredSessions, isUnread } = useSessionFilter(props);
+const { unreadCount, backgroundCount, filteredSessions, isUnread } = useSessionFilter(props);
 
 // The horizontal bar never scrolls — tabs flex to share the available width.
 // Cap to the most-recent N (sessions are already sorted by recency) so they
@@ -38,7 +38,13 @@ const visibleSessions = computed(() => filteredSessions.value.slice(0, MAX_TABS)
     </button>
 
     <div class="flex shrink-0 items-center gap-1.5">
-      <SessionFilters :filter="filter" :unread-count="unreadCount" @update:filter="emit('update:filter', $event)" @refresh="emit('refresh')" />
+      <SessionFilters
+        :filter="filter"
+        :unread-count="unreadCount"
+        :background-count="backgroundCount"
+        @update:filter="emit('update:filter', $event)"
+        @refresh="emit('refresh')"
+      />
     </div>
 
     <div class="flex min-w-0 flex-1 gap-1.5 overflow-hidden">

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useSessionFilter, type SessionListEmits, type SessionListProps } from "../composables/sessionList";
+import { sessionListEmptyMessage, useSessionFilter, type SessionListEmits, type SessionListProps } from "../composables/sessionList";
 import SessionFilters from "./SessionFilters.vue";
 import { relativeTime } from "./cellDisplay";
 
@@ -15,7 +15,7 @@ const props = defineProps<
 >();
 const emit = defineEmits<SessionListEmits>();
 
-const { unreadCount, filteredSessions, isUnread } = useSessionFilter(props);
+const { unreadCount, backgroundCount, filteredSessions, isUnread } = useSessionFilter(props);
 </script>
 
 <template>
@@ -52,6 +52,7 @@ const { unreadCount, filteredSessions, isUnread } = useSessionFilter(props);
       <SessionFilters
         :filter="filter"
         :unread-count="unreadCount"
+        :background-count="backgroundCount"
         align-refresh-end
         @update:filter="emit('update:filter', $event)"
         @refresh="emit('refresh')"
@@ -63,7 +64,7 @@ const { unreadCount, filteredSessions, isUnread } = useSessionFilter(props);
       {{ error }}
     </div>
     <div v-else-if="sessions.length === 0" class="px-3.5 py-3 text-[13px] text-muted">No sessions yet</div>
-    <div v-else-if="filteredSessions.length === 0" class="px-3.5 py-3 text-[13px] text-muted">No unread sessions</div>
+    <div v-else-if="filteredSessions.length === 0" class="px-3.5 py-3 text-[13px] text-muted">{{ sessionListEmptyMessage(filter) }}</div>
 
     <ul v-else class="m-0 flex-1 list-none overflow-y-auto p-0">
       <li

--- a/src/composables/sessionList.ts
+++ b/src/composables/sessionList.ts
@@ -1,5 +1,5 @@
 import { computed } from "vue";
-import { isUnread, type Session, type Filter } from "./useSessions";
+import { isBackground, isUnread, matchesFilter, type Session, type Filter } from "./useSessions";
 
 // The event contract App.vue wires to both session-list layouts (the vertical
 // Sidebar and the horizontal SessionTabBar); v-model:filter drives update:filter.
@@ -18,12 +18,22 @@ export interface SessionListProps {
   filter: Filter;
 }
 
-// The Unread chip's count and the filter-applied list, shared by both layouts.
+// The chips' counts and the filter-applied list, shared by both layouts.
 // The horizontal bar caps `filteredSessions` to its most-recent tabs itself.
 // `isUnread` rides along because both layouts also mark rows with it — one import
 // gets a layout everything the session-list contract offers.
 export function useSessionFilter(props: Pick<SessionListProps, "sessions" | "filter">) {
   const unreadCount = computed(() => props.sessions.filter(isUnread).length);
-  const filteredSessions = computed(() => (props.filter === "unread" ? props.sessions.filter(isUnread) : props.sessions));
-  return { unreadCount, filteredSessions, isUnread };
+  const backgroundCount = computed(() => props.sessions.filter(isBackground).length);
+  const filteredSessions = computed(() => props.sessions.filter((s) => matchesFilter(s, props.filter)));
+  return { unreadCount, backgroundCount, filteredSessions, isUnread };
+}
+
+// What to say when the server returned sessions but the chip matched none of them. The
+// default chip can land here too: a project whose only sessions are background workers has
+// rows to list and no chats, which "No sessions yet" would report as an empty project.
+export function sessionListEmptyMessage(filter: Filter): string {
+  if (filter === "unread") return "No unread sessions";
+  if (filter === "background") return "No background sessions";
+  return "No chat sessions";
 }

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -10,7 +10,8 @@ export interface Session {
   /** The hook that set the current state ("Stop" | "Notification" | …), or null —
    *  splits `waiting` into done (Stop) vs blocked (Notification). */
   event?: string | null;
-  /** A hidden background worker (spawnBackgroundChat hidden:true) — listed, but
+  /** A background worker: a scheduled collection refresh, or spawnBackgroundChat
+   *  hidden:true. Listed under the Background filter rather than among the chats, and
    *  never treated as unread/bold. */
   hidden?: boolean;
   /** "codex" for a codex session (from ~/.codex); absent = a Claude session. Drives the
@@ -18,14 +19,31 @@ export interface Session {
   agent?: "codex";
 }
 
-// "unread" = a session whose `waiting` flag is set, EXCEPT hidden background
-// workers (mulmoclaude's unread, minus the background noise).
-export type Filter = "all" | "unread";
+// The session-list chips, mirroring mulmoclaude's history filters: "unread" is a session
+// whose `waiting` flag is set, "background" the machine-started workers.
+export type Filter = "all" | "unread" | "background";
 
 /** A session that should draw the user's attention (bold + Unread filter): waiting
- *  for input, and not a hidden background worker. */
+ *  for input, and not a background worker. */
 export function isUnread(s: Session): boolean {
   return !!s.waiting && !s.hidden;
+}
+
+/** A session nobody started by hand: a scheduled collection refresh, or a plugin's hidden
+ *  spawnBackgroundChat. */
+export function isBackground(s: Session): boolean {
+  return !!s.hidden;
+}
+
+/** Which rows a chip shows. "all" means all CHATS — the background workers are the ones
+ *  the user did not start, and letting them share the default list is the clutter this
+ *  filter exists to undo (#1060). They stay one click away rather than being dropped:
+ *  a MulmoTerminal session is a live terminal, so a row the user cannot reach is also a
+ *  process they cannot stop. */
+export function matchesFilter(s: Session, filter: Filter): boolean {
+  if (filter === "unread") return isUnread(s);
+  if (filter === "background") return isBackground(s);
+  return !isBackground(s);
 }
 
 // Merge a freshly-fetched list into the displayed one while keeping the order

--- a/test/server/session/session-id-log.spec.ts
+++ b/test/server/session/session-id-log.spec.ts
@@ -1,33 +1,33 @@
 import { describe, it, expect } from "vitest";
 
-import { parseDevTerminalSessionIds, devTerminalSessionLine } from "../../../server/session/dev-terminal-sessions.js";
+import { parseSessionIdLog, sessionIdLogLine } from "../../../server/session/session-id-log.js";
 
 const A = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
 const B = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
 const C = "16fd2706-8baf-433b-82eb-8c7fada847da";
 const isUuid = (id: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
-const parse = (contents: string) => parseDevTerminalSessionIds(contents, isUuid);
+const parse = (contents: string) => parseSessionIdLog(contents, isUuid);
 
-describe("devTerminalSessionLine", () => {
+describe("sessionIdLogLine", () => {
   // Leading, not trailing: the legacy file ends WITHOUT a newline, so a trailing one would
   // weld the first appended id onto the end of the JSON array.
   it("starts the record on its own line", () => {
-    expect(devTerminalSessionLine(A)).toBe(`\n${A}`);
+    expect(sessionIdLogLine(A)).toBe(`\n${A}`);
   });
 
   it("round-trips through the parser", () => {
-    expect(parse(devTerminalSessionLine(A) + devTerminalSessionLine(B))).toEqual([A, B]);
+    expect(parse(sessionIdLogLine(A) + sessionIdLogLine(B))).toEqual([A, B]);
   });
 
   // The regression Codex caught: a trailing newline welds the first id onto the array.
   it("does not weld the first id onto a legacy array", () => {
     const welded = JSON.stringify([A]) + `${C}\n`;
     expect(parse(welded)).not.toContain(A);
-    expect(parse(JSON.stringify([A]) + devTerminalSessionLine(C))).toEqual([A, C]);
+    expect(parse(JSON.stringify([A]) + sessionIdLogLine(C))).toEqual([A, C]);
   });
 });
 
-describe("parseDevTerminalSessionIds", () => {
+describe("parseSessionIdLog", () => {
   describe("the append log", () => {
     it("reads one id per line", () => {
       expect(parse(`${A}\n${B}\n`)).toEqual([A, B]);
@@ -80,17 +80,17 @@ describe("parseDevTerminalSessionIds", () => {
     // trailing newline, so the appended record has to bring its own. Getting this wrong
     // loses every id that was already hidden — the whole point of the file.
     it("reads a legacy array appended to exactly as the writer writes it", () => {
-      const onDisk = JSON.stringify([A, B]) + devTerminalSessionLine(C);
+      const onDisk = JSON.stringify([A, B]) + sessionIdLogLine(C);
       expect(parse(onDisk)).toEqual([A, B, C]);
     });
 
     it("survives several appends onto a legacy file", () => {
-      const onDisk = JSON.stringify([A]) + devTerminalSessionLine(B) + devTerminalSessionLine(C);
+      const onDisk = JSON.stringify([A]) + sessionIdLogLine(B) + sessionIdLogLine(C);
       expect(parse(onDisk)).toEqual([A, B, C]);
     });
 
     it("reads appends onto an empty file", () => {
-      expect(parse(devTerminalSessionLine(A) + devTerminalSessionLine(B))).toEqual([A, B]);
+      expect(parse(sessionIdLogLine(A) + sessionIdLogLine(B))).toEqual([A, B]);
     });
 
     it("does not lose the legacy ids when an appended one repeats them", () => {

--- a/test/server/session/session-list.spec.ts
+++ b/test/server/session/session-list.spec.ts
@@ -17,8 +17,10 @@ const ids = (rows: SessionRow[]) => rows.map((r) => r.id);
 const filter = (over: Partial<Parameters<typeof selectSessionRows>[1]> = {}) => ({
   isInternalHelper: never,
   isDevTerminal: never,
+  isBackground: never,
   includePending: true,
   limit: 50,
+  backgroundLimit: 10,
   ...over,
 });
 
@@ -69,6 +71,43 @@ describe("selectSessionRows", () => {
   it("filters before capping, so a hidden row cannot consume a slot", () => {
     const rows = [disk("worker", 9), disk("a", 2), disk("b", 1)];
     expect(ids(selectSessionRows(rows, filter({ isInternalHelper: (id) => id === "worker", limit: 2 })))).toEqual(["a", "b"]);
+  });
+
+  // Background workers are LISTED — the client puts them behind a chip. Dropping them here
+  // would take away the only way to open one, and a MulmoTerminal session is a live
+  // terminal: a row you cannot reach is a process you cannot stop (#1060).
+  it("keeps background rows, in recency order with the chats", () => {
+    const rows = [disk("chat", 2), disk("refresh", 3)];
+    expect(ids(selectSessionRows(rows, filter({ isBackground: (id) => id === "refresh" })))).toEqual(["refresh", "chat"]);
+  });
+
+  // The rule that pays for the separate cap: the client hides background rows by default, so
+  // under one shared cap a busy refresh schedule empties the chat list and the screen just
+  // looks like a project with no history.
+  it("does not let background rows consume the chat cap", () => {
+    const rows = [disk("bg1", 9), disk("bg2", 8), disk("a", 2), disk("b", 1)];
+    const isBackground = (id: string) => id.startsWith("bg");
+    expect(ids(selectSessionRows(rows, filter({ isBackground, limit: 2 })))).toEqual(["bg1", "bg2", "a", "b"]);
+  });
+
+  it("caps background rows on their own limit, keeping the newest", () => {
+    const rows = [disk("bg1", 9), disk("bg2", 8), disk("bg3", 7), disk("a", 1)];
+    const isBackground = (id: string) => id.startsWith("bg");
+    expect(ids(selectSessionRows(rows, filter({ isBackground, backgroundLimit: 2 })))).toEqual(["bg1", "bg2", "a"]);
+  });
+
+  it("lists no background rows at a zero background limit, and keeps the chats", () => {
+    const rows = [disk("bg", 9), disk("a", 1)];
+    expect(ids(selectSessionRows(rows, filter({ isBackground: (id) => id === "bg", backgroundLimit: 0 })))).toEqual(["a"]);
+  });
+
+  // Both exclusions apply to the same row set: a grid session that is also a background
+  // worker is still a grid session, and the chat listing must not get it back through the
+  // background bucket.
+  it("still hides a grid session from chat when it is also a background worker", () => {
+    const rows = [disk("chat", 1), disk("grid", 3)];
+    const only = { isDevTerminal: (id: string) => id === "grid", isBackground: (id: string) => id === "grid" };
+    expect(ids(selectSessionRows(rows, filter(only)))).toEqual(["chat"]);
   });
 
   it("does not mutate the caller's array", () => {

--- a/test/server/session/session-tool-groups.spec.ts
+++ b/test/server/session/session-tool-groups.spec.ts
@@ -44,7 +44,7 @@ describe("parseSessionToolGroups", () => {
 });
 
 describe("sessionToolGroupLine", () => {
-  // Leading newline, like dev-terminal-sessions.ts: whatever the file ended with — including a
+  // Leading newline, like session-id-log.ts: whatever the file ended with — including a
   // write cut off mid-line — an appended entry starts its own line, so the damage is one entry.
   it("leads with the newline so an append always starts its own line", () => {
     expect(sessionToolGroupLine(ID, "render")).toBe(`\n${ID} render`);

--- a/test/src/components/Sidebar.spec.ts
+++ b/test/src/components/Sidebar.spec.ts
@@ -83,6 +83,62 @@ describe("Sidebar", () => {
     expect(wrapper.emitted("update:filter")?.[0]).toEqual(["unread"]);
   });
 
+  // The behaviour the feature is for: a scheduled collection refresh must not sit in the
+  // list the user reads, and must still be one click away (#1060).
+  it("leaves background workers out of the default list", () => {
+    const wrapper = mountSidebar({
+      sessions: [row({ id: "chat" }), row({ id: "refresh", hidden: true })],
+    });
+    const items = wrapper.findAll('[data-testid="session-item"]');
+    expect(items).toHaveLength(1);
+    expect(items[0].text()).toContain("chat");
+  });
+
+  it("shows only background workers under the background filter", () => {
+    const wrapper = mountSidebar({
+      sessions: [row({ id: "chat" }), row({ id: "refresh", hidden: true })],
+      filter: "background",
+    });
+    const items = wrapper.findAll('[data-testid="session-item"]');
+    expect(items).toHaveLength(1);
+    expect(items[0].text()).toContain("refresh");
+  });
+
+  it("emits update:filter when the background chip is clicked, with its count", async () => {
+    const wrapper = mountSidebar({
+      sessions: [row({ id: "chat" }), row({ id: "refresh", hidden: true })],
+    });
+    const backgroundChip = wrapper.findAll("[aria-pressed]")[2];
+    expect(backgroundChip.text()).toContain("(1)");
+    await backgroundChip.trigger("click");
+    expect(wrapper.emitted("update:filter")?.[0]).toEqual(["background"]);
+  });
+
+  // No collections, no chip: an installation that never spawns a worker should not carry a
+  // permanently empty filter.
+  it("hides the background chip when there is nothing behind it", () => {
+    const wrapper = mountSidebar({ sessions: [row({ id: "chat" })] });
+    expect(wrapper.findAll("[aria-pressed]")).toHaveLength(2);
+  });
+
+  // ...unless it is the chip in use — the last worker finishing must not pull the selected
+  // filter out from under the user.
+  it("keeps the background chip while it is the active filter", () => {
+    const wrapper = mountSidebar({ sessions: [row({ id: "chat" })], filter: "background" });
+    const chips = wrapper.findAll("[aria-pressed]");
+    expect(chips).toHaveLength(3);
+    expect(chips[2].text()).toContain("Background");
+    expect(wrapper.text()).toContain("No background sessions");
+  });
+
+  // A project whose only sessions are workers has rows to list and no chats; "No sessions
+  // yet" would report that as an empty project.
+  it("says which filter came up empty, not that the project has no sessions", () => {
+    const wrapper = mountSidebar({ sessions: [row({ id: "refresh", hidden: true })] });
+    expect(wrapper.text()).toContain("No chat sessions");
+    expect(wrapper.text()).not.toContain("No sessions yet");
+  });
+
   it("emits refresh when the sort button is clicked", async () => {
     const wrapper = mountSidebar({ sessions: [row({ id: "a" })] });
     await wrapper.find('[aria-label="Sort by most recent"]').trigger("click");

--- a/test/src/composables/useSessions.spec.ts
+++ b/test/src/composables/useSessions.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { nextTick } from "vue";
 import { flushPromises } from "@vue/test-utils";
-import { mergeStable, isUnread, useSessions, type Session } from "../../../src/composables/useSessions";
+import { mergeStable, isBackground, isUnread, matchesFilter, useSessions, type Session } from "../../../src/composables/useSessions";
 
 function row(id: string): Session {
   return { id, title: id, mtime: 1, working: false, waiting: false };
@@ -18,6 +18,51 @@ describe("isUnread", () => {
 
   it("is false for a hidden background worker even when waiting (the bug fix)", () => {
     expect(isUnread({ ...row("a"), waiting: true, hidden: true })).toBe(false);
+  });
+});
+
+describe("isBackground", () => {
+  it("is true for a hidden worker", () => {
+    expect(isBackground({ ...row("a"), hidden: true })).toBe(true);
+  });
+
+  it("is false for a session the user started", () => {
+    expect(isBackground(row("a"))).toBe(false);
+  });
+});
+
+describe("matchesFilter", () => {
+  const chat = row("chat");
+  const worker = { ...row("worker"), hidden: true };
+  const waitingChat = { ...row("waiting"), waiting: true };
+  const waitingWorker = { ...row("waiting-worker"), waiting: true, hidden: true };
+
+  // The point of the feature: the default chip is the user's own chats, so a collection
+  // refreshing on a schedule stops filling the history (#1060).
+  it("excludes background workers from the default chip", () => {
+    expect(matchesFilter(chat, "all")).toBe(true);
+    expect(matchesFilter(worker, "all")).toBe(false);
+  });
+
+  it("shows only background workers under the background chip", () => {
+    expect(matchesFilter(worker, "background")).toBe(true);
+    expect(matchesFilter(chat, "background")).toBe(false);
+  });
+
+  // A background worker sitting at a permission prompt is `waiting`; it is still not
+  // something to read, so unread stays what isUnread says.
+  it("keeps unread free of background workers", () => {
+    expect(matchesFilter(waitingChat, "unread")).toBe(true);
+    expect(matchesFilter(waitingWorker, "unread")).toBe(false);
+    expect(matchesFilter(chat, "unread")).toBe(false);
+  });
+
+  // Every row the server sends is reachable from some chip — otherwise a session exists
+  // that cannot be opened, and a MulmoTerminal session is a live terminal.
+  it("matches every row under exactly one of all/background", () => {
+    for (const s of [chat, worker, waitingChat, waitingWorker]) {
+      expect(matchesFilter(s, "all")).not.toBe(matchesFilter(s, "background"));
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

コレクションの定期データ同期など、**ユーザーが始めていないセッション**をチャット履歴の
**Background チップの裏**に移す。既定の `All` は人が始めたチャットだけになる。

issue #1060 は「MulmoClaude の `origin: "system"` と同じく履歴から**丸ごと落とす**」を提案して
いたが、採らなかった。MulmoTerminal のセッションは**チャット記録ではなく生きた端末**で、消すと
開けなくなる＝止める手段も失う。MulmoClaude の履歴フィルタと同じくチップで絞れるようにすれば、
既定の画面からは消えつつ、開くことも止めることもできる。

| チップ | 出るもの |
| --- | --- |
| `All`（既定） | 人が始めたチャットのみ |
| `Unread` | 従来どおり（元々 hidden を除外していた） |
| `Background` | ワーカーのみ。**該当が 0 件のときは表示しない** |

手動 Refresh（`hidden:false`）は今までどおり見えるセッションのまま — デバッグできることが目的。

## Items to Confirm / Review

1. **`All` の意味を変えた** — 「全部」ではなく「全チャット」。issue のクラッタ問題を既定で解決する
   ために選んだ挙動で、`Background` チップが常に逃げ道。文言を `All` のままにするか
   `Chats` にするかは議論の余地あり。
2. **永続化を足した (`~/.mulmoterminal/background-sessions.json`)** — フィルタ案でも issue の勘所1
   は避けられなかった。`hiddenSessions` はメモリのみ＋reap で削除されるので、フラグだけだと
   **ワーカーが終わった瞬間に普通のチャットとして戻る**。dev-terminal と同じ append ログ。
   append-only なので**取り消せない**（後述の失敗時の扱いを確認してほしい）。
3. **上限をチャットと背景で分けた** (`selectSessionRows`) — クライアントが既定で背景を隠すので、
   上限 1 本だと背景が増えるほど本物のチャットが押し出され、画面上は「履歴が短くなった」だけで
   理由が出ない。`limit: 50` / `backgroundLimit: 10`。**背景の 10 という数字**は要確認。
4. **刈り取りへの登録を同じ PR に入れた（issue 勘所2）** — 既定で見えなくする以上、#541
   （76 セッション / 41.8GB）の再発を防ぐ側とセットでないと危ない。`feedsSpawnWorker` と
   `spawnBackgroundChat` の `hidden:true` を `scheduledSessions.register()` に載せた。
   `spawnBackgroundChat` 側は `PluginRouteDeps` にコールバックを 1 つ足す形（プラグイン層が
   セッション層を import しないため）。
5. **`server/index.ts` の初期化順序** — `scheduledSessions` は `feedsSpawnWorker` と
   `mountAppRoutes` より後で定義される。どちらもクロージャ経由で呼ぶだけで、feeds を起動する
   システムタスクの登録は `initUserTaskScheduler`（さらに後）、HTTP リクエストは `listen()` の後
   なので実行時には必ず初期化済み。**ここは暗黙の順序依存なのでレビューしてほしい。**
6. **`dev-terminal-sessions.ts` → `session-id-log.ts` にリネーム** — 中身は「id を 1 行ずつ追記する
   ログ」で grid 固有の要素がなく、2 つ目の同形セットを足すので一般化した。leading-newline の罠
   （legacy JSON 配列に welding する）は元のコメントとテストごと引き継いでいる。
7. **失敗した spawn は永続ログに残る** — `backgroundMarkers.delete` は live フラグしか戻せない
   （append-only）。spawn が落ちたセッションは transcript を書かないので一覧に出ることはないが、
   ログ行だけが残る。許容と判断した。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1060 single view の chat の話だと思うけど、
> mulmoclaude と同じように filter できるとよいね

判断を仰いだ結果:

- `All` チップの意味 → **「チャットのみ（既定で背景を除外）」** を選択
- 進め方 → **plans/ を書いて実装まで進める**

## 実装

### サーバ

| ファイル | 内容 |
| --- | --- |
| `session/session-id-log.ts` | `dev-terminal-sessions.ts` を一般化してリネーム（`parseSessionIdLog` / `sessionIdLogLine`） |
| `session/registry.ts` | 永続セット `backgroundSessions` + `isBackgroundSession()` + `backgroundMarkers`。hydrate / append ヘルパを 2 つのログで共有 |
| `session/session-reads.ts` | ワイヤの `hidden` を `isBackgroundSession()` に切り替え（on-disk 行と pending 行の両方） |
| `session/session-list.ts` | `isBackground` 述語 + `backgroundLimit`、上限を別枠で適用してから mtime で再マージ |
| `routes/session-routes.ts` | 述語と `backgroundSessionsHydrated` の await |
| `index.ts` / `routes/plugin-routes.ts` / `routes/app-routes.ts` | `backgroundMarkers` を渡し、hidden な spawn を刈り取りに登録 |

`backgroundMarkers` を 1 箇所にまとめたのは、spawn 地点が 2 つあるため。片方が live フラグだけ
覚えて永続ログを忘れると「終わるまで背景、終わったら普通のチャット」という一番気づきにくい壊れ方をする。

副次的に、`hidden` が reap を越えて残るようになったので「終了した hidden ワーカーが再び太字になる」
既知の穴も塞がった。

### クライアント

| ファイル | 内容 |
| --- | --- |
| `composables/useSessions.ts` | `Filter` に `"background"`、`isBackground()`、純粋関数 `matchesFilter()` |
| `composables/sessionList.ts` | `backgroundCount`、`sessionListEmptyMessage(filter)` |
| `components/SessionFilters.vue` | `Background` チップ（0 件かつ非アクティブなら非表示） |
| `components/Sidebar.vue` / `SessionTabBar.vue` | `backgroundCount` を渡す。ハードコードの "No unread sessions" を置き換え |

## テスト

`yarn test` 全パス（408 files / 6055 tests）。追加したのは:

- `session-list.spec.ts` — 背景行は残ること、別枠の上限、背景がチャットを押し出さないこと、
  grid かつ背景の行がチャット一覧に戻らないこと
- `useSessions.spec.ts` — `matchesFilter` の全分岐、全行が `all`/`background` のどちらか一方に必ず入ること
- `Sidebar.spec.ts` — 既定の除外、Background 表示、チップの出し分け、空表示の文言

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `knip`
すべて通過（knip の 2 件は既存の指摘で無関係）。

## 実機確認

隔離した `HOME` + workspace で実際にサーバを起動し、**永続ログに 1 件だけ書いた状態で再起動**して
確認した（memory-only フラグでは壊れる、まさにその状況）:

```
chips:            ["All", "Unread (0)", "Background (1)"]
default rows:     ["New session", "a chat I started"]
background rows:  ["scheduled feed refresh"]
```

`GET /api/sessions` も、このプロセスが spawn していないセッションに `hidden: true` を返した。

## やらないこと（別 PR）

**`onComplete` の接続（issue の PR 2）** — feeds エンジンは hidden ワーカー向けに `onComplete` を
受け取れるが、MulmoTerminal の runner は捨てている。繋ぐにはセッション層から完了/失敗を渡す経路が要る。
フィルタ案では失敗したセッション自体が Background チップの裏に残って開けるので、PR 1 とセットである
必然性がなくなった。

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
