### PR TITLE
feat: run a scheduled task's chat as a background worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,9 @@ disconnected, or with no device registered, the toggle is a no-op.
 **Dev worklog (cross-clone).** Set `worklogEnabled: true` in
 `~/.mulmoterminal/config.json` (and **restart** — the scheduler reads its tasks at boot)
 to register a built-in scheduled task. Every `worklogIntervalHours` (default 6) it spawns
-a Claude session that reviews the work you did across **all your saved working dirs**
+a Claude session — as a **background worker**: behind the Background filter, never bold,
+and it takes no grid cell, so an hourly task cannot fill the grid — that reviews the work
+you did across **all your saved working dirs**
 (`cwdPresets`) since it last ran, and writes it up as a short manager-style report.
 Multiple clones/worktrees of the same repo (e.g. `myapp`, `myapp2`) are **merged into one
 per-repository section**, each covering what problem was addressed, what got solved, what's
@@ -1490,7 +1492,8 @@ Key rules:
   exists) via the in-memory `knownSessions` registry + a `created` push; an
   unused one disappears when its PTY is reaped.
 - **Background workers get their own filter.** A session nobody started by hand —
-  a collection's scheduled refresh, or a plugin's `spawnBackgroundChat`
+  a collection's scheduled refresh, a **user scheduled task** (the dev worklog and
+  anything else the scheduler runs), or a plugin's `spawnBackgroundChat`
   `hidden: true` — is listed under the **Background** chip instead of among the
   chats, so a refresh schedule doesn't fill the history. It stays openable (a
   MulmoTerminal session is a live terminal, so a row you can't reach is a process

--- a/README.md
+++ b/README.md
@@ -630,10 +630,11 @@ disconnected, or with no device registered, the toggle is a no-op.
 **Dev worklog (cross-clone).** Set `worklogEnabled: true` in
 `~/.mulmoterminal/config.json` (and **restart** — the scheduler reads its tasks at boot)
 to register a built-in scheduled task. Every `worklogIntervalHours` (default 6) it spawns
-a Claude session — as a **background worker**: behind the Background filter, never bold,
-and it takes no grid cell, so an hourly task cannot fill the grid — that reviews the work
-you did across **all your saved working dirs**
+a Claude session that reviews the work you did across **all your saved working dirs**
 (`cwdPresets`) since it last ran, and writes it up as a short manager-style report.
