### PR TITLE
feat: open the Canvas by itself when the agent draws on the cell you are looking at

### DIFF
--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -37,6 +37,9 @@ import {
 import { setFilesPaneOpener } from "../composables/filesPaneOpener";
 import { paneCanShowClick } from "./paneClickTarget";
 import { onToolGroupsAnnounced } from "../composables/useToolGroupsAnnounce";
+import { usePubSub } from "../composables/usePubSub";
+import { getPlugin } from "../plugins-registry";
+import { isRecord } from "../../common/isRecord";
 import { hasCanvasGroup } from "../../common/toolGroups";
 import type { RightPane } from "./gridCell";
 import { parsePaneStore, rememberPane, recallPane } from "./filesPaneStore";
@@ -257,6 +260,48 @@ const expandedCwd = computed(() => props.cells.find((c) => c.uid === props.expan
 // The enlarged cell's session — what Canvas and Tools read. Null for a cell with no session
 // yet (a launcher, a command cell), which both panes already render as empty.
 const expandedSessionId = computed(() => props.cells.find((c) => c.uid === props.expandedUid)?.session ?? null);
+
+// A drawing that lands on the cell you are already looking at opens the Canvas by itself. The
+// agent calling presentDocument IS its answer to what was asked; with the pane closed that answer
+// left no trace but a count on a chip, which reads as a notification rather than as the reply, and
+// the user had to know that a pane exists and which button opens it.
+//
+// Scoped to the ENLARGED cell, deliberately. A background cell drawing must NOT seize the screen
+// away from whatever is being done in another one, so that case keeps exactly what it has today:
+// TerminalCell's unseen-canvas chip, which enlarges and opens on click. Owner's call.
+//
+// It re-opens every time, including after the user closed the pane by hand: closing is how you
+// dismiss the drawing in front of you, not a standing preference against the next one.
+const { subscribe: subscribeSession } = usePubSub();
+let unsubscribeDrawn: (() => void) | undefined;
+
+// Only a result that will actually RENDER counts. Every GUI tool result publishes on this channel,
+// including ones with no view of their own (manageCollection, google) — taking over the pane for
+// those would be a switch with nothing behind it to explain itself. Same question the panel asks
+// before rendering a card, so the two cannot disagree about what "drew something" means.
+function isDrawnResult(data: unknown): boolean {
+  if (!isRecord(data)) return false;
+  return typeof data.toolName === "string" && Boolean(getPlugin(data.toolName));
+}
+
+watch(
+  expandedSessionId,
+  (sessionId) => {
+    unsubscribeDrawn?.();
+    unsubscribeDrawn = undefined;
+    if (!sessionId) return;
+    unsubscribeDrawn = subscribeSession(`session:${sessionId}`, (data) => {
+      if (rightPane.value === "canvas" || props.expandedUid === null) return;
+      if (!isDrawnResult(data)) return;
+      // Through openCanvasFor rather than setRightPane: the files pane has a buffer to flush on
+      // the way out and may refuse to go, and "reveal this cell's canvas" stays one function
+      // however it is reached.
+      void openCanvasFor(props.expandedUid);
+    });
+  },
+  { immediate: true },
+);
+onBeforeUnmount(() => unsubscribeDrawn?.());
 
 // GUI -> LLM for the enlarged cell (a submitted form's answer). App.vue routes this through the
 // single view's Terminal ref; here the slot key is derivable from the uid, so the connection

--- a/src/components/TerminalGrid.vue
+++ b/src/components/TerminalGrid.vue
@@ -233,9 +233,19 @@ async function toggleFiles(): Promise<void> {
 // two steps, same reason, just nobody clicking. It stays ONE function because "reveal this cell's
 // canvas" has to mean the same thing however it is reached — including the files-buffer flush,
 // which a second implementation would be the natural place to forget.
-async function openCanvasFor(uid: number): Promise<void> {
+//
+// `enlarge` is the one thing the callers disagree about, and it matters only because the flush
+// above is ASYNC. A click on the chip means "bring that cell here", so a zoom that moved while the
+// buffer was being saved must still end on the cell that was asked for. The agent drawing on the
+// cell you are looking at means "put it beside what is already there" — if the user has walked the
+// zoom away in the meantime, enlarging the drawing cell back would be exactly the takeover that
+// case refuses to do, so it gives up instead. Caught by Codex on PR #1227.
+async function openCanvasFor(uid: number, enlarge = true): Promise<void> {
   if (filesOpen.value && (await filesPane.value?.flush()) === false) return;
-  if (props.expandedUid !== uid) emit("toggle-expand", uid);
+  if (props.expandedUid !== uid) {
+    if (!enlarge) return;
+    emit("toggle-expand", uid);
+  }
   setRightPane("canvas");
 }
 
@@ -295,8 +305,9 @@ watch(
       if (!isDrawnResult(data)) return;
       // Through openCanvasFor rather than setRightPane: the files pane has a buffer to flush on
       // the way out and may refuse to go, and "reveal this cell's canvas" stays one function
-      // however it is reached.
-      void openCanvasFor(props.expandedUid);
+      // however it is reached. Never enlarging (see there): a zoom the user moved while that
+      // flush was running is theirs to keep.
+      void openCanvasFor(props.expandedUid, false);
     });
   },
   { immediate: true },

--- a/test/src/components/canvasAutoOpen.spec.ts
+++ b/test/src/components/canvasAutoOpen.spec.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { h, type VNode } from "vue";
+import TerminalGrid from "../../../src/components/TerminalGrid.vue";
+import type { Cell } from "../../../src/components/gridTabs.js";
+
+// A drawing that lands on the cell you are looking at opens the Canvas by itself: presentDocument
+// IS the agent's answer, and with the pane closed the only trace was a count on a chip.
+//
+// The two limits pinned here are the whole design. It follows the ENLARGED cell only, so a
+// background cell drawing never takes the screen from what you are doing elsewhere; and it acts
+// only on a result that will actually RENDER, so the tools that publish without a view of their
+// own do not cause a pane switch with nothing behind it.
+
+// One shared registry of live handlers, so the test can publish on a session's channel exactly as
+// the server does.
+const bus = vi.hoisted(() => new Map<string, Set<(data: unknown) => void>>());
+vi.mock("../../../src/composables/usePubSub", () => ({
+  usePubSub: () => ({
+    subscribe: (channel: string, cb: (data: unknown) => void) => {
+      const entry = bus.get(channel) ?? new Set<(data: unknown) => void>();
+      entry.add(cb);
+      bus.set(channel, entry);
+      return () => entry.delete(cb);
+    },
+    onReconnect: () => () => {},
+  }),
+}));
+const publish = (channel: string, data: unknown) => {
+  for (const cb of bus.get(channel) ?? []) cb(data);
+};
+
+vi.mock("../../../src/components/TerminalCell.vue", () => ({
+  default: {
+    name: "TerminalCell",
+    props: ["expanded", "rightPane", "canvasAvailable"],
+    emits: ["toggle-expand", "toggle-files", "toggle-canvas", "open-canvas", "toggle-tools", "session", "cwd", "run", "close", "move", "status"],
+    template: '<div class="stub-cell" />',
+  },
+}));
+vi.mock("../../../src/components/CommandCell.vue", () => ({
+  default: {
+    name: "CommandCell",
+    props: ["expanded", "command"],
+    emits: ["toggle-expand", "close", "move", "status"],
+    template: '<div class="stub-command-cell" />',
+  },
+}));
+vi.mock("../../../src/components/LauncherCell.vue", () => ({
+  default: {
+    name: "LauncherCell",
+    props: ["expanded", "launcher"],
+    emits: ["toggle-expand", "close", "move", "status", "session"],
+    template: '<div class="stub-launcher-cell" />',
+  },
+}));
+vi.mock("../../../src/components/GuiPanel.vue", () => ({
+  default: { name: "GuiPanel", props: ["sessionId", "sendTextMessage", "unavailable"], template: '<div class="stub-canvas" />' },
+}));
+vi.mock("../../../src/components/ToolsPane.vue", () => ({ default: { name: "ToolsPane", props: ["sessionId"], template: '<div class="stub-tools" />' } }));
+// The files pane refuses to go while its buffer cannot be saved — the one case where a drawing
+// must NOT take the slot. `flush` is re-stubbed per test that cares.
+const filesStub = vi.hoisted(() => ({ flush: vi.fn(async () => undefined as boolean | undefined) }));
+vi.mock("../../../src/components/FilesPane.vue", () => ({
+  default: {
+    name: "FilesPane",
+    props: ["cwd", "requestedPath", "initialState"],
+    emits: ["close", "dirty"],
+    setup: (_p: unknown, { expose, slots }: { expose: (e: Record<string, unknown>) => void; slots: { title?: () => VNode[] } }) => {
+      expose({ flush: filesStub.flush, reload: () => {}, snapshot: () => ({ openPath: "README.md", expanded: ["src"] }) });
+      return () => h("div", { class: "stub-files-pane" }, slots.title?.());
+    },
+  },
+}));
+
+const cell = (uid: number, session: string | null = null): Cell => ({ uid, session, cwd: "/work" });
+
+const mountGrid = (cells: Cell[], expandedUid: number | null) =>
+  mount(TerminalGrid, {
+    props: {
+      cells,
+      expandedUid,
+      listRows: [],
+      cancelUid: null,
+      defaultCwd: "/work",
+      presets: [],
+      launchers: [],
+      home: "/work",
+      openSessionIds: [],
+      openCwds: [],
+      reorderable: false,
+      listMode: true,
+    },
+  });
+
+const canvasOpen = (w: ReturnType<typeof mount>) => w.findComponent({ name: "GuiPanel" }).exists();
+const drew = { uuid: "u1", toolName: "presentDocument", data: { markdown: "# hi" } };
+
+beforeEach(() => {
+  bus.clear();
+  // jsdom has no matchMedia; the grid asks it for prefers-reduced-motion when the zoom moves.
+  vi.stubGlobal("matchMedia", () => ({ matches: false, addEventListener: () => {}, removeEventListener: () => {} }));
+  localStorage.clear();
+  filesStub.flush.mockReset();
+  filesStub.flush.mockResolvedValue(undefined);
+  // /api/tools, asked for the enlarged cell.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ groups: ["render"], tools: [] }) })),
+  );
+});
+
+describe("the canvas opening itself when the agent draws", () => {
+  it("opens on the enlarged cell when a result that renders arrives", async () => {
+    const w = mountGrid([cell(1, "s1")], 1);
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(false);
+
+    publish("session:s1", drew);
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(true);
+    expect(w.findComponent({ name: "GuiPanel" }).props("sessionId")).toBe("s1");
+  });
+
+  // manageCollection / google publish on the same channel and draw no card. Switching the pane
+  // for one shows the user whatever was already there, with no visible reason.
+  it("ignores a result no plugin renders", async () => {
+    const w = mountGrid([cell(1, "s1")], 1);
+    await flushPromises();
+
+    publish("session:s1", { uuid: "u2", toolName: "manageCollection", data: {} });
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(false);
+  });
+
+  // The point of scoping this to the enlarged cell: cell 2 working in the background must not
+  // pull the screen away from cell 1. Its unread chip (TerminalCell) is what reports it.
+  it("leaves the pane alone when another cell draws", async () => {
+    const w = mountGrid([cell(1, "s1"), cell(2, "s2")], 1);
+    await flushPromises();
+
+    publish("session:s2", drew);
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(false);
+  });
+
+  // Nothing is enlarged, so there is no slot to put it in.
+  it("does nothing while no cell is enlarged", async () => {
+    const w = mountGrid([cell(1, "s1")], null);
+    await flushPromises();
+
+    publish("session:s1", drew);
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(false);
+  });
+
+  // Closing the pane dismisses the drawing in front of you; it is not a standing preference
+  // against the next one.
+  it("re-opens after the user closed the pane by hand", async () => {
+    const w = mountGrid([cell(1, "s1")], 1);
+    await flushPromises();
+    publish("session:s1", drew);
+    await flushPromises();
+
+    // The same toggle the header button drives.
+    w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-canvas");
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(false);
+
+    publish("session:s1", { ...drew, uuid: "u3" });
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(true);
+  });
+
+  // Taking the slot from the files pane unmounts its editor, so the buffer goes to disk first —
+  // and a buffer that can be saved neither way keeps the pane it is visible in.
+  it("flushes the files pane on the way out, and yields to one that refuses", async () => {
+    const w = mountGrid([cell(1, "s1")], 1);
+    await flushPromises();
+    w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
+    await flushPromises();
+    expect(w.find(".stub-files-pane").exists()).toBe(true);
+
+    filesStub.flush.mockResolvedValue(false);
+    publish("session:s1", drew);
+    await flushPromises();
+    expect(filesStub.flush).toHaveBeenCalled();
+    expect(canvasOpen(w)).toBe(false);
+    expect(w.find(".stub-files-pane").exists()).toBe(true);
+
+    filesStub.flush.mockResolvedValue(undefined);
+    publish("session:s1", { ...drew, uuid: "u4" });
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(true);
+  });
+
+  // The subscription follows the enlarged cell, so walking the zoom must not leave the old
+  // session able to open the pane.
+  it("follows the zoom to another cell", async () => {
+    const w = mountGrid([cell(1, "s1"), cell(2, "s2")], 1);
+    await flushPromises();
+    await w.setProps({ expandedUid: 2 });
+    await flushPromises();
+
+    publish("session:s1", drew);
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(false);
+
+    publish("session:s2", { ...drew, uuid: "u5" });
+    await flushPromises();
+    expect(canvasOpen(w)).toBe(true);
+  });
+});

--- a/test/src/components/canvasAutoOpen.spec.ts
+++ b/test/src/components/canvasAutoOpen.spec.ts
@@ -194,6 +194,32 @@ describe("the canvas opening itself when the agent draws", () => {
     expect(canvasOpen(w)).toBe(true);
   });
 
+  // The flush is ASYNC, and the user can walk the zoom while a dirty buffer is being saved. On the
+  // way back the drawing cell is no longer the enlarged one — enlarging it back would take the
+  // screen from the cell they just moved to, which is the takeover this whole feature refuses.
+  // Caught by Codex on PR #1227.
+  it("gives up rather than pulling the zoom back when the user moved it during the flush", async () => {
+    const w = mountGrid([cell(1, "s1"), cell(2, "s2")], 1);
+    await flushPromises();
+    w.findComponent({ name: "TerminalCell" }).vm.$emit("toggle-files");
+    await flushPromises();
+
+    // A save still in flight when the drawing lands.
+    let finishFlush: () => void = () => {};
+    filesStub.flush.mockReturnValue(new Promise<undefined>((resolve) => (finishFlush = () => resolve(undefined))));
+    publish("session:s1", drew);
+
+    // The user zooms to cell 2 before the buffer is down.
+    await w.setProps({ expandedUid: 2 });
+    await flushPromises();
+    finishFlush();
+    await flushPromises();
+
+    expect(canvasOpen(w)).toBe(false);
+    // And above all: no attempt to drag cell 1 back into the zoom.
+    expect(w.emitted("toggle-expand")).toBeUndefined();
+  });
+
   // The subscription follows the enlarged cell, so walking the zoom must not leave the old
   // session able to open the pane.
   it("follows the zoom to another cell", async () => {


### PR DESCRIPTION
## What

When the agent calls `presentDocument` (or any other tool that draws a card) on the cell you currently have enlarged, the Canvas pane now opens by itself.

## Why

The drawing IS the agent's answer to what was asked. With the pane closed, that answer left no trace but a count on the cell's unread chip — which reads as a notification rather than as the reply, and finding it meant knowing a pane exists and which button opens it.

## The limits, which are the design

- **The enlarged cell only.** A background cell drawing must not take the screen away from what is being done in another one, so that case keeps exactly what it has today: `TerminalCell`'s unread chip, which enlarges and opens on click. (Owner's call.)
- **Only a result that will actually RENDER** — gated on `getPlugin(toolName)`, the same question `GuiPanel` asks before drawing a card, so the two cannot disagree about what "drew something" means. Every GUI tool result publishes on the session channel, including ones with no view of their own (`manageCollection`, `google`); switching the pane for those is a takeover with nothing behind it to explain itself.
- **It re-opens after the user closed the pane by hand.** Closing dismisses the drawing in front of you; it is not a standing preference against the next one.

Routed through the existing `openCanvasFor` rather than `setRightPane`, so the files pane still flushes its buffer on the way out and may refuse to go — a buffer that can be saved neither way keeps the pane it is visible in.

## Verification

New spec `test/src/components/canvasAutoOpen.spec.ts` (7 cases): opens on the enlarged cell; ignores a result no plugin renders; leaves the pane alone when another cell draws; does nothing while no cell is enlarged; re-opens after a manual close; flushes the files pane and yields to one that refuses; follows the zoom to another cell.

`yarn format`, `yarn lint`, `yarn typecheck`, `yarn typecheck:server`, `yarn typecheck:test` and `yarn test` (7286 passed) all clean.

Not done: live browser check — this instance serves a built `dist/`, so it needs a `yarn build` on the box that runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal