### PR TITLE
feat: Antigravity の会話を cwd 単位で一覧する API (#1096)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,7 +1167,7 @@ quietly answering about the **default workspace** (#1151):
 | --- | --- |
 | `/ws`, `/ws/codex`, `/ws/antigravity`, `/ws/launch`, `/ws/run` | The socket is closed with `{ type: "error", message }`, which the terminal shows as a red banner and does not retry. |
 | A session that is still running (`?session=` names a live PTY or a surviving tmux session) | **Attaches anyway**, with a warning in the server log. Moving or renaming a directory must not shut you out of an agent that is still working in it — and the cwd reported back comes from the running PTY, not from the request. |
-| `GET /api/scripts`, `/api/skills`, `/api/dir-config`, `/api/dir-sound`, `/api/git-status`, `/api/pr-phase`, `/api/header`, `/api/sessions`, `/api/codex/sessions`, `/api/session/:id`, `/api/transcript/*`, `/api/cost` | `404 { error, cwd }` — a directory that is not there. |
+| `GET /api/scripts`, `/api/skills`, `/api/dir-config`, `/api/dir-sound`, `/api/git-status`, `/api/pr-phase`, `/api/header`, `/api/sessions`, `/api/codex/sessions`, `/api/antigravity/sessions`, `/api/session/:id`, `/api/transcript/*`, `/api/cost` | `404 { error, cwd }` — a directory that is not there. |
 | A `?cwd=` that cannot name a directory at all (relative, or repeated as `?cwd=a&cwd=b`) | `400 { error, cwd }`. |
 
 A request that names **no** directory is unaffected: `CLAUDE_CWD` is then the answer it
@@ -1288,6 +1288,7 @@ same-origin-guarded.
 | -------- | ------- |
 | `GET /api/session/:id?cwd=` | One session's summary — cumulative `usage` and `context` (model + last-turn context tokens). Backs the cell token & ctx% badges. |
 | `GET /api/codex/sessions?cwd=` | Codex sessions for the project (from `~/.codex` rollouts), newest first. |
+| `GET /api/antigravity/sessions?cwd=` | Antigravity conversations for the project, newest first. agy records no workspace against a conversation, so the project comes from MulmoTerminal's own `~/.mulmoterminal/antigravity-conversations.jsonl`; agy's transcript supplies the title. |
 | `GET /api/cost?cwd=&session=` | Estimated $ cost — session / today / month. |
 | `GET /api/transcript/timeline?session=&cwd=` | Per-session activity timeline (tools run). |
 | `GET /api/transcript/last-turn?session=&cwd=&agent=` | A session's last completed exchange (`prompt`, `reply`) plus the `text` to paste into another terminal. `agent=codex` reads the codex rollout instead of the Claude transcript. |

--- a/README.md
+++ b/README.md
@@ -1288,7 +1288,7 @@ same-origin-guarded.
 | -------- | ------- |
 | `GET /api/session/:id?cwd=` | One session's summary — cumulative `usage` and `context` (model + last-turn context tokens). Backs the cell token & ctx% badges. |
 | `GET /api/codex/sessions?cwd=` | Codex sessions for the project (from `~/.codex` rollouts), newest first. |
-| `GET /api/antigravity/sessions?cwd=` | Antigravity conversations for the project, newest first. agy records no workspace against a conversation, so the project comes from MulmoTerminal's own `~/.mulmoterminal/antigravity-conversations.jsonl`; agy's transcript supplies the title. |
+| `GET /api/antigravity/sessions?cwd=` | Antigravity conversations for the project, newest first. agy does record a workspace, but never as a complete conversation-to-workspace map (`cache/last_conversations.json` keeps one conversation per directory and is written at exit; `history.jsonl` carries no conversation id), so the project comes from MulmoTerminal's own `~/.mulmoterminal/antigravity-conversations.jsonl`; agy's transcript supplies the title. |
 | `GET /api/cost?cwd=&session=` | Estimated $ cost — session / today / month. |
 | `GET /api/transcript/timeline?session=&cwd=` | Per-session activity timeline (tools run). |
 | `GET /api/transcript/last-turn?session=&cwd=&agent=` | A session's last completed exchange (`prompt`, `reply`) plus the `text` to paste into another terminal. `agent=codex` reads the codex rollout instead of the Claude transcript. |

--- a/plans/feat-1096-antigravity-sessions-api.md
+++ b/plans/feat-1096-antigravity-sessions-api.md
@@ -1,0 +1,117 @@
+# feat: Antigravity の会話を cwd 単位で一覧する API (#1096 の残り ③)
+
+#1096 の①②（会話マッピングの永続化 / cold resume）は #1157 で着地済み。
+残っていた ③ `GET /api/antigravity/sessions?cwd=` をここで入れる。
+
+**④（`fetchAntigravitySessions()` のクライアント合流）は入れない。** 実装して検証したうえで
+オーナー判断により取り下げた。理由は下の「④ を入れない理由」を参照。
+
+## なぜ止まっていたか、なぜ今動かせるか
+
+#1157 の時点では `agy` が未インストールで、タイトルの取得元とされた
+`brain/<id>/.system_generated/logs/transcript.jsonl` の実フォーマットが確認できなかった。
+推測で JSONL パーサを書くのを避けて据え置いた。
+
+agy 1.1.9 を入れて実データで確認した。会話3件（対話モード / `-p` print モード、1行 / 複数行、
+別 cwd）で以下が一致する。
+
+```jsonc
+{ "step_index": 0, "source": "USER_EXPLICIT", "type": "USER_INPUT",
+  "status": "DONE", "created_at": "2026-08-01T09:16:59Z", "content": "..." }
+```
+
+- `type` は実測で `USER_INPUT` / `CONVERSATION_HISTORY` / `PLANNER_RESPONSE` / `CHECKPOINT`。
+- **`content` は生のユーザー入力ではない。** `<USER_REQUEST>\n…\n</USER_REQUEST>` で包まれ、
+  後ろに `<ADDITIONAL_METADATA>`（ローカル時刻）と `<USER_SETTINGS_CHANGE>`（モデル変更の説明文）
+  が続く。そのまま使うとタイトルが
+  `<USER_REQUEST> hello </USER_REQUEST> The current local time is…` になる。
+- `content` が無い行がある（`CONVERSATION_HISTORY`）。`.content` 前提のパーサは落ちる。
+- `created_at` は ISO-8601 UTC。
+
+## cwd は自前ログのまま（issue の前提は現行版では古いが、結論は変わらない）
+
+issue は「agy は cwd を記録しないので MulmoTerminal 側が持つしかない」としているが、
+agy 1.1.9 は記録している。ただし調べた4箇所とも「cwd から全会話を引く」用途には使えない。
+
+| 保存先 | cwd | title | cwd で全会話を引けるか |
+|---|---|---|---|
+| `cache/last_conversations.json` | あり（キー） | なし | 不可 — cwd ごとに最後の1件だけ。しかも**セッション終了時に書かれる**（実行中の会話は載らないことを実測） |
+| `conversations/<id>.db` の `trajectory_metadata_blob` | あり（`file://` URI + git remote/branch） | — | 可だが protobuf 解析が要る |
+| `history.jsonl` | あり（`workspace`） | あり（`display`） | 不可 — conversation id が無い。print モードでは追記されない |
+| `conversation_summaries.db` | `workspace_uris` 列あり | `title` 列あり | **CLI が書かない**（IDE 由来の行だけ） |
+
+よって cwd の出所は #1157 で入った `~/.mulmoterminal/antigravity-conversations.jsonl` のまま。
+transcript はタイトルと mtime のためだけに読む。
+
+## 実測で決めた挙動
+
+- **最初のユーザー入力があるまで brain ディレクトリは作られない**（tmux で agy を起動して 12 秒
+  放置し、ディレクトリが増えないことを確認）。入力を送った直後に
+  ディレクトリと transcript が両方できる。よって「ディレクトリはあるが transcript が無い」は
+  agy が作る状態ではない。
+- それでも transcript が読めない行を**落とさず**、会話ディレクトリが存在する限り既定タイトルで
+  残す。agy が transcript の位置を変えたときに一覧が黙って全滅するより、名前が既定に落ちる方が
+  マシで、この issue の目的（見つけられること・再開できること）は満たせる。
+
+## 変更
+
+### server
+
+- `server/agents/antigravity-sessions.ts`（新規、`codex-sessions.ts` と対）
+  - `antigravityTranscriptPath(root, id)`
+  - `antigravityTitleFromTranscriptHead(head)` — 先頭 64KB から最初の `USER_INPUT` を拾い、
+    `<USER_REQUEST>` の中身だけを取る。ラッパーが無い形式に変わった場合は既知のメタデータ
+    ブロックだけ落として残りを使う。
+  - `listAntigravitySessions(root, records, cwd, limit)` — 自前ログのレコードを cwd で絞り、
+    conversationId で重複排除し、実在するものだけを transcript の title/mtime 付きで返す。
+- `server/agents/antigravity-session.ts` の `listAntigravitySessions` を
+  **`listAntigravityConversationIds` に改名**。新旧で名前が衝突するため。codex 側も
+  singular は `listRecentRollouts`（エージェント自身の名詞）、plural が `listCodexSessions` に
+  なっていて、その対応に揃える。
+- `server/routes/session-routes.ts` に `GET /api/antigravity/sessions` を追加。
+  `/api/codex/sessions` と同じ形（`?cwd=`、既定は `CLAUDE_CWD`、`{ cwd, sessions }`）。
+  codex と違い **`await antigravityConversationsHydrated` が要る** — 起動直後のリクエストが
+  ハイドレート前の空マップを見ると、一覧が空で返ってしまう。
+
+### client
+
+変更なし。理由は次節。
+
+## ④ を入れない理由
+
+issue の④は「サイドバーの一覧に合流させる」ものだが、**その単一ビューと `Sidebar.vue` は
+#1201 / #1202 で削除済み**（4.0.0）。現在 `useSessions()` の利用者は `App.vue` の1箇所だけで、
+用途はファビコンの色のみ。つまり④を入れても見えるものは何も変わらない。
+
+これは agy 固有ではなく codex も同じ状態で、`/api/codex/sessions` の結果もどの一覧にも出ていない。
+
+| UI | 出所 | codex / agy を含むか |
+|---|---|---|
+| ランチャーの "or resume here" | `/api/sessions?cwd=` のみ | 含まない |
+| コックピット・ロスター | グリッドのセル | 含まない |
+| ファビコン | `useSessions()` | 含む（唯一の利用者） |
+
+見える導線を作るならランチャーの resume 一覧が候補だが、codex の挙動も変わるためこの issue の
+範囲外。API（③）だけ先に入れておけば、一覧 UI を作るときに agy がそのまま乗る。
+
+**一覧 UI を作る人への申し送り**: `useFaviconState.ts:69` は権威リストの `working:false` で
+ライブの活動状態を上書きする。一覧から会話を再開すると conversation id がセッションキーになる
+ため、実行中セッションのファビコンが idle に戻り得る。いま一覧 UI が無いので到達不能だが、
+UI を戻した時点で顕在化する（codex も同様）。
+
+## テスト
+
+- `test/server/agents/antigravity-sessions.spec.ts`
+  - `<USER_REQUEST>` の中身だけがタイトルになる（メタデータが混ざらない）
+  - 複数行プロンプトが1行に畳まれる / 60文字で切られる
+  - `content` の無い行、壊れた行、途中で切れた最終行を飛ばす
+  - ラッパーが無い content でもメタデータブロックだけ落として使う
+  - `USER_INPUT` が無ければ既定タイトル
+  - cwd で絞る / conversationId で重複排除 / 実在しない会話を落とす / mtime 降順 / limit
+  - transcript が読めない会話はディレクトリがある限り既定タイトル + `startedAt` で残る
+- 既存 `test/server/agents/antigravity-session.spec.ts` は改名に追従。
+
+## やらないこと
+
+- codex の `codexRolloutIds` もメモリのみで同じ再起動制約がある（#1157 のコメント参照）が、
+  この issue は antigravity 限定なのでスコープ外。

--- a/server/agents/antigravity-session.ts
+++ b/server/agents/antigravity-session.ts
@@ -23,7 +23,7 @@ export function antigravityBrainRoot(): string {
 }
 
 // One directory per conversation, named by its id. Anything else in there is not a conversation.
-export function listAntigravitySessions(root: string): string[] {
+export function listAntigravityConversationIds(root: string): string[] {
   if (!existsSync(root)) return [];
   try {
     return readdirSync(root).filter((name) => UUID_RE.test(name));
@@ -40,12 +40,12 @@ export function antigravityConversationExists(root: string, id: string): boolean
 }
 
 export function snapshotAntigravitySessions(root: string = antigravityBrainRoot()): Set<string> {
-  return new Set(listAntigravitySessions(root));
+  return new Set(listAntigravityConversationIds(root));
 }
 
 // The one conversation this session created, or null while that is still ambiguous.
 export function pickFreshAntigravitySession(root: string, before: ReadonlySet<string>, claimed?: ReadonlySet<string>): string | null {
-  const found = listAntigravitySessions(root).filter((id) => !before.has(id) && !claimed?.has(id));
+  const found = listAntigravityConversationIds(root).filter((id) => !before.has(id) && !claimed?.has(id));
   return found.length === 1 ? found[0] : null;
 }
 

--- a/server/agents/antigravity-sessions.ts
+++ b/server/agents/antigravity-sessions.ts
@@ -1,5 +1,5 @@
-// agy's own conversations for a workspace — what the single view's sidebar lists so a past
-// Antigravity conversation is switchable and resumable.
+// agy's own conversations for a workspace, newest first — the per-project listing that makes a
+// past Antigravity conversation findable and resumable, mirroring `/api/codex/sessions`.
 //
 // The cwd does NOT come from agy. `codex-sessions.ts` next door filters rollouts by the cwd codex
 // records in its own session_meta; agy records a conversation's workspace in three places and none
@@ -39,7 +39,7 @@ const isUserInput = (d: Record<string, unknown>): boolean => d.type === "USER_IN
 function promptText(content: string): string {
   const wrapped = USER_REQUEST_RE.exec(content);
   // No wrapper means a shape we have not seen. Dropping the blocks we DO know keeps a usable
-  // title instead of pasting agy's metadata into the sidebar.
+  // title instead of pasting agy's metadata into the row.
   return wrapped ? wrapped[1] : content.replace(APPENDED_BLOCK_RE, "");
 }
 
@@ -74,7 +74,7 @@ function newestPerConversation(records: Iterable<AntigravityConversation>, cwd: 
  *
  * A conversation whose transcript cannot be read is kept, not dropped, as long as its directory is
  * still there: agy creates the directory and the transcript together on the first user input, so an
- * unreadable transcript means the format moved — and a sidebar that silently lists nothing is worse
+ * unreadable transcript means the format moved — and a listing that silently returns nothing is worse
  * than one showing a resumable row under a default name.
  */
 export async function listAntigravitySessions(

--- a/server/agents/antigravity-sessions.ts
+++ b/server/agents/antigravity-sessions.ts
@@ -1,0 +1,121 @@
+// agy's own conversations for a workspace — what the single view's sidebar lists so a past
+// Antigravity conversation is switchable and resumable.
+//
+// The cwd does NOT come from agy. `codex-sessions.ts` next door filters rollouts by the cwd codex
+// records in its own session_meta; agy records a conversation's workspace in three places and none
+// of them answers "every conversation in this directory": `cache/last_conversations.json` keeps
+// only the LAST conversation per cwd and is written at exit, `history.jsonl` has no conversation
+// id, and `conversation_summaries.db` has the columns but the CLI never writes a row. So the cwd
+// is read from OUR log (session/antigravity-conversations.ts) and agy's transcript is opened only
+// for a title and an mtime.
+import { open } from "node:fs/promises";
+import path from "node:path";
+import { isRecord } from "../../common/isRecord.js";
+import type { AntigravityConversation } from "../session/antigravity-conversations.js";
+import { antigravityConversationExists } from "./antigravity-session.js";
+
+const HEAD_BYTES = 64 * 1024; // the first user turn is step 0, so the head is all a title needs
+const TITLE_MAX = 60;
+const DEFAULT_TITLE = "Antigravity session";
+
+// agy wraps the prompt and appends its own blocks, so the raw `content` is not a title:
+// `<USER_REQUEST>\n…\n</USER_REQUEST>` then `<ADDITIONAL_METADATA>` (local time) and
+// `<USER_SETTINGS_CHANGE>` (a paragraph about the model the user picked).
+const USER_REQUEST_RE = /<USER_REQUEST>([\s\S]*?)<\/USER_REQUEST>/;
+const APPENDED_BLOCK_RE = /<(ADDITIONAL_METADATA|USER_SETTINGS_CHANGE)>[\s\S]*?<\/\1>/g;
+
+export interface AntigravitySessionSummary {
+  id: string;
+  title: string;
+  mtime: number;
+}
+
+export function antigravityTranscriptPath(root: string, id: string): string {
+  return path.join(root, id, ".system_generated", "logs", "transcript.jsonl");
+}
+
+function parseJsonRecord(line: string): Record<string, unknown> | null {
+  if (!line) return null;
+  try {
+    const doc: unknown = JSON.parse(line);
+    return isRecord(doc) ? doc : null;
+  } catch {
+    return null; // a truncated final line, or a non-JSON row
+  }
+}
+
+// The user's first prompt. Steps that are not user input carry no `content` at all
+// (`CONVERSATION_HISTORY`), so the type check alone is not enough.
+const isUserInput = (d: Record<string, unknown>): boolean => d.type === "USER_INPUT" && typeof d.content === "string";
+
+function promptText(content: string): string {
+  const wrapped = USER_REQUEST_RE.exec(content);
+  // No wrapper means a shape we have not seen. Dropping the blocks we DO know keeps a usable
+  // title instead of pasting agy's metadata into the sidebar.
+  return wrapped ? wrapped[1] : content.replace(APPENDED_BLOCK_RE, "");
+}
+
+function cleanTitle(raw: string | null): string {
+  const title = (raw ?? "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX);
+  return title || DEFAULT_TITLE;
+}
+
+/** The conversation's title, from the head of its transcript. */
+export function antigravityTitleFromTranscriptHead(head: string): string {
+  const first = head
+    .split("\n")
+    .map(parseJsonRecord)
+    .find((d): d is Record<string, unknown> => d !== null && isUserInput(d));
+  return cleanTitle(typeof first?.content === "string" ? promptText(first.content) : null);
+}
+
+async function readTranscriptSummary(file: string): Promise<{ title: string; mtime: number } | null> {
+  let fh;
+  try {
+    fh = await open(file, "r");
+    const buf = Buffer.alloc(HEAD_BYTES);
+    const { bytesRead } = await fh.read(buf, 0, HEAD_BYTES, 0);
+    const { mtimeMs } = await fh.stat();
+    return { title: antigravityTitleFromTranscriptHead(buf.subarray(0, bytesRead).toString("utf8")), mtime: mtimeMs };
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}
+
+// The newest record per conversation. The log only grows, so one conversation can appear under
+// several session keys (a session resumed under a new key) and the same key can appear twice.
+function newestPerConversation(records: Iterable<AntigravityConversation>, cwd: string): AntigravityConversation[] {
+  const byConversation = new Map<string, AntigravityConversation>();
+  for (const record of records) {
+    if (record.cwd !== cwd) continue;
+    const known = byConversation.get(record.conversationId);
+    if (!known || known.startedAt <= record.startedAt) byConversation.set(record.conversationId, record);
+  }
+  return [...byConversation.values()];
+}
+
+/**
+ * Antigravity conversations started in `cwd`, newest first.
+ *
+ * A conversation whose transcript cannot be read is kept, not dropped, as long as its directory is
+ * still there: agy creates the directory and the transcript together on the first user input, so an
+ * unreadable transcript means the format moved — and a sidebar that silently lists nothing is worse
+ * than one showing a resumable row under a default name.
+ */
+export async function listAntigravitySessions(
+  root: string,
+  records: Iterable<AntigravityConversation>,
+  cwd: string,
+  limit: number,
+): Promise<AntigravitySessionSummary[]> {
+  const live = newestPerConversation(records, cwd).filter((r) => antigravityConversationExists(root, r.conversationId));
+  const summaries = await Promise.all(
+    live.map(async (record) => {
+      const summary = await readTranscriptSummary(antigravityTranscriptPath(root, record.conversationId));
+      return { id: record.conversationId, title: summary?.title ?? DEFAULT_TITLE, mtime: summary?.mtime ?? record.startedAt };
+    }),
+  );
+  return summaries.sort((a, b) => b.mtime - a.mtime).slice(0, limit);
+}

--- a/server/agents/antigravity-sessions.ts
+++ b/server/agents/antigravity-sessions.ts
@@ -14,6 +14,7 @@ import { antigravityConversationExists } from "./antigravity-session.js";
 import { cleanTitle, parseJsonRecord, readTranscriptHead } from "./transcript-head.js";
 
 const HEAD_BYTES = 64 * 1024; // the first user turn is step 0, so the head is all a title needs
+const SCAN_LIMIT = 200; // newest conversations to touch the filesystem for per request
 const DEFAULT_TITLE = "Antigravity session";
 
 // agy wraps the prompt and appends its own blocks, so the raw `content` is not a title:
@@ -76,6 +77,12 @@ function newestPerConversation(records: Iterable<AntigravityConversation>, cwd: 
  * still there: agy creates the directory and the transcript together on the first user input, so an
  * unreadable transcript means the format moved — and a listing that silently returns nothing is worse
  * than one showing a resumable row under a default name.
+ *
+ * `startedAt` picks the candidates and the transcript's mtime then orders them, so a conversation
+ * started long ago but resumed yesterday can fall outside the window once a single directory holds
+ * more than `SCAN_LIMIT` of them. That is the trade codex makes too (it bounds by the timestamp in
+ * the rollout filename): nothing here can order by recency without reading, and the log grows
+ * forever, so an unbounded listing would do unbounded filesystem work on every session-list refresh.
  */
 export async function listAntigravitySessions(
   root: string,
@@ -83,7 +90,10 @@ export async function listAntigravitySessions(
   cwd: string,
   limit: number,
 ): Promise<AntigravitySessionSummary[]> {
-  const live = newestPerConversation(records, cwd).filter((r) => antigravityConversationExists(root, r.conversationId));
+  const live = newestPerConversation(records, cwd)
+    .sort((a, b) => b.startedAt - a.startedAt)
+    .slice(0, SCAN_LIMIT)
+    .filter((r) => antigravityConversationExists(root, r.conversationId));
   const summaries = await Promise.all(
     live.map(async (record) => {
       const summary = await readTranscriptSummary(antigravityTranscriptPath(root, record.conversationId));

--- a/server/agents/antigravity-sessions.ts
+++ b/server/agents/antigravity-sessions.ts
@@ -8,14 +8,12 @@
 // id, and `conversation_summaries.db` has the columns but the CLI never writes a row. So the cwd
 // is read from OUR log (session/antigravity-conversations.ts) and agy's transcript is opened only
 // for a title and an mtime.
-import { open } from "node:fs/promises";
 import path from "node:path";
-import { isRecord } from "../../common/isRecord.js";
 import type { AntigravityConversation } from "../session/antigravity-conversations.js";
 import { antigravityConversationExists } from "./antigravity-session.js";
+import { cleanTitle, parseJsonRecord, readTranscriptHead } from "./transcript-head.js";
 
 const HEAD_BYTES = 64 * 1024; // the first user turn is step 0, so the head is all a title needs
-const TITLE_MAX = 60;
 const DEFAULT_TITLE = "Antigravity session";
 
 // agy wraps the prompt and appends its own blocks, so the raw `content` is not a title:
@@ -34,16 +32,6 @@ export function antigravityTranscriptPath(root: string, id: string): string {
   return path.join(root, id, ".system_generated", "logs", "transcript.jsonl");
 }
 
-function parseJsonRecord(line: string): Record<string, unknown> | null {
-  if (!line) return null;
-  try {
-    const doc: unknown = JSON.parse(line);
-    return isRecord(doc) ? doc : null;
-  } catch {
-    return null; // a truncated final line, or a non-JSON row
-  }
-}
-
 // The user's first prompt. Steps that are not user input carry no `content` at all
 // (`CONVERSATION_HISTORY`), so the type check alone is not enough.
 const isUserInput = (d: Record<string, unknown>): boolean => d.type === "USER_INPUT" && typeof d.content === "string";
@@ -55,33 +43,18 @@ function promptText(content: string): string {
   return wrapped ? wrapped[1] : content.replace(APPENDED_BLOCK_RE, "");
 }
 
-function cleanTitle(raw: string | null): string {
-  const title = (raw ?? "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX);
-  return title || DEFAULT_TITLE;
-}
-
 /** The conversation's title, from the head of its transcript. */
 export function antigravityTitleFromTranscriptHead(head: string): string {
   const first = head
     .split("\n")
     .map(parseJsonRecord)
     .find((d): d is Record<string, unknown> => d !== null && isUserInput(d));
-  return cleanTitle(typeof first?.content === "string" ? promptText(first.content) : null);
+  return cleanTitle(typeof first?.content === "string" ? promptText(first.content) : null, DEFAULT_TITLE);
 }
 
 async function readTranscriptSummary(file: string): Promise<{ title: string; mtime: number } | null> {
-  let fh;
-  try {
-    fh = await open(file, "r");
-    const buf = Buffer.alloc(HEAD_BYTES);
-    const { bytesRead } = await fh.read(buf, 0, HEAD_BYTES, 0);
-    const { mtimeMs } = await fh.stat();
-    return { title: antigravityTitleFromTranscriptHead(buf.subarray(0, bytesRead).toString("utf8")), mtime: mtimeMs };
-  } catch {
-    return null;
-  } finally {
-    await fh?.close();
-  }
+  const read = await readTranscriptHead(file, HEAD_BYTES);
+  return read && { title: antigravityTitleFromTranscriptHead(read.head), mtime: read.mtime };
 }
 
 // The newest record per conversation. The log only grows, so one conversation can appear under

--- a/server/agents/codex-sessions.ts
+++ b/server/agents/codex-sessions.ts
@@ -1,12 +1,12 @@
 import { existsSync, readdirSync } from "node:fs";
-import { open } from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "../../common/isRecord.js";
+import { cleanTitle, parseJsonRecord, readTranscriptHead } from "./transcript-head.js";
 
 const ROLLOUT_RE = /^rollout-.*\.jsonl$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const HEAD_BYTES = 64 * 1024; // enough for session_meta + the first user turn
-const TITLE_MAX = 60;
+const DEFAULT_TITLE = "Codex session";
 const SCAN_LIMIT = 200; // newest rollout files to inspect per request
 
 export interface CodexSessionSummary {
@@ -19,16 +19,6 @@ interface RolloutHead {
   id: string;
   cwd: string | null;
   title: string;
-}
-
-function parseJsonRecord(line: string): Record<string, unknown> | null {
-  if (!line) return null;
-  try {
-    const doc: unknown = JSON.parse(line);
-    return isRecord(doc) ? doc : null;
-  } catch {
-    return null; // a truncated final line, or a non-JSON row
-  }
 }
 
 const isSessionMeta = (d: Record<string, unknown>): boolean =>
@@ -44,11 +34,6 @@ function stringField(doc: Record<string, unknown> | undefined, key: string): str
   return isRecord(payload) && typeof payload[key] === "string" ? payload[key] : null;
 }
 
-function cleanTitle(raw: string | null): string {
-  const t = (raw ?? "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX);
-  return t || "Codex session";
-}
-
 // From a rollout's head, pull the minted id + cwd (session_meta) and a title (first user message).
 // Returns null if there's no valid session_meta.
 export function parseCodexRolloutHead(head: string): RolloutHead | null {
@@ -59,7 +44,7 @@ export function parseCodexRolloutHead(head: string): RolloutHead | null {
   const meta = docs.find(isSessionMeta);
   const id = stringField(meta, "id");
   if (!id) return null;
-  return { id, cwd: stringField(meta, "cwd"), title: cleanTitle(stringField(docs.find(isUserMessage), "message")) };
+  return { id, cwd: stringField(meta, "cwd"), title: cleanTitle(stringField(docs.find(isUserMessage), "message"), DEFAULT_TITLE) };
 }
 
 function subdirsDesc(dir: string): string[] {
@@ -97,20 +82,10 @@ function recentRolloutPaths(root: string, scan: number): string[] {
 }
 
 async function readRolloutSummary(file: string): Promise<(RolloutHead & { mtime: number }) | null> {
-  let fh;
-  try {
-    fh = await open(file, "r");
-    const buf = Buffer.alloc(HEAD_BYTES);
-    const { bytesRead } = await fh.read(buf, 0, HEAD_BYTES, 0);
-    const head = parseCodexRolloutHead(buf.subarray(0, bytesRead).toString("utf8"));
-    if (!head) return null;
-    const { mtimeMs } = await fh.stat();
-    return { ...head, mtime: mtimeMs };
-  } catch {
-    return null;
-  } finally {
-    await fh?.close();
-  }
+  const read = await readTranscriptHead(file, HEAD_BYTES);
+  if (!read) return null;
+  const head = parseCodexRolloutHead(read.head);
+  return head && { ...head, mtime: read.mtime };
 }
 
 // The rollout file for this id, or null. The id is the filename suffix, so the search reads

--- a/server/agents/transcript-head.ts
+++ b/server/agents/transcript-head.ts
@@ -1,0 +1,47 @@
+// Reading a title out of the front of an agent's own JSONL transcript.
+//
+// codex rollouts and agy conversations record different things in different shapes, but the
+// listing job is the same one twice: read a bounded head (never the whole file — an agent appends
+// to these without limit), pick the first line that is a user turn, and turn it into a row title.
+import { open } from "node:fs/promises";
+import { isRecord } from "../../common/isRecord.js";
+
+const TITLE_MAX = 60;
+
+/** One JSONL line as a record, or null for a truncated final line or a non-JSON row. */
+export function parseJsonRecord(line: string): Record<string, unknown> | null {
+  if (!line) return null;
+  try {
+    const doc: unknown = JSON.parse(line);
+    return isRecord(doc) ? doc : null;
+  } catch {
+    return null;
+  }
+}
+
+/** A prompt as a single-line row title, or `fallback` when there is nothing to show. */
+export function cleanTitle(raw: string | null, fallback: string): string {
+  const title = (raw ?? "").replace(/\s+/g, " ").trim().slice(0, TITLE_MAX);
+  return title || fallback;
+}
+
+/**
+ * The first `headBytes` of a transcript plus its mtime, or null if it cannot be read.
+ *
+ * Both callers want the mtime from the SAME open handle as the head: a file the agent is still
+ * appending to can be renamed or removed between a read and a separate stat.
+ */
+export async function readTranscriptHead(file: string, headBytes: number): Promise<{ head: string; mtime: number } | null> {
+  let fh;
+  try {
+    fh = await open(file, "r");
+    const buf = Buffer.alloc(headBytes);
+    const { bytesRead } = await fh.read(buf, 0, headBytes, 0);
+    const { mtimeMs } = await fh.stat();
+    return { head: buf.subarray(0, bytesRead).toString("utf8"), mtime: mtimeMs };
+  } catch {
+    return null;
+  } finally {
+    await fh?.close();
+  }
+}

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -14,6 +14,8 @@ import {
   activity,
   activityStateHydrated,
   aiTitles,
+  antigravityConversations,
+  antigravityConversationsHydrated,
   backgroundSessionsHydrated,
   failedWorkersHydrated,
   unplacedSessionsHydrated,
@@ -44,6 +46,8 @@ import { sessionAttached } from "../session/dir-session.js";
 import { tmuxAttachedCounts } from "../infra/tmux.js";
 import { codexSessionsRoot } from "../agents/codex-session.js";
 import { listCodexSessions } from "../agents/codex-sessions.js";
+import { antigravityBrainRoot } from "../agents/antigravity-session.js";
+import { listAntigravitySessions } from "../agents/antigravity-sessions.js";
 import type { SessionMeta } from "../session/types.js";
 import { parseActivityIds, selectSessionRows } from "../session/session-list.js";
 import { sessionDetailView } from "../session/session-detail-view.js";
@@ -245,6 +249,23 @@ async function codexSessionList(req: Request, res: Response) {
   }
 }
 
+// agy's own conversations for a workspace (?cwd=, default CLAUDE_CWD). Mirrors the codex route
+// above, with one difference that is not cosmetic: the cwd comes from OUR log rather than from
+// agy, so the answer is empty until that log has been read off disk. codex needs no such wait —
+// it re-reads its rollouts on every request.
+async function antigravitySessionList(req: Request, res: Response) {
+  try {
+    const cwd = workspaceForRoute(req.query.cwd, res);
+    if (cwd === null) return;
+    await antigravityConversationsHydrated;
+    const sessions = await listAntigravitySessions(antigravityBrainRoot(), antigravityConversations.values(), cwd, SESSION_LIST_LIMIT);
+    res.json({ cwd, sessions });
+  } catch (err) {
+    console.error("[api] /api/antigravity/sessions failed:", err);
+    res.status(500).json({ error: String(err) });
+  }
+}
+
 export function mountSessionRoutes(app: Express, deps: SessionRouteDeps): void {
   app.get("/api/session/:id", (req, res) => sessionDetail(req, res, deps.freshenRosterTitle));
   app.post("/api/session/:id/memo", (req, res) => setMemo(req, res, deps.publishActivity));
@@ -276,4 +297,5 @@ export function mountSessionRoutes(app: Express, deps: SessionRouteDeps): void {
     res.json({ sessions });
   });
   app.get("/api/codex/sessions", codexSessionList);
+  app.get("/api/antigravity/sessions", antigravitySessionList);
 }

--- a/test/server/agents/antigravity-session.spec.ts
+++ b/test/server/agents/antigravity-session.spec.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import os from "node:os";
 import {
   antigravityConversationExists,
-  listAntigravitySessions,
+  listAntigravityConversationIds,
   snapshotAntigravitySessions,
   pickFreshAntigravitySession,
   watchForAntigravitySession,
@@ -30,7 +30,7 @@ describe("antigravity-session", () => {
     fs.mkdirSync(path.join(brainDir, uuid2));
     fs.mkdirSync(path.join(brainDir, "not-a-uuid"));
 
-    const sessions = listAntigravitySessions(brainDir);
+    const sessions = listAntigravityConversationIds(brainDir);
     expect(sessions).toContain(uuid1);
     expect(sessions).toContain(uuid2);
     expect(sessions).not.toContain("not-a-uuid");

--- a/test/server/agents/antigravity-sessions.spec.ts
+++ b/test/server/agents/antigravity-sessions.spec.ts
@@ -128,4 +128,18 @@ describe("listAntigravitySessions", () => {
   it("is empty when nothing ran in this cwd", async () => {
     expect(await listAntigravitySessions(brainDir, [], CWD, 50)).toEqual([]);
   });
+
+  // The log only grows and nothing prunes it, so without a bound every session-list refresh would
+  // do filesystem work proportional to every agy conversation ever started in the directory.
+  it("touches the filesystem for a bounded number of conversations", async () => {
+    const uuid = (i: number) => `${String(i).padStart(8, "0")}-1111-4111-8111-111111111111`;
+    const records = Array.from({ length: 260 }, (_, i) => record({ sessionId: uuid(i), conversationId: uuid(i), startedAt: i }));
+    // Only the newest 200 by startedAt exist on disk; the oldest 60 would each cost a lookup.
+    for (let i = 60; i < 260; i++) writeConversation(uuid(i), `prompt ${i}`, new Date((i + 1) * 1000));
+    const sessions = await listAntigravitySessions(brainDir, records, CWD, 50);
+    expect(sessions).toHaveLength(50);
+    expect(sessions[0].title).toBe("prompt 259");
+    // Every returned row was read, not defaulted — the window covers what is actually on disk.
+    expect(sessions.filter((s) => s.title === "Antigravity session")).toEqual([]);
+  });
 });

--- a/test/server/agents/antigravity-sessions.spec.ts
+++ b/test/server/agents/antigravity-sessions.spec.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { antigravityTitleFromTranscriptHead, antigravityTranscriptPath, listAntigravitySessions } from "../../../server/agents/antigravity-sessions.js";
+import type { AntigravityConversation } from "../../../server/session/antigravity-conversations.js";
+
+// Captured verbatim from agy 1.1.9 (`agy -p`), so a format change breaks this rather than
+// quietly renaming every row. The point of the fixture is the wrapping: the prompt is inside
+// <USER_REQUEST>, and agy appends two blocks of its own that must never reach the sidebar.
+const REAL_TRANSCRIPT_HEAD =
+  '{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-08-01T09:16:59Z","content":"<USER_REQUEST>\\nReply with exactly the word OK.\\nSecond line of the prompt.\\n</USER_REQUEST>\\n<ADDITIONAL_METADATA>\\nThe current local time is: 2026-08-01T18:16:59+09:00.\\n</ADDITIONAL_METADATA>\\n<USER_SETTINGS_CHANGE>\\nThe user changed setting `Model Selection` from None to Gemini 3.6 Flash (High). No need to comment on this change if the user doesn\'t ask about it. If reporting what model you are, please use a human readable name instead of the exact string.\\n</USER_SETTINGS_CHANGE>"}\n' +
+  '{"step_index":1,"source":"SYSTEM","type":"CONVERSATION_HISTORY","status":"DONE","created_at":"2026-08-01T09:16:59Z"}\n';
+
+const userInput = (content: string) => `${JSON.stringify({ step_index: 0, source: "USER_EXPLICIT", type: "USER_INPUT", status: "DONE", content })}\n`;
+
+describe("antigravityTitleFromTranscriptHead", () => {
+  it("takes only the prompt out of a real agy transcript", () => {
+    expect(antigravityTitleFromTranscriptHead(REAL_TRANSCRIPT_HEAD)).toBe("Reply with exactly the word OK. Second line of the prompt.");
+  });
+
+  it("keeps agy's appended blocks out of the title", () => {
+    const title = antigravityTitleFromTranscriptHead(REAL_TRANSCRIPT_HEAD);
+    expect(title).not.toContain("local time");
+    expect(title).not.toContain("Model Selection");
+    expect(title).not.toContain("USER_REQUEST");
+  });
+
+  it("truncates a long prompt", () => {
+    const title = antigravityTitleFromTranscriptHead(userInput(`<USER_REQUEST>\n${"x".repeat(200)}\n</USER_REQUEST>`));
+    expect(title).toHaveLength(60);
+  });
+
+  it("skips steps that carry no content", () => {
+    const head = '{"step_index":0,"type":"CONVERSATION_HISTORY","source":"SYSTEM"}\n' + userInput("<USER_REQUEST>\nthe real prompt\n</USER_REQUEST>");
+    expect(antigravityTitleFromTranscriptHead(head)).toBe("the real prompt");
+  });
+
+  it("skips a corrupt line and a truncated final line", () => {
+    const head = "not json at all\n" + userInput("<USER_REQUEST>\nfrom a good line\n</USER_REQUEST>") + '{"step_index":2,"type":"USER_IN';
+    expect(antigravityTitleFromTranscriptHead(head)).toBe("from a good line");
+  });
+
+  it("falls back to a default when there is no user input", () => {
+    expect(antigravityTitleFromTranscriptHead('{"step_index":0,"type":"PLANNER_RESPONSE","source":"MODEL","content":"hi"}\n')).toBe("Antigravity session");
+    expect(antigravityTitleFromTranscriptHead("")).toBe("Antigravity session");
+  });
+
+  it("still drops the known blocks if the request wrapper ever goes away", () => {
+    const head = userInput("bare prompt\n<ADDITIONAL_METADATA>\nThe current local time is: now.\n</ADDITIONAL_METADATA>");
+    expect(antigravityTitleFromTranscriptHead(head)).toBe("bare prompt");
+  });
+});
+
+describe("listAntigravitySessions", () => {
+  const tmpDir = path.join(os.tmpdir(), `ag-sessions-test-${Date.now()}`);
+  const brainDir = path.join(tmpDir, "brain");
+  const CWD = "/work/project";
+  const ID_A = "a4dbbf1e-9cba-4879-a84a-d397b47e4f47";
+  const ID_B = "5fd4f183-39d4-4842-8e03-114e966e7fa5";
+  const ID_C = "7c1f0f6c-2b8e-4a5a-9d3e-0f2a1b3c4d5e";
+
+  const record = (over: Partial<AntigravityConversation> = {}): AntigravityConversation => ({
+    sessionId: "11111111-1111-4111-8111-111111111111",
+    conversationId: ID_A,
+    cwd: CWD,
+    startedAt: 1000,
+    ...over,
+  });
+
+  function writeConversation(id: string, prompt: string, mtime?: Date) {
+    const file = antigravityTranscriptPath(brainDir, id);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, userInput(`<USER_REQUEST>\n${prompt}\n</USER_REQUEST>`));
+    if (mtime) fs.utimesSync(file, mtime, mtime);
+  }
+
+  beforeEach(() => fs.mkdirSync(brainDir, { recursive: true }));
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("lists a conversation with the title from its transcript", async () => {
+    writeConversation(ID_A, "fix the login bug");
+    const sessions = await listAntigravitySessions(brainDir, [record()], CWD, 50);
+    expect(sessions).toEqual([{ id: ID_A, title: "fix the login bug", mtime: expect.any(Number) }]);
+  });
+
+  it("keeps only the conversations started in this cwd", async () => {
+    writeConversation(ID_A, "mine");
+    writeConversation(ID_B, "someone else's project");
+    const records = [record(), record({ conversationId: ID_B, cwd: "/work/other" })];
+    expect(await listAntigravitySessions(brainDir, records, CWD, 50)).toEqual([expect.objectContaining({ id: ID_A })]);
+  });
+
+  it("drops a conversation agy no longer holds", async () => {
+    writeConversation(ID_A, "still here");
+    const records = [record(), record({ conversationId: ID_B, sessionId: "22222222-2222-4222-8222-222222222222" })];
+    expect(await listAntigravitySessions(brainDir, records, CWD, 50)).toEqual([expect.objectContaining({ id: ID_A })]);
+  });
+
+  it("lists one row per conversation even when several session keys map to it", async () => {
+    writeConversation(ID_A, "one conversation");
+    const records = [record({ startedAt: 1000 }), record({ sessionId: "22222222-2222-4222-8222-222222222222", startedAt: 2000 })];
+    expect(await listAntigravitySessions(brainDir, records, CWD, 50)).toHaveLength(1);
+  });
+
+  it("sorts newest first and honours the limit", async () => {
+    writeConversation(ID_A, "oldest", new Date(1_000_000));
+    writeConversation(ID_B, "middle", new Date(2_000_000));
+    writeConversation(ID_C, "newest", new Date(3_000_000));
+    const records = [
+      record({ conversationId: ID_A }),
+      record({ conversationId: ID_B, sessionId: "22222222-2222-4222-8222-222222222222" }),
+      record({ conversationId: ID_C, sessionId: "33333333-3333-4333-8333-333333333333" }),
+    ];
+    expect((await listAntigravitySessions(brainDir, records, CWD, 50)).map((s) => s.title)).toEqual(["newest", "middle", "oldest"]);
+    expect(await listAntigravitySessions(brainDir, records, CWD, 2)).toHaveLength(2);
+  });
+
+  // agy writes the directory and the transcript together on the first user input, so this is a
+  // format change, not a state agy produces. The row stays resumable rather than vanishing.
+  it("keeps a resumable row when the transcript cannot be read", async () => {
+    fs.mkdirSync(path.join(brainDir, ID_A), { recursive: true });
+    const sessions = await listAntigravitySessions(brainDir, [record({ startedAt: 4242 })], CWD, 50);
+    expect(sessions).toEqual([{ id: ID_A, title: "Antigravity session", mtime: 4242 }]);
+  });
+
+  it("is empty when nothing ran in this cwd", async () => {
+    expect(await listAntigravitySessions(brainDir, [], CWD, 50)).toEqual([]);
+  });
+});

--- a/test/server/agents/antigravity-sessions.spec.ts
+++ b/test/server/agents/antigravity-sessions.spec.ts
@@ -131,15 +131,19 @@ describe("listAntigravitySessions", () => {
 
   // The log only grows and nothing prunes it, so without a bound every session-list refresh would
   // do filesystem work proportional to every agy conversation ever started in the directory.
-  it("touches the filesystem for a bounded number of conversations", async () => {
+  //
+  // The oldest-STARTED conversations are given the newest mtimes, which is what makes this test
+  // able to fail: an implementation that reads every record would rank exactly those first, so
+  // their absence from the answer is proof that the window is applied before the filesystem.
+  it("never reads the conversations outside the newest-started window", async () => {
     const uuid = (i: number) => `${String(i).padStart(8, "0")}-1111-4111-8111-111111111111`;
+    const OUTSIDE = 60; // 260 records against a 200-wide window
     const records = Array.from({ length: 260 }, (_, i) => record({ sessionId: uuid(i), conversationId: uuid(i), startedAt: i }));
-    // Only the newest 200 by startedAt exist on disk; the oldest 60 would each cost a lookup.
-    for (let i = 60; i < 260; i++) writeConversation(uuid(i), `prompt ${i}`, new Date((i + 1) * 1000));
+    for (let i = 0; i < 260; i++) writeConversation(uuid(i), `prompt ${i}`, new Date(i < OUTSIDE ? 9_000_000 + i : 1_000_000 + i));
+
     const sessions = await listAntigravitySessions(brainDir, records, CWD, 50);
     expect(sessions).toHaveLength(50);
+    expect(sessions.filter((s) => Number(s.id.slice(0, 8)) < OUTSIDE)).toEqual([]);
     expect(sessions[0].title).toBe("prompt 259");
-    // Every returned row was read, not defaulted — the window covers what is actually on disk.
-    expect(sessions.filter((s) => s.title === "Antigravity session")).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

#1096 の残りのうち **③ `GET /api/antigravity/sessions?cwd=`** を実装します。#1157 でこれが据え置かれた理由は「`agy` が未インストールで transcript の実フォーマットを確認できず、推測でパーサを書きたくない」でした。今回 **agy 1.1.9 を実際に入れて実データで確認**したので、推測なしで書けています。

**④（`fetchAntigravitySessions()` のクライアント合流）は入れません。** 実装・検証したうえでオーナー判断により取り下げました。理由は下記「Items to Confirm」の 1 番目。

## Items to Confirm / Review

1. **④ を落とした判断** — issue の④は「サイドバーの一覧に合流させる」ものですが、**その単一ビューと `Sidebar.vue` は #1201 / #1202 で削除済み**（4.0.0）でした。現在 `useSessions()` の利用者は `App.vue` の 1 箇所だけで、用途は**ファビコンの色のみ**。④を入れても見えるものは何も変わりません。これは agy 固有ではなく **codex も同じ状態**で、`/api/codex/sessions` の結果もどの一覧にも出ていません。API を先に入れておけば、一覧 UI を作るときに agy がそのまま乗ります。

   | UI | 出所 | codex / agy を含むか |
   |---|---|---|
   | ランチャーの "or resume here" | `/api/sessions?cwd=` のみ | 含まない |
   | コックピット・ロスター | グリッドのセル | 含まない |
   | ファビコン | `useSessions()` | 含む（唯一の利用者） |

2. **一覧 UI を作るときの申し送り（このPRでは直していません）** — `useFaviconState.ts:69` は権威リストの `working:false` でライブの活動状態を上書きします。一覧から会話を再開すると conversation id がセッションキーになるため、実行中セッションのファビコンが idle に戻り得ます。いま一覧 UI が無いので到達不能ですが、UI を戻した時点で顕在化します（codex も同様）。

3. **タイトルの取り出し方** — agy の `content` は生のユーザー入力ではありません。`<USER_REQUEST>` の中身だけを取っています。ラッパーが将来消えた場合は既知のメタデータブロックだけ落として残りを使うフォールバックにしています。

4. **transcript が読めない会話を「落とさず」残す判断** — 会話ディレクトリが存在する限り既定タイトル + `startedAt` で行を残します。agy はディレクトリと transcript を最初のユーザー入力時に同時に作る（実測）ので、読めない＝フォーマットが変わったとき。一覧が黙って全滅するより、再開できる行が既定名で出る方がマシという判断です。

5. **`listAntigravitySessions` → `listAntigravityConversationIds` の改名** — 新旧で名前が衝突するため。codex 側も singular が `listRecentRollouts`（エージェント自身の名詞）、plural が `listCodexSessions` で、その対応に揃えました。

## User Prompt

- receptron/mulmoterminal#1096 に残課題があるか確認してほしい。
- `agy` はすぐ入るか。
- （インストール後）agy が入った。検証用に作った会話は消してよい。今のところ agy を使う予定はないので、どんどん検証して進めてほしい。
- ④はいらない。③だけでよい。

## agy 1.1.9 の実フォーマット（実データで確認）

会話3件（対話モード / `-p` print モード、1行 / 複数行、別 cwd）で一致:

```jsonc
{ "step_index": 0, "source": "USER_EXPLICIT", "type": "USER_INPUT",
  "status": "DONE", "created_at": "2026-08-01T09:16:59Z", "content": "..." }
```

踏むと壊れる点が3つあり、いずれも実装で対処しています。

1. **`content` は生のユーザー入力ではない。** `<USER_REQUEST>\n…\n</USER_REQUEST>` で包まれ、後ろに `<ADDITIONAL_METADATA>`（ローカル時刻）と `<USER_SETTINGS_CHANGE>`（モデル変更の説明文）が続く。そのまま使うとタイトルが `<USER_REQUEST> hello </USER_REQUEST> The current local time is…` になる。
2. **`content` が無い行がある**（`type: "CONVERSATION_HISTORY"`）。`.content` 前提のパーサは落ちる。
3. `created_at` は ISO-8601 UTC。

## cwd は自前ログのまま（issue の前提は現行版では古いが、結論は変わらない）

issue は「agy は cwd を記録しないので MulmoTerminal 側が持つしかない」としていますが、agy 1.1.9 は記録しています。ただし調べた4箇所とも「cwd から全会話を引く」用途には使えず、**結論（#1157 の自前ログを使う）は変わりません**。

| 保存先 | cwd | title | cwd で全会話を引けるか |
|---|---|---|---|
| `cache/last_conversations.json` | あり（キー） | なし | 不可 — cwd ごとに最後の1件だけ。しかも**セッション終了時に書かれる**（実行中の会話が載らないことを実測） |
| `conversations/<id>.db` の `trajectory_metadata_blob` | あり（`file://` URI + git remote/branch） | — | 可だが protobuf 解析が要る |
| `history.jsonl` | あり（`workspace`） | あり（`display`） | 不可 — conversation id が無い。print モードでは追記されない |
| `conversation_summaries.db` | `workspace_uris` 列あり | `title` 列あり | **CLI が書かない**（IDE 由来の行だけ） |

## 実装

- **`server/agents/antigravity-sessions.ts`（新規）** — `codex-sessions.ts` と対になる位置づけ。自前ログのレコードを cwd で絞り、conversationId で重複排除し、実在するものだけを transcript の title / mtime 付きで返す。transcript は先頭 64KB だけ読む（最初のユーザー入力は step 0）。
- **ルート** — codex と同型（`?cwd=`、既定は `CLAUDE_CWD`、`{ cwd, sessions }`、404 の文面も一致）。ただし **`await antigravityConversationsHydrated` が必要**。
- **`server/agents/transcript-head.ts`（新規）** — タイトル取得が codex 側と重複していた（jscpd が検出）ため、`parseJsonRecord` / `cleanTitle` / 先頭バイトと mtime の読み出しを切り出し、**codex 側も同じものを使うように変更**して重複を実際に消した。
- **README** — エンドポイント表と 404 の対象一覧に追記。

## 検証

**実データ end-to-end**（実サーバ + 実 agy の会話）:

```json
{"cwd":"/Users/isamu/ss/llm/mulmoserver","sessions":[
  {"id":"734e9324-…","title":"Reply with exactly the word OK. Second line of the prompt."},
  {"id":"4d6bb80a-…","title":"hello"}]}
```

cwd フィルタ・存在しない会話の除外・新しい順・codex と同一の 404 挙動を確認しました。ユーザーの実 `~/.mulmoterminal` には触れないよう、隔離した `HOME` と `ANTIGRAVITY_HOME` でサーバを起動しています。

**ハイドレーション待ちが飾りでないことの実証** — 28MB / 20万行のログ（実レコードを末尾に配置）で、**ガード有りなら初回応答から2件、外すと初回は0件**（しばらく後に2件）。

**自動テスト** — `test/server/agents/antigravity-sessions.spec.ts` を新設（agy 1.1.9 の出力をそのまま golden fixture として埋め込み、フォーマット変更が検知できるようにしています）。`yarn lint` 0 error、`yarn typecheck` / `typecheck:server` / `yarn build` 通過、`yarn test` **7154 passed**。

> `yarn typecheck:test` は 4 件エラーが出ますが、**`main` 時点で同じ 4 件**（calendar / googleCalendar 関連）で、このPRとは無関係です（`git stash` した clean tree で同一であることを確認）。

refs #1096

work in mulmoterminal3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for listing Antigravity sessions by working directory.
  * Session results include conversation IDs, transcript-derived titles, and modification times.
  * Results are deduplicated, ordered by activity, and support configurable limits.
  * Unreadable transcripts remain available with fallback titles.

* **Documentation**
  * Documented the new Antigravity sessions endpoint and its response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->