### PR TITLE
refactor: git remote からホスト種別を返す層を足す（#981 段階1）

### DIFF
--- a/plans/refactor-981-forge-host.md
+++ b/plans/refactor-981-forge-host.md
@@ -1,0 +1,56 @@
+# refactor(#1214 / #981 段階1): git remote からホスト種別を返す層を足す
+
+## なぜ先にこれなのか
+
+`parseGithubWebUrl` が `string | null` を返し、その null が 6 箇所に伝播している。
+
+```
+server/index.ts（2）  server/config/header-context.ts  server/routes/dir-routes.ts（2）
+server/git/repo-dirs.ts  server/git/worktree-pr.ts
+```
+
+問題は **「GitLab のリポジトリだ」と「そもそも git remote が無い」が同じ null に潰れている**こと。
+どの機能もその null を「GitHub じゃないから自分は消える」と読むので、GitLab ユーザーには
+**説明ではなく沈黙**が返る。
+
+しかもその面は #981 を書いた時点より広がっている。`gh` を叩くファイルのうち 3 つが #981 の表に
+無い（`issue-work.ts` は 3.0.0 で追加、`work-comment.ts`、`branch-query.ts`）。3.0.0 の
+`repo-dirs.ts` も同じ経路なので、**新機能が同じ形で黙って無効化される**。やらない間もコストが増える。
+
+## 構造
+
+`remote-ref.ts`（git の URL 形式。ホストに無関心）の上に 1 枚だけ足す。
+
+```
+remote-ref.ts   git の URL 形式          → { host, path }
+forge-host.ts   どの forge か（今回）     → { host, kind, path, webUrl }
+gitRemote.ts    GitHub 視点の答え（既存）  → string | null
+```
+
+`parseGithubWebUrl` は `forgeOf` の上の薄いラッパーに書き換える。**6 箇所の呼び出しは変えない。**
+
+## 決めたこと
+
+- **`kind` は URL から分かるものだけ**。`github.com` / `gitlab.com` の 2 つで、それ以外は `unknown`。
+  自前ホスティングの GitLab は URL では判別できないので、**宣言する設定は入れない** —
+  それを読む GitLab 実装（#981 段階4）が無いうちは使い道が無く、先取りになる
+- **`path` は分割しない**。GitHub は `owner/repo` の 2 セグメント、GitLab はグループがネストするので
+  「何セグメントで 1 プロジェクトか」は**ホストの規則**。`webUrl` の組み立てだけが kind ごとに違う
+- **null は「読める remote が無い」だけに残す**。`unknown` と別物にすることがこのモジュールの要点
+- **UI は入れない**。「未対応です」の見せ方は #981 の未決事項（GitHub ユーザーへのノイズとの
+  トレードオフ）なので独立して決める
+
+## テスト
+
+- `forgeOf`: URL 形式 7 種すべてで kind が保たれる / gitlab.com / ネストしたグループパス /
+  GitHub の深いパスの切り詰め / 自前ホスト・codeberg が `unknown` で **null ではない** /
+  ホストの小文字化 / null になる 3 ケース
+- **既存の `parseGithubWebUrl` / `remote-ref` の spec 45 件がそのまま通ること**（振る舞い不変の証拠）
+- `/api/git-remote` が `forge` を返す・remote 無しでは `forge: null`
+
+## この段階でやらないこと
+
+- forge インターフェイス（#981 段階2）
+- 語彙の中立化（#981 段階3）
+- GitLab 実装 / `glab`（#981 段階4）— `glab` のコマンド体系はこの環境で未検証
+- doctor と設定の追随（#981 段階5）

--- a/server/config/header-context.ts
+++ b/server/config/header-context.ts
@@ -10,7 +10,7 @@ import { mergeHeaderConfig, type HeaderConfig, type HeaderContext } from "./head
 import { loadDirConfig } from "./dir-config.js";
 import { isStrictlyWithin } from "../infra/path-within.js";
 import { parseRemoteRef } from "../git/remote-ref.js";
