### PR TITLE
fix: read a Windows path as a Windows path in the registry fs doubles (#1212)

### DIFF
--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -74,6 +74,17 @@ const SIBLING = path.resolve(BASE, "../lib");  // the expectation, computed the 
 
 → `test/server/config/add-dirs.spec.ts` for the shape.
 
+**A double that routes on a file NAME is a path comparison too.** The specs that mock `node:fs`
+pick a log apart by basename, and `String(file).split("/").pop()` returns the whole path on
+Windows — so a read falls through to `""` and a recorded write filters out to nothing. Neither
+throws: the spec reads empty logs and reports the feature as broken. #1189 and #1196 each shipped
+one, and Windows daily stayed red for eight days.
+
+Use `mockedFileName()` from `test/support/mockFsPath.ts` (`split(/[/\\]/)`). Not `path.basename` —
+correct at runtime, but on POSIX it leaves `\` alone, so the Windows case cannot be asserted on the
+machine that runs the suite. Not `endsWith` either: `unplaced-sessions.json` ends with
+`placed-sessions.json`, so a suffix match reads the two logs as one.
+
 **Verify on the real runner before merging**, with the dispatch at the top of this file. Local
 `yarn test` on macOS/Linux cannot see any of this — the whole class only appears where the
 separator and the drive letter differ.

--- a/docs/windows-gotchas.md
+++ b/docs/windows-gotchas.md
@@ -78,7 +78,7 @@ const SIBLING = path.resolve(BASE, "../lib");  // the expectation, computed the 
 pick a log apart by basename, and `String(file).split("/").pop()` returns the whole path on
 Windows — so a read falls through to `""` and a recorded write filters out to nothing. Neither
 throws: the spec reads empty logs and reports the feature as broken. #1189 and #1196 each shipped
-one, and Windows daily stayed red for eight days.
+one, and Windows daily went red on 12 consecutive runs before it was traced (#1212).
 
 Use `mockedFileName()` from `test/support/mockFsPath.ts` (`split(/[/\\]/)`). Not `path.basename` —
 correct at runtime, but on POSIX it leaves `\` alone, so the Windows case cannot be asserted on the

--- a/plans/fix-1212-windows-spec-basename.md
+++ b/plans/fix-1212-windows-spec-basename.md
@@ -1,0 +1,65 @@
+# fix #1212 — the fs doubles must read a Windows path as a Windows path
+
+## The failure
+
+Windows (daily) has been red on every run since #1189 landed (2026-07-31 17:16 UTC); the most
+recent is [run 30690834441](https://github.com/receptron/mulmoterminal/actions/runs/30690834441)
+on `mulmoterminal@4.0.0`. Eight assertions, on both 22.x and 24.x, in two files:
+
+| file | failures | landed in |
+| --- | --- | --- |
+| `test/server/session/unplaced-sessions.spec.ts` | 6 | #1189 |
+| `test/server/session/push-classification.spec.ts` | 2 | #1196 |
+
+Linux and macOS are green, which is why both PRs merged clean.
+
+## Root cause
+
+Both specs mock `node:fs` and route on the file's basename, spelled `String(file).split("/").pop()`.
+The registry builds those paths with `path.join(MULMOTERMINAL_HOME, "unplaced-sessions.json")`, so
+on Windows the double receives `C:\Users\...\unplaced-sessions.json`. Splitting on `/` returns a
+single element — the whole path — so the name never equals `"unplaced-sessions.json"`:
+
+- `readFile` falls through to `""`, so every hydrator sees an empty log; and
+- `loggedTo()` filters every append out, so the recorded writes read as `""`.
+
+Which is precisely the reported shape — `expected '' to contain '1111…'`, `expected [] to deeply
+equal [...]`, and `{ background: false, userScheduled: false }` where both were `true`.
+
+The product code is correct. Only the doubles are POSIX-only.
+
+## Fix
+
+`split(/[/\\]/)` — the separator-agnostic idiom the repo already uses in
+`src/composables/soundSettings.ts`, `server/infra/pty-env.ts`, `common/workComment.ts` and
+`src/components/presets.ts`.
+
+Deliberately **not** `path.basename`: it is correct at runtime but untestable on the machines that
+run the suite, because on POSIX it leaves `\` alone. A fix whose Windows behaviour can only be
+observed on Windows is how this bug reached `main` in the first place.
+
+Deliberately **not** `endsWith`: `"unplaced-sessions.json"` ends with `"placed-sessions.json"`, so
+a suffix match reads the two logs as one and every assertion about the placed log silently counts
+the unplaced one too. `unplaced-sessions.spec.ts` already carries a comment saying exactly this.
+
+## Steps
+
+1. `test/support/mockFsPath.ts` — one exported `mockedFileName(file: unknown): string`. Both specs
+   had the same bug for the same reason, so this is one helper, not two edits.
+2. `test/support/mockFsPath.spec.ts` — feed it a `\`-separated path, a `/`-separated one, and a
+   bare name, so the Windows case is asserted on every platform. Pin the `endsWith` trap directly:
+   the two sessions logs must come back as different names.
+3. Point both specs at the helper (three call sites: the two `readFile` doubles and `loggedTo`).
+4. `tsconfig.test-server.json` — add `test/support/**/*.ts` to `include`. Helpers under
+   `test/support/` are only type-checked today as a side effect of a spec importing them, so a
+   spec that lives there is checked by nothing. Adding the glob closes that gap.
+
+## Verification
+
+The suite passing on macOS proves only that the change is not a regression — the bug is invisible
+there by construction. The ground truth for this fix is:
+
+- the helper spec, which asserts the Windows spelling on this machine, and
+- a re-run of the real Windows job on the pushed branch, which is what actually failed.
+
+Both are required before the PR is called done.

--- a/test/server/session/push-classification.spec.ts
+++ b/test/server/session/push-classification.spec.ts
@@ -8,6 +8,8 @@
 // (Codex, PR #1196).
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { mockedFileName } from "../../support/mockFsPath.js";
+
 const ID = "11111111-1111-1111-1111-111111111111";
 
 // Hydration reads through this. The user-scheduled log is answered LATE on purpose: that is the
@@ -16,7 +18,7 @@ let slowLog = "";
 vi.mock("node:fs", () => {
   const promises = {
     readFile: vi.fn(async (file: unknown) => {
-      const name = String(file).split("/").pop() ?? "";
+      const name = mockedFileName(file);
       if (name === "background-sessions.json") return ID;
       if (name === "user-scheduled-sessions.json") {
         await new Promise((resolve) => setTimeout(resolve, 10));

--- a/test/server/session/unplaced-sessions.spec.ts
+++ b/test/server/session/unplaced-sessions.spec.ts
@@ -10,12 +10,14 @@
 // worker (tool-group-reset.spec's pattern).
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { mockedFileName } from "../../support/mockFsPath.js";
+
 const appended: { file: string; data: string }[] = [];
 let readBack: Record<string, string> = {};
 
 vi.mock("node:fs", () => {
   const promises = {
-    readFile: vi.fn(async (file: unknown) => readBack[String(file).split("/").pop() ?? ""] ?? ""),
+    readFile: vi.fn(async (file: unknown) => readBack[mockedFileName(file)] ?? ""),
     appendFile: vi.fn(async (file: string, data: string) => {
       appended.push({ file: String(file), data });
     }),
@@ -39,7 +41,7 @@ async function freshRegistry() {
 // placed log silently counts the unplaced one too.
 const loggedTo = (name: string) =>
   appended
-    .filter((a) => a.file.split("/").pop() === name)
+    .filter((a) => mockedFileName(a.file) === name)
     .map((a) => a.data)
     .join("");
 

--- a/test/support/mockFsPath.spec.ts
+++ b/test/support/mockFsPath.spec.ts
@@ -2,8 +2,8 @@
 // The Windows spelling, asserted on whatever platform is running.
 //
 // This helper exists because two registry specs read a `\`-separated path as one nameless blob and
-// went red on Windows only, for eight days, on every daily run. So the case that matters is the one
-// this machine will never produce on its own — it is passed in literally.
+// went red on Windows only, on 12 consecutive daily runs. So the case that matters is the one this
+// machine will never produce on its own — it is passed in literally.
 import { describe, it, expect } from "vitest";
 
 import { mockedFileName } from "./mockFsPath.js";

--- a/test/support/mockFsPath.spec.ts
+++ b/test/support/mockFsPath.spec.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+// The Windows spelling, asserted on whatever platform is running.
+//
+// This helper exists because two registry specs read a `\`-separated path as one nameless blob and
+// went red on Windows only, for eight days, on every daily run. So the case that matters is the one
+// this machine will never produce on its own — it is passed in literally.
+import { describe, it, expect } from "vitest";
+
+import { mockedFileName } from "./mockFsPath.js";
+
+describe("mockedFileName", () => {
+  it("reads the name off a Windows path", () => {
+    expect(mockedFileName("C:\\Users\\runneradmin\\.mulmoterminal\\unplaced-sessions.json")).toBe("unplaced-sessions.json");
+  });
+
+  it("reads the name off a POSIX path", () => {
+    expect(mockedFileName("/Users/me/.mulmoterminal/unplaced-sessions.json")).toBe("unplaced-sessions.json");
+  });
+
+  it("leaves a bare name alone", () => {
+    expect(mockedFileName("placed-sessions.json")).toBe("placed-sessions.json");
+  });
+
+  // The reason callers compare with `===`: one of these names is a suffix of the other, so
+  // `endsWith` would read the two logs as one and count every unplaced line as a placed one.
+  it("tells the two sessions logs apart on both separators", () => {
+    const unplaced = ["/home/me/.mulmoterminal/unplaced-sessions.json", "C:\\Users\\me\\.mulmoterminal\\unplaced-sessions.json"];
+    unplaced.forEach((file) => expect(mockedFileName(file)).not.toBe("placed-sessions.json"));
+  });
+
+  // `readFile` doubles are typed `(file: unknown)` because that is what vi.fn hands them.
+  it("accepts whatever the double was called with", () => {
+    expect(mockedFileName(undefined)).toBe("undefined");
+  });
+});

--- a/test/support/mockFsPath.ts
+++ b/test/support/mockFsPath.ts
@@ -1,0 +1,14 @@
+// The basename of a path a mocked `node:fs` was handed, on either separator.
+//
+// The registry builds its log paths with `path.join(MULMOTERMINAL_HOME, ...)`, so on Windows a
+// double receives `C:\Users\...\unplaced-sessions.json`. Split on "/" that is one element — the
+// whole path — so the name never equals the file the double is looking for: reads fall through to
+// "" and recorded writes filter out to nothing. The spec then fails on Windows alone, which is how
+// it reached main twice (#1212).
+//
+// `path.basename` is right at runtime and wrong here: on POSIX it leaves "\" alone, so the Windows
+// case would be unassertable on the machines that run the suite.
+//
+// Compare on the exact name this returns, never `endsWith`: "unplaced-sessions.json" ends with
+// "placed-sessions.json", so a suffix match reads the two logs as one.
+export const mockedFileName = (file: unknown): string => String(file).split(/[/\\]/).pop() ?? "";

--- a/tsconfig.test-server.json
+++ b/tsconfig.test-server.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test-server.tsbuildinfo"
   },
-  "include": ["test/server/**/*.ts", "test/bin/**/*.ts", "test/scripts/**/*.ts", "server/**/*.spec.ts"],
+  "include": ["test/server/**/*.ts", "test/bin/**/*.ts", "test/scripts/**/*.ts", "test/support/**/*.ts", "server/**/*.spec.ts"],
   "exclude": []
 }


### PR DESCRIPTION
## Summary

Windows daily CI has failed on **every run since #1189** (2026-07-31 17:16 UTC) — most recently [run 30690834441](https://github.com/receptron/mulmoterminal/actions/runs/30690834441) on `mulmoterminal@4.0.0`. 8 assertions, both 22.x and 24.x, in two spec files.

Both specs mock `node:fs` and route on the file's basename, spelled `String(file).split("/").pop()`. The registry builds those paths with `path.join(MULMOTERMINAL_HOME, ...)`, so on Windows the double receives `C:\Users\...\unplaced-sessions.json` — splitting that on `/` yields one element, the whole path, which never equals the name being looked for. Reads fall through to `""` and recorded writes filter out to nothing, so hydration sees empty logs and every append assertion reads an empty string.

**The product code is correct. Only the test doubles were POSIX-only.**

Fixed by extracting `mockedFileName()` into `test/support/`, splitting on either separator (`split(/[/\\]/)` — the idiom already used in `src/composables/soundSettings.ts`, `server/infra/pty-env.ts`, `common/workComment.ts`).

## Items to Confirm / Review

1. **`path.basename` was deliberately not used.** It is correct at runtime, but on POSIX it does not strip `\`, so the Windows case would be unassertable on the machines that run the suite — and a fix whose Windows behaviour is only observable on Windows is how this bug reached `main` twice. Reviewers who prefer `path.basename` should weigh that trade-off.
2. **`endsWith` is not an option**, in case it looks simpler: `"unplaced-sessions.json"` ends with `"placed-sessions.json"`, so a suffix match reads the two logs as one and every assertion about the placed log silently counts the unplaced one too. `unplaced-sessions.spec.ts` already carried a comment saying this.
3. **`tsconfig.test-server.json` gained `test/support/**/*.ts`.** Helpers there were type-checked only as a side effect of a spec importing them, so a spec *living* there was checked by nothing. Verified the glob works by planting a deliberate type error and confirming `yarn typecheck:test` caught it. Please sanity-check that widening.
4. **The `mulmoscript.spec.ts` "socket hang up"** seen in one local full-suite run is a pre-existing load flake, not from this change — it passes when run alone, and `vitest.config.ts` documents this class of flake.

## User Prompt

> https://github.com/receptron/mulmoterminal/actions/runs/30690834441 fix

## How this was verified

Passing on macOS proves nothing here — the bug is invisible on macOS by construction. So the failure was **reproduced locally** by mocking `node:path` to `path.win32` in a throwaway copy of each spec, making the registry build `\`-separated paths on macOS:

| spec | with the old `split("/")` | with `mockedFileName` |
| --- | --- | --- |
| `unplaced-sessions` | **6 failed**, 3 passed | 9 passed |
| `push-classification` | **2 failed**, 1 passed | 3 passed |

The 6 failing test names match the CI annotations exactly, and 6 + 2 = the 8 failures CI reported. The throwaway repro files were deleted, not committed.

Gates, after a `yarn install` to match the pulled lockfile: `yarn format`, `yarn lint` (0 errors), `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test`, `yarn build`, `yarn test` all pass.

`windows-daily.yaml` has been dispatched on this branch — **that run is the real ground truth and should be green before merge.**

## Changes

- `test/support/mockFsPath.ts` — new; one `mockedFileName(file: unknown)`.
- `test/support/mockFsPath.spec.ts` — new; asserts the Windows spelling on every platform, plus the `endsWith` trap.
- `test/server/session/unplaced-sessions.spec.ts`, `test/server/session/push-classification.spec.ts` — three call sites now use the helper.
- `tsconfig.test-server.json` — type-check `test/support/`.
- `docs/windows-gotchas.md` — new entry under "Tests that handle paths", since that doc is the required read before debugging a Windows-only failure.
- `plans/fix-1212-windows-spec-basename.md` — the plan.

Closes #1212

work in mulmoterminal5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows compatibility for mocked filesystem paths in session-related tests.
  - Prevented ambiguous matching between similarly named session log files.

- **Tests**
  - Added coverage for Windows and POSIX path separators, bare filenames, suffix collisions, and invalid inputs.
  - Expanded server test checks to include shared filesystem test utilities.

- **Documentation**
  - Added guidance for writing cross-platform filesystem mock tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->