### PR TITLE
refactor: JsonObject の二重キャストを core の toJsonObject に置き換える (#1121)

### DIFF
--- a/server/backends/remoteHost/collectionPage.ts
+++ b/server/backends/remoteHost/collectionPage.ts
@@ -18,8 +18,14 @@ export { clampLimit, clampOffset };
 export const deriveItems = (schema: { fields?: Record<string, DerivableFieldSpec> }, items: unknown[]): DerivableRecord[] =>
   items.map((item) => deriveAll({ fields: schema.fields ?? {} }, item as DerivableRecord, {}));
 
-/** Build the paginated result. `detail` (a CollectionDetail) and `items`
- *  (CollectionItem[]) are plain JSON, but their interfaces lack an index
- *  signature so they don't structurally match JsonValue — the cast is safe. */
+/** Build the paginated result.
+ *
+ *  `toJsonObject` cannot serve this one. `detail` and `items` arrive as `unknown`, and
+ *  `CollectionDetail` reaches `schema.spawn.set`, typed `Record<string, unknown>` — so the payload
+ *  genuinely CANNOT be proven JSON by the type system. It is JSON at runtime because the schema
+ *  loader only ever puts JSON there, a fact about the loader that these types do not record.
+ *
+ *  Removing this assertion means giving `spawn.set` a JSON-valued type at the schema layer, not
+ *  adjusting anything here. (Same call, same reason, as MulmoClaude's own `pageResult`.) */
 export const pageResult = (detail: unknown, items: unknown[], offset: number, limit: number): JsonObject =>
-  ({ collection: detail, items: items.slice(offset, offset + limit), total: items.length, offset, limit }) as unknown as JsonObject;
+  ({ collection: detail, items: items.slice(offset, offset + limit), total: items.length, offset, limit }) as JsonObject;

--- a/server/backends/remoteHost/handlers.ts
+++ b/server/backends/remoteHost/handlers.ts
@@ -19,6 +19,7 @@ import { discoverCollections, listItems, loadCollection, toDetail, toSummary } f
 import { listFeeds, readFeedState } from "@mulmoclaude/core/feeds/server";
 import { normalizeFields, normalizeMutate } from "@mulmoclaude/core/remote-view";
 import { listBooks } from "@mulmoclaude/accounting-plugin/server";
+import { toJsonObject } from "@mulmoclaude/core/remote-host";
 import type { CommandHandlers, JsonObject, JsonValue } from "@mulmoclaude/core/remote-host";
 
 import { readShortcuts } from "../shortcuts.js";
@@ -98,7 +99,7 @@ const composeMessage = (message: string, attachments: Attachment[]): string => {
 // (source "feed") are excluded — they are served by listFeeds.
 const listCollections: CommandHandlers["listCollections"] = async () => {
   const collections = (await discoverCollections()).filter((collection) => collection.source !== "feed").map(toSummary);
-  return { collections } as unknown as JsonObject;
+  return toJsonObject({ collections });
 };
 
 // One collection's detail + a PAGE of its records (pagination mandatory — the result
@@ -123,7 +124,7 @@ const getRemoteView: CommandHandlers["getRemoteView"] = async (params: JsonObjec
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await buildRemoteView(collection, viewId, locale);
   if (result.kind !== "ok") throw new Error(remoteViewFailureMessage(result, slug));
-  return { view: result.view, srcdoc: result.srcdoc, bytes: result.bytes } as unknown as JsonObject;
+  return toJsonObject({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
 };
 
 // One page of a mobile view's records, projected to the view's fields. Image fields are
@@ -138,6 +139,11 @@ const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (params:
   if (!collection) throw new Error(`collection '${slug}' not found`);
   const result = await remoteViewItems(collection, viewId, request);
   if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
+  // `toJsonObject` cannot serve this one, and neither can a single assertion: `RemoteViewPage` has
+  // no index signature at all, so it does not even overlap `JsonObject`. It IS JSON at runtime —
+  // the collection loader only ever puts JSON in it — a fact about the loader these types do not
+  // record. Removing this double cast means giving `RemoteViewPage`/`RemoteViewItem` JSON-valued
+  // types upstream, not adjusting anything here.
   return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
 };
 
@@ -155,10 +161,12 @@ const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (par
   // The write applied but its response blew the byte budget — report success (+refetch),
   // not a thrown error the phone shows as a failed edit while keeping stale data (#747).
   if (mutateWriteApplied(result)) {
-    return { op: request.op, id: request.id, applied: true, warning: mutateRemoteViewFailureMessage(result, slug) } as unknown as JsonObject;
+    return toJsonObject({ op: request.op, id: request.id, applied: true, warning: mutateRemoteViewFailureMessage(result, slug) });
   }
   if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
-  return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as unknown as JsonObject;
+  // Same reason as getRemoteViewItems above: `CollectionItem`'s `unknown`-valued index signature
+  // is not provably JSON, though the loader only ever writes JSON into it.
+  return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as JsonObject;
 };
 
 // The phone's remote terminal view (#435): pick a session, read its screen, and —
@@ -181,7 +189,7 @@ const terminalScreenHandlers = ({
   // One sender per host, so its per-session ordering actually spans every command.
   const sendInput = createTerminalInputSender({ writeToSession, canClearBox, submitSequence });
   return {
-    listTerminalSessions: async () => ({ sessions: await listTerminalSessions() }) as unknown as JsonObject,
+    listTerminalSessions: async () => toJsonObject({ sessions: await listTerminalSessions() }),
 
     // `suggestion` is the agent's own dim ghost text — the phone offers it as a chip,
     // since it has no Tab key to accept it with (#563). The screen also carries the
@@ -191,7 +199,7 @@ const terminalScreenHandlers = ({
     getTerminalScreen: async (params: JsonObject) => {
       const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
       if (!sessionId) throw new Error("sessionId is required");
-      return (await captureTerminalScreen(sessionId)) as unknown as JsonObject;
+      return toJsonObject(await captureTerminalScreen(sessionId));
     },
 
     // Type a line into the session and press Enter, as if the user were at the
@@ -201,7 +209,7 @@ const terminalScreenHandlers = ({
       const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
       if (!sessionId) throw new Error("sessionId is required");
       const text = typeof params.text === "string" ? params.text : "";
-      return (await sendInput(sessionId, text)) as unknown as JsonObject;
+      return toJsonObject(await sendInput(sessionId, text));
     },
 
     // Open a NEW grid terminal in the directory of the session the phone is viewing (#831).
@@ -214,7 +222,7 @@ const terminalScreenHandlers = ({
     launchTerminal: async (params: JsonObject) => {
       const result = launchTerminal(params.agent, params.sessionId);
       if (!result.ok) throw new Error(result.error);
-      return { ok: true } as unknown as JsonObject;
+      return toJsonObject({ ok: true });
     },
   };
 };
@@ -248,7 +256,7 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
         const state = await readFeedState(workspace, feed);
         summaries.push(feedSummary(feed, state.lastFetchedAt));
       }
-      return { feeds: summaries } as unknown as JsonObject;
+      return toJsonObject({ feeds: summaries });
     },
 
     // One feed's detail + a PAGE of its records. A feed IS a LoadedCollection
@@ -267,7 +275,7 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
     },
 
     // Pinned launcher shortcuts (favorites), read-only.
-    listShortcuts: async () => ({ shortcuts: await readShortcuts(workspace) }) as unknown as JsonObject,
+    listShortcuts: async () => toJsonObject({ shortcuts: await readShortcuts(workspace) }),
 
     // Discoverable skill ids (~/.claude/skills + <workspace>/.claude/skills),
     // read-only. Collection slugs are subtracted — a skill dir that ships a
@@ -276,13 +284,13 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
     listSkills: async () => {
       const [names, collections] = await Promise.all([discoverSkillNames({ workspaceRoot: workspace }), discoverCollections()]);
       const collectionSlugs = new Set(collections.filter((collection) => collection.source !== "feed").map((collection) => collection.slug));
-      return { skills: names.filter((name) => !collectionSlugs.has(name)) } as unknown as JsonObject;
+      return toJsonObject({ skills: names.filter((name) => !collectionSlugs.has(name)) });
     },
 
     // { id, name } per accounting book, for a mobile book picker.
     listAccountingBooks: async () => {
       const { books } = await listBooks(workspace);
-      return { books: books.map((book) => ({ id: book.id, name: book.name })) } as unknown as JsonObject;
+      return toJsonObject({ books: books.map((book) => ({ id: book.id, name: book.name })) });
     },
 
     // Start a visible chat from the phone, seeded with `message`. This host has


### PR DESCRIPTION
## Summary

`server/backends/remoteHost/` の `as unknown as JsonObject` を、`@mulmoclaude/core/remote-host` が**既に export している** `toJsonObject` に置き換えました。

**14 箇所 → 3 箇所**（うち 11 箇所が `toJsonObject`、残る 3 箇所は型システムが JSON だと証明できない正当な例外）。

`toJsonObject` は `<T extends object>(payload: Jsonify<T>) => JsonObject` で、`Jsonify<T>` を通るので **JSON にできない payload はコンパイルエラーになります**。二重キャストは型システムを完全に迂回していたので、単なる書き換えではなく検査が戻ります。

## Items to Confirm / Review

1. **残した 3 箇所の判断**。`toJsonObject` に通らなかったものは、payload が `unknown` 値の index signature を持っていて **本当に JSON だと証明できない**ものでした。MulmoClaude の `pageResult` と同じ形（なぜ証明できないか＋何を直せば消せるか、をコメントに書く）に揃えています。

| 箇所 | 形 | 理由 |
|---|---|---|
| `handlers.ts:147` | `as unknown as` のまま | `RemoteViewPage` に index signature が**無い**ので、単一 assertion すら通らない（重なりが無い） |
| `handlers.ts:169` | **単一に縮めた** | `CollectionItem` の `[key: string]: unknown` |
| `collectionPage.ts:31` | **単一に縮めた** | `CollectionDetail` が `schema.spawn.set: Record<string, unknown>` に到達する |

2. **`collectionPage.ts` のコメントを訂正しています。** 元は「their interfaces lack an index signature so they don't structurally match JsonValue」と書いてありましたが、コンパイラの実際の言い分は逆で、**`unknown` 値の index signature を持っている**ことが理由でした（`Jsonify` が `unknown` を `never` に落とす）。MulmoClaude 側の同じ関数のコメントと同じ根拠に直しました。

3. 挙動は変わりません。ランタイムの出力は同一で、変わったのは型チェックが通るかどうかだけです。

## この helper はまさにこのために作られている

`node_modules/@mulmoclaude/core/dist/remote-host/index.d.ts:20-26` の doc コメント:

> Widen a JSON-shaped handler payload to the channel's `JsonObject`.
> Exists so the `Jsonify` reasoning above lives in ONE place. **Before this, eight remote-host handlers each carried their own `as unknown as JsonObject` with the justification re-argued in eight slightly different comments** — which is how a rule stops being reviewable.

MulmoClaude 側はこれを使って素のキャストを 2 箇所（どちらも理由コメント付き）まで減らしています。こちらだけ 14 箇所で迂回したままでした。`CLAUDE.md` の「MulmoClaude is the reference host」「MUST use existing utility functions from libraries」「NEVER use `as` type casts」に該当します。

## 検証

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` すべて緑。`yarn test` **6495 passed**。
- 置換は**行単位の完全一致で 13 箇所**を書き換えています（最初に正規表現でやったらファイルを壊したので、破棄して 1 行ずつ照合する方式にしました）。
- 型エラーが出た 2 箇所は「机上で正当化して押し通す」のではなく、**コンパイラが何と言っているかを読んで**、単一 assertion で足りるか / 二重が要るかを 1 件ずつ確かめています。

Closes #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency when displaying responses from remote-host commands.
  * Fixed response handling for collections, remote views, terminal sessions, feeds, shortcuts, skills, and accounting books.
  * Improved handling of remote-view edits and terminal actions to prevent response-format issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->