### PR TITLE
fix: common/prPhase.ts の as を外す (#1231)

### DIFF
--- a/common/prPhase.ts
+++ b/common/prPhase.ts
@@ -10,7 +10,7 @@ export type PrPhase = "none" | "draft" | "ci-failing" | "changes-requested" | "c
 
 export const PR_PHASES: readonly PrPhase[] = ["none", "draft", "ci-failing", "changes-requested", "ci-running", "ready", "merged", "closed"];
 
-export const isPrPhase = (v: unknown): v is PrPhase => typeof v === "string" && (PR_PHASES as readonly string[]).includes(v);
+export const isPrPhase = (v: unknown): v is PrPhase => typeof v === "string" && PR_PHASES.some((phase) => phase === v);
 
 // The /api/pr-phase response. `phase` and `prUrl` predate the rest and the roster reads them;
 // the numbers are what lets a cell say WHICH work it is on rather than just how far along it is.


### PR DESCRIPTION
## Summary

#1231。`common/prPhase.ts` の `as` 1 箇所を外します。

## Items to Confirm / Review

**同じパターンが common/ に 4 箇所ありました**（prPhase / terminalSubmit / themeVars / keymap）。それぞれ別 PR にしていますが、原因と直し方は共通です。

`as const` / `readonly T[]` の配列は `.includes(v)` が要素型しか受け取らないため、`string` を渡すと型エラーになる。cast はその配列を `readonly string[]` に**広げて**黙らせていた。`.some((x) => x === v)` は述語を取るので広げる必要がなく、cast が消える。

```diff
-export const isPrPhase = (v: unknown): v is PrPhase => typeof v === "string" && (PR_PHASES as readonly string[]).includes(v);
+export const isPrPhase = (v: unknown): v is PrPhase => typeof v === "string" && PR_PHASES.some((phase) => phase === v);
```

なお `common/sessionAgent.ts` は**もともとこの `.some()` の書き方**でした（#1240）。つまりリポジトリ内に正解が既にあって、他の 4 箇所が cast のままだった、という状態です。ルールが無いと揃わない、の実例だと思います。

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` 7305 passed。

refs #1231

work in mulmoterminal3
