### PR TITLE
fix: adopt a server-spawned session while the grid is already on screen

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -612,6 +612,30 @@ watch(
   },
   { immediate: true },
 );
+// ...and the same sweep on the PUSH, for a session spawned while the grid is already on screen:
+// the phone's remote chat (index.ts remoteHostSpawnChat), a scheduled task, an agent spawning one
+// from another session. The route watcher above only fires when the route CHANGES, so a user
+// sitting on the grid — which is where they normally are — saw a live agent nowhere at all until
+// they happened to open an overlay and come back, or reloaded.
+//
+// Only "created". The same channel carries every working/waiting/closed push, so sweeping on all
+// of them would refetch many times a turn to learn nothing; the spawn is the one moment a session
+// can become unplaced. A create that arrives while the user is elsewhere in the app needs nothing
+// extra — the watcher adopts it on the way back.
+const isSessionCreated = (data: unknown): boolean => typeof data === "object" && data !== null && (data as { event?: unknown }).event === "created";
+const { subscribe: subscribeSessions, onReconnect } = usePubSub();
+const unsubscribeSessions = subscribeSessions("sessions", (data) => {
+  if (isSessionCreated(data) && onTerminalsRoute()) void adoptUnplacedSessions();
+});
+// pub/sub replays room membership on reconnect but not the events missed while disconnected, so a
+// spawn during a dropped socket would never be swept — the same re-sync useSessions does.
+const offReconnect = onReconnect(() => {
+  if (onTerminalsRoute()) void adoptUnplacedSessions();
+});
+onBeforeUnmount(() => {
+  unsubscribeSessions();
+  offReconnect();
+});
 
 // Registered for the life of the component, like the new-terminal opener above and for the same
 // reason: this is the only grid there is.

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -569,12 +569,22 @@ const placeChat = ({ id, agent, canvas }: SpawnedChatRequest): boolean => {
 // Asked on ACTIVATE rather than mount: the grid is kept alive across route changes, so mount fires
 // once per page load and would miss everything spawned while the user was elsewhere in the app.
 let adoptingUnplaced = false;
+// A trigger that arrived mid-sweep and has to be answered once this one lands. Deferred, not
+// DROPPED: the in-flight response was generated when the fetch was sent, so a session marked after
+// that is not in it, and simply refusing the overlapping trigger would leave that session with no
+// cell until a later route change or reload — the exact bug this whole path exists to fix (Codex,
+// this PR). One flag rather than a count: every sweep asks for the whole list, so N deferred
+// triggers and one are the same question.
+let sweepAgain = false;
 async function adoptUnplacedSessions(): Promise<void> {
   // One sweep at a time. The route watcher can fire again before the fetch resolves — leave the
   // grid for an overlay and come straight back — and both runs would read `cells` before either
   // inserted, so both would adopt the same session and give it two cells fighting over one socket.
   // The per-row guard below cannot catch that: it reads state neither call has written yet.
-  if (adoptingUnplaced) return;
+  if (adoptingUnplaced) {
+    sweepAgain = true;
+    return;
+  }
   adoptingUnplaced = true;
   try {
     const res = await fetch("/api/sessions/unplaced");
@@ -598,6 +608,13 @@ async function adoptUnplacedSessions(): Promise<void> {
     // Best effort: a grid that cannot ask still works, and the sessions stay marked for next time.
   } finally {
     adoptingUnplaced = false;
+    // Whatever came in while this was in flight, asked now that the state it would have raced is
+    // written. Not route-guarded again: the trigger passed that check when it ARRIVED, and the
+    // grid stays mounted under an overlay anyway — the cell is simply there when the user returns.
+    if (sweepAgain) {
+      sweepAgain = false;
+      void adoptUnplacedSessions();
+    }
   }
 }
 // Driven by the ACTUAL route, not by activation. Since #1193 the grid stays mounted underneath a

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -9,9 +9,30 @@ import { defineComponent, h, KeepAlive, type Component } from "vue";
 // silently exercises a grid that registered nothing — which is not the component the app runs.
 const mountActivated = (component: Component, options: Parameters<typeof mount>[1]) => mount({ render: () => h(KeepAlive, null, [h(component)]) }, options);
 
-// The grid subscribes to the pub/sub socket on mount — stub it so no real socket opens.
+// The grid subscribes to the pub/sub socket on mount — stub it so no real socket opens. The
+// handlers are kept so a test can push on a channel the way the server would.
+const pubsub = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(data: unknown) => void>>();
+  return {
+    handlers,
+    push(channel: string, data: unknown) {
+      handlers.get(channel)?.forEach((cb) => cb(data));
+    },
+    reset() {
+      handlers.clear();
+    },
+  };
+});
 vi.mock("../../../src/composables/usePubSub", () => ({
-  usePubSub: () => ({ subscribe: () => () => {}, onReconnect: () => () => {} }),
+  usePubSub: () => ({
+    subscribe: (channel: string, cb: (data: unknown) => void) => {
+      const set = pubsub.handlers.get(channel) ?? new Set();
+      set.add(cb);
+      pubsub.handlers.set(channel, set);
+      return () => set.delete(cb);
+    },
+    onReconnect: () => () => {},
+  }),
 }));
 
 // Session ids for the roster-ordering test (must be valid UUIDs or parseGridState drops them).
