### PR TITLE
chore: ファイルサイズと dead code のガードレールを入れる (#1129)

### DIFF
--- a/.github/workflows/dead-code-scan.yaml
+++ b/.github/workflows/dead-code-scan.yaml
@@ -6,15 +6,22 @@ name: dead-code-scan
 # or a helper whose last caller was removed (exactly the class of orphan a refactor
 # leaves behind when it deletes the only call site in another module).
 #
-# Reports only — this workflow NEVER fails the build (`continue-on-error`), mirroring
-# duplication-scan.yaml:
-#   1. knip can't infer every entry point (CLI subcommands spawned via tsx, codegen),
-#      so a few false positives are expected. Blocking on day one would just train
-#      people to add `// knip-ignore` reflexively.
-#   2. knip has no base-branch diffing, so the report is the FULL current inventory,
-#      not this PR's delta. It's a review aid — a human decides whether a finding is
-#      real and whether this PR made it worse — not a gate. Revisit gating once the
-#      config is tuned enough to be trustworthy.
+# Gates on UNUSED FILES; everything else it finds is reported without failing.
+#
+# This was reports-only, on two conditions it set for itself: that the config be tuned enough
+# to be trustworthy, and that a full-inventory report (knip has no base-branch diffing) not be
+# read as this PR's delta. Both are now met — the inventory is EMPTY, so "the whole inventory"
+# and "your delta" are the same list, and `ignoreDependencies` has gone from `.*` to four named
+# entries with reasons.
+#
+# What tipped it: an orphaned file is invisible to everything else in CI. #1124 replaced a
+# 311-line module with a directory and left the old file behind; typecheck, the full test suite
+# and the build all stayed green, and only jscpd noticed (because the two copies happened to be
+# similar — a less similar orphan would have shipped unnoticed).
+#
+# Unused EXPORTS stay reporting-only: they are the finding knip is most likely to get wrong,
+# since it cannot infer every entry point (CLI subcommands spawned via tsx, codegen). Promote
+# them the same way if that stops being true.
 #
 # Config lives in `knip.jsonc`; run it locally with `yarn knip`.
 
@@ -45,7 +52,6 @@ jobs:
     name: Dead Code Scan (knip)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/dead-code-scan.yaml
+++ b/.github/workflows/dead-code-scan.yaml
@@ -65,16 +65,21 @@ jobs:
       # to be installed. `--frozen-lockfile` keeps CI honest against yarn.lock.
       - run: yarn install --frozen-lockfile --network-timeout 120000
 
-      # `|| true`: knip exits non-zero when it finds anything, and this workflow is
-      # report-only. The report goes to the PR job summary.
+      # knip's exit code is captured rather than swallowed, and rather than left to decide the
+      # step on its own: the summary has to be written EITHER WAY (a failing job is exactly when
+      # someone wants to read what it found), and a `{ ... } >> $GITHUB_STEP_SUMMARY` block ends
+      # with printf's status, so the knip result would be lost even without a `|| true`.
       - name: Run knip
         run: |
           set -uo pipefail
+          knip_status=0
+          output=$(yarn --silent knip --reporter compact 2>&1) || knip_status=$?
           {
             printf '## Dead code scan (knip)\n\n'
-            printf 'Unused exports / files below. Report-only — a human decides what is\n'
-            printf 'real. See .github/workflows/dead-code-scan.yaml.\n\n'
+            printf 'An unused FILE fails this job. Everything else below is reported for a human\n'
+            printf 'to judge. See .github/workflows/dead-code-scan.yaml.\n\n'
             printf '```\n'
-            yarn --silent knip --reporter compact 2>&1 || true
+            printf '%s\n' "$output"
             printf '```\n'
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$knip_status"

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,7 +78,14 @@ export default [
     // (error@15). All ERRORS (enforced going forward) except max-params, which stays WARN
     // for its one intentional offender: spawnClaudePty's 7 params (hot path, not worth
     // churning 5 call sites into an options object) — flip it to error once resolved.
+    //
+    // max-lines is per FILE and was the gap: the per-function guards were all passing while
+    // TerminalCell.vue reached 2000 lines, because nothing was watching the file. Counted
+    // without comments, which is why the three heavily-documented 800+ line files
+    // (useTerminalConnections.ts, server/index.ts, collections.ts) are already under it —
+    // long because they explain themselves, not because they do too much.
     rules: {
+      "max-lines": ["error", { max: 600, skipBlankLines: true, skipComments: true }],
       "max-lines-per-function": ["error", { max: 60, skipBlankLines: true, skipComments: true, IIFEs: true }],
       complexity: ["error", 20],
       "max-depth": ["error", 4],
@@ -112,11 +119,30 @@ export default [
     rules: {
       "max-lines-per-function": "off",
       "max-nested-callbacks": "off",
+      // The FILE limit still applies here, but as a warning: a 1900-line spec is worth
+      // seeing, and yet splitting one moves assertions away from each other — the same
+      // trade-off the paragraph below describes for stubs. Warn says so without making a
+      // long-standing spec block anyone's CI.
+      "max-lines": ["warn", { max: 600, skipBlankLines: true, skipComments: true }],
       // Same reasoning for components: a spec defines throwaway stubs next to the case that
       // uses them (useCaptureKeydown, useNewTerminal). Splitting one-line stubs into their own
       // files would put the fixture further from the assertion, which is the opposite of what
       // the rule is for — it exists to keep SHIPPED components findable.
       "vue/one-component-per-file": "off",
+    },
+  },
+  {
+    // The files that already exceed max-lines, listed here rather than silenced with
+    // eslint-disable comments so the debt is countable in one place (CLAUDE.md forbids the
+    // comments, and rightly — they hide at the scene). Delete an entry once its file is under
+    // the limit; the rule then holds it there.
+    files: [
+      "src/components/TerminalCell.vue", // 1605 — extract the launch form (#1122)
+      "src/components/TerminalGrid.vue", //  815 — layout state machine + its documented <style> exception (#1125)
+      "src/components/SettingsModal.vue", //  786 — split the 15 sections (#1126)
+    ],
+    rules: {
+      "max-lines": "off",
     },
   },
   {

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -2,7 +2,6 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": ["server/cli-init.ts", "server/cli-google.ts", "bin/update-check.js", "test/**/*.spec.ts", "*.config.ts"],
   "project": ["server/**/*.ts", "src/**/*.{ts,vue}", "bin/**/*.js", "common/**/*.ts"],
-  "ignore": ["**/dist/**", "**/*.d.ts", "**/logs/**"],
   // Only the dependencies knip structurally cannot see, each with the reason it is
   // invisible. This was `.*` — every dependency ignored — which left the scan silent
   // about dependency rot. Anything absent from this list is checked now, so a
@@ -20,7 +19,11 @@
   "ignoreExportsUsedInFile": true,
   "includeEntryExports": false,
   "rules": {
-    "files": "off",
+    // "error" is what makes knip exit non-zero — a "warn" rule is reported and then exits 0,
+    // so the workflow dropping `continue-on-error` would have gated on nothing. `files` is the
+    // one promoted here: an orphaned file passes typecheck, tests and build (#1124 shipped one),
+    // so nothing else in CI is watching for it. The rest stay reporting-only.
+    "files": "error",
     "dependencies": "warn",
     "devDependencies": "warn",
     "unlisted": "warn",


### PR DESCRIPTION
## Summary

2000 行のコンポーネントと孤児ファイルが**静かに**育った穴を 2 つ塞ぎます。

| ガード | 設定 |
|---|---|
| `max-lines` | **error 600**（製品）／ **warn 600**（spec）／ 既存の製品 3 ファイルは overrides で除外 |
| `dead-code-scan` | **unused files でゲート**（`continue-on-error` を削除、knip `files` を error に） |

## Items to Confirm / Review

### 1. しきい値を決める前提が、実測で 2 回変わりました

**`wc -l` と ESLint の数え方は別物です。** `skipComments: true` が効くので:

| | `wc -l` | ESLint が数える行 | 違反? |
|---|---|---|---|
| `src/components/TerminalCell.vue` | 2019 | 1605 | ○ |
| `src/components/TerminalGrid.vue` | 1100 | 815 | ○ |
| `src/components/SettingsModal.vue` | 907 | 786 | ○ |
| `src/composables/useTerminalConnections.ts` | 898 | **600 未満** | × |
| `server/index.ts` | 887 | **600 未満** | × |
| `server/backends/collections.ts` | 812 | **600 未満** | × |

つまり**除外は 6 件ではなく 3 件**で済みました。落ちた 3 つは「説明が長いだけでコード量は少ない」ファイルで、これは望ましい長さです。

### 2. `continue-on-error` を外すだけでは、何もゲートしませんでした

**knip は warn レベルの検出では exit 0 を返します**（実測）。全ルールが `warn` だったので、`continue-on-error` を消しても**ゲートはゼロのまま**でした。`files` を `"error"` に上げて初めて exit 1 になります。

```
files:"warn"  + 未使用ファイル 1 件 → exit 0   ← ゲートにならない
files:"error" + 未使用ファイル 1 件 → exit 1   ← 止まる
files:"error" + クリーン            → exit 0
```

`exports` / `types` / 依存系は **`warn` のまま**にしました。entry point を推定できないケース（tsx 経由の CLI、codegen）で誤検知しやすい、というワークフロー自身の指摘が今も有効なので。**ここを上げるかは別途判断でよいと思います**（現状の検出は 0 件なので、上げても今は緑です）。

### 3. ゲートが実際に効くことを確認しています

推測ではなく、プローブを置いて測りました:

- **701 行の新規製品ファイル** → `error  File has too many lines (701). Maximum allowed is 600`、eslint **exit 1**
- **500 行の新規ファイル** → 検出 0
- **孤児ファイル 1 件** → knip **exit 1**、削除後 **exit 0**
- `yarn lint` は警告のみなら **exit 0**（spec の 5 件で CI は落ちない）

プローブは全て削除済みです。

### 4. spec が warn なので `yarn lint` に 5 件の警告が常時出ます

```
1893  test/src/components/TerminalCell.spec.ts
 878  test/src/components/gridTabs.spec.ts
 694  test/src/composables/useTerminalConnections.spec.ts
 661  test/server/backends/collections.spec.ts
 624  test/src/components/TerminalGrid.spec.ts
```

これまで `yarn lint` は無音だったので、ノイズが増えます。既存 config が spec の長さ系ガードを外している方針（"a describe/it suite is one big (nested) callback by design"）と、1893 行は見えるべきという要請の折衷です。

## 副産物

冗長だった knip の `ignore` 3 件（`**/dist/**` / `**/*.d.ts` / `**/logs/**`）を削除しました。project glob ですでに対象外で、knip 自身が "Remove from ignore" と言っていたものです。設定ヒントは 4 件 → 1 件（残る `.css` は knip が CSS import を追わない仕様上のもの）。

## 検証

- `yarn format` / `yarn lint`（0 errors）/ `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` 緑。`yarn test` **6506 passed**。
- ワークフロー YAML は構造を確認（`continue-on-error` 0 件、`steps:` のインデント維持、タブ文字なし）。

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
