### PR TITLE
fix: server 5ファイルの as を21箇所とも外す (#1231)

### DIFF
--- a/server/backends/collections.ts
+++ b/server/backends/collections.ts
@@ -60,12 +60,13 @@ import {
   remoteViewItems,
   remoteViewItemsFailureMessage,
 } from "./remoteView.js";
-import { clampCapabilities, mintViewToken, requireViewToken, type ViewCapability } from "./viewToken.js";
+import { clampCapabilities, isCapability, mintViewToken, requireViewToken } from "./viewToken.js";
 // The shared manageCollection binding — the query route reuses its queryItems
 // action so a view can never do more than the agent's own data plane.
 import { manageCollectionHandler } from "../infra/collection-tool.js";
 import { hostLogger } from "./hostLogger.js";
 import { mutateStatus, mutateWriteApplied } from "./mutateStatus.js";
+import { isRecord } from "../../common/isRecord.js";
 
 // Console-backed logger matching the engine's CollectionLogger shape
 // (prefix, message, optional structured data) — shared with the other engines'
@@ -137,8 +138,7 @@ function guarded<P extends Record<string, string>>(op: string, handler: RequestH
 
 /** A request body usable as a record: a non-null, non-array object. */
 function extractRecord(body: unknown): CollectionItem | null {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
-  return body as CollectionItem;
+  return isRecord(body) ? body : null;
 }
 
 // A loaded collection, sans the null that `loadCollection` returns on a miss —
@@ -225,7 +225,8 @@ async function writeViewItem(collection: ResolvedCollection, raw: unknown, mode:
   const record = extractRecord(raw);
   if (!record) return { rejected: { id: "", problem: "item must be a JSON object" } };
   const { singleton, primaryKey } = collection.schema;
-  const itemId = typeof record[primaryKey] === "string" ? (record[primaryKey] as string) : "";
+  const declaredId = record[primaryKey];
+  const itemId = typeof declaredId === "string" ? declaredId : "";
   if (!itemId) return { rejected: { id: "", problem: `missing primary key '${primaryKey}'` } };
   if (singleton && itemId !== singleton) {
     return { rejected: { id: itemId, problem: `collection '${collection.slug}' is a singleton; the only valid item id is '${singleton}'` } };
@@ -455,7 +456,7 @@ const respondForMutateAction = async (
   body: { params?: unknown } | undefined,
 ): Promise<void> => {
   const raw = body?.params;
-  const params = raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
+  const params = isRecord(raw) ? raw : {};
   const outcome = await applyMutateAction(collection, action, itemId, params);
   if (!outcome.ok) {
     // `itemId` is caller-controlled (a route param) — strip CR/LF so a crafted
@@ -518,7 +519,7 @@ const itemActionHandler: RequestHandler<{ slug: string; itemId: string; actionId
       res.status(405).json({ error: readOnlyRefusal(collection.slug) });
       return;
     }
-    await respondForMutateAction(res, collection, action, req.params.itemId, req.body as { params?: unknown } | undefined);
+    await respondForMutateAction(res, collection, action, req.params.itemId, isRecord(req.body) ? req.body : undefined);
     return;
   }
   const template = await readActionTemplateOr500(res, collection, action);
@@ -608,9 +609,13 @@ const remoteViewHandler: RequestHandler<{ slug: string }> = async (req, res) => 
 // preview's write channel. Same builder + host-side policy as the channel's
 // `mutateRemoteViewItem`, so a preview mutation runs the exact enforcement the
 // phone will.
+// The predicate the write-mode check needs: `VIEW_WRITE_MODES.includes()` only accepts a value
+// already typed as a mode, which is what forced the assertion it replaces.
+const isViewWriteMode = (value: unknown): value is ViewWriteMode => VIEW_WRITE_MODES.some((mode) => mode === value);
+
 const remoteViewMutateHandler: RequestHandler<{ slug: string; viewId: string }> = async (req, res) => {
   const { slug, viewId } = req.params;
-  const request = normalizeMutate((req.body ?? {}) as { op?: unknown; id?: unknown; patch?: unknown });
+  const request = normalizeMutate(isRecord(req.body) ? req.body : {});
   if (!request) {
     res.status(400).json({ error: "invalid mutate request — expected { op: 'update'|'delete', id, patch? }" });
     return;
@@ -653,7 +658,7 @@ const remoteViewItemsHandler: RequestHandler<{ slug: string; viewId: string }> =
 // read-only view can never obtain a write token.
 const viewTokenHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   const { slug } = req.params;
-  const body = (req.body ?? {}) as { viewId?: unknown; capabilities?: unknown };
+  const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
   const viewId = typeof body.viewId === "string" ? body.viewId.trim() : "";
   if (!viewId) {
     res.status(400).json({ error: "`viewId` is required" });
@@ -666,7 +671,10 @@ const viewTokenHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   // The write tier is wired below (PUT /view-data), so grant exactly what the
   // view declared. `clampCapabilities` defaults the requested set to the declared
   // set, so a `["read"]` view still can never obtain a `write` token.
-  const granted = clampCapabilities(view.capabilities as ViewCapability[] | undefined, undefined);
+  // Filtered rather than asserted. The schema validator already rejects an unrecognised capability
+  // (a collection declaring one fails to load at all), so this changes nothing today — but it is
+  // the local code proving what it hands to the minter rather than declaring it.
+  const granted = clampCapabilities(Array.isArray(view.capabilities) ? view.capabilities.filter(isCapability) : undefined, undefined);
   const minted = mintViewToken(slug, granted);
   res.json({ token: minted.token, exp: minted.exp, dataUrl: `/api/collections/${encodeURIComponent(slug)}/view-data`, capabilities: granted });
 };
@@ -704,13 +712,15 @@ const viewDataPutHandler: RequestHandler<{ slug: string }> = async (req, res) =>
     res.status(405).json({ error: readOnlyRefusal(collection.slug) });
     return;
   }
-  const body = (req.body ?? {}) as { items?: unknown; mode?: unknown };
+  const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
   if (!Array.isArray(body.items)) {
     res.status(400).json({ error: "`items` must be an array" });
     return;
   }
-  const mode: ViewWriteMode = body.mode === undefined ? "upsert" : (body.mode as ViewWriteMode);
-  if (!VIEW_WRITE_MODES.includes(mode)) {
+  // Checked BEFORE it is typed. The assertion this replaces named `body.mode` a valid mode and
+  // then asked whether it was one — the answer arrived after the claim.
+  const mode = body.mode === undefined ? "upsert" : body.mode;
+  if (!isViewWriteMode(mode)) {
     const modeList = VIEW_WRITE_MODES.map((m) => `"${m}"`).join(", ");
     res.status(400).json({ error: `\`mode\` must be one of ${modeList}` });
     return;
@@ -758,7 +768,7 @@ const viewQueryConcurrency = (req: Request<{ slug?: string }>, res: Response, ne
 // is not a trusted audience for those.
 const viewDataQueryHandler: RequestHandler<{ slug: string }> = async (req, res) => {
   try {
-    const body = (req.body ?? {}) as { query?: unknown };
+    const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
     const raw = await manageCollectionHandler({ action: "queryItems", slug: req.params.slug, query: body.query });
     try {
       res.json(JSON.parse(raw));

--- a/server/backends/remoteHost/terminalScreen.ts
+++ b/server/backends/remoteHost/terminalScreen.ts
@@ -3,7 +3,7 @@
 // Both entry points are dependency-injected and free of server/index.ts internals, so the
 // join rules and the capture fallback are unit-testable without a live PTY or tmux.
 import { parseStyledRows, rowsToScreen, suggestionFromRows, type ScreenRow } from "../../session/screen-rows.js";
-import type { SessionAgent } from "../../../common/sessionAgent.js";
+import { TERMINAL_AGENTS, type SessionAgent } from "../../../common/sessionAgent.js";
 import { workItemHeadline, type PrPhase, type WorkItem } from "../../../common/prPhase.js";
 import type { QuickCommandChip } from "./quickCommands.js";
 import { basename } from "node:path";
@@ -23,9 +23,11 @@ const AGENT_DEFAULT_COMMAND: Record<AgentKind, string> = { claude: "claude", cod
 
 const agentCommands = (): Record<string, SessionAgent> => {
   const map: Record<string, SessionAgent> = {};
-  for (const [kind, command] of Object.entries(AGENT_DEFAULT_COMMAND)) {
-    map[command] = kind as SessionAgent;
-    map[basename(getAgentAdapter(kind as AgentKind).bin())] = kind as SessionAgent;
+  // Over the KIND list rather than Object.entries, which widens the keys of a Record back to
+  // `string` and cost three assertions to undo.
+  for (const kind of TERMINAL_AGENTS) {
+    map[AGENT_DEFAULT_COMMAND[kind]] = kind;
+    map[basename(getAgentAdapter(kind).bin())] = kind;
   }
   return map;
 };

--- a/server/backends/viewToken.ts
+++ b/server/backends/viewToken.ts
@@ -13,10 +13,11 @@
 // changes), the same lifecycle MulmoClaude gets for free.
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import type { Request, Response, NextFunction } from "express";
+import { isRecord } from "../../common/isRecord.js";
 
 export type ViewCapability = "read" | "write";
 
-function isCapability(value: unknown): value is ViewCapability {
+export function isCapability(value: unknown): value is ViewCapability {
   return value === "read" || value === "write";
 }
 
@@ -39,11 +40,15 @@ function signPayload(payloadB64: string): string {
   return createHmac("sha256", SIGNING_KEY).update(payloadB64).digest("base64url");
 }
 
+// Least privilege when a view declares nothing. A module constant rather than a literal cast
+// at the call site: an annotation is checked, an assertion is not.
+const LEAST_PRIVILEGE: ViewCapability[] = ["read"];
+
 /** Clamp a view's requested capabilities to what it declared in its schema — a
  *  `["read"]` view can never get a `write` token. The result is declared ∩
  *  requested; undefined declared ⇒ least-privilege `["read"]`. */
 export function clampCapabilities(declared: ViewCapability[] | undefined, requested: ViewCapability[] | undefined): ViewCapability[] {
-  const declaredCaps = declared && declared.length > 0 ? declared : (["read"] as ViewCapability[]);
+  const declaredCaps = declared && declared.length > 0 ? declared : LEAST_PRIVILEGE;
   const requestedCaps = requested && requested.length > 0 ? requested : declaredCaps;
   return declaredCaps.filter((cap) => requestedCaps.includes(cap));
 }
@@ -74,12 +79,13 @@ export function verifyViewToken(token: string, nowMs: number = Date.now()): View
   } catch {
     return null;
   }
-  if (!parsed || typeof parsed !== "object") return null;
-  const candidate = parsed as Record<string, unknown>;
-  if (typeof candidate.slug !== "string" || typeof candidate.exp !== "number") return null;
-  if (!Array.isArray(candidate.caps) || !candidate.caps.every(isCapability)) return null;
-  if (nowMs >= candidate.exp) return null;
-  return { slug: candidate.slug, caps: candidate.caps as ViewCapability[], exp: candidate.exp };
+  if (!isRecord(parsed)) return null;
+  const { slug, exp, caps } = parsed;
+  if (typeof slug !== "string" || typeof exp !== "number") return null;
+  // `every` with a type predicate narrows the array itself, so the checked value IS the typed one.
+  if (!Array.isArray(caps) || !caps.every(isCapability)) return null;
+  if (nowMs >= exp) return null;
+  return { slug, caps, exp };
 }
 
 /** Express middleware: require a valid scoped token whose slug matches the route

--- a/server/config/cwd-presets.ts
+++ b/server/config/cwd-presets.ts
@@ -45,7 +45,8 @@ export function sanitizePresets(input: unknown, max = 50): CwdPreset[] {
 export function loadPresets(file: string): CwdPreset[] {
   try {
     if (!existsSync(file)) return [];
-    return sanitizePresets((readJsonFile(file) as { cwdPresets?: unknown } | null)?.cwdPresets);
+    const parsed: unknown = readJsonFile(file);
+    return sanitizePresets(isRecord(parsed) ? parsed.cwdPresets : undefined);
   } catch {
     return [];
   }
@@ -75,7 +76,8 @@ export function extractCwdFromTranscript(raw: string): string | null {
   for (const line of raw.split("\n")) {
     if (!line) continue;
     try {
-      const cwd = (JSON.parse(line) as { cwd?: unknown }).cwd;
+      const entry: unknown = JSON.parse(line);
+      const cwd = isRecord(entry) ? entry.cwd : undefined;
       if (typeof cwd === "string" && cwd) return cwd;
     } catch {
       // a partial / non-JSON line (e.g. a truncated head read) — keep scanning

--- a/server/infra/gui-mcp-registration.ts
+++ b/server/infra/gui-mcp-registration.ts
@@ -18,6 +18,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { spawnCaptureAsync } from "./spawnCapture.js";
 import { toolGroupServerId, type ToolGroup } from "../../common/toolGroups.js";
+import { isRecord } from "../../common/isRecord.js";
 
 export const guiMcpUrlTemplate = (group: ToolGroup): string => `http://127.0.0.1:\${MULMOTERMINAL_PORT}/api/mcp/${group}/\${MULMOTERMINAL_SESSION_ID}`;
 
@@ -57,7 +58,7 @@ const claudeConfigFile = (): string => path.join(process.env.CLAUDE_CONFIG_DIR?.
 async function readJsonObject(file: string): Promise<Record<string, unknown> | null> {
   try {
     const parsed: unknown = JSON.parse(await readFile(file, "utf8"));
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+    return isRecord(parsed) ? parsed : null;
   } catch {
     // Absent, unreadable or half-written (Claude Code rewrites this file live). Nothing
     // registered is the honest answer, and it is also the safe one: the switch renders OFF, and
@@ -69,10 +70,9 @@ async function readJsonObject(file: string): Promise<Record<string, unknown> | n
 // `mcpServers` is a JSON object keyed by server id. Read with Object.keys on an own-property
 // check rather than indexed lookups, so a key like `constructor` in the user's file cannot
 // resolve through Object.prototype (same reason common/toolGroups.ts uses a Map).
-const serverIdsIn = (value: unknown): string[] => (value && typeof value === "object" && !Array.isArray(value) ? Object.keys(value as object) : []);
+const serverIdsIn = (value: unknown): string[] => (isRecord(value) ? Object.keys(value) : []);
 
-const ownProp = (obj: unknown, key: string): unknown =>
-  obj && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key) ? (obj as Record<string, unknown>)[key] : undefined;
+const ownProp = (obj: unknown, key: string): unknown => (isRecord(obj) && Object.prototype.hasOwnProperty.call(obj, key) ? obj[key] : undefined);
 
 // The servers a scope holds. Every scope spells them the same way — `{ mcpServers: { <id>: … } }`
 // — a per-directory entry under `projects` included.


### PR DESCRIPTION
## Summary

#1231。CI 待ちが長いので**1ファイル1PRをやめて5ファイルまとめ**にしました。server 側 5 ファイル・**21 箇所**。

残り **112 → 91 箇所**。

## Items to Confirm / Review

### 1. `body.mode` は「検査より先に型を主張」していた（`collections.ts`）

```diff
-  const mode: ViewWriteMode = body.mode === undefined ? "upsert" : (body.mode as ViewWriteMode);
-  if (!VIEW_WRITE_MODES.includes(mode)) {
+  const mode = body.mode === undefined ? "upsert" : body.mode;
+  if (!isViewWriteMode(mode)) {
```

`body.mode as ViewWriteMode` で「これは有効なモードだ」と宣言してから、次の行で「それは有効なモードか？」と聞いていました。**答えが主張より後に来る**形です。実行時の結果は同じ（不正なら 400）ですが、順序が逆でした。

### 2. `view.capabilities` の filter は「防御の重ね」で、**脆弱性の修正ではありません**

最初この PR を「不正な capability がトークンに載り得る」と書こうとしましたが、**テストを書いたら違いました**。`capabilities: ["read", "admin"]` を宣言したビューを fixture に足すと、スキーマ検証がコレクション自体を弾いて 404 になります（26 テストが落ちて気づきました）。

つまり不正な capability はここに到達できません。filter は挙動を変えず、「渡すものをローカルで証明する」だけです。**そう書き直しました**し、書けないテストは入れていません。

### 3. `req.body` を無検査で信じていた（5 箇所）

```diff
-  const body = (req.body ?? {}) as { items?: unknown; mode?: unknown };
+  const body: Record<string, unknown> = isRecord(req.body) ? req.body : {};
```

後続の `Array.isArray(body.items)` などの検査はそのままです。挙動を変えず、**「オブジェクトである」を主張から検査に変えた**だけです。

### 4. `Object.entries` が型を捨てていた（`terminalScreen.ts`）

`Object.entries(AGENT_DEFAULT_COMMAND)` は `Record<AgentKind, string>` のキーを `string` に広げるので、アサーション 3 つで戻していました。既存の `TERMINAL_AGENTS` を回せば型が付いたままです。

```diff
-  for (const [kind, command] of Object.entries(AGENT_DEFAULT_COMMAND)) {
-    map[command] = kind as SessionAgent;
-    map[basename(getAgentAdapter(kind as AgentKind).bin())] = kind as SessionAgent;
+  for (const kind of TERMINAL_AGENTS) {
+    map[AGENT_DEFAULT_COMMAND[kind]] = kind;
+    map[basename(getAgentAdapter(kind).bin())] = kind;
```

### 5. `every` の型述語は配列ごと narrow する（`viewToken.ts`）

`caps.every(isCapability)` を通れば `caps` は `ViewCapability[]` に narrow されるので、最後の `as ViewCapability[]` は不要でした。`isCapability` は `collections.ts` からも使うので export しています。

### 6. `isRecord` への置換（残り）

`gui-mcp-registration.ts` / `cwd-presets.ts` / `collections.ts` の手書き object 判定。prototype 汚染対策の `hasOwnProperty` 検査は**そのまま残しています**（`isRecord` は「object か」だけを担当）。

## User Prompt

- #1231 を1ファイルずつ進めてほしい。修正中にバグを見つけたら、元の issue に詳細と原因を残してほしい。
- PR は並列で動かして PR → review → マージ。CodeRabbit は無視で良い。
- 1ファイルずつだと時間がかかるので、今度は5つくらいまとめてやろう。CI に時間がかかる。

## 検証

`yarn lint`（0 error、96 warnings ← 112）/ `yarn typecheck` / `yarn typecheck:server` / `yarn build` / `yarn test` **7337 passed**。

token の mint/verify と capability clamp は security 経路なので `viewToken.spec.ts` + `collections.spec.ts`（65 tests）を個別にも実行しています。

> `yarn typecheck:test` の 4 件エラーは main 時点で同じ（calendar 関連）で無関係です。

refs #1231

work in mulmoterminal3
