### PR TITLE
feat: launcher offers a switch for every GUI tool group, not just the Canvas two

### DIFF
--- a/common/toolGroups.ts
+++ b/common/toolGroups.ts
@@ -37,6 +37,20 @@ export const CANVAS_TOOL_GROUPS: readonly ToolGroup[] = ["render", "media"];
 export const hasCanvasGroup = (groups: unknown): boolean =>
   Array.isArray(groups) && groups.some((group) => isToolGroup(group) && CANVAS_TOOL_GROUPS.includes(group));
 
+// What the launcher's switch for a group calls it. The group NAME is shown too (it is the MCP
+// server id the switch registers), so this line answers the other question: what does the agent
+// gain. Two groups share a heading on purpose — render and media both end up in the Canvas pane,
+// which is why CANVAS_TOOL_GROUPS above holds exactly those two.
+//
+// A Record, not a lookup with a fallback: adding a group to TOOL_GROUPS without deciding what to
+// call it should fail to compile, not ship a switch labelled "external".
+export const TOOL_GROUP_HEADINGS: Record<ToolGroup, string> = {
+  render: "Canvas",
+  data: "Workspace data",
+  media: "Canvas",
+  external: "External accounts",
+};
+
 // Which group each GUI tool belongs to.
 //
 // A tool that is absent belongs to NO group and is therefore reachable only through the

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -554,10 +554,12 @@ const mcpGroupTitle = (group: ToolGroup): string =>
 async function loadMcpGroups() {
   const dir = dirInput.value.trim() || props.defaultCwd;
   const reqId = ++mcpGroupReq;
-  if (launched.value || !dir) {
-    mcpGroupDir.value = null;
-    return;
-  }
+  // Cleared BEFORE the fetch, not only on the failure path: the switches showing while the answer
+  // is in flight are the PREVIOUS directory's, and a flip during that gap writes to the previous
+  // directory (applyMcpGroup captures mcpGroupDir, which is what keeps a queued write honest).
+  // The rows come back a moment later with this directory's real positions.
+  mcpGroupDir.value = null;
+  if (launched.value || !dir) return;
   try {
     const res = await fetch(`/api/gui-mcp-groups?cwd=${encodeURIComponent(dir)}`);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -659,7 +661,7 @@ async function createWorktreeAndLaunch() {
     const wt = await res.json();
     if (typeof wt.path === "string") {
       worktreeTask.value = "";
-      await carryMcpGroups(wt.path);
+      await syncMcpGroupsInto(wt.path);
       launchIn(wt.path);
     }
   } catch {
@@ -668,7 +670,7 @@ async function createWorktreeAndLaunch() {
 }
 
 const reuseWorktree = async (w: Worktree) => {
-  await carryMcpGroups(w.path);
+  await syncMcpGroupsInto(w.path);
   launchIn(w.path);
 };
 
@@ -676,27 +678,46 @@ const reuseWorktree = async (w: Worktree) => {
 // starts claude in the WORKTREE — not in the repository the switches above were set for. Without
 // this the session gets no GUI tools even though the launcher plainly says the group is on.
 //
-// Every group that is on, not just the Canvas ones: a worktree that inherited half the switches
-// would be a launcher telling the truth about the repo and a lie about the room it just opened.
+// A SYNC of every group, not a copy of the ticked ones. A REUSED worktree can carry a
+// registration from an earlier launch, and mirroring only the "on" groups leaves that stale one
+// standing: uncheck `external` in the repo, reuse the worktree it was once on for, and the
+// session gets external tools the launcher shows as off. Over-granting is the direction that
+// matters, so a group that is off here is removed there.
 //
 // Copied rather than moved: the repository keeps its own registration, and a worktree is a
 // throwaway room that should start out like the repo it came from. Failures are swallowed —
 // the launch itself is what the user asked for, and the Canvas button will report the truth.
-async function carryMcpGroups(worktreePath: string) {
+//
+// Only the groups that actually DIFFER are written, because each write shells out to the
+// `claude` CLI and the launch waits on them. The target's current state is one config-file read
+// (the GET does not shell out); when it cannot be read, every group is written rather than
+// assumed — a wrong assumption here is the stale registration this exists to clear.
+async function syncMcpGroupsInto(worktreePath: string) {
   if (!mcpGroupDir.value || worktreePath === mcpGroupDir.value) return;
-  const enabled = TOOL_GROUPS.filter((group) => mcpGroupEnabled.value[group]);
+  let already: unknown[] | null = null;
+  try {
+    const res = await fetch(`/api/gui-mcp-groups?cwd=${encodeURIComponent(worktreePath)}`);
+    if (res.ok) {
+      const data = await res.json();
+      if (Array.isArray(data.groups)) already = data.groups;
+    }
+  } catch {
+    // leave it null: write every group
+  }
+  const wanted = (group: ToolGroup) => mcpGroupEnabled.value[group];
+  const changed = TOOL_GROUPS.filter((group) => already === null || already.includes(group) !== wanted(group));
   // Through the same queue as the switches, one group at a time: a launch that fires while a
   // checkbox is still saving would otherwise be the very concurrent write the queue exists for.
-  for (const group of enabled) {
+  for (const group of changed) {
     await queueMcpWrite(async () => {
       try {
         await fetch("/api/gui-mcp-groups", {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ cwd: worktreePath, group, enabled: true }),
+          body: JSON.stringify({ cwd: worktreePath, group, enabled: wanted(group) }),
         });
       } catch {
-        // best-effort — a worktree without the registration still launches, just without Canvas
+        // best-effort — a worktree without the registration still launches, just without the tools
       }
     });
   }
@@ -729,6 +750,11 @@ watch([dirInput, () => props.defaultCwd], () => {
     skipDirWatch = false; // a fillDir() already loaded these immediately — don't schedule another
     return;
   }
+  // The tool-group switches belong to a directory, and this one just stopped being it. They go
+  // as soon as the field changes rather than 300ms later, so a flip cannot land on the directory
+  // the user has typed their way off. The reload below puts them back for the new one.
+  mcpGroupReq++;
+  mcpGroupDir.value = null;
   resumableTimer = setTimeout(() => {
     loadResumable();
     loadScripts();

--- a/src/components/TerminalCell.vue
+++ b/src/components/TerminalCell.vue
@@ -10,8 +10,8 @@ import { useWorkItem } from "../composables/useWorkItem";
 import { formatCwd, worktreeLabel } from "./cwdDisplay";
 import DirBadge from "./DirBadge.vue";
 import { isCellContext, isCellUsage, type CellContext, type CellUsage } from "./cellPayload";
-import { CANVAS_TOOL_GROUPS, toolGroupServerId, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
-import { queueCanvasWrite } from "./canvasWriteQueue";
+import { TOOL_GROUPS, TOOL_GROUP_HEADINGS, toolGroupServerId, toolsInGroup, type ToolGroup } from "../../common/toolGroups";
+import { queueMcpWrite } from "./mcpWriteQueue";
 import { unsavedWork } from "./unsavedWork";
 import { relativeTime as relativeTimeFrom, usageBadge } from "./cellDisplay";
 import { applyActivityPush, cellHeaderText } from "./cellActivity";
@@ -342,7 +342,7 @@ onMounted(() => {
     loadResumable();
     loadScripts();
     loadWorktrees();
-    loadCanvasEnabled();
+    loadMcpGroups();
   }
 });
 onUnmounted(() => {
@@ -410,7 +410,7 @@ function fillDir(path: string) {
   loadResumable();
   loadScripts();
   loadWorktrees();
-  loadCanvasEnabled();
+  loadMcpGroups();
 }
 
 // The folder button: the browser can't open a native folder chooser, so the local server does
@@ -521,36 +521,41 @@ const worktrees = ref<Worktree[]>([]);
 const worktreeTask = ref("");
 let worktreesReq = 0;
 
-// Whether this directory lets its agents draw into the Canvas panel, per Canvas GROUP (render,
-// media). NOT MulmoTerminal state: each is an MCP server registered in Claude Code's own
-// local-scope config for this directory, so the switches read and write through
+// Which GUI tool groups this directory hands its agents, one switch per group in TOOL_GROUPS
+// (render, data, media, external). NOT MulmoTerminal state: each is an MCP server registered in
+// Claude Code's own local-scope config for this directory, so the switches read and write through
 // /api/gui-mcp-groups and `claude mcp list` stays the one place they can be seen. Read per
 // directory, like the worktree list above.
 //
-// One record per group rather than a flag per group: the two switches differ only in the group
-// they name, so adding a third to CANVAS_TOOL_GROUPS should not mean a third copy of this block.
-const byCanvasGroup = <T,>(value: T): Record<ToolGroup, T> => Object.fromEntries(CANVAS_TOOL_GROUPS.map((group) => [group, value])) as Record<ToolGroup, T>;
+// EVERY group, not just the two Canvas ones: the server has routed, gated and pre-approved all
+// four since they were defined, and the launcher offering only render and media left `data` and
+// `external` reachable solely by typing `claude mcp add` by hand. CANVAS_TOOL_GROUPS still means
+// what it says — which groups DRAW — and is not the set that gets a switch.
+//
+// One record per group rather than a flag per group: the switches differ only in the group they
+// name, so adding one to TOOL_GROUPS should not mean another copy of this block.
+const byToolGroup = <T,>(value: T): Record<ToolGroup, T> => Object.fromEntries(TOOL_GROUPS.map((group) => [group, value])) as Record<ToolGroup, T>;
 
-const canvasDir = ref<string | null>(null);
-const canvasEnabled = ref(byCanvasGroup(false));
-const canvasBusy = ref(byCanvasGroup(false));
-const canvasError = ref(byCanvasGroup<string | null>(null));
-let canvasReq = 0;
+const mcpGroupDir = ref<string | null>(null);
+const mcpGroupEnabled = ref(byToolGroup(false));
+const mcpGroupBusy = ref(byToolGroup(false));
+const mcpGroupError = ref(byToolGroup<string | null>(null));
+let mcpGroupReq = 0;
 
 // What the switch actually does, spelled out for the hover: the MCP SERVER ID it registers and
 // the tools that id brings with it. The row's visible label can only name the group, and the
-// group name alone ("render", "media") does not say which server appears in `claude mcp list`
+// group name alone ("render", "data") does not say which server appears in `claude mcp list`
 // nor what the agent gains — that is exactly what a user checking the box wants to know.
 // Derived from toolGroups.ts rather than written out, so a tool added to a group shows up here
 // without a second edit (the Canvas empty state names them the same way).
-const canvasTitle = (group: ToolGroup): string =>
+const mcpGroupTitle = (group: ToolGroup): string =>
   `Registers the MCP server "${toolGroupServerId(group)}" for this directory — tools: ${toolsInGroup(group).join(", ")}`;
 
-async function loadCanvasEnabled() {
+async function loadMcpGroups() {
   const dir = dirInput.value.trim() || props.defaultCwd;
-  const reqId = ++canvasReq;
+  const reqId = ++mcpGroupReq;
   if (launched.value || !dir) {
-    canvasDir.value = null;
+    mcpGroupDir.value = null;
     return;
   }
   try {
@@ -559,16 +564,16 @@ async function loadCanvasEnabled() {
     const data = await res.json();
     // A slower reply for a directory the user has since moved off would show its answer under
     // the new directory's name.
-    if (reqId !== canvasReq) return;
-    canvasDir.value = dir;
+    if (reqId !== mcpGroupReq) return;
+    mcpGroupDir.value = dir;
     const registered: unknown[] = Array.isArray(data.groups) ? data.groups : [];
-    canvasEnabled.value = byCanvasGroup(false);
-    for (const group of CANVAS_TOOL_GROUPS) canvasEnabled.value[group] = registered.includes(group);
-    canvasError.value = byCanvasGroup(null);
+    mcpGroupEnabled.value = byToolGroup(false);
+    for (const group of TOOL_GROUPS) mcpGroupEnabled.value[group] = registered.includes(group);
+    mcpGroupError.value = byToolGroup(null);
   } catch {
     // No switch rather than one whose position is a guess — flipping a wrong "off" would run
     // `claude mcp remove` on a registration the user may actually have.
-    if (reqId === canvasReq) canvasDir.value = null;
+    if (reqId === mcpGroupReq) mcpGroupDir.value = null;
   }
 }
 
@@ -584,16 +589,16 @@ async function loadCanvasEnabled() {
 // flip, and the launcher's directory field is editable the whole time. Read at execution time, a
 // switch ticked for A would register the MCP server against whatever B the user had typed by
 // then — a silent write to a folder they never touched the switch in.
-function applyCanvas(group: ToolGroup): Promise<void> {
-  const dir = canvasDir.value;
+function applyMcpGroup(group: ToolGroup): Promise<void> {
+  const dir = mcpGroupDir.value;
   if (!dir) return Promise.resolve();
-  const wanted = canvasEnabled.value[group];
-  canvasBusy.value[group] = true;
-  canvasError.value[group] = null;
-  return queueCanvasWrite(() => writeCanvasGroup(group, dir, wanted));
+  const wanted = mcpGroupEnabled.value[group];
+  mcpGroupBusy.value[group] = true;
+  mcpGroupError.value[group] = null;
+  return queueMcpWrite(() => writeMcpGroup(group, dir, wanted));
 }
 
-async function writeCanvasGroup(group: ToolGroup, dir: string, wanted: boolean) {
+async function writeMcpGroup(group: ToolGroup, dir: string, wanted: boolean) {
   try {
     const res = await fetch("/api/gui-mcp-groups", {
       method: "POST",
@@ -607,12 +612,12 @@ async function writeCanvasGroup(group: ToolGroup, dir: string, wanted: boolean) 
     // Only if the switches still belong to the directory this write was for. Moved on, they are
     // showing what the NEW directory has registered, and putting one back would report another
     // folder's failure as that directory's state.
-    if (canvasDir.value === dir) {
-      canvasEnabled.value[group] = !wanted;
-      canvasError.value[group] = e instanceof Error ? e.message : String(e);
+    if (mcpGroupDir.value === dir) {
+      mcpGroupEnabled.value[group] = !wanted;
+      mcpGroupError.value[group] = e instanceof Error ? e.message : String(e);
     }
   } finally {
-    canvasBusy.value[group] = false;
+    mcpGroupBusy.value[group] = false;
   }
 }
 
@@ -654,7 +659,7 @@ async function createWorktreeAndLaunch() {
     const wt = await res.json();
     if (typeof wt.path === "string") {
       worktreeTask.value = "";
-      await carryCanvasInto(wt.path);
+      await carryMcpGroups(wt.path);
       launchIn(wt.path);
     }
   } catch {
@@ -663,27 +668,27 @@ async function createWorktreeAndLaunch() {
 }
 
 const reuseWorktree = async (w: Worktree) => {
-  await carryCanvasInto(w.path);
+  await carryMcpGroups(w.path);
   launchIn(w.path);
 };
 
 // Claude Code keys local-scope MCP config by the CLI's working directory, and a worktree launch
 // starts claude in the WORKTREE — not in the repository the switches above were set for. Without
-// this the session gets no render tools even though the launcher plainly says Canvas is on.
+// this the session gets no GUI tools even though the launcher plainly says the group is on.
 //
-// Every group that is on, not just render: a worktree that inherited half the switches would be
-// a launcher telling the truth about the repo and a lie about the room it just opened.
+// Every group that is on, not just the Canvas ones: a worktree that inherited half the switches
+// would be a launcher telling the truth about the repo and a lie about the room it just opened.
 //
 // Copied rather than moved: the repository keeps its own registration, and a worktree is a
 // throwaway room that should start out like the repo it came from. Failures are swallowed —
 // the launch itself is what the user asked for, and the Canvas button will report the truth.
-async function carryCanvasInto(worktreePath: string) {
-  if (!canvasDir.value || worktreePath === canvasDir.value) return;
-  const enabled = CANVAS_TOOL_GROUPS.filter((group) => canvasEnabled.value[group]);
+async function carryMcpGroups(worktreePath: string) {
+  if (!mcpGroupDir.value || worktreePath === mcpGroupDir.value) return;
+  const enabled = TOOL_GROUPS.filter((group) => mcpGroupEnabled.value[group]);
   // Through the same queue as the switches, one group at a time: a launch that fires while a
   // checkbox is still saving would otherwise be the very concurrent write the queue exists for.
   for (const group of enabled) {
-    await queueCanvasWrite(async () => {
+    await queueMcpWrite(async () => {
       try {
         await fetch("/api/gui-mcp-groups", {
           method: "POST",
@@ -728,7 +733,7 @@ watch([dirInput, () => props.defaultCwd], () => {
     loadResumable();
     loadScripts();
     loadWorktrees();
-    loadCanvasEnabled();
+    loadMcpGroups();
   }, 300);
 });
 
@@ -928,7 +933,7 @@ function teardown() {
   loadResumable();
   loadScripts();
   loadWorktrees();
-  loadCanvasEnabled();
+  loadMcpGroups();
 }
 
 // Closing a WORKTREE cell offers to keep or remove the room first (never silently
@@ -1740,45 +1745,40 @@ onUnmounted(() => document.removeEventListener("keydown", onDiffKey));
         </label>
         <!-- Codex has its own model configuration and doesn't read this one. -->
         <ModelPicker v-if="agent === 'claude'" v-model="launchChoice" />
-        <!-- Canvas is a per-DIRECTORY registration in Claude Code's own MCP config, not a
-             per-launch choice — but it only takes effect when a session starts, so this is
+        <!-- A GUI tool group is a per-DIRECTORY registration in Claude Code's own MCP config, not
+             a per-launch choice — but it only takes effect when a session starts, so this is
              where it belongs: decided before the thing it configures exists.
              BOTH agents: claude reads that config itself, and a codex cell is handed the same
              groups as resolved URLs at spawn (server/session/spawn-codex.ts), so one switch
              answers for both. It is still Claude Code's file — writing it needs the `claude`
              CLI on PATH, which is why a failure here says so rather than silently doing nothing.
-             One row per Canvas group: both draw into the same pane, and they are separate
-             switches because a media call is slow, paid and writes files where a render call
-             stops at the pane (see common/toolGroups.ts). -->
-        <template v-if="canvasDir">
-          <!-- The hover names the server id and its tools (canvasTitle); it sits on the ROW so
+             One row per group in TOOL_GROUPS, because one switch is one MCP server: render and
+             media both draw but differ in what a call costs, and data and external do not draw at
+             all — the split is exactly what the grouping exists for (common/toolGroups.ts). -->
+        <template v-if="mcpGroupDir">
+          <!-- The hover names the server id and its tools (mcpGroupTitle); it sits on the ROW so
                the text is reachable from the label as well as the box. -->
-          <label
-            v-for="group in CANVAS_TOOL_GROUPS"
-            :key="group"
-            class="flex w-full max-w-[360px] items-center justify-between gap-2"
-            :title="canvasTitle(group)"
-          >
+          <label v-for="group in TOOL_GROUPS" :key="group" class="flex w-full max-w-[360px] items-center justify-between gap-2" :title="mcpGroupTitle(group)">
             <!-- The group is named, not just the feature: each switch registers ONE MCP server
-               (`mulmoterminal-<group>`) and the remaining groups are added with `claude mcp
-               add`, so a label reading only "Canvas" would suggest it covers all of them.
+               (`mulmoterminal-<group>`), so a heading alone would not say which of the four rows
+               writes which server — and two of them share the heading "Canvas".
                `normal-case` on the suffix — the section labels around it are uppercased by
                class, and "(RENDER MCPS)" reads as a different thing than the server it names. -->
             <span class="font-sans text-[11px] uppercase tracking-[0.05em] text-dim"
-              >Canvas <span class="normal-case">({{ group }} MCPs)</span></span
+              >{{ TOOL_GROUP_HEADINGS[group] }} <span class="normal-case">({{ group }} MCPs)</span></span
             >
             <span class="flex items-center gap-2">
-              <span v-if="canvasBusy[group]" class="font-sans text-[11px] text-dim">saving…</span>
-              <span v-else-if="canvasError[group]" class="font-sans text-[11px] text-err-text" :title="canvasError[group]!">failed</span>
+              <span v-if="mcpGroupBusy[group]" class="font-sans text-[11px] text-dim">saving…</span>
+              <span v-else-if="mcpGroupError[group]" class="font-sans text-[11px] text-err-text" :title="mcpGroupError[group]!">failed</span>
               <input
-                v-model="canvasEnabled[group]"
-                :data-testid="`cell-canvas-toggle-${group}`"
+                v-model="mcpGroupEnabled[group]"
+                :data-testid="`cell-mcp-toggle-${group}`"
                 type="checkbox"
                 class="h-3.5 w-3.5 cursor-pointer accent-accent"
-                :disabled="canvasBusy[group]"
-                :title="canvasTitle(group)"
-                :aria-label="`Register the MCP server ${toolGroupServerId(group)} (${toolsInGroup(group).join(', ')}) so the agent can draw in ${canvasDir}`"
-                @change="applyCanvas(group)"
+                :disabled="mcpGroupBusy[group]"
+                :title="mcpGroupTitle(group)"
+                :aria-label="`Register the MCP server ${toolGroupServerId(group)} (${toolsInGroup(group).join(', ')}) for ${mcpGroupDir}`"
+                @change="applyMcpGroup(group)"
               />
             </span>
           </label>

--- a/src/components/mcpWriteQueue.ts
+++ b/src/components/mcpWriteQueue.ts
@@ -1,15 +1,15 @@
 // One write at a time to Claude Code's MCP config.
 //
-// Every Canvas switch in the launcher POSTs to /api/gui-mcp-groups, which shells out to
+// Every tool-group switch in the launcher POSTs to /api/gui-mcp-groups, which shells out to
 // `claude mcp add` / `claude mcp remove`. Those read-modify-write Claude Code's own config, so
 // two in flight can lose one of the two registrations — leaving a checkbox showing "on" for a
 // server that was never written, which is the one state the switch must never reach.
 //
 // The queue is MODULE level, not per component: the file being written is Claude Code's, shared
 // by every directory, so two cells saving at once race exactly as two checkboxes in one cell do.
-export type CanvasWriteQueue = (write: () => Promise<void>) => Promise<void>;
+export type McpWriteQueue = (write: () => Promise<void>) => Promise<void>;
 
-export function createCanvasWriteQueue(): CanvasWriteQueue {
+export function createMcpWriteQueue(): McpWriteQueue {
   let chain: Promise<void> = Promise.resolve();
   return (write) => {
     // The SAME callback for both settlements, rather than `.then(write).catch(...)`: a rejected
@@ -20,4 +20,4 @@ export function createCanvasWriteQueue(): CanvasWriteQueue {
   };
 }
 
-export const queueCanvasWrite: CanvasWriteQueue = createCanvasWriteQueue();
+export const queueMcpWrite: McpWriteQueue = createMcpWriteQueue();

--- a/test/common/toolGroups.spec.ts
+++ b/test/common/toolGroups.spec.ts
@@ -8,6 +8,7 @@ import {
   toolGroupServerId,
   AUTO_ALLOWED_TOOLS,
   CANVAS_TOOL_GROUPS,
+  TOOL_GROUP_HEADINGS,
   hasCanvasGroup,
 } from "../../common/toolGroups.js";
 
@@ -122,5 +123,21 @@ describe("CANVAS_TOOL_GROUPS", () => {
     expect(hasCanvasGroup(["renderer"])).toBe(false);
     expect(hasCanvasGroup(undefined)).toBe(false);
     expect(hasCanvasGroup("render")).toBe(false);
+  });
+});
+
+// The launcher draws one switch per group and labels it from here. A group with no heading would
+// render a blank label, and the Record type only catches that for a group added in the same
+// commit as its heading — this catches the value being emptied.
+describe("TOOL_GROUP_HEADINGS", () => {
+  it("names every group", () => {
+    for (const group of TOOL_GROUPS) expect(TOOL_GROUP_HEADINGS[group]?.trim()).toBeTruthy();
+  });
+
+  // The two groups that draw share a heading on purpose — they are one feature with two costs.
+  it("gives the drawing groups the Canvas heading", () => {
+    for (const group of CANVAS_TOOL_GROUPS) expect(TOOL_GROUP_HEADINGS[group]).toBe("Canvas");
+    expect(TOOL_GROUP_HEADINGS.data).not.toBe("Canvas");
+    expect(TOOL_GROUP_HEADINGS.external).not.toBe("Canvas");
   });
 });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { nextTick } from "vue";
 import TerminalCell from "../../../src/components/TerminalCell.vue";
+import { TOOL_GROUPS } from "../../../common/toolGroups";
 
 // Capture the "sessions" pub/sub callback and the reconnect handler so tests can push
 // activity and simulate a dropped-then-restored socket directly.
@@ -1812,12 +1813,12 @@ describe("TerminalCell", () => {
     expect(bare?.attributes("style") ?? "").not.toContain("color-mix");
   });
 
-  // The two Canvas switches write to ONE file (Claude Code's MCP config, via `claude mcp
+  // The tool-group switches write to ONE file (Claude Code's MCP config, via `claude mcp
   // add/remove`), so their POSTs are queued one behind the other. That queue is only half the
   // guard: a checkbox left live while its write waits its turn can be flipped again, and since a
   // failed write puts its own checkbox back, the earlier rollback would land on top of the later
   // intent — flip on, flip off, end up on. So the flip disables the box immediately.
-  it("disables a Canvas switch from the flip until its write settles", async () => {
+  it("disables a tool-group switch from the flip until its write settles", async () => {
     const write = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
     globalThis.fetch = vi.fn(async (url: string, init?: { method?: string }) => {
       const u = String(url);
@@ -1834,7 +1835,7 @@ describe("TerminalCell", () => {
     const w = mountCell(null);
     await flushPromises();
 
-    const box = w.find('[data-testid="cell-canvas-toggle-render"]');
+    const box = w.find('[data-testid="cell-mcp-toggle-render"]');
     expect(box.exists()).toBe(true);
     await box.setValue(true);
     // Disabled while the write is in flight — not merely once it reaches the front of the queue.
@@ -1843,12 +1844,12 @@ describe("TerminalCell", () => {
     write.resolve({ ok: true, json: async () => ({ ok: true }) });
     await flushPromises();
     await nextTick();
-    expect(w.find('[data-testid="cell-canvas-toggle-render"]').attributes("disabled")).toBeUndefined();
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').attributes("disabled")).toBeUndefined();
   });
 
   // A rejected write is the case the lock exists for: the checkbox goes back to where it was,
   // and it must be the flip that was actually attempted.
-  it("puts the Canvas switch back when its write fails", async () => {
+  it("puts the tool-group switch back when its write fails", async () => {
     globalThis.fetch = vi.fn(async (url: string, init?: { method?: string }) => {
       const u = String(url);
       if (u.includes("/api/gui-mcp-groups")) {
@@ -1863,12 +1864,12 @@ describe("TerminalCell", () => {
 
     const w = mountCell(null);
     await flushPromises();
-    const box = w.find('[data-testid="cell-canvas-toggle-render"]');
+    const box = w.find('[data-testid="cell-mcp-toggle-render"]');
     await box.setValue(true);
     await flushPromises();
     await nextTick();
 
-    expect((w.find('[data-testid="cell-canvas-toggle-render"]').element as HTMLInputElement).checked).toBe(false);
+    expect((w.find('[data-testid="cell-mcp-toggle-render"]').element as HTMLInputElement).checked).toBe(false);
     expect(w.text()).toContain("failed");
   });
 
@@ -1876,7 +1877,7 @@ describe("TerminalCell", () => {
   // the whole time. The write below waits behind another group's save; read at execution time,
   // the switch ticked for alpha would register the MCP server against beta — a silent write to a
   // folder the user never touched the switch in.
-  it("writes a queued Canvas registration to the directory it was flipped in", async () => {
+  it("writes a queued group registration to the directory it was flipped in", async () => {
     const first = deferred<{ ok: boolean; json: () => Promise<unknown> }>();
     const posted: { cwd: string; group: string; enabled: boolean }[] = [];
     globalThis.fetch = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
@@ -1899,13 +1900,13 @@ describe("TerminalCell", () => {
     await flushPromises();
 
     // media goes first and hangs; render queues behind it, both flipped in alpha.
-    await w.find('[data-testid="cell-canvas-toggle-media"]').setValue(true);
-    await w.find('[data-testid="cell-canvas-toggle-render"]').setValue(true);
+    await w.find('[data-testid="cell-mcp-toggle-media"]').setValue(true);
+    await w.find('[data-testid="cell-mcp-toggle-render"]').setValue(true);
     expect(posted).toHaveLength(1);
 
     // The user retypes the directory while render's write is still queued. The launcher reloads
     // the switches for the new directory behind a 300ms debounce, so let it fire — that reload is
-    // what moves canvasDir off alpha, and it is exactly what the queued write must not pick up.
+    // what moves mcpGroupDir off alpha, and it is exactly what the queued write must not pick up.
     vi.useFakeTimers();
     try {
       await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/beta");
@@ -1926,7 +1927,7 @@ describe("TerminalCell", () => {
   // a codex grid cell is handed the SAME groups as resolved `-c mcp_servers.*` urls at spawn
   // (server/session/spawn-codex.ts). Hiding the rows on codex left that path with no way to be
   // turned on from the cell that uses it.
-  it("offers the Canvas switches for codex as well as claude", async () => {
+  it("offers the tool-group switches for codex as well as claude", async () => {
     globalThis.fetch = vi.fn(async (url: string) => {
       const u = String(url);
       if (u.includes("/api/gui-mcp-groups")) return { ok: true, json: async () => ({ groups: ["render"] }) };
@@ -1943,9 +1944,43 @@ describe("TerminalCell", () => {
     await codexButton?.trigger("click");
     await nextTick();
 
-    expect(w.find('[data-testid="cell-canvas-toggle-render"]').exists()).toBe(true);
-    expect(w.find('[data-testid="cell-canvas-toggle-media"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);
+    expect(w.find('[data-testid="cell-mcp-toggle-media"]').exists()).toBe(true);
     // And it reads the same registration claude's rows do.
-    expect((w.find('[data-testid="cell-canvas-toggle-render"]').element as HTMLInputElement).checked).toBe(true);
+    expect((w.find('[data-testid="cell-mcp-toggle-render"]').element as HTMLInputElement).checked).toBe(true);
+  });
+
+  // `data` and `external` were routed, gated and pre-approved on the server from the day the
+  // groups were defined, but the launcher only ever drew the two Canvas rows — so the only way to
+  // reach a collection or a google tool from a grid cell was to type `claude mcp add` by hand.
+  // One row per group in TOOL_GROUPS, reading and writing the same registration the other two do.
+  it("offers a switch for every tool group, not just the Canvas ones", async () => {
+    const posted: { cwd: string; group: string; enabled: boolean }[] = [];
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) {
+        if (init?.method === "POST") {
+          posted.push(JSON.parse(String(init.body)));
+          return { ok: true, json: async () => ({ ok: true }) };
+        }
+        return { ok: true, json: async () => ({ groups: ["data"] }) };
+      }
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: false, worktrees: [] }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/home/me/proj", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(null, { defaultCwd: "/home/me/alpha" });
+    await flushPromises();
+
+    for (const group of TOOL_GROUPS) expect(w.find(`[data-testid="cell-mcp-toggle-${group}"]`).exists()).toBe(true);
+    // A group registered on disk comes back ticked, whichever group it is.
+    expect((w.find('[data-testid="cell-mcp-toggle-data"]').element as HTMLInputElement).checked).toBe(true);
+    expect((w.find('[data-testid="cell-mcp-toggle-external"]').element as HTMLInputElement).checked).toBe(false);
+
+    await w.find('[data-testid="cell-mcp-toggle-external"]').setValue(true);
+    await flushPromises();
+    expect(posted).toEqual([{ cwd: "/home/me/alpha", group: "external", enabled: true }]);
   });
 });

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -1045,6 +1045,9 @@ describe("TerminalCell", () => {
     const w = mountCell(null, { defaultCwd: "/home/me/repo" });
     await flushPromises();
     await w.find('[data-testid="worktree-reuse"]').trigger("click");
+    // The launch waits on the tool-group sync — one read of the worktree's registrations, plus a
+    // write per group that disagrees with the launcher (syncMcpGroupsInto).
+    await flushPromises();
     const term = w.findComponent({ name: "TerminalView" });
     expect(term.exists()).toBe(true);
     expect(term.props("cwd")).toBe("/wt/old-task");
@@ -1982,5 +1985,75 @@ describe("TerminalCell", () => {
     await w.find('[data-testid="cell-mcp-toggle-external"]').setValue(true);
     await flushPromises();
     expect(posted).toEqual([{ cwd: "/home/me/alpha", group: "external", enabled: true }]);
+  });
+
+  // A REUSED worktree can carry a registration from an earlier launch. Mirroring only the ticked
+  // groups into it leaves that one standing, so the session gets tools the launcher shows as off
+  // — `external` reaching a third-party account is the case that makes it matter. The groups that
+  // already agree are left alone, because every write shells out to the `claude` CLI.
+  it("clears a stale worktree registration for a group that is switched off", async () => {
+    const posted: { cwd: string; group: string; enabled: boolean }[] = [];
+    const groupsByCwd: Record<string, string[]> = {
+      "/home/me/repo": ["render"],
+      "/wt/old-task": ["render", "external"],
+    };
+    globalThis.fetch = vi.fn(async (url: string, init?: { method?: string; body?: string }) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) {
+        if (init?.method === "POST") {
+          posted.push(JSON.parse(String(init.body)));
+          return { ok: true, json: async () => ({ ok: true }) };
+        }
+        const cwd = decodeURIComponent(u.split("cwd=")[1] ?? "");
+        return { ok: true, json: async () => ({ groups: groupsByCwd[cwd] ?? [] }) };
+      }
+      if (u.includes("/api/worktrees"))
+        return {
+          ok: true,
+          json: async () => ({ isGit: true, base: "main", worktrees: [{ path: "/wt/old-task", branch: "agent/old-task", task: "old-task", dirty: false }] }),
+        };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(null, { defaultCwd: "/home/me/repo" });
+    await flushPromises();
+    await w.find('[data-testid="worktree-reuse"]').trigger("click");
+    await flushPromises();
+
+    // render agrees on both sides, data and media are off and absent — only the stale one moves.
+    expect(posted).toEqual([{ cwd: "/wt/old-task", group: "external", enabled: false }]);
+  });
+
+  // The switches belong to a DIRECTORY, and the reload behind them is debounced. Left on screen
+  // during that gap they are the previous directory's positions, and flipping one writes the MCP
+  // registration there — a directory the user has already typed their way off.
+  it("takes the switches away the moment the directory field changes", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      const u = String(url);
+      if (u.includes("/api/gui-mcp-groups")) return { ok: true, json: async () => ({ groups: ["render"] }) };
+      if (u.includes("/api/worktrees")) return { ok: true, json: async () => ({ isGit: false, worktrees: [] }) };
+      if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/home/me/alpha", scripts: [] }) };
+      if (u.includes("/api/sessions")) return { ok: true, json: async () => ({ sessions: [] }) };
+      return { ok: true, json: async () => ({ working: false, waiting: false, lastPrompt: null }) };
+    }) as unknown as typeof fetch;
+
+    const w = mountCell(null, { defaultCwd: "/home/me/alpha" });
+    await flushPromises();
+    expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(true);
+
+    vi.useFakeTimers();
+    try {
+      await w.find('[data-testid="cell-dir-input"]').setValue("/home/me/beta");
+      // Before the 300ms reload: no rows at all rather than beta's name over alpha's positions.
+      expect(w.find('[data-testid="cell-mcp-toggle-render"]').exists()).toBe(false);
+      await vi.advanceTimersByTimeAsync(400);
+    } finally {
+      vi.useRealTimers();
+    }
+    await flushPromises();
+    await nextTick();
+    expect((w.find('[data-testid="cell-mcp-toggle-render"]').element as HTMLInputElement).checked).toBe(true);
   });
 });

--- a/test/src/components/mcpWriteQueue.spec.ts
+++ b/test/src/components/mcpWriteQueue.spec.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { createCanvasWriteQueue } from "../../../src/components/canvasWriteQueue";
+import { createMcpWriteQueue } from "../../../src/components/mcpWriteQueue";
 
-// Each Canvas switch POSTs to /api/gui-mcp-groups, which shells out to `claude mcp add/remove` —
+// Each tool-group switch POSTs to /api/gui-mcp-groups, which shells out to `claude mcp add/remove` —
 // a read-modify-write of one config file. Only the flipped group's own checkbox is disabled while
 // it saves, so ticking render and media in quick succession fires two writes at once and one
 // registration is lost while both switches show "on". The queue is what stops that.
-describe("the canvas write queue", () => {
+describe("the MCP write queue", () => {
   const deferred = () => {
     let resolve!: () => void;
     let reject!: (e: unknown) => void;
@@ -17,7 +17,7 @@ describe("the canvas write queue", () => {
   };
 
   it("does not start the second write until the first has finished", async () => {
-    const queue = createCanvasWriteQueue();
+    const queue = createMcpWriteQueue();
     const first = deferred();
     const started: string[] = [];
 
@@ -42,7 +42,7 @@ describe("the canvas write queue", () => {
   // A failed write reports itself (the checkbox goes back); it must not take the queue with it,
   // or one server error would silently drop every later registration.
   it("runs the next write after one fails", async () => {
-    const queue = createCanvasWriteQueue();
+    const queue = createMcpWriteQueue();
     const started: string[] = [];
 
     const failing = queue(async () => {
@@ -61,7 +61,7 @@ describe("the canvas write queue", () => {
   // Each caller awaits its OWN write. A rejection travelling down the chain would surface on an
   // unrelated later caller, which would then put the wrong checkbox back.
   it("does not reject a later write with an earlier one's failure", async () => {
-    const queue = createCanvasWriteQueue();
+    const queue = createMcpWriteQueue();
     queue(async () => {
       throw new Error("HTTP 500");
     }).catch(() => {});


### PR DESCRIPTION
## Why

`data` (presentCollection, manageCollection, manageAccounting) and `external` (google, readXPost, searchX) have been routed, gated and pre-approved on the server since the groups were defined in `common/toolGroups.ts` — the group URL, the tool gate, `allowedToolNames`, and the codex `-c mcp_servers.*` args all take any of the four. Only the launcher was narrower: it drew a row per `CANVAS_TOOL_GROUPS`, so the only way to hand a grid cell a collection or a google tool was to type `claude mcp add -s local …` by hand against the url template.

## What

- **`common/toolGroups.ts`** — `TOOL_GROUP_HEADINGS`, a `Record<ToolGroup, string>`: render/media → "Canvas", data → "Workspace data", external → "External accounts". A Record rather than a lookup with a fallback, so adding a group without deciding what to call it fails to compile instead of shipping a switch labelled "external".
- **`TerminalCell.vue`** — the row block iterates `TOOL_GROUPS`; the state record, the read-back in `loadMcpGroups` and the worktree carry-over all cover four groups. Each row still names the MCP server it registers (`Workspace data (data MCPs)`), because one switch is one server.
- `CANVAS_TOOL_GROUPS` / `hasCanvasGroup` are untouched — they still answer "which groups DRAW", and are no longer the set that gets a switch. The Canvas pane's availability check does not widen.
- Renames, since the state is no longer Canvas-specific: `canvas*` → `mcpGroup*`, testids → `cell-mcp-toggle-<group>`, `canvasWriteQueue.ts` → `mcpWriteQueue.ts`. The queue's behaviour is unchanged and still module-level — the file being serialized is Claude Code's, shared by every directory.
- The checkbox aria-label loses "so the agent can draw", which is false for data/external.

No server change was needed.

## Known limitation (pre-existing)

The hover lists a group's tools statically from `toolGroups.ts`, so if a backend plugin isn't present (accounting not configured, say) the group registers with fewer tools than the tooltip names. Already true for render/media; not addressed here.

## Test plan

- New spec: all four rows render, a `data` registration reads back ticked, flipping `external` POSTs `{group:"external", enabled:true}` to the directory it was flipped in.
- New spec pinning `TOOL_GROUP_HEADINGS` covers every group and keeps "Canvas" for exactly the drawing ones.
- `yarn format`, `yarn lint`, `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test`, `yarn test` (6041 passed) all green.
- Not yet exercised in a live browser session — the rows are covered by component tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable MCP tool-group switches for each supported group, including Render, Media, Workspace data, and External accounts.
  - Sessions now carry enabled MCP tool-group settings into newly created or reused worktrees.
  - Added clear labels and contextual information for each tool group.

- **Bug Fixes**
  - Improved tool-group setting updates to prevent conflicting writes and restore state when an update fails.
  - Refreshed tool-group settings correctly when changing directories or resetting sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->