### PR TITLE
fix: server/backends/translation.ts の as を4箇所とも外す (#1231)

### DIFF
--- a/server/backends/translation.ts
+++ b/server/backends/translation.ts
@@ -22,6 +22,7 @@ import { promises as fs } from "node:fs";
 import { randomUUID } from "node:crypto";
 import type { Express, Request, Response } from "express";
 import { stripBom } from "../infra/read-text-file.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // ── On-disk cache schema (SHARED with MulmoClaude — do not diverge) ───────────
 
@@ -39,12 +40,12 @@ function emptyDictionary(): DictionaryFile {
 // dictionary on anything unrecognized, so a `{}` / `{ sentences: null }` file can't
 // turn every request for the namespace into a 500.
 function isValidDictionary(value: unknown): value is DictionaryFile {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const { sentences } = value as { sentences?: unknown };
-  if (typeof sentences !== "object" || sentences === null || Array.isArray(sentences)) return false;
+  if (!isRecord(value)) return false;
+  const { sentences } = value;
+  if (!isRecord(sentences)) return false;
   for (const inner of Object.values(sentences)) {
-    if (typeof inner !== "object" || inner === null || Array.isArray(inner)) return false;
-    for (const translated of Object.values(inner as Record<string, unknown>)) {
+    if (!isRecord(inner)) return false;
+    for (const translated of Object.values(inner)) {
       if (typeof translated !== "string") return false;
     }
   }
@@ -164,7 +165,7 @@ interface TranslateRequest {
 
 /** Validate + narrow the request body. Throws TranslationInputError on bad input. */
 export function validateRequest(body: unknown): TranslateRequest {
-  const req = (body ?? {}) as Record<string, unknown>;
+  const req: Record<string, unknown> = isRecord(body) ? body : {};
   if (typeof req.namespace !== "string" || !NAMESPACE_RE.test(req.namespace)) {
     throw new TranslationInputError(`invalid namespace: ${JSON.stringify(req.namespace)}`);
   }
@@ -178,10 +179,14 @@ export function validateRequest(body: unknown): TranslateRequest {
     throw new TranslationInputError(`sentences exceeds ${MAX_SENTENCES} entries`);
   }
   let totalChars = 0;
+  // Collected as they are checked, so the validated strings ARE the returned array — asserting
+  // `req.sentences as string[]` afterwards would re-state what this loop already proved.
+  const sentences: string[] = [];
   for (const sentence of req.sentences) {
     if (typeof sentence !== "string" || sentence.length === 0) {
       throw new TranslationInputError("sentences must contain non-empty strings");
     }
+    sentences.push(sentence);
     if (sentence.length > MAX_SENTENCE_CHARS) {
       throw new TranslationInputError(`sentence exceeds ${MAX_SENTENCE_CHARS} characters`);
     }
@@ -190,7 +195,7 @@ export function validateRequest(body: unknown): TranslateRequest {
       throw new TranslationInputError(`total sentence length exceeds ${MAX_TOTAL_CHARS} characters`);
     }
   }
-  return { namespace: req.namespace, targetLanguage: req.targetLanguage, sentences: req.sentences as string[] };
+  return { namespace: req.namespace, targetLanguage: req.targetLanguage, sentences };
 }
 
 // ── LLM step (injected) ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

#1231。`server/backends/translation.ts` の `as` 4 箇所を外します。**HTTP リクエストボディと、手編集され得るキャッシュファイル**を読む経路です。

## Items to Confirm / Review

### 1. `req.sentences as string[]` — 検査済みなのに伝わっていなかった（ここが本題）

ループが既に全要素の「string かつ非空」を検査していたのに、その結果がコンパイラに伝わらないので最後に cast していました。

```diff
+  const sentences: string[] = [];
   for (const sentence of req.sentences) {
     if (typeof sentence !== "string" || sentence.length === 0) {
       throw new TranslationInputError("sentences must contain non-empty strings");
     }
+    sentences.push(sentence);
     ...
   }
-  return { ..., sentences: req.sentences as string[] };
+  return { ..., sentences };
```

throw の直後で `sentence` は `string` に narrow されているので、push した配列が**そのまま** `string[]` になります。#1244 の `isCompleteThemeVars` と同じ「検査済みの事実をコンパイラに渡す」パターンですが、こちらは型述語すら要りませんでした。

### 2. `(body ?? {}) as Record<string, unknown>`

```diff
-  const req = (body ?? {}) as Record<string, unknown>;
+  const req: Record<string, unknown> = isRecord(body) ? body : {};
```

**挙動は変えていません。** 非オブジェクト（文字列、配列、null）は元も `req.namespace` が `undefined` になり `invalid namespace: undefined` を投げていました。新しい形も `{}` に落ちるので同じ例外・同じメッセージです。

### 3. `isValidDictionary` の 2 箇所 → `isRecord`

手書きの「object かつ null でなく配列でない」は `isRecord` そのものです。

## 検証

`yarn lint`（0 error）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7305 passed**（translation の spec を含む — `validateRequest` の不正入力ケースが pin されています）。

refs #1231

work in mulmoterminal3
