### PR TITLE
fix(ci): Codex にテスト実行を試させない — 依存が無いことを prompt に明示する

### DIFF
--- a/.github/workflows/codex_review.yaml
+++ b/.github/workflows/codex_review.yaml
@@ -215,6 +215,20 @@ jobs:
           or top-level comments via:
             gh pr comment ${PR_NUMBER}
 
+          This checkout has NO project dependencies installed — only
+          the codex CLI itself. Do not try to run the test suite, the
+          linter or the build: vitest, eslint and vue-tsc are all
+          absent, and the attempt only costs you time. Running them
+          is the CI job's role — ci.yml installs dependencies and
+          runs lint, three typechecks, the build and the full test
+          suite on ubuntu AND macOS for every PR — so a second
+          execution here would buy nothing the PR does not already
+          report. Review by READING the diff and the surrounding
+          code through gh. If a claim you want to make could only be
+          settled by running something, say so plainly instead; do
+          NOT report the missing tooling itself as a finding, since
+          a reader takes that for a broken pipeline.
+
           Focus on: correctness, edge cases, security (XSS / SSRF /
           path traversal / prompt injection), accessibility, test
           coverage for the happy path + boundary cases, and


### PR DESCRIPTION
## Summary

`codex_review.yaml` の prompt に、**このジョブには依存がインストールされていない**ことを明示する段落を追加した。

#1175（テスト専用の refactor）で Codex がテストを走らせようとして失敗し、レビュー本文に

> Note: I could not run the test suite in this environment because `vitest` is not installed (`/bin/sh: vitest: not found`).

という注記を残した。**これを読んだ人は「CI が壊れているのか」と考える** — 実際そうなり、確認のための往復が発生した。無駄な試行と、人間の判断を曇らせる注記の両方を消す。

## 頻度についての訂正（初版の記述は誤りだった）

初版の本文で「毎回テストを走らせようとして注記を残している」と書いたが、**これは事実に反する**。直近 4 PR の verdict を確認したところ:

| PR | 種類 | 注記 |
| --- | --- | --- |
| #1165 | 機能 + テスト | なし |
| #1170 | docs のみ | なし |
| #1175 | **テスト専用の refactor** | **あり（2 回とも）** |
| #1176（本 PR） | workflow のみ | なし |

つまり**毎回ではなく、diff がテスト中心のときに起きる**。Codex は「テストは通るのか」が主題の PR でだけ実行を試みている、という読みが妥当。

**したがって本 PR の価値は初版で書いたより小さい。** 全 PR で消えるノイズではなく、**テスト中心の PR で確実に出るノイズ**を消す変更。それでも安く・リスクが無く・出る場面が「テストの正しさが主題の PR」＝人間の判断が最も重要な場面なので、入れる価値はあると考える。

**あわせて、この PR 自身で注記が出なかったことは、変更が効いた証拠にはならない**（workflow のみの diff は #1170 と同じく、そもそも Codex が実行を試みない類）。効果が確認できるのは次のテスト中心の PR。

## なぜ `yarn install` を足さないのか

「依存を入れれば Codex もテストを走らせられる」は成立するが、3 点で割に合わない。

1. **重複** — `ci.yml` の `lint-and-build` が既に `yarn install --frozen-lockfile` のあと lint / typecheck ×3 / build / `yarn test` を **ubuntu と macOS の両方**で回している。Codex がもう一度走らせても、別のジョブが既に報告している事実を CI 時間で学び直すだけ。
2. **タイムアウト設計と衝突する** — `codex exec` には 1 回あたり **300 秒**のデッドラインがあり（#1020 のハング対策）、リトライは 1 回だけ。install + テスト実行を足すと健全な run が 300 秒に近づき、**ハングとして殺される**ようになる。現状 codex-review は 1 分前後で終わっている。
3. **セキュリティ** — このジョブは今 pinned な codex CLI しか入れない。`yarn install` を足すと、**その PR のロックファイルと postinstall スクリプトが、`AZURE_OPENAI_API_KEY` と `pull-requests: write` を持つジョブの中で、`--sandbox danger-full-access`（サンドボックス無効）で実行される**ことになる。`pull_request` トリガーなので fork の PR に secrets は渡らず影響は同一リポのブランチに限られるが、「未検証のコードを秘密情報を持つジョブで実行する」形が増えるのは確か。

## Items to Confirm / Review

- **上の「頻度についての訂正」を読んでから判断してほしい。** 初版の売り込みは過大だった。
- **Codex は diff を読むだけではない**という点が前提。`--sandbox danger-full-access` でシェルコマンドを自由に実行できる（bubblewrap を切らないと `gh` すら起動できないため、とワークフローのコメントにある）。だから自発的に `vitest` を叩いた。
- **prompt は非クォートの heredoc の中**にあり、`$` / バッククォート / `\` はシェルに解釈される。追加文はそれらを一切含まない（既存の prompt もバッククォートを避けている）。
- **文言に「missing tooling 自体を finding として報告するな」を含めた。** これを書かないと、次は「依存が無い」を指摘として上げてくるだけで、紛らわしさが形を変えて残る。

## 検証

YAML パースが通ることに加え、**実際に heredoc を実行してレンダリング結果を確認した**（`${PR_NUMBER}` / `${REPO}` が正しく展開され、追加段落がシェルに壊されず、後続の verdict marker の節も無傷、終了コード 0）。YAML が読めることは「Codex に渡る文字列が正しい」ことを意味しないため。

アプリのソースは変更していないので `yarn build` / `test` は対象外。

## User Prompt

> む！それなら、 codex_review.yaml でyarn installくらいはしておいたほうがよいの？codexってここのファイルを実行するの？差分見るだけじゃなくて。

work in mulmoterminal2