### PR TITLE
docs(remote-host): terminalInput のモジュール冒頭コメントを実装に合わせる (#1142)

### DIFF
--- a/server/backends/remoteHost/terminalInput.ts
+++ b/server/backends/remoteHost/terminalInput.ts
@@ -12,8 +12,12 @@
 //      keystrokes it might interpret one by one.
 //   3. Send the submitting Enter as a SEPARATE write a beat later — Claude's TUI
 //      drops a CR that arrives while it is still committing the paste.
-//   4. End the pasted line so no completion menu is open when that Enter lands
-//      (submittableLine) — an open menu eats the ESC of an ESC+CR submit.
+//   4. For a CLAUDE session, end the pasted line with a space (submittableLine) so no
+//      completion menu is open when that Enter lands. An open menu takes the key for
+//      itself: it eats the ESC of an ESC+CR submit, and the `@path` picker eats even a
+//      plain CR — which is why the guard is not scoped to the reversed submit mapping.
+//      Claude-only because anywhere else that space is real input: a shell line ending
+//      in `\` escapes the newline, and with a space appended it runs instead.
 
 import type { SessionAgent } from "../../../common/sessionAgent.js";
 import { submittableLineForAgent } from "../../../common/terminalSubmit.js";


### PR DESCRIPTION
## Summary

#1147 で入れたガードのスコープがレビュー中に変わった（無条件 → **Claude セッション限定**）のに、`server/backends/remoteHost/terminalInput.ts` の**冒頭コメントだけ最初の版のまま**残っていました。コメント 1 箇所の修正です。動作変更なし。

## Items to Confirm / Review

1. **なぜコメント 1 個で PR を切るのか** — この冒頭コメントはこのモジュールの契約そのもの（「TUI に正しく届けるために何が必要か」の一覧）で、次にここを触る人が読む場所です。しかも残っていた記述は、**将来「esc-cr のときだけで良いのでは」と絞り直す誘導になる**内容でした。実測ではそれは間違いです。
2. **書き換えた内容が実測と一致しているか** — 下の表が根拠です。

## 何が不正確だったか

```
4. End the pasted line so no completion menu is open when that Enter lands
   (submittableLine) — an open menu eats the ESC of an ESC+CR submit.
```

- 「メニューが食うのは ESC+CR の ESC」だけを書いていました。実測では **`@path` のピッカーは素の CR も食います** — まさにそれが「esc-cr 限定にしなかった」理由なのに、コメントは限定できるように読めます。
- 現在 load-bearing な **「Claude セッション限定」** と、その理由（shell では末尾スペースが実入力になり、`\` の改行エスケープが壊れる）に触れていませんでした。

修正後:

```
4. For a CLAUDE session, end the pasted line with a space (submittableLine) so no
   completion menu is open when that Enter lands. An open menu takes the key for
   itself: it eats the ESC of an ESC+CR submit, and the `@path` picker eats even a
   plain CR — which is why the guard is not scoped to the reversed submit mapping.
   Claude-only because anywhere else that space is real input: a shell line ending
   in `\` escapes the newline, and with a space appended it runs instead.
```

## 根拠（#1147 で取った実測、Claude Code 2.1.220 / tmux + 実 claude）

| 送ったもの | 結果 |
| --- | --- |
| paste `/help` → `ESC CR` | 送信されない（メニューが ESC を食う） |
| paste `look at @common/terminalSubmit.ts` → **素の `CR`** | **送信されない**（ピッカーがその CR を取る） |
| いずれも末尾スペースあり | 送信される |
| shell (zsh): `echo foo\` → `CR` / `echo foo\ ` → `CR` | 継続プロンプト / 実行され `foo` が出る |

## User Prompt

> （#1147 のマージ後、`/gh-review-loop` を実行）

loop の対象が無い状態（#1147 は merged、唯一の open PR #1149 は別セッションが作業中）だったため、マージ済み差分を自分で再レビューし、見つかったこの 1 点を follow-up として出しています。**bot の指摘ではありません。**

なお #1147 の CodeRabbit は結局 2 回とも rate limit でレビューが走っておらず、こちらのトリアージ要約に含めた文字列がコマンドとして解釈されて no-op になっていました（以後、要約にあの文字列を素で書かないようにします）。Codex は #1147 で LGTM、CI は全 green でマージ済みです。

## テスト

コメントのみの変更ですが、リポジトリの規定どおり全部回しました: `yarn format` / `lint`（0 errors）/ `typecheck`・`typecheck:server`・`typecheck:test` / `build` / `test`（**444 files / 6600 tests passed**）。

Refs #1142, #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how pasted text and submission keystrokes are handled in live terminal sessions.
  * Documented the behavior of the added space across different terminal contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->