### PR TITLE
feat: プログラムから起動したチャットをグリッドのセルとして開き、そのセルで Canvas を使えるようにする

### DIFF
--- a/plans/feat-remove-single-view.md
+++ b/plans/feat-remove-single-view.md
@@ -1,0 +1,338 @@
+# feat: eliminate the single-terminal view; the grid becomes the only view
+
+## The observation this starts from
+
+A grid cell whose cwd is the default workspace (`CLAUDE_CWD`) is already almost the single
+view: same PTY, same `spawnClaudePty`, same agent, and since #1000 / #1032 / #1040 / #1071 the
+same Canvas and GUI tool groups beside a zoomed cell.
+
+What separates them is **one query parameter**. `?gui=0` (`attachGuiMcp`,
+`server/routes/ws-routes.ts:282`) is set by every grid cell (`TerminalCell.vue:1086` passes
+`dev-terminal` unconditionally → `wsUrl.ts:30`) and omitted by the single view. That one flag
+currently decides five unrelated things:
+
+| # | What `attachGuiMcp` decides | Where |
+|---|---|---|
+| 1 | MCP surface: full `--mcp-config` + `GUI_MCP_TOOLS` + user MCP servers, vs. the directory's own `.mcp.json` + `GRID_MCP_TOOLS` | `spawn-claude.ts:123,142`, `index.ts:185,193` |
+| 2 | Docker sandbox eligibility | `pty-spawn.ts:59` (`sandboxWouldRun`) |
+| 3 | tmux persistence (the inverse — sandbox and tmux are exclusive spawn wrappers) | `spawn-claude.ts:~148`, `plans/feat-202-docker-sandbox-mcp.md:7` |
+| 4 | Whether the session is hidden from `/api/sessions` (`markDevTerminalSession`) | `ws-routes.ts:303,462,531` |
+| 5 | The session's initial `active` (= "the user is looking at it", drives waiting/attention) | `ws-routes.ts:349,514` |
+
+Plus client-side: `Terminal.vue:177` (`gitCwd` null for dev terminals) and
+`terminalViewActive.ts:14` (a dev-terminal cell is "active" only when expanded).
+
+## Decisions (owner, this session)
+
+1. **MCP surface** — a grid cell **at `{workspace}`** gets the full GUI MCP, by **default auto
+   configuration** (no opt-in, no launcher checkbox). **Normal grid cells do not change at all**
+   — they keep `GRID_MCP_TOOLS` and the directory's own `.mcp.json`.
+2. **Docker sandbox** — **cut the feature.** It is opt-in (`MULMOTERMINAL_SANDBOX=1`, default
+   off, `sandbox.ts:31`), macOS-only, and its exclusivity with tmux is the only thing making
+   "persistent AND fully-tooled" impossible.
+3. **tmux persistence** — by design; it stays, and with the sandbox gone nothing contends with it.
+
+**The discriminator is the cwd, not the view.** This is what keeps the change small: of the five
+jobs `attachGuiMcp` does today, only #1 moves. #2 is deleted. #3 is already right. **#4 and #5
+stay keyed on "is this a grid cell", exactly as now** — so the workspace cell remains hidden from
+`/api/sessions` and starts inactive like any other cell, and no attention/waiting behaviour is
+touched. The earlier draft of this plan proposed re-basing #4/#5 for every cell; that is no longer
+needed and should not be done.
+
+## The invariant: a normal terminal does not change. At all.
+
+**This overrides every other goal in this plan.** A grid cell whose cwd is not `{workspace}`
+must behave after all five PRs exactly as it does today — same claude argv, same MCP servers,
+same tmux reattach, same session-list visibility, same attention/waiting, same reload.
+If a step cannot be taken without touching them, the step does not happen.
+
+Make it checkable, not just asserted:
+
+- **Characterization spec on `buildClaudeArgs`.** Snapshot the argv for a non-workspace cwd
+  before PR2 and assert it is unchanged after — including `--allowedTools`, the absence of
+  `--mcp-config`, and `--strict-mcp-config`. This is the single highest-value test in the whole
+  plan: it is exactly where a "small" refactor leaks.
+- **The same for the codex and antigravity spawns** (`spawn-codex.ts:73`), which take the same
+  flag.
+- **PR1 costs nothing here by construction**: `sandboxWouldRun` already requires `attachGuiMcp`
+  (`pty-spawn.ts:59`), so a grid cell has *never* been sandboxed. Deleting the sandbox cannot
+  reach them. Worth saying in the PR body, because "we removed the sandbox" otherwise sounds
+  like it might.
+- **Renames are allowed, re-decisions are not.** PR2 renames the `gui` wire flag to say "grid
+  cell"; the value each consumer computes must be identical. Land the rename as its own commit
+  with no behaviour delta so the diff can be read as such.
+- **Nothing new keys off "grid cell".** The temptation in PR3/PR4 will be to hang a new
+  behaviour off the flag while it is already being touched. Don't.
+
+Where each PR touches shared code, the audit is: PR1 — no path a grid cell can reach. PR2 —
+derivation only, guarded by the spec above. PR3 — *adds* cells, changes none; reconciliation is
+scoped (see below) so an existing cell's reload is untouched. PR4 — moves overlays, which are
+app-level and render above the grid either way. PR5 — deletes single-view-only code.
+
+## What identifies the workspace cell
+
+`CLAUDE_CWD` (`server/config/env.ts:36`, default `~/mulmoclaude`) is server truth, and
+`spawnClaudePty` already has both it and the session's `cwd` in scope
+(`spawn-claude.ts:98`) — so the whole rule is server-side and the client sends nothing new.
+
+Three things to get right, each of which silently produces "the feature just doesn't turn on":
+
+- **An empty cwd IS the workspace.** The launch form's blank field means "the server's default"
+  (`CellLaunchForm.vue:64`), and `spawnClaudePty` defaults `cwd = CLAUDE_CWD`. That cell must
+  match.
+- **Canonicalise before comparing.** The cwd arrives from a `?cwd=` query built from a user
+  preset: trailing slash, `..`, and above all **symlinks** (a `~/mulmoclaude` that is a symlink is
+  normal on this machine). Compare `realpathSync` of both sides, and fall back to a normalised
+  string compare when the path does not exist rather than throwing.
+- **Subdirectories do not count.** `{workspace}/foo` is a normal cell. Equality, not prefix.
+
+**Multiple workspace cells are required, not merely tolerated** (owner). Each gets its own full
+GUI MCP; the broker is already per-session (`/mcp/:sessionId`), so nothing needs to change for
+this. The singularity of the single view was an artifact of it being a view.
+
+## Every programmatic chat becomes a grid cell (owner)
+
+This is the requirement that makes the workspace cell more than a convenience: **all
+programmatically started chats run in the grid.** They already spawn at `CLAUDE_CWD` with no
+`cwd` option, so under the PR2 rule they are workspace cells and get the full GUI MCP for free —
+no call site changes for the MCP half.
+
+The six spawn sites, all `spawnClaudePty(id, null, null, …)` with the default cwd:
+
+| Site | What it is | Visible? |
+|---|---|---|
+| `index.ts:320` | translation worker | **hidden** — must stay cell-less |
+| `index.ts:543` | feeds / collection refresh worker | `hidden` flag decides |
+| `index.ts:561` | remote-host `spawnChat` (phone) | visible |
+| `index.ts:774` | `spawnScheduledChat` (user cron tasks) | visible |
+| `plugin-routes.ts:63,64` | `spawnBackgroundChat` tool (claude-draft / -run) | `hidden` flag decides |
+| `GridView.vue:494` | Settings skill button | visible, already placed as a cell |
+
+**The hard part: the grid lives in the browser.** A cell exists because `GridView`'s
+localStorage state (`GridView.vue:75`) says so. The host cannot open one — `index.ts:686` says
+this outright — which is why the phone's request goes out over `LAUNCH_TERMINAL_CHANNEL` to
+*one* tab (`publishToOne`, `index.ts:699`) and fails with `NO_BROWSER_ERROR` when no tab is
+listening. A server-spawned session today therefore appears **nowhere in the grid**; only
+`launchSkill` gets a cell, and only because the browser initiated the spawn and then adopted it
+(`GridView.vue:494-507`).
+
+So two mechanisms are needed, and the second is the one that actually makes this reliable:
+
+1. **A placement channel** — like `LAUNCH_TERMINAL_CHANNEL` but carrying an *existing*
+   `sessionId` to adopt rather than a cwd to spawn at. `publishToOne`, same reasoning: a
+   broadcast would place one cell per open tab.
+2. **Reconciliation on grid load** — visible, non-hidden sessions the server knows about that
+   are absent from this tab's state get cells. Without this, anything spawned while no browser
+   was open (a cron task at 3am — the common case) is invisible forever. This also makes #1 a
+   latency optimisation rather than the correctness mechanism, which is the right split.
+
+Excluded from placement: hidden workers. They are already marked — `runWithHiddenMarker` /
+`backgroundMarkers` (`index.ts:543`), `scheduledSessions.register`, `hidden: true` in
+`background-chat.ts:14` — and `session-list.ts:17` already keeps them behind a Background
+filter. Pin the exclusion with a spec; a translation worker acquiring a visible cell would be an
+obvious regression and an easy one to cause.
+
+**The 81-cell cap needs a real answer.** `insertCellAfter` silently returns the state unchanged
+when the grid is full, and today's fallback is `showSpawnedSession` → the single view
+(`GridView.vue:505`), which is exactly what is being deleted. Options: refuse the spawn and say
+so in the text `spawnBackgroundChat` returns to the calling agent (it is a tool result, so the
+agent can react); or park the session in an "unplaced" list the grid can pull from. Owner's
+call — but note that "silently nowhere" is the current failure mode and must not be the one that
+survives.
+
+## Sequencing
+
+Five PRs. The order is load-bearing: the single view cannot be deleted while it is the only
+place five overlays render, nor while it is where a programmatic chat lands.
+
+### PR1 — cut the sandbox
+
+Pure deletion, independent of everything else, no user-visible change with the flag off.
+
+- Delete `server/infra/sandbox.ts` (384 lines), `test/server/infra/sandbox.spec.ts` (242),
+  `Dockerfile.sandbox` and the `~/.mulmoterminal/sandbox` scratch dir it writes.
+- `pty-spawn.ts` — drop `sandboxWouldRun` / `spawnSandboxEntry`; `ptySpawn` keeps the tmux path only.
+- `spawn-claude.ts:105-123` — the `sandbox` local, `SANDBOX_HOST` in `hookSettingsJson` /
+  `mcpConfigJson` (both revert to `localhost` / `127.0.0.1`).
+- `ws-routes.ts:315` — the `live?.sandbox || sandboxWouldRun(...)` refusal branch.
+- `server/index.ts:866-877` — the boot-time sandbox diagnostics.
+- `bin/mulmoterminal.js` — any doctor line about Docker / the sandbox image.
+- Grep for the env names before declaring done: `MULMOTERMINAL_SANDBOX`,
+  `MULMOTERMINAL_SANDBOX_IMAGE`, `SANDBOX_MOUNT_CONFIGS`, `SANDBOX_SSH_AGENT_FORWARD` — these
+  are documented, so README / docs guide / `mulmoterminal-model` + `-bug-report` skills need the
+  same sweep. Removing a documented env var is a changelog line.
+
+### PR2 — the workspace cell gets the full GUI MCP
+
+Small and server-side. The wire flag keeps its current meaning; what changes is that the MCP
+decision stops reading it.
+
+- **Separate the two facts.** `?gui=0` (`ws-routes.ts:282`) keeps meaning *"this is a grid
+  cell"* and keeps driving `markDevTerminalSession` (:303) and `entry.active` (:349) for every
+  cell including the workspace one — untouched, so normal cells are bit-for-bit unchanged.
+  Rename it to say so (`gridCell` / `isGridCell`); `attachGuiMcp` becomes a derived value.
+- **Derive the MCP surface from the cwd**, inside `spawnClaudePty` where both values already
+  live: `const fullGuiMcp = isWorkspaceCwd(cwd)`. That single value then feeds the two places
+  that read `attachGuiMcp` today — `mcpConfig` (`spawn-claude.ts:123`) and `allowedTools`
+  (:142). `GRID_MCP_TOOLS`, `autoAllowedToolNames()` and `spawn-deps.ts:15` all **stay**: they
+  are still what a normal cell gets.
+- **Put `isWorkspaceCwd` in one place with its own spec** — the canonicalisation rules above
+  (empty = workspace, realpath, equality not prefix) are exactly the kind of thing that gets
+  re-implemented slightly differently in a second call site. `server/config/env.ts` next to
+  `CLAUDE_CWD` is the natural home.
+- **Per-session MCP config file** (`mcpConfigArgument` → `mcp-config.ts`): now written for
+  workspace cells too. It was already written for every single-view session, so the volume is
+  comparable — but confirm `fs-cleanup.ts` reaps them for grid sessions as well.
+- **codex / antigravity**: `spawn-codex.ts:73` (`allTools`) and the antigravity path take the
+  same flag. Apply the same derivation so a codex cell at `{workspace}` behaves like a claude
+  one — or decide explicitly to leave them grid-only, and say so in a comment.
+- The per-project registered-groups path (#1040, `registeredGuiMcpGroups`,
+  `ws-routes.ts:443,469,538`) is **unaffected** and stays: it is how a normal cell gets Canvas.
+
+### PR3 — programmatic chats land in the grid — **START HERE**
+
+Independent of PR2 (placement is not MCP) and of PR1. Done first it fixes a defect that exists
+today: the grid renders only its own localStorage cells (`GridView.vue:75`), so a session spawned
+by the scheduler, the feeds worker or the phone appears **nowhere** in grid mode — it is reachable
+only from the single view's sidebar. It is also the only step that could invalidate the rest of
+the plan, so it belongs first.
+
+Doing it first also **defers the 81-cell cap question** instead of blocking on it: the existing
+`showSpawnedSession` → single view fallback (`GridView.vue:507`) is still there and stays
+untouched until PR5, which is where the cap must actually be answered.
+
+Split in two.
+
+#### PR3a — placement channel + one choke point
+
+**Every chat started from the collection UI goes through `startCollectionChat`**
+(`useChatLauncher.ts`), so re-pointing that one function's "show it" step covers all of them:
+
+- the collections index "create" button, a collection action, a record action → the plugin's
+  `startChat` capability (`collectionUi.ts:234`);
+- the new-collection template cards and **custom views** → `startNewChatDraft`
+  (`collectionUi.ts:239`). The custom-view path starts inside a sandboxed iframe, which
+  postMessages `mc-start-chat` (`customViewSrcdoc.ts:69`) to the plugin, which then calls the
+  same host capability — so it converges here too and needs no separate handling.
+- the Settings skill buttons (`App.vue:231`, `GridView.vue:497`).
+
+`registerChatOpener` (`App.vue:284`) is what currently means "show it in the single view". That
+registration is the seam: point it at grid placement and every caller above follows, with no
+per-call-site changes. Keep the draft path intact — a `draft:true` spawn has the text typed into
+the PTY without an Enter, and the adopting cell must show it that way.
+
+#### PR3a-2 — the placed cell shows the collection it came from
+
+A chat started from a record view must not land in a cell with an empty Canvas: the user was
+looking at something, and the context is the point. So placement carries a Canvas seed.
+
+**The mechanism already exists and needs no agent round-trip.** `storeToolResult(sessionId,
+result)` (`tool-store.ts:160`) is host-callable, deduped by uuid, disk-backed and publishes to
+the panel — the same store the broker writes through. Placing a cell can append a synthetic
+`presentCollection` result for the new session, and the panel replays it like any other.
+
+**Proposed rule — seed with what the chat was started FROM** (confirm before building):
+
+| Started from | Canvas seed |
+|---|---|
+| a collection record view | that record |
+| a collection | that collection |
+| the collections index / a template card | nothing — there is no subject yet |
+| a Settings skill button, cron, feeds, the phone | nothing |
+
+**Two blockers, both real:**
+
+1. ~~**`presentCollection` is in the `data` group, not `canvas`**~~ — **RESOLVED, and it was not
+   the gate that was wrong.** Reported live: a chat started from the collections UI landed in the
+   grid as intended but had no Canvas at all, not even for `render` tools. The cause is that a
+   programmatically spawned chat is spawned with the **whole** GUI MCP on `--mcp-config`
+   (`spawnClaudePty`'s `attachGuiMcp` defaults to true) and then ADOPTED as a grid cell, so it
+   attaches with `?gui=0` and is marked a grid session — at which point `narrowedTools`' rule
+   ("grid cell + no groups learned = has nothing") withholds every tool from a session holding
+   every tool there is.
+
+   Fixed at the source of the fact: `/api/mcp/:sessionId`, the all-tools URL, now records
+   **`TOOL_GROUPS`** — reaching it is proof of the full MCP, since only `--mcp-config` hands it
+   out. `data` therefore comes along with the rest and needs no per-cell widening, and
+   `hasCanvasGroup` is untouched. Normal grid cells never reach that URL, so the invariant holds
+   by construction rather than by a conditional.
+2. **The renderer has to be mounted on the grid path.** `collectionUi.ts:3` / `main.ts:5` mount
+   the collection engine "once, before any presentCollection card mounts", and that has only ever
+   been exercised from the single view's `GuiPanel`. **Verify this before committing to the
+   seed** — if the grid's Canvas cannot render a `presentCollection` result today, that is its own
+   piece of work and should be established first, not discovered mid-PR.
+
+#### PR3b — the durable half
+
+The server-side unplaced marker + reconciliation on grid load, i.e. the case where no tab was
+open at all. Details below.
+
+- **Placement channel**: a new pub/sub channel carrying `{ sessionId, agent, cwd }` for a session
+  the server has already spawned, delivered with `publishToOne`. Reuse the shape and the
+  no-listener handling of `LAUNCH_TERMINAL_CHANNEL` (`common/launchAgent.ts:15`,
+  `index.ts:688-700`) rather than inventing a second convention — but note the payloads differ
+  (adopt an id vs. spawn at a cwd), so it is a sibling channel, not a widened one.
+- **Grid side**: subscribe where `App.vue:58` already subscribes (NOT in `GridView`, which is
+  `v-if`d on the route and does not exist until `/terminals` has been visited once — the same
+  trap #831 hit), and adopt via the existing `sessionCell` + `insertCellAfter` path that
+  `launchSkill` uses.
+- **Reconciliation on load**: on `GridView` mount, ask the server for **programmatically spawned,
+  visible, unplaced** sessions and add cells for them. Scope it to exactly that set — server-side,
+  by a marker set at spawn time (the same place `runWithHiddenMarker` and
+  `scheduledSessions.register` already sit), **not** by diffing "all sessions" against the grid
+  state. A broad diff would sweep up ordinary sessions and change what a reload does to a normal
+  cell, which the invariant forbids.
+  Two more things to be careful of: a session already placed in another tab (duplicate cells
+  across tabs are acceptable — cells are per-tab by design), and one the user deliberately closed
+  (a closed cell must not resurrect on reload — clear the marker on close, so "unplaced" is
+  server-side state with one writer rather than a growing dismissed-set in each tab).
+- **Exclude hidden workers** — and add a spec that pins it (translation, hidden feeds refresh).
+- **Cap policy** — implement whichever answer the owner picks above, and make it audible.
+- Re-pointing `registerChatOpener` also removes the `hidden: true` workaround at
+  `GridView.vue:496`, whose only purpose is stopping the single view from stealing the session.
+- **`hidden` keeps its other meaning.** `hidden: true` in `background-chat.ts:14` marks a real
+  background worker; the skill button's use of it is a workaround, not the same thing. Do not
+  collapse the two while removing the workaround.
+
+### PR4 — make the grid self-sufficient
+
+Everything the single view currently owns has to exist in the grid *before* PR4.
+
+- **Five full-screen overlays live inside the `!isGrid` block** (`App.vue:398-412`):
+  `CollectionsBrowseOverlay`, `AccountingOverlay`, `WikiBrowseOverlay`, `PrsOverlay`,
+  `FilesOverlay`, plus `AppSettingsModal`. Hoist them out of the branch so they render on
+  `/terminals` too. The comment at `App.vue:39` warns about exactly this.
+- `overlayOrigin.ts:34` falls back to `{ name: "chat" }` — must become `terminals`.
+- `AppToolbar.vue:102` pushes `{ name: "chat" }` (the #941 view switch) — the switch goes away.
+- The chat launcher and the 81-cell fallback are handled in PR3 above.
+- `ToolsPane` is still single-view-only; `GuiPanel` already has a grid home (zoomed cell).
+  Decide whether ToolsPane moves beside the zoomed cell or is dropped.
+- The session list: `Sidebar` / `SessionTabBar` filter + selection has no grid equivalent
+  beyond the cockpit roster. Confirm the roster covers it (it does show every cell) — and note
+  it does NOT show off-grid sessions (`GridView.vue:102`).
+
+### PR5 — delete the single view
+
+Only after PR3 and PR4 land and the grid has been used for a few days.
+
+- `App.vue`: the whole `v-if="!isGrid"` block, `isGrid`, `singleAgent`, `connectKey`,
+  `terminalWidth` + splitter (`splitterWidth.ts`), `persist-key="single"`, the `"single"` half of
+  `useUnloadGuard` (`App.vue:80-93`).
+- Components with no other caller: `Sidebar.vue`, `SessionTabBar.vue`, possibly `ToolsPane.vue`.
+- Router: drop `/chat`; `/` already redirects by NAME to `terminals` (`router/index.ts:20`) so the
+  default view needs no change. Keep `/chat` as a redirect to `/terminals` for one release —
+  people have it bookmarked.
+- `hiddenMarker` / `background-chat` / translation workers are **not** single-view concepts and
+  must keep working — they spawn headless, with no view at all. Pin that with a spec.
+
+## What has to be true before PR5
+
+- A grid cell at `{workspace}` can do everything the single view could: full GUI MCP, Canvas,
+  every overlay, skill buttons, collection chats.
+- Every visible programmatic spawn lands in the grid — including one made while no browser was
+  open, which is the case the placement channel alone does not cover.
+- No route, composable or plugin resolves `{ name: "chat" }`.
+- `yarn typecheck`, `typecheck:server`, `typecheck:test`, `yarn test` — all four, per CLAUDE.md.
+- Changelog entry + a dated `docs/guide/{en,ja}/v<version>.md`: two features are being REMOVED
+  (single view, sandbox) and one env var family disappears. That page is what an upgrader who
+  used `MULMOTERMINAL_SANDBOX=1` needs.

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -14,7 +14,7 @@ import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { buildGuiMcpServer } from "../mcp/broker.js";
 import type { GuiCallRecorder } from "../mcp/gui-call-history.js";
 import { translationWorkerIds, markSessionToolGroup, sessionToolGroups } from "../session/registry.js";
-import { isToolGroup, type ToolGroup } from "../../common/toolGroups.js";
+import { isToolGroup, TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { submitTranslation } from "../session/translation-worker.js";
 import { translationSubmitOutcome } from "../session/translation-submit.js";
 
@@ -68,6 +68,21 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     deps.publish(TOOL_GROUPS_CHANNEL, { sessionId });
   }
 
+  /**
+   * Record what reaching us on this URL proves the session can call, and tell the panel — once,
+   * on the transition, so the per-request MCP servers don't republish on every tool call.
+   *
+   * Shared by both routes because the evidence is the same kind: the URL a client connected to.
+   * One group for the group URL; every group for the all-tools one.
+   */
+  function learnToolGroups(sessionId: string, groups: readonly ToolGroup[]): void {
+    if (!SESSION_ID_RE.test(sessionId)) return;
+    const known = sessionToolGroups(sessionId);
+    if (groups.every((group) => known.includes(group))) return;
+    for (const group of groups) markSessionToolGroup(sessionId, group);
+    deps.publish(TOOL_GROUPS_CHANNEL, { sessionId, groups: sessionToolGroups(sessionId) });
+  }
+
   // We run in STATELESS mode (sessionIdGenerator: undefined): one fresh Server+transport per
   // request, no session header and no initialize handshake required across requests. The SDK
   // forbids reusing a stateless transport, so it is never cached.
@@ -111,7 +126,22 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     }
   }
 
-  app.post("/api/mcp/:sessionId", (req, res) => handleMcpRequest(req, res, req.params.sessionId, null));
+  // The ALL-TOOLS surface: a session gets this URL from --mcp-config (spawnClaudePty's
+  // attachGuiMcp), never from a user's per-folder config, so connecting here is proof it carries
+  // the whole GUI MCP — every group, not none.
+  //
+  // Recorded rather than left implicit because the answer is read from a place that cannot see
+  // how the session was spawned: a chat started programmatically (the collections UI) is spawned
+  // with the full MCP and then ADOPTED as a grid cell, so the cell attaches with `?gui=0` and is
+  // marked a grid session — at which point "no groups learned" is read as "cannot draw" and the
+  // Canvas button is withheld from a session that has every drawing tool there is.
+  //
+  // Grid cells proper are untouched: without --mcp-config they never reach this URL, and what
+  // they can call still comes only from what their directory registered.
+  app.post("/api/mcp/:sessionId", (req, res) => {
+    learnToolGroups(req.params.sessionId, TOOL_GROUPS);
+    return handleMcpRequest(req, res, req.params.sessionId, null);
+  });
   app.get("/api/mcp/:sessionId", rejectNonPost);
   app.delete("/api/mcp/:sessionId", rejectNonPost);
 
@@ -126,12 +156,7 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
     // Reaching us here IS the evidence that this session has the group — nothing else tells
     // us, since the registration lives in the user's own MCP config. Marked before the request
     // is served so a panel asking right after the first ListTools already sees it.
-    if (SESSION_ID_RE.test(sessionId) && !sessionToolGroups(sessionId).includes(group)) {
-      markSessionToolGroup(sessionId, group);
-      // Announced only on the transition, so the panel is told once per handshake rather than
-      // on every tool call for the life of the session.
-      deps.publish(TOOL_GROUPS_CHANNEL, { sessionId, groups: sessionToolGroups(sessionId) });
-    }
+    learnToolGroups(sessionId, [group]);
     return handleMcpRequest(req, res, sessionId, group);
   });
   app.get("/api/mcp/:group/:sessionId", rejectNonPost);

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -54,6 +54,7 @@ import { becameCiFailing, EMPTY_SESSION_META, isPrPhase, mergeSessionMeta, type 
 import { notifySound } from "../composables/notifySound";
 import { useGridActivity } from "../composables/useGridActivity";
 import { registerNewTerminalHandler, type NewTerminalRequest } from "../composables/useNewTerminal";
+import { registerSpawnedChatHandler, type SpawnedChatRequest } from "../composables/useSpawnedChat";
 import { usePendingScript } from "../composables/usePendingScript";
 import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
@@ -489,24 +490,46 @@ useCaptureKeydown(onShortcutKey);
 // app losing your place — you came back to a different screen than the one you left.
 //
 // Spawned first, then adopted: the spawn route is the only way to seed a first turn (a plain claude
-// cell has no channel to be handed a prompt), and `hidden` is what stops useChatLauncher selecting
-// it in the single view — the switch being avoided. The cell attaches to the session it is given,
-// which is the same path a reload takes to reattach.
-async function launchSkill(skill: BundledSkillName) {
+// cell has no channel to be handed a prompt). The cell attaches to the session it is given, which
+// is the same path a reload takes to reattach.
+//
+// No `hidden` here any more: it used to mean "don't let useChatLauncher select this in the single
+// view", which was a workaround for the switch this now avoids by default. `hidden` keeps its own
+// meaning on the server (a real background worker, background-chat.ts) and must not be reused for
+// placement.
+function launchSkill(skill: BundledSkillName) {
   closeSettings();
-  const spawned = await startCollectionChat(skillSeed(skill, "claude"), { hidden: true });
-  if (!spawned) return;
+  void startCollectionChat(skillSeed(skill, "claude"));
+}
+
+// Place an already-spawned chat as a cell. Every programmatically started chat arrives here —
+// the collection UI's actions and template cards, custom views, the Settings skill buttons —
+// via useChatLauncher's one choke point.
+const placeChat = ({ id, agent }: SpawnedChatRequest) => {
   // Seeded with the directory the server spawns these in (CLAUDE_CWD, which /api/config reports as
   // `cwd`); the cell adopts whatever the PTY reports anyway. sessionCell carries the agent, which
   // matters because a spawn follows the Claude/Codex/Antigravity toggle.
-  const placed = insertCellAfter(state.value, NO_ORIGIN_UID, sessionCell(spawned.id, defaultCwd.value, spawned.agent));
+  const placed = insertCellAfter(state.value, NO_ORIGIN_UID, sessionCell(id, defaultCwd.value, agent));
   // A full grid (MAX_TERMINALS) drops the cell and insertCellAfter hands the state straight back,
   // which would leave a live agent with nowhere here to appear — show it in the single view instead
   // of losing it. Judged by identity AFTER the spawn, not by counting before it: the count can
   // cross the cap while the spawn is in flight, and then the answer taken earlier is wrong.
-  if (placed === state.value) showSpawnedSession(spawned);
+  // (This fallback is what has to be replaced when the single view goes: see
+  // plans/feat-remove-single-view.md.)
+  if (placed === state.value) showSpawnedSession({ id, agent });
   else state.value = placed;
-}
+};
+// Registered on the same activate/deactivate cycle as the new-terminal opener, and for the same
+// reason: <KeepAlive> keeps this grid alive while the user is in the single view, and a chat
+// started there must queue + navigate rather than silently mutate a hidden grid.
+let offSpawnedChat: (() => void) | null = null;
+const detachSpawnedChat = () => {
+  offSpawnedChat?.();
+  offSpawnedChat = null;
+};
+onActivated(() => (offSpawnedChat = registerSpawnedChatHandler(placeChat)));
+onDeactivated(detachSpawnedChat);
+onBeforeUnmount(detachSpawnedChat);
 </script>
 
 <template>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -505,7 +505,7 @@ function launchSkill(skill: BundledSkillName) {
 // Place an already-spawned chat as a cell. Every programmatically started chat arrives here —
 // the collection UI's actions and template cards, custom views, the Settings skill buttons —
 // via useChatLauncher's one choke point.
-const placeChat = ({ id, agent }: SpawnedChatRequest) => {
+const placeChat = ({ id, agent, draft }: SpawnedChatRequest) => {
   // Seeded with the directory the server spawns these in (CLAUDE_CWD, which /api/config reports as
   // `cwd`); the cell adopts whatever the PTY reports anyway. sessionCell carries the agent, which
   // matters because a spawn follows the Claude/Codex/Antigravity toggle.
@@ -516,7 +516,11 @@ const placeChat = ({ id, agent }: SpawnedChatRequest) => {
   // cross the cap while the spawn is in flight, and then the answer taken earlier is wrong.
   // (This fallback is what has to be replaced when the single view goes: see
   // plans/feat-remove-single-view.md.)
-  if (placed === state.value) showSpawnedSession({ id, agent });
+  // `draft` goes with it: the single view shows a "preparing your draft…" hint on one, and
+  // dropping the flag here would make a full grid the one case where startNewChatDraft looks like
+  // a turn already running. The CELL needs no such flag — the server types the draft into the PTY,
+  // so the terminal shows it either way; the hint is a single-view affordance.
+  if (placed === state.value) showSpawnedSession({ id, agent, draft });
   else state.value = placed;
 };
 // Registered on the same activate/deactivate cycle as the new-terminal opener, and for the same

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -1,19 +1,26 @@
 // Bridges the collection plugin's chat capabilities to MulmoTerminal's terminal.
 // The plugin calls startChat(prompt, role) / startNewChatDraft(prompt) from contexts
 // with no active chat (the collections index "create" button, a collection/record
-// action like Repair, the new-collection template cards). We spawn a fresh terminal
-// session via the server's spawnBackgroundChat, and — unless `hidden` — select it so
-// the user SEES it in the terminal (App.vue registers the opener, which also closes
-// the browse overlay).
+// action like Repair, the new-collection template cards, a custom view's chat button).
+// We spawn a fresh terminal session via the server's spawnBackgroundChat, and — unless
+// `hidden` — place it as a GRID CELL (useSpawnedChat), switching to the grid if that is
+// not where the user is.
+//
+// This function is the ONE choke point for every programmatically started chat, which is
+// why the grid/single-view decision is made here rather than at each call site: the
+// collection UI reaches it through the plugin's two capabilities (collectionUi.ts), and a
+// custom view reaches those through the plugin from inside its iframe.
 //
 // `hidden` defaults to false: a collection action's chat is something the user should
-// watch, so we surface it. A future hidden=true caller would leave it in the sidebar.
+// watch, so we surface it. A hidden=true caller is placing the session itself (or is a
+// real background worker) and gets only the id back.
 // `draft` (startNewChatDraft) prefills the prompt in claude's input box WITHOUT
 // submitting, so the user can review / edit before pressing Enter; without it the
 // prompt is auto-sent as claude's first turn (startChat / actions).
 
 import { ref, watch } from "vue";
 import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
+import { placeSpawnedChat } from "./useSpawnedChat";
 
 export type Agent = TerminalAgent;
 type OpenSessionFn = (sessionId: string, opts?: { draft?: boolean; agent?: Agent }) => void;
@@ -26,7 +33,10 @@ const saved = localStorage.getItem(LAUNCH_AGENT_KEY);
 export const launchAgent = ref<Agent>(asTerminalAgent(saved));
 watch(launchAgent, (agent) => localStorage.setItem(LAUNCH_AGENT_KEY, agent));
 
-/** App.vue registers how to make a session visible (close the overlay + select it).
+/** App.vue registers how to make a session visible in the SINGLE VIEW (close the overlay +
+ *  select it). No longer the normal path — a spawn now goes to the grid — but it is still what
+ *  the grid falls back to when it is full (MAX_TERMINALS), so a live agent is never left with
+ *  nowhere to appear. Goes away with the single view itself.
  *  `opts.draft` lets it show a "preparing draft…" hint while claude boots + the text
  *  is typed into the input box. */
 export function registerChatOpener(fn: OpenSessionFn): void {
@@ -77,8 +87,10 @@ export async function startCollectionChat(prompt: string, opts: { hidden?: boole
     console.error("[startChat] spawn failed", err);
     return null;
   }
-  // hidden=false → bring the new terminal session into view for the user (as the right agent).
-  if (chatId && !opts.hidden) openSessionFn?.(chatId, { draft, agent });
+  // hidden=false → place the new session as a grid cell (as the right agent), navigating there
+  // if the user is somewhere else. `draft` travels along: the cell must show a prompt waiting in
+  // the input box rather than treat it as a turn already running.
+  if (chatId && !opts.hidden) placeSpawnedChat({ id: chatId, agent, draft });
   // `agent` is what the route was ASKED for, and the route echoes it back in jsonData — so this is
   // the agent the PTY actually runs, not a second reading of the toggle.
   return chatId ? { id: chatId, agent } : null;

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -52,12 +52,15 @@ export interface SpawnedChat {
   agent: Agent;
 }
 
-/** Show an ALREADY-spawned session — what a non-hidden spawn does, as its own step. A `hidden`
- *  caller that means to place the session itself can only find out whether it managed to at the
- *  end; without this it would have to commit to "the shell shows it" before spawning, and be wrong
- *  by the time it knew. */
-export function showSpawnedSession(spawned: SpawnedChat): void {
-  openSessionFn?.(spawned.id, { agent: spawned.agent });
+/** Show an ALREADY-spawned session in the SINGLE VIEW. The one caller left is the grid's
+ *  full-capacity fallback, which can only find out that it has no room at the end — without this
+ *  it would have to commit to where the session goes before spawning, and be wrong by the time it
+ *  knew.
+ *
+ *  `draft` is carried rather than defaulted: it is what shows the "preparing your draft…" hint
+ *  (App.vue), so a draft spawn arriving here without it looks like a turn already running. */
+export function showSpawnedSession(spawned: SpawnedChat & { draft?: boolean }): void {
+  openSessionFn?.(spawned.id, { agent: spawned.agent, draft: spawned.draft === true });
 }
 
 /** Spawn a new chat seeded with `prompt`; when not hidden, make it visible. With

--- a/src/composables/useSpawnedChat.ts
+++ b/src/composables/useSpawnedChat.ts
@@ -1,0 +1,64 @@
+// A seam for placing an ALREADY-SPAWNED chat session as a grid cell — the sibling of
+// useNewTerminal, which spawns a fresh one. Everything that starts a chat programmatically goes
+// through here: the collection UI's create button and its collection / record actions, the
+// new-collection template cards and custom views (all via startCollectionChat), and the Settings
+// skill buttons. GridView owns the grid state, so it REGISTERS a handler; callers just call
+// placeSpawnedChat().
+//
+// Why a separate seam rather than a flag on useNewTerminal: that one carries a cwd to spawn AT,
+// this one carries a session id to ADOPT. The spawn already happened — it is the only way to seed
+// a first turn, since a plain claude cell has no channel to be handed a prompt — so a cell here
+// attaches to a live PTY, which is the same path a reload takes to reattach.
+//
+// When the grid isn't mounted (the chat was started from a collection overlay, which renders in
+// the single-view shell), the request is QUEUED and the app switches to /terminals; GridView
+// drains the queue when it registers on activate. Same contract as useNewTerminal, including the
+// queue holding EVERY waiting request: a collection action can spawn more than one chat before
+// the route changes, and a dropped one is a live agent with nowhere to appear.
+import { router } from "../router";
+import type { TerminalAgent } from "../../common/sessionAgent";
+
+export interface SpawnedChatRequest {
+  /** The session the server already spawned. The cell attaches to it. */
+  id: string;
+  /** Travels WITH the id: without it the cell reconnects on Claude's endpoint, so a codex
+   *  session would attach as claude. */
+  agent: TerminalAgent;
+  /** The prompt was typed into the input box without an Enter (spawnBackgroundChat draft:true)
+   *  and is waiting for the user to review it — not a turn already running. */
+  draft: boolean;
+}
+type Handler = (req: SpawnedChatRequest) => void;
+
+let handler: Handler | null = null;
+let pending: SpawnedChatRequest[] = [];
+
+// GridView registers its placer; every request queued before it activated drains immediately, in
+// arrival order. The returned function unregisters it (call in onDeactivated / onBeforeUnmount).
+export function registerSpawnedChatHandler(h: Handler): () => void {
+  handler = h;
+  // Taken before dispatching, as in useNewTerminal: a handler that itself queues would otherwise
+  // have its request dropped by the clear below.
+  const queued = pending;
+  pending = [];
+  queued.forEach((req) => h(req));
+  return () => {
+    if (handler === h) handler = null;
+  };
+}
+
+/** Show a spawned chat as a grid cell. If the grid isn't mounted yet, queue it and switch to it. */
+export function placeSpawnedChat(req: SpawnedChatRequest): void {
+  if (handler) {
+    handler(req);
+    return;
+  }
+  pending.push(req);
+  router.push({ name: "terminals" }).catch(() => {});
+}
+
+/** Test seam: drop anything queued by a previous case. Not used by the app. */
+export function resetSpawnedChatQueue(): void {
+  handler = null;
+  pending = [];
+}

--- a/test/server/routes/mcp-announce.spec.ts
+++ b/test/server/routes/mcp-announce.spec.ts
@@ -1,10 +1,10 @@
 // @vitest-environment node
-// The announcement every MCP session makes on first contact, and the one thing it must NOT say.
+// What an MCP session's URL tells us about it, and when that is announced.
 //
 // The tools pane asks what a session has while the agent is still being spawned, so its first
-// answer is empty; this is what tells it to ask again. The GROUP route announced already, which is
-// why the grid was fixed and the single view was not — an all-tools session learns no group, so it
-// announced nothing and its pane stayed on the too-early answer for the whole session.
+// answer is empty; the first-contact announcement is what tells it to ask again. Which groups the
+// session has is the separate question, and both URLs answer it now: one group for a group URL,
+// every group for the all-tools one it can only have been given by --mcp-config.
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -32,6 +32,7 @@ afterAll(() => {
 });
 
 const { mountMcpRoutes, TOOL_GROUPS_CHANNEL } = await import("../../../server/routes/mcp-routes.js");
+const { TOOL_GROUPS } = await import("../../../common/toolGroups.js");
 
 const published: { channel: string; data: Record<string, unknown> }[] = [];
 const app = express();
@@ -53,14 +54,27 @@ beforeEach(() => {
 });
 
 describe("MCP first-contact announcement", () => {
-  it("announces a single-view (all-tools) session, which has no group to announce with", async () => {
+  it("announces first contact with no `groups` key at all", async () => {
     const id = randomUUID();
     await call(`/api/mcp/${id}`);
-    expect(announcementsFor(id)).toHaveLength(1);
-    // No `groups` key at all. The grid reads that field to decide whether a cell has the Canvas
-    // MCP, and an all-tools session genuinely has none to report — sending `[]` would tell a cell
-    // that can draw that it cannot.
-    expect("groups" in announcementsFor(id)[0].data).toBe(false);
+    const bare = announcementsFor(id).filter((p) => !("groups" in p.data));
+    expect(bare).toHaveLength(1);
+    // Undefined and `[]` are different answers downstream: a consumer reading a missing field as
+    // an empty list would tell a cell that can draw that it cannot. Only a message that actually
+    // carries groups says anything about them.
+    expect(bare[0].data).toEqual({ sessionId: id });
+  });
+
+  it("reports EVERY group for an all-tools session", async () => {
+    // This URL comes from --mcp-config and nowhere else, so reaching it is proof the session
+    // carries the whole GUI MCP. Announcing no groups was right while only the single view used
+    // it; a programmatically started chat is spawned the same way and then adopted as a grid
+    // cell, where "no groups" is read as "no Canvas" — for a session holding every drawing tool.
+    const id = randomUUID();
+    await call(`/api/mcp/${id}`);
+    const withGroups = announcementsFor(id).filter((p) => Array.isArray(p.data.groups));
+    expect(withGroups).toHaveLength(1);
+    expect([...(withGroups[0].data.groups as string[])].sort()).toEqual([...TOOL_GROUPS].sort());
   });
 
   it("announces once per session, not once per tool call", async () => {
@@ -68,7 +82,9 @@ describe("MCP first-contact announcement", () => {
     await call(`/api/mcp/${id}`);
     await call(`/api/mcp/${id}`);
     await call(`/api/mcp/${id}`);
-    expect(announcementsFor(id)).toHaveLength(1);
+    // One first-contact and one groups message, from the first call only: a server is built per
+    // request, so anything not guarded on the transition would republish on every tool call.
+    expect(announcementsFor(id)).toHaveLength(2);
   });
 
   it("still announces the learned groups for a grid cell's group url", async () => {

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -501,6 +501,30 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
     expect(openSession).toHaveBeenCalledWith(SPAWNED, expect.objectContaining({ agent: "claude" }));
     w.unmount();
   });
+
+  // The full-grid fallback is the ONE path where `draft` still has to reach the single view, and
+  // it is the easiest to drop: the cell it would otherwise have made needs no such flag (the
+  // server types the draft into the PTY), so nothing else here carries one. Without it a
+  // startNewChatDraft at MAX_TERMINALS silently loses the "preparing your draft…" hint and reads
+  // as a turn already running.
+  it("carries `draft` into the single-view fallback when the grid is full", async () => {
+    const openSession = vi.fn();
+    (await import("../../../src/composables/useChatLauncher")).registerChatOpener(openSession);
+    const { placeSpawnedChat } = await import("../../../src/composables/useSpawnedChat");
+    localStorage.setItem("grid_v2", filledGrid(81)); // MAX_TERMINALS
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+
+    // Straight through the placement seam: a draft spawn is startNewChatDraft's, and going via a
+    // skill button would only ever produce draft:false.
+    placeSpawnedChat({ id: SPAWNED, agent: "claude", draft: true });
+    await flushPromises();
+
+    expect(openSession).toHaveBeenCalledWith(SPAWNED, expect.objectContaining({ agent: "claude", draft: true }));
+    w.unmount();
+  });
 });
 
 // #1114: the launch form's Shell option sends a launcher with no configured index — the grid has to

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
+import { h, KeepAlive, type Component } from "vue";
+
+// App.vue renders GridView inside <KeepAlive>, and the grid registers its openers (new terminal,
+// spawned-chat placement) on ACTIVATE so a cached-but-hidden grid is never mutated behind the
+// user's back. onActivated does not fire for a bare mount, so a test that skips the KeepAlive
+// silently exercises a grid that registered nothing — which is not the component the app runs.
+const mountActivated = (component: Component, options: Parameters<typeof mount>[1]) => mount({ render: () => h(KeepAlive, null, [h(component)]) }, options);
 
 // The grid subscribes to the pub/sub socket on mount — stub it so no real socket opens.
 vi.mock("../../../src/composables/usePubSub", () => ({
@@ -389,7 +396,7 @@ describe("GridView skill launch (#1111)", () => {
       }
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();
@@ -466,7 +473,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
       if (String(url).includes("spawnBackgroundChat")) return { ok: true, json: async () => ({ jsonData: { chatId: SPAWNED } }) } as Response;
       return realFetch(url, init);
     }) as typeof fetch;
-    const w = mount((await import("../../../src/components/GridView.vue")).default, {
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
       global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
     });
     await flushPromises();

--- a/test/src/composables/spawnedChat.spec.ts
+++ b/test/src/composables/spawnedChat.spec.ts
@@ -1,0 +1,86 @@
+// The placement seam for programmatically started chats: what happens to a spawned session
+// depending on whether the grid is mounted. The rules that matter are "never dropped" and
+// "never silently placed into a grid the user isn't looking at" — both are how a live agent
+// ends up with nowhere to appear.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.hoisted, because vi.mock's factory is hoisted above the const it would otherwise close over.
+const { push } = vi.hoisted(() => ({ push: vi.fn(() => Promise.resolve()) }));
+vi.mock("../../../src/router", () => ({ router: { push } }));
+
+import { placeSpawnedChat, registerSpawnedChatHandler, resetSpawnedChatQueue, type SpawnedChatRequest } from "../../../src/composables/useSpawnedChat";
+
+const chat = (id: string, over: Partial<SpawnedChatRequest> = {}): SpawnedChatRequest => ({ id, agent: "claude", draft: false, ...over });
+
+describe("placeSpawnedChat", () => {
+  beforeEach(() => {
+    resetSpawnedChatQueue();
+    push.mockClear();
+  });
+
+  it("hands the request straight to a registered grid, without navigating", () => {
+    const placed: SpawnedChatRequest[] = [];
+    registerSpawnedChatHandler((req) => placed.push(req));
+
+    placeSpawnedChat(chat("a"));
+
+    expect(placed).toEqual([chat("a")]);
+    // Already in the grid: a push would re-enter the route the user is on.
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("queues and switches to the grid when none is mounted", () => {
+    placeSpawnedChat(chat("a"));
+
+    expect(push).toHaveBeenCalledWith({ name: "terminals" });
+  });
+
+  it("drains EVERY queued request in arrival order once the grid registers", () => {
+    // A collection action can spawn more than one chat before the route changes; a single
+    // slot would report the earlier ones as launched and show neither.
+    placeSpawnedChat(chat("a"));
+    placeSpawnedChat(chat("b"));
+
+    const placed: SpawnedChatRequest[] = [];
+    registerSpawnedChatHandler((req) => placed.push(req));
+
+    expect(placed.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("carries the agent and the draft flag through, both paths", () => {
+    // The agent decides which endpoint the cell reconnects on — a codex session adopted as
+    // claude attaches to the wrong one. `draft` means the prompt is waiting in the input box.
+    placeSpawnedChat(chat("queued", { agent: "codex", draft: true }));
+    const placed: SpawnedChatRequest[] = [];
+    registerSpawnedChatHandler((req) => placed.push(req));
+    placeSpawnedChat(chat("direct", { agent: "antigravity" }));
+
+    expect(placed).toEqual([chat("queued", { agent: "codex", draft: true }), chat("direct", { agent: "antigravity" })]);
+  });
+
+  it("stops delivering once the grid unregisters, and queues again", () => {
+    // GridView drops its handler on deactivate: a chat started from the single view must not
+    // silently mutate the cached grid behind it.
+    const placed: SpawnedChatRequest[] = [];
+    const off = registerSpawnedChatHandler((req) => placed.push(req));
+    off();
+
+    placeSpawnedChat(chat("a"));
+
+    expect(placed).toEqual([]);
+    expect(push).toHaveBeenCalledWith({ name: "terminals" });
+  });
+
+  it("keeps a request queued by a handler that re-enters during the drain", () => {
+    // The drain takes the queue BEFORE dispatching, so a handler reaching placeSpawnedChat
+    // again (it can, through the grid) does not have its own request cleared underneath it.
+    placeSpawnedChat(chat("first"));
+    const seen: string[] = [];
+    registerSpawnedChatHandler((req) => {
+      seen.push(req.id);
+      if (req.id === "first") placeSpawnedChat(chat("second"));
+    });
+
+    expect(seen).toEqual(["first", "second"]);
+  });
+});

--- a/test/src/composables/useChatLauncher.spec.ts
+++ b/test/src/composables/useChatLauncher.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { nextTick } from "vue";
 import { registerChatOpener, startCollectionChat, launchAgent } from "../../../src/composables/useChatLauncher";
+import { registerSpawnedChatHandler, resetSpawnedChatQueue, type SpawnedChatRequest } from "../../../src/composables/useSpawnedChat";
 
 function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; json: () => unknown }) {
   const fn = vi.fn((url: string, init?: RequestInit) => {
@@ -12,16 +13,25 @@ function mockFetch(impl: (url: string, init?: RequestInit) => { ok: boolean; jso
 }
 
 describe("startCollectionChat", () => {
-  beforeEach(() => registerChatOpener(vi.fn()));
+  // Every non-hidden spawn is PLACED AS A GRID CELL, not selected in the single view. The
+  // real placement seam is used rather than a mock of it, so these pin the actual wiring the
+  // collection UI depends on. A registered handler also keeps the no-grid path (queue +
+  // router.push) out of these cases — it has its own spec.
+  let placed: SpawnedChatRequest[];
+  beforeEach(() => {
+    registerChatOpener(vi.fn());
+    resetSpawnedChatQueue();
+    placed = [];
+    registerSpawnedChatHandler((req) => placed.push(req));
+  });
   afterEach(() => {
     vi.unstubAllGlobals();
     launchAgent.value = "claude"; // reset shared state so the codex test doesn't leak
+    resetSpawnedChatQueue(); // a request left queued here would drain into the next spec's handler
   });
 
-  it("spawns a chat seeded with the prompt and selects it (hidden=false)", async () => {
+  it("spawns a chat seeded with the prompt and places it as a cell (hidden=false)", async () => {
     const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-1" } }) }));
-    const opener = vi.fn();
-    registerChatOpener(opener);
 
     await startCollectionChat("fix my records", { hidden: false });
 
@@ -30,39 +40,38 @@ describe("startCollectionChat", () => {
     expect(url).toBe("/api/plugin/spawnBackgroundChat");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual({ message: "fix my records", draft: false, agent: "claude" });
-    expect(opener).toHaveBeenCalledWith("sess-1", { draft: false, agent: "claude" });
+    expect(placed).toEqual([{ id: "sess-1", agent: "claude", draft: false }]);
   });
 
   it("spawns a codex chat (auto-run, draft forced off) when the launch agent is codex", async () => {
     launchAgent.value = "codex";
     const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "cx-1", agent: "codex" } }) }));
-    const opener = vi.fn();
-    registerChatOpener(opener);
 
     await startCollectionChat("summarize this", { draft: true }); // codex ignores draft — it auto-runs
 
     expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({ message: "summarize this", draft: false, agent: "codex" });
-    expect(opener).toHaveBeenCalledWith("cx-1", { draft: false, agent: "codex" });
+    // The agent travels with the id: the cell reconnects on codex's endpoint, not claude's.
+    expect(placed).toEqual([{ id: "cx-1", agent: "codex", draft: false }]);
   });
 
   it("sends draft:true so the prompt is prefilled but not auto-sent", async () => {
     const fetchFn = mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-3" } }) }));
-    const opener = vi.fn();
-    registerChatOpener(opener);
 
     await startCollectionChat("track my tasks", { hidden: false, draft: true });
 
     expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({ message: "track my tasks", draft: true, agent: "claude" });
-    expect(opener).toHaveBeenCalledWith("sess-3", { draft: true, agent: "claude" }); // surfaced + flagged for the preparing hint
+    // draft travels to the cell too: a prompt waiting in the input box, not a turn running.
+    expect(placed).toEqual([{ id: "sess-3", agent: "claude", draft: true }]);
   });
 
-  it("does NOT select when hidden=true (stays in the sidebar)", async () => {
+  it("does NOT place when hidden=true (a real background worker)", async () => {
     mockFetch(() => ({ ok: true, json: () => ({ jsonData: { chatId: "sess-2" } }) }));
     const opener = vi.fn();
     registerChatOpener(opener);
 
     await startCollectionChat("background work", { hidden: true });
 
+    expect(placed).toEqual([]);
     expect(opener).not.toHaveBeenCalled();
   });
 
@@ -72,13 +81,15 @@ describe("startCollectionChat", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  it("does not select when the spawn fails", async () => {
+  it("does not place a cell when the spawn fails", async () => {
     mockFetch(() => ({ ok: false, json: () => ({}) }));
     const opener = vi.fn();
     registerChatOpener(opener);
 
     await startCollectionChat("oops");
 
+    // An empty cell attached to nothing is worse than no cell: there is no session to adopt.
+    expect(placed).toEqual([]);
     expect(opener).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
単一ターミナルビューを廃止していく最初の一手。「グリッドモードで {workspace} に立てたターミナルは、単一ターミナルモードのターミナルとほぼ等価」という気づきから始まった一連の作業のうち、**プログラムから起動したチャットをグリッドに着地させる**部分（計画中の PR3a）と、それによって表面化した Canvas の不在の修正。

設計ノートは `plans/feat-remove-single-view.md` に新規追加した（全 5 PR の並び、および「通常のグリッドセルの挙動は一切変えない」という不変条件を検査可能な形にしたもの）。

## 1. プログラムから起動したチャットがグリッドのセルになる

コレクション UI から始まるチャット — インデックスの作成ボタン、コレクション／レコードのアクション、新規コレクションのテンプレートカード、カスタムビューの iframe、Settings のスキルボタン — は、これまで単一ビューに選択表示されていた。これを全部グリッドのセルにする。

- **配置口として `useSpawnedChat` を追加。** `useNewTerminal` と同じ queue-and-navigate 契約だが、運ぶものが違う: あちらは spawn する cwd、こちらは adopt する session id。グリッドが mount されていない場合（コレクションのオーバーレイは単一ビュー側に出るので普通に起こる）はリクエストを queue して `/terminals` へ遷移し、GridView が activate 時に drain する。
- **分岐は `useChatLauncher` の 1 箇所だけ。** すべての起点がこの関数を通るので、呼び出し元を個別に直す必要がない。`openSessionFn?.(...)` を `placeSpawnedChat({ id, agent, draft })` に差し替えた 1 行が本体。
- **`launchSkill` の回避策を削除。** `hidden: true` で開かせずに自前で配置していたが、既定の経路がそれを本物としてやるようになったので不要になった。サーバ側の `hidden`（本当のバックグラウンドワーカー）の意味は変えていない。
- **グリッドが満杯（MAX_TERMINALS）のときだけ単一ビューにフォールバックする。** 生きたエージェントが行き場を失わないための経路で、単一ビューを消すときに一緒に消える。上限に達したときの方針（spawn を断るか、未配置として置いておくか）はそこで決める。

## 2. そのセルに Canvas が出なかった件

実機で確認して発覚。原因は Canvas のゲートではなかった。

プログラムから起動したチャットは `--mcp-config` で GUI MCP を**丸ごと**持って spawn される（`spawnClaudePty` の `attachGuiMcp` の既定値が true で、`spawnBackgroundChat` はその既定に乗っている）。それをグリッドのセルとして adopt すると `?gui=0` で接続するためグリッドセッションとして記録され（`ws-routes.ts:303`）、`narrowedTools` の

> グリッドセル かつ グループ未学習 = 何も持たない

という規則が適用される。この規則はディレクトリの MCP 設定からしかツールを得ない本物のグリッドセルには正しい。しかしこのセッションは**グループを持たない URL に接続しているからこそグループを学習しない**ので、真逆になる。結果、全描画ツールを持つセッションから Canvas が隠れていた。

**事実の出どころで直した。** 全ツール URL `/api/mcp/:sessionId` に接続したことを、`TOOL_GROUPS`（全 4 グループ）の記録として扱う。グループ URL 側が「その URL に来たこと自体が証拠」で動いているのと同じ種類の証拠で、この URL は `--mcp-config` からしか渡らない（ユーザーの per-folder 設定が指すのはグループ URL）。両者を `learnToolGroups` に寄せた。

計画では「`presentCollection` は `data` グループなので、workspace セルに限ってゲートを広げる」と書いていたが、**その条件分岐は要らなくなった**:

- `hasCanvasGroup` も `TerminalGrid` も変更していない
- `data` も一緒に付いてくるので、`presentCollection` は PR3a-2 でそのまま扱える
- 通常のグリッドセルは `--mcp-config` を持たずこの URL に到達しない。つまり不変条件が**条件分岐ではなく構造から**言える

サーバ側だけの変更なので、反映にはサーバの再起動だけでよい（リビルド不要）。既に開いているセッションは、次に GUI ツールを呼んだ時点で記録され追いつく。

## 確認したこと

- 実機で確認済み: コレクション UI から起動したチャットがグリッドに配置され、Canvas が出る
- `yarn test` 458 files / 6743 tests 全通過
- `yarn typecheck` / `yarn typecheck:test` / `yarn typecheck:server` 全通過
- `yarn lint` エラー 0（既存の max-lines 警告 5 件のみ）、`yarn build` 成功

## 直したテスト、とその理由

- `test/server/routes/mcp-announce.spec.ts` — 「全ツールセッションには告知すべきグループが無い」を趣旨として固定していた spec。それがまさに間違っていた前提なので書き換えた。
- `test/src/components/GridView.spec.ts` — GridView を素で mount していたため `onActivated` が発火せず、**オープナーを 1 つも登録していないグリッド**を検証していた。アプリは `<KeepAlive>` の中で動かしている。テストに合わせて登録を `onMounted` に移すのではなく、mount 側を KeepAlive で包んだ。既存の new-terminal オープナーも同じ穴に入っていた。

## この PR に入っていないもの

- PR3a-2（配置したセルの Canvas に、その元になったコレクションを最初から出す）。ブロッカーの 1 つ目は上記のとおり解消したが、2 つ目 — グリッドの Canvas 経路にコレクションのレンダラが mount されているか — は未確認。
- PR3b（サーバ側の未配置マーカーと、グリッド読み込み時の突き合わせ。ブラウザが 1 つも開いていない場合）
- PR1（sandbox の削除）、PR2（workspace の cwd から GUI MCP を導出）、PR4（オーバーレイの巻き上げ）、PR5（単一ビューの削除）

Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spawned chats now appear directly in available grid cells, carrying their agent and draft state.
  * Chats launched while the grid is unavailable are queued and opened when placement becomes available.
  * Grid-based chat launching now supports automatic navigation and placement.
  * MCP connections now announce available tool groups consistently.
* **Bug Fixes**
  * Prevented hidden or failed chat launches from creating visible grid cells.
  * Improved handling when the grid reaches capacity.
* **Tests**
  * Expanded coverage for chat placement, queuing, metadata, and MCP announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->