### PR TITLE
chore: knip の未使用 export を片付ける (#1128)

### DIFF
--- a/common/fileWriteChannel.ts
+++ b/common/fileWriteChannel.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "./isRecord.js";
+
 // The pub/sub channel carrying "an agent just wrote this file". Both sides decide from it —
 // the server publishes, the editor listens to know its open file moved under it — so the name
 // and the payload shape live here rather than as a string literal on each side.
@@ -7,3 +9,7 @@ export const FILE_WRITE_CHANNEL = "file-write";
 export interface FileWriteEvent {
   file: string;
 }
+
+/** Both sides go through this rather than re-spelling `{ file: string }`: the publisher pins its
+ *  payload with `satisfies`, the subscriber narrows an untyped pub/sub frame with it. */
+export const isFileWriteEvent = (data: unknown): data is FileWriteEvent => isRecord(data) && typeof data.file === "string";

--- a/common/sessionAgent.ts
+++ b/common/sessionAgent.ts
@@ -17,13 +17,3 @@ export type TerminalAgent = (typeof TERMINAL_AGENTS)[number];
 // Validated rather than cast: anything unrecognised is Claude, which is also what an older
 // persisted cell (written before the field existed) means.
 export const asTerminalAgent = (value: unknown): TerminalAgent => (TERMINAL_AGENTS.some((agent) => agent === value) ? (value as TerminalAgent) : "claude");
-
-// A cell / connection / header button carries its agent as booleans, because Claude is the
-// default and the default is the absence of a flag. One function turns them back into the name,
-// so the precedence lives in one place rather than in a ternary repeated at every call site —
-// and adding a fourth agent is one edit here.
-export function terminalAgent(flags: { codex?: boolean | null; antigravity?: boolean | null }): TerminalAgent {
-  if (flags.antigravity) return "antigravity";
-  if (flags.codex) return "codex";
-  return "claude";
-}

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -50,7 +50,7 @@ import { mountTranslationRoutes } from "../backends/translation.js";
 import { mountHtmlDispatchRoute, mountHtmlFileRoute, mountHtmlPreviewRoute } from "../backends/html.js";
 import { mountMulmoScriptDispatchRoute, mountMulmoScriptMediaRoute } from "../backends/mulmoscript.js";
 import { CLAUDE_CWD, MULMOTERMINAL_HOME, PORT, SESSION_ID_RE } from "../config/env.js";
-import { FILE_WRITE_CHANNEL } from "../../common/fileWriteChannel.js";
+import { FILE_WRITE_CHANNEL, type FileWriteEvent } from "../../common/fileWriteChannel.js";
 import { resolveWorkspace } from "../config/workspace.js";
 import type { createToolStores } from "../session/tool-store.js";
 import type { createClaudeSpawner } from "../session/spawn-claude.js";
@@ -249,7 +249,7 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
     recordToolCallStart: deps.toolStores.recordToolCallStart,
     recordToolCallEnd: deps.toolStores.recordToolCallEnd,
     publishDirConfig: (cwd) => deps.publish(DIR_CONFIG_CHANNEL, { cwd }),
-    publishFileWrite: (file) => deps.publish(FILE_WRITE_CHANNEL, { file }),
+    publishFileWrite: (file) => deps.publish(FILE_WRITE_CHANNEL, { file } satisfies FileWriteEvent),
     // Express serves the built SPA on PORT; under `yarn dev` the UI is Vite's own server,
     // whose port the backend only knows when CLIENT_PORT is set in its environment.
     uiPort: String(process.env.CLIENT_PORT || PORT),

--- a/server/session/tmux-size-sync.ts
+++ b/server/session/tmux-size-sync.ts
@@ -180,5 +180,3 @@ export function createTmuxSizeSync(deps: TmuxSizeSyncDeps) {
   // rather than asserted in a comment — nothing in the app reads it.
   return { requestCheck, cancel, forget, trackedSessionCount: tickets.size };
 }
-
-export type TmuxSizeSync = ReturnType<typeof createTmuxSizeSync>;

--- a/src/components/FilesPane.vue
+++ b/src/components/FilesPane.vue
@@ -12,8 +12,7 @@ import { createEditor, langKindForFilename, type CmEditor } from "./cmEditor";
 import { expandedPaths, restoreOrder } from "./filesTreeState";
 import { isWriteToOpenFile } from "../composables/fileWriteMatch";
 import { usePubSub } from "../composables/usePubSub";
-import { FILE_WRITE_CHANNEL } from "../../common/fileWriteChannel";
-import { isRecord } from "../../common/isRecord";
+import { FILE_WRITE_CHANNEL, isFileWriteEvent } from "../../common/fileWriteChannel";
 
 interface Node {
   name: string;
@@ -309,7 +308,7 @@ async function checkForExternalChange(): Promise<void> {
 function watchExternalChanges(): () => void {
   externalTimer = setInterval(checkForExternalChange, EXTERNAL_CHECK_MS);
   const unsubscribe = usePubSub().subscribe(FILE_WRITE_CHANNEL, (data) => {
-    if (isRecord(data) && typeof data.file === "string" && isWriteToOpenFile(data.file, props.cwd, openPath.value)) checkForExternalChange();
+    if (isFileWriteEvent(data) && isWriteToOpenFile(data.file, props.cwd, openPath.value)) checkForExternalChange();
   });
   return () => {
     if (externalTimer !== null) clearInterval(externalTimer);


### PR DESCRIPTION
## Summary

`yarn knip` が報告していた未使用 export を、**1 件ずつ確認して消すもの / 使う側に回すものに分けました**。

| export | 判断 |
|---|---|
| `common/sessionAgent.ts` の `terminalAgent` | **削除** |
| `server/session/tmux-size-sync.ts` の `TmuxSizeSync` | **削除** |
| `common/fileWriteChannel.ts` の `FileWriteEvent` | **残して、両側から使うようにした** |
| `LAST_TURN_MAX_BYTES` | #1123 (PR #1132) の範囲 |

この 2 つが merge されると knip の未使用 export は **0 件**になります。

## Items to Confirm / Review

**`FileWriteEvent` だけ「消す」ではなく「使う」にしています。** ここが一番見てほしい判断です。

`common/fileWriteChannel.ts` は自分でこう書いています:

> Both sides decide from it — the server publishes, the editor listens to know its open file moved under it — **so the name and the payload shape live here** rather than as a string literal on each side.

ところが実際は、payload の shape を**両側が各自で書いていました**:

- publisher (`app-routes.ts:252`): `deps.publish(FILE_WRITE_CHANNEL, { file })`
- subscriber (`FilesPane.vue:312`): `isRecord(data) && typeof data.file === "string"`

つまり `FileWriteEvent` が未使用なのは「不要だから」ではなく「**使い忘れているから**」でした。消すとコメントが嘘になるので、`isFileWriteEvent` ガードを足して両側を通しました（publisher は `satisfies`、subscriber はそのガードで narrow）。`CLAUDE.md` の `common/` の規則（両側が決めるものは `common/` に置く）にも合います。

副次的に `FilesPane.vue` の `isRecord` import が不要になったので落としています。

**`terminalAgent` の削除は、消す前に「再実装が無いか」を確認しています。** この関数のコメントが「so the precedence lives in one place rather than in a ternary repeated at every call site」と書いていたので、呼び出しが消えただけで**三項演算子が call site に散っている**なら削除ではなく復帰が正解でした。grep した結果そういう箇所は無く、実際に使われているのは兄弟の `asTerminalAgent`（13 箇所）でした。

## 検証

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` すべて緑。`yarn test` **6495 passed**。
- `yarn knip` はこのブランチで **`LAST_TURN_MAX_BYTES` の 1 件のみ**（#1132 で消える）。

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
