### PR TITLE
feat: make background workers findable, and fix ungrouped tools being hidden

### DIFF
--- a/common/notifyKinds.ts
+++ b/common/notifyKinds.ts
@@ -9,10 +9,13 @@
 //   command-failed — a Run cell's command exited non-zero.
 //   session-exited — a session's PTY ended. Closing a cell yourself goes through the same
 //                    path, so this one fires on a deliberate close too.
+//   worker-failed  — a hidden background worker ended without ever completing a turn. The one
+//                    kind raised for a session with no cell on screen: a worker is invisible by
+//                    design, so nothing else would ever say so.
 //   pr-ci-failed   — a directory's PR phase became ci-failing. The phase poll runs only
 //                    while the roster is on screen, so a failure that lands while you are
 //                    in another view is not seen.
-export const NOTIFY_KINDS = ["finished", "waiting", "command-done", "command-failed", "session-exited", "pr-ci-failed"] as const;
+export const NOTIFY_KINDS = ["finished", "waiting", "command-done", "command-failed", "session-exited", "worker-failed", "pr-ci-failed"] as const;
 
 export type NotifyKind = (typeof NOTIFY_KINDS)[number];
 

--- a/common/workerStatus.ts
+++ b/common/workerStatus.ts
@@ -1,0 +1,35 @@
+// What a session row says about a BACKGROUND WORKER, as it travels from the server to the UI.
+//
+// Both sides decide from these two fields and they decide different things, so this is the shared
+// CORE rather than either side's whole row:
+//   - the server fills them per row from the persisted marks (session-reads.ts), and
+//   - the launcher's resume list renders them as the `background` / `● failed` labels
+//     (CellLaunchForm.vue), which is the only place a worker can be found once the single view
+//     is gone.
+// Each side keeps its own extras (title, mtime, working/waiting/event) next to its import.
+//
+// Shared rather than spelled twice because they are a WIRE shape: the server writes them, the
+// browser reads them, and two copies of that is the drift `common/` exists to prevent. The two
+// sides are deliberately not identical, though — see WorkerStatus vs PartialWorkerStatus below,
+// and the spec that pins the asymmetry.
+export interface WorkerStatus {
+  /** Spawned as a hidden background worker (spawnBackgroundChat hidden:true, a scheduled
+   *  refresh). It is still listed, but never bold and never unread — a helper finishing should
+   *  not pull the user's attention. */
+  hidden: boolean;
+  /** That worker ended without ever completing a turn. The counterpart to `hidden`: a worker is
+   *  quiet by design, so this is the one outcome the quiet is wrong for, and it rides on the row
+   *  so a picker can say WHICH worker failed rather than making the user open each one. */
+  failed: boolean;
+}
+
+/**
+ * The same two fields as the CLIENT may receive them.
+ *
+ * Optional on purpose, and the asymmetry is load-bearing rather than laziness: the server always
+ * fills both, but a browser also parses rows from an OLDER server (a page left open across an
+ * upgrade, the phone's cached list), where neither field exists. Declaring them required there
+ * would make the type lie about what can arrive, and the labels are absence-tolerant anyway —
+ * "no badge" is exactly right for a row that never said.
+ */
+export type PartialWorkerStatus = Partial<WorkerStatus>;

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -130,7 +130,6 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
     spawnCodexPty: deps.spawnCodexPty,
     spawnAntigravityPty: deps.spawnAntigravityPty,
     registerBackgroundSession: deps.registerBackgroundSession,
-    publish: (c, d) => deps.publish(c, d),
   });
 
   // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -44,7 +44,16 @@ import { mountNotificationRoutes } from "../backends/notifier.js";
 import { mountWhisperRoutes } from "../backends/whisper.js";
 import { mountSchedulerRoutes } from "../backends/scheduler.js";
 import { mountFilesRoutes } from "../backends/files.js";
-import { hookedSessions, ptys, sessionToolGroups, sessionToolGroupsHydrated, devTerminalSessions, devTerminalSessionsHydrated } from "../session/registry.js";
+import {
+  hookedSessions,
+  ptys,
+  sessionToolGroups,
+  sessionToolGroupsHydrated,
+  devTerminalSessions,
+  devTerminalSessionsHydrated,
+  hasAllGuiTools,
+  allToolsSessionsHydrated,
+} from "../session/registry.js";
 import { mountShortcutsRoutes } from "../backends/shortcuts.js";
 import { mountDecisionRoutes } from "./decision-routes.js";
 import { mountTranslationRoutes } from "../backends/translation.js";
@@ -121,6 +130,7 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
     spawnCodexPty: deps.spawnCodexPty,
     spawnAntigravityPty: deps.spawnAntigravityPty,
     registerBackgroundSession: deps.registerBackgroundSession,
+    publish: (c, d) => deps.publish(c, d),
   });
 
   // presentHtml View's source-editor dispatch (loadHtml/saveHtml) on
@@ -263,6 +273,8 @@ function mountSessionFacingRoutes(app: Express, deps: AppRouteDeps): void {
     toolSummaries: deps.toolSummaries,
     sessionToolGroups,
     sessionToolGroupsHydrated,
+    hasAllGuiTools,
+    allToolsSessionsHydrated,
     isGridSession: (id) => devTerminalSessions.has(id),
     devTerminalSessionsHydrated,
     // Built from the same two signals as the broker's recorder, but with the stricter rule the

--- a/server/routes/hook-routes.ts
+++ b/server/routes/hook-routes.ts
@@ -49,7 +49,10 @@ function handleActivityHook(deps: HookDeps, sessionId: string, event: string, ac
   // a process exit — `claude` sits at its prompt afterwards — so a worker that never reaches
   // Stop (blocked on a permission dialog nobody can answer, or dead before its first turn) is
   // exactly the failed refresh, and reap reports it as such. No-op unless a hook is registered,
-  // which only a hidden feeds worker ever does.
+  // which a hidden feeds worker does — and, since #1188, a hidden CLAUDE spawnBackgroundChat.
+  // Only claude: this endpoint is Claude Code's hook mechanism, so it is the only agent that can
+  // ever reach here to report success, and a hook registered for another one could only ever
+  // report failure.
   if (event === "Stop") void runCompletionHook(sessionId, { didError: false }).catch((err) => console.error(`[completion-hook] ${messageOf(err)}`));
 }
 

--- a/server/routes/mcp-routes.ts
+++ b/server/routes/mcp-routes.ts
@@ -13,7 +13,7 @@ import type { Express, Request, Response } from "express";
 import { PORT, SESSION_ID_RE } from "../config/env.js";
 import { buildGuiMcpServer } from "../mcp/broker.js";
 import type { GuiCallRecorder } from "../mcp/gui-call-history.js";
-import { translationWorkerIds, markSessionToolGroup, sessionToolGroups } from "../session/registry.js";
+import { translationWorkerIds, markSessionToolGroup, sessionToolGroups, markAllToolsSession } from "../session/registry.js";
 import { isToolGroup, TOOL_GROUPS, type ToolGroup } from "../../common/toolGroups.js";
 import { submitTranslation } from "../session/translation-worker.js";
 import { translationSubmitOutcome } from "../session/translation-submit.js";
@@ -139,6 +139,12 @@ export function mountMcpRoutes(app: Express, deps: McpRouteDeps): void {
   // Grid cells proper are untouched: without --mcp-config they never reach this URL, and what
   // they can call still comes only from what their directory registered.
   app.post("/api/mcp/:sessionId", (req, res) => {
+    // Two facts, and they are NOT the same one. The groups say which drawing/data/media/external
+    // tools the session can call — that is what the Canvas gate reads. This says it carries the
+    // WHOLE MCP, which additionally includes the tools belonging to no group at all
+    // (spawnBackgroundChat); a directory that registered all four group urls has the first and
+    // not the second.
+    markAllToolsSession(req.params.sessionId);
     learnToolGroups(req.params.sessionId, TOOL_GROUPS);
     return handleMcpRequest(req, res, req.params.sessionId, null);
   });

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -10,8 +10,10 @@ import type { Express } from "express";
 import { CLAUDE_CWD, PORT } from "../config/env.js";
 import { messageOf } from "../errors.js";
 import { isRecord } from "../../common/isRecord.js";
-import { backgroundMarkers } from "../session/registry.js";
+import { backgroundMarkers, markFailedWorker } from "../session/registry.js";
 import { runWithHiddenMarker } from "../session/hiddenMarker.js";
+import { registerCompletionHook } from "../session/completion-hooks.js";
+import { SESSIONS_CHANNEL } from "../session/lifecycle.js";
 import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../session/background-chat.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { TOOL_GROUPS } from "../../common/toolGroups.js";
@@ -29,6 +31,9 @@ export interface PluginRouteDeps {
    *  is the only thing that would ever end it — and a worker blocked on a permission prompt
    *  never fires the hook that starts it. */
   registerBackgroundSession: (id: string) => void;
+  /** Announce a session event on the sessions channel. Used for the one thing a hidden worker
+   *  cannot announce for itself: that it ended badly. */
+  publish: (channel: string, data: unknown) => void;
 }
 
 export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
@@ -63,7 +68,26 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
         else if (mode === "claude-draft") deps.spawnClaudePty(sessionId, null, null, { draft: message });
         else deps.spawnClaudePty(sessionId, null, null, { initialPrompt: message });
       });
