### PR TITLE
refactor: dir 由来のリポ解決を 1 つにまとめ、forge を通す（#981 段階2b）

### DIFF
--- a/plans/refactor-981-2b-dir-forge.md
+++ b/plans/refactor-981-2b-dir-forge.md
@@ -1,0 +1,42 @@
+# refactor(#1228 / #981 段階2b): dir 由来のリポ解決を 1 つにまとめ、forge を通す
+
+**振る舞いは変わりません。画面に出る変化はゼロです。** 段階4（GitLab 実装）が「1箇所を変えれば
+届く」状態にするための構造の仕事で、そのことを先に書いておきます。
+
+## いま
+
+「このディレクトリの remote はどのリポか」を **5 箇所が別々に書いていました**。
+
+```
+server/index.ts                  repoFromWebUrl(await resolveGithubUrl(cwd))
+server/routes/dir-routes.ts × 2  repoFromWebUrl(await resolveGithubUrl(cwd))
+server/git/repo-dirs.ts          repoFromWebUrl(await resolveGithubUrl(dir))
+server/config/header-context.ts  repoFromWebUrl(parseGithubWebUrl(remoteUrl))
+```
+
+どれも **GitHub 以外は null**。呼び出し側はそれを「リポが無い」と読みます。`work-comment` は実際に
+`reason: "no-repo"` を返していましたが、**リポはあります** — GitHub ではないだけです。
+
+`repoFromWebUrl` のコメント自身が「それを広げるのは forge abstraction の仕事」と書いていました。
+
+## やったこと
+
+1. `repoForDir(dir)` / `repoForRemote(url)` が `{ forge, repo }` を返す。
+   **`repo` は扱える forge のときだけ文字列**、それ以外は null（＝今までの値そのまま）
+2. 5 箇所を置き換え
+3. `work-comment` の `reason` が `unsupported-forge` と `no-repo` を区別する
+   （**クライアントはこの値を読んでいない**ので、サーバ側の正確さだけ）
+
+## 意図的にやらなかったこと
+
+- **`phaseForRepoBranch` のシグネチャは変えない。** GitLab へ分岐する実装が無いうちに forge を
+  受け取らせても、設定する側の無いフィールドと同じで先取りになる。段階4 で変える
+- **UI を足さない。** 段階2a は既存の per-repo `error` という置き場所があったが、
+  **セル側には無い**。「未対応をどう見せるか」は #981 の未決事項のまま
+
+## テスト
+
+- `repoForRemote`: GitHub は `owner/repo` / **GitLab と自前ホストは「見えているが扱えない」
+  （`repo` は null だが答え自体は null ではない）** / 読めない文字列だけが null /
+  深い GitHub パスの切り詰めが従来どおり
+- `repoForDir`: 実リポの origin を読む / remote 無しは null

--- a/server/config/header-context.ts
+++ b/server/config/header-context.ts
@@ -9,20 +9,8 @@ import { repoForRemote } from "../git/forge-support.js";
 import { mergeHeaderConfig, type HeaderConfig, type HeaderContext } from "./header-config.js";
 import { loadDirConfig } from "./dir-config.js";
 import { isStrictlyWithin } from "../infra/path-within.js";
-import { parseRemoteRef } from "../git/remote-ref.js";
-import { GITHUB_HOST } from "../git/forge-host.js";
 
 const WORKTREES_ROOT = path.join(os.homedir(), ".mulmoterminal", "worktrees");
-
-// The repository path in a web URL — `owner/repo` out of "https://github.com/owner/repo" — for
-// ${repo}. Parsed with the shared remote parser rather than by splitting on the host name (#981);
-// the GitHub check stays, because ${repo} is interpolated into https://github.com/${repo} by the
-// default header button, so a path from another host would build a link to the wrong site.
-// Widening that is part of the forge abstraction, not of moving the parsing.
-export function repoFromWebUrl(webUrl: string | null): string | null {
-  const ref = webUrl ? parseRemoteRef(webUrl) : null;
-  return ref?.host === GITHUB_HOST ? ref.path : null;
-}
 
 // A managed worktree lives at <root>/<repo>-<hash>/<task>. The task is the FIRST segment
 // under <root> — NOT path.basename, which would return the wrong name for any cwd deeper

--- a/server/config/header-context.ts
+++ b/server/config/header-context.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import os from "node:os";
 import { gitStatus } from "../git/git-status.js";
 import { git } from "../git/worktrees.js";
