### PR TITLE
fix: セッションメモをスマホの1セッション画面に届ける (#1110)

### DIFF
--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -82,11 +82,19 @@ was never a cell are excluded, even while live.
   quickCommands: { label, text }[];   // the user's saved phrases for THIS session (#830)
   cwd?: string;              // ─┐
   branch?: string;           //  │ absent when the host cannot answer —
-  summary?: string;          //  │ see "absent vs empty" below (#786)
+  memo?: string;             //  │ see "absent vs empty" below (#786)
+  summary?: string;          //  │
   prompt?: string;           //  │
   githubUrl?: string;        // ─┘ the repository ROOT, never /tree/<branch> (#832)
 }
 ```
+
+**`memo` and `summary` are two different sentences, not two spellings of one** (#1110). `memo` is
+the one line the user typed about the session (#1084); `summary` is what the AI called it. The
+picker's `title` carries the memo *instead of* the AI title because a row there is a single line
+and the user's words win — but a header has room for both, so here they arrive as their own fields
+and the memo is drawn above. Putting a handwritten note into a row labelled as the AI's summary
+would mislabel it.
 
 ## The rules that keep coming up
 

--- a/plans/fix-1110-memo-in-phone-session-screen.md
+++ b/plans/fix-1110-memo-in-phone-session-screen.md
@@ -1,0 +1,52 @@
+# fix: セッションメモをスマホの1セッション画面に届ける (#1110)
+
+#1084 のセッションメモは、スマホ（mulmoserver PWA）に**半分だけ**届いている。一覧では行の名前
+として出るのに、その行をタップして開いた画面のヘッダは AI サマリに戻る。同じセッションが、見る
+場所によって2つの違う名前で出ている。
+
+## 何が起きているか
+
+| 経路                            | メモ                 | 実装                                                                    |
+| ------------------------------- | -------------------- | ----------------------------------------------------------------------- |
+| `listTerminalSessions`（一覧）  | **届く**             | `title: sessionDisplayName(sessionMemos.get(id), ...)`（#1084 の設計）  |
+| `getTerminalScreen`（1画面）    | **届かない**         | screen meta は `summary: aiTitles.get(sessionId) ?? ""` だけ            |
+| Firestore の activity doc       | 届かない（設計通り） | `sessionActivity.ts` は status 専用。ここは変えない                      |
+
+一覧がスキーマ変更なしで通ったのは、メモを既存の `title` に相乗りさせたから。`getTerminalScreen`
+には相乗りできる相手がいない。
+
+## 決めたこと（issue の案A）
+
+| 論点                     | 決定                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| フィールド               | `SessionScreenMeta` に `memo?: string` を**追加**                                 |
+| `summary` を上書きするか | **しない**。「AI サマリ」というラベルの行に手書きメモを入れると表示が嘘になる      |
+| 空メモ                   | `definedScreenMeta()` がキーごと落とす。メモの無いセッションの応答は今と同じ       |
+| 先に入れて壊れないか     | 壊れない。[docs/remote-host-protocol.md](../docs/remote-host-protocol.md) の「スマホは教わっていないフィールドを無視する」 |
+| ハイドレーション         | 一覧と同じく `await sessionMemosHydrated` — 起動直後のポーリングにメモが無いと出ない |
+| ラベルと位置             | `memo` / `summary` の上。グリッドの cockpit roster（#1108）と揃える（描くのは mulmoserver 側） |
+
+### なぜ `summary` に混ぜないか（案B の却下理由）
+
+`summary` は mulmoserver の `SessionMetaHeader.vue` で「AI サマリ」の行として描かれる。そこに
+ユーザーの手書きメモを入れれば mulmoserver を触らずに今日出せるが、ラベルと中身が食い違う。
+`memo` と `summary` は別のものが言った別の文で、`sessionDisplayName()` の不変条件（ユーザーが
+書いた行 > エージェントが言ったこと）は**どちらを上に描くか**の話であって、片方を消す話ではない。
+
+## 触るところ
+
+- `server/backends/remoteHost/terminalScreen.ts` — `SessionScreenMeta.memo?`
+- `server/index.ts` — `remoteHostSessionScreenMeta()` に `memo` と `await sessionMemosHydrated`
+- `docs/remote-host-protocol.md` — `SessionScreen` の形と、memo が `summary` と併存する理由
+
+## テスト
+
+- memo が screen に載る／`summary` を置き換えず**併存**する
+- memo の無いセッションは `memo` キーごと落ちる（`definedScreenMeta`）
+- 既存の「メタが無いホストは screen だけ返す」が memo 込みでも成り立つ
+
+## やらないこと
+
+- **mulmoserver 側の描画。** 実際にスマホに出るのはあちらが `memo` を読むようになってから。
+  companion issue が必要（receptron/mulmoserver）
+- **activity doc への配線。** status 専用のドキュメントで、メモは status ではない

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -193,6 +193,38 @@ export function definedScreenMeta(meta: ScreenMetaDraft): SessionScreenMeta {
   return Object.fromEntries(Object.entries(meta).filter(([, value]) => value !== undefined && value.trim() !== ""));
 }
 
+// Where each field of the header comes from. Injected, like the rest of this file, so the join
+// AND the order of the reads are testable without a PTY, a git checkout, or the server's
+// module graph.
+export interface ScreenMetaSources {
+  cwdOf: (id: string) => string;
+  // Both take the cwd, and neither is called for a session that has none — a dir the host
+  // cannot name has no branch and no GitHub page either.
+  branchOf: (cwd: string) => Promise<string | null>;
+  githubUrlOf: (cwd: string) => Promise<string | null>;
+  memoOf: (id: string) => string;
+  summaryOf: (id: string) => string;
+  promptOf: (id: string) => string;
+  // The memo store's boot read. Awaited BEFORE memoOf, or a screen pulled during startup is
+  // told the note is gone — which is indistinguishable from the user having erased it (#1110).
+  memosHydrated: Promise<void>;
+}
+
+export async function buildScreenMeta(id: string, sources: ScreenMetaSources): Promise<SessionScreenMeta> {
+  const cwd = sources.cwdOf(id);
+  await sources.memosHydrated;
+  // Both git reads are independent, so the phone waits for one spawn rather than two.
+  const [branch, githubUrl] = await Promise.all([cwd ? sources.branchOf(cwd) : null, cwd ? sources.githubUrlOf(cwd) : null]);
+  return definedScreenMeta({
+    cwd,
+    branch: branch ?? "",
+    memo: sources.memoOf(id),
+    summary: sources.summaryOf(id),
+    prompt: sources.promptOf(id),
+    githubUrl: githubUrl ?? "",
+  });
+}
+
 // tmux first: it renders the real screen, works while detached, and survives a restart.
 // Falling back to the in-process buffer covers the tmux-less host, the non-persistent
 // spawn, AND the race where the session ends between listing and reading.

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -153,6 +153,11 @@ export interface CaptureScreenDeps {
 export interface SessionScreenMeta {
   cwd?: string;
   branch?: string;
+  // The user's own one-line note on the session (#1084), which the phone shows ABOVE the summary:
+  // the line the user wrote outranks what the agent said (sessionDisplayName). Its own field
+  // rather than riding in `summary` the way the picker's row rides in `title` — `summary` is drawn
+  // as a row labelled as the AI's summary, so a handwritten note put there would be mislabelled.
+  memo?: string;
   summary?: string;
   prompt?: string;
   // The dir's REPOSITORY ROOT on GitHub, so the phone can link out to it (#832). Absent for

--- a/server/index.ts
+++ b/server/index.ts
@@ -617,16 +617,18 @@ const remoteHostWriteToSession = (sessionId: string, chunk: string): boolean => 
 const remoteHostCanClearBox = (sessionId: string): boolean => canClearInputBox(ptys.get(sessionId)?.agent, activity.get(sessionId)?.working);
 
 // What the phone's per-session view heads the screen with (#786, mulmoserver#107): the same
-// dir / branch / summary / prompt the grid cell shows, read from the tables /api/sessions
+// dir / branch / memo / summary / prompt the grid cell shows, read from the tables /api/sessions
 // answers from. A session that outlived a restart has no PtyEntry, so it has no cwd here and
 // no branch to look up — those fields are simply absent, and the phone shows the screen alone.
 const remoteHostSessionScreenMeta = async (sessionId: string): Promise<SessionScreenMeta> => {
   const cwd = ptys.get(sessionId)?.cwd ?? "";
+  await sessionMemosHydrated; // a screen pulled during startup must not be told the memo is gone
   // Both git reads are independent, so the phone waits for one spawn rather than two.
   const [head, repoUrl] = await Promise.all([cwd ? currentBranch(cwd) : null, cwd ? resolveGithubUrl(cwd) : null]);
   return {
     cwd,
     branch: head?.branch ?? "",
+    memo: sessionMemos.get(sessionId) ?? "", // beside the summary, never instead of it — see SessionScreenMeta (#1110)
     summary: aiTitles.get(sessionId) ?? "",
     prompt: lastPrompts.get(sessionId) ?? "",
     // The repository root, never /tree/<branch>: whether a branch is still ON GitHub cannot

--- a/server/index.ts
+++ b/server/index.ts
@@ -78,6 +78,7 @@ import { createAntigravitySpawner } from "./session/spawn-antigravity.js";
 import { renderScreen } from "./session/headlessScreen.js";
 import {
   agentFromPaneCommand,
+  buildScreenMeta,
   buildSessionList,
   captureSessionScreen,
   sessionWorkSummary,
@@ -620,26 +621,22 @@ const remoteHostCanClearBox = (sessionId: string): boolean => canClearInputBox(p
 // dir / branch / memo / summary / prompt the grid cell shows, read from the tables /api/sessions
 // answers from. A session that outlived a restart has no PtyEntry, so it has no cwd here and
 // no branch to look up — those fields are simply absent, and the phone shows the screen alone.
-const remoteHostSessionScreenMeta = async (sessionId: string): Promise<SessionScreenMeta> => {
-  const cwd = ptys.get(sessionId)?.cwd ?? "";
-  await sessionMemosHydrated; // a screen pulled during startup must not be told the memo is gone
-  // Both git reads are independent, so the phone waits for one spawn rather than two.
-  const [head, repoUrl] = await Promise.all([cwd ? currentBranch(cwd) : null, cwd ? resolveGithubUrl(cwd) : null]);
-  return {
-    cwd,
-    branch: head?.branch ?? "",
-    memo: sessionMemos.get(sessionId) ?? "", // beside the summary, never instead of it — see SessionScreenMeta (#1110)
-    summary: aiTitles.get(sessionId) ?? "",
-    prompt: lastPrompts.get(sessionId) ?? "",
+const remoteHostSessionScreenMeta = (sessionId: string): Promise<SessionScreenMeta> =>
+  buildScreenMeta(sessionId, {
+    cwdOf: (id) => ptys.get(id)?.cwd ?? "",
+    branchOf: async (cwd) => (await currentBranch(cwd)).branch,
     // The repository root, never /tree/<branch>: whether a branch is still ON GitHub cannot
     // be known without asking GitHub. `refs/remotes/origin/*` is a local cache, so a merged
     // branch deleted at merge time keeps resolving here until someone prunes — and every
     // branch this app creates is deleted that way. Measured: the tree URL 404s, the root
     // does not. A per-poll `ls-remote` is the only local fix and costs a network round trip
     // on a screen the phone polls (#832).
-    githubUrl: repoUrl ?? "",
-  };
-};
+    githubUrlOf: resolveGithubUrl,
+    memoOf: (id) => sessionMemos.get(id) ?? "", // beside the summary, never instead of it — see SessionScreenMeta (#1110)
+    summaryOf: (id) => aiTitles.get(id) ?? "",
+    promptOf: (id) => lastPrompts.get(id) ?? "",
+    memosHydrated: sessionMemosHydrated,
+  });
 
 const remoteHostCaptureTerminalScreen = (sessionId: string) =>
   captureSessionScreen(sessionId, {

--- a/test/server/backends/remoteHost/terminalScreen.spec.ts
+++ b/test/server/backends/remoteHost/terminalScreen.spec.ts
@@ -222,10 +222,31 @@ describe("captureSessionScreen", () => {
     expect(metaOf).toHaveBeenCalledWith("a");
   });
 
+  // The user's own note travels BESIDE the AI summary rather than in place of it (#1110). The
+  // picker's row overwrites `title` with the memo because a row there is one line, but the
+  // header draws each field as its own labelled row — a memo shown as the AI's summary is
+  // mislabelled, so the asymmetry between the two routes is the point, not an oversight.
+  it("carries the user's memo alongside the AI summary", async () => {
+    const captured = await captureSessionScreen(
+      "a",
+      captureDeps({ metaOf: async () => ({ summary: "Adding meta to the phone view", memo: "ask Tom before merging" }) }),
+    );
+    expect(captured.memo).toBe("ask Tom before merging");
+    expect(captured.summary).toBe("Adding meta to the phone view");
+  });
+
+  // A session with no note is the common case, and it must look exactly like a host built
+  // before #1110: no `memo` key at all, so the phone draws no empty memo row.
+  it("drops the memo row for a session the user never wrote a note on", async () => {
+    const captured = await captureSessionScreen("a", captureDeps({ metaOf: async () => ({ summary: "Adding meta", memo: "" }) }));
+    expect(Object.hasOwn(captured, "memo")).toBe(false);
+    expect(captured.summary).toBe("Adding meta");
+  });
+
   // A host that answers nothing looks exactly like one built before #786 — the phone
   // renders the screen alone.
   it("sends only the screen when the host has no metadata to add", async () => {
-    const captured = await captureSessionScreen("a", captureDeps({ metaOf: async () => ({ cwd: "", branch: "", summary: "", prompt: "" }) }));
+    const captured = await captureSessionScreen("a", captureDeps({ metaOf: async () => ({ cwd: "", branch: "", memo: "", summary: "", prompt: "" }) }));
     expect(captured).toEqual({ screen: "rendered:buffered", suggestion: "", quickCommands: [] });
   });
 
@@ -269,7 +290,7 @@ describe("captureSessionScreen", () => {
 // and the phone renders one labelled row per field it receives.
 describe("definedScreenMeta", () => {
   it("keeps the fields the host could answer", () => {
-    const meta = { cwd: "/repo", branch: "main", summary: "Fix the parser", prompt: "fix it" };
+    const meta = { cwd: "/repo", branch: "main", memo: "ask Tom first", summary: "Fix the parser", prompt: "fix it" };
     expect(definedScreenMeta(meta)).toEqual(meta);
   });
 

--- a/test/server/backends/remoteHost/terminalScreen.spec.ts
+++ b/test/server/backends/remoteHost/terminalScreen.spec.ts
@@ -3,10 +3,12 @@ import { describe, it, expect, vi } from "vitest";
 
 import {
   agentFromPaneCommand,
+  buildScreenMeta,
   buildSessionList,
   captureSessionScreen,
   definedScreenMeta,
   type CaptureScreenDeps,
+  type ScreenMetaSources,
   type SessionListInput,
 } from "../../../../server/backends/remoteHost/terminalScreen.js";
 import { undefinedPaths } from "@mulmoclaude/core/remote-host/server";
@@ -320,6 +322,110 @@ describe("definedScreenMeta", () => {
   // a prompt's own leading spaces are the user's text, not ours to edit.
   it("passes a value with surrounding whitespace through unchanged", () => {
     expect(definedScreenMeta({ prompt: "  fix it  " })).toEqual({ prompt: "  fix it  " });
+  });
+});
+
+// The join behind the phone's header. Injected sources rather than the server's tables, so the
+// ORDER of the reads is assertable — which is the part a reader cannot verify by looking at the
+// answer (CodeRabbit asked for this on #1112).
+describe("buildScreenMeta", () => {
+  const sources = (over: Partial<ScreenMetaSources> = {}): ScreenMetaSources => ({
+    cwdOf: () => "/repo",
+    branchOf: async () => "feat/1110",
+    githubUrlOf: async () => "https://github.com/o/r",
+    memoOf: () => "ask Tom before merging",
+    summaryOf: () => "Adding meta to the phone view",
+    promptOf: () => "add the memo",
+    memosHydrated: Promise.resolve(),
+    ...over,
+  });
+
+  it("heads the screen with everything the host could answer", async () => {
+    expect(await buildScreenMeta("a", sources())).toEqual({
+      cwd: "/repo",
+      branch: "feat/1110",
+      memo: "ask Tom before merging",
+      summary: "Adding meta to the phone view",
+      prompt: "add the memo",
+      githubUrl: "https://github.com/o/r",
+    });
+  });
+
+  // THE regression this seam exists for. The memo lives only in the server's map, and that map is
+  // filled by a boot read of the append log: reading it first answers "" for every session, which
+  // the phone cannot tell apart from the user having erased the note.
+  it("reads the memo only after the memo store has hydrated", async () => {
+    const order: string[] = [];
+    let hydrate = () => {};
+    const memosHydrated = new Promise<void>((resolve) => {
+      hydrate = () => {
+        order.push("hydrated");
+        resolve();
+      };
+    });
+    const pending = buildScreenMeta(
+      "a",
+      sources({
+        memosHydrated,
+        memoOf: () => {
+          order.push("memoOf");
+          return "ask Tom before merging";
+        },
+      }),
+    );
+    // A full turn of the event loop, not one microtask: every other source here resolves
+    // immediately, so without the barrier the memo would already have been read by now — which
+    // is what makes this assertion fail if the await is ever dropped.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual([]);
+    hydrate();
+    expect((await pending).memo).toBe("ask Tom before merging");
+    expect(order).toEqual(["hydrated", "memoOf"]);
+  });
+
+  // The branch lookup shells out to git, and so does the GitHub remote read. Sequencing them
+  // would double the latency of a screen the phone polls.
+  it("runs the two git reads concurrently", async () => {
+    const order: string[] = [];
+    await buildScreenMeta(
+      "a",
+      sources({
+        branchOf: async () => {
+          order.push("branch:start");
+          await Promise.resolve();
+          order.push("branch:end");
+          return "main";
+        },
+        githubUrlOf: async () => {
+          order.push("github:start");
+          return null;
+        },
+      }),
+    );
+    expect(order).toEqual(["branch:start", "github:start", "branch:end"]);
+  });
+
+  // A session that outlived a restart has no PtyEntry, so the host has no dir for it. Spawning
+  // git against "" would ask about THIS process's cwd — an answer from the wrong repository.
+  it("asks git nothing when the host has no directory for the session", async () => {
+    const branchOf = vi.fn(async () => "main");
+    const githubUrlOf = vi.fn(async () => "https://github.com/o/r");
+    expect(await buildScreenMeta("a", sources({ cwdOf: () => "", branchOf, githubUrlOf }))).toEqual({
+      memo: "ask Tom before merging",
+      summary: "Adding meta to the phone view",
+      prompt: "add the memo",
+    });
+    expect(branchOf).not.toHaveBeenCalled();
+    expect(githubUrlOf).not.toHaveBeenCalled();
+  });
+
+  // A detached HEAD has no branch name, and a session with no note has no memo: both lose the
+  // key rather than arriving as "", which the phone would draw as an empty labelled row.
+  it("drops what the host could not answer, key and all", async () => {
+    const meta = await buildScreenMeta("a", sources({ branchOf: async () => null, memoOf: () => "", githubUrlOf: async () => null }));
+    expect(meta).toEqual({ cwd: "/repo", summary: "Adding meta to the phone view", prompt: "add the memo" });
+    expect(Object.hasOwn(meta, "memo")).toBe(false);
+    expect(Object.hasOwn(meta, "branch")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

`getTerminalScreen` の応答に **`memo?: string`** を追加し、`server/index.ts` の screen meta から `sessionMemos` を渡す。#1084 のセッションメモが、スマホ（mulmoserver PWA）の**一覧には出るのに、開いた1セッション画面のヘッダでは AI サマリに戻る**という非対称を直す。

ワイヤ形の**追加のみ**で、既存フィールドの意味は変えていない。メモが無いセッションでは `definedScreenMeta()` がキーごと落とすので、応答は従来とまったく同じ。

**実際にスマホに出るのは receptron/mulmoserver#122 が入ってから**です（先に入れても壊れないのは、[docs/remote-host-protocol.md](docs/remote-host-protocol.md) の「スマホは教わっていないフィールドを無視する」という前提のため）。

Closes #1110

## Items to Confirm / Review

1. **`summary` に混ぜず別フィールドにした判断**（issue の案A / 案B）。案B（`summary` をメモ優先にする）なら mulmoserver を触らずに今日出せるが、「AI サマリ」というラベルの行に手書きメモが入る。表示が嘘になるのを避けて案A にしています。
2. **`await sessionMemosHydrated` の位置。** git 2本の `Promise.all` の**前**に直列で置いた。起動直後だけ git 呼び出しが待たされるが、スマホは必ず一覧→画面の順に叩くのでハイドレーションは温まっており、一覧ルート・`/api/session` と同じ体裁に揃える方を選んだ。`Promise.all` に混ぜる形の方が良ければ変えます。
3. **`server/index.ts` の配線2行はユニットテストが無い。** `getTerminalScreen` の入口は Firestore 経由の remote-host コマンドだけで、`index.ts` はテストから import できない。代わりに、`memo?: string` を型から**消すと `server/index.ts:633` と spec の両方で typecheck が落ちる**ことを実測して、契約が型で守られていることを確認しています。
4. **レビューで見つけた既存バグ（本PRのスコープ外、未修正）** — 下の「レビューで見つけた点」を参照。follow-up issue を立てるかどうかの判断をお願いします。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1110 A

（issue #1110 の「どう直すか（要相談）」に挙げた案A = `SessionScreenMeta` に `memo?` を足す、を選択。続けて「mulmoserver 側には issue を立てる。こっちは review を」「PR で review」）

## 実装

| ファイル | 変更 |
| --- | --- |
| `server/backends/remoteHost/terminalScreen.ts` | `SessionScreenMeta` に `memo?: string`。位置は `summary` の**上**（スマホでの表示順に合わせた） |
| `server/index.ts` | `remoteHostSessionScreenMeta()` に `memo: sessionMemos.get(sessionId) ?? ""` と `await sessionMemosHydrated` |
| `docs/remote-host-protocol.md` | `SessionScreen` の形 ＋ 「`memo` と `summary` は別の文で、片方が片方の代わりではない」という不変条件 |
| `test/.../terminalScreen.spec.ts` | 新規2件（併存 / 空メモのキー落ち）＋ 既存2件を memo 込みに拡張 |
| `plans/fix-1110-memo-in-phone-session-screen.md` | 決定事項（案B の却下理由、ハイドレーション、やらないこと） |

### 決めたこと

| 論点 | 決定 |
| --- | --- |
| `summary` を上書きするか | **しない**。`memo` は**ユーザーが書いた行**、`summary` / `prompt` は**エージェントが言ったこと** |
| 空メモ | `definedScreenMeta()` がキーごと落とす（`""` は「メモが空」と読めてしまう） |
| ハイドレーション | 一覧ルートと同じく `await sessionMemosHydrated` — 起動直後のポーリングでメモが「無い」と報告されないため |
| ラベルと位置 | `memo` / `summary` の上。グリッドの cockpit roster（#1108）と同じ順。描くのは mulmoserver 側 |
| 一覧の `title` | **変更なし**（メモ優先のまま）。一覧はすでに正しい |

### 正しさの確認（コードパスを追って）

- **消去パスが効く**: `applySessionMemo()` は空テキストで `Map.delete` する → `.get()` が `undefined` → `?? ""` → キーごと落ちる。デスクトップでメモを消せばスマホのヘッダからも消え、残留しない。
- **ハイドレーション待ちが screen を人質に取らない**: `sessionMemosHydrated` は IIFE 内部に try/catch があり **reject し得ない**。`screenMetaOf()` の catch は meta 全体を捨てる実装なので、もしここが reject するとメモの読み失敗が `cwd` / `branch` まで奪っていた。
- **正規化済み**: `normalizeMemo()` が制御文字を空白化して200コードポイントで切るので、`definedScreenMeta` の `.trim()` は no-op、ANSI や改行がスマホのヘッダに流れる経路も無い。

### 確認したコマンド

`yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn test`（6407 passed）/ `yarn build` すべて green。

## Companion

- **receptron/mulmoserver#122** — スマホ側で `memo` を読んでヘッダに描く（`useTerminalScreen.ts` / `SessionMetaHeader.vue` / i18n `terminal.meta.memo`、アイコンは MulmoTerminal と同じ `edit_note`）

work in mulmoterminal2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session screens now support displaying a user-provided memo alongside the AI-generated summary, with the memo shown in the picker title when present.
* **Documentation**
  * Clarified the distinction and display behavior between user memos and AI summaries.
* **Bug Fixes**
  * Improved memo availability on the phone “1 session screen” so memos aren’t inconsistently missing during early loading.
  * Empty memos are omitted to preserve prior behavior for hosts without available metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->