### PR TITLE
fix: common/sessionAgent.ts の as を外す (#1231)

### DIFF
--- a/common/sessionAgent.ts
+++ b/common/sessionAgent.ts
@@ -16,7 +16,7 @@ export type TerminalAgent = (typeof TERMINAL_AGENTS)[number];
 // A remembered agent — a persisted grid cell, a localStorage toggle, a query param — read back.
 // Validated rather than cast: anything unrecognised is Claude, which is also what an older
 // persisted cell (written before the field existed) means.
-export const asTerminalAgent = (value: unknown): TerminalAgent => (TERMINAL_AGENTS.some((agent) => agent === value) ? (value as TerminalAgent) : "claude");
+export const asTerminalAgent = (value: unknown): TerminalAgent => (typeof value === "string" && isTerminalAgent(value) ? value : "claude");
 
 // Narrowing rather than coercing, for the callers that must be able to say "this is not an agent
 // at all": a shell is a session kind but not something a cell can be relaunched AS, and reading


### PR DESCRIPTION
## Summary

#1231。`common/sessionAgent.ts` の `as` 1 箇所を外します。

## Items to Confirm / Review

**同じ判定をする型ガードが 9 行下に既にありました。** `asTerminalAgent` はメンバーシップ判定を自前で書いたうえで結果を cast していましたが、`isTerminalAgent`（`value is TerminalAgent` を返す本物の型ガード）が同じファイルの 28 行目にあります。

```diff
-export const asTerminalAgent = (value: unknown): TerminalAgent => (TERMINAL_AGENTS.some((agent) => agent === value) ? (value as TerminalAgent) : "claude");
+export const asTerminalAgent = (value: unknown): TerminalAgent => (typeof value === "string" && isTerminalAgent(value) ? value : "claude");
```

`.some()` は述語を取るので型エラーにはなりませんが、**値を narrow しません**。だから cast が要りました。型ガードなら narrow されるので cast が不要になり、判定の二重管理も消えます。

`isTerminalAgent` は `string` を取るので `typeof value === "string"` を先に置いています（`unknown` を受ける `asTerminalAgent` との差）。

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` 7305 passed。

refs #1231

work in mulmoterminal3
