### PR TITLE
fix: show the Canvas's newest card instead of stacking every draw

### DIFF
--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
+import { ref, computed, watch, nextTick } from "vue";
 import { useSessionFeed } from "../composables/useSessionFeed";
 import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
 import { getPlugin } from "../plugins-registry";
 import PluginFrame from "./PluginFrame.vue";
 import { TOOL_GROUPS, groupOfTool, toolsInGroup } from "../../common/toolGroups";
 import { reconcileCollectionCard } from "../../common/collectionSeed";
+import { collapseByIdentity } from "../utils/canvasCollapse";
 
 // The GUI panel renders the toolResults produced by GUI-protocol plugins. It
 // mirrors the terminal's active session: live results arrive on that session's
@@ -37,6 +38,15 @@ const emit = defineEmits<{ toggleTools: [] }>();
 
 const results = ref<ToolResult[]>([]);
 
+// Auto-follow state. Declared HERE, above useSessionFeed: its session watcher is `immediate`, so
+// the onSessionChange below runs during that call — a declaration further down would still be in
+// its temporal dead zone when it fires.
+const scrollRef = ref<HTMLElement | null>(null);
+// True while the reader is parked at the end. Ported from MulmoClaude's StackView (#2179): a
+// reader who scrolled UP to look at an earlier card must not be yanked back down.
+const stickToBottom = ref(true);
+const NEAR_BOTTOM_THRESHOLD_PX = 80;
+
 // Deduping by uuid mirrors applyToolResultToSession.
 const { upsert } = useSessionFeed(results, {
   sessionId: () => props.sessionId,
@@ -52,7 +62,14 @@ const { upsert } = useSessionFeed(results, {
   // Drop the previous session's views the moment the session changes, rather than when its
   // replacement's history arrives: until then the panel would still be showing another cell's
   // drawings under this cell's name.
-  onSessionChange: () => (results.value = []),
+  //
+  // Re-arming the auto-follow gate is part of the same reset: having scrolled up in the cell you
+  // came from must not decide where you land in the one you switched to, and arriving on the
+  // newest card is the point of the follow.
+  onSessionChange: () => {
+    results.value = [];
+    stickToBottom.value = true;
+  },
 });
 
 // A plugin view changed its state (e.g. a form field edited / submitted). Per the
@@ -83,6 +100,54 @@ async function onUpdateResult(existing: ToolResult, update: Partial<ToolResult>)
 }
 
 const hasContent = computed(() => results.value.length > 0);
+
+// What a result IS, for the purpose of "this is the same thing you already drew". The plugin
+// decides (Registration.identityOf); the toolName prefix is added here so two plugins returning
+// the same string — a collection slug that happens to read like a path — stay separate.
+function cardIdentity(result: ToolResult): string | null {
+  const identity = getPlugin(result.toolName)?.identityOf?.(result) ?? null;
+  return identity === null ? null : `${result.toolName}:${identity}`;
+}
+
+// The cards actually rendered: one per identity, newest at that identity's newest position. See
+// canvasCollapse.ts for why the superseded ones are dropped rather than kept as members.
+const cards = computed(() => collapseByIdentity(results.value, cardIdentity));
+
+// v-for key. Keying on the IDENTITY where there is one is not just uniqueness: re-presenting a
+// collection replaces the result object, and a uuid key would make Vue tear down the view and
+// build a new one — losing the table's scroll position, its expanded rows, everything the view
+// holds internally — on every edit. Same key, same component instance, props updated.
+const cardKey = (result: ToolResult) => cardIdentity(result) ?? result.uuid;
+
+// Auto-follow. The pane never scrolled itself, so each new card landed below the fold and the
+// user had to go find it; collapsing above removes most of that, but a card can still arrive
+// under an earlier one that is still on screen. State is declared above useSessionFeed.
+function onScroll() {
+  const element = scrollRef.value;
+  if (!element) return;
+  // A programmatic jump lands AT the bottom, so it re-affirms the gate rather than cancelling it
+  // — which is why this needs no suppression flag around the scroll below.
+  stickToBottom.value = element.scrollHeight - element.scrollTop - element.clientHeight <= NEAR_BOTTOM_THRESHOLD_PX;
+}
+
+// Changes when a card is added, or when a DIFFERENT result takes the last slot (a re-presented
+// collection moving down from above). Deliberately NOT sensitive to a view persisting its own
+// state: onUpdateResult replaces the object but keeps its uuid, and following a form's every
+// keystroke back to the bottom would fight the person typing in it.
+const latestCardKey = computed(() => {
+  const list = cards.value;
+  const last = list[list.length - 1];
+  return `${list.length}:${last ? cardKey(last) : ""}:${last?.uuid ?? ""}`;
+});
+
+watch(latestCardKey, () => {
+  if (!stickToBottom.value) return;
+  // After the new card has been laid out — its height is what we are scrolling past.
+  nextTick(() => {
+    const element = scrollRef.value;
+    if (element) element.scrollTop = element.scrollHeight;
+  });
+});
 
 // What each tool produces, so the empty state says what asking for one would get rather than
 // only naming it. A Map for the same reason common/toolGroups.ts uses one, and consulted with a
@@ -174,7 +239,7 @@ const hasTools = computed(() => toolSections.value.some((section) => section.too
         <span class="material-symbols-outlined" aria-hidden="true">build</span>
       </button>
     </div>
-    <div class="flex-1 overflow-y-auto px-4 py-3 font-sans text-[14px] leading-normal text-fg">
+    <div ref="scrollRef" data-testid="canvas-scroll" class="flex-1 overflow-y-auto px-4 py-3 font-sans text-[14px] leading-normal text-fg" @scroll="onScroll">
       <!-- Unavailable outranks empty: both look like "nothing here", but only one of them is
            something the user can act on by talking to the agent. -->
       <div v-if="unavailable" data-testid="canvas-unavailable" class="text-[13px] text-dim">
@@ -213,7 +278,7 @@ const hasTools = computed(() => toolSections.value.some((section) => section.too
       </div>
       <!-- Guarded as well as cleared on session change: a stale view rendered under an
            "unavailable" heading would contradict it. -->
-      <template v-for="r in unavailable ? [] : results" :key="r.uuid">
+      <template v-for="r in unavailable ? [] : cards" :key="cardKey(r)">
         <PluginFrame
           v-if="getPlugin(r.toolName)"
           class="[&+&]:mt-4 [&+&]:border-t [&+&]:border-border [&+&]:pt-4"

--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -113,11 +113,23 @@ function cardIdentity(result: ToolResult): string | null {
 // canvasCollapse.ts for why the superseded ones are dropped rather than kept as members.
 const cards = computed(() => collapseByIdentity(results.value, cardIdentity));
 
-// v-for key. Keying on the IDENTITY where there is one is not just uniqueness: re-presenting a
-// collection replaces the result object, and a uuid key would make Vue tear down the view and
-// build a new one — losing the table's scroll position, its expanded rows, everything the view
-// holds internally — on every edit. Same key, same component instance, props updated.
-const cardKey = (result: ToolResult) => cardIdentity(result) ?? result.uuid;
+// v-for key. The UUID, deliberately — NOT the identity, which would look like the tidier choice
+// (same subject, same key, one instance kept across edits) and is the wrong one.
+//
+// The remount IS the refresh. A re-presented card is meant to show state that CHANGED, and the
+// views have no other way to learn that. The collection View reloads from a
+// `watch(activeSlug, …)`: re-presenting the same collection leaves that slug identical, so the
+// watch never fires, and MulmoTerminal does not configure the package's optional
+// `subscribeChanges` hook (see src/composables/collectionUi.ts) that would otherwise push the
+// change in. Keeping the instance therefore keeps its STALE contents — a card that collapsed to
+// "the newest" while rendering the oldest, which is worse than the stacking this replaces.
+// presentHtml's iframe and presentDocument's rendered body are the same story.
+//
+// What is lost is what the view held internally — the table's scroll position, expanded rows —
+// and that is exactly what today's behaviour already loses, since today every edit draws a whole
+// new card. Correct-and-unchanged beats stale-but-smooth. Caught by Codex on PR #1223; pinned by
+// "remounts the view … so it refetches" in GuiPanelCollapse.spec.ts.
+const cardKey = (result: ToolResult) => result.uuid;
 
 // Auto-follow. The pane never scrolled itself, so each new card landed below the fold and the
 // user had to go find it; collapsing above removes most of that, but a card can still arrive
@@ -137,7 +149,7 @@ function onScroll() {
 const latestCardKey = computed(() => {
   const list = cards.value;
   const last = list[list.length - 1];
-  return `${list.length}:${last ? cardKey(last) : ""}:${last?.uuid ?? ""}`;
+  return `${list.length}:${last?.uuid ?? ""}`;
 });
 
 watch(latestCardKey, () => {

--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -16,6 +16,7 @@ import { plugin as mulmoScriptPlugin, MULMOSCRIPT_HOST_ADAPTER_KEY, type MulmoSc
 import { AccountingView } from "@mulmoclaude/accounting-plugin/vue";
 import { wrapWithPluginRuntime } from "./composables/pluginRuntime";
 import CollectionCardView from "./components/CollectionCardView.vue";
+import { documentIdentity, filePathIdentity, collectionIdentity } from "./utils/canvasIdentity";
 // Import each package's compiled stylesheet as a STRING (?inline), not as a global
 // side-effect. GuiPanel injects it into a per-view Shadow DOM (see PluginFrame),
 // which encapsulates the plugin's Tailwind preflight so it can't clobber
@@ -68,6 +69,16 @@ interface Registration {
   toolName: string;
   viewComponent: Component;
   css?: string;
+  /**
+   * What makes two results of this tool the SAME THING, so the Canvas shows only the newest —
+   * see src/utils/canvasCollapse.ts. Return null for a result that must stand alone (inline
+   * content with no backing file, an unrecognised shape); a tool that omits this never collapses,
+   * which is what every tool did before this existed.
+   *
+   * The value is namespaced by toolName at the call site, so two plugins may return the same
+   * string without colliding.
+   */
+  identityOf?: (result: unknown) => string | null;
   // Optional fixed frame height for views that rely on an internal h-full layout
   // (vs flowing at natural content height). See PluginFrame's `height` prop.
   height?: string;
@@ -84,6 +95,9 @@ const PACKAGES: Record<string, Registration> = {
     // file-change forward channel; dispatch targets the presentDocument route.
     viewComponent: wrapWithPluginRuntime("markdown", markdownPlugin.toolDefinition.name, markdownPlugin.viewComponent as unknown as Component),
     css: markdownCss,
+    // Re-presenting one document supersedes the card showing its older state; inline markdown has
+    // no path and stands alone. See canvasIdentity.ts.
+    identityOf: documentIdentity,
   },
   "@mulmoclaude/form-plugin": {
     toolName: formPlugin.toolDefinition.name,
@@ -101,6 +115,8 @@ const PACKAGES: Record<string, Registration> = {
     // The View renders an h-full iframe; give it a definite frame height (like the
     // collection card) so the page renders, with internal scroll.
     height: "80vh",
+    // The page on disk, so only re-presenting the SAME page collapses. See canvasIdentity.ts.
+    identityOf: filePathIdentity,
   },
   "@mulmochat-plugin/generate-image": {
     toolName: GenerateImagePlugin.plugin.toolDefinition.name,
@@ -131,6 +147,9 @@ const PACKAGES: Record<string, Registration> = {
     // Full storyboard editor with an internal h-full layout — give it a definite
     // frame height (like the collection/html cards) so that chain resolves.
     height: "80vh",
+    // The story on disk (`stories/<name>.json`), so this collapses re-opens of ONE story rather
+    // than distinct stories. See canvasIdentity.ts.
+    identityOf: filePathIdentity,
   },
   // Keyed by the plugins.json `packages` entry (the cfg.packages loop below looks up
   // PACKAGES[name]). The collection engine + presentCollection tool moved to
@@ -151,6 +170,9 @@ const PACKAGES: Record<string, Registration> = {
     // fixed frame so that chain resolves — matches MulmoClaude's StackView
     // DEFAULT_PLUGIN_HEIGHT.
     height: "80vh",
+    // The collection, by slug alone — NOT slug+itemId, and the same key reconcileCollectionCard
+    // uses. See canvasIdentity.ts for both decisions.
+    identityOf: collectionIdentity,
   },
 };
 

--- a/src/utils/canvasCollapse.ts
+++ b/src/utils/canvasCollapse.ts
@@ -1,0 +1,47 @@
+// Collapse the Canvas feed so a thing that was drawn twice appears once.
+//
+// Editing one collection over several turns calls presentCollection each time, and every call is
+// its own tool result — so the panel grew a fresh 80vh card per edit and pushed the current one
+// off the bottom of the pane. The results are not duplicates in the store (they are a real
+// history, and the server keeps them); they are duplicates ON SCREEN, because all but the last
+// render a state that no longer exists.
+//
+// The rule: results sharing an identity collapse to the LAST one, placed at the last one's
+// position. A result whose identity is null never collapses — that is the default, so a tool
+// that has not opted in behaves exactly as before.
+//
+// DELIBERATE DIVERGENCE from MulmoClaude. Its equivalent (`buildStackDisplayItems` in
+// ../mulmoclaude/src/utils/canvas/stackGrouping.ts) keeps the merged card at the group's FIRST
+// occurrence and retains every member for its sidebar to select. Both differences are on purpose:
+//   - Position: MulmoClaude has a sidebar listing every result, so "latest" is reachable without
+//     the stack order saying anything. MulmoTerminal has no such list — the bottom of the pane is
+//     the only affordance that means "newest", so a re-drawn card has to move there or the
+//     auto-follow below scrolls to something that did not change.
+//   - Members: this drops the superseded results instead of keeping them under a `members[]`,
+//     because nothing here can select one. They remain in the server's store either way.
+// Owner's call, on the feedback that prompted this (see the PR).
+
+/**
+ * Keep the last result per identity, at that last result's position.
+ *
+ * `identityOf` returns null for anything that should stand alone — inline content with no backing
+ * file, a tool with no notion of "the same thing again", or a shape the accessor did not
+ * recognise. Callers must namespace the identity by tool, so a collection slug and a file path
+ * cannot collide.
+ */
+export function collapseByIdentity<T>(results: readonly T[], identityOf: (result: T) => string | null): T[] {
+  // Backwards, keeping the first sighting of each identity — which is the LAST in reading order —
+  // then reversed. One pass, and the survivors come out in the order their kept occurrence had.
+  const seen = new Set<string>();
+  const kept: T[] = [];
+  for (let i = results.length - 1; i >= 0; i--) {
+    const result = results[i];
+    const identity = identityOf(result);
+    if (identity !== null) {
+      if (seen.has(identity)) continue;
+      seen.add(identity);
+    }
+    kept.push(result);
+  }
+  return kept.reverse();
+}

--- a/src/utils/canvasIdentity.ts
+++ b/src/utils/canvasIdentity.ts
@@ -1,0 +1,82 @@
+// What makes two Canvas results "the same thing", per tool — the `identityOf` accessors that
+// src/plugins-registry.ts hands to collapseByIdentity (see canvasCollapse.ts for the rule they
+// feed, and why the superseded card is dropped).
+//
+// Separate from the registry so they can be tested without mounting it: the registry pulls in
+// every plugin's Vue View and compiled stylesheet, none of which this decision involves.
+//
+// Each returns null for a result that must stand alone. That is the important default — an
+// unrecognised shape, or content with nothing durable behind it, has no business superseding a
+// card that is still on screen.
+import { documentPathOf, type MarkdownToolData } from "@mulmoclaude/markdown-plugin/vue";
+import { isRecord } from "../../common/isRecord";
+import { collectionSlugOf } from "../../common/collectionSeed";
+
+// A tool result's payload travels in `data` and `jsonData` both. Read through both because a
+// partial update (a view persisting its state) may carry only one — the same lookup, for the same
+// reason, as common/collectionSeed.ts's `collectionSlugOf`.
+function payloadsOf(result: unknown): Record<string, unknown>[] {
+  if (!isRecord(result)) return [];
+  return [result.data, result.jsonData].filter(isRecord);
+}
+
+/** A non-empty string field off whichever payload carries it. */
+export function payloadString(result: unknown, field: string): string | null {
+  for (const payload of payloadsOf(result)) {
+    const value = payload[field];
+    if (typeof value === "string" && value) return value;
+  }
+  return null;
+}
+
+/**
+ * presentDocument: the document on disk, or null for inline markdown.
+ *
+ * The package's own accessor rather than a field read — `docPath` is authoritative, but results
+ * stored before that field existed kept the path in `markdown`, and only `documentPathOf` knows
+ * which values in there mean "path" rather than "a one-line document".
+ */
+export function documentIdentity(result: unknown): string | null {
+  for (const payload of payloadsOf(result)) {
+    // Built field by field rather than cast: `markdown` is required on MarkdownToolData and a
+    // partial update may not carry it, so an assertion here would be a lie the compiler rejects.
+    // An absent one becomes "", which is not a path, leaving `docPath` to answer on its own.
+    const { markdown, docPath } = payload;
+    const data: MarkdownToolData = {
+      markdown: typeof markdown === "string" ? markdown : "",
+      // Omitted rather than set to undefined: exactOptionalPropertyTypes is on.
+      ...(typeof docPath === "string" ? { docPath } : {}),
+    };
+    const path = documentPathOf(data);
+    if (path) return path;
+  }
+  return null;
+}
+
+/**
+ * presentHtml / presentMulmoScript: the artifact on disk.
+ *
+ * `filePath` is required on both payloads (the HTML is too large to travel in the result; the
+ * story's path is the wire form every mulmoScript endpoint keys on), and each tool's CREATE path
+ * writes a FRESH path — so this collapses re-presentations of one artifact without ever merging
+ * two distinct ones.
+ */
+export function filePathIdentity(result: unknown): string | null {
+  return payloadString(result, "filePath");
+}
+
+/**
+ * presentCollection: the collection, by slug alone — NOT slug+itemId.
+ *
+ * Editing a collection's schema and editing one of its records are one piece of work on one
+ * subject, and the View self-fetches from the slug, so whichever card survives renders the
+ * current state. Owner's call on the feedback behind this change (see the PR).
+ *
+ * The same key `reconcileCollectionCard` uses, deliberately. That rule drops a browser-seeded
+ * placeholder from the STORE once the agent's real card lands (a placeholder is not history);
+ * this one collapses real cards for display only. Two rules, one notion of "the same collection"
+ * — hence one accessor.
+ */
+export function collectionIdentity(result: unknown): string | null {
+  return collectionSlugOf(result) ?? null;
+}

--- a/test/src/canvasCollapse.spec.ts
+++ b/test/src/canvasCollapse.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { collapseByIdentity } from "../../src/utils/canvasCollapse";
+
+// The Canvas rule: a thing drawn twice appears once, as its newest drawing, at that drawing's
+// position. See src/utils/canvasCollapse.ts — the "at that drawing's position" half is a
+// deliberate divergence from MulmoClaude and is pinned here rather than left to the reader.
+
+interface Card {
+  uuid: string;
+  id: string | null;
+}
+const card = (uuid: string, id: string | null): Card => ({ uuid, id });
+const identity = (c: Card) => c.id;
+const uuids = (list: Card[]) => list.map((c) => c.uuid);
+
+describe("collapseByIdentity", () => {
+  it("keeps a list with no repeats exactly as it is", () => {
+    const list = [card("a", "doc"), card("b", "html"), card("c", "coll")];
+    expect(collapseByIdentity(list, identity)).toEqual(list);
+  });
+
+  it("keeps only the newest of a repeated identity", () => {
+    const list = [card("a1", "coll"), card("a2", "coll"), card("a3", "coll")];
+    expect(uuids(collapseByIdentity(list, identity))).toEqual(["a3"]);
+  });
+
+  it("moves the survivor to the newest occurrence's position, not the first", () => {
+    // The whole point of the divergence: MulmoClaude would leave the merged card at index 0,
+    // where nothing signals that it just changed. Here it lands last, which is where the panel's
+    // auto-follow scrolls to.
+    const list = [card("a1", "coll"), card("b", "doc"), card("a2", "coll")];
+    expect(uuids(collapseByIdentity(list, identity))).toEqual(["b", "a2"]);
+  });
+
+  it("collapses non-adjacent repeats, not just consecutive ones", () => {
+    const list = [card("a1", "coll"), card("b1", "doc"), card("a2", "coll"), card("b2", "doc"), card("a3", "coll")];
+    expect(uuids(collapseByIdentity(list, identity))).toEqual(["b2", "a3"]);
+  });
+
+  it("never collapses a null identity, however many there are", () => {
+    // A tool that has not opted in — and inline content, which has nothing durable behind it —
+    // must behave exactly as before this existed.
+    const list = [card("a", null), card("b", null), card("c", null)];
+    expect(uuids(collapseByIdentity(list, identity))).toEqual(["a", "b", "c"]);
+  });
+
+  it("collapses identified cards while leaving unidentified ones interleaved in place", () => {
+    const list = [card("x1", null), card("a1", "coll"), card("x2", null), card("a2", "coll")];
+    expect(uuids(collapseByIdentity(list, identity))).toEqual(["x1", "x2", "a2"]);
+  });
+
+  it("keeps distinct identities apart", () => {
+    const list = [card("a1", "one"), card("b1", "two"), card("a2", "one")];
+    expect(uuids(collapseByIdentity(list, identity))).toEqual(["b1", "a2"]);
+  });
+
+  it("returns a new array and does not mutate its input", () => {
+    // The caller is a computed over a ref's array; reversing in place would corrupt the feed.
+    const list = [card("a1", "coll"), card("a2", "coll")];
+    const before = [...list];
+    collapseByIdentity(list, identity);
+    expect(list).toEqual(before);
+  });
+
+  it("handles an empty list", () => {
+    expect(collapseByIdentity([], identity)).toEqual([]);
+  });
+});

--- a/test/src/canvasIdentity.spec.ts
+++ b/test/src/canvasIdentity.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { collectionIdentity, documentIdentity, filePathIdentity, payloadString } from "../../src/utils/canvasIdentity";
+
+// What each tool calls "the same thing". These decide whether a card on screen is REPLACED, so
+// the cases that must return null (nothing durable behind the result, an unrecognised shape) are
+// pinned as hard as the ones that must match.
+
+describe("payloadString", () => {
+  it("reads the field from data", () => {
+    expect(payloadString({ data: { filePath: "artifacts/html/a.html" } }, "filePath")).toBe("artifacts/html/a.html");
+  });
+
+  it("falls back to jsonData when data lacks the field", () => {
+    // A view persisting its own state may send a partial result carrying only one of the two.
+    expect(payloadString({ jsonData: { filePath: "stories/x.json" } }, "filePath")).toBe("stories/x.json");
+  });
+
+  it("prefers data over jsonData", () => {
+    expect(payloadString({ data: { filePath: "a" }, jsonData: { filePath: "b" } }, "filePath")).toBe("a");
+  });
+
+  it("returns null for an empty string, so a blank path never merges two cards", () => {
+    expect(payloadString({ data: { filePath: "" } }, "filePath")).toBeNull();
+  });
+
+  it("returns null for a non-string value", () => {
+    expect(payloadString({ data: { filePath: 42 } }, "filePath")).toBeNull();
+  });
+
+  it("returns null for shapes with no payload at all", () => {
+    expect(payloadString({}, "filePath")).toBeNull();
+    expect(payloadString(null, "filePath")).toBeNull();
+    expect(payloadString("nope", "filePath")).toBeNull();
+    expect(payloadString({ data: "nope" }, "filePath")).toBeNull();
+  });
+});
+
+describe("filePathIdentity", () => {
+  it("identifies presentHtml by its page on disk", () => {
+    expect(filePathIdentity({ data: { filePath: "artifacts/html/report.html", title: "Report" } })).toBe("artifacts/html/report.html");
+  });
+
+  it("identifies presentMulmoScript by its story on disk", () => {
+    expect(filePathIdentity({ data: { filePath: "stories/demo.json", script: {} } })).toBe("stories/demo.json");
+  });
+
+  it("gives two different artifacts two different identities", () => {
+    const one = filePathIdentity({ data: { filePath: "artifacts/html/a.html" } });
+    const two = filePathIdentity({ data: { filePath: "artifacts/html/b.html" } });
+    expect(one).not.toBe(two);
+  });
+});
+
+describe("documentIdentity", () => {
+  it("identifies a document by docPath", () => {
+    expect(documentIdentity({ data: { markdown: "# hi", docPath: "artifacts/documents/notes.md" } })).toBe("artifacts/documents/notes.md");
+  });
+
+  it("returns null for inline markdown, which has nothing durable behind it", () => {
+    expect(documentIdentity({ data: { markdown: "# just some text" } })).toBeNull();
+  });
+
+  it("does not mistake a one-line markdown body for a path", () => {
+    // `README.md` is a perfectly good document body as well as a path — the package's accessor
+    // only reads the legacy in-`markdown` form for its own artifacts directory.
+    expect(documentIdentity({ data: { markdown: "README.md" } })).toBeNull();
+  });
+
+  it("reads the legacy pre-docPath form, where the artifact path lived in `markdown`", () => {
+    expect(documentIdentity({ data: { markdown: "artifacts/documents/old.md" } })).toBe("artifacts/documents/old.md");
+  });
+
+  it("returns null for shapes with no payload", () => {
+    expect(documentIdentity({})).toBeNull();
+    expect(documentIdentity(null)).toBeNull();
+  });
+});
+
+describe("collectionIdentity", () => {
+  it("identifies a collection by its slug", () => {
+    expect(collectionIdentity({ data: { collectionSlug: "books" } })).toBe("books");
+  });
+
+  it("ignores itemId, so editing a record and editing the collection are one subject", () => {
+    // The owner's decision behind this change: slug alone, not slug+itemId.
+    expect(collectionIdentity({ data: { collectionSlug: "books", itemId: "42" } })).toBe("books");
+    expect(collectionIdentity({ data: { collectionSlug: "books" } })).toBe(collectionIdentity({ data: { collectionSlug: "books", itemId: "42" } }));
+  });
+
+  it("keeps two collections apart", () => {
+    expect(collectionIdentity({ data: { collectionSlug: "books" } })).not.toBe(collectionIdentity({ data: { collectionSlug: "films" } }));
+  });
+
+  it("returns null when there is no slug", () => {
+    expect(collectionIdentity({ data: {} })).toBeNull();
+    expect(collectionIdentity(null)).toBeNull();
+  });
+});

--- a/test/src/components/GuiPanelCollapse.spec.ts
+++ b/test/src/components/GuiPanelCollapse.spec.ts
@@ -128,16 +128,31 @@ describe("GuiPanel — collapsing repeated cards", () => {
     expect(rendered(wrapper)).toEqual(["p1", "p2"]);
   });
 
-  it("reuses the view instance across a re-presentation instead of remounting it", async () => {
-    // Keyed on identity, not uuid: a remount would throw away whatever the view holds — the
-    // table's scroll position, its expanded rows — on every single edit.
+  it("remounts the view on a re-presentation, so the card refetches", async () => {
+    // The v-for key is the UUID, not the identity, and this is why. A re-presented card exists to
+    // show state that CHANGED, and the views have no other way to learn that: the collection View
+    // reloads from a `watch(activeSlug, …)` that a same-slug re-present never fires, and
+    // MulmoTerminal does not configure the package's optional `subscribeChanges` hook. Keying on
+    // the identity keeps the instance — and its STALE contents — which is a card that collapsed to
+    // "the newest" while rendering the oldest. Reported live and caught by Codex on PR #1223.
     const wrapper = mountPanel();
     await flushPromises();
     await push(collapsing("c1", "books"));
     expect(viewMounts).toBe(1);
     await push(collapsing("c2", "books"));
-    expect(viewMounts).toBe(1);
+    expect(viewMounts).toBe(2);
     expect(rendered(wrapper)).toEqual(["c2"]);
+  });
+
+  it("does NOT remount a card just because a view persisted its own state", async () => {
+    // The other half of the rule above: onUpdateResult replaces the result object but keeps its
+    // uuid, so the key is stable and a form does not lose what is being typed into it.
+    mountPanel();
+    await flushPromises();
+    await push(plain("p1"));
+    expect(viewMounts).toBe(1);
+    await push({ uuid: "p1", toolName: "plain", data: {}, viewState: { typed: "x" } });
+    expect(viewMounts).toBe(1);
   });
 });
 

--- a/test/src/components/GuiPanelCollapse.spec.ts
+++ b/test/src/components/GuiPanelCollapse.spec.ts
@@ -1,0 +1,199 @@
+// The Canvas showed one card per tool CALL, so editing a collection over several turns buried the
+// current one under its own history — each card is 80vh, so every edit pushed it a full pane down,
+// and the panel never scrolled itself.
+//
+// canvasCollapse.spec.ts pins the rule and canvasIdentity.spec.ts pins the keys; this drives the
+// panel itself, because neither proves GuiPanel actually applies them — or that a re-presented card
+// keeps its component instance rather than being torn down and rebuilt on every edit.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { defineComponent, h, nextTick } from "vue";
+import { flushPromises, mount } from "@vue/test-utils";
+
+const handlers = new Map<string, (data: unknown) => void>();
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, handler: (data: unknown) => void) => {
+      handlers.set(channel, handler);
+      return () => handlers.delete(channel);
+    },
+  }),
+}));
+
+vi.mock("../../../src/composables/useToolGroupsAnnounce", () => ({ onToolGroupsAnnounced: () => {} }));
+
+// Counts every mount of a card's view, so "the instance was REUSED" is observable rather than
+// inferred from the rendered output (which looks identical either way).
+let viewMounts = 0;
+const StubView = defineComponent({
+  name: "StubView",
+  props: { selectedResult: { type: Object, required: true } },
+  setup(props) {
+    viewMounts += 1;
+    return () => h("div", { class: "stub-view", "data-uuid": props.selectedResult.uuid }, String(props.selectedResult.uuid));
+  },
+});
+
+// A registry with just the two tools this file needs: one that collapses (by a `data.key`) and one
+// that does not, so the opt-out default is exercised alongside the new behaviour.
+vi.mock("../../../src/plugins-registry", () => ({
+  getPlugin: (toolName: string) => {
+    if (toolName === "collapsing") {
+      return { toolName, viewComponent: StubView, identityOf: (r: { data?: { key?: string } }) => r.data?.key ?? null };
+    }
+    if (toolName === "plain") return { toolName, viewComponent: StubView };
+    return undefined;
+  },
+}));
+
+// PluginFrame puts each view in a Shadow DOM, which hides it from the queries below and has
+// nothing to do with what is being tested.
+vi.mock("../../../src/components/PluginFrame.vue", () => ({
+  default: defineComponent({
+    name: "PluginFrameStub",
+    setup:
+      (_p, { slots }) =>
+      () =>
+        h("div", { class: "frame" }, slots.default?.()),
+  }),
+}));
+
+const GuiPanel = (await import("../../../src/components/GuiPanel.vue")).default;
+
+function mountPanel() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => ({
+      ok: true,
+      json: async () => (url.includes("/api/tools") ? { tools: [] } : { toolResults: [] }),
+    })),
+  );
+  return mount(GuiPanel, { props: { sessionId: "s1", sendTextMessage: () => true } });
+}
+
+// Deliver a result the way the server does — on the session channel.
+async function push(result: unknown) {
+  handlers.get("session:s1")?.(result);
+  await flushPromises();
+  await nextTick();
+}
+
+const collapsing = (uuid: string, key: string) => ({ uuid, toolName: "collapsing", data: { key } });
+const plain = (uuid: string) => ({ uuid, toolName: "plain", data: {} });
+const rendered = (wrapper: ReturnType<typeof mountPanel>) => wrapper.findAll(".stub-view").map((v) => v.attributes("data-uuid"));
+
+// jsdom gives every element zero height, so the auto-follow gate can't be exercised without
+// saying how tall the container is.
+function stubScrollMetrics(element: Element, { scrollHeight = 1000, clientHeight = 400 } = {}) {
+  Object.defineProperty(element, "scrollHeight", { value: scrollHeight, configurable: true });
+  Object.defineProperty(element, "clientHeight", { value: clientHeight, configurable: true });
+}
+
+beforeEach(() => {
+  handlers.clear();
+  viewMounts = 0;
+});
+
+describe("GuiPanel — collapsing repeated cards", () => {
+  it("shows one card when the same subject is presented twice", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(collapsing("c1", "books"));
+    await push(collapsing("c2", "books"));
+    expect(rendered(wrapper)).toEqual(["c2"]);
+  });
+
+  it("keeps distinct subjects as separate cards", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(collapsing("c1", "books"));
+    await push(collapsing("f1", "films"));
+    expect(rendered(wrapper)).toEqual(["c1", "f1"]);
+  });
+
+  it("moves a re-presented card to the bottom, past what arrived while it sat above", async () => {
+    // The owner's decision, and the reason the auto-follow below can just go to the bottom.
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(collapsing("c1", "books"));
+    await push(plain("p1"));
+    await push(collapsing("c2", "books"));
+    expect(rendered(wrapper)).toEqual(["p1", "c2"]);
+  });
+
+  it("never collapses a tool that declares no identity", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(plain("p1"));
+    await push(plain("p2"));
+    expect(rendered(wrapper)).toEqual(["p1", "p2"]);
+  });
+
+  it("reuses the view instance across a re-presentation instead of remounting it", async () => {
+    // Keyed on identity, not uuid: a remount would throw away whatever the view holds — the
+    // table's scroll position, its expanded rows — on every single edit.
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(collapsing("c1", "books"));
+    expect(viewMounts).toBe(1);
+    await push(collapsing("c2", "books"));
+    expect(viewMounts).toBe(1);
+    expect(rendered(wrapper)).toEqual(["c2"]);
+  });
+});
+
+describe("GuiPanel — following the newest card", () => {
+  it("scrolls to the bottom when a card arrives", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    const scroller = wrapper.get('[data-testid="canvas-scroll"]').element;
+    stubScrollMetrics(scroller);
+    await push(plain("p1"));
+    await nextTick();
+    expect(scroller.scrollTop).toBe(1000);
+  });
+
+  it("stays put when the reader has scrolled up to look at an earlier card", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    const scroller = wrapper.get('[data-testid="canvas-scroll"]');
+    stubScrollMetrics(scroller.element);
+    scroller.element.scrollTop = 0;
+    await scroller.trigger("scroll");
+    await push(plain("p1"));
+    await nextTick();
+    expect(scroller.element.scrollTop).toBe(0);
+  });
+
+  it("resumes following once the reader scrolls back to the bottom", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    const scroller = wrapper.get('[data-testid="canvas-scroll"]');
+    stubScrollMetrics(scroller.element);
+    scroller.element.scrollTop = 0;
+    await scroller.trigger("scroll");
+    scroller.element.scrollTop = 600; // 1000 - 600 - 400 = 0, within the tolerance band
+    await scroller.trigger("scroll");
+    await push(plain("p1"));
+    await nextTick();
+    expect(scroller.element.scrollTop).toBe(1000);
+  });
+
+  it("does not chase a view persisting its own state", async () => {
+    // onUpdateResult replaces the result object but keeps its uuid; following that would fight
+    // someone typing in a form.
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(plain("p1"));
+    const scroller = wrapper.get('[data-testid="canvas-scroll"]');
+    stubScrollMetrics(scroller.element);
+    scroller.element.scrollTop = 0;
+    await scroller.trigger("scroll");
+    scroller.element.scrollTop = 600;
+    await scroller.trigger("scroll");
+    scroller.element.scrollTop = 250; // reader moved inside the card, gate now closed
+    await scroller.trigger("scroll");
+    await push({ uuid: "p1", toolName: "plain", data: {}, viewState: { typed: "x" } });
+    await nextTick();
+    expect(scroller.element.scrollTop).toBe(250);
+  });
+});