-import { GITHUB_HOST } from "../git/gitRemote.js";
+import { GITHUB_HOST } from "../git/forge-host.js";
 
 const WORKTREES_ROOT = path.join(os.homedir(), ".mulmoterminal", "worktrees");
 

--- a/server/git/forge-host.ts
+++ b/server/git/forge-host.ts
@@ -1,0 +1,54 @@
+// Which FORGE a git remote points at — the layer between "what the URL says" (remote-ref.ts, pure
+// git) and "what we can do with it" (the gh-backed features). #981 step 1.
+//
+// It exists because `parseGithubWebUrl` answers one question with `string | null`, which collapses
+// two very different situations into the same value: "this is a GitLab repo" and "this directory
+// has no origin at all". Every feature downstream reads that null as "no GitHub here" and removes
+// itself, so a GitLab user gets silence rather than an explanation — and the surface doing that
+// keeps growing (three more `gh` call sites arrived after #981 was written).
+//
+// Nothing here decides what to SHOW. Splitting the question from the answer is the point: the
+// showing is a separate decision, and one this repo has not made yet.
+import { parseRemoteRef, topSegments } from "./remote-ref.js";
+
+export type ForgeKind = "github" | "gitlab" | "unknown";
+
+export interface RemoteForge {
+  /** Lower-cased hostname the remote points at. */
+  host: string;
+  kind: ForgeKind;
+  /** The repository path, whole. How many segments name a project is the host's rule, not git's. */
+  path: string;
+  /** The repository's web page, or null when the kind is not one we know how to address. */
+  webUrl: string | null;
+}
+
+export const GITHUB_HOST = "github.com";
+const GITLAB_HOST = "gitlab.com";
+
+// Only the hosts we can name from the URL alone. A self-hosted GitLab at `git.example.com` is
+// indistinguishable from anything else here and comes out `unknown` — declaring those needs config,
+// which belongs with the GitLab implementation that would read it rather than ahead of it.
+const KNOWN_HOSTS: Readonly<Record<string, ForgeKind>> = { [GITHUB_HOST]: "github", [GITLAB_HOST]: "gitlab" };
+
+// GitHub: a project is exactly `owner/repo`, so a deeper path is truncated to it.
+const GITHUB_PATH_SEGMENTS = 2;
+
+// GitLab nests groups (`group/subgroup/project`), so the whole path names the project and there is
+// no segment count to apply.
+function webUrlFor(kind: ForgeKind, host: string, path: string): string | null {
+  if (kind === "github") {
+    const repo = topSegments(path, GITHUB_PATH_SEGMENTS);
+    return repo ? `https://${host}/${repo}` : null;
+  }
+  if (kind === "gitlab") return `https://${host}/${path}`;
+  return null;
+}
+
+/** What forge a remote URL points at, or null when it is not a remote URL we can read at all. */
+export function forgeOf(remoteUrl: string): RemoteForge | null {
+  const ref = parseRemoteRef(remoteUrl);
+  if (!ref) return null;
+  const kind = KNOWN_HOSTS[ref.host] ?? "unknown";
+  return { host: ref.host, kind, path: ref.path, webUrl: webUrlFor(kind, ref.host, ref.path) };
+}

--- a/server/git/gitRemote.ts
+++ b/server/git/gitRemote.ts
@@ -1,17 +1,17 @@
 import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
 import { resolveDirRequest } from "../files/dirRequest.js";
-import { forgeOf, GITHUB_HOST, type RemoteForge } from "./forge-host.js";
+import { forgeOf, type RemoteForge } from "./forge-host.js";
 
-export { GITHUB_HOST };
+// The GitHub view of a forge lookup — the shape this module's callers have always read. A remote
+// on any other host has no GitHub URL, which is exactly what they treat as "not a GitHub repo".
+const githubUrlOf = (forge: RemoteForge | null): string | null => (forge?.kind === "github" ? forge.webUrl : null);
 