-import { parseGithubWebUrl } from "../git/gitRemote.js";
+import { repoForRemote } from "../git/forge-support.js";
 import { mergeHeaderConfig, type HeaderConfig, type HeaderContext } from "./header-config.js";
 import { loadDirConfig } from "./dir-config.js";
 import { isStrictlyWithin } from "../infra/path-within.js";
@@ -38,7 +38,7 @@ export function worktreeTask(cwd: string, root: string = WORKTREES_ROOT): string
 async function remoteInfo(cwd: string): Promise<{ remoteUrl: string | null; repo: string | null }> {
   const res = await git(["remote", "get-url", "origin"], cwd);
   const remoteUrl = res.ok && res.stdout.trim() ? res.stdout.trim() : null;
-  const repo = remoteUrl ? repoFromWebUrl(parseGithubWebUrl(remoteUrl)) : null;
+  const repo = remoteUrl ? (repoForRemote(remoteUrl)?.repo ?? null) : null;
   return { remoteUrl, repo };
 }
 

--- a/server/git/forge-host.ts
+++ b/server/git/forge-host.ts
@@ -36,13 +36,18 @@ const GITHUB_PATH_SEGMENTS = 2;
 
 // GitLab nests groups (`group/subgroup/project`), so the whole path names the project and there is
 // no segment count to apply.
+const projectPathFor = (kind: ForgeKind, path: string): string | null => {
+  if (kind === "github") return topSegments(path, GITHUB_PATH_SEGMENTS);
+  return kind === "gitlab" ? path : null;
+};
+
+/** How the host itself addresses this project — GitHub's `owner/repo`, GitLab's whole group path —
+ *  or null for a host whose layout we do not know. */
+export const projectPath = (forge: RemoteForge): string | null => projectPathFor(forge.kind, forge.path);
+
 function webUrlFor(kind: ForgeKind, host: string, path: string): string | null {
-  if (kind === "github") {
-    const repo = topSegments(path, GITHUB_PATH_SEGMENTS);
-    return repo ? `https://${host}/${repo}` : null;
-  }
-  if (kind === "gitlab") return `https://${host}/${path}`;
-  return null;
+  const project = projectPathFor(kind, path);
+  return project ? `https://${host}/${project}` : null;
 }
 
 /** What forge a remote URL points at, or null when it is not a remote URL we can read at all. */

