### PR TITLE
feat: コレクションから始めたチャットを、そのコレクションを開いた Canvas 付きでグリッドに出す

### DIFF
--- a/common/collectionSeed.ts
+++ b/common/collectionSeed.ts
@@ -1,0 +1,126 @@
+// A chat started from a collection view shows that collection in the Canvas IMMEDIATELY, instead
+// of an empty pane while the agent boots and calls presentCollection itself. The browser seeds a
+// placeholder card at spawn; the agent's real result supersedes it moments later.
+//
+// MulmoClaude ships the same feature (its #1768) — `../mulmoclaude/src/utils/collections/
+// presentSeed.ts` is the authority for the shapes and the supersede rule, and this is its
+// counterpart. Two things are deliberately NOT copied, because the hosts differ:
+//
+//   - MulmoClaude keeps tool results in an in-memory ActiveSession and reconciles in
+//     eventDispatch. Ours are stored SERVER-side (toolResultsStore, deduped by uuid) and
+//     replayed per session, so the supersede has to happen on both sides — the server for what
+//     is replayed after a reload, the panel for what is on screen now.
+//   - its synthetic marker is client-only; ours round-trips through the store and back out of
+//     /api/agent/toolResults, so the flag is part of the stored shape.
+//
+// In common/ because BOTH sides decide from it: the browser builds the placeholder and the
+// server decides which stored card a real result replaces. Two copies of "what counts as
+// synthetic" is exactly the drift this directory exists to prevent.
+import { TOOL_NAME as PRESENT_COLLECTION_TOOL_NAME, type PresentCollectionData } from "@mulmoclaude/core/collection";
+import { isRecord } from "./isRecord";
+
+export { PRESENT_COLLECTION_TOOL_NAME };
+
+export interface CollectionSlashSeed {
+  slug: string;
+  itemId?: string;
+}
+
+/** Parse a collection chat seed (`/<slug> …`, or `/<slug> id=<itemId> …` for one record) into the
+ *  addressing a placeholder card needs. These are the shapes `skillCommandSeed` builds — a
+ *  collection IS a skill, so its slug doubles as a slash command.
+ *
+ *  Returns null for anything else, which is what makes "no subject" fall out rather than needing a
+ *  case per caller: a FEED's seed is prose (no skill behind it), and the collections index, the
+ *  template cards, the Settings skill buttons and cron all send no slash command either.
+ *
+ *  A slug may not contain `/`, so a path-like input is not mistaken for a collection. Token-split
+ *  rather than one regex, to keep away from a ReDoS-flagged pattern (same as MulmoClaude's). */
+export function parseCollectionSlashSeed(message: string): CollectionSlashSeed | null {
+  const trimmed = message.trimStart();
+  if (!trimmed.startsWith("/")) return null;
+  const [slug, second] = trimmed.slice(1).split(/\s+/);
+  if (!slug || slug.includes("/")) return null;
+  const itemId = second?.startsWith("id=") ? second.slice(3) : "";
+  return itemId ? { slug, itemId } : { slug };
+}
+
+/** The marker that says a card was seeded by the browser rather than called by the agent. A
+ *  literal so both sides spell it the same way. */
+export const SYNTHETIC_COLLECTION_KEY = "syntheticCollection";
+
+/** Anything with a uuid. Deliberately NOT an index signature: the store's `ToolResult` has one and
+ *  the panel's own interface does not, and requiring it would exclude the panel — which is half of
+ *  what this file exists to keep in step. Everything else is read through `isRecord`. */
+type Carded = { uuid: string };
+
+/** The placeholder card's own shape, so a caller sees the fields it can send rather than `Carded`. */
+export interface SyntheticCollectionCard extends Carded {
+  toolName: string;
+  message: string;
+  data: PresentCollectionData;
+  jsonData: PresentCollectionData;
+  /** Spelled out as well as written through {@link SYNTHETIC_COLLECTION_KEY}, because a computed
+   *  key is not a declaration — the interface has to name it or the literal below is excess. */
+  syntheticCollection: true;
+}
+
+export const isPresentCollection = (result: unknown): boolean => isRecord(result) && result.toolName === PRESENT_COLLECTION_TOOL_NAME;
+
+export const isSyntheticCollection = (result: unknown): boolean => isRecord(result) && result[SYNTHETIC_COLLECTION_KEY] === true;
+
+/** Which collection a card presents. Reads `data` then `jsonData` because the tool result carries
+ *  the payload in both and a partial update (a view persisting its state) may carry only one. */
+export function collectionSlugOf(result: unknown): string | undefined {
+  if (!isRecord(result)) return undefined;
+  for (const field of [result.data, result.jsonData]) {
+    if (isRecord(field) && typeof field.collectionSlug === "string" && field.collectionSlug) return field.collectionSlug;
+  }
+  return undefined;
+}
+
+/** Build the placeholder card. The payload is only the addressing — the collection View
+ *  SELF-FETCHES from `collectionSlug`, so seeding needs no collection data at all, and a
+ *  placeholder is never stale in the way a snapshot would be.
+ *
+ *  `uuid` is a parameter rather than generated here so this stays pure: the value is a caller's
+ *  `crypto.randomUUID()`, and a test can pin the card without stubbing a global. */
+export function makeSyntheticCollectionResult(uuid: string, collectionSlug: string, itemId?: string): SyntheticCollectionCard {
+  const data: PresentCollectionData = itemId ? { collectionSlug, itemId } : { collectionSlug };
+  const target = itemId ? `${collectionSlug} / ${itemId}` : collectionSlug;
+  return {
+    uuid,
+    toolName: PRESENT_COLLECTION_TOOL_NAME,
+    message: `Presented collection ${target}`,
+    data,
+    jsonData: data,
+    [SYNTHETIC_COLLECTION_KEY]: true,
+  };
+}
+
+/**
+ * Fold `incoming` into `list` under the one rule that matters: a placeholder and the agent's real
+ * card for the same collection are two renderings of one thing, and the real one wins. Whichever
+ * arrives second — the agent can be faster than our own validation fetch.
+ *
+ * Returns what the caller should do with `incoming`, and MUTATES `list` to drop a superseded
+ * placeholder. Both halves are needed: dropping alone would leave the real card unstored, and
+ * skipping alone would leave two cards up.
+ *
+ * Anything that is not a presentCollection result passes straight through, so this is safe to run
+ * over every result rather than only the ones a caller thinks are collections.
+ */
+export function reconcileCollectionCard<T extends Carded>(list: T[], incoming: unknown): "store" | "skip" {
+  const slug = collectionSlugOf(incoming);
+  if (!isPresentCollection(incoming) || !slug) return "store";
+  const sameCollection = (candidate: T) => isPresentCollection(candidate) && collectionSlugOf(candidate) === slug;
+
+  if (isSyntheticCollection(incoming)) {
+    // The real card is already up: a placeholder now would be a stale duplicate that nothing
+    // later removes, since the supersede below has already run with nothing to find.
+    return list.some((candidate) => sameCollection(candidate) && !isSyntheticCollection(candidate)) ? "skip" : "store";
+  }
+  const index = list.findIndex((candidate) => sameCollection(candidate) && isSyntheticCollection(candidate));
+  if (index >= 0) list.splice(index, 1);
+  return "store";
+}

