### PR TITLE
docs: X アカウントを各 top で紹介してフォローを呼びかける

### DIFF
--- a/docs/guide/en/index.md
+++ b/docs/guide/en/index.md
@@ -10,7 +10,7 @@ description: A browser-terminal cockpit for running several AI coding agents (Cl
 
 > **[What's new in 2.9.1](v2.9.1.html)** — the rate-limit readout no longer shows Codex's figure unmarked next to `claude usage n/a`, and no longer decides "API-key billing" from a status line that arrived before Claude answered (as of 2026-07-31)
 >
-> **Update announcements** — new releases and features are announced **in Japanese** on X: [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci).
+> **Follow us on X** — new releases and features are announced **in Japanese** on X: [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci). That is where everything ships first, so [**follow @SingularitySoci**](https://x.com/SingularitySoci) to hear about it as it lands.
 >
 > **Something looks wrong?** Type `/mulmoterminal-bug-report` in any session. The bundled skill hears the symptom out, checks your **real** config and version to see whether it is configuration or by design, searches the existing issues — and only helps you file one if none of that explains it, with the environment collected and secrets masked.
 

--- a/docs/guide/ja/index.md
+++ b/docs/guide/ja/index.md
@@ -10,7 +10,7 @@ description: 複数の AI コーディングエージェント（Claude Code / C
 
 > **[2.9.1 で変わったこと](v2.9.1.html)** — レート制限表示が `claude usage n/a` の隣に Codex の数字を無印で並べなくなり、Claude が答える前の status line から「API キー課金」と決めつけなくなった（2026-07-31 時点）
 >
-> **アップデート情報（日本語）** — 新バージョンや新機能のお知らせは X の [Singularity Society（@SingularitySoci）](https://x.com/SingularitySoci) で流しています。
+> **X で最新情報を発信しています** — 新バージョンや新機能のお知らせは X の [Singularity Society（@SingularitySoci）](https://x.com/SingularitySoci) で流していきます。ここが一番早いので、[**@SingularitySoci をフォローしてください！**](https://x.com/SingularitySoci)
 >
 > **「なんか変」と思ったら** — セッションで `/mulmoterminal-bug-report` と打ってください。同梱スキルが症状を聞き、**実際の**設定とバージョンを読んで仕様・設定で説明がつかないかを先に確かめ、既知の issue を検索し、それでも残ったものだけを報告にまとめます（環境情報は自動収集、鍵はマスク）。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,15 @@ lose a session**, and open git/dirs in **one click** — a **terminal-first mode
 
 ![A board of parallel AI-agent terminals](guide/images/grid-2x2.png)
 
+> **最新情報は X で発信しています / Follow us on X**
+>
+> 新バージョンや新機能のお知らせは、X の
+> [Singularity Society（@SingularitySoci）](https://x.com/SingularitySoci) で流していきます。
+> **ぜひフォローしてください！**
+>
+> New releases and features are announced on X (in Japanese) —
+> [**follow @SingularitySoci**](https://x.com/SingularitySoci) to hear about them first.
+
 ## ✨ おすすめ機能 / Highlights
 
 **📋 コックピット・ロスター / The cockpit roster** — 1 体に拡大したまま、横の一覧で全セッションの
@@ -120,6 +129,4 @@ The launcher detects it and prints the exact removal command; run that, then `np
 > Repo: [github.com/receptron/mulmoterminal](https://github.com/receptron/mulmoterminal) ·
 > npm: [`mulmoterminal`](https://www.npmjs.com/package/mulmoterminal) — `npx mulmoterminal@latest`
 
-> **アップデート情報 / Updates** — 新バージョンや新機能のお知らせは X の
-> [Singularity Society（@SingularitySoci）](https://x.com/SingularitySoci) で流しています
-> (release and feature announcements, in Japanese).
+> X: [**@SingularitySoci**](https://x.com/SingularitySoci) — 更新情報はこちらで / follow for updates


### PR DESCRIPTION
## Summary

ドキュメントサイトの 3 つの「top」で X アカウント（[@SingularitySoci](https://x.com/SingularitySoci)）を紹介し、**フォローの呼びかけ**を入れた。GitHub の README が上部の Documentation ブロックで紹介しているのと同じ扱いにする。

| ページ | 変更前 | 変更後 |
| --- | --- | --- |
| `docs/index.md`（サイト top） | **最下部**のフッターに告知が 1 行 | **ヒーロー画像の直後**に日英併記の呼びかけブロックを追加。フッターは 1 行の短い署名に圧縮（同じ文面を 2 回言わないため） |
| `docs/guide/ja/index.md` | 冒頭バナーに告知のみ | 「ここが一番早いのでフォローしてください！」を追加 |
| `docs/guide/en/index.md` | 同上 | 同じ趣旨を英語で追加 |

## Items to Confirm / Review

- **サイト top の配置をヒーロー画像の直後にした。** README は intro 直後の Documentation ブロックに置いているので、それに相当する位置。intro とヒーロー画像の間に挟むと導入の流れを切るため後ろに回している。ここでよいか。
- **フッターの告知は消さずに 1 行へ圧縮した。** 上部に強い呼びかけを置いたので、同じ説明を繰り返すとノイズになる。ただし読み終わりに CTA があるのは自然なので、リンクだけ残した。まるごと消す判断もありうる。
- **README は変更していない。** 依頼は「README **同様に**」＝ README を手本にする、という読みで、README 自体の変更は求められていないと解釈した。README にも同じ呼びかけを足すなら別途。
- **絵文字は追加していない**（このリポジトリの規約）。`docs/index.md` に既にある絵文字は既存のものなので触っていない。
- リンクは 6 箇所すべて `https://x.com/SingularitySoci` に揃っていることを確認済み。

## User Prompt

> https://receptron.github.io/mulmoterminal/ のtopと日本とtopに　githubのtopのreadme同様にtwitterのアカウントを紹介して、最新情報はここで発信していくのでフォローしてください！と。

work in mulmoterminal2