### PR TITLE
fix: セッションメモを cockpit roster に出す (#1105)

### DIFF
--- a/plans/fix-1105-memo-in-cockpit-roster.md
+++ b/plans/fix-1105-memo-in-cockpit-roster.md
@@ -1,0 +1,61 @@
+# fix: セッションメモを cockpit roster に出す (#1105)
+
+#1084 で入れたセッションメモが、グリッドを拡大したときの cockpit roster に出ない。
+
+## 何が起きているか
+
+サーバはもうメモを返している。**クライアントのロスターがマージで捨てている。**
+
+`GET /api/session/:id` → `sessionDetailView()` は `memo` を含む（#1084 で入った）。ロスターは
+`seedMeta()` でそれを取り、`mergeSessionMeta()` に通して `sessionMeta` に入れる。その
+`SessionMetaView` に `memo` のフィールドが無いので、取得した値はここで消える。
+
+出ない場所は cockpit roster **だけ**。セルヘッダ（`cellHeaderText`）と縦の Sidebar
+（`/api/sessions` → `sessionListTitle`）は #1084 の時点で通っている。
+
+## 決めたこと
+
+| 論点               | 決定                                                                        |
+| ------------------ | --------------------------------------------------------------------------- |
+| 行の位置           | `summary` の**上**。下の3行はすべてエージェントが言ったこと、メモはユーザーが言ったこと |
+| 既存行との関係     | 置き換えではなく**追加**。セルヘッダは1行しかないので置き換えたが、ロスター行は複数行ある |
+| マージ規約         | `aiTitle` と同じ（absent = 据え置き、`null` = 消えた）。`lastPrompt` の `??` ではない |
+| 行数クランプ       | **付けない**。`cockpitLines` にノブを増やさない（理由は下）                  |
+| ラベル             | `memo`。既存の `summary` / `prompt` / `reply` と同じ体裁                     |
+
+### なぜ `??` ではなく `!== undefined` か
+
+`lastPrompt` / `lastResponse` は**トランスクリプト由来**で、読みが一時的に外すことがある。だから
+`??` にして「null は据え置き」にしてある。メモは違う — サーバのメモマップにしか無く、取得が
+成功した時点でそれが答えで、`null` は「いま無い」（= ユーザーが消した）という**値**。`??` にすると
+消したメモが次のポーリング（4秒）で画面に戻ってくる。`aiTitle` が既に同じ理由で
+`!== undefined` になっている（#1085）。
+
+### なぜクランプを付けないか
+
+`cockpitLines` の3つのノブは、**長さに上限が無いエージェントのテキスト**のためにある。メモは
+`normalizeMemo()` が改行を空白に潰して 200 コードポイントで切るので、構造的に有界。ユーザー自身が
+書いた1行を途中で切る理由が無く、ノブを4つ目に増やすのは #1105 が頼まれた仕事ではない。
+
+## 触るところ
+
+- `src/components/rosterPhase.ts` — `SessionMetaView.memo`、`EMPTY_SESSION_META`、
+  `mergeSessionMeta()` に `aiTitle` と同じ規約で追加
+- `src/components/GridView.vue` — ローカルの `SessionMeta` 型と `listRows` に `memo`
+- `src/components/TerminalGrid.vue` — `CockpitRow.memo` と、`summary` 行の上のマークアップ
+
+## テスト
+
+- `mergeSessionMeta` — memo の absent = 据え置き / `null` = クリア / 新しい値で更新
+- `EMPTY_SESSION_META` — `memo: null` を持つ
+- `TerminalGrid` — memo がある行は memo 行を出す / 無い行は出さない / memo 行が summary より前に来る
+
+## やらないこと
+
+- **`getTerminalScreen`（スマホの1セッション画面）へのメモ配線。** 調査で判明した非対称
+  （一覧の `title` には出るが、開いた画面のヘッダは AI サマリに戻る）は本 issue の対象外。
+  mulmoserver 側の対応が要るので別 issue。
+- **ロスターの即時更新。** ロスター行はポーリング（4秒）でしか更新されない。これは
+  `summary` / `prompt` / `reply` と同じで、`sessionMeta` の唯一の書き手を
+  `GET /api/session/:id` に保つという既存の不変条件（GridView.vue のコメント）に従う。
+  メモを編集した直後はセルヘッダが先に変わり、ロスター行が最大4秒遅れる。

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch, onMounted, onBeforeUnmount, onActivated, onDeactivated, nextTick } from "vue";
-import TerminalGrid from "./TerminalGrid.vue";
+import TerminalGrid, { type CockpitRow } from "./TerminalGrid.vue";
 import AppSettingsModal from "./AppSettingsModal.vue";
 import AppToolbar from "./AppToolbar.vue";
 import GuideLinks from "./GuideLinks.vue";