### PR DESCRIPTION
## The feedback

> MulmoTerminal の Collection の Canvas の画面について、チャット画面でコレクションの編集をしていると、編集の度に Canvas が蓄積されていきます。（新しいものは下部に追加される）
>
> 私は Canvas の表示は、最新のものを見ることができれば十分なので、最新のものがすぐに見れる状態になっているか、最新のものを上に積んでいくような表示の方が嬉しいと思いました。

## What was actually happening

Editing a collection from the chat calls `presentCollection` once per turn, and the Canvas rendered one card per **call**. Two things compounded:

- The collection card is `height: "80vh"` (`src/plugins-registry.ts`), so **each edit pushed the current state a full pane down**.
- `GuiPanel.vue`'s scroll container was a plain `overflow-y-auto` with **no scroll control of any kind** — the panel never followed anything. (`scrollIntoView`/`scrollTop` appeared exactly once in `src/`, in `TerminalGrid.vue`, unrelated.)

So the user had to manually scroll to find the state they had just asked for. Not specific to collections — `presentDocument` / `presentHtml` / `presentMulmoScript` all accumulate the same way — but collections hit it hardest because editing is inherently iterative.

MulmoTerminal turns out to have shipped **MulmoClaude's `stack` mode with its grouping, auto-scroll and scroll-spy removed**; this restores the two of those three that apply here.

