### PR TITLE
fix(remote-host): 補完メニューが submit を握り潰すのでスラッシュコマンドが送れない (#1142)

### DIFF
--- a/common/terminalSubmit.ts
+++ b/common/terminalSubmit.ts
@@ -30,6 +30,24 @@ export const newlineSequence = (mode: TerminalSubmitMode): string => (mode === "
 // where ESC+CR is Alt+Enter, not submit.
 export const submitSequenceForAgent = (agent: string | undefined, mode: TerminalSubmitMode): string => (agent === "claude" ? submitSequence(mode) : CR);
 
+// Text we are about to submit ON the user's behalf, ended so the TUI has no completion menu
+// open when the submit byte(s) arrive.
+//
+// Claude Code holds a completion menu open while the cursor sits at the end of a completion
+// token — a `/command` or an `@path` — and while it is open the TUI runs its Autocomplete
+// keybinding context, where `escape` is the menu's dismiss key. So the ESC+CR that submits in
+// "esc-cr" mode never arrives as one Alt+Enter: the ESC is eaten and the line stays in the box,
+// however many times it is sent (#1142). One trailing space ends the token and closes the menu.
+//
+// Measured against Claude Code 2.1.220 for both `/help` and `@path`; a plain-CR host submits the
+// same line unchanged either way, and off a TUI (a shell) the space is inert (`echo hi ` runs).
+// Deliberately unconditional rather than a list of Claude Code's trigger characters: a trigger
+// we failed to enumerate would silently restore a dead end that looks like a broken feature.
+//
+// For auto-submitted text only. A draft the user still edits keeps exactly what was handed over —
+// their own Enter is a keystroke they can retry once they see the menu.
+export const submittableLine = (text: string): string => (/\S$/.test(text) ? `${text} ` : text);
+
 // The structural shape of a keydown the override needs. A real DOM KeyboardEvent satisfies
 // it, and so does a plain test object — no DOM dependency, so this stays testable and shared.
 export interface EnterKeyEvent {

--- a/common/terminalSubmit.ts
+++ b/common/terminalSubmit.ts
@@ -30,23 +30,34 @@ export const newlineSequence = (mode: TerminalSubmitMode): string => (mode === "
 // where ESC+CR is Alt+Enter, not submit.
 export const submitSequenceForAgent = (agent: string | undefined, mode: TerminalSubmitMode): string => (agent === "claude" ? submitSequence(mode) : CR);
 
-// Text we are about to submit ON the user's behalf, ended so the TUI has no completion menu
+// Text we are about to submit ON the user's behalf, ended so Claude Code has no completion menu
 // open when the submit byte(s) arrive.
 //
-// Claude Code holds a completion menu open while the cursor sits at the end of a completion
-// token — a `/command` or an `@path` — and while it is open the TUI runs its Autocomplete
-// keybinding context, where `escape` is the menu's dismiss key. So the ESC+CR that submits in
-// "esc-cr" mode never arrives as one Alt+Enter: the ESC is eaten and the line stays in the box,
-// however many times it is sent (#1142). One trailing space ends the token and closes the menu.
+// Claude Code holds a completion menu open while the cursor sits at the end of a completion token
+// — a `/command` or an `@path` — and an open menu consumes the key that should have submitted.
+// Measured against Claude Code 2.1.220:
 //
-// Measured against Claude Code 2.1.220 for both `/help` and `@path`; a plain-CR host submits the
-// same line unchanged either way, and off a TUI (a shell) the space is inert (`echo hi ` runs).
-// Deliberately unconditional rather than a list of Claude Code's trigger characters: a trigger
-// we failed to enumerate would silently restore a dead end that looks like a broken feature.
+//   `/help` + CR        submits          (the one case that always worked)
+//   `/help` + ESC CR    does NOT submit  — the menu's own `escape` binding eats the ESC, so the
+//                                          "esc-cr" submit never lands, however often it is sent
+//   `@path` + CR        does NOT submit  — the file picker takes that CR for itself
+//   either + a trailing space            submits: the space ends the token, closing the menu
+//
+// So this is NOT specific to the reversed submit mapping (#1142 was reported there, but the
+// `@path` half hits the default mapping too), and it is deliberately not a list of Claude Code's
+// trigger characters: a trigger we failed to enumerate would silently restore a dead end that
+// looks like a broken feature.
 //
 // For auto-submitted text only. A draft the user still edits keeps exactly what was handed over —
 // their own Enter is a keystroke they can retry once they see the menu.
 export const submittableLine = (text: string): string => (/\S$/.test(text) ? `${text} ` : text);
+
+// The same Claude-only scoping as submitSequenceForAgent, and for a sharper reason: the completion
+// menu is Claude Code's behaviour, while for every other target the trailing space would be REAL
+// input. A shell line ending in `\` escapes the newline and waits for more (`echo foo\` → a
+// continuation prompt); with a space appended it is an escaped space and runs instead. So a
+// shell/codex/command session's bytes stay exactly what the sender wrote.
+export const submittableLineForAgent = (agent: string | undefined, text: string): string => (agent === "claude" ? submittableLine(text) : text);
 
 // The structural shape of a keydown the override needs. A real DOM KeyboardEvent satisfies
 // it, and so does a plain test object — no DOM dependency, so this stays testable and shared.

--- a/plans/fix-1142-slash-command-submit.md
+++ b/plans/fix-1142-slash-command-submit.md
@@ -1,0 +1,93 @@
+# fix #1142 — a slash command sent from the phone never submits on an `esc-cr` host
+
+## Symptom
+
+With `terminalSubmit: "esc-cr"` (the host's Claude submits on ESC+CR, i.e. Alt/Option+Enter),
+sending `/sync-repos` from the phone leaves `/sync-repos` sitting in the host's input box with
+the command-completion menu open. Ordinary sentences submit fine through the same path;
+resending changes nothing. That kills the whole point of `listSkills` — a phone skill list whose
+entries reach the session as `/<slug>` — for exactly the hosts `terminalSubmit` exists to serve.
+
+## Root cause
+
+Claude Code keeps a **completion menu** open while the cursor sits at the end of a completion
+token (`/command`, `@path`). While that menu is open, the TUI runs its **`Autocomplete`
+keybinding context** — which binds `escape` to `autocomplete:dismiss` — so the `ESC CR` that
+submits in `esc-cr` mode is not seen as one Alt+Enter key: the ESC is eaten by the menu. A plain
+CR is unaffected, which is why default hosts never saw this.
+
+`sanitizeTerminalInput`'s `.trim()` is what makes it unfixable from the phone: a trailing space
+closes the menu, but the server strips it before the paste, so no text the client sends can
+carry one.
+
+### Why `sanitizeTerminalInput` trims (it must keep doing so)
+
+`text.replace(CONTROL_BYTES_RE, " ").replace(/\s+/g, " ").trim()` — the trim is not cosmetic:
+
+1. Control bytes are replaced with a **space**, not removed, so `a\nb` cannot become `ab`.
+2. That manufactures whitespace the user never typed: `"\x03"` → `" "`, `"\r\n"` → `" "`.
+3. `.trim()` is what turns those into `""`, which is what makes the caller's
+   `if (!safe) throw new Error("text is required")` guard work. Without it, control-only input
+   is truthy and the host submits an **empty turn** (or a blank shell line). A leading space
+   would also be typed into the box for real (`HISTCONTROL=ignorespace` in a shell).
+
+So the fix must not touch the sanitizer — #781 also settled the policy that phone text stays
+untrusted and the sanitizer does not get loosened. The trailing space is added **after** the
+emptiness decision, by the layer that already owns the framing and the submit bytes.
+
+## Measured (Claude Code 2.1.220, real TUI in tmux, bytes sent with `tmux send-keys -H`)
+
+| # | sent | result |
+| --- | --- | --- |
+| M1 | paste `/help` → `CR` | submitted (default binding — the untouched case) |
+| M3 | paste `/help` → `ESC CR` | **not submitted**; menu ate the ESC, the CR landed as a newline |
+| M2 | paste `/help ` → `CR` | menu **closed** on the paste, submitted, command ran |
+| M5 | paste `look at @common/terminalSubmit.ts` | file picker **open** — same trap, not just `/` |
+| M6 | paste `look at @common/terminalSubmit.ts ` | picker **closed** |
+| R1 | **raw-typed** `/help` → `ESC CR` | not submitted — the browser UI's own path has this too |
+| R2 | **raw-typed** `/help ` → `CR` | submitted |
+| S1 | shell (zsh): paste `echo hi ` → `CR` | ran `echo hi` — trailing space is inert off-TUI |
+
+M5/M6 are why the fix is not "when the text starts with `/`": a false negative silently
+reproduces a dead end, so the rule must not try to enumerate Claude Code's trigger characters.
+
+## Fix
+
+One shared helper next to the submit-byte mapping both sides already read, applied at every
+place that types text and then submits it **for** the user:
+
+```ts
+// common/terminalSubmit.ts
+export const submittableLine = (text: string): string => (/\s$/.test(text) ? text : `${text} `);
+```
+
+- `server/backends/remoteHost/terminalInput.ts` — inside the bracketed paste, after the
+  emptiness check. Submit bytes untouched.
+- `src/composables/useTerminalConnections.ts` — `submitText` (header buttons, the Skill menu's
+  `/<slug>`, the worktree commit prompt) and `pasteAndSubmit` (cross-talk). R1 shows the browser
+  Skill menu has the same dead end on an `esc-cr` host.
+
+Not applied to `insertText` / `pasteText`: those hand the user a draft to review, and their own
+Enter is a keystroke they can retry after seeing the menu.
+
+## Deliberately out of scope
+
+`server/session/draft-injection.ts` auto-submits an `initialPrompt` with a **hardcoded `\r`**,
+so on an `esc-cr` host that prompt is typed and never submitted regardless of any menu — a
+separate gap (#772 covered the browser handler and the phone submit, not this path). A guard
+space would not fix it; it needs the configured submit sequence. Reported, not changed here.
+
+## Tests
+
+- `test/common/terminalSubmit.spec.ts` — the helper: appends exactly one space, is idempotent on
+  text already ending in whitespace (no double space), leaves a multi-line block ending in `\n`
+  alone, adds nothing but that one space.
+- `server/backends/remoteHost/terminalInput.spec.ts` — the `/command` regression end to end: the
+  guard is **inside** the paste (a bare space keystroke could be read by an open menu), the paste
+  is still opened once and closed once, the submit sequence is unchanged in both modes, the
+  Ctrl-C clear still leads the write, and — the trim's own purpose — control-only text still
+  throws instead of the guard smuggling it past the emptiness check.
+- `test/server/backends/remoteHost/terminalInput.spec.ts` — the sanitizer still trims a trailing
+  space (the behaviour the fix routes around rather than removes).
+- `test/src/composables/useTerminalConnections.spec.ts` — `submitText` / `pasteAndSubmit` carry
+  the guard in both modes; `insertText` / `pasteText` do not.

--- a/plans/fix-1142-slash-command-submit.md
+++ b/plans/fix-1142-slash-command-submit.md
@@ -44,31 +44,47 @@ emptiness decision, by the layer that already owns the framing and the submit by
 | M2 | paste `/help ` → `CR` | menu **closed** on the paste, submitted, command ran |
 | M5 | paste `look at @common/terminalSubmit.ts` | file picker **open** — same trap, not just `/` |
 | M6 | paste `look at @common/terminalSubmit.ts ` | picker **closed** |
+| M7 | paste `look at @…terminalSubmit.ts` → `CR` | **not submitted** — the picker takes the CR itself |
+| M8 | paste `look at @…terminalSubmit.ts ` → `CR` | submitted (turn started) |
 | R1 | **raw-typed** `/help` → `ESC CR` | not submitted — the browser UI's own path has this too |
 | R2 | **raw-typed** `/help ` → `CR` | submitted |
-| S1 | shell (zsh): paste `echo hi ` → `CR` | ran `echo hi` — trailing space is inert off-TUI |
+| S1 | shell (zsh): paste `echo hi ` → `CR` | ran `echo hi` — a trailing space is inert here |
+| S2 | shell (zsh): `echo foo\` → `CR` vs `echo foo\ ` → `CR` | **continuation prompt** vs **runs, prints `foo`** |
 
 M5/M6 are why the fix is not "when the text starts with `/`": a false negative silently
 reproduces a dead end, so the rule must not try to enumerate Claude Code's trigger characters.
 
+M7/M8 are why it is not scoped to `esc-cr` either. The `@path` half of the family breaks on the
+DEFAULT mapping too — one plain CR is consumed by the file picker — so a guard that only ran for
+ESC-prefixed submits would leave every default host with the same dead end.
+
+S2 is why it IS scoped to Claude sessions (Codex's review of this PR raised it). For a shell the
+trailing space is real input: a line ending in `\` escapes the newline and waits for more, and with
+a space appended it is an escaped space that runs instead. Different execution, same bytes from us.
+
 ## Fix
 
 One shared helper next to the submit-byte mapping both sides already read, applied at every
-place that types text and then submits it **for** the user:
+place that types text and then submits it **for** the user — and, like that mapping, scoped to
+Claude sessions:
 
 ```ts
 // common/terminalSubmit.ts
-export const submittableLine = (text: string): string => (/\s$/.test(text) ? text : `${text} `);
+export const submittableLine = (text: string): string => (/\S$/.test(text) ? `${text} ` : text);
+export const submittableLineForAgent = (agent: string | undefined, text: string): string =>
+  agent === "claude" ? submittableLine(text) : text;
 ```
 
 - `server/backends/remoteHost/terminalInput.ts` — inside the bracketed paste, after the
-  emptiness check. Submit bytes untouched.
+  emptiness check. Submit bytes untouched. The agent arrives through a new `sessionAgent` dep,
+  the same `ptys.get(id)?.agent` lookup `canClearBox` and `submitSequence` already use.
 - `src/composables/useTerminalConnections.ts` — `submitText` (header buttons, the Skill menu's
-  `/<slug>`, the worktree commit prompt) and `pasteAndSubmit` (cross-talk). R1 shows the browser
-  Skill menu has the same dead end on an `esc-cr` host.
+  `/<slug>`, the worktree commit prompt) and `pasteAndSubmit` (cross-talk), gated by the existing
+  `isClaudeTarget`. R1 shows the browser Skill menu has the same dead end on an `esc-cr` host.
 
 Not applied to `insertText` / `pasteText`: those hand the user a draft to review, and their own
-Enter is a keystroke they can retry after seeing the menu.
+Enter is a keystroke they can retry after seeing the menu. Not applied to shell / codex / command
+/ dev-terminal sessions at all (S2).
 
 ## Deliberately out of scope
 
@@ -81,7 +97,8 @@ space would not fix it; it needs the configured submit sequence. Reported, not c
 
 - `test/common/terminalSubmit.spec.ts` — the helper: appends exactly one space, is idempotent on
   text already ending in whitespace (no double space), leaves a multi-line block ending in `\n`
-  alone, adds nothing but that one space.
+  alone, adds nothing but that one space. Plus the agent scoping, including a test that it and
+  `submitSequenceForAgent` agree on who counts as Claude, so they cannot drift.
 - `server/backends/remoteHost/terminalInput.spec.ts` — the `/command` regression end to end: the
   guard is **inside** the paste (a bare space keystroke could be read by an open menu), the paste
   is still opened once and closed once, the submit sequence is unchanged in both modes, the
@@ -90,4 +107,7 @@ space would not fix it; it needs the configured submit sequence. Reported, not c
 - `test/server/backends/remoteHost/terminalInput.spec.ts` — the sanitizer still trims a trailing
   space (the behaviour the fix routes around rather than removes).
 - `test/src/composables/useTerminalConnections.spec.ts` — `submitText` / `pasteAndSubmit` carry
-  the guard in both modes; `insertText` / `pasteText` do not.
+  the guard in both modes; a shell cell's `echo foo\` stays byte-exact; `insertText` / `pasteText`
+  do not carry it.
+- Mutation-checked: reducing `submittableLine` to the identity function fails 24 tests, so the
+  suite pins the behaviour rather than describing it.

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -62,6 +62,7 @@ describe("createRemoteHostHandlers · getFeed", () => {
       writeToSession: () => false,
       canClearBox: () => false,
       submitSequence: () => "\r",
+      sessionAgent: () => "claude" as const,
       launchTerminal: () => ({ ok: true }) as const,
     });
   });

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -14,6 +14,7 @@ const unusedTerminalDeps = {
   writeToSession: () => false,
   canClearBox: () => false,
   submitSequence: () => "\r",
+  sessionAgent: () => "claude" as const,
   launchTerminal: () => ({ ok: true }) as const,
 };
 

--- a/server/backends/remoteHost/handlers/deps.ts
+++ b/server/backends/remoteHost/handlers/deps.ts
@@ -5,6 +5,7 @@
 // and every terminal accessor are wired in server/index.ts, where the PTY table lives. So this
 // host keeps a FACTORY (see ./index.ts) and passes deps down — a deliberate divergence from the
 // reference host, forced by where the state lives rather than by taste.
+import type { SessionAgent } from "../../../../common/sessionAgent.js";
 import type { IngestResult } from "../ingestAttachments.js";
 import type { SessionScreen, TerminalSessionSummary } from "../terminalScreen.js";
 
@@ -31,6 +32,10 @@ export interface RemoteHostHandlerDeps {
   // sends only text; which byte commits it is the host's Claude binding — but only for a
   // Claude session, so this is resolved per session id (shell/codex stay on plain CR).
   submitSequence: (sessionId: string) => string;
+  // Which agent runs in a given session, for the completion-menu guard on typed text (#1142).
+  // Same lookup as canClearBox / submitSequence: only Claude Code has the menu that eats a
+  // submit, and only there is the guard's trailing space not real input.
+  sessionAgent: (sessionId: string) => SessionAgent | undefined;
   // Open a new grid terminal in the directory of the session the phone is looking at
   // (#831). Answered in server/index.ts, which owns the PTY table and the pub/sub the
   // grid listens on. Resolves to an error string when it could not be started.

--- a/server/backends/remoteHost/handlers/terminalSession.ts
+++ b/server/backends/remoteHost/handlers/terminalSession.ts
@@ -9,7 +9,7 @@ import type { RemoteHostHandlerDeps } from "./deps.js";
 
 type TerminalSessionDeps = Pick<
   RemoteHostHandlerDeps,
-  "listTerminalSessions" | "captureTerminalScreen" | "writeToSession" | "canClearBox" | "submitSequence" | "launchTerminal"
+  "listTerminalSessions" | "captureTerminalScreen" | "writeToSession" | "canClearBox" | "submitSequence" | "sessionAgent" | "launchTerminal"
 >;
 
 export const createTerminalSessionHandlers = ({
@@ -18,10 +18,11 @@ export const createTerminalSessionHandlers = ({
   writeToSession,
   canClearBox,
   submitSequence,
+  sessionAgent,
   launchTerminal,
 }: TerminalSessionDeps): CommandHandlers => {
   // One sender per host, so its per-session ordering actually spans every command.
-  const sendInput = createTerminalInputSender({ writeToSession, canClearBox, submitSequence });
+  const sendInput = createTerminalInputSender({ writeToSession, canClearBox, submitSequence, sessionAgent });
   return {
     listTerminalSessions: async () => toJsonObject({ sessions: await listTerminalSessions() }),
 

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -99,6 +99,7 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
       writeToSession: deps.writeToSession,
       canClearBox: deps.canClearBox,
       submitSequence: deps.submitSequence,
+      sessionAgent: deps.sessionAgent,
       launchTerminal: deps.launchTerminal,
     }),
     log: { ...log, debug: () => undefined },

--- a/server/backends/remoteHost/terminalInput.spec.ts
+++ b/server/backends/remoteHost/terminalInput.spec.ts
@@ -31,6 +31,12 @@ const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean)
   return { chunks, submits, flushSubmit: () => submits.shift()?.(), send: createTerminalInputSender(deps) };
 };
 
+// What one auto-submitted paste must look like on the wire: the text, then the guard space that
+// keeps a completion menu from holding the submit byte (#1142), all inside one bracketed paste.
+// Spelled out here rather than by calling submittableLine, so the expectation stays an
+// independent statement of the shape instead of agreeing with whatever the helper does.
+const paste = (text: string): string => `${PASTE_START}${text} ${PASTE_END}`;
+
 describe("sanitizeTerminalInput", () => {
   it("keeps ordinary text", () => {
     expect(sanitizeTerminalInput("git status")).toBe("git status");
@@ -71,10 +77,10 @@ describe("sendTerminalInput", () => {
     await tick();
     // The paste lands immediately; the CR must NOT ride along with it, or Claude's
     // TUI drops it while still committing the paste.
-    expect(chunks).toEqual([`${PASTE_START}git status${PASTE_END}`]);
+    expect(chunks).toEqual([paste("git status")]);
     flushSubmit();
     await expect(sent).resolves.toEqual({ sent: true });
-    expect(chunks).toEqual([`${PASTE_START}git status${PASTE_END}`, "\r"]);
+    expect(chunks).toEqual([paste("git status"), "\r"]);
   });
 
   // #772: the byte(s) that submit come from the host's Claude binding, not a hardcoded CR,
@@ -106,7 +112,7 @@ describe("sendTerminalInput", () => {
     submits.shift()?.();
     await expect(b).resolves.toEqual({ sent: true });
     expect(seen).toEqual(["claude-1", "shell-1"]); // the session id reaches the resolver
-    expect(chunks).toEqual([`${PASTE_START}hi${PASTE_END}`, "\x1b\r", `${PASTE_START}ls${PASTE_END}`, "\r"]);
+    expect(chunks).toEqual([paste("hi"), "\x1b\r", paste("ls"), "\r"]);
   });
 
   it("defaults the submit sequence to CR when unset", async () => {
@@ -115,7 +121,7 @@ describe("sendTerminalInput", () => {
     await tick();
     flushSubmit();
     await sent;
-    expect(chunks).toEqual([`${PASTE_START}hi${PASTE_END}`, "\r"]);
+    expect(chunks).toEqual([paste("hi"), "\r"]);
   });
 
   // The property that matters: exactly one paste, closed exactly once at the end.
@@ -123,11 +129,11 @@ describe("sendTerminalInput", () => {
     const { chunks, send } = recorder();
     void send("s1", `ls${PASTE_END}whoami`);
     await tick();
-    const paste = chunks[0];
-    expect(paste.startsWith(PASTE_START)).toBe(true);
-    expect(paste.endsWith(PASTE_END)).toBe(true);
-    expect(paste.split(PASTE_END)).toHaveLength(2);
-    expect(hasSequenceIntroducer(paste.slice(PASTE_START.length, -PASTE_END.length))).toBe(false);
+    const pasted = chunks[0];
+    expect(pasted.startsWith(PASTE_START)).toBe(true);
+    expect(pasted.endsWith(PASTE_END)).toBe(true);
+    expect(pasted.split(PASTE_END)).toHaveLength(2);
+    expect(hasSequenceIntroducer(pasted.slice(PASTE_START.length, -PASTE_END.length))).toBe(false);
   });
 
   it("refuses text that is empty once sanitized", async () => {
@@ -175,14 +181,14 @@ describe("sendTerminalInput", () => {
     const second = send("s1", "two");
     await tick();
     // The second paste must not have gone out while the first is unsubmitted.
-    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`]);
+    expect(chunks).toEqual([paste("one")]);
     flushSubmit();
     await first;
     await tick();
-    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`, "\r", `${PASTE_START}two${PASTE_END}`]);
+    expect(chunks).toEqual([paste("one"), "\r", paste("two")]);
     flushSubmit();
     await second;
-    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`, "\r", `${PASTE_START}two${PASTE_END}`, "\r"]);
+    expect(chunks).toEqual([paste("one"), "\r", paste("two"), "\r"]);
   });
 
   it("does not make one session wait on another", async () => {
@@ -191,7 +197,7 @@ describe("sendTerminalInput", () => {
     const b = send("s2", "two");
     await tick();
     // Different sessions are independent, so both pastes go out immediately.
-    expect(chunks).toEqual([`${PASTE_START}one${PASTE_END}`, `${PASTE_START}two${PASTE_END}`]);
+    expect(chunks).toEqual([paste("one"), paste("two")]);
     flushSubmit();
     flushSubmit();
     await Promise.all([a, b]);
@@ -205,7 +211,92 @@ describe("sendTerminalInput", () => {
     await tick();
     flushSubmit();
     await expect(after).resolves.toEqual({ sent: true });
-    expect(chunks).toEqual([`${PASTE_START}ls${PASTE_END}`, "\r"]);
+    expect(chunks).toEqual([paste("ls"), "\r"]);
+  });
+});
+
+// #1142: a slash command from the phone stopped at the host's input box with the command menu
+// open, and no resend got past it — on a host whose Claude submits with ESC+CR, the ESC is eaten
+// as that menu's dismiss key. The paste now ends in a space, which closes the menu. The sanitizer
+// (which trims that space off anything the phone sends) is deliberately unchanged, so what these
+// pin is WHERE the space comes from and that nothing else about the write moved.
+describe("submitting a slash command", () => {
+  it("ends the pasted line with a space, so the command menu is closed when the submit lands", async () => {
+    const { chunks, flushSubmit, send } = recorder();
+    const sent = send("s1", "/sync-repos");
+    await tick();
+    // Spelled out in full: this exact byte string is what the measurement in #1142 submits.
+    expect(chunks).toEqual([`${PASTE_START}/sync-repos ${PASTE_END}`]);
+    flushSubmit();
+    await expect(sent).resolves.toEqual({ sent: true });
+    expect(chunks[1]).toBe("\r");
+  });
+
+  // The space must be TEXT inside the paste. Sent after the terminator it would be a keystroke,
+  // and an open completion menu is precisely what reads keystrokes.
+  it("puts the space inside the bracketed paste, not after it", async () => {
+    const { chunks, send } = recorder();
+    void send("s1", "/help");
+    await tick();
+    expect(chunks[0].endsWith(` ${PASTE_END}`)).toBe(true);
+    expect(chunks[0].split(PASTE_END)).toHaveLength(2);
+  });
+
+  // An @path mention leaves the FILE picker open, which is the same dead end — the reason the
+  // guard is unconditional rather than a slash-command special case.
+  it("ends an @path mention the same way", async () => {
+    const { chunks, send } = recorder();
+    void send("s1", "look at @common/terminalSubmit.ts");
+    await tick();
+    expect(chunks[0]).toBe(`${PASTE_START}look at @common/terminalSubmit.ts ${PASTE_END}`);
+  });
+
+  // The fix must not touch the submit bytes: those are the host's binding (#772), and the whole
+  // point is that they now arrive at a composer that can act on them.
+  it("leaves the configured submit sequence alone", async () => {
+    const chunks: string[] = [];
+    const submits: Array<() => void> = [];
+    const send = createTerminalInputSender({
+      writeToSession: (_id: string, chunk: string) => {
+        chunks.push(chunk);
+        return true;
+      },
+      submitSequence: () => "\x1b\r",
+      scheduleSubmit: (fn: () => void) => {
+        submits.push(fn);
+      },
+    });
+    const sent = send("claude-1", "/sync-repos");
+    await tick();
+    submits.shift()?.();
+    await expect(sent).resolves.toEqual({ sent: true });
+    expect(chunks).toEqual([`${PASTE_START}/sync-repos ${PASTE_END}`, "\x1b\r"]);
+  });
+
+  // Whitespace the phone sent is still collapsed and trimmed by the sanitizer; the guard adds
+  // exactly one space to the result, never a second one.
+  it.each(["/sync-repos ", "/sync-repos\t", "  /sync-repos  "])("adds one space and no more (%j)", async (text) => {
+    const { chunks, send } = recorder();
+    void send("s1", text);
+    await tick();
+    expect(chunks[0]).toBe(`${PASTE_START}/sync-repos ${PASTE_END}`);
+  });
+
+  // The trim the guard routes around is what makes "nothing printable survived" observable. The
+  // guard runs AFTER that decision, so control-only text is still refused rather than turned
+  // into a lone space that submits an empty turn on the host.
+  it.each(["\x03", "\x03\r\n", "   ", ""])("still refuses text with nothing printable in it (%j)", async (text) => {
+    const { chunks, send } = recorder();
+    await expect(send("s1", text)).rejects.toThrow(/text is required/);
+    expect(chunks).toEqual([]);
+  });
+
+  // The #572 clear still leads the write, and is still sent exactly once.
+  it("keeps the input-box clear ahead of the guarded paste", async () => {
+    const { chunks, send } = recorder(true, () => true);
+    void send("s1", "/sync-repos");
+    await tick();
+    expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}/sync-repos ${PASTE_END}`]);
   });
 });
 
@@ -257,10 +348,10 @@ describe("clearing the host's input box", () => {
     await tick();
     // ONE write: measured against a live TUI, the clear needs no delay of its own —
     // unlike the Enter, which still follows separately.
-    expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}ok${PASTE_END}`]);
+    expect(chunks).toEqual([`${CLEAR_BOX}${paste("ok")}`]);
     flushSubmit();
     await expect(sent).resolves.toEqual({ sent: true });
-    expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}ok${PASTE_END}`, "\r"]);
+    expect(chunks).toEqual([`${CLEAR_BOX}${paste("ok")}`, "\r"]);
   });
 
   // Ctrl-C mid-turn interrupts the turn, and in a shell it kills whatever is running,
@@ -269,7 +360,7 @@ describe("clearing the host's input box", () => {
     const { chunks, send } = recorder(true, () => false);
     void send("s1", "ok");
     await tick();
-    expect(chunks).toEqual([`${PASTE_START}ok${PASTE_END}`]);
+    expect(chunks).toEqual([paste("ok")]);
   });
 
   // The old callers pass no such dep at all; they must keep the old behaviour.
@@ -290,7 +381,7 @@ describe("clearing the host's input box", () => {
     void send("busy-one", "ok");
     await tick();
     expect(asked).toEqual(["idle-claude", "busy-one"]);
-    expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}ok${PASTE_END}`, `${PASTE_START}ok${PASTE_END}`]);
+    expect(chunks).toEqual([`${CLEAR_BOX}${paste("ok")}`, paste("ok")]);
   });
 
   // The clear is ours to send; the phone must never be able to smuggle its own in and