+It runs as a **background worker**: behind the Background filter, never bold, and it takes
+no grid cell, so an hourly task cannot fill the grid. Web **Push** still fires for it —
+being quiet means out of the way, not unreachable, and it runs while you are away.
 Multiple clones/worktrees of the same repo (e.g. `myapp`, `myapp2`) are **merged into one
 per-repository section**, each covering what problem was addressed, what got solved, what's
 still in progress, and — mined from the transcripts — decisions that were only *discussed

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -25,9 +25,14 @@ scheduled task that ends without completing a turn is recorded and shows as `●
 launcher's session list — the same signal a hidden `spawnBackgroundChat` gets. Turn the sound on
 under Settings → Notifications if you want to hear it.
 
-**What you lose:** a scheduled task's session no longer goes bold/unread when it finishes. If you
-were watching for that, look under the Background filter, or in the launcher's list for the
-workspace.
+**Web Push still fires for it.** Being quiet means out of the chat list and off the grid, not
+unreachable: a background session's finished turn normally never reaches the phone, on the
+reasoning that it is not a real user task — and a task you configured to run while you are away is
+exactly that. If you have push on, a scheduled task notifies as before.
+
+**What you lose:** a scheduled task's session no longer goes bold/unread in the chat list when it
+finishes. If you were watching for that, look under the Background filter, in the launcher's list
+for the workspace — or turn push on.
 
 ### The Docker sandbox is removed (#1194)
 

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -6,6 +6,29 @@ This file records **what changed and why**. For **how to actually use** a new fe
 
 ## Unreleased
 
+### A scheduled task's chat is a background worker (#1196)
+
+A task the scheduler runs — the dev worklog, or anything else you have configured — now behaves
+like every other session nobody started by hand: it sits behind the **Background** filter rather
+than among your chats, never renders bold, and **takes no grid cell**.
+
+It was already half of one. Scheduled sessions have always been put on the background retention,
+whose whole reason is that nobody is waiting for them to finish; only the chat list still called
+them yours. The two agree now.
+
+The grid part is the one you would have noticed: a visible spawn is adopted as a cell the next time
+the grid loads, so an hourly task meant a cell per firing, indefinitely, without anyone asking for
+a terminal.
+
+**A failed one still tells you.** Being quiet is right while it works and wrong when it dies, so a
+scheduled task that ends without completing a turn is recorded and shows as `● failed` in the
+launcher's session list — the same signal a hidden `spawnBackgroundChat` gets. Turn the sound on
+under Settings → Notifications if you want to hear it.
+
+**What you lose:** a scheduled task's session no longer goes bold/unread when it finishes. If you
+were watching for that, look under the Background filter, or in the launcher's list for the
+workspace.
+
 ### The Docker sandbox is removed (#1194)
 
 `MULMOTERMINAL_SANDBOX` and its three companion variables — `MULMOTERMINAL_SANDBOX_IMAGE`,

--- a/server/index.ts
+++ b/server/index.ts
@@ -71,6 +71,7 @@ import {
 import { hydrateClearedTranscripts } from "./session/cleared-transcripts.js";
 import { runWithHiddenMarker } from "./session/hiddenMarker.js";
 import { registerCompletionHook } from "./session/completion-hooks.js";
+import { spawnScheduledWorker } from "./session/scheduled-chat.js";
 import { createToolStores } from "./session/tool-store.js";
 import { writeDecisionDigest } from "./session/decision-digest-file.js";
 import { createScheduledSessionRegistry, scheduledSessionInUse, scheduledSessionsDir } from "./session/scheduled-sessions.js";
@@ -781,14 +782,15 @@ function refreshDecisionDigests(): void {
 refreshDecisionDigests();
 setInterval(refreshDecisionDigests, DECISION_DIGEST_INTERVAL_MS).unref();
 
+// A user's scheduled task runs as a BACKGROUND WORKER — see scheduled-chat.ts for why, and for
+// what follows from it (no grid cell, but a failed one still says so).
 function spawnScheduledChat(message: string): void {
   const sessionId = randomUUID();
   try {
-    spawnClaudePty(sessionId, null, null, { initialPrompt: message });
-    scheduledSessions.register(sessionId);
-    // The clearest case for the unplaced mark: a task firing at 3am has no browser to place its
-    // chat, and without this the only trace would be a row in a list nobody is looking at.
-    markUnplacedSession(sessionId);
+    spawnScheduledWorker(sessionId, {
+      spawn: (id) => spawnClaudePty(id, null, null, { initialPrompt: message }),
+      retain: (id) => scheduledSessions.register(id),
+    });
   } catch (err) {
     console.error(`[scheduler] failed to spawn chat for a scheduled task: ${messageOf(err)}`);
   }

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -326,6 +326,33 @@ export function hasAllGuiTools(id: string): boolean {
   return allToolsSessions.has(id);
 }
 
+// Sessions the SCHEDULER started — a user's own configured task, as opposed to a collection
+// refresh or an internal helper.
+//
+// They are background sessions in every other respect (out of the chat list, never bold, no grid
+// cell), and this exists because ONE of those respects is wrong for them: a turn ending on a
+// background session never reaches the phone, on the reasoning that it "isn't a real user task".
+// A task the user configured to run while they are away is exactly a real user task, and push is
+// the only way they would ever hear about it (Codex, PR #1196).
+//
+// Persisted like its siblings: a tmux session outlives a server restart, so the turn that raises
+// the push can happen long after the process that spawned it is gone.
+const userScheduledSessions = new Set<string>();
+const USER_SCHEDULED_SESSIONS_FILE = path.join(MULMOTERMINAL_HOME, "user-scheduled-sessions.json");
+export const userScheduledSessionsHydrated = hydrateIdLog(USER_SCHEDULED_SESSIONS_FILE, userScheduledSessions);
+const appendUserScheduledSession = idLogAppender(USER_SCHEDULED_SESSIONS_FILE, "user-scheduled-sessions");
+
+export function markUserScheduledSession(id: string): void {
+  if (!isValidSessionId(id) || userScheduledSessions.has(id)) return;
+  userScheduledSessions.add(id);
+  appendUserScheduledSession(id);
+}
+
+/** Did the scheduler start this? Asked by the push rules, which suppress background sessions. */
+export function isUserScheduledSession(id: string): boolean {
+  return userScheduledSessions.has(id);
+}
+
 // Background workers whose run ENDED BADLY: reached teardown without ever reporting a finished
 // turn. A worker is invisible on purpose, so a failed one is the single case where that design
 // works against the user — nothing pulls their attention and nothing is waiting to be clicked, so

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -353,6 +353,22 @@ export function isUserScheduledSession(id: string): boolean {
   return userScheduledSessions.has(id);
 }
 
+/**
+ * The two durable answers the Web Push gate needs, read TOGETHER and only once both logs have
+ * hydrated.
+ *
+ * One function rather than two calls, because the HAZARD IS THE COMBINATION. Read separately
+ * during startup, `background` can hydrate before `userScheduled` — and `(background: true,
+ * userScheduled: false)` is precisely "a background session that is not the user's task", so the
+ * push is suppressed for the one run that most needs it. A scheduled session survives a restart in
+ * tmux, so its turn finishing moments after boot is the ordinary case here, not a corner (Codex,
+ * PR #1196).
+ */
+export async function pushClassification(id: string): Promise<{ background: boolean; userScheduled: boolean }> {
+  await Promise.all([backgroundSessionsHydrated, userScheduledSessionsHydrated]);
+  return { background: isBackgroundSession(id), userScheduled: isUserScheduledSession(id) };
+}
+
 // Background workers whose run ENDED BADLY: reached teardown without ever reporting a finished
 // turn. A worker is invisible on purpose, so a failed one is the single case where that design
 // works against the user — nothing pulls their attention and nothing is waiting to be clicked, so

--- a/server/session/scheduled-chat.ts
+++ b/server/session/scheduled-chat.ts
@@ -16,7 +16,10 @@
 //     nobody having asked for a single terminal.
 //   - a FAILED one still says so. Quiet is right while it works and wrong when it dies: nothing
 //     pulls the user's attention, so without the hook a failed task is never learned.
-import { backgroundMarkers, markFailedWorker } from "./registry.js";
+//
+// And one thing it does NOT inherit: Web Push still fires for it. See markUserScheduledSession —
+// "quiet" here means out of the chat list and off the grid, not unreachable.
+import { backgroundMarkers, markFailedWorker, markUserScheduledSession } from "./registry.js";
 import { runWithHiddenMarker } from "./hiddenMarker.js";
 import { registerCompletionHook } from "./completion-hooks.js";
 
@@ -40,6 +43,11 @@ export interface ScheduledChatDeps {
 export function spawnScheduledWorker(sessionId: string, deps: ScheduledChatDeps): void {
   runWithHiddenMarker(true, sessionId, backgroundMarkers, () => deps.spawn(sessionId));
   deps.retain(sessionId);
+  // Background in every respect EXCEPT the phone. A background session's finished turn never
+  // pushes, on the reasoning that it "isn't a real user task" — and a task the user configured to
+  // run while they are away is exactly that, with the phone the only way they would hear about it
+  // (Codex, PR #1196). Marked after the spawn, like the hook below.
+  markUserScheduledSession(sessionId);
   registerCompletionHook(sessionId, ({ didError }) => {
     if (didError) markFailedWorker(sessionId);
   });

--- a/server/session/scheduled-chat.ts
+++ b/server/session/scheduled-chat.ts
@@ -1,0 +1,46 @@
+// What a user's scheduled task's chat IS, as opposed to how it is spawned.
+//
+// Split from index.ts for the reason background-chat.ts was split from its route: the rules below
+// are policy, and the caller is otherwise a uuid, a spawn and a try/catch. Policy nothing can
+// assert is policy that drifts — and this one is two halves that have to agree.
+//
+// A scheduled chat is a BACKGROUND WORKER, the same as `spawnBackgroundChat hidden:true`, because
+// it is dispatched by a clock rather than by someone at a keyboard. It was already half of one:
+// `scheduledSessions.register` puts it on the background retention, whose stated reason is that
+// "nobody is waiting for it to finish and nothing else would ever end it". The chat list still
+// showed it as a session the user had started. These two now agree.
+//
+// Two consequences follow, and both are the point rather than side effects:
+//   - it takes NO grid cell. A visible spawn is marked unplaced so the next grid adopts it, and
+//     for a task firing hourly that is a cell per firing, forever — reaching MAX_TERMINALS with
+//     nobody having asked for a single terminal.
+//   - a FAILED one still says so. Quiet is right while it works and wrong when it dies: nothing
+//     pulls the user's attention, so without the hook a failed task is never learned.
+import { backgroundMarkers, markFailedWorker } from "./registry.js";
+import { runWithHiddenMarker } from "./hiddenMarker.js";
+import { registerCompletionHook } from "./completion-hooks.js";
+
+export interface ScheduledChatDeps {
+  /** Start the PTY. Separate so the policy can be exercised without spawning anything. */
+  spawn: (sessionId: string) => void;
+  /** Put it on the scheduled-session retention — nothing else would ever end it. */
+  retain: (sessionId: string) => void;
+}
+
+/**
+ * Run a scheduled task's chat as a background worker.
+ *
+ * The completion hook is registered AFTER the spawn: a launch that threw has no session to report
+ * on, and registering first would leave a hook nothing will ever fire or clear.
+ *
+ * Claude-only by construction — this path always spawns claude — which matters because the Stop
+ * hook is the only success signal a PTY-hosted agent gives. A recorder on an agent that cannot
+ * report success would mark every successful run as failed.
+ */
+export function spawnScheduledWorker(sessionId: string, deps: ScheduledChatDeps): void {
+  runWithHiddenMarker(true, sessionId, backgroundMarkers, () => deps.spawn(sessionId));
+  deps.retain(sessionId);
+  registerCompletionHook(sessionId, ({ didError }) => {
+    if (didError) markFailedWorker(sessionId);
+  });
+}

--- a/server/session/task-push.ts
+++ b/server/session/task-push.ts
@@ -9,7 +9,7 @@ import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
 import { buildPushText } from "./activity-hook.js";
 import type { PushKind } from "../../common/pushKinds.js";
 import { asTerminalAgent } from "../../common/sessionAgent.js";
-import { aiTitles, isBackgroundSession, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
+import { aiTitles, isBackgroundSession, isUserScheduledSession, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
 import { clearedTranscripts } from "./cleared-transcripts.js";
 import { sessionLastTurn, LAST_RESPONSE_MAX } from "./session-reads.js";
 import { buildPushDetail, pushWhere, shouldSuppressPush, wantsPushKind } from "./taskPushRules.js";
@@ -41,7 +41,7 @@ export async function notifyTaskFinished(sessionId: string, kind: PushKind, mess
   // of the DURABLE predicate, not the live set: tmux keeps a worker's agent running across a
   // server restart, and the live set does not survive one — so the gate would open for exactly
   // the long-running scheduled refresh it exists to silence.
-  if (shouldSuppressPush(isBackgroundSession(sessionId), translationWorkerIds.has(sessionId))) return;
+  if (shouldSuppressPush(isBackgroundSession(sessionId), translationWorkerIds.has(sessionId), isUserScheduledSession(sessionId))) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = pushWhere(cwd);
   // Not after a `/clear`: our transcript is frozen on the conversation the user just ended, so

--- a/server/session/task-push.ts
+++ b/server/session/task-push.ts
@@ -9,7 +9,7 @@ import { HOST_ID as REMOTE_HOST_ID } from "../backends/remoteHost/index.js";
 import { buildPushText } from "./activity-hook.js";
 import type { PushKind } from "../../common/pushKinds.js";
 import { asTerminalAgent } from "../../common/sessionAgent.js";
-import { aiTitles, isBackgroundSession, isUserScheduledSession, lastPrompts, lastResponses, ptys, translationWorkerIds } from "./registry.js";
+import { aiTitles, lastPrompts, lastResponses, ptys, pushClassification, translationWorkerIds } from "./registry.js";
 import { clearedTranscripts } from "./cleared-transcripts.js";
 import { sessionLastTurn, LAST_RESPONSE_MAX } from "./session-reads.js";
 import { buildPushDetail, pushWhere, shouldSuppressPush, wantsPushKind } from "./taskPushRules.js";
@@ -41,7 +41,10 @@ export async function notifyTaskFinished(sessionId: string, kind: PushKind, mess
   // of the DURABLE predicate, not the live set: tmux keeps a worker's agent running across a
   // server restart, and the live set does not survive one — so the gate would open for exactly
   // the long-running scheduled refresh it exists to silence.
-  if (shouldSuppressPush(isBackgroundSession(sessionId), translationWorkerIds.has(sessionId), isUserScheduledSession(sessionId))) return;
+  // Both durable answers from one call, so they cannot be read at different points of hydration —
+  // see pushClassification for why that combination is the dangerous one.
+  const { background, userScheduled } = await pushClassification(sessionId);
+  if (shouldSuppressPush(background, translationWorkerIds.has(sessionId), userScheduled)) return;
   const cwd = ptys.get(sessionId)?.cwd ?? null;
   const where = pushWhere(cwd);
   // Not after a `/clear`: our transcript is frozen on the conversation the user just ended, so

--- a/server/session/taskPushRules.ts
+++ b/server/session/taskPushRules.ts
@@ -24,8 +24,18 @@ export function buildPushDetail(input: PushDetailInput): string {
 // Background workers and translation workers aren't real user tasks, so a turn ending on one
 // must never reach the phone. "never" is why the caller answers `background` from the durable
 // marking rather than from which sessions this process happens to have spawned.
-export function shouldSuppressPush(background: boolean, translationWorker: boolean): boolean {
-  return background || translationWorker;
+//
+// A user's SCHEDULED task is the exception, and it is the reason this takes three answers rather
+// than two. It is a background session in every other respect — out of the chat list, never bold,
+// no grid cell — but it is a task the user configured, running while they are away, and the phone
+// is the only way they would ever hear about it. Suppressing it would silence exactly the case the
+// setting exists for (Codex, PR #1196).
+//
+// A translation worker is still refused even if something ever schedules one: it is an internal
+// helper with no output a person reads, so there is nothing to tell them about.
+export function shouldSuppressPush(background: boolean, translationWorker: boolean, userScheduled = false): boolean {
+  if (translationWorker) return true;
+  return background && !userScheduled;
 }
 
 // Whether the user asked to hear about THIS moment (#850). Two independent answers: the master

--- a/test/server/session/push-classification.spec.ts
+++ b/test/server/session/push-classification.spec.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+// The two durable answers the Web Push gate reads, and why they are read together.
+//
+// A scheduled session survives a server restart in tmux, so its turn finishing moments after boot
+// is the ORDINARY case here. Read separately during that window, `background` can hydrate before
+// `userScheduled` — and (background: true, userScheduled: false) is exactly "a background session
+// that is not the user's task", so the push is suppressed for the one run that most needs it
+// (Codex, PR #1196).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ID = "11111111-1111-1111-1111-111111111111";
+
+// Hydration reads through this. The user-scheduled log is answered LATE on purpose: that is the
+// ordering the bug needs, and an immediate answer would let a non-awaiting implementation pass.
+let slowLog = "";
+vi.mock("node:fs", () => {
+  const promises = {
+    readFile: vi.fn(async (file: unknown) => {
+      const name = String(file).split("/").pop() ?? "";
+      if (name === "background-sessions.json") return ID;
+      if (name === "user-scheduled-sessions.json") {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return slowLog;
+      }
+      return "";
+    }),
+    appendFile: vi.fn(async () => undefined),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  return { promises, default: { promises } };
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("pushClassification", () => {
+  it("waits for the SLOWER log before answering", async () => {
+    // Asked immediately, as a turn finishing right after boot would. Without the await this reads
+    // the half-hydrated state and reports the session as a background worker that nobody
+    // scheduled — which is the combination that silences it.
+    slowLog = ID;
+    vi.resetModules();
+    const { pushClassification } = await import("../../../server/session/registry.js");
+
+    expect(await pushClassification(ID)).toEqual({ background: true, userScheduled: true });
+  });
+
+  it("still reports a background session that really was not scheduled", async () => {
+    // The rule it protects has to keep working: a collection's refresh stays silenced.
+    slowLog = "";
+    vi.resetModules();
+    const { pushClassification } = await import("../../../server/session/registry.js");
+
+    expect(await pushClassification(ID)).toEqual({ background: true, userScheduled: false });
+  });
+
+  it("says neither for an ordinary session", async () => {
+    slowLog = "";
+    vi.resetModules();
+    const { pushClassification } = await import("../../../server/session/registry.js");
+
+    expect(await pushClassification("22222222-2222-2222-2222-222222222222")).toEqual({ background: false, userScheduled: false });
+  });
+});

--- a/test/server/session/scheduled-chat.spec.ts
+++ b/test/server/session/scheduled-chat.spec.ts
@@ -48,6 +48,16 @@ describe("a scheduled task's chat", () => {
     expect(registry.unplacedSessionRows()).toEqual([]);
   });
 
+  // The one thing it does NOT inherit from being a background session. Suppressing this would
+  // silence exactly the case the setting exists for: a task running while the user is away.
+  it("stays reachable by Web Push", async () => {
+    const { registry, spawnScheduledWorker } = await fresh();
+    spawnScheduledWorker(ID, noop);
+    expect(registry.isUserScheduledSession(ID)).toBe(true);
+    // Both facts together are what the push rule reads — background, and yet the user's own task.
+    expect(registry.isBackgroundSession(ID)).toBe(true);
+  });
+
   it("still says so when it fails", async () => {
     // The other half of being quiet: nothing pulls the user's attention, so without the hook a
     // failed task is never learned. This is what reap does for a session that never reported a

--- a/test/server/session/scheduled-chat.spec.ts
+++ b/test/server/session/scheduled-chat.spec.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+// What a scheduled task's chat IS. Three properties, and they are one decision seen from three
+// sides — a scheduled task is dispatched by a clock, not by someone at a keyboard.
+//
+// node:fs is mocked rather than moving HOME: process.env is shared by every file in a vitest
+// worker (tool-group-reset.spec's pattern).
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs", () => {
+  const promises = {
+    readFile: vi.fn(async () => ""),
+    appendFile: vi.fn(async () => undefined),
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+  };
+  return { promises, default: { promises } };
+});
+
+const ID = "11111111-1111-1111-1111-111111111111";
+
+async function fresh() {
+  vi.resetModules();
+  const registry = await import("../../../server/session/registry.js");
+  const { spawnScheduledWorker } = await import("../../../server/session/scheduled-chat.js");
+  const { runCompletionHook } = await import("../../../server/session/completion-hooks.js");
+  return { registry, spawnScheduledWorker, runCompletionHook };
+}
+
+const noop = { spawn: () => {}, retain: () => {} };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("a scheduled task's chat", () => {
+  it("is a background worker, not a chat the user started", async () => {
+    // It was already half of one — scheduledSessions.register puts it on the background retention,
+    // whose reason is that nobody is waiting for it. The classification now agrees with that.
+    const { registry, spawnScheduledWorker } = await fresh();
+    spawnScheduledWorker(ID, noop);
+    expect(registry.isBackgroundSession(ID)).toBe(true);
+  });
+
+  it("takes NO grid cell, however often the task fires", async () => {
+    // THE reason this changed. A visible spawn is marked unplaced so the next grid adopts it, and
+    // an hourly task would then add a cell per firing until MAX_TERMINALS — with nobody having
+    // asked for a single terminal.
+    const { registry, spawnScheduledWorker } = await fresh();
+    for (let i = 0; i < 5; i++) spawnScheduledWorker(ID, noop);
+    expect(registry.unplacedSessionRows()).toEqual([]);
+  });
+
+  it("still says so when it fails", async () => {
+    // The other half of being quiet: nothing pulls the user's attention, so without the hook a
+    // failed task is never learned. This is what reap does for a session that never reported a
+    // finished turn.
+    const { registry, spawnScheduledWorker, runCompletionHook } = await fresh();
+    spawnScheduledWorker(ID, noop);
+    await runCompletionHook(ID, { didError: true });
+    expect(registry.isFailedWorker(ID)).toBe(true);
+  });
+
+  it("is NOT marked failed when its turn finished", async () => {
+    // The one-shot contract: a finished turn reports success first, and the teardown that follows
+    // every session cannot overturn it. Without this every successful task would be marked failed.
+    const { registry, spawnScheduledWorker, runCompletionHook } = await fresh();
+    spawnScheduledWorker(ID, noop);
+    await runCompletionHook(ID, { didError: false });
+    await runCompletionHook(ID, { didError: true }); // reap, moments later
+    expect(registry.isFailedWorker(ID)).toBe(false);
+  });
+
+  it("spawns and retains, in that order", async () => {
+    // Retention exists because nothing else would ever end this session; registering a session
+    // that failed to spawn would put a dead id on it.
+    const { spawnScheduledWorker } = await fresh();
+    const order: string[] = [];
+    spawnScheduledWorker(ID, { spawn: () => order.push("spawn"), retain: () => order.push("retain") });
+    expect(order).toEqual(["spawn", "retain"]);
+  });
+
+  it("does not retain — or register a hook — when the spawn throws", async () => {
+    // A launch that threw has no session to report on, and a hook registered for it would never
+    // fire or be cleared.
+    const { registry, spawnScheduledWorker, runCompletionHook } = await fresh();
+    const retained: string[] = [];
+    expect(() =>
+      spawnScheduledWorker(ID, {
+        spawn: () => {
+          throw new Error("claude missing");
+        },
+        retain: (id) => retained.push(id),
+      }),
+    ).toThrow();
+
+    expect(retained).toEqual([]);
+    await runCompletionHook(ID, { didError: true });
+    expect(registry.isFailedWorker(ID)).toBe(false);
+  });
+});

--- a/test/server/session/taskPushRules.spec.ts
+++ b/test/server/session/taskPushRules.spec.ts
@@ -85,3 +85,31 @@ describe("wantsPushKind", () => {
     expect(wantsPushKind(true, [], "waiting")).toBe(false);
   });
 });
+
+// A user's SCHEDULED task is a background session in every other respect — out of the chat list,
+// never bold, no grid cell — and this is the one respect where that is wrong. It is a task the
+// user configured, running while they are away, so the phone is the only way they would ever hear
+// about it: suppressing it silences exactly the case push exists for (Codex, PR #1196).
+describe("shouldSuppressPush — a user's scheduled task", () => {
+  it("lets it through, even though it is a background session", () => {
+    expect(shouldSuppressPush(true, false, true)).toBe(false);
+  });
+
+  it("still suppresses every OTHER background session", () => {
+    // A collection's refresh, a plugin's hidden spawnBackgroundChat: nobody configured those to
+    // report to them.
+    expect(shouldSuppressPush(true, false, false)).toBe(true);
+    expect(shouldSuppressPush(true, false)).toBe(true); // the parameter is optional
+  });
+
+  it("refuses a translation worker whatever else is true", () => {
+    // An internal helper with no output a person reads — there is nothing to tell them about, so
+    // this one is not an exception waiting to be made.
+    expect(shouldSuppressPush(true, true, true)).toBe(true);
+    expect(shouldSuppressPush(false, true, true)).toBe(true);
+  });
+
+  it("leaves an ordinary session alone", () => {
+    expect(shouldSuppressPush(false, false, false)).toBe(false);
+  });
+});


### PR DESCRIPTION
Owner's call, from noticing that 81 cells is a large number **as long as nothing accumulates in it**.

Hidden workers already can't: they are excluded from placement and from the unplaced marker, with a spec pinning that a hidden worker can never be marked. **Scheduled user tasks were the one path left that could fill the grid on its own** — a visible spawn is adopted as a cell the next time the grid loads, so an hourly task meant a cell per firing, indefinitely, reaching `MAX_TERMINALS` with nobody having asked for a terminal.

## The change

A task the scheduler runs is dispatched by a clock, not by someone at a keyboard — the definition of a background worker everywhere else here. It now gets that treatment: behind the **Background** filter, never bold, and **no grid cell**.

## It was already half of one

This is the argument for the change rather than a justification after the fact.

`scheduledSessions.register` has *always* put these on the background retention, whose stated reason is that *"nobody is waiting for it to finish and nothing else would ever end it"*. So the code already assumed nobody was watching — while the chat list still showed the session as one the user had started. The two halves now agree.

## A failed one still says so

Being quiet is right while it works and wrong when it dies, so the completion hook `spawnBackgroundChat` uses is registered here too. A scheduled task that reaches teardown without completing a turn is recorded and shows as `● failed` in the launcher's session list.

**Claude-only, by construction** — this path always spawns claude — and that limit matters: the Stop hook is the only success signal a PTY-hosted agent gives, so a recorder on an agent that cannot report success would mark every successful run as failed (the defect caught in #1188).

Without this, the change would have made scheduled tasks quiet **and** silent about failing, which is exactly the combination the failed-worker signal exists to prevent.

## Where the policy lives

Moved out of `index.ts` into `server/session/scheduled-chat.ts`, for the reason `background-chat.ts` was split from its route: these are rules, the caller is a uuid and a try/catch, and **policy nothing can assert is policy that drifts**.

Six tests, including two that are about the spawn rather than the classification: the order is spawn-then-retain (registering a session that failed to spawn would put a dead id on the retention), and a throwing spawn neither retains nor registers a hook (a hook for a session that never started would never fire or be cleared).

## What a user loses

A scheduled task's session no longer goes **bold/unread** when it finishes. If you were watching for that, it is under the Background filter, or in the launcher's list for the workspace. Said plainly in both the README and the changelog, since it is a visible behaviour change for anyone with the dev worklog on.

## Verified

- `yarn test` — 7062 pass (+6)
- `yarn typecheck` / `:test` / `:server` all pass, `yarn lint` 0 errors, `yarn build` succeeds
- The background-worker assertion was checked to fail with the hidden marker flipped off

**Not verified in a running app.** The check worth doing: with `worklogEnabled: true`, confirm the next firing shows under Background rather than among the chats, and that the grid gains no cell for it.

Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal
