### PR TITLE
fix: match the draft-ready marker against the stream a terminal actually sends

### DIFF
--- a/server/agents/claude.ts
+++ b/server/agents/claude.ts
@@ -1,11 +1,21 @@
 import type { AgentAdapter } from "./types.js";
 
-// "shift+tab to cycle" is the hint Claude paints once its input box is ready for a paste.
+// The status line Claude paints under its input box once that box is ready for a paste.
+// Two spellings because it is a UI string that has already drifted once: "shift+tab to
+// cycle" is what older versions printed, "? for shortcuts" is what 2.1.220 prints in every
+// mode. Both are kept — the marker has to work against whatever claude the user has, and a
+// version that prints neither still lands on draft-injection's quiet fallback.
+//
+// NO SPACES, and lowercase: this is matched against `squashForMarker`'s output (see
+// server/session/pty-scan.ts), because the raw pty stream carries cursor-positioning
+// escapes BETWEEN the words — "?ESC[24GforESC[28Gshortcuts" — so a spaced regex matches
+// nothing that a terminal actually sends.
+//
 // `satisfies` (not a `: AgentAdapter` annotation) keeps draftReadyMarker's concrete type so
 // callers that rely on it (the draft-injection scanner) don't see it as possibly-undefined.
 export const claudeAdapter = {
   kind: "claude",
   bin: () => process.env.CLAUDE_BIN || "claude",
   binEnvVar: "CLAUDE_BIN",
-  draftReadyMarker: /shift\+tab to cycle/,
+  draftReadyMarker: /shift\+tabtocycle|\?forshortcuts/,
 } satisfies AgentAdapter;

--- a/server/session/draft-injection.ts
+++ b/server/session/draft-injection.ts
@@ -6,6 +6,7 @@ import type { IPty } from "node-pty";
 import { claudeAdapter } from "../agents/claude.js";
 import type { PtyEntry } from "./types.js";
 import { sanitizeDraftText } from "./pty-text.js";
+import { squashForMarker } from "./pty-scan.js";
 import { planDraftInjection } from "./draft-plan.js";
 import { submittableLineForAgent } from "../../common/terminalSubmit.js";
 
@@ -15,8 +16,17 @@ type DraftTarget = Pick<PtyEntry, "agent"> & { term: Pick<IPty, "write"> };
 
 // Claude must have its input box + bracketed-paste mode up before it will capture a
 // typed `draft`; too early and the bytes are echoed into the scrollback instead. We
-// wait for its status line to paint (the "shift+tab to cycle" mode hint), settle
-// briefly, then type. A fallback fires if that marker never shows (UI string drift).
+// wait for its status line to paint (the mode hint — "? for shortcuts" on current
+// versions), settle briefly, then type. A fallback fires if that marker never shows
+// (UI string drift).
+//
+// Every marker below is matched against the SQUASHED stream, never the raw bytes: a TUI
+// redraws by positioning the cursor between words, so the readiness hint reaches us as
+// "?ESC[24GforESC[28Gshortcuts" and the trust dialog as "Yes,ESC[12GIESC[14Gtrust…".
+// Both were written as spaced regexes over raw data and therefore matched NOTHING — the
+// readiness one silently cost every claude spawn the full DRAFT_QUIET_MS below (~10s to a
+// visible prompt in a chat started from the collection UI), and the trust guard was
+// holding only because a dialog screen is also a quiet one.
 const DRAFT_READY_MARKER = claudeAdapter.draftReadyMarker;
 const DRAFT_SETTLE_MS = 250;
 // The drift fallback waits for the stream to go QUIET for this long, not for this long since the
@@ -37,7 +47,7 @@ const DRAFT_QUIET_MS = 6000;
 // new screen together, and then the screen stops changing — so a scanner that waited forever for
 // proof would never type at all. Observed doing exactly that.
 const TRUST_QUIET_MS = 60_000;
-const TRUST_PROMPT_MARKER = /Yes, I trust this folder|project you created or one you trust/i;
+const TRUST_PROMPT_MARKER = /yes,itrustthisfolder|projectyoucreatedoroneyoutrust/;
 // Claude's TUI commits a bracketed paste to its input box asynchronously; a CR glued
 // onto the same write can arrive before the paste lands and be dropped — leaving an
 // auto-run prompt typed-but-unsent. Send the submitting Enter as a SEPARATE chunk a
