### PR TITLE
fix: GuiPanel の非 null アサーション3箇所を外す (#1231)

### DIFF
--- a/src/components/GuiPanel.vue
+++ b/src/components/GuiPanel.vue
@@ -131,6 +131,19 @@ const cards = computed(() => collapseByIdentity(results.value, cardIdentity));
 // "remounts the view … so it refetches" in GuiPanelCollapse.spec.ts.
 const cardKey = (result: ToolResult) => result.uuid;
 
+// Each card paired with the plugin that draws it, resolved ONCE here rather than in the template.
+// A template cannot carry `v-if="getPlugin(...)"` narrowing across to the sibling attributes, so
+// expressing this inline meant looking the plugin up four times per card and asserting away the
+// undefined three times — and a non-null assertion inside a template is invisible to
+// @typescript-eslint/no-non-null-assertion, which is on and catches the same thing in .ts (#1231).
+// Resolving here puts it where the compiler proves it instead.
+const drawableCards = computed(() =>
+  cards.value.flatMap((result) => {
+    const plugin = getPlugin(result.toolName);
+    return plugin ? [{ result, plugin }] : [];
+  }),
+);
+
 // Auto-follow. The pane never scrolled itself, so each new card landed below the fold and the
 // user had to go find it; collapsing above removes most of that, but a card can still arrive
 // under an earlier one that is still on screen. State is declared above useSessionFeed.
@@ -290,18 +303,13 @@ const hasTools = computed(() => toolSections.value.some((section) => section.too
       </div>
       <!-- Guarded as well as cleared on session change: a stale view rendered under an
            "unavailable" heading would contradict it. -->
-      <template v-for="r in unavailable ? [] : cards" :key="cardKey(r)">
-        <PluginFrame
-          v-if="getPlugin(r.toolName)"
-          class="[&+&]:mt-4 [&+&]:border-t [&+&]:border-border [&+&]:pt-4"
-          :css="getPlugin(r.toolName)!.css"
-          :height="getPlugin(r.toolName)!.height"
-        >
+      <template v-for="{ result, plugin } in unavailable ? [] : drawableCards" :key="cardKey(result)">
+        <PluginFrame class="[&+&]:mt-4 [&+&]:border-t [&+&]:border-border [&+&]:pt-4" :css="plugin.css" :height="plugin.height">
           <component
-            :is="getPlugin(r.toolName)!.viewComponent"
-            :selected-result="r"
+            :is="plugin.viewComponent"
+            :selected-result="result"
             :send-text-message="sendTextMessage"
-            @update-result="(update: Partial<ToolResult>) => onUpdateResult(r, update)"
+            @update-result="(update: Partial<ToolResult>) => onUpdateResult(result, update)"
           />
         </PluginFrame>
       </template>

--- a/test/src/components/GuiPanelCollapse.spec.ts
+++ b/test/src/components/GuiPanelCollapse.spec.ts
@@ -102,6 +102,19 @@ describe("GuiPanel — collapsing repeated cards", () => {
     expect(rendered(wrapper)).toEqual(["c2"]);
   });
 
+  // A result whose tool has no registered renderer is skipped rather than drawn as an empty frame,
+  // and must not take the cards around it down with it. This is the branch that used to be the
+  // template's `v-if="getPlugin(...)"` (#1231).
+  it("skips a result whose tool has no plugin, and still draws the rest", async () => {
+    const wrapper = mountPanel();
+    await flushPromises();
+    await push(plain("p1"));
+    await push({ uuid: "unknown1", toolName: "notRegistered", data: {} });
+    await push(plain("p2"));
+    expect(rendered(wrapper)).toEqual(["p1", "p2"]);
+    expect(wrapper.findAll(".frame")).toHaveLength(2);
+  });
+
   it("keeps distinct subjects as separate cards", async () => {
     const wrapper = mountPanel();
     await flushPromises();


### PR DESCRIPTION
## Summary

#1231 に含めて対応します（別 issue にしない方針）。`src/components/GuiPanel.vue` の非 null アサーション `!` 3箇所を外します。

`as` とは別ルールの管轄ですが同じ「**無検査アサーション**」で、issue の趣旨（コンパイラを黙らせる書き方を機械で止める）そのものです。

## Items to Confirm / Review

1. **なぜ3箇所だけ生き残っていたか、が本題です。**

   `@typescript-eslint/no-non-null-assertion` は `tseslint.configs.strict` 経由で **すでに error として有効**でした。実際に確かめると:

   | 場所 | 結果 |
   |---|---|
   | `.ts` に `m.get("x")!.a` | `error Forbidden non-null assertion` |
   | `GuiPanel.vue` のテンプレート内の同じ構文 | **何も報告されない** |

   **Vue テンプレート内は typescript-eslint から見えません。** リポジトリ全体で `!` がこの3つしか無いのはルールが効いている証拠で、その3つはちょうどルールが見られない場所にありました。

   → **ルールの追加は不要**（すでに on）。テンプレートが盲点であることを認識しておくのが対応です。

2. **原因と直し方**: テンプレートは `v-if="getPlugin(...)"` のナローイングを兄弟の属性へ持ち越せません。そのため 1 カードあたり `getPlugin()` を **4 回**引き、undefined を 3 回 assert していました。

   `drawableCards` として script 側で 1 回だけ解決します。コンパイラが証明できる場所へ移すので `!` が消え、ついでに **lookup が 4 回 → 1 回**になります。

3. **テストを1つ追加しました。** 「プラグインが無い結果は描かない」分岐（旧 `v-if`）が未テストで、そこはまさに今回書き換えた箇所です。フィルタを外すとこのテストだけが落ちることを確認済み（ミューテーション確認）。

## User Prompt

- receptron/mulmoterminal#1231 を 1 ファイルずつ進めてほしい。修正中にバグを見つけたら、元の issue に詳細と原因を残してほしい。
- PR は 1 ファイルずつにして、並列で動かして PR → review → マージとする。
- （`GuiPanel.vue` の非 null アサーションを別 issue にするか尋ねたのに対し）このissueで対応して。

## 変更

```diff
-<template v-for="r in unavailable ? [] : cards" :key="cardKey(r)">
-  <PluginFrame v-if="getPlugin(r.toolName)" :css="getPlugin(r.toolName)!.css" :height="getPlugin(r.toolName)!.height">
-    <component :is="getPlugin(r.toolName)!.viewComponent" :selected-result="r" ... />
+<template v-for="{ result, plugin } in unavailable ? [] : drawableCards" :key="cardKey(result)">
+  <PluginFrame :css="plugin.css" :height="plugin.height">
+    <component :is="plugin.viewComponent" :selected-result="result" ... />
```

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn build` / `yarn test` **7305 passed**。GuiPanel の spec は実際にコンポーネントを mount してカードの描画結果を uuid で検証しており、今回書き換えた経路をそのまま通ります（24 passed）。

refs #1231

work in mulmoterminal3