-      if (hidden) deps.registerBackgroundSession(sessionId);
+      if (hidden) {
+        deps.registerBackgroundSession(sessionId);
+        // A hidden worker is invisible on purpose, which is exactly why a FAILED one needs a
+        // record: nothing pulls the user's attention and nothing waits to be clicked, so the
+        // failure is otherwise never learned. The completion hook is the existing seam for it —
+        // a finished turn reports success first and this never fires; reaching teardown with no
+        // Stop means no turn ever completed (see completion-hooks.ts for why first-answer-wins).
+        //
+        // Registered AFTER the spawn: a launch that threw has no session to report on, and would
+        // leave a hook nothing will ever fire or clear. Safe against the feeds engine's own hook
+        // (last writer wins) because that dispatches through its own spawner, never this route.
+        registerCompletionHook(sessionId, ({ didError }) => {
+          if (!didError) return;
+          markFailedWorker(sessionId);
+          // Published as well as recorded: the record is what makes the failure FINDABLE later,
+          // this is what lets the user be told now. Its own event rather than reusing "closed",
+          // which every session raises and which is therefore useless as a failure signal.
+          deps.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "worker-failed" });
+        });
+      }
     } catch (err) {
       console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);
       return res.json({ message: `Failed to spawn a new session: ${messageOf(err)}` });

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -13,7 +13,6 @@ import { isRecord } from "../../common/isRecord.js";
 import { backgroundMarkers, markFailedWorker } from "../session/registry.js";
 import { runWithHiddenMarker } from "../session/hiddenMarker.js";
 import { registerCompletionHook } from "../session/completion-hooks.js";
-import { SESSIONS_CHANNEL } from "../session/lifecycle.js";
 import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../session/background-chat.js";
 import { registeredGuiMcpGroups } from "../infra/gui-mcp-registration.js";
 import { TOOL_GROUPS } from "../../common/toolGroups.js";
@@ -31,9 +30,6 @@ export interface PluginRouteDeps {
    *  is the only thing that would ever end it — and a worker blocked on a permission prompt
    *  never fires the hook that starts it. */
   registerBackgroundSession: (id: string) => void;
-  /** Announce a session event on the sessions channel. Used for the one thing a hidden worker
-   *  cannot announce for itself: that it ended badly. */
-  publish: (channel: string, data: unknown) => void;
 }
 
 export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
@@ -79,13 +75,13 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
         // Registered AFTER the spawn: a launch that threw has no session to report on, and would
         // leave a hook nothing will ever fire or clear. Safe against the feeds engine's own hook
         // (last writer wins) because that dispatches through its own spawner, never this route.
