### PR TITLE
fix: server/agents/probe-transcript.ts の as を4箇所とも外す (#1231)

### DIFF
--- a/server/agents/probe-transcript.ts
+++ b/server/agents/probe-transcript.ts
@@ -26,6 +26,7 @@ import { forEachJsonlLine } from "../infra/jsonl-file.js";
 import { encodeProjectDirName, projectSessionsDir } from "../session/project-dir.js";
 import { isProbeSessionId } from "./probe-session.js";
 import { PROBE_PROMPT } from "./rate-limit-probe.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // Every probe transcript measured came in at 87-91KB. The cap is an order of magnitude above that
 // so a future, chattier claude still fits, and it exists to keep the sweep from reading a 14MB
@@ -33,26 +34,22 @@ import { PROBE_PROMPT } from "./rate-limit-probe.js";
 export const PROBE_TRANSCRIPT_MAX_BYTES = 1_000_000;
 
 const messageContent = (entry: unknown): { type: string; content: unknown } | null => {
-  if (typeof entry !== "object" || entry === null) return null;
-  const record = entry as Record<string, unknown>;
-  if (typeof record.type !== "string") return null;
-  const message = record.message;
-  if (typeof message !== "object" || message === null) return { type: record.type, content: null };
-  return { type: record.type, content: (message as Record<string, unknown>).content };
+  if (!isRecord(entry)) return null;
+  const type = entry.type;
+  if (typeof type !== "string") return null;
+  const message = entry.message;
+  return { type, content: isRecord(message) ? message.content : null };
 };
 
 const textOf = (content: unknown): string | null => {
   if (typeof content === "string") return content;
   if (!Array.isArray(content)) return null;
-  const texts = content.filter(
-    (part): part is { text: string } => typeof part === "object" && part !== null && typeof (part as { text?: unknown }).text === "string",
-  );
+  const texts = content.filter((part): part is { text: string } => isRecord(part) && typeof part.text === "string");
   return texts.length > 0 ? texts.map((part) => part.text).join("") : null;
 };
 
 const usesTools = (content: unknown): boolean =>
-  Array.isArray(content) &&
-  content.some((part) => typeof part === "object" && part !== null && ["tool_use", "tool_result"].includes(String((part as { type?: unknown }).type)));
+  Array.isArray(content) && content.some((part) => isRecord(part) && ["tool_use", "tool_result"].includes(String(part.type)));
 
 /** Whether a transcript's CONTENT says a probe wrote it. Pure, so the boundary between "delete
  *  this" and "this is someone's work" is pinned by tests rather than by trying it on a disk.


### PR DESCRIPTION
## Summary

#1231。`server/agents/probe-transcript.ts` の `as` 4 箇所を外します。JSONL トランスクリプトという**外から来るデータ**を読む経路です。

## Items to Confirm / Review

4 箇所とも同じ形でした: 手書きの `typeof x === "object" && x !== null` を置いてから `as Record<string, unknown>` で読む。**既存の `isRecord` がその判定そのもの**（しかも配列も除外する）なので、判定と cast が 1 つの述語に畳めます。

### 型ガードの中で cast していた 2 箇所

```diff
-    (part): part is { text: string } => typeof part === "object" && part !== null && typeof (part as { text?: unknown }).text === "string",
+    (part): part is { text: string } => isRecord(part) && typeof part.text === "string",
```

```diff
-  content.some((part) => typeof part === "object" && part !== null && ["tool_use", "tool_result"].includes(String((part as { type?: unknown }).type)));
+  content.some((part) => isRecord(part) && ["tool_use", "tool_result"].includes(String(part.type)));
```

「string か確かめる前に、そのフィールドがあると宣言する」形になっていました。#1245 の `isSendBinding` と同じ構造です。

### `messageContent` の 2 箇所

```diff
-  if (typeof entry !== "object" || entry === null) return null;
-  const record = entry as Record<string, unknown>;
-  if (typeof record.type !== "string") return null;
-  const message = record.message;
-  if (typeof message !== "object" || message === null) return { type: record.type, content: null };
-  return { type: record.type, content: (message as Record<string, unknown>).content };
+  if (!isRecord(entry)) return null;
+  const type = entry.type;
+  if (typeof type !== "string") return null;
+  const message = entry.message;
+  return { type, content: isRecord(message) ? message.content : null };
```

**挙動の差**: `isRecord` は配列を除外するので、`entry` や `message` が配列だった場合に一段早く弾かれます。結果は同じです（配列に `.type` / `.content` は無いので、元のコードも直後に null を返していました）。

## 検証

この関数群は「消してよい probe トランスクリプト」と「ユーザーの作業」を分ける判定に使われるので、間違えると**人の会話を消しかねません**。ファイル冒頭のコメントもそう書いています。

`yarn test` **7305 passed**（`probe-transcript.spec.ts` を含む — この境界を pin しているテスト群です）。`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build`。

refs #1231

work in mulmoterminal3
