### PR TITLE
refactor: jscpd が報告している重複のうち、本物の3件を潰す (#1074)

### DIFF
--- a/common/finiteNumber.ts
+++ b/common/finiteNumber.ts
@@ -1,0 +1,9 @@
+/** The guard both sides use before reading a NUMBER off parsed JSON. Null — never 0 — for
+ *  anything that is not a real number, because the callers are gauges and costs where a missing
+ *  value and a zero mean opposite things (see common/rateLimits.ts).
+ *
+ *  `Number.isFinite` rather than a bare typeof: `JSON.parse` cannot produce NaN or Infinity, but
+ *  these values also arrive from arithmetic on parsed fields, and NaN reaching a gauge renders as
+ *  an empty bar rather than as an error. Sibling of common/isRecord.ts, which exists because the
+ *  same one-liner had been hand-copied into 29 files. */
+export const finiteNumber = (value: unknown): number | null => (typeof value === "number" && Number.isFinite(value) ? value : null);

--- a/common/rateLimits.ts
+++ b/common/rateLimits.ts
@@ -8,6 +8,8 @@
 // because the plan is API-key billed, because no session has answered yet, or because upstream
 // dropped the field (anthropics/claude-code#40094). None of those are zero, and a gauge reading
 // 0% when the truth is 83% is the worst thing this data can do.
+import { isRecord } from "./isRecord.js";
+import { finiteNumber } from "./finiteNumber.js";
 
 export interface RateLimitWindow {
   usedPercentage: number; // 0-100, fractional
@@ -18,9 +20,6 @@ export interface RateLimits {
   fiveHour: RateLimitWindow | null;
   sevenDay: RateLimitWindow | null;
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value !== null;
-const finiteNumber = (value: unknown): number | null => (typeof value === "number" && Number.isFinite(value) ? value : null);
 
 export function parseRateLimitWindow(raw: unknown): RateLimitWindow | null {
   if (!isRecord(raw)) return null;

--- a/plans/refactor-1074-jscpd-real-duplicates.md
+++ b/plans/refactor-1074-jscpd-real-duplicates.md
@@ -1,0 +1,92 @@
+# refactor(#1074): jscpd が報告している重複のうち、本物の3件を潰す
+
+Code scanning の jscpd アラート 10 件を、ローカルで同じスキャンを走らせて**両側**を突き合わせた
+結果（アラートは片側しか出ない）。**本物は3件、残り7件は既に共有済みのものの呼び出し側**。
+
+`plans/refactor-jscpd-duplicates.md` の方針をそのまま引き継ぐ: 本当に抽象が欠けている重複だけ
+潰し、偶然の一致は残す。**誤った抽象は重複より悪い。**
+
+## 1. `isRecord` / `finiteNumber` の手書きコピー（alert #110）
+
+`common/isRecord.ts` は「29ファイルにコピペされていたのを一本化した」と自分で書いている。
+その手書きが5ファイルに残っていて、しかも**中身が違う**。
+
+```ts
+// ローカル版（5箇所）— 配列を通す
+const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+// common/isRecord.ts — 配列を意図的に弾く
+export const isRecord = (value) => isObject(value) && !Array.isArray(value);
+```
+
+共有版が配列を弾く理由もそこに書いてある: 配列を `Record` に narrow するのは**型に嘘をつく**
+行為で、`Object.entries()` する呼び出し側が添字をフィールド名として歩く。
+
+**実害の有無は確認済み: 現時点では無い。** 各呼び出しを追ったところ、配列が来ても
+
+- `parseRateLimitCache` → `parsed["claude"]` が `undefined` → 空を返す
+- `useRateLimits.load` → `data.claude` が `undefined` → 空の snapshot
+
+となり、結果は厳しい版と同じ。**直す理由は将来の実害ではなく、一本化したはずのものが戻りかけて
+いること。**
+
+対象:
+
+| ファイル | `isRecord` | `finiteNumber` |
+|---|---|---|
+| `server/agents/statusline.ts` | ○ | ○ |
+| `server/agents/codex-rate-limits.ts` | ○ | ○ |
+| `server/agents/rate-limit-persist.ts` | ○ | ○（`finite` という名） |
+| `src/composables/useRateLimits.ts` | ○ | — |
+| `common/rateLimits.ts` | ○ | ○ |
+| `src/composables/useCost.ts` | — | ○（`undefined` を返す変種） |
+
+方針:
+
+- `isRecord` は5箇所すべて `common/isRecord.ts` に寄せる。クライアントは既に10箇所以上で
+  これを import しているので bundle 都合の分離ではない。
+- `finiteNumber` は `common/` に置いて共有する。**`useCost.ts` の変種（`undefined` を返す）は
+  別物**なので無理に畳まない — `null` と `undefined` はこのコードベースで意味が違う。
+- 置き換え後、**配列を渡したときの挙動が変わらないこと**をテストで固定する（厳しい版に変える
+  以上、それが唯一の観測可能な差分）。
+
+## 2. `server/backends/html.ts` の自己重複（alert #120）
+
+HTML を返す2経路が、それぞれ Content-Type / `X-Content-Type-Options: nosniff` /
+`Content-Security-Policy` / stream を書いている。**片方が CSP を落としても誰も気づかない。**
+
+`sendHtmlDocument(res, abs)` に寄せ、ヘッダ3種と stream を1箇所にする。`statFileOr404` の
+呼び出しも同じ形なので一緒に入れるか、呼び出し側に残すかは実装時に読みやすい方を採る。
+
+## 3. `server/routes/ws-routes.ts` の起動＋配線（alert #119）
+
+launch と codex の2経路が同じ手順を書いている:
+
+```
+entry を起動 → 失敗ならログ・early.discard()・closeWithError
+→ ws.on("message") / ws.on("close") を配線 → early.release(...)
+```
+
+差分は**起動関数・ログのタグ・エラー文言だけ**。しかも codex 側にだけ「本物の listener を
+張った後だから、replay 中に届いたフレームでも順序が保たれる」というコメントがあり、launch 側に
+は無い。**不変条件が片側にしか書かれていない**のが、この重複の一番の害。
+
+`startAndWire(deps, ws, { sessionId, early, tag, failureMessage }, start)` に寄せ、順序の理由を
+そこに1回だけ書く。
+
+## 残すもの（意図的）
+
+- **Vue の6件**（#112 #113 #114 #115 #116 #102）— すべて**既に共有済み**のコンポーネント /
+  コンポーザブルの呼び出し側。`CellChromeButtons` の props/emit 転送（CommandCell /
+  LauncherCell / TerminalCell）、`useSessionFilter` の定型（SessionTabBar / Sidebar）、
+  `TerminalGrid` の TerminalCell / LauncherCell 呼び出し。これ以上畳むと「emit を props で
+  渡すな」というルールと衝突し、どのイベントがどこへ行くのかも追えなくなる。
+- **`ws-routes.ts` の #118** — 並行した構造だが `markDevTerminalSession` の条件も
+  `registeredGuiMcpGroups` の取り方も違う。パラメータ化すると分岐だらけの関数になる。
+
+## 制約
+
+純粋なリファクタで**挙動は変えない**。`yarn format` / `lint` / `typecheck` ×3 / `build` /
+`test` が green であること。
+
+`isRecord` の置き換えだけは観測可能な差分がある（配列を弾くようになる）ので、そこはテストで
+現行挙動が保たれることを示す。

--- a/server/agents/codex-rate-limits.spec.ts
+++ b/server/agents/codex-rate-limits.spec.ts
@@ -51,6 +51,15 @@ describe("extractCodexRateLimits", () => {
   it("ignores a window whose duration matches neither", () => {
     expect(extractCodexRateLimits({ primary: { used_percent: 5, window_minutes: 1, resets_at: 1 } })).toBeNull();
   });
+
+  // #1074 swapped a hand-copied `isRecord` for the shared one, which REJECTS arrays where the copy
+  // accepted them. Same answer either way — pinned so the swap stays invisible.
+  it.each([
+    ["the payload itself is an array", [{ primary: { used_percent: 5, window_minutes: FIVE_HOUR_MIN } }]],
+    ["a window is an array", { primary: [{ used_percent: 5, window_minutes: FIVE_HOUR_MIN }] }],
+  ])("is null when %s", (_case, raw) => {
+    expect(extractCodexRateLimits(raw)).toBeNull();
+  });
 });
 
 describe("latestRateLimitsInRollout", () => {

--- a/server/agents/codex-rate-limits.spec.ts
+++ b/server/agents/codex-rate-limits.spec.ts
@@ -71,6 +71,17 @@ describe("latestRateLimitsInRollout", () => {
     expect(latestRateLimitsInRollout([line(5), "{}", line(42)])?.fiveHour?.usedPercentage).toBe(42);
   });
 
+  // The search looks for the KEY rather than a fixed path precisely because Codex's surrounding
+  // shape has changed before — and an array on that path (a `content` list, a batch of events) is
+  // one of the shapes it has to survive. Losing it would blank the gauge with nothing to see.
+  it("finds the windows nested inside an array", () => {
+    const nested = JSON.stringify({
+      type: "event",
+      payload: { content: [{ rate_limits: { primary: { used_percent: 37, window_minutes: FIVE_HOUR_MIN, resets_at: 1 } } }] },
+    });
+    expect(latestRateLimitsInRollout([nested])?.fiveHour?.usedPercentage).toBe(37);
+  });
+
   // The file is appended to while we read it, so the last line can be half-written. That must cost
   // the newest reading, not the whole file.
   it("skips a truncated last line and falls back to the one before", () => {

--- a/server/agents/codex-rate-limits.ts
+++ b/server/agents/codex-rate-limits.ts
@@ -76,16 +76,27 @@ export function latestRateLimitsInRollout(lines: readonly string[]): RateLimits 
   return null;
 }
 
+// What the search may descend into — a different question from `isRecord`, which answers "may I
+// read named fields off this". An array must fail that one and pass this one.
+function childrenOf(node: unknown): unknown[] {
+  if (isRecord(node)) return Object.values(node);
+  return Array.isArray(node) ? node : [];
+}
+
 // `rate_limits` sits inside a record whose surrounding shape is Codex's business and has changed
 // before. Searching for the key rather than a fixed path means a re-nesting upstream costs nothing.
+//
+// Arrays are descended into as well as records (see childrenOf): a `content: []` on the path is one
+// of the shapes this search exists to survive, and stopping there would blank the gauge with nothing
+// on screen to explain it.
 function findRateLimits(node: unknown, depth = 0): RateLimits | null {
   const MAX_DEPTH = 6;
-  if (depth > MAX_DEPTH || !isRecord(node)) return null;
-  if (isRecord(node.rate_limits)) {
+  if (depth > MAX_DEPTH) return null;
+  if (isRecord(node) && isRecord(node.rate_limits)) {
     const extracted = extractCodexRateLimits(node.rate_limits);
     if (extracted) return extracted;
   }
-  for (const value of Object.values(node)) {
+  for (const value of childrenOf(node)) {
     const found = findRateLimits(value, depth + 1);
     if (found) return found;
   }

--- a/server/agents/codex-rate-limits.ts
+++ b/server/agents/codex-rate-limits.ts
@@ -11,9 +11,8 @@
 //     "secondary": {"used_percent": 1.0, "window_minutes": 10080, "resets_at": 1784358265}
 //   }
 import type { RateLimits, RateLimitWindow } from "./statusline.js";
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
-const finiteNumber = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
+import { isRecord } from "../../common/isRecord.js";
+import { finiteNumber } from "../../common/finiteNumber.js";
 
 const FIVE_HOUR_MINUTES = 300;
 const SEVEN_DAY_MINUTES = 7 * 24 * 60;

--- a/server/agents/rate-limit-persist.spec.ts
+++ b/server/agents/rate-limit-persist.spec.ts
@@ -11,6 +11,27 @@ const snapshot = (percent: number): RateLimitSnapshot => ({
 
 const cachedPercent = (file: string): number | null | undefined => parseRateLimitCache(readFileSync(file, "utf8")).codex?.limits.fiveHour?.usedPercentage;
 
+// The file survives upgrades, so it is the one input guaranteed to have been written by a
+// different version of this code — junk in it must cost the head start, never the feature.
+describe("parseRateLimitCache", () => {
+  it.each([
+    ["not JSON at all", "{ not json"],
+    ["a JSON array", "[]"],
+    // #1074 swapped a hand-copied `isRecord` for the shared one, which REJECTS arrays where the
+    // copy accepted them. Same answer either way — pinned so the swap stays invisible.
+    ["an array holding what looks like an entry", '[{"codex":{"limits":{"fiveHour":{"usedPercentage":5}},"reportedAt_ms":1}}]'],
+    ["an entry that is an array", '{"codex":[{"limits":{"fiveHour":{"usedPercentage":5}},"reportedAt_ms":1}]}'],
+    ["an entry with no timestamp", '{"codex":{"limits":{"fiveHour":{"usedPercentage":5}}}}'],
+  ])("reads %s as an empty cache", (_case, text) => {
+    expect(parseRateLimitCache(text)).toEqual({});
+  });
+
+  it("keeps an entry that carries both the limits and the timestamp", () => {
+    const text = JSON.stringify(snapshot(42));
+    expect(parseRateLimitCache(text).codex?.limits.fiveHour?.usedPercentage).toBe(42);
+  });
+});
+
 describe("createRateLimitCacheWriter", () => {
   let dir: string;
   let file: string;

--- a/server/agents/rate-limit-persist.ts
+++ b/server/agents/rate-limit-persist.ts
@@ -12,11 +12,10 @@ import path from "node:path";
 import { MULMOTERMINAL_HOME } from "../config/env.js";
 import type { RateLimitSnapshot } from "./rate-limit-store.js";
 import { parseRateLimits } from "../../common/rateLimits.js";
+import { isRecord } from "../../common/isRecord.js";
+import { finiteNumber } from "../../common/finiteNumber.js";
 
 export const rateLimitCacheFile = (): string => path.join(MULMOTERMINAL_HOME, "rate-limits.json");
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
-const finite = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
 
 /**
  * What was cached, as the store's own shape. Every field is re-validated rather than trusted: this
@@ -31,7 +30,7 @@ export function parseRateLimitCache(text: string): RateLimitSnapshot {
       const entry = parsed[agent];
       if (!isRecord(entry)) return [];
       const limits = parseRateLimits(entry.limits);
-      const reportedAt_ms = finite(entry.reportedAt_ms);
+      const reportedAt_ms = finiteNumber(entry.reportedAt_ms);
       return limits && reportedAt_ms !== null ? [[agent, { limits, reportedAt_ms }] as const] : [];
     });
     return Object.fromEntries(entries);

--- a/server/agents/statusline.spec.ts
+++ b/server/agents/statusline.spec.ts
@@ -47,6 +47,10 @@ describe("extractRateLimits", () => {
     expect(extractRateLimits("not json")).toBeNull();
     expect(extractRateLimits(payload("nope"))).toBeNull();
     expect(extractRateLimits(payload({ five_hour: 5 }))).toBeNull();
+    // #1074 swapped a hand-copied `isRecord` for the shared one, which REJECTS arrays where the
+    // copy accepted them. Same answer either way — pinned so the swap stays invisible.
+    expect(extractRateLimits([])).toBeNull();
+    expect(extractRateLimits(payload([{ used_percentage: 23.5 }]))).toBeNull();
   });
 });
 

--- a/server/agents/statusline.ts
+++ b/server/agents/statusline.ts
@@ -16,11 +16,10 @@
 // "show nothing", and a gauge reading 0% when the truth is 83% is the worst thing this could do.
 
 import type { RateLimits, RateLimitWindow } from "../../common/rateLimits.js";
+import { isRecord } from "../../common/isRecord.js";
+import { finiteNumber } from "../../common/finiteNumber.js";
 
 export type { RateLimits, RateLimitWindow };
-
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
-const finiteNumber = (v: unknown): number | null => (typeof v === "number" && Number.isFinite(v) ? v : null);
 
 function windowFrom(raw: unknown): RateLimitWindow | null {
   if (!isRecord(raw)) return null;

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -55,6 +55,22 @@ const HTML_PREVIEW_CSP = [
   "connect-src 'none'",
 ].join("; ");
 
+// Both preview routes end here, and it is one function because of WHICH headers these are: the
+// CSP is what gives an LLM-authored page an opaque origin, so a mount that served HTML without
+// it would run that page against the app's own origin. Both existing routes assert the header
+// (test/server/backends/html.spec.ts) — this is what makes the NEXT mount inherit it rather
+// than have to remember it.
+//
+// statSync follows symlinks, so isFile() judges the TARGET — a link to a directory or a FIFO
+// named `page.html` is refused here rather than hanging a read.
+function sendHtmlDocument(res: Response, abs: string): void {
+  if (!statFileOr404(res, abs)) return;
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Content-Security-Policy", HTML_PREVIEW_CSP);
+  streamFileToResponse(abs, res);
+}
+
 /** Intercept the View's dispatch (loadHtml/saveHtml) on /api/plugin/presentHtml,
  *  before the generic plugin catch-all (which handles the tool-call). MUST be
  *  registered BEFORE mountAllRoutes. */
@@ -95,12 +111,7 @@ export function mountHtmlPreviewRoute(app: Express, deps: { workspace: string })
       res.status(400).json({ error: "not an .html file" });
       return;
     }
-    const stat = statFileOr404(res, abs);
-    if (!stat) return;
-    res.setHeader("Content-Type", "text/html; charset=utf-8");
-    res.setHeader("X-Content-Type-Options", "nosniff");
-    res.setHeader("Content-Security-Policy", HTML_PREVIEW_CSP);
-    streamFileToResponse(abs, res);
+    sendHtmlDocument(res, abs);
   });
 }
 
@@ -137,14 +148,7 @@ export function mountHtmlFileRoute(app: Express): void {
           res.status(404).json({ error: "not found" });
           return;
         }
-        // statSync follows symlinks, so isFile() judges the TARGET — a link to a
-        // directory or a FIFO named `page.html` is refused rather than hanging a read.
-        const stat = statFileOr404(res, abs);
-        if (!stat) return;
-        res.setHeader("Content-Type", "text/html; charset=utf-8");
-        res.setHeader("X-Content-Type-Options", "nosniff");
-        res.setHeader("Content-Security-Policy", HTML_PREVIEW_CSP);
-        streamFileToResponse(abs, res);
+        sendHtmlDocument(res, abs);
       })
       .catch(() => {
         if (!res.headersSent) res.status(404).json({ error: "not found" });

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -23,7 +23,7 @@ import { codexSessionsRoot } from "../agents/codex-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
 import { codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
 import { sandboxWouldRun } from "../session/pty-spawn.js";
-import { bufferEarlyFrames } from "../session/early-frames.js";
+import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
 import { launcherCommandWithGuiMcp } from "../session/launcher-gui-mcp.js";
 import { codexGuiMcpServers } from "../session/mcp-config.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
@@ -318,6 +318,35 @@ function handleRunConnection(deps: WsRouteDeps, ws: WebSocket, req: { url?: stri
   void startRunTerminal(deps, ws, new URL(req.url ?? "/", "http://localhost"));
 }
 
+// Start the pty for a resolved session, then hand the socket to it — or fail the socket cleanly.
+//
+// One function for both agents because the ORDER is the fragile part, not the lines: the buffered
+// early frames may only be replayed once the real message listener is installed, or a frame that
+// lands mid-replay overtakes the ones before it (see early-frames.ts). Inlined, that rule was
+// written as a comment on the codex path and nowhere on the launch path.
+//
+// `start` throwing is the spawn refusing — a missing CLI, a directory that vanished. The buffer is
+// dropped rather than replayed: there is no pty to replay it into, and the socket is closing.
+export function startAndWire(
+  deps: Pick<WsRouteDeps, "handleClientFrame" | "handleClientClose">,
+  ws: WebSocket,
+  session: { id: string; tag: string; early: EarlyFrames<{ toString(): string }>; startFailureMessage: string },
+  start: () => PtyEntry,
+): void {
+  let entry: PtyEntry;
+  try {
+    entry = start();
+  } catch (err) {
+    console.error(`[ws/${session.tag}] failed to start ${session.id}: ${messageOf(err)}`);
+    session.early.discard();
+    return closeWithError(ws, session.startFailureMessage);
+  }
+  const deliver = (raw: { toString(): string }) => deps.handleClientFrame(entry, ws, raw, session.id);
+  ws.on("message", deliver);
+  ws.on("close", () => deps.handleClientClose(entry, ws, session.id));
+  session.early.release(deliver);
+}
+
 // Launcher terminal (?launcher=<index>&cwd=<dir>, ?session=<id> to reattach): run a
 // configured launch command as a persistent, reattachable PTY. Reuses the /ws session
 // lifecycle (reattach + reap grace + handleClientClose) but with no hooks/transcript,
@@ -348,18 +377,9 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: { u
     return early.discard();
   }
 
-  let entry: PtyEntry;
-  try {
-    entry = startLaunchEntry(deps, sessionId, ws, live, launchCommand, cwd);
-  } catch (err) {
-    console.error(`[ws/launch] failed to start ${sessionId}: ${messageOf(err)}`);
-    early.discard();
-    return closeWithError(ws, "Failed to start the launch command.");
-  }
-
-  ws.on("message", (raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
-  ws.on("close", () => deps.handleClientClose(entry, ws, sessionId));
-  early.release((raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
+  startAndWire(deps, ws, { id: sessionId, tag: "launch", early, startFailureMessage: "Failed to start the launch command." }, () =>
+    startLaunchEntry(deps, sessionId, ws, live, launchCommand, cwd),
+  );
 }
 
 // codex terminal (?cwd=<dir>, ?session=<id> to reattach/resume). ?gui=0 (grid dev terminal) runs
@@ -390,19 +410,10 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: { ur
     return early.discard();
   }
 
-  let entry: PtyEntry;
-  try {
-    entry = startCodexEntry(deps, ws, { sessionId, live, resumeRolloutId, cwd, attachGuiMcp, mcpGroups });
-  } catch (err) {
-    console.error(`[ws/codex] failed to start ${sessionId}: ${messageOf(err)}`);
-    early.discard();
-    return closeWithError(ws, "Failed to start codex. Is the `codex` CLI installed and on your PATH?");
-  }
-
-  ws.on("message", (raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
-  ws.on("close", () => deps.handleClientClose(entry, ws, sessionId));
-  // After the real listener is installed, so ordering holds for a frame that lands mid-replay.
-  early.release((raw) => deps.handleClientFrame(entry, ws, raw, sessionId));
+  const startFailureMessage = "Failed to start codex. Is the `codex` CLI installed and on your PATH?";
+  startAndWire(deps, ws, { id: sessionId, tag: "codex", early, startFailureMessage }, () =>
+    startCodexEntry(deps, ws, { sessionId, live, resumeRolloutId, cwd, attachGuiMcp, mcpGroups }),
+  );
 }
 
 export function mountTerminalWebSockets(deps: WsRouteDeps) {

--- a/src/composables/useRateLimits.ts
+++ b/src/composables/useRateLimits.ts
@@ -9,6 +9,7 @@
 // happens to visit, at their expense.
 import { ref } from "vue";
 import { parseRateLimits } from "../../common/rateLimits";
+import { isRecord } from "../../common/isRecord";
 import type { ClaudeProbeState, RateLimitSnapshot } from "./rateLimitGauge";
 
 const FETCH_TIMEOUT_MS = 8000;
@@ -25,7 +26,6 @@ const snapshot = ref<RateLimitSnapshot | null>(null);
 let timer: ReturnType<typeof setTimeout> | null = null;
 let watchers = 0;
 
-const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
 const PROBE_STATES: readonly ClaudeProbeState[] = ["ok", "no-claude", "no-windows", "no-report"];
 const isProbeState = (v: unknown): v is ClaudeProbeState => typeof v === "string" && (PROBE_STATES as readonly string[]).includes(v);
 

--- a/test/common/rateLimits.spec.ts
+++ b/test/common/rateLimits.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { parseRateLimits, parseRateLimitWindow } from "../../common/rateLimits";
+
+// The wire parser both sides run (#387). Its guards were hand-copied one-liners until #1074 moved
+// them to common/isRecord.ts and common/finiteNumber.ts — the shared `isRecord` REJECTS arrays
+// where the copy accepted them, so the array cases below are what pin that swap as invisible.
+describe("parseRateLimitWindow", () => {
+  it("keeps a fractional percentage and the epoch reset", () => {
+    expect(parseRateLimitWindow({ usedPercentage: 23.5, resetsAt_sec: 1738425600 })).toEqual({ usedPercentage: 23.5, resetsAt_sec: 1738425600 });
+  });
+
+  // Absent is not zero: a gauge reading 0% when the truth is 83% is the worst thing this can do.
+  it.each([
+    ["a missing percentage", { resetsAt_sec: 1738425600 }],
+    ["a percentage that is not a number", { usedPercentage: "23.5" }],
+    ["NaN, which no gauge can render", { usedPercentage: Number.NaN }],
+    ["an array", [{ usedPercentage: 23.5 }]],
+    ["null", null],
+  ])("is null for %s", (_case, raw) => {
+    expect(parseRateLimitWindow(raw)).toBeNull();
+  });
+
+  // Only the percentage is required — a window with no known reset is still a real reading.
+  it("keeps the window when only the reset is missing", () => {
+    expect(parseRateLimitWindow({ usedPercentage: 0 })).toEqual({ usedPercentage: 0, resetsAt_sec: null });
+  });
+});
+
+describe("parseRateLimits", () => {
+  it("reads both windows", () => {
+    expect(parseRateLimits({ fiveHour: { usedPercentage: 1 }, sevenDay: { usedPercentage: 2 } })).toEqual({
+      fiveHour: { usedPercentage: 1, resetsAt_sec: null },
+      sevenDay: { usedPercentage: 2, resetsAt_sec: null },
+    });
+  });
+
+  // Null rather than a pair of nulls, so a caller can tell "nothing to show" from "0% used".
+  it.each([
+    ["neither window survives", { fiveHour: null, sevenDay: {} }],
+    ["an array", [{ fiveHour: { usedPercentage: 1 } }]],
+    ["a string", "fiveHour"],
+    ["null", null],
+  ])("is null when %s", (_case, raw) => {
+    expect(parseRateLimits(raw)).toBeNull();
+  });
+
+  it("keeps the pair when only one window survives", () => {
+    expect(parseRateLimits({ fiveHour: { usedPercentage: 7 }, sevenDay: null })).toEqual({
+      fiveHour: { usedPercentage: 7, resetsAt_sec: null },
+      sevenDay: null,
+    });
+  });
+});

--- a/test/server/routes/start-and-wire.spec.ts
+++ b/test/server/routes/start-and-wire.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { startAndWire } from "../../../server/routes/ws-routes.js";
+import { bufferEarlyFrames } from "../../../server/session/early-frames.js";
+import type { PtyEntry } from "../../../server/session/types.js";
+
+// #1074 pulled this out of the launch and codex paths, which had written the same steps twice —
+// and the ORDER is what the function is for. The buffered early frames may only be replayed once
+// the real message listener is installed, or a frame that lands mid-replay overtakes the ones
+// before it. That rule used to be a comment on the codex path and absent from the launch path;
+// here it is a test.
+
+class FakeSocket {
+  readonly OPEN = 1;
+  readyState = 1;
+  sent: string[] = [];
+  closed = false;
+  private listeners = new Map<string, ((raw: unknown) => void)[]>();
+
+  on(event: string, cb: (raw: unknown) => void) {
+    this.listeners.set(event, [...(this.listeners.get(event) ?? []), cb]);
+    return this;
+  }
+  off(event: string, cb: (raw: unknown) => void) {
+    this.listeners.set(
+      event,
+      (this.listeners.get(event) ?? []).filter((l) => l !== cb),
+    );
+    return this;
+  }
+  emit(event: string, raw?: unknown) {
+    for (const l of [...(this.listeners.get(event) ?? [])]) l(raw);
+  }
+  send(text: string) {
+    this.sent.push(text);
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+const asWebSocket = (socket: FakeSocket): WebSocket => socket as unknown as WebSocket;
+const entry = { pty: null } as unknown as PtyEntry;
+
+function harness() {
+  const socket = new FakeSocket();
+  const delivered: string[] = [];
+  const handleClientClose = vi.fn();
+  const deps = {
+    handleClientFrame: (_entry: PtyEntry, _ws: WebSocket, raw: { toString(): string }): void => {
+      delivered.push(raw.toString());
+    },
+    handleClientClose,
+  };
+  const early = bufferEarlyFrames<{ toString(): string }>(asWebSocket(socket));
+  return { socket, delivered, handleClientClose, deps, early };
+}
+
+describe("startAndWire", () => {
+  it("replays what arrived before the pty existed, then live frames, in arrival order", () => {
+    const { socket, delivered, deps, early } = harness();
+    socket.emit("message", "resize-80x24"); // arrived while the spawn was still deciding
+    socket.emit("message", "first-keystroke");
+
+    startAndWire(deps, asWebSocket(socket), { id: "s1", tag: "codex", early, startFailureMessage: "nope" }, () => entry);
+    socket.emit("message", "after-spawn");
+
+    expect(delivered).toEqual(["resize-80x24", "first-keystroke", "after-spawn"]);
+  });
+
+  // The reason the release comes last: a frame landing DURING the replay must reach the real
+  // listener, not a buffer nobody drains again — and it must not overtake what was already queued.
+  it("keeps order for a frame that lands mid-replay", () => {
+    const { socket, delivered, deps, early } = harness();
+    let reentered = false;
+    const reentrantDeps = {
+      ...deps,
+      handleClientFrame: (_entry: PtyEntry, _ws: WebSocket, raw: { toString(): string }): void => {
+        delivered.push(raw.toString());
+        if (reentered) return;
+        reentered = true;
+        socket.emit("message", "landed-mid-replay");
+      },
+    };
+    socket.emit("message", "buffered-1");
+    socket.emit("message", "buffered-2");
+
+    startAndWire(reentrantDeps, asWebSocket(socket), { id: "s1", tag: "codex", early, startFailureMessage: "nope" }, () => entry);
+
+    expect(delivered).toEqual(["buffered-1", "landed-mid-replay", "buffered-2"]);
+  });
+
+  it("wires the close handler to the started entry", () => {
+    const { socket, handleClientClose, deps, early } = harness();
+    startAndWire(deps, asWebSocket(socket), { id: "s1", tag: "launch", early, startFailureMessage: "nope" }, () => entry);
+    socket.emit("close");
+    expect(handleClientClose).toHaveBeenCalledWith(entry, expect.anything(), "s1");
+  });
+
+  // A spawn that throws is a missing CLI or a directory that vanished. There is no pty to replay
+  // into, so the buffer is dropped rather than delivered, and the socket is told why.
+  describe("when the spawn refuses", () => {
+    const refuse = () => {
+      const h = harness();
+      h.socket.emit("message", "resize-80x24");
+      startAndWire(h.deps, asWebSocket(h.socket), { id: "s1", tag: "codex", early: h.early, startFailureMessage: "no codex on PATH" }, () => {
+        throw new Error("spawn failed");
+      });
+      return h;
+    };
+
+    it("closes the socket with the caller's message", () => {
+      const { socket } = refuse();
+      expect(JSON.parse(socket.sent[0])).toEqual({ type: "error", message: "no codex on PATH" });
+      expect(socket.closed).toBe(true);
+    });
+
+    it("delivers nothing, then or later", () => {
+      const { socket, delivered } = refuse();
+      socket.emit("message", "after-failure");
+      expect(delivered).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Code scanning の jscpd アラート 10 件を、ローカルで同じスキャンを走らせて**両側**を突き合わせ（アラートは片側しか出ない）、**本物の3件だけ**を潰しました。**10 → 7 件**。残った7件は「既に共有済みのものの呼び出し側」で、意図的に残しています。

`plans/refactor-jscpd-duplicates.md` の既存方針をそのまま引き継いでいます — 本当に抽象が欠けている重複だけ潰す。**誤った抽象は重複より悪い。**

純粋なリファクタで、**挙動は変えていません**。

| # | 重複 | 対応 |
|---|---|---|
| 1 | `isRecord` / `finiteNumber` の手書きコピー ×5ファイル | 共有版に寄せた |
| 2 | `server/backends/html.ts` 自己重複（CSP を含むヘッダ） | `sendHtmlDocument` に集約 |
| 3 | `server/routes/ws-routes.ts` の「起動して配線」×2 | `startAndWire` に集約 |

## Items to Confirm / Review

1. **`isRecord` の置き換えは唯一挙動が変わりうる箇所です。** ローカル版は配列を通し、共有版は弾きます。**実害が無いことは各呼び出しを追って確認済み**（配列が来ても最終的に空を返す）で、4つの入口すべてで配列の挙動が変わらないことをテストで固定しました。この判断で良いか見てください。
2. **`useCost.ts` の `finiteNumber` は畳んでいません** — `undefined` を返す変種で、このコードベースでは `null` と `undefined` は意味が違うため。
3. **`startAndWire` を export してテスト可能にしました。** private のままだと、この関数の存在理由である順序の不変条件をテストで縛れないためです。
4. **7件を意図的に残した判断**（下記）。ここが一番議論の余地があります。

## 1. `isRecord` / `finiteNumber` の手書きコピー（alert #110）

`common/isRecord.ts` は「**29ファイルにコピペされていたのを一本化した**」と自分で書いています。その手書きが5ファイルに戻ってきていて、しかも**中身が違いました**。

```ts
// ローカル版（5箇所）— 配列を通す
const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
// common/isRecord.ts — 配列を意図的に弾く
export const isRecord = (value) => isObject(value) && !Array.isArray(value);
```

共有版が配列を弾く理由もそこに書いてあります: 配列を `Record` に narrow するのは**型に嘘をつく**行為で、`Object.entries()` する呼び出し側が添字をフィールド名として歩く。

**実害の有無は確認済み: 現時点では無い。** `parseRateLimitCache` は `parsed["claude"]` が `undefined` になり空を返す、`useRateLimits.load` も同様。**直す理由は将来の実害ではなく、一本化したはずのものが戻りかけていること。**

厳しい版に変えたことで唯一観測できる差分が配列なので、4つの入口それぞれでテストを足しました。`common/rateLimits.ts` にはパーサの spec がそもそも無かったので新設しています。

`finiteNumber` は `common/finiteNumber.ts` へ。クライアントは既に `common/isRecord` を10箇所以上で import しているので、bundle 都合の分離ではありませんでした。

## 2. `server/backends/html.ts`（alert #120）

HTML を返す2経路が Content-Type / nosniff / **CSP** / stream をそれぞれ書いていました。CSP は LLM が書いたページに opaque origin を与えているものなので、これを持たない mount はそのページを**アプリ自身の origin で走らせる**ことになります。

既存の2経路はどちらも spec でヘッダを検証しているので、これは「**次に足す mount が思い出さなくても継承する**」ための変更です（コード中のコメントもそう直しました — 最初「テストが通ってしまう」と書きましたが、実際には両方検証されていたので不正確でした）。

## 3. `server/routes/ws-routes.ts`（alert #119）

launch と codex が同じ手順を書いていました。差分は起動関数・ログのタグ・エラー文言だけ。**重複そのものより、順序の不変条件が codex 側のコメントにしか書かれていなかったことが害です**:

> バッファした早期フレームを replay できるのは本物の message listener を張った後だけ。先に release すると、replay 中に届いたフレームが行き先を失う。

コメントではなくテストにしました。**`release` を listener の前に動かすと `keeps order for a frame that lands mid-replay` だけが落ちることを確認済み**です（テストが本当に効くかを確かめずに置くと、次に順序が壊れたとき静かに通ってしまうので）。

なお main の #1068 が同じ箇所を変えていた（起動失敗メッセージを err から作る）ため、`startFailureMessage` を `(err: unknown) => string` にして**main の挙動をそのまま保って**います。`SpawnBinaryError` の診断文がそのままユーザーに出る経路も維持し、テストを1本足しました。

## 残した7件（意図的）

- **Vue の6件**（#112 #113 #114 #115 #116 #102）— すべて**既に共有済み**のコンポーネント / コンポーザブルの呼び出し側です。`CellChromeButtons` の props/emit 転送（CommandCell / LauncherCell / TerminalCell）、`useSessionFilter` の定型（SessionTabBar / Sidebar）、`TerminalGrid` の TerminalCell / LauncherCell 呼び出し。これ以上畳むと「emit を props で渡すな」というルールと衝突し、どのイベントがどこへ行くのかも追えなくなります。
- **`ws-routes.ts` の #118** — 並行した構造ですが `markDevTerminalSession` の条件も `registeredGuiMcpGroups` の取り方も違います。パラメータ化すると分岐だらけの関数になります。

## 検証

- ローカルで CI と同じ jscpd を再実行し、**10 → 7 件**、狙った3件がすべて消えていること、残り7件が「残す」と決めたものと一致することを確認。
- `yarn format` / `lint` / `typecheck` ×3 / `build` / `test`（6195 passed）すべて green。origin/main（#1068 まで）をマージした後にも通しています。
- 追加したテストが**当該の不具合で実際に落ちること**を、①（配列）と③（順序）の両方で確認済み。

Fixes #1074

work in mulmoterminal2