@@ -39,6 +60,7 @@ beforeEach(async () => {
 const posts: Array<{ url: string; body: unknown }> = [];
 beforeEach(() => {
   posts.length = 0;
+  pubsub.reset();
   localStorage.clear();
   globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
     const u = String(url);
@@ -551,6 +573,61 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
     // was actually spawned in, rather than this grid's default.
     expect(adopted?.agent).toBe("codex");
     expect(adopted?.cwd).toBe("/proj");
+    w.unmount();
+  });
+
+  // The live half of the same thing, and the one the user actually hits: the phone starts a chat
+  // while the host is SITTING on the grid. The route never changes, so the sweep above never runs
+  // and the live agent has no cell until something else forces a route change or a reload. The
+  // spawn publishes `event: "created"` on the sessions channel — sweep on that.
+  it("adopts a session spawned while the user is already on the grid", async () => {
+    const LIVE = "66666666-6666-6666-6666-666666666666";
+    let rows: Array<{ id: string; agent: string; cwd: string }> = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
+      if (String(url).includes("/api/sessions/unplaced")) return { ok: true, json: async () => ({ sessions: rows }) } as Response;
+      return realFetch(url, init);
+    }) as typeof fetch;
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises(); // the mount sweep: nothing waiting yet
+    expect((w.findComponent(CellsStub).props("cells") as Array<{ session: string | null }>).some((c) => c.session === LIVE)).toBe(false);
+
+    // The phone starts a chat: the server marks it unplaced and publishes the spawn.
+    rows = [{ id: LIVE, agent: "claude", cwd: "/proj" }];
+    pubsub.push("sessions", { id: LIVE, working: false, event: "created" });
+    await flushPromises();
+
+    const cells = w.findComponent(CellsStub).props("cells") as Array<{ session: string | null; cwd?: string | null }>;
+    expect(cells.find((c) => c.session === LIVE)?.cwd).toBe("/proj");
+    w.unmount();
+  });
+
+  // The same channel carries every working/waiting/closed push — several a turn, per session. A
+  // sweep on each would refetch constantly to learn nothing.
+  it("does not sweep on activity pushes, only on a spawn", async () => {
+    let asked = 0;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
+      if (String(url).includes("/api/sessions/unplaced")) {
+        asked++;
+        return { ok: true, json: async () => ({ sessions: [] }) } as Response;
+      }
+      return realFetch(url, init);
+    }) as typeof fetch;
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+    expect(asked).toBe(1); // the mount sweep
+
+    pubsub.push("sessions", { id: SPAWNED, working: true, event: null });
+    pubsub.push("sessions", { id: SPAWNED, working: false, waiting: true, event: "Notification" });
+    pubsub.push("sessions", { id: SPAWNED, working: false, event: "closed" });
+    await flushPromises();
+
+    expect(asked).toBe(1);
     w.unmount();
   });
 

--- a/test/src/components/GridView.spec.ts
+++ b/test/src/components/GridView.spec.ts
@@ -13,13 +13,19 @@ const mountActivated = (component: Component, options: Parameters<typeof mount>[
 // handlers are kept so a test can push on a channel the way the server would.
 const pubsub = vi.hoisted(() => {
   const handlers = new Map<string, Set<(data: unknown) => void>>();
+  const reconnects = new Set<() => void>();
   return {
     handlers,
+    reconnects,
     push(channel: string, data: unknown) {
       handlers.get(channel)?.forEach((cb) => cb(data));
     },
+    reconnect() {
+      reconnects.forEach((cb) => cb());
+    },
     reset() {
       handlers.clear();
+      reconnects.clear();
     },
   };
 });
@@ -31,7 +37,10 @@ vi.mock("../../../src/composables/usePubSub", () => ({
       pubsub.handlers.set(channel, set);
       return () => set.delete(cb);
     },
-    onReconnect: () => () => {},
+    onReconnect: (cb: () => void) => {
+      pubsub.reconnects.add(cb);
+      return () => pubsub.reconnects.delete(cb);
+    },
   }),
 }));
 
