### PR TITLE
fix(lint): 型アサーションを consistent-type-assertions で止める（まず warn） (#1231)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -113,6 +113,30 @@ export default [
     },
   },
   {
+    // `as` casts, which CLAUDE.md forbids ("MUST use type guards instead") and nothing was
+    // enforcing — so they accumulated to 90 in the app while the rule existed only on paper.
+    // A cast asserts a type the compiler could not prove; a type guard PROVES it, and the
+    // difference shows up at runtime, on the data you least control.
+    //
+    // WARN while the existing ones are worked off file by file (#1231), so CI keeps passing and
+    // the remaining count stays visible. It goes to ERROR once the last one is resolved — the
+    // allowlist below is the only way to keep one, with a reason, since inline eslint-disable
+    // is forbidden and hides the debt at the scene.
+    files: ["**/*.{ts,tsx,mts,cts}", "**/*.vue"],
+    rules: {
+      "@typescript-eslint/consistent-type-assertions": ["warn", { assertionStyle: "never" }],
+    },
+  },
+  {
+    // Tests may build values the types forbid on purpose: a malformed payload to prove the
+    // parser rejects it, a partial stub standing in for a big interface. Asserting there is
+    // the point of the test, not a hole in the app.
+    files: ["**/*.spec.{ts,tsx,js}", "**/*.test.{ts,tsx,js}", "test/**/*.{ts,tsx,js}"],
+    rules: {
+      "@typescript-eslint/consistent-type-assertions": "off",
+    },
+  },
+  {
     // Test files: a describe/it suite is one big (nested) callback by design, so the
     // length + callback-nesting guards are noise here. Keep the logic-complexity guards on.
     files: ["**/*.spec.{ts,js}", "**/*.test.{ts,js}"],

--- a/plans/fix-1231-no-type-assertions.md
+++ b/plans/fix-1231-no-type-assertions.md
@@ -1,0 +1,98 @@
+# fix(lint): 型アサーション（`as`）を ESLint で止める (#1231)
+
+`CLAUDE.md` は `as` を禁止しているのに ESLint が強制しておらず、規約と実際が乖離していた。
+ルールを入れ、既存の違反を **1ファイルずつ** 潰していく。
+
+## 実際の数（ESLint で計測。issue の記載より多い）
+
+issue には「本体 90 箇所 / 51 ファイル」とあるが、これは grep ベースの概算だった。
+`@typescript-eslint/consistent-type-assertions` を実際に有効化して数えると:
+
+| 対象 | 箇所 | ファイル |
+|---|---|---|
+| server | 71 | |
+| src | 64 | |
+| common | 12 | |
+| scripts | 2 | |
+| **合計** | **149** | **73** |
+
+`as const` は**このルールでは報告されない**ことを確認済み（フラグされた 149 行のうち
+`as const` を含む行は 0。リポジトリ内では 42 ファイルが `as const` を使っている）。
+つまり定数アサーションは今までどおり書ける。
+
+## 進め方
+
+issue の段階的導入に従う。
+
+1. **`warn` で導入**（CI を落とさず全件を可視化） ← 済
+   - テスト（`**/*.spec.*` / `**/*.test.*` / `test/**`）は override で対象外。
+     不正な入力をわざと作る・部分モックを渡す、といった正当な用途があるため。
+2. **1ファイルずつ直す** ← 進行中
+3. 直せないものを `eslint.config.js` の allowlist に **1エントリ1理由** で移す
+4. 最後に **`error`** へ上げる
+
+インラインの `eslint-disable` は使わない（`CLAUDE.md` で禁止。debt が現場に隠れるため）。
+
+## `as` を消すときの型付けの原則
+
+- **アサーションではなく注釈にする**。`const x = v as T` は無検査だが、`const x: T = v` は
+  コンパイラが代入可能性を検証する。同じ見た目で意味が正反対。
+- **本当に実行時にしか分からないものだけ**、型ガード（`(x: unknown): x is T`）か
+  ナローイング関数にする。
+- **`as unknown as T` は原則として直す**。二段にしないと通らない = 型が重なっていない、
+  つまり「コンパイラが強く反対している」という意味。
+
+## 進捗
+
+| # | ファイル | 箇所 | 対応 | PR |
+|---|---|---|---|---|
+| 1 | `src/plugins-registry.ts` | 12 | 型ガード + 注釈 + 不要キャスト削除 | this |
+
+## 直しながら見つかった問題（#1231 に記録する）
+
+### 1. `viewComponent` の `undefined` を握り潰していた — `src/plugins-registry.ts`
+
+6 箇所の `viewComponent as Component` / `as unknown as Component` は、**Vue の型不一致では
+なかった**。外すと出る本当のエラーはこれ:
+
+```
+Type 'Component | undefined' is not assignable to type 'Component'
+```
+
+`gui-chat-protocol/dist/vue.d.ts:164` が `viewComponent?: Component;` と **optional** で
+宣言している（Vue の View を持たないプラグインがあり得るため）。キャストはその
+`undefined` の可能性を黙らせていた。通れば `undefined` がレジストリに入り、Canvas は
+「描けないツール」を抱えることになる。
+
+**現時点では顕在化しない**（対象 5 パッケージはいずれも実際に viewComponent を出荷している
+ことを dist で確認済み）。潜在的な穴であって、今動いていないバグではない。
+
+対応: `viewOf(packageName, viewComponent)` で存在を確認し、無ければパッケージ名付きで
+throw する。ナローイングなのでキャストではない。
+
+### 2. 9 箇所のうち 2 箇所は「そもそも不要」だった
+
+`CollectionCardView as Component` と `AccountingView as Component` は、外しても
+型エラーが出なかった。`.vue` の SFC は `Component` に代入可能なので、最初から無意味な
+キャストだった。**キャストは一度書かれると誰も必要性を再検証しない**ことの実例。
+
+### 3. `config as { packages?: string[]; local?: string[] }` は注釈で足りた
+
+`plugins.json` の `local` が空配列 `[]` のため `never[]` と推論され、
+`new Set(cfg.local ?? [])` が `Set<never>` になって `.has(name: string)` が
+`Argument of type 'string' is not assignable to parameter of type 'never'` になる、
+というのが原因だった。
+
+`const cfg: { packages?: string[]; local?: string[] } = config;` と**注釈**にすれば、
+`never[]` は `string[]` に代入可能なのでそのまま通る。しかもこちらは
+**コンパイラが検証する**ので、JSON の形が変わればここで落ちる（キャストなら黙って通る）。
+
+## 検証
+
+型と lint だけでは足りない。`plugins-registry.ts` は Canvas の全プラグインを登録するので、
+実際にアプリを起動して確認した:
+
+- 8 ツール（presentDocument / presentForm / presentChart / presentHtml / presentMulmoScript /
+  presentCollection / manageAccounting / generateImage）すべてが登録され、
+  `viewComponent` が **nullish でない**ことをブラウザ上で確認
+- 画面が描画され、uncaught console error が 0


### PR DESCRIPTION
## Summary

#1231 の土台。`@typescript-eslint/consistent-type-assertions` を `assertionStyle: "never"` で導入します。`CLAUDE.md` は `as` を禁止しているのに ESLint が強制しておらず、規約と実際が乖離していました。

**まず `warn`** です。既存分を 1 ファイル 1 PR で潰していく間、CI を落とさず残数を可視化するため。最後に `error` へ上げます。

## Items to Confirm / Review

1. **件数が issue の記載より多いです。** issue の「本体 90 箇所 / 51 ファイル」は grep ベースの概算でした。ルールを有効化して ESLint に数えさせると **149 箇所 / 73 ファイル**（server 71・src 64・common 12・scripts 2）。

2. **`as const` は報告されません。** フラグされた 149 行のうち `as const` を含む行は 0、リポジトリでは 42 ファイルが `as const` を使用。定数アサーションは今までどおり書けます。

3. **テストを対象外にした範囲** — `**/*.spec.*` / `**/*.test.*` / `test/**`。不正な入力をわざと作る・部分モックを渡す、といった正当な用途があるためで、issue の方針どおりです。この範囲でよいかご確認ください。

4. **`warn` で入れる期間** — この PR 単体では CI は green のままです（`yarn lint` exit 0、142〜154 warnings）。`error` への昇格は全ファイル対応後の別 PR にします。

## User Prompt

- receptron/mulmoterminal#1231 を 1 ファイルずつ進めてほしい。
- 修正中にバグを見つけたら、元の issue に詳細と原因を残してほしい。
- PR は 1 ファイルずつにして、並列で動かして PR → review → マージとする。

## 実装

- `eslint.config.js` にルールを追加（`**/*.{ts,tsx,mts,cts}` と `**/*.vue`）。
- テスト向け override で `off`。
- `plans/fix-1231-no-type-assertions.md` に方針・実測値・型付けの原則・進捗表・発見した問題を記録。

## 型付けの原則（後続 PR で使う）

- **アサーションではなく注釈にする**。`const x = v as T` は無検査、`const x: T = v` はコンパイラが代入可能性を検証する。見た目はほぼ同じで意味が正反対。
- 本当に実行時にしか分からないものだけ型ガード / ナローイング関数にする。
- `as unknown as T` は原則として直す。二段にしないと通らない = 型が重なっていない = コンパイラが強く反対している。

refs #1231

work in mulmoterminal3
