### PR TITLE
feat: adopt sessions the server spawned while nothing was open

### DIFF
--- a/plans/feat-remove-single-view.md
+++ b/plans/feat-remove-single-view.md
@@ -335,7 +335,33 @@ store — it is not client-only here.
    So a `presentCollection` result renders in a grid cell exactly as it does in the single view.
    Nothing to build here; the seeding work is all that is left.
 
-#### PR3b — the durable half
+#### PR3b — the durable half — **DONE**
+
+Implemented, with two departures from what is written below:
+
+1. **No new pub/sub channel.** The plan opened with a `publishToOne` sibling of
+   `LAUNCH_TERMINAL_CHANNEL`. It is not needed: reconciliation runs on **activate**, not mount, so
+   switching to the grid picks up everything spawned while the user was elsewhere — and if the grid
+   is not mounted there is nothing to deliver to anyway. A channel would only shorten the window
+   for a chat spawned while the user is *already sitting on* `/terminals`, at the cost of a second
+   mechanism that has to be kept from double-placing what the browser just placed. Worth adding
+   later if that window proves annoying; not worth it up front.
+2. **The marker needs a second log, not one.** `MULMOTERMINAL_HOME` is shared between server
+   instances so these logs are append-only, and hydration reads the unplaced log as it was —
+   including ids that a later line has since answered. A single log would therefore re-adopt, on
+   every load, every session any grid has ever taken. So "placed" is its own append-only log and
+   `unplacedSessionIds()` is the difference. A spec pins exactly that (`does not hand back a
+   session that was placed BEFORE this process started`).
+
+Also worth recording: the mark is cleared on **any** attach, not just a grid one — "unplaced" means
+nobody is looking, and a viewer is a viewer. That is what stops a browser-placed chat coming back
+as a duplicate on the next load, and it lands at `ws-routes`' four attach points, the same choke
+points `markDevTerminalSession` uses.
+
+The cap policy is still unanswered, and this PR does not force it: a full grid simply leaves the
+session marked, so the next load with room adopts it. PR5 is where it has to be decided.
+
+---
 
 The server-side unplaced marker + reconciliation on grid load, i.e. the case where no tab was
 open at all. Details below.

--- a/server/index.ts
+++ b/server/index.ts
@@ -66,6 +66,7 @@ import {
   sessionCwd,
   sessionMemos,
   sessionMemosHydrated,
+  markUnplacedSession,
 } from "./session/registry.js";
 import { hydrateClearedTranscripts } from "./session/cleared-transcripts.js";
 import { runWithHiddenMarker } from "./session/hiddenMarker.js";
@@ -560,6 +561,9 @@ initFeedsBackend({ workspace: CLAUDE_CWD, spawnWorker: feedsSpawnWorker });
 const remoteHostSpawnChat = (message: string) => {
   const sessionId = randomUUID();
   spawnClaudePty(sessionId, null, null, { initialPrompt: message });
+  // Started from the PHONE, so by definition no browser placed it. Marked so the next grid to
+  // load adopts it instead of leaving a live agent with nowhere to appear.
+  markUnplacedSession(sessionId);
   return { chatId: sessionId };
 };
 // The phone's remote terminal view (#435). Both accessors live here because the PTY table
