### PR TITLE
feat: resolve presentDocument / presentHtml paths against the calling session's cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmoterminal",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Run multiple Claude Code and Codex sessions in parallel — a browser terminal grid that shows which agent needs you. Local, tmux-backed.",
   "type": "module",
   "license": "MIT",

--- a/server/backends/sessionRelativePath.ts
+++ b/server/backends/sessionRelativePath.ts
@@ -1,0 +1,98 @@
+// Make presentDocument / presentHtml's `path` argument mean what the AGENT meant by it.
+//
+// Both tools take "workspace-relative or absolute", and the workspace is CLAUDE_CWD — the
+// one directory the server was started in. But a MulmoTerminal grid runs sessions in MANY
+// directories (each cell has its own cwd), and an agent sitting in one of them writes
+// `docs/report.html` meaning "relative to where I am", which is the only reading it has any
+// reason to expect. Resolved against CLAUDE_CWD that is a file nobody named — usually
+// missing, and worse when a file of the same name happens to exist there.
+//
+// So: before the tool call reaches the plugin, a RELATIVE `path` that exists under the
+// calling session's own cwd is rewritten to that absolute path. The session comes from the
+// header the MCP broker attaches to its dispatch POST (the only thing that knows which
+// session made the call — the route itself sees just the args).
+//
+// Deliberately narrow, because this rewrites an argument the agent supplied:
+//   - Only when the file EXISTS under the session cwd. Otherwise the value is left alone and
+//     resolves against the workspace exactly as before, so nothing that worked stops working
+//     and a bad path still reports itself against the workspace root.
+//   - Only for a relative value. An absolute path already means one thing.
+//   - Only for the two `path`-taking tools. presentMulmoScript's `filePath` is
+//     `artifacts/`-relative by contract and is NOT touched.
+//
+// Mounted before every /api/plugin route (including the View's own loadHtml/saveHtml and
+// loadDoc/saveDoc dispatches, which carry no session header and so pass through unchanged —
+// by then the path they hold is already the absolute one this rewrote).
+import fs from "node:fs";
+import path from "node:path";
+import type { Express, Request, Response, NextFunction } from "express";
+import { SESSION_ID_RE } from "../config/env.js";
+import { ptys, sessionCwd } from "../session/registry.js";
+import { isRecord } from "../../common/isRecord.js";
+
+/** Header the GUI MCP broker stamps on `POST /api/plugin/<tool>` so the route knows which
+ *  session the call came from. Defined here because the two ends must agree. */
+export const SESSION_HEADER = "x-mulmoterminal-session";
+
+/** The tools whose `path` argument names a file on disk. presentMulmoScript is absent on
+ *  purpose — its `filePath` is resolved against `artifacts/`, not a directory. */
+const PATH_TOOLS = ["presentDocument", "presentHtml"] as const;
+
+/** Where a session is ACTUALLY running. `ptys` knows where the agent process was spawned and is
+ *  the truer answer while it lives; `sessionCwd` is the memo for sessions this process did not
+ *  spawn, and survives the reap. A relative path means the directory the agent is sitting in, so
+ *  the live pty wins. */
+function cwdOfSession(id: string): string | null {
+  return ptys.get(id)?.cwd ?? sessionCwd(id);
+}
+
+function isRegularFile(abs: string): boolean {
+  try {
+    // statSync follows symlinks, so a link to a real document counts and a directory
+    // named `report.html` does not.
+    return fs.statSync(abs).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The absolute path a relative `value` names inside `sessionCwd`, or null when it should be
+ * left as it is — no session cwd, an absolute or NUL-bearing value, or nothing there.
+ *
+ * Exported for the spec: the whole behaviour is in this decision, and it is worth pinning
+ * without an HTTP round-trip.
+ */
+export function sessionRelativePath(value: unknown, sessionCwdPath: string | null): string | null {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) return null;
+  if (!sessionCwdPath) return null;
+  // Absolute under EITHER platform's rules: a Windows-shaped value must not be re-rooted
+  // into the session cwd on POSIX (it is refused downstream, which is the right answer).
+  if (path.isAbsolute(value) || /^[A-Za-z]:/.test(value) || value.startsWith("\\")) return null;
+  const abs = path.resolve(sessionCwdPath, value);
+  // `..` can climb out of the session cwd — that is fine (the `path` form is uncontained by
+  // design; see backends/openPath.ts), but the file still has to be there.
+  return isRegularFile(abs) ? abs : null;
+}
+
+/** Rewrite `body.path` in place when the calling session's cwd is where the file actually is. */
+function rewritePathArg(req: Request): void {
+  const body = req.body;
+  if (!isRecord(body) || typeof body.path !== "string") return;
+  const sessionId = req.get(SESSION_HEADER);
+  if (!sessionId || !SESSION_ID_RE.test(sessionId)) return;
+  const resolved = sessionRelativePath(body.path, cwdOfSession(sessionId));
+  if (resolved !== null) body.path = resolved;
+}
+
+/** Mount the rewrite ahead of every /api/plugin route — the plugin dispatch routes,
+ *  the host-answered ones, and the generic catch-all alike. MUST be registered after
+ *  `express.json` (it reads the parsed body) and before any of them. */
+export function mountSessionRelativePathRewrite(app: Express): void {
+  for (const tool of PATH_TOOLS) {
+    app.post(`/api/plugin/${tool}`, (req: Request, _res: Response, next: NextFunction) => {
+      rewritePathArg(req);
+      next();
+    });
+  }
+}

--- a/server/mcp/broker.ts
+++ b/server/mcp/broker.ts
@@ -33,14 +33,15 @@ import { interpretToolEnvelope } from "./tool-envelope.js";
 import { isRecord } from "../../common/isRecord.js";
 import type { GuiCallRecorder } from "./gui-call-history.js";
 import { messageOf } from "../errors.js";
+import { SESSION_HEADER } from "../backends/sessionRelativePath.js";
 
 // Shape of the dispatch route's response (POST /api/plugin/<tool>). `data` gates
 // whether a toolResult is published to the GUI; the rest is narration/metadata.
 
-async function postJson(url: string, body: unknown) {
+async function postJson(url: string, body: unknown, headers: Record<string, string> = {}) {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`${url} responded ${res.status}`);
@@ -133,7 +134,10 @@ export function buildGuiMcpServer(
     started();
     try {
       // Dispatch to the plugin's server-side handler, then interpret its envelope (tool-envelope.ts).
-      const parsed = await (await postJson(`${baseUrl}/api/plugin/${name}`, args ?? {})).json();
+      // The session header is what lets a route resolve a path argument against the directory
+      // this agent is actually running in (backends/sessionRelativePath.ts) — the args alone
+      // carry no clue which of the grid's directories the call came from.
+      const parsed = await (await postJson(`${baseUrl}/api/plugin/${name}`, args ?? {}, { [SESSION_HEADER]: sessionId })).json();
       const { publish, narration } = interpretToolEnvelope(isRecord(parsed) ? parsed : {});
 
       // A GUI toolResult, only when there is data to render.

--- a/server/routes/app-routes.ts
+++ b/server/routes/app-routes.ts
@@ -58,6 +58,7 @@ import { mountShortcutsRoutes } from "../backends/shortcuts.js";
 import { mountDecisionRoutes } from "./decision-routes.js";
 import { mountTranslationRoutes } from "../backends/translation.js";
 import { mountHtmlDispatchRoute, mountHtmlFileRoute, mountHtmlPreviewRoute } from "../backends/html.js";
+import { mountSessionRelativePathRewrite } from "../backends/sessionRelativePath.js";
 import { mountMulmoScriptDispatchRoute, mountMulmoScriptMediaRoute } from "../backends/mulmoscript.js";
 import { CLAUDE_CWD, MULMOTERMINAL_HOME, PORT, SESSION_ID_RE } from "../config/env.js";
 import { FILE_WRITE_CHANNEL, type FileWriteEvent } from "../../common/fileWriteChannel.js";
@@ -121,6 +122,12 @@ export function mountAppRoutes(app: Express, deps: AppRouteDeps): void {
   mountDropRoutes(app);
 
   app.use(express.json({ limit: "25mb" }));
+
+  // presentDocument / presentHtml only: a RELATIVE `path` sent by a session running in another
+  // directory means THAT session's cwd, not CLAUDE_CWD. Rewritten here — after the body parser,
+  // before every /api/plugin handler — so the dispatch routes below and the catch-all all see
+  // the same resolved value. See backends/sessionRelativePath.ts.
+  mountSessionRelativePathRewrite(app);
 
   // The GUI-plugin tool routes this server answers itself: spawnBackgroundChat,
   // manageAccounting, manageCollection (routes/plugin-routes.ts). ALL of them must precede

--- a/test/server/backends/sessionRelativePath.spec.ts
+++ b/test/server/backends/sessionRelativePath.spec.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+// presentDocument / presentHtml's `path`, resolved against the CALLING SESSION's directory
+// rather than CLAUDE_CWD (backends/sessionRelativePath.ts). The decision is entirely in
+// `sessionRelativePath`, so it is pinned directly; the route wiring around it is a two-line
+// middleware asserted through an express app at the bottom.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { sessionRelativePath, mountSessionRelativePathRewrite, SESSION_HEADER } from "../../../server/backends/sessionRelativePath.js";
+import { ptys } from "../../../server/session/registry.js";
+
+let dir: string;
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "mt-sessrel-"));
+  tempDirs.push(dir);
+});
+
+afterEach(() => {
+  for (const d of tempDirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+function seed(rel: string): string {
+  const abs = path.join(dir, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, "# hi\n");
+  return abs;
+}
+
+describe("sessionRelativePath", () => {
+  it("resolves a relative path against the session cwd when the file is there", () => {
+    const abs = seed("docs/report.html");
+    expect(sessionRelativePath("docs/report.html", dir)).toBe(abs);
+  });
+
+  it("leaves the value alone when nothing exists there (workspace resolution still applies)", () => {
+    expect(sessionRelativePath("docs/missing.html", dir)).toBeNull();
+  });
+
+  it("leaves a directory alone even when the name matches", () => {
+    mkdirSync(path.join(dir, "report.html"));
+    expect(sessionRelativePath("report.html", dir)).toBeNull();
+  });
+
+  it("never rewrites an absolute path", () => {
+    const abs = seed("docs/report.html");
+    expect(sessionRelativePath(abs, dir)).toBeNull();
+  });
+
+  it("never rewrites a Windows-shaped value on POSIX", () => {
+    expect(sessionRelativePath("C:/proj/x.md", dir)).toBeNull();
+    expect(sessionRelativePath("\\\\server\\share\\x.md", dir)).toBeNull();
+  });
+
+  it("does nothing without a session cwd, or for an unusable value", () => {
+    seed("docs/report.html");
+    expect(sessionRelativePath("docs/report.html", null)).toBeNull();
+    expect(sessionRelativePath("", dir)).toBeNull();
+    expect(sessionRelativePath("doc\0s.md", dir)).toBeNull();
+    expect(sessionRelativePath(42, dir)).toBeNull();
+  });
+
+  it("allows a value that climbs out of the session cwd, since the `path` form is uncontained", () => {
+    const outside = mkdtempSync(path.join(tmpdir(), "mt-sessrel-out-"));
+    tempDirs.push(outside);
+    writeFileSync(path.join(outside, "x.md"), "x");
+    const climbed = path.join("..", path.basename(outside), "x.md");
+    expect(sessionRelativePath(climbed, dir)).toBe(path.join(outside, "x.md"));
+  });
+});
+
+describe("the /api/plugin rewrite", () => {
+  const sessionId = "11111111-2222-3333-4444-555555555555";
+
+  function app() {
+    const instance = express();
+    instance.use(express.json());
+    mountSessionRelativePathRewrite(instance);
+    instance.post("/api/plugin/:tool", (req, res) => res.json({ path: (req.body as { path?: unknown }).path }));
+    return instance;
+  }
+
+  afterEach(() => ptys.delete(sessionId));
+
+  it("rewrites presentHtml's path to the session cwd's copy", async () => {
+    const abs = seed("docs/report.html");
+    ptys.set(sessionId, { cwd: dir } as never);
+    const res = await request(app()).post("/api/plugin/presentHtml").set(SESSION_HEADER, sessionId).send({ path: "docs/report.html" }).expect(200);
+    expect(res.body.path).toBe(abs);
+  });
+
+  it("leaves presentMulmoScript's filePath-shaped `path` untouched — it is not a path tool", async () => {
+    seed("docs/report.html");
+    ptys.set(sessionId, { cwd: dir } as never);
+    const res = await request(app()).post("/api/plugin/presentMulmoScript").set(SESSION_HEADER, sessionId).send({ path: "docs/report.html" }).expect(200);
+    expect(res.body.path).toBe("docs/report.html");
+  });
+
+  it("passes through a request with no session header (the View's own dispatch)", async () => {
+    seed("docs/report.md");
+    ptys.set(sessionId, { cwd: dir } as never);
+    const res = await request(app()).post("/api/plugin/presentDocument").send({ path: "docs/report.md" }).expect(200);
+    expect(res.body.path).toBe("docs/report.md");
+  });
+
+  it("ignores a malformed session id rather than trusting it", async () => {
+    seed("docs/report.md");
+    const res = await request(app()).post("/api/plugin/presentDocument").set(SESSION_HEADER, "../../etc").send({ path: "docs/report.md" }).expect(200);
+    expect(res.body.path).toBe("docs/report.md");
+  });
+});


### PR DESCRIPTION
## What

`presentDocument` and `presentHtml` document their `path` as "workspace-relative or absolute", and the workspace is `CLAUDE_CWD` — the one directory the server was started in. But the grid runs sessions in **many** directories, and an agent sitting in one of them writes `docs/report.html` meaning *"relative to where I am"*, which is the only reading it has any reason to expect. Resolved against `CLAUDE_CWD` that is a file nobody named — usually missing, and worse when a file of the same name happens to exist there.

A relative `path` that **exists under the calling session's own cwd** is now rewritten to that absolute path before the call reaches the plugin.

## How

- **`server/backends/sessionRelativePath.ts`** (new) — the decision plus a middleware mounted on `/api/plugin/presentDocument` and `/api/plugin/presentHtml`, after `express.json` and ahead of every plugin handler, so the dispatch routes and the catch-all all see the same resolved value.
- **`server/mcp/broker.ts`** — stamps `x-mulmoterminal-session: <sessionId>` on the dispatch POST. The args alone carry no clue which of the grid's directories the call came from. Session cwd resolves live pty first, then the `sessionCwds` memo.
- **`server/routes/app-routes.ts`** — mounts it.

Deliberately narrow, because this rewrites an argument the agent supplied:

- only when the file **exists** there — otherwise the value is untouched and resolves against the workspace exactly as before, so nothing that worked stops working and a bad path still reports itself against the workspace root;
- only for a **relative** value (absolute already means one thing, and a Windows-shaped value is never re-rooted on POSIX);
- only for the two `path`-taking tools. **`presentMulmoScript` is untouched** — its `filePath` is `artifacts/`-relative by contract, not directory-relative.

The View's own dispatches (`loadHtml`/`saveHtml`, `loadDoc`/`saveDoc`) carry no session header and pass through unchanged; by then the path they hold is already the absolute one this rewrote.

## Version

`package.json` bumped to **4.1.0**. `docs/ChangeLog.md` and the dated `docs/guide/{en,ja}/v4.1.0.md` pages are **not** in this PR — those are written at release time by `/publish`, and there is nothing here to configure.

## Test plan

- `test/server/backends/sessionRelativePath.spec.ts` (new, 11 cases): the resolution decision (present / absent / directory / absolute / Windows-shaped / no cwd / climbing out of the cwd) and the route wiring (rewritten for `presentHtml`, untouched for `presentMulmoScript`, passthrough with no header, malformed session id ignored).
- `vitest run test/server` — 254 files, 3859 tests pass.
- `tsc -p tsconfig.server.json`, `tsc -p tsconfig.test-server.json`, `eslint` on the touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoclaude
