### PR TITLE
fix: server/backends/shortcuts.ts の as を5箇所とも外す (#1231)

### DIFF
--- a/server/backends/shortcuts.ts
+++ b/server/backends/shortcuts.ts
@@ -10,6 +10,8 @@ import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
 import type { Express, Request, Response } from "express";
 import { sameShortcut, SHORTCUT_KINDS, type Shortcut, type ShortcutKind } from "../../common/shortcuts.js";
+import { isRecord } from "../../common/isRecord.js";
+import { hasErrnoCode } from "../errors.js";
 
 /** On-disk shape — object wrapper (not a bare array) so the schema can grow
  *  without a migration. THIS is the cross-app contract. */
@@ -18,6 +20,9 @@ interface ShortcutsFile {
 }
 
 const KINDS = new Set<string>(SHORTCUT_KINDS);
+// The Set answers membership; the predicate is what carries that answer into the type, so the
+// entry below can be built without asserting the kind it just checked.
+const isShortcutKind = (value: string): value is ShortcutKind => KINDS.has(value);
 
 /** Coerce arbitrary JSON into a clean `Shortcut[]`: drop malformed entries (bad
  *  kind / empty slug / non-string fields), default title→slug and icon→"bookmark",
@@ -26,13 +31,12 @@ export function normalizeShortcuts(input: unknown): Shortcut[] {
   if (!Array.isArray(input)) return [];
   const out: Shortcut[] = [];
   for (const raw of input) {
-    if (typeof raw !== "object" || raw === null) continue;
-    const candidate = raw as Record<string, unknown>;
-    const { kind, slug, title, icon } = candidate;
-    if (typeof kind !== "string" || !KINDS.has(kind)) continue;
+    if (!isRecord(raw)) continue;
+    const { kind, slug, title, icon } = raw;
+    if (typeof kind !== "string" || !isShortcutKind(kind)) continue;
     if (typeof slug !== "string" || slug.length === 0) continue;
     const entry: Shortcut = {
-      kind: kind as ShortcutKind,
+      kind,
       slug,
       title: typeof title === "string" ? title : slug,
       icon: typeof icon === "string" && icon.length > 0 ? icon : "bookmark",
@@ -57,8 +61,8 @@ export async function readShortcuts(workspace: string): Promise<Shortcut[]> {
     return [];
   }
   try {
-    const parsed = JSON.parse(text) as Partial<ShortcutsFile>;
-    return normalizeShortcuts(parsed?.shortcuts);
+    const parsed: unknown = JSON.parse(text);
+    return normalizeShortcuts(isRecord(parsed) ? parsed.shortcuts : undefined);
   } catch {
     return [];
   }
@@ -76,7 +80,7 @@ async function renameReplacing(from: string, to: string): Promise<void> {
     try {
       return await fs.rename(from, to);
     } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code ?? "";
+      const code = (hasErrnoCode(err) ? err.code : undefined) ?? "";
       if (attempt >= RENAME_RETRIES || !RENAME_LOCK_CODES.has(code)) throw err;
       await new Promise((resolve) => setTimeout(resolve, RENAME_RETRY_DELAY_MS));
     }
@@ -123,7 +127,7 @@ export function mountShortcutsRoutes(app: Express, deps: { workspace: string }):
   // normalises (validate kind, non-empty slug, dedupe) before persisting. A single
   // replace endpoint avoids add/remove route sprawl.
   app.put("/api/shortcuts", async (req: Request, res: Response) => {
-    const incoming = (req.body ?? {}) as { shortcuts?: unknown };
+    const incoming: Record<string, unknown> = isRecord(req.body) ? req.body : {};
     if (!Array.isArray(incoming.shortcuts)) {
       res.status(400).json({ error: "Request body must be { shortcuts: Shortcut[] }" });
       return;


### PR DESCRIPTION
## Summary

#1231。`server/backends/shortcuts.ts` の `as` 5 箇所を外します。

## Items to Confirm / Review

**5 箇所とも、必要な道具がリポジトリに既にありました。** 新しい抽象は 1 つも足していません（`isShortcutKind` は既存の `KINDS` Set をそのまま使う 1 行の述語）。

### 1. `(err as NodeJS.ErrnoException).code` → 既存の `hasErrnoCode`

**issue で「DOM/Node の型付けの限界。allowlist に理由付きで」と想定されていた類型ですが、`server/errors.ts` に `hasErrnoCode` が既にありました。** allowlist は不要です。

```diff
-      const code = (err as NodeJS.ErrnoException).code ?? "";
+      const code = (hasErrnoCode(err) ? err.code : undefined) ?? "";
```

### 2. `JSON.parse(...) as Partial<ShortcutsFile>` → 検査する

issue が「型ガードに置き換える（本来やるべきもの）」としていた類型です。ディスク上のファイルは手で編集され得るのに、無検査で `ShortcutsFile` だと信じていました。

```diff
-    const parsed = JSON.parse(text) as Partial<ShortcutsFile>;
-    return normalizeShortcuts(parsed?.shortcuts);
+    const parsed: unknown = JSON.parse(text);
+    return normalizeShortcuts(isRecord(parsed) ? parsed.shortcuts : undefined);
```

深い検証は既存の `normalizeShortcuts` が行うので、ここは「オブジェクトか」だけ確かめれば足ります。

### 3. `req.body` を無検査で信じていた（HTTP の生入力）

```diff
-    const incoming = (req.body ?? {}) as { shortcuts?: unknown };
+    const incoming: Record<string, unknown> = isRecord(req.body) ? req.body : {};
```

`Array.isArray(incoming.shortcuts)` の検査は元のままです。挙動は同じで、**「オブジェクトである」ことを主張から検査に変えた**だけです。

### 4. `kind as ShortcutKind` → 述語で narrow

`KINDS` は `Set<string>` なので `.has()` は narrow しません。Set をそのまま使う述語を足すと、判定した型が値に乗ります。

```ts
const isShortcutKind = (value: string): value is ShortcutKind => KINDS.has(value);
```

### 5. `raw as Record<string, unknown>` → `isRecord`

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7305 passed**（shortcuts の spec を含む）。

> `yarn typecheck:test` は 4 件エラーが出ますが **main 時点で同じ 4 件**（calendar 関連）で、この PR とは無関係です。

refs #1231

work in mulmoterminal3
