### PR TITLE
feat: Antigravity の会話マッピングを永続化し、再起動後も cold resume できるようにする (#1096)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,9 @@ today — **Claude Code** (the default), **Codex**, and **Antigravity** (`agy`).
   `--model`). Antigravity runs on its own WebSocket (`/ws/antigravity`). Like Codex it mints its
   own conversation id, so the server watches `~/.gemini/antigravity-cli/brain/` (home overridable
   via `ANTIGRAVITY_HOME`) for the directory the new conversation creates — attributed only when
-  unambiguous — and cold-resumes it with `--conversation <id>`.
+  unambiguous — and cold-resumes it with `--conversation <id>`. That mapping is appended to
+  `~/.mulmoterminal/antigravity-conversations.jsonl`, so a conversation is still resumable after
+  the server restarts.
 
   Its **GUI tools work differently**, because `agy` takes no MCP flag: it reads its servers from
   `.agents/mcp_config.json` in the working directory. MulmoTerminal writes that file from the

--- a/common/sessionAgent.ts
+++ b/common/sessionAgent.ts
@@ -17,3 +17,26 @@ export type TerminalAgent = (typeof TERMINAL_AGENTS)[number];
 // Validated rather than cast: anything unrecognised is Claude, which is also what an older
 // persisted cell (written before the field existed) means.
 export const asTerminalAgent = (value: unknown): TerminalAgent => (TERMINAL_AGENTS.some((agent) => agent === value) ? (value as TerminalAgent) : "claude");
+
+export interface AgentBadge {
+  /** Where there is room for it — a sidebar row, a header bar. */
+  full: string;
+  /** For the tab bar, which fits about two characters between the dot and the title. */
+  short: string;
+}
+
+// Claude has no badge on purpose: it is the default everywhere, so badging it would put one on
+// nearly every row and stop the badge meaning "this one is different". A shell is not an agent
+// and reaches this with no entry, which is the same answer.
+const AGENT_BADGES: Partial<Record<TerminalAgent, AgentBadge>> = {
+  codex: { full: "codex", short: "cx" },
+  antigravity: { full: "agy", short: "agy" },
+};
+
+/** How a session row announces which agent it is running, or null when it wears no badge. The one
+ *  place the wording lives: the sidebar and the tab bar show the SAME list, so a literal compared
+ *  in each is how the two came to disagree about a third agent. */
+export function agentBadge(agent: string | null | undefined): AgentBadge | null {
+  const known = TERMINAL_AGENTS.find((candidate) => candidate === agent);
+  return known ? (AGENT_BADGES[known] ?? null) : null;
+}