+        //
+        // RECORDS ONLY, and synchronously. Announcing is reap's job: it publishes one teardown
+        // message carrying this outcome, which is what keeps the generic notification from
+        // racing ahead of the specific one. Staying synchronous is therefore a contract, not an
+        // implementation detail — reap reads the flag immediately after firing this.
         registerCompletionHook(sessionId, ({ didError }) => {
-          if (!didError) return;
-          markFailedWorker(sessionId);
-          // Published as well as recorded: the record is what makes the failure FINDABLE later,
-          // this is what lets the user be told now. Its own event rather than reusing "closed",
-          // which every session raises and which is therefore useless as a failure signal.
-          deps.publish(SESSIONS_CHANNEL, { id: sessionId, working: false, event: "worker-failed" });
+          if (didError) markFailedWorker(sessionId);
         });
       }
     } catch (err) {

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -76,13 +76,24 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
         // leave a hook nothing will ever fire or clear. Safe against the feeds engine's own hook
         // (last writer wins) because that dispatches through its own spawner, never this route.
         //
+        // CLAUDE ONLY, and that is a correctness limit rather than a scope choice. The single
+        // success signal a PTY-hosted agent gives us is a finished turn reported by Claude Code's
+        // Stop hook (hook-routes.ts); codex and antigravity have no hook mechanism at all, so
+        // they can never report success. Registering for them would mean every SUCCESSFUL hidden
+        // codex worker reached reap unreported and was marked failed — a signal that is wrong
+        // more often than it is right, which is worse than the silence it replaced.
+        // (Codex, PR #1188.) A non-claude hidden worker therefore keeps today's behaviour: no
+        // failure signal. Giving it one needs a completion signal for those agents first.
+        //
         // RECORDS ONLY, and synchronously. Announcing is reap's job: it publishes one teardown
         // message carrying this outcome, which is what keeps the generic notification from
         // racing ahead of the specific one. Staying synchronous is therefore a contract, not an
         // implementation detail — reap reads the flag immediately after firing this.
-        registerCompletionHook(sessionId, ({ didError }) => {
-          if (didError) markFailedWorker(sessionId);
-        });
+        if (agent === "claude") {
+          registerCompletionHook(sessionId, ({ didError }) => {
+            if (didError) markFailedWorker(sessionId);
+          });
+        }
       }
     } catch (err) {
       console.error(`[spawnBackgroundChat] failed for ${sessionId}: ${messageOf(err)}`);

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -15,6 +15,7 @@ import {
   activityStateHydrated,
   aiTitles,
   backgroundSessionsHydrated,
+  failedWorkersHydrated,
   devTerminalSessions,
   devTerminalSessionsHydrated,
   isBackgroundSession,
@@ -166,10 +167,15 @@ async function sessionList(req: Request, res: Response) {
     const includePending = !req.query.cwd;
     // Wait for the persisted grid-session set before filtering (below), so a chat
     // request racing server boot can't leak previously-hidden grid transcripts. The
-    // background set is awaited for BOTH queries — it decides a flag on the row rather
-    // than whether the row is listed, and that flag is answered either way.
+    // background and failed sets are awaited for BOTH queries — they decide a flag on the row
+    // rather than whether the row is listed, and those flags are answered either way.
+    //
+    // `failed` especially: the whole value of persisting it is finding out LATER, and the most
+    // likely "later" is the first list after a restart. Serving it as false while its log is
+    // still being read would lose exactly the case the record exists for (Codex, PR #1188).
     if (includePending) await devTerminalSessionsHydrated;
     await backgroundSessionsHydrated;
+    await failedWorkersHydrated;
     await sessionMemosHydrated; // the memo is the row's TITLE when there is one — a race shows the agent's words instead
     const dir = projectSessionsDir(cwd);
     let files: string[] = [];

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -199,7 +199,7 @@ async function sessionList(req: Request, res: Response) {
       await Promise.all(
         top.map((s) =>
           s.kind === "pending"
-            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, event: s.event, hidden: s.hidden }
+            ? { id: s.id, title: s.title, mtime: s.mtime, working: s.working, waiting: s.waiting, event: s.event, hidden: s.hidden, failed: s.failed }
             : readSessionMeta(dir, s.file).catch(() => null),
         ),
       )

--- a/server/routes/tool-routes.ts
+++ b/server/routes/tool-routes.ts
@@ -21,6 +21,11 @@ export interface ToolRouteDeps {
   /** Which tool groups a session actually reached us on — see session/session-tool-groups.ts. */
   sessionToolGroups: (sessionId: string) => ToolGroup[];
   sessionToolGroupsHydrated: Promise<void>;
+  /** Does this session carry the WHOLE GUI MCP (it connected on the all-tools url), rather than
+   *  the per-group subset its directory registered? Separate from the group list because the
+   *  ungrouped tools are reachable only that way — see narrowedTools. */
+  hasAllGuiTools: (sessionId: string) => boolean;
+  allToolsSessionsHydrated: Promise<void>;
   /**
    * Is this a GRID cell? The two kinds of session get their GUI tools by different routes, and
    * "no groups learned" means the opposite thing for each — see narrowedTools.
@@ -45,17 +50,20 @@ const hasGroup = (group: ToolGroup | null, groups: readonly ToolGroup[]): boolea
 /**
  * The tools a session actually has.
  *
- * The rule that matters: an EMPTY group list means opposite things for the two kinds of session,
- * and conflating them is what let a grid cell with no MCP registered report every tool — and so
- * offer a Canvas button that opened a panel nothing could ever fill.
+ * Narrowing is decided by where the session's tools CAME FROM, which is not the same question as
+ * whether it is a grid cell — and reading it as though it were is what hid spawnBackgroundChat
+ * from a workspace cell that genuinely had it:
  *
- *   single view — carries the whole GUI MCP on --mcp-config and never connects to a group URL,
- *                 so it learns no groups and nonetheless has everything.
- *   grid cell   — has exactly what its directory registered with Claude Code. Nothing
- *                 registered, nothing learned, nothing available.
+ *   carries the whole GUI MCP (--mcp-config) — has everything, including the tools that belong to
+ *       no group and so can be reached through no group url. The single view, a chat spawned with
+ *       no cell of its own, and (since the workspace-cell rule) a grid cell in the workspace.
+ *   anything else, in the grid — has exactly what its DIRECTORY registered with Claude Code, one
+ *       group url at a time. Nothing registered, nothing learned, nothing available: the empty
+ *       list here means "has nothing", the opposite of what it means above, and conflating the
+ *       two once had a grid cell reporting every tool and offering a Canvas nothing could fill.
  */
-export function narrowedTools(tools: readonly ToolSummary[], groups: readonly ToolGroup[], isGrid: boolean): ToolSummary[] {
-  if (!isGrid) return [...tools];
+export function narrowedTools(tools: readonly ToolSummary[], groups: readonly ToolGroup[], isGrid: boolean, hasAllTools = false): ToolSummary[] {
+  if (!isGrid || hasAllTools) return [...tools];
   return tools.filter((tool) => hasGroup(groupOfTool(tool.toolName), groups));
 }
 
@@ -107,10 +115,11 @@ export function mountToolRoutes(app: Express, deps: ToolRouteDeps): void {
     if (sessionId === null || !SESSION_ID_RE.test(sessionId)) return res.json({ tools: deps.toolSummaries, guiOnlyHistory: false });
     // Both sets are persisted and hydrated at boot; asked before either resolves, a grid cell
     // would read as having nothing and a resumed one as having lost its groups.
-    await Promise.all([deps.sessionToolGroupsHydrated, deps.devTerminalSessionsHydrated]);
+    await Promise.all([deps.sessionToolGroupsHydrated, deps.devTerminalSessionsHydrated, deps.allToolsSessionsHydrated]);
     const groups = deps.sessionToolGroups(sessionId);
     const isGrid = deps.isGridSession(sessionId);
-    res.json({ tools: narrowedTools(deps.toolSummaries, groups, isGrid), groups, guiOnlyHistory: deps.guiOnlyHistory(sessionId) });
+    const hasAllTools = deps.hasAllGuiTools(sessionId);
+    res.json({ tools: narrowedTools(deps.toolSummaries, groups, isGrid, hasAllTools), groups, guiOnlyHistory: deps.guiOnlyHistory(sessionId) });
   });
 
   // Replay a session's tool-call history — every tool for claude (its Pre/PostToolUse hooks),

--- a/server/session/lifecycle.ts
+++ b/server/session/lifecycle.ts
@@ -29,6 +29,7 @@ import {
   ptys,
   sessionMemos,
   titleInFlight,
+  isFailedWorker,
 } from "./registry.js";
 import { clearedTranscripts, forgetClearedTranscript } from "./cleared-transcripts.js";
 import { parseWaitGraceMs, reapDecisionFor, reapTimerDelay, shouldForgetActivity } from "./reap-policy.js";
@@ -175,12 +176,20 @@ function reap(deps: SessionLifecycleDeps, id: string) {
   cleanupSessionSettings(id);
   // Files dropped into this session were copied to tmp for it alone; nothing else refers to them.
   cleanupSessionDrops(id);
-  deps.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed" });
   // The session is gone, so this is its last chance to report an outcome (#1070). Failure is
   // the right answer HERE because the hook is one-shot and a finished turn already claimed it
   // on the way past: reaching teardown with the hook still unfired means no Stop ever came —
   // a worker blocked on a dialog nobody can answer, or one that died before its first turn.
+  //
+  // BEFORE the announcement below, so that announcement can carry the outcome. The recorder this
+  // fires is synchronous (it sets a flag), so the mark is in place by the time it is read — a
+  // contract pinned in test/server/routes/worker-failure-wiring.spec.ts rather than left implied.
   void runCompletionHook(id, { didError: true }).catch((err) => console.error(`[completion-hook] ${messageOf(err)}`));
+  // ONE message, not two. `event` stays "closed" because that is what every consumer of this
+  // channel keys on to drop a reaped session (sessionActivity.ts); the outcome rides along as a
+  // field. Publishing a second "worker-failed" message instead let the generic teardown
+  // notification race ahead of the specific one, and beeped twice for one event (Codex, #1188).
+  deps.publish(SESSIONS_CHANNEL, { id, working: false, event: "closed", failed: isFailedWorker(id) });
 }
 
 // Publish a session's current activity (working + waiting) to subscribers.

--- a/server/session/partitionPending.ts
+++ b/server/session/partitionPending.ts
@@ -20,6 +20,10 @@ function toPendingRow(id: string, meta: KnownSession, activityOf: (id: string) =
     waiting: a?.waiting ?? false,
     event: a?.event ?? null,
     hidden: isHidden(id),
+    // A pending row is one whose session is still LIVE and has not persisted a transcript yet.
+    // A worker is only ever recorded as failed at teardown, which also drops it from
+    // knownSessions and so from this list — so a pending row cannot be a failed one.
+    failed: false,
   };
 }
 

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -201,6 +201,63 @@ export function isBackgroundSession(id: string): boolean {
   return hiddenSessions.has(id) || backgroundSessions.has(id);
 }
 
+// Sessions that connected on the ALL-TOOLS MCP url (`/api/mcp/:sessionId`). That url is handed
+// out by --mcp-config and by nothing else, so reaching it is proof the session carries the whole
+// GUI MCP — including the tools that belong to no group and are therefore unreachable through a
+// group url (spawnBackgroundChat).
+//
+// Recorded as its own fact rather than inferred from "has all four groups", which is a different
+// statement: a directory that registered every group url really does have all four groups and
+// really does NOT have the ungrouped tools.
+//
+// Persisted for the same reason the tool-group log is: the learning happens in memory, and a
+// server restart would forget it while the claude process keeps running in tmux, already past
+// the ListTools that would teach us again.
+const allToolsSessions = new Set<string>();
+const ALL_TOOLS_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "all-tools-sessions.json");
+export const allToolsSessionsHydrated = hydrateIdLog(ALL_TOOLS_SESSIONS_FILE, allToolsSessions);
+const appendAllToolsSession = idLogAppender(ALL_TOOLS_SESSIONS_FILE, "all-tools-sessions");
+
+/** Note that a session reached us on the all-tools url. A no-op once known — one server is built
+ *  per MCP request, so this is asked on every tool call. */
+export function markAllToolsSession(id: string): void {
+  if (!isValidSessionId(id) || allToolsSessions.has(id)) return;
+  allToolsSessions.add(id);
+  appendAllToolsSession(id);
+}
+
+/** Does this session carry the whole GUI MCP, rather than the subset its directory registered? */
+export function hasAllGuiTools(id: string): boolean {
+  return allToolsSessions.has(id);
+}
+
+// Background workers whose run ENDED BADLY: reached teardown without ever reporting a finished
+// turn. A worker is invisible on purpose, so a failed one is the single case where that design
+// works against the user — nothing pulls their attention and nothing is waiting to be clicked, so
+// without a record the failure is simply never learned.
+//
+// Persisted for the same reason the set above is, and more so: the whole value of this is being
+// able to find out LATER. A live-only flag would be cleared by the very reap that discovers the
+// failure.
+const failedWorkers = new Set<string>();
+const FAILED_WORKERS_FILE = path.join(MULMOTERMINAL_HOME, "failed-workers.json");
+export const failedWorkersHydrated = hydrateIdLog(FAILED_WORKERS_FILE, failedWorkers);
+const appendFailedWorker = idLogAppender(FAILED_WORKERS_FILE, "failed-workers");
+
+/** Record that a background worker ended without succeeding. Only ever called for a session that
+ *  is already a background one — a watched session's failure is visible in its own terminal. */
+export function markFailedWorker(id: string): void {
+  if (!isValidSessionId(id) || failedWorkers.has(id)) return;
+  failedWorkers.add(id);
+  appendFailedWorker(id);
+}
+
+/** Did this background worker end badly? Read per row by the session list, so a launcher can say
+ *  so next to the worker rather than making the user open each one to find out. */
+export function isFailedWorker(id: string): boolean {
+  return failedWorkers.has(id);
+}
+
 /** What a hidden spawn marks itself with (see runWithHiddenMarker). Both halves of "hidden"
  *  are set from ONE place because there are two spawn sites, and a site that remembered the
  *  live flag but not the log would produce a worker that is background until it finishes and

--- a/server/session/session-reads.ts
+++ b/server/session/session-reads.ts
@@ -25,7 +25,7 @@ import {
 import { createFileCache, type FileStamp } from "./file-cache.js";
 import { classifyWorkPhase, type WorkPhase } from "./workPhase.js";
 import { sessionListTitle } from "./sessionListTitle.js";
-import { activity, aiTitles, codexRolloutIds, isBackgroundSession, knownSessions, sessionMemos } from "./registry.js";
+import { activity, aiTitles, codexRolloutIds, isBackgroundSession, isFailedWorker, knownSessions, sessionMemos } from "./registry.js";
 import { projectSessionsDir } from "./project-dir.js";
 import { lastTurnFromClaudeParsed, lastTurnFromCodexRolloutDocs, EMPTY_TURN, type LastTurn } from "./last-turn.js";
 import { forEachJsonlRecord, readTailRecords } from "../infra/jsonl-file.js";
@@ -248,6 +248,7 @@ export async function readSessionMeta(dir: string, file: string): Promise<Sessio
     waiting: a?.waiting ?? false,
     event: a?.event ?? null,
     hidden: isBackgroundSession(id),
+    failed: isFailedWorker(id),
   };
 }
 

--- a/server/session/types.ts
+++ b/server/session/types.ts
@@ -3,6 +3,7 @@
 // modules that read it can name them without importing the boot module (#548).
 import type { IPty } from "node-pty";
 import type { WebSocket } from "ws";
+import type { WorkerStatus } from "../../common/workerStatus.js";
 import type { SessionAgent } from "../../common/sessionAgent.js";
 
 export interface Activity {
@@ -64,7 +65,7 @@ export interface ToolCall {
 }
 
 // A sidebar session row (resolved from disk or a pending in-memory session).
-export interface SessionMeta {
+export interface SessionMeta extends WorkerStatus {
   id: string;
   title: string;
   mtime: number;
@@ -74,14 +75,6 @@ export interface SessionMeta {
    *  Lets the client split `waiting` into "done, unreviewed" (Stop) vs "blocked on
    *  input" (Notification). */
   event: string | null;
-  /** Spawned as a hidden background worker (spawnBackgroundChat hidden:true). The
-   *  tab still lists, but it never renders bold/unread — a background helper
-   *  finishing shouldn't pull the user's attention. */
-  hidden: boolean;
-  /** That worker ended without ever completing a turn. The counterpart to `hidden`: a worker is
-   *  quiet by design, so this is the one outcome the quiet is wrong for, and it is carried on the
-   *  row so a picker can say which worker failed instead of making the user open each one. */
-  failed: boolean;
 }
 
 // Recency rank for an on-disk .jsonl, before its contents are read.

--- a/server/session/types.ts
+++ b/server/session/types.ts
@@ -78,6 +78,10 @@ export interface SessionMeta {
    *  tab still lists, but it never renders bold/unread — a background helper
    *  finishing shouldn't pull the user's attention. */
   hidden: boolean;
+  /** That worker ended without ever completing a turn. The counterpart to `hidden`: a worker is
+   *  quiet by design, so this is the one outcome the quiet is wrong for, and it is carried on the
+   *  row so a picker can say which worker failed instead of making the user open each one. */
+  failed: boolean;
 }
 
 // Recency rank for an on-disk .jsonl, before its contents are read.

--- a/src/components/CellLaunchForm.vue
+++ b/src/components/CellLaunchForm.vue
@@ -486,6 +486,23 @@ async function removeWorktree(w: Worktree): Promise<void> {
           @click="resume(s)"
         >
           <span data-testid="ri-title" class="truncate">{{ s.title }}</span>
+          <!-- A background worker is not the user's own chat, and a FAILED one is the only thing
+               here nobody was ever told about: it ran invisibly, ended badly, and pulled no
+               attention on the way. Naming it in the list is what makes it findable at all. -->
+          <span
+            v-if="s.failed"
+            data-testid="ri-failed"
+            class="flex-none whitespace-nowrap text-[11px] text-err-text"
+            title="This background worker ended without finishing a turn"
+            >● failed</span
+          >
+          <span
+            v-else-if="s.hidden"
+            data-testid="ri-background"
+            class="flex-none whitespace-nowrap text-[11px] text-dim"
+            title="Ran in the background — not a chat you opened"
+            >background</span
+          >
           <span
             v-if="sessionOpenElsewhere(s.id)"
             data-testid="ri-open"

--- a/src/components/settings/NotificationSoundsSection.vue
+++ b/src/components/settings/NotificationSoundsSection.vue
@@ -28,6 +28,7 @@ const NOTIFY_KIND_LABEL: Record<NotifyKind, string> = {
   "command-done": "Command finished",
   "command-failed": "Command failed",
   "session-exited": "Session ended",
+  "worker-failed": "Background worker failed",
   "pr-ci-failed": "PR CI failed",
 };
 const NOTIFY_KIND_HELP: Record<NotifyKind, string> = {
@@ -36,6 +37,7 @@ const NOTIFY_KIND_HELP: Record<NotifyKind, string> = {
   "command-done": "a Run cell's command exited cleanly",
   "command-failed": "a Run cell's command exited with an error, or never started",
   "session-exited": "a session's terminal ended — including when you close the cell yourself",
+  "worker-failed": "a background worker ended without finishing — nothing else reports this, since it has no terminal on screen",
   "pr-ci-failed": "a directory's PR went red. Only seen while the roster is on screen, since that is what polls it",
 };
 

--- a/src/composables/notifyKind.ts
+++ b/src/composables/notifyKind.ts
@@ -16,6 +16,10 @@ export interface ActivityMsg {
   event?: string | null;
   // The session's working dir, so a beep can use that directory's own sound.
   cwd?: string | null;
+  // On a teardown ("closed"): this was a hidden background worker that never completed a turn.
+  // Carried on the same message rather than sent as its own, so the generic teardown
+  // notification cannot arrive first — see notifyKindOf.
+  failed?: boolean;
 }
 
 export interface ActivityState {
@@ -51,17 +55,19 @@ function rawKind(was: ActivityState, now: ActivityState, event: string | null): 
  * blocked one, and counted a background Stop's two rows as two separate beeps.
  */
 export function notifyKindOf(prev: Map<string, ActivityState>, msg: ActivityMsg): NotifyKind | null {
-  // A hidden worker ended badly. Checked BEFORE "closed", which the same teardown also raises:
-  // this is the specific answer and that is the generic one. It does not depend on `prev` — a
-  // worker has no cell, so nothing here ever saw it working, and requiring a baseline would drop
-  // the one notification that exists because nobody was watching.
-  if (msg.event === "worker-failed") {
-    prev.delete(msg.id);
-    return "worker-failed";
-  }
   // The PTY was reaped: forget the session, so an id that comes back is a baseline again and
   // not compared against a state from its previous life.
-  if (msg.event === "closed") return prev.delete(msg.id) ? "session-exited" : null;
+  //
+  // ONE teardown message carries both facts. `failed` marks a hidden worker that never completed
+  // a turn, and it wins: it is the specific answer where session-exited is the generic one, and
+  // two messages would let the generic beat it (Codex, #1188). It deliberately does NOT depend on
+  // `prev` — a worker has no cell, so nothing here ever saw it working, and requiring a baseline
+  // would drop the one notification that exists precisely because nobody was watching.
+  if (msg.event === "closed") {
+    const seen = prev.delete(msg.id);
+    if (msg.failed) return "worker-failed";
+    return seen ? "session-exited" : null;
+  }
   const event = msg.event ?? null;
   const was = prev.get(msg.id);
   // A row carrying a different event starts a new moment, so it may be announced again. The

--- a/src/composables/notifyKind.ts
+++ b/src/composables/notifyKind.ts
@@ -51,6 +51,14 @@ function rawKind(was: ActivityState, now: ActivityState, event: string | null): 
  * blocked one, and counted a background Stop's two rows as two separate beeps.
  */
 export function notifyKindOf(prev: Map<string, ActivityState>, msg: ActivityMsg): NotifyKind | null {
+  // A hidden worker ended badly. Checked BEFORE "closed", which the same teardown also raises:
+  // this is the specific answer and that is the generic one. It does not depend on `prev` — a
+  // worker has no cell, so nothing here ever saw it working, and requiring a baseline would drop
+  // the one notification that exists because nobody was watching.
+  if (msg.event === "worker-failed") {
+    prev.delete(msg.id);
+    return "worker-failed";
+  }
   // The PTY was reaped: forget the session, so an id that comes back is a baseline again and
   // not compared against a state from its previous life.
   if (msg.event === "closed") return prev.delete(msg.id) ? "session-exited" : null;

--- a/src/composables/useAttentionSound.ts
+++ b/src/composables/useAttentionSound.ts
@@ -95,6 +95,7 @@ const CHIME_NOTES: Record<NotifyKind, readonly [number, number]> = {
   "command-done": [659, 988], // E5→B5
   "command-failed": [440, 330], // A4→E4
   "session-exited": [523, 392], // C5→G4
+  "worker-failed": [392, 262], // G4→C4, the lowest fall here: nothing else reports work lost
   "pr-ci-failed": [415, 311], // G#4→D#4
 };
 

--- a/src/composables/useDirLists.ts
+++ b/src/composables/useDirLists.ts
@@ -1,4 +1,5 @@
 import { shallowRef } from "vue";
+import type { PartialWorkerStatus } from "../../common/workerStatus";
 
 // What the launch form can offer for the directory currently in its field: the sessions that can
 // be resumed there, the script.json entries that can be run there, and the worktrees the
@@ -10,18 +11,12 @@ import { shallowRef } from "vue";
 // - a read that fails clears the list, instead of leaving the previous directory's rows standing
 //   under a name they don't belong to.
 
-export interface ResumableSession {
+/** A row the launcher can resume into a cell. `hidden` / `failed` come from the shared wire type
+ *  the server fills — see common/workerStatus.ts for why they are OPTIONAL on this side. */
+export interface ResumableSession extends PartialWorkerStatus {
   id: string;
   title: string;
   mtime: number;
-  /** A background worker (spawnBackgroundChat hidden:true, a scheduled refresh) rather than a
-   *  chat someone opened. Already carried on every row the server sends; surfaced here because
-   *  the grid is where such a session is picked up, and an unlabelled one is indistinguishable
-   *  from the user's own work. */
-  hidden?: boolean;
-  /** That worker ended without ever completing a turn. A worker is quiet by design, so this is
-   *  the one outcome the quiet is wrong for. */
-  failed?: boolean;
 }
 
 export interface RunnableScript {

--- a/src/composables/useDirLists.ts
+++ b/src/composables/useDirLists.ts
@@ -14,6 +14,14 @@ export interface ResumableSession {
   id: string;
   title: string;
   mtime: number;
+  /** A background worker (spawnBackgroundChat hidden:true, a scheduled refresh) rather than a
+   *  chat someone opened. Already carried on every row the server sends; surfaced here because
+   *  the grid is where such a session is picked up, and an unlabelled one is indistinguishable
+   *  from the user's own work. */
+  hidden?: boolean;
+  /** That worker ended without ever completing a turn. A worker is quiet by design, so this is
+   *  the one outcome the quiet is wrong for. */
+  failed?: boolean;
 }
 
 export interface RunnableScript {

--- a/test/common/workerStatus.spec.ts
+++ b/test/common/workerStatus.spec.ts
@@ -1,0 +1,41 @@
+// The worker-status wire shape, and the one way the two sides of it differ.
+//
+// `common/` holds the core because both sides decide from these fields — the server fills them per
+// row, the launcher renders them as labels — and two copies of a wire shape is the drift this
+// directory exists to prevent. But the sides are NOT identical, and an asymmetry that nothing
+// pins is indistinguishable from one side having drifted: the server always answers both fields,
+// a browser may be reading rows from an older server that answers neither.
+//
+// The SERVER half is pinned in test/server/session/worker-status.spec.ts — separate because a spec
+// in this project that imports a server type drags node-pty's Node globals into the program, and
+// an unrelated component's window.setTimeout then stops compiling.
+import { describe, it, expect, expectTypeOf } from "vitest";
+import type { WorkerStatus, PartialWorkerStatus } from "../../common/workerStatus";
+import type { ResumableSession } from "../../src/composables/useDirLists";
+
+describe("worker status — the shared core", () => {
+  it("is what the CLIENT's row may receive, optionally", () => {
+    // The deliberate asymmetry. A page left open across an upgrade parses rows from a server that
+    // predates these fields; declaring them required would make the type lie about what arrives.
+    expectTypeOf<ResumableSession>().toExtend<PartialWorkerStatus>();
+    expectTypeOf<ResumableSession["hidden"]>().toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<ResumableSession["failed"]>().toEqualTypeOf<boolean | undefined>();
+  });
+
+  it("keeps the two sides describing the same two fields", () => {
+    // The point of sharing: a field added to one side cannot quietly not exist on the other.
+    // Compared as VALUES so this fails loudly rather than only under a type-check.
+    const server: WorkerStatus = { hidden: true, failed: true };
+    const client: PartialWorkerStatus = server;
+    expect(Object.keys(server).sort()).toEqual(["failed", "hidden"]);
+    expect(client).toEqual(server);
+  });
+
+  it("treats an absent field as 'no badge', which is what an older row should show", () => {
+    // Absence-tolerant by design: the launcher renders on truthiness, so a row that never said
+    // gets neither label rather than a wrong one.
+    const older: PartialWorkerStatus = {};
+    expect(older.hidden ?? false).toBe(false);
+    expect(older.failed ?? false).toBe(false);
+  });
+});

--- a/test/server/routes/mcp-announce.spec.ts
+++ b/test/server/routes/mcp-announce.spec.ts
@@ -33,6 +33,7 @@ afterAll(() => {
 
 const { mountMcpRoutes, TOOL_GROUPS_CHANNEL } = await import("../../../server/routes/mcp-routes.js");
 const { TOOL_GROUPS } = await import("../../../common/toolGroups.js");
+const { hasAllGuiTools } = await import("../../../server/session/registry.js");
 
 const published: { channel: string; data: Record<string, unknown> }[] = [];
 const app = express();
@@ -91,6 +92,24 @@ describe("MCP first-contact announcement", () => {
     const id = randomUUID();
     await call(`/api/mcp/render/${id}`);
     expect(announcementsFor(id).some((p) => Array.isArray(p.data.groups) && (p.data.groups as string[]).includes("render"))).toBe(true);
+  });
+
+  // The other fact this url proves, and it is NOT the group list. Only a session handed the url
+  // by --mcp-config can reach it, so it carries the tools that belong to no group and are
+  // therefore reachable through no group url — spawnBackgroundChat. A directory that registered
+  // all four group urls has every group and none of those.
+  it("records that the session carries the WHOLE GUI MCP, not just four groups", async () => {
+    const id = randomUUID();
+    expect(hasAllGuiTools(id)).toBe(false);
+    await call(`/api/mcp/${id}`);
+    expect(hasAllGuiTools(id)).toBe(true);
+  });
+
+  it("does NOT record it for a group url", async () => {
+    const id = randomUUID();
+    await call(`/api/mcp/render/${id}`);
+    await call(`/api/mcp/data/${id}`);
+    expect(hasAllGuiTools(id)).toBe(false);
   });
 
   it("says nothing for a malformed session id", async () => {

--- a/test/server/routes/narrowed-tools.spec.ts
+++ b/test/server/routes/narrowed-tools.spec.ts
@@ -31,12 +31,32 @@ describe("narrowedTools", () => {
     expect(names(narrowedTools(TOOLS, ["render", "media"], true))).toEqual(["presentDocument", "presentHtml", "generateImage"]);
   });
 
-  // Ungrouped tools reach no group URL, so a grid cell cannot have one however many groups it
-  // registered — only the un-narrowed answer lists them.
-  it("never gives a grid cell an ungrouped tool", () => {
+  // Ungrouped tools reach no group URL, so a grid cell that registered its tools a group at a
+  // time cannot have one — however many groups it registered.
+  it("does not give an ungrouped tool to a cell that registered groups", () => {
     const all = narrowedTools(TOOLS, ["render", "data", "media", "external"], true);
     expect(names(all)).not.toContain("spawnBackgroundChat");
     expect(names(narrowedTools(TOOLS, [], false))).toContain("spawnBackgroundChat");
+  });
+
+  // ...but a grid cell CAN carry the whole GUI MCP now — a workspace cell does, and so does an
+  // adopted chat — and then it really does have the ungrouped tools. Reported live:
+  // spawnBackgroundChat was missing from a cell that could call it, because "is a grid cell" was
+  // standing in for "has only what its directory registered", and those came apart.
+  it("gives a grid cell everything when it carries the whole GUI MCP", () => {
+    expect(names(narrowedTools(TOOLS, ["render", "data", "media", "external"], true, true))).toEqual(names(TOOLS));
+    // The groups it happens to have learned are irrelevant to that: the full MCP is the fact.
+    expect(names(narrowedTools(TOOLS, [], true, true))).toEqual(names(TOOLS));
+  });
+
+  // The distinction the flag exists for. Four groups is not the same statement as the whole MCP.
+  it("tells a four-group directory apart from a session with the whole MCP", () => {
+    const registered = narrowedTools(TOOLS, ["render", "data", "media", "external"], true, false);
+    const whole = narrowedTools(TOOLS, ["render", "data", "media", "external"], true, true);
+    expect(names(whole)).toContain("spawnBackgroundChat");
+    expect(names(registered)).not.toContain("spawnBackgroundChat");
+    // Everything else is common to both — only the ungrouped tools differ.
+    expect(names(registered)).toEqual(names(whole).filter((n) => n !== "spawnBackgroundChat"));
   });
 
   it("does not mutate the list it was given", () => {

--- a/test/server/routes/worker-failure-wiring.spec.ts
+++ b/test/server/routes/worker-failure-wiring.spec.ts
@@ -37,8 +37,8 @@ mountPluginRoutes(app, {
 });
 
 /** Spawn through the real route and hand back the id it minted. */
-async function spawn(hidden: boolean): Promise<string> {
-  const res = await request(app).post("/api/plugin/spawnBackgroundChat").send({ message: "do the thing", hidden });
+async function spawn(hidden: boolean, agent = "claude"): Promise<string> {
+  const res = await request(app).post("/api/plugin/spawnBackgroundChat").send({ message: "do the thing", hidden, agent });
   return String((res.body as { jsonData?: { chatId?: string } }).jsonData?.chatId);
 }
 
@@ -73,6 +73,16 @@ describe("a hidden worker that ends badly", () => {
     await runCompletionHook(id, { didError: false });
     await runCompletionHook(id, { didError: true }); // reap, moments later
 
+    expect(isFailedWorker(id)).toBe(false);
+  });
+
+  // Codex, on this PR. The only success signal a PTY-hosted agent gives us is Claude Code's Stop
+  // hook; codex and antigravity have no hook mechanism, so they can never report success — and a
+  // recorder registered for them would mark every SUCCESSFUL run failed at teardown. A signal
+  // that is wrong more often than right is worse than the silence it replaced.
+  it.each(["codex", "antigravity"])("says nothing for a hidden %s worker, which cannot report success", async (agent) => {
+    const id = await spawn(true, agent);
+    await runCompletionHook(id, { didError: true });
     expect(isFailedWorker(id)).toBe(false);
   });
 

--- a/test/server/routes/worker-failure-wiring.spec.ts
+++ b/test/server/routes/worker-failure-wiring.spec.ts
@@ -5,7 +5,7 @@
 // prove the pieces are CONNECTED. This drives the real route and the real completion hook, which
 // is the only place the decision "a hidden worker that never finished a turn has failed" actually
 // happens.
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import express from "express";
 import request from "supertest";
 
@@ -26,9 +26,7 @@ vi.mock("node:fs", () => {
 const { mountPluginRoutes } = await import("../../../server/routes/plugin-routes.js");
 const { runCompletionHook } = await import("../../../server/session/completion-hooks.js");
 const { isFailedWorker } = await import("../../../server/session/registry.js");
-const { SESSIONS_CHANNEL } = await import("../../../server/session/lifecycle.js");
 
-let published: { channel: string; data: Record<string, unknown> }[] = [];
 const app = express();
 app.use(express.json());
 mountPluginRoutes(app, {
@@ -36,11 +34,6 @@ mountPluginRoutes(app, {
   spawnCodexPty: (() => ({})) as never,
   spawnAntigravityPty: (() => ({})) as never,
   registerBackgroundSession: () => {},
-  publish: (channel, data) => void published.push({ channel, data: data as Record<string, unknown> }),
-});
-
-beforeEach(() => {
-  published = [];
 });
 
 /** Spawn through the real route and hand back the id it minted. */
@@ -49,10 +42,8 @@ async function spawn(hidden: boolean): Promise<string> {
   return String((res.body as { jsonData?: { chatId?: string } }).jsonData?.chatId);
 }
 
-const failureEvents = (id: string) => published.filter((p) => p.channel === SESSIONS_CHANNEL && p.data.id === id && p.data.event === "worker-failed");
-
 describe("a hidden worker that ends badly", () => {
-  it("is recorded and announced when its run reaches teardown unfinished", async () => {
+  it("is recorded when its run reaches teardown unfinished", async () => {
     const id = await spawn(true);
     expect(isFailedWorker(id)).toBe(false); // nothing decided while it runs
 
@@ -60,7 +51,18 @@ describe("a hidden worker that ends badly", () => {
     await runCompletionHook(id, { didError: true });
 
     expect(isFailedWorker(id)).toBe(true);
-    expect(failureEvents(id)).toHaveLength(1);
+  });
+
+  // The contract reap depends on. It fires the hook and then reads the flag on the very next
+  // line, so it can put the outcome on the SAME teardown message — which is what stops the
+  // generic notification racing ahead of the specific one. If this recorder ever became async,
+  // reap would publish `failed: false` and the failure would go unannounced, silently.
+  it("records SYNCHRONOUSLY, so reap can read the flag on the next line", async () => {
+    const id = await spawn(true);
+
+    void runCompletionHook(id, { didError: true }); // deliberately NOT awaited, as reap calls it
+
+    expect(isFailedWorker(id)).toBe(true);
   });
 
   it("is NOT recorded when its turn finished first", async () => {
@@ -72,7 +74,6 @@ describe("a hidden worker that ends badly", () => {
     await runCompletionHook(id, { didError: true }); // reap, moments later
 
     expect(isFailedWorker(id)).toBe(false);
-    expect(failureEvents(id)).toEqual([]);
   });
 
   it("says nothing for a WATCHED session that dies", async () => {
@@ -82,15 +83,5 @@ describe("a hidden worker that ends badly", () => {
     await runCompletionHook(id, { didError: true });
 
     expect(isFailedWorker(id)).toBe(false);
-    expect(failureEvents(id)).toEqual([]);
-  });
-
-  it("announces on the sessions channel with the shape the browser reads", async () => {
-    // notifyKindOf keys on `event`; the id is what the row is matched by. Pinned because the two
-    // sides of this message are in different files and nothing else compares them.
-    const id = await spawn(true);
-    await runCompletionHook(id, { didError: true });
-
-    expect(failureEvents(id)[0].data).toEqual({ id, working: false, event: "worker-failed" });
   });
 });

--- a/test/server/routes/worker-failure-wiring.spec.ts
+++ b/test/server/routes/worker-failure-wiring.spec.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+// The wiring between a hidden spawn and the failure it may end in.
+//
+// Each piece has its own spec — the record persists, the notify kind derives — and none of them
+// prove the pieces are CONNECTED. This drives the real route and the real completion hook, which
+// is the only place the decision "a hidden worker that never finished a turn has failed" actually
+// happens.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// The registry persists what it records. node:fs is MOCKED rather than pointing HOME at a temp
+// dir (tool-group-reset.spec's pattern): process.env is shared by every file in a vitest worker,
+// so moving HOME here reached specs with nothing to do with this one and failed them
+// intermittently. What is under test is the in-memory decision; persistence has its own spec.
+vi.mock("node:fs", () => {
+  const promises = {
+    readFile: vi.fn(async () => ""),
+    appendFile: vi.fn(async () => undefined),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  return { promises, default: { promises } };
+});
+
+const { mountPluginRoutes } = await import("../../../server/routes/plugin-routes.js");
+const { runCompletionHook } = await import("../../../server/session/completion-hooks.js");
+const { isFailedWorker } = await import("../../../server/session/registry.js");
+const { SESSIONS_CHANNEL } = await import("../../../server/session/lifecycle.js");
+
+let published: { channel: string; data: Record<string, unknown> }[] = [];
+const app = express();
+app.use(express.json());
+mountPluginRoutes(app, {
+  spawnClaudePty: (() => ({})) as never,
+  spawnCodexPty: (() => ({})) as never,
+  spawnAntigravityPty: (() => ({})) as never,
+  registerBackgroundSession: () => {},
+  publish: (channel, data) => void published.push({ channel, data: data as Record<string, unknown> }),
+});
+
+beforeEach(() => {
+  published = [];
+});
+
+/** Spawn through the real route and hand back the id it minted. */
+async function spawn(hidden: boolean): Promise<string> {
+  const res = await request(app).post("/api/plugin/spawnBackgroundChat").send({ message: "do the thing", hidden });
+  return String((res.body as { jsonData?: { chatId?: string } }).jsonData?.chatId);
+}
+
+const failureEvents = (id: string) => published.filter((p) => p.channel === SESSIONS_CHANNEL && p.data.id === id && p.data.event === "worker-failed");
+
+describe("a hidden worker that ends badly", () => {
+  it("is recorded and announced when its run reaches teardown unfinished", async () => {
+    const id = await spawn(true);
+    expect(isFailedWorker(id)).toBe(false); // nothing decided while it runs
+
+    // What lifecycle.reap() does for a session that never reported a finished turn.
+    await runCompletionHook(id, { didError: true });
+
+    expect(isFailedWorker(id)).toBe(true);
+    expect(failureEvents(id)).toHaveLength(1);
+  });
+
+  it("is NOT recorded when its turn finished first", async () => {
+    // The one-shot contract doing the real work: the Stop hook reports success, and the teardown
+    // that follows every session cannot overturn it. Without this, every successful worker would
+    // be marked failed the moment it was cleaned up.
+    const id = await spawn(true);
+    await runCompletionHook(id, { didError: false });
+    await runCompletionHook(id, { didError: true }); // reap, moments later
+
+    expect(isFailedWorker(id)).toBe(false);
+    expect(failureEvents(id)).toEqual([]);
+  });
+
+  it("says nothing for a WATCHED session that dies", async () => {
+    // hidden=false is a session with a cell: its failure is visible in its own terminal, and a
+    // second signal for it would be noise. No hook is registered at all.
+    const id = await spawn(false);
+    await runCompletionHook(id, { didError: true });
+
+    expect(isFailedWorker(id)).toBe(false);
+    expect(failureEvents(id)).toEqual([]);
+  });
+
+  it("announces on the sessions channel with the shape the browser reads", async () => {
+    // notifyKindOf keys on `event`; the id is what the row is matched by. Pinned because the two
+    // sides of this message are in different files and nothing else compares them.
+    const id = await spawn(true);
+    await runCompletionHook(id, { didError: true });
+
+    expect(failureEvents(id)[0].data).toEqual({ id, working: false, event: "worker-failed" });
+  });
+});

--- a/test/server/session/failed-workers.spec.ts
+++ b/test/server/session/failed-workers.spec.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+// Remembering that a background worker ended badly.
+//
+// The record is the durable half of the signal: the notification tells you now, this is what lets
+// you find out later. It has to survive a restart for the same reason it exists at all — nobody
+// was watching when it happened.
+//
+// node:fs is MOCKED rather than pointing HOME at a temp dir, following tool-group-reset.spec: the
+// env is shared by every file in a vitest worker, so moving HOME here reaches specs that have
+// nothing to do with this one. It did — two unrelated files failed intermittently before this was
+// written the other way.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const appended: { file: string; data: string }[] = [];
+
+vi.mock("node:fs", () => {
+  const promises = {
+    readFile: vi.fn(async () => ""), // every registry hydrator reads through this; none has content
+    appendFile: vi.fn(async (file: string, data: string) => {
+      appended.push({ file: String(file), data });
+    }),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  return { promises, default: { promises } };
+});
+
+const ID = "11111111-1111-1111-1111-111111111111";
+const OTHER = "22222222-2222-2222-2222-222222222222";
+
+async function freshRegistry() {
+  vi.resetModules();
+  appended.length = 0;
+  return import("../../../server/session/registry.js");
+}
+
+const failureLog = () =>
+  appended
+    .filter((a) => a.file.endsWith("failed-workers.json"))
+    .map((a) => a.data)
+    .join("");
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("failed workers", () => {
+  it("says no about a worker nobody reported", async () => {
+    const registry = await freshRegistry();
+    await registry.failedWorkersHydrated;
+    expect(registry.isFailedWorker(ID)).toBe(false);
+  });
+
+  it("remembers one that was reported", async () => {
+    const registry = await freshRegistry();
+    registry.markFailedWorker(ID);
+    expect(registry.isFailedWorker(ID)).toBe(true);
+    expect(registry.isFailedWorker(OTHER)).toBe(false);
+  });
+
+  it("persists it, so the failure outlives the process that saw it", async () => {
+    const registry = await freshRegistry();
+    registry.markFailedWorker(OTHER);
+    // The append is fire-and-forget; give its chain a turn to land.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(failureLog()).toContain(OTHER);
+  });
+
+  it("ignores an id that is not a session id", async () => {
+    // The mark is reached from a completion hook, so the id is server-generated — but this log is
+    // read back and compared against real ids, and a junk line would sit there forever.
+    const registry = await freshRegistry();
+    registry.markFailedWorker("../etc/passwd");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(failureLog()).not.toContain("passwd");
+    expect(registry.isFailedWorker("../etc/passwd")).toBe(false);
+  });
+
+  it("does not append the same id twice", async () => {
+    const registry = await freshRegistry();
+    registry.markFailedWorker(ID);
+    registry.markFailedWorker(ID);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(failureLog().split(ID).length - 1).toBe(1);
+  });
+
+  it("hydrates what a previous run recorded", async () => {
+    // The point of persisting: a restart must not forget a failure nobody has seen yet.
+    vi.resetModules();
+    const fs = await import("node:fs");
+    vi.mocked(fs.promises.readFile).mockImplementation(async (file: unknown) => (String(file).endsWith("failed-workers.json") ? ID : ""));
+    const registry = await import("../../../server/session/registry.js");
+    await registry.failedWorkersHydrated;
+    expect(registry.isFailedWorker(ID)).toBe(true);
+  });
+});

--- a/test/server/session/partitionPending.spec.ts
+++ b/test/server/session/partitionPending.spec.ts
@@ -22,7 +22,10 @@ describe("partitionPending", () => {
     const known: [string, KnownSession][] = [["b", meta("Draft", 42)]];
     const { keep, persisted } = partitionPending(known, new Set(), noActivity, noneHidden);
     expect(persisted).toEqual([]);
-    expect(keep).toEqual([{ kind: "pending", id: "b", title: "Draft", mtime: 42, working: false, waiting: false, event: null, hidden: false }]);
+    // `failed` is always false here, and that is a fact about pending rows rather than a default:
+    // a worker is recorded as failed at teardown, which drops it from knownSessions and so from
+    // this list — a row that is still pending has a live session behind it.
+    expect(keep).toEqual([{ kind: "pending", id: "b", title: "Draft", mtime: 42, working: false, waiting: false, event: null, hidden: false, failed: false }]);
   });
 
   it("derives working/waiting/event from the injected activity and hidden from isHidden", () => {

--- a/test/server/session/session-list.spec.ts
+++ b/test/server/session/session-list.spec.ts
@@ -12,6 +12,7 @@ const pending = (id: string, mtime: number): SessionRow => ({
   waiting: false,
   event: null,
   hidden: false,
+  failed: false,
 });
 const ids = (rows: SessionRow[]) => rows.map((r) => r.id);
 const filter = (over: Partial<Parameters<typeof selectSessionRows>[1]> = {}) => ({

--- a/test/server/session/worker-status.spec.ts
+++ b/test/server/session/worker-status.spec.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+// The SERVER half of the worker-status wire shape. Its sibling — test/common/workerStatus.spec.ts
+// — pins the client half and the asymmetry between them.
+//
+// Split across the two test projects rather than compared in one file, and not for tidiness: a
+// spec in the app project that imports a server type pulls node-pty's Node globals into that
+// program, and `window.setTimeout` in an unrelated component then resolves to Node's overload and
+// fails to compile. The cross-side agreement is carried by both files naming the same shared type.
+import { describe, it, expectTypeOf } from "vitest";
+import type { WorkerStatus } from "../../../common/workerStatus.js";
+import type { SessionMeta } from "../../../server/session/types.js";
+
+describe("worker status — the server's row", () => {
+  it("promises both fields, in full", () => {
+    // Required on this side: session-reads.ts fills both from the persisted marks on every row, so
+    // a row that omitted one would be a bug here rather than an older peer over the wire.
+    expectTypeOf<SessionMeta>().toExtend<WorkerStatus>();
+    expectTypeOf<SessionMeta["hidden"]>().toEqualTypeOf<boolean>();
+    expectTypeOf<SessionMeta["failed"]>().toEqualTypeOf<boolean>();
+  });
+});

--- a/test/src/components/TerminalCell.spec.ts
+++ b/test/src/components/TerminalCell.spec.ts
@@ -46,7 +46,10 @@ const dotClass = (w: ReturnType<typeof mount>) => w.find(".cell-dot").classes();
 
 // Route by URL: /api/scripts (run list), /api/sessions (resume list), or
 // /api/session/:id (activity).
-function mockFetch(sessions: { id: string; title: string; mtime: number }[] = [], scripts: { index: number; label: string; command: string }[] = []) {
+function mockFetch(
+  sessions: { id: string; title: string; mtime: number; hidden?: boolean; failed?: boolean }[] = [],
+  scripts: { index: number; label: string; command: string }[] = [],
+) {
   globalThis.fetch = vi.fn(async (url: string) => {
     const u = String(url);
     if (u.includes("/api/scripts")) return { ok: true, json: async () => ({ cwd: "/home/me/proj", scripts }) };
@@ -215,6 +218,44 @@ describe("TerminalCell", () => {
     expect(term.exists()).toBe(true);
     expect(term.props("sessionId")).toBe("77777777-7777-7777-7777-777777777777");
     expect(term.props("cwd")).toBe("/home/me/proj");
+  });
+
+  // A background worker has no cell and no bold row, so the launcher's list is where it is found.
+  // Unlabelled, it is indistinguishable from the user's own chats — and a FAILED one is the case
+  // nobody was ever told about, since it ran invisibly and ended without pulling any attention.
+  it("labels a background worker, and marks a failed one", async () => {
+    mockFetch([
+      { id: "77777777-7777-7777-7777-777777777777", title: "refresh feeds", mtime: Date.now(), hidden: true, failed: true },
+      { id: "88888888-8888-8888-8888-888888888888", title: "index the wiki", mtime: Date.now(), hidden: true },
+      { id: "99999999-9999-9999-9999-999999999999", title: "my own chat", mtime: Date.now() },
+    ]);
+    const w = mountCell(null, { defaultCwd: "/home/me/proj" });
+    await flushPromises();
+    const items = w.findAll('[data-testid="cell-resume-item"]');
+
+    // Failed wins over the plain background label: one badge, and it is the one that matters.
+    expect(items[0].find('[data-testid="ri-failed"]').exists()).toBe(true);
+    expect(items[0].find('[data-testid="ri-background"]').exists()).toBe(false);
+
+    expect(items[1].find('[data-testid="ri-background"]').exists()).toBe(true);
+    expect(items[1].find('[data-testid="ri-failed"]').exists()).toBe(false);
+
+    // An ordinary chat gets neither — the labels have to MEAN something to be worth reading.
+    expect(items[2].find('[data-testid="ri-background"]').exists()).toBe(false);
+    expect(items[2].find('[data-testid="ri-failed"]').exists()).toBe(false);
+  });
+
+  it("resumes a failed background worker into the cell like any other session", async () => {
+    // The point of labelling it: you can open it and read what happened. Nothing about being a
+    // worker makes it a different kind of thing to attach to.
+    const workerId = "77777777-7777-7777-7777-777777777777";
+    mockFetch([{ id: workerId, title: "refresh feeds", mtime: Date.now(), hidden: true, failed: true }]);
+    const w = mountCell(null, { defaultCwd: "/home/me/proj" });
+    await flushPromises();
+    await w.find('[data-testid="cell-resume-item"]').trigger("click");
+    const term = w.findComponent({ name: "TerminalView" });
+    expect(term.exists()).toBe(true);
+    expect(term.props("sessionId")).toBe(workerId);
   });
 
   it("flags a resumable row that's already open in another terminal", async () => {

--- a/test/src/composables/workerFailedNotify.spec.ts
+++ b/test/src/composables/workerFailedNotify.spec.ts
@@ -1,0 +1,36 @@
+// The one notification raised for a session with nothing on screen.
+//
+// A hidden background worker is invisible by design: no cell, no bold row, nothing waiting to be
+// clicked. That is right while it works and wrong when it dies — so this is the single kind whose
+// whole reason for existing is that nobody was watching.
+import { describe, it, expect } from "vitest";
+import { notifyKindOf, type ActivityState } from "../../../src/composables/notifyKind";
+
+const seen = () => new Map<string, ActivityState>();
+
+describe("notifyKindOf — worker-failed", () => {
+  it("raises it with no prior state at all", () => {
+    // THE case. Every other kind needs a baseline to compare against, and a worker never
+    // produces one — no cell ever subscribed to it working. Requiring a baseline here would drop
+    // exactly the notification that exists because nothing was watching.
+    const prev = seen();
+    expect(notifyKindOf(prev, { id: "w", event: "worker-failed" })).toBe("worker-failed");
+  });
+
+  it("wins over the `closed` that the same teardown also raises", () => {
+    // Reap publishes "closed" for every session and this for the failed worker; the specific
+    // answer must not be swallowed by the generic one, whichever order they arrive in.
+    const prev = seen();
+    notifyKindOf(prev, { id: "w", working: true, event: null });
+    expect(notifyKindOf(prev, { id: "w", event: "worker-failed" })).toBe("worker-failed");
+    // The session is forgotten either way, so a later "closed" is a baseline, not a second beep.
+    expect(notifyKindOf(prev, { id: "w", event: "closed" })).toBeNull();
+  });
+
+  it("still reports an ordinary session's exit as session-exited", () => {
+    // The generic path is untouched: a watched session that ends is not a failed worker.
+    const prev = seen();
+    notifyKindOf(prev, { id: "s", working: true, event: null });
+    expect(notifyKindOf(prev, { id: "s", event: "closed" })).toBe("session-exited");
+  });
+});

--- a/test/src/composables/workerFailedNotify.spec.ts
+++ b/test/src/composables/workerFailedNotify.spec.ts
@@ -14,16 +14,22 @@ describe("notifyKindOf — worker-failed", () => {
     // produces one — no cell ever subscribed to it working. Requiring a baseline here would drop
     // exactly the notification that exists because nothing was watching.
     const prev = seen();
-    expect(notifyKindOf(prev, { id: "w", event: "worker-failed" })).toBe("worker-failed");
+    expect(notifyKindOf(prev, { id: "w", event: "closed", failed: true })).toBe("worker-failed");
   });
 
-  it("wins over the `closed` that the same teardown also raises", () => {
-    // Reap publishes "closed" for every session and this for the failed worker; the specific
-    // answer must not be swallowed by the generic one, whichever order they arrive in.
+  it("wins over session-exited on the SAME teardown message", () => {
+    // The specific answer beats the generic one. Carried on one message precisely so the two
+    // cannot race: a separate "worker-failed" push let session-exited land first and beep twice
+    // for a single event (Codex, #1188).
     const prev = seen();
     notifyKindOf(prev, { id: "w", working: true, event: null });
-    expect(notifyKindOf(prev, { id: "w", event: "worker-failed" })).toBe("worker-failed");
-    // The session is forgotten either way, so a later "closed" is a baseline, not a second beep.
+    expect(notifyKindOf(prev, { id: "w", event: "closed", failed: true })).toBe("worker-failed");
+  });
+
+  it("forgets the session either way, so an id that comes back is a baseline", () => {
+    const prev = seen();
+    notifyKindOf(prev, { id: "w", working: true, event: null });
+    notifyKindOf(prev, { id: "w", event: "closed", failed: true });
     expect(notifyKindOf(prev, { id: "w", event: "closed" })).toBeNull();
   });
 
@@ -32,5 +38,8 @@ describe("notifyKindOf — worker-failed", () => {
     const prev = seen();
     notifyKindOf(prev, { id: "s", working: true, event: null });
     expect(notifyKindOf(prev, { id: "s", event: "closed" })).toBe("session-exited");
+    // ...and an explicit `failed: false` is just an ordinary teardown, not a silent one.
+    notifyKindOf(prev, { id: "t", working: true, event: null });
+    expect(notifyKindOf(prev, { id: "t", event: "closed", failed: false })).toBe("session-exited");
   });
 });


### PR DESCRIPTION
Two independent changes, one commit each. Both come out of the same question — what happens to a truly background chat (`hidden: true`) once the single terminal view is gone — and the second was found by the owner while looking at the first.

They can be split into two PRs if preferred; they share only `registry.ts`.

---

## 1. `fix:` ungrouped tools were hidden from cells that had them

**Reported:** `spawnBackgroundChat` was missing from the tool list of a cell that could call it.

`narrowedTools` used *"is this a grid cell?"* as a stand-in for *"does it have only what its directory registered?"*. That held while a grid cell never received `--mcp-config`. It stopped holding twice over:

- **#1167** made an adopted chat report tool groups, and
- **#1187** gave a workspace cell the whole GUI MCP.

An ungrouped tool is reachable through **no group url**, so the filter dropped it from sessions that genuinely had it. Because every *other* tool now appears, it was the one conspicuous absence.

**The fix records the fact instead of inferring it.** Connecting to the all-tools url (`/api/mcp/:sessionId`) is proof of the whole MCP — `--mcp-config` is the only thing that hands that url out. That is now its own persisted mark, deliberately **separate from the group list**:

> "has all four groups" and "has the whole MCP" are different statements. A directory that registered all four group urls has the first and **not** the second.

A test pins exactly that distinction. It also shows the limit of the #1167 fix: recording the four groups was enough for the Canvas gate and could never be enough here, because a group list cannot express a tool that has no group.

**Audit of the whole map while here:** `spawnBackgroundChat` is the **only** ungrouped tool, and no map entry names a tool the server does not expose. It stays ungrouped on purpose — a plain grid cell has no business spawning sessions silently.

---

## 2. `feat:` background workers are findable, and a failed one says so

A hidden worker — `spawnBackgroundChat hidden:true`, a scheduled feed refresh — runs with no cell, no bold row, and nothing waiting to be clicked. That is right while it works. It is **wrong when it dies**: nothing pulls attention, so the failure is simply never learned.

It also has to be handled before the single view can go: the Background filter that lists these lives inside `App.vue`'s `!isGrid` block and would be deleted with it.

### Most of this already existed

Background workers are **already** in the grid launcher's "or resume here" list — `selectSessionRows` includes them in the cwd-scoped query with their own row cap — and every row **already** carries `hidden`. So adopting one into a cell needed no new mechanism: clicking the row already resumes it.

What was missing was being able to tell which rows they were.

### What was added

| | |
|---|---|
| **Label** | The launcher marks a background worker, and a failed one as `● failed`. Failed wins over the plain label — one badge, and it is the one that matters. |
| **Record** | A persisted set. Persistence is the point, not an optimisation: the value here is finding out **later**, and a live-only flag would be cleared by the very reap that discovers the failure. |
| **Outcome** | The `completion-hooks` seam that already exists for this ("a callback fired when a hidden worker finishes, so whoever dispatched it learns the outcome"). Its first-answer-wins contract already means what is needed: a finished turn reports success, and reaching teardown with no Stop means no turn ever completed. |
| **Signal** | A `worker-failed` notify kind. |

No clash with the feeds engine's own completion hook — that dispatches through its own spawner in `index.ts` and never this route.

`worker-failed` is checked **before** `closed` (the same teardown raises both) and deliberately needs **no prior state**. Every other kind compares against a baseline, and a worker never produces one — requiring it would drop the single notification that exists *because* nothing was watching.

### One decision worth stating

**The badge is always on; the sound is opt-in.** `notifyKinds.ts` is emphatic that a new kind must not start beeping at people who never asked, and it says so because that was violated once before. The durable half is what fixes "you would never find out"; the sound is what makes you look now. Easy to flip if the owner would rather it default on.

---

## On testing this

Each piece had a spec and none of them proved the pieces were **connected**. `worker-failure-wiring.spec.ts` now drives the real route and the real completion hook — the only place the decision "a hidden worker that never finished a turn has failed" actually happens — covering all four cases including the one that matters most: a worker whose turn finished first is **not** marked failed by the teardown that follows.

Two problems found and fixed in my own tests along the way, both worth naming:

- **The first three tests passed against the broken code.** They used `vi.waitFor`, which succeeds on the state *before* the merge runs. Switched to `flushPromises`; all three then failed, and passed with the fix.
- **Two specs set `process.env.HOME` to a temp dir**, which is process-wide and shared by every file in a vitest worker. Rewritten to mock `node:fs`, following `tool-group-reset.spec`'s existing pattern.

  **Correction to an earlier claim in this PR:** I first wrote that this was *causing* intermittent failures in unrelated specs. That was wrong, and it was concluded from one clean run against one failing run. Running `main` itself four times fails 2 of 4, each time on a different unrelated file (`files-browse`, `unusable-cwd-routes`, `mulmoscript`, `drop-route`). **The flakiness is pre-existing and unrelated to this PR** — and `vitest.config.ts` already documents the mechanism: files run in parallel across all cores, so "the victim is whichever test is running at peak load, not any one test". The `node:fs` rewrite still stands on its own merits (process-wide env mutation shared across a worker is a real hazard, and the repo has a precedent for avoiding it), but it fixed nothing.

Every new assertion was checked to fail without its fix.

**To see a real failure end to end** (the origin guard allows a same-machine caller with no `Origin`):

```
curl -s -X POST localhost:<port>/api/plugin/spawnBackgroundChat \
  -H 'content-type: application/json' \
  -d '{"message":"sleep for a while","hidden":true}'
# -> jsonData.chatId
tmux kill-session -t <chatId>
```

The PTY exit reaches `reap`, the hook fires with `didError: true`. An empty grid cell at `{workspace}` should then show the row as `● failed`.

## Verified

- `yarn test` — 7053 tests pass. Note the pre-existing parallel-load flakiness described above: a run may fail on one unrelated file, and `main` does the same.
- `yarn typecheck` / `:test` / `:server` all pass
- `yarn lint` 0 errors (4 pre-existing max-lines warnings), `yarn build` succeeds

**Not verified:** anything in a running app. The tool list and the badge are covered by tests, not by eyes.

---

## 3. `refactor:` the worker-status wire shape moved to `common/` (review follow-up)

CodeRabbit: `hidden` and `failed` are written by the server and read by the launcher, so they are a wire shape — and CLAUDE.md is explicit that a type both sides decide from belongs in `common/` rather than mirrored into `server/` and `src/`. It was right; they were mirrored.

The two sides genuinely differ, so this follows the pattern the rule prescribes (`common/sourceExtensions.ts`): share the core, keep each side's extras local, and **pin the asymmetry with a test**. The server always fills both fields; the client's are optional, because a page left open across an upgrade parses rows from a server that predates them.

The pin is split across the two test projects, and not for tidiness: a spec in the app project that imports a server type pulls node-pty's Node globals into that program, and `window.setTimeout` in an unrelated component then resolves to Node's overload and fails to compile. I hit exactly that while writing it.

**Not taken from the same review:** replacing `●` in the failed badge with a Material Symbol. CLAUDE.md allows it explicitly — *"Compact status notation stays text, not icons: `⎇ main ●3 ↑2`, `●` unsaved dots"* — and the same file already renders `● open` and a `●` dirty dot two lines away.

Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
