### PR TITLE
fix(windows): picker の stdout を UTF-8 に固定して非ASCIIパスを壊さない (#1146)

### DIFF
--- a/plans/fix-1146-windows-picker-utf8.md
+++ b/plans/fix-1146-windows-picker-utf8.md
@@ -1,0 +1,63 @@
+# fix(windows): フォルダ/ファイル選択が非ASCIIパスで壊れる（#1146）
+
+Issue: #1146 / Branch: `fix/1146-windows-picker-utf8`
+
+## User Prompt
+
+https://github.com/receptron/mulmoterminal/issues/1146 これって対応でできる？win/mac や CJK などの対応も必要（というか多言語）
+
+## 症状と原因
+
+日本語 Windows で 📁 ボタンから日本語名のフォルダを選ぶと、ターミナルが**デフォルトパスで**起動する。
+
+1. `pick-file.ts` は picker の stdout を `Buffer.concat(out).toString()`（= UTF-8）で復号する。
+2. しかし `child_process.spawn` された Windows PowerShell 5.1 は、コンソールを持たないパイプ出力を
+   **OEM コードページ**（日本語 Windows なら CP932）で書く。→ 非ASCII部分だけ化ける。
+3. `C:\` の ASCII 前置は生き残るので `parsePickerOutput` の `path.isAbsolute` を通過し、
+   壊れたパスが `?cwd=` として送られる。
+4. `existingWorkspace` の `statSync` が ENOENT → `resolveWorkspace` が無言で `CLAUDE_CWD` に差し替える。
+
+つまり **CJK 固有ではなくコードページ依存**。中文・한국어・キリル・アクセント付きラテン（café）も同経路で壊れる。
+
+## mac / Linux は影響なし（実測）
+
+macOS 上で `osascript -e 'return POSIX path of (POSIX file "…" as alias)'` の stdout バイトを確認:
+
+| ディレクトリ | stdout バイト |
+| --- | --- |
+| `パソコン` | `e38391 e382bd e382b3 e383b3`（UTF-8 / NFC） |
+| `中文目录` | `e4b8ad e69687 e79bae e5bd95` |
+| `café` | `636166 c3a9`（NFC のまま） |
+
+UTF-8 で、APFS 上では NFC も保持される。zenity も UTF-8。よって本件は **Windows 固有**。
+（HFS+ ボリューム等で NFD が返るケースは `statSync` は通る＝起動はするので、本 PR の対象外。）
+
+## 修正
+
+1. PowerShell に UTF-8 で出力させる prelude を 1 箇所に切り出し、**フォルダ picker とファイル picker の両方**に適用する。
+   ファイル picker（`OpenFileDialog`、通知音の選択・header の `open` + `pickFile`）も同じバグを持つ。
+2. `[System.Text.Encoding]::UTF8` は **使わない**。BOM 付きなので、ホストによっては stdout 先頭に
+   `EF BB BF` が出て `\uFEFFC:\…` になり、`path.isAbsolute` が false → `paths: []`
+   （＝「選んでも何も起きない」）で全ロケールを巻き込む回帰になる。`New-Object System.Text.UTF8Encoding $false` を使う。
+3. Node 側の BOM 耐性は `parsePickerOutput` の `.trim()` が既に担っている
+   （U+FEFF は ECMAScript の WhiteSpace なので trim が落とす）。**偶然に頼らないよう spec で固定**し、
+   なぜ trim が load-bearing なのかをコメントに残す。冗長な二重除去は入れない。
+
+## 検証
+
+`windows-daily.yaml` が windows-latest で `yarn test` を回しているので、Windows 実機の spec を追加する
+（`it.skipIf(process.platform !== "win32")`）。英語ランナーでも先に
+`[Console]::OutputEncoding = [Text.Encoding]::GetEncoding(932)` を入れれば日本語 Windows を再現できる:
+
+- prelude **あり** → 多言語パスが byte 単位で round-trip する。
+- prelude **なし**（対照） → 化ける。＝ このテストが回帰を実際に捕まえられることの証明。
+
+PowerShell に渡す文字列は `[char]0x…` の連結で組み、argv のエンコーディングを変数から外す
+（テスト対象を stdout のエンコーディングだけに絞る）。
+
+## 対象外（別 issue）
+
+- 解決できない `?cwd=` を `resolveWorkspace` が**無言で**デフォルトに差し替える件。
+  本件の発見を遅らせた本質だが、reattach など広い範囲が現在の意味論に依存しているので独立して設計する。
+- picker のダイアログタイトル（`"Select folder"`）の i18n。PowerShell / AppleScript への
+  クォート埋め込み（現状「定数のみ・補間なし」）を崩すので別扱い。

--- a/server/files/pick-file.ts
+++ b/server/files/pick-file.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
 import { winFolderDialogScript } from "./win-folder-dialog.js";
+import { PS_UTF8_STDOUT } from "./win-powershell-utf8.js";
 import { requestOriginAllowed } from "../routes/same-origin-guard.js";
 
 // A native "open file/folder" dialog per platform whose stdout is the selection's
@@ -38,7 +39,7 @@ function macArgs(directory: boolean): string[] {
 function winArgs(directory: boolean): string[] {
   if (directory) return ["-NoProfile", "-STA", "-Command", winFolderDialogScript(DIR_PROMPT)];
   const dialog = `$d = New-Object System.Windows.Forms.OpenFileDialog; $d.Multiselect = $true; if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join "\`n" }`;
-  return ["-NoProfile", "-STA", "-Command", `Add-Type -AssemblyName System.Windows.Forms; ${dialog}`];
+  return ["-NoProfile", "-STA", "-Command", `${PS_UTF8_STDOUT}; Add-Type -AssemblyName System.Windows.Forms; ${dialog}`];
 }
 
 export function pickFileCommand(platform: NodeJS.Platform, directory = false): { cmd: string; args: string[] } {
@@ -50,6 +51,9 @@ export function pickFileCommand(platform: NodeJS.Platform, directory = false): {
   return { cmd: "zenity", args: zenity };
 }
 
+// `trim` is load-bearing beyond whitespace: U+FEFF is ECMAScript WhiteSpace, so it also drops a
+// UTF-8 BOM a console host may print ahead of the first path — and BOM + `C:\proj` is not an
+// absolute path, which would silently turn every pick into a cancel. A spec pins it.
 export function parsePickerOutput(stdout: string): string[] {
   return stdout
     .split(/\r?\n/)

--- a/server/files/win-folder-dialog.ts
+++ b/server/files/win-folder-dialog.ts
@@ -1,3 +1,5 @@
+import { PS_UTF8_STDOUT } from "./win-powershell-utf8.js";
+
 // The Windows folder picker, in the dialog Explorer actually uses (#1003).
 //
 // `System.Windows.Forms.FolderBrowserDialog` — what this used to open, and what the fallback at
@@ -93,6 +95,7 @@ namespace MtPicker {
 // a syntax error. A spec pins that, because prettier reflowing this template would not fail
 // anything else.
 export const winFolderDialogScript = (prompt: string): string => `
