### PR TITLE
refactor: remoteHost/handlers.ts を 1 ハンドラ 1 ファイルに分ける (#1124)

### DIFF
--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -7,7 +7,7 @@ so nothing in `README.md`'s `/api/*` table describes it.
 
 This page is the contract between the two: **every command the host answers, the shapes it
 answers with, and the rules that decide what belongs on which side.** Written because three
-features in a row (#830, #831, #832) each had to re-derive them by reading `handlers.ts`.
+features in a row (#830, #831, #832) each had to re-derive them by reading the handlers.
 
 > Adding or changing a command? Update this page in the same commit, and file the matching
 > issue on `receptron/mulmoserver` — the phone ignores a field it was never taught about, so a
@@ -28,8 +28,9 @@ account, subscribes to a per-user command channel, and answers each doc it sees.
 
 ## Commands
 
-Handlers live in `server/backends/remoteHost/handlers.ts`; the terminal ones are grouped in
-`terminalScreenHandlers`.
+Handlers live in `server/backends/remoteHost/handlers/`, one file per command (the same layout
+MulmoClaude uses); `handlers/index.ts` is the table that names them all, and the terminal ones are
+grouped in `handlers/terminalSession.ts`.
 
 | Command | Params | Answers |
 |---|---|---|
@@ -99,7 +100,7 @@ would mislabel it.
 ## The rules that keep coming up
 
 **`SessionScreen` is the wire shape.** A field added to it reaches the phone without touching
-`handlers.ts` — that is stated in the handler's own comment and is the intended extension
+the handler — that is stated in the handler's own comment and is the intended extension
 point. Adding a command is the exception, not the rule.
 
 **The host decides; the phone renders.** `quickCommands` is filtered to the session's kind
@@ -143,7 +144,7 @@ Consequences the phone has to live with:
 
 | Concern | File |
 |---|---|
-| Command handlers | `server/backends/remoteHost/handlers.ts` |
+| Command handlers | `server/backends/remoteHost/handlers/` (one file per command; `index.ts` is the table) |
 | Session list + screen assembly | `server/backends/remoteHost/terminalScreen.ts` |
 | Typing into a session (sanitize, bracketed paste, Enter timing) | `server/backends/remoteHost/terminalInput.ts` |
 | Quick-command scoping | `server/backends/remoteHost/quickCommands.ts` |

--- a/server/backends/feed-summary.ts
+++ b/server/backends/feed-summary.ts
@@ -1,6 +1,6 @@
 // One feeds-index row, from a registered feed's schema and its last-fetch state.
 //
-// The desktop route (feeds.ts) and the phone command channel (remoteHost/handlers.ts) both
+// The desktop route (feeds.ts) and the phone command channel (remoteHost/handlers/) both
 // build this, and both had their own copy of the same defaulting: a feed that declares no
 // `ingest` block still shows a kind and a schedule, `"rss"` and `"on-demand"`. Two copies
 // documented as mirrors is how they drift — the two surfaces would then disagree on a feed's

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { listFeeds } from "@mulmoclaude/core/feeds/server";
-import { createRemoteHostHandlers } from "./handlers.js";
+import { createRemoteHostHandlers } from "./handlers/index.js";
 import { initCollectionsBackend } from "../collections.js";
 
 // Only listFeeds is stubbed; listItems/toDetail/deriveItems/pageResult stay real.

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { createRemoteHostHandlers } from "./handlers.js";
+import { createRemoteHostHandlers } from "./handlers/index.js";
 import type { SessionScreen } from "./terminalScreen.js";
 import { initCollectionsBackend } from "../collections.js";
 

--- a/server/backends/remoteHost/handlers/deps.ts
+++ b/server/backends/remoteHost/handlers/deps.ts
@@ -1,0 +1,38 @@
+// What the remote-host handlers need from the process around them.
+//
+// MulmoClaude's handler table is a static const, because its handlers reach their engines through
+// module-level imports. Ours cannot be: the workspace, the chat spawner, the attachment ingester
+// and every terminal accessor are wired in server/index.ts, where the PTY table lives. So this
+// host keeps a FACTORY (see ./index.ts) and passes deps down — a deliberate divergence from the
+// reference host, forced by where the state lives rather than by taste.
+import type { IngestResult } from "../ingestAttachments.js";
+import type { SessionScreen, TerminalSessionSummary } from "../terminalScreen.js";
+
+export interface RemoteHostHandlerDeps {
+  workspace: string;
+  // Start a visible chat seeded with `message`; returns the new session id.
+  spawnChat: (message: string) => { chatId: string };
+  // Download the phone's staged uploads (by storage_id) into the workspace and return
+  // path-only attachments plus a deferred staging cleanup (remoteHost/ingestAttachments.ts).
+  ingest: (storageIds: string[]) => Promise<IngestResult>;
+  // The phone's remote terminal view (#435) — the picker's list and one session's
+  // current screen. Wired in server/index.ts, where the PTY table lives.
+  listTerminalSessions: () => Promise<TerminalSessionSummary[]>;
+  captureTerminalScreen: (sessionId: string) => Promise<SessionScreen>;
+  // Type into one session's live PTY (#445). Returns false when no PTY is attached
+  // in this process — a tmux session that outlived a restart stays viewable but not
+  // writable from here.
+  writeToSession: (sessionId: string, chunk: string) => boolean;
+  // Whether typing may empty the session's input box first, so only the phone's text
+  // is submitted (#572). Answered in server/index.ts, where the agent kind and the
+  // turn state live.
+  canClearBox: (sessionId: string) => boolean;
+  // The byte(s) that submit for a given session (#772), read live from config. The phone
+  // sends only text; which byte commits it is the host's Claude binding — but only for a
+  // Claude session, so this is resolved per session id (shell/codex stay on plain CR).
+  submitSequence: (sessionId: string) => string;
+  // Open a new grid terminal in the directory of the session the phone is looking at
+  // (#831). Answered in server/index.ts, which owns the PTY table and the pub/sub the
+  // grid listens on. Resolves to an error string when it could not be started.
+  launchTerminal: (agent: unknown, sessionId: unknown) => { ok: true } | { ok: false; error: string };
+}

--- a/server/backends/remoteHost/handlers/getCollection.ts
+++ b/server/backends/remoteHost/handlers/getCollection.ts
@@ -1,0 +1,17 @@
+// getCollection command handler.
+//
+// One collection's detail + a PAGE of its records (pagination mandatory — the result
+// rides inside a 1 MiB Firestore command doc).
+import { listItems, loadCollection, toDetail } from "@mulmoclaude/core/collection/server";
+import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
+import { clampLimit, clampOffset, deriveItems, pageResult } from "../collectionPage.js";
+
+export const getCollection: CommandHandlers["getCollection"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const offset = clampOffset(params.offset);
+  const limit = clampLimit(params.limit);
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const all = deriveItems(collection.schema, await listItems(collection.dataDir));
+  return pageResult(toDetail(collection), all, offset, limit);
+};

--- a/server/backends/remoteHost/handlers/getFeed.ts
+++ b/server/backends/remoteHost/handlers/getFeed.ts
@@ -1,0 +1,22 @@
+// getFeed command handler.
+//
+// One feed's detail + a PAGE of its records. A feed IS a LoadedCollection with an `ingest` block,
+// located via the feed registry (feeds live under their own registry, not the collections dir), so
+// this reuses the exact collection page path and returns the SAME shape as getCollection — the
+// phone renders feed records with the same card view.
+import { listItems, toDetail } from "@mulmoclaude/core/collection/server";
+import { listFeeds } from "@mulmoclaude/core/feeds/server";
+import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
+import { clampLimit, clampOffset, deriveItems, pageResult } from "../collectionPage.js";
+
+export const createGetFeed =
+  (workspace: string): CommandHandlers["getFeed"] =>
+  async (params: JsonObject) => {
+    const slug = String(params.slug ?? "");
+    const offset = clampOffset(params.offset);
+    const limit = clampLimit(params.limit);
+    const feed = (await listFeeds(workspace)).find((entry) => entry.slug === slug);
+    if (!feed) throw new Error(`feed '${slug}' not found`);
+    const all = deriveItems(feed.schema, await listItems(feed.dataDir));
+    return pageResult(toDetail(feed), all, offset, limit);
+  };

--- a/server/backends/remoteHost/handlers/getRemoteView.ts
+++ b/server/backends/remoteHost/handlers/getRemoteView.ts
@@ -1,0 +1,18 @@
+// getRemoteView command handler.
+//
+// One mobile custom view, wrapped host-side into its sandboxed srcdoc (CSP +
+// postMessage bootstrap) — the phone renders the artifact verbatim.
+import { loadCollection } from "@mulmoclaude/core/collection/server";
+import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
+import { buildRemoteView, remoteViewFailureMessage } from "../../remoteView.js";
+
+export const getRemoteView: CommandHandlers["getRemoteView"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const viewId = String(params.viewId ?? "");
+  const locale = typeof params.locale === "string" ? params.locale : "";
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const result = await buildRemoteView(collection, viewId, locale);
+  if (result.kind !== "ok") throw new Error(remoteViewFailureMessage(result, slug));
+  return toJsonObject({ view: result.view, srcdoc: result.srcdoc, bytes: result.bytes });
+};

--- a/server/backends/remoteHost/handlers/getRemoteViewItems.ts
+++ b/server/backends/remoteHost/handlers/getRemoteViewItems.ts
@@ -1,0 +1,27 @@
+// getRemoteViewItems command handler.
+//
+// One page of a mobile view's records, projected to the view's fields. Image fields are
+// NOT inlined on this host yet (no thumbnail store) — they come back as workspace paths
+// (unrenderable on the phone) and count as `omitted`.
+import { loadCollection } from "@mulmoclaude/core/collection/server";
+import { normalizeFields } from "@mulmoclaude/core/remote-view";
+import type { CommandHandlers, JsonObject } from "@mulmoclaude/core/remote-host";
+import { clampLimit, clampOffset } from "../collectionPage.js";
+import { remoteViewItems, remoteViewItemsFailureMessage } from "../../remoteView.js";
+
+export const getRemoteViewItems: CommandHandlers["getRemoteViewItems"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const viewId = String(params.viewId ?? "");
+  const fields = normalizeFields(params.fields);
+  const request = { offset: clampOffset(params.offset), limit: clampLimit(params.limit), ...(fields ? { fields } : {}) };
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const result = await remoteViewItems(collection, viewId, request);
+  if (result.kind !== "ok") throw new Error(remoteViewItemsFailureMessage(result, slug));
+  // `toJsonObject` cannot serve this one, and neither can a single assertion: `RemoteViewPage` has
+  // no index signature at all, so it does not even overlap `JsonObject`. It IS JSON at runtime —
+  // the collection loader only ever puts JSON in it — a fact about the loader these types do not
+  // record. Removing this double cast means giving `RemoteViewPage`/`RemoteViewItem` JSON-valued
+  // types upstream, not adjusting anything here.
+  return { page: result.page, inlined: result.inlined, omitted: result.omitted } as unknown as JsonObject;
+};

--- a/server/backends/remoteHost/handlers/index.ts
+++ b/server/backends/remoteHost/handlers/index.ts
@@ -1,0 +1,62 @@
+// Command-handler table for MulmoTerminal's remote host — the single place the runner learns
+// which methods it serves. Add a capability by importing its handler and adding it here.
+//
+// A FACTORY rather than MulmoClaude's static `handlers` const: this host's deps (workspace, chat
+// spawner, attachment ingester, PTY accessors) are wired in server/index.ts. See ./deps.ts.
+//
+// ── DOCS ──────────────────────────────────────────────────────────────────────
+// The command surface and its wire shapes are documented for the phone's authors
+// in docs/remote-host-protocol.md. Add or change a command and update it in the
+// same commit, then file the matching issue on receptron/mulmoserver — the phone
+// ignores a field it was never taught about, so a host-only change ships as
+// silence rather than as a feature.
+// ──────────────────────────────────────────────────────────────────────────────
+import type { CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { googleCalendarColors, googleCalendarCreateEvent, googleCalendarListCalendars, googleCalendarListEvents } from "../googleCalendar.js";
+import { getCollection } from "./getCollection.js";
+import { createGetFeed } from "./getFeed.js";
+import { getRemoteView } from "./getRemoteView.js";
+import { getRemoteViewItems } from "./getRemoteViewItems.js";
+import { createListAccountingBooks } from "./listAccountingBooks.js";
+import { listCollections } from "./listCollections.js";
+import { createListFeeds } from "./listFeeds.js";
+import { createListShortcuts } from "./listShortcuts.js";
+import { createListSkills } from "./listSkills.js";
+import { mutateRemoteViewItem } from "./mutateRemoteView.js";
+import { createStartChat } from "./startChat.js";
+import { createTerminalSessionHandlers } from "./terminalSession.js";
+import type { RemoteHostHandlerDeps } from "./deps.js";
+
+export type { RemoteHostHandlerDeps } from "./deps.js";
+
+export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHandlers {
+  const { workspace } = deps;
+
+  return {
+    listCollections,
+    getCollection,
+    getRemoteView,
+    getRemoteViewItems,
+    mutateRemoteViewItem,
+
+    // Google Calendar, run host-side against the locally linked account. These
+    // are advertised as capabilities unconditionally: linking is a host-machine
+    // action (`mulmoterminal google login`), so a not-linked error is the only
+    // way the phone can learn it needs to be run.
+    "google.calendar.createEvent": googleCalendarCreateEvent,
+    "google.calendar.listEvents": googleCalendarListEvents,
+    // Non-primary calendars + colour palettes (core 0.23). listCalendars needs the
+    // calendar-list read scope, so an existing link errors until the user re-authorizes.
+    "google.calendar.listCalendars": googleCalendarListCalendars,
+    "google.calendar.colors": googleCalendarColors,
+
+    listFeeds: createListFeeds(workspace),
+    getFeed: createGetFeed(workspace),
+    listShortcuts: createListShortcuts(workspace),
+    listSkills: createListSkills(workspace),
+    listAccountingBooks: createListAccountingBooks(workspace),
+    startChat: createStartChat(deps),
+
+    ...createTerminalSessionHandlers(deps),
+  };
+}

--- a/server/backends/remoteHost/handlers/listAccountingBooks.ts
+++ b/server/backends/remoteHost/handlers/listAccountingBooks.ts
@@ -1,0 +1,12 @@
+// listAccountingBooks command handler.
+//
+// { id, name } per accounting book, for a mobile book picker.
+import { listBooks } from "@mulmoclaude/accounting-plugin/server";
+import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+
+export const createListAccountingBooks =
+  (workspace: string): CommandHandlers["listAccountingBooks"] =>
+  async () => {
+    const { books } = await listBooks(workspace);
+    return toJsonObject({ books: books.map((book) => ({ id: book.id, name: book.name })) });
+  };

--- a/server/backends/remoteHost/handlers/listCollections.ts
+++ b/server/backends/remoteHost/handlers/listCollections.ts
@@ -1,0 +1,11 @@
+// listCollections command handler.
+//
+// Mirrors GET /api/collections/list → { collections: CollectionSummary[] }. Feeds
+// (source "feed") are excluded — they are served by listFeeds.
+import { discoverCollections, toSummary } from "@mulmoclaude/core/collection/server";
+import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+
+export const listCollections: CommandHandlers["listCollections"] = async () => {
+  const collections = (await discoverCollections()).filter((collection) => collection.source !== "feed").map(toSummary);
+  return toJsonObject({ collections });
+};

--- a/server/backends/remoteHost/handlers/listFeeds.ts
+++ b/server/backends/remoteHost/handlers/listFeeds.ts
@@ -1,0 +1,18 @@
+// listFeeds command handler.
+//
+// Feed registry with retrieval kind / schedule / last-fetch time (read-only).
+import { listFeeds, readFeedState } from "@mulmoclaude/core/feeds/server";
+import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { feedSummary } from "../../feed-summary.js";
+
+export const createListFeeds =
+  (workspace: string): CommandHandlers["listFeeds"] =>
+  async () => {
+    const feeds = await listFeeds(workspace);
+    const summaries = [];
+    for (const feed of feeds) {
+      const state = await readFeedState(workspace, feed);
+      summaries.push(feedSummary(feed, state.lastFetchedAt));
+    }
+    return toJsonObject({ feeds: summaries });
+  };

--- a/server/backends/remoteHost/handlers/listShortcuts.ts
+++ b/server/backends/remoteHost/handlers/listShortcuts.ts
@@ -1,0 +1,10 @@
+// listShortcuts command handler.
+//
+// Pinned launcher shortcuts (favorites), read-only.
+import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { readShortcuts } from "../../shortcuts.js";
+
+export const createListShortcuts =
+  (workspace: string): CommandHandlers["listShortcuts"] =>
+  async () =>
+    toJsonObject({ shortcuts: await readShortcuts(workspace) });

--- a/server/backends/remoteHost/handlers/listSkills.ts
+++ b/server/backends/remoteHost/handlers/listSkills.ts
@@ -1,0 +1,16 @@
+// listSkills command handler.
+//
+// Discoverable skill ids (~/.claude/skills + <workspace>/.claude/skills), read-only. Collection
+// slugs are subtracted — a skill dir that ships a schema.json is a collection served by
+// listCollections, so it must not double-list here (mirrors MulmoClaude's listSkills).
+import { discoverCollections } from "@mulmoclaude/core/collection/server";
+import { toJsonObject, type CommandHandlers } from "@mulmoclaude/core/remote-host";
+import { discoverSkillNames } from "../skills.js";
+
+export const createListSkills =
+  (workspace: string): CommandHandlers["listSkills"] =>
+  async () => {
+    const [names, collections] = await Promise.all([discoverSkillNames({ workspaceRoot: workspace }), discoverCollections()]);
+    const collectionSlugs = new Set(collections.filter((collection) => collection.source !== "feed").map((collection) => collection.slug));
+    return toJsonObject({ skills: names.filter((name) => !collectionSlugs.has(name)) });
+  };

--- a/server/backends/remoteHost/handlers/mutateRemoteView.ts
+++ b/server/backends/remoteHost/handlers/mutateRemoteView.ts
@@ -1,0 +1,29 @@
+// mutateRemoteViewItem command handler.
+//
+// Apply one update/delete requested by a writable mobile view, authorized by that view's
+// declared surface (editableFields / allowDelete) and enforced HOST-side — the sandboxed
+// view is never trusted.
+import { loadCollection } from "@mulmoclaude/core/collection/server";
+import { normalizeMutate } from "@mulmoclaude/core/remote-view";
+import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
+import { mutateRemoteView, mutateRemoteViewFailureMessage } from "../../remoteView.js";
+import { mutateWriteApplied } from "../../mutateStatus.js";
+
+export const mutateRemoteViewItem: CommandHandlers["mutateRemoteViewItem"] = async (params: JsonObject) => {
+  const slug = String(params.slug ?? "");
+  const viewId = String(params.viewId ?? "");
+  const request = normalizeMutate({ op: params.op, id: params.id, patch: params.patch });
+  if (!request) throw new Error("invalid mutate request — expected { op: 'update'|'delete', id, patch? }");
+  const collection = await loadCollection(slug);
+  if (!collection) throw new Error(`collection '${slug}' not found`);
+  const result = await mutateRemoteView(collection, viewId, request);
+  // The write applied but its response blew the byte budget — report success (+refetch),
+  // not a thrown error the phone shows as a failed edit while keeping stale data (#747).
+  if (mutateWriteApplied(result)) {
+    return toJsonObject({ op: request.op, id: request.id, applied: true, warning: mutateRemoteViewFailureMessage(result, slug) });
+  }
+  if (result.kind !== "ok") throw new Error(mutateRemoteViewFailureMessage(result, slug));
+  // Same reason as getRemoteViewItems: `CollectionItem`'s `unknown`-valued index signature is not
+  // provably JSON, though the loader only ever writes JSON into it.
+  return (result.op === "delete" ? { op: "delete", id: result.id } : { op: "update", item: result.item }) as JsonObject;
+};

--- a/server/backends/remoteHost/handlers/startChat.ts
+++ b/server/backends/remoteHost/handlers/startChat.ts
@@ -1,0 +1,51 @@
+// startChat command handler.
+//
+// Start a visible chat from the phone, seeded with `message`. This host has no roles, so a `role`
+// param is ignored. Optional `attachments` ([{ storage_id }]) are downloaded into the workspace and
+// referenced by path in the seeded prompt (the PTY claude reads them via its Read tool). Ingest
+// BEFORE spawning so a download failure rejects the command instead of starting a chat missing its
+// files.
+import { type CommandHandlers, type JsonObject, type JsonValue } from "@mulmoclaude/core/remote-host";
+import type { Attachment } from "../ingestAttachments.js";
+import type { RemoteHostHandlerDeps } from "./deps.js";
+
+// Parse the optional `attachments` param ([{ storage_id }]) into storage ids. A malformed shape
+// rejects the whole command: the remote already uploaded the bytes and is waiting, so a surfaced
+// error beats a chat missing its file.
+const readStorageIds = (attachments: JsonValue | undefined): string[] => {
+  if (attachments == null) return [];
+  if (!Array.isArray(attachments)) throw new Error("attachments must be an array of { storage_id }");
+  return attachments.map((entry) => {
+    const storageId = entry && typeof entry === "object" && !Array.isArray(entry) ? entry.storage_id : undefined;
+    if (typeof storageId !== "string" || storageId.length === 0) throw new Error("each attachments entry must be { storage_id: string }");
+    return storageId;
+  });
+};
+
+// The PTY-driven `claude` can't take image content blocks, so reference the saved files by their
+// workspace path in the seeded prompt — claude reads them with its Read tool (its cwd is the
+// workspace).
+const composeMessage = (message: string, attachments: Attachment[]): string => {
+  if (attachments.length === 0) return message;
+  const paths = attachments.map((file) => file.path).join("\n");
+  return `${message}\n\nAttached file(s) — read them from the workspace:\n${paths}`;
+};
+
+type StartChatDeps = Pick<RemoteHostHandlerDeps, "spawnChat" | "ingest">;
+
+export const createStartChat =
+  ({ spawnChat, ingest }: StartChatDeps): CommandHandlers["startChat"] =>
+  async (params: JsonObject) => {
+    const message = (typeof params.message === "string" ? params.message : "").trim();
+    if (!message) throw new Error("message is required");
+    const { attachments, cleanupStaging } = await ingest(readStorageIds(params.attachments));
+    // Spawn FIRST, reap staging only after it succeeds: a spawn failure (e.g. a missing
+    // provider token) must leave the staged uploads intact so the phone can retry the same
+    // command — deleting them before spawn would strand a retry with no bytes to re-fetch.
+    const { chatId } = spawnChat(composeMessage(message, attachments));
+    // The chat HAS started; staging cleanup is best-effort background work that must never
+    // turn a successful start into a reported failure (which the phone would retry, spawning
+    // a duplicate chat). Isolate any rejection at this boundary.
+    await cleanupStaging().catch((err) => console.warn("[remote-host] staging cleanup after startChat failed", String(err)));
+    return { started: true, chatId };
+  };

--- a/server/backends/remoteHost/handlers/terminalSession.ts
+++ b/server/backends/remoteHost/handlers/terminalSession.ts
@@ -1,0 +1,62 @@
+// The phone's remote terminal view (#435): pick a session, read its screen, and — since #445 —
+// type into it. Screens are bounded by the terminal's own geometry (rows x cols), so unlike
+// collections they need no paging to stay under the 1 MiB command-doc ceiling.
+//
+// No MulmoClaude counterpart: that host has no PTY table to look at.
+import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
+import { createTerminalInputSender } from "../terminalInput.js";
+import type { RemoteHostHandlerDeps } from "./deps.js";
+
+type TerminalSessionDeps = Pick<
+  RemoteHostHandlerDeps,
+  "listTerminalSessions" | "captureTerminalScreen" | "writeToSession" | "canClearBox" | "submitSequence" | "launchTerminal"
+>;
+
+export const createTerminalSessionHandlers = ({
+  listTerminalSessions,
+  captureTerminalScreen,
+  writeToSession,
+  canClearBox,
+  submitSequence,
+  launchTerminal,
+}: TerminalSessionDeps): CommandHandlers => {
+  // One sender per host, so its per-session ordering actually spans every command.
+  const sendInput = createTerminalInputSender({ writeToSession, canClearBox, submitSequence });
+  return {
+    listTerminalSessions: async () => toJsonObject({ sessions: await listTerminalSessions() }),
+
+    // `suggestion` is the agent's own dim ghost text — the phone offers it as a chip,
+    // since it has no Tab key to accept it with (#563). The screen also carries the
+    // session's cwd / branch / summary / prompt when the host knows them, so the phone can
+    // head the terminal with what the grid cell shows (#786); the whole SessionScreen is
+    // the wire shape, so a field added there reaches the phone without another edit here.
+    getTerminalScreen: async (params: JsonObject) => {
+      const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
+      if (!sessionId) throw new Error("sessionId is required");
+      return toJsonObject(await captureTerminalScreen(sessionId));
+    },
+
+    // Type a line into the session and press Enter, as if the user were at the
+    // keyboard. The phone sends only text; the framing, sanitizing and Enter timing
+    // are terminalInput.ts's job.
+    sendTerminalInput: async (params: JsonObject) => {
+      const sessionId = typeof params.sessionId === "string" ? params.sessionId : "";
+      if (!sessionId) throw new Error("sessionId is required");
+      const text = typeof params.text === "string" ? params.text : "";
+      return toJsonObject(await sendInput(sessionId, text));
+    },
+
+    // Open a NEW grid terminal in the directory of the session the phone is viewing (#831).
+    // The phone names the session, never a path: the host looks the directory up, so a
+    // remote client cannot choose where a process starts.
+    //
+    // Throwing rather than returning the error is what puts the reason on the phone's
+    // screen — the command layer turns a rejection into the message it shows, and the
+    // most likely failure ("no browser is open") is one the user can act on.
+    launchTerminal: async (params: JsonObject) => {
+      const result = launchTerminal(params.agent, params.sessionId);
+      if (!result.ok) throw new Error(result.error);
+      return toJsonObject({ ok: true });
+    },
+  };
+};

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -25,7 +25,7 @@ import { publish, clear, listFor } from "@mulmoclaude/core/notifier";
 
 import type { RunnerHealth } from "../../../common/remoteHostHealth.js";
 import { createHealthNotice } from "./healthNotice.js";
-import { createRemoteHostHandlers, type RemoteHostHandlerDeps } from "./handlers.js";
+import { createRemoteHostHandlers, type RemoteHostHandlerDeps } from "./handlers/index.js";
 import { createSaveAttachment } from "./attachmentStore.js";
 import { buildIngestAttachments } from "./ingestAttachments.js";
 import { onExpire } from "./onExpire.js";

--- a/server/backends/remoteView.ts
+++ b/server/backends/remoteView.ts
@@ -1,5 +1,5 @@
 // Shared mobile custom-view builder, used by BOTH the remote-host command
-// channel (remoteHost/handlers.ts → the phone) and the desktop collection routes
+// channel (remoteHost/handlers/ → the phone) and the desktop collection routes
 // (collections.ts → the phone-frame preview), so both render the identical
 // artifact (preview === phone).
 //


### PR DESCRIPTION
## Summary

`server/backends/remoteHost/handlers.ts`（**311 行 1 枚**）を `handlers/` 以下の **14 ファイル（最大 62 行）**に分けました。ファイル名は `../mulmoclaude/server/remoteHost/handlers/` に寄せてあり、**14 中 12 が同名**です。

```
handlers/
  index.ts (62)          deps.ts (38)           terminalSession.ts (62)
  startChat.ts (51)      mutateRemoteView.ts (29)  getRemoteViewItems.ts (27)
  getFeed.ts (22)        getRemoteView.ts (18)  listFeeds.ts (18)
  getCollection.ts (17)  listSkills.ts (16)     listAccountingBooks.ts (12)
  listCollections.ts (11)  listShortcuts.ts (10)
```

ロジックは一行も変えていません。移動と、それに伴う相対パスの付け替えだけです。

## Items to Confirm / Review

**MulmoClaude と意図的に違う点が 2 つあります。** `CLAUDE.md` の「Deliberate divergence is fine — say so in a comment with the reason, and flag it in the PR」に従って挙げます。

1. **静的な `handlers` const ではなく `createRemoteHostHandlers` ファクトリのまま**にしました。MulmoClaude の handlers は module レベルの import で engine に届くので静的な table にできますが、**こちらの deps は `server/index.ts` で実行時に注入されます**（`workspace` / `spawnChat` / `ingest` / PTY アクセサ群）。静的 table に寄せると本当に挙動が変わるので、寄せていません。理由は `handlers/deps.ts` の冒頭コメントに書きました。
   - deps が要るハンドラは `createXxx(deps)` を export（MulmoClaude の `createListShortcuts` と同じ命名）、要らないものは素の const。

2. **`terminalSession.ts` は MulmoClaude に対応物がありません**（あちらは PTY テーブルを持たない）。元の `terminalScreenHandlers` をそのまま持ってきて、ファイル名だけこの層の命名に合わせています。

3. `deps.ts` も MulmoClaude には無いファイルです（1 の帰結）。

## ドキュメントも同じコミットで直しています

`handlers.ts` を**名指ししていた箇所が 6 つ**あり、全部更新しました:

- `docs/remote-host-protocol.md` の 4 箇所（導入・Commands 節・拡張ポイントの説明・末尾の「Concern / File」表）
- `server/backends/remoteView.ts` と `server/backends/feed-summary.ts` のコメント各 1 箇所

`grep -rn "handlers\.ts"` で残りが無いことを確認済みです。

## 順序について

#1121（`toJsonObject` 化、PR #1130）を**先に merge してからこれをやりました**。逆順だと同じ置換が 13 ファイルに散ってコンフリクトするためです（issue にもそう書いてありました）。

## 検証

- `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` すべて緑。`yarn test` **6495 passed**（分割前と同数）。
- `yarn knip` に**新しい未使用 export は増えていません**（このブランチで出る 4 件は分割と無関係で、#1128/#1123 の PR で消えるもの）。
- import 元は 3 箇所（`index.ts` / `handlers.spec.ts` / `getFeed.spec.ts`）で、ESM はディレクトリ index を解決しないので `./handlers.js` → `./handlers/index.js` に明示的に付け替えています。

Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
