### PR TITLE
docs: 検索される一行に統一（README / npm / docs サイト）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mulmoterminal
 
-**Run a whole team of coding agents from your browser — and actually keep up with them.**
+**Run multiple Claude Code and Codex sessions in parallel — and see which one needs you.**
 
 A **browser terminal** for **parallel AI coding agents**: several **Claude Code** and **Codex**
 sessions side by side, each in its own cell, with the one that needs you marked in colour. Vibe

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,8 @@
 title: MulmoTerminal Guide
 description: >-
-  User guide for MulmoTerminal — the grid view, everyday workflows, the full
-  feature list, and configuration. 日本語 / English.
+  Run multiple Claude Code and Codex sessions in parallel — a browser terminal grid
+  that shows which agent needs you. Setup, the grid view, git worktrees, phone push
+  and configuration. 日本語 / English.
 # Built via GitHub Actions (see .github/workflows/pages.yml) with Jekyll 4 + the just-the-docs
 # gem (docs/Gemfile), so we can use the current theme instead of the legacy Pages Jekyll 3.9 builder.
 theme: just-the-docs

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 title: Home
 layout: default
 nav_order: 1
+description: Run multiple Claude Code and Codex sessions in parallel — a browser terminal grid that shows which agent needs you. 複数の AI コーディングエージェントを並列で回し、どれが自分待ちかを一目で。ローカル・tmux 永続化・MIT。
 ---
 
 # MulmoTerminal Guide

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulmoterminal",
   "version": "2.7.0",
-  "description": "MulmoTerminal — browser terminal + GUI panel for Claude Code. One command to start.",
+  "description": "Run multiple Claude Code and Codex sessions in parallel — a browser terminal grid that shows which agent needs you. Local, tmux-backed.",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -9,13 +9,18 @@
     "url": "git+https://github.com/receptron/mulmoterminal.git"
   },
   "keywords": [
-    "claude",
     "claude-code",
+    "codex",
+    "ai-agents",
+    "agentic-coding",
+    "vibe-coding",
     "terminal",
-    "gui",
-    "ai",
-    "agent",
-    "mulmoterminal"
+    "parallel-agents",
+    "tmux",
+    "git-worktree",
+    "xterm",
+    "mulmoterminal",
+    "claude"
   ],
   "bin": {
     "mulmoterminal": "bin/mulmoterminal.js",
@@ -143,5 +148,6 @@
     "vitest": "^4.1.10",
     "vue-eslint-parser": "^10.4.1",
     "vue-tsc": "^3.3.8"
-  }
+  },
+  "homepage": "https://receptron.github.io/mulmoterminal/"
 }


### PR DESCRIPTION
## Summary

**検索面のメタデータを揃えました。** GitHub 側（description / topics / homepage）は `gh repo edit` で設定済みで、この PR はリポジトリ内のファイル分です。

## 発見: 主要なメタデータが空でした

| 場所 | 変更前 | 対応 |
|---|---|---|
| **GitHub repo description** | **空** | ✅ 設定済み（PR外・`gh repo edit`） |
| **GitHub topics** | **空** | ✅ 12個設定済み（PR外） |
| **GitHub homepage** | **空** | ✅ 設定済み（PR外） |
| **npm description** | v1時代の文言（並列も Codex も無し） | 本PR |
| **npm keywords** | 7個・`codex` 等が欠落 | 本PR（12個に） |
| `docs/index.md` | **description 無し**（サイトの入口なのに） | 本PR |
| `docs/_config.yml` | 「ユーザーガイド」としか書いていない | 本PR |
| README タグライン | 詩的だが検索語が無い | 本PR |

## 統一した一行

```
Run multiple Claude Code and Codex sessions in parallel —
a browser terminal grid that shows which agent needs you.
```

**「terminal for vibe coding」にしなかった理由:**

1. **競争が激しすぎる** — `vibe coding tools` は大手まとめサイトが上位を占有
2. **意図が合わない** — その語で検索するのは「これから始めたい人」。本製品は「**既に複数走らせて困っている人**」向け
3. **差分が無い** — Claude Code 自体が "terminal for vibe coding"

代わりに、ユーザーインタビュー4名＋自発的な記事2本で**全員が実際に使っていた語彙**を採用しました。

- `multiple Claude Code sessions` — 実際に検索される語
- `in parallel` / `browser terminal grid` — 差分
- `which agent needs you` — **6人全員が語った痛み**

`vibe-coding` は topics に残してあり、README 本文にも出てきます（狙わないのではなく、**主役にしない**）。

## Items to Confirm / Review

- [ ] README のタグライン変更 — 変更前は "Run a whole team of coding agents from your browser — and actually keep up with them."。詩的でしたが検索語が無く、"a whole team" は[インタビューの実態](並列数 1〜6)とも合っていませんでした
- [ ] npm の description 差し替え（次回 publish で反映されます）
- [ ] topics 12個の妥当性: `claude-code` `codex` `ai-agents` `agentic-coding` `vibe-coding` `terminal` `parallel-agents` `tmux` `git-worktree` `xterm-js` `typescript` `developer-tools`

## User Prompt

> terminal for vibe coding みたいなのを header に入れたほうが SEO 的に良いのかな。さまざまなページで。
> もっとよい、検索向けの一行がよいけど。
> 両方。

🤖 Generated with [Claude Code](https://claude.com/claude-code)