### PR TITLE
chore: @mulmoclaude/core を 1.12.0 へ（カレンダーのホスト間 soft-dedup、#1191 項目1 の前提）

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@mulmoclaude/accounting-plugin": "^1.1.0",
     "@mulmoclaude/chart-plugin": "^1.0.3",
     "@mulmoclaude/collection-plugin": "^1.2.1",
-    "@mulmoclaude/core": "^1.11.0",
+    "@mulmoclaude/core": "^1.12.0",
     "@mulmoclaude/form-plugin": "^1.0.2",
     "@mulmoclaude/google-plugin": "^1.2.0",
     "@mulmoclaude/html-plugin": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1972,10 +1972,10 @@
   resolved "https://registry.yarnpkg.com/@mulmoclaude/common/-/common-1.1.1.tgz#38c57cb4d6530679996e9ce2732d3be207ad3872"
   integrity sha512-bq47GoDVsKFraKrvRpzhkRJHQ6/omXCIRYrMNch7mq8eXU/kRNHFU7e+rfdoNaoDnLt1S/lZY5nZu7RVoPx9CA==
 
-"@mulmoclaude/core@^1.11.0":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-1.11.0.tgz#dc25c80e9570ade4443130f76156f19516957253"
-  integrity sha512-KvIvnKLpDdg73dJaSCO4qMXFY7Ii6kXnISAT6bB+0rN7s/Au51SoOtdLidGF2NqpS89NlN5YwxX4Gu4wWmOcwg==
+"@mulmoclaude/core@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@mulmoclaude/core/-/core-1.12.0.tgz#a871cb8b9860ad17cdb259a31162c8e0dcf45c80"
+  integrity sha512-y0Ik+9nJeoQ87ztv0XL7bDIcAmYIEHgPfAglQQnJ7VvxHeojW4Gq3eIzTAFNZzzEpsAtLxWCQa7MecrHKG+Ypg==
   dependencies:
     "@duckdb/node-api" "^1.5.5-r.2"
     "@mulmoclaude/common" "^1.1.1"


### PR DESCRIPTION
## Summary

`@mulmoclaude/core` を **1.11.0 → 1.12.0** へ。**#1191 の項目1（カレンダーのスケジュール同期）の前提だった上流の修正**が入ったリリースです。

上流 receptron/mulmoclaude#2678 → PR #2680（`83b6186`）。カレンダー単位の `lastSyncedAt` をワークスペース（`.sync-state.json`、sync token の隣）に持たせ、`syncDueCalendarCollections` が名前どおり「due だけ回す」ようになりました。

**このリポジトリのソース修正はゼロです。** 1.11.0 のときは `CalendarEventSummary` と `CalendarCollectionPushResult` に必須フィールドが増えて spec が4箇所壊れましたが、今回は3種の typecheck すべてが無修正で通っています。

差分は `package.json` 1行 + `yarn.lock` 8行のみ。

## Items to Confirm / Review

1. **この PR は #1191 の項目1 を「実行」しません。** `googleCalendarSyncTaskDef()` の登録は**含めていません**。前提が揃っただけで、登録するかどうかは別の判断だからです。判断材料は #1191 に整理してあります。

2. **上流に1つ残件があります → receptron/mulmoclaude#2679（OPEN）。** `.push-state.json` のクロスプロセス lost update。soft-dedup はスケジュール実行同士にしかゲートを掛けていません（ユーザーのクリックを黙って skip できないため意図的）。ただしこの経路は**登録の有無に関わらず今日すでに存在します**（こちらに手動 push ルートがあり、MulmoClaude がスケジュールを回しているため）。

3. **前提条件は確認済みです。** 上流は「同じ workspace root を指すホスト同士にしか効かない」と注記していますが、`CLAUDE_CWD` は既定で `~/mulmoclaude`（`server/config/env.ts:37`）、MulmoClaude と同一です。

## User Prompt

> https://github.com/receptron/mulmoterminal/issues/1191 mulmoclaude側、更新した

> つづけて。

（#1191 の項目1 について上流が更新されたことを受け、残る前提だった core の bump を実施しています。）

## 型の変更（公開 tarball を 1.11.0 と直接 diff）

変更は `google` サブパスに限られ、**すべて追加**です。削除も、既存型への必須フィールド追加もありません。

**新規 export**

```
claimCalendarSyncIfDue     開始時 claim。判定と stamp を1操作に閉じる
clearCalendarLastSyncedAt  マーカーを落として次の tick で即同期させる
loadCalendarLastSyncedAt
calendarSyncDueWindowMs    (新ファイル calendarSyncDue.js)
isCalendarSyncDue
```

**新規型**: `ClaimGuard`（スケジュール経路はマーカーに従い、ユーザー操作の経路は常に claim する、という分岐の型）

**無変更**: `CalendarEventSummary`、`CalendarCollectionPushResult`（1.11.0 で spec を壊した2つ）

推移的依存の移動もありません（`@duckdb/node-api` は `^1.5.5-r.2` のまま）。

## 実装が提案とどう違うか

feeds の `lastFetchedAt` は成功時にスタンプしますが、カレンダーは**開始時に claim** します。`autoPush` 以降は Google に書き込むため、終了時スタンプでは実行時間まるごと（初回フルウォークなら数分）が他ホストの開始に対して開いたままになるからです。

上流のレビューで Codex / CodeRabbit の両方から check-then-claim レースを指摘され、事前フィルタを廃して判定点を1つに統合したとのこと。`calendarSyncStore.d.ts` のコメントにその経緯が残っています。

あわせて上流が見つけたのが、**`interval` スケジュールは壁時計境界で発火する**という事実です（`task-manager.ts:95`）。プロセス起動時刻からではなく UTC 0時からの経過で判定するため、2ホストは毎時「同じ分」に発火します。位相のズレに期待できないことが、開始時 claim を選んだ直接の理由です。

## 検証

`node_modules` を削除し、コミット済み lockfile からのクリーン install で実施:

```
yarn install --frozen-lockfile   OK（lockfile に追加差分が出ないことも確認）
yarn format:check                All matched files use Prettier code style!
yarn lint                        0 errors（既存の max-lines 警告4件のみ、増減なし）
yarn typecheck                   OK
yarn typecheck:server            OK
yarn typecheck:test              OK  ← 1.11.0 で壊れたのはここ。今回は無修正で通過
yarn build                       OK
yarn knip                        差分なし
yarn test                        7070 passed | 45 skipped (7115)
```

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s core package to version 1.12.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->