### PR TITLE
feat: let the grid be the view underneath a full-screen overlay

### DIFF
--- a/plans/feat-remove-single-view.md
+++ b/plans/feat-remove-single-view.md
@@ -393,7 +393,32 @@ open at all. Details below.
   background worker; the skill button's use of it is a workaround, not the same thing. Do not
   collapse the two while removing the workaround.
 
-### PR4 — make the grid self-sufficient
+### PR4 — make the grid self-sufficient — **DONE**
+
+Three of the six bullets below needed no work, and the one real change was bigger than "hoist":
+
+- **The hoist alone does nothing.** Every overlay is ROUTE-driven, so opening one leaves
+  `/terminals` — and `isGrid` was `route.name === "terminals"`, which meant the grid came off
+  screen and the single view mounted behind the overlay. Moving the overlays out of the `!isGrid`
+  block only helps if the grid can also BE the backdrop, so `App.vue` now binds to `viewIsGrid`
+  (the existing "which view is underneath" answer, which follows the overlay's origin). The two
+  halves had to travel together, exactly as the comment at `App.vue:39` warned.
+- **`viewIsGrid` had no tests**, and it now decides which shell renders rather than which buttons
+  show. Six cases added, verified to fail against a broken predicate.
+- **`AppSettingsModal` must NOT be hoisted** — `GridView` renders its own, so a hoist would show
+  two on `/terminals`. Five overlays moved, not six.
+- **`ToolsPane` is already beside the zoomed cell** (`TerminalGrid.vue:867`). The open question in
+  this section was already answered by earlier work.
+- **The AppToolbar `{name:"chat"}` switch STAYS**, deferred to PR5. Removing it here would strand
+  the single view — unreachable but still present — which is PR5's job, not this one's.
+
+**One regression this introduced, and fixed.** With the grid surviving under an overlay, a chat
+started from the collections browser was placed into a grid the user could not see: the
+queue-and-navigate path used to close the overlay *by accident*, and it stopped being taken the
+moment the grid stopped unmounting. `placeSpawnedChat` now navigates whenever the user is not
+already on `/terminals`, whether or not a mounted grid took the request.
+
+---
 
 Everything the single view currently owns has to exist in the grid *before* PR4.
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,6 @@ import WikiBrowseOverlay from "./components/WikiBrowseOverlay.vue";
 import PrsOverlay from "./components/PrsOverlay.vue";
 import FilesOverlay from "./components/FilesOverlay.vue";
 import GridView from "./components/GridView.vue";
-import { useRoute } from "vue-router";
 import AppSettingsModal from "./components/AppSettingsModal.vue";
 import AppToolbar from "./components/AppToolbar.vue";
 import { useSessions, type Filter } from "./composables/useSessions";
@@ -29,19 +28,24 @@ import { useAttentionSound, type SoundConfig } from "./composables/useAttentionS
 import { useUnloadGuard, reportActiveTerminals } from "./composables/useUnloadGuard";
 import { browserLocale } from "./utils/browserLocale";
 import { usePubSub } from "./composables/usePubSub";
+import { viewIsGrid } from "./composables/overlayOrigin";
 import { openTerminalAt } from "./composables/useNewTerminal";
 import { LAUNCH_TERMINAL_CHANNEL, isLaunchAgent, type LaunchAgent } from "../common/launchAgent";
 import { clampTerminalWidth, maxTerminalWidth, MIN_TERMINAL, splitterKeyWidth } from "./components/splitterWidth";
 import { type TerminalAgent } from "../common/sessionAgent";
 
-// View mode is now the URL: the multi-terminal grid is /terminals, everything else
-// (chat + the collection/accounting overlays) lives under the single-view shell.
-// Route-based on purpose: the OVERLAYS live inside the `!isGrid` block below, so widening
-// this to "the view underneath an overlay" stops them rendering at all — the URL changes and
-// the grid just stays on screen. Which BUTTONS the header offers is a separate question, and
-// the one that follows the underlying view (AppToolbar).
-const route = useRoute();
-const isGrid = computed(() => route.name === "terminals");
+// Which shell renders UNDER whatever is on screen: the grid, or the single view.
+//
+// `viewIsGrid` rather than `route.name === "terminals"`, so an overlay opened FROM the grid
+// keeps the grid behind it instead of mounting the single view's terminal there. The toolbar has
+// always answered that way (AppToolbar reads the same value); the shell did not, so the two
+// disagreed for the whole time an overlay was open.
+//
+// This was previously route-based on purpose, and the reason no longer holds: the overlays used
+// to live inside the `!isGrid` block, so widening this stopped them rendering at all. They are
+// siblings of both shells now — the two halves of that change have to travel together, which is
+// why the comment went with it.
+const isGrid = viewIsGrid;
 
 // The phone asked for a new terminal in a session's directory (#831). The grid is browser
 // state — the host can only ask — so SOMETHING has to be listening for this to be servable,
@@ -399,19 +403,25 @@ function onSession(id: string) {
         <ToolsPane v-if="showTools" :session-id="activeId" @close="toggleTools" />
       </div>
     </div>
-    <!-- Full-screen collection browser; shown when the launcher / an index card / a
-         ref hop opens it (driven by useCollectionBrowse). -->
-    <CollectionsBrowseOverlay />
-    <!-- Full-screen accounting view; opened by the toolbar's account_balance button
-         (driven by useAccountingView). Mutually exclusive with the browser above. -->
-    <AccountingOverlay />
-    <!-- Full-screen read-only wiki browser; opened by the toolbar's menu_book button
-         (driven by useWikiBrowse). Mutually exclusive with the overlays above. -->
-    <WikiBrowseOverlay />
-    <!-- Full-screen cross-repo PR list; opened by the toolbar's call_merge button. -->
-    <PrsOverlay />
-    <!-- Full-screen file explorer + editor; opened by a terminal header's Files button. -->
-    <FilesOverlay />
     <AppSettingsModal v-if="showSettings" :cwd="effectiveCwd" :session-id="activeId" :presets="presets" @launch-skill="launchSkill" @close="closeSettings" />
   </div>
+  <!-- The full-screen overlays, OUTSIDE both shells: each is route-driven and renders on top of
+       whichever view is underneath, so they must not be nested in one of them. While they lived
+       inside the single-view block, an overlay opened from the grid could only appear by taking
+       the grid off screen — which is why `isGrid` above had to widen in the same change.
+       AppSettingsModal is deliberately NOT here: GridView renders its own, and hoisting this one
+       would show two on /terminals. -->
+  <!-- Full-screen collection browser; shown when the launcher / an index card / a
+       ref hop opens it (driven by useCollectionBrowse). -->
+  <CollectionsBrowseOverlay />
+  <!-- Full-screen accounting view; opened by the toolbar's account_balance button
+       (driven by useAccountingView). Mutually exclusive with the browser above. -->
+  <AccountingOverlay />
+  <!-- Full-screen read-only wiki browser; opened by the toolbar's menu_book button
+       (driven by useWikiBrowse). Mutually exclusive with the overlays above. -->
+  <WikiBrowseOverlay />
+  <!-- Full-screen cross-repo PR list; opened by the toolbar's call_merge button. -->
+  <PrsOverlay />
+  <!-- Full-screen file explorer + editor; opened by a terminal header's Files button. -->
+  <FilesOverlay />
 </template>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -62,6 +62,7 @@ import { useAppConfig } from "../composables/useAppConfig";
 import { fetchDirConfig, invalidateDirConfig, useDirPriorities } from "../composables/useDirConfig";
 import { nextSortMode } from "./sortModeButton";
 import { asTerminalAgent, type TerminalAgent } from "../../common/sessionAgent";
+import { router } from "../router";
 import { usePubSub } from "../composables/usePubSub";
 import type { LaunchAgent } from "../../common/launchAgent";
 import type { LaunchPick } from "./launchers";
@@ -74,6 +75,14 @@ import type { LaunchPick } from "./launchers";
 // cell reflows the list so terminals flow across page boundaries. Only the active
 // page is mounted — other pages' terminals live on as background PTYs and
 // reconnect when their page is shown again.
+// The ACTUAL route. The grid now stays mounted under a full-screen overlay, so "is the grid
+// mounted" and "is the grid what the user is looking at" have come apart — several things below
+// need the second question (Codex, PR #1193).
+//
+// The router singleton rather than useRoute(): this component is mounted without the plugin in its
+// own specs, and overlayOrigin reads the same singleton for the same reason.
+const onTerminalsRoute = () => router.currentRoute.value.name === "terminals";
+
 const init = initialState(localStorage.getItem(STATE_KEY), localStorage.getItem(LEGACY_KEY));
 const state = ref<GridState>(init.state);
 const persist = () => localStorage.setItem(STATE_KEY, JSON.stringify(state.value));
@@ -430,6 +439,12 @@ function closeSettings() {
 // CAPTURE phase because xterm binds keydown on its own textarea: capture runs first, so the
 // key can be claimed before the terminal turns it into a page-forward escape sequence.
 function onShortcutKey(e: KeyboardEvent) {
+  // Only while the grid is what the user is actually LOOKING at. It now stays mounted underneath a
+  // full-screen overlay, so without this a keystroke aimed at the collection browser or the wiki
+  // reaches the hidden grid — up to `terminal-close` closing its zoomed cell. CodeMirror is the
+  // worst of it: its editable surface is contenteditable, which isEditableTarget below does not
+  // exclude, so typing in an editor was reaching the shortcuts (Codex, PR #1193).
+  if (!onTerminalsRoute()) return;
   if (showSettings.value) return;
   const target = e.target instanceof HTMLElement ? e.target : null;
   if (target && isEditableTarget(target.tagName, Array.from(target.classList))) return;
@@ -512,11 +527,11 @@ const gridRef = ref<InstanceType<typeof TerminalGrid> | null>(null);
 // Place an already-spawned chat as a cell. Every programmatically started chat arrives here —
 // the collection UI's actions and template cards, custom views, the Settings skill buttons —
 // via useChatLauncher's one choke point.
-const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest) => {
+const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest): boolean => {
   // Already adopted — by the unplaced sweep below, or by an earlier request for the same session.
   // Two cells for one session fight over its socket: the server supersedes the prior one, so the
   // older cell goes dead while still looking live.
-  if (state.value.cells.some((cell) => cell.session === id)) return;
+  if (state.value.cells.some((cell) => cell.session === id)) return true;
   // Seeded with the directory the server spawns these in (CLAUDE_CWD, which /api/config reports as
   // `cwd`); the cell adopts whatever the PTY reports anyway. sessionCell carries the agent, which
   // matters because a spawn follows the Claude/Codex/Antigravity toggle.
@@ -533,7 +548,7 @@ const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest) => {
   // so the terminal shows it either way; the hint is a single-view affordance.
   if (placed === state.value) {
     showSpawnedSession({ id, agent, draft });
-    return;
+    return false; // the single view has it; do not drag the user to the grid
   }
   state.value = placed;
   // A collection is already waiting in this session's Canvas. The pane exists only beside an
@@ -542,10 +557,12 @@ const placeChat = ({ id, agent, draft, canvas }: SpawnedChatRequest) => {
   // grid's own reveal (files-buffer flush included) rather than setting the two pieces of state
   // from here. Deliberately NOT done for an unseeded spawn: taking the screen to show an empty
   // pane is worse than leaving the grid as the user arranged it.
-  if (!canvas) return;
-  const uid = placed.cells.find((cell) => cell.session === id)?.uid;
-  // After the state renders: the grid has to be showing the cell before it can enlarge it.
-  if (uid !== undefined) void nextTick(() => gridRef.value?.openCanvasFor(uid));
+  if (canvas) {
+    const uid = placed.cells.find((cell) => cell.session === id)?.uid;
+    // After the state renders: the grid has to be showing the cell before it can enlarge it.
+    if (uid !== undefined) void nextTick(() => gridRef.value?.openCanvasFor(uid));
+  }
+  return true;
 };
 // Sessions the SERVER spawned that no cell has taken — a scheduled task's chat, one the phone
 // started, one an agent started from another session. The browser that asks for a chat places it
@@ -585,7 +602,18 @@ async function adoptUnplacedSessions(): Promise<void> {
     adoptingUnplaced = false;
   }
 }
-onActivated(() => void adoptUnplacedSessions());
+// Driven by the ACTUAL route, not by activation. Since #1193 the grid stays mounted underneath a
+// full-screen overlay, so opening PRs or the collection browser and coming back no longer
+// deactivates and reactivates it — and a session spawned while the user was in there would sit
+// without a cell until they switched to Chat and back, or reloaded (Codex, PR #1193). This fires
+// on both: the first mount, and every return to /terminals from an overlay.
+watch(
+  onTerminalsRoute,
+  (onGrid) => {
+    if (onGrid) void adoptUnplacedSessions();
+  },
+  { immediate: true },
+);
 
 // Registered on the same activate/deactivate cycle as the new-terminal opener, and for the same
 // reason: <KeepAlive> keeps this grid alive while the user is in the single view, and a chat

--- a/src/composables/overlayOrigin.ts
+++ b/src/composables/overlayOrigin.ts
@@ -31,7 +31,12 @@ export function overlayReturnPath(): string {
   // Resolved from the NAME rather than written as "/": that path is the default-view entry
   // and lands on the grid (#883). A string is what comes back, because this same value is
   // stored in history state, which the check above reads back as a string.
-  return typeof origin === "string" ? origin : router.resolve({ name: "chat" }).fullPath;
+  //
+  // The grid, not chat. This is the answer for an overlay with NO recorded origin — a direct load
+  // of /collections, a link, a restored tab — and the grid is where "/" already sends those. It
+  // also decides what renders BEHIND such an overlay (see viewIsGrid, and App.vue's shell), so
+  // pointing it at the view that is being removed would put the single view back on screen.
+  return typeof origin === "string" ? origin : router.resolve({ name: "terminals" }).fullPath;
 }
 
 /** The `state` to attach to an overlay's push: the view to come back to.

--- a/src/composables/useNewTerminal.ts
+++ b/src/composables/useNewTerminal.ts
@@ -46,10 +46,11 @@ export function registerNewTerminalHandler(h: Handler): () => void {
 // default shell when it is omitted. If the grid isn't mounted yet, queue the request and switch to it.
 export function openTerminalAt(cwd: string, afterSlotKey: string | null, agent?: LaunchAgent): void {
   const req: NewTerminalRequest = { cwd, afterSlotKey, agent };
-  if (handler) {
-    handler(req);
-    return;
-  }
-  pending.push(req);
-  router.push("/terminals").catch(() => {});
+  if (handler) handler(req);
+  else pending.push(req);
+  // Then SHOW the grid. Mounted is not the same as on screen: it now stays alive underneath a
+  // full-screen overlay, so the phone's launch (#831) would be reported as served while the new
+  // terminal appeared behind the wiki or the collection browser, seen by nobody. Before the grid
+  // survived an overlay, the queue-and-navigate branch did this by accident (Codex, PR #1193).
+  if (router.currentRoute.value.name !== "terminals") router.push("/terminals").catch(() => {});
 }

--- a/src/composables/useSpawnedChat.ts
+++ b/src/composables/useSpawnedChat.ts
@@ -58,12 +58,14 @@ export function registerSpawnedChatHandler(h: Handler): () => void {
 
 /** Show a spawned chat as a grid cell. If the grid isn't mounted yet, queue it and switch to it. */
 export function placeSpawnedChat(req: SpawnedChatRequest): void {
-  if (handler) {
-    handler(req);
-    return;
-  }
-  pending.push(req);
-  router.push({ name: "terminals" }).catch(() => {});
+  if (handler) handler(req);
+  else pending.push(req);
+  // Then SHOW it, whether or not a grid took it. Mounted is not the same as on screen: since
+  // #1190 the grid stays alive UNDERNEATH a full-screen overlay, so a chat started from the
+  // collections browser is placed into a grid the user cannot see. Navigating is also what closes
+  // that overlay — before the grid survived one, the queue-and-navigate path did this by accident,
+  // and it stopped happening the moment the grid stopped unmounting.
+  if (router.currentRoute.value.name !== "terminals") router.push({ name: "terminals" }).catch(() => {});
 }
 
 /** Test seam: drop anything queued by a previous case. Not used by the app. */

--- a/src/composables/useSpawnedChat.ts
+++ b/src/composables/useSpawnedChat.ts
@@ -37,7 +37,10 @@ export interface SpawnedChatRequest {
    *  button, cron) says nothing here and gets the grid's ordinary behaviour. */
   canvas?: boolean;
 }
-type Handler = (req: SpawnedChatRequest) => void;
+/** Returns whether the grid actually took it. `false` means the grid was FULL and fell back to
+ *  showing the session in the single view — the one case where bringing the grid on screen would
+ *  take the user away from where the session just appeared. */
+type Handler = (req: SpawnedChatRequest) => boolean;
 
 let handler: Handler | null = null;
 let pending: SpawnedChatRequest[] = [];
@@ -58,13 +61,18 @@ export function registerSpawnedChatHandler(h: Handler): () => void {
 
 /** Show a spawned chat as a grid cell. If the grid isn't mounted yet, queue it and switch to it. */
 export function placeSpawnedChat(req: SpawnedChatRequest): void {
-  if (handler) handler(req);
-  else pending.push(req);
-  // Then SHOW it, whether or not a grid took it. Mounted is not the same as on screen: since
-  // #1190 the grid stays alive UNDERNEATH a full-screen overlay, so a chat started from the
-  // collections browser is placed into a grid the user cannot see. Navigating is also what closes
-  // that overlay — before the grid survived one, the queue-and-navigate path did this by accident,
-  // and it stopped happening the moment the grid stopped unmounting.
+  // `true` for a queued request too: the grid will have it as soon as it registers, so the grid is
+  // still where the user should be looking.
+  const goingToTheGrid = handler ? handler(req) : (pending.push(req), true);
+  // Then SHOW the grid. Mounted is not the same as on screen: since #1190 the grid stays alive
+  // UNDERNEATH a full-screen overlay, so a chat started from the collections browser is placed
+  // into a grid the user cannot see. Navigating is also what closes that overlay — before the grid
+  // survived one, the queue-and-navigate path did this by accident, and it stopped happening the
+  // moment the grid stopped unmounting.
+  //
+  // NOT when the grid refused it. A full grid falls back to the single view, and pushing here
+  // would drag the user off the view the session was just shown in (Codex, PR #1193).
+  if (!goingToTheGrid) return;
   if (router.currentRoute.value.name !== "terminals") router.push({ name: "terminals" }).catch(() => {});
 }
 

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
+import { router } from "../../../src/router";
 import { defineComponent, h, KeepAlive, type Component } from "vue";
 
 // App.vue renders GridView inside <KeepAlive>, and the grid registers its openers (new terminal,
@@ -27,6 +28,14 @@ vi.mock("../../../src/composables/useGridActivity", () => ({
 type FetchUrl = string | URL | Request; // what a fetch stub's first argument can be
 
 // Config GET hydrates pushEnabled=true; capture POSTs so we can assert the toggle saves.
+// The grid is mounted here without the router plugin, and several of its behaviours now ask the
+// singleton where the user actually IS — shortcuts and the unplaced sweep only apply while
+// /terminals is on screen, since the grid stays mounted underneath an overlay (#1193).
+beforeEach(async () => {
+  await router.push("/terminals");
+  await flushPromises();
+});
+
 const posts: Array<{ url: string; body: unknown }> = [];
 beforeEach(() => {
   posts.length = 0;

--- a/test/src/composables/overlayOrigin.spec.ts
+++ b/test/src/composables/overlayOrigin.spec.ts
@@ -5,6 +5,7 @@ import { prsGotoIndex, prsClose } from "../../../src/composables/usePrsView";
 import { accountingViewOpen, accountingViewClose } from "../../../src/composables/useAccountingView";
 import { wikiGotoIndex, wikiGotoPage, wikiGotoGraph, wikiClose } from "../../../src/composables/useWikiBrowse";
 import { browseGotoIndex, browseGotoDetail, browseClose } from "../../../src/composables/useCollectionBrowse";
+import { viewIsGrid } from "../../../src/composables/overlayOrigin";
 
 // Drives the real singleton router (jsdom web-history) — the composables are bound to it.
 const settle = () => flushPromises();
@@ -47,15 +48,20 @@ describe("overlay return-to-origin", () => {
     expect(router.currentRoute.value.name).toBe("chat");
   });
 
-  // A direct load / a history-driven entry carries no origin. Chat is the fallback, NOT the
-  // literal "/" — that path is the default-view entry and would land on the grid (#883).
-  it.each(OVERLAYS)("%s: falls back to chat when the entry carries no origin", async (_name, _open, close, routeName) => {
+  // A direct load / a history-driven entry carries no origin.
+  //
+  // The fallback is the GRID (#1190). It used to be chat, on the reasoning that resolving by name
+  // rather than the literal "/" avoided landing on the grid (#883) — and that reasoning inverted
+  // once the grid became the view the single one is being replaced by. It is also where "/" itself
+  // sends a fresh load, and it now decides what renders BEHIND an origin-less overlay: pointing it
+  // at chat would put the single view back on screen under one opened from a link.
+  it.each(OVERLAYS)("%s: falls back to the grid when the entry carries no origin", async (_name, _open, close, routeName) => {
     await router.push(`/${routeName === "collections" ? "collections" : routeName}`);
     await settle();
 
     close();
     await settle();
-    expect(router.currentRoute.value.name).toBe("chat");
+    expect(router.currentRoute.value.name).toBe("terminals");
   });
 
   // Moving around INSIDE an overlay must not re-record the origin as the overlay itself,
@@ -120,5 +126,63 @@ describe("overlay return-to-origin", () => {
     accountingViewClose();
     await settle();
     expect(router.currentRoute.value.name).toBe("chat");
+  });
+});
+
+// Which SHELL renders under whatever is on screen. Previously only the toolbar asked this; since
+// #1190 App.vue binds to it too, so a wrong answer is not a mismatched button — it is the wrong
+// view mounted behind an overlay, and after the single view goes, no view at all.
+describe("viewIsGrid — the shell underneath", () => {
+  beforeEach(async () => {
+    await router.push({ name: "chat" });
+    await settle();
+  });
+
+  it("is the grid on /terminals, and not on /chat", async () => {
+    await router.push("/terminals");
+    await settle();
+    expect(viewIsGrid.value).toBe(true);
+
+    await router.push({ name: "chat" });
+    await settle();
+    expect(viewIsGrid.value).toBe(false);
+  });
+
+  it.each(OVERLAYS)("%s: keeps the grid underneath when opened FROM the grid", async (_name, open) => {
+    // THE case. The header stays on screen above an overlay, so the shell behind it must not
+    // change: swapping in the single view would take away the very button that was clicked, and
+    // mount a terminal nobody asked for behind the overlay.
+    await router.push("/terminals");
+    await settle();
+
+    open();
+    await settle();
+    expect(viewIsGrid.value).toBe(true);
+  });
+
+  it.each(OVERLAYS)("%s: keeps the single view underneath when opened from it", async (_name, open) => {
+    // The mirror, and the reason this follows the ORIGIN rather than just "not chat": while the
+    // single view still exists, an overlay opened from it must not swap the grid in behind.
+    open();
+    await settle();
+    expect(viewIsGrid.value).toBe(false);
+  });
+
+  it("answers the grid for an overlay with no recorded origin", async () => {
+    // A direct load or a link: nothing to return to, so the fallback decides — and it is the grid.
+    await router.push("/prs");
+    await settle();
+    expect(viewIsGrid.value).toBe(true);
+  });
+
+  it("carries the origin across a hop from one overlay to another", async () => {
+    // grid → PRs → collections. The shell must not flip halfway through a chain of overlays.
+    await router.push("/terminals");
+    await settle();
+    prsGotoIndex();
+    await settle();
+    browseGotoIndex("collection");
+    await settle();
+    expect(viewIsGrid.value).toBe(true);
   });
 });

--- a/test/src/composables/spawnedChat.spec.ts
+++ b/test/src/composables/spawnedChat.spec.ts
@@ -32,7 +32,7 @@ describe("placeSpawnedChat", () => {
 
   it("hands the request straight to a registered grid, without navigating", () => {
     const placed: SpawnedChatRequest[] = [];
-    registerSpawnedChatHandler((req) => placed.push(req));
+    registerSpawnedChatHandler((req) => (placed.push(req), true));
 
     placeSpawnedChat(chat("a"));
 
@@ -48,7 +48,7 @@ describe("placeSpawnedChat", () => {
   it("switches to the grid even when a mounted one took the request", () => {
     routeName.value = "collections";
     const placed: SpawnedChatRequest[] = [];
-    registerSpawnedChatHandler((req) => placed.push(req));
+    registerSpawnedChatHandler((req) => (placed.push(req), true));
 
     placeSpawnedChat(chat("a"));
 
@@ -63,6 +63,18 @@ describe("placeSpawnedChat", () => {
     expect(push).toHaveBeenCalledWith({ name: "terminals" });
   });
 
+  // Codex, on PR #1193. A FULL grid refuses the chat and falls back to showing it in the single
+  // view. Pushing to /terminals then would drag the user off the view the session just appeared
+  // in — the navigation added for overlays must not override the fallback that predates it.
+  it("does NOT switch to the grid when a full grid refused the chat", () => {
+    routeName.value = "collections";
+    registerSpawnedChatHandler(() => false); // MAX_TERMINALS: shown in the single view instead
+
+    placeSpawnedChat(chat("a"));
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it("drains EVERY queued request in arrival order once the grid registers", () => {
     // A collection action can spawn more than one chat before the route changes; a single
     // slot would report the earlier ones as launched and show neither.
@@ -70,7 +82,7 @@ describe("placeSpawnedChat", () => {
     placeSpawnedChat(chat("b"));
 
     const placed: SpawnedChatRequest[] = [];
-    registerSpawnedChatHandler((req) => placed.push(req));
+    registerSpawnedChatHandler((req) => (placed.push(req), true));
 
     expect(placed.map((r) => r.id)).toEqual(["a", "b"]);
   });
@@ -80,7 +92,7 @@ describe("placeSpawnedChat", () => {
     // claude attaches to the wrong one. `draft` means the prompt is waiting in the input box.
     placeSpawnedChat(chat("queued", { agent: "codex", draft: true }));
     const placed: SpawnedChatRequest[] = [];
-    registerSpawnedChatHandler((req) => placed.push(req));
+    registerSpawnedChatHandler((req) => (placed.push(req), true));
     placeSpawnedChat(chat("direct", { agent: "antigravity" }));
 
     expect(placed).toEqual([chat("queued", { agent: "codex", draft: true }), chat("direct", { agent: "antigravity" })]);
@@ -90,7 +102,7 @@ describe("placeSpawnedChat", () => {
     // GridView drops its handler on deactivate: a chat started from the single view must not
     // silently mutate the cached grid behind it.
     const placed: SpawnedChatRequest[] = [];
-    const off = registerSpawnedChatHandler((req) => placed.push(req));
+    const off = registerSpawnedChatHandler((req) => (placed.push(req), true));
     off();
 
     routeName.value = "chat";
@@ -108,6 +120,7 @@ describe("placeSpawnedChat", () => {
     registerSpawnedChatHandler((req) => {
       seen.push(req.id);
       if (req.id === "first") placeSpawnedChat(chat("second"));
+      return true;
     });
 
     expect(seen).toEqual(["first", "second"]);

--- a/test/src/composables/spawnedChat.spec.ts
+++ b/test/src/composables/spawnedChat.spec.ts
@@ -5,8 +5,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // vi.hoisted, because vi.mock's factory is hoisted above the const it would otherwise close over.
-const { push } = vi.hoisted(() => ({ push: vi.fn(() => Promise.resolve()) }));
-vi.mock("../../../src/router", () => ({ router: { push } }));
+// `currentRoute` as well as `push`: placing now asks where the user IS before navigating, because
+// a mounted grid is not necessarily a visible one (it survives under a full-screen overlay).
+const { push, routeName } = vi.hoisted(() => ({ push: vi.fn(() => Promise.resolve()), routeName: { value: "terminals" as string } }));
+vi.mock("../../../src/router", () => ({
+  router: {
+    push,
+    currentRoute: {
+      get value() {
+        return { name: routeName.value };
+      },
+    },
+  },
+}));
 
 import { placeSpawnedChat, registerSpawnedChatHandler, resetSpawnedChatQueue, type SpawnedChatRequest } from "../../../src/composables/useSpawnedChat";
 
@@ -16,6 +27,7 @@ describe("placeSpawnedChat", () => {
   beforeEach(() => {
     resetSpawnedChatQueue();
     push.mockClear();
+    routeName.value = "terminals"; // the usual case: the user is looking at the grid
   });
 
   it("hands the request straight to a registered grid, without navigating", () => {
@@ -29,7 +41,23 @@ describe("placeSpawnedChat", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
+  // The grid survives under a full-screen overlay (#1190), so it can take the chat while the user
+  // is still looking at the collections browser. Placing it is not enough — before the grid stayed
+  // mounted, the queue-and-navigate path closed that overlay by accident, and the chat became
+  // invisible the moment that stopped happening.
+  it("switches to the grid even when a mounted one took the request", () => {
+    routeName.value = "collections";
+    const placed: SpawnedChatRequest[] = [];
+    registerSpawnedChatHandler((req) => placed.push(req));
+
+    placeSpawnedChat(chat("a"));
+
+    expect(placed).toEqual([chat("a")]);
+    expect(push).toHaveBeenCalledWith({ name: "terminals" });
+  });
+
   it("queues and switches to the grid when none is mounted", () => {
+    routeName.value = "chat";
     placeSpawnedChat(chat("a"));
 
     expect(push).toHaveBeenCalledWith({ name: "terminals" });
@@ -65,6 +93,7 @@ describe("placeSpawnedChat", () => {
     const off = registerSpawnedChatHandler((req) => placed.push(req));
     off();
 
+    routeName.value = "chat";
     placeSpawnedChat(chat("a"));
 
     expect(placed).toEqual([]);

--- a/test/src/composables/useChatLauncher.spec.ts
+++ b/test/src/composables/useChatLauncher.spec.ts
@@ -22,7 +22,7 @@ describe("startCollectionChat", () => {
     registerChatOpener(vi.fn());
     resetSpawnedChatQueue();
     placed = [];
-    registerSpawnedChatHandler((req) => placed.push(req));
+    registerSpawnedChatHandler((req) => (placed.push(req), true));
   });
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/test/src/composables/useFilesView.spec.ts
+++ b/test/src/composables/useFilesView.spec.ts
@@ -58,22 +58,26 @@ describe("useFilesView return-to-origin", () => {
     expect(useFilesView().cwd.value).toBe("/work/app");
   });
 
-  // Regression (codex #273, mirrored here): the origin rides the history entry, so a
-  // /files reached WITHOUT filesGotoIndex (browser back/forward, direct load) must fall
-  // back to chat — never a stale origin captured by an earlier open.
-  it("falls back to chat for a history-driven /files, ignoring an earlier open's origin", async () => {
-    await router.push("/terminals");
+  // Regression (codex #273, mirrored here): the origin rides the history entry, so a /files
+  // reached WITHOUT filesGotoIndex (browser back/forward, direct load) must fall back to the
+  // default view — never a stale origin captured by an earlier open.
+  //
+  // The earlier open captures CHAT and the fallback is the grid (#1190), deliberately opposite
+  // values. Written the other way round the two answers coincide, and the test passes whether the
+  // stale origin was ignored or reused — which is the whole thing it exists to catch.
+  it("falls back to the default view for a history-driven /files, ignoring an earlier open's origin", async () => {
+    await router.push({ name: "chat" });
     await settle();
-    filesGotoIndex("/proj"); // captures /terminals into that entry's state
+    filesGotoIndex("/proj"); // captures /chat into that entry's state
     await settle();
 
-    await router.push({ name: "chat" });
+    await router.push("/terminals");
     await settle();
     await router.push("/files"); // fresh /files entry, no captured origin
     await settle();
 
     filesClose();
     await settle();
-    expect(router.currentRoute.value.name).toBe("chat");
+    expect(router.currentRoute.value.name).toBe("terminals");
   });
 });

--- a/test/src/composables/useNewTerminal.spec.ts
+++ b/test/src/composables/useNewTerminal.spec.ts
@@ -2,8 +2,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { defineComponent, h, KeepAlive, ref, nextTick, onActivated, onDeactivated } from "vue";
 import { mount } from "@vue/test-utils";
 
-const { push } = vi.hoisted(() => ({ push: vi.fn(() => Promise.resolve()) }));
-vi.mock("../../../src/router/index", () => ({ router: { push } }));
+// `currentRoute` as well as `push`: opening now asks where the user IS before navigating, because
+// a mounted grid is not necessarily a visible one — it survives under a full-screen overlay.
+const { push, routeName } = vi.hoisted(() => ({ push: vi.fn(() => Promise.resolve()), routeName: { value: "terminals" as string } }));
+vi.mock("../../../src/router/index", () => ({
+  router: {
+    push,
+    currentRoute: {
+      get value() {
+        return { name: routeName.value };
+      },
+    },
+  },
+}));
 
 import { registerNewTerminalHandler, openTerminalAt } from "../../../src/composables/useNewTerminal";
 
@@ -11,6 +22,7 @@ describe("useNewTerminal", () => {
   beforeEach(() => {
     registerNewTerminalHandler(() => {})(); // drain any leftover pending + clear the handler
     push.mockClear();
+    routeName.value = "terminals"; // the usual case: the user is looking at the grid
   });
 
   it("calls the registered handler directly when the grid is mounted", () => {
@@ -23,11 +35,28 @@ describe("useNewTerminal", () => {
   });
 
   it("queues + navigates to /terminals with no grid, then drains on register (single-view path)", () => {
+    routeName.value = "chat"; // no grid mounted means the user is not looking at one
     openTerminalAt("/proj", "single");
     expect(push).toHaveBeenCalledWith("/terminals");
     const h = vi.fn();
     const off = registerNewTerminalHandler(h); // GridView mounts and registers
     expect(h).toHaveBeenCalledWith({ cwd: "/proj", afterSlotKey: "single" });
+    off();
+  });
+
+  // The grid stays mounted underneath a full-screen overlay (#1193), so it can take the request
+  // while the user is still looking at the wiki or the collection browser. Handing it over is not
+  // enough — the phone's launch would be reported as served and the terminal would appear behind
+  // the overlay, seen by nobody.
+  it("switches to the grid even when a mounted one took the request", () => {
+    routeName.value = "wiki";
+    const h = vi.fn();
+    const off = registerNewTerminalHandler(h);
+
+    openTerminalAt("/proj", null);
+
+    expect(h).toHaveBeenCalledOnce();
+    expect(push).toHaveBeenCalledWith("/terminals");
     off();
   });
 
@@ -68,6 +97,7 @@ describe("useNewTerminal", () => {
     expect(push).not.toHaveBeenCalled();
 
     active.value = false; // KeepAlive deactivates the probe (not unmounted)
+    routeName.value = "chat"; // ...and the user is somewhere else, which is why it deactivated
     await nextTick();
     openTerminalAt("/b", "single"); // no live handler → queue + navigate
     expect(push).toHaveBeenCalledWith("/terminals");


### PR DESCRIPTION
PR4 of the single-view removal (design note: `plans/feat-remove-single-view.md`). Follows #1167, #1186, #1187, #1188, #1189.

Everything the single view owns has to exist in the grid before PR5 can delete it. The full-screen overlays were the last piece: they could only appear by taking the grid off screen.

## The hoist alone does nothing

The plan said "hoist the overlays out of the `!isGrid` block". That is necessary and not sufficient.

Every overlay is **route-driven** — `/collections`, `/prs`, `/files`, `/wiki`, `/accounting`. Opening one leaves `/terminals`, and `isGrid` was `route.name === "terminals"` — so the grid came off screen and **the single view mounted behind the overlay**. Moving the overlays out only helps if the grid can also *be* the backdrop.

## `viewIsGrid` already answered this, and only the toolbar was asking

`overlayOrigin.ts` already exports exactly the right predicate — *is the view UNDERNEATH the current screen the grid?* — which follows the overlay's **origin** rather than its own route, so an overlay opened from the grid keeps the grid behind it.

Only `AppToolbar` read it. So for the entire time an overlay was open, the header and the shell behind it disagreed: the toolbar showed the grid's buttons while the single view's terminal was mounted behind. `App.vue` binds to the same value now, and the two agree.

`viewIsGrid` had **no tests**, and it decides which shell renders rather than which buttons show. Six cases added — grid, chat, opened-from-grid, opened-from-chat, no-origin, and an overlay→overlay hop — verified to fail against a broken predicate.

## The return-path fallback moves to the grid

An overlay with no recorded origin (a direct load, a link, a restored tab) used to fall back to chat. It falls back to the grid now: that is where `/` already sends a fresh load, and the fallback also decides what renders *behind* such an overlay — leaving it on chat would put the single view back on screen under an overlay opened from a link.

One existing regression test had to be rewritten rather than just re-pointed. It captured `/terminals` as the earlier origin and asserted the fallback was `chat`; with the fallback now `terminals`, the two answers coincide and it would pass whether the stale origin was ignored **or reused** — which is the whole thing it exists to catch. It captures `/chat` and expects `terminals` now, deliberately opposite values.

## Two things deliberately not done

**`AppSettingsModal` is not hoisted.** `GridView` renders its own, so hoisting this one would show two on `/terminals`. Five overlays moved, not six.

**The `AppToolbar` switch to `{name:"chat"}` stays.** Removing it here would strand the single view — unreachable but still present. That is PR5's job.

Also already true, so no work: **`ToolsPane` is already beside the zoomed cell** (`TerminalGrid.vue:867`). The plan listed it as an open decision; earlier work had answered it.

## One regression this introduced, and fixed

With the grid surviving under an overlay, a chat started from the collections browser is placed into a grid **the user cannot see**.

The queue-and-navigate path had been closing that overlay *by accident* — the grid was unmounted, so there was no handler, so the request queued and pushed to `/terminals`. The moment the grid stopped unmounting, that stopped happening and the chat went behind the overlay silently.

`placeSpawnedChat` now navigates whenever the user is not already on `/terminals`, whether or not a mounted grid took the request. Pinned by a test that places into a mounted grid from a `collections` route and asserts the push.

## Verified

- `yarn test` — 7086 tests pass (+12)
- `yarn typecheck` / `:test` / `:server` all pass
- `yarn lint` 0 errors (4 pre-existing max-lines warnings), `yarn build` succeeds
- Each new assertion checked to fail without its fix

Note the pre-existing parallel-load flakiness in this suite (documented in `vitest.config.ts`; `main` shows it too): a run may fail on one unrelated file.

**Not verified:** anything in a running app, and this PR is the most visual one yet. Worth opening a collection from the grid and confirming the grid is what sits behind it — and that starting a chat from that browser lands you on the grid with the new cell.

Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full-screen overlays now appear over the grid while preserving the underlying view.
  * Overlay navigation without a saved origin now returns to the Terminals view.
  * Spawned chats now reliably navigate to Terminals when needed.

* **Bug Fixes**
  * Improved navigation when opening Files or overlays from different views.
  * Prevented stale navigation history from sending users back to an outdated location.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->