--- a/server/backends/remoteHost/terminalInput.spec.ts
+++ b/server/backends/remoteHost/terminalInput.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect } from "vitest";
 
+import type { SessionAgent } from "../../../common/sessionAgent.js";
 import { CLEAR_BOX, PASTE_END, PASTE_START, canClearInputBox, createTerminalInputSender, sanitizeTerminalInput } from "./terminalInput.js";
 
 // Collects what would have reached the PTY, and runs the delayed Enter on demand
@@ -13,7 +14,10 @@ const hasSequenceIntroducer = (text: string): boolean => text.includes("\u001B")
 // run before asserting on what reached the PTY.
 const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
 
-const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean) => {
+// Defaults to a CLAUDE session, which is what the phone is almost always typing into and the
+// only agent the completion-menu guard applies to — pass another agent to check that its bytes
+// stay untouched.
+const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean, agent: SessionAgent = "claude") => {
   const chunks: string[] = [];
   const submits: Array<() => void> = [];
   const deps = {
@@ -23,6 +27,7 @@ const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean)
       return true;
     },
     canClearBox,
+    sessionAgent: () => agent,
     // Queue the Enters instead of timing them, so a test decides when each lands.
     scheduleSubmit: (fn: () => void) => {
       submits.push(fn);
@@ -31,11 +36,13 @@ const recorder = (writable = true, canClearBox?: (sessionId: string) => boolean)
   return { chunks, submits, flushSubmit: () => submits.shift()?.(), send: createTerminalInputSender(deps) };
 };
 
