### PR TITLE
refactor: サンドボックス view の CDN allowlist を core から取る (#1191 項目4)

### DIFF
--- a/plans/refactor-1191-cdn-allowlist-single-source.md
+++ b/plans/refactor-1191-cdn-allowlist-single-source.md
@@ -1,0 +1,74 @@
+# refactor: take the sandboxed-view CDN allowlist from core, not from a local copy
+
+refs #1191 (item 4 of that memo; the other items are untouched here)
+
+## The observation this starts from
+
+`server/backends/html.ts:30-37` hand-maintains a six-entry CDN allowlist that feeds the
+`Content-Security-Policy` of every LLM-authored HTML page this host serves — both the contained
+`/artifacts/html/…` preview and the uncontained `/htmlfile` mount.
+
+The same six entries live in `@mulmoclaude/core` as `SANDBOXED_VIEW_CDN_ALLOWLIST`, and core is
+not a passive holder of them. MulmoClaude's `src/utils/html/previewCsp.ts:8-11` says so outright:
+
+> The list itself lives in `@mulmoclaude/core/remote-view` (SANDBOXED_VIEW_CDN_ALLOWLIST) so the
+> remote-view CSP and these desktop policies can't drift — **widen it THERE**, and keep it
+> audited: every entry is a potential supply-chain surface.
+
+So the list already HAS a declared owner, and this repo is the one host not reading from it.
+
+## Why this is worth a change rather than a comment
+
+The two lists are **identical today** — verified entry by entry against
+`node_modules/@mulmoclaude/core/dist/remote-view/index.js`. Nothing is broken right now, and
+that is precisely the problem: the day core adds a seventh entry, this file keeps six and
+nothing anywhere fails. No type error (the local value is a fresh array literal), no test
+(the specs assert CSP *directives*, never the CDN list — `test/server/backends/html.spec.ts:96-101`),
+no lint. A security boundary that drifts silently is the failure mode worth spending a change on.
+
+`CLAUDE.md` already states the general rule for the on-disk layout and the `/api/*` surface —
+"MulmoClaude is the reference host, find its counterpart first". This is the same rule applied
+to a shared constant.
+
+## Decisions (owner, this session)
+
+**1. Import the list; keep the joining and the CSP construction local.**
+
+Core owns *which origins are trusted*. It does not own how this host assembles its CSP — the
+`sandbox allow-scripts` / `connect-src 'none'` shape here is deliberately stricter than what a
+collection custom view gets, and that stays this file's business. So the import replaces the
+array literal only.
+
+**2. Add a spec that pins the resolved allowlist.**
+
+This is the part that is NOT mere deduplication, so it is called out for review.
+
+Replacing a visible literal with an import *removes* the local record of what this host trusts.
+Core's own instruction is "keep it audited" — an import with no assertion is the opposite: a
+core release could widen the trusted set of this host's CSP and no one here would see it in a
+diff or a test run.
+
+The spec pins the exact six origins. When core widens the list the spec fails, a human reads
+what was added, and updates the spec deliberately. That converts a silent supply-chain widening
+into a one-line review. It is a **canary, not a duplicate**: it asserts on the imported value,
+so it cannot drift from what is actually served.
+
+**3. Do not touch the other five items in #1191.**
+
+Item 1 (calendar scheduled sync) needs cross-process locking work first — core's calendar lock
+is in-process module state by design. Item 2 has no UI affordance to break. Neither belongs in
+this change.
+
+## Steps
+
+1. `server/backends/html.ts` — import `SANDBOXED_VIEW_CDN_ALLOWLIST` from
+   `@mulmoclaude/core/remote-view`; `ALLOWED_CDNS` becomes its `.join(" ")`. Rewrite the comment
+   to point at the owner and say "widen it there".
+2. `test/server/backends/html.spec.ts` — pin the six origins, and assert the served CSP actually
+   carries them (so the pin is tied to the response, not just to the constant).
+3. Gate: `format` → `lint` → `typecheck` / `typecheck:server` / `typecheck:test` → `build` → `test`.
+
+## What this does not change
+
+No behaviour. The served CSP header is byte-identical as long as core's list is unchanged, which
+step 2 is there to keep true.

--- a/server/backends/html.ts
+++ b/server/backends/html.ts
@@ -18,6 +18,7 @@
 import path from "node:path";
 import type { Express, Request, Response, NextFunction } from "express";
 import { executeHtmlDispatch, HTML_FILE_MOUNT } from "@mulmoclaude/html-plugin";
+import { SANDBOXED_VIEW_CDN_ALLOWLIST } from "@mulmoclaude/core/remote-view";
 import { artifactsFileOps } from "./artifacts.js";
 import { htmlByPath, resolveHtmlRequest } from "./openPath.js";
 import { publishFileChange } from "./fileChange.js";
@@ -25,16 +26,12 @@ import { statFileOr404 } from "./statFileOr404.js";
 import { streamFileToResponse } from "./streamFile.js";
 import { isWithin } from "../infra/path-within.js";
 
-// Curated CDN allowlist (matches the collection custom-view policy) for an
-// LLM-authored page that may pull a charting/util lib or font from a CDN.
-const ALLOWED_CDNS = [
-  "https://cdn.jsdelivr.net",
-  "https://unpkg.com",
-  "https://cdnjs.cloudflare.com",
-  "https://fonts.googleapis.com",
-  "https://fonts.gstatic.com",
-  "https://cdn.plot.ly",
-].join(" ");
+// Curated CDN allowlist for an LLM-authored page that may pull a charting/util lib or font
+// from a CDN. Core owns the list so this policy and the remote-view CSP can't drift — widen
+// it THERE, never here. Every entry is a supply-chain surface, so html.spec.ts pins the
+// resolved set: a core release that adds an origin fails that spec rather than silently
+// widening what this host trusts.
+const ALLOWED_CDNS = SANDBOXED_VIEW_CDN_ALLOWLIST.join(" ");
 
 // Preview CSP for a presentHtml page. This HTML is LLM-authored, so the RESPONSE
 // itself must sandbox it — not just the embedding iframe. `sandbox allow-scripts`

--- a/test/server/backends/html.spec.ts
+++ b/test/server/backends/html.spec.ts
@@ -101,6 +101,25 @@ describe("html preview route", () => {
     expect(csp).toMatch(/script-src 'unsafe-inline'/);
   });
 
+  // The origins themselves are core's (SANDBOXED_VIEW_CDN_ALLOWLIST), so this is a canary, not a
+  // second copy: it reads the SERVED header, and a core release that widens the trusted set fails
+  // here instead of silently widening what this host's CSP allows. Read what was added, then pin it.
+  const AUDITED_CDNS = [
+    "https://cdn.jsdelivr.net",
+    "https://unpkg.com",
+    "https://cdnjs.cloudflare.com",
+    "https://fonts.googleapis.com",
+    "https://fonts.gstatic.com",
+    "https://cdn.plot.ly",
+  ];
+
+  it("trusts exactly the audited CDN origins", async () => {
+    const csp = (await fetch(`${base}/${REL}`)).headers.get("content-security-policy") ?? "";
+    // Bare `https:` in img-src/media-src is a scheme, not an origin — the `//` keeps it out.
+    const served = [...new Set(csp.match(/https:\/\/[^\s;]+/g) ?? [])].sort();
+    expect(served).toEqual([...AUDITED_CDNS].sort());
+  });
+
   it("403s a path that escapes artifacts/html", async () => {
     const res = await fetch(`${base}/artifacts/html/${encodeURIComponent("../../etc/passwd")}`);
     expect([403, 404]).toContain(res.status); // blocked either by containment or non-.html


### PR DESCRIPTION
## Summary

`server/backends/html.ts` が手書きで持っていた6件の CDN allowlist を、**core の `SANDBOXED_VIEW_CDN_ALLOWLIST` から import する形に置き換え**ます。この allowlist は、このホストが配信する LLM 生成 HTML すべて（`/artifacts/html/…` プレビューと `/htmlfile` マウント）の `Content-Security-Policy` を決めています。

core は単なる置き場ではなく、**このリストの持ち主だと明示的に宣言しています**。MulmoClaude の `src/utils/html/previewCsp.ts:8-11`:

> The list itself lives in `@mulmoclaude/core/remote-view` (SANDBOXED_VIEW_CDN_ALLOWLIST) so the remote-view CSP and these desktop policies can't drift — **widen it THERE**, and keep it audited: every entry is a potential supply-chain surface.

MulmoTerminal がその宣言に従っていない唯一のホストでした。

**挙動の変更はありません。** 配信される CSP ヘッダが変更前後で byte-identical であることを、両バージョンで実際にルートを起動してヘッダを実測し diff して確認しています（後述）。

`@mulmoclaude/core` #1191 の項目4 のみを扱います。**項目1・2 には手を付けていません**（クロージングキーワードを使っていないのはこのため）。

## Items to Confirm / Review

1. **`html.spec.ts` に追加した canary が、単なるデデュープを超えた部分です。** ここだけは「重複を消す」以上のことをしているので、意図を確認してください。

   リテラルを import に置き換えると、**このホストが何を信頼しているかがローカルのコードから消えます**。core 側の指示は "keep it audited" なので、アサーションの無い import はむしろ逆行です — core のリリースがこのホストの CSP の信頼範囲を広げても、diff にもテスト結果にも現れません。

   追加した spec は **配信されたヘッダから origin を抽出して6件と厳密一致**を見ます。core が広げたらここが落ちて、人間が「何が追加されたか」を読んで意図的に更新する、という流れになります。**import した定数ではなく SERVED ヘッダを見ている**ので、実際に配信されているものからは乖離しません（定数と定数を比べる無意味なテストにはなっていません）。

   「余計なテストを増やすな」という判断もあり得ると思うので、そこは委ねます。

2. **`AUDITED_CDNS` を spec にハードコードしている点。** 1 の理由でこれは意図的な「2つ目のコピー」ですが、**プロダクションコードではなくテスト側**に置いています。プロダクション側は core を単一の持ち主として参照し、テスト側が監査ポイントになる、という分担です。

3. **origin 抽出の正規表現 `/https:\/\/[^\s;]+/g`。** `img-src` / `media-src` にある**裸の `https:`（スキーム指定）**を拾わないよう `//` を必須にしています。ここを緩めると常に一致しなくなるので、変更する場合は注意してください。

## User Prompt

> ◯ @mulmoclaude/core  latest  1.10.0   ❯  1.11.0
> あげられる？

> yarn add が無関係な6件も書き換えましたもふくめてPRをつくって

> このあたりのmulmoterminal/claudeでのcoreまわりの差分、できたらissueにメモとしてまとめてほしい。これはサポートしてないよ的な。

> 1191の 1,2 4 は対応必須かな？

> では4!

（1・2番目は #1190 で対応済み。3番目が #1191。4番目の問いに対して「4 は実質必須、1 は方針明記のみ、2 は不要」と回答し、本 PR で項目4 を実装しています。）

## 実装の詳細

### 変更点

**`server/backends/html.ts`** — 配列リテラルを import に置き換え。`ALLOWED_CDNS` の `.join(" ")` と、その先の CSP 組み立ては**ローカルのまま**です。

core が持つのは「どの origin を信頼するか」であって、このホストが CSP をどう組むかではありません。ここの `sandbox allow-scripts` / `connect-src 'none'` という形は、コレクションのカスタムビューが受け取るものより意図的に厳しくしてあり、それはこのファイルの責任範囲として残しています。

**`test/server/backends/html.spec.ts`** — canary を1件追加（上記 Items 1）。

**`plans/refactor-1191-cdn-allowlist-single-source.md`** — 設計メモ。

### 検証

**1. 挙動が変わらないことの実測（外部 ground truth）**

変更前後それぞれで実際に `mountHtmlPreviewRoute` を起動し、返ってきた `Content-Security-Policy` ヘッダを取得して diff しました。**完全一致（byte-identical）**です。core 側のリストの順序が元のリテラルと同一だったため、join した文字列も一致します。

**2. canary が本当に落ちることの確認**

`node_modules` の core に `https://evil.example.com` を1件注入して spec を実行:

```
× trusts exactly the audited CDN origins
AssertionError: expected [ 'https://cdn.jsdelivr.net', …(6) ] to deeply equal [ …(5) ]
+   "https://evil.example.com",
```

追加された origin を名指しして落ちます。確認後 core は復元済みです。落ちない canary には意味がないので、この確認込みで初めて「入れた」と言えると考えました。

**3. 通常のゲート**

```
yarn format / lint       0 errors（既存の max-lines 警告4件のみ、増減なし）
yarn typecheck           OK
yarn typecheck:server    OK
yarn typecheck:test      OK
yarn build               OK
yarn knip                差分なし（新しい import が dead code 判定されないことの確認）
yarn test                7075 passed | 45 skipped (7120)
```

### スコープ外

#1191 の項目1（カレンダーのスケジュール同期）は、core のカレンダーロックが**プロセス内の module state**（`withKeyedLock`、`.push-state.json` の更新も in-process の write queue のみ）であるため、MulmoTerminal 側にもスケジュールタスクを登録すると「2プロセスが定期的に push する」形になり、baseline の lost update が起き得ます。クロスプロセス排他の設計が先に必要なので、本 PR には含めていません。項目2 は UI 側に導線が存在しないため、壊れているものはありません。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML preview compatibility by consistently applying the approved CDN sources in content security policies.
  * Added validation to ensure served security policies include exactly the expected CDN origins.

* **Quality Improvements**
  * Reduced the risk of mismatches between supported CDN sources and browser security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->