### PR TITLE
fix: Windows で pty-spawn の spec が落ちるのを直す — cwd に実在するディレクトリを渡す

### DIFF
--- a/test/server/session/pty-spawn-env.spec.ts
+++ b/test/server/session/pty-spawn-env.spec.ts
@@ -16,6 +16,12 @@ vi.mock("../../../server/infra/tmux.js", () => ({
 let tmuxOn = false;
 const liveTmuxSessions = new Set<string>();
 
+// ptySpawn stats the cwd and refuses a spawn into a directory that is not there, so this cannot
+// be a literal: "/tmp" is not a directory on Windows, which failed only in the Windows job. Our
+// own cwd is a directory on every platform, by definition — the same reasoning diagnoseSpawnCwd
+// applies to an empty cwd.
+const EXISTING_CWD = process.cwd();
+
 const { spawnPty, ptySpawn, ptyWouldReattach } = await import("../../../server/session/pty-spawn.js");
 
 const envOf = (call: number = 0): NodeJS.ProcessEnv => (spawn.mock.calls[call] as unknown as [string, string[], { env: NodeJS.ProcessEnv }])[2].env;
@@ -35,17 +41,17 @@ beforeEach(() => {
 // exactly what shipped first) leaves the routing broken with no symptom until a request.
 describe("spawnPty — the environment it hands the pty", () => {
   it("removes the named variables", () => {
-    spawnPty("claude", [], "/tmp", ["ANTHROPIC_API_KEY"]);
+    spawnPty("claude", [], EXISTING_CWD, ["ANTHROPIC_API_KEY"]);
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
   });
 
   it("keeps everything else", () => {
-    spawnPty("claude", [], "/tmp", ["ANTHROPIC_API_KEY"]);
+    spawnPty("claude", [], EXISTING_CWD, ["ANTHROPIC_API_KEY"]);
     expect(envOf().MT_KEEP_ME).toBe("kept");
   });
 
   it("leaves the environment alone when nothing is named", () => {
-    spawnPty("claude", [], "/tmp");
+    spawnPty("claude", [], EXISTING_CWD);
     expect(envOf().ANTHROPIC_API_KEY).toBe("sk-ant-leftover");
   });
 });
@@ -80,13 +86,13 @@ describe("ptyWouldReattach", () => {
 // there is what actually protects it — but the non-tmux path has only this.
 describe("ptySpawn — carries the removal down both paths", () => {
   it("applies it on the direct spawn", () => {
-    ptySpawn("s1", "claude", [], "/tmp", false, { unset: ["ANTHROPIC_API_KEY"] });
+    ptySpawn("s1", "claude", [], EXISTING_CWD, false, { unset: ["ANTHROPIC_API_KEY"] });
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
   });
 
   it("applies it on the tmux spawn too", () => {
     tmuxOn = true;
-    const result = ptySpawn("s1", "claude", [], "/tmp", true, { unset: ["ANTHROPIC_API_KEY"] });
+    const result = ptySpawn("s1", "claude", [], EXISTING_CWD, true, { unset: ["ANTHROPIC_API_KEY"] });
     expect(result.tmux).toBe(true);
     expect(envOf()).not.toHaveProperty("ANTHROPIC_API_KEY");
   });
@@ -98,13 +104,13 @@ describe("ptySpawn — carries the removal down both paths", () => {
 describe("ptySpawn — the tmux server's own environment", () => {
   it("scrubs the names from the running server before a provider spawn", () => {
     tmuxOn = true;
-    ptySpawn("s1", "claude", [], "/tmp", true, { unset: ["ANTHROPIC_API_KEY"] });
+    ptySpawn("s1", "claude", [], EXISTING_CWD, true, { unset: ["ANTHROPIC_API_KEY"] });
     expect(scrub).toHaveBeenCalledWith(["ANTHROPIC_API_KEY"]);
   });
 
   it("leaves the server alone for an ordinary session", () => {
     tmuxOn = true;
-    ptySpawn("s1", "claude", [], "/tmp", true);
+    ptySpawn("s1", "claude", [], EXISTING_CWD, true);
     expect(scrub).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Windows (daily) が落ちていたのを直す。原因はテスト側のプラットフォーム依存で、製品コードの不具合ではない。

`test/server/session/pty-spawn-env.spec.ts` が cwd にリテラルの `"/tmp"` を渡していた。`ptySpawn` は #1078 (`85ce28d0`) で spawn 前に cwd を `stat` して存在しないディレクトリへの起動を拒否するようになったため、`/tmp` がディレクトリではない Windows でだけ `SpawnCwdError` になっていた。`/tmp` が実在する macOS / Linux の CI は緑のままだったので、Windows の日次ジョブだけが検出していた。

`/tmp` を `process.cwd()`（どのプラットフォームでも必ずディレクトリ）に置き換えた。テスト 1 ファイル、実質 1 定数の変更で、製品コードには触っていない。

## Items to Confirm / Review

- **`process.cwd()` を選んだ判断**: `os.tmpdir()` でもよいが、隣の `test/server/session/tool-group-reattach.spec.ts` が既に「実在するディレクトリ」に `process.cwd()` を使っており、`diagnoseSpawnCwd` 自身も空の cwd について「node-pty falls back to our own cwd, which exists by definition」と同じ理屈を置いている。そこに合わせた。
- **カバレッジの穴（この PR では埋めていない）**: `ptySpawn` が存在しないディレクトリに対して `SpawnCwdError` を投げること自体を pin する spec は無い。今回それを足すのは CI 復旧のスコープ外と判断したが、別 issue にする価値はあると思う。判断を確認したい。
- **他の spec の `"/tmp"` は今回そのまま**: `test/server/infra/spawn-cwd.spec.ts` は偽の probe を注入していてファイルシステムに触らない、`workspace.spec.ts` / `dirRequest.spec.ts` / `rate-limit-probe.spec.ts` の `"/tmp"` は stat されない単なるデータ。いずれも Windows で緑なので触っていない。

## User Prompt

> 直せるかな？
> https://github.com/receptron/mulmoterminal/actions/runs/30486213385

## 原因の切り分け

失敗していた run 30486213385（node 22.x / 24.x の両方）の中身:

- 落ちたのは 1 ファイル 4 テストだけ。`Test Files 1 failed | 429 passed (430)`
- すべて同じ理由: `SpawnCwdError: The directory /tmp no longer exists, so nothing can be started in it` / `Serialized Error: { diagnosis: { kind: 'missing' } }`
- lint・typecheck・typecheck:server・build は Windows でも通っていた

`git log -S "refuseUnusableCwd"` で `refuseUnusableCwd` の導入は #1078 (`85ce28d0`) と特定。この spec の `ptySpawn` テスト自体はそれより前（#1000 / #1031 の頃）からあり、cwd は環境変数の検査に付随するだけの値だった。つまり #1078 が既存のリテラルを load-bearing に変えたかたちで、リグレッションの入口はそこ。

## 検証

macOS では修正前も後も通るため、ローカルの緑は今回の根拠にならない。そこで:

1. **製品コードの判定関数そのものに聞いた**（自分の別の出力ではなく権威側）。`diagnoseSpawnCwd` を直接呼ぶと macOS では `/tmp -> {"kind":"ok"}`、存在しないディレクトリは `{"kind":"missing"}` で、CI ログの `{ diagnosis: { kind: 'missing' } }` と一致する。`process.cwd() -> {"kind":"ok"}`。プラットフォーム依存が消えたことがこれで確認できる。
2. **Windows 実機**: `windows-daily.yaml` をこのブランチ ref で `workflow_dispatch` して緑を確認（run 30492689315）。
3. ローカルゲート: `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` / `yarn test`（431 files, 6396 tests passed）。

work in mulmoterminal
