### PR TITLE
fix: common/themeVars.ts の as を3箇所とも外す (#1231)

### DIFF
--- a/common/themeVars.ts
+++ b/common/themeVars.ts
@@ -50,7 +50,7 @@ export function isThemeIdLike(value: unknown): value is string {
 }
 
 export function isBuiltinThemeId(id: string): id is ThemeId {
-  return (THEME_IDS as readonly string[]).includes(id);
+  return THEME_IDS.some((builtin) => builtin === id);
 }
 
 /** Whether an id may be used for a CUSTOM theme. Built-in ids are refused rather than merged
@@ -70,13 +70,19 @@ export interface CustomThemeInput {
 /** The full variable set for a theme: the base it extends, with its own colours on top.
  *  `builtins` supplies the base sets so this stays pure — the client reads them from the
  *  stylesheet's source of truth, the specs from a fixture. */
+// Every variable present, which is what separates a set we can paint with from one we cannot.
+// A guard rather than a length check on the missing keys: both ask the same question, but only
+// this one hands the answer to the compiler.
+function isCompleteThemeVars(vars: Partial<ThemeVars>): vars is ThemeVars {
+  return THEME_VAR_KEYS.every((key) => !!vars[key]);
+}
+
 export function resolveThemeVars(theme: CustomThemeInput, builtins: Record<ThemeId, ThemeVars>): ThemeVars | null {
   const base = theme.extends ? builtins[theme.extends] : null;
-  const merged = { ...(base ?? {}), ...theme.colors } as Partial<ThemeVars>;
-  const missing = THEME_VAR_KEYS.filter((key) => !merged[key]);
+  const merged: Partial<ThemeVars> = { ...(base ?? {}), ...theme.colors };
   // No base and an incomplete list is the one case we cannot paint: report it rather than
   // leaving the gaps to whatever the previously applied theme put on the element.
-  return missing.length ? null : (merged as ThemeVars);
+  return isCompleteThemeVars(merged) ? merged : null;
 }
 
 function channel(hex: string, at: number): number {


### PR DESCRIPTION
## Summary

#1231。`common/themeVars.ts` の `as` 3 箇所を外します。**3 箇所とも理由が違う**ので、この issue の類型がまとめて出てきた例です。

## Items to Confirm / Review

### 1. 配列を広げていただけ → `.some()`

```diff
-  return (THEME_IDS as readonly string[]).includes(id);
+  return THEME_IDS.some((builtin) => builtin === id);
```

### 2. アサーション → 注釈

```diff
-  const merged = { ...(base ?? {}), ...theme.colors } as Partial<ThemeVars>;
+  const merged: Partial<ThemeVars> = { ...(base ?? {}), ...theme.colors };
```

見た目はほとんど同じですが、**アサーションは無検査、注釈はコンパイラが代入可能性を検証**します。スプレッドの結果が `Partial<ThemeVars>` と食い違うようになれば、注釈ならここで落ちます。

### 3. 本物の narrowing が要る箇所 → 型ガード（ここが一番レビューしてほしい点です）

```diff
-  const missing = THEME_VAR_KEYS.filter((key) => !merged[key]);
-  return missing.length ? null : (merged as ThemeVars);
+  return isCompleteThemeVars(merged) ? merged : null;
```

```ts
function isCompleteThemeVars(vars: Partial<ThemeVars>): vars is ThemeVars {
  return THEME_VAR_KEYS.every((key) => !!vars[key]);
}
```

**元のコードは「全キーが揃っている」ことを既に確かめていました**（`missing.length` が 0）。ただしその結果はコンパイラに伝わらないので cast していた、という形です。同じ問いを型述語として書けば伝わるので cast が消えます。

判定内容は等価です（`filter(...).length === 0` ⇔ `every(...)`）。falsy 判定（`!vars[key]`）も元のまま変えていません — 空文字列を「欠け」とみなす挙動を維持するためです。

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` 7305 passed（themeVars の spec を含む）。

refs #1231

work in mulmoterminal3