--- a/plans/feat-remove-single-view.md
+++ b/plans/feat-remove-single-view.md
@@ -231,16 +231,56 @@ result)` (`tool-store.ts:160`) is host-callable, deduped by uuid, disk-backed an
 the panel — the same store the broker writes through. Placing a cell can append a synthetic
 `presentCollection` result for the new session, and the panel replays it like any other.
 
-**Proposed rule — seed with what the chat was started FROM** (confirm before building):
+**The rule — parse the subject out of the SEED PROMPT, not the route.** This replaces an earlier
+proposal here to read `browseRouteSlug()` / `browseRouteSelectedId()` at spawn time. That would
+have worked, but MulmoClaude already ships this exact feature (its #1768) and takes the subject
+from the prompt, which is better on three counts:
 
-| Started from | Canvas seed |
-|---|---|
-| a collection record view | that record |
-| a collection | that collection |
-| the collections index / a template card | nothing — there is no subject yet |
-| a Settings skill button, cron, feeds, the phone | nothing |
+- **It survives navigation.** `placeSpawnedChat` pushes to `/terminals` when no grid is mounted,
+  and the route watcher in `useCollectionBrowse.ts:34` clears the open record on any path change.
+  Route-derived state is gone by the time the spawn resolves; the prompt travels with it.
+- **It covers every entry point with one rule**, including the ones that have no route to read —
+  a custom view's iframe button, a template card.
+- **It cannot disagree with what the agent does.** The seed prompt is what the agent acts on, so
+  parsing the same string is the same subject by construction.
 
-**Two blockers, both real:**
+It works because a collection IS a skill: the shared `CollectionView.buildChatSeed` builds
+`/<slug> <message>` (and `/<slug> id=<itemId> …` for a record). A **feed** gets prose with no
+slash command, and the collections index / template cards / skill buttons / cron send no slash
+command either — so "no subject yet" falls out of the parse rather than needing a case.
+
+| Started from | Seed prompt | Canvas seed |
+|---|---|---|
+| a collection record | `/<slug> id=<itemId> …` | that record |
+| a collection | `/<slug> …` | that collection |
+| a feed | prose naming the data path | nothing |
+| the index / a template card / a skill button / cron | no slash command | nothing |
+
+**Follow `../mulmoclaude/src/utils/collections/presentSeed.ts`.** Per the reference-host rule, that
+file is the authority, and three of its decisions are behaviour rather than style:
+
+- **The payload is tiny** — `{ collectionSlug, itemId? }`. The card SELF-FETCHES from the slug, so
+  seeding needs no collection data at all. `PresentCollectionData` and the tool name both come from
+  `@mulmoclaude/core/collection`, which we already depend on: **no upstream change is needed.**
+- **Validate the slug against the real collection list before seeding.** Otherwise a non-collection
+  slash command flashes a "not found" canvas.
+- **The placeholder is superseded, not stacked.** When the agent's real `presentCollection` lands,
+  the synthetic one for that slug is dropped.
+
+**Where MulmoTerminal must diverge, and it is not optional.** MulmoClaude holds tool results in an
+in-memory `ActiveSession` and reconciles in `eventDispatch`. MulmoTerminal's live server-side in
+`toolResultsStore`, deduped **by uuid** (`tool-store.ts:160`). So:
+
+- seeding is a POST to `/api/agent/toolResult` for the new `chatId`, not a client-side array push;
+- the real result carries its own uuid, so uuid-dedupe will NOT collapse the pair — the reconcile
+  has to be written, in `storeToolResult`, dropping a synthetic entry with the same
+  `collectionSlug` when a real `presentCollection` arrives. Skipping it stacks two cards.
+
+Mark the synthetic entry so it is identifiable (MulmoClaude uses a `syntheticCollection: true`
+flag). Unlike there, ours is persisted to disk, so the flag has to survive a round trip through the
+store — it is not client-only here.
+
+**Blockers — both now resolved:**
 
 1. ~~**`presentCollection` is in the `data` group, not `canvas`**~~ — **RESOLVED, and it was not
    the gate that was wrong.** Reported live: a chat started from the collections UI landed in the
@@ -256,11 +296,18 @@ the panel — the same store the broker writes through. Placing a cell can appen
    out. `data` therefore comes along with the rest and needs no per-cell widening, and
    `hasCanvasGroup` is untouched. Normal grid cells never reach that URL, so the invariant holds
    by construction rather than by a conditional.
-2. **The renderer has to be mounted on the grid path.** `collectionUi.ts:3` / `main.ts:5` mount
-   the collection engine "once, before any presentCollection card mounts", and that has only ever
-   been exercised from the single view's `GuiPanel`. **Verify this before committing to the
-   seed** — if the grid's Canvas cannot render a `presentCollection` result today, that is its own
-   piece of work and should be established first, not discovered mid-PR.
+2. ~~**The renderer has to be mounted on the grid path.**~~ — **RESOLVED: it already is, and there
+   is no grid-specific path to mount.** Checked rather than assumed, as this section demanded:
+
+   - the grid's Canvas renders the **same component** as the single view — `TerminalGrid.vue:849`
+     mounts `<GuiPanel>`, the one `App.vue:398` mounts;
+   - `GuiPanel` takes only `sessionId` and reads the shared plugin registry — it has no notion of
+     which view it is in;
+   - the collection engine is configured **globally at app boot** by `main.ts:6` importing
+     `./composables/collectionUi` for its side effect, not per view or per panel.
+
+   So a `presentCollection` result renders in a grid cell exactly as it does in the single view.
+   Nothing to build here; the seeding work is all that is left.
 
 #### PR3b — the durable half
 

--- a/server/routes/tool-routes.ts
+++ b/server/routes/tool-routes.ts
@@ -72,9 +72,11 @@ export function mountToolRoutes(app: Express, deps: ToolRouteDeps): void {
     if (!plan.ok) {
       return res.status(400).json({ error: plan.error });
     }
-    await deps.stores.storeToolResult(plan.sessionId, plan.stored);
+    // A dropped result (a collection placeholder the agent's real card has already beaten) must
+    // not publish either: the panel would render a card that no reload would bring back.
+    const stored = await deps.stores.storeToolResult(plan.sessionId, plan.stored);
 
-    if (plan.publish) {
+    if (stored && plan.publish) {
       deps.publish(deps.sessionChannel(plan.sessionId), plan.stored);
       console.log(`[gui] toolResult ${plan.toolName} for ${plan.sessionId}`);
     }

--- a/server/session/tool-store.ts
+++ b/server/session/tool-store.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import { messageOf } from "../errors.js";
 import type { ToolCall, ToolResult } from "./types.js";
+import { reconcileCollectionCard } from "../../common/collectionSeed.js";
 
 export interface ToolStoreDeps {
   /** Fan a change out to the panel; a no-op before pub/sub exists. */
@@ -157,8 +158,18 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
   // Upsert a toolResult into a session's list, deduped by uuid — a re-emitted result
   // (e.g. a form whose viewState changed after the user submitted) updates in place.
   // Mirrors MulmoClaude's applyToolResultToSession.
-  async function storeToolResult(sessionId: string, result: ToolResult) {
+  //
+  // Returns whether it was stored. A browser-seeded collection placeholder is DROPPED when the
+  // agent's real card for that collection is already here (see reconcileCollectionCard) — uuid
+  // dedupe cannot catch that pair, because the two arrive with different uuids from different
+  // writers. The caller needs the answer so a result that was not stored is not published either.
+  async function storeToolResult(sessionId: string, result: ToolResult): Promise<boolean> {
     const list = await toolResultsStore.get(sessionId);
+    if (reconcileCollectionCard(list, result) === "skip") {
+      // The list may still have changed above; save so a supersede is not lost on restart.
+      toolResultsStore.save(sessionId);
+      return false;
+    }
     const idx = list.findIndex((r) => r.uuid === result.uuid);
     if (idx >= 0) {
       list[idx] = result;
@@ -167,6 +178,7 @@ export function createToolStores({ publish, root = MULMOTERMINAL_HOME }: ToolSto
       if (list.length > GUI_HISTORY_LIMIT) list.splice(0, list.length - GUI_HISTORY_LIMIT);
     }
     toolResultsStore.save(sessionId);
+    return true;
   }
 
   // Per-session tool-call history, published on a per-session channel the tools pane

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -505,10 +505,14 @@ function launchSkill(skill: BundledSkillName) {
   void startCollectionChat(skillSeed(skill, "claude"));
 }
 
+// The grid component itself, for the one thing GridView drives that is not cell state: revealing
+// a placed chat's Canvas (see placeChat).
+const gridRef = ref<InstanceType<typeof TerminalGrid> | null>(null);
+
 // Place an already-spawned chat as a cell. Every programmatically started chat arrives here —
 // the collection UI's actions and template cards, custom views, the Settings skill buttons —
 // via useChatLauncher's one choke point.
-const placeChat = ({ id, agent, draft }: SpawnedChatRequest) => {
+const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest) => {
   // Seeded with the directory the server spawns these in (CLAUDE_CWD, which /api/config reports as
   // `cwd`); the cell adopts whatever the PTY reports anyway. sessionCell carries the agent, which
   // matters because a spawn follows the Claude/Codex/Antigravity toggle.
@@ -523,8 +527,21 @@ const placeChat = ({ id, agent, draft }: SpawnedChatRequest) => {
   // dropping the flag here would make a full grid the one case where startNewChatDraft looks like
   // a turn already running. The CELL needs no such flag — the server types the draft into the PTY,
   // so the terminal shows it either way; the hint is a single-view affordance.
-  if (placed === state.value) showSpawnedSession({ id, agent, draft });
-  else state.value = placed;
+  if (placed === state.value) {
+    showSpawnedSession({ id, agent, draft });
+    return;
+  }
+  state.value = placed;
+  // A collection is already waiting in this session's Canvas. The pane exists only beside an
+  // ENLARGED cell, so a card in a tiled one is two gestures away and invisible until both are
+  // made — which is how a seeded collection reads as a feature that does nothing. Reuses the
+  // grid's own reveal (files-buffer flush included) rather than setting the two pieces of state
+  // from here. Deliberately NOT done for an unseeded spawn: taking the screen to show an empty
+  // pane is worse than leaving the grid as the user arranged it.
+  if (!canvas) return;
+  const uid = placed.cells.find((cell) => cell.session === id)?.uid;
+  // After the state renders: the grid has to be showing the cell before it can enlarge it.
+  if (uid !== undefined) void nextTick(() => gridRef.value?.openCanvasFor(uid));
 };
 // Registered on the same activate/deactivate cycle as the new-terminal opener, and for the same
 // reason: <KeepAlive> keeps this grid alive while the user is in the single view, and a chat
@@ -568,6 +585,7 @@ onBeforeUnmount(detachSpawnedChat);
       </button>
     </nav>
     <TerminalGrid
+      ref="gridRef"
       class="flex-1 min-h-0 min-w-0"
       :cells="displayCells"
       :expanded-uid="expandedUid"

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -5,6 +5,7 @@ import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
 import { getPlugin } from "../plugins-registry";
 import PluginFrame from "./PluginFrame.vue";
 import { TOOL_GROUPS, groupOfTool, toolsInGroup } from "../../common/toolGroups";
+import { reconcileCollectionCard } from "../../common/collectionSeed";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -43,6 +44,11 @@ const { upsert } = useSessionFeed(results, {
   historyKey: "toolResults",
   channel: (id) => `session:${id}`,
   identify: (result) => result.uuid,
+  // The one pair uuid dedupe cannot relate: a collection placeholder seeded by the browser at
+  // spawn, and the agent's own presentCollection card for the same collection. Different writers,
+  // different uuids, one thing on screen — the real card wins. The server applies the same rule to
+  // what it stores, so a reload agrees with what is here now.
+  reconcile: (list, incoming) => reconcileCollectionCard(list, incoming),
   // Drop the previous session's views the moment the session changes, rather than when its
   // replacement's history arrives: until then the panel would still be showing another cell's
   // drawings under this cell's name.

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -225,11 +225,21 @@ async function toggleFiles(): Promise<void> {
 // The unread-canvas chip on a tiled cell: enlarge that cell AND put the pane beside it, in one
 // click. Two steps because the pane only exists while a cell is enlarged — asking the user to
 // expand first and then find the button is the gesture this chip exists to remove.
+//
+// Also exposed (below) for a chat placed with a collection already seeded into its Canvas: same
+// two steps, same reason, just nobody clicking. It stays ONE function because "reveal this cell's
+// canvas" has to mean the same thing however it is reached — including the files-buffer flush,
+// which a second implementation would be the natural place to forget.
 async function openCanvasFor(uid: number): Promise<void> {
   if (filesOpen.value && (await filesPane.value?.flush()) === false) return;
   if (props.expandedUid !== uid) emit("toggle-expand", uid);
   setRightPane("canvas");
 }
+
+// GridView drives this one from OUTSIDE a user gesture (placing a spawned chat whose Canvas is
+// already seeded). The pane is TerminalGrid's own state — GridView owns the cells, not what sits
+// beside them — so this is the seam rather than another prop to watch.
+defineExpose({ openCanvasFor });
 
 // A pane button: opens its pane, or closes it when it is already the one showing.
 async function toggleRightPane(pane: RightPane): Promise<void> {

--- a/src/composables/seedCollectionCanvas.ts
+++ b/src/composables/seedCollectionCanvas.ts
@@ -1,0 +1,67 @@
+// Show the collection in the new chat's Canvas the moment the chat is placed, instead of an empty
+// pane for as long as the agent takes to boot and call presentCollection itself. The card is a
+// placeholder with the same render contract as the real one — the View self-fetches from the slug
+// — and the agent's own result supersedes it (see common/collectionSeed.ts).
+//
+// MulmoClaude's counterpart is `seedCollectionPresentation` in its App.vue (#1768). The subject
+// comes from the SEED PROMPT rather than from whatever screen the user was on, which is what makes
+// it work here: placing a spawned chat can navigate to /terminals, and useCollectionBrowse drops
+// the open record on any path change — so route-derived state is already gone by the time a spawn
+// resolves. The prompt travels with the chat.
+import { parseCollectionSlashSeed, makeSyntheticCollectionResult } from "../../common/collectionSeed";
+
+interface CollectionsListResponse {
+  collections?: { slug?: unknown }[];
+}
+
+/** Does `slug` name a real collection? Asked before seeding so a NON-collection slash command
+ *  (`/deep-research`, a typo) does not flash a "collection not found" card. A failed request
+ *  answers no: the agent still presents the collection a moment later, so the cost of skipping is
+ *  a slower first paint, while the cost of guessing wrong is a visible error. */
+async function isKnownCollection(slug: string): Promise<boolean> {
+  try {
+    const res = await fetch("/api/collections/list");
+    if (!res.ok) return false;
+    const body = (await res.json()) as CollectionsListResponse;
+    return Array.isArray(body.collections) && body.collections.some((entry) => entry?.slug === slug);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Seed `sessionId`'s Canvas with the collection `prompt` addresses, if it addresses one.
+ *
+ * No-op for every other kind of chat, and that is the point of parsing the prompt rather than
+ * branching per caller: a feed's seed is prose, and the collections index, the new-collection
+ * template cards, the Settings skill buttons and cron all send no slash command at all.
+ *
+ * Returns whether a card was seeded. The caller needs the answer to decide whether to REVEAL the
+ * Canvas: enlarging a cell and opening the pane is right when there is a collection waiting in it
+ * and intrusive when there is not, and this is the only place that knows which.
+ *
+ * A failure costs the head start and nothing else — the agent presents the collection itself a
+ * moment later — so it is logged and reported as "not seeded" rather than surfaced.
+ */
+export async function seedCollectionCanvas(sessionId: string, prompt: string): Promise<boolean> {
+  const seed = parseCollectionSlashSeed(prompt);
+  if (!seed) return false;
+  if (!(await isKnownCollection(seed.slug))) return false;
+  // The race where the agent's real card beats this one is settled SERVER-side, in
+  // storeToolResult: it holds the list both writers append to, so it is the only place that can
+  // compare them without a check-then-act gap. MulmoClaude asks its own session first because its
+  // results live in the browser.
+  const card = makeSyntheticCollectionResult(crypto.randomUUID(), seed.slug, seed.itemId);
+  try {
+    const res = await fetch("/api/agent/toolResult", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...card, sessionId }),
+    });
+    if (res.ok) return true;
+    console.error(`[seedCollectionCanvas] HTTP ${res.status}`);
+  } catch (err) {
+    console.error("[seedCollectionCanvas] failed", err);
+  }
+  return false;
+}

--- a/src/composables/useChatLauncher.ts
+++ b/src/composables/useChatLauncher.ts
@@ -21,6 +21,7 @@
 import { ref, watch } from "vue";
 import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
 import { placeSpawnedChat } from "./useSpawnedChat";
+import { seedCollectionCanvas } from "./seedCollectionCanvas";
 
 export type Agent = TerminalAgent;
 type OpenSessionFn = (sessionId: string, opts?: { draft?: boolean; agent?: Agent }) => void;
@@ -93,7 +94,14 @@ export async function startCollectionChat(prompt: string, opts: { hidden?: boole
   // hidden=false → place the new session as a grid cell (as the right agent), navigating there
   // if the user is somewhere else. `draft` travels along: the cell must show a prompt waiting in
   // the input box rather than treat it as a turn already running.
-  if (chatId && !opts.hidden) placeSpawnedChat({ id: chatId, agent, draft });
+  if (chatId && !opts.hidden) {
+    // Seeded BEFORE placing, and awaited, so the cell can arrive with its Canvas already open
+    // rather than rearranging itself under the user a moment later. Both are local requests
+    // against a session that already exists. Seeded here for the SAME reason placement is —
+    // every collection entry point passes through this one function.
+    const canvas = await seedCollectionCanvas(chatId, message);
+    placeSpawnedChat({ id: chatId, agent, draft, canvas });
+  }
   // `agent` is what the route was ASKED for, and the route echoes it back in jsonData — so this is
   // the agent the PTY actually runs, not a second reading of the toggle.
   return chatId ? { id: chatId, agent } : null;

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -21,7 +21,26 @@ interface SessionFeedOptions<T> {
    * by different sources and so never share a uuid. The server applies the same rule to what it
    * stores; this is the live half, for the panel already on screen.
    */
-  reconcile?: (items: T[], incoming: T) => "store" | "skip";
+  reconcile?: Reconcile<T>;
+}
+
+type Reconcile<T> = (items: T[], incoming: T) => "store" | "skip";
+
+/**
+ * A fetched snapshot plus what arrived while it was in flight, with any `reconcile` rule applied.
+ *
+ * The identity merge alone is not enough once a rule is in play: the pair it relates has two
+ * different identities, so the merge can put back an item the live path already superseded — and
+ * the mirror case is just as real, a snapshot READ before the newer item was stored still holding
+ * the one it replaces. Replaying the rule over the merged list, in arrival order, is the same fold
+ * the live path does one item at a time, so both directions settle to the same answer.
+ */
+function mergeSettled<T>(snapshot: readonly T[], buffered: readonly T[], identify: (item: T) => string | undefined, reconcile?: Reconcile<T>): T[] {
+  const merged = mergeLiveIntoSnapshot(snapshot, buffered, identify);
+  if (!reconcile) return merged;
+  const settled: T[] = [];
+  for (const item of merged) if (reconcile(settled, item) === "store") settled.push(item);
+  return settled;
 }
 
 export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T>) {
@@ -37,15 +56,15 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
   let latestLoad = 0;
 
   function upsert(item: T) {
-    if (loadingSession !== null) arrivedDuringLoad.push(item);
-    if (reconcile) {
-      // Over a copy, assigned back: the callback removes what `item` supersedes, and a splice on
-      // the ref's own array would leave the list mutated whether or not the item is then stored.
-      const next = [...items.value];
-      const verdict = reconcile(next, item);
-      items.value = next;
-      if (verdict === "skip") return;
-    }
+    // Over a copy, assigned back: the callback removes what `item` supersedes, and a splice on the
+    // ref's own array would leave the list mutated whether or not the item is then stored.
+    const next = reconcile ? [...items.value] : items.value;
+    const verdict = reconcile ? reconcile(next, item) : "store";
+    items.value = next;
+    // Buffered only if it survived: the buffer is replayed when the history lands, so an item
+    // dropped here and left in it would come straight back (Codex, PR #1186).
+    if (loadingSession !== null && verdict === "store") arrivedDuringLoad.push(item);
+    if (verdict === "skip") return;
     const id = identify(item);
     const index = id === undefined ? -1 : items.value.findIndex((existing) => identify(existing) === id);
     if (index >= 0) items.value[index] = item;
@@ -65,10 +84,10 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       if (overtaken()) return;
-      items.value = mergeLiveIntoSnapshot(data[historyKey] ?? [], arrivedDuringLoad, identify);
+      items.value = mergeSettled(data[historyKey] ?? [], arrivedDuringLoad, identify, reconcile);
     } catch {
       // A failed history read must not take the live events with it.
-      if (!overtaken()) items.value = mergeLiveIntoSnapshot([], arrivedDuringLoad, identify);
+      if (!overtaken()) items.value = mergeSettled([], arrivedDuringLoad, identify, reconcile);
     } finally {
       // Only if a newer load has not already taken over the tracking. Comparing the load,
       // not the session id: switching back gives the newer load the same id as this one.

--- a/src/composables/useSessionFeed.ts
+++ b/src/composables/useSessionFeed.ts
@@ -12,10 +12,20 @@ interface SessionFeedOptions<T> {
   channel: (id: string) => string;
   identify: (item: T) => string | undefined;
   onSessionChange?: () => void;
+  /**
+   * Fold an arriving item into the list by something OTHER than its identity, before the dedupe
+   * below runs. Return "skip" to drop it; mutate `items` to remove what it supersedes.
+   *
+   * Exists for a pair the identity cannot relate: a browser-seeded collection placeholder and the
+   * agent's real card for the same collection are one thing rendered twice, but they are written
+   * by different sources and so never share a uuid. The server applies the same rule to what it
+   * stores; this is the live half, for the panel already on screen.
+   */
+  reconcile?: (items: T[], incoming: T) => "store" | "skip";
 }
 
 export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T>) {
-  const { sessionId, historyUrl, historyKey, channel, identify, onSessionChange } = options;
+  const { sessionId, historyUrl, historyKey, channel, identify, onSessionChange, reconcile } = options;
 
   // What the live channel delivered while a history request was in flight. The response is
   // authoritative as of when it was SENT, so these have to survive it (#620 F1).
@@ -28,6 +38,14 @@ export function useSessionFeed<T>(items: Ref<T[]>, options: SessionFeedOptions<T
 
   function upsert(item: T) {
     if (loadingSession !== null) arrivedDuringLoad.push(item);
+    if (reconcile) {
+      // Over a copy, assigned back: the callback removes what `item` supersedes, and a splice on
+      // the ref's own array would leave the list mutated whether or not the item is then stored.
+      const next = [...items.value];
+      const verdict = reconcile(next, item);
+      items.value = next;
+      if (verdict === "skip") return;
+    }
     const id = identify(item);
     const index = id === undefined ? -1 : items.value.findIndex((existing) => identify(existing) === id);
     if (index >= 0) items.value[index] = item;

--- a/src/composables/useSpawnedChat.ts
+++ b/src/composables/useSpawnedChat.ts
@@ -27,6 +27,11 @@ export interface SpawnedChatRequest {
   /** The prompt was typed into the input box without an Enter (spawnBackgroundChat draft:true)
    *  and is waiting for the user to review it — not a turn already running. */
   draft: boolean;
+  /** A collection card is ALREADY waiting in this session's Canvas, so the cell should arrive
+   *  enlarged with the pane open — otherwise the card sits behind two gestures nobody knows to
+   *  make. False for every other spawn: taking over the screen to show an EMPTY pane is worse
+   *  than leaving the grid alone. */
+  canvas: boolean;
 }
 type Handler = (req: SpawnedChatRequest) => void;
 

--- a/src/composables/useSpawnedChat.ts
+++ b/src/composables/useSpawnedChat.ts
@@ -29,9 +29,13 @@ export interface SpawnedChatRequest {
   draft: boolean;
   /** A collection card is ALREADY waiting in this session's Canvas, so the cell should arrive
    *  enlarged with the pane open — otherwise the card sits behind two gestures nobody knows to
-   *  make. False for every other spawn: taking over the screen to show an EMPTY pane is worse
-   *  than leaving the grid alone. */
-  canvas: boolean;
+   *  make.
+   *
+   *  OPT-IN, not a field every caller answers: revealing is right only when something is already
+   *  in the pane, and taking over the screen to show an EMPTY one is worse than leaving the grid
+   *  as the user arranged it. A spawn with no canvas to show (an issue being started, a skill
+   *  button, cron) says nothing here and gets the grid's ordinary behaviour. */
+  canvas?: boolean;
 }
 type Handler = (req: SpawnedChatRequest) => void;
 

--- a/test/common/collectionSeed.spec.ts
+++ b/test/common/collectionSeed.spec.ts
@@ -1,0 +1,100 @@
+// Parsing a collection chat seed, and the rule that keeps a placeholder card and the agent's real
+// one from stacking. Both sides of the app decide from these, so they are pinned here once rather
+// than through either caller.
+import { describe, it, expect } from "vitest";
+import {
+  parseCollectionSlashSeed,
+  makeSyntheticCollectionResult,
+  reconcileCollectionCard,
+  isSyntheticCollection,
+  PRESENT_COLLECTION_TOOL_NAME,
+} from "../../common/collectionSeed";
+
+const real = (uuid: string, collectionSlug: string) => ({
+  uuid,
+  toolName: PRESENT_COLLECTION_TOOL_NAME,
+  data: { collectionSlug },
+});
+
+describe("parseCollectionSlashSeed", () => {
+  it("reads the collection out of a plain seed", () => {
+    expect(parseCollectionSlashSeed("/invoices summarise this quarter")).toEqual({ slug: "invoices" });
+  });
+
+  it("reads the record out of an id= seed", () => {
+    // The `id=` selector comes BEFORE the prose so the skill's parser reads it as a flag —
+    // skillCommandSeed builds it that way, and this is the half that reads it back.
+    expect(parseCollectionSlashSeed("/clients id=acme-42 fix the address")).toEqual({ slug: "clients", itemId: "acme-42" });
+  });
+
+  it("tolerates leading whitespace and a bare slug", () => {
+    expect(parseCollectionSlashSeed("   /todo")).toEqual({ slug: "todo" });
+  });
+
+  it("returns null for prose, which is how feeds and template cards seed nothing", () => {
+    // A feed's seed names a data path instead of a slash command; the index, the template cards,
+    // the Settings skill buttons and cron send prose too. No case per caller — they all land here.
+    expect(parseCollectionSlashSeed("Look at data/feeds/news and tell me what changed")).toBeNull();
+    expect(parseCollectionSlashSeed("")).toBeNull();
+  });
+
+  it("refuses a path-like slug, so a file path is never mistaken for a collection", () => {
+    expect(parseCollectionSlashSeed("/Users/me/notes.md what is this")).toBeNull();
+    expect(parseCollectionSlashSeed("/ leading space then prose")).toBeNull();
+  });
+});
+
+describe("makeSyntheticCollectionResult", () => {
+  it("carries only the addressing — the View self-fetches from the slug", () => {
+    const card = makeSyntheticCollectionResult("u-1", "invoices", "inv-9");
+    expect(card.toolName).toBe(PRESENT_COLLECTION_TOOL_NAME);
+    // Both fields: the panel reads `data`, and a partial view-state update may carry only jsonData.
+    expect(card.data).toEqual({ collectionSlug: "invoices", itemId: "inv-9" });
+    expect(card.jsonData).toEqual({ collectionSlug: "invoices", itemId: "inv-9" });
+    expect(isSyntheticCollection(card)).toBe(true);
+  });
+
+  it("omits itemId entirely when the seed named no record", () => {
+    // Not `itemId: undefined` — the payload is sent as JSON and read by the shared View.
+    expect(makeSyntheticCollectionResult("u-2", "invoices").data).toEqual({ collectionSlug: "invoices" });
+  });
+});
+
+describe("reconcileCollectionCard", () => {
+  it("drops the placeholder when the agent's real card for that collection arrives", () => {
+    const list = [makeSyntheticCollectionResult("seed", "invoices")];
+    expect(reconcileCollectionCard(list, real("agent", "invoices"))).toBe("store");
+    expect(list).toEqual([]); // the real one is appended by the caller, in the placeholder's place
+  });
+
+  it("skips a placeholder that the real card has already beaten", () => {
+    // The race this exists for: our validation fetch is slower than the agent's first tool call.
+    // Storing now would leave a duplicate nothing later removes — the supersede above has already
+    // run and found nothing.
+    const list = [real("agent", "invoices")];
+    expect(reconcileCollectionCard(list, makeSyntheticCollectionResult("seed", "invoices"))).toBe("skip");
+    expect(list).toHaveLength(1);
+  });
+
+  it("leaves a placeholder for a DIFFERENT collection alone", () => {
+    const list = [makeSyntheticCollectionResult("seed", "invoices")];
+    expect(reconcileCollectionCard(list, real("agent", "clients"))).toBe("store");
+    expect(list).toHaveLength(1);
+  });
+
+  it("passes every other tool through untouched", () => {
+    // Safe to run over EVERY result, which is why the callers don't pre-filter.
+    const list = [makeSyntheticCollectionResult("seed", "invoices")];
+    expect(reconcileCollectionCard(list, { uuid: "x", toolName: "presentChart", data: { a: 1 } })).toBe("store");
+    expect(reconcileCollectionCard(list, { uuid: "y" })).toBe("store");
+    expect(list).toHaveLength(1);
+  });
+
+  it("stores two real cards for one collection rather than folding them", () => {
+    // Only the PLACEHOLDER is superseded. A second real presentCollection is the agent choosing to
+    // present again, and collapsing that would be a behaviour change nothing here asked for.
+    const list = [real("first", "invoices")];
+    expect(reconcileCollectionCard(list, real("second", "invoices"))).toBe("store");
+    expect(list).toHaveLength(1);
+  });
+});

--- a/test/server/session/tool-store.spec.ts
+++ b/test/server/session/tool-store.spec.ts
@@ -164,6 +164,42 @@ describe("createToolStores", () => {
     expect(await s.toolResultsStore.get(SESSION)).toEqual([{ uuid: "a", value: 2 }]);
   });
 
+  // The collection placeholder the browser seeds when a chat is started from a collection view, and
+  // the agent's own presentCollection card for it. Different writers, so different uuids — the
+  // dedupe above cannot relate them, and without this the cell shows the same collection twice.
+  // Settled HERE rather than in the browser because this is the list both writers append to: any
+  // client-side check has a gap between asking and posting that the agent can arrive in.
+  const seeded = (uuid: string, collectionSlug: string) => ({
+    uuid,
+    toolName: "presentCollection",
+    data: { collectionSlug },
+    syntheticCollection: true,
+  });
+  const agentCard = (uuid: string, collectionSlug: string) => ({ uuid, toolName: "presentCollection", data: { collectionSlug } });
+
+  it("replaces a seeded collection placeholder with the agent's real card", async () => {
+    const s = stores();
+    expect(await s.storeToolResult(SESSION, seeded("seed", "invoices"))).toBe(true);
+    expect(await s.storeToolResult(SESSION, agentCard("agent", "invoices"))).toBe(true);
+    expect(await s.toolResultsStore.get(SESSION)).toEqual([agentCard("agent", "invoices")]);
+  });
+
+  // The other order, which is the race: our validation fetch resolves after the agent has already
+  // presented. Storing the placeholder now would leave a duplicate that nothing later removes.
+  it("drops a placeholder the agent's real card has already beaten, and says it did not store it", async () => {
+    const s = stores();
+    await s.storeToolResult(SESSION, agentCard("agent", "invoices"));
+    expect(await s.storeToolResult(SESSION, seeded("seed", "invoices"))).toBe(false);
+    expect(await s.toolResultsStore.get(SESSION)).toEqual([agentCard("agent", "invoices")]);
+  });
+
+  it("leaves a placeholder for a different collection alone", async () => {
+    const s = stores();
+    await s.storeToolResult(SESSION, seeded("seed", "invoices"));
+    await s.storeToolResult(SESSION, agentCard("agent", "clients"));
+    expect((await s.toolResultsStore.get(SESSION)).map((r) => r.uuid)).toEqual(["seed", "agent"]);
+  });
+
   it("caps the result history at 50, keeping the newest", async () => {
     const s = stores();
     for (let i = 0; i < 55; i++) await s.storeToolResult(SESSION, { uuid: `u${i}` });

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -528,6 +528,63 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
     w.unmount();
   });
 
+  // What the seeded collection is FOR: the Canvas pane exists only beside an enlarged cell, so a
+  // card placed into a tiled one is two gestures away and invisible until both are made. Reported
+  // live — the card was landing correctly and looked like a feature that did nothing.
+  it("enlarges the placed cell and opens its Canvas when a collection was seeded", async () => {
+    const { placeSpawnedChat } = await import("../../../src/composables/useSpawnedChat");
+    const opened: number[] = [];
+    const CanvasGridStub = {
+      name: "TerminalGrid",
+      props: ["cells", "expandedUid"],
+      template: '<div class="canvas-stub" />',
+      setup: (_: unknown, { expose }: { expose: (api: Record<string, unknown>) => void }) => {
+        expose({ openCanvasFor: (uid: number) => opened.push(uid) });
+        return () => {};
+      },
+    };
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CanvasGridStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+
+    placeSpawnedChat({ id: SPAWNED, agent: "claude", draft: false, canvas: true });
+    await flushPromises();
+
+    // The uid of the cell just placed for THIS session — not a guess at the counter.
+    const cells = w.findComponent(CanvasGridStub).props("cells") as Array<{ uid: number; session: string | null }>;
+    const placedUid = cells.find((c) => c.session === SPAWNED)?.uid;
+    expect(placedUid).toBeDefined();
+    expect(opened).toEqual([placedUid]);
+    w.unmount();
+  });
+
+  it("leaves the grid alone when nothing was seeded", async () => {
+    // Every other spawn — a skill button, a template card, cron. Taking over the screen to show an
+    // empty pane is worse than leaving the grid as the user arranged it.
+    const { placeSpawnedChat } = await import("../../../src/composables/useSpawnedChat");
+    const opened: number[] = [];
+    const CanvasGridStub = {
+      name: "TerminalGrid",
+      props: ["cells", "expandedUid"],
+      template: '<div class="canvas-stub" />',
+      setup: (_: unknown, { expose }: { expose: (api: Record<string, unknown>) => void }) => {
+        expose({ openCanvasFor: (uid: number) => opened.push(uid) });
+        return () => {};
+      },
+    };
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CanvasGridStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+
+    placeSpawnedChat({ id: SPAWNED, agent: "claude", draft: false, canvas: false });
+    await flushPromises();
+
+    expect(opened).toEqual([]);
+    w.unmount();
+  });
+
   // The full-grid fallback is the ONE path where `draft` still has to reach the single view, and
   // it is the easiest to drop: the cell it would otherwise have made needs no such flag (the
   // server types the draft into the PTY), so nothing else here carries one. Without it a
@@ -545,7 +602,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
 
     // Straight through the placement seam: a draft spawn is startNewChatDraft's, and going via a
     // skill button would only ever produce draft:false.
-    placeSpawnedChat({ id: SPAWNED, agent: "claude", draft: true });
+    placeSpawnedChat({ id: SPAWNED, agent: "claude", draft: true, canvas: false });
     await flushPromises();
 
     expect(openSession).toHaveBeenCalledWith(SPAWNED, expect.objectContaining({ agent: "claude", draft: true }));

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -559,9 +559,12 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
     w.unmount();
   });
 
-  it("leaves the grid alone when nothing was seeded", async () => {
-    // Every other spawn — a skill button, a template card, cron. Taking over the screen to show an
-    // empty pane is worse than leaving the grid as the user arranged it.
+  it("leaves the grid alone for a spawn that asks for no canvas", async () => {
+    // Every other spawn — a skill button, a template card, cron, an issue being started. Taking
+    // over the screen to show an empty pane is worse than leaving the grid as the user arranged it.
+    //
+    // The field is OMITTED here, not set false: `canvas` is opt-in precisely so a caller with no
+    // canvas to show says nothing. A required field broke useIssueStart the day it landed.
     const { placeSpawnedChat } = await import("../../../src/composables/useSpawnedChat");
     const opened: number[] = [];
     const CanvasGridStub = {
@@ -578,7 +581,7 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
     });
     await flushPromises();
 
-    placeSpawnedChat({ id: SPAWNED, agent: "claude", draft: false, canvas: false });
+    placeSpawnedChat({ id: SPAWNED, agent: "claude", draft: false });
     await flushPromises();
 
     expect(opened).toEqual([]);

--- a/test/src/composables/seedCollectionCanvas.spec.ts
+++ b/test/src/composables/seedCollectionCanvas.spec.ts
@@ -1,0 +1,80 @@
+// What a spawned chat seeds into its Canvas, and — more importantly — what it does NOT.
+// Every collection entry point reaches this through useChatLauncher, so a seed fired for a
+// non-collection prompt would put a "not found" card in front of a chat that never mentioned one.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { seedCollectionCanvas } from "../../../src/composables/seedCollectionCanvas";
+import { PRESENT_COLLECTION_TOOL_NAME } from "../../../common/collectionSeed";
+
+const SESSION = "11111111-1111-1111-1111-111111111111";
+
+/** Records every POSTed toolResult; `collections` is what /api/collections/list answers with. */
+function stubFetch(collections: string[], opts: { listOk?: boolean } = {}) {
+  const posted: Record<string, unknown>[] = [];
+  const fn = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes("/api/collections/list")) {
+      if (opts.listOk === false) return { ok: false, status: 500, json: async () => ({}) } as Response;
+      return { ok: true, status: 200, json: async () => ({ collections: collections.map((slug) => ({ slug })) }) } as Response;
+    }
+    if (u.includes("/api/agent/toolResult")) {
+      posted.push(JSON.parse(String(init?.body)));
+      return { ok: true, status: 200, json: async () => ({ ok: true }) } as Response;
+    }
+    throw new Error(`unexpected fetch: ${u}`);
+  });
+  vi.stubGlobal("fetch", fn);
+  return posted;
+}
+
+describe("seedCollectionCanvas", () => {
+  beforeEach(() => vi.spyOn(console, "error").mockImplementation(() => {}));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("seeds the collection a chat was started from", async () => {
+    const posted = stubFetch(["invoices"]);
+    await seedCollectionCanvas(SESSION, "/invoices summarise this quarter");
+    expect(posted).toHaveLength(1);
+    expect(posted[0]).toMatchObject({
+      sessionId: SESSION,
+      toolName: PRESENT_COLLECTION_TOOL_NAME,
+      data: { collectionSlug: "invoices" },
+      syntheticCollection: true,
+    });
+  });
+
+  it("seeds the RECORD when the chat was started from one", async () => {
+    const posted = stubFetch(["clients"]);
+    await seedCollectionCanvas(SESSION, "/clients id=acme-42 fix the address");
+    expect(posted[0]).toMatchObject({ data: { collectionSlug: "clients", itemId: "acme-42" } });
+  });
+
+  it("seeds nothing for a prompt with no slash command", async () => {
+    // The collections index, the template cards, the Settings skill buttons and cron all land here.
+    const posted = stubFetch(["invoices"]);
+    await seedCollectionCanvas(SESSION, "Set up a new collection for my invoices");
+    expect(posted).toEqual([]);
+  });
+
+  it("seeds nothing when the slug is not a collection", async () => {
+    // `/deep-research …` is a slash command for a SKILL, not a collection. Seeding it would flash
+    // a "collection not found" card in a chat that is working perfectly well.
+    const posted = stubFetch(["invoices"]);
+    await seedCollectionCanvas(SESSION, "/deep-research the market for X");
+    expect(posted).toEqual([]);
+  });
+
+  it("seeds nothing when the collection list cannot be read", async () => {
+    // Skipping costs a slower first paint — the agent presents it anyway. Guessing costs a
+    // visible error, so an unreachable list is treated as "unknown", not as "probably fine".
+    const posted = stubFetch(["invoices"], { listOk: false });
+    await seedCollectionCanvas(SESSION, "/invoices summarise this quarter");
+    expect(posted).toEqual([]);
+  });
+
+  it("gives each card its own uuid", async () => {
+    const posted = stubFetch(["invoices"]);
+    await seedCollectionCanvas(SESSION, "/invoices one");
+    await seedCollectionCanvas(SESSION, "/invoices two");
+    expect(posted[0].uuid).not.toBe(posted[1].uuid);
+  });
+});

--- a/test/src/composables/spawnedChat.spec.ts
+++ b/test/src/composables/spawnedChat.spec.ts
@@ -10,7 +10,7 @@ vi.mock("../../../src/router", () => ({ router: { push } }));
 
 import { placeSpawnedChat, registerSpawnedChatHandler, resetSpawnedChatQueue, type SpawnedChatRequest } from "../../../src/composables/useSpawnedChat";
 
-const chat = (id: string, over: Partial<SpawnedChatRequest> = {}): SpawnedChatRequest => ({ id, agent: "claude", draft: false, ...over });
+const chat = (id: string, over: Partial<SpawnedChatRequest> = {}): SpawnedChatRequest => ({ id, agent: "claude", draft: false, canvas: false, ...over });
 
 describe("placeSpawnedChat", () => {
   beforeEach(() => {

--- a/test/src/composables/useChatLauncher.spec.ts
+++ b/test/src/composables/useChatLauncher.spec.ts
@@ -40,7 +40,7 @@ describe("startCollectionChat", () => {
     expect(url).toBe("/api/plugin/spawnBackgroundChat");
     expect(init?.method).toBe("POST");
     expect(JSON.parse(String(init?.body))).toEqual({ message: "fix my records", draft: false, agent: "claude" });
-    expect(placed).toEqual([{ id: "sess-1", agent: "claude", draft: false }]);
+    expect(placed).toEqual([{ id: "sess-1", agent: "claude", draft: false, canvas: false }]);
   });
 
   it("spawns a codex chat (auto-run, draft forced off) when the launch agent is codex", async () => {
@@ -51,7 +51,7 @@ describe("startCollectionChat", () => {
 
     expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({ message: "summarize this", draft: false, agent: "codex" });
     // The agent travels with the id: the cell reconnects on codex's endpoint, not claude's.
-    expect(placed).toEqual([{ id: "cx-1", agent: "codex", draft: false }]);
+    expect(placed).toEqual([{ id: "cx-1", agent: "codex", draft: false, canvas: false }]);
   });
 
   it("sends draft:true so the prompt is prefilled but not auto-sent", async () => {
@@ -61,7 +61,34 @@ describe("startCollectionChat", () => {
 
     expect(JSON.parse(String(fetchFn.mock.calls[0][1]?.body))).toEqual({ message: "track my tasks", draft: true, agent: "claude" });
     // draft travels to the cell too: a prompt waiting in the input box, not a turn running.
-    expect(placed).toEqual([{ id: "sess-3", agent: "claude", draft: true }]);
+    expect(placed).toEqual([{ id: "sess-3", agent: "claude", draft: true, canvas: false }]);
+  });
+
+  // The Canvas is revealed only when there is something in it. That decision is made here, on the
+  // seed, and travels with the placement — the grid must not have to re-derive it from the prompt.
+  it("asks for the Canvas when the chat was started from a collection", async () => {
+    mockFetch((url) => {
+      if (url.includes("/api/collections/list")) return { ok: true, json: () => ({ collections: [{ slug: "invoices" }] }) };
+      if (url.includes("/api/agent/toolResult")) return { ok: true, json: () => ({ ok: true }) };
+      return { ok: true, json: () => ({ jsonData: { chatId: "sess-c" } }) };
+    });
+
+    await startCollectionChat("/invoices summarise this quarter");
+
+    expect(placed).toEqual([{ id: "sess-c", agent: "claude", draft: false, canvas: true }]);
+  });
+
+  it("does not ask for the Canvas when the slug is not a collection", async () => {
+    // `/deep-research …` is a SKILL's slash command. Enlarging a cell to show an empty pane takes
+    // over the screen to display nothing.
+    mockFetch((url) => {
+      if (url.includes("/api/collections/list")) return { ok: true, json: () => ({ collections: [{ slug: "invoices" }] }) };
+      return { ok: true, json: () => ({ jsonData: { chatId: "sess-d" } }) };
+    });
+
+    await startCollectionChat("/deep-research the market for X");
+
+    expect(placed).toEqual([{ id: "sess-d", agent: "claude", draft: false, canvas: false }]);
   });
 
   it("does NOT place when hidden=true (a real background worker)", async () => {

--- a/test/src/composables/useSessionFeed.spec.ts
+++ b/test/src/composables/useSessionFeed.spec.ts
@@ -24,7 +24,7 @@ interface Item {
 }
 
 // Mount the composable with a history fetch we control the timing of.
-function mountFeed(respond: () => Promise<{ ok: boolean; json?: () => Promise<unknown> }>) {
+function mountFeed(respond: () => Promise<{ ok: boolean; json?: () => Promise<unknown> }>, reconcile?: (items: Item[], incoming: Item) => "store" | "skip") {
   const items = ref<Item[]>([]);
   const sessionId = ref<string | null>("s1");
   vi.stubGlobal("fetch", vi.fn().mockImplementation(respond));
@@ -37,6 +37,7 @@ function mountFeed(respond: () => Promise<{ ok: boolean; json?: () => Promise<un
           historyKey: "items",
           channel: (id) => `feed:${id}`,
           identify: (item) => item.id,
+          ...(reconcile ? { reconcile } : {}),
         });
         return () => h("div");
       },
@@ -128,5 +129,44 @@ describe("useSessionFeed — overlapping loads for the same session", () => {
     gates[0]?.(); // the stale one, arriving last
     await flushPromises();
     expect(items.value.map((item) => item.id)).toEqual(["new"]);
+  });
+});
+
+// The `reconcile` seam, added for the collection placeholder: a pair the identity cannot
+// relate — the card the browser seeds at spawn and the agent's own card for the same
+// collection — where the second must REPLACE the first rather than sit beside it.
+describe("useSessionFeed — reconcile", () => {
+  // Stand-in for reconcileCollectionCard, spelled in this spec's own Item shape: text is the
+  // subject, and a "seed:" id marks the placeholder.
+  const supersede = (items: Item[], incoming: Item): "store" | "skip" => {
+    const same = (candidate: Item) => candidate.text === incoming.text;
+    if (incoming.id.startsWith("seed:")) return items.some((candidate) => same(candidate) && !candidate.id.startsWith("seed:")) ? "skip" : "store";
+    const index = items.findIndex((candidate) => same(candidate) && candidate.id.startsWith("seed:"));
+    if (index >= 0) items.splice(index, 1);
+    return "store";
+  };
+
+  it("removes what an arriving item supersedes, instead of showing both", async () => {
+    const { items } = mountFeed(async () => ({ ok: true, json: async () => ({ items: [{ id: "seed:1", text: "invoices" }] }) }), supersede);
+    await vi.waitFor(() => expect(items.value.map((i) => i.id)).toEqual(["seed:1"]));
+
+    deliver("feed:s1", { id: "agent", text: "invoices" });
+    expect(items.value.map((i) => i.id)).toEqual(["agent"]);
+  });
+
+  it("drops an item the callback skips, without disturbing the list", async () => {
+    const { items } = mountFeed(async () => ({ ok: true, json: async () => ({ items: [{ id: "agent", text: "invoices" }] }) }), supersede);
+    await vi.waitFor(() => expect(items.value).toHaveLength(1));
+
+    deliver("feed:s1", { id: "seed:1", text: "invoices" });
+    expect(items.value.map((i) => i.id)).toEqual(["agent"]);
+  });
+
+  it("leaves unrelated items alone", async () => {
+    const { items } = mountFeed(async () => ({ ok: true, json: async () => ({ items: [{ id: "seed:1", text: "invoices" }] }) }), supersede);
+    await vi.waitFor(() => expect(items.value).toHaveLength(1));
+
+    deliver("feed:s1", { id: "agent", text: "clients" });
+    expect(items.value.map((i) => i.id)).toEqual(["seed:1", "agent"]);
   });
 });

--- a/test/src/composables/useSessionFeed.spec.ts
+++ b/test/src/composables/useSessionFeed.spec.ts
@@ -162,6 +162,57 @@ describe("useSessionFeed — reconcile", () => {
     expect(items.value.map((i) => i.id)).toEqual(["agent"]);
   });
 
+  // Codex, on PR #1186. The buffer of live arrivals is replayed by IDENTITY once the history
+  // lands, and the pair `reconcile` relates has two different identities — so a placeholder the
+  // live path already superseded came back with the snapshot, and the cell showed two cards.
+  it("does not resurrect a superseded item when the history lands", async () => {
+    let release!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const { items } = mountFeed(() => new Promise((resolve) => (release = resolve)), supersede);
+    await nextTick();
+
+    // Both arrive while the history request is in flight — the normal case here: the panel opens
+    // as the cell is placed, and the seed and the agent land moments apart.
+    deliver("feed:s1", { id: "seed:1", text: "invoices" });
+    deliver("feed:s1", { id: "agent", text: "invoices" });
+    expect(items.value.map((i) => i.id)).toEqual(["agent"]);
+
+    release({ ok: true, json: async () => ({ items: [] }) });
+    // Flushed rather than polled: waitFor would pass on the state BEFORE the merge ran, so the
+    // resurrection this guards against would never be observed (same trap as above).
+    await flushPromises();
+    await flushPromises();
+    expect(items.value.map((i) => i.id)).toEqual(["agent"]);
+  });
+
+  it("drops a placeholder the SNAPSHOT still holds when the real one arrived live", async () => {
+    // The mirror case: the history was read before the real card was stored, so the SNAPSHOT is
+    // the stale one. Merging by identity keeps both; the rule has to run over the merge.
+    let release!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const { items } = mountFeed(() => new Promise((resolve) => (release = resolve)), supersede);
+    await nextTick();
+
+    deliver("feed:s1", { id: "agent", text: "invoices" });
+    release({ ok: true, json: async () => ({ items: [{ id: "seed:1", text: "invoices" }] }) });
+    await flushPromises();
+    await flushPromises();
+
+    expect(items.value.map((i) => i.id)).toEqual(["agent"]);
+  });
+
+  it("keeps a skipped item out of the replay too", async () => {
+    let release!: (value: { ok: boolean; json: () => Promise<unknown> }) => void;
+    const { items } = mountFeed(() => new Promise((resolve) => (release = resolve)), supersede);
+    await nextTick();
+
+    deliver("feed:s1", { id: "agent", text: "invoices" });
+    deliver("feed:s1", { id: "seed:1", text: "invoices" }); // skipped: the real card is already up
+    release({ ok: true, json: async () => ({ items: [] }) });
+    await flushPromises();
+    await flushPromises();
+
+    expect(items.value.map((i) => i.id)).toEqual(["agent"]);
+  });
+
   it("leaves unrelated items alone", async () => {
     const { items } = mountFeed(async () => ({ ok: true, json: async () => ({ items: [{ id: "seed:1", text: "invoices" }] }) }), supersede);
     await vi.waitFor(() => expect(items.value).toHaveLength(1));


### PR DESCRIPTION
単一ターミナルビュー廃止の続き（#1167 に続く PR3a-2）。コレクションのビューから始めたチャットが、その**コレクションを最初から Canvas に出した状態**でグリッドに現れるようにする。

設計ノートは `plans/feat-remove-single-view.md` の PR3a-2 節（この PR で書き直した。理由は下記）。

## なぜ

#1167 でコレクション UI から始めたチャットはグリッドに着地するようになったが、Canvas は空だった。ユーザーは何かを見ていて、その対象こそが文脈なので、エージェントが起動して `presentCollection` を呼ぶまでの往復の間だけ空白にする理由がない。

## 1. シードのプロンプトから対象を取る

**当初の計画（ルート状態を読む）は捨てた。** MulmoClaude が同じ機能を既に持っていて（#1768、`../mulmoclaude/src/utils/collections/presentSeed.ts`）、そちらは**プロンプト**から取る。こちらの実装では、それが単に良いのではなく**必要**だった:

- `placeSpawnedChat` はグリッドが mount されていなければ `/terminals` へ遷移し、`useCollectionBrowse.ts:34` の watcher は path が変わると開いているレコードを捨てる。spawn が解決する頃にはルート由来の情報は既に消えている。プロンプトはチャットと一緒に移動する。
- 読むべきルートが無い経路（カスタムビューの iframe、テンプレートカード）も同じ 1 つの規則で覆える。
- エージェントが実際に作用するのはそのプロンプトなので、同じ文字列をパースする限り対象がずれない。

コレクションはスキルなので、共有の `CollectionView.buildChatSeed` が `/<slug> …`（レコードなら `/<slug> id=<itemId> …`）を作る。

| 起点 | シードのプロンプト | Canvas |
|---|---|---|
| コレクションのレコード | `/<slug> id=<itemId> …` | そのレコード |
| コレクション | `/<slug> …` | そのコレクション |
| フィード | データパスを示す prose | 出さない |
| インデックス / テンプレートカード / スキルボタン / cron | スラッシュコマンド無し | 出さない |

**「対象なし」は呼び出し元ごとの分岐ではなくパースの結果として出る。** 表の下 2 行は規則ではなく帰結。

ペイロードは `{ collectionSlug, itemId? }` だけ（View が slug から自分で fetch する）。型とツール名は既に依存している `@mulmoclaude/core/collection` から取るので**上流の変更は不要**。スラッシュコマンドが実在のコレクションを指すかは投入前に検証する（`/deep-research …` で "not found" のカードを一瞬出さないため）。

## 2. MulmoClaude と分かれるところ

あちらは tool result をブラウザ内の `ActiveSession` に持ち `eventDispatch` で突き合わせる。こちらは**サーバ側**の `toolResultsStore` に持ち uuid で dedupe する。プレースホルダと本物は書き手が違うので uuid が異なり、dedupe では関係づけられない。したがって:

- **突き合わせは `storeToolResult` に置いた。** 両方の書き手が append する list を持つのはここだけで、クライアント側のチェックは「尋ねてから POST するまで」の隙間にエージェントが割り込める。両方向を扱う（本物が来たらプレースホルダを落とす / 本物が既にあればプレースホルダを捨てる）。
- **画面に出ている分は別に必要**なので `useSessionFeed` に `reconcile` を足した。サーバは reload 後に replay される内容、パネルは今表示されている内容を受け持つ。
- **`storeToolResult` は保存したかを返す。** 保存しなかった結果を publish すると、reload では戻ってこないカードをパネルが描く。

判定そのもの（`reconcileCollectionCard`）は `common/collectionSeed.ts` に置いた。両側が同じ判断をするため — 「何が synthetic か」の写しが 2 つあるのは、このディレクトリが防ぐために存在する drift そのもの。

## 3. 拡大 + Canvas 選択を自動で

**実機で確認して判明した:** カードは正しく置かれていたが、グリッドが既に "Expand" で、かつ Canvas が既に選ばれている場合にしか見えなかった。Canvas ペインは拡大されたセルの横にしか存在しないので、タイル表示のセルのカードは 2 つの操作の向こう側にある。

グリッドには既にこの操作が 1 つの関数としてある: `openCanvasFor(uid)`（タイル表示セルの未読 Canvas チップ用 — セルを拡大し、同時にペインを開く）。`expanded` と `rightPane` を GridView から個別に触るのではなく、これを `defineExpose` して呼ぶ。「このセルの Canvas を出す」はどこから来ても同じ意味であるべきで、**files バッファの flush** はまさに 2 つ目の実装が忘れる場所だから。

**開くのは実際にシードしたときだけ。** `seedCollectionCanvas` がシードしたかを返し、その答えが配置リクエストの `canvas` として運ばれる。スキルボタン / テンプレートカード / cron は開かない — 空のペインを出すために画面を占有するのは、グリッドをユーザーが並べたままにしておくより悪い。

シードは配置の**前**に移して await する。セルが現れてから一拍おいて並び替わるのではなく、最初から拡大 + ペインを開いた状態で現れる。

## 通常のグリッドセルへの影響

無い。シードは `useChatLauncher` を通るチャット（= プログラムから起動したもの）だけで、`reconcileCollectionCard` は presentCollection 以外を素通しする。`useSessionFeed` の `reconcile` は任意で、渡しているのは `GuiPanel` だけ。

## 計画の修正

`plans/feat-remove-single-view.md` の PR3a-2 節を書き直した。ブロッカーは 2 つとも解消:

1. `presentCollection` が `data` グループである件 → #1167 で解決済み（ゲートではなく事実の記録側が誤っていた）。
2. **「レンダラがグリッド経路に mount されているか」→ 既にされていた。** グリッドの Canvas は単一ビューと**同じ** `GuiPanel`（`TerminalGrid.vue:849` と `App.vue:398`）で、`GuiPanel` は `sessionId` しか受け取らず、コレクションエンジンは `main.ts:6` が起動時に一度設定する。グリッド固有の経路は存在しない。

## 確認したこと

- `yarn test` 464 files / 6828 tests 全通過（+86）
- `yarn typecheck` / `yarn typecheck:test` / `yarn typecheck:server` 全通過
- `yarn lint` エラー 0（既存の max-lines 警告 5 件のみ）、`yarn build` 成功
- 拡大 + Canvas のテストは、reveal の 1 行を潰すと落ちることを確認済み（stub が呼ばれずに通るだけのテストになっていないこと自体を確認した）

**未確認:** 実機での見え方。テストが示すのは `openCanvasFor` が正しい uid で呼ばれることまでで、画面上で正しく見えるかは別。反映には `yarn build` とサーバ再起動が要る。

Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collection slash commands now seed Canvas chats with an initial collection card.
  * Seeded collection chats automatically open their Canvas pane when placed in the grid.
  * Placeholder collection cards are replaced by the corresponding real results when available.

* **Bug Fixes**
  * Prevented duplicate or outdated collection cards from appearing during result updates.
  * Suppressed publication of tool results that were discarded during reconciliation.

* **Tests**
  * Added coverage for collection seeding, Canvas placement, card reconciliation, and related chat behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->