### PR TITLE
fix: common/terminalSubmit.ts の as を外す (#1231)

### DIFF
--- a/common/terminalSubmit.ts
+++ b/common/terminalSubmit.ts
@@ -13,7 +13,7 @@ export type TerminalSubmitMode = (typeof TERMINAL_SUBMIT_MODES)[number];
 export const DEFAULT_TERMINAL_SUBMIT_MODE: TerminalSubmitMode = "cr";
 
 export const isTerminalSubmitMode = (value: unknown): value is TerminalSubmitMode =>
-  typeof value === "string" && (TERMINAL_SUBMIT_MODES as readonly string[]).includes(value);
+  typeof value === "string" && TERMINAL_SUBMIT_MODES.some((mode) => mode === value);
 
 // CR on its own. ESC+CR is what a terminal emits for Alt/Meta+Enter.
 const CR = "\r";


### PR DESCRIPTION
## Summary

#1231。`common/terminalSubmit.ts` の `as` 1 箇所を外します。#1241 と同じパターンです。

## Items to Confirm / Review

`as const` / `readonly T[]` の配列は `.includes(v)` が要素型しか受け取らないため、`string` を渡すと型エラーになる。cast はその配列を `readonly string[]` に**広げて**黙らせていた。`.some((x) => x === v)` は述語を取るので広げる必要がなく、cast が消える。

```diff
-  typeof value === "string" && (TERMINAL_SUBMIT_MODES as readonly string[]).includes(value);
+  typeof value === "string" && TERMINAL_SUBMIT_MODES.some((mode) => mode === value);
```

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` 7305 passed。

refs #1231

work in mulmoterminal3