-// The GitHub view of a remote: its repository web URL, or null when the remote isn't on
-// github.com. Which host a remote points at — and that a GitHub project is exactly `owner/repo`
-// while a GitLab one nests — now lives in forge-host.ts (#981 step 1); this stays as the
-// GitHub-shaped answer its six callers already read, so none of them change.
+// Which host a remote points at — and that a GitHub project is exactly `owner/repo` while a GitLab
+// one nests — lives in forge-host.ts (#981 step 1). This stays as the GitHub-shaped answer its six
+// callers already read, so none of them change.
 export function parseGithubWebUrl(remoteUrl: string): string | null {
-  const forge = forgeOf(remoteUrl);
-  return forge?.kind === "github" ? forge.webUrl : null;
+  return githubUrlOf(forgeOf(remoteUrl));
 }
 
 // Read the dir's `origin` remote. Null when the dir isn't a git repo, has no origin, or git is
@@ -36,8 +36,7 @@ export async function resolveRemoteForge(dir: string): Promise<RemoteForge | nul
 
 // Kept for the callers that only ever wanted the GitHub URL.
 export async function resolveGithubUrl(dir: string): Promise<string | null> {
-  const forge = await resolveRemoteForge(dir);
-  return forge?.kind === "github" ? forge.webUrl : null;
+  return githubUrlOf(await resolveRemoteForge(dir));
 }
 
 interface GitRemoteOptions {
@@ -56,7 +55,8 @@ export function mountGitRemoteRoute(app: Express, { isAllowedOrigin }: GitRemote
   app.post("/api/git-remote", async (req: Request, res) => {
     const dir = resolveDirRequest(req, res, isAllowedOrigin);
     if (!dir) return;
+    // One lookup for both fields: resolveGithubUrl would spawn git a second time for the same dir.
     const forge = await resolveRemoteForge(dir);
-    res.json({ githubUrl: forge?.kind === "github" ? forge.webUrl : null, forge });
+    res.json({ githubUrl: githubUrlOf(forge), forge });
   });
 }

--- a/server/git/gitRemote.ts
+++ b/server/git/gitRemote.ts
@@ -1,49 +1,62 @@
 import type { Express, Request } from "express";
 import { spawn } from "node:child_process";
 import { resolveDirRequest } from "../files/dirRequest.js";
-import { parseRemoteRef, topSegments } from "./remote-ref.js";
+import { forgeOf, GITHUB_HOST, type RemoteForge } from "./forge-host.js";
 
-// Convert a git remote URL to its GitHub repository web URL, or null when the remote isn't on
-// github.com. Pure (no I/O) so it's exhaustively unit-tested.
-//
-// The URL FORMS a remote can take live in remote-ref.ts — they belong to git, not to GitHub
-// (#981). What is GitHub's own is the two rules here: the host, and that a project is exactly
-// two path segments (owner/repo), so a deeper path is truncated rather than rejected.
-export const GITHUB_HOST = "github.com";
-const GITHUB_PATH_SEGMENTS = 2;
+export { GITHUB_HOST };
 
+// The GitHub view of a remote: its repository web URL, or null when the remote isn't on
+// github.com. Which host a remote points at — and that a GitHub project is exactly `owner/repo`
+// while a GitLab one nests — now lives in forge-host.ts (#981 step 1); this stays as the
+// GitHub-shaped answer its six callers already read, so none of them change.
 export function parseGithubWebUrl(remoteUrl: string): string | null {
-  const ref = parseRemoteRef(remoteUrl);
-  if (!ref || ref.host !== GITHUB_HOST) return null;
-  const repo = topSegments(ref.path, GITHUB_PATH_SEGMENTS);
-  return repo ? `https://${GITHUB_HOST}/${repo}` : null;
+  const forge = forgeOf(remoteUrl);
+  return forge?.kind === "github" ? forge.webUrl : null;
 }
 
-// Read the dir's `origin` remote and map it to a GitHub web URL (null if the dir
-// isn't a git repo, has no origin, git is missing, or origin isn't GitHub).
-export function resolveGithubUrl(dir: string): Promise<string | null> {
+// Read the dir's `origin` remote. Null when the dir isn't a git repo, has no origin, or git is
+// missing — the three ways there is no remote to speak of, which are not the same as a remote we
+// do not support.
+function readOriginUrl(dir: string): Promise<string | null> {
   return new Promise((resolve) => {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- 'git' is a standard tool resolved from PATH in this local dev server; dir is passed via -C as a separate argv (no shell)
     const child = spawn("git", ["-C", dir, "config", "--get", "remote.origin.url"], { stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     child.stdout.on("data", (chunk) => (out += chunk.toString()));
     child.on("error", () => resolve(null)); // git not installed
-    child.on("close", () => resolve(parseGithubWebUrl(out)));
+    child.on("close", () => resolve(out.trim() || null));
   });
+}
+
+/** Which forge this dir's `origin` points at, or null when it has no readable remote. */
+export async function resolveRemoteForge(dir: string): Promise<RemoteForge | null> {
+  const url = await readOriginUrl(dir);
+  return url ? forgeOf(url) : null;
+}
+
+// Kept for the callers that only ever wanted the GitHub URL.
+export async function resolveGithubUrl(dir: string): Promise<string | null> {
+  const forge = await resolveRemoteForge(dir);
+  return forge?.kind === "github" ? forge.webUrl : null;
 }
 
 interface GitRemoteOptions {
   isAllowedOrigin: (origin: string | undefined, remoteAddress: string | undefined) => boolean;
 }
 
-// POST /api/git-remote { path } -> { githubUrl: string | null }. Lets the browser
-// (which can't read the filesystem) learn whether a cell's working dir is a
-// GitHub repo, and where its repository page is. Same-origin guarded like the
-// other local-only routes.
+// POST /api/git-remote { path } -> { githubUrl: string | null, forge: RemoteForge | null }.
+// Lets the browser (which can't read the filesystem) learn whether a cell's working dir is a
+// GitHub repo, and where its repository page is. Same-origin guarded like the other local-only
+// routes.
+//
+// `forge` is the same lookup without the GitHub assumption, so a caller can tell a repo on a forge
+// we do not support from a directory with no remote at all — `githubUrl` is null for both. Nothing
+// reads it yet (#981 step 1 is the model; what to show is a separate decision).
 export function mountGitRemoteRoute(app: Express, { isAllowedOrigin }: GitRemoteOptions) {
   app.post("/api/git-remote", async (req: Request, res) => {
     const dir = resolveDirRequest(req, res, isAllowedOrigin);
     if (!dir) return;
-    res.json({ githubUrl: await resolveGithubUrl(dir) });
+    const forge = await resolveRemoteForge(dir);
+    res.json({ githubUrl: forge?.kind === "github" ? forge.webUrl : null, forge });
   });
 }

--- a/test/server/git/forge-host.spec.ts
+++ b/test/server/git/forge-host.spec.ts
@@ -1,0 +1,75 @@
+// Which forge a remote points at. The distinction this layer exists to make is the one
+// `parseGithubWebUrl` cannot: "a repo we do not support" vs "no remote at all" — both of which the
+// GitHub-shaped answer reports as null (#981).
+import { describe, it, expect } from "vitest";
+import { forgeOf, type ForgeKind } from "../../../server/git/forge-host.js";
+
+describe("forgeOf", () => {
+  // The URL forms belong to git and are covered by remote-ref.spec; what matters here is that the
+  // kind survives every one of them, since a user's remote could be written any of these ways.
+  it.each([
+    ["scp-like SSH", "git@github.com:owner/repo.git"],
+    ["scp-like without .git", "git@github.com:owner/repo"],
+    ["ssh:// URL", "ssh://git@github.com/owner/repo.git"],
+    ["ssh:// with a port", "ssh://git@github.com:22/owner/repo.git"],
+    ["https", "https://github.com/owner/repo.git"],
+    ["https with credentials", "https://user:token@github.com/owner/repo.git"],
+    ["git://", "git://github.com/owner/repo.git"],
+  ])("reads github from a %s remote", (_form, url) => {
+    expect(forgeOf(url)).toMatchObject({ host: "github.com", kind: "github", webUrl: "https://github.com/owner/repo" });
+  });
+
+  it("reads gitlab.com", () => {
+    expect(forgeOf("git@gitlab.com:group/project.git")).toMatchObject({ host: "gitlab.com", kind: "gitlab" });
+  });
+
+  // The whole reason `path` is not split here: GitLab nests groups, so the project is the whole
+  // path, while GitHub's is exactly the first two segments.
+  it("keeps a nested GitLab group path whole", () => {
+    expect(forgeOf("git@gitlab.com:group/sub/project.git")).toMatchObject({ path: "group/sub/project", webUrl: "https://gitlab.com/group/sub/project" });
+  });
+
+  it("truncates a deeper GitHub path to owner/repo", () => {
+    expect(forgeOf("https://github.com/owner/repo/tree/main")).toMatchObject({ path: "owner/repo/tree/main", webUrl: "https://github.com/owner/repo" });
+  });
+
+  // The case that motivates the layer. A self-hosted forge is indistinguishable from any other
+  // host by URL alone, so it is `unknown` — but it is NOT null, which is what lets a caller say
+  // "this remote is on a host we do not support" instead of saying nothing.
+  it.each([
+    ["a self-hosted forge", "git@git.example.com:team/project.git"],
+    ["a codeberg remote", "https://codeberg.org/owner/repo.git"],
+  ])("reports %s as unknown rather than nothing", (_case, url) => {
+    const forge = forgeOf(url);
+    expect(forge).not.toBeNull();
+    expect(forge?.kind).toBe("unknown");
+    // No URL is invented for a host whose layout we do not know.
+    expect(forge?.webUrl).toBeNull();
+  });
+
+  it("keeps the host so an unsupported remote can be named", () => {
+    expect(forgeOf("git@git.example.com:team/project.git")?.host).toBe("git.example.com");
+  });
+
+  it("lower-cases the host, so a shouted remote is still recognised", () => {
+    expect(forgeOf("git@GitHub.COM:owner/repo.git")).toMatchObject({ host: "github.com", kind: "github" });
+  });
+
+  // Null is reserved for "there is no remote here to read", which is what the callers treat as
+  // "not a repo" — keeping it distinct from `unknown` is the point of the whole module.
+  it.each([
+    ["an empty string", ""],
+    ["whitespace", "   "],
+    ["something that is not a URL", "not a remote"],
+  ])("returns null for %s", (_case, url) => {
+    expect(forgeOf(url)).toBeNull();
+  });
+
+  it("has no host that maps to a kind it cannot build a URL for", () => {
+    const known: ForgeKind[] = ["github", "gitlab"];
+    known.forEach((kind) => {
+      const url = kind === "github" ? "git@github.com:o/r.git" : "git@gitlab.com:o/r.git";
+      expect(forgeOf(url)?.webUrl).toBeTruthy();
+    });
+  });
+});

--- a/test/server/git/gitRemote.spec.ts
+++ b/test/server/git/gitRemote.spec.ts
@@ -158,4 +158,23 @@ describe("mountGitRemoteRoute (POST /api/git-remote)", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // The pair `githubUrl` cannot express (#981 step 1): a repo on a forge we do not support and a
+  // directory with no remote both answer null there, and only `forge` tells them apart.
+  it("reports the forge alongside the GitHub URL", async () => {
+    const res = makeRes();
+    await captureHandler(allow)({ headers: {}, body: { path: process.cwd() } }, res);
+    expect(res.payload).toMatchObject({ forge: { host: "github.com", kind: "github" } });
+  });
+
+  it("reports forge: null for a directory with no remote", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "gitremote-"));
+    try {
+      const res = makeRes();
+      await captureHandler(allow)({ headers: {}, body: { path: dir } }, res);
+      expect(res.payload).toMatchObject({ githubUrl: null, forge: null });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

#981 の**段階1**。「これが無いと他がどこも始まらない」と #981 が書いている土台だけを入れます。
**振る舞いは1つも変わりません。**

`parseGithubWebUrl` は `string | null` を返し、その null が 6 箇所に伝播しています。問題は
**「GitLab のリポジトリだ」と「そもそも git remote が無い」が同じ null に潰れている**こと。
どの機能もそれを「GitHub じゃないから自分は消える」と読むので、他 forge のユーザーには
**説明ではなく沈黙**が返ります。

`remote-ref.ts`（git の URL 形式。ホストに無関心）の上に 1 枚だけ足しました。

```
remote-ref.ts   git の URL 形式          → { host, path }
forge-host.ts   どの forge か（今回）     → { host, kind, path, webUrl }
gitRemote.ts    GitHub 視点の答え（既存）  → string | null
```

## Items to Confirm / Review

### 振る舞い不変の証拠

`parseGithubWebUrl` を `forgeOf` の薄いラッパーに書き換えましたが、**6 箇所の呼び出しは 1 行も
変えていません**。そして **既存 45 テスト（`gitRemote.spec` / `remote-ref.spec`）が無改変で通ります**。
これがレビューで一番見てほしい点です。

### 意図的に入れなかったもの

先取りを避けるため、次を**入れていません**。

1. **UI 表示。** 「このリモートは未対応です」の見せ方は #981 が未決事項として挙げていて、
   **GitHub ユーザー（＝今の全員）へのノイズとのトレードオフ**があります。事実を持つことと
   見せ方を決めることを分けました
2. **自前ホスティングの宣言設定。** `git.example.com` が GitLab だと宣言する仕組みは、それを読む
   GitLab 実装（#981 段階4）が無いうちは使い道がありません
3. **forge インターフェイス**（段階2）、**語彙の中立化**（段階3）

### `path` を分割していません

GitHub のプロジェクトは `owner/repo` の 2 セグメント、GitLab はグループがネストします
（`group/sub/project`）。**何セグメントで 1 プロジェクトかはホストの規則**なので、`path` は丸ごと
持ち、`webUrl` の組み立てだけを kind ごとに分けました。

### #981 の棚卸しは古くなっていました

調べたところ、`gh` を叩くファイルのうち **3 つが #981 の表に載っていません** —
`issue-work.ts`（3.0.0 で追加）、`work-comment.ts`、`branch-query.ts`。さらに 3.0.0 の
`repo-dirs.ts` も `resolveGithubUrl` を通るので、**新機能が同じ形で黙って無効化されます**。
**やらない間もコストが増える**、というのがこの段階を先に入れる理由です。

## User Prompt

> gitlabサポートできる？ / #981 の段階1を！できる限り１つ１つすすめよう

## テスト

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` /
`test` / `knip` — **すべて終了コードで確認**。

- `forgeOf` 18 件: URL 形式 7 種すべてで kind が保たれる / gitlab.com / ネストしたグループパス /
  GitHub の深いパスの切り詰め / 自前ホスト・codeberg が **`unknown` で null ではない** /
  ホストの小文字化 / null になる 3 ケース
- `/api/git-remote` 2 件: `forge` を返す / remote 無しでは `forge: null`
- **既存 45 件が無改変で通過**

Fixes #1214

refs #981

work in mulmoterminal4
