### PR TITLE
docs: 2.8.0 のチェンジログに #1117 を足す

### DIFF
--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -216,7 +216,7 @@ stats the cwd before spawning and refuses a directory that does not exist, so on
 Windows daily job saw it. Now `process.cwd()`, which is a directory on every platform. Test-only; the
 product code was correct.
 
-### Docs (#1092, #1093, #1102)
+### Docs (#1092, #1093, #1102, #1117)
 
 - **One searchable line** across README, npm and the docs site (#1093). The npm description still
   described v1 (no parallelism, no Codex) and the keyword list was missing `codex`; the repo's
@@ -230,6 +230,9 @@ product code was correct.
   what the code reads from `process.env` against what the docs mention: added to the README and both
   guides. Also fixed a `MULMOTERMINAL_HOME` row in the Japanese guide that had been orphaned below
   the table it belongs to.
+- **2.7.0's setup guide got its screenshots** (#1117, closes #1090): the session note beside a cell
+  header that does not make it taller, and a zoomed cell's divider mid-drag. The prose is unchanged —
+  that page stays the snapshot it was written as — and the placeholder "Screenshots" section is gone.
 
 ## mulmoterminal@2.7.0 — 2026-07-29
 


### PR DESCRIPTION
## Summary

#1118（2.8.0 のリリース文書）を書いている最中に **#1117 が main に入った**ため、2.8.0 の
チェンジログの Docs 節にその 1 行が抜けていました。1 行の追記だけです。

`/publish` の規約が「前のタグ以降に入った**全ての** PR をリリースノートに書く」なので、
#1117（2.7.0 ガイドのスクリーンショット、closes #1090）も 2.7.0 タグ以降の未リリース PR に
当たります。

## Items to Confirm / Review

- **そもそも載せるべきかの判断。** #1117 は**前のリリースの**ガイドページに画像を足した PR で、
  2.8.0 のユーザーに向けた変更ではありません。「全 PR を書く」規約に従って載せましたが、
  リリースノートのノイズと感じるなら落としてください（この PR を閉じるだけで済みます）。
- **publish のブロッカーではありません。** マージせず `/publish` に進んでも、欠けるのは
  チェンジログのこの 1 行だけです。

## User Prompt

> 957がおわったらpublishするので用意して。

（#1118 の作業中に派生した追記です）

work in mulmoterminal4