### PR TITLE
fix: common/dirConfigSource.ts の as を外す (#1231)

### DIFF
--- a/common/dirConfigSource.ts
+++ b/common/dirConfigSource.ts
@@ -82,7 +82,7 @@ export const EMPTY_DIR_CONFIG_EXTRAS: DirConfigExtras = {
 function isEmptyValue(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   if (Array.isArray(value)) return value.length === 0;
-  if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length === 0;
+  if (typeof value === "object") return Object.keys(value).length === 0;
   return false;
 }
 


### PR DESCRIPTION
## Summary

#1231。`common/dirConfigSource.ts` の `as` 1 箇所を外します。

## Items to Confirm / Review

**そもそも不要なキャストでした。** 外しても型エラーが出ません。

```diff
-  if (typeof value === "object") return Object.keys(value as Record<string, unknown>).length === 0;
+  if (typeof value === "object") return Object.keys(value).length === 0;
```

`Object.keys` のシグネチャは `object` を受け取ります。さらに関数の先頭で `value === null || value === undefined` を返しているので、`typeof value === "object"` の時点で `object` に narrow されています。つまりコンパイラは最初から十分な情報を持っていました。

#1234 の `CollectionCardView as Component` / `AccountingView as Component` と同じで、**一度書かれたキャストは誰も必要性を再検証しない**という例です。137 箇所のうち一定数はこれだと思われるので、まず「外してみる」を最初の手順にしています。

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` 7305 passed。

refs #1231

work in mulmoterminal3