@@ -49,7 +49,7 @@ import { preferredLaunchDir } from "./launchDir";
 import * as conn from "../composables/useTerminalConnections";
 import { rosterCellsKey, staleCacheKeys } from "./rosterCache";
 import type { RunCommand } from "./runCommand";
-import { becameCiFailing, EMPTY_SESSION_META, isPrPhase, mergeSessionMeta, type PrPhase, type WorkPhase } from "./rosterPhase";
+import { becameCiFailing, EMPTY_SESSION_META, isPrPhase, mergeSessionMeta, type PrPhase, type SessionMetaView } from "./rosterPhase";
 import { notifySound } from "../composables/notifySound";
 import { useGridActivity } from "../composables/useGridActivity";
 import { registerNewTerminalHandler, type NewTerminalRequest } from "../composables/useNewTerminal";
@@ -130,11 +130,10 @@ const orderedCells = computed(() => orderCells(state.value.cells, statusForSort.
 const displayCells = computed(() => (zoomedUid(state.value) !== null ? orderedCells.value : pageSlice(orderedCells.value, state.value.page)));
 const expandedUid = computed(() => zoomedUid(state.value));
 
-// The zoomed grid's cockpit roster: a text row per cell — status + dir + AI summary +
-// current prompt + the agent's latest reply — so many parallel agents can be supervised
-// past the 9-thumbnail grid, and the enlarged terminal is switched by picking a row.
-type SessionMeta = { lastPrompt: string | null; aiTitle: string | null; lastResponse: string | null; workPhase: WorkPhase | null };
-const sessionMeta = reactive(new Map<string, SessionMeta>());
+// The zoomed grid's cockpit roster: a text row per cell — status + dir + the user's memo +
+// AI summary + current prompt + the agent's latest reply — so many parallel agents can be
+// supervised past the 9-thumbnail grid, and the enlarged terminal is switched by picking a row.
+const sessionMeta = reactive(new Map<string, SessionMetaView>());
 // Single source of truth for the roster's prompt / summary / reply: each cell's on-disk
 // transcript, read via GET /api/session/:id (always current, and works for sessions this
 // MulmoTerminal doesn't manage — a plain `claude` you resumed emits nothing over pub/sub).
@@ -152,7 +151,7 @@ async function seedMeta(id: string, cwd: string | null) {
     const query = cwd ? `?cwd=${encodeURIComponent(cwd)}` : "";
     const res = await fetch(`/api/session/${id}${query}`);
     if (!res.ok || latestMetaSeed.get(id) !== seed) return;
-    const d = (await res.json()) as Partial<SessionMeta>;
+    const d = (await res.json()) as Partial<SessionMetaView>;
     if (latestMetaSeed.get(id) !== seed) return;
     sessionMeta.set(id, mergeSessionMeta(sessionMeta.get(id) ?? EMPTY_SESSION_META, d));
   } catch {
@@ -293,25 +292,31 @@ onBeforeUnmount(stopPoll);
 
 // A cell with no session/prompt yet still gets a human label from what it IS running.
 const fallbackLabel = (c: Cell): string | null => c.command?.label ?? c.launcher?.label ?? (c.session ? "starting…" : "empty");
-const listRows = computed(() =>
-  orderedCells.value.map((c) => {
-    const meta = c.session ? sessionMeta.get(c.session) : undefined;
-    return {
-      uid: c.uid,
-      cwd: c.cwd,
-      agent: c.agent ?? "claude",
-      status: statusForSort.value[c.uid] ?? ("idle" as CellStatus),
-      summary: meta?.aiTitle ?? null,
-      prompt: meta?.lastPrompt ?? null,
-      response: meta?.lastResponse ?? null,
-      fallback: fallbackLabel(c),
-      phase: (c.cwd ? phaseByCwd.get(c.cwd) : undefined) ?? ("none" as PrPhase),
-      workPhase: meta?.workPhase ?? null,
-      headerColor: (c.cwd ? chromeByCwd.get(c.cwd)?.headerColor : null) ?? null,
-      headerTextColor: (c.cwd ? chromeByCwd.get(c.cwd)?.headerTextColor : null) ?? null,
-    };
-  }),
-);
+// "Nothing known yet" is resolved ONCE per lookup rather than per field. Five of the row's fields
+// come out of the meta and two out of the chrome, so a `??` on each both crossed the complexity
+// limit and made every field independently defaultable — which is how a field the roster never
+// wired up reads as a legitimate null rather than failing to typecheck.
+const chromeOf = (cwd: string | null): RowChrome => (cwd ? chromeByCwd.get(cwd) : undefined) ?? { headerColor: null, headerTextColor: null };
+const rosterRow = (c: Cell): CockpitRow => {
+  const meta = (c.session ? sessionMeta.get(c.session) : undefined) ?? EMPTY_SESSION_META;
+  const chrome = chromeOf(c.cwd);
+  return {
+    uid: c.uid,
+    cwd: c.cwd,
+    agent: c.agent ?? "claude",
+    status: statusForSort.value[c.uid] ?? ("idle" as CellStatus),
+    memo: meta.memo,
+    summary: meta.aiTitle,
+    prompt: meta.lastPrompt,
+    response: meta.lastResponse,
+    fallback: fallbackLabel(c),
+    phase: (c.cwd ? phaseByCwd.get(c.cwd) : undefined) ?? ("none" as PrPhase),
+    workPhase: meta.workPhase,
+    headerColor: chrome.headerColor,
+    headerTextColor: chrome.headerTextColor,
+  };
+};
+const listRows = computed(() => orderedCells.value.map(rosterRow));
 // The cancelable trailing launch cell's uid (null when there's nothing to cancel):
 // drives both the toolbar's cancel state and the launcher's in-cell close button.
 const cancelUid = computed(() => cancelableLaunchUid(state.value));

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -53,6 +53,7 @@ export interface CockpitRow {
   cwd: string | null;
   agent: string;
   status: CellStatus;
+  memo: string | null; // the user's own one-line note (#1084)
   summary: string | null; // AI title
   prompt: string | null; // current user prompt
   response: string | null; // tail of the agent's latest reply
@@ -672,7 +673,7 @@ watch(
 
 <template>
   <div ref="stage" class="stage" :class="{ zoomed, listmode: listMode, flipping: flippingUids.size > 0 }" :style="flipVars" @focusin="onFocusIn">
-    <!-- Cockpit roster: a tall text row per cell (status / dir / summary / prompt / latest
+    <!-- Cockpit roster: a tall text row per cell (status / dir / memo / summary / prompt / latest
          reply). Click a row to swap which terminal is enlarged. -->
     <aside
       v-if="zoomed && listMode"
@@ -715,6 +716,15 @@ watch(
             @move="(dir) => emit('move', row.uid, dir)"
           />
         </CockpitHeader>
+        <!-- The user's own note, above every line below it: those are what the AGENT said, and the
+             memo is the user saying what the cell is FOR (#1084) — the same precedence the cell
+             header, the sidebar row and the phone's roster already share via sessionDisplayName.
+             Unclamped, alone among these lines, because it needs no guard: normalizeMemo caps a
+             memo at one line of 200 code points, where the three below are agent text of no
+             bounded length, which is what `cockpitLines` exists for. -->
+        <span v-if="row.memo" data-testid="cockpit-memo" class="text-[12px] leading-[1.35]"
+          ><b class="mr-1 text-[10px] font-bold text-[#7a8aa0]">memo</b> {{ row.memo }}</span
+        >
         <!-- The clamp is a runtime value, so the utility reads a CSS variable each line sets for
              itself — `line-clamp-N` only exists for the literals Tailwind found in the source.
              `title` carries the rest, so a low clamp hides nothing you can't get at. -->

--- a/src/components/rosterPhase.ts
+++ b/src/components/rosterPhase.ts
@@ -47,6 +47,10 @@ export const WORK_WORD: Record<WorkPhase, string> = { planning: "planning", impl
 // like the text is how a `/clear`ed session kept showing the title of the conversation the user
 // had just ended (#1085) — the server had already dropped it. Same rule as applyActivityPush.
 //
+// `memo` follows aiTitle, not the text, and for the same reason: it lives only in the server's
+// memo map, so a successful fetch answers it outright and `null` is the user having ERASED it.
+// Merged like the prompt, a memo the user just cleared comes back on the next poll.
+//
 // `workPhase` is taken AS-IS, including null, because a successful fetch is authoritative for
 // it: null means "no tools yet / not working", which is a real state. Merge it like the text
 // and a finished agent keeps a "planning" badge forever.
@@ -54,10 +58,11 @@ export interface SessionMetaView {
   lastPrompt: string | null;
   aiTitle: string | null;
   lastResponse: string | null;
+  memo: string | null;
   workPhase: WorkPhase | null;
 }
 
-export const EMPTY_SESSION_META: SessionMetaView = { lastPrompt: null, aiTitle: null, lastResponse: null, workPhase: null };
+export const EMPTY_SESSION_META: SessionMetaView = { lastPrompt: null, aiTitle: null, lastResponse: null, memo: null, workPhase: null };
 
 // `workPhase` is typed unknown because it arrives as untrusted JSON — isWorkPhase is the
 // only thing that may decide it is a phase.
@@ -66,6 +71,7 @@ export function mergeSessionMeta(previous: SessionMetaView, fetched: Omit<Partia
     lastPrompt: fetched.lastPrompt ?? previous.lastPrompt,
     aiTitle: fetched.aiTitle !== undefined ? fetched.aiTitle : previous.aiTitle,
     lastResponse: fetched.lastResponse ?? previous.lastResponse,
+    memo: fetched.memo !== undefined ? fetched.memo : previous.memo,
     workPhase: isWorkPhase(fetched.workPhase) ? fetched.workPhase : null,
   };
 }

--- a/test/src/components/TerminalGrid.spec.ts
+++ b/test/src/components/TerminalGrid.spec.ts
@@ -77,6 +77,7 @@ const rosterRow = (uid: number, over: Partial<CockpitRow> = {}): CockpitRow => (
   cwd: "/work",
   agent: "claude",
   status: "idle",
+  memo: null,
   summary: null,
   prompt: null,
   response: null,
@@ -286,6 +287,41 @@ describe("grid cockpit (list view)", () => {
     const lines = w.findAll('[data-testid="cockpit-line"]').map((l) => l.text());
     expect(lines.some((t) => t.includes("summary"))).toBe(false); // no summary line
     expect(lines.some((t) => t.includes("prompt") && t.includes("bash"))).toBe(true); // fallback in the prompt line
+  });
+
+  // The memo is the one line in a row the USER wrote; everything below it is what the agent said.
+  // Asserting the ORDER, not just presence: reading it first is the whole point of the feature
+  // (#1105), and a row that buries it under the agent's summary answers the wrong question.
+  it("puts the user's memo above the summary, and omits the line when there is none", async () => {
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { memo: "ship before the demo", summary: "Login fix", prompt: "fix login" })]);
+    await nextTick();
+    expect(w.get('[data-testid="cockpit-memo"]').text()).toContain("ship before the demo");
+    const texts = w
+      .get('[data-testid="cockpit-row"]')
+      .findAll("span")
+      .map((s) => s.text());
+    const indexOf = (needle: string) => texts.findIndex((t) => t.includes(needle));
+    expect(indexOf("ship before the demo")).toBeLessThan(indexOf("Login fix"));
+
+    const bare = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { summary: "Login fix" })]);
+    await nextTick();
+    expect(bare.find('[data-testid="cockpit-memo"]').exists()).toBe(false);
+  });
+
+  // The memo must stay OUT of the clamped set: normalizeMemo already caps it at one line of 200
+  // code points, and `cockpitLines` is the knob for agent text of no bounded length. A memo that
+  // joined the clamped lines would also shift what the three configured counts land on.
+  it("leaves the memo unclamped, so the configured counts still land on summary / prompt / reply", async () => {
+    setCockpitLines({ summary: 6, prompt: 1, response: 9 });
+    const w = mountCockpit([cell(0, "s0")], 0, [rosterRow(0, { memo: "mine", summary: "s", prompt: "p", response: "r" })]);
+    await nextTick();
+    expect(w.findAll('[data-testid="cockpit-line"]').map((l) => l.attributes("style"))).toEqual([
+      "--cockpit-lines: 6;",
+      "--cockpit-lines: 1;",
+      "--cockpit-lines: 9;",
+    ]);
+    expect(w.get('[data-testid="cockpit-memo"]').classes()).not.toContain("line-clamp-[var(--cockpit-lines)]");
+    setCockpitLines(undefined); // leave the singleton as the next test expects to find it
   });
 
   // The clamp is a runtime value, so it reaches the DOM as a CSS variable the Tailwind utility

--- a/test/src/components/rosterPhase.spec.ts
+++ b/test/src/components/rosterPhase.spec.ts
@@ -32,11 +32,17 @@ describe("phaseDisplay", () => {
 });
 
 describe("mergeSessionMeta", () => {
-  const shown = { lastPrompt: "fix the login bug", aiTitle: "Login fix", lastResponse: "done", workPhase: "implementing" as const };
+  const shown = {
+    lastPrompt: "fix the login bug",
+    aiTitle: "Login fix",
+    lastResponse: "done",
+    memo: "ship before the demo",
+    workPhase: "implementing" as const,
+  };
 
   it("takes what the fetch returned", () => {
-    const merged = mergeSessionMeta(shown, { lastPrompt: "new task", aiTitle: "New", lastResponse: "ok", workPhase: "planning" });
-    expect(merged).toEqual({ lastPrompt: "new task", aiTitle: "New", lastResponse: "ok", workPhase: "planning" });
+    const merged = mergeSessionMeta(shown, { lastPrompt: "new task", aiTitle: "New", lastResponse: "ok", memo: "review only", workPhase: "planning" });
+    expect(merged).toEqual({ lastPrompt: "new task", aiTitle: "New", lastResponse: "ok", memo: "review only", workPhase: "planning" });
   });
 
   // The text fields MERGE: the summary can transiently miss a transcript, and blanking every
@@ -52,6 +58,15 @@ describe("mergeSessionMeta", () => {
   // session kept showing the title of the conversation the user had just ended (#1085).
   it("drops the summary when the fetch says there is none", () => {
     expect(mergeSessionMeta(shown, { aiTitle: null }).aiTitle).toBeNull();
+  });
+
+  // The memo follows aiTitle, not the prompt, for the same reason (#1105): it lives only in the
+  // server's memo map, so a null is the user having ERASED it. Merged like the prompt, an erased
+  // memo would come back on the very next poll — 4 seconds after the user cleared the box.
+  it("keeps the memo when the fetch omits it, and erases it on a null", () => {
+    expect(mergeSessionMeta(shown, {}).memo).toBe("ship before the demo");
+    expect(mergeSessionMeta(shown, { memo: null }).memo).toBeNull();
+    expect(mergeSessionMeta(shown, { memo: "rewritten" }).memo).toBe("rewritten");
   });
 
   // The other two DO fall back to the transcript, which can transiently miss — so for them a
@@ -84,7 +99,13 @@ describe("mergeSessionMeta", () => {
   });
 
   it("starts from nothing for a session it has not seen", () => {
-    expect(mergeSessionMeta(EMPTY_SESSION_META, { lastPrompt: "first" })).toEqual({ lastPrompt: "first", aiTitle: null, lastResponse: null, workPhase: null });
+    expect(mergeSessionMeta(EMPTY_SESSION_META, { lastPrompt: "first" })).toEqual({
+      lastPrompt: "first",
+      aiTitle: null,
+      lastResponse: null,
+      memo: null,
+      workPhase: null,
+    });
   });
 
   it("does not mutate what it was given", () => {


### PR DESCRIPTION
## Summary

#1084 で追加したセッションメモが、**グリッドを拡大したときの cockpit roster** にだけ表示されていなかった。原因はサーバではなくクライアント側で、`GET /api/session/:id` が返している `memo` を `mergeSessionMeta()` が捨てていた。ロスター行の `summary` の上に `memo` 行を出す。

セルヘッダと縦の Sidebar（Sessions 一覧）は #1084 の時点で既に動いていた。出ていなかったのは cockpit roster だけ。

実機（`PORT=34599`、隔離した `HOME`）で確認した内容:

- `POST /api/session/:id/memo` → 200、`~/.mulmoterminal/session-memos.jsonl` に追記される
- ブラウザでグリッドを開いてセッションを起こし、そのセッションにメモを POST → **ロスター自身の4秒ポーリング**が拾ってきて `memo` 行が出る
- 行の DOM 順が `memo` → `prompt` になっている（コンソールエラーなし）

## Items to Confirm / Review

1. **行数クランプを付けていない** — ロスターの他の3行（`summary` / `prompt` / `reply`）は `cockpitLines` でクランプされるが、`memo` 行は付けなかった。理由は、あの3つのノブは**長さに上限が無いエージェントのテキスト**のためにあり、メモは `normalizeMemo()` が改行を潰して 200 コードポイントで切るので構造的に有界だから。`cockpitLines` に4つ目のノブを増やす（= 設定スキーマ変更 + 日英ガイド + SKILL.md の更新）のは #1105 の範囲外と判断した。**200文字のメモを狭いロスターに入れると4行くらい占める**ので、そこが気になるなら要相談。

2. **マージ規約を `aiTitle` 側に合わせた** — `memo: fetched.memo !== undefined ? fetched.memo : previous.memo`。`lastPrompt` の `??` にすると、ユーザーが消したメモが次のポーリング（4秒後）で画面に戻ってくる。メモはサーバのメモマップにしか無く、取得が成功した時点で `null` は「消えた」という値なので、トランスクリプトにフォールバックする2フィールドとは規約が違う。

3. **ロスターは即時更新ではない（意図的）** — メモを編集するとセルヘッダは pub/sub で即座に変わるが、ロスター行は最大4秒遅れる。`sessionMeta` の唯一の書き手を `GET /api/session/:id` に保つという既存の不変条件（GridView.vue のコメント）に従った。`summary` / `prompt` / `reply` も同じ挙動。即時にしたいなら別 PR。

4. **GridView のローカル `SessionMeta` 型を削って共有の `SessionMetaView` に寄せた** — 構造が同一の2つ目のコピーで、片方だけに `memo` を足し忘れることがこの不具合そのものだった。ついでに `listRows` を `rosterRow()` に切り出している（`??` を1フィールドずつ書くと complexity 22 で lint に落ちたため）。ここは本質的な修正ではないので、分けたほうが良ければ言ってください。

## スマホ（mulmoserver）への到達状況 — この PR の範囲外

調査したところ、メモは**半分だけ**スマホに届いている。この PR では触っていない。

| 経路 | メモ | 実装 |
|---|---|---|
| `listTerminalSessions`（スマホのセッション一覧） | **届く** | `server/index.ts` が `title: sessionDisplayName(sessionMemos.get(id), …)` を載せている |
| `getTerminalScreen`（スマホの1セッション画面のヘッダ） | **届かない** | `summary: aiTitles.get(sessionId) ?? ""` — AI タイトルのみ |
| Firestore の activity doc | 届かない（設計通り。status 専用） |

つまり「一覧ではメモの名前で出るのに、その行をタップした画面のヘッダは AI サマリに戻る」という非対称が残っている。直すには `SessionScreenMeta` に `memo?` を足して mulmoserver 側が読むようにする必要があり、別 issue に切り出すべき。

## 原因（詳細）

サーバは #1084 の時点でメモを返していた:

- `server/session/session-detail-view.ts` の `SessionDetailView.memo`
- `server/routes/session-routes.ts` が `memo: sessionMemos.get(id)` を渡す

ロスターはそれを `seedMeta()` で取り、`mergeSessionMeta()` に通して `sessionMeta` に入れる。その `SessionMetaView` に `memo` のフィールドが無かったので、取得した値はマージで消えていた。さらに `GridView.vue` の `listRows` と `TerminalGrid.vue` の `CockpitRow` にも `memo` が無かった。

## 変更点

- `src/components/rosterPhase.ts` — `SessionMetaView.memo` / `EMPTY_SESSION_META` / `mergeSessionMeta()`
- `src/components/GridView.vue` — ローカル型を共有の `SessionMetaView` に置き換え、`listRows` を `rosterRow()` に切り出して `memo` を通す
- `src/components/TerminalGrid.vue` — `CockpitRow.memo` と、`summary` 行の上のマークアップ（`data-testid="cockpit-memo"`）
- `plans/fix-1105-memo-in-cockpit-roster.md` — 設計メモ

`data-testid` を既存の `cockpit-line` と分けたのは、クランプ3行を正確に数えている既存テストをそのまま保つため。

## テスト

- `mergeSessionMeta` — memo の absent = 据え置き / `null` = 消去 / 新しい値で更新
- `EMPTY_SESSION_META` — `memo: null` を持つ
- `TerminalGrid` — memo 行が summary より DOM 上で前に来る / memo が無い行には出ない / memo はクランプ対象外で、設定した3つの数値が今も summary・prompt・reply に当たる

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `test`（6376 passed）/ `build` すべて通っている。

## User Prompt

> memo機能追加したけど、grid viewのsidemenuにでない。summary promptとかの上に、memoがあればmemoをだそう！！あとmemoってmulmoserverにもとどいているかな？

スコープの確認に対して「ロスターだけ直す（スマホの `getTerminalScreen` は別 issue）」を選択。

Closes #1105

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