## What changed

**1. Results that are the same *thing* collapse to the newest one.**

Each plugin declares what "the same thing" means, through a new optional `Registration.identityOf` (`src/plugins-registry.ts`). The accessors live in `src/utils/canvasIdentity.ts`:

| Tool | Identity | Notes |
|---|---|---|
| `presentCollection` | `collectionSlug` | **Slug alone, not slug+itemId** — owner's call: editing a collection's schema and editing one of its records are one piece of work on one subject, and the View self-fetches, so the surviving card renders the current state either way. |
| `presentDocument` | `documentPathOf(data)` | The package's own accessor, so pre-`docPath` results still resolve. Inline markdown returns `null` and stands alone. |
| `presentHtml` | `data.filePath` | |
| `presentMulmoScript` | `data.filePath` | |

No new parsing was needed — all four accessors already existed. And it does not over-collapse: the **create** paths of `presentDocument` / `presentHtml` write a fresh artifact path per call, so two distinct documents stay two cards and only re-presenting **one** file collapses.

Tools that declare nothing (`presentChart`, `presentForm`, `generateImage`, `manageAccounting`) behave exactly as before. That is the default.

**2. The pane follows the newest card.**

Stick-to-bottom ported from MulmoClaude's `StackView` (its #2179): a reader who scrolled up to look at something earlier is not yanked back down, and the gate re-arms on session change so arriving in a cell lands you on its newest card. It deliberately does **not** fire on a view persisting its own state (`onUpdateResult` keeps the uuid), which would fight someone typing in a form.

