### PR TITLE
fix: 解決できない cwd を無言でデフォルトワークスペースに差し替えない (#1151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,13 +1140,32 @@ newest first, including freshly-created sessions that aren't yet written to disk
 - `500 { "error": string }` on an unexpected filesystem error. A missing project
   directory is **not** an error — it yields an empty `sessions` array.
 
+### Directories that cannot be used
+
+Every `?cwd=` — on the terminal sockets and on the read routes alike — names the directory
+the request is about. When one is named and cannot be used, the server says so instead of
+quietly answering about the **default workspace** (#1151):
+
+| Where | What happens |
+| --- | --- |
+| `/ws`, `/ws/codex`, `/ws/antigravity`, `/ws/launch`, `/ws/run` | The socket is closed with `{ type: "error", message }`, which the terminal shows as a red banner and does not retry. |
+| A session that is still running (`?session=` names a live PTY or a surviving tmux session) | **Attaches anyway**, with a warning in the server log. Moving or renaming a directory must not shut you out of an agent that is still working in it — and the cwd reported back comes from the running PTY, not from the request. |
+| `GET /api/scripts`, `/api/skills`, `/api/dir-config`, `/api/dir-sound`, `/api/git-status`, `/api/pr-phase`, `/api/header`, `/api/sessions`, `/api/codex/sessions`, `/api/session/:id`, `/api/transcript/*`, `/api/cost` | `404 { error, cwd }` — a directory that is not there. |
+| A `?cwd=` that cannot name a directory at all (relative, or repeated as `?cwd=a&cwd=b`) | `400 { error, cwd }`. |
+
+A request that names **no** directory is unaffected: `CLAUDE_CWD` is then the answer it
+asked for. The wording of the refusal is the one a refused spawn already uses, so the same
+condition reads the same whether it is caught here or by `ptySpawn` itself.
+
 ### HTTP: `GET /api/scripts`
 
 The runnable entries from `<cwd>/script.json` for a cell's chosen directory
-(`?cwd=<dir>`, falling back to `CLAUDE_CWD`); see
-[Scripts (Run menu)](#scripts-run-menu). The resolved `cwd` is echoed back (the
-server may fall back from a bad path), and each entry carries its `index` (the
-position the client sends back to `/ws/run`).
+(`?cwd=<dir>`, or `CLAUDE_CWD` when none is named); see
+[Scripts (Run menu)](#scripts-run-menu). The resolved `cwd` is echoed back, and each
+entry carries its `index` (the position the client sends back to `/ws/run`). A `?cwd=`
+that names a directory the server cannot enter is answered `404 { error, cwd }` rather
+than with the default workspace's scripts — see
+[Directories that cannot be used](#directories-that-cannot-be-used).
 
 ```jsonc
 // GET /api/scripts?cwd=/Users/me/proj
@@ -1164,8 +1183,8 @@ A missing or invalid `script.json` is **not** an error — it yields an empty
 
 ### HTTP: `GET /api/skills`
 
-The Claude skills discoverable for a terminal's chosen directory (`?cwd=<dir>`,
-falling back to `CLAUDE_CWD`) — project scope (`<cwd>/.claude/skills`) plus user scope
+The Claude skills discoverable for a terminal's chosen directory (`?cwd=<dir>`, or
+`CLAUDE_CWD` when none is named) — project scope (`<cwd>/.claude/skills`) plus user scope
 (`~/.claude/skills`), deduped by slug (project shadows user), **working-dir skills
 first**; see [Skills (Skill menu)](#skills-skill-menu). A `skills` allowlist in that
 directory's `.mulmoterminal.json` narrows and reorders the result; absent → all. The

--- a/plans/fix-1151-unresolvable-cwd.md
+++ b/plans/fix-1151-unresolvable-cwd.md
@@ -1,0 +1,111 @@
+# fix: 解決できない cwd を無言でデフォルトワークスペースに差し替えない (#1151)
+
+`resolveWorkspace(cwd) = existingWorkspace(cwd) ?? CLAUDE_CWD` が、**明示的に渡された `?cwd=`**
+まで黙ってデフォルトに差し替える。#1146（Windows の picker が CP932 で書いて日本語パスが化ける）
+はこの増幅器のせいで「選んだフォルダで開かない」以外の手がかりが無い症状になった。エンコーディング
+自体は #1150 で直っているが、増幅器は残っている。
+
+## 決めたこと（ユーザー確認済み）
+
+| 論点 | 決定 |
+| --- | --- |
+| 対象範囲 | **起動経路 + 読み取り系ルートの両方**。呼び出し元ごとにフォールバックの是非を判断する |
+| 生きているセッションへの再接続 | **今のまま通す + ログ警告**。ディレクトリを移動しただけで実行中のエージェントから締め出さない |
+| 絶対パスでない `?cwd=` | **同じく拒否**、専用の文言 |
+
+## 3 つの結果を区別する
+
+いま `resolveWorkspace` は 2 つの入力（「渡されていない」「渡されたが解決できない」）を 1 つの答え
+（デフォルト）に潰している。ここを分ける:
+
+```ts
+export type WorkspaceRequest =
+  | { kind: "default"; cwd: string }      // ?cwd= が無い → デフォルトが正しい答え
+  | { kind: "resolved"; cwd: string }     // ?cwd= が実在するディレクトリを指した
+  | { kind: "unusable"; requested: string; problem: string }; // 渡されたが使えない
+```
+
+`?cwd=` が**空文字**のときは「無い」と同じ（現状維持。`resolveWorkspace("")` は CLAUDE_CWD）。
+文字列でない値（`?cwd=a&cwd=b` の配列など）は **unusable** にする — 渡されてはいるので、黙って
+デフォルトにするのはこの issue が問題にしている挙動そのもの。
+
+### 文言は #1078 のものを使い回す
+
+`problem` は `server/infra/spawn-cwd.ts` の `cwdProblemMessage` から作る（`SpawnCwdError` が
+出すのと同じ文）。「絶対パスでない」だけは spawn 側の概念ではない（子プロセスは相対パスを
+自分の cwd から解決できる）ので workspace 側に置く。
+
+## 起動経路（ws-routes）
+
+`wsConnectionContext` が `resolveWorkspace` を通すせいで、`ptySpawn` の
+`refuseUnusableCwd` / `SpawnCwdError`（#1078）は**この経路では絶対に発火しない**。届く前に
+パスが差し替わっているため。
+
+- **新規 spawn** で `unusable` → `closeWithError(problem)`。クライアントは既に
+  `messageEffect` で赤い `[…]` バナーをセルに書き、terminal 扱いで再接続もしない。
+  **新しい UI は要らない**。
+- **再接続**（同一プロセスの live pty / 生存している tmux）で `unusable` → `console.warn` して
+  従来どおりデフォルトへフォールバック。ここを拒否すると、ディレクトリを移動しただけで
+  実行中のエージェントに戻れなくなる（`refuseUnusableCwd(cwd, reattached)` が同じ判断をしている）。
+  なお生の壊れたパスを tmux クライアントの cwd に渡すと macOS では子プロセスが黙って exit 1 する
+  ので、**フォールバックは再接続を守っている**。表示上の cwd は `effectiveSessionCwd` が
+  live pty 側を優先するので変わらない。
+- `/ws/run` は ephemeral（reattach が無い）ので常に拒否側。
+
+## 読み取り系ルート
+
+`workspaceFromQuery` を使っている 10 ルートは、解決できない `?cwd=` に対して**要求された
+ディレクトリの名前で別のディレクトリの答え**を返している。実害の大きい順に:
+
+| ルート | 何が起きるか |
+| --- | --- |
+| `/api/scripts` | 返した `cwd` でセルがスクリプトを**実行する** |
+| `/api/sessions` | 返した `cwd` でセルがセッションを**resume する** |
+| `/api/session/:id`・`/api/transcript/*`・timeline | 別プロジェクトの transcript を読む |
+| `/api/dir-config`・`/api/dir-sound` | 別ディレクトリの色・音を着る |
+| `/api/git-status`・`/api/pr-phase`・`/api/header`・`/api/skills`・`/api/cost` | 別ディレクトリの答え |
+
+いずれも `unusable` なら答えない: **404 + `{ error: problem }`**（絶対パスでない等の壊れた要求は
+400）。クライアント側は既に「取れなければ空」を実装しているので追加の分岐は不要
+（`useDirLists` は !ok を空リスト、`useDirConfig` は EMPTY、`fetchSessionDetail` は null）。
+
+200 + 空ペイロードにしない理由: それは「ここには何も設定されていない」と見分けが付かず、この
+issue が問題にしている沈黙そのものになる。404 なら理由が body とログに残る。
+
+### 触らないもの
+
+`/api/dir-config-detail` と `/api/gui-mcp-groups` は既に `existingWorkspaceFromQuery` で
+フォールバックしない（200 + 空ペイロードを返す）。**この issue の要件は既に満たしている**ので、
+クライアント契約を変えてまで 404 に揃えることはしない。差分を最小にする方を採る。
+
+## テスト
+
+- `workspace.spec` — 3 つの結果、空文字と非文字列の扱い、文言
+- ws — 新規 spawn は `closeWithError` で拒否 / 再接続は警告して通す / `/ws/run` は拒否
+- 読み取り系 — supertest で 404 + 理由、`?cwd=` 無しは従来どおりデフォルト
+
+## 実測（本物のサーバーに対して）
+
+spec が緑なのは「自分の書いたものどうしが一致した」だけなので、`PORT=7719 yarn server` で
+**実際のサーバーを起動して** HTTP と WebSocket を直接叩いた。
+
+| 条件 | 結果 |
+| --- | --- |
+| `GET /api/scripts`（cwd 無し） | 200 / `cwd` = デフォルトワークスペース |
+| `GET /api/scripts?cwd=/tmp` | 200 / `cwd` = `/tmp` |
+| `GET /api/scripts?cwd=<消したディレクトリ>` | **404** + 理由（"no longer exists …"） |
+| `/ws?cwd=<消したディレクトリ>` | **error フレーム**（同じ文言） |
+| `/ws?cwd=relative/path` | **error フレーム**（"is not an absolute path"） |
+| `/ws/run?cwd=<消したディレクトリ>` | **error フレーム** |
+| `/ws/launch?shell=1&cwd=<消したディレクトリ>` | **error フレーム** |
+| `/ws/launch?shell=1&cwd=/tmp` | **session フレーム**（普通の起動は壊れていない） |
+| 生きているセッションへ `?session=<id>&cwd=<消したディレクトリ>` | **attach 成功**。しかも返る cwd は実際の `/tmp`（`effectiveSessionCwd`） |
+| 存在しない session id + 同じ cwd | **error フレーム**（reattach の抜け道になっていない） |
+
+サーバーログにも `[ws/claude] refusing to start — …` と
+`[ws/launch] attaching <id> despite an unusable ?cwd= — …` が出ることを確認。
+
+## 検証
+
+`yarn format` → `yarn lint` → `yarn typecheck` → `yarn typecheck:server` → `yarn typecheck:test` →
+`yarn build` → `yarn test`。

--- a/server/config/workspace.ts
+++ b/server/config/workspace.ts
@@ -2,18 +2,13 @@ import { statSync } from "node:fs";
 import path from "node:path";
 import { CLAUDE_CWD } from "./env.js";
 import { canonicalDir } from "../infra/path-within.js";
+import { cwdProblemMessage, diagnoseSpawnCwd } from "../infra/spawn-cwd.js";
 
-// Validate a client-supplied workspace dir: must be an absolute, existing
-// directory. Anything else (relative, missing, a file) falls back to CLAUDE_CWD,
-// so a cell can launch a terminal in a chosen dir without trusting raw input.
-export function resolveWorkspace(cwd: string | null): string {
-  return existingWorkspace(cwd) ?? CLAUDE_CWD;
-}
-
-// The same validation WITHOUT the fallback, for a route that REPORTS ON the directory it was
-// asked about. Falling back there is a correctness bug rather than a safe default: the caller
-// would render another directory's answer under the requested directory's name — and a stale
-// preset (a project since deleted) is exactly when it happens.
+// Validate a client-supplied workspace dir: an absolute path naming an existing directory, or
+// null. There is deliberately no variant that answers the DEFAULT workspace for a directory it
+// rejected — a caller that asked about one directory would then be handed another one's answer
+// under the requested one's name, and a stale preset (a project since deleted) is exactly when
+// that happens. Callers take `workspaceRequest` below and decide what to do about it.
 // Canonical, not verbatim: this return value is the identity a directory is known by everywhere
 // downstream — the PTY's cwd, the cwd echoed back to the cell, the key its dir-config
 // subscription uses, and the path recorded as a launcher preset. `/a/b/` passes both guards
@@ -41,8 +36,43 @@ export function existingWorkspaceFromQuery(cwd: unknown): string | null {
   return existingWorkspace(typeof cwd === "string" ? cwd : null);
 }
 
-// Every `?cwd=` route resolves the same way: a string query param or the default
-// workspace. Shared so a route can't accidentally skip the validation above.
-export function workspaceFromQuery(cwd: unknown): string {
-  return resolveWorkspace(typeof cwd === "string" ? cwd : null);
+// What a request asked for, with the two cases that used to be answered identically told apart:
+// NO directory was named (the default workspace is then the right answer), and a directory WAS
+// named but cannot be used. Folding the second into the first is what made a mistyped path, a
+// preset whose project was deleted, and a path mangled in transit (#1146) all look alike — and
+// what they looked like was "it just opened somewhere else" (#1151).
+//
+// `malformed` separates "this request cannot name a directory at all" (not a path, or a relative
+// one) from "it names a directory that is not there" — a bad request versus a missing one, which
+// is the difference an HTTP status is for.
+export type WorkspaceRequest =
+  { kind: "default"; cwd: string } | { kind: "resolved"; cwd: string } | { kind: "unusable"; requested: string; problem: string; malformed: boolean };
+
+// Why a named directory cannot be used, in the words `SpawnCwdError` already says it in (#1078) —
+// one wording for one condition, whether it surfaces as a refused spawn or a refused read.
+//
+// Absoluteness is this layer's own rule and not diagnoseSpawnCwd's: a child process resolves a
+// relative cwd against OUR working directory perfectly well, so it is not a spawn problem — it is
+// a client sending something no part of this app has a basis to interpret.
+function unusableWorkspace(requested: string): WorkspaceRequest {
+  if (!path.isAbsolute(requested))
+    return { kind: "unusable", requested, problem: `${requested} is not an absolute path, so it names no directory on this machine.`, malformed: true };
+  const dir = canonicalDir(requested);
+  // The fallback covers the one case the diagnosis calls fine and `existingWorkspace` did not:
+  // a probe that could not answer (a permission error, a broken mount). Saying so beats a
+  // refusal with no reason attached.
+  const problem = cwdProblemMessage(dir, diagnoseSpawnCwd(dir)) ?? `${dir} cannot be read, so it cannot be used as a working directory.`;
+  return { kind: "unusable", requested, problem, malformed: false };
+}
+
+// Every `?cwd=` route reads the query the same way. An ABSENT param (and an empty one, which is
+// how a browser spells the same thing) asks for no particular directory. Anything else was asked
+// for on purpose — including a non-string, which is what `?cwd=a&cwd=b` arrives as — so it is
+// answered about or refused, never quietly swapped for the default.
+export function workspaceRequest(cwd: unknown): WorkspaceRequest {
+  if (cwd === undefined || cwd === null || cwd === "") return { kind: "default", cwd: CLAUDE_CWD };
+  if (typeof cwd !== "string")
+    return { kind: "unusable", requested: String(cwd), problem: "The working directory must be given exactly once, as a path.", malformed: true };
+  const resolved = existingWorkspace(cwd);
+  return resolved ? { kind: "resolved", cwd: resolved } : unusableWorkspace(cwd);
 }

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -51,7 +51,6 @@ import { mountHtmlDispatchRoute, mountHtmlFileRoute, mountHtmlPreviewRoute } fro
 import { mountMulmoScriptDispatchRoute, mountMulmoScriptMediaRoute } from "../backends/mulmoscript.js";
 import { CLAUDE_CWD, MULMOTERMINAL_HOME, PORT, SESSION_ID_RE } from "../config/env.js";
 import { FILE_WRITE_CHANNEL, type FileWriteEvent } from "../../common/fileWriteChannel.js";
-import { resolveWorkspace } from "../config/workspace.js";
 import type { createToolStores } from "../session/tool-store.js";
 import type { createClaudeSpawner } from "../session/spawn-claude.js";
 import type { createCodexSpawner } from "../session/spawn-codex.js";
@@ -63,6 +62,7 @@ import { resumableSessionPredicate } from "../session/resumable-sessions.js";
 import type { SessionActivityDeps } from "../session/session-activity-deps.js";
 import { mountSpaFallback } from "../infra/spa-fallback.js";
 import { mountRateLimitRoutes, type RateLimitRouteDeps } from "../agents/rate-limit-routes.js";
+import { workspaceForRoute } from "./routeParams.js";
 
 export interface AppRouteDeps extends SessionActivityDeps {
   clientDir: string;
@@ -318,7 +318,7 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
 
   // GET /api/cost — estimated $ cost (session + today/month roll-up) for a project's
   // sessions, from public per-model pricing. Read-only; shown in the Settings modal (#245).
-  mountCostRoute(app, { resolveCwd: resolveWorkspace });
+  mountCostRoute(app, { resolveCwd: workspaceForRoute });
 
   // POST /api/remote-host/connect|disconnect + GET /status — start/stop the
   // Firestore host loop from the toolbar Connect control. Same-origin guarded like

--- a/server/routes/dir-routes.ts
+++ b/server/routes/dir-routes.ts
@@ -64,6 +64,17 @@ async function workCommentHandler(req: Request, res: Response): Promise<void> {
   res.json(result);
 }
 
+async function prPhaseHandler(req: Request, res: Response): Promise<void> {
+  const cwd = workspaceForRoute(req.query.cwd, res);
+  if (cwd === null) return;
+  const status = await gitStatus(cwd);
+  const repo = status.repo && status.branch ? repoFromWebUrl(await resolveGithubUrl(cwd)) : null;
+  // The same shape as the resolved path, not a two-field subset: a dir with no GitHub remote
+  // is a normal answer, and a route that changes its response shape by branch is a trap for
+  // the next reader of the contract (Codex review).
+  res.json(!repo || !status.branch ? { ...EMPTY_WORK_ITEM } : await phaseForRepoBranch(repo, status.branch));
+}
+
 const positiveInt = (v: unknown): number | null => (typeof v === "number" && Number.isSafeInteger(v) && v > 0 ? v : null);
 
 export function mountDirRoutes(app: Express): void {
@@ -125,17 +136,7 @@ export function mountDirRoutes(app: Express): void {
   // to merge / merged (server/git/prPhase.ts). The cockpit roster shows it alongside the agent
   // status. Resolves the branch's repo here (same as the header's PR button); a non-repo dir,
   // detached HEAD, or non-GitHub remote yields `none`. Read-only; the gh call is cached.
-  app.get("/api/pr-phase", async (req, res) => {
-    const cwd = workspaceForRoute(req.query.cwd, res);
-    if (cwd === null) return;
-    const status = await gitStatus(cwd);
-    const repo = status.repo && status.branch ? repoFromWebUrl(await resolveGithubUrl(cwd)) : null;
-    // The same shape as the resolved path, not a two-field subset: a dir with no GitHub remote
-    // is a normal answer, and a route that changes its response shape by branch is a trap for
-    // the next reader of the contract (Codex review).
-    if (!repo || !status.branch) return res.json({ ...EMPTY_WORK_ITEM });
-    res.json(await phaseForRepoBranch(repo, status.branch));
-  });
+  app.get("/api/pr-phase", prPhaseHandler);
 
   app.post("/api/work-comment", workCommentHandler);
 

--- a/server/routes/dir-routes.ts
+++ b/server/routes/dir-routes.ts
@@ -5,8 +5,8 @@
 // injected; the mount only needs the app.
 import type { Express, Request, Response } from "express";
 import { SESSION_ID_RE } from "../config/env.js";
-import { workspaceFromQuery, existingWorkspaceFromQuery } from "../config/workspace.js";
-import { normalizeAgent } from "./routeParams.js";
+import { existingWorkspaceFromQuery } from "../config/workspace.js";
+import { normalizeAgent, workspaceForRoute } from "./routeParams.js";
 import { getHeaderConfig, getIssueWorkComments } from "../config/config-routes.js";
 import { publicDirConfig, dirSoundFor, loadDirConfig, dirConfigDetail, MISSING_DIR_CONFIG_DETAIL } from "../config/dir-config.js";
 import { readSoundPreset } from "../config/sound-presets.js";
@@ -68,12 +68,13 @@ const positiveInt = (v: unknown): number | null => (typeof v === "number" && Num
 
 export function mountDirRoutes(app: Express): void {
   // GRID-ONLY (dev_tool): the `script.json` entries a cell's launcher offers for its
-  // chosen directory (?cwd=<dir>, falling back to CLAUDE_CWD). The browser shows
+  // chosen directory (?cwd=<dir>, the default workspace when none is named). The browser shows
   // these and sends back only an INDEX + the cwd (see /ws/run), so the file is the
   // allowlist of what can run. The resolved `cwd` is returned so the cell runs the
   // script in the same dir it listed scripts for.
   app.get("/api/scripts", (req, res) => {
-    const cwd = workspaceFromQuery(req.query.cwd);
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     res.json({ cwd, scripts: loadScripts(cwd).map((s, index) => ({ index, label: s.label, command: s.command, cwd: s.cwd })) });
   });
 
@@ -84,7 +85,8 @@ export function mountDirRoutes(app: Express): void {
   // A per-dir `.mulmoterminal.json` `skills` allowlist narrows/orders the list;
   // absent => show all.
   app.get("/api/skills", async (req, res) => {
-    const cwd = workspaceFromQuery(req.query.cwd);
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     const skills = applySkillFilter(await discoverSkills({ workspaceRoot: cwd }), loadDirConfig(cwd).skills);
     res.json({ cwd, skills });
   });
@@ -93,7 +95,8 @@ export function mountDirRoutes(app: Express): void {
   // terminal opened in this directory should use. cwd is validated like every other
   // cwd-scoped route; the raw sound path stays server-side (see /api/dir-sound).
   app.get("/api/dir-config", (req, res) => {
-    const cwd = workspaceFromQuery(req.query.cwd);
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     res.json(publicDirConfig(cwd));
   });
 
@@ -101,9 +104,9 @@ export function mountDirRoutes(app: Express): void {
   // how each fared (applied / dropped in validation / not a key we read). Its own route rather
   // than fields on /api/dir-config, which every cell fetches — this re-reads the file and is
   // only wanted while the modal is open.
-  // NOT workspaceFromQuery: this route reports ON the directory it is asked about, so falling
-  // back to the default workspace would answer about a DIFFERENT directory under the requested
-  // one's name — and a preset that outlived its project is exactly when that happens.
+  // Answers about an unusable directory with the "unknown" payload rather than the 404 the
+  // routes above give it: the settings modal renders that payload as "no config here", and it
+  // asks about a directory the user is still typing.
   app.get("/api/dir-config-detail", (req, res) => {
     const cwd = existingWorkspaceFromQuery(req.query.cwd);
     res.json(cwd ? dirConfigDetail(cwd) : MISSING_DIR_CONFIG_DETAIL);
@@ -113,7 +116,8 @@ export function mountDirRoutes(app: Express): void {
   // header can show it without the user typing `git status`. A non-git dir is
   // `repo:false`, not an error.
   app.get("/api/git-status", async (req, res) => {
-    const cwd = workspaceFromQuery(req.query.cwd);
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     res.json(await gitStatus(cwd));
   });
 
@@ -122,7 +126,8 @@ export function mountDirRoutes(app: Express): void {
   // status. Resolves the branch's repo here (same as the header's PR button); a non-repo dir,
   // detached HEAD, or non-GitHub remote yields `none`. Read-only; the gh call is cached.
   app.get("/api/pr-phase", async (req, res) => {
-    const cwd = workspaceFromQuery(req.query.cwd);
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     const status = await gitStatus(cwd);
     const repo = status.repo && status.branch ? repoFromWebUrl(await resolveGithubUrl(cwd)) : null;
     // The same shape as the resolved path, not a two-field subset: a dir with no GitHub remote
@@ -138,7 +143,8 @@ export function mountDirRoutes(app: Express): void {
   // dir's, with `when` evaluated and ${vars} substituted for this session's live context. `chips:null`
   // means unconfigured, so the client keeps its default header (see plans/feat-header-toolbar-config.md).
   app.get("/api/header", async (req, res) => {
-    const cwd = workspaceFromQuery(req.query.cwd);
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     const session = typeof req.query.session === "string" && SESSION_ID_RE.test(req.query.session) ? req.query.session : null;
     const agent = normalizeAgent(req.query.agent);
     const model = typeof req.query.model === "string" ? req.query.model : null;
@@ -157,7 +163,8 @@ export function mountDirRoutes(app: Express): void {
   // so there's no traversal surface. 404 when unset/missing (the client falls back to
   // the global sound, then the built-in chime).
   app.get("/api/dir-sound", async (req, res) => {
-    const cwd = workspaceFromQuery(req.query.cwd);
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     // An unknown/absent `kind` asks for the directory's all-kind sound, which is also what a
     // client from before #873 sends. The value only ever selects a map entry — never a path.
     const kind = isNotifyKind(req.query.kind) ? req.query.kind : null;

--- a/server/routes/routeParams.ts
+++ b/server/routes/routeParams.ts
@@ -1,6 +1,8 @@
-// Two tiny query-param decisions shared by the terminal ws/session/dir routes, pulled out of
+// Small query-param decisions shared by the terminal ws/session/dir routes, pulled out of
 // the handlers so the parse rules live in one place (they were copied verbatim across three
 // files, which is how they drift).
+import type { Response } from "express";
+import { workspaceRequest } from "../config/workspace.js";
 
 // A non-negative integer index from a query param, or NaN for anything else — empty string,
 // "-1", "1.5", "1e2", or a missing param. The anchored /^\d+$/ is deliberate: downstream
@@ -18,4 +20,20 @@ export function normalizeAgent(raw: unknown): "codex" | "antigravity" | "claude"
   if (raw === "codex") return "codex";
   if (raw === "antigravity") return "antigravity";
   return "claude";
+}
+
+// The directory a `?cwd=` route is to answer about, or null once it has answered the refusal
+// itself — so a handler reads `if (cwd === null) return;` and is otherwise unchanged.
+//
+// A route that REPORTS ON a directory must not answer about a different one under the requested
+// one's name (#1151): a stale preset, a mistyped path or one mangled in transit would otherwise
+// come back as the default workspace's sessions, scripts, colours and git status. 404 rather than
+// an empty 200, because "there is no such directory" and "that directory has nothing" are
+// different answers and only one of them is worth telling the user about — an empty 200 is the
+// silence this exists to end. A path that cannot name a directory at all is a malformed request.
+export function workspaceForRoute(cwd: unknown, res: Response): string | null {
+  const request = workspaceRequest(cwd);
+  if (request.kind !== "unusable") return request.cwd;
+  res.status(request.malformed ? 400 : 404).json({ error: request.problem, cwd: request.requested });
+  return null;
 }

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -6,9 +6,8 @@
 // a summarizer, which belongs to the title machinery index.ts still owns.
 import type { Express, Request, Response } from "express";
 import { promises as fs } from "node:fs";
-import { CLAUDE_CWD, SESSION_ID_RE } from "../config/env.js";
-import { normalizeAgent } from "./routeParams.js";
-import { resolveWorkspace } from "../config/workspace.js";
+import { SESSION_ID_RE } from "../config/env.js";
+import { normalizeAgent, workspaceForRoute } from "./routeParams.js";
 import { hasErrnoCode } from "../errors.js";
 import { isProbeSessionId } from "../agents/probe-session.js";
 import {
@@ -69,7 +68,8 @@ export interface SessionRouteDeps {
 async function sessionDetail(req: Request<{ id: string }>, res: Response, freshenRosterTitle: SessionRouteDeps["freshenRosterTitle"]) {
   const { id } = req.params;
   if (!SESSION_ID_RE.test(id)) return res.status(400).json({ error: "invalid session id" });
-  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  const cwd = workspaceForRoute(req.query.cwd, res);
+  if (cwd === null) return;
   await activityStateHydrated; // a reconnect re-fetch must see the restored working/waiting, not idle
   const { lastPrompt: transcriptPrompt, lastResponse: transcriptResponse, userTurns, usage, context, workPhase } = await readSessionSummary(cwd, id);
   // If we haven't titled it yet, kick off a summary; sessionDetailView falls back meanwhile.
@@ -128,7 +128,8 @@ async function activitySnapshot(req: Request, res: Response) {
 async function toolTimeline(req: Request, res: Response) {
   const { session } = req.query;
   if (typeof session !== "string" || !SESSION_ID_RE.test(session)) return res.status(400).json({ error: "invalid session id" });
-  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  const cwd = workspaceForRoute(req.query.cwd, res);
+  if (cwd === null) return;
   res.json(await sessionTimeline(cwd, session));
 }
 
@@ -143,7 +144,8 @@ async function lastTurn(req: Request, res: Response) {
   const { session } = req.query;
   if (typeof session !== "string" || !SESSION_ID_RE.test(session)) return res.status(400).json({ error: "invalid session id" });
   const agent = normalizeAgent(req.query.agent);
-  const cwd = resolveWorkspace(typeof req.query.cwd === "string" ? req.query.cwd : null);
+  const cwd = workspaceForRoute(req.query.cwd, res);
+  if (cwd === null) return;
   const turn = await sessionLastTurn(cwd, session, agent);
   // ?as=reply drops the prompt block: the caller is relaying an ANSWER back to whoever
   // asked, and that prompt is the asker's own text coming home.
@@ -159,9 +161,9 @@ async function sessionList(req: Request, res: Response) {
     // Optional ?cwd= scopes the list to that project's on-disk sessions (the grid
     // cell's resume picker). Without it, the classic single view's behavior is
     // unchanged: CLAUDE_CWD + in-memory pending sessions.
-    const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
-    const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
-    const includePending = !cwdParam;
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
+    const includePending = !req.query.cwd;
     // Wait for the persisted grid-session set before filtering (below), so a chat
     // request racing server boot can't leak previously-hidden grid transcripts. The
     // background set is awaited for BOTH queries — it decides a flag on the row rather
@@ -216,8 +218,8 @@ async function sessionList(req: Request, res: Response) {
 // the single view's sidebar lists these so past codex conversations are switchable + resumable.
 async function codexSessionList(req: Request, res: Response) {
   try {
-    const cwdParam = typeof req.query.cwd === "string" ? req.query.cwd : null;
-    const cwd = cwdParam ? resolveWorkspace(cwdParam) : CLAUDE_CWD;
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
     const sessions = await listCodexSessions(codexSessionsRoot(), cwd, SESSION_LIST_LIMIT);
     res.json({ cwd, sessions });
   } catch (err) {

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -100,7 +100,11 @@ type WsUpgradeRequest = { url?: string | undefined; headers?: unknown };
 // proceed on it (see refuseUnusableWorkspace) and handing tmux a directory that is not there
 // would break the one path this must not break.
 export function workspaceFromUrl(url: URL): { cwd: string; unusable: string | null } {
-  const request = workspaceRequest(url.searchParams.get("cwd") ?? undefined);
+  // getAll, not get: a repeated `?cwd=a&cwd=b` names two directories, and `get` would silently
+  // pick the first — the same swap this exists to stop, and the HTTP routes already refuse it
+  // (express hands them the array). Passing the array on keeps ONE rule for both transports.
+  const values = url.searchParams.getAll("cwd");
+  const request = workspaceRequest(values.length > 1 ? values : values[0]);
   if (request.kind === "unusable") return { cwd: CLAUDE_CWD, unusable: request.problem };
   return { cwd: request.cwd, unusable: null };
 }

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -10,8 +10,8 @@ import { WebSocketServer, WebSocket } from "ws";
 import type { Server } from "node:http";
 import { randomUUID } from "node:crypto";
 import { messageOf } from "../errors.js";
-import { PORT, SESSION_ID_RE } from "../config/env.js";
-import { resolveWorkspace } from "../config/workspace.js";
+import { CLAUDE_CWD, PORT, SESSION_ID_RE } from "../config/env.js";
+import { workspaceRequest } from "../config/workspace.js";
 import { getHeaderConfig } from "../config/config-routes.js";
 import { buildHeaderContext, loadHeaderConfig } from "../config/header-context.js";
 import { resolveButtonCommand, shellQuoteFor } from "../config/header-resolve.js";
@@ -96,12 +96,40 @@ export function effectiveSessionCwd(liveCwd: string | undefined, requestCwd: str
 // genuinely absent on some upgrades.
 type WsUpgradeRequest = { url?: string | undefined; headers?: unknown };
 
-function wsConnectionContext(req: WsUpgradeRequest): { url: URL; requested: string | null; cwd: string } {
+// The default is still what an unusable `?cwd=` resolves to, because a REATTACH is allowed to
+// proceed on it (see refuseUnusableWorkspace) and handing tmux a directory that is not there
+// would break the one path this must not break.
+export function workspaceFromUrl(url: URL): { cwd: string; unusable: string | null } {
+  const request = workspaceRequest(url.searchParams.get("cwd") ?? undefined);
+  if (request.kind === "unusable") return { cwd: CLAUDE_CWD, unusable: request.problem };
+  return { cwd: request.cwd, unusable: null };
+}
+
+function wsConnectionContext(req: WsUpgradeRequest): { url: URL; requested: string | null; cwd: string; unusable: string | null } {
   const url = new URL(req.url ?? "/", "http://localhost");
   const raw = url.searchParams.get("session");
   const requested = raw && SESSION_ID_RE.test(raw) ? raw : null;
-  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
-  return { url, requested, cwd };
+  return { url, requested, ...workspaceFromUrl(url) };
+}
+
+// A directory was named and cannot be entered. For a FRESH start that is the end of it: this is
+// the refusal `ptySpawn` would have made (#1078), moved to the only place it can still happen —
+// `resolveWorkspace` used to swap the path for the default workspace first, so the terminal came
+// up silently in another project and #1146 had no symptom but "it opened somewhere else" (#1151).
+//
+// A reattach is let through with a warning, exactly as `refuseUnusableCwd` lets one through:
+// shutting someone out of an agent that is still running because they moved its directory would
+// be a worse bug than the one being reported. It runs no new program, and the cwd it reports
+// comes from the live PTY rather than from this request (effectiveSessionCwd).
+export function refuseUnusableWorkspace(ws: WebSocket, kind: TerminalWsKind, unusable: string | null, requested: string | null): boolean {
+  if (!unusable) return false;
+  if (requested && (ptys.has(requested) || tmuxHasSession(requested))) {
+    console.warn(`[ws/${kind}] attaching ${requested} despite an unusable ?cwd= — ${unusable}`);
+    return false;
+  }
+  console.warn(`[ws/${kind}] refusing to start — ${unusable}`);
+  closeWithError(ws, unusable);
+  return true;
 }
 
 async function resolveButtonRun(url: URL, cwd: string): Promise<{ command: string; cwd: string } | null> {
@@ -116,8 +144,7 @@ async function resolveButtonRun(url: URL, cwd: string): Promise<{ command: strin
   return command ? { command, cwd } : null;
 }
 
-async function resolveRunTarget(url: URL): Promise<{ command: string; cwd: string } | null> {
-  const cwd = resolveWorkspace(url.searchParams.get("cwd"));
+async function resolveRunTarget(url: URL, cwd: string): Promise<{ command: string; cwd: string } | null> {
   const byButton = await resolveButtonRun(url, cwd);
   if (byButton) return byButton;
   return resolveScript(cwd, parseIndexParam(url.searchParams.get("index")));
@@ -134,7 +161,10 @@ export function attachSocketErrorLogger(ws: Pick<WebSocket, "on">, kind: Termina
 }
 
 async function startRunTerminal(deps: WsRouteDeps, ws: WebSocket, url: URL): Promise<void> {
-  const resolved = await resolveRunTarget(url);
+  // No session to reattach: /ws/run is ephemeral, so an unusable directory is always a refusal.
+  const { cwd, unusable } = workspaceFromUrl(url);
+  if (refuseUnusableWorkspace(ws, "run", unusable, null)) return;
+  const resolved = await resolveRunTarget(url, cwd);
   if (!resolved) return closeWithError(ws, "Command not found — check your config / script.json.");
   beginRunTerminal(deps, ws, resolved);
 }
@@ -234,7 +264,8 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // ?session=<id> resumes an existing conversation; absent => fresh session. For
   // new sessions we generate the id ourselves (--session-id) so the server always
   // knows the current session's id, even before any file exists.
-  const { url, requested, cwd } = wsConnectionContext(req);
+  const { url, requested, cwd, unusable } = wsConnectionContext(req);
+  if (refuseUnusableWorkspace(ws, "claude", unusable, requested)) return;
   // A bad id is never silently reused — closing the socket without a replacement
   // makes the client auto-reconnect with the same bad id forever, so we warn and
   // fall through to mint a fresh session, then tell the browser the new id.
@@ -390,7 +421,8 @@ function clientStillConnected(ws: WebSocket, tag: string, sessionId: string, ear
 // lifecycle (reattach + reap grace + handleClientClose) but with no hooks/transcript,
 // and is marked a dev-terminal session so it stays out of the chat sidebar.
 async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
-  const { url, requested, cwd } = wsConnectionContext(req);
+  const { url, requested, cwd, unusable } = wsConnectionContext(req);
+  if (refuseUnusableWorkspace(ws, "launch", unusable, requested)) return;
   const index = parseIndexParam(url.searchParams.get("launcher"));
   const shell = url.searchParams.get("shell") === "1";
 
@@ -418,7 +450,8 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
 // codex without the GUI MCP and keeps it out of the sidebar; absent (single view) attaches the GUI
 // MCP so codex drives the GUI panel like claude.
 async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
-  const { url, requested, cwd } = wsConnectionContext(req);
+  const { url, requested, cwd, unusable } = wsConnectionContext(req);
+  if (refuseUnusableWorkspace(ws, "codex", unusable, requested)) return;
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
@@ -483,7 +516,8 @@ function startAntigravityEntry(deps: WsRouteDeps, ws: WebSocket, start: Antigrav
 // in the DIRECTORY, so every session there reaches whatever that directory registered — `?gui=0`
 // only keeps a grid dev terminal out of the sidebar.
 async function handleAntigravityConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
-  const { url, requested, cwd } = wsConnectionContext(req);
+  const { url, requested, cwd, unusable } = wsConnectionContext(req);
+  if (refuseUnusableWorkspace(ws, "antigravity", unusable, requested)) return;
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
   const { sessionId, live, resumeConversationId } = resolveAntigravitySession(requested);
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));

--- a/server/session/cost.ts
+++ b/server/session/cost.ts
@@ -4,7 +4,7 @@
 // (see MODEL_PRICING); unknown models are left unpriced rather than guessed.
 import path from "node:path";
 import fs from "node:fs/promises";
-import type { Express } from "express";
+import type { Express, Response } from "express";
 import { forEachJsonlRecord } from "../infra/jsonl-file.js";
 import { parseJsonl } from "./transcript.js";
 import { isRecord } from "../../common/isRecord.js";
@@ -199,9 +199,12 @@ async function rollupProjectCost(cwd: string): Promise<CostRollup> {
 // (optional) is one transcript. The session's OWN unpriced-turn count is reported
 // separately, since that session may fall outside the month window / file cap and so
 // isn't reflected in `unpricedTurns` (which covers the roll-up only).
-export function mountCostRoute(app: Express, deps: { resolveCwd: (cwd: string | null) => string }): void {
+// `resolveCwd` answers null once it has refused the request itself (an unusable `?cwd=`), so the
+// roll-up is never computed for a directory other than the one asked about.
+export function mountCostRoute(app: Express, deps: { resolveCwd: (cwd: unknown, res: Response) => string | null }): void {
   app.get("/api/cost", async (req, res) => {
-    const cwd = deps.resolveCwd(typeof req.query.cwd === "string" ? req.query.cwd : null);
+    const cwd = deps.resolveCwd(req.query.cwd, res);
+    if (cwd === null) return;
     const sessionParam = typeof req.query.session === "string" ? req.query.session : null;
     try {
       const rollup = await rollupProjectCost(cwd);

--- a/test/server/config/dir-config.spec.ts
+++ b/test/server/config/dir-config.spec.ts
@@ -12,7 +12,7 @@ import {
   MISSING_DIR_CONFIG_DETAIL,
 } from "../../../server/config/dir-config";
 import { DIR_CONFIG_KEYS } from "../../../common/dirConfigSource";
-import { resolveWorkspace } from "../../../server/config/workspace";
+import { existingWorkspace } from "../../../server/config/workspace";
 
 const tmp = () => makeTempDir("mt-dircfg-");
 const EMPTY = {
@@ -289,7 +289,7 @@ describe("dirConfigWriteTarget", () => {
     const dir = tmp();
     const launchedAs = dir + path.sep;
     const announced = dirConfigWriteTarget("Write", { file_path: path.join(dir, ".mulmoterminal.json") }, launchedAs);
-    expect(announced).toBe(resolveWorkspace(launchedAs));
+    expect(announced).toBe(existingWorkspace(launchedAs));
     expect(announced).toBe(dir);
   });
 

--- a/test/server/config/workspace.spec.ts
+++ b/test/server/config/workspace.spec.ts
@@ -2,12 +2,16 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { makeTempDirAsync } from "../../support/tempDir.js";
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { resolveWorkspace, workspaceFromQuery, existingWorkspace, existingWorkspaceFromQuery } from "../../../server/config/workspace.js";
+import { workspaceRequest, existingWorkspace, existingWorkspaceFromQuery } from "../../../server/config/workspace.js";
 import { CLAUDE_CWD } from "../../../server/config/env.js";
+import { cwdProblemMessage } from "../../../server/infra/spawn-cwd.js";
 
-// resolveWorkspace guards what becomes a PTY's cwd, so every rejection matters: anything
-// it lets through unchecked is a path the client chose.
-describe("resolveWorkspace", () => {
+// workspaceRequest guards what becomes a PTY's cwd, so every rejection matters: anything it lets
+// through unchecked is a path the client chose. It also decides what a rejection MEANS — #1151:
+// a directory that was named and cannot be used is not the same request as one that named none,
+// and answering both with the default workspace is how a terminal opened somewhere else in
+// silence.
+describe("workspaceRequest", () => {
   let dir = "";
   let file = "";
 
@@ -22,49 +26,53 @@ describe("resolveWorkspace", () => {
   });
 
   it("accepts an absolute path to an existing directory", () => {
-    expect(resolveWorkspace(dir)).toBe(dir);
+    expect(workspaceRequest(dir)).toEqual({ kind: "resolved", cwd: dir });
   });
 
-  it("falls back for a relative path, however real it is", () => {
-    expect(resolveWorkspace("server")).toBe(CLAUDE_CWD);
-    expect(resolveWorkspace("./server")).toBe(CLAUDE_CWD);
-    expect(resolveWorkspace("../mulmoterminal")).toBe(CLAUDE_CWD);
+  // No directory was asked for, so the default IS the answer — the case the fallback was right
+  // for, and the only one that keeps it. An empty param is how a browser spells the same thing.
+  it("answers the default workspace when no directory is named", () => {
+    expect(workspaceRequest(undefined)).toEqual({ kind: "default", cwd: CLAUDE_CWD });
+    expect(workspaceRequest(null)).toEqual({ kind: "default", cwd: CLAUDE_CWD });
+    expect(workspaceRequest("")).toEqual({ kind: "default", cwd: CLAUDE_CWD });
   });
 
-  it("falls back for a path that does not exist", () => {
-    expect(resolveWorkspace(path.join(dir, "no-such-dir"))).toBe(CLAUDE_CWD);
+  it("refuses a relative path, however real it is, and says it is not absolute", () => {
+    for (const relative of ["server", "./server", "../mulmoterminal"]) {
+      const request = workspaceRequest(relative);
+      expect(request.kind).toBe("unusable");
+      expect(request).toMatchObject({ requested: relative, malformed: true });
+      if (request.kind === "unusable") expect(request.problem).toContain("is not an absolute path");
+    }
   });
 
-  it("falls back for a file — a cwd has to be a directory", () => {
-    expect(resolveWorkspace(file)).toBe(CLAUDE_CWD);
+  // The #1146 shape: the path was real when it was recorded and is not any more. The wording is
+  // SpawnCwdError's own (#1078), so the reason reads the same whether the directory is refused
+  // here or by the spawn itself.
+  it("refuses a path that does not exist, in the words a refused spawn uses", () => {
+    const gone = path.join(dir, "no-such-dir");
+    const request = workspaceRequest(gone);
+    expect(request).toMatchObject({ kind: "unusable", requested: gone, malformed: false });
+    if (request.kind === "unusable") expect(request.problem).toBe(cwdProblemMessage(gone, { kind: "missing" }));
   });
 
-  it("falls back for null and for empty", () => {
-    expect(resolveWorkspace(null)).toBe(CLAUDE_CWD);
-    expect(resolveWorkspace("")).toBe(CLAUDE_CWD);
+  it("refuses a file — a cwd has to be a directory", () => {
+    const request = workspaceRequest(file);
+    expect(request).toMatchObject({ kind: "unusable", malformed: false });
+    if (request.kind === "unusable") expect(request.problem).toBe(cwdProblemMessage(file, { kind: "not-a-directory" }));
+  });
+
+  // Express hands over an array when a param repeats (?cwd=a&cwd=b). It was ASKED for, so it is
+  // refused rather than quietly swapped for the default — but as a malformed request, not a
+  // missing directory.
+  it("refuses anything that is not a string, having been given one", () => {
+    expect(workspaceRequest(["/tmp", "/etc"])).toMatchObject({ kind: "unusable", malformed: true });
+    expect(workspaceRequest(42)).toMatchObject({ kind: "unusable", malformed: true });
   });
 });
 
-describe("workspaceFromQuery", () => {
-  it("resolves a string query", async () => {
-    const dir = await makeTempDirAsync("mt-wsq-");
-    expect(workspaceFromQuery(dir)).toBe(dir);
-    await fs.rm(dir, { recursive: true, force: true });
-  });
-
-  // Express hands over an array when a param repeats (?cwd=a&cwd=b) and undefined when it
-  // is absent; neither may reach the validation as a path.
-  it("falls back for anything that is not a string", () => {
-    expect(workspaceFromQuery(undefined)).toBe(CLAUDE_CWD);
-    expect(workspaceFromQuery(["/tmp", "/etc"])).toBe(CLAUDE_CWD);
-    expect(workspaceFromQuery(42)).toBe(CLAUDE_CWD);
-    expect(workspaceFromQuery(null)).toBe(CLAUDE_CWD);
-  });
-});
-
-// The fallback in resolveWorkspace is right for a route that RUNS somewhere and wrong for one
-// that REPORTS on the directory it was asked about — that one would answer about a different
-// directory under the requested one's name (Codex, #952).
+// The raw guard behind workspaceRequest, still used directly by the routes that answer their own
+// "unknown directory" payload rather than a refusal (Codex, #952).
 describe("existingWorkspace", () => {
   it("returns a real directory unchanged", () => {
     expect(existingWorkspace(process.cwd())).toBe(process.cwd());
@@ -103,19 +111,18 @@ describe("canonical spelling of the accepted directory", () => {
   });
 
   it("drops a trailing separator — the shape tab-completion leaves behind", () => {
-    expect(resolveWorkspace(dir + path.sep)).toBe(dir);
     expect(existingWorkspace(dir + path.sep)).toBe(dir);
-    expect(workspaceFromQuery(dir + path.sep)).toBe(dir);
     expect(existingWorkspaceFromQuery(dir + path.sep)).toBe(dir);
+    expect(workspaceRequest(dir + path.sep)).toEqual({ kind: "resolved", cwd: dir });
   });
 
   it("collapses . and .. inside an absolute path", () => {
-    expect(resolveWorkspace(path.join(dir, "sub", ".."))).toBe(dir);
-    expect(resolveWorkspace(path.join(dir, "."))).toBe(dir);
+    expect(workspaceRequest(path.join(dir, "sub", ".."))).toEqual({ kind: "resolved", cwd: dir });
+    expect(workspaceRequest(path.join(dir, "."))).toEqual({ kind: "resolved", cwd: dir });
   });
 
   it("leaves an already-canonical path untouched", () => {
-    expect(resolveWorkspace(dir)).toBe(dir);
+    expect(workspaceRequest(dir)).toEqual({ kind: "resolved", cwd: dir });
   });
 
   // The guard order matters: canonicalizing BEFORE the isAbsolute check would splice a relative
@@ -156,6 +163,6 @@ describe("canonical spelling of the accepted directory", () => {
 
   it("keeps the filesystem root, whose separator is not trailing", () => {
     const root = path.parse(dir).root;
-    expect(resolveWorkspace(root)).toBe(root);
+    expect(workspaceRequest(root)).toEqual({ kind: "resolved", cwd: root });
   });
 });

--- a/test/server/routes/unusable-cwd-routes.spec.ts
+++ b/test/server/routes/unusable-cwd-routes.spec.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+// #1151, the read half: a route asked ABOUT a directory must not answer about a different one
+// under the requested one's name. `/api/scripts` is the sharpest case — the `cwd` it returns is
+// where the cell then RUNS the script — but the same swap reached sessions, colours, git status
+// and the cost roll-up.
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { mountDirRoutes } from "../../../server/routes/dir-routes";
+import { CLAUDE_CWD } from "../../../server/config/env";
+
+const app = express();
+app.use(express.json());
+mountDirRoutes(app);
+
+const withTempDir = async (run: (dir: string) => Promise<void>) => {
+  const dir = mkdtempSync(path.join(tmpdir(), "mt-cwdroute-"));
+  try {
+    await run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+describe("a route asked about a directory it cannot use", () => {
+  it("answers 404 with the reason instead of the default workspace's scripts", async () => {
+    await withTempDir(async (dir) => {
+      const gone = path.join(dir, "deleted-project");
+      const res = await request(app).get("/api/scripts").query({ cwd: gone });
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain(gone);
+      expect(res.body.error).toContain("no longer exists");
+      // The point of the 404: no `cwd` the cell could go on to run something in.
+      expect(res.body.scripts).toBeUndefined();
+    });
+  });
+
+  it("answers 400 for a request that cannot name a directory at all", async () => {
+    const relative = await request(app).get("/api/scripts").query({ cwd: "relative/path" });
+    expect(relative.status).toBe(400);
+    expect(relative.body.error).toContain("not an absolute path");
+    // Express hands a repeated param over as an array; it was asked for, so it is refused.
+    const repeated = await request(app).get("/api/scripts?cwd=/tmp&cwd=/etc");
+    expect(repeated.status).toBe(400);
+  });
+
+  it("answers a file the same way — a working directory has to be a directory", async () => {
+    await withTempDir(async (dir) => {
+      const file = path.join(dir, "not-a-dir");
+      writeFileSync(file, "");
+      const res = await request(app).get("/api/scripts").query({ cwd: file });
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain("is a file, not a directory");
+    });
+  });
+
+  // The half that must NOT change: no directory was named, so the default workspace is the answer
+  // the caller wanted. That is the case the fallback was always right for.
+  it("still answers the default workspace when no directory is named", async () => {
+    const res = await request(app).get("/api/scripts");
+    expect(res.status).toBe(200);
+    expect(res.body.cwd).toBe(CLAUDE_CWD);
+  });
+
+  it("still answers about a directory that is there", async () => {
+    await withTempDir(async (dir) => {
+      const res = await request(app).get("/api/scripts").query({ cwd: dir });
+      expect(res.status).toBe(200);
+      expect(res.body.cwd).toBe(dir);
+    });
+  });
+
+  // Every `?cwd=` read route shares the guard, so the colours a stale preset chip wears and the
+  // branch its header shows come from the directory asked about or from nowhere.
+  it("applies to the other directory-scoped reads, not just scripts", async () => {
+    await withTempDir(async (dir) => {
+      const gone = path.join(dir, "deleted-project");
+      for (const route of ["/api/dir-config", "/api/git-status", "/api/skills", "/api/header"]) {
+        const res = await request(app).get(route).query({ cwd: gone });
+        expect(res.status, route).toBe(404);
+        expect(res.body.error, route).toContain("no longer exists");
+      }
+    });
+  });
+});

--- a/test/server/routes/ws-unusable-cwd.spec.ts
+++ b/test/server/routes/ws-unusable-cwd.spec.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+// #1151: a `?cwd=` that names a directory the server cannot enter must not become the DEFAULT
+// workspace in silence. Until this, `resolveWorkspace` swapped the path before anything else saw
+// it, so the terminal came up in another project and `ptySpawn`'s own refusal (#1078) could never
+// fire on this path — which is what left #1146 with no symptom but "it opened somewhere else".
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { WebSocket } from "ws";
+
+let tmuxSessions = new Set<string>();
+vi.mock("../../../server/infra/tmux.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../server/infra/tmux.js")>()),
+  tmuxHasSession: (id: string) => tmuxSessions.has(id),
+}));
+
+const { workspaceFromUrl, refuseUnusableWorkspace } = await import("../../../server/routes/ws-routes.js");
+const { ptys } = await import("../../../server/session/registry.js");
+const { CLAUDE_CWD } = await import("../../../server/config/env.js");
+
+// Just the two members closeWithError touches, plus a record of what it sent.
+function fakeWs() {
+  const sent: string[] = [];
+  let closed = false;
+  return {
+    sent,
+    get closed() {
+      return closed;
+    },
+    readyState: 1,
+    OPEN: 1,
+    send: (raw: string) => sent.push(raw),
+    close: () => (closed = true),
+  };
+}
+const errorFrom = (ws: ReturnType<typeof fakeWs>) => JSON.parse(ws.sent[0] ?? "{}");
+
+const urlWith = (cwd: string | null) => new URL(`ws://localhost/ws${cwd === null ? "" : `?cwd=${encodeURIComponent(cwd)}`}`);
+
+const SESSION = "11111111-2222-3333-4444-555555555555";
+let dir = "";
+
+beforeEach(() => {
+  tmuxSessions = new Set();
+  ptys.clear();
+  dir = mkdtempSync(path.join(tmpdir(), "mt-wscwd-"));
+});
+afterEach(() => {
+  ptys.clear();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("workspaceFromUrl", () => {
+  it("resolves a real directory and names no problem", () => {
+    expect(workspaceFromUrl(urlWith(dir))).toEqual({ cwd: dir, unusable: null });
+  });
+
+  it("answers the default workspace when the socket names no directory", () => {
+    expect(workspaceFromUrl(urlWith(null))).toEqual({ cwd: CLAUDE_CWD, unusable: null });
+  });
+
+  // The default still comes back as the cwd — a reattach is allowed to proceed on it, and handing
+  // tmux a directory that is not there would break the one path this must not break.
+  it("reports a problem for a directory that is not there, keeping the default as the cwd", () => {
+    const gone = path.join(dir, "gone");
+    const { cwd, unusable } = workspaceFromUrl(urlWith(gone));
+    expect(cwd).toBe(CLAUDE_CWD);
+    expect(unusable).toContain(gone);
+    expect(unusable).toContain("no longer exists");
+  });
+});
+
+describe("refuseUnusableWorkspace", () => {
+  it("lets a connection through when the directory is fine", () => {
+    const ws = fakeWs();
+    expect(refuseUnusableWorkspace(ws as unknown as WebSocket, "claude", null, null)).toBe(false);
+    expect(ws.sent).toEqual([]);
+  });
+
+  // The bug this exists for: a FRESH start in a directory that is not there used to open the
+  // default workspace instead. The reason reaches the cell as an error frame, which the browser
+  // renders as the red banner and does not retry.
+  it("refuses a fresh start and sends the reason to the cell", () => {
+    const ws = fakeWs();
+    const refused = refuseUnusableWorkspace(ws as unknown as WebSocket, "claude", "The directory /gone no longer exists…", null);
+    expect(refused).toBe(true);
+    expect(errorFrom(ws)).toEqual({ type: "error", message: "The directory /gone no longer exists…" });
+    expect(ws.closed).toBe(true);
+  });
+
+  it("refuses a fresh start even when a session id is offered but nothing is running under it", () => {
+    const ws = fakeWs();
+    expect(refuseUnusableWorkspace(ws as unknown as WebSocket, "codex", "gone", SESSION)).toBe(true);
+    expect(ws.closed).toBe(true);
+  });
+
+  // Refusing here would shut someone out of an agent that is still running because they moved or
+  // renamed its directory — a worse bug than the one being reported. The same call `ptySpawn`
+  // makes for a reattach (refuseUnusableCwd) reaches the same verdict.
+  it("lets a live PTY reattach despite an unusable directory", () => {
+    const ws = fakeWs();
+    ptys.set(SESSION, { cwd: "/wherever" } as never);
+    expect(refuseUnusableWorkspace(ws as unknown as WebSocket, "claude", "gone", SESSION)).toBe(false);
+    expect(ws.sent).toEqual([]);
+  });
+
+  it("lets a surviving tmux session reattach despite an unusable directory", () => {
+    const ws = fakeWs();
+    tmuxSessions.add(SESSION);
+    expect(refuseUnusableWorkspace(ws as unknown as WebSocket, "launch", "gone", SESSION)).toBe(false);
+    expect(ws.sent).toEqual([]);
+  });
+});

--- a/test/server/routes/ws-unusable-cwd.spec.ts
+++ b/test/server/routes/ws-unusable-cwd.spec.ts
@@ -36,7 +36,10 @@ function fakeWs() {
 }
 const errorFrom = (ws: ReturnType<typeof fakeWs>) => JSON.parse(ws.sent[0] ?? "{}");
 
-const urlWith = (cwd: string | null) => new URL(`ws://localhost/ws${cwd === null ? "" : `?cwd=${encodeURIComponent(cwd)}`}`);
+const urlWith = (cwd: string | null) => {
+  const query = cwd === null ? "" : `?cwd=${encodeURIComponent(cwd)}`;
+  return new URL(`ws://localhost/ws${query}`);
+};
 
 const SESSION = "11111111-2222-3333-4444-555555555555";
 let dir = "";
@@ -58,6 +61,15 @@ describe("workspaceFromUrl", () => {
 
   it("answers the default workspace when the socket names no directory", () => {
     expect(workspaceFromUrl(urlWith(null))).toEqual({ cwd: CLAUDE_CWD, unusable: null });
+  });
+
+  // `URLSearchParams.get` would take the first of the two and start there — the silent pick this
+  // whole change exists to stop, and the HTTP routes already refuse it. One rule, both transports.
+  it("refuses a repeated ?cwd= instead of taking the first one", () => {
+    const url = new URL(`ws://localhost/ws?cwd=${encodeURIComponent(dir)}&cwd=${encodeURIComponent("/tmp")}`);
+    const { cwd, unusable } = workspaceFromUrl(url);
+    expect(cwd).toBe(CLAUDE_CWD);
+    expect(unusable).toContain("exactly once");
   });
 
   // The default still comes back as the cwd — a reattach is allowed to proceed on it, and handing


### PR DESCRIPTION
## Summary

`resolveWorkspace(cwd) = existingWorkspace(cwd) ?? CLAUDE_CWD` が、**渡されていない `?cwd=`** と
**渡されたが解決できない `?cwd=`** を同じ答え（デフォルトワークスペース）に潰していました。後者が
#1146 の増幅器で、picker が化けたパスを寄越しても症状は「選んだフォルダで開かない」だけになります。
`ptySpawn` には既に `refuseUnusableCwd` / `SpawnCwdError`（#1078）があるのに、**手前でパスが
差し替わるのでこの経路では絶対に発火しませんでした**。

`workspaceRequest` が 3 つの結果を返すようにしました:

```ts
| { kind: "default";  cwd }                              // ?cwd= が無い → デフォルトが答え（従来どおり）
| { kind: "resolved"; cwd }                              // 実在するディレクトリ
| { kind: "unusable"; requested, problem, malformed }    // 名指されたが使えない
```

| 経路 | 解決できない `?cwd=` に対して |
| --- | --- |
| `/ws`・`/ws/codex`・`/ws/antigravity`・`/ws/launch`・`/ws/run` | `closeWithError(problem)` → セルに**赤いバナー**（既存の `messageEffect`）、再接続もしない |
| 生きているセッション（live PTY / 生存 tmux）への再接続 | **通す** + ログ警告 |
| 読み取り系 10 ルート | **404** `{ error, cwd }`（絶対パスでない等は 400） |
| `?cwd=` が無い場合 | **変更なし** — デフォルトが要求された答え |

文言は `SpawnCwdError` のもの（#1078）をそのまま使うので、同じ状態はここで捕まえても spawn で
捕まえても同じ文で読めます。**新しい UI は 1 つも足していません。**

## Items to Confirm / Review

1. **`resolveWorkspace` と `workspaceFromQuery` を削除しました。** この issue が問題にしている
   API そのもので、残すと次に誰かが使います。呼び出し元は全て新 API に移しました。
2. **再接続を通す判断**（ユーザー確認済み）。ディレクトリを移動しただけで実行中のエージェントに
   戻れなくなる方が悪いバグで、`refuseUnusableCwd(cwd, reattached)` も同じ判断をしています。
   加えて**生の壊れたパスを tmux クライアントの cwd に渡すと macOS では子プロセスが黙って exit 1**
   するので、ここでデフォルトへフォールバックするのは再接続を守っています。表示される cwd は
   `effectiveSessionCwd` が live PTY 側を優先するので変わりません（実測で確認）。
3. **読み取り系を 404 にした判断**。200 + 空ペイロードは「ここには何も無い」と見分けが付かず、
   この issue が問題にしている沈黙そのものになります。クライアントは既に「取れなければ空」を
   実装しているので追加の分岐は不要でした（`useDirLists` は !ok を空リスト、`useDirConfig` は
   EMPTY、`useHeaderButtons` はデフォルトヘッダ、`fetchSessionDetail` は null、`useCost` は catch）。
4. **`?cwd=a&cwd=b`（配列）を 400 にしました。** 従来は黙ってデフォルト。渡されてはいるので、
   黙って差し替えるのはこの issue の挙動そのものという判断です。`workspaceFromQuery(42)` を
   CLAUDE_CWD に固定していた spec を書き換えています。
5. **`/api/dir-config-detail` と `/api/gui-mcp-groups` は触っていません。** 既に
   `existingWorkspaceFromQuery` でフォールバックせず、200 + 空ペイロードという**クライアント契約**を
   持っているためです（この issue の要件は既に満たしている）。404 に揃えるかは別途。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1151 できる？

（実装前に 3 点を確認し、以下の回答を得ています）

- **対象範囲**: 起動経路だけでなく**読み取り系ルートも**
- **生きているセッションへの再接続**: 今のまま通す + ログ警告
- **絶対パスでない `?cwd=`**: 同じく拒否・専用文言

## 実測（本物のサーバーに対して）

spec が緑なのは「自分の書いたものどうしが一致した」だけなので、`PORT=7719 yarn server` で
**実際のサーバーを起動して** HTTP と WebSocket を直接叩きました。

| 条件 | 結果 |
| --- | --- |
| `GET /api/scripts`（cwd 無し） | 200 / `cwd` = デフォルトワークスペース |
| `GET /api/scripts?cwd=/tmp` | 200 / `cwd` = `/tmp` |
| `GET /api/scripts?cwd=<消したディレクトリ>` | **404** + 理由 |
| `/ws?cwd=<消したディレクトリ>` | **error フレーム**（同じ文言） |
| `/ws?cwd=relative/path` | **error フレーム**（"is not an absolute path"） |
| `/ws/run?cwd=<消したディレクトリ>` | **error フレーム** |
| `/ws/launch?shell=1&cwd=<消したディレクトリ>` | **error フレーム** |
| `/ws/launch?shell=1&cwd=/tmp` | **session フレーム** — 普通の起動は壊れていない |
| 生きているセッションへ `?session=<id>&cwd=<消したディレクトリ>` | **attach 成功**、返る cwd は実際の `/tmp` |
| 存在しない session id + 同じ cwd | **error フレーム** — reattach が抜け道になっていない |

サーバーログにも `[ws/claude] refusing to start — …` と
`[ws/launch] attaching <id> despite an unusable ?cwd= — …` が出ることを確認しました。
起動したプローブ用 tmux セッションは後始末済みです。

## テスト

- `test/server/config/workspace.spec.ts` — 3 つの結果、空文字と非文字列、文言（`cwdProblemMessage`
  と一致することをアサート）
- `test/server/routes/ws-unusable-cwd.spec.ts`（新規）— 新規 spawn は拒否 / live PTY・tmux の
  再接続は通す / 存在しない id は拒否
- `test/server/routes/unusable-cwd-routes.spec.ts`（新規）— supertest で 404・400・理由、
  `?cwd=` 無しと実在ディレクトリは従来どおり

`yarn format` → `yarn lint` → `yarn typecheck` → `yarn typecheck:server` → `yarn typecheck:test` →
`yarn build` → `yarn test`（**6634 passed**、うち新規 14）。

README に「Directories that cannot be used」節を追加し、`?cwd=` のフォールバックを謳っていた
既存の記述を直しました。

Closes #1151

work in mulmoterminal5
