### PR TITLE
feat: スマホから始めた issue 作業をそのまま実行する（startIssueWork に run オプション）

### DIFF
--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -81,7 +81,7 @@ id `getTerminalScreen` takes, so the phone can watch what it just started.
 **An issue has ONE worktree, so a second call for it does not start a second thing** (#1219).
 `outcome` says which of three happened:
 
-| `outcome` | what happened | is the issue in the input box? |
+| `outcome` | what happened | was the issue typed into it? |
 |---|---|---|
 | `created` | the worktree was cut and a session seeded in it | yes |
 | `reused` | the worktree was already there and empty; the session is new | yes |
@@ -107,7 +107,7 @@ before-paste Ctrl-C. So this is a parameter here rather than a sequence the phon
 through first and confirm the approach with me before implementing"*, so the session stops for a
 decision before it writes anything.
 
-`ran` reports what actually happened, not what was asked for:
+`ran` is not an echo of `run` — it is false whenever nothing was seeded, whatever was asked:
 
 | | `run: true` | `run` absent / `false` |
 |---|---|---|
@@ -118,6 +118,11 @@ decision before it writes anything.
 into it**, so submitting would send whatever the user left in its box, or an empty line. Anything
 other than `true` is read as `false`, which leaves the behaviour every caller had before this
 option existed.
+
+**`ran: true` means the session was started to run its seed, not that a keystroke has landed.** The
+reply is sent as soon as the session exists; the seed is typed — and submitted — afterwards, once
+the TUI's input box has painted. So the phone should word it as *started*, not as *the agent has
+answered*, and read the session itself (`getTerminalScreen`) for the latter.
 
 **The desktop keeps the draft.** `POST /api/issues/start` takes no `run` — there, the person who
 opened the issue and the person about to run it are often not the same, and the reviewing Enter is

--- a/docs/remote-host-protocol.md
+++ b/docs/remote-host-protocol.md
@@ -40,7 +40,7 @@ grouped in `handlers/terminalSession.ts`.
 | `launchTerminal` | `agent`, `sessionId` | `{ ok: true }` |
 | `startChat` | `message`, `attachments?` | `{ started: true, chatId }` |
 | `listIssues` | — | `{ repos: RepoIssueRows[] }` |
-| `startIssueWork` | `repo`, `issue` | `{ started: true, sessionId, branch, issue }` |
+| `startIssueWork` | `repo`, `issue`, `run?` | `{ started: true, sessionId, branch, issue, outcome, ran }` |
 | `listFeeds` | — | `{ feeds }` |
 | `getFeed` | `slug`, `offset?`, `limit?` | the feed page |
 | `listCollections` | — | `{ collections }` (feed-backed ones excluded) |
@@ -74,10 +74,9 @@ Settings' `prRepos`, capped per repo, no bodies. Each repo row carries what
 ```
 
 `startIssueWork` then reads the issue, cuts its `issue/<N>-<slug>` worktree off the fetched
-mainline, and spawns a session there with the issue **waiting in the input box, not submitted** —
-the text was written by whoever opened the issue, so the Enter is the user's. It answers
-`{ started: true, sessionId, branch, issue: { number, title }, outcome }`; `sessionId` is the id
-`getTerminalScreen` takes, so the phone can watch what it just started.
+mainline, and spawns a session there seeded with the issue. It answers
+`{ started: true, sessionId, branch, issue: { number, title }, outcome, ran }`; `sessionId` is the
+id `getTerminalScreen` takes, so the phone can watch what it just started.
 
 **An issue has ONE worktree, so a second call for it does not start a second thing** (#1219).
 `outcome` says which of three happened:
@@ -91,6 +90,38 @@ the text was written by whoever opened the issue, so the Enter is the user's. It
 A fourth case is a refusal rather than an answer: the worktree's session is **open in another
 terminal**, and the sentence says to close it there first. One working tree runs one agent
 (#1207), and that rule is not suspended because the request came from the phone.
+
+### `run` — start it, don't just type it (#1253)
+
+By default the seed is **typed and not submitted**: the text was written by whoever opened the
+issue, so the Enter is the user's. That is right on the desktop and wrong on a phone, which has no
+Enter key — the work simply stops there. **`run: true`** submits it instead.
+
+**Only the host can do this.** The seed is typed once the TUI's input box has painted
+(`server/session/draft-injection.ts`), so an Enter sent from the phone would race the injection,
+and nothing outside this process knows when it landed. `sendTerminalInput` cannot send a bare Enter
+either (empty text is rejected), and a one-character workaround would be cleared by the
+before-paste Ctrl-C. So this is a parameter here rather than a sequence the phone performs.
+
+**Auto-running is safe because of what the seed says.** `issueSeedPrompt` ends with *"Read it
+through first and confirm the approach with me before implementing"*, so the session stops for a
+decision before it writes anything.
+
+`ran` reports what actually happened, not what was asked for:
+
+| | `run: true` | `run` absent / `false` |
+|---|---|---|
+| `created` / `reused` | `ran: true` — typed and submitted | `ran: false` — typed, waiting for Enter |
+| `resumed` | **`ran: false`** — nothing was typed, so there is nothing to submit | `ran: false` |
+
+`resumed` never runs, whatever was asked: that session has its own history and **nothing was typed
+into it**, so submitting would send whatever the user left in its box, or an empty line. Anything
+other than `true` is read as `false`, which leaves the behaviour every caller had before this
+option existed.
+
+**The desktop keeps the draft.** `POST /api/issues/start` takes no `run` — there, the person who
+opened the issue and the person about to run it are often not the same, and the reviewing Enter is
+the point.
 
 **It takes no `dir`, by rule** (see "The phone never sends a path" below). The work starts in the
 clone recorded for that repo — or in the only one, when the repo has exactly one here. When
@@ -207,6 +238,7 @@ that SPAWNS can mark its session unplaced and let a grid adopt it later, which i
 | Quick-command scoping | `server/backends/remoteHost/quickCommands.ts` |
 | Launch validation | `server/backends/remoteHost/launchTerminal.ts` |
 | Issue work (list, refuse, start) | `server/backends/remoteHost/handlers/issueWork.ts`, `server/git/issue-work.ts` |
+| Whether the seed is typed or typed-and-run | `server/session/issue-spawn-options.ts` |
 | Which clone a repo starts in | `server/git/repo-dirs.ts`, `common/issueStartPlan.ts` |
 | Reconnect + health | `server/backends/remoteHost/resilientRunner.ts`, `healthNotice.ts` |
 | Wiring (PTY table, pub/sub, config) | `server/index.ts` |

--- a/plans/feat-1253-issue-work-run.md
+++ b/plans/feat-1253-issue-work-run.md
@@ -1,0 +1,86 @@
+# feat(#1253): スマホから始めた issue 作業をそのまま実行する
+
+## 何が止まっているか
+
+スマホから issue の行をタップすると worktree が切られてセッションは立ち上がるが、issue 本文は
+**入力欄に置かれるだけで走らない**。スマホには Enter が無いので、そこで止まる。
+
+スマホ側だけでは直せない。理由は3つとも「ホストしか知らない事実」に依存している:
+
+- 種プロンプトは `draft` として入る。`planDraftInjection` は draft を `autoSubmit: false` と決め打ちする
+  （未レビューのテキストは絶対に自動送信しない、という設計上の規則）。
+- `sendTerminalInput` は Enter だけを送れない。`sanitizeTerminalInput` 後に空なら throw する。
+- 何か文字を送る回避策も駄目。`canClearInputBox` が貼り付け前に Ctrl-C で入力欄を消す。
+- そもそも注入は TUI の準備完了マーカー待ちなので、外から撃つ Enter は注入と競合する。
+
+## 直し方 — 既存の auto-run 経路に乗せるだけ
+
+`initialPrompt` で spawn すれば、`attachDraftInjection` が入力欄の準備を待ってからペーストし、
+`DRAFT_SUBMIT_MS` 後に**別チャンクで** submit まで送る。`startChat` が既に使っている経路で、
+新しい仕掛けは要らない。draft と initialPrompt の違いは `planDraftInjection` の1行だけ。
+
+```
+run: true  → { cwd, initialPrompt: seed }   autoSubmit: true   タイプして Enter
+run: false → { cwd, draft: seed }           autoSubmit: false  タイプするだけ（現行）
+```
+
+## `resumed` の除外は書かない — 構造で保証する
+
+`run` を **spawn クロージャに閉じ込める**ので、`server/git/issue-work.ts` は無変更。
+
+`startIssueWork` は `outcome: "resumed"` のとき `reopenIssueWorktree` の
+`action === "resume"` で早期 return し、**`spawnDraft` を呼ばない**。呼ばれない以上 `run` は
+届かない。「resumed のときは実行しない」を新しい条件分岐として書き足すと、同じ規則が2箇所に
+できて片方だけ腐る。
+
+同じ理由で、返り値の `ran` は `outcome` から導出せず**クロージャが呼ばれたかを観測**する。
+将来 `outcome` が増えても嘘にならない。
+
+## デスクトップは現行のまま
+
+`server/routes/issue-work-routes.ts` は変更なし。issue を書いた人と走らせる人が違う、という
+理由はデスクトップにはそのまま当てはまる。分岐はスマホ側の `run` だけが動かす。
+
+## なぜ自動実行して安全か
+
+`issueSeedPrompt` の最終行が
+`Let's work on this issue. Read it through first and confirm the approach with me before implementing.`
+なので、自動実行しても**実装の前に一度必ず止まって方針を確認する**。
+
+## 変更するファイル
+
+| ファイル | 変更 |
+|---|---|
+| `server/session/issue-spawn-options.ts` | 新規。`run` → spawn オプションの純関数 |
+| `server/backends/remoteHost/handlers/deps.ts` | `spawnIssueDraft` → `spawnIssueSeed(cwd, seed, run)` |
+| `server/backends/remoteHost/handlers/issueWork.ts` | `params.run` を読み、`ran` を返す |
+| `server/backends/remoteHost/index.ts` | dep 名の付け替え |
+| `server/index.ts` | `remoteHostSpawnIssueSeed` が純関数を使って spawn |
+| `docs/remote-host-protocol.md` | params 表・outcome 表・理由 |
+
+## なぜ純関数を1つ切るのか
+
+`draft` と `initialPrompt` を**両方**渡すと `planDraftInjection` の `??` で draft が勝ち、
+**エラーも警告も出ないまま走らない**。「必ず片方だけ」はテストで固定する価値がある不変条件で、
+`server/index.ts` は単体テストできない場所なので、決定だけを純関数に出す。
+
+## `run` が boolean でなかったら
+
+`params.run === true`。boolean 以外は draft 扱い（現行動作）に落ちる。安全な側であり、
+返り値の `ran` が実際どうなったかを正しく報告するので、スマホが「実行しました」と誤表示することは
+起きない。
+
+## テストで固定すること
+
+- `run` を渡すと `initialPrompt` だけが立ち、`draft` は**立たない**（逆も同様）
+- `attachGuiMcp: false` はどちらでも変わらない（worktree の作業セッションなので）
+- スマホが `run: true` を送ると spawner の第3引数が `true` で呼ばれる
+- `run` 無し / `run: false` / `run: "true"`（非 boolean）はいずれも `ran: false` で draft のまま
+- `outcome: "resumed"` は `run: true` でも `ran: false`（spawner が呼ばれない）
+- worktree-busy の拒否は `run` に関係なく従来どおり文面ごと伝わる
+
+## やらないこと
+
+- デスクトップ `POST /api/issues/start` の挙動変更
+- `sendTerminalInput` で Enter を送れるようにすること（#1253 が退けた道）
+- スマホ側（mulmoserver）の変更 — このオプションが入ったら `run: true` を足すだけ

--- a/server/backends/remoteHost/getFeed.spec.ts
+++ b/server/backends/remoteHost/getFeed.spec.ts
@@ -57,7 +57,7 @@ describe("createRemoteHostHandlers · getFeed", () => {
       workspace: ws,
       spawnChat: () => ({ chatId: "x" }),
       ingest: async () => ({ attachments: [], cleanupStaging: async () => {} }),
-      spawnIssueDraft: () => "unused-session",
+      spawnIssueSeed: () => "unused-session",
       listTerminalSessions: async () => [],
       captureTerminalScreen: async () => ({ screen: "", suggestion: "", quickCommands: [] }),
       writeToSession: () => false,

--- a/server/backends/remoteHost/handlers.spec.ts
+++ b/server/backends/remoteHost/handlers.spec.ts
@@ -9,7 +9,7 @@ import type { SessionScreen } from "./terminalScreen.js";
 import { initCollectionsBackend } from "../collections.js";
 
 const unusedTerminalDeps = {
-  spawnIssueDraft: () => "unused-session",
+  spawnIssueSeed: () => "unused-session",
   listTerminalSessions: async () => [],
   captureTerminalScreen: async () => ({ screen: "", suggestion: "", quickCommands: [] }),
   writeToSession: () => false,

--- a/server/backends/remoteHost/handlers/deps.ts
+++ b/server/backends/remoteHost/handlers/deps.ts
@@ -36,11 +36,15 @@ export interface RemoteHostHandlerDeps {
   // Same lookup as canClearBox / submitSequence: only Claude Code has the menu that eats a
   // submit, and only there is the guard's trailing space not real input.
   sessionAgent: (sessionId: string) => SessionAgent | undefined;
-  // Start a session in the worktree the host just cut for an issue, with the issue waiting in its
-  // input box (#1184); returns the new session id. Wired in server/index.ts, which owns both the
+  // Start a session in the worktree the host just cut for an issue, with the issue in its input
+  // box (#1184); returns the new session id. Wired in server/index.ts, which owns both the
   // spawner and the unplaced mark — the mark is what gets a session nobody's browser asked for a
   // cell, and it is why this command needs no open tab the way launchTerminal does.
-  spawnIssueDraft: (cwd: string, draft: string) => string;
+  //
+  // `run` submits the seed instead of leaving it for review (#1253). Only the host can do this:
+  // the seed is typed once the TUI's input box has painted, so an Enter sent from outside would
+  // race that, and this side is the one that knows when it landed.
+  spawnIssueSeed: (cwd: string, seed: string, run: boolean) => string;
   // Open a new grid terminal in the directory of the session the phone is looking at
   // (#831). Answered in server/index.ts, which owns the PTY table and the pub/sub the
   // grid listens on. Resolves to an error string when it could not be started.

--- a/server/backends/remoteHost/handlers/issueWork.ts
+++ b/server/backends/remoteHost/handlers/issueWork.ts
@@ -45,7 +45,7 @@ export function issueStartRefusal(plan: BlockedIssueStartPlan, repo: string): st
 
 const repoDirsNow = (): Promise<RepoDirs[]> => repoDirsFromPresets(getCwdPresets(), getRepoDirs());
 
-type IssueWorkDeps = Pick<RemoteHostHandlerDeps, "spawnIssueDraft">;
+type IssueWorkDeps = Pick<RemoteHostHandlerDeps, "spawnIssueSeed">;
 
 // `canStart` is always present and the sentence only when there is one: the phone's rule is
 // "render it if it's there", and an empty string would read as a reason nobody could name.
@@ -60,19 +60,32 @@ const listIssuesHandler: CommandHandlers[string] = async () => {
 };
 
 const startIssueWorkHandler =
-  ({ spawnIssueDraft }: IssueWorkDeps): CommandHandlers[string] =>
+  ({ spawnIssueSeed }: IssueWorkDeps): CommandHandlers[string] =>
   async (params: JsonObject) => {
     const repo = typeof params.repo === "string" ? params.repo.trim() : "";
     if (!isRepoEntry(repo)) throw new Error("repo is required, as [host/]owner/repo");
     const { issue } = params;
     if (!isIssueNumber(issue)) throw new Error("issue is required, as a positive issue number");
+    // Anything that is not `true` leaves the seed as a draft — the behaviour every caller had
+    // before this option existed. A caller that meant to run and spelled it wrong learns so from
+    // `ran` below, which reports what happened rather than what was asked for.
+    const run = params.run === true;
 
     const plan = issueStartPlan(entryFor(await repoDirsNow(), repo), repo);
     if (plan.kind !== "ready") throw new Error(issueStartRefusal(plan, repo));
 
+    // OBSERVED, not derived from the outcome: startIssueWork spawns for `created` and `reused` and
+    // skips it for `resumed`, and that rule lives there. Reading it off the outcome here would be
+    // a second copy of it, right up until a fourth outcome is added.
+    let seeded = false;
     // Named the way its own host does, like the desktop route — an entry may declare a host that
     // the repo's own identity does not carry.
-    const result = await startIssueWork(canonicalRepo(repo), issue, plan.dir, { spawnDraft: spawnIssueDraft });
+    const result = await startIssueWork(canonicalRepo(repo), issue, plan.dir, {
+      spawnDraft: (cwd, seed) => {
+        seeded = true;
+        return spawnIssueSeed(cwd, seed, run);
+      },
+    });
     // A failed step stops here with the reason it failed — the same detail the desktop route turns
     // into a status code, which on this channel is simply the sentence the phone shows.
     if (!result.ok || !result.sessionId) throw new Error(result.detail ?? `could not start work on ${repo}#${issue}`);
@@ -84,6 +97,9 @@ const startIssueWorkHandler =
       // describe as a fresh start: that session was already working on this issue, and the issue
       // text is NOT waiting in its box.
       outcome: result.outcome ?? "created",
+      // Whether the seed was SUBMITTED (#1253), so the phone says "started" rather than "it's in
+      // the input box, press Enter yourself" — which on a phone is not something the reader can do.
+      ran: run && seeded,
       // The title, so the phone can confirm WHICH issue it just started without a second call. The
       // body is deliberately not echoed: it is already in the session's input box, and it is the
       // one field here with no upper bound.

--- a/server/backends/remoteHost/handlers/issueWork.ts
+++ b/server/backends/remoteHost/handlers/issueWork.ts
@@ -97,8 +97,10 @@ const startIssueWorkHandler =
       // describe as a fresh start: that session was already working on this issue, and the issue
       // text is NOT waiting in its box.
       outcome: result.outcome ?? "created",
-      // Whether the seed was SUBMITTED (#1253), so the phone says "started" rather than "it's in
-      // the input box, press Enter yourself" — which on a phone is not something the reader can do.
+      // Whether this session was started to SUBMIT its seed (#1253), so the phone says "started"
+      // rather than "it's in the input box, press Enter yourself" — which on a phone is not
+      // something the reader can do. Not a landed keystroke: the typing happens after this reply,
+      // once the TUI's input box has painted.
       ran: run && seeded,
       // The title, so the phone can confirm WHICH issue it just started without a second call. The
       // body is deliberately not echoed: it is already in the session's input box, and it is the

--- a/server/backends/remoteHost/index.ts
+++ b/server/backends/remoteHost/index.ts
@@ -93,7 +93,7 @@ export function initRemoteHostBackend(deps: RemoteHostBackendDeps): void {
     handlers: createRemoteHostHandlers({
       workspace: deps.workspace,
       spawnChat: deps.spawnChat,
-      spawnIssueDraft: deps.spawnIssueDraft,
+      spawnIssueSeed: deps.spawnIssueSeed,
       ingest,
       listTerminalSessions: deps.listTerminalSessions,
       captureTerminalScreen: deps.captureTerminalScreen,

--- a/server/backends/remoteHost/issueWork.spec.ts
+++ b/server/backends/remoteHost/issueWork.spec.ts
@@ -31,16 +31,27 @@ const { createIssueWorkHandlers } = await import("./handlers/issueWork.js");
 const clone = (path: string, label = path): RepoDirs["dirs"][number] => ({ path, label, orderPriority: null });
 const repoDirs = (paths: string[], primary: string | null = null, repo = "acme/web"): RepoDirs => ({ repo, dirs: paths.map((p) => clone(p)), primary });
 
-const spawnIssueDraft = vi.fn<(cwd: string, draft: string) => string>();
-const handlers = createIssueWorkHandlers({ spawnIssueDraft });
+const spawnIssueSeed = vi.fn<(cwd: string, seed: string, run: boolean) => string>();
+const handlers = createIssueWorkHandlers({ spawnIssueSeed });
 
 const start = (params: Record<string, unknown>) => handlers.startIssueWork({ ...params } as Parameters<(typeof handlers)["startIssueWork"]>[0]);
 const list = () => handlers.listIssues({});
 
+// A start that actually seeds a session — `created` / `reused`. The suites' default stub answers
+// without ever calling the spawner, which is what `resumed` does, so a case about what reached the
+// spawner has to say so.
+const startsBySpawning = (outcome: "created" | "reused" = "created") =>
+  issueWork.start.mockImplementation(async (_repo: string, _issue: number, _dir: string, deps: { spawnDraft: (cwd: string, seed: string) => string }) => ({
+    ok: true,
+    outcome,
+    sessionId: deps.spawnDraft("/wt/thing", "GitHub issue #7"),
+    branch: "issue/7-thing",
+  }));
+
 describe("startIssueWork (phone)", () => {
   beforeEach(() => {
-    spawnIssueDraft.mockReset();
-    spawnIssueDraft.mockReturnValue("s-1");
+    spawnIssueSeed.mockReset();
+    spawnIssueSeed.mockReturnValue("s-1");
     issueWork.start.mockReset();
     issueWork.start.mockResolvedValue({ ok: true, sessionId: "s-1", branch: "issue/7-thing", worktree: "/wt/thing", issue: { number: 7, title: "The thing" } });
     dirs.rows = [repoDirs(["/clones/web"], "/clones/web")];
@@ -130,14 +141,66 @@ describe("startIssueWork (phone)", () => {
   });
 
   it("passes the spawner through, so the session is the one the host started", async () => {
-    issueWork.start.mockImplementation(async (_repo: string, _issue: number, _dir: string, deps: { spawnDraft: (cwd: string, draft: string) => string }) => ({
-      ok: true,
-      sessionId: deps.spawnDraft("/wt/thing", "GitHub issue #7"),
-      branch: "issue/7-thing",
-    }));
+    startsBySpawning();
     const answer = await start({ repo: "acme/web", issue: 7 });
-    expect(spawnIssueDraft).toHaveBeenCalledWith("/wt/thing", "GitHub issue #7");
+    expect(spawnIssueSeed).toHaveBeenCalledWith("/wt/thing", "GitHub issue #7", false);
     expect(answer).toMatchObject({ sessionId: "s-1" });
+  });
+});
+
+// #1253. The phone has no Enter key, so a seed left in the input box is where the work stops.
+describe("startIssueWork run (phone)", () => {
+  beforeEach(() => {
+    spawnIssueSeed.mockReset();
+    spawnIssueSeed.mockReturnValue("s-1");
+    issueWork.start.mockReset();
+    dirs.rows = [repoDirs(["/clones/web"], "/clones/web")];
+  });
+
+  it("submits the seed when the caller asks it to, and says it ran", async () => {
+    startsBySpawning();
+    const answer = await start({ repo: "acme/web", issue: 7, run: true });
+    expect(spawnIssueSeed).toHaveBeenCalledWith("/wt/thing", "GitHub issue #7", true);
+    expect(answer).toMatchObject({ ran: true });
+  });
+
+  it("runs a reused worktree's new session too — it is seeded like a fresh one", async () => {
+    startsBySpawning("reused");
+    await expect(start({ repo: "acme/web", issue: 7, run: true })).resolves.toMatchObject({ outcome: "reused", ran: true });
+    expect(spawnIssueSeed).toHaveBeenCalledWith("/wt/thing", "GitHub issue #7", true);
+  });
+
+  // The case that must not run: nothing was typed into that session, so submitting would send
+  // whatever the user left in its box — or an empty line.
+  it("does not run a resumed session, even when asked to", async () => {
+    issueWork.start.mockResolvedValue({ ok: true, outcome: "resumed", sessionId: "s-old", branch: "issue/7-thing" });
+    await expect(start({ repo: "acme/web", issue: 7, run: true })).resolves.toMatchObject({ outcome: "resumed", ran: false });
+    expect(spawnIssueSeed).not.toHaveBeenCalled();
+  });
+
+  // The desktop's behaviour, which is also every caller's default: typed, not sent.
+  it.each([
+    ["run is absent", {}],
+    ["run is false", { run: false }],
+    // Not `true` is not a run. A caller that meant to and spelled it wrong reads `ran` and learns
+    // so, rather than being told the work started when it is sitting in an input box.
+    ["run is a string", { run: "true" }],
+    ["run is 1", { run: 1 }],
+  ])("leaves the seed as a draft when %s", async (_case, extra) => {
+    startsBySpawning();
+    await expect(start({ repo: "acme/web", issue: 7, ...extra })).resolves.toMatchObject({ ran: false });
+    expect(spawnIssueSeed).toHaveBeenCalledWith("/wt/thing", "GitHub issue #7", false);
+  });
+
+  // One working tree runs one agent (#1207), and asking to run does not suspend that.
+  it("still refuses a worktree held by another terminal", async () => {
+    issueWork.start.mockResolvedValue({
+      ok: false,
+      reason: "worktree-busy",
+      detail: "this worktree's session is open in another terminal — close it there first",
+    });
+    await expect(start({ repo: "acme/web", issue: 7, run: true })).rejects.toThrow(/open in another terminal/);
+    expect(spawnIssueSeed).not.toHaveBeenCalled();
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ import { messageOf } from "./errors.js";
 import { hookSettingsJson } from "./session/hook-settings.js";
 import { mcpConfigJson } from "./session/mcp-config.js";
 import { createClaudeSpawner } from "./session/spawn-claude.js";
+import { issueSpawnOptions } from "./session/issue-spawn-options.js";
 import { spawnPty } from "./session/pty-spawn.js";
 import { createRateLimitStore } from "./agents/rate-limit-store.js";
 import { startRateLimitProbe } from "./agents/rate-limit-probe.js";
@@ -577,12 +578,12 @@ const remoteHostSpawnChat = (message: string) => {
   return { chatId: sessionId };
 };
 // Starting work on an issue from the phone (#1184). The same spawn the desktop's POST
-// /api/issues/start makes — a working session in a repository, so the project's own MCP servers
-// load instead of being replaced by the GUI one — plus the unplaced mark for the same reason as
-// above: the phone has no grid, so nothing else would give this session a cell.
-const remoteHostSpawnIssueDraft = (cwd: string, draft: string): string => {
+// /api/issues/start makes, plus the unplaced mark for the same reason as above: the phone has no
+// grid, so nothing else would give this session a cell. `run` submits the seed rather than leaving
+// it in the box (#1253) — see issueSpawnOptions for why the choice is a function and not two keys.
+const remoteHostSpawnIssueSeed = (cwd: string, seed: string, run: boolean): string => {
   const sessionId = randomUUID();
-  spawnClaudePty(sessionId, null, null, { cwd, draft, attachGuiMcp: false });
+  spawnClaudePty(sessionId, null, null, issueSpawnOptions(cwd, seed, run));
   markUnplacedSession(sessionId);
   return sessionId;
 };
@@ -733,7 +734,7 @@ const remoteHostLaunchTerminal = (agent: unknown, sessionId: unknown) => {
 initRemoteHostBackend({
   workspace: CLAUDE_CWD,
   spawnChat: remoteHostSpawnChat,
-  spawnIssueDraft: remoteHostSpawnIssueDraft,
+  spawnIssueSeed: remoteHostSpawnIssueSeed,
   launchTerminal: remoteHostLaunchTerminal,
   listTerminalSessions: remoteHostListTerminalSessions,
   captureTerminalScreen: remoteHostCaptureTerminalScreen,

--- a/server/session/issue-spawn-options.ts
+++ b/server/session/issue-spawn-options.ts
@@ -1,0 +1,20 @@
+// How an issue's seed reaches its session: typed and left for review, or typed and run (#1253).
+//
+// A decision rather than two call sites because the two keys are NOT independent. planDraftInjection
+// resolves `draft ?? initialPrompt`, so a spawn carrying both types the draft and never submits —
+// no error, no warning, and the session simply sits there. Exactly one key is the invariant, and it
+// is worth a test of its own; server/index.ts, where the spawn happens, has no way to have one.
+import type { SpawnClaudeOptions } from "./spawn-claude.js";
+
+/** The seed's spawn options. `run` is the phone's (#1253): it has no Enter key, so text left in the
+ *  input box is where the work stops. The desktop keeps the draft — there, the person who opened
+ *  the issue and the person about to run it are often not the same. */
+export function issueSpawnOptions(cwd: string, seed: string, run: boolean): SpawnClaudeOptions {
+  return {
+    cwd,
+    // A working session in a repository, the same shape as a grid dev terminal, so the project's
+    // own MCP servers load instead of being replaced by the GUI one under --strict-mcp-config.
+    attachGuiMcp: false,
+    ...(run ? { initialPrompt: seed } : { draft: seed }),
+  };
+}

--- a/test/server/session/issue-spawn-options.spec.ts
+++ b/test/server/session/issue-spawn-options.spec.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+// #1253. The invariant worth a test of its own is that EXACTLY ONE of draft / initialPrompt is
+// set: planDraftInjection resolves `draft ?? initialPrompt`, so a spawn carrying both types the
+// text and never submits — with no error anywhere, which reads as "the run option does nothing".
+import { describe, it, expect } from "vitest";
+
+import { issueSpawnOptions } from "../../../server/session/issue-spawn-options.js";
+import { planDraftInjection } from "../../../server/session/draft-plan.js";
+
+const SEED = "GitHub issue #1253: run it";
+const identity = (s: string) => s;
+
+describe("issueSpawnOptions", () => {
+  it("leaves the seed for review when run is false", () => {
+    expect(issueSpawnOptions("/wt/1253", SEED, false)).toEqual({ cwd: "/wt/1253", attachGuiMcp: false, draft: SEED });
+  });
+
+  it("hands the seed over as the first turn when run is true", () => {
+    expect(issueSpawnOptions("/wt/1253", SEED, true)).toEqual({ cwd: "/wt/1253", attachGuiMcp: false, initialPrompt: SEED });
+  });
+
+  it.each([true, false])("sets exactly one of draft / initialPrompt (run=%s)", (run) => {
+    const options = issueSpawnOptions("/wt/1253", SEED, run);
+    expect([options.draft, options.initialPrompt].filter((value) => value !== undefined)).toEqual([SEED]);
+  });
+
+  // Both directions against the rule they exist to drive, rather than against the keys alone: the
+  // keys are only right because planDraftInjection reads them this way.
+  it.each([
+    [true, true],
+    [false, false],
+  ])("run=%s reaches the injector as autoSubmit=%s", (run, autoSubmit) => {
+    const { initialPrompt, draft } = issueSpawnOptions("/wt/1253", SEED, run);
+    expect(planDraftInjection(initialPrompt, draft, identity)).toEqual({ text: SEED, autoSubmit });
+  });
+
+  // A worktree session is a working session in a repository, the same shape as a grid dev
+  // terminal, so the project's own MCP servers load — running the seed does not change that.
+  it("never attaches the GUI MCP", () => {
+    expect(issueSpawnOptions("/wt/1253", SEED, true).attachGuiMcp).toBe(false);
+    expect(issueSpawnOptions("/wt/1253", SEED, false).attachGuiMcp).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`startIssueWork`（スマホ経路）に **`run?: boolean`** を追加。`run: true` のとき、種プロンプトを
`draft` ではなく **`initialPrompt`** として spawn するので、既存の注入経路が入力欄の準備を待って
タイプし、**Enter まで送る**。スマホには Enter が無く、入力欄に置かれた種はそこで止まっていた。

返り値に **`ran`** を追加。**デスクトップは現行のまま draft。**

`ran` は「このセッションが種を**送信する形で起動したか**」であって、Enter が既に着弾したことでは
ありません（応答はセッション生成直後に返り、タイプと送信は入力欄の描画後に非同期で起きる）。
スマホは「開始しました」と出す根拠に使い、実際に動いているかは `getTerminalScreen` を見る想定です。

`server/git/issue-work.ts` は**無変更**。`run` を spawn クロージャに閉じ込めたので、
`outcome: "resumed"`（何もタイプされないケース）は既存の早期 return によって**構造的に**実行されない。

## Items to Confirm / Review

人に見てほしい判断は4つです。

1. **`ran` を `outcome` から導出せず「観測」している** — `handlers/issueWork.ts` の `let seeded`。
   `spawnDraft` が呼ばれたかどうかを直接見ています。`outcome` から導くと「どの outcome が種を
   まくか」という規則の**2つ目のコピー**ができ、4つ目の outcome が増えた日に片方だけ腐るため。
   `let` を1つ使うのはこの理由です。
   - 変異テストで実証済み: `ran: run && seeded` を `ran: run` に書き換えると
     `does not run a resumed session, even when asked to` が落ちます。

2. **純関数 `server/session/issue-spawn-options.ts` を新設したこと** — `draft` と `initialPrompt`
   を**両方**渡すと `planDraftInjection` の `draft ?? initialPrompt` で draft が勝ち、
   **エラーも警告も出ないまま走らない**（＝「run オプションが効かない」という形で現れる）。
   「必ず片方だけ」はテストで固定する価値のある不変条件で、`server/index.ts` は単体テストできない
   ので、決定だけを純関数に出しました。1呼び出し元のための関数なので、過剰なら言ってください。

3. **`run` が boolean でないときは throw せず draft 扱い** — `params.run === true`。
   `repo` / `issue` は throw するので不揃いに見えますが、こちらは安全な側（現行動作）に落ち、
   かつ返り値の `ran` が実際どうなったかを正しく報告するので、スマホが「実行しました」と
   誤表示することは起きません。`run: 1` のような綴り間違いは `ran: false` で分かります。
   throw に揃えるべきなら変えます。

4. **dep 名を `spawnIssueDraft` → `spawnIssueSeed` に改名した** — `run: true` のとき draft では
   なくなるため。`deps.ts` / `remoteHost/index.ts` / `server/index.ts` / `handlers/issueWork.ts` と
   spec 3本の計7ファイル。

5. **trust ダイアログとの兼ね合い（既知の残存エッジ・レビュー中に自分で確認）** — Claude の起動は
   `--dangerously-skip-permissions` を使わないので、**新しく作った worktree では trust ダイアログが
   出得ます**（#1173 で `attachDraftInjection` に `TRUST_QUIET_MS` が入っている理由）。検出できた場合は
   60秒待ちますが、検出漏れ（ペインが狭く文言が出ない等）や、誰も答えないまま窓が切れた場合、
   フォールバックがダイアログに向けてタイプします。
   - draft のとき: 種はダイアログに食われて消える（**現行の挙動**）
   - `run: true` のとき: 同じく種は消え、加えて Enter がダイアログの選択肢を確定させる
   - どちらも種は失われるので**機能的な後退ではなく**、対象はアプリ自身がユーザの選んだリポの下に
     作った worktree なので信頼の是非としても後退ではないと判断しました。`ran` の文言を上記のように
     直したのはこのためでもあります。trust ダイアログの扱いそのものは #1253 の範囲外なので触っていません。

### 検討して**やらなかった**こと

`server/routes/issue-work-routes.ts`（デスクトップ）も `issueSpawnOptions(cwd, draft, false)` を
使えば `attachGuiMcp: false` の理由コメントの重複が消えます。**issue に「変更なし」とあるので
触っていません**が、出力は完全に同一になる純リファクタです。やるべきなら別 PR / このPRどちらでも。

## User Prompt

> ## やりたいこと
>
> スマホ（mulmoserver）から issue の行をタップして作業を始めると、worktree が切られてセッションは
> 立ち上がるが、**issue 本文は入力欄に置かれるだけで走らない**。スマホには Enter が無いので、
> そこで止まってしまう。**スマホから始めたときは、そのまま実行まで行ってほしい。**
>
> ## なぜスマホ側だけでは直せないか
>
> - 種プロンプトは `spawnDraft` 経由で **draft** として入る。`server/session/draft-plan.ts` の
>   `planDraftInjection` は `draft` を渡された場合 `autoSubmit: false` で、「draft は未レビューの
>   テキストなので絶対に自動送信しない」と設計上明記されている。
> - `sendTerminalInput` で Enter だけ送ることはできない。`server/backends/remoteHost/terminalInput.ts`
>   は `sanitizeTerminalInput` 後に空なら `text is required` で throw する。
> - 何か文字を送る回避策も駄目で、`canClearInputBox`（claude かつ idle と分かっているとき）が
>   貼り付け前に Ctrl-C で**入力欄を消す**。消えなかった場合は下書きの後ろに文字が混ざって送信される。
> - そもそも draft の注入は TUI の準備完了マーカー（`DRAFT_READY_MARKER` / quiet window）を待ってから
>   行われるので、スマホから撃つ Enter は注入と競合する。タイミングを知っているのはホストだけ。
>
> ## 提案（ホスト側）
>
> `startIssueWork` に `run?: boolean`（既定 false）を足し、true のときは種を **draft ではなく
> `initialPrompt`** として spawn する。`planDraftInjection` は `initialPrompt` なら入力欄の準備を
> 待った上で **タイプして Enter まで送る**（`autoSubmit: true`）— `startChat` が既に使っている
> 経路なので、新しい仕掛けは要らない。
>
> - `server/backends/remoteHost/handlers/deps.ts` の `spawnIssueDraft: (cwd, draft) => string` を、
>   実行するかどうかを渡せる形にする（別 dep でも、第3引数でも）。
> - `server/backends/remoteHost/handlers/issueWork.ts` の
>   `startIssueWork(repo, issue, plan.dir, { spawnDraft: spawnIssueDraft })` に、`params.run` を通す。
> - **デスクトップは現行のまま**（draft）。`server/routes/issue-work-routes.ts` 側は変更なし。
>   issue を書いた人と走らせる人が違う、という既存の理由はデスクトップにはそのまま当てはまる。
>
> ### `resumed` のときは実行しない
>
> `outcome: "resumed"` は、その issue の worktree に既にセッションがあって**何もタイプされない**
> ケース。ここで実行に回ると、無関係な入力欄の中身（あるいは空）を送ることになる。
> `created` / `reused` のときだけ。
>
> ### 返り値（任意）
>
> 実際に実行まで行ったかを `ran: true` のような形で返してもらえると、スマホ側が「開始しました」と
> 「入力欄に入れました（Enter はご自分で）」を出し分けられる。無くても実装は可能。
>
> ## なぜ自動実行して安全か
>
> `issueSeedPrompt` が最後に付ける一文が `Let's work on this issue. Read it through first and
> confirm the approach with me before implementing.` なので、自動実行しても**実装の前に一度必ず
> 止まって方針を確認する**。走り出してそのままコードが書かれるわけではない。
>
> ## スマホ側（mulmoserver）
>
> このオプションが入ったら、`startIssueWorkRequest` に `run: true` を足すだけ（数行）。
> スマホから始めたときは常に実行、で確定している。

実装前の確認で、以下2点をユーザーに選んでもらいました:

- **`run` の通し方** → 「クロージャで捕捉」（`server/git/issue-work.ts` 無変更）
- **dep 名** → 「`spawnIssueSeed` に改名」

## 実装

### 走らせ方 — 既存の auto-run 経路に乗せるだけ

```
run: true  → { cwd, initialPrompt: seed }   autoSubmit: true   タイプして Enter
run: false → { cwd, draft: seed }           autoSubmit: false  タイプするだけ（現行）
```

`attachDraftInjection` が `DRAFT_READY_MARKER`（入力欄の描画）を待ってからペーストし、
`DRAFT_SUBMIT_MS` 後に**別チャンクで** submit を送ります。新しい仕掛けはゼロで、
`startChat` が既に通っている経路そのものです。

### `resumed` の除外を「書かない」

`startIssueWork` は `reopenIssueWorktree` の `action === "resume"` で早期 return し、
**`spawnDraft` を呼びません**。`run` をクロージャに閉じ込めたので、呼ばれない以上 `run` は届かない。
新しい条件分岐を足すと同じ規則が2箇所にでき、片方だけ腐ります。

### 変更ファイル

| ファイル | 変更 |
|---|---|
| `server/session/issue-spawn-options.ts` | **新規**。`run` → spawn オプションの純関数 |
| `test/server/session/issue-spawn-options.spec.ts` | **新規**。8 tests |
| `server/backends/remoteHost/handlers/deps.ts` | `spawnIssueDraft` → `spawnIssueSeed(cwd, seed, run)` |
| `server/backends/remoteHost/handlers/issueWork.ts` | `params.run` を読み、`ran` を返す |
| `server/backends/remoteHost/index.ts` · `server/index.ts` | dep の付け替え・純関数の使用 |
| `server/backends/remoteHost/issueWork.spec.ts` | run/ran の 7 tests を追加 |
| `docs/remote-host-protocol.md` | params 表・`run` の節・`ran` の表 |
| `plans/feat-1253-issue-work-run.md` | 設計メモ |
| `server/git/issue-work.ts` · `server/routes/issue-work-routes.ts` | **無変更** |

## テスト

新規 15 本。

**`issue-spawn-options`（8）**
- `run` の各値で `draft` / `initialPrompt` が**片方だけ**立つ（両方向）
- 実オプションを `planDraftInjection` に食わせて `run: true → autoSubmit: true` /
  `false → false` を固定 — キーが合っていて挙動が違う、が起きない
- `attachGuiMcp: false` は `run` に関係なく不変

**`startIssueWork run`（7）**
- `run: true` → spawner の第3引数が `true`、`ran: true`
- `reused` でも実行される（新しいセッションに種はまかれるため）
- **`resumed` は `run: true` でも `ran: false`、spawner は呼ばれない**
- `run` 無し / `false` / `"true"` / `1` はいずれも `ran: false` で draft のまま
- `worktree-busy` の拒否は `run: true` でも文面ごと伝わる（#1207 は解除されない）

### 実行結果

- `yarn format` / `yarn lint`（新規エラー 0） / `yarn typecheck` / `yarn typecheck:server` /
  `yarn typecheck:test` / `yarn build` / `yarn knip`（新規指摘 0）
- `yarn test` — **510 files / 7403 tests 全 pass**
- **変異テスト**: `ran: run && seeded` を `ran: run` に書き換えると
  `does not run a resumed session, even when asked to` が落ちることを確認。
  `resumed` の除外がテストで実際に守られています。

## スマホ側（別リポジトリ）

このあと mulmoserver 側で `startIssueWorkRequest` に `run: true` を足すだけです。
関連: mulmoserver#132 / mulmoserver#134、#1184 / #1216。

Closes #1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)

work in mulmoterminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote issue work can now optionally run and submit the issue seed automatically.
  * Responses indicate whether execution occurred and report the resulting outcome.
  * Added handling for newly created, reused, and resumed sessions with appropriate run behavior.

* **Documentation**
  * Updated remote-host protocol documentation with the new option, response fields, safety rules, and session behavior.
  * Added an implementation plan for mobile issue work.

* **Tests**
  * Added coverage for run behavior, session types, invalid values, busy worktrees, and spawn options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->