### PR TITLE
docs: skill-bridge はここで再実装するなと5行だけ書く (#1191 項目3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,15 +114,19 @@ startup: a bundled dispatcher at `<workspace>/.claude/hooks/mulmoclaude-dispatch
 That does **not** mean the bridge is off under MulmoTerminal, and this is the part worth knowing
 before you "fix" a missing mirror here. **Claude Code merges hooks from `--settings` and the
 project's `.claude/settings.json` — both fire** (verified by running `claude -p` with a hook in
-each; both markers appeared). We pass ours as inline JSON (`server/session/hook-settings.ts`),
-which layers on top rather than replacing. The dispatcher's mirroring is plain `fs`, and its
+each; both markers appeared). Ours go through `--settings` (`server/session/hook-settings.ts`) —
+inline JSON, or a 0600 file when the payload carries a provider token and always a file on Windows
+(`session-settings.ts`) — which layers on top rather than replacing. Whichever transport, the
+project file is still read. The dispatcher's mirroring is plain `fs`, and its
 follow-up POST to MulmoClaude goes through a `safePost` that swallows a refused connection. So in
 a workspace MulmoClaude has ever started against, **an agent MulmoTerminal spawned still gets its
 skills mirrored, with MulmoClaude not running.**
 
 The real gap is narrow: a workspace MulmoClaude has never started against has no dispatcher, so
-`data/skills/` is staged and never mirrored. Before reimplementing anything, check whether
-`<workspace>/.claude/settings.json` has the entry — that, not this host's code, is what decides.
+`data/skills/` is staged and never mirrored. Before reimplementing anything, check BOTH halves —
+`<workspace>/.claude/hooks/mulmoclaude-dispatcher.mjs` and the `PostToolUse` entry naming it in
+`<workspace>/.claude/settings.json`. Either alone does nothing (a settings entry survives a
+deleted script), and that pair, not this host's code, is what decides.
 
 `mulmoterminal-config` is the **entry point**: it routes to the skill that owns an area, and it
 reports on how things are configured now. The writing skills are `mulmoterminal-dirs` (per-project

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,28 @@ spec pins the two together). It is in `common/` because the UI names skills too:
 section a skill can write ends in a `SkillLaunchButton`, whose `skill` prop is a `BundledSkillName`,
 so a slug naming nothing that ships is a type error rather than an agent that can't find it.
 
+### `data/skills/` staging is a different mechanism, and this host does not install it
+
+`BUNDLED_SKILL_NAMES` is about what MulmoTerminal *ships*. Separately, core's `skill-bridge`
+mirrors a workspace's `data/skills/<slug>/` staging into the `.claude/skills/<slug>/` the CLI
+actually discovers — that is how an agent authors a skill and has it go live. **This repo never
+imports `@mulmoclaude/core/skill-bridge`, and never provisions it.** MulmoClaude does, at server
+startup: a bundled dispatcher at `<workspace>/.claude/hooks/mulmoclaude-dispatcher.mjs` plus one
+`PostToolUse` entry in `<workspace>/.claude/settings.json`.
+
+That does **not** mean the bridge is off under MulmoTerminal, and this is the part worth knowing
+before you "fix" a missing mirror here. **Claude Code merges hooks from `--settings` and the
+project's `.claude/settings.json` — both fire** (verified by running `claude -p` with a hook in
+each; both markers appeared). We pass ours as inline JSON (`server/session/hook-settings.ts`),
+which layers on top rather than replacing. The dispatcher's mirroring is plain `fs`, and its
+follow-up POST to MulmoClaude goes through a `safePost` that swallows a refused connection. So in
+a workspace MulmoClaude has ever started against, **an agent MulmoTerminal spawned still gets its
+skills mirrored, with MulmoClaude not running.**
+
+The real gap is narrow: a workspace MulmoClaude has never started against has no dispatcher, so
+`data/skills/` is staged and never mirrored. Before reimplementing anything, check whether
+`<workspace>/.claude/settings.json` has the entry — that, not this host's code, is what decides.
+
 `mulmoterminal-config` is the **entry point**: it routes to the skill that owns an area, and it
 reports on how things are configured now. The writing skills are `mulmoterminal-dirs` (per-project
 colours, grid/launcher order, name, font size), `-theme` (custom global colour schemes), `-header`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,31 +102,11 @@ spec pins the two together). It is in `common/` because the UI names skills too:
 section a skill can write ends in a `SkillLaunchButton`, whose `skill` prop is a `BundledSkillName`,
 so a slug naming nothing that ships is a type error rather than an agent that can't find it.
 
