### PR TITLE
fix: main の typecheck:test を直す（core 1.12.0 で消えたフィールドを spec が参照していた）

### DIFF
--- a/server/backends/remoteHost/googleCalendar.spec.ts
+++ b/server/backends/remoteHost/googleCalendar.spec.ts
@@ -22,8 +22,6 @@ const sampleEvent: CalendarEventSummary = {
   htmlLink: "https://calendar.google.com/event?eid=ev1",
   status: "confirmed",
   colorId: "",
-  description: "",
-  location: "",
 };
 
 const sampleCalendar: CalendarSummary = {

--- a/test/server/backends/calendarPush.spec.ts
+++ b/test/server/backends/calendarPush.spec.ts
@@ -16,7 +16,7 @@ import { PUSH_NOT_DECLARED_ERROR, PUSH_NOT_LINKED_ERROR } from "../../../server/
 
 const PUSHED: CalendarPushOutcome = {
   kind: "pushed",
-  result: { slug: "meetings", created: 2, updated: 1, conflicts: 0, localDeletes: 0, skipped: [], errors: [], unpushedIds: [] },
+  result: { slug: "meetings", created: 2, updated: 1, conflicts: 0, localDeletes: 0, skipped: [], errors: [] },
 };
 
 const stubDeps = (over: Partial<CalendarPushRouteDeps> = {}): CalendarPushRouteDeps => ({

--- a/test/server/backends/calendarPushResult.spec.ts
+++ b/test/server/backends/calendarPushResult.spec.ts
@@ -18,7 +18,7 @@ describe("toCollectionPushResult", () => {
   it("carries a successful push's counts through", () => {
     const outcome: CalendarPushOutcome = {
       kind: "pushed",
-      result: { slug: "meetings", created: 3, updated: 2, conflicts: 1, localDeletes: 4, skipped: ["r7: no start time"], errors: [], unpushedIds: ["r4"] },
+      result: { slug: "meetings", created: 3, updated: 2, conflicts: 1, localDeletes: 4, skipped: ["r7: no start time"], errors: [] },
     };
     expect(toCollectionPushResult(outcome)).toEqual({
       pushed: true,
@@ -45,7 +45,6 @@ describe("toCollectionPushResult", () => {
         localDeletes: 0,
         skipped: ["r2: end before start"],
         errors: ["r9: 403"],
-        unpushedIds: ["r9"],
       },
     });
     expect(result.skipped).toEqual(["r2: end before start"]);


### PR DESCRIPTION
## Summary

**`main` が `typecheck:test` で落ちています。4.0.0 はその上でリリースされました。** それを直します。

`@mulmoclaude/core` を 1.12.0 に上げた `370955a` で、`CalendarEventSummary` から `description` と
`location` が、`CalendarCollectionPushResult` から `unpushedIds` が消えました。**spec だけがその名前を
参照したまま**残っています。

`yarn build` はアプリのコードだけをコンパイルするので通り、**CI が実際に回すゲート（`typecheck:test`）
だけが赤**になっていました。CLAUDE.md が警告している分裂そのもので、bump がローカルで問題なく見えた
理由もこれです。

## Items to Confirm / Review

### リリース済みユーザーへの影響はありません

型エラー4件は**すべて spec の中**で、spec は実行時に import されません。出荷されるコードで
`unpushedIds` を読む箇所も、`CalendarEventSummary.description` を名指しする箇所も**ゼロ**です
（確認済み）。イベント作成ハンドラは `return { event: { ...event } }` と**スプレッドで素通し**して
いるので、パッケージ側のフィールド増減はそもそもこちらのコードを通りません。

### 消したフィールドは「戻すべきもの」ではないか

`unpushedIds`（push できなかったレコード）は、現在の型では **`skipped: string[]`（理由つき）** が
その役割を持っています。イベントの `description` / `location` も、パッケージが公開型から外した
ものです。**どちらもこちら側の機能ではなく、パッケージの表面**なので、spec を追随させるのが正しいと
判断しました。ここは目で見てほしいところです。

### 確認できなかったこと

カレンダーイベントの `description` が**スマホの表示まで届いているか**は、1.12.0 自身の実行時の挙動
次第で、minified bundle からは読み取れませんでした。表示側は別レポ（`receptron/mulmoserver`）です。
もし返却をやめているなら、それは 4.0.0 と一緒に入った**パッケージ側の変更**で、本 PR とは別件です。

### 別件として見つけたもの（この PR では直しません）

`package.json` の `files:` に `server/` が入っているため、**spec ファイルが 19 個 npm に出荷されて
います**。import されないので実害はありませんが、意図したものではないはずです。

## User Prompt

> 直したほうが良いし、これってリリースユーザに影響ある？

## テスト

`yarn format` / `lint` / `typecheck` / `typecheck:server` / **`typecheck:test`** / `build` /
`test`（7135 passed）— **すべて終了コードで確認**して PASS。

work in mulmoterminal4