## Deliberate divergence from MulmoClaude

Flagging this per `CLAUDE.md`; the reasoning is also in `src/utils/canvasCollapse.ts`.

MulmoClaude's equivalent — `buildStackDisplayItems` in `../mulmoclaude/src/utils/canvas/stackGrouping.ts` — differs in two ways:

- **Position.** It keeps a merged card at the group's **first** occurrence. Here the survivor moves to the **newest** occurrence's position. MulmoClaude has a sidebar listing every result, so stack order carries no "newest" meaning; MulmoTerminal has no such list, so the bottom of the pane is the only affordance that means newest — and if the card did not move there, the auto-follow above would scroll to something that did not change.
- **Members.** It retains superseded results under `members[]` for its sidebar to select. Here they are dropped from the view, because nothing in MulmoTerminal could select one. Owner confirmed no access to them is wanted.

**The server's store is untouched.** `tool-store.ts` still keeps the full history (50-card cap, persisted per session), so this is display-only and reversible — which is the right side to be wrong on while the identity rules are new. `reconcileCollectionCard`'s store-level supersede is unchanged and still separate: it drops a browser-seeded *placeholder* (not history) and shares the same `collectionSlugOf` accessor, so both rules mean one thing by "the same collection".

## The one thing that went wrong, and why it is worth reading