@@ -99,9 +109,9 @@ export function attachDraftInjection(
       // pty already gone — nothing to draft into
     }
   };
-  // Fallback: type even if the readiness marker never appears (UI string drift, or a mode whose
-  // status line does not carry it — v2.1.220's manual mode reads "? for shortcuts"). Re-armed on
-  // every burst below, so it measures silence rather than elapsed time.
+  // Fallback: type even if the readiness marker never appears — a further UI string drift, or a
+  // status line too narrow for the hint (claude drops it for the context meter in a small pane).
+  // Re-armed on every burst below, so it measures silence rather than elapsed time.
   let quiet = setTimeout(typeDraft, DRAFT_QUIET_MS);
   const waitFor = (ms: number) => {
     clearTimeout(quiet);
@@ -111,10 +121,14 @@ export function attachDraftInjection(
     if (done) return;
     // Type the draft once claude's input box has painted (its mode-hint status line),
     // then settle briefly so the paste lands in the input rather than the scrollback.
+    // Squashed, not raw: the words of both markers arrive with cursor moves between them. The tail
+    // kept is the RAW one, so a sequence split across two reads still squashes correctly once its
+    // second half arrives.
     scan = (scan + data).slice(-4096);
+    const screen = squashForMarker(scan);
     // Checked before the dialog: answering it repaints the dismissed dialog and the new prompt in
     // ONE burst, and the marker is the stronger fact — it means an input box exists now.
-    if (DRAFT_READY_MARKER.test(scan)) {
+    if (DRAFT_READY_MARKER.test(screen)) {
       scan = "";
       clearTimeout(quiet);
       setTimeout(typeDraft, DRAFT_SETTLE_MS);
@@ -122,7 +136,7 @@ export function attachDraftInjection(
     }
     // The one quiet screen that must not be typed into: hold much longer than usual. `scan` is
     // cleared so a repaint does not keep re-arming the long window forever.
-    if (TRUST_PROMPT_MARKER.test(scan)) {
+    if (TRUST_PROMPT_MARKER.test(screen)) {
       scan = "";
       waitFor(TRUST_QUIET_MS);
       return;

--- a/server/session/draft-injection.ts
+++ b/server/session/draft-injection.ts
@@ -47,7 +47,35 @@ const DRAFT_QUIET_MS = 6000;
 // new screen together, and then the screen stops changing — so a scanner that waited forever for
 // proof would never type at all. Observed doing exactly that.
 const TRUST_QUIET_MS = 60_000;
-const TRUST_PROMPT_MARKER = /yes,itrustthisfolder|projectyoucreatedoroneyoutrust/;
+const TRUST_PROMPT_MARKER = /yes,itrustthisfolder|projectyoucreatedoroneyoutrust/g;
+
+// Which is why the dialog's text ALONE is not the question — "was it painted" and "is it still on
+// screen" are different facts, and the long window is only right for the second. An answering
+// repaint carries the dismissed dialog and the new screen in one burst, so text-alone re-arms the
+// full minute at the exact moment the input box appears. With a readiness hint in that same burst
+// the marker above wins and none of this is reached; in a pane too narrow for the hint there is
+// nothing else to go on, and a fresh-worktree draft waits a minute for a box already waiting for it.
+//
+// What separates the two is what FOLLOWS the dialog. Up, it is the last thing painted: a couple of
+// short lines (the second option, the confirm hint) and then the stream stops, since nothing paints
+// while it waits for an answer. Answered, a whole screen is drawn after it. So the long window is
+// armed only when little enough follows the LAST match for the dialog to still be what is showing.
+//
+// The threshold is deliberately far below a screen and comfortably above the dialog's own tail
+// (~40 characters squashed): the failure it must not have is reading an ANSWERED dialog as an open
+// one, which is the minute-long wait this exists to remove. Erring the other way costs the guard on
+// a pane so narrow that the repaint squashes to under this — the behaviour before this rule, so
+// nothing regresses.
+const TRUST_TAIL_MAX = 120;
+
+// Is the trust dialog what the screen is CURRENTLY showing? Scans for the last match because a
+// repaint can hold several: the answered dialog earlier in the burst, and any older one still in
+// the tail we keep.
+const trustDialogIsUp = (screen: string): boolean => {
+  let end = -1;
+  for (const match of screen.matchAll(TRUST_PROMPT_MARKER)) end = match.index + match[0].length;
+  return end !== -1 && screen.length - end <= TRUST_TAIL_MAX;
+};
 // Claude's TUI commits a bracketed paste to its input box asynchronously; a CR glued
 // onto the same write can arrive before the paste lands and be dropped — leaving an
 // auto-run prompt typed-but-unsent. Send the submitting Enter as a SEPARATE chunk a
@@ -135,8 +163,10 @@ export function attachDraftInjection(
       return;
     }
     // The one quiet screen that must not be typed into: hold much longer than usual. `scan` is
-    // cleared so a repaint does not keep re-arming the long window forever.
-    if (TRUST_PROMPT_MARKER.test(screen)) {
+    // cleared so a repaint does not keep re-arming the long window forever — and the repaint that
+    // ANSWERS it then arrives against an empty buffer, where the new screen it draws is all the
+    // tail there is and trustDialogIsUp reads it as gone.
+    if (trustDialogIsUp(screen)) {
       scan = "";
       waitFor(TRUST_QUIET_MS);
       return;

--- a/server/session/pty-scan.ts
+++ b/server/session/pty-scan.ts
@@ -1,0 +1,43 @@
+// Reading markers OUT of a pty stream — the opposite direction from pty-text.ts, which
+// sanitizes text we type INTO one. Used by the draft-injection scanner to recognize
+// claude's "input box is ready" hint and its trust dialog.
+//
+// The stream is not the screen. A TUI redraws by positioning the cursor between words, so
+// the bytes carrying "? for shortcuts" arrive as
+//
+//   ?ESC[24GforESC[28Gshortcuts
+//
+// and a plain-text regex over raw pty data never matches. That is how the draft readiness
+// marker became dead code: every claude spawn fell through to the 6-second quiet fallback,
+// which is why a chat started from the collection UI sat ~10s before its prompt appeared.
+// The trust-dialog guard was matched the same way and had the same hole.
+//
+// So markers are matched against a SQUASHED form: escape sequences, control bytes and ALL
+// whitespace removed, lowercased. Dropping whitespace rather than replacing each escape
+// with a space is what makes it hold in both directions — an escape between two words and
+// one that lands inside a word squash identically — and marker strings are distinctive
+// enough that losing the spaces cannot make one match something else.
+//
+// Markers written for this function therefore carry no spaces: /\?forshortcuts/, not
+// /\? for shortcuts/.
+
+const ESC = "\u001b";
+const BEL = "\u0007";
+
+// The three escape shapes screen-rows.ts splits on, with the full CSI parameter range
+// rather than just digits (a stream carries ESC[?2004h and ESC[>4;2m, a capture does not):
+//
+//   ESC ] <text> (BEL | ESC \)  |  ESC [ <params> <intermediates> <final>  |  ESC <byte>
+//
+// Composed from the control bytes rather than written as one literal, for the same reason
+// as there: a regex literal carrying them is what the control-character lint rules forbid.
+const ESCAPES = new RegExp(`${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)?|${ESC}\\[[0-?]*[ -/]*[@-~]|${ESC}[@-_]`, "gu");
+
+// Whatever control bytes survive escape removal (a stray BEL, a sequence split across two
+// reads). Not text, and never part of a marker.
+// eslint-disable-next-line no-control-regex -- intentional: match terminal control bytes (C0/C1) to strip them
+const CONTROL_BYTES = /[\u0000-\u001F\u007F-\u009F]/gu;
+
+/** A pty read reduced to the form markers are matched against: no escapes, no control
+ *  bytes, no whitespace, lowercase. */
+export const squashForMarker = (data: string): string => data.replace(ESCAPES, "").replace(CONTROL_BYTES, "").replace(/\s+/gu, "").toLowerCase();

--- a/test/server/agents/registry.spec.ts
+++ b/test/server/agents/registry.spec.ts
@@ -3,6 +3,7 @@ import { getAgentAdapter } from "../../../server/agents/registry.js";
 import { claudeAdapter } from "../../../server/agents/claude.js";
 import { codexAdapter } from "../../../server/agents/codex.js";
 import { antigravityAdapter } from "../../../server/agents/antigravity.js";
+import { squashForMarker } from "../../../server/session/pty-scan.js";
 
 function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) Reflect.deleteProperty(process.env, key);
@@ -49,8 +50,16 @@ describe("agent registry", () => {
     expect(antigravityAdapter.bin()).toBe("/custom/agy");
   });
 
+  // The marker is matched against squashForMarker's output, so it is spelled without spaces —
+  // asserted here against real status lines put through that same function, because a marker that
+  // reads correctly and matches nothing a terminal sends is exactly the bug this shape fixes.
   it("exposes Claude's draft-ready marker but not codex or antigravity (not wired yet)", () => {
-    expect(claudeAdapter.draftReadyMarker.test("... press shift+tab to cycle modes")).toBe(true);
+    expect(claudeAdapter.draftReadyMarker.test(squashForMarker("⏵⏵ auto mode on (shift+tab to cycle)"))).toBe(true);
+    // What 2.1.220 prints, and how it prints it: the words arrive separated by cursor moves.
+    expect(claudeAdapter.draftReadyMarker.test(squashForMarker("⏸ manual mode on · ? for shortcuts"))).toBe(true);
+    expect(claudeAdapter.draftReadyMarker.test(squashForMarker("\u001b[3G⏸\u001b[5Gmanual\u001b[20G·\u001b[22G?\u001b[24Gfor\u001b[28Gshortcuts"))).toBe(true);
+    // Not every "shift+tab" hint means an input box: this one is a review prompt.
+    expect(claudeAdapter.draftReadyMarker.test(squashForMarker("shift+tab to approve with this feedback"))).toBe(false);
     expect(getAgentAdapter("codex").draftReadyMarker).toBeUndefined();
     expect(getAgentAdapter("antigravity").draftReadyMarker).toBeUndefined();
   });

--- a/test/server/session/draft-injection.spec.ts
+++ b/test/server/session/draft-injection.spec.ts
@@ -205,6 +205,33 @@ describe("attachDraftInjection", () => {
       expect(t.writes).toEqual([`${PASTE_START}edit me${PASTE_END}`]);
     });
 
+    // Codex, on #1206. The long window is for a dialog that is UP, and the burst that answers one
+    // carries the dismissed dialog together with the screen replacing it — so matching the dialog's
+    // text alone re-arms the full minute at the moment the input box appears. Only reachable with
+    // no readiness hint in that burst, which is a pane too narrow for claude to print one; the
+    // draft then waits a minute for a box that is already waiting for it.
+    it("falls back to the normal window when the answering repaint draws a screen after the dialog", () => {
+      const t = target();
+      const scan = attachDraftInjection(t.entry, undefined, "edit me", () => ESC_CR);
+      scan(TRUST);
+      vi.advanceTimersByTime(FALLBACK_MS * 5);
+      expect(t.writes).toEqual([]);
+      // The dialog repeated, then a whole screen after it — and NO status-line hint anywhere in it.
+      scan(`${TRUST}\n${"─".repeat(60)}\n❯ Try "fix lint errors"\n${"─".repeat(60)}\n Claude Code v2.1.220 · Opus 5 · ~/git/ai/mulmoterminal`);
+      vi.advanceTimersByTime(FALLBACK_MS);
+      expect(t.writes).toEqual([`${PASTE_START}edit me${PASTE_END}`]);
+    });
+
+    // The other half of that rule: a dialog still on screen must keep the long window even though
+    // its own last lines follow the matched text.
+    it("still holds when only the dialog's own closing lines follow the matched text", () => {
+      const t = target();
+      const scan = attachDraftInjection(t.entry, undefined, "edit me", () => ESC_CR);
+      scan(`${TRUST}\n 2. No, exit\n\n Enter to confirm · Esc to cancel`);
+      vi.advanceTimersByTime(FALLBACK_MS * 5);
+      expect(t.writes).toEqual([]);
+    });
+
     it("types once the dialog is answered and the input box paints", () => {
       const t = target();
       const scan = attachDraftInjection(t.entry, undefined, "edit me", () => ESC_CR);

--- a/test/server/session/draft-injection.spec.ts
+++ b/test/server/session/draft-injection.spec.ts
@@ -205,15 +205,32 @@ describe("attachDraftInjection", () => {
       expect(t.writes).toEqual([`${PASTE_START}edit me${PASTE_END}`]);
     });
 
-    it("types once the dialog is answered and the screen settles, with no marker at all", () => {
+    it("types once the dialog is answered and the input box paints", () => {
       const t = target();
       const scan = attachDraftInjection(t.entry, undefined, "edit me", () => ESC_CR);
       scan(TRUST);
       vi.advanceTimersByTime(FALLBACK_MS * 5);
-      // Answering repaints. v2.1.220's manual mode never prints the marker, so quiet is all
-      // there is to go on.
+      // Answering repaints, and the repaint carries the status line — so the draft goes in on the
+      // marker rather than on a further quiet window.
       scan("manual mode on · ? for shortcuts");
-      vi.advanceTimersByTime(FALLBACK_MS);
+      vi.advanceTimersByTime(SETTLE_MS);
+      expect(t.writes).toEqual([`${PASTE_START}edit me${PASTE_END}`]);
+    });
+
+    // The bytes above, as a terminal actually sends them. Both markers reach the scanner with
+    // cursor moves BETWEEN their words, which is what made the spaced regexes match nothing:
+    // readiness was never seen (every spawn paid the full quiet window) and the dialog was held
+    // through only because its screen happens to be quiet too.
+    it("recognizes both markers through the cursor moves a redraw puts between the words", () => {
+      const t = target();
+      const scan = attachDraftInjection(t.entry, undefined, "edit me", () => ESC_CR);
+      scan(
+        `\u001b[2GQuick\u001b[8Gsafety\u001b[15Gcheck:\u001b[22GIs\u001b[25Gthis\u001b[30Ga\u001b[32Gproject\u001b[40Gyou\u001b[44Gcreated\u001b[52Gor\u001b[55Gone\u001b[59Gyou\u001b[63Gtrust?`,
+      );
+      vi.advanceTimersByTime(FALLBACK_MS * 5);
+      expect(t.writes).toEqual([]);
+      scan(`\u001b[3G⏸\u001b[5Gmanual\u001b[12Gmode\u001b[17Gon\u001b[20G·\u001b[22G?\u001b[24Gfor\u001b[28Gshortcuts`);
+      vi.advanceTimersByTime(SETTLE_MS);
       expect(t.writes).toEqual([`${PASTE_START}edit me${PASTE_END}`]);
     });
 

--- a/test/server/session/pty-scan.spec.ts
+++ b/test/server/session/pty-scan.spec.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+// squashForMarker, against bytes captured from a real `claude` pty (v2.1.220). The captures
+// matter more than the unit cases: the whole reason the readiness marker sat dead was that
+// hand-written test strings looked nothing like what a terminal sends.
+import { describe, it, expect } from "vitest";
+
+import { squashForMarker } from "../../../server/session/pty-scan.js";
+
+const ESC = "\u001b";
+const BEL = "\u0007";
+
+describe("squashForMarker", () => {
+  it("drops the cursor moves a redraw puts between words", () => {
+    expect(squashForMarker(`?${ESC}[24Gfor${ESC}[28Gshortcuts`)).toBe("?forshortcuts");
+  });
+
+  // The same words with no escapes at all squash identically — which is what lets one marker
+  // serve both a real stream and a plain-text fixture.
+  it("squashes plain text to the same form", () => {
+    expect(squashForMarker("? for shortcuts")).toBe("?forshortcuts");
+    expect(squashForMarker("⏸ manual mode on · ? for shortcuts")).toBe("⏸manualmodeon·?forshortcuts");
+  });
+
+  it("drops SGR colour, OSC 8 hyperlinks and the DEC private modes a TUI turns on", () => {
+    expect(squashForMarker(`${ESC}[38;2;153;153;153m⏸${ESC}[39m manual`)).toBe("⏸manual");
+    expect(squashForMarker(`${ESC}]8;id=zaxmda;https://code.claude.com/docs${BEL}Security guide${ESC}]8;;${BEL}`)).toBe("securityguide");
+    expect(squashForMarker(`${ESC}[?2004h${ESC}[>4;2m${ESC}[<u ready`)).toBe("ready");
+  });
+
+  // Claude draws its empty input box as "❯" + U+00A0, which a plain trim would keep.
+  it("drops non-breaking space along with the rest of the whitespace", () => {
+    expect(squashForMarker("❯\u00a0 \r\n\tTry")).toBe("❯try");
+  });
+
+  it("lowercases, so a marker can be written in one case", () => {
+    expect(squashForMarker("Yes, I trust this folder")).toBe("yes,itrustthisfolder");
+  });
+
+  // Verbatim from a `claude` spawn in a directory it had not seen. Every word is separated by a
+  // column move, which is exactly what the old spaced regex could not match.
+  it("recognizes the trust dialog as it actually arrives", () => {
+    const captured = `${ESC}[2GIs${ESC}[25Gthis${ESC}[30Ga${ESC}[32Gproject${ESC}[40Gyou${ESC}[44Gcreated${ESC}[52Gor${ESC}[55Gone${ESC}[59Gyou${ESC}[63Gtrust?`;
+    expect(squashForMarker(captured)).toContain("projectyoucreatedoroneyoutrust");
+  });
+});


### PR DESCRIPTION
## The bug

Start a chat from the Collection UI and the terminal appears at once, then sits for **about ten seconds** before the seeded prompt shows up in claude's input box. Reported by the maintainer.

## Why

The prompt is TYPED into claude's TUI rather than passed as a CLI argument (a long prompt overflows tmux's `new-session` command-length limit). `attachDraftInjection` (`server/session/draft-injection.ts`) waits for a readiness marker before typing, with a quiet-window fallback if it never paints.

The marker never painted. Two separate reasons:

1. **The string is stale.** It was `/shift\+tab to cycle/`. `strings` on the Claude Code 2.1.220 binary returns **zero** hits for it — the status line now reads `? for shortcuts`. The spec at `draft-injection.spec.ts:215` already noted this ("v2.1.220's manual mode never prints the marker") and treated the fallback as the answer.

2. **The match was against the raw stream, which is not the screen.** A TUI redraws by positioning the cursor between words, so the bytes actually delivered are

   ```
   ?ESC[24GforESC[28Gshortcuts
   ```

   A spaced regex over `data` could not have matched on *any* version. Captured from a live `claude` pty to confirm.

So every claude spawn fell through to `DRAFT_QUIET_MS` (6s) — and that timer is re-armed on every output burst, so it is "six seconds after the boot output stops", not six seconds total. Boot draw plus the window is the ten seconds observed.

`TRUST_PROMPT_MARKER` had the identical hole. The trust dialog arrives as `Yes,ESC[12GIESC[14Gtrust…`, so #1173's guard has been matching nothing; it was holding the draft only because a dialog screen is also a quiet one.

## The fix

`squashForMarker` (new, `server/session/pty-scan.ts`) reduces a read to the form markers are matched against: escape sequences, control bytes and **all** whitespace removed, lowercased.

- **Squashing whitespace beats replacing each escape with a space.** An escape between two words and one that lands inside a word squash identically, so the fix does not depend on where the redraw happens to break. Marker strings are distinctive enough that losing the spaces cannot make one match something else.
- **Markers are therefore spelled without spaces**: `/shift\+tabtocycle|\?forshortcuts/`. Both spellings are kept so this works on whatever claude the user has, and a version that prints neither still lands on the quiet fallback.
- **The scan tail stays RAW.** A sequence split across two reads still squashes correctly once its second half arrives.
- The trust marker moves to the same form, which repairs #1173's guard rather than leaving it leaning on the quiet window.

Counterpart in `../mulmoclaude`: none — draft injection into a PTY is MulmoTerminal's own path, MulmoClaude has no terminal.

## Tests

`test/server/session/pty-scan.spec.ts` (new) covers the normalizer against bytes **captured from a real claude pty**, not hand-written strings — writing test strings that looked nothing like terminal output is precisely how the marker came to be dead code with a green suite. `draft-injection.spec.ts` gains a case feeding both markers with the cursor moves in place, and the "dialog answered" case now asserts typing on the marker instead of on a further quiet window. `registry.spec.ts` asserts the marker through `squashForMarker` against real status lines, plus a negative for `shift+tab to approve with this feedback`.

`yarn test` (7042 passed / 45 skipped), `yarn lint` (0 errors), `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test` all clean.

## Verification

Driving a real `claude` through node-pty and feeding the stream to the new scanner:

| path | marker matches after |
| --- | --- |
| `claude` direct | 1626 ms |
| via tmux, as the app spawns it | 783 ms |
| **before this change** | **never (15s timeout)** |

Maintainer confirmed the fix live in a running server: the prompt now appears immediately instead of after ten seconds.

work in mulmoterminal
