### PR TITLE
fix: src/plugins-registry.ts の as を12箇所すべて外す (#1231)

### DIFF
--- a/src/plugins-registry.ts
+++ b/src/plugins-registry.ts
@@ -65,6 +65,22 @@ function withMulmoScriptHostAdapter(inner: Component): Component {
   );
 }
 
+// gui-chat-protocol types `viewComponent` as OPTIONAL (vue.d.ts) — a plugin may ship a tool with
+// no Vue view at all. Every package registered below is one whose view is the whole reason it is
+// registered, so a missing one is a packaging error, and this says which package rather than
+// storing `undefined` and leaving the Canvas holding a tool it cannot draw.
+//
+// DELIBERATE DIVERGENCE from MulmoClaude, which treats an absent view as normal: it declares the
+// field optional in its own runtimeLoader and guards at the render site (`v-if="...?.viewComponent"`).
+// It has to — it loads plugins the USER installed at runtime, so a view-less one is a condition, not
+// a defect. Here the packages are pinned npm deps that Vite bundles at build time, so absence cannot
+// vary per user, and GuiPanel renders them through `getPlugin(...)!` without a guard. Failing at
+// registration with the package name beats crashing later inside a template.
+function viewOf(packageName: string, viewComponent: Component | undefined): Component {
+  if (!viewComponent) throw new Error(`${packageName} ships no viewComponent, so the Canvas cannot render its results`);
+  return viewComponent;
+}
+
 interface Registration {
   toolName: string;
   viewComponent: Component;
@@ -93,7 +109,7 @@ const PACKAGES: Record<string, Registration> = {
     // The package View uses useRuntime() (dispatch/pubsub/locale/openUrl), so wrap
     // it in MulmoTerminal's runtime provider. scope "markdown" matches the server's
     // file-change forward channel; dispatch targets the presentDocument route.
-    viewComponent: wrapWithPluginRuntime("markdown", markdownPlugin.toolDefinition.name, markdownPlugin.viewComponent as unknown as Component),
+    viewComponent: wrapWithPluginRuntime("markdown", markdownPlugin.toolDefinition.name, viewOf("@mulmoclaude/markdown-plugin", markdownPlugin.viewComponent)),
     css: markdownCss,
     // Re-presenting one document supersedes the card showing its older state; inline markdown has
     // no path and stands alone. See canvasIdentity.ts.
@@ -101,7 +117,7 @@ const PACKAGES: Record<string, Registration> = {
   },
   "@mulmoclaude/form-plugin": {
     toolName: formPlugin.toolDefinition.name,
-    viewComponent: formPlugin.viewComponent as Component,
+    viewComponent: viewOf("@mulmoclaude/form-plugin", formPlugin.viewComponent),
     css: formCss,
   },
   "@mulmoclaude/html-plugin": {
@@ -110,7 +126,7 @@ const PACKAGES: Record<string, Registration> = {
     // for live-refresh). scope "html" matches the server's file-change channel
     // (plugin:html:file:<path>); dispatch targets /api/plugin/presentHtml, where the
     // server intercepts loadHtml/saveHtml (see server/backends/html.ts).
-    viewComponent: wrapWithPluginRuntime("html", htmlPlugin.toolDefinition.name, htmlPlugin.viewComponent as unknown as Component),
+    viewComponent: wrapWithPluginRuntime("html", htmlPlugin.toolDefinition.name, viewOf("@mulmoclaude/html-plugin", htmlPlugin.viewComponent)),
     css: htmlCss,
     // The View renders an h-full iframe; give it a definite frame height (like the
     // collection card) so the page renders, with internal scroll.
@@ -120,7 +136,7 @@ const PACKAGES: Record<string, Registration> = {
   },
   "@mulmochat-plugin/generate-image": {
     toolName: GenerateImagePlugin.plugin.toolDefinition.name,
-    viewComponent: GenerateImagePlugin.plugin.viewComponent as Component,
+    viewComponent: viewOf("@mulmochat-plugin/generate-image", GenerateImagePlugin.plugin.viewComponent),
     css: mulmochatPluginCss,
   },
   "@mulmoclaude/chart-plugin": {
@@ -128,7 +144,7 @@ const PACKAGES: Record<string, Registration> = {
     // No runtime wrap: the chart View reads everything from selectedResult.data and
     // only optionally injects the runtime for locale (inject(KEY, undefined)?.locale
     // ?? "en"), so it renders standalone. Its style.css is self-contained Tailwind.
-    viewComponent: chartPlugin.viewComponent as Component,
+    viewComponent: viewOf("@mulmoclaude/chart-plugin", chartPlugin.viewComponent),
     css: chartCss,
   },
   "@mulmoclaude/mulmoscript-plugin": {
@@ -141,7 +157,7 @@ const PACKAGES: Record<string, Registration> = {
     viewComponent: wrapWithPluginRuntime(
       "mulmoScript",
       mulmoScriptPlugin.toolDefinition.name,
-      withMulmoScriptHostAdapter(mulmoScriptPlugin.viewComponent as unknown as Component),
+      withMulmoScriptHostAdapter(viewOf("@mulmoclaude/mulmoscript-plugin", mulmoScriptPlugin.viewComponent)),
     ),
     css: mulmoScriptCss,
     // Full storyboard editor with an internal h-full layout — give it a definite
@@ -163,7 +179,7 @@ const PACKAGES: Record<string, Registration> = {
     // root as the record modal's teleport target (see the component + collectionUi).
     // The binding (data fetch, asset URLs, nav, confirm) is configured once at
     // startup by importing ./composables/collectionUi in main.ts.
-    viewComponent: CollectionCardView as Component,
+    viewComponent: CollectionCardView,
     css: collectionShadowCss,
     // The collection View uses an internal h-full layout (table/kanban scroll
     // areas, and the custom-view iframe has no intrinsic content height). Give it a
@@ -181,7 +197,7 @@ const localModules = import.meta.glob<{ REGISTRATION: Registration }>("../plugin
   eager: true,
 });
 
-const cfg = config as { packages?: string[]; local?: string[] };
+const cfg: { packages?: string[]; local?: string[] } = config;
 const registry: Record<string, Registration> = {};
 
 for (const name of cfg.packages ?? []) {
@@ -205,7 +221,7 @@ for (const [modulePath, mod] of Object.entries(localModules)) {
 // host via its own configureAccountingHost DI (see composables/accountingUi.ts).
 registry["manageAccounting"] = {
   toolName: "manageAccounting",
-  viewComponent: AccountingView as Component,
+  viewComponent: AccountingView,
   css: accountingCss,
   // Full canvas app with an internal h-full layout — give it a fixed frame height
   // (like the collection/html cards) so that chain resolves.


### PR DESCRIPTION
## Summary

#1231 の **1 ファイル目**。`src/plugins-registry.ts` の `as` を 12 箇所（9 サイト、うち 3 つは `as unknown as` の二段）すべて外します。

ルール導入そのものは #1233。この PR はそれと独立に適用できます（キャストを外すのにルールは要らない）。

## Items to Confirm / Review

1. **キャストが黙らせていたのは Vue の型不一致ではなく nullability でした。** 外すと出る本当のエラーは:

   ```
   Type 'Component | undefined' is not assignable to type 'Component'
   ```

   `gui-chat-protocol/dist/vue.d.ts:164` が `viewComponent?: Component` と **optional** で宣言しています。通っていれば `undefined` がレジストリに入り、Canvas が「登録されているのに描けないツール」を抱えます。

   **現時点では顕在化しません** — 対象 5 パッケージはいずれも実際に viewComponent を出荷していることを dist で確認済み。開いていた穴であって、今動いていないバグではありません。

2. **`viewOf()` が throw することの是非（MulmoClaude との意図的な差異）。** ここが一番レビューしてほしい点です。

   MulmoClaude は同じ条件を**正常系**として扱います（`src/tools/runtimeLoader.ts:41` で optional 宣言、`src/App.vue:182` で `v-if="...?.viewComponent"` とガード）。あちらは**ユーザーがインストールしたプラグインを実行時にロード**するので、View を持たないものは「条件」であって不具合ではないからです。

   こちらは pinned な npm 依存を Vite が**ビルド時にバンドル**するので、欠落はユーザーごとに変わり得ない packaging error です。さらに `GuiPanel.vue:301` が `getPlugin(...)!.viewComponent` と**ガードなしで**描画しています。よって登録時にパッケージ名付きで落とす方が、テンプレート内で落ちるより良いと判断しました。コード内にも理由付きで明記しています。

   `gui-chat-protocol` 側は**修正不要**と判断しました。optional は意図的な設計（View を持たないツールプラグインがあり得る）で、リファレンス実装の MulmoClaude もそれ前提で書かれています。

3. **9 サイトのうち 2 つは、そもそも不要なキャストでした。** `CollectionCardView as Component` / `AccountingView as Component` は外しても型エラーが出ません。`.vue` の SFC 型は `Component` に代入可能なので、最初から無意味でした。

4. **`config as {...}` は注釈で足りました。** `plugins.json` の `local: []` が `never[]` と推論され `Set<never>.has(string)` で落ちるのが原因。`const cfg: {...} = config` にすれば `never[]` は `string[]` に代入可能で通り、しかも**コンパイラが検証する**ので JSON の形が変われば落ちます。この「アサーションではなく注釈」は残り 137 箇所でも最初に試す価値があります。

## User Prompt

- receptron/mulmoterminal#1231 を 1 ファイルずつ進めてほしい。
- 修正中にバグを見つけたら、元の issue に詳細と原因を残してほしい。
- PR は 1 ファイルずつにして、並列で動かして PR → review → マージとする。

## 内訳

| 対応 | 数 | 内容 |
|---|---|---|
| ナローイング | 6 | `viewOf(packageName, viewComponent)` で存在を確認。無ければパッケージ名付きで throw |
| 削除 | 2 | `CollectionCardView` / `AccountingView` — 最初から不要 |
| 注釈へ変更 | 1 | `config as {...}` → `const cfg: {...} = config` |

## 検証

型と lint だけでは足りない（この 1 ファイルが Canvas の全プラグイン登録を担うため、`viewOf` が throw すれば白画面）ので、**実際にアプリを起動して確認**しました。

- 8 ツール（presentDocument / presentForm / presentChart / presentHtml / presentMulmoScript / presentCollection / manageAccounting / generateImage）がすべて登録され、`viewComponent` が **nullish でない**ことをブラウザ上で確認
- 画面が描画され、uncaught console error は 0
- `yarn typecheck` / `yarn lint`（0 error）/ `yarn build` / `yarn test`（7303 passed）

refs #1231

work in mulmoterminal3
