### PR TITLE
fix: ヘッダの git / work chip にフォントを宣言する（serif 落ちの解消）(#1251)

### DIFF
--- a/src/components/GitBranchChip.vue
+++ b/src/components/GitBranchChip.vue
@@ -19,7 +19,7 @@ const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => gitT
   <span
     v-if="status?.repo && (status.branch || status.detached)"
     data-testid="git-chip"
-    class="inline-flex flex-none items-center gap-[0.25em] px-[0.4em] h-[1.5em] rounded-[0.75em] text-[0.72rem] leading-[1.5em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] opacity-85 whitespace-nowrap max-w-[16ch] overflow-hidden"
+    class="inline-flex h-[1.5em] max-w-[16ch] flex-none items-center gap-[0.25em] overflow-hidden whitespace-nowrap rounded-[0.75em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] px-[0.4em] font-sans text-[0.72rem] leading-[1.5em] opacity-85"
     :class="status.detached ? 'text-[#d19a66]' : 'text-inherit'"
     :aria-describedby="described ? HOVER_TIP_ID : undefined"
     @pointerenter="showTip"

--- a/src/components/WorkItemChip.vue
+++ b/src/components/WorkItemChip.vue
@@ -28,7 +28,7 @@ const { described, show: showTip, hide: hideTip } = useHoverTipAnchor(() => work
   <span
     v-if="show"
     data-testid="work-chip"
-    class="inline-flex h-[1.5em] max-w-[18ch] flex-none items-center gap-[0.25em] overflow-hidden whitespace-nowrap rounded-[0.75em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] px-[0.4em] text-[0.72rem] leading-[1.5em] opacity-85"
+    class="inline-flex h-[1.5em] max-w-[18ch] flex-none items-center gap-[0.25em] overflow-hidden whitespace-nowrap rounded-[0.75em] bg-[color-mix(in_srgb,currentColor_12%,transparent)] px-[0.4em] font-sans text-[0.72rem] leading-[1.5em] opacity-85"
     :aria-describedby="described ? HOVER_TIP_ID : undefined"
     @pointerenter="showTip"
     @pointerleave="hideTip"

--- a/test/src/components/headerChipFont.spec.ts
+++ b/test/src/components/headerChipFont.spec.ts
@@ -1,0 +1,43 @@
+// Every cell-header chip declares its own font (#1251).
+//
+// This app sets no font-family on <body> — each element carries a utility instead — so a chip that
+// declares none falls through to the browser's default, which is a SERIF. That is not a subtle
+// difference next to the sans chips beside it, and it went unnoticed for a long time because
+// nothing fails: it renders, it is the right size, it is just the wrong typeface. Measured in a
+// real browser at the time of the fix; jsdom resolves no fonts, so the attribute is what can be
+// pinned here.
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import GitBranchChip from "../../../src/components/GitBranchChip.vue";
+import WorkItemChip from "../../../src/components/WorkItemChip.vue";
+import DirBadge from "../../../src/components/DirBadge.vue";
+import ModelContextBadge from "../../../src/components/ModelContextBadge.vue";
+import { EMPTY_WORK_ITEM } from "../../../common/prPhase";
+import type { GitStatus } from "../../../common/gitStatus";
+
+const gitStatus: GitStatus = { repo: true, branch: "main", detached: false, dirty: 0, ahead: 0, behind: 0, upstream: true } as GitStatus;
+
+// A chip may be sans or mono — what it may NOT be is silent, which is what leaves it serif.
+const FONT_CLASS = /^font-(sans|mono)$/;
+
+const chips = [
+  ["git branch", () => mount(GitBranchChip, { props: { status: gitStatus } }), '[data-testid="git-chip"]'],
+  ["work item", () => mount(WorkItemChip, { props: { item: { ...EMPTY_WORK_ITEM, phase: "ready", pr: 977 } } }), '[data-testid="work-chip"]'],
+  ["dir badge", () => mount(DirBadge, { props: { name: "demo", color: null } }), "span"],
+  [
+    "model / context",
+    () => mount(ModelContextBadge, { props: { agent: "claude", model: "claude-opus-4-20250514", contextTokens: 1000 } }),
+    '[data-testid="model-badge"]',
+  ],
+] as const;
+
+describe("cell-header chips", () => {
+  it.each(chips)("%s declares a font rather than inheriting the browser's serif", (_name, mountChip, selector) => {
+    expect(
+      mountChip()
+        .get(selector)
+        .classes()
+        .some((c) => FONT_CLASS.test(c)),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

ヘッダの **git chip と work chip だけが serif（Times）で描画されていた**のを直しました（#1251）。

**原因は1つです。** このアプリは **`<body>` にフォントを指定せず**、要素ごとに utility を当てる方式です。宣言し忘れた要素は**ブラウザ既定の serif に落ちます**。ヘッダで宣言が無かったのはこの2つだけでした — `DirBadge` は `font-sans`、`ModelContextBadge` と `.cell-dir` は `font-mono` を持っています。

**目視ではなく実測しました。** 実ブラウザで画面上の全テキスト要素の computed `font-family` を採ったところ:

| | 修正前 | 修正後 |
|---|---|---|
| serif で描画 | **6件**（`⎇ fix/…` `●2` `#2689` `→` `#2688` `CI…`） | **0件** |
| それ以外 | 35件（system-ui / Arial / ui-monospace） | 42件・**内訳は不変** |

serif の6件はすべてこの2 chip の中で、他は一切動いていません。

**`font-sans` を選んだ理由**: 隣にある同じ「ラベル」系の chip である `DirBadge` に合わせました。あわせて **#1247 で入れたホバーの中身とも揃います** — あちらは body へ teleport した結果、同じ根本原因で serif になり、`font-sans` を明示して直した箇所です。**これまで chip とその説明のツールチップでフォントが食い違っていました。**

## Items to Confirm / Review

1. **`font-sans` か `font-mono` か。** ブランチ名は code 的なので `font-mono`（`.cell-dir` や `ModelContextBadge` と同じ）も筋は通ります。上記の理由で sans にしましたが、**好みが分かれるところなので見てください**。スクリーンショットは #1251 に貼った実測どおりの見た目です。
2. **テストは「どのフォントか」ではなく「宣言があるか」を固定しています。** sans / mono は chip ごとの設計判断で、**欠陥は"無言であること"だから**です。修正前のコードに当てて2件落ちることを確認済みです。
3. **根本原因側（`<body>` にフォントを置く）は触っていません。** それをすれば同種の再発を防げますが、アプリ全体の既定を変える話になるので別判断としました。実測では現在フォールバックしている要素はこの6件だけなので、影響範囲は把握できています — 必要なら別 issue にします。

## User Prompt

> 次にフォント修正を。

（#1247 のレビュー中に実測で判明した、スコープ外として残していた項目です）

## 検証

- **実ブラウザ**（隔離した HOME と空きポートの dev サーバ ＋ Playwright）で、上記の serif 件数 6→0 を確認。uncaught console error なし
- ヘッダ全体が同じ書体で揃うことをスクリーンショットで確認
- 追加テストが**修正前のコードで落ちる**ことを確認（2 failed → 4 passed）

`yarn lint`（**error 0**。warning 130 は main に元からあるもので、私が触っていないファイル群の `consistent-type-assertions`）/ `typecheck`・`typecheck:server`・`typecheck:test` / `build` / `yarn test`（**7337 passed**）。

Refs #1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal6
