### PR TITLE
feat: tool-call history for codex and agy, fed by the MCP broker

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -429,6 +429,7 @@ mountAppRoutes(app, {
   reap,
   // Defined further down; reached only from a request, which cannot arrive before listen().
   registerBackgroundSession: (id: string) => scheduledSessions.register(id),
+  agentOfSession: (id: string) => agentOfSession(id),
   setWorking,
   setWaiting,
   publishActivity,

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -31,6 +31,8 @@ import { offeredTools, routeToolCall, SUBMIT_TRANSLATION_TOOL_NAME } from "./too
 import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
 import { interpretToolEnvelope } from "./tool-envelope.js";
 import { isRecord } from "../../common/isRecord.js";
+import type { GuiCallRecorder } from "./gui-call-history.js";
+import { messageOf } from "../errors.js";
 
 // Shape of the dispatch route's response (POST /api/plugin/<tool>). `data` gates
 // whether a toolResult is published to the GUI; the rest is narration/metadata.
@@ -75,8 +77,15 @@ const SUBMIT_TRANSLATION_TOOL = {
  * @param opts.group  serve only one GROUP of the GUI tools (the `/api/mcp/<group>/<id>` URLs,
  *                    which exist so a directory can enable a subset through Claude Code's own
  *                    per-folder MCP config). Null/absent = every tool, the single view's URL.
+ * @param opts.history  feed each call into the tools pane's call history. Set only for agents
+ *                      that have no hooks of their own — see mcp/gui-call-history.ts, which
+ *                      also explains why claude must NOT get one.
  */
-export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { submitTranslationTool?: boolean; group?: ToolGroup | null } = {}): Server {
+export function buildGuiMcpServer(
+  sessionId: string,
+  baseUrl: string,
+  opts: { submitTranslationTool?: boolean; group?: ToolGroup | null; history?: GuiCallRecorder | null } = {},
+): Server {
   const group = opts.group ?? null;
   // The advertised server name follows the id a group is expected to be registered under, so
   // what a user sees in `claude mcp list` matches what they wrote in their own config.
@@ -102,19 +111,45 @@ export function buildGuiMcpServer(sessionId: string, baseUrl: string, opts: { su
       return { content: [{ type: "text", text: "Translation received. You are done." }] };
     }
 
+    // The tools pane's call history, for an agent that cannot report its own (codex, agy).
+    // Recorded around the DISPATCH so a slow plugin shows as "running…" while it runs, which
+    // is what claude's PreToolUse gives the pane. Null for claude — its hooks already report
+    // this same call — and for the hidden translation worker, which has no pane.
+    const history = opts.history ?? null;
+    const toolUseId = randomUUID();
+    const startedAt = Date.now();
+    const started = () => history?.start({ toolUseId, toolName: name, toolInput: args });
+    const finished = (toolOutput: unknown, status: "completed" | "failed") =>
+      history?.end({ toolUseId, toolName: name, toolInput: args, toolOutput, durationMs: Date.now() - startedAt, status });
+
     if (route.kind === "refused") {
+      // Recorded, not skipped: a tool the agent named and was refused is precisely what someone
+      // reading the history is looking for.
+      started();
+      finished(route.message, "failed");
       return { content: [{ type: "text", text: route.message }], isError: true };
     }
 
-    // Dispatch to the plugin's server-side handler, then interpret its envelope (tool-envelope.ts).
-    const parsed = await (await postJson(`${baseUrl}/api/plugin/${name}`, args ?? {})).json();
-    const { publish, narration } = interpretToolEnvelope(isRecord(parsed) ? parsed : {});
+    started();
+    try {
+      // Dispatch to the plugin's server-side handler, then interpret its envelope (tool-envelope.ts).
+      const parsed = await (await postJson(`${baseUrl}/api/plugin/${name}`, args ?? {})).json();
+      const { publish, narration } = interpretToolEnvelope(isRecord(parsed) ? parsed : {});
 
-    // A GUI toolResult, only when there is data to render.
-    if (publish) {
-      await postJson(`${baseUrl}/api/agent/toolResult`, { sessionId, toolName: name, uuid: randomUUID(), ...publish });
+      // A GUI toolResult, only when there is data to render.
+      if (publish) {
+        await postJson(`${baseUrl}/api/agent/toolResult`, { sessionId, toolName: name, uuid: randomUUID(), ...publish });
+      }
+      finished(narration, "completed");
+      return { content: [{ type: "text", text: narration }] };
+    } catch (err) {
+      // The dispatch route answered non-2xx, or its JSON was unreadable. Closing the entry here
+      // is the same reason PostToolUseFailure is registered alongside PostToolUse for claude:
+      // without it a failed call sits on "running…" for the life of the session. The error still
+      // propagates — the SDK turns it into the agent's error response, as before.
+      finished(messageOf(err), "failed");
+      throw err;
     }
-    return { content: [{ type: "text", text: narration }] };
   });
 
   return server;

--- a/server/mcp/gui-call-history.ts
+++ b/server/mcp/gui-call-history.ts
@@ -50,6 +50,25 @@ export function brokerRecordsGuiCalls({ agent, reportsOwnCalls }: { agent: Sessi
   return !reportsOwnCalls && agent !== "claude";
 }
 
+/**
+ * Does this session's history hold the GUI tools ALONE — the claim the pane makes to the user?
+ *
+ * Stricter than the recording gate above, and deliberately so. The gate runs when a tool call
+ * ARRIVES, by which point the session has certainly been spawned. This runs whenever the pane
+ * asks, and the pane asks EARLY: the browser is handed a session id while the agent is still
+ * being spawned, so a claude session can be asked about before `spawnClaudePty` has registered
+ * its hooks. Both signals then say "not claude" and the gate would answer yes — leaving the pane
+ * telling the user that claude's complete, hook-fed history contains GUI calls only.
+ *
+ * So this claim additionally requires that we can SEE the session at all. A null agent means no
+ * pty and no tmux pane — either the session has not started yet, or it is gone; neither is
+ * something to make a statement about. Saying nothing about a GUI-only history is a smaller
+ * error than mislabelling a complete one, and the pane re-asks when the session announces itself.
+ */
+export function historyIsGuiOnly(session: { agent: SessionAgent | null; reportsOwnCalls: boolean }): boolean {
+  return session.agent !== null && brokerRecordsGuiCalls(session);
+}
+
 /** The same two writers `/api/hook` uses, so both feeds land in one store in one shape. */
 export interface ToolCallSink {
   recordToolCallStart: (sessionId: string, call: ToolCallStart) => Promise<void>;

--- a/server/mcp/gui-call-history.ts
+++ b/server/mcp/gui-call-history.ts
@@ -1,0 +1,77 @@
+// Feeding the tools pane's call history from the BROKER, for the agents that cannot feed it
+// themselves.
+//
+// The history has one writer everywhere else: `/api/hook`, driven by the PreToolUse /
+// PostToolUse settings claude carries (session/hook-settings.ts). codex has no hook mechanism
+// and neither does agy — see the note at the top of agents/codex-activity.ts, and
+// docs/codex-vs-claude.md — so for those two the pane sat empty however much they did.
+//
+// The broker is the one place their work is visible to us: every GUI tool they call arrives at
+// /api/mcp/:sessionId with the session id in the URL. That is a PARTIAL history — their Bash,
+// their edits and their other MCP servers never touch us — but a partial one is what we have,
+// and the pane says so rather than implying the agent ran nothing else.
+//
+// Claude is deliberately EXCLUDED: its hooks match `""`, so they already report `mcp__*` calls
+// too. Recording here as well would list every GUI call twice, and not even as duplicates the
+// store could collapse — the broker mints its own uuid while the hook carries claude's
+// `tool_use_id`, so `recordToolCallStart`'s dedupe would never see them as the same call.
+import type { SessionAgent } from "../../common/sessionAgent.js";
+import type { ToolCallEnd, ToolCallStart } from "../session/tool-hook.js";
+import { messageOf } from "../errors.js";
+
+/** What the broker reports about one GUI tool call. Mirrors ToolCallStart/End in session/tool-hook.ts. */
+export interface GuiCallRecorder {
+  start(call: { toolUseId: string; toolName: string; toolInput: unknown }): void;
+  end(call: { toolUseId: string; toolName: string; toolInput: unknown; toolOutput: unknown; durationMs: number; status: "completed" | "failed" }): void;
+}
+
+/**
+ * Should the broker record this session's GUI tool calls itself?
+ *
+ * The question is NOT "is this codex or agy" — that was the first version of this gate and it was
+ * wrong. A codex LAUNCHER CHIP runs `zsh -lc exec codex …` (ws-routes.ts hands it the same GUI MCP
+ * URLs), so its PtyEntry is honestly labelled `"shell"`, and matching on the agent name left that
+ * cell — a real codex session, calling our tools — with an empty pane while the agent-toggle one
+ * worked. No agent name identifies a session started by a command the user wrote.
+ *
+ * The real question is whether something ELSE is already recording these calls, and exactly one
+ * thing does: claude's `--settings` hooks. So the gate is an exclusion, on two independent
+ * signals, because a double entry is worse than a missing one:
+ *
+ *   reportsOwnCalls — this process spawned it with our hooks (registry.hookedSessions). Exact.
+ *   agent           — a backstop for a claude session that outlived a restart and was never
+ *                     reattached here, so nothing added it to that set, yet its pane command
+ *                     still says what it is.
+ *
+ * Everything else records: codex and agy however they were started, and an unknown session, which
+ * cannot be a hooked claude once both signals have said otherwise.
+ */
+export function brokerRecordsGuiCalls({ agent, reportsOwnCalls }: { agent: SessionAgent | null; reportsOwnCalls: boolean }): boolean {
+  return !reportsOwnCalls && agent !== "claude";
+}
+
+/** The same two writers `/api/hook` uses, so both feeds land in one store in one shape. */
+export interface ToolCallSink {
+  recordToolCallStart: (sessionId: string, call: ToolCallStart) => Promise<void>;
+  recordToolCallEnd: (sessionId: string, call: ToolCallEnd) => Promise<void>;
+}
+
+/**
+ * A recorder for one session, or null when that session's agent reports its own calls.
+ *
+ * The recorder is SYNCHRONOUS and fire-and-forget: it sits on the tool-call path, and an agent
+ * waiting on `presentDocument` must not also wait on our history write. A failed write costs one
+ * row in a pane, so it is logged and dropped rather than turned into a tool error.
+ */
+export function guiCallRecorderFor(
+  sessionId: string,
+  session: { agent: SessionAgent | null; reportsOwnCalls: boolean },
+  sink: ToolCallSink,
+): GuiCallRecorder | null {
+  if (!brokerRecordsGuiCalls(session)) return null;
+  const swallow = (p: Promise<void>) => void p.catch((err: unknown) => console.error(`[gui-history] ${sessionId}: ${messageOf(err)}`));
+  return {
+    start: (call) => swallow(sink.recordToolCallStart(sessionId, call)),
+    end: (call) => swallow(sink.recordToolCallEnd(sessionId, call)),
+  };
+}

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -18,6 +18,8 @@ import { mountTmuxRoutes } from "../infra/tmux-routes.js";
 import { mountHookRoute } from "../routes/hook-routes.js";
 import { mountPluginRoutes } from "../routes/plugin-routes.js";
 import { mountMcpRoutes } from "../routes/mcp-routes.js";
+import { brokerRecordsGuiCalls, guiCallRecorderFor } from "../mcp/gui-call-history.js";
+import type { SessionAgent } from "../../common/sessionAgent.js";
 import { mountSessionRoutes } from "../routes/session-routes.js";
 import { mountToolRoutes } from "../routes/tool-routes.js";
 import { mountRepoRoutes } from "../routes/repo-routes.js";
@@ -41,7 +43,7 @@ import { mountNotificationRoutes } from "../backends/notifier.js";
 import { mountWhisperRoutes } from "../backends/whisper.js";
 import { mountSchedulerRoutes } from "../backends/scheduler.js";
 import { mountFilesRoutes } from "../backends/files.js";
-import { ptys, sessionToolGroups, sessionToolGroupsHydrated, devTerminalSessions, devTerminalSessionsHydrated } from "../session/registry.js";
+import { hookedSessions, ptys, sessionToolGroups, sessionToolGroupsHydrated, devTerminalSessions, devTerminalSessionsHydrated } from "../session/registry.js";
 import { mountShortcutsRoutes } from "../backends/shortcuts.js";
 import { mountDecisionRoutes } from "./decision-routes.js";
 import { mountTranslationRoutes } from "../backends/translation.js";
@@ -69,6 +71,9 @@ export interface AppRouteDeps extends SessionActivityDeps {
   publish: (channel: string, data: unknown) => void;
   sessionChannel: (id: string) => string;
   toolStores: ReturnType<typeof createToolStores>;
+  /** What a session is running, or null when the host cannot tell. Gates the broker's own
+   *  tool-call history — see mcp/gui-call-history.ts. */
+  agentOfSession: (id: string) => SessionAgent | null;
   toolSummaries: Parameters<typeof mountToolRoutes>[1]["toolSummaries"];
   spawnClaudePty: ReturnType<typeof createClaudeSpawner>["spawnClaudePty"];
   spawnCodexPty: ReturnType<typeof createCodexSpawner>["spawnCodexPty"];
@@ -81,6 +86,15 @@ export interface AppRouteDeps extends SessionActivityDeps {
 
 // The channel a directory-config change is announced on.
 const DIR_CONFIG_CHANNEL = "dir-config";
+
+// The two signals that decide whether the MCP broker writes this session's tool-call history —
+// and, through /api/tools, whether the pane tells the user its history is GUI-tools-only. Read
+// here so both answers come from one place: they must agree, or the pane disclaims a history it
+// is not actually giving (or worse, keeps quiet about one it is).
+const sessionCallReporting = (deps: AppRouteDeps, sessionId: string) => ({
+  agent: deps.agentOfSession(sessionId),
+  reportsOwnCalls: hookedSessions.has(sessionId),
+});
 
 export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
   const clientDir = deps.clientDir;
@@ -197,7 +211,13 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
 
   // The agent-facing MCP surface (routes/mcp-routes.ts): the in-process GUI MCP server over
   // Streamable HTTP, and the worker-only landing point the hidden translation worker reports to.
-  mountMcpRoutes(app, { publish: (c, d) => deps.publish(c, d) });
+  mountMcpRoutes(app, {
+    publish: (c, d) => deps.publish(c, d),
+    // codex and agy have no hooks, so the broker is the only place their tool calls can reach
+    // the tools pane's history. Claude's do NOT come through here — it would double every entry
+    // its own PreToolUse/PostToolUse already writes.
+    guiCallHistory: (sessionId) => guiCallRecorderFor(sessionId, sessionCallReporting(deps, sessionId), deps.toolStores),
+  });
 
   // Serve Vite build output
   app.use(express.static(path.join(clientDir, "../dist")));
@@ -244,6 +264,9 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
     sessionToolGroupsHydrated,
     isGridSession: (id) => devTerminalSessions.has(id),
     devTerminalSessionsHydrated,
+    // The same call that gates the broker's recorder, so the pane's disclaimer and the history it
+    // disclaims can never disagree.
+    guiOnlyHistory: (id) => brokerRecordsGuiCalls(sessionCallReporting(deps, id)),
     publish: (c, d) => deps.publish(c, d),
     sessionChannel: deps.sessionChannel,
   });

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -18,7 +18,7 @@ import { mountTmuxRoutes } from "../infra/tmux-routes.js";
 import { mountHookRoute } from "../routes/hook-routes.js";
 import { mountPluginRoutes } from "../routes/plugin-routes.js";
 import { mountMcpRoutes } from "../routes/mcp-routes.js";
-import { brokerRecordsGuiCalls, guiCallRecorderFor } from "../mcp/gui-call-history.js";
+import { guiCallRecorderFor, historyIsGuiOnly } from "../mcp/gui-call-history.js";
 import type { SessionAgent } from "../../common/sessionAgent.js";
 import { mountSessionRoutes } from "../routes/session-routes.js";
 import { mountToolRoutes } from "../routes/tool-routes.js";
@@ -87,10 +87,10 @@ export interface AppRouteDeps extends SessionActivityDeps {
 // The channel a directory-config change is announced on.
 const DIR_CONFIG_CHANNEL = "dir-config";
 
-// The two signals that decide whether the MCP broker writes this session's tool-call history —
-// and, through /api/tools, whether the pane tells the user its history is GUI-tools-only. Read
-// here so both answers come from one place: they must agree, or the pane disclaims a history it
-// is not actually giving (or worse, keeps quiet about one it is).
+// The two signals behind both halves of the broker-fed history: whether it is written at all, and
+// whether the pane tells the user it holds the GUI tools alone. Read here so the two answers are
+// built from one reading of the session — they are not the same question (the claim is stricter,
+// see historyIsGuiOnly), but they must never be built from different facts.
 const sessionCallReporting = (deps: AppRouteDeps, sessionId: string) => ({
   agent: deps.agentOfSession(sessionId),
   reportsOwnCalls: hookedSessions.has(sessionId),
@@ -264,9 +264,10 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
     sessionToolGroupsHydrated,
     isGridSession: (id) => devTerminalSessions.has(id),
     devTerminalSessionsHydrated,
-    // The same call that gates the broker's recorder, so the pane's disclaimer and the history it
-    // disclaims can never disagree.
-    guiOnlyHistory: (id) => brokerRecordsGuiCalls(sessionCallReporting(deps, id)),
+    // Built from the same two signals as the broker's recorder, but with the stricter rule the
+    // user-facing claim needs — see historyIsGuiOnly for why the pane must not answer this the
+    // moment a session id exists.
+    guiOnlyHistory: (id) => historyIsGuiOnly(sessionCallReporting(deps, id)),
     publish: (c, d) => deps.publish(c, d),
     sessionChannel: deps.sessionChannel,
   });

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -42,7 +42,32 @@ export interface McpRouteDeps {
   guiCallHistory: (sessionId: string) => GuiCallRecorder | null;
 }
 
+// Sessions whose MCP client has made contact, so the announcement below is sent once per session
+// rather than on every tool call. In-memory only: after a restart a session announcing itself
+// again is exactly right, since the panel it is telling has also just reconnected.
+const announcedSessions = new Set<string>();
+
 export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
+  /**
+   * Tell the panel this session's MCP client is up, so anything it asked too early can be re-asked.
+   *
+   * The pane is handed a session id while the agent is still being spawned, so its first
+   * `/api/tools` lands before there is anything to answer with. The GROUP route below already
+   * announces (with the groups it just learned) and that fixed the grid; a single-view session
+   * connects on the ALL-TOOLS url, learns no group, and so announced nothing — leaving that pane
+   * on whatever the too-early answer said for the rest of the session.
+   *
+   * Deliberately carries NO `groups` field. The grid reads that field to decide whether a cell has
+   * the Canvas MCP, and an all-tools session genuinely has no groups to report — sending `[]` would
+   * read as "this cell cannot draw" for a session that can. Consumers that need groups ignore a
+   * message without them; consumers that only need "ask again" (the tools pane) act on both.
+   */
+  function announceMcpContact(sessionId: string): void {
+    if (announcedSessions.has(sessionId)) return;
+    announcedSessions.add(sessionId);
+    deps.publish(TOOL_GROUPS_CHANNEL, { sessionId });
+  }
+
   // We run in STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
   // request, no session header and no initialize handshake required across requests. The SDK
   // forbids reusing a stateless transport, so it is never cached.
@@ -50,6 +75,9 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     if (!SESSION_ID_RE.test(sessionId)) {
       return res.status(400).json({ error: "invalid sessionId" });
     }
+    // Both routes, because both kinds of session are asked about too early. The group route's own
+    // announcement below carries the groups it learned; this one only says "I am here".
+    announceMcpContact(sessionId);
     // Hidden translation workers (and only they) get the worker-only submitTranslation
     // tool, so a normal chat's tool list stays clean.
     // A translation worker is a hidden claude session with no pane to feed, so it never gets a

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -12,6 +12,7 @@ import type { Express, Request, Response } from "express";
 
 import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { buildGuiMcpServer } from "../mcp/broker.js";
+import type { GuiCallRecorder } from "../mcp/gui-call-history.js";
 import { translationWorkerIds, markSessionToolGroup, sessionToolGroups } from "../session/registry.js";
 import { isToolGroup, type ToolGroup } from "../../common/toolGroups.js";
 import { submitTranslation } from "../session/translation-worker.js";
@@ -32,6 +33,13 @@ export const TOOL_GROUPS_CHANNEL = "tool-groups";
 
 export interface McpRouteDeps {
   publish: (channel: string, data: unknown) => void;
+  /**
+   * A recorder for this session's GUI tool calls, or null to record nothing. Resolved per
+   * request rather than per session id up front: a session's agent is known only once its PTY
+   * exists, and the same id is asked about again on every later call. See mcp/gui-call-history.ts
+   * for which agents get one and why claude must not.
+   */
+  guiCallHistory: (sessionId: string) => GuiCallRecorder | null;
 }
 
 export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
@@ -44,9 +52,13 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     }
     // Hidden translation workers (and only they) get the worker-only submitTranslation
     // tool, so a normal chat's tool list stays clean.
+    // A translation worker is a hidden claude session with no pane to feed, so it never gets a
+    // recorder — asking would only be an extra lookup for a guaranteed null.
+    const isWorker = translationWorkerIds.has(sessionId);
     const server = buildGuiMcpServer(sessionId, `http://127.0.0.1:${PORT}`, {
-      submitTranslationTool: translationWorkerIds.has(sessionId),
+      submitTranslationTool: isWorker,
       group,
+      history: isWorker ? null : deps.guiCallHistory(sessionId),
     });
     // No sessionIdGenerator at all is the SDK's stateless mode. Spelling it `undefined` says
     // the same thing to the runtime but not to the type — the option is exact-optional.

--- a/server/routes/tool-routes.ts
+++ b/server/routes/tool-routes.ts
@@ -27,6 +27,13 @@ export interface ToolRouteDeps {
    */
   isGridSession: (sessionId: string) => boolean;
   devTerminalSessionsHydrated: Promise<void>;
+  /**
+   * Is this session's tool-call history fed by the MCP broker rather than by hooks — i.e. does it
+   * hold the GUI tools ALONE? The pane says so, because an empty GUI-only history looks exactly
+   * like an agent that ran nothing. Answered server-side because the client cannot work it out:
+   * a codex launcher chip is a cell with no agent name on it (see mcp/gui-call-history.ts).
+   */
+  guiOnlyHistory: (sessionId: string) => boolean;
   publish: (channel: string, data: unknown) => void;
   sessionChannel: (id: string) => string;
 }
@@ -93,17 +100,20 @@ export function mountToolRoutes(app: Express, deps: ToolRouteDeps): void {
   // answer stays the whole set (the single view, which carries every tool).
   app.get("/api/tools", async (req, res) => {
     const sessionId = typeof req.query.sessionId === "string" ? req.query.sessionId : null;
-    if (sessionId === null || !SESSION_ID_RE.test(sessionId)) return res.json({ tools: deps.toolSummaries });
+    // With no session there is no history to describe either, so the flag stays false rather than
+    // disclaiming a pane that is showing nobody's history.
+    if (sessionId === null || !SESSION_ID_RE.test(sessionId)) return res.json({ tools: deps.toolSummaries, guiOnlyHistory: false });
     // Both sets are persisted and hydrated at boot; asked before either resolves, a grid cell
     // would read as having nothing and a resumed one as having lost its groups.
     await Promise.all([deps.sessionToolGroupsHydrated, deps.devTerminalSessionsHydrated]);
     const groups = deps.sessionToolGroups(sessionId);
     const isGrid = deps.isGridSession(sessionId);
-    res.json({ tools: narrowedTools(deps.toolSummaries, groups, isGrid), groups });
+    res.json({ tools: narrowedTools(deps.toolSummaries, groups, isGrid), groups, guiOnlyHistory: deps.guiOnlyHistory(sessionId) });
   });
 
-  // Replay a session's tool-call history (every tool, via the Pre/PostToolUse hooks)
-  // so the tools pane can render it when the user (re)selects that session. Loads
+  // Replay a session's tool-call history — every tool for claude (its Pre/PostToolUse hooks),
+  // the GUI tools alone for codex / agy (the broker; they have no hooks) — so the tools pane
+  // can render it when the user (re)selects that session. Loads
   // from disk (~/.mulmoterminal/toolcalls) on first access so it survives a reboot.
   app.get("/api/tool-calls/:sessionId", async (req, res) => {
     const { sessionId } = req.params;

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -88,6 +88,18 @@ export const codexRolloutIds = new Map<string, string>();
 // (which would let both cold-resume the same conversation). Serialized by the single event loop.
 export const claimedCodexRollouts = new Set<string>();
 
+// Sessions spawned with our `--settings` hooks, i.e. the ones that report their own tool calls to
+// /api/hook. Only spawn-claude registers them, because only claude has a hook mechanism.
+//
+// It exists so the MCP broker can tell whether a session's tool calls are ALREADY being recorded,
+// without asking what agent it is: a codex launcher chip runs codex through the login shell, so
+// its PtyEntry is honestly labelled "shell" and no agent name identifies it (see
+// mcp/gui-call-history.ts). What the broker actually needs to know is this, not the name.
+//
+// Never pruned. An id is a v4 uuid used once, the set costs a string per session, and forgetting
+// one would silently start double-recording that session's GUI calls — the opposite of cheap.
+export const hookedSessions = new Set<string>();
+
 // mulmoterminal session key -> the antigravity conversation id it maps to.
 export const antigravityConversationIds = new Map<string, string>();
 export const claimedAntigravityConversations = new Set<string>();

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -9,7 +9,7 @@ import { SANDBOX_HOST } from "../infra/sandbox.js";
 import { buildClaudeArgs } from "../agents/claude-args.js";
 import { claudeAdapter } from "../agents/claude.js";
 import { appendedSystemPrompt } from "../agents/appended-prompt.js";
-import { knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
+import { hookedSessions, knownSessions, launchChoices, ptys, resetSessionToolGroups } from "./registry.js";
 import { ptySpawn, ptyWouldReattach, sandboxWouldRun, spawnSandboxEntry } from "./pty-spawn.js";
 import { ptyExitLine, ptyStartLine } from "./pty-exit-log.js";
 import { attachDraftInjection } from "./draft-injection.js";
@@ -183,6 +183,10 @@ export function createClaudeSpawner(deps: SpawnDeps) {
       return { term, ws, buffer: "", cwd, tmux, active: false, agent: "claude" };
     }
     ptys.set(sessionId, entry);
+    // Every claude spawn above carries `--settings` with the Pre/PostToolUse hooks, so from here
+    // on this session reports its own tool calls — which is what stops the MCP broker recording
+    // its GUI calls a second time (mcp/gui-call-history.ts).
+    hookedSessions.add(sessionId);
 
     if (!canResume) {
       // Brand-new (or restarted-idle) session: surface it in the sidebar before it's persisted.

--- a/server/session/tool-store.ts
+++ b/server/session/tool-store.ts
@@ -169,11 +169,17 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
     toolResultsStore.save(sessionId);
   }
 
-  // Per-session tool-call history, fed by Claude's PreToolUse/PostToolUse hooks so
-  // it captures EVERY tool call — built-ins (Bash, Read, …), the user's MCP tools,
-  // AND our GUI plugin tools — not just the GUI ones the broker sees. Published on a
-  // per-session channel the tools pane subscribes to. (The broker's toolResults
-  // store above is separate; it only drives rendering of GUI views.)
+  // Per-session tool-call history, published on a per-session channel the tools pane
+  // subscribes to. (The broker's toolResults store above is separate; it only drives
+  // rendering of GUI views.) It has two writers, and which one a session gets decides
+  // how complete its history is:
+  //
+  //   claude          — its PreToolUse/PostToolUse hooks, matcher "", so EVERY tool call:
+  //                     built-ins (Bash, Read, …), the user's MCP tools, and ours.
+  //   codex / agy     — the MCP broker, since neither has a hook mechanism. GUI tools only.
+  //
+  // Never both for one session — see mcp/gui-call-history.ts for why that would double
+  // rather than dedupe.
   //
   // Persisted under ~/.mulmoterminal/toolcalls via the same disk-backed store as
   // the toolResults, so the history survives a server reboot.

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -292,6 +292,11 @@ const { subscribe: subscribeToolGroups } = usePubSub();
 const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
   const msg = data as { sessionId?: string; groups?: string[] };
   if (!msg?.sessionId || msg.sessionId !== expandedSessionId.value) return;
+  // A message with no `groups` is the bare "my MCP client is up" announcement, sent for every
+  // session so a pane that asked too early can ask again. It says nothing about groups — an
+  // all-tools session has none to report — and reading it as an empty list would tell a cell
+  // that can draw that it cannot.
+  if (!Array.isArray(msg.groups)) return;
   canvasAvailable.value = hasCanvasGroup(msg.groups);
   canvasChecked.value = true;
 });

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { ref, watch, onUnmounted } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
+import { usePubSub } from "../composables/usePubSub";
+import { TOOL_GROUPS_CHANNEL } from "../toolGroupsChannel";
 
 // The tools pane mirrors MulmoClaude's right sidebar: an "Available Tools" list
 // (the GUI plugin tools, with collapsible descriptions) and a "Tool Call History"
-// for the active session. The history is fed by Claude's PreToolUse/PostToolUse
-// hooks, so it shows EVERY tool call — built-ins (Bash, Read, …), other MCP tools,
-// and our GUI plugin tools — not just the GUI ones. Live updates arrive on the
+// for the active session. For a CLAUDE session the history is fed by its PreToolUse/PostToolUse
+// hooks, so it shows EVERY tool call — built-ins (Bash, Read, …), other MCP tools, and our GUI
+// plugin tools. For codex / agy, which have no hooks, it is fed by our MCP broker and holds the
+// GUI tools alone — /api/tools reports which, as `guiOnlyHistory`. Live updates arrive on the
 // toolcalls:<id> channel; history replays from /api/tool-calls/:id on (re)select.
 interface AvailableTool {
   toolName: string;
@@ -25,6 +28,15 @@ interface ToolCall {
 
 const props = defineProps<{ sessionId: string | null }>();
 const emit = defineEmits<{ close: [] }>();
+
+// Whether this session's history holds the GUI tools ALONE (the broker fed it) rather than every
+// tool (claude's hooks fed it). An empty GUI-only history looks exactly like an agent that ran
+// nothing, so the pane says which it is — see the note in the template.
+//
+// The SERVER decides it, and the client cannot: a codex launcher chip runs the user's own command
+// through the login shell, so nothing the browser holds about that cell names an agent at all
+// (server/mcp/gui-call-history.ts).
+const guiOnlyHistory = ref(false);
 
 const availableTools = ref<AvailableTool[]>([]);
 const toolCalls = ref<ToolCall[]>([]);
@@ -49,11 +61,34 @@ async function loadAvailableTools(sessionId: string | null) {
     // from showing another cell's tools.
     if (sessionId !== props.sessionId) return;
     availableTools.value = body.tools ?? [];
+    guiOnlyHistory.value = body.guiOnlyHistory === true;
   } catch {
-    if (sessionId === props.sessionId) availableTools.value = [];
+    if (sessionId === props.sessionId) {
+      availableTools.value = [];
+      // Unknown, so claim nothing: a note that appears on a failed request would be a statement
+      // about a history we could not ask about.
+      guiOnlyHistory.value = false;
+    }
   }
 }
 watch(() => props.sessionId, loadAvailableTools, { immediate: true });
+
+// The question above is normally asked BEFORE it can be answered: the browser is handed a session
+// id while the agent is still being spawned, so its MCP client has not connected and the server
+// has learned no groups yet. That first "nothing" then stood until something happened to remount
+// the pane — closing and reopening it, or switching cells — which is exactly the "No GUI plugin
+// tools enabled." a freshly started session showed.
+//
+// So re-ask when the server says it has learned this session's groups. The same channel and the
+// same reason as the grid's Canvas button (TerminalGrid.vue) — asked once at mount, both were
+// asking too early. Re-asking rather than reading the pushed `groups`: the reply also carries the
+// tool DESCRIPTIONS and `guiOnlyHistory`, which the push does not.
+const { subscribe: subscribeToolGroups } = usePubSub();
+const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
+  const msg = data as { sessionId?: string };
+  if (msg?.sessionId && msg.sessionId === props.sessionId) void loadAvailableTools(props.sessionId);
+});
+onUnmounted(offToolGroups);
 
 function callKey(c: ToolCall, i: number): string {
   return c.toolUseId ?? `${c.toolName}-${i}`;
@@ -179,7 +214,10 @@ onUnmounted(() => window.clearTimeout(historyCopyTimer));
             {{ historyCopied ? "Copied" : "Copy all" }}
           </button>
         </div>
-        <div v-if="toolCalls.length === 0" class="text-[12px] text-dim">No tool calls yet.</div>
+        <div v-if="guiOnlyHistory" data-testid="gui-only-note" class="mb-1.5 text-[11px] leading-[1.35] text-dim">
+          This agent reports no hooks, so the list holds its GUI tool calls only — not its shell commands or file edits.
+        </div>
+        <div v-if="toolCalls.length === 0" class="text-[12px] text-dim">{{ guiOnlyHistory ? "No GUI tool calls yet." : "No tool calls yet." }}</div>
         <div v-for="(call, i) in toolCalls" :key="callKey(call, i)" data-testid="tool-call" class="mt-1.5 rounded-md border border-border bg-deep px-2 py-1.5">
           <button
             class="flex w-full cursor-pointer items-center justify-between gap-2 border-0 bg-transparent px-0 py-1 text-left text-inherit"

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -51,24 +51,31 @@ const expandedCalls = ref<Set<string>>(new Set());
 // Reloaded on every session change rather than cached per id: the server learns a session's
 // groups from the connections it makes, so the answer for one id can go from "everything" to
 // the real subset within a second of that session starting.
+//
+// The session id is NOT enough to tell two loads apart, and since the re-ask below there are
+// routinely two in flight for the id that is current — the early one asked at mount and the one
+// the announcement triggered. Both pass a session-id guard, so an older reply landing second
+// would restore the empty list this pane exists to get rid of. Only the newest may apply, which
+// is the same rule and the same counter useSessionFeed keeps (#620).
+let latestToolsLoad = 0;
 async function loadAvailableTools(sessionId: string | null) {
+  const loadId = ++latestToolsLoad;
   const url = sessionId ? `/api/tools?sessionId=${encodeURIComponent(sessionId)}` : "/api/tools";
+  // Overtaken: a load for another session (we switched away), or a newer load for this one.
+  const overtaken = () => sessionId !== props.sessionId || loadId !== latestToolsLoad;
   try {
     const res = await fetch(url);
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const body = await res.json();
-    // Late reply for a session we have since switched away from: dropping it keeps the list
-    // from showing another cell's tools.
-    if (sessionId !== props.sessionId) return;
+    if (overtaken()) return;
     availableTools.value = body.tools ?? [];
     guiOnlyHistory.value = body.guiOnlyHistory === true;
   } catch {
-    if (sessionId === props.sessionId) {
-      availableTools.value = [];
-      // Unknown, so claim nothing: a note that appears on a failed request would be a statement
-      // about a history we could not ask about.
-      guiOnlyHistory.value = false;
-    }
+    if (overtaken()) return;
+    availableTools.value = [];
+    // Unknown, so claim nothing: a note that appears on a failed request would be a statement
+    // about a history we could not ask about.
+    guiOnlyHistory.value = false;
   }
 }
 watch(() => props.sessionId, loadAvailableTools, { immediate: true });

--- a/src/components/ToolsPane.vue
+++ b/src/components/ToolsPane.vue
@@ -86,10 +86,11 @@ watch(() => props.sessionId, loadAvailableTools, { immediate: true });
 // the pane — closing and reopening it, or switching cells — which is exactly the "No GUI plugin
 // tools enabled." a freshly started session showed.
 //
-// So re-ask when the server says it has learned this session's groups. The same channel and the
-// same reason as the grid's Canvas button (TerminalGrid.vue) — asked once at mount, both were
-// asking too early. Re-asking rather than reading the pushed `groups`: the reply also carries the
-// tool DESCRIPTIONS and `guiOnlyHistory`, which the push does not.
+// So re-ask when the server says that session's MCP client is up. The same channel and the same
+// reason as the grid's Canvas button and the GUI panel's tool hint — all three asked once at
+// mount, and all three were asking too early. Re-asking rather than reading the pushed `groups`:
+// the reply also carries the tool DESCRIPTIONS and `guiOnlyHistory`, which the push does not, and
+// the announcement for a single-view session carries no groups at all (see mcp-routes.ts).
 const { subscribe: subscribeToolGroups } = usePubSub();
 const offToolGroups = subscribeToolGroups(TOOL_GROUPS_CHANNEL, (data) => {
   const msg = data as { sessionId?: string };

--- a/test/server/mcp/broker-history.spec.ts
+++ b/test/server/mcp/broker-history.spec.ts
@@ -1,0 +1,120 @@
+// The broker feeding the tools pane's call history — the only source codex / agy have, since
+// neither reports tool calls the way claude's hooks do (server/mcp/gui-call-history.ts).
+//
+// Driven through a real MCP client over an in-memory transport rather than by reaching for the
+// request handler: what matters is that a normal tools/call produces the pair of entries, and a
+// handler called directly would not prove the SDK path does.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { buildGuiMcpServer } from "../../../server/mcp/broker.js";
+import type { GuiCallRecorder } from "../../../server/mcp/gui-call-history.js";
+
+interface Recorded {
+  starts: { toolUseId: string; toolName: string; toolInput: unknown }[];
+  ends: { toolUseId: string; toolName: string; toolOutput: unknown; status: string; durationMs: number }[];
+}
+
+const recorder = (): GuiCallRecorder & Recorded => {
+  const starts: Recorded["starts"] = [];
+  const ends: Recorded["ends"] = [];
+  return { starts, ends, start: (c) => void starts.push(c), end: (c) => void ends.push(c) };
+};
+
+// The two hosts the broker POSTs to: the plugin dispatch route, and the toolResult sink.
+function stubFetch(dispatch: () => { status: number; body: unknown }) {
+  return vi.fn(async (url: unknown) => {
+    if (String(url).includes("/api/plugin/")) {
+      const { status, body } = dispatch();
+      return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
+    }
+    return { ok: true, status: 200, json: async () => ({ ok: true }) } as unknown as Response;
+  });
+}
+
+async function callTool(server: ReturnType<typeof buildGuiMcpServer>, name: string, args: Record<string, unknown>) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "spec", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  try {
+    return await client.callTool({ name, arguments: args });
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+let fetchSpy: ReturnType<typeof stubFetch>;
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("buildGuiMcpServer tool-call history", () => {
+  it("records a running entry and then completes it", async () => {
+    fetchSpy = stubFetch(() => ({ status: 200, body: { message: "Rendered.", data: { html: "<p/>" } } }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const history = recorder();
+    const server = buildGuiMcpServer("11111111-1111-4111-8111-111111111111", "http://127.0.0.1:1", { history });
+
+    await callTool(server, "presentHtml", { html: "<p/>" });
+
+    expect(history.starts).toHaveLength(1);
+    expect(history.starts[0].toolName).toBe("presentHtml");
+    expect(history.starts[0].toolInput).toEqual({ html: "<p/>" });
+    expect(history.ends).toHaveLength(1);
+    // Same id on both, so the store completes the entry in place rather than appending a second.
+    expect(history.ends[0].toolUseId).toBe(history.starts[0].toolUseId);
+    expect(history.ends[0].status).toBe("completed");
+    expect(history.ends[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // Without this the entry would sit on "running…" for the life of the session — the same reason
+  // claude registers PostToolUseFailure alongside PostToolUse.
+  it("closes the entry as failed when the plugin dispatch fails", async () => {
+    fetchSpy = stubFetch(() => ({ status: 500, body: {} }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const history = recorder();
+    const server = buildGuiMcpServer("11111111-1111-4111-8111-111111111111", "http://127.0.0.1:1", { history });
+
+    // The error still reaches the agent as an error response — recording it must not swallow it.
+    await expect(callTool(server, "presentHtml", { html: "<p/>" })).rejects.toThrow(/500/);
+
+    expect(history.starts).toHaveLength(1);
+    expect(history.ends).toHaveLength(1);
+    expect(history.ends[0].status).toBe("failed");
+  });
+
+  // A tool the agent named and was refused (outside its group) is exactly what someone reading
+  // the history is looking for.
+  it("records a refused tool as a failed call", async () => {
+    fetchSpy = stubFetch(() => ({ status: 200, body: {} }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const history = recorder();
+    const server = buildGuiMcpServer("11111111-1111-4111-8111-111111111111", "http://127.0.0.1:1", { history, group: "render" });
+
+    await callTool(server, "manageCollection", { action: "list" });
+
+    expect(history.ends).toHaveLength(1);
+    expect(history.ends[0].status).toBe("failed");
+    // Refused before dispatch: the plugin route is never called.
+    expect(fetchSpy.mock.calls.some((call) => String(call[0]).includes("/api/plugin/"))).toBe(false);
+  });
+
+  // Claude gets no recorder at all (its hooks already report the call), and the broker must work
+  // exactly as before when there is none.
+  it("serves the call normally with no recorder", async () => {
+    fetchSpy = stubFetch(() => ({ status: 200, body: { message: "Rendered." } }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const server = buildGuiMcpServer("11111111-1111-4111-8111-111111111111", "http://127.0.0.1:1", {});
+
+    const result = await callTool(server, "presentHtml", { html: "<p/>" });
+
+    expect(JSON.stringify(result.content)).toContain("Rendered.");
+  });
+});

--- a/test/server/mcp/gui-call-history.spec.ts
+++ b/test/server/mcp/gui-call-history.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { brokerRecordsGuiCalls, guiCallRecorderFor, type ToolCallSink } from "../../../server/mcp/gui-call-history.js";
+import { brokerRecordsGuiCalls, guiCallRecorderFor, historyIsGuiOnly, type ToolCallSink } from "../../../server/mcp/gui-call-history.js";
 
 const sink = (): ToolCallSink & { starts: unknown[]; ends: unknown[] } => {
   const starts: unknown[] = [];
@@ -42,6 +42,26 @@ describe("brokerRecordsGuiCalls", () => {
   // Neither signal says claude, so nothing else is writing this history.
   it("records an unknown session", () => {
     expect(brokerRecordsGuiCalls({ agent: null, reportsOwnCalls: false })).toBe(true);
+  });
+});
+
+describe("historyIsGuiOnly", () => {
+  it("says so for the sessions the broker actually feeds", () => {
+    expect(historyIsGuiOnly({ agent: "codex", reportsOwnCalls: false })).toBe(true);
+    expect(historyIsGuiOnly({ agent: "shell", reportsOwnCalls: false })).toBe(true);
+  });
+
+  it("says nothing for a hook-fed session", () => {
+    expect(historyIsGuiOnly({ agent: "claude", reportsOwnCalls: true })).toBe(false);
+  });
+
+  // The claim is asked EARLY — the browser holds a session id before the agent is spawned — so a
+  // claude session can be asked about before spawnClaudePty registers its hooks. Both signals then
+  // say "not claude", and answering the recording gate here would tell the user that claude's
+  // complete hook-fed history contains GUI calls only. Nothing visible means nothing claimed.
+  it("says nothing about a session it cannot see yet", () => {
+    expect(brokerRecordsGuiCalls({ agent: null, reportsOwnCalls: false })).toBe(true);
+    expect(historyIsGuiOnly({ agent: null, reportsOwnCalls: false })).toBe(false);
   });
 });
 

--- a/test/server/mcp/gui-call-history.spec.ts
+++ b/test/server/mcp/gui-call-history.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { brokerRecordsGuiCalls, guiCallRecorderFor, type ToolCallSink } from "../../../server/mcp/gui-call-history.js";
+
+const sink = (): ToolCallSink & { starts: unknown[]; ends: unknown[] } => {
+  const starts: unknown[] = [];
+  const ends: unknown[] = [];
+  return {
+    starts,
+    ends,
+    recordToolCallStart: async (id, call) => void starts.push({ id, call }),
+    recordToolCallEnd: async (id, call) => void ends.push({ id, call }),
+  };
+};
+
+describe("brokerRecordsGuiCalls", () => {
+  it("records for the agents that have no hooks of their own", () => {
+    expect(brokerRecordsGuiCalls({ agent: "codex", reportsOwnCalls: false })).toBe(true);
+    expect(brokerRecordsGuiCalls({ agent: "antigravity", reportsOwnCalls: false })).toBe(true);
+  });
+
+  // The regression this gate was rewritten for: a codex LAUNCHER CHIP runs `zsh -lc exec codex …`,
+  // so its PtyEntry is labelled "shell" and no agent name says codex anywhere. Matching on the
+  // name left that cell — a real codex session calling our tools — with a permanently empty pane.
+  it("records for a codex launcher chip, whose session is labelled a shell", () => {
+    expect(brokerRecordsGuiCalls({ agent: "shell", reportsOwnCalls: false })).toBe(true);
+  });
+
+  // The other half: claude's PreToolUse/PostToolUse match "" and so already report every mcp__
+  // call. Recording here too would list each GUI call twice — and with a different id each time,
+  // so nothing downstream could collapse them.
+  it("does NOT record a session that reports its own calls", () => {
+    expect(brokerRecordsGuiCalls({ agent: "claude", reportsOwnCalls: true })).toBe(false);
+  });
+
+  // The backstop, for a claude session that outlived a restart and was never reattached here, so
+  // nothing added it to hookedSessions — its pane command still says what it is.
+  it("does NOT record a claude session this process never spawned", () => {
+    expect(brokerRecordsGuiCalls({ agent: "claude", reportsOwnCalls: false })).toBe(false);
+  });
+
+  // Neither signal says claude, so nothing else is writing this history.
+  it("records an unknown session", () => {
+    expect(brokerRecordsGuiCalls({ agent: null, reportsOwnCalls: false })).toBe(true);
+  });
+});
+
+describe("guiCallRecorderFor", () => {
+  it("is null for an agent that reports its own calls", () => {
+    expect(guiCallRecorderFor("s1", { agent: "claude", reportsOwnCalls: true }, sink())).toBeNull();
+    expect(guiCallRecorderFor("s1", { agent: "claude", reportsOwnCalls: false }, sink())).toBeNull();
+  });
+
+  it("routes start and end to the sink under the session id", () => {
+    const s = sink();
+    const recorder = guiCallRecorderFor("s1", { agent: "codex", reportsOwnCalls: false }, s);
+    recorder?.start({ toolUseId: "u1", toolName: "presentDocument", toolInput: { a: 1 } });
+    recorder?.end({ toolUseId: "u1", toolName: "presentDocument", toolInput: { a: 1 }, toolOutput: "ok", durationMs: 12, status: "completed" });
+    expect(s.starts).toEqual([{ id: "s1", call: { toolUseId: "u1", toolName: "presentDocument", toolInput: { a: 1 } } }]);
+    expect(s.ends).toEqual([
+      { id: "s1", call: { toolUseId: "u1", toolName: "presentDocument", toolInput: { a: 1 }, toolOutput: "ok", durationMs: 12, status: "completed" } },
+    ]);
+  });
+
+  // It sits on the tool-call path: a failed history write must cost a row in a pane, never the
+  // agent's tool call.
+  it("swallows a rejected write instead of throwing at the caller", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const failing: ToolCallSink = {
+      recordToolCallStart: () => Promise.reject(new Error("disk full")),
+      recordToolCallEnd: () => Promise.reject(new Error("disk full")),
+    };
+    const recorder = guiCallRecorderFor("s1", { agent: "codex", reportsOwnCalls: false }, failing);
+    expect(() => recorder?.start({ toolUseId: "u1", toolName: "presentDocument", toolInput: {} })).not.toThrow();
+    await Promise.resolve();
+    expect(error).toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/test/server/routes/mcp-announce.spec.ts
+++ b/test/server/routes/mcp-announce.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+// The announcement every MCP session makes on first contact, and the one thing it must NOT say.
+//
+// The tools pane asks what a session has while the agent is still being spawned, so its first
+// answer is empty; this is what tells it to ask again. The GROUP route announced already, which is
+// why the grid was fixed and the single view was not — an all-tools session learns no group, so it
+// announced nothing and its pane stayed on the too-early answer for the whole session.
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+
+// The group route PERSISTS what it learned, under a MULMOTERMINAL_HOME derived from the home
+// directory at import time — so point HOME somewhere disposable BEFORE importing, or this spec
+// appends test uuids to the developer's own ~/.mulmoterminal (the same reason tool-store.ts takes
+// its root as a parameter).
+//
+// `process.env` is per PROCESS, not per spec file, and vitest reuses a worker for several files.
+// Leaving HOME pointed at a directory this file then deletes would hand the next file in the same
+// worker a home that does not exist, so it is put back — the module registry is per file, so the
+// next file's imports read the restored value.
+const HOME = mkdtempSync(path.join(os.tmpdir(), "mt-mcp-announce-"));
+const REAL_HOME = process.env.HOME;
+process.env.HOME = HOME;
+afterAll(() => {
+  if (REAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = REAL_HOME;
+  rmSync(HOME, { recursive: true, force: true });
+});
+
+const { mountMcpRoutes, TOOL_GROUPS_CHANNEL } = await import("../../../server/routes/mcp-routes.js");
+
+const published: { channel: string; data: Record<string, unknown> }[] = [];
+const app = express();
+app.use(express.json());
+mountMcpRoutes(app, {
+  publish: (channel, data) => void published.push({ channel, data: data as Record<string, unknown> }),
+  guiCallHistory: () => null,
+});
+
+// A tools/list, the cheapest real MCP request: it needs no plugin dispatch, so nothing here
+// depends on a running host.
+const call = (route: string) =>
+  request(app).post(route).set("accept", "application/json, text/event-stream").send({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} });
+
+const announcementsFor = (id: string) => published.filter((p) => p.channel === TOOL_GROUPS_CHANNEL && p.data.sessionId === id);
+
+beforeEach(() => {
+  published.length = 0;
+});
+
+describe("MCP first-contact announcement", () => {
+  it("announces a single-view (all-tools) session, which has no group to announce with", async () => {
+    const id = randomUUID();
+    await call(`/api/mcp/${id}`);
+    expect(announcementsFor(id)).toHaveLength(1);
+    // No `groups` key at all. The grid reads that field to decide whether a cell has the Canvas
+    // MCP, and an all-tools session genuinely has none to report — sending `[]` would tell a cell
+    // that can draw that it cannot.
+    expect("groups" in announcementsFor(id)[0].data).toBe(false);
+  });
+
+  it("announces once per session, not once per tool call", async () => {
+    const id = randomUUID();
+    await call(`/api/mcp/${id}`);
+    await call(`/api/mcp/${id}`);
+    await call(`/api/mcp/${id}`);
+    expect(announcementsFor(id)).toHaveLength(1);
+  });
+
+  it("still announces the learned groups for a grid cell's group url", async () => {
+    const id = randomUUID();
+    await call(`/api/mcp/render/${id}`);
+    expect(announcementsFor(id).some((p) => Array.isArray(p.data.groups) && (p.data.groups as string[]).includes("render"))).toBe(true);
+  });
+
+  it("says nothing for a malformed session id", async () => {
+    await call("/api/mcp/not-a-uuid");
+    expect(published).toHaveLength(0);
+  });
+});

--- a/test/server/session/tool-group-reattach.spec.ts
+++ b/test/server/session/tool-group-reattach.spec.ts
@@ -40,6 +40,9 @@ vi.mock("../../../server/session/registry.js", () => ({
   knownSessions: new Map(),
   launchChoices: new Map(),
   ptys: new Map(),
+  // Every claude spawn registers itself as reporting its own tool calls (the MCP broker reads this
+  // to decide it must NOT record them a second time — see mcp/gui-call-history.ts).
+  hookedSessions: new Set(),
   resetSessionToolGroups: (id: string) => resetSessionToolGroups(id),
 }));
 

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -2,13 +2,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import ToolsPane from "../../../src/components/ToolsPane.vue";
 
-// Capture the pub/sub callback so tests can simulate a server push without a
-// real socket (mirrors Sidebar.spec.ts).
+// Capture the pub/sub callbacks so tests can simulate a server push without a real socket
+// (mirrors Sidebar.spec.ts). Kept per channel: the pane subscribes twice — its history feed, and
+// the tool-groups announcement that tells it to re-ask what tools this session has.
 let captured: ((data: unknown) => void) | null = null;
+let capturedGroups: ((data: unknown) => void) | null = null;
 vi.mock("../../../src/composables/usePubSub", () => ({
   usePubSub: () => ({
-    subscribe: (_channel: string, cb: (data: unknown) => void) => {
-      captured = cb;
+    subscribe: (channel: string, cb: (data: unknown) => void) => {
+      if (channel === "tool-groups") capturedGroups = cb;
+      else captured = cb;
       return () => {};
     },
   }),
@@ -36,6 +39,7 @@ function mockFetch(handler: (url: string) => Promise<unknown>) {
 describe("ToolsPane", () => {
   beforeEach(() => {
     captured = null;
+    capturedGroups = null;
   });
 
   it("lists available tools and renders history rows with running/completed/failed badges", async () => {
@@ -105,5 +109,59 @@ describe("ToolsPane", () => {
     await flushPromises();
     expect(wrapper.text()).toContain("NewTool");
     expect(wrapper.text()).not.toContain("OldTool");
+  });
+
+  // The pane asks what tools a session has while the agent is still starting, so the first answer
+  // is "none" — and it used to stand there until something remounted the pane. That is the
+  // "No GUI plugin tools enabled." a freshly launched session showed until it was redrawn.
+  it("re-asks for the tool list when the server announces this session's groups", async () => {
+    let toolsReply: unknown[] = [];
+    mockFetch((url) => Promise.resolve(jsonRes(url.startsWith("/api/tools") ? { tools: toolsReply } : { toolCalls: [] })));
+
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.text()).toContain("No GUI plugin tools enabled.");
+
+    // The agent's MCP client has now connected, so the server knows what it has.
+    toolsReply = [{ toolName: "presentDocument", description: "Render markdown" }];
+    capturedGroups?.({ sessionId: "a", groups: ["render"] });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+
+    // Another session's announcement must not repoint this pane.
+    toolsReply = [{ toolName: "manageCollection" }];
+    capturedGroups?.({ sessionId: "b", groups: ["data"] });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+  });
+
+  // A broker-fed history holds ONLY the GUI tools. An empty list there means "called no GUI tool",
+  // not "did nothing" — without the note the pane looks identical to a claude session's and is read
+  // as the stronger claim. The SERVER decides it: a codex launcher chip carries no agent name the
+  // client could key off.
+  it("says the history is GUI-tools-only when the server reports it", async () => {
+    mockFetch((url) => Promise.resolve(jsonRes(url.startsWith("/api/tools") ? { tools: [], guiOnlyHistory: true } : { toolCalls: [] })));
+
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain("No GUI tool calls yet.");
+  });
+
+  it("stays quiet for a hook-fed history, and when the tools request fails", async () => {
+    mockFetch((url) => Promise.resolve(jsonRes(url.startsWith("/api/tools") ? { tools: [], guiOnlyHistory: false } : { toolCalls: [] })));
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(false);
+    expect(wrapper.text()).toContain("No tool calls yet.");
+
+    // A failed /api/tools must not leave the note behind claiming something about a history we
+    // could not ask about.
+    globalThis.fetch = vi.fn((url: string) =>
+      String(url).startsWith("/api/tools") ? Promise.reject(new Error("offline")) : Promise.resolve(jsonRes({ toolCalls: [] })),
+    ) as unknown as typeof fetch;
+    await wrapper.setProps({ sessionId: "b" });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(false);
   });
 });

--- a/test/src/components/ToolsPane.spec.ts
+++ b/test/src/components/ToolsPane.spec.ts
@@ -27,7 +27,9 @@ function deferred<T>() {
   const promise = new Promise<T>((r) => {
     resolve = r;
   });
-  return { promise, resolve };
+  // `settled` is the test's own flag for "we have moved past the phase this gate stands in", so a
+  // fetch stub can answer differently before and after without a second gate.
+  return { promise, resolve, settled: false };
 }
 
 // Route fetch by URL so /api/tools and /api/tool-calls/:id can return distinct
@@ -133,6 +135,32 @@ describe("ToolsPane", () => {
     capturedGroups?.({ sessionId: "b", groups: ["data"] });
     await flushPromises();
     expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+  });
+
+  // Since the re-ask there are routinely two /api/tools loads in flight for the SAME session — the
+  // early one asked at mount and the one the announcement triggered. A session-id guard passes both,
+  // so an older reply landing second would restore the empty list the re-ask exists to get rid of.
+  it("drops an older tools reply that lands after the re-ask's", async () => {
+    const earlyGate = deferred<undefined>();
+    mockFetch((url) => {
+      if (!url.startsWith("/api/tools")) return Promise.resolve(jsonRes({ toolCalls: [] }));
+      // The first load hangs; the one the announcement triggers answers straight away.
+      return earlyGate.settled
+        ? Promise.resolve(jsonRes({ tools: [{ toolName: "presentDocument" }], guiOnlyHistory: true }))
+        : earlyGate.promise.then(() => jsonRes({ tools: [], guiOnlyHistory: false }));
+    });
+
+    const wrapper = mount(ToolsPane, { props: { sessionId: "a" } });
+    earlyGate.settled = true;
+    capturedGroups?.({ sessionId: "a", groups: ["render"] });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+
+    // The pre-announcement reply arrives late. It must not put the empty list back.
+    earlyGate.resolve(undefined);
+    await flushPromises();
+    expect(wrapper.find('[data-testid="tool-name"]').text()).toBe("presentDocument");
+    expect(wrapper.find('[data-testid="gui-only-note"]').exists()).toBe(true);
   });
 
   // A broker-fed history holds ONLY the GUI tools. An empty list there means "called no GUI tool",


### PR DESCRIPTION
## What this fixes

The tools pane's **Tool Call History** had exactly one writer: `POST /api/hook`, driven by the `Pre/PostToolUse` settings that only `claude` carries (`session/hook-settings.ts`). codex has no hook mechanism and neither does agy — the note at the top of `agents/codex-activity.ts` says so, which is why codex turn boundaries are read by tailing the rollout instead.

So for those two the history was empty however much they did, while **Available Tools** directly above it populated normally (that half comes from broker registration, not hooks). Half-alive reads as broken, not as missing.

## How

The broker is the one place their work reaches us: every GUI tool they call arrives at `/api/mcp/:sessionId` with the session id in the URL. `broker.ts` now records start/end around the dispatch, and the existing store, pub/sub channel and pane render it with no changes.

- **Refused tools** (a tool outside the URL's group) are recorded as failed — that is precisely what someone reading the history is looking for.
- **A failed dispatch** closes the entry too, for the same reason claude registers `PostToolUseFailure` alongside `PostToolUse`: otherwise it sits on \`running…\` for the life of the session. The error still propagates to the agent.
- The recorder is **fire-and-forget**: it sits on the tool-call path, and an agent waiting on `presentDocument` must not also wait on our history write.

This is a **partial** history — their Bash, their edits and their other MCP servers never touch us. An empty GUI-only history looks exactly like an agent that ran nothing, so the pane says which kind it is showing. `/api/tools` answers that, computed from the same predicate as the gate below, so the disclaimer and the history can never disagree.

## Not doubling claude — and why the gate is not an agent check

Claude's hooks match `\"\"`, so they already report `mcp__*` calls. Recording in the broker as well would list every GUI call twice, and not as duplicates anything could collapse: the broker mints its own uuid while the hook carries claude's `tool_use_id`.

The first version of the gate was \`agent === \"codex\" || agent === \"antigravity\"\`. That shipped and **half-worked**: agy recorded, codex did not. A codex **launcher chip** runs

\`\`\`
tmux … -- /bin/zsh -lc exec codex -c 'mcp_servers.mulmoterminal-render.url=\"…/api/mcp/render/<id>\"' …
\`\`\`

— `ws-routes.ts` hands it the same GUI MCP URLs, but the PTY comes from `spawnLauncherPty`, so its `PtyEntry` is honestly labelled `\"shell\"`. No agent name identifies a session started by a command the user wrote.

So the gate asks the real question instead: **is something else already recording these calls?** Exactly one thing is — claude's `--settings` hooks — and that is now recorded per spawn in `registry.hookedSessions`, with the agent name kept as a second, independent backstop for a claude session that outlived a restart and was never reattached in this process. Two signals, because a doubled entry is read as the agent having called the tool twice, while a missing one is merely missing.

## Also in here

The pane asked `/api/tools` while the agent was still starting — before its MCP client had connected and the server had learned any groups — and let that first \"none\" stand until something remounted it. That was the \"No GUI plugin tools enabled.\" a freshly launched session showed until it was redrawn. It now re-asks on the `tool-groups` announcement, the same fix the grid's Canvas button already carries.

## Verification

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` clean; `yarn test` 6332 passing.
- New specs: the broker path driven through a real MCP client over an in-memory transport (completed / dispatch-failed / refused / no-recorder), the gate including the launcher-chip case that regressed, and the pane's re-ask and disclaimer. The re-ask spec was confirmed to fail without its fix.
- The diagnosis was made against the running server: the same harmless JSON-RPC probe sent to a live agy session and a live codex session added a row for one and no file at all for the other.

Not yet verified in a live browser session — the dev server needs a restart to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GUI tool-call history recording for MCP sessions, including per-session control for worker vs non-worker flows.
  * Updated the tools API and Tools pane to surface whether a session’s history is GUI-only, with improved refresh behavior as tool data arrives.
* **Bug Fixes**
  * Prevented duplicate GUI call history entries and ensured refused/failed tool calls are captured correctly.
  * Made Tools pane and tool-group announcements more robust against out-of-order or malformed data.
* **Tests**
  * Added/expanded coverage for GUI call-history recording, broker behavior, and Tools pane race/GUI-only UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->