### PR TITLE
fix: 再アタッチ後に TUI へホイールが届かなくなる問題を修正 (#1073)

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -198,6 +198,18 @@ force the DOM renderer or observe effects (`window.open`, buffer state) instead 
   device queries (a DA reply would surface as `0;276;0c` in the prompt).
 - The replay buffer tail is sliced carefully so a cut never lands inside an escape sequence (#434),
   and is sized (~1 MiB) so scrollback survives a reattach (#776).
+- **A tail cannot carry a mode the app set once.** `CSI ? 1049 h` is written at pty offset 0 — when
+  our tmux client attaches — and never again, so past 1 MiB it is certainly gone from the replay
+  and the browser restores into the **normal** buffer. Measured on a real session: the tail had
+  five `?1003h`/`?1006h` (apps re-set those) and **zero** `?1049h`. That alone switches the wheel
+  and click synthesis off for good, since both are gated on the alternate buffer (#1073).
+  So `reattachPty` asks tmux what the pane is in right now (`tmuxTerminalModes` — `alternate_on`
+  and the `mouse_*_flag`s) and prefixes the DECSETs to the replay. tmux owns this state, which is
+  why nothing here parses the pty stream for it.
+  - **One sequence per mode.** The client only swallows a `CSI ? … h` whose parameters are ALL
+    mouse modes; `CSI ? 1049 ; 1003 h` would reach xterm and put it into real mouse tracking,
+    turning every drag into coordinate reports — the #729 regression.
+  - Only tmux-backed sessions restore; a sandbox/tmux-less pty replays as before.
 
 ## The tmux passthrough rule
 
@@ -251,7 +263,7 @@ looking) — flag them for QA on the release.
 | File-path links | `registerFilePathLinks` order vs WebLinks; `/api/files/raw` cwd containment | click a generated file path → previews the file |
 | Enter / newline | `terminalSubmit` mapping + `isComposing` guard; `macOptionIsMeta` | Enter submits, Shift+Enter newlines; IME confirm not eaten; both `cr` and `esc-cr` |
 | Mouse / wheel | `guardMouseTracking` swallow set (1000/1002/1003/1006); wheel→SGR in alt buffer; `wheelNotches` accumulation vs xterm's own `consumeWheelEvent` | wheel scrolls transcript (not prompt history); drag selects, doesn't emit mouse reports; a trackpad swipe moves a TUI about as far as it moves the scrollback |
-| Reattach | `stripTerminalQueries` patterns; replay buffer size | reattaching a session doesn't leak `0;276;0c`-style junk; scrollback survives |
+| Reattach | `stripTerminalQueries` patterns; replay buffer size; `tmuxTerminalModes` still reports `alternate_on` / `mouse_*_flag` on the installed tmux | reattaching a session doesn't leak `0;276;0c`-style junk; scrollback survives; after a reload the wheel still scrolls a Claude cell's transcript (#1073) |
 
 **Fast isolation techniques** (learned the hard way):
 - A terminal behavior that works on a **direct `term.write()`** but fails through a live session ⇒
@@ -266,4 +278,4 @@ looking) — flag them for QA on the release.
 `docs/spawn-architecture.md` (session lifecycle), `docs/gui-protocol-spike.md`,
 `docs/remote-host-protocol.md` (what the phone can ask of a session),
 `src/composables/useTerminalConnections.ts`, `server/infra/tmux.ts`, `server/session/*.ts`.
-Issues: #206, #263/#264/#293, #265/#266, #434, #445, #572, #729, #737, #772/#780, #776, #778, #782, #783/#785.
+Issues: #206, #263/#264/#293, #265/#266, #434, #445, #572, #729, #737, #772/#780, #776, #778, #782, #783/#785, #1073.

--- a/plans/fix-1073-reattach-terminal-modes.md
+++ b/plans/fix-1073-reattach-terminal-modes.md
@@ -1,0 +1,154 @@
+# Restore the terminal's sticky modes on reattach
+
+Fixes #1073. 2026-07-29.
+
+## Why
+
+After a reattach — sidebar switch, reload, second tab (`superseded`), WebSocket reconnect — a
+Claude/Codex cell stops delivering the wheel to the app. The transcript can't be scrolled past
+the current screen, and the TUI's own click targets (#845) go dead at the same moment.
+
+Both come from one gate, which requires **two** things at once:
+
+```ts
+// src/composables/terminalMouseInput.ts
+term.buffer.active.type === "alternate" && wantsMouseReports(swallowedMouseModes)
+```
+
+and a reattach destroys both:
+
+1. The client starts clean — `connect()` calls `c.term.reset()` (back to the normal buffer) and
+   `c.swallowedMouseModes.clear()` (`useTerminalConnections.ts`).
+2. The server replays only a bounded tail — `entry.buffer`, capped at 1 MiB by
+   `appendBoundedOutput` (`spawn-claude.ts`, `spawn-codex.ts`, `spawn-shell.ts`).
+3. `ESC[?1049h` is written **once, at offset 0** of the pty stream, when the tmux client attaches,
+   and never again. Past 1 MiB of output it is guaranteed to have fallen off the front of the
+   replay; the mouse modes fall off too unless the app happened to re-set them late.
+
+So xterm restores into the normal buffer with an empty mode record, `reportsMouseToApp()` is false
+forever, and nothing in an ordinary conversation puts it back (a server restart does, because the
+pty — and its offset 0 — is recreated).
+
+The history itself is fine. #1073 measured it: injecting the same SGR wheel-up report the client
+synthesises walks Claude Code back to the first turn. What is broken is **delivery**, not storage.
+
+## What
+
+Restore the modes ahead of the replay, and read them from **tmux** rather than tracking the byte
+stream ourselves. tmux is the emulator that owns this pane's state and already exposes it:
+
+```
+mt-0108e983…  cmd=2.1.220  alt=1 std=0 btn=0 all=1 sgr=1   <- Claude Code
+mt-0937e3b2…  cmd=zsh      alt=0 std=0 btn=0 all=0 sgr=0   <- shell cell
+```
+
+(measured on live sessions of this checkout, tmux 3.6a / Claude Code 2.1.220)
+
+That removes every hard part of the stream-tracking approach #1073 sketched: no DECRST tracking,
+no CSI split across pty chunks, no reset handling. One `display-message` at reattach, ~7 ms, in a
+path that already makes sync tmux calls (`tmuxPaneCommand`).
+
+| tmux flag | mode |
+|---|---|
+| `alternate_on` | 1049 |
+| `mouse_standard_flag` | 1000 |
+| `mouse_button_flag` | 1002 |
+| `mouse_all_flag` | 1003 |
+| `mouse_utf8_flag` | 1005 |
+| `mouse_sgr_flag` | 1006 |
+
+1001 / 1015 / 1016 are in the client's swallow set but tmux has no flag for them; no current agent
+asks for them, and `wantsMouseReports` needs 1006 plus one of 1000/1001/1002/1003, which the table
+covers. 2004 (bracketed paste) and cursor-key mode stay out of scope, as #1073 argues.
+
+### Pieces
+
+- `server/infra/tmux.ts` — `parseTmuxTerminalModes(stdout)` (pure) and `tmuxTerminalModes(id)`.
+  One comma-joined format string built from the same table the parser indexes, so an unknown
+  variable on an older tmux renders empty without shifting the fields.
+- `server/session/terminal-replay.ts` — `terminalModePrefix(modes)`, the DECSETs as a string.
+- `server/session/pty-connection.ts` — `reattachPty` sends `prefix + stripTerminalQueries(buffer)`,
+  and asks only when `entry.tmux`.
+- `server/index.ts` — binds the dep.
+
+### One sequence per mode, never combined
+
+`terminalModePrefix` emits `ESC[?1049h ESC[?1003h ESC[?1006h`, not `ESC[?1049;1003;1006h`. The
+client's `swallowsMouseTracking` only swallows a sequence whose parameters are **all** mouse modes;
+a combined one would pass through to xterm, which would then enable real mouse tracking and turn
+every drag into coordinate reports — the exact regression #729 exists to prevent. A test pins it.
+
+The prefix must also go through the client's parser (not a side-channel frame) so
+`guardMouseTracking`'s `?h` handler rebuilds `swallowedMouseModes`. No client change is needed.
+
+## Scope
+
+- **Not** tmux-backed sessions (`entry.tmux` false — sandbox containers, tmux-less hosts) keep
+  today's behaviour. They don't survive a server restart anyway.
+- Shell cells report `alt=0` and every flag 0, so their prefix is empty — unchanged. A shell cell
+  running vim gets `?1049h` restored, which is a bonus fix of the same bug.
+
+## Behaviour change to review
+
+Before this, a reattached Claude cell rendered its replayed tail into the **normal** buffer, so
+whatever scrolled there became xterm scrollback. After, the tail renders into the alternate buffer,
+which has none — the same as a live connection that never detached.
+
+Measured on the captured 1 MiB replay, rendered at the session's real geometry:
+
+```
+without prefix (old)   buffer=normal      scrollable above screen =  9 lines
+with prefix (new)      buffer=alternate   scrollable above screen =  0 lines
+```
+
+Nine lines, from a stream of `seq 1 200000` — the most scroll-heavy content there is. It is that
+small because tmux is the renderer: it repaints the screen in place (`ESC[H`, `ESC[30S`) instead of
+emitting newlines, so almost nothing ever reaches the outer terminal's scrollback. This is #782's
+finding, and a Claude cell (pure repaints, no line scrolling) has even less — which is why #1073's
+symptom is "nothing above the current screen appears".
+
+So the trade is 9 lines of tmux-repaint residue for the app's complete transcript. #782's selection
+limits are unchanged either way.
+
+## Tests
+
+- `parseTmuxTerminalModes`: Claude-shaped row, all-zero shell row, empty stdout, an empty field
+  from an unknown variable not shifting the rest.
+- `terminalModePrefix`: empty in / empty out; one DECSET per mode; never a combined parameter list.
+- `reattachPty`: prefix ahead of the replay; nothing for a non-tmux entry; the prefix still sent
+  when the buffer is empty; not asked for at all when the socket is closed.
+
+## Measured, against a real server
+
+A shell session put into Claude Code's state (`printf '\033[?1049h\033[?1003h\033[?1006h'`), driven
+past the 1 MiB limit, then reattached over a second socket (the `superseded` path):
+
+```
+                 before                              after
+live bytes       1415050 (overran)                   1395114 (overran)
+replay bytes     1048576                             1048600   (= tail + 24-byte prefix)
+?1049h           0 occurrences                       at offset 0
+?1003h           5, first at 720818                  at offset 8
+?1006h           5, first at 720794                  at offset 16
+```
+
+The before column is the issue's claim exactly: the mouse modes happened to survive (an app re-sets
+those), and `?1049h` did not — and the gate needs both, so the wheel was dead either way.
+
+That captured replay was then rendered both ways through `@xterm/headless` at the session's real
+geometry. The **visible screen is byte-identical**; only `buffer.active.type` differs (`alternate`
+vs `normal`). So the restore costs nothing on screen — the difference is only which buffer holds
+it, and hence the scrollback noted above.
+
+## One unrelated type change
+
+`cellFromPoint` took a `DOMRect`, the only browser type in `mouseReports.ts` — which otherwise
+holds pure rules, as its own header says. That made the module unimportable from a node test
+project, and the spec above needs exactly that. Narrowed to a local `ScreenBox` (`left/top/width/
+height`), which a `DOMRect` satisfies structurally; no call site changes.
+
+## Docs
+
+`docs/terminal-notes.md` (replay section + the mouse-tracking section) and the bug-report FAQ
+entry, which currently describes the alt-screen limits without mentioning that reattach used to
+sever wheel delivery entirely.

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import {
   tmuxPaneCommand,
   tmuxAttachedClientCount,
   tmuxCaptureStyledPane,
+  tmuxTerminalModes,
 } from "./infra/tmux.js";
 import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage } from "./infra/sandbox.js";
 import { bindSecurityWarning, browserOriginHostnames, createIsAllowedOrigin } from "./infra/allowed-origin.js";
@@ -200,6 +201,7 @@ const { reattachPty, handleClientFrame, handleClientClose } = createConnectionHa
   reap: (id) => reap(id),
   setWaiting: (id, waiting) => setWaiting(id, waiting),
   armReapForDetached: (id) => armReapForDetached(id),
+  terminalModesOf: (id) => tmuxTerminalModes(id),
 });
 
 // Mirrors session activity into Firestore so the phone's terminal viewer can refresh

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -291,6 +291,47 @@ export function tmuxPaneCommand(id: string): string | null {
   return name === "" ? null : name;
 }
 
+// The pane state that an application SETS ONCE and then relies on forever: which screen buffer
+// it owns, and which mouse reports it asked for. Read back as the DEC private modes that would
+// re-establish it (#1073).
+//
+// Needed because the reattach replay is a bounded tail: `CSI ? 1049 h` is written at pty offset 0
+// (when our tmux client attaches) and never again, so past ~1 MiB it is gone from the replay and
+// the browser restores into the normal buffer — which silently disables the wheel and click
+// synthesis, both gated on the alternate buffer (see session/terminal-replay.ts).
+//
+// Asking tmux instead of tracking the byte stream is what keeps this small: tmux is the emulator
+// that owns the state, so there is no DECRST bookkeeping and no CSI split across pty chunks.
+//
+// 1001/1015/1016 are in the client's swallow set but tmux has no flag for them. No agent we run
+// asks for them, and the client needs 1006 plus one tracking mode — which this covers.
+const TERMINAL_MODE_FLAGS = [
+  { flag: "alternate_on", mode: 1049 },
+  { flag: "mouse_standard_flag", mode: 1000 },
+  { flag: "mouse_button_flag", mode: 1002 },
+  { flag: "mouse_all_flag", mode: 1003 },
+  { flag: "mouse_utf8_flag", mode: 1005 },
+  { flag: "mouse_sgr_flag", mode: 1006 },
+] as const;
+
+// Comma-separated, not space: a variable an older tmux doesn't know renders EMPTY, and only a
+// delimiter that survives an empty field keeps the rest of the values on their own modes.
+const TERMINAL_MODE_FORMAT = TERMINAL_MODE_FLAGS.map(({ flag }) => `#{${flag}}`).join(",");
+
+/** Parse one `TERMINAL_MODE_FORMAT` line into the modes that are on. Positional against the same
+ *  table the format is built from, so the two cannot drift. */
+export function parseTmuxTerminalModes(stdout: string): number[] {
+  const values = stdout.trim().split(",");
+  return TERMINAL_MODE_FLAGS.filter((_, i) => values[i] === "1").map(({ mode }) => mode);
+}
+
+// Empty rather than null when tmux can't answer: an unreadable session and a plain shell lead to
+// the same action — restore nothing — so a nullable would only push a `?? []` onto every caller.
+export function tmuxTerminalModes(id: string): number[] {
+  const r = tmux(["display-message", "-p", "-t", tmuxSessionName(id), TERMINAL_MODE_FORMAT]);
+  return r.status === 0 ? parseTmuxTerminalModes(r.stdout) : [];
+}
+
 // Parse `#{session_attached}`. Its own function so the "unreadable means nobody" rule is
 // testable: a caller deciding whether to KILL a session must not read a failure as 0.
 export function parseAttachedClientCount(stdout: string): number | null {

--- a/server/session/pty-connection.ts
+++ b/server/session/pty-connection.ts
@@ -9,7 +9,7 @@ import type { IPty } from "node-pty";
 import type { WebSocket } from "ws";
 import { messageOf } from "../errors.js";
 import { isResizeFrame } from "./ws-frames.js";
-import { stripTerminalQueries } from "./terminal-replay.js";
+import { stripTerminalQueries, terminalModePrefix } from "./terminal-replay.js";
 import type { PtyEntry } from "./types.js";
 
 /** A frame as it arrives off the socket. Only `toString()` is used — ws hands us a
@@ -24,6 +24,9 @@ export interface ConnectionDeps {
   setWaiting: (id: string, waiting: boolean) => void;
   /** Socket gone: keep, grace, or reap according to what the session was doing. */
   armReapForDetached: (id: string) => void;
+  /** The screen-buffer / mouse modes this session's pane is in right now, for the replay to
+   *  re-establish (#1073). Empty when there is nothing to restore. */
+  terminalModesOf: (id: string) => readonly number[];
 }
 
 // browser -> command PTY. Like handleClientFrame but for the session-less command
@@ -65,10 +68,16 @@ export function createConnectionHandlers(deps: ConnectionDeps) {
       entry.ws.close();
     }
     entry.ws = ws;
-    if (entry.buffer && ws.readyState === ws.OPEN) {
+    if (ws.readyState === ws.OPEN) {
+      // The replay is a bounded TAIL, and the modes an app sets once at startup — the alternate
+      // buffer above all — fell off its front long ago. Restore them first, or the browser draws
+      // this into the normal buffer and the wheel stops reaching the app (#1073). Only a tmux
+      // session can be asked; anything else replays as before.
+      const prefix = entry.tmux ? terminalModePrefix(deps.terminalModesOf(sessionId)) : "";
       // Strip terminal queries from the replay so xterm doesn't re-answer them as stray input
       // (e.g. a DA reply surfacing as "0;276;0c" in the prompt) — see terminal-replay.ts.
-      ws.send(JSON.stringify({ type: "output", data: stripTerminalQueries(entry.buffer) }));
+      const data = prefix + stripTerminalQueries(entry.buffer);
+      if (data) ws.send(JSON.stringify({ type: "output", data }));
     }
     return entry;
   }

--- a/server/session/terminal-replay.ts
+++ b/server/session/terminal-replay.ts
@@ -23,6 +23,21 @@ export function stripTerminalQueries(data: string): string {
   return QUERY_PATTERNS.reduce((out, re) => out.replace(re, ""), data);
 }
 
+// The DECSETs that put a reattaching browser back into the screen buffer and mouse modes the app
+// set once and never repeated (#1073) — read from tmux, sent AHEAD of the replay so the tail
+// renders where it was written.
+//
+// ONE SEQUENCE PER MODE, never `CSI ? 1049 ; 1003 h`. The client only swallows a sequence whose
+// parameters are ALL mouse modes (src/composables/mouseTrackingModes.ts); a combined one would
+// reach xterm, which would then do the mouse tracking itself and turn every drag into coordinate
+// reports instead of a text selection — the regression #729 exists to prevent.
+//
+// Order within the prefix doesn't matter (the client records modes into a Set, and xterm's mouse
+// state survives the buffer switch). Preceding the replay is what matters.
+export function terminalModePrefix(modes: readonly number[]): string {
+  return modes.map((mode) => `${ESC}[?${mode}h`).join("");
+}
+
 // A CSI sequence closes with a final byte in 0x40-0x7E; an OSC string closes with BEL
 // or ST. Neither can appear inside the sequence before its terminator, so the first
 // occurrence IS the end.

--- a/server/skills/mulmoterminal-bug-report/faq.md
+++ b/server/skills/mulmoterminal-bug-report/faq.md
@@ -86,6 +86,12 @@ file and open it in the browser viewer (source/text files render inline, #785), 
 screen-by-screen. Background and the parked shell-cell fix live in #782 and docs/terminal-notes.md;
 **do not open a new issue** — add repro details to #782.
 
+Scrolling that history with the wheel does work, and is a separate thing from selecting it. If the
+wheel itself stops moving a Claude/Codex cell after a reload or a session switch, that was #1073 —
+the alternate-screen SET fell off the front of the bounded replay, so the browser came back in the
+normal buffer and the wheel had nothing to deliver to. Fixed by restoring the pane's modes from
+tmux ahead of the replay; on a version that has the fix, report it as a new bug.
+
 ## The phone's terminal view shows no directory or branch
 
 source: server/backends/remoteHost/terminalScreen.ts

--- a/src/composables/mouseReports.ts
+++ b/src/composables/mouseReports.ts
@@ -143,11 +143,21 @@ export interface GridCell {
   row: number;
 }
 
+/** The four numbers a cell mapping needs out of the screen element's box. Named here rather
+ *  than taken as `DOMRect` so these rules stay usable without the DOM lib — a `DOMRect`
+ *  satisfies it structurally, and this is the module's only reference to a browser type. */
+export interface ScreenBox {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 const clamp = (value: number, max: number): number => Math.min(Math.max(value, 1), max);
 
 /** The 1-based cell under a pointer position, clamped to the grid. xterm 6 exposes no
  *  pixel-to-cell mapping, so the cell size comes from the screen element's own box. */
-export function cellFromPoint(rect: DOMRect, cols: number, rows: number, pointer: PointerPosition): GridCell {
+export function cellFromPoint(rect: ScreenBox, cols: number, rows: number, pointer: PointerPosition): GridCell {
   if (rect.width <= 0 || rect.height <= 0 || cols <= 0 || rows <= 0) return { col: 1, row: 1 };
   const col = Math.floor((pointer.clientX - rect.left) / (rect.width / cols)) + 1;
   const row = Math.floor((pointer.clientY - rect.top) / (rect.height / rows)) + 1;

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -6,6 +6,7 @@ import {
   isResumableTmuxSession,
   parseTmuxEnvironment,
   parseAttachedClientCount,
+  parseTmuxTerminalModes,
   planMsOverride,
   MS_OVERRIDE_ENTRY,
 } from "../../../server/infra/tmux";
@@ -220,5 +221,33 @@ describe("parseAttachedClientCount", () => {
     expect(parseAttachedClientCount("no server running")).toBeNull();
     expect(parseAttachedClientCount("-1")).toBeNull();
     expect(parseAttachedClientCount("1.5")).toBeNull();
+  });
+});
+
+// Fields, in order: alternate_on, mouse_standard_flag, mouse_button_flag, mouse_all_flag,
+// mouse_utf8_flag, mouse_sgr_flag.
+describe("parseTmuxTerminalModes", () => {
+  // Measured on a live Claude Code 2.1.220 pane under tmux 3.6a.
+  it("reads a mouse TUI's pane as the alternate buffer plus its tracking and SGR modes", () => {
+    expect(parseTmuxTerminalModes("1,0,0,1,0,1\n")).toEqual([1049, 1003, 1006]);
+  });
+
+  it("reads a plain shell's pane as nothing to restore", () => {
+    expect(parseTmuxTerminalModes("0,0,0,0,0,0\n")).toEqual([]);
+  });
+
+  it("maps the older tracking flags too", () => {
+    expect(parseTmuxTerminalModes("1,1,1,0,1,1")).toEqual([1049, 1000, 1002, 1005, 1006]);
+  });
+
+  // A tmux that doesn't know a variable renders it EMPTY. The remaining fields must keep their
+  // own modes rather than sliding onto the previous one.
+  it("keeps the fields aligned when a variable is unknown to this tmux", () => {
+    expect(parseTmuxTerminalModes("1,0,0,,,1")).toEqual([1049, 1006]);
+  });
+
+  it("restores nothing from output tmux could not produce", () => {
+    expect(parseTmuxTerminalModes("")).toEqual([]);
+    expect(parseTmuxTerminalModes("no server running")).toEqual([]);
   });
 });

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -46,13 +46,17 @@ function fakeSocket(readyState = OPEN) {
   };
 }
 
-function setup() {
+function setup(terminalModes: readonly number[] = []) {
   const calls: string[] = [];
   const handlers = createConnectionHandlers({
     cancelReap: (id) => calls.push(`cancelReap:${id}`),
     reap: (id) => calls.push(`reap:${id}`),
     setWaiting: (id, waiting) => calls.push(`setWaiting:${id}:${waiting}`),
     armReapForDetached: (id) => calls.push(`armReap:${id}`),
+    terminalModesOf: (id) => {
+      calls.push(`terminalModes:${id}`);
+      return terminalModes;
+    },
   });
   return { ...handlers, calls };
 }
@@ -251,10 +255,54 @@ describe("reattachPty", () => {
     expect(s.parsed()[0].data).not.toContain("\x1b[c");
   });
 
-  it("sends nothing when there is no buffered output", () => {
+  it("sends nothing when there is no buffered output and no modes to restore", () => {
     const { reattachPty } = setup();
     const s = fakeSocket();
     reattachPty(entryWith({ ws: null, buffer: "" }), s.ws as never, SESSION);
+    expect(s.sent).toEqual([]);
+  });
+
+  // #1073: `CSI ? 1049 h` is written once at pty offset 0 and has long fallen off the bounded
+  // tail, so without this the browser restores into the NORMAL buffer and the wheel and click
+  // synthesis (#737/#845) stay switched off for the rest of the session.
+  it("re-establishes the pane's modes before replaying the tail", () => {
+    const { reattachPty } = setup([1049, 1003, 1006]);
+    const s = fakeSocket();
+    const entry = entryWith({ ws: null, buffer: "previous output", tmux: true });
+    reattachPty(entry, s.ws as never, SESSION);
+    expect(s.parsed()).toEqual([{ type: "output", data: `\x1b[?1049h\x1b[?1003h\x1b[?1006h${"previous output"}` }]);
+  });
+
+  it("restores the modes even when the tail is empty", () => {
+    // A session reattached right after a reset has nothing to replay and still owns the alt buffer.
+    const { reattachPty } = setup([1049]);
+    const s = fakeSocket();
+    reattachPty(entryWith({ ws: null, buffer: "", tmux: true }), s.ws as never, SESSION);
+    expect(s.parsed()).toEqual([{ type: "output", data: "\x1b[?1049h" }]);
+  });
+
+  it("asks nothing of tmux for a session that isn't tmux-backed", () => {
+    const { reattachPty, calls } = setup([1049]);
+    const s = fakeSocket();
+    reattachPty(entryWith({ ws: null, buffer: "sandboxed output" }), s.ws as never, SESSION);
+    expect(calls).toEqual([`cancelReap:${SESSION}`]);
+    expect(s.parsed()).toEqual([{ type: "output", data: "sandboxed output" }]);
+  });
+
+  it("leaves a pane with nothing sticky set replaying exactly as before", () => {
+    // A plain shell reports every flag off — restoring `?1049h` there would strand it in an
+    // alternate buffer it never asked for, losing its scrollback.
+    const { reattachPty } = setup([]);
+    const s = fakeSocket();
+    reattachPty(entryWith({ ws: null, buffer: "$ ls\n", tmux: true }), s.ws as never, SESSION);
+    expect(s.parsed()).toEqual([{ type: "output", data: "$ ls\n" }]);
+  });
+
+  it("does not query a socket that is already gone", () => {
+    const { reattachPty, calls } = setup([1049]);
+    const s = fakeSocket(CLOSED);
+    reattachPty(entryWith({ ws: null, buffer: "x", tmux: true }), s.ws as never, SESSION);
+    expect(calls).toEqual([`cancelReap:${SESSION}`]);
     expect(s.sent).toEqual([]);
   });
 

--- a/test/server/session/reattach-mode-restore.spec.ts
+++ b/test/server/session/reattach-mode-restore.spec.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { Terminal } from "@xterm/headless";
+import { terminalModePrefix } from "../../../server/session/terminal-replay";
+import { parseTmuxTerminalModes } from "../../../server/infra/tmux";
+import { swallowsMouseTracking } from "../../../src/composables/mouseTrackingModes";
+import { recordSwallowedModes, wantsMouseReports } from "../../../src/composables/mouseReports";
+
+// Does the server's reattach prefix actually switch the wheel back on? (#1073)
+//
+// It lives under test/server/ despite driving a src/ rule, for the reason given in
+// notify-kind-from-server.spec.ts: these modules are pure TypeScript, so they run under node.
+//
+// The unit specs on either side can both pass while the fix does nothing. The prefix has to
+// survive the CLIENT's parser, which deliberately drops mouse-tracking SETs (#729) and records
+// them instead — so the same bytes must end up in two different places: 1049 applied by xterm,
+// 1000/1002/1003/1006 swallowed into the record the wheel and click synthesis read (#737/#845).
+// Get that split wrong and the replay restores a terminal that still ignores the wheel, which is
+// exactly the bug. So this runs the real prefix through the real handlers on a real terminal.
+
+const write = (term: Terminal, data: string) => new Promise<void>((resolve) => term.write(data, resolve));
+
+// Mirrors guardMouseTracking() in src/composables/useTerminalConnections.ts.
+function attachGuard(term: Terminal): Set<number> {
+  const swallowedMouseModes = new Set<number>();
+  term.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+    const swallowed = swallowsMouseTracking(params);
+    if (swallowed) recordSwallowedModes(swallowedMouseModes, params);
+    return swallowed;
+  });
+  return swallowedMouseModes;
+}
+
+// The gate both mouse handlers answer to — src/composables/terminalMouseInput.ts.
+const reportsMouseToApp = (term: Terminal, modes: ReadonlySet<number>): boolean => term.buffer.active.type === "alternate" && wantsMouseReports(modes);
+
+// What tmux reports for a Claude Code pane: alternate buffer, any-motion tracking, SGR encoding.
+const CLAUDE_PANE = "1,0,0,1,0,1";
+const SHELL_PANE = "0,0,0,0,0,0";
+
+describe("restoring a reattached session's terminal modes", () => {
+  // The bug: a reattach replays a tail that no longer contains the startup `?1049h`, so the
+  // browser sits in the normal buffer and the gate is false however much the user scrolls.
+  it("leaves the wheel disconnected when the replay carries no modes", async () => {
+    const term = new Terminal({ allowProposedApi: true });
+    const modes = attachGuard(term);
+    await write(term, "a Claude turn from the middle of the stream\r\n");
+    expect(reportsMouseToApp(term, modes)).toBe(false);
+    term.dispose();
+  });
+
+  it("hands the wheel back when the prefix goes in ahead of the same replay", async () => {
+    const term = new Terminal({ allowProposedApi: true });
+    const modes = attachGuard(term);
+    await write(term, terminalModePrefix(parseTmuxTerminalModes(CLAUDE_PANE)) + "a Claude turn from the middle of the stream\r\n");
+    expect(reportsMouseToApp(term, modes)).toBe(true);
+    term.dispose();
+  });
+
+  it("puts each mode where it belongs: 1049 applied, the mouse modes swallowed", async () => {
+    const term = new Terminal({ allowProposedApi: true });
+    const modes = attachGuard(term);
+    await write(term, terminalModePrefix(parseTmuxTerminalModes(CLAUDE_PANE)));
+    expect(term.buffer.active.type).toBe("alternate");
+    expect([...modes].sort()).toEqual([1003, 1006]);
+    // Swallowed means xterm itself never tracks the mouse — a drag stays a text selection (#729).
+    expect(term.modes.mouseTrackingMode).toBe("none");
+    term.dispose();
+  });
+
+  it("restores nothing for a plain shell pane, which owns the normal buffer and its scrollback", async () => {
+    const term = new Terminal({ allowProposedApi: true });
+    const modes = attachGuard(term);
+    await write(term, terminalModePrefix(parseTmuxTerminalModes(SHELL_PANE)) + "$ ls\r\n");
+    expect(term.buffer.active.type).toBe("normal");
+    expect(reportsMouseToApp(term, modes)).toBe(false);
+    term.dispose();
+  });
+});

--- a/test/server/session/terminal-replay.spec.ts
+++ b/test/server/session/terminal-replay.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { appendBoundedOutput, stripTerminalQueries } from "../../../server/session/terminal-replay.js";
+import { appendBoundedOutput, stripTerminalQueries, terminalModePrefix } from "../../../server/session/terminal-replay.js";
 
 const ESC = String.fromCharCode(0x1b);
 const BEL = String.fromCharCode(0x07);
@@ -138,5 +138,22 @@ describe("appendBoundedOutput", () => {
   it("stays within the limit", () => {
     const stream = `${"z".repeat(500)}\n${"w".repeat(500)}`;
     expect(appendBoundedOutput(stream, "more", 64).length).toBeLessThanOrEqual(64);
+  });
+});
+
+describe("terminalModePrefix", () => {
+  it("re-establishes each mode the reattaching browser lost", () => {
+    expect(terminalModePrefix([1049, 1003, 1006])).toBe(`${ESC}[?1049h${ESC}[?1003h${ESC}[?1006h`);
+  });
+
+  it("sends nothing when the pane has nothing sticky to restore", () => {
+    expect(terminalModePrefix([])).toBe("");
+  });
+
+  // A combined `CSI ? 1049 ; 1003 h` is NOT all mouse modes, so the client would let it through to
+  // xterm — which would then track the mouse itself and turn every drag into coordinate reports
+  // instead of a text selection (#729). One sequence per mode is what keeps the swallow working.
+  it("never combines modes into one parameter list", () => {
+    expect(terminalModePrefix([1049, 1003, 1006])).not.toContain(";");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1073 — after a reattach (リロード / サイドバーでのセッション切り替え / 別タブ / WebSocket 再接続)、Claude・Codex セルでホイールによる履歴スクロールと TUI のクリック要素が効かなくなる問題。

原因は `?1049h`（代替スクリーン開始）が **pty offset 0 で1回だけ**流れ、再アタッチ時にサーバが返す末尾 1 MiB からは確実に落ちること。クライアントは normal バッファのまま復元され、ホイール/クリック合成（#737/#845）のゲート `alternate バッファ AND マウスモード` が false のまま固定される。

修正は **tmux に現在の状態を尋ねて、リプレイの前に DECSET を前置きする**。#1073 が検討していた「pty バイト列を舐めてスティッキー状態を追跡する」方式は採らなかった — tmux がこの状態を持つエミュレータ本人なので、DECRST の追跡もチャンク境界をまたぐ CSI の処理も不要になる。クライアント側の変更はゼロ（前置きが既存パーサを通り `swallowedMouseModes` が再構築される）。

```
mt-0108e983…  cmd=2.1.220  alt=1 std=0 btn=0 all=1 sgr=1   <- Claude Code
mt-0937e3b2…  cmd=zsh      alt=0 std=0 btn=0 all=0 sgr=0   <- シェルセル
```

## Items to Confirm / Review

1. **スクロールバックの trade-off（要判断）** — リプレイが alternate バッファに描かれるので、再アタッチ後の xterm 側スクロールバックが無くなる。実測すると、その「失われる分」は **9 行**だった（`seq 1 200000` という最もスクロールしやすいストリームで、1 MiB のリプレイを実ジオメトリで描画）。tmux が `ESC[H` / `ESC[30S` で画面をその場で再描画するため、外側の端末にはほとんど何も渡らない（#782 の知見）。Claude セルは純粋な再描画なのでさらに少なく、それが #1073 の「今の画面より上が出ない」という症状そのもの。**9 行の tmux 再描画残骸 と アプリ本体の完全な履歴 の交換**という理解でよいか確認したい。
2. **可視スクリーンは不変** — 同じリプレイを headless xterm で両方描画して比較したところ、可視 30 行は完全一致。差は `buffer.active.type` のみ。
3. **`terminalModePrefix` はモードごとに1シーケンス**（`CSI ? 1049 ; 1003 h` にしない）。クライアントは「全パラメータがマウスモード」の場合のみ swallow するので、結合すると xterm に届いて実際のマウストラッキングが有効になり、ドラッグが座標レポートになる（#729 の退行）。テストで固定している。
4. **コスト** — 再アタッチごとに `display-message` が1回（実測 ~7 ms）。既に同期 tmux 呼び出しをしているパス（`tmuxPaneCommand`）と同じ扱い。グリッドの一括リロードで N セッション分走る点は許容と判断した。
5. **スコープ外** — tmux を使わないセッション（サンドボックス / tmux 未インストール）は従来どおり。シェルセルは全フラグ 0 なので前置きなしで完全に不変。1001/1015/1016 は tmux にフラグが無く、2004 と cursor-key mode は #1073 の判断どおり対象外。
6. **付随する型変更** — `cellFromPoint` の `DOMRect` を局所的な `ScreenBox` に置換。`mouseReports.ts` で唯一のブラウザ型で、これがあると node 側テストプロジェクトから import できず、下記の結合テストが書けなかった。`DOMRect` は構造的に適合するので呼び出し側は無変更。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1073 これって私も気になっていたけど、原因わかる？
>
> はい、できる限り改善するようにつめていって。

## 実装

| ファイル | 変更 |
|---|---|
| `server/infra/tmux.ts` | `parseTmuxTerminalModes`（純粋）と `tmuxTerminalModes(id)`。フラグ表から組み立てた1つのフォーマット文字列を、同じ表で位置解析する |
| `server/session/terminal-replay.ts` | `terminalModePrefix(modes)` — DECSET を並べた文字列 |
| `server/session/pty-connection.ts` | `reattachPty` が `prefix + stripTerminalQueries(buffer)` を送る。`entry.tmux` のときだけ問い合わせる |
| `server/index.ts` | dep の bind |

| tmux フラグ | mode |
|---|---|
| `alternate_on` | 1049 |
| `mouse_standard_flag` | 1000 |
| `mouse_button_flag` | 1002 |
| `mouse_all_flag` | 1003 |
| `mouse_utf8_flag` | 1005 |
| `mouse_sgr_flag` | 1006 |

フォーマットの区切りはスペースではなくカンマ。古い tmux が知らない変数は**空**に展開されるので、空フィールドが潰れない区切りでないと残りの値が別の mode にずれる。

## 実測（実サーバに対する A/B）

シェルセッションを Claude Code と同じ状態にし（`printf '\033[?1049h\033[?1003h\033[?1006h'`）、1 MiB を超えるまで出力させてから、2本目のソケットで再アタッチ（`superseded` 経路）:

```
                 修正前                              修正後
live bytes       1415050 (overran)                   1395114 (overran)
replay bytes     1048576                             1048600   (= tail + 24 byte の前置き)
?1049h           0 occurrences                       offset 0
?1003h           5, first at 720818                  offset 8
?1006h           5, first at 720794                  offset 16
```

修正前の列は #1073 の主張どおり: マウスモードは（アプリが再送するので）たまたま残っていて、`?1049h` は残っていない。ゲートは両方を要求するので、いずれにせよホイールは死んでいた。

## テスト

- `parseTmuxTerminalModes` — Claude 形状 / シェル形状 / 空出力 / 未知の変数による空フィールドで位置がずれないこと
- `terminalModePrefix` — 空入力、mode ごとに1シーケンス、パラメータを結合しないこと
- `reattachPty` — リプレイの前に前置きされること、非 tmux セッションでは問い合わせないこと、バッファが空でも前置きは送ること、閉じたソケットには問い合わせないこと
- `test/server/session/reattach-mode-restore.spec.ts`（新規）— **サーバの前置きを、クライアントの実際のパーサに、実際の headless terminal 上で通す結合テスト**。両側の単体テストが揃って通っていても修正が無効になりうる箇所（1049 は xterm に適用され、マウスモードは swallow されて記録に入る、という振り分け）を固定する

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test`（418 files, 6231 tests）すべて green。

## ドキュメント

`docs/terminal-notes.md`（replay 節と QA マトリクス）と `server/skills/mulmoterminal-bug-report/faq.md`。設計メモは `plans/fix-1073-reattach-terminal-modes.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3