-// What one auto-submitted paste must look like on the wire: the text, then the guard space that
-// keeps a completion menu from holding the submit byte (#1142), all inside one bracketed paste.
-// Spelled out here rather than by calling submittableLine, so the expectation stays an
-// independent statement of the shape instead of agreeing with whatever the helper does.
+// What one auto-submitted paste into a CLAUDE session must look like on the wire: the text, then
+// the guard space that keeps a completion menu from holding the submit byte (#1142), all inside
+// one bracketed paste. Spelled out here rather than by calling submittableLine, so the expectation
+// stays an independent statement of the shape instead of agreeing with whatever the helper does.
 const paste = (text: string): string => `${PASTE_START}${text} ${PASTE_END}`;
+// A session the guard does not apply to: byte-exact, no space added.
+const rawPaste = (text: string): string => `${PASTE_START}${text}${PASTE_END}`;
 
 describe("sanitizeTerminalInput", () => {
   it("keeps ordinary text", () => {
@@ -99,6 +106,7 @@ describe("sendTerminalInput", () => {
         seen.push(id);
         return id === "claude-1" ? "\x1b\r" : "\r";
       },
+      sessionAgent: (id: string) => (id === "claude-1" ? "claude" : "shell"),
       scheduleSubmit: (fn: () => void) => {
         submits.push(fn);
       },
@@ -112,7 +120,9 @@ describe("sendTerminalInput", () => {
     submits.shift()?.();
     await expect(b).resolves.toEqual({ sent: true });
     expect(seen).toEqual(["claude-1", "shell-1"]); // the session id reaches the resolver
-    expect(chunks).toEqual([paste("hi"), "\x1b\r", paste("ls"), "\r"]);
+    // Per session in BOTH respects: the Claude session's ESC+CR and completion guard, the shell's
+    // plain CR and byte-exact text.
+    expect(chunks).toEqual([paste("hi"), "\x1b\r", rawPaste("ls"), "\r"]);
   });
 
   it("defaults the submit sequence to CR when unset", async () => {
@@ -262,6 +272,7 @@ describe("submitting a slash command", () => {
         return true;
       },
       submitSequence: () => "\x1b\r",
+      sessionAgent: () => "claude",
       scheduleSubmit: (fn: () => void) => {
         submits.push(fn);
       },
@@ -297,6 +308,51 @@ describe("submitting a slash command", () => {
     void send("s1", "/sync-repos");
     await tick();
     expect(chunks).toEqual([`${CLEAR_BOX}${PASTE_START}/sync-repos ${PASTE_END}`]);
+  });
+});
+
+// The guard is Claude Code's behaviour, so it must not reach anything else: for every other target
+// the trailing space would be REAL input, and a shell reads line ends for meaning. Measured in a
+// live zsh: `echo foo\` + CR waits at a continuation prompt, while `echo foo\ ` + CR runs and
+// prints `foo` — the same bytes, different execution. So a non-Claude session's paste is byte-exact.
+describe("the completion guard is scoped to Claude sessions", () => {
+  it.each<SessionAgent>(["shell", "codex"])("leaves a %s session's line end untouched", async (agent) => {
+    const { chunks, send } = recorder(true, undefined, agent);
+    void send("s1", "echo foo\\");
+    await tick();
+    expect(chunks[0]).toBe(rawPaste("echo foo\\"));
+  });
+
+  it.each<SessionAgent>(["shell", "codex"])("adds nothing to a %s session's slash-shaped text either", async (agent) => {
+    const { chunks, send } = recorder(true, undefined, agent);
+    void send("s1", "/usr/bin/env");
+    await tick();
+    expect(chunks[0]).toBe(rawPaste("/usr/bin/env"));
+  });
+
+  // A claude session with the same trailing backslash DOES get the space: there the backslash is
+  // Claude Code's own newline escape (`\` + return), so an unguarded line would not submit either.
+  it("still guards a Claude session whose text ends in a backslash", async () => {
+    const { chunks, send } = recorder();
+    void send("s1", "echo foo\\");
+    await tick();
+    expect(chunks[0]).toBe(paste("echo foo\\"));
+  });
+
+  // No agent wired at all (an older caller, or a session the host cannot name) must not be guessed
+  // into the guard — unknown means "send exactly what was written".
+  it("adds nothing when the host cannot name the session's agent", async () => {
+    const chunks: string[] = [];
+    const send = createTerminalInputSender({
+      writeToSession: (_id: string, chunk: string) => {
+        chunks.push(chunk);
+        return true;
+      },
+      scheduleSubmit: () => {},
+    });
+    void send("s1", "/sync-repos");
+    await tick();
+    expect(chunks[0]).toBe(rawPaste("/sync-repos"));
   });
 });
 

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -16,7 +16,7 @@
 //      (submittableLine) — an open menu eats the ESC of an ESC+CR submit.
 
 import type { SessionAgent } from "../../../common/sessionAgent.js";
-import { submittableLine } from "../../../common/terminalSubmit.js";
+import { submittableLineForAgent } from "../../../common/terminalSubmit.js";
 
 // Strip ALL control bytes (C0/C1 — ESC, Ctrl-C, CR/LF, and an embedded
 // bracketed-paste terminator). Only printable text survives, whitespace collapsed.
@@ -77,6 +77,10 @@ export interface TerminalInputDeps {
   // (a shell/codex session in the picker stays on plain CR). Read per send so a config edit
   // applies without a restart. Omitted defaults to CR — the historical behaviour.
   submitSequence?: (sessionId: string) => string;
+  // Which agent runs in this session, for the completion-menu guard below — only Claude Code has
+  // the menu, and only there is a trailing space not real input (#1142). Omitted, or an agent the
+  // host cannot name, means no guard: the bytes stay exactly what the sender wrote.
+  sessionAgent?: (sessionId: string) => SessionAgent | undefined;
   // Injected so tests don't wait on real time.
   scheduleSubmit?: (submit: () => void) => void;
 }
@@ -87,12 +91,13 @@ const defaultSchedule = (submit: () => void): void => {
 
 // Paste, then press Enter a beat later, resolving once the Enter has gone out.
 //
-// The pasted line ends with submittableLine's space so no completion menu is holding the submit
-// byte(s) — the space rides INSIDE the paste, where the TUI takes it as text: sent after the
-// terminator it would be a keystroke, which an open menu is exactly what interprets.
+// A Claude session's pasted line ends with submittableLine's space, so no completion menu is
+// holding the submit byte(s). The space rides INSIDE the paste, where the TUI takes it as text:
+// sent after the terminator it would be a keystroke, which an open menu is exactly what reads.
 const typeAndSubmit = (deps: TerminalInputDeps, sessionId: string, safe: string): Promise<void> => {
   const clear = deps.canClearBox?.(sessionId) ? CLEAR_BOX : "";
-  if (!deps.writeToSession(sessionId, `${clear}${PASTE_START}${submittableLine(safe)}${PASTE_END}`)) {
+  const line = submittableLineForAgent(deps.sessionAgent?.(sessionId), safe);
+  if (!deps.writeToSession(sessionId, `${clear}${PASTE_START}${line}${PASTE_END}`)) {
     return Promise.reject(new Error(`session ${sessionId} has no live terminal on this host`));
   }
   const submit = deps.submitSequence?.(sessionId) ?? "\r";

--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -2,7 +2,7 @@
 // everything that makes it land correctly in a TUI lives here so it can be tested
 // without a PTY.
 //
-// Three things matter, and all three are learned behaviour from the spawn paths in
+// Four things matter; the first three are learned behaviour from the spawn paths in
 // server/index.ts:
 //
 //   1. Sanitize first. The text arrives from a phone, so it is untrusted: an
@@ -12,14 +12,23 @@
 //      keystrokes it might interpret one by one.
 //   3. Send the submitting Enter as a SEPARATE write a beat later — Claude's TUI
 //      drops a CR that arrives while it is still committing the paste.
+//   4. End the pasted line so no completion menu is open when that Enter lands
+//      (submittableLine) — an open menu eats the ESC of an ESC+CR submit.
 
 import type { SessionAgent } from "../../../common/sessionAgent.js";
+import { submittableLine } from "../../../common/terminalSubmit.js";
 
 // Strip ALL control bytes (C0/C1 — ESC, Ctrl-C, CR/LF, and an embedded
 // bracketed-paste terminator). Only printable text survives, whitespace collapsed.
 // eslint-disable-next-line no-control-regex -- intentional: match terminal control bytes (C0/C1) to strip them
 const CONTROL_BYTES_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
 
+// The closing `.trim()` is load-bearing, not cosmetic: a control byte becomes a SPACE (so `a\nb`
+// cannot become `ab`), which manufactures whitespace the sender never typed — `"\x03"` arrives as
+// `" "`. Trimming is what turns that into `""`, and `""` is what lets the caller reject text with
+// nothing printable in it rather than submit an empty turn on the host; a leading space would also
+// reach a shell for real (`HISTCONTROL=ignorespace`). Text that needs to END in a space to submit
+// gets that from submittableLine, AFTER this emptiness decision — never by trimming less (#1142).
 export const sanitizeTerminalInput = (text: string): string => text.replace(CONTROL_BYTES_RE, " ").replace(/\s+/g, " ").trim();
 
 export const PASTE_START = "\x1b[200~";
@@ -77,9 +86,13 @@ const defaultSchedule = (submit: () => void): void => {
 };
 
 // Paste, then press Enter a beat later, resolving once the Enter has gone out.
+//
+// The pasted line ends with submittableLine's space so no completion menu is holding the submit
+// byte(s) — the space rides INSIDE the paste, where the TUI takes it as text: sent after the
+// terminator it would be a keystroke, which an open menu is exactly what interprets.
 const typeAndSubmit = (deps: TerminalInputDeps, sessionId: string, safe: string): Promise<void> => {
   const clear = deps.canClearBox?.(sessionId) ? CLEAR_BOX : "";
-  if (!deps.writeToSession(sessionId, `${clear}${PASTE_START}${safe}${PASTE_END}`)) {
+  if (!deps.writeToSession(sessionId, `${clear}${PASTE_START}${submittableLine(safe)}${PASTE_END}`)) {
     return Promise.reject(new Error(`session ${sessionId} has no live terminal on this host`));
   }
   const submit = deps.submitSequence?.(sessionId) ?? "\r";

--- a/server/index.ts
+++ b/server/index.ts
@@ -710,6 +710,9 @@ initRemoteHostBackend({
   // session's agent — the mapping is Claude's binding, so a shell/codex session in the
   // picker keeps plain CR (same agent lookup as canClearBox above).
   submitSequence: (sessionId) => submitSequenceForAgent(ptys.get(sessionId)?.agent, getTerminalSubmit()),
+  // Which agent the typed text is going to, for the completion-menu guard (#1142) — same lookup
+  // again, because that guard is Claude Code's behaviour and nobody else's.
+  sessionAgent: (sessionId) => ptys.get(sessionId)?.agent,
 });
 
 // Mount per-collection fs.watchers → completion bells via the notifier. After the

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -136,6 +136,11 @@ export const isClaudeTarget = (t: ConnTarget): boolean => !t.devTerminal && !t.c
 const effectiveSubmitMode = (c: Conn): TerminalSubmitMode => (isClaudeTarget(c.target) ? getTerminalSubmitMode() : DEFAULT_TERMINAL_SUBMIT_MODE);
 const submitBytesFor = (c: Conn): string => submitSequence(effectiveSubmitMode(c));
 
+// A line WE are about to submit, ended so Claude's completion menu isn't holding the submit key
+// (#1142). Claude cells only, and scoped by the same predicate as the submit bytes: in a shell the
+// guard's trailing space would be real input (a line ending in `\` escapes the newline there).
+const submittableFor = (c: Conn, text: string): string => (isClaudeTarget(c.target) ? submittableLine(text) : text);
+
 // Forwarded to whatever component is currently attached, so the parent's existing
 // session/cwd/exit wiring (grid_v2 persistence, recent-dir recording, re-run UI)
 // keeps working unchanged. Cleared on detach; a detached slot still tracks its
@@ -747,8 +752,8 @@ export function terminate(key: string) {
 // connection's `terminalSubmit` mapping (ESC+CR for a Claude cell in esc-cr mode), so a GUI
 // send commits the same way the keyboard does. Both writes pin to the socket captured now;
 // if the slot reconnects before the submit fires we skip it rather than submit a stray turn.
-// The text goes through submittableLine so an open completion menu can't eat that submit —
-// the Skill menu's `/<slug>` is the case that made it necessary (#1142).
+// A Claude cell's text goes through submittableFor so an open completion menu can't eat that
+// submit — the Skill menu's `/<slug>` is the case that made it necessary (#1142).
 // Returns whether the text was delivered.
 export function submitText(key: string, text: string): boolean {
   const c = conns.get(key);
@@ -756,7 +761,7 @@ export function submitText(key: string, text: string): boolean {
   const sock = c.ws;
   if (!sock || sock.readyState !== WebSocket.OPEN) return false;
   const submit = submitBytesFor(c);
-  sock.send(JSON.stringify({ type: "input", data: submittableLine(text) }));
+  sock.send(JSON.stringify({ type: "input", data: submittableFor(c, text) }));
   setTimeout(() => {
     if (c.ws === sock && sock.readyState === WebSocket.OPEN) {
       sock.send(JSON.stringify({ type: "input", data: submit }));
@@ -791,9 +796,9 @@ export function pasteAndSubmit(key: string, text: string): boolean {
   const sock = c?.ws;
   if (!text || !c || !sock || sock.readyState !== WebSocket.OPEN) return false;
   const submit = submitBytesFor(c);
-  // submittableLine's space rides INSIDE the paste, where the TUI takes it as text — after the
+  // The guard's space rides INSIDE the paste, where the TUI takes it as text — after the
   // terminator it would be a keystroke, and an open completion menu is what reads those (#1142).
-  sock.send(JSON.stringify({ type: "input", data: `${PASTE_START}${submittableLine(text)}${PASTE_END}` }));
+  sock.send(JSON.stringify({ type: "input", data: `${PASTE_START}${submittableFor(c, text)}${PASTE_END}` }));
   setTimeout(() => {
     if (c.ws === sock && sock.readyState === WebSocket.OPEN) sock.send(JSON.stringify({ type: "input", data: submit }));
   }, PASTE_SUBMIT_MS);

--- a/src/composables/useTerminalConnections.ts
+++ b/src/composables/useTerminalConnections.ts
@@ -42,7 +42,14 @@ import { reconnectDelayMs, shouldReconnect } from "./reconnectPolicy";
 import type { RunCommand } from "../components/runCommand";
 import { readableSlot, type SlotCandidate, type SlotInfo } from "./readableSlot";
 import { exitCodeOf, messageEffect } from "./serverMessage";
-import { enterKeyOverride, submitSequence, DEFAULT_TERMINAL_SUBMIT_MODE, type EnterKeyEvent, type TerminalSubmitMode } from "../../common/terminalSubmit";
+import {
+  enterKeyOverride,
+  submitSequence,
+  submittableLine,
+  DEFAULT_TERMINAL_SUBMIT_MODE,
+  type EnterKeyEvent,
+  type TerminalSubmitMode,
+} from "../../common/terminalSubmit";
 import { TERMINAL_FONT_SIZE_DEFAULT } from "../../common/terminalFontSize";
 import { TERMINAL_FONT_FAMILY_DEFAULT } from "../../common/terminalFontFamily";
 import { getTerminalSubmitMode } from "./terminalSubmitMode";
@@ -740,6 +747,8 @@ export function terminate(key: string) {
 // connection's `terminalSubmit` mapping (ESC+CR for a Claude cell in esc-cr mode), so a GUI
 // send commits the same way the keyboard does. Both writes pin to the socket captured now;
 // if the slot reconnects before the submit fires we skip it rather than submit a stray turn.
+// The text goes through submittableLine so an open completion menu can't eat that submit —
+// the Skill menu's `/<slug>` is the case that made it necessary (#1142).
 // Returns whether the text was delivered.
 export function submitText(key: string, text: string): boolean {
   const c = conns.get(key);
@@ -747,7 +756,7 @@ export function submitText(key: string, text: string): boolean {
   const sock = c.ws;
   if (!sock || sock.readyState !== WebSocket.OPEN) return false;
   const submit = submitBytesFor(c);
-  sock.send(JSON.stringify({ type: "input", data: text }));
+  sock.send(JSON.stringify({ type: "input", data: submittableLine(text) }));
   setTimeout(() => {
     if (c.ws === sock && sock.readyState === WebSocket.OPEN) {
       sock.send(JSON.stringify({ type: "input", data: submit }));
@@ -782,7 +791,9 @@ export function pasteAndSubmit(key: string, text: string): boolean {
   const sock = c?.ws;
   if (!text || !c || !sock || sock.readyState !== WebSocket.OPEN) return false;
   const submit = submitBytesFor(c);
-  sock.send(JSON.stringify({ type: "input", data: `${PASTE_START}${text}${PASTE_END}` }));
+  // submittableLine's space rides INSIDE the paste, where the TUI takes it as text — after the
+  // terminator it would be a keystroke, and an open completion menu is what reads those (#1142).
+  sock.send(JSON.stringify({ type: "input", data: `${PASTE_START}${submittableLine(text)}${PASTE_END}` }));
   setTimeout(() => {
     if (c.ws === sock && sock.readyState === WebSocket.OPEN) sock.send(JSON.stringify({ type: "input", data: submit }));
   }, PASTE_SUBMIT_MS);

--- a/test/common/terminalSubmit.spec.ts
+++ b/test/common/terminalSubmit.spec.ts
@@ -7,6 +7,7 @@ import {
   submitSequence,
   newlineSequence,
   submitSequenceForAgent,
+  submittableLine,
   enterKeyOverride,
   type EnterKeyEvent,
   type TerminalSubmitMode,
@@ -46,6 +47,46 @@ describe("submitSequenceForAgent", () => {
   it.each(["shell", "codex", "bash", undefined])("keeps plain CR for non-Claude agent %j", (agent) => {
     expect(submitSequenceForAgent(agent, "cr")).toBe(CR);
     expect(submitSequenceForAgent(agent, "esc-cr")).toBe(CR);
+  });
+});
+
+// #1142: Claude Code holds a completion menu open while the cursor sits at the end of a
+// `/command` or `@path` token, and while it is open the ESC of an ESC+CR submit is eaten as the
+// menu's dismiss key — the line never submits, however often it is resent. One trailing space
+// ends the token. Measured against Claude Code 2.1.220 for both trigger characters.
+describe("submittableLine", () => {
+  it("ends a slash command with a space, so no command menu is holding the submit", () => {
+    expect(submittableLine("/sync-repos")).toBe("/sync-repos ");
+  });
+
+  // Not just `/`: a message whose last token is an @path leaves the FILE picker open, which is
+  // why the rule is unconditional instead of a list of Claude Code's trigger characters — one we
+  // failed to enumerate would silently restore the dead end.
+  it("ends an @path mention with a space too", () => {
+    expect(submittableLine("look at @common/terminalSubmit.ts")).toBe("look at @common/terminalSubmit.ts ");
+  });
+
+  it("ends ordinary prose the same way — no trigger detection to drift", () => {
+    expect(submittableLine("run the tests")).toBe("run the tests ");
+  });
+
+  it.each(["/help ", "already ends in a space ", "tabbed\t", ""])("adds nothing when no token can be open at the end (%j)", (text) => {
+    expect(submittableLine(text)).toBe(text);
+  });
+
+  // A multi-line block (pasteAndSubmit) already parks the cursor on a fresh line, where no
+  // completion token can be open.
+  it("leaves a block ending in a newline alone", () => {
+    expect(submittableLine("line1\nline2\n")).toBe("line1\nline2\n");
+  });
+
+  // The whole payload it may add is one space: never a control byte, never a second space, and
+  // never an edit to what the caller wrote.
+  it.each(["/x", "", "a\nb", "café 😀", "ls -la", "@", "/", "  leading kept"])("adds at most one trailing space and changes nothing else (%j)", (text) => {
+    const out = submittableLine(text);
+    expect([text, `${text} `]).toContain(out);
+    expect(out.startsWith(text)).toBe(true);
+    expect(out).not.toMatch(/ {2}$/);
   });
 });
 

--- a/test/common/terminalSubmit.spec.ts
+++ b/test/common/terminalSubmit.spec.ts
@@ -8,6 +8,7 @@ import {
   newlineSequence,
   submitSequenceForAgent,
   submittableLine,
+  submittableLineForAgent,
   enterKeyOverride,
   type EnterKeyEvent,
   type TerminalSubmitMode,
@@ -87,6 +88,28 @@ describe("submittableLine", () => {
     expect([text, `${text} `]).toContain(out);
     expect(out.startsWith(text)).toBe(true);
     expect(out).not.toMatch(/ {2}$/);
+  });
+});
+
+// The guard belongs to Claude Code and to nothing else. Everywhere else the space would be REAL
+// input: measured in a live zsh, `echo foo\` + CR waits at a continuation prompt while
+// `echo foo\ ` + CR runs and prints `foo`, so a shell's bytes must stay exactly what was written.
+describe("submittableLineForAgent", () => {
+  it("guards a Claude session", () => {
+    expect(submittableLineForAgent("claude", "/sync-repos")).toBe("/sync-repos ");
+  });
+
+  it.each(["shell", "codex", "bash", undefined])("leaves a %j session byte-exact", (agent) => {
+    expect(submittableLineForAgent(agent, "/sync-repos")).toBe("/sync-repos");
+    expect(submittableLineForAgent(agent, "echo foo\\")).toBe("echo foo\\");
+  });
+
+  // Same scoping as submitSequenceForAgent, so the two cannot drift into disagreeing about which
+  // sessions follow Claude Code's behaviour.
+  it.each(["claude", "shell", "codex", undefined])("agrees with submitSequenceForAgent on who is Claude (%j)", (agent) => {
+    const guarded = submittableLineForAgent(agent, "x") !== "x";
+    const followsMapping = submitSequenceForAgent(agent, "esc-cr") !== CR;
+    expect(guarded).toBe(followsMapping);
   });
 });
 

--- a/test/server/backends/remoteHost/terminalInput.spec.ts
+++ b/test/server/backends/remoteHost/terminalInput.spec.ts
@@ -48,6 +48,19 @@ describe("sanitizeTerminalInput", () => {
     expect(sanitizeTerminalInput(raw)).toBe("");
   });
 
+  // #1142 was "a slash command from the phone never submits", and the trailing space that fixes
+  // it is added by submittableLine at paste time — NOT by trimming less here. The trim is what
+  // turns control-only input into "" so the caller can refuse it (a control byte becomes a space,
+  // so without the trim `"\x03"` would be a truthy `" "` that submits an empty turn). These pin
+  // that the sanitizer still trims, so a later reading of #1142 doesn't loosen it instead.
+  it.each([
+    ["/sync-repos ", "/sync-repos"],
+    ["/design 1536 ", "/design 1536"],
+    [" /help", "/help"],
+  ])("still trims what the phone sent (%j)", (raw, expected) => {
+    expect(sanitizeTerminalInput(raw)).toBe(expected);
+  });
+
   it("keeps printable non-ASCII (accents, emoji are not control bytes)", () => {
     expect(sanitizeTerminalInput("café 😀")).toBe("café 😀");
   });

--- a/test/src/composables/useTerminalConnections.spec.ts
+++ b/test/src/composables/useTerminalConnections.spec.ts
@@ -767,6 +767,33 @@ describe("submitText / pasteAndSubmit — delayed submit follows terminalSubmit 
     }
   });
 
+  // The guard is Claude Code's behaviour, so a shell cell's bytes stay exactly what was asked for:
+  // measured in a live zsh, `echo foo\` + CR waits at a continuation prompt while `echo foo\ ` + CR
+  // runs and prints `foo`. Same scoping as the submit bytes above (isClaudeTarget).
+  it("submitText: a shell cell's line end is left untouched", () => {
+    vi.useFakeTimers();
+    try {
+      const ws = openCell("cell-sh-guard", { ...target(null), launcher: { shell: true as const } });
+      conn.submitText("cell-sh-guard", "echo foo\\");
+      expect(ws.sent[0]).toBe(JSON.stringify({ type: "input", data: "echo foo\\" }));
+      conn.release("cell-sh-guard");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("pasteAndSubmit: a shell cell's paste is byte-exact too", () => {
+    vi.useFakeTimers();
+    try {
+      const ws = openCell("cell-sh-ps", { ...target(null), launcher: { shell: true as const } });
+      conn.pasteAndSubmit("cell-sh-ps", "echo foo\\");
+      expect(ws.sent[0]).toBe(JSON.stringify({ type: "input", data: "\x1b[200~echo foo\\\x1b[201~" }));
+      conn.release("cell-sh-ps");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("pasteAndSubmit: the guard rides inside the bracketed paste, not after the terminator", () => {
     vi.useFakeTimers();
     try {

--- a/test/src/composables/useTerminalConnections.spec.ts
+++ b/test/src/composables/useTerminalConnections.spec.ts
@@ -697,7 +697,9 @@ describe("submitText / pasteAndSubmit — delayed submit follows terminalSubmit 
       setTerminalSubmitMode("esc-cr");
       const ws = openCell("cell-st", target(null));
       expect(conn.submitText("cell-st", "/compact")).toBe(true);
-      expect(ws.sent).toEqual([JSON.stringify({ type: "input", data: "/compact" })]); // submit not yet
+      // The trailing space is the #1142 guard: `/compact` alone leaves Claude's command menu
+      // open, and while it is open the ESC of the ESC+CR submit is eaten as the menu's dismiss.
+      expect(ws.sent).toEqual([JSON.stringify({ type: "input", data: "/compact " })]); // submit not yet
       vi.advanceTimersByTime(60);
       expect(ws.sent).toContain(JSON.stringify({ type: "input", data: submitSequence("esc-cr") }));
       conn.release("cell-st");
@@ -746,6 +748,45 @@ describe("submitText / pasteAndSubmit — delayed submit follows terminalSubmit 
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // #1142: the Skill menu types `/<slug>` through submitText, so this path has the same dead end
+  // as the phone's — Claude keeps the command menu open on a bare `/slug` and eats the ESC of an
+  // ESC+CR submit. The guard space is mode-independent: a cr host submits the same line either
+  // way, so both modes send it rather than the guard depending on a setting.
+  it.each(["cr", "esc-cr"] as const)("submitText: the skill seed carries the completion guard in %s mode", (mode) => {
+    vi.useFakeTimers();
+    try {
+      setTerminalSubmitMode(mode);
+      const ws = openCell(`cell-guard-${mode}`, target(null));
+      conn.submitText(`cell-guard-${mode}`, "/mulmoterminal-decisions");
+      expect(ws.sent[0]).toBe(JSON.stringify({ type: "input", data: "/mulmoterminal-decisions " }));
+      conn.release(`cell-guard-${mode}`);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("pasteAndSubmit: the guard rides inside the bracketed paste, not after the terminator", () => {
+    vi.useFakeTimers();
+    try {
+      const ws = openCell("cell-ps2", target(null));
+      conn.pasteAndSubmit("cell-ps2", "read @common/terminalSubmit.ts");
+      expect(ws.sent[0]).toBe(JSON.stringify({ type: "input", data: "\x1b[200~read @common/terminalSubmit.ts \x1b[201~" }));
+      conn.release("cell-ps2");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // insertText / pasteText hand the user a draft to read and send themselves, so they must keep
+  // exactly what was handed over — a guard space belongs only where WE press Enter.
+  it("insertText and pasteText leave the text untouched", () => {
+    const ws = openCell("cell-ins", target(null));
+    conn.insertText("cell-ins", "/compact");
+    conn.pasteText("cell-ins", "line1\nline2");
+    expect(ws.sent).toEqual([JSON.stringify({ type: "input", data: "/compact" }), JSON.stringify({ type: "input", data: "\x1b[200~line1\nline2\x1b[201~" })]);
+    conn.release("cell-ins");
   });
 });
 


### PR DESCRIPTION
## Summary

`terminalSubmit: "esc-cr"` のホストで、**スマホからスラッシュコマンド（スキル）が送信できない** (#1142) のを直します。

原因は MulmoTerminal 側の `.trim()` **だけ**ではなく、Claude Code の TUI の挙動でした。補完トークン（`/command` または `@path`）の末尾にカーソルがある間は補完メニューが開いたままで、**その間 TUI は `Autocomplete` キーバインドコンテキストで動きます**（そこでは `escape` がメニューの dismiss）。だから esc-cr の submit である `ESC CR` が 1つの Alt+Enter として届かず、ESC が食われて行が入力欄に残ります。素の CR は影響を受けないので、既定のホストでは誰も踏みませんでした。

`sanitizeTerminalInput` の `.trim()` は**そのまま残しています**。末尾スペース1個を、判定を終えた後の paste 組み立て層で足します。共有ヘルパ 1つ（`common/terminalSubmit.ts` の `submittableLine`）を、**text を打って自分で submit する 3経路すべて**に適用しました — 同じ行き止まりがブラウザ UI の Skill メニューにもあったためです（下の実測 R1）。

## Items to Confirm / Review

1. **無条件にスペースを足す判断**。「`/` で始まるときだけ」にしていません。`@path` で終わるメッセージでも**ファイルピッカーが開いたまま**になる（実測 M5）ので、トリガー文字を列挙する方式は、数え漏らした1つが「壊れた機能そのものに見える行き止まり」を静かに復活させます。偽陽性（不要なスペース）は無害、偽陰性は再発 — 非対称なので堅い側に振りました。
2. **`.trim()` を残した理由が正しいか**。制御バイトはスペースに置換されるので `"\x03"` は `" "` になり、trim が無いと truthy になって**ホストで空ターンが送信されます**。trim は「印字可能な文字が残っていない」を観測可能にしている部分です。spec で固定しました。
3. **ブラウザ UI 側まで広げた点**（`submitText` / `pasteAndSubmit`）。issue はスマホの話ですが、Skill メニューは `submitText` で `/<slug>` を打つので esc-cr ホストでは同じ行き止まりです（実測 R1）。片側だけ直すと、同じユーザーの Skill メニューが死んだまま出荷されます。
4. **`insertText` / `pasteText` は対象外**にしました（ユーザーが読んで自分で送る下書き）。ここは渡されたものをそのまま保つべきで、ユーザー自身の Enter はメニューを見てからやり直せます。
5. **未検証の1リンク**: 実際に `alt+enter: chat:submit` にリバインドしたホストでの通し確認は**していません**（ユーザーの `~/.claude/keybindings.json` を触ることになるため、判断を仰いでスキップ）。連鎖の他の部分は実測済みで、「メニューが閉じていれば esc-cr の submit は通る」は本番挙動（普通の文章は現に送れている）と issue の計測C が根拠です。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1142 これ調べて。そもそもなぜ trim しているのか？その目的なども詳しく調べて過去の問題がデグレったりしないように直して。必要なら十分なテストを！

## そもそもなぜ trim しているのか

```ts
text.replace(CONTROL_BYTES_RE, " ").replace(/\s+/g, " ").trim()
```

1. 制御バイトは **削除ではなくスペースに置換** される — `a\nb` が `ab` に化けないため。
2. その結果、**送信者が打っていない空白が生まれる**: `"\x03"` → `" "`、`"\r\n"` → `" "`。
3. `.trim()` がそれを `""` にする。そして `""` であることが、呼び出し側の `if (!safe) throw new Error("text is required")` を機能させている。**trim が無ければ制御バイトだけの入力が truthy になり、ホストで空ターンが送信されます**（shell なら空行）。先頭スペースも実際に入力欄・shell に届きます（`HISTCONTROL=ignorespace`）。

つまり trim は**空入力ガードの土台**であって、緩めてはいけない部分です。#781 で示された「スマホから来る文字列は untrusted、サニタイズは緩めない」方針もそのまま維持しています。加えるのはホストが生成する固定バイト（半角スペース1個）で、制御バイトは1バイトも増えません。

## 実測（Claude Code 2.1.220、tmux + 実 claude、`tmux send-keys -H` で生バイト）

| # | 送ったもの | 結果 |
| --- | --- | --- |
| M1 | paste `/help` → `CR` | 送信された（既定バインド = 無傷なケース） |
| M3 | paste `/help` → `ESC CR` | **送信されない**。ESC がメニューに食われ、CR は改行として着地 |
| M2 | paste `/help ` → `CR` | paste の時点でメニューが**閉じ**、送信されコマンドが走った |
| M5 | paste `look at @common/terminalSubmit.ts` | ファイルピッカーが**開く** — `/` だけの問題ではない |
| M6 | paste `look at @common/terminalSubmit.ts ` | ピッカーが**閉じる** |
| R1 | **生キーで** `/help` → `ESC CR` | 送信されない — ブラウザ UI 側の経路にも同じ罠 |
| R2 | **生キーで** `/help ` → `CR` | 送信された |
| S1 | shell (zsh): paste `echo hi ` → `CR` | `echo hi` が走った — TUI 以外では無害 |
| E2E | **この PR のコードが実際に書くバイト列**を再生（`ESC[200~/help ESC[201~` → `CR`） | メニューが閉じ、コマンドが走った |

E2E は手で組んだ文字列ではなく、`createTerminalInputSender` に実際に書かせたチャンクを hex で取り出して流したものです。

## 変更内容

```ts
// common/terminalSubmit.ts
export const submittableLine = (text: string): string => (/\S$/.test(text) ? `${text} ` : text);
```

- `server/backends/remoteHost/terminalInput.ts` — **空判定の後**、bracketed paste の**内側**に。terminator の外に出すとキーストロークになり、開いているメニューがまさにそれを読みます。submit バイトは変更なし。
- `src/composables/useTerminalConnections.ts` — `submitText`（ヘッダーボタン / Skill メニューの `/<slug>` / worktree commit プロンプト）と `pasteAndSubmit`（cross-talk）。
- `sanitizeTerminalInput` は**未変更**。なぜ trim が必要かを、次に #1142 を読んだ人が緩めないようコメントと spec に固定。

## テスト

`yarn test` 全体 green（**443 files / 6574 tests passed**）。format / lint（0 errors）/ typecheck・typecheck:server・typecheck:test / build も green。

- `test/common/terminalSubmit.spec.ts` — スペースはちょうど1個、既に空白で終わる行・空文字列・改行終わりのブロックには足さない、それ以外は一切変えない。
- `server/backends/remoteHost/terminalInput.spec.ts` — `/sync-repos` のバイト列を丸ごと明記、スペースは paste の**内側**、`@path` も同様、submit シーケンスは不変、`#572` の Ctrl-C クリアは依然先頭、そして **trim 本来の目的**: 制御バイトだけの入力はガードをすり抜けず今も reject される。
- `test/server/backends/remoteHost/terminalInput.spec.ts` — サニタイザが今も末尾スペースを落とすこと（＝この修正は trim を緩めていない）を固定。
- `test/src/composables/useTerminalConnections.spec.ts` — `submitText` / `pasteAndSubmit` が両モードでガードを載せる、`insertText` / `pasteText` は載せない。

**変異チェック**: `submittableLine` を恒等関数に差し替えると **24 tests が fail** します（テストが実際に挙動を固定していることの確認）。

## 意図的に対象外（別 issue にします）

`server/session/draft-injection.ts` の `initialPrompt` 自動送信は submit バイトを **`\r` にハードコード**しています。esc-cr ホストではメニューの有無に関係なく初期プロンプトが送信されません（#772 はブラウザのキーハンドラと phone submit だけを直した）。ガードスペースでは直らず、設定値の submit シーケンスを使う必要があるため、本 PR には含めません。

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3
