### PR TITLE
fix: 再アタッチ後の画面を tmux に描き直させる (#1073 follow-up)

### DIFF
--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -219,6 +219,9 @@ force the DOM renderer or observe effects (`window.open`, buffer state) instead 
   buffer does not reflow. So `reattachPty` marks the entry and the first `resize` frame after it
   calls `tmuxRedrawClient` (`list-clients` → `refresh-client`), which repaints every row. Waiting
   for that frame is deliberate: it is where the client reports the size it settled at.
+  - **Which client** is picked by `client_pid`, not by list order: a session can carry several
+    (another server, a stray `tmux attach`) and tmux orders them arbitrarily. The pty we spawned IS
+    the tmux client, so its pid identifies ours.
 
 ## The tmux passthrough rule
 

--- a/docs/terminal-notes.md
+++ b/docs/terminal-notes.md
@@ -210,6 +210,15 @@ force the DOM renderer or observe effects (`window.open`, buffer state) instead 
     mouse modes; `CSI ? 1049 ; 1003 h` would reach xterm and put it into real mouse tracking,
     turning every drag into coordinate reports — the #729 regression.
   - Only tmux-backed sessions restore; a sandbox/tmux-less pty replays as before.
+- **The replay is a stream of deltas, not a screen — so the screen is asked for.** The bounded tail
+  reconstructs only the cells that changed inside its window: rows painted before it opened stay
+  blank, and cells written at different moments sit side by side. A TUI makes this the normal case
+  (Claude Code paints a transcript row once, then spends megabytes rewriting one status row). A pty
+  **resize** used to hide it — tmux answers a size change with a full repaint, and the normal buffer
+  reflowed — but a reattach at the size the pty already had leaves tmux silent, and the alternate
+  buffer does not reflow. So `reattachPty` marks the entry and the first `resize` frame after it
+  calls `tmuxRedrawClient` (`list-clients` → `refresh-client`), which repaints every row. Waiting
+  for that frame is deliberate: it is where the client reports the size it settled at.
 
 ## The tmux passthrough rule
 
@@ -263,7 +272,7 @@ looking) — flag them for QA on the release.
 | File-path links | `registerFilePathLinks` order vs WebLinks; `/api/files/raw` cwd containment | click a generated file path → previews the file |
 | Enter / newline | `terminalSubmit` mapping + `isComposing` guard; `macOptionIsMeta` | Enter submits, Shift+Enter newlines; IME confirm not eaten; both `cr` and `esc-cr` |
 | Mouse / wheel | `guardMouseTracking` swallow set (1000/1002/1003/1006); wheel→SGR in alt buffer; `wheelNotches` accumulation vs xterm's own `consumeWheelEvent` | wheel scrolls transcript (not prompt history); drag selects, doesn't emit mouse reports; a trackpad swipe moves a TUI about as far as it moves the scrollback |