The first commit keyed the `v-for` on the **identity**, so a re-presented collection kept its component instance — the table's scroll position and expanded rows survived the edit. That looked like a free win. It is a bug, reported live ("the view does not update the contents" on a real collection) and caught by Codex on this PR.

**The remount IS the refresh.** A re-presented card exists to show state that *changed*, and the views have no other way to learn that:

- the collection View reloads from `watch(activeSlug, …, { immediate: true })` (`@mulmoclaude/collection-plugin` `dist/vue.js:6570`), and `activeSlug` derives from the slug alone — re-presenting the **same** collection leaves it identical, so the watch never fires;
- the package's optional `subscribeChanges` hook, which would otherwise push the change in, is **not** configured by `src/composables/collectionUi.ts`. The package documents a host without it as falling back to manual refresh.

So keeping the instance kept its **stale contents**: a card that collapsed to "the newest" while rendering the oldest — worse than the stacking this PR set out to fix. `presentHtml`'s iframe and `presentDocument`'s rendered body are the same story.

Fixed in `f692463`: the key is the **uuid**. What that gives up is what the view held internally, which is exactly what today's behaviour already gives up — every edit currently draws a whole new card at a fresh scroll position. Correct-and-unchanged beats stale-but-smooth.

The collapse itself is untouched, and a view persisting its own state still does **not** remount (`onUpdateResult` keeps the uuid, so a form doesn't lose what is being typed into it). `GuiPanelCollapse.spec.ts` counts view mounts and now pins **both** halves, so neither can silently regress.

## Testing

- `test/src/canvasCollapse.spec.ts` — 10 cases on the rule, including that the survivor lands at the newest position (the divergence), that non-adjacent repeats collapse, that `null` identities never do, and that the input array isn't mutated.
- `test/src/canvasIdentity.spec.ts` — 17 cases on the four accessors, weighted toward what must return `null` (inline markdown, a one-line body that looks like a path, empty/non-string fields, unrecognised shapes), since a wrong non-null replaces a card that is on screen.
- `test/src/components/GuiPanelCollapse.spec.ts` — 9 cases driving the panel itself: collapse, move-to-bottom past an interleaved card, the opt-out default, instance reuse, and all four auto-follow behaviours.

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` clean; full suite 7278 passed.

**Not done:** `docs/ChangeLog.md` and a dated setup guide page — those belong to `/publish`, and there is nothing here to configure.

**Verified by tests only — not yet exercised in a live browser session.** Worth a look at a real collection edit before merge, since the auto-follow's feel is the part a test can't judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repeated tool results are now consolidated by item identity, keeping the latest version visible.
  * The interface automatically follows new results when scrolled near the bottom, while preserving the reader’s position when reviewing earlier content.
  * View state is preserved when results are refreshed or replaced.

* **Bug Fixes**
  * Improved handling of document, file, and collection identities for more reliable result updates.

* **Tests**
  * Added comprehensive coverage for result consolidation, identity matching, scrolling, and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