-### `data/skills/` staging is a different mechanism, and this host does not install it
-
-`BUNDLED_SKILL_NAMES` is about what MulmoTerminal *ships*. Separately, core's `skill-bridge`
-mirrors a workspace's `data/skills/<slug>/` staging into the `.claude/skills/<slug>/` the CLI
-actually discovers — that is how an agent authors a skill and has it go live. **This repo never
-imports `@mulmoclaude/core/skill-bridge`, and never provisions it.** MulmoClaude does, at server
-startup: a bundled dispatcher at `<workspace>/.claude/hooks/mulmoclaude-dispatcher.mjs` plus one
-`PostToolUse` entry in `<workspace>/.claude/settings.json`.
-
-That does **not** mean the bridge is off under MulmoTerminal, and this is the part worth knowing
-before you "fix" a missing mirror here. **Claude Code merges hooks from `--settings` and the
-project's `.claude/settings.json` — both fire** (verified by running `claude -p` with a hook in
-each; both markers appeared). Ours go through `--settings` (`server/session/hook-settings.ts`) —
-inline JSON, or a 0600 file when the payload carries a provider token and always a file on Windows
-(`session-settings.ts`) — which layers on top rather than replacing. Whichever transport, the
-project file is still read. The dispatcher's mirroring is plain `fs`, and its
-follow-up POST to MulmoClaude goes through a `safePost` that swallows a refused connection. So in
-a workspace MulmoClaude has ever started against, **an agent MulmoTerminal spawned still gets its
-skills mirrored, with MulmoClaude not running.**
-
-The real gap is narrow: a workspace MulmoClaude has never started against has no dispatcher, so
-`data/skills/` is staged and never mirrored. Before reimplementing anything, check BOTH halves —
-`<workspace>/.claude/hooks/mulmoclaude-dispatcher.mjs` and the `PostToolUse` entry naming it in
-`<workspace>/.claude/settings.json`. Either alone does nothing (a settings entry survives a
-deleted script), and that pair, not this host's code, is what decides.
+Core's `skill-bridge` — a workspace's `data/skills/` staged into the `.claude/skills/` the CLI
+discovers — is a separate mechanism we never import. MulmoClaude provisions it into
+`<workspace>/.claude/settings.json`, and Claude Code MERGES those hooks with our `--settings`, so
+it already fires for our sessions in any workspace MulmoClaude has started against. Don't
+reimplement it here; check that workspace first (#1191).
 
 `mulmoterminal-config` is the **entry point**: it routes to the skill that owns an area, and it
 reports on how things are configured now. The writing skills are `mulmoterminal-dirs` (per-project


### PR DESCRIPTION
## Summary

`CLAUDE.md` に **5行**追加するだけの PR です（#1191 の項目3）。

```
Core's `skill-bridge` — a workspace's `data/skills/` staged into the `.claude/skills/` the CLI
discovers — is a separate mechanism we never import. MulmoClaude provisions it into
`<workspace>/.claude/settings.json`, and Claude Code MERGES those hooks with our `--settings`, so
it already fires for our sessions in any workspace MulmoClaude has started against. Don't
reimplement it here; check that workspace first (#1191).
```

当初は見出し付きで 26 行書いていましたが、CLAUDE.md は毎セッション読み込まれるため稀なケースに割く量ではないという指摘を受け、**行動を変える一点だけ**に削りました。見出しも消して既存の Bundled skills 節に畳んでいます。検証の詳細は #1191 にあります。

## Items to Confirm / Review

**確認してほしいのは「MERGES」の一語が正しいかだけです。** ここが違うと文章全体が嘘になります。

推測ではなく実測しました。一時ディレクトリに片方ずつ別の hook を置いて `claude` を走らせています:

```
$T/proj/.claude/settings.json  -> PostToolUse(matcher "") : touch $T/PROJECT_HOOK_FIRED
$T/cli-settings.json           -> PostToolUse(matcher "") : touch $T/CLI_HOOK_FIRED

cd $T/proj && claude -p "Create a file named hello.txt containing the single word hi." \
  --settings "$T/cli-settings.json" --permission-mode acceptEdits
```

結果は `CLI_HOOK_FIRED` と `PROJECT_HOOK_FIRED` の**両方**。`--settings` は project 設定を置換しません。

ただし検証したのは**このマシンの `claude` 1バージョンのみ**です。将来変わればこの記述は嘘になります。

## User Prompt

> \- #1191 項目3（skill-bridge）

> claude mdはコンパクトにしたいので、このPRは不要。もしくは簡素に

## なぜ「意図的に対象外」と書かなかったか

#1191 の項目3 は当初「skill-bridge は MulmoTerminal では意図的に対象外」と書き残すつもりでしたが、調べたら前提が2つとも崩れました。

1. **MulmoTerminal にフック機構はあります。** `server/routes/hook-routes.ts` が Pre/PostToolUse を処理し、`server/session/hook-settings.ts` が `--settings` で渡しています。「フックを挟むアーキテクチャが無いから対象外」という理由は成立しません。
2. **登録していない＝動かない、ではありません。** 上記のとおり hook はマージされ、dispatcher のミラー本体は純粋な fs、後続の POST は `safePost` が握りつぶすので、**MulmoClaude が起動していなくてもミラーは走ります**。

本当のギャップは「MulmoClaude が一度も起動していないワークスペース」だけです。#1191 の本文もこの内容に訂正済みです。

## 検証

ドキュメントのみ（コード変更ゼロ）。`.prettierignore` が `*.md` を除外しているため `yarn format` の対象外、`yarn lint` は 0 errors（既存の max-lines 警告4件のみ、増減なし）。

なお 26 行版に対して CodeRabbit が付けた指摘2件（settings の transport、dispatcher の2つの契約）は、対象の文章ごと削除されたため現在の差分には残っていません。内容自体は #1191 に反映済みです。

work in mulmoterminal
