### PR TITLE
docs: 「PR ではなく issue で」を README とガイドの front door から辿れるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ The launcher detects it and prints the exact, OS-appropriate removal command; ru
 - [Session discovery & titles](#session-discovery--titles)
 - [Project structure](#project-structure)
 - [Testing](#testing)
+- [Contributing](#contributing)
 
 ---
 
@@ -1688,3 +1689,19 @@ yarn test
 session list, the working dot, the `waiting` bold state, refetching on a pub/sub
 push, and emitting `select` on click. The pub/sub composable and `fetch` are
 mocked so the tests run without a server.
+
+---
+
+## Contributing
+
+**Please open an issue rather than a pull request.** Bug reports and feature requests are very
+welcome and are the way a change gets in; outside pull requests are closed automatically,
+whatever their size.
+
+Writing code stopped being the bottleneck — reading it did not, and a large generated diff is
+hard to audit for a reviewer who did not help shape the design. This app runs coding agents
+against your real machine and repositories, so we do not merge what we cannot fully review.
+What is scarce instead is the bug we cannot reach from here and the idea we have not had.
+
+The full policy, the issue-writing rules and the automated triage: **[CONTRIBUTING.md](CONTRIBUTING.md)**
+(bilingual).

--- a/docs/guide/en/index.md
+++ b/docs/guide/en/index.md
@@ -13,6 +13,8 @@ description: A browser-terminal cockpit for running several AI coding agents (Cl
 > **Follow us on X** — new releases and features are announced **in Japanese** on X: [Singularity Society (@SingularitySoci)](https://x.com/SingularitySoci). That is where everything ships first, so [**follow @SingularitySoci**](https://x.com/SingularitySoci) to hear about it as it lands.
 >
 > **Something looks wrong?** Type `/mulmoterminal-bug-report` in any session. The bundled skill hears the symptom out, checks your **real** config and version to see whether it is configuration or by design, searches the existing issues — and only helps you file one if none of that explains it, with the environment collected and secrets masked.
+>
+> **Want to change something?** **Open an issue, not a pull request** — outside PRs are closed automatically, whatever their size. That is not a brush-off: the bug we cannot reach from our machines and the idea we have not had are exactly what we are short of. See [CONTRIBUTING.md](https://github.com/receptron/mulmoterminal/blob/main/CONTRIBUTING.md).
 
 **Run a whole team of AI coding agents (Claude Code / Codex) in parallel, on one board** —
 MulmoTerminal is the cockpit for that — a browser terminal, so it doesn't care which editor you use.

--- a/docs/guide/ja/index.md
+++ b/docs/guide/ja/index.md
@@ -13,6 +13,8 @@ description: 複数の AI コーディングエージェント（Claude Code / C
 > **X で最新情報を発信しています** — 新バージョンや新機能のお知らせは X の [Singularity Society（@SingularitySoci）](https://x.com/SingularitySoci) で流していきます。ここが一番早いので、[**@SingularitySoci をフォローしてください！**](https://x.com/SingularitySoci)
 >
 > **「なんか変」と思ったら** — セッションで `/mulmoterminal-bug-report` と打ってください。同梱スキルが症状を聞き、**実際の**設定とバージョンを読んで仕様・設定で説明がつかないかを先に確かめ、既知の issue を検索し、それでも残ったものだけを報告にまとめます（環境情報は自動収集、鍵はマスク）。
+>
+> **直したいところがあったら** — **pull request ではなく issue を立ててください。**外部からの PR は規模によらず自動でクローズされます。冷たく聞こえるかもしれませんが、いま足りないのは手ではなく、こちらの環境では踏めないバグと、思いついていないアイデアです。詳細は [CONTRIBUTING.md](https://github.com/receptron/mulmoterminal/blob/main/CONTRIBUTING.md)。
 
 **複数の AI コーディングエージェント（Claude Code / Codex）を、1 つのボードで並行して回す**——
 MulmoTerminal はそのためのコックピットです。ブラウザのターミナルなので、エディタを選びません。


### PR DESCRIPTION
## Summary

「PR は受け付けず issue で」という方針を README とガイドの index から辿れるようにします。**方針そのものは新設していません** — `CONTRIBUTING.md` に日英で既に完備されており、`.github/workflows/pr_triage.yaml` が機械的に適用しています。

問題は**参照元**でした。`CONTRIBUTING.md` を指しているのは `docs/ChangeLog.md` と `docs/guide/{en,ja}/v2.1.0.md` だけ。後者はこのリポジトリの規約上「古いスナップショットであり、当てにしてはいけないページ」です。

つまり **front door には一言も無い**状態でした。README を読んで手を動かしたくなった人は、PR を書いて自動クローズされるまで方針を知る手段がありません。

## 変更

| ファイル | 変更 |
|---|---|
| `README.md` | 末尾に `## Contributing` 節（規約 + 理由 + `CONTRIBUTING.md` への導線）、TOC に1行 |
| `docs/guide/en/index.md` | 冒頭バナーに1行（`Something looks wrong?` の隣） |
| `docs/guide/ja/index.md` | 同上（日英セットで維持） |

計21行の追加のみ。コード変更はありません。

## Items to Confirm / Review

1. **理由を短く添えた判断。** 規約だけを書くと「外部を拒絶している」と読めますが、実態は逆で、issue こそ今いちばん必要としているものです。そこで README には「書く速度はボトルネックでなくなったが読む速度は変わっていない」「このアプリはユーザーの実機とリポジトリに対してエージェントを走らせるので、監査しきれないものはマージできない」「代わりに希少なのは、こちらの環境では踏めないバグと思いついていないアイデア」を3文で入れました。**長すぎ／不要なら削ってください。**

2. **ガイド index の文面。** ユーザー向けページなので、`CONTRIBUTING.md` の硬い言い回しではなく「冷たく聞こえるかもしれませんが」と一段やわらげています。トーンの好みが分かれるところです。

3. **`CONTRIBUTING.md` 本体は触っていません。** 既存の記述で十分と判断しましたが、front door の文面と本体の言い回しを揃えたいなら合わせます。

## User Prompt

> PR を受け付けないをREADMEや開発系のdocがあればかいておいて。

（先に私が「方針はどこにも明文化されていない」と報告したのが誤りで、実際には `CONTRIBUTING.md` に完備されていました。本 PR は不足していた導線だけを埋めるものです。）

## 検証

ドキュメントのみ。`.prettierignore` が `*.md` を除外するため `yarn format` の対象外、`yarn lint` は 0 errors（既存の max-lines 警告4件のみ、増減なし）。プロジェクトの no-emoji ルールに反する文字が入っていないことも確認済みです。

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidance to the README and user guides.
  * Clarified that suggestions and improvements should be submitted as issues rather than pull requests.
  * Added links to the full contribution policy, with guidance available in English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->