### PR TITLE
docs: 実在するのに未記載だった環境変数4件を追記し、ja ガイドの孤立行を直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ the `claude` / `codex` sessions themselves.
 | `CLAUDE_CONFIG_DIR` | `~` | Claude Code's own config directory. `.claude.json` lives **inside** it, so relocating your Claude Code config moves that file too — MulmoTerminal reads it to tell whether the per-project GUI MCP server is registered (`server/infra/gui-mcp-registration.ts`). Leave it unset and `~/.claude.json` is used. |
 | `MULMOCLAUDE_WORKSPACE_PATH` | `~/mulmoclaude` | Where the managed MulmoClaude workspace lives. MulmoTerminal seeds presets/helps **only** into this directory, so launching in an arbitrary project never writes them there (`server/backends/workspaceSetup.ts`). Set it to the same value MulmoClaude uses. |
 | `MULMOTERMINAL_NO_SKILL_INSTALL` | unset | Set to any value to skip installing the bundled skills (`mulmoterminal-config`, `mulmoterminal-bug-report`, `mulmoterminal-decisions`) into `~/.claude/skills/` and the Codex skills root on startup. |
-| `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Model used for image generation (needs `GEMINI_API_KEY`). The default is a **preview** model Google schedules for retirement, so pin a stable one here (e.g. `gemini-2.5-flash-image`) rather than waiting for a code change. |
+| `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Model used for image generation (needs `GEMINI_API_KEY`). The default is a **preview** model Google schedules for retirement around mid-2026, so pin a stable one here (e.g. `gemini-2.5-flash-image`) rather than waiting for a code change. |
 | `WAIT_REAP_GRACE_MS` | `1800000` | How long a **waiting** background session is kept before it's auto-reaped (`0` or negative = never). |
 
 The Docker-sandbox variables (`MULMOTERMINAL_SANDBOX`, `MULMOTERMINAL_SANDBOX_IMAGE`,

--- a/README.md
+++ b/README.md
@@ -528,6 +528,10 @@ the `claude` / `codex` sessions themselves.
 | `ANTIGRAVITY_MODEL` | agy default | Model passed to Antigravity as `--model` (unset = agy's own default). |
 | `ANTIGRAVITY_HOME` | `~/.gemini/antigravity-cli` | Antigravity home directory containing session brain storage. |
 | `MULMOTERMINAL_HOME` | `~/.mulmoterminal` | Root for managed **git worktrees**. |
+| `CLAUDE_CONFIG_DIR` | `~` | Claude Code's own config directory. `.claude.json` lives **inside** it, so relocating your Claude Code config moves that file too — MulmoTerminal reads it to tell whether the per-project GUI MCP server is registered (`server/infra/gui-mcp-registration.ts`). Leave it unset and `~/.claude.json` is used. |
+| `MULMOCLAUDE_WORKSPACE_PATH` | `~/mulmoclaude` | Where the managed MulmoClaude workspace lives. MulmoTerminal seeds presets/helps **only** into this directory, so launching in an arbitrary project never writes them there (`server/backends/workspaceSetup.ts`). Set it to the same value MulmoClaude uses. |
+| `MULMOTERMINAL_NO_SKILL_INSTALL` | unset | Set to any value to skip installing the bundled skills (`mulmoterminal-config`, `mulmoterminal-bug-report`, `mulmoterminal-decisions`) into `~/.claude/skills/` and the Codex skills root on startup. |
+| `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | Model used for image generation (needs `GEMINI_API_KEY`). The default is a **preview** model Google schedules for retirement, so pin a stable one here (e.g. `gemini-2.5-flash-image`) rather than waiting for a code change. |
 | `WAIT_REAP_GRACE_MS` | `1800000` | How long a **waiting** background session is kept before it's auto-reaped (`0` or negative = never). |
 
 The Docker-sandbox variables (`MULMOTERMINAL_SANDBOX`, `MULMOTERMINAL_SANDBOX_IMAGE`,

--- a/docs/guide/en/config.md
+++ b/docs/guide/en/config.md
@@ -1254,6 +1254,10 @@ there to look at.
 | `MULMOTERMINAL_HOST` | `127.0.0.1` | The interface the server binds to (→ [below](#bind-host)) |
 | `MULMOTERMINAL_ALLOWED_ORIGINS` | *(none)* | Extra browser origins allowed to attach a terminal, comma-separated. Only needed alongside a wider `MULMOTERMINAL_HOST` (→ [below](#bind-host)) |
 | `MULMOTERMINAL_HOME` | `~/.mulmoterminal` | The root for managed git worktrees |
+| `CLAUDE_CONFIG_DIR` | `~` | Claude Code's own config directory. `.claude.json` lives **inside** it, so relocating your Claude Code config moves that file too. MulmoTerminal reads it to tell whether the per-project GUI MCP server is registered. Unset means `~/.claude.json` |
+| `MULMOCLAUDE_WORKSPACE_PATH` | `~/mulmoclaude` | Where the managed MulmoClaude workspace lives. Presets and helps are seeded **only** into this directory, so launching in an arbitrary project never writes them there. Set it to the same value MulmoClaude uses |
+| `MULMOTERMINAL_NO_SKILL_INSTALL` | *(none)* | Set to any value to skip installing the bundled skills (`mulmoterminal-config`, `mulmoterminal-bug-report`, `mulmoterminal-decisions`) into `~/.claude/skills/` and the Codex skills root on startup |
+| `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | The model used for image generation (needs `GEMINI_API_KEY`). The default is a **preview** model Google schedules for retirement around mid-2026 — pin a stable one here (e.g. `gemini-2.5-flash-image`) rather than waiting for a code change |
 
 ### Who can reach the server (`MULMOTERMINAL_HOST`) {#bind-host}
 

--- a/docs/guide/ja/config.md
+++ b/docs/guide/ja/config.md
@@ -1219,6 +1219,11 @@ Merged in #983. Work done in `mulmoterminal5`.
 | `PORT` | `34567` | サーバのポート |
 | `MULMOTERMINAL_HOST` | `127.0.0.1` | サーバが待ち受けるインターフェース（→ [下記](#bind-host)） |
 | `MULMOTERMINAL_ALLOWED_ORIGINS` | *(なし)* | ターミナルに接続してよいブラウザのオリジンを追加（カンマ区切り）。`MULMOTERMINAL_HOST` を広げたときにだけ必要（→ [下記](#bind-host)） |
+| `MULMOTERMINAL_HOME` | `~/.mulmoterminal` | 管理下 git worktree のルート |
+| `CLAUDE_CONFIG_DIR` | `~` | Claude Code 自身の設定ディレクトリ。`.claude.json` は**この中**に置かれるので、Claude Code の設定を移すとこのファイルも一緒に移ります。MulmoTerminal は、プロジェクトごとの GUI MCP サーバが登録済みかを判定するのにこれを読みます。未設定なら `~/.claude.json` |
+| `MULMOCLAUDE_WORKSPACE_PATH` | `~/mulmoclaude` | 管理下の MulmoClaude ワークスペースの場所。プリセットや helps の書き込みは**このディレクトリに限定**されるので、任意のプロジェクトで起動しても余計なファイルが増えません。MulmoClaude 側と同じ値を指定してください |
+| `MULMOTERMINAL_NO_SKILL_INSTALL` | *(なし)* | 何か値を入れると、同梱スキル（`mulmoterminal-config` / `mulmoterminal-bug-report` / `mulmoterminal-decisions`）を起動時に `~/.claude/skills/` と Codex のスキルルートへ入れる処理をやめます |
+| `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | 画像生成に使うモデル（`GEMINI_API_KEY` が必要）。既定は Google が 2026 年半ばごろの廃止を予告している**プレビュー**モデルなので、安定版（例 `gemini-2.5-flash-image`）に固定したいときはここで指定します |
 
 ### 誰がサーバに到達できるか（`MULMOTERMINAL_HOST`） {#bind-host}
 
@@ -1286,7 +1291,6 @@ MULMOTERMINAL_HOST=0.0.0.0 MULMOTERMINAL_ALLOWED_ORIGINS=nuc.local npx mulmoterm
 
 **スマホから使うためにこの設定は不要です。** スマホ連携は Firestore 経由で、ローカルネットワークを
 使いません（→ [スマホから使う](phone.html)）。
-| `MULMOTERMINAL_HOME` | `~/.mulmoterminal` | 管理下 git worktree のルート |
 
 ---
 


### PR DESCRIPTION
## Summary

コードが `process.env` から読んでいる変数と、ドキュメントに出てくる変数を機械的に突き合わせて、**実在するのにどこにも書かれていない env var** を洗い出した。ユーザーが設定しうる4件を README とバイリンガルガイド（en/ja）の両方に追記している。

あわせて、ja ガイドで `MULMOTERMINAL_HOME` の表の行が**文書末尾の散文の後に孤立**していた（en では表の中にある）のを直した。

docs のみ。コードは触っていない。

## Items to Confirm / Review

1. **`GEMINI_IMAGE_MODEL` の「2026年半ばごろ廃止」という記述** — 実装のコメント（`server/backends/image-gen.ts`）に `~mid-2026` とあるのをそのまま書いた。Google の予告を自分で確認したわけではないので、時期が変わっていたら直したい。
2. **`CLAUDE_CONFIG_DIR` の既定値を `~` と書いた** — 実装は `process.env.CLAUDE_CONFIG_DIR?.trim() || homedir()` を base に `.claude.json` を結合するので、未設定なら `~/.claude.json`。表の「既定」列に何を書くのが読みやすいか（`~` か `~/.claude.json` か）は好みが分かれるかもしれない。
3. **ガイドの節見出しは変えていない** — 「環境変数 — ポート・バインド先・バイナリ」という見出しに、バイナリでもポートでもない4件が入る形になった。見出しを変えるとアンカーが変わるので触らなかったが、変えるなら別途。
4. **`MULMOTERMINAL_TOOL_GROUP` を意図的に除外した判断** — 下記参照。

## User Prompt

> https://github.com/receptron/mulmoclaude/pull/2648 このPRを確認して、バグが有るものは直したいし、documentも間違いは更新したい。１つ１つ確認してバグは１つ１つissue化して。
>
> これってmulmoterminalでも同様な問題ないか次に調べて。

MulmoClaude 側で「ドキュメントが実装と食い違う」問題を1件ずつ検証して直した（receptron/mulmoclaude#2652）あと、同種の問題が MulmoTerminal にもないかを調べた結果のうち、**docs に閉じるもの**が本 PR。

## 追記した4件

| 変数 | 既定 | 実装 |
|---|---|---|
| `CLAUDE_CONFIG_DIR` | `~` | `server/infra/gui-mcp-registration.ts` — GUI MCP が登録済みかの判定に `.claude.json` を読む |
| `MULMOCLAUDE_WORKSPACE_PATH` | `~/mulmoclaude` | `server/backends/workspaceSetup.ts` — プリセット/helps の seeding をこのディレクトリに限定する |
| `MULMOTERMINAL_NO_SKILL_INSTALL` | *(なし)* | `server/infra/install-bundled-skills.ts` — 同梱スキル3件の自動インストールを止める |
| `GEMINI_IMAGE_MODEL` | `gemini-3.1-flash-image-preview` | `server/backends/image-gen.ts` — 画像生成モデル |

`CLAUDE_CONFIG_DIR` については、`.claude.json` が**そのディレクトリの中に置かれる**ことを `claude` CLI で実測して確認した。

```console
$ TMP=$(mktemp -d); CLAUDE_CONFIG_DIR="$TMP" claude mcp list
$ ls -a "$TMP"
.claude.json  backups/
```

（公式ドキュメントは `.claude.json` が `~/.claude.json` にあるとだけ書いており、`CLAUDE_CONFIG_DIR` との関係には触れていない。）

この実測の副産物として、**MulmoClaude 側が同じ env var を逆に解釈しているバグ**が見つかったので、そちらは receptron/mulmoclaude#2654 として別途出してある。MulmoTerminal の実装のほうが正しい。

## ja ガイドの孤立行

`docs/guide/ja/config.md` の末尾近く、「スマホから使うためにこの設定は不要です。」という段落の**直後**に表の行が1本だけ残っていた。

```markdown
使いません（→ [スマホから使う](phone.html)）。
| `MULMOTERMINAL_HOME` | `~/.mulmoterminal` | 管理下 git worktree のルート |
```

表から切り離されているので、レンダリング後は1行だけの表かパイプ入りの生テキストになる。en 版では環境変数の表の中に正しく入っており、バイリンガルの同期が崩れていた。表の中（`MULMOTERMINAL_ALLOWED_ORIGINS` の次、en と同じ位置）に戻した。

## 追記しなかったもの

**`MULMOTERMINAL_TOOL_GROUP`** — 洗い出しには引っかかったが、ユーザーが設定する変数ではない。アプリが生成する MCP 設定の `env` ブロックに書き込み（`server/agents/antigravity-mcp.ts`）、spawn された bridge が読む（`server/mcp/bridge.mjs`）というサーバ内部の受け渡しで、`MULMOTERMINAL_SESSION_ID` / `MULMOTERMINAL_PORT` と同じ性質のもの。ユーザー向けの表に入れると設定できるものに見えるため除外した。

兄弟2件は `docs/gui-protocol-spike.md` で言及されているが、あれは「throwaway spike」と自称するスナップショット文書で、`MULMOTERMINAL_TOOL_GROUP` はその後（#1095 の per-project GUI MCP）に入ったもの。**後から出来た仕様に合わせて過去のスナップショットを書き換えるのは筋が違う**ので触っていない。

`LANG` / `LC_ALL` / `LC_MESSAGES` もコードが読んでいるが、ロケールの標準変数で MulmoTerminal 固有の設定ではないため対象外。

## 確認したこと

- `.prettierignore` が `*.md` を除外しているので `yarn format` の対象外。`yarn lint` は `src server test e2e e2e-live packages` が対象で `docs/` `README.md` を含まない
- 追記した4行が README / en / ja のそれぞれに **1回ずつ**存在すること
- 追記行の列数（3列）が既存の表と揃っていること
- ja の孤立行が消え、`MULMOTERMINAL_HOME` が表の中の en と同じ位置にあること
- `origin/main` をマージしてから再検証した（マージ後に表が壊れていないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2