@@ -601,6 +610,66 @@ describe("GridView skill launch — capacity and placement (#1111)", () => {
 
     const cells = w.findComponent(CellsStub).props("cells") as Array<{ session: string | null; cwd?: string | null }>;
     expect(cells.find((c) => c.session === LIVE)?.cwd).toBe("/proj");
+    w.unmount();
+  });
+
+  // Codex, on this PR. A create landing while a sweep is already in flight used to be dropped by
+  // the one-at-a-time guard — and the in-flight answer was generated BEFORE the session was marked,
+  // so it does not contain it either. The session then waits for a route change or a reload, which
+  // is the bug this whole path exists to remove. The deferred trigger must be re-asked.
+  it("re-sweeps for a create that arrived while a sweep was in flight", async () => {
+    const LATE = "77777777-7777-7777-7777-777777777777";
+    // Each sweep takes the next answer: the first was generated before the phone's spawn.
+    const answers: Array<Array<{ id: string; agent: string; cwd: string }>> = [[], [{ id: LATE, agent: "claude", cwd: "/proj" }]];
+    let release: (() => void) | null = null;
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
+      if (String(url).includes("/api/sessions/unplaced")) {
+        const sessions = answers.shift() ?? [];
+        // Hold the FIRST sweep open so the push below lands mid-flight.
+        if (release === null && sessions.length === 0) await new Promise<void>((r) => (release = r));
+        return { ok: true, json: async () => ({ sessions }) } as Response;
+      }
+      return realFetch(url, init);
+    }) as typeof fetch;
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises(); // the mount sweep is now parked inside its fetch
+
+    pubsub.push("sessions", { id: LATE, working: false, event: "created" }); // refused, but remembered
+    await flushPromises();
+    expect((w.findComponent(CellsStub).props("cells") as Array<{ session: string | null }>).some((c) => c.session === LATE)).toBe(false);
+
+    (release as unknown as () => void)(); // the stale answer lands — empty, as the server saw it
+    await flushPromises();
+
+    const cells = w.findComponent(CellsStub).props("cells") as Array<{ session: string | null }>;
+    expect(cells.some((c) => c.session === LATE)).toBe(true);
+    w.unmount();
+  });
+
+  // CodeRabbit, on this PR. pub/sub replays room membership on reconnect but not the events missed
+  // while the socket was down, so a spawn during the outage raises no "created" anyone still hears.
+  it("sweeps on pub/sub reconnect", async () => {
+    const MISSED = "88888888-8888-8888-8888-888888888888";
+    let rows: Array<{ id: string; agent: string; cwd: string }> = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async (url: FetchUrl, init?: RequestInit) => {
+      if (String(url).includes("/api/sessions/unplaced")) return { ok: true, json: async () => ({ sessions: rows }) } as Response;
+      return realFetch(url, init);
+    }) as typeof fetch;
+    const w = mountActivated((await import("../../../src/components/GridView.vue")).default, {
+      global: { stubs: { TerminalGrid: CellsStub, AppToolbar: ToolbarStub, SettingsModal: SkillSettingsStub } },
+    });
+    await flushPromises();
+
+    rows = [{ id: MISSED, agent: "claude", cwd: "/proj" }]; // spawned while the socket was down
+    pubsub.reconnect();
+    await flushPromises();
+
+    const cells = w.findComponent(CellsStub).props("cells") as Array<{ session: string | null }>;
+    expect(cells.some((c) => c.session === MISSED)).toBe(true);
     w.unmount();
   });
 


### PR DESCRIPTION
## The bug

Start a chat from the phone and it does not appear on the host until you do something that forces a route change (open PRs / the collection browser and come back) or reload. The session is live the whole time — it just has no cell.

## Why

`remoteHostSpawnChat` (`server/index.ts:566`) spawns a visible PTY and calls `markUnplacedSession(sessionId)` — "marked so the next grid to load adopts it".

`GridView.adoptUnplacedSessions()` fetches `/api/sessions/unplaced` and inserts a cell per row, but it had exactly one caller: a watcher on `onTerminalsRoute`. That fires on first mount and on every *return* to `/terminals` from an overlay. While the user sits on the grid the route never changes, so nothing ever asks.

The spawn does publish `event: "created"` on the `sessions` channel (`spawn-claude.ts:216` -> `publishSessionCreated`). Three consumers listen — the session list, `useGridActivity`, `TerminalCell` — and none of them place cells. `GridView` subscribed to `dir-config` only.

## The fix

Sweep on the `created` push as well, and on pub/sub reconnect.

- **Only `created`**: the same channel carries several working/waiting/closed pushes per turn per session; the spawn is the one moment a session can become unplaced. A spec pins that activity pushes trigger no refetch.
- **Both paths guarded on the terminals route**: a spawn while the user is in an overlay needs nothing extra, the existing watcher adopts it on the way back.
- **Reconnect**: pub/sub replays room membership but not the events missed while disconnected — the same re-sync `useSessions.ts:144` does.

Re-entrancy and double cells were already handled by the `adoptingUnplaced` flag and the per-row `cells.some(...)` check, so a push landing mid-sweep is refused rather than doubling a cell.

## Tests

The spec's pub/sub mock now retains handlers so a test can push the way the server does. Two new specs: a session spawned while the user is already on the grid gets a cell (carrying its real `cwd`), and activity/closed pushes cause no sweep. Verified the first fails with the component change reverted.

`yarn test` (7033 passed / 45 skipped), `yarn lint` (0 errors), `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test` all clean. One new lint *warning*: `GridView.spec.ts` crossed the 600-line advisory at 603; four other spec files already exceed it and I did not split it.

Verified live by the maintainer against a running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New sessions created while viewing the terminals grid are now automatically adopted and displayed.
  * Sessions created during temporary connection interruptions are recovered after reconnecting.
  * Unrelated activity events no longer trigger unnecessary session checks.
* **Tests**
  * Added coverage for session adoption after creation events and reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->