--- a/plans/feat-1096-antigravity-conversation-log.md
+++ b/plans/feat-1096-antigravity-conversation-log.md
@@ -1,0 +1,88 @@
+# feat #1096 — Antigravity の会話ログを永続化し、cold resume を再起動後も効かせる
+
+Issue #1096 の 4 項目のうち **①②④** を対象とする。③（`GET /api/antigravity/sessions`）は
+別 PR に回す。理由は「やらないこと」に書く。
+
+## 背景
+
+`antigravityConversationIds`（`server/session/registry.ts`）はメモリ上の `Map` だけなので、
+サーバを再起動すると「MulmoTerminal のセッションキー → agy の会話 id」の対応が消える。
+`resolveAntigravitySession`（`server/routes/ws-routes.ts`）はその Map を見ているため、
+再起動後は resume id を得られず、会話に戻れない。
+
+安全側には倒れている。`agentResumeId` は `mappedId` が無いとき「キー自体が会話 id か」を
+`antigravityConversationExists()` で確かめてからでないと resume しないので、対応が失われても
+**古い id を `agy --conversation` に渡してしまうことはない**。失われるのは会話への到達手段だけ。
+
+## やること
+
+### ① 会話ログ（append-only）
+
+新規 `server/session/antigravity-conversations.ts`。既存の `session-memos.ts` と同じ形にする
+（`~/.mulmoterminal` は同一マシンの全インスタンス・全バージョンで共有されるため、
+読んで書き戻すスナップショットではなく追記ログにする、という既存の理由がそのまま当てはまる）。
+
+- レコード: `{ sessionId, conversationId, cwd, startedAt }`
+- 1 行 1 JSON オブジェクト（`session-memos.jsonl` と同じ）。`cwd` に空白が入りうるので、
+  `dev-terminal-cwds` の `<id> <path>` 形式は使えない。
+- 同じ `sessionId` の**後の行が勝つ**（セルを別ディレクトリで起動し直せる）。
+- 保存先: `~/.mulmoterminal/antigravity-conversations.jsonl`。既存ログを広げず新ファイルにするのは
+  `dev-terminal-cwds.ts` が挙げている理由と同じ — 古いビルドのパーサが行を落とすのを避ける。
+
+`registry.ts` 側:
+
+- `antigravityConversationIds: Map<string, string>` を
+  `antigravityConversations: Map<string, AntigravityConversation>` に置き換える。
+  **メモリの Map をログの投影にする**ことで、参照元が 2 つに割れるのを防ぐ（②がほぼ自明になる）。
+- `antigravityConversationsHydrated` を公開。読み出しは `forEachJsonlRecord`（ストリーム）で、
+  ファイル全体を 1 つの文字列にしない。
+- `rememberAntigravityConversation(sessionId, conversationId, cwd)` を公開。
+  同じ内容なら追記しない（ログをむやみに伸ばさない）。
+- **この起動中に自分が書いた `sessionId` は hydrate で上書きしない**。hydrate は自分の追記が
+  届く前のファイルを読むので、上書きすると古い cwd で答えてしまう（`session-memos.ts` の
+  `memoWrittenIds` と同じ罠）。
+
+書き込み点は `server/session/spawn-antigravity.ts` の 2 箇所:
+
+1. spawn watcher が会話 id を確定したとき（新規セッション）
+2. resume で id が既知のとき（サイドバー等から会話 id そのものを渡された場合を含む）
+
+### ② `resolveAntigravitySession` がログを見る
+
+- `mappedId` を `antigravityConversations.get(requested)?.conversationId` から取る。
+- `handleAntigravityConnection` の中で `resolveAntigravitySession` を呼ぶ**前に**
+  `await antigravityConversationsHydrated` する。これを忘れると、hydrate 完了前に届いた
+  再接続が空の Map を見て resume を諦める（`devTerminalCwdsHydrated` と同じ理由）。
+
+### ④ クライアント側の型とバッジ
+
+- `Session.agent` を `"codex"` リテラルから `TerminalAgent` に広げる（`common/sessionAgent.ts`）。
+- `common/sessionAgent.ts` に `agentBadge()` を足し、バッジ文言の唯一の出所にする。
+  claude は既定なのでバッジ無し（ほぼ全行に付いてしまう）、`shell` も対象外。
+- ハードコードされた `agent === 'codex'` を 3 箇所差し替える:
+  `Sidebar.vue` / `SessionTabBar.vue`（同じ `Session[]` を見る縦横 2 つのビュー。片方だけ直すと
+  同じ一覧が食い違う）と `CockpitHeader.vue`（ロスターは別データ源だが、#1089 でセルが agent を
+  持つようになった以上、agy のセルだけ無印なのは不整合）。
+
+## テスト方針（動作テストなしで担保できる範囲）
+
+`agy` はこの開発機に無く、実際の `agy --conversation <id>` の復元は確認できない。ただし
+**今回変えるのは「resume id をどこから取るか」だけ**で、渡したあとの経路は #1095 のまま。
+かつ `agentResumeId` の `conversationExists()` ガードが残るので、ログが壊れていても最悪ケースは
+「resume しない」に縮退し、別の会話に接続することはない。この前提でユニットテストに寄せる。
+
+- `test/server/session/antigravity-conversations.spec.ts`
+  - 行のラウンドトリップ、同一 sessionId の後勝ち、空白入り cwd
+  - 壊れた行 / 別ログの行 / 途中で切れた最終行を落とす
+  - hydrate が「この起動中に書いた分」を上書きしない
+- `test/common/agentBadge.spec.ts`
+  - claude と shell と未知の値はバッジ無し、codex / antigravity は文言つき
+
+## やらないこと（この PR の範囲外）
+
+- ③ `GET /api/antigravity/sessions` — ルート自体は①のログから cwd で引けるので容易だが、
+  タイトルの取得元とされる `brain/<id>/.system_generated/logs/transcript.jsonl` の実フォーマットが
+  **この環境では確認できない**（`agy` 未インストール、リポジトリ内にフィクスチャも記述も無い）。
+  推測で JSONL パーサを書くのは避ける。
+- ④ の `fetchAntigravitySessions()` — ③のエンドポイントが無いと 404 を握って空配列を返すだけの
+  死にコードになる。③と同じ PR に置く。

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -22,7 +22,7 @@ import { launchChoiceFromParams } from "../session/launch-choice.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { antigravityBrainRoot, antigravityConversationExists } from "../agents/antigravity-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
-import { antigravityConversationIds, codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
+import { antigravityConversations, antigravityConversationsHydrated, codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
 import { sandboxWouldRun, SpawnRefusedError } from "../session/pty-spawn.js";
 import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
 import { launcherCommandWithGuiMcp } from "../session/launcher-gui-mcp.js";
@@ -484,7 +484,7 @@ function resolveAntigravitySession(requested: string | null): { sessionId: strin
   // key resumes, which means a stale one is handed to `agy --conversation` — agy answers a
   // conversation it cannot find by starting a fresh one, silently, under the old session's id.
   const resumeConversationId = agentResumeId(requested, {
-    mappedId: requested ? antigravityConversationIds.get(requested) : null,
+    mappedId: requested ? antigravityConversations.get(requested)?.conversationId : null,
     conversationExists: () => !!requested && antigravityConversationExists(antigravityBrainRoot(), requested),
     hasLivePty,
     tmuxAlive,
@@ -523,6 +523,10 @@ async function handleAntigravityConnection(deps: WsRouteDeps, ws: WebSocket, req
   const { url, requested, cwd, unusable } = wsConnectionContext(req);
   if (refuseUnusableWorkspace(ws, "antigravity", unusable, requested)) return;
   const attachGuiMcp = url.searchParams.get("gui") !== "0";
+  // Before resolving, not after: the mapping this reads lives on disk, and a reconnect that
+  // arrives while the log is still being read would see an empty map and decline to resume a
+  // conversation that is right there — which is the restart case this exists for.
+  await antigravityConversationsHydrated;
   const { sessionId, live, resumeConversationId } = resolveAntigravitySession(requested);
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
   const early = announceSession(ws, sessionId, live?.cwd ?? cwd);

--- a/server/session/antigravity-conversations.ts
+++ b/server/session/antigravity-conversations.ts
@@ -1,0 +1,71 @@
+// Which agy conversation each antigravity session is running, as it is read from and written back
+// to disk.
+//
+// agy mints the conversation id itself and prints it nowhere we can read, so the spawn watcher
+// discovers it after the fact (agents/antigravity-session.ts). Kept only in memory, that mapping
+// dies with the process: after a restart nothing connects a session key to a conversation, and the
+// conversation becomes unreachable even though its directory is still sitting in agy's brain root.
+//
+// An APPEND LOG, for the reason the memo log next door spells out: ~/.mulmoterminal is one
+// directory for every server on the machine, and launching twice is the ordinary way to get two
+// instances. A rewritten snapshot has to be read, merged and written back, and two instances doing
+// that at once lose whichever finishes first. Appending needs no read.
+//
+// Its OWN file rather than a widened id log, the same call dev-terminal-cwds.ts made: those files
+// are shared between BUILDS as well as instances, and widening a line format makes an older build's
+// parser drop every line of a log it relies on. A file it has never heard of is simply ignored.
+//
+// One JSON object per line rather than the id log's bare `<id> <value>`: a cwd can contain spaces,
+// so there is no separator left to split on.
+
+export interface AntigravityConversation {
+  sessionId: string;
+  conversationId: string;
+  cwd: string;
+  startedAt: number;
+}
+
+/** One line of the log. */
+export function antigravityConversationLine(record: AntigravityConversation): string {
+  return `${JSON.stringify(record)}\n`;
+}
+
+/**
+ * The record a parsed line holds, or null for anything unusable.
+ *
+ * Both ids are validated: they become a filename lookup under agy's brain root and the key a
+ * reconnect arrives with. `startedAt` is only ever displayed, so a line missing it is still worth
+ * keeping — it is the id mapping that makes the conversation reachable again.
+ */
+export function antigravityConversationRecord(parsed: Record<string, unknown>, isValidId: (id: string) => boolean): AntigravityConversation | null {
+  const { sessionId, conversationId, cwd, startedAt } = parsed;
+  if (typeof sessionId !== "string" || !isValidId(sessionId)) return null;
+  if (typeof conversationId !== "string" || !isValidId(conversationId)) return null;
+  if (typeof cwd !== "string" || cwd === "") return null;
+  return { sessionId, conversationId, cwd, startedAt: typeof startedAt === "number" ? startedAt : 0 };
+}
+
+/**
+ * Fold one record into the map: the newest line for a session wins.
+ *
+ * The log only grows, so a session relaunched somewhere else — or resumed after its conversation
+ * was remapped — appends a second line rather than replacing the first.
+ */
+export function applyAntigravityConversation(conversations: Map<string, AntigravityConversation>, record: AntigravityConversation): void {
+  conversations.set(record.sessionId, record);
+}
+
+/**
+ * Fold a record read at BOOT, leaving alone any session this process has already recorded.
+ *
+ * Hydration reads the file as it was before our own append could reach it, so for a session
+ * spawned while it was still reading, the file's line is older by definition. Overwriting would
+ * answer with the conversation and directory that session used to have.
+ */
+export function hydrateAntigravityConversationInto(
+  conversations: Map<string, AntigravityConversation>,
+  written: ReadonlySet<string>,
+  record: AntigravityConversation,
+): void {
+  if (!written.has(record.sessionId)) applyAntigravityConversation(conversations, record);
+}

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -14,6 +14,13 @@ import type { DirModelChoice } from "./provider-env.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { parseSessionIdLog, sessionIdLogLine } from "./session-id-log.js";
+import {
+  antigravityConversationLine,
+  antigravityConversationRecord,
+  applyAntigravityConversation,
+  hydrateAntigravityConversationInto,
+  type AntigravityConversation,
+} from "./antigravity-conversations.js";
 import { applySessionMemo, createMemoWriteGuard, sessionMemoLine, sessionMemoRecord } from "./session-memos.js";
 import { normalizeMemo } from "../../common/sessionMemo.js";
 import { forEachJsonlRecord } from "../infra/jsonl-file.js";
@@ -100,8 +107,9 @@ export const claimedCodexRollouts = new Set<string>();
 // one would silently start double-recording that session's GUI calls — the opposite of cheap.
 export const hookedSessions = new Set<string>();
 
-// mulmoterminal session key -> the antigravity conversation id it maps to.
-export const antigravityConversationIds = new Map<string, string>();
+// Conversation directories already attributed to a session, so one is never mapped to two keys
+// (which would let both cold-resume the same conversation). The session -> conversation mapping
+// itself is persisted; see `antigravityConversations` below.
 export const claimedAntigravityConversations = new Set<string>();
 
 // Hidden translation-worker sessions run in CLAUDE_CWD — the workspace the user has
@@ -234,6 +242,45 @@ function rememberSessionCwd(id: string, cwd: string): void {
     .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
     .then(() => fs.appendFile(DEV_TERMINAL_CWDS_FILE, devTerminalCwdLine(id, cwd)))
     .catch((e) => console.error(`[dev-terminal-cwds] failed to persist: ${messageOf(e)}`));
+}
+
+// Which agy conversation each antigravity session runs, so a cold reconnect can resume it with
+// `--conversation <id>`. Persisted because agy mints the id and we discover it after the spawn: a
+// map that dies with the process leaves the conversation on disk with nothing pointing at it.
+export const antigravityConversations = new Map<string, AntigravityConversation>();
+const ANTIGRAVITY_CONVERSATIONS_FILE = path.join(MULMOTERMINAL_HOME, "antigravity-conversations.jsonl");
+
+// Sessions this process has already recorded. Hydration reads the file as it was BEFORE our append
+// could reach it, so without this a session spawned during startup is overwritten by an older line
+// — and the cwd it answers with would be the directory that session used to run in.
+const antigravityWrittenIds = new Set<string>();
+
+export const antigravityConversationsHydrated: Promise<void> = (async () => {
+  try {
+    // Streamed rather than read whole: one line per antigravity spawn, and nothing prunes it.
+    await forEachJsonlRecord(ANTIGRAVITY_CONVERSATIONS_FILE, (parsed) => {
+      const record = antigravityConversationRecord(parsed, isValidSessionId);
+      if (record) hydrateAntigravityConversationInto(antigravityConversations, antigravityWrittenIds, record);
+    });
+  } catch {
+    // absent on first run / unreadable => nothing to resume, which is today's behaviour anyway
+  }
+})();
+
+let antigravityPersist: Promise<void> = Promise.resolve();
+
+/** Map a session to the agy conversation it is running, and persist it. */
+export function rememberAntigravityConversation(sessionId: string, conversationId: string, cwd: string): void {
+  if (!isValidSessionId(sessionId) || !isValidSessionId(conversationId) || !cwd) return;
+  const known = antigravityConversations.get(sessionId);
+  if (known?.conversationId === conversationId && known.cwd === cwd) return; // already the answer; appending would only grow the log
+  const record: AntigravityConversation = { sessionId, conversationId, cwd, startedAt: Date.now() };
+  antigravityWrittenIds.add(sessionId);
+  applyAntigravityConversation(antigravityConversations, record);
+  antigravityPersist = antigravityPersist
+    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+    .then(() => fs.appendFile(ANTIGRAVITY_CONVERSATIONS_FILE, antigravityConversationLine(record)))
+    .catch((e) => console.error(`[antigravity-conversations] failed to persist: ${messageOf(e)}`));
 }
 
 // The one-line note the user wrote on a session (#1084). Their own words about what a cell is

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -274,7 +274,10 @@ export function rememberAntigravityConversation(sessionId: string, conversationI
   if (!isValidSessionId(sessionId) || !isValidSessionId(conversationId) || !cwd) return;
   const known = antigravityConversations.get(sessionId);
   if (known?.conversationId === conversationId && known.cwd === cwd) return; // already the answer; appending would only grow the log
-  const record: AntigravityConversation = { sessionId, conversationId, cwd, startedAt: Date.now() };
+  // Carried over rather than re-stamped: a session relaunched somewhere else appends a second
+  // line, and taking the clock there would make `startedAt` mean "last written", which is not
+  // what a reader sorting by it would get. The first line for a session is written at its spawn.
+  const record: AntigravityConversation = { sessionId, conversationId, cwd, startedAt: known?.startedAt ?? Date.now() };
   antigravityWrittenIds.add(sessionId);
   applyAntigravityConversation(antigravityConversations, record);
   antigravityPersist = antigravityPersist

--- a/server/session/spawn-antigravity.ts
+++ b/server/session/spawn-antigravity.ts
@@ -12,17 +12,17 @@ import { antigravityBrainRoot, snapshotAntigravitySessions, watchForAntigravityS
 import { ptySpawn } from "./pty-spawn.js";
 import { wireAgentPtyRelay } from "./pty-relay.js";
 import { ptyStartLine } from "./pty-exit-log.js";
-import { antigravityConversationIds, claimedAntigravityConversations, ptys } from "./registry.js";
+import { claimedAntigravityConversations, ptys, rememberAntigravityConversation } from "./registry.js";
 import type { PtyEntry } from "./types.js";
 import type { SpawnDeps } from "./spawn-deps.js";
 
 export function createAntigravitySpawner(deps: SpawnDeps) {
-  function rememberAntigravityConversation(sessionId: string, root: string, before: ReadonlySet<string>): void {
+  function captureAntigravityConversation(sessionId: string, root: string, before: ReadonlySet<string>, cwd: string): void {
     watchForAntigravitySession(root, before, { claimed: claimedAntigravityConversations, isCancelled: () => !ptys.has(sessionId) })
       .then((id) => {
         if (!id) return;
         claimedAntigravityConversations.add(id);
-        antigravityConversationIds.set(sessionId, id);
+        rememberAntigravityConversation(sessionId, id, cwd);
         console.log(`[pty] captured antigravity conversation ${id} for session ${sessionId}`);
       })
       .catch(() => {});
@@ -68,11 +68,13 @@ export function createAntigravitySpawner(deps: SpawnDeps) {
     ptys.set(sessionId, entry);
 
     if (resumeConversationId) {
-      antigravityConversationIds.set(sessionId, resumeConversationId);
+      // Recorded on resume too, not just on the spawn that discovered it: a session resumed by the
+      // conversation id itself carries no mapping yet, and one whose cell moved needs the new cwd.
+      rememberAntigravityConversation(sessionId, resumeConversationId, cwd);
     } else {
       // Only for a FRESH session: on resume the id is already known, and running the watcher could
       // overwrite it with a mis-attributed concurrent conversation.
-      rememberAntigravityConversation(sessionId, root, before);
+      captureAntigravityConversation(sessionId, root, before, cwd);
     }
 
     wireAgentPtyRelay(entry, sessionId, spawnedAtMs, deps);

--- a/src/components/CockpitHeader.vue
+++ b/src/components/CockpitHeader.vue
@@ -10,6 +10,7 @@ import { CELL_DIR_PATH, DIR_TRUNCATE_FRONT } from "./cellChromeClasses";
 import { headerStyleFor } from "./cellHeaderStyle";
 import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterPhase";
 import type { AttentionStatus } from "./attentionStatus";
+import { agentBadge } from "../../common/sessionAgent";
 
 const props = withDefaults(
   defineProps<{
@@ -47,6 +48,8 @@ const PHASE_CLASS: Record<string, string> = {
 // A working cell shows what it's doing (planning / editing) when known, else the plain word.
 const badgeWord = computed(() => (props.status === "working" && props.workPhase ? WORK_WORD[props.workPhase] : STATUS_WORD[props.status]));
 const phaseInfo = computed(() => phaseDisplay(props.phase ?? "none"));
+// Null for claude (the default, so nearly every row) and for a shell, which is not an agent.
+const badge = computed(() => agentBadge(props.agent));
 const phaseColor = computed(() => PHASE_CLASS[props.phase ?? "none"] ?? "text-[#9aa4b2]");
 const dirText = computed(() => formatCwd(props.cwd, props.home, props.dirLength ?? 44) || "—");
 const barStyle = computed(() => headerStyleFor(props.headerColor, props.headerTextColor));
@@ -68,7 +71,7 @@ const barStyle = computed(() => headerStyleFor(props.headerColor, props.headerTe
       :title="phaseInfo.title"
       >{{ phaseInfo.label }}</span
     >
-    <span v-if="agent === 'codex'" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">codex</span>
+    <span v-if="badge" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">{{ badge.full }}</span>
     <span
       data-testid="cockpit-dir"
       class="min-w-0 flex-auto text-[11px] text-[var(--cell-header-fg,var(--text-dim))]"

--- a/src/components/SessionTabBar.vue
+++ b/src/components/SessionTabBar.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 import { SESSION_SPINNER, sessionDotFor, useSessionFilter, type SessionListEmits, type SessionListProps } from "../composables/sessionList";
 import SessionFilters from "./SessionFilters.vue";
+import { agentBadge } from "../../common/sessionAgent";
 
 // Presentational: list + filter are owned by App.vue and shared with the
 // vertical Sidebar, so switching layouts preserves them (no refetch/reset).
@@ -77,7 +78,9 @@ const visibleSessions = computed(() => filteredSessions.value.slice(0, MAX_TABS)
           title="Claude is working"
           aria-label="Claude is working"
         />
-        <span v-if="s.agent === 'codex'" class="shrink-0 rounded-[3px] bg-selected px-1 text-[9px] font-bold uppercase text-dim">cx</span>
+        <span v-if="agentBadge(s.agent)" class="shrink-0 rounded-[3px] bg-selected px-1 text-[9px] font-bold uppercase text-dim">{{
+          agentBadge(s.agent)?.short
+        }}</span>
         <span class="truncate" :class="{ 'font-bold text-fg': isUnread(s) }">{{ s.title }}</span>
         <!-- One dot, two meanings until #1139: `--err-strong` red marked both a row stopped on a
              permission prompt and one that had merely finished — and a finished turn is not an

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,6 +9,7 @@ import {
 } from "../composables/sessionList";
 import SessionFilters from "./SessionFilters.vue";
 import { relativeTime } from "./cellDisplay";
+import { agentBadge } from "../../common/sessionAgent";
 
 // Presentational: the session list + filter are owned by App.vue (a single
 // useSessions instance shared across layouts) so toggling vertical/horizontal
@@ -111,10 +112,10 @@ const { unreadCount, backgroundCount, filteredSessions, isUnread } = useSessionF
             :aria-label="sessionDotFor(s)?.label"
           />
           <span
-            v-if="s.agent === 'codex'"
+            v-if="agentBadge(s.agent)"
             data-testid="agent-badge"
             class="mr-[5px] inline-block rounded-[4px] bg-selected px-[5px] align-middle text-[10px] font-semibold uppercase text-dim"
-            >codex</span
+            >{{ agentBadge(s.agent)?.full }}</span
           >
           {{ s.title }}
         </span>

--- a/src/composables/useSessions.ts
+++ b/src/composables/useSessions.ts
@@ -1,5 +1,6 @@
 import { ref, onMounted, onUnmounted } from "vue";
 import { usePubSub } from "./usePubSub";
+import type { TerminalAgent } from "../../common/sessionAgent";
 
 export interface Session {
   id: string;
@@ -14,9 +15,9 @@ export interface Session {
    *  hidden:true. Listed under the Background filter rather than among the chats, and
    *  never treated as unread/bold. */
   hidden?: boolean;
-  /** "codex" for a codex session (from ~/.codex); absent = a Claude session. Drives the
-   *  row badge and which agent the single view resumes as. */
-  agent?: "codex";
+  /** The agent this session runs; absent = a Claude session. Drives the row badge and which
+   *  agent the single view resumes as. */
+  agent?: TerminalAgent;
 }
 
 // The session-list chips, mirroring mulmoclaude's history filters: "unread" is a session

--- a/test/common/agentBadge.spec.ts
+++ b/test/common/agentBadge.spec.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+// The badge a session row wears to say which agent it runs (#1096). Read by the sidebar and the
+// tab bar, which show the SAME list — comparing a literal in each is how they came to disagree
+// about a third agent, so the wording lives in one place and is pinned here.
+import { describe, it, expect } from "vitest";
+import { agentBadge, TERMINAL_AGENTS } from "../../common/sessionAgent";
+
+describe("agentBadge", () => {
+  it("badges codex", () => {
+    expect(agentBadge("codex")).toEqual({ full: "codex", short: "cx" });
+  });
+
+  it("badges antigravity by the name its CLI goes by", () => {
+    expect(agentBadge("antigravity")).toEqual({ full: "agy", short: "agy" });
+  });
+
+  // Claude is the default everywhere, so badging it would put one on nearly every row and stop
+  // the badge meaning "this one is different".
+  it("gives claude no badge", () => {
+    expect(agentBadge("claude")).toBeNull();
+  });
+
+  it.each([
+    ["a shell, which is not an agent", "shell"],
+    ["an agent this build has never heard of", "some-future-agent"],
+    ["a claude session, which carries no agent at all", undefined],
+    ["nothing", null],
+    ["an empty string", ""],
+  ])("gives %s no badge", (_label, agent) => {
+    expect(agentBadge(agent)).toBeNull();
+  });
+
+  // The tab bar fits about two characters. A short form that is not short defeats the point.
+  it("keeps every short form to two or three characters", () => {
+    TERMINAL_AGENTS.forEach((agent) => {
+      const badge = agentBadge(agent);
+      if (badge) expect(badge.short.length).toBeLessThanOrEqual(3);
+    });
+  });
+});

--- a/test/server/session/antigravity-conversations.spec.ts
+++ b/test/server/session/antigravity-conversations.spec.ts
@@ -3,7 +3,11 @@
 // what makes a conversation reachable after a restart, it is written by several instances at once,
 // and it is read by builds older and newer than the one that wrote it — so what a line means, and
 // what an unusable one costs, is pinned here.
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { forEachJsonlRecord } from "../../../server/infra/jsonl-file";
 import {
   antigravityConversationLine,
   antigravityConversationRecord,
@@ -27,37 +31,44 @@ const record = (over: Partial<AntigravityConversation> = {}): AntigravityConvers
   ...over,
 });
 
-// What the registry does with a file: parse each line, drop the unusable ones, fold the rest.
-function foldLog(contents: string): Map<string, AntigravityConversation> {
+// Exactly what the registry does with the file, through the SAME reader — a hand-rolled
+// split/parse here would be a paraphrase of forEachJsonlRecord, and the two could drift apart
+// (CRLF, blank lines, a line holding a bare array) while these tests kept passing (CodeRabbit).
+let logDir: string;
+let logSeq = 0;
+
+beforeAll(async () => {
+  logDir = await mkdtemp(path.join(tmpdir(), "antigravity-log-"));
+});
+
+afterAll(async () => {
+  await rm(logDir, { recursive: true, force: true });
+});
+
+async function foldLog(contents: string): Promise<Map<string, AntigravityConversation>> {
+  const file = path.join(logDir, `log-${logSeq++}.jsonl`);
+  await writeFile(file, contents);
   const conversations = new Map<string, AntigravityConversation>();
-  contents.split("\n").forEach((line) => {
-    if (!line.trim()) return;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      return;
-    }
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return;
-    const found = antigravityConversationRecord({ ...parsed }, isValidId);
+  await forEachJsonlRecord(file, (parsed) => {
+    const found = antigravityConversationRecord(parsed, isValidId);
     if (found) applyAntigravityConversation(conversations, found);
   });
   return conversations;
 }
 
 describe("antigravityConversationLine", () => {
-  it("round-trips through the parser", () => {
-    expect(foldLog(antigravityConversationLine(record())).get(SESSION_A)).toEqual(record());
+  it("round-trips through the parser", async () => {
+    expect((await foldLog(antigravityConversationLine(record()))).get(SESSION_A)).toEqual(record());
   });
 
-  it("keeps a cwd that contains spaces — the reason this is JSON and not a split line", () => {
+  it("keeps a cwd that contains spaces — the reason this is JSON and not a split line", async () => {
     const line = antigravityConversationLine(record({ cwd: "/work/my project" }));
-    expect(foldLog(line).get(SESSION_A)?.cwd).toBe("/work/my project");
+    expect((await foldLog(line)).get(SESSION_A)?.cwd).toBe("/work/my project");
   });
 
-  it("ends its own line, so the next append cannot weld onto it", () => {
+  it("ends its own line, so the next append cannot weld onto it", async () => {
     const log = `${antigravityConversationLine(record())}${antigravityConversationLine(record({ sessionId: SESSION_B, conversationId: CONVERSATION_B }))}`;
-    expect([...foldLog(log).keys()]).toEqual([SESSION_A, SESSION_B]);
+    expect([...(await foldLog(log)).keys()]).toEqual([SESSION_A, SESSION_B]);
   });
 });
 
@@ -85,28 +96,29 @@ describe("antigravityConversationRecord", () => {
     ["the id log next door", `\n${SESSION_A}`],
     ["a memo log line", JSON.stringify({ id: SESSION_A, text: "note", at: 1 })],
     ["a torn last line", `${antigravityConversationLine(record())}{"sessionId":"${SESSION_B}`],
-  ])("reads nothing usable out of %s", (_label, contents) => {
-    expect([...foldLog(contents).keys()]).not.toContain(SESSION_B);
+  ])("reads nothing usable out of %s", async (_label, contents) => {
+    expect([...(await foldLog(contents)).keys()]).not.toContain(SESSION_B);
   });
 
-  it("still keeps the good lines around a broken one", () => {
+  it("still keeps the good lines around a broken one", async () => {
     const log = `not json\n${antigravityConversationLine(record())}{"sessionId":"truncated`;
-    expect([...foldLog(log).keys()]).toEqual([SESSION_A]);
+    expect([...(await foldLog(log)).keys()]).toEqual([SESSION_A]);
   });
 });
 
 // The log only grows — a session relaunched elsewhere, or resumed after its cell moved, appends a
 // second line rather than replacing the first.
 describe("applyAntigravityConversation", () => {
-  it("lets the last line for a session win", () => {
+  it("lets the last line for a session win", async () => {
     const log = `${antigravityConversationLine(record({ cwd: "/work/old" }))}${antigravityConversationLine(record({ cwd: "/work/new" }))}`;
-    expect(foldLog(log).get(SESSION_A)?.cwd).toBe("/work/new");
+    expect((await foldLog(log)).get(SESSION_A)?.cwd).toBe("/work/new");
   });
 
-  it("keeps sessions apart", () => {
+  it("keeps sessions apart", async () => {
     const log = `${antigravityConversationLine(record())}${antigravityConversationLine(record({ sessionId: SESSION_B, conversationId: CONVERSATION_B }))}`;
-    expect(foldLog(log).get(SESSION_A)?.conversationId).toBe(CONVERSATION_A);
-    expect(foldLog(log).get(SESSION_B)?.conversationId).toBe(CONVERSATION_B);
+    const conversations = await foldLog(log);
+    expect(conversations.get(SESSION_A)?.conversationId).toBe(CONVERSATION_A);
+    expect(conversations.get(SESSION_B)?.conversationId).toBe(CONVERSATION_B);
   });
 });
 
@@ -141,29 +153,32 @@ describe("hydrateAntigravityConversationInto", () => {
 describe("a hydrated log as agentResumeId's mappedId", () => {
   const coldFacts = { conversationExists: () => false, hasLivePty: false, tmuxAlive: false };
 
-  it("resumes a session whose mapping only exists on disk — the restart this log is for", () => {
-    const conversations = foldLog(antigravityConversationLine(record()));
+  it("resumes a session whose mapping only exists on disk — the restart this log is for", async () => {
+    const conversations = await foldLog(antigravityConversationLine(record()));
     expect(agentResumeId(SESSION_A, { ...coldFacts, mappedId: conversations.get(SESSION_A)?.conversationId })).toBe(CONVERSATION_A);
   });
 
-  it("resumes the LAST conversation recorded for a session, not the first", () => {
+  it("resumes the LAST conversation recorded for a session, not the first", async () => {
     const log = `${antigravityConversationLine(record())}${antigravityConversationLine(record({ conversationId: CONVERSATION_B }))}`;
-    expect(agentResumeId(SESSION_A, { ...coldFacts, mappedId: foldLog(log).get(SESSION_A)?.conversationId })).toBe(CONVERSATION_B);
+    const conversations = await foldLog(log);
+    expect(agentResumeId(SESSION_A, { ...coldFacts, mappedId: conversations.get(SESSION_A)?.conversationId })).toBe(CONVERSATION_B);
   });
 
   // The guard that makes an empty or corrupt log cost a resume rather than the WRONG conversation.
-  it("declines to resume an unmapped key that names no conversation on disk", () => {
-    expect(agentResumeId(SESSION_B, { ...coldFacts, mappedId: foldLog("").get(SESSION_B)?.conversationId })).toBeNull();
+  it("declines to resume an unmapped key that names no conversation on disk", async () => {
+    const conversations = await foldLog("");
+    expect(agentResumeId(SESSION_B, { ...coldFacts, mappedId: conversations.get(SESSION_B)?.conversationId })).toBeNull();
   });
 
   // The sidebar hands over a conversation id directly; that path must survive an empty log.
-  it("still resumes a key that IS a conversation on disk", () => {
-    const facts = { ...coldFacts, conversationExists: () => true, mappedId: foldLog("").get(CONVERSATION_A)?.conversationId };
+  it("still resumes a key that IS a conversation on disk", async () => {
+    const conversations = await foldLog("");
+    const facts = { ...coldFacts, conversationExists: () => true, mappedId: conversations.get(CONVERSATION_A)?.conversationId };
     expect(agentResumeId(CONVERSATION_A, facts)).toBe(CONVERSATION_A);
   });
 
-  it("does not carry a resume id into a reattach of a live session", () => {
-    const conversations = foldLog(antigravityConversationLine(record()));
+  it("does not carry a resume id into a reattach of a live session", async () => {
+    const conversations = await foldLog(antigravityConversationLine(record()));
     const facts = { ...coldFacts, hasLivePty: true, mappedId: conversations.get(SESSION_A)?.conversationId };
     expect(agentResumeId(SESSION_A, facts)).toBeNull();
   });

--- a/test/server/session/antigravity-conversations.spec.ts
+++ b/test/server/session/antigravity-conversations.spec.ts
@@ -1,0 +1,170 @@
+// @vitest-environment node
+// The log that maps a MulmoTerminal session to the agy conversation it is running (#1096). It is
+// what makes a conversation reachable after a restart, it is written by several instances at once,
+// and it is read by builds older and newer than the one that wrote it — so what a line means, and
+// what an unusable one costs, is pinned here.
+import { describe, it, expect } from "vitest";
+import {
+  antigravityConversationLine,
+  antigravityConversationRecord,
+  applyAntigravityConversation,
+  hydrateAntigravityConversationInto,
+  type AntigravityConversation,
+} from "../../../server/session/antigravity-conversations";
+import { agentResumeId } from "../../../server/agents/agent-resume";
+
+const SESSION_A = "bf488420-850f-4dcb-931c-727614d6eaf7";
+const SESSION_B = "33149419-234b-4d31-bd8c-341290f4c090";
+const CONVERSATION_A = "9c2f0f8e-1a4b-4c7d-8e5f-0a1b2c3d4e5f";
+const CONVERSATION_B = "1d3e5f70-2b4c-4d6e-9f80-a1b2c3d4e5f6";
+const isValidId = (id: string) => /^[0-9a-f-]{36}$/.test(id);
+
+const record = (over: Partial<AntigravityConversation> = {}): AntigravityConversation => ({
+  sessionId: SESSION_A,
+  conversationId: CONVERSATION_A,
+  cwd: "/work/one",
+  startedAt: 1_700_000_000_000,
+  ...over,
+});
+
+// What the registry does with a file: parse each line, drop the unusable ones, fold the rest.
+function foldLog(contents: string): Map<string, AntigravityConversation> {
+  const conversations = new Map<string, AntigravityConversation>();
+  contents.split("\n").forEach((line) => {
+    if (!line.trim()) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return;
+    const found = antigravityConversationRecord({ ...parsed }, isValidId);
+    if (found) applyAntigravityConversation(conversations, found);
+  });
+  return conversations;
+}
+
+describe("antigravityConversationLine", () => {
+  it("round-trips through the parser", () => {
+    expect(foldLog(antigravityConversationLine(record())).get(SESSION_A)).toEqual(record());
+  });
+
+  it("keeps a cwd that contains spaces — the reason this is JSON and not a split line", () => {
+    const line = antigravityConversationLine(record({ cwd: "/work/my project" }));
+    expect(foldLog(line).get(SESSION_A)?.cwd).toBe("/work/my project");
+  });
+
+  it("ends its own line, so the next append cannot weld onto it", () => {
+    const log = `${antigravityConversationLine(record())}${antigravityConversationLine(record({ sessionId: SESSION_B, conversationId: CONVERSATION_B }))}`;
+    expect([...foldLog(log).keys()]).toEqual([SESSION_A, SESSION_B]);
+  });
+});
+
+describe("antigravityConversationRecord", () => {
+  it.each([
+    ["no sessionId", { conversationId: CONVERSATION_A, cwd: "/work/one" }],
+    ["a sessionId that is not an id", { sessionId: "nope", conversationId: CONVERSATION_A, cwd: "/work/one" }],
+    ["no conversationId", { sessionId: SESSION_A, cwd: "/work/one" }],
+    ["a conversationId that is not an id", { sessionId: SESSION_A, conversationId: "nope", cwd: "/work/one" }],
+    ["no cwd", { sessionId: SESSION_A, conversationId: CONVERSATION_A }],
+    ["an empty cwd", { sessionId: SESSION_A, conversationId: CONVERSATION_A, cwd: "" }],
+  ])("drops a record with %s rather than guessing", (_label, parsed) => {
+    expect(antigravityConversationRecord(parsed, isValidId)).toBeNull();
+  });
+
+  // startedAt is only ever displayed. Dropping the line over it would throw away the id mapping,
+  // which is the one thing that makes the conversation reachable again.
+  it("keeps a record whose startedAt is missing or unusable", () => {
+    const parsed = { sessionId: SESSION_A, conversationId: CONVERSATION_A, cwd: "/work/one", startedAt: "yesterday" };
+    expect(antigravityConversationRecord(parsed, isValidId)).toEqual(record({ startedAt: 0 }));
+  });
+
+  // The logs live side by side in ~/.mulmoterminal, and a build reads whichever it is pointed at.
+  it.each([
+    ["the id log next door", `\n${SESSION_A}`],
+    ["a memo log line", JSON.stringify({ id: SESSION_A, text: "note", at: 1 })],
+    ["a torn last line", `${antigravityConversationLine(record())}{"sessionId":"${SESSION_B}`],
+  ])("reads nothing usable out of %s", (_label, contents) => {
+    expect([...foldLog(contents).keys()]).not.toContain(SESSION_B);
+  });
+
+  it("still keeps the good lines around a broken one", () => {
+    const log = `not json\n${antigravityConversationLine(record())}{"sessionId":"truncated`;
+    expect([...foldLog(log).keys()]).toEqual([SESSION_A]);
+  });
+});
+
+// The log only grows — a session relaunched elsewhere, or resumed after its cell moved, appends a
+// second line rather than replacing the first.
+describe("applyAntigravityConversation", () => {
+  it("lets the last line for a session win", () => {
+    const log = `${antigravityConversationLine(record({ cwd: "/work/old" }))}${antigravityConversationLine(record({ cwd: "/work/new" }))}`;
+    expect(foldLog(log).get(SESSION_A)?.cwd).toBe("/work/new");
+  });
+
+  it("keeps sessions apart", () => {
+    const log = `${antigravityConversationLine(record())}${antigravityConversationLine(record({ sessionId: SESSION_B, conversationId: CONVERSATION_B }))}`;
+    expect(foldLog(log).get(SESSION_A)?.conversationId).toBe(CONVERSATION_A);
+    expect(foldLog(log).get(SESSION_B)?.conversationId).toBe(CONVERSATION_B);
+  });
+});
+
+// Hydration reads the file as it was BEFORE this process's append could reach it, so a session
+// spawned while it was still reading must keep the record the spawn wrote.
+describe("hydrateAntigravityConversationInto", () => {
+  it("fills what is missing", () => {
+    const conversations = new Map<string, AntigravityConversation>();
+    hydrateAntigravityConversationInto(conversations, new Set(), record());
+    expect(conversations.get(SESSION_A)).toEqual(record());
+  });
+
+  it("does not overwrite a session recorded while it was reading", () => {
+    const conversations = new Map([[SESSION_A, record({ cwd: "/work/live" })]]);
+    hydrateAntigravityConversationInto(conversations, new Set([SESSION_A]), record({ cwd: "/work/from-disk" }));
+    expect(conversations.get(SESSION_A)?.cwd).toBe("/work/live");
+  });
+
+  it("still fills the OTHER sessions in the same file", () => {
+    const conversations = new Map([[SESSION_A, record({ cwd: "/work/live" })]]);
+    const written = new Set([SESSION_A]);
+    hydrateAntigravityConversationInto(conversations, written, record({ cwd: "/work/from-disk" }));
+    hydrateAntigravityConversationInto(conversations, written, record({ sessionId: SESSION_B, conversationId: CONVERSATION_B }));
+    expect(conversations.get(SESSION_A)?.cwd).toBe("/work/live");
+    expect(conversations.get(SESSION_B)?.conversationId).toBe(CONVERSATION_B);
+  });
+});
+
+// What the log is FOR, composed the way resolveAntigravitySession composes it: the hydrated
+// mapping feeds agentResumeId's `mappedId`. `agy` cannot be run here, so this pins the decision
+// rather than the resume itself — and the decision is the only part #1096 changes.
+describe("a hydrated log as agentResumeId's mappedId", () => {
+  const coldFacts = { conversationExists: () => false, hasLivePty: false, tmuxAlive: false };
+
+  it("resumes a session whose mapping only exists on disk — the restart this log is for", () => {
+    const conversations = foldLog(antigravityConversationLine(record()));
+    expect(agentResumeId(SESSION_A, { ...coldFacts, mappedId: conversations.get(SESSION_A)?.conversationId })).toBe(CONVERSATION_A);
+  });
+
+  it("resumes the LAST conversation recorded for a session, not the first", () => {
+    const log = `${antigravityConversationLine(record())}${antigravityConversationLine(record({ conversationId: CONVERSATION_B }))}`;
+    expect(agentResumeId(SESSION_A, { ...coldFacts, mappedId: foldLog(log).get(SESSION_A)?.conversationId })).toBe(CONVERSATION_B);
+  });
+
+  // The guard that makes an empty or corrupt log cost a resume rather than the WRONG conversation.
+  it("declines to resume an unmapped key that names no conversation on disk", () => {
+    expect(agentResumeId(SESSION_B, { ...coldFacts, mappedId: foldLog("").get(SESSION_B)?.conversationId })).toBeNull();
+  });
+
+  // The sidebar hands over a conversation id directly; that path must survive an empty log.
+  it("still resumes a key that IS a conversation on disk", () => {
+    const facts = { ...coldFacts, conversationExists: () => true, mappedId: foldLog("").get(CONVERSATION_A)?.conversationId };
+    expect(agentResumeId(CONVERSATION_A, facts)).toBe(CONVERSATION_A);
+  });
+
+  it("does not carry a resume id into a reattach of a live session", () => {
+    const conversations = foldLog(antigravityConversationLine(record()));
+    const facts = { ...coldFacts, hasLivePty: true, mappedId: conversations.get(SESSION_A)?.conversationId };
+    expect(agentResumeId(SESSION_A, facts)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Antigravity (`agy`) セッションの「MulmoTerminal セッションキー → agy 会話 id」の対応を
`~/.mulmoterminal/antigravity-conversations.jsonl` に永続化し、**サーバ再起動後も cold resume
できる**ようにする。あわせてセッション一覧の `agent` 型とバッジを 3 つ目の agent に耐えるよう広げた。

Issue #1096 の 4 項目のうち **①②④**。③（`GET /api/antigravity/sessions`）は見送り、理由は下記。

## Items to Confirm / Review

人間に見てほしい点。

1. **`agy` を実際に動かした検証はしていない**（この開発機に `agy` 未インストール）。
   ただし今回変えたのは「resume id を**どこから取るか**」だけで、渡したあとの経路は #1095 のまま。
   代わりに以下で担保した:
   - ユニットテスト 33 件（後述）
   - **実ファイルでのプロセス跨ぎ検証**: プロセス1で記録 → 別プロセス（＝再起動）で hydrate →
     `agentResumeId` が会話 id を返すことを確認。対照として**ログを消すと `null` を返す**ことも確認済み
     （＝この変更が resume を生んでいる）。後勝ち・壊れた行混入の条件でも確認。
2. **resume 時にも記録している**（`spawn-antigravity.ts`）。issue は「watcher が確定したとき」と
   しか書いていないが、会話 id そのもので resume された経路は対応表を持たないため。
   意図どおりか確認してほしい。
3. **`CockpitHeader.vue` も一緒に直した**。issue が名指ししているのはサイドバーだけだが、
   ロスターは #1089 でセルが agent を持つようになっており、agy のセルだけ無印なのは不整合と判断。
   `agentBadge()` は `shell` にも claude にもバッジを出さないので、ロスターの既存挙動は変わらない。
4. **`antigravity` のバッジ表記を `agy` にした**（`codex` は `codex` のまま）。
   サイドバーで `antigravity` は長すぎるため CLI 名に寄せた。表記の好みがあれば変更する。
5. ログは**刈り込まない**。`dev-terminal-cwds` / `session-memos` と同じで、agy セッション 1 回につき
   1 行増える。

## User Prompt

> これって対応終わっている？ https://github.com/receptron/mulmoterminal/issues/1096
>
> 1〜4 の難易度は？簡単にできそうなのある？
>
> 4 やろうか。1,2 は unit test をしっかりかけば動作テスト不要？もしそうならやってほしい

## 背景

`agy` は会話 id を自分で発行し、読める形でどこにも出力しない。そのため spawn 後に
`~/.gemini/antigravity-cli/brain/` を watcher が監視して id を拾っている
（`server/agents/antigravity-session.ts`）。

その対応表 `antigravityConversationIds` が**メモリ上の `Map` だけ**だったので、サーバを再起動すると
対応が消える。`resolveAntigravitySession` はその Map を見ているため resume id を得られず、
会話ディレクトリがディスクに残っているのに到達できなくなっていた。

安全側には倒れていた。`agentResumeId` は `mappedId` が無いとき
`antigravityConversationExists()` でキー自体が会話 id か確かめてからでないと resume しないので、
**古い id を `agy --conversation` に渡すことはなかった**。失われていたのは到達手段だけ。

## 実装

### ① 会話ログ（append-only）— `server/session/antigravity-conversations.ts`

- レコード: `{ sessionId, conversationId, cwd, startedAt }`、1 行 1 JSON。
- **追記ログ**にしたのは `session-memos.jsonl` と同じ理由 — `~/.mulmoterminal` は同一マシンの
  全インスタンスで共有され（ポート衝突時にランチャが別ポートで 2 つ目を上げるのは日常）、
  読んで書き戻すスナップショットは同時実行で片方を失う。追記なら読まないので競合しない。
- **既存ログを広げず新ファイル**にしたのは `dev-terminal-cwds.ts` が挙げている理由と同じ。
  これらのファイルは**ビルド間**でも共有されるので、行形式を広げると古いビルドのパーサが
  そのログの全行を落とす。知らないファイルは単に無視される。
- `<id> <value>` 形式ではなく **JSON** にしたのは cwd に空白が入りうるため（区切りが取れない）。
- 同一 `sessionId` は**後の行が勝つ**。

`registry.ts` 側:

- `antigravityConversationIds: Map<string, string>` を
  `antigravityConversations: Map<string, AntigravityConversation>` に置き換え、
  **メモリの Map をログの投影**にした。参照元が 2 つに割れるのを防ぐため（結果として②がほぼ 1 行になった）。
- 読み出しは `forEachJsonlRecord` でストリーム。ファイル全体を 1 つの文字列にしない。
- **この起動中に自分が書いた `sessionId` は hydrate で上書きしない**。hydrate は自分の追記が届く前の
  ファイルを読むので、上書きすると起動中に spawn したセッションが「昔いたディレクトリ」を答えてしまう
  （`session-memos.ts` の `memoWrittenIds` と同じ罠）。この規則は
  `hydrateAntigravityConversationInto()` として切り出し、テストで固定した。

### ② `resolveAntigravitySession` がログを見る

- `mappedId` の取得元が変わるだけ（1 行）。
- `handleAntigravityConnection` で resolve の**前に** `await antigravityConversationsHydrated`。
  これを忘れると hydrate 完了前の再接続が空 Map を見て resume を諦める
  （`devTerminalCwdsHydrated` と同じ理由）。

### ④ クライアント側の型とバッジ

- `Session.agent` を `"codex"` リテラルから `TerminalAgent` へ。
- `common/sessionAgent.ts` に `agentBadge()` を追加し、**バッジ文言の唯一の出所**にした。
  サイドバーとタブバーは同じ `Session[]` を見ているので、リテラル比較を各所に置いたことが
  3 つ目の agent で食い違う原因になる。claude は既定なのでバッジ無し、`shell` も対象外。
- 差し替えた 3 箇所: `Sidebar.vue` / `SessionTabBar.vue` / `CockpitHeader.vue`。

## 検証

- `yarn format` / `yarn lint`（error 0）/ `yarn typecheck` / `yarn typecheck:server` /
  `yarn typecheck:test` / `yarn build` すべて green。
- `yarn test`: **6690 passed**（新規 33 件を含む、既存の失敗なし）。
- 新規テスト:
  - `test/server/session/antigravity-conversations.spec.ts` — 行のラウンドトリップ、空白入り cwd、
    後勝ち、壊れた行 / 隣のログの行 / 途中で切れた最終行を落とすこと、hydrate が自分の書き込みを
    上書きしないこと、そして**ログ → `agentResumeId` の合成**（②が実際に主張していること）。
  - `test/common/agentBadge.spec.ts` — claude / shell / 未知の値はバッジ無し、codex と antigravity の文言。
- 実ファイル検証（スクラッチの `HOME` を使い、実際の `~/.mulmoterminal` には触れていない）:
  - プロセス1が書いたログを、別プロセスが hydrate して `agentResumeId` が会話 id を返す
  - **対照**: ログを消すと `null`（＝修正前の挙動）
  - 同一セッションの 2 行目が勝つ / 壊れた行が混ざっても復元できる

## この PR でやらないこと

- **③ `GET /api/antigravity/sessions`** — ルート自体は①のログから cwd で引けるので容易だが、
  title の取得元とされる `brain/<id>/.system_generated/logs/transcript.jsonl` の実フォーマットが
  **この環境では確認できない**（`agy` 未インストール、リポジトリ内にフィクスチャも記述も無い）。
  推測で JSONL パーサを書くのは避けた。`agy` を入れて実フォーマットを確認してから別 PR で行う。
- **`fetchAntigravitySessions()`** — ③のエンドポイントが無いと 404 を握って空配列を返すだけの
  死にコードになるため、③と同じ PR に置く。

Closes なし（#1096 は ③④(b) が残るため open のまま）

work in mulmoterminal5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Antigravity conversation mappings now persist across server restarts, keeping sessions resumable after reconnects.
  * Added agent badges for supported terminal agents across session lists, tabs, and headers.
  * Session handling now supports multiple terminal agents beyond Codex.

* **Documentation**
  * Clarified Antigravity cold-resume mapping and persistence behavior in the README.
  * Added implementation guidance for conversation-log persistence and resume behavior.

* **Tests**
  * Added coverage for conversation recovery, malformed log entries, and agent badge display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->