+${PS_UTF8_STDOUT}
 $ErrorActionPreference = 'Stop'
 function Get-MtModernFolder {
   Add-Type -TypeDefinition @'

--- a/server/files/win-powershell-utf8.ts
+++ b/server/files/win-powershell-utf8.ts
@@ -1,0 +1,17 @@
+// Make a spawned PowerShell print UTF-8, for every script here whose stdout we read back.
+//
+// Windows PowerShell 5.1 writes a piped stdout in the console's OEM code page — CP932 on Japanese
+// Windows, CP936 / CP949 / CP1251 elsewhere — so a chosen path arrives with its non-ASCII part
+// mangled while the ASCII `C:\` prefix survives. The corrupted path then passes `path.isAbsolute`,
+// fails `statSync`, and the launcher starts in the default workspace instead of the folder the user
+// picked (#1146). Nothing about this is CJK-specific; `café` breaks the same way.
+//
+// `UTF8Encoding $false`, never `[System.Text.Encoding]::UTF8`: that one carries a BOM preamble,
+// which some console hosts emit ahead of the first line. `parsePickerOutput` tolerates it, but only
+// just — a picker that returns nothing at all on every locale would be a worse bug than the one
+// being fixed, so don't stake the fix on that.
+//
+// The `catch` is empty and deliberate: the setter calls SetConsoleOutputCP, which can fail where no
+// console is attached. Losing UTF-8 there costs a mangled path — the behaviour before this existed.
+// Letting the exception out would kill the script, and the button would do nothing.
+export const PS_UTF8_STDOUT = "try { [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false } catch { }";

--- a/test/server/files/pick-file.spec.ts
+++ b/test/server/files/pick-file.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { pickFileCommand, parsePickerOutput } from "../../../server/files/pick-file.js";
+import { PS_UTF8_STDOUT } from "../../../server/files/win-powershell-utf8.js";
 
 describe("pickFileCommand", () => {
   it("uses osascript on macOS", () => {
@@ -56,6 +57,33 @@ describe("pickFileCommand (directory mode)", () => {
   });
 });
 
+// #1146: PowerShell 5.1 pipes stdout in the OEM code page, so a path's non-ASCII part reaches Node
+// mangled while `C:\` survives — an absolute-looking path that does not exist, which the launcher
+// then quietly replaces with the default workspace. Both dialogs read stdout, so both need this.
+describe("Windows picker output encoding", () => {
+  it("forces UTF-8 stdout in the folder picker, before the dialog is shown", () => {
+    const script = pickFileCommand("win32", true).args[3];
+    expect(script).toContain(PS_UTF8_STDOUT);
+    expect(script.indexOf(PS_UTF8_STDOUT)).toBeLessThan(script.indexOf("Folder]::Pick"));
+  });
+  it("forces UTF-8 stdout in the file picker too", () => {
+    const script = pickFileCommand("win32", false).args[3];
+    expect(script).toContain(PS_UTF8_STDOUT);
+    expect(script.indexOf(PS_UTF8_STDOUT)).toBeLessThan(script.indexOf("OpenFileDialog"));
+  });
+  // `[System.Text.Encoding]::UTF8` carries a BOM preamble, which turns the first path into
+  // "\uFEFFC:\..." — not absolute, so every pick would look like a cancel, on every locale.
+  it("uses the BOM-less UTF8Encoding, not [System.Text.Encoding]::UTF8", () => {
+    expect(PS_UTF8_STDOUT).toContain("UTF8Encoding $false");
+    expect(PS_UTF8_STDOUT).not.toContain("[System.Text.Encoding]::UTF8");
+  });
+  // SetConsoleOutputCP can fail where no console is attached. Mangled output is the old behaviour;
+  // a terminating error would cost the user the dialog itself.
+  it("cannot kill the script when the console has no code page to set", () => {
+    expect(PS_UTF8_STDOUT).toMatch(/^try \{.*\} catch \{ \}$/);
+  });
+});
+
 describe("parsePickerOutput", () => {
   it("splits newline-separated absolute paths", () => {
     expect(parsePickerOutput("/a/b.txt\n/c/d.txt")).toEqual(["/a/b.txt", "/c/d.txt"]);
@@ -71,5 +99,15 @@ describe("parsePickerOutput", () => {
   });
   it("returns empty for empty output (user canceled)", () => {
     expect(parsePickerOutput("")).toEqual([]);
+  });
+  // Not CJK-specific: the bug is a code page, so every non-ASCII script travels the same path.
+  it("keeps non-ASCII paths byte-for-byte, in any script", () => {
+    const paths = ["/proj/日本語フォルダ", "/proj/中文目录", "/proj/한국어폴더", "/proj/café", "/proj/Кириллица", "/proj/📁"];
+    expect(parsePickerOutput(paths.join("\n"))).toEqual(paths);
+  });
+  // A console host may print a UTF-8 BOM ahead of the first line; `trim` drops it because U+FEFF is
+  // ECMAScript WhiteSpace. Pinned so a "tidier" line filter cannot turn a pick into a cancel.
+  it("tolerates a UTF-8 BOM ahead of the first path", () => {
+    expect(parsePickerOutput("\uFEFF/proj/日本語\n/proj/b")).toEqual(["/proj/日本語", "/proj/b"]);
   });
 });

--- a/test/server/files/win-picker-encoding.spec.ts
+++ b/test/server/files/win-picker-encoding.spec.ts
@@ -1,0 +1,62 @@
+// Windows-only: does a chosen path survive the pipe from PowerShell back to us? (#1146)
+//
+// Nothing else in the suite can answer that. pick-file.spec asserts the SHAPE of the script from any
+// host; the bug lives in how the child ENCODES what it prints, which only a real Windows PowerShell
+// 5.1 can demonstrate. This runs in windows-daily.yaml and is skipped everywhere else.
+//
+// The runner is en-US (OEM code page 437), where the bug does not reproduce — so every case sets
+// CP932 first to stand in for the reporter's Japanese Windows. That is the condition the fix has to
+// beat: whatever the console's code page already is, the path must come back intact.
+//
+// The path travels in the ENVIRONMENT rather than argv or a PowerShell literal: a Windows
+// environment block is UTF-16, so the child receives the exact string, and the only variable left
+// under test is the encoding of its stdout.
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { parsePickerOutput, pickFileCommand } from "../../../server/files/pick-file.js";
+import { PS_UTF8_STDOUT } from "../../../server/files/win-powershell-utf8.js";
+
+const isWindows = process.platform === "win32";
+const PATH_VAR = "MT_PICKER_TEST_PATH";
+const AS_JAPANESE_CONSOLE = "[Console]::OutputEncoding = [Text.Encoding]::GetEncoding(932);";
+const PRINT_PICKED_PATH = `$env:${PATH_VAR}`;
+
+// One per script the bug can reach, because a code page is not a CJK problem: CP932 cannot spell
+// `é` or Hangul either, and mangles the Cyrillic it does have.
+const NON_ASCII_PATHS = ["C:\\proj\\日本語フォルダ", "C:\\proj\\中文目录", "C:\\proj\\한국어폴더", "C:\\proj\\café", "C:\\proj\\Кириллица"];
+
+// The interpreter the route itself spawns, taken from the route, so this exercises the same
+// resolution rather than a second guess at where PowerShell lives.
+const { cmd: POWERSHELL } = pickFileCommand("win32", true);
+
+function powershellStdout(script: string, picked: string): Buffer {
+  const result = spawnSync(POWERSHELL, ["-NoProfile", "-Command", script], { env: { ...process.env, [PATH_VAR]: picked } });
+  expect(result.error).toBeUndefined();
+  expect(result.status).toBe(0);
+  return result.stdout;
+}
+
+// Exactly how the route reads the picker: decode as UTF-8, then parse the lines.
+const pickedPaths = (stdout: Buffer): string[] => parsePickerOutput(stdout.toString());
+
+describe.skipIf(!isWindows)("a Windows picker's stdout", () => {
+  it.each(NON_ASCII_PATHS)("comes back byte-for-byte from a CP932 console: %s", (picked) => {
+    expect(pickedPaths(powershellStdout(`${AS_JAPANESE_CONSOLE} ${PS_UTF8_STDOUT}; ${PRINT_PICKED_PATH}`, picked))).toEqual([picked]);
+  });
+
+  // The control. Without the prelude the path IS mangled here — which is what proves the case above
+  // tests the fix rather than an en-US runner's harmless default.
+  it("is mangled without the prelude, so the case above is a real guard", () => {
+    const picked = NON_ASCII_PATHS[0];
+    const [decoded] = pickedPaths(powershellStdout(`${AS_JAPANESE_CONSOLE} ${PRINT_PICKED_PATH}`, picked));
+    expect(decoded).not.toBe(picked);
+    expect(decoded?.startsWith("C:\\proj\\")).toBe(true); // ...and absolute-looking, hence the silent fallback
+  });
+
+  // A BOM-carrying encoding would prefix the first line with EF BB BF. `parsePickerOutput` survives
+  // that, but only via `trim`, so keep the bytes clean at the source too.
+  it("carries no BOM", () => {
+    const stdout = powershellStdout(`${PS_UTF8_STDOUT}; ${PRINT_PICKED_PATH}`, NON_ASCII_PATHS[0]);
+    expect([...stdout.subarray(0, 3)]).not.toEqual([0xef, 0xbb, 0xbf]);
+  });
+});


### PR DESCRIPTION
## Summary

日本語 Windows で 📁 ボタンからフォルダを選ぶと、日本語名のディレクトリではターミナルが**デフォルトパスで**起動する (#1146)。原因は picker の stdout のエンコーディング:

1. `pick-file.ts` は stdout を `Buffer.concat(out).toString()` = **UTF-8 決め打ち**で復号する。
2. しかし `child_process.spawn` された Windows PowerShell 5.1 は、コンソールを持たないパイプ出力を **OEM コードページ**（日本語 Windows なら CP932）で書く。→ 非ASCII部分だけ化ける。
3. ASCII の `C:\` 前置は生き残るので `parsePickerOutput` の `path.isAbsolute` を通過し、壊れたパスが `?cwd=` として送られる。
4. `existingWorkspace` の `statSync` が ENOENT → `resolveWorkspace` が無言で `CLAUDE_CWD` に差し替える。

修正は、**フォルダ picker とファイル picker の両方**のスクリプト先頭で UTF-8 出力を強制する 1 行。

これは **CJK 固有ではなくコードページ依存**なので、日本語だけでなく 中文 / 한국어 / キリル / アクセント付きラテン (`café`) も同じ経路で壊れる。テストも多言語セットで書いた。

## Items to Confirm / Review

- **`UTF8Encoding $false` を使い、`[System.Text.Encoding]::UTF8` は使わない。** 後者は BOM 付きで、ホストによっては stdout 先頭に `EF BB BF` が出る。`\uFEFFC:\…` は絶対パスではないので `paths: []` = 「選んでも何も起きない」になり、**ロケール固有のバグを全ロケールのバグに置き換えてしまう**。issue 本文の提案パッチはこの `::UTF8` を使っていたので、意図的に変えている。
- **prelude を `try { … } catch { }` で包んだ。** 空 catch は意図的: setter は `SetConsoleOutputCP` を呼ぶので、コンソールが無い環境では失敗しうる。そこで例外を外に出すとスクリプトが死んでダイアログ自体が出なくなる（= 無反応なボタン）。UTF-8 を失うコストは「化けたパス」= 本 PR 以前の動作。`win-folder-dialog.ts` の COM fallback と同じ設計方針。
- **Node 側の BOM 除去は追加していない。** `parsePickerOutput` の `.trim()` が既に落としている（U+FEFF は ECMAScript の WhiteSpace）。偶然に頼らないよう **spec で固定 + なぜ trim が load-bearing なのかをコメント**に残した。冗長な二重除去より意図の明示を選んだ、という判断なのでレビューしてほしい。
- **ファイル picker（`OpenFileDialog`）も直している。** issue はフォルダ picker の話だが、通知音の選択と header の `open` + `pickFile` は同じ復号を通るので同じバグを持つ。
- **Windows 実機 spec の検証状況。** `windows-daily.yaml` は `pull_request` 対象外なので PR CI では回らない。`workflow_dispatch` でこのブランチに対して実行して確認する（結果はコメントで報告する）。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1146 これって対応でできる？win/mac や CJK などの対応も必要（というか多言語）

## mac / Linux は影響なし（実測）

macOS 上で `osascript -e 'return POSIX path of (POSIX file "…" as alias)'` の stdout バイトを実測した:

| ディレクトリ | stdout バイト |
| --- | --- |
| `パソコン` | `e38391 e382bd e382b3 e383b3`（UTF-8 / NFC） |
| `中文目录` | `e4b8ad e69687 e79bae e5bd95` |
| `café` | `636166 c3a9`（NFC のまま） |

UTF-8 で、APFS 上では NFC も保持される。zenity も UTF-8。よって本件は **Windows 固有**。

（HFS+ ボリューム等で `POSIX path` が NFD を返すケースは残るが、その NFD 文字列自体がディスク上の名前なので `statSync` は通る＝起動はする。「同一ディレクトリが config 上で 2 つの綴りになりうる」という別の問題なので本 PR の対象外。）

## 検証

`windows-daily.yaml` が windows-latest で `yarn test` を回しているので、Windows 実機 spec を追加した（`describe.skipIf(!isWindows)`）:

- **round-trip**: 5 言語のパスが byte 単位で戻ってくる。ランナーは en-US（OEM CP 437）でバグが再現しないので、各ケースで**先に CP932 をセットして日本語 Windows を再現**している — prelude はコンソールの既存コードページに勝たなければならない、というのが本来の条件。
- **対照テスト**: prelude 無しでは同じパスが化ける。これがあることで、上の round-trip が「fix を検証している」のか「en-US ランナーの無害なデフォルトを見ているだけ」なのかが区別できる。
- **BOM チェック**: 出力先頭が `EF BB BF` でないこと。
- パスは **argv でも PowerShell リテラルでもなく環境変数**で渡している。Windows の環境ブロックは UTF-16 なので子プロセスは文字列をそのまま受け取り、テスト対象が「stdout のエンコーディング」だけに絞られる。

ローカル (macOS): `yarn format` / `yarn lint` / `yarn typecheck` / `yarn typecheck:server` / `yarn typecheck:test` / `yarn build` / `yarn test`（6606 pass）。

## 対象外（別 issue にする）

- 解決できない `?cwd=` を `resolveWorkspace` が**無言で**デフォルトに差し替える件。本件の発見を遅らせた本質だが、reattach など広い範囲が現在の意味論に依存しているので独立して設計したい。
- picker のダイアログタイトル（`"Select folder"`）の i18n。PowerShell / AppleScript へのクォート埋め込み（現状は「定数のみ・補間なし」）を崩すので別扱い。

Closes #1146

work in mulmoterminal2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
