### PR TITLE
refactor: SettingsModal の 17 セクションを 1 セクション 1 コンポーネントに分割 (#1126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1636,7 +1636,11 @@ src/
     PrsOverlay.vue                           cross-repo PRs & Issues
     Wiki*View.vue, Collections*.vue, AccountingOverlay.vue   workspace views
     TimelineOverlay.vue, ToolsPane.vue, NotificationBell.vue, RemoteHostControl.vue
-    SettingsModal.vue                        ⚙ settings
+    SettingsModal.vue                        ⚙ settings — the dialog shell + section order
+    settings/                                one file per settings section (theme, sounds,
+                                             web push, google, PR repos, launchers, quick
+                                             commands, MCP, cost, shortcuts, …), plus the
+                                             shared SettingsStepper / SettingsListRow
   composables/                  useSessions, usePubSub, useGitStatus, useCost,
                                 useChatLauncher, useFilesView, useWikiBrowse,
                                 useCollectionBrowse, useNotifications, useVoiceInput, …

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -139,7 +139,6 @@ export default [
     files: [
       "src/components/TerminalCell.vue", // 1605 — extract the launch form (#1122)
       "src/components/TerminalGrid.vue", //  815 — layout state machine + its documented <style> exception (#1125)
-      "src/components/SettingsModal.vue", //  786 — split the 15 sections (#1126)
     ],
     rules: {
       "max-lines": "off",

--- a/plans/refactor-1126-settings-sections.md
+++ b/plans/refactor-1126-settings-sections.md
@@ -1,0 +1,167 @@
+# refactor: SettingsModal の 17 セクションを 1 セクション 1 コンポーネントに分割 (#1126)
+
+`src/components/SettingsModal.vue`（907 行 / script 410・template 495）を、`src/components/settings/`
+配下の**セクション 1 つ = ファイル 1 つ**に分ける。あわせて、分割中に見えてきた重複 3 件を潰す。
+
+issue の step 1（見出しクラスを `SECTION_HEADING` 定数にまとめる）は #1136 で完了済み。ここは step 2。
+
+## なぜ 1 セクション 1 コンポーネントか
+
+17 セクションは**互いに状態を共有していない**（それぞれ自分の composable か、自分の prop / emit 1 組
+だけを見ている）。まとめる理由が「ファイル数を減らしたい」しかない一方、分けると:
+
+- **skill ボタンとセクションの対応が 1 ファイルに収まる**。CLAUDE.md の「A skill with a Settings
+  section is launched from it」は、controls とその `SkillLaunchButton` が同じファイルにある方が
+  追える。#1097 は「1 つの巨大ファイルの中に散っている記述を 1 箇所見落とす」事故だった。
+- **4 重複が見える場所に出る**。リスト編集 4 セクションが 4 ファイルになれば、同じ形をしていることが
+  ファイル名の並びで分かる。900 行の中に埋まっている限り jscpd も規則も届かない（issue 参照）。
+
+## 設計
+
+### 1. 殻に残すもの
+
+`SettingsModal.vue` は「モーダルの殻 + セクションを並べる + props/emits の転送」だけになる:
+
+- overlay / dialog の div、ヘッダ（タイトル + 閉じるボタン）、フッタの Close
+- Escape で閉じる / Tab を dialog 内に閉じ込める（`onKeydown` + `modalEl`）
+- マウント直後の初期フォーカス
+
+**props と emits の口は現状のまま変えない**。`SettingsModal.spec.ts` は `mount(SettingsModal)` に
+props を直接渡して `w.emitted("update-...")` を見ているので、子で `useAppConfig()` を直読みする形
+（AppSettingsModal がやっているような）に寄せると spec が全部壊れる。子は prop を受け、emit を親へ
+転送する。
+
+### 2. `src/components/settings/` に 17 ファイル
+
+`src/components/` は 106 ファイルのフラットなディレクトリなので、17 ファイルを足すならサブ
+ディレクトリを切る。spec 側は既に `test/src/components/` のようにパスを写しているので、新規 spec は
+`test/src/components/settings/` に置く。
+
+| ファイル | 状態の出どころ |
+| --- | --- |
+| `ThemeSection.vue` | `useTheme` |
+| `TerminalFontSizeSection.vue` | `useTerminalFontSize` |
+| `TerminalScrollSection.vue` | `useTerminalScrollSpeed` |
+| `WaitingRowsSection.vue` | `useRosterAlert` |
+| `DirAppearanceSection.vue` | prose + skill ボタンのみ |
+| `DirSettingsSection.vue` | `dirPaths` prop |
+| `NotificationSoundsSection.vue` | `soundFile` / `soundKinds` / `sounds` + 3 emit |
+| `VoiceInputSection.vue` | `voiceLanguage` + capable probe |
+| `WebPushSection.vue` | `pushEnabled` / `pushKinds` + 2 emit |
+| `GoogleAccountSection.vue` | `useGoogleLink` |
+| `PrReposSection.vue` | `prRepos` + emit |
+| `LaunchersSection.vue` | `launchers` + emit |
+| `QuickCommandsSection.vue` | `quickCommands` + emit |
+| `McpServersSection.vue` | `userMcpServers` + emit |
+| `CostSection.vue` | `useCost` + `cwd` / `sessionId` |
+| `ShortcutsSection.vue` | `activeKeymap` |
+| `HelpSection.vue` | `GuideLinks` |
+
+### 3. セクションの root はフラグメントのまま
+
+各セクションは `<h3>` + `<p>` + controls という**複数ルート**になる。Vue はフラグメント
+コンポーネントの子を親へ直接描くので、モーダルの `flex-col` から見た DOM と flex アイテムの並びは
+今と同一で、セクション間の余白（`h3` の `mt-3.5` / `p` の `mb-3`）もそのまま効く。
+
+ラッパー div を足さないのは、足すと flex アイテムの数が変わって余白が崩れるから。そして
+フラグメント root でも困らないのは、見た目が全部ユーティリティで、共有 CSS クラスに依存していない
+ため（#787 でフラグメント root が scope id を受け取らないと分かって以来の方針 — `docs/styling.md`）。
+
+`VoiceInputSection` だけは中身全体が `v-if="voiceCapable"`。描かないときはコメントアンカーだけが
+残り、flex レイアウトには影響しない。
+
+### 4. onMounted の分配
+
+今は 3 つの初期フェッチが親の `onMounted` に集まっている。それぞれ自分のセクションへ移す:
+
+- `refreshCost()` → `CostSection`（`cwd` / `sessionId` の watch も一緒に）
+- `refreshGoogle()` + `disposeGoogle()` → `GoogleAccountSection`
+- `refreshVoiceCapable()` → `VoiceInputSection`
+
+モーダルは `v-if` で開閉されるので子も一緒にマウント/アンマウントされ、`useGoogleLink` の
+ポーラー停止（`dispose`）のタイミングは変わらない。
+
+## 分割にあわせて潰す重複
+
+いずれも issue には書かれていないが、分割すると 4 ファイルに散る形で残ってしまうので同じ PR で扱う。
+
+### a. `SettingsListRow.vue` — 削除ボタン付きの行（4 箇所）
+
+PR repos / Launch commands / Phone quick commands / MCP servers が、`<li>` の枠 6 ユーティリティと
+**同一の close ボタン 8 行**を 4 回書いている。`name` から `Remove ${name}` の `title` /
+`aria-label` を作り、行の中身は slot。
+
+`<ul>` 側の `m-0 mb-2 flex list-none flex-col gap-1 p-0` も 4 回なので、`SETTINGS_LIST` という
+class 文字列定数にする（`v-if` の条件が各セクションで違うので `<ul>` 自体はセクションに残す）。
+
+なお、同じ close ボタンの並びは**モーダルのヘッダにもある**（合計 5 箇所）。4 箇所が
+`SettingsListRow` に吸収されればヘッダの 1 箇所だけが残るので、そこは触らない。`TerminalCell.vue`
+にも `--err-hover-bg` を使うボタンがあるが、ユーティリティの並びは別物なので対象外。
+
+### b. `SettingsStepper.vue` — −/値/+（2 箇所）
+
+Terminal font size と Terminal scroll speed の 25 行がほぼ同一。`value` / `unit` / `min` / `max` /
+`step` / `label` を受け、`@nudge` で符号付きの step を返す。`aria-label` は
+`Decrease ${label}` / `Increase ${label}` で現状の文言（"Decrease terminal font size" など）に一致。
+
+値の表示は `{{ value }}{{ unit }}` で、`px` は前に空白あり・`×` は空白なしという**今の表示を変えない**
+ため `unit` は `:unit="' px'"` のようにバインドで渡す（静的属性の先頭空白は読み手に消される）。
+
+分割前は属性が多くて prettier が改行していたため、ボタンの中身が `> − <`（グリフの両側に空白）で
+描画されていた。共有コンポーネントでは 1 行に収まるので prettier が `>−<` に畳む。**これが唯一
+残った描画差**（下記）。
+
+### c. `useSavedListMirror` — 編集ミラーの script（4 箇所）
+
+「保存値を watch してローカル ref に写す + 新リストを emit する」が 4 本ある。`items` と `replace`
+だけを持つ composable にし、**`add` / `remove` は各セクションに残す**（フィールド数と検証が 4 つで
+違う。`settingsValidators.ts` はそのまま使う）。
+
+ローカルコピーであることが仕様: 最初の POST が返る前に 2 回目の編集をすると、両方が保存前の同じ
+スナップショットから計算されて 2 回目が 1 回目を取り消す。この理由のコメントは composable 側へ移す。
+
+内部は `ref<T[]>` ではなく `shallowRef<T[]>`。`ref` はジェネリックだと `UnwrapRef` を噛ませるので
+`as Ref<T[]>` が必要になり、CLAUDE.md の `as` 禁止に触れる。リストは常に丸ごと差し替える使い方
+なので `shallowRef` が意味的にも正しい。
+
+## テスト
+
+`SettingsModal.spec.ts`（369 行）は `mount` からツリー全体を `find` / `findAllComponents` している
+ので、子に切り出しても**emit を親まで転送すれば**セレクタは無改変で通る。ここを緑のまま保つのが
+この refactor の合否条件。`AppSettingsModal.spec.ts` と `GridView.spec.ts` は SettingsModal を
+スタブしているので影響なし。
+
+新規に追加するもの:
+
+- `useSavedListMirror` — 保存値の反映、丸ごと差し替え、保存前の 2 連続編集
+- `SettingsStepper` — min / max での disabled、`@nudge` の符号、`aria-label` の文言
+- `SettingsListRow` — `@remove` と `Remove ${name}` の `title` / `aria-label`
+
+## 検証
+
+`yarn format` → `yarn lint` → `yarn typecheck` → `yarn typecheck:server` → `yarn typecheck:test` →
+`yarn build` → `yarn test`。
+
+### DOM が変わっていないことは spec では足りない
+
+「spec が緑」は「見た目が同じ」ではない。分割前のコンポーネントを `SettingsModalBeforeSplit.vue`
+として一時的に併置し、**同じ props で両方を mount して `html()` を直接 diff** した（使い捨て、
+コミットしない）。条件を振ったのは 9 通り: 全リスト有り / 全て未設定 / push off / cwd と session
+無し（グリッド） / 存在しない theme / 文字起こし不可 / Google が使えない / Google 連携済み /
+cost 取得失敗。
+
+43KB の描画結果のうち、**構造差はゼロ**。生の差分は whitespace だけで、全量は次の 2 種類:
+
+1. ステッパーボタンの内側 `> − <` → `>−<`（4 箇所 = 2 ボタン × 2 セクション）
+2. Notification sounds の **HTML コメント**のインデント（6 箇所）。コメントは描画されないので無害
+
+### 1 の扱い（PR で human に見てもらう項目）
+
+`w-8 h-8` の flex ボックスに `items-center justify-center` が掛かっているので、テキストは匿名
+flex アイテムになり、その両端の空白は CSS が落とす — つまり見た目は変わらない、が **これは仕様の
+読みであって実測ではない**。Playwright は未導入で、同じ形（フレックス中央寄せの固定サイズ箱に
+裸のテキスト 1 文字）のボタンはリポジトリ内に他に無いため、出荷済みの UI からも裏が取れない。
+依存を足さずに済ませ、PR の「要確認」に挙げて実機で 1 度見てもらう。
+
+ソース側で ` − ` を復元する案は捨てた: prettier は 160 桁に収まると畳み直すので、`{{ " − " }}`
+のような構造にしないと保てず、それを正当化するコメントは「実は無害」と矛盾する。

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,37 +1,40 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
+// The Settings modal's shell: the dialog frame, its keyboard behavior, and the order the
+// sections appear in.
+//
+// Each section owns its own state — its composable, or the one prop/emit pair it edits — so it
+// is one file under ./settings, and what stays here is what belongs to the modal itself. The
+// props/emits below are pure plumbing: they exist because the shells (and the specs) address
+// this component, and each one is handed straight to the section that reads it.
+import { ref, onMounted, onUnmounted, nextTick } from "vue";
 import { MODAL_FOCUSABLE, trapTabKey } from "../utils/focusTrap";
-import { useTheme } from "../composables/useTheme";
-import { useTerminalFontSize } from "../composables/useTerminalFontSize";
-import { useTerminalScrollSpeed } from "../composables/useTerminalScrollSpeed";
-import { useRosterAlert } from "../composables/useRosterAlert";
-import { previewNotify } from "../composables/useAttentionSound";
-import { useCost } from "../composables/useCost";
-import { activeKeymap } from "../composables/activeKeymap";
-import { keymapRows, sendRows } from "./keymapLabels";
-import { useGoogleLink } from "../composables/useGoogleLink";
-import { VOICE_LANGUAGES, voiceLanguage } from "../composables/voiceLanguage";
-import { fetchVoiceInputStatus } from "../composables/voiceModelStatus";
-import { SELECT_CONTROL } from "./selectClasses";
 import SettingsButton from "./SettingsButton.vue";
-import SettingsField from "./SettingsField.vue";
-import SkillLaunchButton from "./SkillLaunchButton.vue";
-import GuideLinks from "./GuideLinks.vue";
-import DirConfigPreview from "./DirConfigPreview.vue";
+import ThemeSection from "./settings/ThemeSection.vue";
+import TerminalFontSizeSection from "./settings/TerminalFontSizeSection.vue";
+import TerminalScrollSection from "./settings/TerminalScrollSection.vue";
+import WaitingRowsSection from "./settings/WaitingRowsSection.vue";
+import DirAppearanceSection from "./settings/DirAppearanceSection.vue";
+import DirSettingsSection from "./settings/DirSettingsSection.vue";
+import NotificationSoundsSection from "./settings/NotificationSoundsSection.vue";
+import VoiceInputSection from "./settings/VoiceInputSection.vue";
+import WebPushSection from "./settings/WebPushSection.vue";
+import GoogleAccountSection from "./settings/GoogleAccountSection.vue";
+import PrReposSection from "./settings/PrReposSection.vue";
+import LaunchersSection from "./settings/LaunchersSection.vue";
+import QuickCommandsSection from "./settings/QuickCommandsSection.vue";
+import McpServersSection from "./settings/McpServersSection.vue";
+import CostSection from "./settings/CostSection.vue";
+import ShortcutsSection from "./settings/ShortcutsSection.vue";
+import HelpSection from "./settings/HelpSection.vue";
 import type { Launcher } from "./launchers";
 import type { UserMcpServer } from "./userMcp";
 import type { QuickCommand } from "../../common/quickCommands";
-import { SESSION_AGENTS, type SessionAgent } from "../../common/sessionAgent";
-import { PUSH_KINDS, type PushKind } from "../../common/pushKinds";
-import { NOTIFY_KINDS, type NotifyKind } from "../../common/notifyKinds";
-import { presetRef, SOUND_PRESETS } from "../../common/notifySounds";
-import { customSoundLabel, isCustomSound, toggledKinds, withKindSound, type SoundMap } from "../composables/soundSettings";
-import { canAddLauncher, canAddMcpServer, canAddQuickCommand, canAddRepo } from "./settingsValidators";
+import type { PushKind } from "../../common/pushKinds";
+import type { NotifyKind } from "../../common/notifyKinds";
+import type { SoundMap } from "../composables/soundSettings";
 import type { BundledSkillName } from "../../common/bundledSkills";
-import { formatUsd } from "./formatUsd";
-import { isRecord } from "../../common/isRecord";
 
-const props = defineProps<{
+defineProps<{
   soundFile?: string | null;
   soundKinds?: NotifyKind[];
   sounds?: SoundMap;
@@ -47,11 +50,6 @@ const props = defineProps<{
   // session's own directory when it isn't one of them yet.
   dirPaths?: string[];
 }>();
-// Every section of this modal is headed the same way. One constant rather than the same six
-// utilities on every section, so the headings cannot drift apart one edit at a time (CLAUDE.md:
-// repeated utility runs become a shared component or a class string constant — never a CSS class,
-// which a fragment-root template would silently fail to receive, #787).
-const SECTION_HEADING = "mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted";
 
 const emit = defineEmits<{
   (e: "update-sound", file: string | null): void;
@@ -69,316 +67,6 @@ const emit = defineEmits<{
   (e: "close"): void;
 }>();
 
-// Cross-repo PR view's repos ("owner/repo"). Editable list mirroring the saved value;
-// add/remove emits the new list up (App persists it).
-const repos = ref<string[]>([...(props.prRepos ?? [])]);
-watch(
-  () => props.prRepos,
-  (r) => (repos.value = [...(r ?? [])]),
-);
-const newRepo = ref("");
-const newRepoValid = computed(() => canAddRepo(newRepo.value, repos.value));
-function addRepo() {
-  const r = newRepo.value.trim();
-  if (!newRepoValid.value) return;
-  repos.value = [...repos.value, r];
-  newRepo.value = "";
-  emit("update-repos", repos.value);
-}
-function removeRepo(r: string) {
-  repos.value = repos.value.filter((x) => x !== r);
-  emit("update-repos", repos.value);
-}
-
-// Cell-launcher commands (label + command). Editable list mirroring the saved value;
-// add/remove emits the new list up (App persists it).
-const launcherList = ref<Launcher[]>([...(props.launchers ?? [])]);
-watch(
-  () => props.launchers,
-  (l) => (launcherList.value = [...(l ?? [])]),
-);
-const newLauncherLabel = ref("");
-const newLauncherCommand = ref("");
-const newLauncherValid = computed(() => canAddLauncher(newLauncherLabel.value, newLauncherCommand.value, launcherList.value));
-function addLauncher() {
-  const label = newLauncherLabel.value.trim();
-  const command = newLauncherCommand.value.trim();
-  if (!newLauncherValid.value) return;
-  launcherList.value = [...launcherList.value, { label, command }];
-  newLauncherLabel.value = "";
-  newLauncherCommand.value = "";
-  emit("update-launchers", launcherList.value);
-}
-function removeLauncher(label: string) {
-  launcherList.value = launcherList.value.filter((l) => l.label !== label);
-  emit("update-launchers", launcherList.value);
-}
-
-// Phrases the phone offers as chips on a session (#830). Same editable-mirror shape as the
-// lists above; `agents` scopes an entry to session kinds, and selecting none means every kind.
-const quickCommandList = ref<QuickCommand[]>([...(props.quickCommands ?? [])]);
-watch(
-  () => props.quickCommands,
-  (c) => (quickCommandList.value = [...(c ?? [])]),
-);
-const newQuickLabel = ref("");
-const newQuickText = ref("");
-const newQuickAgents = ref<SessionAgent[]>([]);
-const newQuickValid = computed(() => canAddQuickCommand(newQuickLabel.value, newQuickText.value, quickCommandList.value));
-
-function toggleNewQuickAgent(agent: SessionAgent) {
-  newQuickAgents.value = newQuickAgents.value.includes(agent) ? newQuickAgents.value.filter((a) => a !== agent) : [...newQuickAgents.value, agent];
-}
-
-function addQuickCommand() {
-  if (!newQuickValid.value) return;
-  const label = newQuickLabel.value.trim();
-  const text = newQuickText.value.trim();
-  // Omit `agents` rather than send [] — the server reads an empty list as "every kind" too,
-  // but leaving the key out is what the config format documents for "unscoped".
-  const agents = newQuickAgents.value.length ? [...newQuickAgents.value] : undefined;
-  quickCommandList.value = [...quickCommandList.value, agents ? { label, text, agents } : { label, text }];
-  newQuickLabel.value = "";
-  newQuickText.value = "";
-  newQuickAgents.value = [];
-  emit("update-quick-commands", quickCommandList.value);
-}
-
-function removeQuickCommand(label: string) {
-  quickCommandList.value = quickCommandList.value.filter((c) => c.label !== label);
-  emit("update-quick-commands", quickCommandList.value);
-}
-
-const agentScopeLabel = (command: QuickCommand): string => (command.agents?.length ? command.agents.join(" / ") : "all");
-
-// User HTTP MCP servers (id + url) merged into the single-view Claude session. Editable
-// list mirroring the saved value; add/remove emits the new list up.
-const mcpServers = ref<UserMcpServer[]>([...(props.userMcpServers ?? [])]);
-watch(
-  () => props.userMcpServers,
-  (s) => (mcpServers.value = [...(s ?? [])]),
-);
-const newMcpId = ref("");
-const newMcpUrl = ref("");
-const newMcpValid = computed(() => canAddMcpServer(newMcpId.value, newMcpUrl.value, mcpServers.value));
-function addMcpServer() {
-  const id = newMcpId.value.trim();
-  const url = newMcpUrl.value.trim();
-  if (!newMcpValid.value) return;
-  mcpServers.value = [...mcpServers.value, { id, url }];
-  newMcpId.value = "";
-  newMcpUrl.value = "";
-  emit("update-user-mcp", mcpServers.value);
-}
-function removeMcpServer(id: string) {
-  mcpServers.value = mcpServers.value.filter((s) => s.id !== id);
-  emit("update-user-mcp", mcpServers.value);
-}
-
-// Custom attention sound, applied immediately (like the theme) — empty => the
-// built-in chime. The text box mirrors the saved value; Browse / typing apply it.
-const soundPath = ref(props.soundFile ?? "");
-watch(
-  () => props.soundFile,
-  (f) => (soundPath.value = f ?? ""),
-);
-
-function applySound() {
-  emit("update-sound", soundPath.value.trim() || null);
-}
-function clearSound() {
-  soundPath.value = "";
-  emit("update-sound", null);
-}
-// Web Push toggle — stateless: reflects props.pushEnabled, emits the new value up (App persists it).
-function onPushToggle(e: Event) {
-  if (e.target instanceof HTMLInputElement) emit("update-push-enabled", e.target.checked);
-}
-
-// Which kinds of push to send (#850). The master toggle above says whether to notify at all;
-// this says which moments qualify, so a user who only wants finished turns can decline the ones
-// a blocked agent raises. Editable list mirroring the saved value, like the other lists here.
-const PUSH_KIND_LABEL: Record<PushKind, string> = { finished: "Turn finished", waiting: "Waiting for you" };
-const PUSH_KIND_HELP: Record<PushKind, string> = {
-  finished: "the agent replied and the output is unread",
-  waiting: "it stopped to ask — a permission prompt or a question. Fires once per prompt, so a task that asks a lot pushes a lot",
-};
-const pushKindList = ref<PushKind[]>([...(props.pushKinds ?? [])]);
-watch(
-  () => props.pushKinds,
-  (k) => (pushKindList.value = [...(k ?? [])]),
-);
-function togglePushKind(kind: PushKind) {
-  // Emitted in PUSH_KINDS order so the saved list reads the same however it was clicked.
-  const next = pushKindList.value.includes(kind) ? pushKindList.value.filter((k) => k !== kind) : [...pushKindList.value, kind];
-  pushKindList.value = PUSH_KINDS.filter((k) => next.includes(k));
-  emit("update-push-kinds", pushKindList.value);
-}
-async function browseSound() {
-  try {
-    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" } });
-    if (!res.ok) return;
-    const data: unknown = await res.json();
-    const picked = isRecord(data) && Array.isArray(data.paths) && typeof data.paths[0] === "string" ? data.paths[0] : "";
-    if (picked) {
-      soundPath.value = picked;
-      applySound();
-    }
-  } catch {
-    // native dialog unavailable / canceled — leave the field as-is
-  }
-}
-// Which moments beep, and what each one plays (#873). Same shape as the push kinds above:
-// the toolbar's speaker icon says whether to beep at all, this says which moments qualify.
-const NOTIFY_KIND_LABEL: Record<NotifyKind, string> = {
-  finished: "Turn finished",
-  waiting: "Waiting for you",
-  "command-done": "Command finished",
-  "command-failed": "Command failed",
-  "session-exited": "Session ended",
-  "pr-ci-failed": "PR CI failed",
-};
-const NOTIFY_KIND_HELP: Record<NotifyKind, string> = {
-  finished: "the agent replied and the output is unread",
-  waiting: "it stopped to ask — a permission prompt or a question",
-  "command-done": "a Run cell's command exited cleanly",
-  "command-failed": "a Run cell's command exited with an error, or never started",
-  "session-exited": "a session's terminal ended — including when you close the cell yourself",
-  "pr-ci-failed": "a directory's PR went red. Only seen while the roster is on screen, since that is what polls it",
-};
-
-const soundKindList = ref<NotifyKind[]>([...(props.soundKinds ?? [])]);
-watch(
-  () => props.soundKinds,
-  (k) => (soundKindList.value = [...(k ?? [])]),
-);
-function toggleSoundKind(kind: NotifyKind) {
-  soundKindList.value = toggledKinds(soundKindList.value, kind);
-  emit("update-sound-kinds", soundKindList.value);
-}
-
-// Editable mirror of the saved map, like the lists above. It has to be a LOCAL ref and not
-// `props.sounds`: the whole map is persisted on every change, so two picks made before the
-// first POST answers would both compute from the same pre-save snapshot and the second would
-// drop the first. This is the hazard createPresetMutations serializes writes for.
-const soundMap = ref<SoundMap>({ ...(props.sounds ?? {}) });
-watch(
-  () => props.sounds,
-  (m) => (soundMap.value = { ...(m ?? {}) }),
-);
-
-// "" is the fallback (the file below, else the chime). A kind whose saved value is a PATH —
-// only settable by hand in config.json — gets an extra option so picking a preset for another
-// kind can't silently drop it. The editing itself is pure, in composables/soundSettings.
-const soundValue = (kind: NotifyKind): string => soundMap.value[kind] ?? "";
-function setKindSound(kind: NotifyKind, value: string) {
-  soundMap.value = withKindSound(soundMap.value, kind, value);
-  emit("update-sounds", soundMap.value);
-}
-function onKindSoundChange(kind: NotifyKind, e: Event) {
-  if (e.target instanceof HTMLSelectElement) setKindSound(kind, e.target.value);
-}
-// Preview what this kind would play, resolved the same way a real beep resolves it (the kind's
-// own sound, else the fallback file, else the chime). Reads the LOCAL map so a preset picked a
-// moment ago is what you hear — a preset is fetched by id and needs no saved config. Falling
-// back to `soundFile` still shows the saved path, which is the only value the server can stream.
-function testKindSound(kind: NotifyKind) {
-  void previewNotify(kind, { kinds: soundKindList.value, sounds: soundMap.value, soundFile: props.soundFile ?? null });
-}
-
-// Theme is applied immediately on click.
-const { themeId, themes, setTheme, missingThemeId } = useTheme();
-const themesEl = ref<HTMLElement>();
-
-// Terminal font size, applied immediately (like the theme). Per-browser, so a phone and a
-// desktop on the same server keep their own; a directory can pin its own in .mulmoterminal.json.
-const { fontSize, nudgeFontSize, min: fontSizeMin, max: fontSizeMax, step: fontSizeStep } = useTerminalFontSize();
-
-// Terminal scroll speed, same shape and the same per-browser reasoning as the font size: it is a
-// property of the pointing device, and a trackpad and a wheel mouse want different answers.
-const { scrollSpeed, nudgeScrollSpeed, min: scrollSpeedMin, max: scrollSpeedMax, step: scrollSpeedStep } = useTerminalScrollSpeed();
-
-// Whether a roster row waiting on the user blinks (#1131) — per browser for the same reason: it is
-// the person watching the screen who finds movement useful or distracting, not the host.
-const { blink: rosterBlink, setBlink: setRosterBlink } = useRosterAlert();
-function onRosterBlinkToggle(e: Event) {
-  if (e.target instanceof HTMLInputElement) setRosterBlink(e.target.checked);
-}
-
-// Google account link. The modal is v-if'd, so a fresh load on mount also picks up
-// out-of-band changes (`mulmoterminal google login`, a deleted token file).
-const {
-  status: googleStatus,
-  busy: googleBusy,
-  error: googleError,
-  refresh: refreshGoogle,
-  connect: connectGoogle,
-  unlink: unlinkGoogle,
-  dispose: disposeGoogle,
-} = useGoogleLink();
-
-const googleStatusText = computed(() => {
-  if (!googleStatus.value) return "Checking…";
-  if (googleStatus.value.pending) return "Waiting for consent in your browser…";
-  return googleStatus.value.linked ? "Linked" : "Not linked";
-});
-
-// Broker (GCP settings-free link) removes the client secret requirement. When a broker is available,
-// consent can flow through it; otherwise, a Desktop client's secret on disk is needed.
-const googleSecretHint = computed(() => {
-  if (googleStatus.value?.brokerAvailable) return "";
-  const presence = googleStatus.value?.clientSecret;
-  if (presence === "missing")
-    return "No OAuth client secret found in ~/.secrets. Add a Desktop client's client_secret_*.json there to enable sign-in, or use the GCP-settings-free broker link if available.";
-  if (presence === "ambiguous") return "Multiple client_secret_*.json files in ~/.secrets — keep exactly one.";
-  return "";
-});
-
-async function onUnlinkGoogle() {
-  if (!window.confirm("Unlink this Google account? MulmoTerminal will lose Calendar access until you sign in again.")) return;
-  await unlinkGoogle();
-}
-
-// ARIA radiogroup keyboard contract: arrows move selection (and focus) within
-// the group, wrapping at the ends; only the checked radio is tabbable (roving
-// tabindex), so Tab enters/leaves the group as one stop.
-// Roving tabindex, with a floor: when the selection names a theme that isn't in the list — the
-// missing-theme case this build added (#996) — nothing matches and EVERY option would be
-// tabindex="-1", so a keyboard user could not reach the picker at all while the notice above it
-// says to pick one. The first option becomes the tab stop in that state.
-const hasSelectedTheme = computed(() => themes.value.some((t) => t.id === themeId.value));
-function isThemeTabStop(id: string, index: number): boolean {
-  return hasSelectedTheme.value ? themeId.value === id : index === 0;
-}
-
-function onThemeKey(e: KeyboardEvent, index: number) {
-  const forward = e.key === "ArrowRight" || e.key === "ArrowDown";
-  const backward = e.key === "ArrowLeft" || e.key === "ArrowUp";
-  if (!forward && !backward) return;
-  e.preventDefault();
-  const next = (index + (forward ? 1 : themes.value.length - 1)) % themes.value.length;
-  setTheme(themes.value[next].id);
-  themesEl.value?.querySelectorAll<HTMLElement>('[role="radio"]')[next]?.focus();
-}
-
-// Voice input's language mode. The setting is a singleton ref (localStorage-backed), so it
-// needs no prop/emit plumbing — but the section is only worth showing on a machine that can
-// transcribe at all, and capability lives on the server. One cheap GET when the modal opens;
-// a failed/absent probe leaves the section hidden rather than offering a setting for a mic
-// that will never appear.
-const voiceCapable = ref(false);
-async function refreshVoiceCapable() {
-  voiceCapable.value = (await fetchVoiceInputStatus())?.capable ?? false;
-}
-
-// Read-only estimated cost (Session / Today / Month), loaded when the modal opens.
-const { cost, error: costError, load: loadCost } = useCost();
-
-// Reactive, not a snapshot: /api/config is fetched asynchronously, so a modal opened before it
-// lands would otherwise sit on "Not set" for every action until it is closed and reopened.
-const shortcutRows = computed(() => keymapRows(activeKeymap.value));
-const sendKeyRows = computed(() => sendRows(activeKeymap.value));
-
 const modalEl = ref<HTMLElement>();
 
 // Modal keyboard behavior: Escape closes; Tab is trapped within the dialog.
@@ -391,22 +79,11 @@ function onKeydown(e: KeyboardEvent) {
   trapTabKey(e, modalEl.value, MODAL_FOCUSABLE);
 }
 
-// Load cost unconditionally — the server falls back to the workspace when no cwd is
-// passed, so Today/Month still populate in the grid view (no active single-view
-// session ⇒ no cwd/sessionId). Re-fetch if cwd/sessionId arrive or change while open.
-const refreshCost = () => loadCost(props.cwd ?? null, props.sessionId ?? null);
 onMounted(() => {
   document.addEventListener("keydown", onKeydown);
   nextTick(() => modalEl.value?.querySelector<HTMLElement>("input, button")?.focus());
-  refreshCost();
-  refreshGoogle();
-  refreshVoiceCapable();
 });
-watch([() => props.cwd, () => props.sessionId], refreshCost);
-onUnmounted(() => {
-  document.removeEventListener("keydown", onKeydown);
-  disposeGoogle();
-});
+onUnmounted(() => document.removeEventListener("keydown", onKeydown));
 </script>
 
 <template>
@@ -430,473 +107,36 @@ onUnmounted(() => {
         </button>
       </div>
 
-      <h3 :class="SECTION_HEADING">Theme</h3>
-      <p v-if="missingThemeId" class="mb-2 mt-1.5 text-[12px] text-[var(--warn-text,#e0a030)]" data-testid="theme-missing">
-        The selected theme <code>{{ missingThemeId }}</code> is not defined. Add it to <code>themes</code> in <code>~/.mulmoterminal/config.json</code>, or pick
-        one below. Your choice is kept until then.
-      </p>
-      <p class="mb-2 mt-1.5 text-[12px] text-dim">
-        Picks from the schemes that exist. Your own go in <code>themes</code> in <code>~/.mulmoterminal/config.json</code> and appear here next to the built-in
-        four — the skill writes one from a palette, a photo or a brand's colours, and checks it for contrast.
-      </p>
-      <div ref="themesEl" class="flex flex-wrap gap-2" role="radiogroup" aria-label="Theme">
-        <button
-          v-for="(t, i) in themes"
-          :key="t.id"
-          type="button"
-          class="flex w-[84px] cursor-pointer flex-col items-center gap-1.5 rounded-lg border bg-elevated p-2 hover:bg-hover"
-          :class="themeId === t.id ? 'border-accent text-fg' : 'border-border text-muted hover:text-fg'"
-          role="radio"
-          :aria-checked="themeId === t.id"
-          :tabindex="isThemeTabStop(t.id, i) ? 0 : -1"
-          :title="t.label"
-          @click="setTheme(t.id)"
-          @keydown="onThemeKey($event, i)"
-        >
-          <span class="relative h-[34px] w-full overflow-hidden rounded-md border border-border" :style="{ background: t.swatch.base }">
-            <span class="absolute bottom-1.5 left-2 h-3 w-3 rounded-full" :style="{ background: t.swatch.panel }" />
-            <span class="absolute bottom-1.5 left-6 h-3 w-3 rounded-full" :style="{ background: t.swatch.accent }" />
-          </span>
-          <span class="text-[12px]">{{ t.label }}</span>
-        </button>
-      </div>
-      <div class="mt-3">
-        <SkillLaunchButton skill="mulmoterminal-theme" icon="format_paint" label="Create a theme…" @launch="emit('launch-skill', $event)" />
-      </div>
-
-      <h3 :class="SECTION_HEADING">Terminal font size</h3>
-      <div class="flex items-center gap-2">
-        <button
-          type="button"
-          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-border bg-elevated text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
-          :disabled="fontSize <= fontSizeMin"
-          aria-label="Decrease terminal font size"
-          @click="nudgeFontSize(-fontSizeStep)"
-        >
-          −
-        </button>
-        <span class="min-w-[56px] text-center text-[13px] text-fg" aria-live="polite">{{ fontSize }} px</span>
-        <button
-          type="button"
-          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-border bg-elevated text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
-          :disabled="fontSize >= fontSizeMax"
-          aria-label="Increase terminal font size"
-          @click="nudgeFontSize(fontSizeStep)"
-        >
-          +
-        </button>
-      </div>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Applies to every terminal on this browser. A directory can pin its own with <code>fontSize</code> in its <code>.mulmoterminal.json</code>.
-      </p>
-
-      <h3 :class="SECTION_HEADING">Terminal scroll speed</h3>
-      <div class="flex items-center gap-2">
-        <button
-          type="button"
-          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-border bg-elevated text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
-          :disabled="scrollSpeed <= scrollSpeedMin"
-          aria-label="Decrease terminal scroll speed"
-          @click="nudgeScrollSpeed(-scrollSpeedStep)"
-        >
-          −
-        </button>
-        <span class="min-w-[56px] text-center text-[13px] text-fg" aria-live="polite">{{ scrollSpeed }}×</span>
-        <button
-          type="button"
-          class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-border bg-elevated text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
-          :disabled="scrollSpeed >= scrollSpeedMax"
-          aria-label="Increase terminal scroll speed"
-          @click="nudgeScrollSpeed(scrollSpeedStep)"
-        >
-          +
-        </button>
-      </div>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        How far one wheel notch or trackpad swipe moves the terminal — 1× is the default. Lower it if a two-finger scroll on a Mac trackpad flies past what you
-        were reading. Per browser, and it covers both a shell's scrollback and a full-screen app like Claude Code.
-      </p>
-
-      <h3 :class="SECTION_HEADING">Waiting rows</h3>
-      <p class="mb-2 mt-1.5 text-[12px] text-dim">
-        In the list beside an enlarged cell, a row whose agent is <strong>waiting on you</strong> — a permission prompt, a question — carries an amber ring and
-        blinks. A row that has simply <strong>finished</strong> is green and holds still. Turning this off keeps both colours and stops the movement; rows never
-        blink when your system asks for reduced motion.
-      </p>
-      <label class="mb-3 flex cursor-pointer items-center gap-2">
-        <input type="checkbox" class="cursor-pointer" :checked="rosterBlink" aria-label="Blink a row that is waiting on me" @change="onRosterBlinkToggle" />
-        <span class="text-[13px]">Blink a row that is waiting on me</span>
-      </label>
-
-      <h3 :class="SECTION_HEADING">Directory appearance</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Launch the <code>mulmoterminal-dirs</code> skill to style and order your directories — name badge, colors, terminal palette, grid position. It starts
-        from the directories you actually open, reads the settings you already have, and follows the same pattern for the ones that have none.
-      </p>
-      <SkillLaunchButton skill="mulmoterminal-dirs" icon="palette" label="Configure appearance…" @launch="emit('launch-skill', $event)" />
-
-      <h3 :class="SECTION_HEADING">Directory settings</h3>
-      <p class="mb-1 mt-1.5 text-[12px] text-dim">
-        What each directory's <code>.mulmoterminal.json</code> is actually doing. Expand one to see the values in force, and any key the app dropped or doesn't
-        recognise — a setting that never took effect looks the same as one you never made until you can see this.
-      </p>
-      <DirConfigPreview :paths="dirPaths ?? []" />
-      <p class="mb-3 mt-2.5 text-[12px] text-dim">
-        This lists what is wrong; the skill reads the same thing and says why, then fixes it or points you at whichever skill owns that key.
-      </p>
-      <SkillLaunchButton skill="mulmoterminal-config" icon="troubleshoot" label="Explain my settings…" @launch="emit('launch-skill', $event)" />
-
-      <h3 :class="SECTION_HEADING">Notification sounds</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Which moments beep, and what each one plays. Running many agents at once is what turns notifications into noise — untick the ones you don't need. The
-        speaker button in the toolbar silences all of them at once.
-      </p>
-      <div v-for="kind in NOTIFY_KINDS" :key="kind" class="py-0.5">
-        <div class="flex items-center gap-2">
-          <label class="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
-            <input
-              type="checkbox"
-              class="shrink-0 cursor-pointer"
-              :checked="soundKindList.includes(kind)"
-              :aria-label="`Beep when a session is ${kind}`"
-              @change="toggleSoundKind(kind)"
-            />
-            <span class="truncate text-[12px]"
-              ><strong>{{ NOTIFY_KIND_LABEL[kind] }}</strong></span
-            >
-          </label>
-          <!-- The width lives on this wrapper, not the select: SELECT_CONTROL is `w-full`, and a
-               `w-44` beside it is the same specificity — which of the two wins is decided by the
-               order Tailwind emits them, not by the order written here. -->
-          <div class="w-36 shrink-0">
-            <select
-              :value="soundValue(kind)"
-              :disabled="!soundKindList.includes(kind)"
-              :aria-label="`Sound for ${NOTIFY_KIND_LABEL[kind]}`"
-              :class="SELECT_CONTROL"
-              class="truncate"
-              @change="onKindSoundChange(kind, $event)"
-            >
-              <option value="">Default</option>
-              <option v-for="preset in SOUND_PRESETS" :key="preset.id" :value="presetRef(preset.id)">{{ preset.label }}</option>
-              <option v-if="isCustomSound(soundValue(kind))" :value="soundValue(kind)">{{ customSoundLabel(soundValue(kind)) }}</option>
-            </select>
-          </div>
-          <SettingsButton class="shrink-0" :title="`Play the ${NOTIFY_KIND_LABEL[kind]} sound`" @click="testKindSound(kind)"
-            ><span class="material-symbols-outlined" aria-hidden="true">play_arrow</span></SettingsButton
-          >
-        </div>
-        <p class="ml-6 text-[11px] text-dim">{{ NOTIFY_KIND_HELP[kind] }}</p>
-      </div>
-
-      <p class="mb-1.5 mt-3 text-[12px] text-dim">
-        <strong>Default</strong> plays your own file below, or the built-in chime when that is empty. The presets are fetched once and kept on this machine, so
-        they keep working offline.
-      </p>
-      <div class="flex items-center gap-2">
-        <SettingsField
-          v-model="soundPath"
-          class="flex-auto font-mono"
-          placeholder="/absolute/path/to/sound.wav"
-          aria-label="Custom notification sound file"
-          spellcheck="false"
-          @change="applySound"
-        />
-        <SettingsButton @click="browseSound">Browse…</SettingsButton>
-        <SettingsButton :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</SettingsButton>
-      </div>
-      <p class="mb-3 mt-3 text-[12px] text-dim">
-        These are the sounds for every session. The skill also gives one project its own sound, picks which moments push to your phone, and works out which of
-        them is the one waking you up.
-      </p>
-      <SkillLaunchButton skill="mulmoterminal-notify" icon="notifications_active" label="Configure notifications…" @launch="emit('launch-skill', $event)" />
-
-      <template v-if="voiceCapable">
-        <h3 :class="SECTION_HEADING">Voice input</h3>
-        <p class="mb-3 mt-1.5 text-[12px] text-dim">
-          The language you dictate in. Speaking a language the mic is not expecting comes back <strong>translated</strong> into the expected one — so pick the
-          one you actually speak rather than leaving it on your browser's.
-        </p>
-        <select v-model="voiceLanguage" aria-label="Language for voice input" :class="SELECT_CONTROL">
-          <option value="locale">My browser's language</option>
-          <option value="auto">Detect from what I say</option>
-          <optgroup label="Always this language">
-            <option v-for="lang in VOICE_LANGUAGES" :key="lang.code" :value="lang.code">{{ lang.label }}</option>
-          </optgroup>
-        </select>
-      </template>
-
-      <h3 :class="SECTION_HEADING">Web Push notifications</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Send a push to your registered devices when a background task finishes. Requires the <strong>RemoteHost</strong> connection — its sign-in provides the
-        notification auth, so pushes only send while it's connected.
-      </p>
-      <label class="flex cursor-pointer items-center gap-2">
-        <input type="checkbox" class="cursor-pointer" :checked="props.pushEnabled ?? false" aria-label="Send a Web Push to my devices" @change="onPushToggle" />
-        <span>Notify my devices</span>
-      </label>
-      <div class="mt-2.5" :class="pushEnabled ? '' : 'pointer-events-none opacity-50'">
-        <p class="mb-1.5 text-[12px] text-dim">Which moments are worth a push:</p>
-        <label v-for="kind in PUSH_KINDS" :key="kind" class="flex cursor-pointer items-start gap-2 py-0.5">
-          <input
-            type="checkbox"
-            class="mt-1 cursor-pointer"
-            :checked="pushKindList.includes(kind)"
-            :disabled="!pushEnabled"
-            :aria-label="`Push when a session is ${kind}`"
-            @change="togglePushKind(kind)"
-          />
-          <span class="text-[12px]">
-            <strong>{{ PUSH_KIND_LABEL[kind] }}</strong> — {{ PUSH_KIND_HELP[kind] }}
-          </span>
-        </label>
-      </div>
-
-      <h3 :class="SECTION_HEADING">Google account</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Link a Google account so the <code>google</code> tool and your phone can read and create <strong>Calendar</strong> events. Sign-in opens in a new tab
-        and finishes on <strong>this machine</strong>, so use a browser here — over a remote connection, run
-        <code>npx mulmoterminal@latest google login</code> instead. The link is shared with MulmoClaude.
-      </p>
-      <p v-if="googleSecretHint" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-err-text">{{ googleSecretHint }}</p>
-      <div class="mb-3 flex items-center gap-2.5">
-        <span class="text-[12px]" :class="googleStatus?.linked ? 'text-ok' : 'text-muted'">{{ googleStatusText }}</span>
-        <SettingsButton
-          v-if="!googleStatus?.linked"
-          :disabled="googleBusy || googleStatus?.pending || (googleStatus?.clientSecret !== 'found' && !googleStatus?.brokerAvailable)"
-          @click="connectGoogle"
-        >
-          Sign in with Google
-        </SettingsButton>
-        <SettingsButton v-else :disabled="googleBusy" @click="onUnlinkGoogle">Unlink</SettingsButton>
-      </div>
-      <p v-if="googleError" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-err-text" role="alert">{{ googleError }}</p>
-
-      <h3 :class="SECTION_HEADING">Pull request repos</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Repos whose open PRs the cross-repo <strong>Pull requests</strong> view lists. Uses your <code>gh</code> login. Format: <code>owner/repo</code>.
-      </p>
-      <ul v-if="repos.length" class="m-0 mb-2 flex list-none flex-col gap-1 p-0">
-        <li v-for="r in repos" :key="r" class="flex items-center gap-2 rounded-md border border-border bg-elevated py-1 pl-2.5 pr-1.5">
-          <span class="flex-auto font-mono text-[12px] text-secondary">{{ r }}</span>
-          <button
-            class="cursor-pointer rounded-md border-0 bg-transparent px-1.5 py-1 text-[14px] text-muted hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-            type="button"
-            :title="`Remove ${r}`"
-            :aria-label="`Remove ${r}`"
-            @click="removeRepo(r)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">close</span>
-          </button>
-        </li>
-      </ul>
-      <div class="flex items-center gap-2">
-        <SettingsField
-          v-model="newRepo"
-          class="flex-auto font-mono"
-          placeholder="owner/repo"
-          aria-label="Add a repository (owner/repo)"
-          spellcheck="false"
-          @keydown.enter="addRepo"
-        />
-        <SettingsButton :disabled="!newRepoValid" @click="addRepo">Add</SettingsButton>
-      </div>
-
-      <h3 :class="SECTION_HEADING">Launch commands</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Programs a grid cell can launch besides Claude — a plain shell, <code>codex</code>, any interactive command. They run in the cell's directory as a
-        persistent terminal. Example: <code>Shell</code> → <code>$SHELL</code>, <code>Codex</code> → <code>codex</code>.
-      </p>
-      <ul v-if="launcherList.length" class="m-0 mb-2 flex list-none flex-col gap-1 p-0">
-        <li v-for="l in launcherList" :key="l.label" class="flex items-center gap-2 rounded-md border border-border bg-elevated py-1 pl-2.5 pr-1.5">
-          <span class="flex-auto font-mono text-[12px] text-secondary">{{ l.label }}</span>
-          <code class="min-w-0 flex-auto truncate font-mono text-[11px] text-dim">{{ l.command }}</code>
-          <button
-            class="cursor-pointer rounded-md border-0 bg-transparent px-1.5 py-1 text-[14px] text-muted hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-            type="button"
-            :title="`Remove ${l.label}`"
-            :aria-label="`Remove ${l.label}`"
-            @click="removeLauncher(l.label)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">close</span>
-          </button>
-        </li>
-      </ul>
-      <div class="flex items-center gap-2">
-        <SettingsField
-          v-model="newLauncherLabel"
-          class="min-w-0 shrink grow basis-[30%]"
-          placeholder="Label"
-          aria-label="Launcher label"
-          spellcheck="false"
-          @keydown.enter="addLauncher"
-        />
-        <SettingsField
-          v-model="newLauncherCommand"
-          class="min-w-0 flex-auto font-mono"
-          placeholder="command (e.g. $SHELL)"
-          aria-label="Launcher command"
-          spellcheck="false"
-          @keydown.enter="addLauncher"
-        />
-        <SettingsButton :disabled="!newLauncherValid" @click="addLauncher">Add</SettingsButton>
-      </div>
-
-      <h3 :class="SECTION_HEADING">Phone quick commands</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Phrases you send often, offered as chips on the phone's terminal view. Tapping one puts the text in the input box — it isn't sent until you press send.
-        The label is the chip's face, so keep it short. Example: <code>PR</code> → <code>PR作って</code>. Leave every kind unchecked to offer a command
-        everywhere, or tick the ones it suits — <code>git status</code> belongs to a shell, not to Claude.
-      </p>
-      <ul v-if="quickCommandList.length" class="m-0 mb-2 flex list-none flex-col gap-1 p-0">
-        <li v-for="c in quickCommandList" :key="c.label" class="flex items-center gap-2 rounded-md border border-border bg-elevated py-1 pl-2.5 pr-1.5">
-          <span class="flex-none font-mono text-[12px] text-secondary">{{ c.label }}</span>
-          <code class="min-w-0 flex-auto truncate font-mono text-[11px] text-dim">{{ c.text }}</code>
-          <span class="flex-none rounded-sm bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-muted">{{ agentScopeLabel(c) }}</span>
-          <button
-            class="cursor-pointer rounded-md border-0 bg-transparent px-1.5 py-1 text-[14px] text-muted hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-            type="button"
-            :title="`Remove ${c.label}`"
-            :aria-label="`Remove ${c.label}`"
-            @click="removeQuickCommand(c.label)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">close</span>
-          </button>
-        </li>
-      </ul>
-      <div class="flex items-center gap-2">
-        <SettingsField
-          v-model="newQuickLabel"
-          class="min-w-0 shrink grow basis-[25%]"
-          placeholder="Label"
-          aria-label="Quick command label"
-          spellcheck="false"
-          @keydown.enter="addQuickCommand"
-        />
-        <SettingsField
-          v-model="newQuickText"
-          class="min-w-0 flex-auto"
-          placeholder="text to insert (e.g. PR作って)"
-          aria-label="Quick command text"
-          spellcheck="false"
-          @keydown.enter="addQuickCommand"
-        />
-        <SettingsButton :disabled="!newQuickValid" @click="addQuickCommand">Add</SettingsButton>
-      </div>
-      <div class="mt-1.5 flex items-center gap-3">
-        <span class="text-[11px] text-muted">Offer to:</span>
-        <label v-for="agent in SESSION_AGENTS" :key="agent" class="flex cursor-pointer items-center gap-1 text-[11px] text-dim">
-          <input
-            type="checkbox"
-            class="cursor-pointer"
-            :checked="newQuickAgents.includes(agent)"
-            :aria-label="`Offer to ${agent} sessions`"
-            @change="toggleNewQuickAgent(agent)"
-          />
-          <span class="font-mono">{{ agent }}</span>
-        </label>
-        <span class="text-[11px] text-muted">(none ticked = every kind)</span>
-      </div>
-
-      <h3 :class="SECTION_HEADING">MCP servers</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        HTTP MCP servers the <strong>single-view</strong> Claude session loads (in addition to the built-in GUI tools). <code>id</code> is the server name;
-        <code>url</code> is its streamable-HTTP endpoint. In the Docker sandbox, a <code>localhost</code> URL is reached over <code>host.docker.internal</code>
-        automatically. Takes effect on the next Claude session.
-      </p>
-      <ul v-if="mcpServers.length" class="m-0 mb-2 flex list-none flex-col gap-1 p-0">
-        <li v-for="s in mcpServers" :key="s.id" class="flex items-center gap-2 rounded-md border border-border bg-elevated py-1 pl-2.5 pr-1.5">
-          <span class="flex-auto font-mono text-[12px] text-secondary">{{ s.id }}</span>
-          <code class="min-w-0 flex-auto truncate font-mono text-[11px] text-dim">{{ s.url }}</code>
-          <button
-            class="cursor-pointer rounded-md border-0 bg-transparent px-1.5 py-1 text-[14px] text-muted hover:bg-[var(--err-hover-bg)] hover:text-err-text"
-            type="button"
-            :title="`Remove ${s.id}`"
-            :aria-label="`Remove ${s.id}`"
-            @click="removeMcpServer(s.id)"
-          >
-            <span class="material-symbols-outlined" aria-hidden="true">close</span>
-          </button>
-        </li>
-      </ul>
-      <div class="flex items-center gap-2">
-        <SettingsField
-          v-model="newMcpId"
-          class="min-w-0 shrink grow basis-[30%]"
-          placeholder="id (e.g. weather)"
-          aria-label="MCP server id"
-          spellcheck="false"
-          @keydown.enter="addMcpServer"
-        />
-        <SettingsField
-          v-model="newMcpUrl"
-          class="min-w-0 flex-auto font-mono"
-          placeholder="https://… or http://localhost:PORT/mcp"
-          aria-label="MCP server URL"
-          spellcheck="false"
-          @keydown.enter="addMcpServer"
-        />
-        <SettingsButton :disabled="!newMcpValid" @click="addMcpServer">Add</SettingsButton>
-      </div>
-
-      <h3 :class="SECTION_HEADING">Cost (estimated)</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Estimated spend for this project from <strong>public per-model pricing</strong> (input, output, and cache tokens) — actual billing may differ, and
-        flat-plan (Max) usage isn't reflected. Today / Month roll up this project's sessions.
-      </p>
-      <div class="flex gap-2" role="group" aria-label="Estimated cost" title="Estimated from public per-model pricing; actual billing may differ.">
-        <div class="flex flex-1 flex-col gap-1 rounded-lg border border-border bg-elevated p-2.5">
-          <span class="text-[11px] uppercase tracking-[0.04em] text-muted">Session</span>
-          <span class="font-mono text-[16px] font-semibold text-fg">{{ formatUsd(cost?.session) }}</span>
-        </div>
-        <div class="flex flex-1 flex-col gap-1 rounded-lg border border-border bg-elevated p-2.5">
-          <span class="text-[11px] uppercase tracking-[0.04em] text-muted">Today</span>
-          <span class="font-mono text-[16px] font-semibold text-fg">{{ formatUsd(cost?.today) }}</span>
-        </div>
-        <div class="flex flex-1 flex-col gap-1 rounded-lg border border-border bg-elevated p-2.5">
-          <span class="text-[11px] uppercase tracking-[0.04em] text-muted">Month</span>
-          <span class="font-mono text-[16px] font-semibold text-fg">{{ formatUsd(cost?.month) }}</span>
-        </div>
-      </div>
-      <p v-if="costError" class="mt-2 text-[12px] text-dim">Couldn't load cost estimate.</p>
-      <p v-else-if="cost && (cost.unpricedTurns > 0 || cost.sessionUnpricedTurns > 0)" class="mt-2 text-[12px] text-dim">
-        Some turns used a model with no known price and are excluded from these estimates.
-      </p>
-
-      <h3 :class="SECTION_HEADING">Keyboard shortcuts</h3>
-      <p class="mb-3 mt-1.5 text-[12px] text-dim">
-        Read-only. Shortcuts are off until you bind them in <code>~/.mulmoterminal/config.json</code> under <code>keymap</code> — every key you bind stops
-        reaching the program inside the terminal, so the skill checks a binding against what your agent already uses before writing it. Or see the
-        <a class="text-accent underline" href="https://receptron.github.io/mulmoterminal/guide/en/config.html#keymap" target="_blank" rel="noopener noreferrer"
-          >guide</a
-        >.
-      </p>
-      <div class="flex flex-col gap-1" role="list" aria-label="Keyboard shortcuts">
-        <div
-          v-for="row in shortcutRows"
-          :key="row.action"
-          role="listitem"
-          class="flex items-center gap-2 rounded-md border border-border bg-elevated px-2.5 py-1.5"
-        >
-          <span class="min-w-0 flex-1 truncate text-[12px] text-fg">{{ row.label }}</span>
-          <code v-if="row.binding" class="shrink-0 rounded border border-border bg-subtle px-1.5 py-0.5 font-mono text-[11px] text-fg">{{ row.binding }}</code>
-          <span v-else class="shrink-0 text-[11px] text-muted">Not set</span>
-          <code class="shrink-0 font-mono text-[10px] text-muted">{{ row.action }}</code>
-        </div>
-        <div v-for="row in sendKeyRows" :key="row.id" role="listitem" class="flex items-center gap-2 rounded-md border border-border bg-elevated px-2.5 py-1.5">
-          <span class="min-w-0 flex-1 truncate text-[12px] text-fg"
-            >Send <code class="font-mono text-[11px]">{{ row.label }}</code> to the terminal</span
-          >
-          <code class="shrink-0 rounded border border-border bg-subtle px-1.5 py-0.5 font-mono text-[11px] text-fg">{{ row.key }}</code>
-          <code class="shrink-0 font-mono text-[10px] text-muted">send</code>
-        </div>
-      </div>
-      <div class="mt-3">
-        <SkillLaunchButton skill="mulmoterminal-keys" icon="keyboard" label="Set up shortcuts…" @launch="emit('launch-skill', $event)" />
-      </div>
-
-      <h3 :class="SECTION_HEADING">Help &amp; user guide</h3>
-      <GuideLinks />
+      <ThemeSection @launch-skill="emit('launch-skill', $event)" />
+      <TerminalFontSizeSection />
+      <TerminalScrollSection />
+      <WaitingRowsSection />
+      <DirAppearanceSection @launch-skill="emit('launch-skill', $event)" />
+      <DirSettingsSection :dir-paths="dirPaths" @launch-skill="emit('launch-skill', $event)" />
+      <NotificationSoundsSection
+        :sound-file="soundFile"
+        :sound-kinds="soundKinds"
+        :sounds="sounds"
+        @update-sound="emit('update-sound', $event)"
+        @update-sound-kinds="emit('update-sound-kinds', $event)"
+        @update-sounds="emit('update-sounds', $event)"
+        @launch-skill="emit('launch-skill', $event)"
+      />
+      <VoiceInputSection />
+      <WebPushSection
+        :push-enabled="pushEnabled"
+        :push-kinds="pushKinds"
+        @update-push-enabled="emit('update-push-enabled', $event)"
+        @update-push-kinds="emit('update-push-kinds', $event)"
+      />
+      <GoogleAccountSection />
+      <PrReposSection :pr-repos="prRepos" @update-repos="emit('update-repos', $event)" />
+      <LaunchersSection :launchers="launchers" @update-launchers="emit('update-launchers', $event)" />
+      <QuickCommandsSection :quick-commands="quickCommands" @update-quick-commands="emit('update-quick-commands', $event)" />
+      <McpServersSection :user-mcp-servers="userMcpServers" @update-user-mcp="emit('update-user-mcp', $event)" />
+      <CostSection :cwd="cwd" :session-id="sessionId" />
+      <ShortcutsSection @launch-skill="emit('launch-skill', $event)" />
+      <HelpSection />
 
       <div class="mt-4 flex items-center gap-2">
         <span class="flex-1" />

--- a/src/components/settings/CostSection.vue
+++ b/src/components/settings/CostSection.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { onMounted, watch } from "vue";
+import { useCost } from "../../composables/useCost";
+import { formatUsd } from "../formatUsd";
+import { SECTION_HEADING } from "./sectionClasses";
+
+const props = defineProps<{ cwd?: string | null | undefined; sessionId?: string | null | undefined }>();
+
+// Read-only estimated cost (Session / Today / Month), loaded when the modal opens.
+const { cost, error: costError, load: loadCost } = useCost();
+
+// Load unconditionally — the server falls back to the workspace when no cwd is passed, so
+// Today/Month still populate in the grid view (no active single-view session ⇒ no cwd/sessionId).
+// Re-fetch if cwd/sessionId arrive or change while open.
+const refreshCost = () => void loadCost(props.cwd ?? null, props.sessionId ?? null);
+onMounted(refreshCost);
+watch([() => props.cwd, () => props.sessionId], refreshCost);
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Cost (estimated)</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Estimated spend for this project from <strong>public per-model pricing</strong> (input, output, and cache tokens) — actual billing may differ, and flat-plan
+    (Max) usage isn't reflected. Today / Month roll up this project's sessions.
+  </p>
+  <div class="flex gap-2" role="group" aria-label="Estimated cost" title="Estimated from public per-model pricing; actual billing may differ.">
+    <div class="flex flex-1 flex-col gap-1 rounded-lg border border-border bg-elevated p-2.5">
+      <span class="text-[11px] uppercase tracking-[0.04em] text-muted">Session</span>
+      <span class="font-mono text-[16px] font-semibold text-fg">{{ formatUsd(cost?.session) }}</span>
+    </div>
+    <div class="flex flex-1 flex-col gap-1 rounded-lg border border-border bg-elevated p-2.5">
+      <span class="text-[11px] uppercase tracking-[0.04em] text-muted">Today</span>
+      <span class="font-mono text-[16px] font-semibold text-fg">{{ formatUsd(cost?.today) }}</span>
+    </div>
+    <div class="flex flex-1 flex-col gap-1 rounded-lg border border-border bg-elevated p-2.5">
+      <span class="text-[11px] uppercase tracking-[0.04em] text-muted">Month</span>
+      <span class="font-mono text-[16px] font-semibold text-fg">{{ formatUsd(cost?.month) }}</span>
+    </div>
+  </div>
+  <p v-if="costError" class="mt-2 text-[12px] text-dim">Couldn't load cost estimate.</p>
+  <p v-else-if="cost && (cost.unpricedTurns > 0 || cost.sessionUnpricedTurns > 0)" class="mt-2 text-[12px] text-dim">
+    Some turns used a model with no known price and are excluded from these estimates.
+  </p>
+</template>

--- a/src/components/settings/DirAppearanceSection.vue
+++ b/src/components/settings/DirAppearanceSection.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import SkillLaunchButton from "../SkillLaunchButton.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+import type { BundledSkillName } from "../../../common/bundledSkills";
+
+const emit = defineEmits<{ (e: "launch-skill", skill: BundledSkillName): void }>();
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Directory appearance</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Launch the <code>mulmoterminal-dirs</code> skill to style and order your directories — name badge, colors, terminal palette, grid position. It starts from
+    the directories you actually open, reads the settings you already have, and follows the same pattern for the ones that have none.
+  </p>
+  <SkillLaunchButton skill="mulmoterminal-dirs" icon="palette" label="Configure appearance…" @launch="emit('launch-skill', $event)" />
+</template>

--- a/src/components/settings/DirSettingsSection.vue
+++ b/src/components/settings/DirSettingsSection.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import DirConfigPreview from "../DirConfigPreview.vue";
+import SkillLaunchButton from "../SkillLaunchButton.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+import type { BundledSkillName } from "../../../common/bundledSkills";
+
+defineProps<{ dirPaths?: string[] | undefined }>();
+const emit = defineEmits<{ (e: "launch-skill", skill: BundledSkillName): void }>();
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Directory settings</h3>
+  <p class="mb-1 mt-1.5 text-[12px] text-dim">
+    What each directory's <code>.mulmoterminal.json</code> is actually doing. Expand one to see the values in force, and any key the app dropped or doesn't
+    recognise — a setting that never took effect looks the same as one you never made until you can see this.
+  </p>
+  <DirConfigPreview :paths="dirPaths ?? []" />
+  <p class="mb-3 mt-2.5 text-[12px] text-dim">
+    This lists what is wrong; the skill reads the same thing and says why, then fixes it or points you at whichever skill owns that key.
+  </p>
+  <SkillLaunchButton skill="mulmoterminal-config" icon="troubleshoot" label="Explain my settings…" @launch="emit('launch-skill', $event)" />
+</template>

--- a/src/components/settings/GoogleAccountSection.vue
+++ b/src/components/settings/GoogleAccountSection.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted } from "vue";
+import { useGoogleLink } from "../../composables/useGoogleLink";
+import SettingsButton from "../SettingsButton.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+
+// The modal is v-if'd, so a fresh load on mount also picks up out-of-band changes
+// (`mulmoterminal google login`, a deleted token file).
+const {
+  status: googleStatus,
+  busy: googleBusy,
+  error: googleError,
+  refresh: refreshGoogle,
+  connect: connectGoogle,
+  unlink: unlinkGoogle,
+  dispose: disposeGoogle,
+} = useGoogleLink();
+
+const googleStatusText = computed(() => {
+  if (!googleStatus.value) return "Checking…";
+  if (googleStatus.value.pending) return "Waiting for consent in your browser…";
+  return googleStatus.value.linked ? "Linked" : "Not linked";
+});
+
+// Broker (GCP settings-free link) removes the client secret requirement. When a broker is available,
+// consent can flow through it; otherwise, a Desktop client's secret on disk is needed.
+const googleSecretHint = computed(() => {
+  if (googleStatus.value?.brokerAvailable) return "";
+  const presence = googleStatus.value?.clientSecret;
+  if (presence === "missing")
+    return "No OAuth client secret found in ~/.secrets. Add a Desktop client's client_secret_*.json there to enable sign-in, or use the GCP-settings-free broker link if available.";
+  if (presence === "ambiguous") return "Multiple client_secret_*.json files in ~/.secrets — keep exactly one.";
+  return "";
+});
+
+async function onUnlinkGoogle() {
+  if (!window.confirm("Unlink this Google account? MulmoTerminal will lose Calendar access until you sign in again.")) return;
+  await unlinkGoogle();
+}
+
+onMounted(() => void refreshGoogle());
+onUnmounted(disposeGoogle);
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Google account</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Link a Google account so the <code>google</code> tool and your phone can read and create <strong>Calendar</strong> events. Sign-in opens in a new tab and
+    finishes on <strong>this machine</strong>, so use a browser here — over a remote connection, run <code>npx mulmoterminal@latest google login</code> instead.
+    The link is shared with MulmoClaude.
+  </p>
+  <p v-if="googleSecretHint" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-err-text">{{ googleSecretHint }}</p>
+  <div class="mb-3 flex items-center gap-2.5">
+    <span class="text-[12px]" :class="googleStatus?.linked ? 'text-ok' : 'text-muted'">{{ googleStatusText }}</span>
+    <SettingsButton
+      v-if="!googleStatus?.linked"
+      :disabled="googleBusy || googleStatus?.pending || (googleStatus?.clientSecret !== 'found' && !googleStatus?.brokerAvailable)"
+      @click="connectGoogle"
+    >
+      Sign in with Google
+    </SettingsButton>
+    <SettingsButton v-else :disabled="googleBusy" @click="onUnlinkGoogle">Unlink</SettingsButton>
+  </div>
+  <p v-if="googleError" data-testid="google-warn" class="mb-3 mt-1.5 text-[12px] text-err-text" role="alert">{{ googleError }}</p>
+</template>

--- a/src/components/settings/HelpSection.vue
+++ b/src/components/settings/HelpSection.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import GuideLinks from "../GuideLinks.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Help &amp; user guide</h3>
+  <GuideLinks />
+</template>

--- a/src/components/settings/LaunchersSection.vue
+++ b/src/components/settings/LaunchersSection.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useSavedListMirror } from "../../composables/useSavedListMirror";
+import SettingsButton from "../SettingsButton.vue";
+import SettingsField from "../SettingsField.vue";
+import { canAddLauncher } from "../settingsValidators";
+import type { Launcher } from "../launchers";
+import SettingsListRow from "./SettingsListRow.vue";
+import { SECTION_HEADING, SETTINGS_LIST } from "./sectionClasses";
+
+const props = defineProps<{ launchers?: Launcher[] | undefined }>();
+const emit = defineEmits<{ (e: "update-launchers", launchers: Launcher[]): void }>();
+
+// Cell-launcher commands (label + command).
+const { items: launcherList, replace } = useSavedListMirror<Launcher>(
+  () => props.launchers,
+  (next) => emit("update-launchers", next),
+);
+
+const newLauncherLabel = ref("");
+const newLauncherCommand = ref("");
+const newLauncherValid = computed(() => canAddLauncher(newLauncherLabel.value, newLauncherCommand.value, launcherList.value));
+function addLauncher() {
+  if (!newLauncherValid.value) return;
+  replace([...launcherList.value, { label: newLauncherLabel.value.trim(), command: newLauncherCommand.value.trim() }]);
+  newLauncherLabel.value = "";
+  newLauncherCommand.value = "";
+}
+function removeLauncher(label: string) {
+  replace(launcherList.value.filter((l) => l.label !== label));
+}
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Launch commands</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Programs a grid cell can launch besides Claude — a plain shell, <code>codex</code>, any interactive command. They run in the cell's directory as a
+    persistent terminal. Example: <code>Shell</code> → <code>$SHELL</code>, <code>Codex</code> → <code>codex</code>.
+  </p>
+  <ul v-if="launcherList.length" :class="SETTINGS_LIST">
+    <SettingsListRow v-for="l in launcherList" :key="l.label" :name="l.label" @remove="removeLauncher(l.label)">
+      <span class="flex-auto font-mono text-[12px] text-secondary">{{ l.label }}</span>
+      <code class="min-w-0 flex-auto truncate font-mono text-[11px] text-dim">{{ l.command }}</code>
+    </SettingsListRow>
+  </ul>
+  <div class="flex items-center gap-2">
+    <SettingsField
+      v-model="newLauncherLabel"
+      class="min-w-0 shrink grow basis-[30%]"
+      placeholder="Label"
+      aria-label="Launcher label"
+      spellcheck="false"
+      @keydown.enter="addLauncher"
+    />
+    <SettingsField
+      v-model="newLauncherCommand"
+      class="min-w-0 flex-auto font-mono"
+      placeholder="command (e.g. $SHELL)"
+      aria-label="Launcher command"
+      spellcheck="false"
+      @keydown.enter="addLauncher"
+    />
+    <SettingsButton :disabled="!newLauncherValid" @click="addLauncher">Add</SettingsButton>
+  </div>
+</template>

--- a/src/components/settings/McpServersSection.vue
+++ b/src/components/settings/McpServersSection.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useSavedListMirror } from "../../composables/useSavedListMirror";
+import SettingsButton from "../SettingsButton.vue";
+import SettingsField from "../SettingsField.vue";
+import { canAddMcpServer } from "../settingsValidators";
+import type { UserMcpServer } from "../userMcp";
+import SettingsListRow from "./SettingsListRow.vue";
+import { SECTION_HEADING, SETTINGS_LIST } from "./sectionClasses";
+
+const props = defineProps<{ userMcpServers?: UserMcpServer[] | undefined }>();
+const emit = defineEmits<{ (e: "update-user-mcp", servers: UserMcpServer[]): void }>();
+
+// User HTTP MCP servers (id + url) merged into the single-view Claude session.
+const { items: mcpServers, replace } = useSavedListMirror<UserMcpServer>(
+  () => props.userMcpServers,
+  (next) => emit("update-user-mcp", next),
+);
+
+const newMcpId = ref("");
+const newMcpUrl = ref("");
+const newMcpValid = computed(() => canAddMcpServer(newMcpId.value, newMcpUrl.value, mcpServers.value));
+function addMcpServer() {
+  if (!newMcpValid.value) return;
+  replace([...mcpServers.value, { id: newMcpId.value.trim(), url: newMcpUrl.value.trim() }]);
+  newMcpId.value = "";
+  newMcpUrl.value = "";
+}
+function removeMcpServer(id: string) {
+  replace(mcpServers.value.filter((s) => s.id !== id));
+}
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">MCP servers</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    HTTP MCP servers the <strong>single-view</strong> Claude session loads (in addition to the built-in GUI tools). <code>id</code> is the server name;
+    <code>url</code> is its streamable-HTTP endpoint. In the Docker sandbox, a <code>localhost</code> URL is reached over <code>host.docker.internal</code>
+    automatically. Takes effect on the next Claude session.
+  </p>
+  <ul v-if="mcpServers.length" :class="SETTINGS_LIST">
+    <SettingsListRow v-for="s in mcpServers" :key="s.id" :name="s.id" @remove="removeMcpServer(s.id)">
+      <span class="flex-auto font-mono text-[12px] text-secondary">{{ s.id }}</span>
+      <code class="min-w-0 flex-auto truncate font-mono text-[11px] text-dim">{{ s.url }}</code>
+    </SettingsListRow>
+  </ul>
+  <div class="flex items-center gap-2">
+    <SettingsField
+      v-model="newMcpId"
+      class="min-w-0 shrink grow basis-[30%]"
+      placeholder="id (e.g. weather)"
+      aria-label="MCP server id"
+      spellcheck="false"
+      @keydown.enter="addMcpServer"
+    />
+    <SettingsField
+      v-model="newMcpUrl"
+      class="min-w-0 flex-auto font-mono"
+      placeholder="https://… or http://localhost:PORT/mcp"
+      aria-label="MCP server URL"
+      spellcheck="false"
+      @keydown.enter="addMcpServer"
+    />
+    <SettingsButton :disabled="!newMcpValid" @click="addMcpServer">Add</SettingsButton>
+  </div>
+</template>

--- a/src/components/settings/NotificationSoundsSection.vue
+++ b/src/components/settings/NotificationSoundsSection.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { previewNotify } from "../../composables/useAttentionSound";
+import { customSoundLabel, isCustomSound, toggledKinds, withKindSound, type SoundMap } from "../../composables/soundSettings";
+import SettingsButton from "../SettingsButton.vue";
+import SettingsField from "../SettingsField.vue";
+import SkillLaunchButton from "../SkillLaunchButton.vue";
+import { SELECT_CONTROL } from "../selectClasses";
+import { SECTION_HEADING } from "./sectionClasses";
+import { NOTIFY_KINDS, type NotifyKind } from "../../../common/notifyKinds";
+import { presetRef, SOUND_PRESETS } from "../../../common/notifySounds";
+import type { BundledSkillName } from "../../../common/bundledSkills";
+import { isRecord } from "../../../common/isRecord";
+
+const props = defineProps<{ soundFile?: string | null | undefined; soundKinds?: NotifyKind[] | undefined; sounds?: SoundMap | undefined }>();
+const emit = defineEmits<{
+  (e: "update-sound", file: string | null): void;
+  (e: "update-sound-kinds", kinds: NotifyKind[]): void;
+  (e: "update-sounds", sounds: SoundMap): void;
+  (e: "launch-skill", skill: BundledSkillName): void;
+}>();
+
+// Which moments beep, and what each one plays (#873). The toolbar's speaker icon says whether to
+// beep at all, this says which moments qualify.
+const NOTIFY_KIND_LABEL: Record<NotifyKind, string> = {
+  finished: "Turn finished",
+  waiting: "Waiting for you",
+  "command-done": "Command finished",
+  "command-failed": "Command failed",
+  "session-exited": "Session ended",
+  "pr-ci-failed": "PR CI failed",
+};
+const NOTIFY_KIND_HELP: Record<NotifyKind, string> = {
+  finished: "the agent replied and the output is unread",
+  waiting: "it stopped to ask — a permission prompt or a question",
+  "command-done": "a Run cell's command exited cleanly",
+  "command-failed": "a Run cell's command exited with an error, or never started",
+  "session-exited": "a session's terminal ended — including when you close the cell yourself",
+  "pr-ci-failed": "a directory's PR went red. Only seen while the roster is on screen, since that is what polls it",
+};
+
+const soundKindList = ref<NotifyKind[]>([...(props.soundKinds ?? [])]);
+watch(
+  () => props.soundKinds,
+  (k) => (soundKindList.value = [...(k ?? [])]),
+);
+function toggleSoundKind(kind: NotifyKind) {
+  soundKindList.value = toggledKinds(soundKindList.value, kind);
+  emit("update-sound-kinds", soundKindList.value);
+}
+
+// Editable mirror of the saved map. It has to be a LOCAL ref and not `props.sounds`: the whole
+// map is persisted on every change, so two picks made before the first POST answers would both
+// compute from the same pre-save snapshot and the second would drop the first. This is the hazard
+// createPresetMutations serializes writes for.
+const soundMap = ref<SoundMap>({ ...(props.sounds ?? {}) });
+watch(
+  () => props.sounds,
+  (m) => (soundMap.value = { ...(m ?? {}) }),
+);
+
+// "" is the fallback (the file below, else the chime). A kind whose saved value is a PATH —
+// only settable by hand in config.json — gets an extra option so picking a preset for another
+// kind can't silently drop it. The editing itself is pure, in composables/soundSettings.
+const soundValue = (kind: NotifyKind): string => soundMap.value[kind] ?? "";
+function setKindSound(kind: NotifyKind, value: string) {
+  soundMap.value = withKindSound(soundMap.value, kind, value);
+  emit("update-sounds", soundMap.value);
+}
+function onKindSoundChange(kind: NotifyKind, e: Event) {
+  if (e.target instanceof HTMLSelectElement) setKindSound(kind, e.target.value);
+}
+// Preview what this kind would play, resolved the same way a real beep resolves it (the kind's
+// own sound, else the fallback file, else the chime). Reads the LOCAL map so a preset picked a
+// moment ago is what you hear — a preset is fetched by id and needs no saved config. Falling
+// back to `soundFile` still shows the saved path, which is the only value the server can stream.
+function testKindSound(kind: NotifyKind) {
+  void previewNotify(kind, { kinds: soundKindList.value, sounds: soundMap.value, soundFile: props.soundFile ?? null });
+}
+
+// Custom attention sound, applied immediately (like the theme) — empty => the
+// built-in chime. The text box mirrors the saved value; Browse / typing apply it.
+const soundPath = ref(props.soundFile ?? "");
+watch(
+  () => props.soundFile,
+  (f) => (soundPath.value = f ?? ""),
+);
+
+function applySound() {
+  emit("update-sound", soundPath.value.trim() || null);
+}
+function clearSound() {
+  soundPath.value = "";
+  emit("update-sound", null);
+}
+async function browseSound() {
+  try {
+    const res = await fetch("/api/pick-file", { method: "POST", headers: { "content-type": "application/json" } });
+    if (!res.ok) return;
+    const data: unknown = await res.json();
+    const picked = isRecord(data) && Array.isArray(data.paths) && typeof data.paths[0] === "string" ? data.paths[0] : "";
+    if (picked) {
+      soundPath.value = picked;
+      applySound();
+    }
+  } catch {
+    // native dialog unavailable / canceled — leave the field as-is
+  }
+}
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Notification sounds</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Which moments beep, and what each one plays. Running many agents at once is what turns notifications into noise — untick the ones you don't need. The
+    speaker button in the toolbar silences all of them at once.
+  </p>
+  <div v-for="kind in NOTIFY_KINDS" :key="kind" class="py-0.5">
+    <div class="flex items-center gap-2">
+      <label class="flex min-w-0 flex-1 cursor-pointer items-center gap-2">
+        <input
+          type="checkbox"
+          class="shrink-0 cursor-pointer"
+          :checked="soundKindList.includes(kind)"
+          :aria-label="`Beep when a session is ${kind}`"
+          @change="toggleSoundKind(kind)"
+        />
+        <span class="truncate text-[12px]"
+          ><strong>{{ NOTIFY_KIND_LABEL[kind] }}</strong></span
+        >
+      </label>
+      <!-- The width lives on this wrapper, not the select: SELECT_CONTROL is `w-full`, and a
+           `w-44` beside it is the same specificity — which of the two wins is decided by the
+           order Tailwind emits them, not by the order written here. -->
+      <div class="w-36 shrink-0">
+        <select
+          :value="soundValue(kind)"
+          :disabled="!soundKindList.includes(kind)"
+          :aria-label="`Sound for ${NOTIFY_KIND_LABEL[kind]}`"
+          :class="SELECT_CONTROL"
+          class="truncate"
+          @change="onKindSoundChange(kind, $event)"
+        >
+          <option value="">Default</option>
+          <option v-for="preset in SOUND_PRESETS" :key="preset.id" :value="presetRef(preset.id)">{{ preset.label }}</option>
+          <option v-if="isCustomSound(soundValue(kind))" :value="soundValue(kind)">{{ customSoundLabel(soundValue(kind)) }}</option>
+        </select>
+      </div>
+      <SettingsButton class="shrink-0" :title="`Play the ${NOTIFY_KIND_LABEL[kind]} sound`" @click="testKindSound(kind)"
+        ><span class="material-symbols-outlined" aria-hidden="true">play_arrow</span></SettingsButton
+      >
+    </div>
+    <p class="ml-6 text-[11px] text-dim">{{ NOTIFY_KIND_HELP[kind] }}</p>
+  </div>
+
+  <p class="mb-1.5 mt-3 text-[12px] text-dim">
+    <strong>Default</strong> plays your own file below, or the built-in chime when that is empty. The presets are fetched once and kept on this machine, so they
+    keep working offline.
+  </p>
+  <div class="flex items-center gap-2">
+    <SettingsField
+      v-model="soundPath"
+      class="flex-auto font-mono"
+      placeholder="/absolute/path/to/sound.wav"
+      aria-label="Custom notification sound file"
+      spellcheck="false"
+      @change="applySound"
+    />
+    <SettingsButton @click="browseSound">Browse…</SettingsButton>
+    <SettingsButton :disabled="!soundPath" title="Use the built-in chime" @click="clearSound">Use chime</SettingsButton>
+  </div>
+  <p class="mb-3 mt-3 text-[12px] text-dim">
+    These are the sounds for every session. The skill also gives one project its own sound, picks which moments push to your phone, and works out which of them
+    is the one waking you up.
+  </p>
+  <SkillLaunchButton skill="mulmoterminal-notify" icon="notifications_active" label="Configure notifications…" @launch="emit('launch-skill', $event)" />
+</template>

--- a/src/components/settings/PrReposSection.vue
+++ b/src/components/settings/PrReposSection.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useSavedListMirror } from "../../composables/useSavedListMirror";
+import SettingsButton from "../SettingsButton.vue";
+import SettingsField from "../SettingsField.vue";
+import { canAddRepo } from "../settingsValidators";
+import SettingsListRow from "./SettingsListRow.vue";
+import { SECTION_HEADING, SETTINGS_LIST } from "./sectionClasses";
+
+const props = defineProps<{ prRepos?: string[] | undefined }>();
+const emit = defineEmits<{ (e: "update-repos", repos: string[]): void }>();
+
+// Cross-repo PR view's repos ("owner/repo").
+const { items: repos, replace } = useSavedListMirror<string>(
+  () => props.prRepos,
+  (next) => emit("update-repos", next),
+);
+
+const newRepo = ref("");
+const newRepoValid = computed(() => canAddRepo(newRepo.value, repos.value));
+function addRepo() {
+  if (!newRepoValid.value) return;
+  replace([...repos.value, newRepo.value.trim()]);
+  newRepo.value = "";
+}
+function removeRepo(repo: string) {
+  replace(repos.value.filter((r) => r !== repo));
+}
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Pull request repos</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Repos whose open PRs the cross-repo <strong>Pull requests</strong> view lists. Uses your <code>gh</code> login. Format: <code>owner/repo</code>.
+  </p>
+  <ul v-if="repos.length" :class="SETTINGS_LIST">
+    <SettingsListRow v-for="r in repos" :key="r" :name="r" @remove="removeRepo(r)">
+      <span class="flex-auto font-mono text-[12px] text-secondary">{{ r }}</span>
+    </SettingsListRow>
+  </ul>
+  <div class="flex items-center gap-2">
+    <SettingsField
+      v-model="newRepo"
+      class="flex-auto font-mono"
+      placeholder="owner/repo"
+      aria-label="Add a repository (owner/repo)"
+      spellcheck="false"
+      @keydown.enter="addRepo"
+    />
+    <SettingsButton :disabled="!newRepoValid" @click="addRepo">Add</SettingsButton>
+  </div>
+</template>

--- a/src/components/settings/QuickCommandsSection.vue
+++ b/src/components/settings/QuickCommandsSection.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useSavedListMirror } from "../../composables/useSavedListMirror";
+import SettingsButton from "../SettingsButton.vue";
+import SettingsField from "../SettingsField.vue";
+import { canAddQuickCommand } from "../settingsValidators";
+import SettingsListRow from "./SettingsListRow.vue";
+import { SECTION_HEADING, SETTINGS_LIST } from "./sectionClasses";
+import type { QuickCommand } from "../../../common/quickCommands";
+import { SESSION_AGENTS, type SessionAgent } from "../../../common/sessionAgent";
+
+const props = defineProps<{ quickCommands?: QuickCommand[] | undefined }>();
+const emit = defineEmits<{ (e: "update-quick-commands", commands: QuickCommand[]): void }>();
+
+// Phrases the phone offers as chips on a session (#830). `agents` scopes an entry to session
+// kinds, and selecting none means every kind.
+const { items: quickCommandList, replace } = useSavedListMirror<QuickCommand>(
+  () => props.quickCommands,
+  (next) => emit("update-quick-commands", next),
+);
+
+const newQuickLabel = ref("");
+const newQuickText = ref("");
+const newQuickAgents = ref<SessionAgent[]>([]);
+const newQuickValid = computed(() => canAddQuickCommand(newQuickLabel.value, newQuickText.value, quickCommandList.value));
+
+function toggleNewQuickAgent(agent: SessionAgent) {
+  newQuickAgents.value = newQuickAgents.value.includes(agent) ? newQuickAgents.value.filter((a) => a !== agent) : [...newQuickAgents.value, agent];
+}
+
+function addQuickCommand() {
+  if (!newQuickValid.value) return;
+  const label = newQuickLabel.value.trim();
+  const text = newQuickText.value.trim();
+  // Omit `agents` rather than send [] — the server reads an empty list as "every kind" too,
+  // but leaving the key out is what the config format documents for "unscoped".
+  const agents = newQuickAgents.value.length ? [...newQuickAgents.value] : undefined;
+  replace([...quickCommandList.value, agents ? { label, text, agents } : { label, text }]);
+  newQuickLabel.value = "";
+  newQuickText.value = "";
+  newQuickAgents.value = [];
+}
+
+function removeQuickCommand(label: string) {
+  replace(quickCommandList.value.filter((c) => c.label !== label));
+}
+
+const agentScopeLabel = (command: QuickCommand): string => (command.agents?.length ? command.agents.join(" / ") : "all");
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Phone quick commands</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Phrases you send often, offered as chips on the phone's terminal view. Tapping one puts the text in the input box — it isn't sent until you press send. The
+    label is the chip's face, so keep it short. Example: <code>PR</code> → <code>PR作って</code>. Leave every kind unchecked to offer a command everywhere, or
+    tick the ones it suits — <code>git status</code> belongs to a shell, not to Claude.
+  </p>
+  <ul v-if="quickCommandList.length" :class="SETTINGS_LIST">
+    <SettingsListRow v-for="c in quickCommandList" :key="c.label" :name="c.label" @remove="removeQuickCommand(c.label)">
+      <span class="flex-none font-mono text-[12px] text-secondary">{{ c.label }}</span>
+      <code class="min-w-0 flex-auto truncate font-mono text-[11px] text-dim">{{ c.text }}</code>
+      <span class="flex-none rounded-sm bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-muted">{{ agentScopeLabel(c) }}</span>
+    </SettingsListRow>
+  </ul>
+  <div class="flex items-center gap-2">
+    <SettingsField
+      v-model="newQuickLabel"
+      class="min-w-0 shrink grow basis-[25%]"
+      placeholder="Label"
+      aria-label="Quick command label"
+      spellcheck="false"
+      @keydown.enter="addQuickCommand"
+    />
+    <SettingsField
+      v-model="newQuickText"
+      class="min-w-0 flex-auto"
+      placeholder="text to insert (e.g. PR作って)"
+      aria-label="Quick command text"
+      spellcheck="false"
+      @keydown.enter="addQuickCommand"
+    />
+    <SettingsButton :disabled="!newQuickValid" @click="addQuickCommand">Add</SettingsButton>
+  </div>
+  <div class="mt-1.5 flex items-center gap-3">
+    <span class="text-[11px] text-muted">Offer to:</span>
+    <label v-for="agent in SESSION_AGENTS" :key="agent" class="flex cursor-pointer items-center gap-1 text-[11px] text-dim">
+      <input
+        type="checkbox"
+        class="cursor-pointer"
+        :checked="newQuickAgents.includes(agent)"
+        :aria-label="`Offer to ${agent} sessions`"
+        @change="toggleNewQuickAgent(agent)"
+      />
+      <span class="font-mono">{{ agent }}</span>
+    </label>
+    <span class="text-[11px] text-muted">(none ticked = every kind)</span>
+  </div>
+</template>

--- a/src/components/settings/SettingsListRow.vue
+++ b/src/components/settings/SettingsListRow.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+// One saved entry in a Settings list, with the button that removes it. The four lists (PR repos,
+// launchers, phone quick commands, MCP servers) all show a row this shape, so the frame and the
+// remove button are one decision; what the row SAYS is the slot.
+//
+// `name` is what the entry is called in the list — the repo, the launcher's label, the server id.
+// It only reaches the accessible name, so a screen reader hears which entry a button removes
+// rather than fourteen buttons all called "Remove".
+defineProps<{ name: string }>();
+const emit = defineEmits<{ (e: "remove"): void }>();
+</script>
+
+<template>
+  <li class="flex items-center gap-2 rounded-md border border-border bg-elevated py-1 pl-2.5 pr-1.5">
+    <slot />
+    <button
+      class="cursor-pointer rounded-md border-0 bg-transparent px-1.5 py-1 text-[14px] text-muted hover:bg-[var(--err-hover-bg)] hover:text-err-text"
+      type="button"
+      :title="`Remove ${name}`"
+      :aria-label="`Remove ${name}`"
+      @click="emit('remove')"
+    >
+      <span class="material-symbols-outlined" aria-hidden="true">close</span>
+    </button>
+  </li>
+</template>

--- a/src/components/settings/SettingsStepper.vue
+++ b/src/components/settings/SettingsStepper.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+// A −/value/+ nudger for the Settings modal's numeric per-browser settings (terminal font size,
+// terminal scroll speed). Emits the SIGNED step, so the caller's nudge function takes it as-is.
+//
+// `label` is the setting in lower case as it reads inside a sentence ("terminal font size"), and
+// becomes the buttons' accessible names: "Decrease terminal font size".
+//
+// `unit` is appended to the value as given — " px" carries its own leading space, "×" does not.
+defineProps<{ value: number; unit: string; min: number; max: number; step: number; label: string }>();
+const emit = defineEmits<{ (e: "nudge", delta: number): void }>();
+
+const STEPPER_BUTTON =
+  "flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg border border-border bg-elevated text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40";
+</script>
+
+<template>
+  <div class="flex items-center gap-2">
+    <button type="button" :class="STEPPER_BUTTON" :disabled="value <= min" :aria-label="`Decrease ${label}`" @click="emit('nudge', -step)">−</button>
+    <span class="min-w-[56px] text-center text-[13px] text-fg" aria-live="polite">{{ value }}{{ unit }}</span>
+    <button type="button" :class="STEPPER_BUTTON" :disabled="value >= max" :aria-label="`Increase ${label}`" @click="emit('nudge', step)">+</button>
+  </div>
+</template>

--- a/src/components/settings/ShortcutsSection.vue
+++ b/src/components/settings/ShortcutsSection.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { activeKeymap } from "../../composables/activeKeymap";
+import { keymapRows, sendRows } from "../keymapLabels";
+import SkillLaunchButton from "../SkillLaunchButton.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+import type { BundledSkillName } from "../../../common/bundledSkills";
+
+const emit = defineEmits<{ (e: "launch-skill", skill: BundledSkillName): void }>();
+
+// Reactive, not a snapshot: /api/config is fetched asynchronously, so a modal opened before it
+// lands would otherwise sit on "Not set" for every action until it is closed and reopened.
+const shortcutRows = computed(() => keymapRows(activeKeymap.value));
+const sendKeyRows = computed(() => sendRows(activeKeymap.value));
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Keyboard shortcuts</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Read-only. Shortcuts are off until you bind them in <code>~/.mulmoterminal/config.json</code> under <code>keymap</code> — every key you bind stops reaching
+    the program inside the terminal, so the skill checks a binding against what your agent already uses before writing it. Or see the
+    <a class="text-accent underline" href="https://receptron.github.io/mulmoterminal/guide/en/config.html#keymap" target="_blank" rel="noopener noreferrer"
+      >guide</a
+    >.
+  </p>
+  <div class="flex flex-col gap-1" role="list" aria-label="Keyboard shortcuts">
+    <div
+      v-for="row in shortcutRows"
+      :key="row.action"
+      role="listitem"
+      class="flex items-center gap-2 rounded-md border border-border bg-elevated px-2.5 py-1.5"
+    >
+      <span class="min-w-0 flex-1 truncate text-[12px] text-fg">{{ row.label }}</span>
+      <code v-if="row.binding" class="shrink-0 rounded border border-border bg-subtle px-1.5 py-0.5 font-mono text-[11px] text-fg">{{ row.binding }}</code>
+      <span v-else class="shrink-0 text-[11px] text-muted">Not set</span>
+      <code class="shrink-0 font-mono text-[10px] text-muted">{{ row.action }}</code>
+    </div>
+    <div v-for="row in sendKeyRows" :key="row.id" role="listitem" class="flex items-center gap-2 rounded-md border border-border bg-elevated px-2.5 py-1.5">
+      <span class="min-w-0 flex-1 truncate text-[12px] text-fg"
+        >Send <code class="font-mono text-[11px]">{{ row.label }}</code> to the terminal</span
+      >
+      <code class="shrink-0 rounded border border-border bg-subtle px-1.5 py-0.5 font-mono text-[11px] text-fg">{{ row.key }}</code>
+      <code class="shrink-0 font-mono text-[10px] text-muted">send</code>
+    </div>
+  </div>
+  <div class="mt-3">
+    <SkillLaunchButton skill="mulmoterminal-keys" icon="keyboard" label="Set up shortcuts…" @launch="emit('launch-skill', $event)" />
+  </div>
+</template>

--- a/src/components/settings/TerminalFontSizeSection.vue
+++ b/src/components/settings/TerminalFontSizeSection.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useTerminalFontSize } from "../../composables/useTerminalFontSize";
+import SettingsStepper from "./SettingsStepper.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+
+// Applied immediately (like the theme). Per-browser, so a phone and a desktop on the same server
+// keep their own; a directory can pin its own in .mulmoterminal.json.
+const { fontSize, nudgeFontSize, min, max, step } = useTerminalFontSize();
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Terminal font size</h3>
+  <SettingsStepper :value="fontSize" :unit="' px'" :min="min" :max="max" :step="step" label="terminal font size" @nudge="nudgeFontSize" />
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Applies to every terminal on this browser. A directory can pin its own with <code>fontSize</code> in its <code>.mulmoterminal.json</code>.
+  </p>
+</template>

--- a/src/components/settings/TerminalScrollSection.vue
+++ b/src/components/settings/TerminalScrollSection.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { useTerminalScrollSpeed } from "../../composables/useTerminalScrollSpeed";
+import SettingsStepper from "./SettingsStepper.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+
+// Same shape and the same per-browser reasoning as the font size: it is a property of the
+// pointing device, and a trackpad and a wheel mouse want different answers.
+const { scrollSpeed, nudgeScrollSpeed, min, max, step } = useTerminalScrollSpeed();
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Terminal scroll speed</h3>
+  <SettingsStepper :value="scrollSpeed" unit="×" :min="min" :max="max" :step="step" label="terminal scroll speed" @nudge="nudgeScrollSpeed" />
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    How far one wheel notch or trackpad swipe moves the terminal — 1× is the default. Lower it if a two-finger scroll on a Mac trackpad flies past what you were
+    reading. Per browser, and it covers both a shell's scrollback and a full-screen app like Claude Code.
+  </p>
+</template>

--- a/src/components/settings/ThemeSection.vue
+++ b/src/components/settings/ThemeSection.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useTheme } from "../../composables/useTheme";
+import SkillLaunchButton from "../SkillLaunchButton.vue";
+import { SECTION_HEADING } from "./sectionClasses";
+import type { BundledSkillName } from "../../../common/bundledSkills";
+
+const emit = defineEmits<{ (e: "launch-skill", skill: BundledSkillName): void }>();
+
+// Theme is applied immediately on click.
+const { themeId, themes, setTheme, missingThemeId } = useTheme();
+const themesEl = ref<HTMLElement>();
+
+// ARIA radiogroup keyboard contract: arrows move selection (and focus) within
+// the group, wrapping at the ends; only the checked radio is tabbable (roving
+// tabindex), so Tab enters/leaves the group as one stop.
+// Roving tabindex, with a floor: when the selection names a theme that isn't in the list — the
+// missing-theme case this build added (#996) — nothing matches and EVERY option would be
+// tabindex="-1", so a keyboard user could not reach the picker at all while the notice above it
+// says to pick one. The first option becomes the tab stop in that state.
+const hasSelectedTheme = computed(() => themes.value.some((t) => t.id === themeId.value));
+function isThemeTabStop(id: string, index: number): boolean {
+  return hasSelectedTheme.value ? themeId.value === id : index === 0;
+}
+
+function onThemeKey(e: KeyboardEvent, index: number) {
+  const forward = e.key === "ArrowRight" || e.key === "ArrowDown";
+  const backward = e.key === "ArrowLeft" || e.key === "ArrowUp";
+  if (!forward && !backward) return;
+  e.preventDefault();
+  const next = (index + (forward ? 1 : themes.value.length - 1)) % themes.value.length;
+  setTheme(themes.value[next].id);
+  themesEl.value?.querySelectorAll<HTMLElement>('[role="radio"]')[next]?.focus();
+}
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Theme</h3>
+  <p v-if="missingThemeId" class="mb-2 mt-1.5 text-[12px] text-[var(--warn-text,#e0a030)]" data-testid="theme-missing">
+    The selected theme <code>{{ missingThemeId }}</code> is not defined. Add it to <code>themes</code> in <code>~/.mulmoterminal/config.json</code>, or pick one
+    below. Your choice is kept until then.
+  </p>
+  <p class="mb-2 mt-1.5 text-[12px] text-dim">
+    Picks from the schemes that exist. Your own go in <code>themes</code> in <code>~/.mulmoterminal/config.json</code> and appear here next to the built-in four
+    — the skill writes one from a palette, a photo or a brand's colours, and checks it for contrast.
+  </p>
+  <div ref="themesEl" class="flex flex-wrap gap-2" role="radiogroup" aria-label="Theme">
+    <button
+      v-for="(t, i) in themes"
+      :key="t.id"
+      type="button"
+      class="flex w-[84px] cursor-pointer flex-col items-center gap-1.5 rounded-lg border bg-elevated p-2 hover:bg-hover"
+      :class="themeId === t.id ? 'border-accent text-fg' : 'border-border text-muted hover:text-fg'"
+      role="radio"
+      :aria-checked="themeId === t.id"
+      :tabindex="isThemeTabStop(t.id, i) ? 0 : -1"
+      :title="t.label"
+      @click="setTheme(t.id)"
+      @keydown="onThemeKey($event, i)"
+    >
+      <span class="relative h-[34px] w-full overflow-hidden rounded-md border border-border" :style="{ background: t.swatch.base }">
+        <span class="absolute bottom-1.5 left-2 h-3 w-3 rounded-full" :style="{ background: t.swatch.panel }" />
+        <span class="absolute bottom-1.5 left-6 h-3 w-3 rounded-full" :style="{ background: t.swatch.accent }" />
+      </span>
+      <span class="text-[12px]">{{ t.label }}</span>
+    </button>
+  </div>
+  <div class="mt-3">
+    <SkillLaunchButton skill="mulmoterminal-theme" icon="format_paint" label="Create a theme…" @launch="emit('launch-skill', $event)" />
+  </div>
+</template>

--- a/src/components/settings/VoiceInputSection.vue
+++ b/src/components/settings/VoiceInputSection.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { VOICE_LANGUAGES, voiceLanguage } from "../../composables/voiceLanguage";
+import { fetchVoiceInputStatus } from "../../composables/voiceModelStatus";
+import { SELECT_CONTROL } from "../selectClasses";
+import { SECTION_HEADING } from "./sectionClasses";
+
+// Voice input's language mode. The setting is a singleton ref (localStorage-backed), so it
+// needs no prop/emit plumbing — but the section is only worth showing on a machine that can
+// transcribe at all, and capability lives on the server. One cheap GET when the modal opens;
+// a failed/absent probe leaves the section hidden rather than offering a setting for a mic
+// that will never appear.
+const voiceCapable = ref(false);
+async function refreshVoiceCapable() {
+  voiceCapable.value = (await fetchVoiceInputStatus())?.capable ?? false;
+}
+onMounted(() => void refreshVoiceCapable());
+</script>
+
+<template>
+  <template v-if="voiceCapable">
+    <h3 :class="SECTION_HEADING">Voice input</h3>
+    <p class="mb-3 mt-1.5 text-[12px] text-dim">
+      The language you dictate in. Speaking a language the mic is not expecting comes back <strong>translated</strong> into the expected one — so pick the one
+      you actually speak rather than leaving it on your browser's.
+    </p>
+    <select v-model="voiceLanguage" aria-label="Language for voice input" :class="SELECT_CONTROL">
+      <option value="locale">My browser's language</option>
+      <option value="auto">Detect from what I say</option>
+      <optgroup label="Always this language">
+        <option v-for="lang in VOICE_LANGUAGES" :key="lang.code" :value="lang.code">{{ lang.label }}</option>
+      </optgroup>
+    </select>
+  </template>
+</template>

--- a/src/components/settings/WaitingRowsSection.vue
+++ b/src/components/settings/WaitingRowsSection.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { useRosterAlert } from "../../composables/useRosterAlert";
+import { SECTION_HEADING } from "./sectionClasses";
+
+// Whether a roster row waiting on the user blinks (#1131) — per browser for the same reason the
+// sizes above are: it is the person watching the screen who finds movement useful or distracting,
+// not the host.
+const { blink: rosterBlink, setBlink: setRosterBlink } = useRosterAlert();
+function onRosterBlinkToggle(e: Event) {
+  if (e.target instanceof HTMLInputElement) setRosterBlink(e.target.checked);
+}
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Waiting rows</h3>
+  <p class="mb-2 mt-1.5 text-[12px] text-dim">
+    In the list beside an enlarged cell, a row whose agent is <strong>waiting on you</strong> — a permission prompt, a question — carries an amber ring and
+    blinks. A row that has simply <strong>finished</strong> is green and holds still. Turning this off keeps both colours and stops the movement; rows never
+    blink when your system asks for reduced motion.
+  </p>
+  <label class="mb-3 flex cursor-pointer items-center gap-2">
+    <input type="checkbox" class="cursor-pointer" :checked="rosterBlink" aria-label="Blink a row that is waiting on me" @change="onRosterBlinkToggle" />
+    <span class="text-[13px]">Blink a row that is waiting on me</span>
+  </label>
+</template>

--- a/src/components/settings/WebPushSection.vue
+++ b/src/components/settings/WebPushSection.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { SECTION_HEADING } from "./sectionClasses";
+import { PUSH_KINDS, type PushKind } from "../../../common/pushKinds";
+
+const props = defineProps<{ pushEnabled?: boolean | undefined; pushKinds?: PushKind[] | undefined }>();
+const emit = defineEmits<{
+  (e: "update-push-enabled", on: boolean): void;
+  (e: "update-push-kinds", kinds: PushKind[]): void;
+}>();
+
+// Stateless: reflects props.pushEnabled, emits the new value up (App persists it).
+function onPushToggle(e: Event) {
+  if (e.target instanceof HTMLInputElement) emit("update-push-enabled", e.target.checked);
+}
+
+// Which kinds of push to send (#850). The master toggle above says whether to notify at all;
+// this says which moments qualify, so a user who only wants finished turns can decline the ones
+// a blocked agent raises. Editable mirror of the saved value, like the other lists here.
+const PUSH_KIND_LABEL: Record<PushKind, string> = { finished: "Turn finished", waiting: "Waiting for you" };
+const PUSH_KIND_HELP: Record<PushKind, string> = {
+  finished: "the agent replied and the output is unread",
+  waiting: "it stopped to ask — a permission prompt or a question. Fires once per prompt, so a task that asks a lot pushes a lot",
+};
+const pushKindList = ref<PushKind[]>([...(props.pushKinds ?? [])]);
+watch(
+  () => props.pushKinds,
+  (k) => (pushKindList.value = [...(k ?? [])]),
+);
+function togglePushKind(kind: PushKind) {
+  // Emitted in PUSH_KINDS order so the saved list reads the same however it was clicked.
+  const next = pushKindList.value.includes(kind) ? pushKindList.value.filter((k) => k !== kind) : [...pushKindList.value, kind];
+  pushKindList.value = PUSH_KINDS.filter((k) => next.includes(k));
+  emit("update-push-kinds", pushKindList.value);
+}
+</script>
+
+<template>
+  <h3 :class="SECTION_HEADING">Web Push notifications</h3>
+  <p class="mb-3 mt-1.5 text-[12px] text-dim">
+    Send a push to your registered devices when a background task finishes. Requires the <strong>RemoteHost</strong> connection — its sign-in provides the
+    notification auth, so pushes only send while it's connected.
+  </p>
+  <label class="flex cursor-pointer items-center gap-2">
+    <input type="checkbox" class="cursor-pointer" :checked="props.pushEnabled ?? false" aria-label="Send a Web Push to my devices" @change="onPushToggle" />
+    <span>Notify my devices</span>
+  </label>
+  <div class="mt-2.5" :class="pushEnabled ? '' : 'pointer-events-none opacity-50'">
+    <p class="mb-1.5 text-[12px] text-dim">Which moments are worth a push:</p>
+    <label v-for="kind in PUSH_KINDS" :key="kind" class="flex cursor-pointer items-start gap-2 py-0.5">
+      <input
+        type="checkbox"
+        class="mt-1 cursor-pointer"
+        :checked="pushKindList.includes(kind)"
+        :disabled="!pushEnabled"
+        :aria-label="`Push when a session is ${kind}`"
+        @change="togglePushKind(kind)"
+      />
+      <span class="text-[12px]">
+        <strong>{{ PUSH_KIND_LABEL[kind] }}</strong> — {{ PUSH_KIND_HELP[kind] }}
+      </span>
+    </label>
+  </div>
+</template>

--- a/src/components/settings/sectionClasses.ts
+++ b/src/components/settings/sectionClasses.ts
@@ -1,0 +1,12 @@
+// The Settings modal's repeated utility runs, as class-string constants so the styling travels
+// with the markup (docs/styling.md) instead of becoming a CSS class — which a fragment-root
+// section template would silently fail to receive (#787).
+
+// Every section is headed the same way. One constant rather than the same six utilities per
+// section, so the headings cannot drift apart one edit at a time.
+export const SECTION_HEADING = "mb-2 mt-3.5 text-[12px] font-semibold uppercase tracking-[0.04em] text-muted";
+
+// The <ul> around a section's saved entries. The list itself stays in each section because what
+// makes it worth rendering differs (a repo string, a launcher, an MCP server); only the chrome
+// is shared. The rows are SettingsListRow.
+export const SETTINGS_LIST = "m-0 mb-2 flex list-none flex-col gap-1 p-0";

--- a/src/composables/useSavedListMirror.ts
+++ b/src/composables/useSavedListMirror.ts
@@ -1,0 +1,22 @@
+import { shallowRef, watch } from "vue";
+
+// An editable copy of a list the parent persists, for the Settings lists (PR repos, cell
+// launchers, phone quick commands, MCP servers). Each edit hands the WHOLE new list up.
+//
+// It has to be a LOCAL copy and not the prop itself: the whole list is persisted on every
+// change, so two edits made before the first POST answers would both compute from the same
+// pre-save snapshot, and the second would drop the first.
+//
+// `shallowRef` rather than `ref`: the list is always replaced wholesale, never mutated in
+// place, and a generic `ref<T[]>` needs a cast to shake off UnwrapRef.
+export function useSavedListMirror<T>(saved: () => readonly T[] | undefined, publish: (next: T[]) => void) {
+  const items = shallowRef<T[]>([...(saved() ?? [])]);
+  watch(saved, (next) => (items.value = [...(next ?? [])]));
+
+  function replace(next: T[]): void {
+    items.value = next;
+    publish(next);
+  }
+
+  return { items, replace };
+}

--- a/test/src/components/settings/SettingsListRow.spec.ts
+++ b/test/src/components/settings/SettingsListRow.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SettingsListRow from "../../../../src/components/settings/SettingsListRow.vue";
+
+// Shared by the four Settings lists. `name` exists so a screen reader hears WHICH entry a button
+// removes — four lists of "Remove" buttons is what it reads as otherwise.
+const mountRow = (name: string, slot = "<span>body</span>") => mount(SettingsListRow, { props: { name }, slots: { default: slot } });
+
+describe("SettingsListRow", () => {
+  it("names the remove button after the entry", () => {
+    const button = mountRow("owner/repo").find("button");
+    expect(button.attributes("aria-label")).toBe("Remove owner/repo");
+    expect(button.attributes("title")).toBe("Remove owner/repo");
+  });
+
+  it("emits remove when the button is pressed", async () => {
+    const w = mountRow("owner/repo");
+    await w.find("button").trigger("click");
+    expect(w.emitted("remove")).toHaveLength(1);
+  });
+
+  it("renders the entry's own content before the button", () => {
+    const w = mountRow("Shell", '<span class="mine">$SHELL</span>');
+    expect(w.find(".mine").text()).toBe("$SHELL");
+    // The row is a list item — the four callers put it inside their own <ul>.
+    expect(w.element.tagName).toBe("LI");
+  });
+
+  // The button must not submit anything: three of the four lists sit next to an add field, and a
+  // default-type button inside a form would submit it.
+  it("is an explicit type=button", () => {
+    expect(mountRow("owner/repo").find("button").attributes("type")).toBe("button");
+  });
+});

--- a/test/src/components/settings/SettingsStepper.spec.ts
+++ b/test/src/components/settings/SettingsStepper.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SettingsStepper from "../../../../src/components/settings/SettingsStepper.vue";
+
+// Shared by the two numeric Settings sections (terminal font size, terminal scroll speed). The
+// contract worth pinning is what the caller relies on: the emitted delta is SIGNED, so the
+// caller's nudge function takes it as-is, and the ends of the range are unreachable rather than
+// clamped after the fact.
+const mountStepper = (props: Partial<{ value: number; unit: string; min: number; max: number; step: number; label: string }> = {}) =>
+  mount(SettingsStepper, { props: { value: 14, unit: " px", min: 8, max: 32, step: 1, label: "terminal font size", ...props } });
+
+const decrease = (w: ReturnType<typeof mountStepper>) => w.find('[aria-label="Decrease terminal font size"]');
+const increase = (w: ReturnType<typeof mountStepper>) => w.find('[aria-label="Increase terminal font size"]');
+
+describe("SettingsStepper", () => {
+  it("names both buttons from the label", () => {
+    const w = mountStepper();
+    expect(decrease(w).exists()).toBe(true);
+    expect(increase(w).exists()).toBe(true);
+  });
+
+  it("emits the step signed by which button was pressed", async () => {
+    const w = mountStepper({ step: 2 });
+    await increase(w).trigger("click");
+    expect(w.emitted("nudge")?.at(-1)?.[0]).toBe(2);
+    await decrease(w).trigger("click");
+    expect(w.emitted("nudge")?.at(-1)?.[0]).toBe(-2);
+  });
+
+  it("shows the value with its unit appended as given", () => {
+    expect(mountStepper({ value: 14, unit: " px" }).text()).toContain("14 px");
+    expect(mountStepper({ value: 1.5, unit: "×", label: "terminal scroll speed" }).text()).toContain("1.5×");
+  });
+
+  it("disables the end of the range it is already at", () => {
+    const atMin = mountStepper({ value: 8 });
+    expect(decrease(atMin).attributes("disabled")).toBe("");
+    expect(increase(atMin).attributes("disabled")).toBeUndefined();
+
+    const atMax = mountStepper({ value: 32 });
+    expect(increase(atMax).attributes("disabled")).toBe("");
+    expect(decrease(atMax).attributes("disabled")).toBeUndefined();
+  });
+
+  // A value already outside the range — a config edited by hand, a stored value from an older
+  // build with a wider range — must not offer the button that pushes it further out.
+  it("disables past the end, not only at it", () => {
+    expect(decrease(mountStepper({ value: 4 })).attributes("disabled")).toBe("");
+    expect(increase(mountStepper({ value: 40 })).attributes("disabled")).toBe("");
+  });
+
+  // The readout is what a screen reader announces after a press, so it has to be live.
+  it("announces the value politely", () => {
+    expect(mountStepper().find('[aria-live="polite"]').text()).toContain("14 px");
+  });
+});

--- a/test/src/composables/useSavedListMirror.spec.ts
+++ b/test/src/composables/useSavedListMirror.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { nextTick, ref } from "vue";
+import { useSavedListMirror } from "../../../src/composables/useSavedListMirror";
+
+// The four Settings lists (PR repos, cell launchers, phone quick commands, MCP servers) all hold
+// an editable copy of a value the parent persists. What is worth pinning is the copy: the whole
+// list is saved on every change, so an edit made before the previous save answers has to build on
+// the previous edit rather than on the value the props still show.
+
+const mirror = <T>(saved: { value: readonly T[] | undefined }, publish: (next: T[]) => void) => useSavedListMirror<T>(() => saved.value, publish);
+
+describe("useSavedListMirror", () => {
+  it("starts from the saved value", () => {
+    const saved = ref<string[]>(["a/one", "b/two"]);
+    const { items } = mirror(saved, vi.fn());
+    expect(items.value).toEqual(["a/one", "b/two"]);
+  });
+
+  it("starts empty when nothing is saved yet", () => {
+    const { items } = mirror(ref<string[] | undefined>(undefined), vi.fn());
+    expect(items.value).toEqual([]);
+  });
+
+  it("publishes the whole new list, and shows it immediately", () => {
+    const publish = vi.fn();
+    const { items, replace } = mirror(ref<string[]>(["a/one"]), publish);
+    replace([...items.value, "b/two"]);
+    expect(publish).toHaveBeenCalledWith(["a/one", "b/two"]);
+    expect(items.value).toEqual(["a/one", "b/two"]);
+  });
+
+  // The regression this exists for: two edits made before the first POST answers must compound.
+  // The saved value deliberately stays put here — that is what an in-flight save looks like from
+  // the component's side, and reading the prop instead of the local copy would drop the first.
+  it("compounds edits made before the save lands", () => {
+    const publish = vi.fn();
+    const saved = ref<string[]>([]);
+    const { items, replace } = mirror(saved, publish);
+    replace([...items.value, "a/one"]);
+    replace([...items.value, "b/two"]);
+    expect(publish).toHaveBeenLastCalledWith(["a/one", "b/two"]);
+  });
+
+  it("takes the saved value back over when it changes", async () => {
+    const saved = ref<string[]>(["a/one"]);
+    const { items, replace } = mirror(saved, vi.fn());
+    replace([]);
+    saved.value = ["c/three"];
+    await nextTick();
+    expect(items.value).toEqual(["c/three"]);
+  });
+
+  it("empties when the saved value goes away", async () => {
+    const saved = ref<string[] | undefined>(["a/one"]);
+    const { items } = mirror(saved, vi.fn());
+    saved.value = undefined;
+    await nextTick();
+    expect(items.value).toEqual([]);
+  });
+
+  // A copy, not the array itself: mutating what the caller handed in — or what it read back —
+  // must not reach into the saved value.
+  it("copies rather than aliases the saved array", () => {
+    const saved = ref<string[]>(["a/one"]);
+    const { items } = mirror(saved, vi.fn());
+    expect(items.value).not.toBe(saved.value);
+  });
+});


### PR DESCRIPTION
## Summary

`src/components/SettingsModal.vue`（907 行 / script 410・template 495）を、**1 セクション = 1 ファイル**に分けました。17 セクションは互いに状態を共有しておらず、それぞれ自分の composable か自分の prop/emit 1 組だけを見ています。

殻に残るのは dialog のフレーム・Escape/Tab のキーボード操作・セクションの並び順・props/emits の転送で **147 行**。最大のファイルは `NotificationSoundsSection.vue` の 177 行です。

**props/emits の口は変えていません。** `SettingsModal.spec.ts`（369 行）は `mount(SettingsModal)` からツリー全体を引いているので、emit を親まで転送すれば**無改変で通ります**。子で `useAppConfig()` を直読みする形（`AppSettingsModal` がやっているような）に寄せると spec が全部壊れるので取りませんでした。

issue の step 1（見出しクラスの定数化）は #1136 で完了済みなので、これは step 2 です。分割の粒度（1 セクション 1 コンポーネント / まとめる）は issue で「要相談」だったので、事前に確認して**1 セクション 1 コンポーネント**を選びました。

あわせて、分割すると 4 ファイルに散ってしまう重複 3 件を同じ PR で潰しています（issue 未記載、事前に合意済み）。

## Items to Confirm / Review

1. **⚠ ステッパーボタンの whitespace 差（唯一残った描画差）** — Terminal font size / Terminal scroll speed の `−` `+` ボタンの中身が `> − <`（グリフの両側に空白）から `>−<` に変わります。分割前は属性が多くて prettier が改行していたためで、共有コンポーネントでは 1 行に収まるので畳まれます。
   - `w-8 h-8` の flex ボックスに `items-center justify-center` が掛かっているので、テキストは匿名 flex アイテムになりその両端の空白は CSS が落とす、つまり見た目は変わらない **はず** です。ただし**これは仕様の読みで、実測ではありません**。Playwright は未導入で、同じ形（フレックス中央寄せの固定サイズ箱に裸のテキスト 1 文字）のボタンはリポジトリ内に他に無いため、出荷済みの UI からも裏が取れませんでした。
   - **Settings を開いて、この 2 行の `−` / `+` が中央に見えるか 1 度見てください。**
   - ソース側で ` − ` を復元する案は捨てました: prettier は 160 桁に収まると畳み直すので `{{ " − " }}` のような構造にしないと保てず、それを正当化するコメントは「実は無害」と矛盾します。

2. **`src/components/settings/` というサブディレクトリを新設した** — `src/components/` は 106 ファイルのフラットなディレクトリで、これが最初のサブディレクトリです。17 ファイルをフラットに足すのを避けました。spec は既存どおりパスを写して `test/src/components/settings/` に置いています。この方針でよいか。

3. **`useSavedListMirror` の抽象の深さ** — `items` と `replace` だけを共有し、**`add` / `remove` は各セクションに残しました**（フィールド数と検証が 4 つで違い、`settingsValidators.ts` はそのまま使っています）。もっと踏み込んで `add` まで共有すべきか、逆にやりすぎか。

4. **`exactOptionalPropertyTypes` のための `| undefined`** — 親の `soundKinds?: NotifyKind[]` を読むと `NotifyKind[] | undefined` になるので、子側の prop を `soundKinds?: NotifyKind[] | undefined` と書いています（既存の `cwd?: string | null | undefined` と同じ書き方）。7 箇所。

5. **`VoiceInputSection` の root が `<template v-if>`** — 描かないときはコメントアンカーだけが残ります。flex レイアウトには影響しませんが、root がフラグメントになる形は意図的です（見た目が全部ユーティリティなので #787 の scope id 問題は起きない）。

## User Prompt

> #1126

（issue #1126 の step 2。分割粒度と重複の扱いは会話中に確認して決定:「1 セクション = 1 コンポーネント」＋「リスト行の chrome を共有する」「ステッパーを共有する」「編集ミラーの script も共有する」の 3 件すべて実施。）

## 設計

### なぜ 1 セクション 1 コンポーネントか

- **skill ボタンとセクションの対応が 1 ファイルに収まる**。`CLAUDE.md` の「A skill with a Settings section is launched from it」は、controls とその `SkillLaunchButton` が同じファイルにある方が追えます。#1097 は「1 つの巨大ファイルの中に散っている記述を 1 箇所見落とす」事故でした。
- **4 重複が見える場所に出る**。リスト編集 4 セクションが 4 ファイルになれば、同じ形をしていることがファイル名の並びで分かります。900 行の中に埋まっている限り jscpd も規則も届きません。

### ファイル構成

| ファイル | 行 | 状態の出どころ |
| --- | ---: | --- |
| `ThemeSection.vue` | 71 | `useTheme` |
| `TerminalFontSizeSection.vue` | 17 | `useTerminalFontSize` |
| `TerminalScrollSection.vue` | 18 | `useTerminalScrollSpeed` |
| `WaitingRowsSection.vue` | 25 | `useRosterAlert` |
| `DirAppearanceSection.vue` | 16 | prose + skill ボタンのみ |
| `DirSettingsSection.vue` | 22 | `dirPaths` prop |
| `NotificationSoundsSection.vue` | 177 | props + 3 emit |
| `VoiceInputSection.vue` | 35 | `voiceLanguage` + capable probe |
| `WebPushSection.vue` | 64 | props + 2 emit |
| `GoogleAccountSection.vue` | 65 | `useGoogleLink` |
| `PrReposSection.vue` | 52 | prop + emit |
| `LaunchersSection.vue` | 65 | prop + emit |
| `QuickCommandsSection.vue` | 98 | prop + emit |
| `McpServersSection.vue` | 66 | prop + emit |
| `CostSection.vue` | 44 | `useCost` + `cwd`/`sessionId` |
| `ShortcutsSection.vue` | 49 | `activeKeymap` |
| `HelpSection.vue` | 9 | `GuideLinks` |

共有部品: `SettingsListRow.vue` (26) / `SettingsStepper.vue` (22) / `sectionClasses.ts` (12) / `useSavedListMirror.ts` (22)。

### セクションの root はフラグメントのまま

各セクションは `<h3>` + `<p>` + controls という**複数ルート**です。Vue はフラグメントコンポーネントの子を親へ直接描くので、モーダルの `flex-col` から見た DOM と flex アイテムの並びは今と同一で、セクション間の余白（`h3` の `mt-3.5` / `p` の `mb-3`）もそのまま効きます。

ラッパー div を足さないのは、足すと flex アイテムの数が変わって余白が崩れるからです。そしてフラグメント root でも困らないのは、見た目が全部ユーティリティで共有 CSS クラスに依存していないため（#787 でフラグメント root が scope id を受け取らないと分かって以来の方針 — `docs/styling.md`）。

### onMounted の分配

親の `onMounted` に集まっていた 3 つの初期フェッチを、それぞれ自分のセクションへ移しました。

- `refreshCost()` → `CostSection`（`cwd`/`sessionId` の watch も一緒に）
- `refreshGoogle()` + `disposeGoogle()` → `GoogleAccountSection`
- `refreshVoiceCapable()` → `VoiceInputSection`

モーダルは `v-if` で開閉されるので子も一緒にマウント/アンマウントされ、`useGoogleLink` のポーラー停止（`dispose`）のタイミングは変わりません。

### 潰した重複 3 件

**a. `SettingsListRow.vue`** — PR repos / Launch commands / Phone quick commands / MCP servers が、`<li>` の枠 6 ユーティリティと**同一の close ボタン 8 行**を 4 回書いていました。`name` から `Remove ${name}` の `title` / `aria-label` を作り、行の中身は slot。`<ul>` 側の 6 連 utility も 4 回だったので `SETTINGS_LIST` 定数に（`v-if` の条件が各セクションで違うので `<ul>` 自体はセクションに残す）。

同じ close ボタンの並びはモーダルのヘッダにもあり合計 5 箇所でしたが、4 箇所が吸収されるとヘッダの 1 箇所だけになるので触っていません。`TerminalCell.vue` にも `--err-hover-bg` を使うボタンがありますが、ユーティリティの並びは別物なので対象外です。

**b. `SettingsStepper.vue`** — font size と scroll speed の 25 行がほぼ同一。`aria-label` は `Decrease ${label}` / `Increase ${label}` で現状の文言に一致します。`unit` は `px` が前に空白あり・`×` が空白なしなので `:unit="' px'"` とバインドで渡しています。

**c. `useSavedListMirror`** — 「保存値を watch してローカル ref に写す + 新リストを emit する」が 4 本。ローカルコピーであることが仕様で、最初の POST が返る前に 2 回目の編集をすると両方が保存前の同じスナップショットから計算されて 2 回目が 1 回目を取り消します。この理由のコメントは composable 側へ移しました。

内部は `ref<T[]>` ではなく `shallowRef<T[]>` です。`ref` はジェネリックだと `UnwrapRef` を噛ませるので `as Ref<T[]>` が必要になり `as` 禁止に触れます。リストは常に丸ごと差し替える使い方なので `shallowRef` が意味的にも正しいです。

## 検証

`yarn format` → `yarn lint` → `yarn typecheck` → `yarn typecheck:server` → `yarn typecheck:test` → `yarn build` → `yarn test` すべて green。

- **既存テスト: 441 files / 6523 passed**（分割前は 6506、新規 17 を追加）。`SettingsModal.spec.ts` は**無改変**。
- 新規 spec: `useSavedListMirror`（保存値の反映、丸ごと差し替え、保存前の 2 連続編集、saved が消えたとき、エイリアスしないこと）、`SettingsStepper`（min/max での disabled・範囲外でも disabled・`@nudge` の符号・`aria-label`・aria-live）、`SettingsListRow`（`@remove`・`Remove ${name}`・`type=button`）。

### 「spec が緑」は「見た目が同じ」ではないので、描画結果を直接 diff した

分割前のコンポーネントを一時的に併置し、**同じ props で両方を mount して `html()` を diff** しました（使い捨て、コミットしていません）。条件を振ったのは 9 通り: 全リスト有り / 全て未設定 / push off / cwd と session 無し（グリッド）/ 存在しない theme / 文字起こし不可 / Google が使えない / Google 連携済み / cost 取得失敗。

**43KB の描画結果のうち構造差はゼロ。** 生の差分は whitespace だけで、全量は 2 種類でした:

1. ステッパーボタンの内側 `> − <` → `>−<`（4 箇所）← 上の「要確認 1」
2. Notification sounds の **HTML コメント**のインデント（6 箇所）。コメントは描画されないので無害

この検証手順とその結論は `plans/refactor-1126-settings-sections.md` に残してあります。

## ドキュメント

`README.md` のソースツリーに `settings/` を追記しました（`SettingsModal.vue` が載っていたため）。

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal2