@@ -774,6 +778,9 @@ function spawnScheduledChat(message: string): void {
   try {
     spawnClaudePty(sessionId, null, null, { initialPrompt: message });
     scheduledSessions.register(sessionId);
+    // The clearest case for the unplaced mark: a task firing at 3am has no browser to place its
+    // chat, and without this the only trace would be a row in a list nobody is looking at.
+    markUnplacedSession(sessionId);
   } catch (err) {
     console.error(`[scheduler] failed to spawn chat for a scheduled task: ${messageOf(err)}`);
   }

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -68,7 +68,7 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
       // places it immediately (useChatLauncher), and this covers every other caller — an agent
       // calling the tool from another session, with no tab open at all. The mark is cleared the
       // moment any cell attaches, so the browser-placed case does not come back as a duplicate.
-      if (!hidden) markUnplacedSession(sessionId);
+      if (!hidden) markUnplacedSession(sessionId, agent);
       if (hidden) {
         deps.registerBackgroundSession(sessionId);
         // A hidden worker is invisible on purpose, which is exactly why a FAILED one needs a

--- a/server/routes/plugin-routes.ts
+++ b/server/routes/plugin-routes.ts
@@ -10,7 +10,7 @@ import type { Express } from "express";
 import { CLAUDE_CWD, PORT } from "../config/env.js";
 import { messageOf } from "../errors.js";
 import { isRecord } from "../../common/isRecord.js";
-import { backgroundMarkers, markFailedWorker } from "../session/registry.js";
+import { backgroundMarkers, markFailedWorker, markUnplacedSession } from "../session/registry.js";
 import { runWithHiddenMarker } from "../session/hiddenMarker.js";
 import { registerCompletionHook } from "../session/completion-hooks.js";
 import { backgroundChatMessage, parseBackgroundChat, spawnModeFor } from "../session/background-chat.js";
@@ -64,6 +64,11 @@ export function mountPluginRoutes(app: Express, deps: PluginRouteDeps): void {
         else if (mode === "claude-draft") deps.spawnClaudePty(sessionId, null, null, { draft: message });
         else deps.spawnClaudePty(sessionId, null, null, { initialPrompt: message });
       });
+      // Visible: somebody should be able to SEE this session. The browser that asked for it
+      // places it immediately (useChatLauncher), and this covers every other caller — an agent
+      // calling the tool from another session, with no tab open at all. The mark is cleared the
+      // moment any cell attaches, so the browser-placed case does not come back as a duplicate.
+      if (!hidden) markUnplacedSession(sessionId);
       if (hidden) {
         deps.registerBackgroundSession(sessionId);
         // A hidden worker is invisible on purpose, which is exactly why a FAILED one needs a

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -16,6 +16,10 @@ import {
   aiTitles,
   backgroundSessionsHydrated,
   failedWorkersHydrated,
+  unplacedSessionsHydrated,
+  placedSessionsHydrated,
+  unplacedSessionIds,
+  ptys,
   devTerminalSessions,
   devTerminalSessionsHydrated,
   isBackgroundSession,
@@ -241,5 +245,26 @@ export function mountSessionRoutes(app: Express, deps: SessionRouteDeps): void {
   app.get("/api/transcript/timeline", toolTimeline);
   app.get("/api/transcript/last-turn", lastTurn);
   app.get("/api/sessions", sessionList);
+  // The sessions a loading grid should adopt: spawned VISIBLE by the server and never taken by a
+  // cell (a scheduled task's chat, one the phone started, one an agent started from another
+  // session). Deliberately its own endpoint answering a server-side marker, rather than the grid
+  // diffing "all sessions" against its own state: a diff would sweep up ordinary sessions and
+  // change what a reload does to a normal cell, which is the one thing this whole line of work
+  // must not do.
+  //
+  // Hidden workers are absent by construction — the mark is only ever set for a visible spawn —
+  // and a spec pins that, since "it happens not to be marked" and "it cannot be marked" read the
+  // same until someone adds a caller.
+  app.get("/api/sessions/unplaced", async (_req, res) => {
+    await Promise.all([unplacedSessionsHydrated, placedSessionsHydrated]);
+    const sessions = unplacedSessionIds().map((id) => {
+      const entry = ptys.get(id);
+      // A session whose PTY is gone (the server restarted, tmux ended) is still worth adopting —
+      // the cell resumes it from disk. It just cannot say which agent or directory it used, so
+      // the grid falls back to its own defaults.
+      return { id, agent: entry?.agent ?? null, cwd: entry?.cwd ?? null };
+    });
+    res.json({ sessions });
+  });
   app.get("/api/codex/sessions", codexSessionList);
 }

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -18,7 +18,7 @@ import {
   failedWorkersHydrated,
   unplacedSessionsHydrated,
   placedSessionsHydrated,
-  unplacedSessionIds,
+  unplacedSessionRows,
   ptys,
   devTerminalSessions,
   devTerminalSessionsHydrated,
@@ -257,12 +257,14 @@ export function mountSessionRoutes(app: Express, deps: SessionRouteDeps): void {
   // same until someone adds a caller.
   app.get("/api/sessions/unplaced", async (_req, res) => {
     await Promise.all([unplacedSessionsHydrated, placedSessionsHydrated]);
-    const sessions = unplacedSessionIds().map((id) => {
+    const sessions = unplacedSessionRows().map(({ id, agent }) => {
       const entry = ptys.get(id);
       // A session whose PTY is gone (the server restarted, tmux ended) is still worth adopting —
-      // the cell resumes it from disk. It just cannot say which agent or directory it used, so
-      // the grid falls back to its own defaults.
-      return { id, agent: entry?.agent ?? null, cwd: entry?.cwd ?? null };
+      // the cell resumes it from disk. The AGENT comes from the mark rather than the entry for
+      // exactly that case: a codex session adopted as claude reconnects on the wrong endpoint, and
+      // the entry that would have said so is what is missing (Codex, PR #1189). The live entry
+      // still wins when there is one — it is the process actually running.
+      return { id, agent: entry?.agent ?? agent, cwd: entry?.cwd ?? null };
     });
     res.json({ sessions });
   });

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -22,7 +22,14 @@ import { launchChoiceFromParams } from "../session/launch-choice.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { antigravityBrainRoot, antigravityConversationExists } from "../agents/antigravity-session.js";
 import { codexRolloutExists } from "../agents/codex-sessions.js";
-import { antigravityConversations, antigravityConversationsHydrated, codexRolloutIds, markDevTerminalSession, ptys } from "../session/registry.js";
+import {
+  antigravityConversations,
+  antigravityConversationsHydrated,
+  codexRolloutIds,
+  markDevTerminalSession,
+  markSessionPlaced,
+  ptys,
+} from "../session/registry.js";
 import { sandboxWouldRun, SpawnRefusedError } from "../session/pty-spawn.js";
 import { bufferEarlyFrames, type EarlyFrames } from "../session/early-frames.js";
 import { launcherCommandWithGuiMcp } from "../session/launcher-gui-mcp.js";
@@ -324,6 +331,10 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // choke point for every grid attach — new, resumed, or reattached — so the mark is
   // recorded (and re-recorded after a reboot when the cell reconnects) exactly once.
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
+  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
+  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
+  // This is the one choke point every attach passes through — new, resumed or reattached.
+  markSessionPlaced(sessionId);
 
   // Tell the browser which session this is (it learns the id of new sessions) and
   // the EFFECTIVE cwd — where claude really runs. On reattach that's the live
@@ -457,6 +468,10 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   if (!resolved) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
   const { sessionId, live, command } = resolved;
   markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
+  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
+  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
+  // This is the one choke point every attach passes through — new, resumed or reattached.
+  markSessionPlaced(sessionId);
   const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
 
   // A launcher that runs codex gets the directory's registered tool groups too. The chip and the
@@ -485,6 +500,10 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUp
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
+  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
+  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
+  // This is the one choke point every attach passes through — new, resumed or reattached.
+  markSessionPlaced(sessionId);
   const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
 
   // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
@@ -554,6 +573,10 @@ async function handleAntigravityConnection(deps: WsRouteDeps, ws: WebSocket, req
   await antigravityConversationsHydrated;
   const { sessionId, live, resumeConversationId } = resolveAntigravitySession(requested);
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
+  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
+  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
+  // This is the one choke point every attach passes through — new, resumed or reattached.
+  markSessionPlaced(sessionId);
   const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
 
   // The directory's registered groups, read here because the lookup reads Claude Code's config

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -27,7 +27,7 @@ import {
   antigravityConversationsHydrated,
   codexRolloutIds,
   markDevTerminalSession,
-  markSessionPlaced,
+  markAttachedSessionPlaced,
   ptys,
 } from "../session/registry.js";
 import { sandboxWouldRun, SpawnRefusedError } from "../session/pty-spawn.js";
@@ -292,22 +292,6 @@ function startCodexEntry(deps: WsRouteDeps, ws: WebSocket, start: CodexStart): P
   const { sessionId, live, resumeRolloutId, cwd, attachGuiMcp, mcpGroups } = start;
   if (live) return deps.reattachPty(live, ws, sessionId);
   return deps.spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp, { mcpGroups }); // interactive: no seed
-}
-
-/**
- * A viewer now has this session, so it stops waiting for a home (see the unplaced marker).
- *
- * BOTH ids. The resolvers mint a FRESH one when the requested session can be served neither from a
- * live pty nor from a transcript — a spawn that died before writing one, which is exactly the kind
- * that ends up unplaced. Clearing only the new id would leave the requested one marked forever, so
- * every activate would adopt it again and mint another session, accumulating cells (Codex, #1189).
- *
- * Cleared for ANY attach, not only a grid one: "unplaced" means nobody is looking, and a viewer is
- * a viewer.
- */
-function markAttachedSessionPlaced(sessionId: string, requested: string | null): void {
-  markSessionPlaced(sessionId);
-  if (requested && requested !== sessionId) markSessionPlaced(requested);
 }
 
 async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {

--- a/server/routes/ws-routes.ts
+++ b/server/routes/ws-routes.ts
@@ -294,6 +294,22 @@ function startCodexEntry(deps: WsRouteDeps, ws: WebSocket, start: CodexStart): P
   return deps.spawnCodexPty(sessionId, ws, resumeRolloutId, cwd, attachGuiMcp, { mcpGroups }); // interactive: no seed
 }
 
+/**
+ * A viewer now has this session, so it stops waiting for a home (see the unplaced marker).
+ *
+ * BOTH ids. The resolvers mint a FRESH one when the requested session can be served neither from a
+ * live pty nor from a transcript — a spawn that died before writing one, which is exactly the kind
+ * that ends up unplaced. Clearing only the new id would leave the requested one marked forever, so
+ * every activate would adopt it again and mint another session, accumulating cells (Codex, #1189).
+ *
+ * Cleared for ANY attach, not only a grid one: "unplaced" means nobody is looking, and a viewer is
+ * a viewer.
+ */
+function markAttachedSessionPlaced(sessionId: string, requested: string | null): void {
+  markSessionPlaced(sessionId);
+  if (requested && requested !== sessionId) markSessionPlaced(requested);
+}
+
 async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUpgradeRequest) {
   // ?session=<id> resumes an existing conversation; absent => fresh session. For
   // new sessions we generate the id ourselves (--session-id) so the server always
@@ -331,10 +347,7 @@ async function handleClaudeConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   // choke point for every grid attach — new, resumed, or reattached — so the mark is
   // recorded (and re-recorded after a reboot when the cell reconnects) exactly once.
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
-  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
-  // This is the one choke point every attach passes through — new, resumed or reattached.
-  markSessionPlaced(sessionId);
+  markAttachedSessionPlaced(sessionId, requested);
 
   // Tell the browser which session this is (it learns the id of new sessions) and
   // the EFFECTIVE cwd — where claude really runs. On reattach that's the live
@@ -468,10 +481,7 @@ async function handleLaunchConnection(deps: WsRouteDeps, ws: WebSocket, req: WsU
   if (!resolved) return closeWithError(ws, "Launcher not found — check Settings → Launch commands.");
   const { sessionId, live, command } = resolved;
   markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
-  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
-  // This is the one choke point every attach passes through — new, resumed or reattached.
-  markSessionPlaced(sessionId);
+  markAttachedSessionPlaced(sessionId, requested);
   const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
 
   // A launcher that runs codex gets the directory's registered tool groups too. The chip and the
@@ -500,10 +510,7 @@ async function handleCodexConnection(deps: WsRouteDeps, ws: WebSocket, req: WsUp
 
   const { sessionId, live, resumeRolloutId } = resolveCodexSession(requested);
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
-  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
-  // This is the one choke point every attach passes through — new, resumed or reattached.
-  markSessionPlaced(sessionId);
+  markAttachedSessionPlaced(sessionId, requested);
   const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
 
   // A grid cell's GUI tools are whatever its DIRECTORY registered — the same switches claude's
@@ -573,10 +580,7 @@ async function handleAntigravityConnection(deps: WsRouteDeps, ws: WebSocket, req
   await antigravityConversationsHydrated;
   const { sessionId, live, resumeConversationId } = resolveAntigravitySession(requested);
   if (!attachGuiMcp) markDevTerminalSession(sessionId, effectiveSessionCwd(live?.cwd, cwd));
-  // Someone now has this session on screen, so it is no longer waiting for a home. Cleared for
-  // ANY attach, not just a grid one: "unplaced" means nobody is looking, and a viewer is a viewer.
-  // This is the one choke point every attach passes through — new, resumed or reattached.
-  markSessionPlaced(sessionId);
+  markAttachedSessionPlaced(sessionId, requested);
   const early = announceSession(ws, sessionId, live?.cwd ?? cwd);
 
   // The directory's registered groups, read here because the lookup reads Claude Code's config

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -275,6 +275,22 @@ const PLACED_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "placed-sessions.json
 export const placedSessionsHydrated = hydrateIdLog(PLACED_SESSIONS_FILE, placedSessions);
 const appendPlacedSession = idLogAppender(PLACED_SESSIONS_FILE, "placed-sessions");
 
+/**
+ * A viewer now has this session, so it stops waiting for a home (see the unplaced marker).
+ *
+ * BOTH ids. The resolvers mint a FRESH one when the requested session can be served neither from a
+ * live pty nor from a transcript — a spawn that died before writing one, which is exactly the kind
+ * that ends up unplaced. Clearing only the new id would leave the requested one marked forever, so
+ * every activate would adopt it again and mint another session, accumulating cells (Codex, #1189).
+ *
+ * Cleared for ANY attach, not only a grid one: "unplaced" means nobody is looking, and a viewer is
+ * a viewer.
+ */
+export function markAttachedSessionPlaced(sessionId: string, requested: string | null): void {
+  markSessionPlaced(sessionId);
+  if (requested && requested !== sessionId) markSessionPlaced(requested);
+}
+
 /** The sessions a loading grid should adopt: spawned visible by the server, never taken. */
 export function unplacedSessionRows(): { id: string; agent: TerminalAgent }[] {
   return [...unplacedSessions].filter(([id]) => !placedSessions.has(id)).map(([id, agent]) => ({ id, agent }));

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -11,6 +11,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { MULMOTERMINAL_HOME, SESSION_ID_RE } from "../config/env.js";
 import type { DirModelChoice } from "./provider-env.js";
+import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent.js";
 import { messageOf } from "../errors.js";
 import { buildActivitySnapshot, mergeOwnedActivity, parseActivityState, type PersistedActivity } from "./activity-state.js";
 import { parseSessionIdLog, sessionIdLogLine } from "./session-id-log.js";
@@ -216,21 +217,44 @@ export function isBackgroundSession(id: string): boolean {
 //
 // Persisted because the case it exists for is precisely "nobody was looking": a mark held only in
 // memory would be lost by the restart that happens before anyone opens a tab.
-const unplacedSessions = new Set<string>();
+// `<session id> <agent>` per line, because the ID ALONE is not enough to reconnect. A cell adopting
+// a codex session over claude's endpoint attaches to the wrong agent, and the live PtyEntry that
+// would have said so is exactly what is gone in the case this exists for — the server restarted,
+// or the pty was reaped, before anyone opened a tab (Codex, PR #1189).
+const unplacedSessions = new Map<string, TerminalAgent>();
 const UNPLACED_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "unplaced-sessions.json");
-export const unplacedSessionsHydrated = hydrateIdLog(UNPLACED_SESSIONS_FILE, unplacedSessions);
-const appendUnplacedSession = idLogAppender(UNPLACED_SESSIONS_FILE, "unplaced-sessions");
+export const unplacedSessionsHydrated = (async () => {
+  try {
+    const contents = await fs.readFile(UNPLACED_SESSIONS_FILE, "utf8");
+    for (const line of contents.split("\n")) {
+      const [id, agent] = line.trim().split(/\s+/);
+      // A line with no agent is one written before this field existed; claude is what those were.
+      if (id && isValidSessionId(id)) unplacedSessions.set(id, asTerminalAgent(agent));
+    }
+  } catch {
+    // absent on first run / unreadable => nothing waiting
+  }
+})();
+let unplacedPersist: Promise<void> = Promise.resolve();
+function appendUnplacedSession(id: string, agent: TerminalAgent): void {
+  unplacedPersist = unplacedPersist
+    .then(() => fs.mkdir(MULMOTERMINAL_HOME, { recursive: true }))
+    .then(() => fs.appendFile(UNPLACED_SESSIONS_FILE, `\n${id} ${agent}`))
+    .catch((e) => console.error(`[unplaced-sessions] failed to persist: ${messageOf(e)}`));
+}
 // Ids whose mark has been cleared this process. The log is append-only (MULMOTERMINAL_HOME is
 // shared between server instances, so a read-merge-write loses one of them), and hydration reads
 // it as it was BEFORE a clear could be appended — so without this a session adopted during startup
 // would be handed back as unplaced.
 const placedSessions = new Set<string>();
 
-/** Note that the server spawned a VISIBLE session nobody has a cell for yet. */
-export function markUnplacedSession(id: string): void {
+/** Note that the server spawned a VISIBLE session nobody has a cell for yet. The agent travels
+ *  with the id for the same reason it does everywhere else: the cell has to reconnect on the right
+ *  endpoint, and by the time this is read the running process may be gone. */
+export function markUnplacedSession(id: string, agent: TerminalAgent = "claude"): void {
   if (!isValidSessionId(id) || unplacedSessions.has(id)) return;
-  unplacedSessions.add(id);
-  appendUnplacedSession(id);
+  unplacedSessions.set(id, agent);
+  appendUnplacedSession(id, agent);
 }
 
 /** A grid cell has taken this session — or the user closed it. Either way it is no longer waiting
@@ -246,8 +270,8 @@ export const placedSessionsHydrated = hydrateIdLog(PLACED_SESSIONS_FILE, placedS
 const appendPlacedSession = idLogAppender(PLACED_SESSIONS_FILE, "placed-sessions");
 
 /** The sessions a loading grid should adopt: spawned visible by the server, never taken. */
-export function unplacedSessionIds(): string[] {
-  return [...unplacedSessions].filter((id) => !placedSessions.has(id));
+export function unplacedSessionRows(): { id: string; agent: TerminalAgent }[] {
+  return [...unplacedSessions].filter(([id]) => !placedSessions.has(id)).map(([id, agent]) => ({ id, agent }));
 }
 
 // Sessions that connected on the ALL-TOOLS MCP url (`/api/mcp/:sessionId`). That url is handed

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -201,6 +201,55 @@ export function isBackgroundSession(id: string): boolean {
   return hiddenSessions.has(id) || backgroundSessions.has(id);
 }
 
+// Visible sessions the SERVER spawned that no grid cell has taken yet.
+//
+// A chat started from the collections UI is placed by the browser that asked for it, which covers
+// the common case and only that case: an agent calling spawnBackgroundChat, a scheduled task, or
+// the phone can all start a visible chat while no tab is open at all — and once the single view is
+// gone there is nowhere for such a session to appear. This is the durable half: the server
+// remembers that one is waiting, and the next grid to load adopts it.
+//
+// UNPLACED is the whole meaning, so the mark is cleared the moment a grid cell attaches (see
+// ws-routes, the one choke point for every grid attach). That keeps it server-side state with one
+// writer, rather than a dismissed-set growing in each tab — and it is why a browser-placed chat
+// does not come back as a second cell on the next load.
+//
+// Persisted because the case it exists for is precisely "nobody was looking": a mark held only in
+// memory would be lost by the restart that happens before anyone opens a tab.
+const unplacedSessions = new Set<string>();
+const UNPLACED_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "unplaced-sessions.json");
+export const unplacedSessionsHydrated = hydrateIdLog(UNPLACED_SESSIONS_FILE, unplacedSessions);
+const appendUnplacedSession = idLogAppender(UNPLACED_SESSIONS_FILE, "unplaced-sessions");
+// Ids whose mark has been cleared this process. The log is append-only (MULMOTERMINAL_HOME is
+// shared between server instances, so a read-merge-write loses one of them), and hydration reads
+// it as it was BEFORE a clear could be appended — so without this a session adopted during startup
+// would be handed back as unplaced.
+const placedSessions = new Set<string>();
+
+/** Note that the server spawned a VISIBLE session nobody has a cell for yet. */
+export function markUnplacedSession(id: string): void {
+  if (!isValidSessionId(id) || unplacedSessions.has(id)) return;
+  unplacedSessions.add(id);
+  appendUnplacedSession(id);
+}
+
+/** A grid cell has taken this session — or the user closed it. Either way it is no longer waiting
+ *  for a home, and must not be adopted again on the next load. */
+export function markSessionPlaced(id: string): void {
+  if (!isValidSessionId(id)) return;
+  placedSessions.add(id);
+  unplacedSessions.delete(id);
+  appendPlacedSession(id);
+}
+const PLACED_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "placed-sessions.json");
+export const placedSessionsHydrated = hydrateIdLog(PLACED_SESSIONS_FILE, placedSessions);
+const appendPlacedSession = idLogAppender(PLACED_SESSIONS_FILE, "placed-sessions");
+
+/** The sessions a loading grid should adopt: spawned visible by the server, never taken. */
+export function unplacedSessionIds(): string[] {
+  return [...unplacedSessions].filter((id) => !placedSessions.has(id));
+}
+
 // Sessions that connected on the ALL-TOOLS MCP url (`/api/mcp/:sessionId`). That url is handed
 // out by --mcp-config and by nothing else, so reaching it is proof the session carries the whole
 // GUI MCP — including the tools that belong to no group and are therefore unreachable through a

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -261,8 +261,14 @@ export function markUnplacedSession(id: string, agent: TerminalAgent = "claude")
  *  for a home, and must not be adopted again on the next load. */
 export function markSessionPlaced(id: string): void {
   if (!isValidSessionId(id)) return;
-  placedSessions.add(id);
   unplacedSessions.delete(id);
+  // A no-op once known, like every other mark in this file — and here it is not just tidiness.
+  // This runs at ALL FOUR ws attach points, so a long-lived session reconnecting (a reload, a
+  // network blip, a page switch in the grid) would otherwise append a line every time: the log
+  // would grow with ATTACH count rather than session count, and /api/sessions/unplaced waits on
+  // hydrating it (Codex, PR #1189).
+  if (placedSessions.has(id)) return;
+  placedSessions.add(id);
   appendPlacedSession(id);
 }
 const PLACED_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "placed-sessions.json");

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -61,7 +61,7 @@ import { reportActiveTerminals } from "../composables/useUnloadGuard";
 import { useAppConfig } from "../composables/useAppConfig";
 import { fetchDirConfig, invalidateDirConfig, useDirPriorities } from "../composables/useDirConfig";
 import { nextSortMode } from "./sortModeButton";
-import type { TerminalAgent } from "../../common/sessionAgent";
+import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
 import { usePubSub } from "../composables/usePubSub";
 import type { LaunchAgent } from "../../common/launchAgent";
 import type { LaunchPick } from "./launchers";
@@ -513,6 +513,10 @@ const gridRef = ref<InstanceType<typeof TerminalGrid> | null>(null);
 // the collection UI's actions and template cards, custom views, the Settings skill buttons —
 // via useChatLauncher's one choke point.
 const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest) => {
+  // Already adopted — by the unplaced sweep below, or by an earlier request for the same session.
+  // Two cells for one session fight over its socket: the server supersedes the prior one, so the
+  // older cell goes dead while still looking live.
+  if (state.value.cells.some((cell) => cell.session === id)) return;
   // Seeded with the directory the server spawns these in (CLAUDE_CWD, which /api/config reports as
   // `cwd`); the cell adopts whatever the PTY reports anyway. sessionCell carries the agent, which
   // matters because a spawn follows the Claude/Codex/Antigravity toggle.
@@ -543,6 +547,37 @@ const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest) => {
   // After the state renders: the grid has to be showing the cell before it can enlarge it.
   if (uid !== undefined) void nextTick(() => gridRef.value?.openCanvasFor(uid));
 };
+// Sessions the SERVER spawned that no cell has taken — a scheduled task's chat, one the phone
+// started, one an agent started from another session. The browser that asks for a chat places it
+// itself (placeChat above); this is the other half, for when there was no browser at all.
+//
+// Asked on ACTIVATE rather than mount: the grid is kept alive across route changes, so mount fires
+// once per page load and would miss everything spawned while the user was elsewhere in the app.
+async function adoptUnplacedSessions(): Promise<void> {
+  try {
+    const res = await fetch("/api/sessions/unplaced");
+    if (!res.ok) return;
+    const body = (await res.json()) as { sessions?: { id?: unknown; agent?: unknown; cwd?: unknown }[] };
+    for (const row of body.sessions ?? []) {
+      if (typeof row?.id !== "string" || !row.id) continue;
+      // Already here: the server clears the mark when a cell attaches, but this tab may still be
+      // holding a cell whose attach has not landed yet — and adopting twice would give one session
+      // two cells fighting over the same socket.
+      if (state.value.cells.some((cell) => cell.session === row.id)) continue;
+      const agent = asTerminalAgent(row.agent);
+      const placed = insertCellAfter(state.value, NO_ORIGIN_UID, sessionCell(row.id, typeof row.cwd === "string" ? row.cwd : defaultCwd.value, agent));
+      // A full grid drops the cell and hands the state straight back. Nothing to fall back to
+      // here — this session has been waiting, and it can keep waiting: the mark is only cleared
+      // by an attach, so the next load with room adopts it.
+      if (placed === state.value) break;
+      state.value = placed;
+    }
+  } catch {
+    // Best effort: a grid that cannot ask still works, and the sessions stay marked for next time.
+  }
+}
+onActivated(() => void adoptUnplacedSessions());
+
 // Registered on the same activate/deactivate cycle as the new-terminal opener, and for the same
 // reason: <KeepAlive> keeps this grid alive while the user is in the single view, and a chat
 // started there must queue + navigate rather than silently mutate a hidden grid.

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -553,7 +553,14 @@ const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest) => {
 //
 // Asked on ACTIVATE rather than mount: the grid is kept alive across route changes, so mount fires
 // once per page load and would miss everything spawned while the user was elsewhere in the app.
+let adoptingUnplaced = false;
 async function adoptUnplacedSessions(): Promise<void> {
+  // One sweep at a time. onActivated can fire again before the fetch resolves — leave the grid and
+  // come straight back — and both runs would read `cells` before either inserted, so both would
+  // adopt the same session and give it two cells fighting over one socket. The per-row guard below
+  // cannot catch that: it reads state neither call has written yet.
+  if (adoptingUnplaced) return;
+  adoptingUnplaced = true;
   try {
     const res = await fetch("/api/sessions/unplaced");
     if (!res.ok) return;
@@ -574,6 +581,8 @@ async function adoptUnplacedSessions(): Promise<void> {
     }
   } catch {
     // Best effort: a grid that cannot ask still works, and the sessions stay marked for next time.
+  } finally {
+    adoptingUnplaced = false;
   }
 }
 onActivated(() => void adoptUnplacedSessions());

--- a/test/server/routes/attached-session-placed.spec.ts
+++ b/test/server/routes/attached-session-placed.spec.ts
@@ -22,15 +22,13 @@ vi.mock("node:fs", () => {
 const REQUESTED = "11111111-1111-1111-1111-111111111111";
 const MINTED = "22222222-2222-2222-2222-222222222222";
 
+// The REAL helper, from the same freshly-reset module graph as the registry it writes to. A copy
+// of the rule here would keep passing while the real one drifted, which is the one thing this file
+// exists to prevent (CodeRabbit, PR #1189) — and importing it from a DIFFERENT graph would leave it
+// marking a registry instance the assertions never read.
 async function freshRegistry() {
   vi.resetModules();
   return import("../../../server/session/registry.js");
-}
-
-/** What ws-routes' markAttachedSessionPlaced does, against the real registry. */
-function attach(registry: { markSessionPlaced: (id: string) => void }, sessionId: string, requested: string | null): void {
-  registry.markSessionPlaced(sessionId);
-  if (requested && requested !== sessionId) registry.markSessionPlaced(requested);
 }
 
 beforeEach(() => vi.clearAllMocks());
@@ -39,7 +37,7 @@ describe("an attach clears the unplaced mark", () => {
   it("clears it when the session keeps the id it was asked for", async () => {
     const registry = await freshRegistry();
     registry.markUnplacedSession(REQUESTED);
-    attach(registry, REQUESTED, REQUESTED);
+    registry.markAttachedSessionPlaced(REQUESTED, REQUESTED);
     expect(registry.unplacedSessionRows()).toEqual([]);
   });
 
@@ -48,7 +46,7 @@ describe("an attach clears the unplaced mark", () => {
     // one stays marked, and the next activate does it all again.
     const registry = await freshRegistry();
     registry.markUnplacedSession(REQUESTED);
-    attach(registry, MINTED, REQUESTED);
+    registry.markAttachedSessionPlaced(MINTED, REQUESTED);
     expect(registry.unplacedSessionRows()).toEqual([]);
   });
 
@@ -56,14 +54,14 @@ describe("an attach clears the unplaced mark", () => {
     const registry = await freshRegistry();
     registry.markUnplacedSession(REQUESTED);
     registry.markUnplacedSession(MINTED);
-    attach(registry, REQUESTED, REQUESTED);
+    registry.markAttachedSessionPlaced(REQUESTED, REQUESTED);
     expect(registry.unplacedSessionRows().map((r) => r.id)).toEqual([MINTED]);
   });
 
   it("is harmless for a fresh session nobody requested", async () => {
     // The ordinary case: a new cell with no ?session= at all.
     const registry = await freshRegistry();
-    expect(() => attach(registry, MINTED, null)).not.toThrow();
+    expect(() => registry.markAttachedSessionPlaced(MINTED, null)).not.toThrow();
     expect(registry.unplacedSessionRows()).toEqual([]);
   });
 });

--- a/test/server/routes/attached-session-placed.spec.ts
+++ b/test/server/routes/attached-session-placed.spec.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+// Clearing the unplaced mark when a viewer attaches — and the case that makes it two ids, not one.
+//
+// The resolvers mint a FRESH session id when the requested one can be served neither from a live
+// pty nor from an on-disk transcript. A visible spawn that died before writing a transcript is
+// exactly that, and exactly the kind that ends up unplaced — so the id the grid ADOPTED and the id
+// the session ends up with are different. Clearing only the new one leaves the requested one
+// marked forever: every activate adopts it again and mints another session, and the grid fills
+// with cells nobody asked for (Codex, PR #1189).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs", () => {
+  const promises = {
+    readFile: vi.fn(async () => ""),
+    appendFile: vi.fn(async () => undefined),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  return { promises, default: { promises } };
+});
+
+const REQUESTED = "11111111-1111-1111-1111-111111111111";
+const MINTED = "22222222-2222-2222-2222-222222222222";
+
+async function freshRegistry() {
+  vi.resetModules();
+  return import("../../../server/session/registry.js");
+}
+
+/** What ws-routes' markAttachedSessionPlaced does, against the real registry. */
+function attach(registry: { markSessionPlaced: (id: string) => void }, sessionId: string, requested: string | null): void {
+  registry.markSessionPlaced(sessionId);
+  if (requested && requested !== sessionId) registry.markSessionPlaced(requested);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("an attach clears the unplaced mark", () => {
+  it("clears it when the session keeps the id it was asked for", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(REQUESTED);
+    attach(registry, REQUESTED, REQUESTED);
+    expect(registry.unplacedSessionRows()).toEqual([]);
+  });
+
+  it("clears the REQUESTED id even when a fresh one was minted", async () => {
+    // Without this the adoption loops: the grid asks, adopts, the server mints a new id, the old
+    // one stays marked, and the next activate does it all again.
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(REQUESTED);
+    attach(registry, MINTED, REQUESTED);
+    expect(registry.unplacedSessionRows()).toEqual([]);
+  });
+
+  it("leaves other sessions waiting", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(REQUESTED);
+    registry.markUnplacedSession(MINTED);
+    attach(registry, REQUESTED, REQUESTED);
+    expect(registry.unplacedSessionRows().map((r) => r.id)).toEqual([MINTED]);
+  });
+
+  it("is harmless for a fresh session nobody requested", async () => {
+    // The ordinary case: a new cell with no ?session= at all.
+    const registry = await freshRegistry();
+    expect(() => attach(registry, MINTED, null)).not.toThrow();
+    expect(registry.unplacedSessionRows()).toEqual([]);
+  });
+});

--- a/test/server/routes/worker-failure-wiring.spec.ts
+++ b/test/server/routes/worker-failure-wiring.spec.ts
@@ -25,7 +25,7 @@ vi.mock("node:fs", () => {
 
 const { mountPluginRoutes } = await import("../../../server/routes/plugin-routes.js");
 const { runCompletionHook } = await import("../../../server/session/completion-hooks.js");
-const { isFailedWorker, unplacedSessionIds } = await import("../../../server/session/registry.js");
+const { isFailedWorker, unplacedSessionRows } = await import("../../../server/session/registry.js");
 
 const app = express();
 app.use(express.json());
@@ -49,12 +49,12 @@ async function spawn(hidden: boolean, agent = "claude"): Promise<string> {
 describe("what a spawn leaves waiting for a cell", () => {
   it("marks a visible chat as unplaced", async () => {
     const id = await spawn(false);
-    expect(unplacedSessionIds()).toContain(id);
+    expect(unplacedSessionRows().map((r) => r.id)).toContain(id);
   });
 
   it("does NOT mark a hidden worker", async () => {
     const id = await spawn(true);
-    expect(unplacedSessionIds()).not.toContain(id);
+    expect(unplacedSessionRows().map((r) => r.id)).not.toContain(id);
   });
 });
 

--- a/test/server/routes/worker-failure-wiring.spec.ts
+++ b/test/server/routes/worker-failure-wiring.spec.ts
@@ -25,7 +25,7 @@ vi.mock("node:fs", () => {
 
 const { mountPluginRoutes } = await import("../../../server/routes/plugin-routes.js");
 const { runCompletionHook } = await import("../../../server/session/completion-hooks.js");
-const { isFailedWorker } = await import("../../../server/session/registry.js");
+const { isFailedWorker, unplacedSessionIds } = await import("../../../server/session/registry.js");
 
 const app = express();
 app.use(express.json());
@@ -41,6 +41,22 @@ async function spawn(hidden: boolean, agent = "claude"): Promise<string> {
   const res = await request(app).post("/api/plugin/spawnBackgroundChat").send({ message: "do the thing", hidden, agent });
   return String((res.body as { jsonData?: { chatId?: string } }).jsonData?.chatId);
 }
+
+// PR3b: a VISIBLE spawn is marked as waiting for a grid cell. A hidden worker must never be —
+// it has no business taking a cell, and the grid adopts whatever this list holds. Pinned because
+// "it happens not to be marked" and "it cannot be marked" read identically until someone adds a
+// caller, and the difference is a background refresh silently opening a terminal.
+describe("what a spawn leaves waiting for a cell", () => {
+  it("marks a visible chat as unplaced", async () => {
+    const id = await spawn(false);
+    expect(unplacedSessionIds()).toContain(id);
+  });
+
+  it("does NOT mark a hidden worker", async () => {
+    const id = await spawn(true);
+    expect(unplacedSessionIds()).not.toContain(id);
+  });
+});
 
 describe("a hidden worker that ends badly", () => {
   it("is recorded when its run reaches teardown unfinished", async () => {

--- a/test/server/session/unplaced-sessions.spec.ts
+++ b/test/server/session/unplaced-sessions.spec.ts
@@ -50,14 +50,14 @@ describe("unplaced sessions", () => {
     const registry = await freshRegistry();
     await Promise.all([registry.unplacedSessionsHydrated, registry.placedSessionsHydrated]);
     registry.markUnplacedSession(A);
-    expect(registry.unplacedSessionIds()).toEqual([A]);
+    expect(registry.unplacedSessionRows().map((r) => r.id)).toEqual([A]);
   });
 
   it("drops it once a cell has attached", async () => {
     const registry = await freshRegistry();
     registry.markUnplacedSession(A);
     registry.markSessionPlaced(A);
-    expect(registry.unplacedSessionIds()).toEqual([]);
+    expect(registry.unplacedSessionRows().map((r) => r.id)).toEqual([]);
   });
 
   it("persists both facts, so neither is lost to a restart", async () => {
@@ -76,7 +76,7 @@ describe("unplaced sessions", () => {
     readBack = { "unplaced-sessions.json": `${A}\n${B}`, "placed-sessions.json": A };
     const registry = await freshRegistry();
     await Promise.all([registry.unplacedSessionsHydrated, registry.placedSessionsHydrated]);
-    expect(registry.unplacedSessionIds()).toEqual([B]);
+    expect(registry.unplacedSessionRows().map((r) => r.id)).toEqual([B]);
   });
 
   it("does not re-append an id it already holds", async () => {
@@ -87,12 +87,39 @@ describe("unplaced sessions", () => {
     expect(loggedTo("unplaced-sessions.json").split(A).length - 1).toBe(1);
   });
 
+  // Codex, on this PR. The id alone cannot reconnect a cell: adopting a codex session over
+  // claude's endpoint attaches to the wrong agent, and the live PtyEntry that would have said so
+  // is exactly what is missing in the case this marker exists for.
+  it("remembers which agent the session runs, and survives with it", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(A, "codex");
+    registry.markUnplacedSession(B); // default
+    expect(registry.unplacedSessionRows()).toEqual([
+      { id: A, agent: "codex" },
+      { id: B, agent: "claude" },
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(loggedTo("unplaced-sessions.json")).toContain(`${A} codex`);
+  });
+
+  it("reads the agent back after a restart, and defaults a line written without one", async () => {
+    // The second half is the upgrade case: a log written before the agent field existed holds
+    // bare ids, and those sessions were all claude.
+    readBack = { "unplaced-sessions.json": `${A} antigravity\n${B}` };
+    const registry = await freshRegistry();
+    await Promise.all([registry.unplacedSessionsHydrated, registry.placedSessionsHydrated]);
+    expect(registry.unplacedSessionRows()).toEqual([
+      { id: A, agent: "antigravity" },
+      { id: B, agent: "claude" },
+    ]);
+  });
+
   it("ignores an id that is not a session id", async () => {
     const registry = await freshRegistry();
     registry.markUnplacedSession("../etc/passwd");
     registry.markSessionPlaced("../etc/passwd");
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(loggedTo("unplaced-sessions.json")).not.toContain("passwd");
-    expect(registry.unplacedSessionIds()).toEqual([]);
+    expect(registry.unplacedSessionRows().map((r) => r.id)).toEqual([]);
   });
 });

--- a/test/server/session/unplaced-sessions.spec.ts
+++ b/test/server/session/unplaced-sessions.spec.ts
@@ -34,9 +34,12 @@ async function freshRegistry() {
   return import("../../../server/session/registry.js");
 }
 
+// Matched on the exact BASENAME, not endsWith: "unplaced-sessions.json" ends with
+// "placed-sessions.json", so a suffix match reads both logs as one and every assertion about the
+// placed log silently counts the unplaced one too.
 const loggedTo = (name: string) =>
   appended
-    .filter((a) => a.file.endsWith(name))
+    .filter((a) => a.file.split("/").pop() === name)
     .map((a) => a.data)
     .join("");
 
@@ -112,6 +115,20 @@ describe("unplaced sessions", () => {
       { id: A, agent: "antigravity" },
       { id: B, agent: "claude" },
     ]);
+  });
+
+  // Codex, on this PR. markSessionPlaced runs at ALL FOUR ws attach points, so a long-lived
+  // session reconnecting — a reload, a network blip, a page switch in the grid — would append a
+  // line every time. The log would then grow with ATTACH count rather than session count, and
+  // /api/sessions/unplaced waits on hydrating it. Every other mark in the registry is already a
+  // no-op once known; this one was not.
+  it("appends the placed mark once, however many times a session reattaches", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(A);
+    for (let i = 0; i < 20; i++) registry.markSessionPlaced(A);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(loggedTo("placed-sessions.json").split(A).length - 1).toBe(1);
+    expect(registry.unplacedSessionRows()).toEqual([]);
   });
 
   it("ignores an id that is not a session id", async () => {

--- a/test/server/session/unplaced-sessions.spec.ts
+++ b/test/server/session/unplaced-sessions.spec.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+// Which sessions are waiting for a grid cell, and — the part that matters — which stop waiting.
+//
+// The mark exists for the case nobody is looking: a task firing at 3am, a chat the phone started,
+// one an agent started from another session. So the two things worth pinning are that it SURVIVES
+// (it is persisted, and a restart is exactly what happens before anyone opens a tab) and that it
+// is CLEARED once a cell has the session — otherwise every load re-adopts what the last one took.
+//
+// node:fs is mocked rather than moving HOME: process.env is shared by every file in a vitest
+// worker (tool-group-reset.spec's pattern).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const appended: { file: string; data: string }[] = [];
+let readBack: Record<string, string> = {};
+
+vi.mock("node:fs", () => {
+  const promises = {
+    readFile: vi.fn(async (file: unknown) => readBack[String(file).split("/").pop() ?? ""] ?? ""),
+    appendFile: vi.fn(async (file: string, data: string) => {
+      appended.push({ file: String(file), data });
+    }),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  return { promises, default: { promises } };
+});
+
+const A = "11111111-1111-1111-1111-111111111111";
+const B = "22222222-2222-2222-2222-222222222222";
+
+async function freshRegistry() {
+  vi.resetModules();
+  appended.length = 0;
+  return import("../../../server/session/registry.js");
+}
+
+const loggedTo = (name: string) =>
+  appended
+    .filter((a) => a.file.endsWith(name))
+    .map((a) => a.data)
+    .join("");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readBack = {};
+});
+
+describe("unplaced sessions", () => {
+  it("lists a session the server spawned with nobody to place it", async () => {
+    const registry = await freshRegistry();
+    await Promise.all([registry.unplacedSessionsHydrated, registry.placedSessionsHydrated]);
+    registry.markUnplacedSession(A);
+    expect(registry.unplacedSessionIds()).toEqual([A]);
+  });
+
+  it("drops it once a cell has attached", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(A);
+    registry.markSessionPlaced(A);
+    expect(registry.unplacedSessionIds()).toEqual([]);
+  });
+
+  it("persists both facts, so neither is lost to a restart", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(A);
+    registry.markSessionPlaced(A);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(loggedTo("unplaced-sessions.json")).toContain(A);
+    expect(loggedTo("placed-sessions.json")).toContain(A);
+  });
+
+  it("does not hand back a session that was placed BEFORE this process started", async () => {
+    // The append-only hazard: hydration reads the unplaced log as it was, including ids a later
+    // line in the placed log has since answered. Replaying only the first would re-adopt, on every
+    // load, every session any grid has ever taken.
+    readBack = { "unplaced-sessions.json": `${A}\n${B}`, "placed-sessions.json": A };
+    const registry = await freshRegistry();
+    await Promise.all([registry.unplacedSessionsHydrated, registry.placedSessionsHydrated]);
+    expect(registry.unplacedSessionIds()).toEqual([B]);
+  });
+
+  it("does not re-append an id it already holds", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession(A);
+    registry.markUnplacedSession(A);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(loggedTo("unplaced-sessions.json").split(A).length - 1).toBe(1);
+  });
+
+  it("ignores an id that is not a session id", async () => {
+    const registry = await freshRegistry();
+    registry.markUnplacedSession("../etc/passwd");
+    registry.markSessionPlaced("../etc/passwd");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(loggedTo("unplaced-sessions.json")).not.toContain("passwd");
+    expect(registry.unplacedSessionIds()).toEqual([]);
+  });
+});

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
-import { h, KeepAlive, type Component } from "vue";
+import { defineComponent, h, KeepAlive, type Component } from "vue";
 
 // App.vue renders GridView inside <KeepAlive>, and the grid registers its openers (new terminal,
 // spawned-chat placement) on ACTIVATE so a cached-but-hidden grid is never mutated behind the
@@ -551,6 +551,42 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
     // was actually spawned in, rather than this grid's default.
     expect(adopted?.agent).toBe("codex");
     expect(adopted?.cwd).toBe("/proj");
+    w.unmount();
+  });
+
+  // CodeRabbit, on this PR. onActivated fires again when the user leaves the grid and comes
+  // straight back. Both runs read `cells` before either inserts, so the per-row guard cannot see
+  // the other — and the same unplaced session gets two cells fighting over one socket.
+  it("runs one adoption sweep at a time", async () => {
+    let asked = 0;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
+      if (String(url).includes("/api/sessions/unplaced")) {
+        asked++;
+        return new Promise<Response>(() => {}); // never resolves: both activations are in flight
+      }
+      return realFetch(url, init);
+    }) as typeof fetch;
+
+    const GridView = (await import("../../../src/components/GridView.vue")).default;
+    const holder = defineComponent({
+      props: { show: { type: Boolean, default: true } },
+      render() {
+        return h(KeepAlive, null, [this.show ? h(GridView) : h("div")]);
+      },
+    });
+    const w = mount(holder, {
+      props: { show: true },
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+    expect(asked).toBe(1);
+
+    await w.setProps({ show: false }); // deactivate
+    await w.setProps({ show: true }); // ...and straight back
+    await flushPromises();
+
+    expect(asked).toBe(1); // the first sweep is still in flight, so the second is refused
     w.unmount();
   });
 

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -528,6 +528,53 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
     w.unmount();
   });
 
+  // PR3b: the durable half. A chat spawned while no tab was open — a scheduled task at 3am, the
+  // phone, an agent calling the tool from another session — has nowhere to appear once the single
+  // view is gone. The grid asks for those on activate and adopts them.
+  it("adopts sessions the server spawned while nothing was open", async () => {
+    const UNPLACED = "44444444-4444-4444-4444-444444444444";
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
+      if (String(url).includes("/api/sessions/unplaced"))
+        return { ok: true, json: async () => ({ sessions: [{ id: UNPLACED, agent: "codex", cwd: "/proj" }] }) } as Response;
+      return realFetch(url, init);
+    }) as typeof fetch;
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+
+    const cells = w.findComponent(CellsStub).props("cells") as Array<{ session: string | null; agent?: string; cwd?: string | null }>;
+    const adopted = cells.find((c) => c.session === UNPLACED);
+    expect(adopted).toBeDefined();
+    // The agent travels with it, or the cell reconnects on the wrong endpoint; so does the cwd it
+    // was actually spawned in, rather than this grid's default.
+    expect(adopted?.agent).toBe("codex");
+    expect(adopted?.cwd).toBe("/proj");
+    w.unmount();
+  });
+
+  it("does not adopt a session it already has a cell for", async () => {
+    // The server clears the mark when a cell attaches, but this tab may still be holding a cell
+    // whose attach has not landed. Two cells for one session fight over its socket.
+    const DUPE = "55555555-5555-5555-5555-555555555555";
+    localStorage.setItem("grid_v2", JSON.stringify({ cells: [{ uid: 3, session: DUPE, cwd: "/w" }], expanded: null, page: 0, sortMode: "manual" }));
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
+      if (String(url).includes("/api/sessions/unplaced"))
+        return { ok: true, json: async () => ({ sessions: [{ id: DUPE, agent: "claude", cwd: "/w" }] }) } as Response;
+      return realFetch(url, init);
+    }) as typeof fetch;
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+
+    const cells = w.findComponent(CellsStub).props("cells") as Array<{ session: string | null }>;
+    expect(cells.filter((c) => c.session === DUPE)).toHaveLength(1);
+    w.unmount();
+  });
+
   // What the seeded collection is FOR: the Canvas pane exists only beside an enlarged cell, so a
   // card placed into a tiled one is two gestures away and invisible until both are made. Reported
   // live — the card was landing correctly and looked like a feature that did nothing.


### PR DESCRIPTION
PR3b of the single-view removal (design note: `plans/feat-remove-single-view.md`). Follows #1167, #1186, #1187, #1188.

This is the half PR3a could not cover.

## The gap

A chat started from the collections UI is placed by the browser that asked for it. That is the common case and **only** that case. Three others start a **visible** chat with no tab open at all:

- an agent calling `spawnBackgroundChat` from another session,
- a scheduled task firing at 3am,
- the phone.

Today those land in the chat sidebar. Once the single view is gone, they have nowhere to appear.

## The shape

The server remembers that a session is waiting, and the next grid to load adopts it.

**Marked** at the three server-side spawns that start a visible session: `spawnBackgroundChat` when NOT hidden, the phone's `startChat`, and the scheduler's. The translation worker is deliberately absent — and a spec pins that a hidden worker can *never* be marked, because "happens not to be marked" and "cannot be marked" read identically until someone adds a caller, and the difference is a background refresh silently opening a terminal.

**Cleared on ANY attach**, not just a grid one: *unplaced* means nobody is looking, and a viewer is a viewer. It lands at `ws-routes`' four attach points — the same choke points `markDevTerminalSession` already uses, covering new, resumed and reattached. This is what stops a browser-placed chat coming back as a duplicate cell on the next load.

**`GET /api/sessions/unplaced`** answers the marker directly, rather than having the grid diff "all sessions" against its own state. A diff would sweep up ordinary sessions and change what a reload does to a normal cell — the invariant this whole line of work is written around.

**The grid asks on ACTIVATE, not mount.** It is kept alive across route changes, so mount fires once per page load and would miss everything spawned while the user was elsewhere in the app.

## Two things the plan did not anticipate

**1. The marker needs two append-only logs, not one.**

`MULMOTERMINAL_HOME` is shared between server instances, so these logs cannot be rewritten — and hydration reads the unplaced log as it *was*, including ids that a later line has since answered. A single log would therefore re-adopt, on every load, **every session any grid has ever taken**. So `placed` is its own log and `unplacedSessionIds()` is the difference.

Pinned directly: `does not hand back a session that was placed BEFORE this process started`.

**2. No new pub/sub channel, which the plan opened with.**

The plan called for a `publishToOne` sibling of `LAUNCH_TERMINAL_CHANNEL`. It is not needed. Reconciliation on activate covers everything except a chat spawned while the user is *already sitting on* `/terminals` — and a channel for that window would be a second mechanism that has to be kept from double-placing what the browser just placed. Worth adding later if that window proves annoying; not worth it up front. Recorded in the plan.

## Duplicate cells

Guarded on **both** paths — the live placement and the sweep. Two cells for one session fight over its socket: the server supersedes the prior one, so the older cell goes dead while still looking live. The sweep's guard is not redundant with the server clearing the mark, because a tab may still hold a cell whose attach has not landed yet.

## Cap policy

Still unanswered, and this PR does not force it: a full grid simply leaves the session marked, so the next load with room adopts it. PR5 is where it has to be decided, since that is where the single-view fallback disappears.

## Verified

- `yarn test` — 7066 tests pass (+12)
- `yarn typecheck` / `:test` / `:server` all pass
- `yarn lint` 0 errors (4 pre-existing max-lines warnings), `yarn build` succeeds
- The grid-side adoption test was checked to fail with the `onActivated` hook removed

Note the pre-existing parallel-load flakiness in this suite (documented in `vitest.config.ts`, and `main` shows it too): a run may fail on one unrelated file.

**Not verified:** anything in a running app. The most convincing check is a real one — let a scheduled task fire, or `curl` a visible `spawnBackgroundChat` with no tab open, then open the grid and see the cell appear.

Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server-created chat sessions can now appear in the grid automatically when it is activated.
  * Session details, including agent and working directory, are preserved during adoption.
* **Bug Fixes**
  * Prevented sessions from appearing in multiple grid cells.
  * Prevented already-attached sessions from being adopted again.
  * Grid activation retries adoption when the grid is temporarily full or loading fails.
* **Tests**
  * Added coverage for session persistence, adoption, deduplication, attachment, and restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->