### PR TITLE
refactor: 誰も立てない last-turn の tooLarge を撤去する (#1123)

### DIFF
--- a/server/session/last-turn.ts
+++ b/server/session/last-turn.ts
@@ -10,10 +10,6 @@ import { isRecord } from "../../common/isRecord.js";
 export interface LastTurn {
   prompt: string | null;
   reply: string | null;
-  // Set when the transcript was refused for its size rather than read (see
-  // sessionLastTurn). Absent means "read it, and this is what was in it" — including the
-  // ordinary empty result, which a caller must not report as a failure.
-  tooLarge?: true;
 }
 
 export const EMPTY_TURN: LastTurn = { prompt: null, reply: null };

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -201,12 +201,8 @@ async function codexLastTurn(sessionKey: string): Promise<LastTurn> {
 // 334-character reply — 1.9 seconds with the event loop stopped, every terminal in the app frozen.
 // Past ~512 MB the read could not complete at all (V8's maximum string length), so the button did
 // nothing. The last turn is in the last few lines either way, so the size of the file behind it
-// stopped mattering: the same read now costs 256 KB whatever the transcript weighs.
-//
-// `LAST_TURN_MAX_BYTES` / `tooLarge` are consequently dead as a limit. They stay for now because
-// `tooLarge` reaches the UI (useHandoff, codeBlockCopy) and removing a wire field is its own
-// change; nothing sets it any more.
-export const LAST_TURN_MAX_BYTES = 64 * 1024 * 1024;
+// stopped mattering: the same read now costs 256 KB whatever the transcript weighs. There is
+// consequently no size limit here at all, and no "too large" answer for a caller to handle.
 
 export async function sessionLastTurn(cwd: string, id: string, agent: "claude" | "codex" | "antigravity"): Promise<LastTurn> {
   if (agent === "codex") return codexLastTurn(id);

--- a/src/components/CopyCodeBlock.vue
+++ b/src/components/CopyCodeBlock.vue
@@ -9,7 +9,7 @@
 // server — only the fence extraction and this entry point are new.
 import { ref, onUnmounted } from "vue";
 import { fetchLastTurn } from "../composables/useHandoff";
-import { copyOutcomeFor, copyOutcomeMessage, clipboardAvailable, turnOf } from "./codeBlockCopy";
+import { copyOutcomeFor, copyOutcomeMessage, clipboardAvailable } from "./codeBlockCopy";
 import { trapTabKey, MODAL_FOCUSABLE } from "../utils/focusTrap";
 import type { TerminalAgent } from "../../common/sessionAgent";
 
@@ -38,7 +38,7 @@ async function copyLastBlock(): Promise<void> {
   busy.value = true;
   try {
     const turn = await fetchLastTurn({ sessionId: props.sessionId, cwd: props.cwd, agent: props.agent }, "reply");
-    const outcome = copyOutcomeFor(turnOf(turn));
+    const outcome = copyOutcomeFor(turn);
     if (outcome.kind !== "ok") return flash(copyOutcomeMessage(outcome));
     if (!clipboardAvailable()) return showForManualCopy(outcome.text);
     try {

--- a/src/components/codeBlockCopy.ts
+++ b/src/components/codeBlockCopy.ts
@@ -1,19 +1,14 @@
 // What "copy the last code block" should do with a fetched turn (#865). Pure, so the states a
 // user can land in are pinned by tests rather than only reachable by clicking.
 //
-// Three of the four outcomes are NOT errors, and telling them apart is the whole point: "that
-// reply had no code", "this session is too big to read", and "there is no completed turn yet"
-// each need a different sentence. Collapsing them into one failure message is what makes a
-// button feel broken.
+// Both non-ok outcomes are NOT errors, and telling them apart is the whole point: "that reply had
+// no code" and "there is no completed turn yet" need different sentences. Collapsing them into one
+// failure message is what makes a button feel broken.
 import { lastFencedBlock } from "../../common/codeBlocks";
-import type { FetchedTurn } from "../composables/useHandoff";
 
-export type CopyOutcome = { kind: "ok"; text: string; lang: string | null } | { kind: "no-code" } | { kind: "too-large" } | { kind: "no-turn" };
+export type CopyOutcome = { kind: "ok"; text: string; lang: string | null } | { kind: "no-code" } | { kind: "no-turn" };
 
-/** `tooLarge` is the server refusing to read an oversized transcript; it rides on the same
- *  response as the turn, so it is checked before the (necessarily empty) reply. */
-export function copyOutcomeFor(turn: { reply: string | null; tooLarge?: boolean | undefined }): CopyOutcome {
-  if (turn.tooLarge) return { kind: "too-large" };
+export function copyOutcomeFor(turn: { reply: string | null }): CopyOutcome {
   if (!turn.reply) return { kind: "no-turn" };
   const block = lastFencedBlock(turn.reply);
   return block ? { kind: "ok", text: block.body, lang: block.lang } : { kind: "no-code" };
@@ -27,8 +22,6 @@ export function copyOutcomeMessage(outcome: CopyOutcome): string {
       return "Copied";
     case "no-code":
       return "No code block in the last reply";
-    case "too-large":
-      return "This session's transcript is too large to read";
     case "no-turn":
       return "No completed turn yet";
   }
@@ -39,10 +32,3 @@ export function copyOutcomeMessage(outcome: CopyOutcome): string {
  *  into another app is exactly what those users are here for, so the caller shows the text for
  *  manual selection instead of reporting a failure. */
 export const clipboardAvailable = (): boolean => typeof navigator !== "undefined" && !!navigator.clipboard?.writeText;
-
-/** True when `turn` is the shape fetchLastTurn returns. Kept next to the outcome logic so the
- *  component never has to widen a type to call it. */
-export const turnOf = (fetched: FetchedTurn & { tooLarge?: boolean | undefined }): { reply: string | null; tooLarge?: boolean | undefined } => ({
-  reply: fetched.reply,
-  tooLarge: fetched.tooLarge,
-});

--- a/src/composables/useHandoff.ts
+++ b/src/composables/useHandoff.ts
@@ -52,9 +52,6 @@ export interface FetchedTurn {
   prompt: string | null;
   reply: string | null;
   text: string;
-  // The server refused to read an oversized transcript rather than freezing on it (#865).
-  // Distinct from an empty reply, which means "read it, there was nothing".
-  tooLarge?: boolean;
 }
 
 // `shape: "reply"` asks for the answer alone — see the server's HandoffShape.
@@ -70,7 +67,7 @@ export async function fetchLastTurn(source: HandoffSource, shape: "exchange" | "
     const data: unknown = await res.json();
     if (!isRecord(data)) return { prompt: null, reply: null, text: "" };
     const str = (v: unknown): string | null => (typeof v === "string" ? v : null);
-    return { prompt: str(data.prompt), reply: str(data.reply), text: str(data.text) ?? "", tooLarge: data.tooLarge === true };
+    return { prompt: str(data.prompt), reply: str(data.reply), text: str(data.text) ?? "" };
   } finally {
     clearTimeout(timer);
   }

--- a/test/src/components/codeBlockCopy.spec.ts
+++ b/test/src/components/codeBlockCopy.spec.ts
@@ -20,12 +20,6 @@ describe("copyOutcomeFor", () => {
     expect(copyOutcomeFor({ reply: "I changed three files and pushed." })).toEqual({ kind: "no-code" });
   });
 
-  // The size refusal rides on the same response as the turn, and the reply it comes with is
-  // necessarily empty — so it has to be read FIRST or it reads as "no completed turn".
-  it("reports too-large ahead of the empty reply that comes with it", () => {
-    expect(copyOutcomeFor({ reply: null, tooLarge: true })).toEqual({ kind: "too-large" });
-  });
-
   it.each([
     ["a session with nothing on disk yet", null],
     ["an empty reply", ""],
@@ -37,15 +31,12 @@ describe("copyOutcomeFor", () => {
 describe("copyOutcomeMessage", () => {
   // Every outcome must say something. A missing case would surface as an empty toast, which is
   // exactly the "the button does nothing" complaint this feature is meant to avoid.
-  it.each<CopyOutcome>([{ kind: "ok", text: "x", lang: null }, { kind: "no-code" }, { kind: "too-large" }, { kind: "no-turn" }])(
-    "has a message for %o",
-    (outcome) => {
-      expect(copyOutcomeMessage(outcome).length).toBeGreaterThan(0);
-    },
-  );
+  it.each<CopyOutcome>([{ kind: "ok", text: "x", lang: null }, { kind: "no-code" }, { kind: "no-turn" }])("has a message for %o", (outcome) => {
+    expect(copyOutcomeMessage(outcome).length).toBeGreaterThan(0);
+  });
 
   it("does not call any of them a failure — none is something a retry fixes", () => {
-    const messages = (["no-code", "too-large", "no-turn"] as const).map((kind) => copyOutcomeMessage({ kind }));
+    const messages = (["no-code", "no-turn"] as const).map((kind) => copyOutcomeMessage({ kind }));
     messages.forEach((m) => expect(m.toLowerCase()).not.toContain("error"));
   });
 });
@@ -69,7 +60,7 @@ describe("the manual-copy dialog", () => {
   const withoutClipboard = async () => {
     vi.stubGlobal("navigator", { ...navigator, clipboard: undefined });
     vi.doMock("../../../src/composables/useHandoff", () => ({
-      fetchLastTurn: async () => ({ prompt: null, reply: REPLY, text: "", tooLarge: false }),
+      fetchLastTurn: async () => ({ prompt: null, reply: REPLY, text: "" }),
     }));
     const { default: CopyCodeBlock } = await import("../../../src/components/CopyCodeBlock.vue");
     const w = mount(CopyCodeBlock, { props: { sessionId: "s", cwd: "/x", agent: "claude" as const } });


### PR DESCRIPTION
## Summary

`#998` で last-turn が「ファイル全体」から「末尾 256 KB だけ」を読む形になった時点で、**サイズ上限という概念自体が要らなくなっていました**。`session-reads.ts` のコメントが自分でそう書いています:

> `LAST_TURN_MAX_BYTES` / `tooLarge` are consequently dead as a limit. They stay for now because `tooLarge` reaches the UI (useHandoff, codeBlockCopy) and removing a wire field is its own change; nothing sets it any more.

その「its own change」がこの PR です。**-49 / +15 行。**

production で `tooLarge` を立てている場所は 1 つもありませんでした。にもかかわらず UI には**到達不能な `CopyOutcome` `"too-large"`** が残っていて、テストもその到達不能分岐を assert していました。

| ファイル | 落としたもの |
|---|---|
| `server/session/last-turn.ts` | wire の `tooLarge?: true` |
| `server/session/session-reads.ts` | `LAST_TURN_MAX_BYTES` と保留コメント |
| `src/composables/useHandoff.ts` | `FetchedTurn.tooLarge` とそのパース |
| `src/components/codeBlockCopy.ts` | `"too-large"` variant / 分岐 / メッセージ、および**それを運ぶためだけに在った `turnOf` アダプタ** |
| `src/components/CopyCodeBlock.vue` | `turnOf` 経由をやめ `copyOutcomeFor(turn)` を直接呼ぶ |
| `test/src/components/codeBlockCopy.spec.ts` | 到達不能ケースと、2 つの網羅リストから `"too-large"` |

## Items to Confirm / Review

**`tooLarge` / `"too-large"` という名前は、この repo に 3 つあります。触ったのは 1 つだけです。**

| | 状態 | 扱い |
|---|---|---|
| `last-turn` の `tooLarge` | 死んでいる | **これを消した** |
| `rawServingPlan.ts` / `files.ts` の `tooLarge`（`size > cap` で大きすぎるファイルの配信を断る） | **生きている・spec 6 ケース** | 触っていない |
| `remoteView` の `kind: "too-large"`（`remoteViewFailureMessage` / `mutateStatus`） | **生きている・spec あり** | 触っていない |

grep で一括置換していたらファイル配信とリモートビューが壊れていました。撤去後に `grep -rn tooLarge` を回して、残っているのが上記 2 つ（とその spec）だけであることを確認しています。

`turnOf` の削除も見てほしい点です。`tooLarge` を通すためだけのアダプタになっていたので、`FetchedTurn` をそのまま `copyOutcomeFor` に渡せるようになりました（呼び出し側は `CopyCodeBlock.vue` の 1 箇所のみ、spec なし）。

## 副次的な効果

`yarn knip` の未使用 export が **4 件 → 3 件** に減りました（`LAST_TURN_MAX_BYTES` が消えたため）。残り 3 件は #1128 で扱います。

## 検証

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` すべて緑。
- `yarn test` **6493 passed**（削除した到達不能ケースの分だけ 6495 から 2 件減）。
- 撤去範囲は「grep して出たものを消す」のではなく、**誰が立てているか**を先に確認しました（`grep -rn "tooLarge: true\|tooLarge = true" server src common` → 0 件）。立てる側が無いことが撤去の根拠です。

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
