### PR TITLE
feat: セルヘッダの hover を即座に・中身のあるものにする (#1235)

### DIFF
--- a/plans/feat-1235-instant-header-tips.md
+++ b/plans/feat-1235-instant-header-tips.md
@@ -1,0 +1,78 @@
+# feat(#1235): セルヘッダの hover を即座に・中身のある表示にする
+
+## なぜ `title` をやめるか
+
+依頼は「すぐ出てほしい」。**標準 `title` の遅延はブラウザ仕様で、CSS でも JS でも変えられない。**
+中身も1行のプレーンテキストのみ。この2つは `title` を使い続ける限り直せないので、置き換える。
+
+## 出すものは全部もう手元にある
+
+`useWorkItem.ts` が **`prTitle` / `issueTitle` を既に受け取って parse している**（#1014 でスマホ用に
+追加され、デスクトップでは一度も表示されていない）。**サーバ変更は不要**。
+
+## 形 — シングルトンの tip レイヤ
+
+chip を wrapper で囲むと **flex の子が1段増えてヘッダのレイアウトが変わる**。ヘッダは
+`flex` で `flex-none` / `min-w-0` を細かく効かせているので、そこには触らない。
+
+代わりに:
+
+- `useHoverTip()` が**共有状態**（アンカーの矩形 ＋ 中身）を持ち、既存要素に載せるハンドラを返す
+- `<HoverTip>` が**アプリに1つだけ**あり、body へ teleport ＋ `fixed`
+- DOM は増えず、同時に2つ出ることも構造的に起きない
+
+teleport ＋ fixed は `CockpitRowMenu.vue` と同じ理由 — セルは `overflow-hidden` なので、
+その場に置いた要素は切られる。スクロールで閉じるのも同じ（アンカーが下から抜ける）。
+
+## 中身のデータ形
+
+```ts
+type TipSection = { head: string; note?: string };  // head=見出し行 / note=説明行
+type TipContent = TipSection[];
+```
+
+| chip | 中身 |
+| --- | --- |
+| work | `[{head:"PR #2689 · CI running", note:<PRタイトル>}, {head:"issue #2688", note:<issueタイトル>}]` |
+| git branch | `[{head:"branch fix/…"}, {head:"2 uncommitted · 1 ahead"}]` |
+| model / ctx | `[{head:"Claude · opus"}, {head:"context 96,000 / 200,000 (48%)"}]` |
+| dir badge / cwd | `[{head:<名前 or フルパス>}]` |
+| roster phase | `[{head:<phase の説明>}]` |
+
+**組み立ては純関数**にして単体テストする（`tipContent.ts`）。
+
+## 配置
+
+`placeHoverTip(anchor, tip, viewport)` の純関数。下に出す → 入らなければ上へ反転 → 横は画面内へ寄せる。
+セルは9分割まで小さくなり、端の chip は普通に画面際に来るので、**寄せは必須**。
+
+## アクセシビリティ
+
+`title` を消すと支援技術が読むものが無くなる。tip 要素に固定 id ＋ `role="tooltip"` を持たせ、
+開いている間だけアンカーに `aria-describedby` を張る（同時に1つなので id は1つでよい）。
+**フォーカスでも出す** — work chip の中の `<a>` はキーボードで到達できるのに、hover だけだと何も出ない。
+
+## 変更するファイル
+
+1. `src/composables/hoverTipPlacement.ts` — 配置の純関数
+2. `src/composables/useHoverTip.ts` — 共有状態 ＋ ハンドラ
+3. `src/components/HoverTip.vue` — 唯一の描画側
+4. `src/components/tipContent.ts` — 各 chip の中身を組む純関数
+5. `src/App.vue` — `<HoverTip>` を1つ置く
+6. `WorkItemChip` / `GitBranchChip` / `ModelContextBadge` / `DirBadge` / `CellShell` / `CockpitHeader`
+   — `title` を外してハンドラを付ける
+
+## テストで固定すること
+
+- work の中身に **PR / issue のタイトルが入る**（今まで捨てていた値）。無いときは行が消える
+- 各 chip の中身が今の `title` の情報を落としていない
+- 配置: 下に入らなければ上／右端・左端で画面内に収まる
+- `title` 属性が**残っていない**（二重表示の防止）
+- 開いている間だけ `aria-describedby` が張られる
+- hover を外すと消える／フォーカスでも出る
+
+## やらないこと
+
+- hover card 化（マウスを中に入れる）— #1235 の決定。リンクは chip の番号自体が既に持っている
+- ヘッダ以外の `title`（ツールバー、設定画面）
+- ツールチップのための追加の通信

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@ import AccountingOverlay from "./components/AccountingOverlay.vue";
 import WikiBrowseOverlay from "./components/WikiBrowseOverlay.vue";
 import PrsOverlay from "./components/PrsOverlay.vue";
 import FilesOverlay from "./components/FilesOverlay.vue";
+import HoverTip from "./components/HoverTip.vue";
 import GridView from "./components/GridView.vue";
 import { useSessions } from "./composables/useSessions";
 import { useAppConfig } from "./composables/useAppConfig";
@@ -86,4 +87,8 @@ useFaviconState(sessions);
   <!-- Full-screen file explorer + editor; opened by the toolbar's Files button, or by a terminal
        header's Files button rooted at that terminal's own directory. -->
   <FilesOverlay />
+  <!-- The one hover tip every cell-header chip opens (#1235). Mounted here, and only here, so the
+       document can never hold two — it teleports to <body> and positions itself against whichever
+       chip the pointer is on. -->
+  <HoverTip />
 </template>

--- a/src/components/CellShell.vue
+++ b/src/components/CellShell.vue
@@ -16,6 +16,8 @@ import CellChromeButtons from "./CellChromeButtons.vue";
 import { cellChromeBinding, type CellChromeSource } from "./cellChromeBinding";
 import { useCellChrome } from "../composables/useCellChrome";
 import { formatCwd } from "./cwdDisplay";
+import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
+import { textTip } from "./tipContent";
 import { shouldZoomOnHeaderClick } from "./cellHeaderZoom";
 import {
   CELL_ACTIONS,
@@ -67,6 +69,11 @@ const { config: dirConfig, cellStyle, headerStyle } = useCellChrome(toRef(() => 
 
 const dirDisplay = computed(() => formatCwd(props.cwd, props.home));
 
+// The header shows the path shortened to fit; the tip is the full one. Anchored on the dir span
+// only — the running/idle dot beside it keeps its `title`, since a two-word state does not need a
+// panel and the dot is not what anyone hovers to read.
+const { described: dirDescribed, show: showDirTip, hide: hideDirTip } = useHoverTipAnchor(() => textTip(props.cwd));
+
 // Clicking the header background zooms (switches to) this cell, except the already-expanded one.
 // Buttons keep their action.
 function onHeaderClick(event: MouseEvent) {
@@ -83,7 +90,15 @@ function onHeaderClick(event: MouseEvent) {
           :class="[CELL_DOT, finished ? `is-idle ${CELL_DOT_IDLE}` : `is-working ${CELL_DOT_WORKING}`]"
           :title="finished ? idleTitle : 'Running…'"
         />
-        <span v-if="dirDisplay" class="cell-dir" :class="CELL_DIR" :title="cwd ?? ''"
+        <span
+          v-if="dirDisplay"
+          class="cell-dir"
+          :class="CELL_DIR"
+          :aria-describedby="dirDescribed ? HOVER_TIP_ID : undefined"
+          @pointerenter="showDirTip"
+          @pointerleave="hideDirTip"
+          @focusin="showDirTip"
+          @focusout="hideDirTip"
           ><span class="cell-dir-path" :class="CELL_DIR_PATH">{{ dirDisplay }}</span></span
         >
         <DirBadge :name="dirConfig.name" :color="dirConfig.badgeColor" />

--- a/src/components/CockpitHeader.vue
+++ b/src/components/CockpitHeader.vue
@@ -8,7 +8,9 @@ import { computed } from "vue";
 import { formatCwd } from "./cwdDisplay";
 import { CELL_DIR_PATH, DIR_TRUNCATE_FRONT } from "./cellChromeClasses";
 import { headerStyleFor } from "./cellHeaderStyle";
+import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
 import { phaseDisplay, WORK_WORD, type PrPhase, type WorkPhase } from "./rosterPhase";
+import { textTip } from "./tipContent";
 import type { AttentionStatus } from "./attentionStatus";
 import { agentBadge } from "../../common/sessionAgent";
 
@@ -48,6 +50,12 @@ const PHASE_CLASS: Record<string, string> = {
 // A working cell shows what it's doing (planning / editing) when known, else the plain word.
 const badgeWord = computed(() => (props.status === "working" && props.workPhase ? WORK_WORD[props.workPhase] : STATUS_WORD[props.status]));
 const phaseInfo = computed(() => phaseDisplay(props.phase ?? "none"));
+
+// The roster row is its own template, not a TerminalCell (docs/grid-view-modes.md), so it binds the
+// shared tip itself. Its two chips are the ones that hide something: a phase pill abbreviated to a
+// word, and a path truncated from the front.
+const { described: phaseDescribed, show: showPhaseTip, hide: hidePhaseTip } = useHoverTipAnchor(() => textTip(phaseInfo.value?.title));
+const { described: dirDescribed, show: showDirTip, hide: hideDirTip } = useHoverTipAnchor(() => textTip(props.cwd));
 // Null for claude (the default, so nearly every row) and for a shell, which is not an agent.
 const badge = computed(() => agentBadge(props.agent));
 const phaseColor = computed(() => PHASE_CLASS[props.phase ?? "none"] ?? "text-[#9aa4b2]");
@@ -68,7 +76,11 @@ const barStyle = computed(() => headerStyleFor(props.headerColor, props.headerTe
       data-testid="cockpit-phase"
       class="flex-none whitespace-nowrap rounded-full border border-current px-1.5 text-[10px] font-bold"
       :class="[`ph-${phase}`, phaseColor]"
-      :title="phaseInfo.title"
+      :aria-describedby="phaseDescribed ? HOVER_TIP_ID : undefined"
+      @pointerenter="showPhaseTip"
+      @pointerleave="hidePhaseTip"
+      @focusin="showPhaseTip"
+      @focusout="hidePhaseTip"
       >{{ phaseInfo.label }}</span
     >
     <span v-if="badge" class="flex-none rounded-[4px] border border-border px-1 text-[10px] text-[#9ab]">{{ badge.full }}</span>
@@ -76,7 +88,11 @@ const barStyle = computed(() => headerStyleFor(props.headerColor, props.headerTe
       data-testid="cockpit-dir"
       class="min-w-0 flex-auto text-[11px] text-[var(--cell-header-fg,var(--text-dim))]"
       :class="DIR_TRUNCATE_FRONT"
-      :title="cwd ?? ''"
+      :aria-describedby="dirDescribed ? HOVER_TIP_ID : undefined"
+      @pointerenter="showDirTip"
+      @pointerleave="hideDirTip"
+      @focusin="showDirTip"
+      @focusout="hideDirTip"
       ><span :class="CELL_DIR_PATH">{{ dirText }}</span></span
     >
     <slot />

--- a/src/components/DirBadge.vue
+++ b/src/components/DirBadge.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
 import { badgeStyleFor } from "./dirBadge";
+import { textTip } from "./tipContent";
 
 // The directory's `name` from .mulmoterminal.json, as the coloured chip in a GRID cell's header.
 // Shared by all three grid cells (Claude/codex, launcher, command) so a project reads the same
@@ -7,7 +9,10 @@ import { badgeStyleFor } from "./dirBadge";
 //
 // The single view's badge (Terminal.vue) is deliberately NOT this component: its header has more
 // room and uses a wider cap and looser leading, and unifying them would change how it looks.
-defineProps<{ name: string | null | undefined; color: string | null | undefined }>();
+const props = defineProps<{ name: string | null | undefined; color: string | null | undefined }>();
+
+// The badge truncates at 14ch, so the tip is the only place a longer project name is readable.
+const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => textTip(props.name));
 </script>
 
 <template>
@@ -15,7 +20,11 @@ defineProps<{ name: string | null | undefined; color: string | null | undefined 
     v-if="name"
     class="max-w-[14ch] flex-none truncate rounded-[10px] px-[7px] py-px font-sans text-[11px] font-semibold"
     :style="badgeStyleFor(color)"
-    :title="name"
+    :aria-describedby="described ? HOVER_TIP_ID : undefined"
+    @pointerenter="showTip"
+    @pointerleave="hideTip"
+    @focusin="showTip"
+    @focusout="hideTip"
     >{{ name }}</span
   >
 </template>

--- a/src/components/GitBranchChip.vue
+++ b/src/components/GitBranchChip.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { GitStatus } from "../../common/gitStatus";
+import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
+import { gitTip } from "./tipContent";
 
 // `hideDirty` suppresses the dirty count for worktree cells, which already show
 // ahead/dirty vs their base branch in the diff badge next to this chip.
@@ -8,15 +10,9 @@ const props = defineProps<{ status: GitStatus | null; hideDirty?: boolean }>();
 
 const label = computed(() => (props.status?.detached ? "detached" : (props.status?.branch ?? "")));
 
-const title = computed(() => {
-  const s = props.status;
-  if (!s?.repo) return "";
-  const parts = [s.detached ? "detached HEAD" : `branch ${s.branch}`];
-  if (s.dirty > 0) parts.push(`${s.dirty} uncommitted`);
-  if (s.upstream && s.ahead > 0) parts.push(`${s.ahead} ahead`);
-  if (s.upstream && s.behind > 0) parts.push(`${s.behind} behind`);
-  return parts.join(" · ");
-});
+// The tip keeps the full branch name, which the chip truncates at 16ch — the part a long
+// `fix/1235-…` name loses is exactly the part that says what the branch is for.
+const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => gitTip(props.status));
 </script>
 
 <template>
@@ -25,7 +21,11 @@ const title = computed(() => {
     data-testid="git-chip"
     class="inline-flex flex-none items-center gap-[0.25em] px-[0.4em] h-[1.5em] rounded-[0.75em] text-[0.72rem] leading-[1.5em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] opacity-85 whitespace-nowrap max-w-[16ch] overflow-hidden"
     :class="status.detached ? 'text-[#d19a66]' : 'text-inherit'"
-    :title="title"
+    :aria-describedby="described ? HOVER_TIP_ID : undefined"
+    @pointerenter="showTip"
+    @pointerleave="hideTip"
+    @focusin="showTip"
+    @focusout="hideTip"
   >
     <span data-testid="git-branch" class="overflow-hidden text-ellipsis">⎇ {{ label }}</span>
     <span v-if="!hideDirty && status.dirty > 0" data-testid="git-dirty" class="text-[#e5c07b]">●{{ status.dirty }}</span>

--- a/src/components/HoverTip.vue
+++ b/src/components/HoverTip.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+// The one hover tip on screen (#1235). Mounted once by App.vue; every cell-header chip opens THIS
+// one through useHoverTip.
+//
+// Teleported to <body> and fixed-positioned for the same reason CockpitRowMenu is: a grid cell is
+// `overflow-hidden`, so a tip left where its chip lives is clipped by the cell that owns the chip —
+// which is exactly the cell whose header you are reading. Fixed also means it cannot widen a
+// column: it overlays, so a narrow screen loses no room to it (the request).
+//
+// `font-sans` is spelled out for the same reason: this app sets no font on <body> (it renders
+// Times), each element carries its own utility instead — so a teleported panel inherits the
+// browser default and comes out in a serif nobody chose. Only visible in a real browser; jsdom
+// resolves no fonts at all.
+import { computed, nextTick, ref, watch, onBeforeUnmount, useTemplateRef, type CSSProperties } from "vue";
+import { HOVER_TIP_ID, hideHoverTip, useHoverTipState } from "../composables/useHoverTip";
+import { placeHoverTip } from "../composables/hoverTipPlacement";
+
+const { tip } = useHoverTipState();
+const box = useTemplateRef<HTMLElement>("box");
+const pos = ref({ top: 0, left: 0 });
+// Drawn only once it has been measured and placed, so the first frame is not painted at 0,0 and
+// then jumped to where it belongs.
+const placed = ref(false);
+
+// Measured AFTER the content renders: the height depends on how many sections there are and on how
+// far a PR title wraps, and placing it from a guess is what puts a two-line tip off the bottom of a
+// short window.
+watch(
+  tip,
+  async (open) => {
+    placed.value = false;
+    if (!open) return;
+    await nextTick();
+    const el = box.value;
+    if (!el) return;
+    pos.value = placeHoverTip(open.anchor, { width: el.offsetWidth, height: el.offsetHeight }, { width: window.innerWidth, height: window.innerHeight });
+    placed.value = true;
+  },
+  { flush: "post" },
+);
+
+// Anything that moves the chip out from under a fixed tip closes it. A scroll is the common one —
+// the roster scrolls, the grid pages — and the capture phase catches the inner scrollers too. A
+// pointerdown covers the case no leave event can: the chip's cell being closed under the pointer.
+const CLOSING_EVENTS = ["scroll", "resize", "pointerdown"] as const;
+const listenWhileOpen = (open: boolean): void => {
+  CLOSING_EVENTS.forEach((name) => {
+    if (open) window.addEventListener(name, hideHoverTip, true);
+    else window.removeEventListener(name, hideHoverTip, true);
+  });
+};
+watch(tip, (open) => listenWhileOpen(open !== null));
+onBeforeUnmount(() => listenWhileOpen(false));
+
+const style = computed<CSSProperties>(() => ({ top: `${pos.value.top}px`, left: `${pos.value.left}px`, visibility: placed.value ? "visible" : "hidden" }));
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="tip"
+      :id="HOVER_TIP_ID"
+      ref="box"
+      data-testid="hover-tip"
+      role="tooltip"
+      class="pointer-events-none fixed z-[110] max-w-[min(24rem,calc(100vw-1rem))] rounded-lg border border-border bg-panel px-2.5 py-1.5 font-sans text-[11px] leading-snug text-fg shadow-xl"
+      :style="style"
+    >
+      <div v-for="(sec, i) in tip.content" :key="i" :class="i > 0 ? 'mt-1.5' : ''">
+        <div data-testid="hover-tip-head" class="whitespace-nowrap font-semibold">{{ sec.head }}</div>
+        <div v-if="sec.note" data-testid="hover-tip-note" class="mt-0.5 text-dim">{{ sec.note }}</div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/src/components/ModelContextBadge.vue
+++ b/src/components/ModelContextBadge.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
 import { modelBadge, type BadgeAgent } from "./modelBadge";
+import { badgeTip } from "./tipContent";
 
 // Which model is running + how full its context is, e.g. `Opus · ctx 35%`. Nothing renders until
-// the transcript has told us the model; the text and tooltip are decided in ./modelBadge.
+// the transcript has told us the model; the text and the tip's wording are decided in ./modelBadge.
 const props = defineProps<{
   agent: BadgeAgent;
   model: string | null;
@@ -11,10 +13,21 @@ const props = defineProps<{
 }>();
 
 const badge = computed(() => (props.model ? modelBadge(props.agent, props.model, props.contextTokens) : null));
+
+// The badge shortens the model to `Opus`; the tip is where the full name and the token counts live.
+const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => badgeTip(badge.value?.title ?? ""));
 </script>
 
 <template>
-  <span v-if="badge" data-testid="model-badge" class="flex-none font-mono text-[10px] text-dim whitespace-nowrap tracking-[0.02em]" :title="badge.title">{{
-    badge.text
-  }}</span>
+  <span
+    v-if="badge"
+    data-testid="model-badge"
+    class="flex-none whitespace-nowrap font-mono text-[10px] tracking-[0.02em] text-dim"
+    :aria-describedby="described ? HOVER_TIP_ID : undefined"
+    @pointerenter="showTip"
+    @pointerleave="hideTip"
+    @focusin="showTip"
+    @focusout="hideTip"
+    >{{ badge.text }}</span
+  >
 </template>

--- a/src/components/WorkItemChip.vue
+++ b/src/components/WorkItemChip.vue
@@ -9,19 +9,19 @@
 import { computed } from "vue";
 import type { WorkItem } from "../../common/prPhase";
 import { hasWorkToShow } from "../composables/useWorkItem";
+import { HOVER_TIP_ID, useHoverTipAnchor } from "../composables/useHoverTip";
 import { phaseDisplay } from "./rosterPhase";
+import { workTip } from "./tipContent";
 
 const props = defineProps<{ item: WorkItem }>();
 
 const show = computed(() => hasWorkToShow(props.item));
 const phase = computed(() => phaseDisplay(props.item.phase));
 
-const title = computed(() => {
-  const parts: string[] = [];
-  if (props.item.pr !== null) parts.push(phase.value ? `PR #${props.item.pr} — ${phase.value.title}` : `PR #${props.item.pr}`);
-  if (props.item.issue !== null) parts.push(`issue #${props.item.issue}`);
-  return parts.join(" · ");
-});
+// The hover tip carries what the chip has no room for: what the PR and the issue actually ARE.
+// Those titles have been arriving since #1014 and were shown nowhere on the desktop, which is why
+// the chip could say `#2689 → #2688` and still leave you opening GitHub to find out which is which.
+const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => workTip(props.item));
 </script>
 
 <template>
@@ -29,7 +29,11 @@ const title = computed(() => {
     v-if="show"
     data-testid="work-chip"
     class="inline-flex h-[1.5em] max-w-[18ch] flex-none items-center gap-[0.25em] overflow-hidden whitespace-nowrap rounded-[0.75em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] px-[0.4em] text-[0.72rem] leading-[1.5em] opacity-85"
-    :title="title"
+    :aria-describedby="described ? HOVER_TIP_ID : undefined"
+    @pointerenter="showTip"
+    @pointerleave="hideTip"
+    @focusin="showTip"
+    @focusout="hideTip"
   >
     <a
       v-if="item.pr !== null"

--- a/src/components/rosterPhase.ts
+++ b/src/components/rosterPhase.ts
@@ -9,16 +9,20 @@ import type { PrPhase } from "../../common/prPhase";
 // shows the agent status until a PR exists.
 interface PhaseDisplay {
   label: string;
+  /** Standalone wording, for a place that has not already said what it is talking about. */
   title: string;
+  /** The same state where the PR is ALREADY named. Without it, a heading that begins `PR #2689`
+   *  runs into a title that begins `PR —` and reads `PR #2689 · PR — CI running` (#1235). */
+  state: string;
 }
 const DISPLAY: Record<Exclude<PrPhase, "none">, PhaseDisplay> = {
-  draft: { label: "draft", title: "Draft PR" },
-  "ci-failing": { label: "CI fail", title: "PR — CI failing" },
-  "changes-requested": { label: "changes", title: "PR — changes requested" },
-  "ci-running": { label: "CI…", title: "PR — CI running" },
-  ready: { label: "ready", title: "PR ready to merge" },
-  merged: { label: "merged", title: "PR merged" },
-  closed: { label: "closed", title: "PR closed" },
+  draft: { label: "draft", title: "Draft PR", state: "draft" },
+  "ci-failing": { label: "CI fail", title: "PR — CI failing", state: "CI failing" },
+  "changes-requested": { label: "changes", title: "PR — changes requested", state: "changes requested" },
+  "ci-running": { label: "CI…", title: "PR — CI running", state: "CI running" },
+  ready: { label: "ready", title: "PR ready to merge", state: "ready to merge" },
+  merged: { label: "merged", title: "PR merged", state: "merged" },
+  closed: { label: "closed", title: "PR closed", state: "closed" },
 };
 
 export const phaseDisplay = (phase: PrPhase): PhaseDisplay | null => (phase === "none" ? null : DISPLAY[phase]);

--- a/src/components/tipContent.ts
+++ b/src/components/tipContent.ts
@@ -1,0 +1,60 @@
+// What each cell-header chip says when you hover it (#1235).
+//
+// Pure builders, one per chip, because this is the content the change exists to improve and the
+// interesting cases are all absences: a repo with no upstream, a model whose window is unknown, a
+// PR whose title has not been fetched. Each builder drops the section it cannot fill rather than
+// showing a heading with nothing under it.
+import type { GitStatus } from "../../common/gitStatus";
+import type { WorkItem } from "../../common/prPhase";
+import { phaseDisplay } from "./rosterPhase";
+
+export interface TipSection {
+  /** The line that names the thing. */
+  head: string;
+  /** What it is, in words — a PR's title, an issue's. Absent when nobody could tell us. */
+  note?: string;
+}
+
+export type TipContent = TipSection[];
+
+const section = (head: string, note: string | null | undefined): TipSection => (note ? { head, note } : { head });
+
+/** The PR and the issue behind it, each with the TITLE — which the desktop has been receiving and
+ *  throwing away since #1014, and which is the whole reason a number alone was not enough. */
+export function workTip(item: WorkItem): TipContent {
+  const phase = phaseDisplay(item.phase);
+  const out: TipContent = [];
+  // `phase.state`, not `phase.title`: the heading has already said "PR", and the standalone
+  // wording says it again — which is the `PR #2689 — PR — CI running` in the report.
+  if (item.pr !== null) out.push(section(phase ? `PR #${item.pr} · ${phase.state}` : `PR #${item.pr}`, item.prTitle));
+  if (item.issue !== null) out.push(section(`issue #${item.issue}`, item.issueTitle));
+  return out;
+}
+
+// The counts spelled out as words. `title` said `2 uncommitted · 1 ahead`; the difference here is
+// that the branch gets a line of its own, so a long branch name stops competing with the numbers.
+export function gitTip(status: GitStatus | null): TipContent {
+  if (!status?.repo) return [];
+  const counts: string[] = [];
+  if (status.dirty > 0) counts.push(`${status.dirty} uncommitted`);
+  if (status.upstream && status.ahead > 0) counts.push(`${status.ahead} ahead`);
+  if (status.upstream && status.behind > 0) counts.push(`${status.behind} behind`);
+  return [{ head: status.detached ? "detached HEAD" : `branch ${status.branch}` }, ...(counts.length ? [{ head: counts.join(" · ") }] : [])];
+}
+
+/** A one-line `title` split at the separator it already used, so the model and the context reading
+ *  stop sharing a line. Built from the string rather than from the parts because `modelBadge` is
+ *  what decides how a context reading is worded (measured / overflow / unknown), and restating
+ *  that here would be a second copy of a rule that has three cases. */
+export function badgeTip(title: string): TipContent {
+  return title
+    .split(" · ")
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .map((head) => ({ head }));
+}
+
+/** One line, for the chips whose whole tip is a name or a path. */
+export function textTip(text: string | null | undefined): TipContent {
+  return text?.trim() ? [{ head: text.trim() }] : [];
+}

--- a/src/composables/hoverTipPlacement.ts
+++ b/src/composables/hoverTipPlacement.ts
@@ -1,0 +1,56 @@
+// Where the hover tip goes, given the thing it describes and the room around it (#1235).
+//
+// Pure, because the two rules it encodes are the whole reason the tip is usable at all and each
+// one has a cell geometry that breaks it: a grid runs to nine cells, so a header chip is routinely
+// within a tip's width of the viewport edge and within a tip's height of the bottom.
+
+export interface TipRect {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+export interface TipSize {
+  width: number;
+  height: number;
+}
+
+export interface TipViewport {
+  width: number;
+  height: number;
+}
+
+export interface TipPosition {
+  top: number;
+  left: number;
+}
+
+/** Between the anchor and the tip, and between the tip and the viewport edge. */
+const GAP_PX = 6;
+const EDGE_PX = 8;
+
+// Below the anchor unless the tip would run off the bottom, in which case above it. Flipping
+// rather than shrinking: a tip that fits by wrapping to six lines is not more readable than one
+// that moved.
+function verticalTop(anchor: TipRect, tip: TipSize, viewport: TipViewport): number {
+  const below = anchor.bottom + GAP_PX;
+  if (below + tip.height <= viewport.height - EDGE_PX) return below;
+  const above = anchor.top - GAP_PX - tip.height;
+  // Only when there is genuinely room above: a tall tip against a short viewport would otherwise
+  // be placed off the top, which is worse than overflowing the bottom (nothing scrolls it back).
+  return above >= EDGE_PX ? above : below;
+}
+
+// Left-aligned with the anchor, then pulled back inside the viewport. The pull is what a chip at
+// the right-hand edge of the last grid column needs, and it is why the tip is not simply
+// `position: absolute` next to the chip.
+function horizontalLeft(anchor: TipRect, tip: TipSize, viewport: TipViewport): number {
+  const rightMost = viewport.width - EDGE_PX - tip.width;
+  // A tip wider than the viewport clamps to the left edge rather than to a negative `rightMost`.
+  return Math.round(Math.max(EDGE_PX, Math.min(anchor.left, Math.max(EDGE_PX, rightMost))));
+}
+
+export function placeHoverTip(anchor: TipRect, tip: TipSize, viewport: TipViewport): TipPosition {
+  return { top: Math.round(verticalTop(anchor, tip, viewport)), left: horizontalLeft(anchor, tip, viewport) };
+}

--- a/src/composables/useHoverTip.ts
+++ b/src/composables/useHoverTip.ts
@@ -12,7 +12,7 @@
 //
 // No delay. That is the request, and it is also why `title` could not be kept: its delay belongs to
 // the browser and is not settable from CSS or script.
-import { ref, type Ref } from "vue";
+import { computed, ref, type ComputedRef, type Ref } from "vue";
 import type { TipContent } from "../components/tipContent";
 import type { TipRect } from "./hoverTipPlacement";
 
@@ -23,6 +23,9 @@ export const HOVER_TIP_ID = "hover-tip";
 export interface OpenTip {
   content: TipContent;
   anchor: TipRect;
+  /** Which anchor this tip belongs to, so an anchor can tell whether it is the one being
+   *  described. See `useHoverTipAnchor` — it is why that is derived rather than remembered. */
+  owner: number;
 }
 
 const tip = ref<OpenTip | null>(null);
@@ -37,10 +40,10 @@ const rectOf = (el: Element): TipRect => {
  *  Empty content CLOSES rather than opening an empty box: every builder in tipContent.ts answers
  *  `[]` for a state it cannot describe (a directory that is not a repo, a work item still being
  *  fetched), so this is the ordinary case for a chip whose data has not arrived yet. */
-export function showHoverTip(event: Event, content: TipContent): boolean {
+export function showHoverTip(event: Event, content: TipContent, owner = 0): boolean {
   const el = event.currentTarget;
   const open = el instanceof Element && content.length > 0;
-  tip.value = open && el instanceof Element ? { content, anchor: rectOf(el) } : null;
+  tip.value = open && el instanceof Element ? { content, anchor: rectOf(el), owner } : null;
   return open;
 }
 
@@ -48,21 +51,23 @@ export function hideHoverTip(): void {
   tip.value = null;
 }
 
+let nextAnchorId = 0;
+
 /** Bind a chip to the shared tip. `content` is read at hover time rather than watched, because a
  *  header polls (git status, work item, context) and the value wanted is the one on screen now.
  *
- *  `described` is per-anchor so the chip can carry `aria-describedby` only while ITS tip is up —
- *  pointing at the tip while it describes a different chip would misread it to a screen reader. */
-export function useHoverTipAnchor(content: () => TipContent) {
-  const described = ref(false);
+ *  `described` is DERIVED from the shared state, not remembered locally. A local mirror goes stale
+ *  the moment anything closes the tip without telling this anchor — a scroll, a resize, a
+ *  pointerdown, all of which HoverTip.vue listens for — and the chip is then left pointing
+ *  `aria-describedby` at an element that no longer exists (Codex, this PR). Derived, one anchor at
+ *  a time is true by construction and closing needs to tell nobody. */
+export function useHoverTipAnchor(content: () => TipContent): { described: ComputedRef<boolean>; show: (event: Event) => void; hide: () => void } {
+  const id = ++nextAnchorId;
+  const described = computed(() => tip.value?.owner === id);
   const show = (event: Event): void => {
-    described.value = showHoverTip(event, content());
+    showHoverTip(event, content(), id);
   };
-  const hide = (): void => {
-    described.value = false;
-    hideHoverTip();
-  };
-  return { described, show, hide };
+  return { described, show, hide: hideHoverTip };
 }
 
 export function useHoverTipState(): { tip: Ref<OpenTip | null> } {

--- a/src/composables/useHoverTip.ts
+++ b/src/composables/useHoverTip.ts
@@ -51,6 +51,8 @@ export function hideHoverTip(): void {
   tip.value = null;
 }
 
+// Ids start at 1, so the `owner = 0` default above means "opened by no anchor" and can never be
+// mistaken for one. Handing out 0 would make whichever chip holds it claim every such tip.
 let nextAnchorId = 0;
 
 /** Bind a chip to the shared tip. `content` is read at hover time rather than watched, because a

--- a/src/composables/useHoverTip.ts
+++ b/src/composables/useHoverTip.ts
@@ -1,0 +1,70 @@
+// The cell header's hover tips (#1235): one shared tip, opened by whichever chip the pointer is on.
+//
+// A SINGLETON with handlers bound to the existing chip, rather than a wrapper component around each
+// one. Two reasons, both about the header: it is a flex row whose children carry `flex-none` and
+// `min-w-0` deliberately, so an extra element between them changes the layout the chips were tuned
+// in; and one tip in the document cannot become two, which a per-chip component can when a pointer
+// leaves one chip straight onto the next.
+//
+// Moving between chips needs no special handling: the DOM fires the old element's `pointerleave`
+// BEFORE the new one's `pointerenter`, so the close-then-open lands in one tick and Vue renders it
+// as a change of content rather than as a blink.
+//
+// No delay. That is the request, and it is also why `title` could not be kept: its delay belongs to
+// the browser and is not settable from CSS or script.
+import { ref, type Ref } from "vue";
+import type { TipContent } from "../components/tipContent";
+import type { TipRect } from "./hoverTipPlacement";
+
+/** The one tip element's id, so an anchor can point at it with `aria-describedby` while its own tip
+ *  is up. One id is enough precisely because there is only ever one tip. */
+export const HOVER_TIP_ID = "hover-tip";
+
+export interface OpenTip {
+  content: TipContent;
+  anchor: TipRect;
+}
+
+const tip = ref<OpenTip | null>(null);
+
+const rectOf = (el: Element): TipRect => {
+  const { top, bottom, left, right } = el.getBoundingClientRect();
+  return { top, bottom, left, right };
+};
+
+/** Show `content` describing the element the handler is bound to; answers whether it opened.
+ *
+ *  Empty content CLOSES rather than opening an empty box: every builder in tipContent.ts answers
+ *  `[]` for a state it cannot describe (a directory that is not a repo, a work item still being
+ *  fetched), so this is the ordinary case for a chip whose data has not arrived yet. */
+export function showHoverTip(event: Event, content: TipContent): boolean {
+  const el = event.currentTarget;
+  const open = el instanceof Element && content.length > 0;
+  tip.value = open && el instanceof Element ? { content, anchor: rectOf(el) } : null;
+  return open;
+}
+
+export function hideHoverTip(): void {
+  tip.value = null;
+}
+
+/** Bind a chip to the shared tip. `content` is read at hover time rather than watched, because a
+ *  header polls (git status, work item, context) and the value wanted is the one on screen now.
+ *
+ *  `described` is per-anchor so the chip can carry `aria-describedby` only while ITS tip is up —
+ *  pointing at the tip while it describes a different chip would misread it to a screen reader. */
+export function useHoverTipAnchor(content: () => TipContent) {
+  const described = ref(false);
+  const show = (event: Event): void => {
+    described.value = showHoverTip(event, content());
+  };
+  const hide = (): void => {
+    described.value = false;
+    hideHoverTip();
+  };
+  return { described, show, hide };
+}
+
+export function useHoverTipState(): { tip: Ref<OpenTip | null> } {
+  return { tip };
+}

--- a/test/src/components/CockpitHeader.spec.ts
+++ b/test/src/components/CockpitHeader.spec.ts
@@ -62,6 +62,9 @@ describe("CockpitHeader", () => {
     expect(dir.classes()).toContain("text-left");
     // rtl reorders punctuation unless the path text opts back into logical order.
     expect(dir.get("span").classes()).toContain("[unicode-bidi:plaintext]");
-    expect(dir.attributes("title")).toBe("/home/me/work/nested/deep/proj");
+    // The full path moved from a `title` to the shared hover tip (#1235) — asserted end to end in
+    // hoverTip.spec.ts. The attribute has to be gone, or the browser's own slow tooltip appears a
+    // second time on top of it.
+    expect(dir.attributes("title")).toBeUndefined();
   });
 });

--- a/test/src/components/ModelContextBadge.spec.ts
+++ b/test/src/components/ModelContextBadge.spec.ts
@@ -11,10 +11,14 @@ function mountBadge(props: { agent?: "claude" | "codex"; model: string | null; c
 }
 
 describe("ModelContextBadge", () => {
-  it("renders the badge text, with the tooltip on the same element", () => {
+  // The reading moved from a `title` to the shared hover tip (#1235): the browser's tooltip could
+  // not be made to appear promptly, and its one line had nowhere to put the full model name. What
+  // the tip says is pinned in tipContent.spec.ts; what matters here is that the attribute is GONE,
+  // or the old slow tooltip would surface a second time on top of the new one.
+  it("renders the badge text and no longer carries a native tooltip", () => {
     const badge = mountBadge({ model: "claude-opus-4-20250514", contextTokens: 70_000 }).find('[data-testid="model-badge"]');
     expect(badge.text()).toBe("Opus · ctx 35%");
-    expect(badge.attributes("title")).toContain("70,000 / 200,000 (35%)");
+    expect(badge.attributes("title")).toBeUndefined();
   });
 
   it("renders nothing when the model is unknown/null (no transcript model yet)", () => {

--- a/test/src/components/hoverTip.spec.ts
+++ b/test/src/components/hoverTip.spec.ts
@@ -59,6 +59,23 @@ describe("hovering a work chip", () => {
     expect(tipText()).toContain("a pull request");
   });
 
+  // Codex, on this PR. HoverTip closes on scroll / resize / pointerdown — events the chip never
+  // hears — so an anchor that REMEMBERED being described would keep pointing `aria-describedby` at
+  // an element that has been removed from the document. A screen reader then looks up nothing.
+  it.each(["scroll", "resize", "pointerdown"])("drops aria-describedby when a %s closes the tip", async (event) => {
+    mount(HoverTip);
+    const chip = mount(WorkItemChip, { props: { item: work({ phase: "ready", pr: 977 }) } });
+    const el = chip.get('[data-testid="work-chip"]');
+    await el.trigger("pointerenter");
+    expect(el.attributes("aria-describedby")).toBe(HOVER_TIP_ID);
+
+    window.dispatchEvent(new Event(event));
+    await nextTick();
+
+    expect(tipEl()).toBeNull();
+    expect(el.attributes("aria-describedby")).toBeUndefined();
+  });
+
   // Removing `title` takes the text away from assistive tech unless something replaces it.
   it("points at the tip with aria-describedby, and only while its own tip is up", async () => {
     mount(HoverTip);

--- a/test/src/components/hoverTip.spec.ts
+++ b/test/src/components/hoverTip.spec.ts
@@ -59,23 +59,6 @@ describe("hovering a work chip", () => {
     expect(tipText()).toContain("a pull request");
   });
 
-  // Codex, on this PR. HoverTip closes on scroll / resize / pointerdown — events the chip never
-  // hears — so an anchor that REMEMBERED being described would keep pointing `aria-describedby` at
-  // an element that has been removed from the document. A screen reader then looks up nothing.
-  it.each(["scroll", "resize", "pointerdown"])("drops aria-describedby when a %s closes the tip", async (event) => {
-    mount(HoverTip);
-    const chip = mount(WorkItemChip, { props: { item: work({ phase: "ready", pr: 977 }) } });
-    const el = chip.get('[data-testid="work-chip"]');
-    await el.trigger("pointerenter");
-    expect(el.attributes("aria-describedby")).toBe(HOVER_TIP_ID);
-
-    window.dispatchEvent(new Event(event));
-    await nextTick();
-
-    expect(tipEl()).toBeNull();
-    expect(el.attributes("aria-describedby")).toBeUndefined();
-  });
-
   // Removing `title` takes the text away from assistive tech unless something replaces it.
   it("points at the tip with aria-describedby, and only while its own tip is up", async () => {
     mount(HoverTip);
@@ -117,6 +100,26 @@ describe("the cockpit roster row", () => {
     await row.get('[data-testid="cockpit-dir"]').trigger("pointerenter");
     await nextTick();
     expect(tipText()).toBe("/home/me/work/nested/deep/proj");
+  });
+});
+
+// Codex, on this PR. HoverTip closes on scroll / resize / pointerdown — events the CHIP never
+// hears — so an anchor that REMEMBERED being described kept pointing `aria-describedby` at an
+// element no longer in the document, and a screen reader looked up nothing. Its own describe
+// block: this is about the layer's closing paths, not about any one chip.
+describe("closing the tip from outside the chip", () => {
+  it.each(["scroll", "resize", "pointerdown"])("drops aria-describedby when a %s closes it", async (event) => {
+    mount(HoverTip);
+    const chip = mount(WorkItemChip, { props: { item: work({ phase: "ready", pr: 977 }) } });
+    const el = chip.get('[data-testid="work-chip"]');
+    await el.trigger("pointerenter");
+    expect(el.attributes("aria-describedby")).toBe(HOVER_TIP_ID);
+
+    window.dispatchEvent(new Event(event));
+    await nextTick();
+
+    expect(tipEl()).toBeNull();
+    expect(el.attributes("aria-describedby")).toBeUndefined();
   });
 });
 

--- a/test/src/components/hoverTip.spec.ts
+++ b/test/src/components/hoverTip.spec.ts
@@ -1,0 +1,162 @@
+// The hover tip end to end (#1235): a chip is hovered, the one shared tip shows what that chip
+// could not fit, and nothing about it is deferred.
+import { describe, it, expect, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import HoverTip from "../../../src/components/HoverTip.vue";
+import WorkItemChip from "../../../src/components/WorkItemChip.vue";
+import GitBranchChip from "../../../src/components/GitBranchChip.vue";
+import CockpitHeader from "../../../src/components/CockpitHeader.vue";
+import { hideHoverTip, showHoverTip, HOVER_TIP_ID } from "../../../src/composables/useHoverTip";
+import type { TipContent } from "../../../src/components/tipContent";
+import { EMPTY_WORK_ITEM, type WorkItem } from "../../../common/prPhase";
+import type { GitStatus } from "../../../common/gitStatus";
+
+const work = (over: Partial<WorkItem>): WorkItem => ({ ...EMPTY_WORK_ITEM, ...over });
+
+const tipEl = () => document.querySelector('[data-testid="hover-tip"]');
+const tipText = () => tipEl()?.textContent ?? "";
+
+// The tip is teleported to <body>, so it outlives a wrapper unmount unless it is closed.
+beforeEach(() => hideHoverTip());
+
+describe("hovering a work chip", () => {
+  it("shows the PR and issue titles the chip has no room for", async () => {
+    mount(HoverTip);
+    const chip = mount(WorkItemChip, {
+      props: { item: work({ phase: "ci-running", pr: 2689, prTitle: "経路A/Bの分離実装", issue: 2688, issueTitle: "セッション復元が2経路" }) },
+    });
+
+    expect(tipEl()).toBeNull(); // nothing before the pointer arrives
+    await chip.get('[data-testid="work-chip"]').trigger("pointerenter");
+    await nextTick();
+
+    expect(tipText()).toContain("PR #2689 · CI running");
+    expect(tipText()).toContain("経路A/Bの分離実装");
+    expect(tipText()).toContain("issue #2688");
+    expect(tipText()).toContain("セッション復元が2経路");
+  });
+
+  it("closes when the pointer leaves", async () => {
+    mount(HoverTip);
+    const chip = mount(WorkItemChip, { props: { item: work({ phase: "ready", pr: 977 }) } });
+    await chip.get('[data-testid="work-chip"]').trigger("pointerenter");
+    await nextTick();
+    expect(tipEl()).not.toBeNull();
+
+    await chip.get('[data-testid="work-chip"]').trigger("pointerleave");
+    await nextTick();
+    expect(tipEl()).toBeNull();
+  });
+
+  // The chip's numbers are links, so a keyboard user reaches them — and would otherwise be the one
+  // person who never sees what the PR is.
+  it("shows on focus too, not only on hover", async () => {
+    mount(HoverTip);
+    const chip = mount(WorkItemChip, { props: { item: work({ phase: "ready", pr: 977, prTitle: "a pull request" }) } });
+    await chip.get('[data-testid="work-chip"]').trigger("focusin");
+    await nextTick();
+    expect(tipText()).toContain("a pull request");
+  });
+
+  // Removing `title` takes the text away from assistive tech unless something replaces it.
+  it("points at the tip with aria-describedby, and only while its own tip is up", async () => {
+    mount(HoverTip);
+    const chip = mount(WorkItemChip, { props: { item: work({ phase: "ready", pr: 977 }) } });
+    const el = chip.get('[data-testid="work-chip"]');
+    expect(el.attributes("aria-describedby")).toBeUndefined();
+
+    await el.trigger("pointerenter");
+    expect(el.attributes("aria-describedby")).toBe(HOVER_TIP_ID);
+
+    await el.trigger("pointerleave");
+    expect(el.attributes("aria-describedby")).toBeUndefined();
+  });
+});
+
+// The roster row is a SEPARATE component, not a TerminalCell (docs/grid-view-modes.md), so wiring
+// the cell's chips leaves it untouched — the trap that doc exists to warn about. Asserted here so
+// "the header has instant tips" cannot be true in two view modes and false in the third.
+describe("the cockpit roster row", () => {
+  it("opens the tip from its own phase pill and path", async () => {
+    mount(HoverTip);
+    const row = mount(CockpitHeader, {
+      props: {
+        status: "working",
+        agent: "claude",
+        cwd: "/home/me/work/nested/deep/proj",
+        home: "/home/me",
+        headerColor: null,
+        headerTextColor: null,
+        phase: "ci-running",
+      },
+    });
+
+    await row.get('[data-testid="cockpit-phase"]').trigger("pointerenter");
+    await nextTick();
+    expect(tipText()).toContain("PR — CI running");
+
+    await row.get('[data-testid="cockpit-phase"]').trigger("pointerleave");
+    await row.get('[data-testid="cockpit-dir"]').trigger("pointerenter");
+    await nextTick();
+    expect(tipText()).toBe("/home/me/work/nested/deep/proj");
+  });
+});
+
+describe("the shared tip", () => {
+  // One element, whichever chip opened it: a per-chip tooltip can leave the previous one on screen
+  // when the pointer crosses straight from one chip to the next.
+  it("is a single element that changes content between chips", async () => {
+    mount(HoverTip);
+    const chip = mount(WorkItemChip, { props: { item: work({ phase: "ready", pr: 977 }) } });
+    const branch = mount(GitBranchChip, {
+      props: { status: { repo: true, branch: "fix/1235-instant-header-tips", detached: false, dirty: 2, ahead: 0, behind: 0, upstream: true } as GitStatus },
+    });
+
+    await chip.get('[data-testid="work-chip"]').trigger("pointerenter");
+    await nextTick();
+    expect(tipText()).toContain("PR #977");
+
+    // Leaving the first fires BEFORE entering the second, which is the ordering the singleton
+    // relies on — assert the end state has one tip holding the second chip's content.
+    await chip.get('[data-testid="work-chip"]').trigger("pointerleave");
+    await branch.get('[data-testid="git-chip"]').trigger("pointerenter");
+    await nextTick();
+
+    expect(document.querySelectorAll('[data-testid="hover-tip"]')).toHaveLength(1);
+    expect(tipText()).toContain("branch fix/1235-instant-header-tips");
+    expect(tipText()).toContain("2 uncommitted");
+    expect(tipText()).not.toContain("PR #977");
+  });
+
+  // Empty content means "nothing worth saying" and must not open an empty panel. Asserted on the
+  // layer rather than through a chip: every chip that RENDERS today also has something to say
+  // (a chip with no repo, no work item and no name does not render at all), so a component-level
+  // version of this would be theatre. This is the guard that keeps that true as builders change.
+  it("does not open for content with no sections", async () => {
+    mount(HoverTip);
+    // A real dispatch rather than a hand-built object: `currentTarget` is what the handler reads,
+    // and it is only ever set by an actual dispatch.
+    const el = document.createElement("span");
+    document.body.appendChild(el);
+    const enter = (content: TipContent): boolean => {
+      let opened = false;
+      const handler = (event: Event) => {
+        opened = showHoverTip(event, content);
+      };
+      el.addEventListener("pointerenter", handler);
+      el.dispatchEvent(new Event("pointerenter"));
+      el.removeEventListener("pointerenter", handler);
+      return opened;
+    };
+
+    expect(enter([])).toBe(false);
+    await nextTick();
+    expect(tipEl()).toBeNull();
+
+    expect(enter([{ head: "something" }])).toBe(true);
+    await nextTick();
+    expect(tipText()).toContain("something");
+    el.remove();
+  });
+});

--- a/test/src/components/tipContent.spec.ts
+++ b/test/src/components/tipContent.spec.ts
@@ -1,0 +1,90 @@
+// What each cell-header chip says on hover (#1235). The interesting cases are the absences: a
+// section with a heading and nothing under it is worse than no section, and it is what a naive
+// builder produces for a PR whose title has not been fetched.
+import { describe, it, expect } from "vitest";
+import { badgeTip, gitTip, textTip, workTip } from "../../../src/components/tipContent";
+import { EMPTY_WORK_ITEM, type WorkItem } from "../../../common/prPhase";
+import type { GitStatus } from "../../../common/gitStatus";
+
+const work = (over: Partial<WorkItem>): WorkItem => ({ ...EMPTY_WORK_ITEM, ...over });
+const git = (over: Partial<GitStatus>): GitStatus =>
+  ({ repo: true, branch: "main", detached: false, dirty: 0, ahead: 0, behind: 0, upstream: true, ...over }) as GitStatus;
+
+describe("workTip", () => {
+  // The point of the whole change: these titles have been arriving since #1014 and the desktop
+  // showed neither of them, so the header could say `#2689 → #2688` and you still had to open
+  // GitHub to learn which request that was.
+  it("names the PR and the issue in words, not just numbers", () => {
+    const tip = workTip(work({ phase: "ci-running", pr: 2689, prTitle: "経路A/Bの分離実装", issue: 2688, issueTitle: "セッション復元が2経路に分かれている" }));
+    expect(tip).toEqual([
+      { head: "PR #2689 · CI running", note: "経路A/Bの分離実装" },
+      { head: "issue #2688", note: "セッション復元が2経路に分かれている" },
+    ]);
+  });
+
+  it("drops the note when nobody could tell us the title", () => {
+    expect(workTip(work({ phase: "ready", pr: 977 }))).toEqual([{ head: "PR #977 · ready to merge" }]);
+  });
+
+  it("shows the issue alone before a PR exists", () => {
+    expect(workTip(work({ phase: "none", issue: 979, issueTitle: "work item" }))).toEqual([{ head: "issue #979", note: "work item" }]);
+  });
+
+  // Nothing to describe: the tip layer reads an empty list as "do not open", so a chip whose poll
+  // has not answered yet stays silent rather than flashing an empty box.
+  it("says nothing when there is neither", () => {
+    expect(workTip(work({}))).toEqual([]);
+  });
+});
+
+describe("gitTip", () => {
+  it("gives the branch its own line, then the counts", () => {
+    expect(gitTip(git({ branch: "fix/1235-instant-header-tips", dirty: 2, ahead: 1 }))).toEqual([
+      { head: "branch fix/1235-instant-header-tips" },
+      { head: "2 uncommitted · 1 ahead" },
+    ]);
+  });
+
+  it("omits the counts line when the tree is clean and level", () => {
+    expect(gitTip(git({}))).toEqual([{ head: "branch main" }]);
+  });
+
+  // Ahead/behind against no upstream is not a fact, so it must not be stated — the same rule the
+  // chip itself follows.
+  it("ignores ahead/behind with no upstream", () => {
+    expect(gitTip(git({ upstream: false, ahead: 3, behind: 2, dirty: 1 }))).toEqual([{ head: "branch main" }, { head: "1 uncommitted" }]);
+  });
+
+  it("says detached rather than naming a branch", () => {
+    expect(gitTip(git({ detached: true, branch: null }))).toEqual([{ head: "detached HEAD" }]);
+  });
+
+  it("says nothing outside a repo", () => {
+    expect(gitTip(null)).toEqual([]);
+    expect(gitTip(git({ repo: false }))).toEqual([]);
+  });
+});
+
+describe("badgeTip", () => {
+  it("splits the model from its context reading, so neither shares a line", () => {
+    expect(badgeTip("Claude · claude-opus-4 · context 70,000 / 200,000 (35%) tokens")).toEqual([
+      { head: "Claude" },
+      { head: "claude-opus-4" },
+      { head: "context 70,000 / 200,000 (35%) tokens" },
+    ]);
+  });
+
+  it("says nothing when there is no badge to describe", () => {
+    expect(badgeTip("")).toEqual([]);
+  });
+});
+
+describe("textTip", () => {
+  it("carries one line", () => {
+    expect(textTip("/Users/x/ss/llm/mulmoterminal6")).toEqual([{ head: "/Users/x/ss/llm/mulmoterminal6" }]);
+  });
+
+  it.each([null, undefined, "", "   "])("says nothing for %p", (value) => {
+    expect(textTip(value)).toEqual([]);
+  });
+});

--- a/test/src/components/workItemChip.spec.ts
+++ b/test/src/components/workItemChip.spec.ts
@@ -114,7 +114,9 @@ describe("WorkItemChip", () => {
     expect(w.get('[data-testid="work-issue"]').text()).toBe("#966");
     expect(w.get('[data-testid="work-issue"]').attributes("href")).toBe("https://x/issues/966");
     expect(w.get('[data-testid="work-phase"]').text()).toBe("ready");
-    expect(w.get('[data-testid="work-chip"]').attributes("title")).toContain("PR #977");
+    // The detail moved to the shared hover tip (#1235) — see tipContent.spec.ts. The native
+    // attribute must be gone, or the browser's own slow tooltip appears on top of the new one.
+    expect(w.get('[data-testid="work-chip"]').attributes("title")).toBeUndefined();
   });
 
   it("renders the issue alone before a PR exists, with no arrow", () => {

--- a/test/src/composables/hoverTipPlacement.spec.ts
+++ b/test/src/composables/hoverTipPlacement.spec.ts
@@ -1,0 +1,41 @@
+// Where the hover tip lands (#1235). Both rules exist because of a geometry the grid actually
+// reaches: nine cells means a header chip sits within a tip's width of the right edge and within a
+// tip's height of the bottom, routinely.
+import { describe, it, expect } from "vitest";
+import { placeHoverTip, type TipRect } from "../../../src/composables/hoverTipPlacement";
+
+const anchor = (over: Partial<TipRect> = {}): TipRect => ({ top: 100, bottom: 120, left: 200, right: 260, ...over });
+const TIP = { width: 300, height: 80 };
+const SCREEN = { width: 1400, height: 900 };
+
+describe("placeHoverTip", () => {
+  it("sits just below the chip, left-aligned with it", () => {
+    expect(placeHoverTip(anchor(), TIP, SCREEN)).toEqual({ top: 126, left: 200 });
+  });
+
+  // A cell in the bottom row: below would be off-screen, and nothing scrolls a fixed element back.
+  it("flips above when there is no room below", () => {
+    expect(placeHoverTip(anchor({ top: 830, bottom: 850 }), TIP, SCREEN)).toEqual({ top: 744, left: 200 });
+  });
+
+  // Neither side fits — a short window. Below is the lesser evil: above would put the HEAD of the
+  // tip off the top, where the first line, the one that names the thing, is the part that is lost.
+  it("stays below when it fits neither way", () => {
+    expect(placeHoverTip(anchor({ top: 60, bottom: 80 }), { width: 300, height: 400 }, { width: 1400, height: 420 })).toEqual({ top: 86, left: 200 });
+  });
+
+  it("pulls back inside the right edge for a chip in the last column", () => {
+    // 1380 - 8 - 300 = 1072: flush against the margin rather than 300px off-screen.
+    expect(placeHoverTip(anchor({ left: 1300, right: 1380 }), TIP, { width: 1380, height: 900 })).toEqual({ top: 126, left: 1072 });
+  });
+
+  it("never crosses the left edge", () => {
+    expect(placeHoverTip(anchor({ left: 2, right: 60 }), TIP, SCREEN).left).toBe(8);
+  });
+
+  // A narrow phone-width window with a wide tip: clamping to `viewport - tip` would compute a
+  // NEGATIVE left and push the start of every line off-screen.
+  it("clamps to the left edge when the tip is wider than the window", () => {
+    expect(placeHoverTip(anchor({ left: 40, right: 90 }), { width: 500, height: 80 }, { width: 320, height: 700 }).left).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary

セルヘッダの hover を **標準 `title` から自前のツールチップに置き換え**、**即座に出る**ようにした上で、**中身を厚く**しました（#1235）。

**`title` をやめた理由は2つとも「直せないから」です。** 出るまでの遅延はブラウザ仕様で CSS でも JS でも変えられません（依頼の「すぐ出てほしい」は `title` のままでは不可能）。中身も1行のプレーンテキストのみで、chip が省略した部分を入れる場所がありません。

**work chip が出す内容が今回の主眼です。** `prTitle` / `issueTitle` は **#1014 以降サーバから届いていて、`useWorkItem` が parse し、デスクトップでは一度も表示されていませんでした**。つまり `#2689 → #2688` と出ていても「それが何の依頼か」は GitHub を開くまで分からない状態でした。**サーバ側の変更はゼロ**です。

| chip | hover で出るもの |
|---|---|
| work | `PR #2689 · CI running` ＋ **PR のタイトル** / `issue #2688` ＋ **issue のタイトル** |
| git branch | 省略されないブランチ名 ＋ `2 uncommitted · 1 ahead` |
| model / ctx | 短縮前のモデル名 ＋ トークンの内訳 |
| dir badge / cwd / roster の phase | 省略前の全文 |

対象は**セルヘッダ全部・3ビューすべて**。roster 行は `TerminalCell` ではなく別コンポーネント（`docs/grid-view-modes.md`）なので、セル側だけ直すと roster が遅いまま残ります — テストで固定しました。

## Items to Confirm / Review

1. **見るだけのツールチップ**にしています（hover card にしない = マウスを中に入れられない）。リンクが要るときは **chip の番号自体が既に GitHub へのリンク**なので、ツールチップ内に再度置く必要がないという判断です。
2. **`phaseDisplay` に `state` を足しました。** 既存の `title` は "PR — CI running" と PR を含むので、そのまま使うと `PR #2689 · PR — CI running` になります。**報告のスクリーンショットに写っている二重表記そのもの**です。主語が既に出ている場所用の言い方を表に足しました。
3. **スコープ外の発見**: **ヘッダの chip 自体が元から serif（Times）で描画されています。** 実ブラウザで計測しました（`work-chip` / `git-chip` / `.cell-header` すべて `Times`）。私の変更が原因ではなく、**依頼に添付されたスクリーンショットでも同じ**です。ツールチップ側は今回 `font-sans` を明示したので、**chip と tip でフォントが揃っていません**。直すのは1語ですが全セルヘッダの見た目が変わるため、**別issueとして判断を仰ぎます**。
4. **`title` は置き換えた箇所から完全に削除**しています。残っていると標準ツールチップが遅れて重なって出るためで、テストで属性が無いことを固定しました。
5. **`aria-describedby`** で支援技術向けの説明を残し、**フォーカスでも開く**ようにしています（chip の番号はリンクなのでキーボードで到達できるのに、hover だけだと何も出ませんでした）。

## User Prompt

> header の PR 表示部分とか hover すると pr/issue の詳細がここで確認できるようにしたい。hover も時間かけないですぐに出てくれるとうれしい。他にももし表示があればそこも同様に。できる限り狭い画面は潰さないでユーザが欲しい情報をそこで見れるとうれしい。

対話で確認した決定:

- ツールチップの性質 → **見るだけ**（hover card にしない）
- 対象範囲 → **セルヘッダ全部**（work chip だけにしない）

## 設計

**シングルトン ＋ 既存 chip にハンドラを載せる**（chip を wrapper で囲まない）。理由は2つともヘッダ固有です。

- ヘッダは flex 行で、子に `flex-none` / `min-w-0` を意図的に効かせています。間に要素を1つ挟むと、chip が調整されてきたレイアウトが変わります。
- **文書内のツールチップが2つになることが構造的に起きません。** chip ごとのコンポーネントだと、隣の chip へマウスが直接移ったときに前のものが残り得ます。

body へ teleport ＋ `fixed` は `CockpitRowMenu` と同じ理由 — **セルは `overflow-hidden` なので、その場に置くと「今読んでいるヘッダのセル自身」に切られます**。overlay であることが「狭い画面を潰さない」も満たします。

配置（`placeHoverTip`）は純関数: 下に出す → 入らなければ上へ反転 → 横は画面内へ寄せる。**9分割まで小さくなるグリッドでは、端の chip が画面際に来るのは普通**なので寄せは必須です。

設計メモ: `plans/feat-1235-instant-header-tips.md`

## 検証

**実ブラウザで確認しました**（jsdom だけでは足りないため）。隔離した HOME と空きポートで dev サーバを立て、Playwright で操作:

- hover した瞬間に出て、離すと消える（**遅延なし**）
- work chip: `PR #2689 · CI running` ＋ 日本語のタイトル、`issue #2688` ＋ 日本語のタイトルが実際に描画される
- git chip: 省略された `fix/1235-in…` に対し、tip は `branch fix/1235-instant-header-tips` の全文
- chip の下に配置され、**uncaught console error なし**
- **実ブラウザでしか出ない不具合を1つ発見・修正**: ツールチップだけ **Times（明朝）** で描画されていました。このアプリは `<body>` にフォントを指定せず要素ごとに utility を当てる方式なので、teleport 先はブラウザ既定を継承します。`font-sans` を明示しました。

`yarn format` / `lint`（error 0）/ `typecheck`・`typecheck:server`・**`typecheck:test`** / `build` / `yarn test`（**7333 passed**、新規 spec 3ファイル）。

> `yarn test` は通るのに `typecheck:test` だけ落ちる状態が一度ありました（CLAUDE.md が「最もよくある CI 落ち」と書いているケース）。修正済みです。

## テストで固定したこと

- work の tip に **PR / issue のタイトルが入る**（今まで捨てていた値）。タイトルが無ければその行が消える
- 各 chip の中身が、今までの `title` の情報を落としていない（`gitTip` の upstream 無しでの ahead/behind 抑制など）
- 配置: 下に入らなければ上／両端で画面内に収まる／tip が画面より広いときも左端で止まる
- **`title` 属性が残っていない**（二重表示の防止）
- **開いている間だけ** `aria-describedby` が張られる／フォークスでも開く
- **roster 行でも開く**（3ビュー中1つだけ取り残されないため）
- 空の内容では開かない

Refs #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal6