--- a/server/git/forge-support.ts
+++ b/server/git/forge-support.ts
@@ -52,3 +52,12 @@ export const repoForRemote = (remoteUrl: string): DirRepo | null => dirRepo(forg
  *  "a remote we do not support" — and the callers then report the second as the first.
  */
 export const repoForDir = async (dir: string): Promise<DirRepo | null> => dirRepo(await resolveRemoteForge(dir));
+
+/** Why a directory named no repository this app can act on.
+ *
+ *  Two answers, not one: `repo` is null both for a forge we cannot act on and for a remote on a
+ *  forge we CAN that does not name a project (`github.com/onlyone`). Collapsing them is the exact
+ *  mistake this module exists to undo, and the second is not the host's fault (Codex review).
+ */
+export const missingRepoReason = (found: DirRepo | null): "no-repo" | "unsupported-forge" =>
+  found && found.forge.kind !== "github" ? "unsupported-forge" : "no-repo";

--- a/server/git/forge-support.ts
+++ b/server/git/forge-support.ts
@@ -5,7 +5,8 @@
 // an empty section with no explanation, because every lookup went through a GitHub-shaped helper
 // that answered null. The cross-repo lists already carry a per-repo `error`, so the answer reaches
 // the screen through the channel a failing `gh` call already uses — no new UI.
-import { forgeFromRepoEntry, type RemoteForge } from "./forge-host.js";
+import { forgeFromRepoEntry, forgeOf, projectPath, type RemoteForge } from "./forge-host.js";
+import { resolveRemoteForge } from "./gitRemote.js";
 
 export interface SupportedRepo {
   /** The entry as configured, which is what the row is labelled with. */
@@ -29,3 +30,25 @@ export function repoSupport(entry: string): RepoSupport {
   if (forge.kind !== "github") return { entry, error: notImplemented(forge.host) };
   return { entry, forge };
 }
+
+/** What a working directory's `origin` names. */
+export interface DirRepo {
+  forge: RemoteForge;
+  /** `owner/repo` when this app can act on that forge, else null — a repository we can see but not
+   *  work with. Every dir-derived caller has always used exactly this value; keeping it null for an
+   *  unsupported forge is what makes this change behaviour-preserving (#981 step 2b). */
+  repo: string | null;
+}
+
+const dirRepo = (forge: RemoteForge | null): DirRepo | null => (forge ? { forge, repo: forge.kind === "github" ? projectPath(forge) : null } : null);
+
+/** The repository a remote URL names, or null when the string is not a remote at all. */
+export const repoForRemote = (remoteUrl: string): DirRepo | null => dirRepo(forgeOf(remoteUrl));
+
+/** The repository a directory's `origin` names, or null when it has no readable remote.
+ *
+ *  One place decides this for all of it: five call sites each wrote
+ *  `repoFromWebUrl(await resolveGithubUrl(dir))`, which answers null both for "no remote" and for
+ *  "a remote we do not support" — and the callers then report the second as the first.
+ */
+export const repoForDir = async (dir: string): Promise<DirRepo | null> => dirRepo(await resolveRemoteForge(dir));

--- a/server/git/gitRemote.ts
+++ b/server/git/gitRemote.ts
@@ -7,13 +7,6 @@ import { forgeOf, type RemoteForge } from "./forge-host.js";
 // on any other host has no GitHub URL, which is exactly what they treat as "not a GitHub repo".
 const githubUrlOf = (forge: RemoteForge | null): string | null => (forge?.kind === "github" ? forge.webUrl : null);
 
-// Which host a remote points at — and that a GitHub project is exactly `owner/repo` while a GitLab
-// one nests — lives in forge-host.ts (#981 step 1). This stays as the GitHub-shaped answer its six
-// callers already read, so none of them change.
-export function parseGithubWebUrl(remoteUrl: string): string | null {
-  return githubUrlOf(forgeOf(remoteUrl));
-}
-
 // Read the dir's `origin` remote. Null when the dir isn't a git repo, has no origin, or git is
 // missing — the three ways there is no remote to speak of, which are not the same as a remote we
 // do not support.

--- a/server/git/repo-dirs.ts
+++ b/server/git/repo-dirs.ts
@@ -8,8 +8,7 @@
 // The resolution is derived from `cwdPresets` rather than a second hand-kept list: a directory the
 // user registered in Settings IS the set of places they work, and a mapping they had to maintain
 // separately would drift the moment they added a clone.
-import { resolveGithubUrl } from "./gitRemote.js";
-import { repoFromWebUrl } from "../config/header-context.js";
+import { repoForDir } from "./forge-support.js";
 import { publicDirConfig } from "../config/dir-config.js";
 import { createTtlCache } from "./ttl-cache.js";
 import { orderByDirPriority } from "../../common/dirPriorityOrder.js";
@@ -36,7 +35,7 @@ export interface RepoDirsDeps {
 // `owner/repo` for a directory, or null when it is not a git repo, has no origin, or the origin
 // is not on GitHub. All three are ordinary answers for a saved directory, not errors.
 async function resolveRepo(dir: string): Promise<string | null> {
-  return repoFromWebUrl(await resolveGithubUrl(dir));
+  return (await repoForDir(dir))?.repo ?? null;
 }
 
 async function cachedRepoOf(dir: string, deps: RepoDirsDeps): Promise<string | null> {

--- a/server/index.ts
+++ b/server/index.ts
@@ -97,7 +97,7 @@ import { decideLaunchTerminal, NO_BROWSER_ERROR } from "./backends/remoteHost/la
 import { LAUNCH_TERMINAL_CHANNEL } from "../common/launchAgent.js";
 import { currentBranch, gitStatus } from "./git/git-status.js";
 import { phaseForRepoBranch } from "./git/prPhase.js";
-import { repoFromWebUrl } from "./config/header-context.js";
+import { repoForDir } from "./git/forge-support.js";
 import { resolveGithubUrl } from "./git/gitRemote.js";
 import { canClearInputBox } from "./backends/remoteHost/terminalInput.js";
 import { initCollectionsBackend } from "./backends/collections.js";
@@ -604,7 +604,7 @@ const workByCwd = async (cwds: readonly string[]): Promise<Map<string, SessionWo
       try {
         const status = await gitStatus(cwd);
         if (!status.repo || !status.branch) return;
-        const repo = repoFromWebUrl(await resolveGithubUrl(cwd));
+        const repo = (await repoForDir(cwd))?.repo ?? null;
         if (!repo) return;
         const summary = sessionWorkSummary(await phaseForRepoBranch(repo, status.branch));
         if (summary) out.set(cwd, summary);

--- a/server/routes/dir-routes.ts
+++ b/server/routes/dir-routes.ts
@@ -11,11 +11,11 @@ import { getHeaderConfig, getIssueWorkComments } from "../config/config-routes.j
 import { publicDirConfig, dirSoundFor, loadDirConfig, dirConfigDetail, MISSING_DIR_CONFIG_DETAIL } from "../config/dir-config.js";
 import { readSoundPreset } from "../config/sound-presets.js";
 import { isNotifyKind } from "../../common/notifyKinds.js";
-import { buildHeaderContext, loadHeaderConfig, repoFromWebUrl } from "../config/header-context.js";
+import { buildHeaderContext, loadHeaderConfig } from "../config/header-context.js";
 import { headerHasPrButton, resolveHeader } from "../config/header-resolve.js";
 import { loadScripts } from "../files/scripts.js";
 import { gitStatus } from "../git/git-status.js";
-import { resolveGithubUrl } from "../git/gitRemote.js";
+import { repoForDir } from "../git/forge-support.js";
 import { phaseForRepoBranch } from "../git/prPhase.js";
 import { EMPTY_WORK_ITEM, isIssueNumber } from "../../common/prPhase.js";
 import { ensureWorkComment } from "../git/work-comment.js";
@@ -55,11 +55,18 @@ async function workCommentHandler(req: Request, res: Response): Promise<void> {
     res.json({ posted: false, reason: "no-cwd" });
     return;
   }
-  const repo = repoFromWebUrl(await resolveGithubUrl(cwd));
-  if (!repo) {
+  const found = await repoForDir(cwd);
+  // Separated so the answer is not a lie: a repository on a forge this app cannot act on is not
+  // the same as a directory with no remote, and both used to report `no-repo` (#981).
+  if (!found) {
     res.json({ posted: false, reason: "no-repo" });
     return;
   }
+  if (!found.repo) {
+    res.json({ posted: false, reason: "unsupported-forge" });
+    return;
+  }
+  const repo = found.repo;
   const result = await ensureWorkComment(repo, issue, kind, workCommentDirLabel(cwd), positiveInt(body.pr), { closeIssue: kind === "merged" });
   res.json(result);
 }
@@ -68,7 +75,7 @@ async function prPhaseHandler(req: Request, res: Response): Promise<void> {
   const cwd = workspaceForRoute(req.query.cwd, res);
   if (cwd === null) return;
   const status = await gitStatus(cwd);
-  const repo = status.repo && status.branch ? repoFromWebUrl(await resolveGithubUrl(cwd)) : null;
+  const repo = status.repo && status.branch ? ((await repoForDir(cwd))?.repo ?? null) : null;
   // The same shape as the resolved path, not a two-field subset: a dir with no GitHub remote
   // is a normal answer, and a route that changes its response shape by branch is a trap for
   // the next reader of the contract (Codex review).

--- a/server/routes/dir-routes.ts
+++ b/server/routes/dir-routes.ts
@@ -15,7 +15,7 @@ import { buildHeaderContext, loadHeaderConfig } from "../config/header-context.j
 import { headerHasPrButton, resolveHeader } from "../config/header-resolve.js";
 import { loadScripts } from "../files/scripts.js";
 import { gitStatus } from "../git/git-status.js";
-import { repoForDir } from "../git/forge-support.js";
+import { missingRepoReason, repoForDir } from "../git/forge-support.js";
 import { phaseForRepoBranch } from "../git/prPhase.js";
 import { EMPTY_WORK_ITEM, isIssueNumber } from "../../common/prPhase.js";
 import { ensureWorkComment } from "../git/work-comment.js";
@@ -56,14 +56,10 @@ async function workCommentHandler(req: Request, res: Response): Promise<void> {
     return;
   }
   const found = await repoForDir(cwd);
-  // Separated so the answer is not a lie: a repository on a forge this app cannot act on is not
-  // the same as a directory with no remote, and both used to report `no-repo` (#981).
-  if (!found) {
-    res.json({ posted: false, reason: "no-repo" });
-    return;
-  }
-  if (!found.repo) {
-    res.json({ posted: false, reason: "unsupported-forge" });
+  // The reason is split so the answer is not a lie: a repository on a forge this app cannot act on
+  // is not the same as a directory with no remote, and both used to report `no-repo` (#981).
+  if (!found?.repo) {
+    res.json({ posted: false, reason: missingRepoReason(found) });
     return;
   }
   const repo = found.repo;

--- a/test/server/config/header-context.spec.ts
+++ b/test/server/config/header-context.spec.ts
@@ -1,20 +1,6 @@
 import { describe, it, expect } from "vitest";
 import path from "node:path";
-import { repoFromWebUrl, worktreeTask } from "../../../server/config/header-context.js";
-
-describe("repoFromWebUrl", () => {
-  it("extracts owner/repo from a github web url", () => {
-    expect(repoFromWebUrl("https://github.com/receptron/mulmoterminal")).toBe("receptron/mulmoterminal");
-  });
-  it("strips a trailing .git and slashes", () => {
-    expect(repoFromWebUrl("https://github.com/o/r.git")).toBe("o/r");
-    expect(repoFromWebUrl("https://github.com/o/r/")).toBe("o/r");
-  });
-  it("returns null for a null input or a non-github url", () => {
-    expect(repoFromWebUrl(null)).toBeNull();
-    expect(repoFromWebUrl("https://gitlab.com/o/r")).toBeNull();
-  });
-});
+import { worktreeTask } from "../../../server/config/header-context.js";
 
 describe("worktreeTask", () => {
   const root = path.join("/home", "u", ".mulmoterminal", "worktrees");

--- a/test/server/git/forge-host.spec.ts
+++ b/test/server/git/forge-host.spec.ts
@@ -19,6 +19,12 @@ describe("forgeOf", () => {
     expect(forgeOf(url)).toMatchObject({ host: "github.com", kind: "github", webUrl: "https://github.com/owner/repo" });
   });
 
+  // How the value actually arrives: `git config --get remote.origin.url` ends in a newline, and
+  // callers pass its stdout straight in. Pinned here now that it is this parser's job.
+  it("trims the whitespace and trailing newline git leaves on its output", () => {
+    expect(forgeOf("  git@github.com:owner/repo.git\n")).toMatchObject({ kind: "github", webUrl: "https://github.com/owner/repo" });
+  });
+
   it("reads gitlab.com", () => {
     expect(forgeOf("git@gitlab.com:group/project.git")).toMatchObject({ host: "gitlab.com", kind: "gitlab" });
   });

--- a/test/server/git/forge-support.spec.ts
+++ b/test/server/git/forge-support.spec.ts
@@ -1,7 +1,7 @@
 // Whether a configured repo can be listed, and what the row says when it cannot. The message is
 // the feature: an unsupported forge used to produce an empty section with no explanation (#981).
 import { describe, it, expect } from "vitest";
-import { repoSupport, isSupported, repoForRemote, repoForDir } from "../../../server/git/forge-support.js";
+import { repoSupport, isSupported, repoForRemote, repoForDir, missingRepoReason } from "../../../server/git/forge-support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -128,5 +128,25 @@ describe("repoForDir", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// Why a directory yielded nothing to act on. `repo` being null has two causes, and calling both
+// "unsupported forge" was the same collapsing this module exists to undo (Codex review).
+describe("missingRepoReason", () => {
+  it("blames the forge only when the forge is the problem", () => {
+    expect(missingRepoReason(repoForRemote("git@gitlab.com:group/project.git"))).toBe("unsupported-forge");
+  });
+
+  // Supported forge, unusable path: the host is fine, the remote just does not name a project.
+  it("does not blame the forge for a GitHub remote that names no project", () => {
+    const found = repoForRemote("https://github.com/onlyone");
+    expect(found?.forge.kind).toBe("github");
+    expect(found?.repo).toBeNull();
+    expect(missingRepoReason(found)).toBe("no-repo");
+  });
+
+  it("says no-repo when there is no remote at all", () => {
+    expect(missingRepoReason(null)).toBe("no-repo");
   });
 });

--- a/test/server/git/forge-support.spec.ts
+++ b/test/server/git/forge-support.spec.ts
@@ -1,7 +1,10 @@
 // Whether a configured repo can be listed, and what the row says when it cannot. The message is
 // the feature: an unsupported forge used to produce an empty section with no explanation (#981).
 import { describe, it, expect } from "vitest";
-import { repoSupport, isSupported } from "../../../server/git/forge-support.js";
+import { repoSupport, isSupported, repoForRemote, repoForDir } from "../../../server/git/forge-support.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { forgeFromRepoEntry } from "../../../server/git/forge-host.js";
 
 describe("forgeFromRepoEntry", () => {
@@ -77,5 +80,53 @@ describe("repoSupport", () => {
   it("says what a malformed entry should look like", () => {
     const support = repoSupport("owner");
     expect(!isSupported(support) && support.error).toContain("owner/repo");
+  });
+});
+
+// The dir-derived half (#981 step 2b). Five call sites each wrote
+// `repoFromWebUrl(await resolveGithubUrl(dir))`, which answers null for BOTH "no remote" and "a
+// remote we cannot act on" — and then reported the second as the first.
+describe("repoForRemote", () => {
+  it("gives the owner/repo a GitHub remote names", () => {
+    expect(repoForRemote("git@github.com:receptron/mulmoterminal.git")).toMatchObject({ repo: "receptron/mulmoterminal", forge: { kind: "github" } });
+  });
+
+  // The distinction the whole step exists for: the repository is SEEN (there is a forge) but not
+  // one this app can act on, so `repo` is null while the answer itself is not.
+  it.each([
+    ["a GitLab remote", "git@gitlab.com:group/project.git", "gitlab"],
+    ["a self-hosted remote", "git@git.example.com:team/project.git", "unknown"],
+  ])("reports %s as seen but not actionable", (_case, url, kind) => {
+    const found = repoForRemote(url);
+    expect(found).not.toBeNull();
+    expect(found?.repo).toBeNull();
+    expect(found?.forge.kind).toBe(kind);
+  });
+
+  // Null stays reserved for "there is nothing here to read", which is what the callers turn into
+  // "no repo".
+  it.each([[""], ["not a remote"]])("is null for %s", (url) => {
+    expect(repoForRemote(url)).toBeNull();
+  });
+
+  // A GitHub remote pointing deeper than owner/repo still names the project, unchanged from what
+  // the old helper produced.
+  it("truncates a deeper GitHub path the way the previous helper did", () => {
+    expect(repoForRemote("https://github.com/owner/repo/tree/main")?.repo).toBe("owner/repo");
+  });
+});
+
+describe("repoForDir", () => {
+  it("reads this repository's own origin", async () => {
+    expect((await repoForDir(process.cwd()))?.repo).toMatch(/^[^/]+\/[^/]+$/);
+  });
+
+  it("is null for a directory with no remote", async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "forge-support-"));
+    try {
+      expect(await repoForDir(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/server/git/gitRemote.spec.ts
+++ b/test/server/git/gitRemote.spec.ts
@@ -3,54 +3,7 @@ import type { Express } from "express";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { parseGithubWebUrl, resolveGithubUrl, mountGitRemoteRoute } from "../../../server/git/gitRemote.js";
-
-const REPO = "https://github.com/owner/repo";
-
-describe("parseGithubWebUrl", () => {
-  it("maps scp-like SSH remotes", () => {
-    expect(parseGithubWebUrl("git@github.com:owner/repo.git")).toBe(REPO);
-    expect(parseGithubWebUrl("git@github.com:owner/repo")).toBe(REPO);
-  });
-
-  it("maps SSH URL remotes, including a port", () => {
-    expect(parseGithubWebUrl("ssh://git@github.com/owner/repo.git")).toBe(REPO);
-    expect(parseGithubWebUrl("ssh://git@github.com:22/owner/repo.git")).toBe(REPO);
-  });
-
-  it("maps HTTPS remotes, with or without .git and credentials", () => {
-    expect(parseGithubWebUrl("https://github.com/owner/repo.git")).toBe(REPO);
-    expect(parseGithubWebUrl("https://github.com/owner/repo")).toBe(REPO);
-    expect(parseGithubWebUrl("https://user:token@github.com/owner/repo.git")).toBe(REPO);
-  });
-
-  it("maps the git:// protocol", () => {
-    expect(parseGithubWebUrl("git://github.com/owner/repo.git")).toBe(REPO);
-  });
-
-  it("trims surrounding whitespace / trailing newline (git output)", () => {
-    expect(parseGithubWebUrl("  git@github.com:owner/repo.git\n")).toBe(REPO);
-  });
-
-  it("is case-insensitive on the host and strips only a trailing .git", () => {
-    expect(parseGithubWebUrl("git@GitHub.com:owner/repo.GIT")).toBe(REPO);
-    expect(parseGithubWebUrl("https://github.com/owner/repo.github.git")).toBe("https://github.com/owner/repo.github");
-  });
-
-  it("returns null for non-GitHub hosts", () => {
-    expect(parseGithubWebUrl("git@gitlab.com:owner/repo.git")).toBeNull();
-    expect(parseGithubWebUrl("https://bitbucket.org/owner/repo.git")).toBeNull();
-    expect(parseGithubWebUrl("git@github.example.com:owner/repo.git")).toBeNull(); // not github.com
-  });
-
-  it("returns null for empty, malformed, or under-specified remotes", () => {
-    expect(parseGithubWebUrl("")).toBeNull();
-    expect(parseGithubWebUrl("   ")).toBeNull();
-    expect(parseGithubWebUrl("not a url")).toBeNull();
-    expect(parseGithubWebUrl("https://github.com/owner")).toBeNull(); // no repo segment
-    expect(parseGithubWebUrl("https://github.com/")).toBeNull();
-  });
-});
+import { resolveGithubUrl, mountGitRemoteRoute } from "../../../server/git/gitRemote.js";
 
 describe("resolveGithubUrl", () => {
   it("maps this repo's origin to its github.com URL", async () => {


### PR DESCRIPTION
## Summary

**振る舞いは1つも変わりません。画面に出る変化もゼロです。** 段階4（GitLab 実装）が
「1箇所を変えれば届く」状態にするための構造の仕事です。先に書いておきます。

「このディレクトリの remote はどのリポか」を **5 箇所が別々に書いていました**。どれも GitHub 以外は
null を返し、呼び出し側はそれを「リポが無い」と読みます。`work-caomment` は実際に
`reason: "no-repo"` を返していましたが、**リポはあります** — GitHub ではないだけです。

## Items to Confirm / Review

### 値は変えていません

`repoForDir` / `repoForRemote` が返す `repo` は、**5 箇所が今まで使っていた文字列そのもの**です。
扱えない forge では null で、これも今までと同じ。**変わったのは「forge がその隣にある」ことだけ**で、
「GitHub かどうか」の次の問いを置く場所ができました。

深い GitHub パスの切り詰め（`owner/repo/tree/main` → `owner/repo`）も従来どおりで、テストで固定
しています。

### `repoFromWebUrl` のコメントがこれを要求していました

> the GitHub check stays, because ${repo} is interpolated into https://github.com/${repo} …
> **Widening that is part of the forge abstraction, not of moving the parsing.**

その forge abstraction が本 PR です。

### 意図的にやらなかったこと

| | 理由 |
| --- | --- |
| **`phaseForRepoBranch` のシグネチャは変えない** | GitLab へ分岐する実装が無いうちに forge を受け取らせても、**設定する側の無いフィールドと同じ**で先取り。段階4 で変える |
| **UI を足さない** | 段階2a は既存の per-repo `error` という置き場所があったが、**セル側には無い**。「未対応をどう見せるか」は #981 の未決事項のまま |

### `reason` の変更は機能ではありません

`work-comment` が `unsupported-forge` と `no-repo` を区別するようになりましたが、
**クライアントはこのフィールドを読んでいません**（確認済み）。サーバ側の正確さだけの改善です。

## User Prompt

> 2b進もう

## テスト

`yarn format` / `lint` / `typecheck` / `typecheck:server` / `typecheck:test` / `build` /
`test`（7250 passed）/ `knip` — **すべて終了コードで確認**。

- `repoForRemote`: GitHub は `owner/repo` / **GitLab と自前ホストは「見えているが扱えない」**
  （`repo` は null だが答え自体は null ではない）/ 読めない文字列だけが null /
  深い GitHub パスの切り詰めが従来どおり
- `repoForDir`: 実リポの origin を読む / remote 無しは null

Fixes #1228

refs #981

work in mulmoterminal4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository detection for GitHub, GitLab, self-hosted forges, and local Git directories.
  * Supports repositories with deep GitHub paths and identifies unsupported forges when possible.

* **Bug Fixes**
  * Improved repository metadata resolution from directory remotes.
  * Distinguished directories without remotes from repositories hosted on unsupported forges.
  * Preserved correct project paths across supported forge types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->