-| Reattach | `stripTerminalQueries` patterns; replay buffer size; `tmuxTerminalModes` still reports `alternate_on` / `mouse_*_flag` on the installed tmux | reattaching a session doesn't leak `0;276;0c`-style junk; scrollback survives; after a reload the wheel still scrolls a Claude cell's transcript (#1073) |
+| Reattach | `stripTerminalQueries` patterns; replay buffer size; `tmuxTerminalModes` still reports `alternate_on` / `mouse_*_flag`, and `refresh-client` still forces a FULL repaint, on the installed tmux | reattaching a session doesn't leak `0;276;0c`-style junk; scrollback survives; after a reload the wheel still scrolls a Claude cell's transcript, and the screen matches `capture-pane` rather than showing spliced-together fragments (#1073) |
 
 **Fast isolation techniques** (learned the hard way):
 - A terminal behavior that works on a **direct `term.write()`** but fails through a live session ⇒

--- a/plans/fix-1073-redraw-after-reattach.md
+++ b/plans/fix-1073-redraw-after-reattach.md
@@ -25,12 +25,22 @@ and the lower half of the screen blank.
 
 After a reattach, ask tmux to repaint the whole pane:
 
-- `server/infra/tmux.ts` — `tmuxRedrawClient(id)`: `list-clients -F '#{client_tty}'` for the session,
-  then `refresh-client -t <tty>`. `parseClientTty` is pure and tested.
+- `server/infra/tmux.ts` — `tmuxRedrawClient(id, clientPid)`: `list-clients -F '#{client_pid}
+  #{client_tty}'` for the session, then `refresh-client` on OUR client. `redrawTargets` is pure and
+  tested.
 - `server/session/types.ts` — `PtyEntry.redrawPending`.
 - `server/session/pty-connection.ts` — `reattachPty` sets the flag (tmux sessions only); the first
   `resize` frame after that clears it and asks for the redraw.
 - `server/index.ts` — binds the dep.
+
+**Which client is repainted.** A session can carry several — another mulmoterminal server holding
+it (what `tmuxAttachedClientCount` exists for), or a stray `tmux attach` — and tmux promises nothing
+about `list-clients` order, so "the first line" can be somebody else's terminal while ours keeps the
+broken screen. Ours is identifiable: the pty we spawned IS the tmux client, so `client_pid` is
+`entry.term.pid`. Measured on a live session — list-clients reported `29421`, and the
+`new-session -A -s mt-<id>` process we spawned was 29421. When no line carries our pid, every client
+is repainted rather than none: a repaint is idempotent, and skipping ours is the one outcome that
+leaves the bug in place. (Raised by Codex on PR #1099; the first version took the first line.)
 
 **Why the redraw waits for the resize frame** rather than firing with the replay: that frame is
 where the client reports the size it actually settled at, so the repaint is drawn at the right

--- a/plans/fix-1073-redraw-after-reattach.md
+++ b/plans/fix-1073-redraw-after-reattach.md
@@ -1,0 +1,65 @@
+# Ask tmux for the screen instead of rebuilding it from the replay
+
+Follow-up to #1073. 2026-07-30.
+
+## Why
+
+The #1073 fix restores the alternate buffer on reattach, which is what puts the wheel back. It also
+exposed a weakness that had been hidden: **the replay is a stream of DELTAS, not a screen.**
+
+`entry.buffer` is the last 1 MiB of tmux's output. Fed to a terminal that was just `reset()`, it
+reconstructs only the cells that happened to change inside that window. Rows that were painted
+before the window opened are never mentioned, so they stay blank; cells written at different moments
+end up side by side. For a TUI this is the normal case, not an edge case — Claude Code paints a
+transcript row once and then spends megabytes rewriting one status row.
+
+This did not show before because a pty **resize** makes tmux repaint everything, and the normal
+buffer the replay used to land in **reflows**, so a late resize repaired whatever was wrong. Neither
+is true now: a reattach that ends at the size the pty already had leaves tmux with nothing to say,
+and the alternate buffer does not reflow.
+
+Reported with a screenshot: text from different moments spliced together character by character,
+and the lower half of the screen blank.
+
+## What
+
+After a reattach, ask tmux to repaint the whole pane:
+
+- `server/infra/tmux.ts` — `tmuxRedrawClient(id)`: `list-clients -F '#{client_tty}'` for the session,
+  then `refresh-client -t <tty>`. `parseClientTty` is pure and tested.
+- `server/session/types.ts` — `PtyEntry.redrawPending`.
+- `server/session/pty-connection.ts` — `reattachPty` sets the flag (tmux sessions only); the first
+  `resize` frame after that clears it and asks for the redraw.
+- `server/index.ts` — binds the dep.
+
+**Why the redraw waits for the resize frame** rather than firing with the replay: that frame is
+where the client reports the size it actually settled at, so the repaint is drawn at the right
+geometry. The client always sends one on `onopen`.
+
+## Measured
+
+`refresh-client` really does force a FULL repaint, on a live session: a 25-row screen comes back in
+one 666-byte burst, where the same pane sends **0** bytes when idle.
+
+End to end against a real server, reattaching at the size the pty already had, with the current
+screen deliberately older than the replay window (one row rewritten past 1 MiB while the rest stays
+untouched) — ground truth is `tmux capture-pane`:
+
+```
+                            without redraw     with redraw
+rows matching tmux            25 / 30           30 / 30
+MARKER rows shown (tmux has 1)  0                 1
+```
+
+## What this cost
+
+One `list-clients` + one `refresh-client` per reattach (~14 ms), plus a screen-sized burst (~1 KB).
+Every reattach pays it, including ones that would have been fine — the screen becoming authoritative
+is worth more than skipping the repaint on the cases we cannot identify in advance.
+
+## What the first fix got wrong
+
+#1073's verification compared the rendered screen with and without the mode prefix and found them
+identical — but only at a **fixed size, with the whole replay window containing the current screen**.
+Neither assumption holds for a returning background tab. The check that would have caught this is
+the one used here: compare against `tmux capture-pane`, not against the other rendering.

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import {
   tmuxAttachedClientCount,
   tmuxCaptureStyledPane,
   tmuxTerminalModes,
+  tmuxRedrawClient,
 } from "./infra/tmux.js";
 import { sandboxEnabled, sandboxPlatformSupported, dockerAvailable, ensureSandboxImage } from "./infra/sandbox.js";
 import { bindSecurityWarning, browserOriginHostnames, createIsAllowedOrigin } from "./infra/allowed-origin.js";
@@ -219,6 +220,7 @@ const { reattachPty, handleClientFrame, handleClientClose } = createConnectionHa
   setWaiting: (id, waiting) => setWaiting(id, waiting),
   armReapForDetached: (id) => armReapForDetached(id),
   terminalModesOf: (id) => tmuxTerminalModes(id),
+  redrawTerminal: (id) => tmuxRedrawClient(id),
 });
 
 // Mirrors session activity into Firestore so the phone's terminal viewer can refresh

--- a/server/index.ts
+++ b/server/index.ts
@@ -220,7 +220,7 @@ const { reattachPty, handleClientFrame, handleClientClose } = createConnectionHa
   setWaiting: (id, waiting) => setWaiting(id, waiting),
   armReapForDetached: (id) => armReapForDetached(id),
   terminalModesOf: (id) => tmuxTerminalModes(id),
-  redrawTerminal: (id) => tmuxRedrawClient(id),
+  redrawTerminal: (id, clientPid) => tmuxRedrawClient(id, clientPid),
 });
 
 // Mirrors session activity into Firestore so the phone's terminal viewer can refresh

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -332,6 +332,34 @@ export function tmuxTerminalModes(id: string): number[] {
   return r.status === 0 ? parseTmuxTerminalModes(r.stdout) : [];
 }
 
