### PR TITLE
feat: スマホから issue 起点で作業を始める（ホスト側 API）(#1184)

### DIFF
--- a/common/issueStartPlan.ts
+++ b/common/issueStartPlan.ts
@@ -1,8 +1,12 @@
-// What the "start work on this issue" control can do for one repo, decided from the repo -> clone
-// answer alone (#1173). Pure, because the three outcomes are the whole behaviour of the control
-// and each one is a different thing for a user to see: a button, a menu, or a disabled button
-// that says why.
-import type { RepoDirs } from "../../common/repoDirs";
+// Whether work on one repo can start here, decided from the repo -> clone answer alone (#1173).
+// Pure, because the three outcomes are the whole behaviour: on the desktop they are a button, a
+// menu, or a disabled button that says why (IssueStartButton.vue).
+//
+// In `common/` because BOTH hosts decide from it: the phone asks the same question over the remote
+// command channel (#1184) and must reach the same answer — with one difference it makes itself,
+// not one encoded here. It cannot offer the menu (the phone never picks a directory, see
+// docs/remote-host-protocol.md), so it refuses `choose` where the desktop opens it.
+import type { RepoDirs } from "./repoDirs";
 
 export type IssueStartPlan =
   /** No clone of this repo on this machine, so there is nowhere for the work to happen. */
@@ -11,6 +15,10 @@ export type IssueStartPlan =
   | { kind: "ready"; dir: string }
   /** Several clones and nothing recorded yet: the user picks, and the pick is remembered. */
   | { kind: "choose"; dirs: RepoDirs["dirs"] };
+
+/** A plan that cannot start work as it stands. Named so a caller that has already narrowed to it
+ *  can be given a sentence rather than a nullable one — see the phone's refusal (#1184). */
+export type BlockedIssueStartPlan = Exclude<IssueStartPlan, { kind: "ready" }>;
 
 export function issueStartPlan(entry: RepoDirs | undefined): IssueStartPlan {
   const dirs = entry?.dirs ?? [];

--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -39,6 +39,8 @@ grouped in `handlers/terminalSession.ts`.
 | `sendTerminalInput` | `sessionId`, `text` | `{ sent: true }` |
 | `launchTerminal` | `agent`, `sessionId` | `{ ok: true }` |
 | `startChat` | `message`, `attachments?` | `{ started: true, chatId }` |
+| `listIssues` | — | `{ repos: RepoIssueRows[] }` |
+| `startIssueWork` | `repo`, `issue` | `{ started: true, sessionId, branch, issue }` |
 | `listFeeds` | — | `{ feeds }` |
 | `getFeed` | `slug`, `offset?`, `limit?` | the feed page |
 | `listCollections` | — | `{ collections }` (feed-backed ones excluded) |
@@ -60,6 +62,34 @@ the byte budget, so a successful edit is never shown as a failure (#747).
 
 Image fields are **not** inlined by this host (there is no thumbnail store yet): they come back
 as workspace paths, unrenderable on the phone, and count toward `omitted`.
+
+### Starting work on an issue (#1184)
+
+`listIssues` is the phone's half of the `/prs` issue list: the open issues of the repos in
+Settings' `prRepos`, capped per repo, no bodies. Each repo row carries what
+`GET /api/issues` answers with (`repo`, `issues[]`, `truncated?`, `url?`, `error?`) plus:
+
+```ts
+{ canStart: boolean; startBlocked?: string }   // the sentence only when canStart is false
+```
+
+`startIssueWork` then reads the issue, cuts its `issue/<N>-<slug>` worktree off the fetched
+mainline, and spawns a session there with the issue **waiting in the input box, not submitted** —
+the text was written by whoever opened the issue, so the Enter is the user's. It answers
+`{ started: true, sessionId, branch, issue: { number, title } }`; `sessionId` is the id
+`getTerminalScreen` takes, so the phone can watch what it just started.
+
+**It takes no `dir`, by rule** (see "The phone never sends a path" below). The work starts in the
+clone recorded for that repo — or in the only one, when the repo has exactly one here. When
+several clones could host it and none has been recorded, the command **refuses** and says to
+choose once on the desktop. Picking for the user is not a smaller decision than it looks: an
+agent runs where it is started, that cannot be undone, and the phone has no way to show which
+tree it landed in. `canStart` exists so the phone learns this before the tap rather than after.
+
+**It has no open-tab prerequisite**, unlike `launchTerminal` below. The spawn is the host's own,
+and the session is marked *unplaced* (`server/session/registry.ts`), which is how a session
+nobody's browser asked for gets a cell: a desktop grid that is already on screen adopts it within
+the moment, and one that isn't picks it up the next time it loads.
 
 ### `TerminalSessionSummary`
 
@@ -115,8 +145,10 @@ rather than "not known". **It calls `.trim()` on every value, so only strings ma
 always present, `[]` when nothing applies.
 
 **The phone never sends a path.** `launchTerminal` takes a session id and the host looks the
-directory up (`ptys.get(id)?.cwd`). A path parameter would let a remote client choose where a
-process starts. Apply this to anything new that touches the filesystem.
+directory up (`ptys.get(id)?.cwd`). `startIssueWork` takes `owner/repo` and the host looks up the
+clone recorded for it. A path parameter would let a remote client choose where a process starts.
+Apply this to anything new that touches the filesystem — including when the host would then have
+to refuse, which is the honest answer and not a gap to close by accepting the path.
 
 **Authorization is the connected Firebase account, with no per-command gate.**
 `sendTerminalInput` already types arbitrary text into a Claude session, which can run anything,
@@ -140,6 +172,10 @@ Consequences the phone has to live with:
 - `agent` is `"shell" | "claude" | "codex"` (`common/launchAgent.ts`) — deliberately not the
   user's configured `launchers`, which are arbitrary commands.
 
+This is about opening a cell for a session that already exists, not about starting one: a command
+that SPAWNS can mark its session unplaced and let a grid adopt it later, which is what
+`startChat` and `startIssueWork` do. Nothing has to be open for those.
+
 ## Where the pieces are
 
 | Concern | File |
@@ -149,6 +185,8 @@ Consequences the phone has to live with:
 | Typing into a session (sanitize, bracketed paste, Enter timing) | `server/backends/remoteHost/terminalInput.ts` |
 | Quick-command scoping | `server/backends/remoteHost/quickCommands.ts` |
 | Launch validation | `server/backends/remoteHost/launchTerminal.ts` |
+| Issue work (list, refuse, start) | `server/backends/remoteHost/handlers/issueWork.ts`, `server/git/issue-work.ts` |
+| Which clone a repo starts in | `server/git/repo-dirs.ts`, `common/issueStartPlan.ts` |
 | Reconnect + health | `server/backends/remoteHost/resilientRunner.ts`, `healthNotice.ts` |
 | Wiring (PTY table, pub/sub, config) | `server/index.ts` |
 | Shared with the UI | `common/sessionAgent.ts`, `common/quickCommands.ts`, `common/launchAgent.ts` |
@@ -156,4 +194,4 @@ Consequences the phone has to live with:
 ## Related
 
 `docs/spawn-architecture.md` (how a session is spawned), `docs/terminal-notes.md` (the terminal
-stack). Issues: #435, #445, #563, #572, #781, #786, #823, #830, #831, #832.
+stack). Issues: #435, #445, #563, #572, #781, #786, #823, #830, #831, #832, #1184.

--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -91,6 +91,13 @@ and the session is marked *unplaced* (`server/session/registry.ts`), which is ho
 nobody's browser asked for gets a cell: a desktop grid that is already on screen adopts it within
 the moment, and one that isn't picks it up the next time it loads.
 
+The same mark is what puts the session in **`listTerminalSessions`** before any of that happens.
+That list is the grid's cells, and the id is written by a browser attach and by nothing else — so
+until #1184 a session the phone had just started was absent from the phone's own list, and the
+work it began was findable only by holding on to the returned `sessionId`. The list now answers
+with cells **and** the sessions on their way to being one, which is the same set one moment later.
+This covers `startChat` too, which had the same hole.
+
 ### `TerminalSessionSummary`
 
 ```ts
@@ -101,8 +108,9 @@ the moment, and one that isn't picks it up the next time it loads.
 (`capture-pane` doesn't need our process) but **not writable**, and `agent` is then `null`
 because the process that knew what it was launched with is gone.
 
-The list is filtered to **grid cells**: the single-view chat session and any tmux shell that
-was never a cell are excluded, even while live.
+The list is filtered to **grid cells, plus the sessions waiting to become one** — a chat or an
+issue the phone started that no browser has adopted yet (`isPhoneListableSession`). A tmux shell
+that was never a cell and that nobody spawned for one is excluded, even while live.
 
 ### `SessionScreen`
 

--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -92,9 +92,9 @@ nobody's browser asked for gets a cell: a desktop grid that is already on screen
 the moment, and one that isn't picks it up the next time it loads.
 
 The same mark is what puts the session in **`listTerminalSessions`** before any of that happens.
-That list is the grid's cells, and the id is written by a browser attach and by nothing else — so
-until #1184 a session the phone had just started was absent from the phone's own list, and the
-work it began was findable only by holding on to the returned `sessionId`. The list now answers
+That list is the grid's cells, and a session joins that set on a browser attach and in no other
+way — so until #1184 a session the phone had just started was absent from the phone's own list,
+and the work it began was findable only by holding on to the returned `sessionId`. It now answers
 with cells **and** the sessions on their way to being one, which is the same set one moment later.
 This covers `startChat` too, which had the same hole.
 

--- a/plans/feat-1184-phone-issue-start.md
+++ b/plans/feat-1184-phone-issue-start.md
@@ -58,6 +58,19 @@ spawnBackgroundChat, a scheduled task, **or the phone**"* とスマホを名指�
 
 `launchTerminal` の「タブが開いていないと失敗する」制約には当たらない。spawn 自体はブラウザ無しでできる。
 
+### 5. ただし「スマホ自身の一覧」には出ていなかった — 同じ PR で直す（レビュー中に判明）
+
+上のデスクトップ側だけでは、issue の2点目に半分しか答えられていなかった。`listTerminalSessions` は
+`devTerminalSessions` で絞っており、その印を書くのは `markDevTerminalSession`
+（`server/routes/ws-routes.ts` の4箇所 ＝ **ブラウザの attach だけ**）。よって Mac にタブが無い間、
+**スマホは自分で始めた作業を自分の一覧に見つけられない**（返ってきた `sessionId` を握っていれば
+画面は見られる）。`startChat` も最初から同じ穴を持っていた。
+
+unplaced の印は「visible に spawn した・セルはまだ無い」そのものなので、一覧の条件を
+**`devTerminalSessions` ∨ unplaced** にする。attach が unplaced を消すのと同じ瞬間に相手側へ入るため、
+両方に入る瞬間も、どちらにも無い瞬間も無い。判定は両方の集合がある `registry.ts` に
+`isPhoneListableSession` として置く（＝テストできる場所）。
+
 ## 変更するファイル
 
 1. `common/issueStartPlan.ts` — `src/composables/` から移動（importer 2つとテストのパスを追従）
@@ -66,7 +79,8 @@ spawnBackgroundChat, a scheduled task, **or the phone**"* とスマホを名指�
 4. `server/backends/remoteHost/handlers/index.ts` — テーブルに登録
 5. `server/index.ts` — `spawnIssueDraft` を配線（spawn ＋ `markUnplacedSession`）
 6. `docs/remote-host-protocol.md` — コマンド表 ＋ 「dir を受け取らない」理由 ＋ 現れ方
-7. spec — `server/backends/remoteHost/issueWork.spec.ts`、`handlers.spec.ts` の deps 追従
+7. `server/session/registry.ts` — `isPhoneListableSession`、`server/index.ts` の一覧の絞り込み（決定5）
+8. spec — `server/backends/remoteHost/issueWork.spec.ts`、`unplaced-sessions.spec.ts`、`handlers.spec.ts` の deps 追従
 
 ## テストで固定すること
 
@@ -74,6 +88,7 @@ spawnBackgroundChat, a scheduled task, **or the phone**"* とスマホを名指�
 - 複数クローン ＋ 未記録 → **spawn せずに** 拒否。文にデスクトップで選ぶことが書いてある
 - クローン無し → 拒否
 - クローン1つ ＋ 未記録 → 始まる
+- **スマホが始めたセッションは、セルが付く前も付いた後も一覧に出る**（決定5。付け替えの瞬間に消えない）
 - `listIssues` の `canStart` / `startBlocked` が上の3状態と一致する
 - 不正な `repo` / `issue` は spawn せずに拒否
 

--- a/plans/feat-1184-phone-issue-start.md
+++ b/plans/feat-1184-phone-issue-start.md
@@ -1,0 +1,85 @@
+# feat(#1184): スマホから issue 起点で作業を始める（ホスト側 API まで）
+
+#1026 の段階4のうち「スマホ」の入口。表示は別レポ（`receptron/mulmoserver`）で、
+ここは **ホストが答えるコマンドを用意するところまで**（#1014 と同じ切り方）。
+
+## 前提はもう揃っている
+
+issue 本文が「これを呼べばよい」と書いていたものは、#1171 / #1172 / #1173 で 3.x に入っている。
+
+| 部品 | 場所 |
+| --- | --- |
+| `startIssueWork(repo, issue, dir, deps)` | `server/git/issue-work.ts` |
+| デスクトップの `POST /api/issues/start`（`dir` を検証して spawn） | `server/routes/issue-work-routes.ts` |
+| repo → クローン候補 ＋ 記録された primary | `server/git/repo-dirs.ts` |
+| 開始可否の判定（`no-clone` / `ready` / `choose`） | `src/composables/issueStartPlan.ts` |
+
+残るのは **コマンド2本と、dir をどう決めるか** だけ。
+
+## 決めたこと
+
+### 1. `dir` は受け取らない。記録された primary を使い、無ければ始めない
+
+プロトコルの規則（`docs/remote-host-protocol.md`）:
+
+> The phone never sends a path. **Apply this to anything new that touches the filesystem.**
+
+なので `startIssueWork` コマンドの引数は `repo` と `issue` だけ。作業ディレクトリは
+`repoDirsFromPresets()` が返す `primary`。**クローンが1つだけならその1つで始める**
+（記録が無くても答えは1つしかない）。複数あって未記録のときは **始めずに拒否**する。
+
+拒否は throw する — プロトコルの「A handler that throws turns into the phone's error message.
+That is the intended way to refuse — the phone shows the sentence, so write it for a person.」に従う。
+
+候補一覧を返してスマホに選ばせる案は採らない。エージェントがどのツリーで走り出すかは
+取り消しの効かない決定で、スマホには「どのクローンに落ちたか」を見る手段が無い。
+
+### 2. 判定は `issueStartPlan()` を両ホストで共有する（`common/` へ移す）
+
+同じ「このリポで作業を始められるか」を、デスクトップの行ボタンとスマホの2箇所が決める。
+CLAUDE.md の「両方が決めるものは `common/`」に従い `src/composables/issueStartPlan.ts` を
+`common/issueStartPlan.ts` へ移動する。ロジックを2つ持って「同期を保つ」形にはしない。
+
+### 3. `listIssues` は「開始できるか」まで答える
+
+`{ repos: RepoIssues[] }` の各行に `canStart: boolean` と、false のときだけ `startBlocked: string`。
+プロトコルの「The host decides; the phone renders」と、`githubUrl` と同じ「あれば描く」規則に合わせる。
+これが無いと、スマホはタップして初めて拒否を知ることになる。
+
+### 4. グリッドへの現れ方は既存の unplaced 経路に乗る（新規の仕組みは要らない）
+
+issue が「決めたいこと」に挙げていた点は、issue が書かれた後に入った #1189 / #1204 が答えている。
+`markUnplacedSession()`（`server/session/registry.ts`）のコメントは *"an agent calling
+spawnBackgroundChat, a scheduled task, **or the phone**"* とスマホを名指ししており、
+`GridView.vue` は `sessions` の `created` push でも掃引する。つまり:
+
+- デスクトップのタブが開いていれば **その場でセルが生える**
+- 開いていなければ、**次にグリッドを開いたときに拾われる**
+
+`launchTerminal` の「タブが開いていないと失敗する」制約には当たらない。spawn 自体はブラウザ無しでできる。
+
+## 変更するファイル
+
+1. `common/issueStartPlan.ts` — `src/composables/` から移動（importer 2つとテストのパスを追従）
+2. `server/backends/remoteHost/handlers/issueWork.ts` — 新規。`listIssues` / `startIssueWork`
+3. `server/backends/remoteHost/handlers/deps.ts` — `spawnIssueDraft` を追加
+4. `server/backends/remoteHost/handlers/index.ts` — テーブルに登録
+5. `server/index.ts` — `spawnIssueDraft` を配線（spawn ＋ `markUnplacedSession`）
+6. `docs/remote-host-protocol.md` — コマンド表 ＋ 「dir を受け取らない」理由 ＋ 現れ方
+7. spec — `server/backends/remoteHost/issueWork.spec.ts`、`handlers.spec.ts` の deps 追従
+
+## テストで固定すること
+
+- **`dir` を渡しても無視して記録されたクローンで始める** — これがプロトコル規則そのもの
+- 複数クローン ＋ 未記録 → **spawn せずに** 拒否。文にデスクトップで選ぶことが書いてある
+- クローン無し → 拒否
+- クローン1つ ＋ 未記録 → 始まる
+- `listIssues` の `canStart` / `startBlocked` が上の3状態と一致する
+- 不正な `repo` / `issue` は spawn せずに拒否
+
+## やらないこと
+
+- **スマホ側の UI** — `receptron/mulmoserver`。ここはデータと操作を届けるまで（#1014 と同じ）
+- **クローン選択の対話をスマホに持ち込むこと** — 上の決定1
+- **同じ issue で2つ目の worktree を防ぐこと** — 現状は連番で別ブランチができる。#1207 の
+  「1 worktree 1 セッション」とは別の話で、必要なら別 issue

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -57,6 +57,7 @@ describe("createRemoteHostHandlers · getFeed", () => {
       workspace: ws,
       spawnChat: () => ({ chatId: "x" }),
       ingest: async () => ({ attachments: [], cleanupStaging: async () => {} }),
+      spawnIssueDraft: () => "unused-session",
       listTerminalSessions: async () => [],
       captureTerminalScreen: async () => ({ screen: "", suggestion: "", quickCommands: [] }),
       writeToSession: () => false,

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -9,6 +9,7 @@ import type { SessionScreen } from "./terminalScreen.js";
 import { initCollectionsBackend } from "../collections.js";
 
 const unusedTerminalDeps = {
+  spawnIssueDraft: () => "unused-session",
   listTerminalSessions: async () => [],
   captureTerminalScreen: async () => ({ screen: "", suggestion: "", quickCommands: [] }),
   writeToSession: () => false,
@@ -62,6 +63,8 @@ describe("createRemoteHostHandlers", () => {
       "listSkills",
       "listAccountingBooks",
       "startChat",
+      "listIssues",
+      "startIssueWork",
       "getRemoteView",
       "getRemoteViewItems",
       "mutateRemoteViewItem",

--- a/server/backends/remoteHost/handlers/deps.ts
+++ b/server/backends/remoteHost/handlers/deps.ts
@@ -36,6 +36,11 @@ export interface RemoteHostHandlerDeps {
   // Same lookup as canClearBox / submitSequence: only Claude Code has the menu that eats a
   // submit, and only there is the guard's trailing space not real input.
   sessionAgent: (sessionId: string) => SessionAgent | undefined;
+  // Start a session in the worktree the host just cut for an issue, with the issue waiting in its
+  // input box (#1184); returns the new session id. Wired in server/index.ts, which owns both the
+  // spawner and the unplaced mark — the mark is what gets a session nobody's browser asked for a
+  // cell, and it is why this command needs no open tab the way launchTerminal does.
+  spawnIssueDraft: (cwd: string, draft: string) => string;
   // Open a new grid terminal in the directory of the session the phone is looking at
   // (#831). Answered in server/index.ts, which owns the PTY table and the pub/sub the
   // grid listens on. Resolves to an error string when it could not be started.

--- a/server/backends/remoteHost/handlers/index.ts
+++ b/server/backends/remoteHost/handlers/index.ts
@@ -16,6 +16,7 @@ import { googleCalendarColors, googleCalendarCreateEvent, googleCalendarListCale
 import { getCollection } from "./getCollection.js";
 import { createGetFeed } from "./getFeed.js";
 import { getRemoteView } from "./getRemoteView.js";
+import { createIssueWorkHandlers } from "./issueWork.js";
 import { getRemoteViewItems } from "./getRemoteViewItems.js";
 import { createListAccountingBooks } from "./listAccountingBooks.js";
 import { listCollections } from "./listCollections.js";
@@ -56,6 +57,10 @@ export function createRemoteHostHandlers(deps: RemoteHostHandlerDeps): CommandHa
     listSkills: createListSkills(workspace),
     listAccountingBooks: createListAccountingBooks(workspace),
     startChat: createStartChat(deps),
+
+    // Starting work on a GitHub issue from the phone (#1184). Reads the configured repos, and
+    // starts in the clone recorded for one — never in a directory the phone named.
+    ...createIssueWorkHandlers(deps),
 
     ...createTerminalSessionHandlers(deps),
   };

--- a/server/backends/remoteHost/handlers/issueWork.ts
+++ b/server/backends/remoteHost/handlers/issueWork.ts
@@ -1,0 +1,84 @@
+// listIssues / startIssueWork command handlers — beginning work on a GitHub issue FROM THE PHONE
+// (#1184). The desktop's half is POST /api/issues/start, and everything below the decision is the
+// same code (server/git/issue-work.ts): read the issue, cut its `issue/<N>-<slug>` worktree, spawn
+// a session with the issue waiting in the input box.
+//
+// What differs is how the working directory is chosen, and it is the whole design here. The phone
+// never sends a path (docs/remote-host-protocol.md), so it cannot name one and is not asked to:
+// the directory is the clone recorded for that repo. When several clones could host the work and
+// none has been recorded, the command REFUSES rather than picking one — an agent runs where it is
+// started, that cannot be taken back, and the phone has no way to show which tree it landed in.
+// The desktop opens a menu for exactly this case, and one pick there settles it for good.
+import { toJsonObject, type CommandHandlers, type JsonObject } from "@mulmoclaude/core/remote-host";
+import { getCwdPresets, getPrRepos, getRepoDirs } from "../../../config/config-routes.js";
+import { listIssuesAcrossRepos } from "../../../git/issues.js";
+import { startIssueWork } from "../../../git/issue-work.js";
+import { repoDirsFromPresets } from "../../../git/repo-dirs.js";
+import { issueStartPlan, type BlockedIssueStartPlan } from "../../../../common/issueStartPlan.js";
+import { isIssueNumber } from "../../../../common/prPhase.js";
+import type { RepoDirs } from "../../../../common/repoDirs.js";
+import type { RemoteHostHandlerDeps } from "./deps.js";
+
+// The same slug shape `prRepos` accepts, checked here too because this value is interpolated into
+// a `gh --repo` argument and an issue URL.
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+// GitHub treats `Owner/Repo` and `owner/repo` as one repository, and the two spellings arrive from
+// different places: `prRepos` is typed by hand, an entry's own name comes from the remote URL.
+const entryFor = (repos: RepoDirs[], repo: string): RepoDirs | undefined => repos.find((r) => r.repo.toLowerCase() === repo.toLowerCase());
+
+/** Why the phone cannot start work on this repo. Written for a person, and it names the DESKTOP
+ *  because that is where the missing answer is given — a sentence that only says "no" would leave
+ *  the reader with nothing to do about it. */
+export function issueStartRefusal(plan: BlockedIssueStartPlan, repo: string): string {
+  return plan.kind === "no-clone"
+    ? `No local clone of ${repo} on this machine. Add one to your directory presets on the desktop to start work here.`
+    : `${repo} has several clones on this machine and none is chosen yet. Start one issue from the desktop to choose which clone the work happens in, and this will use it from then on.`;
+}
+
+const repoDirsNow = (): Promise<RepoDirs[]> => repoDirsFromPresets(getCwdPresets(), getRepoDirs());
+
+type IssueWorkDeps = Pick<RemoteHostHandlerDeps, "spawnIssueDraft">;
+
+// `canStart` is always present and the sentence only when there is one: the phone's rule is
+// "render it if it's there", and an empty string would read as a reason nobody could name.
+const listIssuesHandler: CommandHandlers[string] = async () => {
+  const [repos, dirs] = await Promise.all([listIssuesAcrossRepos(getPrRepos()), repoDirsNow()]);
+  return toJsonObject({
+    repos: repos.map((row) => {
+      const plan = issueStartPlan(entryFor(dirs, row.repo));
+      return plan.kind === "ready" ? { ...row, canStart: true } : { ...row, canStart: false, startBlocked: issueStartRefusal(plan, row.repo) };
+    }),
+  });
+};
+
+const startIssueWorkHandler =
+  ({ spawnIssueDraft }: IssueWorkDeps): CommandHandlers[string] =>
+  async (params: JsonObject) => {
+    const repo = typeof params.repo === "string" ? params.repo.trim() : "";
+    if (!REPO_RE.test(repo)) throw new Error("repo is required, as owner/repo");
+    const { issue } = params;
+    if (!isIssueNumber(issue)) throw new Error("issue is required, as a positive issue number");
+
+    const plan = issueStartPlan(entryFor(await repoDirsNow(), repo));
+    if (plan.kind !== "ready") throw new Error(issueStartRefusal(plan, repo));
+
+    const result = await startIssueWork(repo, issue, plan.dir, { spawnDraft: spawnIssueDraft });
+    // A failed step stops here with the reason it failed — the same detail the desktop route turns
+    // into a status code, which on this channel is simply the sentence the phone shows.
+    if (!result.ok || !result.sessionId) throw new Error(result.detail ?? `could not start work on ${repo}#${issue}`);
+    return toJsonObject({
+      started: true,
+      sessionId: result.sessionId,
+      branch: result.branch ?? "",
+      // The title, so the phone can confirm WHICH issue it just started without a second call. The
+      // body is deliberately not echoed: it is already in the session's input box, and it is the
+      // one field here with no upper bound.
+      issue: { number: issue, title: result.issue?.title ?? "" },
+    });
+  };
+
+export const createIssueWorkHandlers = (deps: IssueWorkDeps): CommandHandlers => ({
+  listIssues: listIssuesHandler,
+  startIssueWork: startIssueWorkHandler(deps),
+});

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -93,6 +93,7 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
     handlers: createRemoteHostHandlers({
       workspace: deps.workspace,
       spawnChat: deps.spawnChat,
+      spawnIssueDraft: deps.spawnIssueDraft,
       ingest,
       listTerminalSessions: deps.listTerminalSessions,
       captureTerminalScreen: deps.captureTerminalScreen,

--- a/server/backends/remoteHost/issueWork.spec.ts
+++ b/server/backends/remoteHost/issueWork.spec.ts
@@ -1,0 +1,157 @@
+// @vitest-environment node
+// The phone's issue commands (#1184). The case that matters most is the one the protocol makes a
+// rule of: the phone never sends a path, so the directory the work starts in comes from the
+// RECORDED clone — and when there is no answer to that, nothing starts at all.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { RepoDirs } from "../../../common/repoDirs.js";
+import type { RepoIssues } from "../../../common/ghItems.js";
+
+const config = { prRepos: ["acme/web"] };
+vi.mock("../../config/config-routes.js", () => ({
+  getPrRepos: () => config.prRepos,
+  getCwdPresets: () => [],
+  getRepoDirs: () => ({}),
+}));
+
+// The repo -> clone answer is this suite's INPUT (repo-dirs.spec.ts covers how it is resolved), so
+// it is stubbed rather than built out of real clones on disk.
+const dirs: { rows: RepoDirs[] } = { rows: [] };
+vi.mock("../../git/repo-dirs.js", () => ({ repoDirsFromPresets: async () => dirs.rows }));
+
+const issues: { rows: RepoIssues[] } = { rows: [] };
+vi.mock("../../git/issues.js", () => ({ listIssuesAcrossRepos: async () => issues.rows }));
+
+const issueWork = { start: vi.fn() };
+vi.mock("../../git/issue-work.js", () => ({
+  startIssueWork: (...args: unknown[]) => issueWork.start(...args),
+}));
+
+const { createIssueWorkHandlers } = await import("./handlers/issueWork.js");
+
+const clone = (path: string, label = path): RepoDirs["dirs"][number] => ({ path, label, orderPriority: null });
+const repoDirs = (paths: string[], primary: string | null = null, repo = "acme/web"): RepoDirs => ({ repo, dirs: paths.map((p) => clone(p)), primary });
+
+const spawnIssueDraft = vi.fn<(cwd: string, draft: string) => string>();
+const handlers = createIssueWorkHandlers({ spawnIssueDraft });
+
+const start = (params: Record<string, unknown>) => handlers.startIssueWork({ ...params } as Parameters<(typeof handlers)["startIssueWork"]>[0]);
+const list = () => handlers.listIssues({});
+
+describe("startIssueWork (phone)", () => {
+  beforeEach(() => {
+    spawnIssueDraft.mockReset();
+    spawnIssueDraft.mockReturnValue("s-1");
+    issueWork.start.mockReset();
+    issueWork.start.mockResolvedValue({ ok: true, sessionId: "s-1", branch: "issue/7-thing", worktree: "/wt/thing", issue: { number: 7, title: "The thing" } });
+    dirs.rows = [repoDirs(["/clones/web"], "/clones/web")];
+    issues.rows = [];
+    config.prRepos = ["acme/web"];
+  });
+
+  it("starts in the recorded clone and answers with the session and branch", async () => {
+    const answer = await start({ repo: "acme/web", issue: 7 });
+    expect(issueWork.start).toHaveBeenCalledWith("acme/web", 7, "/clones/web", expect.anything());
+    expect(answer).toMatchObject({ started: true, sessionId: "s-1", branch: "issue/7-thing", issue: { number: 7, title: "The thing" } });
+  });
+
+  // The protocol rule itself. A `dir` the phone sends must not reach the filesystem, and the way
+  // to be sure of that is that sending one changes nothing about where the work starts.
+  it("ignores a dir the caller sends and uses the recorded clone", async () => {
+    dirs.rows = [repoDirs(["/clones/web", "/clones/web2"], "/clones/web")];
+    await start({ repo: "acme/web", issue: 7, dir: "/etc" });
+    expect(issueWork.start).toHaveBeenCalledWith("acme/web", 7, "/clones/web", expect.anything());
+  });
+
+  it("starts in the only clone when the repo has one and nothing was recorded", async () => {
+    dirs.rows = [repoDirs(["/clones/web"])];
+    await start({ repo: "acme/web", issue: 7 });
+    expect(issueWork.start).toHaveBeenCalledWith("acme/web", 7, "/clones/web", expect.anything());
+  });
+
+  it("refuses when several clones could host the work and none is recorded, and starts nothing", async () => {
+    dirs.rows = [repoDirs(["/clones/web", "/clones/web2"])];
+    await expect(start({ repo: "acme/web", issue: 7 })).rejects.toThrow(/several clones.*desktop/s);
+    expect(issueWork.start).not.toHaveBeenCalled();
+  });
+
+  it("refuses a repo with no clone on this machine, and starts nothing", async () => {
+    dirs.rows = [];
+    await expect(start({ repo: "acme/web", issue: 7 })).rejects.toThrow(/No local clone of acme\/web/);
+    expect(issueWork.start).not.toHaveBeenCalled();
+  });
+
+  // A recording keyed `Acme/Web` and an entry named `acme/web` are the same repository — the two
+  // spellings reach the host from different places (hand-typed config vs. the remote URL).
+  it("matches the repo case-insensitively", async () => {
+    await start({ repo: "Acme/Web", issue: 7 });
+    expect(issueWork.start).toHaveBeenCalledWith("Acme/Web", 7, "/clones/web", expect.anything());
+  });
+
+  it.each([
+    ["a repo that is not owner/repo", { repo: "no-slash", issue: 7 }],
+    ["a missing repo", { issue: 7 }],
+    ["a missing issue number", { repo: "acme/web" }],
+    ["issue zero", { repo: "acme/web", issue: 0 }],
+    ["a non-integer issue", { repo: "acme/web", issue: 1.5 }],
+    ["an issue sent as a string", { repo: "acme/web", issue: "7" }],
+  ])("rejects %s without starting anything", async (_case, params) => {
+    await expect(start(params)).rejects.toThrow();
+    expect(issueWork.start).not.toHaveBeenCalled();
+  });
+
+  // The reason a step failed is the sentence the phone shows, so it has to survive the trip.
+  it("surfaces the reason the work could not be started", async () => {
+    issueWork.start.mockResolvedValue({ ok: false, reason: "issue-not-found", detail: "could not read acme/web#7" });
+    await expect(start({ repo: "acme/web", issue: 7 })).rejects.toThrow("could not read acme/web#7");
+  });
+
+  it("passes the spawner through, so the session is the one the host started", async () => {
+    issueWork.start.mockImplementation(async (_repo: string, _issue: number, _dir: string, deps: { spawnDraft: (cwd: string, draft: string) => string }) => ({
+      ok: true,
+      sessionId: deps.spawnDraft("/wt/thing", "GitHub issue #7"),
+      branch: "issue/7-thing",
+    }));
+    const answer = await start({ repo: "acme/web", issue: 7 });
+    expect(spawnIssueDraft).toHaveBeenCalledWith("/wt/thing", "GitHub issue #7");
+    expect(answer).toMatchObject({ sessionId: "s-1" });
+  });
+});
+
+describe("listIssues (phone)", () => {
+  beforeEach(() => {
+    issues.rows = [
+      {
+        repo: "acme/web",
+        issues: [{ number: 7, title: "The thing", author: "isamu", updatedAt: "2026-08-01T00:00:00Z", url: "https://github.com/acme/web/issues/7" }],
+      },
+    ];
+    dirs.rows = [repoDirs(["/clones/web"], "/clones/web")];
+  });
+
+  it("answers the configured repos' issues, marked as startable", async () => {
+    const answer = await list();
+    expect(answer).toMatchObject({ repos: [{ repo: "acme/web", canStart: true, issues: [{ number: 7, title: "The thing" }] }] });
+    // Absent, not empty: the phone renders a reason it is given, so "" would be a reason nobody wrote.
+    expect(Object.keys((answer as { repos: object[] }).repos[0])).not.toContain("startBlocked");
+  });
+
+  it("marks a repo whose clone has not been chosen as not startable, with the reason", async () => {
+    dirs.rows = [repoDirs(["/clones/web", "/clones/web2"])];
+    const answer = await list();
+    expect(answer).toMatchObject({ repos: [{ repo: "acme/web", canStart: false, startBlocked: expect.stringMatching(/several clones/) }] });
+  });
+
+  it("marks a repo with no clone here as not startable, with the reason", async () => {
+    dirs.rows = [];
+    const answer = await list();
+    expect(answer).toMatchObject({ repos: [{ repo: "acme/web", canStart: false, startBlocked: expect.stringMatching(/No local clone/) }] });
+  });
+
+  // A repo whose `gh issue list` failed still has to come back — the phone shows the per-repo error
+  // rather than dropping the repo, exactly as the desktop list does.
+  it("keeps a repo that could not be read, error and all", async () => {
+    issues.rows = [{ repo: "acme/web", error: "gh issue list failed" }];
+    const answer = await list();
+    expect(answer).toMatchObject({ repos: [{ repo: "acme/web", error: "gh issue list failed", canStart: true }] });
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -574,6 +574,16 @@ const remoteHostSpawnChat = (message: string) => {
   markUnplacedSession(sessionId);
   return { chatId: sessionId };
 };
+// Starting work on an issue from the phone (#1184). The same spawn the desktop's POST
+// /api/issues/start makes — a working session in a repository, so the project's own MCP servers
+// load instead of being replaced by the GUI one — plus the unplaced mark for the same reason as
+// above: the phone has no grid, so nothing else would give this session a cell.
+const remoteHostSpawnIssueDraft = (cwd: string, draft: string): string => {
+  const sessionId = randomUUID();
+  spawnClaudePty(sessionId, null, null, { cwd, draft, attachGuiMcp: false });
+  markUnplacedSession(sessionId);
+  return sessionId;
+};
 // The phone's remote terminal view (#435). Both accessors live here because the PTY table
 // and the title/activity side-tables do; the backend only sees the two functions.
 // A live session knows what it spawned. One that outlived us has no PtyEntry left, so ask
@@ -716,6 +726,7 @@ const remoteHostLaunchTerminal = (agent: unknown, sessionId: unknown) => {
 initRemoteHostBackend({
   workspace: CLAUDE_CWD,
   spawnChat: remoteHostSpawnChat,
+  spawnIssueDraft: remoteHostSpawnIssueDraft,
   launchTerminal: remoteHostLaunchTerminal,
   listTerminalSessions: remoteHostListTerminalSessions,
   captureTerminalScreen: remoteHostCaptureTerminalScreen,

--- a/server/index.ts
+++ b/server/index.ts
@@ -632,8 +632,9 @@ const remoteHostListTerminalSessions = async () => {
     tmuxIds: tmuxListSessionIds(),
     isResumable: await resumableSessionPredicate(),
     // The phone lists the multi-terminal grid's cells, and the sessions on their way to being
-    // one — never a tmux shell that was never a cell. resumableSessionPredicate() above already
-    // awaited devTerminalSessionsHydrated, and the unplaced logs are awaited below.
+    // one — never a tmux shell that was never a cell. resumableSessionPredicate() below already
+    // awaited devTerminalSessionsHydrated, and the unplaced logs are awaited just above; a
+    // session that has only just been spawned passes `isResumable` on its live pty.
     isGridSession: isPhoneListableSession,
     // Empty title rather than the id as a fallback — buildSessionList uses "nameless"
     // to drop the long tail of finished sessions the phone can't meaningfully offer.

--- a/server/index.ts
+++ b/server/index.ts
@@ -59,14 +59,16 @@ import {
   activity,
   aiTitles,
   backgroundMarkers,
-  devTerminalSessions,
+  isPhoneListableSession,
   knownSessions,
   lastPrompts,
+  placedSessionsHydrated,
   ptys,
   sessionCwd,
   sessionMemos,
   sessionMemosHydrated,
   markUnplacedSession,
+  unplacedSessionsHydrated,
 } from "./session/registry.js";
 import { hydrateClearedTranscripts } from "./session/cleared-transcripts.js";
 import { runWithHiddenMarker } from "./session/hiddenMarker.js";
@@ -621,14 +623,18 @@ const remoteHostListTerminalSessions = async () => {
   const cwdOfSession = (id: string) => ptys.get(id)?.cwd ?? sessionCwd(id) ?? "";
   const work = await workByCwd([...new Set([...ptys.keys(), ...tmuxListSessionIds()])].map(cwdOfSession));
   await sessionMemosHydrated; // the memo IS the phone's row title when there is one
+  // Both unplaced logs, because a session waiting for a cell is one the phone may list — and the
+  // case that mark exists for is a server that restarted before any tab opened, where the answer
+  // lives only on disk.
+  await Promise.all([unplacedSessionsHydrated, placedSessionsHydrated]);
   return buildSessionList({
     liveIds: [...ptys.keys()],
     tmuxIds: tmuxListSessionIds(),
     isResumable: await resumableSessionPredicate(),
-    // The phone lists the multi-terminal grid's cells only — not the single-view chat
-    // session or a tmux shell that was never a grid cell. resumableSessionPredicate()
-    // above already awaited devTerminalSessionsHydrated, so this set is fully seeded.
-    isGridSession: (id) => devTerminalSessions.has(id),
+    // The phone lists the multi-terminal grid's cells, and the sessions on their way to being
+    // one — never a tmux shell that was never a cell. resumableSessionPredicate() above already
+    // awaited devTerminalSessionsHydrated, and the unplaced logs are awaited below.
+    isGridSession: isPhoneListableSession,
     // Empty title rather than the id as a fallback — buildSessionList uses "nameless"
     // to drop the long tail of finished sessions the phone can't meaningfully offer.
     detailOf: (id) => {

--- a/server/session/registry.ts
+++ b/server/session/registry.ts
@@ -296,6 +296,18 @@ export function unplacedSessionRows(): { id: string; agent: TerminalAgent }[] {
   return [...unplacedSessions].filter(([id]) => !placedSessions.has(id)).map(([id, agent]) => ({ id, agent }));
 }
 
+/** Whether the phone may list this session: a grid cell, or one on its way to being one.
+ *
+ *  The two halves are one question asked at two moments. `devTerminalSessions` is written by a
+ *  browser attach and by nothing else, so a session the PHONE started — the issue it just began,
+ *  the chat it just sent — is in neither set the desktop reads, and the phone would not find in
+ *  its own list the work it had started (#1184). The unplaced mark is exactly "spawned visible,
+ *  no cell yet", and it is cleared by the attach that adds the id to the other set, so a session
+ *  moves between the halves without ever being in both or in neither. */
+export function isPhoneListableSession(id: string): boolean {
+  return devTerminalSessions.has(id) || (unplacedSessions.has(id) && !placedSessions.has(id));
+}
+
 // Sessions that connected on the ALL-TOOLS MCP url (`/api/mcp/:sessionId`). That url is handed
 // out by --mcp-config and by nothing else, so reaching it is proof the session carries the whole
 // GUI MCP — including the tools that belong to no group and are therefore unreachable through a

--- a/src/components/IssueStartButton.vue
+++ b/src/components/IssueStartButton.vue
@@ -5,7 +5,7 @@
 import { computed, useTemplateRef } from "vue";
 import { useDropdownMenu } from "../composables/useDropdownMenu";
 import { useIssueStart } from "../composables/useIssueStart";
-import { issueStartBlockedReason } from "../composables/issueStartPlan";
+import { issueStartBlockedReason } from "../../common/issueStartPlan";
 import { useAppConfig } from "../composables/useAppConfig";
 import { formatCwd } from "./cwdDisplay";
 

--- a/src/composables/useIssueStart.ts
+++ b/src/composables/useIssueStart.ts
@@ -8,7 +8,7 @@
 // startCollectionChat does for the collection plugin.
 import { ref } from "vue";
 import { placeSpawnedChat } from "./useSpawnedChat";
-import { issueStartPlan, type IssueStartPlan } from "./issueStartPlan";
+import { issueStartPlan, type IssueStartPlan } from "../../common/issueStartPlan";
 import { isRecord } from "../../common/isRecord";
 import { parseRepoDirsResponse, type RepoDirs } from "../../common/repoDirs";
 

--- a/test/common/issueStartPlan.spec.ts
+++ b/test/common/issueStartPlan.spec.ts
@@ -1,8 +1,8 @@
 // What the issue row's start control can do — three outcomes, each a different thing for the
 // user to see, so each is pinned rather than left to the component.
 import { describe, it, expect } from "vitest";
-import { issueStartPlan, issueStartBlockedReason } from "../../../src/composables/issueStartPlan";
-import type { RepoDirs } from "../../../common/repoDirs";
+import { issueStartPlan, issueStartBlockedReason } from "../../common/issueStartPlan";
+import type { RepoDirs } from "../../common/repoDirs";
 
 const entry = (paths: string[], primary: string | null = null): RepoDirs => ({
   repo: "acme/web",

--- a/test/server/session/unplaced-sessions.spec.ts
+++ b/test/server/session/unplaced-sessions.spec.ts
@@ -131,6 +131,33 @@ describe("unplaced sessions", () => {
     expect(registry.unplacedSessionRows()).toEqual([]);
   });
 
+  // What the phone may list (#1184). A session it started itself is in neither set the desktop
+  // reads until a browser attaches, so without the unplaced half the phone could not find the work
+  // it had just begun. The two halves must also never both hold one id, or one session would be
+  // two rows.
+  it("lets the phone list a session it started, until and after a cell takes it", async () => {
+    const registry = await freshRegistry();
+    await Promise.all([registry.unplacedSessionsHydrated, registry.placedSessionsHydrated]);
+    expect(registry.isPhoneListableSession(A)).toBe(false);
+
+    registry.markUnplacedSession(A);
+    expect(registry.isPhoneListableSession(A)).toBe(true);
+    expect(registry.unplacedSessionRows().map((r) => r.id)).toEqual([A]);
+
+    // The attach clears the unplaced mark AND records the cell, so the answer stays true across
+    // the handover rather than blinking off between the two writes.
+    registry.markSessionPlaced(A);
+    registry.markDevTerminalSession(A);
+    expect(registry.isPhoneListableSession(A)).toBe(true);
+    expect(registry.unplacedSessionRows()).toEqual([]);
+  });
+
+  it("does not list a tmux shell that was never a cell and nobody spawned for one", async () => {
+    const registry = await freshRegistry();
+    await Promise.all([registry.unplacedSessionsHydrated, registry.placedSessionsHydrated]);
+    expect(registry.isPhoneListableSession(B)).toBe(false);
+  });
+
   it("ignores an id that is not a session id", async () => {
     const registry = await freshRegistry();
     registry.markUnplacedSession("../etc/passwd");


### PR DESCRIPTION
## Summary

スマホから issue 起点で作業を始められるようにする、その **ホスト側 API まで**（#1026 段階4 / #1014 と同じ切り方）。RemoteHost に2コマンドを足す。

| Command | Params | Answers |
|---|---|---|
| `listIssues` | — | `{ repos: [...] }` 各行に `canStart`（false のときだけ `startBlocked` の文） |
| `startIssueWork` | `repo`, `issue` | `{ started, sessionId, branch, issue }` |

設計の芯は **ディレクトリの決め方**。`startIssueWork` は **`dir` を受け取らない** — プロトコルの「The phone never sends a path」に従い、記録された primary（クローンが1つならその1つ）で始める。**複数あって未記録なら、選ばずに拒否する**。エージェントは起動した場所で走り、取り消しが効かず、スマホには「どのツリーに落ちたか」を見る手段が無いため。デスクトップで一度選べば以後ずっと通る。

`issueStartPlan` は書き直さずに `common/` へ移した。「このリポで作業を始められるか」を両ホストが決めるようになったので、答えが割れない形にしてある（違いはスマホが自分で作る — `choose` をメニューではなく拒否にする、の1点だけ）。

`launchTerminal` と違い **デスクトップのタブは要らない**。spawn はホスト自身が行い、セッションは unplaced として記録される（`registry.ts` のコメントは元々スマホを想定して書かれている / #1189, #1204）。タブが開いていればその場で、無ければ次にグリッドを開いたときにセルになる。

## Items to Confirm / Review

1. **拒否の文言**（`issueWork.ts` の `issueStartRefusal`）。スマホに出る唯一の説明なので、日本語話者が読んで次の行動が分かるか。現状は英語（既存の拒否文 `no MulmoTerminal browser is open …` に合わせた）。
2. **このマシンでは `receptron/mulmoterminal` が最初は拒否される側**です（クローンが6つあり未記録）。実設定に対して流した結果 — `mulmoclaude` / `mulmoserver` / `mulmocast-cli` は `canStart=true`、`graphai` はクローン無しで拒否、`mulmoterminal` は複数クローンで拒否。**一番使うリポでまず拒否に当たる**のは仕様どおりだが、体験として許容できるかは判断が要ります。
3. **`listIssues` に `canStart` を載せた**こと。issue 本文の表は issue 一覧だけだったが、載せないとスマホはタップして初めて拒否を知る。プロトコルの「The host decides; the phone renders」に沿えているか。
4. **同じ issue を2回始めると `issue/1184-…-2` ができる**（デスクトップと同じ）。防ぐかどうかは別 issue と判断しました。
5. **ユーザー向けガイド（`docs/guide/*/phone.md`）は更新していません** — スマホ側 UI は `receptron/mulmoserver` にまだ無く、いま書くと使えない機能を案内することになるため。開発者向けの `docs/remote-host-protocol.md` は同じコミットで更新済み。**mulmoserver 側の追随 issue は未作成**（プロトコル文書の規約どおり必要。指示があれば立てます）。

## User Prompt

> 次なにかできる？ https://github.com/receptron/mulmoterminal/issues/1184

決定を2点、対話で確認:

- 複数クローン ＋ 未記録のときの応答 → **拒否して案内文を返す**（先頭候補で黙って始める / 候補を返してスマホに選ばせる、は不採用）
- `listIssues` に「そのリポで開始できるか」を載せるか → **載せる**

## 前提はもう揃っていた

issue 本文が「これを呼べばよい」と書いていたものは #1171 / #1172 / #1173 で 3.x に入っている（`startIssueWork()` / `POST /api/issues/start` / `repo-dirs.ts`）。

**issue の「決めたいこと」2点のうち1点は、issue が書かれた後に入った #1189 / #1204 が既に答えていました** — 「スマホから始めたセッションがグリッドにどう現れるか」。`markUnplacedSession()` のコメントは *"an agent calling spawnBackgroundChat, a scheduled task, **or the phone**"* とスマホを名指ししており、`GridView.vue` は `sessions` の `created` push でも掃引します。なので新しい仕組みは足していません。

設計メモ: `plans/feat-1184-phone-issue-start.md`

## 変更

| ファイル | 内容 |
|---|---|
| `server/backends/remoteHost/handlers/issueWork.ts` | 新規。2コマンドと拒否文 |
| `server/backends/remoteHost/handlers/{deps,index}.ts` | `spawnIssueDraft` 依存とテーブル登録 |
| `server/backends/remoteHost/index.ts`, `server/index.ts` | 配線（spawn ＋ `markUnplacedSession`） |
| `common/issueStartPlan.ts` | `src/composables/` から移動（両ホストが決めるため） |
| `docs/remote-host-protocol.md` | コマンド表、開始の節、「path を送らない」規則の追記、`launchTerminal` との対比 |
| `server/backends/remoteHost/issueWork.spec.ts` | 新規 16 件 |

## 検証

**外部の ground truth に対して**（コンパイルの成功を「動いた」と報告しないため）:

- **実際の設定に対して** — 上の「Items 2」の結果。読み取りのみ、spawn はスタブ（呼ばれたら throw する形にして、拒否経路で何も起動しないことを確認）
- **ready の経路を通した** — 使い捨ての `HOME` ＋ クローンで、実際の `gh issue view 1184` を読み、`issue/1184-feat-remote-host-issue-api` の worktree が実際に切られ、spawner に渡る draft の先頭が issue のタイトル ＋ URL ＋ 本文になることを確認。**ユーザーの本物の `~/.mulmoterminal/worktrees`（既存6件）は無傷**
- **条件を変えて** — 同じ issue を2回（→ `-2`）、リポ名の大小文字違い、`dir` を送りつけた場合（無視される）

`yarn format` / `lint`（error 0）/ `typecheck` ・ `typecheck:server` ・ `typecheck:test` / `build` / `yarn test`（**7153 passed**）。

なお `@mulmoclaude/core` が 1.8.0 のまま入っていて `typecheck:server` が既存エラーを出していたので `yarn install` で package.json どおり 1.12.0 に揃えました（`yarn.lock` は不変）。

Closes #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal6
