### PR TITLE
feat: give a grid cell in the workspace the full GUI MCP

### DIFF
--- a/plans/feat-remove-single-view.md
+++ b/plans/feat-remove-single-view.md
@@ -162,6 +162,32 @@ Pure deletion, independent of everything else, no user-visible change with the f
   are documented, so README / docs guide / `mulmoterminal-model` + `-bug-report` skills need the
   same sweep. Removing a documented env var is a changelog line.
 
+### PR2 — the workspace cell gets the full GUI MCP — **DONE**
+
+Implemented as described below, with three changes to what was planned:
+
+1. **The wire flag was NOT renamed.** `attachGuiMcp` keeps its name and its meaning ("not a grid
+   cell"); the derivation is a named, exported predicate instead —
+   `carriesFullGuiMcp(attachGuiMcp, cwd)` in `spawn-claude.ts`. Exported so the invariant is
+   assertable: `test/server/session/full-gui-mcp.spec.ts` pins that a project-directory cell is
+   false. A rename would have touched the codex and antigravity paths for no behaviour change.
+2. **`--strict-mcp-config` stays on for the workspace cell**, which means its directory's OWN
+   `.mcp.json` servers do not load there — the single view's behaviour exactly. This is the one
+   real trade in PR2 and it was not called out in the original plan. It is right because the
+   point is parity with the view being deleted, and because dropping strict would double-register
+   the GUI MCP for a workspace directory that had also registered group URLs: the agent would see
+   `mcp__mulmoterminal-gui__presentChart` AND `mcp__mulmoterminal-render__presentChart`.
+3. **codex and antigravity are deliberately left grid-only**, with the reason in a comment at
+   `spawn-codex.ts`. The rule exists to make a workspace cell equivalent to the SINGLE VIEW, and
+   the single view only ever ran claude — so there is no codex behaviour to preserve, and applying
+   it would be a new capability rather than a migrated one.
+
+Confirmed rather than assumed: the per-session MCP config file is already reaped for every kind of
+session — `cleanupSessionSettings` removes it and runs from `lifecycle.ts` reap plus the boot
+sweep, so the extra files a workspace cell now writes need no new cleanup.
+
+---
+
 ### PR2 — the workspace cell gets the full GUI MCP
 
 Small and server-side. The wire flag keeps its current meaning; what changes is that the MCP

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -1,6 +1,7 @@
 // Process-wide settings read from the environment. Their own module because the session
 // registry persists under MULMOTERMINAL_HOME and validates ids with SESSION_ID_RE — taking
 // them from index.ts would make the registry import its own importer.
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -34,6 +35,35 @@ export const BIND_HOST = process.env.MULMOTERMINAL_HOST || "127.0.0.1";
 // The workspace used as the PTY cwd and as the root for persisted session state. index.ts
 // creates it at boot before anything spawns into it.
 export const CLAUDE_CWD = process.env.CLAUDE_CWD || path.join(os.homedir(), "mulmoclaude");
+
+/**
+ * Is this session running IN the workspace itself, rather than in some project directory?
+ *
+ * The one place that answers it, because each of the three rules below is a way for a feature
+ * gated on this to silently not turn on — and a second implementation would get a different one
+ * of them wrong.
+ *
+ *   - An ABSENT cwd is the workspace. The launch form's blank field means "the server's default"
+ *     (CellLaunchForm.vue), and spawnClaudePty defaults `cwd = CLAUDE_CWD`; a cell that never
+ *     named a directory must match.
+ *   - CANONICALISE first. The cwd arrives from a `?cwd=` query built out of a user preset, so a
+ *     trailing slash, a `..` and above all a SYMLINK are all ordinary — a `~/mulmoclaude` that is
+ *     a symlink is normal on a dev machine. A path that does not exist falls back to a normalised
+ *     string compare rather than throwing: a directory that is gone is a spawn failure, and it is
+ *     reported as one elsewhere, not swallowed here.
+ *   - EQUALITY, not prefix. `{workspace}/foo` is an ordinary project directory.
+ */
+export function isWorkspaceCwd(cwd: string | undefined): boolean {
+  const resolve = (target: string): string => {
+    try {
+      return fs.realpathSync(target);
+    } catch {
+      return path.resolve(target);
+    }
+  };
+  if (!cwd) return true;
+  return resolve(cwd) === resolve(CLAUDE_CWD);
+}
 
 // MulmoTerminal's own per-session GUI state (tool-result render data + tool-call history)
 // lives here, keyed by sessionId (a global UUID) — NOT under the workspace dir, so it stays

--- a/server/session/spawn-claude.ts
+++ b/server/session/spawn-claude.ts
@@ -2,7 +2,7 @@
 // piece of index.ts (#548 step 3c): it spans the sandbox decision, the CLI args, the
 // sidebar's optimistic row, the draft typed into the input box, and teardown on exit.
 import type { WebSocket } from "ws";
-import { CLAUDE_CWD, PORT } from "../config/env.js";
+import { CLAUDE_CWD, PORT, isWorkspaceCwd } from "../config/env.js";
 import { guiMcpEnv } from "./mcp-config.js";
 import { getUserMcpServers, getPrWorkdirFooter, getAppendSystemPrompt, getTerminalSubmit } from "../config/config-routes.js";
 import { submitSequenceForAgent } from "../../common/terminalSubmit.js";
@@ -33,6 +33,9 @@ export interface SpawnClaudeOptions {
   // opens it. Mutually exclusive with `draft`.
   initialPrompt?: string;
   cwd?: string;
+  /** NOT a grid cell — the single view, or a chat spawned with no cell of its own yet. It is one
+   *  of the two ways a session earns the full GUI MCP; the other is running in the workspace
+   *  itself, which is derived from `cwd` rather than passed (see fullGuiMcp below). */
   attachGuiMcp?: boolean;
   // Typed into the input box once claude is ready, NOT submitted — the user reviews it.
   draft?: string;
@@ -89,6 +92,35 @@ function resolveSessionBackend(input: { cwd: string; sessionId: string; launch?:
   return { dir, resolved };
 }
 
+/**
+ * The directories this session may read outside its cwd. A file dropped into the session is saved
+ * outside it, so the agent would meet a permission prompt on every Read without this. Granted at
+ * spawn rather than per drop because `--add-dir` is a spawn-time flag: a session already running
+ * cannot be given one later.
+ *
+ * Its own function for the same reason resolveSessionBackend is — the spawn body is at its line
+ * budget, and this is a value derived from two sources rather than part of spawning.
+ */
+function sessionAddDirs(sessionId: string, configured: string[] | null | undefined): string[] | null | undefined {
+  const dropsDirectory = ensureDropsDir(sessionId);
+  return dropsDirectory ? [...(configured ?? []), dropsDirectory] : configured;
+}
+
+/**
+ * Does this session carry the WHOLE GUI MCP on `--mcp-config`, the way the single view always
+ * has? Two ways to earn it, and they are different facts that used to be one flag:
+ *
+ *   `attachGuiMcp` — not a grid cell at all: the single view, or a chat spawned with no cell yet.
+ *   the CWD        — a grid cell running in the workspace itself. Starting a terminal there is
+ *                    all but the same thing as running the single view, and that equivalence is
+ *                    what lets the single view eventually go.
+ *
+ * A cell in a PROJECT directory is false on both counts and takes exactly the branch it takes
+ * today. Named and exported rather than left inline because that last sentence is the invariant
+ * this whole change is written around, and an invariant nothing can assert is just a hope.
+ */
+export const carriesFullGuiMcp = (attachGuiMcp: boolean, cwd: string | undefined): boolean => attachGuiMcp || isWorkspaceCwd(cwd);
+
 export function createClaudeSpawner(deps: SpawnDeps) {
   // Spawn a fresh claude PTY for this session, register it, and wire its output /
   // exit back to the browser socket. `ws` may be null for a session spawned without
@@ -96,9 +128,9 @@ export function createClaudeSpawner(deps: SpawnDeps) {
   // reattaches.
   function spawnClaudePty(sessionId: string, resume: string | null, ws: WebSocket | null, options: SpawnClaudeOptions = {}): PtyEntry {
     const { initialPrompt, cwd = CLAUDE_CWD, attachGuiMcp = true, draft, launch } = options;
-    // attachGuiMcp picks the MCP mode (see buildClaudeArgs): the single view (default)
-    // attaches the GUI MCP + --strict-mcp-config (main's classic behavior); the grid's
-    // dev terminals attach neither, so the user's + project's MCP servers load normally.
+    const fullGuiMcp = carriesFullGuiMcp(attachGuiMcp, cwd);
+    // fullGuiMcp picks the MCP mode (see buildClaudeArgs, and its own doc for who earns it): the
+    // GUI MCP + --strict-mcp-config; a project-directory cell attaches neither, so its own load.
     // Only --resume when the session has an on-disk transcript — claude doesn't write
     // a session's .jsonl until its first prompt, so a started-but-unused session can't
     // be resumed; we restart fresh (reusing the id via --session-id) instead.
@@ -110,17 +142,13 @@ export function createClaudeSpawner(deps: SpawnDeps) {
 
     const { dir, resolved } = resolveSessionBackend({ cwd, sessionId, launch, canResume, sandbox });
 
-    // A file dropped into this session is saved outside its cwd, so the agent would meet a
-    // permission prompt on every Read without this. Granted here rather than per drop because
-    // --add-dir is a spawn-time flag: a session already running cannot be given one later.
-    const dropsDirectory = ensureDropsDir(sessionId);
-    const addDirs = dropsDirectory ? [...(dir.addDirs ?? []), dropsDirectory] : dir.addDirs;
+    const addDirs = sessionAddDirs(sessionId, dir.addDirs);
 
     const hookSettings = deps.hookSettingsJson(sandbox ? SANDBOX_HOST : "localhost", sessionId, resolved.env);
     const mcpJson = deps.mcpConfigJson(sessionId, sandbox ? SANDBOX_HOST : "127.0.0.1", sandbox);
-    // File-ized only when it is actually passed (attachGuiMcp), so a cell that never carries
+    // File-ized only when it is actually passed (fullGuiMcp), so a cell that never carries
     // the GUI MCP leaves no file behind for reap to clean up.
-    const mcpConfig = attachGuiMcp ? mcpConfigArgument(sessionId, mcpJson) : mcpJson;
+    const mcpConfig = fullGuiMcp ? mcpConfigArgument(sessionId, mcpJson) : mcpJson;
     const args = buildClaudeArgs({
       model: resolved.model,
       sessionId,
@@ -131,15 +159,15 @@ export function createClaudeSpawner(deps: SpawnDeps) {
       // argv — see session-settings.ts.
       settings: settingsArgument(sessionId, hookSettings, Object.keys(resolved.env).length > 0),
       permissionMode: deps.permissionMode,
-      attachGuiMcp,
+      attachGuiMcp: fullGuiMcp,
       mcpConfig,
-      // Single view: auto-allow the GUI tools + the user's own configured MCP servers
-      // (mcp__<id>), so their tools don't trip a permission prompt on every call.
-      // Grid: no --mcp-config at all, so there is nothing of ours to name — except the tool
-      // GROUPS the directory may have registered itself, which we pre-approve blind
-      // (see GRID_MCP_TOOLS). The user's own servers keep their normal prompts there, since
+      // Carrying the whole GUI MCP: auto-allow the GUI tools + the user's own configured MCP
+      // servers (mcp__<id>), so their tools don't trip a permission prompt on every call.
+      // A project-directory cell: no --mcp-config at all, so there is nothing of ours to name —
+      // except the tool GROUPS the directory may have registered itself, which we pre-approve
+      // blind (see GRID_MCP_TOOLS). The user's own servers keep their normal prompts there, since
       // that path never went through our allowlist before.
-      allowedTools: attachGuiMcp ? [deps.guiMcpTools, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(",") : deps.gridMcpTools,
+      allowedTools: fullGuiMcp ? [deps.guiMcpTools, ...getUserMcpServers().map((s) => `mcp__${s.id}`)].join(",") : deps.gridMcpTools,
       addDirs,
       appendedPrompt: sessionAppendedPrompt(cwd, dir.appendSystemPrompt),
     });

--- a/server/session/spawn-codex.ts
+++ b/server/session/spawn-codex.ts
@@ -70,6 +70,13 @@ export function createCodexSpawner(deps: SpawnDeps) {
     //     read from the same config claude's own switches write (see the launcher's Canvas
     //     rows). codex cannot read that config itself, so the groups arrive resolved here.
     // A grid cell whose directory registered nothing gets no MCP at all, exactly as before.
+    //
+    // DELIBERATELY not given claude's workspace-cwd rule (carriesFullGuiMcp, PR2): a codex cell in
+    // the workspace stays on its directory's registered groups. That rule exists to make a
+    // workspace cell equivalent to the SINGLE VIEW so the single view can be deleted, and the
+    // single view only ever ran claude — so there is no codex behaviour it would be preserving,
+    // and applying it would be a new capability rather than a migrated one. Revisit if a reason
+    // turns up; it is one call to carriesFullGuiMcp with `cwd`.
     const guiMcpServers = codexGuiMcpServers({ sessionId, port: PORT, groups: mcpGroups, allTools: attachGuiMcp });
     const args = buildCodexArgs({ resume: resumeRolloutId, model: deps.codexModel, guiMcpServers });
     const { term, tmux, reattached } = ptySpawn(sessionId, deps.codexBin, args, cwd, true, { binEnvVar: codexAdapter.binEnvVar });

--- a/test/server/config/workspace-cwd.spec.ts
+++ b/test/server/config/workspace-cwd.spec.ts
@@ -1,0 +1,100 @@
+// @vitest-environment node
+// Which directory counts as THE workspace. The whole of PR2 hangs off this one predicate: answer
+// it wrongly in the false direction and the workspace cell silently behaves like an ordinary one
+// (no GUI MCP, no Canvas, and nothing anywhere says why); wrongly in the true direction and an
+// ordinary project cell quietly changes behaviour, which is the one thing this change must not do.
+import { describe, it, expect, afterAll, beforeAll, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, symlinkSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// CLAUDE_CWD is read from the environment at import time, so it is set BEFORE the import — the
+// same reason the mcp-announce spec points HOME somewhere disposable first.
+const ROOT = mkdtempSync(path.join(os.tmpdir(), "mt-workspace-"));
+const WORKSPACE = path.join(ROOT, "workspace");
+const REAL_CLAUDE_CWD = process.env.CLAUDE_CWD;
+mkdirSync(WORKSPACE, { recursive: true });
+process.env.CLAUDE_CWD = WORKSPACE;
+
+const { isWorkspaceCwd } = await import("../../../server/config/env.js");
+
+afterAll(() => {
+  if (REAL_CLAUDE_CWD === undefined) delete process.env.CLAUDE_CWD;
+  else process.env.CLAUDE_CWD = REAL_CLAUDE_CWD;
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe("isWorkspaceCwd", () => {
+  it("says yes to the workspace itself", () => {
+    expect(isWorkspaceCwd(WORKSPACE)).toBe(true);
+  });
+
+  it("says yes when no cwd was given at all", () => {
+    // The launch form's blank field means "the server's default", and spawnClaudePty defaults
+    // `cwd = CLAUDE_CWD` — so a cell that never named a directory IS in the workspace. Answering
+    // no here is the most likely way for the feature to look broken for the plainest case.
+    expect(isWorkspaceCwd(undefined)).toBe(true);
+    expect(isWorkspaceCwd("")).toBe(true);
+  });
+
+  it("says no to a project directory", () => {
+    const project = path.join(ROOT, "project");
+    mkdirSync(project, { recursive: true });
+    expect(isWorkspaceCwd(project)).toBe(false);
+  });
+
+  it("says NO to a subdirectory of the workspace — equality, not prefix", () => {
+    const inside = path.join(WORKSPACE, "foo");
+    mkdirSync(inside, { recursive: true });
+    expect(isWorkspaceCwd(inside)).toBe(false);
+  });
+
+  it("ignores a trailing slash and a `..` hop", () => {
+    // The cwd arrives from a `?cwd=` query built out of a user preset, so neither is exotic.
+    expect(isWorkspaceCwd(`${WORKSPACE}/`)).toBe(true);
+    expect(isWorkspaceCwd(path.join(WORKSPACE, "foo", ".."))).toBe(true);
+  });
+
+  it("follows a SYMLINK to the workspace", () => {
+    // The case that actually breaks on a dev machine: `~/mulmoclaude` is commonly a symlink, and a
+    // preset pointing at the link would compare unequal to the resolved CLAUDE_CWD.
+    const link = path.join(ROOT, "link-to-workspace");
+    symlinkSync(WORKSPACE, link);
+    expect(isWorkspaceCwd(link)).toBe(true);
+  });
+
+  it("falls back to a normalised compare for a path that does not exist", () => {
+    // realpath throws on a missing directory. A cell whose directory is gone fails to spawn and is
+    // reported as that — this predicate must not be where the error surfaces, nor throw inside the
+    // spawn path and take the session with it.
+    expect(() => isWorkspaceCwd(path.join(ROOT, "gone"))).not.toThrow();
+    expect(isWorkspaceCwd(path.join(ROOT, "gone"))).toBe(false);
+    expect(isWorkspaceCwd(`${WORKSPACE}/../workspace`)).toBe(true);
+  });
+});
+
+describe("isWorkspaceCwd — a workspace that is itself a symlink", () => {
+  // The mirror of the case above, and the one a string compare passes by luck: CLAUDE_CWD names
+  // the LINK while the cell names the real directory.
+  let linkedRoot: string;
+  let target: string;
+  beforeAll(() => {
+    linkedRoot = mkdtempSync(path.join(os.tmpdir(), "mt-workspace-link-"));
+    target = path.join(linkedRoot, "real");
+    mkdirSync(target, { recursive: true });
+  });
+  afterAll(() => rmSync(linkedRoot, { recursive: true, force: true }));
+
+  it("resolves both sides before comparing", async () => {
+    const link = path.join(linkedRoot, "link");
+    symlinkSync(target, link);
+    process.env.CLAUDE_CWD = link;
+    // The module reads CLAUDE_CWD once, at import — so the registry has to be dropped for the new
+    // value to be seen. A plain re-import would hand back the cached module and the assertion
+    // would pass against the OLD workspace, proving nothing.
+    vi.resetModules();
+    const mod = await import("../../../server/config/env.js");
+    expect(mod.isWorkspaceCwd(target)).toBe(true);
+    process.env.CLAUDE_CWD = WORKSPACE;
+  });
+});

--- a/test/server/session/full-gui-mcp.spec.ts
+++ b/test/server/session/full-gui-mcp.spec.ts
@@ -1,0 +1,97 @@
+// @vitest-environment node
+// Which sessions carry the whole GUI MCP, and — the point of the file — which do NOT.
+//
+// PR2 gives a grid cell running in the workspace the surface the single view has always had. The
+// constraint it is written under is that a cell in a PROJECT directory keeps the behaviour it has
+// today, exactly. That is an invariant, and an invariant nothing asserts is just a hope: this is
+// the assertion.
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const ROOT = mkdtempSync(path.join(os.tmpdir(), "mt-fullgui-"));
+const WORKSPACE = path.join(ROOT, "workspace");
+const PROJECT = path.join(ROOT, "project");
+mkdirSync(WORKSPACE, { recursive: true });
+mkdirSync(PROJECT, { recursive: true });
+const REAL_CLAUDE_CWD = process.env.CLAUDE_CWD;
+process.env.CLAUDE_CWD = WORKSPACE;
+
+const { carriesFullGuiMcp } = await import("../../../server/session/spawn-claude.js");
+const { buildClaudeArgs } = await import("../../../server/agents/claude-args.js");
+
+afterAll(() => {
+  if (REAL_CLAUDE_CWD === undefined) delete process.env.CLAUDE_CWD;
+  else process.env.CLAUDE_CWD = REAL_CLAUDE_CWD;
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+// `attachGuiMcp` is what the WIRE says: false for a grid cell (?gui=0), true for everything else.
+const GRID_CELL = false;
+const NOT_A_GRID_CELL = true;
+
+describe("carriesFullGuiMcp", () => {
+  it("does NOT give it to a grid cell in a project directory", () => {
+    // The invariant. If this ever flips, every ordinary cell in the grid silently changes what
+    // tools it has and where they come from.
+    expect(carriesFullGuiMcp(GRID_CELL, PROJECT)).toBe(false);
+  });
+
+  it("gives it to a grid cell running in the workspace", () => {
+    expect(carriesFullGuiMcp(GRID_CELL, WORKSPACE)).toBe(true);
+  });
+
+  it("gives it to a grid cell that named no directory — that IS the workspace", () => {
+    expect(carriesFullGuiMcp(GRID_CELL, undefined)).toBe(true);
+  });
+
+  it("still gives it to everything that is not a grid cell, whatever the directory", () => {
+    // The single view, and every chat spawned without a cell of its own (spawnBackgroundChat,
+    // the translation worker, issue work). Unchanged: the wire flag alone decides these.
+    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, PROJECT)).toBe(true);
+    expect(carriesFullGuiMcp(NOT_A_GRID_CELL, WORKSPACE)).toBe(true);
+  });
+
+  it("does NOT give it to a cell in a subdirectory of the workspace", () => {
+    // Equality, not prefix — `{workspace}/foo` is an ordinary project.
+    expect(carriesFullGuiMcp(GRID_CELL, path.join(WORKSPACE, "foo"))).toBe(false);
+  });
+});
+
+// The other half: that the flag reaches the argv in the two shapes it is supposed to. Pinned
+// against buildClaudeArgs rather than a spawn, so it needs no PTY.
+describe("the argv each kind of session gets", () => {
+  const args = (attachGuiMcp: boolean) =>
+    buildClaudeArgs({
+      model: null,
+      sessionId: "s",
+      resume: null,
+      canResume: false,
+      settings: "{}",
+      permissionMode: "default",
+      attachGuiMcp,
+      mcpConfig: "MCP_CONFIG",
+      allowedTools: attachGuiMcp ? "GUI_TOOLS" : "GRID_TOOLS",
+      addDirs: [],
+      appendedPrompt: null,
+    });
+
+  it("carries --mcp-config and --strict-mcp-config when it has the full GUI MCP", () => {
+    const argv = args(true);
+    expect(argv).toContain("--mcp-config");
+    expect(argv[argv.indexOf("--mcp-config") + 1]).toBe("MCP_CONFIG");
+    expect(argv).toContain("--strict-mcp-config");
+    expect(argv).toContain("GUI_TOOLS");
+  });
+
+  it("carries NEITHER for a project-directory cell, so its own MCP config still loads", () => {
+    // --strict-mcp-config is what makes ours the only source. Withholding both is precisely how a
+    // grid cell keeps reaching the servers its directory registered — the mechanism the Canvas
+    // depends on there.
+    const argv = args(false);
+    expect(argv).not.toContain("--mcp-config");
+    expect(argv).not.toContain("--strict-mcp-config");
+    expect(argv).toContain("GRID_TOOLS");
+  });
+});


### PR DESCRIPTION
PR2 of the single-view removal (design note: `plans/feat-remove-single-view.md`). Follows #1167 and #1186.

A terminal started in grid mode at `{workspace}` is all but the same thing as running the single terminal view. That observation is what this whole line of work starts from. This PR makes it true of the one thing that still differed: **the MCP surface**.

## The change

One wire flag used to decide two unrelated things: *is this a grid cell*, and *does it carry the GUI MCP*. The single view only looked special because it answered both the same way. They are now separated:

- `?gui=0` keeps its name and its meaning — "this is a grid cell" — and keeps driving `markDevTerminalSession` and `entry.active` **untouched**.
- The MCP decision reads a derived value instead:

```ts
carriesFullGuiMcp(attachGuiMcp, cwd) = attachGuiMcp || isWorkspaceCwd(cwd)
```

Derived in `spawnClaudePty`, the one place that already holds both the session's cwd and `CLAUDE_CWD`. The client sends nothing new.

## Normal grid cells do not change

This was the constraint the work was done under, so it is asserted rather than asserted-to-be-true. A cell in a project directory is false on both counts and takes exactly the branch it takes today: same argv, same `allowedTools`, still **no** `--mcp-config`, so its own `.mcp.json` loads and its Canvas still comes from the tool groups its directory registered.

`carriesFullGuiMcp` is **exported** for that reason — `test/server/session/full-gui-mcp.spec.ts` pins the truth table, and the first case in it is the project-directory cell. An invariant nothing can assert is just a hope.

Also unchanged, deliberately: `GRID_MCP_TOOLS`, `autoAllowedToolNames()`, the per-project registered-groups path (#1040), and the sandbox gate (still on the raw wire flag — PR1 removes it).

## `isWorkspaceCwd`

Lives beside `CLAUDE_CWD` as the one place that answers the question. Three rules, each of which is a way for the feature to **silently not turn on**:

| Rule | Why |
|---|---|
| An absent cwd **is** the workspace | The launch form's blank field means "the server's default", and `spawnClaudePty` defaults `cwd = CLAUDE_CWD`. Getting this wrong breaks the plainest case. |
| Canonicalise before comparing | The cwd arrives from a `?cwd=` query built out of a user preset — trailing slash, `..`, and above all **symlinks**: a `~/mulmoclaude` that is a symlink is ordinary on a dev machine. |
| Equality, not prefix | `{workspace}/foo` is an ordinary project directory. |

A path that does not exist falls back to a normalised string compare rather than throwing — a directory that is gone is a spawn failure and is reported as one elsewhere; this predicate must not be where it surfaces, nor throw inside the spawn path and take the session with it.

`test/server/config/workspace-cwd.spec.ts` covers all of these, including the case a string compare passes only by luck: `CLAUDE_CWD` naming a symlink while the cell names the real directory.

## Two decisions worth stating

**1. `--strict-mcp-config` stays on for the workspace cell**, so that cell does **not** load its directory's own `.mcp.json` servers. This is the one real trade in the PR and it was not called out in the original plan.

It is right because the point is parity with the view being deleted — the single view has always behaved exactly this way. And dropping strict would *double-register* the GUI MCP for a workspace directory that had also registered group URLs: the agent would see both `mcp__mulmoterminal-gui__presentChart` and `mcp__mulmoterminal-render__presentChart`.

**2. codex and antigravity are left grid-only**, with the reason in a comment at `spawn-codex.ts`. The rule exists to make a workspace cell equivalent to the **single view**, and the single view only ever ran claude — so there is no codex behaviour it would be preserving, and applying it would be a new capability rather than a migrated one. It is one call to `carriesFullGuiMcp` if that changes.

## Confirmed rather than assumed

The plan flagged that the per-session MCP config file — now written for workspace cells too — needs reaping for grid sessions. It already is: `cleanupSessionSettings` removes it and runs from `lifecycle.ts` reap plus the boot sweep, for every kind of session. No change needed.

## Also here

`sessionAddDirs` is extracted for the same reason `resolveSessionBackend` already was: the spawn body is at its line budget (60) and this is a value derived from two sources, not part of spawning. No behaviour change.

## Verified

- `yarn test` — 479 files / 7030 tests pass (+15)
- `yarn typecheck` / `:test` / `:server` all pass
- `yarn lint` 0 errors (4 pre-existing max-lines warnings), `yarn build` succeeds

**Not verified:** anything in a running app. This is a spawn-time argv change, so seeing it needs a server restart and a workspace cell opened by hand.

Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