+/** The first client tty from `list-clients -F '#{client_tty}'`, or null when nothing is attached.
+ *  Its own function so "no client to redraw" stays distinguishable from a tty we can act on. */
+export function parseClientTty(stdout: string): string | null {
+  const tty = splitLines(stdout)
+    .map((line) => line.trim())
+    .find((line) => line !== "");
+  return tty ?? null;
+}
+
+// Make tmux repaint the WHOLE pane onto our client, even though nothing about the pane changed.
+//
+// The reattach replay is a bounded tail of tmux's output — a stream of DELTAS, not a screen. Fed to
+// a freshly reset terminal it reconstructs only the cells that happened to change inside that
+// window: rows that never changed stay blank, and cells written at different moments end up side by
+// side. A pty resize normally hides this, because tmux answers a size change with a full redraw —
+// but a reattach that ends at the size the pty already had leaves tmux with nothing to say, and the
+// browser keeps the half-built screen. Since the replay now lands in the ALTERNATE buffer, which
+// does not reflow, there is also no later resize that can repair it (#1073).
+//
+// Measured against a live session: one `refresh-client` returns every row of a 25-row screen in a
+// single 666-byte burst, where an idle pane sends nothing at all.
+export function tmuxRedrawClient(id: string): void {
+  const clients = tmux(["list-clients", "-t", tmuxSessionName(id), "-F", "#{client_tty}"]);
+  if (clients.status !== 0) return;
+  const tty = parseClientTty(clients.stdout);
+  if (tty) tmux(["refresh-client", "-t", tty]);
+}
+
 // Parse `#{session_attached}`. Its own function so the "unreadable means nobody" rule is
 // testable: a caller deciding whether to KILL a session must not read a failure as 0.
 export function parseAttachedClientCount(stdout: string): number | null {

--- a/server/infra/tmux.ts
+++ b/server/infra/tmux.ts
@@ -332,13 +332,24 @@ export function tmuxTerminalModes(id: string): number[] {
   return r.status === 0 ? parseTmuxTerminalModes(r.stdout) : [];
 }
 
-/** The first client tty from `list-clients -F '#{client_tty}'`, or null when nothing is attached.
- *  Its own function so "no client to redraw" stays distinguishable from a tty we can act on. */
-export function parseClientTty(stdout: string): string | null {
-  const tty = splitLines(stdout)
-    .map((line) => line.trim())
-    .find((line) => line !== "");
-  return tty ?? null;
+// Which client ttys to repaint, from `list-clients -F '#{client_pid} #{client_tty}'`.
+//
+// A session can carry SEVERAL clients — another mulmoterminal server holding it (the case
+// tmuxAttachedClientCount exists for), or a stray `tmux attach` — and tmux promises nothing about
+// their order, so "the first line" can be somebody else's terminal. Ours is identifiable: the pty
+// we spawned IS the tmux client, so `client_pid` is `entry.term.pid`. Measured on a live session:
+// list-clients reported `29421`, and the `new-session -A -s mt-<id>` process we spawned was 29421.
+//
+// When no line carries our pid — a tmux that doesn't report it, or a client someone else attached
+// after ours went away — every client is repainted rather than none. A repaint is idempotent, and
+// skipping ours is the single outcome that leaves the bug in place.
+export function redrawTargets(stdout: string, clientPid: number): string[] {
+  const clients = splitLines(stdout)
+    .map((line) => line.trim().split(/\s+/))
+    .filter((parts) => parts.length >= 2)
+    .map(([pid, tty]) => ({ pid: Number(pid), tty }));
+  const ours = clients.filter((client) => client.pid === clientPid);
+  return (ours.length > 0 ? ours : clients).map((client) => client.tty);
 }
 
 // Make tmux repaint the WHOLE pane onto our client, even though nothing about the pane changed.
@@ -353,11 +364,10 @@ export function parseClientTty(stdout: string): string | null {
 //
 // Measured against a live session: one `refresh-client` returns every row of a 25-row screen in a
 // single 666-byte burst, where an idle pane sends nothing at all.
-export function tmuxRedrawClient(id: string): void {
-  const clients = tmux(["list-clients", "-t", tmuxSessionName(id), "-F", "#{client_tty}"]);
+export function tmuxRedrawClient(id: string, clientPid: number): void {
+  const clients = tmux(["list-clients", "-t", tmuxSessionName(id), "-F", "#{client_pid} #{client_tty}"]);
   if (clients.status !== 0) return;
-  const tty = parseClientTty(clients.stdout);
-  if (tty) tmux(["refresh-client", "-t", tty]);
+  redrawTargets(clients.stdout, clientPid).forEach((tty) => tmux(["refresh-client", "-t", tty]));
 }
 
 // Parse `#{session_attached}`. Its own function so the "unreadable means nobody" rule is

--- a/server/session/pty-connection.ts
+++ b/server/session/pty-connection.ts
@@ -28,8 +28,9 @@ export interface ConnectionDeps {
    *  re-establish (#1073). Empty when there is nothing to restore. */
   terminalModesOf: (id: string) => readonly number[];
   /** Ask tmux to repaint the whole pane, so a reattached browser stops showing whatever the
-   *  replayed delta window happened to reconstruct (#1073). */
-  redrawTerminal: (id: string) => void;
+   *  replayed delta window happened to reconstruct (#1073). `clientPid` identifies OUR tmux client
+   *  among the several a session can carry — it is the pty's own pid. */
+  redrawTerminal: (id: string, clientPid: number) => void;
 }
 
 // browser -> command PTY. Like handleClientFrame but for the session-less command
@@ -119,7 +120,7 @@ export function createConnectionHandlers(deps: ConnectionDeps) {
         // alternate buffer it now restores into does not reflow, so no later resize repairs it.
         if (entry.redrawPending) {
           entry.redrawPending = false;
-          deps.redrawTerminal(sessionId);
+          deps.redrawTerminal(sessionId, entry.term.pid);
         }
       }
     } catch (err) {

--- a/server/session/pty-connection.ts
+++ b/server/session/pty-connection.ts
@@ -27,6 +27,9 @@ export interface ConnectionDeps {
   /** The screen-buffer / mouse modes this session's pane is in right now, for the replay to
    *  re-establish (#1073). Empty when there is nothing to restore. */
   terminalModesOf: (id: string) => readonly number[];
+  /** Ask tmux to repaint the whole pane, so a reattached browser stops showing whatever the
+   *  replayed delta window happened to reconstruct (#1073). */
+  redrawTerminal: (id: string) => void;
 }
 
 // browser -> command PTY. Like handleClientFrame but for the session-less command
@@ -78,6 +81,9 @@ export function createConnectionHandlers(deps: ConnectionDeps) {
       // (e.g. a DA reply surfacing as "0;276;0c" in the prompt) — see terminal-replay.ts.
       const data = prefix + stripTerminalQueries(entry.buffer);
       if (data) ws.send(JSON.stringify({ type: "output", data }));
+      // What that replay draws is only the part of the screen that changed inside the window, so
+      // the real screen is asked for once the client reports the size it settled at, below.
+      if (entry.tmux) entry.redrawPending = true;
     }
     return entry;
   }
@@ -108,6 +114,13 @@ export function createConnectionHandlers(deps: ConnectionDeps) {
         entry.term.write(msg.data);
       } else if (isResizeFrame(msg)) {
         entry.term.resize(msg.cols, msg.rows);
+        // A size that CHANGED already makes tmux redraw; one that matches what the pty had leaves
+        // it silent, and the reattached browser would keep the half-built screen forever — the
+        // alternate buffer it now restores into does not reflow, so no later resize repairs it.
+        if (entry.redrawPending) {
+          entry.redrawPending = false;
+          deps.redrawTerminal(sessionId);
+        }
       }
     } catch (err) {
       // e.g. a write/resize that races the PTY exiting — drop it, never crash.

--- a/server/session/types.ts
+++ b/server/session/types.ts
@@ -27,6 +27,10 @@ export interface PtyEntry {
   // True when `term` is a tmux client (persistent): killing it only detaches, so reap
   // must kill the tmux session to actually end the program.
   tmux?: boolean;
+  // A reattach replayed a delta tail, so the browser's screen is only as complete as that window
+  // (see tmuxRedrawClient). Cleared by the first resize frame after the reattach — waiting for it
+  // is the point, since that frame is where the client tells us the size it actually settled at.
+  redrawPending?: boolean;
   // True when `term` is a `docker run` client (single-view sandbox): reap force-removes
   // the container, since killing the client alone can leave it running.
   sandbox?: boolean;

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -7,7 +7,7 @@ import {
   parseTmuxEnvironment,
   parseAttachedClientCount,
   parseTmuxTerminalModes,
-  parseClientTty,
+  redrawTargets,
   planMsOverride,
   MS_OVERRIDE_ENTRY,
 } from "../../../server/infra/tmux";
@@ -253,20 +253,33 @@ describe("parseTmuxTerminalModes", () => {
   });
 });
 
-describe("parseClientTty", () => {
-  it("reads the tty of the attached client", () => {
-    expect(parseClientTty("/dev/ttys098\n")).toBe("/dev/ttys098");
+// Fields: `#{client_pid} #{client_tty}`.
+describe("redrawTargets", () => {
+  const OUR_PID = 29421;
+
+  it("repaints our own client", () => {
+    expect(redrawTargets(`${OUR_PID} /dev/ttys019\n`, OUR_PID)).toEqual(["/dev/ttys019"]);
   });
 
-  // Each mulmoterminal server holds one client per session, but a second server (or a stray
-  // `tmux attach`) can add another. Redrawing the first one is still right — the burst goes to
-  // whichever client asked, and ours is the one that just reattached.
-  it("takes the first of several clients", () => {
-    expect(parseClientTty("/dev/ttys098\n/dev/ttys101\n")).toBe("/dev/ttys098");
+  // tmux promises nothing about the order of list-clients, so taking the first line would send the
+  // repaint to another server's browser and leave this one showing the half-built screen.
+  it("picks ours out of a session several clients are attached to, wherever it is listed", () => {
+    const listed = `40100 /dev/ttys002\n${OUR_PID} /dev/ttys019\n40200 /dev/ttys044\n`;
+    expect(redrawTargets(listed, OUR_PID)).toEqual(["/dev/ttys019"]);
   });
 
-  it("reports nothing to redraw when no client is attached", () => {
-    expect(parseClientTty("")).toBeNull();
-    expect(parseClientTty("\n \n")).toBeNull();
+  // Repainting someone else's client is harmless; repainting nobody is the bug itself.
+  it("falls back to every client when our pid is not in the list", () => {
+    const listed = `40100 /dev/ttys002\n40200 /dev/ttys044\n`;
+    expect(redrawTargets(listed, OUR_PID)).toEqual(["/dev/ttys002", "/dev/ttys044"]);
+  });
+
+  it("has nothing to repaint when no client is attached", () => {
+    expect(redrawTargets("", OUR_PID)).toEqual([]);
+    expect(redrawTargets("\n \n", OUR_PID)).toEqual([]);
+  });
+
+  it("ignores a line that carries no tty", () => {
+    expect(redrawTargets(`${OUR_PID}\n${OUR_PID} /dev/ttys019\n`, OUR_PID)).toEqual(["/dev/ttys019"]);
   });
 });

--- a/test/server/infra/tmux.spec.ts
+++ b/test/server/infra/tmux.spec.ts
@@ -7,6 +7,7 @@ import {
   parseTmuxEnvironment,
   parseAttachedClientCount,
   parseTmuxTerminalModes,
+  parseClientTty,
   planMsOverride,
   MS_OVERRIDE_ENTRY,
 } from "../../../server/infra/tmux";
@@ -249,5 +250,23 @@ describe("parseTmuxTerminalModes", () => {
   it("restores nothing from output tmux could not produce", () => {
     expect(parseTmuxTerminalModes("")).toEqual([]);
     expect(parseTmuxTerminalModes("no server running")).toEqual([]);
+  });
+});
+
+describe("parseClientTty", () => {
+  it("reads the tty of the attached client", () => {
+    expect(parseClientTty("/dev/ttys098\n")).toBe("/dev/ttys098");
+  });
+
+  // Each mulmoterminal server holds one client per session, but a second server (or a stray
+  // `tmux attach`) can add another. Redrawing the first one is still right — the burst goes to
+  // whichever client asked, and ours is the one that just reattached.
+  it("takes the first of several clients", () => {
+    expect(parseClientTty("/dev/ttys098\n/dev/ttys101\n")).toBe("/dev/ttys098");
+  });
+
+  it("reports nothing to redraw when no client is attached", () => {
+    expect(parseClientTty("")).toBeNull();
+    expect(parseClientTty("\n \n")).toBeNull();
   });
 });

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -57,7 +57,7 @@ function setup(terminalModes: readonly number[] = []) {
       calls.push(`terminalModes:${id}`);
       return terminalModes;
     },
-    redrawTerminal: (id) => calls.push(`redraw:${id}`),
+    redrawTerminal: (id, clientPid) => calls.push(`redraw:${id}:${clientPid}`),
   });
   return { ...handlers, calls };
 }
@@ -103,7 +103,9 @@ describe("handleClientFrame", () => {
       [100, 30],
       [120, 40],
     ]);
-    expect(calls.filter((c) => c.startsWith("redraw:"))).toEqual([`redraw:${SESSION}`]);
+    // The pid is the pty's own — it is what picks OUR tmux client out of a session that several
+    // servers may have attached (#1099 review).
+    expect(calls.filter((c) => c.startsWith("redraw:"))).toEqual([`redraw:${SESSION}:4242`]);
   });
 
   it("never asks for a redraw on a session that was not reattached", () => {

--- a/test/server/session/pty-connection.spec.ts
+++ b/test/server/session/pty-connection.spec.ts
@@ -57,6 +57,7 @@ function setup(terminalModes: readonly number[] = []) {
       calls.push(`terminalModes:${id}`);
       return terminalModes;
     },
+    redrawTerminal: (id) => calls.push(`redraw:${id}`),
   });
   return { ...handlers, calls };
 }
@@ -86,6 +87,33 @@ describe("handleClientFrame", () => {
     const entry = entryWith({ term: t.term as never, ws: s.ws as never });
     handleClientFrame(entry, s.ws as never, frame({ type: "resize", cols: 100, rows: 40 }), SESSION);
     expect(t.resizes).toEqual([[100, 40]]);
+  });
+
+  // The redraw waits for this frame on purpose: it is where the client reports the size it
+  // actually settled at, so the repaint that follows is drawn at the right geometry.
+  it("asks for the redraw on the first resize after a reattach, and only that one", () => {
+    const { reattachPty, handleClientFrame, calls } = setup();
+    const t = fakeTerm();
+    const s = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: null, buffer: "x", tmux: true });
+    reattachPty(entry, s.ws as never, SESSION);
+    handleClientFrame(entry, s.ws as never, frame({ type: "resize", cols: 100, rows: 30 }), SESSION);
+    handleClientFrame(entry, s.ws as never, frame({ type: "resize", cols: 120, rows: 40 }), SESSION);
+    expect(t.resizes).toEqual([
+      [100, 30],
+      [120, 40],
+    ]);
+    expect(calls.filter((c) => c.startsWith("redraw:"))).toEqual([`redraw:${SESSION}`]);
+  });
+
+  it("never asks for a redraw on a session that was not reattached", () => {
+    // A fresh spawn's client gets the real screen from the live stream; a repaint would be noise.
+    const { handleClientFrame, calls } = setup();
+    const t = fakeTerm();
+    const s = fakeSocket();
+    const entry = entryWith({ term: t.term as never, ws: s.ws as never, tmux: true });
+    handleClientFrame(entry, s.ws as never, frame({ type: "resize", cols: 100, rows: 30 }), SESSION);
+    expect(calls).toEqual([]);
   });
 
   it("ignores a resize outside the allowed bounds", () => {
@@ -296,6 +324,19 @@ describe("reattachPty", () => {
     const s = fakeSocket();
     reattachPty(entryWith({ ws: null, buffer: "$ ls\n", tmux: true }), s.ws as never, SESSION);
     expect(s.parsed()).toEqual([{ type: "output", data: "$ ls\n" }]);
+  });
+
+  // The replay reconstructs only what changed inside its window, and the alternate buffer it now
+  // lands in does not reflow — so the real screen has to be asked for rather than inferred.
+  it("marks a tmux session for a redraw, and leaves a non-tmux one alone", () => {
+    const { reattachPty } = setup();
+    const s = fakeSocket();
+    const persistent = entryWith({ ws: null, buffer: "x", tmux: true });
+    const sandboxed = entryWith({ ws: null, buffer: "x" });
+    reattachPty(persistent, s.ws as never, SESSION);
+    reattachPty(sandboxed, s.ws as never, SESSION);
+    expect(persistent.redrawPending).toBe(true);
+    expect(sandboxed.redrawPending).toBeUndefined();
   });
 
   it("does not query a socket that is already gone", () => {


### PR DESCRIPTION
## Summary

#1073（PR #1089）の **follow-up かつ退行修正**です。裏タブから戻ったときにターミナルの表示が壊れる報告（別時点のテキストが文字単位で混ざり、画面の下半分が空白）を受けて調査しました。

原因は #1073 の修正そのものではなく、**それまで隠れていた弱点が露出した**ことでした。

リプレイは**画面ではなく差分ストリーム**です。`entry.buffer` は tmux 出力の末尾 1 MiB で、`reset()` 直後の端末に流すと**その窓の中で変化したセルしか再構成されません**。窓が開く前に描かれた行は空のまま残り、別々の時点で書かれたセルが隣り合います。TUI ではこれが例外ではなく通常状態です — Claude Code は会話行を一度描いたら二度と触らず、ステータス行1行の書き換えに何 MB も費やします。

これまで露見しなかった理由は 2 つあり、**どちらも今は成り立ちません**:

1. pty のリサイズは tmux の全画面再描画を引き起こす → しかし **pty と同じサイズで再アタッチすると tmux は何も送らない**
2. リプレイ先の normal バッファは reflow する → しかし **alternate バッファは reflow しない**

対処: 再アタッチ後に tmux へペイン全体の再描画を要求します（`list-clients` → `refresh-client`）。

## Items to Confirm / Review

1. **再描画のタイミング** — リプレイと同時ではなく「**再アタッチ後の最初の `resize` フレーム**」で行います。そのフレームがクライアントの確定サイズを伝えてくるので、正しいジオメトリで描かれるためです。クライアントは `onopen` で必ず 1 回送るので、発火しないケースはありません。
2. **コスト** — 再アタッチごとに `list-clients` + `refresh-client` の 2 プロセス（約 14 ms）と、画面 1 枚分のバースト（約 1 KB）。**壊れていない再アタッチでも毎回払います**。事前に「壊れる再アタッチ」を判別できない以上、画面が常に正しいことの方が価値が高いという判断です。
3. **`PtyEntry.redrawPending` を足しました** — エントリに状態を1つ増やしています。クロージャ内の `WeakSet` でも書けますが、エントリに持たせた方がテストで直接観測でき、意味も追いやすいと判断しました。
4. **非 tmux セッション**（サンドボックス / tmux 未インストール）はフラグを立てないので完全に不変です。

## User Prompt

> （スクリーンショット添付）タブで裏でなにか見ていて戻ったときに、こうなることがある。
>
> B

（B = 提示した選択肢のうち「revert せず前進修正する」）

## 前回の検証の何が漏れていたか

#1073 では「前置きあり／なし」の描画結果を比較して**一致**を確認し、それを根拠にマージしました。しかしこの比較には 2 つの前提がありました:

- **固定サイズ**で描画していた
- リプレイ窓の中に**現在の画面が丸ごと入っている**状態だった

裏タブから戻る状況ではどちらも成り立ちません。そして根本的な誤りとして、**自分の2つの描画同士を比べていた**ため、両方が同じように実画面から乖離していても「一致」と出ます。

今回使った検証は `tmux capture-pane` を正解として照合するもので、これなら 1 コマンドで捕捉できました。この教訓はグローバルの CLAUDE.md（Debugging Approach）にも追加済みです。

## 実測

**1. `refresh-client` は本当に全画面を返すか**（実クライアントに対して）

```
clients                   : "/dev/ttys098 100x30"
idle bytes in 1.5s        : 0
bytes after refresh-client: 666
ROW-nn markers in burst   : 25 / 25
VERDICT: refresh-client forces a FULL repaint
```

**2. End to end**（実サーバ。pty と同じサイズで再アタッチし、現在の画面がリプレイ窓より古い状態 — 1行だけを 1 MiB 超書き換え、残りは放置。正解は `tmux capture-pane`）

```
                              修正なし    修正あり
tmux と一致する行              25 / 30     30 / 30
MARKER 行（tmux は 1 行保持）    0           1
```

なお最初に書いた再現ハーネスは「サイズが変わる再アタッチ」だったため**再現しませんでした**（tmux が自力で全画面を再描画して直る）。壊れるのは tmux が沈黙する経路だけだと分かったのが、この形に至った経緯です。

## 実装

| ファイル | 変更 |
|---|---|
| `server/infra/tmux.ts` | `tmuxRedrawClient(id)` と、純粋関数 `parseClientTty(stdout)` |
| `server/session/types.ts` | `PtyEntry.redrawPending` |
| `server/session/pty-connection.ts` | `reattachPty` がフラグを立て（tmux セッションのみ）、最初の `resize` で消費して再描画を要求 |
| `server/index.ts` | dep の bind |

## テスト

- `parseClientTty` — 通常 / 複数クライアント / 未アタッチ / 空白のみ
- `reattachPty` — tmux セッションだけフラグを立て、非 tmux は立てない
- `handleClientFrame` — 再アタッチ後の**最初の** resize でだけ再描画を要求すること、再アタッチしていないセッションでは一度も要求しないこと

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` / `test`（426 files, 6323 tests）すべて green。

## ドキュメント

`docs/terminal-notes.md`（replay 節に「リプレイは差分であって画面ではない」を追記、QA マトリクスも更新）。設計メモは `plans/fix-1073-redraw-after-reattach.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3
