### PR TITLE
fix: NUL バイトで issue-work.ts が grep から不可視になっていた

### DIFF
--- a/server/git/issue-work.ts
+++ b/server/git/issue-work.ts
@@ -152,7 +152,10 @@ function serializePerIssue<T>(key: string, task: () => Promise<T>): Promise<T> {
  *  must already have been checked against the repo's known clones by the caller — this does not
  *  resolve it. */
 export function startIssueWork(repo: string, issue: number, dir: string, deps: StartIssueWorkDeps): Promise<StartedResult> {
-  return serializePerIssue(`${dir} ${issue}`, () => runIssueWork(repo, issue, dir, deps));
+  // NUL joins the two halves because a directory path may contain anything else. Written as the
+  // ESCAPE: a literal NUL in the source makes the file binary to grep, which then skips it
+  // SILENTLY — this module was invisible to several "every place that calls gh" sweeps.
+  return serializePerIssue(`${dir}\0${issue}`, () => runIssueWork(repo, issue, dir, deps));
 }
 
 async function runIssueWork(repo: string, issue: number, dir: string, deps: StartIssueWorkDeps): Promise<StartedResult> {

--- a/test/server/session/draft-injection.spec.ts
+++ b/test/server/session/draft-injection.spec.ts
@@ -252,11 +252,13 @@ describe("attachDraftInjection", () => {
       const t = target();
       const scan = attachDraftInjection(t.entry, undefined, "edit me", () => ESC_CR);
       scan(
-        `\u001b[2GQuick\u001b[8Gsafety\u001b[15Gcheck:\u001b[22GIs\u001b[25Gthis\u001b[30Ga\u001b[32Gproject\u001b[40Gyou\u001b[44Gcreated\u001b[52Gor\u001b[55Gone\u001b[59Gyou\u001b[63Gtrust?`,
+        `\u001b\u001b[2GQuick\u001b\u001b[8Gsafety\u001b\u001b[15Gcheck:\u001b\u001b[22GIs\u001b\u001b[25Gthis\u001b\u001b[30Ga\u001b\u001b[32Gproject\u001b\u001b[40Gyou\u001b\u001b[44Gcreated\u001b\u001b[52Gor\u001b\u001b[55Gone\u001b\u001b[59Gyou\u001b\u001b[63Gtrust?`,
       );
       vi.advanceTimersByTime(FALLBACK_MS * 5);
       expect(t.writes).toEqual([]);
-      scan(`\u001b[3G⏸\u001b[5Gmanual\u001b[12Gmode\u001b[17Gon\u001b[20G·\u001b[22G?\u001b[24Gfor\u001b[28Gshortcuts`);
+      scan(
+        `\u001b\u001b[3G⏸\u001b\u001b[5Gmanual\u001b\u001b[12Gmode\u001b\u001b[17Gon\u001b\u001b[20G·\u001b\u001b[22G?\u001b\u001b[24Gfor\u001b\u001b[28Gshortcuts`,
+      );
       vi.advanceTimersByTime(SETTLE_MS);
       expect(t.writes).toEqual([`${PASTE_START}edit me${PASTE_END}`]);
     });

--- a/test/server/session/shell-spawn-win.spec.ts
+++ b/test/server/session/shell-spawn-win.spec.ts
@@ -22,7 +22,7 @@ const isWindows = process.platform === "win32";
 const plainText = (data: string): string =>
   data
     // eslint-disable-next-line no-control-regex -- reading a terminal's own output back
-    .replace(/\[[0-9;?]*[a-zA-Z]/g, "")
+    .replace(/\u001b\[[0-9;?]*[a-zA-Z]/g, "")
     .replace(/[\r\n]/g, "");
 
 function runShell(command: string, cwd: string, replaceShell = false): Promise<{ output: string; exitCode: number }> {

--- a/test/server/sourceIsText.spec.ts
+++ b/test/server/sourceIsText.spec.ts
@@ -1,0 +1,36 @@
+// No source file may hold a control character that makes it BINARY to the ordinary tools.
+//
+// `server/git/issue-work.ts` held a literal NUL — meant as a key separator, written as the byte
+// rather than the escape. It compiled and ran correctly, so nothing failed; what it did instead was
+// make the file binary to `grep`, which skips such files SILENTLY. Several sweeps across "every
+// place that calls gh" read every module except that one and reported a total that was wrong
+// without saying so.
+//
+// Checked on the BYTES rather than with a regular expression, because a character class holding
+// these characters is itself what `no-control-regex` exists to stop — and the rule is right.
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+const ROOTS = ["server", "src", "common", "bin"];
+const SOURCE = /\.(ts|tsx|vue|js|mjs)$/;
+
+// Tab, newline and carriage return are the only control bytes source is allowed to hold.
+const ALLOWED = new Set([9, 10, 13]);
+const LOWEST_PRINTABLE = 32;
+const holdsBinaryByte = (file: string): boolean => readFileSync(file).some((byte) => byte < LOWEST_PRINTABLE && !ALLOWED.has(byte));
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const full = path.join(dir, name);
+    if (name === "node_modules" || name.startsWith(".")) return [];
+    if (statSync(full).isDirectory()) return sourceFiles(full);
+    return SOURCE.test(name) ? [full] : [];
+  });
+}
+
+describe("source files are text", () => {
+  it("holds no control byte that would make a file binary to grep", () => {
+    expect(ROOTS.flatMap(sourceFiles).filter(holdsBinaryByte)).toEqual([]);
+  });
+});

--- a/test/server/sourceIsText.spec.ts
+++ b/test/server/sourceIsText.spec.ts
@@ -12,7 +12,10 @@ import { describe, it, expect } from "vitest";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
-const ROOTS = ["server", "src", "common", "bin"];
+// `test` is in the list because a spec is where fixtures live — pasted terminal output is
+// exactly how a literal ESC gets into a file — and a spec hidden from grep is hidden just the
+// same. Three of the four offenders found were specs.
+const ROOTS = ["server", "src", "common", "bin", "test", "scripts"];
 const SOURCE = /\.(ts|tsx|vue|js|mjs)$/;
 
 // Tab, newline and carriage return are the only control bytes source is allowed to hold.


### PR DESCRIPTION
## Summary

`server/git/issue-work.ts` に **NUL バイトが1つ**入っていて、**ファイル全体が grep から不可視**に
なっていました。

`startIssueWork` はロックキーを `${dir}<NUL>${issue}` で組み立てます。**キーの区切りとしては妥当**
（パスは NUL 以外なら何でも含み得る）なのですが、**エスケープ `\0` ではなく生のバイト**で
書かれていました。

## Items to Confirm / Review

### 動作は正しく、壊れていたのは「読むこと」でした

コードは正しく動き、テストも通ります。壊れていたのはリポジトリの読み取りです。

**NUL を含むファイルは grep にとってバイナリで、黙ってスキップされます。** このセッションだけで
3回の全走査（「`runGh` を呼ぶ全ファイル」「repo を CLI に渡す全箇所」）が、**このモジュールだけ
読まずに**、間違った総数を何も言わずに報告していました。

```
修正前: server/git/issue-work.ts: data
修正後: server/git/issue-work.ts: Java source, Unicode text, UTF-8 text
```

見えるようになった呼び出し: `runGh(["issue", "view", …])`（49行目）。GitLab 対応の棚卸しから
漏れていた1件です。

### ガードは正規表現ではなくバイトで見ています

制御文字を含む文字クラスは、まさに `no-control-regex` が止めるためのルールです。
**最初にテストを書いたとき、そのルールが実際に発火しました** — ルールが正しいということなので、
`eslint-disable` はせずバイト判定に変えています。

### 空振りしないことを確認済み

`server/` 配下に NUL 入りファイルを置くとテストが落ち、消すと通ることを確認しました。

## User Prompt

（#981 段階4c の着手前に「repo 識別子を CLI に渡す全箇所」を走査していて発見）

## テスト

`yarn format` / `lint` / `typecheck` ×3 / `build` / `test`（7389 passed）/ `knip` —
**すべて終了コードで確認**。

work in mulmoterminal4
